### PR TITLE
[chore]: only release alpha when changeset present

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,25 +46,28 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Check for stagehand changesets
+      - name: Check for stagehand changesets in this push
         id: check_changesets
         run: |
           set -euo pipefail
-          rm -f changeset-status.json
-          pnpm changeset status --output changeset-status.json || true
-          node <<'NODE'
-          const fs = require('fs');
-          if (!fs.existsSync('changeset-status.json')) {
-            fs.appendFileSync(process.env.GITHUB_OUTPUT, 'has_changesets=false\n');
-            process.exit(0);
-          }
-          const status = JSON.parse(fs.readFileSync('changeset-status.json', 'utf8'));
-          const changesets = Array.isArray(status.changesets) ? status.changesets : [];
-          const hasStagehand = changesets.some((cs) =>
-            (cs.releases || []).some((r) => r?.name === '@browserbasehq/stagehand')
-          );
-          fs.appendFileSync(process.env.GITHUB_OUTPUT, `has_changesets=${hasStagehand}\n`);
-          NODE
+
+          # Get changeset files added/modified in this push only
+          new_changesets=$(git diff --name-only --diff-filter=AM ${{ github.event.before }} ${{ github.sha }} -- '.changeset/*.md' | grep -v README.md || true)
+
+          if [ -z "$new_changesets" ]; then
+            echo "has_changesets=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Check if any of the new changesets reference @browserbasehq/stagehand
+          has_stagehand=false
+          for file in $new_changesets; do
+            if grep -q '"@browserbasehq/stagehand"' "$file"; then
+              has_stagehand=true
+              break
+            fi
+          done
+          echo "has_changesets=$has_stagehand" >> $GITHUB_OUTPUT
 
       - name: Publish Canary
         if: github.ref == 'refs/heads/main' && steps.check_changesets.outputs.has_changesets == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,8 +46,28 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Check for stagehand changesets
+        id: check_changesets
+        run: |
+          set -euo pipefail
+          rm -f changeset-status.json
+          pnpm changeset status --output changeset-status.json || true
+          node <<'NODE'
+          const fs = require('fs');
+          if (!fs.existsSync('changeset-status.json')) {
+            fs.appendFileSync(process.env.GITHUB_OUTPUT, 'has_changesets=false\n');
+            process.exit(0);
+          }
+          const status = JSON.parse(fs.readFileSync('changeset-status.json', 'utf8'));
+          const changesets = Array.isArray(status.changesets) ? status.changesets : [];
+          const hasStagehand = changesets.some((cs) =>
+            (cs.releases || []).some((r) => r?.name === '@browserbasehq/stagehand')
+          );
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `has_changesets=${hasStagehand}\n`);
+          NODE
+
       - name: Publish Canary
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && steps.check_changesets.outputs.has_changesets == 'true'
         run: |
           git checkout main
           pnpm run release-canary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,12 +46,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Check for stagehand changesets in this push
+      - name: Check for npm-published package changesets in this push
         id: check_changesets
         run: |
           set -euo pipefail
 
-          # Get changeset files added/modified in this push only
+          # Only look at changeset files added/modified in this push.
+          # || true because grep -v exits 1 when there are no matches (i.e. no new changesets).
           new_changesets=$(git diff --name-only --diff-filter=AM ${{ github.event.before }} ${{ github.sha }} -- '.changeset/*.md' | grep -v README.md || true)
 
           if [ -z "$new_changesets" ]; then
@@ -59,15 +60,16 @@ jobs:
             exit 0
           fi
 
-          # Check if any of the new changesets reference @browserbasehq/stagehand
-          has_stagehand=false
+          # Check if any new changesets reference our npm-published packages.
+          # Private packages (server-v3, server-v4) have their own release workflows.
+          has_publishable=false
           for file in $new_changesets; do
-            if grep -q '"@browserbasehq/stagehand"' "$file"; then
-              has_stagehand=true
+            if grep -qE '"@browserbasehq/stagehand"|"@browserbasehq/browse-cli"' "$file"; then
+              has_publishable=true
               break
             fi
           done
-          echo "has_changesets=$has_stagehand" >> $GITHUB_OUTPUT
+          echo "has_changesets=$has_publishable" >> $GITHUB_OUTPUT
 
       - name: Publish Canary
         if: github.ref == 'refs/heads/main' && steps.check_changesets.outputs.has_changesets == 'true'


### PR DESCRIPTION
# why
- so that we don't release an alpha versions for merges to main without a changeset
# what changed
- added a step in `release.yml` to check for a changeset in the stagehand package. if one exists, it will publish an alpha version. otherwise, it wont publish

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Only publish canary (alpha) on main when this push adds a changeset for `@browserbasehq/stagehand` or `@browserbasehq/browse-cli`. Adds a step in `.github/workflows/release.yml` to scan new `.changeset/*.md` files in the push and gate the publish step, aligning with STG-1583.

<sup>Written for commit 242e26630b2d9d689ba3cde47bd535557fac9947. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1826">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

