### PR TITLE
Improve failed act logs

### DIFF
--- a/.changeset/tasty-candles-retire.md
+++ b/.changeset/tasty-candles-retire.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Improve failed act error logs

--- a/lib/handlers/actHandler.ts
+++ b/lib/handlers/actHandler.ts
@@ -163,7 +163,7 @@ export class StagehandActHandler {
         if (observeResults.length === 0) {
           return {
             success: false,
-            message: `Failed to self heal act: No observe results found for action`,
+            message: `Failed to self heal act: Element not found.`,
             action: actCommand,
           };
         }
@@ -264,9 +264,15 @@ export class StagehandActHandler {
       });
 
       if (observeResults.length === 0) {
+        this.logger({
+          category: "action",
+          message:
+            "No elements found to act on. Check best practices for act: https://docs.stagehand.com/basics/act",
+          level: 2,
+        });
         return {
           success: false,
-          message: `Failed to perform act: No observe results found for action`,
+          message: `Failed to perform act: No elements found to act on.`,
           action,
         };
       }


### PR DESCRIPTION
# why
The current log `No Observe Results found` is too vague and uninformative. 

# what changed
Updated the logs on failed self healing and failing to observe in act; with a link to act best practices in the docs. 

# test plan
