### PR TITLE
patch agent model routing

### DIFF
--- a/packages/core/lib/v3/v3.ts
+++ b/packages/core/lib/v3/v3.ts
@@ -1382,10 +1382,16 @@ export class V3 {
             ? await resolveTools(options.integrations, options.tools)
             : (options?.tools ?? {});
 
+          // Resolve the LLM client for the agent based on the model parameter
+          // Use the agent's model if specified, otherwise fall back to the default
+          const agentLlmClient = options?.model
+            ? this.resolveLlmClient(options.model)
+            : this.llmClient;
+
           const handler = new V3AgentHandler(
             this,
             this.logger,
-            this.llmClient,
+            agentLlmClient,
             typeof options?.executionModel === "string"
               ? options.executionModel
               : options?.executionModel?.modelName,


### PR DESCRIPTION
# why
currently, when defining a model in the non cua agent constructor, if one is present in the stagehand config, it does not override it 

# what changed

now we check for a model to use from agent constructor, and if no model is present use one from stagehand config 

# test plan
