### PR TITLE
filter out elements that don't have an associated xpath

### DIFF
--- a/.changeset/cold-pumas-accept.md
+++ b/.changeset/cold-pumas-accept.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+remove elements that don't have xpaths from observe response


### PR DESCRIPTION
# why
- if we do not find an xpath for an element, the element is not actionable. therefore, it should not be included in the `ObserveResult` array
# what changed
- added a filter step in `observeHandler.ts` to remove elements that have an undefined xpath
# test plan
- `observe` evals
- `act` evals
- `regression` evals