### PR TITLE
Add fix for page.url() race when navigation happens as a result of `act()`

### DIFF
--- a/packages/core/lib/v3/handlers/handlerUtils/actHandlerUtils.ts
+++ b/packages/core/lib/v3/handlers/handlerUtils/actHandlerUtils.ts
@@ -166,6 +166,8 @@ function watchMainFrameUrlChangeStart(
 
   const finish = (value: boolean) => {
     if (disposed) return;
+    // Latch a successful match so wait() can return immediately when a very
+    // fast navigation starts before the post-click timeout window begins.
     if (value) matched = true;
     if (waiter) {
       clearTimeout(waiter.timer);
@@ -176,6 +178,8 @@ function watchMainFrameUrlChangeStart(
   };
 
   const dispose = () => {
+    // dispose() is called from cleanup paths that can overlap, so it must be
+    // safe to run more than once.
     if (disposed) return;
     disposed = true;
     session.off("Page.frameNavigated", onFrameNavigated);
@@ -187,6 +191,8 @@ function watchMainFrameUrlChangeStart(
     }
   };
 
+  // Main-frame identity can shift during navigation. Treat both the original
+  // root frame id and the current page.mainFrameId() as authoritative.
   const isMainFrame = (frameId: string): boolean =>
     frameId === initialMainFrameId || frameId === page.mainFrameId();
 
@@ -224,6 +230,8 @@ function watchMainFrameUrlChangeStart(
         waiter = {
           resolve,
           timer: setTimeout(() => {
+            // Clear waiter before resolving so a late navigation event cannot
+            // race in and resolve the same wait() call twice.
             waiter = undefined;
             resolve(false);
           }, timeoutMs),

--- a/packages/core/lib/v3/handlers/handlerUtils/actHandlerUtils.ts
+++ b/packages/core/lib/v3/handlers/handlerUtils/actHandlerUtils.ts
@@ -77,6 +77,10 @@ export async function performUnderstudyMethod(
     args: Array.from(args),
   });
 
+  const navWatcher = shouldWaitForPostClickSettle(method)
+    ? watchMainFrameUrlChangeStart(page, page.url())
+    : null;
+
   try {
     const handler = METHOD_HANDLER_MAP[method] ?? null;
 
@@ -106,6 +110,12 @@ export async function performUnderstudyMethod(
           );
       }
     }
+    if (navWatcher && (await navWatcher.wait(400))) {
+      await waitForDomNetworkQuiet(page.mainFrame(), domSettleTimeoutMs).catch(
+        () => {},
+      );
+    }
+
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     const stack = e instanceof Error ? e.stack : undefined;
@@ -126,8 +136,96 @@ export async function performUnderstudyMethod(
     }
     throw new UnderstudyCommandException(msg, e);
   } finally {
+    navWatcher?.dispose();
     SessionFileLogger.logUnderstudyActionCompleted();
   }
+}
+
+function shouldWaitForPostClickSettle(method: string): boolean {
+  return method === "click" || method === "doubleClick";
+}
+
+function watchMainFrameUrlChangeStart(
+  page: Page,
+  initialUrl: string,
+): {
+  wait: (timeoutMs: number) => Promise<boolean>;
+  dispose: () => void;
+} {
+  const session = page.mainFrame().session;
+  const initialMainFrameId = page.mainFrameId();
+  let matched = false;
+  let disposed = false;
+  let waiter:
+    | {
+        resolve: (value: boolean) => void;
+        timer: ReturnType<typeof setTimeout>;
+      }
+    | undefined;
+
+  const finish = (value: boolean) => {
+    if (disposed) return;
+    if (value) matched = true;
+    if (waiter) {
+      clearTimeout(waiter.timer);
+      const current = waiter;
+      waiter = undefined;
+      current.resolve(value);
+    }
+  };
+
+  const dispose = () => {
+    if (disposed) return;
+    disposed = true;
+    session.off("Page.frameNavigated", onFrameNavigated);
+    session.off("Page.navigatedWithinDocument", onNavigatedWithinDocument);
+    if (waiter) {
+      clearTimeout(waiter.timer);
+      waiter.resolve(false);
+      waiter = undefined;
+    }
+  };
+
+  const isMainFrame = (frameId: string): boolean =>
+    frameId === initialMainFrameId || frameId === page.mainFrameId();
+
+  const onFrameNavigated = (event: Protocol.Page.FrameNavigatedEvent) => {
+    if (
+      isMainFrame(event.frame.id) &&
+      event.frame.url &&
+      event.frame.url !== initialUrl
+    ) {
+      finish(true);
+    }
+  };
+
+  const onNavigatedWithinDocument = (
+    event: Protocol.Page.NavigatedWithinDocumentEvent,
+  ) => {
+    if (isMainFrame(event.frameId) && event.url !== initialUrl) {
+      finish(true);
+    }
+  };
+
+  session.on("Page.frameNavigated", onFrameNavigated);
+  session.on("Page.navigatedWithinDocument", onNavigatedWithinDocument);
+
+  return {
+    wait: async (timeoutMs: number) => {
+      if (matched) return true;
+      if (disposed) return false;
+      return await new Promise<boolean>((resolve) => {
+        waiter = {
+          resolve,
+          timer: setTimeout(() => {
+            waiter = undefined;
+            resolve(false);
+          }, timeoutMs),
+        };
+      });
+    },
+    dispose,
+  };
 }
 
 /* ===================== Handlers & Map ===================== */

--- a/packages/core/lib/v3/handlers/handlerUtils/actHandlerUtils.ts
+++ b/packages/core/lib/v3/handlers/handlerUtils/actHandlerUtils.ts
@@ -77,6 +77,8 @@ export async function performUnderstudyMethod(
     args: Array.from(args),
   });
 
