### PR TITLE
Static evals environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,7 @@ jobs:
       BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
       BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
       BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
+      PLATO_API_KEY: ${{ secrets.PLATO_API_KEY }}
       HEADLESS: true
       EVAL_ENV: browserbase
     steps:
@@ -209,6 +210,7 @@ jobs:
       BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
       BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
       BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
+      PLATO_API_KEY: ${{ secrets.PLATO_API_KEY }}
       HEADLESS: true
       EVAL_ENV: browserbase
     steps:
@@ -277,6 +279,7 @@ jobs:
       BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
       BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
       BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
+      PLATO_API_KEY: ${{ secrets.PLATO_API_KEY }}
       HEADLESS: true
       EVAL_ENV: browserbase
     steps:
@@ -362,6 +365,7 @@ jobs:
       BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
       BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
       BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
+      PLATO_API_KEY: ${{ secrets.PLATO_API_KEY }}
       HEADLESS: true
       EVAL_ENV: browserbase
     steps:
@@ -431,6 +435,7 @@ jobs:
       BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
       BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
       BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
+      PLATO_API_KEY: ${{ secrets.PLATO_API_KEY }}
       HEADLESS: true
       EVAL_ENV: browserbase
     steps:

--- a/evals/evals.config.json
+++ b/evals/evals.config.json
@@ -2,242 +2,359 @@
   "tasks": [
     {
       "name": "extract_repo_name",
+      "description": "Extract the name of the repository",
+      "startUrl": "https://github.com/facebook/react",
       "categories": ["extract"]
     },
     {
       "name": "amazon_add_to_cart",
+      "description": "Add a product to the cart",
+      "startUrl": "https://www.amazon.com/Laptop-MacBook-Surface-Water-Resistant-Accessories/dp/B0D5M4H5CD",
       "categories": ["act"]
     },
     {
       "name": "instructions",
+      "description": "If the users says `secret12345`, click on the 'quickstart' tab",
+      "startUrl": "https://docs.browserbase.com/",
       "categories": ["combination"]
     },
     {
       "name": "bidnet",
+      "description": "Click on the 'Construction' keyword",
+      "startUrl": "https://www.bidnetdirect.com/",
       "categories": ["act"]
     },
     {
       "name": "ionwave",
+      "description": "Click on 'Closed Bids'",
+      "startUrl": "https://elpasotexas.ionwave.net/Login.aspx",
       "categories": ["act"]
     },
     {
       "name": "laroche_form",
+      "description": "Fill the last name field",
+      "startUrl": "https://www.laroche-posay.us/offers/anthelios-melt-in-milk-sunscreen-sample.html",
       "categories": ["act"]
     },
     {
       "name": "nonsense_action",
+      "description": "Click on the first banana",
+      "startUrl": "https://www.homedepot.com/",
       "categories": ["act"]
     },
     {
       "name": "peeler_simple",
+      "startUrl": "file://evals/assets/peeler.html",
       "categories": ["act"]
     },
+
     {
       "name": "simple_google_search",
+      "description": "Search for 'OpenAI'",
+      "startUrl": "https://www.google.com",
       "categories": ["act"]
     },
     {
       "name": "vantechjournal",
+      "description": "Click on page 8. do not click the next button",
+      "startUrl": "https://vantechjournal.com/",
       "categories": ["act"]
     },
     {
       "name": "wikipedia",
+      "description": "Click on the 'Hit and run' link in this article",
+      "startUrl": "https://en.wikipedia.org/wiki/Baseball",
       "categories": ["act"]
     },
 
     {
       "name": "allrecipes",
+      "description": "Extract the title of the first recipe and the total number of ratings it has received.",
+      "startUrl": "https://www.allrecipes.com/",
       "categories": ["combination"]
     },
     {
       "name": "arxiv",
+      "description": "Search for papers about web agents with multimodal models",
+      "startUrl": "https://arxiv.org/search/",
       "categories": ["combination"]
     },
     {
       "name": "extract_collaborators",
+      "description": "Extract top 20 contributors of this repository",
+      "startUrl": "https://github.com/facebook/react",
       "categories": ["combination"]
     },
     {
       "name": "extract_github_commits",
+      "description": "Extract last 20 commits",
+      "startUrl": "https://github.com/facebook/react",
       "categories": ["combination"]
     },
     {
       "name": "imdb_movie_details",
+      "description": "Extract the list of countries with the most ratings.",
+      "startUrl": "https://www.imdb.com/title/tt0111161/",
       "categories": ["combination"]
     },
     {
       "name": "peeler_complex",
+      "description": "Click the first 'OXO' brand peeler and get its price",
+      "startUrl": "https://chefstoys.com/",
       "categories": ["combination"]
     },
     {
       "name": "sciquest",
+      "description": "Extract the total number of results that the search produced. Not the number of results displayed on the page.",
+      "startUrl": "https://bids.sciquest.com/apps/Router/PublicEvent?tab=PHX_NAV_SourcingAllOpps&CustomerOrg=StateOfUtah",
       "categories": ["combination"]
     },
     {
       "name": "wichita",
+      "description": "Extract the total number of bids that the search produced.",
+      "startUrl": "https://www.wichitafallstx.gov/Bids.aspx",
       "categories": ["combination"]
     },
 
     {
       "name": "apple",
+      "description": "Click on the 'Buy' button",
+      "startUrl": "https://www.apple.com/iphone-16-pro/",
       "categories": ["experimental"]
     },
     {
       "name": "combination_sauce",
+      "description": "Click on the 'Add to Cart' button",
+      "startUrl": "https://www.saucedemo.com/",
       "categories": ["experimental"]
     },
     {
       "name": "costar",
+      "description": "Click on the first article",
+      "startUrl": "https://www.costar.com/",
       "categories": ["experimental"]
     },
     {
       "name": "expedia",
+      "description": "Find round-trip flights from San Francisco (SFO) to Toronto (YYZ) for Jan 1, 2025 (up to one to two weeks)",
+      "startUrl": "https://www.expedia.com/flights",
       "categories": ["experimental"]
     },
     {
       "name": "expedia_search",
+      "description": "Find round-trip flights from San Francisco (SFO) to Toronto (YYZ) for Jan 1, 2025 (up to one to two weeks)",
+      "startUrl": "https://www.expedia.com/flights",
       "categories": ["experimental"]
     },
     {
       "name": "extract_aigrant_companies",
+      "description": "Extract all companies that received the AI grant and group them with their batch numbers as an array of objects. Each object should contain the company name and its corresponding batch number.",
+      "startUrl": "https://aigrant.com/",
       "categories": ["experimental", "text_extract"]
     },
     {
       "name": "extract_capacitor_info",
+      "description": "Extract the ECCN Code, RoHS Status, and Impedance.",
+      "startUrl": "https://www.jakelectronics.com/productdetail/panasonicelectroniccomponents-eeufm1a472l-2937406",
       "categories": ["experimental", "text_extract"]
     },
     {
       "name": "extract_partners",
+      "description": "Extract all of the partner categories on the page.",
+      "startUrl": "https://ramp.com/",
       "categories": ["experimental"]
     },
     {
       "name": "extract_press_releases",
+      "description": "Extract the title and corresponding publish date of EACH AND EVERY press releases on this page. DO NOT MISS ANY PRESS RELEASES.",
+      "startUrl": "https://dummy-press-releases.surge.sh/news",
       "categories": ["experimental", "text_extract"]
     },
     {
       "name": "extract_snowshoeing_destinations",
+      "description": "Extract all the snowshoeing regions and the names of the trails within each region.",
+      "startUrl": "https://www.cbisland.com/blog/10-snowshoeing-adventures-on-cape-breton-island/",
       "categories": ["experimental", "text_extract"]
     },
     {
       "name": "google_jobs",
+      "description": "Extract the following details from the job posting: application deadline, minimum qualifications (degree and years of experience), and preferred qualifications (degree and years of experience)",
+      "startUrl": "https://www.google.com",
       "categories": ["experimental"]
     },
     {
       "name": "homedepot",
+      "description": "Extract the Primary exact Burner BTU of the product",
+      "startUrl": "https://www.homedepot.com/",
       "categories": ["experimental"]
     },
     {
       "name": "rakuten_jp",
+      "description": "Click on online supermarket",
+      "startUrl": "https://www.rakuten.co.jp/",
       "categories": ["experimental"]
     },
     {
       "name": "stock_x",
+      "description": "Click on Jordan 3 Retro Crimson in the related products",
+      "startUrl": "https://stockx.com/air-jordan-3-retro-black-cement-2024",
       "categories": ["experimental"]
     },
     {
       "name": "ted_talk",
+      "description": "Extract the video playlist titles and the number of talks in each playlist. This info is in the Video Playlists about Culture section of the webpage.",
+      "startUrl": "https://www.ted.com/talks/sir_ken_robinson_do_schools_kill_creativity",
       "categories": ["experimental"]
     },
 
     {
       "name": "extract_baptist_health",
+      "description": "Extract the address, phone number, and fax number of the healthcare location.",
+      "startUrl": "https://www.baptistfirst.org/location/baptist-health-ent-partners",
       "categories": ["extract"]
     },
     {
       "name": "extract_github_stars",
+      "description": "Extract the number of stars for the project",
+      "startUrl": "https://github.com/facebook/react",
       "categories": ["extract"]
     },
     {
       "name": "extract_memorial_healthcare",
+      "description": "extract a list of the first three healthcare centers on this page, with their name, full address, and phone number",
+      "startUrl": "https://www.mycmh.org/locations/",
       "categories": ["extract"]
     },
     {
       "name": "extract_nhl_stats",
+      "description": "Extract the name of the goal scoring leader, their number of goals they scored, and the team they played for.",
+      "startUrl": "https://www.hockeydb.com/ihdb/stats/top_league.php?lid=nhl1927&sid=1990",
       "categories": ["extract"]
     },
     {
       "name": "extract_professional_info",
+      "description": "Extract the list of Practices, phone number, and fax number of the professional.",
+      "startUrl": "https://www.paulweiss.com/professionals/partners-and-counsel/brian-bolin",
       "categories": ["extract"]
     },
     {
       "name": "extract_csa",
+      "description": "Extract all the publications on the page including the publication date, session type, publication type, and annotation",
+      "startUrl": "https://clerk.assembly.ca.gov/weekly-histories?from_date=&to_date=2025-01-09",
       "categories": ["text_extract"]
     },
     {
       "name": "extract_resistor_info",
+      "description": "Extract the MOQ, tolerance percentage, ohmic value, and operating temperature range of the resistor.",
+      "startUrl": "https://www.seielect.com/?stockcheck=ASR1JA330R",
       "categories": ["extract"]
     },
     {
       "name": "extract_rockauto",
+      "description": "Extract the part number of all the coolant and antifreeze products in the 'economy' category. Do not include the manufacturer name.",
+      "startUrl": "https://www.rockauto.com/en/catalog/alpine,1974,a310,1.6l+l4,1436055,cooling+system,coolant+/+antifreeze,11393",
       "categories": ["extract"]
     },
     {
       "name": "extract_staff_members",
+      "description": "extract a list of staff members on this page, with their name and their job title",
+      "startUrl": "https://panamcs-static-site.surge.sh/",
       "categories": ["extract"]
     },
 
     {
       "name": "ionwave_observe",
+      "description": "Click on 'Closed Bids'",
+      "startUrl": "https://elpasotexas.ionwave.net/Login.aspx",
       "categories": ["observe"]
     },
     {
       "name": "panamcs",
+      "description": "Click on the 'About Us' button",
+      "startUrl": "https://panamcs.org/about/staff/",
       "categories": ["observe"]
     },
     {
       "name": "shopify_homepage",
+      "description": "Click on the 'Shop' button",
+      "startUrl": "https://www.shopify.com/",
       "categories": ["observe"]
     },
     {
       "name": "vanta",
+      "startUrl": "https://www.vanta.com/",
       "categories": ["observe"]
     },
     {
       "name": "vanta_h",
+      "description": "find the buy now button if it is available",
+      "startUrl": "https://www.vanta.com/",
       "categories": ["observe"]
     },
     {
       "name": "extract_area_codes",
+      "description": "Extract ALL the Primary Center names and their corresponding Area Code, and the name of their corresponding Zone.",
+      "startUrl": "https://www.ncc.gov.ng/technical-regulation/standards/numbering#area-codes-by-zone-primary-centre",
       "categories": ["text_extract"]
     },
     {
       "name": "extract_public_notices",
+      "description": "Extract ALL the public notice descriptions with their corresponding, GG number and publication date. Extract ALL notices from 2024 through 2020. Do not include the Notice number.",
+      "startUrl": "https://www.sars.gov.za/legal-counsel/secondary-legislation/public-notices/",
       "categories": ["text_extract"]
     },
     {
       "name": "extract_jstor_news",
+      "description": "Extract ALL the news report titles and their dates.",
+      "startUrl": "http://jstor-eval.surge.sh",
       "categories": ["text_extract"]
     },
     {
       "name": "extract_apartments",
+      "description": "Extract all the apartment listings with their prices and their addresses.",
+      "startUrl": "https://www.apartments.com/san-francisco-ca/2-bedrooms/",
       "categories": ["text_extract"]
     },
     {
       "name": "extract_zillow",
+      "description": "Extract EACH AND EVERY HOME PRICE AND ADDRESS ON THE PAGE. DO NOT MISS ANY OF THEM.",
+      "startUrl": "https://zillow-eval.surge.sh/",
       "categories": ["text_extract"]
     },
     {
       "name": "observe_github",
+      "description": "find the scrollable element that holds the repos file tree.",
+      "startUrl": "https://github.com/numpy/numpy/tree/main/numpy",
       "categories": ["observe"]
     },
     {
       "name": "observe_vantechjournal",
+      "description": "find the button that takes us to the 11th page",
+      "startUrl": "https://vantechjournal.com/archive?page=8",
       "categories": ["observe"]
     },
     {
       "name": "observe_amazon_add_to_cart",
+      "description": "Find and click the 'Add to Cart' button",
+      "startUrl": "https://www.amazon.com/Laptop-MacBook-Surface-Water-Resistant-Accessories/dp/B0D5M4H5CD",
       "categories": ["observe"]
     },
     {
       "name": "observe_simple_google_search",
+      "description": "Find the search bar and enter 'OpenAI'",
+      "startUrl": "https://www.google.com",
       "categories": ["observe"]
     },
     {
       "name": "observe_yc_startup",
+      "description": "Find the container element that holds links to each of the startup companies. The companies each have a name, a description, and a link to their website.",
+      "startUrl": "https://www.ycombinator.com/companies",
       "categories": ["observe"]
     },
     {
       "name": "observe_taxes",
+      "description": "Find all the form elements under the 'Income' section",
+      "startUrl": "https://file.1040.com/estimate/",
       "categories": ["observe"]
     }
   ]

--- a/evals/index.eval.ts
+++ b/evals/index.eval.ts
@@ -30,10 +30,17 @@ import { EvalFunction, SummaryResult, Testcase } from "@/types/evals";
 import { EvalLogger } from "./logger";
 import { AvailableModel } from "@/dist";
 import dotenv from "dotenv";
+import Plato from "plato-cli";
+
 dotenv.config();
 
 const MAX_CONCURRENCY = 20;
