### PR TITLE
optimize CDP calls when building hybrid tree

### DIFF
--- a/.changeset/deep-apes-hug.md
+++ b/.changeset/deep-apes-hug.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand-lib": patch
+---
+
+optimize CDP calls when building hybrid tree

--- a/types/context.ts
+++ b/types/context.ts
@@ -45,6 +45,14 @@ export interface TreeResult {
   idToUrl: Record<string, string>;
 }
 
+export type DOMNode = {
+  backendNodeId?: number;
+  nodeName?: string;
+  children?: DOMNode[];
+  shadowRoots?: DOMNode[];
+  contentDocument?: DOMNode;
+};
+
 export interface EnhancedContext
   extends Omit<PlaywrightContext, "newPage" | "pages"> {
   newPage(): Promise<Page>;


### PR DESCRIPTION
# why
- when building the hybrid tree, we replace empty role names with the corresponding HTML element names
- currently, we do this by making two separate CDP calls for every node that we want to replace the role of. Namely:
   - `DOM.resolveNode`
   - `Runtime.callFunctionOn`
- this is super expensive and slow. its 2 x RTT for every node that we want to replace
- On sites like wikipedia, there could be hundreds of these
- The solution is to call `DOM.getDocument`, once up front, build a dictionary of ID->tagName, and then we can swap in role names for tagNames as needed with a super fast dictionary lookup
# what changed
- added a `buildBackendIdTagNameMap` which calls `DOM.getDocument` and builds a mapping of `backendNodeId` -> `nodeName`
- updated `cleanStructuralNodes` to use the mapping for lookups instead of making individual CDP calls for every node we want to replace the name of
- when testing locally on wikipedia, this dropped the time for getting the accessibility tree from 1043ms down to 39ms
# test plan
- regression evals
- `act` evals
- `extract` evals
- `observe` evals