### PR TITLE
Setting model defaults in LLMProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 - [Acknowledgements](#acknowledgements)
 - [License](#license)
 
-> [!NOTE]  
+> [!NOTE]
 > `Stagehand` is currently available as an early release, and we're actively seeking feedback from the community. Please join our [Slack community](https://join.slack.com/t/stagehand-dev/shared_invite/zt-2tdncfgkk-fF8y5U0uJzR2y2_M9c9OJA) to stay updated on the latest developments and provide feedback.
 
 ## Intro
@@ -63,12 +63,14 @@ npm install @browserbasehq/stagehand zod
 
 You'll need to provide your API Key for the model provider you'd like to use. The default model provider is OpenAI, but you can also use Anthropic or others. More information on supported models can be found in the [API Reference](#api-reference).
 
-Ensure that an OpenAI API Key or Anthropic API key is accessible in your local environment.
+Ensure that an OpenAI API Key or Anthropic API key is accessible in your local environment (only one is required).
 
 ```
 export OPENAI_API_KEY=sk-...
 export ANTHROPIC_API_KEY=sk-...
 ```
+
+NOTE: Stagehand client will default to openai if these are not specified
 
 ### 3. Create a Stagehand Instance
 
@@ -184,7 +186,7 @@ This constructor is used to create an instance of Stagehand.
 
 `init()` asynchronously initializes the Stagehand instance. It should be called before any other methods.
 
-> [!WARNING]  
+> [!WARNING]
 > Passing parameters to `init()` is deprecated and will be removed in the next major version. Use the constructor options instead.
 
 - **Arguments:**
@@ -278,7 +280,7 @@ This constructor is used to create an instance of Stagehand.
 
 #### `observe()`
 
-> [!NOTE]  
+> [!NOTE]
 > `observe()` currently only evaluates the first chunk in the page.
 
 `observe()` is used to get a list of actions that can be taken on the current page. It's useful for adding context to your planning step, or if you unsure of what page you're on.
@@ -480,7 +482,7 @@ You can see the roadmap [here](./ROADMAP.md). Looking to contribute? Read on!
 
 ## Contributing
 
-> [!NOTE]  
+> [!NOTE]
 > We highly value contributions to Stagehand! For support or code review, please join our [Slack community](https://join.slack.com/t/stagehand-dev/shared_invite/zt-2tdncfgkk-fF8y5U0uJzR2y2_M9c9OJA).
 
 First, clone the repo

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -32,7 +32,6 @@ import { logLineToString } from "./utils";
 
 dotenv.config({ path: ".env" });
 
-const DEFAULT_MODEL_NAME = "gpt-4o";
 const BROWSERBASE_REGION_DOMAIN = {
   "us-west-2": "wss://connect.usw2.browserbase.com",
   "us-east-1": "wss://connect.use1.browserbase.com",
@@ -361,7 +360,7 @@ export class Stagehand {
     this.verbose = verbose ?? 0;
     this.debugDom = debugDom ?? false;
     this.llmClient = this.llmProvider.getClient(
-      modelName ?? DEFAULT_MODEL_NAME,
+      modelName,
       modelClientOptions,
     );
     this.domSettleTimeoutMs = domSettleTimeoutMs ?? 30_000;


### PR DESCRIPTION
# why

I ran through the examples in the README and set the ANTHROPIC_API_KEY but the code yelled at me for OpenAI. I've added defaults to LLMProvider to check for the existence of API keys and added helpful error messages if api keys are not specified

# what changed

- if clientOption.apiKey is not set, then we check environment variables (OPENAI_API_KEY or ANTHROPIC_API_KEY) and if they do not exist we send a friendly error
- we default model in LLMProvider instead of Stagehand Constructor
- we default model to OpenAI unless there is an ANTHROPIC api key set. If there is, then we default to anthropic

# test plan

- Set ANTHROPIC_API_KEY (unset OPENAI_API_KEY) and run example. Code should init correctly
- Do not set any api keys and run example. Code should give error about openai api key
- Set `modelName` to 'anthropic` and do not set api keys. Code should give error about anthropic key
- Test that clientOptions for both openai and anthropic work correctly