### PR TITLE
fix : add check of / in model name

### DIFF
--- a/packages/core/lib/modelUtils.ts
+++ b/packages/core/lib/modelUtils.ts
@@ -17,6 +17,9 @@ export function splitModelName(model: string): {
   modelName: string;
 } {
   const firstSlashIndex = model.indexOf("/");
+  if (firstSlashIndex === -1) {
+    return { provider: "", modelName: model };
+  }
   const provider = model.substring(0, firstSlashIndex);
   const modelName = model.substring(firstSlashIndex + 1);
   return { provider, modelName };


### PR DESCRIPTION

if model name has no `/`, like "gpt-4.1-mini", `provider` will be "gpt-4.1-min"



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix model parsing when the name has no "/". We now return an empty provider and the full model name (e.g., "gpt-4.1-mini") instead of truncating the provider.

<sup>Written for commit cb0234c4ef3511cfc6aefe13cf32804595a75cff. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1930">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

