### PR TITLE
[CANONICALIZATION 1/4] add event bus infrastructure for decoupled LLM execution (Resolves STG-1044)

### DIFF
--- a/packages/core/lib/inference.ts
+++ b/packages/core/lib/inference.ts
@@ -12,6 +12,8 @@ import {
 } from "./prompt";
 import { appendSummary, writeTimestampedTxtFile } from "./inferenceLogUtils";
 import type { InferStagehandSchema, StagehandZodObject } from "./v3/zodCompat";
+import { createChatCompletionViaEventBus } from "./v3/llm/llmEventBridge";
+import type { StagehandEventBus } from "./v3/eventBus";
 
 // Re-export for backward compatibility
 export type { LLMParsedResponse, LLMUsage } from "./v3/llm/LLMClient";
@@ -21,6 +23,7 @@ export async function extract<T extends StagehandZodObject>({
   domElements,
   schema,
   llmClient,
+  eventBus,
   logger,
   userProvidedInstructions,
   logInferenceToFile = false,
@@ -29,6 +32,7 @@ export async function extract<T extends StagehandZodObject>({
   domElements: string;
   schema: T;
   llmClient: LLMClient;
+  eventBus: StagehandEventBus;
   userProvidedInstructions?: string;
   logger: (message: LogLine) => void;
   logInferenceToFile?: boolean;
@@ -74,7 +78,7 @@ export async function extract<T extends StagehandZodObject>({
 
   const extractStartTime = Date.now();
   const extractionResponse =
-    await llmClient.createChatCompletion<ExtractionResponse>({
+    await createChatCompletionViaEventBus<ExtractionResponse>(eventBus, {
       options: {
         messages: extractCallMessages,
         response_model: {
@@ -139,7 +143,7 @@ export async function extract<T extends StagehandZodObject>({
 
   const metadataStartTime = Date.now();
   const metadataResponse =
-    await llmClient.createChatCompletion<MetadataResponse>({
+    await createChatCompletionViaEventBus<MetadataResponse>(eventBus, {
       options: {
         messages: metadataCallMessages,
         response_model: {
@@ -224,6 +228,7 @@ export async function observe({
   instruction,
   domElements,
   llmClient,
+  eventBus,
   userProvidedInstructions,
   logger,
   logInferenceToFile = false,
@@ -231,6 +236,7 @@ export async function observe({
   instruction: string;
   domElements: string;
   llmClient: LLMClient;
+  eventBus: StagehandEventBus;
   userProvidedInstructions?: string;
   logger: (message: LogLine) => void;
   logInferenceToFile?: boolean;
@@ -291,20 +297,23 @@ export async function observe({
   }
 
   const start = Date.now();
-  const rawResponse = await llmClient.createChatCompletion<ObserveResponse>({
-    options: {
-      messages,
-      response_model: {
-        schema: observeSchema,
-        name: "Observation",
+  const rawResponse = await createChatCompletionViaEventBus<ObserveResponse>(
+    eventBus,
+    {
+      options: {
+        messages,
+        response_model: {
+          schema: observeSchema,
+          name: "Observation",
+        },
+        temperature: isGPT5 ? 1 : 0.1,
+        top_p: 1,
+        frequency_penalty: 0,
+        presence_penalty: 0,
       },
-      temperature: isGPT5 ? 1 : 0.1,
-      top_p: 1,
-      frequency_penalty: 0,
-      presence_penalty: 0,
+      logger,
     },
-    logger,
-  });
+  );
   const end = Date.now();
   const usageTimeMs = end - start;
 
@@ -364,6 +373,7 @@ export async function act({
   instruction,
   domElements,
   llmClient,
+  eventBus,
   userProvidedInstructions,
   logger,
   logInferenceToFile = false,
@@ -371,6 +381,7 @@ export async function act({
   instruction: string;
   domElements: string;
   llmClient: LLMClient;
+  eventBus: StagehandEventBus;
   userProvidedInstructions?: string;
   logger: (message: LogLine) => void;
   logInferenceToFile?: boolean;
@@ -424,7 +435,7 @@ export async function act({
   }
 
   const start = Date.now();
-  const rawResponse = await llmClient.createChatCompletion<ActResponse>({
+  const rawResponse = await createChatCompletionViaEventBus<ActResponse>(eventBus, {
     options: {
       messages,
       response_model: {

--- a/packages/core/lib/v3/eventBus.ts
+++ b/packages/core/lib/v3/eventBus.ts
@@ -1,0 +1,64 @@
+/**
+ * Central Event Bus for Stagehand
+ *
+ * Single event emitter shared by:
+ * - V3 class (LLM events, library events)
+ * - StagehandServer (server lifecycle, request/response events)
+ * - External listeners (cloud servers, monitoring, etc.)
+ */
+
+import { EventEmitter } from "events";
+import type { StagehandServerEventMap } from "./server/events";
+
+/**
+ * Type-safe event bus for all Stagehand events
+ */
+export class StagehandEventBus extends EventEmitter {
+  /**
+   * Emit an event and wait for all async listeners to complete
+   */
+  async emitAsync<K extends keyof StagehandServerEventMap>(
+    event: K,
+    data: StagehandServerEventMap[K],
+  ): Promise<void> {
+    const listeners = this.listeners(event);
+    await Promise.all(listeners.map((listener) => listener(data)));
+  }
+
+  /**
+   * Type-safe event listener
+   */
+  on<K extends keyof StagehandServerEventMap>(
+    event: K,
+    listener: (data: StagehandServerEventMap[K]) => void | Promise<void>,
+  ): this {
+    return super.on(event, listener);
+  }
+
+  /**
+   * Type-safe one-time event listener
+   */
+  once<K extends keyof StagehandServerEventMap>(
+    event: K,
+    listener: (data: StagehandServerEventMap[K]) => void | Promise<void>,
+  ): this {
+    return super.once(event, listener);
+  }
+
+  /**
+   * Type-safe remove listener
+   */
+  off<K extends keyof StagehandServerEventMap>(
+    event: K,
+    listener: (data: StagehandServerEventMap[K]) => void | Promise<void>,
+  ): this {
+    return super.off(event, listener);
+  }
+}
+
+/**
+ * Create a new event bus instance
+ */
+export function createEventBus(): StagehandEventBus {
+  return new StagehandEventBus();
+}

--- a/packages/core/lib/v3/handlers/actHandler.ts
+++ b/packages/core/lib/v3/handlers/actHandler.ts
@@ -22,6 +22,7 @@ import {
   performUnderstudyMethod,
   waitForDomNetworkQuiet,
 } from "./handlerUtils/actHandlerUtils";
+import type { StagehandEventBus } from "../eventBus";
 
 export class ActHandler {
   private readonly llmClient: LLMClient;
@@ -40,12 +41,14 @@ export class ActHandler {
     inferenceTimeMs: number,
   ) => void;
   private readonly defaultDomSettleTimeoutMs?: number;
+  private readonly eventBus: StagehandEventBus;
 
   constructor(
     llmClient: LLMClient,
     defaultModelName: AvailableModel,
     defaultClientOptions: ClientOptions,
     resolveLlmClient: (model?: ModelConfiguration) => LLMClient,
+    eventBus: StagehandEventBus,
     systemPrompt?: string,
     logInferenceToFile?: boolean,
     selfHeal?: boolean,
@@ -63,6 +66,7 @@ export class ActHandler {
     this.defaultModelName = defaultModelName;
     this.defaultClientOptions = defaultClientOptions;
     this.resolveLlmClient = resolveLlmClient;
+    this.eventBus = eventBus;
     this.systemPrompt = systemPrompt ?? "";
     this.logInferenceToFile = logInferenceToFile ?? false;
     this.selfHeal = !!selfHeal;
@@ -100,6 +104,7 @@ export class ActHandler {
         instruction: observeActInstruction,
         domElements: combinedTree,
         llmClient,
+        eventBus: this.eventBus,
         userProvidedInstructions: this.systemPrompt,
         logger: v3Logger,
         logInferenceToFile: this.logInferenceToFile,
@@ -230,6 +235,7 @@ export class ActHandler {
         instruction: stepTwoInstructions,
         domElements: diffedTree,
         llmClient,
+        eventBus: this.eventBus,
         userProvidedInstructions: this.systemPrompt,
         logger: v3Logger,
         logInferenceToFile: this.logInferenceToFile,
@@ -422,6 +428,7 @@ export class ActHandler {
             instruction,
             domElements: combinedTree,
             llmClient: effectiveClient,
+            eventBus: this.eventBus,
             userProvidedInstructions: this.systemPrompt,
             logger: v3Logger,
             logInferenceToFile: this.logInferenceToFile,

--- a/packages/core/lib/v3/handlers/extractHandler.ts
+++ b/packages/core/lib/v3/handlers/extractHandler.ts
@@ -25,6 +25,7 @@ import type {
   StagehandZodObject,
   StagehandZodSchema,
 } from "../zodCompat";
+import type { StagehandEventBus } from "../eventBus";
 
 /**
  * Scans the provided Zod schema for any `z.string().url()` fields and
@@ -60,6 +61,7 @@ export class ExtractHandler {
   private readonly defaultModelName: AvailableModel;
   private readonly defaultClientOptions: ClientOptions;
   private readonly resolveLlmClient: (model?: ModelConfiguration) => LLMClient;
+  private readonly eventBus: StagehandEventBus;
   private readonly systemPrompt: string;
   private readonly logInferenceToFile: boolean;
   private readonly experimental: boolean;
@@ -77,6 +79,7 @@ export class ExtractHandler {
     defaultModelName: AvailableModel,
     defaultClientOptions: ClientOptions,
     resolveLlmClient: (model?: ModelConfiguration) => LLMClient,
+    eventBus: StagehandEventBus,
     systemPrompt?: string,
     logInferenceToFile?: boolean,
     experimental?: boolean,
@@ -93,6 +96,7 @@ export class ExtractHandler {
     this.defaultModelName = defaultModelName;
     this.defaultClientOptions = defaultClientOptions;
     this.resolveLlmClient = resolveLlmClient;
+    this.eventBus = eventBus;
     this.systemPrompt = systemPrompt ?? "";
     this.logInferenceToFile = logInferenceToFile ?? false;
     this.experimental = experimental ?? false;
@@ -171,6 +175,7 @@ export class ExtractHandler {
           domElements: combinedTree,
           schema: transformedSchema as StagehandZodObject,
           llmClient,
+          eventBus: this.eventBus,
           userProvidedInstructions: this.systemPrompt,
           logger: v3Logger,
           logInferenceToFile: this.logInferenceToFile,

--- a/packages/core/lib/v3/handlers/observeHandler.ts
+++ b/packages/core/lib/v3/handlers/observeHandler.ts
@@ -13,12 +13,14 @@ import {
   ClientOptions,
   ModelConfiguration,
 } from "../types/public/model";
+import type { StagehandEventBus } from "../eventBus";
 
 export class ObserveHandler {
   private readonly llmClient: LLMClient;
   private readonly defaultModelName: AvailableModel;
   private readonly defaultClientOptions: ClientOptions;
   private readonly resolveLlmClient: (model?: ModelConfiguration) => LLMClient;
+  private readonly eventBus: StagehandEventBus;
   private readonly systemPrompt: string;
   private readonly logInferenceToFile: boolean;
   private readonly experimental: boolean;
@@ -36,6 +38,7 @@ export class ObserveHandler {
     defaultModelName: AvailableModel,
     defaultClientOptions: ClientOptions,
     resolveLlmClient: (model?: ModelConfiguration) => LLMClient,
+    eventBus: StagehandEventBus,
     systemPrompt?: string,
     logInferenceToFile?: boolean,
     experimental?: boolean,
@@ -52,6 +55,7 @@ export class ObserveHandler {
     this.defaultModelName = defaultModelName;
     this.defaultClientOptions = defaultClientOptions;
     this.resolveLlmClient = resolveLlmClient;
+    this.eventBus = eventBus;
     this.systemPrompt = systemPrompt ?? "";
     this.logInferenceToFile = logInferenceToFile ?? false;
     this.experimental = experimental ?? false;
@@ -101,6 +105,7 @@ export class ObserveHandler {
         instruction: effectiveInstruction,
         domElements: combinedTree,
         llmClient,
+        eventBus: this.eventBus,
         userProvidedInstructions: this.systemPrompt,
         logger: v3Logger,
         logInferenceToFile: this.logInferenceToFile,

--- a/packages/core/lib/v3/llm/llmEventBridge.ts
+++ b/packages/core/lib/v3/llm/llmEventBridge.ts
@@ -1,0 +1,123 @@
+/**
+ * LLM Event Bridge - Routes LLM requests through the event bus
+ *
+ * This module provides a bridge between code that needs LLM responses
+ * and the actual LLM implementations. It uses the event bus to allow
+ * remote execution of LLM calls.
+ */
+
+import { randomUUID } from "crypto";
+import type { StagehandEventBus } from "../eventBus";
+import type {
+  ChatCompletionOptions,
+  CreateChatCompletionOptions,
+  LLMParsedResponse,
+  LLMResponse,
+} from "./LLMClient";
+import type { LogLine } from "../types/public";
+
+/**
+ * Make an LLM request via the event bus and wait for a response
+ *
+ * This function emits a StagehandLLMRequest event and waits for a
+ * StagehandLLMResponse event with the same requestId.
+ *
+ * Returns the same structure as llmClient.createChatCompletion: { data: T, usage?: LLMUsage }
+ */
+export async function createChatCompletionViaEventBus<T>(
+  eventBus: StagehandEventBus,
+  options: CreateChatCompletionOptions,
+  sessionId?: string,
+): Promise<LLMParsedResponse<T>> {
+  const requestId = randomUUID();
+  const startTime = Date.now();
+
+  // Create a promise that will resolve when we get the response
+  const responsePromise = new Promise<LLMParsedResponse<T>>((resolve, reject) => {
+    // Set up a one-time listener for the response
+    const responseHandler = (data: any) => {
+      // Only handle responses for this specific request
+      if (data.requestId === requestId) {
+        // Remove the listener
+        eventBus.off("StagehandLLMResponse", responseHandler);
+        eventBus.off("StagehandLLMError", errorHandler);
+
+        // Check if there was an error
+        if (data.error) {
+          reject(new Error(data.error.message));
+        } else {
+          // Return the same structure as llmClient.createChatCompletion
+          if (data.parsedResponse) {
+            resolve(data.parsedResponse as LLMParsedResponse<T>);
+          } else {
+            resolve({ data: data.rawResponse as T, usage: data.usage });
+          }
+        }
+      }
+    };
+
+    const errorHandler = (data: any) => {
+      if (data.requestId === requestId) {
+        eventBus.off("StagehandLLMResponse", responseHandler);
+        eventBus.off("StagehandLLMError", errorHandler);
+        reject(new Error(data.error.message));
+      }
+    };
+
+    // Listen for both response and error events
+    eventBus.on("StagehandLLMResponse", responseHandler);
+    eventBus.on("StagehandLLMError", errorHandler);
+
+    // Set a timeout to prevent hanging forever
+    setTimeout(() => {
+      eventBus.off("StagehandLLMResponse", responseHandler);
+      eventBus.off("StagehandLLMError", errorHandler);
+      reject(new Error("LLM request timeout after 5 minutes"));
+    }, 5 * 60 * 1000); // 5 minute timeout
+  });
+
+  // Emit the request event
+  await eventBus.emitAsync("StagehandLLMRequest", {
+    type: "StagehandLLMRequest",
+    timestamp: new Date(),
+    requestId,
+    sessionId,
+    modelName: options.options.messages[0]?.role ? "unknown" : "unknown", // Will be set by handler
+    temperature: options.options.temperature,
+    maxTokens: options.options.maxOutputTokens,
+    messages: options.options.messages.map((msg) => ({
+      role: msg.role,
+      content:
+        typeof msg.content === "string"
+          ? msg.content
+          : msg.content.map((c) => ({
+              type: c.type,
+              text: c.text,
+              image: (c as any).image_url?.url || (c as any).source?.data,
+            })),
+    })),
+    tools: options.options.tools?.map((tool) => ({
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.parameters as Record<string, unknown>,
+    })),
+    schema: options.options.response_model?.schema
+      ? (options.options.response_model.schema as any)
+      : undefined,
+    requestType: undefined, // Will be determined by context
+  });
+
+  // Wait for and return the response
+  return responsePromise;
+}
+
+/**
+ * Type guard to check if options include a response_model
+ */
+export function hasResponseModel(
+  options: CreateChatCompletionOptions,
+): options is CreateChatCompletionOptions & {
+  options: { response_model: { name: string; schema: any } };
+} {
+  return !!options.options.response_model;
+}

--- a/packages/core/lib/v3/llm/llmEventHandler.ts
+++ b/packages/core/lib/v3/llm/llmEventHandler.ts
@@ -1,0 +1,149 @@
+/**
+ * LLM Event Handler - Listens for LLM requests and executes them
+ *
+ * This module listens for StagehandLLMRequest events on the event bus,
+ * calls the actual LLM implementation, and emits StagehandLLMResponse events.
+ */
+
+import type { StagehandEventBus } from "../eventBus";
+import type { LLMClient, CreateChatCompletionOptions } from "./LLMClient";
+import type { LogLine } from "../types/public";
+
+export interface LLMEventHandlerOptions {
+  eventBus: StagehandEventBus;
+  llmClient: LLMClient;
+  logger: (message: LogLine) => void;
+}
+
+/**
+ * Initialize the LLM event handler
+ *
+ * This sets up a listener on the event bus that will handle LLM requests
+ * by calling the provided LLMClient and emitting responses.
+ *
+ * @returns A cleanup function to remove the listener
+ */
+export function initializeLLMEventHandler({
+  eventBus,
+  llmClient,
+  logger,
+}: LLMEventHandlerOptions): () => void {
+  const handleLLMRequest = async (event: any) => {
+    const { requestId, messages, tools, schema, temperature, maxTokens } =
+      event;
+
+    try {
+      // Build the options for createChatCompletion
+      const options: CreateChatCompletionOptions = {
+        options: {
+          messages: messages.map((msg: any) => ({
+            role: msg.role,
+            content:
+              typeof msg.content === "string"
+                ? msg.content
+                : msg.content.map((c: any) => {
+                    if (c.type === "text") {
+                      return { type: "text", text: c.text };
+                    } else if (c.type === "image_url" || c.image) {
+                      return {
+                        type: "image_url",
+                        image_url: { url: c.image },
+                      };
+                    }
+                    return c;
+                  }),
+          })),
+          temperature,
+          maxOutputTokens: maxTokens,
+          tools,
+          requestId,
+        },
+        logger,
+      };
+
+      // Add response_model if schema is provided
+      if (schema) {
+        options.options.response_model = {
+          name: "Response",
+          schema,
+        };
+      }
+
+      const startTime = Date.now();
+      let response: any;
+      let parsedResponse: any = null;
+
+      // Call the LLM
+      if (schema) {
+        // Structured response
+        const result = await llmClient.createChatCompletion(options as any);
+        parsedResponse = result;
+        response = null;
+      } else {
+        // Raw response
+        response = await llmClient.createChatCompletion(options);
+      }
+
+      const inferenceTimeMs = Date.now() - startTime;
+
+      // Extract usage information
+      let usage: any = undefined;
+      if (parsedResponse?.usage) {
+        usage = {
+          promptTokens: parsedResponse.usage.prompt_tokens,
+          completionTokens: parsedResponse.usage.completion_tokens,
+          totalTokens: parsedResponse.usage.total_tokens,
+        };
+      } else if (response?.usage) {
+        usage = {
+          promptTokens: response.usage.prompt_tokens,
+          completionTokens: response.usage.completion_tokens,
+          totalTokens: response.usage.total_tokens,
+        };
+      }
+
+      // Emit success response
+      await eventBus.emitAsync("StagehandLLMResponse", {
+        type: "StagehandLLMResponse",
+        timestamp: new Date(),
+        requestId,
+        sessionId: event.sessionId,
+        content: parsedResponse
+          ? JSON.stringify(parsedResponse.data || parsedResponse)
+          : response?.choices?.[0]?.message?.content || "",
+        toolCalls: response?.choices?.[0]?.message?.tool_calls?.map(
+          (tc: any) => ({
+            id: tc.id,
+            name: tc.function.name,
+            arguments: JSON.parse(tc.function.arguments),
+          }),
+        ),
+        finishReason: response?.choices?.[0]?.finish_reason || "stop",
+        usage,
+        rawResponse: response,
+        parsedResponse,
+      });
+    } catch (error) {
+      // Emit error response
+      await eventBus.emitAsync("StagehandLLMError", {
+        type: "StagehandLLMError",
+        timestamp: new Date(),
+        requestId,
+        sessionId: event.sessionId,
+        error: {
+          message: error instanceof Error ? error.message : "Unknown error",
+          code: (error as any).code,
+          stack: error instanceof Error ? error.stack : undefined,
+        },
+      });
+    }
+  };
+
+  // Register the handler
+  eventBus.on("StagehandLLMRequest", handleLLMRequest);
+
+  // Return cleanup function
+  return () => {
+    eventBus.off("StagehandLLMRequest", handleLLMRequest);
+  };
+}

--- a/packages/core/lib/v3/server/events.ts
+++ b/packages/core/lib/v3/server/events.ts
@@ -1,0 +1,90 @@
+/**
+ * Base event interface - all events extend this
+ */
+export interface StagehandServerEvent {
+  timestamp: Date;
+  sessionId?: string;
+  requestId?: string;
+}
+
+// ===== LLM REQUEST/RESPONSE EVENTS =====
+// These are the only events with actual subscribers (used by llmEventBridge.ts and llmEventHandler.ts)
+
+export interface StagehandLLMRequestEvent extends StagehandServerEvent {
+  type: "StagehandLLMRequest";
+  requestId: string;
+
+  // Model config
+  modelName: string;
+  temperature?: number;
+  maxTokens?: number;
+
+  // Request data
+  messages: Array<{
+    role: "user" | "assistant" | "system";
+    content: string | Array<{ type: string; text?: string; image?: string }>;
+  }>;
+  tools?: Array<{
+    name: string;
+    description: string;
+    parameters: Record<string, unknown>;
+  }>;
+  schema?: Record<string, unknown>; // JSON schema for structured output
+
+  // Context
+  requestType?: "act" | "extract" | "observe" | "agent" | "cua";
+}
+
+export interface StagehandLLMResponseEvent extends StagehandServerEvent {
+  type: "StagehandLLMResponse";
+  requestId: string; // Must match StagehandLLMRequestEvent.requestId
+
+  // Response data
+  content: string;
+  toolCalls?: Array<{
+    id: string;
+    name: string;
+    arguments: Record<string, unknown>;
+  }>;
+  finishReason: string;
+
+  // Metrics
+  usage?: {
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+  };
+
+  // Raw and parsed responses (for internal use)
+  rawResponse?: unknown;
+  parsedResponse?: unknown;
+
+  // Error handling
+  error?: {
+    message: string;
+    code?: string;
+  };
+}
+
+export interface StagehandLLMErrorEvent extends StagehandServerEvent {
+  type: "StagehandLLMError";
+  requestId: string;
+  error: {
+    message: string;
+    code?: string;
+    stack?: string;
+  };
+}
+
+// Union type for all events
+export type StagehandServerEventType =
+  | StagehandLLMRequestEvent
+  | StagehandLLMResponseEvent
+  | StagehandLLMErrorEvent;
+
+// Type-safe event emitter interface
+export interface StagehandServerEventMap {
+  StagehandLLMRequest: StagehandLLMRequestEvent;
+  StagehandLLMResponse: StagehandLLMResponseEvent;
+  StagehandLLMError: StagehandLLMErrorEvent;
+}

--- a/packages/core/lib/v3/types/public/options.ts
+++ b/packages/core/lib/v3/types/public/options.ts
@@ -2,6 +2,7 @@ import Browserbase from "@browserbasehq/sdk";
 import { LLMClient } from "../../llm/LLMClient";
 import { ModelConfiguration } from "./model";
 import { LogLine } from "./logs";
+import type { StagehandEventBus } from "../../eventBus";
 
 export type V3Env = "LOCAL" | "BROWSERBASE";
 
@@ -85,5 +86,6 @@ export interface V3Options {
   /** Directory used to persist cached actions for act(). */
   cacheDir?: string;
   domSettleTimeout?: number;
-  disableAPI?: boolean;
+  /** Optional shared event bus. If not provided, a new one will be created. */
+  eventBus?: StagehandEventBus;
 }


### PR DESCRIPTION
## Stack Position
```
main
   └── pr/1-event-bus-infrastructure  ← THIS PR
         └── pr/2-api-schemas-openapi
               └── pr/3-session-store-p2p-server
                     └── pr/4-test-infrastructure
```

## What
Introduces a central event bus architecture that enables LLM requests to be routed through an event-driven system rather than direct function calls.

## Why
This decoupling is foundational for enabling peer-to-peer (P2P) Stagehand communication, where a remote Stagehand server can handle LLM requests on behalf of thin clients. The event bus allows the library to emit LLM requests that can be handled either locally (in-process) or remotely (via HTTP).

## How
- `eventBus.ts`: Type-safe EventEmitter wrapper for Stagehand events
- `server/events.ts`: Event type definitions for LLM request/response cycle
- `llm/llmEventBridge.ts`: Routes LLM calls through event bus, waits for responses
- `llm/llmEventHandler.ts`: Listens for LLM requests and executes them locally
- Handler updates: actHandler, extractHandler, observeHandler now use event bus
- `inference.ts`: Updated to use `createChatCompletionViaEventBus` instead of direct calls
- `options.ts`: Added optional `eventBus` configuration option

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a type-safe event bus to decouple LLM calls from direct client usage. This enables local or remote handling of LLM requests and lays groundwork for P2P Stagehand communication.

- **New Features**
  - StagehandEventBus with type-safe emit/on/once/off and emitAsync.
  - Event definitions for LLM request/response/error (server/events.ts).
  - LLM event bridge to send requests and await responses (llmEventBridge.ts).
  - LLM event handler to execute requests and emit responses (llmEventHandler.ts).
  - Optional eventBus in V3Options for sharing a bus across components.

- **Refactors**
  - act/extract/observe handlers now route LLM calls through the event bus.
  - inference uses createChatCompletionViaEventBus instead of direct llmClient calls.

<sup>Written for commit 8f4dc9217c11cc1446cfb028a733cdfbdcf5ff02. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

