### PR TITLE
fixed deepLocator() pathing bug

### DIFF
--- a/lib/handlers/handlerUtils/actHandlerUtils.ts
+++ b/lib/handlers/handlerUtils/actHandlerUtils.ts
@@ -9,37 +9,52 @@ import { StagehandClickError } from "@/types/stagehandErrors";
 const IFRAME_STEP_RE = /^iframe(\[[^\]]+])?$/i;
 
 export function deepLocator(
-  root: Page | FrameLocator,
-  rawXPath: string,
-): Locator {
-  // 1 ─ strip optional 'xpath=' prefix and whitespace
-  let xpath = rawXPath.replace(/^xpath=/i, "").trim();
-  if (!xpath.startsWith("/")) xpath = "/" + xpath;
+    root: Page | FrameLocator,
+    rawXPath: string,
+  ): Locator {
+    // 1 ─ strip optional 'xpath=' prefix and whitespace
+    let xpath = rawXPath.replace(/^xpath=/i, "").trim();
 
-  // 2 ─ split into steps, accumulate until we hit an iframe step
-  const steps = xpath.split("/").filter(Boolean); // tokens
-  let ctx: Page | FrameLocator = root;
-  let buffer: string[] = [];
+    // Split the path by sequences of slashes, but keep the slashes as
+    // separate elements in the array. This preserves separators like '//'.
+    // e.g., '//a/b' becomes ['//', 'a', '/', 'b']
+    const parts = xpath.split(/(\/+)/).filter(Boolean);
 
-  const flushIntoFrame = () => {
-    if (buffer.length === 0) return;
-    const selector = "xpath=/" + buffer.join("/");
-    ctx = (ctx as Page | FrameLocator).frameLocator(selector);
-    buffer = [];
-  };
+    let ctx: Page | FrameLocator = root;
+    let buffer: string[] = [];
 
-  for (const step of steps) {
-    buffer.push(step);
-    if (IFRAME_STEP_RE.test(step)) {
-      // we've included the <iframe> element in buffer ⇒ descend
-      flushIntoFrame();
+    const flushIntoFrame = () => {
+      if (buffer.length === 0) return;
+
+      // Join the buffered parts to form the selector for the iframe.
+      // .join('') is used because the separators are already in the buffer.
+      const selector = "xpath=" + buffer.join("");
+      ctx = (ctx as Page | FrameLocator).frameLocator(selector);
+      buffer = []; // Reset buffer for the next path segment.
+    };
+
+    // Iterate through all parts (which include both steps and their separators).
+    for (const part of parts) {
+      buffer.push(part);
+
+      // A "step" is a part of the path that is NOT a separator.
+      // We test if the current step (a non-slash part) is an iframe locator.
+      const isStep = !/^\/+$/.test(part);
+      if (isStep && IFRAME_STEP_RE.test(part)) {
+        flushIntoFrame();
+      }
     }
-  }
 
-  // 3 ─ whatever is left in buffer addresses the target *inside* the last ctx
-  const finalSelector = "xpath=/" + buffer.join("/");
-  return (ctx as Page | FrameLocator).locator(finalSelector);
-}
+    // If the XPath ended with an iframe, the buffer will be empty. In this case,
+    // we return a locator for the root element ('*') within the final frame.
+    if (buffer.length === 0) {
+      return (ctx as Page | FrameLocator).locator("xpath=/*");
+    }
+
+    // Join the remaining parts for the final locator.
+    const finalSelector = "xpath=" + buffer.join("");
+    return (ctx as Page | FrameLocator).locator(finalSelector);
+  }
 
 /**
  * A mapping of playwright methods that may be chosen by the LLM to their


### PR DESCRIPTION
# why
The logic in deepLocator was consolidating all the double // -> single /s, meaning that if I tried to do any sort of XPATH without specifying direct descendants, the query would break. So for example when I set my selector to `selector: xpath=//*[@id='myID'] , it turns the locator into 'xpath=/*[@id=\'myID\']' removing the 2 slashes. This breaks my search because it's only looking for the ID in the root element, not across the descendants of the whole document (which is what I wanted)

# what changed
I changed the logic so that it preserves the number of slashes in the xpath instead of splitting on "/", dropping all the slashes and then re-adding them

# test plan
I tested locally but the stagehand team should verify that this works on whatever suite of tests they typically try. They should also probably add a test to catch this error like a search on non-direct descendants.
