### PR TITLE
patch cua model handling

### DIFF
--- a/packages/core/lib/v3/v3.ts
+++ b/packages/core/lib/v3/v3.ts
@@ -1275,7 +1275,7 @@ export class V3 {
 
       if (!isCua) {
         throw new Error(
-          "To use our computer use agent, please provide a CUA model in the agent constructor or stagehand config. Try one of our supported CUA models: " +
+          "To use the computer use agent, please provide a CUA model in the agent constructor or stagehand config. Try one of our supported CUA models: " +
             AVAILABLE_CUA_MODELS.join(", "),
         );
       }


### PR DESCRIPTION
# why
when a model is defined in stagehand cofnig, but not the agent instantiation, an error is thrown 

# what changed

now, if no model is passed in agent instantiation, we use the one from stagehand config. 

# test plan
