### PR TITLE
Patch for type builds

### DIFF
--- a/.changeset/poor-numbers-bake.md
+++ b/.changeset/poor-numbers-bake.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Fixing a build type error for async functions being called inside evaulate for observeHandler.

--- a/lib/handlers/observeHandler.ts
+++ b/lib/handlers/observeHandler.ts
@@ -89,9 +89,8 @@ export class StagehandObserveHandler {
     await this.stagehandPage.startDomDebug();
     await this.stagehandPage.enableCDP("DOM");
 
-    const evalResult = await this.stagehand.page.evaluate(async () => {
-      const result = await window.processAllOfDom();
-      return result;
+    const evalResult = await this.stagehand.page.evaluate(() => {
+      return window.processAllOfDom().then((result) => result);
     });
 
     // For each element in the selector map, get its backendNodeId


### PR DESCRIPTION
# why

Solving a compile error on observe when calling await inside evaluate() functions

# what changed

`const evalResult = await this.stagehand.page.evaluate(async () => {
      const result = await window.processAllOfDom();
      return result;
    });`

is now

`const evalResult = await this.stagehand.page.evaluate(() => {
      return window.processAllOfDom().then((result) => result);
    });`

# test plan

- [x] run on observe evals locally
- [ ] run on ci observe evals
