### PR TITLE
Remove user data dir from chrome startup (WIP)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,12 @@
 {
-  "name": "stagehand",
+  "name": "@browserbase/stagehand",
   "version": "1.0.0",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "scripts": {
-    "example": "npm run build-dom-scripts && tsx examples/example.ts",
+    "example": "npm run build-dom-scripts && tsx examples/2048.ts",
     "debug-url": "npm run build-dom-scripts && tsx examples/debugUrl.ts",
-    "2048": "npm run build-dom-scripts && tsx examples/2048.ts",
     "format": "prettier --write .",
     "cache:clear": "rm -rf .cache",
     "evals": "npm run build-dom-scripts && npx braintrust eval evals/index.eval.ts",


### PR DESCRIPTION
# why
It feels like overkill just to use a local user data dir for the PDF setting. 

# what changed
I changed the Chrome start flags to not use persistentContext, and instead just use launch. 

# test plan
Evals seem to be timing out with this change, need to see if it's related