### PR TITLE
proxy page.evaluate()

### DIFF
--- a/.changeset/empty-bugs-occur.md
+++ b/.changeset/empty-bugs-occur.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+wrap page.evaluate to make sure we have injected browser side scripts before calling them

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -31,9 +31,11 @@ import {
   StagehandDefaultError,
 } from "../types/stagehandErrors";
 import { StagehandAPIError } from "@/types/stagehandApiErrors";
+import { scriptContent } from "@/lib/dom/build/scriptContent";
 
 export class StagehandPage {
   private stagehand: Stagehand;
+  private rawPage: PlaywrightPage;
   private intPage: Page;
   private intContext: StagehandContext;
   private actHandler: StagehandActHandler;
@@ -60,6 +62,7 @@ export class StagehandPage {
     api?: StagehandAPI,
     waitForCaptchaSolves?: boolean,
   ) {
+    this.rawPage = page;
     // Create a proxy to intercept all method calls and property access
     this.intPage = new Proxy(page, {
       get: (target: PlaywrightPage, prop: keyof PlaywrightPage) => {
@@ -113,6 +116,34 @@ export class StagehandPage {
         logger: this.stagehand.logger,
         stagehandPage: this,
         userProvidedInstructions,
+      });
+    }
+  }
+
+  private async ensureStagehandScript(): Promise<void> {
+    try {
+      const injected = await this.rawPage.evaluate(
+        () => !!window.__stagehandInjected,
+      );
+
+      if (injected) return;
+
+      const guardedScript = `if (!window.__stagehandInjected) { \
+window.__stagehandInjected = true; \
+${scriptContent} \
+}`;
+
+      await this.rawPage.addInitScript({ content: guardedScript });
+      await this.rawPage.evaluate(guardedScript);
+    } catch (err) {
+      this.stagehand.log({
+        category: "dom",
+        message: "Failed to inject Stagehand helper script",
+        level: 1,
+        auxiliary: {
+          error: { value: (err as Error).message, type: "string" },
+          trace: { value: (err as Error).stack, type: "string" },
+        },
       });
     }
   }
@@ -217,13 +248,31 @@ export class StagehandPage {
 
   async init(): Promise<StagehandPage> {
     try {
-      const page = this.intPage;
+      const page = this.rawPage;
       const stagehand = this.stagehand;
 
       // Create a proxy that updates active page on method calls
       const handler = {
         get: (target: PlaywrightPage, prop: string | symbol) => {
           const value = target[prop as keyof PlaywrightPage];
+
+          // Inject-on-demand for evaluate
+          if (
+            prop === "evaluate" ||
+            prop === "evaluateHandle" ||
+            prop === "$eval" ||
+            prop === "$$eval"
+          ) {
+            return async (...args: unknown[]) => {
+              this.intContext.setActivePage(this);
+              // Make sure helpers exist before the user’s evaluation
+              await this.ensureStagehandScript();
+              return (value as (...a: unknown[]) => unknown).apply(
+                target,
+                args,
+              );
+            };
+          }
 
           // Handle enhanced methods
           if (prop === "act" || prop === "extract" || prop === "observe") {

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -266,7 +266,7 @@ ${scriptContent} \
           ) {
             return async (...args: unknown[]) => {
               this.intContext.setActivePage(this);
-              // Make sure helpers exist before the user’s evaluation
+              // Make sure helpers exist
               await this.ensureStagehandScript();
               return (value as (...a: unknown[]) => unknown).apply(
                 target,

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -145,6 +145,7 @@ ${scriptContent} \
           trace: { value: (err as Error).stack, type: "string" },
         },
       });
+      throw err;
     }
   }
 

--- a/lib/dom/global.d.ts
+++ b/lib/dom/global.d.ts
@@ -3,6 +3,7 @@ import { StagehandContainer } from "./StagehandContainer";
 export {};
 declare global {
   interface Window {
+    __stagehandInjected?: boolean;
     chunkNumber: number;
     showChunks?: boolean;
     processDom: (chunksSeen: Array<number>) => Promise<{

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -715,8 +715,14 @@ export class Stagehand {
       await this.page.setViewportSize({ width: 1280, height: 720 });
     }
 
+    const guardedScript = `
+  if (!window.__stagehandInjected) {
+    window.__stagehandInjected = true;
+    ${scriptContent}
+  }
+`;
     await this.context.addInitScript({
-      content: scriptContent,
+      content: guardedScript,
     });
 
     this.browserbaseSessionID = sessionId;


### PR DESCRIPTION
# why
- sometimes our browser side scripts will get overwritten or removed
- this is problematic, and results in an error like: `window._browser_side_function is not a function`
# what changed
- wrapped `.evaluate()` in our own `.evaluate()` function which checks to make sure our browser side functions still exist before attempting to call them. if they do not exist, they are re-injected
# test plan
- added a test