### PR TITLE
more llm provider caching code (leftover from previous commit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ This constructor is used to create an instance of Stagehand.
     - `2`: LLM-client level logging (most granular)
   - `debugDom`: a `boolean` that draws bounding boxes around elements presented to the LLM during automation.
   - `domSettleTimeoutMs`: an `integer` that specifies the timeout in milliseconds for waiting for the DOM to settle. Defaults to 30000 (30 seconds).
-  - `enableCaching`: a `boolean` that enables caching of LLM responses. When set to `true`, the LLM responses will be cached on disk and reused for identical requests. Defaults to `false`.
+  - `enableCaching`: a `boolean` that enables caching of LLM responses. When set to `true`, the LLM requests will be cached on disk and reused for identical requests. Defaults to `false`.
 
 - **Returns:**
 

--- a/examples/example.ts
+++ b/examples/example.ts
@@ -6,6 +6,7 @@ async function example() {
     env: "LOCAL",
     verbose: 1,
     debugDom: true,
+    enableCaching: true,
   });
 
   await stagehand.init({ modelName: "claude-3-5-sonnet-20241022" });

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1254,6 +1254,21 @@ export class Stagehand {
       useVision,
       verifierUseVision: useVision !== false,
       requestId,
+    }).catch((e) => {
+      this.logger({
+        category: "act",
+        message: `Error acting: ${e.message}\nTrace: ${e.stack}`,
+      });
+
+      if (this.enableCaching) {
+        this.llmProvider.cleanRequestCache(requestId);
+      }
+
+      return {
+        success: false,
+        message: `Internal error: Error acting: ${e.message}`,
+        action: action,
+      };
     });
   }
 
@@ -1278,6 +1293,17 @@ export class Stagehand {
       schema,
       modelName,
       requestId,
+    }).catch((e) => {
+      this.logger({
+        category: "extract",
+        message: `Internal error: Error extracting: ${e.message}\nTrace: ${e.stack}`,
+      });
+
+      if (this.enableCaching) {
+        this.llmProvider.cleanRequestCache(requestId);
+      }
+
+      throw e;
     });
   }
 
@@ -1301,6 +1327,17 @@ export class Stagehand {
       useVision: options?.useVision ?? false,
       fullPage: false,
       requestId,
+    }).catch((e) => {
+      this.logger({
+        category: "observe",
+        message: `Error observing: ${e.message}\nTrace: ${e.stack}`,
+      });
+
+      if (this.enableCaching) {
+        this.llmProvider.cleanRequestCache(requestId);
+      }
+
+      throw e;
     });
   }
 }

--- a/lib/llm/AnthropicClient.ts
+++ b/lib/llm/AnthropicClient.ts
@@ -48,7 +48,7 @@ export class AnthropicClient implements LLMClient {
     };
 
     if (this.enableCaching) {
-      const cachedResponse = await this.cache.get(cacheOptions);
+      const cachedResponse = await this.cache.get(cacheOptions, this.requestId);
       if (cachedResponse) {
         return cachedResponse;
       }

--- a/lib/llm/OpenAIClient.ts
+++ b/lib/llm/OpenAIClient.ts
@@ -44,7 +44,7 @@ export class OpenAIClient implements LLMClient {
     };
 
     if (this.enableCaching) {
-      const cachedResponse = await this.cache.get(cacheOptions);
+      const cachedResponse = await this.cache.get(cacheOptions, this.requestId);
       if (cachedResponse) {
         return cachedResponse;
       }


### PR DESCRIPTION
# why
Leftovers from the last commit to add more reliability to the caching + make it perform better.

# what changed
- Enable caching by default on example 
- Clear cache for all requests on thrown error
- request cache clear will clear all steps that that request took (including ones that were cached from before)

# test plan
Same as prev commit
