### PR TITLE
Update extract docs + remove redundant section

### DIFF
--- a/packages/docs/v2/basics/extract.mdx
+++ b/packages/docs/v2/basics/extract.mdx
@@ -9,7 +9,7 @@ description: Extract structured data from a webpage
 page.extract("extract the name of the repository");
 ```
 
-`extract` grabs structured data from a webpage. You can define your schema with [zod](https://github.com/colinhacks/zod) (TypeScript) or [pydantic](https://github.com/pydantic/pydantic) (Python). If you do not want to define a schema, you can also call `extract` with just a [natural language prompt](#extract-with-just-a-prompt), or call `extract` [with no parameters](#extract-with-no-parameters).
+`extract` grabs structured data from a webpage. You can define your schema with [zod](https://github.com/colinhacks/zod) (TypeScript) or [pydantic](https://github.com/pydantic/pydantic) (Python). If you do not want to define a schema, you can also call `extract` with just a [natural language prompt](#prompt-only-extraction), or call `extract` [with no parameters](#extract-with-no-parameters).
 
 ## Why use `extract()`?
 

--- a/packages/docs/v3/basics/extract.mdx
+++ b/packages/docs/v3/basics/extract.mdx
@@ -9,12 +9,12 @@ description: Extract structured data from a webpage
 await stagehand.extract("extract the name of the repository");
 ```
 
-`extract` grabs structured data from a webpage. You can define your schema with [zod](https://github.com/colinhacks/zod) (TypeScript) or JSON. If you do not want to define a schema, you can also call `extract` with just a [natural language prompt](#extract-with-just-a-prompt), or call `extract` [with no parameters](#extract-with-no-parameters).
+`extract()` grabs structured data from a webpage. You can define your schema with [Zod](https://github.com/colinhacks/zod) (TypeScript) or JSON. If you don't want to define a schema, you can also call `extract` with just a [natural language prompt](#instruction-only), or call `extract` [with no parameters](#no-parameters).
 
 ## Why use `extract()`?
 
 <CardGroup cols={2}>
-  <Card title="Structured" icon="brackets-curly" href="#list-of-objects-extraction">
+  <Card title="Structured" icon="brackets-curly" href="#basic-schema">
     Turn messy webpage data into clean objects that follow a schema.
   </Card>
   <Card title="Resilient" icon="dumbbell" href="#extract-with-context">
@@ -22,15 +22,7 @@ await stagehand.extract("extract the name of the repository");
   </Card>
 </CardGroup>
 
-## Using `extract()`
-
-You can use `extract()` to extract structured data from a webpage. You can define your schema with [zod](https://github.com/colinhacks/zod) (TypeScript) or JSON. If you do not want to define a schema, you can also call `extract` with just a natural language prompt, or call `extract` with no parameters.
-
-```typescript
-const result = await stagehand.extract("extract the product details");
-```
-
-### Return value of `extract()`?
+## Return value
 
 When you use `extract()`, Stagehand will return a `Promise<ExtractResult>` with the following structure:
 <Tabs>


### PR DESCRIPTION
# why

- v2 jump links for `extract` were broken
- v3 jump links for `extract` were also broken + included a redundant section

# what changed

<img width="707" height="797" alt="image" src="https://github.com/user-attachments/assets/9b4bce83-a126-4627-854e-90d2b812b19a" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix broken jump links in the v2 and v3 extract docs and remove a redundant section to improve navigation and clarity.

- **Bug Fixes**
  - v2: Updated "prompt-only" anchor to #prompt-only-extraction.
  - v3: Standardized anchors to #instruction-only and #no-parameters; fixed Card link to #basic-schema.
  - v3: Removed duplicate "Using extract()" section; renamed to "Return value".

<sup>Written for commit 29acc0d81a4cb07facddab2797ef125ed499ba94. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