-const TRIAL_COUNT = 5;
+const TRIAL_COUNT = 1;
+
+const plato = new Plato({
+  apiKey: process.env.PLATO_API_KEY,
+  version: "1.0.0",
+});
 
 /**
  * generateSummary:
@@ -227,6 +234,7 @@ const generateFilteredTestcases = (): Testcase[] => {
             logger,
             useTextExtract,
             useAccessibilityTree,
+            plato,
           });
 
           // Log result to console

--- a/evals/index.eval.ts
+++ b/evals/index.eval.ts
@@ -34,7 +34,7 @@ import Plato from "plato-cli";
 
 dotenv.config();
 
-const MAX_CONCURRENCY = 5;
+const MAX_CONCURRENCY = 20;
 const TRIAL_COUNT = 1;
 
 const USE_PLATO = true;

--- a/evals/index.eval.ts
+++ b/evals/index.eval.ts
@@ -37,11 +37,6 @@ dotenv.config();
 const MAX_CONCURRENCY = 20;
 const TRIAL_COUNT = 1;
 
-const plato = new Plato({
-  apiKey: process.env.PLATO_API_KEY,
-  version: "1.0.0",
-});
-
 /**
  * generateSummary:
  * After all evaluations have finished, aggregate the results into a summary.
@@ -197,6 +192,8 @@ const generateFilteredTestcases = (): Testcase[] => {
     category: filterByCategory || undefined,
     environment: env,
   });
+
+  const plato = await Plato.init(process.env.PLATO_API_KEY!, "1.0.0");
 
   // Determine braintrust project name to use (stagehand in CI, stagehand-dev otherwise)
   const braintrustProjectName =

--- a/evals/index.eval.ts
+++ b/evals/index.eval.ts
@@ -269,27 +269,23 @@ const generateFilteredTestcases = (): Testcase[] => {
 
   try {
     if (USE_PLATO) {
-      evalResult = await Plato.Eval(
-        braintrustProjectName,
-        {
-          name: experimentName,
-          data: generateFilteredTestcases().map((t) => ({
-            ...t,
-            prompt: t.description || t.name,
-          })),
-          task: async (input, simulatorSession) => {
-            const result = await runTask(input.input, {
-              env: "REMOTE",
-              cdpUrl: simulatorSession.cdpUrl,
-            });
-            return result;
-          },
-          customScores: [],
-          maxConcurrency: MAX_CONCURRENCY,
-          trialCount: TRIAL_COUNT,
+      evalResult = await Plato.Eval(braintrustProjectName, {
+        name: experimentName,
+        data: generateFilteredTestcases().map((t) => ({
+          ...t,
+          prompt: t.description || t.name,
+        })),
+        task: async (input, simulatorSession) => {
+          const result = await runTask(input.input, {
+            env: "REMOTE",
+            cdpUrl: simulatorSession.cdpUrl,
+          });
+          return result;
         },
-        { baseUrl: "http://localhost:25565" },
-      );
+        customScores: [],
+        maxConcurrency: MAX_CONCURRENCY,
+        trialCount: TRIAL_COUNT,
+      });
     } else {
       // Run the evaluations with the braintrust Eval function
       evalResult = await Eval(braintrustProjectName, {

--- a/evals/index.eval.ts
+++ b/evals/index.eval.ts
@@ -34,7 +34,7 @@ import Plato from "plato-cli";
 
 dotenv.config();
 
-const MAX_CONCURRENCY = 20;
+const MAX_CONCURRENCY = 5;
 const TRIAL_COUNT = 1;
 
 const USE_PLATO = true;

--- a/evals/index.eval.ts
+++ b/evals/index.eval.ts
@@ -35,7 +35,7 @@ import Plato from "plato-cli";
 dotenv.config();
 
 const MAX_CONCURRENCY = 20;
-const TRIAL_COUNT = 1;
+const TRIAL_COUNT = 5;
 
 /**
  * generateSummary:

--- a/evals/index.eval.ts
+++ b/evals/index.eval.ts
@@ -35,7 +35,7 @@ import Plato from "plato-cli";
 dotenv.config();
 
 const MAX_CONCURRENCY = 20;
-const TRIAL_COUNT = 2;
+const TRIAL_COUNT = 1;
 
 const USE_PLATO = true;
 
@@ -314,6 +314,7 @@ const generateFilteredTestcases = (): Testcase[] => {
 
     // Generate and write the summary
     await generateSummary(summaryResults, experimentName);
+    process.exit(0);
   } catch (error) {
     console.error("Error during evaluation run:", error);
     process.exit(1);

--- a/evals/index.eval.ts
+++ b/evals/index.eval.ts
@@ -264,27 +264,23 @@ const generateFilteredTestcases = (): Testcase[] => {
 
   try {
     if (USE_PLATO) {
-      evalResult = await Plato.Eval(
-        braintrustProjectName,
-        {
-          name: experimentName,
-          data: generateFilteredTestcases().map((t) => ({
-            ...t,
-            prompt: t.name,
-          })),
-          task: async (input, simulatorSession) => {
-            const result = await runTask(input.input, {
-              env: "REMOTE",
-              cdpUrl: simulatorSession.cdpUrl,
-            });
-            return result;
-          },
-          customScores: [],
-          maxConcurrency: MAX_CONCURRENCY,
-          trialCount: TRIAL_COUNT,
+      evalResult = await Plato.Eval(braintrustProjectName, {
+        name: experimentName,
+        data: generateFilteredTestcases().map((t) => ({
+          ...t,
+          prompt: t.name,
+        })),
+        task: async (input, simulatorSession) => {
+          const result = await runTask(input.input, {
+            env: "REMOTE",
+            cdpUrl: simulatorSession.cdpUrl,
+          });
+          return result;
         },
-        { baseUrl: "http://localhost:25565" },
-      );
+        customScores: [],
+        maxConcurrency: MAX_CONCURRENCY,
+        trialCount: TRIAL_COUNT,
+      });
     } else {
       // Run the evaluations with the braintrust Eval function
       evalResult = await Eval(braintrustProjectName, {

--- a/evals/scoring.ts
+++ b/evals/scoring.ts
@@ -2,7 +2,7 @@
  * This file implements scoring functions needed by braintrust.
  */
 
-import { EvalArgs, EvalInput, EvalResult } from "@/types/evals";
+import { EvalArgs, EvalResult, Testcase } from "@/types/evals";
 
 /**
  * Scoring function: exactMatch
@@ -13,10 +13,10 @@ import { EvalArgs, EvalInput, EvalResult } from "@/types/evals";
  * If "expected" is a boolean or an object with _success flag,
  * it checks if output is exactly that success condition.
  */
