### PR TITLE
feat(cli): add network capture to filesystem for agent inspection

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -279,6 +279,43 @@ stagehand tab_switch <index>           # Switch to tab by index
 stagehand tab_close [index]            # Close tab by index (defaults to last tab)
 ```
 
+### Network Capture
+
+Capture HTTP requests to the filesystem for inspection with standard file tools:
+
+```bash
+stagehand network on                   # Enable capture, returns directory path
+stagehand network off                  # Disable capture
+stagehand network path                 # Get capture directory path
+stagehand network clear                # Clear all captured requests
+```
+
+Captured requests are saved as directories with separate files:
+
+```
+/tmp/stagehand-default-network/
+  001-GET-api.github.com-repos/
+    request.json      # method, url, headers, body
+    response.json     # status, headers, body, duration
+  002-POST-api.example.com-login/
+    request.json
+    response.json
+```
+
+**Agent workflow:**
+```bash
+stagehand network on
+# {"enabled": true, "path": "/tmp/stagehand-default-network"}
+
+stagehand open https://api.github.com
+# ... interact with page ...
+
+# Agent uses filesystem tools to inspect traffic:
+# - list_dir /tmp/stagehand-default-network/
+# - read_file .../001-GET-api.github.com-repos/response.json
+# - grep "auth" /tmp/stagehand-default-network/
+```
+
 ### Viewport & Misc
 
 ```bash

--- a/packages/cli/TODO.md
+++ b/packages/cli/TODO.md
@@ -50,6 +50,9 @@ Based on comparison with [agent-browser](https://github.com/vercel-labs/agent-br
 
 ## Network
 
+- [x] **network on/off** - Enable/disable network capture to filesystem
+- [x] **network path** - Get capture directory path for agent filesystem access
+- [x] **network clear** - Clear captured requests
 - [ ] **headers** - Set extra HTTP headers for all requests
 
 ## Not Planned (for now)


### PR DESCRIPTION
Add network capture commands that write HTTP requests/responses to the filesystem, enabling agents to use standard file tools for inspection.

Features:
- network on/off - Enable/disable capture to temp directory
- network path - Get capture directory path
- network clear - Clear captured requests

Captured requests are saved as directories with separate request.json and response.json files, making them easily inspectable with grep, jq, cat, and other standard tools.

# why

# what changed

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds network capture to the CLI, writing HTTP requests and responses to a temp directory so agents can inspect traffic with standard file tools.

- **New Features**
  - stagehand network on/off/path/clear
  - Saves each request in its own directory with request.json and response.json
  - Records method, URL, headers, body, status, mime type, duration, and errors
  - Directory naming: 001-<METHOD>-<domain>-<path-segment>
  - Capture root: /tmp/stagehand-<session>-network; path returned by network on/path

<sup>Written for commit 5803ba7397dee4860aaec6a1bbe71845cd947421. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1607">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

