### PR TITLE
[evals] use cloned google site

### DIFF
--- a/evals/tasks/simple_google_search.ts
+++ b/evals/tasks/simple_google_search.ts
@@ -6,7 +6,9 @@ export const simple_google_search: EvalFunction = async ({
   stagehand,
   logger,
 }) => {
-  await stagehand.page.goto("https://www.google.com");
+  await stagehand.page.goto(
+    "https://browserbase.github.io/stagehand-eval-sites/sites/google/",
+  );
 
   await stagehand.page.act({
     action: 'type "OpenAI" into the search bar',
@@ -14,7 +16,8 @@ export const simple_google_search: EvalFunction = async ({
 
   await stagehand.page.act("click the search button");
 
-  const expectedUrl = "https://www.google.com/search?q=OpenAI";
+  const expectedUrl =
+    "https://browserbase.github.io/stagehand-eval-sites/sites/google/openai.html";
   const currentUrl = stagehand.page.url();
 
   await stagehand.close();


### PR DESCRIPTION
# why
- so we can stop getting captcha'd in `simple_google_search`
# what changed
- added URLs to google homepage clone
# test plan
- this is it