### PR TITLE
[CANONICALIZATION 3/4] add SessionStore interface and P2P server implementation (Resolves STG-1046)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "dev": "turbo run dev",
     "example": "pnpm --filter @browserbasehq/stagehand run example --",
     "cache:clear": "turbo run build --force",
-    "prepare": "turbo run build",
     "release": "turbo run build && changeset publish",
     "release-canary": "turbo run build && changeset version --snapshot && changeset publish --tag alpha"
   },

--- a/packages/core/lib/v3/index.ts
+++ b/packages/core/lib/v3/index.ts
@@ -2,6 +2,21 @@ export { V3 } from "./v3";
 export { V3 as Stagehand } from "./v3";
 
 export * from "./types/public";
+
+// Event bus - shared by library and server
+export { StagehandEventBus, createEventBus } from "./eventBus";
+export * from "./server/events";
+
+// Server exports for P2P functionality
+export { StagehandServer } from "./server";
+export type { StagehandServerOptions } from "./server";
+export { InMemorySessionStore } from "./server/InMemorySessionStore";
+export type {
+  SessionStore,
+  CreateSessionParams,
+  RequestContext,
+  SessionCacheConfig,
+} from "./server/SessionStore";
 export { AnnotatedScreenshotText, LLMClient } from "./llm/LLMClient";
 
 export { AgentProvider, modelToAgentProviderMap } from "./agent/AgentProvider";

--- a/packages/core/lib/v3/server/InMemorySessionStore.ts
+++ b/packages/core/lib/v3/server/InMemorySessionStore.ts
@@ -1,0 +1,331 @@
+import { randomUUID } from "crypto";
+import type { V3Options, LogLine } from "../types/public";
+import type { V3 } from "../v3";
+import type {
+  SessionStore,
+  CreateSessionParams,
+  RequestContext,
+  SessionCacheConfig,
+  SessionStartResult,
+} from "./SessionStore";
+
+const DEFAULT_MAX_CAPACITY = 100;
+const DEFAULT_TTL_MS = 300_000; // 5 minutes
+
+/**
+ * Internal node for LRU linked list
+ */
+interface LruNode {
+  sessionId: string;
+  params: CreateSessionParams;
+  stagehand: V3 | null;
+  loggerRef: { current?: (message: LogLine) => void };
+  expiry: number;
+  prev: LruNode | null;
+  next: LruNode | null;
+}
+
+/**
+ * In-memory implementation of SessionStore with full caching support.
+ *
+ * Features:
+ * - LRU eviction when at capacity
+ * - TTL-based expiration
+ * - Lazy V3 instance creation
+ * - Dynamic logger updates for streaming
+ * - Automatic cleanup of evicted sessions
+ *
+ * This is the default implementation used when no custom store is provided.
+ * For stateless pod architectures, use a database-backed implementation.
+ */
+export class InMemorySessionStore implements SessionStore {
+  private first: LruNode | null = null;
+  private last: LruNode | null = null;
+  private items: Map<string, LruNode> = new Map();
+  private maxCapacity: number;
+  private ttlMs: number;
+  private cleanupInterval: NodeJS.Timeout | null = null;
+
+  constructor(config?: SessionCacheConfig) {
+    this.maxCapacity = config?.maxCapacity ?? DEFAULT_MAX_CAPACITY;
+    this.ttlMs = config?.ttlMs ?? DEFAULT_TTL_MS;
+    this.startCleanupInterval();
+  }
+
+  /**
+   * Start periodic cleanup of expired sessions
+   */
+  private startCleanupInterval(): void {
+    // Run cleanup every minute
+    this.cleanupInterval = setInterval(() => {
+      this.cleanupExpired();
+    }, 60_000);
+  }
+
+  /**
+   * Cleanup expired sessions
+   */
+  private async cleanupExpired(): Promise<void> {
+    const now = Date.now();
+    const expiredIds: string[] = [];
+
+    for (const [sessionId, node] of this.items.entries()) {
+      if (this.ttlMs > 0 && node.expiry <= now) {
+        expiredIds.push(sessionId);
+      }
+    }
+
+    for (const sessionId of expiredIds) {
+      await this.deleteSession(sessionId);
+    }
+  }
+
+  /**
+   * Bump a node to the end of the LRU list (most recently used)
+   */
+  private bumpNode(node: LruNode): void {
+    // Update expiry
+    node.expiry = this.ttlMs > 0 ? Date.now() + this.ttlMs : Infinity;
+
+    if (this.last === node) {
+      return; // Already most recent
+    }
+
+    const { prev, next } = node;
+
+    // Unlink from current position
+    if (prev) prev.next = next;
+    if (next) next.prev = prev;
+    if (this.first === node) this.first = next;
+
+    // Link to end
+    node.prev = this.last;
+    node.next = null;
+    if (this.last) this.last.next = node;
+    this.last = node;
+
+    if (!this.first) this.first = node;
+  }
+
+  /**
+   * Evict the least recently used session
+   */
+  private async evictLru(): Promise<void> {
+    const lruNode = this.first;
+    if (!lruNode) return;
+
+    await this.deleteSession(lruNode.sessionId);
+  }
+
+  async startSession(params: CreateSessionParams): Promise<SessionStartResult> {
+    // Generate session ID or use provided browserbase session ID
+    const sessionId = params.browserbaseSessionID ?? randomUUID();
+
+    // Store the session
+    await this.createSession(sessionId, params);
+
+    return {
+      sessionId,
+      available: true,
+    };
+  }
+
+  async endSession(sessionId: string): Promise<void> {
+    await this.deleteSession(sessionId);
+  }
+
+  async hasSession(sessionId: string): Promise<boolean> {
+    const node = this.items.get(sessionId);
+    if (!node) return false;
+
+    // Check if expired
+    if (this.ttlMs > 0 && node.expiry <= Date.now()) {
+      await this.deleteSession(sessionId);
+      return false;
+    }
+
+    return true;
+  }
+
+  async getOrCreateStagehand(
+    sessionId: string,
+    ctx: RequestContext,
+  ): Promise<V3> {
+    const node = this.items.get(sessionId);
+
+    if (!node) {
+      throw new Error(`Session not found: ${sessionId}`);
+    }
+
+    // Check if expired
+    if (this.ttlMs > 0 && node.expiry <= Date.now()) {
+      await this.deleteSession(sessionId);
+      throw new Error(`Session expired: ${sessionId}`);
+    }
+
+    // Bump to most recently used
+    this.bumpNode(node);
+
+    // Update logger reference for this request
+    if (ctx.logger) {
+      node.loggerRef.current = ctx.logger;
+    }
+
+    // If V3 instance exists, return it
+    if (node.stagehand) {
+      return node.stagehand;
+    }
+
+    // Create V3 instance (lazy initialization)
+    const options = this.buildV3Options(node.params, ctx, node.loggerRef);
+
+    // Import V3 dynamically to avoid circular dependency
+    const { V3: V3Class } = await import("../v3");
+    const stagehand = new V3Class(options);
+    await stagehand.init();
+
+    node.stagehand = stagehand;
+    return stagehand;
+  }
+
+  /**
+   * Build V3Options from stored params and request context
+   */
+  private buildV3Options(
+    params: CreateSessionParams,
+    ctx: RequestContext,
+    loggerRef: { current?: (message: LogLine) => void },
+  ): V3Options {
+    const options: V3Options = {
+      env: "LOCAL",
+      model: {
+        modelName: params.modelName as any,
+        apiKey: ctx.modelApiKey,
+      },
+      verbose: params.verbose,
+      systemPrompt: params.systemPrompt,
+      selfHeal: params.selfHeal,
+      domSettleTimeout: params.domSettleTimeoutMs,
+      experimental: params.experimental,
+      // Wrap logger to use the ref so it can be updated per-request
+      logger: (message: LogLine) => {
+        if (loggerRef.current) {
+          loggerRef.current(message);
+        }
+      },
+    };
+
+    // If browserbaseSessionID is provided, set it up
+    if (params.browserbaseSessionID) {
+      options.browserbaseSessionID = params.browserbaseSessionID;
+    }
+
+    return options;
+  }
+
+  async createSession(
+    sessionId: string,
+    params: CreateSessionParams,
+  ): Promise<void> {
+    // Check if already exists
+    if (this.items.has(sessionId)) {
+      throw new Error(`Session already exists: ${sessionId}`);
+    }
+
+    // Evict LRU if at capacity
+    if (this.maxCapacity > 0 && this.items.size >= this.maxCapacity) {
+      await this.evictLru();
+    }
+
+    // Create new node
+    const node: LruNode = {
+      sessionId,
+      params,
+      stagehand: null, // Lazy initialization
+      loggerRef: {},
+      expiry: this.ttlMs > 0 ? Date.now() + this.ttlMs : Infinity,
+      prev: this.last,
+      next: null,
+    };
+
+    this.items.set(sessionId, node);
+
+    // Link to end of list
+    if (this.last) this.last.next = node;
+    this.last = node;
+    if (!this.first) this.first = node;
+  }
+
+  async deleteSession(sessionId: string): Promise<void> {
+    const node = this.items.get(sessionId);
+    if (!node) return;
+
+    // Close V3 instance if it exists
+    if (node.stagehand) {
+      try {
+        await node.stagehand.close();
+      } catch (error) {
+        console.error(`Error closing stagehand for session ${sessionId}:`, error);
+      }
+    }
+
+    // Remove from map
+    this.items.delete(sessionId);
+
+    // Unlink from list
+    const { prev, next } = node;
+    if (prev) prev.next = next;
+    if (next) next.prev = prev;
+    if (this.first === node) this.first = next;
+    if (this.last === node) this.last = prev;
+  }
+
+  updateCacheConfig(config: SessionCacheConfig): void {
+    if (config.maxCapacity !== undefined) {
+      if (config.maxCapacity <= 0) {
+        throw new Error("Max capacity must be greater than 0");
+      }
+      const previousCapacity = this.maxCapacity;
+      this.maxCapacity = config.maxCapacity;
+
+      // Evict excess if new capacity is smaller
+      if (this.maxCapacity < previousCapacity) {
+        const excess = this.items.size - this.maxCapacity;
+        for (let i = 0; i < excess; i++) {
+          // Fire and forget - don't await to match cloud behavior
+          this.evictLru().catch(console.error);
+        }
+      }
+    }
+
+    if (config.ttlMs !== undefined) {
+      this.ttlMs = config.ttlMs;
+    }
+  }
+
+  getCacheConfig(): SessionCacheConfig {
+    return {
+      maxCapacity: this.maxCapacity,
+      ttlMs: this.ttlMs,
+    };
+  }
+
+  async destroy(): Promise<void> {
+    // Stop cleanup interval
+    if (this.cleanupInterval) {
+      clearInterval(this.cleanupInterval);
+      this.cleanupInterval = null;
+    }
+
+    // Close all V3 instances
+    const sessionIds = Array.from(this.items.keys());
+    await Promise.all(sessionIds.map((id) => this.deleteSession(id)));
+  }
+
+  /**
+   * Get the number of cached sessions
+   */
+  get size(): number {
+    return this.items.size;
+  }
+}

