### PR TITLE
Make BB Session ID public within Stagehand class

### DIFF
--- a/.changeset/wicked-rockets-beg.md
+++ b/.changeset/wicked-rockets-beg.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": minor
+---
+
+Add sessionId to public params

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ This constructor is used to create an instance of Stagehand.
   - A `Promise` that resolves to an object containing:
     - `debugUrl`: a `string` representing the URL for live debugging. This is only available when using a Browserbase browser.
     - `sessionUrl`: a `string` representing the session URL. This is only available when using a Browserbase browser.
+    - `sessionId`: a `string` representing the session ID. This is only available when using a Browserbase browser.
 
 - **Example:**
   ```javascript

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -195,7 +195,7 @@ async function getBrowser(
 
     const context = browser.contexts()[0];
 
-    return { browser, context, debugUrl, sessionUrl };
+    return { browser, context, debugUrl, sessionUrl, sessionId };
   } else {
     logger({
       category: "init",
@@ -307,6 +307,8 @@ export class Stagehand {
   private llmClient: LLMClient;
   public page: Page;
   public context: BrowserContext;
+  public browserbaseSessionID?: string;
+
   private env: "LOCAL" | "BROWSERBASE";
   private apiKey: string | undefined;
   private projectId: string | undefined;
@@ -377,23 +379,24 @@ export class Stagehand {
         "Passing parameters to init() is deprecated and will be removed in the next major version. Use constructor options instead.",
       );
     }
-    const { context, debugUrl, sessionUrl, contextPath } = await getBrowser(
-      this.apiKey,
-      this.projectId,
-      this.env,
-      this.headless,
-      this.logger,
-      this.browserbaseSessionCreateParams,
-      this.browserbaseResumeSessionID,
-    ).catch((e) => {
-      console.error("Error in init:", e);
-      const br: BrowserResult = {
-        context: undefined,
-        debugUrl: undefined,
-        sessionUrl: undefined,
-      };
-      return br;
-    });
+    const { context, debugUrl, sessionUrl, contextPath, sessionId } =
+      await getBrowser(
+        this.apiKey,
+        this.projectId,
+        this.env,
+        this.headless,
+        this.logger,
+        this.browserbaseSessionCreateParams,
+        this.browserbaseResumeSessionID,
+      ).catch((e) => {
+        console.error("Error in init:", e);
+        const br: BrowserResult = {
+          context: undefined,
+          debugUrl: undefined,
+          sessionUrl: undefined,
+        };
+        return br;
+      });
     this.contextPath = contextPath;
     this.context = context;
     this.page = context.pages()[0];
@@ -455,8 +458,9 @@ export class Stagehand {
       verbose: this.verbose,
       llmClient: this.llmClient,
     });
+    this.browserbaseSessionID = sessionId;
 
-    return { debugUrl, sessionUrl };
+    return { debugUrl, sessionUrl, sessionId };
   }
 
   /** @deprecated initFromPage is deprecated and will be removed in the next major version. */

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -394,6 +394,7 @@ export class Stagehand {
           context: undefined,
           debugUrl: undefined,
           sessionUrl: undefined,
+          sessionId: undefined,
         };
         return br;
       });

--- a/types/browser.ts
+++ b/types/browser.ts
@@ -6,4 +6,5 @@ export interface BrowserResult {
   debugUrl?: string;
   sessionUrl?: string;
   contextPath?: string;
+  sessionId?: string;
 }

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -22,11 +22,6 @@ export interface ConstructorParams {
   modelClientOptions?: ClientOptions;
 }
 
-export interface InitResult {
-  debugUrl: string;
-  sessionUrl: string;
-}
-
 export interface InitOptions {
   /** @deprecated Pass this into the Stagehand constructor instead. This will be removed in the next major version. */
   modelName?: AvailableModel;
@@ -39,6 +34,7 @@ export interface InitOptions {
 export interface InitResult {
   debugUrl: string;
   sessionUrl: string;
+  sessionId: string;
 }
 
 export interface InitFromPageOptions {


### PR DESCRIPTION
# why
We should be able to do `stagehand.browserbaseSessionId` to be able to pull relevant information about the Browserbase session.

# what changed
- added `sessionId` as a public param to Stagehand
- edited `getBrowser` to return `sessionId`
- edited associated types
- removed duplicate interface

# test plan
- evals CI