### PR TITLE
Test fallthrough SSE handler matching

### DIFF
--- a/stainless.yml
+++ b/stainless.yml
@@ -205,7 +205,7 @@ streaming:
       handle: yield
     - data_starts_with: error
       handle: error
-    - event_type: null
+    - kind: fallthrough
       handle: yield
 
 settings:


### PR DESCRIPTION
## Summary
- replace the terminal streaming catch-all from event_type: null to documented kind: fallthrough
- test whether Stainless preview SDKs treat the finished event as first-match-only

## Why
We need to confirm whether the documented kind: fallthrough behavior avoids the duplicate finished-event yield while still yielding the final result event once.

## Testing
- config-only change
- preview SDK inspection after Stainless bot comments


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the terminal SSE streaming catch‑all in `stainless.yml` from `event_type: null` to the documented `kind: fallthrough`. This aligns with the spec and should prevent duplicate finished-event yields while still emitting the final result once for preview SDKs.

<sup>Written for commit c9ec74cd2bb021be6d6c9094c3d69527aec07bb5. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1848">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

