### PR TITLE
docs: Playwright-native mode, shadow DOM guide, and demo scripts (Phase 5–8)

### DIFF
--- a/DOCS_UPDATE_PLAN.md
+++ b/DOCS_UPDATE_PLAN.md
@@ -1,0 +1,598 @@
+# Stagehand Documentation Update Plan
+## Phases 5–8: Playwright-Native Mode
+
+**Scope of work:** Document four shipped features across user-facing docs, reference pages,
+and inline code comments. All changes are additive — no existing content needs to be removed.
+
+---
+
+## Background: What shipped in Phases 5–8
+
+| Phase | Feature | User-visible change |
+|-------|---------|---------------------|
+| 5 | `browserContext` option | Run Stagehand on any Playwright `BrowserContext` — including Firefox/camoufox — without launching Chrome |
+| 6 | DOM walker quality | Better accessible names (aria-hidden filtering, label-for association, ARIA state attrs) in snapshot output |
+| 7 | Playwright ARIA engine | Stagehand's internal snapshot now uses Playwright's `_snapshotForAI` on Chromium ≥1.52, producing W3C-compliant accessible trees |
+| 8 | `pierceShadow: "including-closed"` | Opt-in to pierce closed shadow roots (used by SAP, Salesforce, ServiceNow components) |
+
+Phases 6 and 7 are **invisible quality improvements** — no API surface changes, nothing for users to configure. They need a single changelog entry and an optional "How it works" note in the browser config doc.
+
+Phases 5 and 8 add **new public API** and need dedicated documentation.
+
+---
+
+## Part 1 — Changes to existing files
+
+### 1.1 `packages/docs/v3/references/stagehand.mdx`
+
+**What to do:** Add `browserContext` to the V3Options interface block and to the
+`### Configuration Parameters` section as a `<ParamField>` entry.
+
+**Location:** After the `env` ParamField (line ~75), add:
+
+```mdx
+<ParamField path="browserContext" type="BrowserContext">
+  An externally-managed Playwright `BrowserContext` to wrap. When set, Stagehand
+  skips all Chrome/Browserbase launch code and operates on the provided context
+  directly. The caller is responsible for closing the context.
+
+  Use this when you need to run Stagehand on a browser you control — for example
+  a Firefox/camoufox instance, a persistent profile, or a browser launched with
+  custom stealth settings.
+
+  ```typescript
+  import { chromium } from "playwright-core";
+  import { Stagehand } from "@browserbasehq/stagehand";
+
+  const browser = await chromium.connect({ wsEndpoint: process.env.CAMOUFOX_WS });
+  const ctx = browser.contexts()[0] ?? await browser.newContext();
+
+  const stagehand = new Stagehand({
+    env: "LOCAL",      // required, but ignored for launch purposes
+    browserContext: ctx,
+    model: "openai/gpt-4.1-mini",
+  });
+  await stagehand.init();
+  ```
+
+  **Note:** `env` must still be set to `"LOCAL"` to satisfy the type system.
+  The value is not used for browser launch when `browserContext` is provided.
+</ParamField>
+```
+
+Also update the TypeScript interface block at the top to include `browserContext`:
+
+```typescript
+interface V3Options {
+  env: "LOCAL" | "BROWSERBASE";
+
+  // Externally-managed Playwright context (optional — see Playwright-Native Mode)
+  browserContext?: BrowserContext;      // NEW
+
+  // Browserbase options ...
+  // Local browser options ...
+  // AI/LLM configuration ...
+  // Behavior options ...
+  cacheDir?: string;
+  serverCache?: boolean;
+}
+```
+
+---
+
+### 1.2 `packages/docs/v3/configuration/browser.mdx`
+
+**What to do:** Add a new top-level section **"## Playwright-Native Mode"** after the
+existing "## Local Environment" section (before "## Advanced Configuration").
+
+**Proposed content:**
+
+```mdx
+## Playwright-Native Mode
+
+Playwright-Native Mode lets you attach Stagehand to a `BrowserContext` you manage
+yourself. Instead of launching Chrome, Stagehand wraps whatever Playwright browser
+you hand it — Firefox, a custom Chromium build, a stealth browser like camoufox,
+or a persistent profile with saved cookies.
+
+### When to use it
+
+- **Firefox or camoufox** — bypass bot-detection systems that fingerprint Chrome
+- **Custom profiles** — bring a browser with existing cookies, extensions, or settings
+- **Test environments** — wire Stagehand to a Playwright browser already under test
+- **Enterprise stealth** — your organization manages its own browser infrastructure
+
+### Quick start (camoufox)
+
+1. Start camoufox and copy the WebSocket URL it prints:
+   ```
+   ws://localhost:42797/9e2abceb2cbd8d8595f441890e50815f
+   ```
+
+2. Set `CAMOUFOX_WS` in your `.env`:
+   ```bash
+   CAMOUFOX_WS=ws://localhost:42797/<token>
+   ```
+
+3. Connect and wrap:
+   ```typescript
+   import { chromium } from "playwright-core";
+   import { Stagehand } from "@browserbasehq/stagehand";
+
+   const browser = await chromium.connect({ wsEndpoint: process.env.CAMOUFOX_WS! });
+   const ctx  = browser.contexts()[0] ?? await browser.newContext();
+   const page = ctx.pages()[0] ?? await ctx.newPage();
+
+   const stagehand = new Stagehand({
+     env: "LOCAL",
+     browserContext: ctx,
+     model: "openai/gpt-4.1-mini",
+   });
+   await stagehand.init();
+
+   await page.goto("https://example.com");
+
+   const result = await stagehand.extract(
+     "extract the page heading",
+     z.string(),
+     { page },
+   );
+   ```
+
+<Note>
+Pass the Playwright `page` object to `act()`, `extract()`, and `observe()` via the
+`{ page }` option when using an external context. Stagehand needs to know which
+page to operate on.
+</Note>
+
+### Quick start (any Playwright browser)
+
+```typescript
+import { firefox } from "playwright-core"; // or chromium, webkit
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const browser = await firefox.launch({ headless: false });
+const ctx = await browser.newContext();
+const page = await ctx.newPage();
+
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  browserContext: ctx,
+  model: "openai/gpt-4.1-mini",
+});
+await stagehand.init();
+await stagehand.close();           // closes Stagehand; ctx/browser are yours to close
+await browser.close();
+```
+
+### Comparison table
+
+| | `env: "LOCAL"` | `env: "LOCAL"` + `browserContext` |
+|---|---|---|
+| Browser | Stagehand launches Chrome | You provide any Playwright browser |
+| Firefox support | No | Yes |
+| Stealth browser (camoufox) | No | Yes |
+| Persistent profiles | Via `userDataDir` | Via your own context setup |
+| CDP features | Full | None — pure Playwright API |
+| `stagehand.context` | Managed internally | Points to your context |
+| Closing browser | `stagehand.close()` handles it | Your responsibility |
+
+### Known limitations
+
+Playwright-Native Mode uses only Playwright's public API. Some features that rely on
+Chrome DevTools Protocol (CDP) are not available:
+
+- **Element highlight** — `.highlight()` calls on locators are a no-op; no visual overlay
+- **`addInitScript()` scope** — scripts are installed context-wide, affecting all pages
+- **FlowLogger decorators** — flow logging events are not emitted in this mode
+- **`evaluate()` string expressions** — must pass a function, not a string
+
+These limitations apply only when `browserContext` is set. Normal `env: "LOCAL"` and
+`env: "BROWSERBASE"` modes are unchanged.
+
+### Shadow DOM and enterprise components
+
+Enterprise applications (SAP Fiori, Salesforce Lightning, ServiceNow) often use
+**closed shadow roots** to encapsulate their UI components. By default, Stagehand
+cannot see inside closed shadow roots because `el.shadowRoot` is always `null`.
+
+To enable full shadow DOM traversal, pass `pierceShadow: "including-closed"` when
+requesting a snapshot:
+
+```typescript
+// In a low-level snapshot call or via the internal captureSnapshot option
+// See the Shadow DOM guide for full usage
+```
+
+See **Shadow DOM Piercing** in Best Practices for the complete guide.
+```
+
+---
+
+### 1.3 `packages/docs/v3/best-practices/caching.mdx`
+
+**What to do:** Add a callout in the "Local Cache" section noting that local caching
+works with all browser modes, including Playwright-Native Mode.
+
+**Location:** After the introductory paragraph of "## Local Cache" (after line ~79):
+
+```mdx
+<Tip>
+Local Cache (`cacheDir`) works in all three browser modes: `env: "BROWSERBASE"`,
+`env: "LOCAL"` (Chrome), and `env: "LOCAL"` with an external `browserContext`
+(Firefox, camoufox, etc.). The cache is keyed by instruction + page URL, so the
+same automation replay correctly regardless of which browser it runs in.
+</Tip>
+```
+
+Also add a note about how to observe cache hits in native mode (since `ActResult.cacheStatus`
+is only populated by the Browserbase server cache, not the local file cache):
+
+**Location:** After "### Inspecting Cache Status" in the Browserbase Cache section,
+add a new sub-section:
+
+```mdx
+#### Inspecting Local Cache Status
+
+The `cacheStatus` field on `ActResult` reflects **server-side** (Browserbase) cache hits only.
+For local file cache (`cacheDir`), use the `logger` option to observe hits:
+
+```typescript
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  cacheDir: ".cache/my-flow",
+  logger: (line) => {
+    if (line.category === "cache" && line.message?.includes("act cache hit")) {
+      console.log("Cache HIT:", line.auxiliary?.instruction?.value);
+    }
+  },
+});
+```
+```
+
+---
+
+### 1.4 `packages/docs/v3/references/act.mdx`
+
+**What to do:** Add `page` to the `ActOptions` parameter table. It's currently undocumented.
+
+**Add this ParamField entry** in the options section:
+
+```mdx
+<ParamField path="options.page" type="PlaywrightPage | PlaywrightNativePage">
+  The specific page to act on. Required when using Playwright-Native Mode
+  (`browserContext` option) with multiple open pages. When omitted, Stagehand
+  uses its internally managed page.
+
+  ```typescript
+  await stagehand.act("click the submit button", { page: pwPage });
+  ```
+</ParamField>
+```
+
+Apply the same addition to `extract.mdx` and `observe.mdx` (same `page` option exists on
+`ExtractOptions` and `ObserveOptions`).
+
+---
+
+## Part 2 — New files to create
+
+### 2.1 `packages/docs/v3/best-practices/shadow-dom.mdx`
+
+**Title:** Shadow DOM Automation
+**Sidebar title:** Shadow DOM
+**Description:** Automate open and closed shadow root components in enterprise apps
+
+**Full proposed content:**
+
+```mdx
+---
+title: Shadow DOM Automation
+sidebarTitle: Shadow DOM
+description: Automate open and closed shadow root components in enterprise apps
+---
+import { V3Banner } from '/snippets/v3-banner.mdx';
+
+<V3Banner />
+
+Shadow DOM components encapsulate their HTML in a private tree that is invisible to
+standard DOM queries. Enterprise applications in particular — SAP Fiori, Salesforce
+Lightning, ServiceNow, many web component libraries — make heavy use of shadow roots
+to prevent style and script leakage.
+
+Stagehand supports two levels of shadow DOM piercing controlled by the `pierceShadow`
+snapshot option.
+
+## Open shadow roots
+
+Open shadow roots (`attachShadow({ mode: "open" })`) are pierced automatically.
+No configuration is needed — `act()`, `extract()`, and `observe()` all see inside
+open shadows by default.
+
+## Closed shadow roots
+
+Closed shadow roots (`attachShadow({ mode: "closed" })`) set `el.shadowRoot = null`,
+making them invisible to standard DOM queries. Stagehand adds opt-in support via the
+`pierceShadow: "including-closed"` option, which installs a lightweight
+`attachShadow` interceptor as a page init script before any page content loads.
+
+### How it works
+
+When `pierceShadow: "including-closed"` is first used on a page, Stagehand:
+
+1. Installs an `addInitScript` that wraps `Element.prototype.attachShadow`
+2. Any subsequent call to `attachShadow({ mode: "closed" })` on that page stores the
+   shadow root in a `WeakMap`
+3. Stagehand's DOM walker reads the map via `window.__stagehandClosedRoot(host)`
+4. The snapshot includes closed shadow content alongside regular and open-shadow DOM
+
+<Warning>
+`addInitScript` takes effect on the **next navigation only**. If the page has
+already loaded content with closed shadow roots before this option is first used,
+those roots will be invisible. Navigate or reload the page after calling
+`captureSnapshot({ pierceShadow: "including-closed" })` for the first time.
+</Warning>
+
+### Usage
+
+The `pierceShadow` option is passed at the snapshot level:
+
+```typescript
+import { chromium } from "playwright-core";
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext();
+const page = await ctx.newPage();
+
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  browserContext: ctx,
+  model: "openai/gpt-4.1-mini",
+});
+await stagehand.init();
+
+// Step 1: Enable the interceptor (installs init script)
+// Must happen before the page content that creates shadow roots is loaded
+await stagehand.page.captureSnapshot({ pierceShadow: "including-closed" });
+
+// Step 2: Navigate — init script runs before any inline <script> on the page
+await page.goto("https://your-sap-or-salesforce-app.example.com");
+
+// Step 3: Normal act/extract/observe — closed shadow content is now visible
+await stagehand.act("click the 'Submit' button inside the form component");
+```
+
+### Comparison
+
+| `pierceShadow` value | Open shadow roots | Closed shadow roots |
+|---|---|---|
+| `false` | Not pierced | Not pierced |
+| `true` (default) | **Pierced** | Not pierced |
+| `"including-closed"` | **Pierced** | **Pierced** |
+
+### Known side effects
+
+- **Context-wide installation.** `addInitScript` installs the interceptor on all
+  pages in the `BrowserContext`, not only the page that first requested it. Other
+  pages you open will also carry the `__stagehandClosedRoot` global.
+
+- **Pre-existing roots invisible.** Shadow roots attached before the init script
+  ran are not captured. Always navigate after enabling `"including-closed"`.
+
+- **XPath limitations.** Elements inside closed shadow roots receive XPaths that
+  truncate at the shadow host boundary (`/html[1]/body[1]/section[1]/`). These paths
+  are non-unique and may match multiple elements. Use accessible names or ARIA roles
+  in your instructions instead of relying on XPath precision for closed-shadow elements.
+
+### When not to use it
+
+Closed shadow DOM piercing modifies `Element.prototype.attachShadow` via an init
+script. This is detectable by anti-bot systems. Do not use `"including-closed"` on
+pages that actively check for DOM prototype modifications.
+```
+
+---
+
+### 2.2 `packages/docs/v3/configuration/playwright-native.mdx`
+
+**Title:** Playwright-Native Mode
+**Sidebar title:** Playwright-Native
+**Description:** Attach Stagehand to any Playwright browser context — Firefox, camoufox, custom builds
+
+This is a dedicated reference page extracted from the content proposed for `browser.mdx`
+above. Create it so the camoufox/Firefox workflow has a canonical home with a URL users
+can bookmark and share. The `browser.mdx` changes above can link to it.
+
+**Content outline:**
+1. What it is (1 paragraph)
+2. Prerequisites (playwright-core installed, any browser)
+3. Connecting to camoufox (step-by-step with env var)
+4. Connecting to Firefox (plain launch)
+5. Connecting to an existing Playwright test browser
+6. Passing `page` to act/extract/observe
+7. Local caching with external contexts
+8. Limitations (CDP-dependent features not available)
+9. Troubleshooting
+
+---
+
+## Part 3 — Navigation updates (`packages/docs/docs.json`)
+
+### 3.1 Add new pages to navigation
+
+In the `"Best Practices"` group, add after `"v3/best-practices/computer-use"`:
+
+```json
+"v3/best-practices/shadow-dom"
+```
+
+In the `"Configuration"` group, add after `"v3/configuration/browser"`:
+
+```json
+"v3/configuration/playwright-native"
+```
+
+---
+
+## Part 4 — CHANGELOG entries
+
+### `packages/core/CHANGELOG.md`
+
+Add a new entry at the top (under the next version heading):
+
+```markdown
+### New Features
+
+#### Playwright-Native Mode (`browserContext` option)
+Pass an externally-managed Playwright `BrowserContext` to `new Stagehand({ browserContext })`.
+Stagehand wraps it with a pure-Playwright implementation — no CDP required.
+Enables Firefox, camoufox, and any other Playwright-compatible browser.
+
+#### `pierceShadow: "including-closed"` snapshot option
+Opt in to closed shadow DOM traversal via an `attachShadow` interceptor init script.
+Enables automation of SAP Fiori, Salesforce Lightning, ServiceNow, and similar
+enterprise components that use `{ mode: "closed" }` shadow roots.
+
+### Improvements
+
+#### DOM walker quality (Phase 6)
+- `getAccessibleName()` now skips `aria-hidden` subtrees per the accname-1.1 spec —
+  elements marked `aria-hidden="true"` no longer contribute text to their ancestors' names
+- `label[for]` association resolves accessible names on inputs that lack `aria-label`
+- `aria-expanded`, `aria-checked`, `aria-selected`, `aria-disabled` captured in snapshot
+
+#### Playwright ARIA engine (Phase 7)
+On Playwright ≥ 1.52 (Chromium), Stagehand's snapshot engine switches to
+`page._snapshotForAI()`, which returns a W3C-compliant ARIA tree with ref-to-XPath
+resolution. This produces higher-quality accessible names than the DOM walker,
+particularly for complex components. Falls back to the DOM walker automatically on
+older Playwright versions and Firefox.
+```
+
+---
+
+## Part 5 — Code-level JSDoc gaps
+
+These are gaps in inline documentation not covered by the MDX pages.
+
+### 5.1 `packages/core/lib/v3/types/private/snapshot.ts`
+
+`SnapshotOptions.pierceShadow` already has a comment but it should mention the
+`"including-closed"` value explicitly with a link to the docs:
+
+```typescript
+/**
+ * Controls shadow DOM traversal depth.
+ *
+ * - `false`                  — no shadow piercing
+ * - `true` (default)         — pierce open shadow roots only
+ * - `"including-closed"`     — pierce open AND closed shadow roots via
+ *                              an `attachShadow` interceptor init script.
+ *                              See: https://docs.stagehand.dev/v3/best-practices/shadow-dom
+ *
+ * IMPORTANT: "including-closed" only captures roots attached *after* the
+ * init script runs. Navigate the page after first enabling this option.
+ */
+pierceShadow?: boolean | "including-closed";
+```
+
+### 5.2 `packages/core/lib/v3/types/public/options.ts`
+
+`V3Options.browserContext` already has a JSDoc comment (added in Phase 5).
+Add a link to the docs page:
+
+```typescript
+/**
+ * Optional: provide an externally-managed Playwright BrowserContext.
+ * ...existing text...
+ *
+ * See: https://docs.stagehand.dev/v3/configuration/playwright-native
+ */
+browserContext?: BrowserContext;
+```
+
+### 5.3 `packages/core/lib/v3/understudy/native/PlaywrightNativePage.ts`
+
+The file-level comment block already lists Phase 4 limitations. Add a reference
+to the public docs:
+
+```typescript
+/**
+ * PlaywrightNativePage — Playwright-public-API implementation of IStagehandPage.
+ *
+ * ...existing limitation list...
+ *
+ * Public docs: https://docs.stagehand.dev/v3/configuration/playwright-native
+ */
+```
+
+---
+
+## Part 6 — README update
+
+### `packages/core/README.md` (mirrors root `README.md`)
+
+The README currently only mentions `env: "BROWSERBASE"` and `env: "LOCAL"`.
+Add a brief callout in the "Quick Start" or "Configuration" section:
+
+```markdown
+### Using Stagehand with Firefox or camoufox
+
+Pass an external Playwright `BrowserContext` to run Stagehand on any browser:
+
+```typescript
+import { chromium } from "playwright-core";
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const browser = await chromium.connect({ wsEndpoint: process.env.CAMOUFOX_WS });
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  browserContext: browser.contexts()[0],
+  model: "openai/gpt-4.1-mini",
+});
+await stagehand.init();
+```
+
+See [Playwright-Native Mode](https://docs.stagehand.dev/v3/configuration/playwright-native) for the full guide.
+```
+
+---
+
+## Priority order
+
+| Priority | Work item | Effort | Impact |
+|----------|-----------|--------|--------|
+| 1 (High) | Create `playwright-native.mdx` | ~3h | New users can't find the feature without this |
+| 1 (High) | Update `stagehand.mdx` with `browserContext` ParamField | ~30m | Reference docs are incomplete |
+| 2 (High) | Update `browser.mdx` with native mode section | ~2h | Discoverability from existing browser config page |
+| 3 (Medium) | Create `shadow-dom.mdx` | ~2h | Enterprise users need this, but it's a niche feature |
+| 4 (Medium) | Update `caching.mdx` with native mode note | ~30m | Prevents confusion about `cacheStatus` behavior |
+| 5 (Medium) | Update `act.mdx`, `extract.mdx`, `observe.mdx` with `page` param | ~1h | Reference completeness |
+| 6 (Medium) | Update `docs.json` navigation | ~15m | Required once new pages exist |
+| 7 (Low) | CHANGELOG entries | ~30m | Useful for release notes |
+| 8 (Low) | README callout | ~15m | Nice-to-have discoverability |
+| 9 (Low) | JSDoc improvements in `snapshot.ts` and `options.ts` | ~30m | IDE documentation quality |
+
+---
+
+## Files touched summary
+
+| File | Action |
+|------|--------|
+| `packages/docs/v3/references/stagehand.mdx` | Edit — add `browserContext` ParamField |
+| `packages/docs/v3/configuration/browser.mdx` | Edit — add Playwright-Native section |
+| `packages/docs/v3/best-practices/caching.mdx` | Edit — add native mode tip + logger note |
+| `packages/docs/v3/references/act.mdx` | Edit — add `page` option |
+| `packages/docs/v3/references/extract.mdx` | Edit — add `page` option |
+| `packages/docs/v3/references/observe.mdx` | Edit — add `page` option |
+| `packages/docs/v3/configuration/playwright-native.mdx` | **Create** |
+| `packages/docs/v3/best-practices/shadow-dom.mdx` | **Create** |
+| `packages/docs/docs.json` | Edit — add 2 entries to navigation |
+| `packages/core/CHANGELOG.md` | Edit — add Phase 5–8 entries |
+| `packages/core/README.md` | Edit — add native mode callout |
+| `packages/core/lib/v3/types/private/snapshot.ts` | Edit — expand pierceShadow JSDoc |
+| `packages/core/lib/v3/types/public/options.ts` | Edit — add docs link to browserContext JSDoc |
+| `packages/core/lib/v3/understudy/native/PlaywrightNativePage.ts` | Edit — add docs link to file comment |
+
+**Total: 8 edits + 2 new files**

