### PR TITLE
making the instruction more descriptive in observe_taxes

### DIFF
--- a/evals/tasks/observe_taxes.ts
+++ b/evals/tasks/observe_taxes.ts
@@ -12,7 +12,7 @@ export const observe_taxes: EvalFunction = async ({ modelName, logger }) => {
   await stagehand.page.goto("https://file.1040.com/estimate/");
 
   const observations = await stagehand.page.observe({
-    instruction: "Find all the form elements under the 'Income' section",
+    instruction: "Find all the form input elements under the 'Income' section",
   });
 
   if (observations.length === 0) {


### PR DESCRIPTION
# why
After pushing the dom+a11y changes evals for observe_taxes were becoming more inconsistent. Basically selecting the right thing but not the actual input element. Just added more description to account for this

# what changed
Changed prompt for eval observe_taxes

# test plan