### PR TITLE
support browserbasesessionid for resuming a session on api

### DIFF
--- a/.changeset/rare-tires-turn.md
+++ b/.changeset/rare-tires-turn.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Added support for resuming a Stagehand session created on the API.

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -43,6 +43,7 @@ export class StagehandAPI {
     waitForCaptchaSolves,
     actionTimeoutMs,
     browserbaseSessionCreateParams,
+    browserbaseSessionId,
   }: StartSessionParams): Promise<StartSessionResult> {
     const sessionResponse = await this.request("/sessions/start", {
       method: "POST",
@@ -56,6 +57,7 @@ export class StagehandAPI {
         waitForCaptchaSolves,
         actionTimeoutMs,
         browserbaseSessionCreateParams,
+        browserbaseSessionId,
       }),
       headers: {
         "x-model-api-key": modelApiKey,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -626,6 +626,7 @@ export class Stagehand {
         waitForCaptchaSolves: this.waitForCaptchaSolves,
         actionTimeoutMs: this.actTimeoutMs,
         browserbaseSessionCreateParams: this.browserbaseSessionCreateParams,
+        browserbaseSessionId: this.browserbaseSessionID,
       });
       this.browserbaseSessionID = sessionId;
     }

--- a/types/api.ts
+++ b/types/api.ts
@@ -24,6 +24,7 @@ export interface StartSessionParams {
   selfHeal?: boolean;
   waitForCaptchaSolves?: boolean;
   actionTimeoutMs?: number;
+  browserbaseSessionId?: string;
 }
 
 export interface StartSessionResult {


### PR DESCRIPTION
# why
We don't currently send existing `browserbaseSessionId`s on the initial API request

# what changed
Added `browserbaseSessionId` to the initial API payload.

# test plan
E2E
