### PR TITLE
fix(logger): enable disabling logger

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -499,7 +499,7 @@ export class Stagehand {
   private is_processing_browserbase_logs: boolean = false;
 
   log(logObj: LogLine): void {
-    logObj.level = logObj.level || 1;
+    logObj.level = logObj.level ?? 1;
 
     // Normal Logging
     if (this.externalLogger) {
@@ -527,7 +527,7 @@ export class Stagehand {
   }
 
   private async _log_to_browserbase(logObj: LogLine) {
-    logObj.level = logObj.level || 1;
+    logObj.level = logObj.level ?? 1;
 
     if (!this.stagehandPage) {
       return;


### PR DESCRIPTION
# why

Setting `verbose: 0` does not put the logger in quiet mode

# what changed


# test plan

```bash
let a = 0
let c = null

a || 1 // -> 1
c || 1 // -> 1

a ?? 1 // -> 0
c ?? 1 // -> 0

```