### PR TITLE
feat(cli): support Browserbase remote execution

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -52,6 +52,25 @@ function getNetworkDir(session: string): string {
   return path.join(SOCKET_DIR, `browse-${session}-network`);
 }
 
+function getModePath(session: string): string {
+  return path.join(SOCKET_DIR, `browse-${session}.mode`);
+}
+
+/** Explicit mode override set by `browse mode local|remote`. Takes precedence over env var detection. */
+function getModeOverridePath(session: string): string {
+  return path.join(SOCKET_DIR, `browse-${session}.mode-override`);
+}
+
+/** Determine desired mode: explicit override > env var detection */
+async function getDesiredMode(session: string): Promise<"browserbase" | "local"> {
+  try {
+    const override = (await fs.readFile(getModeOverridePath(session), "utf-8")).trim();
+    if (override === "browserbase" || override === "local") return override;
+  } catch {}
+  return (process.env.BROWSERBASE_API_KEY && process.env.BROWSERBASE_PROJECT_ID)
+    ? "browserbase" : "local";
+}
+
 async function isDaemonRunning(session: string): Promise<boolean> {
   try {
     const pidFile = getPidPath(session);
@@ -79,6 +98,9 @@ async function cleanupStaleFiles(session: string): Promise<void> {
   } catch {}
   try {
     await fs.unlink(getChromePidPath(session));
+  } catch {}
+  try {
+    await fs.unlink(getModePath(session));
   } catch {}
 }
 
@@ -130,16 +152,34 @@ async function runDaemon(session: string, headless: boolean): Promise<void> {
   // Write daemon PID file
   await fs.writeFile(getPidPath(session), String(process.pid));
 
-  // Create Stagehand instance with dummy model (never used for CLI operations)
+  // Determine mode: explicit override (from `browse mode`) > env var detection
+  const desiredMode = await getDesiredMode(session);
+  const apiKey = process.env.BROWSERBASE_API_KEY;
+  const projectId = process.env.BROWSERBASE_PROJECT_ID;
+  const useBrowserbase = desiredMode === "browserbase" && !!(apiKey && projectId);
+
+  // Create Stagehand instance — uses Browserbase when credentials are set,
+  // otherwise launches a local Chrome instance.
+  // In Browserbase mode we pass disableAPI + a dummy model key since the CLI
+  // only uses raw browser automation, not AI orchestration.
   const stagehand = new Stagehand({
-    env: "LOCAL",
+    env: useBrowserbase ? "BROWSERBASE" : "LOCAL",
     verbose: 0,
     disablePino: true,
-    localBrowserLaunchOptions: {
-      headless,
-      viewport: DEFAULT_VIEWPORT,
-    },
+    ...(useBrowserbase
+      ? {
+          disableAPI: true,
+          model: { modelName: "openai/gpt-4o" as const, apiKey: "unused" },
+        }
+      : { localBrowserLaunchOptions: { headless, viewport: DEFAULT_VIEWPORT } }
+    ),
   });
+
+  // Persist mode so status command can report it
+  await fs.writeFile(
+    getModePath(session),
+    useBrowserbase ? "browserbase" : "local",
+  );
 
   // Initialize browser
   await stagehand.init();
@@ -1066,7 +1106,21 @@ async function sendCommand(
 
 async function ensureDaemon(session: string, headless: boolean): Promise<void> {
   if (await isDaemonRunning(session)) {
-    return;
+    // Check if the running daemon's mode matches the desired mode.
+    // Desired mode = explicit override (from `browse mode`) > env var detection.
+    const wantMode = await getDesiredMode(session);
+    let currentMode: string | null = null;
+    try {
+      currentMode = (await fs.readFile(getModePath(session), "utf-8")).trim();
+    } catch {}
+    if (currentMode && currentMode !== wantMode) {
+      try { await sendCommandOnce(session, "stop", []); } catch {}
+      // Give the daemon a moment to shut down and release the socket
+      await new Promise((r) => setTimeout(r, 500));
+      await cleanupStaleFiles(session);
+    } else {
+      return;
+    }
   }
 
   const args = ["--session", session, "daemon"];
@@ -1209,6 +1263,8 @@ program
   .action(async (cmdOpts) => {
     const opts = program.opts<GlobalOpts>();
     const session = getSession(opts);
+    // Clear any explicit mode override so next start uses env var detection
+    try { await fs.unlink(getModeOverridePath(session)); } catch {}
     try {
       await sendCommand(session, "stop", []);
       console.log(JSON.stringify({ status: "stopped", session }));
@@ -1231,12 +1287,74 @@ program
     const session = getSession(opts);
     const running = await isDaemonRunning(session);
     let wsUrl = null;
+    let mode = null;
     if (running) {
       try {
         wsUrl = await fs.readFile(getWsPath(session), "utf-8");
       } catch {}
+      try {
+        mode = await fs.readFile(getModePath(session), "utf-8");
+      } catch {}
     }
-    console.log(JSON.stringify({ running, session, wsUrl }));
+    console.log(JSON.stringify({ running, session, wsUrl, mode }));
+  });
+
+program
+  .command("mode [target]")
+  .description("Show or switch daemon mode (local | remote)")
+  .action(async (target?: string) => {
+    const opts = program.opts<GlobalOpts>();
+    const session = getSession(opts);
+
+    // No argument → print current mode
+    if (!target) {
+      let mode: string | null = null;
+      if (await isDaemonRunning(session)) {
+        try {
+          mode = (await fs.readFile(getModePath(session), "utf-8")).trim();
+        } catch {}
+      }
+      console.log(JSON.stringify({ mode: mode ?? "not running", session }));
+      return;
+    }
+
+    // Normalize "remote" → "browserbase" for internal use
+    const modeMap: Record<string, string> = { local: "local", remote: "browserbase" };
+    const mapped = modeMap[target];
+    if (!mapped) {
+      console.error('Usage: browse mode [local|remote]');
+      process.exit(1);
+    }
+
+    if (mapped === "browserbase") {
+      if (!process.env.BROWSERBASE_API_KEY || !process.env.BROWSERBASE_PROJECT_ID) {
+        console.error("Cannot switch to remote: BROWSERBASE_API_KEY and BROWSERBASE_PROJECT_ID must be set.");
+        process.exit(1);
+      }
+    }
+
+    // Write the override file — ensureDaemon and runDaemon will read this
+    await fs.writeFile(getModeOverridePath(session), mapped);
+
+    // If the daemon is already in the desired mode, no restart needed
+    let currentMode: string | null = null;
+    if (await isDaemonRunning(session)) {
+      try {
+        currentMode = (await fs.readFile(getModePath(session), "utf-8")).trim();
+      } catch {}
+      if (currentMode === mapped) {
+        console.log(JSON.stringify({ mode: target, session, restarted: false }));
+        return;
+      }
+      // Mode mismatch — stop and let ensureDaemon restart
+      try { await sendCommandOnce(session, "stop", []); } catch {}
+      await new Promise((r) => setTimeout(r, 500));
+      await cleanupStaleFiles(session);
+    }
+
+    await ensureDaemon(session, isHeadless(opts));
+
+    console.log(JSON.stringify({ mode: target, session, restarted: true }));
   });
 
 program


### PR DESCRIPTION
## Summary

- When `BROWSERBASE_API_KEY` and `BROWSERBASE_PROJECT_ID` are set, the browse daemon connects to a remote Browserbase browser instead of launching local Chrome
- New `browse mode [local|remote]` command for on-the-fly mode switching (e.g., agent hits bot detection → switches to remote)
- Mode override is sticky across commands but cleared on `browse stop`, so fresh starts use env var detection
- `browse status` now reports the daemon's execution mode
- Auto-restart in `ensureDaemon` handles stale daemons from previous sessions with mismatched modes

## New command: `browse mode`

```bash
browse mode                # print current mode ("local" or "browserbase")
browse mode local          # switch to local Chrome (sticky)
browse mode remote         # switch to Browserbase (sticky, requires env vars)
```

## How mode is determined (priority order)

1. **Explicit override** — `browse mode local|remote` writes a `.mode-override` file
2. **Env var detection** — `BROWSERBASE_API_KEY` + `BROWSERBASE_PROJECT_ID` set → remote
3. **Default** — local Chrome

`browse stop` clears the override, so the next start falls back to env var detection.

## Changes

**`packages/cli/src/index.ts`:**
- `getModePath()` / `getModeOverridePath()` — file path helpers
- `getDesiredMode()` — resolves override > env vars
- `runDaemon()` — uses `getDesiredMode()` + `disableAPI: true` for Browserbase
- `ensureDaemon()` — auto-restarts daemon on mode mismatch
- `browse mode` command — explicit mode switching with daemon restart
- `browse stop` — clears mode override
- `browse status` — reports `mode` field

## Tested

- [x] Default start with BB creds → `mode: "browserbase"`
- [x] `browse mode local` → restarts daemon, stays local on subsequent commands
- [x] `browse mode remote` → restarts daemon, stays remote on subsequent commands
- [x] `browse stop` clears override → fresh start uses env var detection
- [x] `browse mode` (no args) → prints current mode
- [x] Remote session confirmed via Browserbase API (session visible in dashboard)
- [x] No-op when mode already matches (fast path, no restart)

🤖 Generated with [Claude Code](https://claude.com/claude-code)