### PR TITLE
chore: update stagehand docs with ai gateway information

### DIFF
--- a/packages/docs/v3/configuration/models.mdx
+++ b/packages/docs/v3/configuration/models.mdx
@@ -8,7 +8,7 @@ import { V3Banner } from '/snippets/v3-banner.mdx';
 <V3Banner />
 
 
-Understand web pages, plan actions, and interact with complex interfaces with Google, OpenAI, Anthropic, xAI, DeepSeek, Perplexity, Azure, Ollama, or any other LLM model from [the Vercel AI SDK](https://sdk.vercel.ai/providers).
+Understand web pages, plan actions, and interact with complex interfaces with Google, OpenAI, Anthropic, xAI, DeepSeek, Perplexity, Azure, Ollama, the [Vercel AI Gateway](https://vercel.com/docs/ai-gateway), or any other LLM model from [the Vercel AI SDK](https://sdk.vercel.ai/providers).
 
 ---
 
@@ -629,6 +629,74 @@ const stagehand = new Stagehand({
 
 ---
 
+### AI Gateway
+
+The [Vercel AI Gateway](https://vercel.com/docs/ai-gateway) lets you access models from multiple providers (OpenAI, Anthropic, Google, and more) through a single API key and interface. No extra provider SDKs or per-provider API keys needed.
+
+<Tip>
+  The AI Gateway is built into the `ai` package that Stagehand already uses -- no additional dependencies required.
+</Tip>
+
+**Key benefits:**
+- Access models from all major providers with a single `AI_GATEWAY_API_KEY`
+- Automatic provider fallback and dynamic routing based on uptime and latency
+- Usage tracking and observability through the Vercel dashboard
+- Bring Your Own Key (BYOK) support for existing provider credentials
+
+<Tabs>
+<Tab title="Simple">
+
+Use the `gateway/` prefix followed by the provider and model name:
+
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const stagehand = new Stagehand({
+  env: "BROWSERBASE",
+  model: "gateway/openai/gpt-5"
+  // API key auto-loads from AI_GATEWAY_API_KEY - set in your .env
+});
+
+await stagehand.init();
+```
+
+Works with any model available on the gateway:
+
+```typescript
+// Anthropic via gateway
+model: "gateway/anthropic/claude-sonnet-4"
+
+// Google via gateway
+model: "gateway/google/gemini-2.5-flash"
+```
+
+</Tab>
+<Tab title="Custom Config">
+
+Pass the API key and optional base URL explicitly using the model object format:
+
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const stagehand = new Stagehand({
+  env: "BROWSERBASE",
+  model: {
+    modelName: "gateway/openai/gpt-5",
+    apiKey: process.env.AI_GATEWAY_API_KEY,
+    baseURL: "https://ai-gateway.vercel.sh/v3/ai" // optional custom endpoint
+  }
+});
+
+await stagehand.init();
+```
+
+</Tab>
+</Tabs>
+
+[View all available AI Gateway models →](https://vercel.com/docs/ai-gateway/models-and-providers)
+
+---
+
 ### Extending the AI SDK Client
 
 For advanced use cases like custom retries or caching logic, you can extend the `AISdkClient`:
@@ -750,6 +818,7 @@ The following models work without the `provider/` prefix in the model parameter 
 | Perplexity | `PERPLEXITY_API_KEY`           |
 | TogetherAI | `TOGETHER_AI_API_KEY`          |
 | xAI        | `XAI_API_KEY`                  |
+| AI Gateway | `AI_GATEWAY_API_KEY`           |
 
 </Accordion>
 


### PR DESCRIPTION
# why

Users need to know how to use the AI gateway provider in stagehand

# what changed

added docs to the models section to show users how to use the ai gateway 

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added first-class support for the Vercel AI Gateway and updated docs so you can use models across providers with a single key and simple model strings. Also improved structured outputs for Kimi/DeepSeek and fixed eval parsing for provider/model names.

- **New Features**
  - Added gateway provider to LLMProvider (use model: "gateway/{provider}/{model}").
  - Updated docs with AI Gateway usage, examples, and env var guidance.
  - For DeepSeek/Kimi, added schema prompt to ensure JSON structured outputs; Kimi uses temperature=1.
  - Consistent temperature handling in object/text generation.
  - Improved evals to parse model strings using the first slash.

- **Migration**
  - Set AI_GATEWAY_API_KEY in your environment.
  - Use model names prefixed with gateway/{provider}/{model}; optional baseURL supported.

<sup>Written for commit 560366afaa8d69dcf668004f3687acd88290b725. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1670">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

