### PR TITLE
Add support for custom OpenAI provider

### DIFF
--- a/.changeset/wide-oranges-yawn.md
+++ b/.changeset/wide-oranges-yawn.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": minor
+---
+
+parameterize openai client

--- a/.changeset/wide-oranges-yawn.md
+++ b/.changeset/wide-oranges-yawn.md
@@ -2,4 +2,4 @@
 "@browserbasehq/stagehand": minor
 ---
 
-parameterize openai client
+You can now pass in an OpenAI instance as an `llmClient` to the Stagehand constructor! This allows you to use Stagehand with any OpenAI-compatible model, like Ollama, Gemini, etc., as well as OpenAI wrappers like Braintrust.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,12 @@ jobs:
           echo "View regression_llm_providers results: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameRegressionLlmProviders}"
           echo "regression_llm_providers_score=$regression_llm_providers_score" >> "$GITHUB_OUTPUT"
 
+          # Fail if regression_llm_providers_score is below 83%
+          if (( $(echo "${regression_llm_providers_score} < 83" | bc -l) )); then
+            echo "regression_llm_providers score is below 83%. Failing CI."
+            exit 1
+          fi
+
   run-regression-evals-dom-extract:
     needs:
       [run-e2e-bb-tests, run-e2e-tests, run-e2e-local-tests, determine-evals]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,8 +194,8 @@ jobs:
     outputs:
       regression_llm_providers_score: ${{ steps.set-llm-providers-score.outputs.regression_llm_providers_score }}
     env:
+      EVAL_MODELS: "gpt-4o-mini"
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
       BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
       BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,57 @@ jobs:
       - name: Run E2E Tests (browserbase)
         run: npm run e2e:bb
 
+  run-regression-evals-llm-providers:
+    needs:
+      [run-e2e-bb-tests, run-e2e-tests, run-e2e-local-tests, determine-evals]
+    runs-on: ubuntu-latest
+    timeout-minutes: 7
+    outputs:
+      regression_llm_providers_score: ${{ steps.set-llm-providers-score.outputs.regression_llm_providers_score }}
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
+      BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
+      BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
+      HEADLESS: true
+      EVAL_ENV: browserbase
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install dependencies
+        run: |
+          rm -rf node_modules
+          rm -f package-lock.json
+          npm install
+
+      - name: Build Stagehand
+        run: npm run build
+
+      - name: Install Playwright browsers
+        run: npm exec playwright install --with-deps
+
+      - name: Run Regression Evals (llmProviders)
+        run: npm run evals category regression_llm_providers trials=2 concurrency=12 env=BROWSERBASE -- --extract-method=llmProviders
+
+      - name: Save Regression llmProviders Results
+        run: mv eval-summary.json eval-summary-regression-llm-providers.json
+
+      - name: Log and Regression (llmProviders) Evals Performance
+        id: set-llm-providers-score
+        run: |
+          experimentNameRegressionLlmProviders=$(jq -r '.experimentName' eval-summary-regression-llm-providers.json)
+          regression_llm_providers_score=$(jq '.categories.regression_llm_providers' eval-summary-regression-llm-providers.json)
+          echo "regression_llm_providers category score: ${regression_llm_providers_score}%"
+          echo "View regression_llm_providers results: https://www.braintrust.dev/app/Browserbase/p/stagehand/experiments/${experimentNameRegressionLlmProviders}"
+          echo "regression_llm_providers_score=$regression_llm_providers_score" >> "$GITHUB_OUTPUT"
+
   run-regression-evals-dom-extract:
     needs:
       [run-e2e-bb-tests, run-e2e-tests, run-e2e-local-tests, determine-evals]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
     needs:
       [run-e2e-bb-tests, run-e2e-tests, run-e2e-local-tests, determine-evals]
     runs-on: ubuntu-latest
-    timeout-minutes: 7
+    timeout-minutes: 10
     outputs:
       regression_llm_providers_score: ${{ steps.set-llm-providers-score.outputs.regression_llm_providers_score }}
     env:

--- a/evals/args.ts
+++ b/evals/args.ts
@@ -63,6 +63,7 @@ const DEFAULT_EVAL_CATEGORIES = process.env.EVAL_CATEGORIES
       "experimental",
       "text_extract",
       "targeted_extract",
+      "llm_providers",
     ];
 
 // Finally, interpret leftover arguments to see if user typed "category X" or a single eval name

--- a/evals/args.ts
+++ b/evals/args.ts
@@ -63,7 +63,9 @@ const DEFAULT_EVAL_CATEGORIES = process.env.EVAL_CATEGORIES
       "experimental",
       "text_extract",
       "targeted_extract",
