### PR TITLE
feat: add Bun runtime check to prevent initialization in Bun environment

### DIFF
--- a/.changeset/rotten-buttons-relate.md
+++ b/.changeset/rotten-buttons-relate.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Bun runs will now throw a more informed error

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -30,7 +30,7 @@ import { StagehandAPI } from "./api";
 import { scriptContent } from "./dom/build/scriptContent";
 import { LLMClient } from "./llm/LLMClient";
 import { LLMProvider } from "./llm/LLMProvider";
-import { logLineToString } from "./utils";
+import { logLineToString, isRunningInBun } from "./utils";
 
 dotenv.config({ path: ".env" });
 
@@ -439,6 +439,14 @@ export class Stagehand {
     /** @deprecated Use constructor options instead */
     initOptions?: InitOptions,
   ): Promise<InitResult> {
+    if (isRunningInBun()) {
+      throw new Error(
+        "Playwright does not currently support the Bun runtime environment. " +
+        "Please use Node.js instead. For more information, see: " +
+        "https://github.com/microsoft/playwright/issues/27139"
+      );
+    }
+
     if (initOptions) {
       console.warn(
         "Passing parameters to init() is deprecated and will be removed in the next major version. Use constructor options instead.",

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -442,8 +442,8 @@ export class Stagehand {
     if (isRunningInBun()) {
       throw new Error(
         "Playwright does not currently support the Bun runtime environment. " +
-        "Please use Node.js instead. For more information, see: " +
-        "https://github.com/microsoft/playwright/issues/27139"
+          "Please use Node.js instead. For more information, see: " +
+          "https://github.com/microsoft/playwright/issues/27139",
       );
     }
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -436,7 +436,9 @@ export async function clearOverlays(page: Page) {
  * @returns {boolean} True if running in Bun, false otherwise.
  */
 export function isRunningInBun(): boolean {
-  return typeof process !== 'undefined' && 
-         typeof process.versions !== 'undefined' && 
-         'bun' in process.versions;
+  return (
+    typeof process !== "undefined" &&
+    typeof process.versions !== "undefined" &&
+    "bun" in process.versions
+  );
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -430,3 +430,13 @@ export async function clearOverlays(page: Page) {
     });
   });
 }
+
+/**
+ * Detects if the code is running in the Bun runtime environment.
+ * @returns {boolean} True if running in Bun, false otherwise.
+ */
+export function isRunningInBun(): boolean {
+  return typeof process !== 'undefined' && 
+         typeof process.versions !== 'undefined' && 
+         'bun' in process.versions;
+}


### PR DESCRIPTION
From @eastlondoner:

This PR adds a runtime check to detect if Stagehand is being initialized in the Bun environment. Since Playwright does not currently support Bun (see https://github.com/microsoft/playwright/issues/27139), this check prevents initialization and provides a helpful error message directing users to use Node.js instead.\n\nChanges:\n- Add isRunningInBun() utility function to detect Bun runtime\n- Add runtime check in Stagehand's init() method\n- Throw descriptive error with reference to Playwright issue\n\nCloses https://github.com/microsoft/playwright/issues/27139

**This PR will throw an error even on local bun runtimes which probably work**