### PR TITLE
simplify stagehand method calls

### DIFF
--- a/.changeset/hungry-scissors-mix.md
+++ b/.changeset/hungry-scissors-mix.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": minor
+---
+
+Simplify Stagehand method calls by allowing a simple string input instead of an options object.

--- a/evals/evals.config.json
+++ b/evals/evals.config.json
@@ -1,6 +1,10 @@
 {
   "tasks": [
     {
+      "name": "extract_repo_name",
+      "categories": ["extract"]
+    },
+    {
       "name": "amazon_add_to_cart",
       "categories": ["act"]
     },

--- a/evals/tasks/arxiv.ts
+++ b/evals/tasks/arxiv.ts
@@ -17,9 +17,9 @@ export const arxiv: EvalFunction = async ({
   try {
     await stagehand.page.goto("https://arxiv.org/search/");
 
-    await stagehand.page.act({
-      action: "search for papers about web agents with multimodal models",
-    });
+    await stagehand.page.act(
+      "search for papers about web agents with multimodal models",
+    );
 
     const paper_links = await stagehand.page.extract({
       instruction: "extract the titles and links for two papers",

--- a/evals/tasks/expedia.ts
+++ b/evals/tasks/expedia.ts
@@ -11,14 +11,13 @@ export const expedia: EvalFunction = async ({ modelName, logger }) => {
 
   try {
     await stagehand.page.goto("https://www.expedia.com/flights");
-    await stagehand.page.act({
-      action:
-        "find round-trip flights from San Francisco (SFO) to Toronto (YYZ) for Jan 1, 2025 (up to one to two weeks)",
-    });
-    await stagehand.page.act({ action: "Go to the first non-stop flight" });
-    await stagehand.page.act({ action: "select the cheapest flight" });
-    await stagehand.page.act({ action: "click on the first non-stop flight" });
-    await stagehand.page.act({ action: "Take me to the checkout page" });
+    await stagehand.page.act(
+      "find round-trip flights from San Francisco (SFO) to Toronto (YYZ) for Jan 1, 2025 (up to one to two weeks)",
+    );
+    await stagehand.page.act("Go to the first non-stop flight");
+    await stagehand.page.act("select the cheapest flight");
+    await stagehand.page.act("click on the first non-stop flight");
+    await stagehand.page.act("Take me to the checkout page");
 
     const url = stagehand.page.url();
     return {

--- a/evals/tasks/extract_repo_name.ts
+++ b/evals/tasks/extract_repo_name.ts
@@ -1,0 +1,55 @@
+import { EvalFunction } from "../../types/evals";
+import { initStagehand } from "../initStagehand";
+
+export const extract_github_commits: EvalFunction = async ({
+  modelName,
+  logger,
+}) => {
+  const { stagehand, initResponse } = await initStagehand({
+    modelName,
+    logger,
+  });
+
+  const { debugUrl, sessionUrl } = initResponse;
+
+  try {
+    await stagehand.page.goto("https://github.com/facebook/react");
+
+    const { extraction } = await stagehand.page.extract(
+      "extract the repo name",
+    );
+
+    logger.log({
+      message: "Extracted repo name",
+      level: 1,
+      auxiliary: {
+        repo_name: {
+          value: extraction,
+          type: "object",
+        },
+      },
+    });
+
+    await stagehand.close();
+
+    return {
+      _success: extraction === "react",
+      extraction,
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
+  } catch (error) {
+    console.error("Error or timeout occurred:", error);
+
+    await stagehand.close();
+
+    return {
+      _success: false,
+      error: JSON.parse(JSON.stringify(error, null, 2)),
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
+  }
+};

--- a/evals/tasks/google_jobs.ts
+++ b/evals/tasks/google_jobs.ts
@@ -16,12 +16,12 @@ export const google_jobs: EvalFunction = async ({
 
   try {
     await stagehand.page.goto("https://www.google.com/");
-    await stagehand.page.act({ action: "click on the about page" });
-    await stagehand.page.act({ action: "click on the careers page" });
-    await stagehand.page.act({ action: "input data scientist into role" });
-    await stagehand.page.act({ action: "input new york city into location" });
-    await stagehand.page.act({ action: "click on the search button" });
-    await stagehand.page.act({ action: "click on the first job link" });
+    await stagehand.page.act("click on the about page");
+    await stagehand.page.act("click on the careers page");
+    await stagehand.page.act("input data scientist into role");
+    await stagehand.page.act("input new york city into location");
+    await stagehand.page.act("click on the search button");
+    await stagehand.page.act("click on the first job link");
 
     const jobDetails = await stagehand.page.extract({
       instruction:

--- a/evals/tasks/homedepot.ts
+++ b/evals/tasks/homedepot.ts
@@ -17,10 +17,10 @@ export const homedepot: EvalFunction = async ({
 
   try {
     await stagehand.page.goto("https://www.homedepot.com/");
-    await stagehand.page.act({ action: "search for gas grills" });
-    await stagehand.page.act({ action: "click on the best selling gas grill" });
-    await stagehand.page.act({ action: "click on the Product Details" });
-    await stagehand.page.act({ action: "find the Primary Burner BTU" });
+    await stagehand.page.act("search for gas grills");
+    await stagehand.page.act("click on the best selling gas grill");
+    await stagehand.page.act("click on the Product Details");
+    await stagehand.page.act("find the Primary Burner BTU");
 
     const productSpecs = await stagehand.page.extract({
       instruction: "Extract the Primary exact Burner BTU of the product",

--- a/evals/tasks/wikipedia.ts
+++ b/evals/tasks/wikipedia.ts
@@ -10,9 +10,7 @@ export const wikipedia: EvalFunction = async ({ modelName, logger }) => {
   const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(`https://en.wikipedia.org/wiki/Baseball`);
-  await stagehand.page.act({
-    action: 'click the "hit and run" link in this article',
-  });
+  await stagehand.page.act('click the "hit and run" link in this article');
 
   const url = "https://en.wikipedia.org/wiki/Hit_and_run_(baseball)";
   const currentUrl = stagehand.page.url();

--- a/examples/example.ts
+++ b/examples/example.ts
@@ -11,6 +11,24 @@ import StagehandConfig from "./stagehand.config";
 async function example() {
   const stagehand = new Stagehand(StagehandConfig);
   await stagehand.init();
+
+  const page = stagehand.page;
+  await page.goto("https://www.google.com");
+
+  const actResult = await page.act(
+    "type 'hello' into the search bar and press enter",
+  );
+  console.log(actResult);
+
+  const { extraction } = await page.extract("extract the first result's title");
+  console.log(extraction);
+
+  const observeResult = await page.observe(
+    "observe the possible actions on this page",
+  );
+  console.log(observeResult);
+
+  await stagehand.close();
 }
 
 (async () => {

--- a/examples/example.ts
+++ b/examples/example.ts
@@ -11,24 +11,6 @@ import StagehandConfig from "./stagehand.config";
 async function example() {
   const stagehand = new Stagehand(StagehandConfig);
   await stagehand.init();
-
-  const page = stagehand.page;
-  await page.goto("https://www.google.com");
-
-  const actResult = await page.act(
-    "type 'hello' into the search bar and press enter",
-  );
-  console.log(actResult);
-
-  const { extraction } = await page.extract("extract the first result's title");
-  console.log(extraction);
-
-  const observeResult = await page.observe(
-    "observe the possible actions on this page",
-  );
-  console.log(observeResult);
-
-  await stagehand.close();
 }
 
 (async () => {

--- a/types/page.ts
+++ b/types/page.ts
@@ -3,7 +3,7 @@ import type {
   BrowserContext as PlaywrightContext,
   Page as PlaywrightPage,
 } from "@playwright/test";
-import type { z } from "zod";
+import { z } from "zod";
 import type {
   ActOptions,
   ActResult,
@@ -13,12 +13,23 @@ import type {
   ObserveResult,
 } from "./stagehand";
 
+export const defaultExtractSchema = z.object({
+  extraction: z.string(),
+});
+
 export interface Page extends Omit<PlaywrightPage, "on"> {
-  act: (options: ActOptions) => Promise<ActResult>;
-  extract: <T extends z.AnyZodObject>(
+  act(action: string): Promise<ActResult>;
+  act(options: ActOptions): Promise<ActResult>;
+
+  extract(
+    instruction: string,
+  ): Promise<ExtractResult<typeof defaultExtractSchema>>;
+  extract<T extends z.AnyZodObject>(
     options: ExtractOptions<T>,
-  ) => Promise<ExtractResult<T>>;
-  observe: (options?: ObserveOptions) => Promise<ObserveResult[]>;
+  ): Promise<ExtractResult<T>>;
+
+  observe(instruction: string): Promise<ObserveResult[]>;
+  observe(options?: ObserveOptions): Promise<ObserveResult[]>;
 
   on: {
     (event: "popup", listener: (page: Page) => unknown): Page;

--- a/types/page.ts
+++ b/types/page.ts
@@ -28,6 +28,7 @@ export interface Page extends Omit<PlaywrightPage, "on"> {
     options: ExtractOptions<T>,
   ): Promise<ExtractResult<T>>;
 
+  observe(): Promise<ObserveResult[]>;
   observe(instruction: string): Promise<ObserveResult[]>;
   observe(options?: ObserveOptions): Promise<ObserveResult[]>;
 


### PR DESCRIPTION
# why
Often times it's unnecessary to pass in Stagehand method options as an object, we want to simplify inputs to just a string. This allows syntax such as the following:
```ts
await page.act("search for browserbase");

// the default schema is:
// z.object({
//  extraction: z.string(),
// });
const { extraction } = await page.extract("the first result's title");

await page.observe("return the possible next steps from this page");
```

# what changed
Added new input types in the Stagehand page interface (`types/page`) and updated input handling in the `StagehandPage`class to parse the inputs accordingly.

# test plan
Run evals to ensure existing functionality has not been altered and add new evals that test the new syntax works as expected.