### PR TITLE
run evals by name

### DIFF
--- a/evals/args.ts
+++ b/evals/args.ts
@@ -4,6 +4,7 @@ import { EvalCategorySchema } from "@/types/evals";
 const rawArgs = process.argv.slice(2);
 
 const parsedArgs: {
+  evalName?: string;
   env?: string;
   trials?: number;
   concurrency?: number;
@@ -17,6 +18,8 @@ const parsedArgs: {
 for (const arg of rawArgs) {
   if (arg.startsWith("env=")) {
     parsedArgs.env = arg.split("=")[1]?.toLowerCase();
+  } else if (arg.startsWith("name=")) {
+    parsedArgs.evalName = arg.split("=")[1];
   } else if (arg.startsWith("trials=")) {
     const val = parseInt(arg.split("=")[1], 10);
     if (!isNaN(val)) {
@@ -76,7 +79,11 @@ const DEFAULT_EVAL_CATEGORIES = process.env.EVAL_CATEGORIES
 let filterByCategory: string | null = null;
 let filterByEvalName: string | null = null;
 
-if (parsedArgs.leftover.length > 0) {
+if (parsedArgs.evalName) {
+  filterByEvalName = parsedArgs.evalName;
+}
+
+if (!filterByEvalName && parsedArgs.leftover.length > 0) {
   if (parsedArgs.leftover[0].toLowerCase() === "category") {
     filterByCategory = parsedArgs.leftover[1];
     if (!filterByCategory) {


### PR DESCRIPTION
# why
- running evals by name stopped working when we went from npm->pnpm
# what changed
- you can run an individual eval by specifying the eval name like this: `pnpm run evals name=eval_name_here`
# test plan
- tested locally