### PR TITLE
fix(core): infer Anthropic tool_result image MIME type

### DIFF
--- a/packages/core/lib/v3/agent/AnthropicCUAClient.ts
+++ b/packages/core/lib/v3/agent/AnthropicCUAClient.ts
@@ -30,6 +30,29 @@ import { v7 as uuidv7 } from "uuid";
 
 export type ResponseInputItem = AnthropicMessage | AnthropicToolResult;
 
+const IMAGE_DATA_URL_PATTERN =
+  /^data:(image\/[a-zA-Z0-9.+-]+);base64,([\s\S]*)$/i;
+const PNG_DATA_URL_PREFIX = /^data:image\/png;base64,/i;
+
+function getImageToolResultSource(screenshot: string): {
+  mediaType: string;
+  base64Data: string;
+} {
+  const match = screenshot.match(IMAGE_DATA_URL_PATTERN);
+  if (match?.[1] && typeof match[2] === "string") {
+    return {
+      mediaType: match[1].toLowerCase(),
+      base64Data: match[2],
+    };
+  }
+
+  // Fallback preserves existing PNG behavior for malformed/unexpected values.
+  return {
+    mediaType: "image/png",
+    base64Data: screenshot.replace(PNG_DATA_URL_PREFIX, ""),
+  };
+}
+
 /**
  * Client for Anthropic's Computer Use API
  * This implementation uses the official Anthropic Messages API for Computer Use
@@ -661,6 +684,7 @@ export class AnthropicCUAClient extends AgentClient {
             message: `Screenshot captured, length: ${screenshot.length}`,
             level: 2,
           });
+          const screenshotSource = getImageToolResultSource(screenshot);
 
           // Create proper image content block for Anthropic
           const imageContent = [
@@ -668,8 +692,8 @@ export class AnthropicCUAClient extends AgentClient {
               type: "image",
               source: {
                 type: "base64",
-                media_type: "image/png",
-                data: screenshot.replace(/^data:image\/png;base64,/, ""),
+                media_type: screenshotSource.mediaType,
+                data: screenshotSource.base64Data,
               },
             },
           ];
@@ -770,6 +794,7 @@ export class AnthropicCUAClient extends AgentClient {
           // For computer tool, try to capture a screenshot even on error
           if (item.name === "computer") {
             const screenshot = await this.captureScreenshot();
+            const screenshotSource = getImageToolResultSource(screenshot);
 
             toolResults.push({
               type: "tool_result",
@@ -779,8 +804,8 @@ export class AnthropicCUAClient extends AgentClient {
                   type: "image",
                   source: {
                     type: "base64",
-                    media_type: "image/png",
-                    data: screenshot.replace(/^data:image\/png;base64,/, ""),
+                    media_type: screenshotSource.mediaType,
+                    data: screenshotSource.base64Data,
                   },
                 },
                 {

--- a/packages/core/tests/unit/anthropic-cua-client.test.ts
+++ b/packages/core/tests/unit/anthropic-cua-client.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+import { AnthropicCUAClient } from "../../lib/v3/agent/AnthropicCUAClient.js";
+import type { ToolUseItem } from "../../lib/v3/types/public/agent.js";
+
+function createClient() {
+  return new AnthropicCUAClient(
+    "anthropic",
+    "anthropic/claude-sonnet-4-6",
+    undefined,
+    { apiKey: "test-key" },
+  );
+}
+
+const noopLogger = vi.fn();
+
+function computerToolUseItem(id: string): ToolUseItem {
+  return {
+    type: "tool_use",
+    id,
+    name: "computer",
+    input: {
+      action: "left_click",
+    },
+  };
+}
+
+function extractImageSource(result: {
+  content: string | Array<{ type: string; source?: Record<string, unknown> }>;
+}): { media_type: string; data: string } {
+  const content = result.content;
+  if (!Array.isArray(content)) {
+    throw new Error("Expected tool_result content array");
+  }
+
+  const imageBlock = content.find(
+    (block) => block.type === "image" && block.source,
+  );
+  if (!imageBlock?.source) {
+    throw new Error("Expected image block in tool_result content");
+  }
+
+  return imageBlock.source as { media_type: string; data: string };
+}
+
+describe("AnthropicCUAClient", () => {
+  it("uses the screenshot MIME type for computer tool_result images", async () => {
+    const client = createClient();
+    vi.spyOn(client, "captureScreenshot").mockResolvedValueOnce(
+      "data:image/jpeg;base64,abcd1234",
+    );
+
+    const results = await client.takeAction(
+      [computerToolUseItem("tool-1")],
+      noopLogger,
+    );
+
+    expect(results).toHaveLength(1);
+    const imageSource = extractImageSource(results[0]!);
+    expect(imageSource.media_type).toBe("image/jpeg");
+    expect(imageSource.data).toBe("abcd1234");
+  });
+
+  it("falls back to PNG metadata when screenshot is not an image data URL", async () => {
+    const client = createClient();
+    vi.spyOn(client, "captureScreenshot").mockResolvedValueOnce(
+      "raw-base64-payload",
+    );
+
+    const results = await client.takeAction(
+      [computerToolUseItem("tool-2")],
+      noopLogger,
+    );
+
+    const imageSource = extractImageSource(results[0]!);
+    expect(imageSource.media_type).toBe("image/png");
+    expect(imageSource.data).toBe("raw-base64-payload");
+  });
+
+  it("uses parsed MIME/data in error tool_result screenshot payloads", async () => {
+    const client = createClient();
+    const captureScreenshotSpy = vi
+      .spyOn(client, "captureScreenshot")
+      .mockRejectedValueOnce(new Error("capture failed"))
+      .mockResolvedValueOnce("data:image/webp;base64,errorimg");
+
+    const results = await client.takeAction(
+      [computerToolUseItem("tool-3")],
+      noopLogger,
+    );
+
+    expect(captureScreenshotSpy).toHaveBeenCalledTimes(2);
+    const imageSource = extractImageSource(results[0]!);
+    expect(imageSource.media_type).toBe("image/webp");
+    expect(imageSource.data).toBe("errorimg");
+    expect(results[0]?.content).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "text",
+          text: expect.stringContaining("Error: capture failed"),
+        }),
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
﻿## why

Anthropic CUA computer tool results currently hardcode `media_type: "image/png"` and strip only a PNG prefix from screenshot data URLs.

That is brittle if screenshot input is non-PNG (for example JPEG/WebP), and can produce mismatched metadata or malformed image payloads.

Fixes #2035.

## what changed

- Added a small internal parser in `AnthropicCUAClient` to extract:
  - `media_type` from image data URLs
  - base64 payload without the data URL prefix
- Applied parsed MIME/data in both computer-tool image paths:
  - normal success tool result
  - error fallback tool result
- Kept a PNG fallback path for malformed/unexpected screenshot strings.
- Added focused unit tests in `packages/core/tests/unit/anthropic-cua-client.test.ts` for:
  - JPEG MIME parsing in success path
  - PNG fallback on non-data URL input
  - MIME/data handling in error path retry screenshot payload

## test plan

- `npm.cmd exec prettier -- --check packages/core/lib/v3/agent/AnthropicCUAClient.ts packages/core/tests/unit/anthropic-cua-client.test.ts`
- `node node_modules/vitest/vitest.mjs run --config .tmp-vitest-unit-config.mjs` from `packages/core` (temporary local config targeting `tests/unit/anthropic-cua-client.test.ts`)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Infer MIME type and base64 data from screenshot data URLs for Anthropic CUA `tool_result` images instead of forcing PNG. Prevents mismatched metadata and malformed image payloads. Fixes #2035.

- **Bug Fixes**
  - Added a parser in `AnthropicCUAClient` to extract `media_type` and base64 data from image data URLs.
  - Used parsed values in both success and error `computer` tool_result paths, with a PNG fallback for malformed inputs.
  - Added unit tests for JPEG parsing, fallback behavior, and error-path screenshot payloads.

<sup>Written for commit 9aa0587f125b071423c441cf041fdb2584ac20ce. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2036">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

