### PR TITLE
pass `observeHandler` into `actHandler`

### DIFF
--- a/.changeset/cool-lemons-report.md
+++ b/.changeset/cool-lemons-report.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+pass observeHandler into actHandler

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -475,7 +475,12 @@ export class StagehandPage {
       : this.llmClient;
 
     if (!slowDomBasedAct) {
-      return this.actHandler.observeAct(actionOrOptions);
+      return this.actHandler.observeAct(
+        actionOrOptions,
+        this.observeHandler,
+        llmClient,
+        requestId,
+      );
     }
 
     this.stagehand.log({


### PR DESCRIPTION
# why
- need to be able add parameters of `observe` in `inference.ts` without adding parameters to the user facing `page.observe()` function
# what changed
- in this PR, we now pass the `observeHandler` into the `actHandler` so that we can call the `observeHandler.observe()` function instead of calling `page.observe()` inside the `actHandler`
