### PR TITLE
Force re-run checks on claimed external contributor PRs so they get the secrets

### DIFF
--- a/.github/workflows/external-contributor-pr.yml
+++ b/.github/workflows/external-contributor-pr.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   actions: read
+  checks: write
   contents: write
   pull-requests: write
   issues: write
@@ -83,6 +84,39 @@ env:
         if (!branch) return fallback;
         const allowed = new RegExp(`^external-contributor-pr-${prNumber}(?:-[A-Za-z0-9._-]+)?$`);
         return allowed.test(branch) ? branch : fallback;
+      }
+
+      function sleep(ms) {
+        return new Promise((resolve) => setTimeout(resolve, ms));
+      }
+
+      async function rerequestCheckSuites(github, context, ref) {
+        for (let attempt = 0; attempt < 6; attempt += 1) {
+          const { data } = await github.request('GET /repos/{owner}/{repo}/commits/{ref}/check-suites', {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            ref,
+            per_page: 100,
+          });
+          const suites = data.check_suites || [];
+          if (!suites.length) {
+            if (attempt < 5) await sleep(5000);
+            continue;
+          }
+
+          for (const suite of suites) {
+            try {
+              await github.request('POST /repos/{owner}/{repo}/check-suites/{check_suite_id}/rerequest', {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                check_suite_id: suite.id,
+              });
+            } catch (error) {
+              if (error.status !== 403 && error.status !== 422) throw error;
+            }
+          }
+          return;
+        }
       }
 
       async function upsertComment(github, context, issueNumber, marker, lines) {
@@ -255,6 +289,7 @@ env:
 
         core.setOutput('should-claim', 'true');
         core.setOutput('claimer', handoff.reviewer);
+        core.setOutput('source-author', pr.user.login);
         core.setOutput('pr-number', String(pr.number));
         core.setOutput('source-sha', pr.head.sha);
         core.setOutput('previous-source-sha', latestClaim?.sourceSha || '');
@@ -278,6 +313,7 @@ env:
           existingMerged,
           refreshStatus,
           refreshReason,
+          sourceAuthor,
         } = input;
 
         if (refreshStatus !== 'updated') {
@@ -324,12 +360,18 @@ env:
           ownedPr = data;
         }
 
-        await github.rest.issues.addAssignees({
-          owner: context.repo.owner,
-          repo: context.repo.repo,
-          issue_number: ownedPr.number,
-          assignees: [claimer],
-        });
+        for (const assignee of [...new Set([claimer, sourceAuthor].filter(Boolean))]) {
+          try {
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ownedPr.number,
+              assignees: [assignee],
+            });
+          } catch (error) {
+            if (error.status !== 422) throw error;
+          }
+        }
         await syncLabels(github, context, prNumber, ['external-contributor', 'external-contributor:mirrored']);
         await syncLabels(github, context, ownedPr.number, ['external-contributor', 'external-contributor:mirrored']);
         await upsertComment(github, context, ownedPr.number, '<!-- external-contributor-pr:owned-status -->', [
@@ -338,10 +380,11 @@ env:
           '',
           'When the external PR gets new commits, this same internal PR will be refreshed in place after the latest external commit is approved.',
         ]);
+        await rerequestCheckSuites(github, context, branch);
 
         const marker = `<!-- external-contributor-pr:claim owned-pr=${ownedPr.number} source-sha=${sourceSha} claimer=${claimer} branch=${branch} -->`;
         const comments = await listComments(github, context, prNumber);
-        if (!comments.some((comment) => comment.body?.includes(marker))) {
+        if (!comments.some((comment) => isManagedComment(comment) && comment.body?.includes(marker))) {
           await github.rest.issues.createComment({
             owner: context.repo.owner,
             repo: context.repo.repo,
@@ -576,6 +619,7 @@ jobs:
                 sourceSha: ${{ toJson(steps.prepare-claim.outputs.source-sha) }},
                 branch: ${{ toJson(steps.prepare-claim.outputs.branch) }},
                 claimer: ${{ toJson(steps.prepare-claim.outputs.claimer) }},
+                sourceAuthor: ${{ toJson(steps.prepare-claim.outputs.source-author) }},
                 title: ${{ toJson(steps.prepare-claim.outputs.title) }},
                 body: ${{ toJson(steps.prepare-claim.outputs.body) }},
                 existingNumber: ${{ toJson(steps.prepare-claim.outputs.owned-pr-number) }},


### PR DESCRIPTION
# why

# what changed

# test plan

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure CI on claimed external contributor PRs runs with secrets by re-running all check suites on the mirrored internal branch. The workflow now keeps a single mirrored PR and refreshes it in place when new commits land.

- **New Features**
  - Force re-run of check suites on the internal branch after a claim using the Checks API (requires `checks: write` and `actions: write`).
  - Keep the mirrored PR open and mark it as stale when the external PR gets new commits; refresh in place after a new approval.
  - Clear status/comment updates on both external and mirrored PRs; consistent labels: `external-contributor:*`.
  - Auto-assign the claimer and the external author to the mirrored PR (best-effort).

- **Refactors**
  - Consolidated logic into an embedded library (`ECPR_LIB`) for labels, comments, claiming, refresh, and owned PR sync.
  - Safer branch refresh: fetch external head, rebase onto previous approved SHA, push with `--force-with-lease`, with explicit failure reasons.
  - Workflow hardening: upgraded to `actions/checkout@v6`, added `checks: write`, expanded allowed tools for `anthropics/claude-code-action@v1`, enabled `track_progress`, and added Node setup with `pnpm`/`turbo` to run `turbo run build` in `claude.yml`.
  - Avoid duplicate claim comments by checking only managed comments; ignore 422 when assigning users.

<sup>Written for commit d10e1a568a8bbc60ff4cf12cde180910aabb1937. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1815">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

