### PR TITLE
incorporate feedback on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ await page.goto("https://docs.stagehand.dev");
 const { description } = await page.extract({
   instruction: "Extract the description of the page",
   schema: z.object({
-	description: z.string(),
+    description: z.string(),
   }),
 });
 

--- a/README.md
+++ b/README.md
@@ -43,11 +43,23 @@
 
 Stagehand is the easiest way to build browser automations. It is fully compatible with [Playwright](https://playwright.dev/), offering three simple AI APIs (`act`, `extract`, and `observe`) on top of the base Playwright `Page` class that provide the building blocks for web automation via natural language. It also makes Playwright more accessible to non-technical users and less vulnerable to minor changes in the UI/DOM.
 
-Anything that can be done in a browser can be done with Stagehand. Consider:
+Here's a sample of what you can do with Stagehand:
 
-1. Go to Hacker News and extract the top stories of the day
-1. Log into Amazon, search for AirPods, and buy the most relevant product
-1. Go to ESPN, search for Steph Curry, and get stats for his last 10 games
+```typescript
+// Keep your existing Playwright code unchanged
+await page.goto("https://docs.stagehand.dev");
+
+// Stagehand AI: Extract data from the page
+const { description } = await page.extract({
+	instruction: "Extract the description of the page",
+	schema: z.object({
+		description: z.string(),
+	}),
+});
+
+// Stagehand AI: Act on the page
+await page.act({ action: "click on the 'Quickstart' button" });
+```
 
 Stagehand makes it easier to write durable, performant browser automation code. When used with [Browserbase](https://browserbase.com/), it offers unparalleled debugging tools like session replay and step-by-step debugging.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ const { description } = await page.extract({
 });
 
 // Stagehand AI: Act on the page
-await page.act({ action: "click on the 'Quickstart' button" });
+await page.act({ action: "click on the 'Quickstart'" });
 ```
 
 Stagehand makes it easier to write durable, performant browser automation code. When used with [Browserbase](https://browserbase.com/), it offers unparalleled debugging tools like session replay and step-by-step debugging.

--- a/README.md
+++ b/README.md
@@ -61,8 +61,6 @@ const { description } = await page.extract({
 await page.act({ action: "click on the 'Quickstart'" });
 ```
 
-Stagehand makes it easier to write durable, performant browser automation code. When used with [Browserbase](https://browserbase.com/), it offers unparalleled debugging tools like session replay and step-by-step debugging.
-
 It's also taking a somewhat unconventional approach to web agents, relying heavily on the underlying DOM and accessibility tree (a11y tree) to feed into LLMs, as opposed to using more traditionally vision-based approaches. For more on this, read [how Stagehand works](https://docs.stagehand.dev/get_started/walkthrough).
 
 > [!NOTE] 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 
 ---
 
-Stagehand is the easiest way to build browser automations. It is fully compatible with [Playwright](https://playwright.dev/), offering three simple AI APIs (`act`, `extract`, and `observe`) on top of the base Playwright `Page` class that provide the building blocks for web automation via natural language. It also makes Playwright more accessible to non-technical users and less vulnerable to minor changes in the UI/DOM.
+Stagehand is the easiest way to build browser automations. It is fully compatible with [Playwright](https://playwright.dev/), offering three simple AI APIs (`act`, `extract`, and `observe`) on top of the base Playwright `Page` class that provide the building blocks for web automation via natural language. 
 
 Here's a sample of what you can do with Stagehand:
 
@@ -61,7 +61,12 @@ const { description } = await page.extract({
 await page.act({ action: "click on the 'Quickstart'" });
 ```
 
-It's also taking a somewhat unconventional approach to web agents, relying heavily on the underlying DOM and accessibility tree (a11y tree) to feed into LLMs, as opposed to using more traditionally vision-based approaches. For more on this, read [how Stagehand works](https://docs.stagehand.dev/get_started/walkthrough).
+## Why?
+**Stagehand adds determinism to otherwise unpredictable agents.**
+
+While there's no limit to what you could instruct Stagehand to do, our primitives allow you to control how much you want to leave to an AI. It works best when your code is a sequence of atomic actions. Instead of writing a single script for a single website, Stagehand allows you to write durable, self-healing, and repeatable web automation workflows that actually work.
+
+Stagehand heavily relies on the underlying DOM and accessibility tree (a11y tree) to feed into LLMs, as opposed to using more traditionally vision-based approaches. For more on how Stagehand works, read [how Stagehand works](https://docs.stagehand.dev/get_started/walkthrough).
 
 > [!NOTE] 
 > `Stagehand` is currently available as an early release, and we're actively seeking feedback from the community. Please join our [Slack community](https://join.slack.com/t/stagehand-dev/shared_invite/zt-2tdncfgkk-fF8y5U0uJzR2y2_M9c9OJA) to stay updated on the latest developments and provide feedback.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ await page.act({ action: "click on the 'Quickstart'" });
 
 Stagehand makes it easier to write durable, performant browser automation code. When used with [Browserbase](https://browserbase.com/), it offers unparalleled debugging tools like session replay and step-by-step debugging.
 
+It's also taking a somewhat unconventional approach to web agents, relying heavily on the underlying DOM and accessibility tree (a11y tree) to feed into LLMs, as opposed to using more traditionally vision-based approaches. For more on this, read [how Stagehand works](https://docs.stagehand.dev/get_started/walkthrough).
+
 > [!NOTE] 
 > `Stagehand` is currently available as an early release, and we're actively seeking feedback from the community. Please join our [Slack community](https://join.slack.com/t/stagehand-dev/shared_invite/zt-2tdncfgkk-fF8y5U0uJzR2y2_M9c9OJA) to stay updated on the latest developments and provide feedback.
 

--- a/README.md
+++ b/README.md
@@ -66,8 +66,6 @@ await page.act({ action: "click on the 'Quickstart'" });
 
 While there's no limit to what you could instruct Stagehand to do, our primitives allow you to control how much you want to leave to an AI. It works best when your code is a sequence of atomic actions. Instead of writing a single script for a single website, Stagehand allows you to write durable, self-healing, and repeatable web automation workflows that actually work.
 
-Stagehand heavily relies on the underlying DOM and accessibility tree (a11y tree) to feed into LLMs, as opposed to using more traditionally vision-based approaches. For more on how Stagehand works, read [how Stagehand works](https://docs.stagehand.dev/get_started/walkthrough).
-
 > [!NOTE] 
 > `Stagehand` is currently available as an early release, and we're actively seeking feedback from the community. Please join our [Slack community](https://join.slack.com/t/stagehand-dev/shared_invite/zt-2tdncfgkk-fF8y5U0uJzR2y2_M9c9OJA) to stay updated on the latest developments and provide feedback.
 

--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ await page.goto("https://docs.stagehand.dev");
 
 // Stagehand AI: Extract data from the page
 const { description } = await page.extract({
-	instruction: "Extract the description of the page",
-	schema: z.object({
-		description: z.string(),
-	}),
+  instruction: "Extract the description of the page",
+  schema: z.object({
+	description: z.string(),
+  }),
 });
 
 // Stagehand AI: Act on the page


### PR DESCRIPTION
Feedback from swyx - we need to make it a lot more obvious on first skim what we're doing. i don't want users to have to actually read the words in the README to communicate value.

Notes:
- Can't skim easily
- Draw more attention to how we use AI/LLMs
- Add a vertical screenshot on the README
- Show simple code example, maybe not prescriptive code but indicative