### PR TITLE
STG-1443 Add section in docs for baseUrl

### DIFF
--- a/packages/core/lib/v3/types/public/api.ts
+++ b/packages/core/lib/v3/types/public/api.ts
@@ -289,7 +289,11 @@ export const BrowserbaseSessionCreateParamsSchema = z
     extensionId: z.string().optional(),
     keepAlive: z.boolean().optional(),
     proxies: z.union([z.boolean(), z.array(ProxyConfigSchema)]).optional(),
-    region: BrowserbaseRegionSchema.optional(),
+    region: BrowserbaseRegionSchema.optional().meta({
+      description:
+        "Deprecated. On hosted Stagehand API, the Browserbase session region is determined by the Stagehand API base URL you call. Prefer selecting the regional endpoint via the SDK client's baseUrl.",
+      example: "eu-central-1",
+    }),
     timeout: z.number().optional(),
     userMetadata: z.record(z.string(), z.unknown()).optional(),
   })

--- a/packages/docs/v3/sdk/go.mdx
+++ b/packages/docs/v3/sdk/go.mdx
@@ -238,10 +238,10 @@ client := stagehand.NewClient(
 )
 ```
 
-For hosted Stagehand API, prefer selecting the regional endpoint with `baseUrl`.
-`browserbaseSessionCreateParams.region` is retained for compatibility, but the
-hosted API determines the actual browser region from the Stagehand API endpoint
-you call.
+For hosted Stagehand API, prefer selecting the regional endpoint with `option.WithBaseURL()`.
+The request-level `region` field is retained for compatibility, but the hosted
+API determines the actual browser region from the Stagehand API endpoint you
+call.
 
 ### Request fields
 

--- a/packages/docs/v3/sdk/go.mdx
+++ b/packages/docs/v3/sdk/go.mdx
@@ -225,6 +225,24 @@ go run examples/basic.go
 
 The example demonstrates the full Stagehand workflow: starting a session, navigating to a page, observing actions, clicking elements, extracting data, and running an autonomous agent.
 
+## Client configuration
+
+Use `option.WithBaseURL()` to select the Stagehand API region:
+
+```go
+client := stagehand.NewClient(
+	option.WithBrowserbaseAPIKey("My Browserbase API Key"),
+	option.WithBrowserbaseProjectID("My Browserbase Project ID"),
+	option.WithModelAPIKey("My Model API Key"),
+	option.WithBaseURL("https://api.euc1.stagehand.browserbase.com"),
+)
+```
+
+For hosted Stagehand API, prefer selecting the regional endpoint with `baseUrl`.
+`browserbaseSessionCreateParams.region` is retained for compatibility, but the
+hosted API determines the actual browser region from the Stagehand API endpoint
+you call.
+
 ### Request fields
 
 The stagehand library uses the [`omitzero`](https://tip.golang.org/doc/go1.24#encodingjsonpkgencodingjson)

--- a/packages/docs/v3/sdk/java.mdx
+++ b/packages/docs/v3/sdk/java.mdx
@@ -266,9 +266,9 @@ StagehandClient client = StagehandOkHttpClient.builder()
 ```
 
 For hosted Stagehand API, prefer selecting the regional endpoint with `baseUrl`.
-`browserbaseSessionCreateParams.region` is retained for compatibility, but the
-hosted API determines the actual browser region from the Stagehand API endpoint
-you call.
+The request-level `region` field is retained for compatibility, but the hosted
+API determines the actual browser region from the Stagehand API endpoint you
+call.
 
 > [!TIP]
 > Don't create more than one client in the same application. Each client has a connection pool and

--- a/packages/docs/v3/sdk/java.mdx
+++ b/packages/docs/v3/sdk/java.mdx
@@ -251,6 +251,25 @@ See this table for the available options:
 
 System properties take precedence over environment variables.
 
