### PR TITLE
Implement pnpm workspace

### DIFF
--- a/evals/package.json
+++ b/evals/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@browserbasehq/stagehand-evals",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Evaluation suite for Stagehand",
+  "main": "./",
+  "scripts": {
+    "build": "pnpm --filter @browserbasehq/stagehand run build",
+    "evals": "pnpm run build && tsx index.eval.ts",
+    "e2e": "pnpm run build && playwright test --config deterministic/e2e.playwright.config.ts",
+    "e2e:bb": "pnpm run build && playwright test --config deterministic/bb.playwright.config.ts",
+    "e2e:local": "pnpm run build && playwright test --config deterministic/local.playwright.config.ts"
+  }
+}

--- a/examples/example.ts
+++ b/examples/example.ts
@@ -17,6 +17,7 @@ async function example() {
   /**
    * Add your code here!
    */
+  await stagehand.page.act("click the quickstart button");
   await stagehand.close();
 }
 

--- a/examples/example.ts
+++ b/examples/example.ts
@@ -13,10 +13,10 @@ async function example() {
     ...StagehandConfig,
   });
   await stagehand.init();
-  await stagehand.page.goto("https://docs.stagehand.dev");
   /**
    * Add your code here!
    */
+  await stagehand.page.goto("https://docs.stagehand.dev");
   await stagehand.page.act("click the quickstart button");
   await stagehand.close();
 }

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@browserbasehq/stagehand-examples",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Example scripts for Stagehand",
+  "main": "./",
+  "scripts": {
+    "build": "pnpm --filter @browserbasehq/stagehand run build",
+    "start": "pnpm run build && tsx example.ts"
+  }
+}

--- a/lib/handlers/agentHandler.ts
+++ b/lib/handlers/agentHandler.ts
@@ -11,7 +11,8 @@ import {
   AgentHandlerOptions,
   ActionExecutionResult,
 } from "@/types/agent";
-import { Stagehand, StagehandFunctionName } from "@/lib";
+import { Stagehand } from "../index";
+import { StagehandFunctionName } from "@/types/stagehand";
 
 export class StagehandAgentHandler {
   private stagehand: Stagehand;

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@browserbasehq/stagehand-lib",
+  "version": "2.2.0",
+  "private": true,
+  "description": "Core Stagehand library sources",
+  "main": "../dist/index.js",
+  "module": "../dist/index.js",
+  "types": "../dist/index.d.ts",
+  "scripts": {
+    "build-dom-scripts": "tsx dom/genDomScripts.ts",
+    "build-js": "tsup index.ts --dts",
+    "build-types": "tsc --emitDeclarationOnly --outDir ../dist",
+    "build": "pnpm run build-dom-scripts && pnpm run build-js && pnpm run build-types",
+    "lint": "prettier --check . && eslint .",
+    "format": "prettier --write ."
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,12 @@ importers:
         specifier: ^8.17.0
         version: 8.31.1(eslint@9.25.1)(typescript@5.8.3)
 
+  evals: {}
+
+  examples: {}
+
+  lib: {}
+
 packages:
 
   '@ai-sdk/anthropic@1.2.10':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+packages:
+  - "./"
+  - "lib"
+  - "examples"
+  - "evals"


### PR DESCRIPTION
# why
One step closer to a monorepo

# what changed
Created a pnpm workspace with package.json files in each repo (lib, examples, evals). 

Fast follow is moving scripts out of the main package.json into the module in which they belong

# test plan
Evals + release