### PR TITLE
[STG-1447] stagehand caching doc

### DIFF
--- a/packages/docs/v3/best-practices/caching.mdx
+++ b/packages/docs/v3/best-practices/caching.mdx
@@ -6,6 +6,13 @@ import { V3Banner } from '/snippets/v3-banner.mdx';
 
 <V3Banner />
 
+<Note>
+**Server-side caching is now available.** 
+
+When running `env: "BROWSERBASE"`, Stagehand automatically caches `act()`, `extract()`, and `observe()` results server-side — repeated calls with the same inputs return instantly without consuming LLM tokens.
+
+Caching is enabled by default and can be disabled via `serverCache: false` on the Stagehand instance or per individual call. Check out the [browserbase blog](https://www.browserbase.com/blog/stagehand-caching) for more details.
+</Note>
 
 Stagehand provides built-in action caching to reduce LLM inference calls and improve performance. Simply specify a `cacheDir` when initializing Stagehand, and actions are automatically cached and reused across runs.
 


### PR DESCRIPTION
# why

# what changed

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a Note to the caching best-practices doc explaining server-side caching when running env: "BROWSERBASE" (STG-1447). It’s enabled by default for act(), extract(), and observe(); repeated calls with the same inputs return instantly, and you can disable it via serverCache: false or per call, with a blog link for details.

<sup>Written for commit 4b6181fbb16ae793ec01b0c274ab7b28495b5253. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1742">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

