### PR TITLE
Remove Need to Add Project ID in Browserbase Params if Already Passed to Stagehand

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -73,7 +73,10 @@ async function getBrowser(
   env: "LOCAL" | "BROWSERBASE" = "LOCAL",
   headless: boolean = false,
   logger: (message: LogLine) => void,
-  browserbaseSessionCreateParams?: Browserbase.Sessions.SessionCreateParams,
+  browserbaseSessionCreateParams?: Omit<
+    Browserbase.Sessions.SessionCreateParams,
+    "projectId"
+  > & { projectId?: string },
   browserbaseSessionID?: string,
   localBrowserLaunchOptions?: LocalBrowserLaunchOptions,
 ): Promise<BrowserResult> {
@@ -377,7 +380,10 @@ export class Stagehand {
   protected apiKey: string | undefined;
   private projectId: string | undefined;
   private externalLogger?: (logLine: LogLine) => void;
-  private browserbaseSessionCreateParams?: Browserbase.Sessions.SessionCreateParams;
+  private browserbaseSessionCreateParams?: Omit<
+    Browserbase.Sessions.SessionCreateParams,
+    "projectId"
+  > & { projectId?: string };
   public variables: { [key: string]: unknown };
   private contextPath?: string;
   public llmClient: LLMClient;

--- a/types/api.ts
+++ b/types/api.ts
@@ -20,7 +20,10 @@ export interface StartSessionParams {
   verbose: number;
   debugDom: boolean;
   systemPrompt?: string;
-  browserbaseSessionCreateParams?: Browserbase.Sessions.SessionCreateParams;
+  browserbaseSessionCreateParams?: Omit<
+    Browserbase.Sessions.SessionCreateParams,
+    "projectId"
+  > & { projectId?: string };
   selfHeal?: boolean;
   waitForCaptchaSolves?: boolean;
   actionTimeoutMs?: number;

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -46,8 +46,9 @@ export interface ConstructorParams {
   /**
    * The parameters to use for creating a Browserbase session
    * See https://docs.browserbase.com/reference/api/create-a-session
+   * Note: projectId is optional here as it will use the main projectId parameter if not provided
    */
-  browserbaseSessionCreateParams?: Browserbase.Sessions.SessionCreateParams;
+  browserbaseSessionCreateParams?: Omit<Browserbase.Sessions.SessionCreateParams, 'projectId'> & { projectId?: string };
   /**
    * Enable caching of LLM responses
    * @default true

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -48,7 +48,10 @@ export interface ConstructorParams {
    * See https://docs.browserbase.com/reference/api/create-a-session
    * Note: projectId is optional here as it will use the main projectId parameter if not provided
    */
-  browserbaseSessionCreateParams?: Omit<Browserbase.Sessions.SessionCreateParams, 'projectId'> & { projectId?: string };
+  browserbaseSessionCreateParams?: Omit<
+    Browserbase.Sessions.SessionCreateParams,
+    "projectId"
+  > & { projectId?: string };
   /**
    * Enable caching of LLM responses
    * @default true


### PR DESCRIPTION
# why

if you add custom browserbase create params, you need to include the project id even if the project id is already passed to the stagehand instance

# what changed

browserbaseSessionCreateParams type changed to omit project id

# test plan

build stagehand locally, use local stagehand to run sessions with
- two project ids: one Stagehand, on in Browserbase Session Create Params
- one project id: only Stagehand