### PR TITLE
feat(cli): emit Page.lifecycleEvent in `browse cdp`

### DIFF
--- a/.changeset/cdp-lifecycle-events.md
+++ b/.changeset/cdp-lifecycle-events.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/browse-cli": patch
+---
+
+`browse cdp` now also calls `Page.setLifecycleEventsEnabled` whenever the Page domain is enabled, so consumers receive `Page.lifecycleEvent` notifications (`init`, `commit`, `DOMContentLoaded`, `load`, `firstPaint`, `firstContentfulPaint`, `networkAlmostIdle`, `networkIdle`, etc.) in addition to `Page.frameNavigated`. `--pretty` mode formats lifecycle events with the milestone name. No effect on consumers that pass `--domain` without `Page`.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2754,6 +2754,18 @@ program
           } else {
             sendCDP(ws, `${domain}.enable`, {}, sessionId);
           }
+
+          // Page.enable does not emit Page.lifecycleEvent on its own; it requires
+          // a separate opt-in. Enable it so consumers see DOMContentLoaded, load,
+          // firstPaint, networkIdle, etc.
+          if (domain === "Page") {
+            sendCDP(
+              ws,
+              "Page.setLifecycleEventsEnabled",
+              { enabled: true },
+              sessionId,
+            );
+          }
         }
       }
 
@@ -2820,6 +2832,11 @@ program
             case "Page.frameNavigated": {
               const url = (params?.frame as { url?: string })?.url ?? "";
               if (url) line += ` ${url}`;
+              break;
+            }
+            case "Page.lifecycleEvent": {
+              const name = (params?.name as string) ?? "";
+              if (name) line += ` ${name}`;
               break;
             }
             case "Target.attachedToTarget": {


### PR DESCRIPTION
## Summary

`browse cdp` enables the Page domain via `Page.enable`, but `Page.enable` does not by itself emit `Page.lifecycleEvent` — that requires a separate `Page.setLifecycleEventsEnabled` opt-in. As a result, consumers of `browse cdp` today see only `Page.frameNavigated` and miss the granular lifecycle milestones (`init`, `commit`, `DOMContentLoaded`, `load`, `firstPaint`, `firstContentfulPaint`, `firstMeaningfulPaint`, `networkAlmostIdle`, `networkIdle`).

This PR enables lifecycle events whenever the Page domain is enabled (so it covers both the default-domain set and explicit `--domain Page`), and adds a `--pretty` formatter case that prints the milestone name.

## Why

These events are exactly what observability/perf tools want from the firehose:

- approximate page-ready timing (`DOMContentLoaded` / `load`)
- network-settled signal (`networkIdle`)
- paint timing (`firstPaint` / `firstContentfulPaint` / `firstMeaningfulPaint`)

Without the opt-in, all of those have to be approximated from `Page.frameNavigated` + `Network.loadingFinished`, which loses the per-milestone resolution.

## Verification

Built locally with `pnpm exec tsx src/index.ts cdp 9333` against a debuggable Chrome and triggered an `example.com` navigation. Before this patch, no `Page.lifecycleEvent` lines. After:

```
[Page.lifecycleEvent] init
[Page.lifecycleEvent] commit
[Page.lifecycleEvent] DOMContentLoaded
[Page.lifecycleEvent] firstPaint
[Page.lifecycleEvent] firstContentfulPaint
[Page.lifecycleEvent] firstMeaningfulPaint
[Page.lifecycleEvent] load
[Page.lifecycleEvent] networkAlmostIdle
[Page.lifecycleEvent] networkIdle
```

Default mode (NDJSON) emits the same events with full params:

```json
{"sessionId":"…","method":"Page.lifecycleEvent","params":{"frameId":"…","loaderId":"…","name":"DOMContentLoaded","timestamp":468107.080156}}
```

## Test plan

- [ ] `pnpm --filter @browserbasehq/browse-cli typecheck` passes
- [ ] `pnpm --filter @browserbasehq/browse-cli eslint` passes
- [ ] `pnpm --filter @browserbasehq/browse-cli test` — no new failures (pre-existing failures in `cli.test.ts` / `mode.test.ts` reproduce on `main` and are unrelated to this change)
- [ ] Manual: `browse cdp <port>` against a debuggable Chrome shows `Page.lifecycleEvent` lines after a navigation
- [ ] Manual: `browse cdp <port> --pretty` formats `[Page.lifecycleEvent] <name>`
- [ ] Manual: `browse cdp <port> --domain Network --domain Console` (no Page) emits no lifecycle events — the opt-in is gated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)