### PR TITLE
add causedBy to `StagehandDefaultError`

### DIFF
--- a/.changeset/swift-hands-divide.md
+++ b/.changeset/swift-hands-divide.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+add causedBy to StagehandDefaultError

--- a/examples/external_clients/aisdk.ts
+++ b/examples/external_clients/aisdk.ts
@@ -364,7 +364,6 @@ export class AISdkClient extends LLMClient {
       },
     } as T;
 
-
     this.logger?.({
       category: "aisdk",
       message: "response",

--- a/types/stagehandErrors.ts
+++ b/types/stagehandErrors.ts
@@ -9,11 +9,14 @@ export class StagehandError extends Error {
 }
 
 export class StagehandDefaultError extends StagehandError {
+  public causedBy?: Error | StagehandError;
+
   constructor(error?: unknown) {
     if (error instanceof Error || error instanceof StagehandError) {
       super(
         `\nHey! We're sorry you ran into an error. \nStagehand version: ${STAGEHAND_VERSION} \nIf you need help, please open a Github issue or reach out to us on Slack: https://stagehand.dev/slack\n\nFull error:\n${error.message}`,
       );
+      this.causedBy = error;
     }
   }
 }


### PR DESCRIPTION
# why
- to show the full error stack
# what changed
- added causedBy to the stagehand default error class
# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds causedBy to StagehandDefaultError to retain the underlying error and make full stacks easier to debug.

- **New Features**
  - StagehandDefaultError now sets causedBy when constructed with Error or StagehandError.
  - Keeps existing message format; no breaking changes.

<sup>Written for commit ce21a9221115cf834f70e87d3d517865c95ea24c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

