### PR TITLE
[docs]: fix userDataDir example for Browserbase sessions

### DIFF
--- a/packages/docs/v3/best-practices/user-data.mdx
+++ b/packages/docs/v3/best-practices/user-data.mdx
@@ -9,24 +9,41 @@ import { V3Banner } from '/snippets/v3-banner.mdx';
 
 ### User Data Directory
 
-Persist browser data between sessions using a custom user data directory:
+Persist browser data between sessions.
+
+#### Local Sessions
+
+For local sessions, use the `userDataDir` option:
 
 ```typescript
 import { Stagehand } from "@browserbasehq/stagehand";
 
-// For Browserbase sessions
 const stagehand = new Stagehand({
-  env: "BROWSERBASE",
-  browserbaseSessionCreateParams: {
-    userDataDir: "/path/to/user/data/directory",
-  },
-});
-
-// For Local sessions
-const localStagehand = new Stagehand({
   env: "LOCAL",
   localBrowserLaunchOptions: {
     userDataDir: "./browser-data",
+  },
+});
+
+await stagehand.init();
+```
+
+#### Browserbase Sessions
+
+For Browserbase sessions, use [contexts](https://docs.browserbase.com/features/contexts) to persist browser data:
+
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const stagehand = new Stagehand({
+  env: "BROWSERBASE",
+  browserbaseSessionCreateParams: {
+    browserSettings: {
+      context: {
+        id: "my-context-id",
+        persist: true,
+      },
+    },
   },
 });
 


### PR DESCRIPTION
## Summary

- Remove incorrect `userDataDir` from `browserbaseSessionCreateParams` example (never a valid option)
- Split docs into separate Local and Browserbase sections
- Add correct Browserbase approach using `browserSettings.context` for persistence

## Context

The documentation incorrectly showed `userDataDir` as a valid `browserbaseSessionCreateParams` property. Per the schema in `/packages/core/lib/v3/types/public/api.ts`, `userDataDir` is only valid in `LocalBrowserLaunchOptions` for `env: "LOCAL"` sessions.

For Browserbase persistence, users should use `browserSettings.context` instead.

## Test plan

- [ ] Verify docs render correctly on Mintlify
- [ ] Confirm link to Browserbase contexts docs works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed docs for user data persistence by removing the invalid userDataDir example for Browserbase sessions and showing the correct contexts-based approach. Split guidance into Local vs Browserbase to reduce confusion.

- **Bug Fixes**
  - Removed userDataDir from browserbaseSessionCreateParams; it’s only valid for env: "LOCAL" via localBrowserLaunchOptions.
  - Added Browserbase example using browserSettings.context (id + persist) and linked to contexts docs.

<sup>Written for commit 1166b792a32b3c29b0ca5eff7dbc8ae9b894ddd0. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1654">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

