### PR TITLE
bump server package version

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@browserbasehq/stagehand-server",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Stagehand API server",
   "type": "module",
   "private": true,


### PR DESCRIPTION
# why

# what changed

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped @browserbasehq/stagehand-server from 3.1.1 to 3.1.2 to publish the latest binary build fix. No functional code changes; this ensures downstream builds pick up the updated binary.

<sup>Written for commit 7ba5a45416508986be43c1c2faf0cff74d9874be. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

