### PR TITLE
add optional granular timeout;

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ This constructor is used to create an instance of Stagehand.
     - `1`: SDK-level logging
     - `2`: LLM-client level logging (most granular)
   - `debugDom`: a `boolean` that draws bounding boxes around elements presented to the LLM during automation.
-  - `domSettleTimeoutMs`: an `integer` that specifies the timeout in milliseconds for waiting for the DOM to settle. Defaults to 30000 (30 seconds).
+  - `domSettleTimeoutMs`: an `integer` that specifies the timeout in milliseconds for waiting for the DOM to settle. It can be overriden in individual function calls if needed. Defaults to 60000 (60 seconds).
   - `enableCaching`: a `boolean` that enables caching of LLM responses. When set to `true`, the LLM requests will be cached on disk and reused for identical requests. Defaults to `false`.
 
 - **Returns:**
@@ -179,6 +179,7 @@ This constructor is used to create an instance of Stagehand.
   - `action`: a `string` describing the action to perform, e.g., `"search for 'x'"`.
   - `modelName`: (optional) an `AvailableModel` string to specify the model to use.
   - `useVision`: (optional) a `boolean` or `"fallback"` to determine if vision-based processing should be used. Defaults to `"fallback"`.
+  - `domSettleTimeoutMs`: (optional) an `integer` that specifies the timeout in milliseconds for waiting for the DOM to settle. If not set, defaults to the timeout value specified during initialization.
 
 - **Returns:**
 
@@ -201,6 +202,7 @@ This constructor is used to create an instance of Stagehand.
   - `instruction`: a `string` providing instructions for extraction.
   - `schema`: a `z.AnyZodObject` defining the structure of the data to extract.
   - `modelName`: (optional) an `AvailableModel` string to specify the model to use.
+  - `domSettleTimeoutMs`: (optional) an `integer` that specifies the timeout in milliseconds for waiting for the DOM to settle. If not set, defaults to the timeout value specified during initialization.
 
 - **Returns:**
 
@@ -229,6 +231,7 @@ If you are looking for a specific element, you can also pass in an instruction t
 
   - `instruction`: a `string` providing instructions for the observation.
   - `useVision`: (optional) a `boolean` or `"fallback"` to determine if vision-based processing should be used. Defaults to `"fallback"`.
+  - `domSettleTimeoutMs`: (optional) an `integer` that specifies the timeout in milliseconds for waiting for the DOM to settle. If not set, defaults to the timeout value specified during initialization.
 
 - **Returns:**
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ This constructor is used to create an instance of Stagehand.
     - `1`: SDK-level logging
     - `2`: LLM-client level logging (most granular)
   - `debugDom`: a `boolean` that draws bounding boxes around elements presented to the LLM during automation.
-  - `domSettleTimeoutMs`: an `integer` that specifies the timeout in milliseconds for waiting for the DOM to settle. It can be overriden in individual function calls if needed. Defaults to 60000 (60 seconds).
+  - `domSettleTimeoutMs`: an `integer` that specifies the timeout in milliseconds for waiting for the DOM to settle. It can be overriden in individual function calls if needed. Defaults to 30000 (30 seconds).
   - `enableCaching`: a `boolean` that enables caching of LLM responses. When set to `true`, the LLM requests will be cached on disk and reused for identical requests. Defaults to `false`.
 
 - **Returns:**

--- a/evals/index.eval.ts
+++ b/evals/index.eval.ts
@@ -321,7 +321,9 @@ const homedepot = async () => {
 
   logger.init(stagehand);
 
-  const { debugUrl, sessionUrl } = await stagehand.init();
+  const { debugUrl, sessionUrl } = await stagehand.init({
+    domSettleTimeoutMs: 60_000,
+  });
 
   try {
     await stagehand.page.goto("https://www.homedepot.com/");

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -235,7 +235,7 @@ export class Stagehand {
     this.verbose = verbose ?? 0;
     this.debugDom = debugDom ?? false;
     this.defaultModelName = "gpt-4o";
-    this.domSettleTimeoutMs = domSettleTimeoutMs ?? 60_000;
+    this.domSettleTimeoutMs = domSettleTimeoutMs ?? 30_000;
     this.headless = headless ?? false;
     this.browserBaseSessionCreateParams = browserBaseSessionCreateParams;
   }


### PR DESCRIPTION
# why

Users may want to control timeout behavior per each call of each stagehand public api methods: `extract`, `act`, or `observe`.

# what changed
added optional timeout variable

# test plan
evals need to pass