### PR TITLE
[fix]: authenticate user pass proxies when using a local browser

### DIFF
--- a/packages/core/lib/v3/v3.ts
+++ b/packages/core/lib/v3/v3.ts
@@ -985,20 +985,22 @@ export class V3 {
         const authHandler = ({
           requestId,
         }: Protocol.Fetch.AuthRequiredEvent) => {
-          session.send("Fetch.continueWithAuth", {
-            requestId,
-            authChallengeResponse: {
-              response: "ProvideCredentials",
-              username: lbo.proxy!.username!,
-              password: lbo.proxy!.password!,
-            },
-          });
+          session
+            .send("Fetch.continueWithAuth", {
+              requestId,
+              authChallengeResponse: {
+                response: "ProvideCredentials",
+                username: lbo.proxy!.username!,
+                password: lbo.proxy!.password!,
+              },
+            })
+            .catch(() => {});
         };
 
         const requestPausedHandler = ({
           requestId,
         }: Protocol.Fetch.RequestPausedEvent) => {
-          session.send("Fetch.continueRequest", { requestId });
+          session.send("Fetch.continueRequest", { requestId }).catch(() => {});
         };
 
         session.on("Fetch.authRequired", authHandler);


### PR DESCRIPTION
# why
Using proxies that need a username and password doesn't work on local mode
# what changed
If a username and password is included in the local options then we authenticate the proxy using fetch domain events
# test plan




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes proxy authentication in local browser mode by supplying username/password credentials via the CDP Fetch domain. Authenticated proxies now work without manual setup.

- **Bug Fixes**
  - Detects lbo.proxy username/password and enables Fetch with handleAuthRequests.
  - Responds to Fetch.authRequired with provided credentials and resumes paused requests.
  - Tracks per-page listeners and cleans them up on teardown to prevent leaks.

<sup>Written for commit 434eca99f5875d6bc8a3f8bdd44720e86b4660a0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



