### PR TITLE
Disable api mode when using custom LLM clients

### DIFF
--- a/.changeset/thirty-falcons-pump.md
+++ b/.changeset/thirty-falcons-pump.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Disable api mode when using custom LLM clients

--- a/packages/core/lib/v3/v3.ts
+++ b/packages/core/lib/v3/v3.ts
@@ -219,6 +219,7 @@ export class V3 {
     if (opts.llmClient) {
       this.llmClient = opts.llmClient;
       this.modelClientOptions = baseClientOptions;
+      this.disableAPI = true;
     } else {
       // Ensure API key is set
       let apiKey = (baseClientOptions as { apiKey?: string }).apiKey;


### PR DESCRIPTION
# why
Custom LLM clients are not supported on api mode yet

# what changed
Disable api when a custom LLM client is provided

# test plan
