### PR TITLE
add build instruction to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ git clone https://github.com/browserbase/stagehand.git
 cd stagehand
 npm install
 npx playwright install
+npm run build
 npm run example # run the blank script at ./examples/example.ts
 ```
 


### PR DESCRIPTION
Users can't run examples directly since the TS has to be compiled into `dist/`. The TS has to first be built with `npm run build`