### PR TITLE
update cua agents key & system prompt handling

### DIFF
--- a/.changeset/quick-clouds-kick.md
+++ b/.changeset/quick-clouds-kick.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+update cua agents key & system prompt handling

--- a/lib/agent/GoogleCUAClient.ts
+++ b/lib/agent/GoogleCUAClient.ts
@@ -203,14 +203,16 @@ export class GoogleCUAClient extends AgentClient {
     // Note: The Python implementation doesn't include the initial screenshot
     // Following the same pattern here
 
+    const systemPromptContent = this.userProvidedInstructions
+      ? this.userProvidedInstructions
+      : buildGoogleCUASystemPrompt().content;
+
     this.history = [
       {
         role: "user",
         parts: [
           {
-            text:
-              "System prompt: " +
-              (buildGoogleCUASystemPrompt().content as string),
+            text: "System prompt: " + systemPromptContent,
           },
         ],
       },

--- a/lib/handlers/cuaAgentHandler.ts
+++ b/lib/handlers/cuaAgentHandler.ts
@@ -271,7 +271,10 @@ export class CuaAgentHandler {
         case "keypress": {
           const { keys } = action;
           if (Array.isArray(keys)) {
-            await this.page.keyboard.press(keys.join("+"));
+            const mappedKeys = keys.map((key) =>
+              mapKeyToPlaywright(String(key)),
+            );
+            await this.page.keyboard.press(mappedKeys.join("+"));
           }
           return { success: true };
         }


### PR DESCRIPTION
# why

currently, for openai cua agent, we are handling keypress actions incorrectly
currently, there is no way to pass a custom system prompt to the Google cua agent

# what changed
- All key actions, are now ran through mapKeyToPlaywright function to ensure we are properly mapping the agents actions to valid playwright keys 
- Custom system prompts now override the default system prompt for Google Cua agent

# test plan
tested locally with google & openai cua agents

Fixes #1122 