### PR TITLE
update refine extraction prompt

### DIFF
--- a/.changeset/healthy-cups-play.md
+++ b/.changeset/healthy-cups-play.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+update refine extraction prompt to ensure correct schema is used

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -294,7 +294,7 @@ const refineSystemPrompt = `You are tasked with refining and filtering informati
 1. Remove exact duplicates for elements in arrays and objects.
 2. For text fields, append or update relevant text if the new content is an extension, replacement, or continuation.
 3. For non-text fields (e.g., numbers, booleans), update with new values if they differ.
-4. Add any completely new fields or objects.
+4. Add any completely new fields or objects ONLY IF they correspond to the provided schema.
 
 Return the updated content that includes both the previous content and the new, non-duplicate, or extended information.`;
 


### PR DESCRIPTION
# why
- when using default extraction schema (passing in a string & no schema to `extract`), claude will sometimes wrap the extraction response in another object.
