### PR TITLE
small refactor. Moved the handlers into separate files

### DIFF
--- a/lib/dom/debug.ts
+++ b/lib/dom/debug.ts
@@ -1,12 +1,24 @@
 async function debugDom() {
   window.chunkNumber = 0;
 
-  const { selectorMap, outputString } = await window.processElements(
-    window.chunkNumber,
-  );
+  const { selectorMap: multiSelectorMap, outputString } =
+    await window.processElements(window.chunkNumber);
+
+  const selectorMap = multiSelectorMapToSelectorMap(multiSelectorMap);
 
   drawChunk(selectorMap);
   setupChunkNav();
+}
+
+function multiSelectorMapToSelectorMap(
+  multiSelectorMap: Record<number, string[]>,
+) {
+  return Object.fromEntries(
+    Object.entries(multiSelectorMap).map(([key, selectors]) => [
+      Number(key),
+      selectors[0],
+    ]),
+  );
 }
 
 function drawChunk(selectorMap: Record<number, string>) {
@@ -90,7 +102,12 @@ function setupChunkNav() {
       window.chunkNumber -= 1;
       window.scrollTo(0, window.chunkNumber * window.innerHeight);
       await window.waitForDomSettle();
-      const { selectorMap } = await processElements(window.chunkNumber);
+      const { selectorMap: multiSelectorMap } = await window.processElements(
+        window.chunkNumber,
+      );
+
+      const selectorMap = multiSelectorMapToSelectorMap(multiSelectorMap);
+
       drawChunk(selectorMap);
       setupChunkNav();
     };
@@ -113,7 +130,10 @@ function setupChunkNav() {
       window.scrollTo(0, window.chunkNumber * window.innerHeight);
       await window.waitForDomSettle();
 
-      const { selectorMap } = await processElements(window.chunkNumber);
+      const { selectorMap: multiSelectorMap } = await window.processElements(
+        window.chunkNumber,
+      );
+      const selectorMap = multiSelectorMapToSelectorMap(multiSelectorMap);
       drawChunk(selectorMap);
       setupChunkNav();
     };

--- a/lib/dom/process.ts
+++ b/lib/dom/process.ts
@@ -10,11 +10,7 @@ export function isTextNode(node: Node): node is Text {
 
 export async function processDom(chunksSeen: Array<number>) {
   const { chunk, chunksArray } = await pickChunk(chunksSeen);
-  const { outputString, selectorMap } = await processElements(
-    chunk,
-    undefined,
-    undefined,
-  );
+  const { outputString, selectorMap } = await processElements(chunk);
 
   console.log(
     `Stagehand (Browser Process): Extracted dom elements:\n${outputString}`,

--- a/lib/dom/xpathUtils.ts
+++ b/lib/dom/xpathUtils.ts
@@ -114,7 +114,7 @@ export async function generateXPathsForElement(
   // This should return in order from most accurate on current page to most cachable.
   // Do not change the order if you are not sure what you are doing.
   // Contact Navid if you need help understanding it.
-  return [...(idBasedXPath ? [idBasedXPath] : []), standardXPath, complexXPath];
+  return [standardXPath, ...(idBasedXPath ? [idBasedXPath] : []), complexXPath];
 }
 
 async function generateComplexXPath(element: ChildNode): Promise<string> {

--- a/lib/dom/xpathUtils.ts
+++ b/lib/dom/xpathUtils.ts
@@ -212,34 +212,28 @@ async function generateStandardXPath(element: ChildNode): Promise<string> {
     const siblings = element.parentElement
       ? Array.from(element.parentElement.childNodes)
       : [];
-
     for (let i = 0; i < siblings.length; i++) {
       const sibling = siblings[i];
-
       if (
         sibling.nodeType === element.nodeType &&
         sibling.nodeName === element.nodeName
       ) {
         index = index + 1;
         hasSameTypeSiblings = true;
-
         if (sibling.isSameNode(element)) {
           break;
         }
       }
     }
-
     // text "nodes" are selected differently than elements with xPaths
     if (element.nodeName !== "#text") {
       const tagName = element.nodeName.toLowerCase();
       const pathIndex = hasSameTypeSiblings ? `[${index}]` : "";
       parts.unshift(`${tagName}${pathIndex}`);
     }
-
     element = element.parentElement as HTMLElement;
   }
-
-  return parts.length ? `//${parts.join("//")}` : "";
+  return parts.length ? `/${parts.join("/")}` : "";
 }
 
 async function generatedIdBasedXPath(

--- a/lib/handlers/extractHandler.ts
+++ b/lib/handlers/extractHandler.ts
@@ -1,0 +1,142 @@
+import { Stagehand } from "../index";
+import { AvailableModel, LLMProvider } from "../llm/LLMProvider";
+import { extract } from "../inference";
+import { z } from "zod";
+
+export class StagehandExtractHandler {
+  private readonly stagehand: Stagehand;
+  private readonly llmProvider: LLMProvider;
+  private readonly defaultModelName: AvailableModel;
+  private readonly logger: (log: {
+    category: string;
+    message: string;
+    level: 0 | 1 | 2;
+  }) => void;
+  private readonly waitForSettledDom: (
+    domSettleTimeoutMs?: number,
+  ) => Promise<void>;
+  private readonly startDomDebug: () => Promise<void>;
+  private readonly cleanupDomDebug: () => Promise<void>;
+
+  constructor({
+    stagehand,
+    llmProvider,
+    defaultModelName,
+    logger,
+    waitForSettledDom,
+    startDomDebug,
+    cleanupDomDebug,
+  }: {
+    stagehand: Stagehand;
+    llmProvider: LLMProvider;
+    defaultModelName: AvailableModel;
+    logger: (log: {
+      category: string;
+      message: string;
+      level: 0 | 1 | 2;
+    }) => void;
+    waitForSettledDom: (domSettleTimeoutMs?: number) => Promise<void>;
+    startDomDebug: () => Promise<void>;
+    cleanupDomDebug: () => Promise<void>;
+  }) {
+    this.stagehand = stagehand;
+    this.llmProvider = llmProvider;
+    this.defaultModelName = defaultModelName;
+    this.logger = logger;
+    this.waitForSettledDom = waitForSettledDom;
+    this.startDomDebug = startDomDebug;
+    this.cleanupDomDebug = cleanupDomDebug;
+  }
+
+  public async extract<T extends z.AnyZodObject>({
+    instruction,
+    schema,
+    progress = "",
+    content = {},
+    chunksSeen = [],
+    modelName,
+    requestId,
+    domSettleTimeoutMs,
+  }: {
+    instruction: string;
+    schema: T;
+    progress?: string;
+    content?: z.infer<T>;
+    chunksSeen?: Array<number>;
+    modelName?: AvailableModel;
+    requestId?: string;
+    domSettleTimeoutMs?: number;
+  }): Promise<z.infer<T>> {
+    this.logger({
+      category: "extraction",
+      message: `starting extraction '${instruction}'`,
+      level: 1,
+    });
+
+    await this.waitForSettledDom(domSettleTimeoutMs);
+    await this.startDomDebug();
+    const { outputString, chunk, chunks } = await this.stagehand.page.evaluate(
+      (chunksSeen?: number[]) => window.processDom(chunksSeen ?? []),
+      chunksSeen,
+    );
+
+    this.logger({
+      category: "extraction",
+      message: `received output from processDom. Current chunk index: ${chunk}, Number of chunks left: ${chunks.length - chunksSeen.length}`,
+      level: 1,
+    });
+
+    const extractionResponse = await extract({
+      instruction,
+      progress,
+      previouslyExtractedContent: content,
+      domElements: outputString,
+      llmProvider: this.llmProvider,
+      schema,
+      modelName: modelName || this.defaultModelName,
+      chunksSeen: chunksSeen.length,
+      chunksTotal: chunks.length,
+      requestId,
+    });
+
+    const {
+      metadata: { progress: newProgress, completed },
+      ...output
+    } = extractionResponse;
+    await this.cleanupDomDebug();
+
+    this.logger({
+      category: "extraction",
+      message: `received extraction response: ${JSON.stringify(extractionResponse)}`,
+      level: 1,
+    });
+
+    chunksSeen.push(chunk);
+
+    if (completed || chunksSeen.length === chunks.length) {
+      this.logger({
+        category: "extraction",
+        message: `response: ${JSON.stringify(extractionResponse)}`,
+        level: 1,
+      });
+
+      return output;
+    } else {
+      this.logger({
+        category: "extraction",
+        message: `continuing extraction, progress: '${newProgress}'`,
+        level: 1,
+      });
+      await this.waitForSettledDom(domSettleTimeoutMs);
+      return this.extract({
+        instruction,
+        schema,
+        progress: newProgress,
+        content: output,
+        chunksSeen,
+        modelName,
+        domSettleTimeoutMs,
+      });
+    }
+  }
+}

--- a/lib/handlers/observeHandler.ts
+++ b/lib/handlers/observeHandler.ts
@@ -1,0 +1,158 @@
+import { AvailableModel, LLMProvider } from "../llm/LLMProvider";
+import { observe } from "../inference";
+import { ScreenshotService } from "../vision";
+import { modelsWithVision } from "../llm/LLMClient";
+import { Stagehand } from "../index";
+import { generateId } from "../utils";
+
+export class StagehandObserveHandler {
+  private readonly stagehand: Stagehand;
+  private readonly llmProvider: LLMProvider;
+  private readonly defaultModelName: AvailableModel;
+  private readonly logger: (message: {
+    category?: string;
+    message: string;
+  }) => void;
+  private readonly waitForSettledDom: (
+    domSettleTimeoutMs?: number,
+  ) => Promise<void>;
+  private readonly startDomDebug: () => Promise<void>;
+  private readonly cleanupDomDebug: () => Promise<void>;
+  private observations: {
+    [key: string]: {
+      result: { selector: string; description: string }[];
+      instruction: string;
+    };
+  };
+
+  constructor({
+    stagehand,
+    llmProvider,
+    defaultModelName,
+    logger,
+    waitForSettledDom,
+    startDomDebug,
+    cleanupDomDebug,
+  }: {
+    stagehand: Stagehand;
+    llmProvider: LLMProvider;
+    defaultModelName: AvailableModel;
+    logger: ({
+      category,
+      message,
+    }: {
+      category: string;
+      message: string;
+    }) => void;
+    waitForSettledDom: (domSettleTimeoutMs?: number) => Promise<void>;
+    startDomDebug: () => Promise<void>;
+    cleanupDomDebug: () => Promise<void>;
+  }) {
+    this.stagehand = stagehand;
+    this.llmProvider = llmProvider;
+    this.defaultModelName = defaultModelName;
+    this.logger = logger;
+    this.waitForSettledDom = waitForSettledDom;
+    this.startDomDebug = startDomDebug;
+    this.cleanupDomDebug = cleanupDomDebug;
+    this.observations = {};
+  }
+
+  private async _recordObservation(
+    instruction: string,
+    result: { selector: string; description: string }[],
+  ): Promise<string> {
+    const id = generateId(instruction);
+
+    this.observations[id] = { result, instruction };
+
+    return id;
+  }
+
+  public async observe({
+    instruction,
+    useVision,
+    fullPage,
+    modelName,
+    requestId,
+    domSettleTimeoutMs,
+  }: {
+    instruction: string;
+    useVision: boolean;
+    fullPage: boolean;
+    modelName?: AvailableModel;
+    requestId?: string;
+    domSettleTimeoutMs?: number;
+  }): Promise<{ selector: string; description: string }[]> {
+    if (!instruction) {
+      instruction = `Find elements that can be used for any future actions in the page. These may be navigation links, related pages, section/subsection links, buttons, or other interactive elements. Be comprehensive: if there are multiple elements that may be relevant for future actions, return all of them.`;
+    }
+
+    const model = modelName ?? this.defaultModelName;
+
+    this.logger({
+      category: "observation",
+      message: `starting observation: ${instruction}`,
+    });
+
+    await this.waitForSettledDom(domSettleTimeoutMs);
+    await this.startDomDebug();
+    let { outputString, selectorMap } = await this.stagehand.page.evaluate(
+      (fullPage: boolean) =>
+        fullPage ? window.processAllOfDom() : window.processDom([]),
+      fullPage,
+    );
+
+    let annotatedScreenshot: Buffer | undefined;
+    if (useVision === true) {
+      if (!modelsWithVision.includes(model)) {
+        this.logger({
+          category: "observation",
+          message: `${model} does not support vision. Skipping vision processing.`,
+        });
+      } else {
+        const screenshotService = new ScreenshotService(
+          this.stagehand.page,
+          selectorMap,
+          this.stagehand.verbose,
+        );
+
+        annotatedScreenshot =
+          await screenshotService.getAnnotatedScreenshot(fullPage);
+        outputString = "n/a. use the image to find the elements.";
+      }
+    }
+
+    const observationResponse = await observe({
+      instruction,
+      domElements: outputString,
+      llmProvider: this.llmProvider,
+      modelName: modelName || this.defaultModelName,
+      image: annotatedScreenshot,
+      requestId,
+    });
+
+    const elementsWithSelectors = observationResponse.elements.map(
+      (element) => {
+        const { elementId, ...rest } = element;
+
+        return {
+          ...rest,
+          selector: `xpath=${selectorMap[elementId][0]}`,
+        };
+      },
+    );
+
+    await this.cleanupDomDebug();
+
+    this._recordObservation(instruction, elementsWithSelectors);
+
+    this.logger({
+      category: "observation",
+      message: `found element ${JSON.stringify(elementsWithSelectors)}`,
+    });
+
+    await this._recordObservation(instruction, elementsWithSelectors);
+    return elementsWithSelectors;
+  }
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -7,7 +7,6 @@ import { AvailableModel, LLMProvider } from "./llm/LLMProvider";
 import path from "path";
 import { ScreenshotService } from "./vision";
 import { modelsWithVision } from "./llm/LLMClient";
-import { ActionCache } from "./cache/ActionCache";
 import { StagehandActHandler } from "./handlers/actHandler";
 import { generateId } from "./utils";
 

--- a/lib/llm/AnthropicClient.ts
+++ b/lib/llm/AnthropicClient.ts
@@ -36,6 +36,16 @@ export class AnthropicClient implements LLMClient {
   async createChatCompletion(
     options: ChatCompletionOptions & { retries?: number },
   ) {
+    const { image: _, ...optionsWithoutImage } = options;
+    this.logger({
+      category: "Anthropic",
+      message: `Creating chat completion with options: ${JSON.stringify(
+        optionsWithoutImage,
+        null,
+        2,
+      )}`,
+      level: 1,
+    });
     // Try to get cached response
     const cacheOptions = {
       model: options.model,
@@ -143,6 +153,12 @@ export class AnthropicClient implements LLMClient {
       tools: anthropicTools,
       system: systemMessage?.content,
       temperature: options.temperature,
+    });
+
+    this.logger({
+      category: "Anthropic",
+      message: `Response: ${JSON.stringify(response, null, 2)}`,
+      level: 1,
     });
 
     // Parse the response here

--- a/lib/llm/OpenAIClient.ts
+++ b/lib/llm/OpenAIClient.ts
@@ -32,6 +32,16 @@ export class OpenAIClient implements LLMClient {
   }
 
   async createChatCompletion(options: ChatCompletionOptions) {
+    const { image: _, ...optionsWithoutImage } = options;
+    this.logger({
+      category: "OpenAI",
+      message: `Creating chat completion with options: ${JSON.stringify(
+        optionsWithoutImage,
+        null,
+        2,
+      )}`,
+      level: 1,
+    });
     const cacheOptions = {
       model: options.model,
       messages: options.messages,
@@ -93,6 +103,12 @@ export class OpenAIClient implements LLMClient {
     const response = await this.client.chat.completions.create({
       ...openAiOptions,
       response_format: responseFormat,
+    });
+
+    this.logger({
+      category: "OpenAI",
+      message: `Response: ${JSON.stringify(response, null, 2)}`,
+      level: 1,
     });
 
     if (response_model) {

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -16,7 +16,7 @@ You have 2 tools that you can call: doAction, and skipSection. Do action only pe
 
 Note: If there is a popup on the page for cookies or advertising that has nothing to do with the goal, try to close it first before proceeding. As this can block the goal from being completed.
 
-Also, verify if the goal has been accomplished already. Do this by checking if the goal has been accomplished based on the previous steps completed, the current page DOM elements and the current page URL / starting page URL. If it has, set completed to true and finish the task.
+Also, verify if the goal will be accomplished after this action. If it will, set completed to true and finish the task.
 
 Do exactly what the user's goal is. Do not exceed the scope of the goal.
 `;
@@ -117,7 +117,7 @@ ${steps}
 ${domElements}
 `;
 
-  if (variables) {
+  if (variables && Object.keys(variables).length > 0) {
     actUserPrompt += `
 # Variables
 ${Object.entries(variables)

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -4,21 +4,23 @@ import { ChatMessage } from "./llm/LLMClient";
 // act
 const actSystemPrompt = `
 # Instructions
-You are a browser automation assistant. Your job is to accomplish the user's goal across multiple model calls.
+You are a browser automation assistant. Your job is to accomplish the user's goal across multiple model calls by running playwright commands.
 
-You are given:
+## Input
+You will receive:
 1. the user's overall goal
 2. the steps that you've taken so far
 3. a list of active DOM elements in this chunk to consider to get closer to the goal. 
 4. Optionally, a list of variable names that the user has provided that you may use to accomplish the goal. To use the variables, you must use the special <|VARIABLE_NAME|> syntax.
 
-You have 2 tools that you can call: doAction, and skipSection. Do action only performs Playwright actions. Do not perform any other actions.
+
+## Your Goal / Specification
+You have 2 tools that you can call: doAction, and skipSection. Do action only performs Playwright actions. Do exactly what the user's goal is. Do not perform any other actions or exceed the scope of the goal.
+If the user's goal will be accomplished after running the playwright action, set completed to true.
 
 Note: If there is a popup on the page for cookies or advertising that has nothing to do with the goal, try to close it first before proceeding. As this can block the goal from being completed.
 
-Also, verify if the goal will be accomplished after this action. If it will, set completed to true and finish the task.
-
-Do exactly what the user's goal is. Do not exceed the scope of the goal.
+Again, if the user's goal will be accomplished after running the playwright action, set completed to true.
 `;
 
 const verifyActCompletionSystemPrompt = `

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -16,7 +16,7 @@ You will receive:
 
 ## Your Goal / Specification
 You have 2 tools that you can call: doAction, and skipSection. Do action only performs Playwright actions. Do exactly what the user's goal is. Do not perform any other actions or exceed the scope of the goal.
-If the user's goal will be accomplished after running the playwright action, set completed to true.
+If the user's goal will be accomplished after running the playwright action, set completed to true. Better to have completed set to true if your are not sure.
 
 Note: If there is a popup on the page for cookies or advertising that has nothing to do with the goal, try to close it first before proceeding. As this can block the goal from being completed.
 


### PR DESCRIPTION
# why
For code consistency, we moved extract and observe into their own handlers. Similar to actHandler.

# what changed

# test plan
