### PR TITLE
Fix Quickstart Guide link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Visit [docs.stagehand.dev](https://docs.stagehand.dev) to view the full document
 
 ## Getting Started
 
-Start with Stagehand with one line of code, or check out our [Quickstart Guide](https://docs.stagehand.dev/get_started/quickstart) for more information:
+Start with Stagehand with one line of code, or check out our [Quickstart Guide](https://docs.stagehand.dev/first-steps/quickstart) for more information:
 
 ```bash
 npx create-browser-app


### PR DESCRIPTION
Updated link in the Getting Started section to point to the correct Quickstart Guide.

# why
Quickstart link in README leads to a non-existent page.
<img width="1556" height="763" alt="image" src="https://github.com/user-attachments/assets/20a1a5b5-8534-43b4-89d5-e3a062b3965a" />

# what changed
Updated quickstart link in README to the correct quickstart address
`https://docs.stagehand.dev/first-steps/quickstart`

# test plan
Access new link to quickstart