### PR TITLE
add fillform actions to playwright arguments

### DIFF
--- a/lib/agent/tools/fillform.ts
+++ b/lib/agent/tools/fillform.ts
@@ -60,12 +60,12 @@ export const createFillFormTool = (
           })
         : await stagehandPage.page.observe(instruction);
 
-      const completedActions = [];
-      for (const result of observeResults) {
-        const action = await stagehandPage.page.act(result);
-        completedActions.push(action);
+      for (const observeResult of observeResults) {
+        await stagehandPage.page.act(observeResult);
       }
-
-      return { success: true, actions: completedActions };
+      return {
+        success: true,
+        playwrightArguments: observeResults,
+      };
     },
   });

--- a/lib/agent/utils/actionMapping.ts
+++ b/lib/agent/utils/actionMapping.ts
@@ -1,0 +1,126 @@
+import {
+  AgentAction,
+  ActToolResult,
+  FillFormResult,
+  ActRelatedToolResult,
+  ToolExecutionResult,
+} from "@/types/agent";
+
+// Type guards for better type safety
+function isActRelatedToolResult(
+  result: unknown,
+): result is ActRelatedToolResult {
+  return isActToolResult(result) || isFillFormResult(result);
+}
+
+function isActToolResult(result: unknown): result is ActToolResult {
+  return typeof result === "object" && result !== null && "success" in result;
+}
+
+function isFillFormResult(result: unknown): result is FillFormResult {
+  return (
+    typeof result === "object" &&
+    result !== null &&
+    "success" in result &&
+    "playwrightArguments" in result
+  );
+}
+
+export interface ActionMappingOptions {
+  toolCallName: string;
+  toolResult: ToolExecutionResult | null;
+  args: Record<string, unknown>;
+  reasoning?: string;
+}
+
+export function mapToolResultToActions({
+  toolCallName,
+  toolResult,
+  args,
+  reasoning,
+}: ActionMappingOptions): AgentAction[] {
+  if (toolResult && isActRelatedToolResult(toolResult.result)) {
+    switch (toolCallName) {
+      case "act":
+        return mapActToolResult(toolResult, args, reasoning);
+      case "fillForm":
+        return mapFillFormToolResult(toolResult, args, reasoning);
+    }
+  }
+
+  return [createStandardAction(toolCallName, args, reasoning)];
+}
+
+function mapActToolResult(
+  toolResult: ToolExecutionResult | null,
+  args: Record<string, unknown>,
+  reasoning?: string,
+): AgentAction[] {
+  if (!toolResult || !isActToolResult(toolResult.result)) {
+    return [createStandardAction("act", args, reasoning)];
+  }
+
+  const result = toolResult.result;
+  const playwrightArguments = result.playwrightArguments
+    ? { playwrightArguments: result.playwrightArguments }
+    : {};
+
+  return [
+    {
+      type: "act",
+      reasoning,
+      taskCompleted: false,
+      ...args,
+      ...playwrightArguments,
+    },
+  ];
+}
+
+function mapFillFormToolResult(
+  toolResult: ToolExecutionResult | null,
+  args: Record<string, unknown>,
+  reasoning?: string,
+): AgentAction[] {
+  if (!toolResult || !isFillFormResult(toolResult.result)) {
+    return [createStandardAction("fillForm", args, reasoning)];
+  }
+
+  const fillResult = toolResult.result;
+  const observeResults = Array.isArray(fillResult.playwrightArguments)
+    ? fillResult.playwrightArguments
+    : [];
+
+  const actions: AgentAction[] = [];
+
+  actions.push({
+    type: "fillForm",
+    reasoning,
+    taskCompleted: false,
+    ...args,
+  });
+
+  for (const observeResult of observeResults) {
+    actions.push({
+      type: "act",
+      reasoning: "acting from fillform tool",
+      taskCompleted: false,
+      playwrightArguments: observeResult,
+    });
+  }
+
+  return actions;
+}
+
+function createStandardAction(
+  toolCallName: string,
+  args: Record<string, unknown>,
+  reasoning?: string,
+): AgentAction {
+  return {
+    type: toolCallName,
+    reasoning,
+    taskCompleted:
+      toolCallName === "close" ? (args?.taskComplete as boolean) : false,
+    ...args,
+  };
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -925,20 +925,6 @@ export class Stagehand {
             );
           }
 
-          const executeOptions: AgentExecuteOptions =
-            typeof instructionOrOptions === "string"
-              ? { instruction: instructionOrOptions }
-              : instructionOrOptions;
-
-          if (this.usingAPI) {
-            const agentConfigForApi: AgentConfig = options;
-
-            return await this.apiClient.agentExecute(
-              agentConfigForApi,
-              executeOptions,
-            );
-          }
-
           const tools = options?.integrations
             ? await resolveTools(options?.integrations, options?.tools)
             : (options?.tools ?? {});
@@ -949,7 +935,7 @@ export class Stagehand {
             executionModel,
             systemInstructions,
             tools,
-          ).execute(executeOptions);
+          ).execute(instructionOrOptions);
         },
       };
     }

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -9,6 +9,17 @@ export interface ActToolResult {
   playwrightArguments?: ObserveResult | null;
 }
 
+export interface FillFormResult {
+  success: boolean;
+  playwrightArguments: ObserveResult[];
+}
+
+export type ActRelatedToolResult = ActToolResult | FillFormResult;
+// generic type for tool results to avoid need for an individual type for each tool
+export interface ToolExecutionResult {
+  result: unknown;
+}
+
 export interface AgentAction {
   type: string;
   reasoning?: string;


### PR DESCRIPTION
# why

Currently, we do not return playwright actions from agents fillform tool 

# what changed

fillforms observe results are now spread into individual actions in the agents response, each containing its respective action within the playwright arguments

# test plan
tested locally 
