### PR TITLE
Revert back to sequential evals runs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,8 +167,10 @@ jobs:
       - name: Build Stagehand
         run: npm run build
 
-      - name: Run Combination Evals
-        run: npm run evals category combination
+      - name: Dummy Combination Evals
+        run: |
+          echo "Running dummy combination evals..."
+          echo '{"experimentName":"dummyCombination","categories":{"combination":95}}' > eval-summary.json
 
       - name: Log Combination Evals Performance
         run: |
@@ -222,8 +224,10 @@ jobs:
       - name: Build Stagehand
         run: npm run build
 
-      - name: Run Act Evals
-        run: npm run evals category act
+      - name: Dummy Act Evals
+        run: |
+          echo "Running dummy act evals..."
+          echo '{"experimentName":"dummyAct","categories":{"act":82}}' > eval-summary.json
 
       - name: Log Act Evals Performance
         run: |
@@ -281,14 +285,18 @@ jobs:
         run: npm exec playwright install --with-deps
 
       # 1. Run extract category with domExtract
-      - name: Run Extract Evals (domExtract)
-        run: npm run evals category extract -- --extract-method=domExtract
+      - name: Dummy Extract Evals (domExtract)
+        run: |
+          echo "Running dummy extract evals (domExtract)..."
+          echo '{"experimentName":"dummyDomExtract","categories":{"extract":85}}' > eval-summary.json
       - name: Save Extract Dom Results
         run: mv eval-summary.json eval-summary-extract-dom.json
 
       # 2. Then run extract category with textExtract
-      - name: Run Extract Evals (textExtract)
-        run: npm run evals category extract -- --extract-method=textExtract
+      - name: Dummy Extract Evals (textExtract)
+        run: |
+          echo "Running dummy extract evals (textExtract)..."
+          echo '{"experimentName":"dummyTextExtract","categories":{"extract":90}}' > eval-summary.json
       - name: Save Extract Text Results
         run: mv eval-summary.json eval-summary-extract-text.json
 
@@ -351,14 +359,18 @@ jobs:
         run: npm run build
 
       # 1. text_extract with textExtract first
-      - name: Run text_extract Evals (textExtract)
-        run: npm run evals category text_extract -- --extract-method=textExtract
+      - name: Dummy text_extract Evals (textExtract)
+        run: |
+          echo "Running dummy text_extract (textExtract)..."
+          echo '{"experimentName":"dummyTextExtract","categories":{"text_extract":90}}' > eval-summary.json
       - name: Save text_extract Text Results
         run: mv eval-summary.json eval-summary-text_extract-text.json
 
       # 2. Then domExtract
-      - name: Run text_extract Evals (domExtract)
-        run: npm run evals category text_extract -- --extract-method=domExtract
+      - name: Dummy text_extract Evals (domExtract)
+        run: |
+          echo "Running dummy text_extract (domExtract)..."
+          echo '{"experimentName":"dummyDomExtract","categories":{"text_extract":88}}' > eval-summary.json
       - name: Save text_extract Dom Results
         run: mv eval-summary.json eval-summary-text_extract-dom.json
 
@@ -420,8 +432,10 @@ jobs:
       - name: Build Stagehand
         run: npm run build
 
-      - name: Run Observe Evals
-        run: npm run evals category observe
+      - name: Dummy Observe Evals
+        run: |
+          echo "Running dummy observe evals..."
+          echo '{"experimentName":"dummyObserve","categories":{"observe":85}}' > eval-summary.json
 
       - name: Log Observe Evals Performance
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,6 @@ env:
   EVAL_MODELS: "gpt-4o,gpt-4o-mini,claude-3-5-sonnet-latest"
   EVAL_CATEGORIES: "observe,act,combination,extract,text_extract"
 
-concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   determine-evals:
     runs-on: ubuntu-latest
@@ -167,28 +163,8 @@ jobs:
       - name: Install Playwright browsers
         run: npm exec playwright install --with-deps
 
-      # --- LOG eval-summary.json (before) ---
-      - name: Log eval-summary.json (before)
-        run: |
-          echo "### eval-summary.json BEFORE combination ###"
-          if [ -f eval-summary.json ]; then
-            cat eval-summary.json
-          else
-            echo "(No eval-summary.json file yet.)"
-          fi
-
       - name: Run Combination Evals
         run: npm run evals category combination
-
-      # --- LOG eval-summary.json (after) ---
-      - name: Log eval-summary.json (after)
-        run: |
-          echo "### eval-summary.json AFTER combination ###"
-          if [ -f eval-summary.json ]; then
-            cat eval-summary.json
-          else
-            echo "(No eval-summary.json file found.)"
-          fi
 
       - name: Log Combination Evals Performance
         run: |
@@ -203,9 +179,6 @@ jobs:
             exit 1
           fi
 
-  ####################################################################
-  #                      ACT EVALS
-  ####################################################################
   run-act-evals:
     needs: [run-combination-evals, determine-evals]
     runs-on: ubuntu-latest
@@ -250,31 +223,9 @@ jobs:
         if: needs.determine-evals.outputs.run-act == 'true'
         run: npm exec playwright install --with-deps
 
-      # --- LOG eval-summary.json (before) ---
-      - name: Log eval-summary.json (before)
-        if: needs.determine-evals.outputs.run-act == 'true'
-        run: |
-          echo "### eval-summary.json BEFORE act ###"
-          if [ -f eval-summary.json ]; then
-            cat eval-summary.json
-          else
-            echo "(No eval-summary.json file yet.)"
-          fi
-
       - name: Run Act Evals
         if: needs.determine-evals.outputs.run-act == 'true'
         run: npm run evals category act
-
-      # --- LOG eval-summary.json (after) ---
-      - name: Log eval-summary.json (after)
-        if: needs.determine-evals.outputs.run-act == 'true'
-        run: |
-          echo "### eval-summary.json AFTER act ###"
-          if [ -f eval-summary.json ]; then
-            cat eval-summary.json
-          else
-            echo "(No eval-summary.json file found.)"
-          fi
 
       - name: Log Act Evals Performance
         if: needs.determine-evals.outputs.run-act == 'true'
@@ -293,9 +244,6 @@ jobs:
             exit 1
           fi
 
-  ####################################################################
-  #                      EXTRACT EVALS
-  ####################################################################
   run-extract-evals:
     needs: [run-act-evals, determine-evals]
     runs-on: ubuntu-latest
@@ -340,32 +288,10 @@ jobs:
         if: needs.determine-evals.outputs.run-extract == 'true'
         run: npm exec playwright install --with-deps
 
-      # --- Log eval-summary.json (before) ---
-      - name: Log eval-summary.json (before)
-        if: needs.determine-evals.outputs.run-extract == 'true'
-        run: |
-          echo "### eval-summary.json BEFORE extract ###"
-          if [ -f eval-summary.json ]; then
-            cat eval-summary.json
-          else
-            echo "(No eval-summary.json file yet.)"
-          fi
-
       # 1. Run extract category with domExtract
       - name: Run Extract Evals (domExtract)
         if: needs.determine-evals.outputs.run-extract == 'true'
         run: npm run evals category extract -- --extract-method=domExtract
-
-      # --- Log eval-summary.json (after domExtract) ---
-      - name: Log eval-summary.json (after dom)
-        if: needs.determine-evals.outputs.run-extract == 'true'
-        run: |
-          echo "### eval-summary.json AFTER domExtract ###"
-          if [ -f eval-summary.json ]; then
-            cat eval-summary.json
-          else
-            echo "(No eval-summary.json file found.)"
-          fi
 
       - name: Save Extract Dom Results
         if: needs.determine-evals.outputs.run-extract == 'true'
@@ -375,17 +301,6 @@ jobs:
       - name: Run Extract Evals (textExtract)
         if: needs.determine-evals.outputs.run-extract == 'true'
         run: npm run evals category extract -- --extract-method=textExtract
-
-      # --- Log eval-summary.json (after textExtract) ---
-      - name: Log eval-summary.json (after text)
-        if: needs.determine-evals.outputs.run-extract == 'true'
-        run: |
-          echo "### eval-summary.json AFTER textExtract ###"
-          if [ -f eval-summary.json ]; then
-            cat eval-summary.json
-          else
-            echo "(No eval-summary.json file found.)"
-          fi
 
       - name: Save Extract Text Results
         if: needs.determine-evals.outputs.run-extract == 'true'
@@ -411,9 +326,6 @@ jobs:
             exit 1
           fi
 
-  ####################################################################
-  #                      TEXT-EXTRACT EVALS
-  ####################################################################
   run-text-extract-evals:
     needs: [run-extract-evals, determine-evals]
     runs-on: ubuntu-latest
@@ -458,32 +370,10 @@ jobs:
         if: needs.determine-evals.outputs.run-text-extract == 'true'
         run: npm run build
 
-      # --- Log eval-summary.json (before) ---
-      - name: Log eval-summary.json (before)
-        if: needs.determine-evals.outputs.run-text-extract == 'true'
-        run: |
-          echo "### eval-summary.json BEFORE text-extract ###"
-          if [ -f eval-summary.json ]; then
-            cat eval-summary.json
-          else
-            echo "(No eval-summary.json file yet.)"
-          fi
-
       # 1. Run text_extract category with textExtract first
       - name: Run text_extract Evals (textExtract)
         if: needs.determine-evals.outputs.run-text-extract == 'true'
         run: npm run evals category text_extract -- --extract-method=textExtract
-
-      # --- Log eval-summary.json (after textExtract) ---
-      - name: Log eval-summary.json (after textExtract)
-        if: needs.determine-evals.outputs.run-text-extract == 'true'
-        run: |
-          echo "### eval-summary.json AFTER textExtract ###"
-          if [ -f eval-summary.json ]; then
-            cat eval-summary.json
-          else
-            echo "(No eval-summary.json file found.)"
-          fi
 
       - name: Save text_extract Text Results
         if: needs.determine-evals.outputs.run-text-extract == 'true'
@@ -493,17 +383,6 @@ jobs:
       - name: Run text_extract Evals (domExtract)
         if: needs.determine-evals.outputs.run-text-extract == 'true'
         run: npm run evals category text_extract -- --extract-method=domExtract
-
-      # --- Log eval-summary.json (after domExtract) ---
-      - name: Log eval-summary.json (after domExtract)
-        if: needs.determine-evals.outputs.run-text-extract == 'true'
-        run: |
-          echo "### eval-summary.json AFTER domExtract ###"
-          if [ -f eval-summary.json ]; then
-            cat eval-summary.json
-          else
-            echo "(No eval-summary.json file found.)"
-          fi
 
       - name: Save text_extract Dom Results
         if: needs.determine-evals.outputs.run-text-extract == 'true'
@@ -529,9 +408,6 @@ jobs:
             exit 1
           fi
 
-  ####################################################################
-  #                      OBSERVE EVALS
-  ####################################################################
   run-observe-evals:
     needs: [run-text-extract-evals, determine-evals]
     runs-on: ubuntu-latest
@@ -576,31 +452,9 @@ jobs:
         if: needs.determine-evals.outputs.run-observe == 'true'
         run: npm run build
 
-      # --- Log eval-summary.json (before) ---
-      - name: Log eval-summary.json (before)
-        if: needs.determine-evals.outputs.run-observe == 'true'
-        run: |
-          echo "### eval-summary.json BEFORE observe ###"
-          if [ -f eval-summary.json ]; then
-            cat eval-summary.json
-          else
-            echo "(No eval-summary.json file yet.)"
-          fi
-
       - name: Run Observe Evals
         if: needs.determine-evals.outputs.run-observe == 'true'
         run: npm run evals category observe
-
-      # --- Log eval-summary.json (after) ---
-      - name: Log eval-summary.json (after)
-        if: needs.determine-evals.outputs.run-observe == 'true'
-        run: |
-          echo "### eval-summary.json AFTER observe ###"
-          if [ -f eval-summary.json ]; then
-            cat eval-summary.json
-          else
-            echo "(No eval-summary.json file found.)"
-          fi
 
       - name: Log Observe Evals Performance
         if: needs.determine-evals.outputs.run-observe == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,8 +172,18 @@ jobs:
       - name: Install Playwright browsers
         run: npm exec playwright install --with-deps
 
-      - name: Run Combination Evals
-        run: npm run evals category combination
+      - name: Run Combination Evals (Dummy)
+        run: |
+          echo "Pretending to run combination eval..."
+          # Write out a dummy eval-summary.json:
+          cat <<EOF > eval-summary.json
+          {
+            "experimentName": "dummyCombination",
+            "categories": {
+              "combination": 90
+            }
+          }
+          EOF
 
       - name: Log Combination Evals Performance
         run: |
@@ -222,213 +232,54 @@ jobs:
       - name: Install Playwright browsers
         run: npm exec playwright install --with-deps
 
-      # 1. Run extract category with domExtract
+      # 1. "Run Extract Evals (domExtract)" - Dummy
       - name: Run Extract Evals (domExtract)
-        run: npm run evals category extract -- --extract-method=domExtract
+        run: |
+          echo "Pretending to run extract eval with domExtract..."
+          cat <<EOF > eval-summary.json
+          {
+            "experimentName": "dummyExtractDom",
+            "categories": {
+              "extract": 85
+            }
+          }
+          EOF
       - name: Save Extract Dom Results
         run: mv eval-summary.json eval-summary-extract-dom.json
 
-      # 2. Then run extract category with textExtract
+      # 2. "Run Extract Evals (textExtract)" - Dummy
       - name: Run Extract Evals (textExtract)
-        run: npm run evals category extract -- --extract-method=textExtract
+        run: |
+          echo "Pretending to run extract eval with textExtract..."
+          cat <<EOF > eval-summary.json
+          {
+            "experimentName": "dummyExtractText",
+            "categories": {
+              "extract": 92
+            }
+          }
+          EOF
       - name: Save Extract Text Results
         run: mv eval-summary.json eval-summary-extract-text.json
 
-      # 3. Log and Compare
+      # 3. Log and Compare (Dummy)
       - name: Log and Compare Extract Evals Performance
         run: |
+          # Check if we have the domExtract results
           if [ -f eval-summary-extract-dom.json ]; then
             experimentNameDom=$(jq -r '.experimentName' eval-summary-extract-dom.json)
             dom_score=$(jq '.categories.extract' eval-summary-extract-dom.json)
             echo "DomExtract Score: $dom_score%"
             echo "See: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameDom}"
 
-            # Fail if below threshold
+            # Example fail if below threshold
             if (( $(echo "$dom_score < 80" | bc -l) )); then
               echo "DomExtract extract category <80%. Failing CI."
               exit 1
             fi
           fi
 
+          # Check if we have the textExtract results
           if [ -f eval-summary-extract-text.json ]; then
             experimentNameText=$(jq -r '.experimentName' eval-summary-extract-text.json)
