### PR TITLE
Override screenshot logic

### DIFF
--- a/.changeset/free-pots-move.md
+++ b/.changeset/free-pots-move.md
@@ -1,5 +1,5 @@
 ---
-"@browserbasehq/stagehand": minor
+"@browserbasehq/stagehand": patch
 ---
 
 Added CDP support for screenshots, find more about the benefits here: https://docs.browserbase.com/features/screenshots#why-use-cdp-for-screenshots%3F

--- a/.changeset/free-pots-move.md
+++ b/.changeset/free-pots-move.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": minor
+---
+
+Added CDP support for screenshots, find more about the benefits here: https://docs.browserbase.com/features/screenshots#why-use-cdp-for-screenshots%3F

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -251,6 +251,41 @@ export class StagehandPage {
           };
         }
 
+        // Handle screenshots with CDP
+        if (prop === "screenshot") {
+          return async (
+            options: {
+              type?: "png" | "jpeg";
+              quality?: number;
+              fullPage?: boolean;
+              clip?: { x: number; y: number; width: number; height: number };
+              omitBackground?: boolean;
+            } = {},
+          ) => {
+            const cdpOptions: Record<string, unknown> = {
+              format: options.type === "jpeg" ? "jpeg" : "png",
+              quality: options.quality,
+              clip: options.clip,
+              omitBackground: options.omitBackground,
+              fromSurface: true,
+            };
+
+            if (options.fullPage) {
+              cdpOptions.captureBeyondViewport = true;
+            }
+
+            const data = await this.sendCDP<{ data: string }>(
+              "Page.captureScreenshot",
+              cdpOptions,
+            );
+
+            // Convert base64 to buffer
+            const buffer = Buffer.from(data.data, "base64");
+
+            return buffer;
+          };
+        }
+
         // Handle goto specially
         if (prop === "goto") {
           return async (url: string, options: GotoOptions) => {

--- a/stagehand.config.ts
+++ b/stagehand.config.ts
@@ -10,7 +10,7 @@ const StagehandConfig: ConstructorParams = {
       : "LOCAL",
   apiKey: process.env.BROWSERBASE_API_KEY /* API key for authentication */,
   projectId: process.env.BROWSERBASE_PROJECT_ID /* Project identifier */,
-  debugDom: true /* Enable DOM debugging features */,
+  debugDom: false /* Enable DOM debugging features */,
   headless: false /* Run browser in headless mode */,
   logger: (message: LogLine) =>
     console.log(logLineToString(message)) /* Custom logging function */,


### PR DESCRIPTION
# why
Adding CDP support for screenshots 

# what changed
Stagehand override for `screenshot()`. There are multiple benefits to using CDP for screenshots rather than automation frameworks: speed, memory, reliability... For more details: check [these docs](https://docs.browserbase.com/features/screenshots#why-use-cdp-for-screenshots%3F)
# test plan