### PR TITLE
make example use stagehand as the repo instead of nextjs

### DIFF
--- a/examples/example.ts
+++ b/examples/example.ts
@@ -9,7 +9,7 @@ async function example() {
   });
 
   await stagehand.init({ modelName: "claude-3-5-sonnet-20241022" });
-  await stagehand.page.goto("https://github.com/vercel/next.js");
+  await stagehand.page.goto("https://github.com/browserbase/stagehand");
   await stagehand.act({ action: "click on the contributors" });
   const contributor = await stagehand.extract({
     instruction: "extract the top contributor",


### PR DESCRIPTION
# why
Why not use our own repo instead of someone elses?

# what changed
switched the example to use https://github.com/browserbase/stagehand instead of the nextjs repo

# test plan
Ran the example