### PR TITLE
feat(cache): add custom tool caching and fix replay navigation timing

### DIFF
--- a/packages/core/lib/v3/handlers/v3CuaAgentHandler.ts
+++ b/packages/core/lib/v3/handlers/v3CuaAgentHandler.ts
@@ -511,7 +511,15 @@ export class V3CuaAgentHandler {
         return { success: true };
       }
       case "custom_tool": {
-        // Custom tools are handled by the agent client directly
+        // Custom tools are handled by the agent client directly.
+        // Record the tool invocation for cache replay.
+        if (recording) {
+          this.v3.recordAgentReplayStep({
+            type: "custom_tool",
+            name: action.name as string,
+            arguments: (action.arguments as Record<string, unknown>) ?? {},
+          });
+        }
         return { success: true };
       }
       default:

--- a/packages/core/lib/v3/types/private/cache.ts
+++ b/packages/core/lib/v3/types/private/cache.ts
@@ -82,6 +82,7 @@ export type AgentReplayStep =
   | AgentReplayWaitStep
   | AgentReplayNavBackStep
   | AgentReplayKeysStep
+  | AgentReplayCustomToolStep
   | { type: string; [key: string]: unknown };
 
 export interface AgentReplayActStep {
@@ -132,6 +133,18 @@ export interface AgentReplayKeysStep {
     keys?: string;
     times?: number;
   };
+}
+
+/**
+ * Represents a custom tool invocation that should be replayed.
+ * During replay, the tool will be re-executed with the same arguments.
+ */
+export interface AgentReplayCustomToolStep {
+  type: "custom_tool";
+  /** The name of the custom tool to execute */
+  name: string;
+  /** The arguments to pass to the tool */
+  arguments: Record<string, unknown>;
 }
 
 export interface SanitizedAgentExecuteOptions {

--- a/packages/core/lib/v3/v3.ts
+++ b/packages/core/lib/v3/v3.ts
@@ -1955,9 +1955,18 @@ export class V3 {
               this.beginAgentReplayRecording();
             }
 
-            const streamResult = await handler.stream(
-              resolvedOptions as AgentStreamExecuteOptions,
-            );
+            let streamResult: AgentStreamResult;
+            try {
+              streamResult = await handler.stream(
+                resolvedOptions as AgentStreamExecuteOptions,
+              );
+            } catch (err) {
+              // Clean up recording state if stream creation fails
+              if (recording) {
+                this.discardAgentReplayRecording();
+              }
+              throw err;
+            }
 
             if (cacheContext) {
               const wrappedStream = this.agentCache.wrapStreamForCaching(

--- a/packages/core/lib/v3/v3.ts
+++ b/packages/core/lib/v3/v3.ts
@@ -6,6 +6,7 @@ import path from "path";
 import process from "process";
 import { v7 as uuidv7 } from "uuid";
 import { z } from "zod";
+import type { ToolSet } from "ai";
 import {
   InferStagehandSchema,
   StagehandZodSchema,
@@ -1582,6 +1583,37 @@ export class V3 {
   }
 
   /**
+   * Wraps custom tools to record their invocations for cache replay.
+   * When recording is active, each tool execution will be recorded as a custom_tool step.
+   */
+  private wrapToolsForRecording(tools: ToolSet): ToolSet {
+    const wrappedTools: ToolSet = {};
+    const v3Instance = this;
+    for (const [name, tool] of Object.entries(tools)) {
+      const originalTool = tool;
+      wrappedTools[name] = {
+        ...tool,
+        execute: async (
+          args: Parameters<typeof originalTool.execute>[0],
+          options: Parameters<typeof originalTool.execute>[1],
+        ) => {
+          // Record the tool invocation if agent replay recording is active
+          if (v3Instance.isAgentReplayActive()) {
+            v3Instance.recordAgentReplayStep({
+              type: "custom_tool",
+              name,
+              arguments: (args as Record<string, unknown>) ?? {},
+            });
+          }
+          // Execute the original tool, preserving its context
+          return originalTool.execute(args, options);
+        },
+      };
+    }
+    return wrappedTools;
+  }
+
+  /**
    * Prepares shared context for agent execution (both execute and stream).
    * Extracts duplicated setup logic into a single helper.
    */
@@ -1598,6 +1630,7 @@ export class V3 {
     instruction: string;
     cacheContext: AgentCacheContext | null;
     llmClient: LLMClient;
+    tools: ToolSet;
   }> {
     // Note: experimental validation is done at the call site before this method
     // Warn if mode is not explicitly set (defaults to "dom")
@@ -1614,6 +1647,9 @@ export class V3 {
       ? await resolveTools(options.integrations, options.tools)
       : (options?.tools ?? {});
 
+    // Wrap custom tools to record invocations for cache replay
+    const wrappedTools = this.wrapToolsForRecording(tools);
+
     const agentLlmClient = options?.model
       ? this.resolveLlmClient(options.model)
       : this.llmClient;
@@ -1626,7 +1662,7 @@ export class V3 {
         ? options.executionModel
         : options?.executionModel?.modelName,
       options?.systemPrompt,
-      tools,
+      wrappedTools,
       options?.mode,
     );
 
@@ -1668,6 +1704,7 @@ export class V3 {
       instruction,
       cacheContext,
       llmClient: agentLlmClient,
+      tools,
     };
   }
 
@@ -1813,7 +1850,11 @@ export class V3 {
                 page: startPage,
               });
               if (cacheContext) {
-                const replayed = await this.agentCache.tryReplay(cacheContext);
+                const replayed = await this.agentCache.tryReplay(
+                  cacheContext,
+                  undefined,
+                  tools,
+                );
                 if (replayed) {
                   SessionFileLogger.logAgentTaskCompleted({ cacheHit: true });
                   return replayed;
@@ -1889,7 +1930,7 @@ export class V3 {
 
           // Streaming mode
           if (isStreaming) {
-            const { handler, resolvedOptions, cacheContext, llmClient } =
+            const { handler, resolvedOptions, cacheContext, llmClient, tools } =
               await this.prepareAgentExecution(
                 options,
                 instructionOrOptions,
@@ -1900,11 +1941,18 @@ export class V3 {
               const replayed = await this.agentCache.tryReplayAsStream(
                 cacheContext,
                 llmClient,
+                tools,
               );
               if (replayed) {
                 SessionFileLogger.logAgentTaskCompleted({ cacheHit: true });
                 return replayed;
               }
+            }
+
+            // Start recording BEFORE stream execution so custom tools are recorded
+            const recording = !!cacheContext;
+            if (recording) {
+              this.beginAgentReplayRecording();
             }
 
             const streamResult = await handler.stream(
@@ -1915,7 +1963,7 @@ export class V3 {
               const wrappedStream = this.agentCache.wrapStreamForCaching(
                 cacheContext,
                 streamResult,
-                () => this.beginAgentReplayRecording(),
+                () => {}, // Recording already started above
                 () => this.endAgentReplayRecording(),
                 () => this.discardAgentReplayRecording(),
               );
@@ -1930,7 +1978,7 @@ export class V3 {
           }
 
           // Non-streaming mode (default)
-          const { handler, resolvedOptions, cacheContext, llmClient } =
+          const { handler, resolvedOptions, cacheContext, llmClient, tools } =
             await this.prepareAgentExecution(
               options,
               instructionOrOptions,
@@ -1941,6 +1989,7 @@ export class V3 {
             const replayed = await this.agentCache.tryReplay(
               cacheContext,
               llmClient,
+              tools,
             );
             if (replayed) {
               SessionFileLogger.logAgentTaskCompleted({ cacheHit: true });

--- a/packages/core/lib/v3/v3.ts
+++ b/packages/core/lib/v3/v3.ts
@@ -1850,6 +1850,9 @@ export class V3 {
                 page: startPage,
               });
               if (cacheContext) {
+                // Pass unwrapped tools (not wrappedTools) for replay. During replay,
+                // tools execute with cached args - using wrappedTools would record
+                // these replayed calls, causing duplicate cache entries.
                 const replayed = await this.agentCache.tryReplay(
                   cacheContext,
                   undefined,
@@ -1938,6 +1941,9 @@ export class V3 {
               );
 
             if (cacheContext) {
+              // Pass unwrapped tools (not wrappedTools) for replay. During replay,
+              // tools execute with cached args - using wrappedTools would record
+              // these replayed calls, causing duplicate cache entries.
               const replayed = await this.agentCache.tryReplayAsStream(
                 cacheContext,
                 llmClient,
@@ -1995,6 +2001,9 @@ export class V3 {
             );
 
           if (cacheContext) {
+            // Pass unwrapped tools (not wrappedTools) for replay. During replay,
+            // tools execute with cached args - using wrappedTools would record
+            // these replayed calls, causing duplicate cache entries.
             const replayed = await this.agentCache.tryReplay(
               cacheContext,
               llmClient,


### PR DESCRIPTION
## Summary

This PR adds two improvements to the agent cache replay system:

### 1. Custom Tool Caching (fixes #1558)

Custom tools (like form-filling helpers) were not being recorded or replayed from cache, causing workflows to fail on cache replay.

**Changes:**
- Add `AgentReplayCustomToolStep` type for caching custom tool invocations
- Wrap custom tools with recording logic via `wrapToolsForRecording()`
- Record custom tool calls in both AISDK (hybrid/dom) and CUA agent modes
- Replay custom tools by re-executing with cached arguments
- Thread `tools` parameter through `tryReplay` and related methods

### 2. Navigation Waiting (fixes #1561)

Cache replay was executing steps too fast without waiting for page navigation to complete, causing subsequent steps to run on the wrong page.

**Changes:**
- Detect URL changes after actions during replay
- Wait for page load (`waitForLoadState`) before continuing to next step
- Apply to `replayAgentActStep`, `replayAgentFillFormStep`, `replayAgentKeysStep`
- Prevents race conditions where steps execute before navigation completes

## Test Plan

Tested with a real-world workflow:
- [x] Login flow with custom `fillUsername` and `fillPassword` tools
- [x] Search flow with custom `fillSearch` tool
- [x] Multi-page navigation (login → home → search → product page)
- [x] Verified 0 token usage on cache replay (no LLM calls)
- [x] Verified consistent results across 3+ replay runs

## Files Changed

- `packages/core/lib/v3/types/private/cache.ts` - Add `AgentReplayCustomToolStep` type
- `packages/core/lib/v3/v3.ts` - Add `wrapToolsForRecording()`, update tool threading
- `packages/core/lib/v3/handlers/v3CuaAgentHandler.ts` - Add custom tool recording for CUA mode
- `packages/core/lib/v3/cache/AgentCache.ts` - Add custom tool replay, add navigation waiting

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add custom tool caching to agent replay and wait for navigation between steps. This fixes tool-based workflows and prevents steps from running on the wrong page.

- **New Features**
  - Record and replay custom tool calls as custom_tool steps.
  - Wrap tools to auto-record; replay re-executes with cached args.
  - Pass tools through tryReplay and stream replay.

- **Bug Fixes**
  - Detect URL changes during replay and wait for page load.
  - Applied to act, fillForm, and keys (e.g., Enter submits forms).
  - Prevents steps executing on the wrong page.
  - Clean up recording state if stream creation fails.

<sup>Written for commit 36d32749ba33e103aad6067b0bd991f9020c71e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

