### PR TITLE
[test]: add tests for focus selector utils

### DIFF
--- a/packages/core/tests/snapshot-focus-selectors-utils.test.ts
+++ b/packages/core/tests/snapshot-focus-selectors-utils.test.ts
@@ -1,0 +1,54 @@
+import type { Step } from "../lib/v3/types/private/snapshot";
+import { describe, expect, it } from "vitest";
+import {
+  buildXPathFromSteps,
+  listChildrenOf,
+  parseXPathToSteps,
+} from "../lib/v3/understudy/a11y/snapshot/focusSelectors";
+
+describe("parseXPathToSteps", () => {
+  it("records axis direction and normalized names", () => {
+    const steps = parseXPathToSteps(" //iframe[1]/div[2]//SPAN ");
+    expect(steps).toEqual([
+      { axis: "desc", raw: "iframe[1]", name: "iframe" },
+      { axis: "child", raw: "div[2]", name: "div" },
+      { axis: "desc", raw: "SPAN", name: "span" },
+    ]);
+  });
+
+  it("drops empty segments and returns [] for blank input", () => {
+    expect(parseXPathToSteps("   ")).toEqual([]);
+    expect(parseXPathToSteps("/ ")).toEqual([]);
+  });
+});
+
+describe("buildXPathFromSteps", () => {
+  it("reconstructs descendant and child hops as a string", () => {
+    const steps: ReadonlyArray<Step> = [
+      { axis: "child", raw: "iframe[1]", name: "iframe" },
+      { axis: "desc", raw: "div[@id='main']", name: "div" },
+      { axis: "child", raw: "span", name: "span" },
+    ];
+    expect(buildXPathFromSteps(steps)).toBe("/iframe[1]//div[@id='main']/span");
+  });
+
+  it("returns '/' for empty sequences", () => {
+    expect(buildXPathFromSteps([])).toBe("/");
+  });
+});
+
+describe("listChildrenOf", () => {
+  it("returns direct children whose parent matches the provided id", () => {
+    const parentByFrame = new Map<string, string | null>([
+      ["frame-1", null],
+      ["frame-2", "frame-1"],
+      ["frame-3", "frame-1"],
+      ["frame-4", "frame-2"],
+    ]);
+    expect(listChildrenOf(parentByFrame, "frame-1")).toEqual([
+      "frame-2",
+      "frame-3",
+    ]);
+    expect(listChildrenOf(parentByFrame, "frame-4")).toEqual([]);
+  });
+});


### PR DESCRIPTION
# why
- to add more coverage for the functions that `captureHybridSnapshot()` depends on
# what changed
added unit tests for:
- `parseXPathToSteps()`
  - checks that descendant (`//`) and child (`/`) axes are stored and names get normalized correctly
  - checks that blank or empty segments are ignored
- `buildXPathFromSteps()`
  - checks that a sequence of step objects gets converted into the expected xpath
  - checks that an empty sequence returns `/`
- `listChildrenOf()`
  - checks that only direct children of the given parent ID are returned (in insertion order)
  - checks that parents without entries yield an empty array
# test plan
- this is it

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for focus selector utils to improve coverage for captureHybridSnapshot(). Tests cover axis handling and name normalization in parseXPathToSteps, XPath reconstruction and empty input in buildXPathFromSteps, and direct-child filtering and order in listChildrenOf.

<sup>Written for commit 119ce4a2c05539e830254d888624df12cf768da4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

