### PR TITLE
Fix deprecated cua: true syntax in v3 migration guide

### DIFF
--- a/packages/docs/v3/migrations/v2.mdx
+++ b/packages/docs/v3/migrations/v2.mdx
@@ -587,7 +587,7 @@ const agent = stagehand.agent({
 const agent = stagehand.agent({
   model: "google/gemini-2.5-computer-use-preview-10-2025",  // Provider now in model string
   systemPrompt: "You are a helpful assistant that can navigate websites.",  // Renamed from 'instructions'
-  cua: true,  // NEW: Computer Use Agent mode
+  mode: "cua",  // Computer Use Agent mode
   integrations: ["https://mcp-server.example.com"],
   tools: customTools
 });


### PR DESCRIPTION
# why

Replace deprecated `cua: true` with `mode: "cua"` in the agent configuration example in the Stagehand V3 migration guide to align with current v3 API patterns.

# what changed

Example uses `mode: "cua"` instead of `cua: true` as the latter has been deprecated, per https://docs.stagehand.dev/v3/basics/agent#computer-use-agents.

# test plan
Docs


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced deprecated cua: true with mode: "cua" in the Stagehand v3 migration guide agent example. This aligns the docs with the current v3 API and prevents users from copying a deprecated config.

<sup>Written for commit f4c904e714683cc36393c7a363752730c616e00b. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1601">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

