### PR TITLE
support telemetry for cua agent

### DIFF
--- a/.changeset/thick-buckets-act.md
+++ b/.changeset/thick-buckets-act.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+add telemetry for cua agents to stagehand.metrics

--- a/lib/agent/AnthropicCUAClient.ts
+++ b/lib/agent/AnthropicCUAClient.ts
@@ -107,10 +107,11 @@ export class AnthropicCUAClient extends AgentClient {
       level: 1,
     });
 
+    let totalInputTokens = 0;
+    let totalOutputTokens = 0;
+    let totalInferenceTime = 0;
+
     try {
-      let totalInputTokens = 0;
-      let totalOutputTokens = 0;
-      let totalInferenceTime = 0;
       // Execute steps until completion or max steps reached
       while (!completed && currentStep < maxSteps) {
         logger({
@@ -184,6 +185,11 @@ export class AnthropicCUAClient extends AgentClient {
         actions,
         message: `Failed to execute task: ${errorMessage}`,
         completed: false,
+        usage: {
+          input_tokens: totalInputTokens,
+          output_tokens: totalOutputTokens,
+          inference_time_ms: totalInferenceTime,
+        },
       };
     }
   }

--- a/lib/agent/OpenAICUAClient.ts
+++ b/lib/agent/OpenAICUAClient.ts
@@ -97,12 +97,12 @@ export class OpenAICUAClient extends AgentClient {
     // Start with the initial instruction
     let inputItems = this.createInitialInputItems(instruction);
     let previousResponseId: string | undefined = undefined;
+    let totalInputTokens = 0;
+    let totalOutputTokens = 0;
+    let totalInferenceTime = 0;
 
     try {
       // Execute steps until completion or max steps reached
-      let totalInputTokens = 0;
-      let totalOutputTokens = 0;
-      let totalInferenceTime = 0;
       while (!completed && currentStep < maxSteps) {
         logger({
           category: "agent",
@@ -169,6 +169,11 @@ export class OpenAICUAClient extends AgentClient {
         actions,
         message: `Failed to execute task: ${errorMessage}`,
         completed: false,
+        usage: {
+          input_tokens: totalInputTokens,
+          output_tokens: totalOutputTokens,
+          inference_time_ms: totalInferenceTime,
+        },
       };
     }
   }

--- a/lib/handlers/agentHandler.ts
+++ b/lib/handlers/agentHandler.ts
@@ -184,7 +184,7 @@ export class StagehandAgentHandler {
         StagehandFunctionName.AGENT,
         result.usage.input_tokens,
         result.usage.output_tokens,
-        0,
+        result.usage.inference_time_ms,
       );
     }
 

--- a/lib/handlers/agentHandler.ts
+++ b/lib/handlers/agentHandler.ts
@@ -11,8 +11,10 @@ import {
   AgentHandlerOptions,
   ActionExecutionResult,
 } from "@/types/agent";
+import { Stagehand, StagehandFunctionName } from "@/lib";
 
 export class StagehandAgentHandler {
+  private stagehand: Stagehand;
   private stagehandPage: StagehandPage;
   private agent: StagehandAgent;
   private provider: AgentProvider;
@@ -21,10 +23,12 @@ export class StagehandAgentHandler {
   private options: AgentHandlerOptions;
 
   constructor(
+    stagehand: Stagehand,
     stagehandPage: StagehandPage,
     logger: (message: LogLine) => void,
     options: AgentHandlerOptions,
   ) {
+    this.stagehand = stagehand;
     this.stagehandPage = stagehandPage;
     this.logger = logger;
     this.options = options;
@@ -175,6 +179,14 @@ export class StagehandAgentHandler {
 
     // Execute the task
     const result = await this.agent.execute(optionsOrInstruction);
+    if (result.usage) {
+      this.stagehand.updateMetrics(
+        StagehandFunctionName.AGENT,
+        result.usage.input_tokens,
+        result.usage.output_tokens,
+        0,
+      );
+    }
 
     // The actions are now executed during the agent's execution flow
     // We don't need to execute them again here

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -417,6 +417,9 @@ export class Stagehand {
     observePromptTokens: 0,
     observeCompletionTokens: 0,
     observeInferenceTimeMs: 0,
+    agentPromptTokens: 0,
+    agentCompletionTokens: 0,
+    agentInferenceTimeMs: 0,
     totalPromptTokens: 0,
     totalCompletionTokens: 0,
     totalInferenceTimeMs: 0,
@@ -449,6 +452,12 @@ export class Stagehand {
         this.stagehandMetrics.observePromptTokens += promptTokens;
         this.stagehandMetrics.observeCompletionTokens += completionTokens;
         this.stagehandMetrics.observeInferenceTimeMs += inferenceTimeMs;
+        break;
+
+      case StagehandFunctionName.AGENT:
+        this.stagehandMetrics.agentPromptTokens += promptTokens;
+        this.stagehandMetrics.agentCompletionTokens += completionTokens;
+        this.stagehandMetrics.agentInferenceTimeMs += inferenceTimeMs;
         break;
     }
     this.updateTotalMetrics(promptTokens, completionTokens, inferenceTimeMs);
@@ -801,6 +810,7 @@ export class Stagehand {
     }
 
     const agentHandler = new StagehandAgentHandler(
+      this,
       this.stagehandPage,
       this.logger,
       {

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -14,6 +14,7 @@ export interface AgentResult {
   usage?: {
     input_tokens: number;
     output_tokens: number;
+    inference_time_ms: number;
   };
 }
 

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -11,6 +11,10 @@ export interface AgentResult {
   actions: AgentAction[];
   completed: boolean;
   metadata?: Record<string, unknown>;
+  usage?: {
+    input_tokens: number;
+    output_tokens: number;
+  };
 }
 
 export interface AgentOptions {

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -202,6 +202,9 @@ export interface StagehandMetrics {
   observePromptTokens: number;
   observeCompletionTokens: number;
   observeInferenceTimeMs: number;
+  agentPromptTokens: number;
+  agentCompletionTokens: number;
+  agentInferenceTimeMs: number;
   totalPromptTokens: number;
   totalCompletionTokens: number;
   totalInferenceTimeMs: number;
@@ -262,6 +265,7 @@ export enum StagehandFunctionName {
   ACT = "ACT",
   EXTRACT = "EXTRACT",
   OBSERVE = "OBSERVE",
+  AGENT = "AGENT",
 }
 
 export interface HistoryEntry {


### PR DESCRIPTION
# why
- need to track tokens on cua agents
# what changed
- added token usage and inference time to `stagehand.metrics` for cua agent
# test plan
- tested locally by cross referencing with token metrics on openai dashboard