### PR TITLE
fix(CI): fix changeset reference to stale server package name blocking CI

### DIFF
--- a/.changeset/add-bedrock-provider-schema.md
+++ b/.changeset/add-bedrock-provider-schema.md
@@ -1,6 +1,6 @@
 ---
 "@browserbasehq/stagehand": patch
-"@browserbasehq/stagehand-server": patch
+"@browserbasehq/stagehand-server-v3": patch
 ---
 
 Add bedrock to the provider enum in model configuration schemas and regenerate OpenAPI spec.


### PR DESCRIPTION
# why

# what changed

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the changeset package reference from `@browserbasehq/stagehand-server` to `@browserbasehq/stagehand-server-v3` to unblock CI and ensure the correct package receives the patch release.

<sup>Written for commit 177bc48b84a442ad4e0d9f85c7dffcfc338720de. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1801">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

