### PR TITLE
use gh pages for static eval sites

### DIFF
--- a/evals/tasks/extract_aigrant_companies.ts
+++ b/evals/tasks/extract_aigrant_companies.ts
@@ -15,7 +15,9 @@ export const extract_aigrant_companies: EvalFunction = async ({
 
   const { debugUrl, sessionUrl } = initResponse;
 
-  await stagehand.page.goto("https://aigrant.com/");
+  await stagehand.page.goto(
+    "https://seanmcguire12.github.io/stagehand-eval-sites/sites/aigrant/",
+  );
   const companyList = await stagehand.page.extract({
     instruction:
       "Extract all companies that received the AI grant and group them with their batch numbers as an array of objects. Each object should contain the company name and its corresponding batch number.",

--- a/evals/tasks/extract_aigrant_companies.ts
+++ b/evals/tasks/extract_aigrant_companies.ts
@@ -16,7 +16,7 @@ export const extract_aigrant_companies: EvalFunction = async ({
   const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(
-    "https://seanmcguire12.github.io/stagehand-eval-sites/sites/aigrant/",
+    "https://browserbase.github.io/stagehand-eval-sites/sites/aigrant/",
   );
   const companyList = await stagehand.page.extract({
     instruction:

--- a/evals/tasks/extract_aigrant_targeted.ts
+++ b/evals/tasks/extract_aigrant_targeted.ts
@@ -15,7 +15,9 @@ export const extract_aigrant_targeted: EvalFunction = async ({
 
   const { debugUrl, sessionUrl } = initResponse;
 
-  await stagehand.page.goto("https://aigrant.com/");
+  await stagehand.page.goto(
+    "https://seanmcguire12.github.io/stagehand-eval-sites/sites/aigrant/",
+  );
   const selector = "/html/body/div/ul[5]/li[28]";
   const company = await stagehand.page.extract({
     instruction: "Extract the company name.",

--- a/evals/tasks/extract_aigrant_targeted.ts
+++ b/evals/tasks/extract_aigrant_targeted.ts
@@ -16,7 +16,7 @@ export const extract_aigrant_targeted: EvalFunction = async ({
   const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(
-    "https://seanmcguire12.github.io/stagehand-eval-sites/sites/aigrant/",
+    "https://browserbase.github.io/stagehand-eval-sites/sites/aigrant/",
   );
   const selector = "/html/body/div/ul[5]/li[28]";
   const company = await stagehand.page.extract({

--- a/evals/tasks/extract_aigrant_targeted_2.ts
+++ b/evals/tasks/extract_aigrant_targeted_2.ts
@@ -15,7 +15,9 @@ export const extract_aigrant_targeted_2: EvalFunction = async ({
 
   const { debugUrl, sessionUrl } = initResponse;
 
-  await stagehand.page.goto("https://aigrant.com/");
+  await stagehand.page.goto(
+    "https://seanmcguire12.github.io/stagehand-eval-sites/sites/aigrant/",
+  );
   const selector = "/html/body/div/ul[5]/li[28]";
   const company = await stagehand.page.extract({
     instruction: "Extract the name of the company that comes after 'Coframe'.",

--- a/evals/tasks/extract_aigrant_targeted_2.ts
+++ b/evals/tasks/extract_aigrant_targeted_2.ts
@@ -16,7 +16,7 @@ export const extract_aigrant_targeted_2: EvalFunction = async ({
   const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(
-    "https://seanmcguire12.github.io/stagehand-eval-sites/sites/aigrant/",
+    "https://browserbase.github.io/stagehand-eval-sites/sites/aigrant/",
   );
   const selector = "/html/body/div/ul[5]/li[28]";
   const company = await stagehand.page.extract({

--- a/evals/tasks/extract_area_codes.ts
+++ b/evals/tasks/extract_area_codes.ts
@@ -16,7 +16,7 @@ export const extract_area_codes: EvalFunction = async ({
 
   await stagehand.init();
   await stagehand.page.goto(
-    "https://ncc-area-codes-clone.surge.sh/operators/",
+    "https://seanmcguire12.github.io/stagehand-eval-sites/sites/ncc-area-codes/www.ncc.gov.ng/operators/",
     { waitUntil: "domcontentloaded" },
   );
 

--- a/evals/tasks/extract_area_codes.ts
+++ b/evals/tasks/extract_area_codes.ts
@@ -16,7 +16,7 @@ export const extract_area_codes: EvalFunction = async ({
 
   await stagehand.init();
   await stagehand.page.goto(
-    "https://seanmcguire12.github.io/stagehand-eval-sites/sites/ncc-area-codes/www.ncc.gov.ng/operators/",
+    "https://browserbase.github.io/stagehand-eval-sites/sites/ncc-area-codes/www.ncc.gov.ng/operators/",
     { waitUntil: "domcontentloaded" },
   );
 

--- a/evals/tasks/extract_area_codes.ts
+++ b/evals/tasks/extract_area_codes.ts
@@ -16,7 +16,7 @@ export const extract_area_codes: EvalFunction = async ({
 
   await stagehand.init();
   await stagehand.page.goto(
-    "https://browserbase.github.io/stagehand-eval-sites/sites/ncc-area-codes/www.ncc.gov.ng/operators/",
+    "https://browserbase.github.io/stagehand-eval-sites/sites/ncc-area-codes/",
     { waitUntil: "domcontentloaded" },
   );
 

--- a/evals/tasks/extract_baptist_health.ts
+++ b/evals/tasks/extract_baptist_health.ts
@@ -16,7 +16,7 @@ export const extract_baptist_health: EvalFunction = async ({
   const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(
-    "https://www.baptistfirst.org/location/baptist-health-ent-partners",
+    "https://browserbase.github.io/stagehand-eval-sites/sites/baptist-health/",
   );
 
   const result = await stagehand.page.extract({

--- a/evals/tasks/extract_capacitor_info.ts
+++ b/evals/tasks/extract_capacitor_info.ts
@@ -16,7 +16,7 @@ export const extract_capacitor_info: EvalFunction = async ({
   const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(
-    "https://www.jakelectronics.com/productdetail/panasonicelectroniccomponents-eeufm1a472l-2937406",
+    "https://browserbase.github.io/stagehand-eval-sites/sites/capacitor/",
   );
 
   const result = await stagehand.page.extract({

--- a/evals/tasks/extract_csa.ts
+++ b/evals/tasks/extract_csa.ts
@@ -16,7 +16,7 @@ export const extract_csa: EvalFunction = async ({
 
   const { page } = stagehand;
   await page.goto(
-    "https://clerk.assembly.ca.gov/weekly-histories?from_date=&to_date=2025-01-09",
+    "https://browserbase.github.io/stagehand-eval-sites/sites/csa/",
   );
 
   const result = await page.extract({

--- a/evals/tasks/extract_geniusee.ts
+++ b/evals/tasks/extract_geniusee.ts
@@ -16,7 +16,7 @@ export const extract_geniusee: EvalFunction = async ({
   const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(
-    "https://browserbase.github.io/stagehand-eval-sites/sites/geniusee/geniusee.com/single-blog/",
+    "https://browserbase.github.io/stagehand-eval-sites/sites/geniusee/",
   );
   const selector = "/html/body/main/div[2]/div[2]/div[2]/table";
   const scalability = await stagehand.page.extract({

--- a/evals/tasks/extract_geniusee.ts
+++ b/evals/tasks/extract_geniusee.ts
@@ -16,7 +16,7 @@ export const extract_geniusee: EvalFunction = async ({
   const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(
-    "https://seanmcguire12.github.io/stagehand-eval-sites/sites/geniusee/geniusee.com/single-blog/",
+    "https://browserbase.github.io/stagehand-eval-sites/sites/geniusee/geniusee.com/single-blog/",
   );
   const selector = "/html/body/main/div[2]/div[2]/div[2]/table";
   const scalability = await stagehand.page.extract({

--- a/evals/tasks/extract_geniusee.ts
+++ b/evals/tasks/extract_geniusee.ts
@@ -15,7 +15,9 @@ export const extract_geniusee: EvalFunction = async ({
 
   const { debugUrl, sessionUrl } = initResponse;
 
-  await stagehand.page.goto("https://geniusee-blog.surge.sh/single-blog/");
+  await stagehand.page.goto(
+    "https://seanmcguire12.github.io/stagehand-eval-sites/sites/geniusee/geniusee.com/single-blog/",
+  );
   const selector = "/html/body/main/div[2]/div[2]/div[2]/table";
   const scalability = await stagehand.page.extract({
     instruction:

--- a/evals/tasks/extract_geniusee_2.ts
+++ b/evals/tasks/extract_geniusee_2.ts
@@ -15,7 +15,9 @@ export const extract_geniusee_2: EvalFunction = async ({
 
   const { debugUrl, sessionUrl } = initResponse;
 
-  await stagehand.page.goto("https://geniusee-blog.surge.sh/single-blog/");
+  await stagehand.page.goto(
+    "https://seanmcguire12.github.io/stagehand-eval-sites/sites/geniusee/geniusee.com/single-blog/",
+  );
   const selector = "/html/body/main/div[2]/div[2]/div[2]/table/tbody/tr[9]";
   const scalability = await stagehand.page.extract({
     instruction:

--- a/evals/tasks/extract_geniusee_2.ts
+++ b/evals/tasks/extract_geniusee_2.ts
@@ -16,7 +16,7 @@ export const extract_geniusee_2: EvalFunction = async ({
   const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(
-    "https://browserbase.github.io/stagehand-eval-sites/sites/geniusee/geniusee.com/single-blog/",
+    "https://browserbase.github.io/stagehand-eval-sites/sites/geniusee/",
   );
   const selector = "/html/body/main/div[2]/div[2]/div[2]/table/tbody/tr[9]";
   const scalability = await stagehand.page.extract({

--- a/evals/tasks/extract_geniusee_2.ts
+++ b/evals/tasks/extract_geniusee_2.ts
@@ -16,7 +16,7 @@ export const extract_geniusee_2: EvalFunction = async ({
   const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(
-    "https://seanmcguire12.github.io/stagehand-eval-sites/sites/geniusee/geniusee.com/single-blog/",
+    "https://browserbase.github.io/stagehand-eval-sites/sites/geniusee/geniusee.com/single-blog/",
   );
   const selector = "/html/body/main/div[2]/div[2]/div[2]/table/tbody/tr[9]";
   const scalability = await stagehand.page.extract({

--- a/evals/tasks/extract_hamilton_weather.ts
+++ b/evals/tasks/extract_hamilton_weather.ts
@@ -16,7 +16,7 @@ export const extract_hamilton_weather: EvalFunction = async ({
 
   try {
     await stagehand.page.goto(
-      "https://seanmcguire12.github.io/stagehand-eval-sites/sites/hamilton-weather/",
+      "https://browserbase.github.io/stagehand-eval-sites/sites/hamilton-weather/",
     );
     const xpath =
       "/html/body[1]/div[5]/main[1]/article[1]/div[6]/div[2]/div[1]/table[1]";

--- a/evals/tasks/extract_hamilton_weather.ts
+++ b/evals/tasks/extract_hamilton_weather.ts
@@ -15,7 +15,9 @@ export const extract_hamilton_weather: EvalFunction = async ({
   const { debugUrl, sessionUrl } = initResponse;
 
   try {
-    await stagehand.page.goto("https://hamilton-weather.surge.sh/");
+    await stagehand.page.goto(
+      "https://seanmcguire12.github.io/stagehand-eval-sites/sites/hamilton-weather/",
+    );
     const xpath =
       "/html/body[1]/div[5]/main[1]/article[1]/div[6]/div[2]/div[1]/table[1]";
 

--- a/evals/tasks/extract_jstor_news.ts
+++ b/evals/tasks/extract_jstor_news.ts
@@ -16,7 +16,7 @@ export const extract_jstor_news: EvalFunction = async ({
 
   await stagehand.init();
   await stagehand.page.goto(
-    "https://seanmcguire12.github.io/stagehand-eval-sites/sites/jstor/",
+    "https://browserbase.github.io/stagehand-eval-sites/sites/jstor/",
     {
       waitUntil: "load",
     },

--- a/evals/tasks/extract_jstor_news.ts
+++ b/evals/tasks/extract_jstor_news.ts
@@ -15,9 +15,12 @@ export const extract_jstor_news: EvalFunction = async ({
   const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.init();
-  await stagehand.page.goto("http://jstor-eval.surge.sh", {
-    waitUntil: "load",
-  });
+  await stagehand.page.goto(
+    "https://seanmcguire12.github.io/stagehand-eval-sites/sites/jstor/",
+    {
+      waitUntil: "load",
+    },
+  );
   await stagehand.page.act({ action: "close the cookie" });
 
   const result = await stagehand.page.extract({

--- a/evals/tasks/extract_memorial_healthcare.ts
+++ b/evals/tasks/extract_memorial_healthcare.ts
@@ -16,7 +16,9 @@ export const extract_memorial_healthcare: EvalFunction = async ({
 
   const { debugUrl, sessionUrl } = initResponse;
 
-  await stagehand.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/mycmh/");
+  await stagehand.page.goto(
+    "https://browserbase.github.io/stagehand-eval-sites/sites/mycmh/",
+  );
 
   const result = await stagehand.page.extract({
     instruction:

--- a/evals/tasks/extract_memorial_healthcare.ts
+++ b/evals/tasks/extract_memorial_healthcare.ts
@@ -16,7 +16,7 @@ export const extract_memorial_healthcare: EvalFunction = async ({
 
   const { debugUrl, sessionUrl } = initResponse;
 
-  await stagehand.page.goto("https://www.mycmh.org/locations/");
+  await stagehand.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/mycmh/");
 
   const result = await stagehand.page.extract({
     instruction:

--- a/evals/tasks/extract_press_releases.ts
+++ b/evals/tasks/extract_press_releases.ts
@@ -31,7 +31,7 @@ export const extract_press_releases: EvalFunction = async ({
 
   try {
     await stagehand.page.goto(
-      "https://seanmcguire12.github.io/stagehand-eval-sites/sites/press-releases/",
+      "https://browserbase.github.io/stagehand-eval-sites/sites/press-releases/",
       {
         waitUntil: "networkidle",
       },

--- a/evals/tasks/extract_press_releases.ts
+++ b/evals/tasks/extract_press_releases.ts
@@ -30,9 +30,12 @@ export const extract_press_releases: EvalFunction = async ({
   type PressRelease = z.infer<typeof schema>["items"][number];
 
   try {
-    await stagehand.page.goto("https://dummy-press-releases.surge.sh/news", {
-      waitUntil: "networkidle",
-    });
+    await stagehand.page.goto(
+      "https://seanmcguire12.github.io/stagehand-eval-sites/sites/press-releases/",
+      {
+        waitUntil: "networkidle",
+      },
+    );
     await new Promise((resolve) => setTimeout(resolve, 5000));
 
     const rawResult = await stagehand.page.extract({

--- a/evals/tasks/extract_professional_info.ts
+++ b/evals/tasks/extract_professional_info.ts
@@ -16,7 +16,7 @@ export const extract_professional_info: EvalFunction = async ({
   const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(
-    "https://www.paulweiss.com/professionals/partners-and-counsel/brian-bolin",
+    "https://browserbase.github.io/stagehand-eval-sites/sites/professional-info/",
   );
 
   const result = await stagehand.page.extract({

--- a/evals/tasks/extract_public_notices.ts
+++ b/evals/tasks/extract_public_notices.ts
@@ -17,7 +17,7 @@ export const extract_public_notices: EvalFunction = async ({
 
   await stagehand.init();
   await stagehand.page.goto(
-    "https://www.sars.gov.za/legal-counsel/secondary-legislation/public-notices/",
+    "https://browserbase.github.io/stagehand-eval-sites/sites/sars/",
     { waitUntil: "load" },
   );
 

--- a/evals/tasks/extract_recipe.ts
+++ b/evals/tasks/extract_recipe.ts
@@ -15,7 +15,7 @@ export const extract_recipe: EvalFunction = async ({
   const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(
-    "https://www.allrecipes.com/recipe/8539032/perfect-pan-seared-filet-mignon/",
+    "https://browserbase.github.io/stagehand-eval-sites/sites/allrecipes-extract/",
     {
       waitUntil: "domcontentloaded",
     },

--- a/evals/tasks/extract_regulations_table.ts
+++ b/evals/tasks/extract_regulations_table.ts
@@ -16,7 +16,7 @@ export const extract_regulations_table: EvalFunction = async ({
 
   try {
     await stagehand.page.goto(
-      "https://ncc-numberingplan-shortened.surge.sh/operators/",
+      "https://seanmcguire12.github.io/stagehand-eval-sites/sites/ncc-numbering-plan/www.ncc.gov.ng/operators/",
     );
 
     const xpath =

--- a/evals/tasks/extract_regulations_table.ts
+++ b/evals/tasks/extract_regulations_table.ts
@@ -20,7 +20,7 @@ export const extract_regulations_table: EvalFunction = async ({
     );
 
     const xpath =
-      "/html/body/div[3]/main/div[2]/div[2]/div/div/div[2]/article/div[2]/div[1]/table";
+      "/html/body/div[3]/main/div[2]/div[2]/div/div/div[2]/article/div[2]/div[1]/div/table";
 
     const allottees = await stagehand.page.extract({
       instruction:

--- a/evals/tasks/extract_regulations_table.ts
+++ b/evals/tasks/extract_regulations_table.ts
@@ -16,7 +16,7 @@ export const extract_regulations_table: EvalFunction = async ({
 
   try {
     await stagehand.page.goto(
-      "https://browserbase.github.io/stagehand-eval-sites/sites/ncc-numbering-plan/www.ncc.gov.ng/operators/",
+      "https://browserbase.github.io/stagehand-eval-sites/sites/ncc-numbering-plan/",
     );
 
     const xpath =

--- a/evals/tasks/extract_regulations_table.ts
+++ b/evals/tasks/extract_regulations_table.ts
@@ -16,7 +16,7 @@ export const extract_regulations_table: EvalFunction = async ({
 
   try {
     await stagehand.page.goto(
-      "https://seanmcguire12.github.io/stagehand-eval-sites/sites/ncc-numbering-plan/www.ncc.gov.ng/operators/",
+      "https://browserbase.github.io/stagehand-eval-sites/sites/ncc-numbering-plan/www.ncc.gov.ng/operators/",
     );
 
     const xpath =

--- a/evals/tasks/extract_resistor_info.ts
+++ b/evals/tasks/extract_resistor_info.ts
@@ -16,7 +16,7 @@ export const extract_resistor_info: EvalFunction = async ({
   const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(
-    "https://browserbase.github.io/stagehand-eval-sites/sites/resistor/www.vniva.com/vniva/",
+    "https://browserbase.github.io/stagehand-eval-sites/sites/resistor/",
   );
 
   const result = await stagehand.page.extract({

--- a/evals/tasks/extract_resistor_info.ts
+++ b/evals/tasks/extract_resistor_info.ts
@@ -16,7 +16,7 @@ export const extract_resistor_info: EvalFunction = async ({
   const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(
-    "https://seanmcguire12.github.io/stagehand-eval-sites/sites/resistor/www.vniva.com/vniva/",
+    "https://browserbase.github.io/stagehand-eval-sites/sites/resistor/www.vniva.com/vniva/",
   );
 
   const result = await stagehand.page.extract({

--- a/evals/tasks/extract_resistor_info.ts
+++ b/evals/tasks/extract_resistor_info.ts
@@ -15,7 +15,9 @@ export const extract_resistor_info: EvalFunction = async ({
 
   const { debugUrl, sessionUrl } = initResponse;
 
-  await stagehand.page.goto("https://vniva-3.surge.sh/vniva/");
+  await stagehand.page.goto(
+    "https://seanmcguire12.github.io/stagehand-eval-sites/sites/resistor/www.vniva.com/vniva/",
+  );
 
   const result = await stagehand.page.extract({
     instruction:

--- a/evals/tasks/extract_rockauto.ts
+++ b/evals/tasks/extract_rockauto.ts
@@ -63,7 +63,13 @@ export const extract_rockauto: EvalFunction = async ({
       sessionUrl,
     };
   }
-  const expectedPartNumbers = ["GREEN5050GAL", "719009", "AF3300", "MV5050GAL"];
+  const expectedPartNumbers = [
+    "GREEN5050GAL",
+    "719009",
+    "AF3300",
+    "AF3100",
+    "MV5050GAL",
+  ];
 
   const missingParts = expectedPartNumbers.filter(
     (expectedPart) =>

--- a/evals/tasks/extract_rockauto.ts
+++ b/evals/tasks/extract_rockauto.ts
@@ -16,7 +16,7 @@ export const extract_rockauto: EvalFunction = async ({
   const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(
-    "https://www.rockauto.com/en/catalog/alpine,1974,a310,1.6l+l4,1436055,cooling+system,coolant+/+antifreeze,11393",
+    "https://browserbase.github.io/stagehand-eval-sites/sites/rockauto/",
   );
   await new Promise((resolve) => setTimeout(resolve, 5000));
   const result = await stagehand.page.extract({

--- a/evals/tasks/extract_rockauto.ts
+++ b/evals/tasks/extract_rockauto.ts
@@ -38,7 +38,14 @@ export const extract_rockauto: EvalFunction = async ({
   await stagehand.close();
 
   const coolantProducts = result.coolant_products;
-  const expectedLength = 4;
+  const expectedPartNumbers = [
+    "GREEN5050GAL",
+    "719009",
+    "AF3300",
+    "AF3100",
+    "MV5050GAL",
+  ];
+  const expectedLength = expectedPartNumbers.length;
 
   if (coolantProducts.length !== expectedLength) {
     logger.error({
@@ -63,13 +70,6 @@ export const extract_rockauto: EvalFunction = async ({
       sessionUrl,
     };
   }
-  const expectedPartNumbers = [
-    "GREEN5050GAL",
-    "719009",
-    "AF3300",
-    "AF3100",
-    "MV5050GAL",
-  ];
 
   const missingParts = expectedPartNumbers.filter(
     (expectedPart) =>

--- a/evals/tasks/extract_staff_members.ts
+++ b/evals/tasks/extract_staff_members.ts
@@ -37,7 +37,7 @@ export const extract_staff_members: EvalFunction = async ({
   const staff_members = result.staff_members;
   await stagehand.close();
 
-  const expectedLength = 49;
+  const expectedLength = 50;
 
   const expectedFirstItem = {
     name: "Louis Alvarez",

--- a/evals/tasks/extract_staff_members.ts
+++ b/evals/tasks/extract_staff_members.ts
@@ -16,7 +16,7 @@ export const extract_staff_members: EvalFunction = async ({
   const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(
-    "https://seanmcguire12.github.io/stagehand-eval-sites/sites/panamcs/",
+    "https://browserbase.github.io/stagehand-eval-sites/sites/panamcs/",
   );
 
   const result = await stagehand.page.extract({

--- a/evals/tasks/extract_staff_members.ts
+++ b/evals/tasks/extract_staff_members.ts
@@ -15,7 +15,9 @@ export const extract_staff_members: EvalFunction = async ({
 
   const { debugUrl, sessionUrl } = initResponse;
 
-  await stagehand.page.goto("https://panamcs-static-site.surge.sh/");
+  await stagehand.page.goto(
+    "https://seanmcguire12.github.io/stagehand-eval-sites/sites/panamcs/",
+  );
 
   const result = await stagehand.page.extract({
     instruction:

--- a/evals/tasks/extract_zillow.ts
+++ b/evals/tasks/extract_zillow.ts
@@ -15,7 +15,9 @@ export const extract_zillow: EvalFunction = async ({
 
   const { debugUrl, sessionUrl } = initResponse;
 
-  await stagehand.page.goto("https://zillow-eval.surge.sh/");
+  await stagehand.page.goto(
+    "https://seanmcguire12.github.io/stagehand-eval-sites/sites/zillow/",
+  );
   // timeout for 5 seconds
   await stagehand.page.waitForTimeout(5000);
   const real_estate_listings = await stagehand.page.extract({

--- a/evals/tasks/extract_zillow.ts
+++ b/evals/tasks/extract_zillow.ts
@@ -16,7 +16,7 @@ export const extract_zillow: EvalFunction = async ({
   const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(
-    "https://seanmcguire12.github.io/stagehand-eval-sites/sites/zillow/",
+    "https://browserbase.github.io/stagehand-eval-sites/sites/zillow/",
   );
   // timeout for 5 seconds
   await stagehand.page.waitForTimeout(5000);

--- a/evals/tasks/hn_aisdk.ts
+++ b/evals/tasks/hn_aisdk.ts
@@ -14,7 +14,9 @@ export const hn_aisdk: EvalFunction = async ({ logger }) => {
 
   const { debugUrl, sessionUrl } = initResponse;
 
-  await stagehand.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/hackernews/");
+  await stagehand.page.goto(
+    "https://browserbase.github.io/stagehand-eval-sites/sites/hackernews/",
+  );
 
   let { story } = await stagehand.page.extract({
     instruction: "extract the title of the top story on the page",

--- a/evals/tasks/hn_aisdk.ts
+++ b/evals/tasks/hn_aisdk.ts
@@ -14,7 +14,7 @@ export const hn_aisdk: EvalFunction = async ({ logger }) => {
 
   const { debugUrl, sessionUrl } = initResponse;
 
-  await stagehand.page.goto("https://news.ycombinator.com");
+  await stagehand.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/hackernews/");
 
   let { story } = await stagehand.page.extract({
     instruction: "extract the title of the top story on the page",

--- a/evals/tasks/hn_customOpenAI.ts
+++ b/evals/tasks/hn_customOpenAI.ts
@@ -17,7 +17,9 @@ export const hn_customOpenAI: EvalFunction = async ({ logger }) => {
 
   const { debugUrl, sessionUrl } = initResponse;
 
-  await stagehand.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/hackernews/");
+  await stagehand.page.goto(
+    "https://browserbase.github.io/stagehand-eval-sites/sites/hackernews/",
+  );
 
   let { story } = await stagehand.page.extract({
     instruction: "extract the title of the top story on the page",

--- a/evals/tasks/hn_customOpenAI.ts
+++ b/evals/tasks/hn_customOpenAI.ts
@@ -17,7 +17,7 @@ export const hn_customOpenAI: EvalFunction = async ({ logger }) => {
 
   const { debugUrl, sessionUrl } = initResponse;
 
-  await stagehand.page.goto("https://news.ycombinator.com");
+  await stagehand.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/hackernews/");
 
   let { story } = await stagehand.page.extract({
     instruction: "extract the title of the top story on the page",

--- a/evals/tasks/hn_langchain.ts
+++ b/evals/tasks/hn_langchain.ts
@@ -16,7 +16,7 @@ export const hn_langchain: EvalFunction = async ({ logger }) => {
 
   const { debugUrl, sessionUrl } = initResponse;
 
-  await stagehand.page.goto("https://news.ycombinator.com");
+  await stagehand.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/hackernews/");
 
   let { story } = await stagehand.page.extract({
     instruction: "extract the title of the top story on the page",

--- a/evals/tasks/hn_langchain.ts
+++ b/evals/tasks/hn_langchain.ts
@@ -16,7 +16,9 @@ export const hn_langchain: EvalFunction = async ({ logger }) => {
 
   const { debugUrl, sessionUrl } = initResponse;
 
-  await stagehand.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/hackernews/");
+  await stagehand.page.goto(
+    "https://browserbase.github.io/stagehand-eval-sites/sites/hackernews/",
+  );
 
   let { story } = await stagehand.page.extract({
     instruction: "extract the title of the top story on the page",

--- a/evals/tasks/panamcs.ts
+++ b/evals/tasks/panamcs.ts
@@ -9,7 +9,9 @@ export const panamcs: EvalFunction = async ({ modelName, logger }) => {
 
   const { debugUrl, sessionUrl } = initResponse;
 
-  await stagehand.page.goto("https://panamcs.org/about/staff/");
+  await stagehand.page.goto(
+    "https://seanmcguire12.github.io/stagehand-eval-sites/sites/panamcs/",
+  );
 
   const observations = await stagehand.page.observe({ onlyVisible: true });
 

--- a/evals/tasks/panamcs.ts
+++ b/evals/tasks/panamcs.ts
@@ -10,7 +10,7 @@ export const panamcs: EvalFunction = async ({ modelName, logger }) => {
   const { debugUrl, sessionUrl } = initResponse;
 
   await stagehand.page.goto(
-    "https://seanmcguire12.github.io/stagehand-eval-sites/sites/panamcs/",
+    "https://browserbase.github.io/stagehand-eval-sites/sites/panamcs/",
   );
 
   const observations = await stagehand.page.observe({ onlyVisible: true });

--- a/evals/tasks/prevChunk.ts
+++ b/evals/tasks/prevChunk.ts
@@ -9,7 +9,9 @@ export const prevChunk: EvalFunction = async ({ modelName, logger }) => {
   });
 
   const { debugUrl, sessionUrl } = initResponse;
-  await stagehand.page.goto("https://aigrant.com/");
+  await stagehand.page.goto(
+    "https://seanmcguire12.github.io/stagehand-eval-sites/sites/aigrant/",
+  );
   await new Promise((resolve) => setTimeout(resolve, 2000));
   const { initialScrollTop, chunkHeight } = await stagehand.page.evaluate(
     () => {

--- a/evals/tasks/prevChunk.ts
+++ b/evals/tasks/prevChunk.ts
@@ -10,7 +10,7 @@ export const prevChunk: EvalFunction = async ({ modelName, logger }) => {
 
   const { debugUrl, sessionUrl } = initResponse;
   await stagehand.page.goto(
-    "https://seanmcguire12.github.io/stagehand-eval-sites/sites/aigrant/",
+    "https://browserbase.github.io/stagehand-eval-sites/sites/aigrant/",
   );
   await new Promise((resolve) => setTimeout(resolve, 2000));
   const { initialScrollTop, chunkHeight } = await stagehand.page.evaluate(

--- a/evals/tasks/scroll_50.ts
+++ b/evals/tasks/scroll_50.ts
@@ -10,7 +10,7 @@ export const scroll_50: EvalFunction = async ({ modelName, logger }) => {
 
   const { debugUrl, sessionUrl } = initResponse;
   await stagehand.page.goto(
-    "https://seanmcguire12.github.io/stagehand-eval-sites/sites/aigrant/",
+    "https://browserbase.github.io/stagehand-eval-sites/sites/aigrant/",
   );
   await stagehand.page.act({
     action: "Scroll 50% down the page",

--- a/evals/tasks/scroll_50.ts
+++ b/evals/tasks/scroll_50.ts
@@ -9,7 +9,9 @@ export const scroll_50: EvalFunction = async ({ modelName, logger }) => {
   });
 
   const { debugUrl, sessionUrl } = initResponse;
-  await stagehand.page.goto("https://aigrant.com/");
+  await stagehand.page.goto(
+    "https://seanmcguire12.github.io/stagehand-eval-sites/sites/aigrant/",
+  );
   await stagehand.page.act({
     action: "Scroll 50% down the page",
   });

--- a/evals/tasks/scroll_75.ts
+++ b/evals/tasks/scroll_75.ts
@@ -9,7 +9,9 @@ export const scroll_75: EvalFunction = async ({ modelName, logger }) => {
   });
 
   const { debugUrl, sessionUrl } = initResponse;
-  await stagehand.page.goto("https://aigrant.com/");
+  await stagehand.page.goto(
+    "https://seanmcguire12.github.io/stagehand-eval-sites/sites/aigrant/",
+  );
   await stagehand.page.act({
     action: "Scroll 75% down the page",
   });

--- a/evals/tasks/scroll_75.ts
+++ b/evals/tasks/scroll_75.ts
@@ -10,7 +10,7 @@ export const scroll_75: EvalFunction = async ({ modelName, logger }) => {
 
   const { debugUrl, sessionUrl } = initResponse;
   await stagehand.page.goto(
-    "https://seanmcguire12.github.io/stagehand-eval-sites/sites/aigrant/",
+    "https://browserbase.github.io/stagehand-eval-sites/sites/aigrant/",
   );
   await stagehand.page.act({
     action: "Scroll 75% down the page",


### PR DESCRIPTION
# why
- surge.sh stopped working :( 
# what changed
- migrated our static eval sites to gh pages, changed URLs of affected evals
# test plan
- lotta evals