### PR TITLE
fix: missing content from (some) same process iframes

### DIFF
--- a/.changeset/sharp-meals-clap.md
+++ b/.changeset/sharp-meals-clap.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+fix: unable to act on/get content from some same process iframes


### PR DESCRIPTION
# why
- we were unable to get the accessibility tree for _some_ same process iframes
- this is because when an iframe is same process, we need to pass the frame ID into `Accessibility.getFullAXTree`
- to get the frame ID, we need to call `Page.getFrameTree`
- within the returned frameTree, we iterate through and find the frame that has a URL that matches the `frame.url()` (playwright), and then grab the frame ID
- the problem is that `frame.url()` will include fragments (like `#`), while the URL from `Page.getFrameTree` does not include fragments.
- this meant the URL comparison returned false, and we couldn't grab the accessibility tree
# what changed
- added some normalization logic `normalizeUrl` so that we have 1:1 URLs before comparing
# test plan
- `act` evals
- `extract` evals
- `observe` evals