### PR TITLE
don't import from barrel in exported example aisdk client

### DIFF
--- a/.changeset/ready-rules-share.md
+++ b/.changeset/ready-rules-share.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+fix circular import in exported aisdk example client

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -61,7 +61,7 @@ Most existing browser automation tools either require you to write low-level cod
 
 2. **Go from AI-driven to repeatable workflows**: Stagehand lets you preview AI actions before running them, and also helps you easily cache repeatable actions to save time and tokens.
 
-3. **Write once, run forever**: Stagehand's auto-caching combined with self-healing remembers previous actions, runs without LLM inference, and knows when to involve AI whenever the website changes and your automation breaks. 
+3. **Write once, run forever**: Stagehand's auto-caching combined with self-healing remembers previous actions, runs without LLM inference, and knows when to involve AI whenever the website changes and your automation breaks.
 
 ## Getting Started
 
@@ -101,7 +101,6 @@ const { author, title } = await stagehand.extract(
 
 Visit [docs.stagehand.dev](https://docs.stagehand.dev) to view the full documentation.
 
-
 ### Build and Run from Source
 
 ```bash
@@ -131,6 +130,7 @@ At a high level, we're focused on improving reliability, extensibility, speed, a
 ## Acknowledgements
 
 We'd like to thank the following people for their major contributions to Stagehand:
+
 - [Paul Klein](https://github.com/pkiv)
 - [Sean McGuire](https://github.com/seanmcguire12)
 - [Miguel Gonzalez](https://github.com/miguelg719)

--- a/packages/core/examples/external_clients/aisdk.ts
+++ b/packages/core/examples/external_clients/aisdk.ts
@@ -13,8 +13,8 @@ import type { LanguageModelV2 } from "@ai-sdk/provider";
 import {
   CreateChatCompletionOptions,
   LLMClient,
-  AvailableModel,
-} from "../../lib/v3";
+} from "../../lib/v3/llm/LLMClient";
+import { AvailableModel } from "../../lib/v3/types/public";
 import { ChatCompletion } from "openai/resources";
 
 export class AISdkClient extends LLMClient {


### PR DESCRIPTION
# why
- circular import caused error when running examples
# what changed
- changed imports in external aisdk example to import from the source instead of the barrel file

