### PR TITLE
docs: make BROWSERBASE_PROJECT_ID optional across v3 docs

### DIFF
--- a/packages/core/lib/v3/types/public/options.ts
+++ b/packages/core/lib/v3/types/public/options.ts
@@ -26,9 +26,9 @@ export interface V3Options {
    * but callers should not rely on that remaining a permanent invariant.
    */
   sessionId?: string;
-  // Browserbase (required when env = "BROWSERBASE")
-  apiKey?: string;
-  projectId?: string;
+  // Browserbase credentials
+  apiKey?: string; // Required when env = "BROWSERBASE" (or set BROWSERBASE_API_KEY env var)
+  projectId?: string; // Optional: defaults to your default project if omitted
   /**
    * Optional: fine-tune Browserbase session creation or resume an existing session.
    */

--- a/packages/docs/v3/configuration/browser.mdx
+++ b/packages/docs/v3/configuration/browser.mdx
@@ -77,13 +77,14 @@ Before getting started, set up the required environment variables:
 
 <CodeGroup>
 ```bash .env
-BROWSERBASE_API_KEY=your_api_key_here
-BROWSERBASE_PROJECT_ID=your_project_id_here
+BROWSERBASE_API_KEY=***
+# Optional: only needed if you want to target a specific project
+# BROWSERBASE_PROJECT_ID=your_project_id_here
 ```
 </CodeGroup>
 
 <Tip>
-Get your API key and Project ID from the [Browserbase Dashboard](https://browserbase.com/overview)
+Get your API key from the [Browserbase Dashboard](https://browserbase.com/overview). A Project ID is optional — if omitted, your default project will be used automatically.
 </Tip>
 
 ### Using Stagehand with Browserbase
@@ -110,8 +111,9 @@ import { Stagehand } from "@browserbasehq/stagehand";
 
 const stagehand = new Stagehand({
   env: "BROWSERBASE",
-  // Optional: API Key and Project ID will be pulled directly from your environment
+  // Optional: API Key will be pulled from BROWSERBASE_API_KEY env var
   apiKey: process.env.BROWSERBASE_API_KEY,
+  // Optional: if omitted, your default project is used
   projectId: process.env.BROWSERBASE_PROJECT_ID,
   browserbaseSessionCreateParams: {
     proxies: true,
@@ -132,9 +134,9 @@ console.log("Session ID:", stagehand.sessionId);
 const stagehand = new Stagehand({
       env: "BROWSERBASE",
       apiKey: process.env.BROWSERBASE_API_KEY,
+      // Optional: defaults to your default project if omitted
       projectId: process.env.BROWSERBASE_PROJECT_ID,
       browserbaseSessionCreateParams: {
-        projectId: process.env.BROWSERBASE_PROJECT_ID!,
         proxies: true,
         region: "us-west-2",
         timeout: 3600, // 1 hour session timeout
@@ -170,7 +172,8 @@ const bb = new Browserbase({
 });
 
 const session = await bb.sessions.create({
-  projectId: process.env.BROWSERBASE_PROJECT_ID!,
+  // Optional: omit to use your default project
+  projectId: process.env.BROWSERBASE_PROJECT_ID,
   // Add configuration options here
 });
 ```
@@ -399,7 +402,7 @@ Setting `domSettleTimeout` too low may cause actions to fail on elements that ar
 
 <AccordionGroup>
 <Accordion title="Browserbase Authentication Errors">
-- Verify your `BROWSERBASE_API_KEY` and `BROWSERBASE_PROJECT_ID` are set correctly
+- Verify your `BROWSERBASE_API_KEY` is set correctly (and optionally `BROWSERBASE_PROJECT_ID` if targeting a specific project)
 - Check that your API key has the necessary permissions
 - Ensure your Browserbase account has sufficient credits
 </Accordion>

--- a/packages/docs/v3/first-steps/installation.mdx
+++ b/packages/docs/v3/first-steps/installation.mdx
@@ -48,8 +48,9 @@ Set environment variables (or a `.env` via your framework):
 <CodeGroup>
 ```bash Bash
 OPENAI_API_KEY=your_api_key
-BROWSERBASE_API_KEY=your_api_key
-BROWSERBASE_PROJECT_ID=your_project_id
+BROWSERBASE_API_KEY=***
+# Optional: only needed if you want to target a specific project
+# BROWSERBASE_PROJECT_ID=your_project_id
 ```
 </CodeGroup>
 

--- a/packages/docs/v3/first-steps/quickstart.mdx
+++ b/packages/docs/v3/first-steps/quickstart.mdx
@@ -87,7 +87,7 @@ main().catch((err) => {
 </CodeGroup>
 
 <Tip>
-To use, set provider keys in `.env` (e.g., `OPENAI_API_KEY`). For cloud browsers, add `BROWSERBASE_API_KEY` and `BROWSERBASE_PROJECT_ID`.
+To use, set provider keys in `.env` (e.g., `OPENAI_API_KEY`). For cloud browsers, add `BROWSERBASE_API_KEY`. Optionally, set `BROWSERBASE_PROJECT_ID` to target a specific project.
 </Tip>
 
 ## Next steps

--- a/packages/docs/v3/integrations/mcp/configuration.mdx
+++ b/packages/docs/v3/integrations/mcp/configuration.mdx
@@ -26,7 +26,7 @@ Your Browserbase API key for authentication
 </Card>
 
 <Card title="BROWSERBASE_PROJECT_ID" icon="key">
-Your Browserbase project ID
+Your Browserbase project ID (optional — defaults to your default project)
 </Card>
 
 </CardGroup>


### PR DESCRIPTION
## Summary

Browserbase now resolves the project ID server-side when omitted, defaulting to the user's default project. This means **only `BROWSERBASE_API_KEY` is required** to get started — no more hunting for a project ID during signup.

This PR updates the v3 documentation and TypeScript type comments to reflect this change, reducing friction for new users.

## Changes

### Docs (v3)
- **quickstart.mdx** — Clarified that `BROWSERBASE_PROJECT_ID` is optional
- **installation.mdx** — Commented out project ID from the required env vars block
- **browser.mdx** — Updated the environment variables section, code examples, and troubleshooting to mark project ID as optional
- **mcp/configuration.mdx** — Marked the project ID environment variable card as optional

### Code
- **options.ts** — Updated type comments to clarify `apiKey` is required and `projectId` is optional (the types themselves were already optional)

## What's NOT changed (and why)
- **v2 docs** — Legacy version; changes should go in v3 only
- **Other language SDK docs** (Python, Java, Go, Ruby) — Those SDKs may still require the project ID on their end; they should be updated in their respective repos once they adopt the server-side default
- **MCP config JSON examples** — Still show `BROWSERBASE_PROJECT_ID` in the JSON blocks since users who configure MCP may want explicit control; the description now notes it's optional

## Testing
- No runtime behavior changes — the TypeScript code already treated `projectId` as optional
- Doc changes are text-only