### PR TITLE
Add support for passing custom headers in clientOptions

### DIFF
--- a/.changeset/yellow-cups-swim.md
+++ b/.changeset/yellow-cups-swim.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Add support for passing custom headers in clientOptions

--- a/packages/core/lib/v3/types/public/model.ts
+++ b/packages/core/lib/v3/types/public/model.ts
@@ -114,6 +114,8 @@ export type ClientOptions = (
   maxImages?: number;
   /** Temperature for model inference */
   temperature?: number;
+  /** Custom headers sent with every request to the provider */
+  headers?: Record<string, string>;
 };
 
 export type ModelConfiguration =


### PR DESCRIPTION
# why

Allow users to pass custom headers in their LLM calls

# what changed

Add headers to the model.ts types 

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `headers` support to `ClientOptions` so clients can send custom HTTP headers with every provider request. Useful for auth tokens or routing hints without changing global config.

- **New Features**
  - Added `headers?: Record<string, string>` to `ClientOptions` in `packages/core/lib/v3/types/public/model.ts`; headers are sent with each request.
  - No breaking changes; default behavior is unchanged.

<sup>Written for commit 424dc1af74da82364f752f3976182f8aafc3f6ed. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1817">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

