### PR TITLE
[docs] add aisdk workaround before npm release + add versions to work with LanguageModelV1

### DIFF
--- a/docs/configuration/models.mdx
+++ b/docs/configuration/models.mdx
@@ -166,7 +166,7 @@ The [Vercel AI SDK](https://sdk.vercel.ai/providers/ai-sdk-providers) is a popul
 
 Vercel AI SDK supports providers for OpenAI, Anthropic, and Google, along with support for **Amazon Bedrock** and **Azure OpenAI**. For a full list, see the [Vercel AI SDK providers page](https://sdk.vercel.ai/providers/ai-sdk-providers).
 
-To get started, you'll need to install the `ai` package (version 4) and the provider you want to use (version 1) - both need to be compatible with LanguageModelV1. For example, to use Amazon Bedrock, you'll need to install the `@ai-sdk/amazon-bedrock` package.
+To get started, you'll need to install the `ai` package (version 4) and the provider you want to use (version 1 - both need to be compatible with LanguageModelV1). For example, to use Amazon Bedrock, you'll need to install the `@ai-sdk/amazon-bedrock` package.
 
 You'll also need to import the [Vercel AI SDK external client](https://github.com/browserbase/stagehand/blob/main/lib/llm/aisdk.ts) through Stagehand to create a client for your model.
 

--- a/docs/configuration/models.mdx
+++ b/docs/configuration/models.mdx
@@ -164,11 +164,11 @@ Integrate any LLM with Stagehand using custom clients. The only requirement is *
 ### Vercel AI SDK
 The [Vercel AI SDK](https://sdk.vercel.ai/providers/ai-sdk-providers) is a popular library for interacting with LLMs. You can use any of the providers supported by the Vercel AI SDK to create a client for your model, **as long as they support structured outputs**.
 
-Vercel AI SDK supports providers for OpenAI, Anthropic, and Google, along with support for **Amazon Bedrock** and **Azure OpenAI**.
+Vercel AI SDK supports providers for OpenAI, Anthropic, and Google, along with support for **Amazon Bedrock** and **Azure OpenAI**. For a full list, see the [Vercel AI SDK providers page](https://sdk.vercel.ai/providers/ai-sdk-providers).
 
 To get started, you'll need to install the `ai` package and the provider you want to use. For example, to use Amazon Bedrock, you'll need to install the `@ai-sdk/amazon-bedrock` package.
 
-You'll also need to import the [Vercel AI SDK external client](https://github.com/browserbase/stagehand/blob/main/lib/llm/aisdk.ts) which is exposed as `AISdkClient` to create a client for your model.
+You'll also need to import the [Vercel AI SDK external client](https://github.com/browserbase/stagehand/blob/main/lib/llm/aisdk.ts) through Stagehand to create a client for your model.
 
 <Tabs>
 	<Tab title="npm">
@@ -190,13 +190,35 @@ You'll also need to import the [Vercel AI SDK external client](https://github.co
 	</Tab>
 </Tabs>
 
-To get started, you can use the [Vercel AI SDK external client](https://github.com/browserbase/stagehand/blob/main/lib/llm/aisdk.ts) which is exposed as `AISdkClient` to create a client for your model.
+<Note>
+The `AISdkClient` is not yet available in the Stagehand npm package. For now, install Stagehand as a dependency to access the `AISdkClient` (this will be included in the npm package in an upcoming release).
+</Note>
+
+<Tabs>
+	<Tab title="npm">
+	```bash
+	npm install @browserbasehq/stagehand
+	```
+	</Tab>
+
+	<Tab title="pnpm">
+	```bash
+	pnpm install @browserbasehq/stagehand
+	```
+	</Tab>
+
+	<Tab title="yarn">
+	```bash
+	yarn add @browserbasehq/stagehand
+	```
+	</Tab>
+</Tabs>
 
 ```ts
 // Install/import the provider you want to use.
-// For example, to use OpenAI, import `openai` from @ai-sdk/openai
+// For example, to use Azure OpenAI, import { createAzure } from '@ai-sdk/azure';
 import { bedrock } from "@ai-sdk/amazon-bedrock";
-import { AISdkClient } from "@browserbasehq/stagehand";
+import { AISdkClient } from "@browserbasehq/stagehand/lib/llm/aisdk";
 
 const stagehand = new Stagehand({
   llmClient: new AISdkClient({

--- a/docs/configuration/models.mdx
+++ b/docs/configuration/models.mdx
@@ -166,50 +166,50 @@ The [Vercel AI SDK](https://sdk.vercel.ai/providers/ai-sdk-providers) is a popul
 
 Vercel AI SDK supports providers for OpenAI, Anthropic, and Google, along with support for **Amazon Bedrock** and **Azure OpenAI**. For a full list, see the [Vercel AI SDK providers page](https://sdk.vercel.ai/providers/ai-sdk-providers).
 
-To get started, you'll need to install the `ai` package and the provider you want to use. For example, to use Amazon Bedrock, you'll need to install the `@ai-sdk/amazon-bedrock` package.
+To get started, you'll need to install the `ai` package (version 4) and the provider you want to use (version 1) - both need to be compatible with LanguageModelV1. For example, to use Amazon Bedrock, you'll need to install the `@ai-sdk/amazon-bedrock` package.
 
 You'll also need to import the [Vercel AI SDK external client](https://github.com/browserbase/stagehand/blob/main/lib/llm/aisdk.ts) through Stagehand to create a client for your model.
 
 <Tabs>
 	<Tab title="npm">
 	```bash
-	npm install ai @ai-sdk/amazon-bedrock
+	npm install ai@4 @ai-sdk/amazon-bedrock@1
 	```
 	</Tab>
 
 	<Tab title="pnpm">
 	```bash
-	pnpm install ai @ai-sdk/amazon-bedrock
+	pnpm install ai@4 @ai-sdk/amazon-bedrock@1
 	```
 	</Tab>
 
 	<Tab title="yarn">
 	```bash
-	yarn add ai @ai-sdk/amazon-bedrock
+	yarn add ai@4 @ai-sdk/amazon-bedrock@1
 	```
 	</Tab>
 </Tabs>
 
 <Note>
-The `AISdkClient` is not yet available in the Stagehand npm package. For now, install Stagehand as a dependency to access the `AISdkClient` (this will be included in the npm package in an upcoming release).
+The `AISdkClient` is not yet available via the Stagehand npm package. For now, install Stagehand as a git repository to access the `AISdkClient` (this will be included in the npm package in an upcoming release).
 </Note>
 
 <Tabs>
 	<Tab title="npm">
 	```bash
-	npm install @browserbasehq/stagehand
+	npm install @browserbasehq/stagehand@git+https://github.com/browserbase/stagehand.git
 	```
 	</Tab>
 
 	<Tab title="pnpm">
 	```bash
-	pnpm install @browserbasehq/stagehand
+	pnpm install @browserbasehq/stagehand@git+https://github.com/browserbase/stagehand.git
 	```
 	</Tab>
 
 	<Tab title="yarn">
 	```bash
-	yarn add @browserbasehq/stagehand
+	yarn add @browserbasehq/stagehand@git+https://github.com/browserbase/stagehand.git
 	```
 	</Tab>
 </Tabs>
@@ -218,7 +218,8 @@ The `AISdkClient` is not yet available in the Stagehand npm package. For now, in
 // Install/import the provider you want to use.
 // For example, to use Azure OpenAI, import { createAzure } from '@ai-sdk/azure';
 import { bedrock } from "@ai-sdk/amazon-bedrock";
-import { AISdkClient } from "@browserbasehq/stagehand/lib/llm/aisdk";
+// @ts-ignore
+import { AISdkClient } from "@browserbasehq/stagehand";
 
 const stagehand = new Stagehand({
   llmClient: new AISdkClient({


### PR DESCRIPTION
# why

1. aisdk not yet available through npm package
2. customLLM provider only works with LanguageModelV1

# what changed

1. change docs to install stagehand from git repo
2. pin versions that use LanguageModelV1

# test plan

local test