### PR TITLE
Update default gemini model for evals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ permissions:
 env:
   BROWSERBASE_FLOW_LOGS: "1"
   LLM_MAX_MS: "15000"
-  EVAL_MODELS: "openai/gpt-4.1,google/gemini-2.0-flash,anthropic/claude-haiku-4-5"
+  EVAL_MODELS: "openai/gpt-4.1,google/gemini-2.5-flash,anthropic/claude-haiku-4-5"
   EVAL_AGENT_MODELS: "computer-use-preview-2025-03-11,claude-sonnet-4-6"
   EVAL_CATEGORIES: "observe,act,combination,extract,targeted_extract,agent"
   EVAL_MAX_CONCURRENCY: 25

--- a/packages/evals/taskConfig.ts
+++ b/packages/evals/taskConfig.ts
@@ -101,7 +101,7 @@ if (filterByEvalName && !tasksByName[filterByEvalName]) {
 const DEFAULT_EVAL_MODELS = process.env.EVAL_MODELS
   ? process.env.EVAL_MODELS.split(",")
   : [
-      "google/gemini-2.0-flash",
+      "google/gemini-2.5-flash",
       "openai/gpt-4.1-mini",
       "anthropic/claude-haiku-4-5",
     ];


### PR DESCRIPTION
# why

# what changed

# test plan

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the default Gemini eval model to `google/gemini-2.5-flash` and updated CI `EVAL_MODELS` to use it, so evals run against the latest flash model both by default and in CI.

<sup>Written for commit 87f421eea7d9e5160e9b3c97ce2b95ecf945eb34. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2024">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

