### PR TITLE
filter eval triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "lib/**"
+      - "types/**"
   pull_request:
     types:
       - opened

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  determine-evals:
+    runs-on: ubuntu-latest
+    outputs:
+      run-extract: ${{ steps.check-labels.outputs.run-extract }}
+      run-act: ${{ steps.check-labels.outputs.run-act }}
+      run-observe: ${{ steps.check-labels.outputs.run-observe }}
+      run-combination: ${{ steps.check-labels.outputs.run-combination }}
+      run-text-extract: ${{ steps.check-labels.outputs.run-text-extract }}
+    steps:
+      - id: check-labels
+        run: |
+          # Default to running all tests on main branch
+          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            echo "Running all tests for main branch"
+            echo "run-extract=true" >> $GITHUB_OUTPUT
+            echo "run-act=true" >> $GITHUB_OUTPUT
+            echo "run-observe=true" >> $GITHUB_OUTPUT
+            echo "run-combination=true" >> $GITHUB_OUTPUT
+            echo "run-text-extract=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Check for specific labels
+          echo "run-extract=${{ contains(github.event.pull_request.labels.*.name, 'extract') }}" >> $GITHUB_OUTPUT
+          echo "run-act=${{ contains(github.event.pull_request.labels.*.name, 'act') }}" >> $GITHUB_OUTPUT
+          echo "run-observe=${{ contains(github.event.pull_request.labels.*.name, 'observe') }}" >> $GITHUB_OUTPUT
+          echo "run-combination=${{ contains(github.event.pull_request.labels.*.name, 'combination') }}" >> $GITHUB_OUTPUT
+          echo "run-text-extract=${{ contains(github.event.pull_request.labels.*.name, 'text-extract') }}" >> $GITHUB_OUTPUT
   run-lint:
     runs-on: ubuntu-latest
     steps:
@@ -86,10 +114,10 @@ jobs:
         run: npm run e2e
 
   run-act-evals:
-    if: contains(join(github.event.pull_request.labels.*.name, ','), 'act')
+    needs: [run-lint, run-build, run-e2e-tests, determine-evals]
+    if: needs.determine-evals.outputs.run-act == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
-    needs: [run-text-extract-evals]
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -134,8 +162,8 @@ jobs:
           fi
 
   run-extract-evals:
-    if: contains(join(github.event.pull_request.labels.*.name, ','), 'extract')
-    needs: [run-lint, run-build, run-e2e-tests]
+    needs: [run-act-evals, determine-evals]
+    if: needs.determine-evals.outputs.run-extract == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 50
     env:
@@ -193,8 +221,8 @@ jobs:
           fi
 
   run-text-extract-evals:
-    if: contains(join(github.event.pull_request.labels.*.name, ','), 'text_extract')
-    needs: [run-extract-evals]
+    needs: [run-extract-evals, determine-evals]
+    if: needs.determine-evals.outputs.run-text-extract == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 120
     env:
@@ -252,10 +280,10 @@ jobs:
           fi
 
   run-observe-evals:
-    if: contains(join(github.event.pull_request.labels.*.name, ','), 'observe')
+    needs: [run-act-evals, determine-evals]
+    if: needs.determine-evals.outputs.run-observe == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
-    needs: [run-act-evals]
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -300,10 +328,10 @@ jobs:
           fi
 
   run-combination-evals:
-    if: contains(join(github.event.pull_request.labels.*.name, ','), 'combination')
+    needs: [run-observe-evals, determine-evals]
+    if: needs.determine-evals.outputs.run-combination == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 40
-    needs: [run-observe-evals]
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
         run: npm run e2e
 
   run-act-evals:
-    needs: [run-lint, run-build, run-e2e-tests, determine-evals]
+    needs: [run-e2e-tests, determine-evals]
     if: needs.determine-evals.outputs.run-act == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         run: npm run e2e
 
   run-act-evals:
-    if: contains(github.event.pull_request.labels.*.name, 'act')
+    if: contains(join(github.event.pull_request.labels.*.name, ','), 'act')
     runs-on: ubuntu-latest
     timeout-minutes: 25
     needs: [run-text-extract-evals]
@@ -134,7 +134,7 @@ jobs:
           fi
 
   run-extract-evals:
-    if: contains(github.event.pull_request.labels.*.name, 'extract')
+    if: contains(join(github.event.pull_request.labels.*.name, ','), 'extract')
     needs: [run-lint, run-build, run-e2e-tests]
     runs-on: ubuntu-latest
     timeout-minutes: 50
@@ -193,7 +193,7 @@ jobs:
           fi
 
   run-text-extract-evals:
