### PR TITLE
bump zod version and add pathing spec

### DIFF
--- a/.changeset/clear-clouds-build.md
+++ b/.changeset/clear-clouds-build.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Bump zod version compatibility and add pathing spec

--- a/docs/examples/nextjs.mdx
+++ b/docs/examples/nextjs.mdx
@@ -47,7 +47,7 @@ Next, let's define our `main` function as a server action in `app/stagehand/main
 "use server";
 
 import { Stagehand } from "@browserbasehq/stagehand";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { Browserbase } from "@browserbasehq/sdk";
 
 /**

--- a/docs/get_started/quickstart.mdx
+++ b/docs/get_started/quickstart.mdx
@@ -206,7 +206,7 @@ Create a file `index.ts`:
 // index.ts
 import { Stagehand, ConstructorParams } from "@browserbasehq/stagehand";
 import dotenv from "dotenv";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 dotenv.config();
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "mintlify": "^4.0.401",
     "tsx": "^4.19.2",
-    "zod": "^3.24.1"
+    "zod": "^3.25.0"
   },
   "packageManager": "pnpm@9.15.0+sha512.76e2379760a4328ec4415815bcd6628dee727af3779aaa4c914e3944156c4299921a89f976381ee107d41f12cfa4b66681ca9c718f0668fa0831ed4c6d8ba56c"
 }

--- a/evals/deterministic/tests/Errors/apiKeyError.test.ts
+++ b/evals/deterministic/tests/Errors/apiKeyError.test.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "@playwright/test";
 import { Stagehand } from "@browserbasehq/stagehand";
 import StagehandConfig from "@/evals/deterministic/stagehand.config";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 test.describe("API key/LLMClient error", () => {
   test("Should confirm that we get an error if we call extract without LLM API key or LLMClient", async () => {

--- a/evals/llm_clients/hn_aisdk.ts
+++ b/evals/llm_clients/hn_aisdk.ts
@@ -1,6 +1,6 @@
 import { Stagehand } from "@browserbasehq/stagehand";
 import { EvalFunction } from "@/types/evals";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const hn_aisdk: EvalFunction = async ({
   debugUrl,

--- a/evals/llm_clients/hn_customOpenAI.ts
+++ b/evals/llm_clients/hn_customOpenAI.ts
@@ -1,5 +1,5 @@
 import { EvalFunction } from "@/types/evals";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { CustomOpenAIClient } from "@/examples/external_clients/customOpenAI";
 import OpenAI from "openai";
 import { Stagehand } from "@browserbasehq/stagehand";

--- a/evals/llm_clients/hn_langchain.ts
+++ b/evals/llm_clients/hn_langchain.ts
@@ -1,5 +1,5 @@
 import { EvalFunction } from "@/types/evals";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { LangchainClient } from "@/examples/external_clients/langchain";
 import { ChatOpenAI } from "@langchain/openai";
 import { Stagehand } from "@browserbasehq/stagehand";

--- a/evals/tasks/allrecipes.ts
+++ b/evals/tasks/allrecipes.ts
@@ -1,5 +1,5 @@
 import { EvalFunction } from "@/types/evals";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const allrecipes: EvalFunction = async ({
   logger,

--- a/evals/tasks/arxiv.ts
+++ b/evals/tasks/arxiv.ts
@@ -1,5 +1,5 @@
 import { EvalFunction } from "@/types/evals";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const arxiv: EvalFunction = async ({
   logger,

--- a/evals/tasks/combination_sauce.ts
+++ b/evals/tasks/combination_sauce.ts
@@ -1,5 +1,5 @@
 import { EvalFunction } from "@/types/evals";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const combination_sauce: EvalFunction = async ({
   logger,

--- a/evals/tasks/costar.ts
+++ b/evals/tasks/costar.ts
@@ -1,5 +1,5 @@
 import { EvalFunction } from "@/types/evals";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const costar: EvalFunction = async ({
   logger,

--- a/evals/tasks/extract_aigrant_companies.ts
+++ b/evals/tasks/extract_aigrant_companies.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 import { EvalFunction } from "@/types/evals";
 
 export const extract_aigrant_companies: EvalFunction = async ({

--- a/evals/tasks/extract_aigrant_targeted.ts
+++ b/evals/tasks/extract_aigrant_targeted.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 import { EvalFunction } from "@/types/evals";
 
 export const extract_aigrant_targeted: EvalFunction = async ({

--- a/evals/tasks/extract_aigrant_targeted_2.ts
+++ b/evals/tasks/extract_aigrant_targeted_2.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 import { EvalFunction } from "@/types/evals";
 
 export const extract_aigrant_targeted_2: EvalFunction = async ({

--- a/evals/tasks/extract_apartments.ts
+++ b/evals/tasks/extract_apartments.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 import { EvalFunction } from "../../types/evals";
 
 export const extract_apartments: EvalFunction = async ({

--- a/evals/tasks/extract_area_codes.ts
+++ b/evals/tasks/extract_area_codes.ts
@@ -1,5 +1,5 @@
 import { EvalFunction } from "@/types/evals";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const extract_area_codes: EvalFunction = async ({
   logger,

--- a/evals/tasks/extract_baptist_health.ts
+++ b/evals/tasks/extract_baptist_health.ts
@@ -1,6 +1,6 @@
 import { EvalFunction } from "@/types/evals";
 import { compareStrings } from "@/evals/utils";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const extract_baptist_health: EvalFunction = async ({
   logger,

--- a/evals/tasks/extract_capacitor_info.ts
+++ b/evals/tasks/extract_capacitor_info.ts
@@ -1,6 +1,6 @@
 import { EvalFunction } from "@/types/evals";
 import { normalizeString } from "@/evals/utils";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const extract_capacitor_info: EvalFunction = async ({
   logger,

--- a/evals/tasks/extract_collaborators.ts
+++ b/evals/tasks/extract_collaborators.ts
@@ -1,5 +1,5 @@
 import { EvalFunction } from "@/types/evals";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const extract_collaborators: EvalFunction = async ({
   logger,

--- a/evals/tasks/extract_csa.ts
+++ b/evals/tasks/extract_csa.ts
@@ -1,5 +1,5 @@
 import { EvalFunction } from "@/types/evals";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const extract_csa: EvalFunction = async ({
   debugUrl,

--- a/evals/tasks/extract_geniusee.ts
+++ b/evals/tasks/extract_geniusee.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 import { EvalFunction } from "@/types/evals";
 
 export const extract_geniusee: EvalFunction = async ({

--- a/evals/tasks/extract_geniusee_2.ts
+++ b/evals/tasks/extract_geniusee_2.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 import { EvalFunction } from "@/types/evals";
 
 export const extract_geniusee_2: EvalFunction = async ({

--- a/evals/tasks/extract_github_commits.ts
+++ b/evals/tasks/extract_github_commits.ts
@@ -1,5 +1,5 @@
 import { EvalFunction } from "@/types/evals";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const extract_github_commits: EvalFunction = async ({
   logger,

--- a/evals/tasks/extract_github_stars.ts
+++ b/evals/tasks/extract_github_stars.ts
@@ -1,5 +1,5 @@
 import { EvalFunction } from "@/types/evals";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const extract_github_stars: EvalFunction = async ({
   logger,

--- a/evals/tasks/extract_hamilton_weather.ts
+++ b/evals/tasks/extract_hamilton_weather.ts
@@ -1,5 +1,5 @@
 import { EvalFunction } from "@/types/evals";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { compareStrings } from "@/evals/utils";
 
 export const extract_hamilton_weather: EvalFunction = async ({

--- a/evals/tasks/extract_jfk_links.ts
+++ b/evals/tasks/extract_jfk_links.ts
@@ -1,5 +1,5 @@
 import { EvalFunction } from "@/types/evals";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const extract_jfk_links: EvalFunction = async ({
   logger,

--- a/evals/tasks/extract_jstor_news.ts
+++ b/evals/tasks/extract_jstor_news.ts
@@ -1,5 +1,5 @@
 import { EvalFunction } from "@/types/evals";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const extract_jstor_news: EvalFunction = async ({
   logger,

--- a/evals/tasks/extract_memorial_healthcare.ts
+++ b/evals/tasks/extract_memorial_healthcare.ts
@@ -1,5 +1,5 @@
 import { EvalFunction } from "@/types/evals";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { compareStrings } from "@/evals/utils";
 
 export const extract_memorial_healthcare: EvalFunction = async ({

--- a/evals/tasks/extract_nhl_stats.ts
+++ b/evals/tasks/extract_nhl_stats.ts
@@ -1,6 +1,6 @@
 import { EvalFunction } from "@/types/evals";
 import { normalizeString } from "@/evals/utils";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const extract_nhl_stats: EvalFunction = async ({
   debugUrl,

--- a/evals/tasks/extract_partners.ts
+++ b/evals/tasks/extract_partners.ts
@@ -1,5 +1,5 @@
 import { EvalFunction } from "@/types/evals";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const extract_partners: EvalFunction = async ({
   debugUrl,

--- a/evals/tasks/extract_press_releases.ts
+++ b/evals/tasks/extract_press_releases.ts
@@ -1,5 +1,5 @@
 import { EvalFunction } from "@/types/evals";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { compareStrings } from "@/evals/utils";
 
 export const extract_press_releases: EvalFunction = async ({

--- a/evals/tasks/extract_professional_info.ts
+++ b/evals/tasks/extract_professional_info.ts
@@ -1,6 +1,6 @@
 import { EvalFunction } from "@/types/evals";
 import { normalizeString } from "@/evals/utils";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const extract_professional_info: EvalFunction = async ({
   debugUrl,

--- a/evals/tasks/extract_public_notices.ts
+++ b/evals/tasks/extract_public_notices.ts
@@ -1,5 +1,5 @@
 import { EvalFunction } from "@/types/evals";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { compareStrings } from "@/evals/utils";
 
 export const extract_public_notices: EvalFunction = async ({

--- a/evals/tasks/extract_recipe.ts
+++ b/evals/tasks/extract_recipe.ts
@@ -1,5 +1,5 @@
 import { EvalFunction } from "@/types/evals";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const extract_recipe: EvalFunction = async ({
   debugUrl,

--- a/evals/tasks/extract_regulations_table.ts
+++ b/evals/tasks/extract_regulations_table.ts
@@ -1,5 +1,5 @@
 import { EvalFunction } from "@/types/evals";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const extract_regulations_table: EvalFunction = async ({
   debugUrl,

--- a/evals/tasks/extract_resistor_info.ts
+++ b/evals/tasks/extract_resistor_info.ts
@@ -1,6 +1,6 @@
 import { EvalFunction } from "@/types/evals";
 import { normalizeString } from "@/evals/utils";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const extract_resistor_info: EvalFunction = async ({
   debugUrl,

--- a/evals/tasks/extract_rockauto.ts
+++ b/evals/tasks/extract_rockauto.ts
@@ -1,5 +1,5 @@
 import { EvalFunction } from "@/types/evals";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const extract_rockauto: EvalFunction = async ({
   debugUrl,

--- a/evals/tasks/extract_single_link.ts
+++ b/evals/tasks/extract_single_link.ts
@@ -1,5 +1,5 @@
 import { EvalFunction } from "@/types/evals";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const extract_single_link: EvalFunction = async ({
   logger,

--- a/evals/tasks/extract_snowshoeing_destinations.ts
+++ b/evals/tasks/extract_snowshoeing_destinations.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 import { EvalFunction } from "@/types/evals";
 
 export const extract_snowshoeing_destinations: EvalFunction = async ({

--- a/evals/tasks/extract_staff_members.ts
+++ b/evals/tasks/extract_staff_members.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 import { EvalFunction } from "@/types/evals";
 
 export const extract_staff_members: EvalFunction = async ({

--- a/evals/tasks/extract_zillow.ts
+++ b/evals/tasks/extract_zillow.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 import { EvalFunction } from "../../types/evals";
 
 export const extract_zillow: EvalFunction = async ({

--- a/evals/tasks/homedepot.ts
+++ b/evals/tasks/homedepot.ts
@@ -1,5 +1,5 @@
 import { EvalFunction } from "@/types/evals";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const homedepot: EvalFunction = async ({
   debugUrl,

--- a/evals/tasks/iframe_hn.ts
+++ b/evals/tasks/iframe_hn.ts
@@ -1,5 +1,5 @@
 import { EvalFunction } from "@/types/evals";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const iframe_hn: EvalFunction = async ({
   debugUrl,

--- a/evals/tasks/imdb_movie_details.ts
+++ b/evals/tasks/imdb_movie_details.ts
@@ -1,5 +1,5 @@
 import { EvalFunction } from "@/types/evals";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const imdb_movie_details: EvalFunction = async ({
   debugUrl,

--- a/evals/tasks/peeler_complex.ts
+++ b/evals/tasks/peeler_complex.ts
@@ -1,5 +1,5 @@
 import { EvalFunction } from "@/types/evals";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const peeler_complex: EvalFunction = async ({
   debugUrl,

--- a/evals/tasks/sciquest.ts
+++ b/evals/tasks/sciquest.ts
@@ -1,5 +1,5 @@
 import { EvalFunction } from "@/types/evals";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const sciquest: EvalFunction = async ({
   debugUrl,

--- a/evals/tasks/ted_talk.ts
+++ b/evals/tasks/ted_talk.ts
@@ -1,6 +1,6 @@
 import { EvalFunction } from "@/types/evals";
 import { normalizeString } from "@/evals/utils";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const ted_talk: EvalFunction = async ({
   debugUrl,

--- a/evals/tasks/wichita.ts
+++ b/evals/tasks/wichita.ts
@@ -1,5 +1,5 @@
 import { EvalFunction } from "@/types/evals";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const wichita: EvalFunction = async ({
   debugUrl,

--- a/examples/2048.ts
+++ b/examples/2048.ts
@@ -1,5 +1,5 @@
 import { Stagehand } from "@browserbasehq/stagehand";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 async function example() {
   console.log("🎮 Starting 2048 bot...");

--- a/examples/custom_client_aisdk.ts
+++ b/examples/custom_client_aisdk.ts
@@ -8,7 +8,7 @@
 import { Stagehand } from "@browserbasehq/stagehand";
 import StagehandConfig from "@/stagehand.config";
 import { AISdkClient } from "./external_clients/aisdk";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { openai } from "@ai-sdk/openai";
 
 async function example() {

--- a/examples/custom_client_langchain.ts
+++ b/examples/custom_client_langchain.ts
@@ -3,7 +3,7 @@
  *
  * You will need to reference the Langchain Client in /external_clients/langchain.ts
  */
