### PR TITLE
Evals pathfix

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -18,5 +18,4 @@ packages/docs/
 **/.browserbase/
 **/.browserbase/**
 stainless.yml
-packages/server/openapi*.yaml
-packages/server/openapi*.yml
+packages/server/openapi.v3.yaml

--- a/packages/evals/suites/webtailbench.ts
+++ b/packages/evals/suites/webtailbench.ts
@@ -1,17 +1,16 @@
-import path from "path";
+import { fileURLToPath } from "url";
 import type { Testcase, EvalInput } from "../types/evals.js";
 import type { AvailableModel } from "@browserbasehq/stagehand";
 import { tasksConfig } from "../taskConfig.js";
 import { readJsonlFile, parseJsonlRows, applySampling } from "../utils.js";
 
 export const buildWebTailBenchTestcases = (models: string[]): Testcase[] => {
-  const webtailbenchFilePath = path.join(
-    __dirname,
-    "..",
-    "datasets",
-    "webtailbench",
-    "WebTailBench_data.jsonl",
-  );
+  const moduleDir =
+    typeof __dirname === "string"
+      ? __dirname
+      : fileURLToPath(new URL(".", import.meta.url)).replace(/\/$/, "");
+  const webtailbenchFilePath =
+    moduleDir + "/../datasets/webtailbench/WebTailBench_data.jsonl";
 
   const lines = readJsonlFile(webtailbenchFilePath);
 


### PR DESCRIPTION
# why

# what changed

# test plan

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed WebTailBench evals to resolve dataset paths under ESM by deriving the module directory from import.meta.url when __dirname isn’t available. Also tightened .prettierignore to only exclude packages/server/openapi.v3.yaml for consistent formatting.

<sup>Written for commit d4e0bd000e9421dc88dfcc170fe2329ef34a5ebf. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1716">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

