### PR TITLE
[fix]: skip CI jobs requiring secrets on fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,7 +374,9 @@ jobs:
     name: server/integration/${{ matrix.test.name }}
     runs-on: ubuntu-latest
     needs: [build-server-sea, discover-server-tests, run-build]
-    if: needs.discover-server-tests.outputs.has-integration-tests == 'true'
+    if: >
+      needs.discover-server-tests.outputs.has-integration-tests == 'true' &&
+      github.event.pull_request.head.repo.full_name == github.repository
 
     strategy:
       fail-fast: false
@@ -572,7 +574,8 @@ jobs:
         needs.run-e2e-bb-tests.result != 'failure' &&
         needs.run-e2e-bb-tests.result != 'cancelled' &&
         needs.determine-evals.outputs.skip-all-evals != 'true' &&
-        needs.determine-evals.outputs.eval-categories != '[]'
+        needs.determine-evals.outputs.eval-categories != '[]' &&
+        github.event.pull_request.head.repo.full_name == github.repository
       }}
     runs-on: ubuntu-latest
     timeout-minutes: 90

--- a/.github/workflows/stainless.yml
+++ b/.github/workflows/stainless.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   preview:
-    if: github.event.action != 'closed'
+    if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Server integration tests, evals, and Stainless preview builds require repo secrets that GitHub doesn't expose to fork PRs
- These jobs were running and failing with missing env var errors on every fork PR
- Add the same fork guard (`head.repo.full_name == github.repository`) that e2e tests already use

### Jobs fixed:
- `server-integration-tests` in `ci.yml`
- `run-evals` in `ci.yml`
- `preview` in `stainless.yml`

## Test plan
- [ ] Verify existing (non-fork) PRs still run all CI jobs
- [ ] Verify fork PRs skip the guarded jobs gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip CI jobs that require repo secrets on fork PRs to prevent missing env errors. These jobs now run only when the PR comes from this repo.

- **Bug Fixes**
  - Guarded server integration tests in ci.yml.
  - Guarded eval runs in ci.yml.
  - Guarded Stainless preview builds in stainless.yml.

<sup>Written for commit f71de8d1f56fd156ac28704d07803c81ccf6b944. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1780">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

