### PR TITLE
[chore]: move playwright to optional deps

### DIFF
--- a/.changeset/tame-zebras-play.md
+++ b/.changeset/tame-zebras-play.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+move playwright to optional dependencies

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,7 +55,6 @@
     "openai": "^4.87.1",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",
-    "playwright": "^1.52.0",
     "ws": "^8.18.0",
     "zod-to-json-schema": "^3.25.0"
   },
@@ -77,6 +76,7 @@
     "chrome-launcher": "^1.2.0",
     "ollama-ai-provider-v2": "^1.5.0",
     "patchright-core": "^1.55.2",
+    "playwright": "^1.52.0",
     "playwright-core": "^1.54.1",
     "puppeteer-core": "^22.8.0"
   },
@@ -89,6 +89,8 @@
     "chalk": "^5.4.1",
     "esbuild": "^0.21.4",
     "eslint": "^9.16.0",
+    "playwright": "^1.52.0",
+    "playwright-core": "^1.54.1",
     "prettier": "^3.2.5",
     "tsup": "^8.2.1",
     "tsx": "^4.10.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,9 +80,6 @@ importers:
       pino-pretty:
         specifier: ^13.0.0
         version: 13.0.0
-      playwright:
-        specifier: ^1.52.0
-        version: 1.54.2
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
@@ -144,6 +141,9 @@ importers:
       patchright-core:
         specifier: ^1.55.2
         version: 1.55.2
+      playwright:
+        specifier: ^1.52.0
+        version: 1.54.2
       playwright-core:
         specifier: ^1.54.1
         version: 1.54.2


### PR DESCRIPTION
# why
- stagehand no longer depends on playwright
- addresses #1463 
# what changed
- moved `playwright` from dependencies to optional dependencies in package.json

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Playwright optional so Stagehand installs cleanly without it. This reduces install size and avoids Playwright install issues; aligns with removing the hard dependency (issue #1463).

- **Dependencies**
  - Removed Playwright from dependencies; added Playwright and Playwright Core to optionalDependencies.
  - Added Playwright and Playwright Core to devDependencies for local development.
  - Updated pnpm-lock.yaml and added a changeset for a patch release.

<sup>Written for commit 1264d716fa21b98b93b0889e6ac138d37e82580f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

