### PR TITLE
added iframes as the last observeResult on pages with 1+ iframes

### DIFF
--- a/.changeset/odd-eggs-bake.md
+++ b/.changeset/odd-eggs-bake.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": minor
+---
+
+Including Iframes in ObserveResults. This appends any iframe(s) found in the page to the end of observe results on any observe call.

--- a/evals/evals.config.json
+++ b/evals/evals.config.json
@@ -239,6 +239,14 @@
     {
       "name": "observe_taxes",
       "categories": ["observe"]
+    },
+    {
+      "name": "observe_iframes1",
+      "categories": ["observe"]
+    },
+    {
+      "name": "observe_iframes2",
+      "categories": ["observe"]
     }
   ]
 }

--- a/evals/tasks/observe_iframes1.ts
+++ b/evals/tasks/observe_iframes1.ts
@@ -1,0 +1,90 @@
+import { initStagehand } from "@/evals/initStagehand";
+import { EvalFunction } from "@/types/evals";
+
+export const observe_iframes1: EvalFunction = async ({ modelName, logger }) => {
+  const { stagehand, initResponse } = await initStagehand({
+    modelName,
+    logger,
+  });
+
+  const { debugUrl, sessionUrl } = initResponse;
+
+  await stagehand.page.goto("https://tucowsdomains.com/abuse-form/phishing/");
+
+  const observations = await stagehand.page.observe({
+    instruction: "find the main header of the page",
+  });
+
+  if (observations.length === 0) {
+    await stagehand.close();
+    return {
+      _success: false,
+      observations,
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
+  }
+
+  const possibleLocators = [
+    `#primary > div.singlePage > section > div > div > article > div > iframe`,
+    `#primary > div.heroBanner > section > div > h1`,
+  ];
+
+  const possibleHandles = [];
+  for (const locatorStr of possibleLocators) {
+    const locator = stagehand.page.locator(locatorStr);
+    const handle = await locator.elementHandle();
+    if (handle) {
+      possibleHandles.push({ locatorStr, handle });
+    }
+  }
+
+  let foundMatch = false;
+  let matchedLocator: string | null = null;
+
+  for (const observation of observations) {
+    try {
+      const observationLocator = stagehand.page
+        .locator(observation.selector)
+        .first();
+      const observationHandle = await observationLocator.elementHandle();
+      if (!observationHandle) {
+        continue;
+      }
+
+      for (const { locatorStr, handle: candidateHandle } of possibleHandles) {
+        const isSameNode = await observationHandle.evaluate(
+          (node, otherNode) => node === otherNode,
+          candidateHandle,
+        );
+        if (isSameNode) {
+          foundMatch = true;
+          matchedLocator = locatorStr;
+          break;
+        }
+      }
+
+      if (foundMatch) {
+        break;
+      }
+    } catch (error) {
+      console.warn(
+        `Failed to check observation with selector ${observation.selector}:`,
+        error.message,
+      );
+      continue;
+    }
+  }
+
+  await stagehand.close();
+
+  return {
+    _success: foundMatch,
+    matchedLocator,
+    observations,
+    debugUrl,
+    sessionUrl,
+    logs: logger.getLogs(),
+  };
+};

--- a/evals/tasks/observe_iframes2.ts
+++ b/evals/tasks/observe_iframes2.ts
@@ -1,0 +1,90 @@
+import { initStagehand } from "@/evals/initStagehand";
+import { EvalFunction } from "@/types/evals";
+
+export const observe_iframes2: EvalFunction = async ({ modelName, logger }) => {
+  const { stagehand, initResponse } = await initStagehand({
+    modelName,
+    logger,
+  });
+
+  const { debugUrl, sessionUrl } = initResponse;
+
+  await stagehand.page.goto(
+    "https://iframetester.com/?url=https://shopify.com",
+  );
+  await new Promise((resolve) => setTimeout(resolve, 5000));
+
+  const observations = await stagehand.page.observe({
+    instruction: "find the main header of the page",
+  });
+
+  if (observations.length === 0) {
+    await stagehand.close();
+    return {
+      _success: false,
+      observations,
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
+  }
+
+  const possibleLocators = [`#iframe-window`, `body > header > h1`];
+
+  const possibleHandles = [];
+  for (const locatorStr of possibleLocators) {
+    const locator = stagehand.page.locator(locatorStr);
+    const handle = await locator.elementHandle();
+    if (handle) {
+      possibleHandles.push({ locatorStr, handle });
+    }
+  }
+
+  let foundMatch = false;
+  let matchedLocator: string | null = null;
+
+  for (const observation of observations) {
+    try {
+      const observationLocator = stagehand.page
+        .locator(observation.selector)
+        .first();
+      const observationHandle = await observationLocator.elementHandle();
+      if (!observationHandle) {
+        continue;
+      }
+
+      for (const { locatorStr, handle: candidateHandle } of possibleHandles) {
+        const isSameNode = await observationHandle.evaluate(
+          (node, otherNode) => node === otherNode,
+          candidateHandle,
+        );
+        if (isSameNode) {
+          foundMatch = true;
+          matchedLocator = locatorStr;
+          break;
+        }
+      }
+
+      if (foundMatch) {
+        break;
+      }
+    } catch (error) {
+      console.warn(
+        `Failed to check observation with selector ${observation.selector}:`,
+        error.message,
+      );
+      continue;
+    }
+  }
+
+  await stagehand.close();
+
+  return {
+    _success: foundMatch,
+    matchedLocator,
+    observations,
+    debugUrl,
+    sessionUrl,
+    logs: logger.getLogs(),
+  };
+};

--- a/lib/a11y/utils.ts
+++ b/lib/a11y/utils.ts
@@ -156,6 +156,7 @@ export async function buildHierarchicalTree(
 ): Promise<TreeResult> {
   // Map to store processed nodes for quick lookup
   const nodeMap = new Map<string, AccessibilityNode>();
+  const iframe_list: AccessibilityNode[] = [];
 
   // First pass: Create nodes that are meaningful
   // We only keep nodes that either have a name or children to avoid cluttering the tree
@@ -194,6 +195,15 @@ export async function buildHierarchicalTree(
   // Second pass: Establish parent-child relationships
   // This creates the actual tree structure by connecting nodes based on parentId
   nodes.forEach((node) => {
+    // Add iframes to a list and include in the return object
+    const isIframe = node.role === "Iframe";
+    if (isIframe) {
+      const iframeNode = {
+        role: node.role,
+        nodeId: node.nodeId,
+      };
+      iframe_list.push(iframeNode);
+    }
     if (node.parentId && nodeMap.has(node.nodeId)) {
       const parentNode = nodeMap.get(node.parentId);
       const currentNode = nodeMap.get(node.nodeId);
@@ -228,6 +238,7 @@ export async function buildHierarchicalTree(
   return {
     tree: finalTree,
     simplified: simplifiedFormat,
+    iframes: iframe_list,
   };
 }
 
@@ -283,7 +294,6 @@ export async function getAccessibilityTree(
       message: `got accessibility tree in ${Date.now() - startTime}ms`,
       level: 1,
     });
-
     return hierarchicalTree;
   } catch (error) {
     logger({

--- a/types/context.ts
+++ b/types/context.ts
@@ -24,4 +24,5 @@ export type AccessibilityNode = {
 export interface TreeResult {
   tree: AccessibilityNode[];
   simplified: string;
+  iframes?: AccessibilityNode[];
 }


### PR DESCRIPTION
# why
Providing a way to flag iframes on observeResults until support for iframes is complete

# what changed
On functions creating the context tree of the website for the LLM, we save iframes as a list and append it to the end of observeResults to generate an XPath for them. Sample result:
```
  {
    description: 'an iframe',
    method: 'not-supported',
    arguments: [],
    selector: 'xpath=/html/body[1]/main[1]/div[2]/section[1]/div[1]/div[1]/article[1]/div[1]/iframe[1]'
  }
```

# test plan
Created two evals:
- [x] observe_iframes1
- [x] observe_iframes2

Both passing