### PR TITLE
allow openai CUA to take in an optional baseURL

### DIFF
--- a/.changeset/three-windows-fail.md
+++ b/.changeset/three-windows-fail.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Allow OpenAI CUA to take in an optional baseURL

--- a/lib/agent/OpenAICUAClient.ts
+++ b/lib/agent/OpenAICUAClient.ts
@@ -41,6 +41,7 @@ export class OpenAICUAClient extends AgentClient {
     // Process client options
     this.apiKey =
       (clientOptions?.apiKey as string) || process.env.OPENAI_API_KEY || "";
+    this.baseURL = (clientOptions?.baseURL as string) || undefined;
     this.organization =
       (clientOptions?.organization as string) || process.env.OPENAI_ORG;
 
@@ -56,6 +57,10 @@ export class OpenAICUAClient extends AgentClient {
     this.clientOptions = {
       apiKey: this.apiKey,
     };
+
+    if (this.baseURL) {
+      this.clientOptions.baseURL = this.baseURL;
+    }
 
     // Initialize the OpenAI client
     this.client = new OpenAI(this.clientOptions);


### PR DESCRIPTION
# why
OpenAI CUA only defaults to the openai base url `api.openai.com/v1`

# what changed
Parametrized `baseURL` for openai cua

# test plan
