### PR TITLE
handle prepended 'xpath='

### DIFF
--- a/.changeset/healthy-walls-refuse.md
+++ b/.changeset/healthy-walls-refuse.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+accept xpaths with 'xpath=' prepended to the front in addition to xpaths without

--- a/lib/handlers/extractHandler.ts
+++ b/lib/handlers/extractHandler.ts
@@ -184,7 +184,7 @@ export class StagehandExtractHandler {
     await this.stagehandPage._waitForSettledDom(domSettleTimeoutMs);
     await this.stagehandPage.startDomDebug();
 
-    const targetXpath = selector;
+    const targetXpath = selector?.replace(/^xpath=/, "") ?? "";
 
     // **2:** Store the original DOM before any mutations
     // we need to store the original DOM here because calling createTextBoundingBoxes()


### PR DESCRIPTION
# why
- change extract to accept xpaths that look like this: `"xpath=/html/body/div[5]/main/article/div[6]/div[2]/div"` in addition to xpaths that look like this `"/html/body/div[5]/main/article/div[6]/div[2]/div"`
- developers dont have to do this `replace(/^xpath=/, "")` in their own code. we handle it internally.

