### PR TITLE
[evals] fix arxiv

### DIFF
--- a/evals/tasks/arxiv.ts
+++ b/evals/tasks/arxiv.ts
@@ -23,7 +23,7 @@ export const arxiv: EvalFunction = async ({
           .array(
             z.object({
               title: z.string().describe("the title of the paper"),
-              link: z.string().describe("the link to the paper").nullable(),
+              link: z.string().url().describe("the link to the paper"),
             }),
           )
           .describe("list of papers"),


### PR DESCRIPTION
# why
- this one was failing because we never updated the code to use the new URL extraction schema
# what changed
- use `z.string().url()`
