### PR TITLE
fix: guard pino-pretty for serverless environments

### DIFF
--- a/packages/core/lib/logger.ts
+++ b/packages/core/lib/logger.ts
@@ -34,6 +34,8 @@ export function createLogger(options: LoggerOptions = {}) {
   // and not in a test environment
   if (options.pretty && !isTestEnvironment()) {
     try {
+      // checking if pino-pretty is available
+      require.resolve("pino-pretty");
       // Use require for dynamic import
       const transport = {
         transport: {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,7 +54,6 @@
     "fetch-cookie": "^3.1.0",
     "openai": "^4.87.1",
     "pino": "^9.6.0",
-    "pino-pretty": "^13.0.0",
     "ws": "^8.18.0",
     "zod-to-json-schema": "^3.25.0"
   },
@@ -78,6 +77,7 @@
     "patchright-core": "^1.55.2",
     "playwright": "^1.52.0",
     "playwright-core": "^1.54.1",
+    "pino-pretty": "^13.0.0",
     "puppeteer-core": "^22.8.0"
   },
   "devDependencies": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -28,10 +28,12 @@
     "fastify-zod-openapi": "^5.5.0",
     "http-status-codes": "^2.3.0",
     "pino": "^9.7.0",
-    "pino-pretty": "^11.3.0",
     "playwright": "1.52.0",
     "uuid": "^11.0.5",
     "zod": "^4.2.0"
+  },
+  "optionalDependencies": {
+    "pino-pretty": "^11.3.0"  
   },
   "devDependencies": {
     "@types/node": "22.13.1",

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -51,15 +51,23 @@ const app = fastify({
 
     level: process.env.NODE_ENV === "production" ? "info" : "trace",
 
-    ...(process.env.NODE_ENV === "development" && {
-      transport: {
-        options: {
-          colorize: true,
-          ignore: "pid,hostname",
-        },
-        target: "pino-pretty",
-      },
-    }),
+    ...(process.env.NODE_ENV === "development" && (() => {
+      try {
+        require.resolve("pino-pretty");
+        return {
+          transport: {
+            options: {
+              colorize: true,
+              ignore: "pid,hostname",
+            },
+            target: "pino-pretty",
+          },
+        };
+      } catch {
+        // pino-pretty not available, use standard logging
+        return {};
+      }
+    })()),
   },
 
   return503OnClosing: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,9 +77,6 @@ importers:
       pino:
         specifier: ^9.6.0
         version: 9.6.0
-      pino-pretty:
-        specifier: ^13.0.0
-        version: 13.0.0
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
@@ -141,6 +138,9 @@ importers:
       patchright-core:
         specifier: ^1.55.2
         version: 1.55.2
+      pino-pretty:
+        specifier: ^13.0.0
+        version: 13.0.0
       playwright:
         specifier: ^1.52.0
         version: 1.54.2
@@ -284,9 +284,6 @@ importers:
       pino:
         specifier: ^9.7.0
         version: 9.14.0
-      pino-pretty:
-        specifier: ^11.3.0
-        version: 11.3.0
       playwright:
         specifier: 1.52.0
         version: 1.52.0
@@ -296,6 +293,10 @@ importers:
       zod:
         specifier: ^4.2.0
         version: 4.2.1
+    optionalDependencies:
+      pino-pretty:
+        specifier: ^11.3.0
+        version: 11.3.0
     devDependencies:
       '@types/node':
         specifier: 22.13.1
@@ -8485,6 +8486,7 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+    optional: true
 
   bufferutil@4.0.9:
     dependencies:
@@ -8644,7 +8646,8 @@ snapshots:
       color-convert: 2.0.1
       color-string: 1.9.1
 
-  colorette@2.0.20: {}
+  colorette@2.0.20:
+    optional: true
 
   combined-stream@1.0.8:
     dependencies:
@@ -8737,7 +8740,8 @@ snapshots:
 
   dataloader@1.4.0: {}
 
-  dateformat@4.6.3: {}
+  dateformat@4.6.3:
+    optional: true
 
   debug@2.6.9:
     dependencies:
@@ -9223,7 +9227,8 @@ snapshots:
 
   eventemitter3@4.0.7: {}
 
-  events@3.3.0: {}
+  events@3.3.0:
+    optional: true
 
   eventsource-parser@1.1.2: {}
 
@@ -9333,7 +9338,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fast-copy@3.0.2: {}
+  fast-copy@3.0.2:
+    optional: true
 
   fast-decode-uri-component@1.0.1: {}
 
@@ -9370,7 +9376,8 @@ snapshots:
 
   fast-redact@3.5.0: {}
 
-  fast-safe-stringify@2.1.1: {}
+  fast-safe-stringify@2.1.1:
+    optional: true
 
   fast-uri@3.0.6: {}
 
@@ -9991,7 +9998,8 @@ snapshots:
       property-information: 7.0.0
       space-separated-tokens: 2.0.2
 
-  help-me@5.0.0: {}
+  help-me@5.0.0:
+    optional: true
 
   html-void-elements@3.0.0: {}
 
@@ -11008,7 +11016,8 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.1
 
-  minimist@1.2.8: {}
+  minimist@1.2.8:
+    optional: true
 
   minipass@3.3.6:
     dependencies:
@@ -11438,6 +11447,7 @@ snapshots:
       secure-json-parse: 2.7.0
       sonic-boom: 4.2.0
       strip-json-comments: 3.1.1
+    optional: true
 
   pino-pretty@13.0.0:
     dependencies:
@@ -11454,6 +11464,7 @@ snapshots:
       secure-json-parse: 2.7.0
       sonic-boom: 4.2.0
       strip-json-comments: 3.1.1
+    optional: true
 
   pino-std-serializers@7.0.0: {}
 
@@ -11589,7 +11600,8 @@ snapshots:
 
   process-warning@5.0.0: {}
 
-  process@0.11.10: {}
+  process@0.11.10:
+    optional: true
 
   progress@2.0.3: {}
 
@@ -11727,6 +11739,7 @@ snapshots:
       events: 3.3.0
       process: 0.11.10
       string_decoder: 1.3.0
+    optional: true
 
   readdirp@3.6.0:
     dependencies:
@@ -12089,7 +12102,8 @@ snapshots:
       extend-shallow: 2.0.1
       kind-of: 6.0.3
 
-  secure-json-parse@2.7.0: {}
+  secure-json-parse@2.7.0:
+    optional: true
 
   secure-json-parse@4.1.0: {}
 
@@ -12457,6 +12471,7 @@ snapshots:
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
+    optional: true
 
   stringify-entities@4.0.4:
     dependencies:


### PR DESCRIPTION
## Why

Stagehand crashes in serverless environments (e.g. Vercel) when `pino-pretty` is not available at runtime.  
`pino-pretty` is a dev-only formatter, but was treated as a required dependency, causing Pino to fail during initialization.

## What changed

- Moved `pino-pretty` to `optionalDependencies`
- Guarded all `pino-pretty` usage with `require.resolve` checks
- Ensured graceful fallback to standard logging when unavailable

## Test plan

This issue cannot be reliably reproduced locally due to Node.js module resolution and pnpm hoisting.  
The fix targets serverless runtimes where optional dependencies are omitted from the runtime bundle.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented serverless crashes by making pino-pretty optional and guarding its usage. Logging now falls back to standard Pino output when pino-pretty isn’t available.

- **Bug Fixes**
  - Guarded pino-pretty with require.resolve in core logger and Fastify server.
  - Enabled pretty transport only in development when available.
  - Fallback to standard logging when pino-pretty is missing.

- **Dependencies**
  - Moved pino-pretty to optionalDependencies to avoid serverless runtime failures.

<sup>Written for commit bcba3c51b483e2662d1746dd2b58002400c3034b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

