### PR TITLE
[BB-68] refactor(examples): use top-level await instead of async IIFE

### DIFF
--- a/.changeset/big-chairs-listen.md
+++ b/.changeset/big-chairs-listen.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+refactor(examples): use top-level await instead of async IIFE

--- a/packages/core/examples/2048.ts
+++ b/packages/core/examples/2048.ts
@@ -1,94 +1,89 @@
 import { Stagehand } from "../lib/v3/index.js";
 import { z } from "zod";
 
-async function example() {
-  console.log("🎮 Starting 2048 bot...");
-  const stagehand = new Stagehand({
-    env: "LOCAL",
-    verbose: 1,
-  });
+console.log("🎮 Starting 2048 bot...");
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  verbose: 1,
+});
 
-  console.log("🌟 Initializing Stagehand...");
-  await stagehand.init();
-  const page = stagehand.context.pages()[0];
-  try {
-    console.log("🌐 Navigating to 2048...");
-    await page.goto("https://ovolve.github.io/2048-AI/");
-    // Main game loop
-    while (true) {
-      console.log("🔄 Game loop iteration...");
-      // Add a small delay for UI updates
-      await new Promise((resolve) => setTimeout(resolve, 300));
-      // Get current game state
-      const gameState = await stagehand.extract(
-        `Extract the current game state:
-          1. Score from the score counter
-          2. All tile values in the 4x4 grid (empty spaces as 0)
-          3. Highest tile value present`,
-        z.object({
-          score: z.number(),
-          highestTile: z.number(),
-          grid: z.array(z.array(z.number())),
-        }),
-      );
-      const transposedGrid = gameState.grid[0].map((_, colIndex) =>
-        gameState.grid.map((row) => row[colIndex]),
-      );
-      const grid = transposedGrid.map((row, rowIndex) => ({
-        [`row${rowIndex + 1}`]: row,
-      }));
-      console.log("Game State:", {
-        score: gameState.score,
-        highestTile: gameState.highestTile,
-        grid: grid,
-      });
-      // Analyze board and decide next move
-      const analysis = await stagehand.extract(
-        `Based on the current game state:
-          - Score: ${gameState.score}
-          - Highest tile: ${gameState.highestTile}
-          - Grid: This is a 4x4 matrix ordered by row (top to bottom) and column (left to right). The rows are stacked vertically, and tiles can move vertically between rows or horizontally between columns:\n${grid
-            .map((row) => {
-              const rowName = Object.keys(row)[0];
-              return `             ${rowName}: ${row[rowName].join(", ")}`;
-            })
-            .join("\n")}
-          What is the best move (up/down/left/right)? Consider:
-          1. Keeping high value tiles in corners (bottom left, bottom right, top left, top right)
-          2. Maintaining a clear path to merge tiles
-          3. Avoiding moves that could block merges
-          4. Only adjacent tiles of the same value can merge
-          5. Making a move will move all tiles in that direction until they hit a tile of a different value or the edge of the board
-          6. Tiles cannot move past the edge of the board
-          7. Each move must move at least one tile`,
-        z.object({
-          move: z.enum(["up", "down", "left", "right"]),
-          confidence: z.number(),
-          reasoning: z.string(),
-        }),
-      );
-      console.log("Move Analysis:", analysis);
-      const moveKey = {
-        up: "ArrowUp",
-        down: "ArrowDown",
-        left: "ArrowLeft",
-        right: "ArrowRight",
-      }[analysis.move];
-      await page.keyPress(moveKey);
-      console.log("🎯 Executed move:", analysis.move);
-    }
-  } catch (error) {
-    console.error("❌ Error in game loop:", error);
-    const isGameOver = await page.evaluate(() => {
-      return document.querySelector(".game-over") !== null;
+console.log("🌟 Initializing Stagehand...");
+await stagehand.init();
+const page = stagehand.context.pages()[0];
+try {
+  console.log("🌐 Navigating to 2048...");
+  await page.goto("https://ovolve.github.io/2048-AI/");
+  // Main game loop
+  while (true) {
+    console.log("🔄 Game loop iteration...");
+    // Add a small delay for UI updates
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    // Get current game state
+    const gameState = await stagehand.extract(
+      `Extract the current game state:
+        1. Score from the score counter
+        2. All tile values in the 4x4 grid (empty spaces as 0)
+        3. Highest tile value present`,
+      z.object({
+        score: z.number(),
+        highestTile: z.number(),
+        grid: z.array(z.array(z.number())),
+      }),
+    );
+    const transposedGrid = gameState.grid[0].map((_, colIndex) =>
+      gameState.grid.map((row) => row[colIndex]),
+    );
+    const grid = transposedGrid.map((row, rowIndex) => ({
+      [`row${rowIndex + 1}`]: row,
+    }));
+    console.log("Game State:", {
+      score: gameState.score,
+      highestTile: gameState.highestTile,
+      grid: grid,
     });
-    if (isGameOver) {
-      console.log("🏁 Game Over!");
-      return;
-    }
+    // Analyze board and decide next move
+    const analysis = await stagehand.extract(
+      `Based on the current game state:
+        - Score: ${gameState.score}
+        - Highest tile: ${gameState.highestTile}
+        - Grid: This is a 4x4 matrix ordered by row (top to bottom) and column (left to right). The rows are stacked vertically, and tiles can move vertically between rows or horizontally between columns:\n${grid
+          .map((row) => {
+            const rowName = Object.keys(row)[0];
+            return `             ${rowName}: ${row[rowName].join(", ")}`;
+          })
+          .join("\n")}
+        What is the best move (up/down/left/right)? Consider:
+        1. Keeping high value tiles in corners (bottom left, bottom right, top left, top right)
+        2. Maintaining a clear path to merge tiles
+        3. Avoiding moves that could block merges
+        4. Only adjacent tiles of the same value can merge
+        5. Making a move will move all tiles in that direction until they hit a tile of a different value or the edge of the board
+        6. Tiles cannot move past the edge of the board
+        7. Each move must move at least one tile`,
+      z.object({
+        move: z.enum(["up", "down", "left", "right"]),
+        confidence: z.number(),
+        reasoning: z.string(),
+      }),
+    );
+    console.log("Move Analysis:", analysis);
+    const moveKey = {
+      up: "ArrowUp",
+      down: "ArrowDown",
+      left: "ArrowLeft",
+      right: "ArrowRight",
+    }[analysis.move];
+    await page.keyPress(moveKey);
+    console.log("🎯 Executed move:", analysis.move);
+  }
+} catch (error) {
+  console.error("❌ Error in game loop:", error);
+  const isGameOver = await page.evaluate(() => {
+    return document.querySelector(".game-over") !== null;
+  });
+  if (isGameOver) {
+    console.log("🏁 Game Over!");
+  } else {
     throw error; // Re-throw non-game-over errors
   }
 }
-(async () => {
-  await example();
-})();

--- a/packages/core/examples/actionable_observe_example.ts
+++ b/packages/core/examples/actionable_observe_example.ts
@@ -14,67 +14,61 @@
 
 import { Action, Stagehand } from "../lib/v3/index.js";
 
-async function example() {
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    verbose: 1,
-  });
-  await stagehand.init();
-  const page = stagehand.context.pages()[0];
+const stagehand = new Stagehand({
+  env: "BROWSERBASE",
+  verbose: 1,
+});
+await stagehand.init();
+const page = stagehand.context.pages()[0];
 
-  await page.goto("https://www.apartments.com/san-francisco-ca/");
+await page.goto("https://www.apartments.com/san-francisco-ca/");
 
-  let observation: Action;
+let observation: Action;
 
-  await new Promise((resolve) => setTimeout(resolve, 3000));
-  [observation] = await stagehand.observe("find the 'all filters' button");
-  await stagehand.act(observation);
+await new Promise((resolve) => setTimeout(resolve, 3000));
+[observation] = await stagehand.observe("find the 'all filters' button");
+await stagehand.act(observation);
 
-  await new Promise((resolve) => setTimeout(resolve, 3000));
-  [observation] = await stagehand.observe(
-    "find the '1+' button in the 'beds' section",
+await new Promise((resolve) => setTimeout(resolve, 3000));
+[observation] = await stagehand.observe(
+  "find the '1+' button in the 'beds' section",
+);
+await stagehand.act(observation);
+
+await new Promise((resolve) => setTimeout(resolve, 3000));
+[observation] = await stagehand.observe(
+  "find the 'apartments' button in the 'home type' section",
+);
+await stagehand.act(observation);
+
+await new Promise((resolve) => setTimeout(resolve, 3000));
+[observation] = await stagehand.observe(
+  "find the pet policy dropdown to click on.",
+);
+await stagehand.act(observation);
+
+await new Promise((resolve) => setTimeout(resolve, 3000));
+[observation] = await stagehand.observe(
+  "find the 'Dog Friendly' option to click on",
+);
+await stagehand.act(observation);
+
+await new Promise((resolve) => setTimeout(resolve, 3000));
+[observation] = await stagehand.observe("find the 'see results' section");
+await stagehand.act(observation);
+
+const currentUrl = page.url();
+await stagehand.close();
+if (
+  currentUrl.includes(
+    "https://www.apartments.com/apartments/san-francisco-ca/min-1-bedrooms-pet-friendly-dog/",
+  )
+) {
+  console.log("✅ Success! we made it to the correct page");
+} else {
+  console.log(
+    "❌ Whoops, looks like we didn't make it to the correct page. " +
+      "\nThanks for testing out this new Stagehand feature!" +
+      "\nReach us on Discord if you have any feedback/questions/suggestions!",
   );
-  await stagehand.act(observation);
-
-  await new Promise((resolve) => setTimeout(resolve, 3000));
-  [observation] = await stagehand.observe(
-    "find the 'apartments' button in the 'home type' section",
-  );
-  await stagehand.act(observation);
-
-  await new Promise((resolve) => setTimeout(resolve, 3000));
-  [observation] = await stagehand.observe(
-    "find the pet policy dropdown to click on.",
-  );
-  await stagehand.act(observation);
-
-  await new Promise((resolve) => setTimeout(resolve, 3000));
-  [observation] = await stagehand.observe(
-    "find the 'Dog Friendly' option to click on",
-  );
-  await stagehand.act(observation);
-
-  await new Promise((resolve) => setTimeout(resolve, 3000));
-  [observation] = await stagehand.observe("find the 'see results' section");
-  await stagehand.act(observation);
-
-  const currentUrl = page.url();
-  await stagehand.close();
-  if (
-    currentUrl.includes(
-      "https://www.apartments.com/apartments/san-francisco-ca/min-1-bedrooms-pet-friendly-dog/",
-    )
-  ) {
-    console.log("✅ Success! we made it to the correct page");
-  } else {
-    console.log(
-      "❌ Whoops, looks like we didn't make it to the correct page. " +
-        "\nThanks for testing out this new Stagehand feature!" +
-        "\nReach us on Discord if you have any feedback/questions/suggestions!",
-    );
-  }
 }
-
-(async () => {
-  await example();
-})();

--- a/packages/core/examples/agent-custom-tools.ts
+++ b/packages/core/examples/agent-custom-tools.ts
@@ -32,76 +32,67 @@ const getWeather = tool({
   },
 });
 
-async function main() {
-  console.log(
-    `\n${chalk.bold("Stagehand 🤘 Computer Use Agent (CUA) Demo")}\n`,
-  );
+console.log(`\n${chalk.bold("Stagehand 🤘 Computer Use Agent (CUA) Demo")}\n`);
 
-  // Initialize Stagehand
-  const stagehand = new Stagehand({
-    env: "LOCAL",
-    verbose: 2,
-    experimental: true, // You must enable experimental mode to use custom tools / MCP integrations
-    model: "anthropic/claude-sonnet-4-5",
-  });
-  await stagehand.init();
-
-  try {
-    const page = stagehand.context.pages()[0];
-
-    // Create a computer use agent
-    const agent = stagehand.agent({
-      mode: "cua",
-      model: {
-        modelName: "anthropic/claude-sonnet-4-5-20250929",
-        apiKey: process.env.ANTHROPIC_API_KEY,
-      },
-      systemPrompt: `You are a helpful assistant that can use a web browser.
-      You are currently on the following page: ${page.url()}.
-      Do not ask follow up questions, the user will trust your judgement. Today's date is ${new Date().toLocaleDateString()}.`,
-      tools: {
-        getWeather, // Pass the tools to the agent
-      },
-    });
-
-    // const agent = stagehand.agent({
-    //   systemPrompt: `You are a helpful assistant that can use a web browser.
-    //   You are currently on the following page: ${page.url()}.
-    //   Do not ask follow up questions, the user will trust your judgement. Today's date is ${new Date().toLocaleDateString()}.`,
-    //   // Pass the tools to the agent
-    //   tools: {
-    //     getWeather: getWeather,
-    //   },
-    // });
-
-    // Navigate to the Browserbase careers page
-    await page.goto("https://www.google.com");
-
-    // Define the instruction for the CUA
-    const instruction = "What's the weather in San Francisco?";
-    console.log(`Instruction: ${chalk.white(instruction)}`);
-
-    // Execute the instruction
-    const result = await agent.execute({
-      instruction,
-      maxSteps: 20,
-    });
-
-    console.log(`${chalk.green("✓")} Execution complete`);
-    console.log(`${chalk.yellow("⤷")} Result:`);
-    console.log(chalk.white(JSON.stringify(result, null, 2)));
-  } catch (error) {
-    console.log(`${chalk.red("✗")} Error: ${error}`);
-    if (error instanceof Error && error.stack) {
-      console.log(chalk.dim(error.stack.split("\n").slice(1).join("\n")));
-    }
-  } finally {
-    // Close the browser
-    await stagehand.close();
-  }
-}
-
-main().catch((error) => {
-  console.log(`${chalk.red("✗")} Unhandled error in main function`);
-  console.log(chalk.red(error));
+// Initialize Stagehand
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  verbose: 2,
+  experimental: true, // You must enable experimental mode to use custom tools / MCP integrations
+  model: "anthropic/claude-sonnet-4-5",
 });
+await stagehand.init();
+
+try {
+  const page = stagehand.context.pages()[0];
+
+  // Create a computer use agent
+  const agent = stagehand.agent({
+    mode: "cua",
+    model: {
+      modelName: "anthropic/claude-sonnet-4-5-20250929",
+      apiKey: process.env.ANTHROPIC_API_KEY,
+    },
+    systemPrompt: `You are a helpful assistant that can use a web browser.
+    You are currently on the following page: ${page.url()}.
+    Do not ask follow up questions, the user will trust your judgement. Today's date is ${new Date().toLocaleDateString()}.`,
+    tools: {
+      getWeather, // Pass the tools to the agent
+    },
+  });
+
+  // const agent = stagehand.agent({
+  //   systemPrompt: `You are a helpful assistant that can use a web browser.
+  //   You are currently on the following page: ${page.url()}.
+  //   Do not ask follow up questions, the user will trust your judgement. Today's date is ${new Date().toLocaleDateString()}.`,
+  //   // Pass the tools to the agent
+  //   tools: {
+  //     getWeather: getWeather,
+  //   },
+  // });
+
+  // Navigate to the Browserbase careers page
+  await page.goto("https://www.google.com");
+
+  // Define the instruction for the CUA
+  const instruction = "What's the weather in San Francisco?";
+  console.log(`Instruction: ${chalk.white(instruction)}`);
+
+  // Execute the instruction
+  const result = await agent.execute({
+    instruction,
+    maxSteps: 20,
+  });
+
+  console.log(`${chalk.green("✓")} Execution complete`);
+  console.log(`${chalk.yellow("⤷")} Result:`);
+  console.log(chalk.white(JSON.stringify(result, null, 2)));
+} catch (error) {
+  console.log(`${chalk.red("✗")} Error: ${error}`);
+  if (error instanceof Error && error.stack) {
+    console.log(chalk.dim(error.stack.split("\n").slice(1).join("\n")));
+  }
+} finally {
+  // Close the browser
+  await stagehand.close();
+}

--- a/packages/core/examples/agent_stream_example.ts
+++ b/packages/core/examples/agent_stream_example.ts
@@ -1,47 +1,44 @@
 import { Stagehand } from "../lib/v3/index.js";
 import chalk from "chalk";
 
-// Load environment variables
-async function main() {
-  console.log(`\n${chalk.bold("Stagehand 🤘 Agent Streaming Example")}\n`);
-  // Initialize Stagehand
-  const stagehand = new Stagehand({
-    env: "LOCAL",
-    verbose: 0,
-    cacheDir: "stagehand-agent-cache",
-    logInferenceToFile: false,
-    experimental: true,
+console.log(`\n${chalk.bold("Stagehand 🤘 Agent Streaming Example")}\n`);
+
+// Initialize Stagehand
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  verbose: 0,
+  cacheDir: "stagehand-agent-cache",
+  logInferenceToFile: false,
+  experimental: true,
+});
+
+await stagehand.init();
+
+try {
+  const page = stagehand.context.pages()[0];
+  await page.goto("https://amazon.com");
+
+  // Create a streaming agent with stream: true in the config
+  const agent = stagehand.agent({
+    model: "anthropic/claude-sonnet-4-5-20250929",
+    stream: true, // This makes execute() return AgentStreamResult
   });
 
-  await stagehand.init();
-
-  try {
-    const page = stagehand.context.pages()[0];
-    await page.goto("https://amazon.com");
-
-    // Create a streaming agent with stream: true in the config
-    const agent = stagehand.agent({
-      model: "anthropic/claude-sonnet-4-5-20250929",
-      stream: true, // This makes execute() return AgentStreamResult
-    });
-
-    const agentRun = await agent.execute({
-      instruction: "go to amazon, and search for shampoo, stop after searching",
-      maxSteps: 20,
-    });
-    // stream the text
-    for await (const delta of agentRun.textStream) {
-      process.stdout.write(delta);
-    }
-    // stream everything ( toolcalls, messages, etc.)
-    // for await (const delta of result.fullStream) {
-    //   console.log(delta);
-    // }
-
-    const finalResult = await agentRun.result;
-    console.log("Final Result:", finalResult);
-  } catch (error) {
-    console.log(`${chalk.red("✗")} Error: ${error}`);
+  const agentRun = await agent.execute({
+    instruction: "go to amazon, and search for shampoo, stop after searching",
+    maxSteps: 20,
+  });
+  // stream the text
+  for await (const delta of agentRun.textStream) {
+    process.stdout.write(delta);
   }
+  // stream everything ( toolcalls, messages, etc.)
+  // for await (const delta of result.fullStream) {
+  //   console.log(delta);
+  // }
+
+  const finalResult = await agentRun.result;
+  console.log("Final Result:", finalResult);
+} catch (error) {
+  console.log(`${chalk.red("✗")} Error: ${error}`);
 }
-main();

--- a/packages/core/examples/cua-example.ts
+++ b/packages/core/examples/cua-example.ts
@@ -9,63 +9,54 @@
 import { Stagehand } from "../lib/v3/index.js";
 import chalk from "chalk";
 
-async function main() {
-  console.log(
-    `\n${chalk.bold("Stagehand 🤘 Computer Use Agent (CUA) Demo")}\n`,
-  );
+console.log(`\n${chalk.bold("Stagehand 🤘 Computer Use Agent (CUA) Demo")}\n`);
 
-  // Initialize Stagehand
-  const stagehand = new Stagehand({
-    env: "LOCAL",
-    verbose: 2,
-  });
-  await stagehand.init();
-
-  try {
-    const page = stagehand.context.pages()[0];
-
-    // Create a computer use agent
-    const agent = stagehand.agent({
-      mode: "cua",
-      model: {
-        modelName: "google/gemini-3-flash-preview",
-        apiKey: process.env.GEMINI_API_KEY ?? process.env.GOOGLE_API_KEY,
-      },
-      systemPrompt: `You are a helpful assistant that can use a web browser.
-      You are currently on the following page: ${page.url()}.
-      Do not ask follow up questions, the user will trust your judgement. Today's date is ${new Date().toLocaleDateString()}.`,
-    });
-
-    // Navigate to the Browserbase careers page
-    await page.goto("https://www.browserbase.com/careers");
-
-    // Define the instruction for the CUA
-    const instruction =
-      "Apply for the first engineer position with mock data. Don't submit the form. You're on the right page";
-    console.log(`Instruction: ${chalk.white(instruction)}`);
-
-    // Execute the instruction
-    const result = await agent.execute({
-      instruction,
-      maxSteps: 20,
-    });
-    await new Promise((resolve) => setTimeout(resolve, 30000));
-
-    console.log(`${chalk.green("✓")} Execution complete`);
-    console.log(`${chalk.yellow("⤷")} Result:`);
-    console.log(chalk.white(JSON.stringify(result, null, 2)));
-  } catch (error) {
-    console.log(`${chalk.red("✗")} Error: ${error}`);
-    if (error instanceof Error && error.stack) {
-      console.log(chalk.dim(error.stack.split("\n").slice(1).join("\n")));
-    }
-  } finally {
-    // Close the browser
-    await stagehand.close();
-  }
-}
-
-main().catch((error) => {
-  console.log(`${chalk.red("✗")} Unhandled error in main function`);
-  console.log(chalk.red(error));
+// Initialize Stagehand
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  verbose: 2,
 });
+await stagehand.init();
+
+try {
+  const page = stagehand.context.pages()[0];
+
+  // Create a computer use agent
+  const agent = stagehand.agent({
+    mode: "cua",
+    model: {
+      modelName: "google/gemini-3-flash-preview",
+      apiKey: process.env.GEMINI_API_KEY ?? process.env.GOOGLE_API_KEY,
+    },
+    systemPrompt: `You are a helpful assistant that can use a web browser.
+    You are currently on the following page: ${page.url()}.
+    Do not ask follow up questions, the user will trust your judgement. Today's date is ${new Date().toLocaleDateString()}.`,
+  });
+
+  // Navigate to the Browserbase careers page
+  await page.goto("https://www.browserbase.com/careers");
+
+  // Define the instruction for the CUA
+  const instruction =
+    "Apply for the first engineer position with mock data. Don't submit the form. You're on the right page";
+  console.log(`Instruction: ${chalk.white(instruction)}`);
+
+  // Execute the instruction
+  const result = await agent.execute({
+    instruction,
+    maxSteps: 20,
+  });
+  await new Promise((resolve) => setTimeout(resolve, 30000));
+
+  console.log(`${chalk.green("✓")} Execution complete`);
+  console.log(`${chalk.yellow("⤷")} Result:`);
+  console.log(chalk.white(JSON.stringify(result, null, 2)));
+} catch (error) {
+  console.log(`${chalk.red("✗")} Error: ${error}`);
+  if (error instanceof Error && error.stack) {
+    console.log(chalk.dim(error.stack.split("\n").slice(1).join("\n")));
+  }
+} finally {
+  // Close the browser
+  await stagehand.close();
+}

--- a/packages/core/examples/custom_client_aisdk.ts
+++ b/packages/core/examples/custom_client_aisdk.ts
@@ -10,33 +10,27 @@ import { AISdkClient } from "./external_clients/aisdk.js";
 import { z } from "zod";
 import { openai } from "@ai-sdk/openai";
 
-async function example() {
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    verbose: 1,
-    llmClient: new AISdkClient({
-      model: openai("gpt-4o"),
-    }),
-  });
+const stagehand = new Stagehand({
+  env: "BROWSERBASE",
+  verbose: 1,
+  llmClient: new AISdkClient({
+    model: openai("gpt-4o"),
+  }),
+});
 
-  await stagehand.init();
-  const page = stagehand.context.pages()[0];
+await stagehand.init();
+const page = stagehand.context.pages()[0];
 
-  await page.goto("https://news.ycombinator.com");
+await page.goto("https://news.ycombinator.com");
 
-  const { story } = await stagehand.extract(
-    "extract the title of the top story on the page",
-    z.object({
-      story: z.string().describe("the top story on the page"),
-    }),
-  );
+const { story } = await stagehand.extract(
+  "extract the title of the top story on the page",
+  z.object({
+    story: z.string().describe("the top story on the page"),
+  }),
+);
 
-  console.log("The top story is:", story);
-  await stagehand.act("click the first story");
+console.log("The top story is:", story);
+await stagehand.act("click the first story");
 
-  await stagehand.close();
-}
-
-(async () => {
-  await example();
-})();
+await stagehand.close();

--- a/packages/core/examples/custom_client_langchain.ts
+++ b/packages/core/examples/custom_client_langchain.ts
@@ -8,29 +8,24 @@ import { Stagehand } from "../lib/v3/index.js";
 import { LangchainClient } from "./external_clients/langchain.js";
 import { ChatOpenAI } from "@langchain/openai";
 
-async function example() {
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    verbose: 1,
-    llmClient: new LangchainClient(
-      new ChatOpenAI({
-        model: "gpt-4o",
-      }),
-    ),
-  });
-  await stagehand.init();
-  const page = stagehand.context.pages()[0];
-  await page.goto("https://news.ycombinator.com");
-  const { story } = await stagehand.extract(
-    "extract the title of the top story on the page",
-    z.object({
-      story: z.string().describe("the top story on the page"),
+const stagehand = new Stagehand({
+  env: "BROWSERBASE",
+  verbose: 1,
+  llmClient: new LangchainClient(
+    new ChatOpenAI({
+      model: "gpt-4o",
     }),
-  );
-  console.log("The top story is:", story);
-  await stagehand.act("click the first story");
-  await stagehand.close();
-}
-(async () => {
-  await example();
-})();
+  ),
+});
+await stagehand.init();
+const page = stagehand.context.pages()[0];
+await page.goto("https://news.ycombinator.com");
+const { story } = await stagehand.extract(
+  "extract the title of the top story on the page",
+  z.object({
+    story: z.string().describe("the top story on the page"),
+  }),
+);
+console.log("The top story is:", story);
+await stagehand.act("click the first story");
+await stagehand.close();

--- a/packages/core/examples/custom_client_openai.ts
+++ b/packages/core/examples/custom_client_openai.ts
@@ -10,41 +10,35 @@ import { z } from "zod";
 import { CustomOpenAIClient } from "./external_clients/customOpenAI.js";
 import OpenAI from "openai";
 
-async function example() {
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    verbose: 1,
-    llmClient: new CustomOpenAIClient({
-      modelName: "gpt-4o-mini",
-      client: new OpenAI({
-        apiKey: process.env.OPENAI_API_KEY,
+const stagehand = new Stagehand({
+  env: "BROWSERBASE",
+  verbose: 1,
+  llmClient: new CustomOpenAIClient({
+    modelName: "gpt-4o-mini",
+    client: new OpenAI({
+      apiKey: process.env.OPENAI_API_KEY,
+    }),
+  }),
+});
+await stagehand.init();
+
+const page = stagehand.context.pages()[0];
+await page.goto("https://news.ycombinator.com");
+await stagehand.act("click on the 'new' link");
+
+const headlines = await stagehand.extract(
+  "Extract the top 3 stories from the Hacker News homepage.",
+  z.object({
+    stories: z.array(
+      z.object({
+        title: z.string(),
+        url: z.string(),
+        points: z.number(),
       }),
-    }),
-  });
-  await stagehand.init();
+    ),
+  }),
+);
 
-  const page = stagehand.context.pages()[0];
-  await page.goto("https://news.ycombinator.com");
-  await stagehand.act("click on the 'new' link");
+console.log(headlines);
 
-  const headlines = await stagehand.extract(
-    "Extract the top 3 stories from the Hacker News homepage.",
-    z.object({
-      stories: z.array(
-        z.object({
-          title: z.string(),
-          url: z.string(),
-          points: z.number(),
-        }),
-      ),
-    }),
-  );
-
-  console.log(headlines);
-
-  await stagehand.close();
-}
-
-(async () => {
-  await example();
-})();
+await stagehand.close();

--- a/packages/core/examples/example.ts
+++ b/packages/core/examples/example.ts
@@ -1,6 +1,19 @@
 import { Stagehand } from "../lib/v3/index.js";
 
-async function example(stagehand: Stagehand) {
+const stagehand = new Stagehand({
+  env: "BROWSERBASE",
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  projectId: process.env.BROWSERBASE_PROJECT_ID,
+  model: {
+    modelName: "openai/gpt-5",
+    apiKey: process.env.MODEL_API_KEY,
+  },
+  verbose: 2,
+});
+
+try {
+  await stagehand.init();
+
   /**
    * Add your code here!
    */
@@ -32,23 +45,6 @@ async function example(stagehand: Stagehand) {
   for (const action of action2) {
     await stagehand.act(action, { page: page2, timeout: 30_000 });
   }
+} finally {
+  await stagehand.close();
 }
-
-(async () => {
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    apiKey: process.env.BROWSERBASE_API_KEY,
-    projectId: process.env.BROWSERBASE_PROJECT_ID,
-    model: {
-      modelName: "openai/gpt-5",
-      apiKey: process.env.MODEL_API_KEY,
-    },
-    verbose: 2,
-  });
-  try {
-    await stagehand.init();
-    await example(stagehand);
-  } finally {
-    await stagehand.close();
-  }
-})();

--- a/packages/core/examples/form_filling_sensible.ts
+++ b/packages/core/examples/form_filling_sensible.ts
@@ -83,6 +83,4 @@ async function formFillingSensible() {
   }
 }
 
-(async () => {
-  await formFillingSensible();
-})();
+await formFillingSensible();

--- a/packages/core/examples/google_enter.ts
+++ b/packages/core/examples/google_enter.ts
@@ -6,19 +6,13 @@
 
 import { Stagehand } from "../lib/v3/index.js";
 
-async function example() {
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    verbose: 1,
-  });
-  await stagehand.init();
-  const page = stagehand.context.pages()[0];
-  await page.goto("https://google.com");
-  await stagehand.act("type in 'Browserbase'");
-  await stagehand.act("press enter");
-  await stagehand.close();
-}
-
-(async () => {
-  await example();
-})();
+const stagehand = new Stagehand({
+  env: "BROWSERBASE",
+  verbose: 1,
+});
+await stagehand.init();
+const page = stagehand.context.pages()[0];
+await page.goto("https://google.com");
+await stagehand.act("type in 'Browserbase'");
+await stagehand.act("press enter");
+await stagehand.close();

