### PR TITLE
Fix stagehand.metrics

### DIFF
--- a/.changeset/sharp-suns-fall.md
+++ b/.changeset/sharp-suns-fall.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": minor
+---
+
+Update stagehand.metrics to work on every environment

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -458,8 +458,21 @@ export class Stagehand {
     totalInferenceTimeMs: 0,
   };
 
-  public get metrics(): StagehandMetrics {
-    return this.stagehandMetrics;
+  public get metrics(): Promise<StagehandMetrics> {
+    if (this.usingAPI && this.apiClient) {
+      // Fetch metrics from the API
+      return this.apiClient.getReplayMetrics().catch((error) => {
+        this.logger({
+          category: "metrics",
+          message: `Failed to fetch metrics from API: ${error}`,
+          level: 0,
+        });
+        // Fall back to local metrics on error
+        return this.stagehandMetrics;
+      });
+    }
+    // Return local metrics wrapped in a Promise for consistency
+    return Promise.resolve(this.stagehandMetrics);
   }
 
   public get isClosed(): boolean {


### PR DESCRIPTION
# why
On api mode `env:BROWSERBASE` the metrics (token usage, inference speed) are not being handled properly client-side
This PR addresses: #926 

# what changed
Updated `stagehand.metrics` to return a promise, that will resolve depending on the environment whenever metrics are received and parsed from api or immediately when running local

# test plan
