### PR TITLE
Add `browse cookies` commands for cookie management

### DIFF
--- a/.changeset/add-cookies-command.md
+++ b/.changeset/add-cookies-command.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/browse-cli": minor
+---
+
+Add `browse cookies` subcommands for cookie management: `cookies get [urls...]` to inspect cookies (with optional URL filtering), `cookies set <json>` to add cookies, and `cookies clear` to remove cookies (with optional `--name`, `--domain`, `--path` filters).

--- a/.changeset/add-cookies-command.md
+++ b/.changeset/add-cookies-command.md
@@ -1,5 +1,5 @@
 ---
-"@browserbasehq/browse-cli": minor
+"@browserbasehq/browse-cli": patch
 ---
 
 Add `browse cookies` subcommands for cookie management: `cookies get [urls...]` to inspect cookies (with optional URL filtering), `cookies set <json>` to add cookies, and `cookies clear` to remove cookies (with optional `--name`, `--domain`, `--path` filters).

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1599,7 +1599,7 @@ async function executeCommand(
       const [opts] = args as [
         { name?: string; domain?: string; path?: string }?,
       ];
-      await context.clearCookies(opts ?? undefined);
+      await context.clearCookies(opts);
       return { cleared: true };
     }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1582,6 +1582,27 @@ async function executeCommand(
       }
     }
 
+    // Cookies
+    case "cookies_get": {
+      const [urls] = args as [string[]?];
+      const cookies = await context.cookies(urls?.length ? urls : undefined);
+      return { cookies };
+    }
+    case "cookies_set": {
+      const [cookieParams] = args as [unknown[]];
+      await context.addCookies(
+        cookieParams as Parameters<typeof context.addCookies>[0],
+      );
+      return { added: cookieParams.length };
+    }
+    case "cookies_clear": {
+      const [opts] = args as [
+        { name?: string; domain?: string; path?: string }?,
+      ];
+      await context.clearCookies(opts ?? undefined);
+      return { cleared: true };
+    }
+
     // Daemon control
     case "stop": {
       process.nextTick(() => {
@@ -2755,6 +2776,70 @@ networkCmd
       process.exit(1);
     }
   });
+
+// ==================== COOKIES ====================
+
+const cookiesCmd = program
+  .command("cookies")
+  .description("Cookie management commands");
+
+cookiesCmd
+  .command("get [urls...]")
+  .description("Get cookies, optionally filtered by URLs")
+  .action(async (urls: string[]) => {
+    const opts = program.opts<GlobalOpts>();
+    try {
+      const result = await runCommand("cookies_get", [
+        urls?.length ? urls : undefined,
+      ]);
+      output(result, opts.json ?? false);
+    } catch (e) {
+      console.error("Error:", e instanceof Error ? e.message : e);
+      process.exit(1);
+    }
+  });
+
+cookiesCmd
+  .command("set <json>")
+  .description(
+    'Add cookies from JSON array (e.g. \'[{"name":"a","value":"b","url":"https://example.com"}]\')',
+  )
+  .action(async (json: string) => {
+    const opts = program.opts<GlobalOpts>();
+    try {
+      const cookies = JSON.parse(json);
+      if (!Array.isArray(cookies)) {
+        console.error("Error: cookies must be a JSON array");
+        process.exit(1);
+      }
+      const result = await runCommand("cookies_set", [cookies]);
+      output(result, opts.json ?? false);
+    } catch (e) {
+      console.error("Error:", e instanceof Error ? e.message : e);
+      process.exit(1);
+    }
+  });
+
+cookiesCmd
+  .command("clear")
+  .description("Clear cookies (all or filtered by name/domain/path)")
+  .option("--name <name>", "Filter by cookie name")
+  .option("--domain <domain>", "Filter by domain")
+  .option("--path <path>", "Filter by path")
+  .action(
+    async (cmdOpts: { name?: string; domain?: string; path?: string }) => {
+      const opts = program.opts<GlobalOpts>();
+      try {
+        const filter =
+          cmdOpts.name || cmdOpts.domain || cmdOpts.path ? cmdOpts : undefined;
+        const result = await runCommand("cookies_clear", [filter]);
+        output(result, opts.json ?? false);
+      } catch (e) {
+        console.error("Error:", e instanceof Error ? e.message : e);
+        process.exit(1);
+      }
+    },
+  );
 
 // ==================== RUN ====================
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2831,7 +2831,11 @@ cookiesCmd
       const opts = program.opts<GlobalOpts>();
       try {
         const filter =
-          cmdOpts.name || cmdOpts.domain || cmdOpts.path ? cmdOpts : undefined;
+          cmdOpts.name !== undefined ||
+          cmdOpts.domain !== undefined ||
+          cmdOpts.path !== undefined
+            ? cmdOpts
+            : undefined;
         const result = await runCommand("cookies_clear", [filter]);
         output(result, opts.json ?? false);
       } catch (e) {


### PR DESCRIPTION
## Summary
- Adds `browse cookies get [urls...]` to inspect cookies (including httpOnly), with optional URL filtering
- Adds `browse cookies set <json>` to add cookies from a JSON array
- Adds `browse cookies clear` to remove all cookies, or filter by `--name`, `--domain`, `--path`
- Uses Understudy's existing `context.cookies()`, `addCookies()`, `clearCookies()` methods

## Usage
```bash
browse cookies get                              # all cookies
browse cookies get https://example.com          # filtered by URL
browse cookies set '[{"name":"session","value":"abc","url":"https://example.com"}]'
browse cookies clear                            # clear all
browse cookies clear --domain example.com       # clear by domain
```

## Test results
| Test | Local | Browserbase |
|------|-------|-------------|
| `cookies get` (empty) | `[]` | `[]` |
| `cookies set` (add 1 cookie) | `{added: 1}` | `{added: 1}` |
| `cookies get` (verify set) | Shows cookie with correct name/value/domain | Same |
| `cookies get <url>` (URL filter) | Filters correctly | Filters correctly |
| `cookies clear --domain` | Cleared, verified empty | Cleared, verified empty |

🤖 Generated with [Claude Code](https://claude.com/claude-code)