### PR TITLE
export agent types

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -853,4 +853,5 @@ export * from "../types/model";
 export * from "../types/page";
 export * from "../types/playwright";
 export * from "../types/stagehand";
+export * from "../types/agent";
 export * from "./llm/LLMClient";


### PR DESCRIPTION
# why
Developers should be able to access agent types from the build files.

# what changed
Added an export in `index.ts` for `types/agent.ts`.

# test plan
