### PR TITLE
return hybrid tree for `extract()` with no arguments

### DIFF
--- a/.changeset/blue-beds-thank.md
+++ b/.changeset/blue-beds-thank.md
@@ -1,5 +1,5 @@
 ---
-"@browserbasehq/stagehand-lib": patch
+"@browserbasehq/stagehand-lib": minor
 ---
 
 make extract() with no arguments return the hybrid tree instead of text-rendered webpage

--- a/.changeset/blue-beds-thank.md
+++ b/.changeset/blue-beds-thank.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand-lib": patch
+---
+
+make extract() with no arguments return the hybrid tree instead of text-rendered webpage


### PR DESCRIPTION
# why
- migrating off of browser side/injected scripts
# what changed
- `extract()` with no arguments now returns the dom+a11y hybrid tree instead of a text rendered webpage
# test plan
- tested locally