### PR TITLE
scroll to next chunk

### DIFF
--- a/.changeset/clean-cups-join.md
+++ b/.changeset/clean-cups-join.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+added support for "scrolling to next/previous chunk"

--- a/evals/evals.config.json
+++ b/evals/evals.config.json
@@ -291,6 +291,14 @@
     {
       "name": "scroll_75",
       "categories": ["act", "regression_dom_extract"]
+    },
+    {
+      "name": "nextChunk",
+      "categories": ["act"]
+    },
+    {
+      "name": "prevChunk",
+      "categories": ["act"]
     }
   ]
 }

--- a/evals/tasks/nextChunk.ts
+++ b/evals/tasks/nextChunk.ts
@@ -1,0 +1,74 @@
+import { initStagehand } from "@/evals/initStagehand";
+import { EvalFunction } from "@/types/evals";
+
+export const nextChunk: EvalFunction = async ({ modelName, logger }) => {
+  const { stagehand, initResponse } = await initStagehand({
+    modelName,
+    logger,
+    domSettleTimeoutMs: 3000,
+  });
+
+  const { debugUrl, sessionUrl } = initResponse;
+
+  await stagehand.page.goto("https://www.apartments.com/san-francisco-ca/");
+  await stagehand.page.act({
+    action: "click on the all filters button",
+    slowDomBasedAct: false,
+  });
+
+  const { initialScrollTop, chunkHeight } = await stagehand.page.evaluate(
+    () => {
+      const container = document.querySelector(
+        "#advancedFilters > div",
+      ) as HTMLElement;
+      if (!container) {
+        console.warn(
+          "Could not find #advancedFilters > div. Returning 0 for measurements.",
+        );
+        return { initialScrollTop: 0, chunkHeight: 0 };
+      }
+      return {
+        initialScrollTop: container.scrollTop,
+        chunkHeight: container.getBoundingClientRect().height,
+      };
+    },
+  );
+
+  await stagehand.page.act({
+    action: "scroll down one chunk on the filters modal",
+    slowDomBasedAct: false,
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+
+  const newScrollTop = await stagehand.page.evaluate(() => {
+    const container = document.querySelector(
+      "#advancedFilters > div",
+    ) as HTMLElement;
+    return container?.scrollTop ?? 0;
+  });
+
+  await stagehand.close();
+
+  const actualDiff = newScrollTop - initialScrollTop;
+  const threshold = 20; // allowable difference in px
+  const scrolledOneChunk = Math.abs(actualDiff - chunkHeight) <= threshold;
+
+  const evaluationResult = scrolledOneChunk
+    ? {
+        _success: true,
+        logs: logger.getLogs(),
+        debugUrl,
+        sessionUrl,
+        message: `Successfully scrolled ~one chunk: expected ~${chunkHeight}, got ${actualDiff}`,
+      }
+    : {
+        _success: false,
+        logs: logger.getLogs(),
+        debugUrl,
+        sessionUrl,
+        message: `Scroll difference expected ~${chunkHeight} but only scrolled ${actualDiff}.`,
+      };
+
+  return evaluationResult;
+};

--- a/evals/tasks/prevChunk.ts
+++ b/evals/tasks/prevChunk.ts
@@ -1,0 +1,65 @@
+import { initStagehand } from "@/evals/initStagehand";
+import { EvalFunction } from "@/types/evals";
+
+export const prevChunk: EvalFunction = async ({ modelName, logger }) => {
+  const { stagehand, initResponse } = await initStagehand({
+    modelName,
+    logger,
+    domSettleTimeoutMs: 3000,
+  });
+
+  const { debugUrl, sessionUrl } = initResponse;
+  await stagehand.page.goto("https://aigrant.com/");
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+  const { initialScrollTop, chunkHeight } = await stagehand.page.evaluate(
+    () => {
+      const halfPage = document.body.scrollHeight / 2;
+
+      window.scrollTo({
+        top: halfPage,
+        left: 0,
+        behavior: "instant",
+      });
+
+      const chunk = window.innerHeight;
+
+      return {
+        initialScrollTop: window.scrollY,
+        chunkHeight: chunk,
+      };
+    },
+  );
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+  await stagehand.page.act({
+    action: "scroll up one chunk",
+    slowDomBasedAct: false,
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 5000));
+
+  const finalScrollTop = await stagehand.page.evaluate(() => window.scrollY);
+
+  await stagehand.close();
+
+  const actualDiff = initialScrollTop - finalScrollTop;
+  const threshold = 20; // px tolerance
+  const scrolledOneChunk = Math.abs(actualDiff - chunkHeight) <= threshold;
+
+  const evaluationResult = scrolledOneChunk
+    ? {
+        _success: true,
+        logs: logger.getLogs(),
+        debugUrl,
+        sessionUrl,
+        message: `Successfully scrolled ~one chunk UP: expected ~${chunkHeight}, got ${actualDiff}.`,
+      }
+    : {
+        _success: false,
+        logs: logger.getLogs(),
+        debugUrl,
+        sessionUrl,
+        message: `Scroll difference expected ~${chunkHeight} but only scrolled ${actualDiff}.`,
+      };
+
+  return evaluationResult;
+};

--- a/lib/dom/global.d.ts
+++ b/lib/dom/global.d.ts
@@ -32,5 +32,6 @@ declare global {
     }>;
     getScrollableElementXpaths: (topN?: number) => Promise<string[]>;
     getNodeFromXpath: (xpath: string) => Node | null;
+    waitForElementScrollEnd: (element: HTMLElement) => Promise<void>;
   }
 }

