### PR TITLE
feat: add Novita AI as an LLM provider

### DIFF
--- a/packages/core/lib/utils.ts
+++ b/packages/core/lib/utils.ts
@@ -693,6 +693,7 @@ export const providerEnvVarMap: Partial<
   azure: "AZURE_API_KEY",
   xai: "XAI_API_KEY",
   google_legacy: "GOOGLE_API_KEY",
+  novita: "NOVITA_API_KEY",
 };
 
 const providersWithoutApiKey = new Set(["bedrock", "ollama"]);

--- a/packages/core/lib/v3/llm/LLMProvider.ts
+++ b/packages/core/lib/v3/llm/LLMProvider.ts
@@ -34,6 +34,11 @@ import { ollama, createOllama } from "ollama-ai-provider-v2";
 import { gateway, createGateway } from "ai";
 import { AISDKProvider, AISDKCustomProvider } from "../types/public/model.js";
 
+const NOVITA_BASE_URL = "https://api.novita.ai/openai";
+const novita = createOpenAI({ baseURL: NOVITA_BASE_URL });
+const createNovita: AISDKCustomProvider = (options) =>
+  createOpenAI({ baseURL: NOVITA_BASE_URL, ...options });
+
 const AISDKProviders: Record<string, AISDKProvider> = {
   openai,
   bedrock,
@@ -50,6 +55,7 @@ const AISDKProviders: Record<string, AISDKProvider> = {
   ollama,
   vertex,
   gateway,
+  novita,
 };
 const AISDKProvidersWithAPIKey: Record<string, AISDKCustomProvider> = {
   openai: createOpenAI,
@@ -67,6 +73,7 @@ const AISDKProvidersWithAPIKey: Record<string, AISDKCustomProvider> = {
   perplexity: createPerplexity,
   ollama: createOllama,
   gateway: createGateway,
+  novita: createNovita,
 };
 
 const modelToProviderMap: { [key in AvailableModel]: ModelProvider } = {

--- a/packages/core/tests/unit/llm-provider.test.ts
+++ b/packages/core/tests/unit/llm-provider.test.ts
@@ -57,6 +57,30 @@ describe("getAISDKLanguageModel", () => {
     });
   });
 
+  describe("novita provider", () => {
+    it("works with apiKey", () => {
+      const model = getAISDKLanguageModel(
+        "novita",
+        "moonshotai/kimi-k2.5",
+        { apiKey: "test-novita-key" },
+      );
+      expect(model).toBeDefined();
+    });
+
+    it("works without clientOptions (uses static provider)", () => {
+      const model = getAISDKLanguageModel("novita", "moonshotai/kimi-k2.5");
+      expect(model).toBeDefined();
+    });
+
+    it("works with custom baseURL override", () => {
+      const model = getAISDKLanguageModel("novita", "minimax/minimax-m2.5", {
+        apiKey: "test-novita-key",
+        baseURL: "https://api.novita.ai/openai",
+      });
+      expect(model).toBeDefined();
+    });
+  });
+
   describe("hasValidOptions logic", () => {
     it("treats undefined apiKey as no options", () => {
       // This should use the default provider path (AISDKProviders)


### PR DESCRIPTION
## Summary

Adds [Novita AI](https://novita.ai) as a supported LLM provider via the existing Vercel AI SDK / OpenAI-compatible path.

- **Provider key**: `novita`
- **Base URL**: `https://api.novita.ai/openai` (OpenAI-compatible)
- **Auth**: `NOVITA_API_KEY` environment variable
- **Usage**: `novita/<model-id>` format (e.g. `novita/moonshotai/kimi-k2.5`)

### Supported models

| Model ID | Notes |
|---|---|
| `novita/moonshotai/kimi-k2.5` | Default — 262k context, vision, function calling |
| `novita/zai-org/glm-5` | 202k context, function calling |
| `novita/minimax/minimax-m2.5` | 204k context, function calling |

### Changes

**`packages/core/lib/v3/llm/LLMProvider.ts`**
- Creates a `novita` static provider and `createNovita` factory using `createOpenAI` with `baseURL: "https://api.novita.ai/openai"`
- Registers both in `AISDKProviders` and `AISDKProvidersWithAPIKey`

**`packages/core/lib/utils.ts`**
- Adds `novita: "NOVITA_API_KEY"` to `providerEnvVarMap`

**`packages/core/tests/unit/llm-provider.test.ts`**
- Adds unit tests for the novita provider (with API key, without options, with baseURL override)

### Notes

- Kimi models already have temperature-clamp (`= 1`) and prompt-JSON-fallback handling in `aisdk.ts` (patterns `"kimi"` and `"glm"` are already in `PROMPT_JSON_FALLBACK_PATTERNS`)
- No new packages required — reuses `@ai-sdk/openai` already present

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Novita as a first-class LLM provider via the OpenAI-compatible endpoint. Use provider key `novita` with `NOVITA_API_KEY` against `https://api.novita.ai/openai`.

- **New Features**
  - Supports `novita/<model-id>`: `moonshotai/kimi-k2.5`, `zai-org/glm-5`, `minimax/minimax-m2.5`.
  - Implements a static provider and factory using `@ai-sdk/openai`; supports API key and baseURL override.
  - Adds unit tests for API key usage, static provider path, and baseURL override.

<sup>Written for commit 1860060c9825dd011571a1893fb00e4fd6564514. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1869">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

