### PR TITLE
fix: respect opts.debug in installV3ShadowPiercer instead of hardcoding true

### DIFF
--- a/packages/core/lib/v3/dom/piercer.runtime.ts
+++ b/packages/core/lib/v3/dom/piercer.runtime.ts
@@ -31,8 +31,7 @@ declare global {
 }
 
 export function installV3ShadowPiercer(opts: V3ShadowPatchOptions = {}): void {
-  // hardcoded debug (remove later if desired)
-  const DEBUG = true;
+  const DEBUG = opts.debug ?? false;
 
   type PatchedFn = Element["attachShadow"] & {
     __v3Patched?: boolean;


### PR DESCRIPTION
## Summary

`installV3ShadowPiercer` defines a `debug?: boolean` option in `V3ShadowPatchOptions` but ignores it — `DEBUG` is hardcoded to `true`:

```ts
// BEFORE
const DEBUG = true;
```

This causes debug logging (`console.info("[v3-piercer] attachShadow", ...)`) to fire on every `attachShadow` call regardless of caller intent.

## Fix

```ts
// AFTER
const DEBUG = opts.debug ?? false;
```

Now callers control debug logging. The existing call site in `piercer.entry.ts` passes `{ debug: true }` so behavior is unchanged there.

Fixes #1996

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect the debug option in installV3ShadowPiercer so debug logging is opt-in instead of always on. Replaces the hardcoded DEBUG = true with opts.debug ?? false; existing callers passing { debug: true } remain unchanged.

<sup>Written for commit 71ecffeae1e673139ab303acd912fd0b4cc6f4e4. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/1997">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

