### PR TITLE
support for targeted extract with domExtract

### DIFF
--- a/.changeset/upset-lizards-smell.md
+++ b/.changeset/upset-lizards-smell.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+support targeted extract for domExtract

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -653,7 +653,7 @@ jobs:
 
       - name: Run targeted extract Evals
         if: needs.determine-evals.outputs.run-targeted-extract == 'true'
-        run: npm run evals category targeted_extract concurrency=25 trials=5 -- --extract-method=textExtract
+        run: npm run evals category targeted_extract concurrency=25 trials=5
 
       - name: Log targeted extract Evals Performance
         if: needs.determine-evals.outputs.run-targeted-extract == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,7 +293,7 @@ jobs:
 
       - name: Run Combination Evals
         if: needs.determine-evals.outputs.run-combination == 'true'
-        run: npm run evals category combination
+        run: npm run evals category combination concurrency=25 trials=5
 
       - name: Log Combination Evals Performance
         if: needs.determine-evals.outputs.run-combination == 'true'
@@ -359,7 +359,7 @@ jobs:
 
       - name: Run Act Evals
         if: needs.determine-evals.outputs.run-act == 'true'
-        run: npm run evals category act
+        run: npm run evals category act concurrency=25 trials=5
 
       - name: Log Act Evals Performance
         if: needs.determine-evals.outputs.run-act == 'true'
@@ -429,7 +429,7 @@ jobs:
       # 1. Run extract category with domExtract
       - name: Run Extract Evals (domExtract)
         if: needs.determine-evals.outputs.run-extract == 'true'
-        run: npm run evals category extract -- --extract-method=domExtract
+        run: npm run evals category extract concurrency=25 trials=5 -- --extract-method=domExtract
 
       - name: Save Extract Dom Results
         if: needs.determine-evals.outputs.run-extract == 'true'
@@ -438,7 +438,7 @@ jobs:
       # 2. Then run extract category with textExtract
       - name: Run Extract Evals (textExtract)
         if: needs.determine-evals.outputs.run-extract == 'true'
-        run: npm run evals category extract -- --extract-method=textExtract
+        run: npm run evals category extract concurrency=25 trials=5 -- --extract-method=textExtract
 
       - name: Save Extract Text Results
         if: needs.determine-evals.outputs.run-extract == 'true'
@@ -514,7 +514,7 @@ jobs:
 
       - name: Run text_extract Evals (textExtract)
         if: needs.determine-evals.outputs.run-text-extract == 'true'
-        run: npm run evals category text_extract -- --extract-method=textExtract
+        run: npm run evals category text_extract concurrency=25 trials=5 -- --extract-method=textExtract
 
       - name: Save text_extract Results
         if: needs.determine-evals.outputs.run-text-extract == 'true'
@@ -584,7 +584,7 @@ jobs:
 
       - name: Run Observe Evals
         if: needs.determine-evals.outputs.run-observe == 'true'
-        run: npm run evals category observe
+        run: npm run evals category observe concurrency=25 trials=5
 
       - name: Log Observe Evals Performance
         if: needs.determine-evals.outputs.run-observe == 'true'
@@ -653,7 +653,7 @@ jobs:
 
       - name: Run targeted extract Evals
         if: needs.determine-evals.outputs.run-targeted-extract == 'true'
-        run: npm run evals category targeted_extract -- --extract-method=textExtract
+        run: npm run evals category targeted_extract concurrency=25 trials=5 -- --extract-method=textExtract
 
       - name: Log targeted extract Evals Performance
         if: needs.determine-evals.outputs.run-targeted-extract == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ on:
 env:
   EVAL_MODELS: "gpt-4.1,gemini-2.0-flash,claude-3-5-sonnet-latest"
   EVAL_CATEGORIES: "observe,act,combination,extract,text_extract,targeted_extract"
+  EVAL_MAX_CONCURRENCY: 25
+  EVAL_TRIAL_COUNT: 5
 
 concurrency:
   group: ${{ github.ref }}
@@ -293,7 +295,7 @@ jobs:
 
       - name: Run Combination Evals
         if: needs.determine-evals.outputs.run-combination == 'true'
-        run: npm run evals category combination concurrency=25 trials=5
+        run: npm run evals category combination
 
       - name: Log Combination Evals Performance
         if: needs.determine-evals.outputs.run-combination == 'true'
@@ -359,7 +361,7 @@ jobs:
 
       - name: Run Act Evals
         if: needs.determine-evals.outputs.run-act == 'true'
-        run: npm run evals category act concurrency=25 trials=5
+        run: npm run evals category act
 
       - name: Log Act Evals Performance
         if: needs.determine-evals.outputs.run-act == 'true'
@@ -429,7 +431,7 @@ jobs:
       # 1. Run extract category with domExtract
       - name: Run Extract Evals (domExtract)
         if: needs.determine-evals.outputs.run-extract == 'true'
-        run: npm run evals category extract concurrency=25 trials=5 -- --extract-method=domExtract
+        run: npm run evals category extract -- --extract-method=domExtract
 
       - name: Save Extract Dom Results
         if: needs.determine-evals.outputs.run-extract == 'true'
@@ -438,7 +440,7 @@ jobs:
       # 2. Then run extract category with textExtract
       - name: Run Extract Evals (textExtract)
         if: needs.determine-evals.outputs.run-extract == 'true'
-        run: npm run evals category extract concurrency=25 trials=5 -- --extract-method=textExtract
+        run: npm run evals category extract -- --extract-method=textExtract
 
       - name: Save Extract Text Results
         if: needs.determine-evals.outputs.run-extract == 'true'
@@ -514,7 +516,7 @@ jobs:
 
       - name: Run text_extract Evals (textExtract)
         if: needs.determine-evals.outputs.run-text-extract == 'true'
