### PR TITLE
add playwright arguments to agent

### DIFF
--- a/.changeset/icy-toes-obey.md
+++ b/.changeset/icy-toes-obey.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Add playwright arguments to agent execute response

--- a/lib/agent/tools/act.ts
+++ b/lib/agent/tools/act.ts
@@ -45,9 +45,7 @@ export const createActTool = (
 
         const observeResult = observeResults[0];
 
-        const result = await stagehandPage.page.act(observeResult);
-
-        const isIframeAction = result.action === "an iframe";
+        const isIframeAction = observeResult.description === "an iframe";
 
         if (isIframeAction) {
           const iframeObserveOptions = executionModel
@@ -88,6 +86,7 @@ export const createActTool = (
           };
         }
 
+        const result = await stagehandPage.page.act(observeResult);
         const playwrightArguments = {
           description: observeResult.description,
           method: observeResult.method,

--- a/lib/agent/tools/act.ts
+++ b/lib/agent/tools/act.ts
@@ -69,7 +69,6 @@ export const createActTool = (
               success: false,
               error: "No observable actions found within iframe context",
               isIframe: true,
-              playwrightArguments: null as null,
             };
           }
 
@@ -106,7 +105,6 @@ export const createActTool = (
         return {
           success: false,
           error: error.message,
-          playwrightArguments: null as null,
         };
       }
     },

--- a/lib/agent/tools/act.ts
+++ b/lib/agent/tools/act.ts
@@ -1,7 +1,8 @@
 import { tool } from "ai";
 import { z } from "zod/v3";
 import { StagehandPage } from "../../StagehandPage";
-
+import { buildActObservePrompt } from "../../prompt";
+import { SupportedPlaywrightAction } from "@/types/act";
 export const createActTool = (
   stagehandPage: StagehandPage,
   executionModel?: string,
@@ -20,8 +21,19 @@ export const createActTool = (
     execute: async ({ action }) => {
       try {
         const observeOptions = executionModel
-          ? { instruction: action, modelName: executionModel }
-          : { instruction: action };
+          ? {
+              instruction: buildActObservePrompt(
+                action,
+                Object.values(SupportedPlaywrightAction),
+              ),
+              modelName: executionModel,
+            }
+          : {
+              instruction: buildActObservePrompt(
+                action,
+                Object.values(SupportedPlaywrightAction),
+              ),
+            };
 
         const observeResults = await stagehandPage.page.observe(observeOptions);
 
@@ -74,8 +86,8 @@ export const createActTool = (
             isIframe: true,
             playwrightArguments: {
               description: iframeObserveResult.description,
-              method: iframeObserveResult.method || "click",
-              arguments: iframeObserveResult.arguments || [],
+              method: iframeObserveResult.method,
+              arguments: iframeObserveResult.arguments,
               selector: iframeObserveResult.selector,
             },
           };
@@ -84,8 +96,8 @@ export const createActTool = (
         // For regular (non-iframe) actions, use the original observe result
         const playwrightArguments = {
           description: observeResult.description,
-          method: observeResult.method || "click",
-          arguments: observeResult.arguments || [],
+          method: observeResult.method,
+          arguments: observeResult.arguments,
           selector: observeResult.selector,
         };
 

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -1,5 +1,20 @@
 import { LogLine } from "./log";
 
+export interface PlaywrightArguments {
+  description: string;
+  method: string;
+  arguments: string[];
+  selector: string;
+}
+
+export interface ActToolResult {
+  success: boolean;
+  action?: string;
+  error?: string;
+  isIframe?: boolean;
+  playwrightArguments?: PlaywrightArguments | null;
+}
+
 export interface AgentAction {
   type: string;
   reasoning?: string;
@@ -10,6 +25,7 @@ export interface AgentAction {
   pageText?: string; // ariaTree tool
   pageUrl?: string; // ariaTree tool
   instruction?: string; // various tools
+  playwrightArguments?: PlaywrightArguments | null; // act tool
   [key: string]: unknown;
 }
 

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -1,18 +1,12 @@
 import { LogLine } from "./log";
-
-export interface PlaywrightArguments {
-  description: string;
-  method: string;
-  arguments: string[];
-  selector: string;
-}
+import { ObserveResult } from "./stagehand";
 
 export interface ActToolResult {
   success: boolean;
   action?: string;
   error?: string;
   isIframe?: boolean;
-  playwrightArguments?: PlaywrightArguments | null;
+  playwrightArguments?: ObserveResult | null;
 }
 
 export interface AgentAction {
@@ -25,7 +19,7 @@ export interface AgentAction {
   pageText?: string; // ariaTree tool
   pageUrl?: string; // ariaTree tool
   instruction?: string; // various tools
-  playwrightArguments?: PlaywrightArguments | null; // act tool
+  playwrightArguments?: ObserveResult | null; // act tool
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
# why

solves #1060 
patch regression of playwright arguments being removed from agent execute response

# what changed

agent.execute now returns playwright arguments in its response 

# test plan

tested locally 


