### PR TITLE
wait for captcha solve after navigation

### DIFF
--- a/.changeset/polite-rivers-sip.md
+++ b/.changeset/polite-rivers-sip.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": minor
+---
+
+Enabled support for Browserbase captcha solving after page navigations. This can be enabled with the new constructor parameter: `waitForCaptchaSolves`.

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -152,6 +152,12 @@ export class StagehandPage {
   }
 
   async waitForCaptcha(timeoutMs?: number) {
+    if (this.stagehand.env === "LOCAL") {
+      throw new Error(
+        "The waitForCaptcha method may only be used when using the Browserbase environment.",
+      );
+    }
+
     this.stagehand.log({
       category: "captcha",
       message: "Waiting for captcha",

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -72,12 +72,8 @@ export class StagehandPage {
           "You seem to be referencing a page in an uninitialized `Stagehand` object. Ensure you are running `await stagehand.init()` on the Stagehand object before referencing the `page` object.",
         );
       },
-      waitForCaptcha: () => {
-        throw new Error(
-          "You seem to be calling `waitForCaptcha` on a page in an uninitialized `Stagehand` object. Ensure you are running `await stagehand.init()` on the Stagehand object before referencing the `page` object.",
-        );
-      },
     });
+
     this.stagehand = stagehand;
     this.intContext = context;
     this.llmClient = llmClient;
@@ -96,6 +92,7 @@ export class StagehandPage {
         llmClient: llmClient,
         userProvidedInstructions,
         selfHeal: this.stagehand.selfHeal,
+        waitForCaptchaSolves: this.waitForCaptchaSolves,
       });
       this.extractHandler = new StagehandExtractHandler({
         stagehand: this.stagehand,
@@ -163,7 +160,7 @@ export class StagehandPage {
    * @throws Error if the timeout is reached before captcha solving starts
    * @returns Promise that resolves when the captcha is solved
    */
-  private async _waitForCaptcha(timeoutMs?: number) {
+  public async waitForCaptchaSolve(timeoutMs?: number) {
     if (this.stagehand.env === "LOCAL") {
       throw new Error(
         "The waitForCaptcha method may only be used when using the Browserbase environment.",
@@ -222,7 +219,7 @@ export class StagehandPage {
 
             if (this.waitForCaptchaSolves) {
               try {
-                await this._waitForCaptcha(1000);
+                await this.waitForCaptchaSolve(1000);
               } catch {
                 // ignore
               }

--- a/lib/handlers/actHandler.ts
+++ b/lib/handlers/actHandler.ts
@@ -30,6 +30,7 @@ export class StagehandActHandler {
   };
   private readonly userProvidedInstructions?: string;
   private readonly selfHeal: boolean;
+  private readonly waitForCaptchaSolves: boolean;
 
   constructor({
     verbose,
@@ -39,6 +40,7 @@ export class StagehandActHandler {
     stagehandPage,
     userProvidedInstructions,
     selfHeal,
+    waitForCaptchaSolves,
   }: {
     verbose: 0 | 1 | 2;
     llmProvider: LLMProvider;
@@ -49,6 +51,7 @@ export class StagehandActHandler {
     stagehandContext: StagehandContext;
     userProvidedInstructions?: string;
     selfHeal: boolean;
+    waitForCaptchaSolves: boolean;
   }) {
     this.verbose = verbose;
     this.llmProvider = llmProvider;
@@ -59,6 +62,7 @@ export class StagehandActHandler {
     this.stagehandPage = stagehandPage;
     this.userProvidedInstructions = userProvidedInstructions;
     this.selfHeal = selfHeal;
+    this.waitForCaptchaSolves = waitForCaptchaSolves;
   }
 
   /**
@@ -1379,6 +1383,14 @@ export class StagehandActHandler {
 
         if (this.stagehandPage.page.url() !== initialUrl) {
           steps += `  Result (Important): Page URL changed from ${initialUrl} to ${this.stagehandPage.page.url()}\n\n`;
+
+          if (this.waitForCaptchaSolves) {
+            try {
+              await this.stagehandPage.waitForCaptchaSolve(1000);
+            } catch {
+              // ignore
+            }
+          }
         }
 
         const actionCompleted = await this._verifyActionCompletion({

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -332,6 +332,7 @@ export class Stagehand {
   private usingAPI: boolean;
   private modelName: AvailableModel;
   private apiClient: StagehandAPI | undefined;
+  private waitForCaptchaSolves: boolean;
   public readonly selfHeal: boolean;
 
   constructor(
@@ -354,6 +355,7 @@ export class Stagehand {
       systemPrompt,
       useAPI,
       selfHeal = true,
+      waitForCaptchaSolves = false,
     }: ConstructorParams = {
       env: "BROWSERBASE",
     },
@@ -398,6 +400,8 @@ export class Stagehand {
         "STAGEHAND_API_URL is required when using the API. Please set it in your environment variables.",
       );
     }
+
+    this.waitForCaptchaSolves = waitForCaptchaSolves;
 
     this.selfHeal = selfHeal;
   }
@@ -498,6 +502,7 @@ export class Stagehand {
       this.llmClient,
       this.userProvidedInstructions,
       this.apiClient,
+      this.waitForCaptchaSolves,
     ).init();
 
     // Set the browser to headless mode if specified

--- a/types/page.ts
+++ b/types/page.ts
@@ -36,6 +36,8 @@ export interface Page extends Omit<PlaywrightPage, "on"> {
   on: {
     (event: "popup", listener: (page: Page) => unknown): Page;
   } & PlaywrightPage["on"];
+
+  waitForCaptcha(): Promise<void>;
 }
 
 // Empty type for now, but will be used in the future

--- a/types/page.ts
+++ b/types/page.ts
@@ -37,7 +37,7 @@ export interface Page extends Omit<PlaywrightPage, "on"> {
     (event: "popup", listener: (page: Page) => unknown): Page;
   } & PlaywrightPage["on"];
 
-  waitForCaptcha(): Promise<void>;
+  waitForCaptcha(timeoutMs?: number): Promise<void>;
 }
 
 // Empty type for now, but will be used in the future

--- a/types/page.ts
+++ b/types/page.ts
@@ -36,8 +36,6 @@ export interface Page extends Omit<PlaywrightPage, "on"> {
   on: {
     (event: "popup", listener: (page: Page) => unknown): Page;
   } & PlaywrightPage["on"];
-
-  waitForCaptcha(timeoutMs?: number): Promise<void>;
 }
 
 // Empty type for now, but will be used in the future

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -31,6 +31,12 @@ export interface ConstructorParams {
    */
   useAPI?: boolean;
   selfHeal?: boolean;
+  /**
+   * Wait for captchas to be solved after navigation when using Browserbase environment.
+   *
+   * @default false
+   */
+  waitForCaptchaSolves?: boolean;
 }
 
 export interface InitOptions {


### PR DESCRIPTION
# why
This PR adds native support for browserbase captcha solving. If a captcha is encountered after the page navigates, it should wait for the browserbase solve events to fire.

# what changed
Added a `waitForCaptchaSolve` method to `StagehandPage` that waits for the `browserbase-solving-finished` console event. There is also a flag in the constructor that can opt-in to automatically calling this method upon page navigation.

# test plan
E2E evals