### PR TITLE
release on tag instead of merge to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: "release"
 on:
   push:
-    branches:
-      - "main"
+    tags:
+      - "v*"
 
 jobs:
   publish:


### PR DESCRIPTION
# why
we don't want to release on every merge to main

# what changed
release on tag instead of merge to main

# test plan
n/a