### PR TITLE
adding template links to docs

### DIFF
--- a/packages/docs/v2/basics/agent.mdx
+++ b/packages/docs/v2/basics/agent.mdx
@@ -57,6 +57,8 @@ await agent.execute("apply for a job at Browserbase")
 ```
 </CodeGroup>
 
+<Callout icon="code" color="#6ec202" iconType="regular">View or run the example template [here](https://www.browserbase.com/templates/gemini-cua)</Callout>
+
 ### Use Stagehand Agent with Any LLM
 
 Use the agent without specifying a provider to utilize any model or LLM provider:

--- a/packages/docs/v2/best-practices/computer-use.mdx
+++ b/packages/docs/v2/best-practices/computer-use.mdx
@@ -195,3 +195,5 @@ await agent.execute(
 )
 ```
 </CodeGroup> 
+
+<Callout icon="code" color="#6ec202" iconType="regular">View or run the example templates [here](https://www.browserbase.com/templates?category=Computer+Use+Agents)</Callout>

--- a/packages/docs/v2/first-steps/introduction.mdx
+++ b/packages/docs/v2/first-steps/introduction.mdx
@@ -122,9 +122,9 @@ Stagehand is designed for developers building production browser automations and
     Generate Stagehand scripts with AI
   </Card>
   <Card
-    title="View Examples"
+    title="View Templates"
     icon="code"
-    href="https://github.com/browserbase/stagehand/tree/v2/examples"
+    href="https://www.browserbase.com/templates"
   >
     See real-world automation examples
   </Card>

--- a/packages/docs/v3/best-practices/computer-use.mdx
+++ b/packages/docs/v3/best-practices/computer-use.mdx
@@ -182,3 +182,5 @@ const agent = stagehand.agent({
 ```
 </Tab>
 </Tabs>
+
+<Callout icon="code" color="#6ec202" iconType="regular">View or run the example templates [here](https://www.browserbase.com/templates?category=Computer+Use+Agents)</Callout>

--- a/packages/docs/v3/first-steps/introduction.mdx
+++ b/packages/docs/v3/first-steps/introduction.mdx
@@ -97,9 +97,9 @@ Stagehand is designed for developers building production browser automations and
     Generate Stagehand scripts with AI
   </Card>
   <Card
-    title="View Examples"
+    title="View Templates"
     icon="code"
-    href="https://github.com/browserbase/stagehand/tree/main/packages/core/examples"
+    href="https://www.browserbase.com/templates"
   >
     See real-world automation examples
   </Card>


### PR DESCRIPTION
# why

Updating links on stagehand docs to link to templates.

# what changed

Links

# test plan

N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds template links across Stagehand docs so readers can quickly try and run examples on Browserbase. Replaces “Examples” with “Templates” and adds callouts on relevant pages.

# Why:
- Make examples easier to discover and run via Browserbase templates.
- Addresses GRO-716 by adding direct template links in docs.

# What:
- v2/v3 “Introduction”: change “View Examples” card to “View Templates” → https://www.browserbase.com/templates.
- v2/v3 “Computer Use” pages: add callout linking to Computer Use Agents templates.
- v2 “Agent” page: add callout linking to the Gemini CUA template.

# Test Plan:
- Build docs and open updated pages:
  - v2: basics/agent, best-practices/computer-use, first-steps/introduction
  - v3: best-practices/computer-use, first-steps/introduction
- Confirm callouts render and all links resolve to the correct Browserbase template pages.

<sup>Written for commit 41e953b26deb761efaf6a0cc8a098685dfd4fd87. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

