### PR TITLE
fix(core): honor maxImages in Anthropic CUA

### DIFF
--- a/packages/core/lib/v3/agent/AnthropicCUAClient.ts
+++ b/packages/core/lib/v3/agent/AnthropicCUAClient.ts
@@ -46,6 +46,7 @@ export class AnthropicCUAClient extends AgentClient {
   private thinkingBudget: number | null = null;
   private thinkingEffort: ThinkingEffort | null = null;
   private userTemperature: number | undefined;
+  private maxImages: number = 2;
   private tools?: ToolSet;
 
   constructor(
@@ -77,6 +78,10 @@ export class AnthropicCUAClient extends AgentClient {
 
     // Track user-specified temperature so we can warn if adaptive thinking overrides it
     this.userTemperature = clientOptions?.temperature;
+
+    if (clientOptions?.maxImages !== undefined) {
+      this.maxImages = clientOptions.maxImages as number;
+    }
 
     // Store client options for reference
     this.clientOptions = {
@@ -360,7 +365,9 @@ export class AnthropicCUAClient extends AgentClient {
       const nextInputItems: ResponseInputItem[] = [...inputItems];
 
       // Add the assistant message with tool_use blocks to the history
-      compressConversationImages(nextInputItems);
+      if (this.maxImages > 0) {
+        compressConversationImages(nextInputItems, this.maxImages);
+      }
 
       nextInputItems.push(assistantMessage);
 

--- a/packages/core/lib/v3/types/public/model.ts
+++ b/packages/core/lib/v3/types/public/model.ts
@@ -135,7 +135,7 @@ export type ClientOptions = (
   thinkingEffort?: ThinkingEffort;
   /** Environment type for CUA agents (browser, mac, windows, ubuntu) */
   environment?: string;
-  /** Max images for Microsoft FARA agent */
+  /** Max images to keep in CUA screenshot history for supported providers */
   maxImages?: number;
   /** Temperature for model inference */
   temperature?: number;

--- a/packages/core/tests/unit/anthropic-cua-max-images.test.ts
+++ b/packages/core/tests/unit/anthropic-cua-max-images.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from "vitest";
+import { AnthropicCUAClient } from "../../lib/v3/agent/AnthropicCUAClient.js";
+
+type AnthropicInputMessage = {
+  role: "user" | "assistant";
+  content: Array<{
+    type: "tool_result";
+    tool_use_id: string;
+    content:
+      | string
+      | Array<{
+          type: "image";
+          source: {
+            type: "base64";
+            media_type: "image/png";
+            data: string;
+          };
+        }>;
+  }>;
+};
+
+const logger = vi.fn();
+
+function makeImageMessage(id: string): AnthropicInputMessage {
+  return {
+    role: "user",
+    content: [
+      {
+        type: "tool_result",
+        tool_use_id: id,
+        content: [
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/png",
+              data: `${id}-image-data`,
+            },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function isCompressed(message: AnthropicInputMessage): boolean {
+  return message.content.some(
+    (contentItem) => contentItem.content === "screenshot taken",
+  );
+}
+
+describe("AnthropicCUAClient maxImages", () => {
+  it("keeps two most recent screenshot items by default", async () => {
+    const client = new AnthropicCUAClient(
+      "anthropic",
+      "anthropic/claude-sonnet-4-6",
+      undefined,
+      { apiKey: "test-key" },
+    );
+
+    vi.spyOn(client, "getAction").mockResolvedValue({
+      content: [{ type: "text", text: "done" }] as never,
+      usage: { input_tokens: 1, output_tokens: 1, inference_time_ms: 1 },
+    });
+
+    const inputItems = [
+      makeImageMessage("oldest"),
+      makeImageMessage("middle"),
+      makeImageMessage("newest"),
+    ] as never;
+
+    const result = await client.executeStep(inputItems, logger);
+    const updated = result.nextInputItems.slice(
+      0,
+      3,
+    ) as AnthropicInputMessage[];
+
+    expect(isCompressed(updated[0])).toBe(true);
+    expect(isCompressed(updated[1])).toBe(false);
+    expect(isCompressed(updated[2])).toBe(false);
+  });
+
+  it("keeps only one recent screenshot item when maxImages is set to 1", async () => {
+    const client = new AnthropicCUAClient(
+      "anthropic",
+      "anthropic/claude-sonnet-4-6",
+      undefined,
+      { apiKey: "test-key", maxImages: 1 },
+    );
+
+    vi.spyOn(client, "getAction").mockResolvedValue({
+      content: [{ type: "text", text: "done" }] as never,
+      usage: { input_tokens: 1, output_tokens: 1, inference_time_ms: 1 },
+    });
+
+    const inputItems = [
+      makeImageMessage("oldest"),
+      makeImageMessage("middle"),
+      makeImageMessage("newest"),
+    ] as never;
+
+    const result = await client.executeStep(inputItems, logger);
+    const updated = result.nextInputItems.slice(
+      0,
+      3,
+    ) as AnthropicInputMessage[];
+
+    expect(isCompressed(updated[0])).toBe(true);
+    expect(isCompressed(updated[1])).toBe(true);
+    expect(isCompressed(updated[2])).toBe(false);
+  });
+
+  it("disables screenshot compression when maxImages is 0", async () => {
+    const client = new AnthropicCUAClient(
+      "anthropic",
+      "anthropic/claude-sonnet-4-6",
+      undefined,
+      { apiKey: "test-key", maxImages: 0 },
+    );
+
+    vi.spyOn(client, "getAction").mockResolvedValue({
+      content: [{ type: "text", text: "done" }] as never,
+      usage: { input_tokens: 1, output_tokens: 1, inference_time_ms: 1 },
+    });
+
+    const inputItems = [
+      makeImageMessage("oldest"),
+      makeImageMessage("middle"),
+      makeImageMessage("newest"),
+    ] as never;
+
+    const result = await client.executeStep(inputItems, logger);
+    const updated = result.nextInputItems.slice(
+      0,
+      3,
+    ) as AnthropicInputMessage[];
+
+    expect(isCompressed(updated[0])).toBe(false);
+    expect(isCompressed(updated[1])).toBe(false);
+    expect(isCompressed(updated[2])).toBe(false);
+  });
+});


### PR DESCRIPTION
## why
`ClientOptions.maxImages` was not honored by `AnthropicCUAClient`, so Anthropic CUA always kept the default image retention behavior instead of using caller-configured limits.

Closes #2043.

## what changed
- Added `maxImages` handling in `AnthropicCUAClient` constructor
- Applied `maxImages` to `compressConversationImages(...)` in step processing
- Preserved existing default behavior (`2`) when option is unset
- Updated `ClientOptions.maxImages` comment to reflect CUA support beyond Microsoft
- Added unit tests for:
  - default keep-2 behavior
  - keep-1 override
  - `maxImages=0` (no compression)

## test plan
- `node node_modules/vitest/vitest.mjs run --config .tmp-vitest-anthropic-max-images.mjs`
  - `tests/unit/anthropic-cua-max-images.test.ts`
- `npm.cmd exec prettier -- --write` on touched files


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors `maxImages` in `AnthropicCUAClient` so Anthropic CUA keeps the caller-configured number of screenshots (default 2). This fixes screenshot retention limits not being applied.

- **Bug Fixes**
  - Read `maxImages` from `ClientOptions` and pass it to `compressConversationImages` during step processing.
  - Keep default 2 when unset; `maxImages=0` disables compression.
  - Update `ClientOptions.maxImages` docs for CUA support and add unit tests for default, 1, and 0 cases.

<sup>Written for commit fdc61332ad76fdf710252f934ff9eb7b3cca8a3b. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2044">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

