### PR TITLE
trim `/text()[1]` from xpaths

### DIFF
--- a/.changeset/brave-taxes-yell.md
+++ b/.changeset/brave-taxes-yell.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand-lib": patch
+---
+
+fix issue where we are unable to take actions on text nodes

--- a/lib/handlers/observeHandler.ts
+++ b/lib/handlers/observeHandler.ts
@@ -3,7 +3,7 @@ import { Stagehand, StagehandFunctionName } from "../index";
 import { observe } from "../inference";
 import { LLMClient } from "../llm/LLMClient";
 import { StagehandPage } from "../StagehandPage";
-import { drawObserveOverlay } from "../utils";
+import { drawObserveOverlay, trimTrailingTextNode } from "../utils";
 import {
   getAccessibilityTree,
   getAccessibilityTreeWithFrames,
@@ -171,7 +171,9 @@ export class StagehandObserveHandler {
         const lookUpIndex = elementId as EncodedId;
         const xpath = combinedXpathMap[lookUpIndex];
 
-        if (!xpath || xpath === "") {
+        const trimmedXpath = trimTrailingTextNode(xpath);
+
+        if (!trimmedXpath || trimmedXpath === "") {
           this.logger({
             category: "observation",
             message: `Empty xpath returned for element: ${elementId}`,
@@ -181,7 +183,7 @@ export class StagehandObserveHandler {
 
         return {
           ...rest,
-          selector: `xpath=${xpath}`,
+          selector: `xpath=${trimmedXpath}`,
           // Provisioning or future use if we want to use direct CDP
           // backendNodeId: elementId,
         };

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -492,3 +492,7 @@ export function loadApiKeyFromEnv(
 
   return undefined;
 }
+
+export function trimTrailingTextNode(path: string): string {
+  return path.replace(/\/text\(\)(\[\d+\])?$/iu, "");
+}


### PR DESCRIPTION
# why
- addresses #824 
# what changed
- added a function `trimTrailingTextNode` which trims the text node from the xpath
# test plan
- run the following eval sets: `act`, `observe`, `targeted_extract`, `combination`, `regression`