### PR TITLE
Improve the Local Browser Customization documentation

### DIFF
--- a/docs/examples/customize_browser.mdx
+++ b/docs/examples/customize_browser.mdx
@@ -163,13 +163,13 @@ stagehand = Stagehand(StagehandConfig(
 
 Stagehand allows you to customize your local browser in a few different ways.
 
-You can use [`localBrowserLaunchOptions` type](https://github.com/browserbase/stagehand/blob/84f810b4631291307a32a47addad7e26e9c1deb3/types/stagehand.ts#L134-L174) to customize the browser you want Stagehand to use.
+You can use the [`localBrowserLaunchOptions` parameter](/reference/initialization_config#param-local-browser-launch-options) to customize the browser you want Stagehand to use.
 
 <CodeGroup>
 ```typescript TypeScript
 const stagehand = new Stagehand({
   localBrowserLaunchOptions: {
-	cdpUrl: 'your-cdp-url',
+    cdpUrl: 'your-cdp-url',
   }
 })
 ```


### PR DESCRIPTION
# why

See below

# what changed

I improved the “Local Browser Customization” section of the docs by:

* using a link to the API reference instead of a specific blob on GitHub. This allows the link to stay up to date, and lead to a place where the attributes are documented.
* fixing a minor wording inaccuracy (type → parameter)
* making the indentation consistent in the code example (using spaces everywhere instead of a mix of spaces + tabs)

# test plan

I ran the doc server manually and I verified that everything works as intended.