### PR TITLE
Issue#186

### DIFF
--- a/docs/references/act.mdx
+++ b/docs/references/act.mdx
@@ -118,11 +118,25 @@ await page.act(observe_result: ObserveResult) -> ActResult
   The action that was performed.
 </ParamField>
 
+<ParamField
+  path="playwrightCommand"
+  type="PlaywrightCommandResult"
+  optional
+>
+  Details about the underlying Playwright method that Stagehand executed,
+  including the selector and arguments that were used.
+</ParamField>
+
 ```Example Response
 {
   success: true,
   message: 'Action [scrollTo] performed successfully on selector: /html[1]',
-  action: 'Scrollable area of the page where user can navigate to the pricing section or other parts of the page'
+  action: 'Scrollable area of the page where user can navigate to the pricing section or other parts of the page',
+  playwrightCommand: {
+    method: 'scrollTo',
+    selector: '/html[1]',
+    arguments: []
+  }
 }
 ```
 

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -125,10 +125,17 @@ export interface ActOptions {
   frameId?: string;
 }
 
+export interface PlaywrightCommandResult {
+  method: string;
+  selector: string;
+  arguments: unknown[];
+}
+
 export interface ActResult {
   success: boolean;
   message: string;
   action: string;
+  playwrightCommand?: PlaywrightCommandResult;
 }
 
 export interface ExtractOptions<T extends z.AnyZodObject> {


### PR DESCRIPTION
## Summary
- expose the Playwright command metadata in `ActResult` so callers can inspect what Stagehand executed
- capture the executed command details throughout the act handler, including self-heal retries
- document the new response shape for `page.act`

## Testing
- pnpm lint

fixes issue #186 
