### PR TITLE
Feat: Add Anthropic CUA adaptive thinking

### DIFF
--- a/packages/core/lib/v3/agent/AnthropicCUAClient.ts
+++ b/packages/core/lib/v3/agent/AnthropicCUAClient.ts
@@ -454,16 +454,19 @@ export class AnthropicCUAClient extends AgentClient {
         isAdaptiveThinkingModel || modelBase === "claude-opus-4-5-20251101";
 
       // Configure thinking capability based on model version
-      // - For 4.6 models: Use adaptive thinking with effort (recommended)
+      // - For 4.6 models: Use adaptive thinking with effort (recommended, defaults to "medium")
       // - For older models: Use enabled thinking with budget_tokens (deprecated)
       let thinking: { type: "adaptive" } | { type: "enabled"; budget_tokens: number } | undefined;
       let outputConfig: { effort: ThinkingEffort } | undefined;
+      let useAdaptiveThinking = false;
 
-      if (isAdaptiveThinkingModel && this.thinkingEffort) {
+      if (isAdaptiveThinkingModel) {
         // Claude 4.6+ models use adaptive thinking with output_config.effort
+        // Default to "medium" effort if not explicitly specified
         // See: https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking
         thinking = { type: "adaptive" };
-        outputConfig = { effort: this.thinkingEffort };
+        outputConfig = { effort: this.thinkingEffort || "medium" };
+        useAdaptiveThinking = true;
       } else if (this.thinkingBudget) {
         // Older models use enabled thinking with budget_tokens (deprecated for 4.6)
         thinking = { type: "enabled", budget_tokens: this.thinkingBudget };
@@ -536,6 +539,12 @@ export class AnthropicCUAClient extends AgentClient {
       // Add output_config for adaptive thinking (Claude 4.6+ models)
       if (outputConfig) {
         requestParams.output_config = outputConfig;
+      }
+
+      // Adaptive thinking requires temperature to be set to 1
+      // See: https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking
+      if (useAdaptiveThinking) {
+        requestParams.temperature = 1;
       }
 
       // Log LLM request

--- a/packages/core/lib/v3/agent/AnthropicCUAClient.ts
+++ b/packages/core/lib/v3/agent/AnthropicCUAClient.ts
@@ -10,7 +10,7 @@ import {
   ToolUseItem,
 } from "../types/public/agent.js";
 import { LogLine } from "../types/public/logs.js";
-import { ClientOptions } from "../types/public/model.js";
+import { ClientOptions, ThinkingEffort } from "../types/public/model.js";
 import {
   AgentScreenshotProviderError,
   StagehandClosedError,
@@ -44,6 +44,7 @@ export class AnthropicCUAClient extends AgentClient {
   private screenshotProvider?: () => Promise<string>;
   private actionHandler?: (action: AgentAction) => Promise<void>;
   private thinkingBudget: number | null = null;
+  private thinkingEffort: ThinkingEffort | null = null;
   private tools?: ToolSet;
 
   constructor(
@@ -60,12 +61,17 @@ export class AnthropicCUAClient extends AgentClient {
       (clientOptions?.apiKey as string) || process.env.ANTHROPIC_API_KEY || "";
     this.baseURL = (clientOptions?.baseURL as string) || undefined;
 
-    // Get thinking budget if specified
+    // Get thinking budget if specified (deprecated for 4.6 models)
     if (
       clientOptions?.thinkingBudget &&
       typeof clientOptions.thinkingBudget === "number"
     ) {
       this.thinkingBudget = clientOptions.thinkingBudget;
+    }
+
+    // Get thinking effort for adaptive thinking (Claude 4.6+ models)
+    if (clientOptions?.thinkingEffort) {
+      this.thinkingEffort = clientOptions.thinkingEffort;
     }
 
     // Store client options for reference
@@ -432,20 +438,36 @@ export class AnthropicCUAClient extends AgentClient {
         // as they should already be properly wrapped in user messages
       }
 
-      // Configure thinking capability if available
-      const thinking = this.thinkingBudget
-        ? { type: "enabled" as const, budget_tokens: this.thinkingBudget }
-        : undefined;
-
       // Claude 4.6+ models require the newer computer_20251124 tool version
+      // and support adaptive thinking instead of budget_tokens
       const modelBase = this.modelName.includes("/")
         ? this.modelName.split("/")[1]
         : this.modelName;
-      const shouldUseNewToolVersion = [
+
+      // Check if this is a Claude 4.6+ model that supports adaptive thinking
+      const isAdaptiveThinkingModel = [
         "claude-opus-4-6",
         "claude-sonnet-4-6",
-        "claude-opus-4-5-20251101",
       ].includes(modelBase);
+
+      const shouldUseNewToolVersion =
+        isAdaptiveThinkingModel || modelBase === "claude-opus-4-5-20251101";
+
+      // Configure thinking capability based on model version
+      // - For 4.6 models: Use adaptive thinking with effort (recommended)
+      // - For older models: Use enabled thinking with budget_tokens (deprecated)
+      let thinking: { type: "adaptive" } | { type: "enabled"; budget_tokens: number } | undefined;
+      let outputConfig: { effort: ThinkingEffort } | undefined;
+
+      if (isAdaptiveThinkingModel && this.thinkingEffort) {
+        // Claude 4.6+ models use adaptive thinking with output_config.effort
+        // See: https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking
+        thinking = { type: "adaptive" };
+        outputConfig = { effort: this.thinkingEffort };
+      } else if (this.thinkingBudget) {
+        // Older models use enabled thinking with budget_tokens (deprecated for 4.6)
+        thinking = { type: "enabled", budget_tokens: this.thinkingBudget };
+      }
 
       const computerToolType = shouldUseNewToolVersion
         ? "computer_20251124"
@@ -509,6 +531,11 @@ export class AnthropicCUAClient extends AgentClient {
       // Add thinking parameter if available
       if (thinking) {
         requestParams.thinking = thinking;
+      }
+
+      // Add output_config for adaptive thinking (Claude 4.6+ models)
+      if (outputConfig) {
+        requestParams.output_config = outputConfig;
       }
 
       // Log LLM request

--- a/packages/core/lib/v3/types/public/model.ts
+++ b/packages/core/lib/v3/types/public/model.ts
@@ -94,6 +94,16 @@ export type ModelProvider =
   | "google"
   | "aisdk";
 
+/**
+ * Effort levels for Claude adaptive thinking.
+ * Used with Claude 4.6+ models (claude-opus-4-6, claude-sonnet-4-6).
+ * - "max": Claude always thinks with no constraints (Opus 4.6 only)
+ * - "high": Claude always thinks with deep reasoning (default when adaptive is enabled)
+ * - "medium": Claude uses moderate thinking, may skip for simple queries
+ * - "low": Claude minimizes thinking, skips for simple tasks
+ */
+export type ThinkingEffort = "low" | "medium" | "high" | "max";
+
 export type ClientOptions = (
   | OpenAIClientOptions
   | AnthropicClientOptions
@@ -106,8 +116,19 @@ export type ClientOptions = (
   organization?: string;
   /** Delay between agent actions in ms */
   waitBetweenActions?: number;
-  /** Anthropic thinking budget for extended thinking */
+  /**
+   * @deprecated For Claude 4.6+ models, use `thinkingEffort` instead.
+   * Anthropic thinking budget for extended thinking (used with older Claude models like 4.5).
+   * Sets `thinking.type: "enabled"` with the specified `budget_tokens`.
+   */
   thinkingBudget?: number;
+  /**
+   * Effort level for Claude adaptive thinking (Claude 4.6+ models only).
+   * Uses `thinking.type: "adaptive"` with `output_config.effort`.
+   * This is the recommended approach for Claude Opus 4.6 and Sonnet 4.6.
+   * @see https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking
+   */
+  thinkingEffort?: ThinkingEffort;
   /** Environment type for CUA agents (browser, mac, windows, ubuntu) */
   environment?: string;
   /** Max images for Microsoft FARA agent */

--- a/packages/core/tests/unit/anthropic-cua-adaptive-thinking.test.ts
+++ b/packages/core/tests/unit/anthropic-cua-adaptive-thinking.test.ts
@@ -55,6 +55,7 @@ describe("AnthropicCUAClient adaptive thinking", () => {
         expect.objectContaining({
           thinking: { type: "adaptive" },
           output_config: { effort: "high" },
+          temperature: 1,
         }),
       );
 
@@ -81,6 +82,7 @@ describe("AnthropicCUAClient adaptive thinking", () => {
         expect.objectContaining({
           thinking: { type: "adaptive" },
           output_config: { effort: "medium" },
+          temperature: 1,
         }),
       );
     });
@@ -103,6 +105,7 @@ describe("AnthropicCUAClient adaptive thinking", () => {
         expect.objectContaining({
           thinking: { type: "adaptive" },
           output_config: { effort: "max" },
+          temperature: 1,
         }),
       );
     });
@@ -125,11 +128,12 @@ describe("AnthropicCUAClient adaptive thinking", () => {
         expect.objectContaining({
           thinking: { type: "adaptive" },
           output_config: { effort: "low" },
+          temperature: 1,
         }),
       );
     });
 
-    it("should NOT include thinking parameter when thinkingEffort is not set for 4.6 models", async () => {
+    it("should default to adaptive thinking with 'medium' effort when thinkingEffort is not set for 4.6 models", async () => {
       const client = new AnthropicCUAClient(
         "anthropic",
         "claude-opus-4-6",
@@ -142,9 +146,57 @@ describe("AnthropicCUAClient adaptive thinking", () => {
 
       await client.getAction([{ role: "user", content: "test" }]);
 
-      const callArgs = mockCreate.mock.calls[0][0];
-      expect(callArgs.thinking).toBeUndefined();
-      expect(callArgs.output_config).toBeUndefined();
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          thinking: { type: "adaptive" },
+          output_config: { effort: "medium" },
+          temperature: 1,
+        }),
+      );
+    });
+
+    it("should set temperature to 1 when adaptive thinking is enabled", async () => {
+      const client = new AnthropicCUAClient(
+        "anthropic",
+        "claude-opus-4-6",
+        undefined,
+        {
+          apiKey: "test-key",
+          thinkingEffort: "high",
+        },
+      );
+      client.setViewport(1280, 720);
+
+      await client.getAction([{ role: "user", content: "test" }]);
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          temperature: 1,
+        }),
+      );
+    });
+
+    it("should set temperature to 1 for claude-sonnet-4-6 with adaptive thinking", async () => {
+      const client = new AnthropicCUAClient(
+        "anthropic",
+        "claude-sonnet-4-6",
+        undefined,
+        {
+          apiKey: "test-key",
+          thinkingEffort: "low",
+        },
+      );
+      client.setViewport(1280, 720);
+
+      await client.getAction([{ role: "user", content: "test" }]);
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          thinking: { type: "adaptive" },
+          output_config: { effort: "low" },
+          temperature: 1,
+        }),
+      );
     });
   });
 
@@ -193,6 +245,25 @@ describe("AnthropicCUAClient adaptive thinking", () => {
           thinking: { type: "enabled", budget_tokens: 10000 },
         }),
       );
+    });
+
+    it("should NOT force temperature to 1 for older models with budget_tokens", async () => {
+      const client = new AnthropicCUAClient(
+        "anthropic",
+        "claude-sonnet-4-5-20250929",
+        undefined,
+        {
+          apiKey: "test-key",
+          thinkingBudget: 8000,
+        },
+      );
+      client.setViewport(1280, 720);
+
+      await client.getAction([{ role: "user", content: "test" }]);
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      // Temperature should not be explicitly set to 1 for older models
+      expect(callArgs.temperature).toBeUndefined();
     });
   });
 

