### PR TITLE
fix chunking in old `act`

### DIFF
--- a/.changeset/fluffy-pumas-do.md
+++ b/.changeset/fluffy-pumas-do.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+fix: continuously adjusting chunk size inside `act`

--- a/evals/tasks/wikipedia.ts
+++ b/evals/tasks/wikipedia.ts
@@ -10,7 +10,10 @@ export const wikipedia: EvalFunction = async ({ modelName, logger }) => {
   const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(`https://en.wikipedia.org/wiki/Baseball`);
-  await stagehand.page.act('click the "hit and run" link in this article');
+  await stagehand.page.act({
+    action: 'click the "hit and run" link in this article',
+    timeoutMs: 360_000,
+  });
 
   const url = "https://en.wikipedia.org/wiki/Hit_and_run_(baseball)";
   const currentUrl = stagehand.page.url();

--- a/lib/dom/debug.ts
+++ b/lib/dom/debug.ts
@@ -23,7 +23,7 @@ export async function debugDom() {
     chunkSize,
     false,
     false, // Don't scroll back to top
-    undefined, // BFS entire doc
+    container.getRootElement(), // BFS entire doc
   );
 
   // We expect exactly 1 chunk

--- a/lib/dom/process.ts
+++ b/lib/dom/process.ts
@@ -127,7 +127,7 @@ export async function processDom(chunksSeen: number[]) {
     chunkSize,
     true,
     false, // scrollBackToTop
-    undefined, // BFS entire doc
+    container.getRootElement(), // BFS entire doc
   );
 
   // We expect exactly 1 chunk


### PR DESCRIPTION
# why
- made a PR to dynamically adjust chunk size to account for lazy loading content
- this caused an issue with `act`, which calls `processDOM` and `debugDom` and handles the chunking/scrolling logic itself
# fix
- pass in a `candidateElementContainer` argument to `collectDomChunks` so that we do not dynamically adjust the chunk size for `processDom` and `debugDom`
