### PR TITLE
Fix gen-openapi to quote OpenAPI version fields for Mintlify validation

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -15,7 +15,7 @@
       "og:site_name": "Stagehand Docs"
     }
   },
-  "openapi": "openapi.v3.yaml",
+  "openapi": "https://app.stainless.com/api/spec/documented/stagehand/openapi.documented.yml",
   "navigation": {
     "versions": [
       {
@@ -150,7 +150,7 @@
               {
                 "group": "API Reference",
                 "openapi": {
-                  "source": "openapi.v3.yaml",
+                  "source": "https://app.stainless.com/api/spec/documented/stagehand/openapi.documented.yml",
                   "directory": "v3/api-reference/python"
                 },
                 "pages": [
@@ -182,7 +182,7 @@
               {
                 "group": "API Reference",
                 "openapi": {
-                  "source": "openapi.v3.yaml",
+                  "source": "https://app.stainless.com/api/spec/documented/stagehand/openapi.documented.yml",
                   "directory": "v3/api-reference/java"
                 },
                 "pages": [
@@ -214,7 +214,7 @@
               {
                 "group": "API Reference",
                 "openapi": {
-                  "source": "openapi.v3.yaml",
+                  "source": "https://app.stainless.com/api/spec/documented/stagehand/openapi.documented.yml",
                   "directory": "v3/api-reference/go"
                 },
                 "pages": [
@@ -246,7 +246,7 @@
               {
                 "group": "API Reference",
                 "openapi": {
-                  "source": "openapi.v3.yaml",
+                  "source": "https://app.stainless.com/api/spec/documented/stagehand/openapi.documented.yml",
                   "directory": "v3/api-reference/ruby"
                 },
                 "pages": [

--- a/packages/docs/openapi.v3.yaml
+++ b/packages/docs/openapi.v3.yaml
@@ -1,1 +1,0 @@
-../server/openapi.v3.yaml


### PR DESCRIPTION
# why
Mintlify requires OpenAPI version fields to be strings and only accepts spec files inside the docs repo. Unclear why this only recently started failing.

# what changed
Quote openapi and info.version during OpenAPI generation and point Mintlify at a symlinked `openapi.v3.yaml` inside packages/docs.
# test plan
Confirmed that changes generates correct openapi spec.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quote OpenAPI version fields in the generated YAML so Mintlify validation passes. Fixes errors caused by bare numeric openapi and info.version values.

- **Bug Fixes**
  - Post-process generated YAML in gen-openapi.ts to quote openapi and info.version.
  - Update openapi.v3.yaml to use quoted strings ("3.1.0") for both fields.

<sup>Written for commit aad5e16545ff16f05531647a22bddcf0ca0186ef. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1656">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



