### PR TITLE
Revert "Revert "Usable evals + error pct (#208)""

### DIFF
--- a/evals/index.eval.ts
+++ b/evals/index.eval.ts
@@ -1414,7 +1414,7 @@ const errorMatch = (args: {
 const testcases = [
   "vanta",
   "vanta_h",
-  "peeler_simple",
+  ...(env === "BROWSERBASE" ? [] : ["peeler_simple"]), // peeler_simple is not supported on Browserbase
   "wikipedia",
   "peeler_complex",
   "simple_google_search",

--- a/evals/index.eval.ts
+++ b/evals/index.eval.ts
@@ -1,4 +1,3 @@
-import fs from "fs";
 import { Eval } from "braintrust";
 import { Stagehand } from "../lib";
 import type { AvailableModel } from "../lib/llm/LLMProvider";
@@ -6,14 +5,11 @@ import { z } from "zod";
 import process from "process";
 import { EvalLogger } from "./utils";
 import { LogLine } from "../lib/types";
-import Browserbase from "@browserbasehq/sdk";
 
 const env: "BROWSERBASE" | "LOCAL" =
   process.env.EVAL_ENV?.toLowerCase() === "browserbase"
     ? "BROWSERBASE"
     : "LOCAL";
-
-console.log("env", env);
 
 const enableCaching = process.env.EVAL_ENABLE_CACHING?.toLowerCase() === "true";
 const models: AvailableModel[] = ["gpt-4o", "claude-3-5-sonnet-20241022"];

--- a/evals/index.eval.ts
+++ b/evals/index.eval.ts
@@ -1486,6 +1486,6 @@ Eval("stagehand", {
     }
   },
   scores: [exactMatch, errorMatch],
-  maxConcurrency: 10,
+  maxConcurrency: env === "BROWSERBASE" ? undefined : 10,
   trialCount: 10,
 });

--- a/evals/index.eval.ts
+++ b/evals/index.eval.ts
@@ -1487,5 +1487,5 @@ Eval("stagehand", {
   },
   scores: [exactMatch, errorMatch],
   maxConcurrency: 10,
-  trialCount: 1,
+  trialCount: 10,
 });

--- a/evals/index.eval.ts
+++ b/evals/index.eval.ts
@@ -6,32 +6,55 @@ import process from "process";
 import { EvalLogger } from "./utils";
 import { LogLine } from "../lib/types";
 
-const env =
+const env: "BROWSERBASE" | "LOCAL" =
   process.env.EVAL_ENV?.toLowerCase() === "browserbase"
     ? "BROWSERBASE"
     : "LOCAL";
 
 const enableCaching = process.env.EVAL_ENABLE_CACHING?.toLowerCase() === "true";
-
 const models: AvailableModel[] = ["gpt-4o", "claude-3-5-sonnet-20241022"];
 
-const expedia = async (modelName: AvailableModel) => {
-  const logger = new EvalLogger();
+const defaultStagehandOptions = {
+  env,
+  headless: false,
+  verbose: 2 as const,
+  debugDom: true,
+  enableCaching,
+};
 
+const initStagehand = async ({
+  modelName,
+  domSettleTimeoutMs,
+}: {
+  modelName: AvailableModel;
+  domSettleTimeoutMs?: number;
+}) => {
+  const logger = new EvalLogger();
   const stagehand = new Stagehand({
-    env,
-    headless: false,
-    verbose: 2,
-    debugDom: true,
+    ...defaultStagehandOptions,
     logger: (logLine: LogLine) => {
       logger.log(logLine);
     },
-    enableCaching,
+  });
+  logger.init(stagehand);
+  const initResponse = await stagehand.init({ modelName, domSettleTimeoutMs });
+  return { stagehand, logger, initResponse };
+};
+
+type EvalFunction = (args: { modelName: AvailableModel }) => Promise<{
+  _success: boolean;
+  logs: LogLine[];
+  debugUrl: string;
+  sessionUrl: string;
+  error?: any;
+}>;
+
+const expedia: EvalFunction = async ({ modelName }) => {
+  const { stagehand, logger, initResponse } = await initStagehand({
+    modelName,
   });
 
-  logger.init(stagehand);
-
-  const { debugUrl, sessionUrl } = await stagehand.init({ modelName });
+  const { debugUrl, sessionUrl } = initResponse;
 
   try {
     await stagehand.page.goto("https://www.expedia.com/flights");
@@ -84,22 +107,12 @@ const expedia = async (modelName: AvailableModel) => {
     await stagehand.context.close().catch(() => {});
   }
 };
-const vanta = async (modelName: AvailableModel) => {
-  const logger = new EvalLogger();
-
-  const stagehand = new Stagehand({
-    env,
-    headless: process.env.HEADLESS !== "false",
-    logger: (message: any) => {
-      logger.log(message);
-    },
-    verbose: 2,
-    enableCaching,
+const vanta: EvalFunction = async ({ modelName }) => {
+  const { stagehand, logger, initResponse } = await initStagehand({
+    modelName,
   });
 
-  logger.init(stagehand);
-
-  const { debugUrl, sessionUrl } = await stagehand.init({ modelName });
+  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://www.vanta.com/");
 
@@ -156,22 +169,12 @@ const vanta = async (modelName: AvailableModel) => {
   };
 };
 
-const vanta_h = async ({ modelName }: { modelName: AvailableModel }) => {
-  const logger = new EvalLogger();
-
-  const stagehand = new Stagehand({
-    env,
-    headless: process.env.HEADLESS !== "false",
-    logger: (logLine: LogLine) => {
-      logger.log(logLine);
-    },
-    verbose: 2,
-    enableCaching,
+const vanta_h: EvalFunction = async ({ modelName }) => {
+  const { stagehand, logger, initResponse } = await initStagehand({
+    modelName,
   });
 
-  logger.init(stagehand);
-
-  const { debugUrl, sessionUrl } = await stagehand.init({ modelName });
+  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://www.vanta.com/");
 
@@ -191,26 +194,12 @@ const vanta_h = async ({ modelName }: { modelName: AvailableModel }) => {
   };
 };
 
-const simple_google_search = async ({
-  modelName,
-}: {
-  modelName: AvailableModel;
-}) => {
-  const logger = new EvalLogger();
-
-  const stagehand = new Stagehand({
-    env,
-    headless: process.env.HEADLESS !== "false",
-    logger: (logLine: LogLine) => {
-      logger.log(logLine);
-    },
-    verbose: 2,
-    enableCaching,
+const simple_google_search: EvalFunction = async ({ modelName }) => {
+  const { stagehand, logger, initResponse } = await initStagehand({
+    modelName,
   });
 
-  logger.init(stagehand);
-
-  const { debugUrl, sessionUrl } = await stagehand.init({ modelName });
+  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://www.google.com");
 
@@ -232,22 +221,12 @@ const simple_google_search = async ({
   };
 };
 
-const peeler_simple = async ({ modelName }: { modelName: AvailableModel }) => {
-  const logger = new EvalLogger();
-
-  const stagehand = new Stagehand({
-    env: "LOCAL",
-    headless: process.env.HEADLESS !== "false",
-    logger: (logLine: LogLine) => {
-      logger.log(logLine);
-    },
-    verbose: 2,
-    enableCaching,
+const peeler_simple: EvalFunction = async ({ modelName }) => {
+  const { stagehand, logger, initResponse } = await initStagehand({
+    modelName,
   });
 
-  logger.init(stagehand);
-
-  const { debugUrl, sessionUrl } = await stagehand.init({ modelName });
+  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(`file://${process.cwd()}/evals/assets/peeler.html`);
 
@@ -267,22 +246,12 @@ const peeler_simple = async ({ modelName }: { modelName: AvailableModel }) => {
   };
 };
 
-const peeler_complex = async ({ modelName }: { modelName: AvailableModel }) => {
-  const logger = new EvalLogger();
-
-  const stagehand = new Stagehand({
-    env,
-    verbose: 2,
-    headless: process.env.HEADLESS !== "false",
-    logger: (logLine: LogLine) => {
-      logger.log(logLine);
-    },
-    enableCaching,
+const peeler_complex: EvalFunction = async ({ modelName }) => {
+  const { stagehand, logger, initResponse } = await initStagehand({
+    modelName,
   });
 
-  logger.init(stagehand);
-
-  const { debugUrl, sessionUrl } = await stagehand.init({ modelName });
+  const { debugUrl, sessionUrl } = initResponse;
 
   try {
     await stagehand.page.goto(`https://chefstoys.com/`, { timeout: 60000 });
@@ -338,25 +307,13 @@ const peeler_complex = async ({ modelName }: { modelName: AvailableModel }) => {
   }
 };
 
-const homedepot = async ({ modelName }: { modelName: AvailableModel }) => {
-  const logger = new EvalLogger();
-
-  const stagehand = new Stagehand({
-    env,
-    verbose: 2,
-    headless: process.env.HEADLESS !== "false",
-    logger: (logLine: LogLine) => {
-      logger.log(logLine);
-    },
-    enableCaching,
-  });
-
-  logger.init(stagehand);
-
-  const { debugUrl, sessionUrl } = await stagehand.init({
+const homedepot: EvalFunction = async ({ modelName }) => {
+  const { stagehand, logger, initResponse } = await initStagehand({
     modelName,
     domSettleTimeoutMs: 60_000,
   });
+
+  const { debugUrl, sessionUrl } = initResponse;
 
   try {
     await stagehand.page.goto("https://www.homedepot.com/");
@@ -454,26 +411,12 @@ const homedepot = async ({ modelName }: { modelName: AvailableModel }) => {
   }
 };
 
-const extract_github_stars = async ({
-  modelName,
-}: {
-  modelName: AvailableModel;
-}) => {
-  const logger = new EvalLogger();
-
-  const stagehand = new Stagehand({
-    env,
-    verbose: 2,
-    headless: process.env.HEADLESS !== "false",
-    logger: (logLine: LogLine) => {
-      logger.log(logLine);
-    },
-    enableCaching,
+const extract_github_stars: EvalFunction = async ({ modelName }) => {
+  const { stagehand, logger, initResponse } = await initStagehand({
+    modelName,
   });
 
-  logger.init(stagehand);
-
-  const { debugUrl, sessionUrl } = await stagehand.init();
+  const { debugUrl, sessionUrl } = initResponse;
 
   try {
     await stagehand.page.goto("https://github.com/facebook/react");
@@ -516,26 +459,14 @@ const extract_github_stars = async ({
   }
 };
 
-const extract_collaborators_from_github_repository = async ({
+const extract_collaborators_from_github_repository: EvalFunction = async ({
   modelName,
-}: {
-  modelName: AvailableModel;
 }) => {
-  const logger = new EvalLogger();
-
-  const stagehand = new Stagehand({
-    env,
-    verbose: 2,
-    headless: process.env.HEADLESS !== "false",
-    logger: (logLine: LogLine) => {
-      logger.log(logLine);
-    },
-    enableCaching,
+  const { stagehand, logger, initResponse } = await initStagehand({
+    modelName,
   });
 
-  logger.init(stagehand);
-
-  const { debugUrl, sessionUrl } = await stagehand.init();
+  const { debugUrl, sessionUrl } = initResponse;
 
   try {
     await stagehand.page.goto("https://github.com/facebook/react");
@@ -580,26 +511,14 @@ const extract_collaborators_from_github_repository = async ({
   }
 };
 
-const extract_last_twenty_github_commits = async ({
+const extract_last_twenty_github_commits: EvalFunction = async ({
   modelName,
-}: {
-  modelName: AvailableModel;
 }) => {
-  const logger = new EvalLogger();
-
-  const stagehand = new Stagehand({
-    env,
-    verbose: 2,
-    headless: process.env.HEADLESS !== "false",
-    logger: (logLine: LogLine) => {
-      logger.log(logLine);
-    },
-    enableCaching,
+  const { stagehand, logger, initResponse } = await initStagehand({
+    modelName,
   });
 
-  logger.init(stagehand);
-
-  const { debugUrl, sessionUrl } = await stagehand.init();
+  const { debugUrl, sessionUrl } = initResponse;
 
   try {
     await stagehand.page.goto("https://github.com/facebook/react");
@@ -653,22 +572,12 @@ const extract_last_twenty_github_commits = async ({
   }
 };
 
-const wikipedia = async ({ modelName }: { modelName: AvailableModel }) => {
-  const logger = new EvalLogger();
-
-  const stagehand = new Stagehand({
-    env,
-    verbose: 2,
-    headless: process.env.HEADLESS !== "false",
-    logger: (logLine: LogLine) => {
-      logger.log(logLine);
-    },
-    enableCaching,
+const wikipedia: EvalFunction = async ({ modelName }) => {
+  const { stagehand, logger, initResponse } = await initStagehand({
+    modelName,
   });
 
-  logger.init(stagehand);
-
-  const { debugUrl, sessionUrl } = await stagehand.init({ modelName });
+  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(`https://en.wikipedia.org/wiki/Baseball`);
   await stagehand.act({
@@ -690,27 +599,12 @@ const wikipedia = async ({ modelName }: { modelName: AvailableModel }) => {
 };
 
 // Validate that the action is not found on the page
-const nonsense_action = async ({
-  modelName,
-}: {
-  modelName: AvailableModel;
-}) => {
-  const logger = new EvalLogger();
-
-  const stagehand = new Stagehand({
-    env: "LOCAL",
-    verbose: 2,
-    debugDom: true,
-    headless: true,
-    logger: (logLine: LogLine) => {
-      logger.log(logLine);
-    },
-    enableCaching,
+const nonsense_action: EvalFunction = async ({ modelName }) => {
+  const { stagehand, logger, initResponse } = await initStagehand({
+    modelName,
   });
 
-  logger.init(stagehand);
-
-  const { debugUrl, sessionUrl } = await stagehand.init({ modelName });
+  const { debugUrl, sessionUrl } = initResponse;
 
   try {
     await stagehand.page.goto("https://www.homedepot.com/");
@@ -751,23 +645,12 @@ const nonsense_action = async ({
   }
 };
 
-const costar = async ({ modelName }: { modelName: AvailableModel }) => {
-  const logger = new EvalLogger();
-
-  const stagehand = new Stagehand({
-    env,
-    verbose: 2,
-    debugDom: true,
-    headless: process.env.HEADLESS !== "false",
-    logger: (logLine: LogLine) => {
-      logger.log(logLine);
-    },
-    enableCaching,
+const costar: EvalFunction = async ({ modelName }) => {
+  const { stagehand, logger, initResponse } = await initStagehand({
+    modelName,
   });
 
-  logger.init(stagehand);
-
-  const { debugUrl, sessionUrl } = await stagehand.init({ modelName });
+  const { debugUrl, sessionUrl } = initResponse;
   // TODO: fix this eval - does not work in headless mode
   try {
     await Promise.race([
@@ -842,23 +725,12 @@ const costar = async ({ modelName }: { modelName: AvailableModel }) => {
   }
 };
 
-const google_jobs = async ({ modelName }: { modelName: AvailableModel }) => {
-  const logger = new EvalLogger();
-
-  const stagehand = new Stagehand({
-    env,
-    verbose: 2,
-    debugDom: true,
-    headless: process.env.HEADLESS !== "false",
-    logger: (logLine: LogLine) => {
-      logger.log(logLine);
-    },
-    enableCaching,
+const google_jobs: EvalFunction = async ({ modelName }) => {
+  const { stagehand, logger, initResponse } = await initStagehand({
+    modelName,
   });
 
-  logger.init(stagehand);
-
-  const { debugUrl, sessionUrl } = await stagehand.init({ modelName });
+  const { debugUrl, sessionUrl } = initResponse;
 
   try {
     await stagehand.page.goto("https://www.google.com/");
@@ -973,27 +845,12 @@ const google_jobs = async ({ modelName }: { modelName: AvailableModel }) => {
   }
 };
 
-const extract_partners = async ({
-  modelName,
-}: {
-  modelName: AvailableModel;
-}) => {
-  const logger = new EvalLogger();
-
-  const stagehand = new Stagehand({
-    env,
-    verbose: 2,
-    debugDom: true,
-    headless: process.env.HEADLESS !== "false",
-    logger: (logLine: LogLine) => {
-      logger.log(logLine);
-    },
-    enableCaching,
+const extract_partners: EvalFunction = async ({ modelName }) => {
+  const { stagehand, logger, initResponse } = await initStagehand({
+    modelName,
   });
 
-  logger.init(stagehand);
-
-  const { debugUrl, sessionUrl } = await stagehand.init({ modelName });
+  const { debugUrl, sessionUrl } = initResponse;
 
   try {
     await stagehand.page.goto("https://ramp.com");
@@ -1127,23 +984,12 @@ const extract_partners = async ({
   }
 };
 
-const laroche_form = async ({ modelName }: { modelName: AvailableModel }) => {
-  const logger = new EvalLogger();
-
-  const stagehand = new Stagehand({
-    env,
-    verbose: 2,
-    debugDom: true,
-    headless: process.env.HEADLESS !== "false",
-    logger: (logLine: LogLine) => {
-      logger.log(logLine);
-    },
-    enableCaching,
+const laroche_form: EvalFunction = async ({ modelName }) => {
+  const { stagehand, logger, initResponse } = await initStagehand({
+    modelName,
   });
 
-  logger.init(stagehand);
-
-  const { debugUrl, sessionUrl } = await stagehand.init({ modelName });
+  const { debugUrl, sessionUrl } = initResponse;
 
   try {
     await stagehand.page.goto(
@@ -1220,23 +1066,12 @@ const laroche_form = async ({ modelName }: { modelName: AvailableModel }) => {
   }
 };
 
-const arxiv = async ({ modelName }: { modelName: AvailableModel }) => {
-  const logger = new EvalLogger();
-
-  const stagehand = new Stagehand({
-    env,
-    verbose: 2,
-    debugDom: true,
-    headless: process.env.HEADLESS !== "false",
-    logger: (logLine: LogLine) => {
-      logger.log(logLine);
-    },
-    enableCaching,
+const arxiv: EvalFunction = async ({ modelName }) => {
+  const { stagehand, logger, initResponse } = await initStagehand({
+    modelName,
   });
 
-  logger.init(stagehand);
-
-  const { debugUrl, sessionUrl } = await stagehand.init({ modelName });
+  const { debugUrl, sessionUrl } = initResponse;
 
   interface Paper {
     title: string;
@@ -1536,6 +1371,22 @@ const exactMatch = (args: {
   };
 };
 
+const errorMatch = (args: {
+  input: any;
+  output: any;
+  expected?: any;
+}): {
+  name: string;
+  score: number;
+} => {
+  console.log(`Task "${args.input.name}" returned: ${args.output}`);
+
+  return {
+    name: "Error rate",
+    score: args.output?.error !== undefined ? 1 : 0,
+  };
+};
+
 const testcases = [
   "vanta",
   "vanta_h",
@@ -1561,8 +1412,12 @@ Eval("stagehand", {
     return models.flatMap((model) =>
       testcases.map((test) => ({
         input: { name: test, modelName: model },
-        name: `${test}-${model}`,
-        tags: [model],
+        name: test,
+        tags: [model, test],
+        metadata: {
+          model,
+          test,
+        },
       })),
     );
   },
@@ -1586,7 +1441,7 @@ Eval("stagehand", {
       };
     }
   },
-  scores: [exactMatch],
-  //   maxConcurrency: 5,
-  // trialCount: 3,
+  scores: [exactMatch, errorMatch],
+  maxConcurrency: 10,
+  trialCount: 10,
 });

--- a/evals/utils.ts
+++ b/evals/utils.ts
@@ -9,17 +9,20 @@ type LogLineEval = LogLine & {
 function parseLogLine(logLine: LogLine): LogLineEval {
   return {
     ...logLine,
-    parsedAuxiliary:
-      logLine.auxiliary &&
-      logLine.auxiliary.value &&
-      (logLine.auxiliary.type as unknown as string) === "object"
-        ? JSON.parse(logLine.auxiliary.value as unknown as string)
-        : logLine.auxiliary?.value,
+    auxiliary: undefined,
+    parsedAuxiliary: logLine.auxiliary
+      ? Object.fromEntries(
+          Object.entries(logLine.auxiliary).map(([key, entry]) => [
+            key,
+            entry.type === "object" ? JSON.parse(entry.value) : entry.value,
+          ]),
+        )
+      : undefined,
   } as LogLineEval;
 }
 
 export class EvalLogger {
-  logs: LogLine[] = [];
+  logs: LogLineEval[] = [];
   stagehand?: Stagehand;
 
   constructor() {}
@@ -30,17 +33,17 @@ export class EvalLogger {
 
   log(logLine: LogLine) {
     console.log(logLineToString(logLine));
-    this.logs.push(logLine);
+    this.logs.push(parseLogLine(logLine));
   }
 
   error(logLine: LogLine) {
     console.error(logLineToString(logLine));
-    this.logs.push(logLine);
+    this.logs.push(parseLogLine(logLine));
   }
 
   warn(logLine: LogLine) {
     console.warn(logLineToString(logLine));
-    this.logs.push(logLine);
+    this.logs.push(parseLogLine(logLine));
   }
 
   getLogs() {

--- a/evals/utils.ts
+++ b/evals/utils.ts
@@ -2,6 +2,22 @@ import { LogLine } from "../lib/types";
 import { Stagehand } from "../lib";
 import { logLineToString } from "../lib/utils";
 
+type LogLineEval = LogLine & {
+  parsedAuxiliary?: string | object;
+};
+
+function parseLogLine(logLine: LogLine): LogLineEval {
+  return {
+    ...logLine,
+    parsedAuxiliary:
+      logLine.auxiliary &&
+      logLine.auxiliary.value &&
+      (logLine.auxiliary.type as unknown as string) === "object"
+        ? JSON.parse(logLine.auxiliary.value as unknown as string)
+        : logLine.auxiliary?.value,
+  } as LogLineEval;
+}
+
 export class EvalLogger {
   logs: LogLine[] = [];
   stagehand?: Stagehand;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@browserbasehq/stagehand",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@browserbasehq/stagehand",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.27.3",
@@ -23,7 +23,7 @@
         "@types/express": "^4.17.21",
         "@types/node": "^20.11.30",
         "autoevals": "^0.0.64",
-        "braintrust": "^0.0.127",
+        "braintrust": "^0.0.171",
         "cheerio": "^1.0.0",
         "esbuild": "^0.21.4",
         "express": "^4.21.0",
@@ -42,9 +42,9 @@
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-0.0.0.tgz",
-      "integrity": "sha512-Gbl9Ei8NPtM85gB/o8cY7s7CLGxK/U6QVheVaI3viFn7o6IpTfy1Ja389e2FXVMNJ4WHK2qYWSp5fAFDuKulTA==",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-0.0.11.tgz",
+      "integrity": "sha512-VTipPQ92Moa5Ovg/nZIc8yNoIFfukZjUHZcQMduJbiUh3CLQyrBAKTEV9AwjPy8wgVxj3+GZjon0yyOJKhfp5g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -52,6 +52,192 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-1.0.22.tgz",
+      "integrity": "sha512-YHK2rpj++wnLVc9vPGzGFP3Pjeld2MwhKinetA0zKXOoHAT/Jit5O8kZsxcSlJPu9wvcGT1UGZEjZrtO7PfFOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "0.0.26",
+        "eventsource-parser": "^1.1.2",
+        "nanoid": "^3.3.7",
+        "secure-json-parse": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils/node_modules/@ai-sdk/provider": {
+      "version": "0.0.26",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-0.0.26.tgz",
+      "integrity": "sha512-dQkfBDs2lTYpKM8389oopPdQgIU007GQyCbuPPrV+K6MtSII3HBfE0stUIMXUb44L+LK1t6GXPP7wjSzjO6uKg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/react": {
+      "version": "0.0.70",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-0.0.70.tgz",
+      "integrity": "sha512-GnwbtjW4/4z7MleLiW+TOZC2M29eCg1tOUpuEiYFMmFNZK8mkrqM0PFZMo6UsYeUYMWqEOOcPOU9OQVJMJh7IQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "1.0.22",
+        "@ai-sdk/ui-utils": "0.0.50",
+        "swr": "^2.2.5",
+        "throttleit": "2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "zod": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/solid": {
+      "version": "0.0.54",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/solid/-/solid-0.0.54.tgz",
+      "integrity": "sha512-96KWTVK+opdFeRubqrgaJXoNiDP89gNxFRWUp0PJOotZW816AbhUf4EnDjBjXTLjXL1n0h8tGSE9sZsRkj9wQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "1.0.22",
+        "@ai-sdk/ui-utils": "0.0.50"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "solid-js": "^1.7.7"
+      },
+      "peerDependenciesMeta": {
+        "solid-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/svelte": {
+      "version": "0.0.57",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/svelte/-/svelte-0.0.57.tgz",
+      "integrity": "sha512-SyF9ItIR9ALP9yDNAD+2/5Vl1IT6kchgyDH8xkmhysfJI6WrvJbtO1wdQ0nylvPLcsPoYu+cAlz1krU4lFHcYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "1.0.22",
+        "@ai-sdk/ui-utils": "0.0.50",
+        "sswr": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "svelte": "^3.0.0 || ^4.0.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "svelte": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/ui-utils": {
+      "version": "0.0.50",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-0.0.50.tgz",
+      "integrity": "sha512-Z5QYJVW+5XpSaJ4jYCCAVG7zIAuKOOdikhgpksneNmKvx61ACFaf98pmOd+xnjahl0pIlc/QIe6O4yVaJ1sEaw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "0.0.26",
+        "@ai-sdk/provider-utils": "1.0.22",
+        "json-schema": "^0.4.0",
+        "secure-json-parse": "^2.7.0",
+        "zod-to-json-schema": "^3.23.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/ui-utils/node_modules/@ai-sdk/provider": {
+      "version": "0.0.26",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-0.0.26.tgz",
+      "integrity": "sha512-dQkfBDs2lTYpKM8389oopPdQgIU007GQyCbuPPrV+K6MtSII3HBfE0stUIMXUb44L+LK1t6GXPP7wjSzjO6uKg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/vue": {
+      "version": "0.0.59",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/vue/-/vue-0.0.59.tgz",
+      "integrity": "sha512-+ofYlnqdc8c4F6tM0IKF0+7NagZRAiqBJpGDJ+6EYhDW8FHLUP/JFBgu32SjxSxC6IKFZxEnl68ZoP/Z38EMlw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "1.0.22",
+        "@ai-sdk/ui-utils": "0.0.50",
+        "swrv": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "vue": "^3.3.4"
+      },
+      "peerDependenciesMeta": {
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -97,6 +283,45 @@
         "zod": "^3.20.2"
       }
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.2.tgz",
+      "integrity": "sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/types": "^7.26.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.26.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
@@ -105,6 +330,21 @@
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.0.tgz",
+      "integrity": "sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1545,6 +1785,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1855,6 +2105,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/diff-match-patch": {
+      "version": "1.0.36",
+      "resolved": "https://registry.npmjs.org/@types/diff-match-patch/-/diff-match-patch-1.0.36.tgz",
+      "integrity": "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -1958,6 +2215,142 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@vercel/functions": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-1.5.0.tgz",
+      "integrity": "sha512-ub3ptVeOsx8UPgiTv9+rpQJqmF7VG8QIzguBZo0E0VRAyJliB8bt1ooB9Wrh3333dKzMNS8NMe3iFtf6OPUP3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 16"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-web-identity": "*"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-web-identity": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.13.tgz",
+      "integrity": "sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.3",
+        "@vue/shared": "3.5.13",
+        "entities": "^4.5.0",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.13.tgz",
+      "integrity": "sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vue/compiler-core": "3.5.13",
+        "@vue/shared": "3.5.13"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.13.tgz",
+      "integrity": "sha512-6VdaljMpD82w6c2749Zhf5T9u5uLBWKnVue6XWxprDobftnletJ8+oel7sexFfM3qIxNmVE7LSFGTpv6obNyaQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.3",
+        "@vue/compiler-core": "3.5.13",
+        "@vue/compiler-dom": "3.5.13",
+        "@vue/compiler-ssr": "3.5.13",
+        "@vue/shared": "3.5.13",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.11",
+        "postcss": "^8.4.48",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.13.tgz",
+      "integrity": "sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.13",
+        "@vue/shared": "3.5.13"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.13.tgz",
+      "integrity": "sha512-NaCwtw8o48B9I6L1zl2p41OHo/2Z4wqYGGIK1Khu5T7yxrn+ATOixn/Udn2m+6kZKB/J7cuT9DbWWhRxqixACg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vue/shared": "3.5.13"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.13.tgz",
+      "integrity": "sha512-Fj4YRQ3Az0WTZw1sFe+QDb0aXCerigEpw418pw1HBUKFtnQHWzwojaukAs2X/c9DQz4MQ4bsXTGlcpGxU/RCIw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vue/reactivity": "3.5.13",
+        "@vue/shared": "3.5.13"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.13.tgz",
+      "integrity": "sha512-dLaj94s93NYLqjLiyFzVs9X6dWhTdAlEAciC3Moq7gzAc13VJUdCnjjRurNM6uTLFATRHexHCTu/Xp3eW6yoog==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vue/reactivity": "3.5.13",
+        "@vue/runtime-core": "3.5.13",
+        "@vue/shared": "3.5.13",
+        "csstype": "^3.1.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.13.tgz",
+      "integrity": "sha512-wAi4IRJV/2SAW3htkTlB+dHeRmpTiVIK1OGLWV1yeStVSebSQQOwGwIq0D3ZIoBj2C2qpgz5+vX9iEBkTdk5YA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.13",
+        "@vue/shared": "3.5.13"
+      },
+      "peerDependencies": {
+        "vue": "3.5.13"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
+      "integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -1984,6 +2377,31 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-typescript": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/acorn-typescript/-/acorn-typescript-1.4.13.tgz",
+      "integrity": "sha512-xsc9Xv0xlVfwp2o7sQ+GCQ1PgbkdcpWdTzrwXxO3xDMTAywVS3oXVOcOHuRjAPkS4P9b+yc/qNF15460v+jp4Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "acorn": ">=8.9.0"
+      }
+    },
     "node_modules/agentkeepalive": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
@@ -1994,6 +2412,68 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/ai": {
+      "version": "3.4.33",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-3.4.33.tgz",
+      "integrity": "sha512-plBlrVZKwPoRTmM8+D1sJac9Bq8eaa2jiZlHLZIWekKWI1yMWYZvCCEezY9ASPwRhULYDJB2VhKOBUUeg3S5JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "0.0.26",
+        "@ai-sdk/provider-utils": "1.0.22",
+        "@ai-sdk/react": "0.0.70",
+        "@ai-sdk/solid": "0.0.54",
+        "@ai-sdk/svelte": "0.0.57",
+        "@ai-sdk/ui-utils": "0.0.50",
+        "@ai-sdk/vue": "0.0.59",
+        "@opentelemetry/api": "1.9.0",
+        "eventsource-parser": "1.1.2",
+        "json-schema": "^0.4.0",
+        "jsondiffpatch": "0.6.0",
+        "secure-json-parse": "^2.7.0",
+        "zod-to-json-schema": "^3.23.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "openai": "^4.42.0",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "sswr": "^2.1.0",
+        "svelte": "^3.0.0 || ^4.0.0 || ^5.0.0",
+        "zod": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "openai": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "sswr": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ai/node_modules/@ai-sdk/provider": {
+      "version": "0.0.26",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-0.0.26.tgz",
+      "integrity": "sha512-dQkfBDs2lTYpKM8389oopPdQgIU007GQyCbuPPrV+K6MtSII3HBfE0stUIMXUb44L+LK1t6GXPP7wjSzjO6uKg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ansi-colors": {
@@ -2067,6 +2547,17 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -2155,6 +2646,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/balanced-match": {
@@ -2259,29 +2761,51 @@
       }
     },
     "node_modules/braintrust": {
-      "version": "0.0.127",
-      "resolved": "https://registry.npmjs.org/braintrust/-/braintrust-0.0.127.tgz",
-      "integrity": "sha512-MrXHSygbpT9+X7URWLX4Tnn8llVS/kLXAaxi3JrZK6FSMIbAnkghrF45TE4M7MwpWc7dhbK2kkRebTsQE4DjQw==",
+      "version": "0.0.171",
+      "resolved": "https://registry.npmjs.org/braintrust/-/braintrust-0.0.171.tgz",
+      "integrity": "sha512-esL1xU9k+Ef9poUMQlFwpF7+DMzCMAihrAfcCCBWHSj8+wWGjPuAbIlegnfrT5Um8YQmiHZLnrYmChfCNVe+Ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@ai-sdk/provider": "^0.0.0",
-        "@braintrust/core": "0.0.34",
+        "@ai-sdk/provider": "^0.0.11",
+        "@braintrust/core": "0.0.67",
         "@next/env": "^14.2.3",
+        "@vercel/functions": "^1.0.2",
+        "ai": "^3.2.16",
         "argparse": "^2.0.1",
         "chalk": "^4.1.2",
         "cli-progress": "^3.12.0",
         "dotenv": "^16.4.5",
         "esbuild": "^0.18.20",
+        "eventsource-parser": "^1.1.2",
         "graceful-fs": "^4.2.11",
         "minimatch": "^9.0.3",
         "mustache": "^4.2.0",
         "pluralize": "^8.0.0",
         "simple-git": "^3.21.0",
-        "uuid": "^9.0.1"
+        "slugify": "^1.6.6",
+        "source-map": "^0.7.4",
+        "uuid": "^9.0.1",
+        "zod": "^3.22.4",
+        "zod-to-json-schema": "^3.22.5"
       },
       "bin": {
         "braintrust": "dist/cli.js"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      }
+    },
+    "node_modules/braintrust/node_modules/@braintrust/core": {
+      "version": "0.0.67",
+      "resolved": "https://registry.npmjs.org/@braintrust/core/-/core-0.0.67.tgz",
+      "integrity": "sha512-aCWOIgGKeYeEQmU8FcPyfp0phaLpt4iaDcealooaI7Lw/Loz2LeHu5FdzVzu34B7zw3ZOkzyrr0I4X/YFdTy1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asteasolutions/zod-to-openapi": "^6.3.1",
+        "uuid": "^9.0.1",
+        "zod": "^3.22.4"
       }
     },
     "node_modules/braintrust/node_modules/@esbuild/android-arm": {
@@ -2696,6 +3220,16 @@
         "@esbuild/win32-x64": "0.18.20"
       }
     },
+    "node_modules/braintrust/node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -2900,6 +3434,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/color": {
       "version": "4.2.3",
@@ -3124,6 +3665,14 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/d3-array": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-0.7.1.tgz",
@@ -3224,6 +3773,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/digest-fetch": {
       "version": "1.3.0",
@@ -3461,6 +4017,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/esm-env": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.1.4.tgz",
+      "integrity": "sha512-oO82nKPHKkzIj/hbtuDYy/JHqBHFlMIW36SDiPCVsj87ntDLcWN+sJ1erdVryd4NxODacFTsdrIE3b7IamqbOg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -3474,6 +4038,26 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/esrap": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-1.2.2.tgz",
+      "integrity": "sha512-F2pSJklxx1BlQIQgooczXCPHmcWpn6EsP5oo73LQfonG9fIlIENQ8vMmfGXeojP9MrkzUNAfyU5vdFlR9shHAw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15",
+        "@types/estree": "^1.0.1"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -3492,6 +4076,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-1.1.2.tgz",
+      "integrity": "sha512-v0eOBUbiaFojBu2s2NPBfYUoRR9GjcDNvCXVaqEf5vVfpIAh9f8RCo4vXTP8c63QRKCFwoLpMpTdPwwhEKVgzA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.18"
       }
     },
     "node_modules/express": {
@@ -4112,6 +4706,17 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-reference": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+      "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "^1.0.6"
+      }
+    },
     "node_modules/is-subdir": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-subdir/-/is-subdir-1.2.0.tgz",
@@ -4185,6 +4790,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -4204,6 +4817,37 @@
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true,
       "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/jsondiffpatch": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.6.0.tgz",
+      "integrity": "sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/diff-match-patch": "^1.0.36",
+        "chalk": "^5.3.0",
+        "diff-match-patch": "^1.0.5"
+      },
+      "bin": {
+        "jsondiffpatch": "bin/jsondiffpatch.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jsondiffpatch/node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
     },
     "node_modules/jsonfile": {
       "version": "4.0.0",
@@ -4258,6 +4902,14 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
+    "node_modules/locate-character": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -4285,12 +4937,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.13",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.13.tgz",
+      "integrity": "sha512-8rYBO+MsWkgjDSOvLomYnzhdwEG51olQ4zL5KXnNJWV5MNmrb4rTZdrtkhxjnD/QyZUqR/Z/XDsUs/4ej2nx0g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
     },
     "node_modules/md5": {
       "version": "2.3.0",
@@ -4575,6 +5252,25 @@
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/negotiator": {
@@ -5008,6 +5704,36 @@
         "node": ">=4"
       }
     },
+    "node_modules/postcss": {
+      "version": "8.4.49",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/postcss-load-config": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
@@ -5176,6 +5902,20 @@
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -5385,6 +6125,13 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
       "version": "7.6.3",
@@ -5635,6 +6382,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/slugify": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.8.0-beta.0",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
@@ -5646,6 +6403,17 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/source-map/node_modules/tr46": {
@@ -5770,6 +6538,19 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/sswr": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sswr/-/sswr-2.1.0.tgz",
+      "integrity": "sha512-Cqc355SYlTAaUt8iDPaC/4DPPXK925PePLMxyBKuWd5kKc5mwsG3nT9+Mq2tyguL5s7b4Jg+IRMpTRsNTAfpSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "swrev": "^4.0.0"
+      },
+      "peerDependencies": {
+        "svelte": "^4.0.0 || ^5.0.0-next.0"
+      }
     },
     "node_modules/statuses": {
       "version": "2.0.1",
@@ -5911,6 +6692,63 @@
         "node": ">=8"
       }
     },
+    "node_modules/svelte": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.2.7.tgz",
+      "integrity": "sha512-cEhPGuLHiH2+Z8B1FwQgiZJgA39uUmJR4516TKrM5zrp0/cuwJkfhUfcTxhAkznanAF5fXUKzvYR4o+Ksx3ZCQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@types/estree": "^1.0.5",
+        "acorn": "^8.12.1",
+        "acorn-typescript": "^1.4.13",
+        "aria-query": "^5.3.1",
+        "axobject-query": "^4.1.0",
+        "esm-env": "^1.0.0",
+        "esrap": "^1.2.2",
+        "is-reference": "^3.0.3",
+        "locate-character": "^3.0.0",
+        "magic-string": "^0.30.11",
+        "zimmerframe": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.5.tgz",
+      "integrity": "sha512-QtxqyclFeAsxEUeZIYmsaQ0UjimSq1RZ9Un7I68/0ClKK/U3LoyQunwkQfJZr2fc22DfIXLNDc2wFyTEikCUpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "^0.0.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/swrev": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/swrev/-/swrev-4.0.0.tgz",
+      "integrity": "sha512-LqVcOHSB4cPGgitD1riJ1Hh4vdmITOp+BkmfmXRh4hSF/t7EnS4iD+SOTmq7w5pPm/SiPeto4ADbKS6dHUDWFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/swrv": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/swrv/-/swrv-1.0.4.tgz",
+      "integrity": "sha512-zjEkcP8Ywmj+xOJW3lIT65ciY/4AL4e/Or7Gj0MzU3zBJNMdJiT8geVZhINavnlHRMMCcJLHhraLTAiDOTmQ9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "vue": ">=3.2.26 < 4"
+      }
+    },
     "node_modules/term-size": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
@@ -5945,6 +6783,19 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tinyexec": {
@@ -7096,6 +7947,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
+      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -7148,6 +8009,29 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.13.tgz",
+      "integrity": "sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.13",
+        "@vue/compiler-sfc": "3.5.13",
+        "@vue/runtime-dom": "3.5.13",
+        "@vue/server-renderer": "3.5.13",
+        "@vue/shared": "3.5.13"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/web-streams-polyfill": {
@@ -7347,6 +8231,14 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/zimmerframe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.2.tgz",
+      "integrity": "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/zod": {
       "version": "3.23.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "autoevals": "^0.0.64",
         "braintrust": "^0.0.171",
         "cheerio": "^1.0.0",
+        "chromium-bidi": "^0.10.0",
         "esbuild": "^0.21.4",
         "express": "^4.21.0",
         "multer": "^1.4.5-lts.1",
@@ -256,9 +257,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
-      "version": "18.19.59",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.59.tgz",
-      "integrity": "sha512-vizm2EqwV/7Zay+A6J3tGl9Lhr7CjZe2HmWS988sefiEmsyP9CeXEleho6i4hJk/8UtZAo0bWN4QPZZr83RxvQ==",
+      "version": "18.19.65",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.65.tgz",
+      "integrity": "sha512-Ay5BZuO1UkTmVHzZJNvZKw/E+iB3GQABb6kijEz89w2JrfhNA+M/ebp18pfz9Gqe9ywhMC8AA8yC01lZq48J+Q==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -378,9 +379,10 @@
       }
     },
     "node_modules/@browserbasehq/sdk/node_modules/@types/node": {
-      "version": "18.19.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.63.tgz",
-      "integrity": "sha512-hcUB7THvrGmaEcPcvUZCZtQ2Z3C+UR/aOcraBLCvTsFMh916Gc1kCCYcfcMuB76HM2pSerxl1PoP3KnmHzd9Lw==",
+      "version": "18.19.65",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.65.tgz",
+      "integrity": "sha512-Ay5BZuO1UkTmVHzZJNvZKw/E+iB3GQABb6kijEz89w2JrfhNA+M/ebp18pfz9Gqe9ywhMC8AA8yC01lZq48J+Q==",
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -388,18 +390,19 @@
     "node_modules/@browserbasehq/sdk/node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
     },
     "node_modules/@changesets/apply-release-plan": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.0.5.tgz",
-      "integrity": "sha512-1cWCk+ZshEkSVEZrm2fSj1Gz8sYvxgUL4Q78+1ZZqeqfuevPTPk033/yUZ3df8BKMohkqqHfzj0HOOrG0KtXTw==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.0.6.tgz",
+      "integrity": "sha512-TKhVLtiwtQOgMAC0fCJfmv93faiViKSDqr8oMEqrnNs99gtSC1sZh/aEMS9a+dseU1ESZRCK+ofLgGY7o0fw/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@changesets/config": "^3.0.3",
+        "@changesets/config": "^3.0.4",
         "@changesets/get-version-range-type": "^0.4.0",
-        "@changesets/git": "^3.0.1",
+        "@changesets/git": "^3.0.2",
         "@changesets/should-skip-package": "^0.1.1",
         "@changesets/types": "^6.0.0",
         "@manypkg/get-packages": "^1.1.3",
@@ -429,9 +432,9 @@
       }
     },
     "node_modules/@changesets/assemble-release-plan": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.4.tgz",
-      "integrity": "sha512-nqICnvmrwWj4w2x0fOhVj2QEGdlUuwVAwESrUo5HLzWMI1rE5SWfsr9ln+rDqWB6RQ2ZyaMZHUcU7/IRaUJS+Q==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.5.tgz",
+      "integrity": "sha512-IgvBWLNKZd6k4t72MBTBK3nkygi0j3t3zdC1zrfusYo0KpdsvnDjrMM9vPnTCLCMlfNs55jRL4gIMybxa64FCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -476,23 +479,23 @@
       }
     },
     "node_modules/@changesets/cli": {
-      "version": "2.27.9",
-      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.27.9.tgz",
-      "integrity": "sha512-q42a/ZbDnxPpCb5Wkm6tMVIxgeI9C/bexntzTeCFBrQEdpisQqk8kCHllYZMDjYtEc1ZzumbMJAG8H0Z4rdvjg==",
+      "version": "2.27.10",
+      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.27.10.tgz",
+      "integrity": "sha512-PfeXjvs9OfQJV8QSFFHjwHX3QnUL9elPEQ47SgkiwzLgtKGyuikWjrdM+lO9MXzOE22FO9jEGkcs4b+B6D6X0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@changesets/apply-release-plan": "^7.0.5",
-        "@changesets/assemble-release-plan": "^6.0.4",
+        "@changesets/apply-release-plan": "^7.0.6",
+        "@changesets/assemble-release-plan": "^6.0.5",
         "@changesets/changelog-git": "^0.2.0",
-        "@changesets/config": "^3.0.3",
+        "@changesets/config": "^3.0.4",
         "@changesets/errors": "^0.2.0",
         "@changesets/get-dependents-graph": "^2.1.2",
-        "@changesets/get-release-plan": "^4.0.4",
-        "@changesets/git": "^3.0.1",
+        "@changesets/get-release-plan": "^4.0.5",
+        "@changesets/git": "^3.0.2",
         "@changesets/logger": "^0.1.1",
         "@changesets/pre": "^2.0.1",
-        "@changesets/read": "^0.6.1",
+        "@changesets/read": "^0.6.2",
         "@changesets/should-skip-package": "^0.1.1",
         "@changesets/types": "^6.0.0",
         "@changesets/write": "^0.3.2",
@@ -508,7 +511,7 @@
         "picocolors": "^1.1.0",
         "resolve-from": "^5.0.0",
         "semver": "^7.5.3",
-        "spawndamnit": "^2.0.0",
+        "spawndamnit": "^3.0.1",
         "term-size": "^2.1.0"
       },
       "bin": {
@@ -516,9 +519,9 @@
       }
     },
     "node_modules/@changesets/config": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.0.3.tgz",
-      "integrity": "sha512-vqgQZMyIcuIpw9nqFIpTSNyc/wgm/Lu1zKN5vECy74u95Qx/Wa9g27HdgO4NkVAaq+BGA8wUc/qvbvVNs93n6A==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.0.4.tgz",
+      "integrity": "sha512-+DiIwtEBpvvv1z30f8bbOsUQGuccnZl9KRKMM/LxUHuDu5oEjmN+bJQ1RIBKNJjfYMQn8RZzoPiX0UgPaLQyXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -528,7 +531,7 @@
         "@changesets/types": "^6.0.0",
         "@manypkg/get-packages": "^1.1.3",
         "fs-extra": "^7.0.1",
-        "micromatch": "^4.0.2"
+        "micromatch": "^4.0.8"
       }
     },
     "node_modules/@changesets/errors": {
@@ -566,16 +569,16 @@
       }
     },
     "node_modules/@changesets/get-release-plan": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.4.tgz",
-      "integrity": "sha512-SicG/S67JmPTrdcc9Vpu0wSQt7IiuN0dc8iR5VScnnTVPfIaLvKmEGRvIaF0kcn8u5ZqLbormZNTO77bCEvyWw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.5.tgz",
+      "integrity": "sha512-E6wW7JoSMcctdVakut0UB76FrrN3KIeJSXvB+DHMFo99CnC3ZVnNYDCVNClMlqAhYGmLmAj77QfApaI3ca4Fkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@changesets/assemble-release-plan": "^6.0.4",
-        "@changesets/config": "^3.0.3",
+        "@changesets/assemble-release-plan": "^6.0.5",
+        "@changesets/config": "^3.0.4",
         "@changesets/pre": "^2.0.1",
-        "@changesets/read": "^0.6.1",
+        "@changesets/read": "^0.6.2",
         "@changesets/types": "^6.0.0",
         "@manypkg/get-packages": "^1.1.3"
       }
@@ -588,17 +591,17 @@
       "license": "MIT"
     },
     "node_modules/@changesets/git": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@changesets/git/-/git-3.0.1.tgz",
-      "integrity": "sha512-pdgHcYBLCPcLd82aRcuO0kxCDbw/yISlOtkmwmE8Odo1L6hSiZrBOsRl84eYG7DRCab/iHnOkWqExqc4wxk2LQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@changesets/git/-/git-3.0.2.tgz",
+      "integrity": "sha512-r1/Kju9Y8OxRRdvna+nxpQIsMsRQn9dhhAZt94FLDeu0Hij2hnOozW8iqnHBgvu+KdnJppCveQwK4odwfw/aWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@changesets/errors": "^0.2.0",
         "@manypkg/get-packages": "^1.1.3",
         "is-subdir": "^1.1.1",
-        "micromatch": "^4.0.2",
-        "spawndamnit": "^2.0.0"
+        "micromatch": "^4.0.8",
+        "spawndamnit": "^3.0.1"
       }
     },
     "node_modules/@changesets/logger": {
@@ -622,30 +625,6 @@
         "js-yaml": "^3.13.1"
       }
     },
-    "node_modules/@changesets/parse/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/@changesets/parse/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/@changesets/pre": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-2.0.1.tgz",
@@ -660,13 +639,13 @@
       }
     },
     "node_modules/@changesets/read": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.6.1.tgz",
-      "integrity": "sha512-jYMbyXQk3nwP25nRzQQGa1nKLY0KfoOV7VLgwucI0bUO8t8ZLCr6LZmgjXsiKuRDc+5A6doKPr9w2d+FEJ55zQ==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.6.2.tgz",
+      "integrity": "sha512-wjfQpJvryY3zD61p8jR87mJdyx2FIhEcdXhKUqkja87toMrP/3jtg/Yg29upN+N4Ckf525/uvV7a4tzBlpk6gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@changesets/git": "^3.0.1",
+        "@changesets/git": "^3.0.2",
         "@changesets/logger": "^0.1.1",
         "@changesets/parse": "^0.4.0",
         "@changesets/types": "^6.0.0",
@@ -1741,9 +1720,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "14.2.16",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.16.tgz",
-      "integrity": "sha512-fLrX5TfJzHCbnZ9YUSnGW63tMV3L4nSfhgOQ0iCcX21Pt+VSTDuaLsSuL8J/2XAiVA5AnzvXDpf6pMs60QxOag==",
+      "version": "14.2.18",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.18.tgz",
+      "integrity": "sha512-2vWLOUwIPgoqMJKG6dt35fVXVhgM09tw4tK3/Q34GFXDrfiHlG7iS33VA4ggnjWxjiz9KV5xzfsQzJX6vGAekA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1807,13 +1786,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.48.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.48.2.tgz",
-      "integrity": "sha512-54w1xCWfXuax7dz4W2M9uw0gDyh+ti/0K/MxcCUxChFh37kkdxPdfZDw5QBbuPUJHr1CiHJ1hXgSs+GgeQc5Zw==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.0.tgz",
+      "integrity": "sha512-DMulbwQURa8rNIQrf94+jPJQ4FmOVdpE5ZppRNvWVjvhC+6sOeo28r8MgIpQRYouXRtt/FCCXU7zn20jnHR4Qw==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "playwright": "1.48.2"
+        "playwright": "1.49.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1823,9 +1802,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.24.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.24.2.tgz",
-      "integrity": "sha512-ufoveNTKDg9t/b7nqI3lwbCG/9IJMhADBNjjz/Jn6LxIZxD7T5L8l2uO/wD99945F1Oo8FvgbbZJRguyk/BdzA==",
+      "version": "4.27.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.27.4.tgz",
+      "integrity": "sha512-2Y3JT6f5MrQkICUyRVCw4oa0sutfAsgaSsb0Lmmy1Wi2y7X5vT9Euqw4gOsCyy0YfKURBg35nhUKZS4mDcfULw==",
       "cpu": [
         "arm"
       ],
@@ -1837,9 +1816,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.24.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.24.2.tgz",
-      "integrity": "sha512-iZoYCiJz3Uek4NI0J06/ZxUgwAfNzqltK0MptPDO4OR0a88R4h0DSELMsflS6ibMCJ4PnLvq8f7O1d7WexUvIA==",
+      "version": "4.27.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.27.4.tgz",
+      "integrity": "sha512-wzKRQXISyi9UdCVRqEd0H4cMpzvHYt1f/C3CoIjES6cG++RHKhrBj2+29nPF0IB5kpy9MS71vs07fvrNGAl/iA==",
       "cpu": [
         "arm64"
       ],
@@ -1851,9 +1830,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.24.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.24.2.tgz",
-      "integrity": "sha512-/UhrIxobHYCBfhi5paTkUDQ0w+jckjRZDZ1kcBL132WeHZQ6+S5v9jQPVGLVrLbNUebdIRpIt00lQ+4Z7ys4Rg==",
+      "version": "4.27.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.27.4.tgz",
+      "integrity": "sha512-PlNiRQapift4LNS8DPUHuDX/IdXiLjf8mc5vdEmUR0fF/pyy2qWwzdLjB+iZquGr8LuN4LnUoSEvKRwjSVYz3Q==",
       "cpu": [
         "arm64"
       ],
@@ -1865,9 +1844,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.24.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.24.2.tgz",
-      "integrity": "sha512-1F/jrfhxJtWILusgx63WeTvGTwE4vmsT9+e/z7cZLKU8sBMddwqw3UV5ERfOV+H1FuRK3YREZ46J4Gy0aP3qDA==",
+      "version": "4.27.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.27.4.tgz",
+      "integrity": "sha512-o9bH2dbdgBDJaXWJCDTNDYa171ACUdzpxSZt+u/AAeQ20Nk5x+IhA+zsGmrQtpkLiumRJEYef68gcpn2ooXhSQ==",
       "cpu": [
         "x64"
       ],
@@ -1879,9 +1858,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.24.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.24.2.tgz",
-      "integrity": "sha512-1YWOpFcGuC6iGAS4EI+o3BV2/6S0H+m9kFOIlyFtp4xIX5rjSnL3AwbTBxROX0c8yWtiWM7ZI6mEPTI7VkSpZw==",
+      "version": "4.27.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.27.4.tgz",
+      "integrity": "sha512-NBI2/i2hT9Q+HySSHTBh52da7isru4aAAo6qC3I7QFVsuhxi2gM8t/EI9EVcILiHLj1vfi+VGGPaLOUENn7pmw==",
       "cpu": [
         "arm64"
       ],
@@ -1893,9 +1872,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.24.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.24.2.tgz",
-      "integrity": "sha512-3qAqTewYrCdnOD9Gl9yvPoAoFAVmPJsBvleabvx4bnu1Kt6DrB2OALeRVag7BdWGWLhP1yooeMLEi6r2nYSOjg==",
+      "version": "4.27.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.27.4.tgz",
+      "integrity": "sha512-wYcC5ycW2zvqtDYrE7deary2P2UFmSh85PUpAx+dwTCO9uw3sgzD6Gv9n5X4vLaQKsrfTSZZ7Z7uynQozPVvWA==",
       "cpu": [
         "x64"
       ],
@@ -1907,9 +1886,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.24.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.24.2.tgz",
-      "integrity": "sha512-ArdGtPHjLqWkqQuoVQ6a5UC5ebdX8INPuJuJNWRe0RGa/YNhVvxeWmCTFQ7LdmNCSUzVZzxAvUznKaYx645Rig==",
+      "version": "4.27.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.27.4.tgz",
+      "integrity": "sha512-9OwUnK/xKw6DyRlgx8UizeqRFOfi9mf5TYCw1uolDaJSbUmBxP85DE6T4ouCMoN6pXw8ZoTeZCSEfSaYo+/s1w==",
       "cpu": [
         "arm"
       ],
@@ -1921,9 +1900,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.24.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.24.2.tgz",
-      "integrity": "sha512-B6UHHeNnnih8xH6wRKB0mOcJGvjZTww1FV59HqJoTJ5da9LCG6R4SEBt6uPqzlawv1LoEXSS0d4fBlHNWl6iYw==",
+      "version": "4.27.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.27.4.tgz",
+      "integrity": "sha512-Vgdo4fpuphS9V24WOV+KwkCVJ72u7idTgQaBoLRD0UxBAWTF9GWurJO9YD9yh00BzbkhpeXtm6na+MvJU7Z73A==",
       "cpu": [
         "arm"
       ],
@@ -1935,9 +1914,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.24.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.24.2.tgz",
-      "integrity": "sha512-kr3gqzczJjSAncwOS6i7fpb4dlqcvLidqrX5hpGBIM1wtt0QEVtf4wFaAwVv8QygFU8iWUMYEoJZWuWxyua4GQ==",
+      "version": "4.27.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.27.4.tgz",
+      "integrity": "sha512-pleyNgyd1kkBkw2kOqlBx+0atfIIkkExOTiifoODo6qKDSpnc6WzUY5RhHdmTdIJXBdSnh6JknnYTtmQyobrVg==",
       "cpu": [
         "arm64"
       ],
@@ -1949,9 +1928,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.24.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.24.2.tgz",
-      "integrity": "sha512-TDdHLKCWgPuq9vQcmyLrhg/bgbOvIQ8rtWQK7MRxJ9nvaxKx38NvY7/Lo6cYuEnNHqf6rMqnivOIPIQt6H2AoA==",
+      "version": "4.27.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.27.4.tgz",
+      "integrity": "sha512-caluiUXvUuVyCHr5DxL8ohaaFFzPGmgmMvwmqAITMpV/Q+tPoaHZ/PWa3t8B2WyoRcIIuu1hkaW5KkeTDNSnMA==",
       "cpu": [
         "arm64"
       ],
@@ -1963,9 +1942,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.24.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.24.2.tgz",
-      "integrity": "sha512-xv9vS648T3X4AxFFZGWeB5Dou8ilsv4VVqJ0+loOIgDO20zIhYfDLkk5xoQiej2RiSQkld9ijF/fhLeonrz2mw==",
+      "version": "4.27.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.27.4.tgz",
+      "integrity": "sha512-FScrpHrO60hARyHh7s1zHE97u0KlT/RECzCKAdmI+LEoC1eDh/RDji9JgFqyO+wPDb86Oa/sXkily1+oi4FzJQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1977,9 +1956,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.24.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.24.2.tgz",
-      "integrity": "sha512-tbtXwnofRoTt223WUZYiUnbxhGAOVul/3StZ947U4A5NNjnQJV5irKMm76G0LGItWs6y+SCjUn/Q0WaMLkEskg==",
+      "version": "4.27.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.27.4.tgz",
+      "integrity": "sha512-qyyprhyGb7+RBfMPeww9FlHwKkCXdKHeGgSqmIXw9VSUtvyFZ6WZRtnxgbuz76FK7LyoN8t/eINRbPUcvXB5fw==",
       "cpu": [
         "riscv64"
       ],
@@ -1991,9 +1970,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.24.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.24.2.tgz",
-      "integrity": "sha512-gc97UebApwdsSNT3q79glOSPdfwgwj5ELuiyuiMY3pEWMxeVqLGKfpDFoum4ujivzxn6veUPzkGuSYoh5deQ2Q==",
+      "version": "4.27.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.27.4.tgz",
+      "integrity": "sha512-PFz+y2kb6tbh7m3A7nA9++eInGcDVZUACulf/KzDtovvdTizHpZaJty7Gp0lFwSQcrnebHOqxF1MaKZd7psVRg==",
       "cpu": [
         "s390x"
       ],
@@ -2005,9 +1984,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.24.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.24.2.tgz",
-      "integrity": "sha512-jOG/0nXb3z+EM6SioY8RofqqmZ+9NKYvJ6QQaa9Mvd3RQxlH68/jcB/lpyVt4lCiqr04IyaC34NzhUqcXbB5FQ==",
+      "version": "4.27.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.27.4.tgz",
+      "integrity": "sha512-Ni8mMtfo+o/G7DVtweXXV/Ol2TFf63KYjTtoZ5f078AUgJTmaIJnj4JFU7TK/9SVWTaSJGxPi5zMDgK4w+Ez7Q==",
       "cpu": [
         "x64"
       ],
@@ -2019,9 +1998,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.24.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.24.2.tgz",
-      "integrity": "sha512-XAo7cJec80NWx9LlZFEJQxqKOMz/lX3geWs2iNT5CHIERLFfd90f3RYLLjiCBm1IMaQ4VOX/lTC9lWfzzQm14Q==",
+      "version": "4.27.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.27.4.tgz",
+      "integrity": "sha512-5AeeAF1PB9TUzD+3cROzFTnAJAcVUGLuR8ng0E0WXGkYhp6RD6L+6szYVX+64Rs0r72019KHZS1ka1q+zU/wUw==",
       "cpu": [
         "x64"
       ],
@@ -2033,9 +2012,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.24.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.24.2.tgz",
-      "integrity": "sha512-A+JAs4+EhsTjnPQvo9XY/DC0ztaws3vfqzrMNMKlwQXuniBKOIIvAAI8M0fBYiTCxQnElYu7mLk7JrhlQ+HeOw==",
+      "version": "4.27.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.27.4.tgz",
+      "integrity": "sha512-yOpVsA4K5qVwu2CaS3hHxluWIK5HQTjNV4tWjQXluMiiiu4pJj4BN98CvxohNCpcjMeTXk/ZMJBRbgRg8HBB6A==",
       "cpu": [
         "arm64"
       ],
@@ -2047,9 +2026,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.24.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.24.2.tgz",
-      "integrity": "sha512-ZhcrakbqA1SCiJRMKSU64AZcYzlZ/9M5LaYil9QWxx9vLnkQ9Vnkve17Qn4SjlipqIIBFKjBES6Zxhnvh0EAEw==",
+      "version": "4.27.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.27.4.tgz",
+      "integrity": "sha512-KtwEJOaHAVJlxV92rNYiG9JQwQAdhBlrjNRp7P9L8Cb4Rer3in+0A+IPhJC9y68WAi9H0sX4AiG2NTsVlmqJeQ==",
       "cpu": [
         "ia32"
       ],
@@ -2061,9 +2040,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.24.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.24.2.tgz",
-      "integrity": "sha512-2mLH46K1u3r6uwc95hU+OR9q/ggYMpnS7pSp83Ece1HUQgF9Nh/QwTK5rcgbFnV9j+08yBrU5sA/P0RK2MSBNA==",
+      "version": "4.27.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.27.4.tgz",
+      "integrity": "sha512-3j4jx1TppORdTAoBJRd+/wJRGCPC0ETWkXOecJ6PPZLj6SptXkrXcNqdj0oclbKML6FkQltdz7bBA3rUSirZug==",
       "cpu": [
         "x64"
       ],
@@ -2160,18 +2139,18 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.17.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.1.tgz",
-      "integrity": "sha512-j2VlPv1NnwPJbaCNv69FO/1z4lId0QmGvpT41YxitRtWlg96g/j8qcv2RKsLKe2F6OJgyXhupN1Xo17b2m139Q==",
+      "version": "20.17.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.7.tgz",
+      "integrity": "sha512-sZXXnpBFMKbao30dUAvzKbdwA2JM1fwUtVEq/kxKuPI5mMwZiRElCpTXb0Biq/LMEVpXDZL5G5V0RPnxKeyaYg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
       }
     },
     "node_modules/@types/node-fetch": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.11.tgz",
-      "integrity": "sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==",
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -2179,9 +2158,9 @@
       }
     },
     "node_modules/@types/qs": {
-      "version": "6.9.16",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.16.tgz",
-      "integrity": "sha512-7i+zxXdPD0T4cKDuxCUXJ4wHcsJLwENa6Z3dCu8cfCK743OGy5Nu1RmAGqDPsoTDINVEcdXKRvR/zre+P2Ku1A==",
+      "version": "6.9.17",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.17.tgz",
+      "integrity": "sha512-rX4/bPcfmvxHDv0XjfJELTTr+iB+tn032nPILqHm5wbthUUUuVtNGGqzhya9XUxjTP8Fpr0qYgSZZKxGY++svQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2601,13 +2580,26 @@
       }
     },
     "node_modules/autoevals/node_modules/@types/node": {
-      "version": "18.19.59",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.59.tgz",
-      "integrity": "sha512-vizm2EqwV/7Zay+A6J3tGl9Lhr7CjZe2HmWS988sefiEmsyP9CeXEleho6i4hJk/8UtZAo0bWN4QPZZr83RxvQ==",
+      "version": "18.19.65",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.65.tgz",
+      "integrity": "sha512-Ay5BZuO1UkTmVHzZJNvZKw/E+iB3GQABb6kijEz89w2JrfhNA+M/ebp18pfz9Gqe9ywhMC8AA8yC01lZq48J+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/autoevals/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/autoevals/node_modules/openai": {
@@ -3220,16 +3212,6 @@
         "@esbuild/win32-x64": "0.18.20"
       }
     },
-    "node_modules/braintrust/node_modules/source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -3404,6 +3386,21 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/chromium-bidi": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.10.0.tgz",
+      "integrity": "sha512-atrmNrCxWGvGTLVpyI930/W7oUbjRzyueGWKb19j10UTWNm1D7GJG+Sks8bFVQZEeExfh1cvWdi2qLHvFQilCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "3.0.1",
+        "urlpattern-polyfill": "10.0.0",
+        "zod": "3.23.8"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
       }
     },
     "node_modules/ci-info": {
@@ -3611,9 +3608,9 @@
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3773,6 +3770,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1387216",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1387216.tgz",
+      "integrity": "sha512-XFL0XfAbXtoevWA8N3c3PBs57pdfCgxwRDuoontHjCfD0wjLhLpOgW0ILsEHNKtOHZK8BdhFHqjFPevNfJALaw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/diff-match-patch": {
       "version": "1.0.5",
@@ -4191,21 +4196,6 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
-      }
-    },
-    "node_modules/fdir": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.2.tgz",
-      "integrity": "sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
       }
     },
     "node_modules/fft.js": {
@@ -4799,16 +4789,27 @@
       "peer": true
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "argparse": "^2.0.1"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/js-yaml/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
       }
     },
     "node_modules/json-schema": {
@@ -5035,19 +5036,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -5118,6 +5106,13 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/mkdirp": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
@@ -5175,25 +5170,25 @@
       }
     },
     "node_modules/ml-spectra-processing": {
-      "version": "14.6.0",
-      "resolved": "https://registry.npmjs.org/ml-spectra-processing/-/ml-spectra-processing-14.6.0.tgz",
-      "integrity": "sha512-16DOpuM5s2ilD+lm7nDJosogvVmMSj9ohYIZDC8CTEtKeh2GOGQfNY8DDPkk2nVmMP46W0PuVb60ySpjdkF+0A==",
+      "version": "14.7.0",
+      "resolved": "https://registry.npmjs.org/ml-spectra-processing/-/ml-spectra-processing-14.7.0.tgz",
+      "integrity": "sha512-O8ztoPhiKe6U2w7U+Lb7Ft9gE6/o6w4Y6x0QOQM74iP40t4tP7ZDMdTtCCEUuk8l/YWxSBsjXYvD1NL5OW+mBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-search": "^1.3.6",
-        "cheminfo-types": "^1.8.0",
+        "cheminfo-types": "^1.8.1",
         "fft.js": "^4.0.4",
         "is-any-array": "^2.0.1",
-        "ml-matrix": "^6.11.1",
-        "ml-xsadd": "^2.0.0",
+        "ml-matrix": "^6.12.0",
+        "ml-xsadd": "^3.0.1",
         "spline-interpolator": "^1.0.0"
       }
     },
     "node_modules/ml-xsadd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ml-xsadd/-/ml-xsadd-2.0.0.tgz",
-      "integrity": "sha512-VoAYUqmPRmzKbbqRejjqceGFp3VF81Qe8XXFGU0UXLxB7Mf4GGvyGq5Qn3k4AiQgDEV6WzobqlPOd+j0+m6IrA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ml-xsadd/-/ml-xsadd-3.0.1.tgz",
+      "integrity": "sha512-Fz2q6dwgzGM8wYKGArTUTZDGa4lQFA2Vi6orjGeTVRy22ZnQFKlJuwS9n8NRviqz1KHAHAzdKJwbnYhdo38uYg==",
       "dev": true,
       "license": "MIT"
     },
@@ -5346,9 +5341,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
-      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
+      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5372,9 +5367,9 @@
       }
     },
     "node_modules/openai": {
-      "version": "4.68.4",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.68.4.tgz",
-      "integrity": "sha512-LRinV8iU9VQplkr25oZlyrsYGPGasIwYN8KFMAAFTHHLHjHhejtJ5BALuLFrkGzY4wfbKhOhuT+7lcHZ+F3iEA==",
+      "version": "4.73.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.73.0.tgz",
+      "integrity": "sha512-NZstV77w3CEol9KQTRBRQ15+Sw6nxVTicAULSjYO4wn9E5gw72Mtp3fAVaBFXyyVPws4241YmFG6ya4L8v03tA==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -5399,9 +5394,9 @@
       }
     },
     "node_modules/openai/node_modules/@types/node": {
-      "version": "18.19.59",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.59.tgz",
-      "integrity": "sha512-vizm2EqwV/7Zay+A6J3tGl9Lhr7CjZe2HmWS988sefiEmsyP9CeXEleho6i4hJk/8UtZAo0bWN4QPZZr83RxvQ==",
+      "version": "18.19.65",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.65.tgz",
+      "integrity": "sha512-Ay5BZuO1UkTmVHzZJNvZKw/E+iB3GQABb6kijEz89w2JrfhNA+M/ebp18pfz9Gqe9ywhMC8AA8yC01lZq48J+Q==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5512,9 +5507,9 @@
       "license": "BlueOak-1.0.0"
     },
     "node_modules/package-manager-detector": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.2.tgz",
-      "integrity": "sha512-VgXbyrSNsml4eHWIvxxG/nTL4wgybMTXCV2Un/+yEc3aDKKU6nQBZjbeP3Pl3qm9Qg92X/1ng4ffvCeD/zwHgg==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.4.tgz",
+      "integrity": "sha512-H/OUu9/zUfP89z1APcBf2X8Us0tt8dUK4lUmKqz12QNXif3DxAs1/YqjGtcutZi1zQqeNQRWr9C+EbQnnvSSFA==",
       "dev": true,
       "license": "MIT"
     },
@@ -5630,13 +5625,13 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=8.6"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -5663,13 +5658,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.48.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.2.tgz",
-      "integrity": "sha512-NjYvYgp4BPmiwfe31j4gHLa3J7bD2WiBz8Lk2RoSsmX38SVIARZ18VYjxLjAcDsAhA+F4iSEXTSGgjua0rrlgQ==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.0.tgz",
+      "integrity": "sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "playwright-core": "1.48.2"
+        "playwright-core": "1.49.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -5682,9 +5677,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.48.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.2.tgz",
-      "integrity": "sha512-sjjw+qrLFlriJo64du+EK0kJgZzoQPsabGF4lBvsid+3CNIZIYLgnMj9V6JY5VhM2Peh20DJWIVpVljLLnlawA==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.0.tgz",
+      "integrity": "sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA==",
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -5814,13 +5809,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5937,30 +5925,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/read-yaml-file/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/read-yaml-file/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -6037,9 +6001,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.24.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.24.2.tgz",
-      "integrity": "sha512-do/DFGq5g6rdDhdpPq5qb2ecoczeK6y+2UAjdJ5trjQJj5f1AiVdLRWRc9A9/fFukfvJRgM0UXzxBIYMovm5ww==",
+      "version": "4.27.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.27.4.tgz",
+      "integrity": "sha512-RLKxqHEMjh/RGLsDxAEsaLO3mWgyoU6x9w6n1ikAzet4B3gI2/3yP6PWY2p9QzRTh6MfEIXB3MwsOY0Iv3vNrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6053,24 +6017,24 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.24.2",
-        "@rollup/rollup-android-arm64": "4.24.2",
-        "@rollup/rollup-darwin-arm64": "4.24.2",
-        "@rollup/rollup-darwin-x64": "4.24.2",
-        "@rollup/rollup-freebsd-arm64": "4.24.2",
-        "@rollup/rollup-freebsd-x64": "4.24.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.24.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.24.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.24.2",
-        "@rollup/rollup-linux-arm64-musl": "4.24.2",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.24.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.24.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.24.2",
-        "@rollup/rollup-linux-x64-gnu": "4.24.2",
-        "@rollup/rollup-linux-x64-musl": "4.24.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.24.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.24.2",
-        "@rollup/rollup-win32-x64-msvc": "4.24.2",
+        "@rollup/rollup-android-arm-eabi": "4.27.4",
+        "@rollup/rollup-android-arm64": "4.27.4",
+        "@rollup/rollup-darwin-arm64": "4.27.4",
+        "@rollup/rollup-darwin-x64": "4.27.4",
+        "@rollup/rollup-freebsd-arm64": "4.27.4",
+        "@rollup/rollup-freebsd-x64": "4.27.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.27.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.27.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.27.4",
+        "@rollup/rollup-linux-arm64-musl": "4.27.4",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.27.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.27.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.27.4",
+        "@rollup/rollup-linux-x64-gnu": "4.27.4",
+        "@rollup/rollup-linux-x64-musl": "4.27.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.27.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.27.4",
+        "@rollup/rollup-win32-x64-msvc": "4.27.4",
         "fsevents": "~2.3.2"
       }
     },
@@ -6393,14 +6357,11 @@
       }
     },
     "node_modules/source-map": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
-      "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "whatwg-url": "^7.0.0"
-      },
       "engines": {
         "node": ">= 8"
       }
@@ -6416,110 +6377,15 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/source-map/node_modules/tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/source-map/node_modules/webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/source-map/node_modules/whatwg-url": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
-      }
-    },
     "node_modules/spawndamnit": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/spawndamnit/-/spawndamnit-2.0.0.tgz",
-      "integrity": "sha512-j4JKEcncSjFlqIwU5L/rp2N5SIPsdxaRsIv678+TZxZ0SRDJTm8JrxJMjE/XuiEZNEir3S8l0Fa3Ke339WI4qA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spawndamnit/-/spawndamnit-3.0.1.tgz",
+      "integrity": "sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==",
       "dev": true,
-      "license": "MIT",
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "cross-spawn": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      }
-    },
-    "node_modules/spawndamnit/node_modules/cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      }
-    },
-    "node_modules/spawndamnit/node_modules/lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      }
-    },
-    "node_modules/spawndamnit/node_modules/shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/spawndamnit/node_modules/shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/spawndamnit/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/spawndamnit/node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
+        "cross-spawn": "^7.0.5",
+        "signal-exit": "^4.0.1"
       }
     },
     "node_modules/spline-interpolator": {
@@ -6819,6 +6685,34 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.2.tgz",
+      "integrity": "sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -6879,9 +6773,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/tslib": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
-      "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD",
       "optional": true
     },
@@ -7393,6 +7287,48 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tsup/node_modules/source-map": {
+      "version": "0.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
+      "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "whatwg-url": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/tsup/node_modules/tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/tsup/node_modules/webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/tsup/node_modules/whatwg-url": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
+    },
     "node_modules/tsx": {
       "version": "4.19.2",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.2.tgz",
@@ -7898,9 +7834,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -7912,9 +7848,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.20.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.20.1.tgz",
-      "integrity": "sha512-AjQF1QsmqfJys+LXfGTNum+qw4S88CojRInG/6t31W/1fk6G59s92bnAvGz5Cmur+kQv2SURXEvvudLmbrE8QA==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.0.tgz",
+      "integrity": "sha512-BUgJXc752Kou3oOIuU1i+yZZypyZRqNPW0vqoMPl8VaoalSfeR0D8/t4iAS3yirs79SSMTxTag+ZC86uswv+Cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7946,6 +7882,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/urlpattern-polyfill": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+      "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/use-sync-external-store": {
       "version": "1.2.2",
@@ -8212,17 +8155,10 @@
         "node": ">=0.4"
       }
     },
-    "node_modules/yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/yaml": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
-      "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
+      "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@types/express": "^4.17.21",
     "@types/node": "^20.11.30",
     "autoevals": "^0.0.64",
-    "braintrust": "^0.0.127",
+    "braintrust": "^0.0.171",
     "cheerio": "^1.0.0",
     "esbuild": "^0.21.4",
     "express": "^4.21.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "autoevals": "^0.0.64",
     "braintrust": "^0.0.171",
     "cheerio": "^1.0.0",
+    "chromium-bidi": "^0.10.0",
     "esbuild": "^0.21.4",
     "express": "^4.21.0",
     "multer": "^1.4.5-lts.1",


### PR DESCRIPTION
Reverts #210 which reverted #208.

Gets evals back to a more usable state so we can establish a better baseline, also updates braintrust to take advantage of functionalities like `maxConcurrency`. This meant having to add `chromium-bidi` to our dev deps to ensure compatibility with braintrust