### PR TITLE
expose onStepStart and onStepEnd callback functions

### DIFF
--- a/packages/core/lib/v3/agent/AnthropicCUAClient.ts
+++ b/packages/core/lib/v3/agent/AnthropicCUAClient.ts
@@ -133,6 +133,13 @@ export class AnthropicCUAClient extends AgentClient {
           level: 1,
         });
 
+        if (executionOptions.onStepStart) {
+          await executionOptions.onStepStart({
+            stepNumber: currentStep + 1,
+            maxSteps,
+          });
+        }
+
         const result = await this.executeStep(inputItems, logger);
         totalInputTokens += result.usage.input_tokens;
         totalOutputTokens += result.usage.output_tokens;
@@ -160,6 +167,17 @@ export class AnthropicCUAClient extends AgentClient {
         if (result.message) {
           messageList.push(result.message);
           finalMessage = result.message;
+        }
+
+        if (executionOptions.onStepEnd) {
+          await executionOptions.onStepEnd({
+            stepNumber: currentStep + 1,
+            maxSteps,
+            message: result.message,
+            actionsPerformed: result.actions.length,
+            totalActionsPerformed: actions.length,
+            completed,
+          });
         }
 
         // Increment step counter

--- a/packages/core/lib/v3/agent/GoogleCUAClient.ts
+++ b/packages/core/lib/v3/agent/GoogleCUAClient.ts
@@ -185,6 +185,13 @@ export class GoogleCUAClient extends AgentClient {
           level: 1,
         });
 
+        if (executionOptions.onStepStart) {
+          await executionOptions.onStepStart({
+            stepNumber: currentStep + 1,
+            maxSteps,
+          });
+        }
+
         const result = await this.executeStep(logger);
         totalInputTokens += result.usage.input_tokens;
         totalOutputTokens += result.usage.output_tokens;
@@ -200,6 +207,17 @@ export class GoogleCUAClient extends AgentClient {
         if (result.message) {
           messageList.push(result.message);
           finalMessage = result.message;
+        }
+
+        if (executionOptions.onStepEnd) {
+          await executionOptions.onStepEnd({
+            stepNumber: currentStep + 1,
+            maxSteps,
+            message: result.message,
+            actionsPerformed: result.actions.length,
+            totalActionsPerformed: actions.length,
+            completed,
+          });
         }
 
         // Increment step counter

--- a/packages/core/lib/v3/agent/OpenAICUAClient.ts
+++ b/packages/core/lib/v3/agent/OpenAICUAClient.ts
@@ -124,6 +124,13 @@ export class OpenAICUAClient extends AgentClient {
           level: 1,
         });
 
+        if (executionOptions.onStepStart) {
+          await executionOptions.onStepStart({
+            stepNumber: currentStep + 1,
+            maxSteps,
+          });
+        }
+
         const result = await this.executeStep(
           inputItems,
           previousResponseId,
@@ -151,6 +158,17 @@ export class OpenAICUAClient extends AgentClient {
         if (result.message) {
           messageList.push(result.message);
           finalMessage = result.message;
+        }
+
+        if (executionOptions.onStepEnd) {
+          await executionOptions.onStepEnd({
+            stepNumber: currentStep + 1,
+            maxSteps,
+            message: result.message,
+            actionsPerformed: result.actions.length,
+            totalActionsPerformed: actions.length,
+            completed,
+          });
         }
 
         // Increment step counter

--- a/packages/core/lib/v3/handlers/v3CuaAgentHandler.ts
+++ b/packages/core/lib/v3/handlers/v3CuaAgentHandler.ts
@@ -140,7 +140,12 @@ export class V3CuaAgentHandler {
     }
 
     const start = Date.now();
-    const result = await this.agent.execute({ options, logger: this.logger });
+    const result = await this.agent.execute({
+      options,
+      logger: this.logger,
+      onStepStart: options.onStepStart,
+      onStepEnd: options.onStepEnd,
+    });
     const inferenceTimeMs = Date.now() - start;
     if (result.usage) {
       this.v3.updateMetrics(

--- a/packages/core/lib/v3/types/public/agent.ts
+++ b/packages/core/lib/v3/types/public/agent.ts
@@ -39,6 +39,28 @@ export interface AgentExecuteOptions {
   maxSteps?: number;
   page?: PlaywrightPage | PuppeteerPage | PatchrightPage | Page;
   highlightCursor?: boolean;
+  onStepStart?: ({
+    stepNumber,
+    maxSteps,
+  }: {
+    stepNumber: number;
+    maxSteps: number;
+  }) => Promise<void>;
+  onStepEnd?: ({
+    stepNumber,
+    maxSteps,
+    message,
+    actionsPerformed,
+    totalActionsPerformed,
+    completed,
+  }: {
+    stepNumber: number;
+    maxSteps: number;
+    message: string;
+    actionsPerformed: number;
+    totalActionsPerformed: number;
+    completed: boolean;
+  }) => Promise<void>;
 }
 export type AgentType = "openai" | "anthropic" | "google";
 
@@ -58,6 +80,28 @@ export interface AgentExecutionOptions<
 > {
   options: TOptions;
   logger: (message: LogLine) => void;
+  onStepStart?: ({
+    stepNumber,
+    maxSteps,
+  }: {
+    stepNumber: number;
+    maxSteps: number;
+  }) => Promise<void>;
+  onStepEnd?: ({
+    stepNumber,
+    maxSteps,
+    message,
+    actionsPerformed,
+    totalActionsPerformed,
+    completed,
+  }: {
+    stepNumber: number;
+    maxSteps: number;
+    message: string;
+    actionsPerformed: number;
+    totalActionsPerformed: number;
+    completed: boolean;
+  }) => Promise<void>;
   retries?: number;
 }
 


### PR DESCRIPTION
# why
helps users run custom code before/after step execution

# what changed
exposed onStepStart and onStepEnd callbacks on agent.execute()

# test plan
