### PR TITLE
Remove docs changeset release metadata

### DIFF
--- a/packages/docs/CHANGELOG.md
+++ b/packages/docs/CHANGELOG.md
@@ -1,7 +1,0 @@
-# @browserbasehq/stagehand-docs
-
-## 1.0.1
-
-### Patch Changes
-
-- [#2017](https://github.com/browserbase/stagehand/pull/2017) [`6b9b46d`](https://github.com/browserbase/stagehand/commit/6b9b46d81e32ed475772bd6c2299782985eef65a) Thanks [@monadoid](https://github.com/monadoid)! - Document the optional MCP `start` `sessionId` parameter for attaching to an existing Browserbase session.

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@browserbasehq/stagehand-docs",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "",
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
# why
The docs-only changeset from PR #2017 created release metadata for a docs workspace package that should not be published to npm.

# what changed
Reverted the generated docs package changelog and version bump while keeping the actual MCP documentation updates intact.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed accidental release metadata for the docs workspace so it isn’t treated as a publishable package. Keeps the MCP docs from #2017 intact. Aligns with Linear STG-1869.

- **Bug Fixes**
  - Deleted `packages/docs/CHANGELOG.md`.
  - Reset `@browserbasehq/stagehand-docs` version to 1.0.0.

<sup>Written for commit ff9c8eb5122903c20745ebf5237137ea8797499c. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2057?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

