### PR TITLE
avoid race conditions

### DIFF
--- a/types/api.ts
+++ b/types/api.ts
@@ -1,3 +1,4 @@
+import Browserbase from "@browserbasehq/sdk";
 import { LogLine } from "./log";
 
 export interface StagehandAPIConstructorParams {
@@ -19,6 +20,7 @@ export interface StartSessionParams {
   verbose: number;
   debugDom: boolean;
   systemPrompt?: string;
+  browserbaseSessionCreateParams?: Browserbase.Sessions.SessionCreateParams;
 }
 
 export interface StartSessionResult {
@@ -36,3 +38,12 @@ export interface ErrorResponse {
 }
 
 export type ApiResponse<T> = SuccessResponse<T> | ErrorResponse;
+
+export class RaceConditionError extends Error {
+  constructor() {
+    super(
+      "Cannot make multiple API calls at the same time. Ensure you aren't calling multiple Stagehand methods in parallel using the API.",
+    );
+    this.name = "RaceConditionError";
+  }
+}


### PR DESCRIPTION
# why
We want to avoid having parallel calls to the API as this can result in unexpected behavior related to keeping the `Page` object updated. To prevent this, we throw a custom error  when an API call is made while a previous call is in-progress.

# what changed
Added an `API_STATE` variable to keep track of outbound requests.

# test plan
Evals and internal API tests.
