### PR TITLE
Enable Multi-Region Support for Sessions

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -33,6 +33,12 @@ import { logLineToString } from "./utils";
 dotenv.config({ path: ".env" });
 
 const DEFAULT_MODEL_NAME = "gpt-4o";
+const BROWSERBASE_REGION_DOMEIN = {
+  "us-west-2": "wss://connect.usw2.browserbase.com",
+  "us-east-1": "wss://connect.use1.browserbase.com",
+  "eu-central-1": "wss://connect.euc1.browserbase.com",
+  "ap-southeast-1": "wss://connect.apse1.browserbase.com",
+};
 
 async function getBrowser(
   apiKey: string | undefined,
@@ -91,7 +97,8 @@ async function getBrowser(
         }
 
         sessionId = browserbaseResumeSessionID;
-        connectUrl = `wss://connect.browserbase.com?apiKey=${apiKey}&sessionId=${sessionId}`;
+        const browserBaseDomain = BROWSERBASE_REGION_DOMEIN[sessionStatus.region] || "wss://connect.browserbase.com";
+        connectUrl = `${browserBaseDomain}?apiKey=${apiKey}&sessionId=${sessionId}`;
 
         logger({
           category: "init",


### PR DESCRIPTION
# why
Added multi-region support for Browserbase session connections.

When reconnecting with browserbaseResumeSessionID, the default domain caused errors if the session was created in a different region (e.g., ap-southeast-1).

Example error:
```
Error in init: [Error: browserType.connectOverCDP: WebSocket error: wss://connect.browserbase.com/ 404 - Session XXXX should be connected to using wss://connect.apse1.browserbase.com
```

# what changed
The connection logic now detects the session’s region and selects the appropriate domain, ensuring proper multi-region support.

# test plan
1.	Create a session in a non-default region (e.g., ap-southeast-1).
2.	Reconnect using the browserbaseResumeSessionID.
3.	Verify that the correct domain is used, and ensure no errors occur.