### PR TITLE
streamline types

### DIFF
--- a/evals/index.eval.ts
+++ b/evals/index.eval.ts
@@ -3,7 +3,8 @@ import { Stagehand } from "../lib";
 import { z } from "zod";
 import process from "process";
 import { EvalLogger } from "./utils";
-import { AvailableModel, LogLine } from "../lib/types";
+import { AvailableModel } from "../types/model";
+import { LogLine } from "../types/log";
 
 const env: "BROWSERBASE" | "LOCAL" =
   process.env.EVAL_ENV?.toLowerCase() === "browserbase"

--- a/evals/utils.ts
+++ b/evals/utils.ts
@@ -1,6 +1,6 @@
-import { LogLine } from "../lib/types";
 import { Stagehand } from "../lib";
 import { logLineToString } from "../lib/utils";
+import { LogLine } from "../types/log";
 
 type LogLineEval = LogLine & {
   parsedAuxiliary?: string | object;

--- a/lib/cache/ActionCache.ts
+++ b/lib/cache/ActionCache.ts
@@ -1,4 +1,4 @@
-import { LogLine } from "../../lib/types";
+import { LogLine } from "../../types/log";
 import { BaseCache, CacheEntry } from "./BaseCache";
 
 export interface PlaywrightCommand {

--- a/lib/cache/BaseCache.ts
+++ b/lib/cache/BaseCache.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as crypto from "crypto";
-import { LogLine } from "../../lib/types";
+import { LogLine } from "../../types/log";
 
 export interface CacheEntry {
   timestamp: number;

--- a/lib/handlers/actHandler.ts
+++ b/lib/handlers/actHandler.ts
@@ -2,15 +2,15 @@ import { Stagehand } from "../index";
 import { LLMProvider } from "../llm/LLMProvider";
 import { ScreenshotService } from "../vision";
 import { verifyActCompletion, act, fillInVariables } from "../inference";
-import {
-  LogLine,
-  PlaywrightCommandException,
-  PlaywrightCommandMethodNotSupportedException,
-} from "../types";
 import { Locator, Page } from "@playwright/test";
 import { ActionCache } from "../cache/ActionCache";
 import { LLMClient, modelsWithVision } from "../llm/LLMClient";
 import { generateId } from "../utils";
+import { LogLine } from "../../types/log";
+import {
+  PlaywrightCommandException,
+  PlaywrightCommandMethodNotSupportedException,
+} from "../../types/playwright";
 
 export class StagehandActHandler {
   private readonly stagehand: Stagehand;
@@ -1096,7 +1096,6 @@ export class StagehandActHandler {
         action,
         domElements: outputString,
         steps,
-        llmProvider: this.llmProvider,
         llmClient,
         screenshot: annotatedScreenshot,
         logger: this.logger,

--- a/lib/handlers/extractHandler.ts
+++ b/lib/handlers/extractHandler.ts
@@ -1,7 +1,7 @@
 import { LLMProvider } from "../llm/LLMProvider";
 import { Stagehand } from "../index";
 import { z } from "zod";
-import { AvailableModel, LogLine } from "../types";
+import { LogLine } from "../../types/log";
 import { extract } from "../inference";
 import { LLMClient } from "../llm/LLMClient";
 
@@ -114,7 +114,6 @@ export class StagehandExtractHandler {
       progress,
       previouslyExtractedContent: content,
       domElements: outputString,
-      llmProvider: this.llmProvider,
       schema,
       llmClient,
       chunksSeen: chunksSeen.length,

--- a/lib/handlers/observeHandler.ts
+++ b/lib/handlers/observeHandler.ts
@@ -1,10 +1,10 @@
-import { LLMProvider } from "../llm/LLMProvider";
-import { LogLine, AvailableModel } from "../types";
+import { LogLine } from "../../types/log";
 import { Stagehand } from "../index";
 import { observe } from "../inference";
-import { LLMClient, modelsWithVision } from "../llm/LLMClient";
-import { ScreenshotService } from "../vision";
+import { LLMClient } from "../llm/LLMClient";
+import { LLMProvider } from "../llm/LLMProvider";
 import { generateId } from "../utils";
+import { ScreenshotService } from "../vision";
 
 export class StagehandObserveHandler {
   private readonly stagehand: Stagehand;
@@ -134,7 +134,6 @@ export class StagehandObserveHandler {
     const observationResponse = await observe({
       instruction,
       domElements: outputString,
-      llmProvider: this.llmProvider,
       llmClient,
       image: annotatedScreenshot,
       requestId,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,18 +1,31 @@
-import { type Page, type BrowserContext, chromium } from "@playwright/test";
-import { z } from "zod";
-import fs from "fs";
-import { Browserbase, ClientOptions } from "@browserbasehq/sdk";
-import { LLMProvider } from "./llm/LLMProvider";
-import { AvailableModel } from "./types";
-// @ts-ignore we're using a built js file as a string here
-import { scriptContent } from "./dom/build/scriptContent";
-import { LogLine } from "./types";
+import { Browserbase } from "@browserbasehq/sdk";
+import { type BrowserContext, chromium, type Page } from "@playwright/test";
 import { randomUUID } from "crypto";
-import { logLineToString } from "./utils";
+import fs from "fs";
+import os from "os";
+import { z } from "zod";
+import { BrowserResult } from "../types/browser";
+import { LogLine } from "../types/log";
+import {
+  ActOptions,
+  ActResult,
+  ConstructorParams,
+  ExtractOptions,
+  ExtractResult,
+  InitFromPageOptions,
+  InitFromPageResult,
+  InitOptions,
+  InitResult,
+  ObserveOptions,
+  ObserveResult,
+} from "../types/stagehand";
+import { scriptContent } from "./dom/build/scriptContent";
+import { StagehandActHandler } from "./handlers/actHandler";
 import { StagehandExtractHandler } from "./handlers/extractHandler";
 import { StagehandObserveHandler } from "./handlers/observeHandler";
-import { StagehandActHandler } from "./handlers/actHandler";
 import { LLMClient } from "./llm/LLMClient";
+import { LLMProvider } from "./llm/LLMProvider";
+import { logLineToString } from "./utils";
 
 require("dotenv").config({ path: ".env" });
 
@@ -26,7 +39,7 @@ async function getBrowser(
   logger: (message: LogLine) => void,
   browserbaseSessionCreateParams?: Browserbase.Sessions.SessionCreateParams,
   browserbaseResumeSessionID?: string,
-) {
+): Promise<BrowserResult> {
   if (env === "BROWSERBASE") {
     if (!apiKey) {
       logger({
@@ -184,7 +197,7 @@ async function getBrowser(
       },
     });
 
-    const tmpDir = fs.mkdtempSync(`/tmp/pwtest`);
+    const tmpDir = fs.mkdtempSync("/tmp/pwtest");
     fs.mkdirSync(`${tmpDir}/userdir/Default`, { recursive: true });
 
     const defaultPreferences = {
@@ -311,22 +324,7 @@ export class Stagehand {
       browserbaseResumeSessionID,
       modelName,
       modelClientOptions,
-    }: {
-      env: "LOCAL" | "BROWSERBASE";
-      apiKey?: string;
-      projectId?: string;
-      verbose?: 0 | 1 | 2;
-      debugDom?: boolean;
-      llmProvider?: LLMProvider;
-      headless?: boolean;
-      logger?: (message: LogLine) => void;
-      domSettleTimeoutMs?: number;
-      browserBaseSessionCreateParams?: Browserbase.Sessions.SessionCreateParams;
-      enableCaching?: boolean;
-      browserbaseResumeSessionID?: string;
-      modelName?: AvailableModel;
-      modelClientOptions?: ClientOptions;
-    } = {
+    }: ConstructorParams = {
       env: "BROWSERBASE",
     },
   ) {
@@ -356,14 +354,7 @@ export class Stagehand {
     modelName,
     modelClientOptions,
     domSettleTimeoutMs,
-  }: {
-    modelName?: AvailableModel;
-    modelClientOptions?: ClientOptions;
-    domSettleTimeoutMs?: number;
-  } = {}): Promise<{
-    debugUrl: string;
-    sessionUrl: string;
-  }> {
+  }: InitOptions = {}): Promise<InitResult> {
     const llmClient = modelName
       ? this.llmProvider.getClient(modelName, modelClientOptions)
       : this.llmClient;
@@ -377,7 +368,11 @@ export class Stagehand {
       this.browserbaseResumeSessionID,
     ).catch((e) => {
       console.error("Error in init:", e);
-      return { context: undefined, debugUrl: undefined, sessionUrl: undefined };
+      return {
+        context: undefined,
+        debugUrl: undefined,
+        sessionUrl: undefined,
+      } as BrowserResult;
     });
     this.context = context;
     this.page = context.pages()[0];
@@ -442,11 +437,11 @@ export class Stagehand {
     return { debugUrl, sessionUrl };
   }
 
-  async initFromPage(
-    page: Page,
-    modelName?: AvailableModel,
-    modelClientOptions?: ClientOptions,
-  ): Promise<{ context: BrowserContext }> {
+  async initFromPage({
+    page,
+    modelName,
+    modelClientOptions,
+  }: InitFromPageOptions): Promise<InitFromPageResult> {
     this.page = page;
     this.context = page.context();
     this.llmClient = modelName
@@ -474,7 +469,6 @@ export class Stagehand {
     return { context: this.context };
   }
 
-  // Logging
   private pending_logs_to_send_to_browserbase: LogLine[] = [];
 
   private is_processing_browserbase_logs: boolean = false;
@@ -653,18 +647,7 @@ export class Stagehand {
     useVision = "fallback",
     variables = {},
     domSettleTimeoutMs,
-  }: {
-    action: string;
-    modelName?: AvailableModel;
-    modelClientOptions?: ClientOptions;
-    useVision?: "fallback" | boolean;
-    variables?: Record<string, string>;
-    domSettleTimeoutMs?: number;
-  }): Promise<{
-    success: boolean;
-    message: string;
-    action: string;
-  }> {
+  }: ActOptions): Promise<ActResult> {
     if (!this.actHandler) {
       throw new Error("Act handler not initialized");
     }
@@ -743,13 +726,7 @@ export class Stagehand {
     modelName,
     modelClientOptions,
     domSettleTimeoutMs,
-  }: {
-    instruction: string;
-    schema: T;
-    modelName?: AvailableModel;
-    modelClientOptions?: ClientOptions;
-    domSettleTimeoutMs?: number;
-  }): Promise<z.infer<T>> {
+  }: ExtractOptions<T>): Promise<ExtractResult<T>> {
     if (!this.extractHandler) {
       throw new Error("Extract handler not initialized");
     }
@@ -812,13 +789,7 @@ export class Stagehand {
       });
   }
 
-  async observe(options?: {
-    instruction?: string;
-    modelName?: AvailableModel;
-    modelClientOptions?: ClientOptions;
-    useVision?: boolean;
-    domSettleTimeoutMs?: number;
-  }): Promise<{ selector: string; description: string }[]> {
+  async observe(options?: ObserveOptions): Promise<ObserveResult[]> {
     if (!this.observeHandler) {
       throw new Error("Observe handler not initialized");
     }

--- a/lib/inference.ts
+++ b/lib/inference.ts
@@ -21,6 +21,8 @@ import {
   ChatMessage,
   LLMClient,
 } from "./llm/LLMClient";
+import { VerifyActCompletionParams } from "../types/inference";
+import { ActResult, ActParams } from "../types/act";
 
 export async function verifyActCompletion({
   goal,
@@ -30,15 +32,7 @@ export async function verifyActCompletion({
   domElements,
   logger,
   requestId,
-}: {
-  goal: string;
-  steps: string;
-  llmClient: LLMClient;
-  screenshot?: Buffer;
-  domElements?: string;
-  logger: (message: { category?: string; message: string }) => void;
-  requestId: string;
-}): Promise<boolean> {
+}: VerifyActCompletionParams): Promise<boolean> {
   const messages: ChatMessage[] = [
     buildVerifyActCompletionSystemPrompt(),
     buildVerifyActCompletionUserPrompt(goal, steps, domElements),
@@ -106,24 +100,7 @@ export async function act({
   logger,
   requestId,
   variables,
-}: {
-  action: string;
-  steps?: string;
-  domElements: string;
-  llmClient: LLMClient;
-  screenshot?: Buffer;
-  retries?: number;
-  logger: (message: { category?: string; message: string }) => void;
-  requestId: string;
-  variables?: Record<string, string>;
-}): Promise<{
-  method: string;
-  element: number;
-  args: any[];
-  completed: boolean;
-  step: string;
-  why?: string;
-} | null> {
+}: ActParams): Promise<ActResult | null> {
   const messages: ChatMessage[] = [
     buildActSystemPrompt(),
     buildActUserPrompt(action, steps, domElements, variables),

--- a/lib/llm/AnthropicClient.ts
+++ b/lib/llm/AnthropicClient.ts
@@ -1,9 +1,10 @@
 import Anthropic, { ClientOptions } from "@anthropic-ai/sdk";
-import { LLMClient, ChatCompletionOptions } from "./LLMClient";
-import { zodToJsonSchema } from "zod-to-json-schema";
-import { LLMCache } from "../cache/LLMCache";
-import { AvailableModel, LogLine } from "../types";
 import { Message, MessageCreateParams } from "@anthropic-ai/sdk/resources";
+import { zodToJsonSchema } from "zod-to-json-schema";
+import { LogLine } from "../../types/log";
+import { AvailableModel } from "../../types/model";
+import { LLMCache } from "../cache/LLMCache";
+import { ChatCompletionOptions, LLMClient } from "./LLMClient";
 
 export class AnthropicClient extends LLMClient {
   private client: Anthropic;

--- a/lib/llm/LLMClient.ts
+++ b/lib/llm/LLMClient.ts
@@ -1,4 +1,4 @@
-import { AvailableModel, ToolCall } from "../types";
+import { AvailableModel, ToolCall } from "../../types/model";
 
 export interface ChatMessage {
   role: "system" | "user" | "assistant";

--- a/lib/llm/LLMProvider.ts
+++ b/lib/llm/LLMProvider.ts
@@ -2,12 +2,12 @@ import { OpenAIClient } from "./OpenAIClient";
 import { AnthropicClient } from "./AnthropicClient";
 import { LLMClient } from "./LLMClient";
 import { LLMCache } from "../cache/LLMCache";
+import { LogLine } from "../../types/log";
 import {
-  LogLine,
   AvailableModel,
   ModelProvider,
   ClientOptions,
-} from "../types";
+} from "../../types/model";
 
 export class LLMProvider {
   private modelToProviderMap: { [key in AvailableModel]: ModelProvider } = {

--- a/lib/llm/OpenAIClient.ts
+++ b/lib/llm/OpenAIClient.ts
@@ -1,9 +1,10 @@
 import OpenAI, { ClientOptions } from "openai";
 import { zodResponseFormat } from "openai/helpers/zod";
-import { LLMClient, ChatCompletionOptions } from "./LLMClient";
-import { LLMCache } from "../cache/LLMCache";
-import { LogLine, AvailableModel } from "../types";
 import { ChatCompletionCreateParamsNonStreaming } from "openai/resources/chat";
+import { LogLine } from "../../types/log";
+import { AvailableModel } from "../../types/model";
+import { LLMCache } from "../cache/LLMCache";
+import { ChatCompletionOptions, LLMClient } from "./LLMClient";
 
 export class OpenAIClient extends LLMClient {
   private client: OpenAI;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,5 +1,5 @@
 import crypto from "crypto";
-import { LogLine } from "./types";
+import { LogLine } from "../types/log";
 
 export function generateId(operation: string) {
   return crypto.createHash("sha256").update(operation).digest("hex");

--- a/lib/vision.ts
+++ b/lib/vision.ts
@@ -1,10 +1,11 @@
-import { type Frame, type ElementHandle, Page } from "@playwright/test";
+import { Page } from "@playwright/test";
+import { exec } from "child_process";
 import fs from "fs";
 import path from "path";
 import sharp from "sharp";
-import { exec } from "child_process";
-import { LogLine } from "./types";
+import { LogLine } from "../types/log";
 import { logLineToString } from "./utils";
+
 type AnnotationBox = {
   x: number;
   y: number;

--- a/types/act.ts
+++ b/types/act.ts
@@ -1,0 +1,23 @@
+import { Buffer } from "buffer";
+import { LLMClient } from "../lib/llm/LLMClient";
+
+export interface ActParams {
+  action: string;
+  steps?: string;
+  domElements: string;
+  llmClient: LLMClient;
+  screenshot?: Buffer;
+  retries?: number;
+  logger: (message: { category?: string; message: string }) => void;
+  requestId: string;
+  variables?: Record<string, string>;
+}
+
+export interface ActResult {
+  method: string;
+  element: number;
+  args: any[];
+  completed: boolean;
+  step: string;
+  why?: string;
+}

--- a/types/browser.ts
+++ b/types/browser.ts
@@ -1,0 +1,8 @@
+import { Browser, BrowserContext } from "@playwright/test";
+
+export interface BrowserResult {
+  browser?: Browser;
+  context: BrowserContext;
+  debugUrl?: string;
+  sessionUrl?: string;
+}

--- a/types/inference.ts
+++ b/types/inference.ts
@@ -1,0 +1,14 @@
+import { Buffer } from "buffer";
+import { LLMClient } from "../lib/llm/LLMClient";
+import { LLMProvider } from "../lib/llm/LLMProvider";
+
+export interface VerifyActCompletionParams {
+  goal: string;
+  steps: string;
+  llmProvider: LLMProvider;
+  llmClient: LLMClient;
+  screenshot?: Buffer;
+  domElements?: string;
+  logger: (message: { category?: string; message: string }) => void;
+  requestId: string;
+}

--- a/types/log.ts
+++ b/types/log.ts
@@ -1,0 +1,13 @@
+export type LogLine = {
+  id?: string;
+  category?: string;
+  message: string;
+  level?: 0 | 1 | 2;
+  timestamp?: string;
+  auxiliary?: {
+    [key: string]: {
+      value: string;
+      type: "object" | "string" | "html" | "integer" | "float" | "boolean";
+    };
+  };
+};

--- a/types/model.ts
+++ b/types/model.ts
@@ -3,34 +3,6 @@ import { Tool as AnthropicTool } from "@anthropic-ai/sdk/resources";
 import type { ClientOptions as OpenAIClientOptions } from "openai";
 import { ChatCompletionTool as OpenAITool } from "openai/resources";
 
-export class PlaywrightCommandException extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "PlaywrightCommandException";
-  }
-}
-
-export class PlaywrightCommandMethodNotSupportedException extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "PlaywrightCommandMethodNotSupportedException";
-  }
-}
-
-export type LogLine = {
-  id?: string;
-  category?: string;
-  message: string;
-  level?: 0 | 1 | 2;
-  timestamp?: string;
-  auxiliary?: {
-    [key: string]: {
-      value: string;
-      type: "object" | "string" | "html" | "integer" | "float" | "boolean";
-    };
-  };
-};
-
 export type AvailableModel =
   | "gpt-4o"
   | "gpt-4o-mini"

--- a/types/playwright.ts
+++ b/types/playwright.ts
@@ -1,0 +1,13 @@
+export class PlaywrightCommandException extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PlaywrightCommandException";
+  }
+}
+
+export class PlaywrightCommandMethodNotSupportedException extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PlaywrightCommandMethodNotSupportedException";
+  }
+}

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -1,0 +1,87 @@
+import Browserbase from "@browserbasehq/sdk";
+import { BrowserContext, Page } from "@playwright/test";
+import { LLMProvider } from "../lib/llm/LLMProvider";
+import { LogLine } from "./log";
+import { AvailableModel, ClientOptions } from "./model";
+import { z } from "zod";
+
+export interface ConstructorParams {
+  env: "LOCAL" | "BROWSERBASE";
+  apiKey?: string;
+  projectId?: string;
+  verbose?: 0 | 1 | 2;
+  debugDom?: boolean;
+  llmProvider?: LLMProvider;
+  headless?: boolean;
+  logger?: (message: LogLine) => void;
+  domSettleTimeoutMs?: number;
+  browserBaseSessionCreateParams?: Browserbase.Sessions.SessionCreateParams;
+  enableCaching?: boolean;
+  browserbaseResumeSessionID?: string;
+  modelName?: AvailableModel;
+  modelClientOptions?: ClientOptions;
+}
+
+export interface InitResult {
+  debugUrl: string;
+  sessionUrl: string;
+}
+
+export interface InitOptions {
+  modelName?: AvailableModel;
+  modelClientOptions?: ClientOptions;
+  domSettleTimeoutMs?: number;
+}
+
+export interface InitResult {
+  debugUrl: string;
+  sessionUrl: string;
+}
+
+export interface InitFromPageOptions {
+  page: Page;
+  modelName?: AvailableModel;
+  modelClientOptions?: ClientOptions;
+}
+
+export interface InitFromPageResult {
+  context: BrowserContext;
+}
+
+export interface ActOptions {
+  action: string;
+  modelName?: AvailableModel;
+  modelClientOptions?: ClientOptions;
+  useVision?: "fallback" | boolean;
+  variables?: Record<string, string>;
+  domSettleTimeoutMs?: number;
+}
+
+export interface ActResult {
+  success: boolean;
+  message: string;
+  action: string;
+}
+
+export interface ExtractOptions<T extends z.AnyZodObject> {
+  instruction: string;
+  schema: T;
+  modelName?: AvailableModel;
+  modelClientOptions?: ClientOptions;
+  domSettleTimeoutMs?: number;
+}
+
+export type ExtractResult<T extends z.AnyZodObject> = z.infer<T>;
+
+export interface ObserveOptions {
+  instruction?: string;
+  modelName?: AvailableModel;
+  modelClientOptions?: ClientOptions;
+  useVision?: boolean;
+  domSettleTimeoutMs?: number;
+}
+
+export interface ObserveResult {
+  selector: string;
+  description: string;
+}


### PR DESCRIPTION
# why
Type definitions are currently unorganized, this makes code more readable and easier to maintain. (Addresses #185)

# what changed
Wrote type definitions for all `Stagehand` class methods and moved existing type definitions to a new `types` folder.

# test plan
Use existing evals.