--- a/packages/core/lib/v3/server/SessionStore.ts
+++ b/packages/core/lib/v3/server/SessionStore.ts
@@ -1,0 +1,168 @@
+import type { LogLine } from "../types/public";
+import type { V3 } from "../v3";
+import type { SessionStartResult } from "./schemas";
+
+export type { SessionStartResult };
+
+/**
+ * Parameters for creating a new session.
+ * This is what gets persisted - a subset of StartSessionParams
+ * that excludes runtime-only values like modelApiKey.
+ *
+ * Includes cloud-specific fields that pass through to cloud implementations.
+ * The library ignores fields it doesn't need, but they're available to SessionStore.
+ */
+export interface CreateSessionParams {
+  /** Model name (e.g., "openai/gpt-4o") */
+  modelName: string;
+  /** Verbosity level */
+  verbose?: 0 | 1 | 2;
+  /** Custom system prompt */
+  systemPrompt?: string;
+  /** Enable self-healing for failed actions */
+  selfHeal?: boolean;
+  /** DOM settle timeout in milliseconds */
+  domSettleTimeoutMs?: number;
+  /** Enable experimental features */
+  experimental?: boolean;
+
+  // Browserbase-specific (used by cloud implementations)
+  /** Browserbase API key */
+  browserbaseApiKey?: string;
+  /** Browserbase project ID */
+  browserbaseProjectId?: string;
+  /** Existing Browserbase session ID to connect to */
+  browserbaseSessionID?: string;
+  /** Wait for captcha solves */
+  waitForCaptchaSolves?: boolean;
+  /** Browserbase session creation params */
+  browserbaseSessionCreateParams?: Record<string, unknown>;
+
+  // Cloud-specific metadata fields
+  /** Debug DOM mode */
+  debugDom?: boolean;
+  /** Act timeout in milliseconds */
+  actTimeoutMs?: number;
+  /** Client language (typescript, python, playground) */
+  clientLanguage?: string;
+  /** SDK version */
+  sdkVersion?: string;
+}
+
+/**
+ * Request-time context passed when resolving a session.
+ * Contains values that come from request headers rather than storage.
+ */
+export interface RequestContext {
+  /** Model API key (from x-model-api-key header) */
+  modelApiKey?: string;
+  /** Logger function for this request */
+  logger?: (message: LogLine) => void;
+}
+
+/**
+ * Configuration options for session cache behavior.
+ */
+export interface SessionCacheConfig {
+  /** Maximum number of sessions to cache. Default: 100 */
+  maxCapacity?: number;
+  /** TTL for cached sessions in milliseconds. Default: 300000 (5 minutes) */
+  ttlMs?: number;
+}
+
+
+/**
+ * SessionStore interface for managing session lifecycle and V3 instances.
+ *
+ * The library provides an InMemorySessionStore as the default implementation
+ * with full caching support (TTL, LRU eviction, etc.).
+ *
+ * Cloud environments can implement this interface to:
+ * - Persist session config to a database
+ * - Use custom caching strategies (e.g., LaunchDarkly-driven config)
+ * - Add eviction hooks for cleanup
+ * - Handle platform-specific session lifecycle (e.g., Browserbase)
+ *
+ * This enables stateless pod architectures where any pod can handle any request.
+ */
+export interface SessionStore {
+  /**
+   * Start a new session.
+   *
+   * This is the main entry point for session creation. Implementations can:
+   * - Create platform-specific resources (e.g., Browserbase session)
+   * - Persist session config to storage
+   * - Check feature flags for availability
+   *
+   * @param params - Session configuration
+   * @returns Session ID and availability status
+   */
+  startSession(params: CreateSessionParams): Promise<SessionStartResult>;
+
+  /**
+   * End a session and cleanup all resources.
+   *
+   * This is the main entry point for session cleanup. Implementations can:
+   * - Close platform-specific resources (e.g., Browserbase session)
+   * - Evict V3 instance from cache
+   * - Update session status in storage
+   *
+   * @param sessionId - The session identifier
+   */
+  endSession(sessionId: string): Promise<void>;
+
+  /**
+   * Check if a session exists.
+   * @param sessionId - The session identifier
+   * @returns true if the session exists
+   */
+  hasSession(sessionId: string): Promise<boolean>;
+
+  /**
+   * Get or create a V3 instance for a session.
+   *
+   * This method handles:
+   * - Checking the cache for an existing V3 instance
+   * - On cache miss: loading config, creating V3, caching it
+   * - Updating the logger reference for streaming
+   *
+   * @param sessionId - The session identifier
+   * @param ctx - Request-time context containing values from headers
+   * @returns The V3 instance ready for use
+   * @throws Error if session not found
+   */
+  getOrCreateStagehand(sessionId: string, ctx: RequestContext): Promise<V3>;
+
+  /**
+   * Create a new session with the given parameters.
+   * Lower-level than startSession - just stores the config.
+   * @param sessionId - The session identifier
+   * @param params - Session configuration to persist
+   */
+  createSession(sessionId: string, params: CreateSessionParams): Promise<void>;
+
+  /**
+   * Delete a session from cache and close V3 instance.
+   * Lower-level than endSession - just handles cache cleanup.
+   * @param sessionId - The session identifier
+   */
+  deleteSession(sessionId: string): Promise<void>;
+
+  /**
+   * Update cache configuration dynamically.
+   * @param config - New cache configuration values
+   */
+  updateCacheConfig?(config: SessionCacheConfig): void;
+
+  /**
+   * Get current cache configuration.
+   * @returns Current cache config
+   */
+  getCacheConfig?(): SessionCacheConfig;
+
+  /**
+   * Cleanup all resources (close all V3 instances, stop timers).
+   * Called when shutting down the server.
+   */
+  destroy(): Promise<void>;
+}

