### PR TITLE
fix(server-v4): accept expect* options on /v4/page/click

### DIFF
--- a/packages/server-v4/openapi.v4.yaml
+++ b/packages/server-v4/openapi.v4.yaml
@@ -2715,6 +2715,12 @@ components:
           enum:
             - jsevent
             - xy
+        expectDownload:
+          type: boolean
+        expectNavigation:
+          type: boolean
+        expectPopup:
+          type: boolean
       required:
         - selector
       additionalProperties: false
@@ -6585,6 +6591,12 @@ components:
           enum:
             - jsevent
             - xy
+        expectDownload:
+          type: boolean
+        expectNavigation:
+          type: boolean
+        expectPopup:
+          type: boolean
       required:
         - selector
         - method

--- a/packages/server-v4/src/schemas/v4/page.ts
+++ b/packages/server-v4/src/schemas/v4/page.ts
@@ -277,7 +277,9 @@ export const PageClickParamsSchema = PageWithPageIdSchema.extend({
   clickCount: z.number().int().lte(3).gte(1).optional(),
   returnSelector: z.boolean().default(false).optional(),
   method: z.enum(["jsevent", "xy"]).default("xy"),
-  // TODO: add expectDownload, expectNavigation, expectPopup  OR expect: z.enum(...)
+  expectDownload: z.boolean().optional(),
+  expectNavigation: z.boolean().optional(),
+  expectPopup: z.boolean().optional(),
 })
   .strict()
   .meta({ id: "PageClickParams" });

--- a/packages/server-v4/test/integration/v4/page.test.ts
+++ b/packages/server-v4/test/integration/v4/page.test.ts
@@ -932,6 +932,22 @@ describe("v4 page routes", { concurrency: false }, () => {
     assertSuccessAction(jseventCtx, "click");
   });
 
+  it("POST /v4/page/click accepts expect* options", async () => {
+    const gotoCtx = await postPageRoute("goto", sessionId, {
+      url: CLICK_TEST_URL,
+      waitUntil: "load",
+    });
+    assertSuccessAction(gotoCtx, "goto");
+
+    const clickCtx = await postPageRoute("click", sessionId, {
+      selector: { css: "#click-target" },
+      expectNavigation: true,
+      expectPopup: false,
+      expectDownload: false,
+    });
+    assertSuccessAction(clickCtx, "click");
+  });
+
   it("POST /v4/page/dragAndDrop accepts mixed selector types (xpath from, coordinates to)", async () => {
     const gotoCtx = await postPageRoute("goto", sessionId, {
       url: METHODS_TEST_URL,


### PR DESCRIPTION
## why

`/v4/page/click` still had a schema TODO for click expectation flags and rejected payloads containing `expectDownload`, `expectNavigation`, or `expectPopup`.

Closes #2051.

## what changed

- Updated `PageClickParamsSchema` to accept optional booleans:
  - `expectDownload`
  - `expectNavigation`
  - `expectPopup`
- Added integration coverage in `page.test.ts` to assert `/v4/page/click` accepts `expect*` options.
- Regenerated `packages/server-v4/openapi.v4.yaml` so the new click params are documented.

## validation

- `npm.cmd exec prettier -- --write packages/server-v4/src/schemas/v4/page.ts packages/server-v4/test/integration/v4/page.test.ts`
- `node node_modules/typescript/bin/tsc -p packages/server-v4/tsconfig.json --noEmit`
- `node --import=tsx -e "...app.inject('/v4/page/click' with expect* params)..."` (status `200`)
- `node --import=tsx packages/server-v4/scripts/gen-openapi.ts`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated `/v4/page/click` to accept `expectDownload`, `expectNavigation`, and `expectPopup` so clients can declare expected side-effects. This fixes rejected payloads and documents the new params.

- **Bug Fixes**
  - Extended `PageClickParamsSchema` with optional booleans: `expectDownload`, `expectNavigation`, `expectPopup`.
  - Added integration test to confirm `/v4/page/click` accepts these options.
  - Regenerated `packages/server-v4/openapi.v4.yaml` to include the new params.

<sup>Written for commit dd81cd4fac704274ecb8df2c1e7986a4a4e75d12. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2052">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

