### PR TITLE
add configurable timeout to act tool in agent

### DIFF
--- a/.changeset/public-results-mate.md
+++ b/.changeset/public-results-mate.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Add configurable timeout to act tool in agent

--- a/packages/core/lib/v3/agent/tools/act.ts
+++ b/packages/core/lib/v3/agent/tools/act.ts
@@ -3,11 +3,13 @@ import { z } from "zod";
 import type { V3 } from "../../v3.js";
 import type { Action } from "../../types/public/methods.js";
 import type { AgentModelConfig, Variables } from "../../types/public/agent.js";
+import { withTimeout, DEFAULT_TOOL_TIMEOUT_MS } from "../utils/toolTimeout.js";
 
 export const actTool = (
   v3: V3,
   executionModel?: string | AgentModelConfig,
   variables?: Variables,
+  toolTimeout?: number,
 ) => {
   const hasVariables = variables && Object.keys(variables).length > 0;
   const actionDescription = hasVariables
@@ -36,7 +38,10 @@ export const actTool = (
         const options = executionModel
           ? { model: executionModel, variables }
           : { variables };
-        const result = await v3.act(action, options);
+
+        const timeoutMs = toolTimeout ?? DEFAULT_TOOL_TIMEOUT_MS;
+        const result = await withTimeout(v3.act(action, options), timeoutMs);
+
         const actions = (result.actions as Action[] | undefined) ?? [];
         v3.recordAgentReplayStep({
           type: "act",

--- a/packages/core/lib/v3/agent/tools/index.ts
+++ b/packages/core/lib/v3/agent/tools/index.ts
@@ -48,6 +48,10 @@ export interface V3AgentToolOptions {
    * When provided, these tools will have an optional useVariable field.
    */
   variables?: Variables;
+  /**
+   * Timeout in milliseconds for tool calls. Defaults to 45000 (45s).
+   */
+  toolTimeout?: number;
 }
 
 /**
@@ -90,9 +94,10 @@ export function createAgentTools(v3: V3, options?: V3AgentToolOptions) {
   const provider = options?.provider;
   const excludeTools = options?.excludeTools;
   const variables = options?.variables;
+  const toolTimeout = options?.toolTimeout;
 
   const allTools: ToolSet = {
-    act: actTool(v3, executionModel, variables),
+    act: actTool(v3, executionModel, variables, toolTimeout),
     ariaTree: ariaTreeTool(v3),
     click: clickTool(v3, provider),
     clickAndHold: clickAndHoldTool(v3, provider),

--- a/packages/core/lib/v3/agent/utils/toolTimeout.ts
+++ b/packages/core/lib/v3/agent/utils/toolTimeout.ts
@@ -1,0 +1,27 @@
+export const DEFAULT_TOOL_TIMEOUT_MS = 45_000;
+
+export function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(
+        new Error(
+          `act call timed out after ${timeoutMs}ms - try adjusting the prompt, or using a different tool`,
+        ),
+      );
+    }, timeoutMs);
+
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err: unknown) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}

--- a/packages/core/lib/v3/handlers/v3AgentHandler.ts
+++ b/packages/core/lib/v3/handlers/v3AgentHandler.ts
@@ -118,7 +118,11 @@ export class V3AgentHandler {
         variables: options.variables,
       });
 
-      const tools = this.createTools(options.excludeTools, options.variables);
+      const tools = this.createTools(
+        options.excludeTools,
+        options.variables,
+        options.toolTimeout,
+      );
       const allTools: ToolSet = { ...tools, ...this.mcpTools };
 
       // Use provided messages for continuation, or start fresh with the instruction
@@ -562,7 +566,11 @@ export class V3AgentHandler {
     };
   }
 
-  private createTools(excludeTools?: string[], variables?: Variables) {
+  private createTools(
+    excludeTools?: string[],
+    variables?: Variables,
+    toolTimeout?: number,
+  ) {
     const provider = this.llmClient?.getLanguageModel?.()?.provider;
     return createAgentTools(this.v3, {
       executionModel: this.executionModel,
@@ -571,6 +579,7 @@ export class V3AgentHandler {
       provider,
       excludeTools,
       variables,
+      toolTimeout,
     });
   }
 

--- a/packages/core/lib/v3/types/public/agent.ts
+++ b/packages/core/lib/v3/types/public/agent.ts
@@ -393,6 +393,13 @@ export interface AgentExecuteOptionsBase {
    * ```
    */
   variables?: Variables;
+  /**
+   * Timeout in milliseconds for each tool call (e.g. act, extract, fillForm).
+   * If a tool call exceeds this duration, it will be aborted and
+   * reported back to the LLM.
+   * @default 45000 (45 seconds)
+   */
+  toolTimeout?: number;
 }
 
 /**


### PR DESCRIPTION
# Why

Agent `act` tool calls can hang for a long time if the underlying `v3.act()` call stalls (e.g. waiting on an abnormally slow LLM inference). We need a safety net that bounds how long the tool call can take and returns control to the LLM so it can adapt.

# What changed

- **New option `toolTimeout`** on `AgentExecuteOptionsBase` — lets users configure the toolcall timeout from `agent.execute()`. Defaults to 45 seconds if not specified.

- **New shared utility `withTimeout`** in `packages/core/lib/v3/agent/utils/toolTimeout.ts` — a generic promise-racing helper that rejects with a descriptive error after the given duration. Extracted into a shared util so other tools can reuse it in the future without duplication.

- **`actTool` wrapped with timeout** — the `v3.act()` call inside the act agent tool is now wrapped with `withTimeout`. If it exceeds the timeout, the catch block returns `{ success: false, error: "act call timed out after {ms}ms - try adjusting the prompt, or using a different tool" }` to the LLM, allowing it to retry or take a different approach.

- **Plumbing through the handler layer** — `toolTimeout` flows from `AgentExecuteOptionsBase` → `v3AgentHandler.prepareAgent` → `createTools` → `createAgentTools` → `actTool`.

### Files changed

| File | Change |
|------|--------|
| `packages/core/lib/v3/types/public/agent.ts` | Added `toolTimeout?: number` to `AgentExecuteOptionsBase` |
| `packages/core/lib/v3/agent/utils/toolTimeout.ts` | New file — `withTimeout` helper and `DEFAULT_TOOL_TIMEOUT_MS` constant |
| `packages/core/lib/v3/agent/tools/act.ts` | Wrapped `v3.act()` with `withTimeout`, accepts `toolTimeout` param |
| `packages/core/lib/v3/agent/tools/index.ts` | Added `toolTimeout` to `V3AgentToolOptions`, passes it to `actTool()` |
| `packages/core/lib/v3/handlers/v3AgentHandler.ts` | Threads `options.toolTimeout` through `createTools` into `createAgentTools` |

# Test plan

- set low timeout to ensure the logic works, and returns correct erorr response to llm 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a configurable timeout to the agent’s act tool to prevent long hangs. Calls that exceed the limit fail fast and return control to the LLM.

- **New Features**
  - Added AgentExecuteOptionsBase.toolTimeout (ms) with a 45,000 ms default.
  - actTool now wraps v3.act(...) with withTimeout; on timeout returns { success: false, error: "act call timed out after {ms}ms..." }.
  - Introduced shared utils: withTimeout and DEFAULT_TOOL_TIMEOUT_MS.
  - Plumbed toolTimeout through v3AgentHandler → createTools → createAgentTools → actTool.

<sup>Written for commit b146a14edaf74190b5acedfcc33d251cdacce79a. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1750">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

