### PR TITLE
add a short doc on releasing

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -40,7 +40,7 @@ git commit -m 'version packages'
 
 Ok, now it's time to publish the release.
 Before we do, we have to build the artifacts that comprise the tarball.
-Let's clean our working directory first:
+Let's clean our working directory first so that we don't accidentally include anything in the tarball that shouldn't be there:
 
 ```
 git clean -fxd -e .env

--- a/docs/release.md
+++ b/docs/release.md
@@ -67,13 +67,16 @@ Before we do, we have to build the artifacts that comprise the tarball.
 Let's clean our working directory first so that we don't accidentally include anything in the tarball that shouldn't be there:
 
 ```
-git clean -fxd -e .env
+% git clean -fxd -e .env
+Removing dist/
+Removing lib/dom/build/
+Removing node_modules/
 ```
 
-Let's build the artifacts:
+Let's reinstall dependencies and build the artifacts:
 
 ```
-npm run build
+npm install && npm run build
 ```
 
 Now we're ready to publish to NPM. You have to be logged in via the `npm` CLI and have to be part of the `@browserbasehq` org:
@@ -82,7 +85,15 @@ Now we're ready to publish to NPM. You have to be logged in via the `npm` CLI an
 npx changeset publish
 ```
 
-Changeset created an annotated git tag.
+Congratulations! You just published a new version of `@browserbasehq/stagehand`. 🤘
+
+In the process of publishing, changeset created an [annotated git tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging):
+
+```
+🦋  Creating git tag...
+🦋  New tag:  v1.3.4
+```
+
 Let's push the commit and tag to GitHub for posterity:
 
 ```

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,66 @@
+# Releasing
+
+We use [Changesets](https://github.com/changesets/changesets) to version and release our packages.
+
+When you're ready to cut a release, start by versioning the packages:
+
+```
+npx changeset version
+```
+
+This will consume the changesets in [`.changeset`](../.changeset) and update the [changelog](../CHANGELOG.md) and [`package.json`](../package.json):
+
+```
+% git status --short
+ M CHANGELOG.md
+ M package.json
+```
+
+Since we updated the `package.json`, we should also update the lockfile ([`package-lock.json`](../package-lock.json)) for tidiness:
+
+```
+npm install
+```
+
+Now the lockfile should be updated:
+
+```
+% git status --short
+ M CHANGELOG.md
+ M package-lock.json
+ M package.json
+```
+
+At this point we're ready to commit our changes.
+It's probably a good idea to have some consistency around the name of this commit message:
+
+```
+git commit -m 'version packages'
+```
+
+Ok, now it's time to publish the release:
+Before we do, we have to build the artifacts that comprise the tarball.
+Let's clean our working directory first:
+
+```
+git clean -fxd -e .env
+```
+
+Now let's build the artifacts:
+
+```
+npm run build
+```
+
+We're ready to publish to NPM:
+
+```
+npx changeset publish
+```
+
+Changeset created an annotated git tag.
+Let's push the commit and tag to GitHub:
+
+```
+git push --follow-tags
+```

--- a/docs/release.md
+++ b/docs/release.md
@@ -38,7 +38,7 @@ It's probably a good idea to have some consistency around the name of this commi
 git commit -m 'version packages'
 ```
 
-Ok, now it's time to publish the release:
+Ok, now it's time to publish the release.
 Before we do, we have to build the artifacts that comprise the tarball.
 Let's clean our working directory first:
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -87,11 +87,11 @@ npx changeset publish
 
 Congratulations! You just published a new version of `@browserbasehq/stagehand`. 🤘
 
-In the process of publishing, changeset created an [annotated git tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging):
+In the process of publishing, Changesets created an [annotated git tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging):
 
 ```
 🦋  Creating git tag...
-🦋  New tag:  v1.3.4
+🦋  New tag:  v1.3.1
 ```
 
 Let's push the commit and tag to GitHub for posterity:

--- a/docs/release.md
+++ b/docs/release.md
@@ -59,7 +59,7 @@ At this point we're ready to commit our changes.
 It's probably a good idea to have some consistency around the name of this commit message:
 
 ```
-git commit -m 'Version Packages'
+git commit -am 'Version Packages'
 ```
 
 Ok, now it's time to publish the release.

--- a/docs/release.md
+++ b/docs/release.md
@@ -16,6 +16,14 @@ This will consume the changesets in [`.changeset`](../.changeset) and update the
  M package.json
 ```
 
+Based on the versions implications declared by the changesets, the package version will be updated to the next patch, minor, or major:
+
+```diff
+   "name": "@browserbasehq/stagehand",
+-  "version": "1.3.0",
++  "version": "1.3.1",
+```
+
 Since we updated the `package.json`, we should also update the lockfile ([`package-lock.json`](../package-lock.json)) for tidiness:
 
 ```
@@ -31,11 +39,27 @@ Now the lockfile should be updated:
  M package.json
 ```
 
+The diff will look something like this:
+
+```diff
+ {
+   "name": "@browserbasehq/stagehand",
+-  "version": "1.3.0",
++  "version": "1.3.1",
+   "lockfileVersion": 3,
+   "requires": true,
+   "packages": {
+     "": {
+       "name": "@browserbasehq/stagehand",
+-      "version": "1.3.0",
++      "version": "1.3.1",
+```
+
 At this point we're ready to commit our changes.
 It's probably a good idea to have some consistency around the name of this commit message:
 
 ```
-git commit -m 'version packages'
+git commit -m 'Version Packages'
 ```
 
 Ok, now it's time to publish the release.
@@ -46,20 +70,20 @@ Let's clean our working directory first so that we don't accidentally include an
 git clean -fxd -e .env
 ```
 
-Now let's build the artifacts:
+Let's build the artifacts:
 
 ```
 npm run build
 ```
 
-We're ready to publish to NPM:
+Now we're ready to publish to NPM. You have to be logged in via the `npm` CLI and have to be part of the `@browserbasehq` org:
 
 ```
 npx changeset publish
 ```
 
 Changeset created an annotated git tag.
-Let's push the commit and tag to GitHub:
+Let's push the commit and tag to GitHub for posterity:
 
 ```
 git push --follow-tags


### PR DESCRIPTION
# why

releasing is scary, but everyone working on stagehand should feel empowered to do it

# what changed

we will add more github workflows to automate the process, but this PR starts small by adding a short doc on how to do a release manually from the CLI

# test plan

i've been testing on my fork