### PR TITLE
move actions out in preparation of looping and chunking

### DIFF
--- a/evals/index.eval.ts
+++ b/evals/index.eval.ts
@@ -1,5 +1,5 @@
 import { Eval } from 'braintrust';
-import { Stagehand } from '../lib/playwright';
+import { Stagehand } from '../lib';
 import { z } from 'zod';
 
 const vanta = async (input) => {

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S pnpm tsx
-import { Stagehand } from '../lib/playwright';
+import { Stagehand } from '../lib';
 import { z } from 'zod';
 
 async function example() {

--- a/lib/inference.ts
+++ b/lib/inference.ts
@@ -1,0 +1,28 @@
+import { buildActSystemPrompt, buildActUserPrompt } from './prompt';
+import OpenAI from 'openai';
+
+export async function act({
+  action,
+  domElements,
+  client,
+}: {
+  action: string;
+  domElements: string;
+  client: OpenAI;
+}): Promise<Array<{ method: string; element: number; args: any[] }>> {
+  const response = await client.chat.completions.create({
+    model: 'gpt-4o',
+    messages: [buildActSystemPrompt(), buildActUserPrompt(action, domElements)],
+    temperature: 0.1,
+    response_format: { type: 'json_object' },
+    top_p: 1,
+    frequency_penalty: 0,
+    presence_penalty: 0,
+  });
+
+  if (!response.choices[0].message.content) {
+    throw new Error('no response from action model');
+  }
+
+  return JSON.parse(response.choices[0].message.content);
+}

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -1,0 +1,30 @@
+import OpenAI from 'openai';
+
+const actSystemPrompt = `
+You are helping the user automate browser by finding one or more actions to take.
+
+you will be given a numbered list of relevant DOM elements to consider and an action to accomplish. for each action required to complete the goal, follow this format in raw JSON, no markdown
+
+[{
+    method: string (the required playwright function to call)
+     element: number (the element number to act on), args: Array<string | number> (the required arguments)
+}]
+`;
+
+export function buildActSystemPrompt(): OpenAI.ChatCompletionMessageParam {
+  const content = actSystemPrompt.replace(/\s+/g, ' ');
+  return {
+    role: 'system',
+    content,
+  };
+}
+
+export function buildActUserPrompt(
+  action: string,
+  domElements: string
+): OpenAI.ChatCompletionMessageParam {
+  return {
+    role: 'user',
+    content: `action: ${action}, DOM: ${domElements}`,
+  };
+}


### PR DESCRIPTION
# why
LLM calls are now going to get smarter, so i'm creating a surface for more logic to go that avoids clogging up the SDK's index

# what changed
Act inference moves to inference.ts and prompt building also happens separately

# test plan
ran the example, no errors