### PR TITLE
Add prepare to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "build-types": "tsc --emitDeclarationOnly --outDir dist",
     "build-js": "tsup lib/index.ts --dts",
     "build": "npm run lint && npm run build-dom-scripts && npm run build-js && npm run build-types",
+    "prepare": "npm run build",
     "lint": "npm run prettier && npm run eslint",
     "release": "npm run build && changeset publish",
     "release-canary": "npm run build && changeset version --snapshot && changeset publish --tag alpha"


### PR DESCRIPTION
# why
We want to be able to npm install Stagehand from a git branch. Right now, when you set your version in package.json to `github:browserbase/stagehand#some-branch`, there's no `dist/` directory in the resulting `node_modules` path. To fix this, we must edit package.json to run `npm run build` in a [prepare script](https://docs.npmjs.com/cli/v11/using-npm/scripts#life-cycle-scripts)

# what changed
Add `npm run build` to `npm run prepare` 

# test plan
Setting version in a `create-browser-app` app to this branch and setting if it works
