### PR TITLE
fix(core): add FlowLogger parity for Microsoft CUA

### DIFF
--- a/packages/core/lib/v3/agent/MicrosoftCUAClient.ts
+++ b/packages/core/lib/v3/agent/MicrosoftCUAClient.ts
@@ -11,6 +11,12 @@ import { AgentClient } from "./AgentClient.js";
 import { AgentScreenshotProviderError } from "../types/public/sdkErrors.js";
 import { mapKeyToPlaywright } from "./utils/cuaKeyMapping.js";
 import { ChatCompletionMessageParam } from "openai/resources/chat/completions";
+import {
+  FlowLogger,
+  extractLlmCuaPromptSummary,
+  extractLlmCuaResponseSummary,
+} from "../flowlogger/FlowLogger.js";
+import { v7 as uuidv7 } from "uuid";
 
 /**
  * Message types for FARA agent
@@ -714,6 +720,13 @@ For each function call, return a json object with function name and arguments wi
       level: 2,
     });
 
+    const llmRequestId = uuidv7();
+    FlowLogger.logLlmRequest({
+      requestId: llmRequestId,
+      model: this.modelName,
+      prompt: extractLlmCuaPromptSummary(history),
+    });
+
     const startTime = Date.now();
     let response;
     try {
@@ -744,6 +757,14 @@ For each function call, return a json object with function name and arguments wi
       completion_tokens: 0,
       total_tokens: 0,
     };
+
+    FlowLogger.logLlmResponse({
+      requestId: llmRequestId,
+      model: this.modelName,
+      output: extractLlmCuaResponseSummary([{ text: content }]),
+      inputTokens: usage.prompt_tokens,
+      outputTokens: usage.completion_tokens,
+    });
 
     // Add assistant response to both histories
     const assistantMsg: FaraMessage = {

--- a/packages/core/tests/unit/microsoft-cua-client.test.ts
+++ b/packages/core/tests/unit/microsoft-cua-client.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from "vitest";
+import { MicrosoftCUAClient } from "../../lib/v3/agent/MicrosoftCUAClient.js";
+import { FlowLogger } from "../../lib/v3/flowlogger/FlowLogger.js";
+
+function createClient() {
+  const client = new MicrosoftCUAClient("microsoft", "fara-7b", undefined, {
+    apiKey: "test-key",
+    baseURL: "https://example.com",
+  });
+  client.setScreenshotProvider(async () => "mock-base64-screenshot");
+  return client;
+}
+
+describe("MicrosoftCUAClient", () => {
+  it("emits FlowLogger request and response events for a successful model call", async () => {
+    const client = createClient();
+    const createCompletion = vi.fn().mockResolvedValue({
+      choices: [
+        {
+          message: {
+            content:
+              'thoughts\n<tool_call>\n{"name":"computer_use","arguments":{"action":"terminate","status":"success"}}\n</tool_call>',
+          },
+        },
+      ],
+      usage: {
+        prompt_tokens: 11,
+        completion_tokens: 5,
+        total_tokens: 16,
+      },
+    });
+
+    (
+      client as unknown as {
+        client: {
+          chat: { completions: { create: (...args: unknown[]) => unknown } };
+        };
+      }
+    ).client = {
+      chat: {
+        completions: {
+          create: createCompletion,
+        },
+      },
+    };
+
+    const requestSpy = vi.spyOn(FlowLogger, "logLlmRequest");
+    const responseSpy = vi.spyOn(FlowLogger, "logLlmResponse");
+
+    try {
+      const result = await (
+        client as unknown as {
+          executeStep: (
+            logger: (message: unknown) => void,
+            isFirstRound?: boolean,
+          ) => Promise<{ completed: boolean }>;
+        }
+      ).executeStep(vi.fn(), false);
+
+      expect(result.completed).toBe(true);
+      expect(createCompletion).toHaveBeenCalledTimes(1);
+      expect(requestSpy).toHaveBeenCalledTimes(1);
+      expect(responseSpy).toHaveBeenCalledTimes(1);
+
+      const requestPayload = requestSpy.mock.calls[0]?.[0] as {
+        requestId: string;
+        model: string;
+      };
+      const responsePayload = responseSpy.mock.calls[0]?.[0] as {
+        requestId: string;
+        model: string;
+        inputTokens: number;
+        outputTokens: number;
+        output: string;
+      };
+
+      expect(requestPayload.model).toBe("fara-7b");
+      expect(responsePayload.model).toBe("fara-7b");
+      expect(responsePayload.requestId).toBe(requestPayload.requestId);
+      expect(responsePayload.inputTokens).toBe(11);
+      expect(responsePayload.outputTokens).toBe(5);
+      expect(responsePayload.output).toContain("terminate");
+    } finally {
+      requestSpy.mockRestore();
+      responseSpy.mockRestore();
+    }
+  });
+
+  it("emits only FlowLogger request event when model call fails", async () => {
+    const client = createClient();
+    const createCompletion = vi
+      .fn()
+      .mockRejectedValue(new Error("upstream model error"));
+
+    (
+      client as unknown as {
+        client: {
+          chat: { completions: { create: (...args: unknown[]) => unknown } };
+        };
+      }
+    ).client = {
+      chat: {
+        completions: {
+          create: createCompletion,
+        },
+      },
+    };
+
+    const requestSpy = vi.spyOn(FlowLogger, "logLlmRequest");
+    const responseSpy = vi.spyOn(FlowLogger, "logLlmResponse");
+
+    try {
+      await expect(
+        (
+          client as unknown as {
+            executeStep: (
+              logger: (message: unknown) => void,
+              isFirstRound?: boolean,
+            ) => Promise<unknown>;
+          }
+        ).executeStep(vi.fn(), false),
+      ).rejects.toThrow("upstream model error");
+
+      expect(requestSpy).toHaveBeenCalledTimes(1);
+      expect(responseSpy).not.toHaveBeenCalled();
+      expect(createCompletion).toHaveBeenCalledTimes(1);
+    } finally {
+      requestSpy.mockRestore();
+      responseSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
Title
  fix(core): add FlowLogger parity for Microsoft CUA

  Description

  # why

  `MicrosoftCUAClient` was the only CUA provider not emitting FlowLogger LLM
  request/response events.
  OpenAI, Google, and Anthropic clients already emit these events, so
  Microsoft CUA lacked observability parity.

  # what changed

  - Added FlowLogger imports and request/response logging to
  `MicrosoftCUAClient`:
    - `FlowLogger.logLlmRequest(...)` before the model call
    - `FlowLogger.logLlmResponse(...)` after a successful response
  - Added request ID correlation via `uuidv7` so request/response pair
  correctly in logs.
  - Kept existing execution behavior unchanged (logging-only change).
  - Added unit tests for Microsoft CUA logging behavior:
    - emits request + response on success
    - emits only request when the model call fails

  # test plan

  - `prettier --check` on touched files
  - `eslint` on touched files
  - `tsc -p packages/core/tsconfig.json --noEmit`
  - Added unit test file:
    - `packages/core/tests/unit/microsoft-cua-client.test.ts`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add LLM request/response logging to `MicrosoftCUAClient` to match other providers and improve observability. This brings Microsoft CUA to parity with OpenAI, Google, and Anthropic clients.

- **Bug Fixes**
  - Emit `FlowLogger.logLlmRequest` before the model call and `FlowLogger.logLlmResponse` after success.
  - Correlate events with a `requestId` using `uuid` v7.
  - No behavior changes to execution; logging-only.
  - Added unit tests for success (request + response) and failure (request only).

<sup>Written for commit 54b258b01fa9e29ea5e044f50c7dbe159364690b. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2019">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

