### PR TITLE
Add explicit SSE event names for v3 streaming

### DIFF
--- a/packages/core/lib/v3/types/public/api.ts
+++ b/packages/core/lib/v3/types/public/api.ts
@@ -901,11 +901,9 @@ export const StreamEventLogDataSchema = z
 /**
  * SSE stream event sent during streaming responses.
  *
- * IMPORTANT: Key ordering matters for Stainless SDK generation.
- * The `data` field MUST be serialized first, with `status` as the first key within it.
- * This allows Stainless to use `data_starts_with: '{"data":{"status":"finished"'` for event handling.
- *
- * Expected serialization order: {"data":{"status":...},"type":...,"id":...}
+ * The SSE wire format includes an `event:` line that mirrors the stream status
+ * (`starting`, `connected`, `running`, `finished`, or `error`) followed by a
+ * JSON `data:` line containing the typed payload below.
  */
 export const StreamEventSchema = z
   .object({
@@ -919,7 +917,7 @@ export const StreamEventSchema = z
   .meta({
     id: "StreamEvent",
     description:
-      "Server-Sent Event emitted during streaming responses. Events are sent as `data: <JSON>\\n\\n`. Key order: data (with status first), type, id.",
+      "Server-Sent Event emitted during streaming responses. Events are sent as `event: <status>\\ndata: <JSON>\\n\\n`, where the JSON payload has the shape `{ data, type, id }`.",
   });
 
 // =============================================================================

--- a/packages/server-v3/openapi.v3.yaml
+++ b/packages/server-v3/openapi.v3.yaml
@@ -1847,8 +1847,8 @@ components:
       additionalProperties: false
     StreamEvent:
       description: "Server-Sent Event emitted during streaming responses. Events are
-        sent as `data: <JSON>\\n\\n`. Key order: data (with status first), type,
-        id."
+        sent as `event: <status>\\ndata: <JSON>\\n\\n`, where the JSON payload
+        has the shape `{ data, type, id }`."
       type: object
       properties:
         data:

--- a/packages/server-v3/src/lib/stream.ts
+++ b/packages/server-v3/src/lib/stream.ts
@@ -27,6 +27,14 @@ interface StreamingResponseOptions<TV3> {
   operation?: string;
 }
 
+type StreamEventName =
+  | "starting"
+  | "connected"
+  | "running"
+  | "finished"
+  | "error";
+type StreamPayloadType = "system" | "log";
+
 export async function createStreamingResponse<TV3>({
   sessionId,
   request,
@@ -104,23 +112,29 @@ export async function createStreamingResponse<TV3>({
     }
   }
 
-  const sendData = (type: string, data: object) => {
+  const sendData = (
+    event: StreamEventName,
+    type: StreamPayloadType,
+    data: object,
+  ) => {
     if (!shouldStreamResponse) {
       return;
     }
 
-    reply.raw.write(`data: ${JSON.stringify({ data, type, id: v4() })}\n\n`);
+    reply.raw.write(
+      `event: ${event}\ndata: ${JSON.stringify({ data, type, id: v4() })}\n\n`,
+    );
   };
 
   const actionId = v4();
 
-  sendData("system", { status: "starting" });
+  sendData("starting", "system", { status: "starting" });
 
   const requestContext: RequestContext = {
     modelApiKey,
     logger: shouldStreamResponse
       ? (message) => {
-          sendData("log", { status: "running", message });
+          sendData("running", "log", { status: "running", message });
         }
       : undefined,
   };
@@ -134,7 +148,7 @@ export async function createStreamingResponse<TV3>({
   } catch (err) {
     const loadError = err instanceof Error ? err : new Error(String(err));
 
-    sendData("system", { status: "error", error: loadError.message });
+    sendData("error", "system", { status: "error", error: loadError.message });
 
     if (shouldStreamResponse) {
       reply.raw.end();
@@ -150,7 +164,7 @@ export async function createStreamingResponse<TV3>({
     );
   }
 
-  sendData("system", { status: "connected" });
+  sendData("connected", "system", { status: "connected" });
 
   let result: Awaited<ReturnType<typeof handler>> | null = null;
   let handlerError: Error | null = null;
@@ -180,7 +194,7 @@ export async function createStreamingResponse<TV3>({
         ? handlerError.getClientMessage()
         : `${operation ?? "operation"} failed`;
 
-    sendData("system", { status: "error", error: clientMessage });
+    sendData("error", "system", { status: "error", error: clientMessage });
 
     if (shouldStreamResponse) {
       reply.raw.end();
@@ -194,7 +208,7 @@ export async function createStreamingResponse<TV3>({
     return error(reply, clientMessage, statusCode);
   }
 
-  sendData("system", {
+  sendData("finished", "system", {
     status: "finished",
     result: result?.result,
     actionId,

--- a/packages/server-v3/test/integration/utils.ts
+++ b/packages/server-v3/test/integration/utils.ts
@@ -359,7 +359,8 @@ export async function readSSEStream(response: Response): Promise<SSEEvent[]> {
 // =============================================================================
 
 // Actual SSE event format from backend (see stream.ts):
-// { data: { status: "starting" | "connected" | "finished", result?: ... }, type: "system" | "log", id: "<uuid>" }
+// event: <status>
+// data: { data: { status: "starting" | "connected" | "finished", result?: ... }, type: "system" | "log", id: "<uuid>" }
 export interface TypedSSEEvent<TResult = unknown> {
   data: {
     status: string;

--- a/packages/server-v3/test/integration/v3/act.test.ts
+++ b/packages/server-v3/test/integration/v3/act.test.ts
@@ -19,6 +19,7 @@ import {
   navigateSession,
   OPENAI_API_KEY,
   readTypedSSEStreamWithContext,
+  readSSEStream,
   requireEnv,
 } from "../utils.js";
 
@@ -398,6 +399,47 @@ describe("POST /v1/sessions/:id/act with SSE streaming (V3)", () => {
       typeof finishedEvent.data.result.success,
       "boolean",
       "Result.success must be a boolean",
+    );
+  });
+
+  it("should include explicit SSE event names that match streamed statuses", async () => {
+    const url = getBaseUrl();
+
+    const response = await fetch(`${url}/v1/sessions/${sessionId}/act`, {
+      method: "POST",
+      headers: {
+        ...getHeaders("3.0.0"),
+      },
+      body: JSON.stringify({
+        input: "click the Learn more link",
+        streamResponse: true,
+      }),
+    });
+
+    const events = await readSSEStream(response);
+
+    assert.ok(events.length >= 2, "Should emit multiple SSE frames");
+    assert.ok(
+      events.every((event) => typeof event.event === "string" && event.event),
+      "Every streamed frame should include an SSE event name",
+    );
+
+    const startingEvent = events.find((event) => event.event === "starting");
+    assert.ok(startingEvent, "Should include a starting SSE event");
+    assert.equal(
+      (startingEvent.parsed as { data?: { status?: string } } | undefined)?.data
+        ?.status,
+      "starting",
+      "Starting SSE event should match the payload status",
+    );
+
+    const finishedEvent = events.find((event) => event.event === "finished");
+    assert.ok(finishedEvent, "Should include a finished SSE event");
+    assert.equal(
+      (finishedEvent.parsed as { data?: { status?: string } } | undefined)?.data
+        ?.status,
+      "finished",
+      "Finished SSE event should match the payload status",
     );
   });
 

--- a/stainless.yml
+++ b/stainless.yml
@@ -201,11 +201,9 @@ resources:
 
 streaming:
   on_event:
-    - data_starts_with: '{"data":{"status":"finished"'
-      handle: yield
-    - data_starts_with: error
+    - event_type: error
       handle: error
-    - event_type: null
+    - event_type: [starting, connected, running, finished]
       handle: yield
 
 settings:


### PR DESCRIPTION
## Summary
- add explicit SSE `event:` names to the shared v3 streaming helper in `packages/server-v3/src/lib/stream.ts`
- switch Stainless streaming handlers from JSON-prefix/null matching to explicit `event_type` matching in `stainless.yml`
- add an integration assertion that streamed frames now carry explicit SSE event names
- update the public v3 stream-event docs in `packages/core` and regenerate `packages/server-v3/openapi.v3.yaml`

## Why
The current SDK generation path has trouble distinguishing the terminal `finished` event from the generic catch-all when the server only emits `data:` frames. Giving each streamed frame an explicit SSE event name makes the protocol more structured and lets Stainless match on non-overlapping `event_type` handlers instead of `data_starts_with` plus a generic null-event rule.

This change is intentionally scoped to the shared v3 stream helper, which is used by all streamed v3 routes:
- `act`
- `extract`
- `observe`
- `agentExecute`
- `navigate`

## Testing
- `pnpm --dir /Users/samfinton/Documents/Programming/browserbase/stagehand --filter @browserbasehq/stagehand lint`
- `pnpm --dir /Users/samfinton/Documents/Programming/browserbase/stagehand --filter @browserbasehq/stagehand-server-v3 lint`
- `pnpm --dir /Users/samfinton/Documents/Programming/browserbase/stagehand exec prettier --check stainless.yml`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add explicit SSE event names to all v3 streaming responses so clients and SDKs can match on `event_type` instead of brittle JSON prefixes. This fixes misclassification of the `finished` event and makes handlers non-overlapping.

- **New Features**
  - `packages/server-v3/src/lib/stream.ts`: emit `event: starting|connected|running|finished|error` with JSON `data: { data, type: "system"|"log", id }`.
  - `stainless.yml`: replace `data_starts_with` with `event_type`; route `error` to `error`, others to `yield`.
  - Docs/schema: update v3 stream event docs in `packages/core` and regenerate `packages/server-v3/openapi.v3.yaml`.
  - Tests: add integration check that each SSE frame includes `event` and it matches the payload `status`.

<sup>Written for commit 0faec064c7fb77aa4cee7d8a6ee9025ec472503b. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1849">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

