### PR TITLE
[fix]: circular import in `customOpenAIClient`

### DIFF
--- a/packages/core/examples/external_clients/customOpenAI.ts
+++ b/packages/core/examples/external_clients/customOpenAI.ts
@@ -5,11 +5,11 @@
  * You can just pass in an OpenAI instance to the client and it will work.
  */
 
+import type { AvailableModel } from "../../lib/v3/types/public/model";
 import {
-  AvailableModel,
   CreateChatCompletionOptions,
   LLMClient,
-} from "../../lib/v3";
+} from "../../lib/v3/llm/LLMClient";
 import OpenAI from "openai";
 import type {
   ChatCompletion,
@@ -21,10 +21,12 @@ import type {
   ChatCompletionSystemMessageParam,
   ChatCompletionUserMessageParam,
 } from "openai/resources/chat/completions";
-import { CreateChatCompletionResponseError } from "../../lib/v3";
 import { toJsonSchema } from "../../lib/v3/zodCompat";
 import { validateZodSchema } from "../../lib/utils";
-import { ZodSchemaValidationError } from "../../lib/v3/types/public/sdkErrors";
+import {
+  CreateChatCompletionResponseError,
+  ZodSchemaValidationError,
+} from "../../lib/v3/types/public/sdkErrors";
 
 export class CustomOpenAIClient extends LLMClient {
   public type = "openai" as const;


### PR DESCRIPTION
# why
- `customOpenAIClient` in `examples/external_clients/customOpenAI.ts` was being exported from the main barrel file `lib/v3/index.ts` (see #1548)
- but, `examples/external_clients/customOpenAI.ts` was also importing from that same barrel file
- this is a circular import, and broke when running examples
# what changed
- changed `examples/external_clients/customOpenAI.ts` to not import directly from the main barrel
# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed a circular import between the example CustomOpenAI client and the lib/v3 barrel. Examples now run without runtime errors.

- **Bug Fixes**
  - Stopped importing from lib/v3 index. Import LLMClient, CreateChatCompletionOptions, errors, and AvailableModel from their direct paths to break the cycle.

<sup>Written for commit 128d83aabf755ac8dabb1717e4a47bec7cd288e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

