### PR TITLE
load env on local e2e

### DIFF
--- a/evals/deterministic/stagehand.config.ts
+++ b/evals/deterministic/stagehand.config.ts
@@ -1,4 +1,6 @@
 import type { ConstructorParams, LogLine } from "../../lib";
+import dotenv from "dotenv";
+dotenv.config({ path: "../../.env" });
 
 const StagehandConfig: ConstructorParams = {
   env: "LOCAL" /* Environment to run Stagehand in */,


### PR DESCRIPTION
# why
Deterministic evals currently do not work on local environments as they are not able to read environment variables.

# what changed
Used `dotenv` to read environment variables from `stagehand.config.ts`

# test plan
Run deterministic evals (`npm run e2e`) on local and confirm it runs as expected.