### PR TITLE
fix(agent): use actual value in fillForm instead of hallucinated placeholder

### DIFF
--- a/packages/core/lib/v3/agent/tools/fillform.ts
+++ b/packages/core/lib/v3/agent/tools/fillform.ts
@@ -4,6 +4,7 @@ import type { V3 } from "../../v3.js";
 import type { Action } from "../../types/public/methods.js";
 import type { AgentModelConfig, Variables } from "../../types/public/agent.js";
 import { TimeoutError } from "../../types/public/sdkErrors.js";
+import { substituteVariables } from "../utils/variables.js";
 
 export const fillFormTool = (
   v3: V3,
@@ -12,18 +13,22 @@ export const fillFormTool = (
   toolTimeout?: number,
 ) => {
   const hasVariables = variables && Object.keys(variables).length > 0;
+  const valueDescription = hasVariables
+    ? `The exact text to type into the field. Use %variableName% to substitute a variable value. Available: ${Object.keys(variables).join(", ")}`
+    : "The exact text to type into the field";
   const actionDescription = hasVariables
-    ? `Must follow the pattern: "type <exact value> into the <field name> <fieldType>". Use %variableName% to substitute a variable value. Available: ${Object.keys(variables).join(", ")}. Examples: "type %email% into the email input", "type %password% into the password input"`
-    : 'Must follow the pattern: "type <exact value> into the <field name> <fieldType>". Examples: "type john@example.com into the email input", "type John into the first name input"';
+    ? `Describe which field to target, e.g. "type into the email input", "type into the password field". Use %variableName% to substitute a variable value. Available: ${Object.keys(variables).join(", ")}. Example: "type %email% into the email input"`
+    : 'Describe which field to target, e.g. "type into the email input", "type into the first name input"';
 
   return tool({
     description:
-      'FORM FILL - MULTI-FIELD INPUT TOOL\nFill 2+ form inputs/textareas at once. Each action MUST include the exact text to type and the target field, e.g. "type john@example.com into the email field".',
+      'FORM FILL - MULTI-FIELD INPUT TOOL\nFill 2+ form inputs/textareas at once. Each field requires an action describing the target element and a value with the text to type.',
     inputSchema: z.object({
       fields: z
         .array(
           z.object({
             action: z.string().describe(actionDescription),
+            value: z.string().describe(valueDescription),
           }),
         )
         .min(1, "Provide at least one field to fill"),
@@ -49,6 +54,17 @@ export const fillFormTool = (
           ? { model: executionModel, timeout: toolTimeout }
           : { timeout: toolTimeout };
         const observeResults = await v3.observe(instruction, observeOptions);
+
+        // Override observe results with the actual values provided by the agent.
+        // The LLM used by observe() may hallucinate placeholder values instead of
+        // using the intended text, so we inject the real values before calling act().
+        for (let i = 0; i < observeResults.length && i < fields.length; i++) {
+          const res = observeResults[i];
+          if (res.method === "fill" && res.arguments && res.arguments.length > 0) {
+            const actualValue = substituteVariables(fields[i].value, variables);
+            res.arguments[0] = actualValue;
+          }
+        }
 
         const completed = [] as unknown[];
         const replayableActions: Action[] = [];


### PR DESCRIPTION
## Problem

The `fillForm` agent tool receives a value parameter but never uses it. When the tool calls `observe()`, it only passes the `action` description, causing the LLM to hallucinate placeholder values like `test@example.com` instead of using the actual provided value.

This affects:
- Custom tool results (e.g., TOTP codes for 2FA flows)
- Any scenario where the agent separates the value from the action string
- Flaky behavior that depends on whether the LLM embeds the value in the action text

Fixes #1789

## Root Cause

The `fillForm` input schema only had an `action` field. The `observe()` call used only the action description to identify elements, but the observe LLM then hallucinates what value to type instead of using the intended one.

## Changes

1. **Added value field to the input schema** — Each field now requires both an action (describing which element to target) and a value (the text to type)
2. **Override observe results with actual values** — After `observe()` returns element identification results, the code injects the actual value into the observe result's arguments before calling `act()`
3. **Variable substitution support** — Uses `substituteVariables()` to support variable tokens in values, matching the behavior of the `type` tool
4. **Updated descriptions** — Action description now clarifies it describes the target element, not the value

## Verification

The fix can be verified by:
1. Using the agent to fill a form where the LLM generates action strings that don't embed the value, and confirming the actual value from the value field is used
2. Testing with 2FA/TOTP flows where custom tools return exact values

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the agent’s `fillForm` tool use the actual provided value for each field instead of hallucinated placeholders. This fixes flaky fills and ensures exact values (e.g., TOTP codes) are typed.

- **Bug Fixes**
  - Add `value` to each field in the input schema; `action` now only identifies the target element.
  - Inject the provided value into `observe()` results before `act()`, with `substituteVariables()` support.
  - Clarify action/value descriptions.

- **Migration**
  - Update all `fillForm` calls to include a `value` for each field.
  - Move any text previously embedded in `action` into `value`; keep `action` focused on the target (e.g., "type into the email input").
  - `%variableName%` tokens are supported in `value` when variables are available.

<sup>Written for commit 331efb3a105676fbe85bf782a4927364a1099f79. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1863">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

