### PR TITLE
return act result in actFromObserve

### DIFF
--- a/.changeset/twenty-cooks-perform.md
+++ b/.changeset/twenty-cooks-perform.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+return act result in actFromObserve

--- a/lib/handlers/actHandler.ts
+++ b/lib/handlers/actHandler.ts
@@ -174,7 +174,7 @@ export class StagehandActHandler {
             ? `${method} ${observe.description}`
             : observe.description;
         // Call act with the ObserveResult description
-        await this.stagehandPage.act({
+        return await this.stagehandPage.act({
           action: actCommand,
           slowDomBasedAct: true,
         });


### PR DESCRIPTION
# why
- not returning result from `page.act` in `actFromObserve`