### PR TITLE
Clean up deprecated fields from stagehand.ts and allow CDP parameterization

### DIFF
--- a/.changeset/shaggy-mails-march.md
+++ b/.changeset/shaggy-mails-march.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": minor
+---
+
+Removed deprecated fields and methods from Stagehand constructor and added cdpUrl to localBrowserLaunchOptions for custom CDP URLs support.

--- a/evals/deterministic/stagehand.config.ts
+++ b/evals/deterministic/stagehand.config.ts
@@ -7,10 +7,12 @@ const StagehandConfig: ConstructorParams = {
   ...DefaultStagehandConfig,
   env: "LOCAL" /* Environment to run Stagehand in */,
   verbose: 1 /* Logging verbosity level (0=quiet, 1=normal, 2=verbose) */,
-  headless: true /* Run browser in headless mode */,
   browserbaseSessionCreateParams: {
     projectId: process.env.BROWSERBASE_PROJECT_ID,
   },
   enableCaching: false /* Enable caching functionality */,
+  localBrowserLaunchOptions: {
+    headless: true /* Run browser in headless mode */,
+  },
 };
 export default StagehandConfig;

--- a/evals/deterministic/tests/browserbase/sessions.test.ts
+++ b/evals/deterministic/tests/browserbase/sessions.test.ts
@@ -1,0 +1,45 @@
+import { test, expect } from "@playwright/test";
+import { Stagehand } from "@/dist";
+import StagehandConfig from "@/evals/deterministic/stagehand.config";
+import Browserbase from "@browserbasehq/sdk";
+
+test.describe("Browserbase Sessions", () => {
+  let stagehand: Stagehand;
+  let browserbase: Browserbase;
+  let sessionId: string;
+
+  test.beforeAll(async () => {
+    browserbase = new Browserbase({
+      apiKey: process.env.BROWSERBASE_API_KEY,
+    });
+    const session = await browserbase.sessions.create({
+      projectId: process.env.BROWSERBASE_PROJECT_ID,
+    });
+    sessionId = session.id;
+  });
+  test("resumes a session via sessionId", async () => {
+    stagehand = new Stagehand({
+      ...StagehandConfig,
+      browserbaseSessionID: sessionId,
+    });
+    await stagehand.init();
+
+    const page = stagehand.page;
+    await page.goto("https://docs.stagehand.dev/get_started/introduction");
+
+    expect(page.url()).toBe(
+      "https://docs.stagehand.dev/get_started/introduction",
+    );
+    await stagehand.close();
+  });
+  test("resumes a session via CDP URL", async () => {
+    const session = await browserbase.sessions.retrieve(sessionId);
+    stagehand = new Stagehand({
+      ...StagehandConfig,
+      localBrowserLaunchOptions: {
+        cdpUrl: session.cdpUrl,
+      },
+    });
+    await stagehand.init();
+  });
+});

