### PR TITLE
Support Gemini 2.5 model family with Google GenAI client

### DIFF
--- a/packages/core/lib/v3/llm/LLMProvider.ts
+++ b/packages/core/lib/v3/llm/LLMProvider.ts
@@ -100,7 +100,12 @@ const modelToProviderMap: { [key in AvailableModel]: ModelProvider } = {
   "gemini-1.5-flash-8b": "google",
   "gemini-2.0-flash-lite": "google",
   "gemini-2.0-flash": "google",
+  "gemini-2.5-flash": "google",
   "gemini-2.5-flash-preview-04-17": "google",
+  "gemini-2.5-flash-preview-09-2025": "google",
+  "gemini-2.5-flash-lite": "google",
+  "gemini-2.5-flash-lite-preview-09-2025": "google",
+  "gemini-2.5-pro": "google",
   "gemini-2.5-pro-preview-03-25": "google",
 };
 

--- a/packages/core/lib/v3/types/public/model.ts
+++ b/packages/core/lib/v3/types/public/model.ts
@@ -87,7 +87,12 @@ export type AvailableModel =
   | "gemini-1.5-flash-8b"
   | "gemini-2.0-flash-lite"
   | "gemini-2.0-flash"
+  | "gemini-2.5-flash"
   | "gemini-2.5-flash-preview-04-17"
+  | "gemini-2.5-flash-preview-09-2025"
+  | "gemini-2.5-flash-lite"
+  | "gemini-2.5-flash-lite-preview-09-2025"
+  | "gemini-2.5-pro"
   | "gemini-2.5-pro-preview-03-25"
   | string;
 


### PR DESCRIPTION
# why

I want to use the latest Gemini 2.5 models.

# what changed

I updated the list of available models and mapping to model provider to include the following models:

- Gemini 2.5 Flash
- Gemini 2.5 Flash (September 2025 Preview)
- Gemini 2.5 Flash Lite
- Gemini 2.5 Flash Lite (September 2025 Preview)
- Gemini 2.5 Pro

# test plan

Works out of the box with the Google GenAI client.