+Use `baseUrl` to select the Stagehand API region:
+
+```java
+import com.browserbase.api.client.StagehandClient;
+import com.browserbase.api.client.okhttp.StagehandOkHttpClient;
+
+StagehandClient client = StagehandOkHttpClient.builder()
+    .browserbaseApiKey("My Browserbase API Key")
+    .browserbaseProjectId("My Browserbase Project ID")
+    .modelApiKey("My Model API Key")
+    .baseUrl("https://api.euc1.stagehand.browserbase.com")
+    .build();
+```
+
+For hosted Stagehand API, prefer selecting the regional endpoint with `baseUrl`.
+`browserbaseSessionCreateParams.region` is retained for compatibility, but the
+hosted API determines the actual browser region from the Stagehand API endpoint
+you call.
+
 > [!TIP]
 > Don't create more than one client in the same application. Each client has a connection pool and
 > thread pools, which are more efficient to share between requests.

--- a/packages/docs/v3/sdk/python.mdx
+++ b/packages/docs/v3/sdk/python.mdx
@@ -242,9 +242,9 @@ client = AsyncStagehand(
 ```
 
 For hosted Stagehand API, prefer selecting the regional endpoint with `base_url`.
-`browserbaseSessionCreateParams.region` is retained for compatibility, but the
-hosted API determines the actual browser region from the Stagehand API endpoint
-you call.
+The request-level `region` field is retained for compatibility, but the hosted
+API determines the actual browser region from the Stagehand API endpoint you
+call.
 
 > [!TIP]
 > Don't create more than one client in the same application. Each client has a connection pool, which is more efficient to share between requests.

--- a/packages/docs/v3/sdk/python.mdx
+++ b/packages/docs/v3/sdk/python.mdx
@@ -228,6 +228,24 @@ See this table for the available options:
 
 Keyword arguments take precedence over environment variables.
 
+Use `base_url` to select the Stagehand API region:
+
+```python
+from stagehand import AsyncStagehand
+
+client = AsyncStagehand(
+    browserbase_api_key="My Browserbase API Key",
+    browserbase_project_id="My Browserbase Project ID",
+    model_api_key="My Model API Key",
+    base_url="https://api.euc1.stagehand.browserbase.com",
+)
+```
+
+For hosted Stagehand API, prefer selecting the regional endpoint with `base_url`.
+`browserbaseSessionCreateParams.region` is retained for compatibility, but the
+hosted API determines the actual browser region from the Stagehand API endpoint
+you call.
+
 > [!TIP]
 > Don't create more than one client in the same application. Each client has a connection pool, which is more efficient to share between requests.
 

--- a/packages/docs/v3/sdk/ruby.mdx
+++ b/packages/docs/v3/sdk/ruby.mdx
@@ -160,9 +160,9 @@ client = Stagehand::Client.new(
 ```
 
 For hosted Stagehand API, prefer selecting the regional endpoint with `base_url`.
-`browserbaseSessionCreateParams.region` is retained for compatibility, but the
-hosted API determines the actual browser region from the Stagehand API endpoint
-you call.
+The request-level `region` field is retained for compatibility, but the hosted
+API determines the actual browser region from the Stagehand API endpoint you
+call.
 
 ### Streaming
 

--- a/packages/docs/v3/sdk/ruby.mdx
+++ b/packages/docs/v3/sdk/ruby.mdx
@@ -146,6 +146,24 @@ bundle install
 bundle exec ruby examples/basic.rb
 ```
 
+### Client configuration
+
+Use `base_url` to select the Stagehand API region:
+
+```ruby
+client = Stagehand::Client.new(
+  browserbase_api_key: "My Browserbase API Key",
+  browserbase_project_id: "My Browserbase Project ID",
+  model_api_key: "My Model API Key",
+  base_url: "https://api.euc1.stagehand.browserbase.com"
+)
+```
+
+For hosted Stagehand API, prefer selecting the regional endpoint with `base_url`.
+`browserbaseSessionCreateParams.region` is retained for compatibility, but the
+hosted API determines the actual browser region from the Stagehand API endpoint
+you call.
+
 ### Streaming
 
 We provide support for streaming responses using Server-Sent Events (SSE).

--- a/packages/server-v3/openapi.v3.yaml
+++ b/packages/server-v3/openapi.v3.yaml
@@ -398,6 +398,10 @@ components:
               items:
                 $ref: "#/components/schemas/ProxyConfig"
         region:
+          description: Deprecated. On hosted Stagehand API, the Browserbase session region
+            is determined by the Stagehand API base URL you call. Prefer
+            selecting the regional endpoint via the SDK client's baseUrl.
+          example: eu-central-1
           $ref: "#/components/schemas/BrowserbaseRegion"
         timeout:
           type: number
@@ -1398,6 +1402,10 @@ components:
               items:
                 $ref: "#/components/schemas/ProxyConfigOutput"
         region:
+          description: Deprecated. On hosted Stagehand API, the Browserbase session region
+            is determined by the Stagehand API base URL you call. Prefer
+            selecting the regional endpoint via the SDK client's baseUrl.
+          example: eu-central-1
           $ref: "#/components/schemas/BrowserbaseRegion"
         timeout:
           type: number
@@ -2151,6 +2159,13 @@ paths:
                 $ref: "#/components/schemas/AgentExecuteResponse"
 servers:
   - url: https://api.stagehand.browserbase.com
+    description: Default us-west-2 Stagehand API endpoint
+  - url: https://api.use1.stagehand.browserbase.com
+    description: us-east-1 Stagehand API endpoint
+  - url: https://api.euc1.stagehand.browserbase.com
+    description: eu-central-1 Stagehand API endpoint
+  - url: https://api.apse1.stagehand.browserbase.com
+    description: ap-southeast-1 Stagehand API endpoint
 security:
   - BrowserbaseApiKey: []
     BrowserbaseProjectId: []

--- a/packages/server-v3/scripts/gen-openapi.ts
+++ b/packages/server-v3/scripts/gen-openapi.ts
@@ -136,6 +136,19 @@ Please try it and give us your feedback, stay tuned for upcoming release announc
       servers: [
         {
           url: "https://api.stagehand.browserbase.com",
+          description: "Default us-west-2 Stagehand API endpoint",
+        },
+        {
+          url: "https://api.use1.stagehand.browserbase.com",
+          description: "us-east-1 Stagehand API endpoint",
+        },
+        {
+          url: "https://api.euc1.stagehand.browserbase.com",
+          description: "eu-central-1 Stagehand API endpoint",
+        },
+        {
+          url: "https://api.apse1.stagehand.browserbase.com",
+          description: "ap-southeast-1 Stagehand API endpoint",
         },
       ],
       components: {

--- a/packages/server-v4/openapi.v4.yaml
+++ b/packages/server-v4/openapi.v4.yaml
@@ -398,6 +398,10 @@ components:
               items:
                 $ref: "#/components/schemas/ProxyConfig"
         region:
+          description: Deprecated. On hosted Stagehand API, the Browserbase session region
+            is determined by the Stagehand API base URL you call. Prefer
+            selecting the regional endpoint via the SDK client's baseUrl.
+          example: eu-central-1
           $ref: "#/components/schemas/BrowserbaseRegion"
         timeout:
           type: number
@@ -1398,6 +1402,10 @@ components:
               items:
                 $ref: "#/components/schemas/ProxyConfigOutput"
         region:
+          description: Deprecated. On hosted Stagehand API, the Browserbase session region
+            is determined by the Stagehand API base URL you call. Prefer
+            selecting the regional endpoint via the SDK client's baseUrl.
+          example: eu-central-1
           $ref: "#/components/schemas/BrowserbaseRegion"
         timeout:
           type: number
@@ -2151,6 +2159,13 @@ paths:
                 $ref: "#/components/schemas/AgentExecuteResponse"
 servers:
   - url: https://api.stagehand.browserbase.com
+    description: Default us-west-2 Stagehand API endpoint
+  - url: https://api.use1.stagehand.browserbase.com
+    description: us-east-1 Stagehand API endpoint
+  - url: https://api.euc1.stagehand.browserbase.com
+    description: eu-central-1 Stagehand API endpoint
+  - url: https://api.apse1.stagehand.browserbase.com
+    description: ap-southeast-1 Stagehand API endpoint
 security:
   - BrowserbaseApiKey: []
     BrowserbaseProjectId: []

--- a/packages/server-v4/scripts/gen-openapi.ts
+++ b/packages/server-v4/scripts/gen-openapi.ts
@@ -136,6 +136,19 @@ Please try it and give us your feedback, stay tuned for upcoming release announc
       servers: [
         {
           url: "https://api.stagehand.browserbase.com",
+          description: "Default us-west-2 Stagehand API endpoint",
+        },
+        {
+          url: "https://api.use1.stagehand.browserbase.com",
+          description: "us-east-1 Stagehand API endpoint",
+        },
+        {
+          url: "https://api.euc1.stagehand.browserbase.com",
+          description: "eu-central-1 Stagehand API endpoint",
+        },
+        {
+          url: "https://api.apse1.stagehand.browserbase.com",
+          description: "ap-southeast-1 Stagehand API endpoint",
         },
       ],
       components: {

--- a/stainless.yml
+++ b/stainless.yml
@@ -79,9 +79,6 @@ targets:
 # "production") to the corresponding url to use.
 environments:
   production: https://api.stagehand.browserbase.com
-  us_east_1: https://api.use1.stagehand.browserbase.com
-  eu_central_1: https://api.euc1.stagehand.browserbase.com
-  ap_southeast_1: https://api.apse1.stagehand.browserbase.com
   # dev: https://api.stagehand.dev.browserbase.com
   # local: http://stagehand-api.localhost
 

--- a/stainless.yml
+++ b/stainless.yml
@@ -79,6 +79,9 @@ targets:
 # "production") to the corresponding url to use.
 environments:
   production: https://api.stagehand.browserbase.com
+  us_east_1: https://api.use1.stagehand.browserbase.com
+  eu_central_1: https://api.euc1.stagehand.browserbase.com
+  ap_southeast_1: https://api.apse1.stagehand.browserbase.com
   # dev: https://api.stagehand.dev.browserbase.com
   # local: http://stagehand-api.localhost
 
@@ -153,6 +156,18 @@ openapi:
         target: "$.components.schemas.StreamEventSystemDataOutput.properties.result"
         value:
           x-stainless-any: true
+    - command: merge
+      reason: Mark hosted-region compatibility field as deprecated
+      args:
+        target: "$.components.schemas.BrowserbaseSessionCreateParams.properties.region"
+        value:
+          deprecated: true
+    - command: merge
+      reason: Mark hosted-region compatibility field as deprecated
+      args:
+        target: "$.components.schemas.BrowserbaseSessionCreateParamsOutput.properties.region"
+        value:
+          deprecated: true
 
 # `resources` define the structure and organization for your API, such as how
 # methods and models are grouped together and accessed. See the [configuration


### PR DESCRIPTION
## What
Add clearer documentation for using `baseUrl` / `base_url` to select a regional Stagehand API endpoint in generated SDK docs. Also mark `browserbaseSessionCreateParams.region` as deprecated in the generated spec/docs.

Note that our bugbots are complaining about not using zod meta for `deprecated` field but they are inaccurate - I tried this.

## Why
For hosted Stagehand, the API endpoint the client calls is what determines the pod region. In the hosted server, any client-provided `browserbaseSessionCreateParams.region` is overridden to the API instance's `AWS_REGION`, so `baseUrl` is the correct user-facing mechanism to document.

## Testing
- validated local Mintlify preview against the local v3 OpenAPI spec