### PR TITLE
Fix light mode for V3 banner

### DIFF
--- a/packages/docs/snippets/v3-banner.mdx
+++ b/packages/docs/snippets/v3-banner.mdx
@@ -1,11 +1,11 @@
 export const V3Banner = () => (
-  <div className="mb-5 flex items-center justify-between gap-4 rounded-md border border-zinc-700/50 bg-zinc-800/50 px-4 py-3 text-sm">
-    <span className="text-zinc-400">
-      🐍&nbsp;&nbsp;Looking for <strong className="text-zinc-200">Stagehand in Python</strong>?
+  <div className="mb-5 flex items-center justify-between gap-4 rounded-md border border-zinc-300 bg-zinc-100 dark:border-zinc-700/50 dark:bg-zinc-800/50 px-4 py-3 text-sm">
+    <span className="text-zinc-600 dark:text-zinc-400">
+      🐍&nbsp;&nbsp;Looking for <strong className="text-zinc-900 dark:text-zinc-200">Stagehand in Python</strong>?
     </span>
     <a 
       href="/v2/first-steps/introduction" 
-      className="text-zinc-400 hover:text-zinc-200 transition-colors no-underline text-xs"
+      className="text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-200 transition-colors no-underline text-xs"
     >
       Switch to v2 →
     </a>


### PR DESCRIPTION
# why

The banner was hard-coded for light mode only

# what changed

<img width="706" height="316" alt="image" src="https://github.com/user-attachments/assets/64fadf31-a96e-43ae-b435-7082db9b6a64" />

<img width="707" height="314" alt="image" src="https://github.com/user-attachments/assets/515ab34a-f040-4574-89bf-7c2d621a63e6" />

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the V3 docs banner to support light mode while preserving dark mode styling. Added light-theme border, background, and text colors with dark: variants and aligned link hover states to improve readability.

<sup>Written for commit 14ab04fe2f56e9454c1e21a6163bcd4abfb404db. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

