### PR TITLE
Uday/upload

### DIFF
--- a/examples/upload_test.ts
+++ b/examples/upload_test.ts
@@ -18,6 +18,7 @@ async function main() {
 
   const stagehand = new Stagehand({
     ...StagehandConfig,
+    env: "BROWSERBASE",
     verbose: 1,
     modelName: "openai/gpt-4o-mini",
   });

--- a/examples/upload_test.ts
+++ b/examples/upload_test.ts
@@ -1,0 +1,129 @@
+import path from "node:path";
+import fs from "node:fs";
+// Import directly from local dist to ensure latest build is used
+import { Stagehand } from "../dist";
+import type { Page as PlaywrightPage } from "playwright";
+import StagehandConfig from "../stagehand.config";
+
+async function downloadFile(url: string, filename: string): Promise<string> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to download file: ${response.statusText}`);
+  }
+
+  const buffer = await response.arrayBuffer();
+  const filePath = path.join(process.cwd(), "downloads", filename);
+
+  // Ensure downloads directory exists
+  if (!fs.existsSync(path.dirname(filePath))) {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  }
+
+  fs.writeFileSync(filePath, Buffer.from(buffer));
+  return filePath;
+}
+
+async function main() {
+  // Accept file URL as command line argument or use default
+  const fileUrl = process.argv[2] || "https://www.orimi.com/pdf-test.pdf";
+  const targetPage =
+    process.argv[3] || "https://ps.uci.edu/~franklin/doc/file_upload.html";
+
+  console.log(`Downloading file from: ${fileUrl}`);
+  console.log(`Target page: ${targetPage}`);
+
+  const stagehand = new Stagehand({ ...StagehandConfig, verbose: 1 });
+  await stagehand.init();
+  const page = stagehand.page;
+
+  try {
+    // Download the file dynamically
+    const filename = path.basename(fileUrl) || "downloaded_file";
+    const filePath = await downloadFile(fileUrl, filename);
+    console.log(`File downloaded to: ${filePath}`);
+
+    // Navigate to the target page
+    await page.goto(targetPage, {
+      waitUntil: "domcontentloaded",
+    });
+
+    // Debug: check presence of file inputs before calling upload
+    const count = await page.locator('input[type="file"]').count();
+    console.log("file input count:", count);
+
+    // Debug: log accessibility tree (full)
+    try {
+      const pw = page as unknown as PlaywrightPage;
+      const ax = await pw.accessibility.snapshot({ interestingOnly: false });
+      console.log("AX tree:");
+      console.log(JSON.stringify(ax, null, 2));
+    } catch (e) {
+      console.log("Failed to snapshot accessibility tree:", e);
+    }
+
+    // Upload using the new helper - let observe find the right input
+    const result = await stagehand.upload("Upload this file", filePath);
+    console.log("upload result:", result);
+
+    // Try to submit the form using observe to find the submit button
+    try {
+      const [submitAction] = await page.observe(
+        "Find and click the submit or send button",
+      );
+      if (submitAction?.selector) {
+        console.log(
+          `Found submit button with selector: ${submitAction.selector}`,
+        );
+
+        // Avoid mixed-content warning by upgrading http action → https when possible
+        try {
+          await page.evaluate(() => {
+            const form = document.querySelector(
+              "form",
+            ) as HTMLFormElement | null;
+            if (
+              form &&
+              typeof form.action === "string" &&
+              form.action.startsWith("http://")
+            ) {
+              form.action = form.action.replace("http://", "https://");
+            }
+          });
+        } catch {
+          // ignore non-fatal submit upgrade errors
+        }
+
+        await page.act(submitAction);
+        console.log("Form submitted successfully");
+      } else {
+        console.log("No submit button found via observe");
+      }
+    } catch (e) {
+      console.log("Failed to find submit button via observe:", e);
+    }
+
+    await page.waitForTimeout(1500);
+  } finally {
+    // Clean up downloaded file
+    try {
+      const filePath = path.join(
+        process.cwd(),
+        "downloads",
+        path.basename(fileUrl) || "downloaded_file",
+      );
+      if (fs.existsSync(filePath)) {
+        fs.unlinkSync(filePath);
+        console.log("Cleaned up downloaded file");
+      }
+    } catch (e) {
+      console.log("Failed to clean up file:", e);
+    }
+
+    await stagehand.close();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1105,7 +1105,7 @@ export class Stagehand {
         }
       }
     } catch {
-      // observe may fail
+      void 0;
     }
 
     return finish({

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -978,11 +978,17 @@ export class Stagehand {
         // If this is a file input → set directly
         const isFileInput = await locator
           .evaluate(
-            (el): boolean =>
-              el.tagName.toLowerCase() === "input" &&
-              (el as HTMLInputElement).type === "file",
+            (el): boolean => {
+              const tagName = el.tagName.toLowerCase();
+              const type = (el as HTMLInputElement).type;
+              console.log(`DEBUG: Element tagName=${tagName}, type=${type}`);
+              return tagName === "input" && type === "file";
+            },
           )
-          .catch(() => false);
+          .catch((e) => {
+            console.log(`DEBUG: evaluate failed:`, e);
+            return false;
+          });
 
         if (isFileInput) {
           await locator.setInputFiles(filesArg);

--- a/lib/package.json
+++ b/lib/package.json
@@ -3,9 +3,9 @@
   "version": "2.4.1",
   "private": true,
   "description": "Core Stagehand library sources",
-  "main": "../dist/index.js",
-  "module": "../dist/index.js",
-  "types": "../dist/index.d.ts",
+  "main": "./index.js",
+  "module": "./index.js",
+  "types": "./index.d.ts",
   "scripts": {
     "build-dom-scripts": "tsx dom/genDomScripts.ts",
     "build-js": "tsup index.ts --dts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,43 @@ importers:
       zod-to-json-schema:
         specifier: ^3.23.5
         version: 3.24.5(zod@3.25.67)
+    optionalDependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^1.2.6
+        version: 1.2.10(zod@3.25.67)
+      '@ai-sdk/azure':
+        specifier: ^1.3.19
+        version: 1.3.22(zod@3.25.67)
+      '@ai-sdk/cerebras':
+        specifier: ^0.2.6
+        version: 0.2.13(zod@3.25.67)
+      '@ai-sdk/deepseek':
+        specifier: ^0.2.13
+        version: 0.2.13(zod@3.25.67)
+      '@ai-sdk/google':
+        specifier: ^1.2.6
+        version: 1.2.14(zod@3.25.67)
+      '@ai-sdk/groq':
+        specifier: ^1.2.4
+        version: 1.2.8(zod@3.25.67)
+      '@ai-sdk/mistral':
+        specifier: ^1.2.7
+        version: 1.2.7(zod@3.25.67)
+      '@ai-sdk/openai':
+        specifier: ^1.0.14
+        version: 1.3.21(zod@3.25.67)
+      '@ai-sdk/perplexity':
+        specifier: ^1.1.7
+        version: 1.1.8(zod@3.25.67)
+      '@ai-sdk/togetherai':
+        specifier: ^0.2.6
+        version: 0.2.13(zod@3.25.67)
+      '@ai-sdk/xai':
+        specifier: ^1.2.15
+        version: 1.2.15(zod@3.25.67)
+      ollama-ai-provider:
+        specifier: ^1.2.0
+        version: 1.2.0(zod@3.25.67)
     devDependencies:
       '@changesets/changelog-github':
         specifier: ^0.5.0
@@ -138,43 +175,6 @@ importers:
       typescript-eslint:
         specifier: ^8.17.0
         version: 8.31.1(eslint@9.25.1(jiti@1.21.7))(typescript@5.8.3)
-    optionalDependencies:
-      '@ai-sdk/anthropic':
-        specifier: ^1.2.6
-        version: 1.2.10(zod@3.25.67)
-      '@ai-sdk/azure':
-        specifier: ^1.3.19
-        version: 1.3.22(zod@3.25.67)
-      '@ai-sdk/cerebras':
-        specifier: ^0.2.6
-        version: 0.2.13(zod@3.25.67)
-      '@ai-sdk/deepseek':
-        specifier: ^0.2.13
-        version: 0.2.13(zod@3.25.67)
-      '@ai-sdk/google':
-        specifier: ^1.2.6
-        version: 1.2.14(zod@3.25.67)
-      '@ai-sdk/groq':
-        specifier: ^1.2.4
-        version: 1.2.8(zod@3.25.67)
-      '@ai-sdk/mistral':
-        specifier: ^1.2.7
-        version: 1.2.7(zod@3.25.67)
-      '@ai-sdk/openai':
-        specifier: ^1.0.14
-        version: 1.3.21(zod@3.25.67)
-      '@ai-sdk/perplexity':
-        specifier: ^1.1.7
-        version: 1.1.8(zod@3.25.67)
-      '@ai-sdk/togetherai':
-        specifier: ^0.2.6
-        version: 0.2.13(zod@3.25.67)
-      '@ai-sdk/xai':
-        specifier: ^1.2.15
-        version: 1.2.15(zod@3.25.67)
-      ollama-ai-provider:
-        specifier: ^1.2.0
-        version: 1.2.0(zod@3.25.67)
 
   docs:
     dependencies:
@@ -4885,6 +4885,7 @@ packages:
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -286,10 +286,39 @@ export enum StagehandFunctionName {
 }
 
 export interface HistoryEntry {
-  method: "act" | "extract" | "observe" | "navigate";
+  method: "act" | "extract" | "observe" | "navigate" | "upload";
   parameters: unknown;
   result: unknown;
   timestamp: string;
+}
+
+/**
+ * Describes a file to upload. You can provide a path or an in-memory payload.
+ */
+export type FileSpec =
+  | string
+  | {
+      /** Absolute path on disk to the file. */
+      path?: string;
+      /** Name to use for the file (required if using buffer). */
+      name?: string;
+      /** MIME type for the file (required if using buffer). */
+      mimeType?: string;
+      /** Raw file bytes (requires name + mimeType). */
+      buffer?: Buffer;
+    };
+
+export interface UploadResult {
+  success: boolean;
+  /** How the upload was performed. */
+  method: "input" | "chooser" | "direct" | "fallback";
+  /** Original hint used to locate the control. */
+  hint: string;
+  /** Selector of the target input, when available. */
+  selector?: string;
+  /** Final file name reported. */
+  fileName?: string;
+  message?: string;
 }
 
 /**


### PR DESCRIPTION
# stagehand upload method

### why

stagehand could click, type, scrape… but uploads were messy.
no way to handle hidden inputs, chooser popups, urls, buffers.
no natural language → file input.
no clean support across local + browserbase.
so i built it.

---

### what changed

**1. new types**

```ts
export type FileSpec = 
  | string 
  | { path: string }
  | { name: string; mimeType: string; buffer: Buffer };

export interface UploadResult {
  success: boolean;
  method: "input" | "chooser" | "fallback";
  hint: string;
  selector?: string;
  fileName?: string;
  message: string;
}

export interface HistoryEntry {
  method: "act" | "extract" | "observe" | "navigate" | "upload";
  // …
}
```

**2. new api**

```ts
await stagehand.upload("Upload resume", fileSpec)
```

* ai finds the right element (`observe`)
* tries 3 ways: input → chooser → fallback
* works with urls, paths, or raw buffers
* runs in local + browserbase the same way
* returns structured `UploadResult`

**3. file processing**

* fetches urls → buffer in memory
* figures out mime + name
* supports direct buffers
* no temp files, all in memory

**4. integration**

* history logs upload events
* ready for metrics
* typed & safe

---

### test plan

✅ done

* pdf upload from url
* ai finds correct input
* submit works after upload
* tested on local + browserbase
* url / buffer / local path support
* observe handles iframes/shadow dom

🧪 next

* multiple file inputs
* hidden + chooser flows
* iframes + dynamic forms
* large files + different mime types
* failure modes (bad url, network, limits, perms)

---

### notes

* pure ai, no hardcoded selectors
* modular → easy to extend
* efficient: single dom query, direct memory stream
* safe: no file writes, validates urls, respects mime

---

### usage

```ts
await stagehand.upload("Upload this file", "https://example.com/file.pdf");

await stagehand.upload("Upload resume", resumeUrl);
await stagehand.upload("Upload cover letter", letterUrl);

await stagehand.upload("Upload doc", {
  name: "document.pdf",
  mimeType: "application/pdf",
  buffer: pdfBuffer
});
```

---

### impact

stagehand now does uploads properly.
handles messy real-world forms.
natural language → correct element.
works across environments.
less brittle, more useful.
opens up workflows like automated form filling + doc processing.

basically: it can now upload files.

p.s. also my first os contribution
