### PR TITLE
add agent structured output feature to docs

### DIFF
--- a/packages/docs/v3/basics/agent.mdx
+++ b/packages/docs/v3/basics/agent.mdx
@@ -49,6 +49,7 @@ Some advanced features are only available with certain agent modes:
 | Abort signal             | ❌  | ✅  | ✅     |
 | Message continuation     | ❌  | ✅  | ✅     |
 | Exclude tools            | ❌  | ✅  | ✅     |
+| Structured output        | ❌  | ✅  | ✅     |
 | DOM-based actions        | ❌  | ✅  | ✅     |
 | Coordinate-based actions | ✅  | ❌  | ✅     |
 | Visual cursor highlight  | ✅  | ❌  | ✅     |
@@ -222,6 +223,11 @@ When you use `agent()`, Stagehand will return a `Promise<AgentResult>` with the 
     }
   ],
   completed: true,
+  // Only populated when `output` schema is provided (DOM/Hybrid modes only)
+  output: {
+    price: "$199",
+    airline: "Delta"
+  },
   usage: {
     input_tokens: 2040,
     output_tokens: 28,
@@ -814,6 +820,95 @@ const thirdResult = await agent.execute({
 
 console.log("Final action:", thirdResult.message);
 ```
+
+## Structured Output
+
+Define a Zod schema to receive structured data when the agent completes its task. This is useful when you need specific information extracted from the agent's execution, such as prices, dates, or other structured data.
+
+<Note>**Non-CUA agents only.** Structured output requires `experimental: true` and is not available with Computer Use Agents.</Note>
+
+<Tip>Use `.describe()` on schema fields to help the agent understand what data to extract.</Tip>
+
+<CodeGroup>
+```typescript Basic Usage
+import { z } from "zod/v3";
+
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  experimental: true, // Required for structured output
+});
+await stagehand.init();
+
+const agent = stagehand.agent({
+  model: "anthropic/claude-sonnet-4-5-20250929",
+});
+
+const page = stagehand.context.pages()[0];
+await page.goto("https://www.google.com/flights");
+
+const result = await agent.execute({
+  instruction: "Find the cheapest flight from NYC to LA for next week",
+  maxSteps: 20,
+  output: z.object({
+    price: z.string().describe("The price of the flight"),
+    airline: z.string().describe("The airline name"),
+    departureTime: z.string().describe("Departure time"),
+    arrivalTime: z.string().describe("Arrival time"),
+  }),
+});
+
+// Access the structured output
+console.log(result.output);
+// { price: "$199", airline: "Delta", departureTime: "8:00 AM", arrivalTime: "11:30 AM" }
+```
+
+```typescript Complex Schema
+const result = await agent.execute({
+  instruction: "Extract all items from the shopping cart",
+  output: z.object({
+    items: z.array(z.object({
+      name: z.string().describe("Product name"),
+      quantity: z.number().describe("Quantity in cart"),
+      unitPrice: z.string().describe("Price per item"),
+      totalPrice: z.string().describe("Total price for this item"),
+    })).describe("List of items in the cart"),
+    subtotal: z.string().describe("Cart subtotal before tax"),
+    tax: z.string().optional().describe("Tax amount if shown"),
+    total: z.string().describe("Final total"),
+  }),
+});
+
+console.log(`Found ${result.output?.items.length} items in cart`);
+console.log(`Total: ${result.output?.total}`);
+```
+
+```typescript With Streaming
+const agent = stagehand.agent({
+  model: "anthropic/claude-sonnet-4-5-20250929",
+  stream: true,
+});
+
+const streamResult = await agent.execute({
+  instruction: "Find the top 3 search results",
+  output: z.object({
+    results: z.array(z.object({
+      title: z.string().describe("The title of the search result"),
+      url: z.string().url().describe("The URL of the search result"),
+      snippet: z.string().describe("A brief description or snippet"),
+    })).max(3).describe("Top 3 search results"),
+  }),
+});
+
+// Stream the text output
+for await (const delta of streamResult.textStream) {
+  process.stdout.write(delta);
+}
+
+// Get the structured output from the final result
+const finalResult = await streamResult.result;
+console.log(finalResult.output?.results);
+```
+</CodeGroup>
 
 ## Agent Execution Configuration
 

--- a/packages/docs/v3/references/agent.mdx
+++ b/packages/docs/v3/references/agent.mdx
@@ -157,6 +157,7 @@ interface AgentExecuteOptions {
   messages?: ModelMessage[]; // Continue from previous conversation (experimental)
   signal?: AbortSignal; // Cancel execution (experimental)
   excludeTools?: string[]; // Tools to exclude from this execution (experimental)
+  output?: ZodObject; // Zod schema for structured output (experimental)
   callbacks?: AgentExecuteCallbacks;
 }
 
@@ -185,6 +186,7 @@ interface AgentStreamExecuteOptions {
   messages?: ModelMessage[]; // Continue from previous conversation (experimental)
   signal?: AbortSignal; // Cancel execution (experimental)
   excludeTools?: string[]; // Tools to exclude from this execution (experimental)
+  output?: ZodObject; // Zod schema for structured output (experimental)
   callbacks?: AgentStreamCallbacks;
 }
 
@@ -254,6 +256,27 @@ interface AgentStreamCallbacks {
   <Warning>**Non-CUA agents only.** Requires `experimental: true`. Not available when `cua: true`.</Warning>
 </ParamField>
 
+<ParamField path="output" type="ZodObject" optional>
+  A Zod schema defining structured output data to return when the task completes. The agent will populate this data based on the information it gathered during execution. The result will be available in `AgentResult.output`.
+
+  <Warning>**Non-CUA agents only.** Requires `experimental: true`. Not available when `mode: "cua"`.</Warning>
+
+  ```typescript
+  import { z } from "zod/v3";
+
+  const result = await agent.execute({
+    instruction: "Find the cheapest flight from NYC to LA",
+    output: z.object({
+      price: z.string().describe("The price of the flight"),
+      airline: z.string().describe("The airline name"),
+      departureTime: z.string().describe("Departure time"),
+    }),
+  });
+
+  console.log(result.output); // { price: "$199", airline: "Delta", departureTime: "8:00 AM" }
+  ```
+</ParamField>
+
 <ParamField path="callbacks" type="AgentExecuteCallbacks | AgentStreamCallbacks" optional>
   Callbacks to hook into the agent's execution lifecycle. The available callbacks depend on whether streaming is enabled.
 
@@ -306,6 +329,7 @@ interface AgentResult {
   completed: boolean;
   metadata?: Record<string, unknown>;
   messages?: ModelMessage[]; // Conversation history for continuation (experimental)
+  output?: Record<string, unknown>; // Structured output data (experimental)
   usage?: {
     input_tokens: number;
     output_tokens: number;
@@ -380,6 +404,12 @@ interface AgentStreamResult {
   <Note>**Non-CUA agents only.** Requires `experimental: true`.</Note>
 </ResponseField>
 
+<ResponseField name="output" type="Record<string, unknown>" optional>
+  Custom structured output data extracted based on the `output` Zod schema provided in execute options. Only populated if an `output` schema was provided.
+
+  <Note>**Non-CUA agents only.** Requires `experimental: true`.</Note>
+</ResponseField>
+
 <ResponseField name="usage" type="object" optional>
   Token usage and performance metrics.
 
@@ -423,6 +453,11 @@ interface AgentStreamResult {
   "completed": true,
   "metadata": {
     "steps_taken": 2
+  },
+  "output": {
+    "price": "$199",
+    "airline": "Delta",
+    "departureTime": "8:00 AM"
   },
   "usage": {
     "input_tokens": 1250,
@@ -736,6 +771,46 @@ const result = await agent.execute({
 });
 
 console.log("Completed:", result.completed);
+```
+
+</Tab>
+<Tab title="Structured Output">
+
+```typescript
+import { z } from "zod/v3";
+
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  experimental: true, // Required for structured output
+});
+await stagehand.init();
+
+const agent = stagehand.agent({
+  model: "anthropic/claude-sonnet-4-5-20250929",
+});
+
+const page = stagehand.context.pages()[0];
+await page.goto("https://www.google.com/flights");
+
+// Define output schema to receive structured data
+const result = await agent.execute({
+  instruction: "Find the cheapest flight from NYC to LA for next week",
+  maxSteps: 20,
+  output: z.object({
+    price: z.string().describe("The price of the flight"),
+    airline: z.string().describe("The airline name"),
+    departureTime: z.string().describe("Departure time"),
+    arrivalTime: z.string().describe("Arrival time"),
+    flightNumber: z.string().optional().describe("Flight number if available"),
+  }),
+});
+
+// Access the structured output
+console.log("Flight found:");
+console.log(`  Price: ${result.output?.price}`);
+console.log(`  Airline: ${result.output?.airline}`);
+console.log(`  Departure: ${result.output?.departureTime}`);
+console.log(`  Arrival: ${result.output?.arrivalTime}`);
 ```
 
 </Tab>


### PR DESCRIPTION
# why

We do not currently have documentation on the structured output feature within agent 

# what changed

added documentation for usign structured output with aget 

# test plan
ran mintlify dev, and looked at docs 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds documentation for the Agent structured output feature, showing how to define a Zod schema via the output option and read data from result.output. Clarifies availability (non-CUA agents) and the need for experimental: true.

- **New Features**
  - Added “Structured Output” guides to basics and reference docs.
  - Documented output in AgentExecuteOptions/AgentStreamExecuteOptions and result.output in AgentResult/AgentStreamResult.
  - Included examples: basic extraction, complex arrays, and streaming, with notes on non-CUA and experimental requirement.

<sup>Written for commit 2ce65f30c688e6b1771517beb22a31ee81f06426. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1676">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

