### PR TITLE
Rename server package to server-v3

### DIFF
--- a/packages/server-v3/scripts/build-sea.ts
+++ b/packages/server-v3/scripts/build-sea.ts
@@ -200,7 +200,7 @@ const resolveNodeBinary = async (): Promise<string> => {
   if (fs.existsSync(binaryPath)) {
     if (!hasSeaFuse(binaryPath)) {
       throw new Error(
-        `Node binary at ${binaryPath} does not include ${seaFuse}; unable to build SEA binary.`,
+        `Node binary at ${binaryPath} does not include ${seaFuse}; unable to build SEA binary. Delete ${tmpRoot} and retry.`,
       );
     }
     return binaryPath;
@@ -229,7 +229,7 @@ const resolveNodeBinary = async (): Promise<string> => {
   }
   if (!hasSeaFuse(binaryPath)) {
     throw new Error(
-      `Node binary at ${binaryPath} does not include ${seaFuse}; unable to build SEA binary.`,
+      `Node binary at ${binaryPath} does not include ${seaFuse}; unable to build SEA binary. Delete ${tmpRoot} and retry.`,
     );
   }
   return binaryPath;


### PR DESCRIPTION
# why
Nick's PR had both some server-v3 changes and server-v4 changes. I split it into two prs - just the v3 changes here, and just the v4 changes [here](https://github.com/browserbase/stagehand/pull/1840) (WIP).

Then, once I rebased this PR, it's really just one small change to the node SEA binary stuff.

# test plan
Verified the split with exact file manifests before creating the branch and ran `pnpm install --lockfile-only --ignore-scripts`. 




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the Stagehand server to `packages/server-v3` and `@browserbasehq/stagehand-server-v3`. Updated CI, release, tests, and SEA build logic; no API or runtime changes.

- **Refactors**
  - Moved `packages/server` to `packages/server-v3` and renamed the package to `@browserbasehq/stagehand-server-v3`.
  - Updated GitHub workflows (CI, SEA build, release) and artifacts to `stagehand-server-v3-*`.
  - Switched OpenAPI/Stainless references to `packages/server-v3/openapi.v3.yaml`.
  - Updated test discovery/commands and Turbo tasks to target `@browserbasehq/stagehand-server-v3`; adjusted ESLint, workspace, and scripts accordingly.
  - Hardened SEA build: verify Node binary includes the required fuse, fall back to the official Node distro when needed, enforce fuse presence, use `stagehand-server-v3-sea` temp paths, centralize the fuse value, and add a clear cache recovery hint when the cached Node binary lacks the fuse.

- **Migration**
  - Use `@browserbasehq/stagehand-server-v3` in `pnpm`/Turbo filters and scripts.
  - Run local tasks from `packages/server-v3`.
  - For SEA builds/tests, use binaries named `stagehand-server-v3-<platform>-<arch>` and set `SEA_BINARY_NAME` if needed.

<sup>Written for commit 645a2e6a83b40f271314cac31da41632f7eb7abf. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1839">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->





