### PR TITLE
Update screenshot collector to use existing screenshots, handle events automagically & update evals to all use collector

### DIFF
--- a/packages/core/lib/v3/handlers/v3AgentHandler.ts
+++ b/packages/core/lib/v3/handlers/v3AgentHandler.ts
@@ -168,14 +168,11 @@ export class V3AgentHandler {
                 : allReasoning || "Task completed successfully";
             }
           }
-          // Intercept screenshot tool output for evals (hybrid mode only)
-          if (this.mode === "hybrid" && toolCall.toolName === "screenshot") {
-            const screenshotOutput = event.toolResults?.[i]?.output;
-            this.v3.bus.emit(
-              "agent_screensot_taken_event",
-              Buffer.from(screenshotOutput.base64, "base64"),
-            );
-          }
+          await this.captureAndEmitScreenshot({
+            toolName: toolCall.toolName,
+            toolOutput: event.toolResults?.[i]?.output
+          });
+
           const mappedActions = mapToolResultToActions({
             toolCallName: toolCall.toolName,
             toolResult,
@@ -190,11 +187,6 @@ export class V3AgentHandler {
           }
         }
         state.currentPageUrl = (await this.v3.context.awaitActivePage()).url();
-
-        // Capture screenshot after tool execution (only for evals, DOM mode)
-        if (process.env.EVALS === "true" && this.mode === "dom") {
-          await this.captureAndEmitScreenshot();
-        }
       }
 
       if (userCallback) {
@@ -489,12 +481,31 @@ export class V3AgentHandler {
   }
 
   /**
-   * Capture a screenshot and emit it via the event bus
+   * Capture a screenshot and emit it via the event bus.
+   * Handles both hybrid mode (uses existing screenshot from tool output) and DOM mode (captures fresh screenshot).
+   * Only runs when EVALS=true.
    */
-  private async captureAndEmitScreenshot(): Promise<void> {
+  private async captureAndEmitScreenshot(options: {
+    toolName: string;
+    toolOutput?: { base64?: string };
+  }): Promise<void> {
+    if (process.env.EVALS !== "true") {
+      return;
+    }
+
     try {
-      const page = await this.v3.context.awaitActivePage();
-      const screenshot = await page.screenshot({ fullPage: false });
+      let screenshot: Buffer;
+
+      if (this.mode === "hybrid") {
+        if (options.toolName !== "screenshot" || !options.toolOutput?.base64) {
+          return;
+        }
+        screenshot = Buffer.from(options.toolOutput.base64, "base64");
+      } else {
+        const page = await this.v3.context.awaitActivePage();
+        screenshot = await page.screenshot({ fullPage: false });
+      }
+
       this.v3.bus.emit("agent_screensot_taken_event", screenshot);
     } catch (error) {
       this.logger({

--- a/packages/core/lib/v3/handlers/v3AgentHandler.ts
+++ b/packages/core/lib/v3/handlers/v3AgentHandler.ts
@@ -170,7 +170,7 @@ export class V3AgentHandler {
           }
           await this.captureAndEmitScreenshot({
             toolName: toolCall.toolName,
-            toolOutput: event.toolResults?.[i]?.output
+            toolOutput: event.toolResults?.[i]?.output,
           });
 
           const mappedActions = mapToolResultToActions({

--- a/packages/core/lib/v3/handlers/v3AgentHandler.ts
+++ b/packages/core/lib/v3/handlers/v3AgentHandler.ts
@@ -506,7 +506,7 @@ export class V3AgentHandler {
         screenshot = await page.screenshot({ fullPage: false });
       }
 
-      this.v3.bus.emit("agent_screensot_taken_event", screenshot);
+      this.v3.bus.emit("agent_screenshot_taken_event", screenshot);
     } catch (error) {
       this.logger({
         category: "agent",

--- a/packages/core/lib/v3/handlers/v3CuaAgentHandler.ts
+++ b/packages/core/lib/v3/handlers/v3CuaAgentHandler.ts
@@ -557,7 +557,7 @@ export class V3CuaAgentHandler {
       const page = await this.v3.context.awaitActivePage();
       const base64Image = await page.screenshot({ fullPage: false });
       // Emit screenshot event via the bus
-      this.v3.bus.emit("agent_screensot_taken_event", base64Image);
+      this.v3.bus.emit("agent_screenshot_taken_event", base64Image);
       const currentUrl = page.url();
       return await this.agentClient.captureScreenshot({
         base64Image,

--- a/packages/evals/tasks/agent/alibaba_supplier_search.ts
+++ b/packages/evals/tasks/agent/alibaba_supplier_search.ts
@@ -15,7 +15,6 @@ export const alibaba_supplier_search: EvalFunction = async ({
 
     // Start collecting screenshots throughout the agent's journey
     const screenshotCollector = new ScreenshotCollector(v3, {
-      interval: 3000,
       maxScreenshots: 15,
     });
     screenshotCollector.start();

--- a/packages/evals/tasks/agent/amazon_shoes_cart.ts
+++ b/packages/evals/tasks/agent/amazon_shoes_cart.ts
@@ -15,7 +15,6 @@ export const amazon_shoes_cart: EvalFunction = async ({
 
     // Start collecting screenshots throughout the agent's journey
     const screenshotCollector = new ScreenshotCollector(v3, {
-      interval: 3000,
       maxScreenshots: 15,
     });
     screenshotCollector.start();

--- a/packages/evals/tasks/agent/apple_trade_in.ts
+++ b/packages/evals/tasks/agent/apple_trade_in.ts
@@ -1,6 +1,7 @@
 //this eval is expected to fail due to issues scrolling within the trade in dialog
 import { EvalFunction } from "../../types/evals";
 import { V3Evaluator } from "@browserbasehq/stagehand";
+import { ScreenshotCollector } from "../../utils/ScreenshotCollector";
 
 export const apple_trade_in: EvalFunction = async ({
   debugUrl,
@@ -12,19 +13,35 @@ export const apple_trade_in: EvalFunction = async ({
   try {
     const page = v3.context.pages()[0];
     await page.goto("https://www.apple.com/shop/trade-in");
-    const evaluator = new V3Evaluator(v3);
-    await agent.execute({
-      instruction:
-        "Find out the trade-in value for an iPhone 13 Pro Max in good condition on the Apple website.",
+
+    const screenshotCollector = new ScreenshotCollector(v3, {
+      maxScreenshots: 15,
+    });
+    screenshotCollector.start();
+
+    const instruction =
+      "Find out the trade-in value for an iPhone 13 Pro Max in good condition on the Apple website.";
+    const agentResult = await agent.execute({
+      instruction,
       maxSteps: Number(process.env.AGENT_EVAL_MAX_STEPS) || 30,
     });
 
-    const { evaluation, reasoning } = await evaluator.ask({
-      question:
-        "Did the agent find the trade-in value for an iPhone 13 Pro Max in good condition on the Apple website?",
-      screenshot: false,
-      answer: "360",
+    const screenshots = await screenshotCollector.stop();
+
+    logger.log({
+      category: "evaluation",
+      message: `Collected ${screenshots.length} screenshots for evaluation`,
+      level: 1,
     });
+
+    const evaluator = new V3Evaluator(v3);
+    const { evaluation, reasoning } = await evaluator.ask({
+      question: `did the agent complete this task successfully? ${instruction}`,
+      screenshot: screenshots,
+      agentReasoning: agentResult.message,
+    });
+
+    console.log(`reasoning: ${reasoning}`);
 
     const success = evaluation === "YES";
 
@@ -44,9 +61,10 @@ export const apple_trade_in: EvalFunction = async ({
       logs: logger.getLogs(),
     };
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       _success: false,
-      message: error.message,
+      message: errorMessage,
       debugUrl,
       sessionUrl,
       logs: logger.getLogs(),

--- a/packages/evals/tasks/agent/apple_tv.ts
+++ b/packages/evals/tasks/agent/apple_tv.ts
@@ -1,5 +1,6 @@
 import { EvalFunction } from "../../types/evals";
 import { V3Evaluator } from "@browserbasehq/stagehand";
+import { ScreenshotCollector } from "../../utils/ScreenshotCollector";
 
 export const apple_tv: EvalFunction = async ({
   debugUrl,
@@ -12,27 +13,41 @@ export const apple_tv: EvalFunction = async ({
     const page = v3.context.pages()[0];
     await page.goto("https://www.apple.com/");
 
+    const screenshotCollector = new ScreenshotCollector(v3, {
+      maxScreenshots: 15,
+    });
+    screenshotCollector.start();
+
+    const instruction =
+      "Identify the size and weight for the Apple TV 4K and list the Siri Remote features introduced.";
     const agentResult = await agent.execute({
-      instruction:
-        "Identify the size and weight for the Apple TV 4K and list the Siri Remote features introduced.",
+      instruction,
       maxSteps: Number(process.env.AGENT_EVAL_MAX_STEPS) || 50,
     });
 
-    const evaluator = new V3Evaluator(v3);
-    const result = await evaluator.ask({
-      question:
-        "did the agent find the height and width of the Apple TV 4K in its reasoning which is 1.2 and 3.66?",
-      answer: agentResult.message,
+    const screenshots = await screenshotCollector.stop();
+
+    logger.log({
+      category: "evaluation",
+      message: `Collected ${screenshots.length} screenshots for evaluation`,
+      level: 1,
     });
 
-    const url = page.url();
-    const success =
-      result.evaluation === "YES" &&
-      url.includes("https://www.apple.com/apple-tv-4k/specs/");
+    const evaluator = new V3Evaluator(v3);
+    const { evaluation, reasoning } = await evaluator.ask({
+      question: `did the agent complete this task successfully? ${instruction}`,
+      screenshot: screenshots,
+      agentReasoning: agentResult.message,
+    });
+
+    console.log(`reasoning: ${reasoning}`);
+
+    const success = evaluation === "YES";
+
     if (!success) {
       return {
         _success: false,
-        message: agentResult.message,
+        message: reasoning,
         debugUrl,
         sessionUrl,
         logs: logger.getLogs(),
@@ -45,9 +60,10 @@ export const apple_tv: EvalFunction = async ({
       logs: logger.getLogs(),
     };
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       _success: false,
-      message: error.message,
+      message: errorMessage,
       debugUrl,
       sessionUrl,
       logs: logger.getLogs(),

--- a/packages/evals/tasks/agent/arxiv_gpt_report.ts
+++ b/packages/evals/tasks/agent/arxiv_gpt_report.ts
@@ -1,6 +1,7 @@
 //agent often fails on this one,
 import { EvalFunction } from "../../types/evals";
 import { V3Evaluator } from "@browserbasehq/stagehand";
+import { ScreenshotCollector } from "../../utils/ScreenshotCollector";
 
 export const arxiv_gpt_report: EvalFunction = async ({
   debugUrl,
@@ -11,22 +12,33 @@ export const arxiv_gpt_report: EvalFunction = async ({
 }) => {
   try {
     const page = v3.context.pages()[0];
-    const evaluator = new V3Evaluator(v3);
     await page.goto("https://arxiv.org/");
 
-    await agent.execute({
-      instruction:
-        "Find the paper 'GPT-4 Technical Report', when was v3 submitted?",
+    const screenshotCollector = new ScreenshotCollector(v3, {
+      maxScreenshots: 15,
+    });
+    screenshotCollector.start();
+
+    const instruction =
+      "Find the paper 'GPT-4 Technical Report', when was v3 submitted?";
+    const agentResult = await agent.execute({
+      instruction,
       maxSteps: Number(process.env.AGENT_EVAL_MAX_STEPS) || 25,
     });
 
-    // Mon, 27 Mar 2023 17:46:54 UTC
+    const screenshots = await screenshotCollector.stop();
 
+    logger.log({
+      category: "evaluation",
+      message: `Collected ${screenshots.length} screenshots for evaluation`,
+      level: 1,
+    });
+
+    const evaluator = new V3Evaluator(v3);
     const { evaluation, reasoning } = await evaluator.ask({
-      question:
-        "Did the agent find the published paper 'GPT-4 Technical Report' and the date it was submitted?",
-      screenshot: false,
-      answer: "03-27-2023",
+      question: `did the agent complete this task successfully? ${instruction}`,
+      screenshot: screenshots,
+      agentReasoning: agentResult.message,
     });
 
     console.log(`reasoning: ${reasoning}`);
@@ -49,9 +61,10 @@ export const arxiv_gpt_report: EvalFunction = async ({
       logs: logger.getLogs(),
     };
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       _success: false,
-      message: error.message,
+      message: errorMessage,
       debugUrl,
       sessionUrl,
       logs: logger.getLogs(),

--- a/packages/evals/tasks/agent/columbia_tuition.ts
+++ b/packages/evals/tasks/agent/columbia_tuition.ts
@@ -15,7 +15,6 @@ export const columbia_tuition: EvalFunction = async ({
 
     // Start collecting screenshots throughout the agent's journey
     const screenshotCollector = new ScreenshotCollector(v3, {
-      interval: 3000,
       maxScreenshots: 15,
     });
     screenshotCollector.start();

--- a/packages/evals/tasks/agent/flipkart_laptops.ts
+++ b/packages/evals/tasks/agent/flipkart_laptops.ts
@@ -15,7 +15,6 @@ export const flipkart_laptops: EvalFunction = async ({
 
     // Start collecting screenshots throughout the agent's journey
     const screenshotCollector = new ScreenshotCollector(v3, {
-      interval: 3000,
       maxScreenshots: 15,
     });
     screenshotCollector.start();

--- a/packages/evals/tasks/agent/github.ts
+++ b/packages/evals/tasks/agent/github.ts
@@ -1,5 +1,6 @@
 import { EvalFunction } from "../../types/evals";
 import { V3Evaluator } from "@browserbasehq/stagehand";
+import { ScreenshotCollector } from "../../utils/ScreenshotCollector";
 
 export const github: EvalFunction = async ({
   debugUrl,
@@ -11,18 +12,35 @@ export const github: EvalFunction = async ({
   try {
     const page = v3.context.pages()[0];
     await page.goto("https://github.com/");
-    const evaluator = new V3Evaluator(v3);
+
+    const screenshotCollector = new ScreenshotCollector(v3, {
+      maxScreenshots: 15,
+    });
+    screenshotCollector.start();
+
+    const instruction =
+      "Find a Ruby repository on GitHub that has been updated in the past 3 days and has at least 1000 stars.";
     const agentResult = await agent.execute({
-      instruction:
-        "Find a Ruby repository on GitHub that has been updated in the past 3 days and has at least 1000 stars.",
+      instruction,
       maxSteps: Number(process.env.AGENT_EVAL_MAX_STEPS) || 20,
     });
-    logger.log(agentResult);
 
-    const { evaluation, reasoning } = await evaluator.ask({
-      question:
-        "Ruby repository on GitHub that has been updated in the past 3 days and has at least 1000 stars.",
+    const screenshots = await screenshotCollector.stop();
+
+    logger.log({
+      category: "evaluation",
+      message: `Collected ${screenshots.length} screenshots for evaluation`,
+      level: 1,
     });
+
+    const evaluator = new V3Evaluator(v3);
+    const { evaluation, reasoning } = await evaluator.ask({
+      question: `did the agent complete this task successfully? ${instruction}`,
+      screenshot: screenshots,
+      agentReasoning: agentResult.message,
+    });
+
+    console.log(`reasoning: ${reasoning}`);
 
     const success = evaluation === "YES";
 
@@ -35,7 +53,6 @@ export const github: EvalFunction = async ({
         logs: logger.getLogs(),
       };
     }
-
     return {
       _success: true,
       debugUrl,
@@ -43,9 +60,10 @@ export const github: EvalFunction = async ({
       logs: logger.getLogs(),
     };
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       _success: false,
-      error,
+      message: errorMessage,
       debugUrl,
       sessionUrl,
       logs: logger.getLogs(),

--- a/packages/evals/tasks/agent/github_react_version.ts
+++ b/packages/evals/tasks/agent/github_react_version.ts
@@ -1,5 +1,6 @@
 import { EvalFunction } from "../../types/evals";
 import { V3Evaluator } from "@browserbasehq/stagehand";
+import { ScreenshotCollector } from "../../utils/ScreenshotCollector";
 
 export const github_react_version: EvalFunction = async ({
   debugUrl,
@@ -10,21 +11,39 @@ export const github_react_version: EvalFunction = async ({
 }) => {
   try {
     const page = v3.context.pages()[0];
-    const evaluator = new V3Evaluator(v3);
     await page.goto("https://github.com/");
-    await agent.execute({
-      instruction:
-        "Check the latest release version of React and the date it was published. ",
+
+    const screenshotCollector = new ScreenshotCollector(v3, {
+      maxScreenshots: 15,
+    });
+    screenshotCollector.start();
+
+    const instruction =
+      "Check the latest release version of React and the date it was published.";
+    const agentResult = await agent.execute({
+      instruction,
       maxSteps: Number(process.env.AGENT_EVAL_MAX_STEPS) || 20,
     });
-    const { evaluation, reasoning } = await evaluator.ask({
-      question:
-        "Does the page show the latest version of react and the date it was published",
+
+    const screenshots = await screenshotCollector.stop();
+
+    logger.log({
+      category: "evaluation",
+      message: `Collected ${screenshots.length} screenshots for evaluation`,
+      level: 1,
     });
-    console.log(`evaluation: ${evaluation}`);
+
+    const evaluator = new V3Evaluator(v3);
+    const { evaluation, reasoning } = await evaluator.ask({
+      question: `did the agent complete this task successfully? ${instruction}`,
+      screenshot: screenshots,
+      agentReasoning: agentResult.message,
+    });
+
     console.log(`reasoning: ${reasoning}`);
-    // only use url check for now, as using extract on the version is prone to breaking in future
+
     const success = evaluation === "YES";
+
     if (!success) {
       return {
         _success: false,
@@ -41,9 +60,10 @@ export const github_react_version: EvalFunction = async ({
       logs: logger.getLogs(),
     };
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       _success: false,
-      message: error.message,
+      message: errorMessage,
       debugUrl,
       sessionUrl,
       logs: logger.getLogs(),

--- a/packages/evals/tasks/agent/google_maps.ts
+++ b/packages/evals/tasks/agent/google_maps.ts
@@ -1,5 +1,6 @@
 import { EvalFunction } from "../../types/evals";
 import { V3Evaluator } from "@browserbasehq/stagehand";
+import { ScreenshotCollector } from "../../utils/ScreenshotCollector";
 
 export const google_maps: EvalFunction = async ({
   debugUrl,
@@ -12,50 +13,57 @@ export const google_maps: EvalFunction = async ({
     const page = v3.context.pages()[0];
     await page.goto("https://maps.google.com");
 
+    const screenshotCollector = new ScreenshotCollector(v3, {
+      maxScreenshots: 15,
+    });
+    screenshotCollector.start();
+
+    const instruction =
+      "How long does it take to get from San Francisco to New York driving?";
     const agentResult = await agent.execute({
-      instruction:
-        "How long does it take to get from San Francisco to New York driving?",
+      instruction,
       maxSteps: Number(process.env.AGENT_EVAL_MAX_STEPS) || 15,
     });
-    logger.log(agentResult);
 
-    const evaluator = new V3Evaluator(v3);
-    const result = await evaluator.ask({
-      question:
-        "Does the page show the time it takes to drive from San Francisco to New York at all?",
+    const screenshots = await screenshotCollector.stop();
+
+    logger.log({
+      category: "evaluation",
+      message: `Collected ${screenshots.length} screenshots for evaluation`,
+      level: 1,
     });
 
-    if (result.evaluation !== "YES" && result.evaluation !== "NO") {
-      return {
-        _success: false,
-        observations: "Evaluator provided an invalid response",
-        debugUrl,
-        sessionUrl,
-        logs: logger.getLogs(),
-      };
-    }
+    const evaluator = new V3Evaluator(v3);
+    const { evaluation, reasoning } = await evaluator.ask({
+      question: `did the agent complete this task successfully? ${instruction}`,
+      screenshot: screenshots,
+      agentReasoning: agentResult.message,
+    });
 
-    if (result.evaluation === "YES") {
-      return {
-        _success: true,
-        observations: result.reasoning,
-        debugUrl,
-        sessionUrl,
-        logs: logger.getLogs(),
-      };
-    } else {
+    console.log(`reasoning: ${reasoning}`);
+
+    const success = evaluation === "YES";
+
+    if (!success) {
       return {
         _success: false,
-        observations: result.reasoning,
+        message: reasoning,
         debugUrl,
         sessionUrl,
         logs: logger.getLogs(),
       };
     }
+    return {
+      _success: true,
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       _success: false,
-      error: error,
+      message: errorMessage,
       debugUrl,
       sessionUrl,
       logs: logger.getLogs(),

--- a/packages/evals/tasks/agent/google_maps_2.ts
+++ b/packages/evals/tasks/agent/google_maps_2.ts
@@ -1,7 +1,6 @@
 import { EvalFunction } from "../../types/evals";
 import { V3Evaluator } from "@browserbasehq/stagehand";
-import type { AvailableModel } from "@browserbasehq/stagehand";
-import { z } from "zod";
+import { ScreenshotCollector } from "../../utils/ScreenshotCollector";
 
 export const google_maps_2: EvalFunction = async ({
   debugUrl,
@@ -14,68 +13,57 @@ export const google_maps_2: EvalFunction = async ({
     const page = v3.context.pages()[0];
     await page.goto("https://maps.google.com");
 
+    const screenshotCollector = new ScreenshotCollector(v3, {
+      maxScreenshots: 15,
+    });
+    screenshotCollector.start();
+
+    const instruction =
+      "Search for the fastest walking route from La Puerta de Alcalá to La Puerta del Sol";
     const agentResult = await agent.execute({
-      instruction:
-        "Search for the fastest walking route from La Puerta de Alcalá to La Puerta del Sol",
+      instruction,
       maxSteps: Number(process.env.AGENT_EVAL_MAX_STEPS) || 20,
     });
-    logger.log(agentResult);
+
+    const screenshots = await screenshotCollector.stop();
+
+    logger.log({
+      category: "evaluation",
+      message: `Collected ${screenshots.length} screenshots for evaluation`,
+      level: 1,
+    });
 
     const evaluator = new V3Evaluator(v3);
-    const result = await evaluator.ask({
-      question:
-        "Does the page show the fastest walking route from La Puerta de Alcalá to La Puerta del Sol? Does the distance between the two points show as 1.5 km?",
+    const { evaluation, reasoning } = await evaluator.ask({
+      question: `did the agent complete this task successfully? ${instruction}`,
+      screenshot: screenshots,
+      agentReasoning: agentResult.message,
     });
-    const { distance } = await v3.extract(
-      "Extract the distance for the fastest route walking to the decimal",
-      z.object({
-        distance: z
-          .number()
-          .describe("The distance between the two destinations in km"),
-      }),
-      { model: "google/gemini-2.5-flash" as AvailableModel },
-    );
 
-    if (result.evaluation !== "YES" && result.evaluation !== "NO") {
+    console.log(`reasoning: ${reasoning}`);
+
+    const success = evaluation === "YES";
+
+    if (!success) {
       return {
         _success: false,
-        observations: "Evaluator provided an invalid response",
+        message: reasoning,
         debugUrl,
         sessionUrl,
         logs: logger.getLogs(),
       };
     }
-
-    if (result.evaluation === "YES") {
-      if (distance <= 1.3 || distance >= 1.6) {
-        return {
-          _success: false,
-          observations: "Distance is not 1.5 km",
-          debugUrl,
-          sessionUrl,
-          logs: logger.getLogs(),
-        };
-      }
-      return {
-        _success: true,
-        observations: result.reasoning,
-        debugUrl,
-        sessionUrl,
-        logs: logger.getLogs(),
-      };
-    } else {
-      return {
-        _success: false,
-        observations: result.reasoning,
-        debugUrl,
-        sessionUrl,
-        logs: logger.getLogs(),
-      };
-    }
+    return {
+      _success: true,
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       _success: false,
-      error: error,
+      message: errorMessage,
       debugUrl,
       sessionUrl,
       logs: logger.getLogs(),

--- a/packages/evals/tasks/agent/google_maps_3.ts
+++ b/packages/evals/tasks/agent/google_maps_3.ts
@@ -1,5 +1,6 @@
 import { EvalFunction } from "../../types/evals";
 import { V3Evaluator } from "@browserbasehq/stagehand";
+import { ScreenshotCollector } from "../../utils/ScreenshotCollector";
 
 export const google_maps_3: EvalFunction = async ({
   debugUrl,
@@ -11,17 +12,35 @@ export const google_maps_3: EvalFunction = async ({
   try {
     const page = v3.context.pages()[0];
     await page.goto("https://maps.google.com/");
-    const evaluator = new V3Evaluator(v3);
-    await agent.execute({
-      instruction:
-        "Search for locksmiths open now but not open 24 hours in Texas City.",
+
+    const screenshotCollector = new ScreenshotCollector(v3, {
+      maxScreenshots: 15,
+    });
+    screenshotCollector.start();
+
+    const instruction =
+      "Search for locksmiths open now but not open 24 hours in Texas City.";
+    const agentResult = await agent.execute({
+      instruction,
       maxSteps: Number(process.env.AGENT_EVAL_MAX_STEPS) || 35,
     });
 
-    const { evaluation, reasoning } = await evaluator.ask({
-      question:
-        "Does the page show a locksmiths open now but not open 24 hours in Texas City?",
+    const screenshots = await screenshotCollector.stop();
+
+    logger.log({
+      category: "evaluation",
+      message: `Collected ${screenshots.length} screenshots for evaluation`,
+      level: 1,
     });
+
+    const evaluator = new V3Evaluator(v3);
+    const { evaluation, reasoning } = await evaluator.ask({
+      question: `did the agent complete this task successfully? ${instruction}`,
+      screenshot: screenshots,
+      agentReasoning: agentResult.message,
+    });
+
+    console.log(`reasoning: ${reasoning}`);
 
     const success = evaluation === "YES";
 
@@ -41,9 +60,10 @@ export const google_maps_3: EvalFunction = async ({
       logs: logger.getLogs(),
     };
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       _success: false,
-      message: error.message,
+      message: errorMessage,
       debugUrl,
       sessionUrl,
       logs: logger.getLogs(),

--- a/packages/evals/tasks/agent/hotels_paris_amenities.ts
+++ b/packages/evals/tasks/agent/hotels_paris_amenities.ts
@@ -15,7 +15,6 @@ export const hotels_paris_amenities: EvalFunction = async ({
 
     // Start collecting screenshots throughout the agent's journey
     const screenshotCollector = new ScreenshotCollector(v3, {
-      interval: 3000,
       maxScreenshots: 15,
     });
     screenshotCollector.start();

--- a/packages/evals/tasks/agent/hugging_face.ts
+++ b/packages/evals/tasks/agent/hugging_face.ts
@@ -1,5 +1,6 @@
 import { EvalFunction } from "../../types/evals";
 import { V3Evaluator } from "@browserbasehq/stagehand";
+import { ScreenshotCollector } from "../../utils/ScreenshotCollector";
 
 export const hugging_face: EvalFunction = async ({
   debugUrl,
@@ -9,25 +10,40 @@ export const hugging_face: EvalFunction = async ({
   v3,
 }) => {
   try {
-    const evaluator = new V3Evaluator(v3);
     const page = v3.context.pages()[0];
     await page.goto("https://huggingface.co/");
+
+    const screenshotCollector = new ScreenshotCollector(v3, {
+      maxScreenshots: 15,
+    });
+    screenshotCollector.start();
+
+    const instruction =
+      "Search for a model on Hugging Face with an Apache-2.0 license that has received the highest number of likes.";
     const agentResult = await agent.execute({
-      instruction:
-        "Search for a model on Hugging Face with an Apache-2.0 license that has received the highest number of likes.",
+      instruction,
       maxSteps: Number(process.env.AGENT_EVAL_MAX_STEPS) || 20,
     });
-    console.log(`agentResult: ${agentResult.message}`);
-    const { evaluation, reasoning } = await evaluator.ask({
-      question:
-        "Does the message mention 'kokoro-82m' or 'hexgrad/Kokoro-82M'?",
-      answer: agentResult.message || "",
-      screenshot: false,
+
+    const screenshots = await screenshotCollector.stop();
+
+    logger.log({
+      category: "evaluation",
+      message: `Collected ${screenshots.length} screenshots for evaluation`,
+      level: 1,
     });
+
+    const evaluator = new V3Evaluator(v3);
+    const { evaluation, reasoning } = await evaluator.ask({
+      question: `did the agent complete this task successfully? ${instruction}`,
+      screenshot: screenshots,
+      agentReasoning: agentResult.message,
+    });
+
+    console.log(`reasoning: ${reasoning}`);
 
     const success = evaluation === "YES";
 
-    console.log(`reasoning: ${reasoning}`);
     if (!success) {
       return {
         _success: false,
@@ -44,9 +60,10 @@ export const hugging_face: EvalFunction = async ({
       logs: logger.getLogs(),
     };
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       _success: false,
-      message: error.message,
+      message: errorMessage,
       debugUrl,
       sessionUrl,
       logs: logger.getLogs(),

--- a/packages/evals/tasks/agent/iframe_form.ts
+++ b/packages/evals/tasks/agent/iframe_form.ts
@@ -1,5 +1,6 @@
 import { EvalFunction } from "../../types/evals";
 import { V3Evaluator } from "@browserbasehq/stagehand";
+import { ScreenshotCollector } from "../../utils/ScreenshotCollector";
 
 export const iframe_form: EvalFunction = async ({
   debugUrl,
@@ -14,70 +15,57 @@ export const iframe_form: EvalFunction = async ({
       "https://browserbase.github.io/stagehand-eval-sites/sites/iframe-form-filling/",
     );
 
-    const agentResult = await agent.execute({
-      instruction: "Fill in the form name with 'John Smith'",
-      maxSteps: Number(process.env.AGENT_EVAL_MAX_STEPS) || 5,
+    const screenshotCollector = new ScreenshotCollector(v3, {
+      maxScreenshots: 15,
     });
-    logger.log(agentResult);
+    screenshotCollector.start();
+
+    const instruction =
+      "Fill in the form name with 'John Smith' and fill in the form email with 'john.smith@example.com'";
+    const agentResult = await agent.execute({
+      instruction,
+      maxSteps: Number(process.env.AGENT_EVAL_MAX_STEPS) || 10,
+    });
+
+    const screenshots = await screenshotCollector.stop();
+
+    logger.log({
+      category: "evaluation",
+      message: `Collected ${screenshots.length} screenshots for evaluation`,
+      level: 1,
+    });
 
     const evaluator = new V3Evaluator(v3);
-    const result = await evaluator.ask({
-      question: "Is the form name input filled with 'John Smith'?",
+    const { evaluation, reasoning } = await evaluator.ask({
+      question: `did the agent complete this task successfully? ${instruction}`,
+      screenshot: screenshots,
+      agentReasoning: agentResult.message,
     });
 
-    if (result.evaluation !== "YES" && result.evaluation !== "NO") {
+    console.log(`reasoning: ${reasoning}`);
+
+    const success = evaluation === "YES";
+
+    if (!success) {
       return {
         _success: false,
-        observations: "Evaluator provided an invalid response",
+        message: reasoning,
         debugUrl,
         sessionUrl,
         logs: logger.getLogs(),
       };
     }
-
-    const agentResult2 = await agent.execute({
-      instruction: "Fill in the form email with 'john.smith@example.com'",
-      maxSteps: Number(process.env.AGENT_EVAL_MAX_STEPS) || 3,
-    });
-    logger.log(agentResult2);
-
-    await page.scroll(0, 0, 0, -1000);
-    const result2 = await evaluator.ask({
-      question: "Is the form email input filled with 'john.smith@example.com'?",
-      screenshot: true,
-    });
-
-    if (result2.evaluation !== "YES" && result2.evaluation !== "NO") {
-      return {
-        _success: false,
-        observations: "Evaluator provided an invalid response",
-        debugUrl,
-        sessionUrl,
-        logs: logger.getLogs(),
-      };
-    }
-
-    if (result.evaluation === "YES" && result2.evaluation === "YES") {
-      return {
-        _success: true,
-        observations: "All fields were filled correctly",
-        debugUrl,
-        sessionUrl,
-        logs: logger.getLogs(),
-      };
-    } else {
-      return {
-        _success: false,
-        observations: "One or more fields were not filled correctly",
-        debugUrl,
-        sessionUrl,
-        logs: logger.getLogs(),
-      };
-    }
+    return {
+      _success: true,
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       _success: false,
-      error: error,
+      message: errorMessage,
       debugUrl,
       sessionUrl,
       logs: logger.getLogs(),

--- a/packages/evals/tasks/agent/iframe_form_multiple.ts
+++ b/packages/evals/tasks/agent/iframe_form_multiple.ts
@@ -1,5 +1,6 @@
 import { EvalFunction } from "../../types/evals";
 import { V3Evaluator } from "@browserbasehq/stagehand";
+import { ScreenshotCollector } from "../../utils/ScreenshotCollector";
 
 export const iframe_form_multiple: EvalFunction = async ({
   debugUrl,
@@ -14,57 +15,57 @@ export const iframe_form_multiple: EvalFunction = async ({
       "https://browserbase.github.io/stagehand-eval-sites/sites/iframe-form-filling/",
     );
 
+    const screenshotCollector = new ScreenshotCollector(v3, {
+      maxScreenshots: 15,
+    });
+    screenshotCollector.start();
+
+    const instruction =
+      "Fill in the form name with 'John Smith', the email with 'john.smith@example.com', and select the 'Are you the domain owner?' option as 'No'";
     const agentResult = await agent.execute({
-      instruction:
-        "Fill in the form name with 'John Smith', the email with 'john.smith@example.com', and select the 'Are you the domain owner?' option as 'No'",
+      instruction,
       maxSteps: Number(process.env.AGENT_EVAL_MAX_STEPS) || 10,
     });
-    logger.log(agentResult);
 
-    await page.scroll(0, 0, 0, -1000);
-    const evaluator = new V3Evaluator(v3);
-    const results = await evaluator.batchAsk({
-      questions: [
-        { question: "Is the form name input filled with 'John Smith'?" },
-        {
-          question:
-            "Is the form email input filled with 'john.smith@example.com'?",
-        },
-      ],
+    const screenshots = await screenshotCollector.stop();
+
+    logger.log({
+      category: "evaluation",
+      message: `Collected ${screenshots.length} screenshots for evaluation`,
+      level: 1,
     });
 
-    for (const r of results) {
-      if (r.evaluation !== "YES" && r.evaluation !== "NO") {
-        return {
-          _success: false,
-          observations: "Evaluator provided an invalid response",
-          debugUrl,
-          sessionUrl,
-          logs: logger.getLogs(),
-        };
-      }
-      if (r.evaluation === "NO") {
-        return {
-          _success: false,
-          observations: r.reasoning,
-          debugUrl,
-          sessionUrl,
-          logs: logger.getLogs(),
-        };
-      }
-    }
+    const evaluator = new V3Evaluator(v3);
+    const { evaluation, reasoning } = await evaluator.ask({
+      question: `did the agent complete this task successfully? ${instruction}`,
+      screenshot: screenshots,
+      agentReasoning: agentResult.message,
+    });
 
+    console.log(`reasoning: ${reasoning}`);
+
+    const success = evaluation === "YES";
+
+    if (!success) {
+      return {
+        _success: false,
+        message: reasoning,
+        debugUrl,
+        sessionUrl,
+        logs: logger.getLogs(),
+      };
+    }
     return {
       _success: true,
-      observations: "All fields were filled correctly",
       debugUrl,
       sessionUrl,
       logs: logger.getLogs(),
     };
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       _success: false,
-      error: error,
+      message: errorMessage,
       debugUrl,
       sessionUrl,
       logs: logger.getLogs(),

--- a/packages/evals/tasks/agent/instacart_organic_bananas.ts
+++ b/packages/evals/tasks/agent/instacart_organic_bananas.ts
@@ -15,7 +15,6 @@ export const instacart_organic_bananas: EvalFunction = async ({
 
     // Start collecting screenshots throughout the agent's journey
     const screenshotCollector = new ScreenshotCollector(v3, {
-      interval: 3000,
       maxScreenshots: 15,
     });
     screenshotCollector.start();

--- a/packages/evals/tasks/agent/kfc_tenders_combo.ts
+++ b/packages/evals/tasks/agent/kfc_tenders_combo.ts
@@ -15,7 +15,6 @@ export const kfc_tenders_combo: EvalFunction = async ({
 
     // Start collecting screenshots throughout the agent's journey
     const screenshotCollector = new ScreenshotCollector(v3, {
-      interval: 3000,
       maxScreenshots: 15,
     });
     screenshotCollector.start();

--- a/packages/evals/tasks/agent/made_in_china_supplier.ts
+++ b/packages/evals/tasks/agent/made_in_china_supplier.ts
@@ -15,7 +15,6 @@ export const made_in_china_supplier: EvalFunction = async ({
 
     // Start collecting screenshots throughout the agent's journey
     const screenshotCollector = new ScreenshotCollector(v3, {
-      interval: 3000,
       maxScreenshots: 15,
     });
     screenshotCollector.start();

--- a/packages/evals/tasks/agent/nvidia_hgx_driver.ts
+++ b/packages/evals/tasks/agent/nvidia_hgx_driver.ts
@@ -15,7 +15,6 @@ export const nvidia_hgx_driver: EvalFunction = async ({
 
     // Start collecting screenshots throughout the agent's journey
     const screenshotCollector = new ScreenshotCollector(v3, {
-      interval: 3000,
       maxScreenshots: 15,
     });
     screenshotCollector.start();

--- a/packages/evals/tasks/agent/oed_word_search.ts
+++ b/packages/evals/tasks/agent/oed_word_search.ts
@@ -15,7 +15,6 @@ export const oed_word_search: EvalFunction = async ({
 
     // Start collecting screenshots throughout the agent's journey
     const screenshotCollector = new ScreenshotCollector(v3, {
-      interval: 3000,
       maxScreenshots: 15,
     });
     screenshotCollector.start();

--- a/packages/evals/tasks/agent/onlineMind2Web.ts
+++ b/packages/evals/tasks/agent/onlineMind2Web.ts
@@ -50,7 +50,7 @@ export const onlineMind2Web: EvalFunction = async ({
     const screenshotHandler = (buffer: Buffer) => {
       screenshotCollector.addScreenshot(buffer);
     };
-    v3.bus.on("agent_screensot_taken_event", screenshotHandler);
+    v3.bus.on("agent_screenshot_taken_event", screenshotHandler);
 
     const agentResult = await agent.execute({
       instruction: params.confirmed_task,
@@ -58,7 +58,7 @@ export const onlineMind2Web: EvalFunction = async ({
     });
 
     // Stop collecting, clean up event listener, and get all screenshots
-    v3.bus.off("agent_screensot_taken_event", screenshotHandler);
+    v3.bus.off("agent_screenshot_taken_event", screenshotHandler);
     const screenshots = await screenshotCollector.stop();
 
     logger.log({

--- a/packages/evals/tasks/agent/onlineMind2Web.ts
+++ b/packages/evals/tasks/agent/onlineMind2Web.ts
@@ -41,24 +41,18 @@ export const onlineMind2Web: EvalFunction = async ({
       systemPrompt: `You are a helpful assistant that must solve the task by browsing. At the end, produce a single line: "Final Answer: <answer>" summarizing the requested result (e.g., score, list, or text). Current page: ${await page.title()}. ALWAYS OPERATE WITHIN THE PAGE OPENED BY THE USER, WHICHEVER TASK YOU ARE ATTEMPTING TO COMPLETE CAN BE ACCOMPLISHED WITHIN THE PAGE.`,
     });
 
-    // Set up event-driven screenshot collection via the V3 event bus
+    // Set up screenshot collection (automatically subscribes to agent events)
     const screenshotCollector = new ScreenshotCollector(v3, {
       maxScreenshots: 5,
     });
-
-    // Subscribe to screenshot events from the agent
-    const screenshotHandler = (buffer: Buffer) => {
-      screenshotCollector.addScreenshot(buffer);
-    };
-    v3.bus.on("agent_screenshot_taken_event", screenshotHandler);
+    screenshotCollector.start();
 
     const agentResult = await agent.execute({
       instruction: params.confirmed_task,
       maxSteps: Number(process.env.AGENT_EVAL_MAX_STEPS) || 50,
     });
 
-    // Stop collecting, clean up event listener, and get all screenshots
-    v3.bus.off("agent_screenshot_taken_event", screenshotHandler);
+    // Stop collecting and get all screenshots
     const screenshots = await screenshotCollector.stop();
 
     logger.log({

--- a/packages/evals/tasks/agent/radiotimes_tv_schedule.ts
+++ b/packages/evals/tasks/agent/radiotimes_tv_schedule.ts
@@ -15,7 +15,6 @@ export const radiotimes_tv_schedule: EvalFunction = async ({
 
     // Start collecting screenshots throughout the agent's journey
     const screenshotCollector = new ScreenshotCollector(v3, {
-      interval: 3000,
       maxScreenshots: 15,
     });
     screenshotCollector.start();

--- a/packages/evals/tasks/agent/redfin_apartment_rental.ts
+++ b/packages/evals/tasks/agent/redfin_apartment_rental.ts
@@ -15,7 +15,6 @@ export const redfin_apartment_rental: EvalFunction = async ({
 
     // Start collecting screenshots throughout the agent's journey
     const screenshotCollector = new ScreenshotCollector(v3, {
-      interval: 3000,
       maxScreenshots: 15,
     });
     screenshotCollector.start();

--- a/packages/evals/tasks/agent/sf_library_card.ts
+++ b/packages/evals/tasks/agent/sf_library_card.ts
@@ -1,5 +1,6 @@
 import { EvalFunction } from "../../types/evals";
 import { V3Evaluator } from "@browserbasehq/stagehand";
+import { ScreenshotCollector } from "../../utils/ScreenshotCollector";
 
 export const sf_library_card: EvalFunction = async ({
   debugUrl,
@@ -11,48 +12,58 @@ export const sf_library_card: EvalFunction = async ({
   try {
     const page = v3.context.pages()[0];
     await page.goto("https://sflib1.sfpl.org/selfreg");
+
+    const screenshotCollector = new ScreenshotCollector(v3, {
+      maxScreenshots: 15,
+    });
+    screenshotCollector.start();
+
+    const instruction =
+      "Fill in the 'street Address' field with '166 Geary St'";
     const agentResult = await agent.execute({
-      instruction: "Fill in the 'street Address' field with '166 Geary St'",
+      instruction,
       maxSteps: Number(process.env.AGENT_EVAL_MAX_STEPS) || 3,
     });
-    logger.log(agentResult);
-    const evaluator = new V3Evaluator(v3);
-    const result = await evaluator.ask({
-      question:
-        "Does the page show the 'street Address' field filled with '166 Geary St'?",
+
+    const screenshots = await screenshotCollector.stop();
+
+    logger.log({
+      category: "evaluation",
+      message: `Collected ${screenshots.length} screenshots for evaluation`,
+      level: 1,
     });
 
-    if (result.evaluation !== "YES" && result.evaluation !== "NO") {
-      return {
-        _success: false,
-        observations: "Evaluator provided an invalid response",
-        debugUrl,
-        sessionUrl,
-        logs: logger.getLogs(),
-      };
-    }
+    const evaluator = new V3Evaluator(v3);
+    const { evaluation, reasoning } = await evaluator.ask({
+      question: `did the agent complete this task successfully? ${instruction}`,
+      screenshot: screenshots,
+      agentReasoning: agentResult.message,
+    });
 
-    if (result.evaluation === "YES") {
-      return {
-        _success: true,
-        observations: result.reasoning,
-        debugUrl,
-        sessionUrl,
-        logs: logger.getLogs(),
-      };
-    } else {
+    console.log(`reasoning: ${reasoning}`);
+
+    const success = evaluation === "YES";
+
+    if (!success) {
       return {
         _success: false,
-        observations: result.reasoning,
+        message: reasoning,
         debugUrl,
         sessionUrl,
         logs: logger.getLogs(),
       };
     }
+    return {
+      _success: true,
+      debugUrl,
+      sessionUrl,
+      logs: logger.getLogs(),
+    };
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       _success: false,
-      error: error,
+      message: errorMessage,
       debugUrl,
       sessionUrl,
       logs: logger.getLogs(),

--- a/packages/evals/tasks/agent/thegamer_opinion_article.ts
+++ b/packages/evals/tasks/agent/thegamer_opinion_article.ts
@@ -15,7 +15,6 @@ export const thegamer_opinion_article: EvalFunction = async ({
 
     // Start collecting screenshots throughout the agent's journey
     const screenshotCollector = new ScreenshotCollector(v3, {
-      interval: 3000,
       maxScreenshots: 15,
     });
     screenshotCollector.start();

--- a/packages/evals/tasks/agent/trailhead_superbadge.ts
+++ b/packages/evals/tasks/agent/trailhead_superbadge.ts
@@ -15,7 +15,6 @@ export const trailhead_superbadge: EvalFunction = async ({
 
     // Start collecting screenshots throughout the agent's journey
     const screenshotCollector = new ScreenshotCollector(v3, {
-      interval: 3000,
       maxScreenshots: 15,
     });
     screenshotCollector.start();

--- a/packages/evals/tasks/agent/trustpilot_hr_companies.ts
+++ b/packages/evals/tasks/agent/trustpilot_hr_companies.ts
@@ -15,7 +15,6 @@ export const trustpilot_hr_companies: EvalFunction = async ({
 
     // Start collecting screenshots throughout the agent's journey
     const screenshotCollector = new ScreenshotCollector(v3, {
-      interval: 3000,
       maxScreenshots: 15,
     });
     screenshotCollector.start();

--- a/packages/evals/tasks/agent/uniqlo_mens_blazers.ts
+++ b/packages/evals/tasks/agent/uniqlo_mens_blazers.ts
@@ -15,7 +15,6 @@ export const uniqlo_mens_blazers: EvalFunction = async ({
 
     // Start collecting screenshots throughout the agent's journey
     const screenshotCollector = new ScreenshotCollector(v3, {
-      interval: 3000,
       maxScreenshots: 15,
     });
     screenshotCollector.start();

--- a/packages/evals/tasks/agent/webmd_audiologist_search.ts
+++ b/packages/evals/tasks/agent/webmd_audiologist_search.ts
@@ -15,7 +15,6 @@ export const webmd_audiologist_search: EvalFunction = async ({
 
     // Start collecting screenshots throughout the agent's journey
     const screenshotCollector = new ScreenshotCollector(v3, {
-      interval: 3000,
       maxScreenshots: 15,
     });
     screenshotCollector.start();

--- a/packages/evals/tasks/agent/webmd_ovulation_calculator.ts
+++ b/packages/evals/tasks/agent/webmd_ovulation_calculator.ts
@@ -15,7 +15,6 @@ export const webmd_ovulation_calculator: EvalFunction = async ({
 
     // Start collecting screenshots throughout the agent's journey
     const screenshotCollector = new ScreenshotCollector(v3, {
-      interval: 3000,
       maxScreenshots: 15,
     });
     screenshotCollector.start();

--- a/packages/evals/tasks/agent/webvoyager.ts
+++ b/packages/evals/tasks/agent/webvoyager.ts
@@ -45,7 +45,7 @@ export const webvoyager: EvalFunction = async ({
     const screenshotHandler = (buffer: Buffer) => {
       screenshotCollector.addScreenshot(buffer);
     };
-    v3.bus.on("agent_screensot_taken_event", screenshotHandler);
+    v3.bus.on("agent_screenshot_taken_event", screenshotHandler);
 
     const agentResult = await agent.execute({
       instruction: params.ques,
@@ -53,7 +53,7 @@ export const webvoyager: EvalFunction = async ({
     });
 
     // Clean up event listener and stop collecting
-    v3.bus.off("agent_screensot_taken_event", screenshotHandler);
+    v3.bus.off("agent_screenshot_taken_event", screenshotHandler);
     // Stop collecting and get all screenshots
     const screenshots = await screenshotCollector.stop();
 

--- a/packages/evals/tasks/agent/webvoyager.ts
+++ b/packages/evals/tasks/agent/webvoyager.ts
@@ -36,24 +36,17 @@ export const webvoyager: EvalFunction = async ({
       systemPrompt: `You are a helpful assistant that must solve the task by browsing. At the end, produce a single line: "Final Answer: <answer>" summarizing the requested result (e.g., score, list, or text). Current page: ${await page.title()}`,
     });
 
-    // Set up event-driven screenshot collection via the V3 event bus
+    // Set up screenshot collection (automatically subscribes to agent events)
     const screenshotCollector = new ScreenshotCollector(v3, {
       maxScreenshots: 7,
     });
-
-    // Subscribe to screenshot events from the agent
-    const screenshotHandler = (buffer: Buffer) => {
-      screenshotCollector.addScreenshot(buffer);
-    };
-    v3.bus.on("agent_screenshot_taken_event", screenshotHandler);
+    screenshotCollector.start();
 
     const agentResult = await agent.execute({
       instruction: params.ques,
       maxSteps: Number(process.env.AGENT_EVAL_MAX_STEPS) || 50,
     });
 
-    // Clean up event listener and stop collecting
-    v3.bus.off("agent_screenshot_taken_event", screenshotHandler);
     // Stop collecting and get all screenshots
     const screenshots = await screenshotCollector.stop();
 

--- a/packages/evals/tasks/agent/youtube.ts
+++ b/packages/evals/tasks/agent/youtube.ts
@@ -1,4 +1,6 @@
 import { EvalFunction } from "../../types/evals";
+import { V3Evaluator } from "@browserbasehq/stagehand";
+import { ScreenshotCollector } from "../../utils/ScreenshotCollector";
 
 export const youtube: EvalFunction = async ({
   debugUrl,
@@ -11,35 +13,57 @@ export const youtube: EvalFunction = async ({
     const page = v3.context.pages()[0];
     await page.goto("https://youtube.com");
 
+    const screenshotCollector = new ScreenshotCollector(v3, {
+      maxScreenshots: 15,
+    });
+    screenshotCollector.start();
+
+    const instruction =
+      "Search for Keinemusik's set under some very famous pointy landmarks. Make sure to click on the video";
     const agentResult = await agent.execute({
-      instruction:
-        "Search for Keinemusik's set under some very famous pointy landmarks. Make sure to click on the video",
+      instruction,
       maxSteps: Number(process.env.AGENT_EVAL_MAX_STEPS) || 15,
     });
-    logger.log(agentResult);
-    const url = page.url();
 
-    if (url.includes("https://www.youtube.com/watch?v=eEobh8iCbIE")) {
+    const screenshots = await screenshotCollector.stop();
+
+    logger.log({
+      category: "evaluation",
+      message: `Collected ${screenshots.length} screenshots for evaluation`,
+      level: 1,
+    });
+
+    const evaluator = new V3Evaluator(v3);
+    const { evaluation, reasoning } = await evaluator.ask({
+      question: `did the agent complete this task successfully? ${instruction}`,
+      screenshot: screenshots,
+      agentReasoning: agentResult.message,
+    });
+
+    console.log(`reasoning: ${reasoning}`);
+
+    const success = evaluation === "YES";
+
+    if (!success) {
       return {
-        _success: true,
-        observations: url,
+        _success: false,
+        message: reasoning,
         debugUrl,
         sessionUrl,
         logs: logger.getLogs(),
       };
     }
-
     return {
-      _success: false,
-      observations: url,
+      _success: true,
       debugUrl,
       sessionUrl,
       logs: logger.getLogs(),
     };
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       _success: false,
-      error: error,
+      message: errorMessage,
       debugUrl,
       sessionUrl,
       logs: logger.getLogs(),

--- a/packages/evals/types/screenshotCollector.ts
+++ b/packages/evals/types/screenshotCollector.ts
@@ -7,10 +7,3 @@ export interface ScreenshotCollectorOptions {
   interval?: number;
   maxScreenshots?: number;
 }
-
-// Minimal page-like interface: supports screenshot() and optional event hooks
-export type ScreenshotCapablePage = {
-  screenshot: (...args: []) => Promise<Buffer | string>;
-  on?: (event: string, listener: (...args: []) => void) => void;
-  off?: (event: string, listener: (...args: []) => void) => void;
-};


### PR DESCRIPTION
# why

- Currently, when using screenshot collector with hybrid mode, it takes a new screenshot on every step
- we have outdated evals which are flaky, and less reliably than screenshot collector based ones 
- screenshot collector currently requires manually handling the events in the file it is defined within


# what changed

- now, we just pass the screenshot taken by agent, directly into the collector when hybrid mode is used. 
- for dom mode, we still take on every step as a non vision model is much more likely to take its own screenshots 
- removed dead code from screenshot collector type 
- moved event handling for screenshot collector into the collector.
- removed timeout from all evals, so they utilize only event images 
- updated all non screenshot collector evals to utilize them, and fixed two evals which would throw false negatives ( apple_tv & nba trades) 
# test plan










<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use agent-provided screenshots in hybrid mode to stop duplicate captures and reduce eval overhead. The screenshot collector now auto-subscribes to agent events, and all evals were updated to use it.

- **Refactors**
  - Hybrid: forward screenshot tool output directly to the collector (no new page screenshot).
  - DOM (evals only): still capture after each tool execution.
  - Collector: automatically handles bus events; optional interval capture remains.
  - Evals: switched to event-driven collector, removed manual listeners, and pass screenshots to the evaluator.
  - Removed unused ScreenshotCapablePage type.

- **Bug Fixes**
  - Corrected event name to agent_screenshot_taken_event.

<sup>Written for commit d9d5e26d3dd29365c0a63316bf9cad806414d29c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->











