### PR TITLE
increase timeout in ci test

### DIFF
--- a/packages/core/lib/v3/tests/agent-abort-signal.spec.ts
+++ b/packages/core/lib/v3/tests/agent-abort-signal.spec.ts
@@ -89,7 +89,7 @@ test.describe("Stagehand agent abort signal", () => {
   });
 
   test("non-streaming: already aborted signal throws AgentAbortError immediately", async () => {
-    test.setTimeout(10000);
+    test.setTimeout(20000);
 
     const agent = v3.agent({
       model: "anthropic/claude-haiku-4-5-20251001",


### PR DESCRIPTION
# why

ci test failed due to timeout being hit on 1/3 ci runs 

unsure if this will fail again, but increasing delay to prevent in the future 

# what changed

increased timeout from 10s to 20s


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increased the test timeout from 10s to 20s in agent-abort-signal.spec to reduce CI flakiness and avoid false timeouts on slower runs.

<sup>Written for commit 8d3c41801e44b4021a1bad6f7027303c4637ad76. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

