### PR TITLE
Remove duplicate logging and export page/context types

### DIFF
--- a/.changeset/tender-years-crash.md
+++ b/.changeset/tender-years-crash.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Remove duplicate logging and expose Page/BrowserContext types

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,5 @@
 import { Browserbase } from "@browserbasehq/sdk";
-import { type BrowserContext, chromium } from "@playwright/test";
+import { chromium } from "@playwright/test";
 import { randomUUID } from "crypto";
 import dotenv from "dotenv";
 import fs from "fs";
@@ -9,7 +9,7 @@ import { z } from "zod";
 import { BrowserResult } from "../types/browser";
 import { LogLine } from "../types/log";
 import { GotoOptions } from "../types/playwright";
-import { Page } from "../types/page";
+import { Page, BrowserContext } from "../types/page";
 import {
   ActOptions,
   ActResult,
@@ -303,6 +303,10 @@ async function applyStealthScripts(context: BrowserContext) {
   });
 }
 
+const defaultLogger = async (logLine: LogLine) => {
+  console.log(logLineToString(logLine));
+};
+
 export class Stagehand {
   private stagehandPage!: StagehandPage;
   private stagehandContext!: StagehandContext;
@@ -319,7 +323,8 @@ export class Stagehand {
   private internalLogger: (logLine: LogLine) => void;
   private apiKey: string | undefined;
   private projectId: string | undefined;
-  private externalLogger?: (logLine: LogLine) => void;
+  // We want external logger to accept async functions
+  private externalLogger?: (logLine: LogLine) => void | Promise<void>;
   private browserbaseSessionCreateParams?: Browserbase.Sessions.SessionCreateParams;
   public variables: { [key: string]: unknown };
   private contextPath?: string;
@@ -348,7 +353,7 @@ export class Stagehand {
       env: "BROWSERBASE",
     },
   ) {
-    this.externalLogger = logger;
+    this.externalLogger = logger || defaultLogger;
     this.internalLogger = this.log.bind(this);
     this.enableCaching =
       enableCaching ??
@@ -504,9 +509,6 @@ export class Stagehand {
     // Normal Logging
     if (this.externalLogger) {
       this.externalLogger(logObj);
-    } else {
-      const logMessage = logLineToString(logObj);
-      console.log(logMessage);
     }
 
     // Add the logs to the browserbase session
@@ -613,3 +615,4 @@ export * from "../types/log";
 export * from "../types/model";
 export * from "../types/playwright";
 export * from "../types/stagehand";
+export * from "../types/page";

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -297,8 +297,8 @@ async function applyStealthScripts(context: BrowserContext) {
     window.navigator.permissions.query = (parameters) =>
       parameters.name === "notifications"
         ? Promise.resolve({
-          state: Notification.permission,
-        } as PermissionStatus)
+            state: Notification.permission,
+          } as PermissionStatus)
         : originalQuery(parameters);
   });
 }
@@ -350,8 +350,8 @@ export class Stagehand {
       modelName,
       modelClientOptions,
     }: ConstructorParams = {
-        env: "BROWSERBASE",
-      },
+      env: "BROWSERBASE",
+    },
   ) {
     this.externalLogger = logger || defaultLogger;
     this.internalLogger = this.log.bind(this);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -297,8 +297,8 @@ async function applyStealthScripts(context: BrowserContext) {
     window.navigator.permissions.query = (parameters) =>
       parameters.name === "notifications"
         ? Promise.resolve({
-            state: Notification.permission,
-          } as PermissionStatus)
+          state: Notification.permission,
+        } as PermissionStatus)
         : originalQuery(parameters);
   });
 }
@@ -350,8 +350,8 @@ export class Stagehand {
       modelName,
       modelClientOptions,
     }: ConstructorParams = {
-      env: "BROWSERBASE",
-    },
+        env: "BROWSERBASE",
+      },
   ) {
     this.externalLogger = logger || defaultLogger;
     this.internalLogger = this.log.bind(this);
@@ -377,10 +377,7 @@ export class Stagehand {
 
   public get logger(): (logLine: LogLine) => void {
     return (logLine: LogLine) => {
-      this.internalLogger(logLine);
-      if (this.externalLogger) {
-        this.externalLogger(logLine);
-      }
+      this.log(logLine);
     };
   }
 

--- a/types/page.ts
+++ b/types/page.ts
@@ -1,4 +1,5 @@
 import type { Page as PlaywrightPage } from "@playwright/test";
+import type { BrowserContext as PlaywrightContext } from "@playwright/test";
 import type { ActResult } from "./act";
 import type {
   ActOptions,
@@ -15,3 +16,6 @@ export interface Page extends PlaywrightPage {
   ) => Promise<ExtractResult<T>>;
   observe: (options?: ObserveOptions) => Promise<ObserveResult[]>;
 }
+
+// Empty type for now, but will be used in the future
+export type BrowserContext = PlaywrightContext;

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -13,7 +13,7 @@ export interface ConstructorParams {
   debugDom?: boolean;
   llmProvider?: LLMProvider;
   headless?: boolean;
-  logger?: (message: LogLine) => void;
+  logger?: (message: LogLine) => void | Promise<void>;
   domSettleTimeoutMs?: number;
   browserbaseSessionCreateParams?: Browserbase.Sessions.SessionCreateParams;
   enableCaching?: boolean;


### PR DESCRIPTION
# why
- we were having duplicate logs, fixed this and added support for async external logging
- we couldn't say `import type { Page }` from Stagehand

# what changed
- added support to import Page/BrowserContext from Stagehand
- Removed duplicate logging

# test plan
- checked dist/index.d.ts
- replaced stagehand in node_modules in a sample project