### PR TITLE
  fix(cli): support multi-value selection in browse select

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1185,19 +1185,11 @@ async function executeCommand(
     }
     case "select": {
       const [selector, values] = args as [string, string[]];
-      if (!stagehand) {
-        throw new Error("Stagehand instance not available");
-      }
       const resolved = resolveSelector(selector);
-      // selectOption takes the first value as argument
-      const action = {
-        selector: resolved,
-        description: "select option",
-        method: "selectOption",
-        arguments: [values[0] || ""],
-      };
-      await stagehand.act(action);
-      return { selected: values };
+      const selected = await page!
+        .deepLocator(resolved)
+        .selectOption(values.length === 1 ? values[0] || "" : values);
+      return { selected };
     }
     case "upload": {
       const [selector, filePaths] = args as [string, string[]];

--- a/packages/cli/tests/cli.test.ts
+++ b/packages/cli/tests/cli.test.ts
@@ -314,6 +314,22 @@ describe("Browse CLI", () => {
       expect(data.typed).toBe(true);
     });
 
+    it("should select multiple values in a multi-select element", async () => {
+      const html = `<!doctype html><html><body><select multiple><option value="red">Red</option><option value="blue">Blue</option><option value="green">Green</option></select></body></html>`;
+      const dataUrl = `data:text/html,${encodeURIComponent(html)}`;
+
+      await browse(`open "${dataUrl}"`);
+      const result = await browse("select select red blue");
+      const data = parseJson<{ selected: string[] }>(result.stdout);
+      expect(data.selected).toEqual(["red", "blue"]);
+
+      const selectedResult = await browse(
+        'eval "Array.from(document.querySelector(\\"select\\").selectedOptions).map(o=>o.value).join(\\\",\\\")"',
+      );
+      const selectedData = parseJson<{ result: string }>(selectedResult.stdout);
+      expect(selectedData.result).toBe("red,blue");
+    });
+
     it("should press keys", async () => {
       await browse("open https://example.com");
       const result = await browse("press Tab");

--- a/packages/core/lib/v3/handlers/handlerUtils/actHandlerUtils.ts
+++ b/packages/core/lib/v3/handlers/handlerUtils/actHandlerUtils.ts
@@ -146,8 +146,10 @@ const METHOD_HANDLER_MAP: Record<
 export async function selectOption(ctx: UnderstudyMethodHandlerContext) {
   const { locator, xpath, args } = ctx;
   try {
-    const text = args[0]?.toString() || "";
-    await locator.selectOption(text);
+    const values = args.map((arg) => arg.toString());
+    await locator.selectOption(
+      values.length <= 1 ? (values[0] ?? "") : values,
+    );
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     const stack = e instanceof Error ? e.stack : undefined;

--- a/packages/core/tests/integration/perform-understudy-method.spec.ts
+++ b/packages/core/tests/integration/perform-understudy-method.spec.ts
@@ -98,6 +98,39 @@ test.describe("tests performUnderstudyMethod", () => {
     expect(inputValue).toBe("Smog Check Technician");
   });
 
+  test("tests selecting multiple options from a multi-select dropdown", async () => {
+    const page = v3.context.pages()[0];
+    await page.goto(
+      "data:text/html," +
+        encodeURIComponent(
+          `<!doctype html><html><body>
+            <select id="colors" multiple>
+              <option value="red">Red</option>
+              <option value="green">Green</option>
+              <option value="blue">Blue</option>
+            </select>
+          </body></html>`,
+        ),
+    );
+
+    await performUnderstudyMethod(
+      page,
+      page.mainFrame(),
+      "selectOptionFromDropdown",
+      "xpath=//*[@id='colors']",
+      ["red", "blue"],
+      30000,
+    );
+
+    const selectedValues = await page.evaluate(() => {
+      const select = document.getElementById("colors") as
+        | HTMLSelectElement
+        | null;
+      return Array.from(select?.selectedOptions ?? []).map((o) => o.value);
+    });
+    expect(selectedValues).toEqual(["red", "blue"]);
+  });
+
   test("tests drag & drop works (start xpath & end xpath)", async () => {
     const page = v3.context.pages()[0];
     await page.goto(


### PR DESCRIPTION
  ## Summary

  - Fix browse select to honor all provided values instead of only the first
    one.
  - Add a regression test covering multi-select behavior.

  ## Problem

  browse select accepts variadic values (<values...>), but implementation
  only forwarded values[0], so multi-select usage was broken :{.

  ## Changes

  - Updated CLI select execution to call deepLocator(...).selectOption(...)
    with:
      - a single string for one value
      - a string array for multiple values
  - Added a CLI test that:
      - opens a page with a <select multiple>
      - runs browse select select red blue
      - verifies both values are selected

  ## Files Changed

  - packages/cli/src/index.ts
  - packages/cli/tests/cli.test.ts

  ## Validation

  - Prettier check passed on touched files.
  - CLI build passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes multi-value selection across the CLI and core so multi-select dropdowns honor all provided values. `browse select` and the deterministic dropdown action now select all specified options.

- **Bug Fixes**
  - CLI: Call `page.deepLocator(...).selectOption` with a single string or `string[]`, and return the selected values.
  - Core: Support multi-select in `selectOptionFromDropdown` by forwarding all args to `locator.selectOption`; adds CLI and core tests verifying multi-select (e.g., "red" and "blue").

<sup>Written for commit 1271e2d5037b95a8d13c2f7fa20b2ea69caaa2a9. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2012">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



