### PR TITLE
update `extract_press_releases`

### DIFF
--- a/evals/deterministic/tests/page/waitFor.test.ts
+++ b/evals/deterministic/tests/page/waitFor.test.ts
@@ -17,7 +17,7 @@ test.describe("StagehandPage - waitFor", () => {
     expect(isVisibleBefore).toBe(false);
 
     const clickableElement = page.locator(
-      "div.mt-12:nth-child(3) > ul:nth-child(2) > li:nth-child(2) > div:nth-child(1)",
+      "div.not-prose:nth-child(2) > a:nth-child(1) > div:nth-child(1)",
     );
     await clickableElement.click();
 
@@ -153,7 +153,7 @@ test.describe("StagehandPage - waitFor", () => {
     await page.goto("https://docs.browserbase.com");
 
     const quickstartLink = page.locator(
-      "div.mt-12:nth-child(3) > ul:nth-child(2) > li:nth-child(2) > div:nth-child(1) > div:nth-child(1)",
+      "div.not-prose:nth-child(2) > a:nth-child(1) > div:nth-child(1)",
     );
     await quickstartLink.click();
 

--- a/evals/tasks/extract_press_releases.ts
+++ b/evals/tasks/extract_press_releases.ts
@@ -54,8 +54,8 @@ export const extract_press_releases: EvalFunction = async ({
       publish_date: "Dec 4, 2024",
     };
     const expectedLastItem: PressRelease = {
-      title: "Brad Lander for Comptroller",
-      publish_date: "Jun 8, 2021",
+      title: "Fox Sued by New York City Pension Funds Over Election Falsehoods",
+      publish_date: "Nov 12, 2023",
     };
 
     if (items.length <= expectedLength) {


### PR DESCRIPTION
# why
- target website changed 
- BB docs changed (failed e2e tests)
# what changed
- update expected value
- update selectors in e2e tests
# test plan
