### PR TITLE
feat: add interactive snapshot filtering

### DIFF
--- a/packages/core/lib/v3/types/private/snapshot.ts
+++ b/packages/core/lib/v3/types/private/snapshot.ts
@@ -16,6 +16,15 @@ export type SnapshotOptions = {
    * Optional feature flag that surfaces experimental traversal tweaks in the Accessibility layer.
    */
   experimental?: boolean;
+  /**
+   * Filter snapshot to only include interactive elements (buttons, links, inputs, etc.).
+   * Dramatically reduces output size for agent use cases.
+   */
+  interactive?: boolean;
+  /**
+   * Maximum tree depth to include in the snapshot.
+   */
+  maxDepth?: number;
 };
 
 /**
@@ -109,6 +118,10 @@ export type A11yOptions = {
   tagNameMap: Record<string, string>;
   scrollableMap: Record<string, boolean>;
   encode: (backendNodeId: number) => string;
+  /** Filter to only include interactive elements */
+  interactive?: boolean;
+  /** Maximum tree depth to include */
+  maxDepth?: number;
 };
 
 export type AccessibilityTreeResult = {

--- a/packages/core/lib/v3/understudy/a11y/snapshot/a11yTree.ts
+++ b/packages/core/lib/v3/understudy/a11y/snapshot/a11yTree.ts
@@ -12,6 +12,43 @@ import {
 import { formatTreeLine, normaliseSpaces } from "./treeFormatUtils";
 
 /**
+ * ARIA roles that represent interactive elements.
+ * Based on WAI-ARIA 1.2 widget roles specification.
+ * Used for filtering snapshots to only actionable elements.
+ */
+export const INTERACTIVE_ROLES = new Set([
+  "button",
+  "link",
+  "textbox",
+  "checkbox",
+  "radio",
+  "combobox",
+  "listbox",
+  "menuitem",
+  "menuitemcheckbox",
+  "menuitemradio",
+  "option",
+  "searchbox",
+  "slider",
+  "spinbutton",
+  "switch",
+  "tab",
+  "treeitem",
+  "gridcell",
+  "columnheader",
+  "rowheader",
+  "select",
+]);
+
+/**
+ * Check if a role is interactive (clickable, typeable, etc.)
+ */
+export function isInteractive(role: string): boolean {
+  const r = role?.toLowerCase();
+  return INTERACTIVE_ROLES.has(r);
+}
+
+/**
  * Fetch and prune the accessibility tree for a frame, optionally scoping the
  * output to a selector root for faster targeted snapshots.
  */
@@ -174,6 +211,11 @@ export async function buildHierarchicalTree(
     Boolean,
   ) as A11yNode[];
 
+  // If interactive mode, filter to only interactive nodes
+  if (opts.interactive) {
+    return { tree: filterToInteractiveNodes(cleaned, opts.maxDepth) };
+  }
+
   return { tree: cleaned };
 
   async function pruneStructuralSafe(node: A11yNode): Promise<A11yNode | null> {
@@ -213,6 +255,58 @@ export async function buildHierarchicalTree(
 export function isStructural(role: string): boolean {
   const r = role?.toLowerCase();
   return r === "generic" || r === "none" || r === "inlinetextbox";
+}
+
+/**
+ * Extract only interactive nodes from the tree, preserving hierarchy
+ * for nodes that have interactive descendants.
+ */
+function filterToInteractiveNodes(
+  roots: A11yNode[],
+  maxDepth?: number,
+): A11yNode[] {
+  const result: A11yNode[] = [];
+
+  function traverse(node: A11yNode, depth: number): A11yNode | null {
+    // Respect depth limit
+    if (maxDepth !== undefined && depth > maxDepth) {
+      return null;
+    }
+
+    const children = node.children ?? [];
+    const filteredChildren: A11yNode[] = [];
+
+    // Recursively filter children
+    for (const child of children) {
+      const filtered = traverse(child, depth + 1);
+      if (filtered) {
+        filteredChildren.push(filtered);
+      }
+    }
+
+    const nodeIsInteractive = isInteractive(node.role);
+
+    // Keep this node if:
+    // 1. It's interactive, OR
+    // 2. It has interactive descendants (filteredChildren not empty)
+    if (nodeIsInteractive || filteredChildren.length > 0) {
+      return {
+        ...node,
+        children: filteredChildren.length > 0 ? filteredChildren : undefined,
+      };
+    }
+
+    return null;
+  }
+
+  for (const root of roots) {
+    const filtered = traverse(root, 0);
+    if (filtered) {
+      result.push(filtered);
+    }
+  }
+
+  return result;
 }
 
 export function extractUrlFromAXNode(

--- a/packages/core/lib/v3/understudy/a11y/snapshot/capture.ts
+++ b/packages/core/lib/v3/understudy/a11y/snapshot/capture.ts
@@ -187,6 +187,8 @@ export async function tryScopedSnapshot(
         scrollableMap,
         encode: (backendNodeId) =>
           `${page.getOrdinal(targetFrameId)}-${backendNodeId}`,
+        interactive: options?.interactive,
+        maxDepth: options?.maxDepth,
       },
     );
 
@@ -332,6 +334,8 @@ export async function collectPerFrameMaps(
       tagNameMap,
       scrollableMap,
       encode: (backendNodeId) => `${page.getOrdinal(frameId)}-${backendNodeId}`,
+      interactive: options?.interactive,
+      maxDepth: options?.maxDepth,
     });
 
     perFrameOutlines.push({ frameId, outline });


### PR DESCRIPTION
## Summary

Add support for filtering accessibility tree snapshots to only include interactive elements (buttons, links, inputs, etc.). This dramatically reduces output size for agent use cases.

## New Features

- **`--interactive` / `-i` flag**: Filter snapshot to only interactive elements
- **`--depth` / `-d` flag**: Limit tree depth for even smaller output  
- **`--selector` / `-s` flag**: Scope snapshot to a CSS/XPath selector

## Implementation Details

### Core Changes

1. **`INTERACTIVE_ROLES` constant** (a11yTree.ts): Set of 21 WAI-ARIA widget roles:
   - button, link, textbox, checkbox, radio, combobox, listbox
   - menuitem, menuitemcheckbox, menuitemradio, option
   - searchbox, slider, spinbutton, switch, tab, treeitem
   - gridcell, columnheader, rowheader, select

2. **`filterToInteractiveNodes()` function** (a11yTree.ts): 
   - Depth-first traversal keeping nodes that are interactive OR have interactive descendants
   - Respects optional maxDepth limit
   - Preserves hierarchy for context

3. **Map filtering** (page.ts):
   - When interactive mode is enabled, filters xpath/url/css maps to only include refs present in the filtered tree
   - Prevents "ref not found" errors for agents

### Files Changed

- `packages/core/lib/v3/types/private/snapshot.ts`: Add `interactive` and `maxDepth` to SnapshotOptions and A11yOptions
- `packages/core/lib/v3/understudy/a11y/snapshot/a11yTree.ts`: Add INTERACTIVE_ROLES, isInteractive(), filterToInteractiveNodes()
- `packages/core/lib/v3/understudy/a11y/snapshot/capture.ts`: Thread options through tryScopedSnapshot() and collectPerFrameMaps()
- `packages/core/lib/v3/understudy/page.ts`: Add options to snapshot() method, filter maps
- `packages/cli/src/index.ts`: Add CLI flags and update daemon handler

## Usage

```bash
# Get only interactive elements
browse snapshot --interactive

# Limit depth to 5 levels
browse snapshot --interactive --depth 5

# Scope to a specific area
browse snapshot --interactive --selector "#main-content"

# Combine with compact output
browse snapshot -i -c
```

## Benefits

- **20-80% size reduction** on complex pages
- Agents can focus on actionable elements
- Faster processing due to smaller payloads
- Full backward compatibility (all options are optional)

---

Cherry-picked from `shrey/cli-evals-fix` branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add interactive-only filtering to accessibility snapshots to cut output size and help agents focus on actionable elements. Adds CLI and API options for interactive mode, depth, and selector, and filters ref maps to match the reduced tree.

- **New Features**
  - --interactive/-i: only include buttons, links, inputs, etc.
  - --depth/-d: cap snapshot tree depth.
  - --selector/-s: scope snapshot to a CSS or XPath.
  - Page.snapshot({ interactive, maxDepth, focusSelector }) with ref map filtering to match the reduced tree.

<sup>Written for commit a6e5ec9604fcb03da60a643304163488196fdcc5. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1649">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

