### PR TITLE
Chromie/fix adaptive thinking hybrid mode

### DIFF
--- a/packages/core/lib/v3/agent/AnthropicCUAClient.ts
+++ b/packages/core/lib/v3/agent/AnthropicCUAClient.ts
@@ -27,6 +27,7 @@ import {
   extractLlmCuaResponseSummary,
 } from "../flowlogger/FlowLogger.js";
 import { v7 as uuidv7 } from "uuid";
+import { supportsAdaptiveThinking } from "./utils/adaptiveThinking.js";
 
 export type ResponseInputItem = AnthropicMessage | AnthropicToolResult;
 
@@ -432,10 +433,16 @@ export class AnthropicCUAClient extends AgentClient {
         // as they should already be properly wrapped in user messages
       }
 
-      // Configure thinking capability if available
-      const thinking = this.thinkingBudget
-        ? { type: "enabled" as const, budget_tokens: this.thinkingBudget }
-        : undefined;
+      // Configure thinking capability.
+      // Claude 4.6+ models support adaptive thinking which dynamically
+      // determines when and how much to reason. For older models, fall back
+      // to the explicit budget-based thinking configuration.
+      const useAdaptive = supportsAdaptiveThinking(this.modelName);
+      const thinking = useAdaptive
+        ? ({ type: "adaptive" } as Record<string, unknown>)
+        : this.thinkingBudget
+          ? { type: "enabled" as const, budget_tokens: this.thinkingBudget }
+          : undefined;
 
       // Claude 4.6+ models require the newer computer_20251124 tool version
       const modelBase = this.modelName.includes("/")

--- a/packages/core/lib/v3/agent/tools/index.ts
+++ b/packages/core/lib/v3/agent/tools/index.ts
@@ -57,6 +57,13 @@ export interface V3AgentToolOptions {
    */
   toolTimeout?: number;
   /**
+   * When true, the custom `think` tool is excluded from the toolset because
+   * the model supports adaptive thinking natively (e.g. Claude 4.6 models).
+   *
+   * @see https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking
+   */
+  useAdaptiveThinking?: boolean;
+  /**
    * Whether to enable the Browserbase-powered web search tool.
    * Requires a valid Browserbase API key.
    */
@@ -184,6 +191,8 @@ export function createAgentTools(v3: V3, options?: V3AgentToolOptions) {
     unwrappedTools.search = braveSearchTool(v3);
   }
 
+  const useAdaptiveThinking = options?.useAdaptiveThinking ?? false;
+
   const allTools: ToolSet = {
     ...Object.fromEntries(
       Object.entries(unwrappedTools).map(([name, t]) => [
@@ -197,7 +206,9 @@ export function createAgentTools(v3: V3, options?: V3AgentToolOptions) {
         ),
       ]),
     ),
-    think: thinkTool(),
+    // When adaptive thinking is enabled the model reasons natively between
+    // tool calls, so the custom think tool is redundant and should be omitted.
+    ...(useAdaptiveThinking ? {} : { think: thinkTool() }),
     wait: waitTool(v3, mode),
   };
 

--- a/packages/core/lib/v3/agent/utils/adaptiveThinking.ts
+++ b/packages/core/lib/v3/agent/utils/adaptiveThinking.ts
@@ -1,0 +1,35 @@
+/**
+ * Anthropic models that support adaptive thinking (thinking.type: "adaptive").
+ *
+ * These models dynamically determine when and how much to use extended thinking
+ * based on the complexity of each request. When adaptive thinking is active the
+ * custom "think" tool should be omitted because the model's native reasoning
+ * replaces it.
+ *
+ * @see https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking
+ */
+const ADAPTIVE_THINKING_MODEL_PATTERNS = [
+  "claude-opus-4-6",
+  "claude-sonnet-4-6",
+];
+
+/**
+ * Returns `true` when the given model identifier refers to an Anthropic model
+ * that supports adaptive thinking (Claude Opus 4.6, Sonnet 4.6 and their
+ * dated variants).
+ */
+export function supportsAdaptiveThinking(
+  modelId: string | undefined,
+): boolean {
+  if (!modelId) return false;
+
+  // Strip the provider prefix (e.g. "anthropic/claude-sonnet-4-6" → "claude-sonnet-4-6")
+  const baseModel = modelId.includes("/")
+    ? modelId.split("/").slice(1).join("/")
+    : modelId;
+
+  return ADAPTIVE_THINKING_MODEL_PATTERNS.some(
+    (pattern) =>
+      baseModel === pattern || baseModel.startsWith(`${pattern}-`),
+  );
+}

--- a/packages/core/lib/v3/handlers/v3AgentHandler.ts
+++ b/packages/core/lib/v3/handlers/v3AgentHandler.ts
@@ -45,6 +45,7 @@ import {
   CAPTCHA_SOLVED_MSG,
   CAPTCHA_ERRORED_MSG,
 } from "../agent/utils/captchaSolver.js";
+import { supportsAdaptiveThinking } from "../agent/utils/adaptiveThinking.js";
 
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -138,11 +139,25 @@ export class V3AgentHandler {
         }
       }
 
