### PR TITLE
parameterize llmclient

### DIFF
--- a/evals/index.eval.ts
+++ b/evals/index.eval.ts
@@ -1,10 +1,9 @@
 import { Eval } from "braintrust";
 import { Stagehand } from "../lib";
-import type { AvailableModel } from "../lib/llm/LLMProvider";
 import { z } from "zod";
 import process from "process";
 import { EvalLogger } from "./utils";
-import { LogLine } from "../lib/types";
+import { AvailableModel, LogLine } from "../lib/types";
 
 const env: "BROWSERBASE" | "LOCAL" =
   process.env.EVAL_ENV?.toLowerCase() === "browserbase"

--- a/examples/parameterizeApiKey.ts
+++ b/examples/parameterizeApiKey.ts
@@ -1,0 +1,46 @@
+import { Stagehand } from "../lib";
+import { z } from "zod";
+
+/**
+ * This example shows how to parameterize the API key for the LLM provider.
+ *
+ * In order to best demonstrate, unset the OPENAI_API_KEY environment variable and
+ * set the USE_OPENAI_API_KEY environment variable to your OpenAI API key.
+ *
+ * export USE_OPENAI_API_KEY=$OPENAI_API_KEY
+ * unset OPENAI_API_KEY
+ */
+
+async function example() {
+  const stagehand = new Stagehand({
+    env: "LOCAL",
+    verbose: 1,
+    debugDom: true,
+    enableCaching: false,
+    modelName: "gpt-4o",
+    modelClientOptions: {
+      apiKey: process.env.USE_OPENAI_API_KEY,
+    },
+  });
+
+  await stagehand.init({
+    modelName: "gpt-4o",
+    modelClientOptions: {
+      apiKey: process.env.USE_OPENAI_API_KEY,
+    },
+  });
+  await stagehand.page.goto("https://github.com/browserbase/stagehand");
+  await stagehand.act({ action: "click on the contributors" });
+  const contributor = await stagehand.extract({
+    instruction: "extract the top contributor",
+    schema: z.object({
+      username: z.string(),
+      url: z.string(),
+    }),
+  });
+  console.log(`Our favorite contributor is ${contributor.username}`);
+}
+
+(async () => {
+  await example();
+})();

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -670,6 +670,10 @@ export class Stagehand {
           value: requestId,
           type: "string",
         },
+        modelName: {
+          value: llmClient.modelName,
+          type: "string",
+        },
       },
     });
 
@@ -748,6 +752,10 @@ export class Stagehand {
           value: requestId,
           type: "string",
         },
+        modelName: {
+          value: llmClient.modelName,
+          type: "string",
+        },
       },
     });
 
