### PR TITLE
Add an option to use the viewport size of the host operating system window

### DIFF
--- a/docs/reference/initialization_config.mdx
+++ b/docs/reference/initialization_config.mdx
@@ -481,7 +481,9 @@ This constructor is used to create an instance of Stagehand.
         </ResponseField>
       </Expandable>
     </ResponseField>
-    <ResponseField name="viewport" type="object">
+    <ResponseField name="viewport" type="object | null">
+      The size of the viewport. If set to `null`, the viewport will be set to the size of the operating system window. Defaults to `{ width: 1024, height: 768 }`.
+
       <Expandable title="properties">
         <ResponseField name="width" type="number">
           Width of the viewport.

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -289,7 +289,10 @@ async function getBrowser(
             },
       locale: localBrowserLaunchOptions?.locale ?? "en-US",
       timezoneId: localBrowserLaunchOptions?.timezoneId ?? "America/New_York",
-      deviceScaleFactor: localBrowserLaunchOptions?.deviceScaleFactor ?? 1,
+      deviceScaleFactor:
+        localBrowserLaunchOptions?.viewport === null
+          ? undefined
+          : (localBrowserLaunchOptions?.deviceScaleFactor ?? 1),
       args: localBrowserLaunchOptions?.args ?? [
         "--disable-blink-features=AutomationControlled",
       ],

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -280,10 +280,13 @@ async function getBrowser(
     const context = await chromium.launchPersistentContext(userDataDir, {
       acceptDownloads: localBrowserLaunchOptions?.acceptDownloads ?? true,
       headless: localBrowserLaunchOptions?.headless ?? headless,
-      viewport: {
-        width: localBrowserLaunchOptions?.viewport?.width ?? 1024,
-        height: localBrowserLaunchOptions?.viewport?.height ?? 768,
-      },
+      viewport:
+        localBrowserLaunchOptions?.viewport === null
+          ? null
+          : {
+              width: localBrowserLaunchOptions?.viewport?.width ?? 1024,
+              height: localBrowserLaunchOptions?.viewport?.height ?? 768,
+            },
       locale: localBrowserLaunchOptions?.locale ?? "en-US",
       timezoneId: localBrowserLaunchOptions?.timezoneId ?? "America/New_York",
       deviceScaleFactor: localBrowserLaunchOptions?.deviceScaleFactor ?? 1,

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -198,7 +198,7 @@ export interface LocalBrowserLaunchOptions {
     urlFilter?: string | RegExp;
   };
   recordVideo?: { dir: string; size?: { width: number; height: number } };
-  viewport?: { width: number; height: number };
+  viewport?: { width: number; height: number } | null;
   deviceScaleFactor?: number;
   timezoneId?: string;
   bypassCSP?: boolean;


### PR DESCRIPTION
# why

By default Playwright [emulates a consistent viewport](https://playwright.dev/docs/api/class-browser/#browser-new-context-option-viewport) for every page no matter what the operating system window size is, which is helpful when using it for automated tests that need to be deterministic. It allows `viewport` to be set to `null` for cases where we want the user to be able to resize the window manually.

# what changed

I allowed `viewport` to be set to `null` and updated the doc to document the new option.

I also modified `deviceScaleFactor` to be undefined when using `viewport: null`. Without this change, the Stagehand initialization would crash when setting `viewport` to `null`:

```
[2025-07-13 09:05:34.620 -0700] ERROR: Error in init:
    error: "Error: \"deviceScaleFactor\" option is not supported with null \"viewport\"\nCall log:\n\u001b[2m  - <launching> /Users/Nicolas/Library/Caches/ms-playwright/chromium-1169/chrome-mac/Chromium.app/Contents/MacOS/Chromium --disable-field-trial-config --disable-background-networking --disable-background-timer-throttling --disable-backgrounding-occluded-windows --disable-back-forward-cache --disable-breakpad --disable-client-side-phishing-detection --disable-component-extensions-with-background-pages --disable-component-update --no-default-browser-check --disable-default-apps --disable-dev-shm-usage --disable-extensions --disable-features=AcceptCHFrame,AutoExpandDetailsElement,AvoidUnnecessaryBeforeUnloadCheckSync,CertificateTransparencyComponentUpdater,DeferRendererTasksAfterInput,DestroyProfileOnBrowserClose,DialMediaRouteProvider,ExtensionManifestV2Disabled,GlobalMediaControls,HttpsUpgrades,ImprovedCookieControls,LazyFrameLoading,LensOverlay,MediaRouter,PaintHolding,ThirdPartyStoragePartitioning,Translate --allow-pre-commit-input --disable-hang-monitor --disable-ipc-flooding-protection --disable-popup-blocking --disable-prompt-on-repost --disable-renderer-backgrounding --force-color-profile=srgb --metrics-recording-only --no-first-run --enable-automation --password-store=basic --use-mock-keychain --no-service-autorun --export-tagged-pdf --disable-search-engine-choice-screen --unsafely-disable-devtools-self-xss-warnings --enable-use-zoom-for-dsf=false --no-sandbox --disable-blink-features=AutomationControlled --user-data-dir=/var/folders/g5/_d0wmqqd1k59r8vl4c1w0pjc0000gn/T/stagehand/ctx_D3pnnW/userdir --remote-debugging-pipe about:blank\u001b[22m\n\u001b[2m  - <launched> pid=43880\u001b[22m\n"
[2025-07-13 09:05:34.620 -0700] ERROR: The browser context is undefined. This means the CDP connection to the browser failed. If running locally, please check if the browser is running and the port is open.
/Users/Nicolas/Documents/stagehand/dist/index.js:22446
        throw new StagehandInitError(errorMessage);
              ^

StagehandInitError: The browser context is undefined. This means the CDP connection to the browser failed
    at Stagehand3.<anonymous> (/Users/Nicolas/Documents/stagehand/dist/index.js:22446:15)
    at Generator.next (<anonymous>)
    at fulfilled (/Users/Nicolas/Documents/stagehand/dist/index.js:66:24)
```

# test plan

I tested the new option manually and it works:


https://github.com/user-attachments/assets/ef46518b-258a-44e9-a41c-9a41237494b9


