### PR TITLE
better stagehand config

### DIFF
--- a/.changeset/large-spies-stop.md
+++ b/.changeset/large-spies-stop.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": minor
+---
+
+Change init return field to return the Stagehand object (should make a separate async method), remove deprecated fields, and init to return the stagehand object instead

--- a/evals/deterministic/bb.stagehand.config.ts
+++ b/evals/deterministic/bb.stagehand.config.ts
@@ -3,14 +3,21 @@ import type { ConstructorParams } from "@/dist";
 import dotenv from "dotenv";
 dotenv.config({ path: "../../.env" });
 
+if (!process.env.BROWSERBASE_PROJECT_ID) {
+  throw new Error("BROWSERBASE_PROJECT_ID is not set");
+}
+
+if (!process.env.BROWSERBASE_API_KEY) {
+  throw new Error("BROWSERBASE_API_KEY is not set");
+}
+
 const StagehandConfig: ConstructorParams = {
   ...DefaultStagehandConfig,
-  env: "LOCAL" /* Environment to run Stagehand in */,
-  verbose: 1 /* Logging verbosity level (0=quiet, 1=normal, 2=verbose) */,
-  headless: true /* Run browser in headless mode */,
+  env: "BROWSERBASE" /* Environment to run Stagehand in */,
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  projectId: process.env.BROWSERBASE_PROJECT_ID,
   browserbaseSessionCreateParams: {
     projectId: process.env.BROWSERBASE_PROJECT_ID,
   },
-  enableCaching: false /* Enable caching functionality */,
 };
 export default StagehandConfig;

--- a/evals/deterministic/e2e.stagehand.config.ts
+++ b/evals/deterministic/e2e.stagehand.config.ts
@@ -1,0 +1,11 @@
+import { default as DefaultStagehandConfig } from "@/stagehand.config";
+import type { ConstructorParams } from "@/dist";
+import dotenv from "dotenv";
+dotenv.config({ path: "../../.env" });
+
+const StagehandConfig: ConstructorParams = {
+  ...DefaultStagehandConfig,
+  env: "LOCAL" /* Environment to run Stagehand in */,
+  headless: true /* Run browser in headless mode */,
+};
+export default StagehandConfig;

--- a/evals/deterministic/e2e.stagehand.config.ts
+++ b/evals/deterministic/e2e.stagehand.config.ts
@@ -6,6 +6,8 @@ dotenv.config({ path: "../../.env" });
 const StagehandConfig: ConstructorParams = {
   ...DefaultStagehandConfig,
   env: "LOCAL" /* Environment to run Stagehand in */,
-  headless: true /* Run browser in headless mode */,
+  localBrowserLaunchOptions: {
+    headless: true,
+  },
 };
 export default StagehandConfig;

