### PR TITLE
Added support for Invalid LLM API KEYS

### DIFF
--- a/lib/llm/AnthropicClient.ts
+++ b/lib/llm/AnthropicClient.ts
@@ -14,7 +14,10 @@ import {
   LLMClient,
   LLMResponse,
 } from "./LLMClient";
-import { CreateChatCompletionResponseError } from "@/types/stagehandErrors";
+import {
+  CreateChatCompletionResponseError,
+  InvalidLLMKeyError,
+} from "@/types/stagehandErrors";
 
 export class AnthropicClient extends LLMClient {
   public type = "anthropic" as const;
@@ -53,325 +56,348 @@ export class AnthropicClient extends LLMClient {
   }: CreateChatCompletionOptions): Promise<T> {
     const optionsWithoutImage = { ...options };
     delete optionsWithoutImage.image;
-
-    logger({
-      category: "anthropic",
-      message: "creating chat completion",
-      level: 2,
-      auxiliary: {
-        options: {
-          value: JSON.stringify(optionsWithoutImage),
-          type: "object",
-        },
-      },
-    });
-
-    // Try to get cached response
-    const cacheOptions = {
-      model: this.modelName,
-      messages: options.messages,
-      temperature: options.temperature,
-      image: options.image,
-      response_model: options.response_model,
-      tools: options.tools,
-      retries: retries,
-    };
-
-    if (this.enableCaching) {
-      const cachedResponse = await this.cache.get<T>(
-        cacheOptions,
-        options.requestId,
-      );
-      if (cachedResponse) {
-        logger({
-          category: "llm_cache",
-          message: "LLM cache hit - returning cached response",
-          level: 1,
-          auxiliary: {
-            cachedResponse: {
-              value: JSON.stringify(cachedResponse),
-              type: "object",
-            },
-            requestId: {
-              value: options.requestId,
-              type: "string",
-            },
-            cacheOptions: {
-              value: JSON.stringify(cacheOptions),
-              type: "object",
-            },
-          },
-        });
-        return cachedResponse as T;
-      } else {
-        logger({
-          category: "llm_cache",
-          message: "LLM cache miss - no cached response found",
-          level: 1,
-          auxiliary: {
-            cacheOptions: {
-              value: JSON.stringify(cacheOptions),
-              type: "object",
-            },
-            requestId: {
-              value: options.requestId,
-              type: "string",
-            },
-          },
-        });
-      }
-    }
-
-    const systemMessage = options.messages.find((msg) => {
-      if (msg.role === "system") {
-        if (typeof msg.content === "string") {
-          return true;
-        } else if (Array.isArray(msg.content)) {
-          return msg.content.every((content) => content.type !== "image_url");
-        }
-      }
-      return false;
-    });
-
-    const userMessages = options.messages.filter(
-      (msg) => msg.role !== "system",
-    );
-
-    const formattedMessages: MessageParam[] = userMessages.map((msg) => {
-      if (typeof msg.content === "string") {
-        return {
-          role: msg.role as "user" | "assistant", // ensure its not checking for system types
-          content: msg.content,
-        };
-      } else {
-        return {
-          role: msg.role as "user" | "assistant",
-          content: msg.content.map((content) => {
-            if ("image_url" in content) {
-              const formattedContent: ImageBlockParam = {
-                type: "image",
-                source: {
-                  type: "base64",
-                  media_type: "image/jpeg",
-                  data: content.image_url.url,
-                },
-              };
-
-              return formattedContent;
-            } else {
-              return { type: "text", text: content.text };
-            }
-          }),
-        };
-      }
-    });
-
-    if (options.image) {
-      const screenshotMessage: MessageParam = {
-        role: "user",
-        content: [
-          {
-            type: "image",
-            source: {
-              type: "base64",
-              media_type: "image/jpeg",
-              data: options.image.buffer.toString("base64"),
-            },
-          },
-        ],
-      };
-      if (
-        options.image.description &&
-        Array.isArray(screenshotMessage.content)
-      ) {
-        screenshotMessage.content.push({
-          type: "text",
-          text: options.image.description,
-        });
-      }
-
-      formattedMessages.push(screenshotMessage);
-    }
-
-    let anthropicTools: Tool[] = options.tools?.map((tool) => {
-      return {
-        name: tool.name,
-        description: tool.description,
-        input_schema: {
-          type: "object",
-          properties: tool.parameters.properties,
-          required: tool.parameters.required,
-        },
-      };
-    });
-
-    let toolDefinition: Tool | undefined;
-    if (options.response_model) {
-      const jsonSchema = zodToJsonSchema(options.response_model.schema);
-      const { properties: schemaProperties, required: schemaRequired } =
-        extractSchemaProperties(jsonSchema);
-
-      toolDefinition = {
-        name: "print_extracted_data",
-        description: "Prints the extracted data based on the provided schema.",
-        input_schema: {
-          type: "object",
-          properties: schemaProperties,
-          required: schemaRequired,
-        },
-      };
-    }
-
-    if (toolDefinition) {
-      anthropicTools = anthropicTools ?? [];
-      anthropicTools.push(toolDefinition);
-    }
-
-    const response = await this.client.messages.create({
-      model: this.modelName,
-      max_tokens: options.maxTokens || 8192,
-      messages: formattedMessages,
-      tools: anthropicTools,
-      system: systemMessage
-        ? (systemMessage.content as string | TextBlockParam[]) // we can cast because we already filtered out image content
-        : undefined,
-      temperature: options.temperature,
-    });
-
-    logger({
-      category: "anthropic",
-      message: "response",
-      level: 2,
-      auxiliary: {
-        response: {
-          value: JSON.stringify(response),
-          type: "object",
-        },
-        requestId: {
-          value: options.requestId,
-          type: "string",
-        },
-      },
-    });
-
-    // We'll compute usage data from the response
-    const usageData = {
-      prompt_tokens: response.usage.input_tokens,
-      completion_tokens: response.usage.output_tokens,
-      total_tokens: response.usage.input_tokens + response.usage.output_tokens,
-    };
-
-    const transformedResponse: LLMResponse = {
-      id: response.id,
-      object: "chat.completion",
-      created: Date.now(),
-      model: response.model,
-      choices: [
-        {
-          index: 0,
-          message: {
-            role: "assistant",
-            content:
-              response.content.find((c) => c.type === "text")?.text || null,
-            tool_calls: response.content
-              .filter((c) => c.type === "tool_use")
-              .map((toolUse) => ({
-                id: toolUse.id,
-                type: "function",
-                function: {
-                  name: toolUse.name,
-                  arguments: JSON.stringify(toolUse.input),
-                },
-              })),
-          },
-          finish_reason: response.stop_reason,
-        },
-      ],
-      usage: usageData,
-    };
-
-    logger({
-      category: "anthropic",
-      message: "transformed response",
-      level: 2,
-      auxiliary: {
-        transformedResponse: {
-          value: JSON.stringify(transformedResponse),
-          type: "object",
-        },
-        requestId: {
-          value: options.requestId,
-          type: "string",
-        },
-      },
-    });
-
-    if (options.response_model) {
-      const toolUse = response.content.find((c) => c.type === "tool_use");
-      if (toolUse && "input" in toolUse) {
-        const result = toolUse.input;
-
-        const finalParsedResponse = {
-          data: result,
-          usage: usageData,
-        } as unknown as T;
-
-        if (this.enableCaching) {
-          this.cache.set(cacheOptions, finalParsedResponse, options.requestId);
-        }
-
-        return finalParsedResponse;
-      } else {
-        if (!retries || retries < 5) {
-          return this.createChatCompletion({
-            options,
-            logger,
-            retries: (retries ?? 0) + 1,
-          });
-        }
-        logger({
-          category: "anthropic",
-          message: "error creating chat completion",
-          level: 0,
-          auxiliary: {
-            requestId: {
-              value: options.requestId,
-              type: "string",
-            },
-          },
-        });
-        throw new CreateChatCompletionResponseError(
-          "No tool use with input in response",
-        );
-      }
-    }
-
-    if (this.enableCaching) {
-      this.cache.set(cacheOptions, transformedResponse, options.requestId);
+    try {
       logger({
         category: "anthropic",
-        message: "cached response",
-        level: 1,
+        message: "creating chat completion",
+        level: 2,
         auxiliary: {
-          requestId: {
-            value: options.requestId,
-            type: "string",
-          },
-          transformedResponse: {
-            value: JSON.stringify(transformedResponse),
-            type: "object",
-          },
-          cacheOptions: {
-            value: JSON.stringify(cacheOptions),
+          options: {
+            value: JSON.stringify(optionsWithoutImage),
             type: "object",
           },
         },
       });
-    }
 
-    // if the function was called with a response model, it would have returned earlier
-    // so we can safely cast here to T, which defaults to AnthropicTransformedResponse
-    return transformedResponse as T;
+      // Try to get cached response
+      const cacheOptions = {
+        model: this.modelName,
+        messages: options.messages,
+        temperature: options.temperature,
+        image: options.image,
+        response_model: options.response_model,
+        tools: options.tools,
+        retries: retries,
+      };
+
+      if (this.enableCaching) {
+        const cachedResponse = await this.cache.get<T>(
+          cacheOptions,
+          options.requestId,
+        );
+        if (cachedResponse) {
+          logger({
+            category: "llm_cache",
+            message: "LLM cache hit - returning cached response",
+            level: 1,
+            auxiliary: {
+              cachedResponse: {
+                value: JSON.stringify(cachedResponse),
+                type: "object",
+              },
+              requestId: {
+                value: options.requestId,
+                type: "string",
+              },
+              cacheOptions: {
+                value: JSON.stringify(cacheOptions),
+                type: "object",
+              },
+            },
+          });
+          return cachedResponse as T;
+        } else {
+          logger({
+            category: "llm_cache",
+            message: "LLM cache miss - no cached response found",
+            level: 1,
+            auxiliary: {
+              cacheOptions: {
+                value: JSON.stringify(cacheOptions),
+                type: "object",
+              },
+              requestId: {
+                value: options.requestId,
+                type: "string",
+              },
+            },
+          });
+        }
+      }
+
+      const systemMessage = options.messages.find((msg) => {
+        if (msg.role === "system") {
+          if (typeof msg.content === "string") {
+            return true;
+          } else if (Array.isArray(msg.content)) {
+            return msg.content.every((content) => content.type !== "image_url");
+          }
+        }
+        return false;
+      });
+
+      const userMessages = options.messages.filter(
+        (msg) => msg.role !== "system",
+      );
+
+      const formattedMessages: MessageParam[] = userMessages.map((msg) => {
+        if (typeof msg.content === "string") {
+          return {
+            role: msg.role as "user" | "assistant", // ensure its not checking for system types
+            content: msg.content,
+          };
+        } else {
+          return {
+            role: msg.role as "user" | "assistant",
+            content: msg.content.map((content) => {
+              if ("image_url" in content) {
+                const formattedContent: ImageBlockParam = {
+                  type: "image",
+                  source: {
+                    type: "base64",
+                    media_type: "image/jpeg",
+                    data: content.image_url.url,
+                  },
+                };
+
+                return formattedContent;
+              } else {
+                return { type: "text", text: content.text };
+              }
+            }),
+          };
+        }
+      });
+
+      if (options.image) {
+        const screenshotMessage: MessageParam = {
+          role: "user",
+          content: [
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: "image/jpeg",
+                data: options.image.buffer.toString("base64"),
+              },
+            },
+          ],
+        };
+        if (
+          options.image.description &&
+          Array.isArray(screenshotMessage.content)
+        ) {
+          screenshotMessage.content.push({
+            type: "text",
+            text: options.image.description,
+          });
+        }
+
+        formattedMessages.push(screenshotMessage);
+      }
+
+      let anthropicTools: Tool[] = options.tools?.map((tool) => {
+        return {
+          name: tool.name,
+          description: tool.description,
+          input_schema: {
+            type: "object",
+            properties: tool.parameters.properties,
+            required: tool.parameters.required,
+          },
+        };
+      });
+
+      let toolDefinition: Tool | undefined;
+      if (options.response_model) {
+        const jsonSchema = zodToJsonSchema(options.response_model.schema);
+        const { properties: schemaProperties, required: schemaRequired } =
+          extractSchemaProperties(jsonSchema);
+
+        toolDefinition = {
+          name: "print_extracted_data",
+          description:
+            "Prints the extracted data based on the provided schema.",
+          input_schema: {
+            type: "object",
+            properties: schemaProperties,
+            required: schemaRequired,
+          },
+        };
+      }
+
+      if (toolDefinition) {
+        anthropicTools = anthropicTools ?? [];
+        anthropicTools.push(toolDefinition);
+      }
+
+      const response = await this.client.messages.create({
+        model: this.modelName,
+        max_tokens: options.maxTokens || 8192,
+        messages: formattedMessages,
+        tools: anthropicTools,
+        system: systemMessage
+          ? (systemMessage.content as string | TextBlockParam[]) // we can cast because we already filtered out image content
+          : undefined,
+        temperature: options.temperature,
+      });
+
+      logger({
+        category: "anthropic",
+        message: "response",
+        level: 2,
+        auxiliary: {
+          response: {
+            value: JSON.stringify(response),
+            type: "object",
+          },
+          requestId: {
+            value: options.requestId,
+            type: "string",
+          },
+        },
+      });
+
+      // We'll compute usage data from the response
+      const usageData = {
+        prompt_tokens: response.usage.input_tokens,
+        completion_tokens: response.usage.output_tokens,
+        total_tokens:
+          response.usage.input_tokens + response.usage.output_tokens,
+      };
+
+      const transformedResponse: LLMResponse = {
+        id: response.id,
+        object: "chat.completion",
+        created: Date.now(),
+        model: response.model,
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: "assistant",
+              content:
+                response.content.find((c) => c.type === "text")?.text || null,
+              tool_calls: response.content
+                .filter((c) => c.type === "tool_use")
+                .map((toolUse) => ({
+                  id: toolUse.id,
+                  type: "function",
+                  function: {
+                    name: toolUse.name,
+                    arguments: JSON.stringify(toolUse.input),
+                  },
+                })),
+            },
+            finish_reason: response.stop_reason,
+          },
+        ],
+        usage: usageData,
+      };
+
+      logger({
+        category: "anthropic",
+        message: "transformed response",
+        level: 2,
+        auxiliary: {
+          transformedResponse: {
+            value: JSON.stringify(transformedResponse),
+            type: "object",
+          },
+          requestId: {
+            value: options.requestId,
+            type: "string",
+          },
+        },
+      });
+
+      if (options.response_model) {
+        const toolUse = response.content.find((c) => c.type === "tool_use");
+        if (toolUse && "input" in toolUse) {
+          const result = toolUse.input;
+
+          const finalParsedResponse = {
+            data: result,
+            usage: usageData,
+          } as unknown as T;
+
+          if (this.enableCaching) {
+            this.cache.set(
+              cacheOptions,
+              finalParsedResponse,
+              options.requestId,
+            );
+          }
+
+          return finalParsedResponse;
+        } else {
+          if (!retries || retries < 5) {
+            return this.createChatCompletion({
+              options,
+              logger,
+              retries: (retries ?? 0) + 1,
+            });
+          }
+          logger({
+            category: "anthropic",
+            message: "error creating chat completion",
+            level: 0,
+            auxiliary: {
+              requestId: {
+                value: options.requestId,
+                type: "string",
+              },
+            },
+          });
+          throw new CreateChatCompletionResponseError(
+            "No tool use with input in response",
+          );
+        }
+      }
+
+      if (this.enableCaching) {
+        this.cache.set(cacheOptions, transformedResponse, options.requestId);
+        logger({
+          category: "anthropic",
+          message: "cached response",
+          level: 1,
+          auxiliary: {
+            requestId: {
+              value: options.requestId,
+              type: "string",
+            },
+            transformedResponse: {
+              value: JSON.stringify(transformedResponse),
+              type: "object",
+            },
+            cacheOptions: {
+              value: JSON.stringify(cacheOptions),
+              type: "object",
+            },
+          },
+        });
+      }
+
+      // if the function was called with a response model, it would have returned earlier
+      // so we can safely cast here to T, which defaults to AnthropicTransformedResponse
+      return transformedResponse as T;
+    } catch (error) {
+      if (error instanceof Anthropic.AuthenticationError) {
+        logger({
+          category: "anthropic",
+          message: "Invalid Anthropic API key",
+          level: 0,
+          auxiliary: {
+            error: {
+              value: error.message,
+              type: "string",
+            },
+          },
+        });
+        throw new InvalidLLMKeyError();
+      }
+      throw error;
+    }
   }
 }
 

