### PR TITLE
fix `useTextExtract` deprecation log

### DIFF
--- a/.changeset/cold-sheep-serve.md
+++ b/.changeset/cold-sheep-serve.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand-lib": patch
+---
+
+fix noisy useTextExtract deprecation log

--- a/lib/handlers/extractHandler.ts
+++ b/lib/handlers/extractHandler.ts
@@ -44,7 +44,7 @@ export class StagehandExtractHandler {
     llmClient,
     requestId,
     domSettleTimeoutMs,
-    useTextExtract = false,
+    useTextExtract,
     selector,
   }: {
     instruction?: string;


### PR DESCRIPTION
# why
- we were setting `useTextExtract: false` which triggered a warning log
- if a user doesn't set this, then we don't need to warn them that it has no effect. this is noisy & annoying. 
- we should only warn them if it is NOT undefined, ie, they set it either `true` or `false`
# what changed
- do not internally set `useTextExtract = false`
# test plan
- `regression` evals
- `extract` evals