### PR TITLE
[STG-1808] Deprecate Browserbase project ID

### DIFF
--- a/.changeset/yummy-poets-fail.md
+++ b/.changeset/yummy-poets-fail.md
@@ -1,0 +1,6 @@
+---
+"@browserbasehq/stagehand-server-v3": patch
+"@browserbasehq/stagehand": patch
+---
+
+Deprecate Browserbase project ID configuration.

--- a/packages/core/lib/v3/types/public/api.ts
+++ b/packages/core/lib/v3/types/public/api.ts
@@ -298,7 +298,11 @@ export const BrowserbaseRegionSchema = z
 /** Browserbase session creation parameters */
 export const BrowserbaseSessionCreateParamsSchema = z
   .object({
-    projectId: z.string().optional(),
+    projectId: z.string().optional().meta({
+      deprecated: true,
+      description:
+        "Deprecated. Browserbase API keys are now project-scoped, so this field is no longer required.",
+    }),
     browserSettings: BrowserbaseBrowserSettingsSchema.optional(),
     extensionId: z.string().optional(),
     keepAlive: z.boolean().optional(),
@@ -975,7 +979,8 @@ export const openApiSecuritySchemes = {
     type: "apiKey",
     in: "header",
     name: "x-bb-project-id",
-    description: "Browserbase project ID",
+    description:
+      "Deprecated. Browserbase API keys are now project-scoped, so this header is no longer required.",
   },
   ModelApiKey: {
     type: "apiKey",

--- a/packages/server-v3/openapi.v3.yaml
+++ b/packages/server-v3/openapi.v3.yaml
@@ -32,7 +32,8 @@ components:
       type: apiKey
       in: header
       name: x-bb-project-id
-      description: Browserbase project ID
+      description: Deprecated. Browserbase API keys are now project-scoped, so this
+        header is no longer required.
     ModelApiKey:
       type: apiKey
       in: header
@@ -428,6 +429,9 @@ components:
       type: object
       properties:
         projectId:
+          deprecated: true
+          description: Deprecated. Browserbase API keys are now project-scoped, so this
+            field is no longer required.
           type: string
         browserSettings:
           $ref: "#/components/schemas/BrowserbaseBrowserSettings"
@@ -1469,6 +1473,9 @@ components:
       type: object
       properties:
         projectId:
+          deprecated: true
+          description: Deprecated. Browserbase API keys are now project-scoped, so this
+            field is no longer required.
           type: string
         browserSettings:
           $ref: "#/components/schemas/BrowserbaseBrowserSettingsOutput"

--- a/packages/server-v3/src/lib/stream.ts
+++ b/packages/server-v3/src/lib/stream.ts
@@ -51,18 +51,16 @@ export async function createStreamingResponse<TV3>({
   const browserType = sessionConfig.browserType ?? "local";
 
   let browserbaseApiKey = sessionConfig.browserbaseApiKey;
-  let browserbaseProjectId = sessionConfig.browserbaseProjectId;
+  const browserbaseProjectId = sessionConfig.browserbaseProjectId;
 
   if (browserType === "browserbase") {
     browserbaseApiKey =
       browserbaseApiKey ?? getOptionalHeader(request, "x-bb-api-key");
-    browserbaseProjectId =
-      browserbaseProjectId ?? getOptionalHeader(request, "x-bb-project-id");
 
     if (!browserbaseApiKey || !browserbaseProjectId) {
       return reply.status(StatusCodes.BAD_REQUEST).send({
         error:
-          "Browserbase API key and project ID are required for browserbase sessions",
+          "Browserbase API key and resolved project ID are required for browserbase sessions",
       });
     }
   }

--- a/packages/server-v3/src/routes/v1/sessions/start.ts
+++ b/packages/server-v3/src/routes/v1/sessions/start.ts
@@ -112,13 +112,12 @@ const startRouteHandler: RouteHandler = withErrorHandling(
     const browserType = browser?.type ?? "browserbase";
 
     let bbApiKey: string | undefined;
-    let bbProjectId: string | undefined;
+    let browserbaseProjectId: string | undefined;
     let browserbaseSessionId: string | undefined;
     let connectUrl: string | undefined;
 
     if (browserType === "browserbase") {
       bbApiKey = getOptionalHeader(request, "x-bb-api-key");
-      bbProjectId = getOptionalHeader(request, "x-bb-project-id");
 
       if (!bbApiKey) {
         return error(
@@ -132,6 +131,7 @@ const startRouteHandler: RouteHandler = withErrorHandling(
       if (browserbaseSessionID) {
         const existing = await bb.sessions.retrieve(browserbaseSessionID);
         browserbaseSessionId = existing?.id;
+        browserbaseProjectId = existing?.projectId;
         connectUrl = existing?.connectUrl;
         if (!browserbaseSessionId) {
           return error(reply, "Failed to retrieve browserbase session");
@@ -140,10 +140,7 @@ const startRouteHandler: RouteHandler = withErrorHandling(
           return error(reply, "Browserbase session missing connectUrl");
         }
       } else {
-        const resolvedProjectId =
-          browserbaseSessionCreateParams?.projectId ?? bbProjectId;
         const createPayload = {
-          ...(resolvedProjectId ? { projectId: resolvedProjectId } : {}),
           ...browserbaseSessionCreateParams,
           browserSettings: {
             ...(browserbaseSessionCreateParams?.browserSettings ?? {}),
@@ -164,6 +161,7 @@ const startRouteHandler: RouteHandler = withErrorHandling(
         )) as SessionRetrieveResponse;
 
         browserbaseSessionId = created?.id;
+        browserbaseProjectId = created?.projectId;
         connectUrl = created?.connectUrl;
         if (!browserbaseSessionId) {
           return error(reply, "Failed to create browserbase session");
@@ -189,7 +187,7 @@ const startRouteHandler: RouteHandler = withErrorHandling(
           ? (browserbaseSessionId ?? browserbaseSessionID)
           : undefined,
       browserbaseApiKey: bbApiKey,
-      browserbaseProjectId: bbProjectId,
+      browserbaseProjectId,
       modelName,
       domSettleTimeoutMs,
       verbose,

--- a/stainless.yml
+++ b/stainless.yml
@@ -229,8 +229,8 @@ client_settings:
     BROWSERBASE_PROJECT_ID:
       type: string
       read_env: BROWSERBASE_PROJECT_ID
-      description: Your [Browserbase Project ID](https://www.browserbase.com/settings)
-      nullable: false
+      description: Deprecated. Browserbase API keys are now project-scoped, so this value is no longer required.
+      nullable: true
       auth:
         security_scheme: BBProjectIdAuth
     MODEL_API_KEY:


### PR DESCRIPTION
# why
Browserbase API keys are project-scoped, so Stagehand should keep accepting project IDs without requiring them.

# what changed
- Mark `browserbaseSessionCreateParams.projectId` deprecated in Zod/OpenAPI.
- Make `BROWSERBASE_PROJECT_ID` nullable/deprecated in Stainless config.
- Use Browserbase-returned `projectId` in the local server instead of `x-bb-project-id`.

```ts
projectId: z.string().optional().meta({ deprecated: true })
```

# test plan
- `pnpm --filter @browserbasehq/stagehand run lint`
- `pnpm --filter @browserbasehq/stagehand-server-v3 run lint`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deprecate Browserbase project ID per STG-1808; Stagehand now relies on project-scoped API keys and the project ID returned by Browserbase. The `x-bb-project-id` header, session `projectId` param, and `BROWSERBASE_PROJECT_ID` config are deprecated but remain optional for now.

- **Refactors**
  - Marked `projectId` in session create params as deprecated in Zod/OpenAPI; updated security scheme descriptions to reflect deprecation of `x-bb-project-id`.
  - Made `BROWSERBASE_PROJECT_ID` nullable and marked deprecated in `stainless.yml`.
  - Server now resolves `projectId` from the retrieved/created Browserbase session; stops reading `x-bb-project-id` and adjusts validation messages.

- **Migration**
  - Stop sending `x-bb-project-id` and remove `BROWSERBASE_PROJECT_ID`; they’re no longer needed.
  - Avoid passing `projectId` in session creation; it’s accepted but deprecated.

<sup>Written for commit 5ee90b860105739405927eec695060a1d1a066fc. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2039">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

