### PR TITLE
make slow act the default

### DIFF
--- a/.changeset/wild-hats-turn.md
+++ b/.changeset/wild-hats-turn.md
@@ -2,4 +2,4 @@
 "@browserbasehq/stagehand": minor
 ---
 
-`act()` now uses `observe()` under the hood. This results in significant performance improvements.
+`act()` can now use `observe()` under the hood, resulting in significant performance improvements. To opt-in to this change, set `slowDomBasedAct` to `true` in `ActOptions`.

--- a/.changeset/wild-hats-turn.md
+++ b/.changeset/wild-hats-turn.md
@@ -2,4 +2,4 @@
 "@browserbasehq/stagehand": minor
 ---
 
-`act()` can now use `observe()` under the hood, resulting in significant performance improvements. To opt-in to this change, set `slowDomBasedAct` to `true` in `ActOptions`.
+`act()` can now use `observe()` under the hood, resulting in significant performance improvements. To opt-in to this change, set `slowDomBasedAct: true` in `ActOptions`.

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -465,7 +465,7 @@ export class StagehandPage {
       useVision, // still destructure this but will not pass it on
       variables = {},
       domSettleTimeoutMs,
-      slowDomBasedAct = false,
+      slowDomBasedAct = true,
     } = actionOrOptions;
 
     if (typeof useVision !== "undefined") {

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -81,7 +81,7 @@ export interface ActOptions {
    * If true, the action will be performed in a slow manner that allows the DOM to settle.
    * This is useful for debugging.
    *
-   * @default false
+   * @default true
    */
   slowDomBasedAct?: boolean;
 }


### PR DESCRIPTION
# why
We don't want to make slow act (`act()` that doesn't use an `ObserveResult`) the default for this release.

# what changed
Default `slowDomBasedAct` to `true`.

# test plan
E2E tests
