### PR TITLE
add support for shadow doms (open & closed mode)

### DIFF
--- a/.changeset/calm-snails-carry.md
+++ b/.changeset/calm-snails-carry.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+add support for shadow DOMs (open & closed mode) when experimental: true

--- a/evals/evals.config.json
+++ b/evals/evals.config.json
@@ -418,6 +418,42 @@
     {
       "name": "agent/sign_in",
       "categories": ["agent"]
+    },
+    {
+      "name": "osr_in_oopif",
+      "categories": ["act"]
+    },
+    {
+      "name": "csr_in_oopif",
+      "categories": ["act"]
+    },
+    {
+      "name": "csr_in_spif",
+      "categories": ["act"]
+    },
+    {
+      "name": "csr_in_spif",
+      "categories": ["act"]
+    },
+    {
+      "name": "spif_in_osr",
+      "categories": ["act"]
+    },
+    {
+      "name": "oopif_in_osr",
+      "categories": ["act"]
+    },
+    {
+      "name": "spif_in_csr",
+      "categories": ["act"]
+    },
+    {
+      "name": "oopif_in_csr",
+      "categories": ["act"]
+    },
+    {
+      "name": "osr_in_spif",
+      "categories": ["act"]
     }
   ]
 }

--- a/evals/tasks/csr_in_oopif.ts
+++ b/evals/tasks/csr_in_oopif.ts
@@ -33,6 +33,13 @@ export const csr_in_oopif: EvalFunction = async ({
         logs: logger.getLogs(),
       };
     }
