### PR TITLE
Fix schema input (response_model) for Google AI client

### DIFF
--- a/.changeset/short-banks-sit.md
+++ b/.changeset/short-banks-sit.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Fixed the schema input for Gemini's response model

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ For more information, please see our [Contributing Guide](https://docs.stagehand
 
 ## Acknowledgements
 
-This project heavily relies on [Playwright](https://playwright.dev/) as a resilient backbone to automate the web. It also would not be possible without the awesome techniques and discoveries made by [tarsier](https://github.com/reworkd/tarsier), and [fuji-web](https://github.com/normal-computing/fuji-web).
+This project heavily relies on [Playwright](https://playwright.dev/) as a resilient backbone to automate the web. It also would not be possible without the awesome techniques and discoveries made by [tarsier](https://github.com/reworkd/tarsier), [gemini-zod](https://github.com/jbeoris/gemini-zod), and [fuji-web](https://github.com/normal-computing/fuji-web).
 
 We'd like to thank the following people for their major contributions to Stagehand:
 - [Paul Klein](https://github.com/pkiv)

--- a/lib/llm/GoogleClient.ts
+++ b/lib/llm/GoogleClient.ts
@@ -14,7 +14,7 @@ import zodToJsonSchema from "zod-to-json-schema";
 import { LogLine } from "../../types/log";
 import { AvailableModel, ClientOptions } from "../../types/model";
 import { LLMCache } from "../cache/LLMCache";
-import { validateZodSchema } from "../utils";
+import { validateZodSchema, toGeminiSchema } from "../utils";
 import {
   ChatCompletionOptions,
   ChatMessage,
@@ -290,24 +290,10 @@ export class GoogleClient extends LLMClient {
       temperature: temperature,
       topP: top_p,
       responseMimeType: response_model ? "application/json" : undefined,
+      responseSchema: response_model
+        ? toGeminiSchema(response_model.schema)
+        : undefined,
     };
-
-    // Handle JSON mode instructions
-    if (response_model) {
-      // Prepend instructions for JSON output if needed (similar to o1 handling)
-      const schemaString = JSON.stringify(
-        zodToJsonSchema(response_model.schema),
-      );
-      formattedMessages.push({
-        role: "user",
-        parts: [
-          {
-            text: `Please respond ONLY with a valid JSON object that strictly adheres to the following JSON schema. Do not include any other text, explanations, or markdown formatting like \`\`\`json ... \`\`\`. Just the JSON object.\n\nSchema:\n${schemaString}`,
-          },
-        ],
-      });
-      formattedMessages.push({ role: "model", parts: [{ text: "{" }] }); // Prime the model
-    }
 
     logger({
       category: "google",


### PR DESCRIPTION
# why
Google's AI api (Gemini) takes a unique response model format. We are migrating our json prompting to match this format

# what changed
Removed the zod stringify function from `GoogleClient.ts` and imported new ones from `utils.ts` that convert zod to Gemini's format. Shoutout to https://github.com/jbeoris @jbeoris for his project gemini-zod

# test plan
