### PR TITLE
improve agent usage metrics

### DIFF
--- a/.changeset/five-frogs-cry.md
+++ b/.changeset/five-frogs-cry.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Update usage/metrics handling in agent

--- a/packages/core/lib/v3/handlers/v3AgentHandler.ts
+++ b/packages/core/lib/v3/handlers/v3AgentHandler.ts
@@ -473,7 +473,7 @@ export class V3AgentHandler {
     inputMessages: ModelMessage[],
     result: {
       text?: string;
-      usage?: LanguageModelUsage;
+      totalUsage?: LanguageModelUsage;
       response?: { messages?: ModelMessage[] };
       steps?: StepResult<ToolSet>[];
     },
@@ -497,13 +497,13 @@ export class V3AgentHandler {
 
     const endTime = Date.now();
     const inferenceTimeMs = endTime - startTime;
-    if (result.usage) {
+    if (result.totalUsage) {
       this.v3.updateMetrics(
         V3FunctionName.AGENT,
-        result.usage.inputTokens || 0,
-        result.usage.outputTokens || 0,
-        result.usage.reasoningTokens || 0,
-        result.usage.cachedInputTokens || 0,
+        result.totalUsage.inputTokens || 0,
+        result.totalUsage.outputTokens || 0,
+        result.totalUsage.reasoningTokens || 0,
+        result.totalUsage.cachedInputTokens || 0,
         inferenceTimeMs,
       );
     }
@@ -514,12 +514,12 @@ export class V3AgentHandler {
       actions: state.actions,
       completed: state.completed,
       output,
-      usage: result.usage
+      usage: result.totalUsage
         ? {
-            input_tokens: result.usage.inputTokens || 0,
-            output_tokens: result.usage.outputTokens || 0,
-            reasoning_tokens: result.usage.reasoningTokens || 0,
-            cached_input_tokens: result.usage.cachedInputTokens || 0,
+            input_tokens: result.totalUsage.inputTokens || 0,
+            output_tokens: result.totalUsage.outputTokens || 0,
+            reasoning_tokens: result.totalUsage.reasoningTokens || 0,
+            cached_input_tokens: result.totalUsage.cachedInputTokens || 0,
             inference_time_ms: inferenceTimeMs,
           }
         : undefined,


### PR DESCRIPTION
# Why

The agent handler was using `usage` from `generateText()` which only reflects the token usage of the **last step**. For multi-step agent executions, this results in underreported token counts.

# What Changed

Updated `v3AgentHandler.ts` to use `totalUsage` instead of `usage`. The `totalUsage` field from the AI SDK represents the sum of token usage across all steps, providing accurate totals for:
- Input tokens
- Output tokens
- Reasoning tokens
- Cached input tokens

# Test Plan

- [x] Verify token metrics are correctly reported for multi-step agent executions


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix underreported agent token metrics by using totalUsage for multi-step executions. Token totals now reflect all steps.

- **Bug Fixes**
  - Use totalUsage from the AI SDK in v3AgentHandler to compute metrics.
  - Response payload includes accurate totals for input, output, reasoning, and cached input tokens, plus inference_time_ms.

<sup>Written for commit 685a7eb8fc5dbc23376a27049a8446a851d77b0e. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1596">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

