### PR TITLE
auto delete ctx

### DIFF
--- a/.changeset/fuzzy-chairs-boil.md
+++ b/.changeset/fuzzy-chairs-boil.md
@@ -1,5 +1,5 @@
 ---
-"@browserbasehq/stagehand": patch
+"@browserbasehq/stagehand": minor
 ---
 
 clean up contexts after use

--- a/.changeset/fuzzy-chairs-boil.md
+++ b/.changeset/fuzzy-chairs-boil.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+clean up contexts after use

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ const contributor = await stagehand.extract({
     url: z.string(),
   }),
 });
+await stagehand.close();
 console.log(`Our favorite contributor is ${contributor.username}`);
 ```
 
@@ -295,6 +296,15 @@ If you are looking for a specific element, you can also pass in an instruction t
 - **Example:**
   ```javascript
   const actions = await stagehand.observe();
+  ```
+
+#### `close()`
+
+`close()` is a cleanup method to remove the temporary files created by Stagehand. It's highly recommended that you call this when you're done with your automation.
+
+- **Example:**
+  ```javascript
+  await stagehand.close();
   ```
 
 #### `page` and `context`

--- a/examples/example.ts
+++ b/examples/example.ts
@@ -19,7 +19,10 @@ async function example() {
       url: z.string(),
     }),
   });
+
   console.log(`Our favorite contributor is ${contributor.username}`);
+
+  await stagehand.close();
 }
 
 (async () => {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -198,7 +198,7 @@ async function getBrowser(
       },
     });
 
-    const tmpDirPath = path.join(os.tmpdir(), "ctx_");
+    const tmpDirPath = path.join(os.tmpdir(), "stagehand");
     if (!fs.existsSync(tmpDirPath)) {
       fs.mkdirSync(tmpDirPath, { recursive: true });
     }
@@ -250,7 +250,7 @@ async function getBrowser(
 
     await applyStealthScripts(context);
 
-    return { context };
+    return { context, contextPath: tmpDir };
   }
 }
 
@@ -309,6 +309,7 @@ export class Stagehand {
   private enableCaching: boolean;
   private variables: { [key: string]: any };
   private browserbaseResumeSessionID?: string;
+  private contextPath?: string;
 
   private actHandler?: StagehandActHandler;
   private extractHandler?: StagehandExtractHandler;
@@ -364,7 +365,7 @@ export class Stagehand {
     const llmClient = modelName
       ? this.llmProvider.getClient(modelName, modelClientOptions)
       : this.llmClient;
-    const { context, debugUrl, sessionUrl } = await getBrowser(
+    const { context, debugUrl, sessionUrl, contextPath } = await getBrowser(
       this.apiKey,
       this.projectId,
       this.env,
@@ -380,6 +381,7 @@ export class Stagehand {
         sessionUrl: undefined,
       } as BrowserResult;
     });
+    this.contextPath = contextPath;
     this.context = context;
     this.page = context.pages()[0];
     // Redundant but needed for users who are re-connecting to a previously-created session
@@ -876,5 +878,17 @@ export class Stagehand {
 
         throw e;
       });
+  }
+
+  async close() {
+    await this.context.close();
+
+    if (this.contextPath) {
+      try {
+        fs.rmSync(this.contextPath, { recursive: true, force: true });
+      } catch (e) {
+        console.error("Error deleting context directory:", e);
+      }
+    }
   }
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -880,7 +880,7 @@ export class Stagehand {
       });
   }
 
-  async close() {
+  async close(): Promise<void> {
     await this.context.close();
 
     if (this.contextPath) {

--- a/types/browser.ts
+++ b/types/browser.ts
@@ -5,4 +5,5 @@ export interface BrowserResult {
   context: BrowserContext;
   debugUrl?: string;
   sessionUrl?: string;
+  contextPath?: string;
 }


### PR DESCRIPTION
# why
Contexts will take up lots of space over time, this will delete them after usage to save space.

# what changed
Added a `close()` method.

# test plan
