### PR TITLE
better logging for `AI_NoObjectGeneratedError`

### DIFF
--- a/.changeset/metal-poems-battle.md
+++ b/.changeset/metal-poems-battle.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand-lib": patch
+---
+
+log NoObjectGenerated error details


### PR DESCRIPTION
# why
- AI SDK exposes useful debugging info for `AI_NoObjectGeneratedError`. Link to docs [here](https://ai-sdk.dev/docs/reference/ai-sdk-errors/ai-no-object-generated-error#checking-for-this-error)
- we should expose this info in our logs
# what changed
- wrapped the `generateObject` call in a try/catch
- if we get the `AI_NoObjectGeneratedError`, we log additional debugging info about the error, such as:
     - error.cause
     - error.response
     - error.usage
     - error.finishReason
     - error.text
# test plan
- regressions