### PR TITLE
update tests to reflect live page proxy

### DIFF
--- a/evals/deterministic/tests/page/livePageProxy.test.ts
+++ b/evals/deterministic/tests/page/livePageProxy.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "@playwright/test";
+import { Stagehand } from "@browserbasehq/stagehand";
+import StagehandConfig from "@/evals/deterministic/stagehand.config";
+
+test.describe("StagehandPage - live page proxy", () => {
+  test("tests that the page URL reflects the URL of the newest opened tab", async () => {
+    const stagehand = new Stagehand(StagehandConfig);
+    await stagehand.init();
+
+    const page = stagehand.page;
+    await page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/five-tab/");
+    await page.locator("body > button").click();
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    await page.waitForURL('**/page2.html', {waitUntil: "commit"});
+    // await new Promise(resolve => setTimeout(resolve, 1000));
+    const currentURL = page.url();
+    const expectedURL = "https://browserbase.github.io/stagehand-eval-sites/sites/five-tab/page2.html";
+
+    expect(currentURL).toBe(expectedURL);
+
+    await stagehand.close();
+  });
+
+  test("tests that opening a new tab does not close the old tab", async () => {
+    const stagehand = new Stagehand(StagehandConfig);
+    await stagehand.init();
+
+    const page = stagehand.page;
+    await page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/five-tab/");
+    await page.locator("body > button").click();
+    await new Promise(resolve => setTimeout(resolve, 1000));
+
+    const expectedNumPages = 2;
+    const actualNumPages = stagehand.context.pages().length;
+
+    expect(actualNumPages).toBe(expectedNumPages);
+
+    await stagehand.close();
+  });
+});

--- a/evals/deterministic/tests/page/on.test.ts
+++ b/evals/deterministic/tests/page/on.test.ts
@@ -3,73 +3,6 @@ import { Stagehand } from "@browserbasehq/stagehand";
 import StagehandConfig from "@/evals/deterministic/stagehand.config";
 
 test.describe("StagehandPage - page.on()", () => {
-  test("should click on the crewAI blog tab", async () => {
-    const stagehand = new Stagehand(StagehandConfig);
-    await stagehand.init();
-
-    const page = stagehand.page;
-    await page.goto(
-      "https://docs.browserbase.com/integrations/crew-ai/introduction",
-    );
-
-    let clickPromise: Promise<void>;
-
-    page.on("popup", async (newPage) => {
-      clickPromise = newPage.click(
-        "body > div.page-wrapper > div.navbar-2.w-nav > div.padding-global.top-bot > div > div.navigation-left > nav > a:nth-child(7)",
-      );
-    });
-
-    await page.goto(
-      "https://docs.browserbase.com/integrations/crew-ai/introduction",
-    );
-
-    await page.click(
-      "#content-area > div.relative.mt-8.prose.prose-gray.dark\\:prose-invert > p:nth-child(2) > a",
-    );
-
-    await clickPromise;
-
-    await stagehand.close();
-  });
-
-  test("should close the new tab and navigate to it on the existing page", async () => {
-    const stagehand = new Stagehand(StagehandConfig);
-    await stagehand.init();
-
-    const page = stagehand.page;
-    await page.goto(
-      "https://docs.browserbase.com/integrations/crew-ai/introduction",
-    );
-
-    let navigatePromise: Promise<unknown>;
-
-    page.on("popup", async (newPage) => {
-      navigatePromise = Promise.allSettled([
-        newPage.close(),
-        page.goto(newPage.url(), { waitUntil: "domcontentloaded" }),
-      ]);
-    });
-
-    // Click on the crewAI blog tab
-    await page.click(
-      "#content-area > div.relative.mt-8.prose.prose-gray.dark\\:prose-invert > p:nth-child(2) > a",
-    );
-
-    await navigatePromise;
-
-    await page.click(
-      "body > div.page-wrapper > div.navbar-2.w-nav > div.padding-global.top-bot > div > div.navigation-left > nav > a:nth-child(3)",
-    );
-
-    await page.waitForLoadState("domcontentloaded");
-
-    const currentUrl = page.url();
-    expect(currentUrl).toBe("https://www.crewai.com/open-source");
-
-    await stagehand.close();
-  });
-
   test("should handle console events", async () => {
     const stagehand = new Stagehand(StagehandConfig);
     await stagehand.init();
@@ -94,7 +27,7 @@ test.describe("StagehandPage - page.on()", () => {
     await stagehand.init();
 
     const page = stagehand.page;
-    await page.goto("https://example.com");
+    await page.goto("https://example.com", { waitUntil: "commit" });
 
     page.on("dialog", async (dialog) => {
       expect(dialog.message()).toBe("Test alert");
@@ -111,7 +44,7 @@ test.describe("StagehandPage - page.on()", () => {
     await stagehand.init();
 
     const page = stagehand.page;
-    await page.goto("https://example.com");
+    await page.goto("https://example.com", { waitUntil: "commit" });
 
     const requests: string[] = [];
     const responses: string[] = [];
@@ -124,7 +57,7 @@ test.describe("StagehandPage - page.on()", () => {
       responses.push(response.url());
     });
 
-    await page.goto("https://example.com");
+    await page.goto("https://example.com", { waitUntil: "commit" });
 
     expect(requests).toContain("https://example.com/");
     expect(responses).toContain("https://example.com/");


### PR DESCRIPTION
# why
- `stagehand.page` is now a proxy pointing to the most recently opened tab
    - this means that the below listener will fail because it closes the page while simultaneously trying to use the same page reference for `goto`:
```typescript
page.on("popup", async (newPage) => {
    navigatePromise = Promise.allSettled([
      newPage.close(),
      page.goto(newPage.url(), { waitUntil: "domcontentloaded" }),
    ]);
  });
```
# what changed
- removed irrelevant & broken tests
- added new tests for the live page proxy
# test plan
- this is it