### PR TITLE
v2 release action fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -21,10 +22,14 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Node.js 20.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20.x
           registry-url: "https://registry.npmjs.org"
+
+      # Ensure npm 11.5.1 or later is installed for Trusted Publishing.
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: |
@@ -42,14 +47,11 @@ jobs:
           publish: pnpm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish Canary
         if: github.ref == 'refs/heads/main'
         run: |
-          pnpm config set //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
           git checkout main
           pnpm run release-canary
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
# why
Fix the v2 release process to use Trusted Publishers

# what changed

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the v2 release workflow to npm Trusted Publishing to fix broken releases. Adds OIDC support and updates tooling so releases no longer require an NPM token.

- **Bug Fixes**
  - Enable OIDC with id-token: write permission.
  - Upgrade actions/setup-node to v4 (Node 20.x).
  - Install latest npm (>=11.5.1) for Trusted Publishing.
  - Remove NODE_AUTH_TOKEN and pnpm registry auth; publishing relies on GITHUB_TOKEN via Trusted Publishers.

<sup>Written for commit 36c74a35b210064bdcb8d861b81bb10b7897cbc2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

