### PR TITLE
Throw custom error if context is referenced without initialization

### DIFF
--- a/.changeset/fast-dodos-yawn.md
+++ b/.changeset/fast-dodos-yawn.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Throw custom error if context is referenced without initialization, remove act/extract handler from index

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -24,8 +24,6 @@ import {
   ObserveResult,
 } from "../types/stagehand";
 import { scriptContent } from "./dom/build/scriptContent";
-import { StagehandExtractHandler } from "./handlers/extractHandler";
-import { StagehandObserveHandler } from "./handlers/observeHandler";
 import { LLMClient } from "./llm/LLMClient";
 import { LLMProvider } from "./llm/LLMProvider";
 import { logLineToString } from "./utils";
@@ -320,7 +318,6 @@ export class Stagehand {
   public llmProvider: LLMProvider;
   public enableCaching: boolean;
 
-  private internalLogger: (logLine: LogLine) => void;
   private apiKey: string | undefined;
   private projectId: string | undefined;
   // We want external logger to accept async functions
@@ -329,9 +326,6 @@ export class Stagehand {
   public variables: { [key: string]: unknown };
   private contextPath?: string;
   private llmClient: LLMClient;
-
-  private extractHandler?: StagehandExtractHandler;
-  private observeHandler?: StagehandObserveHandler;
 
   constructor(
     {
@@ -354,7 +348,6 @@ export class Stagehand {
     },
   ) {
     this.externalLogger = logger || defaultLogger;
-    this.internalLogger = this.log.bind(this);
     this.enableCaching =
       enableCaching ??
       (process.env.ENABLE_CACHING && process.env.ENABLE_CACHING === "true");
@@ -400,6 +393,11 @@ export class Stagehand {
   }
 
   public get context(): BrowserContext {
+    if (!this.stagehandContext) {
+      throw new Error(
+        "Stagehand not initialized. Make sure to await stagehand.init() first.",
+      );
+    }
     return this.stagehandContext.context;
   }
 


### PR DESCRIPTION
# why
We get opaque proxy errors when `stagehand.context` is referenced before `init`. We have a custom error for `page` but not `context`. This addresses that.
![image](https://github.com/user-attachments/assets/4e3b2463-8672-4ccd-8cb1-ebdfdab3bc57)


# what changed
- Throw error if context is referenced without initialization.
- Also remove act/extract handlers from lib/index


# test plan
Changed `example/example.ts` to the following:

```
const stagehand = new Stagehand(StagehandConfig);
  try {
    const context = stagehand.context;
  } catch (error) {
    console.error("Error in example.ts:", error);
    process.exit(1);
  }
```

and got the following result:

```
Error in example.ts: Error: Stagehand not initialized. Make sure to await stagehand.init() first.
    at Stagehand.get context (/Users/anirudhkamath/browserbase/stagehand/lib/index.ts:397:13)
    at example (/Users/anirudhkamath/browserbase/stagehand/examples/example.ts:14:31)
```