-            text_score=$(jq '.categories.extract' eval-summary-extract-text.json)
-            echo "TextExtract Score: $text_score%"
-            echo "See: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameText}"
-          fi
-
-  run-text-extract-evals:
-    needs: [determine-evals, run-combination-evals]
-    if: needs.determine-evals.outputs.run-text-extract == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-    concurrency:
-      group: specialized-evals-${{ github.run_id }}
-      cancel-in-progress: false
-    env:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
-      BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
-      BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
-      HEADLESS: true
-      EVAL_ENV: browserbase
-
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install dependencies
-        run: npm install --no-frozen-lockfile
-
-      - name: Install Playwright browsers
-        run: npm exec playwright install --with-deps
-
-      - name: Build Stagehand
-        run: npm run build
-
-      # 1. text_extract with textExtract
-      - name: Run text_extract Evals (textExtract)
-        run: npm run evals category text_extract -- --extract-method=textExtract
-      - name: Save text_extract Text Results
-        run: mv eval-summary.json eval-summary-text_extract-text.json
-
-      # 2. text_extract with domExtract
-      - name: Run text_extract Evals (domExtract)
-        run: npm run evals category text_extract -- --extract-method=domExtract
-      - name: Save text_extract Dom Results
-        run: mv eval-summary.json eval-summary-text_extract-dom.json
-
-      # 3. Log and Compare
-      - name: Log and Compare text_extract
-        run: |
-          if [ -f eval-summary-text_extract-text.json ]; then
-            experimentNameTxt=$(jq -r '.experimentName' eval-summary-text_extract-text.json)
-            txt_score=$(jq '.categories.text_extract' eval-summary-text_extract-text.json)
-            echo "TextExtract (text_extract) Score: $txt_score%"
-            echo "See: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameTxt}"
-
-            # Optionally fail if <80%
-            if (( $(echo "$txt_score < 80" | bc -l) )); then
-              echo "text_extract score <80%. Failing CI."
-              exit 1
-            fi
-          fi
-
-          if [ -f eval-summary-text_extract-dom.json ]; then
-            experimentNameDom=$(jq -r '.experimentName' eval-summary-text_extract-dom.json)
-            dom_score=$(jq '.categories.text_extract' eval-summary-text_extract-dom.json)
-            echo "DomExtract (text_extract) Score: $dom_score%"
-            echo "See: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameDom}"
-          fi
-
-  run-act-evals:
-    needs: [determine-evals, run-combination-evals]
-    if: needs.determine-evals.outputs.run-act == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
-    concurrency:
-      group: specialized-evals-${{ github.run_id }}
-      cancel-in-progress: false
-    env:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
-      BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
-      BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
-      HEADLESS: true
-      EVAL_ENV: browserbase
-
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install dependencies
-        run: npm install --no-frozen-lockfile
-
-      - name: Install Playwright browsers
-        run: npm exec playwright install --with-deps
-
-      - name: Build Stagehand
-        run: npm run build
-
-      - name: Run Act Evals
-        run: npm run evals category act
-
-      - name: Log Act Evals Performance
-        run: |
-          experimentName=$(jq -r '.experimentName' eval-summary.json)
-          echo "See: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName}"
-          if [ -f eval-summary.json ]; then
-            act_score=$(jq '.categories.act' eval-summary.json)
-            echo "Act category score: $act_score%"
-            if (( $(echo "$act_score < 80" | bc -l) )); then
-              echo "Act <80%. Failing CI."
-              exit 1
-            fi
-          else
-            echo "Eval summary not found. Failing CI."
-            exit 1
-
-  run-observe-evals:
-    needs: [determine-evals, run-combination-evals]
-    if: needs.determine-evals.outputs.run-observe == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
-    concurrency:
-      group: specialized-evals-${{ github.run_id }}
-      cancel-in-progress: false
-    env:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
-      BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
-      BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
-      HEADLESS: true
-      EVAL_ENV: browserbase
-
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install dependencies
-        run: npm install --no-frozen-lockfile
-
-      - name: Install Playwright browsers
-        run: npm exec playwright install --with-deps
-
-      - name: Build Stagehand
-        run: npm run build
-
-      - name: Run Observe Evals
-        run: npm run evals category observe
-
-      - name: Log Observe Evals Performance
-        run: |
-          experimentName=$(jq -r '.experimentName' eval-summary.json)
-          echo "See: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName}"
-          if [ -f eval-summary.json ]; then
-            observe_score=$(jq '.categories.observe' eval-summary.json)
-            echo "Observe category score: $observe_score%"
-            if (( $(echo "$observe_score < 80" | bc -l) )); then
-              echo "Observe <80%. Failing CI."
-              exit 1
-            fi
-          else
-            echo "Eval summary not found. Failing CI."
-            exit 1
+            text_score=$(jq '.categories.extract' eval-summary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,7 @@ jobs:
       - name: Check for 'act' label
         id: label-check
         run: |
-          if [ "${{ contains(github.event.pull_request.labels.*.name, 'act') }}" != "true" ]; then
+          if [ "${{ needs.determine-evals.outputs.run-act }}" != "true" ]; then
             echo "has_label=false" >> $GITHUB_OUTPUT
             echo "No label for ACT. Exiting with success."
           else
@@ -262,7 +262,7 @@ jobs:
 
   # 3) Extract depends on act. If no label: exit 0 and pass.
   run-extract-evals:
-    needs: [run-act-evals]
+    needs: [run-act-evals, determine-evals]
     runs-on: ubuntu-latest
     timeout-minutes: 50
     env:
@@ -336,7 +336,7 @@ jobs:
 
   # 4) Text-extract depends on extract. If no label: exit 0 and pass.
   run-text-extract-evals:
-    needs: [run-extract-evals]
+    needs: [run-extract-evals, determine-evals]
     runs-on: ubuntu-latest
     timeout-minutes: 120
     env:
@@ -410,7 +410,7 @@ jobs:
 
   # 5) Observe depends on text-extract. If no label: exit 0 and pass.
   run-observe-evals:
-    needs: [run-text-extract-evals]
+    needs: [run-text-extract-evals, determine-evals]
     runs-on: ubuntu-latest
     timeout-minutes: 25
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,6 @@ env:
   EVAL_MODELS: "gpt-4o,gpt-4o-mini,claude-3-5-sonnet-latest"
   EVAL_CATEGORIES: "observe,act,combination,extract,text_extract"
 
-concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: false
-
 jobs:
   determine-evals:
     runs-on: ubuntu-latest
@@ -43,6 +39,7 @@ jobs:
           echo "run-text-extract=${{ contains(github.event.pull_request.labels.*.name, 'text-extract') }}" >> $GITHUB_OUTPUT
 
   run-lint:
+    needs: [determine-evals]
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
@@ -60,6 +57,7 @@ jobs:
         run: npm run lint
 
   run-build:
+    needs: [run-lint]
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
@@ -136,7 +134,7 @@ jobs:
         run: npm run e2e:bb
 
   run-combination-evals:
-    needs: [run-e2e-bb-tests, run-e2e-tests, determine-evals]
+    needs: [run-e2e-bb-tests, determine-evals]
     runs-on: ubuntu-latest
     timeout-minutes: 40
     env:
@@ -147,7 +145,6 @@ jobs:
       BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
       HEADLESS: true
       EVAL_ENV: browserbase
-
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -180,7 +177,7 @@ jobs:
           fi
 
   run-act-evals:
-    needs: [run-e2e-tests, determine-evals, run-combination-evals]
+    needs: [run-combination-evals]
     if: needs.determine-evals.outputs.run-act == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
@@ -231,7 +228,7 @@ jobs:
           fi
 
   run-extract-evals:
-    needs: [run-e2e-tests, determine-evals, run-combination-evals]
+    needs: [run-combination-evals]
     if: needs.determine-evals.outputs.run-extract == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 50
@@ -246,6 +243,7 @@ jobs:
       BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
       HEADLESS: true
       EVAL_ENV: browserbase
+
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -267,7 +265,7 @@ jobs:
       - name: Save Extract Dom Results
         run: mv eval-summary.json eval-summary-extract-dom.json
 
-      # 2. Once domExtract finishes, run extract category with textExtract
+      # 2. Run extract category with textExtract
       - name: Run Extract Evals (textExtract)
         run: npm run evals category extract -- --extract-method=textExtract
       - name: Save Extract Text Results
@@ -293,7 +291,7 @@ jobs:
           fi
 
   run-text-extract-evals:
-    needs: [run-e2e-tests, determine-evals, run-combination-evals]
+    needs: [run-combination-evals]
     if: needs.determine-evals.outputs.run-text-extract == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 120
@@ -355,7 +353,7 @@ jobs:
           fi
 
   run-observe-evals:
-    needs: [run-e2e-tests, determine-evals, run-combination-evals]
+    needs: [run-combination-evals]
     if: needs.determine-evals.outputs.run-observe == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,7 @@ jobs:
       - name: Run Act Evals
         if: needs.determine-evals.outputs.run-act == 'true'
         run: |
-          run: npm run evals category act
+          npm run evals category act
 
       - name: Log Act Evals Performance
         if: needs.determine-evals.outputs.run-act == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ env:
   EVAL_MODELS: "gpt-4o,gpt-4o-mini,claude-3-5-sonnet-latest"
   EVAL_CATEGORIES: "observe,act,combination,extract,text_extract"
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   determine-evals:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,10 @@ jobs:
           else
             echo "Eval summary not found for combination category. Failing CI."
             exit 1
-          fi
+
+  #
+  # Specialized evals (dummy data) - run sequentially by concurrency group
+  #
 
   run-extract-evals:
     needs: [determine-evals, run-combination-evals]
@@ -283,5 +286,220 @@ jobs:
           # Check if we have the textExtract results
           if [ -f eval-summary-extract-text.json ]; then
             experimentNameText=$(jq -r '.experimentName' eval-summary-extract-text.json)
-            text_score=$(jq '.categories.extract' eval-summary
+            text_score=$(jq '.categories.extract' eval-summary-extract-text.json)
+            echo "TextExtract Score: $text_score%"
+            echo "See: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameText}"
           fi
+
+  run-text-extract-evals:
+    needs: [determine-evals, run-combination-evals]
+    if: needs.determine-evals.outputs.run-text-extract == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    concurrency:
+      group: specialized-evals-${{ github.run_id }}
+      cancel-in-progress: false
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
+      BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
+      BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
+      HEADLESS: true
+      EVAL_ENV: browserbase
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm install --no-frozen-lockfile
+
+      - name: Build Stagehand
+        run: npm run build
+
+      - name: Install Playwright browsers
+        run: npm exec playwright install --with-deps
+
+      # 1. text_extract with textExtract (Dummy)
+      - name: Run text_extract Evals (textExtract)
+        run: |
+          echo "Pretending to run text_extract eval with textExtract..."
+          cat <<EOF > eval-summary.json
+          {
+            "experimentName": "dummyTextExtract_TextMode",
+            "categories": {
+              "text_extract": 78
+            }
+          }
+          EOF
+      - name: Save text_extract Text Results
+        run: mv eval-summary.json eval-summary-text_extract-text.json
+
+      # 2. text_extract with domExtract (Dummy)
+      - name: Run text_extract Evals (domExtract)
+        run: |
+          echo "Pretending to run text_extract eval with domExtract..."
+          cat <<EOF > eval-summary.json
+          {
+            "experimentName": "dummyTextExtract_DomMode",
+            "categories": {
+              "text_extract": 85
+            }
+          }
+          EOF
+      - name: Save text_extract Dom Results
+        run: mv eval-summary.json eval-summary-text_extract-dom.json
+
+      # 3. Log and Compare text_extract (Dummy)
+      - name: Log and Compare text_extract
+        run: |
+          if [ -f eval-summary-text_extract-text.json ]; then
+            experimentNameTxt=$(jq -r '.experimentName' eval-summary-text_extract-text.json)
+            txt_score=$(jq '.categories.text_extract' eval-summary-text_extract-text.json)
+            echo "TextExtract (text_extract) Score: $txt_score%"
+            echo "See: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameTxt}"
+
+            if (( $(echo "$txt_score < 80" | bc -l) )); then
+              echo "text_extract score <80%. Failing CI."
+              exit 1
+            fi
+          fi
+
+          if [ -f eval-summary-text_extract-dom.json ]; then
+            experimentNameDom=$(jq -r '.experimentName' eval-summary-text_extract-dom.json)
+            dom_score=$(jq '.categories.text_extract' eval-summary-text_extract-dom.json)
+            echo "DomExtract (text_extract) Score: $dom_score%"
+            echo "See: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameDom}"
+          fi
+
+  run-act-evals:
+    needs: [determine-evals, run-combination-evals]
+    if: needs.determine-evals.outputs.run-act == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    concurrency:
+      group: specialized-evals-${{ github.run_id }}
+      cancel-in-progress: false
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
+      BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
+      BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
+      HEADLESS: true
+      EVAL_ENV: browserbase
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm install --no-frozen-lockfile
+
+      - name: Build Stagehand
+        run: npm run build
+
+      - name: Install Playwright browsers
+        run: npm exec playwright install --with-deps
+
+      # Dummy "Act" eval
+      - name: Run Act Evals
+        run: |
+          echo "Pretending to run act eval..."
+          cat <<EOF > eval-summary.json
+          {
+            "experimentName": "dummyActEval",
+            "categories": {
+              "act": 82
+            }
+          }
+          EOF
+
+      - name: Log Act Evals Performance
+        run: |
+          experimentName=$(jq -r '.experimentName' eval-summary.json)
+          echo "See: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName}"
+          if [ -f eval-summary.json ]; then
+            act_score=$(jq '.categories.act' eval-summary.json)
+            echo "Act category score: $act_score%"
+            if (( $(echo "$act_score < 80" | bc -l) )); then
+              echo "Act <80%. Failing CI."
+              exit 1
+            fi
+          else
+            echo "Eval summary not found. Failing CI."
+            exit 1
+
+  run-observe-evals:
+    needs: [determine-evals, run-combination-evals]
+    if: needs.determine-evals.outputs.run-observe == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    concurrency:
+      group: specialized-evals-${{ github.run_id }}
+      cancel-in-progress: false
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
+      BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
+      BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
+      HEADLESS: true
+      EVAL_ENV: browserbase
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm install --no-frozen-lockfile
+
+      - name: Build Stagehand
+        run: npm run build
+
+      - name: Install Playwright browsers
+        run: npm exec playwright install --with-deps
+
+      # Dummy "Observe" eval
+      - name: Run Observe Evals
+        run: |
+          echo "Pretending to run observe eval..."
+          cat <<EOF > eval-summary.json
+          {
+            "experimentName": "dummyObserveEval",
+            "categories": {
+              "observe": 88
+            }
+          }
+          EOF
+
+      - name: Log Observe Evals Performance
+        run: |
+          experimentName=$(jq -r '.experimentName' eval-summary.json)
+          echo "See: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName}"
+          if [ -f eval-summary.json ]; then
+            observe_score=$(jq '.categories.observe' eval-summary.json)
+            echo "Observe category score: $observe_score%"
+            if (( $(echo "$observe_score < 80" | bc -l) )); then
+              echo "Observe <80%. Failing CI."
+              exit 1
+            fi
+          else
+            echo "Eval summary not found. Failing CI."
+            exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,131 +46,57 @@ jobs:
     needs: [determine-evals]
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository code
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install dependencies
-        run: npm install --no-frozen-lockfile
-
-      - name: Run Lint
-        run: npm run lint
+      - name: Dummy Lint
+        run: echo "Pretend lint succeeded"
 
   run-build:
     needs: [run-lint]
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository code
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install dependencies
-        run: npm install --no-frozen-lockfile
-
-      - name: Run Build
-        run: npm run build
+      - name: Dummy Build
+        run: echo "Pretend build succeeded"
 
   run-e2e-tests:
     needs: [run-lint, run-build]
     runs-on: ubuntu-latest
     timeout-minutes: 50
-    env:
-      HEADLESS: true
-
     steps:
-      - name: Check out repository code
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install dependencies
-        run: npm install --no-frozen-lockfile
-
-      - name: Install Playwright browsers
-        run: npm exec playwright install --with-deps
-
-      - name: Run E2E Tests (Deterministic Playwright)
-        run: npm run e2e
+      - name: Dummy E2E Tests
+        run: echo "Pretend E2E tests succeeded"
 
   run-e2e-bb-tests:
     needs: [run-e2e-tests]
     runs-on: ubuntu-latest
     timeout-minutes: 50
-
     if: >
       github.event_name == 'push' ||
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
-
-    env:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
-      BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
-      HEADLESS: true
-
     steps:
-      - name: Check out repository code
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install dependencies
-        run: npm install --no-frozen-lockfile
-
-      - name: Install Playwright browsers
-        run: npm exec playwright install --with-deps
-
-      - name: Run E2E Tests (browserbase)
-        run: npm run e2e:bb
+      - name: Dummy E2E BB Tests
+        run: echo "Pretend E2E BB tests succeeded"
 
   run-combination-evals:
     needs: [run-e2e-bb-tests, determine-evals]
     runs-on: ubuntu-latest
     timeout-minutes: 40
-    env:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
-      BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
-      BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
-      HEADLESS: true
-      EVAL_ENV: browserbase
     steps:
-      - name: Check out repository code
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install dependencies
-        run: npm install --no-frozen-lockfile
-
-      - name: Install Playwright browsers
-        run: npm exec playwright install --with-deps
-
-      - name: Run Combination Evals
-        run: npm run evals category combination
+      - name: Dummy Combination Eval
+        run: |
+          echo "Pretending to run combination eval..."
+          # Create a dummy eval-summary.json with a passing score
+          cat <<EOF > eval-summary.json
+          {
+            "experimentName": "dummyCombExp",
+            "categories": {
+              "combination": 85
+            }
+          }
+          EOF
 
       - name: Log Combination Evals Performance
         run: |
           experimentName=$(jq -r '.experimentName' eval-summary.json)
-          echo "View results at https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName}"
+          echo "View results at https://fake-url.com/experiments/${experimentName}"
           if [ -f eval-summary.json ]; then
             combination_score=$(jq '.categories.combination' eval-summary.json)
             echo "Combination category score: $combination_score%"
@@ -188,37 +114,24 @@ jobs:
     concurrency:
       group: labeled-evals-${{ github.run_id }}
       cancel-in-progress: false
-    env:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
-      BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
-      BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
-      HEADLESS: true
-      EVAL_ENV: browserbase
-
     steps:
-      - name: Check out repository code
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install dependencies
-        run: npm install --no-frozen-lockfile
-
-      - name: Install Playwright browsers
-        run: npm exec playwright install --with-deps
-
-      - name: Run Act Evals
-        run: npm run evals category act
+      - name: Dummy Act Evals
+        run: |
+          echo "Pretending to run ACT eval..."
+          # Create a passing score
+          cat <<EOF > eval-summary.json
+          {
+            "experimentName": "dummyActExp",
+            "categories": {
+              "act": 82
+            }
+          }
+          EOF
 
       - name: Log Act Evals Performance
         run: |
           experimentName=$(jq -r '.experimentName' eval-summary.json)
-          echo "View results at https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName}"
+          echo "View results at https://fake-url.com/experiments/${experimentName}"
           if [ -f eval-summary.json ]; then
             act_score=$(jq '.categories.act' eval-summary.json)
             echo "Act category score: $act_score%"
@@ -239,56 +152,52 @@ jobs:
     concurrency:
       group: labeled-evals-${{ github.run_id }}
       cancel-in-progress: false
-    env:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
-      BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
-      BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
-      HEADLESS: true
-      EVAL_ENV: browserbase
-
     steps:
-      - name: Check out repository code
-        uses: actions/checkout@v4
+      - name: Step 1 - Dummy Extract Evals (domExtract)
+        run: |
+          echo "Pretending to run extract with domExtract..."
+          cat <<EOF > eval-summary.json
+          {
+            "experimentName": "dummyExtractDomExp",
+            "categories": {
+              "extract": 85
+            }
+          }
+          EOF
+        shell: bash
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install dependencies
-        run: npm install --no-frozen-lockfile
-
-      - name: Install Playwright browsers
-        run: npm exec playwright install --with-deps
-
-      # 1. Run extract category with domExtract
-      - name: Run Extract Evals (domExtract)
-        run: npm run evals category extract -- --extract-method=domExtract
       - name: Save Extract Dom Results
         run: mv eval-summary.json eval-summary-extract-dom.json
 
-      # 2. Then run extract category with textExtract
-      - name: Run Extract Evals (textExtract)
-        run: npm run evals category extract -- --extract-method=textExtract
+      - name: Step 2 - Dummy Extract Evals (textExtract)
+        run: |
+          echo "Pretending to run extract with textExtract..."
+          cat <<EOF > eval-summary.json
+          {
+            "experimentName": "dummyExtractTextExp",
+            "categories": {
+              "extract": 90
+            }
+          }
+          EOF
+        shell: bash
+
       - name: Save Extract Text Results
         run: mv eval-summary.json eval-summary-extract-text.json
 
-      # 3. Log and Compare Extract Evals Performance
-      - name: Log and Compare Extract Evals Performance
+      - name: Step 3 - Log and Compare Extract Evals Performance
         run: |
           experimentNameDom=$(jq -r '.experimentName' eval-summary-extract-dom.json)
           dom_score=$(jq '.categories.extract' eval-summary-extract-dom.json)
           echo "DomExtract Extract category score: $dom_score%"
-          echo "View domExtract results: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameDom}"
+          echo "View domExtract results: https://fake-url.com/experiments/${experimentNameDom}"
 
           experimentNameText=$(jq -r '.experimentName' eval-summary-extract-text.json)
           text_score=$(jq '.categories.extract' eval-summary-extract-text.json)
           echo "TextExtract Extract category score: $text_score%"
-          echo "View textExtract results: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameText}"
+          echo "View textExtract results: https://fake-url.com/experiments/${experimentNameText}"
 
-          # 4. If domExtract <80% fail CI
+          # If domExtract <80% fail CI
           if (( $(echo "$dom_score < 80" | bc -l) )); then
             echo "DomExtract extract category score is below 80%. Failing CI."
             exit 1
@@ -302,55 +211,50 @@ jobs:
     concurrency:
       group: labeled-evals-${{ github.run_id }}
       cancel-in-progress: false
-    env:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
-      BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
-      BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
-      HEADLESS: true
-      EVAL_ENV: browserbase
     steps:
-      - name: Check out repository code
-        uses: actions/checkout@v4
+      - name: Step 1 - Dummy text_extract Evals (textExtract)
+        run: |
+          echo "Pretending to run text_extract with textExtract..."
+          cat <<EOF > eval-summary.json
+          {
+            "experimentName": "dummyTextExtractTextExp",
+            "categories": {
+              "text_extract": 88
+            }
+          }
+          EOF
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install dependencies
-        run: npm install --no-frozen-lockfile
-
-      - name: Install Playwright browsers
-        run: npm exec playwright install --with-deps
-
-      # 1. Run text_extract category with textExtract first
-      - name: Run text_extract Evals (textExtract)
-        run: npm run evals category text_extract -- --extract-method=textExtract
       - name: Save text_extract Text Results
         run: mv eval-summary.json eval-summary-text_extract-text.json
 
-      # 2. Then run text_extract category with domExtract
-      - name: Run text_extract Evals (domExtract)
-        run: npm run evals category text_extract -- --extract-method=domExtract
+      - name: Step 2 - Dummy text_extract Evals (domExtract)
+        run: |
+          echo "Pretending to run text_extract with domExtract..."
+          cat <<EOF > eval-summary.json
+          {
+            "experimentName": "dummyTextExtractDomExp",
+            "categories": {
+              "text_extract": 92
+            }
+          }
+          EOF
+
       - name: Save text_extract Dom Results
         run: mv eval-summary.json eval-summary-text_extract-dom.json
 
-      # 3. Log and Compare text_extract Evals Performance
-      - name: Log and Compare text_extract Evals Performance
+      - name: Step 3 - Log and Compare text_extract Evals Performance
         run: |
           experimentNameText=$(jq -r '.experimentName' eval-summary-text_extract-text.json)
           text_score=$(jq '.categories.text_extract' eval-summary-text_extract-text.json)
           echo "TextExtract text_extract category score: $text_score%"
-          echo "View textExtract results: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameText}"
+          echo "View textExtract results: https://fake-url.com/experiments/${experimentNameText}"
 
           experimentNameDom=$(jq -r '.experimentName' eval-summary-text_extract-dom.json)
           dom_score=$(jq '.categories.text_extract' eval-summary-text_extract-dom.json)
           echo "DomExtract text_extract category score: $dom_score%"
-          echo "View domExtract results: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameDom}"
+          echo "View domExtract results: https://fake-url.com/experiments/${experimentNameDom}"
 
-          # 4. If textExtract (for text_extract category) <80% fail CI
+          # If textExtract <80% fail CI
           if (( $(echo "$text_score < 80" | bc -l) )); then
             echo "textExtract text_extract category score is below 80%. Failing CI."
             exit 1
@@ -364,37 +268,28 @@ jobs:
     concurrency:
       group: labeled-evals-${{ github.run_id }}
       cancel-in-progress: false
-    env:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
-      BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
-      BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
-      HEADLESS: true
-      EVAL_ENV: browserbase
-
     steps:
-      - name: Check out repository code
-        uses: actions/checkout@v4
+      - name: Dummy Observe Evals
+        run: |
+          echo "Pretending to run OBSERVE eval..."
+          # This time let's produce a failing score to test the logic:
+          # (uncomment to see it fail!)
+          #score=75
+          score=82
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install dependencies
-        run: npm install --no-frozen-lockfile
-
-      - name: Install Playwright browsers
-        run: npm exec playwright install --with-deps
-
-      - name: Run Observe Evals
-        run: npm run evals category observe
+          cat <<EOF > eval-summary.json
+          {
+            "experimentName": "dummyObserveExp",
+            "categories": {
+              "observe": $score
+            }
+          }
+          EOF
 
       - name: Log Observe Evals Performance
         run: |
           experimentName=$(jq -r '.experimentName' eval-summary.json)
-          echo "View results at https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName}"
+          echo "View results at https://fake-url.com/experiments/${experimentName}"
           if [ -f eval-summary.json ]; then
             observe_score=$(jq '.categories.observe' eval-summary.json)
             echo "Observe category score: $observe_score%"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
 
 concurrency:
   group: ${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   determine-evals:
@@ -186,7 +186,7 @@ jobs:
     timeout-minutes: 25
     concurrency:
       group: evals-${{ github.run_id }}
-      cancel-in-progress: true
+      cancel-in-progress: false
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -237,7 +237,7 @@ jobs:
     timeout-minutes: 50
     concurrency:
       group: evals-${{ github.run_id }}
-      cancel-in-progress: true
+      cancel-in-progress: false
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -299,7 +299,7 @@ jobs:
     timeout-minutes: 120
     concurrency:
       group: evals-${{ github.run_id }}
-      cancel-in-progress: true
+      cancel-in-progress: false
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -361,7 +361,7 @@ jobs:
     timeout-minutes: 25
     concurrency:
       group: evals-${{ github.run_id }}
-      cancel-in-progress: true
+      cancel-in-progress: false
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,6 @@ env:
   EVAL_MODELS: "gpt-4o,gpt-4o-mini,claude-3-5-sonnet-latest"
   EVAL_CATEGORIES: "observe,act,combination,extract,text_extract"
 
-concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   determine-evals:
     runs-on: ubuntu-latest
@@ -449,7 +445,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     concurrency:
-      group: specialized-evals-${{ github.run_id }}
+      group: specialized-evals-${{ github.run_id }}-
       cancel-in-progress: false
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,7 @@ jobs:
           else
             echo "Eval summary not found for combination category. Failing CI."
             exit 1
+          fi
 
   run-extract-evals:
     needs: [determine-evals, run-combination-evals]
@@ -283,3 +284,4 @@ jobs:
           if [ -f eval-summary-extract-text.json ]; then
             experimentNameText=$(jq -r '.experimentName' eval-summary-extract-text.json)
             text_score=$(jq '.categories.extract' eval-summary
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,8 +167,28 @@ jobs:
       - name: Install Playwright browsers
         run: npm exec playwright install --with-deps
 
+      # --- LOG eval-summary.json (before) ---
+      - name: Log eval-summary.json (before)
+        run: |
+          echo "### eval-summary.json BEFORE combination ###"
+          if [ -f eval-summary.json ]; then
+            cat eval-summary.json
+          else
+            echo "(No eval-summary.json file yet.)"
+          fi
+
       - name: Run Combination Evals
         run: npm run evals category combination
+
+      # --- LOG eval-summary.json (after) ---
+      - name: Log eval-summary.json (after)
+        run: |
+          echo "### eval-summary.json AFTER combination ###"
+          if [ -f eval-summary.json ]; then
+            cat eval-summary.json
+          else
+            echo "(No eval-summary.json file found.)"
+          fi
 
       - name: Log Combination Evals Performance
         run: |
@@ -183,6 +203,9 @@ jobs:
             exit 1
           fi
 
+  ####################################################################
+  #                      ACT EVALS
+  ####################################################################
   run-act-evals:
     needs: [run-combination-evals, determine-evals]
     runs-on: ubuntu-latest
@@ -227,10 +250,31 @@ jobs:
         if: needs.determine-evals.outputs.run-act == 'true'
         run: npm exec playwright install --with-deps
 
-      - name: Run Act Evals
+      # --- LOG eval-summary.json (before) ---
+      - name: Log eval-summary.json (before)
         if: needs.determine-evals.outputs.run-act == 'true'
         run: |
-          npm run evals category act
+          echo "### eval-summary.json BEFORE act ###"
+          if [ -f eval-summary.json ]; then
+            cat eval-summary.json
+          else
+            echo "(No eval-summary.json file yet.)"
+          fi
+
+      - name: Run Act Evals
+        if: needs.determine-evals.outputs.run-act == 'true'
+        run: npm run evals category act
+
+      # --- LOG eval-summary.json (after) ---
+      - name: Log eval-summary.json (after)
+        if: needs.determine-evals.outputs.run-act == 'true'
+        run: |
+          echo "### eval-summary.json AFTER act ###"
+          if [ -f eval-summary.json ]; then
+            cat eval-summary.json
+          else
+            echo "(No eval-summary.json file found.)"
+          fi
 
       - name: Log Act Evals Performance
         if: needs.determine-evals.outputs.run-act == 'true'
@@ -249,6 +293,9 @@ jobs:
             exit 1
           fi
 
+  ####################################################################
+  #                      EXTRACT EVALS
+  ####################################################################
   run-extract-evals:
     needs: [run-act-evals, determine-evals]
     runs-on: ubuntu-latest
@@ -285,26 +332,61 @@ jobs:
         if: needs.determine-evals.outputs.run-extract == 'true'
         run: npm install --no-frozen-lockfile
 
+      - name: Build Stagehand
+        if: needs.determine-evals.outputs.run-extract == 'true'
+        run: npm run build
+
       - name: Install Playwright browsers
         if: needs.determine-evals.outputs.run-extract == 'true'
         run: npm exec playwright install --with-deps
 
-      - name: Build Stagehand
+      # --- Log eval-summary.json (before) ---
+      - name: Log eval-summary.json (before)
         if: needs.determine-evals.outputs.run-extract == 'true'
-        run: npm run build
+        run: |
+          echo "### eval-summary.json BEFORE extract ###"
+          if [ -f eval-summary.json ]; then
+            cat eval-summary.json
+          else
+            echo "(No eval-summary.json file yet.)"
+          fi
 
       # 1. Run extract category with domExtract
       - name: Run Extract Evals (domExtract)
         if: needs.determine-evals.outputs.run-extract == 'true'
         run: npm run evals category extract -- --extract-method=domExtract
+
+      # --- Log eval-summary.json (after domExtract) ---
+      - name: Log eval-summary.json (after dom)
+        if: needs.determine-evals.outputs.run-extract == 'true'
+        run: |
+          echo "### eval-summary.json AFTER domExtract ###"
+          if [ -f eval-summary.json ]; then
+            cat eval-summary.json
+          else
+            echo "(No eval-summary.json file found.)"
+          fi
+
       - name: Save Extract Dom Results
         if: needs.determine-evals.outputs.run-extract == 'true'
         run: mv eval-summary.json eval-summary-extract-dom.json
 
-      # 2. Once domExtract finishes, run extract category with textExtract
+      # 2. Then run extract category with textExtract
       - name: Run Extract Evals (textExtract)
         if: needs.determine-evals.outputs.run-extract == 'true'
         run: npm run evals category extract -- --extract-method=textExtract
+
+      # --- Log eval-summary.json (after textExtract) ---
+      - name: Log eval-summary.json (after text)
+        if: needs.determine-evals.outputs.run-extract == 'true'
+        run: |
+          echo "### eval-summary.json AFTER textExtract ###"
+          if [ -f eval-summary.json ]; then
+            cat eval-summary.json
+          else
+            echo "(No eval-summary.json file found.)"
+          fi
+
       - name: Save Extract Text Results
         if: needs.determine-evals.outputs.run-extract == 'true'
         run: mv eval-summary.json eval-summary-extract-text.json
@@ -323,12 +405,15 @@ jobs:
           echo "TextExtract Extract category score: $text_score%"
           echo "View textExtract results: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameText}"
 
-          # 4. If domExtract <80% fail CI
+          # If domExtract <80% fail CI
           if (( $(echo "$dom_score < 80" | bc -l) )); then
             echo "DomExtract extract category score is below 80%. Failing CI."
             exit 1
           fi
 
+  ####################################################################
+  #                      TEXT-EXTRACT EVALS
+  ####################################################################
   run-text-extract-evals:
     needs: [run-extract-evals, determine-evals]
     runs-on: ubuntu-latest
@@ -373,10 +458,32 @@ jobs:
         if: needs.determine-evals.outputs.run-text-extract == 'true'
         run: npm run build
 
+      # --- Log eval-summary.json (before) ---
+      - name: Log eval-summary.json (before)
+        if: needs.determine-evals.outputs.run-text-extract == 'true'
+        run: |
+          echo "### eval-summary.json BEFORE text-extract ###"
+          if [ -f eval-summary.json ]; then
+            cat eval-summary.json
+          else
+            echo "(No eval-summary.json file yet.)"
+          fi
+
       # 1. Run text_extract category with textExtract first
       - name: Run text_extract Evals (textExtract)
         if: needs.determine-evals.outputs.run-text-extract == 'true'
         run: npm run evals category text_extract -- --extract-method=textExtract
+
+      # --- Log eval-summary.json (after textExtract) ---
+      - name: Log eval-summary.json (after textExtract)
+        if: needs.determine-evals.outputs.run-text-extract == 'true'
+        run: |
+          echo "### eval-summary.json AFTER textExtract ###"
+          if [ -f eval-summary.json ]; then
+            cat eval-summary.json
+          else
+            echo "(No eval-summary.json file found.)"
+          fi
 
       - name: Save text_extract Text Results
         if: needs.determine-evals.outputs.run-text-extract == 'true'
@@ -386,6 +493,18 @@ jobs:
       - name: Run text_extract Evals (domExtract)
         if: needs.determine-evals.outputs.run-text-extract == 'true'
         run: npm run evals category text_extract -- --extract-method=domExtract
+
+      # --- Log eval-summary.json (after domExtract) ---
+      - name: Log eval-summary.json (after domExtract)
+        if: needs.determine-evals.outputs.run-text-extract == 'true'
+        run: |
+          echo "### eval-summary.json AFTER domExtract ###"
+          if [ -f eval-summary.json ]; then
+            cat eval-summary.json
+          else
+            echo "(No eval-summary.json file found.)"
+          fi
+
       - name: Save text_extract Dom Results
         if: needs.determine-evals.outputs.run-text-extract == 'true'
         run: mv eval-summary.json eval-summary-text_extract-dom.json
@@ -404,12 +523,15 @@ jobs:
           echo "DomExtract text_extract category score: $dom_score%"
           echo "View domExtract results: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameDom}"
 
-          # 4. If textExtract (for text_extract category) <80% fail CI
+          # If text_score <80% fail CI
           if (( $(echo "$text_score < 80" | bc -l) )); then
             echo "textExtract text_extract category score is below 80%. Failing CI."
             exit 1
           fi
 
+  ####################################################################
+  #                      OBSERVE EVALS
+  ####################################################################
   run-observe-evals:
     needs: [run-text-extract-evals, determine-evals]
     runs-on: ubuntu-latest
@@ -454,9 +576,31 @@ jobs:
         if: needs.determine-evals.outputs.run-observe == 'true'
         run: npm run build
 
+      # --- Log eval-summary.json (before) ---
+      - name: Log eval-summary.json (before)
+        if: needs.determine-evals.outputs.run-observe == 'true'
+        run: |
+          echo "### eval-summary.json BEFORE observe ###"
+          if [ -f eval-summary.json ]; then
+            cat eval-summary.json
+          else
+            echo "(No eval-summary.json file yet.)"
+          fi
+
       - name: Run Observe Evals
         if: needs.determine-evals.outputs.run-observe == 'true'
         run: npm run evals category observe
+
+      # --- Log eval-summary.json (after) ---
+      - name: Log eval-summary.json (after)
+        if: needs.determine-evals.outputs.run-observe == 'true'
+        run: |
+          echo "### eval-summary.json AFTER observe ###"
+          if [ -f eval-summary.json ]; then
+            cat eval-summary.json
+          else
+            echo "(No eval-summary.json file found.)"
+          fi
 
       - name: Log Observe Evals Performance
         if: needs.determine-evals.outputs.run-observe == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,6 @@ env:
   EVAL_CATEGORIES: "observe,act,combination,extract,text_extract"
 
 jobs:
-  ####################################################################
-  # 1. DETERMINE-EVALS
-  #
-  #    Checks if the PR is on main or has certain labels, then sets
-  #    outputs to instruct which specialized evals should run.
-  ####################################################################
   determine-evals:
     runs-on: ubuntu-latest
     outputs:
@@ -28,8 +22,9 @@ jobs:
     steps:
       - id: check-labels
         run: |
-          # Default: run all specialized tests on main
+          # Default to running all tests on main branch
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            echo "Running all tests for main branch"
             echo "run-extract=true" >> $GITHUB_OUTPUT
             echo "run-act=true" >> $GITHUB_OUTPUT
             echo "run-observe=true" >> $GITHUB_OUTPUT
@@ -37,15 +32,12 @@ jobs:
             exit 0
           fi
 
-          # Otherwise check specific labels
+          # Check for specific labels
           echo "run-extract=${{ contains(github.event.pull_request.labels.*.name, 'extract') }}" >> $GITHUB_OUTPUT
           echo "run-act=${{ contains(github.event.pull_request.labels.*.name, 'act') }}" >> $GITHUB_OUTPUT
           echo "run-observe=${{ contains(github.event.pull_request.labels.*.name, 'observe') }}" >> $GITHUB_OUTPUT
           echo "run-text-extract=${{ contains(github.event.pull_request.labels.*.name, 'text-extract') }}" >> $GITHUB_OUTPUT
 
-  ####################################################################
-  # 2. Some Pre-Eval Jobs (examples)
-  ####################################################################
   run-lint:
     runs-on: ubuntu-latest
     steps:
@@ -65,7 +57,6 @@ jobs:
 
   run-build:
     runs-on: ubuntu-latest
-    needs: [run-lint]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -84,252 +75,267 @@ jobs:
   run-e2e-tests:
     needs: [run-lint, run-build]
     runs-on: ubuntu-latest
+    timeout-minutes: 50
+    env:
+      HEADLESS: true
+
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "20"
+
       - name: Install dependencies
         run: npm install --no-frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: npm exec playwright install --with-deps
+
       - name: Build Stagehand
         run: npm run build
-      - name: Run E2E Tests
+
+      - name: Run E2E Tests (Deterministic Playwright)
         run: npm run e2e
 
-  run-combination-evals:
-    needs: [run-e2e-tests, determine-evals]
+  run-e2e-bb-tests:
+    needs: [run-e2e-tests]
     runs-on: ubuntu-latest
+    timeout-minutes: 50
+
+    if: >
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
+      BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
+      HEADLESS: true
+
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "20"
+
       - name: Install dependencies
         run: npm install --no-frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: npm exec playwright install --with-deps
+
       - name: Build Stagehand
         run: npm run build
-      - name: Combination Evals (Dummy)
-        run: |
-          echo "Pretending to run combination eval..."
-          cat <<EOF > combo-summary.json
-          {
-            "experimentName": "dummyCombination",
-            "categories": {
-              "combination": 90
-            }
-          }
-          EOF
-      - name: Log Combination
-        run: |
-          if [ ! -f combo-summary.json ]; then
-            echo "No combination file found, failing"
-            exit 1
-          fi
-          combo_score=$(jq '.categories.combination' combo-summary.json)
-          echo "Combination category score: $combo_score%"
 
-  ####################################################################
-  # 3. SPECIALIZED EVAL JOBS, SEQUENTIAL
-  #
-  #    Each job depends on the previous, so they run strictly in order:
-  #      run-extract-evals -> run-text-extract-evals -> run-act-evals -> run-observe-evals
-  #    If the label isn't set, the job does a no-op and exits 0 = success
-  #    so the next job won't be skipped.
-  ####################################################################
+      - name: Run E2E Tests (browserbase)
+        run: npm run e2e:bb
 
-  # ----------------- EXTRACT EVALS -----------------
-  run-extract-evals:
-    needs: [determine-evals, run-combination-evals]
+  # --------------------------------------------------------------------
+  # From here on, we replace real eval steps with dummy commands
+  # --------------------------------------------------------------------
+  run-combination-evals:
+    needs: [run-e2e-bb-tests, run-e2e-tests, determine-evals]
     runs-on: ubuntu-latest
+    timeout-minutes: 40
+    env:
+      HEADLESS: true
     steps:
-      - name: Check out repository
+      - name: Check out repository code
         uses: actions/checkout@v4
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install dependencies
-        run: npm install --no-frozen-lockfile
-
-      - name: Build Stagehand
-        run: npm run build
-
-      - name: Maybe Run Extract Evals
+      - name: Dummy Combination Evals
         run: |
-          if [ "${{ needs.determine-evals.outputs.run-extract }}" != "true" ]; then
-            echo "Label 'extract' not set. Skipping extract steps."
-            exit 0
-          fi
-          echo "Pretending to run EXTRACT EVALS..."
-          cat <<EOF > eval-summary-extract.json
-          {
-            "experimentName": "dummyExtractEval",
-            "categories": {
-              "extract": 85
-            }
-          }
-          EOF
+          echo "Running dummy combination evals..."
+          echo '{"experimentName":"dummyCombination","categories":{"combination":95}}' > eval-summary.json
 
-      - name: Check Extract Score
+      - name: Log Combination Evals Performance
         run: |
-          # If we didn't run the above step, no file
-          if [ ! -f eval-summary-extract.json ]; then
-            echo "No extract file found. Possibly skipped. Exiting success."
+          experimentName=$(jq -r '.experimentName' eval-summary.json)
+          echo "View results at https://www.example.com/experiments/${experimentName}"
+          if [ -f eval-summary.json ]; then
+            combination_score=$(jq '.categories.combination' eval-summary.json)
+            echo "Combination category score: $combination_score%"
             exit 0
-          fi
-          extract_score=$(jq '.categories.extract' eval-summary-extract.json)
-          echo "Extract category score: $extract_score%"
-          if (( $(echo "$extract_score < 80" | bc -l) )); then
-            echo "Extract <80%. Failing CI."
+          else
+            echo "Eval summary not found for combination category. Failing CI."
             exit 1
           fi
 
-  # ----------------- TEXT-EXTRACT EVALS -----------------
-  run-text-extract-evals:
-    needs: [run-extract-evals] # ensures it runs after run-extract-evals
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install dependencies
-        run: npm install --no-frozen-lockfile
-
-      - name: Build Stagehand
-        run: npm run build
-
-      - name: Maybe Run text_extract Evals
-        run: |
-          if [ "${{ needs.determine-evals.outputs.run-text-extract }}" != "true" ]; then
-            echo "Label 'text-extract' not set. Skipping text_extract steps."
-            exit 0
-          fi
-          echo "Pretending to run TEXT_EXTRACT EVALS..."
-          cat <<EOF > eval-summary-textExtract.json
-          {
-            "experimentName": "dummyTextExtractEval",
-            "categories": {
-              "text_extract": 78
-            }
-          }
-          EOF
-
-      - name: Check text_extract Score
-        run: |
-          if [ ! -f eval-summary-textExtract.json ]; then
-            echo "No text_extract file found. Possibly skipped. Exiting success."
-            exit 0
-          fi
-          text_extract_score=$(jq '.categories.text_extract' eval-summary-textExtract.json)
-          echo "text_extract score: $text_extract_score%"
-          if (( $(echo "$text_extract_score < 80" | bc -l) )); then
-            echo "text_extract <80%. Failing CI."
-            exit 1
-          fi
-
-  # ----------------- ACT EVALS -----------------
   run-act-evals:
-    needs: [run-text-extract-evals] # ensures it runs after text-extract-evals
+    needs: [run-combination-evals]
+    if: >
+      (needs.run-combination-evals.conclusion != 'failure')
+      && needs.determine-evals.outputs.run-act == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      HEADLESS: true
+
     steps:
-      - name: Check out repository
+      - name: Check out repository code
         uses: actions/checkout@v4
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install dependencies
-        run: npm install --no-frozen-lockfile
-
-      - name: Build Stagehand
-        run: npm run build
-
-      - name: Maybe Run Act Evals
+      - name: Dummy Act Evals
         run: |
-          if [ "${{ needs.determine-evals.outputs.run-act }}" != "true" ]; then
-            echo "Label 'act' not set. Skipping act steps."
-            exit 0
-          fi
-          echo "Pretending to run ACT EVALS..."
-          cat <<EOF > eval-summary-act.json
-          {
-            "experimentName": "dummyActEval",
-            "categories": {
-              "act": 82
-            }
-          }
-          EOF
+          echo "Running dummy act evals..."
+          echo '{"experimentName":"dummyAct","categories":{"act":82}}' > eval-summary.json
 
-      - name: Check Act Score
+      - name: Log Act Evals Performance
         run: |
-          if [ ! -f eval-summary-act.json ]; then
-            echo "No act file found. Possibly skipped. Exiting success."
-            exit 0
-          fi
-          act_score=$(jq '.categories.act' eval-summary-act.json)
-          echo "Act category score: $act_score%"
-          if (( $(echo "$act_score < 80" | bc -l) )); then
-            echo "Act <80%. Failing CI."
+          experimentName=$(jq -r '.experimentName' eval-summary.json)
+          echo "View results at https://www.example.com/experiments/${experimentName}"
+          if [ -f eval-summary.json ]; then
+            act_score=$(jq '.categories.act' eval-summary.json)
+            echo "Act category score: $act_score%"
+            if (( $(echo "$act_score < 80" | bc -l) )); then
+              echo "Act category score is below 80%. Failing CI."
+              exit 1
+            fi
+          else
+            echo "Eval summary not found for act category. Failing CI."
             exit 1
           fi
 
-  # ----------------- OBSERVE EVALS -----------------
-  run-observe-evals:
-    needs: [run-act-evals] # ensures it runs after act-evals
+  run-extract-evals:
+    needs: [run-act-evals]
+    if: >
+      (needs.run-act-evals.conclusion != 'failure')
+      && needs.determine-evals.outputs.run-extract == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 50
+    env:
+      HEADLESS: true
+
     steps:
-      - name: Check out repository
+      - name: Check out repository code
         uses: actions/checkout@v4
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install dependencies
-        run: npm install --no-frozen-lockfile
-
-      - name: Build Stagehand
-        run: npm run build
-
-      - name: Maybe Run Observe Evals
+      # 1. Dummy "domExtract"
+      - name: Dummy Extract Evals (domExtract)
         run: |
-          if [ "${{ needs.determine-evals.outputs.run-observe }}" != "true" ]; then
-            echo "Label 'observe' not set. Skipping observe steps."
-            exit 0
-          fi
-          echo "Pretending to run OBSERVE EVALS..."
-          cat <<EOF > eval-summary-observe.json
-          {
-            "experimentName": "dummyObserveEval",
-            "categories": {
-              "observe": 88
-            }
-          }
-          EOF
+          echo "Running dummy extract evals (domExtract)..."
+          echo '{"experimentName":"dummyDomExtract","categories":{"extract":85}}' > eval-summary.json
 
-      - name: Check Observe Score
+      - name: Save Extract Dom Results
+        run: mv eval-summary.json eval-summary-extract-dom.json
+
+      # 2. Dummy "textExtract"
+      - name: Dummy Extract Evals (textExtract)
         run: |
-          if [ ! -f eval-summary-observe.json ]; then
-            echo "No observe file found. Possibly skipped. Exiting success."
-            exit 0
+          echo "Running dummy extract evals (textExtract)..."
+          echo '{"experimentName":"dummyTextExtract","categories":{"extract":90}}' > eval-summary.json
+
+      - name: Save Extract Text Results
+        run: mv eval-summary.json eval-summary-extract-text.json
+
+      # 3. Log and Compare
+      - name: Log and Compare Extract Evals Performance
+        run: |
+          experimentNameDom=$(jq -r '.experimentName' eval-summary-extract-dom.json)
+          dom_score=$(jq '.categories.extract' eval-summary-extract-dom.json)
+          echo "DomExtract Extract category score: $dom_score%"
+          echo "View domExtract results: https://www.example.com/experiments/${experimentNameDom}"
+
+          experimentNameText=$(jq -r '.experimentName' eval-summary-extract-text.json)
+          text_score=$(jq '.categories.extract' eval-summary-extract-text.json)
+          echo "TextExtract Extract category score: $text_score%"
+          echo "View textExtract results: https://www.example.com/experiments/${experimentNameText}"
+
+          # If domExtract <80% fail CI
+          if (( $(echo "$dom_score < 80" | bc -l) )); then
+            echo "DomExtract extract category score is below 80%. Failing CI."
+            exit 1
           fi
-          observe_score=$(jq '.categories.observe' eval-summary-observe.json)
-          echo "Observe category score: $observe_score%"
-          if (( $(echo "$observe_score < 80" | bc -l) )); then
-            echo "Observe <80%. Failing CI."
+
+  run-text-extract-evals:
+    needs: [run-extract-evals]
+    if: >
+      (needs.run-extract-evals.conclusion != 'failure')
+      && needs.determine-evals.outputs.run-text-extract == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    env:
+      HEADLESS: true
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      # 1. Dummy text_extract with textExtract
+      - name: Dummy text_extract Evals (textExtract)
+        run: |
+          echo "Running dummy text_extract (textExtract)..."
+          echo '{"experimentName":"dummyTextExtract","categories":{"text_extract":90}}' > eval-summary.json
+
+      - name: Save text_extract Text Results
+        run: mv eval-summary.json eval-summary-text_extract-text.json
+
+      # 2. Dummy text_extract with domExtract
+      - name: Dummy text_extract Evals (domExtract)
+        run: |
+          echo "Running dummy text_extract (domExtract)..."
+          echo '{"experimentName":"dummyDomExtract","categories":{"text_extract":88}}' > eval-summary.json
+
+      - name: Save text_extract Dom Results
+        run: mv eval-summary.json eval-summary-text_extract-dom.json
+
+      # 3. Log and Compare
+      - name: Log and Compare text_extract Evals Performance
+        run: |
+          experimentNameText=$(jq -r '.experimentName' eval-summary-text_extract-text.json)
+          text_score=$(jq '.categories.text_extract' eval-summary-text_extract-text.json)
+          echo "TextExtract text_extract category score: $text_score%"
+          echo "View textExtract results: https://www.example.com/experiments/${experimentNameText}"
+
+          experimentNameDom=$(jq -r '.experimentName' eval-summary-text_extract-dom.json)
+          dom_score=$(jq '.categories.text_extract' eval-summary-text_extract-dom.json)
+          echo "DomExtract text_extract category score: $dom_score%"
+          echo "View domExtract results: https://www.example.com/experiments/${experimentNameDom}"
+
+          # If text_score <80% fail CI
+          if (( $(echo "$text_score < 80" | bc -l) )); then
+            echo "textExtract text_extract category score is below 80%. Failing CI."
+            exit 1
+          fi
+
+  run-observe-evals:
+    needs: [run-text-extract-evals]
+    if: >
+      (needs.run-text-extract-evals.conclusion != 'failure')
+      && needs.determine-evals.outputs.run-observe == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      HEADLESS: true
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Dummy Observe Evals
+        run: |
+          echo "Running dummy observe evals..."
+          echo '{"experimentName":"dummyObserve","categories":{"observe":85}}' > eval-summary.json
+
+      - name: Log Observe Evals Performance
+        run: |
+          experimentName=$(jq -r '.experimentName' eval-summary.json)
+          echo "View results at https://www.example.com/experiments/${experimentName}"
+          if [ -f eval-summary.json ]; then
+            observe_score=$(jq '.categories.observe' eval-summary.json)
+            echo "Observe category score: $observe_score%"
+            if (( $(echo "$observe_score < 80" | bc -l) )); then
+              echo "Observe category score is below 80%. Failing CI."
+              exit 1
+            fi
+          else
+            echo "Eval summary not found for observe category. Failing CI."
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,7 @@ jobs:
       - name: Check for 'act' label
         id: label-check
         run: |
-          if [ "${{ needs.determine-evals.outputs.run-act }}" != "true" ]; then
+          if [ "${{ contains(github.event.pull_request.labels.*.name, 'act') }}" != "true" ]; then
             echo "has_label=false" >> $GITHUB_OUTPUT
             echo "No label for ACT. Exiting with success."
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
       - synchronize
       - labeled
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   EVAL_MODELS: "gpt-4o,gpt-4o-mini,claude-3-5-sonnet-latest"
   EVAL_CATEGORIES: "observe,act,combination,extract,text_extract"
@@ -182,7 +186,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     concurrency:
-      group: evals-${{ github.run_id }}
+      group: labeled-evals-${{ github.run_id }}
       cancel-in-progress: false
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -233,7 +237,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 50
     concurrency:
-      group: evals-${{ github.run_id }}
+      group: labeled-evals-${{ github.run_id }}
       cancel-in-progress: false
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -265,7 +269,7 @@ jobs:
       - name: Save Extract Dom Results
         run: mv eval-summary.json eval-summary-extract-dom.json
 
-      # 2. Run extract category with textExtract
+      # 2. Then run extract category with textExtract
       - name: Run Extract Evals (textExtract)
         run: npm run evals category extract -- --extract-method=textExtract
       - name: Save Extract Text Results
@@ -296,7 +300,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     concurrency:
-      group: evals-${{ github.run_id }}
+      group: labeled-evals-${{ github.run_id }}
       cancel-in-progress: false
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -358,7 +362,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     concurrency:
-      group: evals-${{ github.run_id }}
+      group: labeled-evals-${{ github.run_id }}
       cancel-in-progress: false
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
     steps:
       - id: check-labels
         run: |
+          # Default to running all tests on main branch
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             echo "Running all tests for main branch"
             echo "run-extract=true" >> $GITHUB_OUTPUT
@@ -31,6 +32,7 @@ jobs:
             exit 0
           fi
 
+          # Check for specific labels
           echo "run-extract=${{ contains(github.event.pull_request.labels.*.name, 'extract') }}" >> $GITHUB_OUTPUT
           echo "run-act=${{ contains(github.event.pull_request.labels.*.name, 'act') }}" >> $GITHUB_OUTPUT
           echo "run-observe=${{ contains(github.event.pull_request.labels.*.name, 'observe') }}" >> $GITHUB_OUTPUT
@@ -212,27 +214,27 @@ jobs:
           fi
 
       - name: Set up Node.js
-        if: steps.label-check.outputs.has_label == 'true'
+        if: needs.determine-evals.outputs.run-act == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: "20"
 
       - name: Install dependencies
-        if: steps.label-check.outputs.has_label == 'true'
+        if: needs.determine-evals.outputs.run-act == 'true'
         run: npm install --no-frozen-lockfile
 
       - name: Build Stagehand
-        if: steps.label-check.outputs.has_label == 'true'
+        if: needs.determine-evals.outputs.run-act == 'true'
         run: npm run build
 
       - name: Dummy Act Evals
-        if: steps.label-check.outputs.has_label == 'true'
+        if: needs.determine-evals.outputs.run-act == 'true'
         run: |
           echo "Running dummy act evals..."
           echo '{"experimentName":"dummyAct","categories":{"act":82}}' > eval-summary.json
 
       - name: Log Act Evals Performance
-        if: steps.label-check.outputs.has_label == 'true'
+        if: needs.determine-evals.outputs.run-act == 'true'
         run: |
           experimentName=$(jq -r '.experimentName' eval-summary.json)
           echo "View results at https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
         run: npm run e2e:bb
 
   # --------------------------------------------------------------------
-  # From here on, we replace real eval steps with dummy commands
+  # From here on, dummy eval steps with approach A for skipping
   # --------------------------------------------------------------------
   run-combination-evals:
     needs: [run-e2e-bb-tests, run-e2e-tests, determine-evals]
@@ -170,9 +170,6 @@ jobs:
 
   run-act-evals:
     needs: [run-combination-evals]
-    if: >
-      (needs.run-combination-evals.conclusion != 'failure')
-      && needs.determine-evals.outputs.run-act == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     env:
@@ -181,6 +178,13 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
+
+      - name: Check for 'act' label
+        run: |
+          if [ "${{ needs.determine-evals.outputs.run-act }}" != "true" ]; then
+            echo "No 'act' label found. Skipping job steps."
+            exit 0
+          fi
 
       - name: Dummy Act Evals
         run: |
@@ -205,9 +209,6 @@ jobs:
 
   run-extract-evals:
     needs: [run-act-evals]
-    if: >
-      (needs.run-act-evals.conclusion != 'failure')
-      && needs.determine-evals.outputs.run-extract == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 50
     env:
@@ -216,6 +217,13 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
+
+      - name: Check for 'extract' label
+        run: |
+          if [ "${{ needs.determine-evals.outputs.run-extract }}" != "true" ]; then
+            echo "No 'extract' label found. Skipping job steps."
+            exit 0
+          fi
 
       # 1. Dummy "domExtract"
       - name: Dummy Extract Evals (domExtract)
@@ -256,9 +264,6 @@ jobs:
 
   run-text-extract-evals:
     needs: [run-extract-evals]
-    if: >
-      (needs.run-extract-evals.conclusion != 'failure')
-      && needs.determine-evals.outputs.run-text-extract == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 120
     env:
@@ -267,6 +272,13 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
+
+      - name: Check for 'text-extract' label
+        run: |
+          if [ "${{ needs.determine-evals.outputs.run-text-extract }}" != "true" ]; then
+            echo "No 'text-extract' label found. Skipping job steps."
+            exit 0
+          fi
 
       # 1. Dummy text_extract with textExtract
       - name: Dummy text_extract Evals (textExtract)
@@ -286,7 +298,7 @@ jobs:
       - name: Save text_extract Dom Results
         run: mv eval-summary.json eval-summary-text_extract-dom.json
 
-      # 3. Log and Compare
+      # 3. Log and Compare text_extract
       - name: Log and Compare text_extract Evals Performance
         run: |
           experimentNameText=$(jq -r '.experimentName' eval-summary-text_extract-text.json)
@@ -307,9 +319,6 @@ jobs:
 
   run-observe-evals:
     needs: [run-text-extract-evals]
-    if: >
-      (needs.run-text-extract-evals.conclusion != 'failure')
-      && needs.determine-evals.outputs.run-observe == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     env:
@@ -318,6 +327,13 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
+
+      - name: Check for 'observe' label
+        run: |
+          if [ "${{ needs.determine-evals.outputs.run-observe }}" != "true" ]; then
+            echo "No 'observe' label found. Skipping job steps."
+            exit 0
+          fi
 
       - name: Dummy Observe Evals
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,8 +220,8 @@ jobs:
 
       - name: Log value of run-act
         run: |
-          # log the value of run-act
-            echo "run-act: ${{ needs.determine-evals.outputs.run-act }}"
+          echo "run-act: ${{ needs.determine-evals.outputs.run-act }}"
+          echo "run-act: ${{ contains(github.event.pull_request.labels.*.name, 'act') }}"
 
       - name: Set up Node.js
         if: needs.determine-evals.outputs.run-act == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
         run: npm run e2e:bb
 
   # --------------------------------------------------------------------
-  # From here on, dummy eval steps with approach A for skipping
+  # Dummy eval steps from combination onward, skipping if label missing
   # --------------------------------------------------------------------
   run-combination-evals:
     needs: [run-e2e-bb-tests, run-e2e-tests, determine-evals]
@@ -180,18 +180,23 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check for 'act' label
+        id: label-check
         run: |
           if [ "${{ needs.determine-evals.outputs.run-act }}" != "true" ]; then
-            echo "No 'act' label found. Skipping job steps."
-            exit 0
+            echo "No label selected for \"act\", continuing without running \"act\"."
+            echo "has_label=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_label=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Dummy Act Evals
+        if: steps.label-check.outputs.has_label == 'true'
         run: |
           echo "Running dummy act evals..."
           echo '{"experimentName":"dummyAct","categories":{"act":82}}' > eval-summary.json
 
       - name: Log Act Evals Performance
+        if: steps.label-check.outputs.has_label == 'true'
         run: |
           experimentName=$(jq -r '.experimentName' eval-summary.json)
           echo "View results at https://www.example.com/experiments/${experimentName}"
@@ -219,32 +224,40 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check for 'extract' label
+        id: label-check
         run: |
           if [ "${{ needs.determine-evals.outputs.run-extract }}" != "true" ]; then
-            echo "No 'extract' label found. Skipping job steps."
-            exit 0
+            echo "No label selected for \"extract\", continuing without running \"extract\"."
+            echo "has_label=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_label=true" >> $GITHUB_OUTPUT
           fi
 
       # 1. Dummy "domExtract"
       - name: Dummy Extract Evals (domExtract)
+        if: steps.label-check.outputs.has_label == 'true'
         run: |
           echo "Running dummy extract evals (domExtract)..."
           echo '{"experimentName":"dummyDomExtract","categories":{"extract":85}}' > eval-summary.json
 
       - name: Save Extract Dom Results
+        if: steps.label-check.outputs.has_label == 'true'
         run: mv eval-summary.json eval-summary-extract-dom.json
 
       # 2. Dummy "textExtract"
       - name: Dummy Extract Evals (textExtract)
+        if: steps.label-check.outputs.has_label == 'true'
         run: |
           echo "Running dummy extract evals (textExtract)..."
           echo '{"experimentName":"dummyTextExtract","categories":{"extract":90}}' > eval-summary.json
 
       - name: Save Extract Text Results
+        if: steps.label-check.outputs.has_label == 'true'
         run: mv eval-summary.json eval-summary-extract-text.json
 
       # 3. Log and Compare
       - name: Log and Compare Extract Evals Performance
+        if: steps.label-check.outputs.has_label == 'true'
         run: |
           experimentNameDom=$(jq -r '.experimentName' eval-summary-extract-dom.json)
           dom_score=$(jq '.categories.extract' eval-summary-extract-dom.json)
@@ -274,32 +287,40 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check for 'text-extract' label
+        id: label-check
         run: |
           if [ "${{ needs.determine-evals.outputs.run-text-extract }}" != "true" ]; then
-            echo "No 'text-extract' label found. Skipping job steps."
-            exit 0
+            echo "No label selected for \"text-extract\", continuing without running \"text-extract\"."
+            echo "has_label=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_label=true" >> $GITHUB_OUTPUT
           fi
 
       # 1. Dummy text_extract with textExtract
       - name: Dummy text_extract Evals (textExtract)
+        if: steps.label-check.outputs.has_label == 'true'
         run: |
           echo "Running dummy text_extract (textExtract)..."
           echo '{"experimentName":"dummyTextExtract","categories":{"text_extract":90}}' > eval-summary.json
 
       - name: Save text_extract Text Results
+        if: steps.label-check.outputs.has_label == 'true'
         run: mv eval-summary.json eval-summary-text_extract-text.json
 
       # 2. Dummy text_extract with domExtract
       - name: Dummy text_extract Evals (domExtract)
+        if: steps.label-check.outputs.has_label == 'true'
         run: |
           echo "Running dummy text_extract (domExtract)..."
           echo '{"experimentName":"dummyDomExtract","categories":{"text_extract":88}}' > eval-summary.json
 
       - name: Save text_extract Dom Results
+        if: steps.label-check.outputs.has_label == 'true'
         run: mv eval-summary.json eval-summary-text_extract-dom.json
 
-      # 3. Log and Compare text_extract
+      # 3. Log and Compare text_extract Evals
       - name: Log and Compare text_extract Evals Performance
+        if: steps.label-check.outputs.has_label == 'true'
         run: |
           experimentNameText=$(jq -r '.experimentName' eval-summary-text_extract-text.json)
           text_score=$(jq '.categories.text_extract' eval-summary-text_extract-text.json)
@@ -323,24 +344,28 @@ jobs:
     timeout-minutes: 25
     env:
       HEADLESS: true
-
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
 
       - name: Check for 'observe' label
+        id: label-check
         run: |
           if [ "${{ needs.determine-evals.outputs.run-observe }}" != "true" ]; then
-            echo "No 'observe' label found. Skipping job steps."
-            exit 0
+            echo "No label selected for \"observe\", continuing without running \"observe\"."
+            echo "has_label=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_label=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Dummy Observe Evals
+        if: steps.label-check.outputs.has_label == 'true'
         run: |
           echo "Running dummy observe evals..."
           echo '{"experimentName":"dummyObserve","categories":{"observe":85}}' > eval-summary.json
 
       - name: Log Observe Evals Performance
+        if: steps.label-check.outputs.has_label == 'true'
         run: |
           experimentName=$(jq -r '.experimentName' eval-summary.json)
           echo "View results at https://www.example.com/experiments/${experimentName}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
 
       - name: Run Build
         run: npm run build
+  ## comment to test concurrency in CI
 
   run-e2e-tests:
     needs: [run-lint, run-build]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,13 @@ env:
   EVAL_CATEGORIES: "observe,act,combination,extract,text_extract"
 
 jobs:
+  ####################################################################
+  # 1. DETERMINE-EVALS
+  #
+  #    Checks if the PR is on the main branch or if it has
+  #    certain labels, then sets outputs to instruct
+  #    which specialized evals should run.
+  ####################################################################
   determine-evals:
     runs-on: ubuntu-latest
     outputs:
@@ -38,6 +45,9 @@ jobs:
           echo "run-observe=${{ contains(github.event.pull_request.labels.*.name, 'observe') }}" >> $GITHUB_OUTPUT
           echo "run-text-extract=${{ contains(github.event.pull_request.labels.*.name, 'text-extract') }}" >> $GITHUB_OUTPUT
 
+  ####################################################################
+  # 2. LINT JOB
+  ####################################################################
   run-lint:
     runs-on: ubuntu-latest
     steps:
@@ -55,6 +65,9 @@ jobs:
       - name: Run Lint
         run: npm run lint
 
+  ####################################################################
+  # 3. BUILD JOB
+  ####################################################################
   run-build:
     runs-on: ubuntu-latest
     needs: [run-lint]
@@ -73,6 +86,9 @@ jobs:
       - name: Run Build
         run: npm run build
 
+  ####################################################################
+  # 4. E2E TESTS JOB
+  ####################################################################
   run-e2e-tests:
     needs: [run-lint, run-build]
     runs-on: ubuntu-latest
@@ -101,6 +117,9 @@ jobs:
       - name: Run E2E Tests (Deterministic Playwright)
         run: npm run e2e
 
+  ####################################################################
+  # 5. E2E-BB (Browserbase) TESTS JOB
+  ####################################################################
   run-e2e-bb-tests:
     needs: [run-e2e-tests]
     runs-on: ubuntu-latest
@@ -137,6 +156,9 @@ jobs:
       - name: Run E2E Tests (browserbase)
         run: npm run e2e:bb
 
+  ####################################################################
+  # 6. COMBINATION EVALS JOB (DUMMY DATA)
+  ####################################################################
   run-combination-evals:
     needs: [run-e2e-bb-tests, run-e2e-tests, determine-evals]
     runs-on: ubuntu-latest
@@ -194,18 +216,22 @@ jobs:
             exit 1
           fi
 
+  ####################################################################
+  # 7. SPECIALIZED EVALS (Single Job, Multi-Step)
   #
-  # Specialized evals (dummy data) - run sequentially by concurrency group
+  #    This job replaces the old separate jobs for:
+  #      - extract
+  #      - text-extract
+  #      - act
+  #      - observe
   #
-
-  run-extract-evals:
+  #    It runs them in sequence, each block gated by an IF condition
+  #    so we skip any eval steps that are not labeled.
+  ####################################################################
+  run-specialized-evals:
     needs: [determine-evals, run-combination-evals]
-    if: needs.determine-evals.outputs.run-extract == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 50
-    concurrency:
-      group: specialized-evals-${{ github.run_id }}
-      cancel-in-progress: false
+    timeout-minutes: 60
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -233,11 +259,14 @@ jobs:
       - name: Install Playwright browsers
         run: npm exec playwright install --with-deps
 
-      # 1. "Run Extract Evals (domExtract)" - Dummy
+      ############################################################
+      # 7A. EXTRACT EVALS (if label = 'extract')
+      ############################################################
       - name: Run Extract Evals (domExtract)
+        if: ${{ needs.determine-evals.outputs.run-extract == 'true' }}
         run: |
           echo "Pretending to run extract eval with domExtract..."
-          cat <<EOF > eval-summary.json
+          cat <<EOF > eval-summary-extract-dom.json
           {
             "experimentName": "dummyExtractDom",
             "categories": {
@@ -245,14 +274,12 @@ jobs:
             }
           }
           EOF
-      - name: Save Extract Dom Results
-        run: mv eval-summary.json eval-summary-extract-dom.json
 
-      # 2. "Run Extract Evals (textExtract)" - Dummy
       - name: Run Extract Evals (textExtract)
+        if: ${{ needs.determine-evals.outputs.run-extract == 'true' }}
         run: |
           echo "Pretending to run extract eval with textExtract..."
-          cat <<EOF > eval-summary.json
+          cat <<EOF > eval-summary-extract-text.json
           {
             "experimentName": "dummyExtractText",
             "categories": {
@@ -260,27 +287,24 @@ jobs:
             }
           }
           EOF
-      - name: Save Extract Text Results
-        run: mv eval-summary.json eval-summary-extract-text.json
 
-      # 3. Log and Compare (Dummy)
       - name: Log and Compare Extract Evals Performance
+        if: ${{ needs.determine-evals.outputs.run-extract == 'true' }}
         run: |
-          # Check if we have the domExtract results
+          # Check domExtract results
           if [ -f eval-summary-extract-dom.json ]; then
             experimentNameDom=$(jq -r '.experimentName' eval-summary-extract-dom.json)
             dom_score=$(jq '.categories.extract' eval-summary-extract-dom.json)
             echo "DomExtract Score: $dom_score%"
             echo "See: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameDom}"
 
-            # Example fail if below threshold
             if (( $(echo "$dom_score < 80" | bc -l) )); then
               echo "DomExtract extract category <80%. Failing CI."
               exit 1
             fi
           fi
 
-          # Check if we have the textExtract results
+          # Check textExtract results
           if [ -f eval-summary-extract-text.json ]; then
             experimentNameText=$(jq -r '.experimentName' eval-summary-extract-text.json)
             text_score=$(jq '.categories.extract' eval-summary-extract-text.json)
@@ -288,46 +312,14 @@ jobs:
             echo "See: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameText}"
           fi
 
-  run-text-extract-evals:
-    needs: [determine-evals, run-combination-evals]
-    if: needs.determine-evals.outputs.run-text-extract == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-    concurrency:
-      group: specialized-evals-${{ github.run_id }}
-      cancel-in-progress: false
-    env:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
-      BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
-      BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
-      HEADLESS: true
-      EVAL_ENV: browserbase
-
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install dependencies
-        run: npm install --no-frozen-lockfile
-
-      - name: Build Stagehand
-        run: npm run build
-
-      - name: Install Playwright browsers
-        run: npm exec playwright install --with-deps
-
-      # 1. text_extract with textExtract (Dummy)
+      ############################################################
+      # 7B. TEXT-EXTRACT EVALS (if label = 'text-extract')
+      ############################################################
       - name: Run text_extract Evals (textExtract)
+        if: ${{ needs.determine-evals.outputs.run-text-extract == 'true' }}
         run: |
           echo "Pretending to run text_extract eval with textExtract..."
-          cat <<EOF > eval-summary.json
+          cat <<EOF > eval-summary-text_extract-text.json
           {
             "experimentName": "dummyTextExtract_TextMode",
             "categories": {
@@ -335,14 +327,12 @@ jobs:
             }
           }
           EOF
-      - name: Save text_extract Text Results
-        run: mv eval-summary.json eval-summary-text_extract-text.json
 
-      # 2. text_extract with domExtract (Dummy)
       - name: Run text_extract Evals (domExtract)
+        if: ${{ needs.determine-evals.outputs.run-text-extract == 'true' }}
         run: |
           echo "Pretending to run text_extract eval with domExtract..."
-          cat <<EOF > eval-summary.json
+          cat <<EOF > eval-summary-text_extract-dom.json
           {
             "experimentName": "dummyTextExtract_DomMode",
             "categories": {
@@ -350,11 +340,9 @@ jobs:
             }
           }
           EOF
-      - name: Save text_extract Dom Results
-        run: mv eval-summary.json eval-summary-text_extract-dom.json
 
-      # 3. Log and Compare text_extract (Dummy)
       - name: Log and Compare text_extract
+        if: ${{ needs.determine-evals.outputs.run-text-extract == 'true' }}
         run: |
           if [ -f eval-summary-text_extract-text.json ]; then
             experimentNameTxt=$(jq -r '.experimentName' eval-summary-text_extract-text.json)
@@ -375,46 +363,14 @@ jobs:
             echo "See: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameDom}"
           fi
 
-  run-act-evals:
-    needs: [determine-evals, run-combination-evals]
-    if: needs.determine-evals.outputs.run-act == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
-    concurrency:
-      group: specialized-evals-${{ github.run_id }}
-      cancel-in-progress: false
-    env:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
-      BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
-      BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
-      HEADLESS: true
-      EVAL_ENV: browserbase
-
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install dependencies
-        run: npm install --no-frozen-lockfile
-
-      - name: Build Stagehand
-        run: npm run build
-
-      - name: Install Playwright browsers
-        run: npm exec playwright install --with-deps
-
-      # Dummy "Act" eval
+      ############################################################
+      # 7C. ACT EVALS (if label = 'act')
+      ############################################################
       - name: Run Act Evals
+        if: ${{ needs.determine-evals.outputs.run-act == 'true' }}
         run: |
           echo "Pretending to run act eval..."
-          cat <<EOF > eval-summary.json
+          cat <<EOF > eval-summary-act.json
           {
             "experimentName": "dummyActEval",
             "categories": {
@@ -424,11 +380,12 @@ jobs:
           EOF
 
       - name: Log Act Evals Performance
+        if: ${{ needs.determine-evals.outputs.run-act == 'true' }}
         run: |
-          experimentName=$(jq -r '.experimentName' eval-summary.json)
+          experimentName=$(jq -r '.experimentName' eval-summary-act.json)
           echo "See: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName}"
-          if [ -f eval-summary.json ]; then
-            act_score=$(jq '.categories.act' eval-summary.json)
+          if [ -f eval-summary-act.json ]; then
+            act_score=$(jq '.categories.act' eval-summary-act.json)
             echo "Act category score: $act_score%"
             if (( $(echo "$act_score < 80" | bc -l) )); then
               echo "Act <80%. Failing CI."
@@ -439,46 +396,14 @@ jobs:
             exit 1
           fi
 
-  run-observe-evals:
-    needs: [determine-evals, run-combination-evals]
-    if: needs.determine-evals.outputs.run-observe == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
-    concurrency:
-      group: specialized-evals-${{ github.run_id }}-
-      cancel-in-progress: false
-    env:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
-      BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
-      BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
-      HEADLESS: true
-      EVAL_ENV: browserbase
-
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install dependencies
-        run: npm install --no-frozen-lockfile
-
-      - name: Build Stagehand
-        run: npm run build
-
-      - name: Install Playwright browsers
-        run: npm exec playwright install --with-deps
-
-      # Dummy "Observe" eval
+      ############################################################
+      # 7D. OBSERVE EVALS (if label = 'observe')
+      ############################################################
       - name: Run Observe Evals
+        if: ${{ needs.determine-evals.outputs.run-observe == 'true' }}
         run: |
           echo "Pretending to run observe eval..."
-          cat <<EOF > eval-summary.json
+          cat <<EOF > eval-summary-observe.json
           {
             "experimentName": "dummyObserveEval",
             "categories": {
@@ -488,11 +413,12 @@ jobs:
           EOF
 
       - name: Log Observe Evals Performance
+        if: ${{ needs.determine-evals.outputs.run-observe == 'true' }}
         run: |
-          experimentName=$(jq -r '.experimentName' eval-summary.json)
+          experimentName=$(jq -r '.experimentName' eval-summary-observe.json)
           echo "See: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName}"
-          if [ -f eval-summary.json ]; then
-            observe_score=$(jq '.categories.observe' eval-summary.json)
+          if [ -f eval-summary-observe.json ]; then
+            observe_score=$(jq '.categories.observe' eval-summary-observe.json)
             echo "Observe category score: $observe_score%"
             if (( $(echo "$observe_score < 80" | bc -l) )); then
               echo "Observe <80%. Failing CI."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
     steps:
       - id: check-labels
         run: |
-          # Default to running all tests on main branch
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             echo "Running all tests for main branch"
             echo "run-extract=true" >> $GITHUB_OUTPUT
@@ -32,7 +31,6 @@ jobs:
             exit 0
           fi
 
-          # Check for specific labels
           echo "run-extract=${{ contains(github.event.pull_request.labels.*.name, 'extract') }}" >> $GITHUB_OUTPUT
           echo "run-act=${{ contains(github.event.pull_request.labels.*.name, 'act') }}" >> $GITHUB_OUTPUT
           echo "run-observe=${{ contains(github.event.pull_request.labels.*.name, 'observe') }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,32 +204,37 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check for 'act' label
+        id: label-check
         run: |
           if [ "${{ needs.determine-evals.outputs.run-act }}" != "true" ]; then
+            echo "has_label=false" >> $GITHUB_OUTPUT
             echo "No label for ACT. Exiting with success."
-            exit 0
+          else
+            echo "has_label=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Set up Node.js
+        if: steps.label-check.outputs.has_label == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: "20"
 
       - name: Install dependencies
+        if: steps.label-check.outputs.has_label == 'true'
         run: npm install --no-frozen-lockfile
 
-      - name: Install Playwright browsers
-        run: npm exec playwright install --with-deps
-
       - name: Build Stagehand
+        if: steps.label-check.outputs.has_label == 'true'
         run: npm run build
 
       - name: Dummy Act Evals
+        if: steps.label-check.outputs.has_label == 'true'
         run: |
           echo "Running dummy act evals..."
           echo '{"experimentName":"dummyAct","categories":{"act":82}}' > eval-summary.json
 
       - name: Log Act Evals Performance
+        if: steps.label-check.outputs.has_label == 'true'
         run: |
           experimentName=$(jq -r '.experimentName' eval-summary.json)
           echo "View results at https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,10 @@ jobs:
         if: needs.determine-evals.outputs.run-act == 'true'
         run: npm run build
 
+      - name: Install Playwright browsers
+        if: needs.determine-evals.outputs.run-act == 'true'
+        run: npm exec playwright install --with-deps
+
       - name: Run Act Evals
         if: needs.determine-evals.outputs.run-act == 'true'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,6 @@ jobs:
 
       - name: Run Build
         run: npm run build
-  ## comment to test concurrency in CI
 
   run-e2e-tests:
     needs: [run-lint, run-build]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,6 @@ jobs:
           echo "run-observe=${{ contains(github.event.pull_request.labels.*.name, 'observe') }}" >> $GITHUB_OUTPUT
           echo "run-text-extract=${{ contains(github.event.pull_request.labels.*.name, 'text-extract') }}" >> $GITHUB_OUTPUT
 
-          echo "Extract label: ${{ contains(github.event.pull_request.labels.*.name, 'extract') }}"
-          echo "Act label: ${{ contains(github.event.pull_request.labels.*.name, 'act') }}"
-          echo "Observe label: ${{ contains(github.event.pull_request.labels.*.name, 'observe') }}"
-          echo "Text-Extract label: ${{ contains(github.event.pull_request.labels.*.name, 'text-extract') }}"
-
   run-lint:
     runs-on: ubuntu-latest
     steps:
@@ -162,16 +157,14 @@ jobs:
       - name: Install dependencies
         run: npm install --no-frozen-lockfile
 
-      - name: Install Playwright browsers
-        run: npm exec playwright install --with-deps
-
       - name: Build Stagehand
         run: npm run build
 
-      - name: Dummy Combination Evals
-        run: |
-          echo "Running dummy combination evals..."
-          echo '{"experimentName":"dummyCombination","categories":{"combination":95}}' > eval-summary.json
+      - name: Install Playwright browsers
+        run: npm exec playwright install --with-deps
+
+      - name: Run Combination Evals
+        run: npm run evals category combination
 
       - name: Log Combination Evals Performance
         run: |
@@ -226,11 +219,10 @@ jobs:
         if: needs.determine-evals.outputs.run-act == 'true'
         run: npm run build
 
-      - name: Dummy Act Evals
+      - name: Run Act Evals
         if: needs.determine-evals.outputs.run-act == 'true'
         run: |
-          echo "Running dummy act evals..."
-          echo '{"experimentName":"dummyAct","categories":{"act":82}}' > eval-summary.json
+          run: npm run evals category act
 
       - name: Log Act Evals Performance
         if: needs.determine-evals.outputs.run-act == 'true'
@@ -294,26 +286,22 @@ jobs:
         run: npm run build
 
       # 1. Run extract category with domExtract
-      - name: Dummy Extract Evals (domExtract)
+      - name: Run Extract Evals (domExtract)
         if: needs.determine-evals.outputs.run-extract == 'true'
-        run: |
-          echo "Running dummy extract evals (domExtract)..."
-          echo '{"experimentName":"dummyDomExtract","categories":{"extract":85}}' > eval-summary.json
+        run: npm run evals category extract -- --extract-method=domExtract
       - name: Save Extract Dom Results
         if: needs.determine-evals.outputs.run-extract == 'true'
         run: mv eval-summary.json eval-summary-extract-dom.json
 
-      # 2. Then run extract category with textExtract
-      - name: Dummy Extract Evals (textExtract)
+      # 2. Once domExtract finishes, run extract category with textExtract
+      - name: Run Extract Evals (textExtract)
         if: needs.determine-evals.outputs.run-extract == 'true'
-        run: |
-          echo "Running dummy extract evals (textExtract)..."
-          echo '{"experimentName":"dummyTextExtract","categories":{"extract":90}}' > eval-summary.json
+        run: npm run evals category extract -- --extract-method=textExtract
       - name: Save Extract Text Results
         if: needs.determine-evals.outputs.run-extract == 'true'
         run: mv eval-summary.json eval-summary-extract-text.json
 
-      # 3. Log and Compare
+      # 3. Log and Compare Extract Evals Performance
       - name: Log and Compare Extract Evals Performance
         if: needs.determine-evals.outputs.run-extract == 'true'
         run: |
@@ -327,7 +315,7 @@ jobs:
           echo "TextExtract Extract category score: $text_score%"
           echo "View textExtract results: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameText}"
 
-          # If domExtract <80% fail CI
+          # 4. If domExtract <80% fail CI
           if (( $(echo "$dom_score < 80" | bc -l) )); then
             echo "DomExtract extract category score is below 80%. Failing CI."
             exit 1
@@ -377,27 +365,24 @@ jobs:
         if: needs.determine-evals.outputs.run-text-extract == 'true'
         run: npm run build
 
-      # 1. text_extract with textExtract first
-      - name: Dummy text_extract Evals (textExtract)
+      # 1. Run text_extract category with textExtract first
+      - name: Run text_extract Evals (textExtract)
         if: needs.determine-evals.outputs.run-text-extract == 'true'
-        run: |
-          echo "Running dummy text_extract (textExtract)..."
-          echo '{"experimentName":"dummyTextExtract","categories":{"text_extract":90}}' > eval-summary.json
+        run: npm run evals category text_extract -- --extract-method=textExtract
+
       - name: Save text_extract Text Results
         if: needs.determine-evals.outputs.run-text-extract == 'true'
         run: mv eval-summary.json eval-summary-text_extract-text.json
 
-      # 2. Then domExtract
-      - name: Dummy text_extract Evals (domExtract)
+      # 2. Then run text_extract category with domExtract
+      - name: Run text_extract Evals (domExtract)
         if: needs.determine-evals.outputs.run-text-extract == 'true'
-        run: |
-          echo "Running dummy text_extract (domExtract)..."
-          echo '{"experimentName":"dummyDomExtract","categories":{"text_extract":88}}' > eval-summary.json
+        run: npm run evals category text_extract -- --extract-method=domExtract
       - name: Save text_extract Dom Results
         if: needs.determine-evals.outputs.run-text-extract == 'true'
         run: mv eval-summary.json eval-summary-text_extract-dom.json
 
-      # 3. Log and Compare
+      # 3. Log and Compare text_extract Evals Performance
       - name: Log and Compare text_extract Evals Performance
         if: needs.determine-evals.outputs.run-text-extract == 'true'
         run: |
@@ -411,7 +396,7 @@ jobs:
           echo "DomExtract text_extract category score: $dom_score%"
           echo "View domExtract results: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameDom}"
 
-          # If text_score <80% fail CI
+          # 4. If textExtract (for text_extract category) <80% fail CI
           if (( $(echo "$text_score < 80" | bc -l) )); then
             echo "textExtract text_extract category score is below 80%. Failing CI."
             exit 1
@@ -461,11 +446,9 @@ jobs:
         if: needs.determine-evals.outputs.run-observe == 'true'
         run: npm run build
 
-      - name: Dummy Observe Evals
+      - name: Run Observe Evals
         if: needs.determine-evals.outputs.run-observe == 'true'
-        run: |
-          echo "Running dummy observe evals..."
-          echo '{"experimentName":"dummyObserve","categories":{"observe":85}}' > eval-summary.json
+        run: npm run evals category observe
 
       - name: Log Observe Evals Performance
         if: needs.determine-evals.outputs.run-observe == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,194 +7,75 @@ on:
       - synchronize
       - labeled
 
-env:
-  EVAL_MODELS: "gpt-4o,gpt-4o-mini,claude-3-5-sonnet-latest"
-  EVAL_CATEGORIES: "observe,act,combination,extract,text_extract"
-
 jobs:
-  ####################################################################
+  ##########################################################################
   # 1. DETERMINE-EVALS
   #
-  #    Checks if the PR is on the main branch or if it has
-  #    certain labels, then sets outputs to instruct
-  #    which specialized evals should run.
-  ####################################################################
+  #    Checks if this is the main branch or specific labels, then outputs
+  #    a JSON array of categories to run, e.g. ["extract","act","observe"].
+  ##########################################################################
   determine-evals:
     runs-on: ubuntu-latest
     outputs:
-      run-extract: ${{ steps.check-labels.outputs.run-extract }}
-      run-act: ${{ steps.check-labels.outputs.run-act }}
-      run-observe: ${{ steps.check-labels.outputs.run-observe }}
-      run-text-extract: ${{ steps.check-labels.outputs.run-text-extract }}
+      dynamic_matrix: ${{ steps.set-matrix.outputs.eval_matrix }}
     steps:
       - id: check-labels
         run: |
-          # Default to running all specialized tests on main branch
+          # Default to running all specialized tests if on main
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
-            echo "Running all specialized categories for main branch"
-            echo "run-extract=true" >> $GITHUB_OUTPUT
-            echo "run-act=true" >> $GITHUB_OUTPUT
-            echo "run-observe=true" >> $GITHUB_OUTPUT
-            echo "run-text-extract=true" >> $GITHUB_OUTPUT
+            echo "::set-output name=run-extract::true"
+            echo "::set-output name=run-act::true"
+            echo "::set-output name=run-observe::true"
+            echo "::set-output name=run-text-extract::true"
             exit 0
           fi
 
-          # Otherwise, check for specific labels
-          echo "run-extract=${{ contains(github.event.pull_request.labels.*.name, 'extract') }}" >> $GITHUB_OUTPUT
-          echo "run-act=${{ contains(github.event.pull_request.labels.*.name, 'act') }}" >> $GITHUB_OUTPUT
-          echo "run-observe=${{ contains(github.event.pull_request.labels.*.name, 'observe') }}" >> $GITHUB_OUTPUT
-          echo "run-text-extract=${{ contains(github.event.pull_request.labels.*.name, 'text-extract') }}" >> $GITHUB_OUTPUT
+          # Otherwise, check labels for each category
+          echo "::set-output name=run-extract::$(echo ${{ contains(github.event.pull_request.labels.*.name, 'extract') }})"
+          echo "::set-output name=run-act::$(echo ${{ contains(github.event.pull_request.labels.*.name, 'act') }})"
+          echo "::set-output name=run-observe::$(echo ${{ contains(github.event.pull_request.labels.*.name, 'observe') }})"
+          echo "::set-output name=run-text-extract::$(echo ${{ contains(github.event.pull_request.labels.*.name, 'text-extract') }})"
 
-  ####################################################################
-  # 2. LINT JOB
-  ####################################################################
-  run-lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v4
+      - id: set-matrix
+        run: |
+          # We'll gather categories into a JSON array
+          cats=()
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
+          if [ "${{ steps.check-labels.outputs.run-extract }}" == "true" ]; then
+            cats+=("extract")
+          fi
+          if [ "${{ steps.check-labels.outputs.run-text-extract }}" == "true" ]; then
+            cats+=("text_extract")
+          fi
+          if [ "${{ steps.check-labels.outputs.run-act }}" == "true" ]; then
+            cats+=("act")
+          fi
+          if [ "${{ steps.check-labels.outputs.run-observe }}" == "true" ]; then
+            cats+=("observe")
+          fi
 
-      - name: Install dependencies
-        run: npm install --no-frozen-lockfile
+          # Convert Bash array to JSON array: ["extract","act",...]
+          # If no categories, it becomes an empty array "[]"
+          JSON_ARRAY="$(printf '%s\n' "${cats[@]}" | jq -R . | jq -s .)"
 
-      - name: Run Lint
-        run: npm run lint
+          echo "Eval categories: $JSON_ARRAY"
 
-  ####################################################################
-  # 3. BUILD JOB
-  ####################################################################
-  run-build:
-    runs-on: ubuntu-latest
-    needs: [run-lint]
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v4
+          # Pass JSON_ARRAY back as an output of this step
+          echo "::set-output name=eval_matrix::$JSON_ARRAY"
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install dependencies
-        run: npm install --no-frozen-lockfile
-
-      - name: Run Build
-        run: npm run build
-
-  ####################################################################
-  # 4. E2E TESTS JOB
-  ####################################################################
-  run-e2e-tests:
-    needs: [run-lint, run-build]
-    runs-on: ubuntu-latest
-    timeout-minutes: 50
-    env:
-      HEADLESS: true
-
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install dependencies
-        run: npm install --no-frozen-lockfile
-
-      - name: Install Playwright browsers
-        run: npm exec playwright install --with-deps
-
-      - name: Build Stagehand
-        run: npm run build
-
-      - name: Run E2E Tests (Deterministic Playwright)
-        run: npm run e2e
-
-  ####################################################################
-  # 5. E2E-BB (Browserbase) TESTS JOB
-  ####################################################################
-  run-e2e-bb-tests:
-    needs: [run-e2e-tests]
-    runs-on: ubuntu-latest
-    timeout-minutes: 50
-    if: >
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
-
-    env:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
-      BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
-      HEADLESS: true
-
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install dependencies
-        run: npm install --no-frozen-lockfile
-
-      - name: Install Playwright browsers
-        run: npm exec playwright install --with-deps
-
-      - name: Build Stagehand
-        run: npm run build
-
-      - name: Run E2E Tests (browserbase)
-        run: npm run e2e:bb
-
-  ####################################################################
-  # 6. COMBINATION EVALS JOB (DUMMY DATA)
-  ####################################################################
+  ##########################################################################
+  # 2. EXAMPLE: COMBINATION EVALS
+  ##########################################################################
   run-combination-evals:
-    needs: [run-e2e-bb-tests, run-e2e-tests, determine-evals]
     runs-on: ubuntu-latest
-    timeout-minutes: 40
-    env:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
-      BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
-      BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
-      HEADLESS: true
-      EVAL_ENV: browserbase
-
+    needs: [determine-evals]
     steps:
-      - name: Check out repository code
+      - name: Check out repo
         uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install dependencies
-        run: npm install --no-frozen-lockfile
-
-      - name: Build Stagehand
-        run: npm run build
-
-      - name: Install Playwright browsers
-        run: npm exec playwright install --with-deps
-
-      - name: Run Combination Evals (Dummy)
+      - name: Pretend to run combo eval
         run: |
           echo "Pretending to run combination eval..."
-          # Write out a dummy eval-summary.json:
-          cat <<EOF > eval-summary.json
+          cat <<EOF > combo-summary.json
           {
             "experimentName": "dummyCombination",
             "categories": {
@@ -202,47 +83,32 @@ jobs:
             }
           }
           EOF
-
-      - name: Log Combination Evals Performance
+      - name: Log combo
         run: |
-          experimentName=$(jq -r '.experimentName' eval-summary.json)
-          echo "View results at https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName}"
-          if [ -f eval-summary.json ]; then
-            combination_score=$(jq '.categories.combination' eval-summary.json)
-            echo "Combination category score: $combination_score%"
-            exit 0
-          else
-            echo "Eval summary not found for combination category. Failing CI."
-            exit 1
-          fi
+          combo_score=$(jq '.categories.combination' combo-summary.json)
+          echo "Combination category score: $combo_score%"
 
-  ####################################################################
-  # 7. SPECIALIZED EVALS (Single Job, Multi-Step)
+  ##########################################################################
+  # 3. SPECIALIZED EVALS - DYNAMIC MATRIX
   #
-  #    This job replaces the old separate jobs for:
-  #      - extract
-  #      - text-extract
-  #      - act
-  #      - observe
+  #    This single job expands into multiple runs—one per category in
+  #    the dynamic_matrix. If the matrix array is empty, the job doesn't
+  #    run any child tasks, so it won't show "skipped" items.
   #
-  #    It runs them in sequence, each block gated by an IF condition
-  #    so we skip any eval steps that are not labeled.
-  ####################################################################
+  #    We set max-parallel: 1 to ensure the runs happen sequentially.
+  ##########################################################################
   run-specialized-evals:
     needs: [determine-evals, run-combination-evals]
     runs-on: ubuntu-latest
-    timeout-minutes: 60
-    env:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
-      BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
-      BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
-      HEADLESS: true
-      EVAL_ENV: browserbase
+
+    # Expand each item in the JSON array as matrix.category
+    strategy:
+      matrix:
+        category: ${{ fromJson(needs.determine-evals.outputs.dynamic_matrix) }}
+      max-parallel: 1 # force sequential runs
 
     steps:
-      - name: Check out repository code
+      - name: Check out repository
         uses: actions/checkout@v4
 
       - name: Set up Node.js
@@ -256,175 +122,78 @@ jobs:
       - name: Build Stagehand
         run: npm run build
 
-      - name: Install Playwright browsers
-        run: npm exec playwright install --with-deps
-
-      ############################################################
-      # 7A. EXTRACT EVALS (if label = 'extract')
-      ############################################################
-      - name: Run Extract Evals (domExtract)
-        if: ${{ needs.determine-evals.outputs.run-extract == 'true' }}
+      - name: Specialized Evals
         run: |
-          echo "Pretending to run extract eval with domExtract..."
-          cat <<EOF > eval-summary-extract-dom.json
-          {
-            "experimentName": "dummyExtractDom",
-            "categories": {
-              "extract": 85
-            }
-          }
-          EOF
-
-      - name: Run Extract Evals (textExtract)
-        if: ${{ needs.determine-evals.outputs.run-extract == 'true' }}
-        run: |
-          echo "Pretending to run extract eval with textExtract..."
-          cat <<EOF > eval-summary-extract-text.json
-          {
-            "experimentName": "dummyExtractText",
-            "categories": {
-              "extract": 92
-            }
-          }
-          EOF
-
-      - name: Log and Compare Extract Evals Performance
-        if: ${{ needs.determine-evals.outputs.run-extract == 'true' }}
-        run: |
-          # Check domExtract results
-          if [ -f eval-summary-extract-dom.json ]; then
-            experimentNameDom=$(jq -r '.experimentName' eval-summary-extract-dom.json)
-            dom_score=$(jq '.categories.extract' eval-summary-extract-dom.json)
-            echo "DomExtract Score: $dom_score%"
-            echo "See: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameDom}"
-
-            if (( $(echo "$dom_score < 80" | bc -l) )); then
-              echo "DomExtract extract category <80%. Failing CI."
+          case "${{ matrix.category }}" in
+            "extract")
+              echo "Running EXTRACT Evals..."
+              cat <<EOF > eval-summary-extract.json
+              {
+                "experimentName": "dummyExtractEval",
+                "categories": {
+                  "extract": 85
+                }
+              }
+              EOF
+              extract_score=$(jq '.categories.extract' eval-summary-extract.json)
+              echo "Extract Score: $extract_score%"
+              if (( $(echo "$extract_score < 80" | bc -l) )); then
+                echo "Extract <80%. Failing."
+                exit 1
+              fi
+              ;;
+            "text_extract")
+              echo "Running TEXT_EXTRACT Evals..."
+              cat <<EOF > eval-summary-text_extract.json
+              {
+                "experimentName": "dummyTextExtractEval",
+                "categories": {
+                  "text_extract": 78
+                }
+              }
+              EOF
+              txt_score=$(jq '.categories.text_extract' eval-summary-text_extract.json)
+              echo "TextExtract Score: $txt_score%"
+              if (( $(echo "$txt_score < 80" | bc -l) )); then
+                echo "text_extract <80%. Failing."
+                exit 1
+              fi
+              ;;
+            "act")
+              echo "Running ACT Evals..."
+              cat <<EOF > eval-summary-act.json
+              {
+                "experimentName": "dummyActEval",
+                "categories": {
+                  "act": 82
+                }
+              }
+              EOF
+              act_score=$(jq '.categories.act' eval-summary-act.json)
+              echo "Act Score: $act_score%"
+              if (( $(echo "$act_score < 80" | bc -l) )); then
+                echo "Act <80%. Failing."
+                exit 1
+              fi
+              ;;
+            "observe")
+              echo "Running OBSERVE Evals..."
+              cat <<EOF > eval-summary-observe.json
+              {
+                "experimentName": "dummyObserveEval",
+                "categories": {
+                  "observe": 88
+                }
+              }
+              EOF
+              observe_score=$(jq '.categories.observe' eval-summary-observe.json)
+              echo "Observe Score: $observe_score%"
+              if (( $(echo "$observe_score < 80" | bc -l) )); then
+                echo "Observe <80%. Failing."
+                exit 1
+              fi
+              ;;
+            *)
+              echo "Unknown category: ${{ matrix.category }}"
               exit 1
-            fi
-          fi
-
-          # Check textExtract results
-          if [ -f eval-summary-extract-text.json ]; then
-            experimentNameText=$(jq -r '.experimentName' eval-summary-extract-text.json)
-            text_score=$(jq '.categories.extract' eval-summary-extract-text.json)
-            echo "TextExtract Score: $text_score%"
-            echo "See: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameText}"
-          fi
-
-      ############################################################
-      # 7B. TEXT-EXTRACT EVALS (if label = 'text-extract')
-      ############################################################
-      - name: Run text_extract Evals (textExtract)
-        if: ${{ needs.determine-evals.outputs.run-text-extract == 'true' }}
-        run: |
-          echo "Pretending to run text_extract eval with textExtract..."
-          cat <<EOF > eval-summary-text_extract-text.json
-          {
-            "experimentName": "dummyTextExtract_TextMode",
-            "categories": {
-              "text_extract": 78
-            }
-          }
-          EOF
-
-      - name: Run text_extract Evals (domExtract)
-        if: ${{ needs.determine-evals.outputs.run-text-extract == 'true' }}
-        run: |
-          echo "Pretending to run text_extract eval with domExtract..."
-          cat <<EOF > eval-summary-text_extract-dom.json
-          {
-            "experimentName": "dummyTextExtract_DomMode",
-            "categories": {
-              "text_extract": 85
-            }
-          }
-          EOF
-
-      - name: Log and Compare text_extract
-        if: ${{ needs.determine-evals.outputs.run-text-extract == 'true' }}
-        run: |
-          if [ -f eval-summary-text_extract-text.json ]; then
-            experimentNameTxt=$(jq -r '.experimentName' eval-summary-text_extract-text.json)
-            txt_score=$(jq '.categories.text_extract' eval-summary-text_extract-text.json)
-            echo "TextExtract (text_extract) Score: $txt_score%"
-            echo "See: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameTxt}"
-
-            if (( $(echo "$txt_score < 80" | bc -l) )); then
-              echo "text_extract score <80%. Failing CI."
-              exit 1
-            fi
-          fi
-
-          if [ -f eval-summary-text_extract-dom.json ]; then
-            experimentNameDom=$(jq -r '.experimentName' eval-summary-text_extract-dom.json)
-            dom_score=$(jq '.categories.text_extract' eval-summary-text_extract-dom.json)
-            echo "DomExtract (text_extract) Score: $dom_score%"
-            echo "See: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameDom}"
-          fi
-
-      ############################################################
-      # 7C. ACT EVALS (if label = 'act')
-      ############################################################
-      - name: Run Act Evals
-        if: ${{ needs.determine-evals.outputs.run-act == 'true' }}
-        run: |
-          echo "Pretending to run act eval..."
-          cat <<EOF > eval-summary-act.json
-          {
-            "experimentName": "dummyActEval",
-            "categories": {
-              "act": 82
-            }
-          }
-          EOF
-
-      - name: Log Act Evals Performance
-        if: ${{ needs.determine-evals.outputs.run-act == 'true' }}
-        run: |
-          experimentName=$(jq -r '.experimentName' eval-summary-act.json)
-          echo "See: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName}"
-          if [ -f eval-summary-act.json ]; then
-            act_score=$(jq '.categories.act' eval-summary-act.json)
-            echo "Act category score: $act_score%"
-            if (( $(echo "$act_score < 80" | bc -l) )); then
-              echo "Act <80%. Failing CI."
-              exit 1
-            fi
-          else
-            echo "Eval summary not found. Failing CI."
-            exit 1
-          fi
-
-      ############################################################
-      # 7D. OBSERVE EVALS (if label = 'observe')
-      ############################################################
-      - name: Run Observe Evals
-        if: ${{ needs.determine-evals.outputs.run-observe == 'true' }}
-        run: |
-          echo "Pretending to run observe eval..."
-          cat <<EOF > eval-summary-observe.json
-          {
-            "experimentName": "dummyObserveEval",
-            "categories": {
-              "observe": 88
-            }
-          }
-          EOF
-
-      - name: Log Observe Evals Performance
-        if: ${{ needs.determine-evals.outputs.run-observe == 'true' }}
-        run: |
-          experimentName=$(jq -r '.experimentName' eval-summary-observe.json)
-          echo "See: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName}"
-          if [ -f eval-summary-observe.json ]; then
-            observe_score=$(jq '.categories.observe' eval-summary-observe.json)
-            echo "Observe category score: $observe_score%"
-            if (( $(echo "$observe_score < 80" | bc -l) )); then
-              echo "Observe <80%. Failing CI."
-              exit 1
-            fi
-          else
-            echo "Eval summary not found. Failing CI."
-            exit 1
-          fi
+          esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,72 +7,112 @@ on:
       - synchronize
       - labeled
 
+env:
+  EVAL_MODELS: "gpt-4o,gpt-4o-mini,claude-3-5-sonnet-latest"
+  EVAL_CATEGORIES: "observe,act,combination,extract,text_extract"
+
 jobs:
-  ##########################################################################
+  ####################################################################
   # 1. DETERMINE-EVALS
   #
-  #    Checks if this is the main branch or specific labels, then outputs
-  #    a JSON array of categories to run, e.g. ["extract","act","observe"].
-  ##########################################################################
+  #    Checks if the PR is on main or has certain labels, then sets
+  #    outputs to instruct which specialized evals should run.
+  ####################################################################
   determine-evals:
     runs-on: ubuntu-latest
     outputs:
-      dynamic_matrix: ${{ steps.set-matrix.outputs.eval_matrix }}
+      run-extract: ${{ steps.check-labels.outputs.run-extract }}
+      run-act: ${{ steps.check-labels.outputs.run-act }}
+      run-observe: ${{ steps.check-labels.outputs.run-observe }}
+      run-text-extract: ${{ steps.check-labels.outputs.run-text-extract }}
     steps:
       - id: check-labels
         run: |
-          # Default to running all specialized tests if on main
+          # Default: run all specialized tests on main
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
-            echo "::set-output name=run-extract::true"
-            echo "::set-output name=run-act::true"
-            echo "::set-output name=run-observe::true"
-            echo "::set-output name=run-text-extract::true"
+            echo "run-extract=true" >> $GITHUB_OUTPUT
+            echo "run-act=true" >> $GITHUB_OUTPUT
+            echo "run-observe=true" >> $GITHUB_OUTPUT
+            echo "run-text-extract=true" >> $GITHUB_OUTPUT
             exit 0
           fi
 
-          # Otherwise, check labels for each category
-          echo "::set-output name=run-extract::$(echo ${{ contains(github.event.pull_request.labels.*.name, 'extract') }})"
-          echo "::set-output name=run-act::$(echo ${{ contains(github.event.pull_request.labels.*.name, 'act') }})"
-          echo "::set-output name=run-observe::$(echo ${{ contains(github.event.pull_request.labels.*.name, 'observe') }})"
-          echo "::set-output name=run-text-extract::$(echo ${{ contains(github.event.pull_request.labels.*.name, 'text-extract') }})"
+          # Otherwise check specific labels
+          echo "run-extract=${{ contains(github.event.pull_request.labels.*.name, 'extract') }}" >> $GITHUB_OUTPUT
+          echo "run-act=${{ contains(github.event.pull_request.labels.*.name, 'act') }}" >> $GITHUB_OUTPUT
+          echo "run-observe=${{ contains(github.event.pull_request.labels.*.name, 'observe') }}" >> $GITHUB_OUTPUT
+          echo "run-text-extract=${{ contains(github.event.pull_request.labels.*.name, 'text-extract') }}" >> $GITHUB_OUTPUT
 
-      - id: set-matrix
-        run: |
-          # We'll gather categories into a JSON array
-          cats=()
-
-          if [ "${{ steps.check-labels.outputs.run-extract }}" == "true" ]; then
-            cats+=("extract")
-          fi
-          if [ "${{ steps.check-labels.outputs.run-text-extract }}" == "true" ]; then
-            cats+=("text_extract")
-          fi
-          if [ "${{ steps.check-labels.outputs.run-act }}" == "true" ]; then
-            cats+=("act")
-          fi
-          if [ "${{ steps.check-labels.outputs.run-observe }}" == "true" ]; then
-            cats+=("observe")
-          fi
-
-          # Convert Bash array to JSON array: ["extract","act",...]
-          # If no categories, it becomes an empty array "[]"
-          JSON_ARRAY="$(printf '%s\n' "${cats[@]}" | jq -R . | jq -s .)"
-
-          echo "Eval categories: $JSON_ARRAY"
-
-          # Pass JSON_ARRAY back as an output of this step
-          echo "::set-output name=eval_matrix::$JSON_ARRAY"
-
-  ##########################################################################
-  # 2. EXAMPLE: COMBINATION EVALS
-  ##########################################################################
-  run-combination-evals:
+  ####################################################################
+  # 2. Some Pre-Eval Jobs (examples)
+  ####################################################################
+  run-lint:
     runs-on: ubuntu-latest
-    needs: [determine-evals]
     steps:
-      - name: Check out repo
+      - name: Check out repository code
         uses: actions/checkout@v4
-      - name: Pretend to run combo eval
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm install --no-frozen-lockfile
+
+      - name: Run Lint
+        run: npm run lint
+
+  run-build:
+    runs-on: ubuntu-latest
+    needs: [run-lint]
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm install --no-frozen-lockfile
+
+      - name: Run Build
+        run: npm run build
+
+  run-e2e-tests:
+    needs: [run-lint, run-build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install dependencies
+        run: npm install --no-frozen-lockfile
+      - name: Build Stagehand
+        run: npm run build
+      - name: Run E2E Tests
+        run: npm run e2e
+
+  run-combination-evals:
+    needs: [run-e2e-tests, determine-evals]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install dependencies
+        run: npm install --no-frozen-lockfile
+      - name: Build Stagehand
+        run: npm run build
+      - name: Combination Evals (Dummy)
         run: |
           echo "Pretending to run combination eval..."
           cat <<EOF > combo-summary.json
@@ -83,30 +123,28 @@ jobs:
             }
           }
           EOF
-      - name: Log combo
+      - name: Log Combination
         run: |
+          if [ ! -f combo-summary.json ]; then
+            echo "No combination file found, failing"
+            exit 1
+          fi
           combo_score=$(jq '.categories.combination' combo-summary.json)
           echo "Combination category score: $combo_score%"
 
-  ##########################################################################
-  # 3. SPECIALIZED EVALS - DYNAMIC MATRIX
+  ####################################################################
+  # 3. SPECIALIZED EVAL JOBS, SEQUENTIAL
   #
-  #    This single job expands into multiple runs—one per category in
-  #    the dynamic_matrix. If the matrix array is empty, the job doesn't
-  #    run any child tasks, so it won't show "skipped" items.
-  #
-  #    We set max-parallel: 1 to ensure the runs happen sequentially.
-  ##########################################################################
-  run-specialized-evals:
+  #    Each job depends on the previous, so they run strictly in order:
+  #      run-extract-evals -> run-text-extract-evals -> run-act-evals -> run-observe-evals
+  #    If the label isn't set, the job does a no-op and exits 0 = success
+  #    so the next job won't be skipped.
+  ####################################################################
+
+  # ----------------- EXTRACT EVALS -----------------
+  run-extract-evals:
     needs: [determine-evals, run-combination-evals]
     runs-on: ubuntu-latest
-
-    # Expand each item in the JSON array as matrix.category
-    strategy:
-      matrix:
-        category: ${{ fromJson(needs.determine-evals.outputs.dynamic_matrix) }}
-      max-parallel: 1 # force sequential runs
-
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -122,78 +160,176 @@ jobs:
       - name: Build Stagehand
         run: npm run build
 
-      - name: Specialized Evals
+      - name: Maybe Run Extract Evals
         run: |
-          case "${{ matrix.category }}" in
-            "extract")
-              echo "Running EXTRACT Evals..."
-              cat <<EOF > eval-summary-extract.json
-              {
-                "experimentName": "dummyExtractEval",
-                "categories": {
-                  "extract": 85
-                }
-              }
-              EOF
-              extract_score=$(jq '.categories.extract' eval-summary-extract.json)
-              echo "Extract Score: $extract_score%"
-              if (( $(echo "$extract_score < 80" | bc -l) )); then
-                echo "Extract <80%. Failing."
-                exit 1
-              fi
-              ;;
-            "text_extract")
-              echo "Running TEXT_EXTRACT Evals..."
-              cat <<EOF > eval-summary-text_extract.json
-              {
-                "experimentName": "dummyTextExtractEval",
-                "categories": {
-                  "text_extract": 78
-                }
-              }
-              EOF
-              txt_score=$(jq '.categories.text_extract' eval-summary-text_extract.json)
-              echo "TextExtract Score: $txt_score%"
-              if (( $(echo "$txt_score < 80" | bc -l) )); then
-                echo "text_extract <80%. Failing."
-                exit 1
-              fi
-              ;;
-            "act")
-              echo "Running ACT Evals..."
-              cat <<EOF > eval-summary-act.json
-              {
-                "experimentName": "dummyActEval",
-                "categories": {
-                  "act": 82
-                }
-              }
-              EOF
-              act_score=$(jq '.categories.act' eval-summary-act.json)
-              echo "Act Score: $act_score%"
-              if (( $(echo "$act_score < 80" | bc -l) )); then
-                echo "Act <80%. Failing."
-                exit 1
-              fi
-              ;;
-            "observe")
-              echo "Running OBSERVE Evals..."
-              cat <<EOF > eval-summary-observe.json
-              {
-                "experimentName": "dummyObserveEval",
-                "categories": {
-                  "observe": 88
-                }
-              }
-              EOF
-              observe_score=$(jq '.categories.observe' eval-summary-observe.json)
-              echo "Observe Score: $observe_score%"
-              if (( $(echo "$observe_score < 80" | bc -l) )); then
-                echo "Observe <80%. Failing."
-                exit 1
-              fi
-              ;;
-            *)
-              echo "Unknown category: ${{ matrix.category }}"
-              exit 1
-          esac
+          if [ "${{ needs.determine-evals.outputs.run-extract }}" != "true" ]; then
+            echo "Label 'extract' not set. Skipping extract steps."
+            exit 0
+          fi
+          echo "Pretending to run EXTRACT EVALS..."
+          cat <<EOF > eval-summary-extract.json
+          {
+            "experimentName": "dummyExtractEval",
+            "categories": {
+              "extract": 85
+            }
+          }
+          EOF
+
+      - name: Check Extract Score
+        run: |
+          # If we didn't run the above step, no file
+          if [ ! -f eval-summary-extract.json ]; then
+            echo "No extract file found. Possibly skipped. Exiting success."
+            exit 0
+          fi
+          extract_score=$(jq '.categories.extract' eval-summary-extract.json)
+          echo "Extract category score: $extract_score%"
+          if (( $(echo "$extract_score < 80" | bc -l) )); then
+            echo "Extract <80%. Failing CI."
+            exit 1
+          fi
+
+  # ----------------- TEXT-EXTRACT EVALS -----------------
+  run-text-extract-evals:
+    needs: [run-extract-evals] # ensures it runs after run-extract-evals
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm install --no-frozen-lockfile
+
+      - name: Build Stagehand
+        run: npm run build
+
+      - name: Maybe Run text_extract Evals
+        run: |
+          if [ "${{ needs.determine-evals.outputs.run-text-extract }}" != "true" ]; then
+            echo "Label 'text-extract' not set. Skipping text_extract steps."
+            exit 0
+          fi
+          echo "Pretending to run TEXT_EXTRACT EVALS..."
+          cat <<EOF > eval-summary-textExtract.json
+          {
+            "experimentName": "dummyTextExtractEval",
+            "categories": {
+              "text_extract": 78
+            }
+          }
+          EOF
+
+      - name: Check text_extract Score
+        run: |
+          if [ ! -f eval-summary-textExtract.json ]; then
+            echo "No text_extract file found. Possibly skipped. Exiting success."
+            exit 0
+          fi
+          text_extract_score=$(jq '.categories.text_extract' eval-summary-textExtract.json)
+          echo "text_extract score: $text_extract_score%"
+          if (( $(echo "$text_extract_score < 80" | bc -l) )); then
+            echo "text_extract <80%. Failing CI."
+            exit 1
+          fi
+
+  # ----------------- ACT EVALS -----------------
+  run-act-evals:
+    needs: [run-text-extract-evals] # ensures it runs after text-extract-evals
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm install --no-frozen-lockfile
+
+      - name: Build Stagehand
+        run: npm run build
+
+      - name: Maybe Run Act Evals
+        run: |
+          if [ "${{ needs.determine-evals.outputs.run-act }}" != "true" ]; then
+            echo "Label 'act' not set. Skipping act steps."
+            exit 0
+          fi
+          echo "Pretending to run ACT EVALS..."
+          cat <<EOF > eval-summary-act.json
+          {
+            "experimentName": "dummyActEval",
+            "categories": {
+              "act": 82
+            }
+          }
+          EOF
+
+      - name: Check Act Score
+        run: |
+          if [ ! -f eval-summary-act.json ]; then
+            echo "No act file found. Possibly skipped. Exiting success."
+            exit 0
+          fi
+          act_score=$(jq '.categories.act' eval-summary-act.json)
+          echo "Act category score: $act_score%"
+          if (( $(echo "$act_score < 80" | bc -l) )); then
+            echo "Act <80%. Failing CI."
+            exit 1
+          fi
+
+  # ----------------- OBSERVE EVALS -----------------
+  run-observe-evals:
+    needs: [run-act-evals] # ensures it runs after act-evals
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm install --no-frozen-lockfile
+
+      - name: Build Stagehand
+        run: npm run build
+
+      - name: Maybe Run Observe Evals
+        run: |
+          if [ "${{ needs.determine-evals.outputs.run-observe }}" != "true" ]; then
+            echo "Label 'observe' not set. Skipping observe steps."
+            exit 0
+          fi
+          echo "Pretending to run OBSERVE EVALS..."
+          cat <<EOF > eval-summary-observe.json
+          {
+            "experimentName": "dummyObserveEval",
+            "categories": {
+              "observe": 88
+            }
+          }
+          EOF
+
+      - name: Check Observe Score
+        run: |
+          if [ ! -f eval-summary-observe.json ]; then
+            echo "No observe file found. Possibly skipped. Exiting success."
+            exit 0
+          fi
+          observe_score=$(jq '.categories.observe' eval-summary-observe.json)
+          echo "Observe category score: $observe_score%"
+          if (( $(echo "$observe_score < 80" | bc -l) )); then
+            echo "Observe <80%. Failing CI."
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,6 @@ jobs:
     timeout-minutes: 50
     env:
       HEADLESS: true
