### PR TITLE
prune screenshots from agent cache entry

### DIFF
--- a/.changeset/cool-otters-follow.md
+++ b/.changeset/cool-otters-follow.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+don't write base64 encoded screenshots to disk when caching agent actions


### PR DESCRIPTION
# why
- writing base64 screenshots to disk is unnecessary: screenshots do not get replayed, so there is no sense in writing it to disk
# what changed
- added a `pruneAgentResult()` fn which prunes the screenshot entry before it is written to disk
# test plan
- existing tests & evals should suffice for this one

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop writing base64 screenshots to the agent cache to reduce disk usage and keep cache entries lean. Screenshots aren’t replayed, so pruning them has no impact on behavior.

- **Refactors**
  - Added pruneAgentResult to remove screenshot base64 blobs from actions before persisting.
  - Prunes only the cached copy; the live AgentResult returned to callers is unchanged.

<sup>Written for commit 625f98253df533957011ccd1e7ef08e0376a652a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

