### PR TITLE
remove redundant static text children

### DIFF
--- a/.changeset/cute-kings-stare.md
+++ b/.changeset/cute-kings-stare.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+collapse redundant text nodes into parent elements

--- a/lib/a11y/utils.ts
+++ b/lib/a11y/utils.ts
@@ -459,7 +459,6 @@ export async function findScrollableElementIds(
   return scrollableBackendIds;
 }
 
-
 /**
  * Removes any StaticText children whose combined text equals the parent's name.
  * This is most often used to avoid duplicating a link's accessible name in separate child nodes.

--- a/lib/a11y/utils.ts
+++ b/lib/a11y/utils.ts
@@ -54,7 +54,7 @@ async function cleanStructuralNodes(
     cleanStructuralNodes(child, page, logger),
   );
   const resolvedChildren = await Promise.all(cleanedChildrenPromises);
-  const cleanedChildren = resolvedChildren.filter(
+  let cleanedChildren = resolvedChildren.filter(
     (child): child is AccessibilityNode => child !== null,
   );
 
@@ -133,6 +133,17 @@ async function cleanStructuralNodes(
           },
         },
       });
+    }
+  }
+
+  // rm redundant StaticText children
+  cleanedChildren = removeRedundantStaticTextChildren(node, cleanedChildren);
+
+  if (cleanedChildren.length === 0) {
+    if (node.role === "generic" || node.role === "none") {
+      return null;
+    } else {
+      return { ...node, children: [] };
     }
   }
 
@@ -446,6 +457,41 @@ export async function findScrollableElementIds(
   }
 
   return scrollableBackendIds;
+}
+
+
+/**
+ * Removes any StaticText children whose combined text equals the parent's name.
+ * This is most often used to avoid duplicating a link's accessible name in separate child nodes.
+ *
+ * @param parent     The parent accessibility node whose `.name` we check.
+ * @param children   The parent's current children list, typically after cleaning.
+ * @returns          A filtered list of children with redundant StaticText nodes removed.
+ */
+function removeRedundantStaticTextChildren(
+  parent: AccessibilityNode,
+  children: AccessibilityNode[],
+): AccessibilityNode[] {
+  if (!parent.name) {
+    return children;
+  }
+
+  const parentName = parent.name.replace(/\s+/g, " ").trim();
+
+  // Gather all StaticText children and combine their text
+  const staticTextChildren = children.filter(
+    (child) => child.role === "StaticText" && child.name,
+  );
+  const combinedChildText = staticTextChildren
+    .map((child) => child.name!.replace(/\s+/g, " ").trim())
+    .join("");
+
+  // If the combined text exactly matches the parent's name, remove those child nodes
+  if (combinedChildText === parentName) {
+    return children.filter((child) => child.role !== "StaticText");
+  }
+
+  return children;
 }
 
 export async function performPlaywrightMethod(


### PR DESCRIPTION
# why
- we dont need a specific line for `StaticText` if the text is the same as whats in it's parent element
### eg, instead of this:
<img width="639" alt="Screenshot 2025-04-08 at 2 58 51 PM" src="https://github.com/user-attachments/assets/91b68c64-3346-4b43-9fdb-63b5607621d1" />

### we do this:
<img width="603" alt="Screenshot 2025-04-08 at 2 59 38 PM" src="https://github.com/user-attachments/assets/a74b94ed-95a4-4d05-95d4-fc4740465bde" />


# what changed
- trimmed these duplicates from the hybrid tree
# test plan
- evals