### PR TITLE
zero out tokens for agent cache

### DIFF
--- a/packages/core/lib/v3/cache/AgentCache.ts
+++ b/packages/core/lib/v3/cache/AgentCache.ts
@@ -306,6 +306,11 @@ export class AgentCache {
         await this.executeAgentReplayStep(step, ctx, handler);
       }
       const result = cloneForCache(entry.result);
+      result.usage = {
+        input_tokens: 0,
+        output_tokens: 0,
+        inference_time_ms: 0,
+      };
       result.metadata = {
         ...(result.metadata ?? {}),
         cacheHit: true,


### PR DESCRIPTION
# why

currently cached agent runs display token usage from previous runs 

# what changed

now when a cached run is used, the token count is returned as 0 

# test plan