-export function exactMatch(
-  args: EvalArgs<EvalInput, boolean | { _success: boolean }, unknown>,
-): EvalResult {
-  console.log(`Task "${args.input.name}" returned: ${args.output}`);
+export async function exactMatch(
+  args: EvalArgs<Testcase, boolean | { _success: boolean }, unknown>,
+): Promise<EvalResult> {
+  console.log(`Task "${args.input.input.name}" returned: ${args.output}`);
 
   const expected = args.expected ?? true;
   if (expected === true) {
@@ -44,22 +44,22 @@ export function exactMatch(
 /**
  * Scoring function: errorMatch
  * Determines if an error occurred in the task.
- * Scores 1 if an error is found, otherwise 0.
+ * Scores 0 if an error is found, otherwise 1.
  */
-export function errorMatch(
+export async function errorMatch(
   args: EvalArgs<
-    EvalInput,
+    Testcase,
     boolean | { _success: boolean; error?: unknown },
     unknown
   >,
-): EvalResult {
-  console.log(`Task "${args.input.name}" returned: ${args.output}`);
+): Promise<EvalResult> {
+  console.log(`Task "${args.input.input.name}" returned: ${args.output}`);
 
   return {
     name: "Error rate",
     score:
       typeof args.output === "object" && args.output.error !== undefined
-        ? 1
-        : 0,
+        ? 0
+        : 1,
   };
 }

--- a/evals/taskConfig.ts
+++ b/evals/taskConfig.ts
@@ -23,13 +23,25 @@ const config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
  * The `tasksConfig` defines all tasks from the config file. Each task has a name and categories.
  * We create a mapping `tasksByName` from task name to its categories for quick lookup.
  */
-type TaskConfig = { name: string; categories: string[] };
+type TaskConfig = {
+  name: string;
+  categories: string[];
+  startUrl?: string;
+  description?: string;
+};
 const tasksConfig = config.tasks as TaskConfig[];
 
 const tasksByName = tasksConfig.reduce<
-  Record<string, { categories: string[] }>
+  Record<
+    string,
+    { categories: string[]; startUrl?: string; description?: string }
+  >
 >((acc, task) => {
-  acc[task.name] = { categories: task.categories };
+  acc[task.name] = {
+    categories: task.categories,
+    startUrl: task.startUrl,
+    description: task.description,
+  };
   return acc;
 }, {});
 

--- a/evals/tasks/allrecipes.ts
+++ b/evals/tasks/allrecipes.ts
@@ -6,10 +6,27 @@ export const allrecipes: EvalFunction = async ({
   modelName,
   logger,
   useTextExtract,
+  plato,
 }) => {
+  const platoSim = await plato.startSimulationSession({
+    name: "allrecipes",
+    prompt: "Search for 'chocolate chip cookies' using the search bar",
+    startUrl: "https://www.allrecipes.com/",
+    outputSchema: z.object({
+      title: z.string().describe("Title of the recipe"),
+      total_ratings: z
+        .string()
+        .describe("Total number of ratings for the recipe"),
+    }),
+  });
+
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      cdpUrl: platoSim.cdpUrl,
+      env: "REMOTE",
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/allrecipes.ts
+++ b/evals/tasks/allrecipes.ts
@@ -1,23 +1,12 @@
-import { initStagehand } from "@/evals/initStagehand";
 import { EvalFunction } from "@/types/evals";
 import { z } from "zod";
 
 export const allrecipes: EvalFunction = async ({
-  modelName,
+  stagehand,
   logger,
+  modelName,
   useTextExtract,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   await stagehand.page.goto("https://www.allrecipes.com/", {
     waitUntil: "domcontentloaded",
   });
@@ -82,8 +71,6 @@ export const allrecipes: EvalFunction = async ({
       _success: false,
       error: "Recipe details extraction validation failed",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
@@ -94,7 +81,5 @@ export const allrecipes: EvalFunction = async ({
       total_ratings: extractedRatings,
     },
     logs: logger.getLogs(),
-    debugUrl,
-    sessionUrl,
   };
 };

--- a/evals/tasks/allrecipes.ts
+++ b/evals/tasks/allrecipes.ts
@@ -6,26 +6,13 @@ export const allrecipes: EvalFunction = async ({
   modelName,
   logger,
   useTextExtract,
-  plato,
+  configOverrides,
 }) => {
-  const platoSim = await plato.startSimulationSession({
-    name: "allrecipes",
-    prompt: "Search for 'chocolate chip cookies' using the search bar",
-    startUrl: "https://www.allrecipes.com/",
-    outputSchema: z.object({
-      title: z.string().describe("Title of the recipe"),
-      total_ratings: z
-        .string()
-        .describe("Total number of ratings for the recipe"),
-    }),
-  });
-
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
     configOverrides: {
-      cdpUrl: platoSim.cdpUrl,
-      env: "REMOTE",
+      ...configOverrides,
     },
   });
 

--- a/evals/tasks/amazon_add_to_cart.ts
+++ b/evals/tasks/amazon_add_to_cart.ts
@@ -36,11 +36,6 @@ export const amazon_add_to_cart: EvalFunction = async ({
   const currentUrl = stagehand.page.url();
   const expectedUrlPrefix = "https://www.amazon.com/ap/signin";
 
-  // close all pages
-  await stagehand.context.pages().forEach(async (page) => {
-    await page.close();
-  });
-
   await stagehand.close();
 
   return {

--- a/evals/tasks/amazon_add_to_cart.ts
+++ b/evals/tasks/amazon_add_to_cart.ts
@@ -1,21 +1,9 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
 
 export const amazon_add_to_cart: EvalFunction = async ({
-  modelName,
   logger,
-  configOverrides,
+  stagehand,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   await stagehand.page.goto(
     "https://www.amazon.com/Laptop-MacBook-Surface-Water-Resistant-Accessories/dp/B0D5M4H5CD",
   );
@@ -41,8 +29,6 @@ export const amazon_add_to_cart: EvalFunction = async ({
   return {
     _success: currentUrl.startsWith(expectedUrlPrefix),
     currentUrl,
-    debugUrl,
-    sessionUrl,
     logs: logger.getLogs(),
   };
 };

--- a/evals/tasks/amazon_add_to_cart.ts
+++ b/evals/tasks/amazon_add_to_cart.ts
@@ -1,27 +1,16 @@
 import { EvalFunction } from "@/types/evals";
 import { initStagehand } from "@/evals/initStagehand";
-import { z } from "zod";
 
 export const amazon_add_to_cart: EvalFunction = async ({
   modelName,
   logger,
-  plato,
+  configOverrides,
 }) => {
-  const platoSim = await plato.startSimulationSession({
-    name: "amazon_add_to_cart",
-    prompt: "Add a MacBook to the cart",
-    startUrl: "https://www.amazon.com/",
-    outputSchema: z.object({
-      success: z.boolean().describe("Whether the action was successful"),
-    }),
-  });
-
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
     configOverrides: {
-      cdpUrl: platoSim.cdpUrl,
-      env: "REMOTE",
+      ...configOverrides,
     },
   });
 

--- a/evals/tasks/apple.ts
+++ b/evals/tasks/apple.ts
@@ -1,21 +1,6 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
 
-export const apple: EvalFunction = async ({
-  modelName,
-  logger,
-  configOverrides,
-}) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
+export const apple: EvalFunction = async ({ stagehand, logger }) => {
   await stagehand.page.goto("https://www.apple.com/iphone-16-pro/");
 
   await stagehand.page.act({ action: "click on the buy button" });
@@ -42,8 +27,6 @@ export const apple: EvalFunction = async ({
 
   return {
     _success: isVisible,
-    debugUrl,
-    sessionUrl,
     logs: logger.getLogs(),
   };
 };

--- a/evals/tasks/apple.ts
+++ b/evals/tasks/apple.ts
@@ -1,10 +1,17 @@
 import { EvalFunction } from "@/types/evals";
 import { initStagehand } from "@/evals/initStagehand";
 
-export const apple: EvalFunction = async ({ modelName, logger }) => {
+export const apple: EvalFunction = async ({
+  modelName,
+  logger,
+  configOverrides,
+}) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/arxiv.ts
+++ b/evals/tasks/arxiv.ts
@@ -6,10 +6,14 @@ export const arxiv: EvalFunction = async ({
   modelName,
   logger,
   useTextExtract,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/arxiv.ts
+++ b/evals/tasks/arxiv.ts
@@ -1,23 +1,12 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
 import { z } from "zod";
 
 export const arxiv: EvalFunction = async ({
+  stagehand,
   modelName,
   logger,
   useTextExtract,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   try {
     await stagehand.page.goto("https://arxiv.org/search/");
 
@@ -51,8 +40,6 @@ export const arxiv: EvalFunction = async ({
       return {
         _success: false,
         logs: logger.getLogs(),
-        debugUrl,
-        sessionUrl,
       };
     }
 
@@ -113,8 +100,6 @@ export const arxiv: EvalFunction = async ({
       return {
         _success: false,
         logs: logger.getLogs(),
-        debugUrl,
-        sessionUrl,
       };
     }
 
@@ -140,8 +125,6 @@ export const arxiv: EvalFunction = async ({
         _success: false,
         error: "Incorrect number of papers extracted",
         logs: logger.getLogs(),
-        debugUrl,
-        sessionUrl,
       };
     }
 
@@ -165,8 +148,6 @@ export const arxiv: EvalFunction = async ({
           _success: false,
           error: "Incomplete paper information",
           logs: logger.getLogs(),
-          debugUrl,
-          sessionUrl,
         };
       }
     }
@@ -177,8 +158,6 @@ export const arxiv: EvalFunction = async ({
       _success: true,
       papers,
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   } catch (error) {
     logger.error({
@@ -201,8 +180,6 @@ export const arxiv: EvalFunction = async ({
     return {
       _success: false,
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 };

--- a/evals/tasks/bidnet.ts
+++ b/evals/tasks/bidnet.ts
@@ -1,10 +1,17 @@
 import { initStagehand } from "@/evals/initStagehand";
 import { EvalFunction } from "@/types/evals";
 
-export const bidnet: EvalFunction = async ({ modelName, logger }) => {
+export const bidnet: EvalFunction = async ({
+  modelName,
+  logger,
+  configOverrides,
+}) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/bidnet.ts
+++ b/evals/tasks/bidnet.ts
@@ -1,21 +1,6 @@
-import { initStagehand } from "@/evals/initStagehand";
 import { EvalFunction } from "@/types/evals";
 
-export const bidnet: EvalFunction = async ({
-  modelName,
-  logger,
-  configOverrides,
-}) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
+export const bidnet: EvalFunction = async ({ stagehand, logger }) => {
   await stagehand.page.goto("https://www.bidnetdirect.com/");
 
   await stagehand.page.act({
@@ -31,8 +16,6 @@ export const bidnet: EvalFunction = async ({
   return {
     _success: currentUrl.startsWith(expectedUrl),
     currentUrl,
-    debugUrl,
-    sessionUrl,
     logs: logger.getLogs(),
   };
 };

--- a/evals/tasks/combination_sauce.ts
+++ b/evals/tasks/combination_sauce.ts
@@ -1,23 +1,12 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
 import { z } from "zod";
 
 export const combination_sauce: EvalFunction = async ({
+  stagehand,
   modelName,
   logger,
   useTextExtract,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   try {
     await stagehand.page.goto("https://www.saucedemo.com/");
 
@@ -60,8 +49,6 @@ export const combination_sauce: EvalFunction = async ({
 
     return {
       _success: usernamesCheck && urlCheck && observationsCheck,
-      debugUrl,
-      sessionUrl,
       logs: logger.getLogs(),
     };
   } catch (error) {
@@ -72,8 +59,6 @@ export const combination_sauce: EvalFunction = async ({
     return {
       _success: false,
       error: JSON.parse(JSON.stringify(error, null, 2)),
-      debugUrl,
-      sessionUrl,
       logs: logger.getLogs(),
     };
   }

--- a/evals/tasks/combination_sauce.ts
+++ b/evals/tasks/combination_sauce.ts
@@ -6,10 +6,14 @@ export const combination_sauce: EvalFunction = async ({
   modelName,
   logger,
   useTextExtract,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/costar.ts
+++ b/evals/tasks/costar.ts
@@ -1,22 +1,12 @@
-import { initStagehand } from "@/evals/initStagehand";
 import { EvalFunction } from "@/types/evals";
 import { z } from "zod";
 
 export const costar: EvalFunction = async ({
+  stagehand,
   modelName,
   logger,
   useTextExtract,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
   // TODO: fix this eval - does not work in headless mode
   try {
     await Promise.race([
@@ -61,8 +51,6 @@ export const costar: EvalFunction = async ({
     return {
       title: articleTitle.title,
       _success: isTitleValid,
-      debugUrl,
-      sessionUrl,
       logs: logger.getLogs(),
     };
   } catch (error) {
@@ -86,8 +74,6 @@ export const costar: EvalFunction = async ({
     return {
       title: null,
       _success: false,
-      debugUrl,
-      sessionUrl,
       logs: logger.getLogs(),
     };
   }

--- a/evals/tasks/costar.ts
+++ b/evals/tasks/costar.ts
@@ -6,10 +6,14 @@ export const costar: EvalFunction = async ({
   modelName,
   logger,
   useTextExtract,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/expedia.ts
+++ b/evals/tasks/expedia.ts
@@ -1,10 +1,17 @@
 import { EvalFunction } from "@/types/evals";
 import { initStagehand } from "@/evals/initStagehand";
 
-export const expedia: EvalFunction = async ({ modelName, logger }) => {
+export const expedia: EvalFunction = async ({
+  modelName,
+  logger,
+  configOverrides,
+}) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/expedia.ts
+++ b/evals/tasks/expedia.ts
@@ -1,21 +1,6 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
 
-export const expedia: EvalFunction = async ({
-  modelName,
-  logger,
-  configOverrides,
-}) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
+export const expedia: EvalFunction = async ({ stagehand, logger }) => {
   try {
     await stagehand.page.goto("https://www.expedia.com/flights");
     await stagehand.page.act(
@@ -30,8 +15,6 @@ export const expedia: EvalFunction = async ({
     return {
       _success: url.startsWith("https://www.expedia.com/Checkout/"),
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   } catch (error) {
     logger.error({
@@ -46,8 +29,6 @@ export const expedia: EvalFunction = async ({
     return {
       _success: false,
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   } finally {
     await stagehand.close();

--- a/evals/tasks/expedia_search.ts
+++ b/evals/tasks/expedia_search.ts
@@ -1,10 +1,17 @@
 import { initStagehand } from "@/evals/initStagehand";
 import { EvalFunction } from "@/types/evals";
 
-export const expedia_search: EvalFunction = async ({ modelName, logger }) => {
+export const expedia_search: EvalFunction = async ({
+  modelName,
+  logger,
+  configOverrides,
+}) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/expedia_search.ts
+++ b/evals/tasks/expedia_search.ts
@@ -1,21 +1,6 @@
-import { initStagehand } from "@/evals/initStagehand";
 import { EvalFunction } from "@/types/evals";
 
-export const expedia_search: EvalFunction = async ({
-  modelName,
-  logger,
-  configOverrides,
-}) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
+export const expedia_search: EvalFunction = async ({ stagehand, logger }) => {
   try {
     await stagehand.page.goto("https://www.expedia.com/flights");
 
@@ -38,8 +23,6 @@ export const expedia_search: EvalFunction = async ({
     return {
       _success: url.startsWith("https://www.expedia.com/Checkout/"),
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   } catch (error) {
     logger.error({
@@ -59,8 +42,6 @@ export const expedia_search: EvalFunction = async ({
     return {
       _success: false,
       error: JSON.parse(JSON.stringify(error, null, 2)),
-      debugUrl,
-      sessionUrl,
       logs: logger.getLogs(),
     };
   } finally {

--- a/evals/tasks/extract_aigrant_companies.ts
+++ b/evals/tasks/extract_aigrant_companies.ts
@@ -1,24 +1,13 @@
 import { z } from "zod";
-import { initStagehand } from "@/evals/initStagehand";
+
 import { EvalFunction } from "@/types/evals";
 
 export const extract_aigrant_companies: EvalFunction = async ({
+  stagehand,
   modelName,
   logger,
   useTextExtract,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    domSettleTimeoutMs: 3000,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   await stagehand.page.goto("https://aigrant.com/");
   const companyList = await stagehand.page.extract({
     instruction:
@@ -68,8 +57,6 @@ export const extract_aigrant_companies: EvalFunction = async ({
       _success: false,
       error: "Incorrect number of companies extracted",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
   const firstItemMatches =
@@ -95,8 +82,6 @@ export const extract_aigrant_companies: EvalFunction = async ({
       _success: false,
       error: "First company extracted does not match expected",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
@@ -123,15 +108,11 @@ export const extract_aigrant_companies: EvalFunction = async ({
       _success: false,
       error: "Last company extracted does not match expected",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
   return {
     _success: true,
     logs: logger.getLogs(),
-    debugUrl,
-    sessionUrl,
   };
 };

--- a/evals/tasks/extract_aigrant_companies.ts
+++ b/evals/tasks/extract_aigrant_companies.ts
@@ -6,11 +6,15 @@ export const extract_aigrant_companies: EvalFunction = async ({
   modelName,
   logger,
   useTextExtract,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
     domSettleTimeoutMs: 3000,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/extract_apartments.ts
+++ b/evals/tasks/extract_apartments.ts
@@ -1,24 +1,12 @@
 import { z } from "zod";
-import { initStagehand } from "../initStagehand";
 import { EvalFunction } from "../../types/evals";
 
 export const extract_apartments: EvalFunction = async ({
+  stagehand,
   modelName,
   logger,
   useTextExtract,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    domSettleTimeoutMs: 3000,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   await stagehand.page.goto(
     "https://www.apartments.com/san-francisco-ca/2-bedrooms/",
   );
@@ -60,15 +48,11 @@ export const extract_apartments: EvalFunction = async ({
       _success: false,
       error: "Incorrect number of listings extracted",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
   return {
     _success: true,
     logs: logger.getLogs(),
-    debugUrl,
-    sessionUrl,
   };
 };

--- a/evals/tasks/extract_apartments.ts
+++ b/evals/tasks/extract_apartments.ts
@@ -6,11 +6,15 @@ export const extract_apartments: EvalFunction = async ({
   modelName,
   logger,
   useTextExtract,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
     domSettleTimeoutMs: 3000,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/extract_area_codes.ts
+++ b/evals/tasks/extract_area_codes.ts
@@ -1,23 +1,13 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
+
 import { z } from "zod";
 
 export const extract_area_codes: EvalFunction = async ({
+  stagehand,
   modelName,
   logger,
   useTextExtract,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   await stagehand.init();
   await stagehand.page.goto(
     "https://www.ncc.gov.ng/technical-regulation/standards/numbering#area-codes-by-zone-primary-centre",
@@ -88,8 +78,6 @@ export const extract_area_codes: EvalFunction = async ({
       _success: false,
       error: "Incorrect number of primary centers extracted",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
   const firstItemMatches =
@@ -117,8 +105,6 @@ export const extract_area_codes: EvalFunction = async ({
       _success: false,
       error: "First primary center extracted does not match expected",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
@@ -151,15 +137,11 @@ export const extract_area_codes: EvalFunction = async ({
       _success: false,
       error: "Last primary center extracted does not match expected",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
   return {
     _success: true,
     logs: logger.getLogs(),
-    debugUrl,
-    sessionUrl,
   };
 };

--- a/evals/tasks/extract_area_codes.ts
+++ b/evals/tasks/extract_area_codes.ts
@@ -6,10 +6,14 @@ export const extract_area_codes: EvalFunction = async ({
   modelName,
   logger,
   useTextExtract,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/extract_baptist_health.ts
+++ b/evals/tasks/extract_baptist_health.ts
@@ -7,10 +7,14 @@ export const extract_baptist_health: EvalFunction = async ({
   modelName,
   logger,
   useTextExtract,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/extract_baptist_health.ts
+++ b/evals/tasks/extract_baptist_health.ts
@@ -1,24 +1,14 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
+
 import { compareStrings } from "@/evals/utils";
 import { z } from "zod";
 
 export const extract_baptist_health: EvalFunction = async ({
+  stagehand,
   modelName,
   logger,
   useTextExtract,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   await stagehand.page.goto(
     "https://www.baptistfirst.org/location/baptist-health-ent-partners",
   );
@@ -94,8 +84,7 @@ export const extract_baptist_health: EvalFunction = async ({
       _success: false,
       error: "Some fields did not meet similarity threshold",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
+
       failedFields,
     };
   }
@@ -103,7 +92,5 @@ export const extract_baptist_health: EvalFunction = async ({
   return {
     _success: true,
     logs: logger.getLogs(),
-    debugUrl,
-    sessionUrl,
   };
 };

--- a/evals/tasks/extract_capacitor_info.ts
+++ b/evals/tasks/extract_capacitor_info.ts
@@ -1,24 +1,13 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
 import { normalizeString } from "@/evals/utils";
 import { z } from "zod";
 
 export const extract_capacitor_info: EvalFunction = async ({
+  stagehand,
   modelName,
   logger,
   useTextExtract,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   await stagehand.page.goto(
     "https://www.jakelectronics.com/productdetail/panasonicelectroniccomponents-eeufm1a472l-2937406",
   );
@@ -63,14 +52,12 @@ export const extract_capacitor_info: EvalFunction = async ({
       _success: false,
       error: "ECCN code extracted does not match expected",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
   if (normalizeString(RoHS_Status) !== normalizeString(expected.RoHS_Status)) {
     logger.error({
-      message: "RoHS Status extracted does not match expected",
+      message: "RoHS status extracted does not match expected",
       level: 0,
       auxiliary: {
         expected: {
@@ -85,10 +72,8 @@ export const extract_capacitor_info: EvalFunction = async ({
     });
     return {
       _success: false,
-      error: "RoHS Status extracted does not match expected",
+      error: "RoHS status extracted does not match expected",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
@@ -111,15 +96,11 @@ export const extract_capacitor_info: EvalFunction = async ({
       _success: false,
       error: "Impedance extracted does not match expected",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
   return {
     _success: true,
     logs: logger.getLogs(),
-    debugUrl,
-    sessionUrl,
   };
 };

--- a/evals/tasks/extract_capacitor_info.ts
+++ b/evals/tasks/extract_capacitor_info.ts
@@ -7,10 +7,14 @@ export const extract_capacitor_info: EvalFunction = async ({
   modelName,
   logger,
   useTextExtract,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/extract_collaborators.ts
+++ b/evals/tasks/extract_collaborators.ts
@@ -1,23 +1,12 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
 import { z } from "zod";
 
 export const extract_collaborators: EvalFunction = async ({
+  stagehand,
   modelName,
   logger,
   useTextExtract,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   try {
     await stagehand.page.goto("https://github.com/facebook/react");
     await stagehand.page.act({
@@ -45,8 +34,6 @@ export const extract_collaborators: EvalFunction = async ({
     return {
       _success: contributors.length === 20,
       contributors,
-      debugUrl,
-      sessionUrl,
       logs: logger.getLogs(),
     };
   } catch (error) {
@@ -57,8 +44,6 @@ export const extract_collaborators: EvalFunction = async ({
     return {
       _success: false,
       error: JSON.parse(JSON.stringify(error, null, 2)),
-      debugUrl,
-      sessionUrl,
       logs: logger.getLogs(),
     };
   }

--- a/evals/tasks/extract_collaborators.ts
+++ b/evals/tasks/extract_collaborators.ts
@@ -6,10 +6,14 @@ export const extract_collaborators: EvalFunction = async ({
   modelName,
   logger,
   useTextExtract,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/extract_csa.ts
+++ b/evals/tasks/extract_csa.ts
@@ -6,10 +6,14 @@ export const extract_csa: EvalFunction = async ({
   modelName,
   logger,
   useTextExtract,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/extract_csa.ts
+++ b/evals/tasks/extract_csa.ts
@@ -1,23 +1,12 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
 import { z } from "zod";
 
 export const extract_csa: EvalFunction = async ({
+  stagehand,
   modelName,
   logger,
   useTextExtract,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   const { page } = stagehand;
   await page.goto(
     "https://clerk.assembly.ca.gov/weekly-histories?from_date=&to_date=2025-01-09",
@@ -79,8 +68,6 @@ export const extract_csa: EvalFunction = async ({
       _success: false,
       error: "Incorrect number of publications extracted",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
@@ -112,8 +99,6 @@ export const extract_csa: EvalFunction = async ({
       _success: false,
       error: "Expected 'first' item not found in publications",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
@@ -145,15 +130,11 @@ export const extract_csa: EvalFunction = async ({
       _success: false,
       error: "Expected 'last' item not found in publications",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
   return {
     _success: true,
     logs: logger.getLogs(),
-    debugUrl,
-    sessionUrl,
   };
 };

--- a/evals/tasks/extract_github_commits.ts
+++ b/evals/tasks/extract_github_commits.ts
@@ -1,23 +1,12 @@
-import { initStagehand } from "@/evals/initStagehand";
 import { EvalFunction } from "@/types/evals";
 import { z } from "zod";
 
 export const extract_github_commits: EvalFunction = async ({
+  stagehand,
   modelName,
   logger,
   useTextExtract,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   try {
     await stagehand.page.goto("https://github.com/facebook/react");
 
@@ -56,8 +45,6 @@ export const extract_github_commits: EvalFunction = async ({
     return {
       _success: commits.length === 20,
       commits,
-      debugUrl,
-      sessionUrl,
       logs: logger.getLogs(),
     };
   } catch (error) {
@@ -68,8 +55,6 @@ export const extract_github_commits: EvalFunction = async ({
     return {
       _success: false,
       error: JSON.parse(JSON.stringify(error, null, 2)),
-      debugUrl,
-      sessionUrl,
       logs: logger.getLogs(),
     };
   }

--- a/evals/tasks/extract_github_commits.ts
+++ b/evals/tasks/extract_github_commits.ts
@@ -6,10 +6,14 @@ export const extract_github_commits: EvalFunction = async ({
   modelName,
   logger,
   useTextExtract,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/extract_github_stars.ts
+++ b/evals/tasks/extract_github_stars.ts
@@ -1,23 +1,12 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
 import { z } from "zod";
 
 export const extract_github_stars: EvalFunction = async ({
+  stagehand,
   modelName,
   logger,
   useTextExtract,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   try {
     await stagehand.page.goto("https://github.com/facebook/react");
 
@@ -47,8 +36,6 @@ export const extract_github_stars: EvalFunction = async ({
     return {
       _success: isWithinTolerance,
       stars,
-      debugUrl,
-      sessionUrl,
       logs: logger.getLogs(),
     };
   } catch (error) {
@@ -59,8 +46,6 @@ export const extract_github_stars: EvalFunction = async ({
     return {
       _success: false,
       error: JSON.parse(JSON.stringify(error, null, 2)),
-      debugUrl,
-      sessionUrl,
       logs: logger.getLogs(),
     };
   }

--- a/evals/tasks/extract_github_stars.ts
+++ b/evals/tasks/extract_github_stars.ts
@@ -6,10 +6,14 @@ export const extract_github_stars: EvalFunction = async ({
   modelName,
   logger,
   useTextExtract,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/extract_jstor_news.ts
+++ b/evals/tasks/extract_jstor_news.ts
@@ -1,23 +1,12 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
 import { z } from "zod";
 
 export const extract_jstor_news: EvalFunction = async ({
+  stagehand,
   modelName,
   logger,
   useTextExtract,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   await stagehand.init();
   await stagehand.page.goto("http://jstor-eval.surge.sh", {
     waitUntil: "load",
@@ -76,8 +65,6 @@ export const extract_jstor_news: EvalFunction = async ({
       _success: false,
       error: "Incorrect number of reports extracted",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
   const firstItemMatches =
@@ -103,8 +90,6 @@ export const extract_jstor_news: EvalFunction = async ({
       _success: false,
       error: "First report extracted does not match expected",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
@@ -131,15 +116,11 @@ export const extract_jstor_news: EvalFunction = async ({
       _success: false,
       error: "Last report extracted does not match expected",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
   return {
     _success: true,
     logs: logger.getLogs(),
-    debugUrl,
-    sessionUrl,
   };
 };

--- a/evals/tasks/extract_jstor_news.ts
+++ b/evals/tasks/extract_jstor_news.ts
@@ -6,10 +6,14 @@ export const extract_jstor_news: EvalFunction = async ({
   modelName,
   logger,
   useTextExtract,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/extract_memorial_healthcare.ts
+++ b/evals/tasks/extract_memorial_healthcare.ts
@@ -7,11 +7,15 @@ export const extract_memorial_healthcare: EvalFunction = async ({
   modelName,
   logger,
   useTextExtract,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
     domSettleTimeoutMs: 3000,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/extract_memorial_healthcare.ts
+++ b/evals/tasks/extract_memorial_healthcare.ts
@@ -1,25 +1,13 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
 import { z } from "zod";
 import { compareStrings } from "@/evals/utils";
 
 export const extract_memorial_healthcare: EvalFunction = async ({
+  stagehand,
   modelName,
   logger,
   useTextExtract,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    domSettleTimeoutMs: 3000,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   await stagehand.page.goto("https://www.mycmh.org/locations/");
 
   const result = await stagehand.page.extract({
@@ -79,8 +67,6 @@ export const extract_memorial_healthcare: EvalFunction = async ({
       _success: false,
       error: "Incorrect number of health centers extracted",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
@@ -113,8 +99,6 @@ export const extract_memorial_healthcare: EvalFunction = async ({
       _success: false,
       error: "One or more health centers have missing fields",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
@@ -181,15 +165,11 @@ export const extract_memorial_healthcare: EvalFunction = async ({
       _success: false,
       error: "One or more fields do not match expected values",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
   return {
     _success: true,
     logs: logger.getLogs(),
-    debugUrl,
-    sessionUrl,
   };
 };

--- a/evals/tasks/extract_nhl_stats.ts
+++ b/evals/tasks/extract_nhl_stats.ts
@@ -7,11 +7,15 @@ export const extract_nhl_stats: EvalFunction = async ({
   modelName,
   logger,
   useTextExtract,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
     domSettleTimeoutMs: 4000,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/extract_nhl_stats.ts
+++ b/evals/tasks/extract_nhl_stats.ts
@@ -1,25 +1,13 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
 import { normalizeString } from "@/evals/utils";
 import { z } from "zod";
 
 export const extract_nhl_stats: EvalFunction = async ({
+  stagehand,
   modelName,
   logger,
   useTextExtract,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    domSettleTimeoutMs: 4000,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   await stagehand.page.goto(
     "https://www.hockeydb.com/ihdb/stats/top_league.php?lid=nhl1927&sid=1990",
     {
@@ -68,8 +56,6 @@ export const extract_nhl_stats: EvalFunction = async ({
       _success: false,
       error: "Player name extracted does not match expected",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
@@ -92,8 +78,6 @@ export const extract_nhl_stats: EvalFunction = async ({
       _success: false,
       error: "Number of goals extracted does not match expected",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
@@ -116,15 +100,11 @@ export const extract_nhl_stats: EvalFunction = async ({
       _success: false,
       error: "Player team extracted does not match expected",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
   return {
     _success: true,
     logs: logger.getLogs(),
-    debugUrl,
-    sessionUrl,
   };
 };

--- a/evals/tasks/extract_partners.ts
+++ b/evals/tasks/extract_partners.ts
@@ -6,10 +6,14 @@ export const extract_partners: EvalFunction = async ({
   modelName,
   logger,
   useTextExtract,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/extract_partners.ts
+++ b/evals/tasks/extract_partners.ts
@@ -1,23 +1,12 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
 import { z } from "zod";
 
 export const extract_partners: EvalFunction = async ({
+  stagehand,
   modelName,
   logger,
   useTextExtract,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   try {
     await stagehand.page.goto("https://ramp.com");
 
@@ -72,8 +61,6 @@ export const extract_partners: EvalFunction = async ({
     return {
       _success: allExpectedPartnersFound,
       partners,
-      debugUrl,
-      sessionUrl,
       logs: logger.getLogs(),
     };
   } catch (error) {
@@ -96,8 +83,6 @@ export const extract_partners: EvalFunction = async ({
 
     return {
       _success: false,
-      debugUrl,
-      sessionUrl,
       error: JSON.parse(JSON.stringify(error, null, 2)),
       logs: logger.getLogs(),
     };

--- a/evals/tasks/extract_press_releases.ts
+++ b/evals/tasks/extract_press_releases.ts
@@ -7,11 +7,15 @@ export const extract_press_releases: EvalFunction = async ({
   modelName,
   logger,
   useTextExtract,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
     domSettleTimeoutMs: 3000,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/extract_professional_info.ts
+++ b/evals/tasks/extract_professional_info.ts
@@ -7,10 +7,14 @@ export const extract_professional_info: EvalFunction = async ({
   modelName,
   logger,
   useTextExtract,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/extract_professional_info.ts
+++ b/evals/tasks/extract_professional_info.ts
@@ -1,24 +1,14 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
+
 import { normalizeString } from "@/evals/utils";
 import { z } from "zod";
 
 export const extract_professional_info: EvalFunction = async ({
+  stagehand,
   modelName,
   logger,
   useTextExtract,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   await stagehand.page.goto(
     "https://www.paulweiss.com/professionals/partners-and-counsel/brian-bolin",
   );
@@ -71,8 +61,6 @@ export const extract_professional_info: EvalFunction = async ({
       _success: false,
       error: "Practices extracted do not match expected",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
@@ -95,8 +83,6 @@ export const extract_professional_info: EvalFunction = async ({
       _success: false,
       error: "Phone number extracted does not match expected",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
@@ -119,15 +105,11 @@ export const extract_professional_info: EvalFunction = async ({
       _success: false,
       error: "Fax number extracted does not match expected",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
   return {
     _success: true,
     logs: logger.getLogs(),
-    debugUrl,
-    sessionUrl,
   };
 };

--- a/evals/tasks/extract_public_notices.ts
+++ b/evals/tasks/extract_public_notices.ts
@@ -1,24 +1,13 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
 import { z } from "zod";
 import { compareStrings } from "@/evals/utils";
 
 export const extract_public_notices: EvalFunction = async ({
+  stagehand,
   modelName,
   logger,
   useTextExtract,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   await stagehand.init();
   await stagehand.page.goto(
     "https://www.sars.gov.za/legal-counsel/secondary-legislation/public-notices/",
@@ -89,8 +78,6 @@ export const extract_public_notices: EvalFunction = async ({
       _success: false,
       error: "Incorrect number of public notices extracted",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
   const firstItemMatches =
@@ -129,8 +116,6 @@ export const extract_public_notices: EvalFunction = async ({
       _success: false,
       error: "First public notice extracted does not match expected",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
@@ -170,15 +155,11 @@ export const extract_public_notices: EvalFunction = async ({
       _success: false,
       error: "Last public notice extracted does not match expected",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
   return {
     _success: true,
     logs: logger.getLogs(),
-    debugUrl,
-    sessionUrl,
   };
 };

--- a/evals/tasks/extract_public_notices.ts
+++ b/evals/tasks/extract_public_notices.ts
@@ -7,10 +7,14 @@ export const extract_public_notices: EvalFunction = async ({
   modelName,
   logger,
   useTextExtract,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/extract_repo_name.ts
+++ b/evals/tasks/extract_repo_name.ts
@@ -1,21 +1,9 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
 
 export const extract_repo_name: EvalFunction = async ({
-  modelName,
+  stagehand,
   logger,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   try {
     await stagehand.page.goto("https://github.com/facebook/react");
 
@@ -39,8 +27,6 @@ export const extract_repo_name: EvalFunction = async ({
     return {
       _success: extraction === "react",
       extraction,
-      debugUrl,
-      sessionUrl,
       logs: logger.getLogs(),
     };
   } catch (error) {
@@ -51,8 +37,6 @@ export const extract_repo_name: EvalFunction = async ({
     return {
       _success: false,
       error: JSON.parse(JSON.stringify(error, null, 2)),
-      debugUrl,
-      sessionUrl,
       logs: logger.getLogs(),
     };
   }

--- a/evals/tasks/extract_repo_name.ts
+++ b/evals/tasks/extract_repo_name.ts
@@ -4,10 +4,14 @@ import { initStagehand } from "@/evals/initStagehand";
 export const extract_repo_name: EvalFunction = async ({
   modelName,
   logger,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/extract_resistor_info.ts
+++ b/evals/tasks/extract_resistor_info.ts
@@ -1,24 +1,14 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
+
 import { normalizeString } from "@/evals/utils";
 import { z } from "zod";
 
 export const extract_resistor_info: EvalFunction = async ({
+  stagehand,
   modelName,
   logger,
   useTextExtract,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   await stagehand.page.goto("https://www.seielect.com/?stockcheck=ASR1JA330R");
 
   const result = await stagehand.page.extract({
@@ -69,8 +59,6 @@ export const extract_resistor_info: EvalFunction = async ({
       _success: false,
       error: "MOQ extracted does not match expected",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
@@ -96,8 +84,6 @@ export const extract_resistor_info: EvalFunction = async ({
       _success: false,
       error: "Tolerance percentage extracted does not match expected",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
@@ -120,8 +106,6 @@ export const extract_resistor_info: EvalFunction = async ({
       _success: false,
       error: "Ohmic value extracted does not match expected",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
@@ -147,15 +131,11 @@ export const extract_resistor_info: EvalFunction = async ({
       _success: false,
       error: "Operating temperature range extracted does not match expected",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
   return {
     _success: true,
     logs: logger.getLogs(),
-    debugUrl,
-    sessionUrl,
   };
 };

--- a/evals/tasks/extract_resistor_info.ts
+++ b/evals/tasks/extract_resistor_info.ts
@@ -7,10 +7,14 @@ export const extract_resistor_info: EvalFunction = async ({
   modelName,
   logger,
   useTextExtract,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/extract_rockauto.ts
+++ b/evals/tasks/extract_rockauto.ts
@@ -1,24 +1,13 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
+
 import { z } from "zod";
 
 export const extract_rockauto: EvalFunction = async ({
+  stagehand,
   modelName,
   logger,
   useTextExtract,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    domSettleTimeoutMs: 10000,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   await stagehand.page.goto(
     "https://www.rockauto.com/en/catalog/alpine,1974,a310,1.6l+l4,1436055,cooling+system,coolant+/+antifreeze,11393",
   );
@@ -70,8 +59,6 @@ export const extract_rockauto: EvalFunction = async ({
       _success: false,
       error: "Incorrect number of coolant products extracted",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
   const firstItemMatches =
@@ -96,8 +83,6 @@ export const extract_rockauto: EvalFunction = async ({
       _success: false,
       error: "First coolant product extracted does not match expected",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
@@ -124,15 +109,11 @@ export const extract_rockauto: EvalFunction = async ({
       _success: false,
       error: "Last coolant product extracted does not match expected",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
   return {
     _success: true,
     logs: logger.getLogs(),
-    debugUrl,
-    sessionUrl,
   };
 };

--- a/evals/tasks/extract_rockauto.ts
+++ b/evals/tasks/extract_rockauto.ts
@@ -6,11 +6,15 @@ export const extract_rockauto: EvalFunction = async ({
   modelName,
   logger,
   useTextExtract,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
     domSettleTimeoutMs: 10000,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/extract_snowshoeing_destinations.ts
+++ b/evals/tasks/extract_snowshoeing_destinations.ts
@@ -1,46 +1,31 @@
-import { z } from "zod";
-import { initStagehand } from "@/evals/initStagehand";
 import { EvalFunction } from "@/types/evals";
+import { z } from "zod";
 
 export const extract_snowshoeing_destinations: EvalFunction = async ({
+  stagehand,
   modelName,
   logger,
   useTextExtract,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   try {
     await stagehand.page.goto(
-      "https://www.cbisland.com/blog/10-snowshoeing-adventures-on-cape-breton-island/",
+      "https://www.wta.org/go-outside/seasonal-hikes/winter-destinations/sno-parks",
     );
 
-    await stagehand.page.act({ action: "reject the cookies" });
-
-    const snowshoeing_regions = await stagehand.page.extract({
-      instruction:
-        "Extract all the snowshoeing regions and the names of the trails within each region.",
+    const result = await stagehand.page.extract({
+      instruction: "Extract all the snowshoeing destinations",
       schema: z.object({
-        snowshoeing_regions: z.array(
+        destinations: z.array(
           z.object({
-            region_name: z
+            name: z.string().describe("name of the destination"),
+            description: z
               .string()
-              .describe("The name of the snowshoeing region"),
-            trails: z
-              .array(
-                z.object({
-                  trail_name: z.string().describe("The name of the trail"),
-                }),
-              )
-              .describe("The list of trails available in this region."),
+              .describe("description of the destination")
+              .nullable(),
+            region: z
+              .string()
+              .describe("region where the destination is located")
+              .nullable(),
           }),
         ),
       }),
@@ -48,26 +33,33 @@ export const extract_snowshoeing_destinations: EvalFunction = async ({
       useTextExtract,
     });
 
-    logger.log({
-      message: "Extracted destinations and trails",
-      level: 1,
-      auxiliary: {
-        destinations: {
-          value: JSON.stringify(snowshoeing_regions),
-          type: "object",
-        },
-      },
-    });
+    const destinations = result.destinations;
 
-    await stagehand.close();
+    const expectedDestinations = [
+      "Cabin Creek Sno-Park",
+      "Crystal Springs Sno-Park",
+      "Gold Creek Sno-Park",
+      "Hyak Sno-Park",
+      "Lake Easton Sno-Park",
+      "Lake Wenatchee State Park",
+      "Mount Spokane State Park",
+      "Paradise",
+      "Price Creek Sno-Park",
+      "Salmon La Sac Sno-Park",
+      "Skyline Lake",
+      "Swauk Creek",
+      "White Pass",
+    ];
 
-    const _success = snowshoeing_regions.snowshoeing_regions.length === 10;
+    const foundDestinations = destinations.map((d) => d.name);
+
+    const allExpectedDestinationsFound = expectedDestinations.every((d) =>
+      foundDestinations.includes(d),
+    );
 
     return {
-      _success,
-      snowshoeing_regions,
-      debugUrl,
-      sessionUrl,
+      _success: allExpectedDestinationsFound,
+      destinations,
       logs: logger.getLogs(),
     };
   } catch (error) {
@@ -88,8 +80,6 @@ export const extract_snowshoeing_destinations: EvalFunction = async ({
     return {
       _success: false,
       error: JSON.parse(JSON.stringify(error, null, 2)),
-      debugUrl,
-      sessionUrl,
       logs: logger.getLogs(),
     };
   } finally {

--- a/evals/tasks/extract_snowshoeing_destinations.ts
+++ b/evals/tasks/extract_snowshoeing_destinations.ts
@@ -6,10 +6,14 @@ export const extract_snowshoeing_destinations: EvalFunction = async ({
   modelName,
   logger,
   useTextExtract,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/extract_staff_members.ts
+++ b/evals/tasks/extract_staff_members.ts
@@ -1,24 +1,13 @@
 import { z } from "zod";
-import { initStagehand } from "@/evals/initStagehand";
+
 import { EvalFunction } from "@/types/evals";
 
 export const extract_staff_members: EvalFunction = async ({
+  stagehand,
   modelName,
   logger,
   useTextExtract,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    domSettleTimeoutMs: 3000,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   await stagehand.page.goto("https://panamcs-static-site.surge.sh/");
 
   const result = await stagehand.page.extract({
@@ -71,8 +60,6 @@ export const extract_staff_members: EvalFunction = async ({
       _success: false,
       error: "Incorrect number of staff members extracted",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
@@ -105,8 +92,6 @@ export const extract_staff_members: EvalFunction = async ({
       _success: false,
       error: "Expected first staff member not found in extracted data",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
@@ -138,8 +123,6 @@ export const extract_staff_members: EvalFunction = async ({
       _success: false,
       error: "Expected last staff member not found in extracted data",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
@@ -148,7 +131,5 @@ export const extract_staff_members: EvalFunction = async ({
   return {
     _success: true,
     logs: logger.getLogs(),
-    debugUrl,
-    sessionUrl,
   };
 };

--- a/evals/tasks/extract_staff_members.ts
+++ b/evals/tasks/extract_staff_members.ts
@@ -6,11 +6,15 @@ export const extract_staff_members: EvalFunction = async ({
   modelName,
   logger,
   useTextExtract,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
     domSettleTimeoutMs: 3000,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/extract_zillow.ts
+++ b/evals/tasks/extract_zillow.ts
@@ -1,25 +1,12 @@
 import { z } from "zod";
-import { initStagehand } from "../initStagehand";
-import { EvalFunction } from "../../types/evals";
+import { EvalFunction } from "@/types/evals";
 
 export const extract_zillow: EvalFunction = async ({
+  stagehand,
   modelName,
   logger,
   useTextExtract,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    domSettleTimeoutMs: 3000,
-    configOverrides: {
-      debugDom: false,
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   await stagehand.page.goto("https://zillow-eval.surge.sh/");
   // timeout for 5 seconds
   await stagehand.page.waitForTimeout(5000);
@@ -61,15 +48,11 @@ export const extract_zillow: EvalFunction = async ({
       _success: false,
       error: "Incorrect number of listings extracted",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
   return {
     _success: true,
     logs: logger.getLogs(),
-    debugUrl,
-    sessionUrl,
   };
 };

--- a/evals/tasks/extract_zillow.ts
+++ b/evals/tasks/extract_zillow.ts
@@ -6,6 +6,7 @@ export const extract_zillow: EvalFunction = async ({
   modelName,
   logger,
   useTextExtract,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
@@ -13,6 +14,7 @@ export const extract_zillow: EvalFunction = async ({
     domSettleTimeoutMs: 3000,
     configOverrides: {
       debugDom: false,
+      ...configOverrides,
     },
   });
 

--- a/evals/tasks/google_jobs.ts
+++ b/evals/tasks/google_jobs.ts
@@ -1,23 +1,12 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
 import { z } from "zod";
 
 export const google_jobs: EvalFunction = async ({
+  stagehand,
   modelName,
   logger,
   useTextExtract,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   try {
     await stagehand.page.goto("https://www.google.com/");
     await stagehand.page.act("click on the about page");
@@ -74,8 +63,6 @@ export const google_jobs: EvalFunction = async ({
     return {
       _success: isJobDetailsValid,
       jobDetails,
-      debugUrl,
-      sessionUrl,
       logs: logger.getLogs(),
     };
   } catch (error) {
@@ -98,8 +85,6 @@ export const google_jobs: EvalFunction = async ({
 
     return {
       _success: false,
-      debugUrl,
-      sessionUrl,
       error: JSON.parse(JSON.stringify(error, null, 2)),
       logs: logger.getLogs(),
     };

--- a/evals/tasks/google_jobs.ts
+++ b/evals/tasks/google_jobs.ts
@@ -6,10 +6,14 @@ export const google_jobs: EvalFunction = async ({
   modelName,
   logger,
   useTextExtract,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/homedepot.ts
+++ b/evals/tasks/homedepot.ts
@@ -1,24 +1,12 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
 import { z } from "zod";
 
 export const homedepot: EvalFunction = async ({
+  stagehand,
   modelName,
   logger,
   useTextExtract,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    domSettleTimeoutMs: 60_000,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   try {
     await stagehand.page.goto("https://www.homedepot.com/");
     await stagehand.page.act("search for gas grills");
@@ -62,8 +50,6 @@ export const homedepot: EvalFunction = async ({
       return {
         _success: false,
         productSpecs,
-        debugUrl,
-        sessionUrl,
         logs: logger.getLogs(),
       };
     }
@@ -77,8 +63,6 @@ export const homedepot: EvalFunction = async ({
     return {
       _success: hasFourZerosAndOne4,
       productSpecs,
-      debugUrl,
-      sessionUrl,
       logs: logger.getLogs(),
     };
   } catch (error) {
@@ -102,8 +86,6 @@ export const homedepot: EvalFunction = async ({
     return {
       _success: false,
       error: JSON.parse(JSON.stringify(error, null, 2)),
-      debugUrl,
-      sessionUrl,
       logs: logger.getLogs(),
     };
   }

--- a/evals/tasks/homedepot.ts
+++ b/evals/tasks/homedepot.ts
@@ -6,11 +6,15 @@ export const homedepot: EvalFunction = async ({
   modelName,
   logger,
   useTextExtract,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
     domSettleTimeoutMs: 60_000,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/imdb_movie_details.ts
+++ b/evals/tasks/imdb_movie_details.ts
@@ -1,23 +1,13 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
+
 import { z } from "zod";
 
 export const imdb_movie_details: EvalFunction = async ({
+  stagehand,
   modelName,
   logger,
   useTextExtract,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   await stagehand.page.goto("https://www.imdb.com/title/tt0111161/", {
     waitUntil: "domcontentloaded",
   });
@@ -66,8 +56,6 @@ export const imdb_movie_details: EvalFunction = async ({
       _success: false,
       error: "Incorrect number of countries extracted",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
@@ -95,8 +83,6 @@ export const imdb_movie_details: EvalFunction = async ({
       _success: false,
       error: "Extracted countries do not match expected countries",
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   }
 
@@ -104,7 +90,5 @@ export const imdb_movie_details: EvalFunction = async ({
     _success: true,
     countries: movieDetails.countries,
     logs: logger.getLogs(),
-    debugUrl,
-    sessionUrl,
   };
 };

--- a/evals/tasks/imdb_movie_details.ts
+++ b/evals/tasks/imdb_movie_details.ts
@@ -6,10 +6,14 @@ export const imdb_movie_details: EvalFunction = async ({
   modelName,
   logger,
   useTextExtract,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/instructions.ts
+++ b/evals/tasks/instructions.ts
@@ -1,13 +1,18 @@
 import { EvalFunction } from "@/types/evals";
 import { initStagehand } from "@/evals/initStagehand";
 
-export const instructions: EvalFunction = async ({ modelName, logger }) => {
+export const instructions: EvalFunction = async ({
+  modelName,
+  logger,
+  configOverrides,
+}) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
     configOverrides: {
       systemPrompt:
         "if the users says `secret12345`, click on the 'quickstart' tab",
+      ...configOverrides,
     },
   });
 

--- a/evals/tasks/instructions.ts
+++ b/evals/tasks/instructions.ts
@@ -1,23 +1,6 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
 
-export const instructions: EvalFunction = async ({
-  modelName,
-  logger,
-  configOverrides,
-}) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      systemPrompt:
-        "if the users says `secret12345`, click on the 'quickstart' tab",
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
+export const instructions: EvalFunction = async ({ stagehand, logger }) => {
   try {
     const page = stagehand.page;
 
@@ -38,8 +21,6 @@ export const instructions: EvalFunction = async ({
 
     return {
       _success: isCorrectUrl,
-      debugUrl,
-      sessionUrl,
       logs: logger.getLogs(),
     };
   } catch (error) {
@@ -50,8 +31,6 @@ export const instructions: EvalFunction = async ({
     return {
       _success: false,
       error: JSON.parse(JSON.stringify(error, null, 2)),
-      debugUrl,
-      sessionUrl,
       logs: logger.getLogs(),
     };
   }

--- a/evals/tasks/ionwave.ts
+++ b/evals/tasks/ionwave.ts
@@ -1,21 +1,6 @@
-import { initStagehand } from "@/evals/initStagehand";
 import { EvalFunction } from "@/types/evals";
 
-export const ionwave: EvalFunction = async ({
-  modelName,
-  logger,
-  configOverrides,
-}) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
+export const ionwave: EvalFunction = async ({ stagehand, logger }) => {
   await stagehand.page.goto("https://elpasotexas.ionwave.net/Login.aspx");
 
   await stagehand.page.act({
@@ -31,8 +16,6 @@ export const ionwave: EvalFunction = async ({
   return {
     _success: currentUrl.startsWith(expectedUrl),
     currentUrl,
-    debugUrl,
-    sessionUrl,
     logs: logger.getLogs(),
   };
 };

--- a/evals/tasks/ionwave.ts
+++ b/evals/tasks/ionwave.ts
@@ -1,10 +1,17 @@
 import { initStagehand } from "@/evals/initStagehand";
 import { EvalFunction } from "@/types/evals";
 
-export const ionwave: EvalFunction = async ({ modelName, logger }) => {
+export const ionwave: EvalFunction = async ({
+  modelName,
+  logger,
+  configOverrides,
+}) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/ionwave_observe.ts
+++ b/evals/tasks/ionwave_observe.ts
@@ -1,10 +1,17 @@
 import { initStagehand } from "@/evals/initStagehand";
 import { EvalFunction } from "@/types/evals";
 
-export const ionwave_observe: EvalFunction = async ({ modelName, logger }) => {
+export const ionwave_observe: EvalFunction = async ({
+  modelName,
+  logger,
+  configOverrides,
+}) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/ionwave_observe.ts
+++ b/evals/tasks/ionwave_observe.ts
@@ -1,21 +1,6 @@
-import { initStagehand } from "@/evals/initStagehand";
 import { EvalFunction } from "@/types/evals";
 
-export const ionwave_observe: EvalFunction = async ({
-  modelName,
-  logger,
-  configOverrides,
-}) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
+export const ionwave_observe: EvalFunction = async ({ stagehand, logger }) => {
   await stagehand.page.goto("https://elpasotexas.ionwave.net/Login.aspx");
 
   const observations = await stagehand.page.observe({ onlyVisible: true });
@@ -25,8 +10,7 @@ export const ionwave_observe: EvalFunction = async ({
     return {
       _success: false,
       observations,
-      debugUrl,
-      sessionUrl,
+
       logs: logger.getLogs(),
     };
   }
@@ -65,8 +49,7 @@ export const ionwave_observe: EvalFunction = async ({
     _success: foundMatch,
     expected: expectedResult,
     observations,
-    debugUrl,
-    sessionUrl,
+
     logs: logger.getLogs(),
   };
 };

--- a/evals/tasks/laroche_form.ts
+++ b/evals/tasks/laroche_form.ts
@@ -1,21 +1,6 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
 
-export const laroche_form: EvalFunction = async ({
-  modelName,
-  logger,
-  configOverrides,
-}) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
+export const laroche_form: EvalFunction = async ({ stagehand, logger }) => {
   try {
     await stagehand.page.goto(
       "https://www.laroche-posay.us/offers/anthelios-melt-in-milk-sunscreen-sample.html",
@@ -34,8 +19,6 @@ export const laroche_form: EvalFunction = async ({
     return {
       _success: true,
       logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
     };
   } catch (error) {
     logger.error({
@@ -55,8 +38,6 @@ export const laroche_form: EvalFunction = async ({
     return {
       _success: false,
       error: error.message,
-      debugUrl,
-      sessionUrl,
       logs: logger.getLogs(),
     };
   } finally {

--- a/evals/tasks/laroche_form.ts
+++ b/evals/tasks/laroche_form.ts
@@ -1,10 +1,17 @@
 import { EvalFunction } from "@/types/evals";
 import { initStagehand } from "@/evals/initStagehand";
 
-export const laroche_form: EvalFunction = async ({ modelName, logger }) => {
+export const laroche_form: EvalFunction = async ({
+  modelName,
+  logger,
+  configOverrides,
+}) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/nonsense_action.ts
+++ b/evals/tasks/nonsense_action.ts
@@ -1,10 +1,17 @@
 import { initStagehand } from "@/evals/initStagehand";
 import { EvalFunction } from "@/types/evals";
 
-export const nonsense_action: EvalFunction = async ({ modelName, logger }) => {
+export const nonsense_action: EvalFunction = async ({
+  modelName,
+  logger,
+  configOverrides,
+}) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/nonsense_action.ts
+++ b/evals/tasks/nonsense_action.ts
@@ -1,21 +1,6 @@
-import { initStagehand } from "@/evals/initStagehand";
 import { EvalFunction } from "@/types/evals";
 
-export const nonsense_action: EvalFunction = async ({
-  modelName,
-  logger,
-  configOverrides,
-}) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
+export const nonsense_action: EvalFunction = async ({ stagehand, logger }) => {
   try {
     await stagehand.page.goto("https://www.homedepot.com/");
 
@@ -36,8 +21,6 @@ export const nonsense_action: EvalFunction = async ({
 
     return {
       _success: isResultCorrect,
-      debugUrl,
-      sessionUrl,
       logs: logger.getLogs(),
     };
   } catch (error) {
@@ -45,8 +28,6 @@ export const nonsense_action: EvalFunction = async ({
     return {
       _success: false,
       error: JSON.parse(JSON.stringify(error, null, 2)),
-      debugUrl,
-      sessionUrl,
       logs: logger.getLogs(),
     };
   } finally {

--- a/evals/tasks/observe_amazon_add_to_cart.ts
+++ b/evals/tasks/observe_amazon_add_to_cart.ts
@@ -1,22 +1,11 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
+
 import { performPlaywrightMethod } from "@/lib/a11y/utils";
 
 export const observe_amazon_add_to_cart: EvalFunction = async ({
-  modelName,
+  stagehand,
   logger,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   await stagehand.page.goto(
     "https://www.amazon.com/Laptop-MacBook-Surface-Water-Resistant-Accessories/dp/B0D5M4H5CD",
   );
@@ -72,8 +61,7 @@ export const observe_amazon_add_to_cart: EvalFunction = async ({
   return {
     _success: currentUrl.startsWith(expectedUrlPrefix),
     currentUrl,
-    debugUrl,
-    sessionUrl,
+
     logs: logger.getLogs(),
   };
 };

--- a/evals/tasks/observe_amazon_add_to_cart.ts
+++ b/evals/tasks/observe_amazon_add_to_cart.ts
@@ -5,10 +5,14 @@ import { performPlaywrightMethod } from "@/lib/a11y/utils";
 export const observe_amazon_add_to_cart: EvalFunction = async ({
   modelName,
   logger,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/observe_github.ts
+++ b/evals/tasks/observe_github.ts
@@ -1,10 +1,17 @@
 import { initStagehand } from "@/evals/initStagehand";
 import { EvalFunction } from "@/types/evals";
 
-export const observe_github: EvalFunction = async ({ modelName, logger }) => {
+export const observe_github: EvalFunction = async ({
+  modelName,
+  logger,
+  configOverrides,
+}) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/observe_github.ts
+++ b/evals/tasks/observe_github.ts
@@ -1,21 +1,6 @@
-import { initStagehand } from "@/evals/initStagehand";
 import { EvalFunction } from "@/types/evals";
 
-export const observe_github: EvalFunction = async ({
-  modelName,
-  logger,
-  configOverrides,
-}) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
+export const observe_github: EvalFunction = async ({ stagehand, logger }) => {
   await stagehand.page.goto("https://github.com/numpy/numpy/tree/main/numpy");
 
   const observations = await stagehand.page.observe({
@@ -27,8 +12,7 @@ export const observe_github: EvalFunction = async ({
     return {
       _success: false,
       observations,
-      debugUrl,
-      sessionUrl,
+
       logs: logger.getLogs(),
     };
   }
@@ -91,8 +75,7 @@ export const observe_github: EvalFunction = async ({
     _success: foundMatch,
     matchedLocator,
     observations,
-    debugUrl,
-    sessionUrl,
+
     logs: logger.getLogs(),
   };
 };

--- a/evals/tasks/observe_simple_google_search.ts
+++ b/evals/tasks/observe_simple_google_search.ts
@@ -1,22 +1,11 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
+
 import { performPlaywrightMethod } from "@/lib/a11y/utils";
 
 export const observe_simple_google_search: EvalFunction = async ({
-  modelName,
+  stagehand,
   logger,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   await stagehand.page.goto("https://www.google.com");
 
   // await stagehand.page.act({
@@ -67,8 +56,7 @@ export const observe_simple_google_search: EvalFunction = async ({
   return {
     _success: currentUrl.startsWith(expectedUrl),
     currentUrl,
-    debugUrl,
-    sessionUrl,
+
     logs: logger.getLogs(),
   };
 };

--- a/evals/tasks/observe_simple_google_search.ts
+++ b/evals/tasks/observe_simple_google_search.ts
@@ -5,10 +5,14 @@ import { performPlaywrightMethod } from "@/lib/a11y/utils";
 export const observe_simple_google_search: EvalFunction = async ({
   modelName,
   logger,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/observe_taxes.ts
+++ b/evals/tasks/observe_taxes.ts
@@ -1,21 +1,6 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
 
-export const observe_taxes: EvalFunction = async ({
-  modelName,
-  logger,
-  configOverrides,
-}) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
+export const observe_taxes: EvalFunction = async ({ stagehand, logger }) => {
   await stagehand.page.goto("https://file.1040.com/estimate/");
 
   const observations = await stagehand.page.observe({
@@ -27,8 +12,7 @@ export const observe_taxes: EvalFunction = async ({
     return {
       _success: false,
       observations,
-      debugUrl,
-      sessionUrl,
+
       logs: logger.getLogs(),
     };
   } else if (observations.length < 13) {
@@ -36,8 +20,7 @@ export const observe_taxes: EvalFunction = async ({
     return {
       _success: false,
       observations,
-      debugUrl,
-      sessionUrl,
+
       logs: logger.getLogs(),
     };
   }
@@ -76,8 +59,7 @@ export const observe_taxes: EvalFunction = async ({
     _success: foundMatch,
     expected: expectedResult,
     observations,
-    debugUrl,
-    sessionUrl,
+
     logs: logger.getLogs(),
   };
 };

--- a/evals/tasks/observe_taxes.ts
+++ b/evals/tasks/observe_taxes.ts
@@ -1,10 +1,17 @@
 import { EvalFunction } from "@/types/evals";
 import { initStagehand } from "@/evals/initStagehand";
 
-export const observe_taxes: EvalFunction = async ({ modelName, logger }) => {
+export const observe_taxes: EvalFunction = async ({
+  modelName,
+  logger,
+  configOverrides,
+}) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/observe_vantechjournal.ts
+++ b/evals/tasks/observe_vantechjournal.ts
@@ -4,10 +4,14 @@ import { EvalFunction } from "@/types/evals";
 export const observe_vantechjournal: EvalFunction = async ({
   modelName,
   logger,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/observe_vantechjournal.ts
+++ b/evals/tasks/observe_vantechjournal.ts
@@ -1,21 +1,9 @@
-import { initStagehand } from "@/evals/initStagehand";
 import { EvalFunction } from "@/types/evals";
 
 export const observe_vantechjournal: EvalFunction = async ({
-  modelName,
+  stagehand,
   logger,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   await stagehand.page.goto("https://vantechjournal.com/archive?page=8");
   await stagehand.page.waitForTimeout(1000);
 
@@ -28,8 +16,7 @@ export const observe_vantechjournal: EvalFunction = async ({
     return {
       _success: false,
       observations,
-      debugUrl,
-      sessionUrl,
+
       logs: logger.getLogs(),
     };
   }
@@ -77,8 +64,7 @@ export const observe_vantechjournal: EvalFunction = async ({
     _success: foundMatch,
     expected: expectedResult,
     observations,
-    debugUrl,
-    sessionUrl,
+
     logs: logger.getLogs(),
   };
 };

--- a/evals/tasks/observe_yc_startup.ts
+++ b/evals/tasks/observe_yc_startup.ts
@@ -1,21 +1,9 @@
-import { initStagehand } from "@/evals/initStagehand";
 import { EvalFunction } from "@/types/evals";
 
 export const observe_yc_startup: EvalFunction = async ({
-  modelName,
+  stagehand,
   logger,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   await stagehand.page.goto("https://www.ycombinator.com/companies");
   await stagehand.page.waitForLoadState("networkidle");
 
@@ -29,8 +17,7 @@ export const observe_yc_startup: EvalFunction = async ({
     return {
       _success: false,
       observations,
-      debugUrl,
-      sessionUrl,
+
       logs: logger.getLogs(),
     };
   }
@@ -92,8 +79,7 @@ export const observe_yc_startup: EvalFunction = async ({
     _success: foundMatch,
     matchedLocator,
     observations,
-    debugUrl,
-    sessionUrl,
+
     logs: logger.getLogs(),
   };
 };

--- a/evals/tasks/observe_yc_startup.ts
+++ b/evals/tasks/observe_yc_startup.ts
@@ -4,10 +4,14 @@ import { EvalFunction } from "@/types/evals";
 export const observe_yc_startup: EvalFunction = async ({
   modelName,
   logger,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/panamcs.ts
+++ b/evals/tasks/panamcs.ts
@@ -1,10 +1,17 @@
 import { EvalFunction } from "@/types/evals";
 import { initStagehand } from "@/evals/initStagehand";
 
-export const panamcs: EvalFunction = async ({ modelName, logger }) => {
+export const panamcs: EvalFunction = async ({
+  modelName,
+  logger,
+  configOverrides,
+}) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/panamcs.ts
+++ b/evals/tasks/panamcs.ts
@@ -1,21 +1,6 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
 
-export const panamcs: EvalFunction = async ({
-  modelName,
-  logger,
-  configOverrides,
-}) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
+export const panamcs: EvalFunction = async ({ stagehand, logger }) => {
   await stagehand.page.goto("https://panamcs.org/about/staff/");
 
   const observations = await stagehand.page.observe({ onlyVisible: true });
@@ -25,8 +10,7 @@ export const panamcs: EvalFunction = async ({
     return {
       _success: false,
       observations,
-      debugUrl,
-      sessionUrl,
+
       logs: logger.getLogs(),
     };
   }
@@ -65,8 +49,7 @@ export const panamcs: EvalFunction = async ({
     _success: foundMatch,
     expected: expectedResult,
     observations,
-    debugUrl,
-    sessionUrl,
+
     logs: logger.getLogs(),
   };
 };

--- a/evals/tasks/peeler_complex.ts
+++ b/evals/tasks/peeler_complex.ts
@@ -6,10 +6,14 @@ export const peeler_complex: EvalFunction = async ({
   modelName,
   logger,
   useTextExtract,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/peeler_complex.ts
+++ b/evals/tasks/peeler_complex.ts
@@ -1,23 +1,13 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
+
 import { z } from "zod";
 
 export const peeler_complex: EvalFunction = async ({
+  stagehand,
   modelName,
   logger,
   useTextExtract,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   try {
     await stagehand.page.goto(`https://chefstoys.com/`, { timeout: 60000 });
 
@@ -44,8 +34,7 @@ export const peeler_complex: EvalFunction = async ({
     return {
       _success: price === 11.99,
       price,
-      debugUrl,
-      sessionUrl,
+
       logs: logger.getLogs(),
     };
   } catch (error) {
@@ -69,8 +58,7 @@ export const peeler_complex: EvalFunction = async ({
     return {
       _success: false,
       error: JSON.parse(JSON.stringify(error, null, 2)),
-      debugUrl,
-      sessionUrl,
+
       logs: logger.getLogs(),
     };
   }

--- a/evals/tasks/peeler_simple.ts
+++ b/evals/tasks/peeler_simple.ts
@@ -6,10 +6,17 @@ const env: "BROWSERBASE" | "LOCAL" =
     ? "BROWSERBASE"
     : "LOCAL";
 
-export const peeler_simple: EvalFunction = async ({ modelName, logger }) => {
+export const peeler_simple: EvalFunction = async ({
+  modelName,
+  logger,
+  configOverrides,
+}) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/peeler_simple.ts
+++ b/evals/tasks/peeler_simple.ts
@@ -1,26 +1,11 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
 
 const env: "BROWSERBASE" | "LOCAL" =
   process.env.EVAL_ENV?.toLowerCase() === "browserbase"
     ? "BROWSERBASE"
     : "LOCAL";
 
-export const peeler_simple: EvalFunction = async ({
-  modelName,
-  logger,
-  configOverrides,
-}) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
+export const peeler_simple: EvalFunction = async ({ stagehand, logger }) => {
   if (env === "BROWSERBASE") {
     throw new Error(
       "Browserbase not supported for this eval since we block all requests to file://",
@@ -39,8 +24,6 @@ export const peeler_simple: EvalFunction = async ({
 
   return {
     _success: isVisible,
-    debugUrl,
-    sessionUrl,
     logs: logger.getLogs(),
   };
 };

--- a/evals/tasks/rakuten_jp.ts
+++ b/evals/tasks/rakuten_jp.ts
@@ -1,10 +1,17 @@
 import { EvalFunction } from "@/types/evals";
 import { initStagehand } from "@/evals/initStagehand";
 
-export const rakuten_jp: EvalFunction = async ({ modelName, logger }) => {
+export const rakuten_jp: EvalFunction = async ({
+  modelName,
+  logger,
+  configOverrides,
+}) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/rakuten_jp.ts
+++ b/evals/tasks/rakuten_jp.ts
@@ -1,21 +1,6 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
 
-export const rakuten_jp: EvalFunction = async ({
-  modelName,
-  logger,
-  configOverrides,
-}) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
+export const rakuten_jp: EvalFunction = async ({ stagehand, logger }) => {
   await stagehand.page.goto("https://www.rakuten.co.jp/");
   await stagehand.page.act({ action: "click on online supermarket" });
 
@@ -35,8 +20,7 @@ export const rakuten_jp: EvalFunction = async ({
 
   return {
     _success: url === successUrl,
-    debugUrl,
-    sessionUrl,
+
     logs: logger.getLogs(),
   };
 };

--- a/evals/tasks/sciquest.ts
+++ b/evals/tasks/sciquest.ts
@@ -1,23 +1,13 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
+
 import { z } from "zod";
 
 export const sciquest: EvalFunction = async ({
+  stagehand,
   modelName,
   logger,
   useTextExtract,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   await stagehand.page.goto(
     "https://bids.sciquest.com/apps/Router/PublicEvent?tab=PHX_NAV_SourcingAllOpps&CustomerOrg=StateOfUtah",
   );
@@ -66,8 +56,7 @@ export const sciquest: EvalFunction = async ({
       _success: false,
       error: "Total number of results is not within the expected range",
       extractedNumber,
-      debugUrl,
-      sessionUrl,
+
       logs: logger.getLogs(),
     };
   }
@@ -75,8 +64,7 @@ export const sciquest: EvalFunction = async ({
   return {
     _success: true,
     extractedNumber,
-    debugUrl,
-    sessionUrl,
+
     logs: logger.getLogs(),
   };
 };

--- a/evals/tasks/sciquest.ts
+++ b/evals/tasks/sciquest.ts
@@ -6,10 +6,14 @@ export const sciquest: EvalFunction = async ({
   modelName,
   logger,
   useTextExtract,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/shopify_homepage.ts
+++ b/evals/tasks/shopify_homepage.ts
@@ -1,21 +1,6 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
 
-export const shopify_homepage: EvalFunction = async ({
-  modelName,
-  logger,
-  configOverrides,
-}) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
+export const shopify_homepage: EvalFunction = async ({ stagehand, logger }) => {
   await stagehand.page.goto("https://www.shopify.com/");
 
   const observations = await stagehand.page.observe({ onlyVisible: true });
@@ -25,8 +10,7 @@ export const shopify_homepage: EvalFunction = async ({
     return {
       _success: false,
       observations,
-      debugUrl,
-      sessionUrl,
+
       logs: logger.getLogs(),
     };
   }
@@ -65,8 +49,7 @@ export const shopify_homepage: EvalFunction = async ({
     _success: foundMatch,
     expected: expectedResult,
     observations,
-    debugUrl,
-    sessionUrl,
+
     logs: logger.getLogs(),
   };
 };

--- a/evals/tasks/shopify_homepage.ts
+++ b/evals/tasks/shopify_homepage.ts
@@ -1,10 +1,17 @@
 import { EvalFunction } from "@/types/evals";
 import { initStagehand } from "@/evals/initStagehand";
 
-export const shopify_homepage: EvalFunction = async ({ modelName, logger }) => {
+export const shopify_homepage: EvalFunction = async ({
+  modelName,
+  logger,
+  configOverrides,
+}) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/simple_google_search.ts
+++ b/evals/tasks/simple_google_search.ts
@@ -1,21 +1,9 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
 
 export const simple_google_search: EvalFunction = async ({
-  modelName,
+  stagehand,
   logger,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   await stagehand.page.goto("https://www.google.com");
 
   await stagehand.page.act({
@@ -30,8 +18,6 @@ export const simple_google_search: EvalFunction = async ({
   return {
     _success: currentUrl.startsWith(expectedUrl),
     currentUrl,
-    debugUrl,
-    sessionUrl,
     logs: logger.getLogs(),
   };
 };

--- a/evals/tasks/simple_google_search.ts
+++ b/evals/tasks/simple_google_search.ts
@@ -4,10 +4,14 @@ import { initStagehand } from "@/evals/initStagehand";
 export const simple_google_search: EvalFunction = async ({
   modelName,
   logger,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/stock_x.ts
+++ b/evals/tasks/stock_x.ts
@@ -1,10 +1,17 @@
 import { EvalFunction } from "@/types/evals";
 import { initStagehand } from "@/evals/initStagehand";
 
-export const stock_x: EvalFunction = async ({ modelName, logger }) => {
+export const stock_x: EvalFunction = async ({
+  modelName,
+  logger,
+  configOverrides,
+}) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/stock_x.ts
+++ b/evals/tasks/stock_x.ts
@@ -1,21 +1,6 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
 
-export const stock_x: EvalFunction = async ({
-  modelName,
-  logger,
-  configOverrides,
-}) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
+export const stock_x: EvalFunction = async ({ stagehand, logger }) => {
   await stagehand.page.goto(
     "https://stockx.com/air-jordan-3-retro-black-cement-2024",
   );
@@ -35,8 +20,7 @@ export const stock_x: EvalFunction = async ({
   return {
     _success: currentUrl.startsWith(expectedUrlPrefix),
     currentUrl,
-    debugUrl,
-    sessionUrl,
+
     logs: logger.getLogs(),
   };
 };

--- a/evals/tasks/ted_talk.ts
+++ b/evals/tasks/ted_talk.ts
@@ -7,10 +7,14 @@ export const ted_talk: EvalFunction = async ({
   modelName,
   logger,
   useTextExtract,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/vanta.ts
+++ b/evals/tasks/vanta.ts
@@ -1,10 +1,17 @@
 import { EvalFunction } from "@/types/evals";
 import { initStagehand } from "@/evals/initStagehand";
 
-export const vanta: EvalFunction = async ({ modelName, logger }) => {
+export const vanta: EvalFunction = async ({
+  modelName,
+  logger,
+  configOverrides,
+}) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/vanta.ts
+++ b/evals/tasks/vanta.ts
@@ -1,21 +1,6 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
 
-export const vanta: EvalFunction = async ({
-  modelName,
-  logger,
-  configOverrides,
-}) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
+export const vanta: EvalFunction = async ({ stagehand, logger }) => {
   await stagehand.page.goto("https://www.vanta.com/");
   await stagehand.page.act({ action: "close the cookies popup" });
 
@@ -26,8 +11,7 @@ export const vanta: EvalFunction = async ({
     return {
       _success: false,
       observations,
-      debugUrl,
-      sessionUrl,
+
       logs: logger.getLogs(),
     };
   }
@@ -66,8 +50,7 @@ export const vanta: EvalFunction = async ({
     _success: foundMatch,
     expected: expectedResult,
     observations,
-    debugUrl,
-    sessionUrl,
+
     logs: logger.getLogs(),
   };
 };

--- a/evals/tasks/vanta_h.ts
+++ b/evals/tasks/vanta_h.ts
@@ -1,10 +1,17 @@
 import { EvalFunction } from "@/types/evals";
 import { initStagehand } from "@/evals/initStagehand";
 
-export const vanta_h: EvalFunction = async ({ modelName, logger }) => {
+export const vanta_h: EvalFunction = async ({
+  modelName,
+  logger,
+  configOverrides,
+}) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/vanta_h.ts
+++ b/evals/tasks/vanta_h.ts
@@ -1,21 +1,6 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
 
-export const vanta_h: EvalFunction = async ({
-  modelName,
-  logger,
-  configOverrides,
-}) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
+export const vanta_h: EvalFunction = async ({ stagehand, logger }) => {
   await stagehand.page.goto("https://www.vanta.com/");
 
   const observations = await stagehand.page.observe({
@@ -29,8 +14,6 @@ export const vanta_h: EvalFunction = async ({
   return {
     _success: observations.length === 0,
     observations,
-    debugUrl,
-    sessionUrl,
     logs: logger.getLogs(),
   };
 };

--- a/evals/tasks/vantechjournal.ts
+++ b/evals/tasks/vantechjournal.ts
@@ -1,10 +1,17 @@
 import { EvalFunction } from "@/types/evals";
 import { initStagehand } from "@/evals/initStagehand";
 
-export const vantechjournal: EvalFunction = async ({ modelName, logger }) => {
+export const vantechjournal: EvalFunction = async ({
+  modelName,
+  logger,
+  configOverrides,
+}) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/vantechjournal.ts
+++ b/evals/tasks/vantechjournal.ts
@@ -1,21 +1,6 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
 
-export const vantechjournal: EvalFunction = async ({
-  modelName,
-  logger,
-  configOverrides,
-}) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
+export const vantechjournal: EvalFunction = async ({ stagehand, logger }) => {
   await stagehand.page.goto("https://vantechjournal.com/");
 
   await stagehand.page.act({
@@ -31,8 +16,7 @@ export const vantechjournal: EvalFunction = async ({
     _success: currentUrl === expectedUrl,
     currentUrl,
     expectedUrl,
-    debugUrl,
-    sessionUrl,
+
     logs: logger.getLogs(),
   };
 };

--- a/evals/tasks/wichita.ts
+++ b/evals/tasks/wichita.ts
@@ -6,10 +6,14 @@ export const wichita: EvalFunction = async ({
   modelName,
   logger,
   useTextExtract,
+  configOverrides,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/wichita.ts
+++ b/evals/tasks/wichita.ts
@@ -1,23 +1,13 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
+
 import { z } from "zod";
 
 export const wichita: EvalFunction = async ({
+  stagehand,
   modelName,
   logger,
   useTextExtract,
-  configOverrides,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
   await stagehand.page.goto("https://www.wichitafallstx.gov/Bids.aspx");
 
   await stagehand.page.act({
@@ -63,8 +53,7 @@ export const wichita: EvalFunction = async ({
       _success: false,
       error: "Total number of results is not within the expected range",
       extractedNumber,
-      debugUrl,
-      sessionUrl,
+
       logs: logger.getLogs(),
     };
   }
@@ -72,8 +61,7 @@ export const wichita: EvalFunction = async ({
   return {
     _success: true,
     extractedNumber,
-    debugUrl,
-    sessionUrl,
+
     logs: logger.getLogs(),
   };
 };

--- a/evals/tasks/wikipedia.ts
+++ b/evals/tasks/wikipedia.ts
@@ -1,21 +1,6 @@
 import { EvalFunction } from "@/types/evals";
-import { initStagehand } from "@/evals/initStagehand";
 
-export const wikipedia: EvalFunction = async ({
-  modelName,
-  logger,
-  configOverrides,
-}) => {
-  const { stagehand, initResponse } = await initStagehand({
-    modelName,
-    logger,
-    configOverrides: {
-      ...configOverrides,
-    },
-  });
-
-  const { debugUrl, sessionUrl } = initResponse;
-
+export const wikipedia: EvalFunction = async ({ stagehand, logger }) => {
   await stagehand.page.goto(`https://en.wikipedia.org/wiki/Baseball`);
   await stagehand.page.act('click the "hit and run" link in this article');
 
@@ -28,8 +13,7 @@ export const wikipedia: EvalFunction = async ({
     _success: currentUrl === url,
     expected: url,
     actual: currentUrl,
-    debugUrl,
-    sessionUrl,
+
     logs: logger.getLogs(),
   };
 };

--- a/evals/tasks/wikipedia.ts
+++ b/evals/tasks/wikipedia.ts
@@ -1,10 +1,17 @@
 import { EvalFunction } from "@/types/evals";
 import { initStagehand } from "@/evals/initStagehand";
 
-export const wikipedia: EvalFunction = async ({ modelName, logger }) => {
+export const wikipedia: EvalFunction = async ({
+  modelName,
+  logger,
+  configOverrides,
+}) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    configOverrides: {
+      ...configOverrides,
+    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -56,6 +56,15 @@ async function getBrowser(
     }
     const browser = await chromium.connectOverCDP(cdpUrl);
     const context = browser.contexts()[0];
+    const originalClose = context.close.bind(context);
+
+    // ensure pages get closed for remote session
+    context.close = async () => {
+      for (const page of context.pages()) {
+        await page.close();
+      }
+      await originalClose();
+    };
     return { browser, context, env: "REMOTE" };
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "express": "^4.21.0",
         "globals": "^15.13.0",
         "multer": "^1.4.5-lts.1",
-        "plato-cli": "^0.0.29",
+        "plato-cli": "^0.0.32",
         "prettier": "^3.2.5",
         "string-comparison": "^1.3.0",
         "tsup": "^8.2.1",
@@ -5792,9 +5792,9 @@
       }
     },
     "node_modules/plato-cli": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/plato-cli/-/plato-cli-0.0.29.tgz",
-      "integrity": "sha512-pfAdzUX6UueM/LVLcHE0l27YXlSZh/bjaftwLNRjwx8tNwJlipWzcHTpdDswM4/Bv1rRvh9lwmrpRrfTny+GVw==",
+      "version": "0.0.31",
+      "resolved": "https://registry.npmjs.org/plato-cli/-/plato-cli-0.0.31.tgz",
+      "integrity": "sha512-wF/zbbitpE2qnK+Y/mQtKww7x1/+vc82Z53TqiUr0R44JuCXgruaxDszcSFHAKdJX1oa1VmaBF5v2vmSKD8L2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "express": "^4.21.0",
         "globals": "^15.13.0",
         "multer": "^1.4.5-lts.1",
-        "plato-cli": "^0.0.27",
+        "plato-cli": "^0.0.29",
         "prettier": "^3.2.5",
         "string-comparison": "^1.3.0",
         "tsup": "^8.2.1",
@@ -5792,9 +5792,9 @@
       }
     },
     "node_modules/plato-cli": {
-      "version": "0.0.27",
-      "resolved": "https://registry.npmjs.org/plato-cli/-/plato-cli-0.0.27.tgz",
-      "integrity": "sha512-6DUrBmXoAIg2iTMZczds37lU9GnbWvh6nOJi14cNyeHQEhqpE9BQ4zMOaAqajl4OLTHmF+ym0R/X+cm4L4cHxw==",
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/plato-cli/-/plato-cli-0.0.29.tgz",
+      "integrity": "sha512-pfAdzUX6UueM/LVLcHE0l27YXlSZh/bjaftwLNRjwx8tNwJlipWzcHTpdDswM4/Bv1rRvh9lwmrpRrfTny+GVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "express": "^4.21.0",
         "globals": "^15.13.0",
         "multer": "^1.4.5-lts.1",
-        "plato-cli": "^0.0.12",
+        "plato-cli": "^0.0.17",
         "prettier": "^3.2.5",
         "string-comparison": "^1.3.0",
         "tsup": "^8.2.1",
@@ -5792,9 +5792,9 @@
       }
     },
     "node_modules/plato-cli": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/plato-cli/-/plato-cli-0.0.12.tgz",
-      "integrity": "sha512-w/ZKbQoLNPz/K4BVKekiT9AVKZWODB+4CI4oTAwNjjOTUFHF9B7RYTAguPpmJ6MOZtT8h7kXE4rrEG3hHPPaCA==",
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/plato-cli/-/plato-cli-0.0.17.tgz",
+      "integrity": "sha512-AaIw9GVhm9b6TCuBFVr62HzG9epibwbv5g1auFjrfBGXsGTNfP/j28uwydjiaSlD8ALxzuY7XdLJGQrBCaaxvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@browserbasehq/stagehand",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@browserbasehq/stagehand",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.27.3",
@@ -37,7 +37,7 @@
         "express": "^4.21.0",
         "globals": "^15.13.0",
         "multer": "^1.4.5-lts.1",
-        "plato-cli": "^0.0.17",
+        "plato-cli": "^0.0.20",
         "prettier": "^3.2.5",
         "string-comparison": "^1.3.0",
         "tsup": "^8.2.1",
@@ -5792,9 +5792,9 @@
       }
     },
     "node_modules/plato-cli": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/plato-cli/-/plato-cli-0.0.17.tgz",
-      "integrity": "sha512-AaIw9GVhm9b6TCuBFVr62HzG9epibwbv5g1auFjrfBGXsGTNfP/j28uwydjiaSlD8ALxzuY7XdLJGQrBCaaxvg==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/plato-cli/-/plato-cli-0.0.20.tgz",
+      "integrity": "sha512-4rMqno6XXXhVD8MdQwt78OgpFH+rjRKQy94r6Ovv41wzUto+/hFuyOG2qVYuO66rQFFkMeiCqPa56qbW0jUr8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "express": "^4.21.0",
         "globals": "^15.13.0",
         "multer": "^1.4.5-lts.1",
-        "plato-cli": "^0.0.25",
+        "plato-cli": "^0.0.27",
         "prettier": "^3.2.5",
         "string-comparison": "^1.3.0",
         "tsup": "^8.2.1",
@@ -5792,9 +5792,9 @@
       }
     },
     "node_modules/plato-cli": {
-      "version": "0.0.25",
-      "resolved": "https://registry.npmjs.org/plato-cli/-/plato-cli-0.0.25.tgz",
-      "integrity": "sha512-fXuJEleks9ryG4tfZ36o2sHU9HmezBpAftFt9ZtCxp2kaEYKoLIChTD3IVoz65TO2enFM9mcs/25IZIG2jklpg==",
+      "version": "0.0.27",
+      "resolved": "https://registry.npmjs.org/plato-cli/-/plato-cli-0.0.27.tgz",
+      "integrity": "sha512-6DUrBmXoAIg2iTMZczds37lU9GnbWvh6nOJi14cNyeHQEhqpE9BQ4zMOaAqajl4OLTHmF+ym0R/X+cm4L4cHxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "express": "^4.21.0",
         "globals": "^15.13.0",
         "multer": "^1.4.5-lts.1",
-        "plato-cli": "^0.0.20",
+        "plato-cli": "^0.0.21",
         "prettier": "^3.2.5",
         "string-comparison": "^1.3.0",
         "tsup": "^8.2.1",
@@ -5792,9 +5792,9 @@
       }
     },
     "node_modules/plato-cli": {
-      "version": "0.0.20",
-      "resolved": "https://registry.npmjs.org/plato-cli/-/plato-cli-0.0.20.tgz",
-      "integrity": "sha512-4rMqno6XXXhVD8MdQwt78OgpFH+rjRKQy94r6Ovv41wzUto+/hFuyOG2qVYuO66rQFFkMeiCqPa56qbW0jUr8w==",
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/plato-cli/-/plato-cli-0.0.21.tgz",
+      "integrity": "sha512-/ufwmvT+yWlChzHcoFJWa/3l06DgtCGOYzH6Fh9WNfCudnNiu3giucwL41J9BF8xGGN8lGFdnyTPV1Lwu/fQSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "express": "^4.21.0",
         "globals": "^15.13.0",
         "multer": "^1.4.5-lts.1",
+        "plato-cli": "^0.0.12",
         "prettier": "^3.2.5",
         "string-comparison": "^1.3.0",
         "tsup": "^8.2.1",
@@ -5788,6 +5789,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/plato-cli": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/plato-cli/-/plato-cli-0.0.12.tgz",
+      "integrity": "sha512-w/ZKbQoLNPz/K4BVKekiT9AVKZWODB+4CI4oTAwNjjOTUFHF9B7RYTAguPpmJ6MOZtT8h7kXE4rrEG3hHPPaCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "zod-to-json-schema": "^3.23.5"
+      },
+      "bin": {
+        "plato": "dist/index.js"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
       }
     },
     "node_modules/playwright": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "express": "^4.21.0",
         "globals": "^15.13.0",
         "multer": "^1.4.5-lts.1",
-        "plato-cli": "^0.0.24",
+        "plato-cli": "^0.0.25",
         "prettier": "^3.2.5",
         "string-comparison": "^1.3.0",
         "tsup": "^8.2.1",
@@ -5792,9 +5792,9 @@
       }
     },
     "node_modules/plato-cli": {
-      "version": "0.0.24",
-      "resolved": "https://registry.npmjs.org/plato-cli/-/plato-cli-0.0.24.tgz",
-      "integrity": "sha512-sPynRbQhX7pX7ld29GDcvfblpQQadhlkEvBhndQBGtLTHfxhHEdbve3iG7QPAdvdiB2b/ZgLwsHhEil1dHz0Iw==",
+      "version": "0.0.25",
+      "resolved": "https://registry.npmjs.org/plato-cli/-/plato-cli-0.0.25.tgz",
+      "integrity": "sha512-fXuJEleks9ryG4tfZ36o2sHU9HmezBpAftFt9ZtCxp2kaEYKoLIChTD3IVoz65TO2enFM9mcs/25IZIG2jklpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "express": "^4.21.0",
         "globals": "^15.13.0",
         "multer": "^1.4.5-lts.1",
-        "plato-cli": "^0.0.22",
+        "plato-cli": "^0.0.24",
         "prettier": "^3.2.5",
         "string-comparison": "^1.3.0",
         "tsup": "^8.2.1",
@@ -5792,9 +5792,9 @@
       }
     },
     "node_modules/plato-cli": {
-      "version": "0.0.22",
-      "resolved": "https://registry.npmjs.org/plato-cli/-/plato-cli-0.0.22.tgz",
-      "integrity": "sha512-yqH5pSFZplernpBPj+4L0AfoC2O/iVdZbL5AiQL12XdTgK8l/Jz5lhfgg0Du+lBLwOrbAwtNsGotu7jxvwnX9g==",
+      "version": "0.0.24",
+      "resolved": "https://registry.npmjs.org/plato-cli/-/plato-cli-0.0.24.tgz",
+      "integrity": "sha512-sPynRbQhX7pX7ld29GDcvfblpQQadhlkEvBhndQBGtLTHfxhHEdbve3iG7QPAdvdiB2b/ZgLwsHhEil1dHz0Iw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "express": "^4.21.0",
         "globals": "^15.13.0",
         "multer": "^1.4.5-lts.1",
-        "plato-cli": "^0.0.21",
+        "plato-cli": "^0.0.22",
         "prettier": "^3.2.5",
         "string-comparison": "^1.3.0",
         "tsup": "^8.2.1",
@@ -5792,9 +5792,9 @@
       }
     },
     "node_modules/plato-cli": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/plato-cli/-/plato-cli-0.0.21.tgz",
-      "integrity": "sha512-/ufwmvT+yWlChzHcoFJWa/3l06DgtCGOYzH6Fh9WNfCudnNiu3giucwL41J9BF8xGGN8lGFdnyTPV1Lwu/fQSg==",
+      "version": "0.0.22",
+      "resolved": "https://registry.npmjs.org/plato-cli/-/plato-cli-0.0.22.tgz",
+      "integrity": "sha512-yqH5pSFZplernpBPj+4L0AfoC2O/iVdZbL5AiQL12XdTgK8l/Jz5lhfgg0Du+lBLwOrbAwtNsGotu7jxvwnX9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "express": "^4.21.0",
     "globals": "^15.13.0",
     "multer": "^1.4.5-lts.1",
-    "plato-cli": "^0.0.20",
+    "plato-cli": "^0.0.21",
     "prettier": "^3.2.5",
     "string-comparison": "^1.3.0",
     "tsup": "^8.2.1",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "express": "^4.21.0",
     "globals": "^15.13.0",
     "multer": "^1.4.5-lts.1",
+    "plato-cli": "^0.0.12",
     "prettier": "^3.2.5",
     "string-comparison": "^1.3.0",
     "tsup": "^8.2.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "express": "^4.21.0",
     "globals": "^15.13.0",
     "multer": "^1.4.5-lts.1",
-    "plato-cli": "^0.0.25",
+    "plato-cli": "^0.0.27",
     "prettier": "^3.2.5",
     "string-comparison": "^1.3.0",
     "tsup": "^8.2.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "express": "^4.21.0",
     "globals": "^15.13.0",
     "multer": "^1.4.5-lts.1",
-    "plato-cli": "^0.0.22",
+    "plato-cli": "^0.0.24",
     "prettier": "^3.2.5",
     "string-comparison": "^1.3.0",
     "tsup": "^8.2.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "express": "^4.21.0",
     "globals": "^15.13.0",
     "multer": "^1.4.5-lts.1",
-    "plato-cli": "^0.0.29",
+    "plato-cli": "^0.0.32",
     "prettier": "^3.2.5",
     "string-comparison": "^1.3.0",
     "tsup": "^8.2.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "express": "^4.21.0",
     "globals": "^15.13.0",
     "multer": "^1.4.5-lts.1",
-    "plato-cli": "^0.0.17",
+    "plato-cli": "^0.0.20",
     "prettier": "^3.2.5",
     "string-comparison": "^1.3.0",
     "tsup": "^8.2.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "express": "^4.21.0",
     "globals": "^15.13.0",
     "multer": "^1.4.5-lts.1",
-    "plato-cli": "^0.0.12",
+    "plato-cli": "^0.0.17",
     "prettier": "^3.2.5",
     "string-comparison": "^1.3.0",
     "tsup": "^8.2.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "express": "^4.21.0",
     "globals": "^15.13.0",
     "multer": "^1.4.5-lts.1",
-    "plato-cli": "^0.0.24",
+    "plato-cli": "^0.0.25",
     "prettier": "^3.2.5",
     "string-comparison": "^1.3.0",
     "tsup": "^8.2.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "express": "^4.21.0",
     "globals": "^15.13.0",
     "multer": "^1.4.5-lts.1",
-    "plato-cli": "^0.0.27",
+    "plato-cli": "^0.0.29",
     "prettier": "^3.2.5",
     "string-comparison": "^1.3.0",
     "tsup": "^8.2.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "express": "^4.21.0",
     "globals": "^15.13.0",
     "multer": "^1.4.5-lts.1",
-    "plato-cli": "^0.0.21",
+    "plato-cli": "^0.0.22",
     "prettier": "^3.2.5",
     "string-comparison": "^1.3.0",
     "tsup": "^8.2.1",

--- a/types/browser.ts
+++ b/types/browser.ts
@@ -1,7 +1,7 @@
 import { Browser, BrowserContext } from "./page";
 
 export interface BrowserResult {
-  env: "LOCAL" | "BROWSERBASE";
+  env: "LOCAL" | "BROWSERBASE" | "REMOTE";
   browser?: Browser;
   context: BrowserContext;
   debugUrl?: string;

--- a/types/browser.ts
+++ b/types/browser.ts
@@ -1,11 +1,12 @@
 import { Browser, BrowserContext } from "./page";
 
 export interface BrowserResult {
-  env: "LOCAL" | "BROWSERBASE" | "REMOTE";
+  env: "LOCAL" | "BROWSERBASE";
   browser?: Browser;
   context: BrowserContext;
   debugUrl?: string;
   sessionUrl?: string;
   contextPath?: string;
   sessionId?: string;
+  connectUrl?: string;
 }

--- a/types/evals.ts
+++ b/types/evals.ts
@@ -42,6 +42,8 @@ export interface Testcase
   input: EvalInput;
   name: string;
   tags: string[];
+  description?: string;
+  startUrl?: string;
   metadata: { model: AvailableModel; test: string };
   expected: unknown;
 }

--- a/types/evals.ts
+++ b/types/evals.ts
@@ -3,12 +3,14 @@ import type { EvalLogger } from "../evals/logger";
 import type { AvailableModel } from "../types/model";
 import type { LogLine } from "../types/log";
 import type { EvalCase } from "braintrust";
+import Plato from "plato-cli";
 
 export type EvalFunction = (args: {
   modelName: AvailableModel;
   logger: EvalLogger;
   useTextExtract: boolean;
   useAccessibilityTree: boolean;
+  plato?: Plato;
 }) => Promise<{
   _success: boolean;
   logs: LogLine[];

--- a/types/evals.ts
+++ b/types/evals.ts
@@ -2,8 +2,7 @@ import { z } from "zod";
 import type { EvalLogger } from "../evals/logger";
 import type { AvailableModel } from "../types/model";
 import type { LogLine } from "../types/log";
-import type { EvalCase } from "braintrust";
-import { PlatoSession } from "plato-cli";
+import { PlatoSession, TestCase } from "plato-cli";
 import { Stagehand } from "@/dist";
 
 export type EvalFunction = (args: {
@@ -34,12 +33,7 @@ export interface EvalInput {
   modelName: AvailableModel;
 }
 
-export interface Testcase
-  extends EvalCase<
-    EvalInput,
-    unknown,
-    { model: AvailableModel; test: string }
-  > {
+export interface Testcase extends TestCase {
   input: EvalInput;
   name: string;
   tags: string[];

--- a/types/evals.ts
+++ b/types/evals.ts
@@ -3,14 +3,13 @@ import type { EvalLogger } from "../evals/logger";
 import type { AvailableModel } from "../types/model";
 import type { LogLine } from "../types/log";
 import type { EvalCase } from "braintrust";
-import Plato from "plato-cli";
 
 export type EvalFunction = (args: {
   modelName: AvailableModel;
   logger: EvalLogger;
   useTextExtract: boolean;
   useAccessibilityTree: boolean;
-  plato?: Plato;
+  configOverrides?: Record<string, unknown>;
 }) => Promise<{
   _success: boolean;
   logs: LogLine[];

--- a/types/evals.ts
+++ b/types/evals.ts
@@ -3,18 +3,19 @@ import type { EvalLogger } from "../evals/logger";
 import type { AvailableModel } from "../types/model";
 import type { LogLine } from "../types/log";
 import type { EvalCase } from "braintrust";
+import { PlatoSession } from "plato-cli";
+import { Stagehand } from "@/dist";
 
 export type EvalFunction = (args: {
-  modelName: AvailableModel;
   logger: EvalLogger;
+  platoSim: PlatoSession;
+  stagehand: Stagehand;
+  modelName: AvailableModel;
   useTextExtract: boolean;
   useAccessibilityTree: boolean;
-  configOverrides?: Record<string, unknown>;
 }) => Promise<{
   _success: boolean;
   logs: LogLine[];
-  debugUrl: string;
-  sessionUrl: string;
   error?: unknown;
 }>;
 

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -7,7 +7,7 @@ import { AvailableModel, ClientOptions } from "./model";
 import { LLMClient } from "../lib/llm/LLMClient";
 
 export interface ConstructorParams {
-  env: "LOCAL" | "BROWSERBASE";
+  env: "LOCAL" | "BROWSERBASE" | "REMOTE";
   apiKey?: string;
   projectId?: string;
   verbose?: 0 | 1 | 2;
@@ -26,6 +26,7 @@ export interface ConstructorParams {
    * Instructions for stagehand.
    */
   systemPrompt?: string;
+  cdpUrl?: string;
 }
 
 export interface InitOptions {

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -7,7 +7,7 @@ import { AvailableModel, ClientOptions } from "./model";
 import { LLMClient } from "../lib/llm/LLMClient";
 
 export interface ConstructorParams {
-  env: "LOCAL" | "BROWSERBASE" | "REMOTE";
+  env: "LOCAL" | "BROWSERBASE";
   apiKey?: string;
   projectId?: string;
   verbose?: 0 | 1 | 2;
@@ -26,7 +26,6 @@ export interface ConstructorParams {
    * Instructions for stagehand.
    */
   systemPrompt?: string;
-  cdpUrl?: string;
 }
 
 export interface InitOptions {
@@ -42,6 +41,7 @@ export interface InitResult {
   debugUrl: string;
   sessionUrl: string;
   sessionId: string;
+  connectUrl: string;
 }
 
 export interface InitFromPageOptions {


### PR DESCRIPTION
# why
- to have ground truth answers for evals

# what changed
- connect plato to the browser session which will serve the simulations
- had to return `connectUrl` from `Stagehand.init` to be able to pass it to plato


