### PR TITLE
Disable client session TTL for local session store

### DIFF
--- a/packages/server/src/lib/InMemorySessionStore.ts
+++ b/packages/server/src/lib/InMemorySessionStore.ts
@@ -10,7 +10,7 @@ import type {
 } from "./SessionStore";
 
 const DEFAULT_MAX_CAPACITY = 100;
-const DEFAULT_TTL_MS = 300_000; // 5 minutes
+const DEFAULT_TTL_MS = 0; // 0 = infinite (no TTL-based eviction)
 
 /**
  * Internal node for LRU linked list


### PR DESCRIPTION
Change DEFAULT_TTL_MS from 5 minutes to 0 (infinite). Sessions will now only be evicted via LRU when the cache hits max capacity, rather than expiring based on time. The code already supports infinite TTL through existing ttlMs <= 0 checks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the InMemorySessionStore default TTL to infinite (0). Sessions no longer expire by time; eviction happens only via LRU when capacity is reached.

- **Migration**
  - If you rely on time-based expiration, set ttlMs > 0 when creating the store (e.g., 300_000 for 5 minutes).

<sup>Written for commit fd69d4568d8da74d20ee65ea4d38f245ff9bd965. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

