### PR TITLE
Add CI specific evals

### DIFF
--- a/.changeset/slow-rings-poke.md
+++ b/.changeset/slow-rings-poke.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+add ci specific evals

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,30 +60,36 @@ jobs:
           
             # Output passing evals
             if [ "$num_passed" -gt 0 ]; then
-            echo ""
-            echo "Passing evals:"
-            echo "$passed_tasks" | jq -c '.[]' | while read -r task; do
-            name=$(echo "$task" | jq -r '.name')
-            model=$(echo "$task" | jq -r '.modelName')
-            echo ""
-            echo "name: $name"
-            echo "model: $model"
-            done
+              echo ""
+              echo "Passing evals:"
+              echo "$passed_tasks" | jq -c '.[]' | while read -r task; do
+                name=$(echo "$task" | jq -r '.name')
+                model=$(echo "$task" | jq -r '.modelName')
+                echo ""
+                echo "name: $name"
+                echo "model: $model"
+              done
             fi
           
             # Output failing evals
             if [ "$num_failed" -gt 0 ]; then
-            echo ""
-            echo "Failing evals:"
-            echo "$failed_tasks" | jq -c '.[]' | while read -r task; do
-            name=$(echo "$task" | jq -r '.name')
-            model=$(echo "$task" | jq -r '.modelName')
-            echo ""
-            echo "name: $name"
-            echo "model: $model"
-            done
+              echo ""
+              echo "Failing evals:"
+              echo "$failed_tasks" | jq -c '.[]' | while read -r task; do
+                name=$(echo "$task" | jq -r '.name')
+                model=$(echo "$task" | jq -r '.modelName')
+                echo ""
+                echo "name: $name"
+                echo "model: $model"
+              done
             fi
-            else
-            echo "Eval summary not found. Failing simulation."
+
+            # fail if exact match score is below 85%
+            if (( $(echo "$exact_match_score < 85" | bc -l) )); then
+              echo "Exact match score is below 85%. Failing CI."
+              exit 1
+            fi
+          else
+            echo "Eval summary not found. Failing CI."
             exit 1
-            fi
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Run Evals
         env:
-          CI_EVALS: "amazon_add_to_cart"
+          CI_EVALS: "google_jobs"
         run: npm run evals
         timeout-minutes: 20
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Run Evals
         env:
-          CI_EVALS: "vanta,extract_github_stars,extract_collaborators_from_github_repository,wikipedia,peeler_complex,simple_google_search,extract_last_twenty_github_commits,laroche_form"
+          CI_EVALS: "amazon_add_to_cart"
         run: npm run evals
         timeout-minutes: 20
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,5 +34,56 @@ jobs:
         run: npm exec playwright install --with-deps
 
       - name: Run Evals
+        env:
+          CI_EVALS: "vanta,extract_github_stars,extract_collaborators_from_github_repository,wikipedia,peeler_complex,simple_google_search,extract_last_twenty_github_commits,laroche_form"
         run: npm run evals
         timeout-minutes: 20
+
+      - name: Check Eval Results
+        run: |
+          if [ -f eval-summary.json ]; then
+            # Read data from eval-summary.json
+            total_tasks=$(jq '.totalTasks' eval-summary.json)
+            passed_tasks=$(jq '.passedTasks' eval-summary.json)
+            failed_tasks=$(jq '.failedTasks' eval-summary.json)
+            exact_match_score=$(jq '.exactMatchScore' eval-summary.json)
+          
+            # Count passed and failed tasks
+            num_passed=$(echo "$passed_tasks" | jq 'length')
+            num_failed=$(echo "$failed_tasks" | jq 'length')
+          
+            # Output summary
+            echo "Total number of evals: $total_tasks"
+            echo "Number of evals that passed: $num_passed"
+            echo "Number of evals that failed: $num_failed"
+            echo "Exact match score: $exact_match_score%"
+          
+            # Output passing evals
+            if [ "$num_passed" -gt 0 ]; then
+            echo ""
+            echo "Passing evals:"
+            echo "$passed_tasks" | jq -c '.[]' | while read -r task; do
+            name=$(echo "$task" | jq -r '.name')
+            model=$(echo "$task" | jq -r '.modelName')
+            echo ""
+            echo "name: $name"
+            echo "model: $model"
+            done
+            fi
+          
+            # Output failing evals
+            if [ "$num_failed" -gt 0 ]; then
+            echo ""
+            echo "Failing evals:"
+            echo "$failed_tasks" | jq -c '.[]' | while read -r task; do
+            name=$(echo "$task" | jq -r '.name')
+            model=$(echo "$task" | jq -r '.modelName')
+            echo ""
+            echo "name: $name"
+            echo "model: $model"
+            done
+            fi
+            else
+            echo "Eval summary not found. Failing simulation."
+            exit 1
+            fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Run Evals
         env:
-          CI_EVALS: "google_jobs"
+          CI_EVALS: "vanta,extract_github_stars,extract_collaborators_from_github_repository,wikipedia,peeler_complex,simple_google_search,extract_last_twenty_github_commits,laroche_form"
         run: npm run evals
         timeout-minutes: 20
 

--- a/eval-summary.json
+++ b/eval-summary.json
@@ -1,0 +1,48 @@
+{
+  "exactMatchScore": 70,
+  "totalTasks": 10,
+  "passedTasks": [
+    {
+      "name": "extract_github_stars",
+      "modelName": "gpt-4o"
+    },
+    {
+      "name": "extract_github_stars",
+      "modelName": "gpt-4o"
+    },
+    {
+      "name": "extract_github_stars",
+      "modelName": "gpt-4o"
+    },
+    {
+      "name": "extract_github_stars",
+      "modelName": "gpt-4o"
+    },
+    {
+      "name": "extract_github_stars",
+      "modelName": "gpt-4o"
+    },
+    {
+      "name": "extract_github_stars",
+      "modelName": "claude-3-5-sonnet-20241022"
+    },
+    {
+      "name": "extract_github_stars",
+      "modelName": "claude-3-5-sonnet-20241022"
+    }
+  ],
+  "failedTasks": [
+    {
+      "name": "extract_github_stars",
+      "modelName": "claude-3-5-sonnet-20241022"
+    },
+    {
+      "name": "extract_github_stars",
+      "modelName": "claude-3-5-sonnet-20241022"
+    },
+    {
+      "name": "extract_github_stars",
+      "modelName": "claude-3-5-sonnet-20241022"
+    }
+  ]
+}


### PR DESCRIPTION
# why
We need to be able to rely on a subset of evals that should be at or around 100% before merging.
# what changed
- added a list of CI specific evals in `ci.yml`
- added a check to make sure the overall `exactMatch` result of these evals is above 90%
# notes
- this list will grow with time, this is just a starting point of evals that are presently known to be reliably passing