-
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -109,18 +108,15 @@ jobs:
     needs: [run-e2e-tests]
     runs-on: ubuntu-latest
     timeout-minutes: 50
-
     if: >
       github.event_name == 'push' ||
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
-
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
       BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
       HEADLESS: true
-
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -190,7 +186,6 @@ jobs:
             exit 1
           fi
 
-  # 2) Act depends on combination. If no label: exit 0 and pass.
   run-act-evals:
     needs: [run-combination-evals, determine-evals]
     runs-on: ubuntu-latest
@@ -203,7 +198,6 @@ jobs:
       BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
       HEADLESS: true
       EVAL_ENV: browserbase
-
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -217,11 +211,6 @@ jobs:
           else
             echo "has_label=true" >> $GITHUB_OUTPUT
           fi
-
-      - name: Log value of run-act
-        run: |
-          echo "run-act: ${{ needs.determine-evals.outputs.run-act }}"
-          echo "run-act: ${{ contains(github.event.pull_request.labels.*.name, 'act') }}"
 
       - name: Set up Node.js
         if: needs.determine-evals.outputs.run-act == 'true'
@@ -260,7 +249,6 @@ jobs:
             exit 1
           fi
 
-  # 3) Extract depends on act. If no label: exit 0 and pass.
   run-extract-evals:
     needs: [run-act-evals, determine-evals]
     runs-on: ubuntu-latest
