### PR TITLE
[evals] enable running evals on the Stagehand API

### DIFF
--- a/evals/args.ts
+++ b/evals/args.ts
@@ -11,6 +11,7 @@ const rawArgs = process.argv.slice(2);
 const parsedArgs: {
   evalName?: string;
   env?: string;
+  api?: string;
   trials?: number;
   concurrency?: number;
   provider?: string;
@@ -22,6 +23,8 @@ const parsedArgs: {
 for (const arg of rawArgs) {
   if (arg.startsWith("env=")) {
     parsedArgs.env = arg.split("=")[1]?.toLowerCase();
+  } else if (arg.startsWith("api=")) {
+    parsedArgs.api = arg.split("=")[1]?.toLowerCase();
   } else if (arg.startsWith("name=")) {
     parsedArgs.evalName = arg.split("=")[1];
   } else if (arg.startsWith("trials=")) {
@@ -46,6 +49,12 @@ if (parsedArgs.env === "browserbase") {
   process.env.EVAL_ENV = "BROWSERBASE";
 } else if (parsedArgs.env === "local") {
   process.env.EVAL_ENV = "LOCAL";
+}
+
+if (parsedArgs.api === "true") {
+  process.env.USE_API = "true";
+} else if (parsedArgs.api === "false") {
+  process.env.USE_API = "false";
 }
 
 if (parsedArgs.trials !== undefined) {
@@ -80,22 +89,21 @@ function buildUsage(detailed = false): string {
 
   const body = dedent`
     ${chalk.magenta.underline("Keys\n")}
-      ${chalk.cyan("env")}          target environment      (default ${chalk.dim(
-        "LOCAL",
-      )})       [${chalk.yellow("LOCAL")}, ${chalk.yellow("BROWSERBASE")}]
-      ${chalk.cyan("trials")}       number of trials        (default ${chalk.dim(
-        "10",
-      )})
-      ${chalk.cyan(
-        "concurrency",
-      )}  max parallel sessions   (default ${chalk.dim("10")})
-      ${chalk.cyan("provider")}  override LLM provider   (default ${chalk.dim(
-        providerDefault,
-      )})       [${chalk.yellow("OPENAI")}, ${chalk.yellow(
-        "ANTHROPIC",
-      )}, ${chalk.yellow("GOOGLE")}, ${chalk.yellow("TOGETHER")}, ${chalk.yellow(
-        "GROQ",
-      )}, ${chalk.yellow("CEREBRAS")}]
+  ${chalk.cyan("env".padEnd(12))} ${"target environment".padEnd(24)}
+    (default ${chalk.dim("LOCAL")})                [${chalk.yellow("BROWSERBASE")}, ${chalk.yellow("LOCAL")}] ${chalk.gray("← LOCAL sets api=false")}
+
+  ${chalk.cyan("api".padEnd(12))} ${"use the Stagehand API".padEnd(24)}
+    (default ${chalk.dim("false")})                [${chalk.yellow("true")},  ${chalk.yellow("false")}]
+
+  ${chalk.cyan("trials".padEnd(12))} ${"number of trials".padEnd(24)}
+    (default ${chalk.dim("10")})
+
+  ${chalk.cyan("concurrency".padEnd(12))} ${"max parallel sessions".padEnd(24)}
+    (default ${chalk.dim("10")})
+
+  ${chalk.cyan("provider".padEnd(12))} ${"override LLM provider".padEnd(24)}
+    (default ${chalk.dim(providerDefault)})        [${chalk.yellow("OPENAI")}, ${chalk.yellow("ANTHROPIC")}, ${chalk.yellow("GOOGLE")}, ${chalk.yellow("TOGETHER")}, ${chalk.yellow("GROQ")}, ${chalk.yellow("CEREBRAS")}]
+
 
     ${chalk.magenta.underline("Positional filters\n")}
       category <category_name>   one of: ${DEFAULT_EVAL_CATEGORIES.map((c) =>
@@ -114,6 +122,13 @@ function buildUsage(detailed = false): string {
       ${chalk.green("pnpm run evals")} ${chalk.cyan("env=")}${chalk.yellow("BROWSERBASE")} ${chalk.cyan(
         "trials=",
       )}${chalk.yellow("3")}
+      
+      
+      ${chalk.dim("# Run evals using the Stagehand API")}
+      
+      ${chalk.green("pnpm run evals")} ${chalk.cyan("env=")}${chalk.yellow("BROWSERBASE")} ${chalk.cyan(
+        "api=",
+      )}${chalk.yellow("true")}
 
 
       ${chalk.dim(
@@ -144,6 +159,8 @@ function buildUsage(detailed = false): string {
       EVAL_MAX_CONCURRENCY  overridable via ${chalk.cyan("concurrency=")}
       
       EVAL_PROVIDER         overridable via ${chalk.cyan("provider=")}
+      
+      USE_API               overridable via ${chalk.cyan("api=true")}
   `;
 
   return `${header}\n\n${synopsis}\n\n${body}\n${envSection}\n`;

--- a/evals/index.eval.ts
+++ b/evals/index.eval.ts
@@ -35,6 +35,8 @@ import OpenAI from "openai";
 import { initStagehand } from "./initStagehand";
 import { AISdkClient } from "@/examples/external_clients/aisdk";
 import { getAISDKLanguageModel } from "@/lib/llm/LLMProvider";
+import { loadApiKeyFromEnv } from "@/lib/utils";
+import { LogLine } from "@/types/log";
 
 dotenv.config();
 
@@ -49,6 +51,8 @@ const MAX_CONCURRENCY = process.env.EVAL_MAX_CONCURRENCY
 const TRIAL_COUNT = process.env.EVAL_TRIAL_COUNT
   ? parseInt(process.env.EVAL_TRIAL_COUNT, 10)
   : 3;
+
+const USE_API: boolean = (process.env.USE_API ?? "").toLowerCase() === "true";
 
 /**
  * generateSummary:
@@ -316,32 +320,53 @@ const generateFilteredTestcases = (): Testcase[] => {
           }
 
           // Execute the task
-          let llmClient: LLMClient;
-          if (input.modelName.includes("/")) {
-            llmClient = new AISdkClient({
-              model: wrapAISDKModel(
-                getAISDKLanguageModel(
-                  input.modelName.split("/")[0],
-                  input.modelName.split("/")[1],
-                ),
-              ),
+          let taskInput: Awaited<ReturnType<typeof initStagehand>>;
+
+          if (USE_API) {
+            const [provider] = input.modelName.split("/") as [string, string];
+
+            const logFn = (line: LogLine): void => logger.log(line);
+            const apiKey = loadApiKeyFromEnv(provider, logFn);
+
+            if (!apiKey) {
+              throw new StagehandEvalError(
+                `USE_API=true but no API key found for provider “${provider}”.`,
+              );
+            }
+
+            taskInput = await initStagehand({
+              logger,
+              modelName: input.modelName,
+              modelClientOptions: { apiKey: apiKey },
             });
           } else {
-            llmClient = new CustomOpenAIClient({
-              modelName: input.modelName as AvailableModel,
-              client: wrapOpenAI(
-                new OpenAI({
-                  apiKey: process.env.TOGETHER_AI_API_KEY,
-                  baseURL: "https://api.together.xyz/v1",
-                }),
-              ),
+            let llmClient: LLMClient;
+            if (input.modelName.includes("/")) {
+              llmClient = new AISdkClient({
+                model: wrapAISDKModel(
+                  getAISDKLanguageModel(
+                    input.modelName.split("/")[0],
+                    input.modelName.split("/")[1],
+                  ),
+                ),
+              });
+            } else {
+              llmClient = new CustomOpenAIClient({
+                modelName: input.modelName as AvailableModel,
+                client: wrapOpenAI(
+                  new OpenAI({
+                    apiKey: process.env.TOGETHER_AI_API_KEY,
+                    baseURL: "https://api.together.xyz/v1",
+                  }),
+                ),
+              });
+            }
+            taskInput = await initStagehand({
+              logger,
+              llmClient,
+              modelName: input.modelName,
             });
           }
-          const taskInput = await initStagehand({
-            logger,
-            llmClient,
-            modelName: input.modelName,
-          });
           let result;
           try {
             result = await taskFunction(taskInput);

--- a/evals/initStagehand.ts
+++ b/evals/initStagehand.ts
@@ -32,13 +32,13 @@ const StagehandConfig = {
   env: env,
   apiKey: process.env.BROWSERBASE_API_KEY,
   projectId: process.env.BROWSERBASE_PROJECT_ID,
+  useAPI: process.env.USE_API === "true",
   verbose: 2 as const,
   debugDom: true,
   headless: false,
   enableCaching,
   domSettleTimeoutMs: 30_000,
   disablePino: true,
-  experimental: true,
   browserbaseSessionCreateParams: {
     projectId: process.env.BROWSERBASE_PROJECT_ID!,
     browserSettings: {
@@ -63,13 +63,15 @@ const StagehandConfig = {
  */
 export const initStagehand = async ({
   llmClient,
+  modelClientOptions,
   domSettleTimeoutMs,
   logger,
   configOverrides,
   actTimeoutMs,
   modelName,
 }: {
-  llmClient: LLMClient;
+  llmClient?: LLMClient;
+  modelClientOptions?: { apiKey: string };
   domSettleTimeoutMs?: number;
   logger: EvalLogger;
   configOverrides?: Partial<ConstructorParams>;
@@ -78,9 +80,15 @@ export const initStagehand = async ({
 }): Promise<StagehandInitResult> => {
   const config = {
     ...StagehandConfig,
+    modelClientOptions,
     llmClient,
     ...(domSettleTimeoutMs && { domSettleTimeoutMs }),
     actTimeoutMs,
+    modelName,
+    experimental:
+      typeof configOverrides?.experimental === "boolean"
+        ? configOverrides.experimental
+        : !StagehandConfig.useAPI,
     ...configOverrides,
     logger: logger.log.bind(logger),
   };


### PR DESCRIPTION
# why
- to evaluate Stagehand performance when using the API
# what changed
- added an evals CLI arg `api=true` which sets the useAPI config param to `true`. defaults to `false`
   - if env is set to `LOCAL`, the `useAPI` param is overridden 
   - if `api=true` the `experimental` constructor param is set to `false`
# test plan
- this is it