### PR TITLE
Chromie/fix deprecation warning for old model format

### DIFF
--- a/packages/core/lib/v3/llm/LLMProvider.ts
+++ b/packages/core/lib/v3/llm/LLMProvider.ts
@@ -178,7 +178,7 @@ export class LLMProvider {
 
     this.logger({
       category: "llm",
-      message: `Deprecation warning: Model format "${modelName}" is deprecated. Please use the provider/model format (e.g., "openai/gpt-4o" or "anthropic/claude-3-5-sonnet-latest").`,
+      message: `Deprecation warning: Model format "${modelName}" is deprecated. Please use the provider/model format (e.g., "openai/gpt-5" or "anthropic/claude-sonnet-4").`,
       level: 0,
     });
 

--- a/packages/core/lib/v3/types/public/sdkErrors.ts
+++ b/packages/core/lib/v3/types/public/sdkErrors.ts
@@ -51,7 +51,7 @@ export class UnsupportedModelError extends StagehandError {
     const modelList = supportedModels.join(", ");
     const deprecationNote =
       `\n\nNote: The legacy model format (e.g., "gpt-4o") is deprecated. ` +
-      `Please use the provider/model format instead (e.g., "openai/gpt-4o", "anthropic/claude-3-5-sonnet-latest").`;
+      `Please use the provider/model format instead (e.g., "openai/gpt-5", "anthropic/claude-sonnet-4").`;
 
     super(
       feature

--- a/packages/core/tests/model-deprecation.test.ts
+++ b/packages/core/tests/model-deprecation.test.ts
@@ -26,8 +26,8 @@ describe("Model format deprecation", () => {
     it("includes example of provider/model format", () => {
       const error = new UnsupportedModelError(["gpt-4o"]);
 
-      // Should provide an example like openai/gpt-4o
-      expect(error.message).toMatch(/openai\/gpt-4o|provider\/model/i);
+      // Should provide an example like openai/gpt-5
+      expect(error.message).toMatch(/openai\/gpt-5|provider\/model/i);
     });
 
     it("works with feature parameter", () => {
@@ -79,7 +79,7 @@ describe("Model format deprecation", () => {
       // Should mention the provider/model format
       expect(message).toContain("provider/model");
       // Should give an example
-      expect(message).toContain("openai/gpt-4o");
+      expect(message).toContain("openai/gpt-5");
     });
 
     it("returns OpenAIClient for legacy OpenAI model names", () => {


### PR DESCRIPTION
# why

# what changed

# test plan

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a deprecation warning for legacy model names (no slash) while keeping them working, and update errors to guide users to the provider/model format. Also improves provider error handling and adds tests.

- **New Features**
  - Log level-0 deprecation warning when using legacy names (e.g., "gpt-4o"); suggest "provider/model" (e.g., "openai/gpt-5", "anthropic/claude-sonnet-4").
  - Update UnsupportedModelError to list supported models and include provider/model guidance with examples.
  - Throw UnsupportedModelProviderError in LLMProvider’s default switch case for unknown providers.
  - Add Vitest tests covering deprecation logs, error messages, legacy model support, provider/model format, and invalid providers.

<sup>Written for commit 71ca391f914dba59bbb2e44103177645d17dd274. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1625">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

