### PR TITLE
Add comment explaining User-Agent header purpose

### DIFF
--- a/packages/core/lib/v3/understudy/cdp.ts
+++ b/packages/core/lib/v3/understudy/cdp.ts
@@ -98,6 +98,7 @@ export class CdpConnection implements CDPSessionLike {
   }
 
   static async connect(wsUrl: string): Promise<CdpConnection> {
+    // Include User-Agent header for server-side observability and version tracking
     const ws = new WebSocket(wsUrl, {
       headers: {
         "User-Agent": `Stagehand/${STAGEHAND_VERSION}`,


### PR DESCRIPTION
Clarifies that the custom User-Agent header enables server-side observability and version tracking for Stagehand CDP connections.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a code comment in CdpConnection.connect explaining that the custom User-Agent enables server-side observability and version tracking for Stagehand CDP connections. Aligns with STG-1262 by documenting the intent behind the header.

<sup>Written for commit 2bf374822a449c60c10336928df7118276011365. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1657">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

