### PR TITLE
Fix broken evals

### DIFF
--- a/.changeset/odd-seahorses-beam.md
+++ b/.changeset/odd-seahorses-beam.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+fix broken evals

--- a/evals/index.eval.ts
+++ b/evals/index.eval.ts
@@ -456,9 +456,13 @@ const extract_github_stars: EvalFunction = async ({ modelName, logger }) => {
       ? parseFloat(expectedStarsString.slice(0, -1)) * 1000
       : parseFloat(expectedStarsString);
 
+    const tolerance = 1000;
+
+    const isWithinTolerance = Math.abs(stars - expectedStars) <= tolerance;
+
     await stagehand.context.close().catch(() => {});
     return {
-      _success: stars === expectedStars,
+      _success: isWithinTolerance,
       stars,
       debugUrl,
       sessionUrl,

--- a/lib/llm/AnthropicClient.ts
+++ b/lib/llm/AnthropicClient.ts
@@ -176,7 +176,7 @@ export class AnthropicClient extends LLMClient {
 
     const response = (await this.client.messages.create({
       model: this.modelName,
-      max_tokens: options.maxTokens || 1500,
+      max_tokens: options.maxTokens || 3000,
       messages: userMessages.map((msg) => ({
         role: msg.role,
         content: msg.content,


### PR DESCRIPTION
# why
- `extract_last_twenty_github_commits` fails with Anthropic because the token limit is too small
- `extract_github_stars` fails with Anthropic because we are expecting the rounded version of the number of stars ~230000, but claude sometimes outputs the precise number, eg., 229,757
# what changed
- increased Anthropic token limit from 1500 to 3000
- added a tolerance of +/- 1000 in `extract_github_stars` so it still passes if the precise number of stars is given
