### PR TITLE
Update inference options for GPT-5

### DIFF
--- a/.changeset/bright-candies-cover.md
+++ b/.changeset/bright-candies-cover.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Patch GPT-5 new api format

--- a/lib/inference.ts
+++ b/lib/inference.ts
@@ -69,6 +69,7 @@ export async function extract({
   type MetadataResponse = z.infer<typeof metadataSchema>;
 
   const isUsingAnthropic = llmClient.type === "anthropic";
+  const isGPT5 = llmClient.modelName.includes("gpt-5");
 
   const extractCallMessages: ChatMessage[] = [
     buildExtractSystemPrompt(isUsingAnthropic, userProvidedInstructions),
@@ -100,7 +101,7 @@ export async function extract({
           schema,
           name: "Extraction",
         },
-        temperature: 0.1,
+        temperature: isGPT5 ? 1 : 0.1,
         top_p: 1,
         frequency_penalty: 0,
         presence_penalty: 0,
@@ -167,7 +168,7 @@ export async function extract({
           name: "Metadata",
           schema: metadataSchema,
         },
-        temperature: 0.1,
+        temperature: isGPT5 ? 1 : 0.1,
         top_p: 1,
         frequency_penalty: 0,
         presence_penalty: 0,
@@ -254,6 +255,8 @@ export async function observe({
   logInferenceToFile?: boolean;
   fromAct?: boolean;
 }) {
+  const isGPT5 = llmClient.modelName.includes("gpt-5");
+
   const observeSchema = z.object({
     elements: z
       .array(
@@ -321,7 +324,7 @@ export async function observe({
         schema: observeSchema,
         name: "Observation",
       },
-      temperature: 0.1,
+      temperature: isGPT5 ? 1 : 0.1,
       top_p: 1,
       frequency_penalty: 0,
       presence_penalty: 0,

--- a/lib/inference.ts
+++ b/lib/inference.ts
@@ -69,7 +69,7 @@ export async function extract({
   type MetadataResponse = z.infer<typeof metadataSchema>;
 
   const isUsingAnthropic = llmClient.type === "anthropic";
-  const isGPT5 = llmClient.modelName.includes("gpt-5");
+  const isGPT5 = llmClient.modelName.includes("gpt-5"); // TODO: remove this as we update support for gpt-5 configuration options
 
   const extractCallMessages: ChatMessage[] = [
     buildExtractSystemPrompt(isUsingAnthropic, userProvidedInstructions),
@@ -255,7 +255,7 @@ export async function observe({
   logInferenceToFile?: boolean;
   fromAct?: boolean;
 }) {
-  const isGPT5 = llmClient.modelName.includes("gpt-5");
+  const isGPT5 = llmClient.modelName.includes("gpt-5"); // TODO: remove this as we update support for gpt-5 configuration options
 
   const observeSchema = z.object({
     elements: z

--- a/lib/llm/aisdk.ts
+++ b/lib/llm/aisdk.ts
@@ -268,6 +268,7 @@ export class AISdkClient extends LLMClient {
     const textResponse = await generateText({
       model: this.model,
       messages: formattedMessages,
+      temperature: options.temperature,
       tools,
     });
 

--- a/lib/llm/aisdk.ts
+++ b/lib/llm/aisdk.ts
@@ -158,6 +158,7 @@ export class AISdkClient extends LLMClient {
     });
 
     let objectResponse: Awaited<ReturnType<typeof generateObject>>;
+    const isGPT5 = this.model.modelId.includes("gpt-5");
     if (options.response_model) {
       try {
         objectResponse = await generateObject({
@@ -165,6 +166,14 @@ export class AISdkClient extends LLMClient {
           messages: formattedMessages,
           schema: options.response_model.schema,
           temperature: options.temperature,
+          providerOptions: isGPT5
+            ? {
+                openai: {
+                  textVerbosity: "low", // Making these the default for gpt-5 for now
+                  reasoningEffort: "minimal",
+                },
+              }
+            : undefined,
         });
       } catch (err) {
         if (NoObjectGeneratedError.isInstance(err)) {

--- a/lib/llm/aisdk.ts
+++ b/lib/llm/aisdk.ts
@@ -164,6 +164,7 @@ export class AISdkClient extends LLMClient {
           model: this.model,
           messages: formattedMessages,
           schema: options.response_model.schema,
+          temperature: options.temperature,
         });
       } catch (err) {
         if (NoObjectGeneratedError.isInstance(err)) {


### PR DESCRIPTION
# why
OpenAI decided to change their inference configuration

# what changed
New GPT-5 family models don't accept temperature as an option, instead they declare this new format:
```
  text={
    "format": {
      "type": "text"
    },
    "verbosity": "low"
  },
  reasoning={
    "effort": "minimal"
  },
```

# test plan
