### PR TITLE
support popups

### DIFF
--- a/.changeset/few-elephants-cough.md
+++ b/.changeset/few-elephants-cough.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": minor
+---
+
+Automatically switch to new tabs when created outside of Stagehand methods

--- a/.changeset/few-elephants-cough.md
+++ b/.changeset/few-elephants-cough.md
@@ -2,4 +2,4 @@
 "@browserbasehq/stagehand": minor
 ---
 
-Automatically switch to new tabs when created outside of Stagehand methods
+Pass in a Stagehand Page object into the `on("popup")` listener to allow for multi-page handling.

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ evals/playground.ts
 tmp/
 eval-summary.json
 pnpm-lock.yaml
+evals/deterministic/tests/BrowserContext/tmp-test.har

--- a/evals/deterministic/tests/page/on.test.ts
+++ b/evals/deterministic/tests/page/on.test.ts
@@ -1,0 +1,37 @@
+import { test } from "@playwright/test";
+import { Stagehand } from "../../../../lib";
+import StagehandConfig from "../../stagehand.config";
+
+test.describe("StagehandPage - page.on()", () => {
+  test("should navigate to the popup page and close it", async () => {
+    const stagehand = new Stagehand(StagehandConfig);
+    await stagehand.init();
+
+    const stagehandPage = stagehand.page;
+    await stagehandPage.goto(
+      "https://docs.browserbase.com/integrations/crew-ai/introduction",
+    );
+
+    let clickPromise: Promise<void>;
+
+    stagehandPage.on("popup", async (newPage) => {
+      clickPromise = newPage.click(
+        "body > div.page-wrapper > div.navbar-2.w-nav > div.padding-global.top-bot > div > div.navigation-left > nav > a:nth-child(7)",
+      );
+    });
+
+    await stagehandPage.goto(
+      "https://docs.browserbase.com/integrations/crew-ai/introduction",
+    );
+
+    await stagehandPage.click(
+      "#content-area > div.relative.mt-8.prose.prose-gray.dark\\:prose-invert > p:nth-child(2) > a",
+    );
+
+    await clickPromise;
+
+    await stagehandPage.waitForTimeout(5000);
+
+    await stagehand.close();
+  });
+});

