### PR TITLE
fix _refreshPageFromApi to respect parametrized apiKey

### DIFF
--- a/.changeset/rich-seals-repair.md
+++ b/.changeset/rich-seals-repair.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand-lib": patch
+---
+
+Fix \_refreshPageFromAPI to use parametrized apiKey

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -190,11 +190,6 @@ ${scriptContent} \
     const browserbase = new Browserbase({
       apiKey: this.stagehand["apiKey"] ?? process.env.BROWSERBASE_API_KEY,
     });
-    this.stagehand.log({
-      category: "browserbase",
-      message: `apiKey: ${this.stagehand["apiKey"]}, ${process.env.BROWSERBASE_API_KEY}`,
-      level: 1,
-    });
 
     const sessionStatus = await browserbase.sessions.retrieve(sessionId);
 

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -188,7 +188,12 @@ ${scriptContent} \
     }
 
     const browserbase = new Browserbase({
-      apiKey: process.env.BROWSERBASE_API_KEY,
+      apiKey: this.stagehand["apiKey"] ?? process.env.BROWSERBASE_API_KEY,
+    });
+    this.stagehand.log({
+      category: "browserbase",
+      message: `apiKey: ${this.stagehand["apiKey"]}, ${process.env.BROWSERBASE_API_KEY}`,
+      level: 1,
     });
 
     const sessionStatus = await browserbase.sessions.retrieve(sessionId);
@@ -209,14 +214,6 @@ ${scriptContent} \
 
     this.intPage = newStagehandPage.page;
 
-    if (this.stagehand.debugDom) {
-      this.stagehand.log({
-        category: "deprecation",
-        message:
-          "Warning: debugDom is not supported in this version of Stagehand",
-        level: 1,
-      });
-    }
     await this.intPage.waitForLoadState("domcontentloaded");
     await this._waitForSettledDom();
   }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -374,7 +374,7 @@ export class Stagehand {
   public verbose: 0 | 1 | 2;
   public llmProvider: LLMProvider;
   public enableCaching: boolean;
-  private apiKey: string | undefined;
+  protected apiKey: string | undefined;
   private projectId: string | undefined;
   private externalLogger?: (logLine: LogLine) => void;
   private browserbaseSessionCreateParams?: Browserbase.Sessions.SessionCreateParams;
@@ -529,7 +529,6 @@ export class Stagehand {
 
     this.llmProvider =
       llmProvider || new LLMProvider(this.logger, this.enableCaching);
-
     this.apiKey = apiKey ?? process.env.BROWSERBASE_API_KEY;
     this.projectId = projectId ?? process.env.BROWSERBASE_PROJECT_ID;
 


### PR DESCRIPTION
# why
To address this issue https://github.com/browserbase/stagehand/issues/829

# what changed
Prioritizes the provided `apiKey` vs the one auto-loaded in `BROWSERBASE_API_KEY` in `StagehandPage.ts` to refresh page from api

# test plan
