### PR TITLE
fix(cli): don't delete connect file when `--connect` is omitted

### DIFF
--- a/.changeset/fix-preserve-connect-file.md
+++ b/.changeset/fix-preserve-connect-file.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/browse-cli": patch
+---
+
+Fix the connect file being unlinked by every command that didn't itself pass `--connect`. After `browse env remote --connect <id>`, the next `browse open <url>` would race against the daemon's lazy initialization and delete the connect file before it could be read, causing a fresh companion session to be created instead of resuming the requested one. The connect file is now only managed when `--connect` is explicitly set on the current invocation.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1678,7 +1678,16 @@ async function runCommand(command: string, args: unknown[]): Promise<unknown> {
     }
   }
 
-  // Handle --connect flag: write session ID for daemon to read
+  // Handle --connect flag: write session ID for daemon to read.
+  //
+  // We only manage the connect file when the user explicitly passes
+  // --connect on this invocation. Unlinking it whenever --connect is
+  // omitted causes a race: `browse env remote --connect <id>` writes
+  // the file and spawns the daemon, but the daemon initializes lazily
+  // on first command. The very next command (e.g. `browse open <url>`)
+  // would land here without --connect and unlink the file before the
+  // daemon could read it, causing a fresh companion session to be
+  // created instead of resuming the requested one.
   if (opts.connect) {
     const desiredMode = await getDesiredMode(session);
     if (desiredMode === "local") {
@@ -1700,10 +1709,6 @@ async function runCommand(command: string, args: unknown[]): Promise<unknown> {
     }
 
     await fs.writeFile(getConnectPath(session), opts.connect);
-  } else {
-    try {
-      await fs.unlink(getConnectPath(session));
-    } catch {}
   }
 
   // Handle session params flags (--proxies, --advanced-stealth, etc.)


### PR DESCRIPTION
## Summary

The generic command dispatcher unconditionally unlinks the connect file whenever `--connect` is not present on the current invocation. This breaks the expected `browse env remote --connect <id>` → `browse open <url>` flow:

1. `browse env remote --connect <id>` writes the connect file and spawns the daemon
2. The daemon starts but initializes the browser **lazily** on first command
3. `browse open <url>` arrives → `opts.connect` is undefined → the dispatcher **unlinks the connect file**
4. The daemon then initializes, reads the (now-missing) connect file, and creates a brand-new companion session tagged `browse_cli: true`

Net effect: the user's session is never resumed. Logs and recordings end up on the companion session, not the one the user passed in.

## Fix

Remove the `else { unlink }` branch in the dispatcher. The connect file's lifecycle should be managed only when the user explicitly opts in or out via `--connect`, not as a side effect of unrelated commands.

```diff
-  } else {
-    try {
-      await fs.unlink(getConnectPath(session));
-    } catch {}
   }
```

This pairs naturally with the env handler change in #2059, which writes the connect file when `--connect` is passed to `env remote` and removes it when switching to `env local`.

### Reproduction (before)

```
$ bb sessions create --keep-alive
{ "id": "abc-123", ... }
$ bb browse env remote --connect abc-123
{ "mode": "remote", "restarted": true }
$ ls $TMPDIR/browse-default.connect    # exists
$ bb browse open https://example.com   # connect file silently deleted
$ ls $TMPDIR/browse-default.connect    # gone
$ bb sessions list --q "user_metadata['browse_cli']:'true'"
# A new session was created — abc-123 is untouched
```

### After

The connect file persists through subsequent commands. The daemon resumes `abc-123` instead of creating a companion.

## Test plan
- [ ] After `browse env remote --connect <id>`, running `browse open <url>` does not delete the connect file
- [ ] `browse open <url> --connect <other-id>` still updates the connect file (existing behavior preserved)
- [ ] Switching to `browse env local` cleans up the connect file (handled in #2059)

🤖 Generated with [Claude Code](https://claude.com/claude-code)