### PR TITLE
add llm client option for AI SDK experimental telemetry config

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -18,7 +18,7 @@ import {
   ObserveOptions,
   ObserveResult,
 } from "../types/stagehand";
-import { AgentExecuteOptions, AgentResult } from ".";
+import { AgentExecuteOptions, AgentResult } from "../types/agent";
 import {
   StagehandAPIUnauthorizedError,
   StagehandHttpError,

--- a/lib/llm/LLMProvider.ts
+++ b/lib/llm/LLMProvider.ts
@@ -172,6 +172,7 @@ export class LLMProvider {
         logger: this.logger,
         enableCaching: this.enableCaching,
         cache: this.cache,
+        telemetrySettings: clientOptions?.aiSdkTelemetrySettings,
       });
     }
 

--- a/lib/llm/aisdk.ts
+++ b/lib/llm/aisdk.ts
@@ -15,6 +15,7 @@ import { LogLine } from "../../types/log";
 import { AvailableModel } from "../../types/model";
 import { ChatCompletion } from "openai/resources";
 import { LLMCache } from "../cache/LLMCache";
+import type { TelemetrySettings } from "ai";
 
 export class AISdkClient extends LLMClient {
   public type = "aisdk" as const;
@@ -22,23 +23,27 @@ export class AISdkClient extends LLMClient {
   private logger?: (message: LogLine) => void;
   private cache: LLMCache | undefined;
   private enableCaching: boolean;
+  private telemetrySettings: TelemetrySettings | undefined;
 
   constructor({
     model,
     logger,
     enableCaching = false,
     cache,
+    telemetrySettings,
   }: {
     model: LanguageModel;
     logger?: (message: LogLine) => void;
     enableCaching?: boolean;
     cache?: LLMCache;
+    telemetrySettings?: TelemetrySettings;
   }) {
     super(model.modelId as AvailableModel);
     this.model = model;
     this.logger = logger;
     this.cache = cache;
     this.enableCaching = enableCaching;
+    this.telemetrySettings = telemetrySettings;
   }
 
   async createChatCompletion<T = ChatCompletion>({
@@ -161,6 +166,7 @@ export class AISdkClient extends LLMClient {
         model: this.model,
         messages: formattedMessages,
         schema: options.response_model.schema,
+        experimental_telemetry: this.telemetrySettings,
       });
 
       const result = {
@@ -227,6 +233,7 @@ export class AISdkClient extends LLMClient {
       model: this.model,
       messages: formattedMessages,
       tools,
+      experimental_telemetry: this.telemetrySettings,
     });
 
     const result = {

--- a/types/model.ts
+++ b/types/model.ts
@@ -1,4 +1,5 @@
 import type { ClientOptions as AnthropicClientOptions } from "@anthropic-ai/sdk";
+import type { TelemetrySettings } from "ai";
 import type { ClientOptions as OpenAIClientOptions } from "openai";
 import { z } from "zod";
 
@@ -44,7 +45,9 @@ export type ModelProvider =
   | "google"
   | "aisdk";
 
-export type ClientOptions = OpenAIClientOptions | AnthropicClientOptions;
+export type ClientOptions = (OpenAIClientOptions | AnthropicClientOptions) & {
+  aiSdkTelemetrySettings?: TelemetrySettings;
+};
 
 export interface AnthropicJsonSchemaObject {
   definitions?: {

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -6,7 +6,6 @@ import { AvailableModel, ClientOptions } from "./model";
 import { LLMClient } from "../lib/llm/LLMClient";
 import { Cookie } from "@playwright/test";
 import { AgentProviderType } from "./agent";
-import type { TelemetrySettings } from "ai";
 
 export interface ConstructorParams {
   /**
@@ -97,11 +96,6 @@ export interface ConstructorParams {
    * Disable Pino (helpful for Next.js or test environments)
    */
   disablePino?: boolean;
-
-  /**
-   * Configuration passed to the AI SDK for telemetry
-   */
-  aiSdkExperimentalTelemetry?: TelemetrySettings;
 }
 
 export interface InitResult {

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -6,6 +6,7 @@ import { AvailableModel, ClientOptions } from "./model";
 import { LLMClient } from "../lib/llm/LLMClient";
 import { Cookie } from "@playwright/test";
 import { AgentProviderType } from "./agent";
+import type { TelemetrySettings } from "ai";
 
 export interface ConstructorParams {
   /**
@@ -96,6 +97,11 @@ export interface ConstructorParams {
    * Disable Pino (helpful for Next.js or test environments)
    */
   disablePino?: boolean;
+
+  /**
+   * Configuration passed to the AI SDK for telemetry
+   */
+  aiSdkExperimentalTelemetry?: TelemetrySettings;
 }
 
 export interface InitResult {


### PR DESCRIPTION
Note: sorry, doesn't seem like evals branch recommended in your [contributing guide](https://docs.stagehand.dev/examples/contributing) exists

# why

To enhance Laminar (or any other) observability for AI SDK calls.

Allow users to configure telemetry for AI SDK

# what changed

Added a new field to `ClientOptions` and passed it down the `generateText` and `generateObject` calls.

# test plan

Tested manually with a simple Laminar script:

```javascript
import { Laminar, getTracer } from "@lmnr-ai/lmnr";
import { Stagehand } from "@browserbasehq/stagehand";
import dotenv from "dotenv";
dotenv.config();

Laminar.initialize({
  instrumentModules: {
    stagehand: Stagehand,
  },
});

async function example() {
  const stagehand = new Stagehand({
    modelName: "anthropic/claude-3-7-sonnet-latest",
    modelClientOptions: {
      apiKey: process.env.ANTHROPIC_API_KEY,
      aiSdkTelemetrySettings: {
        isEnabled: true,
        tracer: getTracer(),
      }
    },
    env: "LOCAL",
    verbose: 0,
  });
  await stagehand.init();
  const page = stagehand.page;

  await page.goto("https://www.lmnr.ai/");

  await page.act("open the blogs page");
  // ...

  await stagehand.close();
}

(async () => {
  await example();
  await Laminar.flush();
})().then(() => {
  console.log('done');
});
```