### PR TITLE
more eval maintenance

### DIFF
--- a/evals/tasks/extract_repo_name.ts
+++ b/evals/tasks/extract_repo_name.ts
@@ -16,11 +16,11 @@ export const extract_repo_name: EvalFunction = async ({
     await stagehand.page.goto("https://github.com/facebook/react");
 
     const { extraction } = await stagehand.page.extract(
-      "extract the repo name",
+      "extract the title of the Github repository. Do not include the owner of the repository.",
     );
 
     logger.log({
-      message: "Extracted repo name",
+      message: "Extracted repo title",
       level: 1,
       auxiliary: {
         repo_name: {

--- a/evals/tasks/extract_staff_members.ts
+++ b/evals/tasks/extract_staff_members.ts
@@ -15,7 +15,7 @@ export const extract_staff_members: EvalFunction = async ({
 
   const { debugUrl, sessionUrl } = initResponse;
 
-  await stagehand.page.goto("https://panamcs.org/about/staff/");
+  await stagehand.page.goto("https://panamcs-static-site.surge.sh/");
 
   const result = await stagehand.page.extract({
     instruction:
@@ -35,7 +35,7 @@ export const extract_staff_members: EvalFunction = async ({
   const staff_members = result.staff_members;
   await stagehand.close();
 
-  const expectedLength = 47;
+  const expectedLength = 49;
 
   const expectedFirstItem = {
     name: "Louis Alvarez",


### PR DESCRIPTION
# why
- target website for `extract_staff_members` changed
- weak prompting in `extract_repo_name`
# what changed
- moved `extract_staff_members` to a cloned site deployed with surge.sh and updated expected value
- improved prompting on `extract_repo_name`

