### PR TITLE
enable scrolling inside of iframes

### DIFF
--- a/.changeset/open-donkeys-shine.md
+++ b/.changeset/open-donkeys-shine.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+enable scrolling inside of iframes

--- a/evals/evals.config.json
+++ b/evals/evals.config.json
@@ -418,6 +418,10 @@
     {
       "name": "agent/sign_in",
       "categories": ["agent"]
+    },
+    {
+      "name": "iframe_scroll",
+      "categories": ["act"]
     }
   ]
 }

--- a/evals/tasks/iframe_scroll.ts
+++ b/evals/tasks/iframe_scroll.ts
@@ -1,0 +1,60 @@
+import { EvalFunction } from "@/types/evals";
+
+export const iframe_scroll: EvalFunction = async ({
+  debugUrl,
+  sessionUrl,
+  stagehand,
+  logger,
+}) => {
+  try {
+    await stagehand.page.goto(
+      "https://browserbase.github.io/stagehand-eval-sites/sites/iframe-same-proc-scroll/",
+    );
+    await stagehand.page.act({
+      action: "scroll down 50% inside the iframe",
+      iframes: true,
+    });
+
+    const frames = stagehand.page.frames();
+    const frame = frames[1];
+
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+
+    // Get the current scroll position and total scroll height
+    const scrollInfo = await frame.evaluate(() => {
+      return {
+        scrollTop: window.scrollY + window.innerHeight / 2,
+        scrollHeight: document.documentElement.scrollHeight,
+      };
+    });
+
+    const halfwayScroll = scrollInfo.scrollHeight / 2;
+    const halfwayReached = Math.abs(scrollInfo.scrollTop - halfwayScroll) <= 1;
+    const evaluationResult = halfwayReached
+      ? {
+          _success: true,
+          logs: logger.getLogs(),
+          debugUrl,
+          sessionUrl,
+        }
+      : {
+          _success: false,
+          logs: logger.getLogs(),
+          debugUrl,
+          sessionUrl,
+          message: `Scroll position (${scrollInfo.scrollTop}px) is not halfway down the page (${halfwayScroll}px).`,
+        };
+
+    return evaluationResult;
+  } catch (error) {
+    return {
+      _success: false,
+      error: error,
+      logs: logger.getLogs(),
+      debugUrl,
+      sessionUrl,
+    };
+  } finally {
+    await stagehand.close();
+  }
+};

--- a/lib/a11y/utils.ts
+++ b/lib/a11y/utils.ts
@@ -1090,7 +1090,7 @@ async function getFrameExecutionContextId(
     {
       frameId,
       worldName: WORLD_NAME,
-      grantUniveralAccess: true,
+      grantUniversalAccess: true,
     },
     frame,
   );

--- a/lib/a11y/utils.ts
+++ b/lib/a11y/utils.ts
@@ -30,6 +30,8 @@ const PUA_END = 0xf8ff;
 
 const NBSP_CHARS = new Set<number>([0x00a0, 0x202f, 0x2007, 0xfeff]);
 
