### PR TITLE
fix(ci): handle new tags in server release workflow

### DIFF
--- a/.changeset/fast-roses-destroy.md
+++ b/.changeset/fast-roses-destroy.md
@@ -1,4 +1,0 @@
----
----
-
-fix(ci): handle new tags in server release workflow


### PR DESCRIPTION
# why
The git fetch command was failing with exit code 128 when trying to fetch a tag that doesn't exist on the remote yet (which is the case for new releases). This caused the entire release workflow to fail.

# what changed
Added `|| true` to allow the fetch to fail gracefully for new tags. The subsequent git rev-parse correctly handles both cases:
- Existing tag: script exits with "Tag already exists" message
- New tag: script proceeds to create and push the new tag

Fixes: https://github.com/browserbase/stagehand/actions/runs/21644437387
# test plan

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the server release workflow failing on new tags by allowing git fetch to fail gracefully when the tag doesn’t exist yet. Prevents release runs from stopping with exit code 128.

- **Bug Fixes**
  - Added || true to git fetch for refs/tags/${TAG} to ignore missing remote tag errors.
  - Existing tag: logs “Tag already exists” and exits; new tag: proceeds to create and push.

<sup>Written for commit 5e25d90ab649b5883a97f20e378dd7e7cad67092. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1660">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

