### PR TITLE
Allow outside contributors to run CI with secrets when approved

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,15 @@ name: Tests
 
 on:
   workflow_run:
-    # DO NOT CHANGE THIS TO pull_request_target as it will leak secrets to external contributors before approval.
-    # DO NOT CHANGE THIS to pull_request as it will prevent us from running CI on PRs from external contributors.
-    # Learn more: https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
-    # https://dvc.org/blog/testing-external-contributions-using-github-actions-secrets/
+    # DO NOT CHANGE THIS TO pull_request_target as it will leak secrets to external contributors before maintainer approves the CI run.
+    # DO NOT CHANGE THIS to pull_request as it will prevent us from running CI on PRs from external contributors with secrets *after* approval.
+    # Learn more:
+    # - https://github.blog/changelog/2025-11-07-actions-pull_request_target-and-environment-branch-protections-changes/
+    # - https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
+    # - https://dvc.org/blog/testing-external-contributions-using-github-actions-secrets/
+    # - https://github.com/orgs/community/discussions/179107
     workflows:
-      - "Ensure Contributor Is Trusted to Run CI"
+      - "Ensure Contributor Is Trusted to Run CI"   # filename: ensure-contributor-is-trusted-to-run-ci.yml
     types:
       - completed
 

--- a/.github/workflows/ensure-contributor-is-trusted-to-run-ci.yml
+++ b/.github/workflows/ensure-contributor-is-trusted-to-run-ci.yml
@@ -9,6 +9,8 @@ name: Ensure Contributor Is Trusted to Run CI
 # - https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
 # - https://dvc.org/blog/testing-external-contributions-using-github-actions-secrets/
 # - https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets
+# - https://github.blog/changelog/2025-11-07-actions-pull_request_target-and-environment-branch-protections-changes/
+# - https://github.com/orgs/community/discussions/179107
 
 on:
   pull_request:


### PR DESCRIPTION
PSA potential hackers: dont get excited, we don't have any real secrets in CI worth stealing, and our CI does not autodeploy anything to prod. All important secrets and CD processes are kept in our closed-source repos.

# why

# what changed

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a gating workflow that blocks CI until a maintainer approves running secrets on forked PRs. CI now triggers from that gate, resolves labels and path filters under workflow_run, removes same-repo guards so integration/e2e/evals run on approved forks, and checks out the PR commit consistently across jobs.

<sup>Written for commit c68284700554566b199875de2b2c901caedf8d6a. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1782">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



