### PR TITLE
Update agent to only calculate xpath when caching is enabled

### DIFF
--- a/.changeset/silly-emus-knock.md
+++ b/.changeset/silly-emus-knock.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Update agent to only calculate xpath when caching is enabled

--- a/packages/core/lib/v3/agent/tools/dragAndDrop.ts
+++ b/packages/core/lib/v3/agent/tools/dragAndDrop.ts
@@ -50,31 +50,34 @@ export const dragAndDropTool = (v3: V3, provider?: string) =>
           },
         });
 
-        // Use returnXpath to get XPaths of both start and end elements for caching
+        // Only request XPath when caching is enabled to avoid unnecessary computation
+        const shouldCollectXpath = v3.isAgentReplayActive();
         const [fromXpath, toXpath] = await page.dragAndDrop(
           processedStart.x,
           processedStart.y,
           processedEnd.x,
           processedEnd.y,
-          { returnXpath: true },
+          { returnXpath: shouldCollectXpath },
         );
 
-        // Record as "act" step with proper Action for deterministic replay
-        const normalizedFrom = ensureXPath(fromXpath);
-        const normalizedTo = ensureXPath(toXpath);
-        if (normalizedFrom && normalizedTo) {
-          const action: Action = {
-            selector: normalizedFrom,
-            description: describe,
-            method: "dragAndDrop",
-            arguments: [normalizedTo],
-          };
-          v3.recordAgentReplayStep({
-            type: "act",
-            instruction: describe,
-            actions: [action],
-            actionDescription: describe,
-          });
+        // Record as "act" step with proper Action for deterministic replay (only when caching)
+        if (shouldCollectXpath) {
+          const normalizedFrom = ensureXPath(fromXpath);
+          const normalizedTo = ensureXPath(toXpath);
+          if (normalizedFrom && normalizedTo) {
+            const action: Action = {
+              selector: normalizedFrom,
+              description: describe,
+              method: "dragAndDrop",
+              arguments: [normalizedTo],
+            };
+            v3.recordAgentReplayStep({
+              type: "act",
+              instruction: describe,
+              actions: [action],
+              actionDescription: describe,
+            });
+          }
         }
 
         return { success: true, describe };

--- a/packages/core/lib/v3/agent/tools/fillFormVision.ts
+++ b/packages/core/lib/v3/agent/tools/fillFormVision.ts
@@ -73,37 +73,40 @@ MANDATORY USE CASES (always use fillFormVision for these):
           },
         });
 
-        // Collect actions with XPaths for cache replay
+        // Only request XPath when caching is enabled to avoid unnecessary computation
+        const shouldCollectXpath = v3.isAgentReplayActive();
         const actions: Action[] = [];
 
         for (const field of processedFields) {
-          // Click the field with returnXpath to get the element's XPath
+          // Click the field, only requesting XPath when caching is enabled
           const xpath = await page.click(
             field.coordinates.x,
             field.coordinates.y,
             {
-              returnXpath: true,
+              returnXpath: shouldCollectXpath,
             },
           );
           await page.type(field.value);
 
-          // Build Action with XPath for deterministic replay
-          const normalizedXpath = ensureXPath(xpath);
-          if (normalizedXpath) {
-            actions.push({
-              selector: normalizedXpath,
-              description: field.action,
-              method: "type",
-              arguments: [field.value],
-            });
+          // Build Action with XPath for deterministic replay (only when caching)
+          if (shouldCollectXpath) {
+            const normalizedXpath = ensureXPath(xpath);
+            if (normalizedXpath) {
+              actions.push({
+                selector: normalizedXpath,
+                description: field.action,
+                method: "type",
+                arguments: [field.value],
+              });
+            }
           }
 
           // Small delay between fields
           await new Promise((resolve) => setTimeout(resolve, 100));
         }
 
-        // Record as "act" step with proper Actions for deterministic replay
-        if (actions.length > 0) {
+        // Record as "act" step with proper Actions for deterministic replay (only when caching)
+        if (shouldCollectXpath && actions.length > 0) {
           v3.recordAgentReplayStep({
             type: "act",
             instruction: `Fill ${fields.length} form fields`,


### PR DESCRIPTION
# why

currently, we calculate the xpath for agent actions, even when the user is not using caching, this is wasteful and should only be done when caching is enabled 

# what changed

we now verify caching is enabled. if it is, we calculate an xpath for the action. if it is not, we do not 

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make agent tools collect XPath only when caching (agent replay) is enabled. This reduces overhead in non-cached runs while preserving deterministic replay when cache is used.

- **Refactors**
  - Gate XPath collection behind v3.isAgentReplayActive in click, type, clickAndHold, dragAndDrop, and fillFormVision.
  - Record agent replay steps only when caching is active.
  - Pass returnXpath: shouldCollectXpath to page actions to avoid unnecessary computation.

<sup>Written for commit 6fd7cc503770d2a471484a61615c20187a065215. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

