### PR TITLE
Fix SEA release workflow for Windows

### DIFF
--- a/.github/workflows/stagehand-server-release.yml
+++ b/.github/workflows/stagehand-server-release.yml
@@ -28,29 +28,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
+          fetch-tags: true
+
+      - uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22.x
-
-      - name: Enable Corepack
-        run: |
-          npm install -g corepack@latest
-          corepack enable
-
-      - name: Get pnpm store directory
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-${{ runner.arch }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-pnpm-store-
+          cache: 'pnpm'
+          cache-dependency-path: '**/pnpm-lock.yaml'
 
       - name: Install dependencies
         env:
@@ -114,7 +102,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git fetch --tags --force
+          git fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}"
 
           if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
             echo "Tag already exists: ${TAG}"
@@ -139,7 +127,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
+          fetch-tags: false
 
       - name: Prepare release assets directory
         run: mkdir -p release-assets

--- a/.github/workflows/stagehand-server-sea-build.yml
+++ b/.github/workflows/stagehand-server-sea-build.yml
@@ -44,30 +44,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 1
+          fetch-tags: false
+
+      - uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22.x
-
-      - name: Enable Corepack
-        run: |
-          npm install -g corepack@latest
-          corepack enable
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-${{ runner.arch }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-pnpm-store-
+          cache: 'pnpm'
+          cache-dependency-path: '**/pnpm-lock.yaml'
 
       - name: Install dependencies
         env:


### PR DESCRIPTION
# why
Windows defaults to powersehell

# what changed
Add shell:bash for the STORE_PATH on all platforms

# test plan

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use pnpm/action-setup and setup-node v6 with built-in pnpm caching, removing the manual pnpm store path and Corepack steps to fix Windows runners. Adjusted checkout depth/tag settings and tag fetching to restore SEA build and release workflows on Windows and keep them consistent across platforms.

<sup>Written for commit 19e52ccff7e1ab567d06107671521494c039e88b. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1603">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

