### PR TITLE
fix release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,11 @@ jobs:
           node-version: 20.x
           registry-url: "https://registry.npmjs.org"
 
-      - name: Install Dependencies
-        run: npm install
+      - name: Install dependencies
+        run: |
+          rm -rf node_modules
+          rm -f package-lock.json
+          npm install
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
# why
Runnign into this error after removing sharp due to old node modules/package lock
![CleanShot 2025-01-26 at 18 46 14@2x](https://github.com/user-attachments/assets/412a99b9-9661-47c0-a351-97c7cc63e4e6)

# what changed
start fresh with node modules/package lock

# test plan
have to merge to main and see if it works