### PR TITLE
Only startDomDebug if it's enabled

### DIFF
--- a/.changeset/tall-pots-share.md
+++ b/.changeset/tall-pots-share.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+only start domdebug if enabled

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -110,36 +110,38 @@ export class StagehandPage {
   }
 
   public async startDomDebug() {
-    try {
-      await this.page
-        .evaluate(() => {
-          if (typeof window.debugDom === "function") {
-            window.debugDom();
-          } else {
-            this.stagehand.log({
-              category: "dom",
-              message: "debugDom is not defined",
-              level: 1,
-            });
-          }
-        })
-        .catch(() => {});
-    } catch (e) {
-      this.stagehand.log({
-        category: "dom",
-        message: "Error in startDomDebug",
-        level: 1,
-        auxiliary: {
-          error: {
-            value: e.message,
-            type: "string",
+    if (this.stagehand.debugDom) {
+      try {
+        await this.page
+          .evaluate(() => {
+            if (typeof window.debugDom === "function") {
+              window.debugDom();
+            } else {
+              this.stagehand.log({
+                category: "dom",
+                message: "debugDom is not defined",
+                level: 1,
+              });
+            }
+          })
+          .catch(() => {});
+      } catch (e) {
+        this.stagehand.log({
+          category: "dom",
+          message: "Error in startDomDebug",
+          level: 1,
+          auxiliary: {
+            error: {
+              value: e.message,
+              type: "string",
+            },
+            trace: {
+              value: e.stack,
+              type: "string",
+            },
           },
-          trace: {
-            value: e.stack,
-            type: "string",
-          },
-        },
-      });
+        });
+      }
     }
   }
 


### PR DESCRIPTION
# why
* DomDebug was being enabled even if it was disabled

# what changed
* Add a matching check just like cleanupDomDebug has

# test plan
* Tested locally