### PR TITLE
add evaluate text to evaluator

### DIFF
--- a/evals/evals.config.json
+++ b/evals/evals.config.json
@@ -515,10 +515,6 @@
     {
       "name": "agent/all_recipes",
       "categories": ["agent"]
-    },
-    {
-      "name": "agent/google_shopping",
-      "categories": ["agent"]
     }
   ]
 }

--- a/evals/evaluator.ts
+++ b/evals/evaluator.ts
@@ -13,7 +13,7 @@ import {
 import dotenv from "dotenv";
 import {
   EvaluateOptions,
-  BatchEvaluateOptions,
+  BatchAskOptions,
   EvaluationResult,
 } from "@/types/evaluator";
 import { LLMParsedResponse } from "@/lib/inference";
@@ -54,7 +54,7 @@ export class Evaluator {
       answer,
       screenshot = true,
       systemPrompt = `You are an expert evaluator that confidently returns YES or NO given a question and the state of a task (in the form of a screenshot, or an answer). Provide a detailed reasoning for your answer.
-          Be critical about the question and the answer, the slightest detail might be the difference between yes and no.
+          Be critical about the question and the answer, the slightest detail might be the difference between yes and no. for text, be lenient and allow for slight variations in wording. we will be comparing the agents trajectory to see if it contains the information we were looking for in the answer.
           Today's date is ${new Date().toLocaleDateString()}`,
       screenshotDelayMs = 250,
     } = options;
@@ -130,115 +130,65 @@ export class Evaluator {
   }
 
   /**
-   * Evaluates the current state of the page against multiple questions in a single screenshot.
-   * Uses structured response generation to ensure proper format.
+   * Evaluates multiple questions with optional answers and/or screenshot.
+   * Similar to ask() but processes multiple questions in a single call.
    * Returns an array of evaluation results.
    *
-   * @param options - The options for batch screenshot evaluation
+   * @param options - The options for batch evaluation
    * @returns A promise that resolves to an array of EvaluationResults
    */
-  async batchEvaluate(
-    options: BatchEvaluateOptions,
-  ): Promise<EvaluationResult[]> {
-    if (options.type === "screenshot") {
-      const {
-        questions,
-        systemPrompt = `You are an expert evaluator that confidently returns YES or NO for each question given the state of a task in the screenshot. Provide a detailed reasoning for your answer.
-          Return your response as a JSON array, where each object corresponds to a question and has the following format:
-          { "evaluation": "YES" | "NO", "reasoning": "detailed reasoning for your answer" }
-          Be critical about the question and the answer, the slightest detail might be the difference between yes and no.
-          todays date is ${new Date().toLocaleDateString()}`,
-        screenshotDelayMs = 1000,
-      } = options;
+  async batchAsk(options: BatchAskOptions): Promise<EvaluationResult[]> {
+    const {
+      questions,
+      screenshot = true,
+      systemPrompt = `You are an expert evaluator that confidently returns YES or NO for each question given the state of a task (in the form of a screenshot, or an answer). Provide a detailed reasoning for your answer.
+           Be critical about the question and the answer, the slightest detail might be the difference between yes and no. for text, be lenient and allow for slight variations in wording. we will be comparing the agents trajectory to see if it contains the information we were looking for in the answer.
+          Today's date is ${new Date().toLocaleDateString()}`,
+      screenshotDelayMs = 1000,
+    } = options;
 
-      // Wait for the specified delay before taking screenshot
-      await new Promise((resolve) => setTimeout(resolve, screenshotDelayMs));
+    // Validate inputs
+    if (!questions || questions.length === 0) {
+      throw new Error("Questions array cannot be empty");
+    }
 
-      // Take a screenshot of the current page state
-      const imageBuffer = await this.stagehand.page.screenshot();
-
-      // Create a numbered list of questions for the VLM
-      const formattedQuestions = questions
-        .map((q, i) => `${i + 1}. ${q}`)
-        .join("\n");
-
-      // Get the LLM client with our preferred model
-      const llmClient = this.stagehand.llmProvider.getClient(
-        this.modelName,
-        this.modelClientOptions,
-      );
-
-      // Use the model-specific LLM client to evaluate the screenshot with all questions
-      const response = await llmClient.createChatCompletion<
-        LLMParsedResponse<LLMResponse>
-      >({
-        logger: this.silentLogger,
-        options: {
-          messages: [
-            {
-              role: "system",
-              content: `${systemPrompt}\n\nYou will be given multiple questions. Answer each question by returning an object in the specified JSON format. Return a single JSON array containing one object for each question in the order they were asked.`,
-            },
-            {
-              role: "user",
-              content: [
-                { type: "text", text: formattedQuestions },
-                {
-                  type: "image_url",
-                  image_url: {
-                    url: `data:image/jpeg;base64,${imageBuffer.toString("base64")}`,
-                  },
-                },
-              ],
-            },
-          ],
-          response_model: {
-            name: "BatchEvaluationResult",
-            schema: BatchEvaluationSchema,
-          },
-        },
-      });
-
-      try {
-        const results = response.data as unknown as z.infer<
-          typeof BatchEvaluationSchema
-        >;
-        return results.map((r) => ({
-          evaluation: r.evaluation,
-          reasoning: r.reasoning,
-        }));
-      } catch (error) {
-        const errorMessage =
-          error instanceof Error ? error.message : String(error);
-        return questions.map(() => ({
-          evaluation: "INVALID" as const,
-          reasoning: `Failed to get structured response: ${errorMessage}`,
-        }));
+    for (const item of questions) {
+      if (!item.question) {
+        throw new Error("Question cannot be an empty string");
+      }
+      if (!item.answer && !screenshot) {
+        throw new Error(
+          "Either answer (text) or screenshot must be provided for each question",
+        );
       }
     }
 
-    // Text batch branch
-    const {
-      actualText,
-      expectedTexts,
-      systemPrompt = `You are an expert evaluator that confidently returns YES or NO for each expected text based on whether the actual text contains or matches it.
-          Return your response as a JSON array, where each object corresponds to an expected text and has the following format:
-          { "evaluation": "YES" | "NO", "reasoning": "detailed reasoning for your answer" }
-          Be critical about matching - look for the key information, concepts, and meaning rather than exact wording.
-          todays date is ${new Date().toLocaleDateString()}`,
-    } = options;
+    // Wait for the specified delay before taking screenshot
+    await new Promise((resolve) => setTimeout(resolve, screenshotDelayMs));
 
-    const formattedExpectations = expectedTexts
-      .map((text, i) => `${i + 1}. ${text}`)
-      .join("\n");
+    let imageBuffer: Buffer;
+    if (screenshot) {
+      imageBuffer = await this.stagehand.page.screenshot();
+    }
 
+    // Get the LLM client with our preferred model
     const llmClient = this.stagehand.llmProvider.getClient(
       this.modelName,
       this.modelClientOptions,
     );
 
-    const userPrompt = `For each expected text below, determine if the actual text contains roughly the same information or meaning.\n\nExpected texts:\n${formattedExpectations}\n\nActual text:\n${actualText}`;
+    // Format all questions with their optional answers
+    const formattedQuestions = questions
+      .map((item, i) => {
+        let text = `${i + 1}. ${item.question}`;
+        if (item.answer) {
+          text += `\n   Answer: ${item.answer}`;
+        }
+        return text;
+      })
+      .join("\n\n");
 
+    // Use the model-specific LLM client to evaluate
     const response = await llmClient.createChatCompletion<
       LLMParsedResponse<LLMResponse>
     >({
@@ -247,12 +197,27 @@ export class Evaluator {
         messages: [
           {
             role: "system",
-            content: `${systemPrompt}\n\nYou will be given multiple expected texts. For each one, determine if the actual text contains or matches it. Return a single JSON array containing one object for each expected text in the order they were given.`,
+            content: `${systemPrompt}\n\nYou will be given multiple questions${screenshot ? " with a screenshot" : ""}. ${questions.some((q) => q.answer) ? "Some questions include answers to evaluate." : ""} Answer each question by returning an object in the specified JSON format. Return a single JSON array containing one object for each question in the order they were asked.`,
           },
-          { role: "user", content: userPrompt },
+          {
+            role: "user",
+            content: [
+              { type: "text", text: formattedQuestions },
+              ...(screenshot
+                ? [
+                    {
+                      type: "image_url",
+                      image_url: {
+                        url: `data:image/jpeg;base64,${imageBuffer.toString("base64")}`,
+                      },
+                    },
+                  ]
+                : []),
+            ],
+          },
         ],
         response_model: {
-          name: "BatchTextEvaluationResult",
+          name: "BatchEvaluationResult",
           schema: BatchEvaluationSchema,
         },
       },
@@ -269,7 +234,7 @@ export class Evaluator {
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
-      return expectedTexts.map(() => ({
+      return questions.map(() => ({
         evaluation: "INVALID" as const,
         reasoning: `Failed to get structured response: ${errorMessage}`,
       }));

--- a/evals/evaluator.ts
+++ b/evals/evaluator.ts
@@ -36,180 +36,6 @@ export class Evaluator {
   private modelClientOptions: ClientOptions | { apiKey: string };
   private silentLogger: (message: LogLine) => void;
 
-  private getTodayDateString(): string {
-    return new Date().toLocaleDateString();
-  }
-
-  private getLLMClient() {
-    return this.stagehand.llmProvider.getClient(
-      this.modelName,
-      this.modelClientOptions,
-    );
-  }
-
-  private async buildSingleMessages(options: EvaluateOptions): Promise<{
-    messages:
-      | { role: "system"; content: string }[]
-      | (
-          | { role: "system"; content: string }
-          | {
-              role: "user";
-              content:
-                | string
-                | (
-                    | { type: "text"; text: string }
-                    | {
-                        type: "image_url";
-                        image_url: { url: string };
-                      }
-                  )[];
-            }
-        )[];
-    responseModelName: string;
-  }> {
-    const today = this.getTodayDateString();
-    if (options.type === "screenshot") {
-      const {
-        question,
-        systemPrompt = `You are an expert evaluator that confidently returns YES or NO given the state of a task (most times in the form of a screenshot) and a question. Provide a detailed reasoning for your answer.
-          Return your response as a JSON object with the following format:
-          { "evaluation": "YES" | "NO", "reasoning": "detailed reasoning for your answer" }
-          Be critical about the question and the answer, the slightest detail might be the difference between yes and no.
-          todays date is ${today}`,
-        screenshotDelayMs = 1000,
-      } = options;
-
-      await new Promise((resolve) => setTimeout(resolve, screenshotDelayMs));
-      const imageBuffer = await this.stagehand.page.screenshot();
-      return {
-        messages: [
-          { role: "system", content: systemPrompt },
-          {
-            role: "user",
-            content: [
-              { type: "text", text: question },
-              {
-                type: "image_url",
-                image_url: {
-                  url: `data:image/jpeg;base64,${imageBuffer.toString("base64")}`,
-                },
-              },
-            ],
-          },
-        ],
-        responseModelName: "EvaluationResult",
-      };
-    }
-
-    const {
-      actualText,
-      expectedText,
-      systemPrompt = `You are an expert evaluator that confidently returns YES or NO based on whether the actual text contains or matches the expected text.
-          Return your response as a JSON object with the following format:
-          { "evaluation": "YES" | "NO", "reasoning": "detailed reasoning for your answer" }
-          look for the key information, concepts, and meaning rather than exact wording.
-          todays date is ${today}
-          `,
-    } = options;
-
-    const userPrompt = `Does the actual text contain roughly the same information or meaning as the expected text?\n\nExpected: ${expectedText}\n\nActual: ${actualText}`;
-    return {
-      messages: [
-        { role: "system", content: systemPrompt },
-        { role: "user", content: userPrompt },
-      ],
-      responseModelName: "TextEvaluationResult",
-    };
-  }
-
-  private async buildBatchMessages(options: BatchEvaluateOptions): Promise<{
-    messages:
-      | { role: "system"; content: string }[]
-      | (
-          | { role: "system"; content: string }
-          | {
-              role: "user";
-              content:
-                | string
-                | (
-                    | { type: "text"; text: string }
-                    | {
-                        type: "image_url";
-                        image_url: { url: string };
-                      }
-                  )[];
-            }
-        )[];
-    responseModelName: string;
-  }> {
-    const today = this.getTodayDateString();
-    if (options.type === "screenshot") {
-      const {
-        questions,
-        systemPrompt = `You are an expert evaluator that confidently returns YES or NO for each question given the state of a task in the screenshot. Provide a detailed reasoning for your answer.
-          Return your response as a JSON array, where each object corresponds to a question and has the following format:
-          { "evaluation": "YES" | "NO", "reasoning": "detailed reasoning for your answer" }
-          Be critical about the question and the answer, the slightest detail might be the difference between yes and no.
-          todays date is ${today}`,
-        screenshotDelayMs = 1000,
-      } = options;
-
-      await new Promise((resolve) => setTimeout(resolve, screenshotDelayMs));
-      const imageBuffer = await this.stagehand.page.screenshot();
-      const formattedQuestions = questions
-        .map((q, i) => `${i + 1}. ${q}`)
-        .join("\n");
-
-      return {
-        messages: [
-          {
-            role: "system",
-            content: `${systemPrompt}\n\nYou will be given multiple questions. Answer each question by returning an object in the specified JSON format. Return a single JSON array containing one object for each question in the order they were asked.`,
-          },
-          {
-            role: "user",
-            content: [
-              { type: "text", text: formattedQuestions },
-              {
-                type: "image_url",
-                image_url: {
-                  url: `data:image/jpeg;base64,${imageBuffer.toString("base64")}`,
-                },
-              },
-            ],
-          },
-        ],
-        responseModelName: "BatchEvaluationResult",
-      };
-    }
-
-    const {
-      actualText,
-      expectedTexts,
-      systemPrompt = `You are an expert evaluator that confidently returns YES or NO for each expected text based on whether the actual text contains or matches it.
-          Return your response as a JSON array, where each object corresponds to an expected text and has the following format:
-          { "evaluation": "YES" | "NO", "reasoning": "detailed reasoning for your answer" }
-          Be critical about matching - look for the key information, concepts, and meaning rather than exact wording.
-          todays date is ${today}`,
-    } = options;
-
-    const formattedExpectations = expectedTexts
-      .map((text, i) => `${i + 1}. ${text}`)
-      .join("\n");
-    const userPrompt = `For each expected text below, determine if the actual text contains roughly the same information or meaning.\n\nExpected texts:\n${formattedExpectations}\n\nActual text:\n${actualText}`;
-
-    return {
-      messages: [
-        {
-          role: "system",
-          content: `${systemPrompt}\n\nYou will be given multiple expected texts. For each one, determine if the actual text contains or matches it. Return a single JSON array containing one object for each expected text in the order they were given.`,
-        },
-        { role: "user", content: userPrompt },
-      ],
-      responseModelName: "BatchTextEvaluationResult",
-    };
-  }
-
   constructor(
     stagehand: Stagehand,
     modelName?: AvailableModel,
@@ -225,16 +51,96 @@ export class Evaluator {
   }
 
   async evaluate(options: EvaluateOptions): Promise<EvaluationResult> {
-    const llmClient = this.getLLMClient();
-    const { messages, responseModelName } =
-      await this.buildSingleMessages(options);
+    if (options.type === "screenshot") {
+      const {
+        question,
+        systemPrompt = `You are an expert evaluator that confidently returns YES or NO given the state of a task (most times in the form of a screenshot) and a question. Provide a detailed reasoning for your answer.
+          Return your response as a JSON object with the following format:
+          { "evaluation": "YES" | "NO", "reasoning": "detailed reasoning for your answer" }
+          Be critical about the question and the answer, the slightest detail might be the difference between yes and no.
+          todays date is ${new Date().toLocaleDateString()}`,
+        screenshotDelayMs = 1000,
+      } = options;
+
+      await new Promise((resolve) => setTimeout(resolve, screenshotDelayMs));
+      const imageBuffer = await this.stagehand.page.screenshot();
+      const llmClient = this.stagehand.llmProvider.getClient(
+        this.modelName,
+        this.modelClientOptions,
+      );
+
+      const response = await llmClient.createChatCompletion<
+        LLMParsedResponse<LLMResponse>
+      >({
+        logger: this.silentLogger,
+        options: {
+          messages: [
+            { role: "system", content: systemPrompt },
+            {
+              role: "user",
+              content: [
+                { type: "text", text: question },
+                {
+                  type: "image_url",
+                  image_url: {
+                    url: `data:image/jpeg;base64,${imageBuffer.toString("base64")}`,
+                  },
+                },
+              ],
+            },
+          ],
+          response_model: {
+            name: "EvaluationResult",
+            schema: EvaluationSchema,
+          },
+        },
+      });
+
+      try {
+        const result = response.data as unknown as z.infer<
+          typeof EvaluationSchema
+        >;
+        return { evaluation: result.evaluation, reasoning: result.reasoning };
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+        return {
+          evaluation: "INVALID" as const,
+          reasoning: `Failed to get structured response: ${errorMessage}`,
+        };
+      }
+    }
+    const {
+      actualText,
+      expectedText,
+      systemPrompt = `You are an expert evaluator that confidently returns YES or NO based on whether the actual text contains or matches the expected text.
+          Return your response as a JSON object with the following format:
+          { "evaluation": "YES" | "NO", "reasoning": "detailed reasoning for your answer" }
+          look for the key information, concepts, and meaning rather than exact wording.
+          todays date is ${new Date().toLocaleDateString()}
+          `,
+    } = options;
+
+    const llmClient = this.stagehand.llmProvider.getClient(
+      this.modelName,
+      this.modelClientOptions,
+    );
+
+    const userPrompt = `Does the actual text contain roughly the same information or meaning as the expected text?\n\nExpected: ${expectedText}\n\nActual: ${actualText}`;
+
     const response = await llmClient.createChatCompletion<
       LLMParsedResponse<LLMResponse>
     >({
       logger: this.silentLogger,
       options: {
-        messages,
-        response_model: { name: responseModelName, schema: EvaluationSchema },
+        messages: [
+          { role: "system", content: systemPrompt },
+          { role: "user", content: userPrompt },
+        ],
+        response_model: {
+          name: "TextEvaluationResult",
+          schema: EvaluationSchema,
+        },
       },
     });
 
@@ -264,17 +170,119 @@ export class Evaluator {
   async batchEvaluate(
     options: BatchEvaluateOptions,
   ): Promise<EvaluationResult[]> {
-    const llmClient = this.getLLMClient();
-    const { messages, responseModelName } =
-      await this.buildBatchMessages(options);
+    if (options.type === "screenshot") {
+      const {
+        questions,
+        systemPrompt = `You are an expert evaluator that confidently returns YES or NO for each question given the state of a task in the screenshot. Provide a detailed reasoning for your answer.
+          Return your response as a JSON array, where each object corresponds to a question and has the following format:
+          { "evaluation": "YES" | "NO", "reasoning": "detailed reasoning for your answer" }
+          Be critical about the question and the answer, the slightest detail might be the difference between yes and no.
+          todays date is ${new Date().toLocaleDateString()}`,
+        screenshotDelayMs = 1000,
+      } = options;
+
+      // Wait for the specified delay before taking screenshot
+      await new Promise((resolve) => setTimeout(resolve, screenshotDelayMs));
+
+      // Take a screenshot of the current page state
+      const imageBuffer = await this.stagehand.page.screenshot();
+
+      // Create a numbered list of questions for the VLM
+      const formattedQuestions = questions
+        .map((q, i) => `${i + 1}. ${q}`)
+        .join("\n");
+
+      // Get the LLM client with our preferred model
+      const llmClient = this.stagehand.llmProvider.getClient(
+        this.modelName,
+        this.modelClientOptions,
+      );
+
+      // Use the model-specific LLM client to evaluate the screenshot with all questions
+      const response = await llmClient.createChatCompletion<
+        LLMParsedResponse<LLMResponse>
+      >({
+        logger: this.silentLogger,
+        options: {
+          messages: [
+            {
+              role: "system",
+              content: `${systemPrompt}\n\nYou will be given multiple questions. Answer each question by returning an object in the specified JSON format. Return a single JSON array containing one object for each question in the order they were asked.`,
+            },
+            {
+              role: "user",
+              content: [
+                { type: "text", text: formattedQuestions },
+                {
+                  type: "image_url",
+                  image_url: {
+                    url: `data:image/jpeg;base64,${imageBuffer.toString("base64")}`,
+                  },
+                },
+              ],
+            },
+          ],
+          response_model: {
+            name: "BatchEvaluationResult",
+            schema: BatchEvaluationSchema,
+          },
+        },
+      });
+
+      try {
+        const results = response.data as unknown as z.infer<
+          typeof BatchEvaluationSchema
+        >;
+        return results.map((r) => ({
+          evaluation: r.evaluation,
+          reasoning: r.reasoning,
+        }));
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+        return questions.map(() => ({
+          evaluation: "INVALID" as const,
+          reasoning: `Failed to get structured response: ${errorMessage}`,
+        }));
+      }
+    }
+
+    // Text batch branch
+    const {
+      actualText,
+      expectedTexts,
+      systemPrompt = `You are an expert evaluator that confidently returns YES or NO for each expected text based on whether the actual text contains or matches it.
+          Return your response as a JSON array, where each object corresponds to an expected text and has the following format:
+          { "evaluation": "YES" | "NO", "reasoning": "detailed reasoning for your answer" }
+          Be critical about matching - look for the key information, concepts, and meaning rather than exact wording.
+          todays date is ${new Date().toLocaleDateString()}`,
+    } = options;
+
+    const formattedExpectations = expectedTexts
+      .map((text, i) => `${i + 1}. ${text}`)
+      .join("\n");
+
+    const llmClient = this.stagehand.llmProvider.getClient(
+      this.modelName,
+      this.modelClientOptions,
+    );
+
+    const userPrompt = `For each expected text below, determine if the actual text contains roughly the same information or meaning.\n\nExpected texts:\n${formattedExpectations}\n\nActual text:\n${actualText}`;
+
     const response = await llmClient.createChatCompletion<
       LLMParsedResponse<LLMResponse>
     >({
       logger: this.silentLogger,
       options: {
-        messages,
+        messages: [
+          {
+            role: "system",
+            content: `${systemPrompt}\n\nYou will be given multiple expected texts. For each one, determine if the actual text contains or matches it. Return a single JSON array containing one object for each expected text in the order they were given.`,
+          },
+          { role: "user", content: userPrompt },
+        ],
         response_model: {
-          name: responseModelName,
+          name: "BatchTextEvaluationResult",
           schema: BatchEvaluationSchema,
         },
       },
@@ -291,17 +299,10 @@ export class Evaluator {
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
-      if (options.type === "screenshot") {
-        return options.questions.map(() => ({
-          evaluation: "INVALID" as const,
-          reasoning: `Failed to get structured response: ${errorMessage}`,
-        }));
-      } else {
-        return options.expectedTexts.map(() => ({
-          evaluation: "INVALID" as const,
-          reasoning: `Failed to get structured response: ${errorMessage}`,
-        }));
-      }
+      return expectedTexts.map(() => ({
+        evaluation: "INVALID" as const,
+        reasoning: `Failed to get structured response: ${errorMessage}`,
+      }));
     }
   }
 }

--- a/evals/tasks/agent/all_recipes.ts
+++ b/evals/tasks/agent/all_recipes.ts
@@ -17,7 +17,8 @@ export const all_recipes: EvalFunction = async ({
       maxSteps: 30,
     });
 
-    const { evaluation, reasoning } = await evaluator.evaluateScreenshot({
+    const { evaluation, reasoning } = await evaluator.evaluate({
+      type: "screenshot",
       question: "Did the agent find a recipe for Beef Wellington",
     });
 

--- a/evals/tasks/agent/all_recipes.ts
+++ b/evals/tasks/agent/all_recipes.ts
@@ -17,7 +17,7 @@ export const all_recipes: EvalFunction = async ({
       maxSteps: 30,
     });
 
-    const { evaluation, reasoning } = await evaluator.evaluate({
+    const { evaluation, reasoning } = await evaluator.evaluateScreenshot({
       question: "Did the agent find a recipe for Beef Wellington",
     });
 

--- a/evals/tasks/agent/all_recipes.ts
+++ b/evals/tasks/agent/all_recipes.ts
@@ -17,8 +17,7 @@ export const all_recipes: EvalFunction = async ({
       maxSteps: 30,
     });
 
-    const { evaluation, reasoning } = await evaluator.evaluate({
-      type: "screenshot",
+    const { evaluation, reasoning } = await evaluator.ask({
       question: "Did the agent find a recipe for Beef Wellington",
     });
 

--- a/evals/tasks/agent/github.ts
+++ b/evals/tasks/agent/github.ts
@@ -17,7 +17,7 @@ export const github: EvalFunction = async ({
     });
     logger.log(agentResult);
 
-    const { evaluation, reasoning } = await evaluator.evaluate({
+    const { evaluation, reasoning } = await evaluator.evaluateScreenshot({
       question:
         "Ruby repository on GitHub that has been updated in the past 3 days and has at least 1000 stars.",
     });

--- a/evals/tasks/agent/github.ts
+++ b/evals/tasks/agent/github.ts
@@ -17,8 +17,7 @@ export const github: EvalFunction = async ({
     });
     logger.log(agentResult);
 
-    const { evaluation, reasoning } = await evaluator.evaluate({
-      type: "screenshot",
+    const { evaluation, reasoning } = await evaluator.ask({
       question:
         "Ruby repository on GitHub that has been updated in the past 3 days and has at least 1000 stars.",
     });

--- a/evals/tasks/agent/github.ts
+++ b/evals/tasks/agent/github.ts
@@ -17,7 +17,8 @@ export const github: EvalFunction = async ({
     });
     logger.log(agentResult);
 
-    const { evaluation, reasoning } = await evaluator.evaluateScreenshot({
+    const { evaluation, reasoning } = await evaluator.evaluate({
+      type: "screenshot",
       question:
         "Ruby repository on GitHub that has been updated in the past 3 days and has at least 1000 stars.",
     });

--- a/evals/tasks/agent/github_react_version.ts
+++ b/evals/tasks/agent/github_react_version.ts
@@ -15,7 +15,8 @@ export const github_react_version: EvalFunction = async ({
         "Check the latest release version of React and the date it was published. ",
       maxSteps: 20,
     });
-    const { evaluation, reasoning } = await evaluator.evaluateScreenshot({
+    const { evaluation, reasoning } = await evaluator.evaluate({
+      type: "screenshot",
       question:
         "Does the page show the latest version of react and the date it was published",
     });

--- a/evals/tasks/agent/github_react_version.ts
+++ b/evals/tasks/agent/github_react_version.ts
@@ -15,8 +15,7 @@ export const github_react_version: EvalFunction = async ({
         "Check the latest release version of React and the date it was published. ",
       maxSteps: 20,
     });
-    const { evaluation, reasoning } = await evaluator.evaluate({
-      type: "screenshot",
+    const { evaluation, reasoning } = await evaluator.ask({
       question:
         "Does the page show the latest version of react and the date it was published",
     });

--- a/evals/tasks/agent/github_react_version.ts
+++ b/evals/tasks/agent/github_react_version.ts
@@ -15,7 +15,7 @@ export const github_react_version: EvalFunction = async ({
         "Check the latest release version of React and the date it was published. ",
       maxSteps: 20,
     });
-    const { evaluation, reasoning } = await evaluator.evaluate({
+    const { evaluation, reasoning } = await evaluator.evaluateScreenshot({
       question:
         "Does the page show the latest version of react and the date it was published",
     });

--- a/evals/tasks/agent/google_flights.ts
+++ b/evals/tasks/agent/google_flights.ts
@@ -19,7 +19,8 @@ export const google_flights: EvalFunction = async ({
     logger.log(agentResult);
 
     const evaluator = new Evaluator(stagehand);
-    const result = await evaluator.evaluateScreenshot({
+    const result = await evaluator.evaluate({
+      type: "screenshot",
       question:
         "Does the page show flights (options, available flights, not a search form) from San Francisco to New York?",
     });

--- a/evals/tasks/agent/google_flights.ts
+++ b/evals/tasks/agent/google_flights.ts
@@ -19,8 +19,7 @@ export const google_flights: EvalFunction = async ({
     logger.log(agentResult);
 
     const evaluator = new Evaluator(stagehand);
-    const result = await evaluator.evaluate({
-      type: "screenshot",
+    const result = await evaluator.ask({
       question:
         "Does the page show flights (options, available flights, not a search form) from San Francisco to New York?",
     });

--- a/evals/tasks/agent/google_flights.ts
+++ b/evals/tasks/agent/google_flights.ts
@@ -19,7 +19,7 @@ export const google_flights: EvalFunction = async ({
     logger.log(agentResult);
 
     const evaluator = new Evaluator(stagehand);
-    const result = await evaluator.evaluate({
+    const result = await evaluator.evaluateScreenshot({
       question:
         "Does the page show flights (options, available flights, not a search form) from San Francisco to New York?",
     });

--- a/evals/tasks/agent/google_maps.ts
+++ b/evals/tasks/agent/google_maps.ts
@@ -19,7 +19,8 @@ export const google_maps: EvalFunction = async ({
     logger.log(agentResult);
 
     const evaluator = new Evaluator(stagehand);
-    const result = await evaluator.evaluateScreenshot({
+    const result = await evaluator.evaluate({
+      type: "screenshot",
       question:
         "Does the page show the time it takes to drive from San Francisco to New York at all?",
     });

--- a/evals/tasks/agent/google_maps.ts
+++ b/evals/tasks/agent/google_maps.ts
@@ -19,8 +19,7 @@ export const google_maps: EvalFunction = async ({
     logger.log(agentResult);
 
     const evaluator = new Evaluator(stagehand);
-    const result = await evaluator.evaluate({
-      type: "screenshot",
+    const result = await evaluator.ask({
       question:
         "Does the page show the time it takes to drive from San Francisco to New York at all?",
     });

--- a/evals/tasks/agent/google_maps.ts
+++ b/evals/tasks/agent/google_maps.ts
@@ -19,7 +19,7 @@ export const google_maps: EvalFunction = async ({
     logger.log(agentResult);
 
     const evaluator = new Evaluator(stagehand);
-    const result = await evaluator.evaluate({
+    const result = await evaluator.evaluateScreenshot({
       question:
         "Does the page show the time it takes to drive from San Francisco to New York at all?",
     });

--- a/evals/tasks/agent/google_maps_2.ts
+++ b/evals/tasks/agent/google_maps_2.ts
@@ -20,7 +20,8 @@ export const google_maps_2: EvalFunction = async ({
     logger.log(agentResult);
 
     const evaluator = new Evaluator(stagehand);
-    const result = await evaluator.evaluateScreenshot({
+    const result = await evaluator.evaluate({
+      type: "screenshot",
       question:
         "Does the page show the fastest walking route from La Puerta de Alcalá to La Puerta del Sol? Does the distance between the two points show as 1.5 km?",
     });

--- a/evals/tasks/agent/google_maps_2.ts
+++ b/evals/tasks/agent/google_maps_2.ts
@@ -20,7 +20,7 @@ export const google_maps_2: EvalFunction = async ({
     logger.log(agentResult);
 
     const evaluator = new Evaluator(stagehand);
-    const result = await evaluator.evaluate({
+    const result = await evaluator.evaluateScreenshot({
       question:
         "Does the page show the fastest walking route from La Puerta de Alcalá to La Puerta del Sol? Does the distance between the two points show as 1.5 km?",
     });

--- a/evals/tasks/agent/google_maps_2.ts
+++ b/evals/tasks/agent/google_maps_2.ts
@@ -20,8 +20,7 @@ export const google_maps_2: EvalFunction = async ({
     logger.log(agentResult);
 
     const evaluator = new Evaluator(stagehand);
-    const result = await evaluator.evaluate({
-      type: "screenshot",
+    const result = await evaluator.ask({
       question:
         "Does the page show the fastest walking route from La Puerta de Alcalá to La Puerta del Sol? Does the distance between the two points show as 1.5 km?",
     });

--- a/evals/tasks/agent/google_maps_3.ts
+++ b/evals/tasks/agent/google_maps_3.ts
@@ -16,7 +16,7 @@ export const google_maps_3: EvalFunction = async ({
       maxSteps: 35,
     });
 
-    const { evaluation, reasoning } = await evaluator.evaluate({
+    const { evaluation, reasoning } = await evaluator.evaluateScreenshot({
       question:
         "Does the page show a locksmiths open now but not open 24 hours in Texas City?",
     });

--- a/evals/tasks/agent/google_maps_3.ts
+++ b/evals/tasks/agent/google_maps_3.ts
@@ -16,7 +16,8 @@ export const google_maps_3: EvalFunction = async ({
       maxSteps: 35,
     });
 
-    const { evaluation, reasoning } = await evaluator.evaluateScreenshot({
+    const { evaluation, reasoning } = await evaluator.evaluate({
+      type: "screenshot",
       question:
         "Does the page show a locksmiths open now but not open 24 hours in Texas City?",
     });

--- a/evals/tasks/agent/google_maps_3.ts
+++ b/evals/tasks/agent/google_maps_3.ts
@@ -16,8 +16,7 @@ export const google_maps_3: EvalFunction = async ({
       maxSteps: 35,
     });
 
-    const { evaluation, reasoning } = await evaluator.evaluate({
-      type: "screenshot",
+    const { evaluation, reasoning } = await evaluator.ask({
       question:
         "Does the page show a locksmiths open now but not open 24 hours in Texas City?",
     });

--- a/evals/tasks/agent/google_shopping.ts
+++ b/evals/tasks/agent/google_shopping.ts
@@ -19,8 +19,7 @@ export const google_shopping: EvalFunction = async ({
     logger.log(agentResult);
 
     const evaluator = new Evaluator(stagehand);
-    const { evaluation, reasoning } = await evaluator.evaluate({
-      type: "screenshot",
+    const { evaluation, reasoning } = await evaluator.ask({
       question:
         "Does the page show a drip coffee maker that is on sale and within $25-60 and has a black finish?",
     });

--- a/evals/tasks/agent/google_shopping.ts
+++ b/evals/tasks/agent/google_shopping.ts
@@ -19,7 +19,7 @@ export const google_shopping: EvalFunction = async ({
     logger.log(agentResult);
 
     const evaluator = new Evaluator(stagehand);
-    const { evaluation, reasoning } = await evaluator.evaluate({
+    const { evaluation, reasoning } = await evaluator.evaluateScreenshot({
       question:
         "Does the page show a drip coffee maker that is on sale and within $25-60 and has a black finish?",
     });

--- a/evals/tasks/agent/google_shopping.ts
+++ b/evals/tasks/agent/google_shopping.ts
@@ -19,7 +19,8 @@ export const google_shopping: EvalFunction = async ({
     logger.log(agentResult);
 
     const evaluator = new Evaluator(stagehand);
-    const { evaluation, reasoning } = await evaluator.evaluateScreenshot({
+    const { evaluation, reasoning } = await evaluator.evaluate({
+      type: "screenshot",
       question:
         "Does the page show a drip coffee maker that is on sale and within $25-60 and has a black finish?",
     });

--- a/evals/tasks/agent/hotel_booking.ts
+++ b/evals/tasks/agent/hotel_booking.ts
@@ -19,7 +19,7 @@ export const hotel_booking: EvalFunction = async ({
     logger.log(agentResult);
 
     const evaluator = new Evaluator(stagehand);
-    const { evaluation, reasoning } = await evaluator.evaluate({
+    const { evaluation, reasoning } = await evaluator.evaluateScreenshot({
       question:
         "Does the page show a hotel in Sydney with a rating of 8 or higher, providing free Wi-Fi and parking, available for a four-night stay starting on December 10, 2025?",
     });

--- a/evals/tasks/agent/hotel_booking.ts
+++ b/evals/tasks/agent/hotel_booking.ts
@@ -19,8 +19,7 @@ export const hotel_booking: EvalFunction = async ({
     logger.log(agentResult);
 
     const evaluator = new Evaluator(stagehand);
-    const { evaluation, reasoning } = await evaluator.evaluate({
-      type: "screenshot",
+    const { evaluation, reasoning } = await evaluator.ask({
       question:
         "Does the page show a hotel in Sydney with a rating of 8 or higher, providing free Wi-Fi and parking, available for a four-night stay starting on December 10, 2025?",
     });

--- a/evals/tasks/agent/hotel_booking.ts
+++ b/evals/tasks/agent/hotel_booking.ts
@@ -19,7 +19,8 @@ export const hotel_booking: EvalFunction = async ({
     logger.log(agentResult);
 
     const evaluator = new Evaluator(stagehand);
-    const { evaluation, reasoning } = await evaluator.evaluateScreenshot({
+    const { evaluation, reasoning } = await evaluator.evaluate({
+      type: "screenshot",
       question:
         "Does the page show a hotel in Sydney with a rating of 8 or higher, providing free Wi-Fi and parking, available for a four-night stay starting on December 10, 2025?",
     });

--- a/evals/tasks/agent/hugging_face.ts
+++ b/evals/tasks/agent/hugging_face.ts
@@ -17,10 +17,11 @@ export const hugging_face: EvalFunction = async ({
       maxSteps: 20,
     });
     console.log(`agentResult: ${agentResult.message}`);
-    const { evaluation, reasoning } = await evaluator.evaluate({
-      type: "text",
-      actualText: agentResult.message || "",
-      expectedText: "kokoro-82m or hexgrad/Kokoro-82M",
+    const { evaluation, reasoning } = await evaluator.ask({
+      question:
+        "Does the message mention 'kokoro-82m' or 'hexgrad/Kokoro-82M'?",
+      answer: agentResult.message || "",
+      screenshot: false,
     });
 
     const success = agentResult.success && evaluation === "YES";

--- a/evals/tasks/agent/hugging_face.ts
+++ b/evals/tasks/agent/hugging_face.ts
@@ -17,7 +17,8 @@ export const hugging_face: EvalFunction = async ({
       maxSteps: 20,
     });
     console.log(`agentResult: ${agentResult.message}`);
-    const { evaluation, reasoning } = await evaluator.evaluateText({
+    const { evaluation, reasoning } = await evaluator.evaluate({
+      type: "text",
       actualText: agentResult.message || "",
       expectedText: "kokoro-82m or hexgrad/Kokoro-82M",
     });

--- a/evals/tasks/agent/hugging_face.ts
+++ b/evals/tasks/agent/hugging_face.ts
@@ -1,5 +1,5 @@
+import { Evaluator } from "@/evals/evaluator";
 import { EvalFunction } from "@/types/evals";
-import { z } from "zod";
 
 export const hugging_face: EvalFunction = async ({
   debugUrl,
@@ -9,28 +9,26 @@ export const hugging_face: EvalFunction = async ({
   agent,
 }) => {
   try {
+    const evaluator = new Evaluator(stagehand);
     await stagehand.page.goto("https://huggingface.co/");
     const agentResult = await agent.execute({
       instruction:
         "Search for a model on Hugging Face with an Apache-2.0 license that has received the highest number of likes.",
       maxSteps: 20,
     });
-
-    const { modelName } = await stagehand.page.extract({
-      modelName: "google/gemini-2.5-flash",
-      instruction: "Extract the name of the model",
-      schema: z.object({
-        modelName: z.string(),
-      }),
+    console.log(`agentResult: ${agentResult.message}`);
+    const { evaluation, reasoning } = await evaluator.evaluateText({
+      actualText: agentResult.message || "",
+      expectedText: "kokoro-82m or hexgrad/Kokoro-82M",
     });
-    console.log(`modelName: ${modelName}`);
-    const success =
-      agentResult.success &&
-      (modelName === "Kokoro-82M" || modelName === "hexgrad/Kokoro-82M");
+
+    const success = agentResult.success && evaluation === "YES";
+
+    console.log(`reasoning: ${reasoning}`);
     if (!success) {
       return {
         _success: false,
-        message: agentResult.message,
+        message: reasoning,
         debugUrl,
         sessionUrl,
         logs: logger.getLogs(),

--- a/evals/tasks/agent/iframe_form.ts
+++ b/evals/tasks/agent/iframe_form.ts
@@ -19,7 +19,7 @@ export const iframe_form: EvalFunction = async ({
 
     await stagehand.page.mouse.wheel(0, -1000);
     const evaluator = new Evaluator(stagehand);
-    const result = await evaluator.evaluate({
+    const result = await evaluator.evaluateScreenshot({
       question: "Is the form name input filled with 'John Smith'?",
     });
 
@@ -40,7 +40,7 @@ export const iframe_form: EvalFunction = async ({
     logger.log(agentResult2);
 
     await stagehand.page.mouse.wheel(0, -1000);
-    const result2 = await evaluator.evaluate({
+    const result2 = await evaluator.evaluateScreenshot({
       question: "Is the form email input filled with 'john.smith@example.com'?",
     });
 

--- a/evals/tasks/agent/iframe_form.ts
+++ b/evals/tasks/agent/iframe_form.ts
@@ -19,7 +19,8 @@ export const iframe_form: EvalFunction = async ({
 
     await stagehand.page.mouse.wheel(0, -1000);
     const evaluator = new Evaluator(stagehand);
-    const result = await evaluator.evaluateScreenshot({
+    const result = await evaluator.evaluate({
+      type: "screenshot",
       question: "Is the form name input filled with 'John Smith'?",
     });
 
@@ -40,7 +41,8 @@ export const iframe_form: EvalFunction = async ({
     logger.log(agentResult2);
 
     await stagehand.page.mouse.wheel(0, -1000);
-    const result2 = await evaluator.evaluateScreenshot({
+    const result2 = await evaluator.evaluate({
+      type: "screenshot",
       question: "Is the form email input filled with 'john.smith@example.com'?",
     });
 

--- a/evals/tasks/agent/iframe_form.ts
+++ b/evals/tasks/agent/iframe_form.ts
@@ -19,8 +19,7 @@ export const iframe_form: EvalFunction = async ({
 
     await stagehand.page.mouse.wheel(0, -1000);
     const evaluator = new Evaluator(stagehand);
-    const result = await evaluator.evaluate({
-      type: "screenshot",
+    const result = await evaluator.ask({
       question: "Is the form name input filled with 'John Smith'?",
     });
 
@@ -41,9 +40,9 @@ export const iframe_form: EvalFunction = async ({
     logger.log(agentResult2);
 
     await stagehand.page.mouse.wheel(0, -1000);
-    const result2 = await evaluator.evaluate({
-      type: "screenshot",
+    const result2 = await evaluator.ask({
       question: "Is the form email input filled with 'john.smith@example.com'?",
+      screenshot: true,
     });
 
     if (result2.evaluation !== "YES" && result2.evaluation !== "NO") {

--- a/evals/tasks/agent/iframe_form_multiple.ts
+++ b/evals/tasks/agent/iframe_form_multiple.ts
@@ -20,12 +20,17 @@ export const iframe_form_multiple: EvalFunction = async ({
 
     await stagehand.page.mouse.wheel(0, -1000);
     const evaluator = new Evaluator(stagehand);
-    const results = await evaluator.batchEvaluate({
-      type: "screenshot",
+    const results = await evaluator.batchAsk({
       questions: [
-        "Is the form name input filled with 'John Smith'?",
-        "Is the form email input filled with 'john.smith@example.com'?",
-        "Is the 'Are you the domain owner?' option selected as 'No'?",
+        { question: "Is the form name input filled with 'John Smith'?" },
+        {
+          question:
+            "Is the form email input filled with 'john.smith@example.com'?",
+        },
+        {
+          question:
+            "Is the 'Are you the domain owner?' option selected as 'No'?",
+        },
       ],
     });
 

--- a/evals/tasks/agent/iframe_form_multiple.ts
+++ b/evals/tasks/agent/iframe_form_multiple.ts
@@ -20,7 +20,8 @@ export const iframe_form_multiple: EvalFunction = async ({
 
     await stagehand.page.mouse.wheel(0, -1000);
     const evaluator = new Evaluator(stagehand);
-    const results = await evaluator.batchEvaluateScreenshot({
+    const results = await evaluator.batchEvaluate({
+      type: "screenshot",
       questions: [
         "Is the form name input filled with 'John Smith'?",
         "Is the form email input filled with 'john.smith@example.com'?",

--- a/evals/tasks/agent/iframe_form_multiple.ts
+++ b/evals/tasks/agent/iframe_form_multiple.ts
@@ -20,7 +20,7 @@ export const iframe_form_multiple: EvalFunction = async ({
 
     await stagehand.page.mouse.wheel(0, -1000);
     const evaluator = new Evaluator(stagehand);
-    const results = await evaluator.batchEvaluate({
+    const results = await evaluator.batchEvaluateScreenshot({
       questions: [
         "Is the form name input filled with 'John Smith'?",
         "Is the form email input filled with 'john.smith@example.com'?",

--- a/evals/tasks/agent/kayak.ts
+++ b/evals/tasks/agent/kayak.ts
@@ -30,7 +30,7 @@ export const kayak: EvalFunction = async ({
         logs: logger.getLogs(),
       };
     }
-    const { evaluation, reasoning } = await evaluator.evaluate({
+    const { evaluation, reasoning } = await evaluator.evaluateScreenshot({
       question:
         "Are the flights shown sorted by price? Check the sort button in the top left corner of the page",
     });

--- a/evals/tasks/agent/kayak.ts
+++ b/evals/tasks/agent/kayak.ts
@@ -30,8 +30,7 @@ export const kayak: EvalFunction = async ({
         logs: logger.getLogs(),
       };
     }
-    const { evaluation, reasoning } = await evaluator.evaluate({
-      type: "screenshot",
+    const { evaluation, reasoning } = await evaluator.ask({
       question:
         "Are the flights shown sorted by price? Check the sort button in the top left corner of the page",
     });

--- a/evals/tasks/agent/kayak.ts
+++ b/evals/tasks/agent/kayak.ts
@@ -30,7 +30,8 @@ export const kayak: EvalFunction = async ({
         logs: logger.getLogs(),
       };
     }
-    const { evaluation, reasoning } = await evaluator.evaluateScreenshot({
+    const { evaluation, reasoning } = await evaluator.evaluate({
+      type: "screenshot",
       question:
         "Are the flights shown sorted by price? Check the sort button in the top left corner of the page",
     });

--- a/evals/tasks/agent/kith.ts
+++ b/evals/tasks/agent/kith.ts
@@ -20,8 +20,7 @@ export const kith: EvalFunction = async ({
       maxSteps: 25,
     });
 
-    const { evaluation, reasoning } = await evaluator.evaluate({
-      type: "screenshot",
+    const { evaluation, reasoning } = await evaluator.ask({
       question: "Did the agent fill the delivery information",
     });
 
@@ -34,8 +33,7 @@ export const kith: EvalFunction = async ({
       });
 
       const { evaluation: evaluation2, reasoning: reasoning2 } =
-        await evaluator.evaluate({
-          type: "screenshot",
+        await evaluator.ask({
           question: "Did the agent fill the payment information",
         });
 

--- a/evals/tasks/agent/kith.ts
+++ b/evals/tasks/agent/kith.ts
@@ -20,7 +20,8 @@ export const kith: EvalFunction = async ({
       maxSteps: 25,
     });
 
-    const { evaluation, reasoning } = await evaluator.evaluateScreenshot({
+    const { evaluation, reasoning } = await evaluator.evaluate({
+      type: "screenshot",
       question: "Did the agent fill the delivery information",
     });
 
@@ -33,7 +34,8 @@ export const kith: EvalFunction = async ({
       });
 
       const { evaluation: evaluation2, reasoning: reasoning2 } =
-        await evaluator.evaluateScreenshot({
+        await evaluator.evaluate({
+          type: "screenshot",
           question: "Did the agent fill the payment information",
         });
 

--- a/evals/tasks/agent/kith.ts
+++ b/evals/tasks/agent/kith.ts
@@ -20,7 +20,7 @@ export const kith: EvalFunction = async ({
       maxSteps: 25,
     });
 
-    const { evaluation, reasoning } = await evaluator.evaluate({
+    const { evaluation, reasoning } = await evaluator.evaluateScreenshot({
       question: "Did the agent fill the delivery information",
     });
 
@@ -33,7 +33,7 @@ export const kith: EvalFunction = async ({
       });
 
       const { evaluation: evaluation2, reasoning: reasoning2 } =
-        await evaluator.evaluate({
+        await evaluator.evaluateScreenshot({
           question: "Did the agent fill the payment information",
         });
 

--- a/evals/tasks/agent/nba_trades.ts
+++ b/evals/tasks/agent/nba_trades.ts
@@ -18,7 +18,7 @@ export const nba_trades: EvalFunction = async ({
     });
     logger.log(agentResult);
 
-    const { evaluation, reasoning } = await evaluator.evaluate({
+    const { evaluation, reasoning } = await evaluator.evaluateScreenshot({
       question: "Did the agent make it to the nba transactions page?",
     });
 

--- a/evals/tasks/agent/nba_trades.ts
+++ b/evals/tasks/agent/nba_trades.ts
@@ -18,7 +18,8 @@ export const nba_trades: EvalFunction = async ({
     });
     logger.log(agentResult);
 
-    const { evaluation, reasoning } = await evaluator.evaluateScreenshot({
+    const { evaluation, reasoning } = await evaluator.evaluate({
+      type: "screenshot",
       question: "Did the agent make it to the nba transactions page?",
     });
 

--- a/evals/tasks/agent/nba_trades.ts
+++ b/evals/tasks/agent/nba_trades.ts
@@ -18,8 +18,7 @@ export const nba_trades: EvalFunction = async ({
     });
     logger.log(agentResult);
 
-    const { evaluation, reasoning } = await evaluator.evaluate({
-      type: "screenshot",
+    const { evaluation, reasoning } = await evaluator.ask({
       question: "Did the agent make it to the nba transactions page?",
     });
 

--- a/evals/tasks/agent/sf_library_card.ts
+++ b/evals/tasks/agent/sf_library_card.ts
@@ -20,8 +20,7 @@ export const sf_library_card: EvalFunction = async ({
 
     await stagehand.page.mouse.wheel(0, -1000);
     const evaluator = new Evaluator(stagehand);
-    const result = await evaluator.evaluate({
-      type: "screenshot",
+    const result = await evaluator.ask({
       question:
         "Does the page show the 'Residential Address' field filled with '166 Geary St'?",
     });

--- a/evals/tasks/agent/sf_library_card.ts
+++ b/evals/tasks/agent/sf_library_card.ts
@@ -20,7 +20,7 @@ export const sf_library_card: EvalFunction = async ({
 
     await stagehand.page.mouse.wheel(0, -1000);
     const evaluator = new Evaluator(stagehand);
-    const result = await evaluator.evaluate({
+    const result = await evaluator.evaluateScreenshot({
       question:
         "Does the page show the 'Residential Address' field filled with '166 Geary St'?",
     });

--- a/evals/tasks/agent/sf_library_card.ts
+++ b/evals/tasks/agent/sf_library_card.ts
@@ -20,7 +20,8 @@ export const sf_library_card: EvalFunction = async ({
 
     await stagehand.page.mouse.wheel(0, -1000);
     const evaluator = new Evaluator(stagehand);
-    const result = await evaluator.evaluateScreenshot({
+    const result = await evaluator.evaluate({
+      type: "screenshot",
       question:
         "Does the page show the 'Residential Address' field filled with '166 Geary St'?",
     });

--- a/evals/tasks/agent/sf_library_card_multiple.ts
+++ b/evals/tasks/agent/sf_library_card_multiple.ts
@@ -19,8 +19,7 @@ export const sf_library_card_multiple: EvalFunction = async ({
     logger.log(agentResult);
 
     const evaluator = new Evaluator(stagehand);
-    const result = await evaluator.evaluate({
-      type: "screenshot",
+    const result = await evaluator.ask({
       question: "Does the page show all the required fields filled?",
     });
 

--- a/evals/tasks/agent/sf_library_card_multiple.ts
+++ b/evals/tasks/agent/sf_library_card_multiple.ts
@@ -19,7 +19,7 @@ export const sf_library_card_multiple: EvalFunction = async ({
     logger.log(agentResult);
 
     const evaluator = new Evaluator(stagehand);
-    const result = await evaluator.evaluate({
+    const result = await evaluator.evaluateScreenshot({
       question: "Does the page show all the required fields filled?",
     });
 

--- a/evals/tasks/agent/sf_library_card_multiple.ts
+++ b/evals/tasks/agent/sf_library_card_multiple.ts
@@ -19,7 +19,8 @@ export const sf_library_card_multiple: EvalFunction = async ({
     logger.log(agentResult);
 
     const evaluator = new Evaluator(stagehand);
-    const result = await evaluator.evaluateScreenshot({
+    const result = await evaluator.evaluate({
+      type: "screenshot",
       question: "Does the page show all the required fields filled?",
     });
 

--- a/evals/tasks/agent/ubereats.ts
+++ b/evals/tasks/agent/ubereats.ts
@@ -18,8 +18,7 @@ export const ubereats: EvalFunction = async ({
       maxSteps: 35,
     });
 
-    const { evaluation, reasoning } = await evaluator.evaluate({
-      type: "screenshot",
+    const { evaluation, reasoning } = await evaluator.ask({
       question: "Did the agent make it to the login page?",
     });
 

--- a/evals/tasks/agent/ubereats.ts
+++ b/evals/tasks/agent/ubereats.ts
@@ -18,7 +18,8 @@ export const ubereats: EvalFunction = async ({
       maxSteps: 35,
     });
 
-    const { evaluation, reasoning } = await evaluator.evaluateScreenshot({
+    const { evaluation, reasoning } = await evaluator.evaluate({
+      type: "screenshot",
       question: "Did the agent make it to the login page?",
     });
 

--- a/evals/tasks/agent/ubereats.ts
+++ b/evals/tasks/agent/ubereats.ts
@@ -18,7 +18,7 @@ export const ubereats: EvalFunction = async ({
       maxSteps: 35,
     });
 
-    const { evaluation, reasoning } = await evaluator.evaluate({
+    const { evaluation, reasoning } = await evaluator.evaluateScreenshot({
       question: "Did the agent make it to the login page?",
     });
 

--- a/lib/llm/aisdk.ts
+++ b/lib/llm/aisdk.ts
@@ -51,7 +51,20 @@ export class AISdkClient extends LLMClient {
       level: 2,
       auxiliary: {
         options: {
-          value: JSON.stringify({ ...options, image: undefined }),
+          value: JSON.stringify({
+            ...options,
+            image: undefined,
+            messages: options.messages.map((msg) => ({
+              ...msg,
+              content: Array.isArray(msg.content)
+                ? msg.content.map((c) =>
+                    "image_url" in c
+                      ? { ...c, image_url: { url: "[IMAGE_REDACTED]" } }
+                      : c,
+                  )
+                : msg.content,
+            })),
+          }),
           type: "object",
         },
         modelName: {
@@ -234,7 +247,19 @@ export class AISdkClient extends LLMClient {
               type: "string",
             },
             cacheOptions: {
-              value: JSON.stringify(cacheOptions),
+              value: JSON.stringify({
+                ...cacheOptions,
+                messages: cacheOptions.messages.map((msg) => ({
+                  ...msg,
+                  content: Array.isArray(msg.content)
+                    ? msg.content.map((c) =>
+                        "image_url" in c
+                          ? { ...c, image_url: { url: "[IMAGE_REDACTED]" } }
+                          : c,
+                      )
+                    : msg.content,
+                })),
+              }),
               type: "object",
             },
             response: {
@@ -249,10 +274,15 @@ export class AISdkClient extends LLMClient {
       this.logger?.({
         category: "aisdk",
         message: "response",
-        level: 2,
+        level: 1,
         auxiliary: {
           response: {
-            value: JSON.stringify(objectResponse),
+            value: JSON.stringify({
+              object: objectResponse.object,
+              usage: objectResponse.usage,
+              finishReason: objectResponse.finishReason,
+              // Omit request and response properties that might contain images
+            }),
             type: "object",
           },
           requestId: {
@@ -301,7 +331,19 @@ export class AISdkClient extends LLMClient {
             type: "string",
           },
           cacheOptions: {
-            value: JSON.stringify(cacheOptions),
+            value: JSON.stringify({
+              ...cacheOptions,
+              messages: cacheOptions.messages.map((msg) => ({
+                ...msg,
+                content: Array.isArray(msg.content)
+                  ? msg.content.map((c) =>
+                      "image_url" in c
+                        ? { ...c, image_url: { url: "[IMAGE_REDACTED]" } }
+                        : c,
+                    )
+                  : msg.content,
+              })),
+            }),
             type: "object",
           },
           response: {
@@ -319,7 +361,12 @@ export class AISdkClient extends LLMClient {
       level: 2,
       auxiliary: {
         response: {
-          value: JSON.stringify(textResponse),
+          value: JSON.stringify({
+            text: textResponse.text,
+            usage: textResponse.usage,
+            finishReason: textResponse.finishReason,
+            // Omit request and response properties that might contain images
+          }),
           type: "object",
         },
         requestId: {

--- a/types/evaluator.ts
+++ b/types/evaluator.ts
@@ -1,68 +1,42 @@
-export interface EvaluateScreenshotOptions {
-  /**
-   * The question to ask about the task state
-   */
-  question: string;
-  /**
-   * Custom system prompt for the evaluator
-   */
-  systemPrompt?: string;
-  /**
-   * Delay in milliseconds before taking the screenshot
-   * @default 1000
-   */
-  screenshotDelayMs?: number;
-}
+export type EvaluateOptions =
+  | {
+      type: "screenshot";
+      /** The question to ask about the task state */
+      question: string;
+      /** Custom system prompt for the evaluator */
+      systemPrompt?: string;
+      /** Delay in milliseconds before taking the screenshot @default 1000 */
+      screenshotDelayMs?: number;
+    }
+  | {
+      type: "text";
+      /** The actual text/message to evaluate */
+      actualText: string;
+      /** The expected text or pattern to check against */
+      expectedText: string;
+      /** Custom system prompt for the evaluator */
+      systemPrompt?: string;
+    };
 
-export interface BatchEvaluateScreenshotOptions {
-  /**
-   * Array of questions to evaluate
-   */
-  questions: string[];
-  /**
-   * Custom system prompt for the evaluator
-   */
-  systemPrompt?: string;
-  /**
-   * Delay in milliseconds before taking the screenshot
-   * @default 1000
-   */
-  screenshotDelayMs?: number;
-  /**
-   * The reasoning behind the evaluation
-   */
-  reasoning?: string;
-}
-
-export interface EvaluateTextOptions {
-  /**
-   * The actual text/message to evaluate
-   */
-  actualText: string;
-  /**
-   * The expected text or pattern to check against
-   */
-  expectedText: string;
-  /**
-   * Custom system prompt for the evaluator
-   */
-  systemPrompt?: string;
-}
-
-export interface BatchEvaluateTextOptions {
-  /**
-   * The actual text/message to evaluate
-   */
-  actualText: string;
-  /**
-   * Array of expected texts or patterns to check against
-   */
-  expectedTexts: string[];
-  /**
-   * Custom system prompt for the evaluator
-   */
-  systemPrompt?: string;
-}
+export type BatchEvaluateOptions =
+  | {
+      type: "screenshot";
+      /** Array of questions to evaluate */
+      questions: string[];
+      /** Custom system prompt for the evaluator */
+      systemPrompt?: string;
+      /** Delay in milliseconds before taking the screenshot @default 1000 */
+      screenshotDelayMs?: number;
+    }
+  | {
+      type: "text";
+      /** The actual text/message to evaluate */
+      actualText: string;
+      /** Array of expected texts or patterns to check against */
+      expectedTexts: string[];
+      /** Custom system prompt for the evaluator */
+      systemPrompt?: string;
+    };
 
 /**
  * Result of an evaluation

--- a/types/evaluator.ts
+++ b/types/evaluator.ts
@@ -1,4 +1,4 @@
-export interface EvaluateOptions {
+export interface EvaluateScreenshotOptions {
   /**
    * The question to ask about the task state
    */
@@ -14,7 +14,7 @@ export interface EvaluateOptions {
   screenshotDelayMs?: number;
 }
 
-export interface BatchEvaluateOptions {
+export interface BatchEvaluateScreenshotOptions {
   /**
    * Array of questions to evaluate
    */
@@ -32,6 +32,36 @@ export interface BatchEvaluateOptions {
    * The reasoning behind the evaluation
    */
   reasoning?: string;
+}
+
+export interface EvaluateTextOptions {
+  /**
+   * The actual text/message to evaluate
+   */
+  actualText: string;
+  /**
+   * The expected text or pattern to check against
+   */
+  expectedText: string;
+  /**
+   * Custom system prompt for the evaluator
+   */
+  systemPrompt?: string;
+}
+
+export interface BatchEvaluateTextOptions {
+  /**
+   * The actual text/message to evaluate
+   */
+  actualText: string;
+  /**
+   * Array of expected texts or patterns to check against
+   */
+  expectedTexts: string[];
+  /**
+   * Custom system prompt for the evaluator
+   */
+  systemPrompt?: string;
 }
 
 /**

--- a/types/evaluator.ts
+++ b/types/evaluator.ts
@@ -1,22 +1,15 @@
-export type EvaluateOptions =
-  | {
-      type: "screenshot";
-      /** The question to ask about the task state */
-      question: string;
-      /** Custom system prompt for the evaluator */
-      systemPrompt?: string;
-      /** Delay in milliseconds before taking the screenshot @default 1000 */
-      screenshotDelayMs?: number;
-    }
-  | {
-      type: "text";
-      /** The actual text/message to evaluate */
-      actualText: string;
-      /** The expected text or pattern to check against */
-      expectedText: string;
-      /** Custom system prompt for the evaluator */
-      systemPrompt?: string;
-    };
+export type EvaluateOptions = {
+  /** The question to ask about the task state */
+  question: string;
+  /** The answer to the question */
+  answer?: string;
+  /** Whether to take a screenshot of the task state */
+  screenshot?: boolean;
+  /** Custom system prompt for the evaluator */
+  systemPrompt?: string;
+  /** Delay in milliseconds before taking the screenshot @default 250 */
+  screenshotDelayMs?: number;
+};
 
 export type BatchEvaluateOptions =
   | {

--- a/types/evaluator.ts
+++ b/types/evaluator.ts
@@ -11,25 +11,19 @@ export type EvaluateOptions = {
   screenshotDelayMs?: number;
 };
 
-export type BatchEvaluateOptions =
-  | {
-      type: "screenshot";
-      /** Array of questions to evaluate */
-      questions: string[];
-      /** Custom system prompt for the evaluator */
-      systemPrompt?: string;
-      /** Delay in milliseconds before taking the screenshot @default 1000 */
-      screenshotDelayMs?: number;
-    }
-  | {
-      type: "text";
-      /** The actual text/message to evaluate */
-      actualText: string;
-      /** Array of expected texts or patterns to check against */
-      expectedTexts: string[];
-      /** Custom system prompt for the evaluator */
-      systemPrompt?: string;
-    };
+export type BatchAskOptions = {
+  /** Array of questions with optional answers */
+  questions: Array<{
+    question: string;
+    answer?: string;
+  }>;
+  /** Whether to take a screenshot of the task state */
+  screenshot?: boolean;
+  /** Custom system prompt for the evaluator */
+  systemPrompt?: string;
+  /** Delay in milliseconds before taking the screenshot @default 1000 */
+  screenshotDelayMs?: number;
+};
 
 /**
  * Result of an evaluation


### PR DESCRIPTION
# why

adds "evaluateText" to evaluator

# what changed

evals can now use the evaluateText method to use the llms messages to evaluate if it came across the proper information required by the eval. This removes the dependency on extract within evals + makes it easier to evaluate within the webvoyager / gaia evals when they are implemented 

# test plan
tested locally