### PR TITLE
Scroll on 'main scrollable element' when possible

### DIFF
--- a/.changeset/stupid-starfishes-type.md
+++ b/.changeset/stupid-starfishes-type.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": minor
+---
+
+in ProcessAllOfDom, scroll on large scrollable elements instead of just the root DOM

--- a/evals/evals.config.json
+++ b/evals/evals.config.json
@@ -204,6 +204,14 @@
     {
       "name": "extract_research_reports",
       "categories": ["text_extract"]
+    },
+    {
+      "name": "extract_apartments",
+      "categories": ["text_extract"]
+    },
+    {
+      "name": "extract_zillow",
+      "categories": ["text_extract"]
     }
   ]
 }

--- a/evals/tasks/extract_apartments.ts
+++ b/evals/tasks/extract_apartments.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+import { initStagehand } from "../initStagehand";
+import { EvalFunction } from "../../types/evals";
+
+export const extract_apartments: EvalFunction = async ({
+  modelName,
+  logger,
+  useTextExtract,
+}) => {
+  const { stagehand, initResponse } = await initStagehand({
+    modelName,
+    logger,
+    domSettleTimeoutMs: 3000,
+  });
+
+  const { debugUrl, sessionUrl } = initResponse;
+
+  await stagehand.page.goto(
+    "https://www.apartments.com/san-francisco-ca/2-bedrooms/",
+  );
+  const apartment_listings = await stagehand.page.extract({
+    instruction:
+      "Extract all the apartment listings with their prices and their addresses.",
+    schema: z.object({
+      listings: z.array(
+        z.object({
+          price: z.string().describe("The price of the listing"),
+          trails: z.string().describe("The address of the listing"),
+        }),
+      ),
+    }),
+    modelName,
+    useTextExtract,
+  });
+
+  await stagehand.close();
+  const listings = apartment_listings.listings;
+  const expectedLength = 40;
+
+  if (listings.length < expectedLength) {
+    logger.error({
+      message: "Incorrect number of listings extracted",
+      level: 0,
+      auxiliary: {
+        expected: {
+          value: expectedLength.toString(),
+          type: "integer",
+        },
+        actual: {
+          value: listings.length.toString(),
+          type: "integer",
+        },
+      },
+    });
+    return {
+      _success: false,
+      error: "Incorrect number of listings extracted",
+      logs: logger.getLogs(),
+      debugUrl,
+      sessionUrl,
+    };
+  }
+
+  return {
+    _success: true,
+    logs: logger.getLogs(),
+    debugUrl,
+    sessionUrl,
+  };
+};

