### PR TITLE
Stagehand Evaluator & first agent evals

### DIFF
--- a/.changeset/whole-yaks-cheat.md
+++ b/.changeset/whole-yaks-cheat.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": minor
+---
+
+Added a new class - Stagehand Evaluator - that wraps around a Stagehand object to determine whether a task is successful or not. Currently used for agent evals

--- a/evals/args.ts
+++ b/evals/args.ts
@@ -69,6 +69,7 @@ const DEFAULT_EVAL_CATEGORIES = process.env.EVAL_CATEGORIES
       "regression_llm_providers",
       "regression",
       "llm_clients",
+      "agent",
     ];
 
 // Finally, interpret leftover arguments to see if user typed "category X" or a single eval name

--- a/evals/evals.config.json
+++ b/evals/evals.config.json
@@ -309,6 +309,26 @@
     {
       "name": "google_flights",
       "categories": ["act"]
+    },
+    {
+      "name": "agent/iframe_form",
+      "categories": ["agent"]
+    },
+    {
+      "name": "agent/iframe_form_multiple",
+      "categories": ["agent"]
+    },
+    {
+      "name": "agent/google_flights",
+      "categories": ["agent"]
+    },
+    {
+      "name": "agent/sf_library_card",
+      "categories": ["agent"]
+    },
+    {
+      "name": "agent/sf_library_card_multiple",
+      "categories": ["agent"]
     }
   ]
 }

