### PR TITLE
fixes and cleanup while working on peeler eval

### DIFF
--- a/evals/assets/peeler.html
+++ b/evals/assets/peeler.html
@@ -11,7 +11,7 @@
     <div class="product-card">
         <div class="product-info">
             <h2>Knife Set</h2>
-            <p>High-quality stainless steel knives for all your cooking needs.</p>
+            <p>High-quality stainless steel knives for all your cooking needs.<a>my stuff</a> more stuff</p>
         </div>
         <button onclick="location.href='cart.html?item=B'">Add to cart</button>
     </div>
@@ -27,5 +27,7 @@
             hi world
         </div>
     </a>
+    <p>Baseball evolved from older <a href="/wiki/Bat-and-ball_games" title="Bat-and-ball games">bat-and-ball games</a> already being played in England by the mid-18th century. This game was brought by immigrants to North America, <a href="/wiki/History_of_baseball_in_the_United_States" title="History of baseball in the United States">where the modern version developed</a>.
+    </p>
 </body>
 </html>

--- a/evals/index.eval.ts
+++ b/evals/index.eval.ts
@@ -64,19 +64,25 @@ const peeler_simple = async () => {
 };
 
 const peeler_complex = async () => {
-  const stagehand = new Stagehand({ env: 'LOCAL', disableCache: true });
+  const stagehand = new Stagehand({
+    env: 'LOCAL',
+    disableCache: true,
+    verbose: true,
+  });
   await stagehand.init();
 
-  await stagehand.page.goto(
-    `https://chefstoys.com/collections/fruit-vegetable-herb-knives-peelers`
-  );
+  await stagehand.page.goto(`https://chefstoys.com/`);
 
   await stagehand.act({
-    action: 'click "add to cart" for the first OXO peeler',
+    action: 'search for peelers',
   });
-  await stagehand.act({ action: 'visit the cart' });
+
+  await stagehand.act({
+    action: 'click on the first OXO peeler',
+  });
+
   const { price } = await stagehand.extract({
-    instruction: 'get the price of the peeler in cart',
+    instruction: 'get the price of the first OXO peeler',
     schema: z.object({ price: z.number().nullable() }),
   });
 

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -31,10 +31,11 @@ async function example() {
 async function debug() {
   const stagehand = new Stagehand({ env: 'LOCAL', verbose: true });
   await stagehand.init();
-  await stagehand.page.goto(
-    'https://chefstoys.com/collections/fruit-vegetable-herb-knives-peelers'
-  );
-  await stagehand.debugDom();
+  await stagehand.page.goto('https://chefstoys.com/');
+  await stagehand.act({
+    action: 'run a search for peelers',
+  });
+  await new Promise((resolve) => setTimeout(resolve, 30000));
 }
 
 (async () => {

--- a/lib/inference.ts
+++ b/lib/inference.ts
@@ -15,7 +15,7 @@ export async function act({
   method: string;
   element: number;
   args: any[];
-  continue: boolean;
+  completed: boolean;
   step: string;
   why?: string;
 } | null> {

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -6,7 +6,7 @@ You are a browser automation assistant.
 You are given:
 1. the user's overall goal
 2. the steps that have been taken so far
-3. a list of relevant DOM elements in this chunk to consider to accompish the goal
+3. a list of active DOM elements in this chunk to consider to accomplish the goal. 
 
 You have 2 tools that you can call: doAction, and skipSection
 `;
@@ -24,14 +24,15 @@ export function buildActUserPrompt(
   steps = 'None',
   domElements: string
 ): OpenAI.ChatCompletionMessageParam {
+  console.log('hi!');
+  console.log(steps);
   const actUserPrompt = `
     goal: ${action}, 
-    steps so far: ${steps},
+    steps completed so far: ${steps},
     elements: ${domElements}
     `;
   const content = actUserPrompt.replace(/\s+/g, ' ');
 
-  console.log('prompt', content);
   return {
     role: 'user',
     content,
@@ -44,10 +45,10 @@ export const actTools: Array<OpenAI.ChatCompletionTool> = [
     function: {
       name: 'doAction',
       description:
-        'execute the next playwright step that accomplishes the goal',
+        'execute the next playwright step that directly accomplishes the goal',
       parameters: {
         type: 'object',
-        required: ['method', 'element', 'args', 'step', 'continue'],
+        required: ['method', 'element', 'args', 'step', 'completed'],
         properties: {
           method: {
             type: 'string',
@@ -67,17 +68,18 @@ export const actTools: Array<OpenAI.ChatCompletionTool> = [
           },
           step: {
             type: 'string',
-            description: 'human readable description of the step that is taken',
+            description:
+              'human readable description of the step that is taken in the past tense',
           },
           why: {
             type: 'string',
             description:
               'why is this step taken? how does it advance the goal?',
           },
-          continue: {
+          completed: {
             type: 'boolean',
             description:
-              'true if this step does not complete the goal and more work is required',
+              'true if the goal should be accomplished after this step',
           },
         },
       },


### PR DESCRIPTION
# why
1 we want to pass more complicated evals


# what changed
1. Switch from children to child nodes. This means we can actually include text nodes, text that lives amongst html elements
2. some debug fixes to paint text and elements differently, as well as clear the screen if you debug on multiple actions
3. fixed the step logic so that steps actually get included in the prompt
4. flipped the continue boolean to completed, the model seems to be able to judge much better if it's done, rather than if it needs to keep going

# test plan
run evals and example
