### PR TITLE
reduce chunk size

### DIFF
--- a/lib/dom/process.ts
+++ b/lib/dom/process.ts
@@ -27,7 +27,7 @@ export async function processDom(chunksSeen: Array<number>) {
 export async function processAllOfDom() {
   console.log("Stagehand (Browser Process): Processing all of DOM");
 
-  const viewportHeight = window.innerHeight;
+  const viewportHeight = window.innerHeight * 0.75;
   const documentHeight = document.documentElement.scrollHeight;
   const totalChunks = Math.ceil(documentHeight / viewportHeight);
 
@@ -87,7 +87,7 @@ export async function processElements(
   selectorMap: Record<number, string[]>;
 }> {
   console.time("processElements:total");
-  const viewportHeight = window.innerHeight;
+  const viewportHeight = Math.ceil(window.innerHeight * 0.75);
   const chunkHeight = viewportHeight * chunk;
 
   // Calculate the maximum scrollable offset
@@ -410,7 +410,7 @@ const isLeafElement = (element: Element) => {
 };
 
 async function pickChunk(chunksSeen: Array<number>) {
-  const viewportHeight = window.innerHeight;
+  const viewportHeight = window.innerHeight * 0.75;
   const documentHeight = document.documentElement.scrollHeight;
 
   const chunks = Math.ceil(documentHeight / viewportHeight);


### PR DESCRIPTION
# why
when processing candidate elements, we process the webpage in chunks, and check if an element is visible. if we use the exact viewport height to determine the chunk size, and there are banners/nav menus that are fixed to the top (or bottom) of the webpage, then some candidate elements (that should be included) will be hidden under these elements as we chunk/scroll. 
# what changed
we set the `viewportHeight` (used to determine chunk height) to be 75% of `window.innerHeight` instead of using the full `window.innerHeight`.
# test plan
can add some evals to show where candidate elements were missing before 
# notes
this may be more of a temporary/quick fix. We may want to investigate dynamically detecting the presence of fixed elements (like banners, nav menus, etc) and determining the chunk height based on their height
