### PR TITLE
feat: Allow user-provided providerOptions in agent config

### DIFF
--- a/packages/core/lib/v3/handlers/v3AgentHandler.ts
+++ b/packages/core/lib/v3/handlers/v3AgentHandler.ts
@@ -14,6 +14,7 @@ import {
   type StreamTextOnStepFinishCallback,
   type PrepareStepFunction,
 } from "ai";
+import type { SharedV2ProviderOptions } from "@ai-sdk/provider";
 import { StagehandZodObject } from "../zodCompat";
 import { processMessages } from "../agent/utils/messageProcessing";
 import { LLMClient } from "../llm/LLMClient";
@@ -50,6 +51,7 @@ export class V3AgentHandler {
   private systemInstructions?: string;
   private mcpTools?: ToolSet;
   private mode: AgentToolMode;
+  private userProviderOptions?: Record<string, unknown>;
 
   constructor(
     v3: V3,
@@ -59,6 +61,7 @@ export class V3AgentHandler {
     systemInstructions?: string,
     mcpTools?: ToolSet,
     mode?: AgentToolMode,
+    userProviderOptions?: Record<string, unknown>,
   ) {
     this.v3 = v3;
     this.logger = logger;
@@ -67,6 +70,65 @@ export class V3AgentHandler {
     this.systemInstructions = systemInstructions;
     this.mcpTools = mcpTools;
     this.mode = mode ?? "dom";
+    this.userProviderOptions = userProviderOptions;
+  }
+
+  /**
+   * Build provider options by merging user-provided options with defaults.
+   * For Gemini 3 models, defaults include mediaResolution: "MEDIA_RESOLUTION_HIGH".
+   * User options take precedence via deep merge.
+   */
+  private buildProviderOptions(
+    modelId: string,
+  ): SharedV2ProviderOptions | undefined {
+    const isGemini3 = modelId.includes("gemini-3");
+
+    if (!isGemini3 && !this.userProviderOptions) {
+      return undefined;
+    }
+
+    const defaultGemini3Options: SharedV2ProviderOptions = isGemini3
+      ? { google: { mediaResolution: "MEDIA_RESOLUTION_HIGH" } }
+      : {};
+
+    if (!this.userProviderOptions) {
+      return defaultGemini3Options;
+    }
+
+    return this.deepMerge(
+      defaultGemini3Options,
+      this.userProviderOptions,
+    ) as SharedV2ProviderOptions;
+  }
+
+  /**
+   * Deep merge two objects. Source values override target values.
+   */
+  private deepMerge(
+    target: Record<string, unknown>,
+    source: Record<string, unknown>,
+  ): Record<string, unknown> {
+    const result = { ...target };
+    for (const key of Object.keys(source)) {
+      const sourceVal = source[key];
+      const targetVal = target[key];
+      if (
+        sourceVal !== null &&
+        typeof sourceVal === "object" &&
+        !Array.isArray(sourceVal) &&
+        targetVal !== null &&
+        typeof targetVal === "object" &&
+        !Array.isArray(targetVal)
+      ) {
+        result[key] = this.deepMerge(
+          targetVal as Record<string, unknown>,
+          sourceVal as Record<string, unknown>,
+        );
+      } else {
+        result[key] = sourceVal;
+      }
+    }
+    return result;
   }
 
   private async prepareAgent(
@@ -286,13 +348,7 @@ export class V3AgentHandler {
         prepareStep: this.createPrepareStep(callbacks?.prepareStep),
         onStepFinish: this.createStepHandler(state, callbacks?.onStepFinish),
         abortSignal: preparedOptions.signal,
-        providerOptions: wrappedModel.modelId.includes("gemini-3")
-          ? {
-              google: {
-                mediaResolution: "MEDIA_RESOLUTION_HIGH",
-              },
-            }
-          : undefined,
+        providerOptions: this.buildProviderOptions(wrappedModel.modelId),
       });
 
       const allMessages = [...messages, ...(result.response?.messages || [])];
@@ -452,13 +508,7 @@ export class V3AgentHandler {
         rejectResult(new AgentAbortError(reason));
       },
       abortSignal: options.signal,
-      providerOptions: wrappedModel.modelId.includes("gemini-3")
-        ? {
-            google: {
-              mediaResolution: "MEDIA_RESOLUTION_HIGH",
-            },
-          }
-        : undefined,
+      providerOptions: this.buildProviderOptions(wrappedModel.modelId),
     });
 
     const agentStreamResult = streamResult as AgentStreamResult;

--- a/packages/core/lib/v3/v3.ts
+++ b/packages/core/lib/v3/v3.ts
@@ -1608,6 +1608,12 @@ export class V3 {
       ? this.resolveLlmClient(options.model)
       : this.llmClient;
 
+    // Extract user-provided providerOptions from model config
+    const userProviderOptions =
+      typeof options?.model === "object"
+        ? (options.model as Record<string, unknown>).providerOptions
+        : undefined;
+
     const handler = new V3AgentHandler(
       this,
       this.logger,
@@ -1618,6 +1624,7 @@ export class V3 {
       options?.systemPrompt,
       tools,
       options?.mode,
+      userProviderOptions as Record<string, unknown> | undefined,
     );
 
     const resolvedOptions: AgentExecuteOptions | AgentStreamExecuteOptions =

--- a/packages/core/tests/v3-agent-handler-provider-options.test.ts
+++ b/packages/core/tests/v3-agent-handler-provider-options.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "vitest";
+import { V3AgentHandler } from "../lib/v3/handlers/v3AgentHandler";
+
+/**
+ * Test suite for V3AgentHandler's providerOptions merging functionality.
+ *
+ * Tests the buildProviderOptions and deepMerge methods that allow users
+ * to pass custom providerOptions (like thinkingConfig) while preserving
+ * default options for specific models (like Gemini 3's mediaResolution).
+ *
+ * @see https://github.com/browserbase/stagehand/issues/1524
+ */
+describe("V3AgentHandler providerOptions", () => {
+  // Helper to create a handler with specific userProviderOptions
+  function createHandler(
+    userProviderOptions?: Record<string, unknown>,
+  ): V3AgentHandler {
+    // Create handler with minimal dependencies (null/undefined for unused params)
+    // We only need to test the providerOptions logic, not the full agent
+    return new V3AgentHandler(
+      null as unknown as ConstructorParameters<typeof V3AgentHandler>[0],
+      () => {},
+      null as unknown as ConstructorParameters<typeof V3AgentHandler>[2],
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      userProviderOptions,
+    );
+  }
+
+  // Access private method for testing
+  function buildProviderOptions(
+    handler: V3AgentHandler,
+    modelId: string,
+  ): unknown {
+    return (handler as unknown as { buildProviderOptions: (id: string) => unknown }).buildProviderOptions(modelId);
+  }
+
+  describe("buildProviderOptions", () => {
+    describe("with no user options", () => {
+      it("returns undefined for non-Gemini3 models", () => {
+        const handler = createHandler();
+        expect(buildProviderOptions(handler, "anthropic/claude-sonnet-4")).toBeUndefined();
+        expect(buildProviderOptions(handler, "openai/gpt-4o")).toBeUndefined();
+        expect(buildProviderOptions(handler, "google/gemini-2.5-flash")).toBeUndefined();
+      });
+
+      it("returns default mediaResolution for Gemini 3 models", () => {
+        const handler = createHandler();
+        const result = buildProviderOptions(handler, "google/gemini-3-flash-preview");
+
+        expect(result).toEqual({
+          google: { mediaResolution: "MEDIA_RESOLUTION_HIGH" },
+        });
+      });
+
+      it("detects Gemini 3 in various model ID formats", () => {
+        const handler = createHandler();
+
+        expect(buildProviderOptions(handler, "gemini-3-flash")).toEqual({
+          google: { mediaResolution: "MEDIA_RESOLUTION_HIGH" },
+        });
+        expect(buildProviderOptions(handler, "vertex/gemini-3-flash-preview")).toEqual({
+          google: { mediaResolution: "MEDIA_RESOLUTION_HIGH" },
+        });
+        expect(buildProviderOptions(handler, "google/gemini-3-pro")).toEqual({
+          google: { mediaResolution: "MEDIA_RESOLUTION_HIGH" },
+        });
+      });
+    });
+
+    describe("with user options", () => {
+      it("returns user options for non-Gemini3 models", () => {
+        const userOptions = {
+          google: {
+            thinkingConfig: { includeThoughts: true, thinkingBudget: 8192 },
+          },
+        };
+        const handler = createHandler(userOptions);
+        const result = buildProviderOptions(handler, "vertex/gemini-2.5-flash");
+
+        expect(result).toEqual(userOptions);
+      });
+
+      it("merges user options with Gemini 3 defaults", () => {
+        const userOptions = {
+          google: {
+            thinkingConfig: { includeThoughts: true },
+          },
+        };
+        const handler = createHandler(userOptions);
+        const result = buildProviderOptions(handler, "google/gemini-3-flash-preview");
+
+        expect(result).toEqual({
+          google: {
+            mediaResolution: "MEDIA_RESOLUTION_HIGH",
+            thinkingConfig: { includeThoughts: true },
+          },
+        });
+      });
+
+      it("user options override Gemini 3 defaults when conflicting", () => {
+        const userOptions = {
+          google: {
+            mediaResolution: "MEDIA_RESOLUTION_LOW",
+          },
+        };
+        const handler = createHandler(userOptions);
+        const result = buildProviderOptions(handler, "google/gemini-3-flash-preview");
+
+        expect(result).toEqual({
+          google: { mediaResolution: "MEDIA_RESOLUTION_LOW" },
+        });
+      });
+
+      it("preserves nested user options during merge", () => {
+        const userOptions = {
+          google: {
+            thinkingConfig: {
+              includeThoughts: true,
+              thinkingBudget: 16384,
+            },
+            customOption: "value",
+          },
+          otherProvider: {
+            setting: true,
+          },
+        };
+        const handler = createHandler(userOptions);
+        const result = buildProviderOptions(handler, "google/gemini-3-flash-preview");
+
+        expect(result).toEqual({
+          google: {
+            mediaResolution: "MEDIA_RESOLUTION_HIGH",
+            thinkingConfig: {
+              includeThoughts: true,
+              thinkingBudget: 16384,
+            },
+            customOption: "value",
+          },
+          otherProvider: {
+            setting: true,
+          },
+        });
+      });
+    });
+  });
+
+  describe("deepMerge", () => {
+    // Access private method for testing
+    function deepMerge(
+      handler: V3AgentHandler,
+      target: Record<string, unknown>,
+      source: Record<string, unknown>,
+    ): Record<string, unknown> {
+      return (handler as unknown as {
+        deepMerge: (t: Record<string, unknown>, s: Record<string, unknown>) => Record<string, unknown>;
+      }).deepMerge(target, source);
+    }
+
+    const handler = createHandler();
+
+    it("merges flat objects", () => {
+      const result = deepMerge(handler, { a: 1 }, { b: 2 });
+      expect(result).toEqual({ a: 1, b: 2 });
+    });
+
+    it("source values override target values", () => {
+      const result = deepMerge(handler, { a: 1 }, { a: 2 });
+      expect(result).toEqual({ a: 2 });
+    });
+
+    it("deeply merges nested objects", () => {
+      const result = deepMerge(
+        handler,
+        { nested: { a: 1, b: 2 } },
+        { nested: { b: 3, c: 4 } },
+      );
+      expect(result).toEqual({ nested: { a: 1, b: 3, c: 4 } });
+    });
+
+    it("replaces arrays instead of merging them", () => {
+      const result = deepMerge(
+        handler,
+        { arr: [1, 2, 3] },
+        { arr: [4, 5] },
+      );
+      expect(result).toEqual({ arr: [4, 5] });
+    });
+
+    it("handles null values in source", () => {
+      const result = deepMerge(
+        handler,
+        { a: { nested: true } },
+        { a: null },
+      );
+      expect(result).toEqual({ a: null });
+    });
+
+    it("preserves target when source nested value is null", () => {
+      const result = deepMerge(
+        handler,
+        { a: { nested: true }, b: 1 },
+        { a: null, b: 2 },
+      );
+      expect(result).toEqual({ a: null, b: 2 });
+    });
+
+    it("does not mutate original objects", () => {
+      const target = { a: { b: 1 } };
+      const source = { a: { c: 2 } };
+      const result = deepMerge(handler, target, source);
+
+      expect(target).toEqual({ a: { b: 1 } });
+      expect(source).toEqual({ a: { c: 2 } });
+      expect(result).toEqual({ a: { b: 1, c: 2 } });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds support for users to pass custom `providerOptions` to the agent via `AgentModelConfig`. This enables features like Gemini's reasoning/thinking output (`thinkingConfig`) that were previously inaccessible due to hardcoded `providerOptions`.

- Update `V3AgentHandler` constructor to accept `userProviderOptions`
- Add `buildProviderOptions()` method to merge user options with Gemini 3 defaults
- Add `deepMerge()` helper for nested object merging
- Extract and pass `providerOptions` from model config in `v3.ts`
- Add comprehensive test suite (14 tests) for the new functionality

## Motivation

Resolves #1524

Stagehand hardcodes `providerOptions` for Gemini 3 models, only setting `mediaResolution: "MEDIA_RESOLUTION_HIGH"`. This prevents users from configuring provider-specific options like `thinkingConfig: { includeThoughts: true, thinkingBudget: 8192 }` which is required to access Gemini's reasoning/thinking output.

## Usage

```typescript
const agent = stagehand.agent({
  model: {
    modelName: "vertex/gemini-2.5-flash",
    providerOptions: {
      google: {
        thinkingConfig: {
          includeThoughts: true,
          thinkingBudget: 8192,
        },
      },
    },
  },
  stream: true,
});

const result = await agent.execute({
  instruction: "Navigate to...",
  callbacks: {
    onStepFinish: ({ reasoning }) => {
      console.log("Reasoning:", reasoning);  // Now populated!
    }
  }
});
```

## Test plan

- [x] All 322 existing vitest tests pass
- [x] Added 14 new tests for `buildProviderOptions` and `deepMerge` functionality
- [x] Manually tested with `vertex/gemini-2.5-flash` + `thinkingBudget: 8192` - reasoning output works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for user-provided providerOptions in AgentModelConfig, enabling provider-specific features like Gemini reasoning output. For Gemini 3 models, we still apply the default mediaResolution and merge user options on top.

- **New Features**
  - Accept providerOptions in V3AgentHandler and pass them from v3.ts.
  - Merge user options with Gemini 3 defaults via buildProviderOptions and deepMerge; user values override defaults.
  - Apply providerOptions in both execute and stream paths, with tests covering merge behavior.

<sup>Written for commit a1b4e74cc0fe43cb2d3dbfeeca57448919765c41. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

