### PR TITLE
add docs on live page proxy

### DIFF
--- a/docs/examples/best_practices.mdx
+++ b/docs/examples/best_practices.mdx
@@ -58,7 +58,7 @@ console.log(`page2 repo: ${repo2}`);
 </Tab>
 <Tab title="Python">
 <Tip>
-Multi tab support is not yet implemented in Python, but its coming soon!
+Multi tab support is not yet implemented in Python, but it's coming soon!
 Setting `use_api=True` in your stagehand config will keep tabs open.
 </Tip>
 </Tab>


### PR DESCRIPTION
# why
- so people understand that the default page (`stagehand.page`) is a proxy to the most recently opened page
