### PR TITLE
[feat]: add support for local caching of agent when using api

### DIFF
--- a/packages/core/lib/v3/types/private/cache.ts
+++ b/packages/core/lib/v3/types/private/cache.ts
@@ -35,6 +35,17 @@ export type AgentCacheDeps = {
   getSystemPrompt: () => string | undefined;
   domSettleTimeoutMs?: number;
   act: ActFn;
+  /**
+   * When true, the cache remains "enabled" even if no persistent storage is
+   * configured. This allows us to record cache entries purely in memory so they
+   * can be transferred elsewhere (e.g. streamed back to an API client).
+   */
+  allowRecordingWithoutStorage?: boolean;
+  /**
+   * When true, the AgentCache keeps the most recent entry in memory so callers
+   * can retrieve it (to send over the wire, for example).
+   */
+  captureEntries?: boolean;
 };
 
 export type ActCacheContext = {
@@ -148,4 +159,9 @@ export interface CachedAgentEntry {
   steps: AgentReplayStep[];
   result: AgentResult;
   timestamp: string;
+}
+
+export interface SerializedAgentCacheEntry {
+  cacheKey: string;
+  entry: CachedAgentEntry;
 }


### PR DESCRIPTION
# why

# what changed

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds local agent caching when running via the API. We stream the agent’s cache entry from the server and persist it to the local cacheDir for future cache hits. Fulfills STG-894.

- **New Features**
  - V3 auto-enables API cache streaming when cacheDir is set; successful runs persist the received entry locally.
  - StagehandAPIClient: new enableAgentCacheHeader option, request header x-stagehand-agent-cache-enabled, and consumeAgentCacheEntry() to retrieve streamed entries.
  - AgentCache: supports recording without storage, capturing the latest entry in memory, and persisting a serialized entry to disk.
  - Agent executions mark cache-eligible calls and validate cacheKey before persisting to prevent mismatches.

<sup>Written for commit 469aae841eaf46b4052cf4b54de6c5a782a03c6e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

