### PR TITLE
update api payload

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -37,18 +37,11 @@ export class StagehandAPI {
     verbose,
     debugDom,
     systemPrompt,
+    selfHeal,
+    waitForCaptchaSolves,
+    actionTimeoutMs,
     browserbaseSessionCreateParams,
   }: StartSessionParams): Promise<StartSessionResult> {
-    const whitelistResponse = await this.request("/healthcheck");
-
-    if (whitelistResponse.status === 401) {
-      throw new Error(
-        "Unauthorized. Ensure you provided a valid API key and that it is whitelisted.",
-      );
-    } else if (whitelistResponse.status !== 200) {
-      throw new Error(`Unknown error: ${whitelistResponse.status}`);
-    }
-
     const sessionResponse = await this.request("/sessions/start", {
       method: "POST",
       body: JSON.stringify({
@@ -57,6 +50,9 @@ export class StagehandAPI {
         verbose,
         debugDom,
         systemPrompt,
+        selfHeal,
+        waitForCaptchaSolves,
+        actionTimeoutMs,
         browserbaseSessionCreateParams,
       }),
       headers: {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -523,8 +523,15 @@ export class Stagehand {
       throw new Error(
         "STAGEHAND_API_URL is required when using the API. Please set it in your environment variables.",
       );
+    } else if (
+      this.usingAPI &&
+      this.llmClient.type !== "openai" &&
+      this.llmClient.type !== "anthropic"
+    ) {
+      throw new Error(
+        "API mode requires an OpenAI or Anthropic LLM. Please provide a compatible model.",
+      );
     }
-
     this.waitForCaptchaSolves = waitForCaptchaSolves;
 
     this.selfHeal = selfHeal;
@@ -613,6 +620,9 @@ export class Stagehand {
         verbose: this.verbose,
         debugDom: this.debugDom,
         systemPrompt: this.userProvidedInstructions,
+        selfHeal: this.selfHeal,
+        waitForCaptchaSolves: this.waitForCaptchaSolves,
+        actionTimeoutMs: this.actTimeoutMs,
         browserbaseSessionCreateParams: this.browserbaseSessionCreateParams,
       });
       this.browserbaseSessionID = sessionId;

--- a/types/api.ts
+++ b/types/api.ts
@@ -21,6 +21,9 @@ export interface StartSessionParams {
   debugDom: boolean;
   systemPrompt?: string;
   browserbaseSessionCreateParams?: Browserbase.Sessions.SessionCreateParams;
+  selfHeal?: boolean;
+  waitForCaptchaSolves?: boolean;
+  actionTimeoutMs?: number;
 }
 
 export interface StartSessionResult {


### PR DESCRIPTION
# why
The updated constructor values were not being sent to the API on initialization.

# what changed
Updated the `/start` payload

# test plan
E2E