### PR TITLE
Optionally persist userDataDir with preserveUserDataDir flag

### DIFF
--- a/evals/deterministic/tests/local/create.test.ts
+++ b/evals/deterministic/tests/local/create.test.ts
@@ -26,6 +26,7 @@ test.describe("Local browser launch options", () => {
       localBrowserLaunchOptions: {
         userDataDir: customUserDataDir,
         headless: true,
+        preserveUserDataDir: true,
       },
     });
     await stagehand.init();
@@ -34,8 +35,53 @@ test.describe("Local browser launch options", () => {
 
     await stagehand.close();
 
+    expect(fs.existsSync(customUserDataDir)).toBeTruthy();
+
     // Cleanup
     fs.rmSync(customUserDataDir, { recursive: true, force: true });
+  });
+
+  test("cleans up userDataDir by default when preserveUserDataDir is false", async () => {
+    const customUserDataDir = path.join(os.tmpdir(), "cleanup-user-data");
+
+    const stagehand = new Stagehand({
+      ...StagehandConfig,
+      localBrowserLaunchOptions: {
+        userDataDir: customUserDataDir,
+        headless: true,
+        preserveUserDataDir: false,
+      },
+    });
+    await stagehand.init();
+
+    expect(fs.existsSync(customUserDataDir)).toBeTruthy();
+
+    await stagehand.close();
+
+    expect(fs.existsSync(customUserDataDir)).toBeFalsy();
+  });
+
+  test("cleans up userDataDir by default when no preserveUserDataDir flag is provided", async () => {
+    const customUserDataDir = path.join(
+      os.tmpdir(),
+      "default-cleanup-user-data",
+    );
+
+    const stagehand = new Stagehand({
+      ...StagehandConfig,
+      localBrowserLaunchOptions: {
+        userDataDir: customUserDataDir,
+        headless: true,
+        // No preserveUserDataDir flag provided - should default to cleanup
+      },
+    });
+    await stagehand.init();
+
+    expect(fs.existsSync(customUserDataDir)).toBeTruthy();
+
+    await stagehand.close();
+
+    expect(fs.existsSync(customUserDataDir)).toBeFalsy();
   });
 
   test("applies custom viewport settings", async () => {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -826,7 +826,10 @@ export class Stagehand {
       }
     }
 
-    if (this.contextPath) {
+    if (
+      this.contextPath &&
+      !this.localBrowserLaunchOptions?.preserveUserDataDir
+    ) {
       try {
         fs.rmSync(this.contextPath, { recursive: true, force: true });
       } catch (e) {

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -181,6 +181,7 @@ export interface LocalBrowserLaunchOptions {
   };
   tracesDir?: string;
   userDataDir?: string;
+  preserveUserDataDir?: boolean;
   acceptDownloads?: boolean;
   downloadsPath?: string;
   extraHTTPHeaders?: Record<string, string>;


### PR DESCRIPTION
Closes (#825)

# why
some users want to preserve the userDataDir between runs in local (per https://github.com/browserbase/stagehand/issues/794 and https://github.com/browserbase/stagehand/pull/825)

# what changed
- new flag in localBrowserLaunchOptions called preserveUserDataDir

# test plan
- added relevant test cases in tests/local/create.test.ts