### PR TITLE
find scrollable nodes using CDP

### DIFF
--- a/.changeset/open-birds-pull.md
+++ b/.changeset/open-birds-pull.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+use CDP to find scrollable nodes instead of injected JS

--- a/examples/external_clients/aisdk.ts
+++ b/examples/external_clients/aisdk.ts
@@ -364,7 +364,6 @@ export class AISdkClient extends LLMClient {
       },
     } as T;
 
-
     this.logger?.({
       category: "aisdk",
       message: "response",

--- a/types/context.ts
+++ b/types/context.ts
@@ -54,12 +54,14 @@ export type DOMNode = {
   contentDocument?: DOMNode;
   nodeType: number;
   frameId?: string;
+  isScrollable?: boolean;
 };
 
 export type BackendIdMaps = {
   tagNameMap: Record<number, string>;
   xpathMap: Record<number, string>;
   iframeXPath?: string;
+  scrollableBackendIds: Set<number>;
 };
 
 export interface EnhancedContext


### PR DESCRIPTION
# why
- using page.evaluate() with long running injected scripts is error prone
# what changed
- this PR changes `getAccessibilityTree()` to use CDP to find scrollable elements instead of finding them with injected JS
# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch scrollable-node detection to CDP to remove error-prone injected scripts, improving reliability of AX tree generation and role decoration.

- **Refactors**
  - Build scrollable element set via CDP DOM tree (records isScrollable; includes html fallback).
  - Remove injected-JS path and `findScrollableElementIds`; `decorateRoles` now uses backend IDs.
  - Update types with `isScrollable` on DOMNode and `scrollableBackendIds` in maps.

<sup>Written for commit 2551c7f904a82cee414ccb9d1f53ce704f5acc0e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

