### PR TITLE
fix: retry on stale execution context during page navigation (fixes #1778)

### DIFF
--- a/packages/core/lib/v3/understudy/a11y/snapshot/focusSelectors.ts
+++ b/packages/core/lib/v3/understudy/a11y/snapshot/focusSelectors.ts
@@ -199,34 +199,23 @@ export async function resolveCssFocusFrameAndTail(
   return { targetFrameId: ctxFrameId, tailSelector, absPrefix };
 }
 
-/** Resolve an XPath to a Runtime remoteObjectId in the given CDP session. */
-export async function resolveObjectIdForXPath(
+/**
+ * Evaluate a Runtime expression with a single retry when the execution context
+ * has been destroyed (e.g. due to navigation). Only retries when `frameId` is
+ * provided and the error message contains 'Cannot find context with specified id'.
+ */
+async function evaluateWithStaleContextRetry(
   session: CDPSessionLike,
-  xpath: string,
-  frameId?: string,
+  expression: string,
+  contextId: number | undefined,
+  frameId: string | undefined,
 ): Promise<string | null> {
-  let contextId: number | undefined;
-  try {
-    if (frameId) {
-      contextId = await executionContexts
-        .waitForMainWorld(session, frameId, 800)
-        .catch(
-          () => executionContexts.getMainWorld(session, frameId) ?? undefined,
-        );
-    }
-  } catch {
-    contextId = undefined;
-  }
-  const expr = buildLocatorInvocation("resolveXPathMainWorld", [
-    JSON.stringify(xpath),
-    "0",
-  ]);
   try {
     const { result, exceptionDetails } = await session.send<{
       result: { objectId?: string | undefined };
       exceptionDetails?: Protocol.Runtime.ExceptionDetails;
     }>("Runtime.evaluate", {
-      expression: expr,
+      expression,
       returnByValue: false,
       contextId,
       awaitPromise: true,
@@ -235,10 +224,7 @@ export async function resolveObjectIdForXPath(
     return result?.objectId ?? null;
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-    if (
-      !msg.includes("Cannot find context with specified id") ||
-      !frameId
-    )
+    if (!msg.includes("Cannot find context with specified id") || !frameId)
       return null;
     const freshCtx =
       executionContexts.getMainWorld(session, frameId) ?? undefined;
@@ -247,7 +233,7 @@ export async function resolveObjectIdForXPath(
         result: { objectId?: string | undefined };
         exceptionDetails?: Protocol.Runtime.ExceptionDetails;
       }>("Runtime.evaluate", {
-        expression: expr,
+        expression,
         returnByValue: false,
         contextId: freshCtx,
         awaitPromise: true,
@@ -260,24 +246,46 @@ export async function resolveObjectIdForXPath(
   }
 }
 
-/** Resolve a CSS selector (supports '>>' within the same frame only) to a Runtime objectId. */
-export async function resolveObjectIdForCss(
+/** Obtain the initial execution context for a frame, if provided. */
+async function resolveInitialContext(
   session: CDPSessionLike,
-  selector: string,
-  frameId?: string,
-): Promise<string | null> {
-  let contextId: number | undefined;
+  frameId: string | undefined,
+): Promise<number | undefined> {
   try {
     if (frameId) {
-      contextId = await executionContexts
+      return await executionContexts
         .waitForMainWorld(session, frameId, 800)
         .catch(
           () => executionContexts.getMainWorld(session, frameId) ?? undefined,
         );
     }
   } catch {
-    contextId = undefined;
+    // fall through
   }
+  return undefined;
+}
+
+/** Resolve an XPath to a Runtime remoteObjectId in the given CDP session. */
+export async function resolveObjectIdForXPath(
+  session: CDPSessionLike,
+  xpath: string,
+  frameId?: string,
+): Promise<string | null> {
+  const contextId = await resolveInitialContext(session, frameId);
+  const expr = buildLocatorInvocation("resolveXPathMainWorld", [
+    JSON.stringify(xpath),
+    "0",
+  ]);
+  return evaluateWithStaleContextRetry(session, expr, contextId, frameId);
+}
+
+/** Resolve a CSS selector (supports '>>' within the same frame only) to a Runtime objectId. */
+export async function resolveObjectIdForCss(
+  session: CDPSessionLike,
+  selector: string,
+  frameId?: string,
+): Promise<string | null> {
+  const contextId = await resolveInitialContext(session, frameId);
   const primaryExpr = buildLocatorInvocation("resolveCssSelector", [
     JSON.stringify(selector),
     "0",
@@ -287,49 +295,19 @@ export async function resolveObjectIdForCss(
     "0",
   ]);
 
-  const evaluate = async (expression: string): Promise<string | null> => {
-    try {
-      const { result, exceptionDetails } = await session.send<{
-        result: { objectId?: string | undefined };
-        exceptionDetails?: Protocol.Runtime.ExceptionDetails;
-      }>("Runtime.evaluate", {
-        expression,
-        returnByValue: false,
-        contextId,
-        awaitPromise: true,
-      });
-      if (exceptionDetails) return null;
-      return result?.objectId ?? null;
-    } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
-      if (
-        !msg.includes("Cannot find context with specified id") ||
-        !frameId
-      )
-        return null;
-      const freshCtx =
-        executionContexts.getMainWorld(session, frameId) ?? undefined;
-      try {
-        const { result, exceptionDetails } = await session.send<{
-          result: { objectId?: string | undefined };
-          exceptionDetails?: Protocol.Runtime.ExceptionDetails;
-        }>("Runtime.evaluate", {
-          expression,
-          returnByValue: false,
-          contextId: freshCtx,
-          awaitPromise: true,
-        });
-        if (exceptionDetails) return null;
-        return result?.objectId ?? null;
-      } catch {
-        return null;
-      }
-    }
-  };
-
-  const primary = await evaluate(primaryExpr);
+  const primary = await evaluateWithStaleContextRetry(
+    session,
+    primaryExpr,
+    contextId,
+    frameId,
+  );
   if (primary) return primary;
-  return evaluate(fallbackExpr);
+  return evaluateWithStaleContextRetry(
+    session,
+    fallbackExpr,
+    contextId,
+    frameId,
+  );
 }
 
 export function listChildrenOf(

--- a/packages/core/lib/v3/understudy/a11y/snapshot/focusSelectors.ts
+++ b/packages/core/lib/v3/understudy/a11y/snapshot/focusSelectors.ts
@@ -221,17 +221,43 @@ export async function resolveObjectIdForXPath(
     JSON.stringify(xpath),
     "0",
   ]);
-  const { result, exceptionDetails } = await session.send<{
-    result: { objectId?: string | undefined };
-    exceptionDetails?: Protocol.Runtime.ExceptionDetails;
-  }>("Runtime.evaluate", {
-    expression: expr,
-    returnByValue: false,
-    contextId,
-    awaitPromise: true,
-  });
-  if (exceptionDetails) return null;
-  return result?.objectId ?? null;
+  try {
+    const { result, exceptionDetails } = await session.send<{
+      result: { objectId?: string | undefined };
+      exceptionDetails?: Protocol.Runtime.ExceptionDetails;
+    }>("Runtime.evaluate", {
+      expression: expr,
+      returnByValue: false,
+      contextId,
+      awaitPromise: true,
+    });
+    if (exceptionDetails) return null;
+    return result?.objectId ?? null;
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    if (
+      !msg.includes("Cannot find context with specified id") ||
+      !frameId
+    )
+      return null;
+    const freshCtx =
+      executionContexts.getMainWorld(session, frameId) ?? undefined;
+    try {
+      const { result, exceptionDetails } = await session.send<{
+        result: { objectId?: string | undefined };
+        exceptionDetails?: Protocol.Runtime.ExceptionDetails;
+      }>("Runtime.evaluate", {
+        expression: expr,
+        returnByValue: false,
+        contextId: freshCtx,
+        awaitPromise: true,
+      });
+      if (exceptionDetails) return null;
+      return result?.objectId ?? null;
+    } catch {
+      return null;
+    }
+  }
 }
 
 /** Resolve a CSS selector (supports '>>' within the same frame only) to a Runtime objectId. */
@@ -262,17 +288,43 @@ export async function resolveObjectIdForCss(
   ]);
 
   const evaluate = async (expression: string): Promise<string | null> => {
-    const { result, exceptionDetails } = await session.send<{
-      result: { objectId?: string | undefined };
-      exceptionDetails?: Protocol.Runtime.ExceptionDetails;
-    }>("Runtime.evaluate", {
-      expression,
-      returnByValue: false,
-      contextId,
-      awaitPromise: true,
-    });
-    if (exceptionDetails) return null;
-    return result?.objectId ?? null;
+    try {
+      const { result, exceptionDetails } = await session.send<{
+        result: { objectId?: string | undefined };
+        exceptionDetails?: Protocol.Runtime.ExceptionDetails;
+      }>("Runtime.evaluate", {
+        expression,
+        returnByValue: false,
+        contextId,
+        awaitPromise: true,
+      });
+      if (exceptionDetails) return null;
+      return result?.objectId ?? null;
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      if (
+        !msg.includes("Cannot find context with specified id") ||
+        !frameId
+      )
+        return null;
+      const freshCtx =
+        executionContexts.getMainWorld(session, frameId) ?? undefined;
+      try {
+        const { result, exceptionDetails } = await session.send<{
+          result: { objectId?: string | undefined };
+          exceptionDetails?: Protocol.Runtime.ExceptionDetails;
+        }>("Runtime.evaluate", {
+          expression,
+          returnByValue: false,
+          contextId: freshCtx,
+          awaitPromise: true,
+        });
+        if (exceptionDetails) return null;
+        return result?.objectId ?? null;
+      } catch {
+        return null;
+      }
+    }
   };
 
   const primary = await evaluate(primaryExpr);

--- a/packages/core/lib/v3/understudy/page.ts
+++ b/packages/core/lib/v3/understudy/page.ts
@@ -1361,16 +1361,35 @@ export class Page {
         })()`;
     }
 
-    const { result, exceptionDetails } =
-      await this.mainSession.send<Protocol.Runtime.EvaluateResponse>(
-        "Runtime.evaluate",
-        {
-          expression,
-          contextId: ctxId,
-          returnByValue: true,
-          awaitPromise: true,
-        },
-      );
+    let result: Protocol.Runtime.EvaluateResponse["result"];
+    let exceptionDetails: Protocol.Runtime.EvaluateResponse["exceptionDetails"];
+    try {
+      ({ result, exceptionDetails } =
+        await this.mainSession.send<Protocol.Runtime.EvaluateResponse>(
+          "Runtime.evaluate",
+          {
+            expression,
+            contextId: ctxId,
+            returnByValue: true,
+            awaitPromise: true,
+          },
+        ));
+    } catch (error) {
+      const errMsg = error instanceof Error ? error.message : String(error);
+      if (!errMsg.includes("Cannot find context with specified id"))
+        throw error;
+      const freshCtxId = await this.mainWorldExecutionContextId();
+      ({ result, exceptionDetails } =
+        await this.mainSession.send<Protocol.Runtime.EvaluateResponse>(
+          "Runtime.evaluate",
+          {
+            expression,
+            contextId: freshCtxId,
+            returnByValue: true,
+            awaitPromise: true,
+          },
+        ));
+    }
 
     if (exceptionDetails) {
       const msg =


### PR DESCRIPTION
## Problem

When a page navigates (especially server-rendered apps with full-page reloads), CDP execution context IDs can become stale between the time they're looked up and used in `Runtime.evaluate`. This causes `-32000 Cannot find context with specified id` unhandled rejections that crash the process.

Reported in #1778.

## Root Cause

Three call sites in the understudy module call `Runtime.evaluate` with a `contextId` but **without** retry logic for stale contexts:

1. **`page.ts`** — `evaluate()` method
2. **`focusSelectors.ts`** — `resolveObjectIdForXPath()`
3. **`focusSelectors.ts`** — `resolveObjectIdForCss()` inner `evaluate()` helper

Meanwhile, `frame.ts` already has the correct pattern: try-catch around `Runtime.evaluate` + retry once with a fresh contextId.

## Fix

Applied the same stale-context retry pattern from `frame.ts` to all three unprotected call sites:

- **`page.ts evaluate()`**: On "Cannot find context" error, gets a fresh context via `mainWorldExecutionContextId()` and retries once. Rethrows on other errors.
- **`focusSelectors.ts` (both functions)**: On "Cannot find context" error, gets a fresh context via `executionContexts.getMainWorld()` and retries once. Returns `null` on failure (consistent with existing error handling).

No new dependencies. No behavioral changes for the happy path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents "-32000 Cannot find context with specified id" crashes during navigation by retrying `Runtime.evaluate` when the CDP context is stale. Uses the same single-retry pattern as `frame.ts`; no happy-path changes (fixes #1778).

- **Bug Fixes**
  - `page.ts` `evaluate()`: on stale context, fetch fresh `mainWorldExecutionContextId()` and retry once; rethrow non-context errors.
  - `focusSelectors.ts` (`resolveObjectIdForXPath`, `resolveObjectIdForCss`): retry with fresh main-world context; return null on failure.

- **Refactors**
  - `focusSelectors.ts`: deduplicated retry and context lookup via `evaluateWithStaleContextRetry` and `resolveInitialContext`.

<sup>Written for commit 9a3135f32d30876733c433aa7d1d089ee2046410. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1991">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

