### PR TITLE
update rockauto & staff members eval

### DIFF
--- a/evals/tasks/extract_staff_members.ts
+++ b/evals/tasks/extract_staff_members.ts
@@ -19,7 +19,7 @@ export const extract_staff_members: EvalFunction = async ({
 
   const result = await stagehand.page.extract({
     instruction:
-      "extract a list of staff members on this page, with their name and their job title",
+      "extract a list of ALL the staff members on this page, with their name and their job title",
     schema: z.object({
       staff_members: z.array(
         z.object({


### PR DESCRIPTION
# why
- `rockauto` eval failing because we were trying to match first and last
- `extract_staff_members` eval failing because the model decides to stop chunking too early
# what changed
- made `rockauto` expected values order agnostic. also added two more expected values, making eval more robust
- added "all" to `extract_staff_members` instruction which encourages the model to continue chunking
