### PR TITLE
[docs]: correct Python dict syntax for cdp_url in browser config

### DIFF
--- a/packages/docs/v2/configuration/browser.mdx
+++ b/packages/docs/v2/configuration/browser.mdx
@@ -400,7 +400,7 @@ from stagehand import Stagehand
 stagehand = Stagehand(
     env="LOCAL",
     local_browser_launch_options={
-      cdp_url="http://localhost:9222"
+      "cdp_url": "http://localhost:9222"
     }
 )
 


### PR DESCRIPTION
## Summary
- Fixes invalid Python syntax in the "Connecting to your local browser" docs example
- The `cdp_url` was written using keyword argument syntax (`cdp_url="..."`) inside a dictionary literal `{}`, which is a syntax error in Python
- Changed to proper dictionary syntax (`"cdp_url": "..."`)

Fixes #1288

## Test plan
- [x] Verify the corrected code example is valid Python syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes invalid Python dictionary syntax in the local browser configuration docs by changing cdp_url="..." to "cdp_url": "...". This removes the syntax error so the example runs when copy-pasted.

<sup>Written for commit c6bf3686b2f40d4d46c0d01b84870ba565fa6c11. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1684">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