-    if: contains(github.event.pull_request.labels.*.name, 'text_extract')
+    if: contains(join(github.event.pull_request.labels.*.name, ','), 'text_extract')
     needs: [run-extract-evals]
     runs-on: ubuntu-latest
     timeout-minutes: 120
@@ -252,7 +252,7 @@ jobs:
           fi
 
   run-observe-evals:
-    if: contains(github.event.pull_request.labels.*.name, 'observe')
+    if: contains(join(github.event.pull_request.labels.*.name, ','), 'observe')
     runs-on: ubuntu-latest
     timeout-minutes: 25
     needs: [run-act-evals]
@@ -300,7 +300,7 @@ jobs:
           fi
 
   run-combination-evals:
-    if: contains(github.event.pull_request.labels.*.name, 'combination')
+    if: contains(join(github.event.pull_request.labels.*.name, ','), 'combination')
     runs-on: ubuntu-latest
     timeout-minutes: 40
     needs: [run-observe-evals]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
           fi
 
   run-extract-evals:
-    needs: [run-act-evals, determine-evals]
+    needs: [run-e2e-tests, determine-evals]
     if: needs.determine-evals.outputs.run-extract == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 50
@@ -221,7 +221,7 @@ jobs:
           fi
 
   run-text-extract-evals:
-    needs: [run-extract-evals, determine-evals]
+    needs: [run-e2e-tests, determine-evals]
     if: needs.determine-evals.outputs.run-text-extract == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 120
@@ -280,7 +280,7 @@ jobs:
           fi
 
   run-observe-evals:
-    needs: [run-act-evals, determine-evals]
+    needs: [run-e2e-tests, determine-evals]
     if: needs.determine-evals.outputs.run-observe == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -328,7 +328,7 @@ jobs:
           fi
 
   run-combination-evals:
-    needs: [run-observe-evals, determine-evals]
+    needs: [run-e2e-tests, determine-evals]
     if: needs.determine-evals.outputs.run-combination == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 40

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,10 @@ on:
       - "lib/**"
       - "types/**"
   pull_request:
-    types: [labeled]
+    types:
+      - opened
+      - synchronize
+      - labeled
 
 env:
   EVAL_MODELS: "gpt-4o,gpt-4o-mini,claude-3-5-sonnet-latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
           fi
 
   run-act-evals:
-    needs: [run-e2e-tests, determine-evals]
+    needs: [run-e2e-tests, determine-evals, run-combination-evals]
     if: needs.determine-evals.outputs.run-act == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -204,7 +204,7 @@ jobs:
           fi
 
   run-extract-evals:
-    needs: [run-e2e-tests, determine-evals]
+    needs: [run-e2e-tests, determine-evals, run-combination-evals]
     if: needs.determine-evals.outputs.run-extract == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 50
@@ -263,7 +263,7 @@ jobs:
           fi
 
   run-text-extract-evals:
-    needs: [run-e2e-tests, determine-evals]
+    needs: [run-e2e-tests, determine-evals, run-combination-evals]
     if: needs.determine-evals.outputs.run-text-extract == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 120
@@ -322,7 +322,7 @@ jobs:
           fi
 
   run-observe-evals:
-    needs: [run-e2e-tests, determine-evals]
+    needs: [run-e2e-tests, determine-evals, run-combination-evals]
     if: needs.determine-evals.outputs.run-observe == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - main
     paths:
       - "lib/**"
-      - "types/**"
+      - "evals/**"
   pull_request:
     types:
       - opened

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,6 @@ jobs:
             echo "run-extract=true" >> $GITHUB_OUTPUT
             echo "run-act=true" >> $GITHUB_OUTPUT
             echo "run-observe=true" >> $GITHUB_OUTPUT
-            echo "run-combination=true" >> $GITHUB_OUTPUT
             echo "run-text-extract=true" >> $GITHUB_OUTPUT
             exit 0
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
       run-extract: ${{ steps.check-labels.outputs.run-extract }}
       run-act: ${{ steps.check-labels.outputs.run-act }}
       run-observe: ${{ steps.check-labels.outputs.run-observe }}
-      run-combination: ${{ steps.check-labels.outputs.run-combination }}
       run-text-extract: ${{ steps.check-labels.outputs.run-text-extract }}
     steps:
       - id: check-labels
@@ -48,7 +47,6 @@ jobs:
           echo "run-extract=${{ contains(github.event.pull_request.labels.*.name, 'extract') }}" >> $GITHUB_OUTPUT
           echo "run-act=${{ contains(github.event.pull_request.labels.*.name, 'act') }}" >> $GITHUB_OUTPUT
           echo "run-observe=${{ contains(github.event.pull_request.labels.*.name, 'observe') }}" >> $GITHUB_OUTPUT
