### PR TITLE
fix: throw error if BROWSERBASE env is set without API key (fixes #592)

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -79,14 +79,11 @@ async function getBrowser(
 ): Promise<BrowserResult> {
   if (env === "BROWSERBASE") {
     if (!apiKey) {
-      logger({
-        category: "init",
-        message:
-          "BROWSERBASE_API_KEY is required to use BROWSERBASE env. Defaulting to LOCAL.",
-        level: 0,
-      });
-      env = "LOCAL";
+      throw new Error(
+        'BROWSERBASE_API_KEY is required to use the BROWSERBASE environment. Please set it in your .env or pass it in.'
+      );
     }
+    
     if (!projectId) {
       logger({
         category: "init",
@@ -537,6 +534,14 @@ export class Stagehand {
     this.intEnv = env;
     this.apiKey = apiKey ?? process.env.BROWSERBASE_API_KEY;
     this.projectId = projectId ?? process.env.BROWSERBASE_PROJECT_ID;
+
+    if (this.intEnv === "BROWSERBASE" && !this.apiKey) {
+      throw new Error(
+        'Stagehand is set to use "BROWSERBASE" but no BROWSERBASE_API_KEY was found. Please set it in your .env or pass it explicitly.'
+      );
+    }
+
+    
     this.verbose = verbose ?? 0;
     // Update logger verbosity level
     this.stagehandLogger.setVerbosity(this.verbose);


### PR DESCRIPTION
Fixes #592

# why
Previously, the fallback to LOCAL mode was silent, which could be misleading in production. Now, the constructor and `getBrowser()` both throw informative errors to help developers catch misconfigurations early.


# what changed
This PR adds an explicit error when `env: "BROWSERBASE"` is used without a valid `BROWSERBASE_API_KEY`.


# test plan
Tested with `npm run example` and verified the error is thrown as expected.
