### PR TITLE
rm refine step in `extract`

### DIFF
--- a/.changeset/bumpy-meals-call.md
+++ b/.changeset/bumpy-meals-call.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+rm refine step in extract

--- a/lib/handlers/extractHandler.ts
+++ b/lib/handlers/extractHandler.ts
@@ -184,7 +184,6 @@ export class StagehandExtractHandler {
   private async textExtract<T extends z.AnyZodObject>({
     instruction,
     schema,
-    content = {},
     llmClient,
     requestId,
     domSettleTimeoutMs,
@@ -320,7 +319,6 @@ export class StagehandExtractHandler {
     // **10:** Pass the formatted text to an LLM for extraction according to the given instruction and schema
     const extractionResponse = await extract({
       instruction,
-      previouslyExtractedContent: content,
       domElements: formattedText,
       schema,
       chunksSeen: 1,
@@ -390,7 +388,6 @@ export class StagehandExtractHandler {
   private async domExtract<T extends z.AnyZodObject>({
     instruction,
     schema,
-    content = {},
     llmClient,
     requestId,
     domSettleTimeoutMs,
@@ -438,7 +435,6 @@ export class StagehandExtractHandler {
     // call extract inference with transformed schema
     const extractionResponse = await extract({
       instruction,
-      previouslyExtractedContent: content,
       domElements: outputString,
       schema: transformedSchema,
       chunksSeen: 1,

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -89,35 +89,6 @@ ONLY print the content using the print_extracted_data tool provided.`;
   };
 }
 
-const refineSystemPrompt = `You are tasked with refining and filtering information for the final output based on newly extracted and previously extracted content. Your responsibilities are:
-1. Remove exact duplicates for elements in arrays and objects.
-2. For text fields, append or update relevant text if the new content is an extension, replacement, or continuation.
-3. For non-text fields (e.g., numbers, booleans), update with new values if they differ.
-4. Add any completely new fields or objects ONLY IF they correspond to the provided schema.
-
-Return the updated content that includes both the previous content and the new, non-duplicate, or extended information.`;
-
-export function buildRefineSystemPrompt(): ChatMessage {
-  return {
-    role: "system",
-    content: refineSystemPrompt,
-  };
-}
-
-export function buildRefineUserPrompt(
-  instruction: string,
-  previouslyExtractedContent: object,
-  newlyExtractedContent: object,
-): ChatMessage {
-  return {
-    role: "user",
-    content: `Instruction: ${instruction}
-Previously extracted content: ${JSON.stringify(previouslyExtractedContent, null, 2)}
-Newly extracted content: ${JSON.stringify(newlyExtractedContent, null, 2)}
-Refined content:`,
-  };
-}
-
 const metadataSystemPrompt = `You are an AI assistant tasked with evaluating the progress and completion status of an extraction task.
 Analyze the extraction response and determine if the task is completed or if more information is needed.
 Strictly abide by the following criteria:


### PR DESCRIPTION
# why
- the refine step inside `extract` was once useful when we processed the DOM in chunks, but it has since become redundant
- right now, it is an unnecessary LLM call which opens the door to hallucinated results 
- it also costs money and increases latency
# what changed
- removed the refine step entirely
# test plan
- run all extract evals