### PR TITLE
Evals/string similarity

### DIFF
--- a/evals/extract/extract_baptist_health.ts
+++ b/evals/extract/extract_baptist_health.ts
@@ -7,7 +7,10 @@ export const extract_baptist_health: EvalFunction = async ({
   modelName,
   logger,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({ modelName, logger });
+  const { stagehand, initResponse } = await initStagehand({
+    modelName,
+    logger,
+  });
 
   const { debugUrl, sessionUrl } = initResponse;
 
@@ -36,13 +39,31 @@ export const extract_baptist_health: EvalFunction = async ({
   };
 
   const similarityThreshold = 0.85;
-  const failedFields: Array<{ field: string; similarity: number; expected: string; actual: string }> = [];
+  const failedFields: Array<{
+    field: string;
+    similarity: number;
+    expected: string;
+    actual: string;
+  }> = [];
 
-  const compareField = (actualVal: string, expectedVal: string, fieldName: string) => {
-    const { similarity, meetsThreshold } = compareStrings(actualVal, expectedVal, similarityThreshold);
+  const compareField = (
+    actualVal: string,
+    expectedVal: string,
+    fieldName: string,
+  ) => {
+    const { similarity, meetsThreshold } = compareStrings(
+      actualVal,
+      expectedVal,
+      similarityThreshold,
+    );
 
     if (!meetsThreshold) {
-      failedFields.push({ field: fieldName, similarity, expected: expectedVal, actual: actualVal });
+      failedFields.push({
+        field: fieldName,
+        similarity,
+        expected: expectedVal,
+        actual: actualVal,
+      });
       logger.error({
         message: `${fieldName} extracted does not meet similarity threshold`,
         level: 0,

--- a/evals/extract/extract_baptist_health.ts
+++ b/evals/extract/extract_baptist_health.ts
@@ -1,16 +1,13 @@
 import { EvalFunction } from "../../types/evals";
 import { initStagehand } from "../utils";
-import { normalizeString } from "../utils";
 import { z } from "zod";
+import { compareStrings } from "../utils";
 
 export const extract_baptist_health: EvalFunction = async ({
   modelName,
   logger,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-  });
+  const { stagehand, initResponse } = await initStagehand({ modelName, logger });
 
   const { debugUrl, sessionUrl } = initResponse;
 
@@ -32,82 +29,47 @@ export const extract_baptist_health: EvalFunction = async ({
   await stagehand.close();
 
   const { address, phone, fax } = result;
-
   const expected = {
     address: "2055 East South Blvd; Suite 908 Montgomery, AL 36116",
     phone: "334-747-2273",
     fax: "334-747-7501",
   };
 
-  if (normalizeString(address) !== normalizeString(expected.address)) {
-    logger.error({
-      message: "Address extracted does not match expected",
-      level: 0,
-      auxiliary: {
-        expected: {
-          value: expected.address,
-          type: "string",
-        },
-        actual: {
-          value: address,
-          type: "string",
-        },
-      },
-    });
-    return {
-      _success: false,
-      error: "Address extracted does not match expected",
-      logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
-    };
-  }
+  const similarityThreshold = 0.85;
+  const failedFields: Array<{ field: string; similarity: number; expected: string; actual: string }> = [];
 
-  if (normalizeString(phone) !== normalizeString(expected.phone)) {
-    logger.error({
-      message: "Phone number extracted does not match expected",
-      level: 0,
-      auxiliary: {
-        expected: {
-          value: expected.phone,
-          type: "string",
-        },
-        actual: {
-          value: phone,
-          type: "string",
-        },
-      },
-    });
-    return {
-      _success: false,
-      error: "Phone number extracted does not match expected",
-      logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
-    };
-  }
+  const compareField = (actualVal: string, expectedVal: string, fieldName: string) => {
+    const { similarity, meetsThreshold } = compareStrings(actualVal, expectedVal, similarityThreshold);
 
-  if (normalizeString(fax) !== normalizeString(expected.fax)) {
-    logger.error({
-      message: "Fax number extracted does not match expected",
-      level: 0,
-      auxiliary: {
-        expected: {
-          value: expected.fax,
-          type: "string",
+    if (!meetsThreshold) {
+      failedFields.push({ field: fieldName, similarity, expected: expectedVal, actual: actualVal });
+      logger.error({
+        message: `${fieldName} extracted does not meet similarity threshold`,
+        level: 0,
+        auxiliary: {
+          field: { value: fieldName, type: "string" },
+          similarity: { value: similarity.toFixed(2), type: "string" },
+          expected: { value: expectedVal, type: "string" },
+          actual: { value: actualVal, type: "string" },
         },
-        actual: {
-          value: fax,
-          type: "string",
-        },
-      },
-    });
+      });
+    }
+
+    return meetsThreshold;
+  };
+
+  const addressOk = compareField(address, expected.address, "Address");
+  const phoneOk = compareField(phone, expected.phone, "Phone number");
+  const faxOk = compareField(fax, expected.fax, "Fax number");
+
+  if (!addressOk || !phoneOk || !faxOk) {
     return {
       _success: false,
-      error: "Fax number extracted does not match expected",
+      error: "Some fields did not meet similarity threshold",
       logs: logger.getLogs(),
       debugUrl,
       sessionUrl,
+      failedFields,
     };
   }
 

--- a/evals/extract/extract_memorial_healthcare.ts
+++ b/evals/extract/extract_memorial_healthcare.ts
@@ -3,7 +3,10 @@ import { initStagehand } from "../utils";
 import { z } from "zod";
 import { compareStrings } from "../utils";
 
-export const extract_memorial_healthcare: EvalFunction = async ({ modelName, logger }) => {
+export const extract_memorial_healthcare: EvalFunction = async ({
+  modelName,
+  logger,
+}) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
@@ -30,8 +33,9 @@ export const extract_memorial_healthcare: EvalFunction = async ({ modelName, log
 
   await stagehand.close();
 
-  const health_centers: Array<Partial<{ name: string; phone_number: string; address: string }>> =
-    result.health_centers;
+  const health_centers: Array<
+    Partial<{ name: string; phone_number: string; address: string }>
+  > = result.health_centers;
 
   const expectedLength = 3;
   const similarityThreshold = 0.85;
@@ -74,7 +78,7 @@ export const extract_memorial_healthcare: EvalFunction = async ({ modelName, log
   }
 
   const validateHealthCenter = (
-    center: Partial<{ name: string; phone_number: string; address: string }>
+    center: Partial<{ name: string; phone_number: string; address: string }>,
   ): { name: string; phone_number: string; address: string } | null => {
     if (center.name && center.phone_number && center.address) {
       return center as { name: string; phone_number: string; address: string };
@@ -91,7 +95,11 @@ export const extract_memorial_healthcare: EvalFunction = async ({ modelName, log
 
   const validHealthCenters = health_centers
     .map(validateHealthCenter)
-    .filter(Boolean) as Array<{ name: string; phone_number: string; address: string }>;
+    .filter(Boolean) as Array<{
+    name: string;
+    phone_number: string;
+    address: string;
+  }>;
 
   if (validHealthCenters.length < expectedLength) {
     return {
@@ -106,12 +114,12 @@ export const extract_memorial_healthcare: EvalFunction = async ({ modelName, log
   const compareField = (
     actual: string,
     expected: string,
-    fieldName: string
+    fieldName: string,
   ): boolean => {
     const { similarity, meetsThreshold } = compareStrings(
       actual,
       expected,
-      similarityThreshold
+      similarityThreshold,
     );
 
     if (!meetsThreshold) {
@@ -133,7 +141,7 @@ export const extract_memorial_healthcare: EvalFunction = async ({ modelName, log
   const compareItem = (
     actual: { name: string; phone_number: string; address: string },
     expected: { name: string; phone_number: string; address: string },
-    position: string
+    position: string,
   ): boolean => {
     const fields = [
       { field: "name", actual: actual.name, expected: expected.name },
@@ -146,15 +154,19 @@ export const extract_memorial_healthcare: EvalFunction = async ({ modelName, log
     ];
 
     return fields.every(({ field, actual, expected }) =>
-      compareField(actual, expected, `${position} ${field}`)
+      compareField(actual, expected, `${position} ${field}`),
     );
   };
 
-  const firstItemMatches = compareItem(validHealthCenters[0], expectedFirstItem, "First");
+  const firstItemMatches = compareItem(
+    validHealthCenters[0],
+    expectedFirstItem,
+    "First",
+  );
   const lastItemMatches = compareItem(
     validHealthCenters[validHealthCenters.length - 1],
     expectedLastItem,
-    "Last"
+    "Last",
   );
 
   if (!firstItemMatches || !lastItemMatches) {

--- a/evals/extract/extract_memorial_healthcare.ts
+++ b/evals/extract/extract_memorial_healthcare.ts
@@ -1,12 +1,9 @@
-import { z } from "zod";
-import { initStagehand } from "../utils";
 import { EvalFunction } from "../../types/evals";
-import { normalizeString } from "../utils";
+import { initStagehand } from "../utils";
+import { z } from "zod";
+import { compareStrings } from "../utils";
 
-export const extract_memorial_healthcare: EvalFunction = async ({
-  modelName,
-  logger,
-}) => {
+export const extract_memorial_healthcare: EvalFunction = async ({ modelName, logger }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
@@ -27,15 +24,26 @@ export const extract_memorial_healthcare: EvalFunction = async ({
     instruction:
       "extract a list of the first three healthcare centers on this page, with their name, full address, and phone number",
     schema: z.object({
-      health_centers: z.array(healthCenterSchema),
+      health_centers: z.array(
+        z.object({
+          name: z.string(),
+          phone_number: z.string(),
+          address: z.string(),
+        }),
+      ),
     }),
   });
 
   await stagehand.close();
 
-  const health_centers = result.health_centers;
+  const health_centers: Array<{
+    name?: string;
+    phone_number?: string;
+    address?: string;
+  }> = result.health_centers;
 
   const expectedLength = 3;
+  const similarityThreshold = 0.85;
 
   const expectedFirstItem = {
     name: "Community Memorial Breast Center",
@@ -74,62 +82,90 @@ export const extract_memorial_healthcare: EvalFunction = async ({
     };
   }
 
-  const normalizeAndCompare = (
-    actual: HealthCenterType,
-    expected: HealthCenterType,
-  ) =>
-    normalizeString(actual.name) === normalizeString(expected.name) &&
-    normalizeString(actual.phone_number) ===
-      normalizeString(expected.phone_number) &&
-    normalizeString(actual.address) === normalizeString(expected.address);
-
-  if (!normalizeAndCompare(health_centers[0], expectedFirstItem)) {
+  const validateHealthCenter = (center: any): { name: string; phone_number: string; address: string } | null => {
+    if (center.name && center.phone_number && center.address) {
+      return center as { name: string; phone_number: string; address: string };
+    }
     logger.error({
-      message: "First health center does not match expected",
+      message: "Invalid health center data",
       level: 0,
       auxiliary: {
-        expected: {
-          value: JSON.stringify(expectedFirstItem),
-          type: "object",
-        },
-        actual: {
-          value: JSON.stringify(health_centers[0]),
-          type: "object",
-        },
+        center: { value: JSON.stringify(center), type: "object" },
       },
     });
+    return null;
+  };
+
+  const validHealthCenters = health_centers.map(validateHealthCenter).filter(Boolean) as Array<{
+    name: string;
+    phone_number: string;
+    address: string;
+  }>;
+
+  if (validHealthCenters.length < expectedLength) {
     return {
       _success: false,
-      error: "First health center does not match expected",
+      error: "One or more health centers have missing fields",
       logs: logger.getLogs(),
       debugUrl,
       sessionUrl,
     };
   }
 
-  if (
-    !normalizeAndCompare(
-      health_centers[health_centers.length - 1],
-      expectedLastItem,
-    )
-  ) {
-    logger.error({
-      message: "Last health center does not match expected",
-      level: 0,
-      auxiliary: {
-        expected: {
-          value: JSON.stringify(expectedLastItem),
-          type: "object",
+  const compareField = (
+    actual: string,
+    expected: string,
+    fieldName: string
+  ): boolean => {
+    const { similarity, meetsThreshold } = compareStrings(
+      actual,
+      expected,
+      similarityThreshold
+    );
+
+    if (!meetsThreshold) {
+      logger.error({
+        message: `Field "${fieldName}" does not meet similarity threshold`,
+        level: 0,
+        auxiliary: {
+          field: { value: fieldName, type: "string" },
+          similarity: { value: similarity.toFixed(2), type: "float" },
+          expected: { value: expected, type: "string" },
+          actual: { value: actual, type: "string" },
         },
-        actual: {
-          value: JSON.stringify(health_centers[health_centers.length - 1]),
-          type: "object",
-        },
+      });
+    }
+
+    return meetsThreshold;
+  };
+
+  const compareItem = (
+    actual: { name: string; phone_number: string; address: string },
+    expected: { name: string; phone_number: string; address: string },
+    position: string
+  ): boolean => {
+    const fields = [
+      { field: "name", actual: actual.name, expected: expected.name },
+      {
+        field: "phone_number",
+        actual: actual.phone_number,
+        expected: expected.phone_number,
       },
-    });
+      { field: "address", actual: actual.address, expected: expected.address },
+    ];
+
+    return fields.every(({ field, actual, expected }) =>
+      compareField(actual, expected, `${position} ${field}`)
+    );
+  };
+
+  const firstItemMatches = compareItem(validHealthCenters[0], expectedFirstItem, "First");
+  const lastItemMatches = compareItem(validHealthCenters[validHealthCenters.length - 1], expectedLastItem, "Last");
+
+  if (!firstItemMatches || !lastItemMatches) {
     return {
       _success: false,
-      error: "Last health center does not match expected",
+      error: "One or more fields do not match expected values",
       logs: logger.getLogs(),
       debugUrl,
       sessionUrl,

--- a/evals/utils.ts
+++ b/evals/utils.ts
@@ -1,6 +1,8 @@
 import { AvailableModel, Stagehand } from "../lib";
 import { logLineToString } from "../lib/utils";
 import { LogLine } from "../types/log";
+import stringComparison from "string-comparison";
+const { jaroWinkler } = stringComparison;
 
 export const env: "BROWSERBASE" | "LOCAL" =
   process.env.EVAL_ENV?.toLowerCase() === "browserbase"
@@ -96,6 +98,22 @@ export function normalizeString(str: string): string {
   return str
     .toLowerCase()
     .replace(/\s+/g, " ")
-    .replace(/[.,/#!$%^&*;:{}=\-_`~()]/g, "")
+    .replace(/[;\/#!$%\^&\*:{}=\-_`~()]/g, "")
+    .replace(/\s*,\s*/g, ", ")
     .trim();
+}
+
+export function compareStrings(
+  actual: string,
+  expected: string,
+  similarityThreshold: number = 0.85
+): { similarity: number; meetsThreshold: boolean } {
+  const similarity = jaroWinkler.similarity(
+    normalizeString(actual),
+    normalizeString(expected)
+  );
+  return {
+    similarity,
+    meetsThreshold: similarity >= similarityThreshold,
+  };
 }

--- a/evals/utils.ts
+++ b/evals/utils.ts
@@ -106,11 +106,11 @@ export function normalizeString(str: string): string {
 export function compareStrings(
   actual: string,
   expected: string,
-  similarityThreshold: number = 0.85
+  similarityThreshold: number = 0.85,
 ): { similarity: number; meetsThreshold: boolean } {
   const similarity = jaroWinkler.similarity(
     normalizeString(actual),
-    normalizeString(expected)
+    normalizeString(expected),
   );
   return {
     similarity,

--- a/evals/utils.ts
+++ b/evals/utils.ts
@@ -98,7 +98,7 @@ export function normalizeString(str: string): string {
   return str
     .toLowerCase()
     .replace(/\s+/g, " ")
-    .replace(/[;\/#!$%\^&\*:{}=\-_`~()]/g, "")
+    .replace(/[;/#!$%^&*:{}=\-_`~()]/g, "")
     .replace(/\s*,\s*/g, ", ")
     .trim();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7607,13 +7607,6 @@
         "node": "^16.0.0 || >=18.0.0"
       }
     },
-    "node_modules/string-similarity": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-4.0.4.tgz",
-      "integrity": "sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "license": "ISC"
-    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@anthropic-ai/sdk": "^0.27.3",
         "@browserbasehq/sdk": "^2.0.0",
         "sharp": "^0.33.5",
+        "string-comparison": "^1.3.0",
         "zod-to-json-schema": "^3.23.3"
       },
       "devDependencies": {
@@ -7596,6 +7597,22 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string-comparison": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string-comparison/-/string-comparison-1.3.0.tgz",
+      "integrity": "sha512-46aD+slEwybxAMPRII83ATbgMgTiz5P8mVd7Z6VJsCzSHFjdt1hkAVLeFxPIyEb11tc6ihpJTlIqoO0MCF6NPw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      }
+    },
+    "node_modules/string-similarity": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-4.0.4.tgz",
+      "integrity": "sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "ISC"
     },
     "node_modules/string-width": {
       "version": "4.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@anthropic-ai/sdk": "^0.27.3",
         "@browserbasehq/sdk": "^2.0.0",
         "sharp": "^0.33.5",
-        "string-comparison": "^1.3.0",
         "zod-to-json-schema": "^3.23.3"
       },
       "devDependencies": {
@@ -32,6 +31,7 @@
         "globals": "^15.13.0",
         "multer": "^1.4.5-lts.1",
         "prettier": "^3.2.5",
+        "string-comparison": "^1.3.0",
         "tsup": "^8.2.1",
         "tsx": "^4.10.5",
         "typescript": "^5.2.2",
@@ -7602,6 +7602,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string-comparison/-/string-comparison-1.3.0.tgz",
       "integrity": "sha512-46aD+slEwybxAMPRII83ATbgMgTiz5P8mVd7Z6VJsCzSHFjdt1hkAVLeFxPIyEb11tc6ihpJTlIqoO0MCF6NPw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^16.0.0 || >=18.0.0"

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "globals": "^15.13.0",
     "multer": "^1.4.5-lts.1",
     "prettier": "^3.2.5",
+    "string-comparison": "^1.3.0",
     "tsup": "^8.2.1",
     "tsx": "^4.10.5",
     "typescript": "^5.2.2",
@@ -63,7 +64,6 @@
     "@anthropic-ai/sdk": "^0.27.3",
     "@browserbasehq/sdk": "^2.0.0",
     "sharp": "^0.33.5",
-    "string-comparison": "^1.3.0",
     "zod-to-json-schema": "^3.23.3"
   },
   "directories": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@anthropic-ai/sdk": "^0.27.3",
     "@browserbasehq/sdk": "^2.0.0",
     "sharp": "^0.33.5",
+    "string-comparison": "^1.3.0",
     "zod-to-json-schema": "^3.23.3"
   },
   "directories": {


### PR DESCRIPTION
# why
- extract evals sometimes fail when there is a small difference between expected output and actual output (like an extra space, punctuation, capital letters, etc
- we can try to mitigate this by normalizing strings with regex, but it is difficult to cover all possible cases. regex is brittle and hard to understand.
# what changed
- for specific evals where this was a problem, instead of using plain string matching, I've added a string similarity function and set a default threshold of 0.85
# test plan
