### PR TITLE
Make type and modelName more flexible in LLMClient.ts

### DIFF
--- a/lib/llm/LLMClient.ts
+++ b/lib/llm/LLMClient.ts
@@ -86,8 +86,8 @@ export interface CreateChatCompletionOptions {
 }
 
 export abstract class LLMClient {
-  public type: "openai" | "anthropic" | "cerebras" | "groq" | string;
-  public modelName: AvailableModel;
+  public type: "openai" | "anthropic" | "cerebras" | "groq" | (string & {});
+  public modelName: AvailableModel | (string & {});
   public hasVision: boolean;
   public clientOptions: ClientOptions;
   public userProvidedInstructions?: string;


### PR DESCRIPTION
# why

Right now `modelName` is strongly typed to only allow the pre-specified model names in AvailableModel. I'm building a custom LLMClient that doesn't use those models.

# what changed

This PR updates it to also accept an arbitrary string, and also updates type to use the `(string & {})` [trick](https://stackoverflow.com/questions/76142160/literal-string-union-autocomplete-in-typescript-3-8-3) to enable autocomplete with a string fallback.

# test plan

Types-only change, should be okay? :)
