### PR TITLE
[STG-1824] fix: stabilize Shopify PCI iframe agent actions

### DIFF
--- a/.changeset/stg-1824-shopify-pci-agent.md
+++ b/.changeset/stg-1824-shopify-pci-agent.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Fix DOM-mode agent interactions with Shopify PCI payment iframes by stabilizing iframe ownership resolution and serializing concurrent agent tool execution.

--- a/packages/core/lib/v3/agent/tools/index.ts
+++ b/packages/core/lib/v3/agent/tools/index.ts
@@ -142,6 +142,32 @@ function wrapToolWithTimeout<T extends Record<string, any>>(
   } as T;
 }
 
+/**
+ * Serializes tool execution for a single agent instance.
+ *
+ * AI SDK tool calls can be emitted in a single step and executed concurrently.
+ * That is unsafe for shared browser state: overlapping act/click/type calls can
+ * race each other against the same page and produce stale frame/selector state.
+ *
+ * We queue tool execution so each browser interaction fully settles before the
+ * next one begins. The queue is per createAgentTools() call, so separate agent
+ * instances do not block each other.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function wrapToolWithExecutionQueue<T extends Record<string, any>>(
+  agentTool: T,
+  enqueue: <R>(task: () => Promise<R>) => Promise<R>,
+): T {
+  if (!agentTool.execute) return agentTool;
+
+  const originalExecute = agentTool.execute;
+  return {
+    ...agentTool,
+    execute: async (...args: unknown[]) =>
+      await enqueue(() => originalExecute(...args)),
+  } as T;
+}
+
 export function createAgentTools(v3: V3, options?: V3AgentToolOptions) {
   const executionModel = options?.executionModel;
   const mode = options?.mode ?? "dom";
@@ -156,6 +182,16 @@ export function createAgentTools(v3: V3, options?: V3AgentToolOptions) {
     extract: "— try using a smaller or simpler schema",
     fillForm:
       "(it may continue executing in the background) — try filling fewer fields at once or use a different tool",
+  };
+
+  let executionChain: Promise<void> = Promise.resolve();
+  const enqueueToolExecution = async <T>(task: () => Promise<T>): Promise<T> => {
+    const run = executionChain.then(task, task);
+    executionChain = run.then<void>(
+      () => undefined,
+      () => undefined,
+    );
+    return await run;
   };
 
   const unwrappedTools: ToolSet = {
@@ -188,17 +224,20 @@ export function createAgentTools(v3: V3, options?: V3AgentToolOptions) {
     ...Object.fromEntries(
       Object.entries(unwrappedTools).map(([name, t]) => [
         name,
-        wrapToolWithTimeout(
-          t,
-          `${name}()`,
-          v3,
-          toolTimeout,
-          timeoutHints[name],
+        wrapToolWithExecutionQueue(
+          wrapToolWithTimeout(
+            t,
+            `${name}()`,
+            v3,
+            toolTimeout,
+            timeoutHints[name],
+          ),
+          enqueueToolExecution,
         ),
       ]),
     ),
-    think: thinkTool(),
-    wait: waitTool(v3, mode),
+    think: wrapToolWithExecutionQueue(thinkTool(), enqueueToolExecution),
+    wait: wrapToolWithExecutionQueue(waitTool(v3, mode), enqueueToolExecution),
   };
 
   return filterTools(allTools, mode, excludeTools);

--- a/packages/core/lib/v3/handlers/handlerUtils/actHandlerUtils.ts
+++ b/packages/core/lib/v3/handlers/handlerUtils/actHandlerUtils.ts
@@ -3,7 +3,10 @@ import { Protocol } from "devtools-protocol";
 import { Frame } from "../../understudy/frame.js";
 import { Locator } from "../../understudy/locator.js";
 import { MouseButton } from "../../types/public/locator.js";
-import { resolveLocatorWithHops } from "../../understudy/deepLocator.js";
+import {
+  resolveLocatorTarget,
+  resolveLocatorWithHops,
+} from "../../understudy/deepLocator.js";
 import type { Page } from "../../understudy/page.js";
 import { v3Logger } from "../../logger.js";
 import { FlowLogger } from "../../flowlogger/FlowLogger.js";
@@ -32,6 +35,173 @@ function normalizeRootXPath(input: string): string {
   return s;
 }
 
+function isRetryableFrameError(message: string): boolean {
+  return /No frame for given id found|main world not ready for frame|Unable to obtain a content frame/i.test(
+    message,
+  );
+}
+
+function isDocumentRootSelector(selector: string): boolean {
+  const normalized = String(selector ?? "").trim().toLowerCase();
+  return (
+    normalized === "/" ||
+    normalized === "/html" ||
+    normalized === "xpath=/" ||
+    normalized === "xpath=/html"
+  );
+}
+
+const FIRST_TEXT_ENTRY_SELECTOR = [
+  'input:not([type="hidden"]):not([disabled])',
+  "textarea:not([disabled])",
+  '[contenteditable=""]',
+  '[contenteditable="true"]',
+].join(", ");
+
+function hintedIframeTextSelector(title: string | null): string | null {
+  const normalized = title?.trim().toLowerCase() ?? "";
+  if (!normalized) return null;
+  if (normalized.includes("card number")) {
+    return 'input[name="number"]';
+  }
+  if (
+    normalized.includes("expiration date") ||
+    normalized.includes("expiry")
+  ) {
+    return 'input[name="expiry"]';
+  }
+  if (
+    normalized.includes("security code") ||
+    normalized.includes("verification") ||
+    normalized.includes("cvv")
+  ) {
+    return 'input[name="verification_value"]';
+  }
+  if (normalized.includes("name on card")) {
+    return 'input[name="name"]';
+  }
+  return null;
+}
+
+async function readLocatorAttribute(
+  locator: Locator,
+  attributeName: string,
+): Promise<string | null> {
+  const session = locator.getFrame().session;
+  const { objectId } = await locator.resolveNode();
+  try {
+    const result = await session.send<Protocol.Runtime.CallFunctionOnResponse>(
+      "Runtime.callFunctionOn",
+      {
+        objectId,
+        functionDeclaration: `
+          function(attributeName) {
+            try {
+              return this.getAttribute ? this.getAttribute(attributeName) : null;
+            } catch {
+              return null;
+            }
+          }
+        `,
+        arguments: [{ value: attributeName }],
+        returnByValue: true,
+      },
+    );
+    return typeof result.result.value === "string"
+      ? result.result.value
+      : null;
+  } finally {
+    await session.send("Runtime.releaseObject", { objectId }).catch(() => {});
+  }
+}
+
+async function setFrameTextEntryValue(
+  frame: Frame,
+  selector: string,
+  value: string,
+): Promise<boolean> {
+  return frame.evaluate(
+    ({ selector, value }: { selector: string; value: string }) => {
+      try {
+        const element = document.querySelector(selector);
+        if (!element) return false;
+
+        const doc = element.ownerDocument || document;
+        const win = doc.defaultView || window;
+
+        const dispatchEvents = () => {
+          let inputEvent: Event;
+          if (typeof win.InputEvent === "function") {
+            try {
+              inputEvent = new win.InputEvent("input", {
+                bubbles: true,
+                composed: true,
+                data: value,
+                inputType: "insertText",
+              });
+            } catch {
+              inputEvent = new win.Event("input", {
+                bubbles: true,
+                composed: true,
+              });
+            }
+          } else {
+            inputEvent = new win.Event("input", {
+              bubbles: true,
+              composed: true,
+            });
+          }
+          element.dispatchEvent(inputEvent);
+          element.dispatchEvent(
+            new win.Event("change", { bubbles: true }),
+          );
+        };
+
+        if (
+          element instanceof win.HTMLInputElement ||
+          element instanceof win.HTMLTextAreaElement
+        ) {
+          const prototype =
+            element instanceof win.HTMLInputElement
+              ? win.HTMLInputElement.prototype
+              : win.HTMLTextAreaElement.prototype;
+          const descriptor = Object.getOwnPropertyDescriptor(prototype, "value");
+          const nativeSetter = descriptor?.set;
+          if (typeof nativeSetter === "function") {
+            nativeSetter.call(element, value);
+          } else {
+            element.value = value;
+          }
+
+          const tracker = (
+            element as HTMLInputElement & {
+              _valueTracker?: { setValue?: (next: string) => void };
+            }
+          )._valueTracker;
+          tracker?.setValue?.(value);
+
+          dispatchEvents();
+          return true;
+        }
+
+        if (
+          element instanceof win.HTMLElement &&
+          element.isContentEditable
+        ) {
+          element.textContent = value;
+          dispatchEvents();
+          return true;
+        }
+
+        return false;
+      } catch {
+        return false;
+      }
+    },
+    { selector, value },
+  );
+}
+
 export async function performUnderstudyMethod(
   page: Page,
   frame: Frame,
@@ -41,81 +211,165 @@ export async function performUnderstudyMethod(
   domSettleTimeoutMs?: number,
 ): Promise<void> {
   const selectorRaw = normalizeRootXPath(rawXPath);
+  const normalizedArgs = args.map((a) => (a == null ? "" : String(a)));
+  const maxAttempts = 4;
 
-  try {
-    await FlowLogger.runWithLogging(
-      {
-        eventType: `Understudy${toTitleCase(method)}`, // e.g. "UnderstudyClick"
-        data: {
-          target: selectorRaw,
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      await FlowLogger.runWithLogging(
+        {
+          eventType: `Understudy${toTitleCase(method)}`, // e.g. "UnderstudyClick"
+          data: {
+            target: selectorRaw,
+          },
         },
-      },
-      async () => {
-        // Unified resolver: supports '>>' hops and XPath across iframes.
-        const locator: Locator = await resolveLocatorWithHops(
-          page,
-          frame,
-          selectorRaw,
-        );
-        const initialUrl = await getFrameUrl(frame);
+        async () => {
+          // Unified resolver: supports '>>' hops and XPath across iframes.
+          const target = await resolveLocatorTarget(
+            page,
+            frame,
+            selectorRaw,
+          );
+          let locator = new Locator(target.frame, target.selector);
 
+          // If the model chose an iframe host for a typing action, retarget to
+          // the first text-entry control inside the iframe's document.
+          if (
+            (method === "type" || method === "fill") &&
+            isDocumentRootSelector(target.selector)
+          ) {
+            const hostLocator = new Locator(frame, selectorRaw);
+            let hostTitle: string | null = null;
+            try {
+              hostTitle = await readLocatorAttribute(hostLocator, "title");
+            } catch {
+              hostTitle = null;
+            }
+            try {
+              await hostLocator.click();
+              await page.waitForTimeout(75);
+            } catch (error) {
+              v3Logger({
+                category: "action",
+                message: "failed to activate iframe host before typing",
+                level: 1,
+                auxiliary: {
+                  xpath: { value: selectorRaw, type: "string" },
+                  error: {
+                    value:
+                      error instanceof Error ? error.message : String(error),
+                    type: "string",
+                  },
+                },
+              });
+            }
+            const hintedSelector = hintedIframeTextSelector(hostTitle);
+            if (hintedSelector) {
+              const directValue = normalizedArgs[0] ?? "";
+              const setDirectly = await setFrameTextEntryValue(
+                target.frame,
+                hintedSelector,
+                directValue,
+              );
+              if (setDirectly) {
+                const iframeSettleMs = Math.min(
+                  500,
+                  Math.max(250, domSettleTimeoutMs ?? 500),
+                );
+                // Shopify briefly re-stabilizes PCI iframe hosts after each
+                // successful card-field update. Without a short pause here,
+                // the next agent tool can snapshot the checkout mid-refresh
+                // and fail to reacquire the following iframe.
+                await page.waitForTimeout(iframeSettleMs);
+                return;
+              }
+            }
+            locator = target.frame
+              .locator(hintedSelector ?? FIRST_TEXT_ENTRY_SELECTOR)
+              .first();
+          }
+
+          const initialUrl = await getFrameUrl(frame);
+
+          v3Logger({
+            category: "action",
+            message: "performing understudy method",
+            level: 2,
+            auxiliary: {
+              xpath: { value: selectorRaw, type: "string" },
+              method: { value: method, type: "string" },
+              url: { value: initialUrl, type: "string" },
+              attempt: { value: String(attempt), type: "string" },
+            },
+          });
+
+          const ctx: UnderstudyMethodHandlerContext = {
+            method,
+            locator,
+            xpath: selectorRaw,
+            args: normalizedArgs,
+            frame,
+            page,
+            initialUrl,
+            domSettleTimeoutMs,
+          };
+          const handler = METHOD_HANDLER_MAP[method] ?? null;
+
+          if (handler) {
+            await handler(ctx);
+            return;
+          }
+
+          v3Logger({
+            category: "action",
+            message: "chosen method is invalid",
+            level: 1,
+            auxiliary: { method: { value: method, type: "string" } },
+          });
+          throw new UnderstudyCommandException(`Method ${method} not supported`);
+        },
+        args,
+      );
+      return;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      const stack = e instanceof Error ? e.stack : undefined;
+
+      if (attempt < maxAttempts && isRetryableFrameError(msg)) {
+        const delayMs = attempt * 250;
         v3Logger({
           category: "action",
-          message: "performing understudy method",
-          level: 2,
+          message: "retrying understudy method after frame instability",
+          level: 1,
           auxiliary: {
-            xpath: { value: selectorRaw, type: "string" },
+            error: { value: msg, type: "string" },
             method: { value: method, type: "string" },
-            url: { value: initialUrl, type: "string" },
+            xpath: { value: selectorRaw, type: "string" },
+            attempt: { value: `${attempt}/${maxAttempts}`, type: "string" },
+            delayMs: { value: String(delayMs), type: "string" },
           },
         });
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        continue;
+      }
 
-        const ctx: UnderstudyMethodHandlerContext = {
-          method,
-          locator,
-          xpath: selectorRaw,
-          args: args.map((a) => (a == null ? "" : String(a))),
-          frame,
-          page,
-          initialUrl,
-          domSettleTimeoutMs,
-        };
-        const handler = METHOD_HANDLER_MAP[method] ?? null;
-
-        if (handler) {
-          await handler(ctx);
-          return;
-        }
-
-        v3Logger({
-          category: "action",
-          message: "chosen method is invalid",
-          level: 1,
-          auxiliary: { method: { value: method, type: "string" } },
-        });
-        throw new UnderstudyCommandException(`Method ${method} not supported`);
-      },
-      args,
-    );
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    const stack = e instanceof Error ? e.stack : undefined;
-    v3Logger({
-      category: "action",
-      message: "error performing method",
-      level: 1,
-      auxiliary: {
-        error: { value: msg, type: "string" },
-        trace: { value: stack ?? "", type: "string" },
-        method: { value: method, type: "string" },
-        xpath: { value: selectorRaw, type: "string" },
-        args: { value: JSON.stringify(args), type: "object" },
-      },
-    });
-    if (e instanceof UnderstudyCommandException) {
-      throw e;
+      v3Logger({
+        category: "action",
+        message: "error performing method",
+        level: 1,
+        auxiliary: {
+          error: { value: msg, type: "string" },
+          trace: { value: stack ?? "", type: "string" },
+          method: { value: method, type: "string" },
+          xpath: { value: selectorRaw, type: "string" },
+          args: { value: JSON.stringify(args), type: "object" },
+        },
+      });
+      if (e instanceof UnderstudyCommandException) {
+        throw e;
+      }
+      throw new UnderstudyCommandException(msg, e);
     }
-    throw new UnderstudyCommandException(msg, e);
   }
 }
 

--- a/packages/core/lib/v3/understudy/a11y/snapshot/a11yTree.ts
+++ b/packages/core/lib/v3/understudy/a11y/snapshot/a11yTree.ts
@@ -37,6 +37,9 @@ export async function a11yForFrame(
       msg.includes("does not belong to the target") ||
       msg.includes("is not found");
     if (!isFrameScopeError || !frameId) throw e;
+    if (!opts.focusSelector?.trim()) {
+      return { outline: "", urlMap: {}, scopeApplied: false };
+    }
     ({ nodes } = await session.send<{
       nodes: Protocol.Accessibility.AXNode[];
     }>("Accessibility.getFullAXTree"));

--- a/packages/core/lib/v3/understudy/a11y/snapshot/capture.ts
+++ b/packages/core/lib/v3/understudy/a11y/snapshot/capture.ts
@@ -21,7 +21,7 @@ import {
   relativizeXPath,
 } from "./domTree.js";
 import { injectSubtrees } from "./treeFormatUtils.js";
-import { ownerSession, parentSession } from "./sessions.js";
+import { ownerSession, resolvedOwnerSession } from "./sessions.js";
 import { normalizeXPath, prefixXPath } from "./xpathUtils.js";
 
 /**
@@ -168,11 +168,11 @@ export async function tryScopedSnapshot(
       absPrefix = cssHit.absPrefix;
     }
 
-    const owningSess = ownerSession(page, targetFrameId);
+    const owningSess = await resolvedOwnerSession(page, targetFrameId);
     const parentId = context.parentByFrame.get(targetFrameId);
     const sameSessionAsParent =
       !!parentId &&
-      ownerSession(page, parentId) === ownerSession(page, targetFrameId);
+      (await resolvedOwnerSession(page, parentId)) === owningSess;
     const { tagNameMap, xpathMap, scrollableMap } = await domMapsForSession(
       owningSess,
       targetFrameId,
@@ -280,7 +280,7 @@ export async function collectPerFrameMaps(
   const perFrameOutlines: Array<{ frameId: string; outline: string }> = [];
 
   for (const frameId of frameIds) {
-    const sess = ownerSession(page, frameId);
+    const sess = await resolvedOwnerSession(page, frameId);
     const sid = sess.id ?? "root";
     let idx = sessionToIndex.get(sid);
     if (!idx) {
@@ -290,7 +290,7 @@ export async function collectPerFrameMaps(
 
     const parentId = context.parentByFrame.get(frameId);
     const sameSessionAsParent =
-      !!parentId && ownerSession(page, parentId) === sess;
+      !!parentId && (await resolvedOwnerSession(page, parentId)) === sess;
     let docRootBe = idx.rootBackend;
     if (sameSessionAsParent) {
       try {
@@ -373,7 +373,10 @@ export async function computeFramePrefixes(
       if (context.parentByFrame.get(child) !== parent) continue;
       queue.push(child);
 
-      const parentSess = parentSession(page, context.parentByFrame, child);
+      const parentId = context.parentByFrame.get(child) ?? null;
+      const parentSess = parentId
+        ? await resolvedOwnerSession(page, parentId)
+        : await resolvedOwnerSession(page, child);
 
       const ownerBackendNodeId = await (async () => {
         try {

--- a/packages/core/lib/v3/understudy/a11y/snapshot/sessions.ts
+++ b/packages/core/lib/v3/understudy/a11y/snapshot/sessions.ts
@@ -1,6 +1,8 @@
 import type { CDPSessionLike } from "../../cdp.js";
 import { Page } from "../../page.js";
 import type { FrameParentIndex } from "../../../types/private/snapshot.js";
+import type { Protocol } from "devtools-protocol";
+import { withTimeout } from "../../../timeoutConfig.js";
 
 /**
  * Session helpers ensure DOM lookups are always executed against the session
@@ -11,6 +13,68 @@ import type { FrameParentIndex } from "../../../types/private/snapshot.js";
 /** Return the owning session for a frame as registered on the Page. */
 export function ownerSession(page: Page, frameId: string): CDPSessionLike {
   return page.getSessionForFrame(frameId);
+}
+
+function findFrameDepth(
+  tree: Protocol.Page.FrameTree,
+  frameId: string,
+  depth = 0,
+): number | null {
+  if (tree.frame.id === frameId) return depth;
+  for (const child of tree.childFrames ?? []) {
+    const childDepth = findFrameDepth(child, frameId, depth + 1);
+    if (childDepth !== null) return childDepth;
+  }
+  return null;
+}
+
+async function sessionFrameDepth(
+  session: CDPSessionLike,
+  frameId: string,
+): Promise<number | null> {
+  const probeTimeoutMs = 500;
+  try {
+    await withTimeout(
+      session.send("Page.enable").catch(() => {}),
+      probeTimeoutMs,
+      "snapshot session Page.enable",
+    );
+    const { frameTree } = await withTimeout(
+      session.send<Protocol.Page.GetFrameTreeResponse>("Page.getFrameTree"),
+      probeTimeoutMs,
+      "snapshot session Page.getFrameTree",
+    );
+    return findFrameDepth(frameTree, frameId);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the live owning session for a frame by probing active sessions when
+ * the registry's current answer is stale. Backend node ids are only unique
+ * within a CDP session, so snapshot capture must use the real owner session to
+ * avoid pairing accessibility nodes with DOM nodes from the wrong process.
+ */
+export async function resolvedOwnerSession(
+  page: Page,
+  frameId: string,
+): Promise<CDPSessionLike> {
+  const preferred = page.getSessionForFrame(frameId);
+  let bestSession = preferred;
+  let bestDepth = await sessionFrameDepth(preferred, frameId);
+
+  for (const session of page.allSessions()) {
+    if (session === preferred) continue;
+    const depth = await sessionFrameDepth(session, frameId);
+    if (depth === null) continue;
+    if (bestDepth === null || depth < bestDepth) {
+      bestSession = session;
+      bestDepth = depth;
+    }
+  }
+
+  return bestSession;
 }
 
 /**

--- a/packages/core/lib/v3/understudy/frameLocator.ts
+++ b/packages/core/lib/v3/understudy/frameLocator.ts
@@ -53,11 +53,27 @@ export class FrameLocator {
         { objectId },
       );
       const iframeBackendNodeId = desc.node.backendNodeId;
+      const describedFrameId = desc.node.frameId as string | undefined;
+
+      if (describedFrameId) {
+        await ensureChildFrameReady(
+          this.page,
+          parentFrame,
+          describedFrameId,
+          1200,
+        );
+        return resolveChildFrameHandle(
+          this.page,
+          parentFrame,
+          describedFrameId,
+          this.selector,
+        );
+      }
 
       // Find direct child frames under the parent by consulting the Page's registry
-      const childIds = await listDirectChildFrameIdsFromRegistry(
+      const childIds = await listDirectChildFrameIds(
         this.page,
-        parentFrame.frameId,
+        parentFrame,
         1000,
       );
 
@@ -70,7 +86,12 @@ export class FrameLocator {
           if (owner.backendNodeId === iframeBackendNodeId) {
             // Ensure child frame is ready (handles OOPIF adoption or same-process)
             await ensureChildFrameReady(this.page, parentFrame, fid, 1200);
-            return this.page.frameForId(fid);
+            return resolveChildFrameHandle(
+              this.page,
+              parentFrame,
+              fid,
+              this.selector,
+            );
           }
         } catch {
           // ignore and try next
@@ -175,16 +196,30 @@ export function frameLocatorFromFrame(
   return new FrameLocator(page, selector, undefined, root);
 }
 
-async function listDirectChildFrameIdsFromRegistry(
+async function listDirectChildFrameIds(
   page: Page,
-  parentFrameId: string,
+  parentFrame: Frame,
   timeoutMs: number,
 ): Promise<string[]> {
   const deadline = Date.now() + timeoutMs;
   while (true) {
     try {
+      await parentFrame.session.send("Page.enable").catch(() => {});
+      const { frameTree } =
+        await parentFrame.session.send<Protocol.Page.GetFrameTreeResponse>(
+          "Page.getFrameTree",
+        );
+      const liveNode = findFrameNode(frameTree, parentFrame.frameId);
+      const liveIds =
+        liveNode?.childFrames?.map((c) => c.frame.id as string) ?? [];
+      if (liveIds.length > 0) return liveIds;
+    } catch {
+      // fall through to registry fallback
+    }
+
+    try {
       const tree = page.getFullFrameTree();
-      const node = findFrameNode(tree, parentFrameId);
+      const node = findFrameNode(tree, parentFrame.frameId);
       const ids = node?.childFrames?.map((c) => c.frame.id as string) ?? [];
       if (ids.length > 0 || Date.now() >= deadline) return ids;
     } catch {
@@ -221,7 +256,7 @@ async function ensureChildFrameReady(
   const deadline = Date.now() + Math.max(0, budgetMs);
 
   // If already owned by a different session (OOPIF adopted), wait briefly there.
-  const owner = page.getSessionForFrame(childFrameId);
+  const owner = page.getKnownSessionForFrame(childFrameId);
   if (owner && owner !== parentSession) {
     try {
       await executionContexts.waitForMainWorld(owner, childFrameId, 600);
@@ -268,7 +303,7 @@ async function ensureChildFrameReady(
       }
       if (hasMainWorldOnParent()) return finish();
       try {
-        const nowOwner = page.getSessionForFrame(childFrameId);
+        const nowOwner = page.getKnownSessionForFrame(childFrameId);
         if (nowOwner && nowOwner !== parentSession) {
           const left = Math.max(150, deadline - Date.now());
           executionContexts
@@ -285,7 +320,7 @@ async function ensureChildFrameReady(
       if (done) return;
       if (hasMainWorldOnParent()) return finish();
       try {
-        const nowOwner = page.getSessionForFrame(childFrameId);
+        const nowOwner = page.getKnownSessionForFrame(childFrameId);
         if (nowOwner && nowOwner !== parentSession) {
           const left = Math.max(150, deadline - Date.now());
           executionContexts
@@ -301,4 +336,22 @@ async function ensureChildFrameReady(
     };
     tick();
   });
+}
+
+function resolveChildFrameHandle(
+  page: Page,
+  parentFrame: Frame,
+  childFrameId: string,
+  selector: string,
+): Frame {
+  const knownOwner = page.getKnownSessionForFrame(childFrameId);
+  if (knownOwner) {
+    return page.frameForId(childFrameId);
+  }
+
+  if (executionContexts.getMainWorld(parentFrame.session, childFrameId)) {
+    return page.frameForIdWithSession(childFrameId, parentFrame.session);
+  }
+
+  throw new ContentFrameNotFoundError(selector);
 }

--- a/packages/core/lib/v3/understudy/frameRegistry.ts
+++ b/packages/core/lib/v3/understudy/frameRegistry.ts
@@ -153,7 +153,7 @@ export class FrameRegistry {
     frameId: FrameId,
     reason: "remove" | "swap" | string = "remove",
   ): void {
-    if (reason === "swap") return;
+    if (reason === "swap" && frameId === this.rootFrameId) return;
 
     // Collect subtree starting from frameId.
     const toRemove: FrameId[] = [];
@@ -210,8 +210,12 @@ export class FrameRegistry {
 
   /**
    * Seed topology and ownership from an existing `Page.getFrameTree` snapshot, typically right after
-   * a session is attached. This is a best-effort: we record frames and set the provided `sessionId`
-   * as owner for the subtree **if** an owner isn't already set.
+   * a session is attached. The snapshot's emitting session is the source of truth for ownership of
+   * that subtree, so we always stamp the provided `sessionId` across the frames we seed.
+   *
+   * This is especially important for adopted OOPIF sessions: the parent session may have observed
+   * descendant frames first, but once the child session is attached those frame ids must migrate to
+   * the child session or later DOM calls will be sent to the wrong target.
    */
   seedFromFrameTree(
     sessionId: SessionId,
@@ -224,10 +228,8 @@ export class FrameRegistry {
       if (parent) this.frames.get(parent)!.children.add(tree.frame.id);
       // last-seen frame
       this.frames.get(tree.frame.id)!.lastSeen = tree.frame;
-      // ownership (only if unknown)
-      if (!this.frames.get(tree.frame.id)!.ownerSessionId) {
-        this.setOwnerSessionIdInternal(tree.frame.id, sessionId);
-      }
+      // Ownership follows the session whose frame tree we just seeded.
+      this.setOwnerSessionIdInternal(tree.frame.id, sessionId);
       for (const c of tree.childFrames ?? []) walk(c, tree.frame.id);
     };
     walk(frameTree, null);

--- a/packages/core/lib/v3/understudy/page.ts
+++ b/packages/core/lib/v3/understudy/page.ts
@@ -533,6 +533,17 @@ export class Page {
     return this.sessions.get(sid) ?? this.mainSession;
   }
 
+  /**
+   * Return the owning CDP session for a frameId only when ownership is known.
+   * Unlike getSessionForFrame(), this does not fall back to the main session.
+   */
+  public getKnownSessionForFrame(frameId: string): CDPSessionLike | null {
+    const sid = this.registry.getOwnerSessionId(frameId);
+    if (!sid) return null;
+    if (sid === "root") return this.mainSession;
+    return this.sessions.get(sid) ?? null;
+  }
+
   /** Always returns a Frame bound to the owning session */
   public frameForId(frameId: string): Frame {
     const hit = this.frameCache.get(frameId);
@@ -544,9 +555,29 @@ export class Page {
     return f;
   }
 
+  /**
+   * Create a Frame bound to a caller-provided session when ownership is not
+   * known yet. We intentionally avoid caching this fallback handle.
+   */
+  public frameForIdWithSession(frameId: string, session: CDPSessionLike): Frame {
+    const owned = this.getKnownSessionForFrame(frameId);
+    if (owned) return this.frameForId(frameId);
+    return new Frame(session, frameId, this.pageId, this.browserIsRemote);
+  }
+
   /** Expose a session by id (used by snapshot to resolve session id -> session) */
   public getSessionById(id: string): CDPSessionLike | undefined {
     return this.sessions.get(id);
+  }
+
+  /** Return every active CDP session for this page (main target + adopted children). */
+  public allSessions(): CDPSessionLike[] {
+    const sessions: CDPSessionLike[] = [this.mainSession];
+    for (const session of this.sessions.values()) {
+      if (session === this.mainSession) continue;
+      sessions.push(session);
+    }
+    return sessions;
   }
 
   public registerSessionForNetwork(session: CDPSessionLike): void {

--- a/packages/core/tests/unit/agent-tool-serialization.test.ts
+++ b/packages/core/tests/unit/agent-tool-serialization.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+import { createAgentTools } from "../../lib/v3/agent/tools/index.js";
+import type { V3 } from "../../lib/v3/v3.js";
+
+function createMockV3() {
+  let concurrentActs = 0;
+  let maxConcurrentActs = 0;
+  const callOrder: string[] = [];
+
+  const mock = {
+    logger: vi.fn(),
+    recordAgentReplayStep: vi.fn(),
+    act: vi.fn(async (instruction: string) => {
+      concurrentActs += 1;
+      maxConcurrentActs = Math.max(maxConcurrentActs, concurrentActs);
+      callOrder.push(`start:${instruction}`);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      callOrder.push(`end:${instruction}`);
+      concurrentActs -= 1;
+      return {
+        success: true,
+        message: "ok",
+        actionDescription: instruction,
+        actions: [],
+      };
+    }),
+  };
+
+  return {
+    v3: mock as unknown as V3,
+    getMaxConcurrentActs: () => maxConcurrentActs,
+    callOrder,
+  };
+}
+
+describe("agent tool execution queue", () => {
+  it("serializes concurrent DOM tool executions against the same agent", async () => {
+    const { v3, getMaxConcurrentActs, callOrder } = createMockV3();
+    const tools = createAgentTools(v3, { mode: "dom" });
+
+    const context = (toolCallId: string) => ({
+      toolCallId,
+      messages: [] as never[],
+      abortSignal: new AbortController().signal,
+    });
+
+    await Promise.all([
+      tools.act.execute?.({ action: "click first button" }, context("t1")),
+      tools.act.execute?.({ action: "click second button" }, context("t2")),
+    ]);
+
+    expect(getMaxConcurrentActs()).toBe(1);
+    expect(callOrder).toEqual([
+      "start:click first button",
+      "end:click first button",
+      "start:click second button",
+      "end:click second button",
+    ]);
+  });
+});

--- a/packages/core/tests/unit/frame-locator.test.ts
+++ b/packages/core/tests/unit/frame-locator.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+import { FrameLocator } from "../../lib/v3/understudy/frameLocator.js";
+import { MockCDPSession } from "./helpers/mockCDPSession.js";
+import { executionContexts } from "../../lib/v3/understudy/executionContextRegistry.js";
+
+describe("FrameLocator.resolveFrame", () => {
+  it("prefers the frameId returned by DOM.describeNode for iframe owners", async () => {
+    const parentSession = new MockCDPSession({
+      "DOM.enable": async () => ({}),
+      "DOM.describeNode": async () => ({
+        node: {
+          backendNodeId: 123,
+          frameId: "child-frame",
+        },
+      }),
+      "Runtime.releaseObject": async () => ({}),
+    });
+
+    const parentFrame = {
+      frameId: "parent-frame",
+      session: parentSession,
+      locator: () => ({
+        resolveNode: async () => ({ objectId: "iframe-object" }),
+      }),
+    };
+
+    const childFrame = {
+      frameId: "child-frame",
+      session: parentSession,
+    };
+
+    const page = {
+      mainFrame: () => parentFrame,
+      frameForId: (frameId: string) => {
+        expect(frameId).toBe("child-frame");
+        return childFrame;
+      },
+      frameForIdWithSession: (frameId: string) => {
+        expect(frameId).toBe("child-frame");
+        return childFrame;
+      },
+      getSessionForFrame: () => parentSession,
+      getKnownSessionForFrame: () => parentSession,
+    };
+
+    const getMainWorldSpy = vi
+      .spyOn(executionContexts, "getMainWorld")
+      .mockReturnValue(1 as never);
+
+    const frameLocator = new FrameLocator(
+      page as never,
+      'iframe[title="Field container for: Card number"]',
+    );
+
+    await expect(frameLocator.resolveFrame()).resolves.toBe(childFrame);
+    expect(parentSession.callsFor("Page.getFrameTree")).toHaveLength(0);
+    expect(parentSession.callsFor("DOM.getFrameOwner")).toHaveLength(0);
+
+    getMainWorldSpy.mockRestore();
+  });
+});

--- a/packages/core/tests/unit/frame-registry.test.ts
+++ b/packages/core/tests/unit/frame-registry.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { FrameRegistry } from "../../lib/v3/understudy/frameRegistry.js";
+
+describe("FrameRegistry.seedFromFrameTree", () => {
+  it("re-owns an adopted child session subtree even if the parent saw it first", () => {
+    const registry = new FrameRegistry("page-target", "main");
+
+    registry.onFrameAttached("child-root", "main", "parent-session");
+    registry.onFrameAttached("grandchild", "child-root", "parent-session");
+
+    expect(registry.getOwnerSessionId("child-root")).toBe("parent-session");
+    expect(registry.getOwnerSessionId("grandchild")).toBe("parent-session");
+
+    registry.adoptChildSession("child-session", "child-root");
+    registry.seedFromFrameTree("child-session", {
+      frame: {
+        id: "child-root",
+        loaderId: "loader-1",
+        url: "https://child.example",
+        domainAndRegistry: "",
+        securityOrigin: "https://child.example",
+        mimeType: "text/html",
+        secureContextType: "Secure",
+        crossOriginIsolatedContextType: "NotIsolated",
+        gatedAPIFeatures: [],
+      },
+      childFrames: [
+        {
+          frame: {
+            id: "grandchild",
+            parentId: "child-root",
+            loaderId: "loader-2",
+            url: "https://grandchild.example",
+            domainAndRegistry: "",
+            securityOrigin: "https://grandchild.example",
+            mimeType: "text/html",
+            secureContextType: "Secure",
+            crossOriginIsolatedContextType: "NotIsolated",
+            gatedAPIFeatures: [],
+          },
+        },
+      ],
+    });
+
+    expect(registry.getOwnerSessionId("child-root")).toBe("child-session");
+    expect(registry.getOwnerSessionId("grandchild")).toBe("child-session");
+  });
+
+  it("prunes swap-detached subframes but preserves root swaps", () => {
+    const registry = new FrameRegistry("page-target", "main");
+
+    registry.onFrameAttached("child-root", "main", "parent-session");
+    registry.onFrameAttached("grandchild", "child-root", "parent-session");
+
+    registry.onFrameDetached("child-root", "swap");
+
+    expect(registry.getOwnerSessionId("child-root")).toBeUndefined();
+    expect(registry.getOwnerSessionId("grandchild")).toBeUndefined();
+    expect(registry.listAllFrames()).toEqual(["main"]);
+
+    registry.onFrameDetached("main", "swap");
+
+    expect(registry.listAllFrames()).toEqual(["main"]);
+  });
+});

--- a/packages/core/tests/unit/snapshot-a11y-resolvers.test.ts
+++ b/packages/core/tests/unit/snapshot-a11y-resolvers.test.ts
@@ -74,6 +74,32 @@ describe("a11yForFrame", () => {
     expect(result.outline).toContain("Docs");
   });
 
+  it("returns an empty frame snapshot when frame-scoped AX lookup fails without focus", async () => {
+    const session = new MockCDPSession({
+      ...baseHandlers,
+      "Accessibility.getFullAXTree": async (params) => {
+        if (params?.frameId) {
+          throw new Error("Frame with the given frameId is not found.");
+        }
+        return { nodes: baseAxNodes() };
+      },
+    });
+
+    const opts: A11yOptions = {
+      focusSelector: undefined,
+      experimental: false,
+      tagNameMap: { "enc-100": "#document", "enc-101": "a" },
+      scrollableMap: {},
+      encode: (backend) => `enc-${backend}`,
+    };
+
+    const result = await a11yForFrame(session, "dead-frame", opts);
+
+    expect(result.scopeApplied).toBe(false);
+    expect(result.urlMap).toEqual({});
+    expect(result.outline).toBe("");
+  });
+
   it("scopes the tree to the resolved focus selector target", async () => {
     const nodes = baseAxNodes().map((n) =>
       n.nodeId === "2"
@@ -275,6 +301,7 @@ describe("tryScopedSnapshot", () => {
       }),
       listAllFrameIds: () => ["frame-1", "frame-2"],
       getSessionForFrame: () => session,
+      allSessions: () => [session],
       getOrdinal: (fid: string) => ordinal(fid),
       ...overrides,
     }) as unknown as Page;

--- a/packages/core/tests/unit/snapshot-session-resolution.test.ts
+++ b/packages/core/tests/unit/snapshot-session-resolution.test.ts
@@ -1,0 +1,92 @@
+import type { Protocol } from "devtools-protocol";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolvedOwnerSession } from "../../lib/v3/understudy/a11y/snapshot/sessions.js";
+import type { CDPSessionLike } from "../../lib/v3/understudy/cdp.js";
+import type { Page } from "../../lib/v3/understudy/page.js";
+
+function createFrameTree(
+  rootId: string,
+  childIds: string[] = [],
+): Protocol.Page.FrameTree {
+  return {
+    frame: {
+      id: rootId,
+      loaderId: `loader-${rootId}`,
+      url: `https://${rootId}.example.com`,
+      domainAndRegistry: "",
+      securityOrigin: `https://${rootId}.example.com`,
+      mimeType: "text/html",
+      secureContextType: "Secure",
+      crossOriginIsolatedContextType: "NotIsolated",
+      gatedAPIFeatures: [],
+    },
+    childFrames: childIds.map((id) => createFrameTree(id)),
+  };
+}
+
+function createSession(
+  id: string,
+  frameTree: Protocol.Page.FrameTree,
+): CDPSessionLike {
+  return {
+    id,
+    send: async (method: string) => {
+      if (method === "Page.enable") return {};
+      if (method === "Page.getFrameTree") return { frameTree };
+      throw new Error(`Unexpected method ${method}`);
+    },
+    on: (): void => undefined,
+    off: (): void => undefined,
+  } as unknown as CDPSessionLike;
+}
+
+describe("resolvedOwnerSession", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("prefers the session whose frame tree reaches the target at the shallowest depth", async () => {
+    const staleSession = createSession(
+      "stale-session",
+      createFrameTree("main", ["child-frame"]),
+    );
+    const liveSession = createSession(
+      "live-session",
+      createFrameTree("child-frame"),
+    );
+
+    const page = {
+      getSessionForFrame: () => staleSession,
+      allSessions: () => [staleSession, liveSession],
+    } as unknown as Page;
+
+    const resolved = await resolvedOwnerSession(page, "child-frame");
+    expect(resolved).toBe(liveSession);
+  });
+
+  it("skips sessions whose frame-tree probe times out", async () => {
+    vi.useFakeTimers();
+
+    const hangingSession = {
+      id: "hanging-session",
+      send: async () => await new Promise(() => undefined),
+      on: (): void => undefined,
+      off: (): void => undefined,
+    } as unknown as CDPSessionLike;
+
+    const liveSession = createSession(
+      "live-session",
+      createFrameTree("child-frame"),
+    );
+
+    const page = {
+      getSessionForFrame: () => hangingSession,
+      allSessions: () => [hangingSession, liveSession],
+    } as unknown as Page;
+
+    const pending = resolvedOwnerSession(page, "child-frame");
+    await vi.advanceTimersByTimeAsync(600);
+
+    await expect(pending).resolves.toBe(liveSession);
+  });
+});


### PR DESCRIPTION
## Summary

Fix DOM-mode agent interactions with Shopify PCI payment iframes by stabilizing iframe/session ownership and serializing concurrent agent tool execution.

## Root Cause

Shopify checkout card fields live inside secure cross-origin PCI iframes. Two separate Stagehand behaviors made this unreliable:

1. Agent tool calls from a single step could execute concurrently, which let multiple iframe typing actions race each other against the same checkout state.
2. When Shopify recycled payment iframes between entries, Stagehand could briefly resolve a child frame before ownership/execution context was actually ready, causing follow-up actions to hit stale or wrong-session frame handles.

## What Changed

- serialize per-agent tool execution so browser actions do not overlap within one agent run
- retarget iframe-host `type`/`fill` actions to the actual inner Shopify PCI input based on iframe title
- add a short settle window after direct PCI field writes so the next action snapshots a stable checkout state
- resolve live owner sessions during snapshot capture instead of trusting stale registry ownership
- tighten frame locator child-frame resolution so we only return a child frame handle when ownership or execution context is genuinely ready
- ensure adopted OOPIF frame trees overwrite stale ownership from the parent session
- add regression coverage for agent tool serialization, frame-locator owner resolution, frame-registry seeding, and stale frame-scoped AX fallbacks

## Validation

- `pnpm run gen-version`
- `pnpm run build-dom-scripts`
- `pnpm run build:esm`
- `pnpm exec vitest run dist/esm/tests/unit/agent-tool-serialization.test.js dist/esm/tests/unit/frame-locator.test.js dist/esm/tests/unit/frame-registry.test.js dist/esm/tests/unit/snapshot-a11y-resolvers.test.js dist/esm/tests/unit/snapshot-session-resolution.test.js`
- Browserbase remote repro against a customer's Shopify storefront (`<customer site>`) using a clean `origin/main` branch plus this patch set: payment-only `agent.execute()` successfully filled card number, expiry, CVV, and name inside the Shopify PCI iframes and read back the expected values

## Linear

- STG-1824


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes DOM-mode agent interactions with Shopify PCI payment iframes so checkout fields fill reliably, addressing Linear STG-1824. Serializes tool execution and hardens frame/session ownership to eliminate races and stale handles.

- **Bug Fixes**
  - Serialize per-agent tool execution so DOM actions don’t overlap.
  - Retarget `type`/`fill` on iframe hosts to inner PCI inputs using iframe title hints; set value with proper events and wait briefly to let Shopify settle.
  - Resolve live frame ownership before acting/snapshotting: prefer `DOM.describeNode`’s `frameId`, wait for main world, handle OOPIF adoption, and seed child-session ownership correctly.
  - Use real owner sessions in snapshots/A11y; return empty output when scoped AX lookup fails without focus; retry transient “frame not ready” errors.
  - Add unit tests for tool serialization, frame locator/registry, session resolution, and a11y fallbacks.

<sup>Written for commit 9549eeac38656776588d7402b2ab435259becc97. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2003">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


