### PR TITLE
patch api agent config

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -931,7 +931,7 @@ export class Stagehand {
               : instructionOrOptions;
 
           if (this.usingAPI) {
-            const agentConfigForApi: AgentConfig = options;
+            const agentConfigForApi: AgentConfig = options ?? {};
 
             return await this.apiClient.agentExecute(
               agentConfigForApi,


### PR DESCRIPTION
# why

When a completely empty stagehand config is passed, an error involving integrations is thrown 

# what changed

fallback to empty agent config when options is not present 

# test plan

tested locally 