### PR TITLE
handle close session

### DIFF
--- a/.changeset/pretty-parrots-wave.md
+++ b/.changeset/pretty-parrots-wave.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+handle attempt to close session that has already been closed when using the api

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -112,9 +112,10 @@ export class StagehandAPI {
     });
   }
 
-  async end(): Promise<void> {
-    return this.execute<void>({
-      method: "end",
+  async end(): Promise<Response> {
+    const url = `/sessions/${this.sessionId}/end`;
+    return await this.request(url, {
+      method: "POST",
     });
   }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -711,7 +711,21 @@ export class Stagehand {
 
   async close(): Promise<void> {
     if (this.apiClient) {
-      await this.apiClient.end();
+      try {
+        await this.apiClient.end();
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          error.message.includes("Attempted to close session")
+        ) {
+          this.log({
+            category: "close",
+            message:
+              "Warning: attempted to end a session that is not currently active",
+            level: 0,
+          });
+        }
+      }
       return;
     } else {
       await this.context.close();


### PR DESCRIPTION
# why
- catch error if we attempt to close a session that has already been closed when using the API 