+  // Arm the watcher before the action so we do not miss very fast URL changes,
+  // but start the timeout window only after the click returns.
   const navWatcher = shouldWaitForPostClickSettle(method)
     ? watchMainFrameUrlChangeStart(page, page.url())
     : null;
@@ -115,7 +117,6 @@ export async function performUnderstudyMethod(
         () => {},
       );
     }
-
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     const stack = e instanceof Error ? e.stack : undefined;
@@ -189,6 +190,9 @@ function watchMainFrameUrlChangeStart(
   const isMainFrame = (frameId: string): boolean =>
     frameId === initialMainFrameId || frameId === page.mainFrameId();
 
+  // We only treat main-frame events with an actual URL change as navigation
+  // start. Real pages can emit same-URL history events that should not trigger
+  // a post-click settle wait.
   const onFrameNavigated = (event: Protocol.Page.FrameNavigatedEvent) => {
     if (
       isMainFrame(event.frame.id) &&
@@ -212,6 +216,8 @@ function watchMainFrameUrlChangeStart(
 
   return {
     wait: async (timeoutMs: number) => {
+      // If navigation started while the click was still in flight, surface that
+      // immediately instead of burning the full timeout budget after the click.
       if (matched) return true;
       if (disposed) return false;
       return await new Promise<boolean>((resolve) => {

--- a/packages/core/tests/integration/perform-understudy-navigation-race.spec.ts
+++ b/packages/core/tests/integration/perform-understudy-navigation-race.spec.ts
@@ -1,0 +1,123 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { expect, test } from "@playwright/test";
+import { V3 } from "../../lib/v3/v3.js";
+import { performUnderstudyMethod } from "../../lib/v3/handlers/handlerUtils/actHandlerUtils.js";
+import { closeV3 } from "./testUtils.js";
+import { v3DynamicTestConfig } from "./v3.dynamic.config.js";
+
+async function writeDelayedNavigationFixture(
+  outputDir: string,
+  delayMs: number,
+): Promise<{ sourceUrl: string; targetUrl: string }> {
+  const targetPath = path.join(outputDir, `target-${delayMs}.html`);
+  const sourcePath = path.join(outputDir, `source-${delayMs}.html`);
+  const targetUrl = pathToFileURL(targetPath).href;
+  const sourceUrl = pathToFileURL(sourcePath).href;
+
+  await fs.mkdir(outputDir, { recursive: true });
+  await fs.writeFile(
+    targetPath,
+    "<!DOCTYPE html><html><body><h1 id='done'>destination</h1></body></html>",
+    "utf8",
+  );
+  await fs.writeFile(
+    sourcePath,
+    `<!DOCTYPE html>
+      <html>
+        <body>
+          <button id="go" type="button">Go</button>
+          <script>
+            window.__navDelayMs = ${delayMs};
+            window.__navScheduled = false;
+            document.getElementById("go").addEventListener("click", () => {
+              window.__navScheduled = true;
+              setTimeout(() => {
+                window.location.assign(${JSON.stringify(targetUrl)});
+              }, ${delayMs});
+            });
+          </script>
+        </body>
+      </html>`,
+    "utf8",
+  );
+
+  return { sourceUrl, targetUrl };
+}
+
+test.describe("performUnderstudyMethod navigation race", () => {
+  let v3: V3;
+
+  test.beforeEach(async () => {
+    v3 = new V3(v3DynamicTestConfig);
+    await v3.init();
+  });
+
+  test.afterEach(async () => {
+    await closeV3(v3);
+  });
+
+  test("waits for navigation that starts within 400ms of click", async (
+    {},
+    testInfo,
+  ) => {
+    const page = v3.context.pages()[0];
+    const { sourceUrl, targetUrl } = await writeDelayedNavigationFixture(
+      testInfo.outputDir,
+      250,
+    );
+
+    await page.goto(sourceUrl, { waitUntil: "load" });
+
+    await performUnderstudyMethod(
+      page,
+      page.mainFrame(),
+      "click",
+      "xpath=//*[@id='go']",
+      [],
+      3_000,
+    );
+
+    expect(page.url()).toBe(targetUrl);
+  });
+
+  test("does not wait for navigation that starts after 400ms of click", async (
+    {},
+    testInfo,
+  ) => {
+    const page = v3.context.pages()[0];
+    const { sourceUrl, targetUrl } = await writeDelayedNavigationFixture(
+      testInfo.outputDir,
+      650,
+    );
+
+    await page.goto(sourceUrl, { waitUntil: "load" });
+
+    await performUnderstudyMethod(
+      page,
+      page.mainFrame(),
+      "click",
+      "xpath=//*[@id='go']",
+      [],
+      3_000,
+    );
+
+    expect(page.url()).toBe(sourceUrl);
+    expect(
+      await page.evaluate(() => {
+        return (window as typeof window & { __navScheduled?: boolean })
+          .__navScheduled;
+      }),
+    ).toBe(true);
+
+    await expect
+      .poll(
+        () => page.url(),
+        {
+          timeout: 3_000,
+        },
+      )
+      .toBe(targetUrl);
+  });
+});

--- a/packages/core/tests/integration/perform-understudy-navigation-race.spec.ts
+++ b/packages/core/tests/integration/perform-understudy-navigation-race.spec.ts
@@ -60,7 +60,10 @@ test.describe("performUnderstudyMethod navigation race", () => {
     await closeV3(v3);
   });
 
-  test("waits for navigation that starts within 400ms of click", async ({}, testInfo) => {
+  test("waits for navigation that starts within 400ms of click", async ({
+    browserName,
+  }, testInfo) => {
+    void browserName;
     const page = v3.context.pages()[0];
     const { sourceUrl, targetUrl } = await writeDelayedNavigationFixture(
       testInfo.outputDir,
@@ -81,11 +84,14 @@ test.describe("performUnderstudyMethod navigation race", () => {
     expect(page.url()).toBe(targetUrl);
   });
 
-  test("does not wait for navigation that starts after 400ms of click", async ({}, testInfo) => {
+  test("does not wait for navigation that starts after 400ms of click", async ({
+    browserName,
+  }, testInfo) => {
+    void browserName;
     const page = v3.context.pages()[0];
     const { sourceUrl, targetUrl } = await writeDelayedNavigationFixture(
       testInfo.outputDir,
-      650,
+      900,
     );
 
     await page.goto(sourceUrl, { waitUntil: "load" });

--- a/packages/core/tests/integration/perform-understudy-navigation-race.spec.ts
+++ b/packages/core/tests/integration/perform-understudy-navigation-race.spec.ts
@@ -43,6 +43,8 @@ async function writeDelayedNavigationFixture(
     "utf8",
   );
 
+  // Use file-backed pages so the navigation behaves like a normal document
+  // load, while the delay stays fully deterministic inside the fixture.
   return { sourceUrl, targetUrl };
 }
 
@@ -58,10 +60,7 @@ test.describe("performUnderstudyMethod navigation race", () => {
     await closeV3(v3);
   });
 
-  test("waits for navigation that starts within 400ms of click", async (
-    {},
-    testInfo,
-  ) => {
+  test("waits for navigation that starts within 400ms of click", async ({}, testInfo) => {
     const page = v3.context.pages()[0];
     const { sourceUrl, targetUrl } = await writeDelayedNavigationFixture(
       testInfo.outputDir,
@@ -82,10 +81,7 @@ test.describe("performUnderstudyMethod navigation race", () => {
     expect(page.url()).toBe(targetUrl);
   });
 
-  test("does not wait for navigation that starts after 400ms of click", async (
-    {},
-    testInfo,
-  ) => {
+  test("does not wait for navigation that starts after 400ms of click", async ({}, testInfo) => {
     const page = v3.context.pages()[0];
     const { sourceUrl, targetUrl } = await writeDelayedNavigationFixture(
       testInfo.outputDir,
@@ -112,12 +108,9 @@ test.describe("performUnderstudyMethod navigation race", () => {
     ).toBe(true);
 
     await expect
-      .poll(
-        () => page.url(),
-        {
-          timeout: 3_000,
-        },
-      )
+      .poll(() => page.url(), {
+        timeout: 3_000,
+      })
       .toBe(targetUrl);
   });
 });

--- a/packages/core/tests/integration/perform-understudy-navigation-race.spec.ts
+++ b/packages/core/tests/integration/perform-understudy-navigation-race.spec.ts
@@ -1,51 +1,53 @@
-import fs from "node:fs/promises";
-import path from "node:path";
-import { pathToFileURL } from "node:url";
 import { expect, test } from "@playwright/test";
 import { V3 } from "../../lib/v3/v3.js";
 import { performUnderstudyMethod } from "../../lib/v3/handlers/handlerUtils/actHandlerUtils.js";
 import { closeV3 } from "./testUtils.js";
 import { v3DynamicTestConfig } from "./v3.dynamic.config.js";
 
-async function writeDelayedNavigationFixture(
-  outputDir: string,
+async function loadDelayedDocumentNavigationFixture(
+  v3: V3,
   delayMs: number,
-): Promise<{ sourceUrl: string; targetUrl: string }> {
-  const targetPath = path.join(outputDir, `target-${delayMs}.html`);
-  const sourcePath = path.join(outputDir, `source-${delayMs}.html`);
-  const targetUrl = pathToFileURL(targetPath).href;
-  const sourceUrl = pathToFileURL(sourcePath).href;
+): Promise<{
+  page: ReturnType<V3["context"]["pages"]>[number];
+  sourceUrl: string;
+  targetUrl: string;
+}> {
+  const page = v3.context.pages()[0];
+  const sourceUrl = "https://example.com/";
+  const targetUrl = `https://example.com/?nav-race=${delayMs}`;
 
-  await fs.mkdir(outputDir, { recursive: true });
-  await fs.writeFile(
-    targetPath,
-    "<!DOCTYPE html><html><body><h1 id='done'>destination</h1></body></html>",
-    "utf8",
-  );
-  await fs.writeFile(
-    sourcePath,
-    `<!DOCTYPE html>
-      <html>
-        <body>
-          <button id="go" type="button">Go</button>
-          <script>
-            window.__navDelayMs = ${delayMs};
-            window.__navScheduled = false;
-            document.getElementById("go").addEventListener("click", () => {
-              window.__navScheduled = true;
-              setTimeout(() => {
-                window.location.assign(${JSON.stringify(targetUrl)});
-              }, ${delayMs});
-            });
-          </script>
-        </body>
-      </html>`,
-    "utf8",
+  await page.goto(sourceUrl, { waitUntil: "load" });
+
+  await page.mainFrame().evaluate(
+    ({ delay, nextUrl }) => {
+      document.open();
+      document.write(`<!DOCTYPE html>
+        <html>
+          <body>
+            <button id="go" type="button">Go</button>
+          </body>
+        </html>`);
+      document.close();
+
+      (window as typeof window & { __navScheduled?: boolean }).__navScheduled =
+        false;
+      document.getElementById("go")?.addEventListener("click", () => {
+        (
+          window as typeof window & { __navScheduled?: boolean }
+        ).__navScheduled = true;
+        setTimeout(() => {
+          window.location.assign(nextUrl);
+        }, delay);
+      });
+    },
+    { delay: delayMs, nextUrl: targetUrl },
   );
 
-  // Use file-backed pages so the navigation behaves like a normal document
-  // load, while the delay stays fully deterministic inside the fixture.
-  return { sourceUrl, targetUrl };
+  return {
+    page,
+    sourceUrl,
+    targetUrl,
+  };
 }
 
 test.describe("performUnderstudyMethod navigation race", () => {
@@ -60,23 +62,17 @@ test.describe("performUnderstudyMethod navigation race", () => {
     await closeV3(v3);
   });
 
-  test("waits for navigation that starts within 400ms of click", async ({
-    browserName,
-  }, testInfo) => {
-    void browserName;
-    const page = v3.context.pages()[0];
-    const { sourceUrl, targetUrl } = await writeDelayedNavigationFixture(
-      testInfo.outputDir,
+  test("waits for navigation that starts within 400ms of click", async () => {
+    const { page, targetUrl } = await loadDelayedDocumentNavigationFixture(
+      v3,
       250,
     );
-
-    await page.goto(sourceUrl, { waitUntil: "load" });
 
     await performUnderstudyMethod(
       page,
       page.mainFrame(),
       "click",
-      "xpath=//*[@id='go']",
+      "xpath=/html/body/button",
       [],
       3_000,
     );
@@ -84,23 +80,15 @@ test.describe("performUnderstudyMethod navigation race", () => {
     expect(page.url()).toBe(targetUrl);
   });
 
-  test("does not wait for navigation that starts after 400ms of click", async ({
-    browserName,
-  }, testInfo) => {
-    void browserName;
-    const page = v3.context.pages()[0];
-    const { sourceUrl, targetUrl } = await writeDelayedNavigationFixture(
-      testInfo.outputDir,
-      900,
-    );
-
-    await page.goto(sourceUrl, { waitUntil: "load" });
+  test("does not wait for navigation that starts after 400ms of click", async () => {
+    const { page, sourceUrl, targetUrl } =
+      await loadDelayedDocumentNavigationFixture(v3, 900);
 
     await performUnderstudyMethod(
       page,
       page.mainFrame(),
       "click",
-      "xpath=//*[@id='go']",
+      "xpath=/html/body/button",
       [],
       3_000,
     );


### PR DESCRIPTION
# why

- Currently if an `act()` call results in a navigation and we immediately call `page.url()` or `.title()` after we may still get the old page, causing the agent to think it needs to navigate again or making it think it's on the wrong page.

# what changed

- Add more in-depth logic to detect if navigation is triggered by JS within 400ms of any `act()` call, and wait until the nav settles before returning so that subsequent steps see the next page instead of the old one.

> [!IMPORTANT]
> **ALTERNATIVE IDEA (which I prefer)** would be add an arg to `act({..., expectNavigation: true | false})` and only wait for nav if `true` is passed.

# test plan

- Adds a test for the specific scenarios


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race where `page.url()`/`page.title()` could return the old page right after an `act()`-triggered navigation. We now detect main-frame navigation that starts within 400ms of a `click`/`doubleClick` and wait for it to settle before returning.

- **Bug Fixes**
  - In `performUnderstudyMethod`, arm a main-frame nav watcher before `click`/`doubleClick`; if it reports a start within 400ms after the click returns, wait for `waitForDomNetworkQuiet`.
  - Added `watchMainFrameUrlChangeStart(page, initialUrl)` to listen for `Page.frameNavigated`/`Page.navigatedWithinDocument` only on real URL changes, handle main-frame ID changes, and dispose cleanly.
  - New test `perform-understudy-navigation-race.spec.ts` verifies wait for <400ms and no wait for >400ms, using live `https://example.com` URLs.

<sup>Written for commit a6bb6ef45ac1fa17e6cf9f0459f64954fb12d1a1. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1795">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



