### PR TITLE
Pass LLM logger in createChatCompletion

### DIFF
--- a/.changeset/soft-snails-lick.md
+++ b/.changeset/soft-snails-lick.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Moved the LLMClient logger paremeter to the createChatCompletion method options.

--- a/.changeset/soft-snails-lick.md
+++ b/.changeset/soft-snails-lick.md
@@ -1,5 +1,5 @@
 ---
-"@browserbasehq/stagehand": patch
+"@browserbasehq/stagehand": minor
 ---
 
 Moved the LLMClient logger paremeter to the createChatCompletion method options.

--- a/examples/external_client.ts
+++ b/examples/external_client.ts
@@ -1,20 +1,15 @@
-import { type ConstructorParams, Stagehand } from "../lib";
+import { Stagehand } from "../lib";
 import { z } from "zod";
 import { OllamaClient } from "./external_clients/ollama";
-
-const StagehandConfig: ConstructorParams = {
-  env: "BROWSERBASE",
-  apiKey: process.env.BROWSERBASE_API_KEY,
-  projectId: process.env.BROWSERBASE_PROJECT_ID,
-  verbose: 1,
-  llmClient: new OllamaClient({
-    modelName: "llama3.2",
-  }),
-  debugDom: true,
-};
+import StagehandConfig from "./stagehand.config";
 
 async function example() {
-  const stagehand = new Stagehand(StagehandConfig);
+  const stagehand = new Stagehand({
+    ...StagehandConfig,
+    llmClient: new OllamaClient({
+      modelName: "llama3.2",
+    }),
+  });
 
   await stagehand.init();
   await stagehand.page.goto("https://news.ycombinator.com");

--- a/lib/handlers/extractHandler.ts
+++ b/lib/handlers/extractHandler.ts
@@ -435,6 +435,7 @@ export class StagehandExtractHandler {
       chunksTotal: chunks.length,
       requestId,
       isUsingTextExtract: false,
+      logger: this.logger,
     });
 
     const {

--- a/lib/handlers/extractHandler.ts
+++ b/lib/handlers/extractHandler.ts
@@ -306,6 +306,7 @@ export class StagehandExtractHandler {
       chunksTotal: 1,
       llmClient,
       requestId,
+      logger: this.logger,
     });
 
     const {

--- a/lib/handlers/observeHandler.ts
+++ b/lib/handlers/observeHandler.ts
@@ -120,6 +120,7 @@ export class StagehandObserveHandler {
       llmClient,
       image: annotatedScreenshot,
       requestId,
+      logger: this.logger,
     });
 
     const elementsWithSelectors = observationResponse.elements.map(

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -366,10 +366,6 @@ export class Stagehand {
         modelClientOptions,
       );
 
-    if (!this.llmClient.logger) {
-      this.llmClient.logger = this.logger;
-    }
-
     this.domSettleTimeoutMs = domSettleTimeoutMs ?? 30_000;
     this.headless = headless ?? false;
     this.browserbaseSessionCreateParams = browserbaseSessionCreateParams;

--- a/lib/inference.ts
+++ b/lib/inference.ts
@@ -1,28 +1,26 @@
-import {
-  actTools,
-  buildActSystemPrompt,
-  buildActUserPrompt,
-  buildAskSystemPrompt,
-  buildExtractSystemPrompt,
-  buildExtractUserPrompt,
-  buildObserveSystemPrompt,
-  buildObserveUserMessage,
-  buildAskUserPrompt,
-  buildVerifyActCompletionSystemPrompt,
-  buildVerifyActCompletionUserPrompt,
-  buildRefineSystemPrompt,
-  buildRefineUserPrompt,
-  buildMetadataSystemPrompt,
-  buildMetadataPrompt,
-} from "./prompt";
 import { z } from "zod";
-import {
+import { ActCommandParams, ActCommandResult } from "../types/act";
+import { VerifyActCompletionParams } from "../types/inference";
+import { LogLine } from "../types/log";
   AnnotatedScreenshotText,
   ChatMessage,
   LLMClient,
 } from "./llm/LLMClient";
-import { VerifyActCompletionParams } from "../types/inference";
-import { ActCommandParams, ActCommandResult } from "../types/act";
+import {
+  actTools,
+  buildActSystemPrompt,
+  buildActUserPrompt,
+  buildExtractSystemPrompt,
+  buildExtractUserPrompt,
+  buildMetadataPrompt,
+  buildMetadataSystemPrompt,
+  buildObserveSystemPrompt,
+  buildObserveUserMessage,
+  buildRefineSystemPrompt,
+  buildRefineUserPrompt,
+  buildVerifyActCompletionSystemPrompt,
+  buildVerifyActCompletionUserPrompt,
+} from "./prompt";
 
 export async function verifyActCompletion({
   goal,
@@ -40,25 +38,28 @@ export async function verifyActCompletion({
   type VerificationResponse = z.infer<typeof verificationSchema>;
 
   const response = await llmClient.createChatCompletion<VerificationResponse>({
-    messages: [
-      buildVerifyActCompletionSystemPrompt(),
-      buildVerifyActCompletionUserPrompt(goal, steps, domElements),
-    ],
-    temperature: 0.1,
-    top_p: 1,
-    frequency_penalty: 0,
-    presence_penalty: 0,
-    image: screenshot
-      ? {
-          buffer: screenshot,
-          description: "This is a screenshot of the whole visible page.",
-        }
-      : undefined,
-    response_model: {
-      name: "Verification",
-      schema: verificationSchema,
+    options: {
+      messages: [
+        buildVerifyActCompletionSystemPrompt(),
+        buildVerifyActCompletionUserPrompt(goal, steps, domElements),
+      ],
+      temperature: 0.1,
+      top_p: 1,
+      frequency_penalty: 0,
+      presence_penalty: 0,
+      image: screenshot
+        ? {
+            buffer: screenshot,
+            description: "This is a screenshot of the whole visible page.",
+          }
+        : undefined,
+      response_model: {
+        name: "Verification",
+        schema: verificationSchema,
+      },
+      requestId,
     },
-    requestId,
+    logger,
   });
 
   if (!response || typeof response !== "object") {
@@ -109,17 +110,20 @@ export async function act({
   ];
 
   const response = await llmClient.createChatCompletion({
-    messages,
-    temperature: 0.1,
-    top_p: 1,
-    frequency_penalty: 0,
-    presence_penalty: 0,
-    tool_choice: "auto" as const,
-    tools: actTools,
-    image: screenshot
-      ? { buffer: screenshot, description: AnnotatedScreenshotText }
-      : undefined,
-    requestId,
+    options: {
+      messages,
+      temperature: 0.1,
+      top_p: 1,
+      frequency_penalty: 0,
+      presence_penalty: 0,
+      tool_choice: "auto" as const,
+      tools: actTools,
+      image: screenshot
+        ? { buffer: screenshot, description: AnnotatedScreenshotText }
+        : undefined,
+      requestId,
+    },
+    logger,
   });
 
   const toolCalls = response.choices[0].message.tool_calls;
@@ -160,6 +164,7 @@ export async function extract({
   chunksSeen,
   chunksTotal,
   requestId,
+  logger,
   isUsingTextExtract,
 }: {
   instruction: string;
@@ -171,6 +176,7 @@ export async function extract({
   chunksTotal: number;
   requestId: string;
   isUsingTextExtract?: boolean;
+  logger: (message: LogLine) => void;
 }) {
   type ExtractionResponse = z.infer<typeof schema>;
   type MetadataResponse = z.infer<typeof metadataSchema>;
@@ -178,40 +184,46 @@ export async function extract({
   const isUsingAnthropic = llmClient.type === "anthropic";
 
   const extractionResponse = await llmClient.createChatCompletion({
-    messages: [
-      buildExtractSystemPrompt(isUsingAnthropic, isUsingTextExtract),
-      buildExtractUserPrompt(instruction, domElements, isUsingAnthropic),
-    ],
-    response_model: {
-      schema: schema,
-      name: "Extraction",
-    },
-    temperature: 0.1,
-    top_p: 1,
-    frequency_penalty: 0,
-    presence_penalty: 0,
-    requestId,
-  });
-
-  const refinedResponse =
-    await llmClient.createChatCompletion<ExtractionResponse>({
+    options: {
       messages: [
-        buildRefineSystemPrompt(),
-        buildRefineUserPrompt(
-          instruction,
-          previouslyExtractedContent,
-          extractionResponse,
-        ),
+        buildExtractSystemPrompt(isUsingAnthropic, isUsingTextExtract),
+        buildExtractUserPrompt(instruction, domElements, isUsingAnthropic),
       ],
       response_model: {
         schema: schema,
-        name: "RefinedExtraction",
+        name: "Extraction",
       },
       temperature: 0.1,
       top_p: 1,
       frequency_penalty: 0,
       presence_penalty: 0,
       requestId,
+    },
+    logger,
+  });
+
+  const refinedResponse =
+    await llmClient.createChatCompletion<ExtractionResponse>({
+      options: {
+        messages: [
+          buildRefineSystemPrompt(),
+          buildRefineUserPrompt(
+            instruction,
+            previouslyExtractedContent,
+            extractionResponse,
+          ),
+        ],
+        response_model: {
+          schema: schema,
+          name: "RefinedExtraction",
+        },
+        temperature: 0.1,
+        top_p: 1,
+        frequency_penalty: 0,
+        presence_penalty: 0,
+        requestId,
+      },
+      logger,
     });
 
   const metadataSchema = z.object({
@@ -229,24 +241,27 @@ export async function extract({
 
   const metadataResponse =
     await llmClient.createChatCompletion<MetadataResponse>({
-      messages: [
-        buildMetadataSystemPrompt(),
-        buildMetadataPrompt(
-          instruction,
-          refinedResponse,
-          chunksSeen,
-          chunksTotal,
-        ),
-      ],
-      response_model: {
-        name: "Metadata",
-        schema: metadataSchema,
+      options: {
+        messages: [
+          buildMetadataSystemPrompt(),
+          buildMetadataPrompt(
+            instruction,
+            refinedResponse,
+            chunksSeen,
+            chunksTotal,
+          ),
+        ],
+        response_model: {
+          name: "Metadata",
+          schema: metadataSchema,
+        },
+        temperature: 0.1,
+        top_p: 1,
+        frequency_penalty: 0,
+        presence_penalty: 0,
+        requestId,
       },
-      temperature: 0.1,
-      top_p: 1,
-      frequency_penalty: 0,
-      presence_penalty: 0,
-      requestId,
+      logger,
     });
 
   return {
@@ -261,12 +276,14 @@ export async function observe({
   llmClient,
   image,
   requestId,
+  logger,
 }: {
   instruction: string;
   domElements: string;
   llmClient: LLMClient;
   image?: Buffer;
   requestId: string;
+  logger: (message: LogLine) => void;
 }): Promise<{
   elements: { elementId: number; description: string }[];
 }> {
@@ -289,22 +306,25 @@ export async function observe({
 
   const observationResponse =
     await llmClient.createChatCompletion<ObserveResponse>({
-      messages: [
-        buildObserveSystemPrompt(),
-        buildObserveUserMessage(instruction, domElements),
-      ],
-      image: image
-        ? { buffer: image, description: AnnotatedScreenshotText }
-        : undefined,
-      response_model: {
-        schema: observeSchema,
-        name: "Observation",
+      options: {
+        messages: [
+          buildObserveSystemPrompt(),
+          buildObserveUserMessage(instruction, domElements),
+        ],
+        image: image
+          ? { buffer: image, description: AnnotatedScreenshotText }
+          : undefined,
+        response_model: {
+          schema: observeSchema,
+          name: "Observation",
+        },
+        temperature: 0.1,
+        top_p: 1,
+        frequency_penalty: 0,
+        presence_penalty: 0,
+        requestId,
       },
-      temperature: 0.1,
-      top_p: 1,
-      frequency_penalty: 0,
-      presence_penalty: 0,
-      requestId,
+      logger,
     });
 
   const parsedResponse = {
@@ -316,26 +336,4 @@ export async function observe({
   } satisfies { elements: { elementId: number; description: string }[] };
 
   return parsedResponse;
-}
-
-export async function ask({
-  question,
-  llmClient,
-  requestId,
-}: {
-  question: string;
-  llmClient: LLMClient;
-  requestId: string;
-}) {
-  const response = await llmClient.createChatCompletion({
-    messages: [buildAskSystemPrompt(), buildAskUserPrompt(question)],
-    temperature: 0.1,
-    top_p: 1,
-    frequency_penalty: 0,
-    presence_penalty: 0,
-    requestId,
-  });
-
-  // The parsing is now handled in the LLM clients
-  return response.choices[0].message.content;
 }

--- a/lib/inference.ts
+++ b/lib/inference.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { ActCommandParams, ActCommandResult } from "../types/act";
 import { VerifyActCompletionParams } from "../types/inference";
 import { LogLine } from "../types/log";
+import {
   AnnotatedScreenshotText,
   ChatMessage,
   LLMClient,

--- a/lib/llm/LLMClient.ts
+++ b/lib/llm/LLMClient.ts
@@ -1,6 +1,7 @@
 import { ZodType } from "zod";
 import { LLMTool } from "../../types/llm";
 import { AvailableModel, ClientOptions } from "../../types/model";
+import { LogLine } from "../../types/log";
 
 export interface ChatMessage {
   role: "system" | "user" | "assistant";
@@ -82,6 +83,12 @@ export type LLMResponse = {
   };
 };
 
+export interface CreateChatCompletionOptions {
+  options: ChatCompletionOptions;
+  logger: (message: LogLine) => void;
+  retries?: number;
+}
+
 export abstract class LLMClient {
   public type: "openai" | "anthropic" | string;
   public modelName: AvailableModel;
@@ -94,7 +101,6 @@ export abstract class LLMClient {
   }
 
   abstract createChatCompletion<T = LLMResponse>(
-    options: ChatCompletionOptions,
+    options: CreateChatCompletionOptions,
   ): Promise<T>;
-  abstract logger: (message: { category?: string; message: string }) => void;
 }

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -351,21 +351,3 @@ export function buildObserveUserMessage(
 DOM: ${domElements}`,
   };
 }
-
-// ask
-const askSystemPrompt = `
-you are a simple question answering assistent given the user's question. respond with only the answer.
-`;
-export function buildAskSystemPrompt(): ChatMessage {
-  return {
-    role: "system",
-    content: askSystemPrompt,
-  };
-}
-
-export function buildAskUserPrompt(question: string): ChatMessage {
-  return {
-    role: "user",
-    content: `question: ${question}`,
-  };
-}


### PR DESCRIPTION
# why
Increased simplicity in instantiating LLMClient objects

# what changed
Removed the `logger` parameter from LLMClient constructors and moved it to the `createChatCompletion` method options.

# test plan
Existing evals