### PR TITLE
fix `stagehand.history`

### DIFF
--- a/.changeset/metal-clowns-cheat.md
+++ b/.changeset/metal-clowns-cheat.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand-lib": patch
+---
+
+fix `stagehand.history`

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -420,9 +420,6 @@ ${scriptContent} \
   }
 
   public get page(): Page {
-    if (!this.initialized) {
-      throw new StagehandNotInitializedError("page");
-    }
     return this.intPage;
   }
 

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -6,7 +6,6 @@ import { Page, defaultExtractSchema } from "../types/page";
 import {
   ExtractOptions,
   ExtractResult,
-  HistoryEntry,
   ObserveOptions,
   ObserveResult,
 } from "../types/stagehand";
@@ -46,11 +45,6 @@ export class StagehandPage {
   private userProvidedInstructions?: string;
   private waitForCaptchaSolves: boolean;
   private initialized: boolean = false;
-  private _history: Array<HistoryEntry> = [];
-
-  public get history(): ReadonlyArray<HistoryEntry> {
-    return Object.freeze([...this._history]);
-  }
 
   constructor(
     page: PlaywrightPage,
@@ -344,7 +338,7 @@ ${scriptContent} \
                 ? await this.api.goto(url, options)
                 : await target.goto(url, options);
 
-              this.addToHistory("navigate", { url, options }, result);
+              this.stagehand.addToHistory("navigate", { url, options }, result);
 
               if (this.waitForCaptchaSolves) {
                 try {
@@ -424,6 +418,9 @@ ${scriptContent} \
   }
 
   public get page(): Page {
+    if (!this.initialized) {
+      throw new StagehandNotInitializedError("page");
+    }
     return this.intPage;
   }
 
@@ -498,24 +495,6 @@ ${scriptContent} \
     }
   }
 
-  public addToHistory(
-    method: HistoryEntry["method"],
-    parameters:
-      | ActOptions
-      | ExtractOptions<z.AnyZodObject>
-      | ObserveOptions
-      | { url: string; options: GotoOptions }
-      | string,
-    result?: unknown,
-  ): void {
-    this._history.push({
-      method,
-      parameters,
-      result: result ?? null,
-      timestamp: new Date().toISOString(),
-    });
-  }
-
   async act(
     actionOrOptions: string | ActOptions | ObserveResult,
   ): Promise<ActResult> {
@@ -536,7 +515,7 @@ ${scriptContent} \
           if (this.api) {
             const result = await this.api.act(observeResult);
             await this._refreshPageFromAPI();
-            this.addToHistory("act", observeResult, result);
+            this.stagehand.addToHistory("act", observeResult, result);
             return result;
           }
 
@@ -568,7 +547,7 @@ ${scriptContent} \
       if (this.api) {
         const result = await this.api.act(actionOrOptions);
         await this._refreshPageFromAPI();
-        this.addToHistory("act", actionOrOptions, result);
+        this.stagehand.addToHistory("act", actionOrOptions, result);
         return result;
       }
 
@@ -603,8 +582,7 @@ ${scriptContent} \
         llmClient,
         requestId,
       );
-
-      this.addToHistory("act", actionOrOptions, result);
+      this.stagehand.addToHistory("act", actionOrOptions, result);
       return result;
     } catch (err: unknown) {
       if (err instanceof StagehandError || err instanceof StagehandAPIError) {
@@ -632,7 +610,7 @@ ${scriptContent} \
         } else {
           result = await this.extractHandler.extract();
         }
-        this.addToHistory("extract", instructionOrOptions, result);
+        this.stagehand.addToHistory("extract", instructionOrOptions, result);
         return result;
       }
 
@@ -656,7 +634,7 @@ ${scriptContent} \
 
       if (this.api) {
         const result = await this.api.extract<T>(options);
-        this.addToHistory("extract", instructionOrOptions, result);
+        this.stagehand.addToHistory("extract", instructionOrOptions, result);
         return result;
       }
 
@@ -719,7 +697,7 @@ ${scriptContent} \
           throw e;
         });
 
-      this.addToHistory("extract", instructionOrOptions, result);
+      this.stagehand.addToHistory("extract", instructionOrOptions, result);
 
       return result;
     } catch (err: unknown) {
@@ -757,7 +735,7 @@ ${scriptContent} \
 
       if (this.api) {
         const result = await this.api.observe(options);
-        this.addToHistory("observe", instructionOrOptions, result);
+        this.stagehand.addToHistory("observe", instructionOrOptions, result);
         return result;
       }
 
@@ -834,7 +812,7 @@ ${scriptContent} \
           throw e;
         });
 
-      this.addToHistory("observe", instructionOrOptions, result);
+      this.stagehand.addToHistory("observe", instructionOrOptions, result);
 
       return result;
     } catch (err: unknown) {

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -332,11 +332,13 @@ ${scriptContent} \
 
           // Handle goto specially
           if (prop === "goto") {
+            const rawGoto: typeof target.goto =
+              Object.getPrototypeOf(target).goto.bind(target);
             return async (url: string, options: GotoOptions) => {
               this.intContext.setActivePage(this);
               const result = this.api
                 ? await this.api.goto(url, options)
-                : await target.goto(url, options);
+                : await rawGoto(url, options);
 
               this.stagehand.addToHistory("navigate", { url, options }, result);
 


### PR DESCRIPTION
# why
- `stagehand.history` was only storing history for `goto`
# what changed
- moved the `history` array onto to the `stagehand` object instead of having it tracked at the page level
# test plan
- evals
