### PR TITLE
add variables to act

### DIFF
--- a/evals/index.eval.ts
+++ b/evals/index.eval.ts
@@ -269,7 +269,10 @@ const peeler_complex = async () => {
     await stagehand.page.goto(`https://chefstoys.com/`, { timeout: 60000 });
 
     await stagehand.act({
-      action: "search for peelers",
+      action: "search",
+      variables: {
+        search_query: "peeler",
+      },
     });
 
     await stagehand.act({

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -705,6 +705,7 @@ export class Stagehand {
     verifierUseVision,
     retries = 0,
     requestId,
+    variables,
   }: {
     action: string;
     steps?: string;
@@ -714,6 +715,7 @@ export class Stagehand {
     verifierUseVision: boolean;
     retries?: number;
     requestId?: string;
+    variables: Record<string, string>;
   }): Promise<{ success: boolean; message: string; action: string }> {
     const model = modelName ?? this.defaultModelName;
 
@@ -793,6 +795,7 @@ export class Stagehand {
       screenshot: annotatedScreenshot,
       logger: this.logger,
       requestId,
+      variables,
     });
 
     this.log({
@@ -824,6 +827,7 @@ export class Stagehand {
           useVision,
           verifierUseVision,
           requestId,
+          variables,
         });
       } else if (useVision === "fallback") {
         this.log({
@@ -840,6 +844,7 @@ export class Stagehand {
           useVision: true,
           verifierUseVision,
           requestId,
+          variables,
         });
       } else {
         if (this.enableCaching) {
@@ -915,6 +920,7 @@ export class Stagehand {
               retries: retries + 1,
               chunksSeen,
               requestId,
+              variables,
             });
           }
         }
@@ -945,6 +951,7 @@ export class Stagehand {
               retries: retries + 1,
               chunksSeen,
               requestId,
+              variables,
             });
           }
         }
@@ -969,6 +976,7 @@ export class Stagehand {
               retries: retries + 1,
               chunksSeen,
               requestId,
+              variables,
             });
           }
         }
@@ -1005,6 +1013,7 @@ export class Stagehand {
               retries: retries + 1,
               chunksSeen,
               requestId,
+              variables,
             });
           }
         }
@@ -1088,6 +1097,7 @@ export class Stagehand {
             retries: retries + 1,
             chunksSeen,
             requestId,
+            variables,
           });
         } else {
           if (this.enableCaching) {
@@ -1194,6 +1204,7 @@ export class Stagehand {
           useVision,
           verifierUseVision,
           requestId,
+          variables,
         });
       } else {
         this.log({
@@ -1224,6 +1235,7 @@ export class Stagehand {
           retries: retries + 1,
           chunksSeen,
           requestId,
+          variables,
         });
       }
 
@@ -1244,10 +1256,12 @@ export class Stagehand {
     action,
     modelName,
     useVision = "fallback",
+    variables = {},
   }: {
     action: string;
     modelName?: AvailableModel;
     useVision?: "fallback" | boolean;
+    variables?: Record<string, string>;
   }): Promise<{
     success: boolean;
     message: string;
@@ -1269,6 +1283,7 @@ export class Stagehand {
       useVision,
       verifierUseVision: useVision !== false,
       requestId,
+      variables,
     }).catch((e) => {
       this.logger({
         category: "act",

--- a/lib/inference.ts
+++ b/lib/inference.ts
@@ -84,6 +84,18 @@ export async function verifyActCompletion({
   return response.completed;
 }
 
+export function fillInVariables(
+  text: string,
+  variables: Record<string, string>,
+) {
+  let processedText = text;
+  Object.entries(variables).forEach(([key, value]) => {
+    const placeholder = `<|${key.toUpperCase()}|>`;
+    processedText = processedText.replace(placeholder, value);
+  });
+  return processedText;
+}
+
 export async function act({
   action,
   domElements,
@@ -94,6 +106,7 @@ export async function act({
   retries = 0,
   logger,
   requestId,
+  variables,
 }: {
   action: string;
   steps?: string;
@@ -104,6 +117,7 @@ export async function act({
   retries?: number;
   logger: (message: { category?: string; message: string }) => void;
   requestId: string;
+  variables?: Record<string, string>;
 }): Promise<{
   method: string;
   element: number;
@@ -115,7 +129,7 @@ export async function act({
   const llmClient = llmProvider.getClient(modelName, requestId);
   const messages: ChatMessage[] = [
     buildActSystemPrompt(),
-    buildActUserPrompt(action, steps, domElements),
+    buildActUserPrompt(action, steps, domElements, variables),
   ];
 
   const response = await llmClient.createChatCompletion({
@@ -133,10 +147,19 @@ export async function act({
   });
 
   const toolCalls = response.choices[0].message.tool_calls;
+
   if (toolCalls && toolCalls.length > 0) {
     if (toolCalls[0].function.name === "skipSection") {
       return null;
     }
+
+    if (variables) {
+      toolCalls[0].function.arguments = fillInVariables(
+        toolCalls[0].function.arguments,
+        variables,
+      );
+    }
+
     return JSON.parse(toolCalls[0].function.arguments);
   } else {
     if (retries >= 2) {

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -10,6 +10,7 @@ You are given:
 1. the user's overall goal
 2. the steps that you've taken so far
 3. a list of active DOM elements in this chunk to consider to get closer to the goal. 
+4. Optionally, a list of variable names that the user has provided that you may use to accomplish the goal. To use the variables, you must use the special <|VARIABLE_NAME|> syntax.
 
 You have 2 tools that you can call: doAction, and skipSection. Do action only performs Playwright actions. Do not perform any other actions.
 
@@ -103,8 +104,9 @@ export function buildActUserPrompt(
   action: string,
   steps = "None",
   domElements: string,
+  variables?: Record<string, string>,
 ): ChatMessage {
-  const actUserPrompt = `
+  let actUserPrompt = `
 # My Goal
 ${action}
 
@@ -114,6 +116,15 @@ ${steps}
 # Current Active Dom Elements
 ${domElements}
 `;
+
+  if (variables) {
+    actUserPrompt += `
+# Variables
+${Object.entries(variables)
+  .map(([key, value]) => `<|${key.toUpperCase()}|>`)
+  .join("\n")}
+`;
+  }
 
   return {
     role: "user",


### PR DESCRIPTION
# why
Multiple users have asked for a more cachable way to use workflows like "log in to this account".

# what changed
We now allow users to pass in variables to act. Allowing the user to use the same prompt using different variables to increase caching likelihood

# test plan
Test it manually