### PR TITLE
allow API custom session creation params

### DIFF
--- a/.changeset/shaggy-planets-fetch.md
+++ b/.changeset/shaggy-planets-fetch.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": minor
+---
+
+Fixed browserbaseSessionCreateParams not being passed in to the API initialization payload.

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -37,6 +37,7 @@ export class StagehandAPI {
     verbose,
     debugDom,
     systemPrompt,
+    browserbaseSessionCreateParams,
   }: StartSessionParams): Promise<StartSessionResult> {
     const whitelistResponse = await this.request("/healthcheck");
 
@@ -56,6 +57,7 @@ export class StagehandAPI {
         verbose,
         debugDom,
         systemPrompt,
+        browserbaseSessionCreateParams,
       }),
       headers: {
         "x-model-api-key": modelApiKey,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -457,6 +457,7 @@ export class Stagehand {
         verbose: this.verbose,
         debugDom: this.debugDom,
         systemPrompt: this.userProvidedInstructions,
+        browserbaseSessionCreateParams: this.browserbaseSessionCreateParams,
       });
       this.browserbaseSessionID = sessionId;
     }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -393,7 +393,12 @@ export class Stagehand {
 
     if (this.usingAPI && env === "LOCAL") {
       throw new Error("API mode can only be used with BROWSERBASE environment");
+    } else if (this.usingAPI && !process.env.STAGEHAND_API_URL) {
+      throw new Error(
+        "STAGEHAND_API_URL is required when using the API. Please set it in your environment variables.",
+      );
     }
+
     this.selfHeal = selfHeal;
   }
 

--- a/types/api.ts
+++ b/types/api.ts
@@ -1,3 +1,4 @@
+import Browserbase from "@browserbasehq/sdk";
 import { LogLine } from "./log";
 
 export interface StagehandAPIConstructorParams {
@@ -19,6 +20,7 @@ export interface StartSessionParams {
   verbose: number;
   debugDom: boolean;
   systemPrompt?: string;
+  browserbaseSessionCreateParams?: Browserbase.Sessions.SessionCreateParams;
 }
 
 export interface StartSessionResult {


### PR DESCRIPTION
# why
We currently aren't passing in custom session creation params to the API. This results in unexpected behavior.

# what changed
Added the `browserbaseSessionCreateParams` object to the API `/start` payload. 

# test plan
E2E evals & internal API evals.