### PR TITLE
Hybrid of a11y tree & DOM for input to observe

### DIFF
--- a/.changeset/chilled-apes-sneeze.md
+++ b/.changeset/chilled-apes-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+create a11y + dom hybrid input for observe

--- a/lib/a11y/utils.ts
+++ b/lib/a11y/utils.ts
@@ -13,7 +13,9 @@ export function formatSimplifiedTree(
   level = 0,
 ): string {
   const indent = "  ".repeat(level);
-  let result = `${indent}[${node.nodeId}] ${node.role}${node.name ? `: ${node.name}` : ""}\n`;
+  let result = `${indent}[${node.nodeId}] [${node.backendDOMNodeId}] ${node.role}${
+    node.name ? `: ${node.name}` : ""
+  }\n`;
 
   if (node.children?.length) {
     result += node.children
@@ -24,10 +26,9 @@ export function formatSimplifiedTree(
 }
 
 /**
- * Helper function to remove or collapse unnecessary structural nodes
- * Handles three cases:
+ * Helper function to remove or collapse unnecessary structural nodes:
  * 1. Removes generic/none nodes with no children
- * 2. Collapses generic/none nodes with single child
+ * 2. Collapses generic/none nodes with a single child
  * 3. Keeps generic/none nodes with multiple children but cleans their subtrees
  */
 function cleanStructuralNodes(
@@ -35,6 +36,7 @@ function cleanStructuralNodes(
 ): AccessibilityNode | null {
   // Base case: leaf node
   if (!node.children) {
+    // Remove if role is generic/none
     return node.role === "generic" || node.role === "none" ? null : node;
   }
 
@@ -46,17 +48,17 @@ function cleanStructuralNodes(
   // Handle generic/none nodes specially
   if (node.role === "generic" || node.role === "none") {
     if (cleanedChildren.length === 1) {
-      // Collapse single-child generic nodes
+      // Collapse single-child generic/none nodes
       return cleanedChildren[0];
     } else if (cleanedChildren.length > 1) {
-      // Keep generic nodes with multiple children
+      // Keep generic/none nodes with multiple children
       return { ...node, children: cleanedChildren };
     }
-    // Remove generic nodes with no children
+    // Remove generic/none node with no children
     return null;
   }
 
-  // For non-generic nodes, keep them if they have children after cleaning
+  // For non-generic nodes, keep them if they still have children
   return cleanedChildren.length > 0
     ? { ...node, children: cleanedChildren }
     : node;
@@ -65,22 +67,25 @@ function cleanStructuralNodes(
 /**
  * Builds a hierarchical tree structure from a flat array of accessibility nodes.
  * The function processes nodes in multiple passes to create a clean, meaningful tree.
- * @param nodes - Flat array of accessibility nodes from the CDP
- * @returns Object containing both the tree structure and a simplified string representation
  */
 export function buildHierarchicalTree(nodes: AccessibilityNode[]): TreeResult {
   // Map to store processed nodes for quick lookup
   const nodeMap = new Map<string, AccessibilityNode>();
 
-  // First pass: Create nodes that are meaningful
-  // We only keep nodes that either have a name or children to avoid cluttering the tree
+  // --- First pass: Create nodes that are meaningful (and skip negative IDs) ---
   nodes.forEach((node) => {
+    // Skip node if its ID is negative (e.g., "-1000002014")
+    const nodeIdValue = parseInt(node.nodeId, 10);
+    if (nodeIdValue < 0) {
+      return;
+    }
+
     const hasChildren = node.childIds && node.childIds.length > 0;
     const hasValidName = node.name && node.name.trim() !== "";
     const isInteractive =
       node.role !== "none" &&
       node.role !== "generic" &&
-      node.role !== "InlineTextBox"; //add other interactive roles here
+      node.role !== "InlineTextBox"; // Add other interactive roles here as needed
 
     // Include nodes that are either named, have children, or are interactive
     if (!hasValidName && !hasChildren && !isInteractive) {
@@ -91,7 +96,7 @@ export function buildHierarchicalTree(nodes: AccessibilityNode[]): TreeResult {
     nodeMap.set(node.nodeId, {
       role: node.role,
       nodeId: node.nodeId,
-      ...(hasValidName && { name: node.name }), // Only include name if it exists and isn't empty
+      ...(hasValidName && { name: node.name }),
       ...(node.description && { description: node.description }),
       ...(node.value && { value: node.value }),
       ...(node.backendDOMNodeId !== undefined && {
@@ -121,7 +126,7 @@ export function buildHierarchicalTree(nodes: AccessibilityNode[]): TreeResult {
     .filter((node) => !node.parentId && nodeMap.has(node.nodeId)) // Get root nodes
     .map((node) => nodeMap.get(node.nodeId))
     .filter(Boolean)
-    .map((node) => cleanStructuralNodes(node))
+    .map((node) => cleanStructuralNodes(node!))
     .filter(Boolean) as AccessibilityNode[];
 
   // Generate a simplified string representation of the tree
@@ -135,6 +140,9 @@ export function buildHierarchicalTree(nodes: AccessibilityNode[]): TreeResult {
   };
 }
 
+/**
+ * Retrieves the full accessibility tree via CDP and transforms it into a hierarchical structure.
+ */
 export async function getAccessibilityTree(
   page: StagehandPage,
   logger: (logLine: LogLine) => void,
@@ -142,11 +150,12 @@ export async function getAccessibilityTree(
   await page.enableCDP("Accessibility");
 
   try {
+    // Fetch the full accessibility tree from Chrome DevTools Protocol
     const { nodes } = await page.sendCDP<{ nodes: AXNode[] }>(
       "Accessibility.getFullAXTree",
     );
 
-    // Extract specific sources
+    // Extract specific sources (including backendDOMNodeId)
     const sources = nodes.map((node) => ({
       role: node.role?.value,
       name: node.name?.value,
@@ -157,6 +166,7 @@ export async function getAccessibilityTree(
       parentId: node.parentId,
       childIds: node.childIds,
     }));
+
     // Transform into hierarchical structure
     const hierarchicalTree = buildHierarchicalTree(sources);
 

--- a/lib/a11y/utils.ts
+++ b/lib/a11y/utils.ts
@@ -188,7 +188,6 @@ export async function buildHierarchicalTree(
       ...(node.backendDOMNodeId !== undefined && {
         backendDOMNodeId: node.backendDOMNodeId,
       }),
-      ...(node.xpath && { xpath: node.xpath }),
     });
   });
 
@@ -259,7 +258,6 @@ export async function getAccessibilityTree(
         backendDOMNodeId: node.backendDOMNodeId,
         parentId: node.parentId,
         childIds: node.childIds,
-        xpath: node.xpath,
       })),
       page,
       logger,

--- a/lib/a11y/utils.ts
+++ b/lib/a11y/utils.ts
@@ -94,6 +94,9 @@ export function buildHierarchicalTree(nodes: AccessibilityNode[]): TreeResult {
       ...(hasValidName && { name: node.name }), // Only include name if it exists and isn't empty
       ...(node.description && { description: node.description }),
       ...(node.value && { value: node.value }),
+      ...(node.backendDOMNodeId !== undefined && {
+        backendDOMNodeId: node.backendDOMNodeId,
+      }),
     });
   });
 
@@ -150,6 +153,7 @@ export async function getAccessibilityTree(
       description: node.description?.value,
       value: node.value?.value,
       nodeId: node.nodeId,
+      backendDOMNodeId: node.backendDOMNodeId,
       parentId: node.parentId,
       childIds: node.childIds,
     }));

--- a/lib/a11y/utils.ts
+++ b/lib/a11y/utils.ts
@@ -58,7 +58,7 @@ function cleanStructuralNodes(
     return null;
   }
 
-  // For non-generic nodes, keep them if they still have children
+  // For non-generic nodes, keep them if they have children after cleaning
   return cleanedChildren.length > 0
     ? { ...node, children: cleanedChildren }
     : node;

--- a/lib/a11y/utils.ts
+++ b/lib/a11y/utils.ts
@@ -269,8 +269,6 @@ export async function getAccessibilityTree(
       level: 1,
     });
 
-    // fs.writeFileSync("../hybrid_tree.txt", hierarchicalTree.simplified);
-
     return hierarchicalTree;
   } catch (error) {
     logger({
@@ -368,7 +366,6 @@ export async function performPlaywrightMethod(
   method: string,
   args: unknown[],
   xpath: string,
-  // domSettleTimeoutMs?: number,
 ) {
   const locator = stagehandPage.locator(`xpath=${xpath}`).first();
   const initialUrl = stagehandPage.url();
@@ -613,7 +610,6 @@ export async function performPlaywrightMethod(
         await newOpenedTab.close();
         await stagehandPage.goto(newOpenedTab.url());
         await stagehandPage.waitForLoadState("domcontentloaded");
-        // await stagehandPage._waitForSettledDom(domSettleTimeoutMs);
       }
 
       await Promise.race([
@@ -674,6 +670,4 @@ export async function performPlaywrightMethod(
       `Method ${method} not supported`,
     );
   }
-
-  // await stagehandPage._waitForSettledDom(domSettleTimeoutMs);
 }

--- a/lib/handlers/observeHandler.ts
+++ b/lib/handlers/observeHandler.ts
@@ -108,7 +108,7 @@ export class StagehandObserveHandler {
       isUsingAccessibilityTree: useAccessibilityTree,
       returnAction,
     });
-    
+
     const elementsWithSelectors = await Promise.all(
       observationResponse.elements.map(async (element) => {
         const { elementId, ...rest } = element;

--- a/lib/handlers/observeHandler.ts
+++ b/lib/handlers/observeHandler.ts
@@ -108,6 +108,7 @@ export class StagehandObserveHandler {
       isUsingAccessibilityTree: useAccessibilityTree,
       returnAction,
     });
+    
     const elementsWithSelectors = await Promise.all(
       observationResponse.elements.map(async (element) => {
         const { elementId, ...rest } = element;
@@ -137,7 +138,6 @@ export class StagehandObserveHandler {
               message: `Invalid object ID returned for element: ${elementId}`,
               level: 1,
             });
-            return null;
           }
 
           const xpath = await getXPathByResolvedObjectId(
@@ -151,7 +151,6 @@ export class StagehandObserveHandler {
               message: `Empty xpath returned for element: ${elementId}`,
               level: 1,
             });
-            return null;
           }
 
           return {

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -361,7 +361,7 @@ You will be given:
 1. a instruction of elements to observe
 2. ${
     isUsingAccessibilityTree
-      ? "a hierarchical accessibility tree showing the semantic structure of the page"
+      ? "a hierarchical accessibility tree showing the semantic structure of the page. The tree is a hybrid of the DOM and the accessibility tree."
       : "a numbered list of possible elements"
   }
 

--- a/types/context.ts
+++ b/types/context.ts
@@ -4,6 +4,7 @@ export interface AXNode {
   description?: { value: string };
   value?: { value: string };
   nodeId: string;
+  backendDOMNodeId?: number;
   parentId?: string;
   childIds?: string[];
 }
@@ -17,6 +18,7 @@ export type AccessibilityNode = {
   childIds?: string[];
   parentId?: string;
   nodeId?: string;
+  backendDOMNodeId?: number;
 };
 
 export interface TreeResult {

--- a/types/context.ts
+++ b/types/context.ts
@@ -7,7 +7,6 @@ export interface AXNode {
   backendDOMNodeId?: number;
   parentId?: string;
   childIds?: string[];
-  xpath?: string;
 }
 
 export type AccessibilityNode = {
@@ -20,7 +19,6 @@ export type AccessibilityNode = {
   parentId?: string;
   nodeId?: string;
   backendDOMNodeId?: number;
-  xpath?: string;
 };
 
 export interface TreeResult {

--- a/types/context.ts
+++ b/types/context.ts
@@ -7,6 +7,7 @@ export interface AXNode {
   backendDOMNodeId?: number;
   parentId?: string;
   childIds?: string[];
+  xpath?: string;
 }
 
 export type AccessibilityNode = {
@@ -19,6 +20,7 @@ export type AccessibilityNode = {
   parentId?: string;
   nodeId?: string;
   backendDOMNodeId?: number;
+  xpath?: string;
 };
 
 export interface TreeResult {


### PR DESCRIPTION
# why
- sometimes the `role` for an `AXNode` is something useless like `none` or `generic`. this isn't very helpful context for the LLM
# what changed
- if the `role` for an `AXNode` is `none` or `generic`, we replace it with the `tagName` of its corresponding DOM element

### before this PR:
<img width="933" alt="Screenshot 2025-02-03 at 7 11 53 PM" src="https://github.com/user-attachments/assets/abdc5dbf-a025-4313-8760-740d3f5d0505" />

### after this PR:
<img width="918" alt="Screenshot 2025-02-03 at 7 14 09 PM" src="https://github.com/user-attachments/assets/a2bcfb80-bfd0-4ec9-a283-ebe70e673663" />
