### PR TITLE
Fix error handling for empty Gemini API response

### DIFF
--- a/packages/core/lib/v3/agent/GoogleCUAClient.ts
+++ b/packages/core/lib/v3/agent/GoogleCUAClient.ts
@@ -324,6 +324,15 @@ export class GoogleCUAClient extends AgentClient {
             throw new LLMResponseError("agent", "Response has no candidates!");
           }
 
+          const candidate = response.candidates[0];
+          if (!candidate.content || !candidate.content.parts) {
+            const reason = candidate.finishReason || "unknown";
+            throw new LLMResponseError(
+              "agent",
+              `Response has no content (finish reason: ${reason})`,
+            );
+          }
+
           // Success - we have a valid response
           break;
         } catch (error) {
@@ -582,21 +591,6 @@ export class GoogleCUAClient extends AgentClient {
       };
     }
     const candidate = response.candidates[0];
-
-    if (!candidate.content || !candidate.content.parts) {
-      const reason = candidate.finishReason || "unknown";
-      logger({
-        category: "agent",
-        message: `No content in response. Finish reason: ${reason}`,
-        level: 0,
-      });
-      return {
-        actions: [],
-        message: `Response blocked or empty (reason: ${reason})`,
-        completed: true,
-        functionCalls: [],
-      };
-    }
 
     // Log the raw response for debugging
     logger({


### PR DESCRIPTION
# why

- Google CUA agent was crashing with `Cannot read properties of undefined (reading 'parts')`
- This can happen when the model's response is blocked due to safety filters, rate limiting, or other API-level issues

# what changed

- Added a null check for `candidate.content` and `candidate.content.parts` in `GoogleCUAClient.processResponse()`
- When content is missing, the agent now gracefully returns with the finishReason logged for debugging



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed crash in the Google CUA agent when Gemini returns an empty or blocked response. We now guard against missing content, log the finishReason, and return a safe, completed response with no actions or function calls.

<sup>Written for commit 53097572d7456f529c1e5fc982826ca45c520746. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