-        run: npm run evals category text_extract concurrency=25 trials=5 -- --extract-method=textExtract
+        run: npm run evals category text_extract -- --extract-method=textExtract
 
       - name: Save text_extract Results
         if: needs.determine-evals.outputs.run-text-extract == 'true'
@@ -584,7 +586,7 @@ jobs:
 
       - name: Run Observe Evals
         if: needs.determine-evals.outputs.run-observe == 'true'
-        run: npm run evals category observe concurrency=25 trials=5
+        run: npm run evals category observe
 
       - name: Log Observe Evals Performance
         if: needs.determine-evals.outputs.run-observe == 'true'
@@ -653,7 +655,7 @@ jobs:
 
       - name: Run targeted extract Evals
         if: needs.determine-evals.outputs.run-targeted-extract == 'true'
-        run: npm run evals category targeted_extract concurrency=25 trials=5
+        run: npm run evals category targeted_extract
 
       - name: Log targeted extract Evals Performance
         if: needs.determine-evals.outputs.run-targeted-extract == 'true'

--- a/evals/evals.config.json
+++ b/evals/evals.config.json
@@ -263,8 +263,7 @@
     },
     {
       "name": "extract_hamilton_weather",
-      "categories": ["targeted_extract", "regression"],
-      "extract_method": "textExtract"
+      "categories": ["targeted_extract", "regression"]
     },
     {
       "name": "extract_regulations_table",

--- a/evals/tasks/extract_hamilton_weather.ts
+++ b/evals/tasks/extract_hamilton_weather.ts
@@ -1,5 +1,6 @@
 import { EvalFunction } from "@/types/evals";
 import { z } from "zod";
+import { compareStrings } from "@/evals/utils";
 
 export const extract_hamilton_weather: EvalFunction = async ({
   logger,
@@ -41,13 +42,27 @@ export const extract_hamilton_weather: EvalFunction = async ({
 
     // Check that every field matches the expected value
     const isWeatherCorrect =
-      weatherData.temperature === expectedWeatherData.temperature &&
-      weatherData.weather_description ===
-        expectedWeatherData.weather_description &&
-      weatherData.wind === expectedWeatherData.wind &&
-      weatherData.humidity === expectedWeatherData.humidity &&
-      weatherData.barometer === expectedWeatherData.barometer &&
-      weatherData.visibility === expectedWeatherData.visibility;
+      compareStrings(
+        weatherData.temperature,
+        expectedWeatherData.temperature,
+        0.9,
+      ).meetsThreshold &&
+      compareStrings(
+        weatherData.weather_description,
+        expectedWeatherData.weather_description,
+        0.9,
+      ).meetsThreshold &&
+      compareStrings(weatherData.wind, expectedWeatherData.wind, 0.9)
+        .meetsThreshold &&
+      compareStrings(weatherData.humidity, expectedWeatherData.humidity, 0.9)
+        .meetsThreshold &&
+      compareStrings(weatherData.barometer, expectedWeatherData.barometer, 0.9)
+        .meetsThreshold &&
+      compareStrings(
+        weatherData.visibility,
+        expectedWeatherData.visibility,
+        0.9,
+      ).meetsThreshold;
 
     await stagehand.close();
 

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -24,7 +24,6 @@ import {
   StagehandNotInitializedError,
   StagehandEnvironmentError,
   CaptchaTimeoutError,
-  StagehandNotImplementedError,
   BrowserbaseSessionNotFoundError,
   MissingLLMConfigurationError,
   HandlerNotInitializedError,
@@ -652,14 +651,6 @@ ${scriptContent} \
         useTextExtract,
         selector,
       } = options;
-
-      // Throw a NotImplementedError if the user passed in an `xpath`
-      // and `useTextExtract` is false
-      if (selector && useTextExtract !== true) {
-        throw new StagehandNotImplementedError(
-          "Passing an xpath into extract is only supported when `useTextExtract: true`.",
-        );
-      }
 
       if (this.api) {
         const result = await this.api.extract<T>(options);

--- a/lib/handlers/extractHandler.ts
+++ b/lib/handlers/extractHandler.ts
@@ -133,6 +133,7 @@ export class StagehandExtractHandler {
         llmClient,
         requestId,
         domSettleTimeoutMs,
+        selector,
       });
     }
   }
@@ -393,6 +394,7 @@ export class StagehandExtractHandler {
     llmClient,
     requestId,
     domSettleTimeoutMs,
+    selector,
   }: {
     instruction: string;
     schema: T;
@@ -400,6 +402,7 @@ export class StagehandExtractHandler {
     llmClient: LLMClient;
     requestId?: string;
     domSettleTimeoutMs?: number;
+    selector?: string;
   }): Promise<z.infer<T>> {
     this.logger({
       category: "extraction",
@@ -414,7 +417,12 @@ export class StagehandExtractHandler {
     });
 
     await this.stagehandPage._waitForSettledDom(domSettleTimeoutMs);
-    const tree = await getAccessibilityTree(this.stagehandPage, this.logger);
+    const targetXpath = selector?.replace(/^xpath=/, "") ?? "";
+    const tree = await getAccessibilityTree(
+      this.stagehandPage,
+      this.logger,
+      targetXpath,
+    );
     this.logger({
       category: "extraction",
       message: "Getting accessibility tree data",


### PR DESCRIPTION
# why
- we should support targeted extract for default extract, not just textExtract
# what changed
- removed stagehandNotImplementedError from extract if selector is passed in without `useTextExtract: true`
- added an optional `selector` arg to `getAccessibilityTree`. if this arg is passed in, we get the node that the selector points to and trim all ancestors from the tree
# test plan
- existing evals