+const WORLD_NAME = "stagehand-world";
+
 /**
  * Clean a string by removing private-use unicode characters, normalizing whitespace,
  * and trimming the result.
@@ -1007,6 +1009,15 @@ export async function findScrollableElementIds(
         window.getScrollableElementXpaths(),
       );
 
+  console.log(`scrollable element xpaths: ${xpaths}`);
+  console.log(`scrollable element xpaths: ${xpaths}`);
+  console.log(`scrollable element xpaths: ${xpaths}`);
+  console.log(`scrollable element xpaths: ${xpaths}`);
+  console.log(`scrollable element xpaths: ${xpaths}`);
+  console.log(`scrollable element xpaths: ${xpaths}`);
+  console.log(`scrollable element xpaths: ${xpaths}`);
+  console.log(`scrollable element xpaths: ${xpaths}`);
+  console.log(`scrollable element xpaths: ${xpaths}`);
   const backendIds = new Set<number>();
 
   for (const xpath of xpaths) {
@@ -1040,6 +1051,8 @@ export async function resolveObjectIdForXPath(
   xpath: string,
   targetFrame?: Frame,
 ): Promise<string | null> {
+  const contextId = await getFrameExecutionContextId(page, targetFrame);
+
   const { result } = await page.sendCDP<{
     result?: { objectId?: string };
   }>(
@@ -1058,11 +1071,40 @@ export async function resolveObjectIdForXPath(
         })();
       `,
       returnByValue: false,
+      ...(contextId !== undefined ? { contextId } : {}),
     },
     targetFrame,
   );
   if (!result?.objectId) throw new StagehandElementNotFoundError([xpath]);
   return result.objectId;
+}
+
+/**
+ * Returns a stable executionContextId for the given frame by creating (or reusing)
+ * an isolated world in that frame.
+ */
+async function getFrameExecutionContextId(
+  stagehandPage: StagehandPage,
+  frame: Frame,
+): Promise<number | undefined> {
+  if (!frame || frame === stagehandPage.page.mainFrame()) {
+    // Main frame (or no frame): use the default world.
+    return undefined;
+  }
+  const frameId: string = await getCDPFrameId(stagehandPage, frame);
+  const { executionContextId } = await stagehandPage.sendCDP<{
+    executionContextId: number;
+  }>(
+    "Page.createIsolatedWorld",
+    {
+      frameId,
+      worldName: WORLD_NAME,
+      grantUniveralAccess: true,
+    },
+    frame,
+  );
+
+  return executionContextId;
 }
 
 /**

--- a/lib/a11y/utils.ts
+++ b/lib/a11y/utils.ts
@@ -1009,15 +1009,6 @@ export async function findScrollableElementIds(
         window.getScrollableElementXpaths(),
       );
 
-  console.log(`scrollable element xpaths: ${xpaths}`);
-  console.log(`scrollable element xpaths: ${xpaths}`);
-  console.log(`scrollable element xpaths: ${xpaths}`);
-  console.log(`scrollable element xpaths: ${xpaths}`);
-  console.log(`scrollable element xpaths: ${xpaths}`);
-  console.log(`scrollable element xpaths: ${xpaths}`);
-  console.log(`scrollable element xpaths: ${xpaths}`);
-  console.log(`scrollable element xpaths: ${xpaths}`);
-  console.log(`scrollable element xpaths: ${xpaths}`);
   const backendIds = new Set<number>();
 
   for (const xpath of xpaths) {


### PR DESCRIPTION
# why
this PR addresses two issues, both related to scrolling inside iframes:
1. we are not calling `.evaluate` inside frames:  
   - currently, the scrolling functionality that exists inside `performPlaywrightMethod` calls `page.evaluate`
   - this means that scrolling can only ever happen at the page level, not inside of iframes
   - inside each of these scroll related helpers, we already have access to a chained locator that optionally points to an element inside an iframe
   - therefore, we should use this chained locator, and call `locator.evaluate`
2. for SPIFs (same process iframes), we are not looking for scrollable elements in the correct execution context:
   - when we call `resolveObjectIdForXPath`, this executes in either the page level execution context, or, for OOPIFs (out of process iframes), the frame level execution context
   - this is problematic because SPIFs share the the same CDP session as the root document, which means that we are responsible for specifying the execution context. since we aren't doing this, `resolveObjectIdForXPath` only searches in the root document execution context, and can't see anything inside of the SPIF
# what changed
- to address issue number 1, I updated `scrollToNextChunk`, `scrollToPreviousChunk`, `scrollElementToPercentage` all use `locator.evaluate` instead of `page.evaluate` which enables scrolling inside (and outside) of iframes
- to address issue number 2, I added a function `getFrameExecutionContextId` which creates an isolated world & returns a SPIF scoped execution context
   - we use this downstream in `resolveObjectIdForXPath` which guarantees that we are searching for scrollable elements in the correct execution context
# test plan
- added an eval for scrolling inside a same-process iframe
- `act` evals
- `targeted_extract` evals
- `observe` evals
- `extract` evals