### PR TITLE
add caching on the llm provider level

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@
 - [Acknowledgements](#acknowledgements)
 - [License](#license)
 
-> [!NOTE]
-> `Stagehand` is currently available as an early release, and we're actively seeking feedback from the community. Please join our [Slack community](https://join.slack.com/t/stagehand-dev/shared_invite/zt-2tdncfgkk-fF8y5U0uJzR2y2_M9c9OJA) to stay updated on the latest developments and provide feedback.
+> [!NOTE] > `Stagehand` is currently available as an early release, and we're actively seeking feedback from the community. Please join our [Slack community](https://join.slack.com/t/stagehand-dev/shared_invite/zt-2tdncfgkk-fF8y5U0uJzR2y2_M9c9OJA) to stay updated on the latest developments and provide feedback.
 
 ## Intro
 
@@ -101,6 +100,7 @@ import { z } from "zod";
 
 const stagehand = new Stagehand({
   env: "BROWSERBASE",
+  enableCaching: true,
 });
 ```
 
@@ -137,6 +137,7 @@ This constructor is used to create an instance of Stagehand.
     - `2`: LLM-client level logging (most granular)
   - `debugDom`: a `boolean` that draws bounding boxes around elements presented to the LLM during automation.
   - `domSettleTimeoutMs`: an `integer` that specifies the timeout in milliseconds for waiting for the DOM to settle. Defaults to 30000 (30 seconds).
+  - `enableCaching`: a `boolean` that enables caching of LLM responses. When set to `true`, the LLM responses will be cached on disk and reused for identical requests. Defaults to `false`.
 
 - **Returns:**
 
@@ -216,8 +217,7 @@ This constructor is used to create an instance of Stagehand.
 
 #### `observe()`
 
-> [!NOTE]
-> `observe()` currently only evaluates the first chunk in the page.
+> [!NOTE] > `observe()` currently only evaluates the first chunk in the page.
 
 `observe()` is used to get a list of actions that can be taken on the current page. It's useful for adding context to your planning step, or if you unsure of what page you're on.
 
@@ -277,7 +277,6 @@ Stagehand currently supports the following models from OpenAI and Anthropic:
   - `claude-3-5-sonnet-20241022`
 
 These models can be specified when initializing the `Stagehand` instance or when calling methods like `act()` and `extract()`.
-
 
 ## How It Works
 
@@ -342,12 +341,14 @@ const productInfo = await stagehand.extract({
 - **Break down complex tasks into smaller, atomic steps**
 
 Instead of combining actions:
+
 ```javascript
 // Avoid this
 await stagehand.act({ action: "log in and purchase the first item" });
 ```
 
 Split them into individual steps:
+
 ```javascript
 await stagehand.act({ action: "click the login button" });
 // ...additional steps to log in...
@@ -385,10 +386,9 @@ await stagehand.act({ action: "fill out the form and submit it" });
 await stagehand.act({ action: "book the cheapest flight available" });
 ```
 
-By following these guidelines, you'll increase the reliability and effectiveness of your web automations with Stagehand. Remember, Stagehand excels at executing precise, well-defined actions so keeping your instructions atomic will lead to the best outcomes. 
+By following these guidelines, you'll increase the reliability and effectiveness of your web automations with Stagehand. Remember, Stagehand excels at executing precise, well-defined actions so keeping your instructions atomic will lead to the best outcomes.
 
 We leave the agentic behaviour to higher-level agentic systems which can use Stagehand as a tool.
-
 
 ## Roadmap
 

--- a/evals/index.eval.ts
+++ b/evals/index.eval.ts
@@ -9,6 +9,8 @@ const env =
     ? "BROWSERBASE"
     : "LOCAL";
 
+const enableCaching = process.env.EVAL_ENABLE_CACHING?.toLowerCase() === "true";
+
 const expedia = async () => {
   const logger = new EvalLogger();
 
@@ -20,6 +22,7 @@ const expedia = async () => {
     logger: (message: { category?: string; message: string }) => {
       logger.log(message.message);
     },
+    enableCaching,
   });
 
   logger.init(stagehand);
@@ -76,6 +79,7 @@ const vanta = async () => {
       logger.log(message);
     },
     verbose: 2,
+    enableCaching,
   });
 
   logger.init(stagehand);
@@ -147,6 +151,7 @@ const vanta_h = async () => {
       logger.log(message.message);
     },
     verbose: 2,
+    enableCaching,
   });
 
   logger.init(stagehand);
@@ -181,6 +186,7 @@ const simple_google_search = async () => {
       logger.log(message.message);
     },
     verbose: 2,
+    enableCaching,
   });
 
   logger.init(stagehand);
@@ -217,6 +223,7 @@ const peeler_simple = async () => {
       logger.log(message.message);
     },
     verbose: 2,
+    enableCaching,
   });
 
   logger.init(stagehand);
@@ -251,6 +258,7 @@ const peeler_complex = async () => {
     logger: (message: { category?: string; message: string }) => {
       logger.log(message.message);
     },
+    enableCaching,
   });
 
   logger.init(stagehand);
@@ -308,6 +316,7 @@ const homedepot = async () => {
     logger: (message: { category?: string; message: string }) => {
       logger.log(message.message);
     },
+    enableCaching,
   });
 
   logger.init(stagehand);
@@ -400,6 +409,7 @@ const extract_github_stars = async () => {
     logger: (message: { category?: string; message: string }) => {
       logger.log(message.message);
     },
+    enableCaching,
   });
 
   logger.init(stagehand);
@@ -422,7 +432,7 @@ const extract_github_stars = async () => {
       .first()
       .innerHTML();
 
-    const expectedStars = expectedStarsString.toLowerCase().endsWith('k') 
+    const expectedStars = expectedStarsString.toLowerCase().endsWith("k")
       ? parseFloat(expectedStarsString.slice(0, -1)) * 1000
       : parseFloat(expectedStarsString);
 
@@ -457,6 +467,7 @@ const extract_collaborators_from_github_repository = async () => {
     logger: (message: { category?: string; message: string }) => {
       logger.log(message.message);
     },
+    enableCaching,
   });
 
   logger.init(stagehand);
@@ -516,6 +527,7 @@ const extract_last_twenty_github_commits = async () => {
     logger: (message: { category?: string; message: string }) => {
       logger.log(message.message);
     },
+    enableCaching,
   });
 
   logger.init(stagehand);
@@ -575,6 +587,7 @@ const wikipedia = async () => {
     logger: (message: { category?: string; message: string }) => {
       logger.log(message.message);
     },
+    enableCaching,
   });
 
   logger.init(stagehand);
@@ -612,6 +625,7 @@ const nonsense_action = async () => {
     logger: (message: { category?: string; message: string }) => {
       logger.log(message.message);
     },
+    enableCaching,
   });
 
   logger.init(stagehand);
@@ -668,6 +682,7 @@ const costar = async () => {
     logger: (message: { category?: string; message: string }) => {
       logger.log(message.message);
     },
+    enableCaching,
   });
 
   logger.init(stagehand);
@@ -736,6 +751,7 @@ const google_jobs = async () => {
     logger: (message: { category?: string; message: string }) => {
       logger.log(message.message);
     },
+    enableCaching,
   });
 
   logger.init(stagehand);
@@ -837,6 +853,7 @@ const extract_partners = async () => {
     logger: (message: { category?: string; message: string }) => {
       logger.log(message.message);
     },
+    enableCaching,
   });
 
   logger.init(stagehand);
@@ -942,6 +959,7 @@ const laroche_form = async () => {
     logger: (message: { category?: string; message: string }) => {
       logger.log(message.message);
     },
+    enableCaching,
   });
 
   logger.init(stagehand);
@@ -1025,6 +1043,7 @@ const arxiv = async () => {
     logger: (message: { category?: string; message: string }) => {
       logger.log(message.message);
     },
+    enableCaching,
   });
 
   logger.init(stagehand);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -182,16 +182,18 @@ export class Stagehand {
     message: string;
   }) => void;
   private domSettleTimeoutMs: number;
+  private enableCaching: boolean;
 
   constructor(
     {
       env,
-      verbose = 0,
-      debugDom = false,
+      verbose,
+      debugDom,
       llmProvider,
-      headless = false,
+      headless,
       logger,
-      domSettleTimeoutMs = 60000,
+      domSettleTimeoutMs,
+      enableCaching,
     }: {
       env: "LOCAL" | "BROWSERBASE";
       verbose?: 0 | 1 | 2;
@@ -204,21 +206,25 @@ export class Stagehand {
         level?: 0 | 1 | 2;
       }) => void;
       domSettleTimeoutMs?: number;
+      enableCaching?: boolean;
     } = {
       env: "BROWSERBASE",
     },
   ) {
     this.externalLogger = logger;
     this.logger = this.log.bind(this);
-    this.llmProvider = llmProvider || new LLMProvider(this.logger);
+    this.enableCaching = enableCaching ?? false;
+    this.llmProvider =
+      llmProvider || new LLMProvider(this.logger, this.enableCaching);
     this.env = env;
     this.observations = {};
     this.actions = {};
-    this.verbose = verbose;
-    this.debugDom = debugDom;
+    this.verbose = verbose ?? 0;
+    this.debugDom = debugDom ?? false;
     this.defaultModelName = "gpt-4o";
     this.headless = headless;
-    this.domSettleTimeoutMs = domSettleTimeoutMs;
+    this.domSettleTimeoutMs = domSettleTimeoutMs ?? 60_000;
+    this.headless = headless ?? false;
   }
 
   async init({

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -827,7 +827,9 @@ export class Stagehand {
           requestId,
         });
       } else {
-        this.llmProvider.cleanRequestCache(requestId);
+        if (this.enableCaching) {
+          this.llmProvider.cleanRequestCache(requestId);
+        }
 
         return {
           success: false,
@@ -1073,7 +1075,9 @@ export class Stagehand {
             requestId,
           });
         } else {
-          this.llmProvider.cleanRequestCache(requestId);
+          if (this.enableCaching) {
+            this.llmProvider.cleanRequestCache(requestId);
+          }
 
           return {
             success: false,
@@ -1209,7 +1213,9 @@ export class Stagehand {
       }
 
       await this._recordAction(action, "");
-      this.llmProvider.cleanRequestCache(requestId);
+      if (this.enableCaching) {
+        this.llmProvider.cleanRequestCache(requestId);
+      }
 
       return {
         success: false,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1236,6 +1236,11 @@ export class Stagehand {
 
     const requestId = Math.random().toString(36).substring(2);
 
+    this.logger({
+      category: "act",
+      message: `Running act with action: ${action}, requestId: ${requestId}`,
+    });
+
     return this._act({
       action,
       modelName,
@@ -1257,6 +1262,11 @@ export class Stagehand {
   }): Promise<z.infer<T>> {
     const requestId = Math.random().toString(36).substring(2);
 
+    this.logger({
+      category: "extract",
+      message: `Running extract with instruction: ${instruction}, requestId: ${requestId}`,
+    });
+
     return this._extract({
       instruction,
       schema,
@@ -1271,6 +1281,11 @@ export class Stagehand {
     useVision?: boolean;
   }): Promise<{ selector: string; description: string }[]> {
     const requestId = Math.random().toString(36).substring(2);
+
+    this.logger({
+      category: "observe",
+      message: `Running observe with instruction: ${options?.instruction}, requestId: ${requestId}`,
+    });
 
     return this._observe({
       instruction:

--- a/lib/inference.ts
+++ b/lib/inference.ts
@@ -27,6 +27,7 @@ export async function verifyActCompletion({
   screenshot,
   domElements,
   logger,
+  requestId,
 }: {
   goal: string;
   steps: string;
@@ -35,8 +36,9 @@ export async function verifyActCompletion({
   screenshot?: Buffer;
   domElements?: string;
   logger: (message: { category?: string; message: string }) => void;
+  requestId: string;
 }): Promise<boolean> {
-  const llmClient = llmProvider.getClient(modelName);
+  const llmClient = llmProvider.getClient(modelName, requestId);
   const messages = [
     buildVerifyActCompletionSystemPrompt() as ChatMessage,
     buildVerifyActCompletionUserPrompt(goal, steps, domElements) as ChatMessage,
@@ -91,6 +93,7 @@ export async function act({
   screenshot,
   retries = 0,
   logger,
+  requestId,
 }: {
   action: string;
   steps?: string;
@@ -100,6 +103,7 @@ export async function act({
   screenshot?: Buffer;
   retries?: number;
   logger: (message: { category?: string; message: string }) => void;
+  requestId: string;
 }): Promise<{
   method: string;
   element: number;
@@ -108,7 +112,7 @@ export async function act({
   step: string;
   why?: string;
 } | null> {
-  const llmClient = llmProvider.getClient(modelName);
+  const llmClient = llmProvider.getClient(modelName, requestId);
   const messages = [
     buildActSystemPrompt() as ChatMessage,
     buildActUserPrompt(action, steps, domElements) as ChatMessage,
@@ -151,6 +155,7 @@ export async function act({
       modelName,
       retries: retries + 1,
       logger,
+      requestId,
     });
   }
 }
@@ -165,6 +170,7 @@ export async function extract({
   modelName,
   chunksSeen,
   chunksTotal,
+  requestId,
 }: {
   instruction: string;
   progress: string;
@@ -175,8 +181,9 @@ export async function extract({
   modelName: AvailableModel;
   chunksSeen: number;
   chunksTotal: number;
+  requestId: string;
 }) {
-  const llmClient = llmProvider.getClient(modelName);
+  const llmClient = llmProvider.getClient(modelName, requestId);
 
   const extractionResponse = await llmClient.createChatCompletion({
     model: modelName,
@@ -259,12 +266,14 @@ export async function observe({
   llmProvider,
   modelName,
   image,
+  requestId,
 }: {
   instruction: string;
   domElements: string;
   llmProvider: LLMProvider;
   modelName: AvailableModel;
   image?: Buffer;
+  requestId: string;
 }): Promise<{
   elements: { elementId: number; description: string }[];
 }> {
@@ -283,7 +292,7 @@ export async function observe({
       .describe("an array of elements that match the instruction"),
   });
 
-  const llmClient = llmProvider.getClient(modelName);
+  const llmClient = llmProvider.getClient(modelName, requestId);
   const observationResponse = await llmClient.createChatCompletion({
     model: modelName,
     messages: [
@@ -314,12 +323,14 @@ export async function ask({
   question,
   llmProvider,
   modelName,
+  requestId,
 }: {
   question: string;
   llmProvider: LLMProvider;
   modelName: AvailableModel;
+  requestId: string;
 }) {
-  const llmClient = llmProvider.getClient(modelName);
+  const llmClient = llmProvider.getClient(modelName, requestId);
   const response = await llmClient.createChatCompletion({
     model: modelName,
     messages: [

--- a/lib/llm/AnthropicClient.ts
+++ b/lib/llm/AnthropicClient.ts
@@ -174,17 +174,20 @@ export class AnthropicClient implements LLMClient {
       const toolUse = response.content.find((c) => c.type === "tool_use");
       if (toolUse && "input" in toolUse) {
         const result = toolUse.input;
-        this.cache.set(cacheOptions, result);
+        if (this.enableCaching) {
+          this.cache.set(cacheOptions, result);
+        }
+
         return result;
       } else {
-        if (!options.retries || options.retries < 2) {
+        if (!options.retries || options.retries < 5) {
           return this.createChatCompletion({
             ...options,
             retries: (options.retries ?? 0) + 1,
           });
         }
         throw new Error(
-          "Extraction failed: No tool use with input in response",
+          "Create Chat Completion Failed: No tool use with input in response",
         );
       }
     }

--- a/lib/llm/LLMCache.ts
+++ b/lib/llm/LLMCache.ts
@@ -93,6 +93,7 @@ export class LLMCache {
         }
 
         fs.writeFileSync(this.lockFile, process.pid.toString(), { flag: "wx" });
+        this.count_lock_acquire_failures = 0;
         this.lock_acquired = true;
         return true;
       } catch (error) {

--- a/lib/llm/LLMCache.ts
+++ b/lib/llm/LLMCache.ts
@@ -1,0 +1,129 @@
+import * as fs from "fs";
+import * as path from "path";
+import * as crypto from "crypto";
+
+interface CacheEntry {
+  timestamp: number;
+  data: any;
+}
+
+interface CacheStore {
+  [key: string]: CacheEntry;
+}
+
+export class LLMCache {
+  private cacheDir: string;
+  private cacheFile: string;
+  private logger: (message: {
+    category?: string;
+    message: string;
+    level?: number;
+  }) => void;
+
+  private readonly CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 1 week in milliseconds
+  private readonly CLEANUP_PROBABILITY = 0.01; // 1% chance
+
+  constructor(
+    logger: (message: {
+      category?: string;
+      message: string;
+      level?: number;
+    }) => void,
+    cacheDir: string = path.join(process.cwd(), "tmp", ".cache"),
+    cacheFile: string = "llm_calls.json",
+  ) {
+    this.logger = logger;
+    this.cacheDir = cacheDir;
+    this.cacheFile = path.join(cacheDir, cacheFile);
+    this.ensureCacheDirectory();
+  }
+
+  private ensureCacheDirectory(): void {
+    if (!fs.existsSync(this.cacheDir)) {
+      fs.mkdirSync(this.cacheDir, { recursive: true });
+    }
+  }
+
+  private createHash(data: any): string {
+    const hash = crypto.createHash("sha256");
+    return hash.update(JSON.stringify(data)).digest("hex");
+  }
+
+  private readCache(): CacheStore {
+    if (fs.existsSync(this.cacheFile)) {
+      return JSON.parse(fs.readFileSync(this.cacheFile, "utf-8"));
+    }
+    return {};
+  }
+
+  private writeCache(cache: CacheStore): void {
+    if (Math.random() < this.CLEANUP_PROBABILITY) {
+      this.cleanupStaleEntries(cache);
+    }
+    fs.writeFileSync(this.cacheFile, JSON.stringify(cache, null, 2));
+  }
+
+  private cleanupStaleEntries(cache: CacheStore): void {
+    const now = Date.now();
+    let entriesRemoved = 0;
+
+    for (const [hash, entry] of Object.entries(cache)) {
+      if (now - entry.timestamp > this.CACHE_MAX_AGE_MS) {
+        delete cache[hash];
+        entriesRemoved++;
+      }
+    }
+
+    if (entriesRemoved > 0) {
+      this.logger({
+        category: "llm_cache",
+        message: `Cleaned up ${entriesRemoved} stale cache entries`,
+        level: 1,
+      });
+    }
+  }
+
+  get(options: any): any | null {
+    try {
+      const hash = this.createHash(options);
+      const cache = this.readCache();
+
+      if (cache[hash]) {
+        this.logger({
+          category: "llm_cache",
+          message: "Cache hit",
+          level: 1,
+        });
+        return cache[hash];
+      }
+      return null;
+    } catch (error) {
+      this.logger({
+        category: "llm_cache",
+        message: `Error getting cache: ${error}`,
+        level: 1,
+      });
+      return null;
+    }
+  }
+
+  set(options: any, response: any): void {
+    try {
+      const hash = this.createHash(options);
+      const cache = this.readCache();
+      cache[hash] = response;
+      this.writeCache(cache);
+      this.logger({
+        category: "llm_cache",
+        message: "Cache miss - saved new response",
+        level: 1,
+      });
+    } catch (error) {
+      this.logger({
+        category: "llm_cache",
+        message: `Error setting cache: ${error}`,
+        level: 1,
+      });
+    }
+  }
+}

--- a/lib/llm/LLMCache.ts
+++ b/lib/llm/LLMCache.ts
@@ -83,6 +83,11 @@ export class LLMCache {
     }
   }
 
+  private resetCache(): void {
+    this.ensureCacheDirectory();
+    fs.writeFileSync(this.cacheFile, "{}");
+  }
+
   get(options: any): any | null {
     try {
       const hash = this.createHash(options);
@@ -100,9 +105,12 @@ export class LLMCache {
     } catch (error) {
       this.logger({
         category: "llm_cache",
-        message: `Error getting cache: ${error}`,
+        message: `Error getting cache: ${error}. Resetting cache.`,
         level: 1,
       });
+
+      this.resetCache();
+
       return null;
     }
   }
@@ -121,9 +129,11 @@ export class LLMCache {
     } catch (error) {
       this.logger({
         category: "llm_cache",
-        message: `Error setting cache: ${error}`,
+        message: `Error setting cache: ${error}. Resetting cache.`,
         level: 1,
       });
+
+      this.resetCache();
     }
   }
 }

--- a/lib/llm/LLMClient.ts
+++ b/lib/llm/LLMClient.ts
@@ -16,6 +16,7 @@ export const modelsWithVision: AvailableModel[] = [
   "gpt-4o-mini",
   "claude-3-5-sonnet-latest",
   "claude-3-5-sonnet-20240620",
+  "claude-3-5-sonnet-20241022",
   "gpt-4o-2024-08-06",
 ];
 

--- a/lib/llm/LLMProvider.ts
+++ b/lib/llm/LLMProvider.ts
@@ -35,6 +35,10 @@ export class LLMProvider {
   }
 
   cleanRequestCache(requestId: string): void {
+    this.logger({
+      category: "llm_cache",
+      message: `Cleaning up cache for requestId: ${requestId}`,
+    });
     this.cache.deleteCacheForRequestId(requestId);
   }
 

--- a/lib/llm/LLMProvider.ts
+++ b/lib/llm/LLMProvider.ts
@@ -21,11 +21,14 @@ export class LLMProvider {
   };
 
   private logger: (message: { category?: string; message: string }) => void;
+  private enableCaching: boolean;
 
   constructor(
     logger: (message: { category?: string; message: string }) => void,
+    enableCaching = false,
   ) {
     this.logger = logger;
+    this.enableCaching = enableCaching;
   }
 
   getClient(modelName: AvailableModel): LLMClient {
@@ -36,9 +39,9 @@ export class LLMProvider {
 
     switch (provider) {
       case "openai":
-        return new OpenAIClient(this.logger);
+        return new OpenAIClient(this.logger, this.enableCaching);
       case "anthropic":
-        return new AnthropicClient(this.logger);
+        return new AnthropicClient(this.logger, this.enableCaching);
       default:
         throw new Error(`Unsupported provider: ${provider}`);
     }

--- a/lib/llm/OpenAIClient.ts
+++ b/lib/llm/OpenAIClient.ts
@@ -1,14 +1,17 @@
 import OpenAI from "openai";
 import { zodResponseFormat } from "openai/helpers/zod";
 import { LLMClient, ChatCompletionOptions } from "./LLMClient";
+import { LLMCache } from "./LLMCache";
 
 export class OpenAIClient implements LLMClient {
   private client: OpenAI;
+  private cache: LLMCache;
   public logger: (message: {
     category?: string;
     message: string;
     level?: number;
   }) => void;
+  private enableCaching: boolean;
 
   constructor(
     logger: (message: {
@@ -16,12 +19,33 @@ export class OpenAIClient implements LLMClient {
       message: string;
       level?: number;
     }) => void,
+    enableCaching = false,
   ) {
     this.client = new OpenAI();
     this.logger = logger;
+    this.cache = new LLMCache(logger);
+    this.enableCaching = enableCaching;
   }
 
   async createChatCompletion(options: ChatCompletionOptions) {
+    const cacheOptions = {
+      model: options.model,
+      messages: options.messages,
+      temperature: options.temperature,
+      top_p: options.top_p,
+      frequency_penalty: options.frequency_penalty,
+      presence_penalty: options.presence_penalty,
+      image: options.image,
+      response_model: options.response_model,
+    };
+
+    if (this.enableCaching) {
+      const cachedResponse = this.cache.get(cacheOptions);
+      if (cachedResponse) {
+        return cachedResponse;
+      }
+    }
+
     if (options.image) {
       const screenshotMessage: any = {
         role: "user",
@@ -55,6 +79,10 @@ export class OpenAIClient implements LLMClient {
       ...openAiOptions,
       response_format: responseFormat,
     });
+
+    if (this.enableCaching) {
+      this.cache.set(cacheOptions, response);
+    }
 
     if (response_model) {
       const extractedData = response.choices[0].message.content;

--- a/lib/llm/OpenAIClient.ts
+++ b/lib/llm/OpenAIClient.ts
@@ -80,17 +80,23 @@ export class OpenAIClient implements LLMClient {
       response_format: responseFormat,
     });
 
-    if (this.enableCaching) {
-      this.cache.set(cacheOptions, response);
-    }
-
     if (response_model) {
       const extractedData = response.choices[0].message.content;
       const parsedData = JSON.parse(extractedData);
 
+      if (this.enableCaching) {
+        this.cache.set(cacheOptions, {
+          ...parsedData,
+        });
+      }
+
       return {
         ...parsedData,
       };
+    }
+
+    if (this.enableCaching) {
+      this.cache.set(cacheOptions, response);
     }
 
     return response;


### PR DESCRIPTION
# why
To save model call costs on tasks that are repeated over and over again.

This is just a first of PRs to enable caching on different layers of Stagehand.

For example, when running evals twice in a row with caching enabled, we get a ~50% cache hit on our LLM calls.

# what changed
Added an LLM Cache class to keep track of previous model calls and their corresponding responses.

# test plan
Run evals with caching on