### PR TITLE
[STG-1828] Relax elementId schema validation for observe() to prevent throws on LLM formatting issues

### DIFF
--- a/packages/core/lib/inference.ts
+++ b/packages/core/lib/inference.ts
@@ -265,7 +265,6 @@ export async function observe({
         z.object({
           elementId: z
             .string()
-            .regex(/^\d+-\d+$/)
             .describe(
               "the ID string associated with the element. Never include surrounding square brackets. This field must follow the format of 'number-number'.",
             ),

--- a/packages/core/lib/v3/handlers/observeHandler.ts
+++ b/packages/core/lib/v3/handlers/observeHandler.ts
@@ -206,13 +206,20 @@ export class ObserveHandler {
               selector: string;
             };
           }
-          // shadow-root fallback:
-          return {
-            description: "an element inside a shadow DOM",
-            method: "not-supported",
-            arguments: [],
-            selector: "not-supported",
-          };
+          // elementId didn't match the expected "number-number" format
+          // (e.g. LLM returned a single number). Filter it out.
+          v3Logger({
+            category: "observation",
+            message: "skipping element with invalid elementId format",
+            level: 1,
+            auxiliary: {
+              elementId: {
+                value: String(elementId),
+                type: "string",
+              },
+            },
+          });
+          return undefined;
         }),
       )
     ).filter(<T>(e: T | undefined): e is T => e !== undefined);


### PR DESCRIPTION
## Summary

`observe()` throws a Zod schema validation error when the LLM returns an `elementId` that doesn't match the strict `/^\d+-\d+$/` regex (e.g. the LLM returns `"5"` instead of `"0-5"`). This is overly strict for `observe()` — it's an informational call, and the handler already gracefully handles invalid IDs. The strict regex is appropriate for `act()` but not here.

## Changes

**`packages/core/lib/inference.ts`**
- Removed the strict `/^\d+-\d+$/` regex from the observe schema's `elementId` field
- Kept the `.describe()` hint so the LLM still aims for the correct format
- `act()` schema is unchanged — it still enforces the strict regex

**`packages/core/lib/v3/handlers/observeHandler.ts`**
- Replaced the shadow-root fallback for invalid elementIds with a log + filter. Elements with malformed IDs are now silently skipped (with a debug log) instead of being returned as `{ method: "not-supported", selector: "not-supported" }`

## Behavior before

`observe()` throws `ZodError` if any element in the LLM response has an `elementId` like `"5"` instead of `"0-5"`.

## Behavior after

`observe()` gracefully skips elements with malformed `elementId`s and returns the remaining valid results. A debug-level log is emitted for filtered elements.

## Test plan

- Verified no existing tests reference the removed shadow-root fallback behavior
- The `.filter()` on line 218 already handles `undefined` entries, so filtered elements are correctly excluded from the result

## Context

Reported by Vanta (Ryan Wong) via Pylon #17324.

Linear: https://linear.app/browserbase/issue/STG-1828