--- a/packages/core/examples/instructions.ts
+++ b/packages/core/examples/instructions.ts
@@ -3,25 +3,19 @@
  */
 import { Stagehand } from "../lib/v3/index.js";
 
-async function example() {
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    verbose: 1,
-    systemPrompt:
-      "if the users says `secret12345`, click on the 'getting started' tab. additionally, if the user says to type something, translate their input into french and type it.",
-  });
-  await stagehand.init();
+const stagehand = new Stagehand({
+  env: "BROWSERBASE",
+  verbose: 1,
+  systemPrompt:
+    "if the users says `secret12345`, click on the 'getting started' tab. additionally, if the user says to type something, translate their input into french and type it.",
+});
+await stagehand.init();
 
-  const page = stagehand.context.pages()[0];
-  await page.goto("https://docs.browserbase.com/");
+const page = stagehand.context.pages()[0];
+await page.goto("https://docs.browserbase.com/");
 
-  await stagehand.act("secret12345");
+await stagehand.act("secret12345");
 
-  await stagehand.act("search for 'how to use browserbase'");
+await stagehand.act("search for 'how to use browserbase'");
 
-  await stagehand.close();
-}
-
-(async () => {
-  await example();
-})();
+await stagehand.close();

--- a/packages/core/examples/integrations/exa.ts
+++ b/packages/core/examples/integrations/exa.ts
@@ -1,6 +1,16 @@
 import { Stagehand } from "../../lib/v3/index.js";
 
