### PR TITLE
fix variable parsing in `act`

### DIFF
--- a/.changeset/strong-hornets-crash.md
+++ b/.changeset/strong-hornets-crash.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+parse out % signs from variables in act

--- a/lib/handlers/actHandler.ts
+++ b/lib/handlers/actHandler.ts
@@ -245,7 +245,7 @@ export class StagehandActHandler {
       if (actionOrOptions.variables) {
         Object.keys(actionOrOptions.variables).forEach((key) => {
           element.arguments = element.arguments.map((arg) =>
-            arg.replace(key, actionOrOptions.variables![key]),
+            arg.replace(`%${key}%`, actionOrOptions.variables![key]),
           );
         });
       }


### PR DESCRIPTION
# why
- when a user wraps their variable name in percentage symbols, those percentage symbols are not currently parsed out, and are therefore included as part of the variable value
- eg, user does something like:
- ```  await stagehand.page.goto("https://google.com");
  await stagehand.page.act({
    action: "search for %search_string%",
    variables: {
      search_string: "stagehand",
    },
  });
  ```
- the resulting search will look like:
<img width="600" alt="Screenshot 2025-04-09 at 4 42 26 PM" src="https://github.com/user-attachments/assets/11eee6ac-62ef-46e1-90ac-1df68b17c62c" />

# what changed
- we now parse out the percentage signs
# test plan
- evals