### PR TITLE
Hybrid tree formatting + link mapping

### DIFF
--- a/.changeset/two-words-sort.md
+++ b/.changeset/two-words-sort.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+trim waste from hybrid tree, store an id->link mapping

--- a/lib/a11y/treeFormatUtils.ts
+++ b/lib/a11y/treeFormatUtils.ts
@@ -1,0 +1,209 @@
+import { AccessibilityNode } from "../../types/context";
+
+/**
+ * In our text‐formatting logic for the accessibility tree, any node whose role
+ * is contained in this set (or whose comma‐separated roles include one of these)
+ * is treated as a “block‐level” container. That means it:
+ *
+ * 1) Appears as its own structural block in the final text output (e.g., a paragraph or heading).
+ * 2) Usually starts on a new line and may contain nested inline content or further blocks.
+ * 3) Receives indentation in our hierarchy, reflecting the parent–child structure.
+ *
+ * Common examples of block‐level roles are:
+ * - "paragraph": Printed as a separate text block/section
+ * - "heading": Represented on its own line, possibly with extra emphasis
+ * - "list" and "listitem": Each item is shown on a new line
+ * - "div": Used as a generic container to encapsulate other content
+ *
+ * Nodes that are *not* in this set (e.g., "StaticText" or simple "link")
+ * are considered “inline” and have their text merged into the nearest block’s text flow,
+ * rather than forming their own block in the output.
+ */
+export const BLOCK_LEVEL_ROLES = new Set(["paragraph", "heading", "list", "listitem", "div"]);
+
+/**
+ * The maximum character width per line when wrapping text segments.
+ */
+export const MAX_LINE_WIDTH = 100;
+
+/**
+ * Determines if a node is "block-level".
+ *
+ * @param node - The accessibility node to evaluate.
+ * @returns true if the node's role matches or includes a block-level role.
+ */
+export function isBlockLevel(node: AccessibilityNode): boolean {
+  const parts = node.role
+    .toLowerCase()
+    .split(",")
+    .map((r) => r.trim());
+  return parts.some((p) => BLOCK_LEVEL_ROLES.has(p));
+}
+
+/**
+ * Determines if a node is an "inline leaf," meaning it:
+ * 1) Is NOT block-level itself, and
+ * 2) Has no children, or only children that are also inline leaves
+ *    (i.e., no block-level descendants).
+ *
+ * @param node - The accessibility node to check.
+ * @returns true if the node can be treated as inline-only with no block substructure.
+ */
+export function isInlineLeaf(node: AccessibilityNode): boolean {
+  if (isBlockLevel(node)) return false;
+
+  if (!node.children || node.children.length === 0) {
+    return true; // no children => definitely a leaf
+  }
+  for (const child of node.children) {
+    if (isBlockLevel(child)) {
+      return false; // if any child is block-level, this node isn't purely inline
+    }
+    if (child.children && child.children.length > 0) {
+      return false; // any grand-children => not a simple leaf
+    }
+  }
+  return true;
+}
+
+/**
+ * Collects text for a node that has been deemed an "inline leaf."
+ *
+ * How it works:
+ * - If the node is StaticText, we split its .name into individual words/tokens.
+ * - If the node is a link, we produce an inline reference like ["[@123]", "some", "text"]
+ *   so we can show "[@123] some text" inline.
+ * - If the node has children but is still considered an inline leaf overall,
+ *   we gather text from each child, concatenating everything into a single array of tokens.
+ *
+ * @param node - The node to gather text from.
+ * @returns An array of string tokens representing the node’s text content.
+ */
+export function gatherInlineLeafText(node: AccessibilityNode): string[] {
+  // 1) Handle StaticText directly
+  if (node.role === "StaticText") {
+    const text = (node.name || "").trim();
+    return text ? text.split(/\s+/) : [];
+  }
+
+  // 2) If it's a link (including comma‐separated roles like "scrollable, link"),
+  //    produce an inline reference and the link text as separate tokens.
+  const parts = node.role.split(",").map((r) => r.trim());
+  if (parts.includes("link")) {
+    const linkText = (node.name || "").trim();
+    if (linkText) {
+      return [`[@${node.nodeId}]`, ...linkText.split(/\s+/)];
+    }
+    return [`[@${node.nodeId}]`];
+  }
+
+  // 3) Otherwise, if it’s some container that is still considered an inline leaf,
+  //    we gather text from its children (recursively).
+  const result: string[] = [];
+  if (node.children) {
+    for (const child of node.children) {
+      if (isInlineLeaf(child)) {
+        result.push(...gatherInlineLeafText(child));
+      }
+    }
+  }
+  return result;
+}
+
+/**
+ * Splits an array of words or tokens into wrapped lines, ensuring
+ * lines do not exceed `maxWidth` characters. Each line is prefixed
+ * with the given `indent` string (for hierarchical display).
+ *
+ * @param segments - Array of individual text tokens.
+ * @param indent - A string (e.g., "  ") prepended to each line.
+ * @param maxWidth - Maximum line length (including indentation).
+ * @returns A multi-line string with the tokens wrapped,
+ *          ensuring lines don't exceed `maxWidth` characters.
+ */
+export function wrapTextSegments(
+  segments: string[],
+  indent: string,
+  maxWidth: number = MAX_LINE_WIDTH,
+): string {
+  const lines: string[] = [];
+  let currentLine = indent;
+
+  for (const seg of segments) {
+    // +1 for a space between existing content and the new segment.
+    if (currentLine.length + seg.length + 1 > maxWidth) {
+      lines.push(currentLine);
+      currentLine = indent + seg;
+    } else {
+      if (currentLine === indent) {
+        currentLine += seg; // first token on the line
+      } else {
+        currentLine += " " + seg;
+      }
+    }
+  }
+
+  if (currentLine.trim() !== "") {
+    lines.push(currentLine);
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Formats an accessibility tree for display, producing a simplified
+ * multi-line string representation.
+ *
+ * How it works:
+ * 1) Print a line describing the current node, e.g. "[nodeId] role(: name?)"
+ * 2) Collect inline-leaf children’s text in a local buffer (inlineBuffer).
+ *    - If we encounter a block-level child, we first flush the inlineBuffer
+ *      by word-wrapping it beneath the current node's line.
+ *    - Then we recursively format the block-level child, increasing indentation.
+ * 3) After processing all children, if the inlineBuffer is still non-empty,
+ *    we do one final flush, appending the wrapped text to the output.
+ *
+ * This approach preserves the node hierarchy (by indentation)
+ * and avoids duplicating text from inline children.
+ *
+ * @param node - The root or subnode to format.
+ * @param level - The current indentation level (defaults to 0).
+ * @returns A string with line-breaks reflecting the node hierarchy and wrapped text.
+ */
+export function formatSimplifiedTree(node: AccessibilityNode, level = 0): string {
+  const indent = "  ".repeat(level);
+
+  // Print a line for the current node
+  let output = `${indent}[${node.nodeId}] ${node.role}`;
+  if (node.name) output += `: ${node.name}`;
+  output += "\n";
+
+  // Buffer for collecting inline text from consecutive inline-leaf children
+  let inlineBuffer: string[] = [];
+
+  if (node.children) {
+    for (const child of node.children) {
+      // If child is purely inline, gather its text
+      if (isInlineLeaf(child)) {
+        inlineBuffer.push(...gatherInlineLeafText(child));
+      } else {
+        // This child is a block-level or container node => flush inline text first
+        if (inlineBuffer.length > 0) {
+          const wrapped = wrapTextSegments(inlineBuffer, indent + "  ", MAX_LINE_WIDTH);
+          output += wrapped + "\n";
+          inlineBuffer = [];
+        }
+        // Then format this block-level child recursively, increasing indentation
+        output += formatSimplifiedTree(child, level + 1);
+      }
+    }
+  }
+
+  // If there's leftover inline text at the end, flush it
+  if (inlineBuffer.length > 0) {
+    const wrapped = wrapTextSegments(inlineBuffer, indent + "  ", MAX_LINE_WIDTH);
+    output += wrapped + "\n";
+  }
+
+  return output;
+}

