### PR TITLE
use semantic chunking to speed up operations

### DIFF
--- a/lib/dom/process.ts
+++ b/lib/dom/process.ts
@@ -549,7 +549,7 @@ async function pickChunk(chunksSeen: Array<number>, chunkPriorities?: Array<numb
 
   if (chunksRemaining.length === 0) {
     throw new Error(`no chunks remaining to check ${chunksRemaining}, `);
-  } else if (chunkPriorities.length > 0) {
+  } else if (chunkPriorities && chunkPriorities.length > 0) {
     const sortedChunks = chunksRemaining.sort((a, b) => chunkPriorities.indexOf(a) - chunkPriorities.indexOf(b));
     return {
       chunk: sortedChunks[0],

--- a/lib/dom/types.ts
+++ b/lib/dom/types.ts
@@ -1,8 +1,17 @@
 export {};
+
+export interface PageElementMap {
+  [key: string]: {
+    string: string;
+    chunk: number;
+    embedding: number[];
+  };
+}
+
 declare global {
   interface Window {
     chunkNumber: number;
-    processDom: (chunksSeen: Array<number>) => Promise<{
+    processDom: (chunksSeen: Array<number>, chunkPriorities?: Array<number>) => Promise<{
       outputString: string;
       selectorMap: Record<number, string>;
       chunk: number;
@@ -15,5 +24,7 @@ declare global {
     debugDom: () => Promise<void>;
     cleanupDebug: () => void;
     scrollToHeight: (height: number) => Promise<void>;
+    getPageElementMap: () => Promise<PageElementMap>;
+    getPageChunkMap: () => Promise<PageElementMap>;
   }
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -9,7 +9,7 @@ const merge = require("deepmerge");
 import path from "path";
 import Browserbase from "./browserbase";
 import { ScreenshotService } from "./vision";
-import { modelsWithVision } from "./llm/LLMClient";
+import { LLMClient, modelsWithVision } from "./llm/LLMClient";
 
 require("dotenv").config({ path: ".env" });
 
@@ -235,6 +235,10 @@ export class Stagehand {
     });
   }
 
+  getLLMClient(modelName: string): LLMClient {
+    return this.llmProvider.getClient(modelName);
+  }
+
   async waitForSettledDom() {
     try {
       await this.page.waitForSelector("body");
@@ -276,11 +280,13 @@ export class Stagehand {
       console.log("Error in startDomDebug:", e);
     }
   }
+
   async cleanupDomDebug() {
     if (this.debugDom) {
       await this.page.evaluate(() => window.cleanupDebug());
     }
   }
+
   getId(operation: string) {
     return crypto.createHash("sha256").update(operation).digest("hex");
   }
@@ -312,6 +318,7 @@ export class Stagehand {
       (chunksSeen?: number[]) => window.processDom(chunksSeen ?? []),
       chunksSeen,
     );
+
     this.log({
       category: "extraction",
       message: `Received output from processDom. Chunk: ${chunk}, Chunks left: ${chunks.length - chunksSeen.length}`,

--- a/lib/llm/LLMClient.ts
+++ b/lib/llm/LLMClient.ts
@@ -40,8 +40,14 @@ export interface ExtractionOptions extends ChatCompletionOptions {
   }; // Schema for the structured output
 }
 
+export interface EmbeddingOptions {
+  model: string;
+  input: string;
+}
+
 export interface LLMClient {
   createChatCompletion(options: ChatCompletionOptions): Promise<any>;
   createExtraction(options: ExtractionOptions): Promise<any>;
+  createEmbedding(options: EmbeddingOptions): Promise<any>;
   logger: (message: { category?: string; message: string }) => void;
 }

--- a/lib/llm/OpenAIClient.ts
+++ b/lib/llm/OpenAIClient.ts
@@ -4,6 +4,7 @@ import {
   LLMClient,
   ChatCompletionOptions,
   ExtractionOptions,
+  EmbeddingOptions,
 } from "./LLMClient";
 
 export class OpenAIClient implements LLMClient {
@@ -84,5 +85,26 @@ export class OpenAIClient implements LLMClient {
     };
 
     return response;
+  }
+
+  async createEmbedding(options: EmbeddingOptions) {
+    this.logger({
+      category: "OpenAI",
+      message: "Creating embedding with options: " + JSON.stringify(options),
+      level: 2
+    });
+
+    const response = await this.client.embeddings.create({
+      model: options.model,
+      input: options.input,
+    });
+
+    this.logger({
+      category: "OpenAI",
+      message: "Embedding response: " + JSON.stringify(response),
+      level: 2
+    });
+
+    return response.data[0].embedding;
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@anthropic-ai/sdk": "^0.27.3",
     "anthropic": "^0.0.0",
     "anthropic-ai": "^0.0.10",
+    "mathjs": "^13.2.0",
     "sharp": "^0.33.5",
     "zod-to-json-schema": "^3.23.3"
   }


### PR DESCRIPTION
# why

If we have many chunks in a page, we often need to wait for each chunk to be processed sequentially (during act or extract). This takes a lot of time since we need to process every chunk, while many chunks may not contain relevant information. 

# what changed

When a page loads, asynchronously parse the elements and compute their embeddings. Then, when performing an action, order chunks by the ones that contain elements that might be more relevant for the action.

# test plan
