### PR TITLE
leave comments for eval performance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,19 +159,16 @@ jobs:
       - name: Log Combination Evals Performance
         run: |
           experimentName=$(jq -r '.experimentName' eval-summary.json)
-          echo "View results at https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName}"
           if [ -f eval-summary.json ]; then
             combination_score=$(jq '.categories.combination' eval-summary.json)
             echo "Combination category score: $combination_score%"
             
-            # Create comment body
-            echo "### 🔄 Combination Eval Results" > comment.md
-            echo "Score: ${combination_score}%" >> comment.md
-            echo "[View detailed results](https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName})" >> comment.md
-            
-            # Post comment
-            gh pr comment ${{ github.event.pull_request.number }} --body-file comment.md
-            exit 0
+            # Create initial results summary
+            echo "### 🧪 Eval Results Summary" > results.md
+            echo "#### 🔄 Combination" >> results.md
+            echo "Score: ${combination_score}%" >> results.md
+            echo "[View detailed results](https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName})" >> results.md
+            echo "" >> results.md
           else
             echo "Eval summary not found for combination category. Failing CI."
             exit 1
@@ -218,13 +215,11 @@ jobs:
             act_score=$(jq '.categories.act' eval-summary.json)
             echo "Act category score: $act_score%"
             
-            # Create comment body
-            echo "### 🎯 Act Eval Results" > comment.md
-            echo "Score: ${act_score}%" >> comment.md
-            echo "[View detailed results](https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName})" >> comment.md
-            
-            # Post comment
-            gh pr comment ${{ github.event.pull_request.number }} --body-file comment.md
+            # Append act results
+            echo "#### 🎯 Act" >> results.md
+            echo "Score: ${act_score}%" >> results.md
+            echo "[View detailed results](https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName})" >> results.md
+            echo "" >> results.md
             
             if (( $(echo "$act_score < 80" | bc -l) )); then
               echo "Act category score is below 80%. Failing CI."
@@ -282,21 +277,17 @@ jobs:
         run: |
           experimentNameDom=$(jq -r '.experimentName' eval-summary-extract-dom.json)
           dom_score=$(jq '.categories.extract' eval-summary-extract-dom.json)
-          echo "DomExtract Extract category score: $dom_score%"
 
           experimentNameText=$(jq -r '.experimentName' eval-summary-extract-text.json)
           text_score=$(jq '.categories.extract' eval-summary-extract-text.json)
-          echo "TextExtract Extract category score: $text_score%"
 
-          # Create comment body
-          echo "### 🔍 Extract Eval Results" > comment.md
-          echo "**DomExtract Score:** ${dom_score}%" >> comment.md
-          echo "[View domExtract results](https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameDom})" >> comment.md
-          echo "**TextExtract Score:** ${text_score}%" >> comment.md
-          echo "[View textExtract results](https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameText})" >> comment.md
-
-          # Post comment
-          gh pr comment ${{ github.event.pull_request.number }} --body-file comment.md
+          # Append extract results
+          echo "#### 🔍 Extract" >> results.md
+          echo "**DomExtract Score:** ${dom_score}%" >> results.md
+          echo "[View domExtract results](https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameDom})" >> results.md
+          echo "**TextExtract Score:** ${text_score}%" >> results.md
+          echo "[View textExtract results](https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameText})" >> results.md
+          echo "" >> results.md
 
           if (( $(echo "$dom_score < 80" | bc -l) )); then
             echo "DomExtract extract category score is below 80%. Failing CI."
@@ -354,15 +345,13 @@ jobs:
           experimentNameDom=$(jq -r '.experimentName' eval-summary-text_extract-dom.json)
           dom_score=$(jq '.categories.text_extract' eval-summary-text_extract-dom.json)
 
-          # Create comment body
-          echo "### 📝 Text Extract Eval Results" > comment.md
-          echo "**TextExtract Score:** ${text_score}%" >> comment.md
-          echo "[View textExtract results](https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameText})" >> comment.md
-          echo "**DomExtract Score:** ${dom_score}%" >> comment.md
-          echo "[View domExtract results](https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameDom})" >> comment.md
-
-          # Post comment
-          gh pr comment ${{ github.event.pull_request.number }} --body-file comment.md
+          # Append text extract results
+          echo "#### 📝 Text Extract" >> results.md
+          echo "**TextExtract Score:** ${text_score}%" >> results.md
+          echo "[View textExtract results](https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameText})" >> results.md
+          echo "**DomExtract Score:** ${dom_score}%" >> results.md
+          echo "[View domExtract results](https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameDom})" >> results.md
+          echo "" >> results.md
 
           if (( $(echo "$text_score < 80" | bc -l) )); then
             echo "textExtract text_extract category score is below 80%. Failing CI."
@@ -410,13 +399,13 @@ jobs:
             observe_score=$(jq '.categories.observe' eval-summary.json)
             echo "Observe category score: $observe_score%"
             
