### PR TITLE
feat(google-cua): add screenshot pruning to prevent memory growth

### DIFF
--- a/.changeset/google-cua-screenshot-pruning.md
+++ b/.changeset/google-cua-screenshot-pruning.md
@@ -1,0 +1,9 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Add screenshot pruning to GoogleCUAClient to prevent memory growth
+
+The GoogleCUAClient now prunes old screenshots from conversation history, keeping only the most recent `maxImages` (default: 3) screenshots. This matches the behavior of MicrosoftCUAClient and prevents unbounded memory growth during long agent sessions, especially on image-heavy websites.
+
+The `maxImages` option can be configured via `clientOptions.maxImages` when initializing the agent.

--- a/packages/core/lib/v3/agent/GoogleCUAClient.ts
+++ b/packages/core/lib/v3/agent/GoogleCUAClient.ts
@@ -58,6 +58,8 @@ export class GoogleCUAClient extends AgentClient {
   private tools?: ToolSet;
   private baseURL?: string;
   private safetyConfirmationHandler?: SafetyConfirmationHandler;
+  private maxImages: number = 3;
+
   constructor(
     type: AgentType,
     modelName: string,
@@ -90,6 +92,11 @@ export class GoogleCUAClient extends AgentClient {
       typeof clientOptions.environment === "string"
     ) {
       this.environment = clientOptions.environment as typeof this.environment;
+    }
+
+    // Max images to keep in history (to prevent memory growth)
+    if (clientOptions?.maxImages !== undefined) {
+      this.maxImages = clientOptions.maxImages as number;
     }
 
     this.generateContentConfig = {
@@ -636,6 +643,10 @@ export class GoogleCUAClient extends AgentClient {
             role: "user",
             parts: functionResponses,
           });
+
+          // Prune old screenshots to prevent memory growth
+          // Keep only the most recent maxImages screenshots in history
+          this.maybeRemoveOldScreenshots(logger);
         }
       }
 
@@ -659,6 +670,74 @@ export class GoogleCUAClient extends AgentClient {
       });
 
       throw error;
+    }
+  }
+
+  /**
+   * Remove old screenshots from history to prevent memory growth.
+   * Keeps only the most recent maxImages screenshots, removing inlineData
+   * from older entries while preserving the rest of the history structure.
+   *
+   * Note: compressGoogleConversationImages() only compresses a *copy* of
+   * history for the API request. This method mutates this.history in place
+   * to actually free memory from accumulated screenshots.
+   */
+  private maybeRemoveOldScreenshots(logger: (message: LogLine) => void): void {
+    if (this.maxImages <= 0) {
+      return;
+    }
+
+    let screenshotCount = 0;
+    let prunedCount = 0;
+
+    // Traverse history from newest to oldest
+    for (let i = this.history.length - 1; i >= 0; i--) {
+      const entry = this.history[i];
+      if (!entry?.parts) continue;
+
+      // Check if this entry contains screenshots (inlineData)
+      const hasScreenshot = entry.parts.some((p: Part) => {
+        const partRecord = p as Record<string, unknown>;
+        const funcResp = partRecord.functionResponse as
+          | { parts?: { inlineData?: unknown }[] }
+          | undefined;
+        if (funcResp?.parts) {
+          return funcResp.parts.some(
+            (pp: { inlineData?: unknown }) => pp.inlineData,
+          );
+        }
+        return false;
+      });
+
+      if (hasScreenshot) {
+        screenshotCount++;
+        if (screenshotCount > this.maxImages) {
+          // Remove inlineData from old screenshots
+          for (const p of entry.parts) {
+            const partRecord = p as Record<string, unknown>;
+            const funcResp = partRecord.functionResponse as
+              | { parts?: { inlineData?: unknown }[] }
+              | undefined;
+            if (funcResp?.parts) {
+              const originalLength = funcResp.parts.length;
+              funcResp.parts = funcResp.parts.filter(
+                (pp: { inlineData?: unknown }) => !pp.inlineData,
+              );
+              if (funcResp.parts.length < originalLength) {
+                prunedCount++;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    if (prunedCount > 0) {
+      logger({
+        category: "agent",
+        message: `Pruned ${prunedCount} old screenshots from history (keeping ${this.maxImages} most recent)`,
+        level: 2,
+      });
     }
   }
 

--- a/packages/core/lib/v3/types/public/model.ts
+++ b/packages/core/lib/v3/types/public/model.ts
@@ -113,7 +113,7 @@ export type ClientOptions = (
   thinkingBudget?: number;
   /** Environment type for CUA agents (browser, mac, windows, ubuntu) */
   environment?: string;
-  /** Max images for Microsoft FARA agent */
+  /** Max images to keep in agent history (applies to Google CUA and Microsoft FARA agents) */
   maxImages?: number;
   /** Temperature for model inference */
   temperature?: number;


### PR DESCRIPTION
## Summary
- Add `maxImages` property to `GoogleCUAClient` (default: 3) to limit screenshots kept in history
- Add `maybeRemoveOldScreenshots()` method that prunes old screenshots after each step
- Update `ClientOptions.maxImages` JSDoc to reflect usage in both Google CUA and Microsoft FARA agents
- Match the existing behavior of `MicrosoftCUAClient`

## Problem
The `GoogleCUAClient` accumulates screenshots in `this.history` without any pruning mechanism. On image-heavy websites, each screenshot is ~2-3 MB base64. During long sessions this causes significant memory growth, leading to OOM errors on memory-constrained environments like AWS Lambda.

Note: the existing `compressGoogleConversationImages()` only compresses a *copy* of history for the API request — it does not free memory from `this.history` itself. This change addresses that gap.

## Solution
After pushing function responses to history, call `maybeRemoveOldScreenshots()` which:
1. Traverses history from newest to oldest
2. Counts entries containing screenshots (inlineData)
3. For entries beyond the `maxImages` limit, removes the `inlineData` while preserving the rest of the history structure

Configurable via `clientOptions.maxImages`.

## Credit
Revives and builds on #1477 by @pkiv.

## Test plan
- [ ] Verify agent still functions correctly after pruning
- [ ] Verify configurable via `clientOptions.maxImages`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add screenshot pruning to the Google CUA agent to cap memory growth during long sessions. Keeps only the latest screenshots by default (3) and matches Microsoft CUA behavior.

- **New Features**
  - Prune old screenshots in GoogleCUAClient after each step; keep only the most recent N.
  - Add ClientOptions.maxImages (config via clientOptions.maxImages, default 3) and update docs to cover Google CUA and Microsoft FARA.
  - Remove only screenshot inlineData while preserving history; log prune counts.

<sup>Written for commit eba0451b77ec16cda7cdb10696b9df1d1d26a429. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2004">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

