### PR TITLE
Added optional param to force empty object

### DIFF
--- a/packages/core/lib/v3/types/public/api.ts
+++ b/packages/core/lib/v3/types/public/api.ts
@@ -394,7 +394,11 @@ export const SessionStartResponseSchema = wrapResponse(
 
 /** Session end request - empty JSON object (required). */
 export const SessionEndRequestSchema = z
-  .object({})
+  .object({
+    // Dummy property to ensure Stainless generates body parameter
+    // The server accepts {} (this field should be omitted)
+    _forceBody: z.undefined().optional(),
+  })
   .strict()
   .meta({ id: "SessionEndRequest" });
 

--- a/packages/server/openapi.v3.yaml
+++ b/packages/server/openapi.v3.yaml
@@ -415,7 +415,9 @@ components:
         - available
     SessionEndRequest:
       type: object
-      properties: {}
+      properties:
+        _forceBody:
+          not: {}
       additionalProperties: false
     ActOptions:
       type: object


### PR DESCRIPTION
# why
Generated sdks need to send empty object for /end endpoint to match prod api
# what changed
Added dummy optional param to schema to force proper code gen
# test plan
Confirmed that the generated wheel linked below by stainless is correct. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added an optional _forceBody field to SessionEndRequest so Stainless generates a body parameter for the endpoint. The server still accepts {} and clients can omit the field, fixing missing-body issues on session end requests.

<sup>Written for commit 7f8a7bc672aceb6b96571cd2f9fb8763fc33220b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

