### PR TITLE
fix: skip CSS pseudo-elements when generating XPath segments

### DIFF
--- a/.changeset/fix-xpath-pseudo-elements.md
+++ b/.changeset/fix-xpath-pseudo-elements.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+fix: skip CSS pseudo-elements when generating XPath segments. Chromium leaks `::before`/`::after` nodes into `Protocol.DOM.Node.children`; they produced unresolvable selectors like `*[name()='::after'][1]` that deterministically broke cached replays.

--- a/packages/core/lib/v3/understudy/a11y/snapshot/domTree.ts
+++ b/packages/core/lib/v3/understudy/a11y/snapshot/domTree.ts
@@ -230,7 +230,8 @@ export async function domMapsForSession(
       const segs = buildChildXPathSegments(kids);
       for (let i = kids.length - 1; i >= 0; i--) {
         const child = kids[i]!;
-        const step = segs[i]!;
+        const step = segs[i];
+        if (step === null) continue;
         stack.push({
           node: child,
           xpath: joinXPath(xpath, step),
@@ -285,7 +286,8 @@ export async function buildSessionDomIndex(
       const segs = buildChildXPathSegments(kids);
       for (let i = kids.length - 1; i >= 0; i--) {
         const child = kids[i]!;
-        const step = segs[i]!;
+        const step = segs[i];
+        if (step === null) continue;
         stack.push({ node: child, xp: joinXPath(xp, step), docRootBe });
       }
     }

--- a/packages/core/lib/v3/understudy/a11y/snapshot/domTree.ts
+++ b/packages/core/lib/v3/understudy/a11y/snapshot/domTree.ts
@@ -227,14 +227,12 @@ export async function domMapsForSession(
 
     const kids = node.children ?? [];
     if (kids.length) {
-      const segs = buildChildXPathSegments(kids);
-      for (let i = kids.length - 1; i >= 0; i--) {
-        const child = kids[i]!;
-        const step = segs[i];
-        if (step === null) continue;
+      const pairs = buildChildXPathSegments(kids);
+      for (let i = pairs.length - 1; i >= 0; i--) {
+        const { child, segment } = pairs[i]!;
         stack.push({
           node: child,
-          xpath: joinXPath(xpath, step),
+          xpath: joinXPath(xpath, segment),
         });
       }
     }
@@ -283,12 +281,10 @@ export async function buildSessionDomIndex(
 
     const kids = node.children ?? [];
     if (kids.length) {
-      const segs = buildChildXPathSegments(kids);
-      for (let i = kids.length - 1; i >= 0; i--) {
-        const child = kids[i]!;
-        const step = segs[i];
-        if (step === null) continue;
-        stack.push({ node: child, xp: joinXPath(xp, step), docRootBe });
+      const pairs = buildChildXPathSegments(kids);
+      for (let i = pairs.length - 1; i >= 0; i--) {
+        const { child, segment } = pairs[i]!;
+        stack.push({ node: child, xp: joinXPath(xp, segment), docRootBe });
       }
     }
 

--- a/packages/core/lib/v3/understudy/a11y/snapshot/xpathUtils.ts
+++ b/packages/core/lib/v3/understudy/a11y/snapshot/xpathUtils.ts
@@ -87,11 +87,17 @@ export function normalizeXPath(x?: string): string {
 }
 
 /** Build per-sibling XPath steps for DOM traversal. */
-export function buildChildXPathSegments(kids: Protocol.DOM.Node[]): string[] {
-  const segs: string[] = [];
+export function buildChildXPathSegments(
+  kids: Protocol.DOM.Node[],
+): (string | null)[] {
+  const segs: (string | null)[] = [];
   const ctr: Record<string, number> = {};
   for (const child of kids) {
     const tag = String(child.nodeName).toLowerCase();
+    if (tag.startsWith("::")) {
+      segs.push(null);
+      continue;
+    }
     const key = `${child.nodeType}:${tag}`;
     const idx = (ctr[key] = (ctr[key] ?? 0) + 1);
     if (child.nodeType === 3) {

--- a/packages/core/lib/v3/understudy/a11y/snapshot/xpathUtils.ts
+++ b/packages/core/lib/v3/understudy/a11y/snapshot/xpathUtils.ts
@@ -89,28 +89,29 @@ export function normalizeXPath(x?: string): string {
 /** Build per-sibling XPath steps for DOM traversal. */
 export function buildChildXPathSegments(
   kids: Protocol.DOM.Node[],
-): (string | null)[] {
-  const segs: (string | null)[] = [];
+): Array<{ child: Protocol.DOM.Node; segment: string }> {
+  const pairs: Array<{ child: Protocol.DOM.Node; segment: string }> = [];
   const ctr: Record<string, number> = {};
   for (const child of kids) {
     const tag = String(child.nodeName).toLowerCase();
-    if (tag.startsWith("::")) {
-      segs.push(null);
-      continue;
-    }
+    // CSS pseudo-elements (::before, ::after, ...) leak into node.children
+    // via CDP but have no XPath-addressable DOM position — skip them entirely.
+    if (tag.startsWith("::")) continue;
     const key = `${child.nodeType}:${tag}`;
     const idx = (ctr[key] = (ctr[key] ?? 0) + 1);
+    let segment: string;
     if (child.nodeType === 3) {
-      segs.push(`text()[${idx}]`);
+      segment = `text()[${idx}]`;
     } else if (child.nodeType === 8) {
-      segs.push(`comment()[${idx}]`);
+      segment = `comment()[${idx}]`;
     } else {
-      segs.push(
-        tag.includes(":") ? `*[name()='${tag}'][${idx}]` : `${tag}[${idx}]`,
-      );
+      segment = tag.includes(":")
+        ? `*[name()='${tag}'][${idx}]`
+        : `${tag}[${idx}]`;
     }
+    pairs.push({ child, segment });
   }
-  return segs;
+  return pairs;
 }
 
 /** Join two XPath fragments while preserving special shadow-root hops. */

--- a/packages/core/tests/unit/snapshot-xpath-utils.test.ts
+++ b/packages/core/tests/unit/snapshot-xpath-utils.test.ts
@@ -72,7 +72,7 @@ describe("buildChildXPathSegments", () => {
       makeNode(8, "#comment"),
     ];
 
-    expect(buildChildXPathSegments(nodes)).toEqual([
+    expect(buildChildXPathSegments(nodes).map((p) => p.segment)).toEqual([
       "div[1]",
       "div[2]",
       "*[name()='svg:path'][1]",
@@ -81,7 +81,7 @@ describe("buildChildXPathSegments", () => {
     ]);
   });
 
-  it("returns null for CSS pseudo-elements (::before, ::after)", () => {
+  it("skips CSS pseudo-elements (::before, ::after)", () => {
     const nodes: Protocol.DOM.Node[] = [
       makeNode(1, "DIV"),
       makeNode(1, "::before"),
@@ -89,12 +89,24 @@ describe("buildChildXPathSegments", () => {
       makeNode(1, "::after"),
       makeNode(1, "DIV"),
     ];
-    expect(buildChildXPathSegments(nodes)).toEqual([
+    const pairs = buildChildXPathSegments(nodes);
+    expect(pairs.map((p) => p.segment)).toEqual([
       "div[1]",
-      null,
       "span[1]",
-      null,
       "div[2]",
+    ]);
+    expect(pairs.map((p) => p.child.nodeName)).toEqual(["DIV", "SPAN", "DIV"]);
+  });
+
+  it("does not count pseudo-elements when indexing same-tag siblings", () => {
+    const nodes: Protocol.DOM.Node[] = [
+      makeNode(1, "SPAN"),
+      makeNode(1, "::before"),
+      makeNode(1, "SPAN"),
+    ];
+    expect(buildChildXPathSegments(nodes).map((p) => p.segment)).toEqual([
+      "span[1]",
+      "span[2]",
     ]);
   });
 });

--- a/packages/core/tests/unit/snapshot-xpath-utils.test.ts
+++ b/packages/core/tests/unit/snapshot-xpath-utils.test.ts
@@ -49,21 +49,21 @@ describe("relativizeXPath", () => {
 });
 
 describe("buildChildXPathSegments", () => {
-  it("produces positional selectors for each node type", () => {
-    const makeNode = (
-      nodeType: number,
-      nodeName: string,
-      override?: Partial<Protocol.DOM.Node>,
-    ): Protocol.DOM.Node => ({
-      nodeId: 1,
-      backendNodeId: 1,
-      localName: nodeName.toLowerCase(),
-      nodeValue: "",
-      ...override,
-      nodeType,
-      nodeName,
-    });
+  const makeNode = (
+    nodeType: number,
+    nodeName: string,
+    override?: Partial<Protocol.DOM.Node>,
+  ): Protocol.DOM.Node => ({
+    nodeId: 1,
+    backendNodeId: 1,
+    localName: nodeName.toLowerCase(),
+    nodeValue: "",
+    ...override,
+    nodeType,
+    nodeName,
+  });
 
+  it("produces positional selectors for each node type", () => {
     const nodes: Protocol.DOM.Node[] = [
       makeNode(1, "DIV"),
       makeNode(1, "DIV"),
@@ -78,6 +78,23 @@ describe("buildChildXPathSegments", () => {
       "*[name()='svg:path'][1]",
       "text()[1]",
       "comment()[1]",
+    ]);
+  });
+
+  it("returns null for CSS pseudo-elements (::before, ::after)", () => {
+    const nodes: Protocol.DOM.Node[] = [
+      makeNode(1, "DIV"),
+      makeNode(1, "::before"),
+      makeNode(1, "SPAN"),
+      makeNode(1, "::after"),
+      makeNode(1, "DIV"),
+    ];
+    expect(buildChildXPathSegments(nodes)).toEqual([
+      "div[1]",
+      null,
+      "span[1]",
+      null,
+      "div[2]",
     ]);
   });
 });


### PR DESCRIPTION
# why

Stagehand's XPath generation produces selectors that include CSS pseudo-elements (`::before`, `::after`), which don't exist in the DOM and can never be resolved by Playwright. When these XPaths get stored in the action cache, replays fail deterministically with "Could not find an element for the given xPath(s)".

Concrete example of a failing cached XPath:

```
xpath=/html[1]/body[1]/div[1]/div[1]/div[2]/div[1]/div[4]/div[1]/div[1]/div[1]/form[1]/div[1]/div[6]/label[1]/div[1]/div[1]/span[1]/label[1]/*[name()='::after'][1]
```

The trailing `*[name()='::after'][1]` segment is syntactically valid XPath but matches no nodes — pseudo-elements are a CSS rendering construct, not part of the DOM tree. Once cached, every subsequent run hits this entry and fails on the same step.

This is analogous to the trailing text-node bug fixed in #824 (where `text()[n]` segments were stripped via `trimTrailingTextNode`); the same class of "impossible XPath" issue, just for pseudo-elements instead of text nodes.

# what changed

### Root cause

According to the CDP spec, pseudo-elements should be returned in `Protocol.DOM.Node.pseudoElements`, separate from `node.children`. In practice — particularly when `DOM.describeNode` is called with `pierce: true` during `hydrateDomTree` — Chromium also returns pseudo-element nodes inside `node.children`. Those nodes have `nodeName` values like `::before` and `::after`.

`buildChildXPathSegments` in `xpathUtils.ts` iterates `kids` without filtering these out. Because `::before` / `::after` contain a colon, they fall into the namespaced-element branch and produce segments like `*[name()='::after'][1]`.

### Fix

- `buildChildXPathSegments` now skips pseudo-element nodes (those with `nodeName` starting with `::`) via `continue` and returns `Array<{ child, segment }>` pairs instead of a plain `string[]`. This way callers get only real DOM nodes with their corresponding XPath segments, without needing to maintain index alignment with the original `kids` array.
- Both call sites in `domTree.ts` (`domMapsForSession` and `buildSessionDomIndex`) iterate over the returned pairs directly, which means pseudo-element nodes never enter the XPath map and are never pushed onto the traversal stack.
- Pseudo-elements are excluded from sibling counting, so positional indexes (e.g. `span[1]`, `span[2]`) remain correct even when `::before`/`::after` nodes appear between real siblings.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip CSS pseudo-elements (`::before`, `::after`) when generating XPath segments to avoid caching impossible selectors and breaking replays. XPaths now resolve to real DOM nodes and sibling indexing stays correct.

- **Bug Fixes**
  - `buildChildXPathSegments` now returns filtered `{ child, segment }` pairs and omits pseudo-elements; `domTree` callers updated to use pairs.
  - Unit tests cover pseudo-element skipping and correct indexing for same-tag siblings.

<sup>Written for commit 5a54be7f5b09442195c78fd8202f45edea9623d1. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2000">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->