### PR TITLE
dont publish lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
     "release-canary": "pnpm run build && changeset version --snapshot && changeset publish --tag alpha"
   },
   "files": [
-    "dist/**",
-    "lib/**"
+    "dist/**"
   ],
   "keywords": [],
   "author": "Browserbase",


### PR DESCRIPTION
# why
- we don't need to directly publish TS source code
