### PR TITLE
chore: rename browserbaseResumeSessionID -> browserbaseSessionID

### DIFF
--- a/.changeset/flat-avocados-sit.md
+++ b/.changeset/flat-avocados-sit.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": minor
+---
+
+rename browserbaseResumeSessionID -> browserbaseSessionID

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ This constructor is used to create an instance of Stagehand.
   - `apiKey`: (optional) your Browserbase API key. Defaults to `BROWSERBASE_API_KEY` environment variable.
   - `projectId`: (optional) your Browserbase project ID. Defaults to `BROWSERBASE_PROJECT_ID` environment variable.
   - `browserbaseSessionCreateParams`: configuration options for creating new Browserbase sessions.
-  - `browserbaseResumeSessionID`: ID of an existing Browserbase session to resume.
+  - `browserbaseSessionID`: ID of an existing live Browserbase session. Overrides `browserbaseSessionCreateParams`.
   - `logger`: a function that handles log messages. Useful for custom logging implementations.
   - `verbose`: an `integer` that enables several levels of logging during automation:
     - `0`: limited to no logging
@@ -174,7 +174,7 @@ This constructor is used to create an instance of Stagehand.
   // Resume existing Browserbase session
   const stagehand = new Stagehand({
     env: "BROWSERBASE",
-    browserbaseResumeSessionID: "existing-session-id",
+    browserbaseSessionID: "existing-session-id",
   });
   ```
 

--- a/examples/stagehand.config.ts
+++ b/examples/stagehand.config.ts
@@ -16,7 +16,7 @@ const StagehandConfig: ConstructorParams = {
     projectId: process.env.BROWSERBASE_PROJECT_ID!,
   },
   enableCaching: true /* Enable caching functionality */,
-  browserbaseResumeSessionID:
+  browserbaseSessionID:
     undefined /* Session ID for resuming Browserbase sessions */,
   modelName: "gpt-4o" /* Name of the model to use */,
   modelClientOptions: {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -47,7 +47,7 @@ async function getBrowser(
   headless: boolean = false,
   logger: (message: LogLine) => void,
   browserbaseSessionCreateParams?: Browserbase.Sessions.SessionCreateParams,
-  browserbaseResumeSessionID?: string,
+  browserbaseSessionID?: string,
 ): Promise<BrowserResult> {
   if (env === "BROWSERBASE") {
     if (!apiKey) {
@@ -83,20 +83,19 @@ async function getBrowser(
       apiKey,
     });
 
-    if (browserbaseResumeSessionID) {
+    if (browserbaseSessionID) {
       // Validate the session status
       try {
-        const sessionStatus = await browserbase.sessions.retrieve(
-          browserbaseResumeSessionID,
-        );
+        const sessionStatus =
+          await browserbase.sessions.retrieve(browserbaseSessionID);
 
         if (sessionStatus.status !== "RUNNING") {
           throw new Error(
-            `Session ${browserbaseResumeSessionID} is not running (status: ${sessionStatus.status})`,
+            `Session ${browserbaseSessionID} is not running (status: ${sessionStatus.status})`,
           );
         }
 
-        sessionId = browserbaseResumeSessionID;
+        sessionId = browserbaseSessionID;
         const browserbaseDomain =
           BROWSERBASE_REGION_DOMAIN[sessionStatus.region] ||
           "wss://connect.browserbase.com";
@@ -173,7 +172,7 @@ async function getBrowser(
 
     logger({
       category: "init",
-      message: browserbaseResumeSessionID
+      message: browserbaseSessionID
         ? "browserbase session resumed"
         : "browserbase session started",
       level: 0,
@@ -321,7 +320,6 @@ export class Stagehand {
   private browserbaseSessionCreateParams?: Browserbase.Sessions.SessionCreateParams;
   private enableCaching: boolean;
   private variables: { [key: string]: unknown };
-  private browserbaseResumeSessionID?: string;
   private contextPath?: string;
 
   private actHandler?: StagehandActHandler;
@@ -341,7 +339,7 @@ export class Stagehand {
       browserbaseSessionCreateParams,
       domSettleTimeoutMs,
       enableCaching,
-      browserbaseResumeSessionID,
+      browserbaseSessionID,
       modelName,
       modelClientOptions,
     }: ConstructorParams = {
@@ -367,7 +365,7 @@ export class Stagehand {
     this.domSettleTimeoutMs = domSettleTimeoutMs ?? 30_000;
     this.headless = headless ?? false;
     this.browserbaseSessionCreateParams = browserbaseSessionCreateParams;
-    this.browserbaseResumeSessionID = browserbaseResumeSessionID;
+    this.browserbaseSessionID = browserbaseSessionID;
   }
 
   async init(
@@ -387,7 +385,7 @@ export class Stagehand {
         this.headless,
         this.logger,
         this.browserbaseSessionCreateParams,
-        this.browserbaseResumeSessionID,
+        this.browserbaseSessionID,
       ).catch((e) => {
         console.error("Error in init:", e);
         const br: BrowserResult = {
@@ -469,7 +467,7 @@ export class Stagehand {
     page,
   }: InitFromPageOptions): Promise<InitFromPageResult> {
     console.warn(
-      "initFromPage is deprecated and will be removed in the next major version. To instantiate from a page, use `browserbaseResumeSessionID` in the constructor.",
+      "initFromPage is deprecated and will be removed in the next major version. To instantiate from a page, use `browserbaseSessionID` in the constructor.",
     );
     this.page = page;
     this.context = page.context();

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -17,7 +17,7 @@ export interface ConstructorParams {
   domSettleTimeoutMs?: number;
   browserbaseSessionCreateParams?: Browserbase.Sessions.SessionCreateParams;
   enableCaching?: boolean;
-  browserbaseResumeSessionID?: string;
+  browserbaseSessionID?: string;
   modelName?: AvailableModel;
   modelClientOptions?: ClientOptions;
 }


### PR DESCRIPTION
# why
user convenience

# what changed
`browserbaseResumeSessionId` -> `browserbaseResumeSessionID`

# test plan
lint/build