### PR TITLE
Add November GPT-4o snapshot

### DIFF
--- a/.changeset/moody-yaks-shout.md
+++ b/.changeset/moody-yaks-shout.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+add gpt 4o november snapshot

--- a/examples/example.ts
+++ b/examples/example.ts
@@ -11,13 +11,9 @@ import StagehandConfig from "@/stagehand.config";
 async function example() {
   const stagehand = new Stagehand({
     ...StagehandConfig,
-    modelName: "gpt-4o-2024-11-20",
-    env: "LOCAL",
   });
   await stagehand.init();
-  await stagehand.page.goto("https://www.google.com");
-  await stagehand.page.act("type 'browserbase' into the search bar");
-  await stagehand.page.act("click the search button");
+  await stagehand.page.goto("https://docs.stagehand.dev");
 }
 
 (async () => {

--- a/examples/example.ts
+++ b/examples/example.ts
@@ -11,10 +11,13 @@ import StagehandConfig from "@/stagehand.config";
 async function example() {
   const stagehand = new Stagehand({
     ...StagehandConfig,
-    modelName: "o3-mini",
+    modelName: "gpt-4o-2024-11-20",
+    env: "LOCAL",
   });
   await stagehand.init();
   await stagehand.page.goto("https://www.google.com");
+  await stagehand.page.act("type 'browserbase' into the search bar");
+  await stagehand.page.act("click the search button");
 }
 
 (async () => {

--- a/lib/llm/LLMProvider.ts
+++ b/lib/llm/LLMProvider.ts
@@ -13,6 +13,8 @@ const modelToProviderMap: { [key in AvailableModel]: ModelProvider } = {
   "gpt-4o": "openai",
   "gpt-4o-mini": "openai",
   "gpt-4o-2024-08-06": "openai",
+  "gpt-4o-2024-11-20": "openai",
+  "gpt-4o-2024-05-13": "openai",
   "o1-mini": "openai",
   "o1-preview": "openai",
   "o3-mini": "openai",

--- a/types/model.ts
+++ b/types/model.ts
@@ -5,7 +5,9 @@ import { z } from "zod";
 export const AvailableModelSchema = z.enum([
   "gpt-4o",
   "gpt-4o-mini",
+  "gpt-4o-2024-11-20",
   "gpt-4o-2024-08-06",
+  "gpt-4o-2024-05-13",
   "claude-3-5-sonnet-latest",
   "claude-3-5-sonnet-20241022",
   "claude-3-5-sonnet-20240620",


### PR DESCRIPTION
# why
OpenAI supports a [variety of 4o snapshots](https://platform.openai.com/docs/models)

# what changed
Added support for other openai gpt 4o snapshots in `AvailableModel`

# test plan
Ran the following in `examples/example.ts` and it passed
```
async function example() {
  const stagehand = new Stagehand({
    ...StagehandConfig,
    modelName: "gpt-4o-2024-11-20",
    env: "LOCAL",
  });
  await stagehand.init();
  await stagehand.page.goto("https://www.google.com");
  await stagehand.page.act("type 'browserbase' into the search bar");
  await stagehand.page.act("click the search button");
}
```