-            # Create comment body
-            echo "### 👀 Observe Eval Results" > comment.md
-            echo "Score: ${observe_score}%" >> comment.md
-            echo "[View detailed results](https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName})" >> comment.md
+            # Append observe results and post final comment
+            echo "#### 👀 Observe" >> results.md
+            echo "Score: ${observe_score}%" >> results.md
+            echo "[View detailed results](https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName})" >> results.md
             
-            # Post comment
-            gh pr comment ${{ github.event.pull_request.number }} --body-file comment.md
+            # Post the consolidated results comment
+            gh pr comment ${{ github.event.pull_request.number }} --body-file results.md
             
             if (( $(echo "$observe_score < 80" | bc -l) )); then
               echo "Observe category score is below 80%. Failing CI."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,42 @@ permissions:
   contents: read
 
 jobs:
+  cleanup-comments:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete previous CI comments
+        run: |
+          # Get all comments from the PR
+          comments=$(gh api graphql -f query='
+            query($owner:String!, $repo:String!, $pr:Int!) {
+              repository(owner:$owner, name:$repo) {
+                pullRequest(number:$pr) {
+                  comments(first:100) {
+                    nodes {
+                      id
+                      author {
+                        login
+                      }
+                      body
+                    }
+                  }
+                }
+              }
+            }' -f owner=$GITHUB_REPOSITORY_OWNER -f repo=$(echo $GITHUB_REPOSITORY | cut -d'/' -f2) -f pr=${{ github.event.pull_request.number }})
+
+          # Delete comments that contain "Eval Results" and are from the github-actions bot
+          echo "$comments" | jq -r '.data.repository.pullRequest.comments.nodes[] | select(.author.login == "github-actions[bot]" and (.body | contains("Eval Results"))) | .id' | \
+          while read -r comment_id; do
+            gh api graphql -f query='
+              mutation($id:ID!) {
+                deleteIssueComment(input:{id:$id}) {
+                  clientMutationId
+                }
+              }' -f id="$comment_id"
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   determine-evals:
     runs-on: ubuntu-latest
     outputs:
@@ -111,6 +147,34 @@ jobs:
       # Add new step to log E2E results
       - name: Log E2E Test Results
         run: |
+          # Delete previous E2E test comments
+          comments=$(gh api graphql -f query='
+            query($owner:String!, $repo:String!, $pr:Int!) {
+              repository(owner:$owner, name:$repo) {
+                pullRequest(number:$pr) {
+                  comments(first:100) {
+                    nodes {
+                      id
+                      author {
+                        login
+                      }
+                      body
+                    }
+                  }
+                }
+              }
+            }' -f owner=$GITHUB_REPOSITORY_OWNER -f repo=$(echo $GITHUB_REPOSITORY | cut -d'/' -f2) -f pr=${{ github.event.pull_request.number }})
+
+          echo "$comments" | jq -r '.data.repository.pullRequest.comments.nodes[] | select(.author.login == "github-actions[bot]" and (.body | contains("E2E Test Results"))) | .id' | \
+          while read -r comment_id; do
+            gh api graphql -f query='
+              mutation($id:ID!) {
+                deleteIssueComment(input:{id:$id}) {
+                  clientMutationId
+                }
+              }' -f id="$comment_id"
+          done
+
           # Create comment body
           echo "### 🧪 E2E Test Results" > comment.md
 
@@ -126,7 +190,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   run-combination-evals:
-    needs: [run-e2e-tests, determine-evals]
+    needs: [run-e2e-tests, determine-evals, cleanup-comments]
     runs-on: ubuntu-latest
     timeout-minutes: 40
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,23 @@ jobs:
       - name: Run E2E Tests
         run: npm run e2e
 
+      # Add new step to log E2E results
+      - name: Log E2E Test Results
+        run: |
+          # Create comment body
+          echo "### 🧪 E2E Test Results" > comment.md
+
+          if [ $? -eq 0 ]; then
+            echo "✅ All E2E tests passed successfully" >> comment.md
+          else
+            echo "❌ Some E2E tests failed" >> comment.md
+          fi
+
+          # Post comment
+          gh pr comment ${{ github.event.pull_request.number }} --body-file comment.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   run-combination-evals:
     needs: [run-e2e-tests, determine-evals]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  pull-requests: write
+  contents: read
+
 jobs:
   determine-evals:
     runs-on: ubuntu-latest
@@ -142,11 +146,21 @@ jobs:
           if [ -f eval-summary.json ]; then
             combination_score=$(jq '.categories.combination' eval-summary.json)
             echo "Combination category score: $combination_score%"
+            
+            # Create comment body
+            echo "### 🔄 Combination Eval Results" > comment.md
+            echo "Score: ${combination_score}%" >> comment.md
+            echo "[View detailed results](https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName})" >> comment.md
+            
+            # Post comment
+            gh pr comment ${{ github.event.pull_request.number }} --body-file comment.md
             exit 0
           else
             echo "Eval summary not found for combination category. Failing CI."
             exit 1
           fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   run-act-evals:
     needs: [run-e2e-tests, determine-evals, run-combination-evals]
@@ -183,10 +197,18 @@ jobs:
       - name: Log Act Evals Performance
         run: |
           experimentName=$(jq -r '.experimentName' eval-summary.json)
-          echo "View results at https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName}"
           if [ -f eval-summary.json ]; then
             act_score=$(jq '.categories.act' eval-summary.json)
             echo "Act category score: $act_score%"
+            
+            # Create comment body
+            echo "### 🎯 Act Eval Results" > comment.md
+            echo "Score: ${act_score}%" >> comment.md
+            echo "[View detailed results](https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName})" >> comment.md
+            
+            # Post comment
+            gh pr comment ${{ github.event.pull_request.number }} --body-file comment.md
+            
             if (( $(echo "$act_score < 80" | bc -l) )); then
               echo "Act category score is below 80%. Failing CI."
               exit 1
@@ -195,6 +217,8 @@ jobs:
             echo "Eval summary not found for act category. Failing CI."
             exit 1
           fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   run-extract-evals:
     needs: [run-e2e-tests, determine-evals, run-combination-evals]
@@ -242,18 +266,27 @@ jobs:
           experimentNameDom=$(jq -r '.experimentName' eval-summary-extract-dom.json)
           dom_score=$(jq '.categories.extract' eval-summary-extract-dom.json)
           echo "DomExtract Extract category score: $dom_score%"
-          echo "View domExtract results: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameDom}"
 
           experimentNameText=$(jq -r '.experimentName' eval-summary-extract-text.json)
           text_score=$(jq '.categories.extract' eval-summary-extract-text.json)
           echo "TextExtract Extract category score: $text_score%"
-          echo "View textExtract results: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameText}"
 
-          # 4. If domExtract <80% fail CI
+          # Create comment body
+          echo "### 🔍 Extract Eval Results" > comment.md
+          echo "**DomExtract Score:** ${dom_score}%" >> comment.md
+          echo "[View domExtract results](https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameDom})" >> comment.md
+          echo "**TextExtract Score:** ${text_score}%" >> comment.md
+          echo "[View textExtract results](https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameText})" >> comment.md
+
+          # Post comment
+          gh pr comment ${{ github.event.pull_request.number }} --body-file comment.md
+
           if (( $(echo "$dom_score < 80" | bc -l) )); then
             echo "DomExtract extract category score is below 80%. Failing CI."
             exit 1
           fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   run-text-extract-evals:
     needs: [run-e2e-tests, determine-evals, run-combination-evals]
@@ -300,19 +333,26 @@ jobs:
         run: |
           experimentNameText=$(jq -r '.experimentName' eval-summary-text_extract-text.json)
           text_score=$(jq '.categories.text_extract' eval-summary-text_extract-text.json)
-          echo "TextExtract text_extract category score: $text_score%"
-          echo "View textExtract results: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameText}"
 
           experimentNameDom=$(jq -r '.experimentName' eval-summary-text_extract-dom.json)
           dom_score=$(jq '.categories.text_extract' eval-summary-text_extract-dom.json)
-          echo "DomExtract text_extract category score: $dom_score%"
-          echo "View domExtract results: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameDom}"
 
-          # 4. If textExtract (for text_extract category) <80% fail CI
+          # Create comment body
+          echo "### 📝 Text Extract Eval Results" > comment.md
+          echo "**TextExtract Score:** ${text_score}%" >> comment.md
+          echo "[View textExtract results](https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameText})" >> comment.md
+          echo "**DomExtract Score:** ${dom_score}%" >> comment.md
+          echo "[View domExtract results](https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameDom})" >> comment.md
+
+          # Post comment
+          gh pr comment ${{ github.event.pull_request.number }} --body-file comment.md
+
           if (( $(echo "$text_score < 80" | bc -l) )); then
             echo "textExtract text_extract category score is below 80%. Failing CI."
             exit 1
           fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   run-observe-evals:
     needs: [run-e2e-tests, determine-evals, run-combination-evals]
@@ -349,10 +389,18 @@ jobs:
       - name: Log Observe Evals Performance
         run: |
           experimentName=$(jq -r '.experimentName' eval-summary.json)
-          echo "View results at https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName}"
           if [ -f eval-summary.json ]; then
             observe_score=$(jq '.categories.observe' eval-summary.json)
             echo "Observe category score: $observe_score%"
+            
+            # Create comment body
+            echo "### 👀 Observe Eval Results" > comment.md
+            echo "Score: ${observe_score}%" >> comment.md
+            echo "[View detailed results](https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName})" >> comment.md
+            
+            # Post comment
+            gh pr comment ${{ github.event.pull_request.number }} --body-file comment.md
+            
             if (( $(echo "$observe_score < 80" | bc -l) )); then
               echo "Observe category score is below 80%. Failing CI."
               exit 1
@@ -361,3 +409,5 @@ jobs:
             echo "Eval summary not found for observe category. Failing CI."
             exit 1
           fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# why
We want an easy way to view eval category performance

# what changed
Added comments from the CI, which log the performance of each eval category

# test plan
Run existing evals and observe if comments are left by CI