-          echo "run-combination=${{ contains(github.event.pull_request.labels.*.name, 'combination') }}" >> $GITHUB_OUTPUT
           echo "run-text-extract=${{ contains(github.event.pull_request.labels.*.name, 'text-extract') }}" >> $GITHUB_OUTPUT
   run-lint:
     runs-on: ubuntu-latest
@@ -112,6 +110,50 @@ jobs:
 
       - name: Run E2E Tests
         run: npm run e2e
+
+  run-combination-evals:
+    needs: [run-e2e-tests, determine-evals]
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
+      BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
+      BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
+      HEADLESS: true
+      EVAL_ENV: browserbase
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm install --no-frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: npm exec playwright install --with-deps
+
+      - name: Run Combination Evals
+        run: npm run evals category combination
+
+      - name: Log Combination Evals Performance
+        run: |
+          experimentName=$(jq -r '.experimentName' eval-summary.json)
+          echo "View results at https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName}"
+          if [ -f eval-summary.json ]; then
+            combination_score=$(jq '.categories.combination' eval-summary.json)
+            echo "Combination category score: $combination_score%"
+            exit 0
+          else
+            echo "Eval summary not found for combination category. Failing CI."
+            exit 1
+          fi
 
   run-act-evals:
     needs: [run-e2e-tests, determine-evals]
@@ -324,50 +366,5 @@ jobs:
             fi
           else
             echo "Eval summary not found for observe category. Failing CI."
-            exit 1
-          fi
-
-  run-combination-evals:
-    needs: [run-e2e-tests, determine-evals]
-    if: needs.determine-evals.outputs.run-combination == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 40
-    env:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
-      BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
-      BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
-      HEADLESS: true
-      EVAL_ENV: browserbase
-
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install dependencies
-        run: npm install --no-frozen-lockfile
-
-      - name: Install Playwright browsers
-        run: npm exec playwright install --with-deps
-
-      - name: Run Combination Evals
-        run: npm run evals category combination
-
-      - name: Log Combination Evals Performance
-        run: |
-          experimentName=$(jq -r '.experimentName' eval-summary.json)
-          echo "View results at https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName}"
-          if [ -f eval-summary.json ]; then
-            combination_score=$(jq '.categories.combination' eval-summary.json)
-            echo "Combination category score: $combination_score%"
-            exit 0
-          else
-            echo "Eval summary not found for combination category. Failing CI."
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,7 @@ on:
       - "lib/**"
       - "types/**"
   pull_request:
-    types:
-      - opened
-      - synchronize
+    types: [labeled]
 
 env:
   EVAL_MODELS: "gpt-4o,gpt-4o-mini,claude-3-5-sonnet-latest"
@@ -21,38 +19,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  determine-evals:
-    runs-on: ubuntu-latest
-    outputs:
-      run-act: ${{ steps.set-outputs.outputs.run-act }}
-      run-extract: ${{ steps.set-outputs.outputs.run-extract }}
-      run-text-extract: ${{ steps.set-outputs.outputs.run-text-extract }}
-      run-observe: ${{ steps.set-outputs.outputs.run-observe }}
-      run-combination: ${{ steps.set-outputs.outputs.run-combination }}
-    steps:
-      - name: Determine Evals to Run
-        id: set-outputs
-        run: |
-          echo "run-act=false" >> $GITHUB_ENV
-          echo "run-extract=false" >> $GITHUB_ENV
-          echo "run-text-extract=false" >> $GITHUB_ENV
-          echo "run-observe=false" >> $GITHUB_ENV
-          echo "run-combination=false" >> $GITHUB_ENV
-
-          for label in "${{ github.event.pull_request.labels.*.name }}"; do
-            if [[ "$label" == "run-act" ]]; then
-              echo "run-act=true" >> $GITHUB_ENV
-            elif [[ "$label" == "run-extract" ]]; then
-              echo "run-extract=true" >> $GITHUB_ENV
-            elif [[ "$label" == "run-text-extract" ]]; then
-              echo "run-text-extract=true" >> $GITHUB_ENV
-            elif [[ "$label" == "run-observe" ]]; then
-              echo "run-observe=true" >> $GITHUB_ENV
-            elif [[ "$label" == "run-combination" ]]; then
-              echo "run-combination=true" >> $GITHUB_ENV
-            fi
-          done
-
   run-lint:
     runs-on: ubuntu-latest
     steps:
@@ -117,7 +83,7 @@ jobs:
         run: npm run e2e
 
   run-act-evals:
