### PR TITLE
default to stagehand LLM clients for evals

### DIFF
--- a/evals/args.ts
+++ b/evals/args.ts
@@ -32,7 +32,7 @@ for (const arg of rawArgs) {
     parsedArgs.extractMethod = arg.split("=")[1];
   } else if (arg.startsWith("provider=")) {
     parsedArgs.provider = arg.split("=")[1]?.toLowerCase();
-  } else if (arg.startsWith("-useExternalClients=")) {
+  } else if (arg.startsWith("useExternalClients=")) {
     const val = arg.split("=")[1]?.toLowerCase();
     parsedArgs.useExternalClients = val === "true";
   } else {

--- a/evals/args.ts
+++ b/evals/args.ts
@@ -32,7 +32,7 @@ for (const arg of rawArgs) {
     parsedArgs.extractMethod = arg.split("=")[1];
   } else if (arg.startsWith("provider=")) {
     parsedArgs.provider = arg.split("=")[1]?.toLowerCase();
-  } else if (arg.startsWith("--useExternalClients=")) {
+  } else if (arg.startsWith("-useExternalClients=")) {
     const val = arg.split("=")[1]?.toLowerCase();
     parsedArgs.useExternalClients = val === "true";
   } else {

--- a/evals/args.ts
+++ b/evals/args.ts
@@ -9,6 +9,7 @@ const parsedArgs: {
   concurrency?: number;
   extractMethod?: string;
   provider?: string;
+  useExternalClients?: boolean;
   leftover: string[];
 } = {
   leftover: [],
@@ -31,6 +32,9 @@ for (const arg of rawArgs) {
     parsedArgs.extractMethod = arg.split("=")[1];
   } else if (arg.startsWith("provider=")) {
     parsedArgs.provider = arg.split("=")[1]?.toLowerCase();
+  } else if (arg.startsWith("--useExternalClients=")) {
+    const val = arg.split("=")[1]?.toLowerCase();
+    parsedArgs.useExternalClients = val === "true";
   } else {
     parsedArgs.leftover.push(arg);
   }

--- a/evals/index.eval.ts
+++ b/evals/index.eval.ts
@@ -274,8 +274,6 @@ const generateFilteredTestcases = (): Testcase[] => {
             openAiKey: process.env.OPENAI_API_KEY,
             googleKey: process.env.GOOGLE_API_KEY,
             anthropicKey: process.env.ANTHROPIC_API_KEY,
-            groqKey: process.env.GROQ_API_KEY,
-            cerebrasKey: process.env.CEREBRAS_API_KEY,
             togetherKey: process.env.TOGETHER_AI_API_KEY,
           });
           const taskInput = await initStagehand({

--- a/evals/taskConfig.ts
+++ b/evals/taskConfig.ts
@@ -95,7 +95,7 @@ if (filterByEvalName && !tasksByName[filterByEvalName]) {
  */
 const DEFAULT_EVAL_MODELS = process.env.EVAL_MODELS
   ? process.env.EVAL_MODELS.split(",")
-  : ["gpt-4o-mini"];
+  : ["claude-3-5-sonnet-latest", "gpt-4o-mini", "gpt-4o"];
 
 /**
  * getModelList:

--- a/evals/taskConfig.ts
+++ b/evals/taskConfig.ts
@@ -95,7 +95,7 @@ if (filterByEvalName && !tasksByName[filterByEvalName]) {
  */
 const DEFAULT_EVAL_MODELS = process.env.EVAL_MODELS
   ? process.env.EVAL_MODELS.split(",")
-  : ["claude-3-5-sonnet-latest", "gpt-4o-mini", "gpt-4o"];
+  : ["gpt-4o-mini"];
 
 /**
  * getModelList:

--- a/evals/utils.ts
+++ b/evals/utils.ts
@@ -143,7 +143,8 @@ export function createLLMClient({
   anthropicKey,
   togetherKey,
 }: CreateLLMClientOptions): LLMClient {
-  const isOpenAIModel = modelName.startsWith("gpt");
+  const isOpenAIModel =
+    modelName.startsWith("gpt") || modelName.startsWith("o");
   const isGoogleModel = modelName.startsWith("gemini");
   const isAnthropicModel = modelName.startsWith("claude");
   const isGroqModel = modelName.includes("groq");

--- a/evals/utils.ts
+++ b/evals/utils.ts
@@ -25,6 +25,7 @@ import { AnthropicClient } from "@/lib/llm/AnthropicClient";
 import { GoogleClient } from "@/lib/llm/GoogleClient";
 import { CreateLLMClientOptions } from "@/types/evals";
 import { StagehandEvalError } from "@/types/stagehandErrors";
+import { openai } from "@ai-sdk/openai";
 
 /**
  * normalizeString:
@@ -163,13 +164,8 @@ export function createLLMClient({
           ),
         });
       }
-      return new CustomOpenAIClient({
-        modelName,
-        client: wrapOpenAI(
-          new OpenAI({
-            apiKey: openAiKey,
-          }),
-        ),
+      return new AISdkClient({
+        model: wrapAISDKModel(openai(modelName)),
       });
     } else if (isGoogleModel) {
       return new AISdkClient({

--- a/evals/utils.ts
+++ b/evals/utils.ts
@@ -23,8 +23,6 @@ import { CustomOpenAIClient } from "@/examples/external_clients/customOpenAI";
 import { OpenAIClient } from "@/lib/llm/OpenAIClient";
 import { AnthropicClient } from "@/lib/llm/AnthropicClient";
 import { GoogleClient } from "@/lib/llm/GoogleClient";
-import { GroqClient } from "@/lib/llm/GroqClient";
-import { CerebrasClient } from "@/lib/llm/CerebrasClient";
 import { CreateLLMClientOptions } from "@/types/evals";
 import { StagehandEvalError } from "@/types/stagehandErrors";
 
@@ -143,11 +141,9 @@ export function createLLMClient({
   openAiKey,
   googleKey,
   anthropicKey,
-  groqKey,
-  cerebrasKey,
   togetherKey,
 }: CreateLLMClientOptions): LLMClient {
-  const isOpenAIModel = modelName.startsWith("gpt") || modelName.includes("/");
+  const isOpenAIModel = modelName.startsWith("gpt");
   const isGoogleModel = modelName.startsWith("gemini");
   const isAnthropicModel = modelName.startsWith("claude");
   const isGroqModel = modelName.includes("groq");
@@ -233,24 +229,10 @@ export function createLLMClient({
           apiKey: anthropicKey,
         },
       });
-    } else if (isGroqModel) {
-      return new GroqClient({
-        logger,
-        modelName,
-        enableCaching: false,
-        clientOptions: {
-          apiKey: groqKey,
-        },
-      });
-    } else if (isCerebrasModel) {
-      return new CerebrasClient({
-        logger,
-        modelName,
-        enableCaching: false,
-        clientOptions: {
-          apiKey: cerebrasKey,
-        },
-      });
+    } else if (isGroqModel || isCerebrasModel) {
+      throw new StagehandEvalError(
+        `${modelName} can only be used when useExternalClients=true`,
+      );
     }
     throw new StagehandEvalError(`Unknown modelName: ${modelName}`);
   }

--- a/types/evals.ts
+++ b/types/evals.ts
@@ -80,12 +80,10 @@ export type LogLineEval = LogLine & {
 
 export interface CreateLLMClientOptions {
   modelName: AvailableModel;
-  useExternalClients: boolean;
+  useExternalClients?: boolean;
   logger?: (msg: LogLine) => void;
   openAiKey?: string;
   googleKey?: string;
   anthropicKey?: string;
-  groqKey?: string;
-  cerebrasKey?: string;
   togetherKey?: string;
 }

--- a/types/evals.ts
+++ b/types/evals.ts
@@ -77,3 +77,15 @@ export interface EvalResult {
 export type LogLineEval = LogLine & {
   parsedAuxiliary?: string | object;
 };
+
+export interface CreateLLMClientOptions {
+  modelName: AvailableModel;
+  useExternalClients: boolean;
+  logger?: (msg: LogLine) => void;
+  openAiKey?: string;
+  googleKey?: string;
+  anthropicKey?: string;
+  groqKey?: string;
+  cerebrasKey?: string;
+  togetherKey?: string;
+}


### PR DESCRIPTION
# why
- we shouldn't use aiSDK (or any other external LLM clients) for evals by default, especially not in CI. We should be testing against our own custom clients
- we still want to be able to wrapped external clients so that we can easily get telemetry in braintrust
# what changed
- added a new CLI arg `useExternalClients` that defaults to false. if you want to run evals with external clients (to get telemetry, you can set `useExternalClients=true`
# test plan
- this is it