@@ -810,6 +818,10 @@ export class Stagehand {
         },
         requestId: {
           value: requestId,
+          type: "string",
+        },
+        modelName: {
+          value: llmClient.modelName,
           type: "string",
         },
       },

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -401,7 +401,7 @@ export class Stagehand {
       waitForSettledDom: this._waitForSettledDom.bind(this),
       startDomDebug: this.startDomDebug.bind(this),
       cleanupDomDebug: this.cleanupDomDebug.bind(this),
-      llmClient: this.llmProvider.getClient(modelName),
+      llmClient: this.llmClient,
     });
 
     this.extractHandler = new StagehandExtractHandler({
@@ -412,7 +412,7 @@ export class Stagehand {
       cleanupDomDebug: this.cleanupDomDebug.bind(this),
       llmProvider: this.llmProvider,
       verbose: this.verbose,
-      llmClient: this.llmProvider.getClient(modelName),
+      llmClient: this.llmClient,
     });
 
     this.observeHandler = new StagehandObserveHandler({
@@ -423,7 +423,7 @@ export class Stagehand {
       cleanupDomDebug: this.cleanupDomDebug.bind(this),
       llmProvider: this.llmProvider,
       verbose: this.verbose,
-      llmClient: this.llmProvider.getClient(modelName),
+      llmClient: this.llmClient,
     });
 
     return { debugUrl, sessionUrl };
@@ -431,13 +431,11 @@ export class Stagehand {
 
   async initFromPage(
     page: Page,
-    modelName?: AvailableModel,
+    modelName: AvailableModel = DEFAULT_MODEL_NAME,
   ): Promise<{ context: BrowserContext }> {
     this.page = page;
     this.context = page.context();
-    this.llmClient = this.llmProvider.getClient(
-      modelName || DEFAULT_MODEL_NAME,
-    );
+    this.llmClient = this.llmProvider.getClient(modelName);
 
     const originalGoto = this.page.goto.bind(this.page);
     this.page.goto = async (url: string, options?: any) => {
@@ -655,7 +653,9 @@ export class Stagehand {
 
     useVision = useVision ?? "fallback";
     const requestId = Math.random().toString(36).substring(2);
-    const llmClient = this.llmProvider.getClient(modelName);
+    const llmClient: LLMClient = modelName
+      ? this.llmProvider.getClient(modelName)
+      : this.llmClient;
 
     this.log({
       category: "act",
@@ -731,7 +731,9 @@ export class Stagehand {
     }
 
     const requestId = Math.random().toString(36).substring(2);
-    const llmClient = this.llmProvider.getClient(modelName);
+    const llmClient = modelName
+      ? this.llmProvider.getClient(modelName)
+      : this.llmClient;
 
     this.logger({
       category: "extract",
@@ -793,9 +795,9 @@ export class Stagehand {
     }
 
     const requestId = Math.random().toString(36).substring(2);
-    const llmClient = this.llmProvider.getClient(
-      options?.modelName ?? DEFAULT_MODEL_NAME,
-    );
+    const llmClient = options?.modelName
+      ? this.llmProvider.getClient(options.modelName)
+      : this.llmClient;
 
     this.logger({
       category: "observe",

--- a/lib/inference.ts
+++ b/lib/inference.ts
@@ -21,7 +21,6 @@ import {
   ChatMessage,
   LLMClient,
 } from "./llm/LLMClient";
-import { AvailableModel } from "./types";
 
 export async function verifyActCompletion({
   goal,

--- a/lib/inference.ts
+++ b/lib/inference.ts
@@ -16,7 +16,6 @@ import {
   buildMetadataPrompt,
 } from "./prompt";
 import { z } from "zod";
-import { LLMProvider } from "./llm/LLMProvider";
 import {
   AnnotatedScreenshotText,
   ChatMessage,
@@ -27,7 +26,6 @@ import { AvailableModel } from "./types";
 export async function verifyActCompletion({
   goal,
   steps,
-  llmProvider,
   llmClient,
   screenshot,
   domElements,
@@ -36,7 +34,6 @@ export async function verifyActCompletion({
 }: {
   goal: string;
   steps: string;
-  llmProvider: LLMProvider;
   llmClient: LLMClient;
   screenshot?: Buffer;
   domElements?: string;
@@ -104,7 +101,6 @@ export async function act({
   action,
   domElements,
   steps,
-  llmProvider,
   llmClient,
   screenshot,
   retries = 0,
@@ -115,7 +111,6 @@ export async function act({
   action: string;
   steps?: string;
   domElements: string;
-  llmProvider: LLMProvider;
   llmClient: LLMClient;
   screenshot?: Buffer;
   retries?: number;
@@ -170,7 +165,6 @@ export async function act({
       action,
       domElements,
       steps,
-      llmProvider,
       llmClient,
       retries: retries + 1,
       logger,
@@ -185,7 +179,6 @@ export async function extract({
   previouslyExtractedContent,
   domElements,
   schema,
-  llmProvider,
   llmClient,
   chunksSeen,
   chunksTotal,
@@ -196,7 +189,6 @@ export async function extract({
   previouslyExtractedContent: any;
   domElements: string;
   schema: z.ZodObject<any>;
-  llmProvider: LLMProvider;
   llmClient: LLMClient;
   chunksSeen: number;
   chunksTotal: number;
@@ -280,14 +272,12 @@ export async function extract({
 export async function observe({
   instruction,
   domElements,
-  llmProvider,
   llmClient,
   image,
   requestId,
 }: {
   instruction: string;
   domElements: string;
-  llmProvider: LLMProvider;
   llmClient: LLMClient;
   image?: Buffer;
   requestId: string;
@@ -337,16 +327,13 @@ export async function observe({
 
 export async function ask({
   question,
-  llmProvider,
-  modelName,
+  llmClient,
   requestId,
 }: {
   question: string;
-  llmProvider: LLMProvider;
-  modelName: AvailableModel;
+  llmClient: LLMClient;
   requestId: string;
 }) {
-  const llmClient = llmProvider.getClient(modelName);
   const response = await llmClient.createChatCompletion({
     messages: [buildAskSystemPrompt(), buildAskUserPrompt(question)],
     temperature: 0.1,

--- a/lib/llm/AnthropicClient.ts
+++ b/lib/llm/AnthropicClient.ts
@@ -23,6 +23,7 @@ export class AnthropicClient extends LLMClient {
     this.logger = logger;
     this.cache = cache;
     this.enableCaching = enableCaching;
+    this.modelName = modelName;
   }
 
   async createChatCompletion(

--- a/lib/llm/AnthropicClient.ts
+++ b/lib/llm/AnthropicClient.ts
@@ -1,34 +1,34 @@
-import Anthropic from "@anthropic-ai/sdk";
+import Anthropic, { ClientOptions } from "@anthropic-ai/sdk";
 import { LLMClient, ChatCompletionOptions } from "./LLMClient";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { LLMCache } from "../cache/LLMCache";
-import { LogLine } from "../types";
+import { AvailableModel, LogLine } from "../types";
+import { Message, MessageCreateParams } from "@anthropic-ai/sdk/resources";
 
-export class AnthropicClient implements LLMClient {
+export class AnthropicClient extends LLMClient {
   private client: Anthropic;
   private cache: LLMCache | undefined;
   public logger: (message: LogLine) => void;
   private enableCaching: boolean;
-  private requestId: string;
 
   constructor(
     logger: (message: LogLine) => void,
     enableCaching = false,
     cache: LLMCache | undefined,
-    requestId: string,
+    modelName: AvailableModel,
+    clientOptions?: ClientOptions,
   ) {
-    this.client = new Anthropic({
-      apiKey: process.env.ANTHROPIC_API_KEY,
-    });
+    super(modelName);
+    this.client = new Anthropic(clientOptions);
     this.logger = logger;
     this.cache = cache;
     this.enableCaching = enableCaching;
-    this.requestId = requestId;
   }
 
   async createChatCompletion(
     options: ChatCompletionOptions & { retries?: number },
-  ) {
+  ): Promise<any> {
+    // TODO (kamath): remove this forced typecast
     const { image: _, ...optionsWithoutImage } = options;
     this.logger({
       category: "anthropic",
@@ -43,7 +43,7 @@ export class AnthropicClient implements LLMClient {
     });
     // Try to get cached response
     const cacheOptions = {
-      model: options.model,
+      model: this.modelName,
       messages: options.messages,
       temperature: options.temperature,
       image: options.image,
@@ -53,7 +53,10 @@ export class AnthropicClient implements LLMClient {
     };
 
     if (this.enableCaching) {
-      const cachedResponse = await this.cache.get(cacheOptions, this.requestId);
+      const cachedResponse = await this.cache.get(
+        cacheOptions,
+        options.requestId,
+      );
       if (cachedResponse) {
         this.logger({
           category: "llm_cache",
@@ -65,7 +68,7 @@ export class AnthropicClient implements LLMClient {
               type: "object",
             },
             requestId: {
-              value: this.requestId,
+              value: options.requestId,
               type: "string",
             },
             cacheOptions: {
@@ -86,7 +89,7 @@ export class AnthropicClient implements LLMClient {
               type: "object",
             },
             requestId: {
-              value: this.requestId,
+              value: options.requestId,
               type: "string",
             },
           },
@@ -141,10 +144,17 @@ export class AnthropicClient implements LLMClient {
       const jsonSchema = zodToJsonSchema(options.response_model.schema);
 
       // Extract the actual schema properties
+      // TODO (kamath): fix this forced typecast
       const schemaProperties =
-        jsonSchema.definitions?.MySchema?.properties || jsonSchema.properties;
+        (
+          jsonSchema.definitions?.MySchema as {
+            properties?: Record<string, any>;
+          }
+        )?.properties ||
+        (jsonSchema as { properties?: Record<string, any> }).properties;
       const schemaRequired =
-        jsonSchema.definitions?.MySchema?.required || jsonSchema.required;
+        (jsonSchema.definitions?.MySchema as { required?: string[] })
+          ?.required || (jsonSchema as { required?: string[] }).required;
 
       toolDefinition = {
         name: "print_extracted_data",
@@ -162,9 +172,9 @@ export class AnthropicClient implements LLMClient {
       anthropicTools.push(toolDefinition);
     }
 
-    const response = await this.client.messages.create({
-      model: options.model,
-      max_tokens: options.max_tokens || 1500,
+    const response = (await this.client.messages.create({
+      model: this.modelName,
+      max_tokens: options.maxTokens || 1500,
       messages: userMessages.map((msg) => ({
         role: msg.role,
         content: msg.content,
@@ -172,7 +182,7 @@ export class AnthropicClient implements LLMClient {
       tools: anthropicTools,
       system: systemMessage?.content,
       temperature: options.temperature,
-    });
+    } as MessageCreateParams)) as Message; // TODO (kamath): remove this forced typecast
 
     this.logger({
       category: "anthropic",
@@ -184,7 +194,7 @@ export class AnthropicClient implements LLMClient {
           type: "object",
         },
         requestId: {
-          value: this.requestId,
+          value: options.requestId,
           type: "string",
         },
       },
@@ -235,7 +245,7 @@ export class AnthropicClient implements LLMClient {
           type: "object",
         },
         requestId: {
-          value: this.requestId,
+          value: options.requestId,
           type: "string",
         },
       },
@@ -246,7 +256,7 @@ export class AnthropicClient implements LLMClient {
       if (toolUse && "input" in toolUse) {
         const result = toolUse.input;
         if (this.enableCaching) {
-          this.cache.set(cacheOptions, result, this.requestId);
+          this.cache.set(cacheOptions, result, options.requestId);
         }
 
         return result;
@@ -263,7 +273,7 @@ export class AnthropicClient implements LLMClient {
           level: 1,
           auxiliary: {
             requestId: {
-              value: this.requestId,
+              value: options.requestId,
               type: "string",
             },
           },
@@ -275,14 +285,14 @@ export class AnthropicClient implements LLMClient {
     }
 
     if (this.enableCaching) {
-      this.cache.set(cacheOptions, transformedResponse, this.requestId);
+      this.cache.set(cacheOptions, transformedResponse, options.requestId);
       this.logger({
         category: "anthropic",
         message: "cached response",
         level: 1,
         auxiliary: {
           requestId: {
-            value: this.requestId,
+            value: options.requestId,
             type: "string",
           },
           transformedResponse: {

--- a/lib/llm/LLMClient.ts
+++ b/lib/llm/LLMClient.ts
@@ -1,4 +1,4 @@
-import { AvailableModel } from "./LLMProvider";
+import { AvailableModel, ToolCall } from "../types";
 
 export interface ChatMessage {
   role: "system" | "user" | "assistant";
@@ -24,7 +24,6 @@ export const AnnotatedScreenshotText =
   "This is a screenshot of the current page state with the elements annotated on it. Each element id is annotated with a number to the top left of it. Duplicate annotations at the same location are under each other vertically.";
 
 export interface ChatCompletionOptions {
-  model: string;
   messages: ChatMessage[];
   temperature?: number;
   top_p?: number;
@@ -34,14 +33,25 @@ export interface ChatCompletionOptions {
     buffer: Buffer;
     description?: string;
   };
-  [key: string]: any; // Additional provider-specific options
   response_model?: {
     name: string;
     schema: any;
   };
+  tools?: ToolCall[];
+  tool_choice?: string;
+  maxTokens?: number;
+  requestId: string;
 }
 
-export interface LLMClient {
-  createChatCompletion(options: ChatCompletionOptions): Promise<any>;
-  logger: (message: { category?: string; message: string }) => void;
+export abstract class LLMClient {
+  public modelName: AvailableModel;
+  public hasVision: boolean;
+
+  constructor(modelName: AvailableModel) {
+    this.modelName = modelName;
+    this.hasVision = modelsWithVision.includes(modelName);
+  }
+
+  abstract createChatCompletion(options: ChatCompletionOptions): Promise<any>;
+  abstract logger: (message: { category?: string; message: string }) => void;
 }

--- a/lib/llm/LLMProvider.ts
+++ b/lib/llm/LLMProvider.ts
@@ -2,18 +2,15 @@ import { OpenAIClient } from "./OpenAIClient";
 import { AnthropicClient } from "./AnthropicClient";
 import { LLMClient } from "./LLMClient";
 import { LLMCache } from "../cache/LLMCache";
-import { LogLine } from "../types";
-
-export type AvailableModel =
-  | "gpt-4o"
-  | "gpt-4o-mini"
-  | "gpt-4o-2024-08-06"
-  | "claude-3-5-sonnet-latest"
-  | "claude-3-5-sonnet-20241022"
-  | "claude-3-5-sonnet-20240620";
+import {
+  LogLine,
+  AvailableModel,
+  ModelProvider,
+  ClientOptions,
+} from "../types";
 
 export class LLMProvider {
-  private modelToProviderMap: { [key in AvailableModel]: string } = {
+  private modelToProviderMap: { [key in AvailableModel]: ModelProvider } = {
     "gpt-4o": "openai",
     "gpt-4o-mini": "openai",
     "gpt-4o-2024-08-06": "openai",
@@ -51,7 +48,10 @@ export class LLMProvider {
     this.cache.deleteCacheForRequestId(requestId);
   }
 
-  getClient(modelName: AvailableModel, requestId: string): LLMClient {
+  getClient(
+    modelName: AvailableModel,
+    clientOptions?: ClientOptions,
+  ): LLMClient {
     const provider = this.modelToProviderMap[modelName];
     if (!provider) {
       throw new Error(`Unsupported model: ${modelName}`);
@@ -63,14 +63,16 @@ export class LLMProvider {
           this.logger,
           this.enableCaching,
           this.cache,
-          requestId,
+          modelName,
+          clientOptions,
         );
       case "anthropic":
         return new AnthropicClient(
           this.logger,
           this.enableCaching,
           this.cache,
-          requestId,
+          modelName,
+          clientOptions,
         );
       default:
         throw new Error(`Unsupported provider: ${provider}`);

--- a/lib/llm/OpenAIClient.ts
+++ b/lib/llm/OpenAIClient.ts
@@ -24,6 +24,7 @@ export class OpenAIClient extends LLMClient {
     this.logger = logger;
     this.cache = cache;
     this.enableCaching = enableCaching;
+    this.modelName = modelName;
   }
 
   async createChatCompletion(options: ChatCompletionOptions) {
@@ -36,6 +37,10 @@ export class OpenAIClient extends LLMClient {
         options: {
           value: JSON.stringify(optionsWithoutImage),
           type: "object",
+        },
+        modelName: {
+          value: this.modelName,
+          type: "string",
         },
       },
     });
@@ -115,6 +120,18 @@ export class OpenAIClient extends LLMClient {
         options.response_model.name,
       );
     }
+
+    this.logger({
+      category: "openai",
+      message: "creating chat completion",
+      level: 1,
+      auxiliary: {
+        openAiOptions: {
+          value: JSON.stringify(openAiOptions),
+          type: "object",
+        },
+      },
+    });
 
     const response = await this.client.chat.completions.create({
       ...openAiOptions,

--- a/lib/llm/OpenAIClient.ts
+++ b/lib/llm/OpenAIClient.ts
@@ -111,7 +111,10 @@ export class OpenAIClient extends LLMClient {
       options.messages = [...options.messages, screenshotMessage];
     }
 
-    const { image, response_model, ...openAiOptions } = options;
+    const { image, response_model, requestId, ...openAiOptions } = {
+      ...options,
+      model: this.modelName,
+    };
 
     let responseFormat = undefined;
     if (options.response_model) {

--- a/lib/llm/OpenAIClient.ts
+++ b/lib/llm/OpenAIClient.ts
@@ -1,25 +1,27 @@
-import OpenAI from "openai";
+import OpenAI, { ClientOptions } from "openai";
 import { zodResponseFormat } from "openai/helpers/zod";
 import { LLMClient, ChatCompletionOptions } from "./LLMClient";
 import { LLMCache } from "../cache/LLMCache";
-import { LogLine } from "../types";
+import { LogLine, AvailableModel } from "../types";
+import { ChatCompletionCreateParamsNonStreaming } from "openai/resources/chat";
 
-export class OpenAIClient implements LLMClient {
+export class OpenAIClient extends LLMClient {
   private client: OpenAI;
   private cache: LLMCache | undefined;
   public logger: (message: LogLine) => void;
   private enableCaching: boolean;
-  private requestId: string;
+  private clientOptions: ClientOptions;
 
   constructor(
     logger: (message: LogLine) => void,
     enableCaching = false,
     cache: LLMCache | undefined,
-    requestId: string,
+    modelName: AvailableModel,
+    clientOptions?: ClientOptions,
   ) {
-    this.client = new OpenAI();
+    super(modelName);
+    this.client = new OpenAI(clientOptions);
     this.logger = logger;
-    this.requestId = requestId;
     this.cache = cache;
     this.enableCaching = enableCaching;
   }
@@ -38,7 +40,7 @@ export class OpenAIClient implements LLMClient {
       },
     });
     const cacheOptions = {
-      model: options.model,
+      model: this.modelName,
       messages: options.messages,
       temperature: options.temperature,
       top_p: options.top_p,
@@ -49,7 +51,10 @@ export class OpenAIClient implements LLMClient {
     };
 
     if (this.enableCaching) {
-      const cachedResponse = await this.cache.get(cacheOptions, this.requestId);
+      const cachedResponse = await this.cache.get(
+        cacheOptions,
+        options.requestId,
+      );
       if (cachedResponse) {
         this.logger({
           category: "llm_cache",
@@ -57,7 +62,7 @@ export class OpenAIClient implements LLMClient {
           level: 1,
           auxiliary: {
             requestId: {
-              value: this.requestId,
+              value: options.requestId,
               type: "string",
             },
             cachedResponse: {
@@ -74,7 +79,7 @@ export class OpenAIClient implements LLMClient {
           level: 1,
           auxiliary: {
             requestId: {
-              value: this.requestId,
+              value: options.requestId,
               type: "string",
             },
           },
@@ -114,7 +119,7 @@ export class OpenAIClient implements LLMClient {
     const response = await this.client.chat.completions.create({
       ...openAiOptions,
       response_format: responseFormat,
-    });
+    } as unknown as ChatCompletionCreateParamsNonStreaming); // TODO (kamath): remove this forced typecast
 
     this.logger({
       category: "openai",
@@ -126,7 +131,7 @@ export class OpenAIClient implements LLMClient {
           type: "object",
         },
         requestId: {
-          value: this.requestId,
+          value: options.requestId,
           type: "string",
         },
       },
@@ -142,7 +147,7 @@ export class OpenAIClient implements LLMClient {
           {
             ...parsedData,
           },
-          this.requestId,
+          options.requestId,
         );
       }
 
@@ -158,7 +163,7 @@ export class OpenAIClient implements LLMClient {
         level: 1,
         auxiliary: {
           requestId: {
-            value: this.requestId,
+            value: options.requestId,
             type: "string",
           },
           cacheOptions: {
@@ -171,7 +176,7 @@ export class OpenAIClient implements LLMClient {
           },
         },
       });
-      this.cache.set(cacheOptions, response, this.requestId);
+      this.cache.set(cacheOptions, response, options.requestId);
     }
 
     return response;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,3 +1,8 @@
+import type { ClientOptions as AnthropicClientOptions } from "@anthropic-ai/sdk";
+import { Tool as AnthropicTool } from "@anthropic-ai/sdk/resources";
+import type { ClientOptions as OpenAIClientOptions } from "openai";
+import { ChatCompletionTool as OpenAITool } from "openai/resources";
+
 export class PlaywrightCommandException extends Error {
   constructor(message: string) {
     super(message);
@@ -25,3 +30,17 @@ export type LogLine = {
     };
   };
 };
+
+export type AvailableModel =
+  | "gpt-4o"
+  | "gpt-4o-mini"
+  | "gpt-4o-2024-08-06"
+  | "claude-3-5-sonnet-latest"
+  | "claude-3-5-sonnet-20241022"
+  | "claude-3-5-sonnet-20240620";
+
+export type ModelProvider = "openai" | "anthropic";
+
+export type ClientOptions = OpenAIClientOptions | AnthropicClientOptions;
+
+export type ToolCall = AnthropicTool | OpenAITool;


### PR DESCRIPTION
# why

Builds off #202 (thanks @ChinmayShrivastava!!) to parameterize LLM Client. Right now, we're passing in `modelName` into very nested functions, which means any additional config to the client, like API Key, also has to be passed down to each function. Instead, it makes more sense to init an LLM Client at the beginning, and pass down that client object.

# what changed
- nothing for the end user
- instead of modelName, we're passing llmClient between functions
- some new types in `types.ts`

# test plan
- evals