### PR TITLE
update: LLMClient default inherits logger from Stagehand

### DIFF
--- a/.changeset/mean-swans-fix.md
+++ b/.changeset/mean-swans-fix.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": minor
+---
+
+Logger in LLMClient is inherited by default from Stagehand. Named rather than positional arguments are used in implemented LLMClients.

--- a/examples/external_client.ts
+++ b/examples/external_client.ts
@@ -1,4 +1,4 @@
-import { type ConstructorParams, type LogLine, Stagehand } from "../lib";
+import { type ConstructorParams, Stagehand } from "../lib";
 import { z } from "zod";
 import { OllamaClient } from "./external_clients/ollama";
 
@@ -7,13 +7,9 @@ const StagehandConfig: ConstructorParams = {
   apiKey: process.env.BROWSERBASE_API_KEY,
   projectId: process.env.BROWSERBASE_PROJECT_ID,
   verbose: 1,
-  llmClient: new OllamaClient(
-    (message: LogLine) =>
-      console.log(`[stagehand::${message.category}] ${message.message}`),
-    false,
-    undefined,
-    "llama3.2",
-  ),
+  llmClient: new OllamaClient({
+    modelName: "llama3.2",
+  }),
   debugDom: true,
 };
 

--- a/examples/external_clients/ollama.ts
+++ b/examples/external_clients/ollama.ts
@@ -28,13 +28,19 @@ export class OllamaClient extends LLMClient {
   private enableCaching: boolean;
   public clientOptions: ClientOptions;
 
-  constructor(
-    logger: (message: LogLine) => void,
+  constructor({
+    logger,
     enableCaching = false,
-    cache: LLMCache | undefined,
-    modelName: "llama3.2",
-    clientOptions?: ClientOptions,
-  ) {
+    cache = undefined,
+    modelName = "llama3.2",
+    clientOptions,
+  }: {
+    logger?: (message: LogLine) => void;
+    enableCaching?: boolean;
+    cache?: LLMCache;
+    modelName?: string;
+    clientOptions?: ClientOptions;
+  }) {
     super(modelName as AvailableModel);
     this.client = new OpenAI({
       ...clientOptions,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -365,6 +365,11 @@ export class Stagehand {
         modelName ?? DEFAULT_MODEL_NAME,
         modelClientOptions,
       );
+
+    if (!this.llmClient.logger) {
+      this.llmClient.logger = this.logger;
+    }
+
     this.domSettleTimeoutMs = domSettleTimeoutMs ?? 30_000;
     this.headless = headless ?? false;
     this.browserbaseSessionCreateParams = browserbaseSessionCreateParams;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -619,3 +619,4 @@ export * from "../types/model";
 export * from "../types/playwright";
 export * from "../types/stagehand";
 export * from "../types/page";
+export { LLMClient } from "./llm/LLMClient";

--- a/lib/llm/AnthropicClient.ts
+++ b/lib/llm/AnthropicClient.ts
@@ -23,13 +23,19 @@ export class AnthropicClient extends LLMClient {
   private enableCaching: boolean;
   public clientOptions: ClientOptions;
 
-  constructor(
-    logger: (message: LogLine) => void,
+  constructor({
+    logger,
     enableCaching = false,
-    cache: LLMCache | undefined,
-    modelName: AvailableModel,
-    clientOptions?: ClientOptions,
-  ) {
+    cache,
+    modelName,
+    clientOptions,
+  }: {
+    logger: (message: LogLine) => void;
+    enableCaching?: boolean;
+    cache?: LLMCache;
+    modelName: AvailableModel;
+    clientOptions?: ClientOptions;
+  }) {
     super(modelName);
     this.client = new Anthropic(clientOptions);
     this.logger = logger;

--- a/lib/llm/LLMProvider.ts
+++ b/lib/llm/LLMProvider.ts
@@ -61,21 +61,21 @@ export class LLMProvider {
 
     switch (provider) {
       case "openai":
-        return new OpenAIClient(
-          this.logger,
-          this.enableCaching,
-          this.cache,
+        return new OpenAIClient({
+          logger: this.logger,
+          enableCaching: this.enableCaching,
+          cache: this.cache,
           modelName,
           clientOptions,
-        );
+        });
       case "anthropic":
-        return new AnthropicClient(
-          this.logger,
-          this.enableCaching,
-          this.cache,
+        return new AnthropicClient({
+          logger: this.logger,
+          enableCaching: this.enableCaching,
+          cache: this.cache,
           modelName,
           clientOptions,
-        );
+        });
       default:
         throw new Error(`Unsupported provider: ${provider}`);
     }

--- a/lib/llm/OpenAIClient.ts
+++ b/lib/llm/OpenAIClient.ts
@@ -25,13 +25,19 @@ export class OpenAIClient extends LLMClient {
   private enableCaching: boolean;
   public clientOptions: ClientOptions;
 
-  constructor(
-    logger: (message: LogLine) => void,
+  constructor({
+    logger,
     enableCaching = false,
-    cache: LLMCache | undefined,
-    modelName: AvailableModel,
-    clientOptions?: ClientOptions,
-  ) {
+    cache,
+    modelName,
+    clientOptions,
+  }: {
+    logger: (message: LogLine) => void;
+    enableCaching?: boolean;
+    cache?: LLMCache;
+    modelName: AvailableModel;
+    clientOptions?: ClientOptions;
+  }) {
     super(modelName);
     this.clientOptions = clientOptions;
     this.client = new OpenAI(clientOptions);


### PR DESCRIPTION
# why
Simplifies the usage of `LLMClient` by eliminating the need for the logger to be defined. Instead, logger is inherited by default from `Stagehand`.

Before:
```
llmClient: new OllamaClient(
  (message: LogLine) =>
    console.log(`[stagehand::${message.category}] ${message.message}`),
  false,
  undefined,
  "llama3.2",
),
```

After:
```
llmClient: new OllamaClient({
  modelName: "llama3.2",
})
```

Additionally, other data members, namely `enableCaching` and `cache,` take on default values so they also do not have to be passed in by the user upon the creation of a client.

# what changed
The provided and example `LLMClient`s now use named properties rather than positional arguments. This follows a better constructor pattern and enables the user to omit certain properties so that their default values can be used.
