### PR TITLE
Specify Zod Version for compatibility with Vercel AI SDK

### DIFF
--- a/lib/llm/LLMClient.ts
+++ b/lib/llm/LLMClient.ts
@@ -1,4 +1,4 @@
-import { ZodType } from "zod";
+import { ZodType } from "zod/v3";
 import { LLMTool } from "../../types/llm";
 import { LogLine } from "../../types/log";
 import { AvailableModel, ClientOptions } from "../../types/model";


### PR DESCRIPTION
# why

We are currently migrating to the vercel v5 AI SDK. As a result when calling generateObject or generateText, it appears that we must specify the zod version for the schemas that we are using (see [here](https://github.com/vercel/ai/issues/7724) for details). To complete the rollout for the migration, we need the zod schema for the ChatCompletionOptions to use a specified zod version.

# what changed
Explicitly specified the zod version for the ChatCompletionOptions file

# test plan
