### PR TITLE
observe with Laminar

### DIFF
--- a/lib/handlers/observeHandler.ts
+++ b/lib/handlers/observeHandler.ts
@@ -1,9 +1,14 @@
+import { Laminar, observe as laminarObserve } from "@lmnr-ai/lmnr";
 import { LogLine } from "../../types/log";
 import { Stagehand } from "../index";
 import { observe } from "../inference";
 import { LLMClient } from "../llm/LLMClient";
 import { StagehandPage } from "../StagehandPage";
-import { generateId, drawObserveOverlay } from "../utils";
+import {
+  generateId,
+  drawObserveOverlay,
+  cleanLLMClientForLaminarObserve,
+} from "../utils";
 import {
   getAccessibilityTree,
   getXPathByResolvedObjectId,
@@ -50,6 +55,55 @@ export class StagehandObserveHandler {
   }
 
   public async observe({
+    instruction,
+    llmClient,
+    requestId,
+    returnAction,
+    onlyVisible,
+    drawOverlay,
+  }: {
+    instruction: string;
+    llmClient: LLMClient;
+    requestId: string;
+    domSettleTimeoutMs?: number;
+    returnAction?: boolean;
+    onlyVisible?: boolean;
+    drawOverlay?: boolean;
+  }) {
+    if (Laminar.initialized()) {
+      return laminarObserve(
+        {
+          name: "observe",
+          input: {
+            instruction,
+            llmClient: cleanLLMClientForLaminarObserve(llmClient),
+            requestId,
+            returnAction,
+            onlyVisible,
+            drawOverlay,
+          },
+        },
+        (observeProps) => this._observe(observeProps),
+        {
+          instruction,
+          llmClient,
+          requestId,
+          returnAction,
+          onlyVisible,
+          drawOverlay,
+        },
+      );
+    }
+
+    return this._observe({
+      instruction,
+      llmClient,
+      requestId,
+      returnAction,
+    });
+  }
+
+  private async _observe({
     instruction,
     llmClient,
     requestId,

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,6 @@
 import crypto from "crypto";
 import { z } from "zod";
-import { ObserveResult, Page } from ".";
+import { LLMClient, ObserveResult, Page } from ".";
 import { LogLine } from "../types/log";
 import { TextAnnotation } from "../types/textannotation";
 
@@ -199,6 +199,25 @@ export function formatText(
 
   // **29: Return the final formatted text.**
   return pageText;
+}
+
+export function cleanLLMClientForLaminarObserve(
+  llmClient: LLMClient,
+): Omit<LLMClient, "client"> {
+  return Object.fromEntries(
+    Object.entries(llmClient)
+      .filter(([key]) => key !== "client")
+      .map(([key, value]) =>
+        key === "clientOptions"
+          ? [
+              key,
+              Object.fromEntries(
+                Object.entries(value).filter(([key]) => key !== "apiKey"),
+              ),
+            ]
+          : [key, value],
+      ),
+  ) as Omit<LLMClient, "client">;
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.27.3",
         "@browserbasehq/sdk": "^2.0.0",
+        "@lmnr-ai/lmnr": "^0.4.40",
         "ws": "^8.18.0",
         "zod-to-json-schema": "^3.23.5"
       },
@@ -52,6 +53,71 @@
         "dotenv": "^16.4.5",
         "openai": "^4.62.1",
         "zod": "^3.23.8"
+      }
+    },
+    "../ts-sdk": {
+      "name": "@lmnr-ai/lmnr",
+      "version": "0.4.40",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.12.5",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "^0.57.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "^0.57.0",
+        "@opentelemetry/instrumentation": "^0.57.0",
+        "@opentelemetry/otlp-exporter-base": "^0.57.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "^0.57.0",
+        "@opentelemetry/sdk-node": "^0.57.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.0",
+        "@opentelemetry/sdk-trace-node": "^1.30.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "@traceloop/ai-semantic-conventions": "^0.11.6",
+        "@traceloop/instrumentation-anthropic": "^0.11.6",
+        "@traceloop/instrumentation-azure": "^0.11.6",
+        "@traceloop/instrumentation-bedrock": "^0.11.6",
+        "@traceloop/instrumentation-chromadb": "^0.11.6",
+        "@traceloop/instrumentation-cohere": "^0.11.6",
+        "@traceloop/instrumentation-langchain": "^0.11.6",
+        "@traceloop/instrumentation-llamaindex": "^0.11.6",
+        "@traceloop/instrumentation-openai": "^0.11.6",
+        "@traceloop/instrumentation-pinecone": "^0.11.6",
+        "@traceloop/instrumentation-qdrant": "^0.11.6",
+        "@traceloop/instrumentation-vertexai": "^0.11.6",
+        "argparse": "^2.0.1",
+        "cli-progress": "^3.12.0",
+        "esbuild": "^0.24.2",
+        "glob": "^11.0.0",
+        "uuid": "^11.0.3"
+      },
+      "bin": {
+        "lmnr": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@anthropic-ai/sdk": "^0.33.1",
+        "@aws-sdk/client-bedrock-runtime": "^3.716.0",
+        "@azure/openai": "^2.0.0",
+        "@browserbasehq/stagehand": "^1.10.1",
+        "@google-cloud/aiplatform": "^3.34.0",
+        "@google-cloud/vertexai": "^1.9.2",
+        "@langchain/core": "^0.3.26",
+        "@pinecone-database/pinecone": "^4.0.0",
+        "@qdrant/js-client-rest": "^1.12.0",
+        "@types/argparse": "^2.0.17",
+        "@types/cli-progress": "^3.11.6",
+        "@types/node": "^22.10.2",
+        "@types/semver": "^7.5.8",
+        "@types/uuid": "^10.0.0",
+        "bufferutil": "^4.0.8",
+        "chromadb": "^1.9.4",
+        "cohere-ai": "^7.15.0",
+        "langchain": "^0.3.8",
+        "llamaindex": "^0.8.30",
+        "openai": "^4.80.1",
+        "playwright": "^1.50.0",
+        "tsup": "^8.3.5",
+        "tsx": "^4.19.2",
+        "typescript": "^5.7.2"
       }
     },
     "node_modules/@ai-sdk/google": {
@@ -1728,6 +1794,10 @@
         "@langchain/core": ">=0.3.39 <0.4.0"
       }
     },
