### PR TITLE
[docs]: add docs for `page.setExtraHTTPHeaders()`

### DIFF
--- a/packages/docs/v3/references/page.mdx
+++ b/packages/docs/v3/references/page.mdx
@@ -431,6 +431,47 @@ console.log("Math.random() returned:", result);
 // Math.random() returned: 42
 ```
 
+## HTTP Headers
+
+### setExtraHTTPHeaders()
+
+Set HTTP headers that will be included in every request made by this page.
+
+```typescript
+await page.setExtraHTTPHeaders(headers: Record<string, string>): Promise<void>
+```
+
+<ParamField path="headers" type="Record<string, string>" required>
+  A plain object of header name–value pairs. All values must be strings.
+</ParamField>
+
+This method:
+- Applies the headers to the page's main CDP session and all of its child sessions (e.g. out-of-process iframes)
+- Automatically applies the same headers to any child sessions adopted after calling `setExtraHTTPHeaders()`
+- Calling it again replaces all previously set extra headers (it does not merge)
+- To clear all extra headers, pass an empty object: `await page.setExtraHTTPHeaders({})`
+
+<Note>
+Headers set via `page.setExtraHTTPHeaders()` are page-scoped. They apply to every network request from this page only, including navigation requests, XHR/fetch calls, and subresource loads. Use [`context.setExtraHTTPHeaders()`](/v3/references/context#setextrahttpheaders) to set headers across all pages in the context.
+</Note>
+
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const stagehand = new Stagehand({ env: "LOCAL" });
+await stagehand.init();
+const page = stagehand.context.pages()[0];
+
+// Set custom headers for all requests from this page
+await page.setExtraHTTPHeaders({
+  "X-Custom-Token": "my-secret-token",
+  "Accept-Language": "en-US",
+});
+
+// All subsequent requests from this page will include these headers
+await page.goto("https://example.com");
+```
+
 ## Screenshot
 
 ### screenshot()
@@ -918,6 +959,36 @@ await page.setViewportSize(375, 667, {
 
 // Then take a screenshot at this size
 const screenshot = await page.screenshot();
+```
+
+</Tab>
+<Tab title="Custom HTTP Headers">
+
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const stagehand = new Stagehand({ env: "LOCAL" });
+await stagehand.init();
+const page = stagehand.context.pages()[0];
+
+// Set authorization headers for requests from this page
+await page.setExtraHTTPHeaders({
+  Authorization: "Bearer my-api-token",
+});
+
+// Navigate — the headers are sent with every request from this page
+await page.goto("https://api.example.com/dashboard");
+
+// Replace headers (previous headers are removed)
+await page.setExtraHTTPHeaders({
+  Authorization: "Bearer refreshed-token",
+  "X-Request-Id": "abc-123",
+});
+
+// Clear all extra headers
+await page.setExtraHTTPHeaders({});
+
+await stagehand.close();
 ```
 
 </Tab>


### PR DESCRIPTION
# why
- to add docs for the new `page.setExtraHTTPHeaders()` function
# what changed
### added docs to the page reference section:
<img width="748" height="525" alt="Screenshot 2026-03-17 at 1 49 33 PM" src="https://github.com/user-attachments/assets/a97d8903-a17d-4af4-88e6-5d9770cb7227" />

### added an example in the code examples section:
<img width="724" height="766" alt="Screenshot 2026-03-17 at 1 50 26 PM" src="https://github.com/user-attachments/assets/3e3da652-70db-4758-b388-c04316f99895" />





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added docs for `page.setExtraHTTPHeaders()` in the Page reference and examples, covering page‑scoped behavior (applies to all requests and child sessions) and how to replace or clear headers. Addresses Linear STG-1413.

<sup>Written for commit be130f0512fbdd7cc9d843a38ea74d18c1d87969. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1842">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