@@ -273,50 +261,61 @@ jobs:
       BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
       HEADLESS: true
       EVAL_ENV: browserbase
-
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
 
       - name: Check for 'extract' label
+        id: label-check
         run: |
           if [ "${{ needs.determine-evals.outputs.run-extract }}" != "true" ]; then
+            echo "has_label=false" >> $GITHUB_OUTPUT
             echo "No label for EXTRACT. Exiting with success."
-            exit 0
+          else
+            echo "has_label=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Set up Node.js
+        if: needs.determine-evals.outputs.run-extract == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: "20"
 
       - name: Install dependencies
+        if: needs.determine-evals.outputs.run-extract == 'true'
         run: npm install --no-frozen-lockfile
 
-      - name: Build Stagehand
-        run: npm run build
-
       - name: Install Playwright browsers
+        if: needs.determine-evals.outputs.run-extract == 'true'
         run: npm exec playwright install --with-deps
+
+      - name: Build Stagehand
+        if: needs.determine-evals.outputs.run-extract == 'true'
+        run: npm run build
 
       # 1. Run extract category with domExtract
       - name: Dummy Extract Evals (domExtract)
+        if: needs.determine-evals.outputs.run-extract == 'true'
         run: |
           echo "Running dummy extract evals (domExtract)..."
           echo '{"experimentName":"dummyDomExtract","categories":{"extract":85}}' > eval-summary.json
       - name: Save Extract Dom Results
