### PR TITLE
Fix session create logs on api

### DIFF
--- a/.changeset/purple-squids-know.md
+++ b/.changeset/purple-squids-know.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Fixed info logs on api session create

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -68,6 +68,11 @@ export class StagehandAPI {
     if (region && region !== "us-west-2") {
       return { sessionId: browserbaseSessionID ?? null, available: false };
     }
+    this.logger({
+      category: "init",
+      message: "creating new browserbase session...",
+      level: 1,
+    });
     const sessionResponse = await this.request("/sessions/start", {
       method: "POST",
       body: JSON.stringify({


### PR DESCRIPTION
# why
On `env:BROWSERBASE` session create logs are confusing. They start by saying `resuming session...`, instead of `creating new session...`

# what changed
Added a log in session init saying `creating new browserbase session`

# test plan
