### PR TITLE
fix(core): add clickAndHold screenshot output parity

### DIFF
--- a/packages/core/lib/v3/agent/tools/clickAndHold.ts
+++ b/packages/core/lib/v3/agent/tools/clickAndHold.ts
@@ -2,7 +2,12 @@ import { tool } from "ai";
 import { z } from "zod";
 import type { V3 } from "../../v3.js";
 import type { Action } from "../../types/public/methods.js";
+import type {
+  ClickAndHoldToolResult,
+  ModelOutputContentItem,
+} from "../../types/public/agent.js";
 import { processCoordinates } from "../utils/coordinateNormalization.js";
+import { waitAndCaptureScreenshot } from "../utils/screenshotHandler.js";
 import { ensureXPath } from "../utils/xpath.js";
 
 export const clickAndHoldTool = (v3: V3, provider?: string) =>
@@ -21,7 +26,11 @@ export const clickAndHoldTool = (v3: V3, provider?: string) =>
         .array(z.number())
         .describe("The (x, y) coordinates to click on"),
     }),
-    execute: async ({ describe, coordinates, duration }) => {
+    execute: async ({
+      describe,
+      coordinates,
+      duration,
+    }): Promise<ClickAndHoldToolResult> => {
       try {
         const page = await v3.context.awaitActivePage();
         const processed = processCoordinates(
@@ -58,6 +67,8 @@ export const clickAndHoldTool = (v3: V3, provider?: string) =>
           { delay: duration, returnXpath: shouldCollectXpath },
         );
 
+        const screenshotBase64 = await waitAndCaptureScreenshot(page);
+
         // Record as "act" step with proper Action for deterministic replay (only when caching)
         if (shouldCollectXpath) {
           const normalizedXpath = ensureXPath(xpath);
@@ -77,12 +88,48 @@ export const clickAndHoldTool = (v3: V3, provider?: string) =>
           }
         }
 
-        return { success: true, describe };
+        return {
+          success: true,
+          describe,
+          duration,
+          coordinates: [processed.x, processed.y],
+          screenshotBase64,
+        };
       } catch (error) {
         return {
           success: false,
           error: `Error clicking and holding: ${error.message}`,
         };
       }
+    },
+    toModelOutput: (result) => {
+      if (result.success === false || result.error !== undefined) {
+        return {
+          type: "content",
+          value: [{ type: "text", text: JSON.stringify(result) }],
+        };
+      }
+
+      const content: ModelOutputContentItem[] = [
+        {
+          type: "text",
+          text: JSON.stringify({
+            success: result.success,
+            describe: result.describe,
+            duration: result.duration,
+            coordinates: result.coordinates,
+          }),
+        },
+      ];
+
+      if (result.screenshotBase64) {
+        content.push({
+          type: "media",
+          mediaType: "image/png",
+          data: result.screenshotBase64,
+        });
+      }
+
+      return { type: "content", value: content };
     },
   });

--- a/packages/core/lib/v3/agent/utils/messageProcessing.ts
+++ b/packages/core/lib/v3/agent/utils/messageProcessing.ts
@@ -3,6 +3,7 @@ import type { ModelMessage } from "ai";
 // Vision action tools that include screenshots in their results
 const VISION_ACTION_TOOLS = [
   "click",
+  "clickAndHold",
   "type",
   "dragAndDrop",
   "wait",

--- a/packages/core/lib/v3/types/public/agent.ts
+++ b/packages/core/lib/v3/types/public/agent.ts
@@ -742,6 +742,15 @@ export interface DragAndDropToolResult {
   screenshotBase64?: string;
 }
 
+export interface ClickAndHoldToolResult {
+  success: boolean;
+  describe?: string;
+  duration?: number;
+  coordinates?: number[];
+  error?: string;
+  screenshotBase64?: string;
+}
+
 export interface FillFormField {
   action: string;
   value: string;

--- a/packages/core/tests/unit/message-processing.test.ts
+++ b/packages/core/tests/unit/message-processing.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import type { ModelMessage } from "ai";
+import { processMessages } from "../../lib/v3/agent/utils/messageProcessing.js";
+
+function visionToolMessage(toolName: string, text: string): ModelMessage {
+  return {
+    role: "tool",
+    content: [
+      {
+        toolName,
+        output: {
+          type: "content",
+          value: [
+            { type: "text", text },
+            {
+              type: "media",
+              mediaType: "image/png",
+              data: "base64-image-data",
+            },
+          ],
+        },
+      },
+    ],
+  } as unknown as ModelMessage;
+}
+
+describe("processMessages", () => {
+  it("treats clickAndHold as a vision action tool for screenshot compression", () => {
+    const messages: ModelMessage[] = [
+      visionToolMessage("clickAndHold", '{"success":true,"describe":"hold"}'),
+      visionToolMessage("click", '{"success":true,"describe":"click"}'),
+      visionToolMessage("wait", '{"success":true,"waited":200}'),
+    ];
+
+    const compressedCount = processMessages(messages);
+
+    expect(compressedCount).toBe(1);
+
+    const oldestOutput = (
+      messages[0] as unknown as {
+        content: Array<{
+          output: { value: Array<{ type: string; text?: string }> };
+        }>;
+      }
+    ).content[0].output.value;
+
+    expect(oldestOutput).toEqual([
+      { type: "text", text: '{"success":true,"describe":"hold"}' },
+    ]);
+  });
+});


### PR DESCRIPTION
  # why

  `clickAndHold` was inconsistent with other coordinate-based vision tools
  (`click`, `type`, `dragAndDrop`):
  - it did not capture a post-action screenshot
  - it did not implement `toModelOutput`

  This made model feedback less reliable and broke parity with existing
  vision tool behavior.

  # what changed

  - Updated `clickAndHold` tool to:
    - capture a screenshot after action execution
    - return richer success payload (`describe`, `duration`, `coordinates`,
  `screenshotBase64`)
    - implement `toModelOutput` with text + media output (matching other
  vision tools)
  - Added a dedicated `ClickAndHoldToolResult` type in public agent types.
  - Added `clickAndHold` to vision-action compression list so older
  screenshots from this tool are pruned consistently with other vision tools.
  - Added unit coverage for message processing to assert `clickAndHold` is
  treated as a vision action for screenshot compression.

  # test plan

  - `prettier --check` on touched files
  - `eslint` on touched files
  - `tsc -p packages/core/tsconfig.json --noEmit`
  - Added unit test:
    - `packages/core/tests/unit/message-processing.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brings `clickAndHold` to parity with other vision tools by capturing a post-action screenshot and emitting proper model output. Improves feedback quality and enables consistent screenshot compression.

- **Bug Fixes**
  - Capture a post-action screenshot and include it in the result/model output.
  - Implement `toModelOutput` (text + optional image), matching `click`, `type`, and `dragAndDrop`.
  - Return a richer payload: `describe`, `duration`, `coordinates`, `screenshotBase64`.
  - Treat `clickAndHold` as a vision action for screenshot compression; added a unit test.
  - Add public `ClickAndHoldToolResult` type.

<sup>Written for commit 85fb256ed27c7d58b446d480580890ae10ed2c6a. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2015">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

