### PR TITLE
Patch disabling api whenever custom LLM clients are provided

### DIFF
--- a/.changeset/cruel-onions-live.md
+++ b/.changeset/cruel-onions-live.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Fix disabling api validation whenever a customLLM client is provided

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -580,6 +580,7 @@ export class Stagehand {
     // Update logger verbosity level
     this.stagehandLogger.setVerbosity(this.verbose);
     this.modelName = modelName ?? DEFAULT_MODEL_NAME;
+    this.usingAPI = useAPI;
 
     let modelApiKey: string | undefined;
 
@@ -643,7 +644,7 @@ export class Stagehand {
     this.browserbaseSessionCreateParams = browserbaseSessionCreateParams;
     this.browserbaseSessionID = browserbaseSessionID;
     this.userProvidedInstructions = systemPrompt;
-    this.usingAPI = useAPI;
+
     if (this.usingAPI && env === "LOCAL") {
       // Make env supersede useAPI
       this.usingAPI = false;


### PR DESCRIPTION
# why
Custom LLM clients are throwing an error on api mode

# what changed
We added logic for disabling api whenever custom LLM clients are provided, but there was a reassignment (re-enabling api mode) downstream

# test plan
