### PR TITLE
fix: use provided value in fillForm instead of LLM-hallucinated arguments

### DIFF
--- a/packages/core/lib/v3/agent/tools/fillform.ts
+++ b/packages/core/lib/v3/agent/tools/fillform.ts
@@ -56,13 +56,23 @@ export const fillFormTool = (
 
         const completed = [] as unknown[];
         const replayableActions: Action[] = [];
+        // Only apply index-based value overrides when observe returned
+        // the same number of results as caller-provided fields.
+        // This avoids misassigning values when the counts diverge.
+        const canMapByIndex = observeResults.length === fields.length;
         for (let i = 0; i < observeResults.length; i++) {
           const res = observeResults[i];
 
           // Override LLM-hallucinated arguments with the actual value
           // provided by the caller to prevent placeholder values like
           // "test@example.com" from being typed instead of real input.
-          if (res.method === "fill" && fields[i]?.value) {
+          // Use != null so that empty-string values ("") are preserved
+          // as valid input rather than being dropped by a truthy check.
+          if (
+            canMapByIndex &&
+            res.method === "fill" &&
+            fields[i]?.value != null
+          ) {
             res.arguments = [fields[i].value];
           }
 


### PR DESCRIPTION
## Summary

Fixes #1789 — The `fillForm` tool now uses the actual `value` parameter instead of LLM-hallucinated placeholder values.

### Problem

The `fillForm` tool receives `{ action, value }` for each field, but only passes `action` to `observe()`. The LLM then hallucinates placeholder values like `test@example.com` in the observe results, which get typed into form fields instead of the real values.

```
// Agent correctly parses: value = "tiwa@trysplendor.com"
// But observe() returns:  arguments = ["test@example.com"]  ← hallucinated
```

This breaks login forms, 2FA flows, search queries, and any workflow where specific values matter.

### Fix

After `observe()` returns results, override the `arguments` array with the actual `value` from the `fields` parameter when `method === "fill"`:

```typescript
if (res.method === "fill" && fields[i]?.value) {
  res.arguments = [fields[i].value];
}
```

### Changes

| File | Change |
|------|--------|
| `packages/core/lib/v3/agent/tools/fillform.ts` | Override observe result arguments with caller-provided values (+10/-1) |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`fillForm` now uses the caller-provided `value` for each field instead of hallucinated placeholders from `observe()`. Preserves empty-string inputs and prevents wrong values in login, 2FA, and search. Fixes #1789.

- **Bug Fixes**
  - When method is "fill", override `observe()` arguments with `fields[i].value` using `!= null` checks.
  - Apply index-based overrides only when `observeResults.length === fields.length` to avoid misassignment.

<sup>Written for commit 7db7b4fc886278dd56ed3d0b38527dd99ac22505. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1805">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

