### PR TITLE
Enable bedrock provider on server

### DIFF
--- a/.changeset/plain-brooms-make.md
+++ b/.changeset/plain-brooms-make.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand-server": patch
+---
+
+Enable bedrock

--- a/packages/server/src/types/model.ts
+++ b/packages/server/src/types/model.ts
@@ -12,6 +12,7 @@ export const AISDK_PROVIDERS = [
   "perplexity",
   "ollama",
   "vertex",
+  "bedrock"
 ] as const;
 export type AISDKProvider = (typeof AISDK_PROVIDERS)[number];
 


### PR DESCRIPTION
# why

# what changed

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enabled the Bedrock provider on the server by adding it to AISDK_PROVIDERS. Clients can now select Bedrock, and the server will route requests to Bedrock models.

<sup>Written for commit 138495917b096bb4b86a55cb4281fe91a369fea7. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1604">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