--- a/packages/core/lib/v3/server/index.ts
+++ b/packages/core/lib/v3/server/index.ts
@@ -1,0 +1,727 @@
+import Fastify, { FastifyInstance } from "fastify";
+import cors from "@fastify/cors";
+import {
+  serializerCompiler,
+  validatorCompiler,
+  type ZodTypeProvider,
+} from "fastify-type-provider-zod";
+import type {
+  ActOptions,
+  ActResult,
+  ExtractResult,
+  ExtractOptions,
+  ObserveOptions,
+  Action,
+  AgentResult,
+  ModelConfiguration,
+} from "../types/public";
+import type { StagehandZodSchema } from "../zodCompat";
+import { jsonSchemaToZod, type JsonSchema } from "../../utils";
+import type { SessionStore, CreateSessionParams } from "./SessionStore";
+import { InMemorySessionStore } from "./InMemorySessionStore";
+import { createStreamingResponse, mapStagehandError } from "./stream";
+
+// Re-export error handling utilities for consumers
+export { StagehandErrorCode, mapStagehandError } from "./stream";
+export type { StagehandErrorResponse } from "./stream";
+import {
+  ActRequestSchema,
+  ActResponseSchema,
+  ExtractRequestSchema,
+  ExtractResponseSchema,
+  ObserveRequestSchema,
+  ObserveResponseSchema,
+  AgentExecuteRequestSchema,
+  AgentExecuteResponseSchema,
+  NavigateRequestSchema,
+  NavigateResponseSchema,
+  SessionStartRequestSchema,
+  SessionStartResponseSchema,
+  SessionIdParamsSchema,
+  SessionEndRequestSchema,
+  SessionEndResponseSchema,
+  type SessionStartRequest,
+  type SessionEndRequest,
+  type ActRequest,
+  type ExtractRequest,
+  type ObserveRequest,
+  type AgentExecuteRequest,
+  type NavigateRequest,
+  type SessionIdParams,
+} from "./schemas";
+
+// =============================================================================
+// Generic HTTP interfaces for cross-version Fastify compatibility
+// =============================================================================
+
+/**
+ * Generic HTTP request interface.
+ * Structurally compatible with FastifyRequest from any version.
+ * @template TBody - Type of the request body (defaults to unknown for backwards compatibility)
+ * @template TParams - Type of the route params (defaults to unknown for backwards compatibility)
+ */
+export interface StagehandHttpRequest<TBody = unknown, TParams = unknown> {
+  headers: Record<string, string | string[] | undefined>;
+  body: TBody;
+  params: TParams;
+}
+
+/**
+ * Generic HTTP reply interface.
+ * Structurally compatible with FastifyReply from any version.
+ */
+export interface StagehandHttpReply {
+  status(code: number): StagehandHttpReply;
+  send(payload: unknown): Promise<unknown> | unknown;
+  raw: {
+    write(chunk: string | Buffer): boolean;
+    end(): void;
+    on(event: string, handler: (...args: unknown[]) => void): unknown;
+  };
+  sent: boolean;
+  hijack(): void;
+}
+
+// Re-export event types for consumers (only LLM events are actually used)
+export * from "./events";
+
+// Re-export SessionStore types
+export type {
+  SessionStore,
+  RequestContext,
+  CreateSessionParams,
+  SessionStartResult,
+} from "./SessionStore";
+export { InMemorySessionStore } from "./InMemorySessionStore";
+
+// Re-export API schemas and types for consumers
+export * from "./schemas";
+
+// =============================================================================
+// Standalone PreHandler Factory Functions
+// =============================================================================
+
+/**
+ * Validates the session ID param exists and session is found in SessionStore.
+ *
+ * This is the core validation logic that can be used by external servers (e.g., cloud API)
+ * to share the same validation as the StagehandServer.
+ *
+ * @param sessionStore - The SessionStore instance to use for validation
+ * @param request - The request object (must have params with id)
+ * @param reply - The reply object (must have status and send methods)
+ * @returns true if validation passed, false if response was sent
+ */
+export async function validateSession(
+  sessionStore: SessionStore,
+  request: { params: unknown },
+  reply: { status(code: number): { send(payload: unknown): unknown } },
+): Promise<boolean> {
+  const { id } = request.params as { id?: string };
+
+  if (!id?.length) {
+    reply.status(400).send({
+      error: "Missing session id",
+    });
+    return false;
+  }
+
+  const hasSession = await sessionStore.hasSession(id);
+  if (!hasSession) {
+    reply.status(404).send({
+      error: "Session not found",
+    });
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Creates a preHandler that validates the session ID param exists and session is found in SessionStore.
+ *
+ * This factory function can be used by external servers (e.g., cloud API) that want to
+ * share the same validation logic as the StagehandServer.
+ *
+ * @param sessionStore - The SessionStore instance to use for validation
+ * @returns A preHandler function compatible with any Fastify version
+ *
+ * @example
+ * ```typescript
+ * import { createSessionValidationPreHandler, DBSessionStore } from '@browserbasehq/stagehand/server';
+ *
+ * const sessionStore = new DBSessionStore();
+ * const sessionValidationPreHandler = createSessionValidationPreHandler(sessionStore);
+ *
+ * app.post('/sessions/:id/act', {
+ *   preHandler: [sessionValidationPreHandler],
+ * }, handler);
+ * ```
+ */
+export function createSessionValidationPreHandler(
+  sessionStore: SessionStore,
+): (
+  request: { params: unknown },
+  reply: { status(code: number): { send(payload: unknown): unknown } },
+) => Promise<void> {
+  return async (
+    request: { params: unknown },
+    reply: { status(code: number): { send(payload: unknown): unknown } },
+  ): Promise<void> => {
+    await validateSession(sessionStore, request, reply);
+  };
+}
+
+export interface StagehandServerOptions {
+  port?: number;
+  host?: string;
+  /**
+   * Session store for managing session lifecycle and V3 instances.
+   * Defaults to InMemorySessionStore if not provided.
+   * Cloud environments should provide a database-backed implementation.
+   */
+  sessionStore?: SessionStore;
+}
+
+/**
+ * StagehandServer - Embedded API server for peer-to-peer Stagehand communication
+ *
+ * This server implements the same API as the cloud Stagehand API, allowing
+ * remote Stagehand instances to connect and execute actions on this machine.
+ *
+ * Uses a SessionStore interface for session management, allowing cloud environments
+ * to provide database-backed implementations for stateless pod architectures.
+ */
+export class StagehandServer {
+  private app: FastifyInstance;
+  private sessionStore: SessionStore;
+  private port: number;
+  private host: string;
+  private isListening: boolean = false;
+
+  constructor(options: StagehandServerOptions = {}) {
+    this.port = options.port || 3000;
+    this.host = options.host || "0.0.0.0";
+    this.sessionStore = options.sessionStore ?? new InMemorySessionStore();
+    this.app = Fastify({
+      logger: false,
+    });
+
+    // Set up Zod type provider for automatic request/response validation
+    this.app.setValidatorCompiler(validatorCompiler);
+    this.app.setSerializerCompiler(serializerCompiler);
+
+    this.setupMiddleware();
+    this.setupRoutes();
+  }
+
+  /**
+   * Get the session store instance
+   */
+  getSessionStore(): SessionStore {
+    return this.sessionStore;
+  }
+
+  private setupMiddleware(): void {
+    this.app.register(cors, {
+      origin: "*",
+      methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+      allowedHeaders: "*",
+      credentials: true,
+    });
+  }
+
+  private setupRoutes(): void {
+    const app = this.app.withTypeProvider<ZodTypeProvider>();
+    const sessionValidationPreHandler = createSessionValidationPreHandler(
+      this.sessionStore,
+    );
+
+    // Health check
+    app.get("/health", async () => {
+      return { status: "ok" };
+    });
+
+    // Start session
+    app.post(
+      "/v1/sessions/start",
+      {
+        schema: {
+          body: SessionStartRequestSchema,
+          response: {
+            200: SessionStartResponseSchema,
+          },
+        },
+      },
+      async (request, reply) => {
+        return this.handleStartSession(request, reply);
+      },
+    );
+
+    // Act endpoint
+    app.post(
+      "/v1/sessions/:id/act",
+      {
+        schema: {
+          params: SessionIdParamsSchema,
+          body: ActRequestSchema,
+          response: {
+            200: ActResponseSchema,
+          },
+        },
+        preHandler: [sessionValidationPreHandler],
+      },
+      async (request, reply) => {
+        return this.handleAct(request, reply);
+      },
+    );
+
+    // Extract endpoint
+    app.post(
+      "/v1/sessions/:id/extract",
+      {
+        schema: {
+          params: SessionIdParamsSchema,
+          body: ExtractRequestSchema,
+          response: {
+            200: ExtractResponseSchema,
+          },
+        },
+        preHandler: [sessionValidationPreHandler],
+      },
+      async (request, reply) => {
+        return this.handleExtract(request, reply);
+      },
+    );
+
+    // Observe endpoint
+    app.post(
+      "/v1/sessions/:id/observe",
+      {
+        schema: {
+          params: SessionIdParamsSchema,
+          body: ObserveRequestSchema,
+          response: {
+            200: ObserveResponseSchema,
+          },
+        },
+        preHandler: [sessionValidationPreHandler],
+      },
+      async (request, reply) => {
+        return this.handleObserve(request, reply);
+      },
+    );
+
+    // Agent execute endpoint
+    app.post(
+      "/v1/sessions/:id/agentExecute",
+      {
+        schema: {
+          params: SessionIdParamsSchema,
+          body: AgentExecuteRequestSchema,
+          response: {
+            200: AgentExecuteResponseSchema,
+          },
+        },
+        preHandler: [sessionValidationPreHandler],
+      },
+      async (request, reply) => {
+        return this.handleAgentExecute(request, reply);
+      },
+    );
+
+    // Navigate endpoint
+    app.post(
+      "/v1/sessions/:id/navigate",
+      {
+        schema: {
+          params: SessionIdParamsSchema,
+          body: NavigateRequestSchema,
+          response: {
+            200: NavigateResponseSchema,
+          },
+        },
+        preHandler: [sessionValidationPreHandler],
+      },
+      async (request, reply) => {
+        return this.handleNavigate(request, reply);
+      },
+    );
+
+    // End session
+    app.post(
+      "/v1/sessions/:id/end",
+      {
+        schema: {
+          params: SessionIdParamsSchema,
+          body: SessionEndRequestSchema,
+          response: {
+            200: SessionEndResponseSchema,
+          },
+        },
+        preHandler: [sessionValidationPreHandler],
+      },
+      async (request, reply) => {
+        return this.handleEndSession(request, reply);
+      },
+    );
+  }
+
+  /**
+   * Handle /sessions/start - Create new session
+   * Body is pre-validated by Fastify using SessionStartRequestSchema
+   */
+  async handleStartSession(
+    request: StagehandHttpRequest<SessionStartRequest>,
+    reply: StagehandHttpReply,
+  ): Promise<void> {
+    try {
+      const { body } = request;
+
+      const createParams: CreateSessionParams = {
+        modelName: body.modelName,
+        verbose: body.verbose,
+        systemPrompt: body.systemPrompt,
+        selfHeal: body.selfHeal,
+        domSettleTimeoutMs: body.domSettleTimeoutMs,
+        experimental: body.experimental,
+        waitForCaptchaSolves: body.waitForCaptchaSolves,
+        browserbaseSessionID: body.browserbaseSessionID ?? body.sessionId,
+        browserbaseSessionCreateParams: body.browserbaseSessionCreateParams,
+        debugDom: body.debugDom,
+        actTimeoutMs: body.actTimeoutMs,
+        browserbaseApiKey: request.headers["x-bb-api-key"] as
+          | string
+          | undefined,
+        browserbaseProjectId: request.headers["x-bb-project-id"] as
+          | string
+          | undefined,
+        clientLanguage: request.headers["x-language"] as string | undefined,
+        sdkVersion: request.headers["x-sdk-version"] as string | undefined,
+      };
+
+      const result = await this.sessionStore.startSession(createParams);
+
+      reply.status(200).send({
+        success: true,
+        data: {
+          sessionId: result.sessionId,
+          available: result.available,
+        },
+      });
+    } catch (error) {
+      const mappedError = mapStagehandError(
+        error instanceof Error ? error : new Error("Failed to create session"),
+        "startSession",
+      );
+      reply.status(mappedError.statusCode).send({
+        success: false,
+        error: mappedError.error,
+        code: mappedError.code,
+      });
+    }
+  }
+
+  /**
+   * Handle /sessions/:id/act - Execute act command
+   * Body is pre-validated by Fastify using ActRequestSchema
+   * Session is pre-validated by sessionValidationPreHandler
+   */
+  async handleAct(
+    request: StagehandHttpRequest<ActRequest, SessionIdParams>,
+    reply: StagehandHttpReply,
+  ): Promise<void> {
+    await createStreamingResponse<ActRequest>({
+      sessionId: request.params.id,
+      sessionStore: this.sessionStore,
+      request,
+      reply,
+      operation: "act",
+      handler: async ({ stagehand }, data) => {
+        const { frameId } = data;
+
+        const page = frameId
+          ? stagehand.context.resolvePageByMainFrameId(frameId)
+          : await stagehand.context.awaitActivePage();
+
+        if (!page) {
+          throw new Error("Page not found");
+        }
+
+        const safeOptions: ActOptions = {
+          model: data.options?.model
+            ? ({
+                ...data.options.model,
+                modelName: data.options.model.model ?? "gpt-4o",
+              } as ModelConfiguration)
+            : undefined,
+          variables: data.options?.variables,
+          timeout: data.options?.timeout,
+          page,
+        };
+
+        let result: ActResult;
+        if (typeof data.input === "string") {
+          result = await stagehand.act(data.input, safeOptions);
+        } else {
+          result = await stagehand.act(data.input as Action, safeOptions);
+        }
+
+        return { result };
+      },
+    });
+  }
+
+  /**
+   * Handle /sessions/:id/extract - Execute extract command
+   * Body is pre-validated by Fastify using ExtractRequestSchema
+   * Session is pre-validated by sessionValidationPreHandler
+   */
+  async handleExtract(
+    request: StagehandHttpRequest<ExtractRequest, SessionIdParams>,
+    reply: StagehandHttpReply,
+  ): Promise<void> {
+    await createStreamingResponse<ExtractRequest>({
+      sessionId: request.params.id,
+      sessionStore: this.sessionStore,
+      request,
+      reply,
+      operation: "extract",
+      handler: async ({ stagehand }, data) => {
+        const { frameId } = data;
+
+        const page = frameId
+          ? stagehand.context.resolvePageByMainFrameId(frameId)
+          : await stagehand.context.awaitActivePage();
+
+        if (!page) {
+          throw new Error("Page not found");
+        }
+
+        const safeOptions: ExtractOptions = {
+          model: data.options?.model
+            ? ({
+                ...data.options.model,
+                modelName: data.options.model.model ?? "gpt-4o",
+              } as ModelConfiguration)
+            : undefined,
+          timeout: data.options?.timeout,
+          selector: data.options?.selector,
+          page,
+        };
+
+        let result: ExtractResult<StagehandZodSchema>;
+
+        if (data.instruction) {
+          if (data.schema) {
+            const zodSchema = jsonSchemaToZod(
+              data.schema as unknown as JsonSchema,
+            ) as StagehandZodSchema;
+            result = await stagehand.extract(
+              data.instruction,
+              zodSchema,
+              safeOptions,
+            );
+          } else {
+            result = await stagehand.extract(data.instruction, safeOptions);
+          }
+        } else {
+          result = await stagehand.extract(safeOptions);
+        }
+
+        return { result };
+      },
+    });
+  }
+
+  /**
+   * Handle /sessions/:id/observe - Execute observe command
+   * Body is pre-validated by Fastify using ObserveRequestSchema
+   * Session is pre-validated by sessionValidationPreHandler
+   */
+  async handleObserve(
+    request: StagehandHttpRequest<ObserveRequest, SessionIdParams>,
+    reply: StagehandHttpReply,
+  ): Promise<void> {
+    await createStreamingResponse<ObserveRequest>({
+      sessionId: request.params.id,
+      sessionStore: this.sessionStore,
+      request,
+      reply,
+      operation: "observe",
+      handler: async ({ stagehand }, data) => {
+        const { frameId } = data;
+
+        const page = frameId
+          ? stagehand.context.resolvePageByMainFrameId(frameId)
+          : await stagehand.context.awaitActivePage();
+
+        if (!page) {
+          throw new Error("Page not found");
+        }
+
+        const safeOptions: ObserveOptions = {
+          model:
+            data.options?.model && typeof data.options.model.model === "string"
+              ? ({
+                  ...data.options.model,
+                  modelName: data.options.model.model,
+                } as ModelConfiguration)
+              : undefined,
+          timeout: data.options?.timeout,
+          selector: data.options?.selector,
+          page,
+        };
+
+        let result: Action[];
+
+        if (data.instruction) {
+          result = await stagehand.observe(data.instruction, safeOptions);
+        } else {
+          result = await stagehand.observe(safeOptions);
+        }
+
+        return { result };
+      },
+    });
+  }
+
+  /**
+   * Handle /sessions/:id/agentExecute - Execute agent command
+   * Body is pre-validated by Fastify using AgentExecuteRequestSchema
+   * Session is pre-validated by sessionValidationPreHandler
+   */
+  async handleAgentExecute(
+    request: StagehandHttpRequest<AgentExecuteRequest, SessionIdParams>,
+    reply: StagehandHttpReply,
+  ): Promise<void> {
+    await createStreamingResponse<AgentExecuteRequest>({
+      sessionId: request.params.id,
+      sessionStore: this.sessionStore,
+      request,
+      reply,
+      operation: "agentExecute",
+      handler: async ({ stagehand }, data) => {
+        const { agentConfig, executeOptions, frameId } = data;
+
+        const page = frameId
+          ? stagehand.context.resolvePageByMainFrameId(frameId)
+          : await stagehand.context.awaitActivePage();
+
+        if (!page) {
+          throw new Error("Page not found");
+        }
+
+        const fullExecuteOptions = {
+          ...executeOptions,
+          page,
+        };
+
+        const result: AgentResult = await stagehand
+          .agent(agentConfig)
+          .execute(fullExecuteOptions);
+
+        return { result };
+      },
+    });
+  }
+
+  /**
+   * Handle /sessions/:id/navigate - Navigate to URL
+   * Body is pre-validated by Fastify using NavigateRequestSchema
+   * Session is pre-validated by sessionValidationPreHandler
+   */
+  async handleNavigate(
+    request: StagehandHttpRequest<NavigateRequest, SessionIdParams>,
+    reply: StagehandHttpReply,
+  ): Promise<void> {
+    await createStreamingResponse<NavigateRequest>({
+      sessionId: request.params.id,
+      sessionStore: this.sessionStore,
+      request,
+      reply,
+      operation: "navigate",
+      handler: async ({ stagehand }, data) => {
+        const { url, options, frameId } = data;
+
+        const page = frameId
+          ? stagehand.context.resolvePageByMainFrameId(frameId)
+          : await stagehand.context.awaitActivePage();
+
+        if (!page) {
+          throw new Error("Page not found");
+        }
+
+        const response = await page.goto(url, options);
+
+        return { result: response };
+      },
+    });
+  }
+
+  /**
+   * Handle /sessions/:id/end - End session and cleanup
+   * Params are pre-validated by Fastify using SessionIdParamsSchema
+   * Session is pre-validated by sessionValidationPreHandler
+   */
+  async handleEndSession(
+    request: StagehandHttpRequest<SessionEndRequest, SessionIdParams>,
+    reply: StagehandHttpReply,
+  ): Promise<void> {
+    try {
+      await this.sessionStore.endSession(request.params.id);
+      reply.status(200).send({ success: true });
+    } catch (error) {
+      const mappedError = mapStagehandError(
+        error instanceof Error ? error : new Error("Failed to end session"),
+        "endSession",
+      );
+      reply.status(mappedError.statusCode).send({
+        error: mappedError.error,
+        code: mappedError.code,
+      });
+    }
+  }
+
+  /**
+   * Start the server
+   */
+  async listen(port?: number): Promise<void> {
+    const listenPort = port || this.port;
+
+    try {
+      await this.app.listen({
+        port: listenPort,
+        host: this.host,
+      });
+      this.isListening = true;
+      console.log(
+        `Stagehand server listening on http://${this.host}:${listenPort}`,
+      );
+    } catch (error) {
+      console.error("Failed to start server:", error);
+      throw error;
+    }
+  }
+
+  /**
+   * Stop the server and cleanup
+   */
+  async close(): Promise<void> {
+    if (this.isListening) {
+      await this.app.close();
+      this.isListening = false;
+    }
+    await this.sessionStore.destroy();
+  }
+
+  /**
+   * Get server URL
+   */
+  getUrl(): string {
+    if (!this.isListening) {
+      throw new Error("Server is not listening");
+    }
+    return `http://${this.host}:${this.port}`;
+  }
+}

--- a/packages/core/lib/v3/server/stream.ts
+++ b/packages/core/lib/v3/server/stream.ts
@@ -1,0 +1,367 @@
+import { randomUUID } from "crypto";
+import type { V3 } from "../v3";
+import type { SessionStore, RequestContext } from "./SessionStore";
+
+// =============================================================================
+// Error Handling
+// =============================================================================
+
+/**
+ * Standard error codes for Stagehand API errors.
+ */
+export enum StagehandErrorCode {
+  // User-actionable errors (400)
+  INVALID_ARGUMENT = "INVALID_ARGUMENT",
+  MISSING_ARGUMENT = "MISSING_ARGUMENT",
+  INVALID_MODEL = "INVALID_MODEL",
+  INVALID_SCHEMA = "INVALID_SCHEMA",
+  EXPERIMENTAL_NOT_CONFIGURED = "EXPERIMENTAL_NOT_CONFIGURED",
+
+  // Operational errors (422)
+  ELEMENT_NOT_FOUND = "ELEMENT_NOT_FOUND",
+  ACTION_FAILED = "ACTION_FAILED",
+  LLM_ERROR = "LLM_ERROR",
+  TIMEOUT = "TIMEOUT",
+
+  // Internal errors (500)
+  SDK_ERROR = "SDK_ERROR",
+  INTERNAL_ERROR = "INTERNAL_ERROR",
+}
+
+/**
+ * Structured error response for Stagehand API.
+ */
+export interface StagehandErrorResponse {
+  error: string;
+  code: StagehandErrorCode;
+  operation?: string;
+  statusCode: number;
+}
+
+// Error name to code mappings for user-actionable errors (400)
+const USER_ERROR_MAP: Record<string, StagehandErrorCode> = {
+  StagehandInvalidArgumentError: StagehandErrorCode.INVALID_ARGUMENT,
+  StagehandMissingArgumentError: StagehandErrorCode.MISSING_ARGUMENT,
+  MissingLLMConfigurationError: StagehandErrorCode.INVALID_MODEL,
+  UnsupportedModelError: StagehandErrorCode.INVALID_MODEL,
+  UnsupportedModelProviderError: StagehandErrorCode.INVALID_MODEL,
+  InvalidAISDKModelFormatError: StagehandErrorCode.INVALID_MODEL,
+  UnsupportedAISDKModelProviderError: StagehandErrorCode.INVALID_MODEL,
+  ExperimentalNotConfiguredError: StagehandErrorCode.EXPERIMENTAL_NOT_CONFIGURED,
+  ExperimentalApiConflictError: StagehandErrorCode.EXPERIMENTAL_NOT_CONFIGURED,
+  CuaModelRequiredError: StagehandErrorCode.INVALID_MODEL,
+  AI_APICallError: StagehandErrorCode.INVALID_MODEL,
+  APICallError: StagehandErrorCode.INVALID_MODEL,
+};
+
+// Operational error mappings (422)
+interface OperationalErrorConfig {
+  code: StagehandErrorCode;
+  sanitize: (msg: string, op: string) => string;
+}
+
+const OPERATIONAL_ERROR_MAP: Record<string, OperationalErrorConfig> = {
+  StagehandElementNotFoundError: {
+    code: StagehandErrorCode.ELEMENT_NOT_FOUND,
+    sanitize: (_msg, op) => `Could not find the requested element during ${op}`,
+  },
+  XPathResolutionError: {
+    code: StagehandErrorCode.ELEMENT_NOT_FOUND,
+    sanitize: (_msg, op) => `XPath selector did not match any element during ${op}`,
+  },
+  ElementNotVisibleError: {
+    code: StagehandErrorCode.ELEMENT_NOT_FOUND,
+    sanitize: (_msg, op) => `Element is not visible during ${op}`,
+  },
+  StagehandClickError: {
+    code: StagehandErrorCode.ACTION_FAILED,
+    sanitize: (_msg, op) => `Click action failed during ${op}`,
+  },
+  StagehandDomProcessError: {
+    code: StagehandErrorCode.ACTION_FAILED,
+    sanitize: (_msg, op) => `DOM processing failed during ${op}`,
+  },
+  LLMResponseError: {
+    code: StagehandErrorCode.LLM_ERROR,
+    sanitize: (_msg, op) => `LLM processing failed during ${op}. Please try again.`,
+  },
+  CreateChatCompletionResponseError: {
+    code: StagehandErrorCode.LLM_ERROR,
+    sanitize: (_msg, op) => `LLM request failed during ${op}. Please try again.`,
+  },
+  CaptchaTimeoutError: {
+    code: StagehandErrorCode.TIMEOUT,
+    sanitize: (_msg, op) => `Captcha solving timed out during ${op}`,
+  },
+  TimeoutError: {
+    code: StagehandErrorCode.TIMEOUT,
+    sanitize: (msg) => msg, // TimeoutError messages are already user-friendly
+  },
+  ConnectionTimeoutError: {
+    code: StagehandErrorCode.TIMEOUT,
+    sanitize: (msg) => msg,
+  },
+};
+
+const MAX_SANITIZED_MESSAGE_LENGTH = 100;
+
+/**
+ * Sanitizes error messages to remove potentially sensitive information.
+ */
+function sanitizeErrorMessage(message: string): string {
+  const sanitized = message
+    // Remove long alphanumeric strings (potential API keys/tokens)
+    .replace(/\b[a-zA-Z0-9_-]{32,}\b/g, "[redacted]")
+    // Remove common API key patterns (sk_, pk_, api_, etc.)
+    .replace(/\b(?:sk|pk|api|key|token|secret)_[a-zA-Z0-9]{16,}\b/gi, "[api-key]")
+    // Remove URLs
+    .replace(/https?:\/\/[^\s<>"']+/g, "[url]")
+    // Remove Unix-style file paths
+    .replace(/(?:^|\s)(\/[\w.-]+){2,}/g, " [path]")
+    // Remove Windows-style file paths
+    .replace(/[A-Z]:\\[\w\\.-]+/gi, "[path]")
+    // Remove emails
+    .replace(/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g, "[email]")
+    // Remove IP addresses
+    .replace(/\b(?:\d{1,3}\.){3}\d{1,3}\b/g, "[ip]");
+
+  const truncated = sanitized.substring(0, MAX_SANITIZED_MESSAGE_LENGTH);
+  return truncated + (sanitized.length > MAX_SANITIZED_MESSAGE_LENGTH ? "..." : "");
+}
+
+/**
+ * Maps Stagehand SDK errors to structured error responses with appropriate codes and messages.
+ */
+export function mapStagehandError(err: Error, operation: string): StagehandErrorResponse {
+  const errorName = err.constructor.name;
+  const { message } = err;
+
+  // User-actionable errors (400) - pass through original message
+  const userErrorCode = USER_ERROR_MAP[errorName];
+  if (userErrorCode) {
+    return {
+      error: message,
+      code: userErrorCode,
+      operation,
+      statusCode: 400,
+    };
+  }
+
+  // Schema validation errors - sanitize to avoid exposing raw data
+  if (errorName === "ZodSchemaValidationError") {
+    return {
+      error: `Schema validation failed during ${operation}`,
+      code: StagehandErrorCode.INVALID_SCHEMA,
+      operation,
+      statusCode: 400,
+    };
+  }
+
+  // Operational errors (422) - sanitize but provide useful context
+  const operationalConfig = OPERATIONAL_ERROR_MAP[errorName];
+  if (operationalConfig) {
+    return {
+      error: operationalConfig.sanitize(message, operation),
+      code: operationalConfig.code,
+      operation,
+      statusCode: 422,
+    };
+  }
+
+  // Check for StagehandError base class errors that weren't explicitly mapped
+  if (errorName.startsWith("Stagehand")) {
+    return {
+      error: `${operation} operation failed: ${sanitizeErrorMessage(message)}`,
+      code: StagehandErrorCode.SDK_ERROR,
+      operation,
+      statusCode: 500,
+    };
+  }
+
+  // Unknown errors - hide details completely
+  return {
+    error: `${operation} operation failed unexpectedly`,
+    code: StagehandErrorCode.INTERNAL_ERROR,
+    operation,
+    statusCode: 500,
+  };
+}
+
+/**
+ * Generic HTTP request interface for streaming.
+ * Structurally compatible with FastifyRequest from any version.
+ */
+export interface StreamingHttpRequest {
+  headers: Record<string, string | string[] | undefined>;
+  body: unknown;
+}
+
+/**
+ * Generic HTTP reply interface for streaming.
+ * Structurally compatible with FastifyReply from any version.
+ */
+export interface StreamingHttpReply {
+  status(code: number): StreamingHttpReply;
+  send(payload: unknown): Promise<unknown> | unknown;
+  raw: {
+    writeHead?(statusCode: number, headers: Record<string, string>): void;
+    write(chunk: string | Buffer): boolean;
+    end(): void;
+    on?(event: string, handler: (...args: unknown[]) => void): unknown;
+  };
+  sent?: boolean;
+  hijack?(): void;
+}
+
+export interface StreamingHandlerResult {
+  result: unknown;
+}
+
+export interface StreamingHandlerContext {
+  stagehand: V3;
+  sessionId: string;
+  request: StreamingHttpRequest;
+}
+
+export interface StreamingResponseOptions<T> {
+  sessionId: string;
+  sessionStore: SessionStore;
+  request: StreamingHttpRequest;
+  reply: StreamingHttpReply;
+  /** The operation name for error reporting (e.g., "act", "extract", "observe") */
+  operation: string;
+  handler: (ctx: StreamingHandlerContext, data: T) => Promise<StreamingHandlerResult>;
+}
+
+/**
+ * Sends an SSE (Server-Sent Events) message to the client
+ */
+function sendSSE(reply: StreamingHttpReply, data: object): void {
+  const message = {
+    id: randomUUID(),
+    ...data,
+  };
+  reply.raw.write(`data: ${JSON.stringify(message)}\n\n`);
+}
+
+/**
+ * Creates a streaming response handler that sends events via SSE.
+ * Extracts RequestContext (modelApiKey, logger) from request headers automatically.
+ * Handles errors with proper status codes and sanitized messages.
+ */
+export async function createStreamingResponse<T>({
+  sessionId,
+  sessionStore,
+  request,
+  reply,
+  operation,
+  handler,
+}: StreamingResponseOptions<T>): Promise<void> {
+  // Check if streaming is requested
+  const streamHeader = request.headers["x-stream-response"];
+  const shouldStream = streamHeader === "true";
+
+  // Parse the request body
+  const data = request.body as T;
+
+  // Set up SSE response if streaming
+  if (shouldStream) {
+    reply.raw.writeHead?.(200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      "Connection": "keep-alive",
+      "Transfer-Encoding": "chunked",
+      "X-Accel-Buffering": "no",
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+      "Access-Control-Allow-Headers": "*",
+      "Access-Control-Allow-Credentials": "true",
+    });
+
+    sendSSE(reply, {
+      type: "system",
+      data: { status: "starting" },
+    });
+  }
+
+  let result: StreamingHandlerResult | null = null;
+  let handlerError: Error | null = null;
+
+  try {
+    // Build request context from headers, adding streaming logger if needed
+    const requestContext: RequestContext = {
+      modelApiKey: request.headers["x-model-api-key"] as string | undefined,
+      logger: shouldStream
+        ? async (message) => {
+            sendSSE(reply, {
+              type: "log",
+              data: {
+                status: "running",
+                message,
+              },
+            });
+          }
+        : undefined,
+    };
+
+    // Get or create the Stagehand instance from the session store
+    const stagehand = await sessionStore.getOrCreateStagehand(sessionId, requestContext);
+
+    if (shouldStream) {
+      sendSSE(reply, {
+        type: "system",
+        data: { status: "connected" },
+      });
+    }
+
+    // Execute the handler
+    const ctx: StreamingHandlerContext = {
+      stagehand,
+      sessionId,
+      request,
+    };
+
+    result = await handler(ctx, data);
+  } catch (err) {
+    handlerError = err instanceof Error ? err : new Error("Unknown error occurred");
+  }
+
+  // Handle error case
+  if (handlerError) {
+    const mappedError = mapStagehandError(handlerError, operation);
+
+    if (shouldStream) {
+      sendSSE(reply, {
+        type: "system",
+        data: {
+          status: "error",
+          error: mappedError.error,
+          code: mappedError.code,
+        },
+      });
+      reply.raw.end();
+    } else {
+      reply.status(mappedError.statusCode).send({
+        error: mappedError.error,
+        code: mappedError.code,
+      });
+    }
+    return;
+  }
+
+  // Handle success case
+  if (shouldStream) {
+    sendSSE(reply, {
+      type: "system",
+      data: {
+        status: "finished",
+        result: result?.result,
+      },
+    });
+    reply.raw.end();
+  } else {
+    reply.status(200).send({
+      result: result?.result,
+    });
+  }
+}

--- a/packages/core/lib/v3/types/private/api.ts
+++ b/packages/core/lib/v3/types/private/api.ts
@@ -5,13 +5,15 @@ import {
   ExtractOptions,
   LogLine,
   ObserveOptions,
+  V3Options,
 } from "../public";
 import type { Protocol } from "devtools-protocol";
 import type { StagehandZodSchema } from "../../zodCompat";
 
 export interface StagehandAPIConstructorParams {
-  apiKey: string;
-  projectId: string;
+  apiKey?: string;
+  projectId?: string;
+  baseUrl?: string;
   logger: (message: LogLine) => void;
 }
 
@@ -21,11 +23,18 @@ export interface ExecuteActionParams {
   params?: unknown;
 }
 
-export interface StartSessionParams {
+export interface StartSessionParams extends Partial<V3Options> {
+  /**
+   * Optional external session identifier.
+   * When provided, StagehandServer will use this as the in-memory session id
+   * instead of generating a new UUID. This allows cloud environments to align
+   * library sessions with their own persisted session IDs (e.g. Browserbase).
+   */
+  sessionId?: string;
   modelName: string;
   modelApiKey: string;
   domSettleTimeoutMs: number;
-  verbose: number;
+  verbose: 0 | 1 | 2;
   systemPrompt?: string;
   browserbaseSessionCreateParams?: Omit<
     Browserbase.Sessions.SessionCreateParams,
@@ -33,12 +42,17 @@ export interface StartSessionParams {
   > & { projectId?: string };
   selfHeal?: boolean;
   browserbaseSessionID?: string;
+  waitForCaptchaSolves?: boolean;
+  experimental?: boolean;
+  // Cloud-specific metadata fields
+  debugDom?: boolean;
+  actTimeoutMs?: number;
+  clientLanguage?: string;
+  sdkVersion?: string;
 }
 
-export interface StartSessionResult {
-  sessionId: string;
-  available?: boolean;
-}
+// Re-export SessionStartResult from schemas (defined as Zod schema)
+export type { SessionStartResult } from "../../server/schemas";
 
 export interface SuccessResponse<T> {
   success: true;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,12 +5,23 @@
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./server": {
+      "import": "./dist/server.js",
+      "require": "./dist/server.js",
+      "types": "./dist/server.d.ts"
+    }
+  },
   "scripts": {
     "gen-version": "tsx scripts/gen-version.ts",
     "build-dom-scripts": "tsx lib/v3/dom/genDomScripts.ts && tsx lib/v3/dom/genLocatorScripts.ts",
-    "build-js": "tsup --entry.index lib/v3/index.ts --dts",
+    "build-js": "tsup --entry.index lib/v3/index.ts --entry.server lib/v3/server/index.ts --dts",
     "typecheck": "tsc --noEmit",
-    "prepare": "pnpm run build",
     "build": "pnpm run gen-version && pnpm run build-dom-scripts && pnpm run build-js && pnpm run typecheck",
     "example": "node --import tsx -e \"const args=process.argv.slice(1).filter(a=>a!=='--'); const [p]=args; const n=(p||'example').replace(/^\\.\\//,'').replace(/\\.ts$/i,''); import(new URL(require('node:path').resolve('examples', n + '.ts'), 'file:'));\" --",
     "test": "playwright test --config=lib/v3/tests/v3.playwright.config.ts",
@@ -24,6 +35,8 @@
   "files": [
     "dist/index.js",
     "dist/index.d.ts",
+    "dist/server.js",
+    "dist/server.d.ts",
     "dist/lib",
     "dist/types",
     "dist/stagehand.config.d.ts"
@@ -46,11 +59,14 @@
     "@ai-sdk/provider": "^2.0.0",
     "@anthropic-ai/sdk": "0.39.0",
     "@browserbasehq/sdk": "^2.4.0",
+    "@fastify/cors": "^10.0.1",
     "@google/genai": "^1.22.0",
     "@langchain/openai": "^0.4.4",
     "@modelcontextprotocol/sdk": "^1.17.2",
     "ai": "^5.0.0",
     "devtools-protocol": "^0.0.1464554",
+    "fastify": "^5.2.4",
+    "fastify-type-provider-zod": "^6.1.0",
     "fetch-cookie": "^3.1.0",
     "openai": "^4.87.1",
     "pino": "^9.6.0",
@@ -86,6 +102,7 @@
     "tsup": "^8.2.1",
     "tsx": "^4.10.5",
     "typescript": "^5.2.2",
+    "vite": "^5.4.10",
     "vitest": "^4.0.8",
     "zod": "3.25.76 || 4.1.8"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 9.25.1
       '@langchain/community':
         specifier: ^1.0.0
-        version: 1.0.0(@browserbasehq/sdk@2.5.0)(@browserbasehq/stagehand@3.0.3(bufferutil@4.0.9)(deepmerge@4.3.1)(dotenv@16.5.0)(zod@3.25.67))(@ibm-cloud/watsonx-ai@1.7.0)(@langchain/core@0.3.50(openai@6.7.0(ws@8.18.3(bufferutil@4.0.9))(zod@3.25.67)))(@opentelemetry/api@1.9.0)(cheerio@1.0.0)(google-auth-library@9.15.1)(ibm-cloud-sdk-core@5.4.3)(ignore@5.3.2)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@6.7.0(ws@8.18.3(bufferutil@4.0.9))(zod@3.25.67))(playwright@1.54.2)(puppeteer@22.15.0(bufferutil@4.0.9)(typescript@5.8.3))(ws@8.18.3(bufferutil@4.0.9))
+        version: 1.0.0(@browserbasehq/sdk@2.5.0)(@browserbasehq/stagehand@3.0.5(deepmerge@4.3.1)(dotenv@16.5.0)(zod@3.25.67))(@ibm-cloud/watsonx-ai@1.7.0)(@langchain/core@0.3.50(openai@6.7.0(ws@8.18.3(bufferutil@4.0.9))(zod@3.25.67)))(@opentelemetry/api@1.9.0)(cheerio@1.0.0)(google-auth-library@9.15.1)(ibm-cloud-sdk-core@5.4.3)(ignore@5.3.2)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@6.7.0(ws@8.18.3(bufferutil@4.0.9))(zod@3.25.67))(playwright@1.54.2)(puppeteer@22.15.0(bufferutil@4.0.9)(typescript@5.8.3))(ws@8.18.3(bufferutil@4.0.9))
       '@langchain/core':
         specifier: ^0.3.40
         version: 0.3.50(openai@6.7.0(ws@8.18.3(bufferutil@4.0.9))(zod@3.25.67))
@@ -67,7 +67,7 @@ importers:
         version: 1.2.0
       chromium-bidi:
         specifier: ^0.10.0
-        version: 0.10.2(devtools-protocol@0.0.1312386)
+        version: 0.10.2(devtools-protocol@0.0.1464554)
       esbuild:
         specifier: ^0.21.4
         version: 0.21.5
@@ -125,6 +125,9 @@ importers:
       '@browserbasehq/sdk':
         specifier: ^2.4.0
         version: 2.5.0
+      '@fastify/cors':
+        specifier: ^10.0.1
+        version: 10.1.0
       '@google/genai':
         specifier: ^1.22.0
         version: 1.24.0(@modelcontextprotocol/sdk@1.17.2)(bufferutil@4.0.9)
@@ -146,6 +149,12 @@ importers:
       dotenv:
         specifier: ^16.4.5
         version: 16.5.0
+      fastify:
+        specifier: ^5.2.4
+        version: 5.6.2
+      fastify-type-provider-zod:
+        specifier: ^6.1.0
+        version: 6.1.0(@fastify/swagger@9.6.1)(fastify@5.6.2)(openapi-types@12.1.3)(zod@4.1.8)
       fetch-cookie:
         specifier: ^3.1.0
         version: 3.1.0
@@ -167,31 +176,6 @@ importers:
       zod-to-json-schema:
         specifier: ^3.25.0
         version: 3.25.0(zod@4.1.8)
-    devDependencies:
-      '@playwright/test':
-        specifier: ^1.42.1
-        version: 1.54.2
-      eslint:
-        specifier: ^9.16.0
-        version: 9.25.1(jiti@1.21.7)
-      prettier:
-        specifier: ^3.2.5
-        version: 3.5.3
-      tsup:
-        specifier: ^8.2.1
-        version: 8.4.0(jiti@1.21.7)(postcss@8.5.6)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
-      tsx:
-        specifier: ^4.10.5
-        version: 4.19.4
-      typescript:
-        specifier: ^5.2.2
-        version: 5.8.3
-      vitest:
-        specifier: ^4.0.8
-        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.17.32)(jiti@1.21.7)(tsx@4.19.4)(yaml@2.7.1)
-      zod:
-        specifier: 3.25.76 || 4.1.8
-        version: 4.1.8
     optionalDependencies:
       '@ai-sdk/anthropic':
         specifier: ^2.0.34
@@ -247,6 +231,34 @@ importers:
       puppeteer-core:
         specifier: ^22.8.0
         version: 22.15.0(bufferutil@4.0.9)
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.42.1
+        version: 1.54.2
+      eslint:
+        specifier: ^9.16.0
+        version: 9.25.1(jiti@1.21.7)
+      prettier:
+        specifier: ^3.2.5
+        version: 3.5.3
+      tsup:
+        specifier: ^8.2.1
+        version: 8.4.0(jiti@1.21.7)(postcss@8.5.6)(tsx@4.19.4)(typescript@5.8.3)(yaml@2.7.1)
+      tsx:
+        specifier: ^4.10.5
+        version: 4.19.4
+      typescript:
+        specifier: ^5.2.2
+        version: 5.8.3
+      vite:
+        specifier: ^5.4.10
+        version: 5.4.21(@types/node@20.17.32)
+      vitest:
+        specifier: ^4.0.8
+        version: 4.0.8(@types/debug@4.1.12)(@types/node@20.17.32)(jiti@1.21.7)(tsx@4.19.4)(yaml@2.7.1)
+      zod:
+        specifier: 3.25.76 || 4.1.8
+        version: 4.1.8
 
   packages/docs:
     dependencies:
@@ -425,12 +437,12 @@ packages:
   '@browserbasehq/sdk@2.5.0':
     resolution: {integrity: sha512-bcnbYZvm5Ht1nrHUfWDK4crspiTy1ESJYMApsMiOTUnlKOan0ocRD6m7hZH34iSC2c2XWsoryR80cwsYgCBWzQ==}
 
-  '@browserbasehq/stagehand@3.0.3':
-    resolution: {integrity: sha512-O/9VgmOmIX4ZYuu2hgQ+7BmK8wkSgPX/kLzGQ/SJLCNYRW9yuU6/b4NRdFU5uJ7OlCKdEOcV1u4Cc4PhY67S0w==}
+  '@browserbasehq/stagehand@3.0.5':
+    resolution: {integrity: sha512-89QPlRKpfq8kJd8oGgodo5I39xDjEPwVIEvdjaICcU33X4yAtkvoR4lM2tEwGiiDu/BPQznB27JFgoGlMjUsTA==}
     peerDependencies:
       deepmerge: ^4.3.1
       dotenv: ^16.4.5
-      zod: 3.25.67
+      zod: 3.25.76 || 4.1.8
 
   '@cfworker/json-schema@4.1.1':
     resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
@@ -980,6 +992,30 @@ packages:
   '@eslint/plugin-kit@0.2.8':
     resolution: {integrity: sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@fastify/ajv-compiler@4.0.5':
+    resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
+
+  '@fastify/cors@10.1.0':
+    resolution: {integrity: sha512-MZyBCBJtII60CU9Xme/iE4aEy8G7QpzGR8zkdXZkDFt7ElEMachbE61tfhAG/bvSaULlqlf0huMT12T7iqEmdQ==}
+
+  '@fastify/error@4.2.0':
+    resolution: {integrity: sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==}
+
+  '@fastify/fast-json-stringify-compiler@5.0.3':
+    resolution: {integrity: sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==}
+
+  '@fastify/forwarded@3.0.1':
+    resolution: {integrity: sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==}
+
+  '@fastify/merge-json-schemas@0.2.1':
+    resolution: {integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==}
+
+  '@fastify/proxy-addr@5.1.0':
+    resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
+
+  '@fastify/swagger@9.6.1':
+    resolution: {integrity: sha512-fKlpJqFMWoi4H3EdUkDaMteEYRCfQMEkK0HJJ0eaf4aRlKd8cbq0pVkOfXDXmtvMTXYcnx3E+l023eFDBsA1HA==}
 
   '@google/genai@1.24.0':
     resolution: {integrity: sha512-e3jZF9Dx3dDaDCzygdMuYByHI2xJZ0PaD3r2fRgHZe2IOwBnmJ/Tu5Lt/nefTCxqr1ZnbcbQK9T13d8U/9UMWg==}
@@ -1747,6 +1783,7 @@ packages:
   '@mintlify/cli@4.0.682':
     resolution: {integrity: sha512-91XL+qCw9hm2KpMgKsNASIfUHYLhYwSmeoMRkE6p5Iy7P5dPAxJd+PUFPXdh4EGhMNALGRLHzm9rUoNvthM89w==}
     engines: {node: '>=18.0.0'}
+    deprecated: This version is deprecated. Please upgrade to version 4.0.423 or later.
     hasBin: true
 
   '@mintlify/common@1.0.496':
@@ -1810,6 +1847,9 @@ packages:
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
+
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -2375,6 +2415,9 @@ packages:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
 
+  abstract-logging@2.0.1:
+    resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
+
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
@@ -2568,6 +2611,9 @@ packages:
   avsc@5.7.7:
     resolution: {integrity: sha512-9cYNccliXZDByFsFliVwk5GvTq058Fj513CiR4E60ndDwmuXzTJEp/Bp8FyuRmGyYupLjHLs+JA9/CBoVS4/NQ==}
     engines: {node: '>=0.11'}
+
+  avvio@9.1.0:
+    resolution: {integrity: sha512-fYASnYi600CsH/j9EQov7lECAniYiBFiiAtBNuZYLA2leLe9qOvZzqYHFjtIj6gD2VMoMLP14834LFWvr4IfDw==}
 
   axios@1.13.0:
     resolution: {integrity: sha512-zt40Pz4zcRXra9CVV31KeyofwiNvAbJ5B6YPz9pMJ+yOSLikvPT4Yi5LjfgjRa9CawVYBaD1JQzIVcIvBejKeA==}
@@ -2940,6 +2986,10 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  cookie@1.0.2:
+    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
+    engines: {node: '>=18'}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -3459,6 +3509,9 @@ packages:
   fast-copy@3.0.2:
     resolution: {integrity: sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==}
 
+  fast-decode-uri-component@1.0.1:
+    resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -3472,11 +3525,17 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
+  fast-json-stringify@6.1.1:
+    resolution: {integrity: sha512-DbgptncYEXZqDUOEl4krff4mUiVrTZZVI7BBrQR/T3BqMj/eM1flTC1Uk2uUoLcWCxjT95xKulV/Lc6hhOZsBQ==}
+
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
   fast-memoize@2.5.2:
     resolution: {integrity: sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==}
+
+  fast-querystring@1.1.2:
+    resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
 
   fast-redact@3.5.0:
     resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
@@ -3487,6 +3546,20 @@ packages:
 
   fast-uri@3.0.6:
     resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
+
+  fastify-plugin@5.1.0:
+    resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
+
+  fastify-type-provider-zod@6.1.0:
+    resolution: {integrity: sha512-Sl19VZFSX4W/+AFl3hkL5YgWk3eDXZ4XYOdrq94HunK+o7GQBCAqgk7+3gPXoWkF0bNxOiIgfnFGJJ3i9a2BtQ==}
+    peerDependencies:
+      '@fastify/swagger': '>=9.5.1'
+      fastify: ^5.5.0
+      openapi-types: ^12.1.3
+      zod: '>=4.1.5'
+
+  fastify@5.6.2:
+    resolution: {integrity: sha512-dPugdGnsvYkBlENLhCgX8yhyGCsCPrpA8lFWbTNU428l+YOnLgYHR69hzV8HWPC79n536EqzqQtvhtdaCE0dKg==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -3543,6 +3616,10 @@ packages:
   finalhandler@2.1.0:
     resolution: {integrity: sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==}
     engines: {node: '>= 0.8'}
+
+  find-my-way@9.3.0:
+    resolution: {integrity: sha512-eRoFWQw+Yv2tuYlK2pjFS2jGXSxSppAs3hSQjfxVKxM5amECzIgYYc1FEI8ZmhSh/Ig+FrKEz43NLRKJjYCZVg==}
+    engines: {node: '>=20'}
 
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
@@ -3972,6 +4049,10 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
+  ipaddr.js@2.2.0:
+    resolution: {integrity: sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==}
+    engines: {node: '>= 10'}
+
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
 
@@ -4210,6 +4291,13 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
+  json-schema-ref-resolver@3.0.0:
+    resolution: {integrity: sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==}
+
+  json-schema-resolver@3.0.0:
+    resolution: {integrity: sha512-HqMnbz0tz2DaEJ3ntsqtx3ezzZyDE7G56A/pPY/NGmrPu76UzsWquOpHFRAf5beTNXoH2LU5cQePVvRli1nchA==}
+    engines: {node: '>=20'}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -4306,6 +4394,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  light-my-request@6.6.0:
+    resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
 
   lighthouse-logger@2.0.2:
     resolution: {integrity: sha512-vWl2+u5jgOQuZR55Z1WM0XDdrJT6mzMP8zHUct7xTlWhuQs+eV0g+QL0RQdFjT54zVmbhLCP8vIVpy1wGn/gCg==}
@@ -4664,6 +4755,7 @@ packages:
   mintlify@4.2.78:
     resolution: {integrity: sha512-g3naXSI7RsmxUNJ87mKzRefKaMdqbAhxfaPaMkApwmeDB0TROwwUO0CS6ZDsbV5Qq3Sm5kH4mEDieEpAE6JG8A==}
     engines: {node: '>=18.0.0'}
+    deprecated: This version is deprecated. Please upgrade to version 4.0.423 or later.
     hasBin: true
 
   mitt@3.0.1:
@@ -4695,6 +4787,9 @@ packages:
 
   ml-xsadd@3.0.1:
     resolution: {integrity: sha512-Fz2q6dwgzGM8wYKGArTUTZDGa4lQFA2Vi6orjGeTVRy22ZnQFKlJuwS9n8NRviqz1KHAHAzdKJwbnYhdo38uYg==}
+
+  mnemonist@0.40.0:
+    resolution: {integrity: sha512-kdd8AFNig2AD5Rkih7EPCXhu/iMvwevQFX/uEiGhZyPZi7fHqOoF4V4kHLpCfysxXMgQ4B52kdPMCwARshKvEg==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -4820,6 +4915,9 @@ packages:
   object.assign@4.1.7:
     resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
     engines: {node: '>= 0.4'}
+
+  obliterator@2.0.5:
+    resolution: {integrity: sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==}
 
   ollama-ai-provider-v2@1.5.0:
     resolution: {integrity: sha512-o8nR80AaENpetYdCtlnZGEwO47N6Z6eEsBetitrh4nTXrbfWdRF4OWE5p5oHyo0R8sxg4zdxUsjmGVzPd3zBUQ==}
@@ -5080,6 +5178,10 @@ packages:
   pino-std-serializers@7.0.0:
     resolution: {integrity: sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==}
 
+  pino@10.1.0:
+    resolution: {integrity: sha512-0zZC2ygfdqvqK8zJIr1e+wT1T/L+LF6qvqvbzEQ6tiMAoTqEVK9a1K3YRu8HEUvGEvNqZyPJTtb2sNIoTkB83w==}
+    hasBin: true
+
   pino@9.6.0:
     resolution: {integrity: sha512-i85pKRCt4qMjZ1+L7sy2Ag4t1atFcdbEt76+7iRJn1g2BvsnRMGu9p8pivl9fs63M2kF/A0OacFZhTub+m/qMg==}
     hasBin: true
@@ -5192,6 +5294,9 @@ packages:
 
   process-warning@4.0.1:
     resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==}
+
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
@@ -5430,6 +5535,10 @@ packages:
     resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  ret@0.5.0:
+    resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==}
+    engines: {node: '>=10'}
+
   retext-latin@4.0.0:
     resolution: {integrity: sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==}
 
@@ -5455,6 +5564,9 @@ packages:
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
   rollup@4.40.1:
     resolution: {integrity: sha512-C5VvvgCCyfyotVITIAv+4efVytl5F7wt+/I2i9q9GZcEXW9BP52YYOXC58igUi+LFZVHukErIIqQSWwv/M3WRw==}
@@ -5498,6 +5610,9 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
+  safe-regex2@5.0.0:
+    resolution: {integrity: sha512-YwJwe5a51WlK7KbOJREPdjNrpViQBI3p4T50lfwPuDhZnE3XGVTlGvi+aolc5+RvxDD6bnUmjVsU9n1eboLUYw==}
+
   safe-stable-stringify@1.1.1:
     resolution: {integrity: sha512-ERq4hUjKDbJfE4+XtZLFPCDi8Vb1JqaxAPTxWFLBx8XcAlf9Bda/ZJdVezs/NAfsMQScyIlUMx+Yeu7P7rx5jw==}
 
@@ -5520,6 +5635,9 @@ packages:
 
   secure-json-parse@2.7.0:
     resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
+
+  secure-json-parse@4.1.0:
+    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
   semver@7.7.1:
     resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
@@ -5867,6 +5985,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toad-cache@3.7.0:
+    resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
+    engines: {node: '>=12'}
+
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
@@ -6167,6 +6289,37 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
 
   vite@7.2.2:
     resolution: {integrity: sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==}
@@ -6743,7 +6896,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@browserbasehq/stagehand@3.0.3(bufferutil@4.0.9)(deepmerge@4.3.1)(dotenv@16.5.0)(zod@3.25.67)':
+  '@browserbasehq/stagehand@3.0.5(deepmerge@4.3.1)(dotenv@16.5.0)(zod@3.25.67)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@anthropic-ai/sdk': 0.39.0
@@ -6776,6 +6929,7 @@ snapshots:
       '@ai-sdk/togetherai': 1.0.23(zod@3.25.67)
       '@ai-sdk/xai': 2.0.26(zod@3.25.67)
       '@langchain/core': 0.3.50(openai@4.96.2(ws@8.18.3(bufferutil@4.0.9))(zod@3.25.67))
+      bufferutil: 4.0.9
       chrome-launcher: 1.2.0
       ollama-ai-provider-v2: 1.5.0(zod@3.25.67)
       patchright-core: 1.55.2
@@ -6783,7 +6937,6 @@ snapshots:
       puppeteer-core: 22.15.0(bufferutil@4.0.9)
     transitivePeerDependencies:
       - bare-buffer
-      - bufferutil
       - encoding
       - supports-color
       - utf-8-validate
@@ -7218,6 +7371,44 @@ snapshots:
       '@eslint/core': 0.13.0
       levn: 0.4.1
 
+  '@fastify/ajv-compiler@4.0.5':
+    dependencies:
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      fast-uri: 3.0.6
+
+  '@fastify/cors@10.1.0':
+    dependencies:
+      fastify-plugin: 5.1.0
+      mnemonist: 0.40.0
+
+  '@fastify/error@4.2.0': {}
+
+  '@fastify/fast-json-stringify-compiler@5.0.3':
+    dependencies:
+      fast-json-stringify: 6.1.1
+
+  '@fastify/forwarded@3.0.1': {}
+
+  '@fastify/merge-json-schemas@0.2.1':
+    dependencies:
+      dequal: 2.0.3
+
+  '@fastify/proxy-addr@5.1.0':
+    dependencies:
+      '@fastify/forwarded': 3.0.1
+      ipaddr.js: 2.2.0
+
+  '@fastify/swagger@9.6.1':
+    dependencies:
+      fastify-plugin: 5.1.0
+      json-schema-resolver: 3.0.0
+      openapi-types: 12.1.3
+      rfdc: 1.4.1
+      yaml: 2.7.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@google/genai@1.24.0(@modelcontextprotocol/sdk@1.17.2)(bufferutil@4.0.9)':
     dependencies:
       google-auth-library: 9.15.1
@@ -7514,9 +7705,9 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/community@1.0.0(@browserbasehq/sdk@2.5.0)(@browserbasehq/stagehand@3.0.3(bufferutil@4.0.9)(deepmerge@4.3.1)(dotenv@16.5.0)(zod@3.25.67))(@ibm-cloud/watsonx-ai@1.7.0)(@langchain/core@0.3.50(openai@6.7.0(ws@8.18.3(bufferutil@4.0.9))(zod@3.25.67)))(@opentelemetry/api@1.9.0)(cheerio@1.0.0)(google-auth-library@9.15.1)(ibm-cloud-sdk-core@5.4.3)(ignore@5.3.2)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@6.7.0(ws@8.18.3(bufferutil@4.0.9))(zod@3.25.67))(playwright@1.54.2)(puppeteer@22.15.0(bufferutil@4.0.9)(typescript@5.8.3))(ws@8.18.3(bufferutil@4.0.9))':
+  '@langchain/community@1.0.0(@browserbasehq/sdk@2.5.0)(@browserbasehq/stagehand@3.0.5(deepmerge@4.3.1)(dotenv@16.5.0)(zod@3.25.67))(@ibm-cloud/watsonx-ai@1.7.0)(@langchain/core@0.3.50(openai@6.7.0(ws@8.18.3(bufferutil@4.0.9))(zod@3.25.67)))(@opentelemetry/api@1.9.0)(cheerio@1.0.0)(google-auth-library@9.15.1)(ibm-cloud-sdk-core@5.4.3)(ignore@5.3.2)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@6.7.0(ws@8.18.3(bufferutil@4.0.9))(zod@3.25.67))(playwright@1.54.2)(puppeteer@22.15.0(bufferutil@4.0.9)(typescript@5.8.3))(ws@8.18.3(bufferutil@4.0.9))':
     dependencies:
-      '@browserbasehq/stagehand': 3.0.3(bufferutil@4.0.9)(deepmerge@4.3.1)(dotenv@16.5.0)(zod@3.25.67)
+      '@browserbasehq/stagehand': 3.0.5(deepmerge@4.3.1)(dotenv@16.5.0)(zod@3.25.67)
       '@ibm-cloud/watsonx-ai': 1.7.0
       '@langchain/classic': 1.0.0(@langchain/core@0.3.50(openai@6.7.0(ws@8.18.3(bufferutil@4.0.9))(zod@3.25.67)))(@opentelemetry/api@1.9.0)(cheerio@1.0.0)(openai@6.7.0(ws@8.18.3(bufferutil@4.0.9))(zod@3.25.67))(ws@8.18.3(bufferutil@4.0.9))
       '@langchain/core': 0.3.50(openai@6.7.0(ws@8.18.3(bufferutil@4.0.9))(zod@3.25.67))
@@ -8009,6 +8200,8 @@ snapshots:
       fast-deep-equal: 3.1.3
 
   '@opentelemetry/api@1.9.0': {}
+
+  '@pinojs/redact@0.4.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -8555,7 +8748,7 @@ snapshots:
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
-      semver: 7.7.1
+      semver: 7.7.2
       ts-api-utils: 2.1.0(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -8625,6 +8818,8 @@ snapshots:
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
+
+  abstract-logging@2.0.1: {}
 
   accepts@1.3.8:
     dependencies:
@@ -8817,6 +9012,11 @@ snapshots:
       possible-typed-array-names: 1.1.0
 
   avsc@5.7.7: {}
+
+  avvio@9.1.0:
+    dependencies:
+      '@fastify/error': 4.2.0
+      fastq: 1.19.1
 
   axios@1.13.0(debug@4.4.3):
     dependencies:
@@ -9105,9 +9305,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  chromium-bidi@0.10.2(devtools-protocol@0.0.1312386):
+  chromium-bidi@0.10.2(devtools-protocol@0.0.1464554):
     dependencies:
-      devtools-protocol: 0.0.1312386
+      devtools-protocol: 0.0.1464554
       mitt: 3.0.1
       zod: 3.23.8
 
@@ -9234,6 +9434,8 @@ snapshots:
   cookie@0.7.1: {}
 
   cookie@0.7.2: {}
+
+  cookie@1.0.2: {}
 
   core-util-is@1.0.3: {}
 
@@ -9924,6 +10126,8 @@ snapshots:
 
   fast-copy@3.0.2: {}
 
+  fast-decode-uri-component@1.0.1: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-fifo@1.3.2: {}
@@ -9938,15 +10142,56 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
+  fast-json-stringify@6.1.1:
+    dependencies:
+      '@fastify/merge-json-schemas': 0.2.1
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      fast-uri: 3.0.6
+      json-schema-ref-resolver: 3.0.0
+      rfdc: 1.4.1
+
   fast-levenshtein@2.0.6: {}
 
   fast-memoize@2.5.2: {}
+
+  fast-querystring@1.1.2:
+    dependencies:
+      fast-decode-uri-component: 1.0.1
 
   fast-redact@3.5.0: {}
 
   fast-safe-stringify@2.1.1: {}
 
   fast-uri@3.0.6: {}
+
+  fastify-plugin@5.1.0: {}
+
+  fastify-type-provider-zod@6.1.0(@fastify/swagger@9.6.1)(fastify@5.6.2)(openapi-types@12.1.3)(zod@4.1.8):
+    dependencies:
+      '@fastify/error': 4.2.0
+      '@fastify/swagger': 9.6.1
+      fastify: 5.6.2
+      openapi-types: 12.1.3
+      zod: 4.1.8
+
+  fastify@5.6.2:
+    dependencies:
+      '@fastify/ajv-compiler': 4.0.5
+      '@fastify/error': 4.2.0
+      '@fastify/fast-json-stringify-compiler': 5.0.3
+      '@fastify/proxy-addr': 5.1.0
+      abstract-logging: 2.0.1
+      avvio: 9.1.0
+      fast-json-stringify: 6.1.1
+      find-my-way: 9.3.0
+      light-my-request: 6.6.0
+      pino: 10.1.0
+      process-warning: 5.0.0
+      rfdc: 1.4.1
+      secure-json-parse: 4.1.0
+      semver: 7.7.2
+      toad-cache: 3.7.0
 
   fastq@1.19.1:
     dependencies:
@@ -10017,6 +10262,12 @@ snapshots:
       statuses: 2.0.1
     transitivePeerDependencies:
       - supports-color
+
+  find-my-way@9.3.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-querystring: 1.1.2
+      safe-regex2: 5.0.0
 
   find-up@4.1.0:
     dependencies:
@@ -10646,6 +10897,8 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
+  ipaddr.js@2.2.0: {}
+
   is-alphabetical@2.0.1: {}
 
   is-alphanumerical@2.0.1:
@@ -10862,6 +11115,18 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
+  json-schema-ref-resolver@3.0.0:
+    dependencies:
+      dequal: 2.0.3
+
+  json-schema-resolver@3.0.0:
+    dependencies:
+      debug: 4.4.3
+      fast-uri: 3.0.6
+      rfdc: 1.4.1
+    transitivePeerDependencies:
+      - supports-color
+
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
@@ -10942,7 +11207,7 @@ snapshots:
       console-table-printer: 2.12.1
       p-queue: 6.6.2
       p-retry: 4.6.2
-      semver: 7.7.1
+      semver: 7.7.2
       uuid: 10.0.0
     optionalDependencies:
       openai: 4.96.2(ws@8.18.3(bufferutil@4.0.9))(zod@3.25.67)
@@ -10955,7 +11220,7 @@ snapshots:
       console-table-printer: 2.12.1
       p-queue: 6.6.2
       p-retry: 4.6.2
-      semver: 7.7.1
+      semver: 7.7.2
       uuid: 10.0.0
     optionalDependencies:
       openai: 4.96.2(ws@8.18.3(bufferutil@4.0.9))(zod@4.1.8)
@@ -10967,7 +11232,7 @@ snapshots:
       console-table-printer: 2.12.1
       p-queue: 6.6.2
       p-retry: 4.6.2
-      semver: 7.7.1
+      semver: 7.7.2
       uuid: 10.0.0
     optionalDependencies:
       openai: 6.7.0(ws@8.18.3(bufferutil@4.0.9))(zod@3.25.67)
@@ -10998,6 +11263,12 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  light-my-request@6.6.0:
+    dependencies:
+      cookie: 1.0.2
+      process-warning: 4.0.1
+      set-cookie-parser: 2.7.1
 
   lighthouse-logger@2.0.2:
     dependencies:
@@ -11665,6 +11936,10 @@ snapshots:
 
   ml-xsadd@3.0.1: {}
 
+  mnemonist@0.40.0:
+    dependencies:
+      obliterator: 2.0.5
+
   mri@1.2.0: {}
 
   ms@2.0.0: {}
@@ -11772,6 +12047,8 @@ snapshots:
       es-object-atoms: 1.1.1
       has-symbols: 1.1.0
       object-keys: 1.1.1
+
+  obliterator@2.0.5: {}
 
   ollama-ai-provider-v2@1.5.0(zod@3.25.67):
     dependencies:
@@ -12093,6 +12370,20 @@ snapshots:
 
   pino-std-serializers@7.0.0: {}
 
+  pino@10.1.0:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pino-std-serializers: 7.0.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.0
+      thread-stream: 3.1.0
+
   pino@9.6.0:
     dependencies:
       atomic-sleep: 1.0.0
@@ -12180,6 +12471,8 @@ snapshots:
   process-nextick-args@2.0.1: {}
 
   process-warning@4.0.1: {}
+
+  process-warning@5.0.0: {}
 
   process@0.11.10: {}
 
@@ -12542,6 +12835,8 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
 
+  ret@0.5.0: {}
+
   retext-latin@4.0.0:
     dependencies:
       '@types/nlcst': 2.0.3
@@ -12574,6 +12869,8 @@ snapshots:
   retry@0.13.1: {}
 
   reusify@1.1.0: {}
+
+  rfdc@1.4.1: {}
 
   rollup@4.40.1:
     dependencies:
@@ -12672,6 +12969,10 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
+  safe-regex2@5.0.0:
+    dependencies:
+      ret: 0.5.0
+
   safe-stable-stringify@1.1.1: {}
 
   safe-stable-stringify@2.5.0: {}
@@ -12690,6 +12991,8 @@ snapshots:
       kind-of: 6.0.3
 
   secure-json-parse@2.7.0: {}
+
+  secure-json-parse@4.1.0: {}
 
   semver@7.7.1: {}
 
@@ -13178,6 +13481,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toad-cache@3.7.0: {}
+
   toidentifier@1.0.1: {}
 
   token-types@4.2.1:
@@ -13509,6 +13814,15 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
+
+  vite@5.4.21(@types/node@20.17.32):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.6
+      rollup: 4.53.2
+    optionalDependencies:
+      '@types/node': 20.17.32
+      fsevents: 2.3.3
 
   vite@7.2.2(@types/node@20.17.32)(jiti@1.21.7)(tsx@4.19.4)(yaml@2.7.1):
     dependencies:


### PR DESCRIPTION
## Stack Position
```
main
   └── pr/1-event-bus-infrastructure
         └── pr/2-api-schemas-openapi
               └── pr/3-session-store-p2p-server  ← THIS PR
                     └── pr/4-test-infrastructure
```

## What
Introduces a complete HTTP server implementation for peer-to-peer Stagehand communication, including session management abstraction and thin client support.

## Why
This enables two key capabilities:
1. **P2P Mode**: Run Stagehand as a server that remote SDK clients can connect to
2. **Cloud Compatibility**: The SessionStore interface allows cloud environments to provide database-backed implementations for stateless pod architectures

## How

### SessionStore Interface
- `SessionStore.ts`: Abstract interface for session lifecycle management
- `InMemorySessionStore.ts`: Default implementation with LRU eviction and TTL
- Supports lazy V3 instance creation and dynamic logger updates for streaming

### HTTP Server (Fastify)
- `server/index.ts`: Fastify server with Zod type provider for validation
- `server/stream.ts`: SSE streaming utilities for real-time log delivery
- Routes: `/sessions/start`, `/sessions/:id/{act,extract,observe,agentExecute,navigate,end}`
- `validateSession` pre-handler for session validation

### API Client Updates
- `api.ts`: Added `baseUrl` parameter, `STAGEHAND_API_URL` env support
- Can now connect to both cloud API and local P2P servers
- Auth headers only required for cloud mode

### V3 Core Changes
- `v3.ts`: Integrated event bus initialization, `createServer()` method
- `BROWSERBASE` env now always uses HTTP API client
- Removed `disableAPI` option (replaced by env/baseUrl routing)

### Package Updates
- New dependencies: `fastify`, `@fastify/cors`, `fastify-type-provider-zod`
- New export: `@browserbasehq/stagehand/server` subpath
- Build now generates `server.js` and `server.d.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a P2P HTTP server and a pluggable SessionStore to run Stagehand as a remote service and support cloud-friendly session persistence. Also updates the API client to route to cloud or local servers via baseUrl.

- **New Features**
  - Fastify server with Zod validation and SSE log streaming.
  - SessionStore interface with default in-memory LRU + TTL implementation.
  - Routes for session start, actions, and end under /sessions.
  - API client supports baseUrl and STAGEHAND_API_URL; works with cloud or local P2P.
  - V3 adds createServer() and event bus initialization; Browserbase always uses HTTP client.
  - New exports under @browserbasehq/stagehand/server.

- **Migration**
  - Use baseUrl or STAGEHAND_API_URL to select cloud vs local; auth headers only for cloud.
  - disableAPI option removed; switch to env/baseUrl routing.

<sup>Written for commit 15b72fc9795d5f3bbba8561a77bab6095c8f80ba. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

