### PR TITLE
[STG-2673] Added support for client certificates (#1063)

### DIFF
--- a/.changeset/blue-islands-unite.md
+++ b/.changeset/blue-islands-unite.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": major
+---
+
+Add support for client certificates on local envs

--- a/.changeset/icy-toes-obey.md
+++ b/.changeset/icy-toes-obey.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Add playwright arguments to agent execute response

--- a/lib/agent/tools/act.ts
+++ b/lib/agent/tools/act.ts
@@ -1,7 +1,8 @@
 import { tool } from "ai";
 import { z } from "zod/v3";
 import { StagehandPage } from "../../StagehandPage";
-
+import { buildActObservePrompt } from "../../prompt";
+import { SupportedPlaywrightAction } from "@/types/act";
 export const createActTool = (
   stagehandPage: StagehandPage,
   executionModel?: string,
@@ -19,37 +20,91 @@ export const createActTool = (
     }),
     execute: async ({ action }) => {
       try {
-        let result;
-        if (executionModel) {
-          result = await stagehandPage.page.act({
-            action,
-            modelName: executionModel,
-          });
-        } else {
-          result = await stagehandPage.page.act(action);
+        const builtPrompt = buildActObservePrompt(
+          action,
+          Object.values(SupportedPlaywrightAction),
+        );
+
+        const observeOptions = executionModel
+          ? {
+              instruction: builtPrompt,
+              modelName: executionModel,
+            }
+          : {
+              instruction: builtPrompt,
+            };
+
+        const observeResults = await stagehandPage.page.observe(observeOptions);
+
+        if (!observeResults || observeResults.length === 0) {
+          return {
+            success: false,
+            error: "No observable actions found for the given instruction",
+          };
         }
-        const isIframeAction = result.action === "an iframe";
+
+        const observeResult = observeResults[0];
+
+        const isIframeAction = observeResult.description === "an iframe";
 
         if (isIframeAction) {
-          const fallback = await stagehandPage.page.act(
-            executionModel
-              ? { action, modelName: executionModel, iframes: true }
-              : { action, iframes: true },
-          );
+          const iframeObserveOptions = executionModel
+            ? {
+                instruction: builtPrompt,
+                modelName: executionModel,
+                iframes: true,
+              }
+            : {
+                instruction: builtPrompt,
+                iframes: true,
+              };
+
+          const iframeObserveResults =
+            await stagehandPage.page.observe(iframeObserveOptions);
+
+          if (!iframeObserveResults || iframeObserveResults.length === 0) {
+            return {
+              success: false,
+              error: "No observable actions found within iframe context",
+              isIframe: true,
+            };
+          }
+
+          const iframeObserveResult = iframeObserveResults[0];
+          const fallback = await stagehandPage.page.act(iframeObserveResult);
+
           return {
             success: fallback.success,
             action: fallback.action,
             isIframe: true,
+            playwrightArguments: {
+              description: iframeObserveResult.description,
+              method: iframeObserveResult.method,
+              arguments: iframeObserveResult.arguments,
+              selector: iframeObserveResult.selector,
+            },
           };
         }
+
+        const result = await stagehandPage.page.act(observeResult);
+        const playwrightArguments = {
+          description: observeResult.description,
+          method: observeResult.method,
+          arguments: observeResult.arguments,
+          selector: observeResult.selector,
+        };
 
         return {
           success: result.success,
           action: result.action,
           isIframe: false,
+          playwrightArguments,
         };
       } catch (error) {
-        return { success: false, error: error.message };
+        return {
+          success: false,
+          error: error.message,
+        };
       }
     },
   });

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -309,6 +309,7 @@ async function getBrowser(
       handleSIGINT: localBrowserLaunchOptions?.handleSIGINT ?? true,
       handleSIGTERM: localBrowserLaunchOptions?.handleSIGTERM ?? true,
       ignoreDefaultArgs: localBrowserLaunchOptions?.ignoreDefaultArgs,
+      clientCertificates: localBrowserLaunchOptions?.clientCertificates,
     });
 
     if (localBrowserLaunchOptions?.cookies) {

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -1,4 +1,13 @@
 import { LogLine } from "./log";
+import { ObserveResult } from "./stagehand";
+
+export interface ActToolResult {
+  success: boolean;
+  action?: string;
+  error?: string;
+  isIframe?: boolean;
+  playwrightArguments?: ObserveResult | null;
+}
 
 export interface AgentAction {
   type: string;
@@ -10,6 +19,7 @@ export interface AgentAction {
   pageText?: string; // ariaTree tool
   pageUrl?: string; // ariaTree tool
   instruction?: string; // various tools
+  playwrightArguments?: ObserveResult | null; // act tool
   [key: string]: unknown;
 }
 

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -174,6 +174,16 @@ export interface ObserveResult {
 export interface LocalBrowserLaunchOptions {
   args?: string[];
   chromiumSandbox?: boolean;
+  clientCertificates?: Array<{
+      origin: string;
+      certPath?: string;
+      cert?: Buffer;
+      keyPath?: string;
+      key?: Buffer;
+      pfxPath?: string;
+      pfx?: Buffer;
+      passphrase?: string;
+  }>;
   devtools?: boolean;
   env?: Record<string, string | number | boolean>;
   executablePath?: string;

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -175,14 +175,14 @@ export interface LocalBrowserLaunchOptions {
   args?: string[];
   chromiumSandbox?: boolean;
   clientCertificates?: Array<{
-      origin: string;
-      certPath?: string;
-      cert?: Buffer;
-      keyPath?: string;
-      key?: Buffer;
-      pfxPath?: string;
-      pfx?: Buffer;
-      passphrase?: string;
+    origin: string;
+    certPath?: string;
+    cert?: Buffer;
+    keyPath?: string;
+    key?: Buffer;
+    pfxPath?: string;
+    pfx?: Buffer;
+    passphrase?: string;
   }>;
   devtools?: boolean;
   env?: Record<string, string | number | boolean>;


### PR DESCRIPTION
### Contrib from @Samat-Imamov

Issue: https://github.com/browserbase/stagehand/issues/1030

# why
Allowing authentication using provided client certificates during local runs.

# what changed
Additional configuration value 'clientCertificates' that's being passed during Playwright context creation.

# test plan
This is additional support for already existing Playwright feature so Playwright team's internal test for this feature should be enough. But to test locally, provide client certificate config according to this API -
https://playwright.dev/docs/api/class-browser#browser-new-context-option-client-certificates
- and authenticate to whichever service that certificate belongs to.
