### PR TITLE
iframes

### DIFF
--- a/.changeset/sixty-bikes-grab.md
+++ b/.changeset/sixty-bikes-grab.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand-lib": minor
+---
+
+iframe support

--- a/docs/reference/act.mdx
+++ b/docs/reference/act.mdx
@@ -45,6 +45,10 @@ You can pass an `ObserveResult` to `act()` to perform the suggested action, whic
     Variables to use in the action. Variables in the action string are referenced using %variable_name%
   </ParamField>
 
+  <ParamField path="iframes" type="boolean" optional>
+    Set `iframes: true` if the target element exists within an iframe
+  </ParamField>
+
   <ParamField path="domSettleTimeoutMs" type="number" optional>
     Timeout in milliseconds for waiting for the DOM to settle
   </ParamField>

--- a/docs/reference/extract.mdx
+++ b/docs/reference/extract.mdx
@@ -107,6 +107,10 @@ const apartments = await stagehand.page.extract({
     Defines the structure of the data to extract
   </ParamField>
 
+  <ParamField path="iframes" type="boolean" optional>
+      Set `iframes: true` if the extraction content exists within an iframe.
+  </ParamField>
+
   <ParamField path="useTextExtract" type="boolean" deprecated>
     This field is now **deprecated** and has no effect.
   </ParamField>

--- a/docs/reference/observe.mdx
+++ b/docs/reference/observe.mdx
@@ -37,6 +37,10 @@ Observe can also return a suggested action for the candidate element by setting 
     Returns an observe result object that contains a suggested action for the candidate element. The suggestion includes method, and arguments (if any). Defaults to `true`.
   </ParamField>
 
+  <ParamField path="iframes" type="boolean" optional>
+    Set `iframes: true` if content from iframes should be included in the observation.
+  </ParamField>
+
   <ParamField path="modelName" type="AvailableModel" optional>
     Specifies the model to use
   </ParamField>

--- a/evals/evals.config.json
+++ b/evals/evals.config.json
@@ -358,6 +358,10 @@
     {
       "name": "iframe_form_filling",
       "categories": ["act"]
+    },
+    {
+      "name": "iframes_nested",
+      "categories": ["act"]
     }
   ]
 }

--- a/evals/evals.config.json
+++ b/evals/evals.config.json
@@ -350,6 +350,14 @@
     {
       "name": "iframe_hn",
       "categories": ["extract"]
+    },
+    {
+      "name": "iframe_same_proc",
+      "categories": ["act"]
+    },
+    {
+      "name": "iframe_form_filling",
+      "categories": ["act"]
     }
   ]
 }

--- a/evals/evals.config.json
+++ b/evals/evals.config.json
@@ -346,6 +346,10 @@
     {
       "name": "login",
       "categories": ["act", "regression"]
+    },
+    {
+      "name": "iframe_hn",
+      "categories": ["extract"]
     }
   ]
 }

