### PR TITLE
Use docs.browserbase.com instead of www for e2e tests

### DIFF
--- a/evals/deterministic/tests/BrowserContext/addInitScript.test.ts
+++ b/evals/deterministic/tests/BrowserContext/addInitScript.test.ts
@@ -28,7 +28,7 @@ test.describe("StagehandContext - addInitScript", () => {
     expect(resultA).toBe("Hello from context.initScript!");
 
     const pageB = await context.newPage();
-    await pageB.goto("https://www.browserbase.com");
+    await pageB.goto("https://docs.browserbase.com");
 
     const resultB = await pageB.evaluate(() => {
       const w = window as typeof window & {

--- a/evals/deterministic/tests/page/addInitScript.test.ts
+++ b/evals/deterministic/tests/page/addInitScript.test.ts
@@ -26,7 +26,7 @@ test.describe("StagehandPage - addInitScript", () => {
     });
     expect(result).toBe("Hello from init script!");
 
-    await page.goto("https://www.browserbase.com/");
+    await page.goto("https://docs.browserbase.com/");
     const resultAfterNavigation = await page.evaluate(() => {
       const w = window as typeof window & {
         __testInitScriptVar?: string;

--- a/evals/deterministic/tests/page/bringToFront.test.ts
+++ b/evals/deterministic/tests/page/bringToFront.test.ts
@@ -20,7 +20,7 @@ test.describe("StagehandPage - bringToFront", () => {
 
     await page1.bringToFront();
 
-    await page1.goto("https://www.browserbase.com");
+    await page1.goto("https://docs.browserbase.com");
     const page1TitleAfter = await page1.title();
     console.log("Page1 Title after:", page1TitleAfter);
 

--- a/evals/deterministic/tests/page/navigation.test.ts
+++ b/evals/deterministic/tests/page/navigation.test.ts
@@ -12,14 +12,14 @@ test.describe("StagehandPage - Navigation", () => {
     await page.goto("https://example.com");
     expect(page.url()).toBe("https://example.com/");
 
-    await page.goto("https://www.browserbase.com/");
-    expect(page.url()).toBe("https://www.browserbase.com/");
+    await page.goto("https://docs.browserbase.com/introduction");
+    expect(page.url()).toBe("https://docs.browserbase.com/introduction");
 
     await page.goBack();
     expect(page.url()).toBe("https://example.com/");
 
     await page.goForward();
-    expect(page.url()).toBe("https://www.browserbase.com/");
+    expect(page.url()).toBe("https://docs.browserbase.com/introduction");
 
     await stagehand.close();
   });

--- a/evals/deterministic/tests/page/reload.test.ts
+++ b/evals/deterministic/tests/page/reload.test.ts
@@ -8,7 +8,7 @@ test.describe("StagehandPage - Reload", () => {
     await stagehand.init();
 
     const page = stagehand.page;
-    await page.goto("https://www.browserbase.com/");
+    await page.goto("https://docs.browserbase.com/");
 
     await page.evaluate(() => {
       const w = window as typeof window & {


### PR DESCRIPTION
# why
www.browserbase.com is a memory-intensive site. docs isn't.

# what changed
Find+Replace basically for www.browserbase.com -> docs. 

No changeset necessary since only evals are changed

# test plan
e2e
