### PR TITLE
Annotations for Scrollable elements in a11y-dom hybrid

### DIFF
--- a/.changeset/chilled-apes-sneeze.md
+++ b/.changeset/chilled-apes-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+create a11y + dom hybrid input for observe

--- a/lib/a11y/utils.ts
+++ b/lib/a11y/utils.ts
@@ -13,7 +13,9 @@ export function formatSimplifiedTree(
   level = 0,
 ): string {
   const indent = "  ".repeat(level);
-  let result = `${indent}[${node.nodeId}] ${node.role}${node.name ? `: ${node.name}` : ""}\n`;
+  let result = `${indent}[${node.nodeId}] [${node.backendDOMNodeId}] ${node.role}${
+    node.name ? `: ${node.name}` : ""
+  }\n`;
 
   if (node.children?.length) {
     result += node.children
@@ -24,10 +26,9 @@ export function formatSimplifiedTree(
 }
 
 /**
- * Helper function to remove or collapse unnecessary structural nodes
- * Handles three cases:
+ * Helper function to remove or collapse unnecessary structural nodes:
  * 1. Removes generic/none nodes with no children
- * 2. Collapses generic/none nodes with single child
+ * 2. Collapses generic/none nodes with a single child
  * 3. Keeps generic/none nodes with multiple children but cleans their subtrees
  */
 function cleanStructuralNodes(
@@ -35,6 +36,7 @@ function cleanStructuralNodes(
 ): AccessibilityNode | null {
   // Base case: leaf node
   if (!node.children) {
+    // Remove if role is generic/none
     return node.role === "generic" || node.role === "none" ? null : node;
   }
 
@@ -46,17 +48,17 @@ function cleanStructuralNodes(
   // Handle generic/none nodes specially
   if (node.role === "generic" || node.role === "none") {
     if (cleanedChildren.length === 1) {
-      // Collapse single-child generic nodes
+      // Collapse single-child generic/none nodes
       return cleanedChildren[0];
     } else if (cleanedChildren.length > 1) {
-      // Keep generic nodes with multiple children
+      // Keep generic/none nodes with multiple children
       return { ...node, children: cleanedChildren };
     }
-    // Remove generic nodes with no children
+    // Remove generic/none node with no children
     return null;
   }
 
-  // For non-generic nodes, keep them if they have children after cleaning
+  // For non-generic nodes, keep them if they still have children
   return cleanedChildren.length > 0
     ? { ...node, children: cleanedChildren }
     : node;
@@ -65,22 +67,25 @@ function cleanStructuralNodes(
 /**
  * Builds a hierarchical tree structure from a flat array of accessibility nodes.
  * The function processes nodes in multiple passes to create a clean, meaningful tree.
- * @param nodes - Flat array of accessibility nodes from the CDP
- * @returns Object containing both the tree structure and a simplified string representation
  */
 export function buildHierarchicalTree(nodes: AccessibilityNode[]): TreeResult {
   // Map to store processed nodes for quick lookup
   const nodeMap = new Map<string, AccessibilityNode>();
 
-  // First pass: Create nodes that are meaningful
-  // We only keep nodes that either have a name or children to avoid cluttering the tree
+  // --- First pass: Create nodes that are meaningful (and skip negative IDs) ---
   nodes.forEach((node) => {
+    // Skip node if its ID is negative (e.g., "-1000002014")
+    const nodeIdValue = parseInt(node.nodeId, 10);
+    if (nodeIdValue < 0) {
+      return;
+    }
+
     const hasChildren = node.childIds && node.childIds.length > 0;
     const hasValidName = node.name && node.name.trim() !== "";
     const isInteractive =
       node.role !== "none" &&
       node.role !== "generic" &&
-      node.role !== "InlineTextBox"; //add other interactive roles here
+      node.role !== "InlineTextBox"; // Add other interactive roles here as needed
 
     // Include nodes that are either named, have children, or are interactive
     if (!hasValidName && !hasChildren && !isInteractive) {
@@ -91,7 +96,7 @@ export function buildHierarchicalTree(nodes: AccessibilityNode[]): TreeResult {
     nodeMap.set(node.nodeId, {
       role: node.role,
       nodeId: node.nodeId,
-      ...(hasValidName && { name: node.name }), // Only include name if it exists and isn't empty
+      ...(hasValidName && { name: node.name }),
       ...(node.description && { description: node.description }),
       ...(node.value && { value: node.value }),
       ...(node.backendDOMNodeId !== undefined && {
@@ -121,7 +126,7 @@ export function buildHierarchicalTree(nodes: AccessibilityNode[]): TreeResult {
     .filter((node) => !node.parentId && nodeMap.has(node.nodeId)) // Get root nodes
     .map((node) => nodeMap.get(node.nodeId))
     .filter(Boolean)
-    .map((node) => cleanStructuralNodes(node))
+    .map((node) => cleanStructuralNodes(node!))
     .filter(Boolean) as AccessibilityNode[];
 
   // Generate a simplified string representation of the tree
@@ -135,6 +140,9 @@ export function buildHierarchicalTree(nodes: AccessibilityNode[]): TreeResult {
   };
 }
 
+/**
+ * Retrieves the full accessibility tree via CDP and transforms it into a hierarchical structure.
+ */
 export async function getAccessibilityTree(
   page: StagehandPage,
   logger: (logLine: LogLine) => void,
@@ -142,11 +150,12 @@ export async function getAccessibilityTree(
   await page.enableCDP("Accessibility");
 
   try {
+    // Fetch the full accessibility tree from Chrome DevTools Protocol
     const { nodes } = await page.sendCDP<{ nodes: AXNode[] }>(
       "Accessibility.getFullAXTree",
     );
 
-    // Extract specific sources
+    // Extract specific sources (including backendDOMNodeId)
     const sources = nodes.map((node) => ({
       role: node.role?.value,
       name: node.name?.value,
@@ -157,6 +166,7 @@ export async function getAccessibilityTree(
       parentId: node.parentId,
       childIds: node.childIds,
     }));
+
     // Transform into hierarchical structure
     const hierarchicalTree = buildHierarchicalTree(sources);
 

--- a/lib/a11y/utils.ts
+++ b/lib/a11y/utils.ts
@@ -94,6 +94,9 @@ export function buildHierarchicalTree(nodes: AccessibilityNode[]): TreeResult {
       ...(hasValidName && { name: node.name }), // Only include name if it exists and isn't empty
       ...(node.description && { description: node.description }),
       ...(node.value && { value: node.value }),
+      ...(node.backendDOMNodeId !== undefined && {
+        backendDOMNodeId: node.backendDOMNodeId,
+      }),
     });
   });
 
@@ -150,6 +153,7 @@ export async function getAccessibilityTree(
       description: node.description?.value,
       value: node.value?.value,
       nodeId: node.nodeId,
+      backendDOMNodeId: node.backendDOMNodeId,
       parentId: node.parentId,
       childIds: node.childIds,
     }));

--- a/lib/a11y/utils.ts
+++ b/lib/a11y/utils.ts
@@ -58,7 +58,7 @@ function cleanStructuralNodes(
     return null;
   }
 
-  // For non-generic nodes, keep them if they still have children
+  // For non-generic nodes, keep them if they have children after cleaning
   return cleanedChildren.length > 0
     ? { ...node, children: cleanedChildren }
     : node;

--- a/lib/dom/global.d.ts
+++ b/lib/dom/global.d.ts
@@ -36,5 +36,6 @@ declare global {
       width: number;
       height: number;
     }>;
+    getScrollableElementXpaths: (topN?: number) => Promise<string[]>;
   }
 }

--- a/lib/dom/process.ts
+++ b/lib/dom/process.ts
@@ -11,18 +11,24 @@ export function isTextNode(node: Node): node is Text {
   return node.nodeType === Node.TEXT_NODE && Boolean(node.textContent?.trim());
 }
 
-function getMainScrollableElement(): HTMLElement {
+/**
+ * Finds and returns a list of scrollable elements on the page,
+ * ordered from the element with the largest scrollHeight to the smallest.
+ *
+ * @param topN Optional maximum number of scrollable elements to return.
+ *             If not provided, all found scrollable elements are returned.
+ * @returns An array of HTMLElements sorted by descending scrollHeight.
+ */
+export function getScrollableElements(topN?: number): HTMLElement[] {
+  // Get the root <html> element
   const docEl = document.documentElement;
-  let mainScrollable: HTMLElement = docEl;
 
-  // 1) Compute how “scrollable” the root <html> is
-  //    i.e. total scrollHeight - visible clientHeight
-  const rootScrollDiff = docEl.scrollHeight - docEl.clientHeight;
+  // 1) Initialize an array to hold all scrollable elements.
+  //    Always include the root <html> element as a fallback.
+  const scrollableElements: HTMLElement[] = [docEl];
 
-  // Keep track of the “largest” scroll diff found so far.
-  let maxScrollDiff = rootScrollDiff;
-
-  // 2) Scan all elements to find if any <div> has a larger scrollable diff
+  // 2) Scan all elements to find potential scrollable containers.
+  //    A candidate must have a scrollable overflow style and extra scrollable content.
   const allElements = document.querySelectorAll<HTMLElement>("*");
   for (const elem of allElements) {
     const style = window.getComputedStyle(elem);
@@ -33,25 +39,44 @@ function getMainScrollableElement(): HTMLElement {
 
     if (isPotentiallyScrollable) {
       const candidateScrollDiff = elem.scrollHeight - elem.clientHeight;
-      // Only pick this <div> if it has strictly more vertical “scrollable distance” than our current best
-      if (candidateScrollDiff > maxScrollDiff) {
-        maxScrollDiff = candidateScrollDiff;
-        mainScrollable = elem;
+      // Only consider this element if it actually has extra scrollable content
+      // and it can truly scroll.
+      if (candidateScrollDiff > 0 && canElementScroll(elem)) {
+        scrollableElements.push(elem);
       }
     }
   }
 
-  // 3) Verify the chosen element truly scrolls
-  if (mainScrollable !== docEl) {
-    if (!canElementScroll(mainScrollable)) {
-      console.log(
-        "Stagehand (Browser Process): Unable to scroll candidate. Fallback to <html>.",
-      );
-      mainScrollable = docEl;
-    }
+  // 3) Sort the scrollable elements from largest scrollHeight to smallest.
+  scrollableElements.sort((a, b) => b.scrollHeight - a.scrollHeight);
+
+  // 4) If a topN limit is specified, return only the first topN elements.
+  if (topN !== undefined) {
+    return scrollableElements.slice(0, topN);
   }
 
-  return mainScrollable;
+  // Return all found scrollable elements if no limit is provided.
+  return scrollableElements;
+}
+
+/**
+ * Calls getScrollableElements, then for each element calls generateXPaths,
+ * and returns the first XPath for each.
+ *
+ * @param topN (optional) integer limit on how many scrollable elements to process
+ * @returns string[] list of XPaths (1 for each scrollable element)
+ */
+export async function getScrollableElementXpaths(
+  topN?: number,
+): Promise<string[]> {
+  const scrollableElems = getScrollableElements(topN);
+  const xpaths = [];
+  for (const elem of scrollableElems) {
+    const allXPaths = await generateXPaths(elem);
+    const firstXPath = allXPaths?.[0] || "";
+    xpaths.push(firstXPath);
+  }
+  return xpaths;
 }
 
 export async function processDom(chunksSeen: Array<number>) {
@@ -80,7 +105,8 @@ export async function processDom(chunksSeen: Array<number>) {
 export async function processAllOfDom() {
   console.log("Stagehand (Browser Process): Processing all of DOM");
 
-  const mainScrollable = getMainScrollableElement();
+  const mainScrollableElements = getScrollableElements(1);
+  const mainScrollable = mainScrollableElements[0];
 
   const container =
     mainScrollable === document.documentElement
@@ -481,7 +507,7 @@ window.restoreDOM = restoreDOM;
 window.createTextBoundingBoxes = createTextBoundingBoxes;
 window.getElementBoundingBoxes = getElementBoundingBoxes;
 window.createStagehandContainer = createStagehandContainer;
-
+window.getScrollableElementXpaths = getScrollableElementXpaths;
 const leafElementDenyList = ["SVG", "IFRAME", "SCRIPT", "STYLE", "LINK"];
 
 const interactiveElementTypes = [

--- a/types/context.ts
+++ b/types/context.ts
@@ -4,6 +4,7 @@ export interface AXNode {
   description?: { value: string };
   value?: { value: string };
   nodeId: string;
+  backendDOMNodeId?: number;
   parentId?: string;
   childIds?: string[];
 }
@@ -17,6 +18,7 @@ export type AccessibilityNode = {
   childIds?: string[];
   parentId?: string;
   nodeId?: string;
+  backendDOMNodeId?: number;
 };
 
 export interface TreeResult {

--- a/types/context.ts
+++ b/types/context.ts
@@ -7,6 +7,7 @@ export interface AXNode {
   backendDOMNodeId?: number;
   parentId?: string;
   childIds?: string[];
+  xpath?: string;
 }
 
 export type AccessibilityNode = {
@@ -19,6 +20,7 @@ export type AccessibilityNode = {
   parentId?: string;
   nodeId?: string;
   backendDOMNodeId?: number;
+  xpath?: string;
 };
 
 export interface TreeResult {


### PR DESCRIPTION
# why
- we want the LLM to be able to find scrollable containers in `observe` calls
- we don't have this level of granularity with the a11y tree alone
# what changed
- changed the `getMainScrollableElement` function in `process.ts` to `getScrollableElements`, which now optionally returns a list of _all_ the scrollable elements on the page unless the `topN` param is specified. 
- For usage in `processAllOfDom`, we set `topN` to `1` to maintain the existing behaviour.
- added a new function in `process.ts` called `getScrollableElementXpaths` which calls `getScrollableElements` and then calls `generateXpaths` on each of the returned elements. This function returns a list of xpaths for each scrollable element on the page.
- exposed the new `getScrollableElementXpaths` globally so that it can be called from `a11y/utils.ts`
- created a new function `findScrollableElementIds` in `a11y/utils.ts` which calls the `getScrollableElementXpaths` function from the browser context, evaluates the returned xpaths, and returns their corresponding `backendDOMId`'s
- updated `getAccessibilityTree` to prepend the string `Scrollable` to the `role` of all the scrollable elements in the a11y tree
# example
## LLM input before this PR:
<img width="818" alt="Screenshot 2025-02-04 at 2 47 22 PM" src="https://github.com/user-attachments/assets/767b2c54-0bcd-48ce-b35a-92428834fc54" />

## LLM input after this PR:
<img width="823" alt="Screenshot 2025-02-04 at 2 48 04 PM" src="https://github.com/user-attachments/assets/6a15a1d1-5c16-4244-b0ea-ea4b6d4d977c" />

