### PR TITLE
set `force: true` for `locator.fill`

### DIFF
--- a/.changeset/sweet-glasses-hope.md
+++ b/.changeset/sweet-glasses-hope.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+allow form filling when form is not top-most element

--- a/evals/evals.config.json
+++ b/evals/evals.config.json
@@ -317,6 +317,10 @@
     {
       "name": "extract_single_link",
       "categories": ["extract"]
+    },
+    {
+      "name": "dropdown",
+      "categories": ["act"]
     }
   ]
 }

--- a/evals/tasks/dropdown.ts
+++ b/evals/tasks/dropdown.ts
@@ -1,0 +1,37 @@
+import { EvalFunction } from "@/types/evals";
+
+export const dropdown: EvalFunction = async ({
+  debugUrl,
+  sessionUrl,
+  stagehand,
+  logger,
+}) => {
+  await stagehand.page.goto(
+    "https://browserbase.github.io/stagehand-eval-sites/sites/dropdown/",
+  );
+
+  // click the dropdown element to expand it
+  const xpath = "xpath=/html/body/div/div/button";
+  await stagehand.page.locator(xpath).click();
+
+  // type into the input box (which should be hidden behind the
+  // expanded dropdown)
+  await stagehand.page.act("type 'test fill' into the input field");
+
+  const input = stagehand.page.locator(`xpath=/html/body/div/input`);
+  const expectedValue = "test fill";
+
+  // get the value of the input box
+  const actualValue = await input.inputValue();
+  await stagehand.close();
+
+  // pass if the value matches expected
+  return {
+    _success: actualValue === expectedValue,
+    expectedValue,
+    actualValue,
+    debugUrl,
+    sessionUrl,
+    logs: logger.getLogs(),
+  };
+};

--- a/lib/handlers/handlerUtils/actHandlerUtils.ts
+++ b/lib/handlers/handlerUtils/actHandlerUtils.ts
@@ -258,15 +258,9 @@ export async function fillOrType(ctx: MethodHandlerContext) {
   const { locator, xpath, args, logger } = ctx;
 
   try {
-    await locator.fill("");
-    await locator.click();
-
+    await locator.fill("", { force: true });
     const text = args[0]?.toString() || "";
-    for (const char of text) {
-      await locator.page().keyboard.type(char, {
-        delay: Math.random() * 50 + 25,
-      });
-    }
+    await locator.fill(text, { force: true });
   } catch (e) {
     logger({
       category: "action",


### PR DESCRIPTION
# why
- we should still fill input boxes even if they do not pass playwrights built in actionability checks
- e.g., dropdown is expanded, and the element we want to fill is hidden underneath it
# what changed
- set `force: true` inside `locator.fill()`
- removed `keyboard.type()` since it is unlikely to make a difference for antibot
# test plan
- added an eval