-async function example(stagehand: Stagehand) {
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  model: "openai/gpt-4.1",
+  verbose: 1,
+  logInferenceToFile: true,
+  experimental: true,
+});
+
+try {
+  await stagehand.init();
+
   const page = stagehand.context.pages()[0];
   await page.goto("https://www.google.com");
 
@@ -20,23 +30,8 @@ async function example(stagehand: Stagehand) {
   );
 
   console.log(result);
+} catch (error) {
+  console.error("Error running example:", error);
+} finally {
+  await stagehand.close();
 }
-
-(async () => {
-  const stagehand = new Stagehand({
-    env: "LOCAL",
-    model: "openai/gpt-4.1",
-    verbose: 1,
-    logInferenceToFile: true,
-    experimental: true,
-  });
-
-  try {
-    await stagehand.init();
-    await example(stagehand);
-  } catch (error) {
-    console.error("Error running example:", error);
-  } finally {
-    await stagehand.close();
-  }
-})();

--- a/packages/core/examples/integrations/supabase.ts
+++ b/packages/core/examples/integrations/supabase.ts
@@ -1,6 +1,13 @@
 import { connectToMCPServer, Stagehand } from "../../lib/v3/index.js";
 
-async function example(stagehand: Stagehand) {
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  verbose: 1,
+});
+
+try {
+  await stagehand.init();
+
   const page = stagehand.context.pages()[0];
   await page.goto("https://www.opentable.com/");
 
@@ -18,20 +25,8 @@ async function example(stagehand: Stagehand) {
   );
 
   console.log(result);
+} catch (error) {
+  console.error("Error running example:", error);
+} finally {
+  await stagehand.close();
 }
