### PR TITLE
fix: add zod/v4 fallback for toJSONSchema detection (fixes #1845)

### DIFF
--- a/.changeset/zod-v4-fallback.md
+++ b/.changeset/zod-v4-fallback.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+fix: add zod/v4 fallback for toJSONSchema detection (fixes #1845)

--- a/packages/core/lib/v3/zodCompat.ts
+++ b/packages/core/lib/v3/zodCompat.ts
@@ -6,6 +6,8 @@ import type {
 } from "zod";
 import zodToJsonSchema from "zod-to-json-schema";
 import type * as z3 from "zod/v3";
+import { createRequire } from "node:module";
+import { getCurrentFilePath } from "./runtimePaths.js";
 export type StagehandZodSchema = Zod4TypeAny | z3.ZodTypeAny;
 
 export type StagehandZodObject =
@@ -30,12 +32,35 @@ export const isZod3Schema = (
 
 export type JsonSchemaDocument = Record<string, unknown>;
 
+// Lazy-init fallback: in transitional zod versions (e.g. 3.25.x), the root
+// "zod" import is a v3-compat layer without toJSONSchema, but the real v4 API
+// is available at "zod/v4". We resolve it once on first use.
+let _zodV4ToJSONSchema: ((schema: Zod4TypeAny) => JsonSchemaDocument) | null =
+  null;
+let _zodV4Resolved = false;
+
+function getZodV4ToJSONSchema(): typeof _zodV4ToJSONSchema {
+  if (!_zodV4Resolved) {
+    _zodV4Resolved = true;
+    try {
+      const req = createRequire(getCurrentFilePath());
+      const zodV4 = req("zod/v4") as {
+        toJSONSchema?: (schema: Zod4TypeAny) => JsonSchemaDocument;
+      };
+      _zodV4ToJSONSchema = zodV4.toJSONSchema ?? null;
+    } catch {
+      // zod/v4 subpath not available — will fall through to error below
+    }
+  }
+  return _zodV4ToJSONSchema;
+}
+
 export function toJsonSchema(schema: StagehandZodSchema): JsonSchemaDocument {
   if (!isZod4Schema(schema)) {
     return zodToJsonSchema(schema);
   }
 
-  // For v4 schemas, use built-in z.toJSONSchema() method
+  // For v4 schemas, try the root z.toJSONSchema() first (works with zod >= 4.x)
   const zodWithJsonSchema = z as typeof z & {
     toJSONSchema?: (schema: Zod4TypeAny) => JsonSchemaDocument;
   };
@@ -44,6 +69,15 @@ export function toJsonSchema(schema: StagehandZodSchema): JsonSchemaDocument {
     return zodWithJsonSchema.toJSONSchema(schema as Zod4TypeAny);
   }
 
-  // This should never happen with Zod v4.1+
-  throw new Error("Zod v4 toJSONSchema method not found");
+  // Fallback: in transitional zod 3.25.x the root "zod" is v3, but
+  // "zod/v4" exposes toJSONSchema.
+  const v4Fallback = getZodV4ToJSONSchema();
+  if (v4Fallback) {
+    return v4Fallback(schema as Zod4TypeAny);
+  }
+
+  throw new Error(
+    "Zod v4 schema detected but toJSONSchema is unavailable. " +
+      'Ensure your zod version exposes toJSONSchema on the root export or via "zod/v4".',
+  );
 }

--- a/packages/core/lib/v3/zodCompat.ts
+++ b/packages/core/lib/v3/zodCompat.ts
@@ -8,6 +8,7 @@ import zodToJsonSchema from "zod-to-json-schema";
 import type * as z3 from "zod/v3";
 import { createRequire } from "node:module";
 import { getCurrentFilePath } from "./runtimePaths.js";
+import { StagehandError } from "./types/public/sdkErrors.js";
 export type StagehandZodSchema = Zod4TypeAny | z3.ZodTypeAny;
 
 export type StagehandZodObject =
@@ -76,7 +77,7 @@ export function toJsonSchema(schema: StagehandZodSchema): JsonSchemaDocument {
     return v4Fallback(schema as Zod4TypeAny);
   }
 
-  throw new Error(
+  throw new StagehandError(
     "Zod v4 schema detected but toJSONSchema is unavailable. " +
       'Ensure your zod version exposes toJSONSchema on the root export or via "zod/v4".',
   );


### PR DESCRIPTION
## Summary

Fixes #1845. When `zod@3.25.76` (transitional version) is installed, the root `zod` import resolves to a v3 compatibility layer that lacks `toJSONSchema`. This causes a runtime crash when Stagehand detects a Zod v4 schema (via `_zod` property) but cannot find the conversion method.

## Changes

**`packages/core/lib/v3/zodCompat.ts`** (+37/-3 lines)

- Added `getZodV4ToJSONSchema()` lazy-loading function that attempts to import `toJSONSchema` from the `zod/v4` subpath as a fallback
- Uses `createRequire(getCurrentFilePath())` for ESM/CJS compatibility (reuses existing `runtimePaths.js` helper)
- Resolution order: root `z.toJSONSchema()` → fallback `zod/v4` subpath → clear error message
- Result is cached after first resolution to avoid repeated dynamic imports

## Testing

- 37 test files passed, 347 tests passed, 0 new failures
- `tsc --noEmit` clean for modified file
- 9 pre-existing test failures in upstream (public-api package resolution + flowlogger assertions)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a fallback to load `toJSONSchema` from `zod/v4` when the root `zod` export doesn’t expose it, preventing crashes on transitional installs. Includes a changeset to publish a patch for `@browserbasehq/stagehand`.

- **Bug Fixes**
  - Resolution order: root `z.toJSONSchema()` → `zod/v4` → clear error if unavailable.
  - Lazy-loads and caches the v4 resolver; ESM/CJS safe via `createRequire` and `getCurrentFilePath()`.

- **Refactors**
  - Replace generic Error with StagehandError for consistent error handling.

<sup>Written for commit b8dc16535a04c62399e512ff3f71d45d8bf518d0. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1918">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

