### PR TITLE
update MCP tools & removed multisession, updated to newer models in docs

### DIFF
--- a/docs/configuration/models.mdx
+++ b/docs/configuration/models.mdx
@@ -48,7 +48,7 @@ Stagehand supports major LLM providers with structured output capabilities:
 | Provider | Best Models | Strengths | Use Case |
 |----------|-------------|-----------|----------|
 | **OpenAI** | `gpt-4.1`, `gpt-4.1-mini` | High accuracy, reliable | Production, complex sites |
-| **Anthropic** | `claude-3-7-sonnet-latest` | Excellent reasoning | Complex automation tasks |
+| **Anthropic** | `claude-sonnet-4-5-20250929, claude-haiku-4-5-20251001` | Excellent reasoning | Complex automation tasks |
 | **Google** | `gemini-2.5-flash`, `gemini-2.5-pro` | Fast, cost-effective | High-volume automation |
 
 ### Additional Providers

--- a/docs/integrations/mcp/configuration.mdx
+++ b/docs/integrations/mcp/configuration.mdx
@@ -284,17 +284,15 @@ When using any custom model (non-default), you must provide your own API key for
 - `google/gemini-1.5-flash`
 
 **OpenAI**
+- `openai/gpt-4.1`
 - `openai/gpt-4o`
 - `openai/gpt-4o-mini`
-- `openai/o1-mini`
-- `openai/o1-preview`
-- `openai/o3-mini`
 
 **Anthropic Claude**
-- `anthropic/claude-3-5-sonnet-latest`
-- `anthropic/claude-3-7-sonnet-latest`
+- `anthropic/claude-sonnet-4-5-20250929`
+- `anthropic/claude-haiku-4-5-20251001`
 
