### PR TITLE
queue jobs based on labels: dont run concurrently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,3 +404,4 @@ jobs:
             echo "Eval summary not found for observe category. Failing CI."
             exit 1
           fi
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,7 @@ jobs:
     timeout-minutes: 25
     concurrency:
       group: evals-${{ github.run_id }}
-      cancel-in-progress: false
+      cancel-in-progress: true
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -237,7 +237,7 @@ jobs:
     timeout-minutes: 50
     concurrency:
       group: evals-${{ github.run_id }}
-      cancel-in-progress: false
+      cancel-in-progress: true
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -299,7 +299,7 @@ jobs:
     timeout-minutes: 120
     concurrency:
       group: evals-${{ github.run_id }}
-      cancel-in-progress: false
+      cancel-in-progress: true
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -361,7 +361,7 @@ jobs:
     timeout-minutes: 25
     concurrency:
       group: evals-${{ github.run_id }}
-      cancel-in-progress: false
+      cancel-in-progress: true
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -404,4 +404,3 @@ jobs:
             echo "Eval summary not found for observe category. Failing CI."
             exit 1
           fi
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,9 @@ jobs:
     if: needs.determine-evals.outputs.run-act == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    concurrency:
+      group: evals-${{ github.run_id }}
+      cancel-in-progress: false
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -232,6 +235,9 @@ jobs:
     if: needs.determine-evals.outputs.run-extract == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 50
+    concurrency:
+      group: evals-${{ github.run_id }}
+      cancel-in-progress: false
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -291,6 +297,9 @@ jobs:
     if: needs.determine-evals.outputs.run-text-extract == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    concurrency:
+      group: evals-${{ github.run_id }}
+      cancel-in-progress: false
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -350,6 +359,9 @@ jobs:
     if: needs.determine-evals.outputs.run-observe == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    concurrency:
+      group: evals-${{ github.run_id }}
+      cancel-in-progress: false
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
# why
- dont overload BB
# what changed
- updated CI to queue jobs instead of running selected jobs all at the same time
# example
## we will do this:
<img width="1031" alt="Screenshot 2025-01-17 at 1 25 35 PM" src="https://github.com/user-attachments/assets/532f8a81-ab25-494c-905a-3633d0e2701d" />

## instead of this:
![screenshot_2025-01-15_at_6 33 19___pm_480](https://github.com/user-attachments/assets/5ad91544-d493-4373-8d99-0b03f4b47ebf)
