### PR TITLE
Improve reliability of radio button clicks

### DIFF
--- a/.changeset/rich-pans-lay.md
+++ b/.changeset/rich-pans-lay.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+improve handling of radio button clicks

--- a/lib/handlers/actHandler.ts
+++ b/lib/handlers/actHandler.ts
@@ -413,13 +413,6 @@ export class StagehandActHandler {
             },
           },
         });
-        // try {
-        //   // Force-click here
-        //   await locator.click({ force: true });
-        // } catch (e) {
-        //   // handle/log exception
-        //   throw new PlaywrightCommandException(e.message);
-        // }
 
         // NAVIDNOTE: Should this happen before we wait for locator[method]?
         const newOpenedTab = await Promise.race([
@@ -548,47 +541,6 @@ export class StagehandActHandler {
       });
 
       const outerHtml = clone.outerHTML;
-
-      //   const variables = {
-      //     // Replace with your actual variables and their values
-      //     // Example:
-      //     username: "JohnDoe",
-      //     email: "john@example.com",
-      //   };
-
-      //   // Function to replace variable values with variable names
-      //   const replaceVariables = (element: Element) => {
-      //     if (element instanceof HTMLElement) {
-      //       for (const [key, value] of Object.entries(variables)) {
-      //         if (value) {
-      //           element.innerText = element.innerText.replace(
-      //             new RegExp(value, "g"),
-      //             key,
-      //           );
-      //         }
-      //       }
-      //     }
-
-      //     if (
-      //       element instanceof HTMLInputElement ||
-      //       element instanceof HTMLTextAreaElement
-      //     ) {
-      //       for (const [key, value] of Object.entries(variables)) {
-      //         if (value) {
-      //           element.value = element.value.replace(
-      //             new RegExp(value, "g"),
-      //             key,
-      //           );
-      //         }
-      //       }
-      //     }
-      //   };
-
-      //   // Replace variables in the cloned element
-      //   replaceVariables(clone);
-
-      //   // Replace variables in all child elements
-      //   clone.querySelectorAll("*").forEach(replaceVariables);
       return outerHtml.trim().replace(/\s+/g, " ");
     });
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@browserbasehq/stagehand",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@browserbasehq/stagehand",
-      "version": "1.10.1",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.27.3",


### PR DESCRIPTION
# why
- clicking a radio button with playwright can be finnicky
- often, it is best to just click the `label` which corresponds to the radio button instead of trying to click the radio button itself
# what changed
- this PR introduces a step in `_performPlaywrightMethod` where we directly check if the target element is a radio button.
- if true, it will run through a series of checks to try and find the corresponding `label` for the radio button
- if a `label` is found, then the `label` is clicked instead of the radio button itself
