### PR TITLE
Fix GPT 5.4 reasoning input

### DIFF
--- a/packages/core/lib/v3/llm/aisdk.ts
+++ b/packages/core/lib/v3/llm/aisdk.ts
@@ -134,10 +134,6 @@ export class AISdkClient extends LLMClient {
     let objectResponse: Awaited<ReturnType<typeof generateObject>>;
     const isGPT5 = this.model.modelId.includes("gpt-5");
     const isCodex = this.model.modelId.includes("codex");
-    const usesLowReasoningEffort =
-      (this.model.modelId.includes("gpt-5.1") ||
-        this.model.modelId.includes("gpt-5.2")) &&
-      !isCodex;
     // Kimi models only support temperature=1
     const isKimi = this.model.modelId.includes("kimi");
     const temperature = isKimi ? 1 : options.temperature;
@@ -184,11 +180,7 @@ You must respond in JSON format. respond WITH JSON. Do not include any other tex
             ? {
                 openai: {
                   textVerbosity: isCodex ? "medium" : "low", // codex models only support 'medium'
-                  reasoningEffort: isCodex
-                    ? "medium"
-                    : usesLowReasoningEffort
-                      ? "low"
-                      : "minimal",
+                  reasoningEffort: isCodex ? "medium" : "low",
                 },
               }
             : undefined,

--- a/packages/evals/lib/AISdkClientWrapped.ts
+++ b/packages/evals/lib/AISdkClientWrapped.ts
@@ -135,10 +135,6 @@ export class AISdkClientWrapped extends LLMClient {
     let objectResponse: Awaited<ReturnType<typeof generateObject>>;
     const isGPT5 = this.model.modelId.includes("gpt-5");
     const isCodex = this.model.modelId.includes("codex");
-    const usesLowReasoningEffort =
-      (this.model.modelId.includes("gpt-5.1") ||
-        this.model.modelId.includes("gpt-5.2")) &&
-      !isCodex;
     const isDeepSeek = this.model.modelId.includes("deepseek");
     // Kimi models only support temperature=1
     const isKimi = this.model.modelId.includes("kimi");
@@ -166,11 +162,7 @@ You must respond in JSON format. respond WITH JSON. Do not include any other tex
             ? {
                 openai: {
                   textVerbosity: isCodex ? "medium" : "low", // codex models only support 'medium'
-                  reasoningEffort: isCodex
-                    ? "medium"
-                    : usesLowReasoningEffort
-                      ? "low"
-                      : "minimal",
+                  reasoningEffort: isCodex ? "medium" : "low",
                 },
               }
             : undefined,


### PR DESCRIPTION
# Summary

 GPT-5.4 doesn't support `reasoningEffort: "minimal"`, causing API errors. Changed default from "minimal" to "low", which is supported by all GPT-5 variants.