### PR TITLE
evals: fix `extract_collaborators`

### DIFF
--- a/evals/tasks/extract_collaborators.ts
+++ b/evals/tasks/extract_collaborators.ts
@@ -18,6 +18,10 @@ export const extract_collaborators: EvalFunction = async ({
     await stagehand.page.waitForLoadState("networkidle");
     await stagehand.page.waitForTimeout(5000);
 
+    await stagehand.page.act({
+      action: "scroll halfway down the page",
+    });
+
     const { contributors } = await stagehand.page.extract({
       instruction: "Extract top 5 contributors of this repository",
       schema: z.object({


### PR DESCRIPTION
# why
- we used to scroll inside of `extract` to render content
- now, we dont scroll automatically, so this eval was failing (not rendering enough content)
# what changed
- added an `act` step to scroll & render more content. eval passes now.
# test plan
- this is it