### PR TITLE
[docs] add link to Discord

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -225,14 +225,19 @@
     "global": {
       "anchors": [
         {
+          "anchor": "Discord",
+          "href": "https://discord.gg/stagehand",
+          "icon": "discord"
+        },
+        {
+          "anchor": "GitHub",
+          "href": "https://github.com/browserbase/stagehand",
+          "icon": "github"
+        },
+        {
           "anchor": "Changelog",
           "href": "https://github.com/browserbase/stagehand/releases",
           "icon": "scroll"
-        },
-        {
-          "anchor": "Stagehand by Browserbase",
-          "href": "https://docs.stagehand.dev/v3/first-steps/introduction",
-          "icon": "code"
         }
       ]
     }
@@ -245,6 +250,10 @@
   "navbar": {
     "links": [
       {
+        "label": "Discord",
+        "href": "https://discord.gg/stagehand"
+      },
+      {
         "label": "Support",
         "href": "mailto:support@browserbase.com"
       }
@@ -252,6 +261,7 @@
   },
   "footer": {
     "socials": {
+      "discord": "https://discord.gg/stagehand",
       "x": "https://x.com/stagehanddev",
       "github": "https://github.com/browserbase/stagehand",
       "linkedin": "https://linkedin.com/company/browserbasehq",


### PR DESCRIPTION
# why

We didn't have a link to our Discord

# what changed

<img width="289" height="245" alt="image" src="https://github.com/user-attachments/assets/d1e12f96-db02-4982-806f-fc45d6bb42fb" />

# test plan

n/a


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a Discord link across the docs (global anchors, navbar, footer) so users can quickly join the community. Also added a GitHub anchor and removed the outdated “Stagehand by Browserbase” link.

<sup>Written for commit fb5d5914e1951a5a76869aaccbcc7a3711928b49. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

