### PR TITLE
fix(core): add gpt-5.5 to CUA model support

### DIFF
--- a/packages/core/lib/v3/agent/AgentProvider.ts
+++ b/packages/core/lib/v3/agent/AgentProvider.ts
@@ -15,6 +15,7 @@ import { MicrosoftCUAClient } from "./MicrosoftCUAClient.js";
 // Map model names to their provider types
 export const modelToAgentProviderMap: Record<string, AgentProviderType> = {
   "gpt-5.4": "openai",
+  "gpt-5.5": "openai",
   "computer-use-preview": "openai",
   "computer-use-preview-2025-03-11": "openai",
   "claude-sonnet-4-20250514": "anthropic",

--- a/packages/core/lib/v3/types/public/agent.ts
+++ b/packages/core/lib/v3/types/public/agent.ts
@@ -450,6 +450,7 @@ export type AgentType =
 
 export const AVAILABLE_CUA_MODELS = [
   "openai/gpt-5.4",
+  "openai/gpt-5.5",
   "openai/computer-use-preview",
   "openai/computer-use-preview-2025-03-11",
   "anthropic/claude-opus-4-5-20251101",

--- a/packages/core/tests/unit/public-api/llm-and-agents.test.ts
+++ b/packages/core/tests/unit/public-api/llm-and-agents.test.ts
@@ -40,6 +40,7 @@ describe("LLM and Agents public API types", () => {
       "openai/computer-use-preview",
       "openai/computer-use-preview-2025-03-11",
       "openai/gpt-5.4",
+      "openai/gpt-5.5",
       "anthropic/claude-opus-4-5-20251101",
       "anthropic/claude-opus-4-6",
       "anthropic/claude-sonnet-4-6",


### PR DESCRIPTION
## why
`openai/gpt-5.5` was missing from the CUA model allowlist/mapping, so CUA mode rejected it even though `gpt-5.4` was already supported.

Closes #2041.

## what changed
- Added `gpt-5.5` -> `openai` in `modelToAgentProviderMap`
- Added `openai/gpt-5.5` to `AVAILABLE_CUA_MODELS`
- Updated public API unit test expected CUA model list

## test plan
- `node node_modules/vitest/vitest.mjs run --config .tmp-vitest-public-api-config.mjs`
  - `tests/unit/public-api/llm-and-agents.test.ts`
- `npm.cmd exec prettier -- --write` on touched files


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CUA support for `openai/gpt-5.5`, which was missing and caused the model to be rejected in CUA mode.
Maps `gpt-5.5` to `openai` in `modelToAgentProviderMap`, adds it to `AVAILABLE_CUA_MODELS`, and updates the public API test.

<sup>Written for commit 05fac0bf2994ec05b2ffc451bb30edf2c2246d46. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2042">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

