### PR TITLE
Version bump v2.5.4

### DIFF
--- a/.changeset/lucky-cycles-care.md
+++ b/.changeset/lucky-cycles-care.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Version bump to 2.5.4


### PR DESCRIPTION
# why
Trigger version bump `2.5.4`

# what changed

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped @browserbasehq/stagehand to 2.5.4 to publish a patch release. Added a changeset entry; no code changes.

<sup>Written for commit 151b4af3dc217383ee09cd40bdddbfe07ca9f861. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