-      "llm_providers",
+      "regression_llm_providers",
+      "regression_text_extract",
+      "regression_dom_extract",
     ];
 
 // Finally, interpret leftover arguments to see if user typed "category X" or a single eval name

--- a/evals/evals.config.json
+++ b/evals/evals.config.json
@@ -87,15 +87,15 @@
     },
     {
       "name": "hn_aisdk",
-      "categories": ["combination", "regression_text_extract"]
+      "categories": ["regression_llm_providers"]
     },
     {
       "name": "hn_langchain",
-      "categories": ["combination", "regression_dom_extract"]
+      "categories": ["regression_llm_providers"]
     },
     {
       "name": "hn_customOpenAI",
-      "categories": ["combination", "regression_text_extract"]
+      "categories": ["regression_llm_providers"]
     },
     {
       "name": "apple",

--- a/evals/evals.config.json
+++ b/evals/evals.config.json
@@ -87,7 +87,7 @@
     },
     {
       "name": "hn_aisdk",
-      "categories": ["combination", "regression_dom_extract"]
+      "categories": ["combination", "regression_text_extract"]
     },
     {
       "name": "hn_langchain",
@@ -95,7 +95,7 @@
     },
     {
       "name": "hn_customOpenAI",
-      "categories": ["combination", "regression_dom_extract"]
+      "categories": ["combination", "regression_text_extract"]
     },
     {
       "name": "apple",

--- a/evals/evals.config.json
+++ b/evals/evals.config.json
@@ -94,6 +94,10 @@
       "categories": ["combination", "regression_dom_extract"]
     },
     {
+      "name": "hn_customOpenAI",
+      "categories": ["combination", "regression_dom_extract"]
+    },
+    {
       "name": "apple",
       "categories": ["experimental"]
     },

