### PR TITLE
fixed anthropic open operator

### DIFF
--- a/.changeset/puny-garlics-join.md
+++ b/.changeset/puny-garlics-join.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Fix the open operator handler to work with anthropic

--- a/lib/handlers/operatorHandler.ts
+++ b/lib/handlers/operatorHandler.ts
@@ -85,10 +85,20 @@ export class StagehandOperatorHandler {
               type: "text",
               text: messageText,
             },
-            {
-              type: "image_url",
-              image_url: { url: `data:image/png;base64,${base64Image}` },
-            },
+            this.llmClient.type === "anthropic"
+              ? {
+                  type: "image",
+                  source: {
+                    type: "base64",
+                    media_type: "image/png",
+                    data: base64Image,
+                  },
+                  text: "the screenshot of the current page",
+                }
+              : {
+                  type: "image_url",
+                  image_url: { url: `data:image/png;base64,${base64Image}` },
+                },
           ],
         });
       }

--- a/lib/llm/LLMClient.ts
+++ b/lib/llm/LLMClient.ts
@@ -13,9 +13,14 @@ export type ChatMessageContent =
   | (ChatMessageImageContent | ChatMessageTextContent)[];
 
 export interface ChatMessageImageContent {
-  type: "image_url";
-  image_url: { url: string };
+  type: string;
+  image_url?: { url: string };
   text?: string;
+  source?: {
+    type: string;
+    media_type: string;
+    data: string;
+  };
 }
 
 export interface ChatMessageTextContent {


### PR DESCRIPTION
# why
Anthropic support for operator agent

# what changed
The image request format for Anthropic is slightly different than that of OpenAI

# test plan
Tested with `examples/operator-example.ts`
