### PR TITLE
A11y empty xpath fix

### DIFF
--- a/.changeset/gentle-pans-mix.md
+++ b/.changeset/gentle-pans-mix.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Updated getAccessibilityTree() to make sure it doesn't skip useful nodes. Improved getXPathByResolvedObjectId() to account for text nodes and not skip generation


### PR DESCRIPTION
# why

Some useful roles were being cleaned on a11y. Xpath generation from backend node id was failing for text nodes.

# what changed

Updated `getAccessibilityTree()` to make sure it doesn't skip useful nodes. Improved `getXPathByResolvedObjectId()` to account for text nodes and not skip generation

# test plan
