### PR TITLE
fix: move pino-pretty to optionalDependencies and fix fallback in serverless envs

### DIFF
--- a/packages/core/lib/logger.ts
+++ b/packages/core/lib/logger.ts
@@ -34,18 +34,23 @@ export function createLogger(options: LoggerOptions = {}) {
   // and not in a test environment
   if (options.pretty && !isTestEnvironment()) {
     try {
-      // Use require for dynamic import
-      const transport = {
-        transport: {
-          target: "pino-pretty",
-          options: {
-            colorize: true,
-            translateTime: "SYS:standard",
-            ignore: "pid,hostname",
+      // pino-pretty is an optional dependency and may not be available in all
+      // environments (e.g. serverless, Next.js). Attempt to initialise pino with
+      // the pretty transport and fall back to plain pino on any error.
+      return pino(
+        {
+          ...loggerConfig,
+          transport: {
+            target: "pino-pretty",
+            options: {
+              colorize: true,
+              translateTime: "SYS:standard",
+              ignore: "pid,hostname",
+            },
           },
         },
-      };
-      Object.assign(loggerConfig, transport);
+        options.destination,
+      );
     } catch {
       console.warn(
         "pino-pretty not available, falling back to standard logging",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -74,7 +74,6 @@
     "fetch-cookie": "^3.1.0",
     "openai": "^4.87.1",
     "pino": "^9.6.0",
-    "pino-pretty": "^13.0.0",
     "uuid": "^11.1.0",
     "ws": "^8.18.0",
     "zod-to-json-schema": "^3.25.0"
@@ -98,6 +97,7 @@
     "chrome-launcher": "^1.2.0",
     "ollama-ai-provider-v2": "^1.5.0",
     "patchright-core": "^1.55.2",
+    "pino-pretty": "^13.0.0",
     "playwright": "^1.52.0",
     "playwright-core": "^1.54.1",
     "puppeteer-core": "^22.8.0"


### PR DESCRIPTION
Fixes #1464

## Problem

`pino-pretty` was declared as a regular `dependency`, so bundlers (Next.js, Vercel, Netlify, AWS Lambda, etc.) always include it in production builds. In serverless runtimes that restrict Node.js worker thread usage, pino fails at startup with:

```
Error: unable to determine transport target for "pino-pretty"
```

Additionally, the existing fallback in `createLogger` was broken: the `try/catch` block only wrapped `Object.assign(loggerConfig, transport)`, which never throws — the actual error comes from the `pino()` call that follows, outside the try block.

## Solution

1. **Move `pino-pretty` to `optionalDependencies`** — bundlers can now exclude it when not needed, and package managers will skip it when it cannot be installed (e.g. restricted environments).

2. **Fix the `try/catch` scope in `createLogger`** — the `pino()` call with the pretty transport is now inside the try block. If pino fails to initialise the pino-pretty worker thread for any reason, the error is caught and pino falls back to plain JSON logging with a console warning. The existing `disablePino: true` workaround continues to work as before.

## Testing

- Existing behaviour: in standard Node.js environments with pino-pretty available, pretty-printed logs still work.
- In environments where pino-pretty is excluded or worker threads are unavailable, stagehand now initialises successfully and logs in plain JSON format instead of throwing.
- The `disablePino: true` option remains as an explicit opt-out.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `pino-pretty` optional and fix the logger fallback so serverless builds don’t crash. If `pino-pretty` isn’t available or worker threads are blocked, we now fall back to plain JSON logging.

- **Dependencies**
  - Moved `pino-pretty` to `optionalDependencies` so bundlers can exclude it.
  - Allows installs to skip `pino-pretty` in restricted environments.

- **Bug Fixes**
  - Wrapped the `pino()` call with the pretty transport in a try/catch; on failure, log a warning and use JSON output.
  - No change when `pino-pretty` is available; `disablePino: true` still works.

<sup>Written for commit 2d4d25dcc3c9614b42b8d36e05421f53fed87dad. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2034">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