--- a/packages/core/tests/unit/anthropic-cua-adaptive-thinking.test.ts
+++ b/packages/core/tests/unit/anthropic-cua-adaptive-thinking.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { AnthropicCUAClient } from "../../lib/v3/agent/AnthropicCUAClient.js";
+import Anthropic from "@anthropic-ai/sdk";
+
+// Mock the Anthropic SDK's beta.messages.create method
+vi.mock("@anthropic-ai/sdk", () => {
+  const mockCreate = vi.fn().mockResolvedValue({
+    id: "test-id",
+    content: [{ type: "text", text: "test response" }],
+    usage: { input_tokens: 10, output_tokens: 20 },
+  });
+
+  return {
+    default: class MockAnthropic {
+      beta = {
+        messages: {
+          create: mockCreate,
+        },
+      };
+    },
+  };
+});
+
+describe("AnthropicCUAClient adaptive thinking", () => {
+  let mockCreate: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Get the mock create function from a new instance
+    const anthropic = new Anthropic({ apiKey: "test" });
+    mockCreate = anthropic.beta.messages.create as ReturnType<typeof vi.fn>;
+    mockCreate.mockResolvedValue({
+      id: "test-id",
+      content: [{ type: "text", text: "test response" }],
+      usage: { input_tokens: 10, output_tokens: 20 },
+    });
+  });
+
+  describe("Claude 4.6 models (adaptive thinking)", () => {
+    it("should use thinking.type: 'adaptive' for claude-opus-4-6 when thinkingEffort is set", async () => {
+      const client = new AnthropicCUAClient(
+        "anthropic",
+        "claude-opus-4-6",
+        undefined,
+        {
+          apiKey: "test-key",
+          thinkingEffort: "high",
+        },
+      );
+      client.setViewport(1280, 720);
+
+      await client.getAction([{ role: "user", content: "test" }]);
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          thinking: { type: "adaptive" },
+          output_config: { effort: "high" },
+        }),
+      );
+
+      // Should NOT have budget_tokens
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.thinking).not.toHaveProperty("budget_tokens");
+    });
+
+    it("should use thinking.type: 'adaptive' for claude-sonnet-4-6 when thinkingEffort is set", async () => {
+      const client = new AnthropicCUAClient(
+        "anthropic",
+        "claude-sonnet-4-6",
+        undefined,
+        {
+          apiKey: "test-key",
+          thinkingEffort: "medium",
+        },
+      );
+      client.setViewport(1280, 720);
+
+      await client.getAction([{ role: "user", content: "test" }]);
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          thinking: { type: "adaptive" },
+          output_config: { effort: "medium" },
+        }),
+      );
+    });
+
+    it("should support 'max' effort level for claude-opus-4-6", async () => {
+      const client = new AnthropicCUAClient(
+        "anthropic",
+        "claude-opus-4-6",
+        undefined,
+        {
+          apiKey: "test-key",
+          thinkingEffort: "max",
+        },
+      );
+      client.setViewport(1280, 720);
+
+      await client.getAction([{ role: "user", content: "test" }]);
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          thinking: { type: "adaptive" },
+          output_config: { effort: "max" },
+        }),
+      );
+    });
+
+    it("should support 'low' effort level", async () => {
+      const client = new AnthropicCUAClient(
+        "anthropic",
+        "claude-sonnet-4-6",
+        undefined,
+        {
+          apiKey: "test-key",
+          thinkingEffort: "low",
+        },
+      );
+      client.setViewport(1280, 720);
+
+      await client.getAction([{ role: "user", content: "test" }]);
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          thinking: { type: "adaptive" },
+          output_config: { effort: "low" },
+        }),
+      );
+    });
+
+    it("should NOT include thinking parameter when thinkingEffort is not set for 4.6 models", async () => {
+      const client = new AnthropicCUAClient(
+        "anthropic",
+        "claude-opus-4-6",
+        undefined,
+        {
+          apiKey: "test-key",
+        },
+      );
+      client.setViewport(1280, 720);
+
+      await client.getAction([{ role: "user", content: "test" }]);
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.thinking).toBeUndefined();
+      expect(callArgs.output_config).toBeUndefined();
+    });
+  });
+
+  describe("older Claude models (budget_tokens - deprecated)", () => {
+    it("should use thinking.type: 'enabled' with budget_tokens for claude-sonnet-4-5 when thinkingBudget is set", async () => {
+      const client = new AnthropicCUAClient(
+        "anthropic",
+        "claude-sonnet-4-5-20250929",
+        undefined,
+        {
+          apiKey: "test-key",
+          thinkingBudget: 8000,
+        },
+      );
+      client.setViewport(1280, 720);
+
+      await client.getAction([{ role: "user", content: "test" }]);
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          thinking: { type: "enabled", budget_tokens: 8000 },
+        }),
+      );
+
+      // Should NOT have output_config for older models
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.output_config).toBeUndefined();
+    });
+
+    it("should use thinking.type: 'enabled' with budget_tokens for claude-opus-4-5 when thinkingBudget is set", async () => {
+      const client = new AnthropicCUAClient(
+        "anthropic",
+        "claude-opus-4-5-20251101",
+        undefined,
+        {
+          apiKey: "test-key",
+          thinkingBudget: 10000,
+        },
+      );
+      client.setViewport(1280, 720);
+
+      await client.getAction([{ role: "user", content: "test" }]);
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          thinking: { type: "enabled", budget_tokens: 10000 },
+        }),
+      );
+    });
+  });
+
+  describe("model detection", () => {
+    it("should detect claude-opus-4-6 as a 4.6 model", async () => {
+      const client = new AnthropicCUAClient(
+        "anthropic",
+        "claude-opus-4-6",
+        undefined,
+        {
+          apiKey: "test-key",
+          thinkingEffort: "high",
+        },
+      );
+      client.setViewport(1280, 720);
+
+      await client.getAction([{ role: "user", content: "test" }]);
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.thinking.type).toBe("adaptive");
+    });
+
+    it("should detect claude-sonnet-4-6 as a 4.6 model", async () => {
+      const client = new AnthropicCUAClient(
+        "anthropic",
+        "claude-sonnet-4-6",
+        undefined,
+        {
+          apiKey: "test-key",
+          thinkingEffort: "high",
+        },
+      );
+      client.setViewport(1280, 720);
+
+      await client.getAction([{ role: "user", content: "test" }]);
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.thinking.type).toBe("adaptive");
+    });
+
+    it("should handle provider-prefixed model names (anthropic/claude-opus-4-6)", async () => {
+      const client = new AnthropicCUAClient(
+        "anthropic",
+        "anthropic/claude-opus-4-6",
+        undefined,
+        {
+          apiKey: "test-key",
+          thinkingEffort: "high",
+        },
+      );
+      client.setViewport(1280, 720);
+
+      await client.getAction([{ role: "user", content: "test" }]);
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.thinking.type).toBe("adaptive");
+    });
+  });
+});


