### PR TITLE
docs: Add Stagehand API region requirement documentation

### DIFF
--- a/packages/docs/v2/best-practices/deployments.mdx
+++ b/packages/docs/v2/best-practices/deployments.mdx
@@ -70,7 +70,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
       // optional session params
       browserbaseSessionCreateParams: {
         projectId: process.env.BROWSERBASE_PROJECT_ID!,
-        region: "us-west-2",
+        region: "us-west-2", // Stagehand API only supports us-west-2
         browserSettings: {
           blockAds: true,
         },

--- a/packages/docs/v2/configuration/browser.mdx
+++ b/packages/docs/v2/configuration/browser.mdx
@@ -74,7 +74,7 @@ const stagehand = new Stagehand({
   projectId: process.env.BROWSERBASE_PROJECT_ID,
   browserbaseSessionCreateParams: {
     proxies: true,
-    region: "us-west-2",
+    region: "us-west-2", // Stagehand API only supports us-west-2
     browserSettings: {
       viewport: { width: 1920, height: 1080 },
       blockAds: true,
@@ -96,7 +96,7 @@ stagehand = Stagehand(
     project_id=os.getenv("BROWSERBASE_PROJECT_ID"),
     browserbase_session_create_params={
         "proxies": True,
-        "region": "us-west-2",
+        "region": "us-west-2",  # Stagehand API only supports us-west-2
         "browser_settings": {
             "viewport": {"width": 1920, "height": 1080},
             "block_ads": True,
@@ -116,7 +116,7 @@ stagehand = Stagehand(
       browserbaseSessionCreateParams: {
         projectId: process.env.BROWSERBASE_PROJECT_ID!,
         proxies: true,
-        region: "us-west-2",
+        region: "us-west-2", // Stagehand API only supports us-west-2
         timeout: 3600, // 1 hour session timeout
         keepAlive: true, // Available on Startup plan
         browserSettings: {
@@ -151,7 +151,7 @@ stagehand = Stagehand(
         browserbase_session_create_params={
             "project_id": os.getenv("BROWSERBASE_PROJECT_ID"),
             "proxies": True,
-            "region": "us-west-2",
+            "region": "us-west-2",  # Stagehand API only supports us-west-2
             "timeout": 3600,  # 1 hour session timeout
             "keep_alive": True,  # Available on Startup plan
             "browser_settings": {

--- a/packages/docs/v3/best-practices/deployments.mdx
+++ b/packages/docs/v3/best-practices/deployments.mdx
@@ -74,7 +74,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
       // optional session params
       browserbaseSessionCreateParams: {
         projectId: process.env.BROWSERBASE_PROJECT_ID!,
-        region: "us-west-2",
+        region: "us-west-2", // Stagehand API only supports us-west-2
         browserSettings: {
           blockAds: true,
         },

--- a/packages/docs/v3/configuration/browser.mdx
+++ b/packages/docs/v3/configuration/browser.mdx
@@ -65,7 +65,7 @@ const stagehand = new Stagehand({
   projectId: process.env.BROWSERBASE_PROJECT_ID,
   browserbaseSessionCreateParams: {
     proxies: true,
-    region: "us-west-2",
+    region: "us-west-2", // Stagehand API only supports us-west-2
     browserSettings: {
       viewport: { width: 1920, height: 1080 },
       blockAds: true,
@@ -77,6 +77,10 @@ await stagehand.init();
 console.log("Session ID:", stagehand.sessionId);
 ```
 
+<Warning>
+**Region Note:** The Stagehand API only supports `us-west-2`. If you specify a different region, set `disableAPI: true`.
+</Warning>
+
 <Accordion title="Advanced Browserbase Configuration Example">
     ```typescript
 const stagehand = new Stagehand({
@@ -86,7 +90,7 @@ const stagehand = new Stagehand({
       browserbaseSessionCreateParams: {
         projectId: process.env.BROWSERBASE_PROJECT_ID!,
         proxies: true,
-        region: "us-west-2",
+        region: "us-west-2", // Stagehand API only supports us-west-2
         timeout: 3600, // 1 hour session timeout
         keepAlive: true, // Available on Startup plan
         browserSettings: {
@@ -278,5 +282,30 @@ Setting `domSettleTimeout` too low may cause actions to fail on elements that ar
 - Increase session timeout in `browserbaseSessionCreateParams.timeout`
 - Use `keepAlive: true` for long-running sessions
 - Monitor session usage to avoid unexpected terminations
+</Accordion>
+
+<Accordion title="Internal Server Error with Stagehand API">
+If you see `An internal server error occurred` pointing to `StagehandAPIClient`, this is likely a region mismatch. The Stagehand API is only available in `us-west-2`.
+
+**Solutions:**
+- Use `region: "us-west-2"` in your `browserbaseSessionCreateParams`
+- Or set `disableAPI: true` when using other regions
+
+```typescript
+// Option 1: Use us-west-2
+const stagehand = new Stagehand({
+  env: "BROWSERBASE",
+  browserbaseSessionCreateParams: {
+    region: "us-west-2",
+  },
+});
+
+// Option 2: Disable API for other regions
+const stagehand = new Stagehand({
+  env: "BROWSERBASE",
+  disableAPI: true,
+  browserbaseSessionID: "your-us-east-1-session-id",
+});
+```
 </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
## Summary
- Document that Stagehand API only supports us-west-2 region
- Added warning in configuration docs explaining the limitation
- Included inline comments on all region examples in both v2 and v3 docs
- Added troubleshooting section with examples for both solutions (use us-west-2 or disable API)

## Test plan
- Verified all doc files have consistent messaging about region support
- Checked that code examples show the constraint clearly with inline comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented the Stagehand API region requirement: it only works in us-west-2. Added warnings and inline notes in v2/v3 configuration and deployment docs, plus a troubleshooting section for region mismatches.

- **Migration**
  - Use region: "us-west-2" when using the Stagehand API.
  - If running in other regions, set disableAPI: true.

<sup>Written for commit f7f2d5304de163b4cc09356230b43120fe48a187. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

