### PR TITLE
Fix type safety for undefined xpath values

### DIFF
--- a/lib/handlers/observeHandler.ts
+++ b/lib/handlers/observeHandler.ts
@@ -170,7 +170,7 @@ export class StagehandObserveHandler {
 
         if (elementId.includes("-")) {
           const lookUpIndex = elementId as EncodedId;
-          const xpath = combinedXpathMap[lookUpIndex];
+          const xpath: string | undefined = combinedXpathMap[lookUpIndex];
 
           const trimmedXpath = trimTrailingTextNode(xpath);
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -493,6 +493,8 @@ export function loadApiKeyFromEnv(
   return undefined;
 }
 
-export function trimTrailingTextNode(path: string): string {
-  return path.replace(/\/text\(\)(\[\d+\])?$/iu, "");
+export function trimTrailingTextNode(
+  path: string | undefined,
+): string | undefined {
+  return path?.replace(/\/text\(\)(\[\d+\])?$/iu, "");
 }


### PR DESCRIPTION
## Summary
- Add proper type annotations for xpath lookup that can return undefined
- Update trimTrailingTextNode to handle undefined input safely
- Fix potential runtime errors when xpath is not found in combinedXpathMap

## Test plan
- [ ] Verify no TypeScript errors

🤖 Generated with [Claude Code](https://claude.ai/code)