### PR TITLE
[docs]: replace dead link

### DIFF
--- a/packages/docs/v3/references/stagehand.mdx
+++ b/packages/docs/v3/references/stagehand.mdx
@@ -5,8 +5,8 @@ icon: 'hand-horns'
 ---
 
 <CardGroup cols={1}>
-<Card title="Getting Started" icon="rocket" href="/v3/getting-started">
-  Learn how to initialize and use Stagehand
+<Card title="Getting Started" icon="rocket" href="/v3/first-steps/quickstart">
+  The fastest way to start using Stagehand
 </Card>
 </CardGroup>
 


### PR DESCRIPTION
# why
- getting-started page does not exist anymore
# what changed
- replaced getting started link in v3 reference page with a link to the quickstart


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the dead “Getting Started” link on the v3 Stagehand reference page with the Quickstart link to prevent 404s and send users to the right doc.

# Why:
- The Getting Started page was removed and the link returned a 404.

# What:
- Updated the card link in packages/docs/v3/references/stagehand.mdx to /v3/first-steps/quickstart.
- Adjusted the card copy to match the Quickstart.

# Test Plan:
- Open the v3 Stagehand reference page and click “Getting Started.”
- Confirm it routes to /v3/first-steps/quickstart without a 404.
- Verify the page shows the Quickstart content.

<sup>Written for commit 44fd747cc719fc63ae5d2c9aed0f97ad64476559. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

