### PR TITLE
Update Mintlify docs to use dynamic redirects

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -294,6 +294,18 @@
       "destination": "/v3/integrations/mcp/:slug*"
     },
     {
+      "source": "/integrations/crew-ai/:slug*",
+      "destination": "/v3/integrations/crew-ai/:slug*"
+    },
+    {
+      "source": "/integrations/langchain/:slug*",
+      "destination": "/v3/integrations/langchain/:slug*"
+    },
+    {
+      "source": "/integrations/vercel/:slug*",
+      "destination": "/v3/integrations/vercel/:slug*"
+    },
+    {
       "source": "/references/:slug*",
       "destination": "/v3/references/:slug*"
     },


### PR DESCRIPTION
## What changed
Mintlify dynamic redirects weren't working at the time of V3's launch, meaning we statically saved them.

## Why
Now, we've updated them accordingly to follow best practices.

## Test plan
Ran `mintlify dev` locally and ensured all paths redirect correctly