### PR TITLE
token usage for act

### DIFF
--- a/.changeset/dirty-garlics-wonder.md
+++ b/.changeset/dirty-garlics-wonder.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+fix token act metrics and inference logging being misplaced as observe metrics and inference logging

--- a/lib/handlers/actHandler.ts
+++ b/lib/handlers/actHandler.ts
@@ -229,6 +229,7 @@ export class StagehandActHandler {
         onlyVisible: false,
         drawOverlay: false,
         returnAction: true,
+        fromAct: true,
       });
 
       if (observeResults.length === 0) {

--- a/lib/handlers/observeHandler.ts
+++ b/lib/handlers/observeHandler.ts
@@ -57,6 +57,7 @@ export class StagehandObserveHandler {
     returnAction,
     onlyVisible,
     drawOverlay,
+    fromAct,
   }: {
     instruction: string;
     llmClient: LLMClient;
@@ -65,6 +66,7 @@ export class StagehandObserveHandler {
     returnAction?: boolean;
     onlyVisible?: boolean;
     drawOverlay?: boolean;
+    fromAct?: boolean;
   }) {
     if (!instruction) {
       instruction = `Find elements that can be used for any future actions in the page. These may be navigation links, related pages, section/subsection links, buttons, or other interactive elements. Be comprehensive: if there are multiple elements that may be relevant for future actions, return all of them.`;
@@ -114,6 +116,7 @@ export class StagehandObserveHandler {
       isUsingAccessibilityTree: useAccessibilityTree,
       returnAction,
       logInferenceToFile: this.stagehand.logInferenceToFile,
+      fromAct: fromAct,
     });
 
     const {
@@ -123,7 +126,7 @@ export class StagehandObserveHandler {
     } = observationResponse;
 
     this.stagehand.updateMetrics(
-      StagehandFunctionName.OBSERVE,
+      fromAct ? StagehandFunctionName.ACT : StagehandFunctionName.OBSERVE,
       prompt_tokens,
       completion_tokens,
       inference_time_ms,

--- a/lib/inference.ts
+++ b/lib/inference.ts
@@ -349,6 +349,7 @@ export async function observe({
   logger,
   returnAction = false,
   logInferenceToFile = false,
+  fromAct,
 }: {
   instruction: string;
   domElements: string;
@@ -359,6 +360,7 @@ export async function observe({
   isUsingAccessibilityTree?: boolean;
   returnAction?: boolean;
   logInferenceToFile?: boolean;
+  fromAct?: boolean;
 }) {
   const observeSchema = z.object({
     elements: z
@@ -407,15 +409,16 @@ export async function observe({
     buildObserveUserMessage(instruction, domElements, isUsingAccessibilityTree),
   ];
 
+  const filePrefix = fromAct ? "act" : "observe";
   let callTimestamp = "";
   let callFile = "";
   if (logInferenceToFile) {
     const { fileName, timestamp } = writeTimestampedTxtFile(
-      "observe_summary",
-      "observe_call",
+      `${filePrefix}_summary`,
+      `${filePrefix}_call`,
       {
         requestId,
-        modelCall: "observe",
+        modelCall: filePrefix,
         messages,
       },
     );
@@ -450,18 +453,18 @@ export async function observe({
   let responseFile = "";
   if (logInferenceToFile) {
     const { fileName: responseFileName } = writeTimestampedTxtFile(
-      "observe_summary",
-      "observe_response",
+      `${filePrefix}_summary`,
+      `${filePrefix}_response`,
       {
         requestId,
-        modelResponse: "observe",
+        modelResponse: filePrefix,
         rawResponse: observeData,
       },
     );
     responseFile = responseFileName;
 
-    appendSummary("observe", {
-      observe_inference_type: "observe",
+    appendSummary(filePrefix, {
+      [`${filePrefix}_inference_type`]: filePrefix,
       timestamp: callTimestamp,
       LLM_input_file: callFile,
       LLM_output_file: responseFile,


### PR DESCRIPTION
# why
- add token usage for act
# what changed
- pass `fromAct` parameter from within act handler -> observe handler -> observe inference if `observe` is being called inside `act`
# test plan
- evals