### PR TITLE
ignore all dist directories

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,7 +6,7 @@ import tseslint from "typescript-eslint";
 export default [
   { files: ["**/*.{js,mjs,cjs,ts}"] },
   { languageOptions: { globals: globals.browser } },
-  { ignores: ["dist/**", "lib/dom/build/**"] },
+  { ignores: ["**/dist/**", "lib/dom/build/**"] },
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
 ];


### PR DESCRIPTION
# why
- need to ignore all `dist` directories when linting so that `npm run build` doesn't fail on the linting step
# what changed
- ignore all `dist` directories in `eslint.config.mjs`

