### PR TITLE
Add date tag for OpenAI CUA

### DIFF
--- a/.changeset/short-moose-deny.md
+++ b/.changeset/short-moose-deny.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand-lib": patch
+---
+
+Add model with date tag for OpenAI CUA

--- a/lib/agent/AgentProvider.ts
+++ b/lib/agent/AgentProvider.ts
@@ -11,6 +11,7 @@ import {
 // Map model names to their provider types
 const modelToAgentProviderMap: Record<string, AgentType> = {
   "computer-use-preview": "openai",
+  "computer-use-preview-2025-03-11": "openai",
   "claude-3-7-sonnet-latest": "anthropic",
   "claude-sonnet-4-20250514": "anthropic",
 };


### PR DESCRIPTION
# why
OpenAI having problems with the default model name. Adding the date tag fixes it

# what changed
Added OpenAI's `computer-use-preview-2025-03-11` to the supported models. Usually, `computer-use-preview` should resolve to that tag, but they're having problems and adding it explicitly bypasses 500s
![image](https://github.com/user-attachments/assets/6f4e2207-70f9-4933-b4f5-9b932d1969d3)


# test plan
- [x] locally