### PR TITLE
fix: support Claude 4.6 CUA tool version

### DIFF
--- a/.changeset/brave-pens-glow.md
+++ b/.changeset/brave-pens-glow.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+fix: support Claude 4.6 (Opus and Sonnet) in CUA mode by using the correct `computer_20251124` tool version and `computer-use-2025-11-24` beta header

--- a/packages/core/lib/v3/agent/AgentProvider.ts
+++ b/packages/core/lib/v3/agent/AgentProvider.ts
@@ -21,6 +21,7 @@ export const modelToAgentProviderMap: Record<string, AgentProviderType> = {
   "claude-sonnet-4-5-20250929": "anthropic",
   "claude-opus-4-5-20251101": "anthropic",
   "claude-opus-4-6": "anthropic",
+  "claude-sonnet-4-6": "anthropic",
   "claude-haiku-4-5-20251001": "anthropic",
   "gemini-2.5-computer-use-preview-10-2025": "google",
   "gemini-3-flash-preview": "google",

--- a/packages/core/lib/v3/agent/AnthropicCUAClient.ts
+++ b/packages/core/lib/v3/agent/AnthropicCUAClient.ts
@@ -435,6 +435,23 @@ export class AnthropicCUAClient extends AgentClient {
         ? { type: "enabled" as const, budget_tokens: this.thinkingBudget }
         : undefined;
 
+      // Claude 4.6+ models require the newer computer_20251124 tool version
+      const modelBase = this.modelName.includes("/")
+        ? this.modelName.split("/")[1]
+        : this.modelName;
+      const shouldUseNewToolVersion = [
+        "claude-opus-4-6",
+        "claude-sonnet-4-6",
+        "claude-opus-4-5-20251101",
+      ].includes(modelBase);
+
+      const computerToolType = shouldUseNewToolVersion
+        ? "computer_20251124"
+        : "computer_20250124";
+      const betaFlag = shouldUseNewToolVersion
+        ? "computer-use-2025-11-24"
+        : "computer-use-2025-01-24";
+
       // Create the request parameters
       const requestParams: Record<string, unknown> = {
         model: this.modelName,
@@ -442,14 +459,14 @@ export class AnthropicCUAClient extends AgentClient {
         messages: messages,
         tools: [
           {
-            type: "computer_20250124", // Use the latest version for Claude 3.7 Sonnet
+            type: computerToolType,
             name: "computer",
             display_width_px: this.currentViewport.width,
             display_height_px: this.currentViewport.height,
             display_number: 1,
           },
         ],
-        betas: ["computer-use-2025-01-24"],
+        betas: [betaFlag],
       };
 
       // Add custom tools if available

--- a/packages/core/lib/v3/types/public/agent.ts
+++ b/packages/core/lib/v3/types/public/agent.ts
@@ -426,6 +426,7 @@ export const AVAILABLE_CUA_MODELS = [
   "anthropic/claude-3-7-sonnet-latest",
   "anthropic/claude-opus-4-5-20251101",
   "anthropic/claude-opus-4-6",
+  "anthropic/claude-sonnet-4-6",
   "anthropic/claude-haiku-4-5-20251001",
   "anthropic/claude-sonnet-4-20250514",
   "anthropic/claude-sonnet-4-5-20250929",

--- a/packages/core/tests/unit/public-api/llm-and-agents.test.ts
+++ b/packages/core/tests/unit/public-api/llm-and-agents.test.ts
@@ -27,6 +27,7 @@ describe("LLM and Agents public API types", () => {
       "anthropic/claude-3-7-sonnet-latest",
       "anthropic/claude-opus-4-5-20251101",
       "anthropic/claude-opus-4-6",
+      "anthropic/claude-sonnet-4-6",
       "anthropic/claude-haiku-4-5-20251001",
       "anthropic/claude-sonnet-4-20250514",
       "anthropic/claude-sonnet-4-5-20250929",


### PR DESCRIPTION
## Summary
- Claude Opus 4.6 and Sonnet 4.6 require the newer `computer_20251124` tool type and `computer-use-2025-11-24` beta header for CUA mode
- The previous hardcoded `computer_20250124` is rejected by the Anthropic API for these models
- Adds conditional tool version selection in `AnthropicCUAClient.getAction()` — older models are unaffected
- Adds `claude-sonnet-4-6` to model maps (Opus 4.6 was already present)

## Test plan
- [x] Direct Anthropic API calls confirmed both Opus 4.6 and Sonnet 4.6 work with `computer_20251124`
- [x] Stagehand `env: "LOCAL"` CUA mode tested — both models successfully completed tasks
- [x] Unit tests pass (18/18 in `llm-and-agents.test.ts`)
- [ ] Verify older models (Sonnet 4, Sonnet 4.5, Haiku 4.5) still work with `computer_20250124`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CUA support for Claude Opus 4.6 and Sonnet 4.6 by switching to the computer_20251124 tool and computer-use-2025-11-24 beta. Older models continue using computer_20250124 to avoid API rejections.

- **Bug Fixes**
  - Select tool/beta per model in AnthropicCUAClient.getAction(), including prefixed names.
  - Use new tool/beta for claude-opus-4-6, claude-sonnet-4-6, and claude-opus-4-5-20251101.
  - Add claude-sonnet-4-6 to modelToAgentProviderMap and AVAILABLE_CUA_MODELS; update unit tests.

<sup>Written for commit 7c0a52c8021a4cffaefa523e72c8a6071abdb5be. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1729">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

