### PR TITLE
[docs]: add missing CUA models to docs

### DIFF
--- a/packages/docs/v3/basics/agent.mdx
+++ b/packages/docs/v3/basics/agent.mdx
@@ -56,7 +56,7 @@ Some advanced features are only available with certain agent modes:
 
 ### Computer Use Agents
 
-You can use specialized computer use models from either Google, OpenAI, or Anthropic as shown below, with `mode` set to `"cua"`. To compare the performance of different computer use models, you can visit our [evals page](https://www.stagehand.dev/agent-evals).
+You can use specialized computer use models from Google, OpenAI, Anthropic, or Microsoft as shown below, with `mode` set to `"cua"`. To compare the performance of different computer use models, you can visit our [evals page](https://www.stagehand.dev/agent-evals).
 
 <Warning>
 **Deprecation Notice:** The `cua: true` option is deprecated and will be removed in a future version. Use `mode: "cua"` instead.

--- a/packages/docs/v3/best-practices/computer-use.mdx
+++ b/packages/docs/v3/best-practices/computer-use.mdx
@@ -1,6 +1,6 @@
 ---
 title: Computer Use Agents
-description: Incorporate Computer Use APIs from Google, Anthropic, and OpenAI with one line of code in Stagehand.
+description: Incorporate Computer Use APIs from Google, Anthropic, OpenAI, and Microsoft with one line of code in Stagehand.
 ---
 import { V3Banner } from '/snippets/v3-banner.mdx';
 
@@ -22,7 +22,7 @@ You might've heard of [Gemini Computer Use](https://blog.google/technology/googl
 
 These are powerful tools that can convert natural language into actions on the computer. However, you'd otherwise need to write your own code to convert these actions into Playwright commands.
 
-Stagehand not only handles the execution of Computer Use outputs, but also lets you hot-swap between Google, OpenAI, and Anthropic models with one line of code. You can find more information on the performance of different computer use models by visiting our [evals page](https://www.stagehand.dev/agent-evals).
+Stagehand not only handles the execution of Computer Use outputs, but also lets you hot-swap between Google, OpenAI, Anthropic, and Microsoft models with one line of code. You can find more information on the performance of different computer use models by visiting our [evals page](https://www.stagehand.dev/agent-evals).
 
 ## How to use a Computer Use Agent in Stagehand
 
@@ -159,7 +159,7 @@ await agent.execute({
 
 ### Select Your Computer Use Model
 
-Stagehand supports computer use models from Google, Anthropic, and OpenAI. You can find all supported models on the [models page](/v3/configuration/models#agent-models-with-cua-support).
+Stagehand supports computer use models from Google, Anthropic, OpenAI, and Microsoft. You can find all supported models on the [models page](/v3/configuration/models#agent-models-with-cua-support).
 
 <Tabs>
 <Tab title="Google">

--- a/packages/docs/v3/configuration/models.mdx
+++ b/packages/docs/v3/configuration/models.mdx
@@ -548,11 +548,16 @@ const agent = stagehand.agent({
 <Accordion title="All Supported CUA Models">
 | Provider | Model |
 | -------- | ----- |
-| Google   | `google/gemini-2.5-computer-use-preview-10-2025` |
 | Anthropic | `anthropic/claude-3-7-sonnet-latest` |
 | Anthropic | `anthropic/claude-haiku-4-5-20251001` |
 | Anthropic | `anthropic/claude-sonnet-4-20250514` |
 | Anthropic | `anthropic/claude-sonnet-4-5-20250929` |
+| Anthropic | `anthropic/claude-opus-4-5-20251101` |
+| Anthropic | `anthropic/claude-opus-4-6` |
+| Google   | `google/gemini-2.5-computer-use-preview-10-2025` |
+| Google   | `google/gemini-3-flash-preview` |
+| Google   | `google/gemini-3-pro-preview` |
+| Microsoft | `microsoft/fara-7b` |
 | OpenAI   | `openai/computer-use-preview` |
 | OpenAI   | `openai/computer-use-preview-2025-03-11` |
 </Accordion>

--- a/packages/docs/v3/references/agent.mdx
+++ b/packages/docs/v3/references/agent.mdx
@@ -67,13 +67,18 @@ interface AgentInstance {
   - An object with `modelName` and additional provider-specific options
 
   **Available CUA Models:**
-  - `"openai/computer-use-preview"`
-  - `"openai/computer-use-preview-2025-03-11"`
   - `"anthropic/claude-3-7-sonnet-latest"`
   - `"anthropic/claude-haiku-4-5-20251001"`
   - `"anthropic/claude-sonnet-4-20250514"`
   - `"anthropic/claude-sonnet-4-5-20250929"`
+  - `"anthropic/claude-opus-4-5-20251101"`
+  - `"anthropic/claude-opus-4-6"`
   - `"google/gemini-2.5-computer-use-preview-10-2025"`
+  - `"google/gemini-3-flash-preview"`
+  - `"google/gemini-3-pro-preview"`
+  - `"microsoft/fara-7b"`
+  - `"openai/computer-use-preview"`
+  - `"openai/computer-use-preview-2025-03-11"`
 
   <Expandable title="AgentModelConfig Object">
     <ParamField path="modelName" type="string" required>


### PR DESCRIPTION
## Summary
- Added 5 missing CUA models to all documentation pages: `anthropic/claude-opus-4-5-20251101`, `anthropic/claude-opus-4-6`, `google/gemini-3-flash-preview`, `google/gemini-3-pro-preview`, and `microsoft/fara-7b`
- Updated provider mentions from "Google, Anthropic, and OpenAI" to include Microsoft across all CUA-related docs
- Organized model lists alphabetically by provider for consistency

The codebase (`AVAILABLE_CUA_MODELS` in `agent.ts`) supports 12 CUA models but the docs only listed 7. This brings the docs in sync with the source of truth.

## Test plan
- [ ] Verify the models page renders the updated accordion table correctly
- [ ] Verify the agent reference page lists all 12 models
- [ ] Verify the computer-use best practices page mentions Microsoft
- [ ] Verify the agent basics page mentions Microsoft

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added five missing CUA models—anthropic/claude-opus-4-5-20251101, anthropic/claude-opus-4-6, google/gemini-3-flash-preview, google/gemini-3-pro-preview, and microsoft/fara-7b—and updated provider mentions to include Microsoft. This syncs all CUA docs with the 12 models supported in the codebase and alphabetizes lists by provider.

<sup>Written for commit d1d5f3d727bd4ecc1c868ebfd911dd95a0c16257. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1693">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

