### PR TITLE
adjust `stagehandLogger.warn` level

### DIFF
--- a/.changeset/warm-chefs-sell.md
+++ b/.changeset/warm-chefs-sell.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand-lib": patch
+---
+
+adjust stagehandLogger.warn() level to be 1 instead of 0

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -248,7 +248,7 @@ export class StagehandLogger {
   warn(message: string, data?: Record<string, unknown>): void {
     this.log({
       message,
-      level: 1, // Using error level for warnings as we don't have a separate warning level
+      level: 1,
       category: "warning",
       auxiliary: this.convertToAuxiliary(data),
     });

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -248,7 +248,7 @@ export class StagehandLogger {
   warn(message: string, data?: Record<string, unknown>): void {
     this.log({
       message,
-      level: 0, // Using error level for warnings as we don't have a separate warning level
+      level: 1, // Using error level for warnings as we don't have a separate warning level
       category: "warning",
       auxiliary: this.convertToAuxiliary(data),
     });


### PR DESCRIPTION
# why
- error level should ideally only be used when there is an actual error
# what changed
- set the `stagehandLogger.warn` to be 1 instead of 0
