### PR TITLE
use CDP to find scrollable elements

### DIFF
--- a/.changeset/wide-buckets-swim.md
+++ b/.changeset/wide-buckets-swim.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+use CDP to find scrollable elements

--- a/evals/deterministic/tests/page/addInitScript.test.ts
+++ b/evals/deterministic/tests/page/addInitScript.test.ts
@@ -62,7 +62,6 @@ test.describe("StagehandPage - addInitScript", () => {
     });
 
     await stagehand.close();
-    // this is the only scrollable element on the page
     expect(Object.keys(selectorMap).length).toBeGreaterThanOrEqual(5);
   });
 });

--- a/evals/deterministic/tests/page/addInitScript.test.ts
+++ b/evals/deterministic/tests/page/addInitScript.test.ts
@@ -48,21 +48,21 @@ test.describe("StagehandPage - addInitScript", () => {
     );
 
     // delete the __stagehandInjected flag, and delete the
-    // getScrollableElementXpaths function
+    // processAllOfDom function
     await page.evaluate(() => {
-      delete window.getScrollableElementXpaths;
+      delete window.processAllOfDom;
       delete window.__stagehandInjected;
     });
 
-    // attempt to call the getScrollableElementXpaths function
+    // attempt to call the processAllOfDom function
     // which we previously deleted. page.evaluate should realize
     // its been deleted and re-inject it
-    const xpaths = await page.evaluate(() => {
-      return window.getScrollableElementXpaths();
+    const { selectorMap } = await page.evaluate(() => {
+      return window.processAllOfDom();
     });
 
     await stagehand.close();
     // this is the only scrollable element on the page
-    expect(xpaths).toContain("/html");
+    expect(Object.keys(selectorMap).length).toBeGreaterThanOrEqual(5);
   });
 });

--- a/lib/a11y/utils.ts
+++ b/lib/a11y/utils.ts
@@ -342,6 +342,11 @@ export async function getAccessibilityTree(
 // It is not meant to be actually executed here
 const functionString = `
 function getNodePath(el) {
+  // If it's a document node, route to \`documentElement\`.
+  if (el && el.nodeType === Node.DOCUMENT_NODE && el.documentElement) {
+    el = el.documentElement;
+  }
+
   if (!el || (el.nodeType !== Node.ELEMENT_NODE && el.nodeType !== Node.TEXT_NODE)) {
     console.log("el is not a valid node type");
     return "";

--- a/lib/dom/global.d.ts
+++ b/lib/dom/global.d.ts
@@ -31,7 +31,6 @@ declare global {
       width: number;
       height: number;
     }>;
-    getScrollableElementXpaths: (topN?: number) => Promise<string[]>;
     getNodeFromXpath: (xpath: string) => Node | null;
     waitForElementScrollEnd: (element: HTMLElement) => Promise<void>;
   }

--- a/lib/dom/process.ts
+++ b/lib/dom/process.ts
@@ -1,4 +1,3 @@
-import { generateXPathsForElement as generateXPaths } from "./xpathUtils";
 import {
   calculateViewportHeight,
   canElementScroll,

--- a/lib/dom/process.ts
+++ b/lib/dom/process.ts
@@ -61,26 +61,6 @@ export function getScrollableElements(topN?: number): HTMLElement[] {
   return scrollableElements;
 }
 
-/**
- * Calls getScrollableElements, then for each element calls generateXPaths,
- * and returns the first XPath for each.
- *
- * @param topN (optional) integer limit on how many scrollable elements to process
- * @returns string[] list of XPaths (1 for each scrollable element)
- */
-export async function getScrollableElementXpaths(
-  topN?: number,
-): Promise<string[]> {
-  const scrollableElems = getScrollableElements(topN);
-  const xpaths = [];
-  for (const elem of scrollableElems) {
-    const allXPaths = await generateXPaths(elem);
-    const firstXPath = allXPaths?.[0] || "";
-    xpaths.push(firstXPath);
-  }
-  return xpaths;
-}
-
 export function getNearestScrollableParent(el: HTMLElement): HTMLElement {
   // 1) Get *all* scrollable elements on the page
   //    (You could pass a large topN or omit it for “all”)
@@ -529,7 +509,6 @@ window.restoreDOM = restoreDOM;
 window.createTextBoundingBoxes = createTextBoundingBoxes;
 window.getElementBoundingBoxes = getElementBoundingBoxes;
 window.createStagehandContainer = createStagehandContainer;
-window.getScrollableElementXpaths = getScrollableElementXpaths;
 window.getNodeFromXpath = getNodeFromXpath;
 window.waitForElementScrollEnd = waitForElementScrollEnd;
 


### PR DESCRIPTION
# why
- relying on heuristics to find scrollable elements is slow, and CDP provides a quick way to do it out of the box
- this also reduces reliance on injected browser-side scripts
# what changed
- use CDP to get scrollable elements instead of browser-side scripts
# test plan
- evals