### PR TITLE
feat: add recordVideo support to localBrowserLaunchOptions

### DIFF
--- a/.changeset/video-recording-support.md
+++ b/.changeset/video-recording-support.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+feat: add recordVideo support to localBrowserLaunchOptions

--- a/packages/core/lib/v3/types/public/api.ts
+++ b/packages/core/lib/v3/types/public/api.ts
@@ -51,6 +51,14 @@ export const LocalBrowserLaunchOptionsSchema = z
     connectTimeoutMs: z.number().optional(),
     downloadsPath: z.string().optional(),
     acceptDownloads: z.boolean().optional(),
+    recordVideo: z
+      .object({
+        dir: z.string(),
+        size: z
+          .object({ width: z.number(), height: z.number() })
+          .optional(),
+      })
+      .optional(),
   })
   .strict()
   .meta({ id: "LocalBrowserLaunchOptions" });

--- a/packages/core/lib/v3/understudy/page.ts
+++ b/packages/core/lib/v3/understudy/page.ts
@@ -107,6 +107,7 @@ export class Page {
   private _videoFrames: Buffer[] = [];
   private _videoRecording = false;
   private _videoFrameCount = 0;
+  private _screencastHandler: ((params: any) => void) | null = null;
 
   private navigationCommandSeq = 0;
   private latestNavigationCommandId = 0;
@@ -1214,44 +1215,58 @@ export class Page {
     this._videoRecordingDir = pathResolve(dir);
     this._videoFrames = [];
     this._videoFrameCount = 0;
-    this._videoRecording = true;
 
     await fs.mkdir(this._videoRecordingDir, { recursive: true });
 
-    // Listen for screencast frames
-    this.mainSession.on(
-      "Page.screencastFrame",
-      async (params: {
-        data: string;
-        metadata: { timestamp: number };
-        sessionId: number;
-      }) => {
-        if (!this._videoRecording) return;
-        try {
-          const frameBuffer = Buffer.from(params.data, "base64");
-          const frameNum = String(this._videoFrameCount++).padStart(6, "0");
-          await fs.writeFile(
-            pathJoin(this._videoRecordingDir!, `frame-${frameNum}.png`),
-            frameBuffer,
-          );
-          // Acknowledge the frame so Chrome sends the next one
-          await this.mainSession
-            .send("Page.screencastFrameAck", {
-              sessionId: params.sessionId,
-            })
-            .catch(() => {});
-        } catch {
-          // best-effort frame capture
-        }
-      },
-    );
+    // Remove any previous listener to prevent duplicates across stop/start cycles
+    if (this._screencastHandler) {
+      this.mainSession.off("Page.screencastFrame", this._screencastHandler);
+      this._screencastHandler = null;
+    }
 
-    await this.mainSession.send("Page.startScreencast", {
-      format: "png",
-      maxWidth: options?.maxWidth ?? 1280,
-      maxHeight: options?.maxHeight ?? 720,
-      everyNthFrame: options?.everyNthFrame ?? 2,
-    });
+    // Create and register the frame handler
+    this._screencastHandler = async (params: {
+      data: string;
+      metadata: { timestamp: number };
+      sessionId: number;
+    }) => {
+      if (!this._videoRecording) return;
+      try {
+        const frameBuffer = Buffer.from(params.data, "base64");
+        const frameNum = String(this._videoFrameCount++).padStart(6, "0");
+        await fs.writeFile(
+          pathJoin(this._videoRecordingDir!, `frame-${frameNum}.png`),
+          frameBuffer,
+        );
+        // Acknowledge the frame so Chrome sends the next one
+        await this.mainSession
+          .send("Page.screencastFrameAck", {
+            sessionId: params.sessionId,
+          })
+          .catch(() => {});
+      } catch {
+        // best-effort frame capture
+      }
+    };
+
+    this.mainSession.on("Page.screencastFrame", this._screencastHandler);
+
+    // Start the screencast — if this fails, reset state so retries are possible
+    try {
+      await this.mainSession.send("Page.startScreencast", {
+        format: "png",
+        maxWidth: options?.maxWidth ?? 1280,
+        maxHeight: options?.maxHeight ?? 720,
+        everyNthFrame: options?.everyNthFrame ?? 2,
+      });
+      this._videoRecording = true;
+    } catch (err) {
+      // Cleanup on failure so the recording can be retried
+      this.mainSession.off("Page.screencastFrame", this._screencastHandler);
+      this._screencastHandler = null;
+      this._videoRecording = false;
+      throw err;
+    }
   }
 
   /**
@@ -1266,6 +1281,12 @@ export class Page {
     await this.mainSession
       .send("Page.stopScreencast")
       .catch(() => {});
+
+    // Remove the listener to prevent leaks
+    if (this._screencastHandler) {
+      this.mainSession.off("Page.screencastFrame", this._screencastHandler);
+      this._screencastHandler = null;
+    }
 
     return this._videoRecordingDir;
   }

--- a/packages/core/lib/v3/understudy/page.ts
+++ b/packages/core/lib/v3/understudy/page.ts
@@ -1,5 +1,7 @@
 import { Protocol } from "devtools-protocol";
 import { promises as fs } from "fs";
+import { createWriteStream, type WriteStream } from "fs";
+import { resolve as pathResolve, join as pathJoin } from "path";
 import { v3Logger } from "../logger.js";
 import { FlowLogger } from "../flowlogger/FlowLogger.js";
 import type { CDPSessionLike } from "./cdp.js";
@@ -99,6 +101,12 @@ export class Page {
   private readonly pageId: string;
   /** Cached current URL for synchronous page.url() */
   private _currentUrl: string = "about:blank";
+
+  /** Video recording state */
+  private _videoRecordingDir: string | null = null;
+  private _videoFrames: Buffer[] = [];
+  private _videoRecording = false;
+  private _videoFrameCount = 0;
 
   private navigationCommandSeq = 0;
   private latestNavigationCommandId = 0;
@@ -339,6 +347,21 @@ export class Page {
       }
     } catch {
       // ignore
+    }
+
+    // Auto-start video recording if configured
+    if (localBrowserLaunchOptions?.recordVideo?.dir) {
+      try {
+        const videoSize = localBrowserLaunchOptions.recordVideo.size;
+        await page.startVideoRecording(
+          localBrowserLaunchOptions.recordVideo.dir,
+          videoSize
+            ? { maxWidth: videoSize.width, maxHeight: videoSize.height }
+            : undefined,
+        );
+      } catch {
+        // best-effort video recording
+      }
     }
 
     // Seed topology + ownership for nodes known at creation time.
