### PR TITLE
Update docs / logging to reflect gpt 5.4 and gemini 3.1 family compatibility with hybrid agent 

### DIFF
--- a/.changeset/tricky-bats-pay.md
+++ b/.changeset/tricky-bats-pay.md
@@ -2,4 +2,4 @@
 "@browserbasehq/stagehand": patch
 ---
 
-Update docs / logging to reflect gpt 5.4 and gemini 3.1 family compatability with agent hybrid mode
+Update docs / logging to reflect gpt 5.4 and gemini 3.1 family compatibility with agent hybrid mode

--- a/.changeset/tricky-bats-pay.md
+++ b/.changeset/tricky-bats-pay.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Update docs / logging to reflect gpt 5.4 and gemini 3.1 family compatability with agent hybrid mode

--- a/claude.md
+++ b/claude.md
@@ -238,7 +238,7 @@ Hybrid mode uses both DOM-based and coordinate-based tools (act, click, type, dr
 
 **Recommended models for hybrid mode:**
 
-- `google/gemini-3-flash-preview`, `google/gemini-3.1-flash-live-preview`, `google/gemini-3.1-pro-preview`
+- `google/gemini-3-flash-preview`, `google/gemini-3.1-flash-lite-preview`, `google/gemini-3.1-pro-preview`
 - `openai/gpt-5.4`, `openai/gpt-5.4-mini`
 - Any `anthropic/claude-*` model
 

--- a/claude.md
+++ b/claude.md
@@ -238,8 +238,9 @@ Hybrid mode uses both DOM-based and coordinate-based tools (act, click, type, dr
 
 **Recommended models for hybrid mode:**
 
-- `google/gemini-3-flash-preview`
-- `anthropic/claude-sonnet-4-20250514`, `anthropic/claude-sonnet-4-5-20250929`, `anthropic/claude-haiku-4-5-20251001`
+- `google/gemini-3-flash-preview`, `google/gemini-3.1-flash-live-preview`, `google/gemini-3.1-pro-preview`
+- `openai/gpt-5.4`, `openai/gpt-5.4-mini`
+- Any `anthropic/claude-*` model
 
 ```typescript
 const stagehand = new Stagehand({

--- a/packages/core/lib/v3/handlers/v3AgentHandler.ts
+++ b/packages/core/lib/v3/handlers/v3AgentHandler.ts
@@ -166,6 +166,8 @@ export class V3AgentHandler {
       if (
         this.mode === "hybrid" &&
         !baseModel.modelId.includes("gemini-3-flash") &&
+        !baseModel.modelId.includes("gemini-3.1") &&
+        !baseModel.modelId.includes("gpt-5.4") &&
         !baseModel.modelId.includes("claude")
       ) {
         this.logger({

--- a/packages/docs/v3/basics/agent.mdx
+++ b/packages/docs/v3/basics/agent.mdx
@@ -137,7 +137,7 @@ Both DOM and CUA modes have their strengths and weaknesses. Hybrid mode combines
 
 <Warning>
 **Model Requirements:** Hybrid mode requires models that can reliably perform coordinate-based actions from screenshots. The following models are recommended:
-- **Google:** `google/gemini-3-flash-preview`, `google/gemini-3.1-flash-live-preview`, `google/gemini-3.1-pro-preview`
+- **Google:** `google/gemini-3-flash-preview`, `google/gemini-3.1-flash-lite-preview`, `google/gemini-3.1-pro-preview`
 - **OpenAI:** `openai/gpt-5.4`, `openai/gpt-5.4-mini`
 - **Anthropic:** Any `anthropic/claude-*` model
 

--- a/packages/docs/v3/basics/agent.mdx
+++ b/packages/docs/v3/basics/agent.mdx
@@ -137,8 +137,9 @@ Both DOM and CUA modes have their strengths and weaknesses. Hybrid mode combines
 
 <Warning>
 **Model Requirements:** Hybrid mode requires models that can reliably perform coordinate-based actions from screenshots. The following models are recommended:
-- **Google:** `google/gemini-3-flash-preview`
-- **Anthropic:** `anthropic/claude-sonnet-4-20250514`, `anthropic/claude-sonnet-4-5-20250929`, `anthropic/claude-haiku-4-5-20251001`
+- **Google:** `google/gemini-3-flash-preview`, `google/gemini-3.1-flash-live-preview`, `google/gemini-3.1-pro-preview`
+- **OpenAI:** `openai/gpt-5.4`, `openai/gpt-5.4-mini`
+- **Anthropic:** Any `anthropic/claude-*` model
 
 Other models may not reliably produce accurate coordinates for clicking and typing.
 

--- a/packages/docs/v3/references/agent.mdx
+++ b/packages/docs/v3/references/agent.mdx
@@ -131,8 +131,9 @@ interface AgentInstance {
   
   <Warning>
   **Hybrid Mode Model Requirements:** Only use hybrid mode with models that can reliably perform coordinate-based actions:
-  - **Google:** `google/gemini-3-flash-preview`
-  - **Anthropic:** `anthropic/claude-sonnet-4-20250514`, `anthropic/claude-sonnet-4-5-20250929`, `anthropic/claude-haiku-4-5-20251001`
+  - **Google:** `google/gemini-3-flash-preview`, `google/gemini-3.1-flash-live-preview`, `google/gemini-3.1-pro-preview`
+  - **OpenAI:** `openai/gpt-5.4`, `openai/gpt-5.4-mini`
+  - **Anthropic:** Any `anthropic/claude-*` model
   
   Requires `experimental: true` in Stagehand constructor.
   </Warning>

--- a/packages/docs/v3/references/agent.mdx
+++ b/packages/docs/v3/references/agent.mdx
@@ -131,7 +131,7 @@ interface AgentInstance {
   
   <Warning>
   **Hybrid Mode Model Requirements:** Only use hybrid mode with models that can reliably perform coordinate-based actions:
-  - **Google:** `google/gemini-3-flash-preview`, `google/gemini-3.1-flash-live-preview`, `google/gemini-3.1-pro-preview`
+  - **Google:** `google/gemini-3-flash-preview`, `google/gemini-3.1-flash-lite-preview`, `google/gemini-3.1-pro-preview`
   - **OpenAI:** `openai/gpt-5.4`, `openai/gpt-5.4-mini`
   - **Anthropic:** Any `anthropic/claude-*` model
   


### PR DESCRIPTION
…ability with agent hybrid mode

# why

Currently when hybrid mode is used with a non anthropic, or gemini 3 flash model we throw a warning and only recommend those in docs. 

# what changed

We now do not throw a warning for gpt 5.4 family, or gemini 3.1 as both work well with vision based actions 

# test plan

Tested models locally to ensure work well with vision based actions 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop showing the hybrid-mode warning for `openai/gpt-5.4`, `openai/gpt-5.4-mini`, and `google/gemini-3.1-*`.
Update docs to recommend `google/gemini-3-flash-preview`, `google/gemini-3.1-flash-lite-preview`, `google/gemini-3.1-pro-preview`, `openai/gpt-5.4*`, and any `anthropic/claude-*` for vision-based actions; corrected the model name to `gemini-3.1-flash-lite-preview`.

<sup>Written for commit e89ead4fed4788558c5d138027a0dec0730c32c8. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1936">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

