### PR TITLE
add `version.ts` to `gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ tmp/
 eval-summary.json
 package-lock.json
 evals/deterministic/tests/BrowserContext/tmp-test.har
+lib/version.ts

--- a/lib/version.ts
+++ b/lib/version.ts
@@ -1,5 +1,0 @@
-/**
- * AUTO-GENERATED — DO NOT EDIT BY HAND
- *  Run `pnpm run gen-version` to refresh.
- */
-export const STAGEHAND_VERSION = "2.3.0" as const;


### PR DESCRIPTION
# why
- `version.ts` is auto generated, should not be committed
# what changed
- removed `version.ts` and added it to gitignore
