### PR TITLE
Reset max concurrency back to 10

### DIFF
--- a/evals/index.eval.ts
+++ b/evals/index.eval.ts
@@ -1486,6 +1486,6 @@ Eval("stagehand", {
     }
   },
   scores: [exactMatch, errorMatch],
-  maxConcurrency: env === "BROWSERBASE" ? undefined : 10,
+  maxConcurrency: 10,
   trialCount: 10,
 });


### PR DESCRIPTION
# why
Originally had unlimited max concurrency, probably better to put this back down to a reasonable number like 10

# what changed
Set max concurrency for evals to 10

# test plan
n/a
