### PR TITLE
Using provider/model syntax in modelName examples within openapi spec

### DIFF
--- a/packages/core/lib/v3/types/public/api.ts
+++ b/packages/core/lib/v3/types/public/api.ts
@@ -69,8 +69,8 @@ export const ModelConfigObjectSchema = z
       }),
     modelName: z.string().meta({
       description:
-        "Model name string without prefix (e.g., 'gpt-5-nano', 'claude-4.5-opus')",
-      example: "gpt-5-nano",
+        "Model name string (e.g., 'openai/gpt-5-nano', 'anthropic/claude-4.5-opus')",
+      example: "openai/gpt-5-nano",
     }),
     apiKey: z.string().optional().meta({
       description: "API key for the model provider",
@@ -311,7 +311,7 @@ export const SessionStartRequestSchema = z
   .object({
     modelName: z.string().meta({
       description: "Model name to use for AI operations",
-      example: "gpt-4o",
+      example: "openai/gpt-4o",
     }),
     domSettleTimeoutMs: z.number().optional().meta({
       description: "Timeout in ms to wait for DOM to settle",

--- a/packages/server/openapi.v3.yaml
+++ b/packages/server/openapi.v3.yaml
@@ -161,8 +161,8 @@ components:
             - google
             - microsoft
         modelName:
-          description: Model name string without prefix (e.g., 'gpt-5-nano',
-            'claude-4.5-opus')
+          description: Model name string (e.g., 'openai/gpt-5-nano',
+            'anthropic/claude-4.5-opus')
           example: openai/gpt-5-nano
           type: string
         apiKey:
@@ -997,8 +997,8 @@ components:
             - google
             - microsoft
         modelName:
-          description: Model name string without prefix (e.g., 'gpt-5-nano',
-            'claude-4.5-opus')
+          description: Model name string (e.g., 'openai/gpt-5-nano',
+            'anthropic/claude-4.5-opus')
           example: openai/gpt-5-nano
           type: string
         apiKey:


### PR DESCRIPTION
# why
`https://stagehand.stldocs.app/api/python/resources/sessions/methods/start` examples were showing `model_name="gpt-4o"`.
# what changed
Changed zod schemas so that the examples show the `provider/model` syntax
# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated Zod schemas and OpenAPI examples to use provider/model syntax for modelName (e.g., "openai/gpt-4o"). This aligns the docs with the API and fixes incorrect examples shown in the Session start endpoint.

<sup>Written for commit 5657c1e41a32cef1e2daefbd499ba70b9ba63cb5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

