### PR TITLE
token usage tracking (Issue #268)

### DIFF
--- a/evals/deterministic/playwright.config.ts
+++ b/evals/deterministic/playwright.config.ts
@@ -1,4 +1,9 @@
 import { defineConfig, devices } from "@playwright/test";
+import dotenv from "dotenv";
+import path from "path";
+
+// Load environment variables from root .env file
+dotenv.config({ path: path.join(__dirname, "../../.env") });
 
 /**
  * See https://playwright.dev/docs/test-configuration.

--- a/evals/deterministic/tests/llm/tokenUsage.test.ts
+++ b/evals/deterministic/tests/llm/tokenUsage.test.ts
@@ -1,0 +1,98 @@
+import { test, expect } from "@playwright/test";
+import { z } from "zod";
+import { Stagehand } from "../../../../lib";
+import StagehandConfig from "../../stagehand.config";
+
+function logTokenUsage(functionName: string, entry: { promptTokens: number, completionTokens: number, totalTokens: number }) {
+  console.log(
+    `\n\x1b[1m${functionName} Token Usage:\x1b[0m
+    \x1b[36mPrompt Tokens:     ${entry.promptTokens.toString().padStart(6)}\x1b[0m
+    \x1b[32mCompletion Tokens: ${entry.completionTokens.toString().padStart(6)}\x1b[0m
+    \x1b[33mTotal Tokens:      ${entry.totalTokens.toString().padStart(6)}\x1b[0m`
+  );
+}
+
+test.describe("Token Usage Tracking", () => {
+  test.setTimeout(120000);
+
+  let stagehand: Stagehand;
+
+  test.beforeEach(async () => {
+    stagehand = new Stagehand(StagehandConfig);
+    await stagehand.init();
+  });
+
+  test.afterEach(async () => {
+    await stagehand.close();
+  });
+
+  // E-commerce scenarios
+  test("should track tokens when browsing Amazon product details", async () => {
+    const page = stagehand.page;
+    await page.goto("https://www.amazon.com/Hitchhikers-Guide-Galaxy-Douglas-Adams/dp/0345418913");
+    
+    // Extract product information
+    const schema = z.object({
+      productName: z.string(),
+      price: z.string(),
+      rating: z.string().optional(),
+    });
+    
+    await page.extract<typeof schema>({
+      instruction: "get the product name, current price, and rating from this product",
+      schema,
+      useVision: true
+    });
+    
+    const usage = stagehand.getUsage();
+    const extractEntry = usage.find(entry => entry.functionName === "extract");
+    if (extractEntry) {
+      logTokenUsage('AMAZON-PRODUCT-EXTRACT', extractEntry);
+    }
+  });
+
+  // News website scenarios
+  test("should track tokens when analyzing news articles", async () => {
+    const page = stagehand.page;
+    await page.goto("https://www.reuters.com");
+    
+    // Find and read main headline
+    await page.act({ 
+      action: "find the main headline article and summarize its key points in 3 sentences" 
+    });
+    
+    const usage = stagehand.getUsage();
+    const actEntry = usage.find(entry => entry.functionName === "act");
+    if (actEntry) {
+      logTokenUsage('REUTERS-SUMMARY-ACT', actEntry);
+    }
+  });
+
+  // Technical data extraction
+  test("should track tokens when parsing technical content", async () => {
+    const page = stagehand.page;
+    await page.goto("https://github.com/microsoft/TypeScript/blob/main/README.md");
+    
+    const schema = z.object({
+      installationSteps: z.array(z.string()),
+      requirements: z.array(z.string()),
+      documentation: z.object({
+        quickStart: z.string(),
+        handbook: z.string().optional(),
+        samples: z.array(z.string()).optional()
+      })
+    });
+    
+    await page.extract<typeof schema>({
+      instruction: "extract the installation steps, requirements, and documentation information from the TypeScript README",
+      schema,
+      useVision: false
+    });
+    
+    const usage = stagehand.getUsage();
+    const extractEntry = usage.find(entry => entry.functionName === "extract");
+    if (extractEntry) {
+      logTokenUsage('GITHUB-README-EXTRACT', extractEntry);
+    }
+  });
+});

--- a/evals/deterministic/tests/llm/tokenUsage.test.ts
+++ b/evals/deterministic/tests/llm/tokenUsage.test.ts
@@ -3,12 +3,19 @@ import { z } from "zod";
 import { Stagehand } from "../../../../lib";
 import StagehandConfig from "../../stagehand.config";
 
-function logTokenUsage(functionName: string, entry: { promptTokens: number, completionTokens: number, totalTokens: number }) {
+function logTokenUsage(
+  functionName: string,
+  entry: {
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+  },
+) {
   console.log(
     `\n\x1b[1m${functionName} Token Usage:\x1b[0m
     \x1b[36mPrompt Tokens:     ${entry.promptTokens.toString().padStart(6)}\x1b[0m
     \x1b[32mCompletion Tokens: ${entry.completionTokens.toString().padStart(6)}\x1b[0m
-    \x1b[33mTotal Tokens:      ${entry.totalTokens.toString().padStart(6)}\x1b[0m`
+    \x1b[33mTotal Tokens:      ${entry.totalTokens.toString().padStart(6)}\x1b[0m`,
   );
 }
 
@@ -29,25 +36,30 @@ test.describe("Token Usage Tracking", () => {
   // E-commerce scenarios
   test("should track tokens when browsing Amazon product details", async () => {
     const page = stagehand.page;
-    await page.goto("https://www.amazon.com/Hitchhikers-Guide-Galaxy-Douglas-Adams/dp/0345418913");
-    
+    await page.goto(
+      "https://www.amazon.com/Hitchhikers-Guide-Galaxy-Douglas-Adams/dp/0345418913",
+    );
+
     // Extract product information
     const schema = z.object({
       productName: z.string(),
       price: z.string(),
       rating: z.string().optional(),
     });
-    
+
     await page.extract<typeof schema>({
-      instruction: "get the product name, current price, and rating from this product",
+      instruction:
+        "get the product name, current price, and rating from this product",
       schema,
-      useVision: true
+      useVision: true,
     });
-    
+
     const usage = stagehand.getUsage();
-    const extractEntry = usage.find(entry => entry.functionName === "extract");
+    const extractEntry = usage.find(
+      (entry) => entry.functionName === "extract",
+    );
     if (extractEntry) {
-      logTokenUsage('AMAZON-PRODUCT-EXTRACT', extractEntry);
+      logTokenUsage("AMAZON-PRODUCT-EXTRACT", extractEntry);
     }
   });
 
@@ -55,44 +67,50 @@ test.describe("Token Usage Tracking", () => {
   test("should track tokens when analyzing news articles", async () => {
     const page = stagehand.page;
     await page.goto("https://www.reuters.com");
-    
+
     // Find and read main headline
-    await page.act({ 
-      action: "find the main headline article and summarize its key points in 3 sentences" 
+    await page.act({
+      action:
+        "find the main headline article and summarize its key points in 3 sentences",
     });
-    
+
     const usage = stagehand.getUsage();
-    const actEntry = usage.find(entry => entry.functionName === "act");
+    const actEntry = usage.find((entry) => entry.functionName === "act");
     if (actEntry) {
-      logTokenUsage('REUTERS-SUMMARY-ACT', actEntry);
+      logTokenUsage("REUTERS-SUMMARY-ACT", actEntry);
     }
   });
 
   // Technical data extraction
   test("should track tokens when parsing technical content", async () => {
     const page = stagehand.page;
-    await page.goto("https://github.com/microsoft/TypeScript/blob/main/README.md");
-    
+    await page.goto(
+      "https://github.com/microsoft/TypeScript/blob/main/README.md",
+    );
+
     const schema = z.object({
       installationSteps: z.array(z.string()),
       requirements: z.array(z.string()),
       documentation: z.object({
         quickStart: z.string(),
         handbook: z.string().optional(),
-        samples: z.array(z.string()).optional()
-      })
+        samples: z.array(z.string()).optional(),
+      }),
     });
-    
+
     await page.extract<typeof schema>({
-      instruction: "extract the installation steps, requirements, and documentation information from the TypeScript README",
+      instruction:
+        "extract the installation steps, requirements, and documentation information from the TypeScript README",
       schema,
-      useVision: false
+      useVision: false,
     });
-    
+
     const usage = stagehand.getUsage();
-    const extractEntry = usage.find(entry => entry.functionName === "extract");
+    const extractEntry = usage.find(
+      (entry) => entry.functionName === "extract",
+    );
     if (extractEntry) {
-      logTokenUsage('GITHUB-README-EXTRACT', extractEntry);
+      logTokenUsage("GITHUB-README-EXTRACT", extractEntry);
     }
   });
 });

--- a/evals/deterministic/tests/llm/tokenUsage.test.ts
+++ b/evals/deterministic/tests/llm/tokenUsage.test.ts
@@ -1,9 +1,23 @@
-import { test } from "@playwright/test";
+import { test, expect } from "@playwright/test";
 import { z } from "zod";
 import { Stagehand } from "../../../../lib";
 import StagehandConfig from "../../stagehand.config";
 
-// Token usage is now directly accessible via _stagehandTokenUsage property on returned objects
+function logTokenUsage(
+  functionName: string,
+  entry: {
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+  },
+) {
+  console.log(
+    `\n\x1b[1m${functionName} Token Usage:\x1b[0m
+    \x1b[36mPrompt Tokens:     ${entry.promptTokens.toString().padStart(6)}\x1b[0m
+    \x1b[32mCompletion Tokens: ${entry.completionTokens.toString().padStart(6)}\x1b[0m
+    \x1b[33mTotal Tokens:      ${entry.totalTokens.toString().padStart(6)}\x1b[0m`,
+  );
+}
 
 test.describe("Token Usage Tracking", () => {
   test.setTimeout(120000);
@@ -33,14 +47,20 @@ test.describe("Token Usage Tracking", () => {
       rating: z.string().optional(),
     });
 
-    const result = await page.extract<typeof schema>({
+    await page.extract<typeof schema>({
       instruction:
         "get the product name, current price, and rating from this product",
       schema,
       useVision: true,
     });
 
-    console.log("Token usage:", result._stagehandTokenUsage);
+    const usage = stagehand.getUsage();
+    const extractEntry = usage.find(
+      (entry) => entry.functionName === "extract",
+    );
+    if (extractEntry) {
+      logTokenUsage("AMAZON-PRODUCT-EXTRACT", extractEntry);
+    }
   });
 
   // News website scenarios
@@ -49,12 +69,16 @@ test.describe("Token Usage Tracking", () => {
     await page.goto("https://www.reuters.com");
 
     // Find and read main headline
-    const actResult = await page.act({
+    await page.act({
       action:
         "find the main headline article and summarize its key points in 3 sentences",
     });
 
-    console.log("Token usage:", actResult._stagehandTokenUsage);
+    const usage = stagehand.getUsage();
+    const actEntry = usage.find((entry) => entry.functionName === "act");
+    if (actEntry) {
+      logTokenUsage("REUTERS-SUMMARY-ACT", actEntry);
+    }
   });
 
   // Technical data extraction
@@ -74,13 +98,19 @@ test.describe("Token Usage Tracking", () => {
       }),
     });
 
-    const readmeResult = await page.extract<typeof schema>({
+    await page.extract<typeof schema>({
       instruction:
         "extract the installation steps, requirements, and documentation information from the TypeScript README",
       schema,
       useVision: false,
     });
 
-    console.log("Token usage:", readmeResult._stagehandTokenUsage);
+    const usage = stagehand.getUsage();
+    const extractEntry = usage.find(
+      (entry) => entry.functionName === "extract",
+    );
+    if (extractEntry) {
+      logTokenUsage("GITHUB-README-EXTRACT", extractEntry);
+    }
   });
 });

--- a/examples/hackernews.ts
+++ b/examples/hackernews.ts
@@ -1,0 +1,95 @@
+import { Stagehand } from "../lib";
+import { z } from "zod";
+
+function logTokenUsage(
+  functionName: string,
+  entry: {
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+  },
+) {
+  console.log(
+    `\n\x1b[1m${functionName} Token Usage:\x1b[0m
+    \x1b[36mPrompt Tokens:     ${entry.promptTokens.toString().padStart(6)}\x1b[0m
+    \x1b[32mCompletion Tokens: ${entry.completionTokens.toString().padStart(6)}\x1b[0m
+    \x1b[33mTotal Tokens:      ${entry.totalTokens.toString().padStart(6)}\x1b[0m`,
+  );
+}
+
+async function scrapeHackerNews() {
+  console.log("🚀 Starting Hacker News scraper...");
+  const stagehand = new Stagehand({
+    env: "LOCAL",
+    verbose: 2, // Maximum verbosity
+    debugDom: true,
+    enableCaching: false,
+    modelName: "gpt-4o",
+    headless: false,
+    modelClientOptions: {
+      apiKey: process.env.OPENAI_API_KEY,
+    },
+  });
+
+  try {
+    console.log("🌟 Initializing Stagehand...");
+    await stagehand.init();
+
+    console.log("🌐 Navigating to Hacker News...");
+    await stagehand.page.goto("https://news.ycombinator.com");
+
+    // Extract top article info
+    const schema = z.object({
+      title: z.string(),
+      url: z.string(),
+      points: z.string(),
+      comments: z.string().optional(),
+    });
+
+    console.log("📊 Extracting top article information...");
+    const topArticle = await stagehand.page.extract({
+      instruction:
+        "Extract the title, URL, points, and number of comments for the top (first) article on the page",
+      schema,
+      useVision: true,
+    });
+
+    // Log token usage for extraction
+    const extractUsage = stagehand.getUsage();
+    const extractEntry = extractUsage.find(
+      (entry) => entry.functionName === "extract",
+    );
+    if (extractEntry) {
+      logTokenUsage("HN-ARTICLE-EXTRACT", extractEntry);
+    }
+
+    console.log("\n📰 Top Article Details:", topArticle);
+
+    // Visit the article
+    console.log("\n🔗 Visiting article URL...");
+    await stagehand.page.goto(topArticle.url);
+
+    // Get article summary
+    console.log("📝 Generating article summary...");
+    const summaryResult = await stagehand.page.act({
+      action: "Read the main content and provide a concise 3-sentence summary",
+    });
+
+    // Log token usage for summary
+    const summaryUsage = stagehand.getUsage();
+    const actEntry = summaryUsage.find((entry) => entry.functionName === "act");
+    if (actEntry) {
+      logTokenUsage("HN-ARTICLE-SUMMARY", actEntry);
+    }
+
+    console.log("\n📋 Summary:", summaryResult);
+
+    // Log total token usage
+    console.log("\n💰 Total Tokens Used:", stagehand.getTotalTokensUsed());
+  } finally {
+    await stagehand.close();
+  }
+}
+
+// Run the script
+scrapeHackerNews().catch(console.error);

--- a/examples/hackernews.ts
+++ b/examples/hackernews.ts
@@ -1,7 +1,21 @@
 import { Stagehand } from "../lib";
 import { z } from "zod";
 
-// Token usage is now directly accessible via _stagehandTokenUsage property on returned objects
+function logTokenUsage(
+  functionName: string,
+  entry: {
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+  },
+) {
+  console.log(
+    `\n\x1b[1m${functionName} Token Usage:\x1b[0m
+    \x1b[36mPrompt Tokens:     ${entry.promptTokens.toString().padStart(6)}\x1b[0m
+    \x1b[32mCompletion Tokens: ${entry.completionTokens.toString().padStart(6)}\x1b[0m
+    \x1b[33mTotal Tokens:      ${entry.totalTokens.toString().padStart(6)}\x1b[0m`,
+  );
+}
 
 async function scrapeHackerNews() {
   console.log("🚀 Starting Hacker News scraper...");
@@ -41,7 +55,13 @@ async function scrapeHackerNews() {
     });
 
     // Log token usage for extraction
-    console.log("Token usage for extract:", topArticle._stagehandTokenUsage);
+    const extractUsage = stagehand.getUsage();
+    const extractEntry = extractUsage.find(
+      (entry) => entry.functionName === "extract",
+    );
+    if (extractEntry) {
+      logTokenUsage("HN-ARTICLE-EXTRACT", extractEntry);
+    }
 
     console.log("\n📰 Top Article Details:", topArticle);
 
@@ -56,7 +76,11 @@ async function scrapeHackerNews() {
     });
 
     // Log token usage for summary
-    console.log("Token usage for summary:", summaryResult._stagehandTokenUsage);
+    const summaryUsage = stagehand.getUsage();
+    const actEntry = summaryUsage.find((entry) => entry.functionName === "act");
+    if (actEntry) {
+      logTokenUsage("HN-ARTICLE-SUMMARY", actEntry);
+    }
 
     console.log("\n📋 Summary:", summaryResult);
 

--- a/examples/hackernews.ts
+++ b/examples/hackernews.ts
@@ -1,21 +1,7 @@
 import { Stagehand } from "../lib";
 import { z } from "zod";
 
-function logTokenUsage(
-  functionName: string,
-  entry: {
-    promptTokens: number;
-    completionTokens: number;
-    totalTokens: number;
-  },
-) {
-  console.log(
-    `\n\x1b[1m${functionName} Token Usage:\x1b[0m
-    \x1b[36mPrompt Tokens:     ${entry.promptTokens.toString().padStart(6)}\x1b[0m
-    \x1b[32mCompletion Tokens: ${entry.completionTokens.toString().padStart(6)}\x1b[0m
-    \x1b[33mTotal Tokens:      ${entry.totalTokens.toString().padStart(6)}\x1b[0m`,
-  );
-}
+// Token usage is now directly accessible via _stagehandTokenUsage property on returned objects
 
 async function scrapeHackerNews() {
   console.log("🚀 Starting Hacker News scraper...");
@@ -55,13 +41,7 @@ async function scrapeHackerNews() {
     });
 
     // Log token usage for extraction
-    const extractUsage = stagehand.getUsage();
-    const extractEntry = extractUsage.find(
-      (entry) => entry.functionName === "extract",
-    );
-    if (extractEntry) {
-      logTokenUsage("HN-ARTICLE-EXTRACT", extractEntry);
-    }
+    console.log("Token usage for extract:", topArticle._stagehandTokenUsage);
 
     console.log("\n📰 Top Article Details:", topArticle);
 
@@ -76,11 +56,7 @@ async function scrapeHackerNews() {
     });
 
     // Log token usage for summary
-    const summaryUsage = stagehand.getUsage();
-    const actEntry = summaryUsage.find((entry) => entry.functionName === "act");
-    if (actEntry) {
-      logTokenUsage("HN-ARTICLE-SUMMARY", actEntry);
-    }
+    console.log("Token usage for summary:", summaryResult._stagehandTokenUsage);
 
     console.log("\n📋 Summary:", summaryResult);
 

--- a/examples/hackernews.ts
+++ b/examples/hackernews.ts
@@ -1,22 +1,6 @@
 import { Stagehand } from "../lib";
 import { z } from "zod";
 
-function logTokenUsage(
-  functionName: string,
-  entry: {
-    promptTokens: number;
-    completionTokens: number;
-    totalTokens: number;
-  },
-) {
-  console.log(
-    `\n\x1b[1m${functionName} Token Usage:\x1b[0m
-    \x1b[36mPrompt Tokens:     ${entry.promptTokens.toString().padStart(6)}\x1b[0m
-    \x1b[32mCompletion Tokens: ${entry.completionTokens.toString().padStart(6)}\x1b[0m
-    \x1b[33mTotal Tokens:      ${entry.totalTokens.toString().padStart(6)}\x1b[0m`,
-  );
-}
-
 async function scrapeHackerNews() {
   console.log("🚀 Starting Hacker News scraper...");
   const stagehand = new Stagehand({
@@ -25,7 +9,7 @@ async function scrapeHackerNews() {
     debugDom: true,
     enableCaching: false,
     modelName: "gpt-4o",
-    headless: false,
+    headless: process.env.HEADLESS === "true",
     modelClientOptions: {
       apiKey: process.env.OPENAI_API_KEY,
     },
@@ -55,37 +39,16 @@ async function scrapeHackerNews() {
     });
 
     // Log token usage for extraction
-    const extractUsage = stagehand.getUsage();
-    const extractEntry = extractUsage.find(
-      (entry) => entry.functionName === "extract",
-    );
-    if (extractEntry) {
-      logTokenUsage("HN-ARTICLE-EXTRACT", extractEntry);
+    if (topArticle._stagehandTokenUsage) {
+      console.log(
+        `\n\x1b[1mHN-ARTICLE-EXTRACT Token Usage:\x1b[0m
+        \x1b[36mPrompt Tokens:     ${topArticle._stagehandTokenUsage.promptTokens.toString().padStart(6)}\x1b[0m
+        \x1b[32mCompletion Tokens: ${topArticle._stagehandTokenUsage.completionTokens.toString().padStart(6)}\x1b[0m
+        \x1b[33mTotal Tokens:      ${topArticle._stagehandTokenUsage.totalTokens.toString().padStart(6)}\x1b[0m`,
+      );
     }
 
     console.log("\n📰 Top Article Details:", topArticle);
-
-    // Visit the article
-    console.log("\n🔗 Visiting article URL...");
-    await stagehand.page.goto(topArticle.url);
-
-    // Get article summary
-    console.log("📝 Generating article summary...");
-    const summaryResult = await stagehand.page.act({
-      action: "Read the main content and provide a concise 3-sentence summary",
-    });
-
-    // Log token usage for summary
-    const summaryUsage = stagehand.getUsage();
-    const actEntry = summaryUsage.find((entry) => entry.functionName === "act");
-    if (actEntry) {
-      logTokenUsage("HN-ARTICLE-SUMMARY", actEntry);
-    }
-
-    console.log("\n📋 Summary:", summaryResult);
-
-    // Log total token usage
-    console.log("\n💰 Total Tokens Used:", stagehand.getTotalTokensUsed());
   } finally {
     await stagehand.close();
   }

--- a/lib/handlers/actHandler.ts
+++ b/lib/handlers/actHandler.ts
@@ -1211,10 +1211,19 @@ export class StagehandActHandler {
             this.actionCache?.deleteCacheForRequestId(requestId);
           }
 
+          const usageForThisCall = this.stagehand
+            .getUsage()
+            .find(
+              (entry) =>
+                entry.functionName === functionName ||
+                entry.functionName === "act",
+            );
+
           return {
             success: false,
             message: `Action was not able to be completed.`,
             action: action,
+            _stagehandTokenUsage: usageForThisCall,
           };
         }
       }

--- a/lib/handlers/actHandler.ts
+++ b/lib/handlers/actHandler.ts
@@ -1211,19 +1211,10 @@ export class StagehandActHandler {
             this.actionCache?.deleteCacheForRequestId(requestId);
           }
 
-          const usageForThisCall = this.stagehand
-            .getUsage()
-            .find(
-              (entry) =>
-                entry.functionName === functionName ||
-                entry.functionName === "act",
-            );
-
           return {
             success: false,
             message: `Action was not able to be completed.`,
             action: action,
-            _stagehandTokenUsage: usageForThisCall,
           };
         }
       }

--- a/lib/handlers/extractHandler.ts
+++ b/lib/handlers/extractHandler.ts
@@ -355,7 +355,18 @@ export class StagehandExtractHandler {
         },
       });
     }
-    return output;
+    const usageForThisCall = this.stagehand
+      .getUsage()
+      .find(
+        (entry) =>
+          entry.functionName === functionName ||
+          entry.functionName === "extract",
+      );
+
+    return {
+      ...output,
+      _stagehandTokenUsage: usageForThisCall,
+    };
   }
 
   private async domExtract<T extends z.AnyZodObject>({
@@ -478,7 +489,18 @@ export class StagehandExtractHandler {
         },
       });
 
-      return output;
+      const usageForThisCall = this.stagehand
+        .getUsage()
+        .find(
+          (entry) =>
+            entry.functionName === functionName ||
+            entry.functionName === "extract",
+        );
+
+      return {
+        ...output,
+        _stagehandTokenUsage: usageForThisCall,
+      };
     } else {
       this.logger({
         category: "extraction",

--- a/lib/handlers/extractHandler.ts
+++ b/lib/handlers/extractHandler.ts
@@ -355,18 +355,7 @@ export class StagehandExtractHandler {
         },
       });
     }
-    const usageForThisCall = this.stagehand
-      .getUsage()
-      .find(
-        (entry) =>
-          entry.functionName === functionName ||
-          entry.functionName === "extract",
-      );
-
-    return {
-      ...output,
-      _stagehandTokenUsage: usageForThisCall,
-    };
+    return output;
   }
 
   private async domExtract<T extends z.AnyZodObject>({
@@ -489,18 +478,7 @@ export class StagehandExtractHandler {
         },
       });
 
-      const usageForThisCall = this.stagehand
-        .getUsage()
-        .find(
-          (entry) =>
-            entry.functionName === functionName ||
-            entry.functionName === "extract",
-        );
-
-      return {
-        ...output,
-        _stagehandTokenUsage: usageForThisCall,
-      };
+      return output;
     } else {
       this.logger({
         category: "extraction",

--- a/lib/handlers/extractHandler.ts
+++ b/lib/handlers/extractHandler.ts
@@ -130,6 +130,7 @@ export class StagehandExtractHandler {
         llmClient,
         requestId,
         domSettleTimeoutMs,
+        functionName: "extract",
       });
     } else {
       return this.domExtract({
@@ -140,6 +141,7 @@ export class StagehandExtractHandler {
         llmClient,
         requestId,
         domSettleTimeoutMs,
+        functionName: "extract",
       });
     }
   }
@@ -151,6 +153,7 @@ export class StagehandExtractHandler {
     llmClient,
     requestId,
     domSettleTimeoutMs,
+    functionName,
   }: {
     instruction: string;
     schema: T;
@@ -158,6 +161,7 @@ export class StagehandExtractHandler {
     llmClient: LLMClient;
     requestId?: string;
     domSettleTimeoutMs?: number;
+    functionName?: string;
   }): Promise<z.infer<T>> {
     this.logger({
       category: "extraction",
@@ -362,6 +366,7 @@ export class StagehandExtractHandler {
     llmClient,
     requestId,
     domSettleTimeoutMs,
+    functionName,
   }: {
     instruction: string;
     schema: T;
@@ -370,6 +375,7 @@ export class StagehandExtractHandler {
     llmClient: LLMClient;
     requestId?: string;
     domSettleTimeoutMs?: number;
+    functionName?: string;
   }): Promise<z.infer<T>> {
     this.logger({
       category: "extraction",

--- a/lib/handlers/observeHandler.ts
+++ b/lib/handlers/observeHandler.ts
@@ -151,18 +151,6 @@ export class StagehandObserveHandler {
     });
 
     await this._recordObservation(instruction, elementsWithSelectors);
-
-    const usageForThisCall = this.stagehand
-      .getUsage()
-      .find(
-        (entry) =>
-          entry.functionName === functionName ||
-          entry.functionName === "observe",
-      );
-
-    return {
-      elements: elementsWithSelectors,
-      _stagehandTokenUsage: usageForThisCall,
-    };
+    return elementsWithSelectors;
   }
 }

--- a/lib/handlers/observeHandler.ts
+++ b/lib/handlers/observeHandler.ts
@@ -151,6 +151,18 @@ export class StagehandObserveHandler {
     });
 
     await this._recordObservation(instruction, elementsWithSelectors);
-    return elementsWithSelectors;
+
+    const usageForThisCall = this.stagehand
+      .getUsage()
+      .find(
+        (entry) =>
+          entry.functionName === functionName ||
+          entry.functionName === "observe",
+      );
+
+    return {
+      elements: elementsWithSelectors,
+      _stagehandTokenUsage: usageForThisCall,
+    };
   }
 }

--- a/lib/handlers/observeHandler.ts
+++ b/lib/handlers/observeHandler.ts
@@ -51,6 +51,7 @@ export class StagehandObserveHandler {
     llmClient,
     requestId,
     domSettleTimeoutMs,
+    functionName = "observe",
   }: {
     instruction: string;
     useVision: boolean;
@@ -58,6 +59,7 @@ export class StagehandObserveHandler {
     llmClient: LLMClient;
     requestId?: string;
     domSettleTimeoutMs?: number;
+    functionName?: string;
   }): Promise<{ selector: string; description: string }[]> {
     if (!instruction) {
       instruction = `Find elements that can be used for any future actions in the page. These may be navigation links, related pages, section/subsection links, buttons, or other interactive elements. Be comprehensive: if there are multiple elements that may be relevant for future actions, return all of them.`;
@@ -120,6 +122,7 @@ export class StagehandObserveHandler {
       llmClient,
       image: annotatedScreenshot,
       requestId,
+      functionName: "observe",
     });
 
     const elementsWithSelectors = observationResponse.elements.map(

--- a/lib/inference.ts
+++ b/lib/inference.ts
@@ -58,6 +58,7 @@ export async function verifyActCompletion({
       name: "Verification",
       schema: verificationSchema,
     },
+    functionName: "verify_act",
     requestId,
   });
 
@@ -119,6 +120,7 @@ export async function act({
     image: screenshot
       ? { buffer: screenshot, description: AnnotatedScreenshotText }
       : undefined,
+    functionName: "act",
     requestId,
   });
 
@@ -189,6 +191,7 @@ export async function extract({
     top_p: 1,
     frequency_penalty: 0,
     presence_penalty: 0,
+    functionName: "extract",
     requestId,
   });
 
@@ -210,6 +213,7 @@ export async function extract({
       top_p: 1,
       frequency_penalty: 0,
       presence_penalty: 0,
+      functionName: "refine_extract",
       requestId,
     });
 
@@ -245,6 +249,7 @@ export async function extract({
       top_p: 1,
       frequency_penalty: 0,
       presence_penalty: 0,
+      functionName: "metadata_extract",
       requestId,
     });
 
@@ -260,12 +265,14 @@ export async function observe({
   llmClient,
   image,
   requestId,
+  functionName = "observe",
 }: {
   instruction: string;
   domElements: string;
   llmClient: LLMClient;
   image?: Buffer;
   requestId: string;
+  functionName?: string;
 }): Promise<{
   elements: { elementId: number; description: string }[];
 }> {
@@ -303,6 +310,7 @@ export async function observe({
       top_p: 1,
       frequency_penalty: 0,
       presence_penalty: 0,
+      functionName: "observe",
       requestId,
     });
 
@@ -332,6 +340,7 @@ export async function ask({
     top_p: 1,
     frequency_penalty: 0,
     presence_penalty: 0,
+    functionName: "ask",
     requestId,
   });
 

--- a/lib/llm/AnthropicClient.ts
+++ b/lib/llm/AnthropicClient.ts
@@ -311,7 +311,7 @@ export class AnthropicClient extends LLMClient {
         this.modelName,
         prompt,
         completion,
-        total
+        total,
       );
     }
 

--- a/lib/llm/AnthropicClient.ts
+++ b/lib/llm/AnthropicClient.ts
@@ -283,6 +283,14 @@ export class AnthropicClient extends LLMClient {
         total_tokens:
           response.usage.input_tokens + response.usage.output_tokens,
       },
+      _stagehandTokenUsage: {
+        functionName: options.functionName || "unknown",
+        modelName: this.modelName,
+        promptTokens: response.usage.input_tokens,
+        completionTokens: response.usage.output_tokens,
+        totalTokens: response.usage.input_tokens + response.usage.output_tokens,
+        timestamp: Date.now(),
+      },
     };
 
     this.logger({
@@ -311,7 +319,7 @@ export class AnthropicClient extends LLMClient {
         this.modelName,
         prompt,
         completion,
-        total
+        total,
       );
     }
 

--- a/lib/llm/AnthropicClient.ts
+++ b/lib/llm/AnthropicClient.ts
@@ -311,7 +311,7 @@ export class AnthropicClient extends LLMClient {
         this.modelName,
         prompt,
         completion,
-        total,
+        total
       );
     }
 

--- a/lib/llm/LLMClient.ts
+++ b/lib/llm/LLMClient.ts
@@ -60,6 +60,7 @@ export interface ChatCompletionOptions {
   tool_choice?: "auto" | ChatCompletionToolChoiceOption;
   maxTokens?: number;
   requestId: string;
+  functionName?: string;
 }
 
 export type LLMResponse = AnthropicTransformedResponse | ChatCompletion;

--- a/lib/llm/LLMClient.ts
+++ b/lib/llm/LLMClient.ts
@@ -7,6 +7,7 @@ import {
   AnthropicTransformedResponse,
   AvailableModel,
   ClientOptions,
+  LLMUsageEntry,
   ToolCall,
 } from "../../types/model";
 
@@ -63,7 +64,9 @@ export interface ChatCompletionOptions {
   functionName?: string;
 }
 
-export type LLMResponse = AnthropicTransformedResponse | ChatCompletion;
+export type LLMResponse = (AnthropicTransformedResponse | ChatCompletion) & {
+  _stagehandTokenUsage?: LLMUsageEntry;
+};
 
 export abstract class LLMClient {
   public type: "openai" | "anthropic";

--- a/lib/llm/LLMProvider.ts
+++ b/lib/llm/LLMProvider.ts
@@ -53,6 +53,7 @@ export class LLMProvider {
   getClient(
     modelName: AvailableModel,
     clientOptions?: ClientOptions,
+    stagehand?: any,
   ): LLMClient {
     const provider = this.modelToProviderMap[modelName];
     if (!provider) {
@@ -67,6 +68,7 @@ export class LLMProvider {
           this.cache,
           modelName,
           clientOptions,
+          stagehand,
         );
       case "anthropic":
         return new AnthropicClient(
@@ -75,6 +77,7 @@ export class LLMProvider {
           this.cache,
           modelName,
           clientOptions,
+          stagehand,
         );
       default:
         throw new Error(`Unsupported provider: ${provider}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "@browserbasehq/stagehand",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@browserbasehq/stagehand",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.27.3",
         "@browserbasehq/sdk": "^2.0.0",
         "sharp": "^0.33.5",
+        "ws": "^8.18.0",
         "zod-to-json-schema": "^3.23.5"
       },
       "devDependencies": {

--- a/types/act.ts
+++ b/types/act.ts
@@ -13,9 +13,7 @@ export interface ActParams {
   variables?: Record<string, string>;
 }
 
-import { WithTokenUsage } from "./tokenUsage";
-
-export interface ActResult extends WithTokenUsage {
+export interface ActResult {
   method: string;
   element: number;
   args: unknown[];

--- a/types/act.ts
+++ b/types/act.ts
@@ -13,7 +13,9 @@ export interface ActParams {
   variables?: Record<string, string>;
 }
 
-export interface ActResult {
+import { WithTokenUsage } from "./tokenUsage";
+
+export interface ActResult extends WithTokenUsage {
   method: string;
   element: number;
   args: unknown[];

--- a/types/act.ts
+++ b/types/act.ts
@@ -1,5 +1,6 @@
 import { Buffer } from "buffer";
 import { LLMClient } from "../lib/llm/LLMClient";
+import { TokenUsageResult } from "./tokenUsage";
 
 export interface ActParams {
   action: string;
@@ -13,11 +14,14 @@ export interface ActParams {
   variables?: Record<string, string>;
 }
 
-export interface ActResult {
+export interface ActResult extends TokenUsageResult {
   method: string;
   element: number;
   args: unknown[];
   completed: boolean;
   step: string;
   why?: string;
+  success?: boolean;
+  message?: string;
+  action?: string;
 }

--- a/types/model.ts
+++ b/types/model.ts
@@ -48,6 +48,7 @@ export type AnthropicTransformedResponse = {
     completion_tokens: number;
     total_tokens: number;
   };
+  _stagehandTokenUsage?: LLMUsageEntry;
 };
 
 export interface AnthropicJsonSchemaObject {
@@ -59,10 +60,10 @@ export interface AnthropicJsonSchemaObject {
 }
 
 export interface LLMUsageEntry {
-  functionName: string;     // e.g. "act", "extract", "observe"
-  modelName: string;        // e.g. "gpt-4o", "claude-3-5-sonnet-2024..."
-  promptTokens: number;     // input/prompt tokens used
+  functionName: string; // e.g. "act", "extract", "observe"
+  modelName: string; // e.g. "gpt-4o", "claude-3-5-sonnet-2024..."
+  promptTokens: number; // input/prompt tokens used
   completionTokens: number; // output/completion tokens used
-  totalTokens: number;      // total tokens for the call
-  timestamp: number;        // Date.now() timestamp
+  totalTokens: number; // total tokens for the call
+  timestamp: number; // Date.now() timestamp
 }

--- a/types/model.ts
+++ b/types/model.ts
@@ -59,10 +59,10 @@ export interface AnthropicJsonSchemaObject {
 }
 
 export interface LLMUsageEntry {
-  functionName: string; // e.g. "act", "extract", "observe"
-  modelName: string; // e.g. "gpt-4o", "claude-3-5-sonnet-2024..."
-  promptTokens: number; // input/prompt tokens used
+  functionName: string;     // e.g. "act", "extract", "observe"
+  modelName: string;        // e.g. "gpt-4o", "claude-3-5-sonnet-2024..."
+  promptTokens: number;     // input/prompt tokens used
   completionTokens: number; // output/completion tokens used
-  totalTokens: number; // total tokens for the call
-  timestamp: number; // Date.now() timestamp
+  totalTokens: number;      // total tokens for the call
+  timestamp: number;        // Date.now() timestamp
 }

--- a/types/model.ts
+++ b/types/model.ts
@@ -57,3 +57,12 @@ export interface AnthropicJsonSchemaObject {
   properties?: Record<string, unknown>;
   required?: string[];
 }
+
+export interface LLMUsageEntry {
+  functionName: string;     // e.g. "act", "extract", "observe"
+  modelName: string;        // e.g. "gpt-4o", "claude-3-5-sonnet-2024..."
+  promptTokens: number;     // input/prompt tokens used
+  completionTokens: number; // output/completion tokens used
+  totalTokens: number;      // total tokens for the call
+  timestamp: number;        // Date.now() timestamp
+}

--- a/types/model.ts
+++ b/types/model.ts
@@ -59,10 +59,10 @@ export interface AnthropicJsonSchemaObject {
 }
 
 export interface LLMUsageEntry {
-  functionName: string;     // e.g. "act", "extract", "observe"
-  modelName: string;        // e.g. "gpt-4o", "claude-3-5-sonnet-2024..."
-  promptTokens: number;     // input/prompt tokens used
+  functionName: string; // e.g. "act", "extract", "observe"
+  modelName: string; // e.g. "gpt-4o", "claude-3-5-sonnet-2024..."
+  promptTokens: number; // input/prompt tokens used
   completionTokens: number; // output/completion tokens used
-  totalTokens: number;      // total tokens for the call
-  timestamp: number;        // Date.now() timestamp
+  totalTokens: number; // total tokens for the call
+  timestamp: number; // Date.now() timestamp
 }

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -58,7 +58,9 @@ export interface ActOptions {
   domSettleTimeoutMs?: number;
 }
 
-export interface ActResult {
+import { WithTokenUsage } from "./tokenUsage";
+
+export interface ActResult extends WithTokenUsage {
   success: boolean;
   message: string;
   action: string;
@@ -74,7 +76,8 @@ export interface ExtractOptions<T extends z.AnyZodObject> {
   useVision?: boolean;
 }
 
-export type ExtractResult<T extends z.AnyZodObject> = z.infer<T>;
+export type ExtractResult<T extends z.AnyZodObject> = z.infer<T> &
+  WithTokenUsage;
 
 export interface ObserveOptions {
   instruction?: string;
@@ -85,7 +88,7 @@ export interface ObserveOptions {
   functionName?: string;
 }
 
-export interface ObserveResult {
+export interface ObserveResult extends WithTokenUsage {
   selector: string;
   description: string;
 }

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { LLMProvider } from "../lib/llm/LLMProvider";
 import { LogLine } from "./log";
 import { AvailableModel, ClientOptions } from "./model";
+import { TokenUsageResult } from "./tokenUsage";
 
 export interface ConstructorParams {
   env: "LOCAL" | "BROWSERBASE";
@@ -58,7 +59,7 @@ export interface ActOptions {
   domSettleTimeoutMs?: number;
 }
 
-export interface ActResult {
+export interface ActResult extends TokenUsageResult {
   success: boolean;
   message: string;
   action: string;
@@ -74,7 +75,8 @@ export interface ExtractOptions<T extends z.AnyZodObject> {
   useVision?: boolean;
 }
 
-export type ExtractResult<T extends z.AnyZodObject> = z.infer<T>;
+export type ExtractResult<T extends z.AnyZodObject> = z.infer<T> &
+  TokenUsageResult;
 
 export interface ObserveOptions {
   instruction?: string;
@@ -85,7 +87,7 @@ export interface ObserveOptions {
   functionName?: string;
 }
 
-export interface ObserveResult {
+export interface ObserveResult extends TokenUsageResult {
   selector: string;
   description: string;
 }

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -71,6 +71,7 @@ export interface ExtractOptions<T extends z.AnyZodObject> {
   modelClientOptions?: ClientOptions;
   domSettleTimeoutMs?: number;
   useTextExtract?: boolean;
+  useVision?: boolean;
 }
 
 export type ExtractResult<T extends z.AnyZodObject> = z.infer<T>;
@@ -81,6 +82,7 @@ export interface ObserveOptions {
   modelClientOptions?: ClientOptions;
   useVision?: boolean;
   domSettleTimeoutMs?: number;
+  functionName?: string;
 }
 
 export interface ObserveResult {

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -58,9 +58,7 @@ export interface ActOptions {
   domSettleTimeoutMs?: number;
 }
 
-import { WithTokenUsage } from "./tokenUsage";
-
-export interface ActResult extends WithTokenUsage {
+export interface ActResult {
   success: boolean;
   message: string;
   action: string;
@@ -76,8 +74,7 @@ export interface ExtractOptions<T extends z.AnyZodObject> {
   useVision?: boolean;
 }
 
-export type ExtractResult<T extends z.AnyZodObject> = z.infer<T> &
-  WithTokenUsage;
+export type ExtractResult<T extends z.AnyZodObject> = z.infer<T>;
 
 export interface ObserveOptions {
   instruction?: string;
@@ -88,7 +85,7 @@ export interface ObserveOptions {
   functionName?: string;
 }
 
-export interface ObserveResult extends WithTokenUsage {
+export interface ObserveResult {
   selector: string;
   description: string;
 }

--- a/types/tokenUsage.ts
+++ b/types/tokenUsage.ts
@@ -1,0 +1,5 @@
+import { LLMUsageEntry } from "./model";
+
+export interface WithTokenUsage {
+  _stagehandTokenUsage?: LLMUsageEntry;
+}

--- a/types/tokenUsage.ts
+++ b/types/tokenUsage.ts
@@ -1,0 +1,12 @@
+export interface TokenUsage {
+  functionName: string;
+  modelName: string;
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  timestamp: number;
+}
+
+export interface TokenUsageResult {
+  _stagehandTokenUsage?: TokenUsage;
+}

--- a/types/tokenUsage.ts
+++ b/types/tokenUsage.ts
@@ -1,5 +1,0 @@
-import { LLMUsageEntry } from "./model";
-
-export interface WithTokenUsage {
-  _stagehandTokenUsage?: LLMUsageEntry;
-}


### PR DESCRIPTION
# why
being able to track input/output/total tokens when using stagehand can be helpful for controlling costs, picking which model to use, etc.

See Issue #268 (https://github.com/browserbase/stagehand/issues/268)

# what changed
- Added LLMUsageEntry interface to track tokens per function call
- Implemented usage recording in OpenAI and Anthropic clients
- Added recordUsage() and getUsage() methods to Stagehand class
- Added getTotalTokensUsed() for aggregating total token usage

Works for act(), observe(), and extract()
12 files edited, added tests and and example (hackernews.ts) demonstrating how to log tokens used. Please see diff

# test plan
i wrote a few test cases and it seems to work but someone on the browserbase team should definitely test as well before merging!