### PR TITLE
adjust log levels for `act`

### DIFF
--- a/lib/handlers/actHandler.ts
+++ b/lib/handlers/actHandler.ts
@@ -69,7 +69,7 @@ export class StagehandActHandler {
       this.logger({
         category: "action",
         message: "Cannot execute ObserveResult with unsupported method",
-        level: 1,
+        level: 0,
         auxiliary: {
           error: {
             value:
@@ -113,7 +113,7 @@ export class StagehandActHandler {
         this.logger({
           category: "action",
           message: "Error performing act from an ObserveResult",
-          level: 1,
+          level: 0,
           auxiliary: {
             error: { value: err.message, type: "string" },
             trace: { value: err.stack, type: "string" },
@@ -130,7 +130,7 @@ export class StagehandActHandler {
         category: "action",
         message:
           "Error performing act from an ObserveResult. Reprocessing the page and trying again",
-        level: 1,
+        level: 0,
         auxiliary: {
           error: { value: err.message, type: "string" },
           trace: { value: err.stack, type: "string" },
@@ -154,7 +154,7 @@ export class StagehandActHandler {
         this.logger({
           category: "action",
           message: "Error performing act from an ObserveResult on fallback",
-          level: 1,
+          level: 0,
           auxiliary: {
             error: { value: err.message, type: "string" },
             trace: { value: err.stack, type: "string" },
@@ -324,7 +324,7 @@ export class StagehandActHandler {
         this.logger({
           category: "action",
           message: "chosen method is invalid",
-          level: 1,
+          level: 0,
           auxiliary: {
             method: { value: method, type: "string" },
           },
@@ -340,7 +340,7 @@ export class StagehandActHandler {
       this.logger({
         category: "action",
         message: "error performing method",
-        level: 1,
+        level: 0,
         auxiliary: {
           error: { value: e.message, type: "string" },
           trace: { value: e.stack, type: "string" },

--- a/lib/handlers/handlerUtils/actHandlerUtils.ts
+++ b/lib/handlers/handlerUtils/actHandlerUtils.ts
@@ -142,7 +142,7 @@ export async function scrollToPreviousChunk(ctx: MethodHandlerContext) {
     logger({
       category: "action",
       message: "error scrolling to previous chunk",
-      level: 1,
+      level: 0,
       auxiliary: {
         error: { value: e.message, type: "string" },
         trace: { value: e.stack, type: "string" },
@@ -173,7 +173,7 @@ export async function scrollElementIntoView(ctx: MethodHandlerContext) {
     logger({
       category: "action",
       message: "error scrolling element into view",
-      level: 1,
+      level: 0,
       auxiliary: {
         error: { value: e.message, type: "string" },
         trace: { value: e.stack, type: "string" },
@@ -243,7 +243,7 @@ export async function scrollElementToPercentage(ctx: MethodHandlerContext) {
     logger({
       category: "action",
       message: "error scrolling element vertically to percentage",
-      level: 1,
+      level: 0,
       auxiliary: {
         error: { value: e.message, type: "string" },
         trace: { value: e.stack, type: "string" },
@@ -266,7 +266,7 @@ export async function fillOrType(ctx: MethodHandlerContext) {
     logger({
       category: "action",
       message: "error filling element",
-      level: 1,
+      level: 0,
       auxiliary: {
         error: { value: e.message, type: "string" },
         trace: { value: e.stack, type: "string" },
@@ -303,7 +303,7 @@ export async function pressKey(ctx: MethodHandlerContext) {
     logger({
       category: "action",
       message: "error pressing key",
-      level: 1,
+      level: 0,
       auxiliary: {
         error: { value: e.message, type: "string" },
         trace: { value: e.stack, type: "string" },
@@ -345,7 +345,7 @@ export async function clickElement(ctx: MethodHandlerContext) {
     logger({
       category: "action",
       message: "error performing click",
-      level: 1,
+      level: 0,
       auxiliary: {
         error: { value: e.message, type: "string" },
         trace: { value: e.stack, type: "string" },
@@ -392,7 +392,7 @@ export async function fallbackLocatorMethod(ctx: MethodHandlerContext) {
     logger({
       category: "action",
       message: "error performing method",
-      level: 1,
+      level: 0,
       auxiliary: {
         error: { value: e.message, type: "string" },
         trace: { value: e.stack, type: "string" },
@@ -416,7 +416,7 @@ async function handlePossiblePageNavigation(
   logger({
     category: "action",
     message: `${actionDescription}, checking for page navigation`,
-    level: 1,
+    level: 0,
     auxiliary: {
       xpath: { value: xpath, type: "string" },
     },


### PR DESCRIPTION
# why
- these are errors that are being caught & not rethrown, but we should make sure we are setting the correct log level
# what changed
- changed log levels inside `actHandler.ts` and `actHandlerUtils.ts` to 0 (the Error level) when we catch & swallow an error
# test plan
- evals