### PR TITLE
Fix press release eval

### DIFF
--- a/evals/text_extract/extract_press_releases.ts
+++ b/evals/text_extract/extract_press_releases.ts
@@ -23,7 +23,7 @@ export const extract_press_releases: EvalFunction = async ({
     // timeout for 5 seconds to allow for the page to load
     await new Promise((resolve) => setTimeout(resolve, 5000));
 
-    const result = await stagehand.extract({
+    const { items } = (await stagehand.extract({
       instruction:
         "extract the title and corresponding publish date of EACH AND EVERY press releases on this page. DO NOT MISS ANY PRESS RELEASES.",
       schema: z.object({
@@ -40,16 +40,16 @@ export const extract_press_releases: EvalFunction = async ({
       }),
       modelName,
       useTextExtract,
-    });
+    })) as { items: { title: string; publish_date: string }[] };
 
     await stagehand.close();
-    const items = result.items;
+
     const expectedLength = 28;
-    const expectedFirstItem: { title: string; publish_date: string } = {
+    const expectedFirstItem = {
       title: "UAW Region 9A Endorses Brad Lander for Mayor",
       publish_date: "Dec 4, 2024",
     };
-    const expectedLastItem: { title: string; publish_date: string } = {
+    const expectedLastItem = {
       title: "An Unassuming Liberal Makes a Rapid Ascent to Power Broker",
       publish_date: "Jan 23, 2014",
     };
@@ -91,11 +91,9 @@ export const extract_press_releases: EvalFunction = async ({
       return titleComparison.meetsThreshold && dateComparison.meetsThreshold;
     };
 
-    // Check if expectedFirstItem is found anywhere in the list
     const foundFirstItem = items.some((item) =>
       isItemMatch(item, expectedFirstItem),
     );
-    // Check if expectedLastItem is found anywhere in the list
     const foundLastItem = items.some((item) =>
       isItemMatch(item, expectedLastItem),
     );

--- a/evals/text_extract/extract_press_releases.ts
+++ b/evals/text_extract/extract_press_releases.ts
@@ -108,7 +108,7 @@ export const extract_press_releases: EvalFunction = async ({
       debugUrl,
       sessionUrl,
     };
-  } catch (error: any) {
+  } catch (error) {
     logger.error({
       message: `Error in extract_press_releases function`,
       level: 0,

--- a/evals/text_extract/extract_press_releases.ts
+++ b/evals/text_extract/extract_press_releases.ts
@@ -40,7 +40,7 @@ export const extract_press_releases: EvalFunction = async ({
       }),
       modelName,
       useTextExtract,
-    })) as { items: { title: string; publish_date: string }[] };
+    })) satisfies { items: { title: string; publish_date: string }[] };
 
     await stagehand.close();
 

--- a/evals/text_extract/extract_press_releases.ts
+++ b/evals/text_extract/extract_press_releases.ts
@@ -82,10 +82,11 @@ export const extract_press_releases: EvalFunction = async ({
       item: { title: string; publish_date: string },
       expected: { title: string; publish_date: string },
     ) => {
-      const titleComparison = compareStrings(item.title, expected.title);
+      const titleComparison = compareStrings(item.title, expected.title, 0.9);
       const dateComparison = compareStrings(
         item.publish_date,
         expected.publish_date,
+        0.9,
       );
       return titleComparison.meetsThreshold && dateComparison.meetsThreshold;
     };

--- a/evals/text_extract/extract_press_releases.ts
+++ b/evals/text_extract/extract_press_releases.ts
@@ -16,25 +16,24 @@ export const extract_press_releases: EvalFunction = async ({
 
   const { debugUrl, sessionUrl } = initResponse;
 
+  const schema = z.object({
+    items: z.array(
+      z.object({
+        title: z.string().describe("The title of the press release"),
+        publish_date: z
+          .string()
+          .describe("The date the press release was published"),
+      }),
+    ),
+  });
+
+  type PressRelease = z.infer<typeof schema>["items"][number];
+
   try {
     await stagehand.page.goto("https://www.landerfornyc.com/news", {
       waitUntil: "networkidle",
     });
-    // timeout for 5 seconds to allow for the page to load
     await new Promise((resolve) => setTimeout(resolve, 5000));
-
-    const schema = z.object({
-      items: z.array(
-        z.object({
-          title: z.string().describe("The title of the press release"),
-          publish_date: z
-            .string()
-            .describe(
-              "The date the press release was published, eg 'Oct 12, 2021'",
-            ),
-        }),
-      ),
-    });
 
     const rawResult = await stagehand.extract({
       instruction:
@@ -44,16 +43,17 @@ export const extract_press_releases: EvalFunction = async ({
       useTextExtract,
     });
 
-    const { items } = schema.parse(rawResult);
+    const parsed = schema.parse(rawResult);
+    const { items } = parsed;
 
     await stagehand.close();
 
     const expectedLength = 28;
-    const expectedFirstItem = {
+    const expectedFirstItem: PressRelease = {
       title: "UAW Region 9A Endorses Brad Lander for Mayor",
       publish_date: "Dec 4, 2024",
     };
-    const expectedLastItem = {
+    const expectedLastItem: PressRelease = {
       title: "An Unassuming Liberal Makes a Rapid Ascent to Power Broker",
       publish_date: "Jan 23, 2014",
     };
@@ -82,10 +82,7 @@ export const extract_press_releases: EvalFunction = async ({
       };
     }
 
-    const isItemMatch = (
-      item: { title: string; publish_date: string },
-      expected: { title: string; publish_date: string },
-    ) => {
+    const isItemMatch = (item: PressRelease, expected: PressRelease) => {
       const titleComparison = compareStrings(item.title, expected.title, 0.9);
       const dateComparison = compareStrings(
         item.publish_date,
@@ -114,11 +111,11 @@ export const extract_press_releases: EvalFunction = async ({
       level: 0,
       auxiliary: {
         error: {
-          value: error.message || JSON.stringify(error),
+          value: (error as Error).message || JSON.stringify(error),
           type: "string",
         },
         trace: {
-          value: error.stack,
+          value: (error as Error).stack,
           type: "string",
         },
       },

--- a/evals/text_extract/extract_press_releases.ts
+++ b/evals/text_extract/extract_press_releases.ts
@@ -45,11 +45,11 @@ export const extract_press_releases: EvalFunction = async ({
     await stagehand.close();
     const items = result.items;
     const expectedLength = 28;
-    const expectedFirstItem = {
+    const expectedFirstItem: { title: string; publish_date: string } = {
       title: "UAW Region 9A Endorses Brad Lander for Mayor",
       publish_date: "Dec 4, 2024",
     };
-    const expectedLastItem = {
+    const expectedLastItem: { title: string; publish_date: string } = {
       title: "An Unassuming Liberal Makes a Rapid Ascent to Power Broker",
       publish_date: "Jan 23, 2014",
     };

--- a/evals/utils.ts
+++ b/evals/utils.ts
@@ -4,12 +4,10 @@ import { LogLine } from "../types/log";
 import stringComparison from "string-comparison";
 const { jaroWinkler } = stringComparison;
 
-// export const env: "BROWSERBASE" | "LOCAL" =
-//   process.env.EVAL_ENV?.toLowerCase() === "browserbase"
-//     ? "BROWSERBASE"
-//     : "LOCAL";
-
-export const env = "BROWSERBASE";
+export const env: "BROWSERBASE" | "LOCAL" =
+  process.env.EVAL_ENV?.toLowerCase() === "browserbase"
+    ? "BROWSERBASE"
+    : "LOCAL";
 
 const enableCaching = process.env.EVAL_ENABLE_CACHING?.toLowerCase() === "true";
 

--- a/evals/utils.ts
+++ b/evals/utils.ts
@@ -4,10 +4,12 @@ import { LogLine } from "../types/log";
 import stringComparison from "string-comparison";
 const { jaroWinkler } = stringComparison;
 
-export const env: "BROWSERBASE" | "LOCAL" =
-  process.env.EVAL_ENV?.toLowerCase() === "browserbase"
-    ? "BROWSERBASE"
-    : "LOCAL";
+// export const env: "BROWSERBASE" | "LOCAL" =
+//   process.env.EVAL_ENV?.toLowerCase() === "browserbase"
+//     ? "BROWSERBASE"
+//     : "LOCAL";
+
+export const env = "BROWSERBASE";
 
 const enableCaching = process.env.EVAL_ENABLE_CACHING?.toLowerCase() === "true";
 


### PR DESCRIPTION
# why
- make eval more robust to website changes
# what changed
- pass if we get at least 28 press releases
