### PR TITLE
docs: add PageSnapshotOptions to page.snapshot() reference

### DIFF
--- a/.changeset/red-carpets-help.md
+++ b/.changeset/red-carpets-help.md
@@ -1,5 +1,0 @@
----
-"@browserbasehq/stagehand-docs": patch
----
-
-docs: add PageSnapshotOptions to page.snapshot() reference


### PR DESCRIPTION
Update snapshot() method documentation to include the new optional PageSnapshotOptions parameter with includeIframes option.

Changes:
- Update method signature to show optional options parameter
- Add ParamField for includeIframes option (defaults to true)
- Add PageSnapshotOptions type definition in Types section
- Add example showing iframe exclusion in code examples

# why

# what changed

# test plan

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update page.snapshot() docs to show the new optional PageSnapshotOptions, including the includeIframes flag (default true) to control iframe content.
Adds the options parameter in the signature, documents includeIframes, defines PageSnapshotOptions in Types, and includes an example excluding iframe content.

<sup>Written for commit 3bffc938ccada9b809ea90e1fdc641e177140dff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

