### PR TITLE
[chore] update `operatorResponseSchema`

### DIFF
--- a/.changeset/many-sheep-trade.md
+++ b/.changeset/many-sheep-trade.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+update operatorResponseSchema based on new openai spec

--- a/lib/handlers/operatorHandler.ts
+++ b/lib/handlers/operatorHandler.ts
@@ -121,9 +121,14 @@ export class StagehandOperatorHandler {
       }
       let extractionResult: unknown | undefined;
       if (result.method === "extract") {
-        extractionResult = await this.stagehandPage.page.extract(
-          result.parameters,
-        );
+        if (result.parameters === null || result.parameters === undefined) {
+          const extractionResultObj = await this.stagehandPage.page.extract();
+          extractionResult = extractionResultObj.page_text;
+        } else {
+          extractionResult = await this.stagehandPage.page.extract(
+            result.parameters,
+          );
+        }
       }
 
       await this.executeAction(result, playwrightArguments, extractionResult);

--- a/types/operator.ts
+++ b/types/operator.ts
@@ -33,7 +33,7 @@ export const operatorResponseSchema = z.object({
         - goto: The URL to navigate to. e.g. "https://www.google.com"
         The other methods do not require a parameter.`,
     )
-    .optional(),
+    .nullable(),
   taskComplete: z
     .boolean()
     .describe(


### PR DESCRIPTION
# why
- to mute the warning logged by the openai api and adhere to the updated spec
```
Zod field at #/definitions/operatorResponseSchema/properties/parameters uses .optional() without .nullable() which is not supported by the API. See: https://platform.openai.com/docs/guides/structured-outputs?api-mode=responses#all-fields-must-be-required
```
# what changed
- changed `optional` to `nullable`
# test plan
- tested locally