### PR TITLE
fix for targetted extract

### DIFF
--- a/.changeset/great-lizards-yell.md
+++ b/.changeset/great-lizards-yell.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+fix targetted extract issue with scrollintoview and not chunking correctly

--- a/lib/dom/ElementContainer.ts
+++ b/lib/dom/ElementContainer.ts
@@ -51,6 +51,7 @@ export class ElementContainer extends StagehandContainer {
    * @returns A promise that resolves once scrolling is finished.
    */
   public async scrollTo(offset: number): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, 1500));
     this.el.scrollTo({ top: offset, behavior: "smooth" });
     await this.waitForScrollEnd();
   }
@@ -67,7 +68,7 @@ export class ElementContainer extends StagehandContainer {
     if (!element) {
       this.el.scrollTo({ top: 0, behavior: "smooth" });
     } else {
-      element.scrollIntoView({ behavior: "smooth", block: "end" });
+      element.scrollIntoView();
     }
     await this.waitForScrollEnd();
   }

--- a/lib/dom/process.ts
+++ b/lib/dom/process.ts
@@ -190,9 +190,10 @@ export async function processAllOfDom(xpath?: string) {
 
       // Now check if the element “fits” in the container’s viewport
       const scrollTargetHeight = scrollTarget.getViewportHeight();
-      const rect = candidateElementContainer.getBoundingClientRect();
+      const candidateElementContainerHeight =
+        candidateElementContainer.scrollHeight;
 
-      if (rect.height <= scrollTargetHeight) {
+      if (candidateElementContainerHeight <= scrollTargetHeight) {
         // Single-chunk approach
         console.log(
           "Element is smaller/equal to container’s viewport. Doing single chunk.",
@@ -235,7 +236,7 @@ export async function processAllOfDom(xpath?: string) {
   const startOffset = scrollTarget.getScrollPosition();
   const viewportHeight = scrollTarget.getViewportHeight();
   const maxScroll = candidateElementContainer
-    ? startOffset + candidateElementContainer.getBoundingClientRect().height
+    ? startOffset + candidateElementContainer.scrollHeight
     : scrollTarget.getScrollHeight();
   const chunkSize = viewportHeight;
 


### PR DESCRIPTION
# why
- our call to scrollIntoView was passing in the wrong args
- we were using boundingClientRect to determine when we should chunk. we need to use `scrollHeight`
