### PR TITLE
Set trial count to 5 per test

### DIFF
--- a/evals/index.eval.ts
+++ b/evals/index.eval.ts
@@ -1486,6 +1486,6 @@ Eval("stagehand", {
     }
   },
   scores: [exactMatch, errorMatch],
-  maxConcurrency: 10,
+  maxConcurrency: 20,
   trialCount: 5,
 });

--- a/evals/index.eval.ts
+++ b/evals/index.eval.ts
@@ -1487,5 +1487,5 @@ Eval("stagehand", {
   },
   scores: [exactMatch, errorMatch],
   maxConcurrency: 10,
-  trialCount: 10,
+  trialCount: 5,
 });


### PR DESCRIPTION
# why
GitHub Actions are timing out due to running so many tests with limited concurrency

# what changed
Set number of tests to 5 instead of 10. We don't need that level of granularity

# test plan
evals