### PR TITLE
refactor actHandler

### DIFF
--- a/packages/core/lib/v3/cache/ActCache.ts
+++ b/packages/core/lib/v3/cache/ActCache.ts
@@ -171,7 +171,7 @@ export class ActCache {
     const execute = async (): Promise<ActResult> => {
       const actionResults: ActResult[] = [];
       for (const action of entry.actions) {
-        const result = await handler.actFromObserveResult(
+        const result = await handler.takeDeterministicAction(
           action,
           page,
           this.domSettleTimeoutMs,

--- a/packages/core/lib/v3/cache/AgentCache.ts
+++ b/packages/core/lib/v3/cache/AgentCache.ts
@@ -557,7 +557,7 @@ export class AgentCache {
     if (actions.length > 0) {
       const page = await ctx.awaitActivePage();
       for (const action of actions) {
-        await handler.actFromObserveResult(
+        await handler.takeDeterministicAction(
           action,
           page,
           this.domSettleTimeoutMs,
@@ -581,7 +581,7 @@ export class AgentCache {
     if (!Array.isArray(actions) || actions.length === 0) return;
     const page = await ctx.awaitActivePage();
     for (const action of actions) {
-      await handler.actFromObserveResult(
+      await handler.takeDeterministicAction(
         action,
         page,
         this.domSettleTimeoutMs,

--- a/packages/core/lib/v3/v3.ts
+++ b/packages/core/lib/v3/v3.ts
@@ -981,7 +981,7 @@ export class V3 {
             frameId: v3Page.mainFrameId(),
           });
         } else {
-          actResult = await this.actHandler.actFromObserveResult(
+          actResult = await this.actHandler.takeDeterministicAction(
             { ...input, selector }, // ObserveResult
             v3Page, // V3 Page
             this.domSettleTimeoutMs,


### PR DESCRIPTION
# why
- to clean up the actHandler before #1330 




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors actHandler to centralize LLM action parsing and execution, reduce duplication, and improve metrics reporting. Behavior stays the same, with clearer naming and more reliable two-step and fallback flows.

## Why:
- Reduce duplicated LLM calls and normalization logic.
- Improve readability and maintainability.
- Ensure consistent metrics and variable substitution.
- Make the self-heal/fallback path more robust.

## What:
- Renamed actFromObserveResult to takeDeterministicAction and updated all call sites (ActCache, AgentCache, v3).
- Added getActionFromLLM for inference, metrics, normalization, and variable substitution.
- Added recordActMetrics to centralize ACT metrics reporting.
- Extracted normalizeActInferenceElement and substituteVariablesInArguments helpers.
- Simplified two-step act flow and fallback retry using shared helpers.
- Kept existing behavior (selector normalization, variable substitution, retries).

## Test Plan:
- [ ] Run unit tests for actHandler to confirm no regressions.
- [ ] Verify single-step actions execute as before.
- [ ] Verify two-step flow triggers when LLM returns twoStep and executes the second action.
- [ ] Confirm fallback self-heal path updates selector and retries successfully.
- [ ] Check metrics are recorded once per inference call in both steps and fallback.
- [ ] Validate variable substitution replaces %key% tokens in action arguments.
- [ ] Exercise AgentCache and ActCache paths to ensure takeDeterministicAction works end-to-end.
- [ ] Build passes and type checks for all renamed method references.

<sup>Written for commit 08d84548aacd06261a2ee8fb6d96672ddf10cdd3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



