### PR TITLE
feat: enabling gpt 5.2

### DIFF
--- a/packages/core/lib/v3/llm/aisdk.ts
+++ b/packages/core/lib/v3/llm/aisdk.ts
@@ -129,7 +129,9 @@ export class AISdkClient extends LLMClient {
 
     let objectResponse: Awaited<ReturnType<typeof generateObject>>;
     const isGPT5 = this.model.modelId.includes("gpt-5");
-    const isGPT51 = this.model.modelId.includes("gpt-5.1");
+    const usesLowReasoningEffort =
+      this.model.modelId.includes("gpt-5.1") ||
+      this.model.modelId.includes("gpt-5.2");
     if (options.response_model) {
       // Log LLM request for generateObject (extract)
       const llmRequestId = uuidv7();
@@ -153,7 +155,7 @@ export class AISdkClient extends LLMClient {
             ? {
                 openai: {
                   textVerbosity: "low", // Making these the default for gpt-5 for now
-                  reasoningEffort: isGPT51 ? "low" : "minimal",
+                  reasoningEffort: usesLowReasoningEffort ? "low" : "minimal",
                 },
               }
             : undefined,

--- a/packages/evals/lib/AISdkClientWrapped.ts
+++ b/packages/evals/lib/AISdkClientWrapped.ts
@@ -133,7 +133,9 @@ export class AISdkClientWrapped extends LLMClient {
 
     let objectResponse: Awaited<ReturnType<typeof generateObject>>;
     const isGPT5 = this.model.modelId.includes("gpt-5");
-    const isGPT51 = this.model.modelId.includes("gpt-5.1");
+    const usesLowReasoningEffort =
+      this.model.modelId.includes("gpt-5.1") ||
+      this.model.modelId.includes("gpt-5.2");
     if (options.response_model) {
       try {
         objectResponse = await generateObject({
@@ -145,7 +147,7 @@ export class AISdkClientWrapped extends LLMClient {
             ? {
                 openai: {
                   textVerbosity: "low", // Making these the default for gpt-5 for now
-                  reasoningEffort: isGPT51 ? "low" : "minimal",
+                  reasoningEffort: usesLowReasoningEffort ? "low" : "minimal",
                 },
               }
             : undefined,


### PR DESCRIPTION
# why

new openai model

# what changed

the model requires the same reasoning format as gpt 5.1, which is configured here if the modelname is gpt-5.2

# test plan

ran evals


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable GPT-5.2 support and align its reasoning settings with GPT-5.1 for consistent behavior across GPT-5 models. This ensures stable outputs and easier model upgrades.

- **New Features**
  - Recognize gpt-5.2 in AISdkClient and AISdkClientWrapped.
  - Use reasoningEffort=low for gpt-5.1 and gpt-5.2; keep minimal for other gpt-5 variants.
  - Keep textVerbosity set to low for all gpt-5 models.

<sup>Written for commit c9ec278bd2b42c015f2db11fae1e80be5ad8d4e9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

