### PR TITLE
add agent API support

### DIFF
--- a/.changeset/curly-rules-build.md
+++ b/.changeset/curly-rules-build.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": minor
+---
+
+Added support for offloading agent tasks to the API.

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -12,11 +12,13 @@ import { GotoOptions } from "../types/playwright";
 import {
   ActOptions,
   ActResult,
+  AgentConfig,
   ExtractOptions,
   ExtractResult,
   ObserveOptions,
   ObserveResult,
 } from "../types/stagehand";
+import { AgentExecuteOptions, AgentResult } from ".";
 
 export class StagehandAPI {
   private apiKey: string;
@@ -109,6 +111,16 @@ export class StagehandAPI {
     return this.execute<void>({
       method: "navigate",
       args: { url, options },
+    });
+  }
+
+  async agentExecute(
+    agentConfig: AgentConfig,
+    executeOptions: AgentExecuteOptions,
+  ): Promise<AgentResult> {
+    return this.execute<AgentResult>({
+      method: "agentExecute",
+      args: { agentConfig, executeOptions },
     });
   }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -841,6 +841,16 @@ export class Stagehand {
           throw new Error("Instruction is required for agent execution");
         }
 
+        if (this.usingAPI) {
+          if (!this.apiClient) {
+            throw new Error(
+              "API client not initialized. Ensure that you have initialized Stagehand via `await stagehand.init()`.",
+            );
+          }
+
+          return await this.apiClient.agentExecute(options, executeOptions);
+        }
+
         return await agentHandler.execute(executeOptions);
       },
     };

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -848,6 +848,22 @@ export class Stagehand {
             );
           }
 
+          if (!options.options) {
+            options.options = {};
+          }
+
+          if (options.provider === "anthropic") {
+            options.options.apiKey = process.env.ANTHROPIC_API_KEY;
+          } else if (options.provider === "openai") {
+            options.options.apiKey = process.env.OPENAI_API_KEY;
+          }
+
+          if (!options.options.apiKey) {
+            throw new Error(
+              `API key not found for \`${options.provider}\` provider. Please set the ${options.provider === "anthropic" ? "ANTHROPIC_API_KEY" : "OPENAI_API_KEY"} environment variable or pass an apiKey in the options object.`,
+            );
+          }
+
           return await this.apiClient.agentExecute(options, executeOptions);
         }
 

--- a/types/api.ts
+++ b/types/api.ts
@@ -8,7 +8,7 @@ export interface StagehandAPIConstructorParams {
 }
 
 export interface ExecuteActionParams {
-  method: "act" | "extract" | "observe" | "navigate" | "end";
+  method: "act" | "extract" | "observe" | "navigate" | "end" | "agentExecute";
   args?: unknown;
   params?: unknown;
 }


### PR DESCRIPTION
# why
To support offloading agentic tasks to the API.

# what changed
Added logic for sending requests to the API with the agent config and execution options.

# test plan
E2E
