### PR TITLE
dont overwrite `.describe()`

### DIFF
--- a/.changeset/eight-tires-rush.md
+++ b/.changeset/eight-tires-rush.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+dont overwrite .describe() when user defines a zod schema with z.string().url().describe()


### PR DESCRIPTION
# why
- when a user is extracting links/url's from a page, they define a field in their zod schema like this: `z.string().url()`
- internally, this gets converted to `z.number().describe("ID of element that points to a URL")` before it is given to the LLM, and then converted back to the original `z.string().url()` type before `extract` returns
- the problem here is:
   - if a user defines a description, i.e., they do `z.string().url().describe("the link to the article about dogs")`, the `describe()` part gets overwritten with `describe("ID of element that points to a URL")` before being sent to the LLM
- we need to preserve the user defined description
# what changed
- this PR introduces a function `makeIdNumberSchema()` that appends the user defined `.describe()` to our own internal `describe()`
### example **_with_** user defined `.describe()`
if a user writes: 
```ts
z.string().url().describe("the link to the article about dogs")
```
internally, we convert it to: 
```ts
z.number("This field must be filled with the numerical ID of the link element that follows this user-defined description: the link to the article about dogs")
```

### example **_without_** user defined `.describe()`
if a user writes: 
```ts
z.string().url()
```
internally, we convert it to: 
```ts
z.number("This field must be filled with the numerical ID of the link element")
```
# test plan
- extract evals