--- a/evals/tasks/extract_zillow.ts
+++ b/evals/tasks/extract_zillow.ts
@@ -13,14 +13,12 @@ export const extract_zillow: EvalFunction = async ({
     domSettleTimeoutMs: 3000,
     configOverrides: {
       debugDom: false,
-    }
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;
 
-  await stagehand.page.goto(
-    "https://zillow-eval.surge.sh/"
-  );
+  await stagehand.page.goto("https://zillow-eval.surge.sh/");
   // timeout for 5 seconds
   await stagehand.page.waitForTimeout(5000);
   const real_estate_listings = await stagehand.page.extract({

--- a/evals/tasks/extract_zillow.ts
+++ b/evals/tasks/extract_zillow.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+import { initStagehand } from "../initStagehand";
+import { EvalFunction } from "../../types/evals";
+
+export const extract_zillow: EvalFunction = async ({
+  modelName,
+  logger,
+  useTextExtract,
+}) => {
+  const { stagehand, initResponse } = await initStagehand({
+    modelName,
+    logger,
+    domSettleTimeoutMs: 3000,
+  });
+
+  const { debugUrl, sessionUrl } = initResponse;
+
+  await stagehand.page.goto(
+    "https://www.zillow.com/homes/San-Francisco,-CA_rb/",
+  );
+  const real_estate_listings = await stagehand.page.extract({
+    instruction:
+      "Extract all the real estate listings with their prices and their addresses.",
+    schema: z.object({
+      listings: z.array(
+        z.object({
+          price: z.string().describe("The price of the listing"),
+          trails: z.string().describe("The address of the listing"),
+        }),
+      ),
+    }),
+    modelName,
+    useTextExtract,
+  });
+
+  await stagehand.close();
+  const listings = real_estate_listings.listings;
+  const expectedLength = 38;
+
+  if (listings.length < expectedLength) {
+    logger.error({
+      message: "Incorrect number of listings extracted",
+      level: 0,
+      auxiliary: {
+        expected: {
+          value: expectedLength.toString(),
+          type: "integer",
+        },
+        actual: {
+          value: listings.length.toString(),
+          type: "integer",
+        },
+      },
+    });
+    return {
+      _success: false,
+      error: "Incorrect number of listings extracted",
+      logs: logger.getLogs(),
+      debugUrl,
+      sessionUrl,
+    };
+  }
+
+  return {
+    _success: true,
+    logs: logger.getLogs(),
+    debugUrl,
+    sessionUrl,
+  };
+};

--- a/evals/tasks/extract_zillow.ts
+++ b/evals/tasks/extract_zillow.ts
@@ -11,21 +11,26 @@ export const extract_zillow: EvalFunction = async ({
     modelName,
     logger,
     domSettleTimeoutMs: 3000,
+    configOverrides: {
+      debugDom: false,
+    }
   });
 
   const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(
-    "https://www.zillow.com/homes/San-Francisco,-CA_rb/",
+    "https://zillow-eval.surge.sh/"
   );
+  // timeout for 5 seconds
+  await stagehand.page.waitForTimeout(5000);
   const real_estate_listings = await stagehand.page.extract({
     instruction:
-      "Extract all the real estate listings with their prices and their addresses.",
+      "Extract EACH AND EVERY HOME PRICE AND ADDRESS ON THE PAGE. DO NOT MISS ANY OF THEM.",
     schema: z.object({
       listings: z.array(
         z.object({
-          price: z.string().describe("The price of the listing"),
-          trails: z.string().describe("The address of the listing"),
+          price: z.string().describe("The price of the home"),
+          trails: z.string().describe("The address of the home"),
         }),
       ),
     }),

--- a/lib/dom/ElementContainer.ts
+++ b/lib/dom/ElementContainer.ts
@@ -12,6 +12,7 @@ export class ElementContainer implements StagehandContainer {
   }
 
   public async scrollTo(offset: number): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, 1500));
     this.el.scrollTo({ top: offset, left: 0, behavior: "smooth" });
     await this.waitForScrollEnd();
   }

--- a/lib/dom/ElementContainer.ts
+++ b/lib/dom/ElementContainer.ts
@@ -1,0 +1,33 @@
+import { StagehandContainer } from "./StagehandContainer";
+
+export class ElementContainer implements StagehandContainer {
+  constructor(private el: HTMLElement) {}
+
+  public getViewportHeight(): number {
+    return this.el.clientHeight;
+  }
+
+  public getScrollHeight(): number {
+    return this.el.scrollHeight;
+  }
+
+  public async scrollTo(offset: number): Promise<void> {
+    this.el.scrollTo({ top: offset, left: 0, behavior: "smooth" });
+    await this.waitForScrollEnd();
+  }
+
+  private async waitForScrollEnd(): Promise<void> {
+    return new Promise<void>((resolve) => {
+      let scrollEndTimer: number;
+      const handleScroll = () => {
+        clearTimeout(scrollEndTimer);
+        scrollEndTimer = window.setTimeout(() => {
+          this.el.removeEventListener("scroll", handleScroll);
+          resolve();
+        }, 100);
+      };
+      this.el.addEventListener("scroll", handleScroll, { passive: true });
+      handleScroll();
+    });
+  }
+}

--- a/lib/dom/GlobalPageContainer.ts
+++ b/lib/dom/GlobalPageContainer.ts
@@ -12,7 +12,7 @@ export class GlobalPageContainer implements StagehandContainer {
 
   public async scrollTo(offset: number): Promise<void> {
     await new Promise((resolve) => setTimeout(resolve, 1500));
-    window.scrollTo({ top: offset, left: 0, behavior: "smooth" , });
+    window.scrollTo({ top: offset, left: 0, behavior: "smooth" });
     await this.waitForScrollEnd();
   }
 

--- a/lib/dom/GlobalPageContainer.ts
+++ b/lib/dom/GlobalPageContainer.ts
@@ -1,0 +1,32 @@
+import { StagehandContainer } from "./StagehandContainer";
+import { calculateViewportHeight } from "./utils";
+
+export class GlobalPageContainer implements StagehandContainer {
+  public getViewportHeight(): number {
+    return calculateViewportHeight();
+  }
+
+  public getScrollHeight(): number {
+    return document.documentElement.scrollHeight;
+  }
+
+  public async scrollTo(offset: number): Promise<void> {
+    window.scrollTo({ top: offset, left: 0, behavior: "smooth" });
+    await this.waitForScrollEnd();
+  }
+
+  private async waitForScrollEnd(): Promise<void> {
+    return new Promise<void>((resolve) => {
+      let scrollEndTimer: number;
+      const handleScroll = () => {
+        clearTimeout(scrollEndTimer);
+        scrollEndTimer = window.setTimeout(() => {
+          window.removeEventListener("scroll", handleScroll);
+          resolve();
+        }, 100);
+      };
+      window.addEventListener("scroll", handleScroll, { passive: true });
+      handleScroll();
+    });
+  }
+}

--- a/lib/dom/GlobalPageContainer.ts
+++ b/lib/dom/GlobalPageContainer.ts
@@ -11,7 +11,8 @@ export class GlobalPageContainer implements StagehandContainer {
   }
 
   public async scrollTo(offset: number): Promise<void> {
-    window.scrollTo({ top: offset, left: 0, behavior: "smooth" });
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+    window.scrollTo({ top: offset, left: 0, behavior: "smooth" , });
     await this.waitForScrollEnd();
   }
 

--- a/lib/dom/StagehandContainer.ts
+++ b/lib/dom/StagehandContainer.ts
@@ -1,0 +1,9 @@
+export interface StagehandContainer {
+  getViewportHeight(): number;
+
+  getScrollHeight(): number;
+
+  scrollTo(offset: number): Promise<void>;
+
+  waitForScrollEnd?(): Promise<void>;
+}

--- a/lib/dom/StagehandContainer.ts
+++ b/lib/dom/StagehandContainer.ts
@@ -1,5 +1,4 @@
 export interface StagehandContainer {
-
   getViewportHeight(): number;
 
   getScrollHeight(): number;

--- a/lib/dom/StagehandContainer.ts
+++ b/lib/dom/StagehandContainer.ts
@@ -1,9 +1,8 @@
 export interface StagehandContainer {
+
   getViewportHeight(): number;
 
   getScrollHeight(): number;
 
   scrollTo(offset: number): Promise<void>;
-
-  waitForScrollEnd?(): Promise<void>;
 }

--- a/lib/dom/containerFactory.ts
+++ b/lib/dom/containerFactory.ts
@@ -1,0 +1,16 @@
+import { StagehandContainer } from "./StagehandContainer";
+import { GlobalPageContainer } from "./GlobalPageContainer";
+import { ElementContainer } from "./ElementContainer";
+
+/**
+ * Decide which container to create.
+ */
+export function createStagehandContainer(
+  obj: Window | HTMLElement,
+): StagehandContainer {
+  if (obj instanceof Window) {
+    return new GlobalPageContainer();
+  } else {
+    return new ElementContainer(obj);
+  }
+}

--- a/lib/dom/global.d.ts
+++ b/lib/dom/global.d.ts
@@ -19,7 +19,10 @@ declare global {
     }>;
     debugDom: () => Promise<void>;
     cleanupDebug: () => void;
-    scrollToHeight: (height: number) => Promise<void>;
+    scrollToHeight: (
+      containerOrWindow: HTMLElement | Window,
+      height: number,
+    ) => Promise<void>;
     waitForDomSettle: () => Promise<void>;
     __playwright?: unknown;
     __pw_manual?: unknown;

--- a/lib/dom/global.d.ts
+++ b/lib/dom/global.d.ts
@@ -1,3 +1,5 @@
+import { StagehandContainer } from "./StagehandContainer";
+
 export {};
 declare global {
   interface Window {
@@ -19,10 +21,7 @@ declare global {
     }>;
     debugDom: () => Promise<void>;
     cleanupDebug: () => void;
-    scrollToHeight: (
-      containerOrWindow: HTMLElement | Window,
-      height: number,
-    ) => Promise<void>;
+    createStagehandContainer: (obj: Window | HTMLElement) => StagehandContainer;
     waitForDomSettle: () => Promise<void>;
     __playwright?: unknown;
     __pw_manual?: unknown;

--- a/lib/dom/process.ts
+++ b/lib/dom/process.ts
@@ -331,11 +331,7 @@ export function createTextBoundingBoxes(): void {
       if (element.closest(".stagehand-nav, .stagehand-marker")) {
         return;
       }
-      if (
-        ["SCRIPT", "STYLE", "IFRAME", "INPUT"].includes(
-          element.tagName,
-        )
-      ) {
+      if (["SCRIPT", "STYLE", "IFRAME", "INPUT"].includes(element.tagName)) {
         return;
       }
 

--- a/lib/dom/process.ts
+++ b/lib/dom/process.ts
@@ -76,7 +76,10 @@ export async function processAllOfDom() {
 
   const mainScrollable = getMainScrollableElement();
 
-  const container = createStagehandContainer(mainScrollable);
+  const container =
+    mainScrollable === document.documentElement
+      ? createStagehandContainer(window)
+      : createStagehandContainer(mainScrollable);
 
   const viewportHeight = container.getViewportHeight();
   const documentHeight = container.getScrollHeight();

--- a/lib/dom/utils.ts
+++ b/lib/dom/utils.ts
@@ -19,3 +19,43 @@ window.waitForDomSettle = waitForDomSettle;
 export function calculateViewportHeight() {
   return Math.ceil(window.innerHeight * 0.75);
 }
+
+/**
+ * Tests if the element actually responds to .scrollTo(...)
+ * and that scrollTop changes as expected.
+ */
+export function canElementScroll(elem: HTMLElement): boolean {
+  // Quick check if scrollTo is a function
+  if (typeof elem.scrollTo !== "function") {
+    console.warn("canElementScroll: .scrollTo is not a function.");
+    return false;
+  }
+
+  try {
+    const originalTop = elem.scrollTop;
+
+    // try to scroll
+    elem.scrollTo({
+      top: originalTop + 100,
+      left: 0,
+      behavior: "instant",
+    });
+
+    // If scrollTop never changed, consider it unscrollable
+    if (elem.scrollTop === originalTop) {
+      throw new Error("scrollTop did not change");
+    }
+
+    // Scroll back to original place
+    elem.scrollTo({
+      top: originalTop,
+      left: 0,
+      behavior: "instant",
+    });
+
+    return true;
+  } catch (error) {
+    console.warn("canElementScroll error:", (error as Error).message || error);
+    return false;
+  }
+}

--- a/lib/handlers/actHandler.ts
+++ b/lib/handlers/actHandler.ts
@@ -1199,7 +1199,7 @@ export class StagehandActHandler {
             },
           });
           await this.stagehandPage.page.evaluate(() =>
-            window.scrollToHeight(0),
+            window.scrollToHeight(document.documentElement, 0),
           );
           return await this.act({
             action,

--- a/lib/handlers/actHandler.ts
+++ b/lib/handlers/actHandler.ts
@@ -1198,10 +1198,12 @@ export class StagehandActHandler {
               },
             },
           });
-          const container = await this.stagehandPage.page.evaluate(() => {
-            return window.createStagehandContainer(document.documentElement);
+          await this.stagehandPage.page.evaluate(() => {
+            const container = window.createStagehandContainer(
+              document.documentElement,
+            );
+            return container.scrollTo(0);
           });
-          await container.scrollTo(0);
 
           return await this.act({
             action,

--- a/lib/handlers/actHandler.ts
+++ b/lib/handlers/actHandler.ts
@@ -1198,9 +1198,11 @@ export class StagehandActHandler {
               },
             },
           });
-          await this.stagehandPage.page.evaluate(() =>
-            window.scrollToHeight(document.documentElement, 0),
-          );
+          const container = await this.stagehandPage.page.evaluate(() => {
+            return window.createStagehandContainer(document.documentElement);
+          });
+          await container.scrollTo(0);
+
           return await this.act({
             action,
             steps,


### PR DESCRIPTION
# why
- currently, we only scroll on the root DOM element. thus, we ignore elements that are inside a scrollable container
- this is problematic, because there may be other elements that we need to scroll into visibility so that they are included in the list of candidate elements
# examples
## Zillow:
<img width="1496" alt="Screenshot 2025-01-14 at 3 02 33 PM" src="https://github.com/user-attachments/assets/f51b00b9-6102-42af-beb7-99ac6b621761" />

## apartments.com
<img width="1496" alt="Screenshot 2025-01-14 at 3 03 46 PM" src="https://github.com/user-attachments/assets/a3329390-e107-43e3-8185-80e0a794deca" />

# what changed
- updated `processAllOfDom` to attempt scrolling on a large scrollable container, and fall back to the original approach (scrolling on the root DOM) if there are no large scrollable containers

# important note
- this PR should only impact `processAllOfDom`
- this means that we will still need a future PR to extend this logic to `processDom` to enable `act` to take actions on elements that are positioned deep within a scrollable container
- the thought process behind this decision was to control the scope of this PR

# test plan
- added evals for Zillow & apartments.com