--- a/evals/deterministic/tests/page/on.test.ts
+++ b/evals/deterministic/tests/page/on.test.ts
@@ -1,36 +1,133 @@
-import { test } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import { Stagehand } from "../../../../lib";
 import StagehandConfig from "../../stagehand.config";
 
 test.describe("StagehandPage - page.on()", () => {
-  test("should navigate to the popup page and close it", async () => {
+  test("should click on the crewAI blog tab", async () => {
     const stagehand = new Stagehand(StagehandConfig);
     await stagehand.init();
 
-    const stagehandPage = stagehand.page;
-    await stagehandPage.goto(
+    const page = stagehand.page;
+    await page.goto(
       "https://docs.browserbase.com/integrations/crew-ai/introduction",
     );
 
     let clickPromise: Promise<void>;
 
-    stagehandPage.on("popup", async (newPage) => {
+    page.on("popup", async (newPage) => {
       clickPromise = newPage.click(
         "body > div.page-wrapper > div.navbar-2.w-nav > div.padding-global.top-bot > div > div.navigation-left > nav > a:nth-child(7)",
       );
     });
 
-    await stagehandPage.goto(
+    await page.goto(
       "https://docs.browserbase.com/integrations/crew-ai/introduction",
     );
 
-    await stagehandPage.click(
+    await page.click(
       "#content-area > div.relative.mt-8.prose.prose-gray.dark\\:prose-invert > p:nth-child(2) > a",
     );
 
     await clickPromise;
 
-    await stagehandPage.waitForTimeout(5000);
+    await stagehand.close();
+  });
+
+  test("should close the new tab and navigate to it on the existing page", async () => {
+    const stagehand = new Stagehand(StagehandConfig);
+    await stagehand.init();
+
+    const page = stagehand.page;
+    await page.goto(
+      "https://docs.browserbase.com/integrations/crew-ai/introduction",
+    );
+
+    let navigatePromise: Promise<unknown>;
+
+    page.on("popup", async (newPage) => {
+      navigatePromise = Promise.allSettled([
+        newPage.close(),
+        page.goto(newPage.url(), { waitUntil: "domcontentloaded" }),
+      ]);
+    });
+
+    // Click on the crewAI blog tab
+    await page.click(
+      "#content-area > div.relative.mt-8.prose.prose-gray.dark\\:prose-invert > p:nth-child(2) > a",
+    );
+
+    await navigatePromise;
+
+    await page.click(
+      "body > div.page-wrapper > div.navbar-2.w-nav > div.padding-global.top-bot > div > div.navigation-left > nav > a:nth-child(3)",
+    );
+
+    await page.waitForLoadState("domcontentloaded");
+
+    const currentUrl = page.url();
+    expect(currentUrl).toBe("https://www.crewai.com/open-source");
+
+    await stagehand.close();
+  });
+
+  test("should handle console events", async () => {
+    const stagehand = new Stagehand(StagehandConfig);
+    await stagehand.init();
+
+    const page = stagehand.page;
+    await page.goto("https://example.com");
+
+    const messages: string[] = [];
+    page.on("console", (msg) => {
+      messages.push(msg.text());
+    });
+
+    await page.evaluate(() => console.log("Test console log"));
+
+    expect(messages).toContain("Test console log");
+
+    await stagehand.close();
+  });
+
+  test("should handle dialog events", async () => {
+    const stagehand = new Stagehand(StagehandConfig);
+    await stagehand.init();
+
+    const page = stagehand.page;
+    await page.goto("https://example.com");
+
+    page.on("dialog", async (dialog) => {
+      expect(dialog.message()).toBe("Test alert");
+      await dialog.dismiss();
+    });
+
+    await page.evaluate(() => alert("Test alert"));
+
+    await stagehand.close();
+  });
+
+  test("should handle request and response events", async () => {
+    const stagehand = new Stagehand(StagehandConfig);
+    await stagehand.init();
+
+    const page = stagehand.page;
+    await page.goto("https://example.com");
+
+    const requests: string[] = [];
+    const responses: string[] = [];
+
+    page.on("request", (request) => {
+      requests.push(request.url());
+    });
+
+    page.on("response", (response) => {
+      responses.push(response.url());
+    });
+
+    await page.goto("https://example.com");
+
+    expect(requests).toContain("https://example.com/");
+    expect(responses).toContain("https://example.com/");
 
     await stagehand.close();
   });

--- a/examples/popup.ts
+++ b/examples/popup.ts
@@ -1,0 +1,36 @@
+/**
+ * This file is meant to be used as a scratchpad for developing new evals.
+ * To create a Stagehand project with best practices and configuration, run:
+ *
+ * npx create-browser-app@latest my-browser-app
+ */
+
+import { Stagehand } from "../lib";
+import StagehandConfig from "./stagehand.config";
+
+async function example() {
+  const stagehand = new Stagehand(StagehandConfig);
+  await stagehand.init();
+
+  const page = await stagehand.page;
+
+  page.on("popup", async (newPage) => {
+    // await Promise.all([page.goto(newPage.url()), newPage.close()]);
+    // or
+    newPage.act({
+      action: "type 'test@gmail.com' in the email field",
+    });
+  });
+
+  await page.goto("https://nextdoor.com/login/");
+
+  await page.act({
+    action: "click on the log in with google button",
+  });
+
+  await stagehand.close();
+}
+
+(async () => {
+  await example();
+})();

--- a/examples/popup.ts
+++ b/examples/popup.ts
@@ -5,7 +5,7 @@
  * npx create-browser-app@latest my-browser-app
  */
 
-import { Stagehand } from "../lib";
+import { ObserveResult, Stagehand } from "../lib";
 import StagehandConfig from "./stagehand.config";
 
 async function example() {
@@ -14,20 +14,29 @@ async function example() {
 
   const page = await stagehand.page;
 
+  let observePromise: Promise<ObserveResult[]>;
+
   page.on("popup", async (newPage) => {
-    // This will close the popup and navigate to it on the existing page
-    // await Promise.all([page.goto(newPage.url()), newPage.close()]);
-    // or
-    newPage.act({
-      action: "type 'test@gmail.com' in the email field",
+    observePromise = newPage.observe({
+      instruction: "return all the next possible actions from the page",
     });
   });
 
-  await page.goto("https://nextdoor.com/login/");
+  await page.goto(
+    "https://docs.browserbase.com/integrations/crew-ai/introduction",
+  );
 
-  await page.act({
-    action: "click on the log in with google button",
-  });
+  await page.click(
+    "#content-area > div.relative.mt-8.prose.prose-gray.dark\\:prose-invert > p:nth-child(2) > a",
+  );
+
+  await page.waitForTimeout(5000);
+
+  if (observePromise) {
+    const observeResult = await observePromise;
+
+    console.log("Observed", observeResult.length, "actions");
+  }
 
   await stagehand.close();
 }

--- a/examples/popup.ts
+++ b/examples/popup.ts
@@ -15,6 +15,7 @@ async function example() {
   const page = await stagehand.page;
 
   page.on("popup", async (newPage) => {
+    // This will close the popup and navigate to it on the existing page
     // await Promise.all([page.goto(newPage.url()), newPage.close()]);
     // or
     newPage.act({

--- a/lib/StagehandContext.ts
+++ b/lib/StagehandContext.ts
@@ -1,5 +1,10 @@
-import type { BrowserContext as PlaywrightContext } from "@playwright/test";
+import type {
+  BrowserContext as PlaywrightContext,
+  Page as PlaywrightPage,
+} from "@playwright/test";
 import { Stagehand } from "./index";
+import { StagehandPage } from "./StagehandPage";
+import { LLMClient } from "./llm/LLMClient";
 
 export class StagehandContext {
   private readonly stagehand: Stagehand;

--- a/lib/StagehandContext.ts
+++ b/lib/StagehandContext.ts
@@ -1,10 +1,5 @@
-import type {
-  BrowserContext as PlaywrightContext,
-  Page as PlaywrightPage,
-} from "@playwright/test";
+import type { BrowserContext as PlaywrightContext } from "@playwright/test";
 import { Stagehand } from "./index";
-import { StagehandPage } from "./StagehandPage";
-import { LLMClient } from "./llm/LLMClient";
 
 export class StagehandContext {
   private readonly stagehand: Stagehand;

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -137,7 +137,10 @@ export class StagehandPage {
               });
             }
 
-            return target[prop as keyof PlaywrightPage];
+            return this.context.on(
+              event as keyof PlaywrightPage["on"],
+              listener,
+            );
           };
         }
 

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -35,22 +35,22 @@ export class StagehandPage {
     this.intPage = Object.assign(page, {
       act: () => {
         throw new Error(
-          "act() is not implemented on the base page object. Ensure you are calling init() on the Stagehand object before calling methods on the page object.",
+          "You seem to be calling `act` on a page in an uninitialized `Stagehand` object. Ensure you are running `await stagehand.init()` on the Stagehand object before referencing the `page` object.",
         );
       },
       extract: () => {
         throw new Error(
-          "extract() is not implemented on the base page object. Ensure you are calling init() on the Stagehand object before calling methods on the page object.",
+          "You seem to be calling `extract` on a page in an uninitialized `Stagehand` object. Ensure you are running `await stagehand.init()` on the Stagehand object before referencing the `page` object.",
         );
       },
       observe: () => {
         throw new Error(
-          "observe() is not implemented on the base page object. Ensure you are calling init() on the Stagehand object before calling methods on the page object.",
+          "You seem to be calling `observe` on a page in an uninitialized `Stagehand` object. Ensure you are running `await stagehand.init()` on the Stagehand object before referencing the `page` object.",
         );
       },
       on: () => {
         throw new Error(
-          "on() is not implemented on the base page object. Stagehand overrides Playwright's on() method to update it's behavior, so ensure you call init() on the Stagehand object before you call on() on the page object.",
+          "You seem to be referencing a page in an uninitialized `Stagehand` object. Ensure you are running `await stagehand.init()` on the Stagehand object before referencing the `page` object.",
         );
       },
     });

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -48,6 +48,11 @@ export class StagehandPage {
           "observe() is not implemented on the base page object. Ensure you are calling init() on the Stagehand object before calling methods on the page object.",
         );
       },
+      on: () => {
+        throw new Error(
+          "on() is not implemented on the base page object. Stagehand overrides Playwright's on() method to update it's behavior, so ensure you call init() on the Stagehand object before you call on() on the page object.",
+        );
+      },
     });
     this.stagehand = stagehand;
     this.intContext = context;

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -128,10 +128,10 @@ export class StagehandPage {
         },
       });
 
-      await newPage.close();
-      await page.goto(newPage.url());
-      await page.waitForLoadState("domcontentloaded");
-      await this._waitForSettledDom();
+      // these can be done in parallel
+      await Promise.all([page.goto(newPage.url()), newPage.close()]);
+
+      this._waitForSettledDom();
     });
 
     await this._waitForSettledDom();

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -114,6 +114,26 @@ export class StagehandPage {
         return target[prop as keyof PlaywrightPage];
       },
     });
+
+    this.intContext.context.on("page", async (newPage) => {
+      this.stagehand.logger({
+        category: "action",
+        message: "new page detected (new tab) with URL",
+        level: 1,
+        auxiliary: {
+          url: {
+            value: newPage.url(),
+            type: "string",
+          },
+        },
+      });
+
+      await newPage.close();
+      await page.goto(newPage.url());
+      await page.waitForLoadState("domcontentloaded");
+      await this._waitForSettledDom();
+    });
+
     await this._waitForSettledDom();
     return this;
   }

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -34,13 +34,19 @@ export class StagehandPage {
   ) {
     this.intPage = Object.assign(page, {
       act: () => {
-        throw new Error("act() is not implemented on the base page object");
+        throw new Error(
+          "act() is not implemented on the base page object. Ensure you are calling init() on the Stagehand object before calling methods on the page object.",
+        );
       },
       extract: () => {
-        throw new Error("extract() is not implemented on the base page object");
+        throw new Error(
+          "extract() is not implemented on the base page object. Ensure you are calling init() on the Stagehand object before calling methods on the page object.",
+        );
       },
       observe: () => {
-        throw new Error("observe() is not implemented on the base page object");
+        throw new Error(
+          "observe() is not implemented on the base page object. Ensure you are calling init() on the Stagehand object before calling methods on the page object.",
+        );
       },
     });
     this.stagehand = stagehand;

--- a/lib/handlers/actHandler.ts
+++ b/lib/handlers/actHandler.ts
@@ -398,18 +398,6 @@ export class StagehandActHandler {
           },
         });
 
-        this.logger({
-          category: "action",
-          message: "clicked element",
-          level: 1,
-          auxiliary: {
-            newOpenedTab: {
-              value: newOpenedTab ? "opened a new tab" : "no new tabs opened",
-              type: "string",
-            },
-          },
-        });
-
         await Promise.race([
           this.stagehandPage.page.waitForLoadState("networkidle"),
           new Promise((resolve) => setTimeout(resolve, 5_000)),

--- a/lib/handlers/actHandler.ts
+++ b/lib/handlers/actHandler.ts
@@ -1,4 +1,4 @@
-import { Locator, Page } from "@playwright/test";
+import { Locator } from "@playwright/test";
 import { LogLine } from "../../types/log";
 import {
   PlaywrightCommandException,
@@ -8,10 +8,10 @@ import { ActionCache } from "../cache/ActionCache";
 import { act, fillInVariables, verifyActCompletion } from "../inference";
 import { LLMClient } from "../llm/LLMClient";
 import { LLMProvider } from "../llm/LLMProvider";
+import { StagehandContext } from "../StagehandContext";
+import { StagehandPage } from "../StagehandPage";
 import { generateId } from "../utils";
 import { ScreenshotService } from "../vision";
-import { StagehandPage } from "../StagehandPage";
-import { StagehandContext } from "../StagehandContext";
 
 export class StagehandActHandler {
   private readonly stagehandPage: StagehandPage;

--- a/lib/handlers/actHandler.ts
+++ b/lib/handlers/actHandler.ts
@@ -398,16 +398,6 @@ export class StagehandActHandler {
           },
         });
 
-        // NAVIDNOTE: Should this happen before we wait for locator[method]?
-        const newOpenedTab = await Promise.race([
-          new Promise<Page | null>((resolve) => {
-            // TODO: This is a hack to get the new page
-            // We should find a better way to do this
-            this.stagehandPage.context.once("page", (page) => resolve(page));
-            setTimeout(() => resolve(null), 1_500);
-          }),
-        ]);
-
         this.logger({
           category: "action",
           message: "clicked element",
@@ -419,24 +409,6 @@ export class StagehandActHandler {
             },
           },
         });
-
-        if (newOpenedTab) {
-          this.logger({
-            category: "action",
-            message: "new page detected (new tab) with URL",
-            level: 1,
-            auxiliary: {
-              url: {
-                value: newOpenedTab.url(),
-                type: "string",
-              },
-            },
-          });
-          await newOpenedTab.close();
-          await this.stagehandPage.page.goto(newOpenedTab.url());
-          await this.stagehandPage.page.waitForLoadState("domcontentloaded");
-          await this.stagehandPage._waitForSettledDom(domSettleTimeoutMs);
-        }
 
         await Promise.race([
           this.stagehandPage.page.waitForLoadState("networkidle"),

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
+    "popup": "npm run build-dom-scripts && tsx examples/popup.ts",
     "2048": "npm run build-dom-scripts && tsx examples/2048.ts",
     "example": "npm run build-dom-scripts && tsx examples/example.ts",
     "debug-url": "npm run build-dom-scripts && tsx examples/debugUrl.ts",

--- a/types/page.ts
+++ b/types/page.ts
@@ -1,6 +1,9 @@
-import type { Page as PlaywrightPage } from "@playwright/test";
-import type { BrowserContext as PlaywrightContext } from "@playwright/test";
-import type { Browser as PlaywrightBrowser } from "@playwright/test";
+import type {
+  Browser as PlaywrightBrowser,
+  BrowserContext as PlaywrightContext,
+  Page as PlaywrightPage,
+} from "@playwright/test";
+import type { z } from "zod";
 import type {
   ActOptions,
   ActResult,
@@ -9,7 +12,7 @@ import type {
   ObserveOptions,
   ObserveResult,
 } from "./stagehand";
-import type { z } from "zod";
+
 export interface Page extends PlaywrightPage {
   act: (options: ActOptions) => Promise<ActResult>;
   extract: <T extends z.AnyZodObject>(

--- a/types/page.ts
+++ b/types/page.ts
@@ -13,12 +13,16 @@ import type {
   ObserveResult,
 } from "./stagehand";
 
-export interface Page extends PlaywrightPage {
+export interface Page extends Omit<PlaywrightPage, "on"> {
   act: (options: ActOptions) => Promise<ActResult>;
   extract: <T extends z.AnyZodObject>(
     options: ExtractOptions<T>,
   ) => Promise<ExtractResult<T>>;
   observe: (options?: ObserveOptions) => Promise<ObserveResult[]>;
+
+  on: {
+    (event: "popup", listener: (page: Page) => unknown): Page;
+  } & PlaywrightPage["on"];
 }
 
 // Empty type for now, but will be used in the future


### PR DESCRIPTION
# why
[Addresses #361]
Stagehand does not handle new pages when they are triggered from `page.click` or other Playwright methods.
# what changed
Added a global listener for new pages, and we now automatically switch to new pages when created.
```ts
// `newPage` is overridden to be a StagehandPage object
page.on("popup", async (newPage) => {
  // This will close the popup and navigate to it on the existing page
  await Promise.all([page.goto(newPage.url()), newPage.close()]);
});

await page.goto("https://nextdoor.com/login/");
// This action will create a new tab, and now Stagehand will automatically switch to it upon creation
await page.click("#google-button > div");
await page.waitForEvent("domcontentloaded");
await page.act({
  action: "type 'test@gmail.com' into the email field",
});
```
Example usage:
# test plan
Existing evals