### PR TITLE
fixed output message when apikey is not present

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -76,8 +76,9 @@ async function getBrowser(
   browserbaseSessionCreateParams?: Browserbase.Sessions.SessionCreateParams,
   browserbaseSessionID?: string,
   localBrowserLaunchOptions?: LocalBrowserLaunchOptions,
+  intEnv: "LOCAL" | "BROWSERBASE" = "LOCAL",
 ): Promise<BrowserResult> {
-  if (env === "BROWSERBASE") {
+  if (intEnv === "BROWSERBASE") {
     if (!apiKey) {
       logger({
         category: "init",
@@ -677,6 +678,7 @@ export class Stagehand {
         this.browserbaseSessionCreateParams,
         this.browserbaseSessionID,
         this.localBrowserLaunchOptions,
+        this.intEnv,
       ).catch((e) => {
         this.stagehandLogger.error("Error in init:", { error: String(e) });
         const br: BrowserResult = {


### PR DESCRIPTION

# why 
solves issue #592. 

# what changed
Added `intEnv` in `getBrowser` method in order to know about initial environment and replaced `env` with `intEnv`  for checking the environment correctly and outputting the message accordingly.

# test plan