-
-(async () => {
-  const stagehand = new Stagehand({
-    env: "LOCAL",
-    verbose: 1,
-  });
-
-  try {
-    await stagehand.init();
-    await example(stagehand);
-  } catch (error) {
-    console.error("Error running example:", error);
-  } finally {
-    await stagehand.close();
-  }
-})();

--- a/packages/core/examples/operator-example.ts
+++ b/packages/core/examples/operator-example.ts
@@ -8,40 +8,36 @@
 import { Stagehand } from "../lib/v3/index.js";
 import chalk from "chalk";
 
-// Load environment variables
+console.log(`\n${chalk.bold("Stagehand 🤘 Operator Example")}\n`);
 
-async function main() {
-  console.log(`\n${chalk.bold("Stagehand 🤘 Operator Example")}\n`);
-  // Initialize Stagehand
-  const stagehand = new Stagehand({
-    env: "LOCAL",
-    verbose: 2,
-    cacheDir: "stagehand-agent-cache",
-    logInferenceToFile: false,
+// Initialize Stagehand
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  verbose: 2,
+  cacheDir: "stagehand-agent-cache",
+  logInferenceToFile: false,
+});
+
+await stagehand.init();
+
+try {
+  const page = stagehand.context.pages()[0];
+  await page.goto(
+    "https://browserbase.github.io/stagehand-eval-sites/sites/shadow-dom/",
+  );
+  const agent = stagehand.agent();
+
+  const result = await agent.execute({
+    instruction: "click the button",
+    maxSteps: 20,
   });
 
-  await stagehand.init();
-
-  try {
-    const page = stagehand.context.pages()[0];
-    await page.goto(
-      "https://browserbase.github.io/stagehand-eval-sites/sites/shadow-dom/",
-    );
-    const agent = stagehand.agent();
-
-    const result = await agent.execute({
-      instruction: "click the button",
-      maxSteps: 20,
-    });
-
-    console.log(`${chalk.green("✓")} Execution complete`);
-    console.log(`${chalk.yellow("⤷")} Result:`);
-    console.log(JSON.stringify(result, null, 2));
-    console.log(chalk.white(result.message));
-  } catch (error) {
-    console.log(`${chalk.red("✗")} Error: ${error}`);
-  } finally {
-    // await stagehand.close();
-  }
+  console.log(`${chalk.green("✓")} Execution complete`);
+  console.log(`${chalk.yellow("⤷")} Result:`);
+  console.log(JSON.stringify(result, null, 2));
+  console.log(chalk.white(result.message));
+} catch (error) {
+  console.log(`${chalk.red("✗")} Error: ${error}`);
+} finally {
+  // await stagehand.close();
 }
-main();

--- a/packages/core/examples/oss-cua-example.ts
+++ b/packages/core/examples/oss-cua-example.ts
@@ -9,75 +9,66 @@
 import { Stagehand } from "../lib/v3/index.js";
 import chalk from "chalk";
 
-async function main() {
-  console.log(
-    `\n${chalk.bold("Stagehand 🤘 Computer Use Agent (CUA) Demo")}\n`,
-  );
+console.log(`\n${chalk.bold("Stagehand 🤘 Computer Use Agent (CUA) Demo")}\n`);
 
-  // Initialize Stagehand
-  const stagehand = new Stagehand({
-    env: "LOCAL",
-    verbose: 2,
-    localBrowserLaunchOptions: {
-      viewport: {
-        width: 1288,
-        height: 711,
-      },
-      deviceScaleFactor: 1,
+// Initialize Stagehand
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  verbose: 2,
+  localBrowserLaunchOptions: {
+    viewport: {
+      width: 1288,
+      height: 711,
     },
-  });
-  await stagehand.init();
-
-  try {
-    const page = stagehand.context.pages()[0];
-
-    // Create a computer use agent
-    const agent = stagehand.agent({
-      mode: "cua",
-      model: {
-        modelName: "microsoft/fara-7b",
-        apiKey: process.env.AZURE_API_KEY,
-        baseURL: process.env.AZURE_ENDPOINT,
-        /** Alternative model configuration for Fireworks Deployments */
-        // modelName: "accounts/...",
-        // apiKey: process.env.FIREWORKS_API_KEY,
-        // baseURL: "https://api.fireworks.ai/inference/v1",
-        // provider: "microsoft", // Important: this routes to the MicrosoftCUAClient
-      },
-      systemPrompt: `You are a helpful assistant that can use a web browser.
-      You are currently on the following page: ${page.url()}.
-      Do not ask follow up questions, the user will trust your judgement. Today's date is ${new Date().toLocaleDateString()}. Remember apply buttons are there for a reason.`,
-    });
-
-    // Navigate to the Browserbase careers page
-    await page.goto("https://www.browserbase.com/careers");
-
-    // Define the instruction for the CUA
-    const instruction = `Apply for the first engineer position with mock data on the ${page.url()} page. Don't submit the form.`;
-    console.log(`Instruction: ${chalk.white(instruction)}`);
-
-    // Execute the instruction
-    const result = await agent.execute({
-      instruction,
-      maxSteps: 20,
-    });
-    await new Promise((resolve) => setTimeout(resolve, 30000));
-
-    console.log(`${chalk.green("✓")} Execution complete`);
-    console.log(`${chalk.yellow("⤷")} Result:`);
-    console.log(chalk.white(JSON.stringify(result, null, 2)));
-  } catch (error) {
-    console.log(`${chalk.red("✗")} Error: ${error}`);
-    if (error instanceof Error && error.stack) {
-      console.log(chalk.dim(error.stack.split("\n").slice(1).join("\n")));
-    }
-  } finally {
-    // Close the browser
-    await stagehand.close();
-  }
-}
-
-main().catch((error) => {
-  console.log(`${chalk.red("✗")} Unhandled error in main function`);
-  console.log(chalk.red(error));
+    deviceScaleFactor: 1,
+  },
 });
+await stagehand.init();
+
+try {
+  const page = stagehand.context.pages()[0];
+
+  // Create a computer use agent
+  const agent = stagehand.agent({
+    mode: "cua",
+    model: {
+      modelName: "microsoft/fara-7b",
+      apiKey: process.env.AZURE_API_KEY,
+      baseURL: process.env.AZURE_ENDPOINT,
+      /** Alternative model configuration for Fireworks Deployments */
+      // modelName: "accounts/...",
+      // apiKey: process.env.FIREWORKS_API_KEY,
+      // baseURL: "https://api.fireworks.ai/inference/v1",
+      // provider: "microsoft", // Important: this routes to the MicrosoftCUAClient
+    },
+    systemPrompt: `You are a helpful assistant that can use a web browser.
+    You are currently on the following page: ${page.url()}.
+    Do not ask follow up questions, the user will trust your judgement. Today's date is ${new Date().toLocaleDateString()}. Remember apply buttons are there for a reason.`,
+  });
+
+  // Navigate to the Browserbase careers page
+  await page.goto("https://www.browserbase.com/careers");
+
+  // Define the instruction for the CUA
+  const instruction = `Apply for the first engineer position with mock data on the ${page.url()} page. Don't submit the form.`;
+  console.log(`Instruction: ${chalk.white(instruction)}`);
+
+  // Execute the instruction
+  const result = await agent.execute({
+    instruction,
+    maxSteps: 20,
+  });
+  await new Promise((resolve) => setTimeout(resolve, 30000));
+
+  console.log(`${chalk.green("✓")} Execution complete`);
+  console.log(`${chalk.yellow("⤷")} Result:`);
+  console.log(chalk.white(JSON.stringify(result, null, 2)));
+} catch (error) {
+  console.log(`${chalk.red("✗")} Error: ${error}`);
+  if (error instanceof Error && error.stack) {
+    console.log(chalk.dim(error.stack.split("\n").slice(1).join("\n")));
+  }
+} finally {
+  // Close the browser
+  await stagehand.close();
+}

--- a/packages/core/examples/parameterizeApiKey.ts
+++ b/packages/core/examples/parameterizeApiKey.ts
@@ -11,30 +11,24 @@ import { z } from "zod";
  * unset OPENAI_API_KEY
  */
 
-async function example() {
-  const stagehand = new Stagehand({
-    env: "LOCAL",
-    verbose: 1,
-    model: {
-      modelName: "gpt-4o",
-      apiKey: process.env.USE_OPENAI_API_KEY,
-    },
-  });
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  verbose: 1,
+  model: {
+    modelName: "gpt-4o",
+    apiKey: process.env.USE_OPENAI_API_KEY,
+  },
+});
 
-  await stagehand.init();
-  const page = stagehand.context.pages()[0];
-  await page.goto("https://github.com/browserbase/stagehand");
-  await stagehand.act("click on the contributors");
-  const contributor = await stagehand.extract(
-    "extract the top contributor",
-    z.object({
-      username: z.string(),
-      url: z.string(),
-    }),
-  );
-  console.log(`Our favorite contributor is ${contributor.username}`);
-}
-
-(async () => {
-  await example();
-})();
+await stagehand.init();
+const page = stagehand.context.pages()[0];
+await page.goto("https://github.com/browserbase/stagehand");
+await stagehand.act("click on the contributors");
+const contributor = await stagehand.extract(
+  "extract the top contributor",
+  z.object({
+    username: z.string(),
+    url: z.string(),
+  }),
+);
+console.log(`Our favorite contributor is ${contributor.username}`);

