### PR TITLE
Export aisdk

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1030,4 +1030,5 @@ export * from "../types/stagehand";
 export * from "../types/stagehandApiErrors";
 export * from "../types/stagehandErrors";
 export * from "./llm/LLMClient";
+export * from "./llm/aisdk";
 export { connectToMCPServer };

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -48,7 +48,7 @@ export interface ConstructorParams {
    * See https://docs.browserbase.com/reference/api/create-a-session
    * Note: projectId is optional here as it will use the main projectId parameter if not provided
    */
-  browserbaseSessionCreateParams?: Omit<Browserbase.Sessions.SessionCreateParams, 'projectId'> & { projectId?: string };
+  browserbaseSessionCreateParams?: Browserbase.Sessions.SessionCreateParams;
   /**
    * Enable caching of LLM responses
    * @default true

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -46,7 +46,6 @@ export interface ConstructorParams {
   /**
    * The parameters to use for creating a Browserbase session
    * See https://docs.browserbase.com/reference/api/create-a-session
-   * Note: projectId is optional here as it will use the main projectId parameter if not provided
    */
   browserbaseSessionCreateParams?: Browserbase.Sessions.SessionCreateParams;
   /**

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -46,8 +46,9 @@ export interface ConstructorParams {
   /**
    * The parameters to use for creating a Browserbase session
    * See https://docs.browserbase.com/reference/api/create-a-session
+   * Note: projectId is optional here as it will use the main projectId parameter if not provided
    */
-  browserbaseSessionCreateParams?: Browserbase.Sessions.SessionCreateParams;
+  browserbaseSessionCreateParams?: Omit<Browserbase.Sessions.SessionCreateParams, 'projectId'> & { projectId?: string };
   /**
    * Enable caching of LLM responses
    * @default true


### PR DESCRIPTION
# why

Easier to use for Custom LLM Clients and keep users up to date with our aisdk file

# what changed

added export of aisdk to lib/index.ts

# test plan

build local stagehand, import local AISdkClient, run Azure Stagehand session