### PR TITLE
docs: fix dropdown routing behavior

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -144,10 +144,7 @@
               {
                 "group": "SDK Reference",
                 "pages": [
-                  "v3/sdk/python",
-                  "v3/sdk/java",
-                  "v3/sdk/go",
-                  "v3/sdk/ruby"
+                  "v3/sdk/python"
                 ]
               },
               {


### PR DESCRIPTION
# why

the dropdown in the docs was having weird behavior where regardless of the language you choose, you'll always be routed to the python sdk. 

# what changed

removing other pages from dropdown to prevent autorouting to python. 

old: 

https://github.com/user-attachments/assets/49618655-6c2d-477f-b573-a3ca1f7ca555

new: 

https://github.com/user-attachments/assets/635ca14b-ffa2-47f6-b474-709bb0269175

# test plan
