### PR TITLE
Fix PR review comments: docs and test improvements

### DIFF
--- a/packages/core/tests/api-multiregion.test.ts
+++ b/packages/core/tests/api-multiregion.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { describe, expect, it } from "vitest";
 import { getApiUrlForRegion, REGION_API_URLS } from "../lib/v3/api";
 
 describe("Multi-region API URL mapping", () => {
@@ -67,28 +67,9 @@ describe("Multi-region API URL mapping", () => {
     });
   });
 
-  describe("STAGEHAND_API_URL env var handling", () => {
-    // These tests verify that the URL construction logic in request() method
-    // correctly appends /v1 to STAGEHAND_API_URL when not present.
-    // The actual logic is in StagehandAPIClient.request() - these tests verify
-    // the expected behavior is documented and the helper function is consistent.
-
-    let originalEnv: string | undefined;
-
-    beforeEach(() => {
-      originalEnv = process.env.STAGEHAND_API_URL;
-    });
-
-    afterEach(() => {
-      if (originalEnv !== undefined) {
-        process.env.STAGEHAND_API_URL = originalEnv;
-      } else {
-        delete process.env.STAGEHAND_API_URL;
-      }
-    });
-
+  describe("URL /v1 suffix handling", () => {
     it("getApiUrlForRegion always includes /v1 suffix for consistency", () => {
-      // When STAGEHAND_API_URL is not set, getApiUrlForRegion returns a URL with /v1
+      // getApiUrlForRegion returns a URL with /v1
       // This documents the expected contract that all API base URLs include /v1
       const url = getApiUrlForRegion("us-west-2");
       expect(url.endsWith("/v1")).toBe(true);

--- a/packages/server/openapi.v3.yaml
+++ b/packages/server/openapi.v3.yaml
@@ -2,19 +2,14 @@ openapi: "3.1.0"
 info:
   title: Stagehand API
   version: "3.1.0"
-  description: >-
+  description: |
     Stagehand SDK for AI browser automation [ALPHA]. This API allows clients to
-
     execute browser automation tasks remotely on the Browserbase cloud.
-
 
     ## Multi-Region Support
 
-
     The Stagehand API is available in multiple regions. Choose the API endpoint
-
     that matches where your browser session is running:
-
 
     | Region | Endpoint |
     |--------|----------|
@@ -23,33 +18,21 @@ info:
     | eu-central-1 | https://api.euc1.stagehand.browserbase.com |
     | ap-southeast-1 | https://api.apse1.stagehand.browserbase.com |
 
-
     **Important:** The API endpoint must match your browser session region.
-
     If there's a mismatch, you'll receive a BAD_REQUEST error:
-
     `Session is in region 'X' but this API instance serves 'Y'. Please route
-
     your request to the X Stagehand API endpoint.`
 
-
     To disable API mode and use local browser automation, set `disableAPI: true`
-
     in your Stagehand configuration.
-
 
     ## Authentication and Usage
 
-
     All endpoints except /sessions/start require an active session ID.
-
     Responses are streamed using Server-Sent Events (SSE) when the
-
     `x-stream-response: true` header is provided.
 
-
     This SDK is currently ALPHA software and is not production ready!
-
     Please try it and give us your feedback, stay tuned for upcoming release
     announcements!
   contact:

--- a/packages/server/test/integration/v3/multiRegion.test.ts
+++ b/packages/server/test/integration/v3/multiRegion.test.ts
@@ -81,10 +81,17 @@ describe("POST /v1/sessions/start - Multi-region support", () => {
       "Should be a success response",
       ctx,
     );
-    assertFetchOk(ctx.body.data.available, "Session should be available", ctx);
-    assertFetchOk(!!ctx.body.data.sessionId, "Should have sessionId", ctx);
 
-    await endSession(ctx.body.data.sessionId, headers);
+    try {
+      assertFetchOk(
+        ctx.body.data.available,
+        "Session should be available",
+        ctx,
+      );
+      assertFetchOk(!!ctx.body.data.sessionId, "Should have sessionId", ctx);
+    } finally {
+      await endSession(ctx.body.data.sessionId, headers);
+    }
   });
 
   it("should start session with us-east-1 region", async () => {
@@ -114,10 +121,17 @@ describe("POST /v1/sessions/start - Multi-region support", () => {
       "Should be a success response",
       ctx,
     );
-    assertFetchOk(ctx.body.data.available, "Session should be available", ctx);
-    assertFetchOk(!!ctx.body.data.sessionId, "Should have sessionId", ctx);
 
-    await endSession(ctx.body.data.sessionId, headers);
+    try {
+      assertFetchOk(
+        ctx.body.data.available,
+        "Session should be available",
+        ctx,
+      );
+      assertFetchOk(!!ctx.body.data.sessionId, "Should have sessionId", ctx);
+    } finally {
+      await endSession(ctx.body.data.sessionId, headers);
+    }
   });
 
   it("should start session with eu-central-1 region", async () => {
@@ -145,10 +159,17 @@ describe("POST /v1/sessions/start - Multi-region support", () => {
       "Should be a success response",
       ctx,
     );
-    assertFetchOk(ctx.body.data.available, "Session should be available", ctx);
-    assertFetchOk(!!ctx.body.data.sessionId, "Should have sessionId", ctx);
 
-    await endSession(ctx.body.data.sessionId, headers);
+    try {
+      assertFetchOk(
+        ctx.body.data.available,
+        "Session should be available",
+        ctx,
+      );
+      assertFetchOk(!!ctx.body.data.sessionId, "Should have sessionId", ctx);
+    } finally {
+      await endSession(ctx.body.data.sessionId, headers);
+    }
   });
 
   it("should start session with ap-southeast-1 region", async () => {
@@ -176,10 +197,17 @@ describe("POST /v1/sessions/start - Multi-region support", () => {
       "Should be a success response",
       ctx,
     );
-    assertFetchOk(ctx.body.data.available, "Session should be available", ctx);
-    assertFetchOk(!!ctx.body.data.sessionId, "Should have sessionId", ctx);
 
-    await endSession(ctx.body.data.sessionId, headers);
+    try {
+      assertFetchOk(
+        ctx.body.data.available,
+        "Session should be available",
+        ctx,
+      );
+      assertFetchOk(!!ctx.body.data.sessionId, "Should have sessionId", ctx);
+    } finally {
+      await endSession(ctx.body.data.sessionId, headers);
+    }
   });
 
   it("should start session without region (defaults to us-west-2)", async () => {
@@ -205,10 +233,17 @@ describe("POST /v1/sessions/start - Multi-region support", () => {
       "Should be a success response",
       ctx,
     );
-    assertFetchOk(ctx.body.data.available, "Session should be available", ctx);
-    assertFetchOk(!!ctx.body.data.sessionId, "Should have sessionId", ctx);
 
-    await endSession(ctx.body.data.sessionId, headers);
+    try {
+      assertFetchOk(
+        ctx.body.data.available,
+        "Session should be available",
+        ctx,
+      );
+      assertFetchOk(!!ctx.body.data.sessionId, "Should have sessionId", ctx);
+    } finally {
+      await endSession(ctx.body.data.sessionId, headers);
+    }
   });
 
   it("should start session without browserbaseSessionCreateParams", async () => {
@@ -233,9 +268,16 @@ describe("POST /v1/sessions/start - Multi-region support", () => {
       "Should be a success response",
       ctx,
     );
-    assertFetchOk(ctx.body.data.available, "Session should be available", ctx);
-    assertFetchOk(!!ctx.body.data.sessionId, "Should have sessionId", ctx);
 
-    await endSession(ctx.body.data.sessionId, headers);
+    try {
+      assertFetchOk(
+        ctx.body.data.available,
+        "Session should be available",
+        ctx,
+      );
+      assertFetchOk(!!ctx.body.data.sessionId, "Should have sessionId", ctx);
+    } finally {
+      await endSession(ctx.body.data.sessionId, headers);
+    }
   });
 });


### PR DESCRIPTION
1. OpenAPI YAML: Change description from >- to | literal scalar to preserve markdown table formatting. The folded scalar was collapsing table rows into a single line.

2. api-multiregion.test.ts: Remove misleading STAGEHAND_API_URL env var scaffolding. The beforeEach/afterEach were dead code since no tests actually set the env var, and getApiUrlForRegion doesn't read it. Renamed the describe block to "URL /v1 suffix handling" to accurately reflect what the tests verify.

3. multiRegion.test.ts: Add try/finally blocks around assertions to ensure endSession is always called even if assertions throw. This prevents session leaks that could cause flaky tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OpenAPI docs rendering and strengthens multi‑region tests to prevent session leaks and clarify URL behavior.

- **Bug Fixes**
  - Preserve markdown table formatting by switching OpenAPI description to a literal scalar (|).
  - Always call endSession via try/finally in integration tests to prevent leaks and flakiness.

- **Refactors**
  - Remove unused STAGEHAND_API_URL env scaffolding in api-multiregion tests.
  - Rename suite to “URL /v1 suffix handling” and document that getApiUrlForRegion always includes /v1.

<sup>Written for commit 28ffac741bc8323b5a82b25de05fcb996a2c586f. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1675">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

