### PR TITLE
update screenshot period on image evaluator

### DIFF
--- a/evals/tasks/agent/webvoyager.ts
+++ b/evals/tasks/agent/webvoyager.ts
@@ -38,7 +38,6 @@ export const webvoyager: EvalFunction = async ({
 
     // Start collecting screenshots in parallel
     const screenshotCollector = new ScreenshotCollector(stagehand.page, {
-      interval: 2000, // Capture every 2 seconds
       maxScreenshots: 10, // Keep last 10 screenshots
       captureOnNavigation: true, // Also capture on page navigation
     });

--- a/evals/utils/ScreenshotCollector.ts
+++ b/evals/utils/ScreenshotCollector.ts
@@ -18,7 +18,7 @@ export class ScreenshotCollector {
 
   constructor(page: Page, options: ScreenshotCollectorOptions = {}) {
     this.page = page;
-    this.interval = options.interval || 2000;
+    this.interval = options.interval || 5000;
     this.maxScreenshots = options.maxScreenshots || 10;
     this.captureOnNavigation = options.captureOnNavigation ?? true;
   }


### PR DESCRIPTION
# why

we need a higher interval than 2000ms, it now uses 5000 by default
 
# what changed

set default screenshot interval to 5000ms
# test plan
