### PR TITLE
add tsc

### DIFF
--- a/examples/debugUrl.ts
+++ b/examples/debugUrl.ts
@@ -8,8 +8,6 @@ async function debug(url: string) {
   });
   await stagehand.init();
   await stagehand.page.goto(url);
-
-  await stagehand.startDomDebug();
 }
 
 (async () => {

--- a/examples/example.ts
+++ b/examples/example.ts
@@ -18,6 +18,7 @@ async function example() {
       username: z.string(),
       url: z.string(),
     }),
+    domSettleTimeoutMs: 60000, // wait up to 60 seconds for the page to load, contributors can sometimes take a while to load
   });
   console.log(`Our favorite contributor is ${contributor.username}`);
 }

--- a/lib/dom/debug.ts
+++ b/lib/dom/debug.ts
@@ -1,4 +1,4 @@
-async function debugDom() {
+export async function debugDom() {
   window.chunkNumber = 0;
 
   const { selectorMap: multiSelectorMap, outputString } =
@@ -10,7 +10,7 @@ async function debugDom() {
   setupChunkNav();
 }
 
-function multiSelectorMapToSelectorMap(
+export function multiSelectorMapToSelectorMap(
   multiSelectorMap: Record<number, string[]>,
 ) {
   return Object.fromEntries(
@@ -21,7 +21,7 @@ function multiSelectorMapToSelectorMap(
   );
 }
 
-function drawChunk(selectorMap: Record<number, string>) {
+export function drawChunk(selectorMap: Record<number, string>) {
   cleanupMarkers();
   Object.entries(selectorMap).forEach(([_index, selector]) => {
     const element = document.evaluate(
@@ -61,26 +61,26 @@ function drawChunk(selectorMap: Record<number, string>) {
   });
 }
 
-async function cleanupDebug() {
+export async function cleanupDebug() {
   cleanupMarkers();
   cleanupNav();
 }
 
-function cleanupMarkers() {
+export function cleanupMarkers() {
   const markers = document.querySelectorAll(".stagehand-marker");
   markers.forEach((marker) => {
     marker.remove();
   });
 }
 
-function cleanupNav() {
+export function cleanupNav() {
   const stagehandNavElements = document.querySelectorAll(".stagehand-nav");
   stagehandNavElements.forEach((element) => {
     element.remove();
   });
 }
 
-function setupChunkNav() {
+export function setupChunkNav() {
   const viewportHeight = window.innerHeight;
   const documentHeight = document.documentElement.scrollHeight;
   const totalChunks = Math.ceil(documentHeight / viewportHeight);

--- a/lib/dom/utils.ts
+++ b/lib/dom/utils.ts
@@ -1,4 +1,4 @@
-async function waitForDomSettle() {
+export async function waitForDomSettle() {
   return new Promise<void>((resolve) => {
     const createTimeout = () => {
       return setTimeout(() => {

--- a/lib/llm/LLMClient.ts
+++ b/lib/llm/LLMClient.ts
@@ -4,11 +4,16 @@ export interface ChatMessage {
   role: "system" | "user" | "assistant";
   content:
     | string
-    | {
-        type: "image_url" | "text";
-        image_url?: { url: string };
-        text?: string;
-      }[];
+    | (
+        | {
+            type: "image_url";
+            image_url: { url: string };
+          }
+        | {
+            type: "text";
+            text: string;
+          }
+      );
 }
 
 export const modelsWithVision: AvailableModel[] = [
@@ -19,6 +24,27 @@ export const modelsWithVision: AvailableModel[] = [
   "claude-3-5-sonnet-20241022",
   "gpt-4o-2024-08-06",
 ];
+
+export type ChatResponse = {
+  id: string;
+  object: "chat.completion";
+  created: number;
+  model: string;
+  choices: {
+    index: number;
+    message: {
+      role: "user" | "assistant";
+      content: string;
+      tool_calls?: unknown;
+    };
+    finish_reason: string;
+  }[];
+  usage: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  };
+};
 
 export const AnnotatedScreenshotText =
   "This is a screenshot of the current page state with the elements annotated on it. Each element id is annotated with a number to the top left of it. Duplicate annotations at the same location are under each other vertically.";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@browserbasehq/stagehand",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@browserbasehq/stagehand",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.27.3",


### PR DESCRIPTION
# why
We don't have actual typing, and we can't easily compile the project with TSC. There's still a way to go with getting rid of `any` and `as`, but this at least allows us to build the project with `tsc`. 

# what changed
Add stronger typing 

# test plan
Ran tsc and ran example with GPT and Claude