### PR TITLE
forcing deprecation of useAccessibilityTree on observe

### DIFF
--- a/.changeset/rude-moles-yawn.md
+++ b/.changeset/rude-moles-yawn.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Adding back useAccessibilityTree param to observe with a deprecation warning/error indicating to use onlyVisible instead

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -478,7 +478,23 @@ export class StagehandPage {
       domSettleTimeoutMs,
       returnAction = false,
       onlyVisible = false,
+      useAccessibilityTree,
     } = options;
+
+    if (useAccessibilityTree !== undefined) {
+      this.stagehand.log({
+        category: "deprecation",
+        message:
+          "useAccessibilityTree is deprecated.\n" +
+          "  To use accessibility tree as context:\n" +
+          "    1. Set onlyVisible to false (default)\n" +
+          "    2. Don't declare useAccessibilityTree",
+        level: 1,
+      });
+      throw new Error(
+        "useAccessibilityTree is deprecated. Use onlyVisible instead.",
+      );
+    }
 
     if (typeof useVision !== "undefined") {
       this.stagehand.log({

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -91,13 +91,14 @@ export interface ObserveOptions {
   domSettleTimeoutMs?: number;
   returnAction?: boolean;
   onlyVisible?: boolean;
+  /** @deprecated `useAccessibilityTree` is now deprecated. Use `onlyVisible` instead. */
+  useAccessibilityTree?: boolean;
 }
 
 export interface ObserveResult {
   selector: string;
   description: string;
   backendNodeId?: number;
-  //TODO: review name
   method?: string;
   arguments?: string[];
 }


### PR DESCRIPTION
# why
new naming for passing a11y as context. Still want to inform the user when they had the previous version

# what changed
throwing an error on useAccessibilityTree declarations suggesting to use onlyVisible

# test plan