+    return {
+      _success: false,
+      message: `unable to click on the button`,
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
   } catch (error) {
     return {
       _success: false,

--- a/evals/tasks/csr_in_oopif.ts
+++ b/evals/tasks/csr_in_oopif.ts
@@ -1,0 +1,47 @@
+import { EvalFunction } from "@/types/evals";
+
+export const csr_in_oopif: EvalFunction = async ({
+  debugUrl,
+  sessionUrl,
+  stagehand,
+  logger,
+}) => {
+  // this eval is designed to test whether stagehand can successfully
+  // click inside an CSR (closed mode shadow) root that is inside an
+  // OOPIF (out of process iframe)
+
+  const page = stagehand.page;
+  try {
+    await page.goto(
+      "https://browserbase.github.io/stagehand-eval-sites/sites/closed-shadow-root-in-oopif/",
+    );
+    await page.act({ action: "click the button", iframes: true });
+
+    const extraction = await page.extract({
+      instruction: "extract the entire page text",
+      iframes: true,
+    });
+
+    const pageText = extraction.extraction;
+
+    if (pageText.includes("button successfully clicked")) {
+      return {
+        _success: true,
+        message: `successfully clicked the button`,
+        debugUrl,
+        sessionUrl,
+        logs: logger.getLogs(),
+      };
+    }
+  } catch (error) {
+    return {
+      _success: false,
+      message: `error: ${error.message}`,
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
+  } finally {
+    await stagehand.close();
+  }
+};

--- a/evals/tasks/csr_in_spif.ts
+++ b/evals/tasks/csr_in_spif.ts
@@ -1,0 +1,47 @@
+import { EvalFunction } from "@/types/evals";
+
+export const csr_in_spif: EvalFunction = async ({
+  debugUrl,
+  sessionUrl,
+  stagehand,
+  logger,
+}) => {
+  // this eval is designed to test whether stagehand can successfully
+  // click inside an CSR (closed mode shadow) root that is inside an
+  // SPIF (same process iframe)
+
+  const page = stagehand.page;
+  try {
+    await page.goto(
+      "https://browserbase.github.io/stagehand-eval-sites/sites/closed-shadow-dom-in-spif/",
+    );
+    await page.act({ action: "click the button", iframes: true });
+
+    const extraction = await page.extract({
+      instruction: "extract the entire page text",
+      iframes: true,
+    });
+
+    const pageText = extraction.extraction;
+
+    if (pageText.includes("button successfully clicked")) {
+      return {
+        _success: true,
+        message: `successfully clicked the button`,
+        debugUrl,
+        sessionUrl,
+        logs: logger.getLogs(),
+      };
+    }
+  } catch (error) {
+    return {
+      _success: false,
+      message: `error: ${error.message}`,
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
+  } finally {
+    await stagehand.close();
+  }
+};

--- a/evals/tasks/csr_in_spif.ts
+++ b/evals/tasks/csr_in_spif.ts
@@ -33,6 +33,13 @@ export const csr_in_spif: EvalFunction = async ({
         logs: logger.getLogs(),
       };
     }
+    return {
+      _success: false,
+      message: `unable to click on the button`,
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
   } catch (error) {
     return {
       _success: false,

--- a/evals/tasks/oopif_in_csr.ts
+++ b/evals/tasks/oopif_in_csr.ts
@@ -1,0 +1,50 @@
+import { EvalFunction } from "@/types/evals";
+
+export const oopif_in_csr: EvalFunction = async ({
+  debugUrl,
+  sessionUrl,
+  stagehand,
+  logger,
+}) => {
+  // this eval is designed to test whether stagehand can successfully
+  // fill a form inside a OOPIF (out of process iframe) that is inside an
+  // CSR (closed mode shadow) root
+
+  const page = stagehand.page;
+  try {
+    await page.goto(
+      "https://browserbase.github.io/stagehand-eval-sites/sites/oopif-in-open-shadow-dom/",
+    );
+    await page.act({
+      action: "fill 'nunya' into the first name field",
+      iframes: true,
+    });
+
+    const extraction = await page.extract({
+      instruction: "extract the entire page text",
+      iframes: true,
+    });
+
+    const pageText = extraction.extraction;
+
+    if (pageText.includes("nunya")) {
+      return {
+        _success: true,
+        message: `successfully clicked the button`,
+        debugUrl,
+        sessionUrl,
+        logs: logger.getLogs(),
+      };
+    }
+  } catch (error) {
+    return {
+      _success: false,
+      message: `error: ${error.message}`,
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
+  } finally {
+    await stagehand.close();
+  }
+};

--- a/evals/tasks/oopif_in_csr.ts
+++ b/evals/tasks/oopif_in_csr.ts
@@ -30,12 +30,19 @@ export const oopif_in_csr: EvalFunction = async ({
     if (pageText.includes("nunya")) {
       return {
         _success: true,
-        message: `successfully clicked the button`,
+        message: `successfully filled the form`,
         debugUrl,
         sessionUrl,
         logs: logger.getLogs(),
       };
     }
+    return {
+      _success: false,
+      message: `unable to fill the form`,
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
   } catch (error) {
     return {
       _success: false,

--- a/evals/tasks/oopif_in_osr.ts
+++ b/evals/tasks/oopif_in_osr.ts
@@ -1,0 +1,50 @@
+import { EvalFunction } from "@/types/evals";
+
+export const oopif_in_osr: EvalFunction = async ({
+  debugUrl,
+  sessionUrl,
+  stagehand,
+  logger,
+}) => {
+  // this eval is designed to test whether stagehand can successfully
+  // fill a form inside a OOPIF (out of process iframe) that is inside an
+  // OSR (open mode shadow) root
+
+  const page = stagehand.page;
+  try {
+    await page.goto(
+      "https://browserbase.github.io/stagehand-eval-sites/sites/oopif-in-open-shadow-dom/",
+    );
+    await page.act({
+      action: "fill 'nunya' into the first name field",
+      iframes: true,
+    });
+
+    const extraction = await page.extract({
+      instruction: "extract the entire page text",
+      iframes: true,
+    });
+
+    const pageText = extraction.extraction;
+
+    if (pageText.includes("nunya")) {
+      return {
+        _success: true,
+        message: `successfully clicked the button`,
+        debugUrl,
+        sessionUrl,
+        logs: logger.getLogs(),
+      };
+    }
+  } catch (error) {
+    return {
+      _success: false,
+      message: `error: ${error.message}`,
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
+  } finally {
+    await stagehand.close();
+  }
+};

--- a/evals/tasks/oopif_in_osr.ts
+++ b/evals/tasks/oopif_in_osr.ts
@@ -30,12 +30,19 @@ export const oopif_in_osr: EvalFunction = async ({
     if (pageText.includes("nunya")) {
       return {
         _success: true,
-        message: `successfully clicked the button`,
+        message: `successfully filled the form`,
         debugUrl,
         sessionUrl,
         logs: logger.getLogs(),
       };
     }
+    return {
+      _success: false,
+      message: `unable to fill the form`,
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
   } catch (error) {
     return {
       _success: false,

--- a/evals/tasks/osr_in_oopif.ts
+++ b/evals/tasks/osr_in_oopif.ts
@@ -33,6 +33,13 @@ export const osr_in_oopif: EvalFunction = async ({
         logs: logger.getLogs(),
       };
     }
+    return {
+      _success: false,
+      message: `unable to click on the button`,
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
   } catch (error) {
     return {
       _success: false,

--- a/evals/tasks/osr_in_oopif.ts
+++ b/evals/tasks/osr_in_oopif.ts
@@ -1,0 +1,47 @@
+import { EvalFunction } from "@/types/evals";
+
+export const osr_in_oopif: EvalFunction = async ({
+  debugUrl,
+  sessionUrl,
+  stagehand,
+  logger,
+}) => {
+  // this eval is designed to test whether stagehand can successfully
+  // click inside an OSR (open mode shadow) root that is inside an
+  // OOPIF (out of process iframe)
+
+  const page = stagehand.page;
+  try {
+    await page.goto(
+      "https://browserbase.github.io/stagehand-eval-sites/sites/open-shadow-root-in-oopif/",
+    );
+    await page.act({ action: "click the button", iframes: true });
+
+    const extraction = await page.extract({
+      instruction: "extract the entire page text",
+      iframes: true,
+    });
+
+    const pageText = extraction.extraction;
+
+    if (pageText.includes("button successfully clicked")) {
+      return {
+        _success: true,
+        message: `successfully clicked the button`,
+        debugUrl,
+        sessionUrl,
+        logs: logger.getLogs(),
+      };
+    }
+  } catch (error) {
+    return {
+      _success: false,
+      message: `error: ${error.message}`,
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
+  } finally {
+    await stagehand.close();
+  }
+};

--- a/evals/tasks/osr_in_spif.ts
+++ b/evals/tasks/osr_in_spif.ts
@@ -1,0 +1,47 @@
+import { EvalFunction } from "@/types/evals";
+
+export const osr_in_spif: EvalFunction = async ({
+  debugUrl,
+  sessionUrl,
+  stagehand,
+  logger,
+}) => {
+  // this eval is designed to test whether stagehand can successfully
+  // click inside an OSR (open mode shadow) root that is inside an
+  // SPIF (same process iframe)
+
+  const page = stagehand.page;
+  try {
+    await page.goto(
+      "https://browserbase.github.io/stagehand-eval-sites/sites/open-shadow-root-in-spif/",
+    );
+    await page.act({ action: "click the button", iframes: true });
+
+    const extraction = await page.extract({
+      instruction: "extract the entire page text",
+      iframes: true,
+    });
+
+    const pageText = extraction.extraction;
+
+    if (pageText.includes("button successfully clicked")) {
+      return {
+        _success: true,
+        message: `successfully clicked the button`,
+        debugUrl,
+        sessionUrl,
+        logs: logger.getLogs(),
+      };
+    }
+  } catch (error) {
+    return {
+      _success: false,
+      message: `error: ${error.message}`,
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
+  } finally {
+    await stagehand.close();
+  }
+};

--- a/evals/tasks/osr_in_spif.ts
+++ b/evals/tasks/osr_in_spif.ts
@@ -33,6 +33,13 @@ export const osr_in_spif: EvalFunction = async ({
         logs: logger.getLogs(),
       };
     }
+    return {
+      _success: false,
+      message: `unable to click on the button`,
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
   } catch (error) {
     return {
       _success: false,

--- a/evals/tasks/shadow_dom.ts
+++ b/evals/tasks/shadow_dom.ts
@@ -11,9 +11,14 @@ export const shadow_dom: EvalFunction = async ({
     await page.goto(
       "https://browserbase.github.io/stagehand-eval-sites/sites/shadow-dom/",
     );
-    const result = await page.act("click the button");
+    await page.act("click the button");
+    const extraction = await page.extract({
+      instruction: "extract the page text",
+    });
 
-    if (!result.success && result.message.includes("not-supported")) {
+    const pageText = extraction.extraction;
+
+    if (pageText.includes("button successfully clicked")) {
       return {
         _success: true,
         debugUrl,

--- a/evals/tasks/spif_in_csr.ts
+++ b/evals/tasks/spif_in_csr.ts
@@ -33,6 +33,13 @@ export const spif_in_csr: EvalFunction = async ({
         logs: logger.getLogs(),
       };
     }
+    return {
+      _success: false,
+      message: `unable to click on the button`,
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
   } catch (error) {
     return {
       _success: false,

--- a/evals/tasks/spif_in_csr.ts
+++ b/evals/tasks/spif_in_csr.ts
@@ -1,0 +1,47 @@
+import { EvalFunction } from "@/types/evals";
+
+export const spif_in_csr: EvalFunction = async ({
+  debugUrl,
+  sessionUrl,
+  stagehand,
+  logger,
+}) => {
+  // this eval is designed to test whether stagehand can successfully
+  // click inside a SPIF (same process iframe) that is inside an
+  // CSR (closed mode shadow) root
+
+  const page = stagehand.page;
+  try {
+    await page.goto(
+      "https://browserbase.github.io/stagehand-eval-sites/sites/spif-in-closed-shadow-dom/",
+    );
+    await page.act({ action: "click the button", iframes: true });
+
+    const extraction = await page.extract({
+      instruction: "extract the entire page text",
+      iframes: true,
+    });
+
+    const pageText = extraction.extraction;
+
+    if (pageText.includes("button successfully clicked")) {
+      return {
+        _success: true,
+        message: `successfully clicked the button`,
+        debugUrl,
+        sessionUrl,
+        logs: logger.getLogs(),
+      };
+    }
+  } catch (error) {
+    return {
+      _success: false,
+      message: `error: ${error.message}`,
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
+  } finally {
+    await stagehand.close();
+  }
+};

--- a/evals/tasks/spif_in_osr.ts
+++ b/evals/tasks/spif_in_osr.ts
@@ -33,6 +33,13 @@ export const spif_in_osr: EvalFunction = async ({
         logs: logger.getLogs(),
       };
     }
+    return {
+      _success: false,
+      message: `unable to click on the button`,
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
   } catch (error) {
     return {
       _success: false,

--- a/evals/tasks/spif_in_osr.ts
+++ b/evals/tasks/spif_in_osr.ts
@@ -1,0 +1,47 @@
+import { EvalFunction } from "@/types/evals";
+
+export const spif_in_osr: EvalFunction = async ({
+  debugUrl,
+  sessionUrl,
+  stagehand,
+  logger,
+}) => {
+  // this eval is designed to test whether stagehand can successfully
+  // click inside a SPIF (same process iframe) that is inside an
+  // OSR (open mode shadow) root
+
+  const page = stagehand.page;
+  try {
+    await page.goto(
+      "https://browserbase.github.io/stagehand-eval-sites/sites/spif-in-open-shadow-dom/",
+    );
+    await page.act({ action: "click the button", iframes: true });
+
+    const extraction = await page.extract({
+      instruction: "extract the entire page text",
+      iframes: true,
+    });
+
+    const pageText = extraction.extraction;
+
+    if (pageText.includes("button successfully clicked")) {
+      return {
+        _success: true,
+        message: `successfully clicked the button`,
+        debugUrl,
+        sessionUrl,
+        logs: logger.getLogs(),
+      };
+    }
+  } catch (error) {
+    return {
+      _success: false,
+      message: `error: ${error.message}`,
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
+  } finally {
+    await stagehand.close();
+  }
+};

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -123,18 +123,21 @@ export class StagehandPage {
         logger: this.stagehand.logger,
         stagehandPage: this,
         selfHeal: this.stagehand.selfHeal,
+        experimental: this.stagehand.experimental,
       });
       this.extractHandler = new StagehandExtractHandler({
         stagehand: this.stagehand,
         logger: this.stagehand.logger,
         stagehandPage: this,
         userProvidedInstructions,
+        experimental: this.stagehand.experimental,
       });
       this.observeHandler = new StagehandObserveHandler({
         stagehand: this.stagehand,
         logger: this.stagehand.logger,
         stagehandPage: this,
         userProvidedInstructions,
+        experimental: this.stagehand.experimental,
       });
     }
   }

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -522,8 +522,7 @@ ${scriptContent} \
 
       this.intPage = new Proxy(page, handler) as unknown as Page;
 
-      // Ensure our backdoor and selector engine are ready up front
-      await this.ensureStagehandScript();
+      // Ensure backdoor and selector engine are ready up front
       await this.ensureStagehandSelectorEngine();
 
       this.initialized = true;

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -1,4 +1,9 @@
-import type { CDPSession, Page as PlaywrightPage, Frame } from "playwright";
+import type {
+  CDPSession,
+  Page as PlaywrightPage,
+  Frame,
+  ElementHandle,
+} from "playwright";
 import { selectors } from "playwright";
 import { z } from "zod/v3";
 import { Page, defaultExtractSchema } from "../types/page";

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -1,9 +1,4 @@
-import type {
-  CDPSession,
-  Page as PlaywrightPage,
-  Frame,
-  ElementHandle,
-} from "playwright";
+import type { CDPSession, Page as PlaywrightPage, Frame } from "playwright";
 import { selectors } from "playwright";
 import { z } from "zod/v3";
 import { Page, defaultExtractSchema } from "../types/page";

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -1,4 +1,10 @@
-import type { CDPSession, Page as PlaywrightPage, Frame } from "playwright";
+import type {
+  CDPSession,
+  Page as PlaywrightPage,
+  Frame,
+  ElementHandle,
+} from "playwright";
+import { selectors } from "playwright";
 import { z } from "zod/v3";
 import { Page, defaultExtractSchema } from "../types/page";
 import {
@@ -29,6 +35,7 @@ import {
 import { StagehandAPIError } from "@/types/stagehandApiErrors";
 import { scriptContent } from "@/lib/dom/build/scriptContent";
 import type { Protocol } from "devtools-protocol";
+import { StagehandBackdoor } from "@/lib/dom/global";
 
 async function getCurrentRootFrameId(session: CDPSession): Promise<string> {
   const { frameTree } = (await session.send(
@@ -36,6 +43,9 @@ async function getCurrentRootFrameId(session: CDPSession): Promise<string> {
   )) as Protocol.Page.GetFrameTreeResponse;
   return frameTree.frame.id;
 }
+
+/** ensure we register the custom selector only once per process */
+let stagehandSelectorRegistered = false;
 
 export class StagehandPage {
   private stagehand: Stagehand;
@@ -186,6 +196,113 @@ ${scriptContent} \
         throw err;
       }
     }
+  }
+
+  /** Register the custom selector engine that pierces open/closed shadow roots. */
+  private async ensureStagehandSelectorEngine(): Promise<void> {
+    if (stagehandSelectorRegistered) return;
+    stagehandSelectorRegistered = true;
+
+    await selectors.register("stagehand", () => {
+      type Backdoor = {
+        getClosedRoot?: (host: Element) => ShadowRoot | undefined;
+      };
+
+      function parseSelector(input: string): { name: string; value: string } {
+        // Accept either:  "abc123"  → uses DEFAULT_ATTR
+        // or explicitly:  "data-__stagehand-id=abc123"
+        const raw = input.trim();
+        const eq = raw.indexOf("=");
+        if (eq === -1) {
+          return {
+            name: "data-__stagehand-id",
+            value: raw.replace(/^["']|["']$/g, ""),
+          };
+        }
+        const name = raw.slice(0, eq).trim();
+        const value = raw
+          .slice(eq + 1)
+          .trim()
+          .replace(/^["']|["']$/g, "");
+        return { name, value };
+      }
+
+      function pushChildren(node: Node, stack: Node[]): void {
+        if (node.nodeType === Node.DOCUMENT_NODE) {
+          const de = (node as Document).documentElement;
+          if (de) stack.push(de);
+          return;
+        }
+
+        if (node.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
+          const frag = node as DocumentFragment;
+          const hc = frag.children as HTMLCollection | undefined;
+          if (hc && hc.length) {
+            for (let i = hc.length - 1; i >= 0; i--)
+              stack.push(hc[i] as Element);
+          } else {
+            const cn = frag.childNodes;
+            for (let i = cn.length - 1; i >= 0; i--) stack.push(cn[i]);
+          }
+          return;
+        }
+
+        if (node.nodeType === Node.ELEMENT_NODE) {
+          const el = node as Element;
+          for (let i = el.children.length - 1; i >= 0; i--)
+            stack.push(el.children[i]);
+        }
+      }
+
+      function* traverseAllTrees(
+        start: Node,
+      ): Generator<Element, void, unknown> {
+        const backdoor = window.__stagehand__ as Backdoor | undefined;
+        const stack: Node[] = [];
+
+        if (start.nodeType === Node.DOCUMENT_NODE) {
+          const de = (start as Document).documentElement;
+          if (de) stack.push(de);
+        } else {
+          stack.push(start);
+        }
+
+        while (stack.length) {
+          const node = stack.pop()!;
+          if (node.nodeType === Node.ELEMENT_NODE) {
+            const el = node as Element;
+            yield el;
+
+            // open shadow
+            const open = el.shadowRoot as ShadowRoot | null;
+            if (open) stack.push(open);
+
+            // closed shadow via backdoor
+            const closed = backdoor?.getClosedRoot?.(el);
+            if (closed) stack.push(closed);
+          }
+          pushChildren(node, stack);
+        }
+      }
+
+      return {
+        query(root: Node, selector: string): Element | null {
+          const { name, value } = parseSelector(selector);
+          for (const el of traverseAllTrees(root)) {
+            if (el.getAttribute(name) === value) return el;
+          }
+          return null;
+        },
+        queryAll(root: Node, selector: string): Element[] {
+          const { name, value } = parseSelector(selector);
+          const out: Element[] = [];
+          for (const el of traverseAllTrees(root)) {
+            if (el.getAttribute(name) === value) out.push(el);
+          }
+          return out;
+        },
+      };
+    });
   }
 
   /**
@@ -410,6 +527,11 @@ ${scriptContent} \
       this.intContext.registerFrameId(rootId, this);
 
       this.intPage = new Proxy(page, handler) as unknown as Page;
+
+      // Ensure our backdoor and selector engine are ready up front
+      await this.ensureStagehandScript();
+      await this.ensureStagehandSelectorEngine();
+
       this.initialized = true;
       return this;
     } catch (err: unknown) {
@@ -998,5 +1120,24 @@ ${scriptContent} \
     target?: PlaywrightPage | Frame,
   ): Promise<void> {
     await this.sendCDP<void>(`${domain}.disable`, {}, target);
+  }
+
+  async getShadowRootHandle(
+    this: StagehandPage,
+    host: ElementHandle<Element>,
+  ): Promise<ElementHandle<ShadowRoot> | null> {
+    const h = await host.evaluateHandle((el: Element): ShadowRoot | null => {
+      // Open root?
+      if ((el as HTMLElement).shadowRoot)
+        return (el as HTMLElement).shadowRoot!;
+      // Closed root kept in our isolated world
+      return (
+        (
+          window as Window & { __stagehand__?: StagehandBackdoor }
+        ).__stagehand__?.getClosedRoot(el) ?? null
+      );
+    });
+
+    return h.asElement() as ElementHandle<ShadowRoot> | null;
   }
 }

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -1,9 +1,4 @@
-import type {
-  CDPSession,
-  Page as PlaywrightPage,
-  Frame,
-  ElementHandle,
-} from "playwright";
+import type { CDPSession, Page as PlaywrightPage, Frame } from "playwright";
 import { selectors } from "playwright";
 import { z } from "zod/v3";
 import { Page, defaultExtractSchema } from "../types/page";
@@ -35,7 +30,6 @@ import {
 import { StagehandAPIError } from "@/types/stagehandApiErrors";
 import { scriptContent } from "@/lib/dom/build/scriptContent";
 import type { Protocol } from "devtools-protocol";
-import { StagehandBackdoor } from "@/lib/dom/global";
 
 async function getCurrentRootFrameId(session: CDPSession): Promise<string> {
   const { frameTree } = (await session.send(
@@ -1120,24 +1114,5 @@ ${scriptContent} \
     target?: PlaywrightPage | Frame,
   ): Promise<void> {
     await this.sendCDP<void>(`${domain}.disable`, {}, target);
-  }
-
-  async getShadowRootHandle(
-    this: StagehandPage,
-    host: ElementHandle<Element>,
-  ): Promise<ElementHandle<ShadowRoot> | null> {
-    const h = await host.evaluateHandle((el: Element): ShadowRoot | null => {
-      // Open root?
-      if ((el as HTMLElement).shadowRoot)
-        return (el as HTMLElement).shadowRoot!;
-      // Closed root kept in our isolated world
-      return (
-        (
-          window as Window & { __stagehand__?: StagehandBackdoor }
-        ).__stagehand__?.getClosedRoot(el) ?? null
-      );
-    });
-
-    return h.asElement() as ElementHandle<ShadowRoot> | null;
   }
 }

--- a/lib/dom/global.d.ts
+++ b/lib/dom/global.d.ts
@@ -1,4 +1,9 @@
-export {};
+export interface StagehandBackdoor {
+  /** Closed shadow-root accessors */
+  getClosedRoot(host: Element): ShadowRoot | undefined;
+  queryClosed(host: Element, selector: string): Element[];
+  xpathClosed(host: Element, xpath: string): Node[];
+}
 declare global {
   interface Window {
     __stagehandInjected?: boolean;
@@ -8,5 +13,6 @@ declare global {
     getScrollableElementXpaths: (topN?: number) => Promise<string[]>;
     getNodeFromXpath: (xpath: string) => Node | null;
     waitForElementScrollEnd: (element: HTMLElement) => Promise<void>;
+    readonly __stagehand__?: StagehandBackdoor;
   }
 }

--- a/lib/dom/process.ts
+++ b/lib/dom/process.ts
@@ -125,12 +125,14 @@ export async function getScrollableElementXpaths(
     },
   };
 
-  Object.defineProperty(window, "__stagehand__", {
-    value: backdoor,
-    enumerable: false,
-    writable: false,
-    configurable: false,
-  });
+  if (!("__stagehand__" in window)) {
+    Object.defineProperty(window, "__stagehand__", {
+      value: backdoor,
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    });
+  }
 })();
 
 window.getScrollableElementXpaths = getScrollableElementXpaths;

--- a/lib/dom/process.ts
+++ b/lib/dom/process.ts
@@ -73,6 +73,66 @@ export async function getScrollableElementXpaths(
   return xpaths;
 }
 
+(() => {
+  // Map <host ➜ shadowRoot> for every root created in closed mode
+  const closedRoots: WeakMap<Element, ShadowRoot> = new WeakMap();
+
+  // Preserve the original method
+  const nativeAttachShadow = Element.prototype.attachShadow;
+
+  // Intercept *before any page script runs*
+  Element.prototype.attachShadow = function (init: ShadowRootInit): ShadowRoot {
+    const root = nativeAttachShadow.call(this, init);
+    if (init.mode === "closed") closedRoots.set(this, root);
+    return root;
+  };
+
+  interface StagehandBackdoor {
+    /** Get the real ShadowRoot (undefined if host has none / is open) */
+    getClosedRoot(host: Element): ShadowRoot | undefined;
+
+    /** CSS‑selector search inside that root */
+    queryClosed(host: Element, selector: string): Element[];
+
+    /** XPath search inside that root (relative XPath supported) */
+    xpathClosed(host: Element, xpath: string): Node[];
+  }
+
+  const backdoor: StagehandBackdoor = {
+    getClosedRoot: (host) => closedRoots.get(host),
+
+    queryClosed: (host, selector) => {
+      const root = closedRoots.get(host);
+      return root ? Array.from(root.querySelectorAll(selector)) : [];
+    },
+
+    xpathClosed: (host, xp) => {
+      const root = closedRoots.get(host);
+      if (!root) return [];
+      const it = document.evaluate(
+        xp,
+        root,
+        null,
+        XPathResult.ORDERED_NODE_SNAPSHOT_TYPE,
+        null,
+      );
+      const out: Node[] = [];
+      for (let i = 0; i < it.snapshotLength; ++i) {
+        const n = it.snapshotItem(i);
+        if (n) out.push(n);
+      }
+      return out;
+    },
+  };
+
+  Object.defineProperty(window, "__stagehand__", {
+    value: backdoor,
+    enumerable: false,
+    writable: false,
+    configurable: false,
+  });
+})();
+
 window.getScrollableElementXpaths = getScrollableElementXpaths;
 window.getNodeFromXpath = getNodeFromXpath;
 window.waitForElementScrollEnd = waitForElementScrollEnd;

--- a/lib/handlers/actHandler.ts
+++ b/lib/handlers/actHandler.ts
@@ -311,7 +311,7 @@ export class StagehandActHandler {
     domSettleTimeoutMs?: number,
   ) {
     const xpath = rawXPath.replace(/^xpath=/i, "").trim();
-    const locator = deepLocator(this.stagehandPage.page, xpath).first();
+    const locator = await deepLocator(this.stagehandPage.page, xpath);
     const initialUrl = this.stagehandPage.page.url();
 
     this.logger({

--- a/lib/handlers/actHandler.ts
+++ b/lib/handlers/actHandler.ts
@@ -18,6 +18,7 @@ import {
   methodHandlerMap,
   fallbackLocatorMethod,
   deepLocator,
+  deepLocatorWithShadow,
 } from "./handlerUtils/actHandlerUtils";
 import { StagehandObserveHandler } from "@/lib/handlers/observeHandler";
 import { StagehandInvalidArgumentError } from "@/types/stagehandErrors";
@@ -30,19 +31,23 @@ export class StagehandActHandler {
   private readonly stagehandPage: StagehandPage;
   private readonly logger: (logLine: LogLine) => void;
   private readonly selfHeal: boolean;
+  private readonly experimental: boolean;
 
   constructor({
     logger,
     stagehandPage,
     selfHeal,
+    experimental,
   }: {
     logger: (logLine: LogLine) => void;
     stagehandPage: StagehandPage;
     selfHeal: boolean;
+    experimental: boolean;
   }) {
     this.logger = logger;
     this.stagehandPage = stagehandPage;
     this.selfHeal = selfHeal;
+    this.experimental = experimental;
   }
 
   /**
@@ -311,7 +316,13 @@ export class StagehandActHandler {
     domSettleTimeoutMs?: number,
   ) {
     const xpath = rawXPath.replace(/^xpath=/i, "").trim();
-    const locator = await deepLocator(this.stagehandPage.page, xpath);
+    let locator;
+    if (this.experimental) {
+      locator = await deepLocatorWithShadow(this.stagehandPage.page, xpath);
+    } else {
+      locator = deepLocator(this.stagehandPage.page, xpath);
+    }
+
     const initialUrl = this.stagehandPage.page.url();
 
     this.logger({

--- a/lib/handlers/handlerUtils/actHandlerUtils.ts
+++ b/lib/handlers/handlerUtils/actHandlerUtils.ts
@@ -4,37 +4,179 @@ import { StagehandPage } from "../../StagehandPage";
 import { getNodeFromXpath } from "@/lib/dom/utils";
 import { Logger } from "../../../types/log";
 import { MethodHandlerContext } from "@/types/act";
-import { StagehandClickError } from "@/types/stagehandErrors";
+import {
+  StagehandClickError,
+  StagehandShadowRootMissingError,
+  StagehandShadowSegmentEmptyError,
+  StagehandShadowSegmentNotFoundError,
+} from "@/types/stagehandErrors";
 
 const IFRAME_STEP_RE = /^iframe(\[[^\]]+])?$/i;
 
-export function deepLocator(root: Page | FrameLocator, xpath: string): Locator {
-  // 1 ─ prepend with slash if not already included
-  if (!xpath.startsWith("/")) xpath = "/" + xpath;
+function stepToCss(step: string): string {
+  const m = step.match(/^([a-zA-Z*][\w-]*)(?:\[(\d+)])?$/);
+  if (!m) return step;
+  const [, tag, idxRaw] = m;
+  const idx = idxRaw ? Number(idxRaw) : null;
+  if (tag === "*") return idx ? `*:nth-child(${idx})` : `*`;
+  return idx ? `${tag}:nth-of-type(${idx})` : tag;
+}
 
-  // 2 ─ split into steps, accumulate until we hit an iframe step
-  const steps = xpath.split("/").filter(Boolean); // tokens
-  let ctx: Page | FrameLocator = root;
-  let buffer: string[] = [];
+const buildDirect = (steps: string[]) => steps.map(stepToCss).join(" > ");
+const buildDesc = (steps: string[]) => steps.map(stepToCss).join(" ");
 
-  const flushIntoFrame = () => {
-    if (buffer.length === 0) return;
-    const selector = "xpath=/" + buffer.join("/");
-    ctx = (ctx as Page | FrameLocator).frameLocator(selector);
-    buffer = [];
-  };
+/** Resolve one contiguous shadow segment and return a stable Locator. */
+async function resolveShadowSegment(
+  hostLoc: Locator,
+  shadowSteps: string[],
+  attr = "data-__stagehand-id",
+  timeout = 1500,
+): Promise<Locator> {
+  const direct = buildDirect(shadowSteps);
+  const desc = buildDesc(shadowSteps);
 
-  for (const step of steps) {
-    buffer.push(step);
-    if (IFRAME_STEP_RE.test(step)) {
-      // we've included the <iframe> element in buffer ⇒ descend
-      flushIntoFrame();
-    }
+  type Result = { id: string | null; noRoot: boolean };
+
+  const { id, noRoot } = await hostLoc.evaluate<
+    Result,
+    { direct: string; desc: string; attr: string; timeout: number }
+  >(
+    (host, { direct, desc, attr, timeout }) => {
+      interface StagehandClosedAccess {
+        getClosedRoot?: (h: Element) => ShadowRoot | undefined;
+      }
+      const backdoor = (
+        window as Window & {
+          __stagehand__?: StagehandClosedAccess;
+        }
+      ).__stagehand__;
+
+      const root =
+        (host as HTMLElement).shadowRoot ?? backdoor?.getClosedRoot?.(host);
+      if (!root) return { id: null, noRoot: true };
+
+      const tryFind = () =>
+        (root.querySelector(direct) as Element | null) ??
+        (root.querySelector(desc) as Element | null);
+
+      return new Promise<Result>((resolve) => {
+        const mark = (el: Element): Result => {
+          let v = el.getAttribute(attr);
+          if (!v) {
+            v =
+              "sh_" +
+              Math.random().toString(36).slice(2) +
+              Date.now().toString(36);
+            el.setAttribute(attr, v);
+          }
+          return { id: v, noRoot: false };
+        };
+
+        const first = tryFind();
+        if (first) return resolve(mark(first));
+
+        const start = Date.now();
+        const tick = () => {
+          const el = tryFind();
+          if (el) return resolve(mark(el));
+          if (Date.now() - start >= timeout)
+            return resolve({ id: null, noRoot: false });
+          setTimeout(tick, 50);
+        };
+        tick();
+      });
+    },
+    { direct, desc, attr, timeout },
+  );
+
+  if (noRoot) {
+    throw new StagehandShadowRootMissingError(
+      `segment='${shadowSteps.join("/")}'`,
+    );
+  }
+  if (!id) {
+    throw new StagehandShadowSegmentNotFoundError(shadowSteps.join("/"));
   }
 
-  // 3 ─ whatever is left in buffer addresses the target *inside* the last ctx
-  const finalSelector = "xpath=/" + buffer.join("/");
-  return (ctx as Page | FrameLocator).locator(finalSelector);
+  return hostLoc.locator(`stagehand=${id}`);
+}
+
+export async function deepLocator(
+  root: Page | FrameLocator,
+  xpath: string,
+): Promise<Locator> {
+  // 1 ─ prepend with slash if not already included
+  if (!xpath.startsWith("/")) xpath = "/" + xpath;
+  const tokens = xpath.split("/"); // keep "" from "//"
+
+  let ctx: Page | FrameLocator | Locator = root;
+  let buffer: string[] = [];
+  let elementScoped = false;
+
+  const xp = () => (elementScoped ? "xpath=./" : "xpath=/");
+
+  const flushIntoFrame = () => {
+    if (!buffer.length) return;
+    ctx = (ctx as Page | FrameLocator | Locator).frameLocator(
+      xp() + buffer.join("/"),
+    );
+    buffer = [];
+    elementScoped = false;
+  };
+
+  const flushIntoLocator = () => {
+    if (!buffer.length) return;
+    ctx = (ctx as Page | FrameLocator | Locator).locator(
+      xp() + buffer.join("/"),
+    );
+    buffer = [];
+    elementScoped = true;
+  };
+
+  for (let i = 1; i < tokens.length; i++) {
+    const step = tokens[i];
+
+    // Shadow hop: “//”
+    if (step === "") {
+      flushIntoLocator();
+
+      // collect full shadow segment until next hop/iframe/end
+      const seg: string[] = [];
+      let j = i + 1;
+      for (; j < tokens.length; j++) {
+        const t = tokens[j];
+        if (t === "" || IFRAME_STEP_RE.test(t)) break;
+        seg.push(t);
+      }
+      if (!seg.length) throw new StagehandShadowSegmentEmptyError();
+
+      // resolve inside the shadow root
+      ctx = await resolveShadowSegment(ctx as Locator, seg);
+      elementScoped = true;
+
+      i = j - 1;
+      continue;
+    }
+
+    // Normal DOM step
+    buffer.push(step);
+
+    // iframe hop → descend into frame
+    if (IFRAME_STEP_RE.test(step)) flushIntoFrame();
+  }
+
+  if (buffer.length === 0) {
+    // If we’re already element-scoped, we already have the final Locator.
+    if (elementScoped) return ctx as Locator;
+
+    // Otherwise (page/frame scoped), return the root element of the current doc.
+    return (ctx as Page | FrameLocator).locator("xpath=/");
+  }
+
+  // Otherwise, resolve the remaining buffered steps.
+  return (ctx as Page | FrameLocator | Locator).locator(
+    xp() + buffer.join("/"),
+  );
 }
 
 /**

--- a/lib/handlers/observeHandler.ts
+++ b/lib/handlers/observeHandler.ts
@@ -14,6 +14,7 @@ export class StagehandObserveHandler {
   private readonly stagehand: Stagehand;
   private readonly logger: (logLine: LogLine) => void;
   private readonly stagehandPage: StagehandPage;
+  private readonly experimental: boolean;
 
   private readonly userProvidedInstructions?: string;
   constructor({
@@ -21,16 +22,19 @@ export class StagehandObserveHandler {
     logger,
     stagehandPage,
     userProvidedInstructions,
+    experimental,
   }: {
     stagehand: Stagehand;
     logger: (logLine: LogLine) => void;
     stagehandPage: StagehandPage;
     userProvidedInstructions?: string;
+    experimental: boolean;
   }) {
     this.stagehand = stagehand;
     this.logger = logger;
     this.stagehandPage = stagehandPage;
     this.userProvidedInstructions = userProvidedInstructions;
+    this.experimental = experimental;
   }
 
   public async observe({
@@ -88,21 +92,25 @@ export class StagehandObserveHandler {
       level: 1,
     });
     const { combinedTree, combinedXpathMap, discoveredIframes } = await (iframes
-      ? getAccessibilityTreeWithFrames(this.stagehandPage, this.logger).then(
-          ({ combinedTree, combinedXpathMap }) => ({
-            combinedTree,
-            combinedXpathMap,
-            discoveredIframes: [] as AccessibilityNode[],
-          }),
-        )
-      : getAccessibilityTree(this.stagehandPage, this.logger).then(
-          ({ simplified, xpathMap, idToUrl, iframes: frameNodes }) => ({
-            combinedTree: simplified,
-            combinedXpathMap: xpathMap,
-            combinedUrlMap: idToUrl,
-            discoveredIframes: frameNodes,
-          }),
-        ));
+      ? getAccessibilityTreeWithFrames(
+          this.experimental,
+          this.stagehandPage,
+          this.logger,
+        ).then(({ combinedTree, combinedXpathMap }) => ({
+          combinedTree,
+          combinedXpathMap,
+          discoveredIframes: [] as AccessibilityNode[],
+        }))
+      : getAccessibilityTree(
+          this.experimental,
+          this.stagehandPage,
+          this.logger,
+        ).then(({ simplified, xpathMap, idToUrl, iframes: frameNodes }) => ({
+          combinedTree: simplified,
+          combinedXpathMap: xpathMap,
+          combinedUrlMap: idToUrl,
+          discoveredIframes: frameNodes,
+        })));
 
     // No screenshot or vision-based annotation is performed
     const observationResponse = await observe({

--- a/types/stagehandErrors.ts
+++ b/types/stagehandErrors.ts
@@ -229,3 +229,27 @@ export class StagehandInitError extends StagehandError {
     super(message);
   }
 }
+
+export class StagehandShadowRootMissingError extends StagehandError {
+  constructor(detail?: string) {
+    super(
+      `No shadow root present on the resolved host` +
+        (detail ? `: ${detail}` : ""),
+    );
+  }
+}
+
+export class StagehandShadowSegmentEmptyError extends StagehandError {
+  constructor() {
+    super(`Empty selector segment after shadow-DOM hop ("//")`);
+  }
+}
+
+export class StagehandShadowSegmentNotFoundError extends StagehandError {
+  constructor(segment: string, hint?: string) {
+    super(
+      `Shadow segment '${segment}' matched no element inside shadow root` +
+        (hint ? ` ${hint}` : ""),
+    );
+  }
+}


### PR DESCRIPTION
# why
- adds support for taking actions on shadow DOMs (both closed & open mode) 
- addresses the following issues:
   - #380  
   - #870  
   - #908  
   - #943  
# what changed
- This PR adds some injected JS which 
   1. intercepts `Element.prototype.attachShadow` early and stashes closed mode shadow roots in a `WeakMap` 
   2. provides a 'backdoor' for safely accessing these closed roots without mutating anything in the actual DOM
- to access the 'backdoor', this PR adds a custom locator engine `selectors.register('stagehand', …)`
- the engine does a DFS over:
   - regular DOM nodes,
   - open shadow roots via `el.shadowRoot`,
   - closed roots via `window.__stagehand__.getClosedRoot(el)`
   - returns a regular playwright locator
# note
- all the logic here is behind the `experimental` flag in the stagehand constructor, so that we can give people access without breaking existing behaviour
- this means that this feature is not available on the API (yet), and you'll need to set `experimental: true` in order to use it
# test plan
- added 8 different evals. They are primarily aimed at testing shadow dom interactions with the various types of shadow DOMs (open & closed mode) and iframes (OOPIFs & SPIFs)
- will also run:
   - `regression` evals
   - `act` evals
   - `extract` evals
   - `observe` evals