### PR TITLE
remove healthcheck ping

### DIFF
--- a/.changeset/full-trams-learn.md
+++ b/.changeset/full-trams-learn.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Fix to remove unnecessary healtcheck ping on sdk

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -39,16 +39,6 @@ export class StagehandAPI {
     systemPrompt,
     browserbaseSessionCreateParams,
   }: StartSessionParams): Promise<StartSessionResult> {
-    const whitelistResponse = await this.request("/healthcheck");
-
-    if (whitelistResponse.status === 401) {
-      throw new Error(
-        "Unauthorized. Ensure you provided a valid API key and that it is whitelisted.",
-      );
-    } else if (whitelistResponse.status !== 200) {
-      throw new Error(`Unknown error: ${whitelistResponse.status}`);
-    }
-
     const sessionResponse = await this.request("/sessions/start", {
       method: "POST",
       body: JSON.stringify({
@@ -64,7 +54,11 @@ export class StagehandAPI {
       },
     });
 
-    if (sessionResponse.status !== 200) {
+    if (sessionResponse.status === 401) {
+      throw new Error(
+        "Unauthorized. Ensure you provided a valid API key and that it is whitelisted.",
+      );
+    } else if (sessionResponse.status !== 200) {
       console.log(await sessionResponse.text());
       throw new Error(`Unknown error: ${sessionResponse.status}`);
     }


### PR DESCRIPTION
# why
Healthcheck is unneccessary from the client

# what changed
Routes changed, deprecating healthcheck ping

# test plan
