### PR TITLE
Add duplicate issue detection bot

### DIFF
--- a/.github/workflows/duplicate_issue_detection.yml
+++ b/.github/workflows/duplicate_issue_detection.yml
@@ -1,0 +1,58 @@
+name: Duplicate Issue Detection
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  check-duplicates:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install opencode
+        run: curl -fsSL https://opencode.ai/install | bash
+
+      - name: Check for duplicate issues
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENCODE_PERMISSION: |
+            {
+              "bash": {
+                "gh issue*": "allow",
+                "*": "deny"
+              },
+              "webfetch": "deny"
+            }
+        run: |
+          opencode run -m opencode/claude-haiku-4-5 "A new issue has been created:'
+
+          Issue number:
+          ${{ github.event.issue.number }}
+
+          Lookup this issue and search through existing issues (excluding #${{ github.event.issue.number }}) in this repository to find any potential duplicates of this new issue.
+          Consider:
+          1. Similar titles or descriptions
+          2. Same error messages or symptoms
+          3. Related functionality or components
+          4. Similar feature requests
+
+          If you find any potential duplicates, please comment on the new issue with:
+          - A brief explanation of why it might be a duplicate
+          - Links to the potentially duplicate issues
+          - A suggestion to check those issues first
+
+          Use this format for the comment:
+          'This issue might be a duplicate of existing issues. Please check:
+          - #[issue_number]: [brief description of similarity]
+
+          Feel free to ignore if none of these address your specific case.'
+
+          If no clear duplicates are found, do not comment."

--- a/.github/workflows/duplicate_issue_detection.yml
+++ b/.github/workflows/duplicate_issue_detection.yml
@@ -32,7 +32,7 @@ jobs:
               "webfetch": "deny"
             }
         run: |
-          opencode run -m opencode/claude-haiku-4-5 "A new issue has been created:'
+          opencode run -m anthropic/claude-haiku-4-5 "A new issue has been created:'
 
           Issue number:
           ${{ github.event.issue.number }}

--- a/.github/workflows/duplicate_issue_detection.yml
+++ b/.github/workflows/duplicate_issue_detection.yml
@@ -37,7 +37,7 @@ jobs:
           Issue number:
           ${{ github.event.issue.number }}
 
-          Lookup this issue and search through existing issues (excluding #${{ github.event.issue.number }}) in this repository to find any potential duplicates of this new issue.
+          Lookup this issue and search through existing issues and PRs (excluding #${{ github.event.issue.number }}) in this repository to find any potential duplicates of this new issue.
           Consider:
           1. Similar titles or descriptions
           2. Same error messages or symptoms
@@ -46,7 +46,7 @@ jobs:
 
           If you find any potential duplicates, please comment on the new issue with:
           - A brief explanation of why it might be a duplicate
-          - Links to the potentially duplicate issues
+          - Links to the potentially duplicate issues or PRs
           - A suggestion to check those issues first
 
           Use this format for the comment:

--- a/.github/workflows/duplicate_issue_detection.yml
+++ b/.github/workflows/duplicate_issue_detection.yml
@@ -27,6 +27,7 @@ jobs:
             {
               "bash": {
                 "gh issue*": "allow",
+                "gh pr*": "allow",
                 "*": "deny"
               },
               "webfetch": "deny"

--- a/.github/workflows/duplicate_issue_detection.yml
+++ b/.github/workflows/duplicate_issue_detection.yml
@@ -32,7 +32,7 @@ jobs:
               "webfetch": "deny"
             }
         run: |
-          opencode run -m anthropic/claude-haiku-4-5 "A new issue has been created:'
+          opencode run -m anthropic/claude-haiku-4-5 "A new issue has been created:
 
           Issue number:
           ${{ github.event.issue.number }}


### PR DESCRIPTION
# why

Duplicate issues take up a lot of review time for us to find and link them together.

# what changed

This bot will leave comments like this on new issues when dupes are found:

<img width="983" height="503" alt="image" src="https://github.com/user-attachments/assets/0d4b0356-e200-48b4-ba1a-ee3c10850506" />









<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Action that scans new issues for potential duplicates across issues and PRs, and comments with links when matches are found. This helps reduce triage time by flagging dupes at creation.

- **New Features**
  - New workflow triggers on issues.opened.
  - Searches existing issues and PRs for similar titles/descriptions and symptoms.
  - Posts one comment with brief reasoning and links; stays silent if none found.
  - Uses minimal GitHub permissions (contents: read, issues: write) and scoped opencode commands.

<sup>Written for commit 8ef0fb9e4f3314d850b828b4805f504bd621c574. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









