### PR TITLE
add error log for BB session timeout

### DIFF
--- a/.changeset/lemon-eggs-happen.md
+++ b/.changeset/lemon-eggs-happen.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+log Browserbase session status when websocket is closed due to session timeout


### PR DESCRIPTION
# why
- if a Browserbase session times out, we are currently logging a generic CDP transport closed message
# what changed
- we can grab the status of the session from the BB API and yield a more informative log
# test plan
- unit tests