### PR TITLE
update e2e tests to reflect docs updates

### DIFF
--- a/evals/deterministic/e2e.playwright.config.ts
+++ b/evals/deterministic/e2e.playwright.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   // Look in "tests" for test files...
   testDir: "./tests",
   // ...but ignore anything in "tests/browserbase & "tests/local"
-  testIgnore: ["**/browserbase/**", "**/local/**"],
+  testIgnore: ["./tests/browserbase/**", "./tests/local/**"],
 
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   /* Run tests in files in parallel */

--- a/evals/deterministic/e2e.playwright.config.ts
+++ b/evals/deterministic/e2e.playwright.config.ts
@@ -7,8 +7,7 @@ export default defineConfig({
   // Look in "tests" for test files...
   testDir: "./tests",
   // ...but ignore anything in "tests/browserbase & "tests/local"
-  testIgnore: ["./tests/browserbase/**", "./tests/local/**"],
-
+  testIgnore: ["**/browserbase/**", "**/local/**"],
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   /* Run tests in files in parallel */
   fullyParallel: true,

--- a/evals/deterministic/tests/page/waitFor.test.ts
+++ b/evals/deterministic/tests/page/waitFor.test.ts
@@ -152,11 +152,6 @@ test.describe("StagehandPage - waitFor", () => {
     const page = stagehand.page;
     await page.goto("https://docs.browserbase.com");
 
-    const getStartedLink = page.locator(
-      "div.not-prose:nth-child(3) > a:nth-child(1) > div:nth-child(1)",
-    );
-    await getStartedLink.click();
-
     await page.waitForURL(/.*what-is-browserbase.*/);
     expect(page.url()).toContain("/what-is-browserbase");
 

--- a/evals/deterministic/tests/page/waitFor.test.ts
+++ b/evals/deterministic/tests/page/waitFor.test.ts
@@ -157,8 +157,8 @@ test.describe("StagehandPage - waitFor", () => {
     );
     await getStartedLink.click();
 
-    await page.waitForURL(/.*getting-started.*/);
-    expect(page.url()).toContain("/getting-started");
+    await page.waitForURL(/.*what-is-browserbase.*/);
+    expect(page.url()).toContain("/what-is-browserbase");
 
     await stagehand.close();
   });


### PR DESCRIPTION
# why
E2E tests, particularly `waitFor` tests, were failing due to the change in the redirect URL of `https://docs.browserbase.com`

# what changed
Updated the `waitForURL` test to reflect the changes.

# test plan
E2E tests should pass on CI.