### PR TITLE
Remove wrong documentation example about parameterized agent workflow

### DIFF
--- a/packages/docs/v3/best-practices/deterministic-agent.mdx
+++ b/packages/docs/v3/best-practices/deterministic-agent.mdx
@@ -301,44 +301,7 @@ const stagehand = new Stagehand({
 ```
 
 ## Advanced Patterns
-
-### Parameterized Agent Workflows
-
-Use variables to make cached workflows reusable with different inputs:
-
-```typescript
-async function executeLogin(username: string, password: string) {
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    cacheDir: "cache/login"
-  });
-
-  await stagehand.init();
-  const page = stagehand.context.pages()[0];
-
-  await page.goto("https://example.com/login");
-
-  const agent = stagehand.agent({
-    model: "anthropic/claude-sonnet-4-20250514"
-  });
-
-  // Variables work with caching
-  const result = await agent.execute({
-    instruction: `Fill in username with "${username}" and password with "${password}", then click submit`,
-    maxSteps: 5
-  });
-
-  await stagehand.close();
-  return result.success;
-}
-
-// First user: Caches the workflow
-await executeLogin("user1@example.com", "password123");
-
-// Second user: Reuses cached workflow structure
-await executeLogin("user2@example.com", "differentpass");
-```
-
+ 
 ### Fallback to Fresh Exploration
 
 Combine caching with fallback for resilience:


### PR DESCRIPTION
Hi,

This example does not work and is misleading. It seems that there is no possible reuse of cache with parameterized workflows now. Each new instruction generate a new cache key.

Refering to issue https://github.com/browserbase/stagehand/issues/1219