### PR TITLE
add streamText to aisdk llm client

### DIFF
--- a/lib/llm/LLMClient.ts
+++ b/lib/llm/LLMClient.ts
@@ -60,6 +60,8 @@ export interface ChatCompletionOptions {
   tool_choice?: "auto" | "none" | "required";
   maxTokens?: number;
   requestId?: string;
+  maxSteps?: number;
+  stream?: boolean;
 }
 
 export type LLMResponse = {

--- a/lib/llm/LLMClient.ts
+++ b/lib/llm/LLMClient.ts
@@ -12,6 +12,7 @@ import {
   embedMany,
   experimental_transcribe,
   experimental_generateSpeech,
+  ToolSet,
 } from "ai";
 
 export interface ChatMessage {
@@ -57,6 +58,7 @@ export interface ChatCompletionOptions {
     schema: ZodType;
   };
   tools?: LLMTool[];
+  aiSDKTools?: ToolSet;
   tool_choice?: "auto" | "none" | "required";
   maxTokens?: number;
   requestId?: string;

--- a/lib/llm/aisdk.ts
+++ b/lib/llm/aisdk.ts
@@ -10,7 +10,6 @@ import {
   LanguageModel,
   NoObjectGeneratedError,
   TextPart,
-  ToolSet,
 } from "ai";
 import { CreateChatCompletionOptions, LLMClient } from "./LLMClient";
 import { LogLine } from "../../types/log";
@@ -165,7 +164,7 @@ export class AISdkClient extends LLMClient {
         model: this.model,
         messages: formattedMessages,
         temperature: options.temperature,
-        tools: options.tools as unknown as ToolSet,
+        tools: options.aiSDKTools,
         maxSteps: options.maxSteps,
         providerOptions: isGPT5
           ? {
@@ -291,7 +290,7 @@ export class AISdkClient extends LLMClient {
       model: this.model,
       messages: formattedMessages,
       temperature: options.temperature,
-      tools: options.tools as unknown as ToolSet,
+      tools: options.aiSDKTools,
     });
 
     const result = {


### PR DESCRIPTION
# why

- Currently we have no way to utilize streamtext, only generateObject, and generateText

# what changed

- Streamtext can now be utilized through createChatCompletion by passing stream:true 

# test plan

- tested locally 