### PR TITLE
remove internal oai zod helper

### DIFF
--- a/lib/llm/OpenAIClient.ts
+++ b/lib/llm/OpenAIClient.ts
@@ -1,5 +1,5 @@
 import OpenAI from "openai";
-import { zodResponseFormat } from "openai/helpers/zod";
+import { zodToJsonSchema } from 'zod-to-json-schema';
 import { LLMClient, ChatCompletionOptions } from "./LLMClient";
 import { LLMCache } from "../cache/LLMCache";
 
@@ -94,7 +94,7 @@ export class OpenAIClient implements LLMClient {
 
     let responseFormat = undefined;
     if (options.response_model) {
-      responseFormat = zodResponseFormat(
+      responseFormat = zodToJsonSchema(
         options.response_model.schema,
         options.response_model.name,
       );


### PR DESCRIPTION
# why
langchain integration should not introduce openai dependency which we have in internal zod helper.

# what changed
updated zod response format to be according to the zod-to-json-schema lib

# test plan
evals should pass.
