### PR TITLE
fara timeout fix

### DIFF
--- a/packages/core/lib/v3/agent/MicrosoftCUAClient.ts
+++ b/packages/core/lib/v3/agent/MicrosoftCUAClient.ts
@@ -521,7 +521,7 @@ For each function call, return a json object with function name and arguments wi
     if (!this.screenshotProvider) {
       throw new AgentScreenshotProviderError("Screenshot provider not set");
     }
-
+    await new Promise((resolve) => setTimeout(resolve, 750));
     const base64Screenshot = await this.screenshotProvider();
     return `data:image/png;base64,${base64Screenshot}`;
   }


### PR DESCRIPTION
# why

# what changed

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 750ms delay before taking screenshots in MicrosoftCUAClient to prevent FARA timeouts when the provider isn’t ready. Improves reliability of screenshot capture without changing the returned data.

# Why:
- Screenshots were requested too soon, causing FARA to time out.
- A brief wait ensures the screenshot provider is ready.

# What:
- Add a 750ms await before calling screenshotProvider() in MicrosoftCUAClient, then return the same data:image/png;base64 string.

# Test Plan:
- Trigger screenshot capture via MicrosoftCUAClient and confirm no timeout errors.
- Verify the response starts with "data:image/png;base64," and decodes to a valid PNG.
- Check logs/timing to see ~750ms delay before capture.

<sup>Written for commit b10fe65c0ff1e33c477a8face7cf5851a8e34c8a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

