### PR TITLE
Clean up handlers and remove bus listeners on v3.close()

### DIFF
--- a/.changeset/orange-peaches-happen.md
+++ b/.changeset/orange-peaches-happen.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Cleanup handlers and bus listeners on close

--- a/packages/core/lib/v3/v3.ts
+++ b/packages/core/lib/v3/v3.ts
@@ -1374,6 +1374,17 @@ export class V3 {
       } catch {
         // ignore
       }
+      // Clear all event bus listeners to prevent memory leaks and hanging handlers
+      try {
+        this.bus.removeAllListeners();
+      } catch {
+        // ignore
+      }
+      // Clear accumulated data to free memory
+      this._history = [];
+      this.actHandler = null;
+      this.extractHandler = null;
+      this.observeHandler = null;
       // Remove from global registry
       V3._instances.delete(this);
     }


### PR DESCRIPTION
# why
With many concurrent sessions, memory leaks can crash the node process

# what changed
Ensured handler cleanup as well as removed eventbus listeners when calling `stagehand.close()`

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fully clean up V3 on close to prevent memory leaks and stuck handlers. We remove event bus listeners and clear local state during teardown.

- **Bug Fixes**
  - Remove all event bus listeners on close.
  - Reset act/extract/observe handlers and clear history.
  - Ensure instance is removed from the global registry.

<sup>Written for commit 6330dde9cf6fa2595b2bdd3e2eb3ef18a178919c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

