### PR TITLE
Canary publish fix 2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,6 @@ jobs:
       - name: Publish Canary
         if: github.ref == 'refs/heads/main'
         run: |
-          pnpm config set //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
           git checkout main
           pnpm run release-canary
         env:


### PR DESCRIPTION
# why

# what changed

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified the canary publish step by removing manual pnpm auth setup in the release workflow. The job now relies on NODE_AUTH_TOKEN from the environment.

## Why:
- The pnpm auth config was redundant and could add noisy logs.
- Publishing already uses NODE_AUTH_TOKEN via env.

## What:
- Removed pnpm config set //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN} from the Publish Canary step.

## Test Plan:
- [ ] Trigger the release workflow on main.
- [ ] Verify canary publish completes successfully.
- [ ] Confirm auth is picked up from NODE_AUTH_TOKEN.
- [ ] Ensure no token value appears in logs.

<sup>Written for commit d0908dbeb0fa013ba23368be171365d5ecb98bab. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

