### PR TITLE
Removed x-language and x-sdk-version from openapi spec

### DIFF
--- a/packages/core/lib/v3/types/public/api.ts
+++ b/packages/core/lib/v3/types/public/api.ts
@@ -157,17 +157,6 @@ export const SessionHeadersSchema = z
       description: "Whether to stream the response via SSE",
       example: "true",
     }),
-    "x-language": z
-      .enum(["typescript", "python", "playground"])
-      .optional()
-      .meta({
-        description: "Client SDK language",
-        example: "typescript",
-      }),
-    "x-sdk-version": z.string().optional().meta({
-      description: "Version of the Stagehand SDK",
-      example: "3.0.6",
-    }),
     "x-sent-at": z.string().datetime().optional().meta({
       description: "ISO timestamp when request was sent",
       example: "2025-01-15T10:30:00Z",

--- a/packages/server/openapi.v3.yaml
+++ b/packages/server/openapi.v3.yaml
@@ -1587,18 +1587,6 @@ components:
           enum:
             - "true"
             - "false"
-        x-language:
-          description: Client SDK language
-          example: typescript
-          type: string
-          enum:
-            - typescript
-            - python
-            - playground
-        x-sdk-version:
-          description: Version of the Stagehand SDK
-          example: 3.0.6
-          type: string
         x-sent-at:
           description: ISO timestamp when request was sent
           example: 2025-01-15T10:30:00Z
@@ -1738,24 +1726,6 @@ paths:
           name: x-stream-response
           description: Whether to stream the response via SSE
         - schema:
-            description: Client SDK language
-            example: typescript
-            type: string
-            enum:
-              - typescript
-              - python
-              - playground
-          in: header
-          name: x-language
-          description: Client SDK language
-        - schema:
-            description: Version of the Stagehand SDK
-            example: 3.0.6
-            type: string
-          in: header
-          name: x-sdk-version
-          description: Version of the Stagehand SDK
-        - schema:
             description: ISO timestamp when request was sent
             example: 2025-01-15T10:30:00Z
             type: string
@@ -1801,24 +1771,6 @@ paths:
           in: header
           name: x-stream-response
           description: Whether to stream the response via SSE
-        - schema:
-            description: Client SDK language
-            example: typescript
-            type: string
-            enum:
-              - typescript
-              - python
-              - playground
-          in: header
-          name: x-language
-          description: Client SDK language
-        - schema:
-            description: Version of the Stagehand SDK
-            example: 3.0.6
-            type: string
-          in: header
-          name: x-sdk-version
-          description: Version of the Stagehand SDK
         - schema:
             description: ISO timestamp when request was sent
             example: 2025-01-15T10:30:00Z
@@ -1866,24 +1818,6 @@ paths:
           name: x-stream-response
           description: Whether to stream the response via SSE
         - schema:
-            description: Client SDK language
-            example: typescript
-            type: string
-            enum:
-              - typescript
-              - python
-              - playground
-          in: header
-          name: x-language
-          description: Client SDK language
-        - schema:
-            description: Version of the Stagehand SDK
-            example: 3.0.6
-            type: string
-          in: header
-          name: x-sdk-version
-          description: Version of the Stagehand SDK
-        - schema:
             description: ISO timestamp when request was sent
             example: 2025-01-15T10:30:00Z
             type: string
@@ -1929,24 +1863,6 @@ paths:
           in: header
           name: x-stream-response
           description: Whether to stream the response via SSE
-        - schema:
-            description: Client SDK language
-            example: typescript
-            type: string
-            enum:
-              - typescript
-              - python
-              - playground
-          in: header
-          name: x-language
-          description: Client SDK language
-        - schema:
-            description: Version of the Stagehand SDK
-            example: 3.0.6
-            type: string
-          in: header
-          name: x-sdk-version
-          description: Version of the Stagehand SDK
         - schema:
             description: ISO timestamp when request was sent
             example: 2025-01-15T10:30:00Z
@@ -1995,24 +1911,6 @@ paths:
           in: header
           name: x-stream-response
           description: Whether to stream the response via SSE
-        - schema:
-            description: Client SDK language
-            example: typescript
-            type: string
-            enum:
-              - typescript
-              - python
-              - playground
-          in: header
-          name: x-language
-          description: Client SDK language
-        - schema:
-            description: Version of the Stagehand SDK
-            example: 3.0.6
-            type: string
-          in: header
-          name: x-sdk-version
-          description: Version of the Stagehand SDK
         - schema:
             description: ISO timestamp when request was sent
             example: 2025-01-15T10:30:00Z
@@ -2095,24 +1993,6 @@ paths:
           name: x-stream-response
           description: Whether to stream the response via SSE
         - schema:
-            description: Client SDK language
-            example: typescript
-            type: string
-            enum:
-              - typescript
-              - python
-              - playground
-          in: header
-          name: x-language
-          description: Client SDK language
-        - schema:
-            description: Version of the Stagehand SDK
-            example: 3.0.6
-            type: string
-          in: header
-          name: x-sdk-version
-          description: Version of the Stagehand SDK
-        - schema:
             description: ISO timestamp when request was sent
             example: 2025-01-15T10:30:00Z
             type: string
@@ -2160,24 +2040,6 @@ paths:
           in: header
           name: x-stream-response
           description: Whether to stream the response via SSE
-        - schema:
-            description: Client SDK language
-            example: typescript
-            type: string
-            enum:
-              - typescript
-              - python
-              - playground
-          in: header
-          name: x-language
-          description: Client SDK language
-        - schema:
-            description: Version of the Stagehand SDK
-            example: 3.0.6
-            type: string
-          in: header
-          name: x-sdk-version
-          description: Version of the Stagehand SDK
         - schema:
             description: ISO timestamp when request was sent
             example: 2025-01-15T10:30:00Z


### PR DESCRIPTION
# why
Once [this PR](https://github.com/browserbase/stagehand-python/pull/264) is merged into core, we no longer need to send `x-language` and `x-sdk-version` headers in our generated SDKs, since they send the `x-stainless` equivalents automatically. 
# what changed
Thus, this PR removes these from the openapi spec, so that the generated clients will stop having these fields.
# test plan
Will ensure that new generated sdks work successfully.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed x-language and x-sdk-version headers from the OpenAPI spec and server types, since generated SDKs now send x-stainless headers automatically. This simplifies SDK generation and removes redundant headers.

- **Migration**
  - Regenerate SDKs after the core change that adds x-stainless headers is merged.
  - Stop sending x-language and x-sdk-version in clients; rely on x-stainless headers.

<sup>Written for commit df65fe92f4bf494a0e3fa15e8224b344ae1ed03a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