--- a/packages/core/examples/v3/demo_01_caching.ts
+++ b/packages/core/examples/v3/demo_01_caching.ts
@@ -1,0 +1,224 @@
+/**
+ * Demo 01 — Stagehand Act() Caching
+ *
+ * Shows how cacheDir enables instant action replay without LLM calls.
+ *
+ *   RUN 1 (cold): LLM resolves every selector  → ~3–8s per step
+ *   RUN 2 (warm): Selectors replayed from disk  → <50ms per step
+ *
+ * Run:
+ *   pnpm example v3/demo_01_caching
+ *
+ * Optional env:
+ *   OPENROUTER_API_KEY  (preferred)
+ *   OPENAI_API_KEY      (fallback)
+ *   STAGEHAND_MODEL     (default: google/gemini-2.5-pro)
+ *   CAMOUFOX_WS         (if set, uses camoufox instead of local Chromium)
+ */
+
+import { chromium } from "playwright-core";
+import { Stagehand } from "../../lib/v3/index.js";
+
+import fs from "fs";
+import path from "path";
+
+// ── Env ──────────────────────────────────────────────────────────────────────
+
+const OPENROUTER_KEY = process.env["OPENROUTER_API_KEY"] ?? "";
+const OPENAI_KEY     = process.env["OPENAI_API_KEY"] ?? "";
+const MODEL_NAME     = process.env["STAGEHAND_MODEL"] ?? "google/gemini-2.5-pro";
+const CAMOUFOX_WS    = process.env["CAMOUFOX_WS"] ?? "";
+
+if (!OPENROUTER_KEY && !OPENAI_KEY) {
+  console.error("ERROR: Set OPENROUTER_API_KEY or OPENAI_API_KEY in .env");
+  process.exit(1);
+}
+
+const model = OPENROUTER_KEY
+  ? {
+      modelName: `openai/${MODEL_NAME}` as `${string}/${string}`,
+      baseURL: "https://openrouter.ai/api/v1",
+      apiKey: OPENROUTER_KEY,
+    }
+  : { modelName: "gpt-4.1-mini" as const, apiKey: OPENAI_KEY };
+
+// ── Style helpers ─────────────────────────────────────────────────────────────
+
+const RST = "\x1b[0m";
+const B   = "\x1b[1m";
+const DIM = "\x1b[2m";
+const G   = "\x1b[32m";
+const Y   = "\x1b[33m";
+const C   = "\x1b[36m";
+const BLU = "\x1b[34m";
+
+function banner(title: string) {
+  const w = 52;
+  const line = "═".repeat(w);
+  const pad  = Math.floor((w - title.length) / 2);
+  const padded = " ".repeat(pad) + title + " ".repeat(w - pad - title.length);
+  console.log(`\n${B}${BLU}╔${line}╗${RST}`);
+  console.log(`${B}${BLU}║${padded}║${RST}`);
+  console.log(`${B}${BLU}╚${line}╝${RST}\n`);
+}
+
+function section(label: string) {
+  console.log(`\n${B}${C}── ${label} ${"─".repeat(Math.max(0, 46 - label.length))}${RST}`);
+}
+
+function fmtMs(n: number): string {
+  return n < 1000
+    ? `${B}${n.toLocaleString()}ms${RST}`
+    : `${B}${(n / 1000).toFixed(2)}s${RST}`;
+}
+
+function cacheBadge(s?: "HIT" | "MISS"): string {
+  if (s === "HIT")  return `${G}${B}✓ HIT ${RST}`;
+  if (s === "MISS") return `${Y}${B}• MISS${RST}`;
+  return `${DIM}  —  ${RST}`;
+}
+
+// ── Cache directory ───────────────────────────────────────────────────────────
+
+const CACHE_DIR = path.resolve(".cache", "stagehand-demo-01");
+
+// ── Automation steps ──────────────────────────────────────────────────────────
+
+const STEPS: { label: string; instruction: string }[] = [
+  {
+    label:       "Click the 'love' tag",
+    instruction: "click the 'love' tag in the tag cloud on the right side",
+  },
+  {
+    label:       "Click Next page",
+    instruction: "click the 'Next' button to go to the next page of quotes",
+  },
+];
+
+// ── One full automation run ───────────────────────────────────────────────────
+
+async function runAutomation(
+  runLabel: string,
+  browser?: Awaited<ReturnType<typeof chromium.connect>>,
+): Promise<{ stepMs: number[]; total: number }> {
+  section(runLabel);
+
+  // External camoufox page or managed local Chromium
+  let externalCtx: Awaited<ReturnType<typeof browser.newContext>> | undefined;
+  let externalPage: Awaited<ReturnType<typeof externalCtx.newPage>> | undefined;
+  if (browser) {
+    externalCtx  = browser.contexts()[0] ?? await browser.newContext();
+    externalPage = externalCtx.pages()[0] ?? await externalCtx.newPage();
+  }
+
+  // The local file-based cache (cacheDir) logs "act cache hit" via the logger
+  // rather than setting ActResult.cacheStatus (that field is Browserbase-only).
+  // Intercept the logger to capture HIT/MISS per step.
+  let stepCacheStatus: "HIT" | "MISS" = "MISS";
+
+  const sh = new Stagehand({
+    env:         "LOCAL",
+    model,
+    cacheDir:    CACHE_DIR,
+    verbose:     2,
+    disablePino: true,
+    logger: (line) => {
+      if (line.category === "cache" && typeof line.message === "string") {
+        if (line.message.includes("act cache hit")) stepCacheStatus = "HIT";
+        if (line.message.includes("act cache miss")) stepCacheStatus = "MISS";
+      }
+    },
+    ...(externalCtx ? { browserContext: externalCtx } : {}),
+  });
+
+  await sh.init();
+
+  // Navigate using the underlying Playwright page
+  const page = externalPage ?? sh.context.pages()[0];
+  await page.goto("https://quotes.toscrape.com");
+  await page.waitForLoadState("networkidle");
+
+  const stepMs: number[] = [];
+  const runStart = Date.now();
+
+  for (const step of STEPS) {
+    stepCacheStatus = "MISS"; // reset before each act()
+    const t0 = process.hrtime.bigint();
+    try {
+      if (externalPage) {
+        await sh.act(step.instruction, { page: externalPage });
+      } else {
+        await sh.act(step.instruction);
+      }
+    } catch {
+      console.log(`  ${Y}⚠ step "${step.label}" failed — skipping${RST}`);
+      stepMs.push(0);
+      continue;
+    }
+    const elapsed = Math.round(Number(process.hrtime.bigint() - t0) / 1_000_000);
+    stepMs.push(elapsed);
+
+    const note = stepCacheStatus === "HIT"
+      ? `${DIM}selector replayed from disk (no LLM call)${RST}`
+      : `${DIM}LLM resolved selector → written to cache${RST}`;
+
+    console.log(
+      `  ${cacheBadge(stepCacheStatus)}  ${fmtMs(elapsed).padEnd(20)}  ${step.label}\n             ${note}`,
+    );
+
+    // Let the page settle after navigation
+    await new Promise((r) => setTimeout(r, 500));
+  }
+
+  const total = Date.now() - runStart;
+  console.log(`\n  ${B}Total wall time: ${fmtMs(total)}${RST}`);
+
+  await sh.close();
+  return { stepMs, total };
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+(async () => {
+  banner("STAGEHAND CACHING DEMO");
+
+  const usingCamoufox = Boolean(CAMOUFOX_WS);
+  console.log(`${DIM}Browser: ${usingCamoufox ? "camoufox (Firefox)" : "local Chromium"}${RST}`);
+  console.log(`${DIM}Site:    quotes.toscrape.com${RST}`);
+  console.log(`${DIM}Steps:   ${STEPS.length} act() calls${RST}`);
+  console.log(`${DIM}Cache:   ${CACHE_DIR}${RST}`);
+
+  // Clear cache before run 1 to guarantee a cold start
+  if (fs.existsSync(CACHE_DIR)) {
+    fs.rmSync(CACHE_DIR, { recursive: true, force: true });
+    console.log(`${DIM}(Cleared existing cache for clean demo.)${RST}`);
+  }
+
+  // Connect camoufox once (keep alive across both runs)
+  let camoufoxBrowser: Awaited<ReturnType<typeof chromium.connect>> | undefined;
+  if (CAMOUFOX_WS) {
+    console.log(`\n${DIM}Connecting to camoufox …${RST}`);
+    camoufoxBrowser = await chromium.connect({ wsEndpoint: CAMOUFOX_WS });
+    console.log(`${DIM}Connected: ${camoufoxBrowser.version()}${RST}`);
+  }
+
+  const r1 = await runAutomation("RUN 1 — Cold Start (empty cache)", camoufoxBrowser);
+  const r2 = await runAutomation("RUN 2 — Warm Cache (instant replay)", camoufoxBrowser);
+
+  if (camoufoxBrowser) await camoufoxBrowser.close().catch(() => {});
+
+  // ── Summary ──────────────────────────────────────────────────────────────
+  section("Summary");
+  const speedup = r2.total > 0 ? Math.round(r1.total / r2.total) : "∞";
+  console.log(`  Run 1 (cold):  ${fmtMs(r1.total)}  — LLM called for every selector`);
+  console.log(`  Run 2 (warm):  ${fmtMs(r2.total)}  — All selectors served from disk`);
+  console.log(
+    `\n  ${G}${B}${speedup}× faster on second run${RST}`,
+  );
+  console.log(
+    `\n  ${DIM}The cache survives process restarts.${RST}`,
+  );
+  console.log(
+    `  ${DIM}Kill this script and run it again — Run 2 timing holds.${RST}\n`,
+  );
+})();

--- a/packages/core/examples/v3/demo_02_camoufox_extract.ts
+++ b/packages/core/examples/v3/demo_02_camoufox_extract.ts
@@ -1,0 +1,207 @@
+/**
+ * Demo 02 — Camoufox + Observe + Structured Extract
+ *
+ * Runs Stagehand on Firefox (camoufox stealth browser) via the native
+ * Playwright path introduced in this sprint. No CDP. Pure Playwright APIs.
+ *
+ * Shows:
+ *   • Connecting Stagehand to an externally-managed BrowserContext
+ *   • observe() — natural-language scan of what's actionable on a page
+ *   • extract() — pulling structured JSON from a live page
+ *   • The ARIA snapshot that drives both (Phase 6/7 improvements)
+ *
+ * Run:
+ *   pnpm example v3/demo_02_camoufox_extract
+ *
+ * Required env:
+ *   CAMOUFOX_WS         — WebSocket URL printed by camoufox on startup
+ *
+ * Optional env:
+ *   OPENROUTER_API_KEY  (preferred)
+ *   OPENAI_API_KEY      (fallback)
+ *   STAGEHAND_MODEL     (default: google/gemini-2.5-pro)
+ */
+
+import { chromium } from "playwright-core";
+import { Stagehand } from "../../lib/v3/index.js";
+import { z } from "zod";
+
+// ── Env ──────────────────────────────────────────────────────────────────────
+
+const WS = process.env["CAMOUFOX_WS"] ?? "";
+if (!WS) {
+  console.error(
+    "ERROR: CAMOUFOX_WS not set.\n" +
+    "Start camoufox, copy the ws:// URL, and set it in .env:\n" +
+    "  CAMOUFOX_WS=ws://localhost:<port>/<token>",
+  );
+  process.exit(1);
+}
+
+const OPENROUTER_KEY = process.env["OPENROUTER_API_KEY"] ?? "";
+const OPENAI_KEY     = process.env["OPENAI_API_KEY"] ?? "";
+const MODEL_NAME     = process.env["STAGEHAND_MODEL"] ?? "google/gemini-2.5-pro";
+
+if (!OPENROUTER_KEY && !OPENAI_KEY) {
+  console.error("ERROR: Set OPENROUTER_API_KEY or OPENAI_API_KEY in .env");
+  process.exit(1);
+}
+
+const model = OPENROUTER_KEY
+  ? {
+      modelName: `openai/${MODEL_NAME}` as `${string}/${string}`,
+      baseURL: "https://openrouter.ai/api/v1",
+      apiKey: OPENROUTER_KEY,
+    }
+  : { modelName: "gpt-4.1-mini" as const, apiKey: OPENAI_KEY };
+
+// ── Style helpers ─────────────────────────────────────────────────────────────
+
+const RST = "\x1b[0m";
+const B   = "\x1b[1m";
+const DIM = "\x1b[2m";
+const G   = "\x1b[32m";
+const Y   = "\x1b[33m";
+const C   = "\x1b[36m";
+const BLU = "\x1b[34m";
+
+function banner(title: string) {
+  const w = 52;
+  const line = "═".repeat(w);
+  const pad  = Math.floor((w - title.length) / 2);
+  const padded = " ".repeat(pad) + title + " ".repeat(w - pad - title.length);
+  console.log(`\n${B}${BLU}╔${line}╗${RST}`);
+  console.log(`${B}${BLU}║${padded}║${RST}`);
+  console.log(`${B}${BLU}╚${line}╝${RST}\n`);
+}
+
+function step(n: number, label: string) {
+  console.log(`\n${B}${C}${n}. ${label}${RST}`);
+}
+
+function ms(n: number): string {
+  return n < 1000
+    ? `${DIM}${n.toLocaleString()}ms${RST}`
+    : `${DIM}${(n / 1000).toFixed(2)}s${RST}`;
+}
+
+// ── Schemas ───────────────────────────────────────────────────────────────────
+
+// Keep schemas small to stay within model token limits
+const QuoteSchema = z.object({
+  quotes: z.array(
+    z.object({
+      author: z.string(),
+      text:   z.string().describe("First 60 characters of the quote text only"),
+    }),
+  ).describe("Up to 5 quotes from the page"),
+});
+
+const BooksSchema = z.object({
+  books: z.array(
+    z.object({
+      title:  z.string(),
+      price:  z.string().describe("Price as shown, e.g. '£51.77'"),
+      rating: z.string().describe("Star rating word, e.g. 'Three'"),
+    }),
+  ).describe("Up to 8 books from the catalogue"),
+});
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+(async () => {
+  banner("CAMOUFOX + STAGEHAND NATIVE MODE");
+
+  // ── 1. Connect to camoufox (Firefox stealth browser) ─────────────────────
+  step(1, "Connect to camoufox");
+  const browser = await chromium.connect({ wsEndpoint: WS });
+  const ctx  = browser.contexts()[0] ?? await browser.newContext();
+  const page = ctx.pages()[0] ?? await ctx.newPage();
+
+  console.log(`   Browser version : ${G}${browser.version()}${RST}`);
+  const ua = await page.evaluate(() => navigator.userAgent);
+  console.log(`   User-Agent      : ${DIM}${ua.slice(0, 80)}${RST}`);
+
+  // ── 2. Init Stagehand wired to camoufox context ───────────────────────────
+  step(2, "Init Stagehand with camoufox browserContext");
+  const sh = new Stagehand({
+    env:         "LOCAL",
+    browserContext: ctx,
+    model,
+    verbose:     0,
+    disablePino: true,
+  });
+  await sh.init();
+  console.log(`   ${G}✓ Stagehand ready (no CDP — pure Playwright API)${RST}`);
+
+  // ── 3. Navigate to quotes.toscrape.com ────────────────────────────────────
+  step(3, "Navigate to quotes.toscrape.com");
+  await page.goto("https://quotes.toscrape.com");
+  await page.waitForLoadState("networkidle");
+  console.log(`   Title: ${await page.title()}`);
+
+  // ── 4. observe() — scan available actions ────────────────────────────────
+  step(4, "observe() — what can we do on this page?");
+  const t0 = Date.now();
+  const actions = await sh.observe(
+    "list all interactive elements and navigation links",
+    { page, timeout: 30_000 },
+  );
+  console.log(`   ${ms(Date.now() - t0)}  Found ${G}${B}${actions.length}${RST} actionable elements:\n`);
+  for (const a of actions.slice(0, 8)) {
+    console.log(`   ${Y}▸${RST} ${a.description}`);
+  }
+  if (actions.length > 8) {
+    console.log(`   ${DIM}  … and ${actions.length - 8} more${RST}`);
+  }
+
+  // ── 5. extract() — get quotes as structured JSON ─────────────────────────
+  step(5, "extract() — quotes as structured JSON");
+  const t1 = Date.now();
+  let quoteResult: { quotes: { author: string; text: string }[] } | null = null;
+  try {
+    quoteResult = await sh.extract(
+      "extract up to 5 quotes from this page — for each quote get the author name and the first 60 characters of the quote text",
+      QuoteSchema,
+      { page, timeout: 30_000 },
+    );
+  } catch (err) {
+    console.log(`   ${Y}⚠ extract threw (${String(err).slice(0, 80)})${RST}`);
+  }
+  const quotes = quoteResult?.quotes ?? [];
+  console.log(`   ${ms(Date.now() - t1)}  Extracted ${G}${B}${quotes.length}${RST} quotes:\n`);
+  for (const q of quotes) {
+    console.log(`   ${C}"${q.text}…"${RST}`);
+    console.log(`     ${DIM}— ${q.author}${RST}\n`);
+  }
+
+  // ── 6. Navigate to books.toscrape.com and do a richer extraction ─────────
+  step(6, "Navigate to books.toscrape.com — richer extraction");
+  await page.goto("https://books.toscrape.com");
+  await page.waitForLoadState("networkidle");
+  console.log(`   Title: ${await page.title()}`);
+
+  const t2 = Date.now();
+  let bookResult: { books: { title: string; price: string; rating: string }[] } | null = null;
+  try {
+    bookResult = await sh.extract(
+      "extract up to 8 books from the catalogue — for each: title, price (e.g. £12.34), and star rating word (One/Two/Three/Four/Five)",
+      BooksSchema,
+      { page, timeout: 30_000 },
+    );
+  } catch (err) {
+    console.log(`   ${Y}⚠ extract threw (${String(err).slice(0, 80)})${RST}`);
+  }
+  const books = bookResult?.books ?? [];
+  console.log(`   ${ms(Date.now() - t2)}  Extracted ${G}${B}${books.length}${RST} books:\n`);
+  for (const bk of books) {
+    console.log(
+      `   ${B}${bk.title.slice(0, 40).padEnd(42)}${RST}  ${Y}${bk.price}${RST}  ${DIM}★ ${bk.rating}${RST}`,
+    );
+  }
+
+  // ── Done ──────────────────────────────────────────────────────────────────
+  await sh.close();
+  await browser.close().catch(() => {});
+  console.log(`\n${G}${B}✓ Done.${RST}\n`);
+})();

--- a/packages/core/examples/v3/demo_03_shadow_dom.ts
+++ b/packages/core/examples/v3/demo_03_shadow_dom.ts
@@ -1,0 +1,207 @@
+/**
+ * Demo 03 — Shadow DOM Piercing: Before & After Phase 8
+ *
+ * No LLM or camoufox required — uses headless Chromium only.
+ *
+ * Demonstrates the closed shadow DOM support added in Phase 8:
+ *   pierceShadow: true             → sees open shadows, MISSES closed shadows
+ *   pierceShadow: "including-closed" → sees BOTH open and closed shadows
+ *
+ * Run:
+ *   pnpm example v3/demo_03_shadow_dom
+ */
+
+import { chromium } from "playwright-core";
+import { captureNativeSnapshot } from "../../lib/v3/understudy/native/snapshot/captureNativeSnapshot.js";
+import type { NativeA11yOptions } from "../../lib/v3/types/private/snapshot.js";
+
+// ── Style helpers ─────────────────────────────────────────────────────────────
+
+const RST = "\x1b[0m";
+const B   = "\x1b[1m";
+const DIM = "\x1b[2m";
+const G   = "\x1b[32m";
+const Y   = "\x1b[33m";
+const C   = "\x1b[36m";
+const RED = "\x1b[31m";
+const BLU = "\x1b[34m";
+
+function banner(title: string) {
+  const w = 52;
+  const line = "═".repeat(w);
+  const pad  = Math.floor((w - title.length) / 2);
+  const padded = " ".repeat(pad) + title + " ".repeat(w - pad - title.length);
+  console.log(`\n${B}${BLU}╔${line}╗${RST}`);
+  console.log(`${B}${BLU}║${padded}║${RST}`);
+  console.log(`${B}${BLU}╚${line}╝${RST}\n`);
+}
+
+function section(label: string) {
+  console.log(`\n${B}${Y}── ${label} ${"─".repeat(Math.max(0, 46 - label.length))}${RST}`);
+}
+
+// ── Test page HTML ────────────────────────────────────────────────────────────
+//
+// Contains three kinds of content:
+//   1. Regular DOM          — always visible
+//   2. Open shadow root     — visible with pierceShadow: true
+//   3. Closed shadow root   — only visible with pierceShadow: "including-closed"
+//
+const PAGE_HTML = `<!DOCTYPE html>
+<html lang="en">
+<head><title>Shadow DOM Demo</title></head>
+<body>
+  <h1>Shadow DOM Demo Page</h1>
+  <p>I am regular page content.</p>
+
+  <!-- Open shadow root (declarative via template) -->
+  <section id="open-host">
+    <template shadowrootmode="open">
+      <nav aria-label="Open Shadow Navigation">
+        <button>Open Shadow Button</button>
+        <a href="#open">Open Shadow Link</a>
+        <p role="note">I live inside an OPEN shadow root</p>
+      </nav>
+    </template>
+  </section>
+
+  <!-- Closed shadow root — created imperatively after page load -->
+  <section id="closed-host"></section>
+
+  <script>
+    var host = document.getElementById("closed-host");
+    var root = host.attachShadow({ mode: "closed" });
+    root.innerHTML =
+      '<nav aria-label="Closed Shadow Navigation">' +
+        '<button>Closed Shadow Button</button>' +
+        '<a href="#closed">Closed Shadow Link</a>' +
+        '<p role="note">I live inside a CLOSED shadow root</p>' +
+      "</nav>";
+  </script>
+
+  <footer>Regular footer content</footer>
+</body>
+</html>`;
+
+// ── Closed-shadow interceptor init script ─────────────────────────────────────
+// Must be installed via addInitScript BEFORE setContent so the WeakMap
+// interceptor is in place when the page's <script> calls attachShadow.
+
+const CLOSED_SHADOW_INTERCEPTOR = `(function() {
+  if (typeof window.__stagehandClosedRoot === "function" || window.__stagehandClosedRootInstalled) return;
+  try {
+    var _closed = new WeakMap();
+    var _orig = Element.prototype.attachShadow;
+    Element.prototype.attachShadow = function(init) {
+      var root = _orig.call(this, init);
+      if (init && init.mode === "closed") _closed.set(this, root);
+      return root;
+    };
+    window.__stagehandClosedRoot = function(host) { return _closed.get(host) ?? null; };
+    window.__stagehandClosedRootInstalled = true;
+  } catch (e) {}
+})();`;
+
+// ── Capture helper ────────────────────────────────────────────────────────────
+
+async function capture(
+  page: import("playwright-core").Page,
+  opts: NativeA11yOptions,
+): Promise<{ tree: string; lines: string[] }> {
+  const snap = await captureNativeSnapshot(page, opts);
+  const lines = snap.combinedTree.trim().split("\n");
+  return { tree: snap.combinedTree, lines };
+}
+
+function printTree(lines: string[]) {
+  for (const line of lines) {
+    if (line.includes("OPEN shadow root") || line.includes("Open Shadow")) {
+      console.log(`    ${G}${line}${RST}`);
+    } else if (line.includes("CLOSED shadow root") || line.includes("Closed Shadow")) {
+      console.log(`    ${C}${line}${RST}`);
+    } else {
+      console.log(`    ${DIM}${line}${RST}`);
+    }
+  }
+}
+
+function yesNo(bool: boolean, trueLabel = "YES", falseLabel = "NO"): string {
+  return bool
+    ? `${G}${B}${trueLabel}${RST}`
+    : `${RED}${B}${falseLabel}${RST}`;
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+(async () => {
+  banner("SHADOW DOM PIERCING — PHASE 8 DEMO");
+
+  console.log(`${DIM}Enterprise UI components (SAP, Salesforce, ServiceNow) frequently use${RST}`);
+  console.log(`${DIM}closed shadow roots to encapsulate their DOM. Without Phase 8, Stagehand${RST}`);
+  console.log(`${DIM}could not see — or interact with — anything inside them.${RST}`);
+
+  const browser = await chromium.launch({ headless: true });
+  const ctx     = await browser.newContext();
+  const page    = await ctx.newPage();
+
+  // Install the interceptor BEFORE setContent — this is the critical ordering.
+  // addInitScript runs before any inline <script> tags in the loaded HTML.
+  await page.addInitScript(CLOSED_SHADOW_INTERCEPTOR);
+  await page.setContent(PAGE_HTML);
+
+  console.log(`\n${B}The page contains:${RST}`);
+  console.log(`  ${G}●${RST}  An OPEN shadow root   — visible with pierceShadow: true`);
+  console.log(`  ${C}●${RST}  A CLOSED shadow root  — ${B}only${RST} visible with pierceShadow: "including-closed"`);
+  console.log(`  ${DIM}●  Regular page content — always visible${RST}`);
+
+  // ── Mode A: pierceShadow: true (default behaviour, unchanged) ─────────────
+  section(`Mode A — pierceShadow: true  (default, open shadows only)`);
+  const a = await capture(page, {
+    pierceShadow: true,
+    includeIframes: false,
+    experimental: false,
+  });
+  printTree(a.lines);
+
+  const aHasOpen   = a.tree.includes("Open Shadow");
+  const aHasClosed = a.tree.includes("Closed Shadow");
+
+  console.log(`\n  Open shadow content visible   : ${yesNo(aHasOpen,   "YES (expected)", "NO — bug!")}`);
+  console.log(`  Closed shadow content visible : ${yesNo(aHasClosed, "YES", "NO (expected — cannot pierce closed)")}`);
+  console.log(`  Snapshot line count: ${a.lines.length}`);
+
+  // ── Mode B: pierceShadow: "including-closed" (Phase 8) ────────────────────
+  section(`Mode B — pierceShadow: "including-closed"  (Phase 8 — NEW)`);
+  const b = await capture(page, {
+    pierceShadow: "including-closed",
+    includeIframes: false,
+    experimental: false,
+  });
+  printTree(b.lines);
+
+  const bHasOpen   = b.tree.includes("Open Shadow");
+  const bHasClosed = b.tree.includes("Closed Shadow");
+
+  console.log(`\n  Open shadow content visible   : ${yesNo(bHasOpen,   "YES (still works)", "NO — regression!")}`);
+  console.log(`  Closed shadow content visible : ${yesNo(bHasClosed, "YES  ← Phase 8 ✓", "NO — bug!")}`);
+  console.log(`  Snapshot line count: ${b.lines.length}`);
+
+  // ── diff summary ──────────────────────────────────────────────────────────
+  section("What Phase 8 unlocks");
+  const newLines = b.lines.length - a.lines.length;
+  console.log(`  pierceShadow: true              → ${a.lines.length} lines in snapshot`);
+  console.log(`  pierceShadow: "including-closed" → ${b.lines.length} lines in snapshot`);
+  console.log(`  Newly visible nodes             → ${G}${B}+${newLines}${RST} from closed shadow DOM`);
+
+  console.log(`
+  ${G}${B}Elements now reachable by Stagehand:${RST}
+    ${C}• Closed Shadow Button${RST}   — can be act()'d via selector
+    ${C}• Closed Shadow Link${RST}     — can be act()'d via selector
+    ${C}• note: "I live inside a CLOSED shadow root"${RST}  — can be extract()'d
+
+  ${DIM}opt-in: new Stagehand({ ... })
+  then: stagehand.captureSnapshot({ pierceShadow: "including-closed" })${RST}
+`);
+
+  await browser.close();
+})();

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -51,6 +51,7 @@
                 "group": "Configuration",
                 "pages": [
                   "v3/configuration/browser",
+                  "v3/configuration/playwright-native",
                   "v3/configuration/observability",
                   "v3/configuration/logging",
                   "v3/configuration/models"
@@ -60,6 +61,7 @@
                 "group": "Best Practices",
                 "pages": [
                   "v3/best-practices/caching",
+                  "v3/best-practices/shadow-dom",
                   "v3/best-practices/cost-optimization",
                   "v3/best-practices/deterministic-agent",
                   "v3/best-practices/using-multiple-tabs",

--- a/packages/docs/v3/best-practices/caching.mdx
+++ b/packages/docs/v3/best-practices/caching.mdx
@@ -173,6 +173,50 @@ const dataExtractionStagehand = new Stagehand({
 });
 ```
 
+### Using Local Cache with Playwright-Native Mode
+
+`cacheDir` works in **all** browser modes, including Playwright-native mode (camoufox, custom browser contexts). The cache key is derived from the instruction and page URL — it is browser-agnostic.
+
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+import { chromium } from "playwright-core";
+
+const browser = await chromium.connect({ wsEndpoint: process.env.CAMOUFOX_WS });
+const ctx = browser.contexts()[0] ?? await browser.newContext();
+
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  browserContext: ctx,
+  cacheDir: ".cache/camoufox-run",  // works exactly like standard mode
+  model: { modelName: "gpt-4o", apiKey: process.env.OPENAI_API_KEY },
+});
+await stagehand.init();
+
+const page = ctx.pages()[0] ?? await ctx.newPage();
+await page.goto("https://example.com");
+
+// First run: LLM resolves selector, writes to .cache/camoufox-run/
+// Second run: selector replayed from disk — no LLM call
+await stagehand.act("click the login button", { page });
+```
+
+<Note>
+**Detecting local cache hits**: `ActResult.cacheStatus` reflects only the Browserbase server-side cache. For local `cacheDir` hits, intercept the `logger` callback:
+
+```typescript
+let wasHit = false;
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  cacheDir: ".cache/my-flow",
+  logger: (line) => {
+    if (line.category === "cache" && String(line.message).includes("act cache hit")) {
+      wasHit = true;
+    }
+  },
+});
+```
+</Note>
+
 ### Best Practices
 
 <AccordionGroup>

--- a/packages/docs/v3/best-practices/shadow-dom.mdx
+++ b/packages/docs/v3/best-practices/shadow-dom.mdx
@@ -1,0 +1,176 @@
+---
+title: Shadow DOM
+sidebarTitle: Shadow DOM
+description: Interact with open and closed shadow roots, including enterprise UI components
+---
+
+import { V3Banner } from '/snippets/v3-banner.mdx';
+
+<V3Banner />
+
+## Overview
+
+The Shadow DOM is a browser mechanism that encapsulates a component's markup and styles from the rest of the page. Stagehand pierces shadow roots automatically, so `act()`, `extract()`, and `observe()` work on shadow-DOM elements without extra configuration.
+
+Stagehand v3 adds support for **closed** shadow roots — the harder case that blocked automation of enterprise UI frameworks like SAP Fiori, Salesforce Lightning, and ServiceNow.
+
+---
+
+## Open vs Closed Shadow Roots
+
+| | Open shadow root | Closed shadow root |
+| --- | --- | --- |
+| **How created** | `attachShadow({ mode: "open" })` | `attachShadow({ mode: "closed" })` |
+| **External JS access** | `el.shadowRoot` works | `el.shadowRoot === null` |
+| **Example frameworks** | Most web components | SAP Fiori, Salesforce Lightning, ServiceNow |
+| **Stagehand v3 support** | Yes (default) | Yes (opt-in interceptor) |
+
+---
+
+## Open Shadow DOM (default)
+
+Open shadow roots are handled automatically. No extra steps needed:
+
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const stagehand = new Stagehand({ env: "LOCAL", model });
+await stagehand.init();
+
+const page = stagehand.context.pages()[0];
+await page.goto("https://app-with-open-shadows.example.com");
+
+// Works on buttons/inputs inside open shadow roots
+await stagehand.act("click the submit button inside the checkout widget");
+const price = await stagehand.extract("get the total price", schema);
+```
+
+---
+
+## Closed Shadow DOM (enterprise apps)
+
+Closed shadow roots hide their internals from external JavaScript. To reach them, install Stagehand's `attachShadow` interceptor **as an `addInitScript`** before the page loads:
+
+```typescript
+const CLOSED_SHADOW_INTERCEPTOR = `(function() {
+  if (window.__stagehandClosedRootInstalled) return;
+  try {
+    var _closed = new WeakMap();
+    var _orig = Element.prototype.attachShadow;
+    Element.prototype.attachShadow = function(init) {
+      var root = _orig.call(this, init);
+      if (init && init.mode === "closed") _closed.set(this, root);
+      return root;
+    };
+    window.__stagehandClosedRoot = function(host) { return _closed.get(host) ?? null; };
+    window.__stagehandClosedRootInstalled = true;
+  } catch (e) {}
+})();`;
+```
+
+Install it on the context (applies to all pages) or on a specific page:
+
+```typescript
+import { chromium } from "playwright-core";
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const browser = await chromium.launch({ headless: true });
+const ctx = await browser.newContext();
+
+// Install BEFORE any navigation — addInitScript runs before inline <script> tags
+await ctx.addInitScript(CLOSED_SHADOW_INTERCEPTOR);
+
+const stagehand = new Stagehand({ env: "LOCAL", browserContext: ctx, model });
+await stagehand.init();
+
+const page = ctx.pages()[0] ?? await ctx.newPage();
+await page.goto("https://enterprise-app.example.com");
+
+// act() / extract() / observe() now see elements inside closed shadow roots
+await stagehand.act("click the Approve button in the workflow panel", { page });
+```
+
+<Warning>
+The interceptor must be installed **before** the page's `<script>` tags run. Using `page.addInitScript()` or `context.addInitScript()` guarantees this ordering.
+
+If you navigate to the page first and then install the interceptor, closed shadow roots created by the page's own scripts will **not** be captured.
+</Warning>
+
+---
+
+## How the Interceptor Works
+
+The interceptor monkey-patches `Element.prototype.attachShadow` to store a reference to every closed shadow root in a `WeakMap`. When Stagehand's DOM walker encounters a shadow host, it calls `window.__stagehandClosedRoot(host)` to retrieve the hidden root and recurse into it.
+
+This is the only reliable approach — there is no standard API to access a closed shadow root from outside the component.
+
+---
+
+## Stagehand-Managed Browser (non-native mode)
+
+If you are using Stagehand's built-in browser (`env: "LOCAL"` without `browserContext`), install the interceptor on the Stagehand context after `init()`:
+
+```typescript
+const stagehand = new Stagehand({ env: "LOCAL", model });
+await stagehand.init();
+
+// Install on the Stagehand-managed context
+await stagehand.context.addInitScript(CLOSED_SHADOW_INTERCEPTOR);
+
+const page = stagehand.context.pages()[0];
+await page.goto("https://enterprise-app.example.com");
+
+await stagehand.act("click the Save button");
+```
+
+<Note>
+When installed on the context object, the interceptor applies automatically to every new page opened within that context.
+</Note>
+
+---
+
+## Verifying Shadow DOM Coverage
+
+Use `captureNativeSnapshot` directly to inspect what the ARIA snapshot can see:
+
+```typescript
+import { captureNativeSnapshot } from "@browserbasehq/stagehand/internal";
+
+// Without interceptor: only open shadows visible
+const snapshotA = await captureNativeSnapshot(page, { pierceShadow: true });
+console.log(snapshotA.combinedTree.split("\n").length, "nodes");
+
+// With interceptor installed + pierceShadow: "including-closed"
+const snapshotB = await captureNativeSnapshot(page, { pierceShadow: "including-closed" });
+console.log(snapshotB.combinedTree.split("\n").length, "nodes");
+// Closed shadow content is now visible to act/extract/observe
+```
+
+A runnable demo comparing both modes is at:
+[`packages/core/examples/v3/demo_03_shadow_dom.ts`](https://github.com/browserbase/stagehand/blob/main/packages/core/examples/v3/demo_03_shadow_dom.ts)
+
+```bash
+pnpm example v3/demo_03_shadow_dom
+```
+
+---
+
+## Troubleshooting
+
+<AccordionGroup>
+
+<Accordion title="Elements inside closed shadow roots are not found">
+1. Check that `addInitScript` is called **before** `page.goto()` or `page.setContent()`
+2. Verify the interceptor is installed: `await page.evaluate(() => !!window.__stagehandClosedRootInstalled)` should return `true`
+3. Some frameworks create shadow roots in response to user interaction. Install the interceptor on the context (`context.addInitScript(...)`) so it covers all future navigations
+</Accordion>
+
+<Accordion title="Act() still fails on closed shadow elements">
+Shadow DOM visibility is necessary but not sufficient. The element must also be reachable by the XPath that Stagehand generates. If the element is deeply nested inside multiple shadow roots, describe it in plain language in your instruction and Stagehand will walk the shadow tree to find it.
+</Accordion>
+
+<Accordion title="Performance impact of the interceptor">
+The interceptor adds negligible overhead — it only stores a `WeakMap` entry per `attachShadow` call, which happens a fixed number of times per page load. There is no per-interaction cost.
+</Accordion>
+
+</AccordionGroup>

--- a/packages/docs/v3/configuration/browser.mdx
+++ b/packages/docs/v3/configuration/browser.mdx
@@ -263,6 +263,88 @@ const stagehand = new Stagehand({
 await stagehand.init();
 ```
 
+## Playwright-Native Mode
+
+Playwright-Native Mode lets you connect Stagehand to a browser that **you** launch and manage — instead of Stagehand creating one for you. This is useful when:
+
+- You want to use **Firefox** (e.g. via [camoufox](https://camoufox.com/) for anti-bot stealth)
+- You need full control over the browser launch flags, profiles, or extensions
+- You want Stagehand to operate on a **CDP-free** browser that only exposes the Playwright public API
+
+### How It Works
+
+Pass a Playwright `BrowserContext` to `browserContext` in the constructor. Stagehand will use that context directly for all operations — it will not launch or close the browser.
+
+```typescript
+import { chromium } from "playwright-core";
+import { Stagehand } from "@browserbasehq/stagehand";
+
+// Launch (or connect to) the browser yourself
+const browser = await chromium.connect({ wsEndpoint: process.env.CAMOUFOX_WS });
+const ctx = browser.contexts()[0] ?? await browser.newContext();
+
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  browserContext: ctx,
+  model: { modelName: "gpt-4o", apiKey: process.env.OPENAI_API_KEY },
+});
+await stagehand.init();
+
+const page = ctx.pages()[0] ?? await ctx.newPage();
+await page.goto("https://example.com");
+
+// Always pass the page explicitly in native mode
+await stagehand.act("click the login button", { page });
+const data = await stagehand.extract("get the page title", schema, { page });
+
+await stagehand.close();       // disconnects Stagehand — browser keeps running
+await browser.close();         // you close the browser when you're done
+```
+
+### Key Differences from Standard Mode
+
+| | Standard Mode | Playwright-Native Mode |
+| --- | --- | --- |
+| **Browser** | Stagehand launches Chromium | You supply any Playwright browser |
+| **Firefox support** | No | Yes (camoufox, Playwright Firefox) |
+| **CDP required** | Yes (internally) | No |
+| **`page` in methods** | Optional (uses active page) | **Required** — must be passed explicitly |
+| **Browser lifecycle** | Managed by Stagehand | Managed by you |
+| **`stagehand.close()`** | Terminates browser | Disconnects only — browser stays alive |
+
+### Using camoufox
+
+[camoufox](https://camoufox.com/) is a hardened Firefox build that mimics real browser fingerprints. Connect to it via its WebSocket endpoint:
+
+```bash
+# Install and launch camoufox (copy the ws:// URL it prints)
+pip install camoufox
+python -m camoufox fetch
+python -m camoufox run
+```
+
+```typescript
+const browser = await chromium.connect({
+  wsEndpoint: process.env.CAMOUFOX_WS  // e.g. ws://localhost:PORT/TOKEN
+});
+const ctx = browser.contexts()[0] ?? await browser.newContext();
+
+const stagehand = new Stagehand({ env: "LOCAL", browserContext: ctx, model });
+await stagehand.init();
+```
+
+<Tip>
+`cacheDir` works normally in Playwright-native mode. Local action caches are keyed by instruction + URL and are browser-agnostic.
+</Tip>
+
+<Note>
+Local cache hits are visible via the `logger` callback (look for `"act cache hit"` in `line.message`), not via `ActResult.cacheStatus` — that field only reflects Browserbase server-side cache.
+</Note>
+
+For a complete working example see [`packages/core/examples/v3/demo_02_camoufox_extract.ts`](https://github.com/browserbase/stagehand/blob/main/packages/core/examples/v3/demo_02_camoufox_extract.ts).
+
+---
+
 ## Advanced Configuration
 
 ### Keep Alive

--- a/packages/docs/v3/configuration/playwright-native.mdx
+++ b/packages/docs/v3/configuration/playwright-native.mdx
@@ -1,0 +1,217 @@
+---
+title: Playwright-Native Mode
+sidebarTitle: Playwright-Native Mode
+description: Connect Stagehand to any Playwright browser — Firefox, camoufox, or your own custom context
+---
+
+import { V3Banner } from '/snippets/v3-banner.mdx';
+
+<V3Banner />
+
+## Overview
+
+By default Stagehand launches and manages its own Chromium browser. **Playwright-Native Mode** inverts this: you launch any Playwright-compatible browser yourself and hand Stagehand a `BrowserContext` to operate on.
+
+This unlocks:
+
+- **Firefox** — Playwright's Firefox engine, including [camoufox](https://camoufox.com/) (hardened anti-detection Firefox)
+- **Custom launch flags** — proxy chains, custom profiles, extensions, persistent user-data dirs
+- **CDP-free automation** — Stagehand uses only the Playwright public API; no Chrome DevTools Protocol tunnel required
+- **Shared browser sessions** — hand the same context to Stagehand and other Playwright code simultaneously
+
+---
+
+## Quick Start
+
+```typescript
+import { chromium } from "playwright-core";
+import { Stagehand } from "@browserbasehq/stagehand";
+import { z } from "zod";
+
+// 1. Launch the browser yourself
+const browser = await chromium.connect({ wsEndpoint: process.env.CAMOUFOX_WS });
+const ctx = browser.contexts()[0] ?? await browser.newContext();
+const page = ctx.pages()[0] ?? await ctx.newPage();
+
+// 2. Wire Stagehand to the external context
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  browserContext: ctx,
+  model: { modelName: "gpt-4o", apiKey: process.env.OPENAI_API_KEY },
+});
+await stagehand.init();
+
+// 3. Use Stagehand — always pass `page` explicitly
+await page.goto("https://quotes.toscrape.com");
+await page.waitForLoadState("networkidle");
+
+const actions = await stagehand.observe("list all navigation links", { page });
+console.log(actions.length, "links found");
+
+const result = await stagehand.extract(
+  "extract up to 5 quotes",
+  z.object({ quotes: z.array(z.object({ author: z.string(), text: z.string() })) }),
+  { page },
+);
+console.log(result.quotes);
+
+// 4. Close in the right order
+await stagehand.close();   // disconnect Stagehand (browser stays alive)
+await browser.close();     // you decide when to close the browser
+```
+
+---
+
+## Using camoufox (Firefox stealth browser)
+
+[camoufox](https://camoufox.com/) is a hardened Firefox fork that randomises browser fingerprints and bypasses many bot-detection heuristics. Install it with:
+
+```bash
+pip install camoufox
+python -m camoufox fetch       # download the Firefox binary (~100 MB, one time)
+python -m camoufox run         # prints  ws://localhost:<PORT>/<TOKEN>
+```
+
+Set `CAMOUFOX_WS` to the printed `ws://` URL, then connect:
+
+```typescript
+import { chromium } from "playwright-core";
+
+const browser = await chromium.connect({ wsEndpoint: process.env.CAMOUFOX_WS });
+const ctx = browser.contexts()[0] ?? await browser.newContext();
+```
+
+<Tip>
+camoufox exposes a Playwright CDP endpoint, so `chromium.connect()` works even though the underlying engine is Firefox.
+</Tip>
+
+---
+
+## Constructor Options
+
+The only new option is `browserContext`. All other `V3Options` apply normally.
+
+```typescript
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  browserContext: ctx,        // the externally-managed Playwright BrowserContext
+  model: { ... },
+  cacheDir: ".cache/native",  // local caching works as normal
+  verbose: 1,
+});
+```
+
+See the [`Stagehand` reference](/v3/references/stagehand) for the full option list.
+
+---
+
+## Passing `page` to Methods
+
+When using `browserContext`, Stagehand has no concept of an "active page" — you control the page. **You must pass `page` explicitly** to every AI method call:
+
+```typescript
+const page = ctx.pages()[0] ?? await ctx.newPage();
+await page.goto("https://example.com");
+
+// ✅ Correct — page passed explicitly
+await stagehand.act("click the login button", { page });
+const data = await stagehand.extract("get the title", schema, { page });
+const found = await stagehand.observe("find all buttons", { page });
+
+// ❌ Will throw — no active page in native mode
+await stagehand.act("click the login button");
+```
+
+---
+
+## Local Caching in Native Mode
+
+`cacheDir` works the same way in Playwright-native mode. Cache entries are keyed by instruction + page URL and are browser-agnostic:
+
+```typescript
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  browserContext: ctx,
+  cacheDir: ".cache/camoufox-login",
+});
+```
+
+On the second run, every `act()` call whose selector was cached replays instantly — no LLM call, no network round-trip.
+
+<Note>
+`ActResult.cacheStatus` reflects the Browserbase server-side cache only. To detect local cache hits, intercept the `logger`:
+
+```typescript
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  browserContext: ctx,
+  cacheDir: ".cache/my-flow",
+  logger: (line) => {
+    if (line.category === "cache" && String(line.message).includes("act cache hit")) {
+      console.log("cache HIT");
+    }
+  },
+});
+```
+</Note>
+
+---
+
+## Shadow DOM in Native Mode
+
+Playwright-native mode fully supports the shadow DOM improvements added in Stagehand v3. To pierce closed shadow roots (e.g. SAP, Salesforce, ServiceNow components), install the interceptor as an `addInitScript` **before** navigating:
+
+```typescript
+// captureNativeSnapshot is the underlying snapshot engine
+import { captureNativeSnapshot } from "@browserbasehq/stagehand/internal";
+
+// Install the closed-shadow interceptor on the page
+await page.addInitScript(`(function() {
+  var _closed = new WeakMap();
+  var _orig = Element.prototype.attachShadow;
+  Element.prototype.attachShadow = function(init) {
+    var root = _orig.call(this, init);
+    if (init && init.mode === "closed") _closed.set(this, root);
+    return root;
+  };
+  window.__stagehandClosedRoot = function(host) { return _closed.get(host) ?? null; };
+  window.__stagehandClosedRootInstalled = true;
+})()`);
+
+await page.goto("https://enterprise-app.example.com");
+// Now act()/extract()/observe() can see elements inside closed shadow roots
+```
+
+See the [Shadow DOM guide](/v3/best-practices/shadow-dom) for full details.
+
+---
+
+## Comparison: Standard vs Playwright-Native
+
+| | Standard Mode | Playwright-Native Mode |
+| --- | --- | --- |
+| **Browser engine** | Chromium (auto-launched) | Any Playwright browser |
+| **Firefox / camoufox** | No | Yes |
+| **CDP** | Required internally | Not required |
+| **`page` in methods** | Optional | **Required** |
+| **Browser lifecycle** | Managed by Stagehand | Managed by you |
+| **`stagehand.close()`** | Terminates browser | Disconnects only |
+| **Local caching** | Yes | Yes |
+| **Shadow DOM** | Yes | Yes |
+| **Browserbase** | Yes | No (`env` must be `"LOCAL"`) |
+
+---
+
+## Complete Example
+
+A fully-annotated demo is available at [`packages/core/examples/v3/demo_02_camoufox_extract.ts`](https://github.com/browserbase/stagehand/blob/main/packages/core/examples/v3/demo_02_camoufox_extract.ts).
+
+Run it with:
+
+```bash
+# Set env vars in .env
+CAMOUFOX_WS=ws://localhost:PORT/TOKEN
+OPENAI_API_KEY=...   # or OPENROUTER_API_KEY
+
+pnpm example v3/demo_02_camoufox_extract
+```

--- a/packages/docs/v3/references/act.mdx
+++ b/packages/docs/v3/references/act.mdx
@@ -47,7 +47,7 @@ interface ActOptions {
   model?: ModelConfiguration;
   variables?: Record<string, VariableValue>;
   timeout?: number;
-  page?: PlaywrightPage | PuppeteerPage | PatchrightPage | Page;
+  page?: PlaywrightPage | PuppeteerPage | PatchrightPage | Page | PlaywrightNativePage;
   serverCache?: boolean;
 }
 
@@ -140,14 +140,17 @@ type ModelConfiguration =
   Maximum time in **milliseconds** to wait for the action to complete. Default varies by configuration.
 </ParamField>
 
-<ParamField path="page" type="PlaywrightPage | PuppeteerPage | PatchrightPage | Page" optional>
+<ParamField path="page" type="PlaywrightPage | PuppeteerPage | PatchrightPage | Page | PlaywrightNativePage" optional>
   Optional: Specify which page to perform the action on. Supports multiple browser automation libraries:
   - **Playwright**: Native Playwright Page objects
   - **Puppeteer**: Puppeteer Page objects
   - **Patchright**: Patchright Page objects
   - **Stagehand Page**: Stagehand's wrapped Page object
+  - **PlaywrightNativePage**: Required when using `browserContext` (Playwright-native mode)
 
   If not specified, defaults to the current "active" page in your Stagehand instance.
+
+  <Note>When using `browserContext` (Playwright-native mode with an external browser like camoufox), you **must** pass `page` explicitly since Stagehand does not manage the browser lifecycle.</Note>
 </ParamField>
 
 <ParamField path="serverCache" type="boolean" optional>

--- a/packages/docs/v3/references/extract.mdx
+++ b/packages/docs/v3/references/extract.mdx
@@ -43,7 +43,7 @@ interface ExtractOptions {
   model?: ModelConfiguration;
   timeout?: number;
   selector?: string;
-  page?: PlaywrightPage | PuppeteerPage | PatchrightPage | Page;
+  page?: PlaywrightPage | PuppeteerPage | PatchrightPage | Page | PlaywrightNativePage;
   serverCache?: boolean;
 }
 
@@ -98,14 +98,17 @@ type ModelConfiguration =
   Optional selector (XPath, CSS selector, etc.) to limit extraction scope to a specific part of the page. Reduces token usage and improves accuracy.
 </ParamField>
 
-<ParamField path="page" type="PlaywrightPage | PuppeteerPage | PatchrightPage | Page" optional>
+<ParamField path="page" type="PlaywrightPage | PuppeteerPage | PatchrightPage | Page | PlaywrightNativePage" optional>
   Optional: Specify which page to perform the extraction on. Supports multiple browser automation libraries:
   - **Playwright**: Native Playwright Page objects
   - **Puppeteer**: Puppeteer Page objects
   - **Patchright**: Patchright Page objects
   - **Stagehand Page**: Stagehand's wrapped Page object
+  - **PlaywrightNativePage**: Required when using `browserContext` (Playwright-native mode)
 
   If not specified, defaults to the current "active" page in your Stagehand instance.
+
+  <Note>When using `browserContext` (Playwright-native mode with an external browser like camoufox), you **must** pass `page` explicitly since Stagehand does not manage the browser lifecycle.</Note>
 </ParamField>
 
 <ParamField path="serverCache" type="boolean" optional>

--- a/packages/docs/v3/references/observe.mdx
+++ b/packages/docs/v3/references/observe.mdx
@@ -33,7 +33,7 @@ interface ObserveOptions {
   model?: ModelConfiguration;
   timeout?: number;
   selector?: string;
-  page?: PlaywrightPage | PuppeteerPage | PatchrightPage | Page;
+  page?: PlaywrightPage | PuppeteerPage | PatchrightPage | Page | PlaywrightNativePage;
   serverCache?: boolean;
 }
 
@@ -84,14 +84,17 @@ type ModelConfiguration =
   Optional XPath selector to focus the observation on a specific part of the page. Useful for narrowing down the search area.
 </ParamField>
 
-<ParamField path="page" type="PlaywrightPage | PuppeteerPage | PatchrightPage | Page" optional>
+<ParamField path="page" type="PlaywrightPage | PuppeteerPage | PatchrightPage | Page | PlaywrightNativePage" optional>
   Optional: Specify which page to perform the observation on. Supports multiple browser automation libraries:
   - **Playwright**: Native Playwright Page objects
   - **Puppeteer**: Puppeteer Page objects
   - **Patchright**: Patchright Page objects
   - **Stagehand Page**: Stagehand's wrapped Page object
+  - **PlaywrightNativePage**: Required when using `browserContext` (Playwright-native mode)
 
   If not specified, defaults to the current "active" page in your Stagehand instance.
+
+  <Note>When using `browserContext` (Playwright-native mode with an external browser like camoufox), you **must** pass `page` explicitly since Stagehand does not manage the browser lifecycle.</Note>
 </ParamField>
 
 <ParamField path="serverCache" type="boolean" optional>

--- a/packages/docs/v3/references/stagehand.mdx
+++ b/packages/docs/v3/references/stagehand.mdx
@@ -48,6 +48,7 @@ interface V3Options {
 
   // Local browser options
   localBrowserLaunchOptions?: LocalBrowserLaunchOptions;
+  browserContext?: BrowserContext; // Playwright-native: bring your own context
 
   // AI/LLM configuration
   model?: ModelConfiguration;
@@ -157,6 +158,34 @@ interface V3Options {
       Attach to existing Chrome instance via CDP WebSocket URL.
     </ParamField>
   </Expandable>
+</ParamField>
+
+<ParamField path="browserContext" type="BrowserContext" optional>
+  Pass an externally-managed Playwright `BrowserContext` (e.g. from camoufox or a custom browser launch) instead of letting Stagehand create its own browser. When set, Stagehand operates entirely through the Playwright public API — no CDP required.
+
+  <Note>When using `browserContext`, you must pass the `page` option explicitly to `act()`, `extract()`, and `observe()` since Stagehand does not manage the browser lifecycle.</Note>
+
+  See the [Playwright-Native Mode guide](/v3/configuration/playwright-native) for full details.
+
+  **Example:**
+  ```typescript
+  import { chromium } from "playwright-core";
+  import { Stagehand } from "@browserbasehq/stagehand";
+
+  const browser = await chromium.connect({ wsEndpoint: process.env.CAMOUFOX_WS });
+  const ctx = browser.contexts()[0] ?? await browser.newContext();
+
+  const stagehand = new Stagehand({
+    env: "LOCAL",
+    browserContext: ctx,
+    model: { modelName: "gpt-4o", apiKey: process.env.OPENAI_API_KEY },
+  });
+  await stagehand.init();
+
+  const page = ctx.pages()[0] ?? await ctx.newPage();
+  await page.goto("https://example.com");
+  await stagehand.act("click the button", { page });
+  ```
 </ParamField>
 
 #### AI/LLM Configuration


### PR DESCRIPTION
## Summary

- **New page**: `v3/configuration/playwright-native` — full guide for `browserContext` option, camoufox/Firefox setup, page-passing requirement, caching behaviour, and mode comparison table
- **New page**: `v3/best-practices/shadow-dom` — open + closed shadow root automation, `attachShadow` interceptor pattern, enterprise app troubleshooting (SAP, Salesforce, ServiceNow)
- **stagehand.mdx** — adds `browserContext` to `V3Options` interface block and `<ParamField>` section
- **act / extract / observe refs** — `page` type updated to include `PlaywrightNativePage`; note that `page` must be passed explicitly in native mode
- **configuration/browser.mdx** — new "Playwright-Native Mode" section with camoufox quickstart and `cacheDir` / logger notes
- **best-practices/caching.mdx** — new native-mode caching section and `logger` snippet for detecting local cache hits
- **docs.json** — `playwright-native` added to Configuration group; `shadow-dom` added to Best Practices group
- **Demo scripts** (`packages/core/examples/v3/`):
  - `demo_01_caching.ts` — act() cold/warm cache comparison using logger interception
  - `demo_02_camoufox_extract.ts` — camoufox + observe() + extract() end-to-end
  - `demo_03_shadow_dom.ts` — `pierceShadow: true` vs `"including-closed"` diff with live node counts

## Test plan

- [ ] Mintlify preview renders both new pages without broken links
- [ ] `v3/configuration/playwright-native` appears under Configuration in sidebar
- [ ] `v3/best-practices/shadow-dom` appears under Best Practices in sidebar
- [ ] `stagehand.mdx` shows `browserContext` ParamField
- [ ] act/extract/observe refs show `PlaywrightNativePage` in `page` type union
- [ ] `pnpm example v3/demo_01_caching` runs (requires `OPENAI_API_KEY`)
- [ ] `pnpm example v3/demo_03_shadow_dom` runs (headless, no API key needed)

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full docs for Playwright‑native mode and closed Shadow DOM automation, plus three runnable demos to showcase caching, camoufox/Firefox, and shadow‑piercing.
Clarifies the `browserContext` option, the need to pass `page` in native mode, and how local caching works with logger hints.

- **New Features**
  - New docs pages: `v3/configuration/playwright-native` and `v3/best-practices/shadow-dom`.
  - Updated docs: `stagehand` reference adds `browserContext`; `act`/`extract`/`observe` reference pages include `PlaywrightNativePage` and note the explicit `page` requirement; `configuration/browser` adds a Playwright‑native section; caching guide documents native‑mode local cache and a `logger` snippet; navigation updated in `docs.json`.
  - New demos in `packages/core/examples/v3/`: `demo_01_caching.ts` (cold vs warm cache), `demo_02_camoufox_extract.ts` (camoufox + observe/extract), `demo_03_shadow_dom.ts` (open vs closed shadow diff).

- **Migration**
  - No breaking changes. When using `browserContext`, always pass the Playwright `page` to `act()`/`extract()`/`observe()`.
  - For closed shadow roots, install the `attachShadow` interceptor via `addInitScript` before navigation to enable `"including-closed"` piercing.

<sup>Written for commit 4657079a681ac8ff6f852f9e8ecd4739f290afa6. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1855">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

