### PR TITLE
fix(ci): handle new tags in server release workflow (#1660)

### DIFF
--- a/.github/workflows/stagehand-server-release.yml
+++ b/.github/workflows/stagehand-server-release.yml
@@ -102,7 +102,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}"
+          # Try to fetch the tag if it exists on remote; ignore failure for new tags
+          git fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}" 2>/dev/null || true
 
           if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
             echo "Tag already exists: ${TAG}"


### PR DESCRIPTION
# why
The git fetch command was failing with exit code 128 when trying to fetch a tag that doesn't exist on the remote yet (which is the case for new releases). This caused the entire release workflow to fail.

# what changed
Added `|| true` to allow the fetch to fail gracefully for new tags. The subsequent git rev-parse correctly handles both cases:
- Existing tag: script exits with "Tag already exists" message
- New tag: script proceeds to create and push the new tag

# test plan

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented the server release workflow from failing on new releases by letting git fetch ignore missing remote tags. Existing tags exit with a clear message; new tags proceed to be created and pushed.

<sup>Written for commit d71339d227d18e96d9fdca926ebc966808e00464. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1661">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

