### PR TITLE
don't use playwright-test

### DIFF
--- a/.changeset/ready-frogs-fetch.md
+++ b/.changeset/ready-frogs-fetch.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+use playwright instead of playwright test

--- a/evals/tasks/iframes_nested.ts
+++ b/evals/tasks/iframes_nested.ts
@@ -1,5 +1,5 @@
 import { EvalFunction } from "@/types/evals";
-import { FrameLocator } from "@playwright/test";
+import { FrameLocator } from "playwright";
 
 export const iframes_nested: EvalFunction = async ({
   debugUrl,

--- a/lib/StagehandContext.ts
+++ b/lib/StagehandContext.ts
@@ -1,7 +1,7 @@
 import type {
   BrowserContext as PlaywrightContext,
   Page as PlaywrightPage,
-} from "@playwright/test";
+} from "playwright";
 import { Stagehand } from "./index";
 import { StagehandPage } from "./StagehandPage";
 import { Page } from "../types/page";

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -1,10 +1,6 @@
 import { Browserbase } from "@browserbasehq/sdk";
-import type {
-  CDPSession,
-  Page as PlaywrightPage,
-  Frame,
-} from "@playwright/test";
-import { chromium } from "@playwright/test";
+import type { CDPSession, Page as PlaywrightPage, Frame } from "playwright";
+import { chromium } from "playwright";
 import { z } from "zod";
 import { Page, defaultExtractSchema } from "../types/page";
 import {

--- a/lib/a11y/utils.ts
+++ b/lib/a11y/utils.ts
@@ -26,7 +26,7 @@ import {
   StagehandIframeError,
   XPathResolutionError,
 } from "@/types/stagehandErrors";
-import { CDPSession, Frame } from "@playwright/test";
+import { CDPSession, Frame } from "playwright";
 
 const IFRAME_STEP_RE = /iframe\[\d+]$/i;
 const PUA_START = 0xe000;

--- a/lib/handlers/actHandler.ts
+++ b/lib/handlers/actHandler.ts
@@ -1,4 +1,4 @@
-import { Locator } from "@playwright/test";
+import { Locator } from "playwright";
 import { LogLine } from "../../types/log";
 import {
   PlaywrightCommandException,

--- a/lib/handlers/handlerUtils/actHandlerUtils.ts
+++ b/lib/handlers/handlerUtils/actHandlerUtils.ts
@@ -1,4 +1,4 @@
-import { Page, Locator, FrameLocator } from "@playwright/test";
+import { Page, Locator, FrameLocator } from "playwright";
 import { PlaywrightCommandException } from "../../../types/playwright";
 import { StagehandPage } from "../../StagehandPage";
 import { getNodeFromXpath } from "@/lib/dom/utils";

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,5 @@
 import { Browserbase } from "@browserbasehq/sdk";
-import { Browser, chromium } from "@playwright/test";
+import { Browser, chromium } from "playwright";
 import dotenv from "dotenv";
 import fs from "fs";
 import os from "os";

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "express": "^4.21.0",
     "globals": "^15.13.0",
     "multer": "^1.4.5-lts.1",
+    "@playwright/test": "^1.42.1",
     "prettier": "^3.2.5",
     "string-comparison": "^1.3.0",
     "tsup": "^8.2.1",
@@ -63,7 +64,6 @@
     "typescript-eslint": "^8.17.0"
   },
   "peerDependencies": {
-    "@playwright/test": "^1.42.1",
     "deepmerge": "^4.3.1",
     "dotenv": "^16.4.5",
     "zod": "^3.23.8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@google/genai':
         specifier: ^0.8.0
         version: 0.8.0
-      '@playwright/test':
-        specifier: ^1.42.1
-        version: 1.52.0
       ai:
         specifier: ^4.3.9
         version: 4.3.12(react@19.1.0)(zod@3.24.3)
@@ -109,6 +106,9 @@ importers:
       '@langchain/openai':
         specifier: ^0.4.4
         version: 0.4.9(@langchain/core@0.3.50(openai@4.96.2(ws@8.18.1)(zod@3.24.3)))(ws@8.18.1)
+      '@playwright/test':
+        specifier: ^1.42.1
+        version: 1.52.0
       '@types/adm-zip':
         specifier: ^0.5.7
         version: 0.5.7

--- a/types/act.ts
+++ b/types/act.ts
@@ -1,5 +1,5 @@
 import { LLMClient } from "../lib/llm/LLMClient";
-import { Locator } from "@playwright/test";
+import { Locator } from "playwright";
 import { Logger } from "@/types/log";
 import { StagehandPage } from "@/lib/StagehandPage";
 

--- a/types/context.ts
+++ b/types/context.ts
@@ -1,7 +1,4 @@
-import type {
-  BrowserContext as PlaywrightContext,
-  Frame,
-} from "@playwright/test";
+import type { BrowserContext as PlaywrightContext, Frame } from "playwright";
 import { Page } from "../types/page";
 
 export interface AXNode {

--- a/types/page.ts
+++ b/types/page.ts
@@ -2,7 +2,7 @@ import type {
   Browser as PlaywrightBrowser,
   BrowserContext as PlaywrightContext,
   Page as PlaywrightPage,
-} from "@playwright/test";
+} from "playwright";
 import { z } from "zod";
 import type {
   ActOptions,

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -4,7 +4,7 @@ import { LLMProvider } from "../lib/llm/LLMProvider";
 import { LogLine } from "./log";
 import { AvailableModel, ClientOptions } from "./model";
 import { LLMClient } from "../lib/llm/LLMClient";
-import { Cookie } from "@playwright/test";
+import { Cookie } from "playwright";
 import { AgentProviderType } from "./agent";
 
 export interface ConstructorParams {


### PR DESCRIPTION
# why
- we should be using playwright, not playwright-test
# what changed
- removed playwright-test from peer deps
- replaced `playwright/test` imports with regular `playwright`
# test plan
- evals