### PR TITLE
Fix/scroll scroll to end

### DIFF
--- a/.changeset/healthy-buttons-sell.md
+++ b/.changeset/healthy-buttons-sell.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+fix issue where processAllOfDom doesnt scroll to end of page when there is dynamic content

--- a/evals/tasks/extract_snowshoeing_destinations.ts
+++ b/evals/tasks/extract_snowshoeing_destinations.ts
@@ -19,7 +19,7 @@ export const extract_snowshoeing_destinations: EvalFunction = async ({
       "https://www.cbisland.com/blog/10-snowshoeing-adventures-on-cape-breton-island/",
     );
 
-    await stagehand.page.act({ action: "reject the cookies" });
+    await stagehand.page.act({ action: "accept the cookies" });
 
     const snowshoeing_regions = await stagehand.page.extract({
       instruction:


### PR DESCRIPTION
# why
- we used to calculate the scrollHeight dynamically within each chunk. this meant that when we were chunking, if there was dynamically loaded content, we would not prematurely stop chunking (because we were recalculating this value every chunk)
# what changed
- i added this behaviour back for the case where we do not have a defined `candidateElementContainer`
- this means that we continuously update the chunk end condition when we are collecting elements from the entire DOM