### PR TITLE
Eval server setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Use Node.js LTS (Long Term Support) image as base
+FROM --platform=linux/amd64 node:20-slim
+
+# Set working directory in container
+WORKDIR /app
+
+# Copy package.json and package-lock.json (if exists)
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the rest of the application code
+COPY . .
+
+RUN npm run build-dom-scripts
+RUN npm run build-js
+RUN npm run build-types
+
+# Expose the port your server will run on (adjust if needed)
+EXPOSE 3000
+
+# Start the server
+CMD npx tsx evals/eval_api_server.ts

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY package.json ./
 
 # Install dependencies while explicitly avoiding platform-specific builds
 RUN npm install --no-optional --legacy-peer-deps --omit=optional
-RUN npm install @rollup/rollup-linux-arm64-gnu
+RUN npm install @rollup/rollup-linux-x64-gnu
 
 # Copy the rest of the application code
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
 # Use Node.js LTS (Long Term Support) image as base
-FROM --platform=linux/amd64 node:20-slim
+FROM node:20-slim
 
 # Set working directory in container
 WORKDIR /app
 
 # Copy package.json and package-lock.json (if exists)
-COPY package*.json ./
+COPY package.json ./
 
-# Install dependencies
-RUN npm install
+# Install dependencies while explicitly avoiding platform-specific builds
+RUN npm install --no-optional --legacy-peer-deps --omit=optional
+RUN npm install @rollup/rollup-linux-arm64-gnu
 
 # Copy the rest of the application code
 COPY . .