--- a/lib/dom/process.ts
+++ b/lib/dom/process.ts
@@ -4,6 +4,7 @@ import {
   canElementScroll,
   getNodeFromXpath,
   waitForDomSettle,
+  waitForElementScrollEnd,
 } from "./utils";
 import { createStagehandContainer } from "./containerFactory";
 import { StagehandContainer } from "./StagehandContainer";
@@ -530,6 +531,7 @@ window.getElementBoundingBoxes = getElementBoundingBoxes;
 window.createStagehandContainer = createStagehandContainer;
 window.getScrollableElementXpaths = getScrollableElementXpaths;
 window.getNodeFromXpath = getNodeFromXpath;
+window.waitForElementScrollEnd = waitForElementScrollEnd;
 
 async function pickChunk(chunksSeen: Array<number>) {
   const viewportHeight = calculateViewportHeight();

--- a/lib/dom/utils.ts
+++ b/lib/dom/utils.ts
@@ -69,3 +69,23 @@ export function getNodeFromXpath(xpath: string) {
     null,
   ).singleNodeValue;
 }
+
+export function waitForElementScrollEnd(
+  element: HTMLElement,
+  idleMs = 100,
+): Promise<void> {
+  return new Promise<void>((resolve) => {
+    let scrollEndTimer: number | undefined;
+
+    const handleScroll = () => {
+      clearTimeout(scrollEndTimer);
+      scrollEndTimer = window.setTimeout(() => {
+        element.removeEventListener("scroll", handleScroll);
+        resolve();
+      }, idleMs);
+    };
+
+    element.addEventListener("scroll", handleScroll, { passive: true });
+    handleScroll();
+  });
+}

--- a/lib/handlers/handlerUtils/actHandlerUtils.ts
+++ b/lib/handlers/handlerUtils/actHandlerUtils.ts
@@ -47,15 +47,30 @@ export async function scrollToNextChunk(ctx: MethodHandlerContext) {
         }
 
         const element = elementNode as HTMLElement;
-        const height = element.getBoundingClientRect().height;
+        const tagName = element.tagName.toLowerCase();
+        let height: number;
 
-        element.scrollBy({
-          top: height,
-          left: 0,
-          behavior: "smooth",
-        });
+        if (tagName === "html" || tagName === "body") {
+          height = window.visualViewport.height;
+          window.scrollBy({
+            top: height,
+            left: 0,
+            behavior: "smooth",
+          });
 
-        return window.waitForElementScrollEnd(element);
+          const scrollingEl =
+            document.scrollingElement || document.documentElement;
+          return window.waitForElementScrollEnd(scrollingEl as HTMLElement);
+        } else {
+          height = element.getBoundingClientRect().height;
+          element.scrollBy({
+            top: height,
+            left: 0,
+            behavior: "smooth",
+          });
+
+          return window.waitForElementScrollEnd(element);
+        }
       },
       { xpath },
     );
@@ -96,15 +111,29 @@ export async function scrollToPreviousChunk(ctx: MethodHandlerContext) {
         }
 
         const element = elementNode as HTMLElement;
-        const height = element.getBoundingClientRect().height;
+        const tagName = element.tagName.toLowerCase();
+        let height: number;
 
-        element.scrollBy({
-          top: -height,
-          left: 0,
-          behavior: "smooth",
-        });
+        if (tagName === "html" || tagName === "body") {
+          height = window.visualViewport.height;
+          window.scrollBy({
+            top: -height,
+            left: 0,
+            behavior: "smooth",
+          });
 
-        return window.waitForElementScrollEnd(element);
+          const scrollingEl =
+            document.scrollingElement || document.documentElement;
+          return window.waitForElementScrollEnd(scrollingEl as HTMLElement);
+        } else {
+          height = element.getBoundingClientRect().height;
+          element.scrollBy({
+            top: -height,
+            left: 0,
+            behavior: "smooth",
+          });
+          return window.waitForElementScrollEnd(element);
+        }
       },
       { xpath },
     );

--- a/lib/handlers/handlerUtils/actHandlerUtils.ts
+++ b/lib/handlers/handlerUtils/actHandlerUtils.ts
@@ -21,7 +21,107 @@ export const methodHandlerMap: Record<
   type: fillOrType,
   press: pressKey,
   click: clickElement,
