### PR TITLE
don't log deprecation warning if `onlyVisible` is undefined

### DIFF
--- a/.changeset/bright-beans-smile.md
+++ b/.changeset/bright-beans-smile.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand-lib": patch
+---
+
+dont log deprecation warning when onlyVisible is undefined

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -751,7 +751,7 @@ ${scriptContent} \
         modelClientOptions,
         domSettleTimeoutMs,
         returnAction = true,
-        onlyVisible = false,
+        onlyVisible,
         drawOverlay,
       } = options;
 
@@ -783,10 +783,12 @@ ${scriptContent} \
             value: llmClient.modelName,
             type: "string",
           },
-          onlyVisible: {
-            value: onlyVisible ? "true" : "false",
-            type: "boolean",
-          },
+          ...(onlyVisible !== undefined && {
+            onlyVisible: {
+              value: onlyVisible ? "true" : "false",
+              type: "boolean",
+            },
+          }),
         },
       });
 


### PR DESCRIPTION
# why
- currently we are logging a deprecation warning for `onlyVisible`, even if the user does not define it
- this is annoying
# what changed
- removed the default value for `onlyVisible` in `StagehandPage.ts` so that it remains undefined if the user does not define it
# test plan
- regression evals
