### PR TITLE
Added support for client certificates

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -308,6 +308,7 @@ async function getBrowser(
       handleSIGINT: localBrowserLaunchOptions?.handleSIGINT ?? true,
       handleSIGTERM: localBrowserLaunchOptions?.handleSIGTERM ?? true,
       ignoreDefaultArgs: localBrowserLaunchOptions?.ignoreDefaultArgs,
+      clientCertificates: localBrowserLaunchOptions?.clientCertificates,
     });
 
     if (localBrowserLaunchOptions?.cookies) {

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -170,6 +170,16 @@ export interface ObserveResult {
 export interface LocalBrowserLaunchOptions {
   args?: string[];
   chromiumSandbox?: boolean;
+  clientCertificates?: Array<{
+      origin: string;
+      certPath?: string;
+      cert?: Buffer;
+      keyPath?: string;
+      key?: Buffer;
+      pfxPath?: string;
+      pfx?: Buffer;
+      passphrase?: string;
+  }>;
   devtools?: boolean;
   env?: Record<string, string | number | boolean>;
   executablePath?: string;


### PR DESCRIPTION
# why
Allowing authentication using provided client certificates during local runs.

# what changed
Additional configuration value 'clientCertificates' that's being passed during Playwright context creation.

# test plan
This is additional support for already existing Playwright feature so Playwright team's internal test for this feature should be enough. But to test locally, provide client certificate config according to this API - https://playwright.dev/docs/api/class-browser#browser-new-context-option-client-certificates - and authenticate to whichever service that certificate belongs to.