### PR TITLE
Fix (v3): global verbosity check in v3Logger console fallback

### DIFF
--- a/packages/core/lib/v3/logger.ts
+++ b/packages/core/lib/v3/logger.ts
@@ -31,6 +31,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 // Per-instance routing using AsyncLocalStorage
 const logContext = new AsyncLocalStorage<string>();
 const instanceLoggers = new Map<string, (line: LogLine) => void>();
+const FALLBACK_VERBOSITY = 1;
 
 export function bindInstanceLogger(
   instanceId: string,
@@ -76,6 +77,10 @@ export function v3Logger(line: LogLine): void {
   const lvl = line.level ?? 1;
   const levelStr = lvl === 0 ? "ERROR" : lvl === 2 ? "DEBUG" : "INFO";
   let output = `[${ts}] ${levelStr}: ${line.message}`;
+
+  if (lvl > FALLBACK_VERBOSITY) {
+    return;
+  }
 
   if (line.auxiliary) {
     for (const [key, { value, type }] of Object.entries(line.auxiliary)) {


### PR DESCRIPTION
## Problem

When using Stagehand V3 with `verbose: 0`, debug-level logs are still printed if `v3Logger` falls back to console logging.The fallback path bypasses verbosity filtering, resulting in unexpected debug output.

## Solution

Applied a default verbosity threshold check to the fallback logging path to ensure debug messages are suppressed unless explicitly allowed.

## Changes

- Added a default fallback verbosity check in `v3Logger`
- Prevented debug-level logs from being printed when verbosity is effectively disabled

Fixes #1490

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops debug logs from printing when verbose: 0 by adding a fallback verbosity threshold (1) to the v3Logger console fallback. Fixes #1490.

<sup>Written for commit 36b82cc7ad3e7c2147b17fac4cc44230d006c193. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

