### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -41,7 +42,6 @@ jobs:
           publish: pnpm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish Canary
         if: github.ref == 'refs/heads/main'
@@ -51,4 +51,3 @@ jobs:
           pnpm run release-canary
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
# why

# what changed

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the release workflow by enabling OIDC (id-token) permissions and removing the extra npm auth env. This unblocks publish and canary runs on main.

## Why:
- Release jobs were failing due to missing OIDC permission and conflicting NODE_AUTH_TOKEN.
- We only need GITHUB_TOKEN and id-token for our publish steps.

## What:
- Add id-token: write to workflow permissions.
- Remove NODE_AUTH_TOKEN from publish and canary steps.
- Keep GITHUB_TOKEN for GitHub operations.

## Test Plan:
- [ ] Push to main and confirm “Publish Canary” job completes.
- [ ] Create a release/tag and confirm “Publish” job completes with no auth errors.
- [ ] Verify logs show an OIDC token request (id-token) during publish.
- [ ] Confirm the package or canary release appears in the registry/releases.

<sup>Written for commit 18a81b8dd6b8c97dd7be11999ac8c1b6f0069559. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