+    "node_modules/@lmnr-ai/lmnr": {
+      "resolved": "../ts-sdk",
+      "link": true
+    },
     "node_modules/@manypkg/find-root": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@manypkg/find-root/-/find-root-1.1.0.tgz",
@@ -1858,6 +1928,7 @@
       "version": "1.50.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.1.tgz",
       "integrity": "sha512-Jii3aBg+CEDpgnuDxEp/h7BimHcUTDlpEtce89xEumlJ5ef2hqepZ+PWp1DDpYC/VO9fmWVI1IlEaoI5fK9FXQ==",
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "playwright": "1.50.1"

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.27.3",
     "@browserbasehq/sdk": "^2.0.0",
+    "@lmnr-ai/lmnr": "^0.4.40",
     "ws": "^8.18.0",
     "zod-to-json-schema": "^3.23.5"
   },


### PR DESCRIPTION
# why

[Laminar](https://www.lmnr.ai/) is introducing browser observability on top of it's OpenTelemetry-based observability stack tailored to LLM apps. For users who install and initialize Laminar, Stagehand will be instrumented out of the box. In addition (out of scope of this PR), users can do `Laminar.wrapStagehand(stagehand)` to get session replays alongside.

Example result: 
<img width="1511" alt="Screenshot 2025-02-17 at 16 26 09" src="https://github.com/user-attachments/assets/e2c20aa9-2b79-4bba-8cb5-46f3e6ce406d" />

We've already done this for [browser-use](https://github.com/browser-use/browser-use) (a higher-level browser agent in Python) and are now expanding the scope to TypeScript.

# what changed

Main methods in `actHandler`, `extractHandler`, `observeHandler` are instrumented with Laminar's [`observe` wrapper](https://docs.lmnr.ai/tracing/structure#grouping-spans-into-traces) if Laminar SDK is initialized. Otherwise, the default methods are returned.

# test plan

1. Installed Stagehand locally
2. Manually tried simple tasks without `Laminar.initialize()`
3. Manually tried simple tasks with `Laminar.initialize()`