--- a/evals/eval_api_server.ts
+++ b/evals/eval_api_server.ts
@@ -1,0 +1,183 @@
+import express from "express";
+import { z } from "zod";
+import { initStagehand } from "./initStagehand";
+import { EvalLogger } from "./logger";
+import jsonSchemaToZod from "json-schema-to-zod";
+import { AvailableModelSchema } from "@/lib";
+
+// Define request body schema
+const RequestSchema = z.object({
+  command: z.string().describe("The instruction or command to execute"),
+  start_url: z.string().url().describe("Starting URL to navigate to"),
+  cdp_url: z.string().url().describe("Chrome DevTools Protocol URL"),
+  output_schema: z
+    .record(z.any())
+    .nullable()
+    .describe("The schema to output in the format of a Draft7 JSON Schema"),
+  mode: z.enum(["actions", "output"]).describe("The mode to run in"),
+  model_name:
+    AvailableModelSchema.default("gpt-4o").describe("The model to use"),
+});
+
+const app = express();
+
+app.use(express.json());
+
+/**
+ * Initialize a new Stagehand instance with default configuration. Necessary so stagehand scripts are injected before page is setup
+ * @route POST /init
+ * @param {string} _req.body.cdp_url - Chrome DevTools Protocol URL to connect to
+ * @throws {Error} Returns 500 status code if initialization fails
+ */
+app.post("/init", async (_req, res) => {
+  try {
+    await initStagehand({
+      modelName: "gpt-4o-mini",
+      logger: new EvalLogger(),
+      configOverrides: {
+        env: "REMOTE",
+        cdpUrl: _req.body.cdp_url,
+        debugDom: false,
+      },
+    });
+
+    res.json({
+      status: "ok",
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.error(error.stack);
+    res.status(500).json({
+      status: "error",
+      message: error.message,
+    });
+  }
+});
+
+/**
+ * Run a Stagehand test with the given command and parameters
+ * @route POST /test
+ * @param {string} _req.body.command - The instruction or command to execute
+ * @param {string} _req.body.cdp_url - Chrome DevTools Protocol URL
+ * @param {string} _req.body.output_schema - The schema to output in the format of a Draft7 JSON Schema
+ * @param {string} _req.body.mode - The mode to run in
+ * @param {string} _req.body.model_name - The model to use
+ * @returns {Stream} Server-sent event stream with status updates and final output
+ */
+
+app.post("/test", async (_req, res) => {
+  try {
+    res.setHeader("Content-Type", "text/event-stream");
+    res.setHeader("Cache-Control", "no-cache");
+    res.setHeader("Connection", "keep-alive");
+
+    try {
+      // Validate request body
+      const {
+        command,
+        cdp_url: cdpUrl,
+        output_schema: outputSchema,
+        mode,
+        model_name: modelName,
+      } = RequestSchema.parse(_req.body);
+
+      const logger = new EvalLogger();
+      const { stagehand } = await initStagehand({
+        modelName: "gpt-4o-mini",
+        logger,
+        configOverrides: {
+          env: "REMOTE",
+          cdpUrl,
+          debugDom: false,
+        },
+      });
+
+      res.write('data: {"message": "Injecting processDom function"}\n\n');
+
+      res.write('data: {"message": "Executing command"}\n\n');
+      let output;
+      if (mode === "actions") {
+        output = await stagehand.page.act({
+          action: command,
+        });
+      } else {
+        // turn the schema into a zod schema string. Ideally could pass in a JSON schema directly but doing this for now
+        const zodSchema = eval(
+          jsonSchemaToZod(outputSchema, { module: "cjs" }),
+        );
+        output = await stagehand.page.extract({
+          instruction: command,
+          schema: zodSchema,
+          modelName: modelName,
+          useTextExtract: true,
+        });
+      }
+
+      const data = {
+        type: "answer",
+        message: output,
+      };
+
+      res.write(`data: ${JSON.stringify(data)}\n\n`);
+
+      res.end();
+    } catch (error) {
+      // print error and stack trace
+      console.error(error.stack);
+      res.write(
+        'data: {"message": "Error", "error": ' +
+          JSON.stringify({ message: error.message }) +
+          "}\n\n",
+      );
+      res.end();
+    }
+  } catch (err) {
+    console.error(err.stack);
+    res.write(
+      'data: {"message": "Error", "error": ' +
+        JSON.stringify({ message: err.message }) +
+        "}\n\n",
+    );
+    res.end();
+  }
+});
+
+app.get("/version", (req, res) => {
+  res.json({
+    version: "v0.1",
+  });
+});
+
+app.get("/health", (req, res) => {
+  res.json({
+    status: "ok",
+    timestamp: new Date().toISOString(),
+  });
+});
+
+// Global error handling middleware
+app.use((err: Error, req: express.Request, res: express.Response) => {
+  console.error("Global error handler caught:", err);
+  console.error(err.stack);
+
+  // Don't send error details in production
+  res.status(500).json({
+    status: "error",
+    message: "An internal server error occurred",
+  });
+});
+
+// Catch unhandled rejections and exceptions
+process.on("unhandledRejection", (reason: unknown) => {
+  console.error("Unhandled Rejection:", reason);
+});
+
+process.on("uncaughtException", (error: Error) => {
+  console.error("Uncaught Exception:", error);
+  // Gracefully shutdown if needed
+  // process.exit(1);
+});
+
+app.listen(3000, () => {
+  console.log("Server is running on port 3000");
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "eslint": "^9.16.0",
         "express": "^4.21.0",
         "globals": "^15.13.0",
+        "json-schema-to-zod": "^2.6.0",
         "multer": "^1.4.5-lts.1",
         "prettier": "^3.2.5",
         "string-comparison": "^1.3.0",
@@ -4895,6 +4896,16 @@
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true,
       "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/json-schema-to-zod": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/json-schema-to-zod/-/json-schema-to-zod-2.6.0.tgz",
+      "integrity": "sha512-6sFZqOzHZeON8g2ZW5HJ114Hb/FffNCjWh8dgulJaKFkUqKCEWZAzF4+g07SQpfBZF7HXemwedtdLypZzmnVpQ==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "json-schema-to-zod": "dist/cjs/cli.js"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "eslint": "^9.16.0",
     "express": "^4.21.0",
     "globals": "^15.13.0",
+    "json-schema-to-zod": "^2.6.0",
     "multer": "^1.4.5-lts.1",
     "prettier": "^3.2.5",
     "string-comparison": "^1.3.0",

--- a/types/browser.ts
+++ b/types/browser.ts
@@ -1,7 +1,7 @@
 import { Browser, BrowserContext } from "./page";
 
 export interface BrowserResult {
-  env: "LOCAL" | "BROWSERBASE";
+  env: "LOCAL" | "BROWSERBASE" | "REMOTE";
   browser?: Browser;
   context: BrowserContext;
   debugUrl?: string;

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -7,7 +7,7 @@ import { AvailableModel, ClientOptions } from "./model";
 import { LLMClient } from "../lib/llm/LLMClient";
 
 export interface ConstructorParams {
-  env: "LOCAL" | "BROWSERBASE";
+  env: "LOCAL" | "BROWSERBASE" | "REMOTE";
   apiKey?: string;
   projectId?: string;
   verbose?: 0 | 1 | 2;
@@ -26,6 +26,7 @@ export interface ConstructorParams {
    * Instructions for stagehand.
    */
   systemPrompt?: string;
+  cdpUrl?: string;
 }
 
 export interface InitOptions {


### PR DESCRIPTION
## What was added
- Express server with `/test` endoint
- Add option to pass in cdp_url

## Why this is necessary
- Express server needed as an interface to run evals on
- cdp_url needed to run tests on our simulated browser environments