--- a/evals/evaluator.ts
+++ b/evals/evaluator.ts
@@ -1,0 +1,359 @@
+/**
+ * This class is responsible for evaluating the result of an agentic task.
+ * The first version includes a VLM evaluator specifically prompted to evaluate the state of a task
+ * usually represented as a screenshot.
+ * The evaluator will reply with YES or NO given the state of the provided task.
+ */
+
+import { AvailableModel, ClientOptions, Stagehand } from "@/dist";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+export interface EvaluateOptions {
+  /**
+   * The question to ask about the task state
+   */
+  question: string;
+  /**
+   * Custom system prompt for the evaluator
+   */
+  systemPrompt?: string;
+  /**
+   * Delay in milliseconds before taking the screenshot
+   * @default 1000
+   */
+  screenshotDelayMs?: number;
+  /**
+   * Whether to throw an error if the response is not a clear YES or NO
+   * @default false
+   */
+  strictResponse?: boolean;
+}
+
+export interface BatchEvaluateOptions {
+  /**
+   * Array of questions to evaluate
+   */
+  questions: string[];
+  /**
+   * Custom system prompt for the evaluator
+   */
+  systemPrompt?: string;
+  /**
+   * Delay in milliseconds before taking the screenshot
+   * @default 1000
+   */
+  screenshotDelayMs?: number;
+  /**
+   * Whether to throw an error if any response is not a clear YES or NO
+   * @default false
+   */
+  strictResponse?: boolean;
+  /**
+   * The reasoning behind the evaluation
+   */
+  reasoning?: string;
+}
+
+/**
+ * Result of an evaluation
+ */
+export interface EvaluationResult {
+  /**
+   * The evaluation result ('YES', 'NO', or 'INVALID' if parsing failed or value was unexpected)
+   */
+  evaluation: "YES" | "NO" | "INVALID";
+  /**
+   * The reasoning behind the evaluation
+   */
+  reasoning: string;
+}
+
+export class Evaluator {
+  private stagehand: Stagehand;
+  private modelName: AvailableModel;
+  private modelClientOptions: ClientOptions | { apiKey: string };
+  // Define regex patterns directly in the class or as constants if preferred elsewhere
+  private yesPattern = /^(YES|Y|TRUE|CORRECT|AFFIRMATIVE)/i;
+  private noPattern = /^(NO|N|FALSE|INCORRECT|NEGATIVE)/i;
+
+  constructor(
+    stagehand: Stagehand,
+    modelName?: AvailableModel,
+    modelClientOptions?: ClientOptions,
+  ) {
+    this.stagehand = stagehand;
+    this.modelName = modelName || "gemini-2.0-flash";
+    this.modelClientOptions = modelClientOptions || {
+      apiKey: process.env.GOOGLE_API_KEY || "",
+    };
+  }
+
+  /**
+   * Evaluates the current state of the page against a specific question.
+   * Expects a JSON object response: { "evaluation": "YES" | "NO", "reasoning": "..." }
+   * Returns the evaluation result with normalized response and success status.
+   *
+   * @param options - The options for evaluation
+   * @returns A promise that resolves to an EvaluationResult
+   * @throws Error if strictResponse is true and response is not clearly YES or NO, or if JSON parsing/validation fails.
+   */
+  async evaluate(options: EvaluateOptions): Promise<EvaluationResult> {
+    const {
+      question,
+      systemPrompt = `You are an expert evaluator that confidently returns YES or NO given the state of a task (most times in the form of a screenshot) and a question. Provide a detailed reasoning for your answer.
+          Return your response as a JSON object with the following format:
+          { "evaluation": "YES" | "NO", "reasoning": "detailed reasoning for your answer" }`,
+      screenshotDelayMs = 1000,
+      strictResponse = false,
+    } = options;
+
+    await new Promise((resolve) => setTimeout(resolve, screenshotDelayMs));
+    const imageBuffer = await this.stagehand.page.screenshot();
+    const llmClient = this.stagehand.llmProvider.getClient(
+      this.modelName,
+      this.modelClientOptions,
+    );
+
+    const response = await llmClient.createChatCompletion({
+      logger: () => {},
+      options: {
+        messages: [
+          { role: "system", content: systemPrompt },
+          { role: "user", content: question },
+        ],
+        image: { buffer: imageBuffer },
+      },
+    });
+
+    const rawResponse = response.choices[0].message.content;
+    let evaluationResult: "YES" | "NO" | "INVALID" = "INVALID";
+    let reasoning = `Failed to process response. Raw response: ${rawResponse}`;
+
+    try {
+      // Clean potential markdown fences
+      const cleanedResponse = rawResponse
+        .replace(/^```json\s*/, "")
+        .replace(/\s*```$/, "")
+        .trim();
+
+      // Attempt to parse the JSON object
+      const parsedResult: { evaluation: unknown; reasoning: unknown } =
+        JSON.parse(cleanedResponse);
+
+      // Validate structure
+      if (
+        typeof parsedResult !== "object" ||
+        parsedResult === null ||
+        typeof parsedResult.evaluation !== "string" ||
+        typeof parsedResult.reasoning !== "string"
+      ) {
+        throw new Error(
+          `Invalid JSON structure received: ${JSON.stringify(parsedResult)}`,
+        );
+      }
+
+      const evaluationString = parsedResult.evaluation.trim().toUpperCase();
+      reasoning = parsedResult.reasoning.trim(); // Update reasoning from parsed object
+
+      // Use regex patterns to validate the evaluation string
+      const isYes = this.yesPattern.test(evaluationString);
+      const isNo = this.noPattern.test(evaluationString);
+
+      if (isYes) {
+        evaluationResult = "YES";
+      } else if (isNo) {
+        evaluationResult = "NO";
+      } else {
+        // Parsed JSON but evaluation value wasn't YES/NO variant
+        if (strictResponse) {
+          throw new Error(
+            `Invalid evaluation value in JSON: ${parsedResult.evaluation}`,
+          );
+        }
+        // Keep INVALID, reasoning already updated
+        reasoning = `Invalid evaluation value: ${parsedResult.evaluation}. Reasoning: ${reasoning}`;
+      }
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      console.error("Failed during evaluation processing:", errorMessage);
+      // Update reasoning with error details
+      reasoning = `Processing error: ${errorMessage}. Raw response: ${rawResponse}`;
+      if (strictResponse) {
+        // Re-throw error if in strict mode
+        throw new Error(reasoning);
+      }
+      // Keep evaluationResult as "INVALID"
+    }
+
+    return {
+      evaluation: evaluationResult,
+      reasoning: reasoning,
+    };
+  }
+
+  /**
+   * Evaluates the current state of the page against multiple questions in a single screenshot.
+   * Returns an array of evaluation results.
+   *
+   * @param options - The options for batch evaluation
+   * @returns A promise that resolves to an array of EvaluationResults
+   * @throws Error if strictResponse is true and any response is not clearly YES or NO
+   */
+  async batchEvaluate(
+    options: BatchEvaluateOptions,
+  ): Promise<EvaluationResult[]> {
+    const {
+      questions,
+      systemPrompt = `You are an expert evaluator that confidently returns YES or NO for each question given the state of a task in the screenshot. Provide a detailed reasoning for your answer.
+          Return your response as a JSON array, where each object corresponds to a question and has the following format:
+          { "evaluation": "YES" | "NO", "reasoning": "detailed reasoning for your answer" }`,
+      screenshotDelayMs = 1000,
+      strictResponse = false,
+    } = options;
+
+    // Wait for the specified delay before taking screenshot
+    await new Promise((resolve) => setTimeout(resolve, screenshotDelayMs));
+
+    // Take a screenshot of the current page state
+    const imageBuffer = await this.stagehand.page.screenshot();
+
+    // Create a numbered list of questions for the VLM
+    const formattedQuestions = questions
+      .map((q, i) => `${i + 1}. ${q}`)
+      .join("\n");
+
+    // Get the LLM client with our preferred model
+    const llmClient = this.stagehand.llmProvider.getClient(
+      this.modelName,
+      this.modelClientOptions,
+    );
+
+    // Use the model-specific LLM client to evaluate the screenshot with all questions
+    const response = await llmClient.createChatCompletion({
+      logger: () => {},
+      options: {
+        messages: [
+          {
+            role: "system",
+            content: `${systemPrompt}\n\nYou will be given multiple questions. Answer each question by returning an object in the specified JSON format. Return a single JSON array containing one object for each question in the order they were asked.`,
+          },
+          {
+            role: "user",
+            content: formattedQuestions,
+          },
+        ],
+        image: {
+          buffer: imageBuffer,
+        },
+      },
+    });
+
+    const rawResponse = response.choices[0].message.content;
+    const finalResults: EvaluationResult[] = [];
+
+    try {
+      // Clean potential markdown fences
+      const cleanedResponse = rawResponse
+        .replace(/^```json\s*/, "")
+        .replace(/\s*```$/, "")
+        .trim();
+
+      // Attempt to parse the JSON array
+      const parsedResults: { evaluation: unknown; reasoning: unknown }[] =
+        JSON.parse(cleanedResponse);
+
+      if (!Array.isArray(parsedResults)) {
+        throw new Error("Response is not a JSON array.");
+      }
+
+      if (parsedResults.length !== questions.length && strictResponse) {
+        // Optional: Log a warning even if not strict?
+        // console.warn(`LLM returned ${parsedResults.length} results, but ${questions.length} questions were asked.`);
+        throw new Error(
+          `Expected ${questions.length} results, but got ${parsedResults.length}`,
+        );
+      }
+
+      for (let i = 0; i < questions.length; i++) {
+        if (i < parsedResults.length) {
+          const item = parsedResults[i];
+          // Ensure item is an object and has the required properties
+          if (
+            typeof item !== "object" ||
+            item === null ||
+            typeof item.evaluation !== "string" ||
+            typeof item.reasoning !== "string"
+          ) {
+            if (strictResponse) {
+              throw new Error(
+                `Invalid object structure for question ${i + 1}: ${JSON.stringify(item)}`,
+              );
+            }
+            finalResults.push({
+              evaluation: "INVALID",
+              reasoning: `Invalid object structure received: ${JSON.stringify(
+                item,
+              )}`,
+            });
+            continue; // Move to the next question
+          }
+
+          // Use regex patterns for validation
+          const evaluationString = item.evaluation.trim().toUpperCase();
+          const reasoning = item.reasoning.trim();
+          const isYes = this.yesPattern.test(evaluationString);
+          const isNo = this.noPattern.test(evaluationString);
+
+          if (isYes) {
+            finalResults.push({ evaluation: "YES", reasoning: reasoning });
+          } else if (isNo) {
+            finalResults.push({ evaluation: "NO", reasoning: reasoning });
+          } else {
+            // Invalid evaluation value
+            if (strictResponse) {
+              throw new Error(
+                `Invalid evaluation value for question ${i + 1}: ${item.evaluation}`,
+              );
+            }
+            finalResults.push({
+              evaluation: "INVALID",
+              reasoning: `Invalid evaluation value: ${item.evaluation}. Reasoning: ${reasoning}`,
+            });
+          }
+        } else {
+          // Missing result for this question
+          if (strictResponse) {
+            throw new Error(`No response found for question ${i + 1}`);
+          }
+          finalResults.push({
+            evaluation: "INVALID",
+            reasoning: "No response found for this question.",
+          });
+        }
+      }
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      console.error("Failed to parse LLM response as JSON:", errorMessage);
+      // If JSON parsing fails or structure is wrong, handle based on strictResponse
+      if (strictResponse) {
+        throw new Error(
+          `Failed to parse LLM response or invalid format: ${rawResponse}. Error: ${errorMessage}`,
+        );
+      }
+      // Fallback: return INVALID for all questions
+      finalResults.length = 0; // Clear any potentially partially filled results
+      for (let i = 0; i < questions.length; i++) {
+        finalResults.push({
+          evaluation: "INVALID",
+          reasoning: `Failed to parse response. Raw response: ${rawResponse}. Error: ${errorMessage}`,
+        });
+      }
+    }
+
+    return finalResults;
+  }
+}