+  nextChunk: scrollToNextChunk,
+  prevChunk: scrollToPreviousChunk,
 };
+
+export async function scrollToNextChunk(ctx: MethodHandlerContext) {
+  const { stagehandPage, xpath, logger } = ctx;
+
+  logger({
+    category: "action",
+    message: "scrolling to next chunk",
+    level: 2,
+    auxiliary: {
+      xpath: { value: xpath, type: "string" },
+    },
+  });
+
+  try {
+    await stagehandPage.page.evaluate(
+      ({ xpath }) => {
+        const elementNode = getNodeFromXpath(xpath);
+        if (!elementNode || elementNode.nodeType !== Node.ELEMENT_NODE) {
+          console.warn(`Could not locate element to scroll by its height.`);
+          return Promise.resolve();
+        }
+
+        const element = elementNode as HTMLElement;
+        const height = element.getBoundingClientRect().height;
+
+        element.scrollBy({
+          top: height,
+          left: 0,
+          behavior: "smooth",
+        });
+
+        return window.waitForElementScrollEnd(element);
+      },
+      { xpath },
+    );
+  } catch (e) {
+    logger({
+      category: "action",
+      message: "error scrolling to next chunk",
+      level: 1,
+      auxiliary: {
+        error: { value: e.message, type: "string" },
+        trace: { value: e.stack, type: "string" },
+        xpath: { value: xpath, type: "string" },
+      },
+    });
+    throw new PlaywrightCommandException(e.message);
+  }
+}
+
+export async function scrollToPreviousChunk(ctx: MethodHandlerContext) {
+  const { stagehandPage, xpath, logger } = ctx;
+
+  logger({
+    category: "action",
+    message: "scrolling to previous chunk",
+    level: 2,
+    auxiliary: {
+      xpath: { value: xpath, type: "string" },
+    },
+  });
+
+  try {
+    await stagehandPage.page.evaluate(
+      ({ xpath }) => {
+        const elementNode = getNodeFromXpath(xpath);
+        if (!elementNode || elementNode.nodeType !== Node.ELEMENT_NODE) {
+          console.warn(`Could not locate element to scroll by its height.`);
+          return Promise.resolve();
+        }
+
+        const element = elementNode as HTMLElement;
+        const height = element.getBoundingClientRect().height;
+
+        element.scrollBy({
+          top: -height,
+          left: 0,
+          behavior: "smooth",
+        });
+
+        return window.waitForElementScrollEnd(element);
+      },
+      { xpath },
+    );
+  } catch (e) {
+    logger({
+      category: "action",
+      message: "error scrolling to previous chunk",
+      level: 1,
+      auxiliary: {
+        error: { value: e.message, type: "string" },
+        trace: { value: e.stack, type: "string" },
+        xpath: { value: xpath, type: "string" },
+      },
+    });
+    throw new PlaywrightCommandException(e.message);
+  }
+}
 
 export async function scrollElementIntoView(ctx: MethodHandlerContext) {
   const { locator, xpath, logger } = ctx;

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -401,7 +401,9 @@ export function buildActObservePrompt(
   let instruction = `Find the most relevant element to perform an action on given the following action: ${action}. 
   Provide an action for this element such as ${supportedActions.join(", ")}, or any other playwright locator method. Remember that to users, buttons and links look the same in most cases.
   If the action is completely unrelated to a potential action to be taken on the page, return an empty array. 
-  ONLY return one action. If multiple actions are relevant, return the most relevant one. If the user is asking to scroll to a position on the page, e.g., 'halfway' or 0.75, etc, you must return the argument formatted as the correct percentage, e.g., '50%' or '75%', etc.`;
+  ONLY return one action. If multiple actions are relevant, return the most relevant one. 
+  If the user is asking to scroll to a position on the page, e.g., 'halfway' or 0.75, etc, you must return the argument formatted as the correct percentage, e.g., '50%' or '75%', etc.
+  If the user is asking to scroll to the next chunk/previous chunk, choose the nextChunk/prevChunk method. No arguments are required here.`;
 
   // Add variable names (not values) to the instruction if any
   if (variables && Object.keys(variables).length > 0) {

--- a/types/act.ts
+++ b/types/act.ts
@@ -36,6 +36,8 @@ export enum SupportedPlaywrightAction {
   FILL = "fill",
   TYPE = "type",
   SCROLL = "scrollTo",
+  NEXT_CHUNK = "nextChunk",
+  PREV_CHUNK = "prevChunk",
 }
 
 /**


### PR DESCRIPTION
# why
- @kamath made me
# what changed
- added support for "scrolling to next/previous chunk" in `performPlaywrightMethod`
- the size of a chunk is determined by the height of the container element that the xpath/selector points to
- if the LLM responds with a `nextChunk` command, here is what `performPlaywrightMethod` will do at a high level:
     - get the height of the `boundingClientRect` of the element that the `xpath` points to
     - call `element.scrollBy` and pass in the height as a parameter
     - vice versa for `prevChunk`