### PR TITLE
fix(server): use LOCAL_BROWSER_BODY in multiRegion test

### DIFF
--- a/packages/server/test/integration/v3/multiRegion.test.ts
+++ b/packages/server/test/integration/v3/multiRegion.test.ts
@@ -8,6 +8,7 @@ import {
   getBaseUrl,
   getHeaders,
   HTTP_OK,
+  LOCAL_BROWSER_BODY,
 } from "../utils.js";
 
 // =============================================================================
@@ -47,14 +48,7 @@ function isSuccessResponse(
 
 describe("POST /v1/sessions/start - Multi-region support", () => {
   const headers = getHeaders("3.0.0");
-  const localBrowser = {
-    browser: {
-      type: "local",
-      launchOptions: {
-        headless: true,
-      },
-    },
-  };
+  const localBrowser = LOCAL_BROWSER_BODY;
 
   it("should start session with us-west-2 region (default)", async () => {
     const url = getBaseUrl();


### PR DESCRIPTION
The multiRegion integration test was defining its own localBrowser config inline without the CI-required settings like executablePath, --no-sandbox args, and connectTimeoutMs. This caused the test to fail in CI environments.

Fix by importing and using LOCAL_BROWSER_BODY from utils.js, which properly handles all CI-specific browser configurations.

# why

# what changed

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use LOCAL_BROWSER_BODY in the multiRegion integration test to apply CI-safe browser settings and stop failures in CI. This replaces the inline localBrowser config with the shared util that sets executablePath, --no-sandbox, and connectTimeoutMs.

<sup>Written for commit 3d2ba15eab2c9f10196742066d6317fbfa30b87a. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1709">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

