### PR TITLE
[api] update root frame ID on init

### DIFF
--- a/.changeset/clean-olives-wash.md
+++ b/.changeset/clean-olives-wash.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+fix: tab handling on API


### PR DESCRIPTION
# why
- tab handling for `act`, `extract` and `observe` was failing because we sometimes sent `frameId: undefined` after a new page had been opened
- the `rootFrameId` only became available after `Page.frameNavigated` fired, so the time between the event firing and a stagehand API call caused undefined `frameId`s 
# what changed
- Added `getCurrentRootFrameId` helper which calls `Page.getFrameTree` to fetch the current root frame ID on page creation
- `attachFrameNavigatedListener` is now called right after a page is wrapped with `createStagehandPage`
- `handleNewPlaywrightPage` now runs before attaching the listener
# test plan
- tested in local dev 
- run all evals