### PR TITLE
Add media resolution high to gemini 3 hybrid agent

### DIFF
--- a/.changeset/quiet-needles-fetch.md
+++ b/.changeset/quiet-needles-fetch.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Add media resolution high provider option to gemini 3 hybrid agent

--- a/packages/core/lib/v3/handlers/v3AgentHandler.ts
+++ b/packages/core/lib/v3/handlers/v3AgentHandler.ts
@@ -273,6 +273,13 @@ export class V3AgentHandler {
         prepareStep: callbacks?.prepareStep,
         onStepFinish: this.createStepHandler(state, callbacks?.onStepFinish),
         abortSignal: preparedOptions.signal,
+        providerOptions: wrappedModel.modelId.includes("gemini-3")
+          ? {
+              google: {
+                mediaResolution: "MEDIA_RESOLUTION_HIGH",
+              },
+            }
+          : undefined,
       });
 
       return this.consolidateMetricsAndResult(
@@ -407,6 +414,13 @@ export class V3AgentHandler {
         rejectResult(new AgentAbortError(reason));
       },
       abortSignal: options.signal,
+      providerOptions: wrappedModel.modelId.includes("gemini-3")
+        ? {
+            google: {
+              mediaResolution: "MEDIA_RESOLUTION_HIGH",
+            },
+          }
+        : undefined,
     });
 
     const agentStreamResult = streamResult as AgentStreamResult;


### PR DESCRIPTION
# why
This setting improves the performance of gemini 3 models for computer use applications (recommended by [Deepmind](https://colab.research.google.com/drive/1OK30EUqrukGsYhHQZIlKq3wCNWlfsrkn#scrollTo=APbcS_6TUI8F))

# what changed
Added a `providerOption` to google models (specifically filtered by gemini-3) to include MEDIA_RESOLUTION_HIGH (nit: ULTRA_HIGH not supported by aisdk yet)

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the Google provider option mediaResolution to MEDIA_RESOLUTION_HIGH for Gemini 3 models in the hybrid agent to improve computer-use performance.
Applied conditionally when the modelId includes "gemini-3" for both step execution and streaming paths.

<sup>Written for commit 5e005812ee5f02b5e7da11f852c8e16264a3f33b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