-[View full list of supported models](https://docs.stagehand.dev/examples/custom_llms#supported-llms)
+[View full list of supported models](https://docs.stagehand.dev/configuration/models#supported-providers)
 </Tab>
 
 <Tab title="Configuration Examples">

--- a/docs/integrations/mcp/introduction.mdx
+++ b/docs/integrations/mcp/introduction.mdx
@@ -12,14 +12,6 @@ The Browserbase MCP Server brings powerful browser automation capabilities to Cl
 This server enables Claude to control browsers, navigate websites, interact with web elements, and extract data—all through simple conversational commands.
 </Info>
 
-<Note>
-**Two Ways to Use MCP:**
-1. **Browserbase MCP Server**: Provides browser automation tools to Claude Desktop and other MCP clients
-2. **MCP Integrations in Stagehand**: Add external tools (like Exa search, Supabase) to Stagehand agents
-
-This documentation covers the Browserbase MCP Server. For using MCP integrations within Stagehand agents, see [MCP Integrations](/best-practices/mcp-integrations).
-</Note>
-
 ## Key Features
 
 <CardGroup cols={2}>
@@ -34,10 +26,6 @@ Navigate, click, and fill forms with ease
 <Card title="Data Extraction" icon="download">
 Extract structured data from any website automatically
 
-</Card>
-
-<Card title="Multi-Session Management" icon="window-restore">
-Run multiple browser sessions simultaneously for complex workflows
 </Card>
 
 <Card title="Screenshot Capture" icon="camera">
@@ -80,10 +68,6 @@ Extract structured information from complex web pages automatically.
 
 <Card title="Session Persistence" icon="cookie-bite">
 Maintain authentication states and cookies across multiple interactions.
-</Card>
-
-<Card title="Multi-Session Support" icon="window-restore">
-Run parallel browser instances for complex workflows.
 </Card>
 </CardGroup>
 </Tab>
@@ -170,30 +154,6 @@ Schedule posts and monitor engagement across platforms
 Automate repetitive web-based business processes
 </Card>
 </CardGroup>
-</Tab>
-</Tabs>
-
-## Session Management
-
-<Info>
-The Browserbase MCP Server supports both single and multi-session architectures to accommodate different automation needs.
-</Info>
-
-<Tabs>
-<Tab title="Single Session Mode">
-**Traditional Approach**
-- One active browser session at a time
-- Simpler for basic automation tasks  
-- Automatic session lifecycle management
-- Ideal for sequential workflows
-</Tab>
-
-<Tab title="Multi-Session Mode">
-**Advanced Parallel Processing**
-- Multiple independent browser sessions
-- Each session maintains separate state
-- Parallel execution capabilities
-- Perfect for complex workflows
 </Tab>
 </Tabs>
 

--- a/docs/integrations/mcp/tools.mdx
+++ b/docs/integrations/mcp/tools.mdx
@@ -33,6 +33,10 @@ Perform an action on the web page using natural language
 Extract all text content from the current page (filters out CSS and JavaScript)
 
 <Info>No input parameters required</Info>
+
+<ParamField path="instruction" type="string">
+  Extracted text content from the current page
+</ParamField>
 </Accordion>
 
 <Accordion title="browserbase_stagehand_observe">
@@ -64,19 +68,9 @@ Get the current URL of the browser page
 </ResponseField>
 </Accordion>
 
-<Accordion title="browserbase_stagehand_get_all_urls">
-Get current URLs of all active browser sessions
+## Session Management
 
-<Info>No input parameters required</Info>
-
-<ResponseField name="sessionUrls" type="object">
-  Mapping of session IDs to their current URLs in JSON format
-</ResponseField>
-</Accordion>
-
-## Single Session Management
-
-Traditional approach with one active browser session. Simpler for basic automation tasks and automatically manages the active session.
+Manage your browser session lifecycle with create and close operations.
 
 <Accordion title="browserbase_session_create">
 Create or reuse a cloud browser session using Browserbase with fully initialized Stagehand
@@ -93,124 +87,6 @@ Close the current Browserbase session, disconnect the browser, and cleanup Stage
 <Info>No input parameters required</Info>
 
 </Accordion>
-
-## Multi-Session Management
-
-Advanced approach with multiple parallel browser sessions for complex automation workflows. Each session maintains independent state, cookies, and browser context.
-
-### Session Lifecycle Management
-
-<Accordion title="multi_browserbase_stagehand_session_create">
-Create a new independent Stagehand browser session with full web automation capabilities
-
-<ParamField path="name" type="string">
-  Human-readable name for tracking (e.g., 'login-flow', 'data-scraping')
-</ParamField>
-</Accordion>
-
-<Accordion title="multi_browserbase_stagehand_session_list">
-List all currently active Stagehand browser sessions with detailed metadata
-
-<Info>No input parameters required</Info>
-
-</Accordion>
-
-<Accordion title="multi_browserbase_stagehand_session_close">
-Close and clean up a specific Stagehand browser session
-
-<ParamField path="sessionId" type="string" required>
-  Exact session ID to close (cannot be undone)
-</ParamField>
-</Accordion>
-
-### Session-Specific Automation Tools
-
-All core browser automation tools are available with session-specific variants:
-
-<Accordion title="multi_browserbase_stagehand_navigate_session">
-Navigate to a URL in a specific browser session
-
-<ParamField path="sessionId" type="string" required>
-  The session ID to use
-</ParamField>
-
-<ParamField path="url" type="string" required>
-  The URL to navigate to
-</ParamField>
-</Accordion>
-
-<Accordion title="multi_browserbase_stagehand_act_session">
-Perform an action in a specific browser session using natural language
-
-<ParamField path="sessionId" type="string" required>
-  The session ID to use
-</ParamField>
-
-<ParamField path="action" type="string" required>
-  The action to perform
-</ParamField>
-
-</Accordion>
-
-<Accordion title="multi_browserbase_stagehand_extract_session">
-Extract structured information from a specific browser session
-
-<ParamField path="sessionId" type="string" required>
-  The session ID to use
-</ParamField>
-
-<ParamField path="instruction" type="string" required>
-  What to extract from the page
-</ParamField>
-</Accordion>
-
-<Accordion title="multi_browserbase_stagehand_observe_session">
-Observe and find actionable elements in a specific browser session
-
-<ParamField path="sessionId" type="string" required>
-  The session ID to use
-</ParamField>
-
-<ParamField path="instruction" type="string" required>
-  What to observe (e.g., "find the login button")
-</ParamField>
-
-<ParamField path="returnAction" type="boolean">
-  Whether to return the action to perform
-</ParamField>
-</Accordion>
-
-<Accordion title="multi_browserbase_stagehand_get_url_session">
-Get the current URL of a specific browser session
-
-<ParamField path="sessionId" type="string" required>
-  The session ID to use
-</ParamField>
-
-<ResponseField name="url" type="string">
-  Complete URL including protocol, domain, path, and any query parameters or fragments
-</ResponseField>
-</Accordion>
-
-### Multi-Session Use Cases
-
-<CardGroup cols={2}>
-  <Card title="Parallel Data Collection" icon="globe">
-    Run multiple scraping sessions simultaneously across different websites
-  </Card>
-  
-  <Card title="A/B Testing" icon="flask">
-    Compare user flows across different browser sessions with varying configurations
-  </Card>
-  
-  <Card title="Cross-Site Operations" icon="link">
-    Perform coordinated actions across multiple websites or applications
-  </Card>
-  
-  <Card title="Backup Sessions" icon="shield">
-    Keep fallback sessions ready in case primary sessions encounter issues
-  </Card>
-</CardGroup>
 
 ## Resources
 


### PR DESCRIPTION
# why

We recently shipped updates to our MCP server that should be reflected in the documentation. 

# what changed

update tools list for MCP update, removing mentions of multisession, adding experimental flag + get url tool

related PR: https://github.com/browserbase/mcp-server-browserbase/pull/123

# test plan
n/a
