### PR TITLE
distribute types

### DIFF
--- a/lib/dom/global.d.ts
+++ b/lib/dom/global.d.ts
@@ -19,5 +19,6 @@ declare global {
     debugDom: () => Promise<void>;
     cleanupDebug: () => void;
     scrollToHeight: (height: number) => Promise<void>;
+    waitForDomSettle: () => Promise<void>;
   }
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -108,7 +108,6 @@ async function getBrowser(
           "--disable-web-security",
         ],
         bypassCSP: true,
-        userDataDir: "./user_data",
       },
     );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@browserbasehq/stagehand",
-  "version": "0.9.2",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@browserbasehq/stagehand",
-      "version": "0.9.2",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.27.3",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "An AI web browsing framework focused on simplicity and extensibility.",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "scripts": {
     "2048": "npm run build-dom-scripts && tsx examples/2048.ts",
     "example": "npm run build-dom-scripts && tsx examples/example.ts",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "evals": "npm run build-dom-scripts && npx braintrust eval evals/index.eval.ts",
     "build-dom-scripts": "mkdir -p ./lib/dom/build && mkdir -p ./dist/dom/build && esbuild ./lib/dom/*.ts --bundle --outdir=./dist/dom/build",
     "bundle-dom-scripts": "esbuild ./lib/dom/index.ts --bundle --outfile=./lib/dom/bundle.js --platform=browser --target=es2015 --minify",
-    "build": "npm run build-dom-scripts && tsup lib/index.ts",
+    "build": "npm run build-dom-scripts && tsup lib/index.ts --dts",
     "release": "changeset publish"
   },
   "files": [


### PR DESCRIPTION
# why

this package does not distribute types

# what changed

fix type errors and generate a declaration file

# test plan

we should be able to run https://github.com/arethetypeswrong/arethetypeswrong.github.io against the tarball or something similar:

```
% npm run build
...
% npm pack     
npm notice
npm notice 📦  @browserbasehq/stagehand@1.0.1
npm notice Tarball Contents
npm notice 1.1kB LICENSE
npm notice 18.7kB README.md
npm notice 4.2kB dist/dom/build/debug.js
npm notice 15B dist/dom/build/global.d.js
npm notice 16.1kB dist/dom/build/index.js
npm notice 11.5kB dist/dom/build/process.js
npm notice 535B dist/dom/build/utils.js
npm notice 3.4kB dist/index.d.ts
npm notice 64.0kB dist/index.js
npm notice 2.3kB package.json
npm notice Tarball Details
npm notice name: @browserbasehq/stagehand
npm notice version: 1.0.1
npm notice filename: browserbasehq-stagehand-1.0.1.tgz
npm notice package size: 30.4 kB
npm notice unpacked size: 121.7 kB
npm notice shasum: 86eb2566b62ecf43702ea843cf9170e9079d4198
npm notice integrity: sha512-rXkLE94sWg8He[...]MVK2bbHM/xtWw==
npm notice total files: 10
npm notice
browserbasehq-stagehand-1.0.1.tgz

% ./node_modules/.bin/attw browserbasehq-stagehand-1.0.1.tgz

@browserbasehq/stagehand v1.0.1

Build tools:
- @arethetypeswrong/cli@^0.16.4
- typescript@^5.2.2
- esbuild@^0.21.4
- tsup@^8.1.0

 No problems found 🌟


┌───────────────────┬────────────────────────────┐
│                   │ "@browserbasehq/stagehand" │
├───────────────────┼────────────────────────────┤
│ node10            │ 🟢                         │
├───────────────────┼────────────────────────────┤
│ node16 (from CJS) │ 🟢 (CJS)                   │
├───────────────────┼────────────────────────────┤
│ node16 (from ESM) │ 🟢 (CJS)                   │
├───────────────────┼────────────────────────────┤
│ bundler           │ 🟢                         │
└───────────────────┴────────────────────────────┘
```