### PR TITLE
[docs]: rm incorrect example about parameterized agent workflow

### DIFF
--- a/packages/docs/v3/best-practices/deterministic-agent.mdx
+++ b/packages/docs/v3/best-practices/deterministic-agent.mdx
@@ -301,44 +301,7 @@ const stagehand = new Stagehand({
 ```
 
 ## Advanced Patterns
-
-### Parameterized Agent Workflows
-
-Use variables to make cached workflows reusable with different inputs:
-
-```typescript
-async function executeLogin(username: string, password: string) {
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    cacheDir: "cache/login"
-  });
-
-  await stagehand.init();
-  const page = stagehand.context.pages()[0];
-
-  await page.goto("https://example.com/login");
-
-  const agent = stagehand.agent({
-    model: "anthropic/claude-sonnet-4-20250514"
-  });
-
-  // Variables work with caching
-  const result = await agent.execute({
-    instruction: `Fill in username with "${username}" and password with "${password}", then click submit`,
-    maxSteps: 5
-  });
-
-  await stagehand.close();
-  return result.success;
-}
-
-// First user: Caches the workflow
-await executeLogin("user1@example.com", "password123");
-
-// Second user: Reuses cached workflow structure
-await executeLogin("user2@example.com", "differentpass");
-```
-
+ 
 ### Fallback to Fresh Exploration
 
 Combine caching with fallback for resilience:


### PR DESCRIPTION
great catch from @loic-carbonne
# why
- currently it is not possible to rerun a cached agent run with a different prompt
- therefore, this docs example is misleading
# what changed
- removed misleading example

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the incorrect docs example that suggested cached agent workflows can be reused with different inputs. This aligns the deterministic agent page with current behavior where each instruction generates a new cache key, so runs cannot be rerun with a different prompt.

<sup>Written for commit 490880534bbd37b80c2c27f2ed24395d0c578a44. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

