### PR TITLE
[fix]: resolve `supervisor.js` via `import.meta.url`

### DIFF
--- a/packages/core/lib/v3/shutdown/supervisorClient.ts
+++ b/packages/core/lib/v3/shutdown/supervisorClient.ts
@@ -21,10 +21,9 @@ import {
 } from "../types/private/shutdownErrors.js";
 
 const READY_TIMEOUT_MS = 500;
-const thisDir =
-  typeof __dirname === "string"
-    ? __dirname
-    : path.dirname(fileURLToPath(import.meta.url));
+// Prefer import.meta.url — always correct per-module in ESM.
+// __dirname may be an incorrect polyfill in some tsx / loader configurations.
+const thisDir = path.dirname(fileURLToPath(import.meta.url));
 
 const resolveSupervisorScript = (): {
   command: string;
@@ -53,7 +52,7 @@ export function startShutdownSupervisor(
   if (!resolved) {
     opts?.onError?.(
       new ShutdownSupervisorResolveError(
-        "Shutdown supervisor script missing (expected supervisor.js or supervisor.ts next to shutdown/supervisorClient).",
+        `Shutdown supervisor script missing (searched ${thisDir} for supervisor.js or supervisor.ts).`,
       ),
       "resolve",
     );


### PR DESCRIPTION
# why
- the `supervisorClient` was unable to find the `supervisor.js` file after we migrated to esm
- the old code preferred `__dirname` over `import.meta.url`, but tsx polyfills `__dirname` in esm mode and it can resolve to the wrong directory
# what changed
- use `import.meta.url` instead of `__dirname`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes supervisor script resolution in ESM by using import.meta.url, preventing failures when __dirname is polyfilled by tsx.

- **Bug Fixes**
  - Resolve supervisor.js using import.meta.url instead of __dirname.
  - Improve missing-script error message to include the searched directory.

<sup>Written for commit 42c84bdfa92d22bb8de700931eebc45b2733d813. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1702">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

