### PR TITLE
bump server package version & fix gen:openapi script for windows

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@browserbasehq/stagehand-server",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Stagehand API server",
   "type": "module",
   "private": true,
@@ -12,7 +12,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run --exclude test/api-client.integration.test.ts",
     "test:integration": "vitest run test/api-client.integration.test.ts",
-    "gen:openapi": "tsx scripts/gen-openapi.ts; cd ../.. && prettier --write packages/server/openapi.v3.yaml"
+    "gen:openapi": "tsx scripts/gen-openapi.ts && prettier --write openapi.v3.yaml"
   },
   "dependencies": {
     "@browserbasehq/sdk": "^2.4.0",


### PR DESCRIPTION
# why

# what changed

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped server package to 3.1.3 and fixed the gen:openapi script so OpenAPI generation works on Windows. The script now uses `&&` and formats the local `openapi.v3.yaml` without changing directories.

<sup>Written for commit 1b850c898aa99f85282f5375db930fbb4f414999. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

