### PR TITLE
[v4]: add index to selector schemas

### DIFF
--- a/packages/server-v4/openapi.v4.yaml
+++ b/packages/server-v4/openapi.v4.yaml
@@ -2355,7 +2355,7 @@ components:
           example: //button[text()='Submit']
           type: string
           minLength: 1
-        index:
+        idx:
           example: 0
           type: integer
           minimum: 0
@@ -2370,7 +2370,7 @@ components:
           example: .btn-submit
           type: string
           minLength: 1
-        index:
+        idx:
           example: 0
           type: integer
           minimum: 0
@@ -2385,7 +2385,7 @@ components:
           example: Submit
           type: string
           minLength: 1
-        index:
+        idx:
           example: 0
           type: integer
           minimum: 0

--- a/packages/server-v4/src/schemas/v4/page.ts
+++ b/packages/server-v4/src/schemas/v4/page.ts
@@ -112,7 +112,7 @@ export const PageActionStatusSchema = z
 export const XPathSelectorSchema = z
   .object({
     xpath: z.string().min(1).meta({ example: "//button[text()='Submit']" }),
-    index: z.number().int().nonnegative().optional().meta({ example: 0 }),
+    idx: z.number().int().nonnegative().optional().meta({ example: 0 }),
   })
   .strict()
   .meta({ id: "XPathSelector" });
@@ -120,7 +120,7 @@ export const XPathSelectorSchema = z
 export const CssSelectorSchema = z
   .object({
     css: z.string().min(1).meta({ example: ".btn-submit" }),
-    index: z.number().int().nonnegative().optional().meta({ example: 0 }),
+    idx: z.number().int().nonnegative().optional().meta({ example: 0 }),
   })
   .strict()
   .meta({ id: "CssSelector" });
@@ -128,7 +128,7 @@ export const CssSelectorSchema = z
 export const TextSelectorSchema = z
   .object({
     text: z.string().min(1).meta({ example: "Submit" }),
-    index: z.number().int().nonnegative().optional().meta({ example: 0 }),
+    idx: z.number().int().nonnegative().optional().meta({ example: 0 }),
   })
   .strict()
   .meta({ id: "TextSelector" });

--- a/packages/server-v4/test/integration/v4/page.test.ts
+++ b/packages/server-v4/test/integration/v4/page.test.ts
@@ -943,17 +943,17 @@ describe("v4 page routes", { concurrency: false }, () => {
     assertSuccessAction(cssSelectorCtx, "click");
 
     const cssWithIndexCtx = await postPageRoute("click", sessionId, {
-      selector: { css: "button", index: 0 },
+      selector: { css: "button", idx: 0 },
     });
     assertSuccessAction(cssWithIndexCtx, "click");
 
     const xpathWithIndexCtx = await postPageRoute("click", sessionId, {
-      selector: { xpath: "//button", index: 0 },
+      selector: { xpath: "//button", idx: 0 },
     });
     assertSuccessAction(xpathWithIndexCtx, "click");
 
     const textWithIndexCtx = await postPageRoute("click", sessionId, {
-      selector: { text: "Submit", index: 0 },
+      selector: { text: "Submit", idx: 0 },
     });
     assertSuccessAction(textWithIndexCtx, "click");
 


### PR DESCRIPTION
# why
- selectors can resolve to multiple nodes
- we need to give the user freedom to optionally provide an `index`, indicating the desired element if multiple are found
# what changed
- added an optional `index` field to `XPathSelectorSchema`, `CssSelectorSchema` & `TextSelectorSchema`
- note: `CoordinateSelectorSchema` remains unchanged, since coordinates are inherently specific

### selector schema before:
<img width="555" height="944" alt="Screenshot 2026-03-19 at 4 31 50 PM" src="https://github.com/user-attachments/assets/cd020162-02c2-44f9-a69e-d226d8501571" />

### selector schema after: 
<img width="603" height="980" alt="Screenshot 2026-03-19 at 4 33 32 PM" src="https://github.com/user-attachments/assets/0e730297-a5db-4a82-a7ee-b828a8520275" />

# test plan
- added new test case in `packages/server-v4/src/schemas/v4/page.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional non-negative idx to XPath, CSS, and text selectors so callers can target a specific element when a selector matches multiple nodes. Updates the v4 schema and OpenAPI spec without breaking existing clients.

- **New Features**
  - Added optional non-negative `idx` to `XPathSelectorSchema`, `CssSelectorSchema`, and `TextSelectorSchema`.
  - Left `CoordinateSelectorSchema` unchanged.
  - Updated `openapi.v4.yaml` with the new `idx` field and examples.
  - Expanded integration tests to cover `css`, `xpath`, and `text` selectors with `idx`.

<sup>Written for commit 0c25f7442cfd0bdc11fb6da761bddf4fe1375699. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1861">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

