### PR TITLE
`drawOverlay` observe option

### DIFF
--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -17,6 +17,7 @@ import {
 import { z } from "zod";
 import { StagehandExtractHandler } from "./handlers/extractHandler";
 import { StagehandObserveHandler } from "./handlers/observeHandler";
+import { clearOverlays } from "./utils";
 
 export class StagehandPage {
   private stagehand: Stagehand;
@@ -292,6 +293,8 @@ export class StagehandPage {
       throw new Error("Act handler not initialized");
     }
 
+    await clearOverlays(this.page);
+
     // If actionOrOptions is an ObserveResult, we call actFromObserveResult.
     // We need to ensure there is both a selector and a method in the ObserveResult.
     if (typeof actionOrOptions === "object" && actionOrOptions !== null) {
@@ -408,6 +411,8 @@ export class StagehandPage {
       throw new Error("Extract handler not initialized");
     }
 
+    await clearOverlays(this.page);
+
     const options: ExtractOptions<T> =
       typeof instructionOrOptions === "string"
         ? {
@@ -491,6 +496,8 @@ export class StagehandPage {
       throw new Error("Observe handler not initialized");
     }
 
+    await clearOverlays(this.page);
+
     const options: ObserveOptions =
       typeof instructionOrOptions === "string"
         ? { instruction: instructionOrOptions }
@@ -505,6 +512,7 @@ export class StagehandPage {
       returnAction = false,
       onlyVisible = false,
       useAccessibilityTree,
+      drawOverlay,
     } = options;
 
     if (useAccessibilityTree !== undefined) {
@@ -568,6 +576,7 @@ export class StagehandPage {
         domSettleTimeoutMs,
         returnAction,
         onlyVisible,
+        drawOverlay,
       })
       .catch((e) => {
         this.stagehand.log({

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,7 +1,8 @@
 import crypto from "crypto";
+import { z } from "zod";
+import { ObserveResult, Page } from ".";
 import { LogLine } from "../types/log";
 import { TextAnnotation } from "../types/textannotation";
-import { z } from "zod";
 
 // This is a heuristic for the width of a character in pixels. It seems to work
 // better than attempting to calculate character widths dynamically, which sometimes
@@ -373,4 +374,59 @@ export function validateZodSchema(schema: z.ZodTypeAny, data: unknown) {
   } catch {
     return false;
   }
+}
+
+export async function drawObserveOverlay(page: Page, results: ObserveResult[]) {
+  // Convert single xpath to array for consistent handling
+  const xpathList = results.map((result) => result.selector);
+
+  // Filter out empty xpaths
+  const validXpaths = xpathList.filter((xpath) => xpath !== "xpath=");
+
+  await page.evaluate((selectors) => {
+    selectors.forEach((selector) => {
+      let element;
+      if (selector.startsWith("xpath=")) {
+        const xpath = selector.substring(6);
+        element = document.evaluate(
+          xpath,
+          document,
+          null,
+          XPathResult.FIRST_ORDERED_NODE_TYPE,
+          null,
+        ).singleNodeValue;
+      } else {
+        element = document.querySelector(selector);
+      }
+
+      if (element instanceof HTMLElement) {
+        const overlay = document.createElement("div");
+        overlay.setAttribute("stagehandObserve", "true");
+        const rect = element.getBoundingClientRect();
+        overlay.style.position = "absolute";
+        overlay.style.left = rect.left + "px";
+        overlay.style.top = rect.top + "px";
+        overlay.style.width = rect.width + "px";
+        overlay.style.height = rect.height + "px";
+        overlay.style.backgroundColor = "rgba(255, 255, 0, 0.3)";
+        overlay.style.pointerEvents = "none";
+        overlay.style.zIndex = "10000";
+        document.body.appendChild(overlay);
+      }
+    });
+  }, validXpaths);
+}
+
+export async function clearOverlays(page: Page) {
+  // remove existing stagehandObserve attributes
+  await page.evaluate(() => {
+    const elements = document.querySelectorAll('[stagehandObserve="true"]');
+    elements.forEach((el) => {
+      const parent = el.parentNode;
+      while (el.firstChild) {
+        parent?.insertBefore(el.firstChild, el);
+      }
+      parent?.removeChild(el);
+    });
+  });
 }

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -93,6 +93,7 @@ export interface ObserveOptions {
   onlyVisible?: boolean;
   /** @deprecated `useAccessibilityTree` is now deprecated. Use `onlyVisible` instead. */
   useAccessibilityTree?: boolean;
+  drawOverlay?: boolean;
 }
 
 export interface ObserveResult {


### PR DESCRIPTION
# why
We want to give users access to utils that highlight `observe()` results in the browser view.

# what changed
Added `drawOverlay: boolean` parameter to `observe()` and called util to clear drawings after the observe call.