+      // Detect whether the model supports adaptive thinking (Claude 4.6+).
+      // When it does we enable native thinking and omit the custom think tool.
+      const modelId = this.llmClient?.getLanguageModel?.()?.modelId;
+      const useAdaptiveThinking = supportsAdaptiveThinking(modelId);
+
+      if (useAdaptiveThinking) {
+        this.logger({
+          category: "agent",
+          message: `Adaptive thinking enabled for model "${modelId}" — custom think tool will be omitted`,
+          level: 1,
+        });
+      }
+
       const tools = this.createTools(
         options.excludeTools,
         options.variables,
         options.toolTimeout,
         options.useSearch,
+        useAdaptiveThinking,
       );
       const allTools: ToolSet = { ...tools, ...this.mcpTools };
 
@@ -183,6 +198,7 @@ export class V3AgentHandler {
         messages,
         wrappedModel,
         initialPageUrl,
+        useAdaptiveThinking,
       };
     } catch (error) {
       this.logger({
@@ -334,6 +350,7 @@ export class V3AgentHandler {
         messages: preparedMessages,
         wrappedModel,
         initialPageUrl,
+        useAdaptiveThinking,
       } = await this.prepareAgent(instructionOrOptions);
 
       // Enable cursor overlay for hybrid mode (coordinate-based interactions)
@@ -385,6 +402,15 @@ export class V3AgentHandler {
         providerOptions: {
           google: { mediaResolution: "MEDIA_RESOLUTION_HIGH" },
           openai: { store: false },
+          // Enable extended thinking for Anthropic models that support it.
+          // The @ai-sdk/anthropic provider (v2.x) supports type: "enabled"
+          // with a budget; when the SDK adds type: "adaptive" support this
+          // should be migrated to { type: "adaptive" }.
+          ...(useAdaptiveThinking && {
+            anthropic: {
+              thinking: { type: "enabled", budgetTokens: 10024 },
+            },
+          }),
         },
       });
 
@@ -459,6 +485,7 @@ export class V3AgentHandler {
       messages,
       wrappedModel,
       initialPageUrl,
+      useAdaptiveThinking,
     } = await this.prepareAgent(instructionOrOptions);
 
     // Enable cursor overlay for hybrid mode (coordinate-based interactions)
@@ -570,6 +597,11 @@ export class V3AgentHandler {
         providerOptions: {
           google: { mediaResolution: "MEDIA_RESOLUTION_HIGH" },
           openai: { store: false },
+          ...(useAdaptiveThinking && {
+            anthropic: {
+              thinking: { type: "enabled", budgetTokens: 10024 },
+            },
+          }),
         },
       });
     } catch (error) {
@@ -647,6 +679,7 @@ export class V3AgentHandler {
     variables?: Variables,
     toolTimeout?: number,
     useSearch?: boolean,
+    useAdaptiveThinking?: boolean,
   ) {
     const provider = this.llmClient?.getLanguageModel?.()?.provider;
     return createAgentTools(this.v3, {
@@ -659,6 +692,7 @@ export class V3AgentHandler {
       toolTimeout,
       useSearch,
       browserbaseApiKey: useSearch ? this.v3.browserbaseApiKey : undefined,
+      useAdaptiveThinking,
     });
   }
 

--- a/packages/core/lib/v3/types/public/agent.ts
+++ b/packages/core/lib/v3/types/public/agent.ts
@@ -65,6 +65,8 @@ export interface AgentContext {
   messages: ModelMessage[];
   wrappedModel: ReturnType<typeof wrapLanguageModel>;
   initialPageUrl: string;
+  /** True when the model supports adaptive thinking natively (e.g. Claude 4.6). */
+  useAdaptiveThinking: boolean;
 }
 
 export interface AgentState {

--- a/packages/core/tests/integration/agent-hybrid-mode.spec.ts
+++ b/packages/core/tests/integration/agent-hybrid-mode.spec.ts
@@ -314,5 +314,29 @@ test.describe("Stagehand agent hybrid mode", () => {
       const tools = createAgentTools(v3, { mode: "hybrid" });
       expect(tools).toHaveProperty("think");
     });
+
+    test("Think tool is excluded when useAdaptiveThinking is true", () => {
+      const tools = createAgentTools(v3, {
+        mode: "hybrid",
+        useAdaptiveThinking: true,
+      });
+      expect(tools).not.toHaveProperty("think");
+    });
+
+    test("Think tool is excluded in DOM mode when useAdaptiveThinking is true", () => {
+      const tools = createAgentTools(v3, {
+        mode: "dom",
+        useAdaptiveThinking: true,
+      });
+      expect(tools).not.toHaveProperty("think");
+    });
+
+    test("Think tool is included when useAdaptiveThinking is false", () => {
+      const tools = createAgentTools(v3, {
+        mode: "hybrid",
+        useAdaptiveThinking: false,
+      });
+      expect(tools).toHaveProperty("think");
+    });
   });
 });

