### PR TITLE
fix element top check

### DIFF
--- a/examples/index.ts
+++ b/examples/index.ts
@@ -50,15 +50,18 @@ async function example() {
 }
 
 async function debug() {
-  const stagehand = new Stagehand({ env: "LOCAL", verbose: true });
+  const stagehand = new Stagehand({
+    env: "LOCAL",
+    verbose: true,
+    debugDom: true,
+  });
   await stagehand.init();
   await stagehand.page.goto("https://chefstoys.com/");
-  await stagehand.act({
-    action: "run a search for peelers",
-  });
-  await new Promise((resolve) => setTimeout(resolve, 30000));
+
+  await stagehand.waitForSettledDom();
+  await stagehand.startDomDebug();
 }
 
 (async () => {
-  await example();
+  await debug();
 })();

--- a/lib/dom/debug.ts
+++ b/lib/dom/debug.ts
@@ -2,7 +2,7 @@ async function debugDom() {
   window.chunkNumber = 0;
 
   const { selectorMap, outputString } = await processElements(
-    window.chunkNumber,
+    window.chunkNumber
   );
   console.log("outputString:", outputString);
   console.log("selectorMap:", selectorMap);
@@ -19,7 +19,7 @@ function drawChunk(selectorMap: Record<number, string>) {
       document,
       null,
       XPathResult.FIRST_ORDERED_NODE_TYPE,
-      null,
+      null
     ).singleNodeValue as Element;
 
     if (element) {
@@ -43,7 +43,7 @@ function drawChunk(selectorMap: Record<number, string>) {
       overlay.style.backgroundColor = color;
       overlay.className = "stagehand-marker";
       overlay.style.opacity = "0.3";
-      overlay.style.zIndex = "10000000"; // Ensure it's above the element
+      overlay.style.zIndex = "1000000000"; // Ensure it's above the element
       overlay.style.border = "1px solid"; // Add a 1px solid border to the overlay
       overlay.style.pointerEvents = "none"; // Ensure the overlay does not capture mouse events
       document.body.appendChild(overlay);
@@ -85,7 +85,7 @@ function setupChunkNav() {
     prevChunkButton.style.bottom = "10px";
     prevChunkButton.style.left = "50%";
     prevChunkButton.style.transform = "translateX(-50%)";
-    prevChunkButton.style.zIndex = "1000";
+    prevChunkButton.style.zIndex = "1000000000";
     prevChunkButton.onclick = async () => {
       cleanupMarkers();
       cleanupNav();
@@ -107,7 +107,7 @@ function setupChunkNav() {
     nextChunkButton.style.bottom = "10px";
     nextChunkButton.style.right = "50%";
     nextChunkButton.style.transform = "translateX(50%)";
-    nextChunkButton.style.zIndex = "1000";
+    nextChunkButton.style.zIndex = "1000000000";
     nextChunkButton.onclick = async () => {
       cleanupMarkers();
       cleanupNav();

--- a/lib/dom/process.ts
+++ b/lib/dom/process.ts
@@ -157,13 +157,12 @@ const isTextVisible = (element: ChildNode) => {
 function isTopElement(elem: ChildNode, rect: DOMRect) {
   let topEl = document.elementFromPoint(
     rect.left + Math.min(rect.width, window.innerWidth - rect.left) / 2,
-    rect.top + Math.min(rect.height, window.innerHeight - rect.top) / 2,
+    rect.top + Math.min(rect.height, window.innerHeight - rect.top) / 2
   );
-
   let found = false;
   while (topEl && topEl !== document.body) {
     // consider checking hit targets in the corner and middle instead of containing
-    if (topEl.contains(elem)) {
+    if (topEl.isSameNode(elem)) {
       found = true;
       break;
     }


### PR DESCRIPTION
# why
in the wordle example, we were allowing some blocked elements to get selected because of an erroneous check. When i added support for text nodes, I mistakenly switched to `contains` to see if an element was on top. Instead, I ended up checking the text nodes parent which means we can check for an exact element match. It's a little complicated, but there can be states where both a popover and some hidden text can have the same parent, so the logic was failing.

It should be fixed now! I would love to add DOM regression tests at the unit level.  

# what changed
1. cleaned up debug script
2. made z index even higher for debug boxes (sad)
3. switched from contains to isSameNode

# test plan
wordle dom is squeaky clean now

<img width="1213" alt="Screenshot 2024-06-06 at 3 21 58 PM" src="https://github.com/browserbase/stagehand/assets/2474027/88ca4f60-2852-42b0-9af2-174793ea946c">
