### PR TITLE
add x-sent-at header

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -228,6 +228,7 @@ export class StagehandAPI {
       // we want real-time logs, so we stream the response
       "x-stream-response": "true",
       "x-model-api-key": this.modelApiKey,
+      "x-sent-at": Date.now().toString(),
     };
 
     if (options.method === "POST" && options.body) {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -228,7 +228,7 @@ export class StagehandAPI {
       // we want real-time logs, so we stream the response
       "x-stream-response": "true",
       "x-model-api-key": this.modelApiKey,
-      "x-sent-at": Date.now().toString(),
+      "x-sent-at": new Date().toISOString(),
     };
 
     if (options.method === "POST" && options.body) {


### PR DESCRIPTION
# why
On the API, we need to know the time which any given action was triggered from the **client-side**.

# what changed
Added an `x-sent-at` header with the timestamp of request trigger.

# test plan
