### PR TITLE
Update dotenv peer dependency version

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,7 @@
   "license": "MIT",
   "peerDependencies": {
     "deepmerge": "^4.3.1",
-    "dotenv": "^16.4.5",
+    "dotenv": "^17.2.3",
     "zod": "^3.25.76 || ^4.1.8"
   },
   "dependencies": {


### PR DESCRIPTION
Update dotenv peer dependency version

# why
The previous version causes conflicts with the new version projects

# what changed
dotenv dependency version from "^16.4.5" to "^17.2.3" 

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated dotenv peer dependency to ^17.2.3 to prevent conflicts with projects using dotenv v17. Ensures the core package remains compatible and resolves peers correctly.

<sup>Written for commit 4800f0d7c0fca3a0768ed46a16c3172ece5be932. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

