### PR TITLE
allow `act()` to call `hover()`

### DIFF
--- a/.changeset/breezy-phones-happen.md
+++ b/.changeset/breezy-phones-happen.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+allow act() to call hover()

--- a/packages/core/lib/v3/handlers/handlerUtils/actHandlerUtils.ts
+++ b/packages/core/lib/v3/handlers/handlerUtils/actHandlerUtils.ts
@@ -144,6 +144,7 @@ const METHOD_HANDLER_MAP: Record<
   prevChunk: scrollToPreviousChunk,
   selectOptionFromDropdown: selectOption,
   selectOption: selectOption,
+  hover: hover,
 };
 
 export async function selectOption(ctx: UnderstudyMethodHandlerContext) {
@@ -489,6 +490,25 @@ async function scrollByElementHeight(
     await ownerSession
       .send("Runtime.releaseObject", { objectId })
       .catch(() => {});
+  }
+}
+
+export async function hover(ctx: UnderstudyMethodHandlerContext) {
+  const { locator, xpath } = ctx;
+  try {
+    await locator.hover();
+  } catch (e) {
+    v3Logger({
+      category: "action",
+      message: "error attempting to hover",
+      level: 0,
+      auxiliary: {
+        error: { value: e.message, type: "string" },
+        trace: { value: e.stack, type: "string" },
+        xpath: { value: xpath, type: "string" },
+      },
+    });
+    throw new UnderstudyCommandException(e.message);
   }
 }
 

--- a/packages/core/lib/v3/types/private/handlers.ts
+++ b/packages/core/lib/v3/types/private/handlers.ts
@@ -37,4 +37,5 @@ export enum SupportedPlaywrightAction {
   NEXT_CHUNK = "nextChunk",
   PREV_CHUNK = "prevChunk",
   SELECT_OPTION_FROM_DROPDOWN = "selectOptionFromDropdown",
+  HOVER = "hover",
 }


### PR DESCRIPTION
# why
- `act()` is currently unable to call `hover()`
# what changed
- added `hover()` to `SupportedPlaywrightAction` enum & `UnderstudyMethodHandlerContext` interface
# test plan
- this is change is pretty benign. existing `act` evals & unit tests should suffice