### PR TITLE
remove old observation map

### DIFF
--- a/.changeset/loose-cooks-lead.md
+++ b/.changeset/loose-cooks-lead.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Fixed removing a hanging observation map that is no longer used

--- a/lib/handlers/observeHandler.ts
+++ b/lib/handlers/observeHandler.ts
@@ -14,12 +14,7 @@ export class StagehandObserveHandler {
   private readonly stagehand: Stagehand;
   private readonly logger: (logLine: LogLine) => void;
   private readonly stagehandPage: StagehandPage;
-  private observations: {
-    [key: string]: {
-      result: { selector: string; description: string }[];
-      instruction: string;
-    };
-  };
+
   private readonly userProvidedInstructions?: string;
   constructor({
     stagehand,
@@ -36,7 +31,6 @@ export class StagehandObserveHandler {
     this.logger = logger;
     this.stagehandPage = stagehandPage;
     this.userProvidedInstructions = userProvidedInstructions;
-    this.observations = {};
   }
 
   public async observe({

--- a/lib/handlers/observeHandler.ts
+++ b/lib/handlers/observeHandler.ts
@@ -3,7 +3,7 @@ import { Stagehand, StagehandFunctionName } from "../index";
 import { observe } from "../inference";
 import { LLMClient } from "../llm/LLMClient";
 import { StagehandPage } from "../StagehandPage";
-import { generateId, drawObserveOverlay } from "../utils";
+import { drawObserveOverlay } from "../utils";
 import {
   getAccessibilityTree,
   getXPathByResolvedObjectId,
@@ -37,17 +37,6 @@ export class StagehandObserveHandler {
     this.stagehandPage = stagehandPage;
     this.userProvidedInstructions = userProvidedInstructions;
     this.observations = {};
-  }
-
-  private async _recordObservation(
-    instruction: string,
-    result: { selector: string; description: string }[],
-  ): Promise<string> {
-    const id = generateId(instruction);
-
-    this.observations[id] = { result, instruction };
-
-    return id;
   }
 
   public async observe({
@@ -219,7 +208,6 @@ export class StagehandObserveHandler {
       await drawObserveOverlay(this.stagehandPage.page, elementsWithSelectors);
     }
 
-    await this._recordObservation(instruction, elementsWithSelectors);
     return elementsWithSelectors;
   }
 }


### PR DESCRIPTION
# why
Old observation map is no longer used 

# what changed
Removed observation map from `observeHandler.ts`

# test plan
