### PR TITLE
[chore]: add dotenv to dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@changesets/cli": "^2.27.9",
     "@eslint/js": "^9.16.0",
     "c8": "^10.1.3",
+    "dotenv": "16.4.5",
     "esbuild": "0.27.2",
     "eslint": "^9.16.0",
     "eslint-plugin-security": "^3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       c8:
         specifier: ^10.1.3
         version: 10.1.3
+      dotenv:
+        specifier: 16.4.5
+        version: 16.4.5
       esbuild:
         specifier: 0.27.2
         version: 0.27.2


### PR DESCRIPTION
# why
- so that `dotenv` is installed with `pnpm i`
# what changed
- added `dotenv` to dev dependencies

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added dotenv 16.4.5 to devDependencies so it installs with pnpm i. This enables .env loading in local dev scripts without manual installation.

<sup>Written for commit 53f8c54776eaefa5aab7a8c755ce37d84ae5f2e9. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1699">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

