### PR TITLE
Add a timeout to dom based act

### DIFF
--- a/.changeset/small-zebras-jog.md
+++ b/.changeset/small-zebras-jog.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": minor
+---
+
+You can now set a timeout for dom-based stagehand act!

--- a/.changeset/wild-hats-turn.md
+++ b/.changeset/wild-hats-turn.md
@@ -2,4 +2,4 @@
 "@browserbasehq/stagehand": minor
 ---
 
-`act()` can now use `observe()` under the hood, resulting in significant performance improvements. To opt-in to this change, set `slowDomBasedAct: true` in `ActOptions`.
+`act()` can now use `observe()` under the hood, resulting in significant performance improvements. To opt-in to this change, set `slowDomBasedAct: false` in `ActOptions`.

--- a/.changeset/wild-hats-turn.md
+++ b/.changeset/wild-hats-turn.md
@@ -2,4 +2,4 @@
 "@browserbasehq/stagehand": minor
 ---
 
-`act()` now uses `observe()` under the hood. This results in significant performance improvements.
+`act()` can now use `observe()` under the hood, resulting in significant performance improvements. To opt-in to this change, set `slowDomBasedAct: true` in `ActOptions`.

--- a/evals/evals.config.json
+++ b/evals/evals.config.json
@@ -1,6 +1,10 @@
 {
   "tasks": [
     {
+      "name": "expect_act_timeout",
+      "categories": ["act"]
+    },
+    {
       "name": "extract_repo_name",
       "categories": ["extract"]
     },

--- a/evals/evals.config.json
+++ b/evals/evals.config.json
@@ -5,6 +5,10 @@
       "categories": ["act"]
     },
     {
+      "name": "expect_act_timeout_global",
+      "categories": ["act"]
+    },
+    {
       "name": "extract_repo_name",
       "categories": ["extract"]
     },

--- a/evals/initStagehand.ts
+++ b/evals/initStagehand.ts
@@ -55,11 +55,13 @@ export const initStagehand = async ({
   domSettleTimeoutMs,
   logger,
   configOverrides,
+  actTimeoutMs,
 }: {
   modelName: AvailableModel;
   domSettleTimeoutMs?: number;
   logger: EvalLogger;
   configOverrides?: Partial<ConstructorParams>;
+  actTimeoutMs?: number;
 }) => {
   let chosenApiKey: string | undefined = process.env.OPENAI_API_KEY;
   if (modelName.startsWith("claude")) {
@@ -73,6 +75,7 @@ export const initStagehand = async ({
     modelClientOptions: {
       apiKey: chosenApiKey,
     },
+    actTimeoutMs,
     logger: (logLine: LogLine) => {
       logger.log(logLine);
     },

--- a/evals/tasks/expect_act_timeout.ts
+++ b/evals/tasks/expect_act_timeout.ts
@@ -1,0 +1,30 @@
+import { initStagehand } from "@/evals/initStagehand";
+import { EvalFunction } from "@/types/evals";
+
+export const expect_act_timeout: EvalFunction = async ({
+  modelName,
+  logger,
+}) => {
+  const { stagehand, initResponse } = await initStagehand({
+    modelName,
+    logger,
+  });
+
+  const { debugUrl, sessionUrl } = initResponse;
+
+  await stagehand.page.goto("https://docs.stagehand.dev");
+
+  const result = await stagehand.page.act({
+    action: "search for 'Stagehand'",
+    timeoutMs: 1_000,
+  });
+
+  await stagehand.close();
+
+  return {
+    _success: result.success,
+    debugUrl,
+    sessionUrl,
+    logs: logger.getLogs(),
+  };
+};

--- a/evals/tasks/expect_act_timeout_global.ts
+++ b/evals/tasks/expect_act_timeout_global.ts
@@ -1,23 +1,25 @@
 import { initStagehand } from "@/evals/initStagehand";
 import { EvalFunction } from "@/types/evals";
 
-export const expect_act_timeout: EvalFunction = async ({
+export const expect_act_timeout_global: EvalFunction = async ({
   modelName,
   logger,
 }) => {
   const { stagehand, initResponse } = await initStagehand({
     modelName,
     logger,
+    actTimeoutMs: 1_000,
   });
 
   const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://docs.stagehand.dev");
+
   const result = await stagehand.page.act({
     action: "search for 'Stagehand'",
-    timeoutMs: 1_000,
     slowDomBasedAct: true,
   });
+  console.log("RESULT", result);
 
   await stagehand.close();
 

--- a/examples/example.ts
+++ b/examples/example.ts
@@ -14,6 +14,10 @@ async function example() {
   });
   await stagehand.init();
   await stagehand.page.goto("https://docs.stagehand.dev");
+  await stagehand.page.act({
+    action: "search for 'Stagehand'",
+    timeoutMs: 1_000,
+  });
 }
 
 (async () => {

--- a/examples/example.ts
+++ b/examples/example.ts
@@ -14,12 +14,9 @@ async function example() {
   });
   await stagehand.init();
   await stagehand.page.goto("https://docs.stagehand.dev");
-  const result = await stagehand.page.act({
-    action: "search for 'Stagehand'",
-    timeoutMs: 1_000,
-    slowDomBasedAct: true,
-  });
-  console.log(result);
+  /**
+   * Add your code here!
+   */
   await stagehand.close();
 }
 

--- a/examples/example.ts
+++ b/examples/example.ts
@@ -14,10 +14,13 @@ async function example() {
   });
   await stagehand.init();
   await stagehand.page.goto("https://docs.stagehand.dev");
-  await stagehand.page.act({
+  const result = await stagehand.page.act({
     action: "search for 'Stagehand'",
     timeoutMs: 1_000,
+    slowDomBasedAct: true,
   });
+  console.log(result);
+  await stagehand.close();
 }
 
 (async () => {

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -487,7 +487,7 @@ export class StagehandPage {
       useVision, // still destructure this but will not pass it on
       variables = {},
       domSettleTimeoutMs,
-      slowDomBasedAct = false,
+      slowDomBasedAct = true,
     } = actionOrOptions;
 
     if (typeof useVision !== "undefined") {

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -487,7 +487,8 @@ export class StagehandPage {
       useVision, // still destructure this but will not pass it on
       variables = {},
       domSettleTimeoutMs,
-      slowDomBasedAct = true,
+      slowDomBasedAct = false,
+      timeoutMs = 10_000,
     } = actionOrOptions;
 
     if (typeof useVision !== "undefined") {
@@ -545,6 +546,7 @@ export class StagehandPage {
         previousSelectors: [],
         skipActionCacheForThisStep: false,
         domSettleTimeoutMs,
+        timeoutMs,
       })
       .catch((e) => {
         this.stagehand.log({

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -487,7 +487,7 @@ export class StagehandPage {
       useVision, // still destructure this but will not pass it on
       variables = {},
       domSettleTimeoutMs,
-      slowDomBasedAct = false,
+      slowDomBasedAct = true,
       timeoutMs = this.stagehand.actTimeoutMs,
     } = actionOrOptions;
 

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -488,7 +488,7 @@ export class StagehandPage {
       variables = {},
       domSettleTimeoutMs,
       slowDomBasedAct = false,
-      timeoutMs = 10_000,
+      timeoutMs = this.stagehand.actTimeoutMs,
     } = actionOrOptions;
 
     if (typeof useVision !== "undefined") {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -378,7 +378,7 @@ export class Stagehand {
   private localBrowserLaunchOptions?: LocalBrowserLaunchOptions;
   public readonly selfHeal: boolean;
   private cleanupCalled = false;
-
+  public readonly actTimeoutMs: number;
   protected setActivePage(page: StagehandPage): void {
     this.stagehandPage = page;
   }
@@ -414,6 +414,7 @@ export class Stagehand {
       localBrowserLaunchOptions,
       selfHeal = true,
       waitForCaptchaSolves = false,
+      actTimeoutMs = 60_000,
     }: ConstructorParams = {
       env: "BROWSERBASE",
     },
@@ -450,6 +451,7 @@ export class Stagehand {
     this.userProvidedInstructions = systemPrompt;
     this.usingAPI = useAPI ?? false;
     this.modelName = modelName ?? DEFAULT_MODEL_NAME;
+    this.actTimeoutMs = actTimeoutMs;
 
     if (this.usingAPI && env === "LOCAL") {
       throw new Error("API mode can only be used with BROWSERBASE environment");

--- a/stagehand.config.ts
+++ b/stagehand.config.ts
@@ -25,5 +25,6 @@ const StagehandConfig: ConstructorParams = {
   modelClientOptions: {
     apiKey: process.env.OPENAI_API_KEY,
   } /* Configuration options for the model client */,
+  actTimeoutMs: 60_000,
 };
 export default StagehandConfig;

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -81,7 +81,7 @@ export interface ActOptions {
    * If true, the action will be performed in a slow manner that allows the DOM to settle.
    * This is useful for debugging.
    *
-   * @default false
+   * @default true
    */
   slowDomBasedAct?: boolean;
 }

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -84,6 +84,7 @@ export interface ActOptions {
    * @default true
    */
   slowDomBasedAct?: boolean;
+  timeoutMs?: number;
 }
 
 export interface ActResult {

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -40,6 +40,7 @@ export interface ConstructorParams {
    */
   waitForCaptchaSolves?: boolean;
   localBrowserLaunchOptions?: LocalBrowserLaunchOptions;
+  actTimeoutMs?: number;
 }
 
 export interface InitOptions {


### PR DESCRIPTION
# why
Customer request -- we can now add timeouts to prevent infinite recursion on `act()`

# what changed
You can now add a timeout to `page.act()` with `timeoutMs` and at a global level at `actTimeoutMs` (default `60_000`)

# test plan
added two evals, one for global timeout, one for each act timeout