### PR TITLE
[STG-1837] Document MCP start sessionId support

### DIFF
--- a/.changeset/mcp-start-session-id-docs.md
+++ b/.changeset/mcp-start-session-id-docs.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand-docs": patch
+---
+
+Document the optional MCP `start` `sessionId` parameter for attaching to an existing Browserbase session.

--- a/packages/docs/v3/integrations/mcp/setup.mdx
+++ b/packages/docs/v3/integrations/mcp/setup.mdx
@@ -102,12 +102,14 @@ Optional extraction instruction.
 </Accordion>
 
 <Accordion title="start">
-Create or reuse a Browserbase session and set it as active for the current MCP transport session.
+Create a new Browserbase session, or attach to an existing Browserbase session, and set it as active for the current MCP transport session.
 
-<Info>No input parameters required.</Info>
+<ParamField path="sessionId" type="string">
+Optional Browserbase session ID to attach to. If omitted, `start` creates a new Browserbase session.
+</ParamField>
 
 <ResponseField name="sessionId" type="string">
-Browserbase session ID.
+Browserbase session ID now active for the current MCP transport session.
 </ResponseField>
 </Accordion>
 

--- a/packages/docs/v3/integrations/mcp/tools.mdx
+++ b/packages/docs/v3/integrations/mcp/tools.mdx
@@ -52,12 +52,14 @@ Extract data from the current page.
 ## Session Management
 
 <Accordion title="start">
-Create or reuse a Browserbase session and set it as active for the current MCP transport session.
+Create a new Browserbase session, or attach to an existing Browserbase session, and set it as active for the current MCP transport session.
 
-<Info>No input parameters required.</Info>
+<ParamField path="sessionId" type="string">
+Optional Browserbase session ID to attach to. If omitted, `start` creates a new Browserbase session.
+</ParamField>
 
 <ResponseField name="sessionId" type="string">
-  Browserbase session ID.
+  Browserbase session ID now active for the current MCP transport session.
 </ResponseField>
 </Accordion>
 


### PR DESCRIPTION
# why

The v3 MCP docs now need to describe the hosted server behavior where `start` can attach to an existing Browserbase session via an optional `sessionId`.

# what changed

- Updated the MCP setup and tools docs to document optional `start.sessionId`.
- Clarified that omitting `sessionId` creates a new Browserbase session.
- Added a patch changeset for `@browserbasehq/stagehand-docs`.

# test plan

- `pnpm exec prettier --check packages/docs/v3/integrations/mcp/setup.mdx packages/docs/v3/integrations/mcp/tools.mdx`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added docs for optional `sessionId` on MCP `start` to attach to an existing Browserbase session; omitting it creates a new session. Addresses STG-1837 and publishes a patch to `@browserbasehq/stagehand-docs`.

<sup>Written for commit edc7cbdef0ce712d369699589e1b24b426bffdd6. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2017">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

