### PR TITLE
feat(google-cua): add screenshot pruning to prevent memory growth

### DIFF
--- a/.changeset/fix-google-cua-screenshot-pruning.md
+++ b/.changeset/fix-google-cua-screenshot-pruning.md
@@ -1,0 +1,9 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Add screenshot pruning to GoogleCUAClient to prevent memory growth
+
+The GoogleCUAClient now prunes old screenshots from conversation history, keeping only the most recent `maxImages` (default: 3) screenshots. This matches the behavior of MicrosoftCUAClient and prevents unbounded memory growth during long agent sessions, especially on image-heavy websites.
+
+The `maxImages` option can be configured via `clientOptions.maxImages` when initializing the agent.


### PR DESCRIPTION
## Summary
- Add `maxImages` property to `GoogleCUAClient` (default: 3) to limit screenshots kept in history
- Add `maybeRemoveOldScreenshots()` method that prunes old screenshots after each step
- Match the behavior of `MicrosoftCUAClient` which already has this feature

## Problem
The `GoogleCUAClient` accumulates screenshots in `this.history` without any pruning mechanism. On image-heavy websites like ncl.com, each screenshot is ~2-3 MB base64. During a 30-step session, this can cause memory growth from ~170 MB to ~400+ MB RSS, leading to OOM errors on memory-constrained environments like AWS Lambda.

## Solution
After pushing function responses to history, call `maybeRemoveOldScreenshots()` which:
1. Traverses history from newest to oldest
2. Counts entries containing screenshots (inlineData)
3. For entries beyond the `maxImages` limit, removes the `inlineData` while preserving the rest of the history structure

This reduces memory delta by ~40% in testing (from 232 MB to 138 MB over a typical session).

## Test plan
- [x] Memory profiled locally with ncl.com (image-heavy site)
- [ ] Verify agent still functions correctly after pruning
- [ ] Verify configurable via `clientOptions.maxImages`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds screenshot pruning to GoogleCUAClient to cap screenshots in history and prevent memory growth during long sessions. Keeps only the most recent maxImages screenshots (default 3), removes inlineData from older entries, is configurable via clientOptions.maxImages, and matches MicrosoftCUAClient behavior.

<sup>Written for commit 3b6588b63281b907b513dc2ccc7c51b75bfe19a4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

