### PR TITLE
Add: initFromPage method to Stagehand to support external Page objects

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -281,6 +281,26 @@ export class Stagehand {
       await this._waitForSettledDom();
       return result;
     };
+
+    // Set the browser to headless mode if specified
+    if (this.headless) {
+      await this.page.setViewportSize({ width: 1280, height: 720 });
+    }
+
+    // Add initialization scripts
+    await this.page.addInitScript({
+      path: path.join(__dirname, "..", "dist", "dom", "build", "process.js"),
+    });
+
+    await this.page.addInitScript({
+      path: path.join(__dirname, "..", "dist", "dom", "build", "utils.js"),
+    });
+
+    await this.page.addInitScript({
+      path: path.join(__dirname, "..", "dist", "dom", "build", "debug.js"),
+    });
+
+    return this;
   }
 
   // Logging

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -270,9 +270,13 @@ export class Stagehand {
     return { debugUrl, sessionUrl };
   }
 
-  async initFromPage(page: Page) {
+  async initFromPage(
+    page: Page,
+    modelName?: AvailableModel,
+  ): Promise<{ context: BrowserContext }> {
     this.page = page;
     this.context = page.context();
+    this.defaultModelName = modelName || this.defaultModelName;
 
     const originalGoto = this.page.goto.bind(this.page);
     this.page.goto = async (url: string, options?: any) => {
@@ -300,7 +304,7 @@ export class Stagehand {
       path: path.join(__dirname, "..", "dist", "dom", "build", "debug.js"),
     });
 
-    return this;
+    return { context: this.context };
   }
 
   // Logging

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -270,6 +270,19 @@ export class Stagehand {
     return { debugUrl, sessionUrl };
   }
 
+  async initFromPage(page: Page) {
+    this.page = page;
+    this.context = page.context();
+
+    const originalGoto = this.page.goto.bind(this.page);
+    this.page.goto = async (url: string, options?: any) => {
+      const result = await originalGoto(url, options);
+      await this.page.waitForLoadState("domcontentloaded");
+      await this._waitForSettledDom();
+      return result;
+    };
+  }
+
   // Logging
   private pending_logs_to_send_to_browserbase: {
     category?: string;


### PR DESCRIPTION
# why
I needed to use Stagehand with [Anon](https://www.anon.com/) for authentication purposes, and therefore needed to initialize Stagehand by passing an external [Page](https://playwright.dev/docs/pom) object.

# what changed
I added `initFromPage` method to initialize Stagehand with an external Page.

# test plan
Just want to ensure that this is the best way to achieve the desired results. Not sure if any other tests are required.