### PR TITLE
fix: support CSS selectors in targeted extract

### DIFF
--- a/lib/handlers/extractHandler.ts
+++ b/lib/handlers/extractHandler.ts
@@ -131,11 +131,10 @@ export class StagehandExtractHandler {
     });
 
     await this.stagehandPage._waitForSettledDom(domSettleTimeoutMs);
-    const targetXpath = selector?.replace(/^xpath=/, "") ?? "";
     const tree = await getAccessibilityTree(
       this.stagehandPage,
       this.logger,
-      targetXpath,
+      selector,
     );
     this.logger({
       category: "extraction",


### PR DESCRIPTION
# why
fixes: https://github.com/browserbase/stagehand/issues/653
# what changed
Added CSS selector support to targeted extract by detecting selector type and routing to the appropriate DOM API (`document.querySelector()` for CSS, `document.evaluate()`for XPath).
# test plan
