### PR TITLE
Fix: Install not working from NPM

### DIFF
--- a/.changeset/young-kids-help.md
+++ b/.changeset/young-kids-help.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": minor
+---
+
+Install wasn't working from NPM due to misconfigured build step. This attempts to fix that.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,12 @@
 {
   "name": "@browserbasehq/stagehand",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@browserbasehq/stagehand",
-      "version": "1.3.0",
-      "hasInstallScript": true,
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.27.3",

--- a/package.json
+++ b/package.json
@@ -16,12 +16,12 @@
     "build-types": "tsc --emitDeclarationOnly --outDir dist",
     "build-js": "tsup lib/index.ts --dts",
     "build": "npm run build-dom-scripts && npm run build-js && npm run build-types",
-    "postinstall": "npm run build",
     "release": "npm run build && changeset publish",
     "release-canary": "npm run build && changeset version --snapshot && changeset publish --tag alpha"
   },
   "files": [
-    "dist/**"
+    "dist/**",
+    "lib/**"
   ],
   "keywords": [],
   "author": "Paul Klein IV",


### PR DESCRIPTION
# why
Version 1.4.0 is not working from NPM due to `postinstall` running build scripts incorrectly. This attempts to fix that.

# what changed
- Remove postinstall script
- Add lib to dist

# test plan
Canary release