-import { z } from "zod";
+import { z } from "zod/v3";
 import { Stagehand } from "@browserbasehq/stagehand";
 import StagehandConfig from "@/stagehand.config";
 import { LangchainClient } from "./external_clients/langchain";

--- a/examples/custom_client_openai.ts
+++ b/examples/custom_client_openai.ts
@@ -6,7 +6,7 @@
  * You will need to reference the Custom OpenAI Client in /external_clients/customOpenAI.ts
  */
 import { Stagehand } from "@browserbasehq/stagehand";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { CustomOpenAIClient } from "./external_clients/customOpenAI";
 import StagehandConfig from "@/stagehand.config";
 import OpenAI from "openai";

--- a/examples/external_clients/customOpenAI.ts
+++ b/examples/external_clients/customOpenAI.ts
@@ -22,7 +22,7 @@ import type {
   ChatCompletionSystemMessageParam,
   ChatCompletionUserMessageParam,
 } from "openai/resources/chat/completions";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { CreateChatCompletionResponseError } from "@/types/stagehandErrors";
 
 function validateZodSchema(schema: z.ZodTypeAny, data: unknown) {

--- a/examples/parameterizeApiKey.ts
+++ b/examples/parameterizeApiKey.ts
@@ -1,5 +1,5 @@
 import { Stagehand } from "@browserbasehq/stagehand";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 /**
  * This example shows how to parameterize the API key for the LLM provider.

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -1,5 +1,5 @@
 import type { CDPSession, Page as PlaywrightPage, Frame } from "playwright";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { Page, defaultExtractSchema } from "../types/page";
 import {
   ExtractOptions,

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 import zodToJsonSchema from "zod-to-json-schema";
 import {
   ApiResponse,

--- a/lib/handlers/extractHandler.ts
+++ b/lib/handlers/extractHandler.ts
@@ -1,4 +1,4 @@
-import { z, ZodTypeAny } from "zod";
+import { z, ZodTypeAny } from "zod/v3";
 import { LogLine } from "../../types/log";
 import { ZodPathSegments } from "../../types/stagehand";
 import { extract } from "../inference";

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -44,7 +44,7 @@ import {
   InvalidAISDKModelFormatError,
   StagehandInitError,
 } from "../types/stagehandErrors";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { GotoOptions } from "@/types/playwright";
 
 dotenv.config({ path: ".env" });

--- a/lib/inference.ts
+++ b/lib/inference.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 import { LogLine } from "../types/log";
 import { ChatMessage, LLMClient } from "./llm/LLMClient";
 import {

--- a/lib/llm/LLMClient.ts
+++ b/lib/llm/LLMClient.ts
@@ -1,4 +1,4 @@
-import { ZodType } from "zod";
+import { ZodType } from "zod/v3";
 import { LLMTool } from "../../types/llm";
 import { LogLine } from "../../types/log";
 import { AvailableModel, ClientOptions } from "../../types/model";

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,4 +1,4 @@
-import { ZodFirstPartyTypeKind as Kind, z } from "zod";
+import { ZodFirstPartyTypeKind as Kind, z } from "zod/v3";
 import { ObserveResult, Page } from ".";
 import { LogLine } from "../types/log";
 import { ZodPathSegments } from "../types/stagehand";

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "peerDependencies": {
     "deepmerge": "^4.3.1",
     "dotenv": "^16.4.5",
-    "zod": "^3.23.8"
+    "zod": ">=3.25.0 <3.25.68"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "0.39.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "peerDependencies": {
     "deepmerge": "^4.3.1",
     "dotenv": "^16.4.5",
-    "zod": ">=3.25.0 <3.25.68"
+    "zod": ">=3.25.0 <4.1.0"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "0.39.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,7 +48,7 @@ importers:
         specifier: ^8.18.0
         version: 8.18.1
       zod:
-        specifier: '>=3.25.0 <3.25.68'
+        specifier: '>=3.25.0 <4.1.0'
         version: 3.25.67
       zod-to-json-schema:
         specifier: ^3.23.5
@@ -165,7 +165,7 @@ importers:
         version: 1.3.0
       tsup:
         specifier: ^8.2.1
-        version: 8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
+        version: 8.4.0(postcss@8.5.6)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
       tsx:
         specifier: ^4.10.5
         version: 4.19.4
@@ -408,8 +408,8 @@ packages:
     resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.27.2':
-    resolution: {integrity: sha512-QYLs8299NA7WM/bZAdp+CviYYkVoYXlDW2rzliy3chxd1PQjej7JORuMJDJXJUb9g0TT+B99EwaVLKmX+sPXWw==}
+  '@babel/parser@7.28.0':
+    resolution: {integrity: sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -417,8 +417,8 @@ packages:
     resolution: {integrity: sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.27.1':
-    resolution: {integrity: sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==}
+  '@babel/types@7.28.2':
+    resolution: {integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==}
     engines: {node: '>=6.9.0'}
 
   '@braintrust/core@0.0.34':
@@ -1209,6 +1209,9 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
+  '@jridgewell/gen-mapping@0.3.12':
+    resolution: {integrity: sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==}
+
   '@jridgewell/gen-mapping@0.3.8':
     resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
     engines: {node: '>=6.0.0'}
@@ -1224,8 +1227,14 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
+  '@jridgewell/sourcemap-codec@1.5.4':
+    resolution: {integrity: sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==}
+
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
+  '@jridgewell/trace-mapping@0.3.29':
+    resolution: {integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==}
 
   '@jsep-plugin/assignment@1.3.0':
     resolution: {integrity: sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==}
@@ -1582,6 +1591,9 @@ packages:
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
 
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
   '@types/express-serve-static-core@4.19.6':
     resolution: {integrity: sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==}
 
@@ -1775,6 +1787,11 @@ packages:
 
   acorn@8.14.1:
     resolution: {integrity: sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -2669,8 +2686,8 @@ packages:
     resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
     engines: {node: '>=0.10'}
 
-  esrap@1.4.6:
-    resolution: {integrity: sha512-F/D2mADJ9SHY3IwksD4DAXjTt7qt7GWUf3/8RhCNWmC/67tyb55dpimHmy7EplakFaflV0R/PC+fdSPqrRHAQw==}
+  esrap@1.4.9:
+    resolution: {integrity: sha512-3OMlcd0a03UGuZpPeUC1HxR3nA23l+HEyCiZw3b3FumJIN9KphoGzDJKMXI1S72jVS1dsenDyQC0kJlO1U9E1g==}
 
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
@@ -3882,6 +3899,7 @@ packages:
   multer@1.4.5-lts.2:
     resolution: {integrity: sha512-VzGiVigcG9zUAoCNU+xShztrlr1auZOlurXynNvO9GiWD1/mTBbUljOKY+qMeazBqXgRnjzeEgJI/wyjJUHg9A==}
     engines: {node: '>= 6.0.0'}
+    deprecated: Multer 1.x is impacted by a number of vulnerabilities, which have been patched in 2.x. You should upgrade to the latest 2.x version.
 
   mustache@4.2.0:
     resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
@@ -4249,8 +4267,8 @@ packages:
       yaml:
         optional: true
 
-  postcss@8.5.3:
-    resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -5455,8 +5473,8 @@ snapshots:
 
   '@ampproject/remapping@2.3.0':
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.8
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/gen-mapping': 0.3.12
+      '@jridgewell/trace-mapping': 0.3.29
 
   '@anthropic-ai/sdk@0.39.0':
     dependencies:
@@ -5513,13 +5531,13 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.27.1': {}
 
-  '@babel/parser@7.27.2':
+  '@babel/parser@7.28.0':
     dependencies:
-      '@babel/types': 7.27.1
+      '@babel/types': 7.28.2
 
   '@babel/runtime@7.27.1': {}
 
-  '@babel/types@7.27.1':
+  '@babel/types@7.28.2':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
@@ -6189,6 +6207,11 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
+  '@jridgewell/gen-mapping@0.3.12':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.4
+      '@jridgewell/trace-mapping': 0.3.29
+
   '@jridgewell/gen-mapping@0.3.8':
     dependencies:
       '@jridgewell/set-array': 1.2.1
@@ -6201,10 +6224,17 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
+  '@jridgewell/sourcemap-codec@1.5.4': {}
+
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@jridgewell/trace-mapping@0.3.29':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.4
 
   '@jsep-plugin/assignment@1.3.0(jsep@1.4.0)':
     dependencies:
@@ -6799,9 +6829,9 @@ snapshots:
       '@stoplight/yaml-ast-parser': 0.0.50
       tslib: 2.8.1
 
-  '@sveltejs/acorn-typescript@1.0.5(acorn@8.14.1)':
+  '@sveltejs/acorn-typescript@1.0.5(acorn@8.15.0)':
     dependencies:
-      acorn: 8.14.1
+      acorn: 8.15.0
 
   '@szmarczak/http-timer@5.0.1':
     dependencies:
@@ -6845,6 +6875,8 @@ snapshots:
       '@types/estree': 1.0.7
 
   '@types/estree@1.0.7': {}
+
+  '@types/estree@1.0.8': {}
 
   '@types/express-serve-static-core@4.19.6':
     dependencies:
@@ -7028,7 +7060,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.13':
     dependencies:
-      '@babel/parser': 7.27.2
+      '@babel/parser': 7.28.0
       '@vue/shared': 3.5.13
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -7041,14 +7073,14 @@ snapshots:
 
   '@vue/compiler-sfc@3.5.13':
     dependencies:
-      '@babel/parser': 7.27.2
+      '@babel/parser': 7.28.0
       '@vue/compiler-core': 3.5.13
       '@vue/compiler-dom': 3.5.13
       '@vue/compiler-ssr': 3.5.13
       '@vue/shared': 3.5.13
       estree-walker: 2.0.2
       magic-string: 0.30.17
-      postcss: 8.5.3
+      postcss: 8.5.6
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.13':
@@ -7094,6 +7126,8 @@ snapshots:
       acorn: 8.14.1
 
   acorn@8.14.1: {}
+
+  acorn@8.15.0: {}
 
   address@1.2.2: {}
 
@@ -8144,9 +8178,9 @@ snapshots:
     dependencies:
       estraverse: 5.3.0
 
-  esrap@1.4.6:
+  esrap@1.4.9:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.4
 
   esrecurse@4.3.0:
     dependencies:
@@ -9002,7 +9036,7 @@ snapshots:
 
   is-reference@3.0.3:
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
 
   is-regex@1.2.1:
     dependencies:
@@ -9243,7 +9277,7 @@ snapshots:
 
   magic-string@0.30.17:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.4
 
   markdown-extensions@2.0.0: {}
 
@@ -10227,15 +10261,15 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-load-config@6.0.1(postcss@8.5.3)(tsx@4.19.4)(yaml@2.7.1):
+  postcss-load-config@6.0.1(postcss@8.5.6)(tsx@4.19.4)(yaml@2.7.1):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
-      postcss: 8.5.3
+      postcss: 8.5.6
       tsx: 4.19.4
       yaml: 2.7.1
 
-  postcss@8.5.3:
+  postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -10998,15 +11032,15 @@ snapshots:
   svelte@5.28.2:
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@jridgewell/sourcemap-codec': 1.5.0
-      '@sveltejs/acorn-typescript': 1.0.5(acorn@8.14.1)
-      '@types/estree': 1.0.7
-      acorn: 8.14.1
+      '@jridgewell/sourcemap-codec': 1.5.4
+      '@sveltejs/acorn-typescript': 1.0.5(acorn@8.15.0)
+      '@types/estree': 1.0.8
+      acorn: 8.15.0
       aria-query: 5.3.2
       axobject-query: 4.1.0
       clsx: 2.1.1
       esm-env: 1.2.2
-      esrap: 1.4.6
+      esrap: 1.4.9
       is-reference: 3.0.3
       locate-character: 3.0.0
       magic-string: 0.30.17
@@ -11122,7 +11156,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.4.0(postcss@8.5.3)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1):
+  tsup@8.4.0(postcss@8.5.6)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.3)
       cac: 6.7.14
@@ -11132,7 +11166,7 @@ snapshots:
       esbuild: 0.25.3
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.3)(tsx@4.19.4)(yaml@2.7.1)
+      postcss-load-config: 6.0.1(postcss@8.5.6)(tsx@4.19.4)(yaml@2.7.1)
       resolve-from: 5.0.0
       rollup: 4.40.1
       source-map: 0.8.0-beta.0
@@ -11141,7 +11175,7 @@ snapshots:
       tinyglobby: 0.2.13
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.5.3
+      postcss: 8.5.6
       typescript: 5.8.3
     transitivePeerDependencies:
       - jiti

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 0.8.0
       ai:
         specifier: ^4.3.9
-        version: 4.3.12(react@19.1.0)(zod@3.24.3)
+        version: 4.3.12(react@19.1.0)(zod@3.25.67)
       deepmerge:
         specifier: ^4.3.1
         version: 4.3.1
@@ -34,7 +34,7 @@ importers:
         version: 3.1.0
       openai:
         specifier: ^4.87.1
-        version: 4.96.2(ws@8.18.1)(zod@3.24.3)
+        version: 4.96.2(ws@8.18.1)(zod@3.25.67)
       pino:
         specifier: ^9.6.0
         version: 9.6.0
@@ -48,48 +48,48 @@ importers:
         specifier: ^8.18.0
         version: 8.18.1
       zod:
-        specifier: ^3.23.8
-        version: 3.24.3
+        specifier: '>=3.25.0 <3.25.68'
+        version: 3.25.67
       zod-to-json-schema:
         specifier: ^3.23.5
-        version: 3.24.5(zod@3.24.3)
+        version: 3.24.5(zod@3.25.67)
     optionalDependencies:
       '@ai-sdk/anthropic':
         specifier: ^1.2.6
-        version: 1.2.10(zod@3.24.3)
+        version: 1.2.10(zod@3.25.67)
       '@ai-sdk/azure':
         specifier: ^1.3.19
-        version: 1.3.22(zod@3.24.3)
+        version: 1.3.22(zod@3.25.67)
       '@ai-sdk/cerebras':
         specifier: ^0.2.6
-        version: 0.2.13(zod@3.24.3)
+        version: 0.2.13(zod@3.25.67)
       '@ai-sdk/deepseek':
         specifier: ^0.2.13
-        version: 0.2.13(zod@3.24.3)
+        version: 0.2.13(zod@3.25.67)
       '@ai-sdk/google':
         specifier: ^1.2.6
-        version: 1.2.14(zod@3.24.3)
+        version: 1.2.14(zod@3.25.67)
       '@ai-sdk/groq':
         specifier: ^1.2.4
-        version: 1.2.8(zod@3.24.3)
+        version: 1.2.8(zod@3.25.67)
       '@ai-sdk/mistral':
         specifier: ^1.2.7
-        version: 1.2.7(zod@3.24.3)
+        version: 1.2.7(zod@3.25.67)
       '@ai-sdk/openai':
         specifier: ^1.0.14
-        version: 1.3.21(zod@3.24.3)
+        version: 1.3.21(zod@3.25.67)
       '@ai-sdk/perplexity':
         specifier: ^1.1.7
-        version: 1.1.8(zod@3.24.3)
+        version: 1.1.8(zod@3.25.67)
       '@ai-sdk/togetherai':
         specifier: ^0.2.6
-        version: 0.2.13(zod@3.24.3)
+        version: 0.2.13(zod@3.25.67)
       '@ai-sdk/xai':
         specifier: ^1.2.15
-        version: 1.2.15(zod@3.24.3)
+        version: 1.2.15(zod@3.25.67)
       ollama-ai-provider:
         specifier: ^1.2.0
-        version: 1.2.0(zod@3.24.3)
+        version: 1.2.0(zod@3.25.67)
     devDependencies:
       '@changesets/changelog-github':
         specifier: ^0.5.0
@@ -102,10 +102,10 @@ importers:
         version: 9.25.1
       '@langchain/core':
         specifier: ^0.3.40
-        version: 0.3.50(openai@4.96.2(ws@8.18.1)(zod@3.24.3))
+        version: 0.3.50(openai@4.96.2(ws@8.18.1)(zod@3.25.67))
       '@langchain/openai':
         specifier: ^0.4.4
-        version: 0.4.9(@langchain/core@0.3.50(openai@4.96.2(ws@8.18.1)(zod@3.24.3)))(ws@8.18.1)
+        version: 0.4.9(@langchain/core@0.3.50(openai@4.96.2(ws@8.18.1)(zod@3.25.67)))(ws@8.18.1)
       '@playwright/test':
         specifier: ^1.42.1
         version: 1.52.0
@@ -132,7 +132,7 @@ importers:
         version: 0.0.64
       braintrust:
         specifier: ^0.0.171
-        version: 0.0.171(openai@4.96.2(ws@8.18.1)(zod@3.24.3))(react@19.1.0)(sswr@2.2.0(svelte@5.28.2))(svelte@5.28.2)(vue@3.5.13(typescript@5.8.3))(zod@3.24.3)
+        version: 0.0.171(openai@4.96.2(ws@8.18.1)(zod@3.25.67))(react@19.1.0)(sswr@2.2.0(svelte@5.28.2))(svelte@5.28.2)(vue@3.5.13(typescript@5.8.3))(zod@3.25.67)
       chalk:
         specifier: ^5.4.1
         version: 5.4.1
@@ -185,8 +185,8 @@ importers:
         specifier: ^4.19.2
         version: 4.19.4
       zod:
-        specifier: ^3.24.1
-        version: 3.24.3
+        specifier: ^3.25.0
+        version: 3.25.76
 
   evals:
     dependencies:
@@ -204,6 +204,9 @@ importers:
         specifier: workspace:*
         version: link:..
     devDependencies:
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
       tsx:
         specifier: ^4.10.5
         version: 4.19.4
@@ -3153,6 +3156,9 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
   immer@9.0.21:
     resolution: {integrity: sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==}
 
@@ -3464,6 +3470,9 @@ packages:
     resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
     engines: {node: '>=0.10.0'}
 
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
   jwa@2.0.0:
     resolution: {integrity: sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==}
 
@@ -3503,6 +3512,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -4109,6 +4121,9 @@ packages:
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -4559,6 +4574,9 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -5243,102 +5261,105 @@ packages:
   zod@3.23.8:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
 
-  zod@3.24.3:
-    resolution: {integrity: sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==}
+  zod@3.25.67:
+    resolution: {integrity: sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
-  '@ai-sdk/anthropic@1.2.10(zod@3.24.3)':
+  '@ai-sdk/anthropic@1.2.10(zod@3.25.67)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.7(zod@3.24.3)
-      zod: 3.24.3
+      '@ai-sdk/provider-utils': 2.2.7(zod@3.25.67)
+      zod: 3.25.67
     optional: true
 
-  '@ai-sdk/azure@1.3.22(zod@3.24.3)':
+  '@ai-sdk/azure@1.3.22(zod@3.25.67)':
     dependencies:
-      '@ai-sdk/openai': 1.3.21(zod@3.24.3)
+      '@ai-sdk/openai': 1.3.21(zod@3.25.67)
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.7(zod@3.24.3)
-      zod: 3.24.3
+      '@ai-sdk/provider-utils': 2.2.7(zod@3.25.67)
+      zod: 3.25.67
     optional: true
 
-  '@ai-sdk/cerebras@0.2.13(zod@3.24.3)':
+  '@ai-sdk/cerebras@0.2.13(zod@3.25.67)':
     dependencies:
-      '@ai-sdk/openai-compatible': 0.2.13(zod@3.24.3)
+      '@ai-sdk/openai-compatible': 0.2.13(zod@3.25.67)
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.7(zod@3.24.3)
-      zod: 3.24.3
+      '@ai-sdk/provider-utils': 2.2.7(zod@3.25.67)
+      zod: 3.25.67
     optional: true
 
-  '@ai-sdk/deepseek@0.2.13(zod@3.24.3)':
+  '@ai-sdk/deepseek@0.2.13(zod@3.25.67)':
     dependencies:
-      '@ai-sdk/openai-compatible': 0.2.13(zod@3.24.3)
+      '@ai-sdk/openai-compatible': 0.2.13(zod@3.25.67)
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.7(zod@3.24.3)
-      zod: 3.24.3
+      '@ai-sdk/provider-utils': 2.2.7(zod@3.25.67)
+      zod: 3.25.67
     optional: true
 
-  '@ai-sdk/google@1.2.14(zod@3.24.3)':
-    dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.7(zod@3.24.3)
-      zod: 3.24.3
-    optional: true
-
-  '@ai-sdk/groq@1.2.8(zod@3.24.3)':
+  '@ai-sdk/google@1.2.14(zod@3.25.67)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.7(zod@3.24.3)
-      zod: 3.24.3
+      '@ai-sdk/provider-utils': 2.2.7(zod@3.25.67)
+      zod: 3.25.67
     optional: true
 
-  '@ai-sdk/mistral@1.2.7(zod@3.24.3)':
+  '@ai-sdk/groq@1.2.8(zod@3.25.67)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.7(zod@3.24.3)
-      zod: 3.24.3
+      '@ai-sdk/provider-utils': 2.2.7(zod@3.25.67)
+      zod: 3.25.67
     optional: true
 
-  '@ai-sdk/openai-compatible@0.2.13(zod@3.24.3)':
+  '@ai-sdk/mistral@1.2.7(zod@3.25.67)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.7(zod@3.24.3)
-      zod: 3.24.3
+      '@ai-sdk/provider-utils': 2.2.7(zod@3.25.67)
+      zod: 3.25.67
     optional: true
 
-  '@ai-sdk/openai@1.3.21(zod@3.24.3)':
+  '@ai-sdk/openai-compatible@0.2.13(zod@3.25.67)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.7(zod@3.24.3)
-      zod: 3.24.3
+      '@ai-sdk/provider-utils': 2.2.7(zod@3.25.67)
+      zod: 3.25.67
     optional: true
 
-  '@ai-sdk/perplexity@1.1.8(zod@3.24.3)':
+  '@ai-sdk/openai@1.3.21(zod@3.25.67)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.7(zod@3.24.3)
-      zod: 3.24.3
+      '@ai-sdk/provider-utils': 2.2.7(zod@3.25.67)
+      zod: 3.25.67
     optional: true
 
-  '@ai-sdk/provider-utils@1.0.22(zod@3.24.3)':
+  '@ai-sdk/perplexity@1.1.8(zod@3.25.67)':
+    dependencies:
+      '@ai-sdk/provider': 1.1.3
+      '@ai-sdk/provider-utils': 2.2.7(zod@3.25.67)
+      zod: 3.25.67
+    optional: true
+
+  '@ai-sdk/provider-utils@1.0.22(zod@3.25.67)':
     dependencies:
       '@ai-sdk/provider': 0.0.26
       eventsource-parser: 1.1.2
       nanoid: 3.3.11
       secure-json-parse: 2.7.0
     optionalDependencies:
-      zod: 3.24.3
+      zod: 3.25.67
 
-  '@ai-sdk/provider-utils@2.2.7(zod@3.24.3)':
+  '@ai-sdk/provider-utils@2.2.7(zod@3.25.67)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
       nanoid: 3.3.11
       secure-json-parse: 2.7.0
-      zod: 3.24.3
+      zod: 3.25.67
 
   '@ai-sdk/provider@0.0.11':
     dependencies:
@@ -5352,84 +5373,84 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@0.0.70(react@19.1.0)(zod@3.24.3)':
+  '@ai-sdk/react@0.0.70(react@19.1.0)(zod@3.25.67)':
     dependencies:
-      '@ai-sdk/provider-utils': 1.0.22(zod@3.24.3)
-      '@ai-sdk/ui-utils': 0.0.50(zod@3.24.3)
+      '@ai-sdk/provider-utils': 1.0.22(zod@3.25.67)
+      '@ai-sdk/ui-utils': 0.0.50(zod@3.25.67)
       swr: 2.3.3(react@19.1.0)
       throttleit: 2.1.0
     optionalDependencies:
       react: 19.1.0
-      zod: 3.24.3
+      zod: 3.25.67
 
-  '@ai-sdk/react@1.2.10(react@19.1.0)(zod@3.24.3)':
+  '@ai-sdk/react@1.2.10(react@19.1.0)(zod@3.25.67)':
     dependencies:
-      '@ai-sdk/provider-utils': 2.2.7(zod@3.24.3)
-      '@ai-sdk/ui-utils': 1.2.9(zod@3.24.3)
+      '@ai-sdk/provider-utils': 2.2.7(zod@3.25.67)
+      '@ai-sdk/ui-utils': 1.2.9(zod@3.25.67)
       react: 19.1.0
       swr: 2.3.3(react@19.1.0)
       throttleit: 2.1.0
     optionalDependencies:
-      zod: 3.24.3
+      zod: 3.25.67
 
-  '@ai-sdk/solid@0.0.54(zod@3.24.3)':
+  '@ai-sdk/solid@0.0.54(zod@3.25.67)':
     dependencies:
-      '@ai-sdk/provider-utils': 1.0.22(zod@3.24.3)
-      '@ai-sdk/ui-utils': 0.0.50(zod@3.24.3)
+      '@ai-sdk/provider-utils': 1.0.22(zod@3.25.67)
+      '@ai-sdk/ui-utils': 0.0.50(zod@3.25.67)
     transitivePeerDependencies:
       - zod
 
-  '@ai-sdk/svelte@0.0.57(svelte@5.28.2)(zod@3.24.3)':
+  '@ai-sdk/svelte@0.0.57(svelte@5.28.2)(zod@3.25.67)':
     dependencies:
-      '@ai-sdk/provider-utils': 1.0.22(zod@3.24.3)
-      '@ai-sdk/ui-utils': 0.0.50(zod@3.24.3)
+      '@ai-sdk/provider-utils': 1.0.22(zod@3.25.67)
+      '@ai-sdk/ui-utils': 0.0.50(zod@3.25.67)
       sswr: 2.2.0(svelte@5.28.2)
     optionalDependencies:
       svelte: 5.28.2
     transitivePeerDependencies:
       - zod
 
-  '@ai-sdk/togetherai@0.2.13(zod@3.24.3)':
+  '@ai-sdk/togetherai@0.2.13(zod@3.25.67)':
     dependencies:
-      '@ai-sdk/openai-compatible': 0.2.13(zod@3.24.3)
+      '@ai-sdk/openai-compatible': 0.2.13(zod@3.25.67)
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.7(zod@3.24.3)
-      zod: 3.24.3
+      '@ai-sdk/provider-utils': 2.2.7(zod@3.25.67)
+      zod: 3.25.67
     optional: true
 
-  '@ai-sdk/ui-utils@0.0.50(zod@3.24.3)':
+  '@ai-sdk/ui-utils@0.0.50(zod@3.25.67)':
     dependencies:
       '@ai-sdk/provider': 0.0.26
-      '@ai-sdk/provider-utils': 1.0.22(zod@3.24.3)
+      '@ai-sdk/provider-utils': 1.0.22(zod@3.25.67)
       json-schema: 0.4.0
       secure-json-parse: 2.7.0
-      zod-to-json-schema: 3.24.5(zod@3.24.3)
+      zod-to-json-schema: 3.24.5(zod@3.25.67)
     optionalDependencies:
-      zod: 3.24.3
+      zod: 3.25.67
 
-  '@ai-sdk/ui-utils@1.2.9(zod@3.24.3)':
+  '@ai-sdk/ui-utils@1.2.9(zod@3.25.67)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.7(zod@3.24.3)
-      zod: 3.24.3
-      zod-to-json-schema: 3.24.5(zod@3.24.3)
+      '@ai-sdk/provider-utils': 2.2.7(zod@3.25.67)
+      zod: 3.25.67
+      zod-to-json-schema: 3.24.5(zod@3.25.67)
 
-  '@ai-sdk/vue@0.0.59(vue@3.5.13(typescript@5.8.3))(zod@3.24.3)':
+  '@ai-sdk/vue@0.0.59(vue@3.5.13(typescript@5.8.3))(zod@3.25.67)':
     dependencies:
-      '@ai-sdk/provider-utils': 1.0.22(zod@3.24.3)
-      '@ai-sdk/ui-utils': 0.0.50(zod@3.24.3)
+      '@ai-sdk/provider-utils': 1.0.22(zod@3.25.67)
+      '@ai-sdk/ui-utils': 0.0.50(zod@3.25.67)
       swrv: 1.1.0(vue@3.5.13(typescript@5.8.3))
     optionalDependencies:
       vue: 3.5.13(typescript@5.8.3)
     transitivePeerDependencies:
       - zod
 
-  '@ai-sdk/xai@1.2.15(zod@3.24.3)':
+  '@ai-sdk/xai@1.2.15(zod@3.25.67)':
     dependencies:
-      '@ai-sdk/openai-compatible': 0.2.13(zod@3.24.3)
+      '@ai-sdk/openai-compatible': 0.2.13(zod@3.25.67)
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.7(zod@3.24.3)
-      zod: 3.24.3
+      '@ai-sdk/provider-utils': 2.2.7(zod@3.25.67)
+      zod: 3.25.67
     optional: true
 
   '@ampproject/remapping@2.3.0':
@@ -5449,10 +5470,10 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@asteasolutions/zod-to-openapi@6.4.0(zod@3.24.3)':
+  '@asteasolutions/zod-to-openapi@6.4.0(zod@3.25.67)':
     dependencies:
       openapi3-ts: 4.4.0
-      zod: 3.24.3
+      zod: 3.25.67
 
   '@asyncapi/parser@3.4.0':
     dependencies:
@@ -5505,15 +5526,15 @@ snapshots:
 
   '@braintrust/core@0.0.34':
     dependencies:
-      '@asteasolutions/zod-to-openapi': 6.4.0(zod@3.24.3)
+      '@asteasolutions/zod-to-openapi': 6.4.0(zod@3.25.67)
       uuid: 9.0.1
-      zod: 3.24.3
+      zod: 3.25.67
 
   '@braintrust/core@0.0.67':
     dependencies:
-      '@asteasolutions/zod-to-openapi': 6.4.0(zod@3.24.3)
+      '@asteasolutions/zod-to-openapi': 6.4.0(zod@3.25.67)
       uuid: 9.0.1
-      zod: 3.24.3
+      zod: 3.25.67
 
   '@browserbasehq/sdk@2.5.0':
     dependencies:
@@ -6205,30 +6226,30 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
-  '@langchain/core@0.3.50(openai@4.96.2(ws@8.18.1)(zod@3.24.3))':
+  '@langchain/core@0.3.50(openai@4.96.2(ws@8.18.1)(zod@3.25.67))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.20
-      langsmith: 0.3.23(openai@4.96.2(ws@8.18.1)(zod@3.24.3))
+      langsmith: 0.3.23(openai@4.96.2(ws@8.18.1)(zod@3.25.67))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
       uuid: 10.0.0
-      zod: 3.24.3
-      zod-to-json-schema: 3.24.5(zod@3.24.3)
+      zod: 3.25.67
+      zod-to-json-schema: 3.24.5(zod@3.25.67)
     transitivePeerDependencies:
       - openai
 
-  '@langchain/openai@0.4.9(@langchain/core@0.3.50(openai@4.96.2(ws@8.18.1)(zod@3.24.3)))(ws@8.18.1)':
+  '@langchain/openai@0.4.9(@langchain/core@0.3.50(openai@4.96.2(ws@8.18.1)(zod@3.25.67)))(ws@8.18.1)':
     dependencies:
-      '@langchain/core': 0.3.50(openai@4.96.2(ws@8.18.1)(zod@3.24.3))
+      '@langchain/core': 0.3.50(openai@4.96.2(ws@8.18.1)(zod@3.25.67))
       js-tiktoken: 1.0.20
-      openai: 4.96.2(ws@8.18.1)(zod@3.24.3)
-      zod: 3.24.3
-      zod-to-json-schema: 3.24.5(zod@3.24.3)
+      openai: 4.96.2(ws@8.18.1)(zod@3.25.67)
+      zod: 3.25.67
+      zod-to-json-schema: 3.24.5(zod@3.25.67)
     transitivePeerDependencies:
       - encoding
       - ws
@@ -6496,7 +6517,7 @@ snapshots:
       unified: 11.0.5
       unist-util-visit: 5.0.0
       yargs: 17.7.2
-      zod: 3.24.3
+      zod: 3.25.76
     transitivePeerDependencies:
       - '@types/react'
       - bare-buffer
@@ -6516,8 +6537,8 @@ snapshots:
       lcm: 0.0.3
       lodash: 4.17.21
       openapi-types: 12.1.3
-      zod: 3.24.3
-      zod-to-json-schema: 3.24.5(zod@3.24.3)
+      zod: 3.25.76
+      zod-to-json-schema: 3.24.5(zod@3.25.76)
     transitivePeerDependencies:
       - debug
 
@@ -7089,40 +7110,40 @@ snapshots:
       clean-stack: 4.2.0
       indent-string: 5.0.0
 
-  ai@3.4.33(openai@4.96.2(ws@8.18.1)(zod@3.24.3))(react@19.1.0)(sswr@2.2.0(svelte@5.28.2))(svelte@5.28.2)(vue@3.5.13(typescript@5.8.3))(zod@3.24.3):
+  ai@3.4.33(openai@4.96.2(ws@8.18.1)(zod@3.25.67))(react@19.1.0)(sswr@2.2.0(svelte@5.28.2))(svelte@5.28.2)(vue@3.5.13(typescript@5.8.3))(zod@3.25.67):
     dependencies:
       '@ai-sdk/provider': 0.0.26
-      '@ai-sdk/provider-utils': 1.0.22(zod@3.24.3)
-      '@ai-sdk/react': 0.0.70(react@19.1.0)(zod@3.24.3)
-      '@ai-sdk/solid': 0.0.54(zod@3.24.3)
-      '@ai-sdk/svelte': 0.0.57(svelte@5.28.2)(zod@3.24.3)
-      '@ai-sdk/ui-utils': 0.0.50(zod@3.24.3)
-      '@ai-sdk/vue': 0.0.59(vue@3.5.13(typescript@5.8.3))(zod@3.24.3)
+      '@ai-sdk/provider-utils': 1.0.22(zod@3.25.67)
+      '@ai-sdk/react': 0.0.70(react@19.1.0)(zod@3.25.67)
+      '@ai-sdk/solid': 0.0.54(zod@3.25.67)
+      '@ai-sdk/svelte': 0.0.57(svelte@5.28.2)(zod@3.25.67)
+      '@ai-sdk/ui-utils': 0.0.50(zod@3.25.67)
+      '@ai-sdk/vue': 0.0.59(vue@3.5.13(typescript@5.8.3))(zod@3.25.67)
       '@opentelemetry/api': 1.9.0
       eventsource-parser: 1.1.2
       json-schema: 0.4.0
       jsondiffpatch: 0.6.0
       secure-json-parse: 2.7.0
-      zod-to-json-schema: 3.24.5(zod@3.24.3)
+      zod-to-json-schema: 3.24.5(zod@3.25.67)
     optionalDependencies:
-      openai: 4.96.2(ws@8.18.1)(zod@3.24.3)
+      openai: 4.96.2(ws@8.18.1)(zod@3.25.67)
       react: 19.1.0
       sswr: 2.2.0(svelte@5.28.2)
       svelte: 5.28.2
-      zod: 3.24.3
+      zod: 3.25.67
     transitivePeerDependencies:
       - solid-js
       - vue
 
-  ai@4.3.12(react@19.1.0)(zod@3.24.3):
+  ai@4.3.12(react@19.1.0)(zod@3.25.67):
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.7(zod@3.24.3)
-      '@ai-sdk/react': 1.2.10(react@19.1.0)(zod@3.24.3)
-      '@ai-sdk/ui-utils': 1.2.9(zod@3.24.3)
+      '@ai-sdk/provider-utils': 2.2.7(zod@3.25.67)
+      '@ai-sdk/react': 1.2.10(react@19.1.0)(zod@3.25.67)
+      '@ai-sdk/ui-utils': 1.2.9(zod@3.25.67)
       '@opentelemetry/api': 1.9.0
       jsondiffpatch: 0.6.0
-      zod: 3.24.3
+      zod: 3.25.67
     optionalDependencies:
       react: 19.1.0
 
@@ -7233,8 +7254,8 @@ snapshots:
       linear-sum-assignment: 1.0.7
       mustache: 4.2.0
       openai: 4.23.0
-      zod: 3.24.3
-      zod-to-json-schema: 3.24.5(zod@3.24.3)
+      zod: 3.25.67
+      zod-to-json-schema: 3.24.5(zod@3.25.67)
     transitivePeerDependencies:
       - encoding
 
@@ -7345,13 +7366,13 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  braintrust@0.0.171(openai@4.96.2(ws@8.18.1)(zod@3.24.3))(react@19.1.0)(sswr@2.2.0(svelte@5.28.2))(svelte@5.28.2)(vue@3.5.13(typescript@5.8.3))(zod@3.24.3):
+  braintrust@0.0.171(openai@4.96.2(ws@8.18.1)(zod@3.25.67))(react@19.1.0)(sswr@2.2.0(svelte@5.28.2))(svelte@5.28.2)(vue@3.5.13(typescript@5.8.3))(zod@3.25.67):
     dependencies:
       '@ai-sdk/provider': 0.0.11
       '@braintrust/core': 0.0.67
       '@next/env': 14.2.28
       '@vercel/functions': 1.6.0
-      ai: 3.4.33(openai@4.96.2(ws@8.18.1)(zod@3.24.3))(react@19.1.0)(sswr@2.2.0(svelte@5.28.2))(svelte@5.28.2)(vue@3.5.13(typescript@5.8.3))(zod@3.24.3)
+      ai: 3.4.33(openai@4.96.2(ws@8.18.1)(zod@3.25.67))(react@19.1.0)(sswr@2.2.0(svelte@5.28.2))(svelte@5.28.2)(vue@3.5.13(typescript@5.8.3))(zod@3.25.67)
       argparse: 2.0.1
       chalk: 4.1.2
       cli-progress: 3.12.0
@@ -7366,8 +7387,8 @@ snapshots:
       slugify: 1.6.6
       source-map: 0.7.4
       uuid: 9.0.1
-      zod: 3.24.3
-      zod-to-json-schema: 3.24.5(zod@3.24.3)
+      zod: 3.25.67
+      zod-to-json-schema: 3.24.5(zod@3.25.67)
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-web-identity'
       - openai
@@ -8825,6 +8846,8 @@ snapshots:
 
   ignore@5.3.2: {}
 
+  immediate@3.0.6: {}
+
   immer@9.0.21: {}
 
   import-fresh@3.3.1:
@@ -9111,6 +9134,13 @@ snapshots:
 
   jsonpointer@5.0.1: {}
 
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   jwa@2.0.0:
     dependencies:
       buffer-equal-constant-time: 1.0.1
@@ -9132,7 +9162,7 @@ snapshots:
 
   kind-of@6.0.3: {}
 
-  langsmith@0.3.23(openai@4.96.2(ws@8.18.1)(zod@3.24.3)):
+  langsmith@0.3.23(openai@4.96.2(ws@8.18.1)(zod@3.25.67)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2
@@ -9142,7 +9172,7 @@ snapshots:
       semver: 7.7.1
       uuid: 10.0.0
     optionalDependencies:
-      openai: 4.96.2(ws@8.18.1)(zod@3.24.3)
+      openai: 4.96.2(ws@8.18.1)(zod@3.25.67)
 
   lcm@0.0.3:
     dependencies:
@@ -9156,6 +9186,10 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lilconfig@3.1.3: {}
 
@@ -9895,13 +9929,13 @@ snapshots:
       has-symbols: 1.1.0
       object-keys: 1.1.1
 
-  ollama-ai-provider@1.2.0(zod@3.24.3):
+  ollama-ai-provider@1.2.0(zod@3.25.67):
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.7(zod@3.24.3)
+      '@ai-sdk/provider-utils': 2.2.7(zod@3.25.67)
       partial-json: 0.1.7
     optionalDependencies:
-      zod: 3.24.3
+      zod: 3.25.67
     optional: true
 
   on-exit-leak-free@2.1.2: {}
@@ -9938,7 +9972,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  openai@4.96.2(ws@8.18.1)(zod@3.24.3):
+  openai@4.96.2(ws@8.18.1)(zod@3.25.67):
     dependencies:
       '@types/node': 18.19.87
       '@types/node-fetch': 2.6.12
@@ -9949,7 +9983,7 @@ snapshots:
       node-fetch: 2.7.0
     optionalDependencies:
       ws: 8.18.1
-      zod: 3.24.3
+      zod: 3.25.67
     transitivePeerDependencies:
       - encoding
 
@@ -10067,6 +10101,8 @@ snapshots:
   package-manager-detector@0.2.11:
     dependencies:
       quansync: 0.2.10
+
+  pako@1.0.11: {}
 
   parent-module@1.0.1:
     dependencies:
@@ -10693,6 +10729,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
+
+  setimmediate@1.0.5: {}
 
   setprototypeof@1.2.0: {}
 
@@ -11485,12 +11523,18 @@ snapshots:
 
   zimmerframe@1.1.2: {}
 
-  zod-to-json-schema@3.24.5(zod@3.24.3):
+  zod-to-json-schema@3.24.5(zod@3.25.67):
     dependencies:
-      zod: 3.24.3
+      zod: 3.25.67
+
+  zod-to-json-schema@3.24.5(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod@3.23.8: {}
 
-  zod@3.24.3: {}
+  zod@3.25.67: {}
+
+  zod@3.25.76: {}
 
   zwitch@2.0.4: {}

--- a/types/evals.ts
+++ b/types/evals.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 import type { AvailableModel } from "../types/model";
 import type { LogLine } from "../types/log";
 import type { EvalCase } from "braintrust";

--- a/types/model.ts
+++ b/types/model.ts
@@ -1,6 +1,6 @@
 import type { ClientOptions as AnthropicClientOptions } from "@anthropic-ai/sdk";
 import type { ClientOptions as OpenAIClientOptions } from "openai";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const AvailableModelSchema = z.enum([
   "gpt-4.1",

--- a/types/operator.ts
+++ b/types/operator.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const operatorResponseSchema = z.object({
   reasoning: z

--- a/types/page.ts
+++ b/types/page.ts
@@ -3,7 +3,7 @@ import type {
   BrowserContext as PlaywrightContext,
   Page as PlaywrightPage,
 } from "playwright";
-import { z } from "zod";
+import { z } from "zod/v3";
 import type {
   ActOptions,
   ActResult,

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -1,5 +1,5 @@
 import Browserbase from "@browserbasehq/sdk";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { LLMProvider } from "../lib/llm/LLMProvider";
 import { LogLine } from "./log";
 import { AvailableModel, ClientOptions } from "./model";

--- a/types/stagehandErrors.ts
+++ b/types/stagehandErrors.ts
@@ -1,4 +1,4 @@
-import { ZodError } from "zod";
+import { ZodError } from "zod/v3";
 import { STAGEHAND_VERSION } from "../lib/version.js";
 
 export class StagehandError extends Error {


### PR DESCRIPTION
# why
To enable compatibility with Zod v4

# what changed
Added v3 pathing spec and allowed zod peer dependency to be `"zod": ">=3.25.0 <4.1.0"`

# test plan