@@ -1174,6 +1197,84 @@ export class Page {
     };
 
     return await withTimeout(exec(), opts.timeout, "screenshot");
+  }
+
+  /**
+   * Start recording the page as a series of PNG frames using CDP screencast.
+   * Frames are saved to the specified directory and can be assembled into a video.
+   * @param dir Directory to save video frames to.
+   * @param options Optional screencast configuration.
+   */
+  async startVideoRecording(
+    dir: string,
+    options?: { maxWidth?: number; maxHeight?: number; everyNthFrame?: number },
+  ): Promise<void> {
+    if (this._videoRecording) return;
+
+    this._videoRecordingDir = pathResolve(dir);
+    this._videoFrames = [];
+    this._videoFrameCount = 0;
+    this._videoRecording = true;
+
+    await fs.mkdir(this._videoRecordingDir, { recursive: true });
+
+    // Listen for screencast frames
+    this.mainSession.on(
+      "Page.screencastFrame",
+      async (params: {
+        data: string;
+        metadata: { timestamp: number };
+        sessionId: number;
+      }) => {
+        if (!this._videoRecording) return;
+        try {
+          const frameBuffer = Buffer.from(params.data, "base64");
+          const frameNum = String(this._videoFrameCount++).padStart(6, "0");
+          await fs.writeFile(
+            pathJoin(this._videoRecordingDir!, `frame-${frameNum}.png`),
+            frameBuffer,
+          );
+          // Acknowledge the frame so Chrome sends the next one
+          await this.mainSession
+            .send("Page.screencastFrameAck", {
+              sessionId: params.sessionId,
+            })
+            .catch(() => {});
+        } catch {
+          // best-effort frame capture
+        }
+      },
+    );
+
+    await this.mainSession.send("Page.startScreencast", {
+      format: "png",
+      maxWidth: options?.maxWidth ?? 1280,
+      maxHeight: options?.maxHeight ?? 720,
+      everyNthFrame: options?.everyNthFrame ?? 2,
+    });
+  }
+
+  /**
+   * Stop video recording and return the directory containing the frames.
+   * Use ffmpeg or similar to assemble frames into a video file.
+   * @returns The directory path containing the recorded frames, or null if not recording.
+   */
+  async stopVideoRecording(): Promise<string | null> {
+    if (!this._videoRecording) return null;
+    this._videoRecording = false;
+
+    await this.mainSession
+      .send("Page.stopScreencast")
+      .catch(() => {});
+
+    return this._videoRecordingDir;
+  }
+
+  /**
+   * Check if the page is currently recording video.
+   */
+  get isVideoRecording(): boolean {
+    return this._videoRecording;
   }
 
   /**

--- a/packages/core/lib/v3/understudy/page.ts
+++ b/packages/core/lib/v3/understudy/page.ts
@@ -106,6 +106,7 @@ export class Page {
   private _videoRecordingDir: string | null = null;
   private _videoFrames: Buffer[] = [];
   private _videoRecording = false;
+  private _videoStarting = false;
   private _videoFrameCount = 0;
   private _screencastHandler: ((params: any) => void) | null = null;
 
@@ -1210,7 +1211,10 @@ export class Page {
     dir: string,
     options?: { maxWidth?: number; maxHeight?: number; everyNthFrame?: number },
   ): Promise<void> {
-    if (this._videoRecording) return;
+    if (this._videoRecording || this._videoStarting) return;
+
+    // Set synchronous lock immediately to prevent concurrent calls from racing
+    this._videoStarting = true;
 
     this._videoRecordingDir = pathResolve(dir);
     this._videoFrames = [];
@@ -1260,11 +1264,13 @@ export class Page {
         everyNthFrame: options?.everyNthFrame ?? 2,
       });
       this._videoRecording = true;
+      this._videoStarting = false;
     } catch (err) {
       // Cleanup on failure so the recording can be retried
       this.mainSession.off("Page.screencastFrame", this._screencastHandler);
       this._screencastHandler = null;
       this._videoRecording = false;
+      this._videoStarting = false;
       throw err;
     }
   }


### PR DESCRIPTION
## Summary
- Adds `recordVideo` option to `LocalBrowserLaunchOptionsSchema` for specifying a video recording directory and optional frame size
- Implements video recording via CDP `Page.startScreencast` API, capturing frames as PNG files
- Auto-starts recording when `recordVideo.dir` is configured in launch options
- Adds `page.startVideoRecording()` and `page.stopVideoRecording()` methods for manual control

Closes #1914

## Motivation
Test automation tools that use Stagehand need to record browser sessions for debugging and test result review. Both Playwright and Puppeteer support `recordVideo` on their browser contexts, but Stagehand's CDP-based architecture doesn't expose this capability. This PR bridges that gap using CDP's screencast API.

## Changes
- `packages/core/lib/v3/types/public/api.ts` — Added `recordVideo` field to `LocalBrowserLaunchOptionsSchema`
- `packages/core/lib/v3/understudy/page.ts` — Added video recording state, `startVideoRecording()`, `stopVideoRecording()`, and `isVideoRecording` getter. Auto-starts recording in `Page.create()` when configured.

## Usage
```typescript
const stagehand = new Stagehand({
  env: "LOCAL",
  localBrowserLaunchOptions: {
    recordVideo: {
      dir: "/tmp/videos",
      size: { width: 1280, height: 720 }, // optional
    },
  },
});
await stagehand.init();
// ... run automation ...
const page = stagehand.context.pages()[0];
const framesDir = await page.stopVideoRecording();
// framesDir contains frame-000000.png, frame-000001.png, etc.
// Use ffmpeg to assemble: ffmpeg -framerate 10 -i frame-%06d.png -c:v libvpx -b:v 1M output.webm
await stagehand.close();
```

## Test plan
- [ ] Verify `recordVideo.dir` creates the directory and saves PNG frames
- [ ] Verify frames are captured during page navigation and interaction
- [ ] Verify `stopVideoRecording()` stops the screencast and returns the directory path
- [ ] Verify no regression when `recordVideo` is not specified

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds video recording to local browsers via CDP screencast. You can auto-start from launch options or control it per page to capture PNG frames for later video assembly, with fixes for listener leaks, startup failures, and a guard to prevent concurrent starts.

- **New Features**
  - `LocalBrowserLaunchOptionsSchema.recordVideo` with `dir` and optional `size { width, height }`
  - Auto-start recording in `Page.create()` when `recordVideo.dir` is set
  - `page.startVideoRecording(dir, { maxWidth, maxHeight, everyNthFrame })`, `page.stopVideoRecording()`, `page.isVideoRecording`
  - Saves `frame-*.png` files to the target directory for tools like `ffmpeg`

- **Bug Fixes**
  - Prevent duplicate `Page.screencastFrame` listeners and concurrent start races via `_videoStarting` lock; remove handler on stop and before new starts
  - Set `isVideoRecording` true only after `Page.startScreencast` succeeds; reset state on failure so retries work

<sup>Written for commit ec5f41bd8ac20b1b4e78ccb2552e79e50995d57d. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1915">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

