### PR TITLE
fix(agent): inject user-provided value into fillForm observe results

### DIFF
--- a/packages/core/lib/v3/agent/tools/fillform.ts
+++ b/packages/core/lib/v3/agent/tools/fillform.ts
@@ -56,7 +56,13 @@ export const fillFormTool = (
 
         const completed = [] as unknown[];
         const replayableActions: Action[] = [];
-        for (const res of observeResults) {
+        for (let i = 0; i < observeResults.length; i++) {
+          const res = observeResults[i];
+
+          if (res.method === "fill" && fields[i] !== undefined) {
+            res.arguments = [fields[i].value];
+          }
+
           const actOptions = variables
             ? { variables, timeout: toolTimeout }
             : { timeout: toolTimeout };


### PR DESCRIPTION
## Summary

- Fixes the `fillForm` agent tool dropping the `value` parameter, which caused LLMs to hallucinate placeholder values
- Injects the user-provided `value` into observe results before calling `act()`

## Problem

The `fillForm` tool receives fields with both `action` and `value`:
```typescript
fillForm({ action: "type email into the textbox", value: "user@example.com" })
```

But the execute function only used `action` when calling `observe()`, causing the LLM to guess what value to fill in. This resulted in hallucinated placeholders like `test@example.com` instead of the actual user-provided value.

This bug caused flaky behavior in:
- Login forms
- Search queries
- Data entry
- 2FA/OTP flows (when using custom tools that return codes)

## Solution

After receiving observe results, inject the user-provided `value` into the result's `arguments` array for fill operations:

```typescript
if (res.method === "fill" && fields[i]?.value) {
  res.arguments = [fields[i].value];
}
```

This ensures the correct value is passed to `act()` rather than the LLM-hallucinated placeholder.

## Test plan

- [ ] Test fillForm with explicit values (e.g., email/password fields)
- [ ] Verify custom tool results (e.g., TOTP codes) are correctly filled
- [ ] Confirm no regression in cases where values are embedded in the action string

Fixes #1789

---

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure fillForm uses the user-provided value for fill actions instead of guessing placeholders. We align observe results with input fields by index and inject the field’s value into “fill” arguments before act(), so forms type exactly what was supplied.

<sup>Written for commit a458c2fdb8b53af611b515cb2c055e2b5803490b. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1790">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

