### PR TITLE
[STG-1825] fix: include agent.execute usage in metrics

### DIFF
--- a/.changeset/funny-melons-smoke.md
+++ b/.changeset/funny-melons-smoke.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Include `agent.execute()` usage in `stagehand.metrics` for API-backed sessions.

--- a/packages/core/lib/v3/v3.ts
+++ b/packages/core/lib/v3/v3.ts
@@ -435,18 +435,160 @@ export class V3 {
   public get metrics(): Promise<StagehandMetrics> {
     if (this.apiClient) {
       // Fetch metrics from the API
-      return this.apiClient.getReplayMetrics().catch((error) => {
-        this.logger({
-          category: "metrics",
-          message: `Failed to fetch metrics from API: ${error}`,
-          level: 0,
+      return this.apiClient
+        .getReplayMetrics()
+        .then((metrics) => this.mergeMetricsWithLocalFallback(metrics))
+        .catch((error) => {
+          this.logger({
+            category: "metrics",
+            message: `Failed to fetch metrics from API: ${error}`,
+            level: 0,
+          });
+          // Fall back to local metrics on error
+          return this.stagehandMetrics;
         });
-        // Fall back to local metrics on error
-        return this.stagehandMetrics;
-      });
     }
     // Return local metrics wrapped in a Promise for consistency
     return Promise.resolve(this.stagehandMetrics);
+  }
+
+  private mergeMetricField(remoteValue: number, localValue: number): number {
+    return Math.max(remoteValue, localValue);
+  }
+
+  private mergeMetricsWithLocalFallback(
+    remoteMetrics: StagehandMetrics,
+  ): StagehandMetrics {
+    const metrics: StagehandMetrics = {
+      actPromptTokens: this.mergeMetricField(
+        remoteMetrics.actPromptTokens,
+        this.stagehandMetrics.actPromptTokens,
+      ),
+      actCompletionTokens: this.mergeMetricField(
+        remoteMetrics.actCompletionTokens,
+        this.stagehandMetrics.actCompletionTokens,
+      ),
+      actReasoningTokens: this.mergeMetricField(
+        remoteMetrics.actReasoningTokens,
+        this.stagehandMetrics.actReasoningTokens,
+      ),
+      actCachedInputTokens: this.mergeMetricField(
+        remoteMetrics.actCachedInputTokens,
+        this.stagehandMetrics.actCachedInputTokens,
+      ),
+      actInferenceTimeMs: this.mergeMetricField(
+        remoteMetrics.actInferenceTimeMs,
+        this.stagehandMetrics.actInferenceTimeMs,
+      ),
+      extractPromptTokens: this.mergeMetricField(
+        remoteMetrics.extractPromptTokens,
+        this.stagehandMetrics.extractPromptTokens,
+      ),
+      extractCompletionTokens: this.mergeMetricField(
+        remoteMetrics.extractCompletionTokens,
+        this.stagehandMetrics.extractCompletionTokens,
+      ),
+      extractReasoningTokens: this.mergeMetricField(
+        remoteMetrics.extractReasoningTokens,
+        this.stagehandMetrics.extractReasoningTokens,
+      ),
+      extractCachedInputTokens: this.mergeMetricField(
+        remoteMetrics.extractCachedInputTokens,
+        this.stagehandMetrics.extractCachedInputTokens,
+      ),
+      extractInferenceTimeMs: this.mergeMetricField(
+        remoteMetrics.extractInferenceTimeMs,
+        this.stagehandMetrics.extractInferenceTimeMs,
+      ),
+      observePromptTokens: this.mergeMetricField(
+        remoteMetrics.observePromptTokens,
+        this.stagehandMetrics.observePromptTokens,
+      ),
+      observeCompletionTokens: this.mergeMetricField(
+        remoteMetrics.observeCompletionTokens,
+        this.stagehandMetrics.observeCompletionTokens,
+      ),
+      observeReasoningTokens: this.mergeMetricField(
+        remoteMetrics.observeReasoningTokens,
+        this.stagehandMetrics.observeReasoningTokens,
+      ),
+      observeCachedInputTokens: this.mergeMetricField(
+        remoteMetrics.observeCachedInputTokens,
+        this.stagehandMetrics.observeCachedInputTokens,
+      ),
+      observeInferenceTimeMs: this.mergeMetricField(
+        remoteMetrics.observeInferenceTimeMs,
+        this.stagehandMetrics.observeInferenceTimeMs,
+      ),
+      agentPromptTokens: this.mergeMetricField(
+        remoteMetrics.agentPromptTokens,
+        this.stagehandMetrics.agentPromptTokens,
+      ),
+      agentCompletionTokens: this.mergeMetricField(
+        remoteMetrics.agentCompletionTokens,
+        this.stagehandMetrics.agentCompletionTokens,
+      ),
+      agentReasoningTokens: this.mergeMetricField(
+        remoteMetrics.agentReasoningTokens,
+        this.stagehandMetrics.agentReasoningTokens,
+      ),
+      agentCachedInputTokens: this.mergeMetricField(
+        remoteMetrics.agentCachedInputTokens,
+        this.stagehandMetrics.agentCachedInputTokens,
+      ),
+      agentInferenceTimeMs: this.mergeMetricField(
+        remoteMetrics.agentInferenceTimeMs,
+        this.stagehandMetrics.agentInferenceTimeMs,
+      ),
+      totalPromptTokens: 0,
+      totalCompletionTokens: 0,
+      totalReasoningTokens: 0,
+      totalCachedInputTokens: 0,
+      totalInferenceTimeMs: 0,
+    };
+
+    metrics.totalPromptTokens =
+      metrics.actPromptTokens +
+      metrics.extractPromptTokens +
+      metrics.observePromptTokens +
+      metrics.agentPromptTokens;
+    metrics.totalCompletionTokens =
+      metrics.actCompletionTokens +
+      metrics.extractCompletionTokens +
+      metrics.observeCompletionTokens +
+      metrics.agentCompletionTokens;
+    metrics.totalReasoningTokens =
+      metrics.actReasoningTokens +
+      metrics.extractReasoningTokens +
+      metrics.observeReasoningTokens +
+      metrics.agentReasoningTokens;
+    metrics.totalCachedInputTokens =
+      metrics.actCachedInputTokens +
+      metrics.extractCachedInputTokens +
+      metrics.observeCachedInputTokens +
+      metrics.agentCachedInputTokens;
+    metrics.totalInferenceTimeMs =
+      metrics.actInferenceTimeMs +
+      metrics.extractInferenceTimeMs +
+      metrics.observeInferenceTimeMs +
+      metrics.agentInferenceTimeMs;
+
+    return metrics;
+  }
+
+  private updateAgentMetricsFromUsage(usage?: AgentResult["usage"]): void {
+    if (!usage) {
+      return;
+    }
+
+    this.updateMetrics(
+      V3FunctionName.AGENT,
+      usage.input_tokens,
+      usage.output_tokens,
+      usage.reasoning_tokens ?? 0,
+      usage.cached_input_tokens ?? 0,
+      usage.inference_time_ms,
+    );
   }
 
   private resolveLlmClient(model?: ModelConfiguration): LLMClient {
@@ -2011,6 +2153,7 @@ export class V3 {
                   page.mainFrameId(),
                   !!cacheContext,
                 );
+                this.updateAgentMetricsFromUsage(result.usage);
                 if (cacheContext) {
                   const transferredEntry =
                     this.apiClient.consumeLatestAgentCacheEntry();
@@ -2145,6 +2288,7 @@ export class V3 {
                 page.mainFrameId(),
                 !!cacheContext,
               );
+              this.updateAgentMetricsFromUsage(result.usage);
               if (cacheContext) {
                 const transferredEntry =
                   this.apiClient.consumeLatestAgentCacheEntry();

--- a/packages/core/lib/v3/v3.ts
+++ b/packages/core/lib/v3/v3.ts
@@ -437,7 +437,7 @@ export class V3 {
       // Fetch metrics from the API
       return this.apiClient
         .getReplayMetrics()
-        .then((metrics) => this.mergeMetricsWithLocalFallback(metrics))
+        .then((metrics) => this.mergeAgentMetricsWithLocalFallback(metrics))
         .catch((error) => {
           this.logger({
             category: "metrics",
@@ -452,94 +452,39 @@ export class V3 {
     return Promise.resolve(this.stagehandMetrics);
   }
 
-  private mergeMetricField(remoteValue: number, localValue: number): number {
-    return Math.max(remoteValue, localValue);
-  }
-
-  private mergeMetricsWithLocalFallback(
+  private mergeAgentMetricsWithLocalFallback(
     remoteMetrics: StagehandMetrics,
   ): StagehandMetrics {
+    // In API mode, agent.execute() is the only path that returns trusted inline
+    // usage today, so only repair the agent bucket from local state.
+    const agentPromptTokens = Math.max(
+      remoteMetrics.agentPromptTokens,
+      this.stagehandMetrics.agentPromptTokens,
+    );
+    const agentCompletionTokens = Math.max(
+      remoteMetrics.agentCompletionTokens,
+      this.stagehandMetrics.agentCompletionTokens,
+    );
+    const agentReasoningTokens = Math.max(
+      remoteMetrics.agentReasoningTokens,
+      this.stagehandMetrics.agentReasoningTokens,
+    );
+    const agentCachedInputTokens = Math.max(
+      remoteMetrics.agentCachedInputTokens,
+      this.stagehandMetrics.agentCachedInputTokens,
+    );
+    const agentInferenceTimeMs = Math.max(
+      remoteMetrics.agentInferenceTimeMs,
+      this.stagehandMetrics.agentInferenceTimeMs,
+    );
+
     const metrics: StagehandMetrics = {
-      actPromptTokens: this.mergeMetricField(
-        remoteMetrics.actPromptTokens,
-        this.stagehandMetrics.actPromptTokens,
-      ),
-      actCompletionTokens: this.mergeMetricField(
-        remoteMetrics.actCompletionTokens,
-        this.stagehandMetrics.actCompletionTokens,
-      ),
-      actReasoningTokens: this.mergeMetricField(
-        remoteMetrics.actReasoningTokens,
-        this.stagehandMetrics.actReasoningTokens,
-      ),
-      actCachedInputTokens: this.mergeMetricField(
-        remoteMetrics.actCachedInputTokens,
-        this.stagehandMetrics.actCachedInputTokens,
-      ),
-      actInferenceTimeMs: this.mergeMetricField(
-        remoteMetrics.actInferenceTimeMs,
-        this.stagehandMetrics.actInferenceTimeMs,
-      ),
-      extractPromptTokens: this.mergeMetricField(
-        remoteMetrics.extractPromptTokens,
-        this.stagehandMetrics.extractPromptTokens,
-      ),
-      extractCompletionTokens: this.mergeMetricField(
-        remoteMetrics.extractCompletionTokens,
-        this.stagehandMetrics.extractCompletionTokens,
-      ),
-      extractReasoningTokens: this.mergeMetricField(
-        remoteMetrics.extractReasoningTokens,
-        this.stagehandMetrics.extractReasoningTokens,
-      ),
-      extractCachedInputTokens: this.mergeMetricField(
-        remoteMetrics.extractCachedInputTokens,
-        this.stagehandMetrics.extractCachedInputTokens,
-      ),
-      extractInferenceTimeMs: this.mergeMetricField(
-        remoteMetrics.extractInferenceTimeMs,
-        this.stagehandMetrics.extractInferenceTimeMs,
-      ),
-      observePromptTokens: this.mergeMetricField(
-        remoteMetrics.observePromptTokens,
-        this.stagehandMetrics.observePromptTokens,
-      ),
-      observeCompletionTokens: this.mergeMetricField(
-        remoteMetrics.observeCompletionTokens,
-        this.stagehandMetrics.observeCompletionTokens,
-      ),
-      observeReasoningTokens: this.mergeMetricField(
-        remoteMetrics.observeReasoningTokens,
-        this.stagehandMetrics.observeReasoningTokens,
-      ),
-      observeCachedInputTokens: this.mergeMetricField(
-        remoteMetrics.observeCachedInputTokens,
-        this.stagehandMetrics.observeCachedInputTokens,
-      ),
-      observeInferenceTimeMs: this.mergeMetricField(
-        remoteMetrics.observeInferenceTimeMs,
-        this.stagehandMetrics.observeInferenceTimeMs,
-      ),
-      agentPromptTokens: this.mergeMetricField(
-        remoteMetrics.agentPromptTokens,
-        this.stagehandMetrics.agentPromptTokens,
-      ),
-      agentCompletionTokens: this.mergeMetricField(
-        remoteMetrics.agentCompletionTokens,
-        this.stagehandMetrics.agentCompletionTokens,
-      ),
-      agentReasoningTokens: this.mergeMetricField(
-        remoteMetrics.agentReasoningTokens,
-        this.stagehandMetrics.agentReasoningTokens,
-      ),
-      agentCachedInputTokens: this.mergeMetricField(
-        remoteMetrics.agentCachedInputTokens,
-        this.stagehandMetrics.agentCachedInputTokens,
-      ),
-      agentInferenceTimeMs: this.mergeMetricField(
-        remoteMetrics.agentInferenceTimeMs,
-        this.stagehandMetrics.agentInferenceTimeMs,
-      ),
+      ...remoteMetrics,
+      agentPromptTokens,
+      agentCompletionTokens,
+      agentReasoningTokens,
+      agentCachedInputTokens,
+      agentInferenceTimeMs,
       totalPromptTokens: 0,
       totalCompletionTokens: 0,
       totalReasoningTokens: 0,

--- a/packages/core/tests/unit/agent-metrics.test.ts
+++ b/packages/core/tests/unit/agent-metrics.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from "vitest";
+import { V3 } from "../../lib/v3/v3";
+import { V3FunctionName } from "../../lib/v3/types/public/methods";
+import type { StagehandMetrics } from "../../lib/v3/types/public/metrics";
+
+type TestStagehand = V3 & Record<string, unknown>;
+
+function createEmptyMetrics(): StagehandMetrics {
+  return {
+    actPromptTokens: 0,
+    actCompletionTokens: 0,
+    actReasoningTokens: 0,
+    actCachedInputTokens: 0,
+    actInferenceTimeMs: 0,
+    extractPromptTokens: 0,
+    extractCompletionTokens: 0,
+    extractReasoningTokens: 0,
+    extractCachedInputTokens: 0,
+    extractInferenceTimeMs: 0,
+    observePromptTokens: 0,
+    observeCompletionTokens: 0,
+    observeReasoningTokens: 0,
+    observeCachedInputTokens: 0,
+    observeInferenceTimeMs: 0,
+    agentPromptTokens: 0,
+    agentCompletionTokens: 0,
+    agentReasoningTokens: 0,
+    agentCachedInputTokens: 0,
+    agentInferenceTimeMs: 0,
+    totalPromptTokens: 0,
+    totalCompletionTokens: 0,
+    totalReasoningTokens: 0,
+    totalCachedInputTokens: 0,
+    totalInferenceTimeMs: 0,
+  };
+}
+
+describe("agent metrics accounting", () => {
+  it("merges API replay metrics with local agent usage fallback", async () => {
+    const remoteMetrics: StagehandMetrics = {
+      ...createEmptyMetrics(),
+      actPromptTokens: 40,
+      actCompletionTokens: 6,
+      actReasoningTokens: 2,
+      actCachedInputTokens: 1,
+      actInferenceTimeMs: 300,
+      totalPromptTokens: 40,
+      totalCompletionTokens: 6,
+      totalReasoningTokens: 2,
+      totalCachedInputTokens: 1,
+      totalInferenceTimeMs: 300,
+    };
+
+    const stagehand = Object.create(V3.prototype) as TestStagehand;
+    const mutableStagehand = stagehand as Record<string, unknown>;
+
+    mutableStagehand["apiClient"] = {
+      getReplayMetrics: vi.fn().mockResolvedValue(remoteMetrics),
+    };
+    mutableStagehand["stagehandMetrics"] = createEmptyMetrics();
+
+    stagehand.updateMetrics(V3FunctionName.AGENT, 25, 4, 3, 2, 180);
+
+    const metrics = await stagehand.metrics;
+
+    expect(metrics.actPromptTokens).toBe(40);
+    expect(metrics.agentPromptTokens).toBe(25);
+    expect(metrics.agentCompletionTokens).toBe(4);
+    expect(metrics.agentReasoningTokens).toBe(3);
+    expect(metrics.agentCachedInputTokens).toBe(2);
+    expect(metrics.agentInferenceTimeMs).toBe(180);
+    expect(metrics.totalPromptTokens).toBe(65);
+    expect(metrics.totalCompletionTokens).toBe(10);
+    expect(metrics.totalReasoningTokens).toBe(5);
+    expect(metrics.totalCachedInputTokens).toBe(3);
+    expect(metrics.totalInferenceTimeMs).toBe(480);
+  });
+
+  it("records returned agent usage into local metrics totals", () => {
+    const stagehand = Object.create(V3.prototype) as TestStagehand;
+    const mutableStagehand = stagehand as Record<string, unknown>;
+
+    mutableStagehand["stagehandMetrics"] = createEmptyMetrics();
+
+    const updateAgentMetricsFromUsage = stagehand[
+      "updateAgentMetricsFromUsage"
+    ] as (usage?: {
+      input_tokens: number;
+      output_tokens: number;
+      reasoning_tokens?: number;
+      cached_input_tokens?: number;
+      inference_time_ms: number;
+    }) => void;
+
+    updateAgentMetricsFromUsage.call(stagehand, {
+      input_tokens: 12,
+      output_tokens: 5,
+      reasoning_tokens: 7,
+      cached_input_tokens: 3,
+      inference_time_ms: 220,
+    });
+
+    const metrics = stagehand["stagehandMetrics"] as StagehandMetrics;
+
+    expect(metrics.agentPromptTokens).toBe(12);
+    expect(metrics.agentCompletionTokens).toBe(5);
+    expect(metrics.agentReasoningTokens).toBe(7);
+    expect(metrics.agentCachedInputTokens).toBe(3);
+    expect(metrics.agentInferenceTimeMs).toBe(220);
+    expect(metrics.totalPromptTokens).toBe(12);
+    expect(metrics.totalCompletionTokens).toBe(5);
+    expect(metrics.totalReasoningTokens).toBe(7);
+    expect(metrics.totalCachedInputTokens).toBe(3);
+    expect(metrics.totalInferenceTimeMs).toBe(220);
+  });
+});

--- a/packages/core/tests/unit/agent-metrics.test.ts
+++ b/packages/core/tests/unit/agent-metrics.test.ts
@@ -36,7 +36,7 @@ function createEmptyMetrics(): StagehandMetrics {
 }
 
 describe("agent metrics accounting", () => {
-  it("merges API replay metrics with local agent usage fallback", async () => {
+  it("merges API replay metrics with a local agent usage fallback only", async () => {
     const remoteMetrics: StagehandMetrics = {
       ...createEmptyMetrics(),
       actPromptTokens: 40,
@@ -44,11 +44,26 @@ describe("agent metrics accounting", () => {
       actReasoningTokens: 2,
       actCachedInputTokens: 1,
       actInferenceTimeMs: 300,
-      totalPromptTokens: 40,
-      totalCompletionTokens: 6,
-      totalReasoningTokens: 2,
-      totalCachedInputTokens: 1,
-      totalInferenceTimeMs: 300,
+      extractPromptTokens: 10,
+      extractCompletionTokens: 3,
+      extractReasoningTokens: 1,
+      extractCachedInputTokens: 2,
+      extractInferenceTimeMs: 120,
+      observePromptTokens: 8,
+      observeCompletionTokens: 2,
+      observeReasoningTokens: 1,
+      observeCachedInputTokens: 0,
+      observeInferenceTimeMs: 90,
+      agentPromptTokens: 5,
+      agentCompletionTokens: 1,
+      agentReasoningTokens: 1,
+      agentCachedInputTokens: 0,
+      agentInferenceTimeMs: 30,
+      totalPromptTokens: 63,
+      totalCompletionTokens: 12,
+      totalReasoningTokens: 5,
+      totalCachedInputTokens: 3,
+      totalInferenceTimeMs: 540,
     };
 
     const stagehand = Object.create(V3.prototype) as TestStagehand;
@@ -64,16 +79,18 @@ describe("agent metrics accounting", () => {
     const metrics = await stagehand.metrics;
 
     expect(metrics.actPromptTokens).toBe(40);
+    expect(metrics.extractPromptTokens).toBe(10);
+    expect(metrics.observePromptTokens).toBe(8);
     expect(metrics.agentPromptTokens).toBe(25);
     expect(metrics.agentCompletionTokens).toBe(4);
     expect(metrics.agentReasoningTokens).toBe(3);
     expect(metrics.agentCachedInputTokens).toBe(2);
     expect(metrics.agentInferenceTimeMs).toBe(180);
-    expect(metrics.totalPromptTokens).toBe(65);
-    expect(metrics.totalCompletionTokens).toBe(10);
-    expect(metrics.totalReasoningTokens).toBe(5);
-    expect(metrics.totalCachedInputTokens).toBe(3);
-    expect(metrics.totalInferenceTimeMs).toBe(480);
+    expect(metrics.totalPromptTokens).toBe(83);
+    expect(metrics.totalCompletionTokens).toBe(15);
+    expect(metrics.totalReasoningTokens).toBe(7);
+    expect(metrics.totalCachedInputTokens).toBe(5);
+    expect(metrics.totalInferenceTimeMs).toBe(690);
   });
 
   it("records returned agent usage into local metrics totals", () => {


### PR DESCRIPTION
## Summary

- include `agent.execute()` usage in the local metrics accumulator for API-backed sessions
- repair only the agent bucket in `await stagehand.metrics` when replay data misses the top-level agent aggregate
- add regression coverage for agent metrics accounting and a patch changeset for `@browserbasehq/stagehand`

## Root Cause

`agent.execute()` returned non-zero `result.usage`, but the API-backed path did not copy that usage into `stagehand.stagehandMetrics`. `stagehand.metrics` also relied on replay metrics that could omit the agent aggregate, so total token usage could be understated unless callers manually read `result.usage`.

## Impact

`stagehand.stagehandMetrics` now records API-mode `agent.execute()` usage directly, and `await stagehand.metrics` overlays only the agent metrics from local state before recomputing totals. Non-agent replay buckets remain API-sourced.

## Validation

- Real Browserbase/API-mode smoke on `https://example.com`: `result.usage`, `await stagehand.metrics`, and `stagehand.stagehandMetrics` all matched (`input_tokens: 9923`, `output_tokens: 45`, `inference_time_ms: 8312`)

Linear: https://linear.app/browserbase/issue/STG-1825/include-agentexecute-usage-in-stagehandmetrics