### PR TITLE
Add support for vertex on stagehand server

### DIFF
--- a/.changeset/thin-things-wear.md
+++ b/.changeset/thin-things-wear.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand-server": patch
+---
+
+Include vertex as a supported provider

--- a/packages/server/src/types/model.ts
+++ b/packages/server/src/types/model.ts
@@ -11,6 +11,7 @@ export const AISDK_PROVIDERS = [
   "deepseek",
   "perplexity",
   "ollama",
+  "vertex",
 ] as const;
 export type AISDKProvider = (typeof AISDK_PROVIDERS)[number];
 


### PR DESCRIPTION
# why
Vertex is supported on local mode

# what changed
Adds vertex as a supported provider for local binary. Unlocks vertex for canonical sdks

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Vertex as a supported provider in Stagehand Server so users can select "vertex" and run models via Vertex. Updates the AISDK provider types to include "vertex" and includes a patch changeset.

<sup>Written for commit 0a5cd3bdffe737d73fd59ee55b7fee0a997966cb. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1602">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