+        if: needs.determine-evals.outputs.run-extract == 'true'
         run: mv eval-summary.json eval-summary-extract-dom.json
 
       # 2. Then run extract category with textExtract
       - name: Dummy Extract Evals (textExtract)
+        if: needs.determine-evals.outputs.run-extract == 'true'
         run: |
           echo "Running dummy extract evals (textExtract)..."
           echo '{"experimentName":"dummyTextExtract","categories":{"extract":90}}' > eval-summary.json
       - name: Save Extract Text Results
+        if: needs.determine-evals.outputs.run-extract == 'true'
         run: mv eval-summary.json eval-summary-extract-text.json
 
       # 3. Log and Compare
       - name: Log and Compare Extract Evals Performance
+        if: needs.determine-evals.outputs.run-extract == 'true'
         run: |
           experimentNameDom=$(jq -r '.experimentName' eval-summary-extract-dom.json)
           dom_score=$(jq '.categories.extract' eval-summary-extract-dom.json)
@@ -334,7 +333,6 @@ jobs:
             exit 1
           fi
 
-  # 4) Text-extract depends on extract. If no label: exit 0 and pass.
   run-text-extract-evals:
     needs: [run-extract-evals, determine-evals]
     runs-on: ubuntu-latest
@@ -347,50 +345,61 @@ jobs:
       BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
       HEADLESS: true
       EVAL_ENV: browserbase
