### PR TITLE
Remove default from twoStep schema requirement

### DIFF
--- a/packages/core/lib/inference.ts
+++ b/packages/core/lib/inference.ts
@@ -445,7 +445,7 @@ export async function act({
       .describe(
         "The element to act on. Return null if no element on the page matches the instruction — do NOT fabricate or guess an element, and never emit empty strings or placeholder values.",
       ),
-    twoStep: z.boolean().default(false),
+    twoStep: z.boolean(),
   });
 
   type ActResponse = z.infer<typeof actSchema>;

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -12,10 +12,6 @@
       "@/*": ["./*"]
     }
   },
-  "include": [
-    "lib/**/*.ts",
-    "tests/**/*.ts",
-    "lib/v3/cli.js"
-  ],
+  "include": ["lib/**/*.ts", "tests/**/*.ts", "lib/v3/cli.js"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
# why
`z.boolean().default(false)` on line 448 is incompatible with OpenAI's strict structured-output mode.     

OpenAI's error:                                                              

> 'required' is required to be supplied and to be an array including every key in properties. Missing 'twoStep'. 


# what changed

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made `twoStep` a required boolean in the `act` schema (no default). This removes the silent `false` default and forces callers to be explicit about two-step actions.

- **Migration**
  - Always pass `twoStep: true | false` when calling `act`.
  - `tsconfig.json` change is formatting-only; no runtime impact.

<sup>Written for commit ca56e780634eacba7aab77ef1222bb4bcbf0a766. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2029">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

