### PR TITLE
Add missing cdpHeaders field to v3 server openapi spec

### DIFF
--- a/packages/server/openapi.v3.yaml
+++ b/packages/server/openapi.v3.yaml
@@ -154,6 +154,12 @@ components:
           type: boolean
         cdpUrl:
           type: string
+        cdpHeaders:
+          type: object
+          propertyNames:
+            type: string
+          additionalProperties:
+            type: string
         connectTimeoutMs:
           type: number
         downloadsPath:
@@ -1137,6 +1143,12 @@ components:
           type: boolean
         cdpUrl:
           type: string
+        cdpHeaders:
+          type: object
+          propertyNames:
+            type: string
+          additionalProperties:
+            type: string
         connectTimeoutMs:
           type: number
         downloadsPath:


### PR DESCRIPTION
# why

cdpHeaders is already plumbed through packages/server correctly, it was just missing from the spec.

- packages/core/lib/v3/types/public/api.ts:15 defines cdpHeaders on LocalBrowserLaunchOptionsSchema.
- packages/server/src/routes/v1/sessions/start.ts:192 forwards browser.launchOptions with a spread into localBrowserLaunchOptions, so cdpHeaders is preserved.
- packages/server/src/lib/InMemorySessionStore.ts:240 passes localBrowserLaunchOptions straight into new V3(...).
- packages/core/lib/v3/v3.ts:750 passes lbo.cdpHeaders into V3Context.create(...).
- packages/core/lib/v3/understudy/context.ts:167 finally uses it in CdpConnection.connect(wsUrl, { headers: opts?.cdpHeaders }).

# what changed

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added the missing `cdpHeaders` field to the v3 server OpenAPI spec so clients can send custom Chrome DevTools Protocol headers. This aligns the spec with server launch options and prevents client codegen/validation errors.

<sup>Written for commit 39ee7372e2e0ae29fc52a8868675f4673a592ac6. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1797">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

