### PR TITLE
suppress injected scripts error log on close

### DIFF
--- a/.changeset/thin-meals-smell.md
+++ b/.changeset/thin-meals-smell.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand-lib": patch
+---
+
+fix "failed to inject helper scripts" log on stagehand.close()

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -135,16 +135,18 @@ ${scriptContent} \
       await this.rawPage.addInitScript({ content: guardedScript });
       await this.rawPage.evaluate(guardedScript);
     } catch (err) {
-      this.stagehand.log({
-        category: "dom",
-        message: "Failed to inject Stagehand helper script",
-        level: 1,
-        auxiliary: {
-          error: { value: (err as Error).message, type: "string" },
-          trace: { value: (err as Error).stack, type: "string" },
-        },
-      });
-      throw err;
+      if (!this.stagehand.isClosed) {
+        this.stagehand.log({
+          category: "dom",
+          message: "Failed to inject Stagehand helper script",
+          level: 1,
+          auxiliary: {
+            error: { value: (err as Error).message, type: "string" },
+            trace: { value: (err as Error).stack, type: "string" },
+          },
+        });
+        throw err;
+      }
     }
   }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -395,6 +395,7 @@ export class Stagehand {
   private modelClientOptions: ClientOptions;
   private _env: "LOCAL" | "BROWSERBASE";
   private _browser: Browser | undefined;
+  private _isClosed: boolean = false;
   protected setActivePage(page: StagehandPage): void {
     this.stagehandPage = page;
   }
@@ -426,6 +427,10 @@ export class Stagehand {
 
   public get metrics(): StagehandMetrics {
     return this.stagehandMetrics;
+  }
+
+  public get isClosed(): boolean {
+    return this._isClosed;
   }
 
   public updateMetrics(
@@ -772,6 +777,7 @@ export class Stagehand {
   }
 
   async close(): Promise<void> {
+    this._isClosed = true;
     if (this.apiClient) {
       const response = await this.apiClient.end();
       const body: ApiResponse<unknown> = await response.json();


### PR DESCRIPTION
# why
- we sometimes get the log `"Failed to inject Stagehand helper script"` when we call `stagehand.close()`
- we should suppress this log if we are in the middle of closing stagehand
# what changed
- added `isClosed` to the stagehand object, which we set to true when `stagehand.close()` is called. 
- now, we avoid logging the error if stagehand is being closed intentionally