### PR TITLE
Fix parametrized 'model' api key auto-loading

### DIFF
--- a/.changeset/floppy-carpets-wish.md
+++ b/.changeset/floppy-carpets-wish.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Fix auto-load key for act/extract/observe parametrized models on api


### PR DESCRIPTION
# why
Auto-loading different provider api keys isn't working on parametrized act/extract/observe `model` string definitions

# what changed
  - Added prepareModelConfig helper method that ensures model configurations 
  include the appropriate API key                                            
  - When a model string or object is passed without an API key, the method:  
    - Uses the default modelApiKey if the provider matches the one from init 
    - Auto-loads the API key from environment variables (via                 
  `loadApiKeyFromEnv`) if the provider differs                                 
  - Applied the helper to `act`, `extract`, and `observe` methods  

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes API key auto-loading for parametrized model inputs in act, extract, and observe. Ensures the correct provider key is attached automatically, falling back to env vars when switching providers.

- **Bug Fixes**
  - Added prepareModelConfig to attach apiKey to model strings/objects.
  - Detects provider from modelName and uses loadApiKeyFromEnv when it differs from the initialized provider; otherwise uses the default modelApiKey.
  - Applied to act, extract, and observe option handling.

<sup>Written for commit 28d764bc5301eba38443f8c2bad30a45e3a2f475. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

