### PR TITLE
Revert broken finished SSE yield config

### DIFF
--- a/stainless.yml
+++ b/stainless.yml
@@ -202,7 +202,7 @@ resources:
 streaming:
   on_event:
     - data_starts_with: '{"data":{"status":"finished"'
-      handle: yield
+      handle: done
     - data_starts_with: error
       handle: error
     - event_type: null


### PR DESCRIPTION
## Summary
- revert the Stainless streaming config change that turned the terminal finished event from `done` into `yield`
- restore the pre-#1846 behavior while we replace it with a compatible fix

## Testing
- `pnpm --dir /tmp/stagehand-revert-sse.mrKx4n exec prettier --check stainless.yml`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the Stainless streaming config so the finished SSE event is handled as done instead of yield. Restores previous behavior and fixes stream completion for clients expecting done.

<sup>Written for commit 687a11f652dc8404cb176a8754b73e017b547ce1. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1856">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