--- a/lib/llm/CerebrasClient.ts
+++ b/lib/llm/CerebrasClient.ts
@@ -10,7 +10,10 @@ import {
   LLMClient,
   LLMResponse,
 } from "./LLMClient";
-import { CreateChatCompletionResponseError } from "@/types/stagehandErrors";
+import {
+  CreateChatCompletionResponseError,
+  InvalidLLMKeyError,
+} from "@/types/stagehandErrors";
 
 export class CerebrasClient extends LLMClient {
   public type = "cerebras" as const;
@@ -306,6 +309,24 @@ export class CerebrasClient extends LLMClient {
 
       return response as T;
     } catch (error) {
+      if (error instanceof OpenAI.AuthenticationError) {
+        logger({
+          category: "cerebras",
+          message: "Invalid Cerebras API key",
+          level: 0,
+          auxiliary: {
+            error: {
+              value: error.message,
+              type: "string",
+            },
+            requestId: {
+              value: options.requestId,
+              type: "string",
+            },
+          },
+        });
+        throw new InvalidLLMKeyError();
+      }
       logger({
         category: "cerebras",
         message: "error creating chat completion",

--- a/lib/llm/GroqClient.ts
+++ b/lib/llm/GroqClient.ts
@@ -10,7 +10,10 @@ import {
   LLMClient,
   LLMResponse,
 } from "./LLMClient";
-import { CreateChatCompletionResponseError } from "@/types/stagehandErrors";
+import {
+  CreateChatCompletionResponseError,
+  InvalidLLMKeyError,
+} from "@/types/stagehandErrors";
 
 export class GroqClient extends LLMClient {
   public type = "groq" as const;
@@ -306,6 +309,24 @@ export class GroqClient extends LLMClient {
 
       return response as T;
     } catch (error) {
+      if (error instanceof OpenAI.AuthenticationError) {
+        logger({
+          category: "groq",
+          message: "Invalid Groq API key",
+          level: 0,
+          auxiliary: {
+            error: {
+              value: error.message,
+              type: "string",
+            },
+            requestId: {
+              value: options.requestId,
+              type: "string",
+            },
+          },
+        });
+        throw new InvalidLLMKeyError();
+      }
       logger({
         category: "groq",
         message: "error creating chat completion",

--- a/types/stagehandErrors.ts
+++ b/types/stagehandErrors.ts
@@ -86,6 +86,14 @@ export class MissingLLMConfigurationError extends StagehandError {
   }
 }
 
+export class InvalidLLMKeyError extends StagehandError {
+  constructor() {
+    super(
+      "Invalid LLM API key or LLM Client configured. Please check your configuration.",
+    );
+  }
+}
+
 export class HandlerNotInitializedError extends StagehandError {
   constructor(handlerType: string) {
     super(`${handlerType} handler not initialized`);


### PR DESCRIPTION
# why
Previously it is displaying a  `StagehandDefaultError` when LLM api keys are not present which does not provide concise details about the error.

# what changed
It now displays invalid LLM API keys with a clean structured message. 
Added error handling in ```createChatCompletion``` method for various LLM Clients ( OpenAI, Grok, Anthropic, Cerebras ).
Created new ```InvalidLLMKeyError``` class for custom Invalid api message

# test plan