-
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
 
       - name: Check for 'text-extract' label
+        id: label-check
         run: |
           if [ "${{ needs.determine-evals.outputs.run-text-extract }}" != "true" ]; then
+            echo "has_label=false" >> $GITHUB_OUTPUT
             echo "No label for TEXT-EXTRACT. Exiting with success."
-            exit 0
+          else
+            echo "has_label=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Set up Node.js
+        if: needs.determine-evals.outputs.run-text-extract == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: "20"
 
       - name: Install dependencies
+        if: needs.determine-evals.outputs.run-text-extract == 'true'
         run: npm install --no-frozen-lockfile
 
       - name: Install Playwright browsers
+        if: needs.determine-evals.outputs.run-text-extract == 'true'
         run: npm exec playwright install --with-deps
 
       - name: Build Stagehand
+        if: needs.determine-evals.outputs.run-text-extract == 'true'
         run: npm run build
 
       # 1. text_extract with textExtract first
       - name: Dummy text_extract Evals (textExtract)
+        if: needs.determine-evals.outputs.run-text-extract == 'true'
         run: |
           echo "Running dummy text_extract (textExtract)..."
           echo '{"experimentName":"dummyTextExtract","categories":{"text_extract":90}}' > eval-summary.json
       - name: Save text_extract Text Results
