### PR TITLE
Refactor LLM Types

### DIFF
--- a/.changeset/calm-teachers-rescue.md
+++ b/.changeset/calm-teachers-rescue.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Unified LLM input/output types for reduced dependence on OpenAI types

--- a/examples/external_clients/ollama.ts
+++ b/examples/external_clients/ollama.ts
@@ -239,7 +239,14 @@ export class OllamaClient extends LLMClient {
       messages: formattedMessages,
       response_format: responseFormat,
       stream: false,
-      tools: options.tools?.filter((tool) => "function" in tool), // ensure only OpenAI compatibletools are used
+      tools: options.tools?.map((tool) => ({
+        function: {
+          name: tool.name,
+          description: tool.description,
+          parameters: tool.parameters,
+        },
+        type: "function",
+      })),
     };
 
     const response = await this.client.chat.completions.create(body);

--- a/lib/handlers/actHandler.ts
+++ b/lib/handlers/actHandler.ts
@@ -1378,7 +1378,6 @@ export class StagehandActHandler {
           llmClient,
           domSettleTimeoutMs,
         }).catch((error) => {
-          console.log("error verifying action completion", error);
           this.logger({
             category: "action",
             message:
@@ -1387,6 +1386,10 @@ export class StagehandActHandler {
             auxiliary: {
               error: {
                 value: error.message,
+                type: "string",
+              },
+              trace: {
+                value: error.stack,
                 type: "string",
               },
             },

--- a/lib/inference.ts
+++ b/lib/inference.ts
@@ -174,6 +174,7 @@ export async function extract({
 }) {
   type ExtractionResponse = z.infer<typeof schema>;
   type MetadataResponse = z.infer<typeof metadataSchema>;
+  // TODO: antipattern
   const isUsingAnthropic = llmClient.type === "anthropic";
 
   const extractionResponse = await llmClient.createChatCompletion({

--- a/lib/llm/AnthropicClient.ts
+++ b/lib/llm/AnthropicClient.ts
@@ -7,13 +7,9 @@ import {
 } from "@anthropic-ai/sdk/resources";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { LogLine } from "../../types/log";
-import {
-  AnthropicJsonSchemaObject,
-  AnthropicTransformedResponse,
-  AvailableModel,
-} from "../../types/model";
+import { AnthropicJsonSchemaObject, AvailableModel } from "../../types/model";
 import { LLMCache } from "../cache/LLMCache";
-import { ChatCompletionOptions, LLMClient } from "./LLMClient";
+import { ChatCompletionOptions, LLMClient, LLMResponse } from "./LLMClient";
 
 export class AnthropicClient extends LLMClient {
   public type = "anthropic" as const;
@@ -39,7 +35,7 @@ export class AnthropicClient extends LLMClient {
     this.clientOptions = clientOptions;
   }
 
-  async createChatCompletion<T = AnthropicTransformedResponse>(
+  async createChatCompletion<T = LLMResponse>(
     options: ChatCompletionOptions & { retries?: number },
   ): Promise<T> {
     const optionsWithoutImage = { ...options };
@@ -245,7 +241,7 @@ export class AnthropicClient extends LLMClient {
       },
     });
 
-    const transformedResponse: AnthropicTransformedResponse = {
+    const transformedResponse: LLMResponse = {
       id: response.id,
       object: "chat.completion",
       created: Date.now(),

--- a/lib/llm/AnthropicClient.ts
+++ b/lib/llm/AnthropicClient.ts
@@ -185,17 +185,15 @@ export class AnthropicClient extends LLMClient {
     }
 
     let anthropicTools: Tool[] = options.tools?.map((tool) => {
-      if (tool.type === "function") {
-        return {
-          name: tool.function.name,
-          description: tool.function.description,
-          input_schema: {
-            type: "object",
-            properties: tool.function.parameters.properties,
-            required: tool.function.parameters.required,
-          },
-        };
-      }
+      return {
+        name: tool.name,
+        description: tool.description,
+        input_schema: {
+          type: "object",
+          properties: tool.parameters.properties,
+          required: tool.parameters.required,
+        },
+      };
     });
 
     let toolDefinition: Tool | undefined;

--- a/lib/llm/LLMClient.ts
+++ b/lib/llm/LLMClient.ts
@@ -7,8 +7,8 @@ import {
   AnthropicTransformedResponse,
   AvailableModel,
   ClientOptions,
-  ToolCall,
 } from "../../types/model";
+import { LLMTools } from "../../types/llm";
 
 export interface ChatMessage {
   role: "system" | "user" | "assistant";
@@ -56,7 +56,7 @@ export interface ChatCompletionOptions {
     name: string;
     schema: ZodType;
   };
-  tools?: ToolCall[];
+  tools?: LLMTools;
   tool_choice?: "auto" | ChatCompletionToolChoiceOption;
   maxTokens?: number;
   requestId: string;

--- a/lib/llm/LLMClient.ts
+++ b/lib/llm/LLMClient.ts
@@ -1,14 +1,6 @@
-import {
-  ChatCompletion,
-  ChatCompletionToolChoiceOption,
-} from "openai/resources";
 import { ZodType } from "zod";
-import {
-  AnthropicTransformedResponse,
-  AvailableModel,
-  ClientOptions,
-} from "../../types/model";
-import { LLMTools } from "../../types/llm";
+import { LLMTool } from "../../types/llm";
+import { AvailableModel, ClientOptions } from "../../types/model";
 
 export interface ChatMessage {
   role: "system" | "user" | "assistant";
@@ -56,13 +48,39 @@ export interface ChatCompletionOptions {
     name: string;
     schema: ZodType;
   };
-  tools?: LLMTools;
-  tool_choice?: "auto" | ChatCompletionToolChoiceOption;
+  tools?: LLMTool[];
+  tool_choice?: "auto" | "none" | "required";
   maxTokens?: number;
   requestId: string;
 }
 
-export type LLMResponse = AnthropicTransformedResponse | ChatCompletion;
+export type LLMResponse = {
+  id: string;
+  object: string;
+  created: number;
+  model: string;
+  choices: {
+    index: number;
+    message: {
+      role: string;
+      content: string | null;
+      tool_calls: {
+        id: string;
+        type: string;
+        function: {
+          name: string;
+          arguments: string;
+        };
+      }[];
+    };
+    finish_reason: string;
+  }[];
+  usage: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  };
+};
 
 export abstract class LLMClient {
   public type: "openai" | "anthropic" | string;

--- a/lib/llm/OpenAIClient.ts
+++ b/lib/llm/OpenAIClient.ts
@@ -319,7 +319,14 @@ export class OpenAIClient extends LLMClient {
       messages: formattedMessages,
       response_format: responseFormat,
       stream: false,
-      tools: options.tools?.filter((tool) => "function" in tool), // ensure only OpenAI tools are used
+      tools: options.tools?.map((tool) => ({
+        function: {
+          name: tool.name,
+          description: tool.description,
+          parameters: tool.parameters,
+        },
+        type: "function",
+      })),
     };
 
     const response = await this.client.chat.completions.create(body);

--- a/lib/llm/OpenAIClient.ts
+++ b/lib/llm/OpenAIClient.ts
@@ -1,7 +1,6 @@
 import OpenAI, { ClientOptions } from "openai";
 import { zodResponseFormat } from "openai/helpers/zod";
 import {
-  ChatCompletion,
   ChatCompletionAssistantMessageParam,
   ChatCompletionContentPartImage,
   ChatCompletionContentPartText,
@@ -15,7 +14,12 @@ import { LogLine } from "../../types/log";
 import { AvailableModel } from "../../types/model";
 import { LLMCache } from "../cache/LLMCache";
 import { validateZodSchema } from "../utils";
-import { ChatCompletionOptions, ChatMessage, LLMClient } from "./LLMClient";
+import {
+  ChatCompletionOptions,
+  ChatMessage,
+  LLMClient,
+  LLMResponse,
+} from "./LLMClient";
 
 export class OpenAIClient extends LLMClient {
   public type = "openai" as const;
@@ -41,7 +45,7 @@ export class OpenAIClient extends LLMClient {
     this.modelName = modelName;
   }
 
-  async createChatCompletion<T = ChatCompletion>(
+  async createChatCompletion<T = LLMResponse>(
     optionsInitial: ChatCompletionOptions,
     retries: number = 3,
   ): Promise<T> {

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -1,4 +1,4 @@
-import OpenAI from "openai";
+import { LLMTool } from "../types/llm";
 import { ChatMessage } from "./llm/LLMClient";
 
 // act
@@ -135,65 +135,60 @@ ${Object.keys(variables)
   };
 }
 
-export const actTools: Array<OpenAI.ChatCompletionTool> = [
+export const actTools: LLMTool[] = [
   {
     type: "function",
-    function: {
-      name: "doAction",
-      description:
-        "execute the next playwright step that directly accomplishes the goal",
-      parameters: {
-        type: "object",
-        required: ["method", "element", "args", "step", "completed"],
-        properties: {
-          method: {
+    name: "doAction",
+    description:
+      "execute the next playwright step that directly accomplishes the goal",
+    parameters: {
+      type: "object",
+      required: ["method", "element", "args", "step", "completed"],
+      properties: {
+        method: {
+          type: "string",
+          description: "The playwright function to call.",
+        },
+        element: {
+          type: "number",
+          description: "The element number to act on",
+        },
+        args: {
+          type: "array",
+          description: "The required arguments",
+          items: {
             type: "string",
-            description: "The playwright function to call.",
+            description: "The argument to pass to the function",
           },
-          element: {
-            type: "number",
-            description: "The element number to act on",
-          },
-          args: {
-            type: "array",
-            description: "The required arguments",
-            items: {
-              type: "string",
-              description: "The argument to pass to the function",
-            },
-          },
-          step: {
-            type: "string",
-            description:
-              "human readable description of the step that is taken in the past tense. Please be very detailed.",
-          },
-          why: {
-            type: "string",
-            description:
-              "why is this step taken? how does it advance the goal?",
-          },
-          completed: {
-            type: "boolean",
-            description:
-              "true if the goal should be accomplished after this step",
-          },
+        },
+        step: {
+          type: "string",
+          description:
+            "human readable description of the step that is taken in the past tense. Please be very detailed.",
+        },
+        why: {
+          type: "string",
+          description: "why is this step taken? how does it advance the goal?",
+        },
+        completed: {
+          type: "boolean",
+          description:
+            "true if the goal should be accomplished after this step",
         },
       },
     },
   },
   {
     type: "function",
-    function: {
-      name: "skipSection",
-      description:
-        "skips this area of the webpage because the current goal cannot be accomplished here",
-      parameters: {
-        type: "object",
-        properties: {
-          reason: {
-            type: "string",
-            description: "reason that no action is taken",
-          },
+    name: "skipSection",
+    description:
+      "skips this area of the webpage because the current goal cannot be accomplished here",
+    parameters: {
+      type: "object",
+      properties: {
+        reason: {
+          type: "string",
+          description: "reason that no action is taken",
         },
       },
     },

--- a/types/llm.ts
+++ b/types/llm.ts
@@ -1,5 +1,3 @@
-export type LLMTools = LLMTool[];
-
 export interface LLMTool {
   type: "function";
   name: string;

--- a/types/llm.ts
+++ b/types/llm.ts
@@ -1,0 +1,8 @@
+export type LLMTools = LLMTool[];
+
+export interface LLMTool {
+  type: "function";
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>;
+}

--- a/types/model.ts
+++ b/types/model.ts
@@ -1,6 +1,5 @@
 import type { ClientOptions as AnthropicClientOptions } from "@anthropic-ai/sdk";
 import type { ClientOptions as OpenAIClientOptions } from "openai";
-import { ChatCompletionTool as OpenAITool } from "openai/resources";
 import { z } from "zod";
 
 export const AvailableModelSchema = z.enum([
@@ -19,36 +18,6 @@ export type AvailableModel = z.infer<typeof AvailableModelSchema>;
 export type ModelProvider = "openai" | "anthropic";
 
 export type ClientOptions = OpenAIClientOptions | AnthropicClientOptions;
-
-export type ToolCall = OpenAITool;
-
-export type AnthropicTransformedResponse = {
-  id: string;
-  object: string;
-  created: number;
-  model: string;
-  choices: {
-    index: number;
-    message: {
-      role: string;
-      content: string | null;
-      tool_calls: {
-        id: string;
-        type: string;
-        function: {
-          name: string;
-          arguments: string;
-        };
-      }[];
-    };
-    finish_reason: string;
-  }[];
-  usage: {
-    prompt_tokens: number;
-    completion_tokens: number;
-    total_tokens: number;
-  };
-};
 
 export interface AnthropicJsonSchemaObject {
   definitions?: {


### PR DESCRIPTION
# why
We want to reduce dependency on OpenAI types as we continue to add more models

# what changed
Added unifying types for LLM inputs and outputs

# test plan
Existing evals