### PR DESCRIPTION
# why

# what changed

# test plan

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add adaptive thinking for Anthropic Claude 4.6 models in the CUA client. Uses `thinkingEffort` with `output_config.effort`, sets temperature=1, and keeps `thinkingBudget` for older models.

- **New Features**
  - Detects 4.6 models (`claude-opus-4-6`, `claude-sonnet-4-6`) and uses `thinking: { type: "adaptive" }` with `output_config.effort`.
  - Defaults to `"medium"` effort when not set and forces `temperature: 1` for adaptive thinking.
  - Adds `ThinkingEffort` and `thinkingEffort` in `ClientOptions` (`"low" | "medium" | "high" | "max"`); falls back to `thinking: { type: "enabled", budget_tokens }` with `thinkingBudget` on older models.
  - Uses `computer_20251124` for 4.6 and `claude-opus-4-5-20251101`; tests cover effort levels, defaults and temperature, provider-prefixed names, and legacy budget behavior.

- **Migration**
  - For 4.6 models, set `thinkingEffort`; `thinkingBudget` is deprecated. Adaptive thinking sets `temperature: 1` automatically.
  - Keep using `thinkingBudget` on older Claude models. No changes needed if you don’t use thinking.

<sup>Written for commit 0ea0332c525017c727743d11a68b8eb74f76b646. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1912">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