--- a/packages/core/examples/persist_logs_example.ts
+++ b/packages/core/examples/persist_logs_example.ts
@@ -4,34 +4,27 @@
 import path from "node:path";
 import { Stagehand } from "../lib/v3/index.js";
 
-async function main() {
-  const logsRoot = path.resolve(process.cwd(), "examples", "logs");
-  process.env.BROWSERBASE_CONFIG_DIR = logsRoot;
+const logsRoot = path.resolve(process.cwd(), "examples", "logs");
+process.env.BROWSERBASE_CONFIG_DIR = logsRoot;
 
-  const stagehand = new Stagehand({
-    env: "LOCAL",
-    verbose: 1,
-  });
-
-  await stagehand.init();
-
-  try {
-    const page = stagehand.context.pages()[0];
-    await page.goto("https://www.google.com");
-
-    const agent = stagehand.agent();
-    await agent.execute({
-      instruction:
-        "Search for Browserbase and stop after the results are visible.",
-      maxSteps: 10,
-    });
-  } finally {
-    // All logs can be found at logs/sessions/$SESSION_ID/session.json, or agent_events.log etc
-    await stagehand.close();
-  }
-}
-
-main().catch((error) => {
-  console.error(error);
-  process.exitCode = 1;
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  verbose: 1,
 });
