### PR TITLE
support api usage for extract with no args

### DIFF
--- a/.changeset/petite-donuts-lead.md
+++ b/.changeset/petite-donuts-lead.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+support api usage for extract with no args

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -584,6 +584,9 @@ export class StagehandPage {
 
     // check if user called extract() with no arguments
     if (!instructionOrOptions) {
+      if (this.api) {
+        return this.api.extract<T>({});
+      }
       return this.extractHandler.extract();
     }
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -91,6 +91,12 @@ export class StagehandAPI {
   async extract<T extends z.AnyZodObject>(
     options: ExtractOptions<T>,
   ): Promise<ExtractResult<T>> {
+    if (!options.schema) {
+      return this.execute<ExtractResult<T>>({
+        method: "extract",
+        args: {},
+      });
+    }
     const parsedSchema = zodToJsonSchema(options.schema);
     return this.execute<ExtractResult<T>>({
       method: "extract",

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -96,8 +96,8 @@ export interface ActResult {
 }
 
 export interface ExtractOptions<T extends z.AnyZodObject> {
-  instruction: string;
-  schema: T;
+  instruction?: string;
+  schema?: T;
   modelName?: AvailableModel;
   modelClientOptions?: ClientOptions;
   domSettleTimeoutMs?: number;


### PR DESCRIPTION
make sure API works for `extract()` with no args