### PR TITLE
Set default schema on extract options with null schema

### DIFF
--- a/.changeset/polite-vans-prove.md
+++ b/.changeset/polite-vans-prove.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Set default schema on extract options with no schema

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -736,7 +736,12 @@ ${scriptContent} \
               instruction: instructionOrOptions,
               schema: defaultExtractSchema as T,
             }
-          : instructionOrOptions;
+          : instructionOrOptions.schema
+            ? instructionOrOptions
+            : {
+                ...instructionOrOptions,
+                schema: defaultExtractSchema as T,
+              };
 
       const {
         instruction,


### PR DESCRIPTION
# why
Used to be possible, now it's breaking

# what changed
Set default schema whenever extract options doesn't provide one

# test plan