--- a/packages/core/tests/unit/adaptive-thinking.test.ts
+++ b/packages/core/tests/unit/adaptive-thinking.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { supportsAdaptiveThinking } from "../../lib/v3/agent/utils/adaptiveThinking.js";
+
+describe("supportsAdaptiveThinking", () => {
+  it("returns true for claude-opus-4-6 models", () => {
+    expect(supportsAdaptiveThinking("anthropic/claude-opus-4-6")).toBe(true);
+  });
+
+  it("returns true for claude-sonnet-4-6 models", () => {
+    expect(supportsAdaptiveThinking("anthropic/claude-sonnet-4-6")).toBe(true);
+  });
+
+  it("returns true for dated variants of 4-6 models", () => {
+    expect(
+      supportsAdaptiveThinking("anthropic/claude-sonnet-4-6-20260301"),
+    ).toBe(true);
+    expect(
+      supportsAdaptiveThinking("anthropic/claude-opus-4-6-20260301"),
+    ).toBe(true);
+  });
+
+  it("returns false for older Anthropic models", () => {
+    expect(
+      supportsAdaptiveThinking("anthropic/claude-sonnet-4-20250514"),
+    ).toBe(false);
+    expect(
+      supportsAdaptiveThinking("anthropic/claude-sonnet-4-5-20250929"),
+    ).toBe(false);
+    expect(
+      supportsAdaptiveThinking("anthropic/claude-haiku-4-5-20251001"),
+    ).toBe(false);
+    expect(
+      supportsAdaptiveThinking("anthropic/claude-opus-4-5-20251101"),
+    ).toBe(false);
+  });
+
+  it("returns false for non-Anthropic models", () => {
+    expect(supportsAdaptiveThinking("openai/gpt-4o")).toBe(false);
+    expect(supportsAdaptiveThinking("google/gemini-2.0-flash")).toBe(false);
+  });
+
+  it("returns false for undefined or empty model names", () => {
+    expect(supportsAdaptiveThinking(undefined)).toBe(false);
+    expect(supportsAdaptiveThinking("")).toBe(false);
+  });
+});


### PR DESCRIPTION
# why

# what changed

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable adaptive thinking for Anthropic Claude 4.6 models and automatically remove the custom `think` tool in hybrid/DOM modes to prevent redundant reasoning. Older models continue to use budget-based thinking.

- **New Features**
  - Detect Claude Opus/Sonnet 4.6 (and dated variants) and enable native adaptive thinking in `AnthropicCUAClient`; fall back to budget-based thinking for older models.
  - Omit the `think` tool when adaptive thinking is supported via a new `useAdaptiveThinking` option in `createAgentTools`, wired through `v3AgentHandler` and exposed on `AgentContext`.
  - Set Anthropic provider options to enable extended thinking during hybrid/DOM runs; add unit and integration tests for model detection and `think` tool exclusion.

- **Bug Fixes**
  - Prevents hybrid-mode reasoning/tool loops by removing the redundant `think` tool for Claude 4.6 models.

<sup>Written for commit d9f50055d5d32165a26d1f6c4462d4fd93bedc36. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1968">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

