### PR TITLE
add timeout for js click

### DIFF
--- a/.changeset/slow-dryers-repeat.md
+++ b/.changeset/slow-dryers-repeat.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+add timeout for JS click

--- a/lib/handlers/handlerUtils/actHandlerUtils.ts
+++ b/lib/handlers/handlerUtils/actHandlerUtils.ts
@@ -410,7 +410,9 @@ export async function clickElement(ctx: MethodHandlerContext) {
     });
 
     try {
-      await locator.evaluate((el) => (el as HTMLElement).click());
+      await locator.evaluate((el) => (el as HTMLElement).click(), undefined, {
+        timeout: 3_500,
+      });
     } catch (e) {
       logger({
         category: "action",


### PR DESCRIPTION
# why
- we have a timeout for playwright click events, we should also have one for the JS click event attempt
# what changed
- added a 3.5 second timeout for the JS click event attempt in `actHandlerUtils.ts`
# test plan
- `act` evals
- `combination` evals