### PR TITLE
[chore]: rm noisy debug log

### DIFF
--- a/packages/core/lib/v3/understudy/deepLocator.ts
+++ b/packages/core/lib/v3/understudy/deepLocator.ts
@@ -1,7 +1,6 @@
 import { Locator } from "./locator.js";
 import type { Frame } from "./frame.js";
 import type { Page } from "./page.js";
-import { v3Logger } from "../logger.js";
 import { FrameLocator, frameLocatorFromFrame } from "./frameLocator.js";
 import { StagehandInvalidArgumentError } from "../types/public/sdkErrors.js";
 
@@ -258,15 +257,6 @@ async function resolveDeepXPathTarget(
   const flushIntoFrameLocator = () => {
     if (!buf.length) return;
     const selectorForIframe = "xpath=" + buildXPathFromSteps(buf);
-    v3Logger({
-      category: "deep-hop",
-      message: "resolving iframe via FrameLocator",
-      level: 2,
-      auxiliary: {
-        selectorForIframe: { value: selectorForIframe, type: "string" },
-        rootFrameId: { value: String(root.frameId), type: "string" },
-      },
-    });
     fl = fl
       ? fl.frameLocator(selectorForIframe)
       : frameLocatorFromFrame(page, root, selectorForIframe);
@@ -280,14 +270,5 @@ async function resolveDeepXPathTarget(
 
   const finalSelector = "xpath=" + buildXPathFromSteps(buf);
   const targetFrame = fl ? await fl.resolveFrame() : root;
-  v3Logger({
-    category: "deep-hop",
-    message: "final tail",
-    level: 2,
-    auxiliary: {
-      frameId: { value: String(targetFrame.frameId), type: "string" },
-      finalSelector: { value: finalSelector, type: "string" },
-    },
-  });
   return { frame: targetFrame, selector: finalSelector };
 }


### PR DESCRIPTION
# why
- these logs dont add much value if any
- they also didn't use the correct logging context, so they get logged no matter what `verbose` level is defined in the stagehand constructor
# what changed
- removed the noisy logs


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed noisy debug logs in deepLocator that ignored the configured verbose level. This reduces log spam during frame resolution with no behavior changes.

<sup>Written for commit fa8b1f34771164287855268723849b62b212d737. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1731">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

