### PR TITLE
remove strictJson schema

### DIFF
--- a/.changeset/twelve-corners-sell.md
+++ b/.changeset/twelve-corners-sell.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Remove deprecated provider option

--- a/packages/core/lib/v3/llm/aisdk.ts
+++ b/packages/core/lib/v3/llm/aisdk.ts
@@ -194,11 +194,6 @@ export class AISdkClient extends LLMClient {
           structuredOutputs: true,
         };
         break;
-      case "anthropic":
-        providerOptions.anthropic = {
-          structuredOutputMode: "auto",
-        };
-        break;
       case "groq":
         providerOptions.groq = {
           structuredOutputs: true,

--- a/packages/core/tests/unit/aisdk-clients.test.ts
+++ b/packages/core/tests/unit/aisdk-clients.test.ts
@@ -41,10 +41,6 @@ describe("AISdkClient structured output provider options", () => {
     ["azure/gpt-4.1", { azure: { strictJsonSchema: true } }],
     ["google/gemini-2.5-pro", { google: { structuredOutputs: true } }],
     ["vertex/gemini-2.5-pro", { vertex: { structuredOutputs: true } }],
-    [
-      "anthropic/claude-sonnet-4-20250514",
-      { anthropic: { structuredOutputMode: "auto" } },
-    ],
     ["groq/llama-3.3-70b-versatile", { groq: { structuredOutputs: true } }],
     ["cerebras/llama-4-scout", { cerebras: { strictJsonSchema: true } }],
     [


### PR DESCRIPTION
# why

Structured output mode is deprecated 

# what changed

removed usage of anthropic structured output mode 

# test plan

Ran tests locally + CI tests 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the deprecated `anthropic.structuredOutputMode` option from AISdk provider options to align with Anthropic’s deprecation and avoid sending unsupported flags. Updated unit tests and added a changeset; behavior for other providers is unchanged.

<sup>Written for commit 64daca7b23c0d19e6281fffc7a1d30350477eabd. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2028">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

