### PR TITLE
Include replay endpoint in stainless spec so SDK clients can get run metrics

### DIFF
--- a/packages/server/openapi.v3.yaml
+++ b/packages/server/openapi.v3.yaml
@@ -1003,6 +1003,18 @@ components:
         - success
         - data
       additionalProperties: false
+    ReplayResponse:
+      type: object
+      properties:
+        success:
+          description: Indicates whether the request was successful
+          type: boolean
+        data:
+          $ref: "#/components/schemas/ReplayResultOutput"
+      required:
+        - success
+        - data
+      additionalProperties: false
     AgentCacheEntryOutput:
       type: object
       properties:
@@ -1732,18 +1744,6 @@ components:
       type: object
       properties: {}
       additionalProperties: false
-    ReplayResponse:
-      type: object
-      properties:
-        success:
-          description: Indicates whether the request was successful
-          type: boolean
-        data:
-          $ref: "#/components/schemas/ReplayResultOutput"
-      required:
-        - success
-        - data
-      additionalProperties: false
     StreamEvent:
       description:
         "Server-Sent Event emitted during streaming responses. Events are
@@ -1952,6 +1952,37 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ObserveResponse"
+  /v1/sessions/{id}/replay:
+    get:
+      operationId: SessionReplay
+      summary: Replay session metrics
+      description: Retrieves replay metrics for a session.
+      parameters:
+        - schema:
+            description: Unique session identifier
+            example: c4dbf3a9-9a58-4b22-8a1c-9f20f9f9e123
+            type: string
+          in: path
+          name: id
+          required: true
+          description: Unique session identifier
+        - schema:
+            description: Whether to stream the response via SSE
+            example: "true"
+            type: string
+            enum:
+              - "true"
+              - "false"
+          in: header
+          name: x-stream-response
+          description: Whether to stream the response via SSE
+      responses:
+        "200":
+          description: Default Response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReplayResponse"
   /v1/sessions/start:
     post:
       operationId: SessionStart

--- a/packages/server/src/routes/v1/sessions/_id/replay.ts
+++ b/packages/server/src/routes/v1/sessions/_id/replay.ts
@@ -22,7 +22,6 @@ const replayRoute: RouteOptions = {
   url: "/sessions/:id/replay",
   schema: {
     ...Api.Operations.SessionReplay,
-    hide: true, // Hide from OpenAPI documentation
     headers: Api.SessionHeadersSchema,
     params: Api.SessionIdParamsSchema,
     response: {

--- a/stainless.yml
+++ b/stainless.yml
@@ -199,6 +199,7 @@ resources:
           stream_event_model: sessions.stream_event
           params_type_name: streamResponse
       navigate: post /v1/sessions/{id}/navigate
+      replay: get /v1/sessions/{id}/replay
       end: post /v1/sessions/{id}/end
 
 streaming:


### PR DESCRIPTION
# why

# what changed

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose the session replay metrics endpoint in the public API and Stainless spec so SDKs can fetch run metrics. This lets clients retrieve replay data for a session and optionally stream results.

- **New Features**
  - Added GET /v1/sessions/{id}/replay to OpenAPI with ReplayResponse.
  - Enabled SDK generation by adding replay to stainless.yml.
  - Removed hide flag so the route appears in API docs.
  - Supports optional SSE via x-stream-response header ("true"/"false").

<sup>Written for commit b7a44b9ae11632ecdf093ca3b3f6ba95d63a4c16. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

