### PR TITLE
make sure node auth token is provided if needed and remove potentially breaking changeset

### DIFF
--- a/.changeset/add-bedrock-provider-schema.md
+++ b/.changeset/add-bedrock-provider-schema.md
@@ -1,6 +1,0 @@
----
-"@browserbasehq/stagehand": patch
-"@browserbasehq/stagehand-server-v3": patch
----
-
-Add bedrock to the provider enum in model configuration schemas and regenerate OpenAPI spec.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
           publish: pnpm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish Canary
         if: github.ref == 'refs/heads/main'
@@ -53,3 +54,4 @@ jobs:
           pnpm run release-canary
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
# why

# what changed

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `NODE_AUTH_TOKEN` from `NPM_TOKEN` in the release and canary publish steps to fix npm auth during publishing. Also remove the stale bedrock schema changeset to avoid an unintended release.

<sup>Written for commit bdb242d0e4f68734e1aed00278d56d7f0f67e64b. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1802">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

