### PR TITLE
[chore]: rm docs changeset

### DIFF
--- a/.changeset/crazy-lions-wear.md
+++ b/.changeset/crazy-lions-wear.md
@@ -1,5 +1,0 @@
----
-"@browserbasehq/stagehand-docs": patch
----
-
-Added /replay endpoint to docs


### PR DESCRIPTION
# why
- to fix release


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the docs-only changeset (.changeset/crazy-lions-wear.md) so it no longer triggers a patch release of @browserbasehq/stagehand-docs. This unblocks the release pipeline.

<sup>Written for commit 2f1195eee05cc8a6807605fc2cf724bface3f314. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1648">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

