### PR TITLE
docs: add documentation for local browser port option

### DIFF
--- a/packages/docs/v3/configuration/browser.mdx
+++ b/packages/docs/v3/configuration/browser.mdx
@@ -186,7 +186,7 @@ const stagehand = new Stagehand({
     devtools: true, // Open developer tools
     viewport: { width: 1280, height: 720 },
     executablePath: '/opt/google/chrome/chrome', // Custom Chrome path
-    port: 9222, // Fixed CDP debugging port (useful for external tools)
+    port: 9222, // Fixed CDP debugging port
     args: [
       '--no-sandbox',
       '--disable-setuid-sandbox',
@@ -217,11 +217,7 @@ await stagehand.init();
 
 ### Fixed CDP Debugging Port
 
-By default, Chrome launches with a randomly assigned debugging port. You can specify a fixed port using the `port` option, which is useful for:
-
-- Attaching external debugging tools (like `chrome://inspect`)
-- Connecting third-party CDP clients
-- Consistent development workflows
+Specify a fixed Chrome DevTools Protocol (CDP) debugging port instead of using a randomly assigned one.
 
 ```typescript
 import { Stagehand } from "@browserbasehq/stagehand";
@@ -229,18 +225,15 @@ import { Stagehand } from "@browserbasehq/stagehand";
 const stagehand = new Stagehand({
   env: "LOCAL",
   localBrowserLaunchOptions: {
-    port: 9222, // Use a fixed CDP debugging port
+    port: 9222,
   },
 });
 
 await stagehand.init();
-
-// You can now connect external tools to chrome://inspect
-// or ws://localhost:9222/devtools/browser/...
 ```
 
 <Tip>
-Port `9222` is the conventional default for Chrome DevTools Protocol. If the port is already in use, Chrome will fail to launch.
+Port `9222` is the standard CDP default. Ensure the port is available before launching.
 </Tip>
 
 ### DOM Settle Timeout

--- a/packages/docs/v3/references/stagehand.mdx
+++ b/packages/docs/v3/references/stagehand.mdx
@@ -116,11 +116,9 @@ interface V3Options {
     </ParamField>
 
     <ParamField path="port" type="number" optional>
-      Fixed Chrome DevTools Protocol (CDP) debugging port. When specified, Chrome will launch with this port for CDP connections instead of a randomly assigned port.
+      Fixed Chrome DevTools Protocol (CDP) debugging port for external tool connections.
 
-      This is useful for attaching external debugging tools or configuring `chrome://inspect` with a fixed port.
-
-      **Example:** `9222`
+      **Default:** Randomly assigned
     </ParamField>
 
     <ParamField path="args" type="string[]" optional>


### PR DESCRIPTION
# why
Missing docs for local browser port
# what changed
Add documentation for the `port` option in `LocalBrowserLaunchOptions` that was added in PR #1575. This option allows users to specify a fixed Chrome CDP debugging port instead of using a randomly assigned port.

Updated:
- packages/docs/v3/references/stagehand.mdx - Added port parameter to LocalBrowserLaunchOptions documentation
- packages/docs/v3/configuration/browser.mdx - Added port to example and new "Fixed CDP Debugging Port" section explaining the feature
# test plan

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document the port option in LocalBrowserLaunchOptions so users can set a fixed Chrome DevTools Protocol debugging port. Adds examples and guidance (including a 9222 tip) in the configuration and API reference pages.

<sup>Written for commit 69f5d613e2c647c0ebaa4639f6eca113c4c17a6e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

