### PR TITLE
fix: XPath resolution for shadow DOM with <slot> elements 

### DIFF
--- a/packages/core/lib/v3/dom/locatorScripts/xpathResolver.ts
+++ b/packages/core/lib/v3/dom/locatorScripts/xpathResolver.ts
@@ -45,14 +45,16 @@ export function resolveXPathAtIndex(
     return resolveNativeAtIndexWithError(xp, targetIndex).value;
   }
 
-  if (!shadowCtx?.hasShadow) {
-    const native = resolveNativeAtIndexWithError(xp, targetIndex);
-    if (!native.error) return native.value;
-    const composed = resolveXPathComposedMatches(xp, shadowCtx?.getClosedRoot);
-    return composed[targetIndex] ?? null;
-  }
+  // Always try native XPath first — it handles flat-DOM and synthetic shadow
+  // XPaths correctly even when real shadow roots exist elsewhere on the page.
+  const native = resolveNativeAtIndexWithError(xp, targetIndex);
+  if (!native.error && native.value) return native.value;
 
-  const composed = resolveXPathComposedMatches(xp, shadowCtx.getClosedRoot);
+  // Fall back to composed resolution for XPaths that cross shadow boundaries.
+  const composed = resolveXPathComposedMatches(
+    xp,
+    shadowCtx?.getClosedRoot ?? null,
+  );
   return composed[targetIndex] ?? null;
 }
 
@@ -194,6 +196,23 @@ function composedChildren(
   }
 
   if (node instanceof Element) {
+    // Handle <slot> elements: return assigned (distributed) content if available,
+    // otherwise fall back to the slot's own children (fallback content).
+    if (node.localName === "slot") {
+      try {
+        const slotEl = node as HTMLSlotElement;
+        if (typeof slotEl.assignedElements === "function") {
+          const assigned = slotEl.assignedElements({ flatten: true });
+          if (assigned.length > 0) {
+            out.push(...assigned);
+            return out;
+          }
+        }
+      } catch {
+        /* fall through to children */
+      }
+    }
+
     out.push(...Array.from(node.children ?? []));
     const open = node.shadowRoot;
     if (open) out.push(...Array.from(open.children ?? []));

--- a/packages/core/lib/v3/dom/rerenderMissingShadows.runtime.ts
+++ b/packages/core/lib/v3/dom/rerenderMissingShadows.runtime.ts
@@ -19,10 +19,27 @@ export function rerenderMissingShadowHosts(): void {
 
     for (const host of needsReset) {
       try {
-        const clone = host.cloneNode(true);
-        host.replaceWith(clone);
+        const tag = host.tagName.toLowerCase();
+        // createElement triggers the constructor → attachShadow() → piercer intercepts
+        const fresh = document.createElement(tag);
+
+        // Transfer attributes
+        for (const attr of Array.from(host.attributes)) {
+          try {
+            fresh.setAttribute(attr.name, attr.value);
+          } catch {
+            /* skip */
+          }
+        }
+
+        // Move light DOM children (preserves event listeners on children)
+        while (host.firstChild) {
+          fresh.appendChild(host.firstChild);
+        }
+
+        host.replaceWith(fresh);
       } catch {
-        // ignore individual failures
+        // ignore individual failures (e.g., constructor throws)
       }
     }
 

--- a/packages/core/lib/v3/dom/rerenderMissingShadows.runtime.ts
+++ b/packages/core/lib/v3/dom/rerenderMissingShadows.runtime.ts
@@ -19,25 +19,8 @@ export function rerenderMissingShadowHosts(): void {
 
     for (const host of needsReset) {
       try {
-        const tag = host.tagName.toLowerCase();
-        // createElement triggers the constructor → attachShadow() → piercer intercepts
-        const fresh = document.createElement(tag);
-
-        // Transfer attributes
-        for (const attr of Array.from(host.attributes)) {
-          try {
-            fresh.setAttribute(attr.name, attr.value);
-          } catch {
-            /* skip */
-          }
-        }
-
-        // Move light DOM children (preserves event listeners on children)
-        while (host.firstChild) {
-          fresh.appendChild(host.firstChild);
-        }
-
-        host.replaceWith(fresh);
+        const clone = host.cloneNode(true);
+        host.replaceWith(clone);
       } catch {
         // ignore individual failures (e.g., constructor throws)
       }


### PR DESCRIPTION
 # why

# what changed
 ### Changes Made

In `packages/core/lib/v3/dom/locatorScripts/xpathResolver.ts`
  Two changes that fixed the actual XPath resolution failure:

  - composedChildren - slot handling: Added support for <slot> elements by using slot.assignedElements({ flatten: true }) to return distributed/assigned content instead of fallback content. This is critical for pages using native shadow DOM with <slot> elements.
  - resolveXPathAtIndex - native-first fallback: Changed the hasShadow = true branch to always try native document.evaluate() first before falling back to composed resolution. Previously, when any shadow root existed on the page, native XPath was completely skipped, even for XPaths that don't cross shadow boundaries.
# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes XPath resolution across native shadow DOM with slot elements and correctly re-renders shadow hosts, restoring Stagehand’s ability to find and fill form fields. Addresses STG-1433 “Could not find an element for the given xpaths.”

- **Bug Fixes**
  - XPath: Treat <slot> correctly by using assignedElements({ flatten: true }) to traverse distributed content.
  - XPath: Always try native document.evaluate first, then fall back to composed resolution when needed.
  - Shadow hosts: Recreate elements with createElement and transfer attributes/children to trigger constructors and attachShadow.
  - Regenerated DOM scripts and added unit tests for rerenderMissingShadows.

<sup>Written for commit 5ac5b4afe91939a09f95c2573909c9138b85b90b. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1736">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

