### PR TITLE
[fix]: Fix -types exposed to the client to match the expected contract

### DIFF
--- a/.changeset/chilled-kangaroos-rhyme.md
+++ b/.changeset/chilled-kangaroos-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Fix $1-types exposed to the user

--- a/lib/inference.ts
+++ b/lib/inference.ts
@@ -22,7 +22,7 @@ import {
   LLMClient,
 } from "./llm/LLMClient";
 import { VerifyActCompletionParams } from "../types/inference";
-import { ActResult, ActParams } from "../types/act";
+import { ActCommandParams, ActCommandResult } from "../types/act";
 
 export async function verifyActCompletion({
   goal,
@@ -102,7 +102,7 @@ export async function act({
   logger,
   requestId,
   variables,
-}: ActParams): Promise<ActResult | null> {
+}: ActCommandParams): Promise<ActCommandResult | null> {
   const messages: ChatMessage[] = [
     buildActSystemPrompt(),
     buildActUserPrompt(action, steps, domElements, variables),

--- a/types/act.ts
+++ b/types/act.ts
@@ -1,7 +1,10 @@
 import { Buffer } from "buffer";
 import { LLMClient } from "../lib/llm/LLMClient";
 
-export interface ActParams {
+// WARNING: This is NOT to be confused with the ActParams type used in `page.act()`.
+// This is the type for the parameters passed to the `act` command in `inference.ts`.
+// page.act() params/result types are defined in `types/stagehand.ts`.
+export interface ActCommandParams {
   action: string;
   steps?: string;
   domElements: string;
@@ -13,7 +16,10 @@ export interface ActParams {
   variables?: Record<string, string>;
 }
 
-export interface ActResult {
+// WARNING: This is NOT to be confused with the ActResult type used in `page.act()`.
+// This is the type for the result of the `act` command in `inference.ts`.
+// page.act() params/result types are defined in `types/stagehand.ts`.
+export interface ActCommandResult {
   method: string;
   element: number;
   args: unknown[];

--- a/types/browser.ts
+++ b/types/browser.ts
@@ -1,4 +1,4 @@
-import { Browser, BrowserContext } from "@playwright/test";
+import { Browser, BrowserContext } from "./page";
 
 export interface BrowserResult {
   env: "LOCAL" | "BROWSERBASE";

--- a/types/page.ts
+++ b/types/page.ts
@@ -1,8 +1,9 @@
 import type { Page as PlaywrightPage } from "@playwright/test";
 import type { BrowserContext as PlaywrightContext } from "@playwright/test";
-import type { ActResult } from "./act";
+import type { Browser as PlaywrightBrowser } from "@playwright/test";
 import type {
   ActOptions,
+  ActResult,
   ExtractOptions,
   ExtractResult,
   ObserveOptions,
@@ -19,3 +20,6 @@ export interface Page extends PlaywrightPage {
 
 // Empty type for now, but will be used in the future
 export type BrowserContext = PlaywrightContext;
+
+// Empty type for now, but will be used in the future
+export type Browser = PlaywrightBrowser;

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -1,5 +1,5 @@
 import Browserbase from "@browserbasehq/sdk";
-import { BrowserContext, Page } from "@playwright/test";
+import { Page, BrowserContext } from "../types/page";
 import { z } from "zod";
 import { LLMProvider } from "../lib/llm/LLMProvider";
 import { LogLine } from "./log";


### PR DESCRIPTION
# why
#357, thanks @its-jz!

# what changed
- Expose Stagehand types instead of Playwright types. Conflicting Stagehand/Playwright types was the cause of this issue. Playwright types that don't have overrides are just empty type copies for now.
- Rename internal `ActParams` and `ActResult` from `lib/inference.ts` to `ActCommandParams` and `ActCommandResult`

# test plan
Build and validate `index.d.ts` to ensure no `$1` types are directly exposed to the end user