### PR TITLE
deprecate onlyVisible

### DIFF
--- a/.changeset/cold-bars-obey.md
+++ b/.changeset/cold-bars-obey.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": minor
+---
+
+deprecated `onlyVisible` param and remove its functionality

--- a/lib/handlers/actHandler.ts
+++ b/lib/handlers/actHandler.ts
@@ -226,7 +226,6 @@ export class StagehandActHandler {
         instruction,
         llmClient,
         requestId,
-        onlyVisible: false,
         drawOverlay: false,
         returnAction: true,
         fromAct: true,

--- a/lib/inference.ts
+++ b/lib/inference.ts
@@ -329,7 +329,6 @@ export async function observe({
   domElements,
   llmClient,
   requestId,
-  isUsingAccessibilityTree,
   userProvidedInstructions,
   logger,
   returnAction = false,
@@ -342,7 +341,6 @@ export async function observe({
   requestId: string;
   userProvidedInstructions?: string;
   logger: (message: LogLine) => void;
-  isUsingAccessibilityTree?: boolean;
   returnAction?: boolean;
   logInferenceToFile?: boolean;
   fromAct?: boolean;
@@ -355,9 +353,7 @@ export async function observe({
           description: z
             .string()
             .describe(
-              isUsingAccessibilityTree
-                ? "a description of the accessible element and its purpose"
-                : "a description of the element and what it is relevant for",
+              "a description of the accessible element and its purpose",
             ),
           ...(returnAction
             ? {
@@ -377,21 +373,14 @@ export async function observe({
             : {}),
         }),
       )
-      .describe(
-        isUsingAccessibilityTree
-          ? "an array of accessible elements that match the instruction"
-          : "an array of elements that match the instruction",
-      ),
+      .describe("an array of accessible elements that match the instruction"),
   });
 
   type ObserveResponse = z.infer<typeof observeSchema>;
 
   const messages: ChatMessage[] = [
-    buildObserveSystemPrompt(
-      userProvidedInstructions,
-      isUsingAccessibilityTree,
-    ),
-    buildObserveUserMessage(instruction, domElements, isUsingAccessibilityTree),
+    buildObserveSystemPrompt(userProvidedInstructions),
+    buildObserveUserMessage(instruction, domElements),
   ];
 
   const filePrefix = fromAct ? "act" : "observe";

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -151,18 +151,13 @@ chunksTotal: ${chunksTotal}`,
 // observe
 export function buildObserveSystemPrompt(
   userProvidedInstructions?: string,
-  isUsingAccessibilityTree = false,
 ): ChatMessage {
   const observeSystemPrompt = `
 You are helping the user automate the browser by finding elements based on what the user wants to observe in the page.
 
 You will be given:
 1. a instruction of elements to observe
-2. ${
-    isUsingAccessibilityTree
-      ? "a hierarchical accessibility tree showing the semantic structure of the page. The tree is a hybrid of the DOM and the accessibility tree."
-      : "a numbered list of possible elements"
-  }
+2. a hierarchical accessibility tree showing the semantic structure of the page. The tree is a hybrid of the DOM and the accessibility tree.
 
 Return an array of elements that match the instruction if they exist, otherwise return an empty array.`;
   const content = observeSystemPrompt.replace(/\s+/g, " ");
@@ -178,12 +173,11 @@ Return an array of elements that match the instruction if they exist, otherwise 
 export function buildObserveUserMessage(
   instruction: string,
   domElements: string,
-  isUsingAccessibilityTree = false,
 ): ChatMessage {
   return {
     role: "user",
     content: `instruction: ${instruction}
-${isUsingAccessibilityTree ? "Accessibility Tree" : "DOM"}: ${domElements}`,
+Accessibility Tree: \n${domElements}`,
   };
 }
 

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -137,6 +137,9 @@ export interface ObserveOptions {
   modelClientOptions?: ClientOptions;
   domSettleTimeoutMs?: number;
   returnAction?: boolean;
+  /**
+   * @deprecated The `onlyVisible` parameter has no effect in this version of Stagehand and will be removed in later versions.
+   */
   onlyVisible?: boolean;
   drawOverlay?: boolean;
 }


### PR DESCRIPTION
# why
- `onlyVisible` is an opaque parameter and makes `observe` very slow
# what changed
- deprecated the `onlyVisible` parameter, and removed its functionality
# test plan
- `observe` evals