### PR TITLE
[chore]: rm duplicate test runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,23 +132,10 @@ jobs:
             exit 0
           fi
 
-          # Skip evals if only docs/examples changed (and not on main)
-          if [[ "${{ needs.determine-changes.outputs.docs-only }}" == "true" && "${{ needs.determine-changes.outputs.core }}" == "false" && "${{ needs.determine-changes.outputs.evals }}" == "false" && "${{ github.ref }}" != "refs/heads/main" ]]; then
+          # Skip evals if only docs/examples changed
+          if [[ "${{ needs.determine-changes.outputs.docs-only }}" == "true" && "${{ needs.determine-changes.outputs.core }}" == "false" && "${{ needs.determine-changes.outputs.evals }}" == "false" ]]; then
             echo "Only docs/examples changed - skipping evals"
             echo "skip-all-evals=true" >> $GITHUB_OUTPUT
-            emit_categories
-            exit 0
-          fi
-
-          # Default to running all tests on main branch
-          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
-            echo "Running all tests for main branch"
-            echo "skip-all-evals=false" >> $GITHUB_OUTPUT
-            IFS=',' read -r -a default_categories <<< "${EVAL_CATEGORIES}"
-            for category in "${default_categories[@]}"; do
-              add_category "$category"
-            done
-            add_category "regression"
             emit_categories
             exit 0
           fi
@@ -505,8 +492,7 @@ jobs:
     timeout-minutes: 50
     if: >
       needs.discover-e2e-tests.outputs.has-e2e-tests == 'true' &&
-      (github.event_name == 'push' ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository))
+      github.event.pull_request.head.repo.full_name == github.repository
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -552,8 +538,7 @@ jobs:
     timeout-minutes: 50
     if: >
       needs.discover-e2e-tests.outputs.has-e2e-tests == 'true' &&
-      (github.event_name == 'push' ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository))
+      github.event.pull_request.head.repo.full_name == github.repository
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
# why
- for now, we only really need to run tests on pull requests. rerunning on merge to main is redundant
# what changed
- reverted the CI trigger to only run on pull requests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run tests only on pull requests to prevent duplicate CI runs on merges to main. This reduces CI noise and usage.

Updated the GitHub Actions workflow to remove the main push trigger, drop main-specific test logic, simplify doc-only skip rules, and run e2e jobs only for PRs from this repo.

<sup>Written for commit 592ad4441c3d2f5d9ccda9f53c4b678fca27ab90. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1704">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

