### PR TITLE
[fix]: rm legacy `handlePossibleNavigation()`

### DIFF
--- a/.changeset/some-parrots-wave.md
+++ b/.changeset/some-parrots-wave.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+fix issue where handlePossibleNavigation was producing unnecessary error logs on clicks that trigger page close

--- a/packages/core/lib/v3/handlers/handlerUtils/actHandlerUtils.ts
+++ b/packages/core/lib/v3/handlers/handlerUtils/actHandlerUtils.ts
@@ -106,8 +106,6 @@ export async function performUnderstudyMethod(
           );
       }
     }
-
-    await handlePossibleNavigation("action", selectorRaw, initialUrl, frame);
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     const stack = e instanceof Error ? e.stack : undefined;
@@ -694,37 +692,4 @@ export async function waitForDomNetworkQuiet(
       resolve();
     };
   });
-}
-
-async function handlePossibleNavigation(
-  actionDescription: string,
-  xpath: string,
-  initialUrl: string,
-  frame: Frame,
-): Promise<void> {
-  v3Logger({
-    category: "action",
-    message: `${actionDescription}, checking for page navigation`,
-    level: 1,
-    auxiliary: { xpath: { value: xpath, type: "string" } },
-  });
-
-  // We only have a frame-scoped session, so detect navigation by URL change.
-  const afterUrl = await getFrameUrl(frame);
-
-  if (afterUrl !== initialUrl) {
-    v3Logger({
-      category: "action",
-      message: "new page (frame) URL detected",
-      level: 1,
-      auxiliary: { url: { value: afterUrl, type: "string" } },
-    });
-  } else {
-    v3Logger({
-      category: "action",
-      message: "no new (frame) URL detected",
-      level: 1,
-      auxiliary: { url: { value: afterUrl, type: "string" } },
-    });
-  }
 }


### PR DESCRIPTION
# why
- this function was from legacy stagehand which only operated on one page
- presently, it was only being used to produce a log which:
  - at best, misinformed users on whether the page had actually navigated, and, 
  - at worst, resulted in a noisy error log
  - the error log would happen if `clickElement()` triggered page closure. this means that the frame.evaluate() to get the URL would attempt `.evaluate()` on a frame that no longer existed
# what changed
- removed `handlePossibleNavigation()`
# test plan
- existing tests are fine here

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the legacy handlePossibleNavigation() that tried to detect navigation by URL and produced misleading logs. This also prevents errors when clicks close the page and evaluate runs on a non-existent frame, reducing log noise.

<sup>Written for commit 1d2c3d68280d8a686e806a3b55bbbbb766a1ea25. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1761">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

