### PR TITLE
Docs: add link extraction to docs

### DIFF
--- a/docs/reference/extract.mdx
+++ b/docs/reference/extract.mdx
@@ -6,8 +6,6 @@ icon: 'brain-circuit'
 
 `extract()` grabs structured text from the current page using [zod](https://github.com/colinhacks/zod). Given instructions and `schema`, you will receive structured data.
 
-<Tip>We strongly suggest you set `useTextExtract` to `true` if you are extracting data from a longer body of text.</Tip>
-
 ### `extract` a single object
 
 Here is how an `extract` call might look for a single object:

--- a/docs/reference/extract.mdx
+++ b/docs/reference/extract.mdx
@@ -115,7 +115,7 @@ const apartments = await stagehand.page.extract({
   <ParamField path="selector" type="string" optional>
       An xpath that can be used to reduce the scope of an extraction. If an xpath is passed in, `extract` will only process
       the contents of the HTML element that the xpath points to. Useful for reducing input tokens and increasing extraction
-      accuracy. Only works when `useTextExtract: true`.
+      accuracy.
   </ParamField>
 
   <ParamField path="modelName" type="AvailableModel" optional>

--- a/docs/reference/extract.mdx
+++ b/docs/reference/extract.mdx
@@ -23,6 +23,22 @@ Your output schema will look like:
 { price: number }
 ```
 
+### `extract` a link
+<Note>To extract links or URLs, the relevant field in your schema needs to be defined using `z.string().url()`. See the snippet below: </Note>
+
+Here is how an `extract` call might look for extracting a link or URL.
+```javascript
+  const extraction = await stagehand.page.extract({
+    instruction: "extract the link to the 'contact us' page",
+    schema: z.object({
+      link: z.string().url(),
+    }),
+  });
+
+  console.log("the link to the contact us page is: ", extraction.link);
+```
+
+
 ### `extract` a list of objects
 
 Here is how an `extract` call might look for a list of objects. Note that you need to wrap the `z.array` in an outer `z.object`.


### PR DESCRIPTION
# why
- explain how to extract links 
# what changed
- added snippet explaining that you need to use `z.string().url()`

<img width="764" alt="Screenshot 2025-05-09 at 1 26 05 PM" src="https://github.com/user-attachments/assets/475951a7-0d6e-408c-8588-8983dfd37a89" />

