### PR TITLE
[test]: add tests for ax tree post-processing

### DIFF
--- a/packages/core/tests/snapshot-a11y-tree-utils.test.ts
+++ b/packages/core/tests/snapshot-a11y-tree-utils.test.ts
@@ -130,7 +130,6 @@ describe("buildHierarchicalTree", () => {
         encodedId: "root",
         parentId: undefined,
         childIds: ["child"],
-        children: [],
       },
       {
         role: "StaticText",
@@ -158,16 +157,14 @@ describe("buildHierarchicalTree", () => {
         encodedId: "root",
         parentId: undefined,
         childIds: ["child"],
-        children: [
-          {
-            role: "StaticText",
-            name: "Ok",
-            nodeId: "child",
-            encodedId: "child",
-            parentId: "root",
-            childIds: [],
-          },
-        ],
+      },
+      {
+        role: "StaticText",
+        name: "Ok",
+        nodeId: "child",
+        encodedId: "child",
+        parentId: "root",
+        childIds: [],
       },
     ];
 
@@ -184,17 +181,14 @@ describe("buildHierarchicalTree", () => {
         encodedId: "root",
         parentId: undefined,
         childIds: ["child"],
-        children: [
-          {
-            role: "generic",
-            name: "",
-            nodeId: "child",
-            encodedId: "child",
-            parentId: "root",
-            childIds: [],
-            children: [],
-          },
-        ],
+      },
+      {
+        role: "generic",
+        name: "",
+        nodeId: "child",
+        encodedId: "child",
+        parentId: "root",
+        childIds: [],
       },
     ];
 
@@ -211,24 +205,22 @@ describe("buildHierarchicalTree", () => {
         encodedId: "root",
         parentId: undefined,
         childIds: ["child-a", "child-b"],
-        children: [
-          {
-            role: "StaticText",
-            name: "A",
-            nodeId: "child-a",
-            encodedId: "child-a",
-            parentId: "root",
-            childIds: [],
-          },
-          {
-            role: "StaticText",
-            name: "B",
-            nodeId: "child-b",
-            encodedId: "child-b",
-            parentId: "root",
-            childIds: [],
-          },
-        ],
+      },
+      {
+        role: "StaticText",
+        name: "A",
+        nodeId: "child-a",
+        encodedId: "child-a",
+        parentId: "root",
+        childIds: [],
+      },
+      {
+        role: "StaticText",
+        name: "B",
+        nodeId: "child-b",
+        encodedId: "child-b",
+        parentId: "root",
+        childIds: [],
       },
     ];
 


### PR DESCRIPTION
# why
- to add more coverage for the hybrid snapshot flow by testing lower level helpers
# what changed
added `tests/snapshot-a11y-tree-utils.test.ts` which tests:
- `decorateRoles()`
  - checks that scrollable nodes get labelled correctly
  - checks that `#document` nodes get left as 'generic'
  - checks that `html` nodes always get the scrollable label
- `buildHierarchicalTree()`
  - checks that structural nodes with no meaningful content are excluded
  - `combobox` & `select` roles are remapped to their HTML tag names
  - tag name substitution is applied to non-combobox structural nodes
  - nodes with negative IDs are skipped
- `isStructural()`
   - confirms "generic", "none", and "InlineTextBox" roles are flagged structural while real roles like "button" stay non-structural
- `removeRedundantStaticTextChildren()`
   - removes `StaticText` children when their combined text exactly matches the parent label, keeps them when the text differs, and returns the original array when the parent has no name
- `extractUrlFromAXNode()`
  - trims and returns the URL when a valid url property exists, but yields undefined when the property is missing or the value isn’t a string
# test plan
- this is it



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for AX tree post-processing helpers to increase coverage of the hybrid snapshot flow (STG-1095). Covers role decoration (scrollable labels, encoding fallback), hierarchical tree building (structural pruning, tag remapping, negative ID skip), structural role detection, redundant StaticText pruning, and URL extraction.

<sup>Written for commit 310fd7508234be2b711deb6fa12ae8c8475e24be. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



