### PR TITLE
OpenAICUAClient.ts reads `baseUrl` from `clientOptions`

### DIFF
--- a/lib/agent/OpenAICUAClient.ts
+++ b/lib/agent/OpenAICUAClient.ts
@@ -43,6 +43,7 @@ export class OpenAICUAClient extends AgentClient {
       (clientOptions?.apiKey as string) || process.env.OPENAI_API_KEY || "";
     this.organization =
       (clientOptions?.organization as string) || process.env.OPENAI_ORG;
+    this.baseURL = (clientOptions?.baseURL as string) || undefined;
 
     // Get environment if specified
     if (
@@ -56,6 +57,10 @@ export class OpenAICUAClient extends AgentClient {
     this.clientOptions = {
       apiKey: this.apiKey,
     };
+
+    if (this.baseURL) {
+      this.clientOptions.baseURL = this.baseURL;
+    }
 
     // Initialize the OpenAI client
     this.client = new OpenAI(this.clientOptions);


### PR DESCRIPTION
# why
https://github.com/browserbase/stagehand/issues/643

# what changed
OpenAICUAClient now respects `baseURL` passed in the options