### PR TITLE
Support for new Gemini Computer Use Models

### DIFF
--- a/.changeset/wicked-ducks-share.md
+++ b/.changeset/wicked-ducks-share.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Add support for new Gemini Computer Use models

--- a/examples/cua-example.ts
+++ b/examples/cua-example.ts
@@ -29,7 +29,7 @@ async function main() {
       provider: "google",
       // For Anthropic, use claude-sonnet-4-20250514 or claude-sonnet-4-5-20250929
       // For OpenAI, use computer-use-preview-03-11
-      model: "computer-use-preview-10-2025",
+      model: "gemini-2.5-computer-use-preview-10-2025",
       instructions: `You are a helpful assistant that can use a web browser.
       You are currently on the following page: ${page.url()}.
       Do not ask follow up questions, the user will trust your judgement.`,

--- a/examples/cua-example.ts
+++ b/examples/cua-example.ts
@@ -18,8 +18,6 @@ async function main() {
   // Initialize Stagehand
   const stagehand = new Stagehand({
     ...StagehandConfig,
-    // useAPI: false
-    env: "LOCAL",
   });
   await stagehand.init();
 

--- a/examples/cua-example.ts
+++ b/examples/cua-example.ts
@@ -18,6 +18,8 @@ async function main() {
   // Initialize Stagehand
   const stagehand = new Stagehand({
     ...StagehandConfig,
+    // useAPI: false
+    env: "LOCAL",
   });
   await stagehand.init();
 

--- a/examples/cua-example.ts
+++ b/examples/cua-example.ts
@@ -26,14 +26,15 @@ async function main() {
 
     // Create a computer use agent
     const agent = stagehand.agent({
-      provider: "openai",
-      // For Anthropic, use claude-sonnet-4-20250514 or claude-3-7-sonnet-latest
-      model: "computer-use-preview",
+      provider: "google",
+      // For Anthropic, use claude-sonnet-4-20250514 or claude-sonnet-4-5-20250929
+      // For OpenAI, use computer-use-preview-03-11
+      model: "computer-use-preview-10-2025",
       instructions: `You are a helpful assistant that can use a web browser.
       You are currently on the following page: ${page.url()}.
       Do not ask follow up questions, the user will trust your judgement.`,
       options: {
-        apiKey: process.env.OPENAI_API_KEY,
+        apiKey: process.env.GOOGLE_API_KEY,
       },
     });
 

--- a/lib/agent/AgentProvider.ts
+++ b/lib/agent/AgentProvider.ts
@@ -8,6 +8,7 @@ import { ToolSet } from "ai/dist";
 import { AgentClient } from "./AgentClient";
 import { AnthropicCUAClient } from "./AnthropicCUAClient";
 import { OpenAICUAClient } from "./OpenAICUAClient";
+import { GoogleCUAClient } from "./GoogleCUAClient";
 
 // Map model names to their provider types
 export const modelToAgentProviderMap: Record<string, AgentType> = {
@@ -16,6 +17,7 @@ export const modelToAgentProviderMap: Record<string, AgentType> = {
   "claude-3-7-sonnet-latest": "anthropic",
   "claude-sonnet-4-20250514": "anthropic",
   "claude-sonnet-4-5-20250929": "anthropic",
+  "computer-use-preview-10-2025": "google",
 };
 
 /**
@@ -64,9 +66,16 @@ export class AgentProvider {
             clientOptions,
             tools,
           );
+        case "google":
+          return new GoogleCUAClient(
+            type,
+            modelName,
+            userProvidedInstructions,
+            clientOptions,
+          );
         default:
           throw new UnsupportedModelProviderError(
-            ["openai", "anthropic"],
+            ["openai", "anthropic", "google"],
             "Computer Use Agent",
           );
       }

--- a/lib/agent/AgentProvider.ts
+++ b/lib/agent/AgentProvider.ts
@@ -17,7 +17,7 @@ export const modelToAgentProviderMap: Record<string, AgentType> = {
   "claude-3-7-sonnet-latest": "anthropic",
   "claude-sonnet-4-20250514": "anthropic",
   "claude-sonnet-4-5-20250929": "anthropic",
-  "computer-use-preview-10-2025": "google",
+  "gemini-2.5-computer-use-preview-10-2025": "google",
 };
 
 /**

--- a/lib/agent/AnthropicCUAClient.ts
+++ b/lib/agent/AnthropicCUAClient.ts
@@ -290,7 +290,7 @@ export class AnthropicCUAClient extends AgentClient {
 
           logger({
             category: "agent",
-            message: `Found text block: ${textBlock.text.substring(0, 50)}...`,
+            message: `Found text block: ${textBlock.text}`,
             level: 2,
           });
         } else {

--- a/lib/agent/AnthropicCUAClient.ts
+++ b/lib/agent/AnthropicCUAClient.ts
@@ -29,7 +29,7 @@ export class AnthropicCUAClient extends AgentClient {
   private baseURL?: string;
   private client: Anthropic;
   public lastMessageId?: string;
-  private currentViewport = { width: 1024, height: 768 };
+  private currentViewport = { width: 1288, height: 711 };
   private currentUrl?: string;
   private screenshotProvider?: () => Promise<string>;
   private actionHandler?: (action: AgentAction) => Promise<void>;

--- a/lib/agent/GoogleCUAClient.ts
+++ b/lib/agent/GoogleCUAClient.ts
@@ -1,0 +1,820 @@
+import {
+  GoogleGenAI,
+  Content,
+  Part,
+  GenerateContentResponse,
+  FunctionCall,
+  GenerateContentConfig,
+  Tool,
+} from "@google/genai";
+import { LogLine } from "../../types/log";
+import {
+  AgentAction,
+  AgentResult,
+  AgentType,
+  AgentExecutionOptions,
+} from "@/types/agent";
+import { AgentClient } from "./AgentClient";
+import { AgentScreenshotProviderError } from "@/types/stagehandErrors";
+import { buildGoogleCUASystemPrompt } from "@/lib/prompt";
+import { compressGoogleConversationImages } from "./utils/imageCompression";
+import { mapKeyToPlaywright } from "./utils/cuaKeyMapping";
+
+/**
+ * Client for Google's Computer Use Assistant API
+ * This implementation uses the Google Generative AI SDK for Computer Use
+ */
+export class GoogleCUAClient extends AgentClient {
+  private apiKey: string;
+  private client: GoogleGenAI;
+  private currentViewport = { width: 1288, height: 711 };
+  private currentUrl?: string;
+  private screenshotProvider?: () => Promise<string>;
+  private actionHandler?: (action: AgentAction) => Promise<void>;
+  private history: Content[] = [];
+  private environment: "ENVIRONMENT_BROWSER" | "ENVIRONMENT_DESKTOP" =
+    "ENVIRONMENT_BROWSER";
+  private generateContentConfig: GenerateContentConfig;
+
+  constructor(
+    type: AgentType,
+    modelName: string,
+    userProvidedInstructions?: string,
+    clientOptions?: Record<string, unknown>,
+  ) {
+    super(type, modelName, userProvidedInstructions);
+
+    // Process client options
+    this.apiKey =
+      (clientOptions?.apiKey as string) || process.env.GEMINI_API_KEY || "";
+
+    // Initialize the Google Generative AI client
+    this.client = new GoogleGenAI({
+      apiKey: this.apiKey,
+    });
+
+    // Get environment if specified
+    if (
+      clientOptions?.environment &&
+      typeof clientOptions.environment === "string"
+    ) {
+      this.environment = clientOptions.environment as typeof this.environment;
+    }
+
+    // Initialize the generation config (similar to Python's _generate_content_config)
+    this.generateContentConfig = {
+      temperature: 1,
+      topP: 0.95,
+      topK: 40,
+      maxOutputTokens: 8192,
+      // systemInstruction: this.userProvidedInstructions
+      //   ? { parts: [{ text: this.userProvidedInstructions }] }
+      //   : { parts: [{ text: buildGoogleCUASystemPrompt() }] },
+      tools: [
+        {
+          computerUse: {
+            environment: this.environment,
+          },
+        } as Tool,
+      ],
+    };
+
+    // Store client options for reference
+    this.clientOptions = {
+      apiKey: this.apiKey,
+    };
+  }
+
+  public setViewport(width: number, height: number): void {
+    this.currentViewport = { width, height };
+  }
+
+  setCurrentUrl(url: string): void {
+    this.currentUrl = url;
+  }
+
+  setScreenshotProvider(provider: () => Promise<string>): void {
+    this.screenshotProvider = provider;
+  }
+
+  setActionHandler(handler: (action: AgentAction) => Promise<void>): void {
+    this.actionHandler = handler;
+  }
+
+  setTools(): void {
+    // TODO: need to convert and pass custom tools to the client
+  }
+
+  /**
+   * Execute a task with the Google CUA
+   * This is the main entry point for the agent
+   * @implements AgentClient.execute
+   */
+  async execute(executionOptions: AgentExecutionOptions): Promise<AgentResult> {
+    const { options, logger } = executionOptions;
+    const { instruction } = options;
+    const maxSteps = options.maxSteps || 10;
+
+    let currentStep = 0;
+    let completed = false;
+    const actions: AgentAction[] = [];
+    const messageList: string[] = [];
+    let finalMessage = "";
+    this.history = []; // Clear history for new execution
+
+    // Start with the initial instruction
+    await this.initializeHistory(instruction);
+
+    let totalInputTokens = 0;
+    let totalOutputTokens = 0;
+    let totalInferenceTime = 0;
+
+    try {
+      // Execute steps until completion or max steps reached
+      while (!completed && currentStep < maxSteps) {
+        logger({
+          category: "agent",
+          message: `Executing step ${currentStep + 1}/${maxSteps}`,
+          level: 2,
+        });
+
+        const result = await this.executeStep(logger);
+        totalInputTokens += result.usage.input_tokens;
+        totalOutputTokens += result.usage.output_tokens;
+        totalInferenceTime += result.usage.inference_time_ms;
+
+        // Add actions to the list
+        actions.push(...result.actions);
+
+        // Update completion status
+        completed = result.completed;
+
+        // Record any message for this step
+        if (result.message) {
+          messageList.push(result.message);
+          finalMessage = result.message;
+        }
+
+        // Increment step counter
+        currentStep++;
+      }
+
+      // Return the final result
+      return {
+        success: completed,
+        actions,
+        message: finalMessage,
+        completed,
+        usage: {
+          input_tokens: totalInputTokens,
+          output_tokens: totalOutputTokens,
+          inference_time_ms: totalInferenceTime,
+        },
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      logger({
+        category: "agent",
+        message: `Error executing agent task: ${errorMessage}`,
+        level: 0,
+      });
+
+      return {
+        success: false,
+        actions,
+        message: `Failed to execute task: ${errorMessage}`,
+        completed: false,
+        usage: {
+          input_tokens: totalInputTokens,
+          output_tokens: totalOutputTokens,
+          inference_time_ms: totalInferenceTime,
+        },
+      };
+    }
+  }
+
+  /**
+   * Initialize conversation history with the initial instruction
+   */
+  private async initializeHistory(instruction: string): Promise<void> {
+    const parts: Part[] = [{ text: instruction }];
+
+    // Note: The Python implementation doesn't include the initial screenshot
+    // Following the same pattern here
+
+    this.history = [
+      {
+        role: "user",
+        parts: [
+          {
+            text:
+              "System prompt: " +
+              (buildGoogleCUASystemPrompt().content as string),
+          },
+        ],
+      },
+      {
+        role: "user",
+        parts,
+      },
+    ];
+  }
+
+  /**
+   * Execute a single step of the agent
+   */
+  async executeStep(logger: (message: LogLine) => void): Promise<{
+    actions: AgentAction[];
+    message: string;
+    completed: boolean;
+    usage: {
+      input_tokens: number;
+      output_tokens: number;
+      inference_time_ms: number;
+    };
+  }> {
+    try {
+      const startTime = Date.now();
+
+      // Compress images in conversation history before sending to the model
+      const compressedResult = compressGoogleConversationImages(
+        this.history,
+        2,
+      );
+      const compressedHistory = compressedResult.items;
+
+      // Use the SDK's generateContent method with retry logic (matching Python's get_model_response)
+      const maxRetries = 5;
+      const baseDelayS = 1;
+      let lastError: Error | null = null;
+      let response: GenerateContentResponse | null = null;
+
+      for (let attempt = 0; attempt < maxRetries; attempt++) {
+        try {
+          // Add exponential backoff delay for retries
+          if (attempt > 0) {
+            const delay = baseDelayS * Math.pow(2, attempt) * 1000; // Convert to ms
+            logger({
+              category: "agent",
+              message: `Generating content failed on attempt ${attempt + 1}. Retrying in ${delay / 1000} seconds...`,
+              level: 2,
+            });
+            await new Promise((resolve) => setTimeout(resolve, delay));
+          }
+
+          // Use the SDK's generateContent method - following Python SDK pattern
+          response = await this.client.models.generateContent({
+            model: this.modelName,
+            contents: compressedHistory,
+            config: this.generateContentConfig,
+          });
+
+          // Check if we have valid response content
+          if (!response.candidates || response.candidates.length === 0) {
+            throw new Error("Response has no candidates!");
+          }
+
+          // Success - we have a valid response
+          break;
+        } catch (error) {
+          lastError = error instanceof Error ? error : new Error(String(error));
+          logger({
+            category: "agent",
+            message: `API call error: ${lastError.message}`,
+            level: 2,
+          });
+
+          // If this was the last attempt, throw the error
+          if (attempt === maxRetries - 1) {
+            logger({
+              category: "agent",
+              message: `Generating content failed after ${maxRetries} attempts.`,
+              level: 0,
+            });
+            throw lastError;
+          }
+        }
+      }
+
+      if (!response) {
+        throw (
+          lastError || new Error("Failed to get response after all retries")
+        );
+      }
+
+      const endTime = Date.now();
+      const elapsedMs = endTime - startTime;
+      const { usageMetadata } = response;
+
+      // Process the response
+      const result = await this.processResponse(response, logger);
+
+      // Add model response to history
+      if (response.candidates && response.candidates[0]) {
+        // Sanitize any out-of-range coordinates in function calls before adding to history
+        const sanitizedContent = JSON.parse(
+          JSON.stringify(response.candidates[0].content),
+        );
+        if (sanitizedContent.parts) {
+          for (const part of sanitizedContent.parts) {
+            if (part.functionCall?.args) {
+              if (
+                typeof part.functionCall.args.x === "number" &&
+                part.functionCall.args.x > 999
+              ) {
+                part.functionCall.args.x = 999;
+              }
+              if (
+                typeof part.functionCall.args.y === "number" &&
+                part.functionCall.args.y > 999
+              ) {
+                part.functionCall.args.y = 999;
+              }
+            }
+          }
+        }
+        this.history.push(sanitizedContent);
+      }
+
+      // Execute actions and collect function responses
+      const functionResponses: Part[] = [];
+
+      if (result.actions.length > 0) {
+        let hasError = false;
+
+        // Execute all actions
+        for (let i = 0; i < result.actions.length; i++) {
+          const action = result.actions[i];
+
+          logger({
+            category: "agent",
+            message: `Executing action ${i + 1}/${result.actions.length}: ${action.type}`,
+            level: 2,
+          });
+
+          // Special handling for open_web_browser - don't execute it
+          if (
+            action.type === "function" &&
+            action.name === "open_web_browser"
+          ) {
+            logger({
+              category: "agent",
+              message: "Skipping open_web_browser action",
+              level: 2,
+            });
+          } else if (this.actionHandler) {
+            try {
+              await this.actionHandler(action);
+
+              // Add a delay between actions to ensure they complete properly
+              // Longer delay for typing actions to ensure fields are ready
+              if (i < result.actions.length - 1) {
+                const nextAction = result.actions[i + 1];
+                const isTypingAction =
+                  action.type === "type" || nextAction.type === "type";
+                const delay = isTypingAction ? 500 : 200;
+                await new Promise((resolve) => setTimeout(resolve, delay));
+              }
+            } catch (actionError) {
+              logger({
+                category: "agent",
+                message: `Error executing action ${action.type}: ${actionError}`,
+                level: 0,
+              });
+              hasError = true;
+              // Continue processing other actions even if one fails
+            }
+          }
+        }
+
+        // Create function responses - one for each function call
+        // We need exactly one response per function call, regardless of how many actions were generated
+        if (result.functionCalls.length > 0 || hasError) {
+          try {
+            logger({
+              category: "agent",
+              message: `Taking screenshot after executing ${result.actions.length} actions${hasError ? " (with errors)" : ""}`,
+              level: 2,
+            });
+
+            const screenshot = await this.captureScreenshot();
+            const base64Data = screenshot.replace(
+              /^data:image\/png;base64,/,
+              "",
+            );
+
+            // Create one function response for each function call
+            // Following Python SDK pattern: FunctionResponse with parts containing inline_data
+            for (const functionCall of result.functionCalls) {
+              const functionResponsePart: Part = {
+                functionResponse: {
+                  name: functionCall.name,
+                  response: {
+                    url: this.currentUrl || "",
+                    // Acknowledge safety decision for evals
+                    ...(functionCall.args?.safety_decision
+                      ? {
+                          safety_acknowledgement: "true",
+                        }
+                      : {}),
+                  },
+                  parts: [
+                    {
+                      inlineData: {
+                        mimeType: "image/png",
+                        data: base64Data,
+                      },
+                    },
+                  ],
+                },
+              };
+              functionResponses.push(functionResponsePart);
+            }
+          } catch (error) {
+            logger({
+              category: "agent",
+              message: `Error capturing screenshot: ${error}`,
+              level: 0,
+            });
+          }
+        }
+
+        // Add all function responses to history in a single user message
+        if (functionResponses.length > 0) {
+          logger({
+            category: "agent",
+            message: `Adding ${functionResponses.length} function responses to history`,
+            level: 2,
+          });
+          this.history.push({
+            role: "user",
+            parts: functionResponses,
+          });
+        }
+      }
+
+      return {
+        actions: result.actions,
+        message: result.message,
+        completed: result.completed,
+        usage: {
+          input_tokens: usageMetadata?.promptTokenCount || 0,
+          output_tokens: usageMetadata?.candidatesTokenCount || 0,
+          inference_time_ms: elapsedMs,
+        },
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      logger({
+        category: "agent",
+        message: `Error executing step: ${errorMessage}`,
+        level: 0,
+      });
+
+      throw error;
+    }
+  }
+
+  /**
+   * Process the response from Google's API
+   */
+  private async processResponse(
+    response: GenerateContentResponse,
+    logger: (message: LogLine) => void,
+  ): Promise<{
+    actions: AgentAction[];
+    message: string;
+    completed: boolean;
+    functionCalls: FunctionCall[];
+  }> {
+    const actions: AgentAction[] = [];
+    let message = "";
+    const functionCalls: FunctionCall[] = [];
+
+    if (!response.candidates || response.candidates.length === 0) {
+      return {
+        actions: [],
+        message: "No candidates in response",
+        completed: true,
+        functionCalls: [],
+      };
+    }
+    const candidate = response.candidates[0];
+
+    // Log the raw response for debugging
+    logger({
+      category: "agent",
+      message: `Raw response from Google: ${JSON.stringify(candidate.content, null, 2)}`,
+      level: 2,
+    });
+
+    // Process all parts - Google can send multiple function calls
+    for (const part of candidate.content.parts) {
+      if (part.text) {
+        message += part.text + "\n";
+        logger({
+          category: "agent",
+          message: `Reasoning: ${part.text}`,
+          level: 1,
+        });
+      }
+      if (part.functionCall) {
+        functionCalls.push(part.functionCall);
+        logger({
+          category: "agent",
+          message: `Found function call: ${part.functionCall.name} with args: ${JSON.stringify(part.functionCall.args)}`,
+          level: 2,
+        });
+
+        // Convert function call to action(s)
+        const action = this.convertFunctionCallToAction(part.functionCall);
+        if (action) {
+          // Special handling for type_text_at - we need to click first
+          if (
+            part.functionCall.name === "type_text_at" &&
+            action.type === "type"
+          ) {
+            logger({
+              category: "agent",
+              message: `Adding action: ${JSON.stringify(action)}`,
+              level: 2,
+            });
+            // First add a click action at the same coordinates
+            actions.push({
+              type: "click",
+              x: action.x,
+              y: action.y,
+              button: "left",
+            });
+
+            // If clear_before_typing is true (default), add a select all
+            if (action.clearBeforeTyping) {
+              // Select all text in the field
+              actions.push({
+                type: "keypress",
+                keys: ["ControlOrMeta+A"],
+              });
+              actions.push({
+                type: "keypress",
+                keys: ["Backspace"],
+              });
+            }
+
+            // Then add the type action
+            actions.push(action);
+            if (action.pressEnter) {
+              actions.push({
+                type: "keypress",
+                keys: ["Enter"],
+              });
+            }
+          } else {
+            actions.push(action);
+          }
+        } else {
+          logger({
+            category: "agent",
+            message: `Warning: Could not convert function call ${part.functionCall.name} to action`,
+            level: 1,
+          });
+        }
+      }
+    }
+
+    // Log summary of what we found
+    logger({
+      category: "agent",
+      message: `Found ${functionCalls.length} function calls, converted to ${actions.length} actions`,
+      level: 2,
+    });
+
+    // Check if task is completed
+    const completed =
+      functionCalls.length === 0 ||
+      (candidate.finishReason && candidate.finishReason !== "STOP");
+
+    return {
+      actions,
+      message: message.trim(),
+      completed,
+      functionCalls,
+    };
+  }
+
+  /**
+   * Convert Google function call to Stagehand action
+   */
+  private convertFunctionCallToAction(
+    functionCall: FunctionCall,
+  ): AgentAction | null {
+    const { name, args } = functionCall;
+
+    if (!name || !args) {
+      return null;
+    }
+
+    switch (name) {
+      case "open_web_browser":
+        return {
+          type: "function",
+          name: "open_web_browser",
+          arguments: null,
+        };
+
+      case "click_at": {
+        const { x, y } = this.normalizeCoordinates(
+          args.x as number,
+          args.y as number,
+        );
+        return {
+          type: "click",
+          x,
+          y,
+          button: args.button || "left",
+        };
+      }
+
+      case "type_text_at": {
+        const { x, y } = this.normalizeCoordinates(
+          args.x as number,
+          args.y as number,
+        );
+        // Google's type_text_at includes press_enter and clear_before_typing parameters
+        const pressEnter = (args.press_enter as boolean) ?? false;
+        const clearBeforeTyping = (args.clear_before_typing as boolean) ?? true;
+
+        // For type_text_at, we need to click first then type
+        // This matches the behavior expected by Google's CUA
+        // We'll handle this in the executeStep method by converting to two actions
+        return {
+          type: "type",
+          text: args.text as string,
+          x,
+          y,
+          pressEnter,
+          clearBeforeTyping,
+        };
+      }
+
+      case "key_combination": {
+        const keys = (args.keys as string)
+          .split("+")
+          .map((key: string) => key.trim())
+          .map((key: string) => mapKeyToPlaywright(key));
+        return {
+          type: "keypress",
+          keys,
+        };
+      }
+
+      case "scroll_document": {
+        const direction = (args.direction as string).toLowerCase();
+        return {
+          type: "keypress",
+          keys: [direction === "up" ? "PageUp" : "PageDown"],
+        };
+      }
+
+      case "scroll_at": {
+        const { x, y } = this.normalizeCoordinates(
+          args.x as number,
+          args.y as number,
+        );
+        const direction = ((args.direction as string) || "down").toLowerCase();
+        const magnitude =
+          typeof args.magnitude === "number" ? (args.magnitude as number) : 800;
+
+        let scroll_x = 0;
+        let scroll_y = 0;
+        if (direction === "up") {
+          scroll_y = -magnitude;
+        } else if (direction === "down") {
+          scroll_y = magnitude;
+        } else if (direction === "left") {
+          scroll_x = -magnitude;
+        } else if (direction === "right") {
+          scroll_x = magnitude;
+        } else {
+          // Default to down if unknown direction
+          scroll_y = magnitude;
+        }
+
+        return {
+          type: "scroll",
+          x,
+          y,
+          scroll_x,
+          scroll_y,
+        };
+      }
+
+      case "navigate":
+        return {
+          type: "function",
+          name: "goto",
+          arguments: { url: args.url as string },
+        };
+
+      case "go_back":
+        return {
+          type: "function",
+          name: "back",
+          arguments: null,
+        };
+
+      case "go_forward":
+        return {
+          type: "function",
+          name: "forward",
+          arguments: null,
+        };
+
+      case "wait_5_seconds":
+        return {
+          type: "wait",
+          milliseconds: 5000, // Google CUA waits for 5 seconds
+        };
+
+      case "hover_at": {
+        const { x, y } = this.normalizeCoordinates(
+          args.x as number,
+          args.y as number,
+        );
+        return {
+          type: "move",
+          x,
+          y,
+        };
+      }
+
+      case "search":
+        return {
+          type: "function",
+          name: "goto",
+          arguments: { url: "https://www.google.com" },
+        };
+
+      case "drag_and_drop": {
+        const startPoint = this.normalizeCoordinates(
+          args.x as number,
+          args.y as number,
+        );
+        const endPoint = this.normalizeCoordinates(
+          args.destination_x as number,
+          args.destination_y as number,
+        );
+        return {
+          type: "drag",
+          path: [
+            { x: startPoint.x, y: startPoint.y },
+            { x: endPoint.x, y: endPoint.y },
+          ],
+        };
+      }
+
+      default:
+        console.warn(`Unsupported Google CUA function: ${name}`);
+        return null;
+    }
+  }
+
+  /**
+   * Normalize coordinates from Google's 0-1000 range to actual viewport dimensions
+   */
+  private normalizeCoordinates(x: number, y: number): { x: number; y: number } {
+    x = Math.min(999, Math.max(0, x));
+    y = Math.min(999, Math.max(0, y));
+    return {
+      x: Math.floor((x / 1000) * this.currentViewport.width),
+      y: Math.floor((y / 1000) * this.currentViewport.height),
+    };
+  }
+
+  async captureScreenshot(options?: {
+    base64Image?: string;
+    currentUrl?: string;
+  }): Promise<string> {
+    // Use provided options if available
+    if (options?.base64Image) {
+      return `data:image/png;base64,${options.base64Image}`;
+    }
+
+    // Use the screenshot provider if available
+    if (this.screenshotProvider) {
+      try {
+        const base64Image = await this.screenshotProvider();
+        return `data:image/png;base64,${base64Image}`;
+      } catch (error) {
+        console.error("Error capturing screenshot:", error);
+        throw error;
+      }
+    }
+
+    throw new AgentScreenshotProviderError(
+      "`screenshotProvider` has not been set. " +
+        "Please call `setScreenshotProvider()` with a valid function that returns a base64-encoded image",
+    );
+  }
+}

--- a/lib/agent/OpenAICUAClient.ts
+++ b/lib/agent/OpenAICUAClient.ts
@@ -24,7 +24,7 @@ export class OpenAICUAClient extends AgentClient {
   private baseURL: string;
   private client: OpenAI;
   public lastResponseId?: string;
-  private currentViewport = { width: 1024, height: 768 };
+  private currentViewport = { width: 1288, height: 711 };
   private currentUrl?: string;
   private screenshotProvider?: () => Promise<string>;
   private actionHandler?: (action: AgentAction) => Promise<void>;

--- a/lib/agent/OpenAICUAClient.ts
+++ b/lib/agent/OpenAICUAClient.ts
@@ -227,6 +227,11 @@ export class OpenAICUAClient extends AgentClient {
       for (const item of output) {
         if (item.type === "reasoning") {
           this.reasoningItems.set(item.id, item);
+          logger({
+            category: "agent",
+            message: `Reasoning: ${String(item.content || "")}`,
+            level: 1,
+          });
         }
       }
 
@@ -234,17 +239,37 @@ export class OpenAICUAClient extends AgentClient {
       const stepActions: AgentAction[] = [];
       for (const item of output) {
         if (item.type === "computer_call" && this.isComputerCallItem(item)) {
+          logger({
+            category: "agent",
+            message: `Found computer_call: ${item.action.type}, call_id: ${item.call_id}`,
+            level: 2,
+          });
           const action = this.convertComputerCallToAction(item);
           if (action) {
             stepActions.push(action);
+            logger({
+              category: "agent",
+              message: `Converted computer_call to action: ${action.type}`,
+              level: 2,
+            });
           }
         } else if (
           item.type === "function_call" &&
           this.isFunctionCallItem(item)
         ) {
+          logger({
+            category: "agent",
+            message: `Found function_call: ${item.name}, call_id: ${item.call_id}`,
+            level: 2,
+          });
           const action = this.convertFunctionCallToAction(item);
           if (action) {
             stepActions.push(action);
+            logger({
+              category: "agent",
+              message: `Converted function_call to action: ${action.type}`,
+              level: 2,
+            });
           }
         }
       }
@@ -253,10 +278,20 @@ export class OpenAICUAClient extends AgentClient {
       let message = "";
       for (const item of output) {
         if (item.type === "message") {
+          logger({
+            category: "agent",
+            message: `Found message block`,
+            level: 2,
+          });
           if (item.content && Array.isArray(item.content)) {
             for (const content of item.content) {
               if (content.type === "output_text" && content.text) {
                 message += content.text + "\n";
+                logger({
+                  category: "agent",
+                  message: `Message text: ${String(content.text || "")}`,
+                  level: 1,
+                });
               }
             }
           }
@@ -416,6 +451,11 @@ export class OpenAICUAClient extends AgentClient {
           const action = this.convertComputerCallToAction(item);
 
           if (action && this.actionHandler) {
+            logger({
+              category: "agent",
+              message: `Executing computer action: ${action.type}`,
+              level: 1,
+            });
             await this.actionHandler(action);
           }
 
@@ -431,6 +471,12 @@ export class OpenAICUAClient extends AgentClient {
               image_url: screenshot,
             },
           } as ResponseInputItem;
+
+          logger({
+            category: "agent",
+            message: `Added computer_call_output for call_id: ${item.call_id}`,
+            level: 2,
+          });
 
           // Add current URL if available
           if (this.currentUrl) {

--- a/lib/agent/utils/imageCompression.ts
+++ b/lib/agent/utils/imageCompression.ts
@@ -2,9 +2,26 @@ import {
   AnthropicMessage,
   AnthropicContentBlock,
   AnthropicToolResult,
+  ResponseInputItem as OpenAIResponseInputItem,
 } from "@/types/agent";
+import type {
+  Content as GoogleContent,
+  Part as GooglePart,
+} from "@google/genai";
 
 export type ResponseInputItem = AnthropicMessage | AnthropicToolResult;
+
+interface FunctionResponseData {
+  inlineData?: {
+    mimeType?: string;
+    data?: string;
+  };
+}
+export type AnthropicResponseInputItem = AnthropicMessage | AnthropicToolResult;
+export type SupportedInputItem =
+  | AnthropicResponseInputItem
+  | OpenAIResponseInputItem
+  | GoogleContent;
 
 /**
  * Finds all items in the conversation history that contain images
@@ -78,6 +95,205 @@ export function compressConversationImages(
           },
         );
       }
+    }
+  });
+
+  return {
+    items,
+  };
+}
+
+/**
+ * Finds all items in the conversation history that contain images (Google format)
+ * @param items - Array of conversation items to check
+ * @returns Array of indices where images were found
+ */
+export function findGoogleItemsWithImages(items: GoogleContent[]): number[] {
+  const itemsWithImages: number[] = [];
+
+  items.forEach((item, index) => {
+    let hasImage = false;
+
+    if (item.parts && Array.isArray(item.parts)) {
+      hasImage = item.parts.some((part: GooglePart) => {
+        // Check for functionResponse with data containing images
+        if (part.functionResponse?.response?.data) {
+          const data = part.functionResponse.response
+            .data as FunctionResponseData[];
+          return data.some((dataItem) =>
+            dataItem.inlineData?.mimeType?.startsWith("image/"),
+          );
+        }
+
+        // Check for functionResponse with parts containing images
+        if (part.functionResponse?.parts) {
+          return part.functionResponse.parts.some((responsePart) =>
+            responsePart.inlineData?.mimeType?.startsWith("image/"),
+          );
+        }
+
+        // Check for direct inline data
+        return part.inlineData?.mimeType?.startsWith("image/");
+      });
+    }
+
+    if (hasImage) {
+      itemsWithImages.push(index);
+    }
+  });
+
+  return itemsWithImages;
+}
+
+/**
+ * Finds all items in the conversation history that contain images (OpenAI format)
+ * @param items - Array of conversation items to check
+ * @returns Array of indices where images were found
+ */
+export function findOpenAIItemsWithImages(
+  items: OpenAIResponseInputItem[],
+): number[] {
+  const itemsWithImages: number[] = [];
+
+  items.forEach((item, index) => {
+    let hasImage = false;
+
+    // Check for computer_call_output with image
+    if (
+      "type" in item &&
+      item.type === "computer_call_output" &&
+      "output" in item
+    ) {
+      const output = item.output as unknown as {
+        type: string;
+        image_url: string;
+      };
+      hasImage = output?.type === "input_image" && !!output?.image_url;
+    }
+
+    if (hasImage) {
+      itemsWithImages.push(index);
+    }
+  });
+
+  return itemsWithImages;
+}
+
+/**
+ * Compresses OpenAI conversation history by removing images from older items
+ * while keeping the most recent images intact
+ * @param items - Array of conversation items to process
+ * @param keepMostRecentCount - Number of most recent image-containing items to preserve (default: 2)
+ * @returns Object with processed items
+ */
+export function compressOpenAIConversationImages(
+  items: OpenAIResponseInputItem[],
+  keepMostRecentCount: number = 2,
+): { items: OpenAIResponseInputItem[] } {
+  const itemsWithImages = findOpenAIItemsWithImages(items);
+
+  items.forEach((item, index) => {
+    const imageIndex = itemsWithImages.indexOf(index);
+    const shouldCompress =
+      imageIndex >= 0 &&
+      imageIndex < itemsWithImages.length - keepMostRecentCount;
+
+    if (shouldCompress) {
+      // For computer_call_output with image, replace with text
+      if (
+        "type" in item &&
+        item.type === "computer_call_output" &&
+        "output" in item
+      ) {
+        const output = item.output as unknown as { type: string };
+        if (output?.type === "input_image") {
+          // Replace the image with a text message
+          (item as unknown as { output: string }).output = "screenshot taken";
+        }
+      }
+    }
+  });
+
+  return {
+    items,
+  };
+}
+
+/**
+ * Compresses Google conversation history by removing images from older items
+ * while keeping the most recent images intact
+ * @param items - Array of conversation items to process
+ * @param keepMostRecentCount - Number of most recent image-containing items to preserve (default: 2)
+ * @returns Object with processed items
+ */
+export function compressGoogleConversationImages(
+  items: GoogleContent[],
+  keepMostRecentCount: number = 2,
+): { items: GoogleContent[] } {
+  const itemsWithImages = findGoogleItemsWithImages(items);
+
+  items.forEach((item, index) => {
+    const imageIndex = itemsWithImages.indexOf(index);
+    const shouldCompress =
+      imageIndex >= 0 &&
+      imageIndex < itemsWithImages.length - keepMostRecentCount;
+
+    if (shouldCompress && item.parts && Array.isArray(item.parts)) {
+      item.parts = item.parts.map((part: GooglePart) => {
+        // Replace functionResponse with data containing images
+        if (part.functionResponse?.response?.data) {
+          const data = part.functionResponse.response
+            .data as FunctionResponseData[];
+          const hasImage = data.some((dataItem) =>
+            dataItem.inlineData?.mimeType?.startsWith("image/"),
+          );
+          if (hasImage) {
+            return {
+              ...part,
+              functionResponse: {
+                ...part.functionResponse,
+                data: [] as FunctionResponseData[],
+                response: {
+                  ...part.functionResponse.response,
+                  compressed: "screenshot taken",
+                },
+              },
+            };
+          }
+        }
+
+        // Replace functionResponse with parts containing images
+        if (part.functionResponse?.parts) {
+          const hasImageInParts = part.functionResponse.parts.some(
+            (responsePart) =>
+              responsePart.inlineData?.mimeType?.startsWith("image/"),
+          );
+          if (hasImageInParts) {
+            return {
+              ...part,
+              functionResponse: {
+                ...part.functionResponse,
+                parts: part.functionResponse.parts.filter(
+                  (responsePart) =>
+                    !responsePart.inlineData?.mimeType?.startsWith("image/"),
+                ),
+                response: {
+                  ...part.functionResponse.response,
+                  compressed: "screenshot taken",
+                },
+              },
+            };
+          }
+        }
+
+        // Replace direct inline data images
+        if (part.inlineData?.mimeType?.startsWith("image/")) {
+          return {
+            text: "screenshot taken",
+          };
+        }
+        return part;
+      });
     }
   });
 

--- a/lib/handlers/cuaAgentHandler.ts
+++ b/lib/handlers/cuaAgentHandler.ts
@@ -25,6 +25,7 @@ export class CuaAgentHandler {
   private options: AgentHandlerOptions;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private screenshotCollector?: any;
+  private highlightCursor: boolean = true;
 
   constructor(
     stagehand: Stagehand,
@@ -79,11 +80,13 @@ export class CuaAgentHandler {
         defaultDelay;
 
       try {
-        // Try to inject cursor before each action
-        try {
-          await this.injectCursor();
-        } catch {
-          // Ignore cursor injection failures
+        // Try to inject cursor before each action if enabled
+        if (this.highlightCursor) {
+          try {
+            await this.injectCursor();
+          } catch {
+            // Ignore cursor injection failures
+          }
         }
 
         // Add a small delay before the action for better visibility
@@ -136,6 +139,8 @@ export class CuaAgentHandler {
         ? { instruction: optionsOrInstruction }
         : optionsOrInstruction;
 
+    this.highlightCursor = options.highlightCursor !== false;
+
     //Redirect to Google if the URL is empty or about:blank
     const currentUrl = this.page.url();
     if (!currentUrl || currentUrl === "about:blank") {
@@ -153,18 +158,20 @@ export class CuaAgentHandler {
       level: 1,
     });
 
-    // Inject cursor for visual feedback
-    try {
-      await this.injectCursor();
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-      this.logger({
-        category: "agent",
-        message: `Warning: Failed to inject cursor: ${errorMessage}. Continuing with execution.`,
-        level: 1,
-      });
-      // Continue execution even if cursor injection fails
+    // Inject cursor for visual feedback if enabled
+    if (this.highlightCursor) {
+      try {
+        await this.injectCursor();
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+        this.logger({
+          category: "agent",
+          message: `Warning: Failed to inject cursor: ${errorMessage}. Continuing with execution.`,
+          level: 1,
+        });
+        // Continue execution even if cursor injection fails
+      }
     }
 
     // Take initial screenshot if needed
@@ -211,9 +218,9 @@ export class CuaAgentHandler {
         case "click": {
           const { x, y, button = "left" } = action;
           // Update cursor position first
-          // await this.updateCursorPosition(x as number, y as number);
+          await this.updateCursorPosition(x as number, y as number);
           // Animate the click
-          // await this.animateClick(x as number, y as number);
+          await this.animateClick(x as number, y as number);
           // Small delay to see the animation
           await new Promise((resolve) => setTimeout(resolve, 200));
           // Perform the actual click
@@ -444,75 +451,75 @@ export class CuaAgentHandler {
    */
   private async injectCursor(): Promise<void> {
     try {
-      // // Define constants for cursor and highlight element IDs
-      // const CURSOR_ID = "stagehand-cursor";
-      // const HIGHLIGHT_ID = "stagehand-highlight";
-      // // Check if cursor already exists
-      // const cursorExists = await this.page.evaluate((id: string) => {
-      //   return !!document.getElementById(id);
-      // }, CURSOR_ID);
-      // if (cursorExists) {
-      //   return;
-      // }
-      // // Inject cursor and highlight elements
-      // await this.page.evaluate(`
-      //   (function(cursorId, highlightId) {
-      //     // Create cursor element
-      //     const cursor = document.createElement('div');
-      //     cursor.id = cursorId;
-      //     // Use the provided SVG for a custom cursor
-      //     cursor.innerHTML = \`
-      //     <svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 28 28" width="28" height="28">
-      //       <polygon fill="#000000" points="9.2,7.3 9.2,18.5 12.2,15.6 12.6,15.5 17.4,15.5"/>
-      //       <rect x="12.5" y="13.6" transform="matrix(0.9221 -0.3871 0.3871 0.9221 -5.7605 6.5909)" width="2" height="8" fill="#000000"/>
-      //     </svg>
-      //     \`;
-      //     // Style the cursor
-      //     cursor.style.position = 'absolute';
-      //     cursor.style.top = '0';
-      //     cursor.style.left = '0';
-      //     cursor.style.width = '28px';
-      //     cursor.style.height = '28px';
-      //     cursor.style.pointerEvents = 'none';
-      //     cursor.style.zIndex = '9999999';
-      //     cursor.style.transform = 'translate(-4px, -4px)'; // Adjust to align the pointer tip
-      //     // Create highlight element for click animation
-      //     const highlight = document.createElement('div');
-      //     highlight.id = highlightId;
-      //     highlight.style.position = 'absolute';
-      //     highlight.style.width = '20px';
-      //     highlight.style.height = '20px';
-      //     highlight.style.borderRadius = '50%';
-      //     highlight.style.backgroundColor = 'rgba(66, 134, 244, 0)';
-      //     highlight.style.transform = 'translate(-50%, -50%) scale(0)';
-      //     highlight.style.pointerEvents = 'none';
-      //     highlight.style.zIndex = '9999998';
-      //     highlight.style.transition = 'transform 0.3s ease-out, opacity 0.3s ease-out';
-      //     highlight.style.opacity = '0';
-      //     // Add elements to the document
-      //     document.body.appendChild(cursor);
-      //     document.body.appendChild(highlight);
-      //     // Add a function to update cursor position
-      //     window.__updateCursorPosition = function(x, y) {
-      //       if (cursor) {
-      //         cursor.style.transform = \`translate(\${x - 4}px, \${y - 4}px)\`;
-      //       }
-      //     };
-      //     // Add a function to animate click
-      //     window.__animateClick = function(x, y) {
-      //       if (highlight) {
-      //         highlight.style.left = \`\${x}px\`;
-      //         highlight.style.top = \`\${y}px\`;
-      //         highlight.style.transform = 'translate(-50%, -50%) scale(1)';
-      //         highlight.style.opacity = '1';
-      //         setTimeout(() => {
-      //           highlight.style.transform = 'translate(-50%, -50%) scale(0)';
-      //           highlight.style.opacity = '0';
-      //         }, 300);
-      //       }
-      //     };
-      //   })('${CURSOR_ID}', '${HIGHLIGHT_ID}');
-      // `);
+      // Define constants for cursor and highlight element IDs
+      const CURSOR_ID = "stagehand-cursor";
+      const HIGHLIGHT_ID = "stagehand-highlight";
+      // Check if cursor already exists
+      const cursorExists = await this.page.evaluate((id: string) => {
+        return !!document.getElementById(id);
+      }, CURSOR_ID);
+      if (cursorExists) {
+        return;
+      }
+      // Inject cursor and highlight elements
+      await this.page.evaluate(`
+        (function(cursorId, highlightId) {
+          // Create cursor element
+          const cursor = document.createElement('div');
+          cursor.id = cursorId;
+          // Use the provided SVG for a custom cursor
+          cursor.innerHTML = \`
+          <svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 28 28" width="28" height="28">
+            <polygon fill="#000000" points="9.2,7.3 9.2,18.5 12.2,15.6 12.6,15.5 17.4,15.5"/>
+            <rect x="12.5" y="13.6" transform="matrix(0.9221 -0.3871 0.3871 0.9221 -5.7605 6.5909)" width="2" height="8" fill="#000000"/>
+          </svg>
+          \`;
+          // Style the cursor
+          cursor.style.position = 'absolute';
+          cursor.style.top = '0';
+          cursor.style.left = '0';
+          cursor.style.width = '28px';
+          cursor.style.height = '28px';
+          cursor.style.pointerEvents = 'none';
+          cursor.style.zIndex = '9999999';
+          cursor.style.transform = 'translate(-4px, -4px)'; // Adjust to align the pointer tip
+          // Create highlight element for click animation
+          const highlight = document.createElement('div');
+          highlight.id = highlightId;
+          highlight.style.position = 'absolute';
+          highlight.style.width = '20px';
+          highlight.style.height = '20px';
+          highlight.style.borderRadius = '50%';
+          highlight.style.backgroundColor = 'rgba(66, 134, 244, 0)';
+          highlight.style.transform = 'translate(-50%, -50%) scale(0)';
+          highlight.style.pointerEvents = 'none';
+          highlight.style.zIndex = '9999998';
+          highlight.style.transition = 'transform 0.3s ease-out, opacity 0.3s ease-out';
+          highlight.style.opacity = '0';
+          // Add elements to the document
+          document.body.appendChild(cursor);
+          document.body.appendChild(highlight);
+          // Add a function to update cursor position
+          window.__updateCursorPosition = function(x, y) {
+            if (cursor) {
+              cursor.style.transform = \`translate(\${x - 4}px, \${y - 4}px)\`;
+            }
+          };
+          // Add a function to animate click
+          window.__animateClick = function(x, y) {
+            if (highlight) {
+              highlight.style.left = \`\${x}px\`;
+              highlight.style.top = \`\${y}px\`;
+              highlight.style.transform = 'translate(-50%, -50%) scale(1)';
+              highlight.style.opacity = '1';
+              setTimeout(() => {
+                highlight.style.transform = 'translate(-50%, -50%) scale(0)';
+                highlight.style.opacity = '0';
+              }, 300);
+            }
+          };
+        })('${CURSOR_ID}', '${HIGHLIGHT_ID}');
+      `);
       this.logger({
         category: "agent",
         message: "Cursor injected for visual feedback",
@@ -532,21 +539,16 @@ export class CuaAgentHandler {
    */
   private async updateCursorPosition(x: number, y: number): Promise<void> {
     try {
-      // await this.page.evaluate(
-      //   ({ x, y }) => {
-      //     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      //     if ((window as any).__updateCursorPosition) {
-      //       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      //       (window as any).__updateCursorPosition(x, y);
-      //     }
-      //   },
-      //   { x, y },
-      // );
-      this.logger({
-        category: "agent",
-        message: `Updating cursor position to ${x}, ${y}`,
-        level: 2,
-      });
+      await this.page.evaluate(
+        ({ x, y }) => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          if ((window as any).__updateCursorPosition) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (window as any).__updateCursorPosition(x, y);
+          }
+        },
+        { x, y },
+      );
     } catch {
       // Silently fail if cursor update fails
       // This is not critical functionality
@@ -556,14 +558,18 @@ export class CuaAgentHandler {
   /**
    * Animate a click at the given position
    */
-  private async animateClick(_x: number, _y: number): Promise<void> {
+  private async animateClick(x: number, y: number): Promise<void> {
     try {
-      //leave empty for now
-      this.logger({
-        category: "agent",
-        message: `Animating click at ${_x}, ${_y}`,
-        level: 2,
-      });
+      await this.page.evaluate(
+        ({ x, y }) => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          if ((window as any).__animateClick) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (window as any).__animateClick(x, y);
+          }
+        },
+        { x, y },
+      );
     } catch {
       // Silently fail if animation fails
       // This is not critical functionality

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -282,8 +282,8 @@ async function getBrowser(
       acceptDownloads: localBrowserLaunchOptions?.acceptDownloads ?? true,
       headless: localBrowserLaunchOptions?.headless ?? headless,
       viewport: {
-        width: localBrowserLaunchOptions?.viewport?.width ?? 1024,
-        height: localBrowserLaunchOptions?.viewport?.height ?? 768,
+        width: localBrowserLaunchOptions?.viewport?.width ?? 1288,
+        height: localBrowserLaunchOptions?.viewport?.height ?? 711,
       },
       locale: localBrowserLaunchOptions?.locale ?? "en-US",
       timezoneId: localBrowserLaunchOptions?.timezoneId ?? "America/New_York",
@@ -997,7 +997,8 @@ export class Stagehand {
             } else if (options.provider === "openai") {
               options.options.apiKey = process.env.OPENAI_API_KEY;
             } else if (options.provider === "google") {
-              options.options.apiKey = process.env.GOOGLE_API_KEY;
+              options.options.apiKey =
+                process.env.GOOGLE_API_KEY || process.env.GEMINI_API_KEY;
             }
 
             if (!options.options.apiKey) {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1002,8 +1002,18 @@ export class Stagehand {
             }
 
             if (!options.options.apiKey) {
+              let envVar;
+              if (options.provider === "anthropic") {
+                envVar = "ANTHROPIC_API_KEY";
+              } else if (options.provider === "openai") {
+                envVar = "OPENAI_API_KEY";
+              } else if (options.provider === "google") {
+                envVar = "GOOGLE_API_KEY or GEMINI_API_KEY";
+              } else {
+                envVar = "the appropriate API key environment variable";
+              }
               throw new StagehandError(
-                `API key not found for \`${options.provider}\` provider. Please set the ${options.provider === "anthropic" ? "ANTHROPIC_API_KEY" : "OPENAI_API_KEY"} environment variable or pass an apiKey in the options object.`,
+                `API key not found for \`${options.provider}\` provider. Please set the ${envVar} environment variable or pass an apiKey in the options object.`,
               );
             }
           }

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -209,3 +209,14 @@ ${goal}
 6. Only use \`close\` when the task is genuinely complete or impossible to achieve`,
   };
 }
+
+export function buildGoogleCUASystemPrompt(): ChatMessage {
+  return {
+    role: "system",
+    content: `You are a general-purpose browser agent whose job is to accomplish the user's goal.
+Today's date is ${new Date().toLocaleDateString()}.
+You have access to a search tool; however, in most cases you should operate within the page/url the user has provided. ONLY use the search tool if you're stuck or the task is impossible to complete within the current page.
+You will be given a goal and a list of steps that have been taken so far. Avoid requesting the user for input as much as possible. Good luck!
+`,
+  };
+}

--- a/lib/prompt.ts
+++ b/lib/prompt.ts
@@ -214,7 +214,7 @@ export function buildGoogleCUASystemPrompt(): ChatMessage {
   return {
     role: "system",
     content: `You are a general-purpose browser agent whose job is to accomplish the user's goal.
-Today's date is ${new Date().toLocaleDateString()}.
+Today's date is ${new Date().toISOString().split("T")[0]}.
 You have access to a search tool; however, in most cases you should operate within the page/url the user has provided. ONLY use the search tool if you're stuck or the task is impossible to complete within the current page.
 You will be given a goal and a list of steps that have been taken so far. Avoid requesting the user for input as much as possible. Good luck!
 `,

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "0.39.0",
     "@browserbasehq/sdk": "^2.4.0",
-    "@google/genai": "^0.8.0",
+    "@google/genai": "^1.22.0",
     "@modelcontextprotocol/sdk": "^1.17.2",
     "ai": "^4.3.9",
     "devtools-protocol": "^0.0.1464554",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,13 +16,13 @@ importers:
         version: 2.6.0
       '@google/genai':
         specifier: ^1.22.0
-        version: 1.22.0(@modelcontextprotocol/sdk@1.18.1)
+        version: 1.22.0(@modelcontextprotocol/sdk@1.19.1)
       '@modelcontextprotocol/sdk':
         specifier: ^1.17.2
-        version: 1.18.1
+        version: 1.19.1
       ai:
         specifier: ^4.3.9
-        version: 4.3.19(react@19.1.1)(zod@3.25.67)
+        version: 4.3.19(react@19.2.0)(zod@3.25.67)
       deepmerge:
         specifier: ^4.3.1
         version: 4.3.1
@@ -40,13 +40,13 @@ importers:
         version: 4.104.0(ws@8.18.3)(zod@3.25.67)
       pino:
         specifier: ^9.6.0
-        version: 9.10.0
+        version: 9.13.1
       pino-pretty:
         specifier: ^13.0.0
         version: 13.1.1
       playwright:
         specifier: ^1.52.0
-        version: 1.55.0
+        version: 1.56.0
       ws:
         specifier: ^8.18.0
         version: 8.18.3
@@ -99,19 +99,19 @@ importers:
         version: 0.5.1
       '@changesets/cli':
         specifier: ^2.27.9
-        version: 2.29.7(@types/node@20.19.17)
+        version: 2.29.7(@types/node@20.19.19)
       '@eslint/js':
         specifier: ^9.16.0
-        version: 9.36.0
+        version: 9.37.0
       '@langchain/core':
         specifier: ^0.3.40
-        version: 0.3.77(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.18.3)(zod@3.25.67))
+        version: 0.3.78(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.18.3)(zod@3.25.67))
       '@langchain/openai':
         specifier: ^0.4.4
-        version: 0.4.9(@langchain/core@0.3.77(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.18.3)(zod@3.25.67)))(ws@8.18.3)
+        version: 0.4.9(@langchain/core@0.3.78(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.18.3)(zod@3.25.67)))(ws@8.18.3)
       '@playwright/test':
         specifier: ^1.42.1
-        version: 1.55.0
+        version: 1.56.0
       '@types/adm-zip':
         specifier: ^0.5.7
         version: 0.5.7
@@ -123,7 +123,7 @@ importers:
         version: 4.17.23
       '@types/node':
         specifier: ^20.11.30
-        version: 20.19.17
+        version: 20.19.19
       '@types/ws':
         specifier: ^8.5.13
         version: 8.18.1
@@ -135,7 +135,7 @@ importers:
         version: 0.0.64
       braintrust:
         specifier: ^0.0.171
-        version: 0.0.171(openai@4.104.0(ws@8.18.3)(zod@3.25.67))(react@19.1.1)(sswr@2.2.0(svelte@5.39.3))(svelte@5.39.3)(vue@3.5.21(typescript@5.9.2))(zod@3.25.67)
+        version: 0.0.171(openai@4.104.0(ws@8.18.3)(zod@3.25.67))(react@19.2.0)(sswr@2.2.0(svelte@5.39.10))(svelte@5.39.10)(vue@3.5.22(typescript@5.9.3))(zod@3.25.67)
       chalk:
         specifier: ^5.4.1
         version: 5.6.2
@@ -150,7 +150,7 @@ importers:
         version: 0.21.5
       eslint:
         specifier: ^9.16.0
-        version: 9.36.0(jiti@1.21.7)
+        version: 9.37.0(jiti@1.21.7)
       express:
         specifier: ^4.21.0
         version: 4.21.2
@@ -168,25 +168,25 @@ importers:
         version: 1.3.0
       tsup:
         specifier: ^8.2.1
-        version: 8.5.0(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
       tsx:
         specifier: ^4.10.5
-        version: 4.20.5
+        version: 4.20.6
       typescript:
         specifier: ^5.2.2
-        version: 5.9.2
+        version: 5.9.3
       typescript-eslint:
         specifier: ^8.17.0
-        version: 8.44.0(eslint@9.36.0(jiti@1.21.7))(typescript@5.9.2)
+        version: 8.46.0(eslint@9.37.0(jiti@1.21.7))(typescript@5.9.3)
 
   docs:
     dependencies:
       mintlify:
         specifier: ^4.2.47
-        version: 4.2.121(@radix-ui/react-popover@1.1.15(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1))(@types/node@20.19.17)(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(typescript@5.9.2)
+        version: 4.2.149(@radix-ui/react-popover@1.1.15(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0))(@types/node@20.19.19)(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
       tsx:
         specifier: ^4.19.2
-        version: 4.20.5
+        version: 4.20.6
       zod:
         specifier: ^3.25.0
         version: 3.25.76
@@ -208,7 +208,7 @@ importers:
         version: 5.5.3
       tsx:
         specifier: ^4.10.5
-        version: 4.20.5
+        version: 4.20.6
 
   examples:
     dependencies:
@@ -221,7 +221,7 @@ importers:
         version: 3.10.1
       tsx:
         specifier: ^4.10.5
-        version: 4.20.5
+        version: 4.20.6
 
   lib: {}
 
@@ -451,6 +451,9 @@ packages:
 
   '@browserbasehq/sdk@2.6.0':
     resolution: {integrity: sha512-83iXP5D7xMm8Wyn66TUaUrgoByCmAJuoMoZQI3sGg3JAiMlTfnCIMqyVBoNSaItaPIkaCnrsj6LiusmXV2X9YA==}
+
+  '@canvas/image-data@1.0.0':
+    resolution: {integrity: sha512-BxOqI5LgsIQP1odU5KMwV9yoijleOPzHL18/YvNqF9KFSGF2K/DLlYAbDQsWqd/1nbaFuSkYD/191dpMtNh4vw==}
 
   '@cfworker/json-schema@4.1.1':
     resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
@@ -959,28 +962,28 @@ packages:
     resolution: {integrity: sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/config-helpers@0.3.1':
-    resolution: {integrity: sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==}
+  '@eslint/config-helpers@0.4.0':
+    resolution: {integrity: sha512-WUFvV4WoIwW8Bv0KeKCIIEgdSiFOsulyN0xrMu+7z43q/hkOLXjvb5u7UC9jDxvRzcrbEmuZBX5yJZz1741jog==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/core@0.15.2':
-    resolution: {integrity: sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==}
+  '@eslint/core@0.16.0':
+    resolution: {integrity: sha512-nmC8/totwobIiFcGkDza3GIKfAw1+hLiYVrh3I1nIomQ8PEr5cxg34jnkmGawul/ep52wGRAcyeDCNtWKSOj4Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/eslintrc@3.3.1':
     resolution: {integrity: sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/js@9.36.0':
-    resolution: {integrity: sha512-uhCbYtYynH30iZErszX78U+nR3pJU3RHGQ57NXy5QupD4SBVwDeU8TNBy+MjMngc1UyIW9noKqsRqfjQTBU2dw==}
+  '@eslint/js@9.37.0':
+    resolution: {integrity: sha512-jaS+NJ+hximswBG6pjNX0uEJZkrT0zwpVi3BA3vX22aFGjJjmgSTSmPpZCRKmoBL5VY/M6p0xsSJx7rk7sy5gg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/object-schema@2.1.6':
     resolution: {integrity: sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/plugin-kit@0.3.5':
-    resolution: {integrity: sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==}
+  '@eslint/plugin-kit@0.4.0':
+    resolution: {integrity: sha512-sB5uyeq+dwCWyPi31B2gQlVlo+j5brPlWx4yZBrEaRo/nhdDE8Xke1gsGgtiBdaBTxuTkceLVuVt/pclrasb0A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@floating-ui/core@1.7.3':
@@ -1306,8 +1309,8 @@ packages:
   '@kwsites/promise-deferred@1.1.1':
     resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
 
-  '@langchain/core@0.3.77':
-    resolution: {integrity: sha512-aqXHea9xfpVn6VoCq9pjujwFqrh3vw3Fgm9KFUZJ1cF7Bx5HI62DvQPw8LlRB3NB4dhwBBA1ldAVkkkd1du8nA==}
+  '@langchain/core@0.3.78':
+    resolution: {integrity: sha512-Nn0x9erQlK3zgtRU1Z8NUjLuyW0gzdclMsvLQ6wwLeDqV91pE+YKl6uQb+L2NUDs4F0N7c2Zncgz46HxrvPzuA==}
     engines: {node: '>=18'}
 
   '@langchain/openai@0.4.9':
@@ -1334,54 +1337,54 @@ packages:
       '@types/react': '>=16'
       react: '>=16'
 
-  '@mintlify/cli@4.0.725':
-    resolution: {integrity: sha512-F4CGPOlb4/xaT14+Jsk1eNG4t22DZv8zOH+rqAXjiJwU9ay0HOhAn6x5eVCX7oTSTGuw3zMW36qClNHkj85l7w==}
+  '@mintlify/cli@4.0.753':
+    resolution: {integrity: sha512-ArV+e3gNMMld0udbj+bbD+9meGmC4yLVVQT95cNsVNr0/s67PB28tqlVuHVa6lTbcvR8HbHqTCArNtwf2ajpEQ==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  '@mintlify/common@1.0.535':
-    resolution: {integrity: sha512-2oKMW123FLKcc78a6+KN1Wjh6YHWsrJd/DwdwuE3WZBeXXKYLwEs7zwYS8sX46bk9Ra+/irKk9d6btogxJLqIw==}
+  '@mintlify/common@1.0.560':
+    resolution: {integrity: sha512-swUqqTbVacrsIG7IdJzISs5pl4Le7cdHgObjSPZQD7zoIyyH2Hi28i5k8Uxf0GnwYkKDzJ9vSyt5M/Rj96Nguw==}
 
-  '@mintlify/link-rot@3.0.672':
-    resolution: {integrity: sha512-kHSpkpiHvw3zrd9TL9yRQ6OWo8w5ujepWw7pBPWc4ouDuNj6D4Af6aan1uV8QCP1KWINisaZUGhlVSe39u+E0A==}
+  '@mintlify/link-rot@3.0.698':
+    resolution: {integrity: sha512-f36w4VybfoHDpZDKaA71ou9fkVDa7fbkdz3P2aAcDoukqTkLJYdzd7MlmMxt09f6xg2eK+sv8kJj32VqioQXJw==}
     engines: {node: '>=18.0.0'}
 
-  '@mintlify/mdx@2.0.11':
-    resolution: {integrity: sha512-yXwuM0BNCxNaJetPrh89c5Q2lhzU2al4QrOM3zLUdrPOdjOpPmv8ewcdiXV/qIhZDpl5Ll9k47dsz33bZjVWTg==}
+  '@mintlify/mdx@3.0.0':
+    resolution: {integrity: sha512-Ao7AidkbRPeR9xb2BZvRtUB7V0qo4XitCbrSCwEolagzlJxboSFkiLDFuxb6P4GCC84Nysee1au5ngcz2PndFQ==}
     peerDependencies:
       '@radix-ui/react-popover': ^1.1.15
       react: ^18.3.1
       react-dom: ^18.3.1
 
-  '@mintlify/models@0.0.229':
-    resolution: {integrity: sha512-1P3R6dQFNzjTbmVDCQf/vAGFGOEUdUv6sCaJAmZCNWY2mhwgvDU/Oa2YLiNmVrAqnWDH1Pkz5nq+i7gClrdXgA==}
+  '@mintlify/models@0.0.231':
+    resolution: {integrity: sha512-WHS03m82Drzyj5in525SbJhFPTxv6nO9ocnXnCbYDvt2iILu/5GhFY2olPif3f+ZN7PfIJhwJz/Qr96eEVX4mg==}
     engines: {node: '>=18.0.0'}
 
-  '@mintlify/openapi-parser@0.0.7':
-    resolution: {integrity: sha512-3ecbkzPbsnkKVZJypVL0H5pCTR7a4iLv4cP7zbffzAwy+vpH70JmPxNVpPPP62yLrdZlfNcMxu5xKeT7fllgMg==}
+  '@mintlify/openapi-parser@0.0.8':
+    resolution: {integrity: sha512-9MBRq9lS4l4HITYCrqCL7T61MOb20q9IdU7HWhqYMNMM1jGO1nHjXasFy61yZ8V6gMZyyKQARGVoZ0ZrYN48Og==}
     engines: {node: '>=18'}
 
-  '@mintlify/prebuild@1.0.659':
-    resolution: {integrity: sha512-JZbGL+JwCYXVlwwFPwCg5NInl2n2vsxeHrXK/WswUZ7FGsNnKMWGhWrzN6KVYiELvEwh87aGqVUMnTloW1aKNA==}
+  '@mintlify/prebuild@1.0.685':
+    resolution: {integrity: sha512-8Gl5amNdyh7ZI91JURzgZ6OijVX7T813nIhS+KLr3QtvQtg8jGdos5W/28Y0dvhameipLn0Uc80h0MlpzE3cMg==}
 
-  '@mintlify/previewing@4.0.708':
-    resolution: {integrity: sha512-MK/ZrmG4wTPgX+hviFa3IQYCis4wmAcJ9zu5NHRDKohmT3qhEnVRHE6Ksf8bXBHHy6ArQB4erydXFSn3wpFb/g==}
+  '@mintlify/previewing@4.0.734':
+    resolution: {integrity: sha512-8+Do9iiCv4C27NLceSEJWQEg7cqQpeGNyrlxKs9BUlEEGp0KqqyzZ4dYcmw4UxHOK2Kx/zSUqc46/thk+9YuVw==}
     engines: {node: '>=18.0.0'}
 
-  '@mintlify/scraping@4.0.394':
-    resolution: {integrity: sha512-Mibw2Rm5le4twdiMKaauAVksDGl5VjuBF2lBmXjp/JQVqVlQEIqg6cxWg13u2lgVjCDSIIOrul8K7+/XO7xRmQ==}
+  '@mintlify/scraping@4.0.419':
+    resolution: {integrity: sha512-tjd8WYSbXLF1hTs4W27BgoEhwRJv4yCpU+MXlx/loWugDN4uZ0QYPkofg06/k4B9KFWr9sN4Ea7f50l4OgEyaA==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  '@mintlify/validation@0.1.471':
-    resolution: {integrity: sha512-lf4zp9sJspXmDA9HH9VaJfK4ll+BaaH9XxuU2SVNuploKjRKmpHYFfN9YI42pA2bda/X32rkqDZSRI+JHdQcNg==}
+  '@mintlify/validation@0.1.486':
+    resolution: {integrity: sha512-mE30lnWuzrMCYC/jrcrHv7IXjN0slP6GxGSZLxf1P0qH/jLUNFKfj8nLfvFSgVOlhQiW9lqTexHAxnya+fEf2g==}
 
-  '@modelcontextprotocol/sdk@1.18.1':
-    resolution: {integrity: sha512-d//GE8/Yh7aC3e7p+kZG8JqqEAwwDUmAfvH1quogtbk+ksS6E0RR6toKKESPYYZVre0meqkJb27zb+dhqE9Sgw==}
+  '@modelcontextprotocol/sdk@1.19.1':
+    resolution: {integrity: sha512-3Y2h3MZKjec1eAqSTBclATlX+AbC6n1LgfVzRMJLt3v6w0RCYgwLrjbxPDbhsYHt6Wdqc/aCceNJYgj448ELQQ==}
     engines: {node: '>=18'}
 
-  '@next/env@14.2.32':
-    resolution: {integrity: sha512-n9mQdigI6iZ/DF6pCTwMKeWgF2e8lg7qgt5M7HXMLtyhZYMnf/u905M18sSpPmHL9MKp9JHo56C6jrD2EvWxng==}
+  '@next/env@14.2.33':
+    resolution: {integrity: sha512-CgVHNZ1fRIlxkLhIX22flAZI/HmpDaZ8vwyJ/B0SDPTBuLZ1PJ+DWMjCHhqnExfmSQzA/PbZi8OAc7PAq2w9IA==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1406,8 +1409,8 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@playwright/test@1.55.0':
-    resolution: {integrity: sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==}
+  '@playwright/test@1.56.0':
+    resolution: {integrity: sha512-Tzh95Twig7hUwwNe381/K3PggZBZblKUe2wv25oIpzWLr6Z0m4KgV1ZVIjnR6GM9ANEqjZD7XsZEa6JL/7YEgg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1634,113 +1637,113 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
-  '@rollup/rollup-android-arm-eabi@4.52.0':
-    resolution: {integrity: sha512-VxDYCDqOaR7NXzAtvRx7G1u54d2kEHopb28YH/pKzY6y0qmogP3gG7CSiWsq9WvDFxOQMpNEyjVAHZFXfH3o/A==}
+  '@rollup/rollup-android-arm-eabi@4.52.4':
+    resolution: {integrity: sha512-BTm2qKNnWIQ5auf4deoetINJm2JzvihvGb9R6K/ETwKLql/Bb3Eg2H1FBp1gUb4YGbydMA3jcmQTR73q7J+GAA==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.52.0':
-    resolution: {integrity: sha512-pqDirm8koABIKvzL59YI9W9DWbRlTX7RWhN+auR8HXJxo89m4mjqbah7nJZjeKNTNYopqL+yGg+0mhCpf3xZtQ==}
+  '@rollup/rollup-android-arm64@4.52.4':
+    resolution: {integrity: sha512-P9LDQiC5vpgGFgz7GSM6dKPCiqR3XYN1WwJKA4/BUVDjHpYsf3iBEmVz62uyq20NGYbiGPR5cNHI7T1HqxNs2w==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.52.0':
-    resolution: {integrity: sha512-YCdWlY/8ltN6H78HnMsRHYlPiKvqKagBP1r+D7SSylxX+HnsgXGCmLiV3Y4nSyY9hW8qr8U9LDUx/Lo7M6MfmQ==}
+  '@rollup/rollup-darwin-arm64@4.52.4':
+    resolution: {integrity: sha512-QRWSW+bVccAvZF6cbNZBJwAehmvG9NwfWHwMy4GbWi/BQIA/laTIktebT2ipVjNncqE6GLPxOok5hsECgAxGZg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.52.0':
-    resolution: {integrity: sha512-z4nw6y1j+OOSGzuVbSWdIp1IUks9qNw4dc7z7lWuWDKojY38VMWBlEN7F9jk5UXOkUcp97vA1N213DF+Lz8BRg==}
+  '@rollup/rollup-darwin-x64@4.52.4':
+    resolution: {integrity: sha512-hZgP05pResAkRJxL1b+7yxCnXPGsXU0fG9Yfd6dUaoGk+FhdPKCJ5L1Sumyxn8kvw8Qi5PvQ8ulenUbRjzeCTw==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.52.0':
-    resolution: {integrity: sha512-Q/dv9Yvyr5rKlK8WQJZVrp5g2SOYeZUs9u/t2f9cQ2E0gJjYB/BWoedXfUT0EcDJefi2zzVfhcOj8drWCzTviw==}
+  '@rollup/rollup-freebsd-arm64@4.52.4':
+    resolution: {integrity: sha512-xmc30VshuBNUd58Xk4TKAEcRZHaXlV+tCxIXELiE9sQuK3kG8ZFgSPi57UBJt8/ogfhAF5Oz4ZSUBN77weM+mQ==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.52.0':
-    resolution: {integrity: sha512-kdBsLs4Uile/fbjZVvCRcKB4q64R+1mUq0Yd7oU1CMm1Av336ajIFqNFovByipciuUQjBCPMxwJhCgfG2re3rg==}
+  '@rollup/rollup-freebsd-x64@4.52.4':
+    resolution: {integrity: sha512-WdSLpZFjOEqNZGmHflxyifolwAiZmDQzuOzIq9L27ButpCVpD7KzTRtEG1I0wMPFyiyUdOO+4t8GvrnBLQSwpw==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.52.0':
-    resolution: {integrity: sha512-aL6hRwu0k7MTUESgkg7QHY6CoqPgr6gdQXRJI1/VbFlUMwsSzPGSR7sG5d+MCbYnJmJwThc2ol3nixj1fvI/zQ==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.4':
+    resolution: {integrity: sha512-xRiOu9Of1FZ4SxVbB0iEDXc4ddIcjCv2aj03dmW8UrZIW7aIQ9jVJdLBIhxBI+MaTnGAKyvMwPwQnoOEvP7FgQ==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.52.0':
-    resolution: {integrity: sha512-BTs0M5s1EJejgIBJhCeiFo7GZZ2IXWkFGcyZhxX4+8usnIo5Mti57108vjXFIQmmJaRyDwmV59Tw64Ap1dkwMw==}
+  '@rollup/rollup-linux-arm-musleabihf@4.52.4':
+    resolution: {integrity: sha512-FbhM2p9TJAmEIEhIgzR4soUcsW49e9veAQCziwbR+XWB2zqJ12b4i/+hel9yLiD8pLncDH4fKIPIbt5238341Q==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.52.0':
-    resolution: {integrity: sha512-uj672IVOU9m08DBGvoPKPi/J8jlVgjh12C9GmjjBxCTQc3XtVmRkRKyeHSmIKQpvJ7fIm1EJieBUcnGSzDVFyw==}
+  '@rollup/rollup-linux-arm64-gnu@4.52.4':
+    resolution: {integrity: sha512-4n4gVwhPHR9q/g8lKCyz0yuaD0MvDf7dV4f9tHt0C73Mp8h38UCtSCSE6R9iBlTbXlmA8CjpsZoujhszefqueg==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.52.0':
-    resolution: {integrity: sha512-/+IVbeDMDCtB/HP/wiWsSzduD10SEGzIZX2945KSgZRNi4TSkjHqRJtNTVtVb8IRwhJ65ssI56krlLik+zFWkw==}
+  '@rollup/rollup-linux-arm64-musl@4.52.4':
+    resolution: {integrity: sha512-u0n17nGA0nvi/11gcZKsjkLj1QIpAuPFQbR48Subo7SmZJnGxDpspyw2kbpuoQnyK+9pwf3pAoEXerJs/8Mi9g==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-loong64-gnu@4.52.0':
-    resolution: {integrity: sha512-U1vVzvSWtSMWKKrGoROPBXMh3Vwn93TA9V35PldokHGqiUbF6erSzox/5qrSMKp6SzakvyjcPiVF8yB1xKr9Pg==}
+  '@rollup/rollup-linux-loong64-gnu@4.52.4':
+    resolution: {integrity: sha512-0G2c2lpYtbTuXo8KEJkDkClE/+/2AFPdPAbmaHoE870foRFs4pBrDehilMcrSScrN/fB/1HTaWO4bqw+ewBzMQ==}
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.52.0':
-    resolution: {integrity: sha512-X/4WfuBAdQRH8cK3DYl8zC00XEE6aM472W+QCycpQJeLWVnHfkv7RyBFVaTqNUMsTgIX8ihMjCvFF9OUgeABzw==}
+  '@rollup/rollup-linux-ppc64-gnu@4.52.4':
+    resolution: {integrity: sha512-teSACug1GyZHmPDv14VNbvZFX779UqWTsd7KtTM9JIZRDI5NUwYSIS30kzI8m06gOPB//jtpqlhmraQ68b5X2g==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.52.0':
-    resolution: {integrity: sha512-xIRYc58HfWDBZoLmWfWXg2Sq8VCa2iJ32B7mqfWnkx5mekekl0tMe7FHpY8I72RXEcUkaWawRvl3qA55og+cwQ==}
+  '@rollup/rollup-linux-riscv64-gnu@4.52.4':
+    resolution: {integrity: sha512-/MOEW3aHjjs1p4Pw1Xk4+3egRevx8Ji9N6HUIA1Ifh8Q+cg9dremvFCUbOX2Zebz80BwJIgCBUemjqhU5XI5Eg==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-musl@4.52.0':
-    resolution: {integrity: sha512-mbsoUey05WJIOz8U1WzNdf+6UMYGwE3fZZnQqsM22FZ3wh1N887HT6jAOjXs6CNEK3Ntu2OBsyQDXfIjouI4dw==}
+  '@rollup/rollup-linux-riscv64-musl@4.52.4':
+    resolution: {integrity: sha512-1HHmsRyh845QDpEWzOFtMCph5Ts+9+yllCrREuBR/vg2RogAQGGBRC8lDPrPOMnrdOJ+mt1WLMOC2Kao/UwcvA==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.52.0':
-    resolution: {integrity: sha512-qP6aP970bucEi5KKKR4AuPFd8aTx9EF6BvutvYxmZuWLJHmnq4LvBfp0U+yFDMGwJ+AIJEH5sIP+SNypauMWzg==}
+  '@rollup/rollup-linux-s390x-gnu@4.52.4':
+    resolution: {integrity: sha512-seoeZp4L/6D1MUyjWkOMRU6/iLmCU2EjbMTyAG4oIOs1/I82Y5lTeaxW0KBfkUdHAWN7j25bpkt0rjnOgAcQcA==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.52.0':
-    resolution: {integrity: sha512-nmSVN+F2i1yKZ7rJNKO3G7ZzmxJgoQBQZ/6c4MuS553Grmr7WqR7LLDcYG53Z2m9409z3JLt4sCOhLdbKQ3HmA==}
+  '@rollup/rollup-linux-x64-gnu@4.52.4':
+    resolution: {integrity: sha512-Wi6AXf0k0L7E2gteNsNHUs7UMwCIhsCTs6+tqQ5GPwVRWMaflqGec4Sd8n6+FNFDw9vGcReqk2KzBDhCa1DLYg==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.52.0':
-    resolution: {integrity: sha512-2d0qRo33G6TfQVjaMR71P+yJVGODrt5V6+T0BDYH4EMfGgdC/2HWDVjSSFw888GSzAZUwuska3+zxNUCDco6rQ==}
+  '@rollup/rollup-linux-x64-musl@4.52.4':
+    resolution: {integrity: sha512-dtBZYjDmCQ9hW+WgEkaffvRRCKm767wWhxsFW3Lw86VXz/uJRuD438/XvbZT//B96Vs8oTA8Q4A0AfHbrxP9zw==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-openharmony-arm64@4.52.0':
-    resolution: {integrity: sha512-A1JalX4MOaFAAyGgpO7XP5khquv/7xKzLIyLmhNrbiCxWpMlnsTYr8dnsWM7sEeotNmxvSOEL7F65j0HXFcFsw==}
+  '@rollup/rollup-openharmony-arm64@4.52.4':
+    resolution: {integrity: sha512-1ox+GqgRWqaB1RnyZXL8PD6E5f7YyRUJYnCqKpNzxzP0TkaUh112NDrR9Tt+C8rJ4x5G9Mk8PQR3o7Ku2RKqKA==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.52.0':
-    resolution: {integrity: sha512-YQugafP/rH0eOOHGjmNgDURrpYHrIX0yuojOI8bwCyXwxC9ZdTd3vYkmddPX0oHONLXu9Rb1dDmT0VNpjkzGGw==}
+  '@rollup/rollup-win32-arm64-msvc@4.52.4':
+    resolution: {integrity: sha512-8GKr640PdFNXwzIE0IrkMWUNUomILLkfeHjXBi/nUvFlpZP+FA8BKGKpacjW6OUUHaNI6sUURxR2U2g78FOHWQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.52.0':
-    resolution: {integrity: sha512-zYdUYhi3Qe2fndujBqL5FjAFzvNeLxtIqfzNEVKD1I7C37/chv1VxhscWSQHTNfjPCrBFQMnynwA3kpZpZ8w4A==}
+  '@rollup/rollup-win32-ia32-msvc@4.52.4':
+    resolution: {integrity: sha512-AIy/jdJ7WtJ/F6EcfOb2GjR9UweO0n43jNObQMb6oGxkYTfLcnN7vYYpG+CN3lLxrQkzWnMOoNSHTW54pgbVxw==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.52.0':
-    resolution: {integrity: sha512-fGk03kQylNaCOQ96HDMeT7E2n91EqvCDd3RwvT5k+xNdFCeMGnj5b5hEgTGrQuyidqSsD3zJDQ21QIaxXqTBJw==}
+  '@rollup/rollup-win32-x64-gnu@4.52.4':
+    resolution: {integrity: sha512-UF9KfsH9yEam0UjTwAgdK0anlQ7c8/pWPU2yVjyWcF1I1thABt6WXE47cI71pGiZ8wGvxohBoLnxM04L/wj8mQ==}
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.52.0':
-    resolution: {integrity: sha512-6iKDCVSIUQ8jPMoIV0OytRKniaYyy5EbY/RRydmLW8ZR3cEBhxbWl5ro0rkUNe0ef6sScvhbY79HrjRm8i3vDQ==}
+  '@rollup/rollup-win32-x64-msvc@4.52.4':
+    resolution: {integrity: sha512-bf9PtUa0u8IXDVxzRToFQKsNCRz9qLYfR/MpECxl4mRoWYjAeFjgxj1XdZr2M/GNVpT05p+LgQOHopYDlUu6/w==}
     cpu: [x64]
     os: [win32]
 
@@ -1857,8 +1860,8 @@ packages:
     resolution: {integrity: sha512-JZlVFE6/dYpP9tQmV0/ADfn32L9uFarHWxfcRhReKUnljz1ZiUM5zpX+PH8h5CJs6lao3TuFqnPm9IJJCEkE2w==}
     engines: {node: '>=10.8'}
 
-  '@sveltejs/acorn-typescript@1.0.5':
-    resolution: {integrity: sha512-IwQk4yfwLdibDlrXVE04jTZYlLnwsTT2PIOQQGNLWfjavGifnk1JD1LcZjZaBTRcxZu2FfPfNLOE04DSu9lqtQ==}
+  '@sveltejs/acorn-typescript@1.0.6':
+    resolution: {integrity: sha512-4awhxtMh4cx9blePWl10HRHj8Iivtqj+2QdDCSMDzxG+XKa9+VCNupQuCuvzEhYPzZSrX+0gC+0lHA/0fFKKQQ==}
     peerDependencies:
       acorn: ^8.9.0
 
@@ -1899,8 +1902,8 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
-  '@types/express-serve-static-core@4.19.6':
-    resolution: {integrity: sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==}
+  '@types/express-serve-static-core@4.19.7':
+    resolution: {integrity: sha512-FvPtiIf1LfhzsaIXhv/PHan/2FeQBbtBDtfX2QfvPxdUelMDEckK08SM6nqo1MIZY3RUlfA+HV8+hFUSio78qg==}
 
   '@types/express@4.17.23':
     resolution: {integrity: sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==}
@@ -1941,11 +1944,11 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@18.19.127':
-    resolution: {integrity: sha512-gSjxjrnKXML/yo0BO099uPixMqfpJU0TKYjpfLU7TrtA2WWDki412Np/RSTPRil1saKBhvVVKzVx/p/6p94nVA==}
+  '@types/node@18.19.129':
+    resolution: {integrity: sha512-hrmi5jWt2w60ayox3iIXwpMEnfUvOLJCRtrOPbHtH15nTjvO7uhnelvrdAs0dO0/zl5DZ3ZbahiaXEVb54ca/A==}
 
-  '@types/node@20.19.17':
-    resolution: {integrity: sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==}
+  '@types/node@20.19.19':
+    resolution: {integrity: sha512-pb1Uqj5WJP7wrcbLU7Ru4QtA0+3kAXrkutGiD26wUKzSMgNNaPARTUDQmElUXp64kh3cWdou3Q0C7qwwxqSFmg==}
 
   '@types/papaparse@5.3.16':
     resolution: {integrity: sha512-T3VuKMC2H0lgsjI9buTB3uuKj3EMD2eap1MOuEQuBQ44EnDx/IkGhU6EwiTf9zG3za4SKlmwKAImdDKdNnCsXg==}
@@ -1956,8 +1959,8 @@ packages:
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
 
-  '@types/react@19.1.13':
-    resolution: {integrity: sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==}
+  '@types/react@19.2.2':
+    resolution: {integrity: sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==}
 
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
@@ -1965,8 +1968,11 @@ packages:
   '@types/send@0.17.5':
     resolution: {integrity: sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==}
 
-  '@types/serve-static@1.15.8':
-    resolution: {integrity: sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==}
+  '@types/send@1.2.0':
+    resolution: {integrity: sha512-zBF6vZJn1IaMpg3xUF25VK3gd3l8zwE0ZLRX7dsQyQi+jp4E8mMDJNGDYnYse+bQhYwWERTxVwHpi3dMOq7RKQ==}
+
+  '@types/serve-static@1.15.9':
+    resolution: {integrity: sha512-dOTIuqpWLyl3BBXU3maNQsS4A3zuuoYRNIvYSxxhebPfXg2mzWQEPne/nlJ37yOse6uGgR386uTpdsx4D0QZWA==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -1986,63 +1992,63 @@ packages:
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
-  '@typescript-eslint/eslint-plugin@8.44.0':
-    resolution: {integrity: sha512-EGDAOGX+uwwekcS0iyxVDmRV9HX6FLSM5kzrAToLTsr9OWCIKG/y3lQheCq18yZ5Xh78rRKJiEpP0ZaCs4ryOQ==}
+  '@typescript-eslint/eslint-plugin@8.46.0':
+    resolution: {integrity: sha512-hA8gxBq4ukonVXPy0OKhiaUh/68D0E88GSmtC1iAEnGaieuDi38LhS7jdCHRLi6ErJBNDGCzvh5EnzdPwUc0DA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.44.0
+      '@typescript-eslint/parser': ^8.46.0
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/parser@8.44.0':
-    resolution: {integrity: sha512-VGMpFQGUQWYT9LfnPcX8ouFojyrZ/2w3K5BucvxL/spdNehccKhB4jUyB1yBCXpr2XFm0jkECxgrpXBW2ipoAw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/project-service@8.44.0':
-    resolution: {integrity: sha512-ZeaGNraRsq10GuEohKTo4295Z/SuGcSq2LzfGlqiuEvfArzo/VRrT0ZaJsVPuKZ55lVbNk8U6FcL+ZMH8CoyVA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/scope-manager@8.44.0':
-    resolution: {integrity: sha512-87Jv3E+al8wpD+rIdVJm/ItDBe/Im09zXIjFoipOjr5gHUhJmTzfFLuTJ/nPTMc2Srsroy4IBXwcTCHyRR7KzA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.44.0':
-    resolution: {integrity: sha512-x5Y0+AuEPqAInc6yd0n5DAcvtoQ/vyaGwuX5HE9n6qAefk1GaedqrLQF8kQGylLUb9pnZyLf+iEiL9fr8APDtQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/type-utils@8.44.0':
-    resolution: {integrity: sha512-9cwsoSxJ8Sak67Be/hD2RNt/fsqmWnNE1iHohG8lxqLSNY8xNfyY7wloo5zpW3Nu9hxVgURevqfcH6vvKCt6yg==}
+  '@typescript-eslint/parser@8.46.0':
+    resolution: {integrity: sha512-n1H6IcDhmmUEG7TNVSspGmiHHutt7iVKtZwRppD7e04wha5MrkV1h3pti9xQLcCMt6YWsncpoT0HMjkH1FNwWQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/types@8.44.0':
-    resolution: {integrity: sha512-ZSl2efn44VsYM0MfDQe68RKzBz75NPgLQXuGypmym6QVOWL5kegTZuZ02xRAT9T+onqvM6T8CdQk0OwYMB6ZvA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.44.0':
-    resolution: {integrity: sha512-lqNj6SgnGcQZwL4/SBJ3xdPEfcBuhCG8zdcwCPgYcmiPLgokiNDKlbPzCwEwu7m279J/lBYWtDYL+87OEfn8Jw==}
+  '@typescript-eslint/project-service@8.46.0':
+    resolution: {integrity: sha512-OEhec0mH+U5Je2NZOeK1AbVCdm0ChyapAyTeXVIYTPXDJ3F07+cu87PPXcGoYqZ7M9YJVvFnfpGg1UmCIqM+QQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/utils@8.44.0':
-    resolution: {integrity: sha512-nktOlVcg3ALo0mYlV+L7sWUD58KG4CMj1rb2HUVOO4aL3K/6wcD+NERqd0rrA5Vg06b42YhF6cFxeixsp9Riqg==}
+  '@typescript-eslint/scope-manager@8.46.0':
+    resolution: {integrity: sha512-lWETPa9XGcBes4jqAMYD9fW0j4n6hrPtTJwWDmtqgFO/4HF4jmdH/Q6wggTw5qIT5TXjKzbt7GsZUBnWoO3dqw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.46.0':
+    resolution: {integrity: sha512-WrYXKGAHY836/N7zoK/kzi6p8tXFhasHh8ocFL9VZSAkvH956gfeRfcnhs3xzRy8qQ/dq3q44v1jvQieMFg2cw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/type-utils@8.46.0':
+    resolution: {integrity: sha512-hy+lvYV1lZpVs2jRaEYvgCblZxUoJiPyCemwbQZ+NGulWkQRy0HRPYAoef/CNSzaLt+MLvMptZsHXHlkEilaeg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/visitor-keys@8.44.0':
-    resolution: {integrity: sha512-zaz9u8EJ4GBmnehlrpoKvj/E3dNbuQ7q0ucyZImm3cLqJ8INTc970B1qEqDX/Rzq65r3TvVTN7kHWPBoyW7DWw==}
+  '@typescript-eslint/types@8.46.0':
+    resolution: {integrity: sha512-bHGGJyVjSE4dJJIO5yyEWt/cHyNwga/zXGJbJJ8TiO01aVREK6gCTu3L+5wrkb1FbDkQ+TKjMNe9R/QQQP9+rA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.46.0':
+    resolution: {integrity: sha512-ekDCUfVpAKWJbRfm8T1YRrCot1KFxZn21oV76v5Fj4tr7ELyk84OS+ouvYdcDAwZL89WpEkEj2DKQ+qg//+ucg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/utils@8.46.0':
+    resolution: {integrity: sha512-nD6yGWPj1xiOm4Gk0k6hLSZz2XkNXhuYmyIrOWcHoPuAhjT9i5bAG+xbWPgFeNR8HPHHtpNKdYUXJl/D3x7f5g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/visitor-keys@8.46.0':
+    resolution: {integrity: sha512-FrvMpAK+hTbFy7vH5j1+tMYHMSKLE6RzluFJlkFNKD0p9YsUT75JlBSmr5so3QRzvMwU5/bIEdeNrxm8du8l3Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript/vfs@1.6.1':
@@ -2062,34 +2068,34 @@ packages:
       '@aws-sdk/credential-provider-web-identity':
         optional: true
 
-  '@vue/compiler-core@3.5.21':
-    resolution: {integrity: sha512-8i+LZ0vf6ZgII5Z9XmUvrCyEzocvWT+TeR2VBUVlzIH6Tyv57E20mPZ1bCS+tbejgUgmjrEh7q/0F0bibskAmw==}
+  '@vue/compiler-core@3.5.22':
+    resolution: {integrity: sha512-jQ0pFPmZwTEiRNSb+i9Ow/I/cHv2tXYqsnHKKyCQ08irI2kdF5qmYedmF8si8mA7zepUFmJ2hqzS8CQmNOWOkQ==}
 
-  '@vue/compiler-dom@3.5.21':
-    resolution: {integrity: sha512-jNtbu/u97wiyEBJlJ9kmdw7tAr5Vy0Aj5CgQmo+6pxWNQhXZDPsRr1UWPN4v3Zf82s2H3kF51IbzZ4jMWAgPlQ==}
+  '@vue/compiler-dom@3.5.22':
+    resolution: {integrity: sha512-W8RknzUM1BLkypvdz10OVsGxnMAuSIZs9Wdx1vzA3mL5fNMN15rhrSCLiTm6blWeACwUwizzPVqGJgOGBEN/hA==}
 
-  '@vue/compiler-sfc@3.5.21':
-    resolution: {integrity: sha512-SXlyk6I5eUGBd2v8Ie7tF6ADHE9kCR6mBEuPyH1nUZ0h6Xx6nZI29i12sJKQmzbDyr2tUHMhhTt51Z6blbkTTQ==}
+  '@vue/compiler-sfc@3.5.22':
+    resolution: {integrity: sha512-tbTR1zKGce4Lj+JLzFXDq36K4vcSZbJ1RBu8FxcDv1IGRz//Dh2EBqksyGVypz3kXpshIfWKGOCcqpSbyGWRJQ==}
 
-  '@vue/compiler-ssr@3.5.21':
-    resolution: {integrity: sha512-vKQ5olH5edFZdf5ZrlEgSO1j1DMA4u23TVK5XR1uMhvwnYvVdDF0nHXJUblL/GvzlShQbjhZZ2uvYmDlAbgo9w==}
+  '@vue/compiler-ssr@3.5.22':
+    resolution: {integrity: sha512-GdgyLvg4R+7T8Nk2Mlighx7XGxq/fJf9jaVofc3IL0EPesTE86cP/8DD1lT3h1JeZr2ySBvyqKQJgbS54IX1Ww==}
 
-  '@vue/reactivity@3.5.21':
-    resolution: {integrity: sha512-3ah7sa+Cwr9iiYEERt9JfZKPw4A2UlbY8RbbnH2mGCE8NwHkhmlZt2VsH0oDA3P08X3jJd29ohBDtX+TbD9AsA==}
+  '@vue/reactivity@3.5.22':
+    resolution: {integrity: sha512-f2Wux4v/Z2pqc9+4SmgZC1p73Z53fyD90NFWXiX9AKVnVBEvLFOWCEgJD3GdGnlxPZt01PSlfmLqbLYzY/Fw4A==}
 
-  '@vue/runtime-core@3.5.21':
-    resolution: {integrity: sha512-+DplQlRS4MXfIf9gfD1BOJpk5RSyGgGXD/R+cumhe8jdjUcq/qlxDawQlSI8hCKupBlvM+3eS1se5xW+SuNAwA==}
+  '@vue/runtime-core@3.5.22':
+    resolution: {integrity: sha512-EHo4W/eiYeAzRTN5PCextDUZ0dMs9I8mQ2Fy+OkzvRPUYQEyK9yAjbasrMCXbLNhF7P0OUyivLjIy0yc6VrLJQ==}
 
-  '@vue/runtime-dom@3.5.21':
-    resolution: {integrity: sha512-3M2DZsOFwM5qI15wrMmNF5RJe1+ARijt2HM3TbzBbPSuBHOQpoidE+Pa+XEaVN+czbHf81ETRoG1ltztP2em8w==}
+  '@vue/runtime-dom@3.5.22':
+    resolution: {integrity: sha512-Av60jsryAkI023PlN7LsqrfPvwfxOd2yAwtReCjeuugTJTkgrksYJJstg1e12qle0NarkfhfFu1ox2D+cQotww==}
 
-  '@vue/server-renderer@3.5.21':
-    resolution: {integrity: sha512-qr8AqgD3DJPJcGvLcJKQo2tAc8OnXRcfxhOJCPF+fcfn5bBGz7VCcO7t+qETOPxpWK1mgysXvVT/j+xWaHeMWA==}
+  '@vue/server-renderer@3.5.22':
+    resolution: {integrity: sha512-gXjo+ao0oHYTSswF+a3KRHZ1WszxIqO7u6XwNHqcqb9JfyIL/pbWrrh/xLv7jeDqla9u+LK7yfZKHih1e1RKAQ==}
     peerDependencies:
-      vue: 3.5.21
+      vue: 3.5.22
 
-  '@vue/shared@3.5.21':
-    resolution: {integrity: sha512-+2k1EQpnYuVuu3N7atWyG3/xoFWIVJZq4Mz8XNOdScFI0etES75fbny/oU4lKWk/577P1zmg0ioYvpGEDZ3DLw==}
+  '@vue/shared@3.5.22':
+    resolution: {integrity: sha512-F4yc6palwq3TT0u+FYf0Ns4Tfl9GRFURDN2gWG7L1ecIaS/4fCIuFOjMTnCyjsu/OK6vaDKLCrGAa+KvvH+h4w==}
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -2203,8 +2209,8 @@ packages:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
 
-  ansi-escapes@7.1.0:
-    resolution: {integrity: sha512-YdhtCd19sKRKfAAUsrcC1wzm4JuzJoiX4pOJqIoW2qmKj5WzG/dL8uUJ0361zaXtHqK7gEhOwtAtz7t3Yq3X5g==}
+  ansi-escapes@7.1.1:
+    resolution: {integrity: sha512-Zhl0ErHcSRUaVfGUeUdDuLgpkEo8KIFjB4Y9uAc46ScOpdDiU1Dbyplh7qWJeJ/ZHpbyMSM26+X3BySgnIz40Q==}
     engines: {node: '>=18'}
 
   ansi-regex@5.0.1:
@@ -2316,8 +2322,8 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
-  b4a@1.7.1:
-    resolution: {integrity: sha512-ZovbrBV0g6JxK5cGUF1Suby1vLfKjv4RWi8IxoaO/Mon8BDD9I21RxjHFtgQ+kskJqLAVyQZly3uMBui+vhc8Q==}
+  b4a@1.7.3:
+    resolution: {integrity: sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==}
     peerDependencies:
       react-native-b4a: '*'
     peerDependenciesMeta:
@@ -2333,8 +2339,8 @@ packages:
   bare-events@2.7.0:
     resolution: {integrity: sha512-b3N5eTW1g7vXkw+0CXh/HazGTcO5KYuu/RCNaJbDMPI6LHDi+7qe8EmxKUVe1sUbY2KZOVZFyj62x0OEz9qyAA==}
 
-  bare-fs@4.4.4:
-    resolution: {integrity: sha512-Q8yxM1eLhJfuM7KXVP3zjhBvtMJCYRByoTT+wHXjpdMELv0xICFJX+1w4c7csa+WZEOsq4ItJ4RGwvzid6m/dw==}
+  bare-fs@4.4.5:
+    resolution: {integrity: sha512-TCtu93KGLu6/aiGWzMr12TmSRS6nKdfhAnzTQRbXoSWxkbb9eRd53jQ51jG7g1gYjjtto3hbBrrhzg6djcgiKg==}
     engines: {bare: '>=1.16.0'}
     peerDependencies:
       bare-buffer: '*'
@@ -2592,6 +2598,10 @@ packages:
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
 
+  color-blend@4.0.0:
+    resolution: {integrity: sha512-fYODTHhI/NG+B5GnzvuL3kiFrK/UnkUezWFTgEPBTY5V+kpyfAn95Vn9sJeeCX6omrCOdxnqCL3CvH+6sXtIbw==}
+    engines: {node: '>=10.0.0'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -2771,6 +2781,14 @@ packages:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
 
+  decode-bmp@0.2.1:
+    resolution: {integrity: sha512-NiOaGe+GN0KJqi2STf24hfMkFitDUaIoUU3eKvP/wAbLe8o6FuW5n/x7MHPR0HKvBokp6MQY/j7w8lewEeVCIA==}
+    engines: {node: '>=8.6.0'}
+
+  decode-ico@0.4.1:
+    resolution: {integrity: sha512-69NZfbKIzux1vBOd31al3XnMnH+2mqDhEgLdpygErm4d60N+UwA5Sq5WFjmEDQzumgB9fElojGwWG0vybVfFmA==}
+    engines: {node: '>=8.6'}
+
   decode-named-character-reference@1.2.0:
     resolution: {integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==}
 
@@ -2829,8 +2847,8 @@ packages:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
 
-  detect-libc@2.1.0:
-    resolution: {integrity: sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==}
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
   detect-node-es@1.1.0:
@@ -3050,8 +3068,8 @@ packages:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  eslint@9.36.0:
-    resolution: {integrity: sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==}
+  eslint@9.37.0:
+    resolution: {integrity: sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     hasBin: true
     peerDependencies:
@@ -3126,6 +3144,9 @@ packages:
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
 
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
   eventsource-parser@1.1.2:
     resolution: {integrity: sha512-v0eOBUbiaFojBu2s2NPBfYUoRR9GjcDNvCXVaqEf5vVfpIAh9f8RCo4vXTP8c63QRKCFwoLpMpTdPwwhEKVgzA==}
     engines: {node: '>=14.18'}
@@ -3188,10 +3209,6 @@ packages:
 
   fast-memoize@2.5.2:
     resolution: {integrity: sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==}
-
-  fast-redact@3.5.0:
-    resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
-    engines: {node: '>=6'}
 
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
@@ -3356,6 +3373,10 @@ packages:
     resolution: {integrity: sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==}
     engines: {node: '>=14'}
 
+  generator-function@2.0.1:
+    resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
+    engines: {node: '>= 0.4'}
+
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -3388,8 +3409,8 @@ packages:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
 
-  get-tsconfig@4.10.1:
-    resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
+  get-tsconfig@4.11.0:
+    resolution: {integrity: sha512-sNsqf7XKQ38IawiVGPOoAlqZo1DMrO7TU+ZcZwi7yLl7/7S0JwmoBMKz/IkUPhSoXM0Ng3vT0yB1iCe5XavDeQ==}
 
   get-uri@6.0.5:
     resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
@@ -3544,6 +3565,10 @@ packages:
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
 
+  hex-rgb@5.0.0:
+    resolution: {integrity: sha512-NQO+lgVUCtHxZ792FodgW0zflK+ozS9X9dwGp9XvvmPlH7pyxd588cn24TD3rmPm/N0AIRXF10Otah8yKqGw4w==}
+    engines: {node: '>=12'}
+
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
@@ -3569,12 +3594,15 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
-  human-id@4.1.1:
-    resolution: {integrity: sha512-3gKm/gCSUipeLsRYZbbdA1BD83lBoWUkZ7G9VFrhWPAU76KwYo5KR8V28bpoPm/ygy0x5/GCbpRQdY7VLYCoIg==}
+  human-id@4.1.2:
+    resolution: {integrity: sha512-v/J+4Z/1eIJovEBdlV5TYj1IR+ZiohcYGRY+qN/oC9dAfKzVT023N/Bgw37hrKCoVRBvk3bqyzpr2PP5YeTMSg==}
     hasBin: true
 
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+
+  ico-endec@0.1.6:
+    resolution: {integrity: sha512-ZdLU38ZoED3g1j3iEyzcQj+wAkY2xfWNkymszfJPoxucIUhK7NayQ+/C4Kv0nDFMIsbtbEHldv3V8PU494/ueQ==}
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -3758,8 +3786,8 @@ packages:
     resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
     engines: {node: '>=18'}
 
-  is-generator-function@1.1.0:
-    resolution: {integrity: sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==}
+  is-generator-function@1.1.2:
+    resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
     engines: {node: '>= 0.4'}
 
   is-glob@4.0.3:
@@ -3955,8 +3983,8 @@ packages:
   jws@4.0.0:
     resolution: {integrity: sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==}
 
-  katex@0.16.22:
-    resolution: {integrity: sha512-XCHRdUw4lf3SKBaJe4EvgqIuWwkPSo9XoeO8GjQW94Bp7TWv9hNhzZjZ+OH9yf1UmLygb7DIT5GSFQiyt16zYg==}
+  katex@0.16.23:
+    resolution: {integrity: sha512-7VlC1hsEEolL9xNO05v9VjrvWZePkCVBJqj8ruICxYjZfHaHbaU53AlP+PODyFIXEnaEIEWi3wJy7FPZ95JAVg==}
     hasBin: true
 
   keyv@4.5.4:
@@ -3966,8 +3994,8 @@ packages:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
 
-  langsmith@0.3.69:
-    resolution: {integrity: sha512-YKzu92YAP2o+d+1VmR38xqFX0RIRLKYj1IqdflVEY83X0FoiVlrWO3xDLXgnu7vhZ2N2M6jx8VO9fVF8yy9gHA==}
+  langsmith@0.3.72:
+    resolution: {integrity: sha512-XjTonMq2fIebzV0BRlPx8mi+Ih/NsQT6W484hrW/pJYuq0aT5kpLtzQthVVmsXH8ZYYkgkbQ5Gh5Mz1qoCrAwg==}
     peerDependencies:
       '@opentelemetry/api': '*'
       '@opentelemetry/exporter-trace-otlp-proto': '*'
@@ -4331,8 +4359,8 @@ packages:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
     engines: {node: '>= 8'}
 
-  mintlify@4.2.121:
-    resolution: {integrity: sha512-th+5Biyxd7puX2UmOV5Ns9dsZ8vJsGEYLuA/ToUHxP+FVhE/tiPMy5WekDAqS+rvASlS9icY2qXhXb+wYaDiIA==}
+  mintlify@4.2.149:
+    resolution: {integrity: sha512-vWYgmTilbaAlhUiJnoYTGI4jnPs1xM7oTVrTKKNvOs5ay0mVc8OvDOrw8bNIy/HIQzLx3rMdrP2xBI9Lvy5cFg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -4360,8 +4388,8 @@ packages:
   ml-matrix@6.12.1:
     resolution: {integrity: sha512-TJ+8eOFdp+INvzR4zAuwBQJznDUfktMtOB6g/hUcGh3rcyjxbz4Te57Pgri8Q9bhSQ7Zys4IYOGhFdnlgeB6Lw==}
 
-  ml-spectra-processing@14.17.1:
-    resolution: {integrity: sha512-ff2K8Nb91I5fSYcRRiHH0RvUIX1nC4TGg/ctbbyf6R7SUR5MgKF5Kicj+w1HACCK4DQ1HvSc2ZHVE2Z1NDvCRQ==}
+  ml-spectra-processing@14.18.0:
+    resolution: {integrity: sha512-vzk7Lf/21mm9Otjn13xDFsFL4reDViU6GbtAxQfkXtprARxRRoQScbnlDNE11UhOKXy88/FTnR4vf2osMkT4fA==}
 
   ml-xsadd@3.0.1:
     resolution: {integrity: sha512-Fz2q6dwgzGM8wYKGArTUTZDGa4lQFA2Vi6orjGeTVRy22ZnQFKlJuwS9n8NRviqz1KHAHAzdKJwbnYhdo38uYg==}
@@ -4419,8 +4447,8 @@ packages:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
     engines: {node: '>= 0.4.0'}
 
-  next-mdx-remote-client@1.1.2:
-    resolution: {integrity: sha512-LZJxBU420dTZsbWOrNYZXkahGJu8lNKxLTrQrZl4JUsKeFtp91yA78dHMTfOcp7UAud3txhM1tayyoKFq4tw7A==}
+  next-mdx-remote-client@1.1.3:
+    resolution: {integrity: sha512-jrmU2IXTM8XhGUfZgaEbLQPW3waewz/rCkwq+DnpBCf1Mh0XpHT9FV6M5m4n7W3CUdaHZX3yl7X1e8Sr+Sq45A==}
     engines: {node: '>=18.18.0'}
     peerDependencies:
       react: '>= 18.3.0 < 19.0.0'
@@ -4728,8 +4756,8 @@ packages:
   pino-std-serializers@7.0.0:
     resolution: {integrity: sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==}
 
-  pino@9.10.0:
-    resolution: {integrity: sha512-VOFxoNnxICtxaN8S3E73pR66c5MTFC+rwRcNRyHV/bV/c90dXvJqMfjkeRFsGBDXmlUN3LccJQPqGIufnaJePA==}
+  pino@9.13.1:
+    resolution: {integrity: sha512-Szuj+ViDTjKPQYiKumGmEn3frdl+ZPSdosHyt9SnUevFosOkMY2b7ipxlEctNKPmMD/VibeBI+ZcZCJK+4DPuw==}
     hasBin: true
 
   pirates@4.0.7:
@@ -4743,13 +4771,13 @@ packages:
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
-  playwright-core@1.55.0:
-    resolution: {integrity: sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==}
+  playwright-core@1.56.0:
+    resolution: {integrity: sha512-1SXl7pMfemAMSDn5rkPeZljxOCYAmQnYLBTExuh6E8USHXGSX3dx6lYZN/xPpTz1vimXmPA9CDnILvmJaB8aSQ==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.55.0:
-    resolution: {integrity: sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==}
+  playwright@1.56.0:
+    resolution: {integrity: sha512-X5Q1b8lOdWIE4KAoHpW3SE8HvUB+ZZsUoN64ZhjnN8dOb1UpujxBtENGiZFE+9F/yhzJwYa+ca3u43FeLbboHA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -4776,18 +4804,6 @@ packages:
     engines: {node: ^12 || ^14 || >= 16}
     peerDependencies:
       postcss: ^8.4.21
-
-  postcss-load-config@4.0.2:
-    resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
-    engines: {node: '>= 14'}
-    peerDependencies:
-      postcss: '>=8.0.9'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      postcss:
-        optional: true
-      ts-node:
-        optional: true
 
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
@@ -4880,7 +4896,7 @@ packages:
   puppeteer@22.15.0:
     resolution: {integrity: sha512-XjCY1SiSEi1T7iSYuxS82ft85kwDJUS7wj1Z0eGVXKdtr5g4xnVcbjwxhq5xBnpK/E7x1VZZoJDxpjAOasHT4Q==}
     engines: {node: '>=18'}
-    deprecated: < 24.10.2 is no longer supported
+    deprecated: < 24.15.0 is no longer supported
     hasBin: true
 
   qs@6.13.0:
@@ -4957,8 +4973,8 @@ packages:
       '@types/react':
         optional: true
 
-  react@19.1.1:
-    resolution: {integrity: sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==}
+  react@19.2.0:
+    resolution: {integrity: sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==}
     engines: {node: '>=0.10.0'}
 
   read-cache@1.0.0:
@@ -5114,8 +5130,8 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  rollup@4.52.0:
-    resolution: {integrity: sha512-+IuescNkTJQgX7AkIDtITipZdIGcWF0pnVvZTWStiazUmcGA2ag8dfg0urest2XlXUi9kuhfQ+qmdc5Stc3z7g==}
+  rollup@4.52.4:
+    resolution: {integrity: sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -5177,8 +5193,8 @@ packages:
   secure-json-parse@2.7.0:
     resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
 
-  secure-json-parse@4.0.0:
-    resolution: {integrity: sha512-dxtLJO6sc35jWidmLxo7ij+Eg48PM/kleBsxpC8QJE0qJICe+KawkDQmvCMZUr9u7WKVHgMW6vy3fQ7zMiFZMA==}
+  secure-json-parse@4.1.0:
+    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
   semver@7.7.2:
     resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
@@ -5225,6 +5241,9 @@ packages:
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  sharp-ico@0.1.5:
+    resolution: {integrity: sha512-a3jODQl82NPp1d5OYb0wY+oFaPk7AvyxipIowCHk7pBsZCWgbe0yAkU2OOXdoH0ENyANhyOQbs9xkAiRHcF02Q==}
 
   sharp@0.33.5:
     resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
@@ -5288,6 +5307,9 @@ packages:
   slice-ansi@7.1.2:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
     engines: {node: '>=18'}
+
+  slow-redact@0.3.1:
+    resolution: {integrity: sha512-NvFvl1GuLZNW4U046Tfi8b26zXo8aBzgCAS2f7yVJR/fArN93mOqSA99cB9uITm92ajSz01bsu1K7SCVVjIMpQ==}
 
   slugify@1.6.6:
     resolution: {integrity: sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==}
@@ -5374,8 +5396,8 @@ packages:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
 
-  streamx@2.22.1:
-    resolution: {integrity: sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==}
+  streamx@2.23.0:
+    resolution: {integrity: sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==}
 
   string-comparison@1.3.0:
     resolution: {integrity: sha512-46aD+slEwybxAMPRII83ATbgMgTiz5P8mVd7Z6VJsCzSHFjdt1hkAVLeFxPIyEb11tc6ihpJTlIqoO0MCF6NPw==}
@@ -5454,8 +5476,8 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  svelte@5.39.3:
-    resolution: {integrity: sha512-7Jwus6iXviGZAvhqbeYu3NNHA6LGyQ8EbmjdAhJUDade5rrW6g9VnBbRhUuYX4pMZLHozijsFolt88zvKPfsbQ==}
+  svelte@5.39.10:
+    resolution: {integrity: sha512-Q3gqCGIgl4r0CR7OaWYjVo22nqFmLLSfn1MiWNFaITamvqhGBD3kyqk51EKuO4Nd1z8QliO5KIz7a2Ka9Rxilw==}
     engines: {node: '>=18'}
 
   swr@2.3.6:
@@ -5471,8 +5493,8 @@ packages:
     peerDependencies:
       vue: '>=3.2.26 < 4'
 
-  tailwindcss@3.4.17:
-    resolution: {integrity: sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==}
+  tailwindcss@3.4.18:
+    resolution: {integrity: sha512-6A2rnmW5xZMdw11LYjhcI5846rt9pbLSabY5XPxo+XWdxwZaFEn47Go4NzFiHu9sNNmr/kXivP1vStfvMaK1GQ==}
     engines: {node: '>=14.0.0'}
     hasBin: true
 
@@ -5523,6 +5545,9 @@ packages:
   tldts@6.1.86:
     resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
     hasBin: true
+
+  to-data-view@1.1.0:
+    resolution: {integrity: sha512-1eAdufMg6mwgmlojAx3QeMnzB/BTVp7Tbndi3U7ftcT2zCZadjxkkmLmd97zmaxWi+sgGcgWrokmpEoy0Dn0vQ==}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -5589,8 +5614,8 @@ packages:
       typescript:
         optional: true
 
-  tsx@4.20.5:
-    resolution: {integrity: sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==}
+  tsx@4.20.6:
+    resolution: {integrity: sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -5637,15 +5662,15 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  typescript-eslint@8.44.0:
-    resolution: {integrity: sha512-ib7mCkYuIzYonCq9XWF5XNw+fkj2zg629PSa9KNIQ47RXFF763S5BIX4wqz1+FLPogTZoiw8KmCiRPRa8bL3qw==}
+  typescript-eslint@8.46.0:
+    resolution: {integrity: sha512-6+ZrB6y2bT2DX3K+Qd9vn7OFOJR+xSLDj+Aw/N3zBwUt27uTw2sw2TE2+UcY1RiyBZkaGbTkVg9SSdPNUG6aUw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  typescript@5.9.2:
-    resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -5761,8 +5786,8 @@ packages:
       '@types/react':
         optional: true
 
-  use-sync-external-store@1.5.0:
-    resolution: {integrity: sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==}
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -5779,6 +5804,10 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
+
+  uuid@11.1.0:
+    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
 
   uuid@9.0.1:
@@ -5807,8 +5836,8 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vue@3.5.21:
-    resolution: {integrity: sha512-xxf9rum9KtOdwdRkiApWL+9hZEMWE90FHh8yS1+KJAiWYh+iGWV1FquPjoO9VUHQ+VIhsCXNNyZ5Sf4++RVZBA==}
+  vue@3.5.22:
+    resolution: {integrity: sha512-toaZjQ3a/G/mYaLSbV+QsQhIdMo9x5rrqIpYRObsJ6T/J+RyCSFwN2LHNVH9v8uIcljDNa3QzPVdv3Y6b9hAJQ==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -6087,22 +6116,22 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@0.0.70(react@19.1.1)(zod@3.25.67)':
+  '@ai-sdk/react@0.0.70(react@19.2.0)(zod@3.25.67)':
     dependencies:
       '@ai-sdk/provider-utils': 1.0.22(zod@3.25.67)
       '@ai-sdk/ui-utils': 0.0.50(zod@3.25.67)
-      swr: 2.3.6(react@19.1.1)
+      swr: 2.3.6(react@19.2.0)
       throttleit: 2.1.0
     optionalDependencies:
-      react: 19.1.1
+      react: 19.2.0
       zod: 3.25.67
 
-  '@ai-sdk/react@1.2.12(react@19.1.1)(zod@3.25.67)':
+  '@ai-sdk/react@1.2.12(react@19.2.0)(zod@3.25.67)':
     dependencies:
       '@ai-sdk/provider-utils': 2.2.8(zod@3.25.67)
       '@ai-sdk/ui-utils': 1.2.11(zod@3.25.67)
-      react: 19.1.1
-      swr: 2.3.6(react@19.1.1)
+      react: 19.2.0
+      swr: 2.3.6(react@19.2.0)
       throttleit: 2.1.0
     optionalDependencies:
       zod: 3.25.67
@@ -6114,13 +6143,13 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  '@ai-sdk/svelte@0.0.57(svelte@5.39.3)(zod@3.25.67)':
+  '@ai-sdk/svelte@0.0.57(svelte@5.39.10)(zod@3.25.67)':
     dependencies:
       '@ai-sdk/provider-utils': 1.0.22(zod@3.25.67)
       '@ai-sdk/ui-utils': 0.0.50(zod@3.25.67)
-      sswr: 2.2.0(svelte@5.39.3)
+      sswr: 2.2.0(svelte@5.39.10)
     optionalDependencies:
-      svelte: 5.39.3
+      svelte: 5.39.10
     transitivePeerDependencies:
       - zod
 
@@ -6149,13 +6178,13 @@ snapshots:
       zod: 3.25.67
       zod-to-json-schema: 3.24.6(zod@3.25.67)
 
-  '@ai-sdk/vue@0.0.59(vue@3.5.21(typescript@5.9.2))(zod@3.25.67)':
+  '@ai-sdk/vue@0.0.59(vue@3.5.22(typescript@5.9.3))(zod@3.25.67)':
     dependencies:
       '@ai-sdk/provider-utils': 1.0.22(zod@3.25.67)
       '@ai-sdk/ui-utils': 0.0.50(zod@3.25.67)
-      swrv: 1.1.0(vue@3.5.21(typescript@5.9.2))
+      swrv: 1.1.0(vue@3.5.22(typescript@5.9.3))
     optionalDependencies:
-      vue: 3.5.21(typescript@5.9.2)
+      vue: 3.5.22(typescript@5.9.3)
     transitivePeerDependencies:
       - zod
 
@@ -6176,7 +6205,7 @@ snapshots:
 
   '@anthropic-ai/sdk@0.39.0':
     dependencies:
-      '@types/node': 18.19.127
+      '@types/node': 18.19.129
       '@types/node-fetch': 2.6.13
       abort-controller: 3.0.0
       agentkeepalive: 4.6.0
@@ -6260,7 +6289,7 @@ snapshots:
 
   '@browserbasehq/sdk@2.6.0':
     dependencies:
-      '@types/node': 18.19.127
+      '@types/node': 18.19.129
       '@types/node-fetch': 2.6.13
       abort-controller: 3.0.0
       agentkeepalive: 4.6.0
@@ -6269,6 +6298,8 @@ snapshots:
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
+
+  '@canvas/image-data@1.0.0': {}
 
   '@cfworker/json-schema@4.1.1': {}
 
@@ -6309,7 +6340,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@changesets/cli@2.29.7(@types/node@20.19.17)':
+  '@changesets/cli@2.29.7(@types/node@20.19.19)':
     dependencies:
       '@changesets/apply-release-plan': 7.0.13
       '@changesets/assemble-release-plan': 6.0.9
@@ -6325,7 +6356,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.2(@types/node@20.19.17)
+      '@inquirer/external-editor': 1.0.2(@types/node@20.19.19)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       ci-info: 3.9.0
@@ -6428,7 +6459,7 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
       fs-extra: 7.0.1
-      human-id: 4.1.1
+      human-id: 4.1.2
       prettier: 2.8.8
 
   '@emnapi/runtime@1.5.0':
@@ -6649,9 +6680,9 @@ snapshots:
   '@esbuild/win32-x64@0.25.10':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.0(eslint@9.36.0(jiti@1.21.7))':
+  '@eslint-community/eslint-utils@4.9.0(eslint@9.37.0(jiti@1.21.7))':
     dependencies:
-      eslint: 9.36.0(jiti@1.21.7)
+      eslint: 9.37.0(jiti@1.21.7)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
@@ -6664,9 +6695,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-helpers@0.3.1': {}
+  '@eslint/config-helpers@0.4.0':
+    dependencies:
+      '@eslint/core': 0.16.0
 
-  '@eslint/core@0.15.2':
+  '@eslint/core@0.16.0':
     dependencies:
       '@types/json-schema': 7.0.15
 
@@ -6684,13 +6717,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/js@9.36.0': {}
+  '@eslint/js@9.37.0': {}
 
   '@eslint/object-schema@2.1.6': {}
 
-  '@eslint/plugin-kit@0.3.5':
+  '@eslint/plugin-kit@0.4.0':
     dependencies:
-      '@eslint/core': 0.15.2
+      '@eslint/core': 0.16.0
       levn: 0.4.1
 
   '@floating-ui/core@1.7.3':
@@ -6702,20 +6735,20 @@ snapshots:
       '@floating-ui/core': 1.7.3
       '@floating-ui/utils': 0.2.10
 
-  '@floating-ui/react-dom@2.1.6(react-dom@18.3.1(react@19.1.1))(react@19.1.1)':
+  '@floating-ui/react-dom@2.1.6(react-dom@18.3.1(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@floating-ui/dom': 1.7.4
-      react: 19.1.1
-      react-dom: 18.3.1(react@19.1.1)
+      react: 19.2.0
+      react-dom: 18.3.1(react@19.2.0)
 
   '@floating-ui/utils@0.2.10': {}
 
-  '@google/genai@1.22.0(@modelcontextprotocol/sdk@1.18.1)':
+  '@google/genai@1.22.0(@modelcontextprotocol/sdk@1.19.1)':
     dependencies:
       google-auth-library: 9.15.1
       ws: 8.18.3
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.18.1
+      '@modelcontextprotocol/sdk': 1.19.1
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -6810,128 +6843,128 @@ snapshots:
 
   '@inquirer/ansi@1.0.0': {}
 
-  '@inquirer/checkbox@4.2.4(@types/node@20.19.17)':
+  '@inquirer/checkbox@4.2.4(@types/node@20.19.19)':
     dependencies:
       '@inquirer/ansi': 1.0.0
-      '@inquirer/core': 10.2.2(@types/node@20.19.17)
+      '@inquirer/core': 10.2.2(@types/node@20.19.19)
       '@inquirer/figures': 1.0.13
-      '@inquirer/type': 3.0.8(@types/node@20.19.17)
+      '@inquirer/type': 3.0.8(@types/node@20.19.19)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 20.19.17
+      '@types/node': 20.19.19
 
-  '@inquirer/confirm@5.1.18(@types/node@20.19.17)':
+  '@inquirer/confirm@5.1.18(@types/node@20.19.19)':
     dependencies:
-      '@inquirer/core': 10.2.2(@types/node@20.19.17)
-      '@inquirer/type': 3.0.8(@types/node@20.19.17)
+      '@inquirer/core': 10.2.2(@types/node@20.19.19)
+      '@inquirer/type': 3.0.8(@types/node@20.19.19)
     optionalDependencies:
-      '@types/node': 20.19.17
+      '@types/node': 20.19.19
 
-  '@inquirer/core@10.2.2(@types/node@20.19.17)':
+  '@inquirer/core@10.2.2(@types/node@20.19.19)':
     dependencies:
       '@inquirer/ansi': 1.0.0
       '@inquirer/figures': 1.0.13
-      '@inquirer/type': 3.0.8(@types/node@20.19.17)
+      '@inquirer/type': 3.0.8(@types/node@20.19.19)
       cli-width: 4.1.0
       mute-stream: 2.0.0
       signal-exit: 4.1.0
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 20.19.17
+      '@types/node': 20.19.19
 
-  '@inquirer/editor@4.2.20(@types/node@20.19.17)':
+  '@inquirer/editor@4.2.20(@types/node@20.19.19)':
     dependencies:
-      '@inquirer/core': 10.2.2(@types/node@20.19.17)
-      '@inquirer/external-editor': 1.0.2(@types/node@20.19.17)
-      '@inquirer/type': 3.0.8(@types/node@20.19.17)
+      '@inquirer/core': 10.2.2(@types/node@20.19.19)
+      '@inquirer/external-editor': 1.0.2(@types/node@20.19.19)
+      '@inquirer/type': 3.0.8(@types/node@20.19.19)
     optionalDependencies:
-      '@types/node': 20.19.17
+      '@types/node': 20.19.19
 
-  '@inquirer/expand@4.0.20(@types/node@20.19.17)':
+  '@inquirer/expand@4.0.20(@types/node@20.19.19)':
     dependencies:
-      '@inquirer/core': 10.2.2(@types/node@20.19.17)
-      '@inquirer/type': 3.0.8(@types/node@20.19.17)
+      '@inquirer/core': 10.2.2(@types/node@20.19.19)
+      '@inquirer/type': 3.0.8(@types/node@20.19.19)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 20.19.17
+      '@types/node': 20.19.19
 
-  '@inquirer/external-editor@1.0.2(@types/node@20.19.17)':
+  '@inquirer/external-editor@1.0.2(@types/node@20.19.19)':
     dependencies:
       chardet: 2.1.0
       iconv-lite: 0.7.0
     optionalDependencies:
-      '@types/node': 20.19.17
+      '@types/node': 20.19.19
 
   '@inquirer/figures@1.0.13': {}
 
-  '@inquirer/input@4.2.4(@types/node@20.19.17)':
+  '@inquirer/input@4.2.4(@types/node@20.19.19)':
     dependencies:
-      '@inquirer/core': 10.2.2(@types/node@20.19.17)
-      '@inquirer/type': 3.0.8(@types/node@20.19.17)
+      '@inquirer/core': 10.2.2(@types/node@20.19.19)
+      '@inquirer/type': 3.0.8(@types/node@20.19.19)
     optionalDependencies:
-      '@types/node': 20.19.17
+      '@types/node': 20.19.19
 
-  '@inquirer/number@3.0.20(@types/node@20.19.17)':
+  '@inquirer/number@3.0.20(@types/node@20.19.19)':
     dependencies:
-      '@inquirer/core': 10.2.2(@types/node@20.19.17)
-      '@inquirer/type': 3.0.8(@types/node@20.19.17)
+      '@inquirer/core': 10.2.2(@types/node@20.19.19)
+      '@inquirer/type': 3.0.8(@types/node@20.19.19)
     optionalDependencies:
-      '@types/node': 20.19.17
+      '@types/node': 20.19.19
 
-  '@inquirer/password@4.0.20(@types/node@20.19.17)':
-    dependencies:
-      '@inquirer/ansi': 1.0.0
-      '@inquirer/core': 10.2.2(@types/node@20.19.17)
-      '@inquirer/type': 3.0.8(@types/node@20.19.17)
-    optionalDependencies:
-      '@types/node': 20.19.17
-
-  '@inquirer/prompts@7.8.6(@types/node@20.19.17)':
-    dependencies:
-      '@inquirer/checkbox': 4.2.4(@types/node@20.19.17)
-      '@inquirer/confirm': 5.1.18(@types/node@20.19.17)
-      '@inquirer/editor': 4.2.20(@types/node@20.19.17)
-      '@inquirer/expand': 4.0.20(@types/node@20.19.17)
-      '@inquirer/input': 4.2.4(@types/node@20.19.17)
-      '@inquirer/number': 3.0.20(@types/node@20.19.17)
-      '@inquirer/password': 4.0.20(@types/node@20.19.17)
-      '@inquirer/rawlist': 4.1.8(@types/node@20.19.17)
-      '@inquirer/search': 3.1.3(@types/node@20.19.17)
-      '@inquirer/select': 4.3.4(@types/node@20.19.17)
-    optionalDependencies:
-      '@types/node': 20.19.17
-
-  '@inquirer/rawlist@4.1.8(@types/node@20.19.17)':
-    dependencies:
-      '@inquirer/core': 10.2.2(@types/node@20.19.17)
-      '@inquirer/type': 3.0.8(@types/node@20.19.17)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 20.19.17
-
-  '@inquirer/search@3.1.3(@types/node@20.19.17)':
-    dependencies:
-      '@inquirer/core': 10.2.2(@types/node@20.19.17)
-      '@inquirer/figures': 1.0.13
-      '@inquirer/type': 3.0.8(@types/node@20.19.17)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 20.19.17
-
-  '@inquirer/select@4.3.4(@types/node@20.19.17)':
+  '@inquirer/password@4.0.20(@types/node@20.19.19)':
     dependencies:
       '@inquirer/ansi': 1.0.0
-      '@inquirer/core': 10.2.2(@types/node@20.19.17)
-      '@inquirer/figures': 1.0.13
-      '@inquirer/type': 3.0.8(@types/node@20.19.17)
+      '@inquirer/core': 10.2.2(@types/node@20.19.19)
+      '@inquirer/type': 3.0.8(@types/node@20.19.19)
+    optionalDependencies:
+      '@types/node': 20.19.19
+
+  '@inquirer/prompts@7.8.6(@types/node@20.19.19)':
+    dependencies:
+      '@inquirer/checkbox': 4.2.4(@types/node@20.19.19)
+      '@inquirer/confirm': 5.1.18(@types/node@20.19.19)
+      '@inquirer/editor': 4.2.20(@types/node@20.19.19)
+      '@inquirer/expand': 4.0.20(@types/node@20.19.19)
+      '@inquirer/input': 4.2.4(@types/node@20.19.19)
+      '@inquirer/number': 3.0.20(@types/node@20.19.19)
+      '@inquirer/password': 4.0.20(@types/node@20.19.19)
+      '@inquirer/rawlist': 4.1.8(@types/node@20.19.19)
+      '@inquirer/search': 3.1.3(@types/node@20.19.19)
+      '@inquirer/select': 4.3.4(@types/node@20.19.19)
+    optionalDependencies:
+      '@types/node': 20.19.19
+
+  '@inquirer/rawlist@4.1.8(@types/node@20.19.19)':
+    dependencies:
+      '@inquirer/core': 10.2.2(@types/node@20.19.19)
+      '@inquirer/type': 3.0.8(@types/node@20.19.19)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 20.19.17
+      '@types/node': 20.19.19
 
-  '@inquirer/type@3.0.8(@types/node@20.19.17)':
+  '@inquirer/search@3.1.3(@types/node@20.19.19)':
+    dependencies:
+      '@inquirer/core': 10.2.2(@types/node@20.19.19)
+      '@inquirer/figures': 1.0.13
+      '@inquirer/type': 3.0.8(@types/node@20.19.19)
+      yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 20.19.17
+      '@types/node': 20.19.19
+
+  '@inquirer/select@4.3.4(@types/node@20.19.19)':
+    dependencies:
+      '@inquirer/ansi': 1.0.0
+      '@inquirer/core': 10.2.2(@types/node@20.19.19)
+      '@inquirer/figures': 1.0.13
+      '@inquirer/type': 3.0.8(@types/node@20.19.19)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 20.19.19
+
+  '@inquirer/type@3.0.8(@types/node@20.19.19)':
+    optionalDependencies:
+      '@types/node': 20.19.19
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -6981,14 +7014,14 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
-  '@langchain/core@0.3.77(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.18.3)(zod@3.25.67))':
+  '@langchain/core@0.3.78(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.18.3)(zod@3.25.67))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.21
-      langsmith: 0.3.69(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.18.3)(zod@3.25.67))
+      langsmith: 0.3.72(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.18.3)(zod@3.25.67))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -7001,9 +7034,9 @@ snapshots:
       - '@opentelemetry/sdk-trace-base'
       - openai
 
-  '@langchain/openai@0.4.9(@langchain/core@0.3.77(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.18.3)(zod@3.25.67)))(ws@8.18.3)':
+  '@langchain/openai@0.4.9(@langchain/core@0.3.78(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.18.3)(zod@3.25.67)))(ws@8.18.3)':
     dependencies:
-      '@langchain/core': 0.3.77(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.18.3)(zod@3.25.67))
+      '@langchain/core': 0.3.78(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.18.3)(zod@3.25.67))
       js-tiktoken: 1.0.21
       openai: 4.104.0(ws@8.18.3)(zod@3.25.67)
       zod: 3.25.67
@@ -7060,29 +7093,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@mdx-js/react@3.1.1(@types/react@19.1.13)(react@19.1.1)':
+  '@mdx-js/react@3.1.1(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
       '@types/mdx': 2.0.13
-      '@types/react': 19.1.13
-      react: 19.1.1
+      '@types/react': 19.2.2
+      react: 19.2.0
 
-  '@mintlify/cli@4.0.725(@radix-ui/react-popover@1.1.15(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1))(@types/node@20.19.17)(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(typescript@5.9.2)':
+  '@mintlify/cli@4.0.753(@radix-ui/react-popover@1.1.15(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0))(@types/node@20.19.19)(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)':
     dependencies:
-      '@mintlify/common': 1.0.535(@radix-ui/react-popover@1.1.15(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1))(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)
-      '@mintlify/link-rot': 3.0.672(@radix-ui/react-popover@1.1.15(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1))(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)
-      '@mintlify/models': 0.0.229
-      '@mintlify/prebuild': 1.0.659(@radix-ui/react-popover@1.1.15(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1))(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)
-      '@mintlify/previewing': 4.0.708(@radix-ui/react-popover@1.1.15(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1))(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(typescript@5.9.2)
-      '@mintlify/validation': 0.1.471
+      '@mintlify/common': 1.0.560(@radix-ui/react-popover@1.1.15(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0))(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
+      '@mintlify/link-rot': 3.0.698(@radix-ui/react-popover@1.1.15(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0))(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
+      '@mintlify/models': 0.0.231
+      '@mintlify/prebuild': 1.0.685(@radix-ui/react-popover@1.1.15(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0))(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
+      '@mintlify/previewing': 4.0.734(@radix-ui/react-popover@1.1.15(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0))(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
+      '@mintlify/validation': 0.1.486(@radix-ui/react-popover@1.1.15(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0))(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       chalk: 5.6.2
+      color: 4.2.3
       detect-port: 1.6.1
       fs-extra: 11.3.2
       gray-matter: 4.0.3
-      ink: 6.3.1(@types/react@19.1.13)(react@19.1.1)
-      inquirer: 12.9.6(@types/node@20.19.17)
+      ink: 6.3.1(@types/react@19.2.2)(react@19.2.0)
+      inquirer: 12.9.6(@types/node@20.19.19)
       js-yaml: 4.1.0
-      react: 19.1.1
+      mdast: 3.0.0
+      mdast-util-mdx-jsx: 3.2.0
+      react: 19.2.0
       semver: 7.7.2
+      unist-util-visit: 5.0.0
       yargs: 17.7.2
     transitivePeerDependencies:
       - '@radix-ui/react-popover'
@@ -7096,26 +7133,29 @@ snapshots:
       - react-dom
       - react-native-b4a
       - supports-color
-      - ts-node
+      - tsx
       - typescript
       - utf-8-validate
+      - yaml
 
-  '@mintlify/common@1.0.535(@radix-ui/react-popover@1.1.15(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1))(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)':
+  '@mintlify/common@1.0.560(@radix-ui/react-popover@1.1.15(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0))(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)':
     dependencies:
       '@asyncapi/parser': 3.4.0
-      '@mintlify/mdx': 2.0.11(@radix-ui/react-popover@1.1.15(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1))(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)
-      '@mintlify/models': 0.0.229
-      '@mintlify/openapi-parser': 0.0.7
-      '@mintlify/validation': 0.1.471
+      '@mintlify/mdx': 3.0.0(@radix-ui/react-popover@1.1.15(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0))(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@mintlify/models': 0.0.231
+      '@mintlify/openapi-parser': 0.0.8
+      '@mintlify/validation': 0.1.486(@radix-ui/react-popover@1.1.15(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0))(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       '@sindresorhus/slugify': 2.2.1
       acorn: 8.15.0
       acorn-jsx: 5.3.2(acorn@8.15.0)
+      color-blend: 4.0.0
       estree-util-to-js: 2.0.0
       estree-walker: 3.0.3
       gray-matter: 4.0.3
       hast-util-from-html: 2.0.3
       hast-util-to-html: 9.0.5
       hast-util-to-text: 4.0.2
+      hex-rgb: 5.0.0
       js-yaml: 4.1.0
       lodash: 4.17.21
       mdast: 3.0.0
@@ -7134,7 +7174,7 @@ snapshots:
       remark-math: 6.0.0
       remark-mdx: 3.1.1
       remark-stringify: 11.0.0
-      tailwindcss: 3.4.17
+      tailwindcss: 3.4.18(tsx@4.20.6)(yaml@2.8.1)
       unified: 11.0.5
       unist-builder: 4.0.0
       unist-util-map: 4.0.0
@@ -7151,15 +7191,16 @@ snapshots:
       - react
       - react-dom
       - supports-color
-      - ts-node
+      - tsx
       - typescript
+      - yaml
 
-  '@mintlify/link-rot@3.0.672(@radix-ui/react-popover@1.1.15(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1))(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)':
+  '@mintlify/link-rot@3.0.698(@radix-ui/react-popover@1.1.15(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0))(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)':
     dependencies:
-      '@mintlify/common': 1.0.535(@radix-ui/react-popover@1.1.15(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1))(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)
-      '@mintlify/prebuild': 1.0.659(@radix-ui/react-popover@1.1.15(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1))(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)
-      '@mintlify/previewing': 4.0.708(@radix-ui/react-popover@1.1.15(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1))(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(typescript@5.9.2)
-      '@mintlify/validation': 0.1.471
+      '@mintlify/common': 1.0.560(@radix-ui/react-popover@1.1.15(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0))(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
+      '@mintlify/prebuild': 1.0.685(@radix-ui/react-popover@1.1.15(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0))(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
+      '@mintlify/previewing': 4.0.734(@radix-ui/react-popover@1.1.15(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0))(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
+      '@mintlify/validation': 0.1.486(@radix-ui/react-popover@1.1.15(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0))(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       fs-extra: 11.3.2
       unist-util-visit: 4.1.2
     transitivePeerDependencies:
@@ -7174,23 +7215,24 @@ snapshots:
       - react-dom
       - react-native-b4a
       - supports-color
-      - ts-node
+      - tsx
       - typescript
       - utf-8-validate
+      - yaml
 
-  '@mintlify/mdx@2.0.11(@radix-ui/react-popover@1.1.15(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1))(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)':
+  '@mintlify/mdx@3.0.0(@radix-ui/react-popover@1.1.15(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0))(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
-      '@radix-ui/react-popover': 1.1.15(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-popover': 1.1.15(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)
       '@shikijs/transformers': 3.13.0
-      '@shikijs/twoslash': 3.13.0(typescript@5.9.2)
+      '@shikijs/twoslash': 3.13.0(typescript@5.9.3)
       hast-util-to-string: 3.0.1
       mdast-util-from-markdown: 2.0.2
       mdast-util-gfm: 3.1.0
       mdast-util-mdx-jsx: 3.2.0
       mdast-util-to-hast: 13.2.0
-      next-mdx-remote-client: 1.1.2(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)(unified@11.0.5)
-      react: 19.1.1
-      react-dom: 18.3.1(react@19.1.1)
+      next-mdx-remote-client: 1.1.3(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)(unified@11.0.5)
+      react: 19.2.0
+      react-dom: 18.3.1(react@19.2.0)
       rehype-katex: 7.0.1
       remark-gfm: 4.0.1
       remark-math: 6.0.0
@@ -7203,14 +7245,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@mintlify/models@0.0.229':
+  '@mintlify/models@0.0.231':
     dependencies:
       axios: 1.12.2
       openapi-types: 12.1.3
     transitivePeerDependencies:
       - debug
 
-  '@mintlify/openapi-parser@0.0.7':
+  '@mintlify/openapi-parser@0.0.8':
     dependencies:
       ajv: 8.17.1
       ajv-draft-04: 1.0.0(ajv@8.17.1)
@@ -7219,12 +7261,12 @@ snapshots:
       leven: 4.1.0
       yaml: 2.8.1
 
-  '@mintlify/prebuild@1.0.659(@radix-ui/react-popover@1.1.15(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1))(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)':
+  '@mintlify/prebuild@1.0.685(@radix-ui/react-popover@1.1.15(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0))(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)':
     dependencies:
-      '@mintlify/common': 1.0.535(@radix-ui/react-popover@1.1.15(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1))(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)
-      '@mintlify/openapi-parser': 0.0.7
-      '@mintlify/scraping': 4.0.394(@radix-ui/react-popover@1.1.15(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1))(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)
-      '@mintlify/validation': 0.1.471
+      '@mintlify/common': 1.0.560(@radix-ui/react-popover@1.1.15(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0))(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
+      '@mintlify/openapi-parser': 0.0.8
+      '@mintlify/scraping': 4.0.419(@radix-ui/react-popover@1.1.15(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0))(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
+      '@mintlify/validation': 0.1.486(@radix-ui/react-popover@1.1.15(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0))(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       chalk: 5.6.2
       favicons: 7.2.0
       fs-extra: 11.3.2
@@ -7232,6 +7274,8 @@ snapshots:
       js-yaml: 4.1.0
       mdast: 3.0.0
       openapi-types: 12.1.3
+      sharp: 0.33.5
+      sharp-ico: 0.1.5
       unist-util-visit: 4.1.2
     transitivePeerDependencies:
       - '@radix-ui/react-popover'
@@ -7244,15 +7288,16 @@ snapshots:
       - react-dom
       - react-native-b4a
       - supports-color
-      - ts-node
+      - tsx
       - typescript
       - utf-8-validate
+      - yaml
 
-  '@mintlify/previewing@4.0.708(@radix-ui/react-popover@1.1.15(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1))(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(typescript@5.9.2)':
+  '@mintlify/previewing@4.0.734(@radix-ui/react-popover@1.1.15(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0))(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)':
     dependencies:
-      '@mintlify/common': 1.0.535(@radix-ui/react-popover@1.1.15(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1))(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)
-      '@mintlify/prebuild': 1.0.659(@radix-ui/react-popover@1.1.15(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1))(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)
-      '@mintlify/validation': 0.1.471
+      '@mintlify/common': 1.0.560(@radix-ui/react-popover@1.1.15(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0))(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
+      '@mintlify/prebuild': 1.0.685(@radix-ui/react-popover@1.1.15(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0))(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
+      '@mintlify/validation': 0.1.486(@radix-ui/react-popover@1.1.15(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0))(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       better-opn: 3.0.2
       chalk: 5.6.2
       chokidar: 3.6.0
@@ -7260,13 +7305,13 @@ snapshots:
       fs-extra: 11.3.2
       got: 13.0.0
       gray-matter: 4.0.3
-      ink: 6.3.1(@types/react@19.1.13)(react@19.1.1)
-      ink-spinner: 5.0.0(ink@6.3.1(@types/react@19.1.13)(react@19.1.1))(react@19.1.1)
+      ink: 6.3.1(@types/react@19.2.2)(react@19.2.0)
+      ink-spinner: 5.0.0(ink@6.3.1(@types/react@19.2.2)(react@19.2.0))(react@19.2.0)
       is-online: 10.0.0
       js-yaml: 4.1.0
       mdast: 3.0.0
       openapi-types: 12.1.3
-      react: 19.1.1
+      react: 19.2.0
       socket.io: 4.8.1
       tar: 6.2.1
       unist-util-visit: 4.1.2
@@ -7282,20 +7327,21 @@ snapshots:
       - react-dom
       - react-native-b4a
       - supports-color
-      - ts-node
+      - tsx
       - typescript
       - utf-8-validate
+      - yaml
 
-  '@mintlify/scraping@4.0.394(@radix-ui/react-popover@1.1.15(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1))(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)':
+  '@mintlify/scraping@4.0.419(@radix-ui/react-popover@1.1.15(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0))(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)':
     dependencies:
-      '@mintlify/common': 1.0.535(@radix-ui/react-popover@1.1.15(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1))(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)
-      '@mintlify/openapi-parser': 0.0.7
+      '@mintlify/common': 1.0.560(@radix-ui/react-popover@1.1.15(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0))(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
+      '@mintlify/openapi-parser': 0.0.8
       fs-extra: 11.3.2
       hast-util-to-mdast: 10.1.2
       js-yaml: 4.1.0
       mdast-util-mdx-jsx: 3.2.0
       neotraverse: 0.6.18
-      puppeteer: 22.15.0(typescript@5.9.2)
+      puppeteer: 22.15.0(typescript@5.9.3)
       rehype-parse: 9.0.1
       remark-gfm: 4.0.1
       remark-mdx: 3.1.1
@@ -7316,23 +7362,34 @@ snapshots:
       - react-dom
       - react-native-b4a
       - supports-color
-      - ts-node
+      - tsx
       - typescript
       - utf-8-validate
+      - yaml
 
-  '@mintlify/validation@0.1.471':
+  '@mintlify/validation@0.1.486(@radix-ui/react-popover@1.1.15(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0))(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)(typescript@5.9.3)':
     dependencies:
-      '@mintlify/models': 0.0.229
+      '@mintlify/mdx': 3.0.0(@radix-ui/react-popover@1.1.15(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0))(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      '@mintlify/models': 0.0.231
       arktype: 2.1.22
+      js-yaml: 4.1.0
       lcm: 0.0.3
       lodash: 4.17.21
+      object-hash: 3.0.0
       openapi-types: 12.1.3
+      uuid: 11.1.0
       zod: 3.25.76
       zod-to-json-schema: 3.24.6(zod@3.25.76)
     transitivePeerDependencies:
+      - '@radix-ui/react-popover'
+      - '@types/react'
       - debug
+      - react
+      - react-dom
+      - supports-color
+      - typescript
 
-  '@modelcontextprotocol/sdk@1.18.1':
+  '@modelcontextprotocol/sdk@1.19.1':
     dependencies:
       ajv: 6.12.6
       content-type: 1.0.5
@@ -7349,7 +7406,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@next/env@14.2.32': {}
+  '@next/env@14.2.33': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -7372,9 +7429,9 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@playwright/test@1.55.0':
+  '@playwright/test@1.56.0':
     dependencies:
-      playwright: 1.55.0
+      playwright: 1.56.0
 
   '@puppeteer/browsers@2.3.0':
     dependencies:
@@ -7393,247 +7450,247 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
-  '@radix-ui/react-arrow@1.1.7(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)':
+  '@radix-ui/react-arrow@1.1.7(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)
-      react: 19.1.1
-      react-dom: 18.3.1(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      react-dom: 18.3.1(react@19.2.0)
     optionalDependencies:
-      '@types/react': 19.1.13
+      '@types/react': 19.2.2
 
-  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.1.13)(react@19.1.1)':
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
-      react: 19.1.1
+      react: 19.2.0
     optionalDependencies:
-      '@types/react': 19.1.13
+      '@types/react': 19.2.2
 
-  '@radix-ui/react-context@1.1.2(@types/react@19.1.13)(react@19.1.1)':
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
-      react: 19.1.1
+      react: 19.2.0
     optionalDependencies:
-      '@types/react': 19.1.13
+      '@types/react': 19.2.2
 
-  '@radix-ui/react-dismissable-layer@1.1.11(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)':
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.13)(react@19.1.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.13)(react@19.1.1)
-      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.1.13)(react@19.1.1)
-      react: 19.1.1
-      react-dom: 18.3.1(react@19.1.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 18.3.1(react@19.2.0)
     optionalDependencies:
-      '@types/react': 19.1.13
+      '@types/react': 19.2.2
 
-  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.1.13)(react@19.1.1)':
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
-      react: 19.1.1
+      react: 19.2.0
     optionalDependencies:
-      '@types/react': 19.1.13
+      '@types/react': 19.2.2
 
-  '@radix-ui/react-focus-scope@1.1.7(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)':
+  '@radix-ui/react-focus-scope@1.1.7(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.13)(react@19.1.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.13)(react@19.1.1)
-      react: 19.1.1
-      react-dom: 18.3.1(react@19.1.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 18.3.1(react@19.2.0)
     optionalDependencies:
-      '@types/react': 19.1.13
+      '@types/react': 19.2.2
 
-  '@radix-ui/react-id@1.1.1(@types/react@19.1.13)(react@19.1.1)':
+  '@radix-ui/react-id@1.1.1(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.13)(react@19.1.1)
-      react: 19.1.1
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
     optionalDependencies:
-      '@types/react': 19.1.13
+      '@types/react': 19.2.2
 
-  '@radix-ui/react-popover@1.1.15(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)':
+  '@radix-ui/react-popover@1.1.15(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.13)(react@19.1.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.1.13)(react@19.1.1)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.1.13)(react@19.1.1)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.1.13)(react@19.1.1)
-      '@radix-ui/react-popper': 1.2.8(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-portal': 1.1.9(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-presence': 1.1.5(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.13)(react@19.1.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.13)(react@19.1.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-popper': 1.2.8(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.2)(react@19.2.0)
       aria-hidden: 1.2.6
-      react: 19.1.1
-      react-dom: 18.3.1(react@19.1.1)
-      react-remove-scroll: 2.7.1(@types/react@19.1.13)(react@19.1.1)
+      react: 19.2.0
+      react-dom: 18.3.1(react@19.2.0)
+      react-remove-scroll: 2.7.1(@types/react@19.2.2)(react@19.2.0)
     optionalDependencies:
-      '@types/react': 19.1.13
+      '@types/react': 19.2.2
 
-  '@radix-ui/react-popper@1.2.8(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)':
+  '@radix-ui/react-popper@1.2.8(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@floating-ui/react-dom': 2.1.6(react-dom@18.3.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-arrow': 1.1.7(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.13)(react@19.1.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.1.13)(react@19.1.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.13)(react@19.1.1)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.13)(react@19.1.1)
-      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.1.13)(react@19.1.1)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.13)(react@19.1.1)
+      '@floating-ui/react-dom': 2.1.6(react-dom@18.3.1(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-arrow': 1.1.7(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.2)(react@19.2.0)
       '@radix-ui/rect': 1.1.1
-      react: 19.1.1
-      react-dom: 18.3.1(react@19.1.1)
+      react: 19.2.0
+      react-dom: 18.3.1(react@19.2.0)
     optionalDependencies:
-      '@types/react': 19.1.13
+      '@types/react': 19.2.2
 
-  '@radix-ui/react-portal@1.1.9(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)':
+  '@radix-ui/react-portal@1.1.9(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.13)(react@19.1.1)
-      react: 19.1.1
-      react-dom: 18.3.1(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 18.3.1(react@19.2.0)
     optionalDependencies:
-      '@types/react': 19.1.13
+      '@types/react': 19.2.2
 
-  '@radix-ui/react-presence@1.1.5(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)':
+  '@radix-ui/react-presence@1.1.5(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.13)(react@19.1.1)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.13)(react@19.1.1)
-      react: 19.1.1
-      react-dom: 18.3.1(react@19.1.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 18.3.1(react@19.2.0)
     optionalDependencies:
-      '@types/react': 19.1.13
+      '@types/react': 19.2.2
 
-  '@radix-ui/react-primitive@2.1.3(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)':
+  '@radix-ui/react-primitive@2.1.3(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.13)(react@19.1.1)
-      react: 19.1.1
-      react-dom: 18.3.1(react@19.1.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 18.3.1(react@19.2.0)
     optionalDependencies:
-      '@types/react': 19.1.13
+      '@types/react': 19.2.2
 
-  '@radix-ui/react-slot@1.2.3(@types/react@19.1.13)(react@19.1.1)':
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.13)(react@19.1.1)
-      react: 19.1.1
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
     optionalDependencies:
-      '@types/react': 19.1.13
+      '@types/react': 19.2.2
 
-  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.1.13)(react@19.1.1)':
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
-      react: 19.1.1
+      react: 19.2.0
     optionalDependencies:
-      '@types/react': 19.1.13
+      '@types/react': 19.2.2
 
-  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.1.13)(react@19.1.1)':
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
-      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.1.13)(react@19.1.1)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.13)(react@19.1.1)
-      react: 19.1.1
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
     optionalDependencies:
-      '@types/react': 19.1.13
+      '@types/react': 19.2.2
 
-  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.1.13)(react@19.1.1)':
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.13)(react@19.1.1)
-      react: 19.1.1
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
     optionalDependencies:
-      '@types/react': 19.1.13
+      '@types/react': 19.2.2
 
-  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.1.13)(react@19.1.1)':
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.13)(react@19.1.1)
-      react: 19.1.1
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
     optionalDependencies:
-      '@types/react': 19.1.13
+      '@types/react': 19.2.2
 
-  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.1.13)(react@19.1.1)':
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
-      react: 19.1.1
+      react: 19.2.0
     optionalDependencies:
-      '@types/react': 19.1.13
+      '@types/react': 19.2.2
 
-  '@radix-ui/react-use-rect@1.1.1(@types/react@19.1.13)(react@19.1.1)':
+  '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
       '@radix-ui/rect': 1.1.1
-      react: 19.1.1
+      react: 19.2.0
     optionalDependencies:
-      '@types/react': 19.1.13
+      '@types/react': 19.2.2
 
-  '@radix-ui/react-use-size@1.1.1(@types/react@19.1.13)(react@19.1.1)':
+  '@radix-ui/react-use-size@1.1.1(@types/react@19.2.2)(react@19.2.0)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.13)(react@19.1.1)
-      react: 19.1.1
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
     optionalDependencies:
-      '@types/react': 19.1.13
+      '@types/react': 19.2.2
 
   '@radix-ui/rect@1.1.1': {}
 
-  '@rollup/rollup-android-arm-eabi@4.52.0':
+  '@rollup/rollup-android-arm-eabi@4.52.4':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.52.0':
+  '@rollup/rollup-android-arm64@4.52.4':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.52.0':
+  '@rollup/rollup-darwin-arm64@4.52.4':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.52.0':
+  '@rollup/rollup-darwin-x64@4.52.4':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.52.0':
+  '@rollup/rollup-freebsd-arm64@4.52.4':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.52.0':
+  '@rollup/rollup-freebsd-x64@4.52.4':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.52.0':
+  '@rollup/rollup-linux-arm-gnueabihf@4.52.4':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.52.0':
+  '@rollup/rollup-linux-arm-musleabihf@4.52.4':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.52.0':
+  '@rollup/rollup-linux-arm64-gnu@4.52.4':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.52.0':
+  '@rollup/rollup-linux-arm64-musl@4.52.4':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.52.0':
+  '@rollup/rollup-linux-loong64-gnu@4.52.4':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.52.0':
+  '@rollup/rollup-linux-ppc64-gnu@4.52.4':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.52.0':
+  '@rollup/rollup-linux-riscv64-gnu@4.52.4':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.52.0':
+  '@rollup/rollup-linux-riscv64-musl@4.52.4':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.52.0':
+  '@rollup/rollup-linux-s390x-gnu@4.52.4':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.52.0':
+  '@rollup/rollup-linux-x64-gnu@4.52.4':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.52.0':
+  '@rollup/rollup-linux-x64-musl@4.52.4':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.52.0':
+  '@rollup/rollup-openharmony-arm64@4.52.4':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.52.0':
+  '@rollup/rollup-win32-arm64-msvc@4.52.4':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.52.0':
+  '@rollup/rollup-win32-ia32-msvc@4.52.4':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.52.0':
+  '@rollup/rollup-win32-x64-gnu@4.52.4':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.52.0':
+  '@rollup/rollup-win32-x64-msvc@4.52.4':
     optional: true
 
   '@shikijs/core@3.13.0':
@@ -7667,12 +7724,12 @@ snapshots:
       '@shikijs/core': 3.13.0
       '@shikijs/types': 3.13.0
 
-  '@shikijs/twoslash@3.13.0(typescript@5.9.2)':
+  '@shikijs/twoslash@3.13.0(typescript@5.9.3)':
     dependencies:
       '@shikijs/core': 3.13.0
       '@shikijs/types': 3.13.0
-      twoslash: 0.3.4(typescript@5.9.2)
-      typescript: 5.9.2
+      twoslash: 0.3.4(typescript@5.9.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -7839,7 +7896,7 @@ snapshots:
       '@stoplight/yaml-ast-parser': 0.0.50
       tslib: 2.8.1
 
-  '@sveltejs/acorn-typescript@1.0.5(acorn@8.15.0)':
+  '@sveltejs/acorn-typescript@1.0.6(acorn@8.15.0)':
     dependencies:
       acorn: 8.15.0
 
@@ -7851,24 +7908,24 @@ snapshots:
 
   '@types/adm-zip@0.5.7':
     dependencies:
-      '@types/node': 20.19.17
+      '@types/node': 20.19.19
 
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 20.19.17
+      '@types/node': 20.19.19
 
   '@types/cheerio@0.22.35':
     dependencies:
-      '@types/node': 20.19.17
+      '@types/node': 20.19.19
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 20.19.17
+      '@types/node': 20.19.19
 
   '@types/cors@2.8.19':
     dependencies:
-      '@types/node': 20.19.17
+      '@types/node': 20.19.19
 
   '@types/debug@4.1.12':
     dependencies:
@@ -7878,7 +7935,7 @@ snapshots:
 
   '@types/es-aggregate-error@1.0.6':
     dependencies:
-      '@types/node': 20.19.17
+      '@types/node': 20.19.19
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -7886,19 +7943,19 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
-  '@types/express-serve-static-core@4.19.6':
+  '@types/express-serve-static-core@4.19.7':
     dependencies:
-      '@types/node': 20.19.17
+      '@types/node': 20.19.19
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
-      '@types/send': 0.17.5
+      '@types/send': 1.2.0
 
   '@types/express@4.17.23':
     dependencies:
       '@types/body-parser': 1.19.6
-      '@types/express-serve-static-core': 4.19.6
+      '@types/express-serve-static-core': 4.19.7
       '@types/qs': 6.14.0
-      '@types/serve-static': 1.15.8
+      '@types/serve-static': 1.15.9
 
   '@types/hast@3.0.4':
     dependencies:
@@ -7928,28 +7985,28 @@ snapshots:
 
   '@types/node-fetch@2.6.13':
     dependencies:
-      '@types/node': 20.19.17
+      '@types/node': 20.19.19
       form-data: 4.0.4
 
   '@types/node@12.20.55': {}
 
-  '@types/node@18.19.127':
+  '@types/node@18.19.129':
     dependencies:
       undici-types: 5.26.5
 
-  '@types/node@20.19.17':
+  '@types/node@20.19.19':
     dependencies:
       undici-types: 6.21.0
 
   '@types/papaparse@5.3.16':
     dependencies:
-      '@types/node': 20.19.17
+      '@types/node': 20.19.19
 
   '@types/qs@6.14.0': {}
 
   '@types/range-parser@1.2.7': {}
 
-  '@types/react@19.1.13':
+  '@types/react@19.2.2':
     dependencies:
       csstype: 3.1.3
 
@@ -7958,12 +8015,16 @@ snapshots:
   '@types/send@0.17.5':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 20.19.17
+      '@types/node': 20.19.19
 
-  '@types/serve-static@1.15.8':
+  '@types/send@1.2.0':
+    dependencies:
+      '@types/node': 20.19.19
+
+  '@types/serve-static@1.15.9':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 20.19.17
+      '@types/node': 20.19.19
       '@types/send': 0.17.5
 
   '@types/unist@2.0.11': {}
@@ -7976,110 +8037,110 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 20.19.17
+      '@types/node': 20.19.19
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 20.19.17
+      '@types/node': 20.19.19
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.44.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@1.21.7))(typescript@5.9.2))(eslint@9.36.0(jiti@1.21.7))(typescript@5.9.2)':
+  '@typescript-eslint/eslint-plugin@8.46.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@1.21.7))(typescript@5.9.3))(eslint@9.37.0(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.44.0(eslint@9.36.0(jiti@1.21.7))(typescript@5.9.2)
-      '@typescript-eslint/scope-manager': 8.44.0
-      '@typescript-eslint/type-utils': 8.44.0(eslint@9.36.0(jiti@1.21.7))(typescript@5.9.2)
-      '@typescript-eslint/utils': 8.44.0(eslint@9.36.0(jiti@1.21.7))(typescript@5.9.2)
-      '@typescript-eslint/visitor-keys': 8.44.0
-      eslint: 9.36.0(jiti@1.21.7)
+      '@typescript-eslint/parser': 8.46.0(eslint@9.37.0(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.46.0
+      '@typescript-eslint/type-utils': 8.46.0(eslint@9.37.0(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.46.0(eslint@9.37.0(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.46.0
+      eslint: 9.37.0(jiti@1.21.7)
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.1.0(typescript@5.9.2)
-      typescript: 5.9.2
+      ts-api-utils: 2.1.0(typescript@5.9.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@1.21.7))(typescript@5.9.2)':
+  '@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.44.0
-      '@typescript-eslint/types': 8.44.0
-      '@typescript-eslint/typescript-estree': 8.44.0(typescript@5.9.2)
-      '@typescript-eslint/visitor-keys': 8.44.0
+      '@typescript-eslint/scope-manager': 8.46.0
+      '@typescript-eslint/types': 8.46.0
+      '@typescript-eslint/typescript-estree': 8.46.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.46.0
       debug: 4.4.3
-      eslint: 9.36.0(jiti@1.21.7)
-      typescript: 5.9.2
+      eslint: 9.37.0(jiti@1.21.7)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.44.0(typescript@5.9.2)':
+  '@typescript-eslint/project-service@8.46.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.44.0(typescript@5.9.2)
-      '@typescript-eslint/types': 8.44.0
+      '@typescript-eslint/tsconfig-utils': 8.46.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.46.0
       debug: 4.4.3
-      typescript: 5.9.2
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.44.0':
+  '@typescript-eslint/scope-manager@8.46.0':
     dependencies:
-      '@typescript-eslint/types': 8.44.0
-      '@typescript-eslint/visitor-keys': 8.44.0
+      '@typescript-eslint/types': 8.46.0
+      '@typescript-eslint/visitor-keys': 8.46.0
 
-  '@typescript-eslint/tsconfig-utils@8.44.0(typescript@5.9.2)':
+  '@typescript-eslint/tsconfig-utils@8.46.0(typescript@5.9.3)':
     dependencies:
-      typescript: 5.9.2
+      typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.44.0(eslint@9.36.0(jiti@1.21.7))(typescript@5.9.2)':
+  '@typescript-eslint/type-utils@8.46.0(eslint@9.37.0(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/types': 8.44.0
-      '@typescript-eslint/typescript-estree': 8.44.0(typescript@5.9.2)
-      '@typescript-eslint/utils': 8.44.0(eslint@9.36.0(jiti@1.21.7))(typescript@5.9.2)
+      '@typescript-eslint/types': 8.46.0
+      '@typescript-eslint/typescript-estree': 8.46.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.46.0(eslint@9.37.0(jiti@1.21.7))(typescript@5.9.3)
       debug: 4.4.3
-      eslint: 9.36.0(jiti@1.21.7)
-      ts-api-utils: 2.1.0(typescript@5.9.2)
-      typescript: 5.9.2
+      eslint: 9.37.0(jiti@1.21.7)
+      ts-api-utils: 2.1.0(typescript@5.9.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.44.0': {}
+  '@typescript-eslint/types@8.46.0': {}
 
-  '@typescript-eslint/typescript-estree@8.44.0(typescript@5.9.2)':
+  '@typescript-eslint/typescript-estree@8.46.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.44.0(typescript@5.9.2)
-      '@typescript-eslint/tsconfig-utils': 8.44.0(typescript@5.9.2)
-      '@typescript-eslint/types': 8.44.0
-      '@typescript-eslint/visitor-keys': 8.44.0
+      '@typescript-eslint/project-service': 8.46.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.46.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.46.0
+      '@typescript-eslint/visitor-keys': 8.46.0
       debug: 4.4.3
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.7.2
-      ts-api-utils: 2.1.0(typescript@5.9.2)
-      typescript: 5.9.2
+      ts-api-utils: 2.1.0(typescript@5.9.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.44.0(eslint@9.36.0(jiti@1.21.7))(typescript@5.9.2)':
+  '@typescript-eslint/utils@8.46.0(eslint@9.37.0(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.36.0(jiti@1.21.7))
-      '@typescript-eslint/scope-manager': 8.44.0
-      '@typescript-eslint/types': 8.44.0
-      '@typescript-eslint/typescript-estree': 8.44.0(typescript@5.9.2)
-      eslint: 9.36.0(jiti@1.21.7)
-      typescript: 5.9.2
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.37.0(jiti@1.21.7))
+      '@typescript-eslint/scope-manager': 8.46.0
+      '@typescript-eslint/types': 8.46.0
+      '@typescript-eslint/typescript-estree': 8.46.0(typescript@5.9.3)
+      eslint: 9.37.0(jiti@1.21.7)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.44.0':
+  '@typescript-eslint/visitor-keys@8.46.0':
     dependencies:
-      '@typescript-eslint/types': 8.44.0
+      '@typescript-eslint/types': 8.46.0
       eslint-visitor-keys: 4.2.1
 
-  '@typescript/vfs@1.6.1(typescript@5.9.2)':
+  '@typescript/vfs@1.6.1(typescript@5.9.3)':
     dependencies:
       debug: 4.4.3
-      typescript: 5.9.2
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -8087,59 +8148,59 @@ snapshots:
 
   '@vercel/functions@1.6.0': {}
 
-  '@vue/compiler-core@3.5.21':
+  '@vue/compiler-core@3.5.22':
     dependencies:
       '@babel/parser': 7.28.4
-      '@vue/shared': 3.5.21
+      '@vue/shared': 3.5.22
       entities: 4.5.0
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
-  '@vue/compiler-dom@3.5.21':
+  '@vue/compiler-dom@3.5.22':
     dependencies:
-      '@vue/compiler-core': 3.5.21
-      '@vue/shared': 3.5.21
+      '@vue/compiler-core': 3.5.22
+      '@vue/shared': 3.5.22
 
-  '@vue/compiler-sfc@3.5.21':
+  '@vue/compiler-sfc@3.5.22':
     dependencies:
       '@babel/parser': 7.28.4
-      '@vue/compiler-core': 3.5.21
-      '@vue/compiler-dom': 3.5.21
-      '@vue/compiler-ssr': 3.5.21
-      '@vue/shared': 3.5.21
+      '@vue/compiler-core': 3.5.22
+      '@vue/compiler-dom': 3.5.22
+      '@vue/compiler-ssr': 3.5.22
+      '@vue/shared': 3.5.22
       estree-walker: 2.0.2
       magic-string: 0.30.19
       postcss: 8.5.6
       source-map-js: 1.2.1
 
-  '@vue/compiler-ssr@3.5.21':
+  '@vue/compiler-ssr@3.5.22':
     dependencies:
-      '@vue/compiler-dom': 3.5.21
-      '@vue/shared': 3.5.21
+      '@vue/compiler-dom': 3.5.22
+      '@vue/shared': 3.5.22
 
-  '@vue/reactivity@3.5.21':
+  '@vue/reactivity@3.5.22':
     dependencies:
-      '@vue/shared': 3.5.21
+      '@vue/shared': 3.5.22
 
-  '@vue/runtime-core@3.5.21':
+  '@vue/runtime-core@3.5.22':
     dependencies:
-      '@vue/reactivity': 3.5.21
-      '@vue/shared': 3.5.21
+      '@vue/reactivity': 3.5.22
+      '@vue/shared': 3.5.22
 
-  '@vue/runtime-dom@3.5.21':
+  '@vue/runtime-dom@3.5.22':
     dependencies:
-      '@vue/reactivity': 3.5.21
-      '@vue/runtime-core': 3.5.21
-      '@vue/shared': 3.5.21
+      '@vue/reactivity': 3.5.22
+      '@vue/runtime-core': 3.5.22
+      '@vue/shared': 3.5.22
       csstype: 3.1.3
 
-  '@vue/server-renderer@3.5.21(vue@3.5.21(typescript@5.9.2))':
+  '@vue/server-renderer@3.5.22(vue@3.5.22(typescript@5.9.3))':
     dependencies:
-      '@vue/compiler-ssr': 3.5.21
-      '@vue/shared': 3.5.21
-      vue: 3.5.21(typescript@5.9.2)
+      '@vue/compiler-ssr': 3.5.22
+      '@vue/shared': 3.5.22
+      vue: 3.5.22(typescript@5.9.3)
 
-  '@vue/shared@3.5.21': {}
+  '@vue/shared@3.5.22': {}
 
   abort-controller@3.0.0:
     dependencies:
@@ -8176,15 +8237,15 @@ snapshots:
       clean-stack: 4.2.0
       indent-string: 5.0.0
 
-  ai@3.4.33(openai@4.104.0(ws@8.18.3)(zod@3.25.67))(react@19.1.1)(sswr@2.2.0(svelte@5.39.3))(svelte@5.39.3)(vue@3.5.21(typescript@5.9.2))(zod@3.25.67):
+  ai@3.4.33(openai@4.104.0(ws@8.18.3)(zod@3.25.67))(react@19.2.0)(sswr@2.2.0(svelte@5.39.10))(svelte@5.39.10)(vue@3.5.22(typescript@5.9.3))(zod@3.25.67):
     dependencies:
       '@ai-sdk/provider': 0.0.26
       '@ai-sdk/provider-utils': 1.0.22(zod@3.25.67)
-      '@ai-sdk/react': 0.0.70(react@19.1.1)(zod@3.25.67)
+      '@ai-sdk/react': 0.0.70(react@19.2.0)(zod@3.25.67)
       '@ai-sdk/solid': 0.0.54(zod@3.25.67)
-      '@ai-sdk/svelte': 0.0.57(svelte@5.39.3)(zod@3.25.67)
+      '@ai-sdk/svelte': 0.0.57(svelte@5.39.10)(zod@3.25.67)
       '@ai-sdk/ui-utils': 0.0.50(zod@3.25.67)
-      '@ai-sdk/vue': 0.0.59(vue@3.5.21(typescript@5.9.2))(zod@3.25.67)
+      '@ai-sdk/vue': 0.0.59(vue@3.5.22(typescript@5.9.3))(zod@3.25.67)
       '@opentelemetry/api': 1.9.0
       eventsource-parser: 1.1.2
       json-schema: 0.4.0
@@ -8193,25 +8254,25 @@ snapshots:
       zod-to-json-schema: 3.24.6(zod@3.25.67)
     optionalDependencies:
       openai: 4.104.0(ws@8.18.3)(zod@3.25.67)
-      react: 19.1.1
-      sswr: 2.2.0(svelte@5.39.3)
-      svelte: 5.39.3
+      react: 19.2.0
+      sswr: 2.2.0(svelte@5.39.10)
+      svelte: 5.39.10
       zod: 3.25.67
     transitivePeerDependencies:
       - solid-js
       - vue
 
-  ai@4.3.19(react@19.1.1)(zod@3.25.67):
+  ai@4.3.19(react@19.2.0)(zod@3.25.67):
     dependencies:
       '@ai-sdk/provider': 1.1.3
       '@ai-sdk/provider-utils': 2.2.8(zod@3.25.67)
-      '@ai-sdk/react': 1.2.12(react@19.1.1)(zod@3.25.67)
+      '@ai-sdk/react': 1.2.12(react@19.2.0)(zod@3.25.67)
       '@ai-sdk/ui-utils': 1.2.11(zod@3.25.67)
       '@opentelemetry/api': 1.9.0
       jsondiffpatch: 0.6.0
       zod: 3.25.67
     optionalDependencies:
-      react: 19.1.1
+      react: 19.2.0
 
   ajv-draft-04@1.0.0(ajv@8.17.1):
     optionalDependencies:
@@ -8245,7 +8306,7 @@ snapshots:
 
   ansi-colors@4.1.3: {}
 
-  ansi-escapes@7.1.0:
+  ansi-escapes@7.1.1:
     dependencies:
       environment: 1.1.0
 
@@ -8354,16 +8415,15 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  b4a@1.7.1: {}
+  b4a@1.7.3: {}
 
   bail@2.0.2: {}
 
   balanced-match@1.0.2: {}
 
-  bare-events@2.7.0:
-    optional: true
+  bare-events@2.7.0: {}
 
-  bare-fs@4.4.4:
+  bare-fs@4.4.5:
     dependencies:
       bare-events: 2.7.0
       bare-path: 3.0.0
@@ -8384,7 +8444,7 @@ snapshots:
 
   bare-stream@2.7.0(bare-events@2.7.0):
     dependencies:
-      streamx: 2.22.1
+      streamx: 2.23.0
     optionalDependencies:
       bare-events: 2.7.0
     transitivePeerDependencies:
@@ -8464,13 +8524,13 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  braintrust@0.0.171(openai@4.104.0(ws@8.18.3)(zod@3.25.67))(react@19.1.1)(sswr@2.2.0(svelte@5.39.3))(svelte@5.39.3)(vue@3.5.21(typescript@5.9.2))(zod@3.25.67):
+  braintrust@0.0.171(openai@4.104.0(ws@8.18.3)(zod@3.25.67))(react@19.2.0)(sswr@2.2.0(svelte@5.39.10))(svelte@5.39.10)(vue@3.5.22(typescript@5.9.3))(zod@3.25.67):
     dependencies:
       '@ai-sdk/provider': 0.0.11
       '@braintrust/core': 0.0.67
-      '@next/env': 14.2.32
+      '@next/env': 14.2.33
       '@vercel/functions': 1.6.0
-      ai: 3.4.33(openai@4.104.0(ws@8.18.3)(zod@3.25.67))(react@19.1.1)(sswr@2.2.0(svelte@5.39.3))(svelte@5.39.3)(vue@3.5.21(typescript@5.9.2))(zod@3.25.67)
+      ai: 3.4.33(openai@4.104.0(ws@8.18.3)(zod@3.25.67))(react@19.2.0)(sswr@2.2.0(svelte@5.39.10))(svelte@5.39.10)(vue@3.5.22(typescript@5.9.3))(zod@3.25.67)
       argparse: 2.0.1
       chalk: 4.1.2
       cli-progress: 3.12.0
@@ -8672,6 +8732,8 @@ snapshots:
 
   collapse-white-space@2.1.0: {}
 
+  color-blend@4.0.0: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -8761,14 +8823,14 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig@9.0.0(typescript@5.9.2):
+  cosmiconfig@9.0.0(typescript@5.9.3):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
       js-yaml: 4.1.0
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 5.9.2
+      typescript: 5.9.3
 
   cross-spawn@7.0.6:
     dependencies:
@@ -8830,6 +8892,17 @@ snapshots:
 
   decamelize@1.2.0: {}
 
+  decode-bmp@0.2.1:
+    dependencies:
+      '@canvas/image-data': 1.0.0
+      to-data-view: 1.1.0
+
+  decode-ico@0.4.1:
+    dependencies:
+      '@canvas/image-data': 1.0.0
+      decode-bmp: 0.2.1
+      to-data-view: 1.1.0
+
   decode-named-character-reference@1.2.0:
     dependencies:
       character-entities: 2.0.2
@@ -8876,7 +8949,7 @@ snapshots:
 
   detect-indent@6.1.0: {}
 
-  detect-libc@2.1.0: {}
+  detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
 
@@ -8978,7 +9051,7 @@ snapshots:
   engine.io@6.6.4:
     dependencies:
       '@types/cors': 2.8.19
-      '@types/node': 20.19.17
+      '@types/node': 20.19.19
       accepts: 1.3.8
       base64id: 2.0.0
       cookie: 0.7.2
@@ -9220,16 +9293,16 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.36.0(jiti@1.21.7):
+  eslint@9.37.0(jiti@1.21.7):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.36.0(jiti@1.21.7))
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.37.0(jiti@1.21.7))
       '@eslint-community/regexpp': 4.12.1
       '@eslint/config-array': 0.21.0
-      '@eslint/config-helpers': 0.3.1
-      '@eslint/core': 0.15.2
+      '@eslint/config-helpers': 0.4.0
+      '@eslint/core': 0.16.0
       '@eslint/eslintrc': 3.3.1
-      '@eslint/js': 9.36.0
-      '@eslint/plugin-kit': 0.3.5
+      '@eslint/js': 9.37.0
+      '@eslint/plugin-kit': 0.4.0
       '@humanfs/node': 0.16.7
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
@@ -9328,6 +9401,10 @@ snapshots:
   event-target-shim@5.0.1: {}
 
   eventemitter3@4.0.7: {}
+
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.7.0
 
   eventsource-parser@1.1.2: {}
 
@@ -9447,8 +9524,6 @@ snapshots:
 
   fast-memoize@2.5.2: {}
 
-  fast-redact@3.5.0: {}
-
   fast-safe-stringify@2.1.1: {}
 
   fast-uri@3.1.0: {}
@@ -9527,7 +9602,7 @@ snapshots:
     dependencies:
       magic-string: 0.30.19
       mlly: 1.8.0
-      rollup: 4.52.0
+      rollup: 4.52.4
 
   flat-cache@4.0.1:
     dependencies:
@@ -9635,6 +9710,8 @@ snapshots:
       - encoding
       - supports-color
 
+  generator-function@2.0.1: {}
+
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.4.0: {}
@@ -9671,7 +9748,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
 
-  get-tsconfig@4.10.1:
+  get-tsconfig@4.11.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
@@ -9970,6 +10047,8 @@ snapshots:
 
   help-me@5.0.0: {}
 
+  hex-rgb@5.0.0: {}
+
   html-void-elements@3.0.0: {}
 
   htmlparser2@10.0.0:
@@ -10008,11 +10087,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  human-id@4.1.1: {}
+  human-id@4.1.2: {}
 
   humanize-ms@1.2.1:
     dependencies:
       ms: 2.1.3
+
+  ico-endec@0.1.6: {}
 
   iconv-lite@0.4.24:
     dependencies:
@@ -10047,16 +10128,16 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ink-spinner@5.0.0(ink@6.3.1(@types/react@19.1.13)(react@19.1.1))(react@19.1.1):
+  ink-spinner@5.0.0(ink@6.3.1(@types/react@19.2.2)(react@19.2.0))(react@19.2.0):
     dependencies:
       cli-spinners: 2.9.2
-      ink: 6.3.1(@types/react@19.1.13)(react@19.1.1)
-      react: 19.1.1
+      ink: 6.3.1(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
 
-  ink@6.3.1(@types/react@19.1.13)(react@19.1.1):
+  ink@6.3.1(@types/react@19.2.2)(react@19.2.0):
     dependencies:
       '@alcalzone/ansi-tokenize': 0.2.0
-      ansi-escapes: 7.1.0
+      ansi-escapes: 7.1.1
       ansi-styles: 6.2.3
       auto-bind: 5.0.1
       chalk: 5.6.2
@@ -10068,8 +10149,8 @@ snapshots:
       indent-string: 5.0.0
       is-in-ci: 2.0.0
       patch-console: 2.0.0
-      react: 19.1.1
-      react-reconciler: 0.32.0(react@19.1.1)
+      react: 19.2.0
+      react-reconciler: 0.32.0(react@19.2.0)
       signal-exit: 3.0.7
       slice-ansi: 7.1.2
       stack-utils: 2.0.6
@@ -10080,24 +10161,24 @@ snapshots:
       ws: 8.18.3
       yoga-layout: 3.2.1
     optionalDependencies:
-      '@types/react': 19.1.13
+      '@types/react': 19.2.2
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
   inline-style-parser@0.2.4: {}
 
-  inquirer@12.9.6(@types/node@20.19.17):
+  inquirer@12.9.6(@types/node@20.19.19):
     dependencies:
       '@inquirer/ansi': 1.0.0
-      '@inquirer/core': 10.2.2(@types/node@20.19.17)
-      '@inquirer/prompts': 7.8.6(@types/node@20.19.17)
-      '@inquirer/type': 3.0.8(@types/node@20.19.17)
+      '@inquirer/core': 10.2.2(@types/node@20.19.19)
+      '@inquirer/prompts': 7.8.6(@types/node@20.19.19)
+      '@inquirer/type': 3.0.8(@types/node@20.19.19)
       mute-stream: 2.0.0
       run-async: 4.0.6
       rxjs: 7.8.2
     optionalDependencies:
-      '@types/node': 20.19.17
+      '@types/node': 20.19.19
 
   install@0.13.0: {}
 
@@ -10192,9 +10273,10 @@ snapshots:
     dependencies:
       get-east-asian-width: 1.4.0
 
-  is-generator-function@1.1.0:
+  is-generator-function@1.1.2:
     dependencies:
       call-bound: 1.0.4
+      generator-function: 2.0.1
       get-proto: 1.0.1
       has-tostringtag: 1.0.2
       safe-regex-test: 1.1.0
@@ -10383,7 +10465,7 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
 
-  katex@0.16.22:
+  katex@0.16.23:
     dependencies:
       commander: 8.3.0
 
@@ -10393,7 +10475,7 @@ snapshots:
 
   kind-of@6.0.3: {}
 
-  langsmith@0.3.69(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.18.3)(zod@3.25.67)):
+  langsmith@0.3.72(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.18.3)(zod@3.25.67)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2
@@ -10430,7 +10512,7 @@ snapshots:
       cheminfo-types: 1.8.1
       install: 0.13.0
       ml-matrix: 6.12.1
-      ml-spectra-processing: 14.17.1
+      ml-spectra-processing: 14.18.0
 
   lines-and-columns@1.2.4: {}
 
@@ -10772,7 +10854,7 @@ snapshots:
     dependencies:
       '@types/katex': 0.16.7
       devlop: 1.1.0
-      katex: 0.16.22
+      katex: 0.16.23
       micromark-factory-space: 2.0.1
       micromark-util-character: 2.1.1
       micromark-util-symbol: 2.0.1
@@ -11013,9 +11095,9 @@ snapshots:
       minipass: 3.3.6
       yallist: 4.0.0
 
-  mintlify@4.2.121(@radix-ui/react-popover@1.1.15(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1))(@types/node@20.19.17)(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(typescript@5.9.2):
+  mintlify@4.2.149(@radix-ui/react-popover@1.1.15(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0))(@types/node@20.19.19)(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1):
     dependencies:
-      '@mintlify/cli': 4.0.725(@radix-ui/react-popover@1.1.15(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1))(@types/node@20.19.17)(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(typescript@5.9.2)
+      '@mintlify/cli': 4.0.753(@radix-ui/react-popover@1.1.15(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0))(@types/node@20.19.19)(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@radix-ui/react-popover'
       - '@types/node'
@@ -11028,9 +11110,10 @@ snapshots:
       - react-dom
       - react-native-b4a
       - supports-color
-      - ts-node
+      - tsx
       - typescript
       - utf-8-validate
+      - yaml
 
   mitt@3.0.1: {}
 
@@ -11059,7 +11142,7 @@ snapshots:
       is-any-array: 2.0.1
       ml-array-rescale: 1.3.7
 
-  ml-spectra-processing@14.17.1:
+  ml-spectra-processing@14.18.0:
     dependencies:
       binary-search: 1.3.6
       cheminfo-types: 1.8.1
@@ -11115,13 +11198,13 @@ snapshots:
 
   netmask@2.0.2: {}
 
-  next-mdx-remote-client@1.1.2(@types/react@19.1.13)(react-dom@18.3.1(react@19.1.1))(react@19.1.1)(unified@11.0.5):
+  next-mdx-remote-client@1.1.3(@types/react@19.2.2)(react-dom@18.3.1(react@19.2.0))(react@19.2.0)(unified@11.0.5):
     dependencies:
       '@babel/code-frame': 7.27.1
       '@mdx-js/mdx': 3.1.1
-      '@mdx-js/react': 3.1.1(@types/react@19.1.13)(react@19.1.1)
-      react: 19.1.1
-      react-dom: 18.3.1(react@19.1.1)
+      '@mdx-js/react': 3.1.1(@types/react@19.2.2)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 18.3.1(react@19.2.0)
       remark-mdx-remove-esm: 1.2.1(unified@11.0.5)
       serialize-error: 12.0.0
       vfile: 6.0.3
@@ -11219,7 +11302,7 @@ snapshots:
 
   openai@4.104.0(ws@8.18.3)(zod@3.25.67):
     dependencies:
-      '@types/node': 18.19.127
+      '@types/node': 18.19.129
       '@types/node-fetch': 2.6.13
       abort-controller: 3.0.0
       agentkeepalive: 4.6.0
@@ -11234,7 +11317,7 @@ snapshots:
 
   openai@4.23.0:
     dependencies:
-      '@types/node': 18.19.127
+      '@types/node': 18.19.129
       '@types/node-fetch': 2.6.13
       abort-controller: 3.0.0
       agentkeepalive: 4.6.0
@@ -11448,16 +11531,15 @@ snapshots:
       on-exit-leak-free: 2.1.2
       pino-abstract-transport: 2.0.0
       pump: 3.0.3
-      secure-json-parse: 4.0.0
+      secure-json-parse: 4.1.0
       sonic-boom: 4.2.0
       strip-json-comments: 5.0.3
 
   pino-std-serializers@7.0.0: {}
 
-  pino@9.10.0:
+  pino@9.13.1:
     dependencies:
       atomic-sleep: 1.0.0
-      fast-redact: 3.5.0
       on-exit-leak-free: 2.1.2
       pino-abstract-transport: 2.0.0
       pino-std-serializers: 7.0.0
@@ -11465,6 +11547,7 @@ snapshots:
       quick-format-unescaped: 4.0.4
       real-require: 0.2.0
       safe-stable-stringify: 2.5.0
+      slow-redact: 0.3.1
       sonic-boom: 4.2.0
       thread-stream: 3.1.0
 
@@ -11478,11 +11561,11 @@ snapshots:
       mlly: 1.8.0
       pathe: 2.0.3
 
-  playwright-core@1.55.0: {}
+  playwright-core@1.56.0: {}
 
-  playwright@1.55.0:
+  playwright@1.56.0:
     dependencies:
-      playwright-core: 1.55.0
+      playwright-core: 1.56.0
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -11504,20 +11587,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.6
 
-  postcss-load-config@4.0.2(postcss@8.5.6):
-    dependencies:
-      lilconfig: 3.1.3
-      yaml: 2.8.1
-    optionalDependencies:
-      postcss: 8.5.6
-
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(yaml@2.8.1):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
       postcss: 8.5.6
-      tsx: 4.20.5
+      tsx: 4.20.6
       yaml: 2.8.1
 
   postcss-nested@6.2.0(postcss@8.5.6):
@@ -11599,10 +11675,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  puppeteer@22.15.0(typescript@5.9.2):
+  puppeteer@22.15.0(typescript@5.9.3):
     dependencies:
       '@puppeteer/browsers': 2.3.0
-      cosmiconfig: 9.0.0(typescript@5.9.2)
+      cosmiconfig: 9.0.0(typescript@5.9.3)
       devtools-protocol: 0.0.1312386
       puppeteer-core: 22.15.0
     transitivePeerDependencies:
@@ -11645,45 +11721,45 @@ snapshots:
       iconv-lite: 0.7.0
       unpipe: 1.0.0
 
-  react-dom@18.3.1(react@19.1.1):
+  react-dom@18.3.1(react@19.2.0):
     dependencies:
       loose-envify: 1.4.0
-      react: 19.1.1
+      react: 19.2.0
       scheduler: 0.23.2
 
-  react-reconciler@0.32.0(react@19.1.1):
+  react-reconciler@0.32.0(react@19.2.0):
     dependencies:
-      react: 19.1.1
+      react: 19.2.0
       scheduler: 0.26.0
 
-  react-remove-scroll-bar@2.3.8(@types/react@19.1.13)(react@19.1.1):
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.2)(react@19.2.0):
     dependencies:
-      react: 19.1.1
-      react-style-singleton: 2.2.3(@types/react@19.1.13)(react@19.1.1)
+      react: 19.2.0
+      react-style-singleton: 2.2.3(@types/react@19.2.2)(react@19.2.0)
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 19.1.13
+      '@types/react': 19.2.2
 
-  react-remove-scroll@2.7.1(@types/react@19.1.13)(react@19.1.1):
+  react-remove-scroll@2.7.1(@types/react@19.2.2)(react@19.2.0):
     dependencies:
-      react: 19.1.1
-      react-remove-scroll-bar: 2.3.8(@types/react@19.1.13)(react@19.1.1)
-      react-style-singleton: 2.2.3(@types/react@19.1.13)(react@19.1.1)
+      react: 19.2.0
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.2)(react@19.2.0)
+      react-style-singleton: 2.2.3(@types/react@19.2.2)(react@19.2.0)
       tslib: 2.8.1
-      use-callback-ref: 1.3.3(@types/react@19.1.13)(react@19.1.1)
-      use-sidecar: 1.1.3(@types/react@19.1.13)(react@19.1.1)
+      use-callback-ref: 1.3.3(@types/react@19.2.2)(react@19.2.0)
+      use-sidecar: 1.1.3(@types/react@19.2.2)(react@19.2.0)
     optionalDependencies:
-      '@types/react': 19.1.13
+      '@types/react': 19.2.2
 
-  react-style-singleton@2.2.3(@types/react@19.1.13)(react@19.1.1):
+  react-style-singleton@2.2.3(@types/react@19.2.2)(react@19.2.0):
     dependencies:
       get-nonce: 1.0.1
-      react: 19.1.1
+      react: 19.2.0
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 19.1.13
+      '@types/react': 19.2.2
 
-  react@19.1.1: {}
+  react@19.2.0: {}
 
   read-cache@1.0.0:
     dependencies:
@@ -11779,7 +11855,7 @@ snapshots:
       '@types/katex': 0.16.7
       hast-util-from-html-isomorphic: 2.0.0
       hast-util-to-text: 4.0.2
-      katex: 0.16.22
+      katex: 0.16.23
       unist-util-visit-parents: 6.0.1
       vfile: 6.0.3
 
@@ -11942,32 +12018,32 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rollup@4.52.0:
+  rollup@4.52.4:
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.52.0
-      '@rollup/rollup-android-arm64': 4.52.0
-      '@rollup/rollup-darwin-arm64': 4.52.0
-      '@rollup/rollup-darwin-x64': 4.52.0
-      '@rollup/rollup-freebsd-arm64': 4.52.0
-      '@rollup/rollup-freebsd-x64': 4.52.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.52.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.52.0
-      '@rollup/rollup-linux-arm64-gnu': 4.52.0
-      '@rollup/rollup-linux-arm64-musl': 4.52.0
-      '@rollup/rollup-linux-loong64-gnu': 4.52.0
-      '@rollup/rollup-linux-ppc64-gnu': 4.52.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.52.0
-      '@rollup/rollup-linux-riscv64-musl': 4.52.0
-      '@rollup/rollup-linux-s390x-gnu': 4.52.0
-      '@rollup/rollup-linux-x64-gnu': 4.52.0
-      '@rollup/rollup-linux-x64-musl': 4.52.0
-      '@rollup/rollup-openharmony-arm64': 4.52.0
-      '@rollup/rollup-win32-arm64-msvc': 4.52.0
-      '@rollup/rollup-win32-ia32-msvc': 4.52.0
-      '@rollup/rollup-win32-x64-gnu': 4.52.0
-      '@rollup/rollup-win32-x64-msvc': 4.52.0
+      '@rollup/rollup-android-arm-eabi': 4.52.4
+      '@rollup/rollup-android-arm64': 4.52.4
+      '@rollup/rollup-darwin-arm64': 4.52.4
+      '@rollup/rollup-darwin-x64': 4.52.4
+      '@rollup/rollup-freebsd-arm64': 4.52.4
+      '@rollup/rollup-freebsd-x64': 4.52.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.52.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.52.4
+      '@rollup/rollup-linux-arm64-gnu': 4.52.4
+      '@rollup/rollup-linux-arm64-musl': 4.52.4
+      '@rollup/rollup-linux-loong64-gnu': 4.52.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.52.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.52.4
+      '@rollup/rollup-linux-riscv64-musl': 4.52.4
+      '@rollup/rollup-linux-s390x-gnu': 4.52.4
+      '@rollup/rollup-linux-x64-gnu': 4.52.4
+      '@rollup/rollup-linux-x64-musl': 4.52.4
+      '@rollup/rollup-openharmony-arm64': 4.52.4
+      '@rollup/rollup-win32-arm64-msvc': 4.52.4
+      '@rollup/rollup-win32-ia32-msvc': 4.52.4
+      '@rollup/rollup-win32-x64-gnu': 4.52.4
+      '@rollup/rollup-win32-x64-msvc': 4.52.4
       fsevents: 2.3.3
 
   router@2.2.0:
@@ -12034,7 +12110,7 @@ snapshots:
 
   secure-json-parse@2.7.0: {}
 
-  secure-json-parse@4.0.0: {}
+  secure-json-parse@4.1.0: {}
 
   semver@7.7.2: {}
 
@@ -12122,10 +12198,16 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
+  sharp-ico@0.1.5:
+    dependencies:
+      decode-ico: 0.4.1
+      ico-endec: 0.1.6
+      sharp: 0.33.5
+
   sharp@0.33.5:
     dependencies:
       color: 4.2.3
-      detect-libc: 2.1.0
+      detect-libc: 2.1.2
       semver: 7.7.2
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.33.5
@@ -12227,6 +12309,8 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
+  slow-redact@0.3.1: {}
+
   slugify@1.6.6: {}
 
   smart-buffer@4.2.0: {}
@@ -12300,9 +12384,9 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
-  sswr@2.2.0(svelte@5.39.3):
+  sswr@2.2.0(svelte@5.39.10):
     dependencies:
-      svelte: 5.39.3
+      svelte: 5.39.10
       swrev: 4.0.0
 
   stack-utils@2.0.6:
@@ -12320,12 +12404,11 @@ snapshots:
 
   streamsearch@1.1.0: {}
 
-  streamx@2.22.1:
+  streamx@2.23.0:
     dependencies:
+      events-universal: 1.0.1
       fast-fifo: 1.3.2
       text-decoder: 1.2.3
-    optionalDependencies:
-      bare-events: 2.7.0
     transitivePeerDependencies:
       - react-native-b4a
 
@@ -12421,11 +12504,11 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte@5.39.3:
+  svelte@5.39.10:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5
-      '@sveltejs/acorn-typescript': 1.0.5(acorn@8.15.0)
+      '@sveltejs/acorn-typescript': 1.0.6(acorn@8.15.0)
       '@types/estree': 1.0.8
       acorn: 8.15.0
       aria-query: 5.3.2
@@ -12438,19 +12521,19 @@ snapshots:
       magic-string: 0.30.19
       zimmerframe: 1.1.4
 
-  swr@2.3.6(react@19.1.1):
+  swr@2.3.6(react@19.2.0):
     dependencies:
       dequal: 2.0.3
-      react: 19.1.1
-      use-sync-external-store: 1.5.0(react@19.1.1)
+      react: 19.2.0
+      use-sync-external-store: 1.6.0(react@19.2.0)
 
   swrev@4.0.0: {}
 
-  swrv@1.1.0(vue@3.5.21(typescript@5.9.2)):
+  swrv@1.1.0(vue@3.5.22(typescript@5.9.3)):
     dependencies:
-      vue: 3.5.21(typescript@5.9.2)
+      vue: 3.5.22(typescript@5.9.3)
 
-  tailwindcss@3.4.17:
+  tailwindcss@3.4.18(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -12469,20 +12552,21 @@ snapshots:
       postcss: 8.5.6
       postcss-import: 15.1.0(postcss@8.5.6)
       postcss-js: 4.1.0(postcss@8.5.6)
-      postcss-load-config: 4.0.2(postcss@8.5.6)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.6)(yaml@2.8.1)
       postcss-nested: 6.2.0(postcss@8.5.6)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.10
       sucrase: 3.35.0
     transitivePeerDependencies:
-      - ts-node
+      - tsx
+      - yaml
 
   tar-fs@3.1.1:
     dependencies:
       pump: 3.0.3
       tar-stream: 3.1.7
     optionalDependencies:
-      bare-fs: 4.4.4
+      bare-fs: 4.4.5
       bare-path: 3.0.0
     transitivePeerDependencies:
       - bare-buffer
@@ -12490,9 +12574,9 @@ snapshots:
 
   tar-stream@3.1.7:
     dependencies:
-      b4a: 1.7.1
+      b4a: 1.7.3
       fast-fifo: 1.3.2
-      streamx: 2.22.1
+      streamx: 2.23.0
     transitivePeerDependencies:
       - react-native-b4a
 
@@ -12509,7 +12593,7 @@ snapshots:
 
   text-decoder@1.2.3:
     dependencies:
-      b4a: 1.7.1
+      b4a: 1.7.3
     transitivePeerDependencies:
       - react-native-b4a
 
@@ -12542,6 +12626,8 @@ snapshots:
     dependencies:
       tldts-core: 6.1.86
 
+  to-data-view@1.1.0: {}
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -12566,9 +12652,9 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-api-utils@2.1.0(typescript@5.9.2):
+  ts-api-utils@2.1.0(typescript@5.9.3):
     dependencies:
-      typescript: 5.9.2
+      typescript: 5.9.3
 
   ts-interface-checker@0.1.13: {}
 
@@ -12576,7 +12662,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.0(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1):
+  tsup@8.5.0(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)(yaml@2.8.1):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.10)
       cac: 6.7.14
@@ -12587,9 +12673,9 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(yaml@2.8.1)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.6)(yaml@2.8.1)
       resolve-from: 5.0.0
-      rollup: 4.52.0
+      rollup: 4.52.4
       source-map: 0.8.0-beta.0
       sucrase: 3.35.0
       tinyexec: 0.3.2
@@ -12597,27 +12683,27 @@ snapshots:
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.5.6
-      typescript: 5.9.2
+      typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
       - supports-color
       - tsx
       - yaml
 
-  tsx@4.20.5:
+  tsx@4.20.6:
     dependencies:
       esbuild: 0.25.10
-      get-tsconfig: 4.10.1
+      get-tsconfig: 4.11.0
     optionalDependencies:
       fsevents: 2.3.3
 
   twoslash-protocol@0.3.4: {}
 
-  twoslash@0.3.4(typescript@5.9.2):
+  twoslash@0.3.4(typescript@5.9.3):
     dependencies:
-      '@typescript/vfs': 1.6.1(typescript@5.9.2)
+      '@typescript/vfs': 1.6.1(typescript@5.9.3)
       twoslash-protocol: 0.3.4
-      typescript: 5.9.2
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -12673,18 +12759,18 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript-eslint@8.44.0(eslint@9.36.0(jiti@1.21.7))(typescript@5.9.2):
+  typescript-eslint@8.46.0(eslint@9.37.0(jiti@1.21.7))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.44.0(@typescript-eslint/parser@8.44.0(eslint@9.36.0(jiti@1.21.7))(typescript@5.9.2))(eslint@9.36.0(jiti@1.21.7))(typescript@5.9.2)
-      '@typescript-eslint/parser': 8.44.0(eslint@9.36.0(jiti@1.21.7))(typescript@5.9.2)
-      '@typescript-eslint/typescript-estree': 8.44.0(typescript@5.9.2)
-      '@typescript-eslint/utils': 8.44.0(eslint@9.36.0(jiti@1.21.7))(typescript@5.9.2)
-      eslint: 9.36.0(jiti@1.21.7)
-      typescript: 5.9.2
+      '@typescript-eslint/eslint-plugin': 8.46.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@1.21.7))(typescript@5.9.3))(eslint@9.37.0(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.46.0(eslint@9.37.0(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.46.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.46.0(eslint@9.37.0(jiti@1.21.7))(typescript@5.9.3)
+      eslint: 9.37.0(jiti@1.21.7)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  typescript@5.9.2: {}
+  typescript@5.9.3: {}
 
   ufo@1.6.1: {}
 
@@ -12805,24 +12891,24 @@ snapshots:
 
   urlpattern-polyfill@10.0.0: {}
 
-  use-callback-ref@1.3.3(@types/react@19.1.13)(react@19.1.1):
+  use-callback-ref@1.3.3(@types/react@19.2.2)(react@19.2.0):
     dependencies:
-      react: 19.1.1
+      react: 19.2.0
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 19.1.13
+      '@types/react': 19.2.2
 
-  use-sidecar@1.1.3(@types/react@19.1.13)(react@19.1.1):
+  use-sidecar@1.1.3(@types/react@19.2.2)(react@19.2.0):
     dependencies:
       detect-node-es: 1.1.0
-      react: 19.1.1
+      react: 19.2.0
       tslib: 2.8.1
     optionalDependencies:
-      '@types/react': 19.1.13
+      '@types/react': 19.2.2
 
-  use-sync-external-store@1.5.0(react@19.1.1):
+  use-sync-external-store@1.6.0(react@19.2.0):
     dependencies:
-      react: 19.1.1
+      react: 19.2.0
 
   util-deprecate@1.0.2: {}
 
@@ -12831,6 +12917,8 @@ snapshots:
   utils-merge@1.0.1: {}
 
   uuid@10.0.0: {}
+
+  uuid@11.1.0: {}
 
   uuid@9.0.1: {}
 
@@ -12860,15 +12948,15 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vue@3.5.21(typescript@5.9.2):
+  vue@3.5.22(typescript@5.9.3):
     dependencies:
-      '@vue/compiler-dom': 3.5.21
-      '@vue/compiler-sfc': 3.5.21
-      '@vue/runtime-dom': 3.5.21
-      '@vue/server-renderer': 3.5.21(vue@3.5.21(typescript@5.9.2))
-      '@vue/shared': 3.5.21
+      '@vue/compiler-dom': 3.5.22
+      '@vue/compiler-sfc': 3.5.22
+      '@vue/runtime-dom': 3.5.22
+      '@vue/server-renderer': 3.5.22(vue@3.5.22(typescript@5.9.3))
+      '@vue/shared': 3.5.22
     optionalDependencies:
-      typescript: 5.9.2
+      typescript: 5.9.3
 
   web-namespaces@2.0.1: {}
 
@@ -12913,7 +13001,7 @@ snapshots:
       is-async-function: 2.1.1
       is-date-object: 1.1.0
       is-finalizationregistry: 1.1.1
-      is-generator-function: 1.1.0
+      is-generator-function: 1.1.2
       is-regex: 1.2.1
       is-weakref: 1.1.1
       isarray: 2.0.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^2.4.0
         version: 2.6.0
       '@google/genai':
-        specifier: ^0.8.0
-        version: 0.8.0
+        specifier: ^1.22.0
+        version: 1.22.0(@modelcontextprotocol/sdk@1.18.1)
       '@modelcontextprotocol/sdk':
         specifier: ^1.17.2
         version: 1.18.1
@@ -998,9 +998,14 @@ packages:
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
-  '@google/genai@0.8.0':
-    resolution: {integrity: sha512-Zs+OGyZKyMbFofGJTR9/jTQSv8kITh735N3tEuIZj4VlMQXTC0soCFahysJ9NaeenRlD7xGb6fyqmX+FwrpU6Q==}
-    engines: {node: '>=18.0.0'}
+  '@google/genai@1.22.0':
+    resolution: {integrity: sha512-siETS3zTm3EGpTT4+BFc1z20xXBYfueD3gCYfxkOjuAKRk8lt8TJevDHi3zepn1oSI6NhG/LZvy0i+Q3qheObg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.11.4
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -6705,10 +6710,12 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
-  '@google/genai@0.8.0':
+  '@google/genai@1.22.0(@modelcontextprotocol/sdk@1.18.1)':
     dependencies:
       google-auth-library: 9.15.1
       ws: 8.18.3
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.18.1
     transitivePeerDependencies:
       - bufferutil
       - encoding

--- a/stagehand.config.ts
+++ b/stagehand.config.ts
@@ -24,13 +24,10 @@ const StagehandConfig: ConstructorParams = {
   browserbaseSessionCreateParams: {
     projectId: process.env.BROWSERBASE_PROJECT_ID!,
     browserSettings: {
-      advancedStealth: true,
       blockAds: true,
-      // @ts-expect-error - os is not a valid property in the BrowserSettings type
-      os: "windows",
       viewport: {
-        width: 2560,
-        height: 1440,
+        width: 1288,
+        height: 711,
       },
     },
   },

--- a/stagehand.config.ts
+++ b/stagehand.config.ts
@@ -24,18 +24,21 @@ const StagehandConfig: ConstructorParams = {
   browserbaseSessionCreateParams: {
     projectId: process.env.BROWSERBASE_PROJECT_ID!,
     browserSettings: {
+      advancedStealth: true,
       blockAds: true,
+      // @ts-expect-error - os is not a valid property in the BrowserSettings type
+      os: "windows",
       viewport: {
-        width: 1024,
-        height: 768,
+        width: 2560,
+        height: 1440,
       },
     },
   },
   localBrowserLaunchOptions: {
     headless: false,
     viewport: {
-      width: 1024,
-      height: 768,
+      width: 1288,
+      height: 711,
     },
   } /* Configuration options for the local browser */,
   experimental: false, // Enable experimental features

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -41,6 +41,7 @@ export interface AgentOptions {
   autoScreenshot?: boolean;
   waitBetweenActions?: number;
   context?: string;
+  highlightCursor?: boolean;
 }
 
 export interface AgentExecuteOptions extends AgentOptions {

--- a/types/agent.ts
+++ b/types/agent.ts
@@ -47,7 +47,7 @@ export interface AgentExecuteOptions extends AgentOptions {
   instruction: string;
 }
 
-export type AgentProviderType = "openai" | "anthropic";
+export type AgentProviderType = "openai" | "anthropic" | "google";
 
 export interface AgentClientOptions {
   apiKey: string;
@@ -57,7 +57,7 @@ export interface AgentClientOptions {
   [key: string]: unknown;
 }
 
-export type AgentType = "openai" | "anthropic";
+export type AgentType = "openai" | "anthropic" | "google";
 
 export interface AgentExecutionOptions {
   options: AgentExecuteOptions;

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -175,7 +175,7 @@ export interface LocalBrowserLaunchOptions {
   args?: string[];
   chromiumSandbox?: boolean;
   devtools?: boolean;
-  env?: Record<string, string | number | boolean>;
+  env?: { [key: string]: string | undefined };
   executablePath?: string;
   handleSIGHUP?: boolean;
   handleSIGINT?: boolean;


### PR DESCRIPTION
# why
Adding support for Gemini's new Computer Use model

# what changed
We partnered with Google Deepmind to help integrate and test their new Computer Use models. 

<img width="1238" height="655" alt="Screenshot 2025-10-07 at 1 14 44 PM" src="https://github.com/user-attachments/assets/af0d854a-8e55-4937-a071-10335497f686" />

The new model tag `gemini-2.5-pro-computer-use-preview-10-2025` is available for Stagehand Agent. You can try it today with the example `cua-example.ts`

To learn more, check out the blog post [https://www.browserbase.com/blog/evaluating-browser-agents](https://www.browserbase.com/blog/evaluating-browser-agents)
