### PR TITLE
Export AISdkClient

### DIFF
--- a/.changeset/weak-states-know.md
+++ b/.changeset/weak-states-know.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Export example AISdkClient properly from the stagehand package

--- a/packages/core/lib/v3/types/public/index.ts
+++ b/packages/core/lib/v3/types/public/index.ts
@@ -7,3 +7,6 @@ export * from "./model";
 export * from "./options";
 export * from "./page";
 export * from "./sdkErrors";
+// Exporting the example AISdkClient for backwards compatibility
+// Note added for revisiting this scaffold for an improved version based on llm/aisdk.ts
+export { AISdkClient } from "../../../../examples/external_clients/aisdk";


### PR DESCRIPTION
# why
AISdkClient was properly imported in examples, but not exported through the stagehand package

# what changed
Export the `AISdkClient` custom example for backwards compatibility and added a note to revisit for improvements based on the internal implementation

# test plan
