### PR TITLE
[docs]: add Google Vertex AI configuration

### DIFF
--- a/packages/docs/v3/configuration/models.mdx
+++ b/packages/docs/v3/configuration/models.mdx
@@ -78,7 +78,7 @@ const stagehand = new Stagehand({
   env: "BROWSERBASE",
   experimental: true, // required for Vertex
   model: {
-    modelName: "vertex/gemini-2.5-flash",
+    modelName: "vertex/gemini-3-flash-preview",
     project: "your-gcp-project-id",
     location: "us-central1",
     googleAuthOptions: {
@@ -96,7 +96,7 @@ await stagehand.init();
 </CodeGroup>
 
 The `model` object accepts:
-- `modelName` — The Vertex model, prefixed with `vertex/` (e.g. `vertex/gemini-2.5-flash`)
+- `modelName` — The Vertex model, prefixed with `vertex/` (e.g. `vertex/gemini-3-flash-preview`)
 - `project` — Your GCP project ID
 - `location` — Your Vertex AI region (e.g. `us-central1`)
 - `googleAuthOptions.credentials` — Service account credentials with `client_email` and `private_key`


### PR DESCRIPTION
## Summary
- Adds a **Google Vertex** tab to the First Class Models section in the v3 models docs
- Documents the `experimental: true` requirement, model object format (`project`, `location`, `googleAuthOptions`), and service account credentials setup
- Adds Google Vertex to the API key troubleshooting table

This was requested in Discord — the `vertex/` provider is fully supported in code but was missing from documentation.

## Test plan
- [ ] Verify the new tab renders correctly on the docs site
- [ ] Confirm code snippet matches the accepted `GoogleVertexProviderSettings` type

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added Google Vertex configuration to v3 models docs. New tab with TS example using vertex/gemini-3-flash-preview, service account setup, and required fields (project, location, googleAuthOptions) with experimental: true; updated troubleshooting to say “Vertex” and point to service account credentials.

<sup>Written for commit c7ed246476436dc3581ae8d0699d8acb50f1d99b. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1696">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

