### PR TITLE
[v2]: deprecate `drawOverlay` param

### DIFF
--- a/.changeset/rich-cooks-rule.md
+++ b/.changeset/rich-cooks-rule.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+deprecate drawOverlay parameter in observe

--- a/lib/StagehandPage.ts
+++ b/lib/StagehandPage.ts
@@ -20,7 +20,6 @@ import { ActOptions, ActResult, GotoOptions, Stagehand } from "./index";
 import { LLMClient } from "./llm/LLMClient";
 import { StagehandContext } from "./StagehandContext";
 import { EncodedId, EnhancedContext } from "../types/context";
-import { clearOverlays } from "./utils";
 import {
   StagehandError,
   StagehandNotInitializedError,
@@ -700,8 +699,6 @@ export class StagehandPage {
         throw new HandlerNotInitializedError("Act");
       }
 
-      await clearOverlays(this.page);
-
       // If actionOrOptions is an ObserveResult, we call actFromObserveResult.
       // We need to ensure there is both a selector and a method in the ObserveResult.
       if (typeof actionOrOptions === "object" && actionOrOptions !== null) {
@@ -803,8 +800,6 @@ export class StagehandPage {
       if (!this.extractHandler) {
         throw new HandlerNotInitializedError("Extract");
       }
-
-      await clearOverlays(this.page);
 
       // check if user called extract() with no arguments
       if (!instructionOrOptions) {
@@ -932,8 +927,6 @@ export class StagehandPage {
       if (!this.observeHandler) {
         throw new HandlerNotInitializedError("Observe");
       }
-
-      await clearOverlays(this.page);
 
       const options: ObserveOptions =
         typeof instructionOrOptions === "string"

--- a/lib/handlers/observeHandler.ts
+++ b/lib/handlers/observeHandler.ts
@@ -3,7 +3,7 @@ import { Stagehand, StagehandFunctionName } from "../index";
 import { observe } from "../inference";
 import { LLMClient } from "../llm/LLMClient";
 import { StagehandPage } from "../StagehandPage";
-import { drawObserveOverlay, trimTrailingTextNode } from "../utils";
+import { trimTrailingTextNode } from "../utils";
 import {
   getAccessibilityTree,
   getAccessibilityTreeWithFrames,
@@ -56,6 +56,9 @@ export class StagehandObserveHandler {
      * @deprecated The `onlyVisible` parameter has no effect in this version of Stagehand and will be removed in later versions.
      */
     onlyVisible?: boolean;
+    /**
+     * @deprecated The `drawOverlay` parameter has no effect in this version of Stagehand and will be removed in later versions.
+     */
     drawOverlay?: boolean;
     fromAct?: boolean;
     iframes?: boolean;
@@ -69,6 +72,15 @@ export class StagehandObserveHandler {
         category: "observation",
         message:
           "Warning: the `onlyVisible` parameter has no effect in this version of Stagehand and will be removed in future versions.",
+        level: 1,
+      });
+    }
+
+    if (drawOverlay !== undefined) {
+      this.logger({
+        category: "observation",
+        message:
+          "Warning: the drawOverlay parameter has been deprecated and this parameter is now a no-op.",
         level: 1,
       });
     }
@@ -220,10 +232,6 @@ export class StagehandObserveHandler {
         },
       },
     });
-
-    if (drawOverlay) {
-      await drawObserveOverlay(this.stagehandPage.page, elementsWithSelectors);
-    }
 
     return elementsWithSelectors;
   }

--- a/types/stagehand.ts
+++ b/types/stagehand.ts
@@ -158,6 +158,9 @@ export interface ObserveOptions {
    * @deprecated The `onlyVisible` parameter has no effect in this version of Stagehand and will be removed in later versions.
    */
   onlyVisible?: boolean;
+  /**
+   * @deprecated The `drawOverlay` parameter has no effect in this version of Stagehand and will be removed in later versions.
+   */
   drawOverlay?: boolean;
   iframes?: boolean;
   frameId?: string;


### PR DESCRIPTION
# why
- this is largely unused, and often results in cryptic `page.evaluate()` errors
# what changed
- removed the `drawOverlay` param from observe
- removed the `clearOverlay()` and `drawObserveOverlay()` functions
- added a warning log stating that the parameter is now a no-op


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deprecated the observe drawOverlay option and removed overlay rendering to prevent frequent page.evaluate errors. The option is now a no-op and logs a warning when used.

- **Refactors**
  - Removed drawObserveOverlay and clearOverlays helpers; dropped overlay clearing calls from StagehandPage.
  - Observe handler logs a deprecation warning if drawOverlay is provided.
  - Updated types to mark drawOverlay as deprecated.

<sup>Written for commit c32483641fd3d86daaf5196606e5f8c7a904aabf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