--- a/lib/a11y/treeFormatUtils.ts
+++ b/lib/a11y/treeFormatUtils.ts
@@ -19,7 +19,13 @@ import { AccessibilityNode } from "../../types/context";
  * are considered “inline” and have their text merged into the nearest block’s text flow,
  * rather than forming their own block in the output.
  */
-export const BLOCK_LEVEL_ROLES = new Set(["paragraph", "heading", "list", "listitem", "div"]);
+export const BLOCK_LEVEL_ROLES = new Set([
+  "paragraph",
+  "heading",
+  "list",
+  "listitem",
+  "div",
+]);
 
 /**
  * The maximum character width per line when wrapping text segments.
@@ -170,7 +176,10 @@ export function wrapTextSegments(
  * @param level - The current indentation level (defaults to 0).
  * @returns A string with line-breaks reflecting the node hierarchy and wrapped text.
  */
-export function formatSimplifiedTree(node: AccessibilityNode, level = 0): string {
+export function formatSimplifiedTree(
+  node: AccessibilityNode,
+  level = 0,
+): string {
   const indent = "  ".repeat(level);
 
   // Print a line for the current node
@@ -189,7 +198,11 @@ export function formatSimplifiedTree(node: AccessibilityNode, level = 0): string
       } else {
         // This child is a block-level or container node => flush inline text first
         if (inlineBuffer.length > 0) {
-          const wrapped = wrapTextSegments(inlineBuffer, indent + "  ", MAX_LINE_WIDTH);
+          const wrapped = wrapTextSegments(
+            inlineBuffer,
+            indent + "  ",
+            MAX_LINE_WIDTH,
+          );
           output += wrapped + "\n";
           inlineBuffer = [];
         }
@@ -201,7 +214,11 @@ export function formatSimplifiedTree(node: AccessibilityNode, level = 0): string
 
   // If there's leftover inline text at the end, flush it
   if (inlineBuffer.length > 0) {
-    const wrapped = wrapTextSegments(inlineBuffer, indent + "  ", MAX_LINE_WIDTH);
+    const wrapped = wrapTextSegments(
+      inlineBuffer,
+      indent + "  ",
+      MAX_LINE_WIDTH,
+    );
     output += wrapped + "\n";
   }
 

--- a/lib/a11y/treeFormatUtils.ts
+++ b/lib/a11y/treeFormatUtils.ts
@@ -25,6 +25,9 @@ export const BLOCK_LEVEL_ROLES = new Set([
   "list",
   "listitem",
   "div",
+  "checkbox",
+  "combobox",
+  "option",
 ]);
 
 /**

--- a/lib/a11y/utils.ts
+++ b/lib/a11y/utils.ts
@@ -6,9 +6,7 @@ import {
   PlaywrightCommandMethodNotSupportedException,
   PlaywrightCommandException,
 } from "@/types/playwright";
-import {
-  formatSimplifiedTree,
-} from "./treeFormatUtils"
+import { formatSimplifiedTree } from "./treeFormatUtils";
 
 /**
  * Helper function to remove or collapse unnecessary structural nodes

--- a/lib/a11y/utils.ts
+++ b/lib/a11y/utils.ts
@@ -6,7 +6,6 @@ import {
   PlaywrightCommandMethodNotSupportedException,
   PlaywrightCommandException,
 } from "@/types/playwright";
-import fs from "fs";
 import {
   formatSimplifiedTree,
 } from "./treeFormatUtils"

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -183,6 +183,9 @@ export function buildObserveUserMessage(
   return {
     role: "user",
     content: `instruction: ${instruction}
+
+CRITICAL: links will be formatted as <[id of link element] (corresponding link text here)>
+
 ${isUsingAccessibilityTree ? "Accessibility Tree" : "DOM"}: ${domElements}`,
   };
 }

--- a/types/context.ts
+++ b/types/context.ts
@@ -10,6 +10,13 @@ export interface AXNode {
   backendDOMNodeId?: number;
   parentId?: string;
   childIds?: string[];
+  properties?: {
+    name: string;
+    value: {
+      type: string;
+      value?: string;
+    };
+  }[];
 }
 
 export type AccessibilityNode = {
@@ -22,12 +29,20 @@ export type AccessibilityNode = {
   parentId?: string;
   nodeId?: string;
   backendDOMNodeId?: number;
+  properties?: {
+    name: string;
+    value: {
+      type: string;
+      value?: string;
+    };
+  }[];
 };
 
 export interface TreeResult {
   tree: AccessibilityNode[];
   simplified: string;
   iframes?: AccessibilityNode[];
+  idToUrl: Record<string, string>;
 }
 
 export interface EnhancedContext


### PR DESCRIPTION
# why
 - reduce tokens & redundancy in the hybrid tree
 - improve formatting of the hybrid tree (by removing & collapsing unnecessary nodes)
# what changed
- this PR reduces redundancy in the hybrid tree by combining `StaticText` nodes into their parent node when possible
- it also excludes `StaticText` nodes if they are a child of a `link`
- links are now formatted inline with the following format: `[@id]`
- the `TreeResult` type now holds an `idToUrl` dictionary where node IDs are keys and URLs are values
# example
### here is what the tree looked like before:

<img width="1383" alt="Screenshot 2025-04-07 at 4 25 36 PM" src="https://github.com/user-attachments/assets/cd3e6267-7329-43dd-ad40-3050db84f9b5" />

### here is what the tree looks like now:

<img width="932" alt="Screenshot 2025-04-07 at 4 23 43 PM" src="https://github.com/user-attachments/assets/919aa4cc-966f-40af-b3be-87301f081131" />

# future PRs (fast follow)
- inform the LLM on the change to link formatting
- when an LLM chooses an ID, lookup the URL in the `idToUrl` mapping, and include that in the extraction result
- remove `text_extract`, just have one `extract` function
- reintroduce chunking

# test plan
- evals
