### PR TITLE
fix: avoid unnecessary 'miss cache' on OpenAiClient

### DIFF
--- a/lib/llm/OpenAIClient.ts
+++ b/lib/llm/OpenAIClient.ts
@@ -149,6 +149,11 @@ export class OpenAIClient extends LLMClient {
     };
 
     if (this.enableCaching) {
+      // TODO: harded coded for now, need to find a better way to do this
+      if (cacheOptions.response_model?.schema?._cached){
+        cacheOptions.response_model.schema._cached = null;
+      }
+
       const cachedResponse = await this.cache.get<T>(
         cacheOptions,
         options.requestId,
@@ -418,6 +423,11 @@ export class OpenAIClient extends LLMClient {
         }
 
         throw new Error("Invalid response schema");
+      }
+
+      // TODO: harded coded for now, need to find a better way to do this
+      if (cacheOptions.response_model?.schema?._cached){
+        cacheOptions.response_model.schema._cached = null;
       }
 
       if (this.enableCaching) {


### PR DESCRIPTION
# why
Fix: cache issue
# what changed
Remove cached value of ZodObject before cache key is generated
# test plan
