### PR TITLE
feat: adding Opus 4.6 to model list for computer use

### DIFF
--- a/packages/core/lib/v3/agent/AgentProvider.ts
+++ b/packages/core/lib/v3/agent/AgentProvider.ts
@@ -20,6 +20,7 @@ export const modelToAgentProviderMap: Record<string, AgentProviderType> = {
   "claude-sonnet-4-20250514": "anthropic",
   "claude-sonnet-4-5-20250929": "anthropic",
   "claude-opus-4-5-20251101": "anthropic",
+  "claude-opus-4-6": "anthropic",
   "claude-haiku-4-5-20251001": "anthropic",
   "gemini-2.5-computer-use-preview-10-2025": "google",
   "gemini-3-flash-preview": "google",

--- a/packages/core/lib/v3/types/public/agent.ts
+++ b/packages/core/lib/v3/types/public/agent.ts
@@ -371,6 +371,7 @@ export const AVAILABLE_CUA_MODELS = [
   "openai/computer-use-preview-2025-03-11",
   "anthropic/claude-3-7-sonnet-latest",
   "anthropic/claude-opus-4-5-20251101",
+  "anthropic/claude-opus-4-6",
   "anthropic/claude-haiku-4-5-20251001",
   "anthropic/claude-sonnet-4-20250514",
   "anthropic/claude-sonnet-4-5-20250929",

--- a/packages/core/tests/public-api/llm-and-agents.test.ts
+++ b/packages/core/tests/public-api/llm-and-agents.test.ts
@@ -26,6 +26,7 @@ describe("LLM and Agents public API types", () => {
       "openai/computer-use-preview-2025-03-11",
       "anthropic/claude-3-7-sonnet-latest",
       "anthropic/claude-opus-4-5-20251101",
+      "anthropic/claude-opus-4-6",
       "anthropic/claude-haiku-4-5-20251001",
       "anthropic/claude-sonnet-4-20250514",
       "anthropic/claude-sonnet-4-5-20250929",


### PR DESCRIPTION
# why

opus 4.6 is sota on os world for computer use 

# what changed

enabled it on list of models 

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added Claude Opus 4.6 to the computer use model list to make it available for agents. Mapped it to the Anthropic provider and updated public API types and tests.

<sup>Written for commit cf0ff380bd2a1f9b40933c9759ae94a3205cd305. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1665">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

