### PR TITLE
Make BROWSERBASE_PROJECT_ID optional in CLI

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -183,7 +183,7 @@ Behavior details:
 - `browse env <target>` persists an override and restarts the daemon
 - `browse stop` clears the override so next start falls back to env-var-based auto detection
 - Auto detection defaults to:
-  - `remote` when `BROWSERBASE_API_KEY` and `BROWSERBASE_PROJECT_ID` are set
+  - `remote` when `BROWSERBASE_API_KEY` is set
   - `local` otherwise
 
 ## Global Options
@@ -202,7 +202,7 @@ Behavior details:
 |----------|-------------|
 | `BROWSE_SESSION` | Default session name (alternative to `--session`) |
 | `BROWSERBASE_API_KEY` | Browserbase API key (required for `browse env remote`) |
-| `BROWSERBASE_PROJECT_ID` | Browserbase project ID (required for `browse env remote`) |
+| `BROWSERBASE_PROJECT_ID` | Browserbase project ID (optional, passed through if set) |
 
 ## Element References
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -145,15 +145,13 @@ function getModeOverridePath(session: string): string {
 type BrowseMode = "browserbase" | "local";
 
 function hasBrowserbaseCredentials(): boolean {
-  return Boolean(
-    process.env.BROWSERBASE_API_KEY && process.env.BROWSERBASE_PROJECT_ID,
-  );
+  return Boolean(process.env.BROWSERBASE_API_KEY);
 }
 
 function assertModeSupported(mode: BrowseMode): void {
   if (mode === "browserbase" && !hasBrowserbaseCredentials()) {
     throw new Error(
-      "Remote mode requires BROWSERBASE_API_KEY and BROWSERBASE_PROJECT_ID. Set both env vars or run `browse env local`.",
+      "Remote mode requires BROWSERBASE_API_KEY. Set the env var or run `browse env local`.",
     );
   }
 }

--- a/packages/cli/tests/mode.test.ts
+++ b/packages/cli/tests/mode.test.ts
@@ -88,12 +88,11 @@ describe("Browse CLI env command", () => {
       env: {
         ...process.env,
         BROWSERBASE_API_KEY: "",
-        BROWSERBASE_PROJECT_ID: "",
       },
     });
     expect(result.exitCode).not.toBe(0);
     expect(result.stderr).toContain(
-      "Remote mode requires BROWSERBASE_API_KEY and BROWSERBASE_PROJECT_ID",
+      "Remote mode requires BROWSERBASE_API_KEY",
     );
   });
 });


### PR DESCRIPTION
## Summary
- Stacked on #1800
- Only `BROWSERBASE_API_KEY` is required for remote mode in the CLI
- `BROWSERBASE_PROJECT_ID` is still passed through if set, but no longer checked

## Changes
- `packages/cli/src/index.ts` — `hasBrowserbaseCredentials()` only checks for API key
- `packages/cli/tests/mode.test.ts` — Updated test to match new error message
- `packages/cli/README.md` — Updated docs to reflect optional project ID

## Test plan
- [x] Existing mode test updated
- [x] Manual: `browse env remote` with only `BROWSERBASE_API_KEY` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `BROWSERBASE_PROJECT_ID` optional in the CLI for remote mode, so only `BROWSERBASE_API_KEY` is required. The project ID is still forwarded when provided.

- **Bug Fixes**
  - Updated remote mode check and error message to only require `BROWSERBASE_API_KEY`.
  - Autodetection now defaults to `remote` when the API key is set; otherwise `local`.
  - Updated tests and `@browserbasehq/browse-cli` README to match.

<sup>Written for commit 99eb1869225948dc8f9a868c27a7bf0c3a47367d. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1803">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->