--- a/evals/index.eval.ts
+++ b/evals/index.eval.ts
@@ -163,20 +163,12 @@ const generateFilteredTestcases = (): Testcase[] => {
       console.log(
         `Task ${filterByEvalName} is agent-specific, using agent models.`,
       );
-    } else if (taskCategories.includes("agent")) {
-      // If it's in multiple categories including agent, we might still want agent models?
-      // For now, let's stick to default if it's multi-category unless --category=agent is explicitly passed.
-      // If effectiveCategory wasn't set by the command line, it remains null here.
-      console.log(
-        `Task ${filterByEvalName} includes 'agent' but has other categories. Using default models unless --category=agent was specified.`,
-      );
     }
   } else if (filterByCategory) {
     // If filtering by category, get all tasks in that category
     taskNamesToRun = Object.keys(tasksByName).filter((name) =>
       tasksByName[name].categories.includes(filterByCategory!),
     );
-    // effectiveCategory is already set from the command line
   } else {
     // If no specific task or category filter, run tasks from default categories
     taskNamesToRun = Object.keys(tasksByName).filter((name) =>
@@ -184,7 +176,6 @@ const generateFilteredTestcases = (): Testcase[] => {
         tasksByName[name].categories.includes(category),
       ),
     );
-    // effectiveCategory remains null, so default models will be used
   }
 
   // Dynamically determine the MODELS based on the effective category
@@ -216,9 +207,7 @@ const generateFilteredTestcases = (): Testcase[] => {
     })),
   );
 
