### PR TITLE
fix(cli): honor `--connect` on `browse env remote`

### DIFF
--- a/.changeset/fix-env-connect-flag.md
+++ b/.changeset/fix-env-connect-flag.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/browse-cli": patch
+---
+
+Fix `browse env remote --connect <session-id>` silently ignoring `--connect`. The env handler now writes the connect file when the flag is set (and removes it when switching to local mode), and restarts the daemon when the connect ID changes. Without this, the daemon would create a fresh companion session instead of resuming the requested one.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1980,7 +1980,18 @@ envCommand.action(
     // Always restart daemon when switching env to pick up new local config
     if (await isDaemonRunning(session)) {
       const currentMode = (await readCurrentMode(session)) ?? "local";
-      const needsRestart = currentMode !== mapped || mapped === "local"; // local always restarts to pick up strategy change
+      let currentConnect: string | null = null;
+      try {
+        currentConnect = (
+          await fs.readFile(getConnectPath(session), "utf-8")
+        ).trim();
+      } catch {
+        // no connect file
+      }
+      const desiredConnect = (opts.connect as string | undefined) ?? null;
+      const connectChanged = desiredConnect !== currentConnect;
+      const needsRestart =
+        currentMode !== mapped || mapped === "local" || connectChanged; // local always restarts to pick up strategy change
       if (!needsRestart) {
         // needsRestart is false only when currentMode === mapped && mapped !== "local"
         // (local always restarts to pick up strategy changes)
@@ -1994,6 +2005,20 @@ envCommand.action(
         return;
       }
       await stopDaemonAndCleanup(session);
+    }
+
+    // Persist --connect for the daemon to pick up at init time. Mirror the
+    // behaviour of the generic command dispatcher, but only manage the file
+    // when the user explicitly sets/unsets --connect on this invocation.
+    if (mapped === "browserbase" && opts.connect) {
+      await fs.writeFile(getConnectPath(session), opts.connect as string);
+    } else if (mapped !== "browserbase") {
+      // Switching to local: drop any stale connect file
+      try {
+        await fs.unlink(getConnectPath(session));
+      } catch {
+        // ignore
+      }
     }
 
     await ensureDaemon(session, isHeadless(opts));


### PR DESCRIPTION
## Summary

`bb browse env remote --connect <session-id>` (or `browse env remote --connect ...`) silently ignores the `--connect` flag.

The env handler currently writes only the mode override and starts the daemon. The connect file (which the daemon reads at init time to set `browserbaseSessionID`) is only managed by the generic command dispatcher. So in practice:

1. `browse env remote --connect <id>` → mode file written, daemon spawned
2. Daemon starts, no connect file present yet → defers session creation
3. `browse open <url>` → also writes connect file via the generic dispatcher, but the daemon has already created its own fresh session

Net effect: a brand-new companion session is created (tagged `browse_cli: true`), and the user's session ID is never resumed. Logs and recordings live on the companion session — not the one the user passed in.

## Fix

Two small changes to the env action:

1. **Write/unlink the connect file** alongside the mode override, scoped to `mapped === "browserbase"`. Switching to local removes any stale connect file.
2. **Restart the daemon when the connect ID changes.** The current `needsRestart` only checks mode; if you're already in remote mode and switch `--connect`, the daemon would otherwise stay running with the old session.

### Reproduction (before)

```
$ bb sessions create --keep-alive
{ "id": "abc-123", ... }
$ bb browse env remote --connect abc-123
{ "mode": "remote", "restarted": true }
$ bb browse open https://example.com
$ bb sessions list --q "user_metadata['browse_cli']:'true'"
# Returns a brand new session — abc-123 is untouched
```

### After

The user's `abc-123` session is the one that gets driven. No companion session is created.

## Test plan
- [ ] `browse env remote --connect <id>` followed by `browse open <url>` drives the supplied session (verify in dashboard)
- [ ] `browse env remote --connect <id1>` then `browse env remote --connect <id2>` restarts the daemon and switches sessions
- [ ] `browse env local` after `browse env remote --connect <id>` cleans up the connect file
- [ ] `browse env remote` (no `--connect`) still works and creates a fresh session

🤖 Generated with [Claude Code](https://claude.com/claude-code)