### PR TITLE
[chore]: add stricter linting rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,7 @@
 import globals from "globals";
 import pluginJs from "@eslint/js";
 import tseslint from "typescript-eslint";
+import security from "eslint-plugin-security";
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
@@ -23,4 +24,38 @@ export default [
   },
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
+  {
+    plugins: {
+      security,
+    },
+    rules: {
+      "no-eval": "error",
+      "no-implied-eval": "error",
+      "no-new-func": "error",
+      "security/detect-eval-with-expression": "error",
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "CallExpression[callee.name='Function']",
+          message: "Dynamic function construction is prohibited.",
+        },
+        {
+          selector: "NewExpression[callee.name='Function']",
+          message: "Dynamic function construction is prohibited.",
+        },
+        {
+          selector:
+            "CallExpression[callee.object.name='window'][callee.property.name='Function']",
+          message:
+            "Dynamic function construction via window.Function is prohibited.",
+        },
+        {
+          selector:
+            "CallExpression[callee.object.name='globalThis'][callee.property.name='Function']",
+          message:
+            "Dynamic function construction via globalThis.Function is prohibited.",
+        },
+      ],
+    },
+  },
 ];

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@changesets/cli": "^2.27.9",
     "@eslint/js": "^9.16.0",
     "eslint": "^9.16.0",
+    "eslint-plugin-security": "^3.0.1",
     "globals": "^15.13.0",
     "prettier": "^3.2.5",
     "turbo": "^2.5.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       eslint:
         specifier: ^9.16.0
         version: 9.25.1(jiti@1.21.7)
+      eslint-plugin-security:
+        specifier: ^3.0.1
+        version: 3.0.1
       globals:
         specifier: ^15.13.0
         version: 15.15.0
@@ -3037,6 +3040,10 @@ packages:
     engines: {node: '>=6.0'}
     hasBin: true
 
+  eslint-plugin-security@3.0.1:
+    resolution: {integrity: sha512-XjVGBhtDZJfyuhIxnQ/WMm385RbX3DBu7H1J7HNNhmB2tnGxMeqVSnYv79oAj992ayvIBZghsymwkYFS6cGH4Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   eslint-scope@8.3.0:
     resolution: {integrity: sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -5058,6 +5065,10 @@ packages:
   regex@6.0.1:
     resolution: {integrity: sha512-uorlqlzAKjKQZ5P+kTJr3eeJGSVroLKoHmquUj4zHWuR+hEyNqlXsSKlYYF5F4NI6nl7tWCs0apKJ0lmfsXAPA==}
 
+  regexp-tree@0.1.27:
+    resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
+    hasBin: true
+
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
@@ -5212,6 +5223,9 @@ packages:
 
   safe-regex2@5.0.0:
     resolution: {integrity: sha512-YwJwe5a51WlK7KbOJREPdjNrpViQBI3p4T50lfwPuDhZnE3XGVTlGvi+aolc5+RvxDD6bnUmjVsU9n1eboLUYw==}
+
+  safe-regex@2.1.1:
+    resolution: {integrity: sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==}
 
   safe-stable-stringify@1.1.1:
     resolution: {integrity: sha512-ERq4hUjKDbJfE4+XtZLFPCDi8Vb1JqaxAPTxWFLBx8XcAlf9Bda/ZJdVezs/NAfsMQScyIlUMx+Yeu7P7rx5jw==}
@@ -5529,6 +5543,7 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   tdigest@0.1.2:
     resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
@@ -9118,6 +9133,10 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
+  eslint-plugin-security@3.0.1:
+    dependencies:
+      safe-regex: 2.1.1
+
   eslint-scope@8.3.0:
     dependencies:
       esrecurse: 4.3.0
@@ -11792,6 +11811,8 @@ snapshots:
     dependencies:
       regex-utilities: 2.3.0
 
+  regexp-tree@0.1.27: {}
+
   regexp.prototype.flags@1.5.4:
     dependencies:
       call-bind: 1.0.8
@@ -12076,6 +12097,10 @@ snapshots:
   safe-regex2@5.0.0:
     dependencies:
       ret: 0.5.0
+
+  safe-regex@2.1.1:
+    dependencies:
+      regexp-tree: 0.1.27
 
   safe-stable-stringify@1.1.1: {}
 


### PR DESCRIPTION
# why
- for better code hygiene 
# what changed
- added some basic security linting rules


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added stricter ESLint security rules to block eval and dynamic Function usage. This improves code hygiene and catches unsafe patterns early.

- **Refactors**
  - Enforce no-eval, no-implied-eval, and no-new-func.
  - Block Function constructors (direct, window.Function, globalThis.Function).
  - Enable security/detect-eval-with-expression.

- **Dependencies**
  - Add eslint-plugin-security.

<sup>Written for commit dda6483f6d84599783f5966e94f6d675c0a40a76. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1597">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

