### PR TITLE
add supported methods to `observe` prompt 

### DIFF
--- a/.changeset/cool-lemons-report.md
+++ b/.changeset/cool-lemons-report.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+pass observeHandler into actHandler

--- a/.changeset/heavy-waves-melt.md
+++ b/.changeset/heavy-waves-melt.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+add supported methods to observe prompt

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -475,7 +475,12 @@ export class StagehandPage {
       : this.llmClient;
 
     if (!slowDomBasedAct) {
-      return this.actHandler.observeAct(actionOrOptions);
+      return this.actHandler.observeAct(
+        actionOrOptions,
+        this.observeHandler,
+        llmClient,
+        requestId,
+      );
     }
 
     this.stagehand.log({

--- a/lib/handlers/actHandler.ts
+++ b/lib/handlers/actHandler.ts
@@ -18,8 +18,7 @@ import {
   ObserveOptions,
   StagehandFunctionName,
 } from "@/types/stagehand";
-import { MethodHandlerContext, SupportedPlaywrightAction } from "@/types/act";
-import { buildActObservePrompt } from "../prompt";
+import { MethodHandlerContext } from "@/types/act";
 import {
   methodHandlerMap,
   fallbackLocatorMethod,
@@ -250,11 +249,7 @@ export class StagehandActHandler {
     }
 
     // Craft the instruction for observe
-    const instruction = buildActObservePrompt(
-      action,
-      Object.values(SupportedPlaywrightAction),
-      actionOrOptions.variables,
-    );
+    const instruction = actionOrOptions.action;
 
     // Call observe with the instruction and extracted options
     const observeResults = await observeHandler.observe({
@@ -264,6 +259,7 @@ export class StagehandActHandler {
       onlyVisible: false,
       drawOverlay: false,
       returnAction: true,
+      fromAct: true,
     });
 
     if (observeResults.length === 0) {

--- a/lib/handlers/observeHandler.ts
+++ b/lib/handlers/observeHandler.ts
@@ -57,6 +57,7 @@ export class StagehandObserveHandler {
     returnAction,
     onlyVisible,
     drawOverlay,
+    fromAct,
   }: {
     instruction: string;
     llmClient: LLMClient;
@@ -65,6 +66,7 @@ export class StagehandObserveHandler {
     returnAction?: boolean;
     onlyVisible?: boolean;
     drawOverlay?: boolean;
+    fromAct?: boolean;
   }) {
     if (!instruction) {
       instruction = `Find elements that can be used for any future actions in the page. These may be navigation links, related pages, section/subsection links, buttons, or other interactive elements. Be comprehensive: if there are multiple elements that may be relevant for future actions, return all of them.`;
@@ -114,6 +116,7 @@ export class StagehandObserveHandler {
       isUsingAccessibilityTree: useAccessibilityTree,
       returnAction,
       logInferenceToFile: this.stagehand.logInferenceToFile,
+      fromAct: fromAct,
     });
 
     const {

--- a/lib/inference.ts
+++ b/lib/inference.ts
@@ -596,6 +596,7 @@ export async function observe({
   logger,
   returnAction = false,
   logInferenceToFile = false,
+  fromAct,
 }: {
   instruction: string;
   domElements: string;
@@ -606,6 +607,7 @@ export async function observe({
   isUsingAccessibilityTree?: boolean;
   returnAction?: boolean;
   logInferenceToFile?: boolean;
+  fromAct: boolean;
 }) {
   const observeSchema = z.object({
     elements: z
@@ -651,7 +653,13 @@ export async function observe({
       userProvidedInstructions,
       isUsingAccessibilityTree,
     ),
-    buildObserveUserMessage(instruction, domElements, isUsingAccessibilityTree),
+    buildObserveUserMessage(
+      instruction,
+      domElements,
+      isUsingAccessibilityTree,
+      returnAction,
+      fromAct,
+    ),
   ];
 
   let callTimestamp = "";

--- a/types/act.ts
+++ b/types/act.ts
@@ -30,14 +30,6 @@ export interface ActCommandResult {
   why?: string;
 }
 
-// We can use this enum to list the actions supported in performPlaywrightMethod
-export enum SupportedPlaywrightAction {
-  CLICK = "click",
-  FILL = "fill",
-  TYPE = "type",
-  SCROLL = "scrollTo",
-}
-
 /**
  * A context object to hold all parameters that might be needed by
  * any of the methods in the `methodHandlerMap`


### PR DESCRIPTION
# why
- we should include a list of 'officially supported' methods to the `observe` prompt so that the LLM has a better understanding of what method to suggest
- this lays the foundation for expanding beyond playwright: for example, we can just add new methods to the list of supported methods that we pass to the LLM
# what changed
- added a prompt that contains a list of 'officially supported' methods
- this prompt is added when we are calling `observe` from within `act`
- this prompt is also added when the `returnAction` flag is set within `observeOptions`
