### PR TITLE
[chore]: fix local browser tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: Evals
 
 on:
-  push:
-    branches-ignore:
-      - main
   pull_request:
     types:
       - opened


### PR DESCRIPTION
# why
- our `e2e:local` tests now require LLM API keys
- these are currently unavailable during the `e2e:local` step in CI, which causes them to fail
# what changed
- added the relevant LLM API keys to the `env` in CI














<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI failures in e2e:local browser tests by exposing required LLM and BrowserBase API keys and gating the job to run only on pushes or same-repo PRs.

# Why:
- e2e:local tests call LLMs and BrowserBase; secrets were missing in CI, causing failures.
- Forked PRs don’t have secrets; running the job there led to avoidable failures.

# What:
- Add these secrets to the e2e:local job env in .github/workflows/ci.yml:
  - OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLE_GENERATIVE_AI_API_KEY
  - BROWSERBASE_API_KEY, BROWSERBASE_PROJECT_ID
- Gate the job with an if condition to run only on push events or PRs from this repo.

# Test Plan:
- Trigger CI on push and same-repo PR; e2e:local should run without missing API keys.
- Open a PR from a fork; e2e:local should be skipped by the new condition.

<sup>Written for commit 4df276c8f528da9389ad56987e2571d906503113. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->













