### PR TITLE
Set stagehand env to "LOCAL" if we default to "LOCAL"

### DIFF
--- a/.changeset/tall-lies-nail.md
+++ b/.changeset/tall-lies-nail.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+bug fix: set this.env to LOCAL if BROWSERBASE_API_KEY is not defined

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -57,7 +57,7 @@ async function getBrowser(
           "BROWSERBASE_API_KEY is required to use BROWSERBASE env. Defaulting to LOCAL.",
         level: 0,
       });
-      env = "LOCAL";
+      this.env = "LOCAL";
     }
     if (!projectId) {
       logger({


### PR DESCRIPTION
# why
If the user sets env "BROWSERBASE" with no api key, we default to "LOCAL". This should modify the Stagehand object itself

# test plan
tested locally with no browserbase api key and `stagehand.env` was "LOCAL"