### PR TITLE
add `history` primitive

### DIFF
--- a/.changeset/empty-spoons-float.md
+++ b/.changeset/empty-spoons-float.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": minor
+---
+
+Added a `stagehand.history` array which stores an array of `act`, `extract`, `observe`, and `goto` calls made. Since this history array is stored on the `StagehandPage` level, it will capture methods even if indirectly called by an agent.

--- a/evals/evals.config.json
+++ b/evals/evals.config.json
@@ -1,6 +1,10 @@
 {
   "tasks": [
     {
+      "name": "history",
+      "categories": ["combination"]
+    },
+    {
       "name": "expect_act_timeout",
       "categories": ["act"]
     },

--- a/evals/tasks/history.ts
+++ b/evals/tasks/history.ts
@@ -1,0 +1,54 @@
+import { initStagehand } from "@/evals/initStagehand";
+import { EvalFunction } from "@/types/evals";
+
+export const history: EvalFunction = async ({ modelName, logger }) => {
+  const { stagehand, initResponse } = await initStagehand({
+    modelName,
+    logger,
+  });
+
+  const { debugUrl, sessionUrl } = initResponse;
+
+  await stagehand.page.goto("https://docs.stagehand.dev");
+
+  await stagehand.page.act("click on the 'Quickstart' tab");
+
+  await stagehand.page.extract("Extract the title of the page");
+
+  await stagehand.page.observe("Find all links on the page");
+
+  const history = stagehand.history;
+
+  const hasCorrectNumberOfEntries = history.length === 4;
+
+  const hasNavigateEntry = history[0].method === "navigate";
+  const hasActEntry = history[1].method === "act";
+  const hasExtractEntry = history[2].method === "extract";
+  const hasObserveEntry = history[3].method === "observe";
+
+  const allEntriesHaveTimestamps = history.every(
+    (entry) =>
+      typeof entry.timestamp === "string" && entry.timestamp.length > 0,
+  );
+  const allEntriesHaveResults = history.every(
+    (entry) => entry.result !== undefined,
+  );
+
+  await stagehand.close();
+
+  const success =
+    hasCorrectNumberOfEntries &&
+    hasNavigateEntry &&
+    hasActEntry &&
+    hasExtractEntry &&
+    hasObserveEntry &&
+    allEntriesHaveTimestamps &&
+    allEntriesHaveResults;
+
+  return {
+    _success: success,
+    debugUrl,
+    sessionUrl,
+    logs: logger.getLogs(),
+  };
+};

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -608,10 +608,14 @@ export class StagehandPage {
 
     // check if user called extract() with no arguments
     if (!instructionOrOptions) {
+      let result: ExtractResult<T>;
       if (this.api) {
-        return this.api.extract<T>({});
+        result = await this.api.extract<T>({});
+      } else {
+        result = await this.extractHandler.extract();
       }
-      return this.extractHandler.extract();
+      this.addToHistory("extract", instructionOrOptions, result);
+      return result;
     }
 
     const options: ExtractOptions<T> =

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -6,6 +6,7 @@ import { Page, defaultExtractSchema } from "../types/page";
 import {
   ExtractOptions,
   ExtractResult,
+  HistoryEntry,
   ObserveOptions,
   ObserveResult,
 } from "../types/stagehand";
@@ -39,19 +40,9 @@ export class StagehandPage {
   private userProvidedInstructions?: string;
   private waitForCaptchaSolves: boolean;
   private initialized: boolean = false;
-  private _history: Array<{
-    method: "act" | "extract" | "observe" | "navigate";
-    parameters: unknown;
-    result: unknown;
-    timestamp: string;
-  }> = [];
+  private _history: Array<HistoryEntry> = [];
 
-  public get history(): ReadonlyArray<{
-    method: "act" | "extract" | "observe" | "navigate";
-    parameters: unknown;
-    result: unknown;
-    timestamp: string;
-  }> {
+  public get history(): ReadonlyArray<HistoryEntry> {
     return this._history;
   }
 
@@ -458,7 +449,7 @@ export class StagehandPage {
   }
 
   private addToHistory(
-    method: "act" | "extract" | "observe" | "navigate",
+    method: HistoryEntry["method"],
     parameters: unknown,
     result?: unknown,
   ): void {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -899,6 +899,15 @@ export class Stagehand {
       },
     };
   }
+
+  public get history(): ReadonlyArray<{
+    method: "act" | "extract" | "observe" | "navigate";
+    parameters: unknown;
+    result: unknown;
+    timestamp: string;
+  }> {
+    return this.stagehandPage ? this.stagehandPage.history : [];
+  }
 }
 
 export * from "../types/browser";

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -28,6 +28,7 @@ import {
   AgentConfig,
   StagehandMetrics,
   StagehandFunctionName,
+  HistoryEntry,
 } from "../types/stagehand";
 import { StagehandContext } from "./StagehandContext";
 import { StagehandPage } from "./StagehandPage";
@@ -900,12 +901,7 @@ export class Stagehand {
     };
   }
 
-  public get history(): ReadonlyArray<{
-    method: "act" | "extract" | "observe" | "navigate";
-    parameters: unknown;
-    result: unknown;
-    timestamp: string;
-  }> {
+  public get history(): ReadonlyArray<HistoryEntry> {
     if (!this.stagehandPage) {
       throw new Error(
         "History is only available after a page has been initialized",

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -906,7 +906,13 @@ export class Stagehand {
     result: unknown;
     timestamp: string;
   }> {
-    return this.stagehandPage ? this.stagehandPage.history : [];
+    if (!this.stagehandPage) {
+      throw new Error(
+        "History is only available after a page has been initialized",
+      );
+    }
+
+    return this.stagehandPage.history;
   }
 }
 

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -244,3 +244,10 @@ export enum StagehandFunctionName {
   EXTRACT = "EXTRACT",
   OBSERVE = "OBSERVE",
 }
+
+export interface HistoryEntry {
+  method: "act" | "extract" | "observe" | "navigate";
+  parameters: unknown;
+  result: unknown;
+  timestamp: string;
+}


### PR DESCRIPTION
# why
We should expose a history of actions taken by Stagehand

# what changed
Added a `history` key to the Stagehand object which stores an array of `act`, `extract`, `observe`, and `goto` calls. Since the history is stored on the `StagehandPage` level, this will capture events even if called by the operator agent.

# test plan
Added a `history.ts` test to combination evals.