+
+await stagehand.init();
+
+try {
+  const page = stagehand.context.pages()[0];
+  await page.goto("https://www.google.com");
+
+  const agent = stagehand.agent();
+  await agent.execute({
+    instruction:
+      "Search for Browserbase and stop after the results are visible.",
+    maxSteps: 10,
+  });
+} finally {
+  // All logs can be found at logs/sessions/$SESSION_ID/session.json, or agent_events.log etc
+  await stagehand.close();
+}

--- a/packages/core/examples/v3/cuaReplay.ts
+++ b/packages/core/examples/v3/cuaReplay.ts
@@ -50,30 +50,29 @@ async function runDemo(runNumber: number) {
   };
 }
 
-async function main() {
-  const metrics1 = await runDemo(1);
+const metrics1 = await runDemo(1);
 
-  v3Logger({
-    level: 1,
-    category: "demo",
-    message: "⏳ Waiting 2 seconds before cached run...",
-  });
-  await new Promise((resolve) => setTimeout(resolve, 2000));
+v3Logger({
+  level: 1,
+  category: "demo",
+  message: "⏳ Waiting 2 seconds before cached run...",
+});
+await new Promise((resolve) => setTimeout(resolve, 2000));
 
-  v3Logger({
-    level: 1,
-    category: "demo",
-    message: "Starting second run with cache...",
-  });
-  const metrics2 = await runDemo(2);
+v3Logger({
+  level: 1,
+  category: "demo",
+  message: "Starting second run with cache...",
+});
+const metrics2 = await runDemo(2);
 
-  const duration1 = `${metrics1.duration.toFixed(2)}s`;
-  const duration2 = `${metrics2.duration.toFixed(2)}s`;
+const duration1 = `${metrics1.duration.toFixed(2)}s`;
+const duration2 = `${metrics2.duration.toFixed(2)}s`;
 
-  v3Logger({
-    level: 1,
-    category: "demo",
-    message: `
+v3Logger({
+  level: 1,
+  category: "demo",
+  message: `
 ╔════════════════════════════════════════════════════════════╗
 ║                  📊 PERFORMANCE COMPARISON                 ║
 ╚════════════════════════════════════════════════════════════╝
@@ -92,7 +91,4 @@ async function main() {
    • First run establishes the CUA action cache
    • Second run reuses cached actions for instant execution
    • Zero LLM tokens used on cached run`,
-  });
-}
-
-main().catch(console.error);
+});

--- a/packages/core/examples/v3/deepLocator.ts
+++ b/packages/core/examples/v3/deepLocator.ts
@@ -1,30 +1,26 @@
 import { Stagehand } from "../../lib/v3/index.js";
 
-async function example(stagehand: Stagehand) {
-  const page = stagehand.context.pages()[0];
-  await page.goto(
-    "https://browserbase.github.io/stagehand-eval-sites/sites/oopif-in-closed-shadow-dom/",
-  );
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  verbose: 0,
+  model: "openai/gpt-4.1",
+});
 
-  // crossing OOPIF & shadow root boundaries with deep locator
-  await page
-    .deepLocator(
-      "/html/body/shadow-host//section/iframe/html/body/main/section[1]/form/div/div[1]/input",
-    )
-    .fill("nunya");
-  await page
-    .deepLocator(
-      "/html/body/shadow-host//section/iframe/html/body/main/section[1]/form/div/div[2]/input",
-    )
-    .fill("business");
-}
+await stagehand.init();
 
-(async () => {
-  const stagehand = new Stagehand({
-    env: "LOCAL",
-    verbose: 0,
-    model: "openai/gpt-4.1",
-  });
-  await stagehand.init();
-  await example(stagehand);
-})();
+const page = stagehand.context.pages()[0];
+await page.goto(
+  "https://browserbase.github.io/stagehand-eval-sites/sites/oopif-in-closed-shadow-dom/",
+);
+
+// crossing OOPIF & shadow root boundaries with deep locator
+await page
+  .deepLocator(
+    "/html/body/shadow-host//section/iframe/html/body/main/section[1]/form/div/div[1]/input",
+  )
+  .fill("nunya");
+await page
+  .deepLocator(
+    "/html/body/shadow-host//section/iframe/html/body/main/section[1]/form/div/div[2]/input",
+  )
+  .fill("business");

--- a/packages/core/examples/v3/dropdown.ts
+++ b/packages/core/examples/v3/dropdown.ts
@@ -1,32 +1,28 @@
 import { Stagehand } from "../../lib/v3/index.js";
 
-async function example(stagehand: Stagehand) {
-  const page = stagehand.context.pages()[0];
-  await page.goto(
-    "https://browserbase.github.io/stagehand-eval-sites/sites/scroll-dropdown/",
-  );
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  verbose: 0,
+  model: "google/gemini-2.5-flash",
+});
 
-  const actResult = await stagehand.act(
-    "choose 'Peach' from the favorite colour dropdown",
-  );
+await stagehand.init();
 
-  const numSteps = actResult.actions.length;
+const page = stagehand.context.pages()[0];
+await page.goto(
+  "https://browserbase.github.io/stagehand-eval-sites/sites/scroll-dropdown/",
+);
 
-  console.log(
-    `\n\nThis act() call took ${numSteps} steps. Here are the actions:`,
-  );
+const actResult = await stagehand.act(
+  "choose 'Peach' from the favorite colour dropdown",
+);
 
-  for (const action of actResult.actions) {
-    console.log(`\naction: `, action);
-  }
+const numSteps = actResult.actions.length;
+
+console.log(
+  `\n\nThis act() call took ${numSteps} steps. Here are the actions:`,
+);
+
+for (const action of actResult.actions) {
+  console.log(`\naction: `, action);
 }
-
-(async () => {
-  const stagehand = new Stagehand({
-    env: "LOCAL",
-    verbose: 0,
-    model: "google/gemini-2.5-flash",
-  });
-  await stagehand.init();
-  await example(stagehand);
-})();

--- a/packages/core/examples/v3/highlight.ts
+++ b/packages/core/examples/v3/highlight.ts
@@ -1,27 +1,23 @@
 import { Stagehand } from "../../lib/v3/index.js";
 
-async function example(stagehand: Stagehand) {
-  const page = stagehand.context.pages()[0];
-  await page.goto(
-    "https://browserbase.github.io/stagehand-eval-sites/sites/closed-shadow-root-in-oopif/",
-  );
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  verbose: 0,
+  model: "google/gemini-2.5-flash",
+});
 
-  await page
-    .deepLocator(
-      "xpath=/html/body/main/section/iframe/html/body/shadow-demo//div/button",
-    )
-    .highlight({
-      durationMs: 20000,
-      contentColor: { r: 255, g: 0, b: 0 },
-    });
-}
+await stagehand.init();
 
-(async () => {
-  const stagehand = new Stagehand({
-    env: "LOCAL",
-    verbose: 0,
-    model: "google/gemini-2.5-flash",
+const page = stagehand.context.pages()[0];
+await page.goto(
+  "https://browserbase.github.io/stagehand-eval-sites/sites/closed-shadow-root-in-oopif/",
+);
+
+await page
+  .deepLocator(
+    "xpath=/html/body/main/section/iframe/html/body/shadow-demo//div/button",
+  )
+  .highlight({
+    durationMs: 20000,
+    contentColor: { r: 255, g: 0, b: 0 },
   });
-  await stagehand.init();
-  await example(stagehand);
-})();

--- a/packages/core/examples/v3/patchright.ts
+++ b/packages/core/examples/v3/patchright.ts
@@ -2,31 +2,27 @@ import { Stagehand } from "../../lib/v3/index.js";
 import { chromium } from "patchright-core";
 import { z } from "zod";
 
-async function example(stagehand: Stagehand) {
-  const browser = await chromium.connectOverCDP({
-    wsEndpoint: stagehand.connectURL(),
-  });
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  verbose: 0,
+  model: "openai/gpt-4.1",
+});
 
-  const prContext = browser.contexts()[0];
-  const prPage = prContext.pages()[0];
-  await prPage.goto("https://github.com/microsoft/playwright/issues/30261");
+await stagehand.init();
 
-  await stagehand.act("scroll to the bottom of the page", { page: prPage });
+const browser = await chromium.connectOverCDP({
+  wsEndpoint: stagehand.connectURL(),
+});
 
-  const reason = await stagehand.extract(
-    "extract the reason why playwright doesn't expose frame IDs",
-    z.string(),
-    // page arg not required
-  );
-  console.log(reason);
-}
+const prContext = browser.contexts()[0];
+const prPage = prContext.pages()[0];
+await prPage.goto("https://github.com/microsoft/playwright/issues/30261");
 
-(async () => {
-  const stagehand = new Stagehand({
-    env: "LOCAL",
-    verbose: 0,
-    model: "openai/gpt-4.1",
-  });
-  await stagehand.init();
-  await example(stagehand);
-})();
+await stagehand.act("scroll to the bottom of the page", { page: prPage });
+
+const reason = await stagehand.extract(
+  "extract the reason why playwright doesn't expose frame IDs",
+  z.string(),
+  // page arg not required
+);
+console.log(reason);

--- a/packages/core/examples/v3/playwright.ts
+++ b/packages/core/examples/v3/playwright.ts
@@ -2,40 +2,36 @@ import { Stagehand } from "../../lib/v3/index.js";
 import { chromium } from "playwright-core";
 import { z } from "zod";
 
-async function example(stagehand: Stagehand) {
-  const browser = await chromium.connectOverCDP({
-    wsEndpoint: stagehand.connectURL(),
-  });
-  const pwContext = browser.contexts()[0];
-  const pwPage1 = pwContext.pages()[0];
-  await pwPage1.goto("https://docs.stagehand.dev/first-steps/introduction");
+const stagehand = new Stagehand({
+  env: "BROWSERBASE",
+  verbose: 1,
+  model: "openai/gpt-4.1",
+});
 
-  const pwPage2 = await pwContext.newPage();
-  await pwPage2.goto("https://docs.stagehand.dev/configuration/observability");
+await stagehand.init();
 
-  const [page1Extraction, page2Extraction] = await Promise.all([
-    stagehand.extract(
-      "extract the names of the four stagehand primitives",
-      z.array(z.string()),
-      { page: pwPage1 },
-    ),
-    stagehand.extract(
-      "extract the list of session dashboard features",
-      z.array(z.string()),
-      { page: pwPage2 },
-    ),
-  ]);
+const browser = await chromium.connectOverCDP({
+  wsEndpoint: stagehand.connectURL(),
+});
+const pwContext = browser.contexts()[0];
+const pwPage1 = pwContext.pages()[0];
+await pwPage1.goto("https://docs.stagehand.dev/first-steps/introduction");
 
-  console.log(page1Extraction);
-  console.log(page2Extraction);
-}
+const pwPage2 = await pwContext.newPage();
+await pwPage2.goto("https://docs.stagehand.dev/configuration/observability");
 
-(async () => {
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    verbose: 1,
-    model: "openai/gpt-4.1",
-  });
-  await stagehand.init();
-  await example(stagehand);
-})();
+const [page1Extraction, page2Extraction] = await Promise.all([
+  stagehand.extract(
+    "extract the names of the four stagehand primitives",
+    z.array(z.string()),
+    { page: pwPage1 },
+  ),
+  stagehand.extract(
+    "extract the list of session dashboard features",
+    z.array(z.string()),
+    { page: pwPage2 },
+  ),
+]);
+
+console.log(page1Extraction);
+console.log(page2Extraction);

--- a/packages/core/examples/v3/puppeteer.ts
+++ b/packages/core/examples/v3/puppeteer.ts
@@ -1,29 +1,25 @@
 import { Stagehand } from "../../lib/v3/index.js";
 import puppeteer from "puppeteer-core";
 
-async function example(stagehand: Stagehand) {
-  const browser = await puppeteer.connect({
-    browserWSEndpoint: stagehand.connectURL(),
-    defaultViewport: null,
-  });
-  const ppPages = await browser.pages();
-  const ppPage = ppPages[0];
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  verbose: 0,
+  model: "openai/gpt-4.1",
+});
 
-  await ppPage.goto("https://www.browserbase.com/blog");
+await stagehand.init();
 
-  const actions = await stagehand.observe("find the next page button", {
-    page: ppPage,
-  });
+const browser = await puppeteer.connect({
+  browserWSEndpoint: stagehand.connectURL(),
+  defaultViewport: null,
+});
+const ppPages = await browser.pages();
+const ppPage = ppPages[0];
 
-  await stagehand.act(actions[0]);
-}
+await ppPage.goto("https://www.browserbase.com/blog");
 
-(async () => {
-  const stagehand = new Stagehand({
-    env: "LOCAL",
-    verbose: 0,
-    model: "openai/gpt-4.1",
-  });
-  await stagehand.init();
-  await example(stagehand);
-})();
+const actions = await stagehand.observe("find the next page button", {
+  page: ppPage,
+});
+
+await stagehand.act(actions[0]);

--- a/packages/core/examples/v3/recordVideo.ts
+++ b/packages/core/examples/v3/recordVideo.ts
@@ -4,7 +4,15 @@ import { Stagehand } from "../../lib/v3/index.js";
 import { chromium } from "playwright-core";
 import { z } from "zod";
 
-async function recordPlaywrightVideo(stagehand: Stagehand): Promise<void> {
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  verbose: 1,
+  model: "google/gemini-2.5-flash",
+});
+
+try {
+  await stagehand.init();
+
   const browser = await chromium.connectOverCDP({
     wsEndpoint: stagehand.connectURL(),
   });
@@ -47,19 +55,6 @@ async function recordPlaywrightVideo(stagehand: Stagehand): Promise<void> {
   } else {
     console.log("Video recording was not enabled for this context.");
   }
+} finally {
+  await stagehand.close().catch(() => {});
 }
-
-(async () => {
-  const stagehand = new Stagehand({
-    env: "LOCAL",
-    verbose: 1,
-    model: "google/gemini-2.5-flash",
-  });
-
-  try {
-    await stagehand.init();
-    await recordPlaywrightVideo(stagehand);
-  } finally {
-    await stagehand.close().catch(() => {});
-  }
-})();

--- a/packages/core/examples/v3/returnXpath.ts
+++ b/packages/core/examples/v3/returnXpath.ts
@@ -1,23 +1,19 @@
 import { Stagehand } from "../../lib/v3/index.js";
 
-async function example(stagehand: Stagehand) {
-  const page = stagehand.context.pages()[0];
-  await page.goto(
-    "https://browserbase.github.io/stagehand-eval-sites/sites/oopif-in-closed-shadow-dom/",
-  );
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  verbose: 0,
+  model: "openai/gpt-4.1",
+});
 
-  const xpath = await page.click(286, 628, { returnXpath: true });
+await stagehand.init();
 
-  // use the xpath that was returned from out coord click
-  await page.deepLocator(xpath).fill("hellooooooooo");
-}
+const page = stagehand.context.pages()[0];
+await page.goto(
+  "https://browserbase.github.io/stagehand-eval-sites/sites/oopif-in-closed-shadow-dom/",
+);
 
-(async () => {
-  const stagehand = new Stagehand({
-    env: "LOCAL",
-    verbose: 0,
-    model: "openai/gpt-4.1",
-  });
-  await stagehand.init();
-  await example(stagehand);
-})();
+const xpath = await page.click(286, 628, { returnXpath: true });
+
+// use the xpath that was returned from out coord click
+await page.deepLocator(xpath).fill("hellooooooooo");

--- a/packages/core/examples/v3/shadowRoot.ts
+++ b/packages/core/examples/v3/shadowRoot.ts
@@ -1,29 +1,25 @@
 import { Stagehand } from "../../lib/v3/index.js";
 
-async function example(stagehand: Stagehand) {
-  const page = stagehand.context.pages()[0];
-  await page.goto(
-    "https://browserbase.github.io/stagehand-eval-sites/sites/shadow-dom-closed/",
-  );
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  verbose: 0,
+  model: "openai/gpt-4.1",
+});
 
-  // clicking in closed mode shadow root with an xpath
-  await page.locator("/html/body/shadow-demo//div/button").click();
+await stagehand.init();
 
-  await new Promise((resolve) => setTimeout(resolve, 3000));
+const page = stagehand.context.pages()[0];
+await page.goto(
+  "https://browserbase.github.io/stagehand-eval-sites/sites/shadow-dom-closed/",
+);
 
-  await page.reload();
-  await new Promise((resolve) => setTimeout(resolve, 3000));
+// clicking in closed mode shadow root with an xpath
+await page.locator("/html/body/shadow-demo//div/button").click();
 
-  // clicking in closed mode shadow root with css selector
-  await page.locator("div > button").click();
-}
+await new Promise((resolve) => setTimeout(resolve, 3000));
 
-(async () => {
-  const stagehand = new Stagehand({
-    env: "LOCAL",
-    verbose: 0,
-    model: "openai/gpt-4.1",
-  });
-  await stagehand.init();
-  await example(stagehand);
-})();
+await page.reload();
+await new Promise((resolve) => setTimeout(resolve, 3000));
+
+// clicking in closed mode shadow root with css selector
+await page.locator("div > button").click();

--- a/packages/core/examples/v3/targetedExtract.ts
+++ b/packages/core/examples/v3/targetedExtract.ts
@@ -1,35 +1,31 @@
 import { Stagehand } from "../../lib/v3/index.js";
 import { z } from "zod";
 
-async function example(stagehand: Stagehand) {
-  const page = stagehand.context.pages()[0];
-  await page.goto(
-    "https://ambarc.github.io/web-element-test/stagehand-breaking-test.html",
-  );
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  verbose: 0,
+  model: "openai/gpt-4.1",
+  logInferenceToFile: true,
+});
 
-  await page
-    .deepLocator("/html/body/div[2]/div[3]/iframe/html/body/p")
-    .highlight({
-      durationMs: 5000,
-      contentColor: { r: 255, g: 0, b: 0 },
-    });
+await stagehand.init();
 
-  const reason = await stagehand.extract(
-    "extract the reason why script injection fails",
-    z.string(),
-    // selector: "// body > div.test-container > div:nth-child(3) > iframe >> body > p:nth-child(3)",
-    { selector: "/html/body/div[2]/div[3]/iframe/html/body/p[2]" },
-  );
-  console.log(reason);
-}
+const page = stagehand.context.pages()[0];
+await page.goto(
+  "https://ambarc.github.io/web-element-test/stagehand-breaking-test.html",
+);
 
-(async () => {
-  const stagehand = new Stagehand({
-    env: "LOCAL",
-    verbose: 0,
-    model: "openai/gpt-4.1",
-    logInferenceToFile: true,
+await page
+  .deepLocator("/html/body/div[2]/div[3]/iframe/html/body/p")
+  .highlight({
+    durationMs: 5000,
+    contentColor: { r: 255, g: 0, b: 0 },
   });
-  await stagehand.init();
-  await example(stagehand);
-})();
+
+const reason = await stagehand.extract(
+  "extract the reason why script injection fails",
+  z.string(),
+  // selector: "// body > div.test-container > div:nth-child(3) > iframe >> body > p:nth-child(3)",
+  { selector: "/html/body/div[2]/div[3]/iframe/html/body/p[2]" },
+);
+console.log(reason);

--- a/packages/core/examples/v3/v3_agent.ts
+++ b/packages/core/examples/v3/v3_agent.ts
@@ -3,48 +3,44 @@ import { V3 } from "../../lib/v3/index.js";
 
 const INSTRUCTION = "scroll down and click on the last hn story";
 
-async function main() {
-  console.log(`\n${chalk.bold("Stagehand V3 🤘 Operator Example")}\n`);
+console.log(`\n${chalk.bold("Stagehand V3 🤘 Operator Example")}\n`);
 
-  // Initialize Stagehand
-  const v3 = new V3({
-    env: "LOCAL",
-    verbose: 2,
+// Initialize Stagehand
+const v3 = new V3({
+  env: "LOCAL",
+  verbose: 2,
+});
+
+await v3.init();
+
+try {
+  const startPage = v3.context.pages()[0];
+  await startPage.goto(
+    "https://browserbase.github.io/stagehand-eval-sites/sites/iframe-hn/",
+  );
+  const agent = v3.agent({
+    cua: false,
+    model: "google/gemini-2.0-flash",
+    executionModel: "google/gemini-2.0-flash",
+  });
+  // {
+  //   model: "computer-use-preview-2025-03-11",
+  //   provider: "openai",
+  // }
+
+  // Execute the agent
+  console.log(`${chalk.cyan("↳")} Instruction: ${INSTRUCTION}`);
+  const result = await agent.execute({
+    instruction: INSTRUCTION,
+    maxSteps: 20,
   });
 
-  await v3.init();
-
-  try {
-    const startPage = v3.context.pages()[0];
-    await startPage.goto(
-      "https://browserbase.github.io/stagehand-eval-sites/sites/iframe-hn/",
-    );
-    const agent = v3.agent({
-      cua: false,
-      model: "google/gemini-2.0-flash",
-      executionModel: "google/gemini-2.0-flash",
-    });
-    // {
-    //   model: "computer-use-preview-2025-03-11",
-    //   provider: "openai",
-    // }
-
-    // Execute the agent
-    console.log(`${chalk.cyan("↳")} Instruction: ${INSTRUCTION}`);
-    const result = await agent.execute({
-      instruction: INSTRUCTION,
-      maxSteps: 20,
-    });
-
-    console.log(`${chalk.green("✓")} Execution complete`);
-    console.log(`${chalk.yellow("⤷")} Result:`);
-    console.log(JSON.stringify(result, null, 2));
-    console.log(chalk.white(result.message));
-  } catch (error) {
-    console.log(`${chalk.red("✗")} Error: ${error}`);
-  } finally {
-    // await v3.close();
-  }
+  console.log(`${chalk.green("✓")} Execution complete`);
+  console.log(`${chalk.yellow("⤷")} Result:`);
+  console.log(JSON.stringify(result, null, 2));
+  console.log(chalk.white(result.message));
+} catch (error) {
+  console.log(`${chalk.red("✗")} Error: ${error}`);
+} finally {
+  // await v3.close();
 }
-
-main();

--- a/packages/core/examples/v3_example.ts
+++ b/packages/core/examples/v3_example.ts
@@ -1,36 +1,32 @@
 import { V3 } from "../lib/v3/index.js";
 import { z } from "zod";
 
-async function example(v3: V3) {
-  const page = v3.context.pages()[0];
-  await page.goto("https://www.apartments.com/san-francisco-ca/2-bedrooms/", {
-    waitUntil: "load",
-  });
-  const apartment_listings = await v3.extract(
-    "Extract all the apartment listings with their prices and their addresses.",
-    z.object({
-      listings: z.array(
-        z.object({
-          price: z.string().describe("The price of the listing"),
-          address: z.string().describe("The address of the listing"),
-        }),
-      ),
-    }),
-  );
+const v3 = new V3({
+  env: "LOCAL",
+  verbose: 2,
+  logInferenceToFile: false,
+  model: "google/gemini-2.0-flash",
+  cacheDir: "stagehand-extract-cache",
+});
 
-  const listings = apartment_listings.listings;
-  console.log(listings);
-  console.log(`found ${listings.length} listings`);
-}
+await v3.init();
 
-(async () => {
-  const v3 = new V3({
-    env: "LOCAL",
-    verbose: 2,
-    logInferenceToFile: false,
-    model: "google/gemini-2.0-flash",
-    cacheDir: "stagehand-extract-cache",
-  });
-  await v3.init();
-  await example(v3);
-})();
+const page = v3.context.pages()[0];
+await page.goto("https://www.apartments.com/san-francisco-ca/2-bedrooms/", {
+  waitUntil: "load",
+});
+const apartment_listings = await v3.extract(
+  "Extract all the apartment listings with their prices and their addresses.",
+  z.object({
+    listings: z.array(
+      z.object({
+        price: z.string().describe("The price of the listing"),
+        address: z.string().describe("The address of the listing"),
+      }),
+    ),
+  }),
+);
+
+const listings = apartment_listings.listings;
+console.log(listings);
+console.log(`found ${listings.length} listings`);

--- a/packages/core/examples/wordle.ts
+++ b/packages/core/examples/wordle.ts
@@ -1,24 +1,18 @@
 import { Stagehand } from "../lib/v3/index.js";
 
-async function example() {
-  const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    verbose: 1,
-  });
-  await stagehand.init();
-  const page = stagehand.context.pages()[0];
-  await page.goto("https://www.nytimes.com/games/wordle/index.html");
-  await stagehand.act("click 'Continue'");
-  await stagehand.act("click 'Play'");
-  await stagehand.act("click cross sign on top right of 'How To Play' card");
-  const word = "WORDS";
-  for (const letter of word) {
-    await stagehand.act(`press ${letter}`);
-  }
-  await stagehand.act("press enter");
-  await stagehand.close();
+const stagehand = new Stagehand({
+  env: "BROWSERBASE",
+  verbose: 1,
+});
+await stagehand.init();
+const page = stagehand.context.pages()[0];
+await page.goto("https://www.nytimes.com/games/wordle/index.html");
+await stagehand.act("click 'Continue'");
+await stagehand.act("click 'Play'");
+await stagehand.act("click cross sign on top right of 'How To Play' card");
+const word = "WORDS";
+for (const letter of word) {
+  await stagehand.act(`press ${letter}`);
 }
-
-(async () => {
-  await example();
-})();
+await stagehand.act("press enter");
+await stagehand.close();


### PR DESCRIPTION
# why
Now that ESM is supported, examples can use top-level await directly instead of wrapping code in `(async () => { ... })()` patterns.

# what changed

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converted example scripts to ESM with top-level await to simplify flow and reduce boilerplate. This makes the examples easier to read and follow.

- **Refactors**
  - Removed async IIFE/main wrappers; use top-level await across all examples.
  - Moved Stagehand/V3 setup to module scope and added try/finally for cleanup where needed.
  - Preserved explicit error logging in cuaReplay.ts and persist_logs_example.ts.
  - Added a changeset for a patch release.

<sup>Written for commit 60f1527516e95a9211233c2cb88ddc928db13da5. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1727">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

