### PR TITLE
wip: generalized llm client

### DIFF
--- a/examples/stagehand.config.ts
+++ b/examples/stagehand.config.ts
@@ -1,9 +1,15 @@
+import { LLMProvider } from "../lib/llm/LLMProvider";
+import { OpenAIClient } from "../lib/llm/OpenAIClient";
 import type { ConstructorParams, LogLine } from "../lib";
 
 const StagehandConfig: ConstructorParams = {
   env: "BROWSERBASE" /* Environment to run Stagehand in */,
   apiKey: process.env.BROWSERBASE_API_KEY /* API key for authentication */,
   projectId: process.env.BROWSERBASE_PROJECT_ID /* Project identifier */,
+  llmProvider: new LLMProvider({
+    enableCaching: true,
+    llmClient: OpenAIClient,
+  }),
   verbose: 1 /* Logging verbosity level (0=quiet, 1=normal, 2=verbose) */,
   debugDom: true /* Enable DOM debugging features */,
   headless: false /* Run browser in headless mode */,

--- a/lib/llm/AnthropicClient.ts
+++ b/lib/llm/AnthropicClient.ts
@@ -16,29 +16,28 @@ import { LLMCache } from "../cache/LLMCache";
 import { ChatCompletionOptions, LLMClient } from "./LLMClient";
 
 export class AnthropicClient extends LLMClient {
-	public type = "anthropic" as const;
-	private client: Anthropic;
-	public logger: (message: LogLine) => void;
-	public clientOptions: ClientOptions;
+  public type = "anthropic" as const;
+  private client: Anthropic;
+  public logger: (message: LogLine) => void;
+  public clientOptions: ClientOptions;
 
-	constructor(
-		logger: (message: LogLine) => void,
-		enableCaching = false,
-		cache: LLMCache | undefined,
-		modelName: AvailableModel,
-		clientOptions?: ClientOptions,
-	) {
-		super({
-			modelName,
-			enableCaching,
-			cache,
-			clientOptions,
-		});
-    console.log(clientOptions)
-		this.client = new Anthropic(clientOptions);
-		this.logger = logger;
-		this.clientOptions = clientOptions;
-	}
+  constructor(
+    logger: (message: LogLine) => void,
+    enableCaching = false,
+    cache: LLMCache | undefined,
+    modelName: AvailableModel,
+    clientOptions?: ClientOptions,
+  ) {
+    super({
+      modelName,
+      enableCaching,
+      cache,
+      clientOptions,
+    });
+    this.client = new Anthropic(clientOptions);
+    this.logger = logger;
+    this.clientOptions = clientOptions;
+  }
 
   async createChatCompletion<T = AnthropicTransformedResponse>(
     options: ChatCompletionOptions & { retries?: number },

--- a/lib/llm/AnthropicClient.ts
+++ b/lib/llm/AnthropicClient.ts
@@ -16,28 +16,29 @@ import { LLMCache } from "../cache/LLMCache";
 import { ChatCompletionOptions, LLMClient } from "./LLMClient";
 
 export class AnthropicClient extends LLMClient {
-  public type = "anthropic" as const;
-  private client: Anthropic;
-  private cache: LLMCache | undefined;
-  public logger: (message: LogLine) => void;
-  private enableCaching: boolean;
-  public clientOptions: ClientOptions;
+	public type = "anthropic" as const;
+	private client: Anthropic;
+	public logger: (message: LogLine) => void;
+	public clientOptions: ClientOptions;
 
-  constructor(
-    logger: (message: LogLine) => void,
-    enableCaching = false,
-    cache: LLMCache | undefined,
-    modelName: AvailableModel,
-    clientOptions?: ClientOptions,
-  ) {
-    super(modelName);
-    this.client = new Anthropic(clientOptions);
-    this.logger = logger;
-    this.cache = cache;
-    this.enableCaching = enableCaching;
-    this.modelName = modelName;
-    this.clientOptions = clientOptions;
-  }
+	constructor(
+		logger: (message: LogLine) => void,
+		enableCaching = false,
+		cache: LLMCache | undefined,
+		modelName: AvailableModel,
+		clientOptions?: ClientOptions,
+	) {
+		super({
+			modelName,
+			enableCaching,
+			cache,
+			clientOptions,
+		});
+    console.log(clientOptions)
+		this.client = new Anthropic(clientOptions);
+		this.logger = logger;
+		this.clientOptions = clientOptions;
+	}
 
   async createChatCompletion<T = AnthropicTransformedResponse>(
     options: ChatCompletionOptions & { retries?: number },

--- a/lib/llm/LLMClient.ts
+++ b/lib/llm/LLMClient.ts
@@ -9,6 +9,7 @@ import {
   ClientOptions,
   ToolCall,
 } from "../../types/model";
+import type { LLMCache } from "../cache/LLMCache";
 
 export interface ChatMessage {
   role: "system" | "user" | "assistant";
@@ -64,16 +65,34 @@ export interface ChatCompletionOptions {
 
 export type LLMResponse = AnthropicTransformedResponse | ChatCompletion;
 
-export abstract class LLMClient {
-  public type: "openai" | "anthropic";
-  public modelName: AvailableModel;
-  public hasVision: boolean;
-  public clientOptions: ClientOptions;
 
-  constructor(modelName: AvailableModel) {
-    this.modelName = modelName;
-    this.hasVision = modelsWithVision.includes(modelName);
-  }
+export abstract class LLMClient {
+	public type: string;
+	public modelName: string;
+	public hasVision: boolean;
+	public clientOptions: ClientOptions;
+	protected enableCaching: boolean;
+	protected cache: LLMCache | undefined;
+
+	constructor({
+		modelName,
+		hasVision = false,
+		clientOptions,
+		enableCaching = false,
+		cache,
+	}: {
+		modelName: string;
+		hasVision?: boolean;
+		clientOptions?: ClientOptions;
+		enableCaching?: boolean;
+		cache?: LLMCache;
+	}) {
+		this.modelName = modelName;
+		this.hasVision = hasVision;
+		this.clientOptions = clientOptions;
+		this.enableCaching = enableCaching;
+		this.cache = cache;
+	}
 
   abstract createChatCompletion<T = LLMResponse>(
     options: ChatCompletionOptions,

--- a/lib/llm/LLMClient.ts
+++ b/lib/llm/LLMClient.ts
@@ -65,34 +65,33 @@ export interface ChatCompletionOptions {
 
 export type LLMResponse = AnthropicTransformedResponse | ChatCompletion;
 
-
 export abstract class LLMClient {
-	public type: string;
-	public modelName: string;
-	public hasVision: boolean;
-	public clientOptions: ClientOptions;
-	protected enableCaching: boolean;
-	protected cache: LLMCache | undefined;
+  public type: string;
+  public modelName: string;
+  public hasVision: boolean;
+  public clientOptions: ClientOptions;
+  protected enableCaching: boolean;
+  protected cache: LLMCache | undefined;
 
-	constructor({
-		modelName,
-		hasVision = false,
-		clientOptions,
-		enableCaching = false,
-		cache,
-	}: {
-		modelName: string;
-		hasVision?: boolean;
-		clientOptions?: ClientOptions;
-		enableCaching?: boolean;
-		cache?: LLMCache;
-	}) {
-		this.modelName = modelName;
-		this.hasVision = hasVision;
-		this.clientOptions = clientOptions;
-		this.enableCaching = enableCaching;
-		this.cache = cache;
-	}
+  constructor({
+    modelName,
+    hasVision = false,
+    clientOptions,
+    enableCaching = false,
+    cache,
+  }: {
+    modelName: string;
+    hasVision?: boolean;
+    clientOptions?: ClientOptions;
+    enableCaching?: boolean;
+    cache?: LLMCache;
+  }) {
+    this.modelName = modelName;
+    this.hasVision = hasVision;
+    this.clientOptions = clientOptions;
+    this.enableCaching = enableCaching;
+    this.cache = cache;
+  }
 
   abstract createChatCompletion<T = LLMResponse>(
     options: ChatCompletionOptions,

--- a/lib/llm/LLMProvider.ts
+++ b/lib/llm/LLMProvider.ts
@@ -4,62 +4,63 @@ import { LLMCache } from "../cache/LLMCache";
 import type { LLMClient } from "./LLMClient";
 
 type LLMClientConstructor = new (
-  logger: (message: LogLine) => void, 
-	enableCaching: boolean,
-	cache: LLMCache | undefined,
-	modelName: string,
-	options?: ClientOptions,
+  logger: (message: LogLine) => void,
+  enableCaching: boolean,
+  cache: LLMCache | undefined,
+  modelName: string,
+  options?: ClientOptions,
 ) => LLMClient;
 
 export class LLMProvider {
-	private logger: (message: LogLine) => void;
-	private enableCaching: boolean;
-	private cache: LLMCache | undefined;
-	private llmClient: LLMClientConstructor;
+  private logger: (message: LogLine) => void;
+  private enableCaching: boolean;
+  private cache: LLMCache | undefined;
+  private llmClient: LLMClientConstructor;
 
-	constructor({
-		logger,
-		enableCaching,
-		llmClient,
-	}: {
-		logger?: (message: LogLine) => void,
-		enableCaching: boolean,
-		llmClient: LLMClientConstructor,
-	}) {
-		this.logger = logger || ((message: LogLine) =>
-      console.log(`[stagehand::${message.category}] ${message.message}`)
-    );
-		this.enableCaching = enableCaching;
-		this.cache = enableCaching ? new LLMCache(this.logger) : undefined;
-		this.llmClient = llmClient;
-	}
+  constructor({
+    logger,
+    enableCaching,
+    llmClient,
+  }: {
+    logger?: (message: LogLine) => void;
+    enableCaching: boolean;
+    llmClient: LLMClientConstructor;
+  }) {
+    this.logger =
+      logger ||
+      ((message: LogLine) =>
+        console.log(`[stagehand::${message.category}] ${message.message}`));
+    this.enableCaching = enableCaching;
+    this.cache = enableCaching ? new LLMCache(this.logger) : undefined;
+    this.llmClient = llmClient;
+  }
 
-	cleanRequestCache(requestId: string): void {
-		if (!this.enableCaching) {
-			return;
-		}
+  cleanRequestCache(requestId: string): void {
+    if (!this.enableCaching) {
+      return;
+    }
 
-		this.logger({
-			category: "llm_cache",
-			message: "cleaning up cache",
-			level: 1,
-			auxiliary: {
-				requestId: {
-					value: requestId,
-					type: "string",
-				},
-			},
-		});
-		this.cache.deleteCacheForRequestId(requestId);
-	}
+    this.logger({
+      category: "llm_cache",
+      message: "cleaning up cache",
+      level: 1,
+      auxiliary: {
+        requestId: {
+          value: requestId,
+          type: "string",
+        },
+      },
+    });
+    this.cache.deleteCacheForRequestId(requestId);
+  }
 
-	getClient(modelName: string, clientOptions?: ClientOptions): LLMClient {
-		return new this.llmClient(
+  getClient(modelName: string, clientOptions?: ClientOptions): LLMClient {
+    return new this.llmClient(
       this.logger,
-			this.enableCaching,
-			this.cache,
-			modelName,
-			clientOptions,
-		);
-	}
+      this.enableCaching,
+      this.cache,
+      modelName,
+      clientOptions,
+    );
+  }
 }

--- a/lib/llm/LLMProvider.ts
+++ b/lib/llm/LLMProvider.ts
@@ -1,83 +1,65 @@
-import { LogLine } from "../../types/log";
-import {
-  AvailableModel,
-  ClientOptions,
-  ModelProvider,
-} from "../../types/model";
+import type { LogLine } from "../../types/log";
+import type { ClientOptions } from "../../types/model";
 import { LLMCache } from "../cache/LLMCache";
-import { AnthropicClient } from "./AnthropicClient";
-import { LLMClient } from "./LLMClient";
-import { OpenAIClient } from "./OpenAIClient";
+import type { LLMClient } from "./LLMClient";
+
+type LLMClientConstructor = new (
+  logger: (message: LogLine) => void, 
+	enableCaching: boolean,
+	cache: LLMCache | undefined,
+	modelName: string,
+	options?: ClientOptions,
+) => LLMClient;
 
 export class LLMProvider {
-  private modelToProviderMap: { [key in AvailableModel]: ModelProvider } = {
-    "gpt-4o": "openai",
-    "gpt-4o-mini": "openai",
-    "gpt-4o-2024-08-06": "openai",
-    "o1-mini": "openai",
-    "o1-preview": "openai",
-    "claude-3-5-sonnet-latest": "anthropic",
-    "claude-3-5-sonnet-20240620": "anthropic",
-    "claude-3-5-sonnet-20241022": "anthropic",
-  };
+	private logger: (message: LogLine) => void;
+	private enableCaching: boolean;
+	private cache: LLMCache | undefined;
+	private llmClient: LLMClientConstructor;
 
-  private logger: (message: LogLine) => void;
-  private enableCaching: boolean;
-  private cache: LLMCache | undefined;
+	constructor({
+		logger,
+		enableCaching,
+		llmClient,
+	}: {
+		logger?: (message: LogLine) => void,
+		enableCaching: boolean,
+		llmClient: LLMClientConstructor,
+	}) {
+		this.logger = logger || ((message: LogLine) =>
+      console.log(`[stagehand::${message.category}] ${message.message}`)
+    );
+		this.enableCaching = enableCaching;
+		this.cache = enableCaching ? new LLMCache(this.logger) : undefined;
+		this.llmClient = llmClient;
+	}
 
-  constructor(logger: (message: LogLine) => void, enableCaching: boolean) {
-    this.logger = logger;
-    this.enableCaching = enableCaching;
-    this.cache = enableCaching ? new LLMCache(logger) : undefined;
-  }
+	cleanRequestCache(requestId: string): void {
+		if (!this.enableCaching) {
+			return;
+		}
 
-  cleanRequestCache(requestId: string): void {
-    if (!this.enableCaching) {
-      return;
-    }
+		this.logger({
+			category: "llm_cache",
+			message: "cleaning up cache",
+			level: 1,
+			auxiliary: {
+				requestId: {
+					value: requestId,
+					type: "string",
+				},
+			},
+		});
+		this.cache.deleteCacheForRequestId(requestId);
+	}
 
-    this.logger({
-      category: "llm_cache",
-      message: "cleaning up cache",
-      level: 1,
-      auxiliary: {
-        requestId: {
-          value: requestId,
-          type: "string",
-        },
-      },
-    });
-    this.cache.deleteCacheForRequestId(requestId);
-  }
-
-  getClient(
-    modelName: AvailableModel,
-    clientOptions?: ClientOptions,
-  ): LLMClient {
-    const provider = this.modelToProviderMap[modelName];
-    if (!provider) {
-      throw new Error(`Unsupported model: ${modelName}`);
-    }
-
-    switch (provider) {
-      case "openai":
-        return new OpenAIClient(
-          this.logger,
-          this.enableCaching,
-          this.cache,
-          modelName,
-          clientOptions,
-        );
-      case "anthropic":
-        return new AnthropicClient(
-          this.logger,
-          this.enableCaching,
-          this.cache,
-          modelName,
-          clientOptions,
-        );
-      default:
-        throw new Error(`Unsupported provider: ${provider}`);
-    }
-  }
+	getClient(modelName: string, clientOptions?: ClientOptions): LLMClient {
+		return new this.llmClient(
+      this.logger,
+			this.enableCaching,
+			this.cache,
+			modelName,
+			clientOptions,
+		);
+	}
 }

--- a/lib/llm/OpenAIClient.ts
+++ b/lib/llm/OpenAIClient.ts
@@ -18,28 +18,28 @@ import { validateZodSchema } from "../utils";
 import { ChatCompletionOptions, ChatMessage, LLMClient } from "./LLMClient";
 
 export class OpenAIClient extends LLMClient {
-  public type = "openai" as const;
-  private client: OpenAI;
-  private cache: LLMCache | undefined;
-  public logger: (message: LogLine) => void;
-  private enableCaching: boolean;
-  public clientOptions: ClientOptions;
+	public type = "openai" as const;
+	private client: OpenAI;
+	public logger: (message: LogLine) => void;
+	public clientOptions: ClientOptions;
 
-  constructor(
-    logger: (message: LogLine) => void,
-    enableCaching = false,
-    cache: LLMCache | undefined,
-    modelName: AvailableModel,
-    clientOptions?: ClientOptions,
-  ) {
-    super(modelName);
-    this.clientOptions = clientOptions;
-    this.client = new OpenAI(clientOptions);
-    this.logger = logger;
-    this.cache = cache;
-    this.enableCaching = enableCaching;
-    this.modelName = modelName;
-  }
+	constructor(
+		logger: (message: LogLine) => void,
+		enableCaching = false,
+		cache: LLMCache | undefined,
+		modelName: AvailableModel,
+		clientOptions?: ClientOptions,
+	) {
+		super({
+			modelName,
+			enableCaching,
+			cache,
+			clientOptions,
+		});
+		this.clientOptions = clientOptions;
+		this.client = new OpenAI(clientOptions);
+		this.logger = logger;
+	}
 
   async createChatCompletion<T = ChatCompletion>(
     optionsInitial: ChatCompletionOptions,

--- a/lib/llm/OpenAIClient.ts
+++ b/lib/llm/OpenAIClient.ts
@@ -18,28 +18,28 @@ import { validateZodSchema } from "../utils";
 import { ChatCompletionOptions, ChatMessage, LLMClient } from "./LLMClient";
 
 export class OpenAIClient extends LLMClient {
-	public type = "openai" as const;
-	private client: OpenAI;
-	public logger: (message: LogLine) => void;
-	public clientOptions: ClientOptions;
+  public type = "openai" as const;
+  private client: OpenAI;
+  public logger: (message: LogLine) => void;
+  public clientOptions: ClientOptions;
 
-	constructor(
-		logger: (message: LogLine) => void,
-		enableCaching = false,
-		cache: LLMCache | undefined,
-		modelName: AvailableModel,
-		clientOptions?: ClientOptions,
-	) {
-		super({
-			modelName,
-			enableCaching,
-			cache,
-			clientOptions,
-		});
-		this.clientOptions = clientOptions;
-		this.client = new OpenAI(clientOptions);
-		this.logger = logger;
-	}
+  constructor(
+    logger: (message: LogLine) => void,
+    enableCaching = false,
+    cache: LLMCache | undefined,
+    modelName: AvailableModel,
+    clientOptions?: ClientOptions,
+  ) {
+    super({
+      modelName,
+      enableCaching,
+      cache,
+      clientOptions,
+    });
+    this.clientOptions = clientOptions;
+    this.client = new OpenAI(clientOptions);
+    this.logger = logger;
+  }
 
   async createChatCompletion<T = ChatCompletion>(
     optionsInitial: ChatCompletionOptions,

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -18,7 +18,7 @@ export interface ConstructorParams {
   browserbaseSessionCreateParams?: Browserbase.Sessions.SessionCreateParams;
   enableCaching?: boolean;
   browserbaseSessionID?: string;
-  modelName?: AvailableModel;
+  modelName?: string;
   modelClientOptions?: ClientOptions;
 }
 


### PR DESCRIPTION
# why
Allow users to easily define their own llm clients rather than adding support for each major provider in the main codebase #350 

# what changed
- Refactored `LLMProvider` and `LLMClient` to allow custom clients to be passed in rather than directly imported.
- Types for model name and options generalized in order to support arbitrary clients