### PR TITLE
Allow session id to be passed through env vars

### DIFF
--- a/stagehand.config.ts
+++ b/stagehand.config.ts
@@ -20,7 +20,7 @@ const StagehandConfig: ConstructorParams = {
   apiKey: process.env.BROWSERBASE_API_KEY /* API key for authentication */,
   projectId: process.env.BROWSERBASE_PROJECT_ID /* Project identifier */,
   browserbaseSessionID:
-    undefined /* Session ID for resuming Browserbase sessions */,
+    process.env.BROWSERBASE_SESSION_ID /* Session ID for resuming Browserbase sessions */,
   browserbaseSessionCreateParams: {
     projectId: process.env.BROWSERBASE_PROJECT_ID!,
     browserSettings: {


### PR DESCRIPTION
If a user instantiates a browserbase session ( which would support live view url ), this allows them to continue the session with stagehand. 

# why
This is helpful for developers who want to embed the stagehand session in their product since they can now use the live view url provided by browserbase instantiation.

# what changed
Allow session id to be passed through env vars

# test plan
Backward compatible change since default will still be `undefined`.