### PR TITLE
rm isTopElement check from isTextVisible

### DIFF
--- a/lib/dom/process.ts
+++ b/lib/dom/process.ts
@@ -532,9 +532,6 @@ const isTextVisible = (element: ChildNode) => {
   if (!parent) {
     return false;
   }
-  if (!isTopElement(parent, rect)) {
-    return false;
-  }
 
   const visible = parent.checkVisibility({
     checkOpacity: true,


### PR DESCRIPTION
# why
- checking if the parent element of text node is the top most element seems arbitrary: the parent element itself does not have to be the top most element for the text node itself to be visible
- this _part of_ what makes a github eval (not yet added to evals) fail
## for example:
The highlighted code below is excluded from candidate elements with this check

<img width="1496" alt="Screenshot 2025-01-17 at 5 34 12 PM" src="https://github.com/user-attachments/assets/b8d471b0-b05a-4ffe-b9e9-827d67627a56" />

# what changed
- remove the `isTopMostElement` check from `isTextVisible`
# test plan
