### PR TITLE
[STG-1802] fix: abort immediately for already-aborted agent signals

### DIFF
--- a/.changeset/quiet-cameras-knock.md
+++ b/.changeset/quiet-cameras-knock.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Abort agent execution immediately when passed an already-aborted signal, and deflake the integration coverage for that path.

--- a/packages/core/lib/v3/v3.ts
+++ b/packages/core/lib/v3/v3.ts
@@ -79,6 +79,7 @@ import {
   MissingEnvironmentVariableError,
   StagehandInitError,
   AgentStreamResult,
+  AgentAbortError,
 } from "./types/public/index.js";
 import { V3Context } from "./understudy/context.js";
 import { Page } from "./understudy/page.js";
@@ -128,6 +129,15 @@ export function resolveModelConfiguration(
   }
 
   return { modelName: DEFAULT_MODEL_NAME };
+}
+
+function throwAgentAbortIfAborted(signal?: AbortSignal): void {
+  if (!signal?.aborted) {
+    return;
+  }
+
+  const reason = signal.reason ? String(signal.reason) : "aborted";
+  throw new AgentAbortError(reason);
 }
 
 /**
@@ -2053,15 +2063,19 @@ export class V3 {
       withInstanceLogContext(
         this.instanceId,
         async (): Promise<AgentResult | AgentStreamResult> => {
+          const executeOptions =
+            typeof instructionOrOptions === "object"
+              ? instructionOrOptions
+              : null;
+
           validateExperimentalFeatures({
             isExperimental: this.experimental,
             agentConfig: options,
-            executeOptions:
-              typeof instructionOrOptions === "object"
-                ? instructionOrOptions
-                : null,
+            executeOptions,
             isStreaming,
           });
+
+          throwAgentAbortIfAborted(executeOptions?.signal);
 
           // Streaming mode
           if (isStreaming) {

--- a/packages/core/tests/integration/agent-abort-signal.spec.ts
+++ b/packages/core/tests/integration/agent-abort-signal.spec.ts
@@ -6,13 +6,18 @@ import { AgentAbortError } from "../../lib/v3/types/public/sdkErrors.js";
 test.describe("Stagehand agent abort signal", () => {
   let v3: V3;
 
-  test.beforeEach(async () => {
-    v3 = new V3({
+  async function createV3(init = true): Promise<V3> {
+    const instance = new V3({
       ...v3TestConfig,
       experimental: true,
     });
-    await v3.init();
-  });
+
+    if (init) {
+      await instance.init();
+    }
+
+    return instance;
+  }
 
   test.afterEach(async () => {
     await v3?.close?.().catch(() => {});
@@ -20,6 +25,8 @@ test.describe("Stagehand agent abort signal", () => {
 
   test("non-streaming: abort signal stops execution and throws AgentAbortError", async () => {
     test.setTimeout(60000);
+
+    v3 = await createV3();
 
     const agent = v3.agent({
       model: "anthropic/claude-haiku-4-5-20251001",
@@ -45,6 +52,8 @@ test.describe("Stagehand agent abort signal", () => {
 
   test("streaming: abort signal stops stream and rejects result with AgentAbortError", async () => {
     test.setTimeout(60000);
+
+    v3 = await createV3();
 
     const agent = v3.agent({
       stream: true,
@@ -91,12 +100,11 @@ test.describe("Stagehand agent abort signal", () => {
   test("non-streaming: already aborted signal throws AgentAbortError immediately", async () => {
     test.setTimeout(20000);
 
+    v3 = await createV3(false);
+
     const agent = v3.agent({
       model: "anthropic/claude-haiku-4-5-20251001",
     });
-
-    const page = v3.context.pages()[0];
-    await page.goto("https://example.com");
 
     // Create an already aborted controller
     const controller = new AbortController();
@@ -113,6 +121,8 @@ test.describe("Stagehand agent abort signal", () => {
 
   test("non-streaming: execution completes normally without abort signal", async () => {
     test.setTimeout(60000);
+
+    v3 = await createV3();
 
     const agent = v3.agent({
       model: "anthropic/claude-haiku-4-5-20251001",
@@ -133,6 +143,8 @@ test.describe("Stagehand agent abort signal", () => {
 
   test("streaming: execution completes normally without abort signal", async () => {
     test.setTimeout(60000);
+
+    v3 = await createV3();
 
     const agent = v3.agent({
       stream: true,

--- a/packages/core/tests/unit/browserbase-session-accessors.test.ts
+++ b/packages/core/tests/unit/browserbase-session-accessors.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { V3 } from "../../lib/v3/v3.js";
+import { AgentAbortError } from "../../lib/v3/types/public/sdkErrors.js";
 
 const MOCK_SESSION_ID = "session-123";
 const MOCK_SESSION_URL = `https://www.browserbase.com/sessions/${MOCK_SESSION_ID}`;
@@ -133,5 +134,33 @@ describe("local accessors", () => {
     } finally {
       await v3.close().catch(() => {});
     }
+  });
+});
+
+describe("agent abort fast path", () => {
+  it("throws AgentAbortError immediately for already-aborted signals", async () => {
+    const v3 = new V3({
+      env: "LOCAL",
+      disableAPI: true,
+      experimental: true,
+      verbose: 0,
+      model: {
+        modelName: "openai/gpt-4.1-mini",
+        apiKey: "test-key",
+      },
+    });
+
+    const controller = new AbortController();
+    controller.abort("unit-test");
+
+    const agent = v3.agent();
+
+    await expect(
+      agent.execute({
+        instruction: "This should not run.",
+        maxSteps: 1,
+        signal: controller.signal,
+      }),
+    ).rejects.toBeInstanceOf(AgentAbortError);
   });
 });


### PR DESCRIPTION
## Summary
- throw AgentAbortError before agent setup when the supplied signal is already aborted
- deflake the abort-signal integration test by removing Browserbase init from the immediate-abort case
- add a changeset and unit coverage for the fast path

## Verification
- pnpm exec prettier --check .changeset/quiet-cameras-knock.md packages/core/lib/v3/v3.ts packages/core/tests/integration/agent-abort-signal.spec.ts packages/core/tests/unit/browserbase-session-accessors.test.ts
- pnpm --filter @browserbasehq/stagehand typecheck
- pnpm --filter @browserbasehq/stagehand build:esm
- pnpm --filter @browserbasehq/stagehand test:core -- packages/core/dist/esm/tests/unit/browserbase-session-accessors.test.js
- node --import tsx -e "already-aborted signal smoke test" 

Linear: https://linear.app/browserbase/issue/STG-1802/abort-immediately-for-already-aborted-agent-signals

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Abort agents immediately when given an already-aborted signal, throwing `AgentAbortError` before any setup. Aligns with Linear STG-1802 and removes flakiness in the immediate-abort path for `@browserbasehq/stagehand`.

- **Bug Fixes**
  - Added early abort check in V3 execute path (`throwAgentAbortIfAborted`), using `signal.reason` when present.
  - Deflaked tests by skipping Browserbase init for the immediate-abort case and added unit coverage for the fast path.

<sup>Written for commit b84f012bc4362eee843ba76b34c1501975e5ecd7. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1982">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

