### PR TITLE
fix(cdp): avoid unhandled detach by returning original sendCDP promise

### DIFF
--- a/.changeset/bitter-years-fly.md
+++ b/.changeset/bitter-years-fly.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Fix unhandled CDP detaches by returning the original sendCDP promise

--- a/packages/core/lib/v3/tests/cdp-session-detached.spec.ts
+++ b/packages/core/lib/v3/tests/cdp-session-detached.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from "@playwright/test";
+import { chromium as playwrightChromium } from "playwright";
+import { V3 } from "../v3";
+import { v3TestConfig } from "./v3.config";
+
+test.describe("CDP session detach handling", () => {
+  let v3: V3;
+
+  test.beforeEach(async () => {
+    v3 = new V3(v3TestConfig);
+    await v3.init();
+  });
+
+  test.afterEach(async () => {
+    await v3?.close?.().catch(() => {});
+  });
+
+  test("rejects inflight CDP calls when a target is closed", async () => {
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => {
+      unhandled.push(reason);
+    };
+
+    process.on("unhandledRejection", onUnhandled);
+
+    let pwBrowser: Awaited<
+      ReturnType<typeof playwrightChromium.connectOverCDP>
+    > | null = null;
+
+    try {
+      pwBrowser = await playwrightChromium.connectOverCDP(v3.connectURL());
+      const pwContext = pwBrowser.contexts()[0];
+      const pwPage = pwContext.pages()[0];
+
+      const v3Page = v3.context.pages()[0];
+      await v3Page.goto("data:text/html,<html><body>cdp</body></html>");
+
+      const pending = v3Page.sendCDP("Runtime.evaluate", {
+        expression: "new Promise(r => setTimeout(() => r('done'), 5000))",
+        awaitPromise: true,
+        returnByValue: true,
+      });
+
+      await pwPage.close();
+
+      await expect(pending).rejects.toThrow(/CDP session detached/);
+
+      await new Promise((r) => setTimeout(r, 50));
+      expect(unhandled).toHaveLength(0);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+      await pwBrowser?.close().catch(() => {});
+    }
+  });
+});

--- a/packages/core/lib/v3/understudy/cdp.ts
+++ b/packages/core/lib/v3/understudy/cdp.ts
@@ -134,6 +134,8 @@ export class CdpConnection implements CDPSessionLike {
         ts: Date.now(),
       });
     });
+    // Prevent unhandledRejection if a session detaches before the caller awaits.
+    void p.catch(() => {});
     this.cdpLogger?.({ method, params, targetId: null });
     this.ws.send(JSON.stringify(payload));
     return p;
@@ -266,6 +268,8 @@ export class CdpConnection implements CDPSessionLike {
         ts: Date.now(),
       });
     });
+    // Prevent unhandledRejection if a session detaches before the caller awaits.
+    void p.catch(() => {});
     const targetId = this.sessionToTarget.get(sessionId) ?? null;
     this.cdpLogger?.({ method, params, targetId });
     this.ws.send(JSON.stringify(payload));

--- a/packages/core/lib/v3/understudy/page.ts
+++ b/packages/core/lib/v3/understudy/page.ts
@@ -607,10 +607,7 @@ export class Page {
    *   { expression: "1 + 1" }
    * );
    */
-  public async sendCDP<T = unknown>(
-    method: string,
-    params?: object,
-  ): Promise<T> {
+  public sendCDP<T = unknown>(method: string, params?: object): Promise<T> {
     return this.mainSession.send<T>(method, params);
   }
 


### PR DESCRIPTION
# why
- We saw worker crashes caused by `unhandledRejection: Error("CDP session detached")` when a Playwright‑connected page closed while Stagehand had inflight CDP calls.
- Root cause: `Page.sendCDP` was async, which wraps the underlying CDP promise. The detach rejection hit the inner promise before the outer wrapper was awaited, so Node treated it as unhandled.
# what changed
  - Fix by making Page.sendCDP return the original promise (remove async) so callers receive the same promise that is already handled internally. This eliminates the unhandled rejection race without changing semantics.

# test plan
 - The new regression test reproduces this by starting a long‑running CDP command and closing the page; it failed on main with an unhandled rejection.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes worker crashes from unhandled CDP session detaches when a page closes during in‑flight calls. Addresses STG-1240 by returning the original sendCDP promise and guarding internal CDP promises.

- **Bug Fixes**
  - Page.sendCDP now returns the original promise (removed async) so rejections are handled by callers.
  - Added catch guards in CdpConnection to prevent early unhandledRejection on detach.
  - New regression test: long Runtime.evaluate + page close rejects cleanly with no unhandledRejection.
  - Patch changeset for @browserbasehq/stagehand.

<sup>Written for commit d5e86daee16826ef10ac12573606a8abcded27b5. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1644">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

