### PR TITLE
[STG-1473] Replace hardcoded provider enum with z.string()

### DIFF
--- a/.changeset/replace-provider-enum-with-string.md
+++ b/.changeset/replace-provider-enum-with-string.md
@@ -1,0 +1,6 @@
+---
+"@browserbasehq/stagehand": patch
+"@browserbasehq/stagehand-server": patch
+---
+
+Replace hardcoded provider enum with z.string() in model configuration schemas. The provider field is optional, not validated server-side, and was out of sync with the actual supported providers. New providers no longer require schema updates.

--- a/packages/core/lib/v3/types/public/agent.ts
+++ b/packages/core/lib/v3/types/public/agent.ts
@@ -418,12 +418,7 @@ export interface AgentStreamExecuteOptions extends AgentExecuteOptionsBase {
    */
   callbacks?: AgentStreamCallbacks;
 }
-export type AgentType =
-  | "openai"
-  | "anthropic"
-  | "google"
-  | "microsoft"
-  | "bedrock";
+export type AgentType = string;
 
 export const AVAILABLE_CUA_MODELS = [
   "openai/computer-use-preview",

--- a/packages/core/lib/v3/types/public/api.ts
+++ b/packages/core/lib/v3/types/public/api.ts
@@ -51,14 +51,11 @@ export const LocalBrowserLaunchOptionsSchema = z
 /** Detailed model configuration object */
 export const ModelConfigObjectSchema = z
   .object({
-    provider: z
-      .enum(["openai", "anthropic", "google", "microsoft", "bedrock"])
-      .optional()
-      .meta({
-        description:
-          "AI provider for the model (or provide a baseURL endpoint instead)",
-        example: "openai",
-      }),
+    provider: z.string().optional().meta({
+      description:
+        "AI provider for the model (or provide a baseURL endpoint instead)",
+      example: "openai",
+    }),
     modelName: z.string().meta({
       description:
         "Model name string with provider prefix (e.g., 'openai/gpt-5-nano')",
@@ -589,7 +586,7 @@ export const ObserveResponseSchema = wrapResponse(
 export const AgentConfigSchema = z
   .object({
     provider: z // cloud accepts provider: at the top level for legacy reasons, in the future we should remove it
-      .enum(["openai", "anthropic", "google", "microsoft", "bedrock"])
+      .string()
       .optional()
       .meta({
         description:

--- a/packages/server/openapi.v3.yaml
+++ b/packages/server/openapi.v3.yaml
@@ -168,12 +168,6 @@ components:
           description: AI provider for the model (or provide a baseURL endpoint instead)
           example: openai
           type: string
-          enum:
-            - openai
-            - anthropic
-            - google
-            - microsoft
-            - bedrock
         modelName:
           description: Model name string with provider prefix (e.g., 'openai/gpt-5-nano')
           example: openai/gpt-5-nano
@@ -648,12 +642,6 @@ components:
             instead)"
           example: openai
           type: string
-          enum:
-            - openai
-            - anthropic
-            - google
-            - microsoft
-            - bedrock
         model:
           description: Model configuration object or model name string (e.g.,
             'openai/gpt-5-nano')
@@ -1151,12 +1139,6 @@ components:
           description: AI provider for the model (or provide a baseURL endpoint instead)
           example: openai
           type: string
-          enum:
-            - openai
-            - anthropic
-            - google
-            - microsoft
-            - bedrock
         modelName:
           description: Model name string with provider prefix (e.g., 'openai/gpt-5-nano')
           example: openai/gpt-5-nano
@@ -1544,12 +1526,6 @@ components:
             instead)"
           example: openai
           type: string
-          enum:
-            - openai
-            - anthropic
-            - google
-            - microsoft
-            - bedrock
         model:
           description: Model configuration object or model name string (e.g.,
             'openai/gpt-5-nano')


### PR DESCRIPTION
## Summary
- Replaces the hardcoded `z.enum(["openai", "anthropic", "google", "microsoft", "bedrock"])` with `z.string()` in `ModelConfigObjectSchema` and `AgentConfigSchema`
- Widens `AgentType` from a union literal to `string` to match
- Regenerates OpenAPI spec (removes enum constraints from provider fields)

## Why

The `provider` field enum was:
- **Out of sync** — 5 providers in the enum vs 14 in `AISDK_PROVIDERS` (and `microsoft` was in the enum but not in `AISDK_PROVIDERS`)
- **Not validated server-side** — the server only checks the provider prefix from `modelName`, never the `provider` field
- **Redundant** — `LLMProvider.getClient()` already rejects unknown providers at runtime
- **A maintenance burden** — every new provider required updating the Zod enum, `AgentType`, `AISDK_PROVIDERS`, and the `AISDKProviders` map separately

## What doesn't change
- Server-side validation of `modelName` prefix against `AISDK_PROVIDERS` (unchanged)
- Runtime provider validation in `LLMProvider` (unchanged)
- The `provider` field remains optional — users typically specify provider via `modelName` prefix

Linear: https://linear.app/browserbase/issue/STG-1473

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced hardcoded provider enums with strings in public schemas to prevent drift and reduce maintenance (STG-1473). No behavior change; runtime and server-side validation remain the same.

- **Refactors**
  - provider in ModelConfigObjectSchema and AgentConfigSchema: enum -> string (still optional)
  - AgentType: union literal -> string
  - Regenerated OpenAPI to remove provider enum lists

<sup>Written for commit c18e86baefebcac6ae359283711a54473d717029. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1760">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

