### PR TITLE
Refactor model ID checks for GPT 5.x model family

### DIFF
--- a/packages/core/lib/v3/llm/aisdk.ts
+++ b/packages/core/lib/v3/llm/aisdk.ts
@@ -135,7 +135,7 @@ export class AISdkClient extends LLMClient {
     const isGPT5 = this.model.modelId.includes("gpt-5");
     const isCodex = this.model.modelId.includes("codex");
     const usesLowReasoningEffort =
-      (this.model.modelId.includes("gpt-5.") &&
+      this.model.modelId.includes("gpt-5.") &&
       !isCodex;
     // Kimi models only support temperature=1
     const isKimi = this.model.modelId.includes("kimi");


### PR DESCRIPTION
All GPT-5.x series models don't support `minimal` as the `reasoningEffort`. Currently, it is enabled only for GPT-5.1 and GPT-5.2 models to set the reasoningEffort as `low`. This would start throwing errors like these.

`Unsupported value: 'minimal' is not supported with the 'gpt-5.4' model. Supported values are: 'none', 'low', 'medium', 'high', and 'xhigh'.`

This PR fixes the behavior to set the reasoning effort as low for all GPT-5.x series models so that we don't need to manually patch it every time when a new SOTA model is released. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set reasoningEffort to "low" for all GPT-5.x models to prevent unsupported "minimal" errors on new releases like `gpt-5.4`. Use a precise `gpt-5.` match (not version-specific) and keep `codex` excluded, removing the need for manual patches.

<sup>Written for commit a637dc329bfc5426bb71c8551c812191ed631527. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1844">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

