### PR TITLE
[docs]: add `keepAlive` docs

### DIFF
--- a/packages/docs/v3/configuration/browser.mdx
+++ b/packages/docs/v3/configuration/browser.mdx
@@ -265,6 +265,70 @@ await stagehand.init();
 
 ## Advanced Configuration
 
+### Keep Alive
+
+The `keepAlive` option controls whether the browser remains running after `stagehand.close()` is called or when the parent process exits unexpectedly (e.g., crash, `SIGTERM`, `SIGINT`).
+
+By default, Stagehand terminates the browser and cleans up all resources when it shuts down. Setting `keepAlive: true` keeps the browser running independently so you can reconnect to it later.
+
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const stagehand = new Stagehand({
+  env: "BROWSERBASE",
+  keepAlive: true,
+});
+
+await stagehand.init();
+
+// The browser session continues running after close()
+await stagehand.close();
+
+// Later, reconnect to the same session
+const stagehand2 = new Stagehand({
+  env: "BROWSERBASE",
+  browserbaseSessionID: stagehand.browserbaseSessionID,
+});
+await stagehand2.init();
+```
+
+#### Behavior by Environment
+
+| Behavior | `keepAlive: true` | `keepAlive: false` (default) |
+| --- | --- | --- |
+| **Browserbase** | Session stays active after `close()` | Session is terminated via API |
+| **Local** | Chrome process continues running | Chrome process is killed and temp profile is removed |
+| **On crash/signal** | Browser is left running | Browser is automatically cleaned up |
+
+#### Local Environment
+
+When running locally with `keepAlive: true`, the Chrome process is detached from the Node.js event loop, allowing your script to exit while the browser stays open. This is useful for debugging or for handing off a browser session to another process.
+
+```typescript
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  keepAlive: true,
+  localBrowserLaunchOptions: {
+    headless: false,
+  },
+});
+
+await stagehand.init();
+const page = stagehand.context.pages()[0];
+await page.goto("https://example.com");
+
+// Browser window stays open after the script exits
+await stagehand.close();
+```
+
+#### Browserbase Environment
+
+On Browserbase, `keepAlive: true` keeps the cloud session active so you can reconnect later using `browserbaseSessionID`. This is useful for long-running workflows that span multiple script executions.
+
+<Note>
+The top-level `keepAlive` option overrides `browserbaseSessionCreateParams.keepAlive` when both are provided.
+</Note>
+
 ### Fixed CDP Debugging Port
 
 Specify a fixed Chrome DevTools Protocol (CDP) debugging port instead of using a randomly assigned one.

--- a/packages/docs/v3/references/stagehand.mdx
+++ b/packages/docs/v3/references/stagehand.mdx
@@ -59,6 +59,7 @@ interface V3Options {
   experimental?: boolean;
   domSettleTimeout?: number;
   cacheDir?: string;
+  keepAlive?: boolean;
 
   // Logging options
   verbose?: 0 | 1 | 2;
@@ -211,6 +212,17 @@ interface V3Options {
   Directory path for caching action observations to improve performance.
 </ParamField>
 
+<ParamField path="keepAlive" type="boolean" optional>
+  Controls whether the browser remains running after `stagehand.close()` is called or the parent process exits unexpectedly.
+
+  - **`true`** - Browser continues running independently. On Browserbase, the session stays active. Locally, the Chrome process is kept alive.
+  - **`false`** - Browser is terminated and resources are cleaned up on close or crash.
+
+  When set, this overrides any value in `browserbaseSessionCreateParams.keepAlive`.
+
+  **Default:** `false`
+</ParamField>
+
 #### Logging Options
 
 <ParamField path="verbose" type="0 | 1 | 2" optional>
@@ -264,6 +276,10 @@ await stagehand.close(options?: { force?: boolean }): Promise<void>
 
   **Default:** `false`
 </ParamField>
+
+<Note>
+When `keepAlive` is `true`, calling `close()` disconnects Stagehand from the browser without terminating it. The browser session continues running independently and can be reconnected to later using `browserbaseSessionID`. When `keepAlive` is `false` (the default), `close()` fully terminates the browser and cleans up all resources.
+</Note>
 
 ### agent()
 


### PR DESCRIPTION
# why
- adds documentation for the new `keepAlive` param
### note:
- hold off on merging until after release


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add keepAlive docs to Stagehand, detailing behavior in Browserbase and Local, close() semantics, defaults/overrides, and how to reconnect via browserbaseSessionID. Addresses Linear STG-1380.

<sup>Written for commit 6eaa9cdd7e1fbb5052f30d8c2b4578965e4a3039. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1747">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