-  // This filtering step might now be redundant if taskNamesToRun is already filtered,
-  // but keeping it ensures consistency if the logic above changes.
-  // Filter by category if a category is specified (applies AFTER model selection)
+  // This filtering step might now be redundant if taskNamesToRun is already filtered
   if (filterByCategory) {
     allTestcases = allTestcases.filter((testcase) =>
       tasksByName[testcase.name].categories.includes(filterByCategory!),

--- a/evals/initStagehand.ts
+++ b/evals/initStagehand.ts
@@ -14,6 +14,7 @@ import { enableCaching, env } from "./env";
 import { ConstructorParams, LLMClient, Stagehand } from "@/dist";
 import { EvalLogger } from "./logger";
 import type { StagehandInitResult } from "@/types/evals";
+import { AvailableModel } from "@/dist";
 
 /**
  * StagehandConfig:
@@ -53,6 +54,7 @@ export const initStagehand = async ({
   configOverrides,
   actTimeoutMs,
   useTextExtract,
+  modelName,
 }: {
   llmClient: LLMClient;
   domSettleTimeoutMs?: number;
@@ -60,6 +62,7 @@ export const initStagehand = async ({
   configOverrides?: Partial<ConstructorParams>;
   actTimeoutMs?: number;
   useTextExtract?: boolean;
+  modelName: AvailableModel;
 }): Promise<StagehandInitResult> => {
   const config = {
     ...StagehandConfig,
@@ -83,5 +86,6 @@ export const initStagehand = async ({
     debugUrl,
     sessionUrl,
     useTextExtract,
+    modelName,
   };
 };

--- a/evals/initStagehand.ts
+++ b/evals/initStagehand.ts
@@ -34,6 +34,15 @@ const StagehandConfig = {
   enableCaching,
   domSettleTimeoutMs: 30_000,
   disablePino: true,
+  browserbaseSessionCreateParams: {
+    projectId: process.env.BROWSERBASE_PROJECT_ID!,
+    browserSettings: {
+      viewport: {
+        width: 1024,
+        height: 768,
+      },
+    },
+  },
 };
 
 /**

--- a/evals/taskConfig.ts
+++ b/evals/taskConfig.ts
@@ -97,44 +97,65 @@ const DEFAULT_EVAL_MODELS = process.env.EVAL_MODELS
   ? process.env.EVAL_MODELS.split(",")
   : ["claude-3-5-sonnet-latest", "gpt-4o-mini", "gpt-4o"];
 
+const DEFAULT_AGENT_MODELS = process.env.EVAL_AGENT_MODELS
+  ? process.env.EVAL_AGENT_MODELS.split(",")
+  : ["computer-use-preview", "claude-3-7-sonnet-20250219"];
+
 /**
  * getModelList:
  * Returns a list of models to be used for the given category.
  * If category is "experimental", it merges DEFAULT_EVAL_MODELS and EXPERIMENTAL_EVAL_MODELS.
  * Otherwise, returns DEFAULT_EVAL_MODELS filtered by provider if specified.
  */
-const getModelList = (): string[] => {
+const getModelList = (category?: string): string[] => {
   const provider = process.env.EVAL_PROVIDER?.toLowerCase();
 
-  if (!provider) {
-    return DEFAULT_EVAL_MODELS;
+  if (category === "agent") {
+    return DEFAULT_AGENT_MODELS;
   }
 
-  return ALL_EVAL_MODELS.filter((model) => {
-    const modelLower = model.toLowerCase();
-    if (provider === "openai") {
-      return modelLower.startsWith("gpt");
-    } else if (provider === "anthropic") {
-      return modelLower.startsWith("claude");
-    } else if (provider === "google") {
-      return modelLower.startsWith("gemini");
-    } else if (provider === "together") {
-      return (
-        modelLower.startsWith("meta-llama") ||
-        modelLower.startsWith("llama") ||
-        modelLower.startsWith("deepseek") ||
-        modelLower.startsWith("qwen")
-      );
-    } else if (provider === "groq") {
-      return modelLower.startsWith("groq");
-    } else if (provider === "cerebras") {
-      return modelLower.startsWith("cerebras");
-    }
-    return true;
-  });
+  if (provider) {
+    return ALL_EVAL_MODELS.filter((model) =>
+      filterModelByProvider(model, provider),
+    );
+  }
+
+  // If no agent category and no provider, return default eval models
+  return DEFAULT_EVAL_MODELS;
 };
+
+// Helper function to contain the provider filtering logic
+const filterModelByProvider = (model: string, provider: string): boolean => {
+  const modelLower = model.toLowerCase();
+  if (provider === "openai") {
+    return modelLower.startsWith("gpt");
+  } else if (provider === "anthropic") {
+    return modelLower.startsWith("claude");
+  } else if (provider === "google") {
+    return modelLower.startsWith("gemini");
+  } else if (provider === "together") {
+    return (
+      modelLower.startsWith("meta-llama") ||
+      modelLower.startsWith("llama") ||
+      modelLower.startsWith("deepseek") ||
+      modelLower.startsWith("qwen")
+    );
+  } else if (provider === "groq") {
+    return modelLower.startsWith("groq");
+  } else if (provider === "cerebras") {
+    return modelLower.startsWith("cerebras");
+  }
+  // If provider doesn't match known ones, maybe return all? Or throw error?
+  // For now, let's assume if provider is specified, it must match.
+  // Returning false if provider is unknown or model doesn't match.
+  console.warn(
+    `Unknown provider specified or model doesn't match: ${provider}`,
+  );
+  return false; // Or true if you want unmatched providers to allow all models
+};
+
 const MODELS: AvailableModel[] = getModelList().map((model) => {
   return model as AvailableModel;
 });
 
-export { tasksByName, MODELS, tasksConfig };
+export { tasksByName, MODELS, tasksConfig, getModelList };

--- a/evals/taskConfig.ts
+++ b/evals/taskConfig.ts
@@ -145,13 +145,10 @@ const filterModelByProvider = (model: string, provider: string): boolean => {
   } else if (provider === "cerebras") {
     return modelLower.startsWith("cerebras");
   }
-  // If provider doesn't match known ones, maybe return all? Or throw error?
-  // For now, let's assume if provider is specified, it must match.
-  // Returning false if provider is unknown or model doesn't match.
   console.warn(
     `Unknown provider specified or model doesn't match: ${provider}`,
   );
-  return false; // Or true if you want unmatched providers to allow all models
+  return false;
 };
 
 const MODELS: AvailableModel[] = getModelList().map((model) => {

--- a/evals/tasks/agent/google_flights.ts
+++ b/evals/tasks/agent/google_flights.ts
@@ -1,0 +1,62 @@
+import { EvalFunction } from "@/types/evals";
+import { Evaluator } from "../../evaluator";
+
+export const google_flights: EvalFunction = async ({
+  debugUrl,
+  sessionUrl,
+  stagehand,
+  logger,
+  modelName,
+}) => {
+  await stagehand.page.goto("https://google.com/travel/flights");
+
+  const agent = stagehand.agent({
+    model: modelName,
+    provider: modelName.startsWith("claude") ? "anthropic" : "openai",
+    instructions: `You are a helpful assistant that can help me with my tasks. Today is ${new Date().toISOString().slice(0, 10)}. The current page is ${await stagehand.page.title()}`,
+  });
+
+  const agentResult = await agent.execute({
+    instruction:
+      "Search for flights from San Francisco to New York for next weekend",
+    maxSteps: 15,
+  });
+  logger.log(agentResult);
+
+  const evaluator = new Evaluator(stagehand);
+  const result = await evaluator.evaluate({
+    question: "Does the page show flights from San Francisco to New York?",
+    strictResponse: true,
+  });
+
+  if (result.evaluation !== "YES" && result.evaluation !== "NO") {
+    await stagehand.close();
+    return {
+      _success: false,
+      observations: "Evaluator provided an invalid response",
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
+  }
+
+  if (result.evaluation === "YES") {
+    await stagehand.close();
+    return {
+      _success: true,
+      observations: result.reasoning,
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
+  } else {
+    await stagehand.close();
+    return {
+      _success: false,
+      observations: result.reasoning,
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
+  }
+};

--- a/evals/tasks/agent/google_flights.ts
+++ b/evals/tasks/agent/google_flights.ts
@@ -25,7 +25,8 @@ export const google_flights: EvalFunction = async ({
 
   const evaluator = new Evaluator(stagehand);
   const result = await evaluator.evaluate({
-    question: "Does the page show flights (options, available flights, not a search form) from San Francisco to New York?",
+    question:
+      "Does the page show flights (options, available flights, not a search form) from San Francisco to New York?",
     strictResponse: true,
   });
 

--- a/evals/tasks/agent/google_flights.ts
+++ b/evals/tasks/agent/google_flights.ts
@@ -13,7 +13,7 @@ export const google_flights: EvalFunction = async ({
   const agent = stagehand.agent({
     model: modelName,
     provider: modelName.startsWith("claude") ? "anthropic" : "openai",
-    instructions: `You are a helpful assistant that can help me with my tasks. Today is ${new Date().toISOString().slice(0, 10)}. The current page is ${await stagehand.page.title()}`,
+    instructions: `You are a helpful assistant that can help me with my tasks. You are given a task and you need to complete it without asking follow up questions. Today is ${new Date().toISOString().slice(0, 10)}. The current page is ${await stagehand.page.title()}`,
   });
 
   const agentResult = await agent.execute({
@@ -25,7 +25,7 @@ export const google_flights: EvalFunction = async ({
 
   const evaluator = new Evaluator(stagehand);
   const result = await evaluator.evaluate({
-    question: "Does the page show flights from San Francisco to New York?",
+    question: "Does the page show flights (options, available flights, not a search form) from San Francisco to New York?",
     strictResponse: true,
   });
 

--- a/evals/tasks/agent/iframe_form.ts
+++ b/evals/tasks/agent/iframe_form.ts
@@ -21,6 +21,7 @@ export const iframe_form: EvalFunction = async ({
   });
   logger.log(agentResult);
 
+  await stagehand.page.mouse.wheel(0, -1000);
   const evaluator = new Evaluator(stagehand);
   const result = await evaluator.evaluate({
     question: "Is the form name input filled with 'John Smith'?",
@@ -44,6 +45,7 @@ export const iframe_form: EvalFunction = async ({
   });
   logger.log(agentResult2);
 
+  await stagehand.page.mouse.wheel(0, -1000);
   const result2 = await evaluator.evaluate({
     question: "Is the form email input filled with 'john.smith@example.com'?",
     strictResponse: true,

--- a/evals/tasks/agent/iframe_form.ts
+++ b/evals/tasks/agent/iframe_form.ts
@@ -1,0 +1,82 @@
+import { EvalFunction } from "@/types/evals";
+import { Evaluator } from "../../evaluator";
+
+export const iframe_form: EvalFunction = async ({
+  debugUrl,
+  sessionUrl,
+  stagehand,
+  logger,
+  modelName,
+}) => {
+  await stagehand.page.goto("https://tucowsdomains.com/abuse-form/phishing/");
+
+  const agent = stagehand.agent({
+    provider: "anthropic",
+    model: modelName,
+  });
+
+  const agentResult = await agent.execute({
+    instruction: "Fill in the form name with 'John Smith'",
+    maxSteps: 3,
+  });
+  logger.log(agentResult);
+
+  const evaluator = new Evaluator(stagehand);
+  const result = await evaluator.evaluate({
+    question: "Is the form name input filled with 'John Smith'?",
+    strictResponse: true,
+  });
+
+  if (result.evaluation !== "YES" && result.evaluation !== "NO") {
+    await stagehand.close();
+    return {
+      _success: false,
+      observations: "Evaluator provided an invalid response",
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
+  }
+
+  const agentResult2 = await agent.execute({
+    instruction: "Fill in the form email with 'john.smith@example.com'",
+    maxSteps: 3,
+  });
+  logger.log(agentResult2);
+
+  const result2 = await evaluator.evaluate({
+    question: "Is the form email input filled with 'john.smith@example.com'?",
+    strictResponse: true,
+  });
+
+  if (result2.evaluation !== "YES" && result2.evaluation !== "NO") {
+    await stagehand.close();
+    return {
+      _success: false,
+      observations: "Evaluator provided an invalid response",
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
+  }
+
+  if (result.evaluation === "YES" && result2.evaluation === "YES") {
+    await stagehand.close();
+    return {
+      _success: true,
+      observations: "All fields were filled correctly",
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
+  } else {
+    await stagehand.close();
+    return {
+      _success: false,
+      observations: "One or more fields were not filled correctly",
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
+  }
+};

--- a/evals/tasks/agent/iframe_form_multiple.ts
+++ b/evals/tasks/agent/iframe_form_multiple.ts
@@ -22,6 +22,7 @@ export const iframe_form_multiple: EvalFunction = async ({
   });
   logger.log(agentResult);
 
+  await stagehand.page.mouse.wheel(0, -1000);
   const evaluator = new Evaluator(stagehand);
   const results = await evaluator.batchEvaluate({
     questions: [

--- a/evals/tasks/agent/iframe_form_multiple.ts
+++ b/evals/tasks/agent/iframe_form_multiple.ts
@@ -34,7 +34,6 @@ export const iframe_form_multiple: EvalFunction = async ({
   });
 
   for (const r of results) {
-    console.log("\n\n\nr", r);
     if (r.evaluation !== "YES" && r.evaluation !== "NO") {
       await stagehand.close();
       return {

--- a/evals/tasks/agent/iframe_form_multiple.ts
+++ b/evals/tasks/agent/iframe_form_multiple.ts
@@ -1,0 +1,67 @@
+import { EvalFunction } from "@/types/evals";
+import { Evaluator } from "../../evaluator";
+
+export const iframe_form_multiple: EvalFunction = async ({
+  debugUrl,
+  sessionUrl,
+  stagehand,
+  logger,
+  modelName,
+}) => {
+  await stagehand.page.goto("https://tucowsdomains.com/abuse-form/phishing/");
+
+  const agent = stagehand.agent({
+    provider: modelName.startsWith("claude") ? "anthropic" : "openai",
+    model: modelName,
+  });
+
+  const agentResult = await agent.execute({
+    instruction:
+      "Fill in the form name with 'John Smith', the email with 'john.smith@example.com', and select the 'Are you the domain owner?' option as 'No'",
+    maxSteps: 10,
+  });
+  logger.log(agentResult);
+
+  const evaluator = new Evaluator(stagehand);
+  const results = await evaluator.batchEvaluate({
+    questions: [
+      "Is the form name input filled with 'John Smith'?",
+      "Is the form email input filled with 'john.smith@example.com'?",
+      "Is the 'Are you the domain owner?' option selected as 'No'?",
+    ],
+    strictResponse: true,
+  });
+
+  for (const r of results) {
+    console.log("\n\n\nr", r);
+    if (r.evaluation !== "YES" && r.evaluation !== "NO") {
+      await stagehand.close();
+      return {
+        _success: false,
+        observations: "Evaluator provided an invalid response",
+        debugUrl,
+        sessionUrl,
+        logs: logger.getLogs(),
+      };
+    }
+    if (r.evaluation === "NO") {
+      await stagehand.close();
+      return {
+        _success: false,
+        observations: r.reasoning,
+        debugUrl,
+        sessionUrl,
+        logs: logger.getLogs(),
+      };
+    }
+  }
+
+  await stagehand.close();
+  return {
+    _success: true,
+    observations: "All fields were filled correctly",
+    debugUrl,
+    sessionUrl,
+    logs: logger.getLogs(),
+  };
+};

--- a/evals/tasks/agent/sf_library_card.ts
+++ b/evals/tasks/agent/sf_library_card.ts
@@ -13,7 +13,7 @@ export const sf_library_card: EvalFunction = async ({
   const agent = stagehand.agent({
     model: modelName,
     provider: modelName.startsWith("claude") ? "anthropic" : "openai",
-    instructions: `You are a helpful assistant that can help me with my tasks. The current page is ${await stagehand.page.title()}`,
+    instructions: `You are a helpful assistant that can help me with my tasks. You are given a task and you need to complete it without asking follow up questions. The current page is ${await stagehand.page.title()}`,
   });
 
   const agentResult = await agent.execute({
@@ -22,6 +22,7 @@ export const sf_library_card: EvalFunction = async ({
   });
   logger.log(agentResult);
 
+  await stagehand.page.mouse.wheel(0, -1000);
   const evaluator = new Evaluator(stagehand);
   const result = await evaluator.evaluate({
     question:

--- a/evals/tasks/agent/sf_library_card.ts
+++ b/evals/tasks/agent/sf_library_card.ts
@@ -1,0 +1,62 @@
+import { EvalFunction } from "@/types/evals";
+import { Evaluator } from "../../evaluator";
+
+export const sf_library_card: EvalFunction = async ({
+  debugUrl,
+  sessionUrl,
+  stagehand,
+  logger,
+  modelName,
+}) => {
+  await stagehand.page.goto("https://sflib1.sfpl.org/selfreg");
+
+  const agent = stagehand.agent({
+    model: modelName,
+    provider: modelName.startsWith("claude") ? "anthropic" : "openai",
+    instructions: `You are a helpful assistant that can help me with my tasks. The current page is ${await stagehand.page.title()}`,
+  });
+
+  const agentResult = await agent.execute({
+    instruction: "Fill in the 'Residential Address' field with '166 Geary St'",
+    maxSteps: 3,
+  });
+  logger.log(agentResult);
+
+  const evaluator = new Evaluator(stagehand);
+  const result = await evaluator.evaluate({
+    question:
+      "Does the page show the 'Residential Address' field filled with '166 Geary St'?",
+    strictResponse: true,
+  });
+
+  if (result.evaluation !== "YES" && result.evaluation !== "NO") {
+    await stagehand.close();
+    return {
+      _success: false,
+      observations: "Evaluator provided an invalid response",
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
+  }
+
+  if (result.evaluation === "YES") {
+    await stagehand.close();
+    return {
+      _success: true,
+      observations: result.reasoning,
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
+  } else {
+    await stagehand.close();
+    return {
+      _success: false,
+      observations: result.reasoning,
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
+  }
+};

--- a/evals/tasks/agent/sf_library_card_multiple.ts
+++ b/evals/tasks/agent/sf_library_card_multiple.ts
@@ -1,0 +1,62 @@
+import { EvalFunction } from "@/types/evals";
+import { Evaluator } from "../../evaluator";
+
+export const sf_library_card_multiple: EvalFunction = async ({
+  debugUrl,
+  sessionUrl,
+  stagehand,
+  logger,
+  modelName,
+}) => {
+  await stagehand.page.goto("https://sflib1.sfpl.org/selfreg");
+
+  const agent = stagehand.agent({
+    model: modelName,
+    provider: modelName.startsWith("claude") ? "anthropic" : "openai",
+    instructions: `You are a helpful assistant that can help me with my tasks. The current page is ${await stagehand.page.title()}`,
+  });
+
+  const agentResult = await agent.execute({
+    instruction:
+      "Fill in ALL the required fields with mock data. DO NOT submit the form",
+    maxSteps: 15,
+  });
+  logger.log(agentResult);
+
+  const evaluator = new Evaluator(stagehand);
+  const result = await evaluator.evaluate({
+    question: "Does the page show all the required fields filled?",
+    strictResponse: true,
+  });
+
+  if (result.evaluation !== "YES" && result.evaluation !== "NO") {
+    await stagehand.close();
+    return {
+      _success: false,
+      observations: "Evaluator provided an invalid response",
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
+  }
+
+  if (result.evaluation === "YES") {
+    await stagehand.close();
+    return {
+      _success: true,
+      observations: result.reasoning,
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
+  } else {
+    await stagehand.close();
+    return {
+      _success: false,
+      observations: result.reasoning,
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
+  }
+};

--- a/evals/tasks/agent/sf_library_card_multiple.ts
+++ b/evals/tasks/agent/sf_library_card_multiple.ts
@@ -13,13 +13,13 @@ export const sf_library_card_multiple: EvalFunction = async ({
   const agent = stagehand.agent({
     model: modelName,
     provider: modelName.startsWith("claude") ? "anthropic" : "openai",
-    instructions: `You are a helpful assistant that can help me with my tasks. The current page is ${await stagehand.page.title()}`,
+    instructions: `You are a helpful assistant that can help me with my tasks. You are given a task and you need to complete it without asking follow up questions. The current page is ${await stagehand.page.title()}`,
   });
 
   const agentResult = await agent.execute({
     instruction:
       "Fill in ALL the required fields with mock data. DO NOT submit the form",
-    maxSteps: 15,
+    maxSteps: 20,
   });
   logger.log(agentResult);
 

--- a/lib/llm/LLMClient.ts
+++ b/lib/llm/LLMClient.ts
@@ -48,7 +48,7 @@ export interface ChatCompletionOptions {
   tools?: LLMTool[];
   tool_choice?: "auto" | "none" | "required";
   maxTokens?: number;
-  requestId: string;
+  requestId?: string;
 }
 
 export type LLMResponse = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@browserbasehq/stagehand",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@browserbasehq/stagehand",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.39.0",

--- a/types/evals.ts
+++ b/types/evals.ts
@@ -13,6 +13,7 @@ export type StagehandInitResult = {
   sessionUrl: string;
   useTextExtract: boolean;
   stagehandConfig: ConstructorParams;
+  modelName: AvailableModel;
 };
 
 export type EvalFunction = (taskInput: StagehandInitResult) => Promise<{
@@ -34,6 +35,7 @@ export const EvalCategorySchema = z.enum([
   "regression",
   "regression_llm_providers",
   "llm_clients",
+  "agent",
 ]);
 
 export type EvalCategory = z.infer<typeof EvalCategorySchema>;

--- a/types/evaluator.ts
+++ b/types/evaluator.ts
@@ -1,0 +1,59 @@
+export interface EvaluateOptions {
+  /**
+   * The question to ask about the task state
+   */
+  question: string;
+  /**
+   * Custom system prompt for the evaluator
+   */
+  systemPrompt?: string;
+  /**
+   * Delay in milliseconds before taking the screenshot
+   * @default 1000
+   */
+  screenshotDelayMs?: number;
+  /**
+   * Whether to throw an error if the response is not a clear YES or NO
+   * @default false
+   */
+  strictResponse?: boolean;
+}
+
+export interface BatchEvaluateOptions {
+  /**
+   * Array of questions to evaluate
+   */
+  questions: string[];
+  /**
+   * Custom system prompt for the evaluator
+   */
+  systemPrompt?: string;
+  /**
+   * Delay in milliseconds before taking the screenshot
+   * @default 1000
+   */
+  screenshotDelayMs?: number;
+  /**
+   * Whether to throw an error if any response is not a clear YES or NO
+   * @default false
+   */
+  strictResponse?: boolean;
+  /**
+   * The reasoning behind the evaluation
+   */
+  reasoning?: string;
+}
+
+/**
+ * Result of an evaluation
+ */
+export interface EvaluationResult {
+  /**
+   * The evaluation result ('YES', 'NO', or 'INVALID' if parsing failed or value was unexpected)
+   */
+  evaluation: "YES" | "NO" | "INVALID";
+  /**
+   * The reasoning behind the evaluation
+   */
+  reasoning: string;
+}

--- a/types/stagehandErrors.ts
+++ b/types/stagehandErrors.ts
@@ -155,3 +155,9 @@ export class StagehandClickError extends StagehandError {
     );
   }
 }
+
+export class LLMResponseError extends StagehandError {
+  constructor(primitive: string, message: string) {
+    super(`${primitive} LLM response error: ${message}`);
+  }
+}


### PR DESCRIPTION
# why
Deterministic evals require high maintenance. A balanced approach is what most frontier labs use for evaluating models: **_LLMs as judges_.** Although not as deterministic as our current evals, this new category scales better while randomizing the potential judging error. Introducing:
### Stagehand Evaluator

# what changed
Created a new class `Evaluator` which reuses a stagehand object to leverage the `llmClient` functionality, sending a screenshot (currently, maybe text-only in the future) asking a question or set of questions (batch). 

Example usage:
```ts
  const evaluator = new Evaluator(stagehand);

  // single evaluation
  const result = await evaluator.evaluate({
    question: "Is the form name input filled with 'John Smith'?"
  });

  // batch evaluate
  const results = await evaluator.batchEvaluate({
    questions: [
      "Is the form name input filled with 'John Smith'?",
      "Is the form email input filled with 'john.smith@example.com'?",
      "Is the 'Are you the domain owner?' option selected as 'No'?",
    ],
    strictResponse: true, // whether or not to throw an error on evaulations !== YES | NO
  });
```

Evaluator will then return a response in the following format:
```
{
   evaluation: "YES" | "NO",
   reasoning:  "reasoning about the evaluation process"
}
```

Also added a few evals for agent that use `Evaluator` as the judge

# test plan
- [x] Tested with local evals
- [x] Tested with BB evals
