### PR TITLE
Add support for gemini 3 on cua/hybrid agent

### DIFF
--- a/.changeset/free-spies-cover.md
+++ b/.changeset/free-spies-cover.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Add support for gemini 3 flash and pro in hybrid/cua agent

--- a/packages/core/examples/cua-example.ts
+++ b/packages/core/examples/cua-example.ts
@@ -28,7 +28,7 @@ async function main() {
     const agent = stagehand.agent({
       mode: "cua",
       model: {
-        modelName: "google/gemini-2.5-computer-use-preview-10-2025",
+        modelName: "google/gemini-3-flash-preview",
         apiKey: process.env.GEMINI_API_KEY ?? process.env.GOOGLE_API_KEY,
       },
       systemPrompt: `You are a helpful assistant that can use a web browser.

--- a/packages/core/lib/v3/agent/AgentProvider.ts
+++ b/packages/core/lib/v3/agent/AgentProvider.ts
@@ -22,6 +22,8 @@ export const modelToAgentProviderMap: Record<string, AgentProviderType> = {
   "claude-opus-4-5-20251101": "anthropic",
   "claude-haiku-4-5-20251001": "anthropic",
   "gemini-2.5-computer-use-preview-10-2025": "google",
+  "gemini-3-flash-preview": "google",
+  "gemini-3-pro-preview": "google",
   "fara-7b": "microsoft",
 };
 

--- a/packages/core/lib/v3/types/public/agent.ts
+++ b/packages/core/lib/v3/types/public/agent.ts
@@ -375,6 +375,8 @@ export const AVAILABLE_CUA_MODELS = [
   "anthropic/claude-sonnet-4-20250514",
   "anthropic/claude-sonnet-4-5-20250929",
   "google/gemini-2.5-computer-use-preview-10-2025",
+  "google/gemini-3-flash-preview",
+  "google/gemini-3-pro-preview",
   "microsoft/fara-7b",
 ] as const;
 export type AvailableCuaModel = (typeof AVAILABLE_CUA_MODELS)[number];

--- a/packages/core/tests/public-api/llm-and-agents.test.ts
+++ b/packages/core/tests/public-api/llm-and-agents.test.ts
@@ -30,6 +30,8 @@ describe("LLM and Agents public API types", () => {
       "anthropic/claude-sonnet-4-20250514",
       "anthropic/claude-sonnet-4-5-20250929",
       "google/gemini-2.5-computer-use-preview-10-2025",
+      "google/gemini-3-flash-preview",
+      "google/gemini-3-pro-preview",
       "microsoft/fara-7b",
     ] as const;
 


### PR DESCRIPTION
# why
Gemini models now support CU tools

# what changed
- Added support for `google/gemini-3-flash-preview` and `google/gemini-3-pro-preview` with access to computer use tools for both hybrid and CUA agent modes
- Updated types accordingly
- Updated tests
- Updated `cua-example.ts` to default to the new gen

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Gemini 3 Flash and Pro support to hybrid and CUA agents, enabling Computer Use tools with these models. Also updates types, provider mapping, tests, and sets the CUA example default to gemini-3-flash-preview.

- **New Features**
  - Enable google/gemini-3-flash-preview and google/gemini-3-pro-preview for CU tools in hybrid and CUA modes.
  - Map both models to the Google provider and include them in AVAILABLE_CUA_MODELS.
  - Update tests and switch cua-example.ts to gemini-3-flash-preview by default.

<sup>Written for commit 25e37215d30ec8e584ab99eace59bdbb1254526b. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1652">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

