### PR TITLE
update invite link

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -20,7 +20,7 @@
       <img alt="MIT License" src="../../media/light_license.svg" />
     </picture>
   </a>
-  <a href="https://join.slack.com/t/stagehand-dev/shared_invite/zt-3hgv6bwqu-s7MXXgPd7_rD53aViGo1MQ">
+  <a href="https://join.slack.com/t/stagehand-dev/shared_invite/zt-3kg9piw3m-rxqCIzeuYQMXG315yHigPQ">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="../../media/dark_slack.svg" />
       <img alt="Slack Community" src="../../media/light_slack.svg" />
@@ -137,9 +137,9 @@ In your project's `package.json` set:
 ## Contributing
 
 > [!NOTE]  
-> We highly value contributions to Stagehand! For questions or support, please join our [Slack community](https://join.slack.com/t/stagehand-dev/shared_invite/zt-3hgv6bwqu-s7MXXgPd7_rD53aViGo1MQ).
+> We highly value contributions to Stagehand! For questions or support, please join our [Slack community](https://join.slack.com/t/stagehand-dev/shared_invite/zt-3kg9piw3m-rxqCIzeuYQMXG315yHigPQ).
 
-At a high level, we're focused on improving reliability, extensibility, speed, and cost in that order of priority. If you're interested in contributing, **bug fixes and small improvements are the best way to get started**. For more involved features, we strongly recommend reaching out to [Miguel Gonzalez](https://x.com/miguel_gonzf) or [Paul Klein](https://x.com/pk_iv) in our [Slack community](https://join.slack.com/t/stagehand-dev/shared_invite/zt-3hgv6bwqu-s7MXXgPd7_rD53aViGo1MQ) before starting to ensure that your contribution aligns with our goals.
+At a high level, we're focused on improving reliability, extensibility, speed, and cost in that order of priority. If you're interested in contributing, **bug fixes and small improvements are the best way to get started**. For more involved features, we strongly recommend reaching out to [Miguel Gonzalez](https://x.com/miguel_gonzf) or [Paul Klein](https://x.com/pk_iv) in our [Slack community](https://join.slack.com/t/stagehand-dev/shared_invite/zt-3kg9piw3m-rxqCIzeuYQMXG315yHigPQ) before starting to ensure that your contribution aligns with our goals.
 
 <!-- For more information, please see our [Contributing Guide](https://docs.stagehand.dev/examples/contributing). -->
 

--- a/packages/docs/v2/best-practices/contributing.mdx
+++ b/packages/docs/v2/best-practices/contributing.mdx
@@ -16,7 +16,7 @@ Any contribution must be explicitly approved by a codeowner. Officially, Stageha
 
 Special thanks to [Jeremy Press](https://github.com/jeremypress), [Navid Pour](https://github.com/navidkpr), and [all the contributors](https://github.com/browserbase/stagehand/graphs/contributors) for your help in making Stagehand the best browser automation framework.
 
-***Please do not hesitate to reach out to anyone listed here in the [public Slack channel](https://join.slack.com/t/stagehand-dev/shared_invite/zt-3hgv6bwqu-s7MXXgPd7_rD53aViGo1MQ)***
+***Please do not hesitate to reach out to anyone listed here in the [public Slack channel](https://join.slack.com/t/stagehand-dev/shared_invite/zt-3kg9piw3m-rxqCIzeuYQMXG315yHigPQ)***
 
 ## General Workflow
 


### PR DESCRIPTION
# why

our slack link expired 

# what changed

updated slack invite link 
# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the expired Slack invite link with a new working one. Updated the core README and contributing docs so contributors can join the community without broken links.

<sup>Written for commit 9f0b26219bbd1028195fc98164d9b2344ee93ca1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

