### PR TITLE
end BB session on exit

### DIFF
--- a/.changeset/ninety-scissors-study.md
+++ b/.changeset/ninety-scissors-study.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+call this.end() if the process exists


### PR DESCRIPTION
# why
- we should call `this.end()` if the process exists on the SDK side (`ctrl + c`, error, etc)
