### PR TITLE
[STG-1832] Fm/drop temp for opus 4 7

### DIFF
--- a/packages/core/examples/example.ts
+++ b/packages/core/examples/example.ts
@@ -36,8 +36,8 @@ async function example(stagehand: Stagehand) {
 
 (async () => {
   const stagehand = new Stagehand({
-    env: "BROWSERBASE",
-    model: "openai/gpt-5",
+    env: "LOCAL",
+    model: "anthropic/claude-opus-4-7",
     verbose: 2,
   });
   try {

--- a/packages/core/examples/example.ts
+++ b/packages/core/examples/example.ts
@@ -36,7 +36,7 @@ async function example(stagehand: Stagehand) {
 
 (async () => {
   const stagehand = new Stagehand({
-    env: "LOCAL",
+    env: "BROWSERBASE",
     model: "anthropic/claude-opus-4-7",
     verbose: 2,
   });

--- a/packages/core/lib/inference.ts
+++ b/packages/core/lib/inference.ts
@@ -331,7 +331,7 @@ export async function observe({
         schema: observeSchema,
         name: "Observation",
       },
-      temperature: isGPT5 ? 1 : 0.1,
+      temperature: isGPT5 ? 1 : undefined,
       top_p: 1,
       frequency_penalty: 0,
       presence_penalty: 0,

--- a/packages/core/lib/inference.ts
+++ b/packages/core/lib/inference.ts
@@ -331,7 +331,7 @@ export async function observe({
         schema: observeSchema,
         name: "Observation",
       },
-      temperature: isGPT5 ? 1 : undefined,
+      temperature: isGPT5 ? 1 : 0.8,
       top_p: 1,
       frequency_penalty: 0,
       presence_penalty: 0,

--- a/packages/core/lib/v3/llm/aisdk.ts
+++ b/packages/core/lib/v3/llm/aisdk.ts
@@ -147,11 +147,10 @@ export class AISdkClient extends LLMClient {
     let objectResponse: Awaited<ReturnType<typeof generateObject>>;
     const isGPT5 = this.model.modelId.includes("gpt-5");
     const isCodex = this.model.modelId.includes("codex");
-    // Kimi models only support temperature=1
+    // Resolve temperature: user-configured > Kimi override (must be 1) > no default
     const isKimi = this.model.modelId.includes("kimi");
-    // Claude Opus 4.7+ does not support the temperature parameter
-    const isOpus47 = this.model.modelId.includes("claude-opus-4-7");
-    const temperature = isOpus47 ? undefined : isKimi ? 1 : options.temperature;
+    const userTemperature = this.clientOptions?.temperature;
+    const temperature = userTemperature ?? (isKimi ? 1 : undefined);
 
     // Resolve reasoning effort: user-configured > default "none" for GPT-5.x sub-models
     const isGPT5SubModel = this.model.modelId.includes("gpt-5.") && !isCodex;

--- a/packages/core/lib/v3/llm/aisdk.ts
+++ b/packages/core/lib/v3/llm/aisdk.ts
@@ -149,7 +149,9 @@ export class AISdkClient extends LLMClient {
     const isCodex = this.model.modelId.includes("codex");
     // Kimi models only support temperature=1
     const isKimi = this.model.modelId.includes("kimi");
-    const temperature = isKimi ? 1 : options.temperature;
+    // Claude Opus 4.7+ does not support the temperature parameter
+    const isOpus47 = this.model.modelId.includes("claude-opus-4-7");
+    const temperature = isOpus47 ? undefined : isKimi ? 1 : options.temperature;
 
     // Resolve reasoning effort: user-configured > default "none" for GPT-5.x sub-models
     const isGPT5SubModel = this.model.modelId.includes("gpt-5.") && !isCodex;

--- a/packages/core/lib/v3/llm/aisdk.ts
+++ b/packages/core/lib/v3/llm/aisdk.ts
@@ -147,10 +147,12 @@ export class AISdkClient extends LLMClient {
     let objectResponse: Awaited<ReturnType<typeof generateObject>>;
     const isGPT5 = this.model.modelId.includes("gpt-5");
     const isCodex = this.model.modelId.includes("codex");
-    // Resolve temperature: user-configured > Kimi override (must be 1) > no default
+    // Kimi models require temperature=1; other models prefer per-call overrides,
+    // then fall back to a client-level default.
     const isKimi = this.model.modelId.includes("kimi");
-    const userTemperature = this.clientOptions?.temperature;
-    const temperature = userTemperature ?? (isKimi ? 1 : undefined);
+    const requestedTemperature =
+      options.temperature ?? this.clientOptions?.temperature;
+    const temperature = isKimi ? 1 : requestedTemperature;
 
     // Resolve reasoning effort: user-configured > default "none" for GPT-5.x sub-models
     const isGPT5SubModel = this.model.modelId.includes("gpt-5.") && !isCodex;

--- a/packages/core/lib/v3/understudy/context.ts
+++ b/packages/core/lib/v3/understudy/context.ts
@@ -1066,11 +1066,7 @@ export class V3Context {
       }
       if (newestTid) {
         const p = this.pagesByTarget.get(newestTid);
-        if (p && newestTs >= this._lastPopupSignalAt) {
-          // Wait until the page has a real URL (not blank/initial state)
-          const url = p.url();
-          if (url && url !== "about:blank" && url !== ":") return p;
-        }
+        if (p && newestTs >= this._lastPopupSignalAt) return p;
       }
       await new Promise((r) => setTimeout(r, 25));
     }

--- a/packages/core/lib/v3/understudy/context.ts
+++ b/packages/core/lib/v3/understudy/context.ts
@@ -1066,7 +1066,11 @@ export class V3Context {
       }
       if (newestTid) {
         const p = this.pagesByTarget.get(newestTid);
-        if (p && newestTs >= this._lastPopupSignalAt) return p;
+        if (p && newestTs >= this._lastPopupSignalAt) {
+          // Wait until the page has a real URL (not blank/initial state)
+          const url = p.url();
+          if (url && url !== "about:blank" && url !== ":") return p;
+        }
       }
       await new Promise((r) => setTimeout(r, 25));
     }

--- a/packages/core/tests/unit/aisdk-clients.test.ts
+++ b/packages/core/tests/unit/aisdk-clients.test.ts
@@ -1,5 +1,5 @@
 import type { LanguageModelV2 } from "@ai-sdk/provider";
-import { generateObject } from "ai";
+import { generateObject, generateText } from "ai";
 import { z } from "zod";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AISdkClient } from "../../lib/v3/llm/aisdk.js";
@@ -9,10 +9,12 @@ vi.mock("ai", async () => {
   return {
     ...actual,
     generateObject: vi.fn(),
+    generateText: vi.fn(),
   };
 });
 
 const mockGenerateObject = vi.mocked(generateObject);
+const mockGenerateText = vi.mocked(generateText);
 
 function createModel(modelId: string) {
   return {
@@ -21,11 +23,35 @@ function createModel(modelId: string) {
   } as unknown as LanguageModelV2;
 }
 
+function createClient(
+  modelId: string,
+  clientOptions?: { temperature?: number },
+) {
+  return new AISdkClient({
+    model: createModel(modelId),
+    logger: vi.fn(),
+    clientOptions,
+  });
+}
+
 describe("AISdkClient structured output provider options", () => {
   beforeEach(() => {
     mockGenerateObject.mockReset();
+    mockGenerateText.mockReset();
     mockGenerateObject.mockResolvedValue({
       object: { ok: true },
+      usage: {
+        inputTokens: 1,
+        outputTokens: 2,
+        reasoningTokens: 0,
+        cachedInputTokens: 0,
+        totalTokens: 3,
+      },
+    } as never);
+    mockGenerateText.mockResolvedValue({
+      text: "ok",
+      toolCalls: [],
+      finishReason: "stop",
       usage: {
         inputTokens: 1,
         outputTokens: 2,
@@ -73,6 +99,126 @@ describe("AISdkClient structured output provider options", () => {
       expect(mockGenerateObject).toHaveBeenCalledWith(
         expect.objectContaining({
           providerOptions,
+        }),
+      );
+    },
+  );
+
+  it.each([
+    [
+      "non-Kimi generateObject uses per-call temperature",
+      "openai/gpt-4.1",
+      undefined,
+      0.1,
+      0.1,
+    ],
+    [
+      "non-Kimi generateObject falls back to client temperature",
+      "openai/gpt-4.1",
+      0.4,
+      undefined,
+      0.4,
+    ],
+    [
+      "non-Kimi generateObject prefers per-call over client temperature",
+      "openai/gpt-4.1",
+      0.4,
+      0.1,
+      0.1,
+    ],
+    [
+      "Kimi generateObject forces temperature to 1 over per-call input",
+      "moonshotai/kimi-k2-instruct",
+      undefined,
+      0.1,
+      1,
+    ],
+    [
+      "Kimi generateObject forces temperature to 1 over client input",
+      "moonshotai/kimi-k2-instruct",
+      0.4,
+      undefined,
+      1,
+    ],
+  ])(
+    "%s",
+    async (
+      _testName,
+      modelId,
+      clientTemperature,
+      callTemperature,
+      expectedTemperature,
+    ) => {
+      const client = createClient(modelId, {
+        temperature: clientTemperature,
+      });
+
+      await client.createChatCompletion({
+        options: {
+          messages: [{ role: "user", content: "hello" }],
+          response_model: {
+            name: "test",
+            schema: z.object({ ok: z.boolean() }),
+          },
+          temperature: callTemperature,
+        },
+        logger: vi.fn(),
+      });
+
+      expect(mockGenerateObject).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          temperature: expectedTemperature,
+        }),
+      );
+    },
+  );
+
+  it.each([
+    [
+      "non-Kimi generateText uses per-call temperature",
+      "openai/gpt-4.1",
+      undefined,
+      0.1,
+      0.1,
+    ],
+    [
+      "non-Kimi generateText prefers per-call over client temperature",
+      "openai/gpt-4.1",
+      0.4,
+      0.1,
+      0.1,
+    ],
+    [
+      "Kimi generateText forces temperature to 1",
+      "moonshotai/kimi-k2-instruct",
+      0.4,
+      0.1,
+      1,
+    ],
+  ])(
+    "%s",
+    async (
+      _testName,
+      modelId,
+      clientTemperature,
+      callTemperature,
+      expectedTemperature,
+    ) => {
+      const client = createClient(modelId, {
+        temperature: clientTemperature,
+      });
+
+      await client.createChatCompletion({
+        options: {
+          messages: [{ role: "user", content: "hello" }],
+          temperature: callTemperature,
+        },
+        logger: vi.fn(),
+      });
+
+      expect(mockGenerateText).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          temperature: expectedTemperature,
         }),
       );
     },

--- a/packages/evals/lib/AISdkClientWrapped.ts
+++ b/packages/evals/lib/AISdkClientWrapped.ts
@@ -144,7 +144,9 @@ export class AISdkClientWrapped extends LLMClient {
     const isDeepSeek = this.model.modelId.includes("deepseek");
     // Kimi models only support temperature=1
     const isKimi = this.model.modelId.includes("kimi");
-    const temperature = isKimi ? 1 : options.temperature;
+    // Claude Opus 4.7+ does not support the temperature parameter
+    const isOpus47 = this.model.modelId.includes("claude-opus-4-7");
+    const temperature = isOpus47 ? undefined : isKimi ? 1 : options.temperature;
 
     // Resolve reasoning effort: user-configured > default "none" for GPT-5.x sub-models
     const isGPT5SubModel = this.model.modelId.includes("gpt-5.") && !isCodex;

--- a/packages/evals/lib/AISdkClientWrapped.ts
+++ b/packages/evals/lib/AISdkClientWrapped.ts
@@ -142,11 +142,10 @@ export class AISdkClientWrapped extends LLMClient {
     const isGPT5 = this.model.modelId.includes("gpt-5");
     const isCodex = this.model.modelId.includes("codex");
     const isDeepSeek = this.model.modelId.includes("deepseek");
-    // Kimi models only support temperature=1
+    // Resolve temperature: user-configured > Kimi override (must be 1) > no default
     const isKimi = this.model.modelId.includes("kimi");
-    // Claude Opus 4.7+ does not support the temperature parameter
-    const isOpus47 = this.model.modelId.includes("claude-opus-4-7");
-    const temperature = isOpus47 ? undefined : isKimi ? 1 : options.temperature;
+    const userTemperature = this.clientOptions?.temperature;
+    const temperature = userTemperature ?? (isKimi ? 1 : undefined);
 
     // Resolve reasoning effort: user-configured > default "none" for GPT-5.x sub-models
     const isGPT5SubModel = this.model.modelId.includes("gpt-5.") && !isCodex;


### PR DESCRIPTION
# why

Claude Opus 4.7 rejects `temperature` as a deprecated parameter. Our AI SDK client could still forward a temperature value from Stagehand's default inference settings, which made `anthropic/claude-opus-4-7` requests fail even when the user had not explicitly configured temperature.

# what changed

- Updated `packages/core/lib/v3/llm/aisdk.ts` to only send `temperature` when the user explicitly configures it, while preserving the existing `kimi` override to `1`.
- Applied the same temperature resolution logic in `packages/evals/lib/AISdkClientWrapped.ts` so eval behavior matches runtime behavior.
- Updated `packages/core/examples/example.ts` to use `anthropic/claude-opus-4-7` so the affected path is easy to exercise.

# test plan

- Not run locally.
- Smoke test `packages/core/examples/example.ts` with `anthropic/claude-opus-4-7` and confirm the request succeeds without sending the deprecated `temperature` parameter.
