### PR TITLE
fix(core): add CUA addContextNote parity across providers

### DIFF
--- a/packages/core/lib/v3/agent/AnthropicCUAClient.ts
+++ b/packages/core/lib/v3/agent/AnthropicCUAClient.ts
@@ -47,6 +47,7 @@ export class AnthropicCUAClient extends AgentClient {
   private thinkingEffort: ThinkingEffort | null = null;
   private userTemperature: number | undefined;
   private tools?: ToolSet;
+  private pendingContextNotes: string[] = [];
 
   constructor(
     type: AgentType,
@@ -113,6 +114,10 @@ export class AnthropicCUAClient extends AgentClient {
     this.tools = tools;
   }
 
+  addContextNote(note: string): void {
+    this.pendingContextNotes.push(note);
+  }
+
   /**
    * Execute a task with the Anthropic CUA
    * This is the main entry point for the agent
@@ -175,6 +180,16 @@ export class AnthropicCUAClient extends AgentClient {
         // Update the input items for the next step if we're continuing
         if (!completed) {
           inputItems = result.nextInputItems;
+          const contextNotes = this.drainContextNotes();
+          if (contextNotes.length > 0) {
+            inputItems = [
+              ...inputItems,
+              ...contextNotes.map((note) => ({
+                role: "user",
+                content: note,
+              })),
+            ];
+          }
         }
 
         // Record any message for this step
@@ -419,6 +434,16 @@ export class AnthropicCUAClient extends AgentClient {
         content: instruction,
       },
     ];
+  }
+
+  private drainContextNotes(): string[] {
+    if (this.pendingContextNotes.length === 0) {
+      return [];
+    }
+
+    const notes = [...this.pendingContextNotes];
+    this.pendingContextNotes = [];
+    return notes;
   }
 
   async getAction(

--- a/packages/core/lib/v3/agent/AnthropicCUAClient.ts
+++ b/packages/core/lib/v3/agent/AnthropicCUAClient.ts
@@ -177,10 +177,11 @@ export class AnthropicCUAClient extends AgentClient {
         // Update completion status
         completed = result.completed;
 
+        const contextNotes = this.drainContextNotes();
+
         // Update the input items for the next step if we're continuing
         if (!completed) {
           inputItems = result.nextInputItems;
-          const contextNotes = this.drainContextNotes();
           if (contextNotes.length > 0) {
             inputItems = [
               ...inputItems,

--- a/packages/core/lib/v3/agent/GoogleCUAClient.ts
+++ b/packages/core/lib/v3/agent/GoogleCUAClient.ts
@@ -58,6 +58,7 @@ export class GoogleCUAClient extends AgentClient {
   private tools?: ToolSet;
   private baseURL?: string;
   private safetyConfirmationHandler?: SafetyConfirmationHandler;
+  private pendingContextNotes: string[] = [];
   constructor(
     type: AgentType,
     modelName: string,
@@ -144,6 +145,10 @@ export class GoogleCUAClient extends AgentClient {
 
   setSafetyConfirmationHandler(handler?: SafetyConfirmationHandler): void {
     this.safetyConfirmationHandler = handler;
+  }
+
+  addContextNote(note: string): void {
+    this.pendingContextNotes.push(note);
   }
 
   private async handleSafetyConfirmation(
@@ -265,6 +270,18 @@ export class GoogleCUAClient extends AgentClient {
         // Update completion status
         completed = result.completed;
 
+        if (!completed) {
+          const contextNotes = this.drainContextNotes();
+          if (contextNotes.length > 0) {
+            this.history.push(
+              ...contextNotes.map((note) => ({
+                role: "user" as const,
+                parts: [{ text: note }],
+              })),
+            );
+          }
+        }
+
         // Record any message for this step
         if (result.message) {
           messageList.push(result.message);
@@ -308,6 +325,16 @@ export class GoogleCUAClient extends AgentClient {
         },
       };
     }
+  }
+
+  private drainContextNotes(): string[] {
+    if (this.pendingContextNotes.length === 0) {
+      return [];
+    }
+
+    const notes = [...this.pendingContextNotes];
+    this.pendingContextNotes = [];
+    return notes;
   }
 
   /**

--- a/packages/core/lib/v3/agent/GoogleCUAClient.ts
+++ b/packages/core/lib/v3/agent/GoogleCUAClient.ts
@@ -270,16 +270,14 @@ export class GoogleCUAClient extends AgentClient {
         // Update completion status
         completed = result.completed;
 
-        if (!completed) {
-          const contextNotes = this.drainContextNotes();
-          if (contextNotes.length > 0) {
-            this.history.push(
-              ...contextNotes.map((note) => ({
-                role: "user" as const,
-                parts: [{ text: note }],
-              })),
-            );
-          }
+        const contextNotes = this.drainContextNotes();
+        if (!completed && contextNotes.length > 0) {
+          this.history.push(
+            ...contextNotes.map((note) => ({
+              role: "user" as const,
+              parts: [{ text: note }],
+            })),
+          );
         }
 
         // Record any message for this step

--- a/packages/core/lib/v3/agent/MicrosoftCUAClient.ts
+++ b/packages/core/lib/v3/agent/MicrosoftCUAClient.ts
@@ -921,16 +921,14 @@ For each function call, return a json object with function name and arguments wi
         // Update completion status
         completed = result.completed;
 
-        if (!completed) {
-          const contextNotes = this.drainContextNotes();
-          if (contextNotes.length > 0) {
-            this.conversationHistory.push(
-              ...contextNotes.map((note) => ({
-                role: "user" as const,
-                content: note,
-              })),
-            );
-          }
+        const contextNotes = this.drainContextNotes();
+        if (!completed && contextNotes.length > 0) {
+          this.conversationHistory.push(
+            ...contextNotes.map((note) => ({
+              role: "user" as const,
+              content: note,
+            })),
+          );
         }
 
         currentStep++;

--- a/packages/core/lib/v3/agent/MicrosoftCUAClient.ts
+++ b/packages/core/lib/v3/agent/MicrosoftCUAClient.ts
@@ -66,6 +66,7 @@ export class MicrosoftCUAClient extends AgentClient {
   private maxImages: number = 3;
   private temperature: number = 0;
   private facts: string[] = [];
+  private pendingContextNotes: string[] = [];
 
   // FARA-specific MLM processor config
   private readonly MLM_PROCESSOR_IM_CFG = {
@@ -144,6 +145,10 @@ export class MicrosoftCUAClient extends AgentClient {
 
   setActionHandler(handler: (action: AgentAction) => Promise<void>): void {
     this.actionHandler = handler;
+  }
+
+  addContextNote(note: string): void {
+    this.pendingContextNotes.push(note);
   }
 
   /**
@@ -916,6 +921,18 @@ For each function call, return a json object with function name and arguments wi
         // Update completion status
         completed = result.completed;
 
+        if (!completed) {
+          const contextNotes = this.drainContextNotes();
+          if (contextNotes.length > 0) {
+            this.conversationHistory.push(
+              ...contextNotes.map((note) => ({
+                role: "user" as const,
+                content: note,
+              })),
+            );
+          }
+        }
+
         currentStep++;
 
         // Record message for this step
@@ -961,5 +978,15 @@ For each function call, return a json object with function name and arguments wi
       // Rethrow to allow eval runner's retry logic to handle transient errors
       throw error;
     }
+  }
+
+  private drainContextNotes(): string[] {
+    if (this.pendingContextNotes.length === 0) {
+      return [];
+    }
+
+    const notes = [...this.pendingContextNotes];
+    this.pendingContextNotes = [];
+    return notes;
   }
 }

--- a/packages/core/tests/unit/cua-context-note-parity.test.ts
+++ b/packages/core/tests/unit/cua-context-note-parity.test.ts
@@ -69,6 +69,62 @@ describe("CUA context note parity", () => {
     ).toBe(false);
   });
 
+  it("does not carry Anthropic context notes into a new execution after terminal step", async () => {
+    const note = "captcha solved: continue and do not click again";
+    const client = new AnthropicCUAClient(
+      "anthropic",
+      "anthropic/claude-sonnet-4-6",
+      undefined,
+      { apiKey: "test-key" },
+    );
+
+    const executeStepSpy = vi.spyOn(
+      client as unknown as {
+        executeStep: (
+          inputItems: unknown[],
+          logger: typeof noopLogger,
+        ) => Promise<unknown>;
+      },
+      "executeStep",
+    );
+
+    const completedByCall = [true, false, true];
+    let callIndex = 0;
+    executeStepSpy.mockImplementation(async () => {
+      const completed = completedByCall[callIndex] ?? true;
+      callIndex += 1;
+      return {
+        actions: [],
+        message: `step-${callIndex}`,
+        completed,
+        nextInputItems: [],
+        usage,
+      };
+    });
+
+    client.addContextNote(note);
+
+    await client.execute({
+      options: { instruction: "first run", maxSteps: 5 } as never,
+      logger: noopLogger,
+    });
+
+    await client.execute({
+      options: { instruction: "second run", maxSteps: 5 } as never,
+      logger: noopLogger,
+    });
+
+    const secondRunStep2Input = executeStepSpy.mock.calls[2]?.[0] as Array<{
+      role?: string;
+      content?: string;
+    }>;
+    expect(
+      secondRunStep2Input.some(
+        (item) => item.role === "user" && item.content === note,
+      ),
+    ).toBe(false);
+  });
+
   it("injects Google context notes once into history between turns", async () => {
     const note = "captcha solved: continue and do not click again";
     const client = new GoogleCUAClient(
@@ -132,6 +188,62 @@ describe("CUA context note parity", () => {
         entry.parts.some((part) => part.text === note),
     ).length;
     expect(noteMessageCount).toBe(1);
+  });
+
+  it("does not carry Google context notes into a new execution after terminal step", async () => {
+    const note = "captcha solved: continue and do not click again";
+    const client = new GoogleCUAClient(
+      "google",
+      "google/gemini-3-flash-preview",
+    );
+
+    const executeStepSpy = vi.spyOn(
+      client as unknown as {
+        executeStep: (logger: typeof noopLogger) => Promise<unknown>;
+      },
+      "executeStep",
+    );
+
+    let callIndex = 0;
+    let leakedInSecondRun = false;
+    executeStepSpy.mockImplementation(async () => {
+      callIndex += 1;
+
+      if (callIndex === 3) {
+        const history = (
+          client as unknown as {
+            history: Array<{ role?: string; parts?: Array<{ text?: string }> }>;
+          }
+        ).history;
+        leakedInSecondRun = history.some(
+          (entry) =>
+            entry.role === "user" &&
+            Array.isArray(entry.parts) &&
+            entry.parts.some((part) => part.text === note),
+        );
+      }
+
+      return {
+        actions: [],
+        message: `step-${callIndex}`,
+        completed: callIndex === 1 || callIndex === 3,
+        usage,
+      };
+    });
+
+    client.addContextNote(note);
+
+    await client.execute({
+      options: { instruction: "first run", maxSteps: 5 } as never,
+      logger: noopLogger,
+    });
+
+    await client.execute({
+      options: { instruction: "second run", maxSteps: 5 } as never,
+      logger: noopLogger,
+    });
+
+    expect(leakedInSecondRun).toBe(false);
   });
 
   it("injects Microsoft context notes once into conversation history between turns", async () => {
@@ -198,5 +310,65 @@ describe("CUA context note parity", () => {
       (entry) => entry.role === "user" && entry.content === note,
     ).length;
     expect(noteMessageCount).toBe(1);
+  });
+
+  it("does not carry Microsoft context notes into a new execution after terminal step", async () => {
+    const note = "captcha solved: continue and do not click again";
+    const client = new MicrosoftCUAClient(
+      "microsoft",
+      "microsoft/fara-7b",
+      undefined,
+      {
+        apiKey: "test-key",
+        baseURL: "https://example.com/v1",
+      },
+    );
+
+    const executeStepSpy = vi.spyOn(
+      client as unknown as {
+        executeStep: (
+          logger: typeof noopLogger,
+          isFirstRound?: boolean,
+        ) => Promise<unknown>;
+      },
+      "executeStep",
+    );
+
+    let callIndex = 0;
+    let leakedInSecondRun = false;
+    executeStepSpy.mockImplementation(async () => {
+      callIndex += 1;
+
+      if (callIndex === 3) {
+        const history = (
+          client as unknown as {
+            conversationHistory: Array<{ role?: string; content?: unknown }>;
+          }
+        ).conversationHistory;
+        leakedInSecondRun = history.some(
+          (entry) => entry.role === "user" && entry.content === note,
+        );
+      }
+
+      return {
+        actions: [],
+        completed: callIndex === 1 || callIndex === 3,
+        usage,
+      };
+    });
+
+    client.addContextNote(note);
+
+    await client.execute({
+      options: { instruction: "first run", maxSteps: 5 } as never,
+      logger: noopLogger,
+    });
+
+    await client.execute({
+      options: { instruction: "second run", maxSteps: 5 } as never,
+      logger: noopLogger,
+    });
+
+    expect(leakedInSecondRun).toBe(false);
   });
 });

--- a/packages/core/tests/unit/cua-context-note-parity.test.ts
+++ b/packages/core/tests/unit/cua-context-note-parity.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it, vi } from "vitest";
+import { AnthropicCUAClient } from "../../lib/v3/agent/AnthropicCUAClient.js";
+import { GoogleCUAClient } from "../../lib/v3/agent/GoogleCUAClient.js";
+import { MicrosoftCUAClient } from "../../lib/v3/agent/MicrosoftCUAClient.js";
+
+const usage = {
+  input_tokens: 0,
+  output_tokens: 0,
+  inference_time_ms: 0,
+};
+
+const noopLogger = vi.fn();
+
+describe("CUA context note parity", () => {
+  it("injects Anthropic context notes into the next turn only", async () => {
+    const note = "captcha solved: continue and do not click again";
+    const client = new AnthropicCUAClient(
+      "anthropic",
+      "anthropic/claude-sonnet-4-6",
+      undefined,
+      { apiKey: "test-key" },
+    );
+
+    const executeStepSpy = vi.spyOn(
+      client as unknown as {
+        executeStep: (
+          inputItems: unknown[],
+          logger: typeof noopLogger,
+        ) => Promise<unknown>;
+      },
+      "executeStep",
+    );
+
+    let step = 0;
+    executeStepSpy.mockImplementation(async () => {
+      step += 1;
+      return {
+        actions: [],
+        message: `step-${step}`,
+        completed: step >= 3,
+        nextInputItems: [],
+        usage,
+      };
+    });
+
+    client.addContextNote(note);
+
+    await client.execute({
+      options: { instruction: "test", maxSteps: 5 } as never,
+      logger: noopLogger,
+    });
+
+    expect(executeStepSpy).toHaveBeenCalledTimes(3);
+
+    const step2Input = executeStepSpy.mock.calls[1]?.[0] as Array<{
+      role?: string;
+      content?: string;
+    }>;
+    const step3Input = executeStepSpy.mock.calls[2]?.[0] as Array<{
+      role?: string;
+      content?: string;
+    }>;
+
+    expect(
+      step2Input.some((item) => item.role === "user" && item.content === note),
+    ).toBe(true);
+    expect(
+      step3Input.some((item) => item.role === "user" && item.content === note),
+    ).toBe(false);
+  });
+
+  it("injects Google context notes once into history between turns", async () => {
+    const note = "captcha solved: continue and do not click again";
+    const client = new GoogleCUAClient(
+      "google",
+      "google/gemini-3-flash-preview",
+    );
+
+    const executeStepSpy = vi.spyOn(
+      client as unknown as {
+        executeStep: (logger: typeof noopLogger) => Promise<unknown>;
+      },
+      "executeStep",
+    );
+
+    let step = 0;
+    let sawNoteBeforeSecondStep = false;
+    executeStepSpy.mockImplementation(async () => {
+      step += 1;
+
+      if (step === 2) {
+        const history = (
+          client as unknown as {
+            history: Array<{ role?: string; parts?: Array<{ text?: string }> }>;
+          }
+        ).history;
+        sawNoteBeforeSecondStep = history.some(
+          (entry) =>
+            entry.role === "user" &&
+            Array.isArray(entry.parts) &&
+            entry.parts.some((part) => part.text === note),
+        );
+      }
+
+      return {
+        actions: [],
+        message: `step-${step}`,
+        completed: step >= 3,
+        usage,
+      };
+    });
+
+    client.addContextNote(note);
+
+    await client.execute({
+      options: { instruction: "test", maxSteps: 5 } as never,
+      logger: noopLogger,
+    });
+
+    expect(executeStepSpy).toHaveBeenCalledTimes(3);
+    expect(sawNoteBeforeSecondStep).toBe(true);
+
+    const finalHistory = (
+      client as unknown as {
+        history: Array<{ role?: string; parts?: Array<{ text?: string }> }>;
+      }
+    ).history;
+    const noteMessageCount = finalHistory.filter(
+      (entry) =>
+        entry.role === "user" &&
+        Array.isArray(entry.parts) &&
+        entry.parts.some((part) => part.text === note),
+    ).length;
+    expect(noteMessageCount).toBe(1);
+  });
+
+  it("injects Microsoft context notes once into conversation history between turns", async () => {
+    const note = "captcha solved: continue and do not click again";
+    const client = new MicrosoftCUAClient(
+      "microsoft",
+      "microsoft/fara-7b",
+      undefined,
+      {
+        apiKey: "test-key",
+        baseURL: "https://example.com/v1",
+      },
+    );
+
+    const executeStepSpy = vi.spyOn(
+      client as unknown as {
+        executeStep: (
+          logger: typeof noopLogger,
+          isFirstRound?: boolean,
+        ) => Promise<unknown>;
+      },
+      "executeStep",
+    );
+
+    let step = 0;
+    let sawNoteBeforeSecondStep = false;
+    executeStepSpy.mockImplementation(async () => {
+      step += 1;
+
+      if (step === 2) {
+        const history = (
+          client as unknown as {
+            conversationHistory: Array<{ role?: string; content?: unknown }>;
+          }
+        ).conversationHistory;
+        sawNoteBeforeSecondStep = history.some(
+          (entry) => entry.role === "user" && entry.content === note,
+        );
+      }
+
+      return {
+        actions: [],
+        completed: step >= 3,
+        usage,
+      };
+    });
+
+    client.addContextNote(note);
+
+    await client.execute({
+      options: { instruction: "test", maxSteps: 5 } as never,
+      logger: noopLogger,
+    });
+
+    expect(executeStepSpy).toHaveBeenCalledTimes(3);
+    expect(sawNoteBeforeSecondStep).toBe(true);
+
+    const finalHistory = (
+      client as unknown as {
+        conversationHistory: Array<{ role?: string; content?: unknown }>;
+      }
+    ).conversationHistory;
+    const noteMessageCount = finalHistory.filter(
+      (entry) => entry.role === "user" && entry.content === note,
+    ).length;
+    expect(noteMessageCount).toBe(1);
+  });
+});


### PR DESCRIPTION
﻿## why

`V3CuaAgentHandler` injects runtime captcha guidance via `addContextNote(...)`, but only `OpenAICUAClient` consumed those notes.

That meant Google/Anthropic/Microsoft CUA clients silently dropped this guidance, causing behavior drift in captcha-related flows.

Closes #2037.

## what changed

- Added pending context-note queue support to:
  - `GoogleCUAClient`
  - `AnthropicCUAClient`
  - `MicrosoftCUAClient`
- Implemented `addContextNote(note)` override in each client.
- Added one-shot drain semantics (`drainContextNotes`) in each client.
- Injected drained notes into the next turn only:
  - Google: append user text message to `history`
  - Anthropic: append user message(s) to `nextInputItems`
  - Microsoft: append user message(s) to `conversationHistory`

## tests

Added `packages/core/tests/unit/cua-context-note-parity.test.ts` covering:
- Anthropic: note appears in next turn input, not subsequent turn
- Google: note appears once in history between turns
- Microsoft: note appears once in conversation history between turns

Regression check run:
- `tests/unit/openai-cua-client.test.ts`

## validation run

- `npm.cmd exec prettier -- --write packages/core/lib/v3/agent/GoogleCUAClient.ts packages/core/lib/v3/agent/AnthropicCUAClient.ts packages/core/lib/v3/agent/MicrosoftCUAClient.ts packages/core/tests/unit/cua-context-note-parity.test.ts`
- `node node_modules/vitest/vitest.mjs run --config .tmp-vitest-unit-config.mjs` from `packages/core` (temporary local config targeting:
  - `tests/unit/cua-context-note-parity.test.ts`
  - `tests/unit/openai-cua-client.test.ts`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds parity for `addContextNote` across CUA providers so runtime captcha guidance is applied consistently; notes are injected once on the next turn and drained on terminal steps to avoid leaks. Fixes #2037.

- **Bug Fixes**
  - Implemented pending context-note queue and `addContextNote(...)` in `GoogleCUAClient`, `AnthropicCUAClient`, and `MicrosoftCUAClient`.
  - One-shot semantics: inject on next turn (Google → `history`, Anthropic → `nextInputItems`, Microsoft → `conversationHistory`) and drain on terminal steps to prevent carry-over.
  - Added unit tests for next-turn injection and no leakage across executions.

<sup>Written for commit 49e832d751663e8e2b13aa56d20b680e2226a310. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2038">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

