### PR TITLE
added fallback try to actFromObserveResult

### DIFF
--- a/.changeset/gentle-grapes-join.md
+++ b/.changeset/gentle-grapes-join.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Adding a fallback try on actFromObserveResult to use the description from observe and call regular act.

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -109,8 +109,11 @@ export class StagehandPage {
 
         if (this.llmClient) {
           if (prop === "act") {
-            return async (options: ActOptions) => {
-              return this.act(options);
+            return async (
+              optionsOrObserve: ActOptions | ObserveResult,
+              options?: { selfHeal?: boolean },
+            ) => {
+              return this.act(optionsOrObserve, options);
             };
           }
           if (prop === "extract") {
@@ -288,7 +291,7 @@ export class StagehandPage {
 
   async act(
     actionOrOptions: string | ActOptions | ObserveResult,
-    selfHeal: boolean = true,
+    options?: { selfHeal?: boolean },
   ): Promise<ActResult> {
     if (!this.actHandler) {
       throw new Error("Act handler not initialized");
@@ -303,10 +306,13 @@ export class StagehandPage {
       if ("selector" in actionOrOptions && "method" in actionOrOptions) {
         const observeResult = actionOrOptions as ObserveResult;
         // validate observeResult.method, etc.
-        return this.actHandler.actFromObserveResult(observeResult, selfHeal);
+        return this.actHandler.actFromObserveResult(
+          observeResult,
+          options?.selfHeal ?? true,
+        );
       } else {
         // If it's an object but no selector/method,
-        // check that it’s truly ActOptions (i.e., has an `action` field).
+        // check that it's truly ActOptions (i.e., has an `action` field).
         if (!("action" in actionOrOptions)) {
           throw new Error(
             "Invalid argument. Valid arguments are: a string, an ActOptions object, " +

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -71,6 +71,7 @@ export class StagehandPage {
         stagehandContext: this.intContext,
         llmClient: llmClient,
         userProvidedInstructions,
+        selfHeal: this.stagehand.selfHeal,
       });
       this.extractHandler = new StagehandExtractHandler({
         stagehand: this.stagehand,
@@ -109,11 +110,8 @@ export class StagehandPage {
 
         if (this.llmClient) {
           if (prop === "act") {
-            return async (
-              optionsOrObserve: ActOptions | ObserveResult,
-              options?: { selfHeal?: boolean },
-            ) => {
-              return this.act(optionsOrObserve, options);
+            return async (options: ActOptions) => {
+              return this.act(options);
             };
           }
           if (prop === "extract") {
@@ -291,7 +289,6 @@ export class StagehandPage {
 
   async act(
     actionOrOptions: string | ActOptions | ObserveResult,
-    options?: { selfHeal?: boolean },
   ): Promise<ActResult> {
     if (!this.actHandler) {
       throw new Error("Act handler not initialized");
@@ -306,10 +303,7 @@ export class StagehandPage {
       if ("selector" in actionOrOptions && "method" in actionOrOptions) {
         const observeResult = actionOrOptions as ObserveResult;
         // validate observeResult.method, etc.
-        return this.actHandler.actFromObserveResult(
-          observeResult,
-          options?.selfHeal ?? true,
-        );
+        return this.actHandler.actFromObserveResult(observeResult);
       } else {
         // If it's an object but no selector/method,
         // check that it's truly ActOptions (i.e., has an `action` field).

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -288,6 +288,7 @@ export class StagehandPage {
 
   async act(
     actionOrOptions: string | ActOptions | ObserveResult,
+    selfHeal: boolean = true,
   ): Promise<ActResult> {
     if (!this.actHandler) {
       throw new Error("Act handler not initialized");
@@ -302,7 +303,7 @@ export class StagehandPage {
       if ("selector" in actionOrOptions && "method" in actionOrOptions) {
         const observeResult = actionOrOptions as ObserveResult;
         // validate observeResult.method, etc.
-        return this.actHandler.actFromObserveResult(observeResult);
+        return this.actHandler.actFromObserveResult(observeResult, selfHeal);
       } else {
         // If it's an object but no selector/method,
         // check that it’s truly ActOptions (i.e., has an `action` field).
@@ -509,7 +510,7 @@ export class StagehandPage {
       modelClientOptions,
       useVision, // still destructure but will not pass it on
       domSettleTimeoutMs,
-      returnAction = false,
+      returnAction = true,
       onlyVisible = false,
       useAccessibilityTree,
       drawOverlay,

--- a/lib/handlers/actHandler.ts
+++ b/lib/handlers/actHandler.ts
@@ -29,6 +29,7 @@ export class StagehandActHandler {
     [key: string]: { result: string; action: string };
   };
   private readonly userProvidedInstructions?: string;
+  private readonly selfHeal: boolean;
 
   constructor({
     verbose,
@@ -37,6 +38,7 @@ export class StagehandActHandler {
     logger,
     stagehandPage,
     userProvidedInstructions,
+    selfHeal,
   }: {
     verbose: 0 | 1 | 2;
     llmProvider: LLMProvider;
@@ -46,6 +48,7 @@ export class StagehandActHandler {
     stagehandPage: StagehandPage;
     stagehandContext: StagehandContext;
     userProvidedInstructions?: string;
+    selfHeal: boolean;
   }) {
     this.verbose = verbose;
     this.llmProvider = llmProvider;
@@ -55,6 +58,7 @@ export class StagehandActHandler {
     this.actions = {};
     this.stagehandPage = stagehandPage;
     this.userProvidedInstructions = userProvidedInstructions;
+    this.selfHeal = selfHeal;
   }
 
   /**
@@ -63,7 +67,6 @@ export class StagehandActHandler {
    */
   public async actFromObserveResult(
     observe: ObserveResult,
-    selfHeal: boolean,
   ): Promise<{ success: boolean; message: string; action: string }> {
     this.logger({
       category: "action",
@@ -91,7 +94,7 @@ export class StagehandActHandler {
         action: observe.description || `ObserveResult action (${method})`,
       };
     } catch (err) {
-      if (!selfHeal) {
+      if (!this.selfHeal) {
         this.logger({
           category: "action",
           message: "Error performing act from an ObserveResult",
@@ -410,7 +413,7 @@ export class StagehandActHandler {
         const clickArg = args.length ? args[0] : undefined;
 
         if (isRadio) {
-          // if it’s a radio button, try to find a label to click
+          // if it's a radio button, try to find a label to click
           const inputId = await locator.evaluate((el) => el.id);
           let labelLocator;
 
@@ -421,7 +424,7 @@ export class StagehandActHandler {
             );
           }
           if (!labelLocator || (await labelLocator.count()) < 1) {
-            // if no label was found or the label doesn’t exist, check if
+            // if no label was found or the label doesn't exist, check if
             // there is an ancestor <label>
             labelLocator = this.stagehandPage.page
               .locator(`xpath=${xpath}/ancestor::label`)

--- a/lib/handlers/actHandler.ts
+++ b/lib/handlers/actHandler.ts
@@ -92,7 +92,8 @@ export class StagehandActHandler {
     } catch (err) {
       this.logger({
         category: "action",
-        message: "Error performing act from an ObserveResult. Trying again with regular act method",
+        message:
+          "Error performing act from an ObserveResult. Trying again with regular act method",
         level: 1,
         auxiliary: {
           error: { value: err.message, type: "string" },
@@ -101,17 +102,23 @@ export class StagehandActHandler {
         },
       });
       try {
-        const actCommand = observe.description.toLowerCase().startsWith(method.toLowerCase()) 
-        ? observe.description
-        : method 
-          ? `${method} ${observe.description}`
-          : observe.description
+        const actCommand = observe.description
+          .toLowerCase()
+          .startsWith(method.toLowerCase())
+          ? observe.description
+          : method
+            ? `${method} ${observe.description}`
+            : observe.description;
         await this.stagehandPage.act(actCommand);
-      } catch (e) {
+      } catch (err) {
         this.logger({
           category: "action",
           message: "Error performing act from an ObserveResult",
           level: 1,
+          auxiliary: {
+            error: { value: err.message, type: "string" },
+            trace: { value: err.stack, type: "string" },
+          },
         });
         return {
           success: false,
@@ -119,7 +126,6 @@ export class StagehandActHandler {
           action: observe.description || `ObserveResult action (${method})`,
         };
       }
-
     }
   }
 

--- a/lib/handlers/actHandler.ts
+++ b/lib/handlers/actHandler.ts
@@ -92,7 +92,7 @@ export class StagehandActHandler {
     } catch (err) {
       this.logger({
         category: "action",
-        message: "Error performing act from an ObserveResult",
+        message: "Error performing act from an ObserveResult. Trying again with regular act method",
         level: 1,
         auxiliary: {
           error: { value: err.message, type: "string" },
@@ -100,11 +100,26 @@ export class StagehandActHandler {
           observeResult: { value: JSON.stringify(observe), type: "object" },
         },
       });
-      return {
-        success: false,
-        message: `Failed to perform act: ${err.message}`,
-        action: observe.description || `ObserveResult action (${method})`,
-      };
+      try {
+        const actCommand = observe.description.toLowerCase().startsWith(method.toLowerCase()) 
+        ? observe.description
+        : method 
+          ? `${method} ${observe.description}`
+          : observe.description
+        await this.stagehandPage.act(actCommand);
+      } catch (e) {
+        this.logger({
+          category: "action",
+          message: "Error performing act from an ObserveResult",
+          level: 1,
+        });
+        return {
+          success: false,
+          message: `Failed to perform act: ${err.message}`,
+          action: observe.description || `ObserveResult action (${method})`,
+        };
+      }
+
     }
   }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -327,6 +327,7 @@ export class Stagehand {
   private contextPath?: string;
   private llmClient: LLMClient;
   private userProvidedInstructions?: string;
+  public readonly selfHeal: boolean;
 
   constructor(
     {
@@ -346,6 +347,7 @@ export class Stagehand {
       modelName,
       modelClientOptions,
       systemPrompt,
+      selfHeal = true,
     }: ConstructorParams = {
       env: "BROWSERBASE",
     },
@@ -380,6 +382,7 @@ export class Stagehand {
     this.browserbaseSessionCreateParams = browserbaseSessionCreateParams;
     this.browserbaseSessionID = browserbaseSessionID;
     this.userProvidedInstructions = systemPrompt;
+    this.selfHeal = selfHeal;
   }
 
   public get logger(): (logLine: LogLine) => void {

--- a/types/page.ts
+++ b/types/page.ts
@@ -21,6 +21,10 @@ export interface Page extends Omit<PlaywrightPage, "on"> {
   act(action: string): Promise<ActResult>;
   act(options: ActOptions): Promise<ActResult>;
   act(observation: ObserveResult): Promise<ActResult>;
+  act(
+    observation: ObserveResult,
+    options?: { selfHeal?: boolean },
+  ): Promise<ActResult>;
 
   extract(
     instruction: string,

--- a/types/page.ts
+++ b/types/page.ts
@@ -21,10 +21,6 @@ export interface Page extends Omit<PlaywrightPage, "on"> {
   act(action: string): Promise<ActResult>;
   act(options: ActOptions): Promise<ActResult>;
   act(observation: ObserveResult): Promise<ActResult>;
-  act(
-    observation: ObserveResult,
-    options?: { selfHeal?: boolean },
-  ): Promise<ActResult>;
 
   extract(
     instruction: string,

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -26,6 +26,7 @@ export interface ConstructorParams {
    * Instructions for stagehand.
    */
   systemPrompt?: string;
+  selfHeal?: boolean;
 }
 
 export interface InitOptions {


### PR DESCRIPTION
# why
Instead of having to do try catches when act from observe result fails, we automatically try again using the method+description on regular act

# what changed
Added logic to actFromObserveResult to retry with regular act and indicate the retry to the user with a log

# test plan
Tested locally