### PR TITLE
test env input

### DIFF
--- a/.changeset/true-moles-hear.md
+++ b/.changeset/true-moles-hear.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+add disablePino flag to stagehand constructor params

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -82,8 +82,12 @@ export class StagehandLogger {
   constructor(
     options: LoggerOptions = {},
     externalLogger?: (logLine: LogLine) => void,
+    userDefinedIsTestEnvironment?: boolean,
   ) {
-    this.isTest = isTestEnvironment();
+    this.isTest =
+      userDefinedIsTestEnvironment !== undefined
+        ? userDefinedIsTestEnvironment
+        : isTestEnvironment();
 
     // In test environments, default to not using Pino to avoid worker thread issues
     this.usePino = this.isTest ? false : options.usePino !== false; // Default to using Pino if not specified and not in test

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -82,12 +82,8 @@ export class StagehandLogger {
   constructor(
     options: LoggerOptions = {},
     externalLogger?: (logLine: LogLine) => void,
-    userDefinedIsTestEnvironment?: boolean,
   ) {
-    this.isTest =
-      userDefinedIsTestEnvironment !== undefined
-        ? userDefinedIsTestEnvironment
-        : isTestEnvironment();
+    this.isTest = isTestEnvironment();
 
     // In test environments, default to not using Pino to avoid worker thread issues
     this.usePino = this.isTest ? false : options.usePino !== false; // Default to using Pino if not specified and not in test

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -95,7 +95,7 @@ export interface ConstructorParams {
   /**
    * Whether Stagehand is running in a test environment
    */
-  isTestEnvironment?: boolean;
+  disablePino?: boolean;
 }
 
 export interface InitResult {

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -92,6 +92,10 @@ export interface ConstructorParams {
    */
   logInferenceToFile?: boolean;
   selfHeal?: boolean;
+  /**
+   * Whether Stagehand is running in a test environment
+   */
+  isTestEnvironment?: boolean;
 }
 
 export interface InitResult {

--- a/types/stagehandErrors.ts
+++ b/types/stagehandErrors.ts
@@ -8,7 +8,7 @@ export class StagehandError extends Error {
 export class StagehandDefaultError extends StagehandError {
   constructor() {
     super(
-      `\nHey! We're sorry you ran into an error. \nIf you need help, please open a Github issue or send us a Slack message: https://stagehand-dev.slack.com\n`,
+      `\nHey! We're sorry you ran into an error. \nIf you need help, please open a Github issue or send us a Slack message: https://stagehand-dev.slack\n`,
     );
   }
 }


### PR DESCRIPTION
# why
Allow users to disable Pino. useful for test environments and preventing errors in CI.

# what changed
Added a `disablePino` parameter to the constructor

# test plan
