### PR TITLE
Docs: rm deprecated onlyVisible

### DIFF
--- a/docs/reference/observe.mdx
+++ b/docs/reference/observe.mdx
@@ -37,10 +37,6 @@ Observe can also return a suggested action for the candidate element by setting 
     Returns an observe result object that contains a suggested action for the candidate element. The suggestion includes method, and arguments (if any). Defaults to `true`.
   </ParamField>
 
-  <ParamField path="onlyVisible" type="boolean" optional>
-    If true, returns only visible elements. Uses DOM inspection instead of accessibility trees. Defaults to `false`.
-  </ParamField>
-
   <ParamField path="modelName" type="AvailableModel" optional>
     Specifies the model to use
   </ParamField>


### PR DESCRIPTION
remove deprecated `onlyVisible` param from docs
