### PR TITLE
fix: unwrap tool parameter name wrapper in Anthropic responses (fixes #1986)

### DIFF
--- a/.changeset/fix-anthropic-unwrap.md
+++ b/.changeset/fix-anthropic-unwrap.md
@@ -1,0 +1,7 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+fix: unwrap tool parameter name wrapper in Anthropic responses
+
+Some Anthropic models wrap tool_use responses in a parameter name key (e.g. `{$PARAMETER_NAME: {actual data}}`), causing Zod schema validation to fail with `AI_NoObjectGeneratedError`. Added defensive unwrapping in both `AISdkClient` and `AnthropicClient` code paths.

--- a/packages/core/lib/v3/llm/AnthropicClient.ts
+++ b/packages/core/lib/v3/llm/AnthropicClient.ts
@@ -17,6 +17,7 @@ import {
 } from "./LLMClient.js";
 import { CreateChatCompletionResponseError } from "../types/public/sdkErrors.js";
 import { toJsonSchema } from "../zodCompat.js";
+import { unwrapToolResponse } from "./unwrapToolResponse.js";
 
 export class AnthropicClient extends LLMClient {
   public type = "anthropic" as const;
@@ -247,7 +248,8 @@ export class AnthropicClient extends LLMClient {
     if (options.response_model) {
       const toolUse = response.content.find((c) => c.type === "tool_use");
       if (toolUse && "input" in toolUse) {
-        const result = toolUse.input;
+        const rawResult = toolUse.input;
+        const result = unwrapToolResponse(rawResult as Record<string, unknown>);
 
         const finalParsedResponse = {
           data: result,

--- a/packages/core/lib/v3/llm/aisdk.ts
+++ b/packages/core/lib/v3/llm/aisdk.ts
@@ -22,6 +22,7 @@ import {
   extractLlmPromptSummary,
 } from "../flowlogger/FlowLogger.js";
 import { toJsonSchema } from "../zodCompat.js";
+import { unwrapToolResponse } from "./unwrapToolResponse.js";
 
 type ProviderOptionValue = string | number | boolean | null;
 type ProviderOptionMap = Record<string, ProviderOptionValue>;
@@ -258,6 +259,58 @@ You must respond in JSON format. respond WITH JSON. Do not include any other tex
         });
 
         if (NoObjectGeneratedError.isInstance(err)) {
+          // Attempt to recover from tool parameter name wrapping.
+          // Some providers (e.g. Anthropic) wrap tool_use responses in a
+          // parameter name key like {"$PARAMETER_NAME": {actual data}}.
+          // The AI SDK's schema validation fails on the wrapper, but the
+          // actual data inside may be valid.
+          if (err.text) {
+            try {
+              const parsed = JSON.parse(err.text);
+              const unwrapped = unwrapToolResponse(parsed);
+              if (unwrapped !== parsed) {
+                // Validate unwrapped data against the schema
+                const validated =
+                  options.response_model.schema.safeParse(unwrapped);
+                if (validated.success) {
+                  this.logger?.({
+                    category: "aisdk",
+                    message:
+                      "recovered from tool parameter name wrapping in response",
+                    level: 1,
+                    auxiliary: {
+                      requestId: {
+                        value: options.requestId,
+                        type: "string",
+                      },
+                    },
+                  });
+
+                  FlowLogger.logLlmResponse({
+                    requestId: llmRequestId,
+                    model: this.model.modelId,
+                    output: JSON.stringify(validated.data),
+                    inputTokens: err.usage?.inputTokens,
+                    outputTokens: err.usage?.outputTokens,
+                  });
+
+                  return {
+                    data: validated.data,
+                    usage: {
+                      prompt_tokens: err.usage?.inputTokens ?? 0,
+                      completion_tokens: err.usage?.outputTokens ?? 0,
+                      reasoning_tokens: err.usage?.reasoningTokens ?? 0,
+                      cached_input_tokens: err.usage?.cachedInputTokens ?? 0,
+                      total_tokens: err.usage?.totalTokens ?? 0,
+                    },
+                  } as T;
+                }
+              }
+            } catch {
+              // JSON parse failed — fall through to original error
+            }
+          }
+
           this.logger?.({
             category: "AISDK error",
             message: err.message,

--- a/packages/core/lib/v3/llm/unwrapToolResponse.ts
+++ b/packages/core/lib/v3/llm/unwrapToolResponse.ts
@@ -1,0 +1,58 @@
+/**
+ * Unwrap tool parameter name wrapping from LLM responses.
+ *
+ * Some providers (notably Anthropic) may wrap tool_use responses in the tool's
+ * parameter name key. For example, when the AI SDK uses an internal "json" tool
+ * for structured output, the response may come back as:
+ *
+ *   { "$PARAMETER_NAME": { "elementId": "11-811", ... } }
+ *
+ * instead of the expected flat object:
+ *
+ *   { "elementId": "11-811", ... }
+ *
+ * This helper detects single-key wrappers where the key starts with "$" or
+ * doesn't match any expected schema property, and unwraps them.
+ */
+export function unwrapToolResponse<T extends Record<string, unknown>>(
+  result: T,
+  expectedKeys?: string[],
+): T {
+  if (result == null || typeof result !== "object" || Array.isArray(result)) {
+    return result;
+  }
+
+  const keys = Object.keys(result);
+
+  // Only unwrap if there's exactly one key that looks like a wrapper
+  if (keys.length !== 1) {
+    return result;
+  }
+
+  const [wrapperKey] = keys;
+  const inner = result[wrapperKey];
+
+  // Don't unwrap if the inner value isn't an object
+  if (inner == null || typeof inner !== "object" || Array.isArray(inner)) {
+    return result;
+  }
+
+  // Unwrap if the key starts with "$" (tool parameter naming convention)
+  if (wrapperKey.startsWith("$")) {
+    return inner as T;
+  }
+
+  // Unwrap if we have expected keys and the wrapper key isn't one of them
+  // but the inner object has at least one expected key
+  if (expectedKeys && expectedKeys.length > 0) {
+    const isWrapperExpected = expectedKeys.includes(wrapperKey);
+    const innerKeys = Object.keys(inner as Record<string, unknown>);
+    const innerHasExpectedKey = innerKeys.some((k) => expectedKeys.includes(k));
+
+    if (!isWrapperExpected && innerHasExpectedKey) {
+      return inner as T;
+    }
+  }
+
+  return result;
+}

--- a/packages/core/tests/unit/unwrapToolResponse.test.ts
+++ b/packages/core/tests/unit/unwrapToolResponse.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { unwrapToolResponse } from "../../lib/v3/llm/unwrapToolResponse";
+
+describe("unwrapToolResponse", () => {
+  it("unwraps $PARAMETER_NAME wrapper", () => {
+    const wrapped = {
+      $PARAMETER_NAME: {
+        elementId: "11-811",
+        description: "Create Invoice link button",
+        method: "click",
+        arguments: [],
+        twoStep: false,
+      },
+    };
+    const result = unwrapToolResponse(wrapped);
+    expect(result).toEqual({
+      elementId: "11-811",
+      description: "Create Invoice link button",
+      method: "click",
+      arguments: [],
+      twoStep: false,
+    });
+  });
+
+  it("unwraps any $-prefixed single-key wrapper", () => {
+    const wrapped = { $value: { name: "test", count: 42 } };
+    const result = unwrapToolResponse(wrapped);
+    expect(result).toEqual({ name: "test", count: 42 });
+  });
+
+  it("does not unwrap objects with multiple keys", () => {
+    const obj = { a: 1, b: 2 };
+    const result = unwrapToolResponse(obj as any);
+    expect(result).toEqual({ a: 1, b: 2 });
+  });
+
+  it("does not unwrap when inner value is not an object", () => {
+    const obj = { $key: "string value" };
+    const result = unwrapToolResponse(obj as any);
+    expect(result).toEqual({ $key: "string value" });
+  });
+
+  it("does not unwrap when inner value is an array", () => {
+    const obj = { $key: [1, 2, 3] };
+    const result = unwrapToolResponse(obj as any);
+    expect(result).toEqual({ $key: [1, 2, 3] });
+  });
+
+  it("returns null/undefined/arrays unchanged", () => {
+    expect(unwrapToolResponse(null as any)).toBeNull();
+    expect(unwrapToolResponse(undefined as any)).toBeUndefined();
+    expect(unwrapToolResponse([] as any)).toEqual([]);
+  });
+
+  it("does not unwrap single-key objects that don't start with $", () => {
+    const obj = { elementId: "11-811" };
+    const result = unwrapToolResponse(obj as any);
+    expect(result).toEqual({ elementId: "11-811" });
+  });
+
+  it("unwraps non-$ key when expectedKeys hint is provided", () => {
+    const wrapped = {
+      json: {
+        elementId: "11-811",
+        method: "click",
+      },
+    };
+    const result = unwrapToolResponse(wrapped as any, ["elementId", "method"]);
+    expect(result).toEqual({ elementId: "11-811", method: "click" });
+  });
+
+  it("does not unwrap when single key matches expected keys", () => {
+    const obj = { elementId: "11-811" };
+    const result = unwrapToolResponse(obj as any, ["elementId", "method"]);
+    expect(result).toEqual({ elementId: "11-811" });
+  });
+});


### PR DESCRIPTION
## Problem

When using Anthropic models (e.g. `anthropic/claude-sonnet-4-5`) with `act()`, Claude wraps `tool_use` responses in a parameter name key:

```json
{"$PARAMETER_NAME": {"elementId": "11-811", "description": "...", "method": "click", ...}}
```

instead of the expected flat object:

```json
{"elementId": "11-811", "description": "...", "method": "click", ...}
```

This causes Zod schema validation to fail with `AI_NoObjectGeneratedError` because all required fields are `undefined` at the top level.

Fixes #1986

## Solution

Add a defensive `unwrapToolResponse()` helper that detects and unwraps single-key wrappers:

- **Detects `$`-prefixed keys** (tool parameter naming convention like `$PARAMETER_NAME`)
- **Detects non-schema keys** when expected property names are provided as hints
- Returns the original object unchanged when no wrapping is detected

Applied in two code paths:

1. **`AISdkClient`** (`aisdk.ts`): When `generateObject()` throws `NoObjectGeneratedError`, attempts to unwrap the raw response text and re-validate against the schema before giving up
2. **`AnthropicClient`** (`AnthropicClient.ts`): Unwraps `toolUse.input` before returning the response model result

## Changes

| File | Change |
|------|--------|
| `packages/core/lib/v3/llm/unwrapToolResponse.ts` | New helper — detects and unwraps tool parameter name wrappers |
| `packages/core/lib/v3/llm/aisdk.ts` | Catch `NoObjectGeneratedError`, attempt unwrap + re-validate |
| `packages/core/lib/v3/llm/AnthropicClient.ts` | Unwrap `toolUse.input` for response model results |
| `packages/core/tests/unit/unwrapToolResponse.test.ts` | 9 unit tests covering wrap/no-wrap/edge cases |

## Testing

- Unit tests for `unwrapToolResponse()` covering:
  - `$PARAMETER_NAME` wrapper → unwraps ✅
  - `$`-prefixed keys → unwraps ✅
  - Multi-key objects → no change ✅
  - Non-object inner values → no change ✅
  - Expected keys hint matching ✅
  - Null/undefined/array inputs → no change ✅

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix schema validation failures with Anthropic `tool_use` outputs by unwrapping `$` parameter-name wrappers so tools receive flat inputs. Restores `act()` and structured object generation for models like `anthropic/claude-sonnet-4-5`.

- **Bug Fixes**
  - Added `unwrapToolResponse()` to detect and unwrap single-key `$` wrappers or non-schema keys.
  - Applied in `AnthropicClient` for `toolUse.input`, and in `AISdkClient` retry path to re-validate unwrapped JSON on `NoObjectGeneratedError`.
  - Added unit tests for wrapped, unwrapped, and edge cases.
  - Added changeset for `@browserbasehq/stagehand` patch release.

<sup>Written for commit 893a261e32227a5a55aebc8057bd519ca7991789. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1990">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

