### PR TITLE
Persist userDataDir if specified in localBrowserLaunchOptions

### DIFF
--- a/evals/deterministic/tests/local/create.test.ts
+++ b/evals/deterministic/tests/local/create.test.ts
@@ -26,6 +26,7 @@ test.describe("Local browser launch options", () => {
       localBrowserLaunchOptions: {
         userDataDir: customUserDataDir,
         headless: true,
+        preserveUserDataDir: true,
       },
     });
     await stagehand.init();
@@ -38,6 +39,49 @@ test.describe("Local browser launch options", () => {
 
     // Cleanup
     fs.rmSync(customUserDataDir, { recursive: true, force: true });
+  });
+
+  test("cleans up userDataDir by default when preserveUserDataDir is false", async () => {
+    const customUserDataDir = path.join(os.tmpdir(), "cleanup-user-data");
+
+    const stagehand = new Stagehand({
+      ...StagehandConfig,
+      localBrowserLaunchOptions: {
+        userDataDir: customUserDataDir,
+        headless: true,
+        preserveUserDataDir: false,
+      },
+    });
+    await stagehand.init();
+
+    expect(fs.existsSync(customUserDataDir)).toBeTruthy();
+
+    await stagehand.close();
+
+    expect(fs.existsSync(customUserDataDir)).toBeFalsy();
+  });
+
+  test("cleans up userDataDir by default when no preserveUserDataDir flag is provided", async () => {
+    const customUserDataDir = path.join(
+      os.tmpdir(),
+      "default-cleanup-user-data",
+    );
+
+    const stagehand = new Stagehand({
+      ...StagehandConfig,
+      localBrowserLaunchOptions: {
+        userDataDir: customUserDataDir,
+        headless: true,
+        // No preserveUserDataDir flag provided - should default to cleanup
+      },
+    });
+    await stagehand.init();
+
+    expect(fs.existsSync(customUserDataDir)).toBeTruthy();
+
+    await stagehand.close();
+
+    expect(fs.existsSync(customUserDataDir)).toBeFalsy();
   });
 
   test("applies custom viewport settings", async () => {

--- a/evals/deterministic/tests/local/create.test.ts
+++ b/evals/deterministic/tests/local/create.test.ts
@@ -34,6 +34,8 @@ test.describe("Local browser launch options", () => {
 
     await stagehand.close();
 
+    expect(fs.existsSync(customUserDataDir)).toBeTruthy();
+
     // Cleanup
     fs.rmSync(customUserDataDir, { recursive: true, force: true });
   });

--- a/evals/test-results/.last-run.json
+++ b/evals/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}

--- a/evals/test-results/.last-run.json
+++ b/evals/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -826,7 +826,7 @@ export class Stagehand {
       }
     }
 
-    if (this.contextPath) {
+    if (this.contextPath && !this.localBrowserLaunchOptions?.userDataDir) {
       try {
         fs.rmSync(this.contextPath, { recursive: true, force: true });
       } catch (e) {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -826,7 +826,10 @@ export class Stagehand {
       }
     }
 
-    if (this.contextPath && !this.localBrowserLaunchOptions?.userDataDir) {
+    if (
+      this.contextPath &&
+      !this.localBrowserLaunchOptions?.preserveUserDataDir
+    ) {
       try {
         fs.rmSync(this.contextPath, { recursive: true, force: true });
       } catch (e) {

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -181,6 +181,7 @@ export interface LocalBrowserLaunchOptions {
   };
   tracesDir?: string;
   userDataDir?: string;
+  preserveUserDataDir?: boolean;
   acceptDownloads?: boolean;
   downloadsPath?: string;
   extraHTTPHeaders?: Record<string, string>;


### PR DESCRIPTION
# why

As per https://github.com/browserbase/stagehand/issues/794, the local userDataDir automatically gets deleted after `stagehand.close()`, making it difficult to reuse the Stagehand browser context locally. 

# what changed

Change `stagehand.close()`so it only deletes the profile folder when Stagehand itself created a temp one. Now a user-supplied userDataDir survives `stagehand.close()`, while temp dirs are still cleaned up.

Let me know if you want to make it a flag instead. 

# test plan

Added to a current test case and ran <code>npm run e2e:local -- tests/local/create.test.ts</code> as well as <code>npm run e2e</code>
