### PR TITLE
[STG-644] rm koala and replace with posthog integration

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -101,8 +101,9 @@
     }
   },
   "integrations": {
-    "koala": {
-      "publicApiKey": "pk_6e508a479e95d94298f034e98ec54590ccf4"
+    "posthog": {
+      "apiKey": "phc_hmwkFrlc9UVrdE1jyG8AEKoCQCSr8dScjsRpKoLBEiV",
+      "apiHost": "https://us.i.posthog.com"
     }
   }
 }


### PR DESCRIPTION
# why

We want to track unique visitors to the docs in posthog. We are also not using koala anymore at all so free to totally remove. 

# what changed

# test plan
