### PR TITLE
Revert "[fix]: skip CI jobs requiring secrets on fork PRs"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,9 +374,7 @@ jobs:
     name: server/integration/${{ matrix.test.name }}
     runs-on: ubuntu-latest
     needs: [build-server-sea, discover-server-tests, run-build]
-    if: >
-      needs.discover-server-tests.outputs.has-integration-tests == 'true' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+    if: needs.discover-server-tests.outputs.has-integration-tests == 'true'
 
     strategy:
       fail-fast: false
@@ -574,8 +572,7 @@ jobs:
         needs.run-e2e-bb-tests.result != 'failure' &&
         needs.run-e2e-bb-tests.result != 'cancelled' &&
         needs.determine-evals.outputs.skip-all-evals != 'true' &&
-        needs.determine-evals.outputs.eval-categories != '[]' &&
-        github.event.pull_request.head.repo.full_name == github.repository
+        needs.determine-evals.outputs.eval-categories != '[]'
       }}
     runs-on: ubuntu-latest
     timeout-minutes: 90

--- a/.github/workflows/stainless.yml
+++ b/.github/workflows/stainless.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   preview:
-    if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Reverts browserbase/stagehand#1780

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the change that skipped CI on forked PRs. Integration tests, evals, and the Stainless preview now run for all PRs by removing the head-repo equality checks in ci.yml and stainless.yml.

<sup>Written for commit 18480e852cf5c3937f22994450c88b169a4fa6c8. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1787">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

