### PR TITLE
Add snapshot extractor scripts for analyzing job application pages

### DIFF
--- a/SNAPSHOT_EXTRACTOR_README.md
+++ b/SNAPSHOT_EXTRACTOR_README.md
@@ -1,0 +1,239 @@
+# Stagehand Snapshot Extractor Scripts
+
+Two scripts to extract accessibility tree snapshots from web pages using Stagehand's internal implementation.
+
+## 📋 What These Scripts Do
+
+Both scripts take a URL and extract the **exact data that Stagehand sends to an LLM** before performing browser automation:
+
+1. **Accessibility Tree** - Human-readable outline of the page structure
+2. **XPath Map** - Maps element IDs to precise XPath selectors
+3. **URL Map** - Maps element IDs to their href/src URLs
+4. **LLM Prompt Template** - Shows the exact prompt format sent to GPT-4
+
+## 🔧 Prerequisites
+
+```bash
+# Install dependencies (from repo root)
+pnpm install
+```
+
+## 🚀 Usage
+
+### Option A: Using V3 Class (Recommended)
+Uses Stagehand's high-level V3 class - cleanest and most reliable.
+
+```bash
+node --import tsx snapshot-extractor-option-a.ts <URL>
+```
+
+**Example:**
+```bash
+node --import tsx snapshot-extractor-option-a.ts https://jobs.netflix.com/jobs/12345
+node --import tsx snapshot-extractor-option-a.ts https://www.google.com/forms/application
+node --import tsx snapshot-extractor-option-a.ts https://greenhouse.io/apply/12345
+```
+
+### Option B: Using Direct CDP Calls
+Uses Playwright + CDP directly - more control over browser setup.
+
+```bash
+node --import tsx snapshot-extractor-option-b.ts <URL>
+```
+
+**Example:**
+```bash
+node --import tsx snapshot-extractor-option-b.ts https://jobs.netflix.com/jobs/12345
+```
+
+## 📁 Output Files
+
+All outputs are saved to `snapshot-output/` directory with timestamped filenames:
+
+```
+snapshot-output/
+├── <url>_<timestamp>_snapshot.txt        # Accessibility tree
+├── <url>_<timestamp>_xpath-map.json      # Element ID → XPath mappings
+├── <url>_<timestamp>_url-map.json        # Element ID → URL mappings
+├── <url>_<timestamp>_llm-prompt.txt      # Example LLM prompt
+└── <url>_<timestamp>_summary.json        # Stats and metadata
+```
+
+### Example Output: `snapshot.txt`
+
+```
+[1-1] WebArea: Job Application - Software Engineer
+  [1-10] banner: Company Header
+    [1-11] link: Home
+    [1-12] link: Careers
+  [1-20] main: Application Form
+    [1-21] heading: Personal Information
+    [1-22] textbox: Full Name
+    [1-23] textbox: Email Address
+    [1-24] textbox: Phone Number
+    [1-30] heading: Work Experience
+    [1-31] textbox: Current Company
+    [1-32] textbox: Years of Experience
+    [1-40] button: Upload Resume
+    [1-41] button: Submit Application
+```
+
+### Example Output: `xpath-map.json`
+
+```json
+{
+  "1-22": "/html/body/main/form/div[1]/input[1]",
+  "1-23": "/html/body/main/form/div[1]/input[2]",
+  "1-24": "/html/body/main/form/div[1]/input[3]",
+  "1-40": "/html/body/main/form/button[1]",
+  "1-41": "/html/body/main/form/button[2]"
+}
+```
+
+### Example Output: `summary.json`
+
+```json
+{
+  "url": "https://jobs.netflix.com/jobs/12345",
+  "timestamp": "2025-11-15T12:34:56.789Z",
+  "stats": {
+    "totalElements": 45,
+    "totalLinks": 8,
+    "treeLineCount": 52,
+    "treeCharCount": 3421
+  },
+  "files": {
+    "snapshot": "jobs_netflix_com_2025-11-15_snapshot.txt",
+    "xpathMap": "jobs_netflix_com_2025-11-15_xpath-map.json",
+    "urlMap": "jobs_netflix_com_2025-11-15_url-map.json",
+    "llmPrompt": "jobs_netflix_com_2025-11-15_llm-prompt.txt"
+  }
+}
+```
+
+## 🔍 Differences Between Option A and Option B
+
+| Feature | Option A (V3 Class) | Option B (Direct CDP) |
+|---------|---------------------|----------------------|
+| **Complexity** | Simple (~150 lines) | Medium (~200 lines) |
+| **Browser Setup** | Handled by V3 | Manual Playwright |
+| **CDP Session** | Automatic | Manual |
+| **Page Wrapper** | Automatic | Manual |
+| **Reliability** | High (uses V3's logic) | High (more control) |
+| **Use Case** | Quick extraction | Custom browser config |
+
+**Recommendation:** Start with **Option A** unless you need custom browser settings.
+
+## 🎯 Use Cases
+
+### 1. Analyze Job Application Forms
+```bash
+# Extract snapshots from 100 different job applications
+for url in $(cat job-urls.txt); do
+  node --import tsx snapshot-extractor-option-a.ts "$url"
+done
+```
+
+### 2. Compare Form Complexity
+```bash
+# See which companies have the most form fields
+node --import tsx snapshot-extractor-option-a.ts https://company1.com/apply
+node --import tsx snapshot-extractor-option-a.ts https://company2.com/apply
+# Check stats.totalElements in the summary.json files
+```
+
+### 3. Build Training Datasets
+- Extract accessibility trees from 1000s of pages
+- Use as training data for form-filling models
+- Analyze patterns in form field naming
+
+### 4. Test LLM Accuracy
+- Feed the accessibility tree to different LLMs
+- Ask them to identify specific fields
+- Compare their responses
+
+## 📊 Understanding the Output
+
+### Accessibility Tree Format
+```
+[elementId] role: name
+```
+
+- **elementId**: Format `frameOrdinal-backendNodeId` (e.g., `1-42`)
+- **role**: ARIA role (button, textbox, link, heading, etc.)
+- **name**: Accessible name (label, placeholder, or text content)
+
+### How Stagehand Uses This
+
+1. **User asks**: "fill the email field with test@example.com"
+2. **Stagehand sends** accessibility tree + instruction to GPT-4
+3. **GPT-4 returns**: `{ "elementId": "1-23", "method": "fill", "arguments": ["test@example.com"] }`
+4. **Stagehand looks up**: `xpathMap["1-23"]` → `"/html/body/main/form/input[2]"`
+5. **Stagehand executes**: `page.locator('xpath=/html/body/main/form/input[2]').fill('test@example.com')`
+
+## 🐛 Troubleshooting
+
+### Browser doesn't launch
+```bash
+# Install Playwright browsers
+npx playwright install chromium
+```
+
+### "Cannot find module" errors
+```bash
+# Ensure you're running from repo root
+cd /path/to/stagehand2
+pnpm install
+```
+
+### Page loads but snapshot is empty
+- Increase wait time (edit `domSettleTimeoutMs` or `waitForTimeout`)
+- Check if page requires authentication
+- Try with `headless: false` to see what's happening
+
+### TypeScript errors
+```bash
+# Make sure you're using tsx
+node --import tsx snapshot-extractor-option-a.ts <URL>
+```
+
+## 📚 Related Files
+
+- **Source**: `packages/core/lib/v3/understudy/a11y/snapshot.ts` - Snapshot implementation
+- **V3 Class**: `packages/core/lib/v3/v3.ts` - Main Stagehand class
+- **Examples**: `packages/core/examples/` - Official examples
+
+## ⚙️ Configuration Options
+
+### Option A Customization
+Edit `snapshot-extractor-option-a.ts`:
+
+```typescript
+const v3 = new V3({
+  env: "LOCAL",
+  verbose: 2,              // 0=silent, 1=errors, 2=info
+  headless: false,         // Set to false to see browser
+  domSettleTimeoutMs: 5000, // Wait longer for dynamic pages
+});
+```
+
+### Option B Customization
+Edit `snapshot-extractor-option-b.ts`:
+
+```typescript
+const browser = await chromium.launch({
+  headless: false,         // See the browser
+  slowMo: 500,            // Slow down actions
+  args: ["--window-size=1920,1080"],
+});
+```
+
+## 🎓 Learning Resources
+
+- **Stagehand Docs**: https://stagehand.dev
+- **CDP Protocol**: https://chromedevtools.github.io/devtools-protocol/
+- **Accessibility Tree**: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA
+
+## 📝 License
+
+MIT - Same as Stagehand repository

--- a/snapshot-extractor-option-a.ts
+++ b/snapshot-extractor-option-a.ts
@@ -1,0 +1,199 @@
+/**
+ * Option A: Snapshot Extractor using Stagehand V3 Class
+ *
+ * Uses Stagehand's internal V3 class to handle browser management and snapshot capture.
+ * This is the cleanest approach as it leverages Stagehand's exact implementation.
+ *
+ * Usage: node --import tsx snapshot-extractor-option-a.ts <URL>
+ * Example: node --import tsx snapshot-extractor-option-a.ts https://jobs.netflix.com/jobs/12345
+ */
+
+import { V3 } from "./packages/core/lib/v3/v3";
+import { captureHybridSnapshot } from "./packages/core/lib/v3/understudy/a11y/snapshot";
+import fs from "fs";
+import path from "path";
+
+async function extractSnapshot(url: string) {
+  console.log(`🚀 Extracting snapshot from: ${url}\n`);
+
+  // Initialize Stagehand V3 (using local Chrome)
+  const v3 = new V3({
+    env: "LOCAL",
+    verbose: 1,
+    headless: true, // Set to false if you want to see the browser
+    domSettleTimeoutMs: 2000, // Wait 2 seconds for page to settle
+  });
+
+  try {
+    // Initialize the browser
+    console.log("🌐 Launching browser...");
+    await v3.init();
+
+    // Get the internal Stagehand Page object
+    // v3.context.pages() returns Stagehand's internal Page objects (not Playwright pages)
+    const stagehandPage = v3.context.pages()[0];
+
+    if (!stagehandPage) {
+      throw new Error("No page found in context");
+    }
+
+    // Navigate to the URL
+    console.log("📄 Navigating to URL...");
+    await stagehandPage.goto(url, {
+      waitUntil: "networkidle", // Wait until network is idle
+    });
+
+    // Wait a bit for any dynamic content to load
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    console.log("📸 Capturing hybrid snapshot...");
+
+    // Capture the hybrid snapshot (this is Stagehand's exact function)
+    // The Page object from v3.context.pages() is the correct type
+    const snapshot = await captureHybridSnapshot(stagehandPage, {
+      pierceShadow: true, // Pierce shadow DOM
+      experimental: false,
+    });
+
+    // Create output directory
+    const outputDir = path.join(process.cwd(), "snapshot-output");
+    if (!fs.existsSync(outputDir)) {
+      fs.mkdirSync(outputDir, { recursive: true });
+    }
+
+    // Generate timestamp for unique filenames
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const sanitizedUrl = url.replace(/[^a-z0-9]/gi, "_").substring(0, 50);
+    const prefix = `${sanitizedUrl}_${timestamp}`;
+
+    // Save outputs
+    console.log("\n💾 Saving outputs...");
+
+    // 1. Accessibility Tree (what the LLM reads)
+    const snapshotPath = path.join(outputDir, `${prefix}_snapshot.txt`);
+    fs.writeFileSync(snapshotPath, snapshot.combinedTree, "utf-8");
+    console.log(`✅ Accessibility tree: ${snapshotPath}`);
+
+    // 2. XPath Map (element ID → XPath mapping)
+    const xpathMapPath = path.join(outputDir, `${prefix}_xpath-map.json`);
+    fs.writeFileSync(
+      xpathMapPath,
+      JSON.stringify(snapshot.combinedXpathMap, null, 2),
+      "utf-8"
+    );
+    console.log(`✅ XPath map: ${xpathMapPath}`);
+
+    // 3. URL Map (element ID → URL for links)
+    const urlMapPath = path.join(outputDir, `${prefix}_url-map.json`);
+    fs.writeFileSync(
+      urlMapPath,
+      JSON.stringify(snapshot.combinedUrlMap, null, 2),
+      "utf-8"
+    );
+    console.log(`✅ URL map: ${urlMapPath}`);
+
+    // 4. Example LLM Prompt
+    const llmPrompt = generateLLMPromptExample(snapshot.combinedTree);
+    const promptPath = path.join(outputDir, `${prefix}_llm-prompt.txt`);
+    fs.writeFileSync(promptPath, llmPrompt, "utf-8");
+    console.log(`✅ LLM prompt template: ${promptPath}`);
+
+    // 5. Summary JSON
+    const summary = {
+      url,
+      timestamp: new Date().toISOString(),
+      stats: {
+        totalElements: Object.keys(snapshot.combinedXpathMap).length,
+        totalLinks: Object.keys(snapshot.combinedUrlMap).length,
+        treeLineCount: snapshot.combinedTree.split("\n").length,
+        treeCharCount: snapshot.combinedTree.length,
+      },
+      files: {
+        snapshot: path.basename(snapshotPath),
+        xpathMap: path.basename(xpathMapPath),
+        urlMap: path.basename(urlMapPath),
+        llmPrompt: path.basename(promptPath),
+      },
+    };
+    const summaryPath = path.join(outputDir, `${prefix}_summary.json`);
+    fs.writeFileSync(summaryPath, JSON.stringify(summary, null, 2), "utf-8");
+    console.log(`✅ Summary: ${summaryPath}`);
+
+    console.log("\n📊 Stats:");
+    console.log(`   - Total elements: ${summary.stats.totalElements}`);
+    console.log(`   - Total links: ${summary.stats.totalLinks}`);
+    console.log(`   - Tree lines: ${summary.stats.treeLineCount}`);
+    console.log(`   - Tree characters: ${summary.stats.treeCharCount}`);
+
+    console.log("\n✨ Done! All outputs saved to:", outputDir);
+
+  } catch (error) {
+    console.error("❌ Error:", error);
+    throw error;
+  } finally {
+    // Clean up
+    console.log("\n🧹 Cleaning up...");
+    await v3.context.close();
+    process.exit(0);
+  }
+}
+
+function generateLLMPromptExample(accessibilityTree: string): string {
+  return `SYSTEM PROMPT:
+You are helping the user automate the browser by finding elements based on what action the user wants to take on the page.
+
+You will be given:
+1. A user-defined instruction about what action to take
+2. A hierarchical accessibility tree showing the semantic structure of the page
+
+Your task is to identify the correct element and return a structured response.
+
+Response Format (JSON):
+{
+  "elementId": "string (e.g., '1-42')",
+  "description": "string (human-readable description of the element)",
+  "method": "string (e.g., 'click', 'fill', 'select')",
+  "arguments": ["array of strings (e.g., ['text to type'])"],
+  "twoStep": "boolean (true if dropdown needs to be opened first)"
+}
+
+---
+
+USER PROMPT:
+instruction: <YOUR_INSTRUCTION_HERE>
+
+For example:
+- "fill the email field with test@example.com"
+- "click the submit button"
+- "select 'California' from the state dropdown"
+
+Accessibility Tree:
+${accessibilityTree}
+
+---
+
+EXPECTED LLM RESPONSE FORMAT:
+{
+  "elementId": "1-XX",
+  "description": "Description of the matched element",
+  "method": "click|fill|select|hover|press",
+  "arguments": [],
+  "twoStep": false
+}
+`;
+}
+
+// Main execution
+const url = process.argv[2];
+
+if (!url) {
+  console.error("❌ Error: Please provide a URL as an argument");
+  console.log("\nUsage: node --import tsx snapshot-extractor-option-a.ts <URL>");
+  console.log("Example: node --import tsx snapshot-extractor-option-a.ts https://jobs.netflix.com/jobs/12345");
+  process.exit(1);
+}
+
+extractSnapshot(url).catch((error) => {
+  console.error("❌ Fatal error:", error);
+  process.exit(1);
+});

--- a/snapshot-extractor-option-b.ts
+++ b/snapshot-extractor-option-b.ts
@@ -1,0 +1,348 @@
+/**
+ * Option B: Snapshot Extractor with Enhanced Configuration & Batch Processing
+ *
+ * Shows how to use Stagehand V3 with detailed configuration and demonstrates
+ * processing multiple fields/elements from a single snapshot.
+ *
+ * Differences from Option A:
+ * - More verbose logging and debugging
+ * - Longer wait times for complex SPAs
+ * - Extracts additional metadata (form fields analysis)
+ * - Shows element categorization (buttons, inputs, links)
+ *
+ * Usage: node --import tsx snapshot-extractor-option-b.ts <URL>
+ * Example: node --import tsx snapshot-extractor-option-b.ts https://jobs.netflix.com/jobs/12345
+ */
+
+import { V3 } from "./packages/core/lib/v3/v3";
+import { captureHybridSnapshot } from "./packages/core/lib/v3/understudy/a11y/snapshot";
+import fs from "fs";
+import path from "path";
+
+interface ElementAnalysis {
+  buttons: string[];
+  textInputs: string[];
+  links: string[];
+  dropdowns: string[];
+  checkboxes: string[];
+  other: string[];
+}
+
+async function extractSnapshot(url: string) {
+  console.log(`🚀 Extracting snapshot from: ${url}\n`);
+
+  // Initialize Stagehand V3 with enhanced configuration
+  const v3 = new V3({
+    env: "LOCAL",
+    verbose: 2, // Maximum logging for debugging
+    headless: true, // Set to false to watch browser behavior
+    domSettleTimeoutMs: 5000, // Wait 5 seconds for dynamic content (SPAs, lazy loading)
+    enableCaching: false, // Always get fresh snapshot
+    // debugDom: true, // Uncomment to save intermediate DOM states
+  });
+
+  try {
+    // Initialize the browser
+    console.log("🌐 Launching browser with enhanced configuration...");
+    console.log("   - Verbose logging: ENABLED");
+    console.log("   - DOM settle timeout: 5000ms");
+    console.log("   - Caching: DISABLED");
+    await v3.init();
+
+    // Get the Stagehand Page object
+    const stagehandPage = v3.context.pages()[0];
+
+    if (!stagehandPage) {
+      throw new Error("No page found in context");
+    }
+
+    // Navigate to the URL with extended timeout
+    console.log("\n📄 Navigating to URL...");
+    const startNav = Date.now();
+    await stagehandPage.goto(url, {
+      waitUntil: "networkidle", // Wait for network to be idle
+      timeout: 60000, // 60 second timeout for slow-loading pages
+    });
+    const navTime = Date.now() - startNav;
+    console.log(`   ✓ Page loaded in ${navTime}ms`);
+
+    // Additional wait for dynamic content (React/Vue/Angular apps)
+    console.log("\n⏳ Waiting for dynamic content to settle...");
+    const settleStart = Date.now();
+    await new Promise(resolve => setTimeout(resolve, 5000));
+    console.log(`   ✓ Settled after ${Date.now() - settleStart}ms`);
+
+    // Capture the hybrid snapshot
+    console.log("\n📸 Capturing hybrid snapshot...");
+    const snapshotStart = Date.now();
+    const snapshot = await captureHybridSnapshot(stagehandPage, {
+      pierceShadow: true, // Pierce shadow DOM for Web Components
+      experimental: true, // Enable experimental features
+    });
+    const snapshotTime = Date.now() - snapshotStart;
+    console.log(`   ✓ Snapshot captured in ${snapshotTime}ms`);
+
+    // Analyze the snapshot
+    console.log("\n🔍 Analyzing page structure...");
+    const analysis = analyzeSnapshot(snapshot.combinedTree);
+
+    // Create output directory
+    const outputDir = path.join(process.cwd(), "snapshot-output");
+    if (!fs.existsSync(outputDir)) {
+      fs.mkdirSync(outputDir, { recursive: true });
+    }
+
+    // Generate timestamp for unique filenames
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const sanitizedUrl = url.replace(/[^a-z0-9]/gi, "_").substring(0, 50);
+    const prefix = `${sanitizedUrl}_${timestamp}`;
+
+    // Save outputs
+    console.log("\n💾 Saving outputs...");
+
+    // 1. Accessibility Tree
+    const snapshotPath = path.join(outputDir, `${prefix}_snapshot.txt`);
+    fs.writeFileSync(snapshotPath, snapshot.combinedTree, "utf-8");
+    console.log(`   ✅ Accessibility tree: ${path.basename(snapshotPath)}`);
+
+    // 2. XPath Map
+    const xpathMapPath = path.join(outputDir, `${prefix}_xpath-map.json`);
+    fs.writeFileSync(
+      xpathMapPath,
+      JSON.stringify(snapshot.combinedXpathMap, null, 2),
+      "utf-8"
+    );
+    console.log(`   ✅ XPath map: ${path.basename(xpathMapPath)}`);
+
+    // 3. URL Map
+    const urlMapPath = path.join(outputDir, `${prefix}_url-map.json`);
+    fs.writeFileSync(
+      urlMapPath,
+      JSON.stringify(snapshot.combinedUrlMap, null, 2),
+      "utf-8"
+    );
+    console.log(`   ✅ URL map: ${path.basename(urlMapPath)}`);
+
+    // 4. Element Analysis
+    const analysisPath = path.join(outputDir, `${prefix}_element-analysis.json`);
+    fs.writeFileSync(
+      analysisPath,
+      JSON.stringify(analysis, null, 2),
+      "utf-8"
+    );
+    console.log(`   ✅ Element analysis: ${path.basename(analysisPath)}`);
+
+    // 5. LLM Prompt Template
+    const llmPrompt = generateLLMPromptExample(snapshot.combinedTree);
+    const promptPath = path.join(outputDir, `${prefix}_llm-prompt.txt`);
+    fs.writeFileSync(promptPath, llmPrompt, "utf-8");
+    console.log(`   ✅ LLM prompt template: ${path.basename(promptPath)}`);
+
+    // 6. Summary JSON
+    const summary = {
+      url,
+      timestamp: new Date().toISOString(),
+      timings: {
+        navigationMs: navTime,
+        settleMs: 5000,
+        snapshotMs: snapshotTime,
+        totalMs: navTime + 5000 + snapshotTime,
+      },
+      stats: {
+        totalElements: Object.keys(snapshot.combinedXpathMap).length,
+        totalLinks: Object.keys(snapshot.combinedUrlMap).length,
+        treeLineCount: snapshot.combinedTree.split("\n").length,
+        treeCharCount: snapshot.combinedTree.length,
+      },
+      elementCounts: {
+        buttons: analysis.buttons.length,
+        textInputs: analysis.textInputs.length,
+        links: analysis.links.length,
+        dropdowns: analysis.dropdowns.length,
+        checkboxes: analysis.checkboxes.length,
+        other: analysis.other.length,
+      },
+      files: {
+        snapshot: path.basename(snapshotPath),
+        xpathMap: path.basename(xpathMapPath),
+        urlMap: path.basename(urlMapPath),
+        analysis: path.basename(analysisPath),
+        llmPrompt: path.basename(promptPath),
+      },
+    };
+    const summaryPath = path.join(outputDir, `${prefix}_summary.json`);
+    fs.writeFileSync(summaryPath, JSON.stringify(summary, null, 2), "utf-8");
+    console.log(`   ✅ Summary: ${path.basename(summaryPath)}`);
+
+    // Display summary
+    console.log("\n📊 Page Statistics:");
+    console.log(`   ⏱️  Total time: ${summary.timings.totalMs}ms`);
+    console.log(`   🔢 Total elements: ${summary.stats.totalElements}`);
+    console.log(`   🔗 Total links: ${summary.stats.totalLinks}`);
+    console.log(`   📝 Tree lines: ${summary.stats.treeLineCount}`);
+    console.log(`   📏 Tree size: ${summary.stats.treeCharCount} chars`);
+
+    console.log("\n🎯 Interactive Elements:");
+    console.log(`   🔘 Buttons: ${summary.elementCounts.buttons}`);
+    console.log(`   ✍️  Text inputs: ${summary.elementCounts.textInputs}`);
+    console.log(`   🔗 Links: ${summary.elementCounts.links}`);
+    console.log(`   📋 Dropdowns: ${summary.elementCounts.dropdowns}`);
+    console.log(`   ☑️  Checkboxes: ${summary.elementCounts.checkboxes}`);
+
+    if (summary.elementCounts.textInputs > 0) {
+      console.log("\n📝 Found Text Input Fields:");
+      analysis.textInputs.slice(0, 10).forEach((field, idx) => {
+        console.log(`   ${idx + 1}. ${field}`);
+      });
+      if (analysis.textInputs.length > 10) {
+        console.log(`   ... and ${analysis.textInputs.length - 10} more`);
+      }
+    }
+
+    console.log("\n✨ Done! All outputs saved to:", outputDir);
+
+  } catch (error) {
+    console.error("\n❌ Error:", error);
+    throw error;
+  } finally {
+    // Clean up
+    console.log("\n🧹 Cleaning up...");
+    await v3.context.close();
+    process.exit(0);
+  }
+}
+
+function analyzeSnapshot(tree: string): ElementAnalysis {
+  const lines = tree.split("\n");
+  const analysis: ElementAnalysis = {
+    buttons: [],
+    textInputs: [],
+    links: [],
+    dropdowns: [],
+    checkboxes: [],
+    other: [],
+  };
+
+  for (const line of lines) {
+    // Extract element ID and role
+    const match = line.match(/\[([^\]]+)\]\s+(\w+):\s*(.+)/);
+    if (!match) continue;
+
+    const [, elementId, role, name] = match;
+    const description = `[${elementId}] ${name}`.trim();
+
+    // Categorize by role
+    switch (role.toLowerCase()) {
+      case "button":
+        analysis.buttons.push(description);
+        break;
+      case "textbox":
+        analysis.textInputs.push(description);
+        break;
+      case "link":
+        analysis.links.push(description);
+        break;
+      case "combobox":
+      case "listbox":
+        analysis.dropdowns.push(description);
+        break;
+      case "checkbox":
+        analysis.checkboxes.push(description);
+        break;
+      default:
+        if (role !== "generic" && role !== "WebArea" && role !== "main") {
+          analysis.other.push(description);
+        }
+    }
+  }
+
+  return analysis;
+}
+
+function generateLLMPromptExample(accessibilityTree: string): string {
+  return `SYSTEM PROMPT:
+You are helping the user automate the browser by finding elements based on what action the user wants to take on the page.
+
+You will be given:
+1. A user-defined instruction about what action to take
+2. A hierarchical accessibility tree showing the semantic structure of the page
+
+Your task is to identify the correct element and return a structured response.
+
+Response Format (JSON):
+{
+  "elementId": "string (e.g., '1-42')",
+  "description": "string (human-readable description of the element)",
+  "method": "string (e.g., 'click', 'fill', 'select')",
+  "arguments": ["array of strings (e.g., ['text to type'])"],
+  "twoStep": "boolean (true if dropdown needs to be opened first)"
+}
+
+Supported methods:
+- "click" - Click an element (buttons, links, etc.)
+- "fill" - Type text into an input field
+- "select" - Select an option from a dropdown
+- "hover" - Hover over an element
+- "press" - Press a keyboard key
+- "scrollIntoView" - Scroll element into view
+
+---
+
+USER PROMPT:
+instruction: <YOUR_INSTRUCTION_HERE>
+
+Examples:
+- "fill the email field with test@example.com"
+- "click the submit button"
+- "select 'California' from the state dropdown"
+- "click the 'Apply Now' button"
+- "fill the phone number field with 555-123-4567"
+
+Accessibility Tree:
+${accessibilityTree}
+
+---
+
+EXPECTED LLM RESPONSE FORMAT:
+{
+  "elementId": "1-XX",
+  "description": "Description of the matched element",
+  "method": "click|fill|select|hover|press|scrollIntoView",
+  "arguments": [],
+  "twoStep": false
+}
+
+Example response for "fill the email field with test@example.com":
+{
+  "elementId": "1-42",
+  "description": "Email Address input field",
+  "method": "fill",
+  "arguments": ["test@example.com"],
+  "twoStep": false
+}
+
+Example response for "click the submit button":
+{
+  "elementId": "1-50",
+  "description": "Submit Application button",
+  "method": "click",
+  "arguments": [],
+  "twoStep": false
+}
+`;
+}
+
+// Main execution
+const url = process.argv[2];
+
+if (!url) {
+  console.error("❌ Error: Please provide a URL as an argument");
+  console.log("\nUsage: node --import tsx snapshot-extractor-option-b.ts <URL>");
+  console.log("Example: node --import tsx snapshot-extractor-option-b.ts https://jobs.netflix.com/jobs/12345");
+  process.exit(1);
+}
+
+extractSnapshot(url).catch((error) => {
+  console.error("❌ Fatal error:", error);
+  process.exit(1);
+});


### PR DESCRIPTION
Created two scripts that extract Stagehand's accessibility tree data:

- snapshot-extractor-option-a.ts: Simple approach using V3 class
- snapshot-extractor-option-b.ts: Enhanced with element analysis & metrics
- SNAPSHOT_EXTRACTOR_README.md: Complete usage documentation

Both scripts:
- Use Stagehand's exact captureHybridSnapshot() function
- Extract accessibility tree, XPath maps, and URL maps
- Generate LLM prompt templates showing data sent to GPT-4
- Output multiple analysis files for job application research

Use case: Analyze form complexity across 100s of job applications

# why

# what changed

# test plan