--- a/evals/deterministic/tests/browserbase/sessions.test.ts
+++ b/evals/deterministic/tests/browserbase/sessions.test.ts
@@ -25,6 +25,9 @@ test.describe("Browserbase Sessions", () => {
       "https://docs.stagehand.dev/get_started/introduction",
     );
     sessionId = bigStagehand.browserbaseSessionID;
+    if (!sessionId) {
+      throw new Error("Failed to get browserbase session ID");
+    }
   });
   test.afterAll(async () => {
     await bigStagehand.close();
@@ -32,6 +35,7 @@ test.describe("Browserbase Sessions", () => {
   test("resumes a session via sessionId", async () => {
     const stagehand = new Stagehand({
       ...StagehandConfig,
+      env: "BROWSERBASE",
       browserbaseSessionID: sessionId,
     });
     await stagehand.init();
@@ -47,13 +51,16 @@ test.describe("Browserbase Sessions", () => {
     const session = await browserbase.sessions.retrieve(sessionId);
     const stagehand = new Stagehand({
       ...StagehandConfig,
+      env: "LOCAL",
       localBrowserLaunchOptions: {
         cdpUrl: session.connectUrl,
       },
     });
     await stagehand.init();
 
+    // Init from CDP URL creates a new page
     const page = stagehand.page;
+    await page.goto("https://docs.stagehand.dev/get_started/introduction");
 
     expect(page.url()).toBe(
       "https://docs.stagehand.dev/get_started/introduction",

--- a/evals/deterministic/tests/browserbase/sessions.test.ts
+++ b/evals/deterministic/tests/browserbase/sessions.test.ts
@@ -53,14 +53,12 @@ test.describe("Browserbase Sessions", () => {
       ...StagehandConfig,
       env: "LOCAL",
       localBrowserLaunchOptions: {
+        headless: true,
         cdpUrl: session.connectUrl,
       },
     });
     await stagehand.init();
-
-    // Init from CDP URL creates a new page
     const page = stagehand.page;
-    await page.goto("https://docs.stagehand.dev/get_started/introduction");
 
     expect(page.url()).toBe(
       "https://docs.stagehand.dev/get_started/introduction",

--- a/evals/deterministic/tests/local/create.test.ts
+++ b/evals/deterministic/tests/local/create.test.ts
@@ -4,21 +4,11 @@ import path from "path";
 import fs from "fs";
 import os from "os";
 import type { Cookie } from "@playwright/test";
+import StagehandConfig from "../../stagehand.config";
 
 test.describe("Local browser launch options", () => {
   test("launches with default options when no localBrowserLaunchOptions provided", async () => {
-    const stagehand = new Stagehand({
-      env: "LOCAL",
-      verbose: 1,
-      headless: true,
-      debugDom: true,
-      domSettleTimeoutMs: 30_000,
-      enableCaching: true,
-      modelName: "gpt-4o",
-      modelClientOptions: {
-        apiKey: process.env.OPENAI_API_KEY,
-      },
-    });
+    const stagehand = new Stagehand(StagehandConfig);
     await stagehand.init();
 
     const context = stagehand.context;
@@ -32,18 +22,10 @@ test.describe("Local browser launch options", () => {
     const customUserDataDir = path.join(os.tmpdir(), "custom-user-data");
 
     const stagehand = new Stagehand({
-      env: "LOCAL",
-      verbose: 1,
-      headless: true,
-      debugDom: true,
-      domSettleTimeoutMs: 30_000,
-      enableCaching: true,
-      modelName: "gpt-4o",
-      modelClientOptions: {
-        apiKey: process.env.OPENAI_API_KEY,
-      },
+      ...StagehandConfig,
       localBrowserLaunchOptions: {
         userDataDir: customUserDataDir,
+        headless: true,
       },
     });
     await stagehand.init();
@@ -60,17 +42,9 @@ test.describe("Local browser launch options", () => {
     const customViewport = { width: 1920, height: 1080 };
 
     const stagehand = new Stagehand({
-      env: "LOCAL",
-      verbose: 1,
-      headless: true,
-      debugDom: true,
-      domSettleTimeoutMs: 30_000,
-      enableCaching: true,
-      modelName: "gpt-4o",
-      modelClientOptions: {
-        apiKey: process.env.OPENAI_API_KEY,
-      },
+      ...StagehandConfig,
       localBrowserLaunchOptions: {
+        ...StagehandConfig.localBrowserLaunchOptions,
         viewport: customViewport,
       },
     });
@@ -99,17 +73,9 @@ test.describe("Local browser launch options", () => {
     ];
 
     const stagehand = new Stagehand({
-      env: "LOCAL",
-      verbose: 1,
-      headless: true,
-      debugDom: true,
-      domSettleTimeoutMs: 30_000,
-      enableCaching: true,
-      modelName: "gpt-4o",
-      modelClientOptions: {
-        apiKey: process.env.OPENAI_API_KEY,
-      },
+      ...StagehandConfig,
       localBrowserLaunchOptions: {
+        ...StagehandConfig.localBrowserLaunchOptions,
         cookies: testCookies,
       },
     });
@@ -133,17 +99,9 @@ test.describe("Local browser launch options", () => {
     };
 
     const stagehand = new Stagehand({
-      env: "LOCAL",
-      verbose: 1,
-      headless: true,
-      debugDom: true,
-      domSettleTimeoutMs: 30_000,
-      enableCaching: true,
-      modelName: "gpt-4o",
-      modelClientOptions: {
-        apiKey: process.env.OPENAI_API_KEY,
-      },
+      ...StagehandConfig,
       localBrowserLaunchOptions: {
+        ...StagehandConfig.localBrowserLaunchOptions,
         geolocation: customGeolocation,
         permissions: ["geolocation"],
       },
@@ -174,17 +132,9 @@ test.describe("Local browser launch options", () => {
 
   test("applies custom timezone and locale", async () => {
     const stagehand = new Stagehand({
-      env: "LOCAL",
-      verbose: 1,
-      headless: true,
-      debugDom: true,
-      domSettleTimeoutMs: 30_000,
-      enableCaching: true,
-      modelName: "gpt-4o",
-      modelClientOptions: {
-        apiKey: process.env.OPENAI_API_KEY,
-      },
+      ...StagehandConfig,
       localBrowserLaunchOptions: {
+        ...StagehandConfig.localBrowserLaunchOptions,
         locale: "ja-JP",
         timezoneId: "Asia/Tokyo",
       },
@@ -210,17 +160,9 @@ test.describe("Local browser launch options", () => {
     fs.mkdirSync(videoDir, { recursive: true });
 
     const stagehand = new Stagehand({
-      env: "LOCAL",
-      verbose: 1,
-      headless: true,
-      debugDom: true,
-      domSettleTimeoutMs: 30_000,
-      enableCaching: true,
-      modelName: "gpt-4o",
-      modelClientOptions: {
-        apiKey: process.env.OPENAI_API_KEY,
-      },
+      ...StagehandConfig,
       localBrowserLaunchOptions: {
+        ...StagehandConfig.localBrowserLaunchOptions,
         recordVideo: {
           dir: videoDir,
           size: { width: 800, height: 600 },

--- a/evals/tasks/expect_act_timeout.ts
+++ b/evals/tasks/expect_act_timeout.ts
@@ -16,7 +16,6 @@ export const expect_act_timeout: EvalFunction = async ({
   const result = await stagehand.page.act({
     action: "search for 'Stagehand'",
     timeoutMs: 1_000,
-    slowDomBasedAct: true,
   });
 
   await stagehand.close();

--- a/evals/tasks/expect_act_timeout_global.ts
+++ b/evals/tasks/expect_act_timeout_global.ts
@@ -17,7 +17,7 @@ export const expect_act_timeout_global: EvalFunction = async ({
 
   const result = await stagehand.page.act({
     action: "search for 'Stagehand'",
-    slowDomBasedAct: true,
+    timeoutMs: 1_000,
   });
   console.log("RESULT", result);
 

--- a/evals/tasks/extract_zillow.ts
+++ b/evals/tasks/extract_zillow.ts
@@ -11,9 +11,6 @@ export const extract_zillow: EvalFunction = async ({
     modelName,
     logger,
     domSettleTimeoutMs: 3000,
-    configOverrides: {
-      debugDom: false,
-    },
   });
 
   const { debugUrl, sessionUrl } = initResponse;

--- a/evals/tasks/nextChunk.ts
+++ b/evals/tasks/nextChunk.ts
@@ -13,7 +13,6 @@ export const nextChunk: EvalFunction = async ({ modelName, logger }) => {
   await stagehand.page.goto("https://www.apartments.com/san-francisco-ca/");
   await stagehand.page.act({
     action: "click on the all filters button",
-    slowDomBasedAct: false,
   });
 
   const { initialScrollTop, chunkHeight } = await stagehand.page.evaluate(
@@ -36,7 +35,6 @@ export const nextChunk: EvalFunction = async ({ modelName, logger }) => {
 
   await stagehand.page.act({
     action: "scroll down one chunk on the filters modal",
-    slowDomBasedAct: false,
   });
 
   await new Promise((resolve) => setTimeout(resolve, 2000));

--- a/evals/tasks/prevChunk.ts
+++ b/evals/tasks/prevChunk.ts
@@ -32,7 +32,6 @@ export const prevChunk: EvalFunction = async ({ modelName, logger }) => {
   await new Promise((resolve) => setTimeout(resolve, 2000));
   await stagehand.page.act({
     action: "scroll up one chunk",
-    slowDomBasedAct: false,
   });
 
   await new Promise((resolve) => setTimeout(resolve, 5000));

--- a/evals/tasks/scroll_50.ts
+++ b/evals/tasks/scroll_50.ts
@@ -12,7 +12,6 @@ export const scroll_50: EvalFunction = async ({ modelName, logger }) => {
   await stagehand.page.goto("https://aigrant.com/");
   await stagehand.page.act({
     action: "Scroll 50% down the page",
-    slowDomBasedAct: false,
   });
 
   await new Promise((resolve) => setTimeout(resolve, 5000));

--- a/evals/tasks/scroll_75.ts
+++ b/evals/tasks/scroll_75.ts
@@ -12,7 +12,6 @@ export const scroll_75: EvalFunction = async ({ modelName, logger }) => {
   await stagehand.page.goto("https://aigrant.com/");
   await stagehand.page.act({
     action: "Scroll 75% down the page",
-    slowDomBasedAct: false,
   });
 
   await new Promise((resolve) => setTimeout(resolve, 5000));

--- a/examples/2048.ts
+++ b/examples/2048.ts
@@ -6,7 +6,6 @@ async function example() {
   const stagehand = new Stagehand({
     env: "LOCAL",
     verbose: 1,
-    debugDom: true,
     domSettleTimeoutMs: 100,
   });
   try {

--- a/examples/debugUrl.ts
+++ b/examples/debugUrl.ts
@@ -4,7 +4,9 @@ async function debug(url: string) {
   const stagehand = new Stagehand({
     env: "LOCAL",
     verbose: 2,
-    debugDom: true,
+    localBrowserLaunchOptions: {
+      headless: true,
+    },
   });
   await stagehand.init();
   await stagehand.page.goto(url);

--- a/examples/parameterizeApiKey.ts
+++ b/examples/parameterizeApiKey.ts
@@ -15,7 +15,6 @@ async function example() {
   const stagehand = new Stagehand({
     env: "LOCAL",
     verbose: 1,
-    debugDom: true,
     enableCaching: false,
     modelName: "gpt-4o",
     modelClientOptions: {

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -558,19 +558,8 @@ export class StagehandPage {
         },
       });
 
-      // `useVision` is no longer passed to the handler
       const result = await this.actHandler
-        .act({
-          action,
-          llmClient,
-          chunksSeen: [],
-          requestId,
-          variables,
-          previousSelectors: [],
-          skipActionCacheForThisStep: false,
-          domSettleTimeoutMs,
-          timeoutMs,
-        })
+        .observeAct(actionOrOptions, this.observeHandler, llmClient, requestId)
         .catch((e) => {
           this.stagehand.log({
             category: "act",

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -517,14 +517,7 @@ export class StagehandPage {
         );
       }
 
-      const {
-        action,
-        modelName,
-        modelClientOptions,
-        variables = {},
-        domSettleTimeoutMs,
-        timeoutMs = this.stagehand.actTimeoutMs,
-      } = actionOrOptions;
+      const { action, modelName, modelClientOptions } = actionOrOptions;
 
       if (this.api) {
         const result = await this.api.act(actionOrOptions);
@@ -558,35 +551,13 @@ export class StagehandPage {
         },
       });
 
-      const result = await this.actHandler
-        .observeAct(actionOrOptions, this.observeHandler, llmClient, requestId)
-        .catch((e) => {
-          this.stagehand.log({
-            category: "act",
-            message: "error acting",
-            level: 1,
-            auxiliary: {
-              error: {
-                value: e.message,
-                type: "string",
-              },
-              trace: {
-                value: e.stack,
-                type: "string",
-              },
-            },
-          });
-
-          return {
-            success: false,
-            message: `Internal error: Error acting: ${e.message}`,
-            action: action,
-          };
-        });
-
-      this.addToHistory("act", actionOrOptions, result);
-
-      return result;
+      // `useVision` is no longer passed to the handler
+      return this.actHandler.observeAct(
+        actionOrOptions,
+        this.observeHandler,
+        llmClient,
+        requestId,
+      );
     } catch (err: unknown) {
       if (err instanceof StagehandError || err instanceof StagehandAPIError) {
         throw err;

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -25,7 +25,6 @@ import {
   StagehandEnvironmentError,
   CaptchaTimeoutError,
   StagehandNotImplementedError,
-  StagehandDeprecationError,
   BrowserbaseSessionNotFoundError,
   MissingLLMConfigurationError,
   HandlerNotInitializedError,
@@ -522,21 +521,10 @@ export class StagehandPage {
         action,
         modelName,
         modelClientOptions,
-        useVision, // still destructure this but will not pass it on
         variables = {},
         domSettleTimeoutMs,
-        slowDomBasedAct = true,
         timeoutMs = this.stagehand.actTimeoutMs,
       } = actionOrOptions;
-
-      if (typeof useVision !== "undefined") {
-        this.stagehand.log({
-          category: "deprecation",
-          message:
-            "Warning: vision is not supported in this version of Stagehand",
-          level: 1,
-        });
-      }
 
       if (this.api) {
         const result = await this.api.act(actionOrOptions);
@@ -549,15 +537,6 @@ export class StagehandPage {
       const llmClient: LLMClient = modelName
         ? this.stagehand.llmProvider.getClient(modelName, modelClientOptions)
         : this.llmClient;
-
-      if (!slowDomBasedAct) {
-        return this.actHandler.observeAct(
-          actionOrOptions,
-          this.observeHandler,
-          llmClient,
-          requestId,
-        );
-      }
 
       this.stagehand.log({
         category: "act",
@@ -770,37 +749,11 @@ export class StagehandPage {
         instruction,
         modelName,
         modelClientOptions,
-        useVision, // still destructure but will not pass it on
         domSettleTimeoutMs,
         returnAction = true,
         onlyVisible = false,
-        useAccessibilityTree,
         drawOverlay,
       } = options;
-
-      if (useAccessibilityTree !== undefined) {
-        this.stagehand.log({
-          category: "deprecation",
-          message:
-            "useAccessibilityTree is deprecated.\n" +
-            "  To use accessibility tree as context:\n" +
-            "    1. Set onlyVisible to false (default)\n" +
-            "    2. Don't declare useAccessibilityTree",
-          level: 1,
-        });
-        throw new StagehandDeprecationError(
-          "useAccessibilityTree is deprecated. Use onlyVisible instead.",
-        );
-      }
-
-      if (typeof useVision !== "undefined") {
-        this.stagehand.log({
-          category: "deprecation",
-          message:
-            "Warning: vision is not supported in this version of Stagehand",
-          level: 1,
-        });
-      }
 
       if (this.api) {
         const result = await this.api.observe(options);

--- a/lib/handlers/actHandler.ts
+++ b/lib/handlers/actHandler.ts
@@ -191,7 +191,6 @@ export class StagehandActHandler {
         // Call act with the ObserveResult description
         return await this.stagehandPage.act({
           action: actCommand,
-          slowDomBasedAct: true,
         });
       } catch (err) {
         this.logger({

--- a/lib/handlers/actHandler.ts
+++ b/lib/handlers/actHandler.ts
@@ -254,45 +254,69 @@ export class StagehandActHandler {
       );
     }
 
-    // Craft the instruction for observe
-    const instruction = buildActObservePrompt(
-      action,
-      Object.values(SupportedPlaywrightAction),
-      actionOrOptions.variables,
-    );
-
-    // Call observe with the instruction and extracted options
-    const observeResults = await observeHandler.observe({
-      instruction,
-      llmClient: llmClient,
-      requestId,
-      onlyVisible: false,
-      drawOverlay: false,
-      returnAction: true,
-    });
-
-    if (observeResults.length === 0) {
-      return {
-        success: false,
-        message: `Failed to perform act: No observe results found for action`,
+    // doObserveAndAct is just a wrapper of observeAct and actFromObserveResult.
+    // we did this so that we can cleanly call a Promise.race, and race
+    // doObserveAndAct against the user defined timeoutMs (if one was defined)
+    const doObserveAndAct = async (): Promise<ActResult> => {
+      const instruction = buildActObservePrompt(
         action,
-      };
+        Object.values(SupportedPlaywrightAction),
+        actionOrOptions.variables,
+      );
+
+      const observeResults = await observeHandler.observe({
+        instruction,
+        llmClient,
+        requestId,
+        onlyVisible: false,
+        drawOverlay: false,
+        returnAction: true,
+      });
+
+      if (observeResults.length === 0) {
+        return {
+          success: false,
+          message: `Failed to perform act: No observe results found for action`,
+          action,
+        };
+      }
+
+      const element: ObserveResult = observeResults[0];
+
+      if (actionOrOptions.variables) {
+        Object.keys(actionOrOptions.variables).forEach((key) => {
+          element.arguments = element.arguments.map((arg) =>
+            arg.replace(key, actionOrOptions.variables![key]),
+          );
+        });
+      }
+
+      return this.actFromObserveResult(
+        element,
+        actionOrOptions.domSettleTimeoutMs,
+      );
+    };
+
+    // if no user defined timeoutMs, just do observeAct + actFromObserveResult
+    // with no timeout
+    if (!actionOrOptions.timeoutMs) {
+      return doObserveAndAct();
     }
 
-    // Perform the action on the first observed element
-    const element: ObserveResult = observeResults[0];
-    // Replace the arguments with the variables if any
-    if (actionOrOptions.variables) {
-      Object.keys(actionOrOptions.variables).forEach((key) => {
-        element.arguments = element.arguments.map((arg) =>
-          arg.replace(key, actionOrOptions.variables[key]),
-        );
-      });
-    }
-    return this.actFromObserveResult(
-      element,
-      actionOrOptions.domSettleTimeoutMs,
-    );
+    // Race observeAct + actFromObserveResult vs. the timeoutMs
+    const { timeoutMs } = actionOrOptions;
+    return await Promise.race([
+      doObserveAndAct(),
+      new Promise<ActResult>((resolve) => {
+        setTimeout(() => {
+          resolve({
+            success: false,
+            message: `Action timed out after ${timeoutMs}ms`,
+            action,
+          });
+        }, timeoutMs);
+      }),
+    ]);
   }
 
   private async _recordAction(action: string, result: string): Promise<string> {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -535,7 +535,6 @@ export class Stagehand {
     // Update logger verbosity level
     this.stagehandLogger.setVerbosity(this.verbose);
 
-    this.debugDom = debugDom ?? false;
     if (llmClient) {
       this.llmClient = llmClient;
     } else {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -239,6 +239,26 @@ async function getBrowser(
       });
     }
 
+    if (localBrowserLaunchOptions?.cdpUrl) {
+      logger({
+        category: "init",
+        message: "connecting to local browser via CDP URL",
+        level: 0,
+        auxiliary: {
+          cdpUrl: {
+            value: localBrowserLaunchOptions.cdpUrl,
+            type: "string",
+          },
+        },
+      });
+
+      const browser = await chromium.connectOverCDP(
+        localBrowserLaunchOptions.cdpUrl,
+      );
+      const context = browser.contexts()[0];
+      return { browser, context, env: "LOCAL" };
+    }
+
     let userDataDir = localBrowserLaunchOptions?.userDataDir;
     if (!userDataDir) {
       const tmpDirPath = path.join(os.tmpdir(), "stagehand");

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -49,12 +49,6 @@ import {
 dotenv.config({ path: ".env" });
 
 const DEFAULT_MODEL_NAME = "gpt-4o";
-const BROWSERBASE_REGION_DOMAIN = {
-  "us-west-2": "wss://connect.usw2.browserbase.com",
-  "us-east-1": "wss://connect.use1.browserbase.com",
-  "eu-central-1": "wss://connect.euc1.browserbase.com",
-  "ap-southeast-1": "wss://connect.apse1.browserbase.com",
-};
 
 async function getBrowser(
   apiKey: string | undefined,
@@ -113,10 +107,8 @@ async function getBrowser(
         }
 
         sessionId = browserbaseSessionID;
-        const browserbaseDomain =
-          BROWSERBASE_REGION_DOMAIN[sessionStatus.region] ||
-          "wss://connect.browserbase.com";
-        connectUrl = `${browserbaseDomain}?apiKey=${apiKey}&sessionId=${sessionId}`;
+        const session = await browserbase.sessions.retrieve(sessionId);
+        connectUrl = session.connectUrl;
 
         logger({
           category: "init",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.39.0",
-        "@browserbasehq/sdk": "^2.0.0",
+        "@browserbasehq/sdk": "^2.4.0",
         "ws": "^8.18.0",
         "zod-to-json-schema": "^3.23.5"
       },
@@ -612,9 +612,9 @@
       }
     },
     "node_modules/@browserbasehq/sdk": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@browserbasehq/sdk/-/sdk-2.3.0.tgz",
-      "integrity": "sha512-H2nu46C6ydWgHY+7yqaP8qpfRJMJFVGxVIgsuHe1cx9HkfJHqzkuIqaK/k8mU4ZeavQgV5ZrJa0UX6MDGYiT4w==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@browserbasehq/sdk/-/sdk-2.4.0.tgz",
+      "integrity": "sha512-o1+6C4MQCpZ9+8je1IUF9UvWLuSzLcBjE1kPfu2sw7MgRFNFJS1NcWCiEmjZe71ke4CNojZWaU7XTNxh8z2PUw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^18.11.18",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "0.39.0",
-    "@browserbasehq/sdk": "^2.0.0",
+    "@browserbasehq/sdk": "^2.4.0",
     "ws": "^8.18.0",
     "zod-to-json-schema": "^3.23.5"
   },

--- a/stagehand.config.ts
+++ b/stagehand.config.ts
@@ -10,8 +10,6 @@ const StagehandConfig: ConstructorParams = {
       : "LOCAL",
   apiKey: process.env.BROWSERBASE_API_KEY /* API key for authentication */,
   projectId: process.env.BROWSERBASE_PROJECT_ID /* Project identifier */,
-  debugDom: false /* Enable DOM debugging features */,
-  headless: false /* Run browser in headless mode */,
   logger: (message: LogLine) =>
     console.log(logLineToString(message)) /* Custom logging function */,
   domSettleTimeoutMs: 30_000 /* Timeout for DOM to settle in milliseconds */,
@@ -32,5 +30,8 @@ const StagehandConfig: ConstructorParams = {
   modelClientOptions: {
     apiKey: process.env.OPENAI_API_KEY,
   } /* Configuration options for the model client */,
+  localBrowserLaunchOptions: {
+    headless: false,
+  },
 };
 export default StagehandConfig;

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -1,5 +1,4 @@
 import Browserbase from "@browserbasehq/sdk";
-import { Page, BrowserContext } from "../types/page";
 import { z } from "zod";
 import { LLMProvider } from "../lib/llm/LLMProvider";
 import { LogLine } from "./log";
@@ -9,50 +8,89 @@ import { Cookie } from "@playwright/test";
 import { AgentProviderType } from "./agent";
 
 export interface ConstructorParams {
+  /**
+   * The environment to use for Stagehand
+   */
   env: "LOCAL" | "BROWSERBASE";
+  /**
+   * Your Browserbase API key
+   */
   apiKey?: string;
+  /**
+   * Your Browserbase project ID
+   */
   projectId?: string;
+  /**
+   * The verbosity of the Stagehand logger
+   * 0 - No logs
+   * 1 - Only errors
+   * 2 - All logs
+   */
   verbose?: 0 | 1 | 2;
-  /** @deprecated Dom Debugging is no longer supported in this version of Stagehand. */
-  debugDom?: boolean;
+  /**
+   * The LLM provider to use for Stagehand
+   * See
+   */
   llmProvider?: LLMProvider;
-  /** @deprecated Please use `localBrowserLaunchOptions` instead. That will override this. */
-  headless?: boolean;
+  /**
+   * The logger to use for Stagehand
+   */
   logger?: (message: LogLine) => void | Promise<void>;
+  /**
+   * The timeout to use for the DOM to settle
+   * @default 10000
+   */
   domSettleTimeoutMs?: number;
+  /**
+   * The parameters to use for creating a Browserbase session
+   * See https://docs.browserbase.com/reference/api/create-a-session
+   */
   browserbaseSessionCreateParams?: Browserbase.Sessions.SessionCreateParams;
+  /**
+   * Enable caching of LLM responses
+   * @default true
+   */
   enableCaching?: boolean;
+  /**
+   * The ID of a Browserbase session to resume
+   */
   browserbaseSessionID?: string;
+  /**
+   * The model to use for Stagehand
+   */
   modelName?: AvailableModel;
+  /**
+   * The LLM client to use for Stagehand
+   */
   llmClient?: LLMClient;
+  /**
+   * The parameters to use for the LLM client
+   * Useful for parameterizing LLM API Keys
+   */
   modelClientOptions?: ClientOptions;
   /**
-   * Instructions for stagehand.
+   * Customize the Stagehand system prompt
    */
   systemPrompt?: string;
   /**
    * Offload Stagehand method calls to the Stagehand API.
+   * Must have a valid API key to use
    */
   useAPI?: boolean;
-  selfHeal?: boolean;
   /**
    * Wait for captchas to be solved after navigation when using Browserbase environment.
    *
    * @default false
    */
   waitForCaptchaSolves?: boolean;
+  /**
+   * The parameters to use for launching a local browser
+   */
   localBrowserLaunchOptions?: LocalBrowserLaunchOptions;
-  actTimeoutMs?: number;
+  /**
+   * Log the inference to a file
+   */
   logInferenceToFile?: boolean;
-}
-
-export interface InitOptions {
-  /** @deprecated Pass this into the Stagehand constructor instead. This will be removed in the next major version. */
-  modelName?: AvailableModel;
-  /** @deprecated Pass this into the Stagehand constructor instead. This will be removed in the next major version. */
-  modelClientOptions?: ClientOptions;
-  /** @deprecated Pass this into the Stagehand constructor instead. This will be removed in the next major version. */
-  domSettleTimeoutMs?: number;
 }
 
 export interface InitResult {
@@ -61,33 +99,12 @@ export interface InitResult {
   sessionId: string;
 }
 
-export interface InitFromPageOptions {
-  page: Page;
-  /** @deprecated Pass this into the Stagehand constructor instead. This will be removed in the next major version. */
-  modelName?: AvailableModel;
-  /** @deprecated Pass this into the Stagehand constructor instead. This will be removed in the next major version. */
-  modelClientOptions?: ClientOptions;
-}
-
-export interface InitFromPageResult {
-  context: BrowserContext;
-}
-
 export interface ActOptions {
   action: string;
   modelName?: AvailableModel;
   modelClientOptions?: ClientOptions;
-  /** @deprecated Vision is not supported in this version of Stagehand. */
-  useVision?: boolean;
   variables?: Record<string, string>;
   domSettleTimeoutMs?: number;
-  /**
-   * If true, the action will be performed in a slow manner that allows the DOM to settle.
-   * This is useful for debugging.
-   *
-   * @default true
-   */
-  slowDomBasedAct?: boolean;
   timeoutMs?: number;
 }
 
@@ -113,13 +130,9 @@ export interface ObserveOptions {
   instruction?: string;
   modelName?: AvailableModel;
   modelClientOptions?: ClientOptions;
-  /** @deprecated Vision is not supported in this version of Stagehand. */
-  useVision?: boolean;
   domSettleTimeoutMs?: number;
   returnAction?: boolean;
   onlyVisible?: boolean;
-  /** @deprecated `useAccessibilityTree` is now deprecated. Use `onlyVisible` instead. */
-  useAccessibilityTree?: boolean;
   drawOverlay?: boolean;
 }
 
@@ -171,6 +184,7 @@ export interface LocalBrowserLaunchOptions {
   timezoneId?: string;
   bypassCSP?: boolean;
   cookies?: Cookie[];
+  cdpUrl?: boolean;
 }
 
 export interface StagehandMetrics {

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -184,7 +184,7 @@ export interface LocalBrowserLaunchOptions {
   timezoneId?: string;
   bypassCSP?: boolean;
   cookies?: Cookie[];
-  cdpUrl?: boolean;
+  cdpUrl?: string;
 }
 
 export interface StagehandMetrics {


### PR DESCRIPTION
# why
Allowing CDP URL parameterization and removing deprecated fields

# what changed
- Removed previously deprecated fields from Stagehand constructor
- Added cdpUrl to localBrowserLaunchOptions
- Added deterministic evals for `cdpUrl` and `resumeSession`
- Changed resume session logic to pull connect URL from BB API

# test plan
evals + added resume session evals