### PR TITLE
offload observe result to api

### DIFF
--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -491,6 +491,14 @@ export class StagehandPage {
         // If it has selector AND method => treat as ObserveResult
         if ("selector" in actionOrOptions && "method" in actionOrOptions) {
           const observeResult = actionOrOptions as ObserveResult;
+
+          if (this.api) {
+            const result = await this.api.act(observeResult);
+            await this._refreshPageFromAPI();
+            this.addToHistory("act", observeResult, result);
+            return result;
+          }
+
           // validate observeResult.method, etc.
           return this.actHandler.actFromObserveResult(observeResult);
         } else {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -95,7 +95,7 @@ export class StagehandAPI {
     return sessionResponseBody.data;
   }
 
-  async act(options: ActOptions): Promise<ActResult> {
+  async act(options: ActOptions | ObserveResult): Promise<ActResult> {
     return this.execute<ActResult>({
       method: "act",
       args: { ...options },


### PR DESCRIPTION
# why
observe -> act wasn't offloading to the api

# what changed
intercepted and offloaded the thing
# test plan
