### PR TITLE
add warning when  models are used with hybrid mode that will not perf…

### DIFF
--- a/.changeset/late-parks-taste.md
+++ b/.changeset/late-parks-taste.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Add warning when incorrect models are used with agents hybrid mode

--- a/packages/core/lib/v3/handlers/v3AgentHandler.ts
+++ b/packages/core/lib/v3/handlers/v3AgentHandler.ts
@@ -113,6 +113,18 @@ export class V3AgentHandler {
         },
       });
 
+      if (
+        this.mode === "hybrid" &&
+        !baseModel.modelId.includes("gemini-3-flash") &&
+        !baseModel.modelId.includes("claude")
+      ) {
+        this.logger({
+          category: "agent",
+          message: `Warning: "${baseModel.modelId}" may not perform well in hybrid mode. See recommended models: https://docs.stagehand.dev/v3/basics/agent#hybrid-mode`,
+          level: 0,
+        });
+      }
+
       return {
         options,
         maxSteps,

--- a/packages/docs/v3/basics/agent.mdx
+++ b/packages/docs/v3/basics/agent.mdx
@@ -140,7 +140,6 @@ Both DOM and CUA modes have their strengths and weaknesses. Hybrid mode combines
 
 Other models may not reliably produce accurate coordinates for clicking and typing.
 
-**Our recommendation:** `google/gemini-3-flash-preview` for the best balance of reliability, speed, and cost.
 </Warning>
 
 <Note>Hybrid mode requires `experimental: true` in your Stagehand constructor.</Note>


### PR DESCRIPTION
# why

hybrid mode requires specific models to perform optimally 

# what changed

if the models we recommend are not used, we throw an error log and link out to the agent docs 

# test plan

tested locally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a runtime warning when hybrid mode is used with models that may not perform well, linking to the docs with recommended models. This helps catch misconfiguration early and improves agent reliability.

- **New Features**
  - Log a warning in hybrid mode if the model ID isn’t “gemini-3-flash” or “claude”, with a link to the agent docs.
  - Updated hybrid mode docs to align guidance with the new warning.

<sup>Written for commit eb0dd6af3fe8ecce01d6a97014dfb2af6ecf9335. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1633">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

