### PR TITLE
combination needs e2e:bb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
         run: npm run e2e:bb
 
   run-combination-evals:
-    needs: [run-e2e-tests, determine-evals]
+    needs: [run-e2e-bb-tests, run-e2e-tests, determine-evals]
     runs-on: ubuntu-latest
     timeout-minutes: 40
     env:


### PR DESCRIPTION
# what changed
- don't run braintrust evals until both e2e and e2e:bb finish
