### PR TITLE
Add v2 Trusted Publisher releases

### DIFF
--- a/.changeset/wild-shoes-peel.md
+++ b/.changeset/wild-shoes-peel.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Update finding scrollable nodes using CDP

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - v2
 
 permissions:
   contents: write


### PR DESCRIPTION
# why

To allow releases of the v2 version of Stagehand using Trusted Publishers

# what changed

Changed `release.yml` to allow for merges of Version Packages (changeset) PRs on the `v2` branch

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables Trusted Publisher releases for the v2 branch and ships a patch improving scrollable node detection in Stagehand via CDP.

- **New Features**
  - Update release workflow to trigger on v2 branch, allowing changeset PR merges to publish via Trusted Publishers.

- **Bug Fixes**
  - Stagehand: improve finding scrollable nodes using CDP (patch).

<sup>Written for commit a366f04bab9a0bdba5d8590cb2a6f8a3fbd0555d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

