### PR TITLE
Fix new tab url intercept for aboutblank

### DIFF
--- a/.changeset/fuzzy-jobs-switch.md
+++ b/.changeset/fuzzy-jobs-switch.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand-lib": patch
+---
+
+Fixes an issue with the new tab intercepts for invalid urls

--- a/lib/handlers/handlerUtils/actHandlerUtils.ts
+++ b/lib/handlers/handlerUtils/actHandlerUtils.ts
@@ -441,7 +441,7 @@ async function handlePossiblePageNavigation(
     },
   });
 
-  if (newOpenedTab) {
+  if (newOpenedTab && newOpenedTab.url() !== "about:blank") {
     logger({
       category: "action",
       message: "new page detected (new tab) with URL",


### PR DESCRIPTION
# why
New tabs opened by popups/link redirects could contain invalid urls

# what changed
Avoid tab redirect on main page with an invalid url

# test plan