### PR TITLE
Handle no-object act inference failures

### DIFF
--- a/.changeset/empty-bags-sip.md
+++ b/.changeset/empty-bags-sip.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Handle no-object act inference failures by returning no action found.

--- a/packages/core/lib/v3/handlers/actHandler.ts
+++ b/packages/core/lib/v3/handlers/actHandler.ts
@@ -1,5 +1,6 @@
 // lib/v3/handlers/actHandler.ts
 import { act as actInference } from "../../inference.js";
+import { NoObjectGeneratedError } from "ai";
 import { buildActPrompt, buildStepTwoPrompt } from "../../prompt.js";
 import { trimTrailingTextNode } from "../../utils.js";
 import { v3Logger } from "../logger.js";
@@ -35,6 +36,10 @@ type ActInferenceElement = {
 };
 
 type ActInferenceResponse = Awaited<ReturnType<typeof actInference>>;
+type ActInferenceResult = {
+  action?: Action;
+  response?: ActInferenceResponse;
+};
 
 export class ActHandler {
   private readonly llmClient: LLMClient;
@@ -106,15 +111,29 @@ export class ActHandler {
     xpathMap: Record<string, string>;
     llmClient: LLMClient;
     requireMethodAndArguments?: boolean;
-  }): Promise<{ action?: Action; response: ActInferenceResponse }> {
-    const response = await actInference({
-      instruction,
-      domElements,
-      llmClient,
-      userProvidedInstructions: this.systemPrompt,
-      logger: v3Logger,
-      logInferenceToFile: this.logInferenceToFile,
-    });
+  }): Promise<ActInferenceResult> {
+    let response: ActInferenceResponse;
+    try {
+      response = await actInference({
+        instruction,
+        domElements,
+        llmClient,
+        userProvidedInstructions: this.systemPrompt,
+        logger: v3Logger,
+        logInferenceToFile: this.logInferenceToFile,
+      });
+    } catch (error) {
+      if (NoObjectGeneratedError.isInstance(error)) {
+        v3Logger({
+          category: "action",
+          message: "act inference did not produce a schema-valid action",
+          level: 1,
+        });
+        return {};
+      }
+
+      throw error;
+    }
 
     this.recordActMetrics(response);
 

--- a/packages/core/tests/unit/timeout-handlers.test.ts
+++ b/packages/core/tests/unit/timeout-handlers.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NoObjectGeneratedError } from "ai";
 import { ActHandler } from "../../lib/v3/handlers/actHandler.js";
 import { ExtractHandler } from "../../lib/v3/handlers/extractHandler.js";
 import { ObserveHandler } from "../../lib/v3/handlers/observeHandler.js";
@@ -248,6 +249,96 @@ describe("ActHandler two-step timeout", () => {
     expect(performUnderstudyMethodMock).toHaveBeenCalledTimes(1);
     // Step 2 LLM call should NOT have happened
     expect(actInferenceMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("ActHandler LLM action selection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns no action found when structured output validation produces no object", async () => {
+    const waitForDomNetworkQuietMock = vi.mocked(waitForDomNetworkQuiet);
+    waitForDomNetworkQuietMock.mockResolvedValue(undefined);
+
+    const captureHybridSnapshotMock = vi.mocked(captureHybridSnapshot);
+    captureHybridSnapshotMock.mockResolvedValue({
+      combinedTree: "tree content",
+      combinedXpathMap: {},
+      combinedUrlMap: {},
+    });
+
+    vi.mocked(createTimeoutGuard).mockImplementation(() => vi.fn());
+
+    vi.mocked(actInference).mockRejectedValueOnce(
+      new NoObjectGeneratedError({
+        message: "No object generated: response did not match schema",
+        text: '{"elementId":""}',
+        response: {
+          id: "response-id",
+          timestamp: new Date(0),
+          modelId: "google/gemini-2.5-flash",
+        },
+        usage: {
+          inputTokens: 1,
+          outputTokens: 1,
+          totalTokens: 2,
+        },
+        finishReason: "stop",
+      }),
+    );
+
+    const { performUnderstudyMethod } = await import(
+      "../../lib/v3/handlers/handlerUtils/actHandlerUtils.js"
+    );
+    const performUnderstudyMethodMock = vi.mocked(performUnderstudyMethod);
+
+    const handler = buildActHandler();
+    const fakePage = {
+      mainFrame: vi.fn().mockReturnValue({}),
+    } as unknown as Page;
+
+    const result = await handler.act({
+      instruction: "click the button",
+      page: fakePage,
+    });
+
+    expect(result).toEqual({
+      success: false,
+      message: "Failed to perform act: No action found",
+      actionDescription: "click the button",
+      actions: [],
+    });
+    expect(performUnderstudyMethodMock).not.toHaveBeenCalled();
+  });
+
+  it("rethrows non-structured-output LLM errors", async () => {
+    const waitForDomNetworkQuietMock = vi.mocked(waitForDomNetworkQuiet);
+    waitForDomNetworkQuietMock.mockResolvedValue(undefined);
+
+    const captureHybridSnapshotMock = vi.mocked(captureHybridSnapshot);
+    captureHybridSnapshotMock.mockResolvedValue({
+      combinedTree: "tree content",
+      combinedXpathMap: {},
+      combinedUrlMap: {},
+    });
+
+    vi.mocked(createTimeoutGuard).mockImplementation(() => vi.fn());
+
+    const llmError = new Error("provider unavailable");
+    vi.mocked(actInference).mockRejectedValueOnce(llmError);
+
+    const handler = buildActHandler();
+    const fakePage = {
+      mainFrame: vi.fn().mockReturnValue({}),
+    } as unknown as Page;
+
+    await expect(
+      handler.act({
+        instruction: "click the button",
+        page: fakePage,
+      }),
+    ).rejects.toThrow("provider unavailable");
   });
 });
 


### PR DESCRIPTION
## Why
- A customer reported `stagehand.act` surfacing an HTTP error after Gemini returned a schema-invalid action object with an empty `elementId`.
- The AI SDK correctly raises `NoObjectGeneratedError`, but that previously bypassed ActHandler's existing `No action found` result path.

## What changed
- Catch AI SDK `NoObjectGeneratedError` at the ActHandler inference boundary using `NoObjectGeneratedError.isInstance(error)`.
- Convert only that structured-output failure into the existing `success: false` result, while rethrowing other LLM/provider errors.

```ts
// before
const response = await actInference(...);

// after
try {
  response = await actInference(...);
} catch (error) {
  if (NoObjectGeneratedError.isInstance(error)) return {};
  throw error;
}
```

## Testing
- Added a regression test for `NoObjectGeneratedError` returning `Failed to perform act: No action found`.
- Added a guard test that ordinary LLM errors still reject.
- Ran `pnpm --filter @browserbasehq/stagehand run test:core -- packages/core/dist/esm/tests/unit/timeout-handlers.test.js` and `pnpm --filter @browserbasehq/stagehand run typecheck`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents HTTP errors when act inference returns no schema-valid action. ActHandler now maps `NoObjectGeneratedError` to the existing “No action found” result and rethrows other provider errors.

- **Bug Fixes**
  - Catch `NoObjectGeneratedError` at the ActHandler boundary, log it, and return the “No action found” path instead of surfacing an HTTP error.
  - Added tests and a changeset to ship a patch for `@browserbasehq/stagehand`; non-structured-output errors still reject.

<sup>Written for commit 91de32e4f033e5f8bddae56ba54c620ab8813895. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2016">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

