### PR TITLE
Revert OpenAPI spec documentation changes from #1673

### DIFF
--- a/packages/server/openapi.v3.yaml
+++ b/packages/server/openapi.v3.yaml
@@ -2152,7 +2152,7 @@ paths:
                 $ref: "#/components/schemas/AgentExecuteResponse"
 servers:
   - url: https://api.stagehand.browserbase.com
-    description: Production Browserbase Cloud API
+    description: US West (Oregon) - us-west-2 (Default)
   - url: https://api.use1.stagehand.browserbase.com
     description: US East (N. Virginia) - us-east-1
   - url: https://api.euc1.stagehand.browserbase.com


### PR DESCRIPTION
Reverts the documentation-related changes to the OpenAPI spec from PR #1673, while preserving the functional multi-region server endpoints.

Changes reverted:
- Restored the info.description to the original format
- Simplified server descriptions back to "Production Browserbase Cloud API"
- Removed multi-region documentation from the spec description

# why

# what changed

# test plan

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the OpenAPI spec docs changes from #1673 to restore a concise info.description and simpler server labels, with no endpoint or behavior changes.

- **Refactors**
  - Removed the multi-region docs section and the local `disableAPI` note; kept brief auth/SSE guidance.
  - Simplified the default server description to "Production Browserbase Cloud API"; regional servers remain labeled by region.
  - No functional changes; multi-region endpoints and routing remain the same.

<sup>Written for commit 3d650d8f8c071f5f67ca4ddf514ca4fde323f3f6. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1739">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

