### PR TITLE
make debug url more useful

### DIFF
--- a/examples/debugUrl.ts
+++ b/examples/debugUrl.ts
@@ -1,0 +1,26 @@
+#!/usr/bin/env -S pnpm tsx
+import { Stagehand } from "../lib";
+
+async function debug(url: string) {
+  const stagehand = new Stagehand({
+    env: "LOCAL",
+    verbose: true,
+    debugDom: true,
+  });
+  await stagehand.init();
+  await stagehand.page.goto(url);
+
+  await stagehand.waitForSettledDom();
+  await stagehand.startDomDebug();
+}
+
+(async () => {
+  const url = process.argv.find((arg) => arg.startsWith("--url="));
+  if (!url) {
+    console.error("No URL flag provided. Usage: --url=https://example.com");
+    process.exit(1);
+  }
+  const targetUrl = url.split("=")[1];
+  console.log(`Navigating to: ${targetUrl}`);
+  await debug(targetUrl);
+})();

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -49,19 +49,6 @@ async function example() {
   }
 }
 
-async function debug() {
-  const stagehand = new Stagehand({
-    env: "LOCAL",
-    verbose: true,
-    debugDom: true,
-  });
-  await stagehand.init();
-  await stagehand.page.goto("https://chefstoys.com/");
-
-  await stagehand.waitForSettledDom();
-  await stagehand.startDomDebug();
-}
-
 (async () => {
-  await debug();
+  await example();
 })();

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "module": "./dist/index.js",
   "scripts": {
     "example": "pnpm build-dom-scripts && tsx examples/index.ts",
+    "debug-url": "pnpm build-dom-scripts && tsx examples/debugUrl.ts",
     "format": "prettier --write .",
     "cache:clear": "rm -rf .cache",
     "evals": "pnpm build-dom-scripts && npx braintrust eval evals/index.eval.ts",


### PR DESCRIPTION
# why
sometimes i want to just open a url and see how the dom would get handled, now you can with a pnpm command

# what changed
1. moved debug out and gave it a janky CLI interface

# test plan
run pnpm debug-url --url="foo.com" and get a debugged dom