### PR TITLE
Try upgrading NPM for Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,14 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Node.js 20.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20.x
           registry-url: "https://registry.npmjs.org"
+
+      # Ensure npm 11.5.1 or later is installed for Trusted Publishing.
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
# why


# what changed


# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable npm Trusted Publishing in the release workflow by upgrading to setup-node v4 and installing npm 11.5+ in CI. This should allow tokenless canary publishes from CI.

## Why:
- Trusted Publishing requires npm >= 11.5.1.
- Our release job used setup-node v3 and an older npm.

## What:
- Upgrade actions/setup-node from v3 to v4 in release.yml.
- Add step to install latest npm globally (ensures >= 11.5.1).

## Test Plan:
- [ ] Run the canary release workflow on this branch.
- [ ] Verify npm -v in logs shows >= 11.5.1.
- [ ] Confirm publish succeeds without NPM_TOKEN (uses OIDC Trusted Publishing).
- [ ] Check the canary publish on npm (version and tag).

<sup>Written for commit 7ab34e4f03d0f6b1280a39cb3c44d897255830f6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

