### PR TITLE
emit both camelCase and snake_case for agent metrics

### DIFF
--- a/packages/core/lib/v3/agent/AnthropicCUAClient.ts
+++ b/packages/core/lib/v3/agent/AnthropicCUAClient.ts
@@ -188,6 +188,10 @@ export class AnthropicCUAClient extends AgentClient {
         message: finalMessage,
         completed,
         usage: {
+          // TODO(deprecation): remove snake_case fields after the deprecation window.
+          inputTokens: totalInputTokens,
+          outputTokens: totalOutputTokens,
+          inferenceTimeMs: totalInferenceTime,
           input_tokens: totalInputTokens,
           output_tokens: totalOutputTokens,
           inference_time_ms: totalInferenceTime,
@@ -208,6 +212,10 @@ export class AnthropicCUAClient extends AgentClient {
         message: `Failed to execute task: ${errorMessage}`,
         completed: false,
         usage: {
+          // TODO(deprecation): remove snake_case fields after the deprecation window.
+          inputTokens: totalInputTokens,
+          outputTokens: totalOutputTokens,
+          inferenceTimeMs: totalInferenceTime,
           input_tokens: totalInputTokens,
           output_tokens: totalOutputTokens,
           inference_time_ms: totalInferenceTime,

--- a/packages/core/lib/v3/agent/GoogleCUAClient.ts
+++ b/packages/core/lib/v3/agent/GoogleCUAClient.ts
@@ -280,6 +280,10 @@ export class GoogleCUAClient extends AgentClient {
         message: finalMessage,
         completed,
         usage: {
+          // TODO(deprecation): remove snake_case fields after the deprecation window.
+          inputTokens: totalInputTokens,
+          outputTokens: totalOutputTokens,
+          inferenceTimeMs: totalInferenceTime,
           input_tokens: totalInputTokens,
           output_tokens: totalOutputTokens,
           inference_time_ms: totalInferenceTime,
@@ -300,6 +304,10 @@ export class GoogleCUAClient extends AgentClient {
         message: `Failed to execute task: ${errorMessage}`,
         completed: false,
         usage: {
+          // TODO(deprecation): remove snake_case fields after the deprecation window.
+          inputTokens: totalInputTokens,
+          outputTokens: totalOutputTokens,
+          inferenceTimeMs: totalInferenceTime,
           input_tokens: totalInputTokens,
           output_tokens: totalOutputTokens,
           inference_time_ms: totalInferenceTime,

--- a/packages/core/lib/v3/agent/MicrosoftCUAClient.ts
+++ b/packages/core/lib/v3/agent/MicrosoftCUAClient.ts
@@ -920,6 +920,10 @@ For each function call, return a json object with function name and arguments wi
         message: finalMessage,
         actions,
         usage: {
+          // TODO(deprecation): remove snake_case fields after the deprecation window.
+          inputTokens: totalInputTokens,
+          outputTokens: totalOutputTokens,
+          inferenceTimeMs: totalInferenceTime,
           input_tokens: totalInputTokens,
           output_tokens: totalOutputTokens,
           inference_time_ms: totalInferenceTime,

--- a/packages/core/lib/v3/agent/OpenAICUAClient.ts
+++ b/packages/core/lib/v3/agent/OpenAICUAClient.ts
@@ -181,6 +181,10 @@ export class OpenAICUAClient extends AgentClient {
         message: finalMessage,
         completed,
         usage: {
+          // TODO(deprecation): remove snake_case fields after the deprecation window.
+          inputTokens: totalInputTokens,
+          outputTokens: totalOutputTokens,
+          inferenceTimeMs: totalInferenceTime,
           input_tokens: totalInputTokens,
           output_tokens: totalOutputTokens,
           inference_time_ms: totalInferenceTime,
@@ -201,6 +205,10 @@ export class OpenAICUAClient extends AgentClient {
         message: `Failed to execute task: ${errorMessage}`,
         completed: false,
         usage: {
+          // TODO(deprecation): remove snake_case fields after the deprecation window.
+          inputTokens: totalInputTokens,
+          outputTokens: totalOutputTokens,
+          inferenceTimeMs: totalInferenceTime,
           input_tokens: totalInputTokens,
           output_tokens: totalOutputTokens,
           inference_time_ms: totalInferenceTime,

--- a/packages/core/lib/v3/cache/AgentCache.ts
+++ b/packages/core/lib/v3/cache/AgentCache.ts
@@ -581,6 +581,12 @@ export class AgentCache {
       }
       const result = cloneForCache(entry.result);
       result.usage = {
+        // TODO(deprecation): remove snake_case fields after the deprecation window.
+        inputTokens: 0,
+        outputTokens: 0,
+        reasoningTokens: 0,
+        cachedInputTokens: 0,
+        inferenceTimeMs: 0,
         input_tokens: 0,
         output_tokens: 0,
         reasoning_tokens: 0,

--- a/packages/core/lib/v3/handlers/v3AgentHandler.ts
+++ b/packages/core/lib/v3/handlers/v3AgentHandler.ts
@@ -516,6 +516,12 @@ export class V3AgentHandler {
       output,
       usage: result.totalUsage
         ? {
+            // TODO(deprecation): remove snake_case fields after the deprecation window.
+            inputTokens: result.totalUsage.inputTokens || 0,
+            outputTokens: result.totalUsage.outputTokens || 0,
+            reasoningTokens: result.totalUsage.reasoningTokens || 0,
+            cachedInputTokens: result.totalUsage.cachedInputTokens || 0,
+            inferenceTimeMs: inferenceTimeMs,
             input_tokens: result.totalUsage.inputTokens || 0,
             output_tokens: result.totalUsage.outputTokens || 0,
             reasoning_tokens: result.totalUsage.reasoningTokens || 0,

--- a/packages/core/lib/v3/types/public/agent.ts
+++ b/packages/core/lib/v3/types/public/agent.ts
@@ -63,13 +63,7 @@ export interface AgentResult {
   actions: AgentAction[];
   completed: boolean;
   metadata?: Record<string, unknown>;
-  usage?: {
-    input_tokens: number;
-    output_tokens: number;
-    reasoning_tokens?: number;
-    cached_input_tokens?: number;
-    inference_time_ms: number;
-  };
+  usage?: AgentUsage;
   /**
    * The conversation messages from this execution.
    * Pass these to a subsequent execute() call via the `messages` option to continue the conversation.
@@ -87,6 +81,31 @@ export interface AgentResult {
 export type AgentStreamResult = StreamTextResult<ToolSet, never> & {
   result: Promise<AgentResult>;
 };
+
+type AgentUsageCamel = {
+  inputTokens: number;
+  outputTokens: number;
+  reasoningTokens?: number;
+  cachedInputTokens?: number;
+  inferenceTimeMs: number;
+};
+
+type AgentUsageSnake = {
+  input_tokens: number;
+  output_tokens: number;
+  reasoning_tokens?: number;
+  cached_input_tokens?: number;
+  inference_time_ms: number;
+};
+
+// TODO(deprecation): remove legacy snake_case support after the deprecation window.
+export type AgentUsage = AgentUsageCamel & Partial<AgentUsageSnake>;
+
+// TODO(deprecation): remove once all inputs are guaranteed camelCase.
+export type AgentUsageInput =
+  | AgentUsageCamel
+  | AgentUsageSnake
+  | (AgentUsageCamel & Partial<AgentUsageSnake>);
 
 /**
  * Base callbacks shared between execute (non-streaming) and streaming modes.

--- a/packages/core/lib/v3/types/public/api.ts
+++ b/packages/core/lib/v3/types/public/api.ts
@@ -636,7 +636,8 @@ export const AgentActionSchema = z
   .meta({ id: "AgentAction" });
 
 /** Token usage statistics for agent execution */
-export const AgentUsageSchema = z
+// TODO(deprecation): remove legacy snake_case schema after the deprecation window.
+const AgentUsageLegacySchema = z
   .object({
     input_tokens: z.number().meta({ example: 1500 }),
     output_tokens: z.number().meta({ example: 250 }),
@@ -644,6 +645,19 @@ export const AgentUsageSchema = z
     cached_input_tokens: z.number().optional(),
     inference_time_ms: z.number().meta({ example: 2500 }),
   })
+  .partial()
+  .meta({ id: "AgentUsageLegacy" });
+
+export const AgentUsageSchema = z
+  .object({
+    inputTokens: z.number().meta({ example: 1500 }),
+    outputTokens: z.number().meta({ example: 250 }),
+    reasoningTokens: z.number().optional(),
+    cachedInputTokens: z.number().optional(),
+    inferenceTimeMs: z.number().meta({ example: 2500 }),
+  })
+  // TODO(deprecation): remove legacy snake_case merge after the deprecation window.
+  .and(AgentUsageLegacySchema)
   .meta({ id: "AgentUsage" });
 
 /** Result data from agent execution */

--- a/packages/core/tests/public-api/public-types.test.ts
+++ b/packages/core/tests/public-api/public-types.test.ts
@@ -30,6 +30,8 @@ type ExpectedExportedTypes = {
   Tool: Stagehand.Tool;
   AgentAction: Stagehand.AgentAction;
   AgentResult: Stagehand.AgentResult;
+  AgentUsage: Stagehand.AgentUsage;
+  AgentUsageInput: Stagehand.AgentUsageInput;
   AgentExecuteOptions: Stagehand.AgentExecuteOptions;
   AgentType: Stagehand.AgentType;
   AgentExecutionOptions: Stagehand.AgentExecutionOptions<Stagehand.AgentExecuteOptions>;
@@ -245,13 +247,7 @@ describe("Stagehand public API types", () => {
       actions: Stagehand.AgentAction[];
       completed: boolean;
       metadata?: Record<string, unknown>;
-      usage?: {
-        input_tokens: number;
-        output_tokens: number;
-        reasoning_tokens?: number;
-        cached_input_tokens?: number;
-        inference_time_ms: number;
-      };
+      usage?: Stagehand.AgentUsage;
       messages?: Stagehand.ModelMessage[];
       output?: Record<string, unknown>;
     };

--- a/packages/server/openapi.v3.yaml
+++ b/packages/server/openapi.v3.yaml
@@ -76,6 +76,22 @@ components:
         id: $response.body#/data/sessionId
       description: End the session and release resources
   schemas:
+    AgentUsageLegacy:
+      type: object
+      properties:
+        input_tokens:
+          example: 1500
+          type: number
+        output_tokens:
+          example: 250
+          type: number
+        reasoning_tokens:
+          type: number
+        cached_input_tokens:
+          type: number
+        inference_time_ms:
+          example: 2500
+          type: number
     AgentCacheEntry:
       type: object
       properties:
@@ -704,25 +720,27 @@ components:
         - type
       additionalProperties: {}
     AgentUsage:
-      type: object
-      properties:
-        input_tokens:
-          example: 1500
-          type: number
-        output_tokens:
-          example: 250
-          type: number
-        reasoning_tokens:
-          type: number
-        cached_input_tokens:
-          type: number
-        inference_time_ms:
-          example: 2500
-          type: number
-      required:
-        - input_tokens
-        - output_tokens
-        - inference_time_ms
+      allOf:
+        - type: object
+          properties:
+            inputTokens:
+              example: 1500
+              type: number
+            outputTokens:
+              example: 250
+              type: number
+            reasoningTokens:
+              type: number
+            cachedInputTokens:
+              type: number
+            inferenceTimeMs:
+              example: 2500
+              type: number
+          required:
+            - inputTokens
+            - outputTokens
+            - inferenceTimeMs
+        - $ref: "#/components/schemas/AgentUsageLegacy"
     AgentResultData:
       type: object
       properties:
@@ -1024,6 +1042,23 @@ components:
       required:
         - success
         - data
+      additionalProperties: false
+    AgentUsageLegacyOutput:
+      type: object
+      properties:
+        input_tokens:
+          example: 1500
+          type: number
+        output_tokens:
+          example: 250
+          type: number
+        reasoning_tokens:
+          type: number
+        cached_input_tokens:
+          type: number
+        inference_time_ms:
+          example: 2500
+          type: number
       additionalProperties: false
     AgentCacheEntryOutput:
       type: object
@@ -1544,26 +1579,28 @@ components:
             - cua
       additionalProperties: false
     AgentUsageOutput:
-      type: object
-      properties:
-        input_tokens:
-          example: 1500
-          type: number
-        output_tokens:
-          example: 250
-          type: number
-        reasoning_tokens:
-          type: number
-        cached_input_tokens:
-          type: number
-        inference_time_ms:
-          example: 2500
-          type: number
-      required:
-        - input_tokens
-        - output_tokens
-        - inference_time_ms
-      additionalProperties: false
+      allOf:
+        - type: object
+          properties:
+            inputTokens:
+              example: 1500
+              type: number
+            outputTokens:
+              example: 250
+              type: number
+            reasoningTokens:
+              type: number
+            cachedInputTokens:
+              type: number
+            inferenceTimeMs:
+              example: 2500
+              type: number
+          required:
+            - inputTokens
+            - outputTokens
+            - inferenceTimeMs
+          additionalProperties: false
+        - $ref: "#/components/schemas/AgentUsageLegacyOutput"
     AgentResultDataOutput:
       type: object
       properties:


### PR DESCRIPTION
# why

# what changed

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit agent usage metrics in both camelCase and snake_case to ease migration to camelCase across the API. Updates clients, types, schemas, and OpenAPI while keeping legacy fields during a deprecation window.

- **Migration**
  - Responses now include camelCase fields: inputTokens, outputTokens, reasoningTokens, cachedInputTokens, inferenceTimeMs.
  - Legacy snake_case remains in outputs and schemas for now; removal planned after the deprecation window.
  - Public types added: AgentUsage (camelCase + partial snake_case) and AgentUsageInput; Zod and OpenAPI schemas expose both forms.

<sup>Written for commit 169071c56f29e51ba164272d44036937f8ad1c5d. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1634">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

