### PR TITLE
export `getAccessibilityTree()` with deprecation warning

### DIFF
--- a/.changeset/whole-ducks-yell.md
+++ b/.changeset/whole-ducks-yell.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+export getAccessibilityTree()

--- a/lib/a11y/utils.ts
+++ b/lib/a11y/utils.ts
@@ -526,6 +526,9 @@ export async function getCDPFrameId(
  * Retrieve and build a cleaned accessibility tree for a document or specific iframe.
  * Prunes, formats, and optionally filters by XPath, including scrollable role decoration.
  *
+ * @deprecated This helper is an escape hatch intended for troubleshooting. Prefer
+ * extract() for supported usage and reach for this only
+ * when absolutely necessary.
  * @param stagehandPage - The StagehandPage instance for Playwright and CDP interaction.
  * @param logger - Logging function for diagnostics and performance metrics.
  * @param selector - Optional XPath to filter the AX tree to a specific subtree.

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1048,4 +1048,7 @@ export * from "../types/stagehandApiErrors";
 export * from "../types/stagehandErrors";
 export * from "./llm/LLMClient";
 export * from "./llm/aisdk";
+export type { TreeResult } from "../types/context";
 export { connectToMCPServer };
+/** @deprecated Direct AX access is not part of the stable API. Prefer extract(). */
+export { getAccessibilityTree } from "./a11y/utils";


### PR DESCRIPTION
# why
- to make this util available, but with a cautionary warning that `extract()` usage is the stable alternative
# what changed
- exported `getAccessibilityTree()` and its return type through `index.ts`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose getAccessibilityTree() in the public API for troubleshooting the AX tree, and export its TreeResult type. The helper is marked deprecated; prefer extract() for supported usage.

<sup>Written for commit 01f43da7b2d57efe7f223807b8c8068a3c6df43b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

