### PR TITLE
[chore]: rm noisy debug log

### DIFF
--- a/packages/core/lib/v3/understudy/selectorResolver.ts
+++ b/packages/core/lib/v3/understudy/selectorResolver.ts
@@ -222,17 +222,6 @@ export class FrameSelectorResolver {
       1000,
     );
 
-    v3Logger({
-      category: "locator",
-      message: "xpath main-world",
-      level: 2,
-      auxiliary: {
-        frameId: { value: String(this.frame.frameId), type: "string" },
-        xp: { value: value, type: "string" },
-        ctxId: { value: String(ctxId), type: "string" },
-      },
-    });
-
     const results: ResolvedNode[] = [];
     for (let index = 0; index < limit; index += 1) {
       const expr = this.buildLocatorInvocation("resolveXPathMainWorld", [


### PR DESCRIPTION
# why
- this log was unhelpful, & also did not respect the global verbosity level
# what changed
- removed the log

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the noisy "xpath main-world" debug log from FrameSelectorResolver to reduce console noise and respect global verbosity settings.

<sup>Written for commit 2f36229e975f16c2e5d7f9b71be6e4e5dac156e0. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1686">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

