### PR TITLE
clean up tree with regex

### DIFF
--- a/.changeset/upset-radios-warn.md
+++ b/.changeset/upset-radios-warn.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+replace NBSP with regular space & remove special characters from dom+a11y tree

--- a/lib/a11y/utils.ts
+++ b/lib/a11y/utils.ts
@@ -11,14 +11,31 @@ import {
   StagehandElementNotFoundError,
 } from "@/types/stagehandErrors";
 
+const CLEAN_RULES: ReadonlyArray<[RegExp, string]> = [
+  // Font-Awesome / Material-Icons placeholders (Private-Use Area)
+  [/[\u{E000}-\u{F8FF}]/gu, ""],
+
+  // NBSP family to regular space
+  [/[\u00A0\u202F\u2007\uFEFF]/g, " "],
+];
+
+// returns the input string with each of the CLEAN_RULES applied
+function cleanText(input: string): string {
+  return CLEAN_RULES.reduce(
+    (txt, [pattern, replacement]) => txt.replace(pattern, replacement),
+    input,
+  ).trim();
+}
+
 // Parser function for str output
 export function formatSimplifiedTree(
   node: AccessibilityNode,
   level = 0,
 ): string {
   const indent = "  ".repeat(level);
+  const cleanName = node.name ? cleanText(node.name) : "";
   let result = `${indent}[${node.nodeId}] ${node.role}${
-    node.name ? `: ${node.name}` : ""
+    cleanName ? `: ${cleanName}` : ""
   }\n`;
 
   if (node.children?.length) {


### PR DESCRIPTION
# why
- trim unnecessary characters from the dom+a11y tree
- this is currently being done with an LLM call (the `refinedResponse` in `inference.ts`) which is super overkill. we can get by with a little regex here
# what changed
- added `CLEAN_RULES`, which is an array of tuples where each tuple holds a regex expression and the corresponding replacement value
- added a `cleanText()` function which accepts a `string`, and "cleans" the `string` based on `CLEAN_RULES`
- added a step to the `formatSimplifiedTree` where we clean each `node.name` before adding it to the formatted tree string
- in this PR, we've only added two `CLEAN_RULES`, but may need to add more in the future
- the two rules we have in this PR are:
   - replace font awesome codes with an empty string:
       - e.g., this: `[249] link: 104-10005-10321.pdf` 
       - becomes this `[249] link: 104-10005-10321.pdf`
   - replace non breaking spaces with regular spaces
       - e.g., this: <img width="346" alt="Screenshot 2025-05-02 at 3 18 05 PM" src="https://github.com/user-attachments/assets/e5eaf46f-582b-47ad-aac9-ecd462587473" />

       - becomes this:  <img width="322" alt="Screenshot 2025-05-02 at 3 19 00 PM" src="https://github.com/user-attachments/assets/64ca6035-e827-40fd-a47b-cc1010c0526d" />
# test plan
- evals