--- a/evals/deterministic/tests/BrowserContext/addInitScript.test.ts
+++ b/evals/deterministic/tests/BrowserContext/addInitScript.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { Stagehand } from "@/dist";
-import StagehandConfig from "@/evals/deterministic/stagehand.config";
+import StagehandConfig from "@/evals/deterministic/e2e.stagehand.config";
 
 test.describe("StagehandContext - addInitScript", () => {
   test("should inject a script on the context before pages load", async () => {

--- a/evals/deterministic/tests/BrowserContext/cookies.test.ts
+++ b/evals/deterministic/tests/BrowserContext/cookies.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { Stagehand } from "@/dist";
-import StagehandConfig from "@/evals/deterministic/stagehand.config";
+import StagehandConfig from "@/evals/deterministic/e2e.stagehand.config";
 
 test.describe("StagehandContext - Cookies", () => {
   let stagehand: Stagehand;

--- a/evals/deterministic/tests/BrowserContext/multiPage.test.ts
+++ b/evals/deterministic/tests/BrowserContext/multiPage.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { Stagehand } from "@/dist";
-import StagehandConfig from "@/evals/deterministic/stagehand.config";
+import StagehandConfig from "@/evals/deterministic/e2e.stagehand.config";
 import { Page } from "@/dist";
 
 import http from "http";

--- a/evals/deterministic/tests/BrowserContext/page.test.ts
+++ b/evals/deterministic/tests/BrowserContext/page.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { Stagehand } from "@/dist";
-import StagehandConfig from "@/evals/deterministic/stagehand.config";
+import StagehandConfig from "@/evals/deterministic/e2e.stagehand.config";
 
 import http from "http";
 import express from "express";

--- a/evals/deterministic/tests/BrowserContext/routing.test.ts
+++ b/evals/deterministic/tests/BrowserContext/routing.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { Stagehand } from "@/dist";
-import StagehandConfig from "@/evals/deterministic/stagehand.config";
+import StagehandConfig from "@/evals/deterministic/e2e.stagehand.config";
 
 import http from "http";
 import express from "express";

--- a/evals/deterministic/tests/Errors/apiKeyError.test.ts
+++ b/evals/deterministic/tests/Errors/apiKeyError.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { Stagehand } from "@/dist";
-import StagehandConfig from "@/evals/deterministic/stagehand.config";
+import StagehandConfig from "@/evals/deterministic/e2e.stagehand.config";
 import { z } from "zod";
 
 test.describe("API key/LLMClient error", () => {

--- a/evals/deterministic/tests/browserbase/contexts.test.ts
+++ b/evals/deterministic/tests/browserbase/contexts.test.ts
@@ -1,6 +1,6 @@
 import Browserbase from "@browserbasehq/sdk";
 import { expect, test } from "@playwright/test";
-import StagehandConfig from "@/evals/deterministic/stagehand.config";
+import StagehandConfig from "@/evals/deterministic/bb.stagehand.config";
 import { Stagehand } from "@/dist";
 
 // Configuration

--- a/evals/deterministic/tests/browserbase/downloads.test.ts
+++ b/evals/deterministic/tests/browserbase/downloads.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import AdmZip from "adm-zip";
-import StagehandConfig from "@/evals/deterministic/stagehand.config";
+import StagehandConfig from "@/evals/deterministic/bb.stagehand.config";
 import { Stagehand } from "@/dist";
 import Browserbase from "@browserbasehq/sdk";
 

--- a/evals/deterministic/tests/browserbase/resumeSession.test.ts
+++ b/evals/deterministic/tests/browserbase/resumeSession.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "@playwright/test";
+import { Stagehand } from "@/dist";
+import Browserbase from "@browserbasehq/sdk";
+import StagehandConfig from "@/evals/deterministic/bb.stagehand.config";
+
+test.describe("Stagehand - resume Browserbase Session", () => {
+  test("should resume an existing BB session", async () => {
+    const bb = new Browserbase();
+    const session = await bb.sessions.create({
+      projectId: process.env.BROWSERBASE_PROJECT_ID!,
+    });
+    const stagehand = new Stagehand({
+      ...StagehandConfig,
+      browserbaseSessionID: session.id,
+    });
+    await stagehand.init();
+    expect(stagehand.browserbaseSessionID).toBeDefined();
+    expect(stagehand.browserbaseSessionID).toBe(session.id);
+
+    const page = stagehand.page;
+    const url = "https://docs.stagehand.dev/get_started/introduction";
+    await page.goto(url);
+    expect(page.url()).toBe(url);
+
+    await stagehand.close();
+  });
+});

--- a/evals/deterministic/tests/browserbase/uploads.test.ts
+++ b/evals/deterministic/tests/browserbase/uploads.test.ts
@@ -1,7 +1,7 @@
 import { join } from "node:path";
 import { test, expect } from "@playwright/test";
 import { Stagehand } from "@/dist";
-import StagehandConfig from "@/evals/deterministic/stagehand.config";
+import StagehandConfig from "@/evals/deterministic/bb.stagehand.config";
 
 test.describe("Playwright Upload", () => {
   let stagehand: Stagehand;

--- a/evals/deterministic/tests/local/create.test.ts
+++ b/evals/deterministic/tests/local/create.test.ts
@@ -4,21 +4,11 @@ import path from "path";
 import fs from "fs";
 import os from "os";
 import type { Cookie } from "@playwright/test";
+import StagehandConfig from "../../e2e.stagehand.config";
 
 test.describe("Local browser launch options", () => {
   test("launches with default options when no localBrowserLaunchOptions provided", async () => {
-    const stagehand = new Stagehand({
-      env: "LOCAL",
-      verbose: 1,
-      headless: true,
-      debugDom: true,
-      domSettleTimeoutMs: 30_000,
-      enableCaching: true,
-      modelName: "gpt-4o",
-      modelClientOptions: {
-        apiKey: process.env.OPENAI_API_KEY,
-      },
-    });
+    const stagehand = new Stagehand(StagehandConfig);
     await stagehand.init();
 
     const context = stagehand.context;
@@ -32,17 +22,9 @@ test.describe("Local browser launch options", () => {
     const customUserDataDir = path.join(os.tmpdir(), "custom-user-data");
 
     const stagehand = new Stagehand({
-      env: "LOCAL",
-      verbose: 1,
-      headless: true,
-      debugDom: true,
-      domSettleTimeoutMs: 30_000,
-      enableCaching: true,
-      modelName: "gpt-4o",
-      modelClientOptions: {
-        apiKey: process.env.OPENAI_API_KEY,
-      },
+      ...StagehandConfig,
       localBrowserLaunchOptions: {
+        headless: true,
         userDataDir: customUserDataDir,
       },
     });
@@ -60,16 +42,7 @@ test.describe("Local browser launch options", () => {
     const customViewport = { width: 1920, height: 1080 };
 
     const stagehand = new Stagehand({
-      env: "LOCAL",
-      verbose: 1,
-      headless: true,
-      debugDom: true,
-      domSettleTimeoutMs: 30_000,
-      enableCaching: true,
-      modelName: "gpt-4o",
-      modelClientOptions: {
-        apiKey: process.env.OPENAI_API_KEY,
-      },
+      ...StagehandConfig,
       localBrowserLaunchOptions: {
         viewport: customViewport,
       },
@@ -99,16 +72,7 @@ test.describe("Local browser launch options", () => {
     ];
 
     const stagehand = new Stagehand({
-      env: "LOCAL",
-      verbose: 1,
-      headless: true,
-      debugDom: true,
-      domSettleTimeoutMs: 30_000,
-      enableCaching: true,
-      modelName: "gpt-4o",
-      modelClientOptions: {
-        apiKey: process.env.OPENAI_API_KEY,
-      },
+      ...StagehandConfig,
       localBrowserLaunchOptions: {
         cookies: testCookies,
       },
@@ -133,16 +97,7 @@ test.describe("Local browser launch options", () => {
     };
 
     const stagehand = new Stagehand({
-      env: "LOCAL",
-      verbose: 1,
-      headless: true,
-      debugDom: true,
-      domSettleTimeoutMs: 30_000,
-      enableCaching: true,
-      modelName: "gpt-4o",
-      modelClientOptions: {
-        apiKey: process.env.OPENAI_API_KEY,
-      },
+      ...StagehandConfig,
       localBrowserLaunchOptions: {
         geolocation: customGeolocation,
         permissions: ["geolocation"],
@@ -174,16 +129,7 @@ test.describe("Local browser launch options", () => {
 
   test("applies custom timezone and locale", async () => {
     const stagehand = new Stagehand({
-      env: "LOCAL",
-      verbose: 1,
-      headless: true,
-      debugDom: true,
-      domSettleTimeoutMs: 30_000,
-      enableCaching: true,
-      modelName: "gpt-4o",
-      modelClientOptions: {
-        apiKey: process.env.OPENAI_API_KEY,
-      },
+      ...StagehandConfig,
       localBrowserLaunchOptions: {
         locale: "ja-JP",
         timezoneId: "Asia/Tokyo",
@@ -210,16 +156,7 @@ test.describe("Local browser launch options", () => {
     fs.mkdirSync(videoDir, { recursive: true });
 
     const stagehand = new Stagehand({
-      env: "LOCAL",
-      verbose: 1,
-      headless: true,
-      debugDom: true,
-      domSettleTimeoutMs: 30_000,
-      enableCaching: true,
-      modelName: "gpt-4o",
-      modelClientOptions: {
-        apiKey: process.env.OPENAI_API_KEY,
-      },
+      ...StagehandConfig,
       localBrowserLaunchOptions: {
         recordVideo: {
           dir: videoDir,

--- a/evals/deterministic/tests/page/addInitScript.test.ts
+++ b/evals/deterministic/tests/page/addInitScript.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { Stagehand } from "@/dist";
-import StagehandConfig from "@/evals/deterministic/stagehand.config";
+import StagehandConfig from "@/evals/deterministic/e2e.stagehand.config";
 
 test.describe("StagehandPage - addInitScript", () => {
   test("should inject a script before the page loads", async () => {

--- a/evals/deterministic/tests/page/addRemoveLocatorHandler.test.ts
+++ b/evals/deterministic/tests/page/addRemoveLocatorHandler.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { Stagehand } from "@/dist";
-import StagehandConfig from "@/evals/deterministic/stagehand.config";
+import StagehandConfig from "@/evals/deterministic/e2e.stagehand.config";
 
 test.describe("StagehandPage - addLocatorHandler and removeLocatorHandler", () => {
   // This HTML snippet is reused by both tests.

--- a/evals/deterministic/tests/page/addTags.test.ts
+++ b/evals/deterministic/tests/page/addTags.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { Stagehand } from "@/dist";
-import StagehandConfig from "@/evals/deterministic/stagehand.config";
+import StagehandConfig from "@/evals/deterministic/e2e.stagehand.config";
 
 test.describe("StagehandPage - addScriptTag and addStyleTag", () => {
   let stagehand: Stagehand;

--- a/evals/deterministic/tests/page/bringToFront.test.ts
+++ b/evals/deterministic/tests/page/bringToFront.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { Stagehand } from "@/dist";
-import StagehandConfig from "@/evals/deterministic/stagehand.config";
+import StagehandConfig from "@/evals/deterministic/e2e.stagehand.config";
 
 test.describe("StagehandPage - bringToFront", () => {
   test("should bring a background page to the front and allow further actions", async () => {

--- a/evals/deterministic/tests/page/content.test.ts
+++ b/evals/deterministic/tests/page/content.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { Stagehand } from "@/dist";
-import StagehandConfig from "@/evals/deterministic/stagehand.config";
+import StagehandConfig from "@/evals/deterministic/e2e.stagehand.config";
 
 test.describe("StagehandPage - content", () => {
   test("should retrieve the full HTML content of the page", async () => {

--- a/evals/deterministic/tests/page/evaluate.test.ts
+++ b/evals/deterministic/tests/page/evaluate.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { Stagehand } from "@/dist";
-import StagehandConfig from "@/evals/deterministic/stagehand.config";
+import StagehandConfig from "@/evals/deterministic/e2e.stagehand.config";
 
 test.describe("StagehandPage - JavaScript Evaluation", () => {
   test("can evaluate JavaScript in the page context", async () => {

--- a/evals/deterministic/tests/page/expose.test.ts
+++ b/evals/deterministic/tests/page/expose.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { Stagehand } from "@/dist";
-import StagehandConfig from "@/evals/deterministic/stagehand.config";
+import StagehandConfig from "@/evals/deterministic/e2e.stagehand.config";
 
 test.describe("StagehandPage - evaluateHandle, exposeBinding, exposeFunction", () => {
   let stagehand: Stagehand;

--- a/evals/deterministic/tests/page/frames.test.ts
+++ b/evals/deterministic/tests/page/frames.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { Stagehand } from "@/dist";
-import StagehandConfig from "@/evals/deterministic/stagehand.config";
+import StagehandConfig from "@/evals/deterministic/e2e.stagehand.config";
 
 test.describe("StagehandPage - frame operations", () => {
   let stagehand: Stagehand;

--- a/evals/deterministic/tests/page/getBy.test.ts
+++ b/evals/deterministic/tests/page/getBy.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { Stagehand } from "@/dist";
-import StagehandConfig from "@/evals/deterministic/stagehand.config";
+import StagehandConfig from "@/evals/deterministic/e2e.stagehand.config";
 
 test.describe("StagehandPage - Built-in locators", () => {
   let stagehand: Stagehand;

--- a/evals/deterministic/tests/page/navigation.test.ts
+++ b/evals/deterministic/tests/page/navigation.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { Stagehand } from "@/dist";
-import StagehandConfig from "@/evals/deterministic/stagehand.config";
+import StagehandConfig from "@/evals/deterministic/e2e.stagehand.config";
 
 test.describe("StagehandPage - Navigation", () => {
   test("should navigate back and forward between pages", async () => {

--- a/evals/deterministic/tests/page/on.test.ts
+++ b/evals/deterministic/tests/page/on.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { Stagehand } from "@/dist";
-import StagehandConfig from "@/evals/deterministic/stagehand.config";
+import StagehandConfig from "@/evals/deterministic/e2e.stagehand.config";
 
 test.describe("StagehandPage - page.on()", () => {
   test("should click on the crewAI blog tab", async () => {

--- a/evals/deterministic/tests/page/pageContext.test.ts
+++ b/evals/deterministic/tests/page/pageContext.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { Stagehand } from "@/dist";
-import StagehandConfig from "@/evals/deterministic/stagehand.config";
+import StagehandConfig from "@/evals/deterministic/e2e.stagehand.config";
 
 test.describe("StagehandPage - page.context()", () => {
   let stagehand: Stagehand;

--- a/evals/deterministic/tests/page/reload.test.ts
+++ b/evals/deterministic/tests/page/reload.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { Stagehand } from "@/dist";
-import StagehandConfig from "@/evals/deterministic/stagehand.config";
+import StagehandConfig from "@/evals/deterministic/e2e.stagehand.config";
 
 test.describe("StagehandPage - Reload", () => {
   test("should reload the page and reset page state", async () => {

--- a/evals/deterministic/tests/page/waitFor.test.ts
+++ b/evals/deterministic/tests/page/waitFor.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { Stagehand } from "@/dist";
-import StagehandConfig from "@/evals/deterministic/stagehand.config";
+import StagehandConfig from "@/evals/deterministic/e2e.stagehand.config";
 
 test.describe("StagehandPage - waitFor", () => {
   test("should wait for an element to become visible", async () => {

--- a/evals/initStagehand.ts
+++ b/evals/initStagehand.ts
@@ -13,6 +13,7 @@
 import { enableCaching, env } from "./env";
 import { AvailableModel, ConstructorParams, LogLine, Stagehand } from "@/dist";
 import { EvalLogger } from "./logger";
+import { getSessionUrls } from "./utils";
 
 /**
  * StagehandConfig:
@@ -62,7 +63,14 @@ export const initStagehand = async ({
   logger: EvalLogger;
   configOverrides?: Partial<ConstructorParams>;
   actTimeoutMs?: number;
-}) => {
+}): Promise<{
+  stagehand: Stagehand;
+  logger: EvalLogger;
+  sessionId?: string;
+  cdpUrl?: string;
+  debugUrl?: string;
+  sessionUrl?: string;
+}> => {
   let chosenApiKey: string | undefined = process.env.OPENAI_API_KEY;
   if (modelName.startsWith("claude")) {
     chosenApiKey = process.env.ANTHROPIC_API_KEY;
@@ -87,6 +95,9 @@ export const initStagehand = async ({
   // Associate the logger with the Stagehand instance
   logger.init(stagehand);
 
-  const initResponse = await stagehand.init();
-  return { stagehand, logger, initResponse };
+  await stagehand.init();
+  const { debugUrl, cdpUrl, sessionUrl } = await getSessionUrls(
+    stagehand.browserbaseSessionID,
+  );
+  return { stagehand, logger, debugUrl, cdpUrl, sessionUrl };
 };

--- a/evals/tasks/allrecipes.ts
+++ b/evals/tasks/allrecipes.ts
@@ -7,12 +7,10 @@ export const allrecipes: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://www.allrecipes.com/", {
     waitUntil: "domcontentloaded",

--- a/evals/tasks/amazon_add_to_cart.ts
+++ b/evals/tasks/amazon_add_to_cart.ts
@@ -5,12 +5,10 @@ export const amazon_add_to_cart: EvalFunction = async ({
   modelName,
   logger,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(
     "https://www.amazon.com/Laptop-MacBook-Surface-Water-Resistant-Accessories/dp/B0D5M4H5CD",

--- a/evals/tasks/apple.ts
+++ b/evals/tasks/apple.ts
@@ -2,12 +2,10 @@ import { EvalFunction } from "@/types/evals";
 import { initStagehand } from "@/evals/initStagehand";
 
 export const apple: EvalFunction = async ({ modelName, logger }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://www.apple.com/iphone-16-pro/");
 

--- a/evals/tasks/arxiv.ts
+++ b/evals/tasks/arxiv.ts
@@ -7,12 +7,10 @@ export const arxiv: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   try {
     await stagehand.page.goto("https://arxiv.org/search/");

--- a/evals/tasks/bidnet.ts
+++ b/evals/tasks/bidnet.ts
@@ -2,12 +2,10 @@ import { initStagehand } from "@/evals/initStagehand";
 import { EvalFunction } from "@/types/evals";
 
 export const bidnet: EvalFunction = async ({ modelName, logger }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://www.bidnetdirect.com/");
 

--- a/evals/tasks/combination_sauce.ts
+++ b/evals/tasks/combination_sauce.ts
@@ -7,12 +7,10 @@ export const combination_sauce: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   try {
     await stagehand.page.goto("https://www.saucedemo.com/");

--- a/evals/tasks/costar.ts
+++ b/evals/tasks/costar.ts
@@ -7,12 +7,11 @@ export const costar: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
 
-  const { debugUrl, sessionUrl } = initResponse;
   // TODO: fix this eval - does not work in headless mode
   try {
     await Promise.race([

--- a/evals/tasks/expect_act_timeout.ts
+++ b/evals/tasks/expect_act_timeout.ts
@@ -5,18 +5,15 @@ export const expect_act_timeout: EvalFunction = async ({
   modelName,
   logger,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://docs.stagehand.dev");
   const result = await stagehand.page.act({
     action: "search for 'Stagehand'",
     timeoutMs: 1_000,
-    slowDomBasedAct: true,
   });
 
   await stagehand.close();

--- a/evals/tasks/expect_act_timeout_global.ts
+++ b/evals/tasks/expect_act_timeout_global.ts
@@ -17,7 +17,6 @@ export const expect_act_timeout_global: EvalFunction = async ({
 
   const result = await stagehand.page.act({
     action: "search for 'Stagehand'",
-    slowDomBasedAct: true,
   });
   console.log("RESULT", result);
 

--- a/evals/tasks/expect_act_timeout_global.ts
+++ b/evals/tasks/expect_act_timeout_global.ts
@@ -5,13 +5,11 @@ export const expect_act_timeout_global: EvalFunction = async ({
   modelName,
   logger,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
     actTimeoutMs: 1_000,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://docs.stagehand.dev");
 

--- a/evals/tasks/expedia.ts
+++ b/evals/tasks/expedia.ts
@@ -2,12 +2,10 @@ import { EvalFunction } from "@/types/evals";
 import { initStagehand } from "@/evals/initStagehand";
 
 export const expedia: EvalFunction = async ({ modelName, logger }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   try {
     await stagehand.page.goto("https://www.expedia.com/flights");

--- a/evals/tasks/expedia_search.ts
+++ b/evals/tasks/expedia_search.ts
@@ -2,12 +2,10 @@ import { initStagehand } from "@/evals/initStagehand";
 import { EvalFunction } from "@/types/evals";
 
 export const expedia_search: EvalFunction = async ({ modelName, logger }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   try {
     await stagehand.page.goto("https://www.expedia.com/flights");

--- a/evals/tasks/extract_aigrant_companies.ts
+++ b/evals/tasks/extract_aigrant_companies.ts
@@ -7,13 +7,11 @@ export const extract_aigrant_companies: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
     domSettleTimeoutMs: 3000,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://aigrant.com/");
   const companyList = await stagehand.page.extract({

--- a/evals/tasks/extract_aigrant_targeted.ts
+++ b/evals/tasks/extract_aigrant_targeted.ts
@@ -7,13 +7,11 @@ export const extract_aigrant_targeted: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
     domSettleTimeoutMs: 3000,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://aigrant.com/");
   const selector = "/html/body/div/ul[5]/li[28]";

--- a/evals/tasks/extract_aigrant_targeted_2.ts
+++ b/evals/tasks/extract_aigrant_targeted_2.ts
@@ -7,13 +7,11 @@ export const extract_aigrant_targeted_2: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
     domSettleTimeoutMs: 3000,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://aigrant.com/");
   const selector = "/html/body/div/ul[5]/li[28]";

--- a/evals/tasks/extract_apartments.ts
+++ b/evals/tasks/extract_apartments.ts
@@ -7,13 +7,11 @@ export const extract_apartments: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
     domSettleTimeoutMs: 3000,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(
     "https://www.apartments.com/san-francisco-ca/2-bedrooms/",

--- a/evals/tasks/extract_area_codes.ts
+++ b/evals/tasks/extract_area_codes.ts
@@ -7,12 +7,10 @@ export const extract_area_codes: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.init();
   await stagehand.page.goto(

--- a/evals/tasks/extract_baptist_health.ts
+++ b/evals/tasks/extract_baptist_health.ts
@@ -8,12 +8,10 @@ export const extract_baptist_health: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(
     "https://www.baptistfirst.org/location/baptist-health-ent-partners",

--- a/evals/tasks/extract_capacitor_info.ts
+++ b/evals/tasks/extract_capacitor_info.ts
@@ -8,12 +8,10 @@ export const extract_capacitor_info: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(
     "https://www.jakelectronics.com/productdetail/panasonicelectroniccomponents-eeufm1a472l-2937406",

--- a/evals/tasks/extract_collaborators.ts
+++ b/evals/tasks/extract_collaborators.ts
@@ -7,12 +7,10 @@ export const extract_collaborators: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   try {
     await stagehand.page.goto("https://github.com/facebook/react");

--- a/evals/tasks/extract_csa.ts
+++ b/evals/tasks/extract_csa.ts
@@ -7,12 +7,10 @@ export const extract_csa: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   const { page } = stagehand;
   await page.goto(

--- a/evals/tasks/extract_geniusee.ts
+++ b/evals/tasks/extract_geniusee.ts
@@ -7,13 +7,11 @@ export const extract_geniusee: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
     domSettleTimeoutMs: 3000,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://geniusee-blog.surge.sh/single-blog/");
   const selector = "/html/body/main/div[2]/div[2]/div[2]/table";

--- a/evals/tasks/extract_geniusee_2.ts
+++ b/evals/tasks/extract_geniusee_2.ts
@@ -7,13 +7,11 @@ export const extract_geniusee_2: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
     domSettleTimeoutMs: 3000,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://geniusee-blog.surge.sh/single-blog/");
   const selector = "/html/body/main/div[2]/div[2]/div[2]/table/tbody/tr[9]";

--- a/evals/tasks/extract_github_commits.ts
+++ b/evals/tasks/extract_github_commits.ts
@@ -7,12 +7,10 @@ export const extract_github_commits: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   try {
     await stagehand.page.goto("https://github.com/facebook/react");

--- a/evals/tasks/extract_github_stars.ts
+++ b/evals/tasks/extract_github_stars.ts
@@ -7,12 +7,10 @@ export const extract_github_stars: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   try {
     await stagehand.page.goto("https://github.com/facebook/react");

--- a/evals/tasks/extract_hamilton_weather.ts
+++ b/evals/tasks/extract_hamilton_weather.ts
@@ -7,12 +7,10 @@ export const extract_hamilton_weather: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   try {
     await stagehand.page.goto("https://hamilton-weather.surge.sh/");

--- a/evals/tasks/extract_jstor_news.ts
+++ b/evals/tasks/extract_jstor_news.ts
@@ -7,12 +7,10 @@ export const extract_jstor_news: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.init();
   await stagehand.page.goto("http://jstor-eval.surge.sh", {

--- a/evals/tasks/extract_memorial_healthcare.ts
+++ b/evals/tasks/extract_memorial_healthcare.ts
@@ -8,13 +8,11 @@ export const extract_memorial_healthcare: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
     domSettleTimeoutMs: 3000,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://www.mycmh.org/locations/");
 

--- a/evals/tasks/extract_nhl_stats.ts
+++ b/evals/tasks/extract_nhl_stats.ts
@@ -8,13 +8,11 @@ export const extract_nhl_stats: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
     domSettleTimeoutMs: 4000,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(
     "https://www.hockeydb.com/ihdb/stats/top_league.php?lid=nhl1927&sid=1990",

--- a/evals/tasks/extract_partners.ts
+++ b/evals/tasks/extract_partners.ts
@@ -7,12 +7,10 @@ export const extract_partners: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   try {
     await stagehand.page.goto("https://ramp.com");

--- a/evals/tasks/extract_press_releases.ts
+++ b/evals/tasks/extract_press_releases.ts
@@ -8,13 +8,11 @@ export const extract_press_releases: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
     domSettleTimeoutMs: 3000,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   const schema = z.object({
     items: z.array(

--- a/evals/tasks/extract_professional_info.ts
+++ b/evals/tasks/extract_professional_info.ts
@@ -8,12 +8,10 @@ export const extract_professional_info: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(
     "https://www.paulweiss.com/professionals/partners-and-counsel/brian-bolin",

--- a/evals/tasks/extract_public_notices.ts
+++ b/evals/tasks/extract_public_notices.ts
@@ -8,12 +8,10 @@ export const extract_public_notices: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.init();
   await stagehand.page.goto(

--- a/evals/tasks/extract_recipe.ts
+++ b/evals/tasks/extract_recipe.ts
@@ -7,12 +7,10 @@ export const extract_recipe: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(
     "https://www.allrecipes.com/recipe/8539032/perfect-pan-seared-filet-mignon/",

--- a/evals/tasks/extract_regulations_table.ts
+++ b/evals/tasks/extract_regulations_table.ts
@@ -7,12 +7,10 @@ export const extract_regulations_table: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   try {
     await stagehand.page.goto(

--- a/evals/tasks/extract_repo_name.ts
+++ b/evals/tasks/extract_repo_name.ts
@@ -5,12 +5,10 @@ export const extract_repo_name: EvalFunction = async ({
   modelName,
   logger,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   try {
     await stagehand.page.goto("https://github.com/facebook/react");

--- a/evals/tasks/extract_resistor_info.ts
+++ b/evals/tasks/extract_resistor_info.ts
@@ -8,12 +8,10 @@ export const extract_resistor_info: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://vniva-3.surge.sh/vniva/");
 

--- a/evals/tasks/extract_rockauto.ts
+++ b/evals/tasks/extract_rockauto.ts
@@ -7,13 +7,11 @@ export const extract_rockauto: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
     domSettleTimeoutMs: 10000,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(
     "https://www.rockauto.com/en/catalog/alpine,1974,a310,1.6l+l4,1436055,cooling+system,coolant+/+antifreeze,11393",

--- a/evals/tasks/extract_snowshoeing_destinations.ts
+++ b/evals/tasks/extract_snowshoeing_destinations.ts
@@ -7,12 +7,10 @@ export const extract_snowshoeing_destinations: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   try {
     await stagehand.page.goto(

--- a/evals/tasks/extract_staff_members.ts
+++ b/evals/tasks/extract_staff_members.ts
@@ -7,13 +7,11 @@ export const extract_staff_members: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
     domSettleTimeoutMs: 3000,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://panamcs-static-site.surge.sh/");
 

--- a/evals/tasks/extract_zillow.ts
+++ b/evals/tasks/extract_zillow.ts
@@ -7,16 +7,11 @@ export const extract_zillow: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
     domSettleTimeoutMs: 3000,
-    configOverrides: {
-      debugDom: false,
-    },
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://zillow-eval.surge.sh/");
   // timeout for 5 seconds

--- a/evals/tasks/google_jobs.ts
+++ b/evals/tasks/google_jobs.ts
@@ -7,12 +7,10 @@ export const google_jobs: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   try {
     await stagehand.page.goto("https://www.google.com/");

--- a/evals/tasks/history.ts
+++ b/evals/tasks/history.ts
@@ -2,12 +2,10 @@ import { initStagehand } from "@/evals/initStagehand";
 import { EvalFunction } from "@/types/evals";
 
 export const history: EvalFunction = async ({ modelName, logger }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://docs.stagehand.dev");
 

--- a/evals/tasks/homedepot.ts
+++ b/evals/tasks/homedepot.ts
@@ -7,13 +7,11 @@ export const homedepot: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
     domSettleTimeoutMs: 60_000,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   try {
     await stagehand.page.goto("https://www.homedepot.com/");

--- a/evals/tasks/imdb_movie_details.ts
+++ b/evals/tasks/imdb_movie_details.ts
@@ -7,12 +7,10 @@ export const imdb_movie_details: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://www.imdb.com/title/tt0111161/", {
     waitUntil: "domcontentloaded",

--- a/evals/tasks/instructions.ts
+++ b/evals/tasks/instructions.ts
@@ -2,7 +2,7 @@ import { EvalFunction } from "@/types/evals";
 import { initStagehand } from "@/evals/initStagehand";
 
 export const instructions: EvalFunction = async ({ modelName, logger }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
     configOverrides: {
@@ -10,8 +10,6 @@ export const instructions: EvalFunction = async ({ modelName, logger }) => {
         "if the users says `secret12345`, click on the 'getting started' tab",
     },
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   try {
     const page = stagehand.page;

--- a/evals/tasks/ionwave.ts
+++ b/evals/tasks/ionwave.ts
@@ -2,12 +2,10 @@ import { initStagehand } from "@/evals/initStagehand";
 import { EvalFunction } from "@/types/evals";
 
 export const ionwave: EvalFunction = async ({ modelName, logger }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://elpasotexas.ionwave.net/Login.aspx");
 

--- a/evals/tasks/ionwave_observe.ts
+++ b/evals/tasks/ionwave_observe.ts
@@ -2,12 +2,10 @@ import { initStagehand } from "@/evals/initStagehand";
 import { EvalFunction } from "@/types/evals";
 
 export const ionwave_observe: EvalFunction = async ({ modelName, logger }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://elpasotexas.ionwave.net/Login.aspx");
 

--- a/evals/tasks/nonsense_action.ts
+++ b/evals/tasks/nonsense_action.ts
@@ -2,12 +2,10 @@ import { initStagehand } from "@/evals/initStagehand";
 import { EvalFunction } from "@/types/evals";
 
 export const nonsense_action: EvalFunction = async ({ modelName, logger }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   try {
     await stagehand.page.goto("https://www.homedepot.com/");

--- a/evals/tasks/observe_amazon_add_to_cart.ts
+++ b/evals/tasks/observe_amazon_add_to_cart.ts
@@ -6,12 +6,10 @@ export const observe_amazon_add_to_cart: EvalFunction = async ({
   modelName,
   logger,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(
     "https://www.amazon.com/Laptop-MacBook-Surface-Water-Resistant-Accessories/dp/B0D5M4H5CD",

--- a/evals/tasks/observe_github.ts
+++ b/evals/tasks/observe_github.ts
@@ -2,12 +2,10 @@ import { initStagehand } from "@/evals/initStagehand";
 import { EvalFunction } from "@/types/evals";
 
 export const observe_github: EvalFunction = async ({ modelName, logger }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://github.com/numpy/numpy/tree/main/numpy");
 

--- a/evals/tasks/observe_iframes1.ts
+++ b/evals/tasks/observe_iframes1.ts
@@ -2,12 +2,10 @@ import { initStagehand } from "@/evals/initStagehand";
 import { EvalFunction } from "@/types/evals";
 
 export const observe_iframes1: EvalFunction = async ({ modelName, logger }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://tucowsdomains.com/abuse-form/phishing/");
 

--- a/evals/tasks/observe_iframes2.ts
+++ b/evals/tasks/observe_iframes2.ts
@@ -2,12 +2,10 @@ import { initStagehand } from "@/evals/initStagehand";
 import { EvalFunction } from "@/types/evals";
 
 export const observe_iframes2: EvalFunction = async ({ modelName, logger }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(
     "https://iframetester.com/?url=https://shopify.com",

--- a/evals/tasks/observe_simple_google_search.ts
+++ b/evals/tasks/observe_simple_google_search.ts
@@ -6,12 +6,10 @@ export const observe_simple_google_search: EvalFunction = async ({
   modelName,
   logger,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://www.google.com");
 

--- a/evals/tasks/observe_taxes.ts
+++ b/evals/tasks/observe_taxes.ts
@@ -2,12 +2,10 @@ import { EvalFunction } from "@/types/evals";
 import { initStagehand } from "@/evals/initStagehand";
 
 export const observe_taxes: EvalFunction = async ({ modelName, logger }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://file.1040.com/estimate/");
 

--- a/evals/tasks/observe_vantechjournal.ts
+++ b/evals/tasks/observe_vantechjournal.ts
@@ -5,12 +5,10 @@ export const observe_vantechjournal: EvalFunction = async ({
   modelName,
   logger,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://vantechjournal.com/archive?page=8");
   await stagehand.page.waitForTimeout(1000);

--- a/evals/tasks/observe_yc_startup.ts
+++ b/evals/tasks/observe_yc_startup.ts
@@ -5,12 +5,10 @@ export const observe_yc_startup: EvalFunction = async ({
   modelName,
   logger,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://www.ycombinator.com/companies");
   await stagehand.page.waitForLoadState("networkidle");

--- a/evals/tasks/panamcs.ts
+++ b/evals/tasks/panamcs.ts
@@ -2,12 +2,10 @@ import { EvalFunction } from "@/types/evals";
 import { initStagehand } from "@/evals/initStagehand";
 
 export const panamcs: EvalFunction = async ({ modelName, logger }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://panamcs.org/about/staff/");
 

--- a/evals/tasks/peeler_complex.ts
+++ b/evals/tasks/peeler_complex.ts
@@ -7,12 +7,10 @@ export const peeler_complex: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   try {
     await stagehand.page.goto(`https://chefstoys.com/`, { timeout: 60000 });

--- a/evals/tasks/peeler_simple.ts
+++ b/evals/tasks/peeler_simple.ts
@@ -8,12 +8,10 @@ const env: "BROWSERBASE" | "LOCAL" =
     : "LOCAL";
 
 export const peeler_simple: EvalFunction = async ({ modelName, logger }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   if (env === "BROWSERBASE") {
     throw new StagehandEnvironmentError(

--- a/evals/tasks/rakuten_jp.ts
+++ b/evals/tasks/rakuten_jp.ts
@@ -2,12 +2,10 @@ import { EvalFunction } from "@/types/evals";
 import { initStagehand } from "@/evals/initStagehand";
 
 export const rakuten_jp: EvalFunction = async ({ modelName, logger }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://www.rakuten.co.jp/");
   await stagehand.page.act({ action: "click on online supermarket" });

--- a/evals/tasks/sciquest.ts
+++ b/evals/tasks/sciquest.ts
@@ -7,12 +7,10 @@ export const sciquest: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(
     "https://bids.sciquest.com/apps/Router/PublicEvent?tab=PHX_NAV_SourcingAllOpps&CustomerOrg=StateOfUtah",

--- a/evals/tasks/scroll_50.ts
+++ b/evals/tasks/scroll_50.ts
@@ -2,17 +2,15 @@ import { initStagehand } from "@/evals/initStagehand";
 import { EvalFunction } from "@/types/evals";
 
 export const scroll_50: EvalFunction = async ({ modelName, logger }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
     domSettleTimeoutMs: 3000,
   });
 
-  const { debugUrl, sessionUrl } = initResponse;
   await stagehand.page.goto("https://aigrant.com/");
   await stagehand.page.act({
     action: "Scroll 50% down the page",
-    slowDomBasedAct: false,
   });
 
   await new Promise((resolve) => setTimeout(resolve, 5000));

--- a/evals/tasks/scroll_75.ts
+++ b/evals/tasks/scroll_75.ts
@@ -2,17 +2,15 @@ import { initStagehand } from "@/evals/initStagehand";
 import { EvalFunction } from "@/types/evals";
 
 export const scroll_75: EvalFunction = async ({ modelName, logger }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
     domSettleTimeoutMs: 3000,
   });
 
-  const { debugUrl, sessionUrl } = initResponse;
   await stagehand.page.goto("https://aigrant.com/");
   await stagehand.page.act({
     action: "Scroll 75% down the page",
-    slowDomBasedAct: false,
   });
 
   await new Promise((resolve) => setTimeout(resolve, 5000));

--- a/evals/tasks/shopify_homepage.ts
+++ b/evals/tasks/shopify_homepage.ts
@@ -2,12 +2,10 @@ import { EvalFunction } from "@/types/evals";
 import { initStagehand } from "@/evals/initStagehand";
 
 export const shopify_homepage: EvalFunction = async ({ modelName, logger }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://www.shopify.com/");
 

--- a/evals/tasks/simple_google_search.ts
+++ b/evals/tasks/simple_google_search.ts
@@ -5,12 +5,10 @@ export const simple_google_search: EvalFunction = async ({
   modelName,
   logger,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://www.google.com");
 

--- a/evals/tasks/stock_x.ts
+++ b/evals/tasks/stock_x.ts
@@ -2,12 +2,10 @@ import { EvalFunction } from "@/types/evals";
 import { initStagehand } from "@/evals/initStagehand";
 
 export const stock_x: EvalFunction = async ({ modelName, logger }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(
     "https://stockx.com/air-jordan-3-retro-black-cement-2024",

--- a/evals/tasks/ted_talk.ts
+++ b/evals/tasks/ted_talk.ts
@@ -8,12 +8,10 @@ export const ted_talk: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(
     "https://www.ted.com/talks/sir_ken_robinson_do_schools_kill_creativity",

--- a/evals/tasks/vanta.ts
+++ b/evals/tasks/vanta.ts
@@ -2,12 +2,10 @@ import { EvalFunction } from "@/types/evals";
 import { initStagehand } from "@/evals/initStagehand";
 
 export const vanta: EvalFunction = async ({ modelName, logger }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://www.vanta.com/");
   await stagehand.page.act({ action: "close the cookies popup" });

--- a/evals/tasks/vanta_h.ts
+++ b/evals/tasks/vanta_h.ts
@@ -2,12 +2,10 @@ import { EvalFunction } from "@/types/evals";
 import { initStagehand } from "@/evals/initStagehand";
 
 export const vanta_h: EvalFunction = async ({ modelName, logger }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://www.vanta.com/");
 

--- a/evals/tasks/vantechjournal.ts
+++ b/evals/tasks/vantechjournal.ts
@@ -2,12 +2,10 @@ import { EvalFunction } from "@/types/evals";
 import { initStagehand } from "@/evals/initStagehand";
 
 export const vantechjournal: EvalFunction = async ({ modelName, logger }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://vantechjournal.com/");
 

--- a/evals/tasks/wichita.ts
+++ b/evals/tasks/wichita.ts
@@ -7,12 +7,10 @@ export const wichita: EvalFunction = async ({
   logger,
   useTextExtract,
 }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto("https://www.wichitafallstx.gov/Bids.aspx");
 

--- a/evals/tasks/wikipedia.ts
+++ b/evals/tasks/wikipedia.ts
@@ -2,12 +2,10 @@ import { EvalFunction } from "@/types/evals";
 import { initStagehand } from "@/evals/initStagehand";
 
 export const wikipedia: EvalFunction = async ({ modelName, logger }) => {
-  const { stagehand, initResponse } = await initStagehand({
+  const { stagehand, debugUrl, sessionUrl } = await initStagehand({
     modelName,
     logger,
   });
-
-  const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(`https://en.wikipedia.org/wiki/Baseball`);
   await stagehand.page.act({

--- a/evals/utils.ts
+++ b/evals/utils.ts
@@ -11,6 +11,7 @@
 import { LogLine } from "@/dist";
 import stringComparison from "string-comparison";
 const { jaroWinkler } = stringComparison;
+import Browserbase from "@browserbasehq/sdk";
 
 /**
  * normalizeString:
@@ -118,4 +119,21 @@ export function logLineToString(logLine: LogLine): string {
     console.error(`Error logging line:`, error);
     return "error logging line";
   }
+}
+
+export async function getSessionUrls(sessionId: string): Promise<{
+  debugUrl: string;
+  cdpUrl: string;
+  sessionUrl: string;
+}> {
+  const bb = new Browserbase({
+    apiKey: process.env.BROWSERBASE_API_KEY,
+  });
+  const session = await bb.sessions.retrieve(sessionId);
+  const debugUrl = await bb.sessions.debug(sessionId);
+  return {
+    debugUrl: debugUrl.debuggerFullscreenUrl,
+    cdpUrl: session.connectUrl,
+    sessionUrl: `https://www.browserbase.com/sessions/${sessionId}`,
+  };
 }

--- a/examples/2048.ts
+++ b/examples/2048.ts
@@ -6,7 +6,6 @@ async function example() {
   const stagehand = new Stagehand({
     env: "LOCAL",
     verbose: 1,
-    debugDom: true,
     domSettleTimeoutMs: 100,
   });
   try {

--- a/examples/debugUrl.ts
+++ b/examples/debugUrl.ts
@@ -4,7 +4,6 @@ async function debug(url: string) {
   const stagehand = new Stagehand({
     env: "LOCAL",
     verbose: 2,
-    debugDom: true,
   });
   await stagehand.init();
   await stagehand.page.goto(url);

--- a/examples/parameterizeApiKey.ts
+++ b/examples/parameterizeApiKey.ts
@@ -15,8 +15,6 @@ async function example() {
   const stagehand = new Stagehand({
     env: "LOCAL",
     verbose: 1,
-    debugDom: true,
-    enableCaching: false,
     modelName: "gpt-4o",
     modelClientOptions: {
       apiKey: process.env.USE_OPENAI_API_KEY,

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -522,21 +522,10 @@ export class StagehandPage {
         action,
         modelName,
         modelClientOptions,
-        useVision, // still destructure this but will not pass it on
         variables = {},
         domSettleTimeoutMs,
-        slowDomBasedAct = true,
         timeoutMs = this.stagehand.actTimeoutMs,
       } = actionOrOptions;
-
-      if (typeof useVision !== "undefined") {
-        this.stagehand.log({
-          category: "deprecation",
-          message:
-            "Warning: vision is not supported in this version of Stagehand",
-          level: 1,
-        });
-      }
 
       if (this.api) {
         const result = await this.api.act(actionOrOptions);
@@ -549,15 +538,6 @@ export class StagehandPage {
       const llmClient: LLMClient = modelName
         ? this.stagehand.llmProvider.getClient(modelName, modelClientOptions)
         : this.llmClient;
-
-      if (!slowDomBasedAct) {
-        return this.actHandler.observeAct(
-          actionOrOptions,
-          this.observeHandler,
-          llmClient,
-          requestId,
-        );
-      }
 
       this.stagehand.log({
         category: "act",

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -25,7 +25,6 @@ import {
   StagehandEnvironmentError,
   CaptchaTimeoutError,
   StagehandNotImplementedError,
-  StagehandDeprecationError,
   BrowserbaseSessionNotFoundError,
   MissingLLMConfigurationError,
   HandlerNotInitializedError,
@@ -750,37 +749,11 @@ export class StagehandPage {
         instruction,
         modelName,
         modelClientOptions,
-        useVision, // still destructure but will not pass it on
         domSettleTimeoutMs,
         returnAction = true,
         onlyVisible = false,
-        useAccessibilityTree,
         drawOverlay,
       } = options;
-
-      if (useAccessibilityTree !== undefined) {
-        this.stagehand.log({
-          category: "deprecation",
-          message:
-            "useAccessibilityTree is deprecated.\n" +
-            "  To use accessibility tree as context:\n" +
-            "    1. Set onlyVisible to false (default)\n" +
-            "    2. Don't declare useAccessibilityTree",
-          level: 1,
-        });
-        throw new StagehandDeprecationError(
-          "useAccessibilityTree is deprecated. Use onlyVisible instead.",
-        );
-      }
-
-      if (typeof useVision !== "undefined") {
-        this.stagehand.log({
-          category: "deprecation",
-          message:
-            "Warning: vision is not supported in this version of Stagehand",
-          level: 1,
-        });
-      }
 
       if (this.api) {
         const result = await this.api.observe(options);

--- a/lib/handlers/actHandler.ts
+++ b/lib/handlers/actHandler.ts
@@ -191,7 +191,6 @@ export class StagehandActHandler {
         // Call act with the ObserveResult description
         return await this.stagehandPage.act({
           action: actCommand,
-          slowDomBasedAct: true,
         });
       } catch (err) {
         this.logger({

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -67,27 +67,15 @@ async function getBrowser(
 ): Promise<BrowserResult> {
   if (env === "BROWSERBASE") {
     if (!apiKey) {
-      logger({
-        category: "init",
-        message:
-          "BROWSERBASE_API_KEY is required to use BROWSERBASE env. Defaulting to LOCAL.",
-        level: 0,
-      });
-      env = "LOCAL";
+      throw new StagehandError(
+        "BROWSERBASE_API_KEY is required. Please set the BROWSERBASE_API_KEY environment variable or pass it via apiKey in Stagehand config.",
+      );
     }
-    if (!projectId) {
-      logger({
-        category: "init",
-        message:
-          "BROWSERBASE_PROJECT_ID is required for some Browserbase features that may not work without it.",
-        level: 1,
-      });
-    }
-  }
 
-  if (env === "BROWSERBASE") {
-    if (!apiKey) {
-      throw new StagehandError("BROWSERBASE_API_KEY is required.");
+    if (!projectId) {
+      throw new StagehandError(
+        "BROWSERBASE_PROJECT_ID is required. Please set the BROWSERBASE_PROJECT_ID environment variable or pass it via projectId in Stagehand config.",
+      );
     }
 
     let debugUrl: string | undefined = undefined;

--- a/stagehand.config.ts
+++ b/stagehand.config.ts
@@ -10,8 +10,6 @@ const StagehandConfig: ConstructorParams = {
       : "LOCAL",
   apiKey: process.env.BROWSERBASE_API_KEY /* API key for authentication */,
   projectId: process.env.BROWSERBASE_PROJECT_ID /* Project identifier */,
-  debugDom: false /* Enable DOM debugging features */,
-  headless: false /* Run browser in headless mode */,
   logger: (message: LogLine) =>
     console.log(logLineToString(message)) /* Custom logging function */,
   domSettleTimeoutMs: 30_000 /* Timeout for DOM to settle in milliseconds */,
@@ -25,7 +23,6 @@ const StagehandConfig: ConstructorParams = {
       },
     },
   },
-  enableCaching: false /* Enable caching functionality */,
   browserbaseSessionID:
     undefined /* Session ID for resuming Browserbase sessions */,
   modelName: "gpt-4o" /* Name of the model to use */,

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -120,13 +120,9 @@ export interface ObserveOptions {
   instruction?: string;
   modelName?: AvailableModel;
   modelClientOptions?: ClientOptions;
-  /** @deprecated Vision is not supported in this version of Stagehand. */
-  useVision?: boolean;
   domSettleTimeoutMs?: number;
   returnAction?: boolean;
   onlyVisible?: boolean;
-  /** @deprecated `useAccessibilityTree` is now deprecated. Use `onlyVisible` instead. */
-  useAccessibilityTree?: boolean;
   drawOverlay?: boolean;
 }
 
@@ -140,6 +136,7 @@ export interface ObserveResult {
 
 export interface LocalBrowserLaunchOptions {
   args?: string[];
+  cdpUrl?: string;
   chromiumSandbox?: boolean;
   devtools?: boolean;
   env?: Record<string, string | number | boolean>;

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -1,5 +1,4 @@
 import Browserbase from "@browserbasehq/sdk";
-import { Page, BrowserContext } from "../types/page";
 import { z } from "zod";
 import { LLMProvider } from "../lib/llm/LLMProvider";
 import { LogLine } from "./log";
@@ -9,85 +8,93 @@ import { Cookie } from "@playwright/test";
 import { AgentProviderType } from "./agent";
 
 export interface ConstructorParams {
+  /**
+   * The environment to run in.
+   */
   env: "LOCAL" | "BROWSERBASE";
+  /**
+   * The API key for the Browserbase project.
+   * @default process.env.BROWSERBASE_API_KEY
+   */
   apiKey?: string;
+  /**
+   * The project ID for the Browserbase project.
+   * @default process.env.BROWSERBASE_PROJECT_ID
+   */
   projectId?: string;
+  /**
+   * The verbosity level. 0 is silent, 1 is verbose, 2 is debug.
+   */
   verbose?: 0 | 1 | 2;
-  /** @deprecated Dom Debugging is no longer supported in this version of Stagehand. */
-  debugDom?: boolean;
+  /**
+   * The LLM provider to use.
+   */
   llmProvider?: LLMProvider;
-  /** @deprecated Please use `localBrowserLaunchOptions` instead. That will override this. */
-  headless?: boolean;
+  /**
+   * Override the default logger.
+   */
   logger?: (message: LogLine) => void | Promise<void>;
+  /**
+   * The timeout for the DOM to settle.
+   */
   domSettleTimeoutMs?: number;
+  /**
+   * The Browserbase session create params.
+   * https://docs.browserbase.com/reference/api/create-a-session
+   */
   browserbaseSessionCreateParams?: Browserbase.Sessions.SessionCreateParams;
-  enableCaching?: boolean;
+  /**
+   * The Browserbase session ID. Useful for resuming a Browserbase session.
+   */
   browserbaseSessionID?: string;
+  /**
+   * The model name to use for a supported LLM provider.
+   */
   modelName?: AvailableModel;
-  llmClient?: LLMClient;
+  /**
+   * Configure the LLM client options.
+   * Most useful for { apiKey: model_api_key }
+   */
   modelClientOptions?: ClientOptions;
+  /**
+   * Configure the LLM client. Use custom LLM clients like Langchain, AI SDK, etc.
+   */
+  llmClient?: LLMClient;
   /**
    * Instructions for stagehand.
    */
   systemPrompt?: string;
   /**
    * Offload Stagehand method calls to the Stagehand API.
+   * Requires STAGEHAND_API_URL env to be set.
    */
   useAPI?: boolean;
-  selfHeal?: boolean;
   /**
    * Wait for captchas to be solved after navigation when using Browserbase environment.
    *
    * @default false
    */
   waitForCaptchaSolves?: boolean;
+  /**
+   * Configure the local browser launch options.
+   */
   localBrowserLaunchOptions?: LocalBrowserLaunchOptions;
+  /**
+   * The timeout for the action to complete.
+   */
   actTimeoutMs?: number;
+  /**
+   * Log the inference to a file.
+   */
   logInferenceToFile?: boolean;
-}
-
-export interface InitOptions {
-  /** @deprecated Pass this into the Stagehand constructor instead. This will be removed in the next major version. */
-  modelName?: AvailableModel;
-  /** @deprecated Pass this into the Stagehand constructor instead. This will be removed in the next major version. */
-  modelClientOptions?: ClientOptions;
-  /** @deprecated Pass this into the Stagehand constructor instead. This will be removed in the next major version. */
-  domSettleTimeoutMs?: number;
-}
-
-export interface InitResult {
-  debugUrl: string;
-  sessionUrl: string;
-  sessionId: string;
-}
-
-export interface InitFromPageOptions {
-  page: Page;
-  /** @deprecated Pass this into the Stagehand constructor instead. This will be removed in the next major version. */
-  modelName?: AvailableModel;
-  /** @deprecated Pass this into the Stagehand constructor instead. This will be removed in the next major version. */
-  modelClientOptions?: ClientOptions;
-}
-
-export interface InitFromPageResult {
-  context: BrowserContext;
 }
 
 export interface ActOptions {
   action: string;
   modelName?: AvailableModel;
   modelClientOptions?: ClientOptions;
-  /** @deprecated Vision is not supported in this version of Stagehand. */
-  useVision?: boolean;
   variables?: Record<string, string>;
   domSettleTimeoutMs?: number;
-  /**
-   * If true, the action will be performed in a slow manner that allows the DOM to settle.
-   * This is useful for debugging.
-   *
-   * @default true
-   */
-  slowDomBasedAct?: boolean;
   timeoutMs?: number;
 }
 


### PR DESCRIPTION
# why

# what changed
- Import `bb` stagehand config for bb evals and `e2e` stagehand config for general e2e evals
- Remove deprecated fields
- Change `init` to return the stagehand object instead
- Add `cdpUrl` to local browser launch options

# test plan
