### PR TITLE
Added support for automatic redirect to google.com in Agents

### DIFF
--- a/.changeset/rude-peas-stay.md
+++ b/.changeset/rude-peas-stay.md
@@ -1,5 +1,5 @@
 ---
-"@browserbasehq/stagehand": minor
+"@browserbasehq/stagehand": patch
 ---
 
 Added support for stagehand agents to automatically redirect to https://google.com when the page URL is empty or set to about:blank, preventing empty screenshots and saving tokens.

--- a/.changeset/rude-peas-stay.md
+++ b/.changeset/rude-peas-stay.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": minor
+---
+
+Added support for stagehand agents to automatically redirect to https://google.com when the page URL is empty or set to about:blank, preventing empty screenshots and saving tokens.

--- a/lib/handlers/agentHandler.ts
+++ b/lib/handlers/agentHandler.ts
@@ -126,6 +126,17 @@ export class StagehandAgentHandler {
         ? { instruction: optionsOrInstruction }
         : optionsOrInstruction;
 
+    //Redirect to Google if the URL is empty or about:blank
+    const currentUrl = this.stagehandPage.page.url();
+    if (!currentUrl || currentUrl === "about:blank") {
+      this.logger({
+        category: "agent",
+        message: `Page URL is empty or about:blank. Redirecting to www.google.com...`,
+        level: 0,
+      });
+      await this.stagehandPage.page.goto("https://www.google.com");
+    }
+
     this.logger({
       category: "agent",
       message: `Executing agent task: ${options.instruction}`,


### PR DESCRIPTION
# why
To prevent the capture and sending of empty screenshots when the page URL is empty or set to about:blank, improving efficiency and saving tokens.

# what changed
Implemented automatic redirection to https://google.com in `StagehandAgentHandler.execute()` method for stagehand agents when the page URL is empty or set to about:blank.

# test plan
execute
