### PR TITLE
[docs]: update docs to reflect deprecation of `cua: true` in favor of `mode: "cua"`

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -198,7 +198,7 @@ For more advanced scenarios using computer-use models:
 
 ```typescript
 const agent = stagehand.agent({
-  cua: true, // Enable Computer Use Agent mode
+  mode: "cua", // Enable Computer Use Agent mode
   model: "anthropic/claude-sonnet-4-20250514",
   // or "google/gemini-2.5-computer-use-preview-10-2025"
   systemPrompt: `You are a helpful assistant that can use a web browser.

--- a/claude.md
+++ b/claude.md
@@ -198,7 +198,7 @@ For more advanced scenarios using computer-use models:
 
 ```typescript
 const agent = stagehand.agent({
-  cua: true, // Enable Computer Use Agent mode
+  mode: "cua", // Enable Computer Use Agent mode
   model: "anthropic/claude-sonnet-4-20250514",
   // or "google/gemini-2.5-computer-use-preview-10-2025"
   systemPrompt: `You are a helpful assistant that can use a web browser.

--- a/packages/core/examples/agent-custom-tools.ts
+++ b/packages/core/examples/agent-custom-tools.ts
@@ -51,7 +51,7 @@ async function main() {
 
     // Create a computer use agent
     const agent = stagehand.agent({
-      cua: true,
+      mode: "cua",
       model: {
         modelName: "anthropic/claude-sonnet-4-5-20250929",
         apiKey: process.env.ANTHROPIC_API_KEY,

--- a/packages/core/examples/cua-example.ts
+++ b/packages/core/examples/cua-example.ts
@@ -26,7 +26,7 @@ async function main() {
 
     // Create a computer use agent
     const agent = stagehand.agent({
-      cua: true,
+      mode: "cua",
       model: {
         modelName: "google/gemini-2.5-computer-use-preview-10-2025",
         apiKey: process.env.GEMINI_API_KEY ?? process.env.GOOGLE_API_KEY,

--- a/packages/core/examples/oss-cua-example.ts
+++ b/packages/core/examples/oss-cua-example.ts
@@ -33,7 +33,7 @@ async function main() {
 
     // Create a computer use agent
     const agent = stagehand.agent({
-      cua: true,
+      mode: "cua",
       model: {
         modelName: "microsoft/fara-7b",
         apiKey: process.env.AZURE_API_KEY,

--- a/packages/core/examples/v3/cuaReplay.ts
+++ b/packages/core/examples/v3/cuaReplay.ts
@@ -28,7 +28,7 @@ async function runDemo(runNumber: number) {
   });
 
   const agent = stagehand.agent({
-    cua: true,
+    mode: "cua",
     model: "anthropic/claude-sonnet-4-20250514",
   });
 

--- a/packages/docs/v3/basics/agent.mdx
+++ b/packages/docs/v3/basics/agent.mdx
@@ -54,12 +54,16 @@ Some advanced features are only available with certain agent modes:
 
 ### Computer Use Agents
 
-You can use specialized computer use models from either Google, OpenAI, or Anthropic as shown below, with `cua` set to `true`. To compare the performance of different computer use models, you can visit our [evals page](https://www.stagehand.dev/agent-evals).
+You can use specialized computer use models from either Google, OpenAI, or Anthropic as shown below, with `mode` set to `"cua"`. To compare the performance of different computer use models, you can visit our [evals page](https://www.stagehand.dev/agent-evals).
+
+<Warning>
+**Deprecation Notice:** The `cua: true` option is deprecated and will be removed in a future version. Use `mode: "cua"` instead.
+</Warning>
 
 <CodeGroup>
 ```typescript Google
 const agent = stagehand.agent({
-    cua: true,
+    mode: "cua",
     model: {
         modelName: "google/gemini-2.5-computer-use-preview-10-2025",
         apiKey: process.env.GOOGLE_GENERATIVE_AI_API_KEY
@@ -76,7 +80,7 @@ await agent.execute({
 
 ```typescript OpenAI
 const agent = stagehand.agent({
-    cua: true,
+    mode: "cua",
     model: {
         modelName: "openai/computer-use-preview",
         apiKey: process.env.OPENAI_API_KEY
@@ -92,7 +96,7 @@ await agent.execute({
 ```
 ```typescript Anthropic
 const agent = stagehand.agent({
-    cua: true,
+    mode: "cua",
     model: {
         modelName: "anthropic/claude-sonnet-4-20250514",
         apiKey: process.env.ANTHROPIC_API_KEY
@@ -273,7 +277,7 @@ import { tool } from "ai";
 import { z } from "zod/v3";
 
 const agent = stagehand.agent({
-  cua: true,
+  mode: "cua",
   model: "anthropic/claude-sonnet-4-20250514",
   tools: {
     searchDatabase: tool({
@@ -368,7 +372,7 @@ Agents can be enhanced with external tools and services through MCP (Model Conte
 <CodeGroup>
 ```typescript Pass URL
 const agent = stagehand.agent({
-    cua: true,
+    mode: "cua",
     model: {
         modelName: "openai/computer-use-preview",
         apiKey: process.env.OPENAI_API_KEY
@@ -390,7 +394,7 @@ const supabaseClient = await connectToMCPServer(
 );
 
 const agent = stagehand.agent({
-    cua: true,
+    mode: "cua",
     model: {
         modelName: "openai/computer-use-preview",
         apiKey: process.env.OPENAI_API_KEY
@@ -412,7 +416,7 @@ MCP integrations enable agents to be more powerful by combining browser automati
 Enable streaming mode to receive incremental responses from the agent. This is useful for building real-time UIs that show the agent's reasoning as it progresses.
 
 <Warning>
-**Non-CUA agents only.** Streaming, callbacks, abort signals, and message continuation are only available when using the standard agent (without `cua: true`). These features are not supported with Computer Use Agents.
+**Non-CUA agents only.** Streaming, callbacks, abort signals, and message continuation are only available when using the standard agent (without `mode: "cua"`). These features are not supported with Computer Use Agents.
 </Warning>
 
 <Note>These are experimental features. Set `experimental: true` in your Stagehand constructor to enable them.</Note>

--- a/packages/docs/v3/best-practices/caching.mdx
+++ b/packages/docs/v3/best-practices/caching.mdx
@@ -64,7 +64,7 @@ const page = stagehand.context.pages()[0];
 await page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/drag-drop/");
 
 const agent = stagehand.agent({
-  cua: true,
+  mode: "cua",
   model: {
     modelName: "google/gemini-2.5-computer-use-preview-10-2025",
     apiKey: process.env.GOOGLE_GENERATIVE_AI_API_KEY

--- a/packages/docs/v3/best-practices/computer-use.mdx
+++ b/packages/docs/v3/best-practices/computer-use.mdx
@@ -28,6 +28,10 @@ Stagehand not only handles the execution of Computer Use outputs, but also lets 
 
 Stagehand lets you use Computer Use Agents with one line of code:
 
+<Warning>
+**Deprecation Notice:** The `cua: true` option is deprecated and will be removed in a future version. Use `mode: "cua"` instead.
+</Warning>
+
 <Note>
 **IMPORTANT! Configure your browser dimensions**
 
@@ -93,7 +97,7 @@ Call `execute` on the agent to assign a task to the agent.
 ```typescript Google
 await page.goto("https://www.google.com/");
 const agent = stagehand.agent({
-    cua: true,
+    mode: "cua",
     model: {
         modelName: "google/gemini-2.5-computer-use-preview-10-2025",
         apiKey: process.env.GOOGLE_GENERATIVE_AI_API_KEY
@@ -111,7 +115,7 @@ await agent.execute({
 ```typescript OpenAI
 await page.goto("https://www.google.com/");
 const agent = stagehand.agent({
-    cua: true,
+    mode: "cua",
     model: {
         modelName: "openai/computer-use-preview",
         apiKey: process.env.OPENAI_API_KEY
@@ -128,7 +132,7 @@ await agent.execute({
 ```typescript Anthropic
 await page.goto("https://www.google.com/");
 const agent = stagehand.agent({
-    cua: true,
+    mode: "cua",
     model: {
         modelName: "anthropic/claude-sonnet-4-20250514",
         apiKey: process.env.ANTHROPIC_API_KEY
@@ -161,7 +165,7 @@ Stagehand supports computer use models from Google, Anthropic, and OpenAI. You c
 <Tab title="Google">
 ```typescript
 const agent = stagehand.agent({
-    cua: true,
+    mode: "cua",
     model: "google/gemini-2.5-computer-use-preview-10-2025",
     // GOOGLE_GENERATIVE_AI_API_KEY is auto-loaded - set in your .env
 });
@@ -170,7 +174,7 @@ const agent = stagehand.agent({
 <Tab title="Anthropic">
 ```typescript
 const agent = stagehand.agent({
-    cua: true,
+    mode: "cua",
     model: "anthropic/claude-sonnet-4-20250514",
     // ANTHROPIC_API_KEY is auto-loaded - set in your .env
 });
@@ -179,7 +183,7 @@ const agent = stagehand.agent({
 <Tab title="OpenAI">
 ```typescript
 const agent = stagehand.agent({
-    cua: true,
+    mode: "cua",
     model: "openai/computer-use-preview",
     // OPENAI_API_KEY is auto-loaded - set in your .env
 });

--- a/packages/docs/v3/best-practices/deterministic-agent.mdx
+++ b/packages/docs/v3/best-practices/deterministic-agent.mdx
@@ -61,7 +61,7 @@ const page = stagehand.context.pages()[0];
 await page.goto("https://example.com");
 
 const agent = stagehand.agent({
-  cua: true,
+  mode: "cua",
   model: {
     modelName: "google/gemini-2.5-computer-use-preview-10-2025",
     apiKey: process.env.GOOGLE_GENERATIVE_AI_API_KEY
@@ -126,7 +126,7 @@ const page = stagehand.context.pages()[0];
 await page.goto("https://github.com");
 
 const agent = stagehand.agent({
-  cua: true,
+  mode: "cua",
   model: {
     modelName: "google/gemini-2.5-computer-use-preview-10-2025",
     apiKey: process.env.GOOGLE_GENERATIVE_AI_API_KEY
@@ -173,7 +173,7 @@ const page = stagehand.context.pages()[0];
 await page.goto("https://github.com");
 
 const agent = stagehand.agent({
-  cua: true,
+  mode: "cua",
   model: {
     modelName: "google/gemini-2.5-computer-use-preview-10-2025",
     apiKey: process.env.GOOGLE_GENERATIVE_AI_API_KEY
@@ -221,7 +221,7 @@ const page = stagehand.context.pages()[0];
 await page.goto("https://example.com");
 
 const agent = stagehand.agent({
-  cua: true,
+  mode: "cua",
   model: {
     modelName: "google/gemini-2.5-computer-use-preview-10-2025",
     apiKey: process.env.GOOGLE_GENERATIVE_AI_API_KEY

--- a/packages/docs/v3/configuration/models.mdx
+++ b/packages/docs/v3/configuration/models.mdx
@@ -494,14 +494,18 @@ const agent = stagehand.agent();
 However, the stagehand agent also accepts a `model` parameter, which accepts any [first class](/v3/configuration/models#first-class-models) model, including [computer use agents (CUA)](/v3/configuration/models#agent-models-with-cua-support). This is useful when you'd like the agent to use a different model than the one passed to Stagehand.
 
 <Tip>
-  To use a cua model, you must pass the `cua` parameter to the `agent()` method. If a non-cua model is used, whether specified in Stagehand or overridden in the `agent()` method, an error will be thrown.
+  To use a CUA model, you must pass the `mode: "cua"` parameter to the `agent()` method. If a non-CUA model is used, whether specified in Stagehand or overridden in the `agent()` method, an error will be thrown.
 </Tip>
+
+<Warning>
+**Deprecation Notice:** The `cua: true` option is deprecated and will be removed in a future version. Use `mode: "cua"` instead.
+</Warning>
 
 <Tabs>
 <Tab title="Google CUA">
 ```typescript
 const agent = stagehand.agent({
-  cua: true,
+  mode: "cua",
   model: "google/gemini-2.5-computer-use-preview-10-2025",
   // GOOGLE_GENERATIVE_AI_API_KEY is auto-loaded from .env
   // ... other agent options
@@ -511,7 +515,7 @@ const agent = stagehand.agent({
 <Tab title="Anthropic CUA">
 ```typescript
 const agent = stagehand.agent({
-  cua: true,
+  mode: "cua",
   model: "anthropic/claude-3-7-sonnet-latest",
   // ANTHROPIC_API_KEY is auto-loaded from .env
   // ... other agent options
@@ -521,7 +525,7 @@ const agent = stagehand.agent({
 <Tab title="OpenAI CUA">
 ```typescript
 const agent = stagehand.agent({
-  cua: true,
+  mode: "cua",
   model: "openai/computer-use-preview",
   // OPENAI_API_KEY is auto-loaded from .env
   // ... other agent options

--- a/packages/docs/v3/first-steps/ai-rules.mdx
+++ b/packages/docs/v3/first-steps/ai-rules.mdx
@@ -292,7 +292,7 @@ For more advanced scenarios using computer-use models:
 
 ```typescript
 const agent = stagehand.agent({
-  cua: true, // Enable Computer Use Agent mode
+  mode: "cua", // Enable Computer Use Agent mode
   model: "anthropic/claude-sonnet-4-20250514",
   // or "google/gemini-2.5-computer-use-preview-10-2025"
   systemPrompt: `You are a helpful assistant that can use a web browser.
@@ -309,7 +309,7 @@ await agent.execute({
 
 ```typescript
 const agent = stagehand.agent({
-  cua: true,
+  mode: "cua",
   model: {
     modelName: "google/gemini-2.5-computer-use-preview-10-2025",
     apiKey: process.env.GEMINI_API_KEY,

--- a/packages/docs/v3/first-steps/introduction.mdx
+++ b/packages/docs/v3/first-steps/introduction.mdx
@@ -52,7 +52,7 @@ const actions = await stagehand.observe("find submit buttons");
 
 // Agent - Automate entire workflows
 const agent = stagehand.agent({
-  cua: true,
+  mode: "cua",
   model: "google/gemini-2.5-computer-use-preview-10-2025",
 });
 await agent.execute("apply for this job");

--- a/packages/docs/v3/first-steps/quickstart.mdx
+++ b/packages/docs/v3/first-steps/quickstart.mdx
@@ -67,7 +67,7 @@ async function main() {
   console.log(`Observe result:\n`, observeResult);
 
   const agent = stagehand.agent({
-    cua: true,
+    mode: "cua",
     model: "google/gemini-2.5-computer-use-preview-10-2025",
     systemPrompt: "You're a helpful assistant that can control a web browser.",
   });

--- a/packages/docs/v3/references/agent.mdx
+++ b/packages/docs/v3/references/agent.mdx
@@ -30,11 +30,12 @@ interface AgentConfig {
   systemPrompt?: string;
   integrations?: (Client | string)[];
   tools?: ToolSet;
+  /** @deprecated Use `mode: "cua"` instead */
   cua?: boolean;
   model?: string | AgentModelConfig<string>;
   executionModel?: string | AgentModelConfig<string>;
   stream?: boolean; // Enable streaming mode (experimental)
-  mode?: "dom" | "hybrid"; // Tool mode (experimental)
+  mode?: "dom" | "hybrid" | "cua"; // Tool mode
 }
 
 // AgentModelConfig for advanced configuration
@@ -91,6 +92,8 @@ interface AgentInstance {
 </ParamField>
 
 <ParamField path="cua" type="boolean" optional>
+  <Warning>**Deprecated:** Use `mode: "cua"` instead. This option will be removed in a future version.</Warning>
+  
   Indicates whether Computer Use Agent (CUA) mode is enabled. When false, the agent uses standard tool-based operation instead of computer control.
 </ParamField>
 
@@ -109,15 +112,16 @@ interface AgentInstance {
   
   **Default:** `false`
   
-  <Warning>**Non-CUA agents only.** Requires `experimental: true`. Not available when `cua: true`.</Warning>
+  <Warning>**Non-CUA agents only.** Requires `experimental: true`. Not available when `mode: "cua"`.</Warning>
 </ParamField>
 
-<ParamField path="mode" type='"dom" | "hybrid"' optional>
+<ParamField path="mode" type='"dom" | "hybrid" | "cua"' optional>
   Tool mode for the agent. Determines which set of tools are available to the agent.
   
   **Modes:**
   - `"dom"` (default): Uses DOM-based tools (`act`, `fillForm`) for structured page interactions. Works with any model.
   - `"hybrid"`: Uses both DOM-based and coordinate-based tools (`act`, `click`, `type`, `dragAndDrop`, `clickAndHold`, `fillForm`) for visual/screenshot-based interactions. Requires models with reliable coordinate-based action capabilities.
+  - `"cua"`: Uses Computer Use Agent (CUA) providers like Anthropic Claude, Google Gemini, or OpenAI for screenshot-based automation. This is the preferred way to enable CUA mode (replaces the deprecated `cua: true` option).
   
   **Default:** `"dom"`
   
@@ -227,19 +231,19 @@ interface AgentStreamCallbacks {
 <ParamField path="messages" type="ModelMessage[]" optional>
   Previous conversation messages to continue from. Pass the `messages` from a previous `AgentResult` to continue that conversation.
 
-  <Warning>**Non-CUA agents only.** Requires `experimental: true`. Not available when `cua: true`.</Warning>
+  <Warning>**Non-CUA agents only.** Requires `experimental: true`. Not available when `mode: "cua"`.</Warning>
 </ParamField>
 
 <ParamField path="signal" type="AbortSignal" optional>
   An `AbortSignal` that can be used to cancel the agent execution. When aborted, the agent will stop and throw an `AgentAbortError`.
 
-  <Warning>**Non-CUA agents only.** Requires `experimental: true`. Not available when `cua: true`.</Warning>
+  <Warning>**Non-CUA agents only.** Requires `experimental: true`. Not available when `mode: "cua"`.</Warning>
 </ParamField>
 
 <ParamField path="callbacks" type="AgentExecuteCallbacks | AgentStreamCallbacks" optional>
   Callbacks to hook into the agent's execution lifecycle. The available callbacks depend on whether streaming is enabled.
 
-  <Warning>**Non-CUA agents only.** Requires `experimental: true`. Not available when `cua: true`.</Warning>
+  <Warning>**Non-CUA agents only.** Requires `experimental: true`. Not available when `mode: "cua"`.</Warning>
 
   <Expandable title="Non-Streaming Callbacks (AgentExecuteCallbacks)">
     <ParamField path="prepareStep" type="PrepareStepFunction<ToolSet>" optional>


### PR DESCRIPTION
# why

cua: true is deprecated 

# what changed

replaced all references of cua: true with mode: "cua"

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deprecates cua: true in favor of mode: "cua" across docs and examples, and adds deprecation notices to guide users toward the new API. Updates references and notes to consistently use mode: "cua", including streaming/callback caveats.

- **Migration**
  - Replace all agent configs using cua: true with mode: "cua".
  - Note: streaming/callbacks remain non-CUA only and now reference mode: "cua".
  - Existing cua: true usage will work for now but is scheduled for removal.

<sup>Written for commit ce5adef7c39f440a7388db4b6fb3a3d1d31df13a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

