### PR TITLE
pass sdk version number to api for debug

### DIFF
--- a/.changeset/proud-weeks-cover.md
+++ b/.changeset/proud-weeks-cover.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Pass sdk version number to API for debugging

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -28,6 +28,7 @@ import {
   StagehandResponseParseError,
 } from "../types/stagehandApiErrors";
 import makeFetchCookie from "fetch-cookie";
+import { STAGEHAND_VERSION } from "./version";
 
 export class StagehandAPI {
   private apiKey: string;
@@ -245,6 +246,7 @@ export class StagehandAPI {
       "x-model-api-key": this.modelApiKey,
       "x-sent-at": new Date().toISOString(),
       "x-language": "typescript",
+      "x-sdk-version": STAGEHAND_VERSION,
     };
 
     if (options.method === "POST" && options.body) {


### PR DESCRIPTION
# why
To help debug sessions faster and to respect backwards version compatibility long term

# what changed

# test plan
