### PR TITLE
add gemini 3 preview

### DIFF
--- a/packages/core/lib/v3/llm/LLMProvider.ts
+++ b/packages/core/lib/v3/llm/LLMProvider.ts
@@ -95,6 +95,8 @@ const modelToProviderMap: { [key in AvailableModel]: ModelProvider } = {
   "gemini-2.0-flash": "google",
   "gemini-2.5-flash-preview-04-17": "google",
   "gemini-2.5-pro-preview-03-25": "google",
+  "gemini-3-flash-preview": "google",
+  "gemini-3-pro-preview": "google",
 };
 
 export function getAISDKLanguageModel(

--- a/packages/core/lib/v3/types/public/model.ts
+++ b/packages/core/lib/v3/types/public/model.ts
@@ -89,6 +89,8 @@ export type AvailableModel =
   | "gemini-2.0-flash"
   | "gemini-2.5-flash-preview-04-17"
   | "gemini-2.5-pro-preview-03-25"
+  | "gemini-3-flash-preview"
+  | "gemini-3-pro-preview"
   | string;
 
 export type ModelProvider =

--- a/packages/evals/taskConfig.ts
+++ b/packages/evals/taskConfig.ts
@@ -26,6 +26,8 @@ const ALL_EVAL_MODELS = [
   "gemini-1.5-flash-8b",
   "gemini-2.5-flash-preview-04-17",
   "gemini-2.5-pro-preview-03-25",
+  "gemini-3-flash-preview",
+  "gemini-3-pro-preview",
   // ANTHROPIC
   "claude-3-5-sonnet-latest",
   "claude-3-7-sonnet-latest",

--- a/packages/server/src/lib/utils.ts
+++ b/packages/server/src/lib/utils.ts
@@ -205,6 +205,8 @@ export function mapModelToProvider(model: LegacyModel): LegacyProvider {
     case "gemini-2.0-flash":
     case "gemini-2.5-pro-preview-03-25":
     case "gemini-2.5-flash-preview-04-17":
+    case "gemini-3-flash-preview":
+    case "gemini-3-pro-preview":
       return "google";
     case "cerebras-llama-3.3-70b":
     case "cerebras-llama-3.1-8b":

--- a/packages/server/src/types/model.ts
+++ b/packages/server/src/types/model.ts
@@ -38,6 +38,8 @@ export type LegacyModel =
   | "gemini-2.0-flash-lite"
   | "gemini-2.0-flash"
   | "gemini-2.5-pro-preview-03-25"
-  | "gemini-2.5-flash-preview-04-17";
+  | "gemini-2.5-flash-preview-04-17"
+  | "gemini-3-flash-preview"
+  | "gemini-3-pro-preview";
 
 export type LegacyProvider = "openai" | "anthropic" | "google";


### PR DESCRIPTION
# why
model was unavailable in the sdk

# what changed
model is now available to use in the sdk

# test plan
the existing tests should pass, no mod needed





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for Gemini 3 preview models so they can be selected and used across the SDK and server. Maps both models to the Google provider with no breaking changes.

- **New Features**
  - Added "gemini-3-flash-preview" and "gemini-3-pro-preview" to AvailableModel and server legacy model types.
  - Mapped both models to the Google provider in core and server utilities.
  - Included both models in the evals model list.

<sup>Written for commit de144726f27e2c906891e0ab9a285d7be7002d86. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





