### PR TITLE
Update permissions to create PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,31 +15,29 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
-      - name: Setup Node.js 20.x
+      - name: Setup Node.js 18.x
         uses: actions/setup-node@v3
         with:
-          node-version: 20.x
+          node-version: 18.x
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install Dependencies
         run: npm install
 
-      - name: Build
-        run: npm run build
+      - name: Publish Canary
+        if: github.ref == 'refs/heads/main'
+        run: |
+          git checkout main
+          npm version prerelease --preid=canary.${GITHUB_SHA::8} --no-git-tag-version
+          npm publish --tag canary --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
         with:
           publish: npm run release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Publish Canary
-        if: github.ref == 'refs/heads/main'
-        run: |
-          git checkout main
-          npm run release-canary
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: write
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -15,14 +17,16 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
-      - name: Setup Node.js 18.x
+      - name: Setup Node.js 20.x
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
-          registry-url: "https://registry.npmjs.org"
+          node-version: 20.x
 
       - name: Install Dependencies
         run: npm install
+
+      - name: Build
+        run: npm run build
 
       - name: Publish Canary
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
# why
Releases still aren't working. Canary releases work, but opening a PR to merge to main doesn't. This works on a personal fork, but not on an organization repo. Unfortunately this may require some manual merges until it works. Continues #256

# what changed

# test plan
