### PR TITLE
fix(server-v4): require DATABASE_URL only for postgres mode

### DIFF
--- a/packages/server-v4/README.md
+++ b/packages/server-v4/README.md
@@ -30,7 +30,8 @@ pnpm install
 cp .env.example .env
 ```
 
-4. Configure your `.env` file with the environment variables required by `src/lib/env.ts` (BB environment, API base URLs, etc.).
+4. Configure your `.env` file with the environment variables required by `src/env.ts` (BB environment, API base URLs, etc.).
+   - `DATABASE_URL` is required only when `STAGEHAND_DB_MODE=postgres`; omit it for `pglite` (the default).
 
 5. `pnpm dev`
 

--- a/packages/server-v4/src/app.ts
+++ b/packages/server-v4/src/app.ts
@@ -58,7 +58,8 @@ export const buildApp = async () => {
       env.STAGEHAND_DB_MODE === "postgres"
         ? {
             mode: "postgres",
-            databaseUrl: env.DATABASE_URL,
+            // parseEnvironment enforces DATABASE_URL when postgres mode is selected.
+            databaseUrl: env.DATABASE_URL!,
           }
         : {
             mode: "pglite",

--- a/packages/server-v4/src/constants.ts
+++ b/packages/server-v4/src/constants.ts
@@ -29,11 +29,4 @@ export const constants = {
      */
     pgliteDataDirSegments: ["db", "stagehand-v4"] as const,
   },
-  urls: {
-    /**
-     * TODO: Replace this placeholder once the real v4 database URL has been provisioned.
-     * @constant
-     */
-    defaultDatabaseUrl: "postgresql://example.com/stagehand_v4",
-  },
 } as const;

--- a/packages/server-v4/src/env.ts
+++ b/packages/server-v4/src/env.ts
@@ -26,7 +26,7 @@ export const parseEnvironment = (runtimeEnv: NodeJS.ProcessEnv) => {
         .default("development"),
       PORT: z.coerce.number().int().positive().default(3000),
       STAGEHAND_DB_MODE: z.enum(["postgres", "pglite"]).default("pglite"),
-      DATABASE_URL: z.url().default(constants.urls.defaultDatabaseUrl),
+      DATABASE_URL: z.url().optional(),
     },
     runtimeEnvStrict: {
       BROWSERBASE_CONFIG_DIR: runtimeEnv.BROWSERBASE_CONFIG_DIR,
@@ -38,10 +38,7 @@ export const parseEnvironment = (runtimeEnv: NodeJS.ProcessEnv) => {
     emptyStringAsUndefined: true,
   });
 
-  if (
-    parsedEnv.STAGEHAND_DB_MODE === "postgres" &&
-    parsedEnv.DATABASE_URL === constants.urls.defaultDatabaseUrl
-  ) {
+  if (parsedEnv.STAGEHAND_DB_MODE === "postgres" && !parsedEnv.DATABASE_URL) {
     throw new Error("DATABASE_URL must be set when STAGEHAND_DB_MODE=postgres");
   }
 

--- a/packages/server-v4/test/unit/env/env.test.ts
+++ b/packages/server-v4/test/unit/env/env.test.ts
@@ -16,13 +16,17 @@ describe("environment parsing", () => {
     );
   });
 
-  it("ignores DATABASE_URL in pglite mode", () => {
+  it("allows DATABASE_URL in pglite mode", () => {
     const env = parseEnvironment({
       STAGEHAND_DB_MODE: "pglite",
       DATABASE_URL: "postgres://user:pass@localhost:5432/stagehand",
     });
 
     assert.equal(env.STAGEHAND_DB_MODE, "pglite");
+    assert.equal(
+      env.DATABASE_URL,
+      "postgres://user:pass@localhost:5432/stagehand",
+    );
   });
 
   it("defaults BROWSERBASE_CONFIG_DIR from the user home directory", () => {
@@ -48,12 +52,12 @@ describe("environment parsing", () => {
     );
   });
 
-  it("defaults DATABASE_URL to the placeholder in pglite mode", () => {
+  it("leaves DATABASE_URL undefined in pglite mode by default", () => {
     const env = parseEnvironment({
       STAGEHAND_DB_MODE: "pglite",
     });
 
-    assert.equal(env.DATABASE_URL, "postgresql://example.com/stagehand_v4");
+    assert.equal(env.DATABASE_URL, undefined);
   });
 
   it("defaults PORT and NODE_ENV", () => {


### PR DESCRIPTION
  ## Why
  `server-v4` previously used a placeholder default `DATABASE_URL`, which
  made DB config ambiguous and could hide misconfiguration.

  ## What changed
  - Removed the placeholder `defaultDatabaseUrl` constant.
  - Changed `DATABASE_URL` to optional in env parsing.
  - Enforced `DATABASE_URL` only when `STAGEHAND_DB_MODE=postgres`.
  - Kept `pglite` behavior unchanged (no `DATABASE_URL` required by default).
  - Updated server wiring to rely on the env validation guarantee in postgres
  mode.
  - Updated env unit tests to reflect the new contract.
  - Added a README note documenting:
    - `DATABASE_URL` is required for postgres mode
    - `DATABASE_URL` can be omitted for pglite mode

  ## Validation
  - `tsc -p packages/server-v4/tsconfig.json --noEmit`
  - `eslint` on touched files
  - `prettier --check` on touched files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `DATABASE_URL` required only when `STAGEHAND_DB_MODE=postgres` and remove the placeholder default to prevent hidden DB misconfigurations. `pglite` remains the default and does not require `DATABASE_URL`.

- **Bug Fixes**
  - Removed `constants.urls.defaultDatabaseUrl`; `DATABASE_URL` is now optional and checked only in `postgres` mode.
  - Updated server wiring to use `env.DATABASE_URL!` when in `postgres`.
  - Adjusted env tests and README to match the new contract.

- **Migration**
  - If `STAGEHAND_DB_MODE=postgres`, set a valid `DATABASE_URL`. In `pglite`, you can omit it.

<sup>Written for commit da27f1dfcee2fb540ddfa1aba0ff2677d439b40a. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2013">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

