### PR TITLE
[chore]: re add registry-url to `release.yml`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           use-prebuilt-artifacts: "false"
 
       - name: Configure npm registry for Trusted Publishing
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20.x
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
# why
- to fix alpha releases which were failing 
# what changed
- this PR adds back the the registry-url config to the `setup-node` step, which is required for trusted publishing


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores npm registry config and updates the Node setup step to v6 for Trusted Publishing, fixing failing alpha releases.

- **Bug Fixes**
  - Configure Trusted Publishing: set registry-url via setup-node v6 with Node 20.x and upgrade npm to latest.
  - Set checkout fetch-depth to 0 to include full git history.

<sup>Written for commit 90123dac483dde9c890c8d754179945ae2bb16a6. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1703">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