-    if: needs.determine-evals.outputs.run-act == 'true'
+    if: contains(github.event.pull_request.labels.*.name, 'act')
     runs-on: ubuntu-latest
     timeout-minutes: 25
     needs: [run-text-extract-evals]
@@ -165,7 +131,7 @@ jobs:
           fi
 
   run-extract-evals:
-    if: needs.determine-evals.outputs.run-extract == 'true'
+    if: contains(github.event.pull_request.labels.*.name, 'extract')
     needs: [run-lint, run-build, run-e2e-tests]
     runs-on: ubuntu-latest
     timeout-minutes: 50
@@ -224,7 +190,7 @@ jobs:
           fi
 
   run-text-extract-evals:
-    if: needs.determine-evals.outputs.run-text-extract == 'true'
+    if: contains(github.event.pull_request.labels.*.name, 'text_extract')
     needs: [run-extract-evals]
     runs-on: ubuntu-latest
     timeout-minutes: 120
@@ -283,7 +249,7 @@ jobs:
           fi
 
   run-observe-evals:
-    if: needs.determine-evals.outputs.run-observe == 'true'
+    if: contains(github.event.pull_request.labels.*.name, 'observe')
     runs-on: ubuntu-latest
     timeout-minutes: 25
     needs: [run-act-evals]
@@ -331,7 +297,7 @@ jobs:
           fi
 
   run-combination-evals:
-    if: needs.determine-evals.outputs.run-combination == 'true'
+    if: contains(github.event.pull_request.labels.*.name, 'combination')
     runs-on: ubuntu-latest
     timeout-minutes: 40
     needs: [run-observe-evals]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,38 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  determine-evals:
+    runs-on: ubuntu-latest
+    outputs:
+      run-act: ${{ steps.set-outputs.outputs.run-act }}
+      run-extract: ${{ steps.set-outputs.outputs.run-extract }}
+      run-text-extract: ${{ steps.set-outputs.outputs.run-text-extract }}
+      run-observe: ${{ steps.set-outputs.outputs.run-observe }}
+      run-combination: ${{ steps.set-outputs.outputs.run-combination }}
+    steps:
+      - name: Determine Evals to Run
+        id: set-outputs
+        run: |
+          echo "run-act=false" >> $GITHUB_ENV
+          echo "run-extract=false" >> $GITHUB_ENV
+          echo "run-text-extract=false" >> $GITHUB_ENV
+          echo "run-observe=false" >> $GITHUB_ENV
+          echo "run-combination=false" >> $GITHUB_ENV
+
+          for label in "${{ github.event.pull_request.labels.*.name }}"; do
+            if [[ "$label" == "run-act" ]]; then
+              echo "run-act=true" >> $GITHUB_ENV
+            elif [[ "$label" == "run-extract" ]]; then
+              echo "run-extract=true" >> $GITHUB_ENV
+            elif [[ "$label" == "run-text-extract" ]]; then
+              echo "run-text-extract=true" >> $GITHUB_ENV
+            elif [[ "$label" == "run-observe" ]]; then
+              echo "run-observe=true" >> $GITHUB_ENV
+            elif [[ "$label" == "run-combination" ]]; then
+              echo "run-combination=true" >> $GITHUB_ENV
+            fi
+          done
+
   run-lint:
     runs-on: ubuntu-latest
     steps:
@@ -85,6 +117,7 @@ jobs:
         run: npm run e2e
 
   run-act-evals:
+    if: needs.determine-evals.outputs.run-act == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     needs: [run-text-extract-evals]
@@ -132,6 +165,7 @@ jobs:
           fi
 
   run-extract-evals:
+    if: needs.determine-evals.outputs.run-extract == 'true'
     needs: [run-lint, run-build, run-e2e-tests]
     runs-on: ubuntu-latest
     timeout-minutes: 50
@@ -190,6 +224,7 @@ jobs:
           fi
 
   run-text-extract-evals:
+    if: needs.determine-evals.outputs.run-text-extract == 'true'
     needs: [run-extract-evals]
     runs-on: ubuntu-latest
     timeout-minutes: 120
@@ -248,6 +283,7 @@ jobs:
           fi
 
   run-observe-evals:
+    if: needs.determine-evals.outputs.run-observe == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     needs: [run-act-evals]
@@ -295,6 +331,7 @@ jobs:
           fi
 
   run-combination-evals:
+    if: needs.determine-evals.outputs.run-combination == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 40
     needs: [run-observe-evals]


### PR DESCRIPTION
# why
Evals take a long time. We should only run evals on the categories that are affected.

# what changed
The workflow for evals now reads the labels of the PR and only runs the eval categories that are tagged.

# test plan
Test workflows