### PR TITLE
Removed default chromium flags that delay browser launching - LOCAL

### DIFF
--- a/.changeset/loud-poems-wear.md
+++ b/.changeset/loud-poems-wear.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand-lib": patch
+---
+
+Removed default chromium flags that delay browser launching

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -289,11 +289,7 @@ async function getBrowser(
       timezoneId: localBrowserLaunchOptions?.timezoneId ?? "America/New_York",
       deviceScaleFactor: localBrowserLaunchOptions?.deviceScaleFactor ?? 1,
       args: localBrowserLaunchOptions?.args ?? [
-        "--enable-webgl",
-        "--use-gl=swiftshader",
-        "--enable-accelerated-2d-canvas",
         "--disable-blink-features=AutomationControlled",
-        "--disable-web-security",
       ],
       bypassCSP: localBrowserLaunchOptions?.bypassCSP ?? true,
       proxy: localBrowserLaunchOptions?.proxy,


### PR DESCRIPTION
# why
A local browser takes a while to load due to certain flags

# what changed
Disabled defaults (still optionally provided through config) to speed up local browser launching

# test plan
