### PR TITLE
fixing 5s timeout on actHandler

### DIFF
--- a/lib/handlers/actHandler.ts
+++ b/lib/handlers/actHandler.ts
@@ -502,7 +502,6 @@ export class StagehandActHandler {
         },
       });
 
-      // NAVIDNOTE: Should this happen before we wait for locator[method]?
       const newOpenedTab = await Promise.race([
         new Promise<Page | null>((resolve) => {
           // TODO: This is a hack to get the new page
@@ -544,7 +543,6 @@ export class StagehandActHandler {
 
       await Promise.race([
         this.stagehandPage.page.waitForLoadState("networkidle"),
-        new Promise((resolve) => setTimeout(resolve, 5_000)),
       ]).catch((e) => {
         this.logger({
           category: "action",


### PR DESCRIPTION
# why
we're waiting too long after any action that could potentially redirect to a new page

# what changed
removed a timeout of 5s in `performPlaywrightMethod` on potential redirect actions

# test plan
ran evals for `observe_amazon_add_to_cart`  locally and on bb, but ci evals should pinpoint issues at a larger scale