### PR TITLE
add pageUrl and timestamp to open_web_browser

### DIFF
--- a/lib/agent/GoogleCUAClient.ts
+++ b/lib/agent/GoogleCUAClient.ts
@@ -623,6 +623,8 @@ export class GoogleCUAClient extends AgentClient {
           type: "function",
           name: "open_web_browser",
           arguments: null,
+          pageUrl: this.currentUrl,
+          timestamp: Date.now(),
         };
 
       case "click_at": {


### PR DESCRIPTION
# why
currently, open_web_browser is hardcoded and does not go through action handler, so we need to add the pageUrl and timestamp to the hardcoded function call to properly show google cua actions on dashboard 
# what changed

# test plan
