### PR TITLE
call browser.close()

### DIFF
--- a/.changeset/bitter-places-spend.md
+++ b/.changeset/bitter-places-spend.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Fix stagehand.close() functionality to include calling browser.close()

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -311,7 +311,7 @@ async function getBrowser(
     if (localBrowserLaunchOptions?.cookies) {
       context.addCookies(localBrowserLaunchOptions.cookies);
     }
-    // This will always be when launched with chromium.launchPersistentContext, but not when connected over CDP to an existing browser
+    // This will always be when null launched with chromium.launchPersistentContext, but not when connected over CDP to an existing browser
     const browser = context.browser();
 
     logger({

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,5 @@
 import { Browserbase } from "@browserbasehq/sdk";
-import { chromium } from "@playwright/test";
+import { Browser, chromium } from "@playwright/test";
 import dotenv from "dotenv";
 import fs from "fs";
 import os from "os";
@@ -311,6 +311,8 @@ async function getBrowser(
     if (localBrowserLaunchOptions?.cookies) {
       context.addCookies(localBrowserLaunchOptions.cookies);
     }
+    // This will always be when launched with chromium.launchPersistentContext, but not when connected over CDP to an existing browser
+    const browser = context.browser();
 
     logger({
       category: "init",
@@ -319,7 +321,7 @@ async function getBrowser(
 
     await applyStealthScripts(context);
 
-    return { context, contextPath: userDataDir, env: "LOCAL" };
+    return { browser, context, contextPath: userDataDir, env: "LOCAL" };
   }
 }
 
@@ -390,7 +392,7 @@ export class Stagehand {
   private stagehandLogger: StagehandLogger;
   private disablePino: boolean;
   private _env: "LOCAL" | "BROWSERBASE";
-
+  private _browser: Browser | undefined;
   protected setActivePage(page: StagehandPage): void {
     this.stagehandPage = page;
   }
@@ -694,7 +696,7 @@ export class Stagehand {
       this.browserbaseSessionID = sessionId;
     }
 
-    const { context, debugUrl, sessionUrl, contextPath, sessionId } =
+    const { browser, context, debugUrl, sessionUrl, contextPath, sessionId } =
       await getBrowser(
         this.apiKey,
         this.projectId,
@@ -716,7 +718,7 @@ export class Stagehand {
         return br;
       });
     this.contextPath = contextPath;
-
+    this._browser = browser;
     this.stagehandContext = await StagehandContext.init(context, this);
 
     const defaultPage = (await this.stagehandContext.getStagehandPages())[0];
@@ -767,6 +769,9 @@ export class Stagehand {
       return;
     } else {
       await this.context.close();
+      if (this._browser) {
+        await this._browser.close();
+      }
     }
 
     if (this.contextPath) {


### PR DESCRIPTION
# why
Launch persistent context doesn't return a browser object, so we were only calling `context.close()`, and not `browser.close()`. This PR fixes that

# what changed
Added a private browser object to the Stagehand class that can be closed after calling `stagehand.close()`

# test plan
