### PR TITLE
add deepseek specific prompting in aisdk

### DIFF
--- a/.changeset/violet-toes-boil.md
+++ b/.changeset/violet-toes-boil.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+update aisdk client to better enforce structured output with deepseek models


### PR DESCRIPTION
# why
- deepseek requires more explicit prompting around JSON schemas when being asked for structured output
# what changed
- added some conditional/model specific prompting in the aisdk client which seems to solve the issue


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added DeepSeek-specific prompt handling in the AISdk client to enforce strict JSON structured output. Converts the Zod schema to JSON Schema and injects a clear “JSON-only” instruction.

- **Bug Fixes**
  - Detect DeepSeek models and append a schema-based prompt.
  - Use toJsonSchema to serialize response_model.schema.
  - Instruct the model to return only a JSON object (no code fences or extra text).

<sup>Written for commit e70aec08b7c455c14fcd555f539499afc7c75a91. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

