### PR TITLE
Client Parameterization

### DIFF
--- a/lib/handlers/actHandler.ts
+++ b/lib/handlers/actHandler.ts
@@ -9,7 +9,7 @@ import {
 } from "../types";
 import { Locator, Page } from "@playwright/test";
 import { ActionCache } from "../cache/ActionCache";
-import { modelsWithVision } from "../llm/LLMClient";
+import { LLMClient, modelsWithVision } from "../llm/LLMClient";
 import { generateId } from "../utils";
 
 export class StagehandActHandler {
@@ -75,6 +75,7 @@ export class StagehandActHandler {
     requestId,
     action,
     steps,
+    llmClient,
     model,
     domSettleTimeoutMs,
   }: {
@@ -83,6 +84,7 @@ export class StagehandActHandler {
     requestId: string;
     action: string;
     steps: string;
+    llmClient: LLMClient;
     model: AvailableModel;
     domSettleTimeoutMs?: number;
   }): Promise<boolean> {
@@ -157,6 +159,7 @@ export class StagehandActHandler {
       actionCompleted = await verifyActCompletion({
         goal: action,
         steps,
+        llmClient: llmClient,
         llmProvider: this.llmProvider,
         modelName: model,
         screenshot: fullpageScreenshot,
@@ -712,6 +715,7 @@ export class StagehandActHandler {
     requestId,
     steps,
     chunksSeen,
+    llmClient,
     modelName,
     useVision,
     verifierUseVision,
@@ -725,6 +729,7 @@ export class StagehandActHandler {
     requestId: string;
     steps: string;
     chunksSeen: number[];
+    llmClient: LLMClient;
     modelName: AvailableModel;
     useVision: boolean | "fallback";
     verifierUseVision: boolean;
@@ -859,6 +864,7 @@ export class StagehandActHandler {
         let actionCompleted = await this._verifyActionCompletion({
           completed: true,
           verifierUseVision,
+          llmClient,
           model,
           steps,
           requestId,
@@ -891,6 +897,7 @@ export class StagehandActHandler {
         action,
         steps,
         chunksSeen,
+        llmClient,
         modelName,
         useVision,
         verifierUseVision,
@@ -927,6 +934,7 @@ export class StagehandActHandler {
     action,
     steps = "",
     chunksSeen,
+    llmClient,
     modelName,
     useVision,
     verifierUseVision,
@@ -940,6 +948,7 @@ export class StagehandActHandler {
     action: string;
     steps?: string;
     chunksSeen: number[];
+    llmClient: LLMClient;
     modelName?: AvailableModel;
     useVision: boolean | "fallback";
     verifierUseVision: boolean;
@@ -964,6 +973,7 @@ export class StagehandActHandler {
           requestId,
           steps,
           chunksSeen,
+          llmClient,
           modelName: model,
           useVision,
           verifierUseVision,
@@ -980,6 +990,7 @@ export class StagehandActHandler {
             action,
             steps,
             chunksSeen,
+            llmClient,
             modelName,
             useVision,
             verifierUseVision,
@@ -1105,6 +1116,7 @@ export class StagehandActHandler {
         action,
         domElements: outputString,
         steps,
+        llmClient,
         llmProvider: this.llmProvider,
         modelName: model,
         screenshot: annotatedScreenshot,
@@ -1150,6 +1162,7 @@ export class StagehandActHandler {
               (!steps.endsWith("\n") ? "\n" : "") +
               "## Step: Scrolled to another section\n",
             chunksSeen,
+            llmClient,
             modelName,
             useVision,
             verifierUseVision,
@@ -1176,6 +1189,7 @@ export class StagehandActHandler {
             action,
             steps,
             chunksSeen,
+            llmClient,
             modelName,
             useVision: true,
             verifierUseVision,
@@ -1312,6 +1326,7 @@ export class StagehandActHandler {
           requestId,
           action,
           steps,
+          llmClient,
           model,
           domSettleTimeoutMs,
         });
@@ -1326,6 +1341,7 @@ export class StagehandActHandler {
           return this.act({
             action,
             steps,
+            llmClient,
             modelName,
             chunksSeen,
             useVision,
@@ -1374,6 +1390,7 @@ export class StagehandActHandler {
           return this.act({
             action,
             steps,
+            llmClient,
             modelName,
             useVision,
             verifierUseVision,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -306,7 +306,6 @@ export class Stagehand {
       projectId,
       verbose,
       debugDom,
-      // initllmClient: llmClient,
       llmProvider,
       headless,
       logger,
@@ -320,7 +319,6 @@ export class Stagehand {
       projectId?: string;
       verbose?: 0 | 1 | 2;
       debugDom?: boolean;
-      // initllmClient?: LLMClient;
       llmProvider?: LLMProvider;
       headless?: boolean;
       logger?: (message: LogLine) => void;
@@ -392,12 +390,6 @@ export class Stagehand {
     await this._waitForSettledDom();
 
     this.defaultModelName = modelName;
-    // this.llmClient =
-    //   llmClient ||
-    //   resolveLLMClient({
-    //     llmProvider: this.llmProvider,
-    //     modelName,
-    //   });
     this.domSettleTimeoutMs = domSettleTimeoutMs ?? this.domSettleTimeoutMs;
 
     // Overload the page.goto method

--- a/lib/inference.ts
+++ b/lib/inference.ts
@@ -24,7 +24,7 @@ import { resolveLLMClient } from "./llm/LLMProvider";
 export async function verifyActCompletion({
   goal,
   steps,
-  llmClient,
+  initllmClient,
   llmProvider,
   modelName,
   screenshot,
@@ -34,7 +34,7 @@ export async function verifyActCompletion({
 }: {
   goal: string;
   steps: string;
-  llmClient?: LLMClient;
+  initllmClient?: LLMClient;
   llmProvider?: LLMProvider;
   modelName?: AvailableModel;
   screenshot?: Buffer;
@@ -42,7 +42,8 @@ export async function verifyActCompletion({
   logger: (message: { category?: string; message: string }) => void;
   requestId: string;
 }): Promise<boolean> {
-  llmClient = resolveLLMClient(llmClient, llmProvider, modelName, requestId);
+  const llmClient =
+    initllmClient || resolveLLMClient({ llmProvider, modelName, requestId });
 
   const messages: ChatMessage[] = [
     buildVerifyActCompletionSystemPrompt(),
@@ -105,7 +106,7 @@ export async function act({
   action,
   domElements,
   steps,
-  llmClient,
+  initllmClient,
   llmProvider,
   modelName,
   screenshot,
@@ -117,7 +118,7 @@ export async function act({
   action: string;
   steps?: string;
   domElements: string;
-  llmClient?: LLMClient;
+  initllmClient?: LLMClient;
   llmProvider?: LLMProvider;
   modelName?: AvailableModel;
   screenshot?: Buffer;
@@ -133,7 +134,8 @@ export async function act({
   step: string;
   why?: string;
 } | null> {
-  llmClient = resolveLLMClient(llmClient, llmProvider, modelName, requestId);
+  const llmClient =
+    initllmClient || resolveLLMClient({ llmProvider, modelName, requestId });
 
   const messages: ChatMessage[] = [
     buildActSystemPrompt(),
@@ -190,7 +192,7 @@ export async function extract({
   previouslyExtractedContent,
   domElements,
   schema,
-  llmClient,
+  initllmClient,
   llmProvider,
   modelName,
   chunksSeen,
@@ -202,14 +204,15 @@ export async function extract({
   previouslyExtractedContent: any;
   domElements: string;
   schema: z.ZodObject<any>;
-  llmClient?: LLMClient;
+  initllmClient?: LLMClient;
   llmProvider?: LLMProvider;
   modelName?: AvailableModel;
   chunksSeen: number;
   chunksTotal: number;
   requestId: string;
 }) {
-  llmClient = resolveLLMClient(llmClient, llmProvider, modelName, requestId);
+  const llmClient =
+    initllmClient || resolveLLMClient({ llmProvider, modelName, requestId });
 
   const extractionResponse = await llmClient.createChatCompletion({
     model: modelName,
@@ -289,7 +292,7 @@ export async function extract({
 export async function observe({
   instruction,
   domElements,
-  llmClient,
+  initllmClient,
   llmProvider,
   modelName,
   image,
@@ -297,7 +300,7 @@ export async function observe({
 }: {
   instruction: string;
   domElements: string;
-  llmClient?: LLMClient;
+  initllmClient?: LLMClient;
   llmProvider?: LLMProvider;
   modelName?: AvailableModel;
   image?: Buffer;
@@ -320,7 +323,8 @@ export async function observe({
       .describe("an array of elements that match the instruction"),
   });
 
-  llmClient = resolveLLMClient(llmClient, llmProvider, modelName, requestId);
+  const llmClient =
+    initllmClient || resolveLLMClient({ llmProvider, modelName, requestId });
 
   const observationResponse = await llmClient.createChatCompletion({
     model: modelName,
@@ -350,18 +354,19 @@ export async function observe({
 
 export async function ask({
   question,
-  llmClient,
+  initllmClient,
   llmProvider,
   modelName,
   requestId,
 }: {
   question: string;
-  llmClient?: LLMClient;
+  initllmClient?: LLMClient;
   llmProvider?: LLMProvider;
   modelName?: AvailableModel;
   requestId: string;
 }) {
-  llmClient = resolveLLMClient(llmClient, llmProvider, modelName, requestId);
+  const llmClient =
+    initllmClient || resolveLLMClient({ llmProvider, modelName, requestId });
 
   const response = await llmClient.createChatCompletion({
     model: modelName,

--- a/lib/inference.ts
+++ b/lib/inference.ts
@@ -24,7 +24,7 @@ import { resolveLLMClient } from "./llm/LLMProvider";
 export async function verifyActCompletion({
   goal,
   steps,
-  initllmClient,
+  initllmClient: llmClient,
   llmProvider,
   modelName,
   screenshot,
@@ -42,8 +42,8 @@ export async function verifyActCompletion({
   logger: (message: { category?: string; message: string }) => void;
   requestId: string;
 }): Promise<boolean> {
-  const llmClient =
-    initllmClient || resolveLLMClient({ llmProvider, modelName, requestId });
+  llmClient =
+    llmClient || resolveLLMClient({ llmProvider, modelName, requestId });
 
   const messages: ChatMessage[] = [
     buildVerifyActCompletionSystemPrompt(),
@@ -106,7 +106,7 @@ export async function act({
   action,
   domElements,
   steps,
-  initllmClient,
+  initllmClient: llmClient,
   llmProvider,
   modelName,
   screenshot,
@@ -134,8 +134,8 @@ export async function act({
   step: string;
   why?: string;
 } | null> {
-  const llmClient =
-    initllmClient || resolveLLMClient({ llmProvider, modelName, requestId });
+  llmClient =
+    llmClient || resolveLLMClient({ llmProvider, modelName, requestId });
 
   const messages: ChatMessage[] = [
     buildActSystemPrompt(),
@@ -192,7 +192,7 @@ export async function extract({
   previouslyExtractedContent,
   domElements,
   schema,
-  initllmClient,
+  initllmClient: llmClient,
   llmProvider,
   modelName,
   chunksSeen,
@@ -211,8 +211,8 @@ export async function extract({
   chunksTotal: number;
   requestId: string;
 }) {
-  const llmClient =
-    initllmClient || resolveLLMClient({ llmProvider, modelName, requestId });
+  llmClient =
+    llmClient || resolveLLMClient({ llmProvider, modelName, requestId });
 
   const extractionResponse = await llmClient.createChatCompletion({
     model: modelName,
@@ -292,7 +292,7 @@ export async function extract({
 export async function observe({
   instruction,
   domElements,
-  initllmClient,
+  initllmClient: llmClient,
   llmProvider,
   modelName,
   image,
@@ -323,8 +323,8 @@ export async function observe({
       .describe("an array of elements that match the instruction"),
   });
 
-  const llmClient =
-    initllmClient || resolveLLMClient({ llmProvider, modelName, requestId });
+  llmClient =
+    llmClient || resolveLLMClient({ llmProvider, modelName, requestId });
 
   const observationResponse = await llmClient.createChatCompletion({
     model: modelName,
@@ -354,7 +354,7 @@ export async function observe({
 
 export async function ask({
   question,
-  initllmClient,
+  initllmClient: llmClient,
   llmProvider,
   modelName,
   requestId,
@@ -365,8 +365,8 @@ export async function ask({
   modelName?: AvailableModel;
   requestId: string;
 }) {
-  const llmClient =
-    initllmClient || resolveLLMClient({ llmProvider, modelName, requestId });
+  llmClient =
+    llmClient || resolveLLMClient({ llmProvider, modelName, requestId });
 
   const response = await llmClient.createChatCompletion({
     model: modelName,

--- a/lib/inference.ts
+++ b/lib/inference.ts
@@ -24,7 +24,7 @@ import { resolveLLMClient } from "./llm/LLMProvider";
 export async function verifyActCompletion({
   goal,
   steps,
-  initllmClient: llmClient,
+  llmClient: initllmClient,
   llmProvider,
   modelName,
   screenshot,
@@ -34,7 +34,7 @@ export async function verifyActCompletion({
 }: {
   goal: string;
   steps: string;
-  initllmClient?: LLMClient;
+  llmClient: LLMClient;
   llmProvider?: LLMProvider;
   modelName?: AvailableModel;
   screenshot?: Buffer;
@@ -42,8 +42,8 @@ export async function verifyActCompletion({
   logger: (message: { category?: string; message: string }) => void;
   requestId: string;
 }): Promise<boolean> {
-  llmClient =
-    llmClient || resolveLLMClient({ llmProvider, modelName, requestId });
+  const llmClient =
+    initllmClient || resolveLLMClient({ llmProvider, modelName, requestId });
 
   const messages: ChatMessage[] = [
     buildVerifyActCompletionSystemPrompt(),
@@ -106,7 +106,7 @@ export async function act({
   action,
   domElements,
   steps,
-  initllmClient: llmClient,
+  llmClient: initllmClient,
   llmProvider,
   modelName,
   screenshot,
@@ -118,7 +118,7 @@ export async function act({
   action: string;
   steps?: string;
   domElements: string;
-  initllmClient?: LLMClient;
+  llmClient: LLMClient;
   llmProvider?: LLMProvider;
   modelName?: AvailableModel;
   screenshot?: Buffer;
@@ -134,8 +134,8 @@ export async function act({
   step: string;
   why?: string;
 } | null> {
-  llmClient =
-    llmClient || resolveLLMClient({ llmProvider, modelName, requestId });
+  const llmClient =
+    initllmClient || resolveLLMClient({ llmProvider, modelName, requestId });
 
   const messages: ChatMessage[] = [
     buildActSystemPrompt(),
@@ -177,6 +177,7 @@ export async function act({
       action,
       domElements,
       steps,
+      llmClient,
       llmProvider,
       modelName,
       retries: retries + 1,
@@ -192,7 +193,7 @@ export async function extract({
   previouslyExtractedContent,
   domElements,
   schema,
-  initllmClient: llmClient,
+  llmClient: initllmClient,
   llmProvider,
   modelName,
   chunksSeen,
@@ -204,15 +205,15 @@ export async function extract({
   previouslyExtractedContent: any;
   domElements: string;
   schema: z.ZodObject<any>;
-  initllmClient?: LLMClient;
+  llmClient: LLMClient;
   llmProvider?: LLMProvider;
   modelName?: AvailableModel;
   chunksSeen: number;
   chunksTotal: number;
   requestId: string;
 }) {
-  llmClient =
-    llmClient || resolveLLMClient({ llmProvider, modelName, requestId });
+  const llmClient =
+    initllmClient || resolveLLMClient({ llmProvider, modelName, requestId });
 
   const extractionResponse = await llmClient.createChatCompletion({
     model: modelName,
@@ -292,7 +293,7 @@ export async function extract({
 export async function observe({
   instruction,
   domElements,
-  initllmClient: llmClient,
+  llmClient: initllmClient,
   llmProvider,
   modelName,
   image,
@@ -300,7 +301,7 @@ export async function observe({
 }: {
   instruction: string;
   domElements: string;
-  initllmClient?: LLMClient;
+  llmClient: LLMClient;
   llmProvider?: LLMProvider;
   modelName?: AvailableModel;
   image?: Buffer;
@@ -323,8 +324,8 @@ export async function observe({
       .describe("an array of elements that match the instruction"),
   });
 
-  llmClient =
-    llmClient || resolveLLMClient({ llmProvider, modelName, requestId });
+  const llmClient =
+    initllmClient || resolveLLMClient({ llmProvider, modelName, requestId });
 
   const observationResponse = await llmClient.createChatCompletion({
     model: modelName,
@@ -354,19 +355,19 @@ export async function observe({
 
 export async function ask({
   question,
-  initllmClient: llmClient,
+  llmClient: initllmClient,
   llmProvider,
   modelName,
   requestId,
 }: {
   question: string;
-  initllmClient?: LLMClient;
+  llmClient: LLMClient;
   llmProvider?: LLMProvider;
   modelName?: AvailableModel;
   requestId: string;
 }) {
-  llmClient =
-    llmClient || resolveLLMClient({ llmProvider, modelName, requestId });
+  const llmClient =
+    initllmClient || resolveLLMClient({ llmProvider, modelName, requestId });
 
   const response = await llmClient.createChatCompletion({
     model: modelName,

--- a/lib/llm/LLMProvider.ts
+++ b/lib/llm/LLMProvider.ts
@@ -78,19 +78,19 @@ export class LLMProvider {
   }
 }
 
-export const resolveLLMClient = (
-  llmClient?: LLMClient,
-  llmProvider?: LLMProvider,
-  modelName?: AvailableModel,
-  requestId?: string,
-) => {
-  if (!llmClient) {
-    if (!llmProvider || !modelName || !requestId) {
-      throw new Error(
-        "Either llmClient or llmProvider, modelName, and requestId must be provided",
-      );
-    }
-    return llmProvider.getClient(modelName, requestId);
+export const resolveLLMClient = ({
+  llmProvider,
+  modelName,
+  requestId,
+}: {
+  llmProvider?: LLMProvider;
+  modelName?: AvailableModel;
+  requestId?: string;
+}) => {
+  if (!llmProvider || !modelName || !requestId) {
+    throw new Error(
+      "Either llmProvider, modelName, and requestId must be provided",
+    );
   }
-  return llmClient;
+  return llmProvider.getClient(modelName, requestId);
 };

--- a/lib/llm/LLMProvider.ts
+++ b/lib/llm/LLMProvider.ts
@@ -77,3 +77,20 @@ export class LLMProvider {
     }
   }
 }
+
+export const resolveLLMClient = (
+  llmClient?: LLMClient,
+  llmProvider?: LLMProvider,
+  modelName?: AvailableModel,
+  requestId?: string,
+) => {
+  if (!llmClient) {
+    if (!llmProvider || !modelName || !requestId) {
+      throw new Error(
+        "Either llmClient or llmProvider, modelName, and requestId must be provided",
+      );
+    }
+    return llmProvider.getClient(modelName, requestId);
+  }
+  return llmClient;
+};


### PR DESCRIPTION
Add: 
Independent events (act, extract, observe) configured to take in LLMClient objects as parameters as an alternative to the model name and the LLMProvider class.