--- a/evals/initStagehand.ts
+++ b/evals/initStagehand.ts
@@ -38,6 +38,7 @@ const StagehandConfig = {
   enableCaching,
   domSettleTimeoutMs: 30_000,
   disablePino: true,
+  experimental: true,
   browserbaseSessionCreateParams: {
     projectId: process.env.BROWSERBASE_PROJECT_ID!,
     browserSettings: {

--- a/evals/tasks/iframe_form_filling.ts
+++ b/evals/tasks/iframe_form_filling.ts
@@ -1,0 +1,55 @@
+import { EvalFunction } from "@/types/evals";
+
+export const iframe_form_filling: EvalFunction = async ({
+  debugUrl,
+  sessionUrl,
+  stagehand,
+  logger,
+}) => {
+  const page = stagehand.page;
+  await page.goto(
+    "https://browserbase.github.io/stagehand-eval-sites/sites/iframe-form-filling/",
+  );
+
+  await page.act("type 'nunya' into the 'first name' field");
+  await page.act("type 'business' into the 'last name' field");
+  await page.act("type 'test@email.com' into the 'email' field");
+  await page.act("click 'phone' as the preferred contact method");
+  await page.act("type 'yooooooooooooooo' into the message box");
+
+  const iframe = page.frameLocator("iframe");
+
+  const firstNameValue: string = await iframe
+    .locator('input[placeholder="Jane"]')
+    .inputValue();
+
+  const lastNameValue: string = await iframe
+    .locator('input[placeholder="Doe"]')
+    .inputValue();
+
+  const emailValue: string = await iframe
+    .locator('input[placeholder="jane@example.com"]')
+    .inputValue();
+
+  const contactValue: boolean = await iframe
+    .locator("xpath=/html/body/main/section[1]/form/fieldset/label[2]/input")
+    .isChecked();
+
+  const messsageValue: string = await iframe
+    .locator('textarea[placeholder="Say hello…"]')
+    .inputValue();
+
+  const passed: boolean =
+    firstNameValue.toLowerCase().trim() === "nunya" &&
+    lastNameValue.toLowerCase().trim() === "business" &&
+    emailValue.toLowerCase() === "test@email.com" &&
+    messsageValue.toLowerCase() === "yooooooooooooooo" &&
+    contactValue;
+
+  return {
+    _success: passed,
+    logs: logger.getLogs(),
+    debugUrl,
+    sessionUrl,
+  };
+};

--- a/evals/tasks/iframe_form_filling.ts
+++ b/evals/tasks/iframe_form_filling.ts
@@ -50,7 +50,7 @@ export const iframe_form_filling: EvalFunction = async ({
     .locator("xpath=/html/body/main/section[1]/form/fieldset/label[2]/input")
     .isChecked();
 
-  const messsageValue: string = await iframe
+  const messageValue: string = await iframe
     .locator('textarea[placeholder="Say hello…"]')
     .inputValue();
 
@@ -58,7 +58,7 @@ export const iframe_form_filling: EvalFunction = async ({
     firstNameValue.toLowerCase().trim() === "nunya" &&
     lastNameValue.toLowerCase().trim() === "business" &&
     emailValue.toLowerCase() === "test@email.com" &&
-    messsageValue.toLowerCase() === "yooooooooooooooo" &&
+    messageValue.toLowerCase() === "yooooooooooooooo" &&
     contactValue;
 
   return {

--- a/evals/tasks/iframe_form_filling.ts
+++ b/evals/tasks/iframe_form_filling.ts
@@ -11,11 +11,26 @@ export const iframe_form_filling: EvalFunction = async ({
     "https://browserbase.github.io/stagehand-eval-sites/sites/iframe-form-filling/",
   );
 
-  await page.act("type 'nunya' into the 'first name' field");
-  await page.act("type 'business' into the 'last name' field");
-  await page.act("type 'test@email.com' into the 'email' field");
-  await page.act("click 'phone' as the preferred contact method");
-  await page.act("type 'yooooooooooooooo' into the message box");
+  await page.act({
+    action: "type 'nunya' into the 'first name' field",
+    iframes: true,
+  });
+  await page.act({
+    action: "type 'business' into the 'last name' field",
+    iframes: true,
+  });
+  await page.act({
+    action: "type 'test@email.com' into the 'email' field",
+    iframes: true,
+  });
+  await page.act({
+    action: "click 'phone' as the preferred contact method",
+    iframes: true,
+  });
+  await page.act({
+    action: "type 'yooooooooooooooo' into the message box",
+    iframes: true,
+  });
 
   const iframe = page.frameLocator("iframe");
 

--- a/evals/tasks/iframe_hn.ts
+++ b/evals/tasks/iframe_hn.ts
@@ -1,0 +1,57 @@
+import { EvalFunction } from "@/types/evals";
+
+export const iframe_hn: EvalFunction = async ({
+  debugUrl,
+  sessionUrl,
+  stagehand,
+  logger,
+}) => {
+  const page = stagehand.page;
+  await page.goto(
+    "https://browserbase.github.io/stagehand-eval-sites/sites/iframe-hn/",
+  );
+
+  const result = await page.extract(
+    "extract the title of the first hackernews story",
+  );
+
+  await stagehand.close();
+
+  const title = result.extraction.toLowerCase();
+  const expectedTitleSubstring = "overengineered anchor links";
+
+  if (!title.includes(expectedTitleSubstring)) {
+    logger.error({
+      message: `Extracted title: ${title} does not contain expected substring: ${expectedTitleSubstring}`,
+      level: 0,
+    });
+    return {
+      _success: false,
+      error: `Extracted title: ${title} does not contain expected substring: ${expectedTitleSubstring}`,
+      logs: logger.getLogs(),
+      debugUrl,
+      sessionUrl,
+    };
+  }
+
+  if (!title.includes(expectedTitleSubstring)) {
+    logger.error({
+      message: `Extracted title: ${title} does not contain expected substring: ${expectedTitleSubstring}`,
+      level: 0,
+    });
+    return {
+      _success: false,
+      error: `Extracted title: ${title} does not contain expected substring: ${expectedTitleSubstring}`,
+      logs: logger.getLogs(),
+      debugUrl,
+      sessionUrl,
+    };
+  }
+
+  return {
+    _success: true,
+    logs: logger.getLogs(),
+    debugUrl,
+    sessionUrl,
+  };
+};

--- a/evals/tasks/iframe_hn.ts
+++ b/evals/tasks/iframe_hn.ts
@@ -39,20 +39,6 @@ export const iframe_hn: EvalFunction = async ({
     };
   }
 
-  if (!title.includes(expectedTitleSubstring)) {
-    logger.error({
-      message: `Extracted title: ${title} does not contain expected substring: ${expectedTitleSubstring}`,
-      level: 0,
-    });
-    return {
-      _success: false,
-      error: `Extracted title: ${title} does not contain expected substring: ${expectedTitleSubstring}`,
-      logs: logger.getLogs(),
-      debugUrl,
-      sessionUrl,
-    };
-  }
-
   return {
     _success: true,
     logs: logger.getLogs(),

--- a/evals/tasks/iframe_hn.ts
+++ b/evals/tasks/iframe_hn.ts
@@ -1,4 +1,5 @@
 import { EvalFunction } from "@/types/evals";
+import { z } from "zod";
 
 export const iframe_hn: EvalFunction = async ({
   debugUrl,
@@ -11,13 +12,17 @@ export const iframe_hn: EvalFunction = async ({
     "https://browserbase.github.io/stagehand-eval-sites/sites/iframe-hn/",
   );
 
-  const result = await page.extract(
-    "extract the title of the first hackernews story",
-  );
+  const result = await page.extract({
+    instruction: "extract the title of the first hackernews story",
+    schema: z.object({
+      story_title: z.string(),
+    }),
+    iframes: true,
+  });
 
   await stagehand.close();
 
-  const title = result.extraction.toLowerCase();
+  const title = result.story_title.toLowerCase();
   const expectedTitleSubstring = "overengineered anchor links";
 
   if (!title.includes(expectedTitleSubstring)) {

--- a/evals/tasks/iframe_same_proc.ts
+++ b/evals/tasks/iframe_same_proc.ts
@@ -11,13 +11,18 @@ export const iframe_same_proc: EvalFunction = async ({
     "https://browserbase.github.io/stagehand-eval-sites/sites/iframe-same-proc/",
   );
 
-  await page.act("type 'stagehand' into the 'your name' field");
+  await page.act({
+    action: "type 'stagehand' into the 'your name' field",
+    iframes: true,
+  });
 
   // overly specific prompting is okay here. we are just trying to evaluate whether
   // we are properly traversing iframes
-  await page.act(
-    "select 'Green' from the favorite colour dropdown. Ensure the word 'Green' is capitalized. Choose the selectOption playwright method.",
-  );
+  await page.act({
+    action:
+      "select 'Green' from the favorite colour dropdown. Ensure the word 'Green' is capitalized. Choose the selectOption playwright method.",
+    iframes: true,
+  });
 
   const iframe = page.frameLocator("iframe");
 

--- a/evals/tasks/iframe_same_proc.ts
+++ b/evals/tasks/iframe_same_proc.ts
@@ -1,0 +1,40 @@
+import { EvalFunction } from "@/types/evals";
+
+export const iframe_same_proc: EvalFunction = async ({
+  debugUrl,
+  sessionUrl,
+  stagehand,
+  logger,
+}) => {
+  const page = stagehand.page;
+  await page.goto(
+    "https://browserbase.github.io/stagehand-eval-sites/sites/iframe-same-proc/",
+  );
+
+  await page.act("type 'stagehand' into the 'your name' field");
+
+  // overly specific prompting is okay here. we are just trying to evaluate whether
+  // we are properly traversing iframes
+  await page.act(
+    "select 'Green' from the favorite colour dropdown. Ensure the word 'Green' is capitalized. Choose the selectOption playwright method.",
+  );
+
+  const iframe = page.frameLocator("iframe");
+
+  const nameValue: string = await iframe
+    .locator('input[placeholder="Alice"]')
+    .inputValue();
+
+  const colorValue: string = await iframe.locator("select").inputValue();
+
+  const passed: boolean =
+    nameValue.toLowerCase().trim() === "stagehand" &&
+    colorValue.toLowerCase().trim() === "green";
+
+  return {
+    _success: passed,
+    logs: logger.getLogs(),
+    debugUrl,
+    sessionUrl,
+  };
+};

--- a/evals/tasks/iframes_nested.ts
+++ b/evals/tasks/iframes_nested.ts
@@ -1,0 +1,49 @@
+import { EvalFunction } from "@/types/evals";
+import { FrameLocator } from "@playwright/test";
+
+export const iframes_nested: EvalFunction = async ({
+  debugUrl,
+  sessionUrl,
+  stagehand,
+  logger,
+}) => {
+  const page = stagehand.page;
+  try {
+    await page.goto(
+      "https://browserbase.github.io/stagehand-eval-sites/sites/nested-iframes/",
+    );
+
+    await page.act({
+      action: "type 'stagehand' into the 'username' field",
+      iframes: true,
+    });
+
+    const inner: FrameLocator = page
+      .frameLocator("iframe.lvl1") // level 1
+      .frameLocator("iframe.lvl2") // level 2
+      .frameLocator("iframe.lvl3"); // level 3 – form lives here
+
+    const usernameText = await inner
+      .locator('input[name="username"]')
+      .inputValue();
+
+    const passed: boolean = usernameText.toLowerCase().trim() === "stagehand";
+
+    return {
+      _success: passed,
+      logs: logger.getLogs(),
+      debugUrl,
+      sessionUrl,
+    };
+  } catch (error) {
+    return {
+      _success: false,
+      logs: logger.getLogs(),
+      debugUrl,
+      sessionUrl,
+      error,
+    };
+  } finally {
+    await stagehand.close();
+  }
+};

--- a/examples/example.ts
+++ b/examples/example.ts
@@ -6,22 +6,28 @@
  */
 
 import { Stagehand } from "@browserbasehq/stagehand";
-import StagehandConfig from "../stagehand.config";
 
 async function example(stagehand: Stagehand) {
   /**
    * Add your code here!
    */
   const page = stagehand.page;
-  await page.goto("https://docs.stagehand.dev");
-  await page.act("click the quickstart button");
+  await page.goto("https://aca-prod.accela.com/BALTIMORE/welcome.aspx");
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+  // await page.act("type 'testusername' into the username field");
+  await page.observe("do nothing");
+
+  // https://www.ycombinator.com/careers?ashby_jid=00c6950f-341f-4924-a456-ea32c9d5601d
+  // https://aca-prod.accela.com/BALTIMORE/welcome.aspx
+  // https://tucowsdomains.com/abuse-form/phishing/
 }
 
 (async () => {
   const stagehand = new Stagehand({
-    ...StagehandConfig,
+    env: "LOCAL",
+    verbose: 1,
+    logInferenceToFile: false,
   });
   await stagehand.init();
   await example(stagehand);
-  await stagehand.close();
 })();

--- a/examples/example.ts
+++ b/examples/example.ts
@@ -6,28 +6,22 @@
  */
 
 import { Stagehand } from "@browserbasehq/stagehand";
+import StagehandConfig from "../stagehand.config";
 
 async function example(stagehand: Stagehand) {
   /**
    * Add your code here!
    */
   const page = stagehand.page;
-  await page.goto("https://aca-prod.accela.com/BALTIMORE/welcome.aspx");
-  await new Promise((resolve) => setTimeout(resolve, 1000));
-  // await page.act("type 'testusername' into the username field");
-  await page.observe("do nothing");
-
-  // https://www.ycombinator.com/careers?ashby_jid=00c6950f-341f-4924-a456-ea32c9d5601d
-  // https://aca-prod.accela.com/BALTIMORE/welcome.aspx
-  // https://tucowsdomains.com/abuse-form/phishing/
+  await page.goto("https://docs.stagehand.dev");
+  await page.act("click the quickstart button");
 }
 
 (async () => {
   const stagehand = new Stagehand({
-    env: "LOCAL",
-    verbose: 1,
-    logInferenceToFile: false,
+    ...StagehandConfig,
   });
   await stagehand.init();
   await example(stagehand);
+  await stagehand.close();
 })();

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -758,6 +758,7 @@ ${scriptContent} \
         domSettleTimeoutMs,
         useTextExtract,
         selector,
+        iframes,
       } = options;
 
       if (this.api) {
@@ -800,6 +801,7 @@ ${scriptContent} \
           domSettleTimeoutMs,
           useTextExtract,
           selector,
+          iframes,
         })
         .catch((e) => {
           this.stagehand.log({
@@ -859,6 +861,7 @@ ${scriptContent} \
         returnAction = true,
         onlyVisible,
         drawOverlay,
+        iframes,
       } = options;
 
       if (this.api) {
@@ -907,6 +910,7 @@ ${scriptContent} \
           returnAction,
           onlyVisible,
           drawOverlay,
+          iframes,
         })
         .catch((e) => {
           this.stagehand.log({

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -131,8 +131,7 @@ export class StagehandPage {
     const cached = this.fidOrdinals.get(fid);
     if (cached !== undefined) return cached;
 
-    const next = this.fidOrdinals.size; // 1, 2, 3, …
-    if (next > 99) throw new Error("Too many frames – widen EncodedId format");
+    const next: number = this.fidOrdinals.size;
     this.fidOrdinals.set(fid, next);
     return next;
   }
@@ -970,7 +969,7 @@ ${scriptContent} \
       this.cdpClients.set(target, session);
       return session;
     } catch (err) {
-      // ── Fallback for same-process iframes ────────────────────────────
+      // Fallback for same-process iframes
       const msg = (err as Error).message ?? "";
       if (msg.includes("does not have a separate CDP session")) {
         // Re-use / create the top-level session instead
@@ -979,7 +978,7 @@ ${scriptContent} \
         this.cdpClients.set(target, rootSession);
         return rootSession;
       }
-      throw err; // genuine failure → propagate
+      throw err;
     }
   }
 
@@ -999,7 +998,6 @@ ${scriptContent} \
   ): Promise<T> {
     const client = await this.getCDPClient(target ?? this.page);
 
-    // Cast *only* at the call site, like the original helper.
     return client.send(
       method as Parameters<CDPSession["send"]>[0],
       params as Parameters<CDPSession["send"]>[1],

--- a/lib/a11y/utils.ts
+++ b/lib/a11y/utils.ts
@@ -10,6 +10,7 @@ import {
   CombinedA11yResult,
   EncodedId,
   RichNode,
+  ID_PATTERN,
 } from "../../types/context";
 import { StagehandPage } from "../StagehandPage";
 import { LogLine } from "../../types/log";
@@ -784,7 +785,7 @@ export function injectSubtrees(
     } else {
       // attempt to extract backendId from “<ordinal>-<backend>” or pure numeric label
       let backendId: number | undefined;
-      const dashMatch = /^\d+-\d+$/.exec(label);
+      const dashMatch = ID_PATTERN.exec(label);
       if (dashMatch) {
         backendId = +dashMatch[0].split("-")[1];
       } else if (/^\d+$/.test(label)) {

--- a/lib/a11y/utils.ts
+++ b/lib/a11y/utils.ts
@@ -417,7 +417,7 @@ export async function buildHierarchicalTree(
     tree: cleanedRoots,
     simplified,
     iframes: iframeList,
-    idToUrl, // EncodedId → absolute URL
+    idToUrl,
     xpathMap,
   };
 }
@@ -478,7 +478,6 @@ export async function getCDPFrameId(
  * @param logger - Logging function for diagnostics and performance metrics.
  * @param selector - Optional XPath to filter the AX tree to a specific subtree.
  * @param targetFrame - Optional Playwright.Frame to scope the AX tree retrieval.
- * @param encodeWithFrameId - Encoder mapping CDP frameId and backendNodeId to EncodedId, scoped per crawl.
  * @returns A Promise resolving to a TreeResult with the hierarchical AX tree and related metadata.
  */
 export async function getAccessibilityTree(

--- a/lib/a11y/utils.ts
+++ b/lib/a11y/utils.ts
@@ -11,6 +11,7 @@ import {
   EncodedId,
   getFrameOrdinal,
   encodeId,
+  RichNode,
 } from "../../types/context";
 import { StagehandPage } from "../StagehandPage";
 import { LogLine } from "../../types/log";
@@ -24,7 +25,6 @@ import {
   StagehandElementNotFoundError,
 } from "@/types/stagehandErrors";
 import { CDPSession, Frame } from "@playwright/test";
-// import fs from "fs";
 
 const PUA_START = 0xe000;
 const PUA_END = 0xf8ff;
@@ -352,10 +352,6 @@ async function cleanStructuralNodes(
   return { ...node, children: pruned };
 }
 
-export interface RichNode extends AccessibilityNode {
-  encodedId?: EncodedId;
-}
-
 /**
  * Convert a flat array of AccessibilityNodes into a cleaned, hierarchical tree.
  * Nodes are pruned, structural wrappers removed, and each kept node is stamped
@@ -489,10 +485,6 @@ export async function getCDPFrameId(
   /* 1️⃣  Same-proc search in the page-session tree ------------------ */
   const rootResp = (await sp.sendCDP("Page.getFrameTree")) as unknown;
   const { frameTree: root } = rootResp as { frameTree: CdpFrameTree };
-  // fs.writeFileSync(
-  //   `frameTree_${Date.now()}.json`,
-  //   JSON.stringify(root, null, 2),
-  // );
 
   const url = frame.url();
   let depth = 0;
@@ -516,10 +508,6 @@ export async function getCDPFrameId(
 
     const ownResp = (await sess.send("Page.getFrameTree")) as unknown;
     const { frameTree } = ownResp as { frameTree: CdpFrameTree };
-    // fs.writeFileSync(
-    //   `frameTree_${Date.now()}.json`,
-    //   JSON.stringify(root, null, 2),
-    // );
 
     return frameTree.frame.id; // root of OOPIF
   } catch (err) {

--- a/lib/handlers/actHandler.ts
+++ b/lib/handlers/actHandler.ts
@@ -230,6 +230,7 @@ export class StagehandActHandler {
         drawOverlay: false,
         returnAction: true,
         fromAct: true,
+        iframes: actionOrOptions?.iframes,
       });
 
       if (observeResults.length === 0) {

--- a/lib/handlers/actHandler.ts
+++ b/lib/handlers/actHandler.ts
@@ -17,6 +17,7 @@ import { buildActObservePrompt } from "../prompt";
 import {
   methodHandlerMap,
   fallbackLocatorMethod,
+  deepLocator,
 } from "./handlerUtils/actHandlerUtils";
 import { StagehandObserveHandler } from "@/lib/handlers/observeHandler";
 import { StagehandInvalidArgumentError } from "@/types/stagehandErrors";
@@ -283,7 +284,7 @@ export class StagehandActHandler {
     xpath: string,
     domSettleTimeoutMs?: number,
   ) {
-    const locator = this.stagehandPage.page.locator(`xpath=${xpath}`).first();
+    const locator = deepLocator(this.stagehandPage.page, xpath).first();
     const initialUrl = this.stagehandPage.page.url();
 
     this.logger({

--- a/lib/handlers/extractHandler.ts
+++ b/lib/handlers/extractHandler.ts
@@ -7,7 +7,10 @@ import { injectUrls, transformSchema } from "../utils";
 import { StagehandPage } from "../StagehandPage";
 import { Stagehand, StagehandFunctionName } from "../index";
 import { pageTextSchema } from "../../types/page";
-import { getAccessibilityTree } from "@/lib/a11y/utils";
+import {
+  getAccessibilityTree,
+  getAccessibilityTreeWithFrames,
+} from "@/lib/a11y/utils";
 
 export class StagehandExtractHandler {
   private readonly stagehand: Stagehand;
@@ -132,7 +135,7 @@ export class StagehandExtractHandler {
 
     await this.stagehandPage._waitForSettledDom(domSettleTimeoutMs);
     const targetXpath = selector?.replace(/^xpath=/, "") ?? "";
-    const tree = await getAccessibilityTree(
+    const tree = await getAccessibilityTreeWithFrames(
       this.stagehandPage,
       this.logger,
       targetXpath,
@@ -142,8 +145,8 @@ export class StagehandExtractHandler {
       message: "Getting accessibility tree data",
       level: 1,
     });
-    const outputString = tree.simplified;
-    const idToUrlMapping = tree.idToUrl;
+    const outputString = tree.combinedTree;
+    const idToUrlMapping = tree.combinedUrlMap;
 
     // Transform user defined schema to replace string().url() with .number()
     const [transformedSchema, urlFieldPaths] =

--- a/lib/handlers/observeHandler.ts
+++ b/lib/handlers/observeHandler.ts
@@ -4,16 +4,13 @@ import { observe } from "../inference";
 import { LLMClient } from "../llm/LLMClient";
 import { StagehandPage } from "../StagehandPage";
 import { drawObserveOverlay } from "../utils";
-import { getAccessibilityTree, getCDPFrameId } from "../a11y/utils";
-import { mkdirSync, writeFileSync } from "node:fs";
-import { join, dirname } from "node:path";
-import { Frame } from "@playwright/test";
+import { getAccessibilityTreeWithFrames } from "../a11y/utils";
+import { CombinedA11yResult } from "@/types/context";
 
 export class StagehandObserveHandler {
   private readonly stagehand: Stagehand;
   private readonly logger: (logLine: LogLine) => void;
   private readonly stagehandPage: StagehandPage;
-  private readonly debugOutput: boolean;
 
   private readonly userProvidedInstructions?: string;
   constructor({
@@ -21,26 +18,16 @@ export class StagehandObserveHandler {
     logger,
     stagehandPage,
     userProvidedInstructions,
-    debugOutput = false,
   }: {
     stagehand: Stagehand;
     logger: (logLine: LogLine) => void;
     stagehandPage: StagehandPage;
     userProvidedInstructions?: string;
-    debugOutput?: boolean;
   }) {
     this.stagehand = stagehand;
     this.logger = logger;
     this.stagehandPage = stagehandPage;
     this.userProvidedInstructions = userProvidedInstructions;
-    if (debugOutput) mkdirSync("out", { recursive: true });
-  }
-
-  private writeDebug(relPath: string, data: string): void {
-    if (!this.debugOutput) return;
-    const abs = join("out", relPath);
-    mkdirSync(dirname(abs), { recursive: true });
-    writeFileSync(abs, data, "utf-8");
   }
 
   public async observe({
@@ -96,150 +83,8 @@ export class StagehandObserveHandler {
       level: 1,
     });
 
-    const getFrameRootBackendNodeId = async (
-      stagehandPage: StagehandPage,
-      frame: Frame | undefined,
-    ): Promise<number | null> => {
-      if (!frame) return null;
-
-      const cdp = await stagehandPage.page
-        .context()
-        .newCDPSession(stagehandPage.page);
-      const frameId = await getCDPFrameId(stagehandPage, frame);
-
-      // Let Playwright infer the raw type, then cast to a narrow interface.
-      const result = (await cdp.send("DOM.getFrameOwner", {
-        frameId,
-      })) as FrameOwnerResult;
-
-      return result.backendNodeId ?? null;
-    };
-
-    const getFrameRootXpath = async (
-      frame: Frame | undefined,
-    ): Promise<string> => {
-      if (!frame) return "/";
-      const handle = await frame.frameElement();
-      return handle.evaluate((node: Element) => {
-        const pos = (el: Element) => {
-          let i = 1;
-          for (
-            let sib = el.previousElementSibling;
-            sib;
-            sib = sib.previousElementSibling
-          )
-            if (sib.tagName === el.tagName) i += 1;
-          return i;
-        };
-        const segs: string[] = [];
-        for (let el: Element | null = node; el; el = el.parentElement)
-          segs.unshift(`${el.tagName.toLowerCase()}[${pos(el)}]`);
-        return `/${segs.join("/")}`;
-      });
-    };
-
-    const snapshots: FrameSnapshot[] = [];
-
-    const walk = async (frame: Frame | undefined, idxPath: number[] = []) => {
-      try {
-        const tree = await getAccessibilityTree(
-          this.stagehandPage,
-          this.logger,
-          undefined,
-          frame,
-        );
-
-        const frameXpath = await getFrameRootXpath(frame);
-        const backendNodeId = await getFrameRootBackendNodeId(
-          this.stagehandPage,
-          frame,
-        );
-
-        // keep everything in memory
-        snapshots.push({
-          tree: tree.simplified.trimEnd(),
-          xpathMap: tree.xpathMap,
-          frameXpath,
-          backendNodeId,
-        });
-
-        // debug dump (optional)
-        const dbgDir = idxPath.join("/");
-        this.writeDebug(join(dbgDir, "tree.txt"), tree.simplified.trim());
-        this.writeDebug(
-          join(dbgDir, "xpathMap.json"),
-          JSON.stringify(tree.xpathMap, null, 2),
-        );
-        this.writeDebug(
-          join(dbgDir, "meta.json"),
-          JSON.stringify(
-            {
-              url: (frame ?? this.stagehandPage.page).url(),
-              frameId: await getCDPFrameId(this.stagehandPage, frame),
-              collectedAt: new Date().toISOString(),
-              xpath: frameXpath,
-              backendNodeId,
-            },
-            null,
-            2,
-          ),
-        );
-      } catch (err) {
-        this.logger({
-          category: "observation",
-          message: `⚠️ failed to get AX tree for ${
-            frame ? `iframe (${frame.url()})` : "main frame"
-          }`,
-          level: 1,
-          auxiliary: { error: { value: String(err), type: "string" } },
-        });
-        return;
-      }
-
-      for (const [i, child] of (frame ?? this.stagehandPage.page.mainFrame())
-        .childFrames()
-        .entries()) {
-        await walk(child, [...idxPath, i]);
-      }
-    };
-
-    await this.stagehandPage._waitForSettledDom();
-    await walk(undefined);
-
-    const combinedXpathMap: Record<number, string> = {};
-    for (const snap of snapshots) {
-      const prefix = snap.frameXpath === "/" ? "" : snap.frameXpath;
-      for (const [idStr, local] of Object.entries(snap.xpathMap)) {
-        const full =
-          prefix + (local.startsWith("/") || !prefix ? "" : "/") + local;
-        combinedXpathMap[Number(idStr)] = full;
-      }
-    }
-    this.writeDebug(
-      "combinedXpathMap.json",
-      JSON.stringify(combinedXpathMap, null, 2),
-    );
-
-    const idToTree = new Map<number, string>();
-    snapshots.forEach((s) => {
-      if (s.backendNodeId != null) idToTree.set(s.backendNodeId, s.tree);
-    });
-
-    const inject = (t: string): string =>
-      t.replace(/^(\s*)\[(\d+)](.*)$/gm, (line, ws: string, idStr: string) => {
-        const child = idToTree.get(+idStr);
-        if (!child) return line;
-        const indented = inject(child)
-          .split("\n")
-          .map((l) => `${ws}  ${l}`)
-          .join("\n");
-        return `${line}\n${indented}`;
-      });
-
-    const root = snapshots.find((s) => s.frameXpath === "/");
-    const combinedTree = root ? inject(root.tree) : "";
-
-    this.writeDebug("combinedTree.txt", combinedTree);
+    const { combinedTree, combinedXpathMap }: CombinedA11yResult =
+      await getAccessibilityTreeWithFrames(this.stagehandPage, this.logger);
 
     // No screenshot or vision-based annotation is performed
     const observationResponse = await observe({
@@ -322,15 +167,4 @@ export class StagehandObserveHandler {
 
     return elementsWithSelectors;
   }
-}
-
-interface FrameSnapshot {
-  tree: string;
-  xpathMap: Record<number, string>;
-  frameXpath: string;
-  backendNodeId: number | null;
-}
-
-interface FrameOwnerResult {
-  backendNodeId?: number;
 }

--- a/lib/handlers/observeHandler.ts
+++ b/lib/handlers/observeHandler.ts
@@ -5,7 +5,7 @@ import { LLMClient } from "../llm/LLMClient";
 import { StagehandPage } from "../StagehandPage";
 import { drawObserveOverlay } from "../utils";
 import { getAccessibilityTreeWithFrames } from "../a11y/utils";
-import { CombinedA11yResult } from "@/types/context";
+import { CombinedA11yResult, EncodedId } from "@/types/context";
 
 export class StagehandObserveHandler {
   private readonly stagehand: Stagehand;
@@ -83,8 +83,14 @@ export class StagehandObserveHandler {
       level: 1,
     });
 
-    const { combinedTree, combinedXpathMap }: CombinedA11yResult =
-      await getAccessibilityTreeWithFrames(this.stagehandPage, this.logger);
+    const {
+      combinedTree,
+      combinedXpathMap,
+      combinedUrlMap,
+    }: CombinedA11yResult = await getAccessibilityTreeWithFrames(
+      this.stagehandPage,
+      this.logger,
+    );
 
     // No screenshot or vision-based annotation is performed
     const observationResponse = await observe({
@@ -130,7 +136,8 @@ export class StagehandObserveHandler {
           },
         });
 
-        const xpath = combinedXpathMap[elementId];
+        const lookUpIndex = elementId as EncodedId;
+        const xpath = combinedXpathMap[lookUpIndex];
 
         if (!xpath || xpath === "") {
           this.logger({

--- a/lib/handlers/observeHandler.ts
+++ b/lib/handlers/observeHandler.ts
@@ -137,6 +137,18 @@ export class StagehandObserveHandler {
         message: `Warning: found ${discoveredIframes.length} iframe(s) on the page. If you wish to interact with iframe content, please make sure you are setting iframes: true`,
         level: 1,
       });
+
+      discoveredIframes.forEach((iframe) => {
+        observationResponse.elements.push({
+          elementId: this.stagehandPage.encodeWithFrameId(
+            undefined,
+            Number(iframe.nodeId),
+          ),
+          description: "an iframe",
+          method: "not-supported",
+          arguments: [],
+        });
+      });
     }
 
     const elementsWithSelectors = await Promise.all(

--- a/lib/handlers/observeHandler.ts
+++ b/lib/handlers/observeHandler.ts
@@ -83,14 +83,8 @@ export class StagehandObserveHandler {
       level: 1,
     });
 
-    const {
-      combinedTree,
-      combinedXpathMap,
-      combinedUrlMap,
-    }: CombinedA11yResult = await getAccessibilityTreeWithFrames(
-      this.stagehandPage,
-      this.logger,
-    );
+    const { combinedTree, combinedXpathMap }: CombinedA11yResult =
+      await getAccessibilityTreeWithFrames(this.stagehandPage, this.logger);
 
     // No screenshot or vision-based annotation is performed
     const observationResponse = await observe({

--- a/lib/inference.ts
+++ b/lib/inference.ts
@@ -258,7 +258,11 @@ export async function observe({
     elements: z
       .array(
         z.object({
-          elementId: z.number().describe("the number of the element"),
+          elementId: z
+            .string()
+            .describe(
+              "the ID string associated with the element. Never include surrounding square brackets.",
+            ),
           description: z
             .string()
             .describe(
@@ -360,7 +364,7 @@ export async function observe({
   const parsedElements =
     observeData.elements?.map((el) => {
       const base = {
-        elementId: Number(el.elementId),
+        elementId: el.elementId,
         description: String(el.description),
       };
       if (returnAction) {

--- a/lib/inference.ts
+++ b/lib/inference.ts
@@ -261,7 +261,7 @@ export async function observe({
           elementId: z
             .string()
             .describe(
-              "the ID string associated with the element. Never include surrounding square brackets.",
+              "the ID string associated with the element. Never include surrounding square brackets. This field must follow the format of 'number-number'.",
             ),
           description: z
             .string()

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -5,6 +5,7 @@ import { ZodPathSegments } from "../types/stagehand";
 import { Schema, Type } from "@google/genai";
 import { ModelProvider } from "../types/model";
 import { ZodSchemaValidationError } from "@/types/stagehandErrors";
+import { ID_PATTERN } from "@/types/context";
 
 export function validateZodSchema(schema: z.ZodTypeAny, data: unknown) {
   const result = schema.safeParse(data);
@@ -398,7 +399,7 @@ export function injectUrls(
       const id =
         typeof fieldValue === "number"
           ? String(fieldValue)
-          : typeof fieldValue === "string" && /^\d+-\d+$/.test(fieldValue)
+          : typeof fieldValue === "string" && ID_PATTERN.test(fieldValue)
             ? fieldValue
             : undefined;
 
@@ -424,17 +425,14 @@ function makeIdStringSchema(orig: z.ZodString): z.ZodString {
     "";
 
   const base =
-    "This field must be the element-ID in the form «frameId-backendId» " +
+    "This field must be the element-ID in the form 'frameId-backendId' " +
     '(e.g. "0-432").';
   const composed =
     userDesc.trim().length > 0
       ? `${base} that follows this user-defined description: ${userDesc}`
       : base;
 
-  return z
-    .string()
-    .regex(/^\d+-\d+$/)
-    .describe(composed);
+  return z.string().regex(ID_PATTERN).describe(composed);
 }
 
 /**

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -428,7 +428,7 @@ function makeIdStringSchema(orig: z.ZodString): z.ZodString {
     '(e.g. "0-432").';
   const composed =
     userDesc.trim().length > 0
-      ? `${base}  that follows this user-defined description: ${userDesc}`
+      ? `${base} that follows this user-defined description: ${userDesc}`
       : base;
 
   return z

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -226,7 +226,7 @@ export function transformSchema(
         (check: { kind: string }) => check.kind === "url",
       ) ?? false;
     if (hasUrlCheck) {
-      return [makeIdNumberSchema(schema as z.ZodString), [{ segments: [] }]];
+      return [makeIdStringSchema(schema as z.ZodString), [{ segments: [] }]];
     }
     return [schema, []];
   }
@@ -385,9 +385,7 @@ export function injectUrls(
 
   if (key === "*") {
     if (Array.isArray(obj)) {
-      for (const item of obj) {
-        injectUrls(item, rest, idToUrlMapping);
-      }
+      for (const item of obj) injectUrls(item, rest, idToUrlMapping);
     }
     return;
   }
@@ -396,9 +394,16 @@ export function injectUrls(
     const record = obj as Record<string | number, unknown>;
     if (path.length === 1) {
       const fieldValue = record[key];
-      if (typeof fieldValue === "number") {
-        const mappedUrl = idToUrlMapping[String(fieldValue)];
-        record[key] = mappedUrl ?? ``;
+
+      const id =
+        typeof fieldValue === "number"
+          ? String(fieldValue)
+          : typeof fieldValue === "string" && /^\d+-\d+$/.test(fieldValue)
+            ? fieldValue
+            : undefined;
+
+      if (id !== undefined) {
+        record[key] = idToUrlMapping[id] ?? "";
       }
     } else {
       injectUrls(record[key], rest, idToUrlMapping);
@@ -410,7 +415,7 @@ function isKind(s: z.ZodTypeAny, kind: Kind): boolean {
   return (s as z.ZodTypeAny)._def.typeName === kind;
 }
 
-function makeIdNumberSchema(orig: z.ZodString): z.ZodNumber {
+function makeIdStringSchema(orig: z.ZodString): z.ZodString {
   const userDesc =
     // Zod ≥3.23 exposes .description directly; fall back to _def for older minor versions
     (orig as unknown as { description?: string }).description ??
@@ -419,13 +424,17 @@ function makeIdNumberSchema(orig: z.ZodString): z.ZodNumber {
     "";
 
   const base =
-    "This field must be filled with the numerical ID of the link element";
+    "This field must be the element-ID in the form «frameId-backendId» " +
+    '(e.g. "0-432").';
   const composed =
     userDesc.trim().length > 0
-      ? `${base} that follows this user-defined description: ${userDesc}`
+      ? `${base}  that follows this user-defined description: ${userDesc}`
       : base;
 
-  return z.number().describe(composed);
+  return z
+    .string()
+    .regex(/^\d+-\d+$/)
+    .describe(composed);
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "chalk": "^5.4.1",
     "cheerio": "^1.0.0",
     "chromium-bidi": "^0.10.0",
+    "devtools-protocol": "^0.0.1464554",
     "esbuild": "^0.21.4",
     "eslint": "^9.16.0",
     "express": "^4.21.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "chalk": "^5.4.1",
     "cheerio": "^1.0.0",
     "chromium-bidi": "^0.10.0",
-    "devtools-protocol": "^0.0.1464554",
     "esbuild": "^0.21.4",
     "eslint": "^9.16.0",
     "express": "^4.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       playwright:
         specifier: ^1.52.0
         version: 1.52.0
+      playwright-core:
+        specifier: ^1.52.0
+        version: 1.52.0
       ws:
         specifier: ^8.18.0
         version: 8.18.1
@@ -135,10 +138,10 @@ importers:
         version: 1.0.0
       chromium-bidi:
         specifier: ^0.10.0
-        version: 0.10.2(devtools-protocol@0.0.1462014)
+        version: 0.10.2(devtools-protocol@0.0.1464554)
       devtools-protocol:
-        specifier: ^0.0.1462014
-        version: 0.0.1462014
+        specifier: ^0.0.1464554
+        version: 0.0.1464554
       esbuild:
         specifier: ^0.21.4
         version: 0.21.5
@@ -402,8 +405,8 @@ packages:
     resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.27.1':
-    resolution: {integrity: sha512-I0dZ3ZpCrJ1c04OqlNsQcKiZlsrXf/kkE4FXzID9rIOYICsAbA8mMDzhW/luRNAHdCNt7os/u8wenklZDlUVUQ==}
+  '@babel/parser@7.27.2':
+    resolution: {integrity: sha512-QYLs8299NA7WM/bZAdp+CviYYkVoYXlDW2rzliy3chxd1PQjej7JORuMJDJXJUb9g0TT+B99EwaVLKmX+sPXWw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -2454,8 +2457,8 @@ packages:
   devtools-protocol@0.0.1312386:
     resolution: {integrity: sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==}
 
-  devtools-protocol@0.0.1462014:
-    resolution: {integrity: sha512-z2rfWuBdh/1p6vVjEU27w7eoS73nZf1lTe/nwvSFjy719dBOCXuADmzNQvdT+coAeF/q5khSUGw4CtIH7Cfo8g==}
+  devtools-protocol@0.0.1464554:
+    resolution: {integrity: sha512-CAoP3lYfwAGQTaAXYvA6JZR0fjGUb7qec1qf4mToyoH2TZgUFeIqYcjh6f9jNuhHfuZiEdH+PONHYrLhRQX6aw==}
 
   diff-match-patch@1.0.5:
     resolution: {integrity: sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==}
@@ -5472,7 +5475,7 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.27.1': {}
 
-  '@babel/parser@7.27.1':
+  '@babel/parser@7.27.2':
     dependencies:
       '@babel/types': 7.27.1
 
@@ -6987,7 +6990,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.13':
     dependencies:
-      '@babel/parser': 7.27.1
+      '@babel/parser': 7.27.2
       '@vue/shared': 3.5.13
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -7000,7 +7003,7 @@ snapshots:
 
   '@vue/compiler-sfc@3.5.13':
     dependencies:
-      '@babel/parser': 7.27.1
+      '@babel/parser': 7.27.2
       '@vue/compiler-core': 3.5.13
       '@vue/compiler-dom': 3.5.13
       '@vue/compiler-ssr': 3.5.13
@@ -7484,9 +7487,9 @@ snapshots:
 
   chownr@2.0.0: {}
 
-  chromium-bidi@0.10.2(devtools-protocol@0.0.1462014):
+  chromium-bidi@0.10.2(devtools-protocol@0.0.1464554):
     dependencies:
-      devtools-protocol: 0.0.1462014
+      devtools-protocol: 0.0.1464554
       mitt: 3.0.1
       zod: 3.23.8
 
@@ -7738,7 +7741,7 @@ snapshots:
 
   devtools-protocol@0.0.1312386: {}
 
-  devtools-protocol@0.0.1462014: {}
+  devtools-protocol@0.0.1464554: {}
 
   diff-match-patch@1.0.5: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       deepmerge:
         specifier: ^4.3.1
         version: 4.3.1
+      devtools-protocol:
+        specifier: ^0.0.1464554
+        version: 0.0.1464554
       dotenv:
         specifier: ^16.4.5
         version: 16.5.0
@@ -39,9 +42,6 @@ importers:
         specifier: ^13.0.0
         version: 13.0.0
       playwright:
-        specifier: ^1.52.0
-        version: 1.52.0
-      playwright-core:
         specifier: ^1.52.0
         version: 1.52.0
       ws:
@@ -139,9 +139,6 @@ importers:
       chromium-bidi:
         specifier: ^0.10.0
         version: 0.10.2(devtools-protocol@0.0.1464554)
-      devtools-protocol:
-        specifier: ^0.0.1464554
-        version: 0.0.1464554
       esbuild:
         specifier: ^0.21.4
         version: 0.21.5

--- a/types/context.ts
+++ b/types/context.ts
@@ -130,3 +130,19 @@ export interface CdpFrameTree {
   /** Child frames (if any). */
   childFrames?: CdpFrameTree[];
 }
+
+export interface FrameOwnerResult {
+  backendNodeId?: number;
+}
+
+export interface CombinedA11yResult {
+  combinedTree: string;
+  combinedXpathMap: Record<number, string>;
+}
+
+export interface FrameSnapshot {
+  tree: string;
+  xpathMap: Record<number, string>;
+  frameXpath: string;
+  backendNodeId: number | null;
+}

--- a/types/context.ts
+++ b/types/context.ts
@@ -154,10 +154,8 @@ export interface FrameSnapshot {
   parentFrame?: Frame;
 }
 
-export type EncodedId = `${number}:${number}`; // "01:421" etc.
+export type EncodedId = `${number}-${number}`;
 
-// ❷ we don’t need NODE_BASE any more
-//     - delete: export const NODE_BASE = …
 export const frameToOrdinal = new Map<Frame | undefined, number>();
 export const ordinalToFrame = new Map<number, Frame | undefined>();
 
@@ -179,9 +177,9 @@ export function getFrameOrdinal(frame: Frame | undefined): number {
 export const encodeId = (
   backendId: number,
   frame: Frame | undefined,
-): EncodedId => `${getFrameOrdinal(frame)}:${backendId}`;
+): EncodedId => `${getFrameOrdinal(frame)}-${backendId}`;
 
 export const decodeId = (id: EncodedId) => {
-  const [ord, backend] = id.split(":");
+  const [ord, backend] = id.split("-");
   return { frameOrdinal: +ord, backendId: +backend };
 };

--- a/types/context.ts
+++ b/types/context.ts
@@ -74,64 +74,26 @@ export interface EnhancedContext
 export type FrameId = string;
 export type LoaderId = string;
 
-/** ----------------------------------------------------------------------------
- * Page.Frame  – information about a single frame
- * ------------------------------------------------------------------------- */
 export interface CdpFrame {
-  /** Unique DevTools frame identifier. */
   id: FrameId;
-
-  /** Parent frame identifier (omitted for the main frame). */
   parentId?: FrameId;
-
-  /** Loader identifier associated with this frame (navigation). */
   loaderId: LoaderId;
-
-  /** <iframe name="…"> or browsing context name. */
   name?: string;
-
-  /** Document URL without the hash fragment. */
   url: string;
-
-  /** Full fragment, including `#`, if present.  (experimental) */
   urlFragment?: string;
-
-  /** e.g. `google.com`, `b.co.uk`  (experimental) */
   domainAndRegistry?: string;
-
-  /** e.g. `https://example.com` */
   securityOrigin: string;
-
-  /** Extra security-origin details (opaque object).  (experimental) */
   securityOriginDetails?: Record<string, unknown>;
-
-  /** MIME type as determined by the browser (`text/html`, `image/svg+xml`, …) */
   mimeType: string;
-
-  /** If the frame failed to load.  (experimental) */
   unreachableUrl?: string;
-
-  /** Ad-tagging information.  (experimental) */
   adFrameStatus?: string;
-
-  /** `"Secure"` / `"Insecure"` / …  (experimental) */
   secureContextType?: string;
-
-  /** `"Isolated"` / `"NotIsolated"` / …  (experimental) */
   crossOriginIsolatedContextType?: string;
-
-  /** List of gated APIs available.  (experimental) */
   gatedAPIFeatures?: string[];
 }
 
-/** ----------------------------------------------------------------------------
- * Page.FrameTree – a node in the frame hierarchy
- * ------------------------------------------------------------------------- */
 export interface CdpFrameTree {
-  /** The frame represented by this tree node. */
   frame: CdpFrame;
-
-  /** Child frames (if any). */
   childFrames?: CdpFrameTree[];
 }
 

--- a/types/context.ts
+++ b/types/context.ts
@@ -45,8 +45,8 @@ export interface TreeResult {
   tree: AccessibilityNode[];
   simplified: string;
   iframes?: AccessibilityNode[];
-  idToUrl: Record<string, string>;
-  xpathMap: Record<number, string>;
+  idToUrl: Record<EncodedId, string>;
+  xpathMap: Record<EncodedId, string>;
 }
 
 export type DOMNode = {

--- a/types/context.ts
+++ b/types/context.ts
@@ -114,32 +114,11 @@ export interface FrameSnapshot {
   frameXpath: string;
   backendNodeId: number | null;
   parentFrame?: Frame;
+  /** CDP frame identifier for this snapshot; used to generate stable EncodedIds. */
+  frameId?: string;
 }
 
 export type EncodedId = `${number}-${number}`;
-
-export const frameToOrdinal = new Map<Frame | undefined, number>();
-export const ordinalToFrame = new Map<number, Frame | undefined>();
-
-/** Return the stable ordinal for a frame (0-based, ≤ 99). */
-export function getFrameOrdinal(frame: Frame | undefined): number {
-  // already registered?
-  const cached = frameToOrdinal.get(frame);
-  if (cached !== undefined) return cached;
-
-  // assign next ordinal
-  const ord = frameToOrdinal.size; // 0 for main frame
-  if (ord > 99) throw new Error("More than 100 frames – enlarge format");
-
-  frameToOrdinal.set(frame, ord);
-  ordinalToFrame.set(ord, frame);
-  return ord;
-}
-
-export const encodeId = (
-  backendId: number,
-  frame: Frame | undefined,
-): EncodedId => `${getFrameOrdinal(frame)}-${backendId}`;
 
 export interface RichNode extends AccessibilityNode {
   encodedId?: EncodedId;

--- a/types/context.ts
+++ b/types/context.ts
@@ -141,7 +141,6 @@ export const encodeId = (
   frame: Frame | undefined,
 ): EncodedId => `${getFrameOrdinal(frame)}-${backendId}`;
 
-export const decodeId = (id: EncodedId) => {
-  const [ord, backend] = id.split("-");
-  return { frameOrdinal: +ord, backendId: +backend };
-};
+export interface RichNode extends AccessibilityNode {
+  encodedId?: EncodedId;
+}

--- a/types/context.ts
+++ b/types/context.ts
@@ -58,10 +58,75 @@ export type DOMNode = {
 export type BackendIdMaps = {
   tagNameMap: Record<number, string>;
   xpathMap: Record<number, string>;
+  iframeXPath?: string;
 };
 
 export interface EnhancedContext
   extends Omit<PlaywrightContext, "newPage" | "pages"> {
   newPage(): Promise<Page>;
   pages(): Page[];
+}
+
+export type FrameId = string;
+export type LoaderId = string;
+
+/** ----------------------------------------------------------------------------
+ * Page.Frame  – information about a single frame
+ * ------------------------------------------------------------------------- */
+export interface CdpFrame {
+  /** Unique DevTools frame identifier. */
+  id: FrameId;
+
+  /** Parent frame identifier (omitted for the main frame). */
+  parentId?: FrameId;
+
+  /** Loader identifier associated with this frame (navigation). */
+  loaderId: LoaderId;
+
+  /** <iframe name="…"> or browsing context name. */
+  name?: string;
+
+  /** Document URL without the hash fragment. */
+  url: string;
+
+  /** Full fragment, including `#`, if present.  (experimental) */
+  urlFragment?: string;
+
+  /** e.g. `google.com`, `b.co.uk`  (experimental) */
+  domainAndRegistry?: string;
+
+  /** e.g. `https://example.com` */
+  securityOrigin: string;
+
+  /** Extra security-origin details (opaque object).  (experimental) */
+  securityOriginDetails?: Record<string, unknown>;
+
+  /** MIME type as determined by the browser (`text/html`, `image/svg+xml`, …) */
+  mimeType: string;
+
+  /** If the frame failed to load.  (experimental) */
+  unreachableUrl?: string;
+
+  /** Ad-tagging information.  (experimental) */
+  adFrameStatus?: string;
+
+  /** `"Secure"` / `"Insecure"` / …  (experimental) */
+  secureContextType?: string;
+
+  /** `"Isolated"` / `"NotIsolated"` / …  (experimental) */
+  crossOriginIsolatedContextType?: string;
+
+  /** List of gated APIs available.  (experimental) */
+  gatedAPIFeatures?: string[];
+}
+
+/** ----------------------------------------------------------------------------
+ * Page.FrameTree – a node in the frame hierarchy
+ * ------------------------------------------------------------------------- */
+export interface CdpFrameTree {
+  /** The frame represented by this tree node. */
+  frame: CdpFrame;
+
+  /** Child frames (if any). */
+  childFrames?: CdpFrameTree[];
 }

--- a/types/context.ts
+++ b/types/context.ts
@@ -123,3 +123,5 @@ export type EncodedId = `${number}-${number}`;
 export interface RichNode extends AccessibilityNode {
   encodedId?: EncodedId;
 }
+
+export const ID_PATTERN = /^\d+-\d+$/;

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -115,6 +115,7 @@ export interface ActOptions {
   variables?: Record<string, string>;
   domSettleTimeoutMs?: number;
   timeoutMs?: number;
+  iframes?: boolean;
 }
 
 export interface ActResult {
@@ -134,6 +135,7 @@ export interface ExtractOptions<T extends z.AnyZodObject> {
    */
   useTextExtract?: boolean;
   selector?: string;
+  iframes?: boolean;
 }
 
 export type ExtractResult<T extends z.AnyZodObject> = z.infer<T>;
@@ -149,6 +151,7 @@ export interface ObserveOptions {
    */
   onlyVisible?: boolean;
   drawOverlay?: boolean;
+  iframes?: boolean;
 }
 
 export interface ObserveResult {

--- a/types/stagehandErrors.ts
+++ b/types/stagehandErrors.ts
@@ -188,14 +188,6 @@ export class XPathResolutionError extends StagehandError {
   }
 }
 
-export class FrameOrdinalOverflowError extends StagehandError {
-  constructor(maxFrames: number) {
-    super(
-      `Page contains more than ${maxFrames} frames – widen EncodedId format or increase the ordinal bit-width`,
-    );
-  }
-}
-
 export class ZodSchemaValidationError extends Error {
   constructor(
     public readonly received: unknown,

--- a/types/stagehandErrors.ts
+++ b/types/stagehandErrors.ts
@@ -168,6 +168,34 @@ export class LLMResponseError extends StagehandError {
   }
 }
 
+export class StagehandIframeError extends StagehandError {
+  constructor(frameUrl: string, message: string) {
+    super(
+      `Unable to resolve frameId for iframe with URL: ${frameUrl} Full error: ${message}`,
+    );
+  }
+}
+
+export class ContentFrameNotFoundError extends StagehandError {
+  constructor(selector: string) {
+    super(`Unable to obtain a content frame for selector: ${selector}`);
+  }
+}
+
+export class XPathResolutionError extends StagehandError {
+  constructor(xpath: string) {
+    super(`XPath "${xpath}" does not resolve in the current page or frames`);
+  }
+}
+
+export class FrameOrdinalOverflowError extends StagehandError {
+  constructor(maxFrames: number) {
+    super(
+      `Page contains more than ${maxFrames} frames – widen EncodedId format or increase the ordinal bit-width`,
+    );
+  }
+}
+
 export class ZodSchemaValidationError extends Error {
   constructor(
     public readonly received: unknown,

--- a/types/stagehandErrors.ts
+++ b/types/stagehandErrors.ts
@@ -188,6 +188,25 @@ export class XPathResolutionError extends StagehandError {
   }
 }
 
+export class ExperimentalApiConflictError extends StagehandError {
+  constructor() {
+    super(
+      "`experimental` mode cannot be used together with the Stagehand API. " +
+        "To use experimental features, set experimental: true, and useApi: false in the stagehand constructor. " +
+        "To use the Stagehand API, set experimental: false and useApi: true in the stagehand constructor. ",
+    );
+  }
+}
+
+export class ExperimentalNotConfiguredError extends StagehandError {
+  constructor(featureName: string) {
+    super(`Feature "${featureName}" is an experimental feature, and cannot be configured when useAPI: true. 
+    Please set experimental: true and useAPI: false in the stagehand constructor to use this feature. 
+    If you wish to use the Stagehand API, please ensure ${featureName} is not defined in your function call, 
+    and set experimental: false, useAPI: true in the Stagehand constructor. `);
+  }
+}
+
 export class ZodSchemaValidationError extends Error {
   constructor(
     public readonly received: unknown,


### PR DESCRIPTION
## why
- addresses stagehand's longest standing issue: #37 
## What changed

This PR adds full support for interacting with nested `iframe`s in
Stagehand—across `extract`, `observe`, and `act` by:

- **Building a combined accessibility tree** (and URL/XPath mappings)
spanning the main document and any nested iframes.
- **Tracking frame‑scoped element IDs** so that element identifiers are
globally unique across frames. This is done because `backendNodeId`'s are not guaranteed to be unique across OOPIF's (out of process iframes).
- **Extending CDP session management** to correctly target Out‑Of‑Process
iframes (OOPIFs) and fallback to same‑process frames.
- **Introducing a “deep” XPath‑based locator** that can step into `<iframe>`
 elements when performing Playwright actions.
- **Updating Zod schema transforms** to expect and handle the new
“frameId-backendId” string format for element IDs.
- **Adding new error types** for improved diagnostics when iframe resolution
 or XPath lookups fail.
- **Updating internal types** (`context.ts`, `stagehand.ts`,
`stagehandErrors.ts`) and utility modules (`a11y/utils.ts`, `utils.ts`,
handlers) to accommodate frame‑aware operations.
- **Adding three end‑to‑end eval tasks** testing iframe support:
    - `iframe_hn` (extract)
    - `iframe_same_proc` (act)
    - `iframe_form_filling` (act).

## Details

### 1. Frame‑Scoped Element IDs (EncodedId)

- **lib/StagehandPage.ts**
   -  Introduced `encodeWithFrameId(…)`, `ordinalForFrameId(…)`, and
`resetFrameOrdinals()` to assign and track per‑frame ordinals.
   - CDP session caching moved to a `WeakMap<Page|Frame, CDPSession>` so we
 can open sessions against arbitrary frames.
- **types/context.ts**
   - Defined ``EncodedId = ${number}-${number}`` for
“frameOrdinal-backendNodeId” IDs.
   - Updated `TreeResult` to key `xpathMap`/`idToUrl` by `EncodedId`.

### 2. Combined Accessibility Tree Across Frames

- **lib/a11y/utils.ts**
   - Added `getAccessibilityTreeWithFrames()` which walks the CDP frame
tree, captures accessibility sub‑trees for each frame, and concatenates them
into a single “combinedTree” string plus combined URL/XPath maps keyed by
`EncodedId`.
   - Updated `formatSimplifiedTree()` to emit the new `encodedId` in tree
lines.
   - Updated `buildBackendIdMaps()` to traverse nested frame DOM nodes
(OOPIF and same‑process iframes) and include the frame’s `frameId` when encoding
 backend IDs.

### 3. Deep XPath Locator for Frame Actions

- **lib/handlers/handlerUtils/actHandlerUtils.ts**
      Added `deepLocator(root, rawXPath)` which splits an XPath on `<iframe>`
steps to descend into `FrameLocator`s automatically before applying the
remainder of the path.
- **lib/handlers/actHandler.ts**
      Uses `deepLocator()` instead of a flat `page.locator(...)` so that
Playwright actions can target elements inside iframes when `options.iframes` is
set.

### 4. Frame‑Aware Extract & Observe Handlers

- **lib/handlers/extractHandler.ts**
   - Imports and uses `getAccessibilityTreeWithFrames()` when `iframes:
true`; otherwise falls back to the legacy single‑frame tree.
   - Passes through the `iframes` flag into its internal calls.
- **lib/handlers/observeHandler.ts**
   - Similarly leverages `getAccessibilityTreeWithFrames()` and builds its
element‑to‑XPath mapping from the combined tree.
   - Removes the old ad‑hoc iframe injection logic in favor of the unified
combined tree approach.

### 5. Inference Schema & Element ID Changes

- **lib/inference.ts**
   - Changed the Observe LLM output schema so `elementId` is now a
**string** matching the regex `/^\d+-\d+$/` (frame‑ID plus backend‑ID) instead
of a raw number.
   - Updated parsing logic to no longer coerce to Number.

### 6. Zod URL‑Field Transformation

- **lib/utils.ts**
   - Renamed `makeIdNumberSchema()` → `makeIdStringSchema()` to emit
`z.string().regex(/^\d+-\d+$/)` for fields that were formerly `string().url()`,
so extracted URL placeholders match the new `EncodedId` format.
   - Updated `injectUrls()` to map both numeric and frame‑ID strings back
into real URLs once extraction is complete.




to do:
- [x] clean up code
- [x] add JSDoc
- [x] add comprehensive PR desc
- [x] parameterize iframe traversal. ie, need to set `iframes: true`
- [ ] ignore iframes without content
- [x] add evals
