### PR TITLE
fix(core): replay cached CUA back/forward navigation steps

### DIFF
--- a/packages/core/lib/v3/cache/AgentCache.ts
+++ b/packages/core/lib/v3/cache/AgentCache.ts
@@ -3,7 +3,9 @@ import type { ActHandler } from "../handlers/actHandler.js";
 import type { LLMClient } from "../llm/LLMClient.js";
 import type {
   AgentReplayActStep,
+  AgentReplayBackStep,
   AgentReplayFillFormStep,
+  AgentReplayForwardStep,
   AgentReplayGotoStep,
   AgentReplayKeysStep,
   AgentReplayNavBackStep,
@@ -660,6 +662,12 @@ export class AgentCache {
       case "navback":
         await this.replayAgentNavBackStep(step as AgentReplayNavBackStep, ctx);
         return step;
+      case "back":
+        await this.replayAgentBackStep(step as AgentReplayBackStep, ctx);
+        return step;
+      case "forward":
+        await this.replayAgentForwardStep(step as AgentReplayForwardStep, ctx);
+        return step;
       case "keys":
         await this.replayAgentKeysStep(
           step as AgentReplayKeysStep,
@@ -811,6 +819,22 @@ export class AgentCache {
   ): Promise<void> {
     const page = await ctx.awaitActivePage();
     await page.goBack({ waitUntil: step.waitUntil ?? "domcontentloaded" });
+  }
+
+  private async replayAgentBackStep(
+    step: AgentReplayBackStep,
+    ctx: V3Context,
+  ): Promise<void> {
+    const page = await ctx.awaitActivePage();
+    await page.goBack({ waitUntil: step.waitUntil ?? "domcontentloaded" });
+  }
+
+  private async replayAgentForwardStep(
+    step: AgentReplayForwardStep,
+    ctx: V3Context,
+  ): Promise<void> {
+    const page = await ctx.awaitActivePage();
+    await page.goForward({ waitUntil: step.waitUntil ?? "domcontentloaded" });
   }
 
   private async replayAgentKeysStep(

--- a/packages/core/lib/v3/types/private/cache.ts
+++ b/packages/core/lib/v3/types/private/cache.ts
@@ -90,6 +90,8 @@ export type AgentReplayStep =
   | AgentReplayScrollStep
   | AgentReplayWaitStep
   | AgentReplayNavBackStep
+  | AgentReplayBackStep
+  | AgentReplayForwardStep
   | AgentReplayKeysStep
   | { type: string; [key: string]: unknown };
 
@@ -129,6 +131,16 @@ export interface AgentReplayWaitStep {
 
 export interface AgentReplayNavBackStep {
   type: "navback";
+  waitUntil?: LoadState;
+}
+
+export interface AgentReplayBackStep {
+  type: "back";
+  waitUntil?: LoadState;
+}
+
+export interface AgentReplayForwardStep {
+  type: "forward";
   waitUntil?: LoadState;
 }
 

--- a/packages/core/tests/unit/cache-llm-resolution.test.ts
+++ b/packages/core/tests/unit/cache-llm-resolution.test.ts
@@ -166,7 +166,7 @@ describe("Cache LLM client selection", () => {
     expect(call?.[3]).toBe(overrideClient);
   });
 
-  it("AgentCache replays non-act steps without requiring an override client", async () => {
+  it("AgentCache replays non-act navigation steps without requiring an override client", async () => {
     const gotoEntry: CachedAgentEntry = {
       version: 1,
       instruction: "navigate home",
@@ -177,6 +177,17 @@ describe("Cache LLM client selection", () => {
         {
           type: "goto",
           url: "https://example.com/target",
+          waitUntil: "load",
+        },
+        {
+          type: "navback",
+          waitUntil: "networkidle",
+        },
+        {
+          type: "back",
+        },
+        {
+          type: "forward",
           waitUntil: "load",
         },
       ],
@@ -195,7 +206,11 @@ describe("Cache LLM client selection", () => {
       takeDeterministicAction: vi.fn(),
     } as unknown as ActHandler;
 
-    const fakePage = { goto: vi.fn() } as unknown as Page;
+    const fakePage = {
+      goto: vi.fn(),
+      goBack: vi.fn(),
+      goForward: vi.fn(),
+    } as unknown as Page;
     const ctx = {
       awaitActivePage: vi.fn().mockResolvedValue(fakePage),
     } as unknown as V3Context;
@@ -226,6 +241,16 @@ describe("Cache LLM client selection", () => {
     expect(result?.success).toBe(true);
     expect(handler.takeDeterministicAction).not.toHaveBeenCalled();
     expect(fakePage.goto).toHaveBeenCalledWith("https://example.com/target", {
+      waitUntil: "load",
+    });
+    expect(fakePage.goBack).toHaveBeenCalledTimes(2);
+    expect(fakePage.goBack).toHaveBeenNthCalledWith(1, {
+      waitUntil: "networkidle",
+    });
+    expect(fakePage.goBack).toHaveBeenNthCalledWith(2, {
+      waitUntil: "domcontentloaded",
+    });
+    expect(fakePage.goForward).toHaveBeenCalledWith({
       waitUntil: "load",
     });
   });


### PR DESCRIPTION
  # why

  CUA replay currently records `back`/`forward` steps but `AgentCache` only
  replays `navback`.
  This causes cached CUA runs to silently skip history navigation actions,
  which can drift page state and break deterministic replay.

  # what changed

  - Added explicit replay step types for:
    - `back`
    - `forward`
  - Updated `AgentCache` replay switch to execute:
    - `back` via `page.goBack(...)`
    - `forward` via `page.goForward(...)`
  - Kept existing `navback` replay behavior for compatibility.
  - Extended unit tests to verify replay of non-act navigation steps:
    - `goto`
    - `navback`
    - `back`
    - `forward`

  # test plan

  - `prettier --check` on touched files
  - `eslint` on touched files
  - `tsc -p packages/core/tsconfig.json --noEmit`
  - Unit test coverage added in:
    - `packages/core/tests/unit/cache-llm-resolution.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cached CUA replays skipping browser history. `AgentCache` now replays `back` and `forward` steps to keep page state deterministic.

- **Bug Fixes**
  - Added `back` and `forward` replay step types and handle them in `AgentCache` via `page.goBack`/`page.goForward` with `waitUntil` (default `domcontentloaded`).
  - Preserved existing `navback` behavior for compatibility.
  - Extended unit tests to cover `goto`, `navback`, `back`, and `forward`.

<sup>Written for commit c3362fcd403d57171eeb61d5216e60e7427b86ed. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2014">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

