### PR TITLE
Error on failed CDP connection

### DIFF
--- a/.changeset/chatty-owls-think.md
+++ b/.changeset/chatty-owls-think.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand-lib": patch
+---
+
+Fix context init error on undefined context

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -754,6 +754,16 @@ export class Stagehand {
       });
     this.contextPath = contextPath;
     this._browser = browser;
+    if (!context) {
+      const errorMessage =
+        "The browser context is undefined. This means the CDP connection to the browser failed";
+      this.stagehandLogger.error(
+        this.env === "LOCAL"
+          ? `${errorMessage}. If running locally, please check if the browser is running and the port is open.`
+          : errorMessage,
+      );
+      process.exit(1);
+    }
     this.stagehandContext = await StagehandContext.init(context, this);
 
     const defaultPage = (await this.stagehandContext.getStagehandPages())[0];

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -43,6 +43,7 @@ import {
   UnsupportedModelError,
   UnsupportedAISDKModelProviderError,
   InvalidAISDKModelFormatError,
+  StagehandInitError,
 } from "../types/stagehandErrors";
 import { z } from "zod";
 import { GotoOptions } from "@/types/playwright";
@@ -762,7 +763,7 @@ export class Stagehand {
           ? `${errorMessage}. If running locally, please check if the browser is running and the port is open.`
           : errorMessage,
       );
-      process.exit(1);
+      throw new StagehandInitError(errorMessage);
     }
     this.stagehandContext = await StagehandContext.init(context, this);
 

--- a/types/stagehandErrors.ts
+++ b/types/stagehandErrors.ts
@@ -195,3 +195,9 @@ ${JSON.stringify(issues, null, 2)}`);
     this.name = "ZodSchemaValidationError";
   }
 }
+
+export class StagehandInitError extends StagehandError {
+  constructor(message: string) {
+    super(`${message}`);
+  }
+}

--- a/types/stagehandErrors.ts
+++ b/types/stagehandErrors.ts
@@ -198,6 +198,6 @@ ${JSON.stringify(issues, null, 2)}`);
 
 export class StagehandInitError extends StagehandError {
   constructor(message: string) {
-    super(`${message}`);
+    super(message);
   }
 }


### PR DESCRIPTION
# why
Stagehand is worthless without a browser connection. The current thrown error is too vague

# what changed
If the context is undefined in `init()` we should not attempt to create a custom proxy to the browser. Instead, we should catch that and exit.
Improves the current trace:
```
TypeError: Cannot create proxy with a non-object as target or handler
    at new _StagehandContext (/Users/miguel-browserbase/Documents/Browserbase/stagehand/dist/index.js:3643:23)
    at _StagehandContext.<anonymous> (/Users/miguel-browserbase/Documents/Browserbase/stagehand/dist/index.js:3695:24)
    at Generator.next (<anonymous>)
    at /Users/miguel-browserbase/Documents/Browserbase/stagehand/dist/index.js:79:61
    at new Promise (<anonymous>)
    at __async (/Users/miguel-browserbase/Documents/Browserbase/stagehand/dist/index.js:63:10)
    at _StagehandContext.init (/Users/miguel-browserbase/Documents/Browserbase/stagehand/dist/index.js:3694:12)
    at Stagehand3.<anonymous> (/Users/miguel-browserbase/Documents/Browserbase/stagehand/dist/index.js:21771:54)
    at Generator.next (<anonymous>)
    at fulfilled (/Users/miguel-browserbase/Documents/Browserbase/stagehand/dist/index.js:66:24)
```
To
```
StagehandInitError: The browser context is undefined. This means the CDP connection to the browser failed
    at Stagehand3.<anonymous> (/Users/miguel-browserbase/Documents/Browserbase/stagehand/dist/index.js:21812:15)
    at Generator.next (<anonymous>)
    at fulfilled (/Users/miguel-browserbase/Documents/Browserbase/stagehand/dist/index.js:66:24)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
```

# test plan