+        if: needs.determine-evals.outputs.run-text-extract == 'true'
         run: mv eval-summary.json eval-summary-text_extract-text.json
 
       # 2. Then domExtract
       - name: Dummy text_extract Evals (domExtract)
+        if: needs.determine-evals.outputs.run-text-extract == 'true'
         run: |
           echo "Running dummy text_extract (domExtract)..."
           echo '{"experimentName":"dummyDomExtract","categories":{"text_extract":88}}' > eval-summary.json
       - name: Save text_extract Dom Results
+        if: needs.determine-evals.outputs.run-text-extract == 'true'
         run: mv eval-summary.json eval-summary-text_extract-dom.json
 
       # 3. Log and Compare
       - name: Log and Compare text_extract Evals Performance
+        if: needs.determine-evals.outputs.run-text-extract == 'true'
         run: |
           experimentNameText=$(jq -r '.experimentName' eval-summary-text_extract-text.json)
           text_score=$(jq '.categories.text_extract' eval-summary-text_extract-text.json)
@@ -408,7 +417,6 @@ jobs:
             exit 1
           fi
 
-  # 5) Observe depends on text-extract. If no label: exit 0 and pass.
   run-observe-evals:
     needs: [run-text-extract-evals, determine-evals]
     runs-on: ubuntu-latest
@@ -421,38 +429,46 @@ jobs:
       BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
       HEADLESS: true
       EVAL_ENV: browserbase
-
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
 
       - name: Check for 'observe' label
+        id: label-check
         run: |
           if [ "${{ needs.determine-evals.outputs.run-observe }}" != "true" ]; then
+            echo "has_label=false" >> $GITHUB_OUTPUT
             echo "No label for OBSERVE. Exiting with success."
-            exit 0
+          else
+            echo "has_label=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Set up Node.js
+        if: needs.determine-evals.outputs.run-observe == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: "20"
 
       - name: Install dependencies
+        if: needs.determine-evals.outputs.run-observe == 'true'
         run: npm install --no-frozen-lockfile
 
       - name: Install Playwright browsers
+        if: needs.determine-evals.outputs.run-observe == 'true'
         run: npm exec playwright install --with-deps
 
       - name: Build Stagehand
+        if: needs.determine-evals.outputs.run-observe == 'true'
         run: npm run build
 
       - name: Dummy Observe Evals
+        if: needs.determine-evals.outputs.run-observe == 'true'
         run: |
           echo "Running dummy observe evals..."
           echo '{"experimentName":"dummyObserve","categories":{"observe":85}}' > eval-summary.json
 
       - name: Log Observe Evals Performance
+        if: needs.determine-evals.outputs.run-observe == 'true'
         run: |
           experimentName=$(jq -r '.experimentName' eval-summary.json)
           echo "View results at https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
         run: npm run e2e:bb
 
   # --------------------------------------------------------------------
-  # Dummy eval steps from combination onward, skipping if label missing
+  # From here on: combination always runs; other evals skip sub-steps if no label
   # --------------------------------------------------------------------
   run-combination-evals:
     needs: [run-e2e-bb-tests, run-e2e-tests, determine-evals]
@@ -233,7 +233,6 @@ jobs:
             echo "has_label=true" >> $GITHUB_OUTPUT
           fi
 
-      # 1. Dummy "domExtract"
       - name: Dummy Extract Evals (domExtract)
         if: steps.label-check.outputs.has_label == 'true'
         run: |
@@ -244,7 +243,6 @@ jobs:
         if: steps.label-check.outputs.has_label == 'true'
         run: mv eval-summary.json eval-summary-extract-dom.json
 
-      # 2. Dummy "textExtract"
       - name: Dummy Extract Evals (textExtract)
         if: steps.label-check.outputs.has_label == 'true'
         run: |
@@ -255,7 +253,6 @@ jobs:
         if: steps.label-check.outputs.has_label == 'true'
         run: mv eval-summary.json eval-summary-extract-text.json
 
-      # 3. Log and Compare
       - name: Log and Compare Extract Evals Performance
         if: steps.label-check.outputs.has_label == 'true'
         run: |
@@ -296,7 +293,6 @@ jobs:
             echo "has_label=true" >> $GITHUB_OUTPUT
           fi
 
-      # 1. Dummy text_extract with textExtract
       - name: Dummy text_extract Evals (textExtract)
         if: steps.label-check.outputs.has_label == 'true'
         run: |
@@ -307,7 +303,6 @@ jobs:
         if: steps.label-check.outputs.has_label == 'true'
         run: mv eval-summary.json eval-summary-text_extract-text.json
 
-      # 2. Dummy text_extract with domExtract
       - name: Dummy text_extract Evals (domExtract)
         if: steps.label-check.outputs.has_label == 'true'
         run: |
@@ -318,7 +313,6 @@ jobs:
         if: steps.label-check.outputs.has_label == 'true'
         run: mv eval-summary.json eval-summary-text_extract-dom.json
 
-      # 3. Log and Compare text_extract Evals
       - name: Log and Compare text_extract Evals Performance
         if: steps.label-check.outputs.has_label == 'true'
         run: |
@@ -344,6 +338,7 @@ jobs:
     timeout-minutes: 25
     env:
       HEADLESS: true
+
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
         run: |
           # Default to running all tests on main branch
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
-            echo "Running all tests for main branch"
             echo "run-extract=true" >> $GITHUB_OUTPUT
             echo "run-act=true" >> $GITHUB_OUTPUT
             echo "run-observe=true" >> $GITHUB_OUTPUT
@@ -47,19 +46,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Dummy Lint
-        run: echo "Pretend lint succeeded"
+        run: echo "Pretend lint completed successfully"
 
   run-build:
     needs: [run-lint]
     runs-on: ubuntu-latest
     steps:
       - name: Dummy Build
-        run: echo "Pretend build succeeded"
+        run: echo "Pretend build completed successfully"
 
   run-e2e-tests:
     needs: [run-lint, run-build]
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    timeout-minutes: 5
     steps:
       - name: Dummy E2E Tests
         run: echo "Pretend E2E tests succeeded"
@@ -67,7 +66,7 @@ jobs:
   run-e2e-bb-tests:
     needs: [run-e2e-tests]
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    timeout-minutes: 5
     if: >
       github.event_name == 'push' ||
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
@@ -78,15 +77,15 @@ jobs:
   run-combination-evals:
     needs: [run-e2e-bb-tests, determine-evals]
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 5
     steps:
       - name: Dummy Combination Eval
         run: |
           echo "Pretending to run combination eval..."
-          # Create a dummy eval-summary.json with a passing score
+          # Create a dummy eval-summary.json with a PASSING combo score
           cat <<EOF > eval-summary.json
           {
-            "experimentName": "dummyCombExp",
+            "experimentName": "dummyCombinationTest",
             "categories": {
               "combination": 85
             }
@@ -95,22 +94,22 @@ jobs:
 
       - name: Log Combination Evals Performance
         run: |
-          experimentName=$(jq -r '.experimentName' eval-summary.json)
-          echo "View results at https://fake-url.com/experiments/${experimentName}"
-          if [ -f eval-summary.json ]; then
-            combination_score=$(jq '.categories.combination' eval-summary.json)
-            echo "Combination category score: $combination_score%"
-            exit 0
-          else
+          if [ ! -f eval-summary.json ]; then
             echo "Eval summary not found for combination category. Failing CI."
             exit 1
           fi
+
+          experimentName=$(jq -r '.experimentName' eval-summary.json)
+          combination_score=$(jq '.categories.combination' eval-summary.json)
+
+          echo "Combination category score: ${combination_score}%"
+          echo "View results at https://example.com/experiments/${experimentName}"
 
   run-act-evals:
     needs: [run-combination-evals]
     if: needs.determine-evals.outputs.run-act == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 5
     concurrency:
       group: labeled-evals-${{ github.run_id }}
       cancel-in-progress: false
@@ -118,7 +117,7 @@ jobs:
       - name: Dummy Act Evals
         run: |
           echo "Pretending to run ACT eval..."
-          # Create a passing score
+          # Create a passing ACT score
           cat <<EOF > eval-summary.json
           {
             "experimentName": "dummyActExp",
@@ -130,17 +129,15 @@ jobs:
 
       - name: Log Act Evals Performance
         run: |
-          experimentName=$(jq -r '.experimentName' eval-summary.json)
-          echo "View results at https://fake-url.com/experiments/${experimentName}"
-          if [ -f eval-summary.json ]; then
-            act_score=$(jq '.categories.act' eval-summary.json)
-            echo "Act category score: $act_score%"
-            if (( $(echo "$act_score < 80" | bc -l) )); then
-              echo "Act category score is below 80%. Failing CI."
-              exit 1
-            fi
-          else
+          if [ ! -f eval-summary.json ]; then
             echo "Eval summary not found for act category. Failing CI."
+            exit 1
+          fi
+          experimentName=$(jq -r '.experimentName' eval-summary.json)
+          act_score=$(jq '.categories.act' eval-summary.json)
+          echo "Act category score: $act_score%"
+          if (( $(echo "$act_score < 80" | bc -l) )); then
+            echo "Act category score <80%. Failing CI."
             exit 1
           fi
 
@@ -148,14 +145,14 @@ jobs:
     needs: [run-combination-evals]
     if: needs.determine-evals.outputs.run-extract == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    timeout-minutes: 5
     concurrency:
       group: labeled-evals-${{ github.run_id }}
       cancel-in-progress: false
     steps:
-      - name: Step 1 - Dummy Extract Evals (domExtract)
+      - name: Step 1 - Dummy Extract (domExtract)
         run: |
-          echo "Pretending to run extract with domExtract..."
+          echo "Pretending to run domExtract..."
           cat <<EOF > eval-summary.json
           {
             "experimentName": "dummyExtractDomExp",
@@ -164,14 +161,13 @@ jobs:
             }
           }
           EOF
-        shell: bash
 
       - name: Save Extract Dom Results
         run: mv eval-summary.json eval-summary-extract-dom.json
 
-      - name: Step 2 - Dummy Extract Evals (textExtract)
+      - name: Step 2 - Dummy Extract (textExtract)
         run: |
-          echo "Pretending to run extract with textExtract..."
+          echo "Pretending to run textExtract..."
           cat <<EOF > eval-summary.json
           {
             "experimentName": "dummyExtractTextExp",
@@ -180,26 +176,18 @@ jobs:
             }
           }
           EOF
-        shell: bash
 
       - name: Save Extract Text Results
         run: mv eval-summary.json eval-summary-extract-text.json
 
-      - name: Step 3 - Log and Compare Extract Evals Performance
+      - name: Step 3 - Compare Extract Evals
         run: |
-          experimentNameDom=$(jq -r '.experimentName' eval-summary-extract-dom.json)
           dom_score=$(jq '.categories.extract' eval-summary-extract-dom.json)
-          echo "DomExtract Extract category score: $dom_score%"
-          echo "View domExtract results: https://fake-url.com/experiments/${experimentNameDom}"
-
-          experimentNameText=$(jq -r '.experimentName' eval-summary-extract-text.json)
           text_score=$(jq '.categories.extract' eval-summary-extract-text.json)
-          echo "TextExtract Extract category score: $text_score%"
-          echo "View textExtract results: https://fake-url.com/experiments/${experimentNameText}"
-
-          # If domExtract <80% fail CI
+          echo "DomExtract score: $dom_score%"
+          echo "TextExtract score: $text_score%"
           if (( $(echo "$dom_score < 80" | bc -l) )); then
-            echo "DomExtract extract category score is below 80%. Failing CI."
+            echo "DomExtract <80%. Failing CI."
             exit 1
           fi
 
@@ -207,12 +195,12 @@ jobs:
     needs: [run-combination-evals]
     if: needs.determine-evals.outputs.run-text-extract == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 5
     concurrency:
       group: labeled-evals-${{ github.run_id }}
       cancel-in-progress: false
     steps:
-      - name: Step 1 - Dummy text_extract Evals (textExtract)
+      - name: Step 1 - Dummy text_extract (textExtract)
         run: |
           echo "Pretending to run text_extract with textExtract..."
           cat <<EOF > eval-summary.json
@@ -227,14 +215,14 @@ jobs:
       - name: Save text_extract Text Results
         run: mv eval-summary.json eval-summary-text_extract-text.json
 
-      - name: Step 2 - Dummy text_extract Evals (domExtract)
+      - name: Step 2 - Dummy text_extract (domExtract)
         run: |
           echo "Pretending to run text_extract with domExtract..."
           cat <<EOF > eval-summary.json
           {
             "experimentName": "dummyTextExtractDomExp",
             "categories": {
-              "text_extract": 92
+              "text_extract": 93
             }
           }
           EOF
@@ -242,21 +230,14 @@ jobs:
       - name: Save text_extract Dom Results
         run: mv eval-summary.json eval-summary-text_extract-dom.json
 
-      - name: Step 3 - Log and Compare text_extract Evals Performance
+      - name: Step 3 - Compare text_extract Evals
         run: |
-          experimentNameText=$(jq -r '.experimentName' eval-summary-text_extract-text.json)
           text_score=$(jq '.categories.text_extract' eval-summary-text_extract-text.json)
-          echo "TextExtract text_extract category score: $text_score%"
-          echo "View textExtract results: https://fake-url.com/experiments/${experimentNameText}"
-
-          experimentNameDom=$(jq -r '.experimentName' eval-summary-text_extract-dom.json)
           dom_score=$(jq '.categories.text_extract' eval-summary-text_extract-dom.json)
-          echo "DomExtract text_extract category score: $dom_score%"
-          echo "View domExtract results: https://fake-url.com/experiments/${experimentNameDom}"
-
-          # If textExtract <80% fail CI
+          echo "TextExtract text_extract score: $text_score%"
+          echo "DomExtract text_extract score: $dom_score%"
           if (( $(echo "$text_score < 80" | bc -l) )); then
-            echo "textExtract text_extract category score is below 80%. Failing CI."
+            echo "textExtract text_extract <80%. Failing CI."
             exit 1
           fi
 
@@ -264,7 +245,7 @@ jobs:
     needs: [run-combination-evals]
     if: needs.determine-evals.outputs.run-observe == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 5
     concurrency:
       group: labeled-evals-${{ github.run_id }}
       cancel-in-progress: false
@@ -272,32 +253,27 @@ jobs:
       - name: Dummy Observe Evals
         run: |
           echo "Pretending to run OBSERVE eval..."
-          # This time let's produce a failing score to test the logic:
-          # (uncomment to see it fail!)
-          #score=75
-          score=82
-
+          # You can simulate a failing score (e.g. 75) or passing (85)
+          observe_score=85
           cat <<EOF > eval-summary.json
           {
             "experimentName": "dummyObserveExp",
             "categories": {
-              "observe": $score
+              "observe": $observe_score
             }
           }
           EOF
 
       - name: Log Observe Evals Performance
         run: |
-          experimentName=$(jq -r '.experimentName' eval-summary.json)
-          echo "View results at https://fake-url.com/experiments/${experimentName}"
-          if [ -f eval-summary.json ]; then
-            observe_score=$(jq '.categories.observe' eval-summary.json)
-            echo "Observe category score: $observe_score%"
-            if (( $(echo "$observe_score < 80" | bc -l) )); then
-              echo "Observe category score is below 80%. Failing CI."
-              exit 1
-            fi
-          else
+          if [ ! -f eval-summary.json ]; then
             echo "Eval summary not found for observe category. Failing CI."
+            exit 1
+          fi
+          experimentName=$(jq -r '.experimentName' eval-summary.json)
+          observe_score=$(jq '.categories.observe' eval-summary.json)
+          echo "Observe category score: $observe_score%"
+          if (( $(echo "$observe_score < 80" | bc -l) )); then
+            echo "Observe category score <80%. Failing CI."
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
 
   # 2) Act depends on combination. If no label: exit 0 and pass.
   run-act-evals:
-    needs: [run-combination-evals]
+    needs: [run-combination-evals, determine-evals]
     runs-on: ubuntu-latest
     timeout-minutes: 25
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
       - opened
       - synchronize
       - labeled
+      - unlabeled
 
 env:
   EVAL_MODELS: "gpt-4o,gpt-4o-mini,claude-3-5-sonnet-latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,11 @@ jobs:
             echo "has_label=true" >> $GITHUB_OUTPUT
           fi
 
+      - name: Log value of run-act
+        run: |
+          # log the value of run-act
+            echo "run-act: ${{ needs.determine-evals.outputs.run-act }}"
+
       - name: Set up Node.js
         if: needs.determine-evals.outputs.run-act == 'true'
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     concurrency:
-      group: labeled-evals-${{ github.run_id }}
+      group: labeled-evals-${{ github.job_id }}
       cancel-in-progress: false
     steps:
       - name: Dummy Act Evals
@@ -147,7 +147,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     concurrency:
-      group: labeled-evals-${{ github.run_id }}
+      group: labeled-evals-${{ github.job_id }}
       cancel-in-progress: false
     steps:
       - name: Step 1 - Dummy Extract (domExtract)
@@ -197,7 +197,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     concurrency:
-      group: labeled-evals-${{ github.run_id }}
+      group: labeled-evals-${{ github.job_id }}
       cancel-in-progress: false
     steps:
       - name: Step 1 - Dummy text_extract (textExtract)
@@ -247,7 +247,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     concurrency:
-      group: labeled-evals-${{ github.run_id }}
+      group: labeled-evals-${{ github.job_id }}
       cancel-in-progress: false
     steps:
       - name: Dummy Observe Evals

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,7 @@ jobs:
           else
             echo "Eval summary not found for combination category. Failing CI."
             exit 1
+          fi
 
   #
   # Specialized evals (dummy data) - run sequentially by concurrency group
@@ -440,6 +441,7 @@ jobs:
           else
             echo "Eval summary not found. Failing CI."
             exit 1
+          fi
 
   run-observe-evals:
     needs: [determine-evals, run-combination-evals]
@@ -503,3 +505,4 @@ jobs:
           else
             echo "Eval summary not found. Failing CI."
             exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,28 +137,43 @@ jobs:
       - name: Run E2E Tests (browserbase)
         run: npm run e2e:bb
 
-  # --------------------------------------------------------------------
-  # From here on: combination always runs; other evals skip sub-steps if no label
-  # --------------------------------------------------------------------
   run-combination-evals:
     needs: [run-e2e-bb-tests, run-e2e-tests, determine-evals]
     runs-on: ubuntu-latest
     timeout-minutes: 40
     env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
+      BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
+      BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
       HEADLESS: true
+      EVAL_ENV: browserbase
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
 
-      - name: Dummy Combination Evals
-        run: |
-          echo "Running dummy combination evals..."
-          echo '{"experimentName":"dummyCombination","categories":{"combination":95}}' > eval-summary.json
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm install --no-frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: npm exec playwright install --with-deps
+
+      - name: Build Stagehand
+        run: npm run build
+
+      - name: Run Combination Evals
+        run: npm run evals category combination
 
       - name: Log Combination Evals Performance
         run: |
           experimentName=$(jq -r '.experimentName' eval-summary.json)
-          echo "View results at https://www.example.com/experiments/${experimentName}"
+          echo "View results at https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName}"
           if [ -f eval-summary.json ]; then
             combination_score=$(jq '.categories.combination' eval-summary.json)
             echo "Combination category score: $combination_score%"
@@ -168,38 +183,52 @@ jobs:
             exit 1
           fi
 
+  # 2) Act depends on combination. If no label: exit 0 and pass.
   run-act-evals:
     needs: [run-combination-evals]
     runs-on: ubuntu-latest
     timeout-minutes: 25
     env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
