### PR TITLE
properly convert custom / mcp tools to anthropic cua format

### DIFF
--- a/.changeset/short-mirrors-switch.md
+++ b/.changeset/short-mirrors-switch.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+patch custom tool support in anthropic cua client


### PR DESCRIPTION
Why

Custom AI SDK tools and MCP integrations weren't working properly with Anthropic CUA - parameters were empty {} and tools weren't tracked.

What Changed


- Convert Zod schemas to JSON Schema before sending to Anthropic (using zodToJsonSchema)
- Track custom tool calls in the actions array
- Silence "Unknown tool name" warnings for custom tools

Test Plan

Tested with examples file. 

Parameters passed correctly ({"city":"San Francisco"} instead of {})
Custom tools execute and appear in actions array
No warnings