### PR TITLE
give act its own inference call

### DIFF
--- a/.changeset/cold-rocks-tell.md
+++ b/.changeset/cold-rocks-tell.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+give act its own inference call

--- a/evals/tasks/hn_customOpenAI.ts
+++ b/evals/tasks/hn_customOpenAI.ts
@@ -8,7 +8,7 @@ export const hn_customOpenAI: EvalFunction = async ({ logger }) => {
   const { stagehand, initResponse } = await initStagehand({
     logger,
     llmClient: new CustomOpenAIClient({
-      modelName: "gpt-4o-mini",
+      modelName: "gpt-4o",
       client: new OpenAI({
         apiKey: process.env.OPENAI_API_KEY,
       }),

--- a/evals/tasks/hn_customOpenAI.ts
+++ b/evals/tasks/hn_customOpenAI.ts
@@ -8,7 +8,7 @@ export const hn_customOpenAI: EvalFunction = async ({ logger }) => {
   const { stagehand, initResponse } = await initStagehand({
     logger,
     llmClient: new CustomOpenAIClient({
-      modelName: "gpt-4o",
+      modelName: "gpt-4o-mini",
       client: new OpenAI({
         apiKey: process.env.OPENAI_API_KEY,
       }),

--- a/evals/tasks/hn_langchain.ts
+++ b/evals/tasks/hn_langchain.ts
@@ -9,7 +9,7 @@ export const hn_langchain: EvalFunction = async ({ logger }) => {
     logger,
     llmClient: new LangchainClient(
       new ChatOpenAI({
-        model: "gpt-4o",
+        model: "gpt-4o-mini",
       }),
     ),
   });

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -105,9 +105,11 @@ export class StagehandPage {
 
     if (this.llmClient) {
       this.actHandler = new StagehandActHandler({
+        stagehand: this.stagehand,
         logger: this.stagehand.logger,
         stagehandPage: this,
         selfHeal: this.stagehand.selfHeal,
+        userProvidedInstructions,
       });
       this.extractHandler = new StagehandExtractHandler({
         stagehand: this.stagehand,
@@ -548,9 +550,8 @@ export class StagehandPage {
         },
       });
 
-      const result = await this.actHandler.observeAct(
+      const result = await this.actHandler.act(
         actionOrOptions,
-        this.observeHandler,
         llmClient,
         requestId,
       );

--- a/lib/handlers/actHandler.ts
+++ b/lib/handlers/actHandler.ts
@@ -317,6 +317,14 @@ export class StagehandActHandler {
         arguments: targetElement.arguments,
       };
 
+      if (actionOrOptions.variables) {
+        Object.keys(actionOrOptions.variables).forEach((key) => {
+          observeResult.arguments = observeResult.arguments.map((arg) =>
+            arg.replace(`%${key}%`, actionOrOptions.variables![key]),
+          );
+        });
+      }
+
       return this.actFromObserveResult(
         observeResult,
         actionOrOptions.domSettleTimeoutMs,

--- a/lib/inference.ts
+++ b/lib/inference.ts
@@ -529,7 +529,9 @@ export async function actInference({
         z
           .string()
           .describe(
-            "the arguments to pass to the method. For example, for a click, the arguments are empty, but for a fill, the arguments are the value to fill in.",
+            "the arguments to pass to the method. For example, for a click, the arguments are empty, but for a fill, the arguments are the value to fill in. " +
+              "If a users instruction contains strings wrapped % (percentage) symbols (eg, %username%), ensure that you include these strings as arguments, keeping them wrapped in " +
+              "% symbols for further processing. ",
           ),
       ),
     }),

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -188,9 +188,9 @@ ${isUsingAccessibilityTree ? "Accessibility Tree" : "DOM"}: ${domElements}`,
 }
 
 /**
- * Builds the instruction for the observeAct method to find the most relevant element for an action
+ * Builds the instruction for the act method to find the most relevant element for an action
  */
-export function buildActObservePrompt(
+export function buildActPrompt(
   action: string,
   supportedActions: string[],
   variables?: Record<string, string>,
@@ -230,5 +230,39 @@ ${goal}
    - Select a single option
 3. Avoid combining multiple actions in one instruction
 4. If multiple actions are needed, they should be separate steps`,
+  };
+}
+
+export function buildActSystemPrompt(
+  userProvidedInstructions?: string,
+): ChatMessage {
+  const actSystemPrompt = `
+You are helping the user automate the browser by finding elements based an action that the user wants to take on the page.
+
+You will be given:
+1. a instruction of elements to observe
+2. a hierarchical accessibility tree showing the semantic structure of the page. The tree is a hybrid of the DOM and the accessibility tree.
+
+Return an array of elements that match the instruction if they exist, otherwise return an empty array.`;
+
+  return {
+    role: "system",
+    content: [
+      actSystemPrompt,
+      buildUserInstructionsString(userProvidedInstructions),
+    ]
+      .filter(Boolean)
+      .join("\n\n"),
+  };
+}
+
+export function buildActUserMessage(
+  instruction: string,
+  domElements: string,
+): ChatMessage {
+  return {
+    role: "user",
+    content: `instruction: ${instruction}\n
+Accessibility Tree: ${domElements}`,
   };
 }

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -237,7 +237,7 @@ export function buildActSystemPrompt(
   userProvidedInstructions?: string,
 ): ChatMessage {
   const actSystemPrompt = `
-You are helping the user automate the browser by finding elements based an action that the user wants to take on the page.
+You are helping the user automate the browser by finding elements based on an action that the user wants to take on the page.
 
 You will be given:
 1. a instruction of elements to observe


### PR DESCRIPTION
# why
- we are calling `observeHandler` inside `actHandler`. This means that the downstream inference call is just an observe inference call. 
- this means that when someone calls `act`, the token metrics are just being added to `observe` token metrics instead of `act`
- it also makes the code confusing
# what changed
- gave `act` its own inference call
# test plan
- evals

# notes
- updated the act schema description (which is given to the LLM) so that it knows the pattern we expect to handle for variable parsing