### PR TITLE
Allow observe to find scrollable elements

### DIFF
--- a/.changeset/ninety-humans-fold.md
+++ b/.changeset/ninety-humans-fold.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+allow observe to find scrollable elements

--- a/lib/dom/global.d.ts
+++ b/lib/dom/global.d.ts
@@ -36,5 +36,7 @@ declare global {
       width: number;
       height: number;
     }>;
+    getScrollableElements: (topN?: number) => HTMLElement[];
+    generateXPathsForElement: (element: ChildNode) => Promise<string[]>;
   }
 }

--- a/lib/dom/process.ts
+++ b/lib/dom/process.ts
@@ -11,18 +11,24 @@ export function isTextNode(node: Node): node is Text {
   return node.nodeType === Node.TEXT_NODE && Boolean(node.textContent?.trim());
 }
 
-function getMainScrollableElement(): HTMLElement {
+/**
+ * Finds and returns a list of scrollable elements on the page,
+ * ordered from the element with the largest scrollHeight to the smallest.
+ *
+ * @param topN Optional maximum number of scrollable elements to return.
+ *             If not provided, all found scrollable elements are returned.
+ * @returns An array of HTMLElements sorted by descending scrollHeight.
+ */
+export function getScrollableElements(topN?: number): HTMLElement[] {
+  // Get the root <html> element
   const docEl = document.documentElement;
-  let mainScrollable: HTMLElement = docEl;
 
-  // 1) Compute how “scrollable” the root <html> is
-  //    i.e. total scrollHeight - visible clientHeight
-  const rootScrollDiff = docEl.scrollHeight - docEl.clientHeight;
+  // 1) Initialize an array to hold all scrollable elements.
+  //    Always include the root <html> element as a fallback.
+  const scrollableElements: HTMLElement[] = [docEl];
 
-  // Keep track of the “largest” scroll diff found so far.
-  let maxScrollDiff = rootScrollDiff;
-
-  // 2) Scan all elements to find if any <div> has a larger scrollable diff
+  // 2) Scan all elements to find potential scrollable containers.
+  //    A candidate must have a scrollable overflow style and extra scrollable content.
   const allElements = document.querySelectorAll<HTMLElement>("*");
   for (const elem of allElements) {
     const style = window.getComputedStyle(elem);
@@ -33,25 +39,24 @@ function getMainScrollableElement(): HTMLElement {
 
     if (isPotentiallyScrollable) {
       const candidateScrollDiff = elem.scrollHeight - elem.clientHeight;
-      // Only pick this <div> if it has strictly more vertical “scrollable distance” than our current best
-      if (candidateScrollDiff > maxScrollDiff) {
-        maxScrollDiff = candidateScrollDiff;
-        mainScrollable = elem;
+      // Only consider this element if it actually has extra scrollable content
+      // and it can truly scroll.
+      if (candidateScrollDiff > 0 && canElementScroll(elem)) {
+        scrollableElements.push(elem);
       }
     }
   }
 
-  // 3) Verify the chosen element truly scrolls
-  if (mainScrollable !== docEl) {
-    if (!canElementScroll(mainScrollable)) {
-      console.log(
-        "Stagehand (Browser Process): Unable to scroll candidate. Fallback to <html>.",
-      );
-      mainScrollable = docEl;
-    }
+  // 3) Sort the scrollable elements from largest scrollHeight to smallest.
+  scrollableElements.sort((a, b) => b.scrollHeight - a.scrollHeight);
+
+  // 4) If a topN limit is specified, return only the first topN elements.
+  if (topN !== undefined) {
+    return scrollableElements.slice(0, topN);
   }
 
-  return mainScrollable;
+  // Return all found scrollable elements if no limit is provided.
+  return scrollableElements;
 }
 
 export async function processDom(chunksSeen: Array<number>) {
@@ -80,7 +85,8 @@ export async function processDom(chunksSeen: Array<number>) {
 export async function processAllOfDom() {
   console.log("Stagehand (Browser Process): Processing all of DOM");
 
-  const mainScrollable = getMainScrollableElement();
+  const mainScrollableElements = getScrollableElements(1);
+  const mainScrollable = mainScrollableElements[0];
 
   const container =
     mainScrollable === document.documentElement
@@ -481,7 +487,8 @@ window.restoreDOM = restoreDOM;
 window.createTextBoundingBoxes = createTextBoundingBoxes;
 window.getElementBoundingBoxes = getElementBoundingBoxes;
 window.createStagehandContainer = createStagehandContainer;
-
+window.getScrollableElements = getScrollableElements;
+window.generateXPathsForElement = generateXPaths;
 const leafElementDenyList = ["SVG", "IFRAME", "SCRIPT", "STYLE", "LINK"];
 
 const interactiveElementTypes = [

--- a/lib/inference.ts
+++ b/lib/inference.ts
@@ -266,6 +266,7 @@ export async function extract({
 export async function observe({
   instruction,
   domElements,
+  scrollableElemNodes,
   llmClient,
   requestId,
   isUsingAccessibilityTree,
@@ -275,6 +276,7 @@ export async function observe({
 }: {
   instruction: string;
   domElements: string;
+  scrollableElemNodes?: string;
   llmClient: LLMClient;
   requestId: string;
   userProvidedInstructions?: string;
@@ -332,6 +334,7 @@ export async function observe({
           buildObserveUserMessage(
             instruction,
             domElements,
+            scrollableElemNodes,
             isUsingAccessibilityTree,
           ),
         ],

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -379,11 +379,17 @@ Return an array of elements that match the instruction if they exist, otherwise 
 export function buildObserveUserMessage(
   instruction: string,
   domElements: string,
+  scrollableElemNodes: string,
   isUsingAccessibilityTree = false,
 ): ChatMessage {
+  const scrollableSection =
+    isUsingAccessibilityTree && scrollableElemNodes.trim().length
+      ? `Here are some scrollable elements:\n${scrollableElemNodes}\n\n`
+      : "";
+
   return {
     role: "user",
-    content: `instruction: ${instruction}
-${isUsingAccessibilityTree ? "Accessibility Tree" : "DOM"}: ${domElements}`,
+    content: `instruction: ${instruction}\n
+${scrollableSection}${isUsingAccessibilityTree ? "Accessibility Tree" : "DOM"}:\n${domElements}`,
   };
 }

--- a/types/context.ts
+++ b/types/context.ts
@@ -16,10 +16,11 @@ export type AccessibilityNode = {
   children?: AccessibilityNode[];
   childIds?: string[];
   parentId?: string;
-  nodeId?: string;
+  nodeId: string;
 };
 
 export interface TreeResult {
   tree: AccessibilityNode[];
   simplified: string;
+  backendNodeMap: Map<string, AccessibilityNode>;
 }


### PR DESCRIPTION
# why
- large scrollable elements are what we use to chunk through during extraction
- we want to allow observe to output these container elements so that they can be passed as the root element/container in an `extract` call. Note that the handling of an `observe` output has not yet been implemented on the `extract` side
# what changed
- in the call that `observe` makes to the LLM, we put scrollable elements at the top of the user prompt so that the LLM can see & understand them easier
# example LLM input
### this is what we were doing before:

<img width="1110" alt="Screenshot 2025-02-02 at 1 53 43 PM" src="https://github.com/user-attachments/assets/b81a4482-0fe0-4ace-b562-5f7e3439714a" />

### this is what this PR introduces:
<img width="954" alt="Screenshot 2025-02-02 at 1 52 53 PM" src="https://github.com/user-attachments/assets/4d6e3c39-7ea1-4e46-a139-1d7192f9d4a3" />