--- a/evals/tasks/hn_customOpenAI.ts
+++ b/evals/tasks/hn_customOpenAI.ts
@@ -1,0 +1,116 @@
+import { EvalFunction } from "@/types/evals";
+import { initStagehand } from "@/evals/initStagehand";
+import { z } from "zod";
+import { CustomOpenAIClient } from "@/examples/external_clients/customOpenAI";
+import OpenAI from "openai";
+
+export const hn_customOpenAI: EvalFunction = async ({ logger }) => {
+  const { stagehand, initResponse } = await initStagehand({
+    logger,
+    llmClient: new CustomOpenAIClient({
+      modelName: "gpt-4o-mini",
+      client: new OpenAI({
+        apiKey: process.env.OPENAI_API_KEY,
+      }),
+    }),
+  });
+
+  const { debugUrl, sessionUrl } = initResponse;
+
+  await stagehand.page.goto("https://news.ycombinator.com");
+
+  let { story } = await stagehand.page.extract({
+    schema: z.object({
+      story: z.string().describe("the title of the top story on the page"),
+    }),
+  });
+  // remove the (url) part of the story title
+  story = story.split(" (")[0];
+
+  const expectedStoryElement = await stagehand.page.$(
+    "xpath=/html/body/center/table/tbody/tr[3]/td/table/tbody/tr[1]/td[3]/span/a",
+  );
+  // remove the (url) part of the story title
+  const expectedStory = (await expectedStoryElement?.textContent())?.split(
+    " (",
+  )?.[0];
+
+  if (!expectedStory) {
+    logger.error({
+      message: "Could not find expected story element",
+      level: 0,
+    });
+    return {
+      _success: false,
+      error: "Could not find expected story element",
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
+  }
+
+  if (story !== expectedStory) {
+    logger.error({
+      message: "Extracted story does not match expected story",
+      level: 0,
+      auxiliary: {
+        expected: {
+          value: expectedStory,
+          type: "string",
+        },
+        actual: {
+          value: story,
+          type: "string",
+        },
+      },
+    });
+    return {
+      _success: false,
+      error: "Extracted story does not match expected story",
+      expectedStory,
+      actualStory: story,
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
+  }
+
+  await stagehand.page.act("Click on the 'new' tab");
+
+  if (stagehand.page.url() !== "https://news.ycombinator.com/newest") {
+    logger.error({
+      message: "Page did not navigate to the 'new' tab",
+      level: 0,
+      auxiliary: {
+        expected: {
+          value: "https://news.ycombinator.com/newest",
+          type: "string",
+        },
+        actual: {
+          value: stagehand.page.url(),
+          type: "string",
+        },
+      },
+    });
+    return {
+      _success: false,
+      error: "Page did not navigate to the 'new' tab",
+      expectedUrl: "https://news.ycombinator.com/newest",
+      actualUrl: stagehand.page.url(),
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
+  }
+
+  await stagehand.close();
+
+  return {
+    _success: true,
+    expectedStory,
+    actualStory: story,
+    debugUrl,
+    sessionUrl,
+    logs: logger.getLogs(),
+  };
+};

--- a/examples/actionable_observe_example.ts
+++ b/examples/actionable_observe_example.ts
@@ -59,7 +59,7 @@ async function example() {
     console.log("✅ Success! we made it to the correct page");
   } else {
     console.log(
-      "❌ Whoops, looks like we didnt make it to the correct page. " +
+      "❌ Whoops, looks like we didn't make it to the correct page. " +
         "\nThanks for testing out this new Stagehand feature!" +
         "\nReach us on Slack if you have any feedback/questions/suggestions!",
     );

--- a/examples/external_client.ts
+++ b/examples/external_client.ts
@@ -1,31 +1,34 @@
 import { Stagehand } from "@/dist";
 import { z } from "zod";
-import { OllamaClient } from "./external_clients/ollama";
+import { CustomOpenAIClient } from "./external_clients/customOpenAI";
 import StagehandConfig from "@/stagehand.config";
+import OpenAI from "openai";
 
 async function example() {
   const stagehand = new Stagehand({
     ...StagehandConfig,
-    llmClient: new OllamaClient({
-      modelName: "llama3.2",
+    llmClient: new CustomOpenAIClient({
+      modelName: "gpt-4o-mini",
+      client: new OpenAI({
+        apiKey: process.env.OPENAI_API_KEY,
+      }),
     }),
   });
 
   await stagehand.init();
   await stagehand.page.goto("https://news.ycombinator.com");
+  await stagehand.page.act("click on the 'new' link");
 
   const headlines = await stagehand.page.extract({
-    instruction: "Extract only 3 stories from the Hacker News homepage.",
+    instruction: "Extract the top 3 stories from the Hacker News homepage.",
     schema: z.object({
-      stories: z
-        .array(
-          z.object({
-            title: z.string(),
-            url: z.string(),
-            points: z.number(),
-          }),
-        )
-        .length(3),
+      stories: z.array(
+        z.object({
+          title: z.string(),
+          url: z.string(),
+          points: z.number(),
+        }),
+      ),
     }),
   });
 

--- a/examples/external_clients/customOpenAI.ts
+++ b/examples/external_clients/customOpenAI.ts
@@ -34,21 +34,7 @@ export class CustomOpenAIClient extends LLMClient {
   public type = "openai" as const;
   private client: OpenAI;
 
-  constructor({
-    modelName,
-    client,
-    enableCaching = false,
-  }: {
-    modelName?: string;
-    client?: OpenAI;
-    enableCaching?: boolean;
-  }) {
-    if (enableCaching) {
-      console.warn(
-        "Caching is not supported yet. Setting enableCaching to true will have no effect.",
-      );
-    }
-
+  constructor({ modelName, client }: { modelName: string; client: OpenAI }) {
     super(modelName as AvailableModel);
     this.client = client;
     this.modelName = modelName as AvailableModel;

--- a/examples/external_clients/customOpenAI.ts
+++ b/examples/external_clients/customOpenAI.ts
@@ -1,19 +1,12 @@
 /**
- * Welcome to the Stagehand Ollama client!
+ * Welcome to the Stagehand custom OpenAI client!
  *
- * This is a client for the Ollama API. It is a wrapper around the OpenAI API
- * that allows you to create chat completions with Ollama.
- *
- * To use this client, you need to have an Ollama instance running. You can
- * start an Ollama instance by running the following command:
- *
- * ```bash
- * ollama run llama3.2
- * ```
+ * This is a client for models that are compatible with the OpenAI API, like Ollama, Gemini, etc.
+ * You can just pass in an OpenAI instance to the client and it will work.
  */
 
 import { AvailableModel, CreateChatCompletionOptions, LLMClient } from "@/dist";
-import OpenAI, { type ClientOptions } from "openai";
+import OpenAI from "openai";
 import { zodResponseFormat } from "openai/helpers/zod";
 import type {
   ChatCompletion,
@@ -37,17 +30,17 @@ function validateZodSchema(schema: z.ZodTypeAny, data: unknown) {
   }
 }
 
-export class OllamaClient extends LLMClient {
-  public type = "ollama" as const;
+export class CustomOpenAIClient extends LLMClient {
+  public type = "openai" as const;
   private client: OpenAI;
 
   constructor({
-    modelName = "llama3.2",
-    clientOptions,
+    modelName,
+    client,
     enableCaching = false,
   }: {
     modelName?: string;
-    clientOptions?: ClientOptions;
+    client?: OpenAI;
     enableCaching?: boolean;
   }) {
     if (enableCaching) {
@@ -57,11 +50,7 @@ export class OllamaClient extends LLMClient {
     }
 
     super(modelName as AvailableModel);
-    this.client = new OpenAI({
-      ...clientOptions,
-      baseURL: clientOptions?.baseURL || "http://localhost:11434/v1",
-      apiKey: "ollama",
-    });
+    this.client = client;
     this.modelName = modelName as AvailableModel;
   }
 
@@ -75,12 +64,12 @@ export class OllamaClient extends LLMClient {
     // TODO: Implement vision support
     if (image) {
       console.warn(
-        "Image provided. Vision is not currently supported for Ollama",
+        "Image provided. Vision is not currently supported for openai",
       );
     }
 
     logger({
-      category: "ollama",
+      category: "openai",
       message: "creating chat completion",
       level: 1,
       auxiliary: {
@@ -100,7 +89,7 @@ export class OllamaClient extends LLMClient {
 
     if (options.image) {
       console.warn(
-        "Image provided. Vision is not currently supported for Ollama",
+        "Image provided. Vision is not currently supported for openai",
       );
     }
 
@@ -114,18 +103,18 @@ export class OllamaClient extends LLMClient {
 
     /* eslint-disable */
     // Remove unsupported options
-    const { response_model, ...ollamaOptions } = {
+    const { response_model, ...openaiOptions } = {
       ...optionsWithoutImageAndRequestId,
       model: this.modelName,
     };
 
     logger({
-      category: "ollama",
+      category: "openai",
       message: "creating chat completion",
       level: 1,
       auxiliary: {
-        ollamaOptions: {
-          value: JSON.stringify(ollamaOptions),
+        openaiOptions: {
+          value: JSON.stringify(openaiOptions),
           type: "object",
         },
       },
@@ -191,7 +180,7 @@ export class OllamaClient extends LLMClient {
       });
 
     const body: ChatCompletionCreateParamsNonStreaming = {
-      ...ollamaOptions,
+      ...openaiOptions,
       model: this.modelName,
       messages: formattedMessages,
       response_format: responseFormat,
@@ -209,7 +198,7 @@ export class OllamaClient extends LLMClient {
     const response = await this.client.chat.completions.create(body);
 
     logger({
-      category: "ollama",
+      category: "openai",
       message: "response",
       level: 1,
       auxiliary: {
@@ -243,9 +232,23 @@ export class OllamaClient extends LLMClient {
         throw new CreateChatCompletionResponseError("Invalid response schema");
       }
 
-      return parsedData;
+      return {
+        data: parsedData,
+        usage: {
+          prompt_tokens: response.usage?.prompt_tokens ?? 0,
+          completion_tokens: response.usage?.completion_tokens ?? 0,
+          total_tokens: response.usage?.total_tokens ?? 0,
+        },
+      } as T;
     }
 
-    return response as T;
+    return {
+      data: response.choices[0].message.content,
+      usage: {
+        prompt_tokens: response.usage?.prompt_tokens ?? 0,
+        completion_tokens: response.usage?.completion_tokens ?? 0,
+        total_tokens: response.usage?.total_tokens ?? 0,
+      },
+    } as T;
   }
 }

--- a/types/evals.ts
+++ b/types/evals.ts
@@ -27,6 +27,7 @@ export const EvalCategorySchema = z.enum([
   "targeted_extract",
   "regression_text_extract",
   "regression_dom_extract",
+  "regression_llm_providers",
 ]);
 
 export type EvalCategory = z.infer<typeof EvalCategorySchema>;


### PR DESCRIPTION
# why
Sometimes you want to wrap the entire OpenAI object, like with Braintrust or LiteLLM

# what changed
Add support for passing in an OpenAI object as an `llmClient` like so:

```
import { CustomOpenAIClient } from "./external_clients/customOpenAI";

const stagehand = new Stagehand({
    ...StagehandConfig,
    llmClient: new CustomOpenAIClient({
      modelName: "llama3.3",
      client: new OpenAI({
        apiKey: "ollama",
        baseUrl: "http://localhost:11434"
      }),
    }),
  });
```

# test plan
Add `hn_customOpenAI` eval
