### PR TITLE
remove base64 from agent actions array

### DIFF
--- a/.changeset/forty-bugs-tap.md
+++ b/.changeset/forty-bugs-tap.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Remove base64 from agent actions array ( still present in messages object )

--- a/packages/core/lib/v3/agent/utils/actionMapping.ts
+++ b/packages/core/lib/v3/agent/utils/actionMapping.ts
@@ -100,7 +100,7 @@ function createStandardAction(
   };
 
   // For screenshot tool, exclude base64 data and just indicate a screenshot was taken,
-  // if somebody really wants the base64 daya, they can access it through messages
+  // if somebody really wants the base64 data, they can access it through messages
   if (toolCallName === "screenshot") {
     action.result = "screenshotTaken";
     return action;


### PR DESCRIPTION
# why

currently, the base64 is displayed within the action array of the result making it very hard to read

# what changed

- replace base64 of screenshot tool call with a string "screenshot taken" 
- base64's can still be accessed from message object returned in result, 

# test plan






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace base64 screenshot payloads in agent actions with a simple "screenshotTaken" marker to keep results readable and lighter. Raw base64 remains accessible via the associated message objects.

<sup>Written for commit 39599f27a0ae8c871f202259ee4e6067d79cb378. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





