### PR TITLE
[STG-1482] Update caching docs: split into Browserbase Cache and Local Cache sections

### DIFF
--- a/packages/docs/v3/best-practices/caching.mdx
+++ b/packages/docs/v3/best-practices/caching.mdx
@@ -80,7 +80,6 @@ Local Cache writes action results to your filesystem so they persist across scri
 
 This is especially useful for:
 
-- **`agent()` workflows** - local caching is the only way to cache agent steps today
 - **CI/CD pipelines** - commit your cache directory to version control for consistent, deterministic runs across environments
 - **Local development** - iterate on automations without burning tokens on repeated runs
 - **Cross-machine sharing** - cache files are portable and can be shared across machines


### PR DESCRIPTION
## Summary

Restructures the caching best practices docs page into two clear sections:

### Changes
- **Removed** the disclaimer/note about server-side caching only working with `env: "BROWSERBASE"` — this is now naturally conveyed in the section description
- **Renamed** "Server-side Caching" → **"Browserbase Cache"** with a clear description of what it is (managed, server-side, automatic, zero-config)
- **Renamed** "Local Caching" → **"Local Cache"** with a clear description of what it is (file-based, works everywhere, portable)
- **Added** use-case bullets to the Local Cache section explaining when to reach for it (agent workflows, CI/CD, local dev, cross-machine sharing)
- **Preserved** all existing code snippets, configuration examples, and best practices

### What stays the same
- All code examples (disabling on constructor, disabling per call, inspecting cache status, act/agent caching, cache directory organization)
- The limitations section for Browserbase Cache
- The best practices accordion (descriptive dirs, clearing cache, committing for CI/CD)
- The blog link for deeper technical details

Only modifies `packages/docs/v3/best-practices/caching.mdx`.

Linear: https://linear.app/browserbase/issue/STG-1482