### PR TITLE
Remove evals on main and make logs sync

### DIFF
--- a/.changeset/shiny-scissors-hear.md
+++ b/.changeset/shiny-scissors-hear.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": minor
+---
+
+make logs only sync

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: Evals
 
 on:
   push:
-    branches:
-      - main
     paths:
       - "lib/**"
       - "evals/**"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: Evals
 
 on:
-  push:
-    paths:
-      - "lib/**"
-      - "evals/**"
   pull_request:
     types:
       - opened

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -321,7 +321,7 @@ export class Stagehand {
   private apiKey: string | undefined;
   private projectId: string | undefined;
   // We want external logger to accept async functions
-  private externalLogger?: (logLine: LogLine) => void | Promise<void>;
+  private externalLogger?: (logLine: LogLine) => void;
   private browserbaseSessionCreateParams?: Browserbase.Sessions.SessionCreateParams;
   public variables: { [key: string]: unknown };
   private contextPath?: string;


### PR DESCRIPTION
# why
If evals pass on a PR, it's redundant to re-run them on main.

# what changed
- Removed evals from main
- Made logs sync only

# test plan
lint basically, nothing here
