### PR TITLE
Fix handling possible navigation on cua clicks

### DIFF
--- a/.changeset/rare-bikes-shake.md
+++ b/.changeset/rare-bikes-shake.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Fix handling possible navigation on cua clicks

--- a/lib/handlers/agentHandler.ts
+++ b/lib/handlers/agentHandler.ts
@@ -12,6 +12,7 @@ import {
 } from "@/types/agent";
 import { Stagehand } from "../index";
 import { StagehandFunctionName } from "@/types/stagehand";
+import { handlePossiblePageNavigation } from "./handlerUtils/actHandlerUtils";
 
 export class StagehandAgentHandler {
   private stagehand: Stagehand;
@@ -215,6 +216,13 @@ export class StagehandAgentHandler {
           await this.page.mouse.click(x as number, y as number, {
             button: button as "left" | "right",
           });
+          await handlePossiblePageNavigation(
+            "clicked",
+            `(coordinates) x:${x}, y:${y}`,
+            this.page.url(),
+            this.stagehandPage,
+            this.logger,
+          );
           return { success: true };
         }
 

--- a/lib/handlers/handlerUtils/actHandlerUtils.ts
+++ b/lib/handlers/handlerUtils/actHandlerUtils.ts
@@ -471,7 +471,7 @@ export async function fallbackLocatorMethod(ctx: MethodHandlerContext) {
   }
 }
 
-async function handlePossiblePageNavigation(
+export async function handlePossiblePageNavigation(
   actionDescription: string,
   xpath: string,
   initialUrl: string,


### PR DESCRIPTION
# why
Now that there's multi-page support, need to update the cua handler. It was previously expecting to only operate on one page. 

# what changed
Added `handlePossibleNavigation` to cua handler clicks 

# test plan
