### PR TITLE
[docs] fix github links

### DIFF
--- a/packages/docs/v2/best-practices/contributing.mdx
+++ b/packages/docs/v2/best-practices/contributing.mdx
@@ -44,8 +44,8 @@ Get listed as [one of our beloved contributors](https://github.com/browserbase/s
     ![Draft PR](/images/pr_draft.png)
     
 2. **Provide a reproducible test plan.** Include an eval (preferred) or example. We can’t merge your PR if we can’t run anything that specifically highlights your contribution. 
-    1. Write a script in [`evals/tasks`](https://github.com/browserbase/stagehand/tree/main/evals/tasks) as `someTask.ts` 
-    2. Add your script to [`evals.config.json`](https://github.com/browserbase/stagehand/blob/main/evals/evals.config.json) with default category `combination` (*or act/extract/observe if you’re* *only* *testing* *act/extract/observe*).
+    1. Write a script in [`evals/tasks`](https://github.com/browserbase/stagehand/tree/v2/evals/tasks) as `someTask.ts`
+    2. Add your script to [`evals.config.json`](https://github.com/browserbase/stagehand/blob/v2/evals/evals.config.json) with default category `combination` (*or act/extract/observe if you’re* *only* *testing* *act/extract/observe*).
 3. **Add a changeset.** Run `npx changeset` in TS or `uvx changeset` in Python to add a changeset that will directly reflect in the `CHANGELOG` in the upcoming release.
     1. `patch` - no net new functionality to an end-user
     2. `minor` - some net new functionality to an end-user (new function parameter, new exposed type, etc.)

--- a/packages/docs/v2/configuration/evals.mdx
+++ b/packages/docs/v2/configuration/evals.mdx
@@ -132,7 +132,7 @@ evals run b:osworld -f source=Mind2Web
 
 #### Configuration Files
 
-You can view the specific evals in [`evals/tasks`](https://github.com/browserbase/stagehand/tree/main/evals/tasks). Each eval is grouped into eval categories based on [`evals/evals.config.json`](https://github.com/browserbase/stagehand/blob/main/evals/evals.config.json).
+You can view the specific evals in [`evals/tasks`](https://github.com/browserbase/stagehand/tree/v2/evals/tasks). Each eval is grouped into eval categories based on [`evals/evals.config.json`](https://github.com/browserbase/stagehand/blob/main/evals/evals.config.json).
 
 
 #### Viewing eval results
@@ -148,7 +148,7 @@ You can use the Braintrust UI to filter by model/eval and aggregate results acro
 
 To run deterministic evals, you can run `npm run e2e` from within the Stagehand repo. This will test the functionality of Playwright within Stagehand to make sure it's working as expected.
 
-These tests are in [`evals/deterministic`](https://github.com/browserbase/stagehand/tree/main/evals/deterministic) and test on both Browserbase browsers and local headless Chromium browsers.
+These tests are in [`evals/deterministic`](https://github.com/browserbase/stagehand/tree/v2/evals/deterministic) and test on both Browserbase browsers and local headless Chromium browsers.
 
 ## Creating Custom Evaluations
 

--- a/packages/docs/v2/configuration/models.mdx
+++ b/packages/docs/v2/configuration/models.mdx
@@ -168,7 +168,7 @@ Vercel AI SDK supports providers for OpenAI, Anthropic, and Google, along with s
 
 To get started, you'll need to install the `ai` package and the provider you want to use. For example, to use Amazon Bedrock, you'll need to install the `@ai-sdk/amazon-bedrock` package.
 
-You'll also need to use the [Vercel AI SDK external client](https://github.com/browserbase/stagehand/blob/main/examples/external_clients/aisdk.ts) as a template to create a client for your model.
+You'll also need to use the [Vercel AI SDK external client](https://github.com/browserbase/stagehand/blob/v2/examples/external_clients/aisdk.ts) as a template to create a client for your model.
 
 <Tabs>
 	<Tab title="npm">

--- a/packages/docs/v2/first-steps/introduction.mdx
+++ b/packages/docs/v2/first-steps/introduction.mdx
@@ -124,7 +124,7 @@ Stagehand is designed for developers building production browser automations and
   <Card
     title="View Examples"
     icon="code"
-    href="https://github.com/browserbase/stagehand/tree/main/examples"
+    href="https://github.com/browserbase/stagehand/tree/v2/examples"
   >
     See real-world automation examples
   </Card>

--- a/packages/docs/v2/references/stagehand.mdx
+++ b/packages/docs/v2/references/stagehand.mdx
@@ -128,7 +128,7 @@ await stagehand.init()
 <ParamField path="localBrowserLaunchOptions" type="LocalBrowserLaunchOptions" optional>
   Configuration options for launching a local browser. Only used when `env` is `LOCAL`.
 
-  See the [full interface definition](https://github.com/browserbase/stagehand/blob/main/types/stagehand.ts#L174) for all available options.
+  See the [full interface definition](https://github.com/browserbase/stagehand/blob/v2/types/stagehand.ts#L174) for all available options.
 </ParamField>
 
 #### LLM Configuration

--- a/packages/docs/v3/basics/evals.mdx
+++ b/packages/docs/v3/basics/evals.mdx
@@ -127,7 +127,7 @@ evals run b:osworld -f source=Mind2Web
 
 #### Configuration Files
 
-You can view the specific evals in [`evals/tasks`](https://github.com/browserbase/stagehand/tree/main/evals/tasks). Each eval is grouped into eval categories based on [`evals/evals.config.json`](https://github.com/browserbase/stagehand/blob/main/evals/evals.config.json).
+You can view the specific evals in [`evals/tasks`](https://github.com/browserbase/stagehand/tree/main/packages/evals/tasks). Each eval is grouped into eval categories based on [`evals/evals.config.json`](https://github.com/browserbase/stagehand/blob/main/evals/evals.config.json).
 
 
 #### Viewing eval results

--- a/packages/docs/v3/first-steps/introduction.mdx
+++ b/packages/docs/v3/first-steps/introduction.mdx
@@ -99,7 +99,7 @@ Stagehand is designed for developers building production browser automations and
   <Card
     title="View Examples"
     icon="code"
-    href="https://github.com/browserbase/stagehand/tree/main/examples"
+    href="https://github.com/browserbase/stagehand/tree/main/packages/core/examples"
   >
     See real-world automation examples
   </Card>


### PR DESCRIPTION
# why
- we had some broken github links in the docs since merging v3 and refactoring the pnpm workspace/repo structure
# what changed
- fixed the broken links