### PR TITLE
Fix: Skip Non-HTTP Protocol in New Tab Handling to Prevent Errors

### DIFF
--- a/lib/handlers/actHandler.ts
+++ b/lib/handlers/actHandler.ts
@@ -525,21 +525,24 @@ export class StagehandActHandler {
       });
 
       if (newOpenedTab) {
-        this.logger({
-          category: "action",
-          message: "new page detected (new tab) with URL",
-          level: 1,
-          auxiliary: {
-            url: {
-              value: newOpenedTab.url(),
-              type: "string",
+        const newOpenedTabUrl = newOpenedTab.url();
+        if (newOpenedTabUrl.startsWith("http")) {
+          this.logger({
+            category: "action",
+            message: "new page detected (new tab) with URL",
+            level: 1,
+            auxiliary: {
+              url: {
+                value: newOpenedTabUrl,
+                type: "string",
+              },
             },
-          },
-        });
-        await newOpenedTab.close();
-        await this.stagehandPage.page.goto(newOpenedTab.url());
-        await this.stagehandPage.page.waitForLoadState("domcontentloaded");
-        await this.stagehandPage._waitForSettledDom(domSettleTimeoutMs);
+          });
+          await newOpenedTab.close();
+          await this.stagehandPage.page.goto(newOpenedTabUrl);
+          await this.stagehandPage.page.waitForLoadState("domcontentloaded");
+          await this.stagehandPage._waitForSettledDom(domSettleTimeoutMs);
+        }
       }
 
       await Promise.race([


### PR DESCRIPTION
#### **Why**  
Opening a new tab with certain protocols (`blob:`, `tel:`, `about:`, `javascript:`, etc.) was causing navigation errors when `goto` was attempted on an invalid URL. This resulted in `Protocol error (Page.navigate): Cannot navigate to invalid URL`, affecting test execution and stability.  

https://github.com/browserbase/stagehand/issues/527

It addresses the following issue where `newOpenedTab` is identified as `:` when the url to navigate to is in a new tab and the protocol does not start with `http`.

E.g.

1. `const url = "blob:http://localhost:3001/3bdb0769-7903-4173-b655-89275ac7296f";`
2. `const url = "tel:+447555333222";`
3. `const url = "mailto:test@test.com";`

```jsx
<a href={url} rel="noopener noreferrer" target="_blank">example</a>
```

```
38/39 steps [=============================================================================  ] 2025-02-26T18:39:40.935Z::[stagehand:action] Performing act from an ObserveResult 
2025-02-26T18:39:40.936Z::[stagehand:action] performing playwright method 
2025-02-26T18:39:40.936Z::[stagehand:action] page URL before click 
2025-02-26T18:39:41.020Z::[stagehand:action] clicking element, checking for page navigation 
2025-02-26T18:39:41.047Z::[stagehand:action] clicked element 
2025-02-26T18:39:41.047Z::[stagehand:action] new page detected (new tab) with URL

### ADDED LOGS
newOpenedTab.url(): ':'
goto url: ':' options: 'undefined'
2025-02-26T18:39:41.052Z::[stagehand:action] Error performing act from an ObserveResult. Trying again with regular act method
 page.goto: Protocol error (Page.navigate): Cannot navigate to invalid URL
Call log:
  - navigating to ":", waiting until "load"

 page.goto: Protocol error (Page.navigate): Cannot navigate to invalid URL
Call log:
  - navigating to ":", waiting until "load"

    at _StagehandPage.<anonymous> (/Users/gruckion/workdir/backend/e2e/node_modules/.pnpm/@browserbasehq+stagehand@1.13.1_@playwright+test@1.50.1_deepmerge@4.3.1_dotenv@16.4.7_openai@_2f543nfxzocuvsmquu7wxjj7dq/node_modules/@browserbasehq/stagehand/dist/index.js:3811:88)
    at /Users/gruckion/workdir/backend/e2e/node_modules/.pnpm/@browserbasehq+stagehand@1.13.1_@playwright+test@1.50.1_deepmerge@4.3.1_dotenv@16.4.7_openai@_2f543nfxzocuvsmquu7wxjj7dq/node_modules/@browserbasehq/stagehand/dist/index.js:76:61
    at __async (/Users/gruckion/workdir/backend/e2e/node_modules/.pnpm/@browserbasehq+stagehand@1.13.1_@playwright+test@1.50.1_deepmerge@4.3.1_dotenv@16.4.7_openai@_2f543nfxzocuvsmquu7wxjj7dq/node_modules/@browserbasehq/stagehand/dist/index.js:60:10)
    at Proxy.<anonymous> (/Users/gruckion/workdir/backend/e2e/node_modules/.pnpm/@browserbasehq+stagehand@1.13.1_@playwright+test@1.50.1_deepmerge@4.3.1_dotenv@16.4.7_openai@_2f543nfxzocuvsmquu7wxjj7dq/node_modules/@browserbasehq/stagehand/dist/index.js:3809:38)
    at StagehandActHandler.<anonymous> (/Users/gruckion/workdir/backend/e2e/node_modules/.pnpm/@browserbasehq+stagehand@1.13.1_@playwright+test@1.50.1_deepmerge@4.3.1_dotenv@16.4.7_openai@_2f543nfxzocuvsmquu7wxjj7dq/node_modules/@browserbasehq/stagehand/dist/index.js:2028:41)
    at fulfilled (/Users/gruckion/workdir/backend/e2e/node_modules/.pnpm/@browserbasehq+stagehand@1.13.1_@playwright+test@1.50.1_deepmerge@4.3.1_dotenv@16.4.7_openai@_2f543nfxzocuvsmquu7wxjj7dq/node_modules/@browserbasehq/stagehand/dist/index.js:63:24)
2025-02-26T18:39:41.055Z::[stagehand:act] running act 
2025-02-26T18:39:41.056Z::[stagehand:action] running / continuing action 
2025-02-26T18:39:41.056Z::[stagehand:action] processing DOM 
2025-02-26T18:39:43.009Z::[stagehand:action] looking at chunk

### ADDED LOGS 
tool2: {
  description: 'execute the next playwright step that directly accomplishes the goal',
  parameters: {
    type: 'object',
    required: [ 'method', 'element', 'args', 'step', 'completed' ],
    properties: {
      method: [Object],
      element: [Object],
      args: [Object],
      step: [Object],
      why: [Object],
      completed: [Object]
    }
  }
}
zodSchema2 {
  type: 'object',
  required: [ 'method', 'element', 'args', 'step', 'completed' ],
  properties: {
    method: { type: 'string', description: 'The playwright function to call.' },
    element: { type: 'number', description: 'The element number to act on' },
    args: {
      type: 'array',
      description: 'The required arguments',
      items: [Object]
    },
    step: {
      type: 'string',
      description: 'human readable description of the step that is taken in the past tense. Please be very detailed.'
    },
    why: {
      type: 'string',
      description: 'why is this step taken? how does it advance the goal?'
    },
    completed: {
      type: 'boolean',
      description: 'true if the goal should be accomplished after this step'
    }
  }
}
options: undefined
schema {
  type: 'object',
  required: [ 'method', 'element', 'args', 'step', 'completed' ],
  properties: {
    method: { type: 'string', description: 'The playwright function to call.' },
    element: { type: 'number', description: 'The element number to act on' },
    args: {
      type: 'array',
      description: 'The required arguments',
      items: [Object]
    },
    step: {
      type: 'string',
      description: 'human readable description of the step that is taken in the past tense. Please be very detailed.'
    },
    why: {
      type: 'string',
      description: 'why is this step taken? how does it advance the goal?'
    },
    completed: {
      type: 'boolean',
      description: 'true if the goal should be accomplished after this step'
    }
  }
}
options { '$refStrategy': 'none', target: 'jsonSchema7' }
2025-02-26T18:39:43.013Z::[stagehand:action] error performing action - b
 Cannot read properties of undefined (reading 'typeName')
 TypeError: Cannot read properties of undefined (reading 'typeName')
    at parseDef (file:///Users/gruckion/workdir/backend/e2e/node_modules/.pnpm/zod-to-json-schema@3.24.2_zod@3.24.2/node_modules/zod-to-json-schema/dist/esm/parseDef.js:19:54)
    at zodToJsonSchema (file:///Users/gruckion/workdir/backend/e2e/node_modules/.pnpm/zod-to-json-schema@3.24.2_zod@3.24.2/node_modules/zod-to-json-schema/dist/esm/zodToJsonSchema.js:21:18)
    at zodSchema (file:///Users/gruckion/workdir/backend/e2e/node_modules/.pnpm/@ai-sdk+ui-utils@1.1.15_zod@3.24.2/node_modules/@ai-sdk/ui-utils/dist/index.mjs:1465:5)
    at asSchema (file:///Users/gruckion/workdir/backend/e2e/node_modules/.pnpm/@ai-sdk+ui-utils@1.1.15_zod@3.24.2/node_modules/@ai-sdk/ui-utils/dist/index.mjs:1497:38)
    at file:///Users/gruckion/workdir/backend/e2e/node_modules/.pnpm/ai@4.1.45_react@19.0.0_zod@3.24.2/node_modules/ai/dist/index.mjs:3580:25
    at Array.map (<anonymous>)
    at prepareToolsAndToolChoice (file:///Users/gruckion/workdir/backend/e2e/node_modules/.pnpm/ai@4.1.45_react@19.0.0_zod@3.24.2/node_modules/ai/dist/index.mjs:3570:26)
    at fn (file:///Users/gruckion/workdir/backend/e2e/node_modules/.pnpm/ai@4.1.45_react@19.0.0_zod@3.24.2/node_modules/ai/dist/index.mjs:3877:12)
    at file:///Users/gruckion/workdir/backend/e2e/node_modules/.pnpm/ai@4.1.45_react@19.0.0_zod@3.24.2/node_modules/ai/dist/index.mjs:470:28
    at Object.startActiveSpan (file:///Users/gruckion/workdir/backend/e2e/node_modules/.pnpm/ai@4.1.45_react@19.0.0_zod@3.24.2/node_modules/ai/dist/index.mjs:397:14)
1 scenario (1 passed)
39 steps (39 passed)
0m52.316s (executing steps: 0m52.292s)
```

#### **What Changed**  
- Added an explicit check to ensure the new tab's URL starts with `"http"` before attempting to navigate using `goto`.  
- Prevents navigation attempts on unsupported or sandboxed protocols.  

#### **Test Plan**  
- Ran E2E tests to verify that valid HTTP(S) pages continue to be handled correctly.  
- Tested cases where new tabs open with unsupported protocols (e.g., `about:blank`, `blob:`, `mailto:`) to ensure they are ignored without causing errors.  
- Monitored logs to confirm correct behaviour when encountering non-http URLs.  
- Ensured Stagehand does not throw navigation errors for unsupported protocols.