### PR TITLE
STG-1307: set Sonatype portal for Java/Kotlin

### DIFF
--- a/stainless.yml
+++ b/stainless.yml
@@ -33,14 +33,16 @@ targets:
     package_name: stagehand
     production_repo: browserbase/stagehand-java
     publish:
-      maven: true
+      maven:
+        sonatype_platform: portal
   kotlin:
     edition: kotlin.2025-10-08
     reverse_domain: com.browserbase.api
     package_name: stagehand
     production_repo: browserbase/stagehand-kotlin
     publish:
-      maven: true
+      maven:
+        sonatype_platform: portal
   ruby:
     edition: ruby.2025-10-08
     gem_name: stagehand


### PR DESCRIPTION
# why
Allows java / kotlin publishing
# what changed
minimal stainless config change as per stainless docs
# test plan
none

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configured Stainless to publish Java and Kotlin packages to Maven Central via Sonatype Portal. Moves STG-1307 forward by enabling publishing for these two languages.

- **New Features**
  - Set maven.sonatype_platform: portal for Java and Kotlin in stainless.yml.

<sup>Written for commit a2f1a108ec472433b2674b7f5dd3587922a4730f. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1757">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

