### PR TITLE
fix: avoid importing non-exported ai/dist

### DIFF
--- a/packages/core/lib/v3/agent/AgentProvider.ts
+++ b/packages/core/lib/v3/agent/AgentProvider.ts
@@ -1,4 +1,4 @@
-import { ToolSet } from "ai/dist";
+import { ToolSet } from "ai";
 import { AgentProviderType } from "../types/public/agent";
 import { LogLine } from "../types/public/logs";
 import { ClientOptions } from "../types/public/model";


### PR DESCRIPTION
## Why

Under `moduleResolution: "NodeNext"` with full type checking enabled, the build fails because the code attempts to import `ai/dist`, which is not exposed via the `ai` package `exports` field.

This import is tolerated under less strict module resolution settings, but NodeNext rejects it due to it's strict nature.

## What changed

Updated the import to reference the public `ai` entry point instead of the non-exported `ai/dist` path, aligning the code with the package’s declared exports.

## Test plan

- Ran `tsc --noEmit` with `moduleResolution: "NodeNext"`
- Verified that strict type checking passes without errors

Fixes #1531


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched ToolSet import from "ai/dist" to the public "ai" entry to comply with package exports and NodeNext strict resolution, fixing TypeScript type-check failures.
Build now passes with moduleResolution: "NodeNext" and strict type checking.

<sup>Written for commit b1ff6feaaec272a2412fca6220712c17f069bb59. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

