### PR TITLE
export tool function & type

### DIFF
--- a/.changeset/gold-women-sell.md
+++ b/.changeset/gold-women-sell.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+export tool function & type to simplify defining custom tools

--- a/packages/core/lib/v3/index.ts
+++ b/packages/core/lib/v3/index.ts
@@ -29,6 +29,7 @@ export { isZod4Schema, isZod3Schema, toJsonSchema } from "./zodCompat";
 
 export { connectToMCPServer } from "./mcp/connection";
 export { V3Evaluator } from "../v3Evaluator";
+export { tool } from "ai";
 
 export type {
   ChatMessage,

--- a/packages/core/lib/v3/types/public/agent.ts
+++ b/packages/core/lib/v3/types/public/agent.ts
@@ -17,6 +17,9 @@ import { ClientOptions } from "./model";
 
 // Re-export ModelMessage for consumers who want to use it for conversation continuation
 export type { ModelMessage } from "ai";
+
+// Re-export Tool type for consumers who want to define custom tools
+export type { Tool } from "ai";
 import { Page as PlaywrightPage } from "playwright-core";
 import { Page as PuppeteerPage } from "puppeteer-core";
 import { Page as PatchrightPage } from "patchright-core";

--- a/packages/core/tests/public-api/export-surface.test.ts
+++ b/packages/core/tests/public-api/export-surface.test.ts
@@ -43,6 +43,7 @@ const publicApiShape = {
   providerEnvVarMap: Stagehand.providerEnvVarMap,
   toGeminiSchema: Stagehand.toGeminiSchema,
   toJsonSchema: Stagehand.toJsonSchema,
+  tool: Stagehand.tool,
   transformSchema: Stagehand.transformSchema,
   trimTrailingTextNode: Stagehand.trimTrailingTextNode,
   validateZodSchema: Stagehand.validateZodSchema,

--- a/packages/core/tests/public-api/public-types.test.ts
+++ b/packages/core/tests/public-api/public-types.test.ts
@@ -27,6 +27,7 @@ type ExpectedExportedTypes = {
   ObserveOptions: Stagehand.ObserveOptions;
   V3FunctionName: Stagehand.V3FunctionName;
   // Types from agent.ts
+  Tool: Stagehand.Tool;
   AgentAction: Stagehand.AgentAction;
   AgentResult: Stagehand.AgentResult;
   AgentExecuteOptions: Stagehand.AgentExecuteOptions;

--- a/packages/core/tests/public-api/tool-type-export.test.ts
+++ b/packages/core/tests/public-api/tool-type-export.test.ts
@@ -1,0 +1,34 @@
+import { describe, expectTypeOf, it, expect } from "vitest";
+import * as Stagehand from "../../dist/index.js";
+import { type Tool } from "ai";
+import { z } from "zod";
+
+/**
+ * Test to verify tool-related exports from Stagehand.
+ * Users should be able to create custom tools using the exported `tool` function
+ * without needing to install the ai package directly.
+ */
+describe("Tool exports from AI SDK", () => {
+  it("exports Tool type that matches AI SDK Tool type", () => {
+    expectTypeOf<Stagehand.Tool>().toEqualTypeOf<Tool>();
+  });
+
+  it("exports tool function", () => {
+    expect(typeof Stagehand.tool).toBe("function");
+  });
+
+  it("tool function can be used to define custom tools", () => {
+    const customTool = Stagehand.tool({
+      description: "A test tool",
+      inputSchema: z.object({
+        input: z.string(),
+      }),
+      execute: async ({ input }) => {
+        return { result: `Processed: ${input}` };
+      },
+    });
+
+    expect(customTool).toBeDefined();
+    expect(customTool.description).toBe("A test tool");
+  });
+});


### PR DESCRIPTION
# why

currently using custom tools requires importing from a separate package

# what changed

- exported tool function & type 
- added test for exported function and type

# test plan

wrote tests & tested locally 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exported the tool function and Tool type from Stagehand core so users can define custom tools without installing an extra package. Added tests to confirm the exports and usage.

<sup>Written for commit 752ee8df9ceed1df38c5a2727962deed66cefaf8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

