### PR TITLE
Fix: Export LLMClient types

### DIFF
--- a/.changeset/thin-squids-listen.md
+++ b/.changeset/thin-squids-listen.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Export LLMClient type

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -626,4 +626,4 @@ export * from "../types/model";
 export * from "../types/playwright";
 export * from "../types/stagehand";
 export * from "../types/page";
-export { LLMClient } from "./llm/LLMClient";
+export * from "./llm/LLMClient";


### PR DESCRIPTION
# why
Can't import `createChatCompletionOptions` when implementing custom LLMClient on `create-browser-app`

# what changed
Export `LLMClient` types

# test plan
test installing `alpha` version on `create-browser-app`