### PR TITLE
Removed MCP from readme for now

### DIFF
--- a/stainless.yml
+++ b/stainless.yml
@@ -54,9 +54,7 @@ targets:
     publish:
       npm: false
     options:
-      mcp_server:
-        package_name: stagehand-mcp
-        enable_all_resources: true
+      mcp_server: false
   php:
     edition: php.2025-10-08
     package_name: stagehand


### PR DESCRIPTION
# why
We don't want the MCP server showing up in readme files for the generated sdks
# what changed
Removed it from the stainless yaml for now - this means no MCP commits.
# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disabled the MCP server in stainless.yml to keep it out of generated SDK READMEs. This prevents MCP-related content and commits for now.

<sup>Written for commit 090a47edcd62b8b5c8e58843cf913dc7e5c12825. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1639">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