+      BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
+      BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
       HEADLESS: true
+      EVAL_ENV: browserbase
 
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
 
       - name: Check for 'act' label
-        id: label-check
         run: |
           if [ "${{ needs.determine-evals.outputs.run-act }}" != "true" ]; then
-            echo "No label selected for \"act\", continuing without running \"act\"."
-            echo "has_label=false" >> $GITHUB_OUTPUT
-          else
-            echo "has_label=true" >> $GITHUB_OUTPUT
+            echo "No label for ACT. Exiting with success."
+            exit 0
           fi
 
-      - name: Dummy Act Evals
-        if: steps.label-check.outputs.has_label == 'true'
-        run: |
-          echo "Running dummy act evals..."
-          echo '{"experimentName":"dummyAct","categories":{"act":82}}' > eval-summary.json
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm install --no-frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: npm exec playwright install --with-deps
+
+      - name: Build Stagehand
+        run: npm run build
+
+      - name: Run Act Evals
+        run: npm run evals category act
 
       - name: Log Act Evals Performance
-        if: steps.label-check.outputs.has_label == 'true'
         run: |
           experimentName=$(jq -r '.experimentName' eval-summary.json)
-          echo "View results at https://www.example.com/experiments/${experimentName}"
+          echo "View results at https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName}"
           if [ -f eval-summary.json ]; then
             act_score=$(jq '.categories.act' eval-summary.json)
             echo "Act category score: $act_score%"
@@ -212,59 +241,69 @@ jobs:
             exit 1
           fi
 
+  # 3) Extract depends on act. If no label: exit 0 and pass.
   run-extract-evals:
     needs: [run-act-evals]
     runs-on: ubuntu-latest
     timeout-minutes: 50
     env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
+      BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
+      BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
       HEADLESS: true
+      EVAL_ENV: browserbase
 
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
 
       - name: Check for 'extract' label
-        id: label-check
         run: |
           if [ "${{ needs.determine-evals.outputs.run-extract }}" != "true" ]; then
-            echo "No label selected for \"extract\", continuing without running \"extract\"."
-            echo "has_label=false" >> $GITHUB_OUTPUT
-          else
-            echo "has_label=true" >> $GITHUB_OUTPUT
+            echo "No label for EXTRACT. Exiting with success."
+            exit 0
           fi
 
-      - name: Dummy Extract Evals (domExtract)
-        if: steps.label-check.outputs.has_label == 'true'
-        run: |
-          echo "Running dummy extract evals (domExtract)..."
-          echo '{"experimentName":"dummyDomExtract","categories":{"extract":85}}' > eval-summary.json
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
 
+      - name: Install dependencies
+        run: npm install --no-frozen-lockfile
+
+      - name: Build Stagehand
+        run: npm run build
+
+      - name: Install Playwright browsers
+        run: npm exec playwright install --with-deps
+
+      # 1. Run extract category with domExtract
+      - name: Run Extract Evals (domExtract)
+        run: npm run evals category extract -- --extract-method=domExtract
       - name: Save Extract Dom Results
-        if: steps.label-check.outputs.has_label == 'true'
         run: mv eval-summary.json eval-summary-extract-dom.json
 
-      - name: Dummy Extract Evals (textExtract)
-        if: steps.label-check.outputs.has_label == 'true'
-        run: |
-          echo "Running dummy extract evals (textExtract)..."
-          echo '{"experimentName":"dummyTextExtract","categories":{"extract":90}}' > eval-summary.json
-
+      # 2. Then run extract category with textExtract
+      - name: Run Extract Evals (textExtract)
+        run: npm run evals category extract -- --extract-method=textExtract
       - name: Save Extract Text Results
-        if: steps.label-check.outputs.has_label == 'true'
         run: mv eval-summary.json eval-summary-extract-text.json
 
+      # 3. Log and Compare
       - name: Log and Compare Extract Evals Performance
-        if: steps.label-check.outputs.has_label == 'true'
         run: |
           experimentNameDom=$(jq -r '.experimentName' eval-summary-extract-dom.json)
           dom_score=$(jq '.categories.extract' eval-summary-extract-dom.json)
           echo "DomExtract Extract category score: $dom_score%"
-          echo "View domExtract results: https://www.example.com/experiments/${experimentNameDom}"
+          echo "View domExtract results: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameDom}"
 
           experimentNameText=$(jq -r '.experimentName' eval-summary-extract-text.json)
           text_score=$(jq '.categories.extract' eval-summary-extract-text.json)
           echo "TextExtract Extract category score: $text_score%"
-          echo "View textExtract results: https://www.example.com/experiments/${experimentNameText}"
+          echo "View textExtract results: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameText}"
 
           # If domExtract <80% fail CI
           if (( $(echo "$dom_score < 80" | bc -l) )); then
@@ -272,59 +311,69 @@ jobs:
             exit 1
           fi
 
+  # 4) Text-extract depends on extract. If no label: exit 0 and pass.
   run-text-extract-evals:
     needs: [run-extract-evals]
     runs-on: ubuntu-latest
     timeout-minutes: 120
     env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
+      BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
+      BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
       HEADLESS: true
+      EVAL_ENV: browserbase
 
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
 
       - name: Check for 'text-extract' label
-        id: label-check
         run: |
           if [ "${{ needs.determine-evals.outputs.run-text-extract }}" != "true" ]; then
-            echo "No label selected for \"text-extract\", continuing without running \"text-extract\"."
-            echo "has_label=false" >> $GITHUB_OUTPUT
-          else
-            echo "has_label=true" >> $GITHUB_OUTPUT
+            echo "No label for TEXT-EXTRACT. Exiting with success."
+            exit 0
           fi
 
-      - name: Dummy text_extract Evals (textExtract)
-        if: steps.label-check.outputs.has_label == 'true'
-        run: |
-          echo "Running dummy text_extract (textExtract)..."
-          echo '{"experimentName":"dummyTextExtract","categories":{"text_extract":90}}' > eval-summary.json
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
 
+      - name: Install dependencies
+        run: npm install --no-frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: npm exec playwright install --with-deps
+
+      - name: Build Stagehand
+        run: npm run build
+
+      # 1. text_extract with textExtract first
+      - name: Run text_extract Evals (textExtract)
+        run: npm run evals category text_extract -- --extract-method=textExtract
       - name: Save text_extract Text Results
-        if: steps.label-check.outputs.has_label == 'true'
         run: mv eval-summary.json eval-summary-text_extract-text.json
 
-      - name: Dummy text_extract Evals (domExtract)
-        if: steps.label-check.outputs.has_label == 'true'
-        run: |
-          echo "Running dummy text_extract (domExtract)..."
-          echo '{"experimentName":"dummyDomExtract","categories":{"text_extract":88}}' > eval-summary.json
-
+      # 2. Then domExtract
+      - name: Run text_extract Evals (domExtract)
+        run: npm run evals category text_extract -- --extract-method=domExtract
       - name: Save text_extract Dom Results
-        if: steps.label-check.outputs.has_label == 'true'
         run: mv eval-summary.json eval-summary-text_extract-dom.json
 
+      # 3. Log and Compare
       - name: Log and Compare text_extract Evals Performance
-        if: steps.label-check.outputs.has_label == 'true'
         run: |
           experimentNameText=$(jq -r '.experimentName' eval-summary-text_extract-text.json)
           text_score=$(jq '.categories.text_extract' eval-summary-text_extract-text.json)
           echo "TextExtract text_extract category score: $text_score%"
-          echo "View textExtract results: https://www.example.com/experiments/${experimentNameText}"
+          echo "View textExtract results: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameText}"
 
           experimentNameDom=$(jq -r '.experimentName' eval-summary-text_extract-dom.json)
           dom_score=$(jq '.categories.text_extract' eval-summary-text_extract-dom.json)
           echo "DomExtract text_extract category score: $dom_score%"
-          echo "View domExtract results: https://www.example.com/experiments/${experimentNameDom}"
+          echo "View domExtract results: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameDom}"
 
           # If text_score <80% fail CI
           if (( $(echo "$text_score < 80" | bc -l) )); then
@@ -332,38 +381,52 @@ jobs:
             exit 1
           fi
 
+  # 5) Observe depends on text-extract. If no label: exit 0 and pass.
   run-observe-evals:
     needs: [run-text-extract-evals]
     runs-on: ubuntu-latest
     timeout-minutes: 25
     env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
+      BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
+      BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
       HEADLESS: true
+      EVAL_ENV: browserbase
 
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
 
       - name: Check for 'observe' label
-        id: label-check
         run: |
           if [ "${{ needs.determine-evals.outputs.run-observe }}" != "true" ]; then
-            echo "No label selected for \"observe\", continuing without running \"observe\"."
-            echo "has_label=false" >> $GITHUB_OUTPUT
-          else
-            echo "has_label=true" >> $GITHUB_OUTPUT
+            echo "No label for OBSERVE. Exiting with success."
+            exit 0
           fi
 
-      - name: Dummy Observe Evals
-        if: steps.label-check.outputs.has_label == 'true'
-        run: |
-          echo "Running dummy observe evals..."
-          echo '{"experimentName":"dummyObserve","categories":{"observe":85}}' > eval-summary.json
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm install --no-frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: npm exec playwright install --with-deps
+
+      - name: Build Stagehand
+        run: npm run build
+
+      - name: Run Observe Evals
+        run: npm run evals category observe
 
       - name: Log Observe Evals Performance
-        if: steps.label-check.outputs.has_label == 'true'
         run: |
           experimentName=$(jq -r '.experimentName' eval-summary.json)
-          echo "View results at https://www.example.com/experiments/${experimentName}"
+          echo "View results at https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName}"
           if [ -f eval-summary.json ]; then
             observe_score=$(jq '.categories.observe' eval-summary.json)
             echo "Observe category score: $observe_score%"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ jobs:
     steps:
       - id: check-labels
         run: |
-          # Default to running all tests on main branch
+          # Default to running all specialized tests on main branch
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
-            echo "Running all tests for main branch"
+            echo "Running all specialized categories for main branch"
             echo "run-extract=true" >> $GITHUB_OUTPUT
             echo "run-act=true" >> $GITHUB_OUTPUT
             echo "run-observe=true" >> $GITHUB_OUTPUT
@@ -36,7 +36,7 @@ jobs:
             exit 0
           fi
 
-          # Check for specific labels
+          # Otherwise, check for specific labels
           echo "run-extract=${{ contains(github.event.pull_request.labels.*.name, 'extract') }}" >> $GITHUB_OUTPUT
           echo "run-act=${{ contains(github.event.pull_request.labels.*.name, 'act') }}" >> $GITHUB_OUTPUT
           echo "run-observe=${{ contains(github.event.pull_request.labels.*.name, 'observe') }}" >> $GITHUB_OUTPUT
@@ -61,6 +61,7 @@ jobs:
 
   run-build:
     runs-on: ubuntu-latest
+    needs: [run-lint]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
@@ -108,7 +109,6 @@ jobs:
     needs: [run-e2e-tests]
     runs-on: ubuntu-latest
     timeout-minutes: 50
-
     if: >
       github.event_name == 'push' ||
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
@@ -186,16 +186,155 @@ jobs:
           else
             echo "Eval summary not found for combination category. Failing CI."
             exit 1
+
+  run-extract-evals:
+    needs: [determine-evals, run-combination-evals]
+    if: needs.determine-evals.outputs.run-extract == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+    concurrency:
+      group: specialized-evals-${{ github.run_id }}
+      cancel-in-progress: false
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
+      BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
+      BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
+      HEADLESS: true
+      EVAL_ENV: browserbase
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm install --no-frozen-lockfile
+
+      - name: Build Stagehand
+        run: npm run build
+
+      - name: Install Playwright browsers
+        run: npm exec playwright install --with-deps
+
+      # 1. Run extract category with domExtract
+      - name: Run Extract Evals (domExtract)
+        run: npm run evals category extract -- --extract-method=domExtract
+      - name: Save Extract Dom Results
+        run: mv eval-summary.json eval-summary-extract-dom.json
+
+      # 2. Then run extract category with textExtract
+      - name: Run Extract Evals (textExtract)
+        run: npm run evals category extract -- --extract-method=textExtract
+      - name: Save Extract Text Results
+        run: mv eval-summary.json eval-summary-extract-text.json
+
+      # 3. Log and Compare
+      - name: Log and Compare Extract Evals Performance
+        run: |
+          if [ -f eval-summary-extract-dom.json ]; then
+            experimentNameDom=$(jq -r '.experimentName' eval-summary-extract-dom.json)
+            dom_score=$(jq '.categories.extract' eval-summary-extract-dom.json)
+            echo "DomExtract Score: $dom_score%"
+            echo "See: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameDom}"
+
+            # Fail if below threshold
+            if (( $(echo "$dom_score < 80" | bc -l) )); then
+              echo "DomExtract extract category <80%. Failing CI."
+              exit 1
+            fi
+          fi
+
+          if [ -f eval-summary-extract-text.json ]; then
+            experimentNameText=$(jq -r '.experimentName' eval-summary-extract-text.json)
+            text_score=$(jq '.categories.extract' eval-summary-extract-text.json)
+            echo "TextExtract Score: $text_score%"
+            echo "See: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameText}"
+          fi
+
+  run-text-extract-evals:
+    needs: [determine-evals, run-combination-evals]
+    if: needs.determine-evals.outputs.run-text-extract == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    concurrency:
+      group: specialized-evals-${{ github.run_id }}
+      cancel-in-progress: false
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
+      BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
+      BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
+      HEADLESS: true
+      EVAL_ENV: browserbase
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: npm install --no-frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: npm exec playwright install --with-deps
+
+      - name: Build Stagehand
+        run: npm run build
+
+      # 1. text_extract with textExtract
+      - name: Run text_extract Evals (textExtract)
+        run: npm run evals category text_extract -- --extract-method=textExtract
+      - name: Save text_extract Text Results
+        run: mv eval-summary.json eval-summary-text_extract-text.json
+
+      # 2. text_extract with domExtract
+      - name: Run text_extract Evals (domExtract)
+        run: npm run evals category text_extract -- --extract-method=domExtract
+      - name: Save text_extract Dom Results
+        run: mv eval-summary.json eval-summary-text_extract-dom.json
+
+      # 3. Log and Compare
+      - name: Log and Compare text_extract
+        run: |
+          if [ -f eval-summary-text_extract-text.json ]; then
+            experimentNameTxt=$(jq -r '.experimentName' eval-summary-text_extract-text.json)
+            txt_score=$(jq '.categories.text_extract' eval-summary-text_extract-text.json)
+            echo "TextExtract (text_extract) Score: $txt_score%"
+            echo "See: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameTxt}"
+
+            # Optionally fail if <80%
+            if (( $(echo "$txt_score < 80" | bc -l) )); then
+              echo "text_extract score <80%. Failing CI."
+              exit 1
+            fi
+          fi
+
+          if [ -f eval-summary-text_extract-dom.json ]; then
+            experimentNameDom=$(jq -r '.experimentName' eval-summary-text_extract-dom.json)
+            dom_score=$(jq '.categories.text_extract' eval-summary-text_extract-dom.json)
+            echo "DomExtract (text_extract) Score: $dom_score%"
+            echo "See: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameDom}"
           fi
 
   run-act-evals:
-    needs: [run-e2e-tests, determine-evals, run-combination-evals]
+    needs: [determine-evals, run-combination-evals]
     if: needs.determine-evals.outputs.run-act == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     concurrency:
-      group: evals-${{ github.run_id }}
-      cancel-in-progress: true
+      group: specialized-evals-${{ github.run_id }}
+      cancel-in-progress: false
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -229,157 +368,26 @@ jobs:
       - name: Log Act Evals Performance
         run: |
           experimentName=$(jq -r '.experimentName' eval-summary.json)
-          echo "View results at https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName}"
+          echo "See: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName}"
           if [ -f eval-summary.json ]; then
             act_score=$(jq '.categories.act' eval-summary.json)
             echo "Act category score: $act_score%"
             if (( $(echo "$act_score < 80" | bc -l) )); then
-              echo "Act category score is below 80%. Failing CI."
+              echo "Act <80%. Failing CI."
               exit 1
             fi
           else
-            echo "Eval summary not found for act category. Failing CI."
+            echo "Eval summary not found. Failing CI."
             exit 1
-          fi
-
-  run-extract-evals:
-    needs: [run-e2e-tests, determine-evals, run-combination-evals]
-    if: needs.determine-evals.outputs.run-extract == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 50
-    concurrency:
-      group: evals-${{ github.run_id }}
-      cancel-in-progress: true
-    env:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
-      BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
-      BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
-      HEADLESS: true
-      EVAL_ENV: browserbase
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install dependencies
-        run: npm install --no-frozen-lockfile
-
-      - name: Build Stagehand
-        run: npm run build
-
-      - name: Install Playwright browsers
-        run: npm exec playwright install --with-deps
-
-      # 1. Run extract category with domExtract
-      - name: Run Extract Evals (domExtract)
-        run: npm run evals category extract -- --extract-method=domExtract
-      - name: Save Extract Dom Results
-        run: mv eval-summary.json eval-summary-extract-dom.json
-
-      # 2. Once domExtract finishes, run extract category with textExtract
-      - name: Run Extract Evals (textExtract)
-        run: npm run evals category extract -- --extract-method=textExtract
-      - name: Save Extract Text Results
-        run: mv eval-summary.json eval-summary-extract-text.json
-
-      # 3. Log and Compare Extract Evals Performance
-      - name: Log and Compare Extract Evals Performance
-        run: |
-          experimentNameDom=$(jq -r '.experimentName' eval-summary-extract-dom.json)
-          dom_score=$(jq '.categories.extract' eval-summary-extract-dom.json)
-          echo "DomExtract Extract category score: $dom_score%"
-          echo "View domExtract results: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameDom}"
-
-          experimentNameText=$(jq -r '.experimentName' eval-summary-extract-text.json)
-          text_score=$(jq '.categories.extract' eval-summary-extract-text.json)
-          echo "TextExtract Extract category score: $text_score%"
-          echo "View textExtract results: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameText}"
-
-          # 4. If domExtract <80% fail CI
-          if (( $(echo "$dom_score < 80" | bc -l) )); then
-            echo "DomExtract extract category score is below 80%. Failing CI."
-            exit 1
-          fi
-
-  run-text-extract-evals:
-    needs: [run-e2e-tests, determine-evals, run-combination-evals]
-    if: needs.determine-evals.outputs.run-text-extract == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-    concurrency:
-      group: evals-${{ github.run_id }}
-      cancel-in-progress: true
-    env:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
-      BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
-      BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
-      HEADLESS: true
-      EVAL_ENV: browserbase
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Install dependencies
-        run: npm install --no-frozen-lockfile
-
-      - name: Install Playwright browsers
-        run: npm exec playwright install --with-deps
-
-      - name: Build Stagehand
-        run: npm run build
-
-      # 1. Run text_extract category with textExtract first
-      - name: Run text_extract Evals (textExtract)
-        run: npm run evals category text_extract -- --extract-method=textExtract
-      - name: Save text_extract Text Results
-        run: mv eval-summary.json eval-summary-text_extract-text.json
-
-      # 2. Then run text_extract category with domExtract
-      - name: Run text_extract Evals (domExtract)
-        run: npm run evals category text_extract -- --extract-method=domExtract
-      - name: Save text_extract Dom Results
-        run: mv eval-summary.json eval-summary-text_extract-dom.json
-
-      # 3. Log and Compare text_extract Evals Performance
-      - name: Log and Compare text_extract Evals Performance
-        run: |
-          experimentNameText=$(jq -r '.experimentName' eval-summary-text_extract-text.json)
-          text_score=$(jq '.categories.text_extract' eval-summary-text_extract-text.json)
-          echo "TextExtract text_extract category score: $text_score%"
-          echo "View textExtract results: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameText}"
-
-          experimentNameDom=$(jq -r '.experimentName' eval-summary-text_extract-dom.json)
-          dom_score=$(jq '.categories.text_extract' eval-summary-text_extract-dom.json)
-          echo "DomExtract text_extract category score: $dom_score%"
-          echo "View domExtract results: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameDom}"
-
-          # 4. If textExtract (for text_extract category) <80% fail CI
-          if (( $(echo "$text_score < 80" | bc -l) )); then
-            echo "textExtract text_extract category score is below 80%. Failing CI."
-            exit 1
-          fi
 
   run-observe-evals:
-    needs: [run-e2e-tests, determine-evals, run-combination-evals]
+    needs: [determine-evals, run-combination-evals]
     if: needs.determine-evals.outputs.run-observe == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     concurrency:
-      group: evals-${{ github.run_id }}
-      cancel-in-progress: true
+      group: specialized-evals-${{ github.run_id }}
+      cancel-in-progress: false
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -413,15 +421,14 @@ jobs:
       - name: Log Observe Evals Performance
         run: |
           experimentName=$(jq -r '.experimentName' eval-summary.json)
-          echo "View results at https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName}"
+          echo "See: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentName}"
           if [ -f eval-summary.json ]; then
             observe_score=$(jq '.categories.observe' eval-summary.json)
             echo "Observe category score: $observe_score%"
             if (( $(echo "$observe_score < 80" | bc -l) )); then
-              echo "Observe category score is below 80%. Failing CI."
+              echo "Observe <80%. Failing CI."
               exit 1
             fi
           else
-            echo "Eval summary not found for observe category. Failing CI."
+            echo "Eval summary not found. Failing CI."
             exit 1
-          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,11 @@ jobs:
           echo "run-observe=${{ contains(github.event.pull_request.labels.*.name, 'observe') }}" >> $GITHUB_OUTPUT
           echo "run-text-extract=${{ contains(github.event.pull_request.labels.*.name, 'text-extract') }}" >> $GITHUB_OUTPUT
 
+          echo "Extract label: ${{ contains(github.event.pull_request.labels.*.name, 'extract') }}"
+          echo "Act label: ${{ contains(github.event.pull_request.labels.*.name, 'act') }}"
+          echo "Observe label: ${{ contains(github.event.pull_request.labels.*.name, 'observe') }}"
+          echo "Text-Extract label: ${{ contains(github.event.pull_request.labels.*.name, 'text-extract') }}"
+
   run-lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# why
- Migrate from concurrency back to sequential evals to avoid overloading BB
# what changed
- we will now run evals in CI sequentially based on the labels that the developer chooses.
# note
- for eval sets that are **NOT** included in the labels chosen by the developer, the job will still _appear_ to have "run", but it wont actually run
- in other words, there will be a green check mark, but we will immediately `exit code 0` from that job
