### PR TITLE
fix(agent): inject user-provided value into fillForm observe results

### DIFF
--- a/packages/core/lib/v3/agent/tools/fillform.ts
+++ b/packages/core/lib/v3/agent/tools/fillform.ts
@@ -56,7 +56,13 @@ export const fillFormTool = (
 
         const completed = [] as unknown[];
         const replayableActions: Action[] = [];
-        for (const res of observeResults) {
+        for (let i = 0; i < observeResults.length; i++) {
+          const res = observeResults[i];
+
+          if (res.method === "fill" && fields[i] !== undefined) {
+            res.arguments = [fields[i].value];
+          }
+
           const actOptions = variables
             ? { variables, timeout: toolTimeout }
             : { timeout: toolTimeout };


### PR DESCRIPTION
## Summary

- Fixes the `fillForm` agent tool dropping the `value` parameter, which caused LLMs to hallucinate placeholder values
- Injects the user-provided `value` into observe results before calling `act()`

## Problem

The `fillForm` tool receives fields with both `action` and `value`:
```typescript
fillForm({ action: "type email into the textbox", value: "user@example.com" })
```

But the execute function only used `action` when calling `observe()`, causing the LLM to guess what value to fill in. This resulted in hallucinated placeholders like `test@example.com` instead of the actual user-provided value.

This bug caused flaky behavior in:
- Login forms
- Search queries
- Data entry
- 2FA/OTP flows (when using custom tools that return codes)

## Solution

After receiving observe results, inject the user-provided `value` into the result's `arguments` array for fill operations:

```typescript
if (res.method === "fill" && fields[i]?.value) {
  res.arguments = [fields[i].value];
}
```

This ensures the correct value is passed to `act()` rather than the LLM-hallucinated placeholder.

Fixes #1789

---

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure fillForm uses the user-provided value by injecting it into observe results before act(), preventing hallucinated placeholders. This fixes incorrect inputs in login, search, data entry, and OTP flows.

- **Bug Fixes**
  - For observeResults with method "fill", set res.arguments = [fields[i].value] so act() types the correct value.

<sup>Written for commit 0e73368f011d6becaddc1c84eb640d1c3bc1d318. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1791">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

