### PR TITLE
Traverse child nodes if they're interactive

### DIFF
--- a/lib/dom/process.ts
+++ b/lib/dom/process.ts
@@ -31,21 +31,21 @@ async function processElements(chunk: number) {
     if (element && isElementNode(element)) {
       const childrenCount = element.childNodes.length;
 
-      // if you have no children you are a leaf node
-      if (isLeafElement(element)) {
-        if ((await isActive(element)) && isVisible(element)) {
-          candidateElements.push(element);
-        }
-        continue;
-      } else if (isInteractiveElement(element)) {
-        if ((await isActive(element)) && isVisible(element)) {
-          candidateElements.push(element);
-        }
-        continue;
-      }
+      // Always traverse child nodes
       for (let i = childrenCount - 1; i >= 0; i--) {
         const child = element.childNodes[i];
-        DOMQueue.push(child as Element);
+        DOMQueue.push(child as ChildNode);
+      }
+
+      // Check if element is interactive
+      if (isInteractiveElement(element)) {
+        if ((await isActive(element)) && isVisible(element)) {
+          candidateElements.push(element);
+        }
+      } else if (isLeafElement(element)) {
+        if ((await isActive(element)) && isVisible(element)) {
+          candidateElements.push(element);
+        }
       }
     } else if (element && isTextNode(element) && isTextVisible(element)) {
       candidateElements.push(element);


### PR DESCRIPTION
# why
Peeler complex was failing because it was selecting a div that wasn't actually inputable. 

# what changed
Always Traverse Children: By removing the continue statements, we ensure that all child nodes are examined, allowing nested interactive elements like <input> fields to be detected.

Collect All Relevant Elements: Even if a parent element is interactive, its child elements might also be interactive or relevant leaf nodes, so we add the parent to candidateElements without skipping its children.

This change should allow your code to correctly identify and return the <input> field instead of the wrapping <div>. Please try this modification and see if it resolves the issue.

# test plan
Evals - peeler complex works now!