### PR TITLE
build xPaths in node

### DIFF
--- a/.changeset/sweet-onions-argue.md
+++ b/.changeset/sweet-onions-argue.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand-lib": patch
+---
+
+build xpaths on node side instead of using injected JS

--- a/lib/handlers/observeHandler.ts
+++ b/lib/handlers/observeHandler.ts
@@ -4,10 +4,7 @@ import { observe } from "../inference";
 import { LLMClient } from "../llm/LLMClient";
 import { StagehandPage } from "../StagehandPage";
 import { drawObserveOverlay } from "../utils";
-import {
-  getAccessibilityTree,
-  getXPathByResolvedObjectId,
-} from "../a11y/utils";
+import { getAccessibilityTree } from "../a11y/utils";
 import { AccessibilityNode } from "../../types/context";
 
 export class StagehandObserveHandler {
@@ -90,6 +87,7 @@ export class StagehandObserveHandler {
     const tree = await getAccessibilityTree(this.stagehandPage, this.logger);
     const outputString = tree.simplified;
     iframes = tree.iframes;
+    const idToXpath = tree.idToXpath;
 
     // No screenshot or vision-based annotation is performed
     const observationResponse = await observe({
@@ -145,23 +143,7 @@ export class StagehandObserveHandler {
           },
         });
 
-        const args = { backendNodeId: elementId };
-        const { object } = await this.stagehandPage.sendCDP<{
-          object: { objectId: string };
-        }>("DOM.resolveNode", args);
-
-        if (!object || !object.objectId) {
-          this.logger({
-            category: "observation",
-            message: `Invalid object ID returned for element: ${elementId}`,
-            level: 1,
-          });
-        }
-
-        const xpath = await getXPathByResolvedObjectId(
-          await this.stagehandPage.getCDPClient(),
-          object.objectId,
-        );
+        const xpath = idToXpath[elementId];
 
         if (!xpath || xpath === "") {
           this.logger({

--- a/types/context.ts
+++ b/types/context.ts
@@ -21,6 +21,7 @@ export interface AXNode {
 
 export type AccessibilityNode = {
   role: string;
+  xpath: string;
   name?: string;
   description?: string;
   value?: string;
@@ -43,6 +44,15 @@ export interface TreeResult {
   simplified: string;
   iframes?: AccessibilityNode[];
   idToUrl: Record<string, string>;
+  idToXpath: Record<string, string>;
+}
+
+export interface DomNode {
+  nodeId: number;
+  backendNodeId: number;
+  nodeName: string;
+  parentId?: number;
+  children?: DomNode[];
 }
 
 export interface EnhancedContext


### PR DESCRIPTION
# why
- we should minimize the amount of javascript that we need to inject
- we can build a lot of xPaths quickly using the same logic that is used in the Chrome Devtools UI (eg, when you do 'copy full xPath')
- storing xPaths in a map where IDs are keys and xPaths are values makes for a super fast lookup. this also gets us a step closer to repeatable `extract`
# what changed
- added an `xpath` field to our `AccessibilityNode` type
- added an `idToXpath` map to our `TreeResult` type
- added an `xpathFor()` function in `a11y/utils.ts` which builds an xpath for a given node
# test plan
- regression evals
- `act` evals
- `observe` evals
- targeted `extract` evals