### PR TITLE
Pushing stagehand-server to github releases with changesets, instead of using github artifacts

### DIFF
--- a/.changeset/lucky-dolls-joke.md
+++ b/.changeset/lucky-dolls-joke.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand-server": minor
+---
+
+First changeset for stagehand-server

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js 20.x
         uses: actions/setup-node@v4
@@ -46,6 +48,37 @@ jobs:
           publish: pnpm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag stagehand/server version for GitHub Releases
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          SERVER_VERSION="$(node -p "require('./packages/server/package.json').version")"
+          TAG="stagehand-server/v${SERVER_VERSION}"
+          BEFORE_SHA="${{ github.event.before }}"
+
+          if [ -n "${BEFORE_SHA}" ] && [ "${BEFORE_SHA}" != "0000000000000000000000000000000000000000" ]; then
+            BEFORE_VERSION="$(git show "${BEFORE_SHA}:packages/server/package.json" 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin)['version'])" 2>/dev/null || true)"
+            if [ -n "${BEFORE_VERSION}" ] && [ "${BEFORE_VERSION}" = "${SERVER_VERSION}" ]; then
+              echo "No @browserbasehq/stagehand-server version change (${SERVER_VERSION}); skipping tag."
+              exit 0
+            fi
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git fetch --tags --force
+
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "Tag already exists: ${TAG}"
+            exit 0
+          fi
+
+          git tag -a "${TAG}" -m "stagehand/server v${SERVER_VERSION}"
+          git push origin "${TAG}"
 
       - name: Publish Canary
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/stagehand-server-release.yml
+++ b/.github/workflows/stagehand-server-release.yml
@@ -1,0 +1,63 @@
+name: Release stagehand/server
+
+on:
+  push:
+    tags:
+      - "stagehand-server/v*"
+
+permissions:
+  contents: write
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+env:
+  OAS_PATH: packages/server/openapi.v3.yaml
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Derive stagehand/server version
+        id: server_version
+        run: |
+          set -euo pipefail
+          TAG_NAME="${GITHUB_REF_NAME}"
+          VERSION="${TAG_NAME#stagehand-server/v}"
+          if [ "$VERSION" = "$TAG_NAME" ] || [ -z "$VERSION" ]; then
+            echo "Unexpected tag: $TAG_NAME" >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Verify tag matches packages/server version
+        env:
+          TAG_VERSION: ${{ steps.server_version.outputs.version }}
+        run: |
+          set -euo pipefail
+          PKG_VERSION="$(node -p "require('./packages/server/package.json').version")"
+          if [ "${PKG_VERSION}" != "${TAG_VERSION}" ]; then
+            echo "Tag version (${TAG_VERSION}) does not match packages/server/package.json version (${PKG_VERSION})." >&2
+            exit 1
+          fi
+
+      - name: Prepare release assets directory
+        run: mkdir -p release-assets
+
+      - name: Prepare stagehand/server release assets
+        run: |
+          set -euo pipefail
+          cp "${{ env.OAS_PATH }}" "release-assets/openapi.v3.stagehand-server-${{ steps.server_version.outputs.version }}.yaml"
+
+      - name: Publish stagehand/server GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: stagehand/server v${{ steps.server_version.outputs.version }}
+          generate_release_notes: true
+          files: |
+            release-assets/openapi.v3.stagehand-server-${{ steps.server_version.outputs.version }}.yaml

--- a/.github/workflows/stainless.yml
+++ b/.github/workflows/stainless.yml
@@ -39,7 +39,7 @@ jobs:
           oas_path: ${{ env.OAS_PATH }}
 
   merge:
-    if: github.event.action == 'closed' && github.event.pull_request.merged == true
+    if: github.event.action == 'closed' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
# why
With my previous artifacts approach, our client sdk repos like `stagehand-python` just pulled the most recent artifact, which could be error prone - by having it pull a versioned release, we avoid a swath of potential issues.
# what changed
Added logic for pushing releases. 
# test plan
We should see a release show up for stagehand-server when this merges, since I added a minor version bump changeset.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish stagehand-server via versioned GitHub Releases driven by Changesets, replacing the previous GitHub Artifacts flow. SDKs can now fetch stable, versioned assets (OpenAPI spec) from releases.

- **New Features**
  - Auto-tag stagehand-server/v{version} when packages/server version changes; skips if unchanged or tag exists.
  - New release workflow verifies the tag matches package.json, packages openapi.v3.yaml, and publishes a GitHub Release with notes.
  - Added a minor Changeset for @browserbasehq/stagehand-server to trigger the first release.

- **Migration**
  - Update SDKs (e.g., stagehand-python) to download openapi.v3.stagehand-server-{version}.yaml from the matching GitHub Release tag.
  - Stop relying on the “latest” GitHub Artifacts.

<sup>Written for commit e47c56e3c1a61c186dc01f867b61f7feba28d76d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

