### PR TITLE
fix(cua): stop custom tools from leaving Gemini on stale screenshots

### DIFF
--- a/packages/core/lib/v3/agent/AnthropicCUAClient.ts
+++ b/packages/core/lib/v3/agent/AnthropicCUAClient.ts
@@ -27,6 +27,10 @@ import {
   extractLlmCuaResponseSummary,
 } from "../flowlogger/FlowLogger.js";
 import { v7 as uuidv7 } from "uuid";
+import {
+  DEFAULT_CUSTOM_TOOL_SUCCESS_RESULT,
+  formatCustomToolResult,
+} from "./utils/customToolResult.js";
 
 export type ResponseInputItem = AnthropicMessage | AnthropicToolResult;
 
@@ -702,7 +706,7 @@ export class AnthropicCUAClient extends AgentClient {
           });
         } else {
           // Handle custom tools
-          let toolResult = "Tool executed successfully";
+          let toolResult = DEFAULT_CUSTOM_TOOL_SUCCESS_RESULT;
           if (this.tools && item.name in this.tools) {
             try {
               const tool = this.tools[item.name];
@@ -717,7 +721,7 @@ export class AnthropicCUAClient extends AgentClient {
                 toolCallId: item.id,
                 messages: [],
               });
-              toolResult = JSON.stringify(result);
+              toolResult = formatCustomToolResult(result);
 
               logger({
                 category: "agent",

--- a/packages/core/lib/v3/agent/GoogleCUAClient.ts
+++ b/packages/core/lib/v3/agent/GoogleCUAClient.ts
@@ -486,6 +486,42 @@ export class GoogleCUAClient extends AgentClient {
 
       if (result.actions.length > 0) {
         let hasError = false;
+        let attemptedPostActionScreenshot = false;
+        let postActionScreenshotBase64: string | undefined;
+
+        const getPostActionScreenshotBase64 = async (): Promise<
+          string | undefined
+        > => {
+          if (attemptedPostActionScreenshot) {
+            return postActionScreenshotBase64;
+          }
+
+          attemptedPostActionScreenshot = true;
+
+          try {
+            logger({
+              category: "agent",
+              message: `Taking screenshot after executing ${result.actions.length} actions${hasError ? " (with errors)" : ""}`,
+              level: 2,
+            });
+
+            const screenshot = await this.captureScreenshot();
+            postActionScreenshotBase64 = screenshot.replace(
+              /^data:image\/png;base64,/,
+              "",
+            );
+
+            return postActionScreenshotBase64;
+          } catch (error) {
+            logger({
+              category: "agent",
+              message: `Error capturing screenshot: ${error}`,
+              level: 0,
+            });
+
+            return undefined;
+          }
+        };
 
         // Execute all actions
         for (let i = 0; i < result.actions.length; i++) {
@@ -559,6 +595,31 @@ export class GoogleCUAClient extends AgentClient {
           }
         }
 
+        if (functionResponses.length > 0) {
+          const base64Data = await getPostActionScreenshotBase64();
+          if (base64Data) {
+            for (const functionResponsePart of functionResponses) {
+              if (!functionResponsePart.functionResponse) {
+                continue;
+              }
+
+              functionResponsePart.functionResponse.response = {
+                url: this.currentUrl || "",
+                ...functionResponsePart.functionResponse.response,
+              };
+              functionResponsePart.functionResponse.parts = [
+                ...(functionResponsePart.functionResponse.parts || []),
+                {
+                  inlineData: {
+                    mimeType: "image/png",
+                    data: base64Data,
+                  },
+                },
+              ];
+            }
+          }
+        }
+
         // Create function responses for computer use actions (non-custom tools)
         // We need exactly one response per function call, regardless of how many actions were generated
         if (result.functionCalls.length > 0 || hasError) {
@@ -568,19 +629,9 @@ export class GoogleCUAClient extends AgentClient {
           );
 
           if (computerUseFunctionCalls.length > 0) {
-            try {
-              logger({
-                category: "agent",
-                message: `Taking screenshot after executing ${result.actions.length} actions${hasError ? " (with errors)" : ""}`,
-                level: 2,
-              });
+            const base64Data = await getPostActionScreenshotBase64();
 
-              const screenshot = await this.captureScreenshot();
-              const base64Data = screenshot.replace(
-                /^data:image\/png;base64,/,
-                "",
-              );
-
+            if (base64Data) {
               // Create one function response for each computer use function call
               // Following Python SDK pattern: FunctionResponse with parts containing inline_data
               for (const functionCall of computerUseFunctionCalls) {
@@ -615,12 +666,6 @@ export class GoogleCUAClient extends AgentClient {
                 };
                 functionResponses.push(functionResponsePart);
               }
-            } catch (error) {
-              logger({
-                category: "agent",
-                message: `Error capturing screenshot: ${error}`,
-                level: 0,
-              });
             }
           }
         }

--- a/packages/core/lib/v3/agent/OpenAICUAClient.ts
+++ b/packages/core/lib/v3/agent/OpenAICUAClient.ts
@@ -30,6 +30,10 @@ import {
   extractLlmCuaResponseSummary,
 } from "../flowlogger/FlowLogger.js";
 import { v7 as uuidv7 } from "uuid";
+import {
+  DEFAULT_CUSTOM_TOOL_SUCCESS_RESULT,
+  formatCustomToolResult,
+} from "./utils/customToolResult.js";
 
 /**
  * Client for OpenAI's Computer Use Assistant API
@@ -803,7 +807,7 @@ export class OpenAICUAClient extends AgentClient {
           }
 
           // Execute the tool if available
-          let toolResult = "Tool executed successfully";
+          let toolResult = DEFAULT_CUSTOM_TOOL_SUCCESS_RESULT;
           if (this.tools && item.name in this.tools) {
             try {
               const tool = this.tools[item.name];
@@ -819,7 +823,7 @@ export class OpenAICUAClient extends AgentClient {
                 toolCallId: item.call_id,
                 messages: [],
               });
-              toolResult = JSON.stringify(result);
+              toolResult = formatCustomToolResult(result);
 
               logger({
                 category: "agent",

--- a/packages/core/lib/v3/agent/utils/customToolResult.ts
+++ b/packages/core/lib/v3/agent/utils/customToolResult.ts
@@ -1,0 +1,5 @@
+export const DEFAULT_CUSTOM_TOOL_SUCCESS_RESULT = "Tool executed successfully";
+
+export function formatCustomToolResult(toolResult: unknown): string {
+  return JSON.stringify(toolResult) ?? DEFAULT_CUSTOM_TOOL_SUCCESS_RESULT;
+}

--- a/packages/core/lib/v3/agent/utils/googleCustomToolHandler.ts
+++ b/packages/core/lib/v3/agent/utils/googleCustomToolHandler.ts
@@ -3,6 +3,7 @@ import { ToolSet } from "ai";
 import { LogLine } from "../../types/public/logs.js";
 import { toJsonSchema } from "../../zodCompat.js";
 import type { StagehandZodSchema } from "../../zodCompat.js";
+import { formatCustomToolResult } from "./customToolResult.js";
 
 /**
  * Result of executing a custom tool for Google CUA
@@ -36,10 +37,11 @@ export async function executeGoogleCustomTool(
       toolCallId: `tool_${Date.now()}`,
       messages: [],
     });
+    const formattedToolResult = formatCustomToolResult(toolResult);
 
     logger({
       category: "agent",
-      message: `Tool ${toolName} completed successfully. Result: ${JSON.stringify(toolResult)}`,
+      message: `Tool ${toolName} completed successfully. Result: ${formattedToolResult}`,
       level: 1,
     });
 
@@ -48,7 +50,7 @@ export async function executeGoogleCustomTool(
       functionResponse: {
         name: toolName,
         response: {
-          result: JSON.stringify(toolResult),
+          result: formattedToolResult,
         },
       },
     };

--- a/packages/core/lib/v3/handlers/v3CuaAgentHandler.ts
+++ b/packages/core/lib/v3/handlers/v3CuaAgentHandler.ts
@@ -76,6 +76,7 @@ export class V3CuaAgentHandler {
       this.ensureNotClosed();
       const page = await this.v3.context.awaitActivePage();
       const screenshotBuffer = await page.screenshot({ fullPage: false });
+      this.agentClient.setCurrentUrl(page.url());
       return screenshotBuffer.toString("base64"); // base64 png
     });
 

--- a/packages/core/tests/unit/agent-captcha-hooks.test.ts
+++ b/packages/core/tests/unit/agent-captcha-hooks.test.ts
@@ -72,7 +72,10 @@ class FakeCuaClient {
   public captureScreenshot = vi.fn(async () => null);
   public setViewport = vi.fn();
   public setCurrentUrl = vi.fn();
-  public setScreenshotProvider = vi.fn();
+  public screenshotProvider?: () => Promise<string>;
+  public setScreenshotProvider = vi.fn((provider: () => Promise<string>) => {
+    this.screenshotProvider = provider;
+  });
   public setSafetyConfirmationHandler = vi.fn();
 
   setActionHandler(
@@ -136,6 +139,41 @@ describe("agent captcha hooks", () => {
       logs.push(line);
     };
     fakeCuaClient = new FakeCuaClient();
+  });
+
+  it("keeps the CUA client URL in sync when the screenshot provider captures the active page", async () => {
+    new V3CuaAgentHandler(
+      {
+        context: {
+          awaitActivePage: async () => page,
+        },
+        bus: { emit: vi.fn() },
+        isCaptchaAutoSolveEnabled: false,
+        isAdvancedStealth: false,
+        configuredViewport: { width: 1288, height: 711 },
+        isAgentReplayActive: () => false,
+        updateMetrics: vi.fn(),
+      } as never,
+      logger,
+      {
+        modelName: "anthropic/claude-haiku-4-5-20251001",
+        clientOptions: { waitBetweenActions: 1 },
+      } as never,
+    );
+
+    await vi.waitFor(() => {
+      expect(fakeCuaClient.setCurrentUrl).toHaveBeenCalledWith(
+        "https://example.com",
+      );
+    });
+    fakeCuaClient.setCurrentUrl.mockClear();
+
+    await expect(fakeCuaClient.screenshotProvider?.()).resolves.toBe(
+      Buffer.from("fake-image").toString("base64"),
+    );
+    expect(fakeCuaClient.setCurrentUrl).toHaveBeenCalledWith(
+      "https://example.com",
+    );
   });
 
   it("blocks regular agent prepareStep until the solver finishes and injects one solved message", async () => {

--- a/packages/core/tests/unit/anthropic-cua-client.test.ts
+++ b/packages/core/tests/unit/anthropic-cua-client.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+import { AnthropicCUAClient } from "../../lib/v3/agent/AnthropicCUAClient.js";
+
+function createClient() {
+  return new AnthropicCUAClient(
+    "anthropic",
+    "claude-sonnet-4-5-20250929",
+    undefined,
+    { apiKey: "test-key" },
+  );
+}
+
+describe("AnthropicCUAClient", () => {
+  it("returns a success result when a custom tool completes with undefined", async () => {
+    const client = createClient();
+    const toolExecute = vi.fn(async () => undefined);
+
+    (
+      client as unknown as {
+        tools: Record<
+          string,
+          {
+            execute: typeof toolExecute;
+          }
+        >;
+      }
+    ).tools = {
+      fillUsername: {
+        execute: toolExecute,
+      },
+    };
+
+    const result = await (
+      client as unknown as {
+        takeAction: (
+          output: unknown[],
+          logger: (msg: unknown) => void,
+        ) => Promise<unknown[]>;
+      }
+    ).takeAction(
+      [
+        {
+          id: "tool-1",
+          name: "fillUsername",
+          input: {},
+        },
+      ],
+      vi.fn(),
+    );
+
+    expect(toolExecute).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([
+      {
+        type: "tool_result",
+        tool_use_id: "tool-1",
+        content: [
+          {
+            type: "text",
+            text: "Tool executed successfully",
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/packages/core/tests/unit/google-cua-client.test.ts
+++ b/packages/core/tests/unit/google-cua-client.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, it, vi } from "vitest";
+import { GoogleCUAClient } from "../../lib/v3/agent/GoogleCUAClient.js";
+import type { Content } from "@google/genai";
+
+function createClient() {
+  return new GoogleCUAClient(
+    "google",
+    "google/gemini-2.5-computer-use-preview-10-2025",
+    "test instructions",
+    { apiKey: "test" },
+  );
+}
+
+describe("GoogleCUAClient", () => {
+  it("returns a fresh screenshot after executing a custom tool", async () => {
+    const client = createClient();
+    const screenshotProvider = vi.fn(async () => "fresh-screenshot-base64");
+    client.setScreenshotProvider(screenshotProvider);
+    client.setCurrentUrl("http://127.0.0.1:6789/");
+
+    const toolExecute = vi.fn(async () => ({ filled: true }));
+    (
+      client as unknown as {
+        tools: Record<
+          string,
+          {
+            execute: typeof toolExecute;
+          }
+        >;
+      }
+    ).tools = {
+      fillUsername: {
+        execute: toolExecute,
+      },
+    };
+
+    const generateContent = vi.fn(async () => ({
+      candidates: [
+        {
+          content: {
+            role: "model",
+            parts: [
+              {
+                functionCall: {
+                  name: "fillUsername",
+                  args: {},
+                },
+              },
+            ],
+          },
+          finishReason: "STOP",
+        },
+      ],
+      usageMetadata: {
+        promptTokenCount: 1,
+        candidatesTokenCount: 1,
+      },
+    }));
+
+    (
+      client as unknown as {
+        client: {
+          models: {
+            generateContent: typeof generateContent;
+          };
+        };
+      }
+    ).client = {
+      models: {
+        generateContent,
+      },
+    };
+
+    await client.executeStep(vi.fn());
+
+    expect(toolExecute).toHaveBeenCalledTimes(1);
+    expect(screenshotProvider).toHaveBeenCalledTimes(1);
+
+    const history = (client as unknown as { history: Content[] }).history;
+    const userResponse = history[history.length - 1];
+    const functionResponse = userResponse.parts?.[0]?.functionResponse;
+
+    expect(functionResponse).toMatchObject({
+      name: "fillUsername",
+      response: {
+        result: JSON.stringify({ filled: true }),
+        url: "http://127.0.0.1:6789/",
+      },
+      parts: [
+        {
+          inlineData: {
+            mimeType: "image/png",
+            data: "fresh-screenshot-base64",
+          },
+        },
+      ],
+    });
+  });
+
+  it("returns a success result and fresh screenshot when a custom tool completes with undefined", async () => {
+    const client = createClient();
+    const screenshotProvider = vi.fn(async () => "fresh-screenshot-base64");
+    client.setScreenshotProvider(screenshotProvider);
+    client.setCurrentUrl("http://127.0.0.1:6789/");
+
+    const toolExecute = vi.fn(async () => undefined);
+    (
+      client as unknown as {
+        tools: Record<
+          string,
+          {
+            execute: typeof toolExecute;
+          }
+        >;
+      }
+    ).tools = {
+      fillUsername: {
+        execute: toolExecute,
+      },
+    };
+
+    const generateContent = vi.fn(async () => ({
+      candidates: [
+        {
+          content: {
+            role: "model",
+            parts: [
+              {
+                functionCall: {
+                  name: "fillUsername",
+                  args: {},
+                },
+              },
+            ],
+          },
+          finishReason: "STOP",
+        },
+      ],
+      usageMetadata: {
+        promptTokenCount: 1,
+        candidatesTokenCount: 1,
+      },
+    }));
+
+    (
+      client as unknown as {
+        client: {
+          models: {
+            generateContent: typeof generateContent;
+          };
+        };
+      }
+    ).client = {
+      models: {
+        generateContent,
+      },
+    };
+
+    await client.executeStep(vi.fn());
+
+    expect(toolExecute).toHaveBeenCalledTimes(1);
+    expect(screenshotProvider).toHaveBeenCalledTimes(1);
+
+    const history = (client as unknown as { history: Content[] }).history;
+    const userResponse = history[history.length - 1];
+    const functionResponse = userResponse.parts?.[0]?.functionResponse;
+
+    expect(functionResponse).toMatchObject({
+      name: "fillUsername",
+      response: {
+        result: "Tool executed successfully",
+        url: "http://127.0.0.1:6789/",
+      },
+      parts: [
+        {
+          inlineData: {
+            mimeType: "image/png",
+            data: "fresh-screenshot-base64",
+          },
+        },
+      ],
+    });
+  });
+
+  it("reuses one fresh screenshot for custom and computer-use responses in the same step", async () => {
+    const client = createClient();
+    const screenshotProvider = vi.fn(async () => "shared-screenshot-base64");
+    const actionHandler = vi.fn(async () => {});
+    client.setScreenshotProvider(screenshotProvider);
+    client.setActionHandler(actionHandler);
+    client.setCurrentUrl("http://127.0.0.1:6789/");
+
+    const toolExecute = vi.fn(async () => ({ filled: true }));
+    (
+      client as unknown as {
+        tools: Record<
+          string,
+          {
+            execute: typeof toolExecute;
+          }
+        >;
+      }
+    ).tools = {
+      fillUsername: {
+        execute: toolExecute,
+      },
+    };
+
+    const generateContent = vi.fn(async () => ({
+      candidates: [
+        {
+          content: {
+            role: "model",
+            parts: [
+              {
+                functionCall: {
+                  name: "fillUsername",
+                  args: {},
+                },
+              },
+              {
+                functionCall: {
+                  name: "click_at",
+                  args: { x: 500, y: 500, button: "left" },
+                },
+              },
+            ],
+          },
+          finishReason: "STOP",
+        },
+      ],
+      usageMetadata: {
+        promptTokenCount: 1,
+        candidatesTokenCount: 1,
+      },
+    }));
+
+    (
+      client as unknown as {
+        client: {
+          models: {
+            generateContent: typeof generateContent;
+          };
+        };
+      }
+    ).client = {
+      models: {
+        generateContent,
+      },
+    };
+
+    await client.executeStep(vi.fn());
+
+    expect(toolExecute).toHaveBeenCalledTimes(1);
+    expect(actionHandler).toHaveBeenCalledTimes(1);
+    expect(screenshotProvider).toHaveBeenCalledTimes(1);
+
+    const history = (client as unknown as { history: Content[] }).history;
+    const userResponse = history[history.length - 1];
+    const functionResponses = userResponse.parts?.map(
+      (part) => part.functionResponse,
+    );
+
+    expect(functionResponses).toHaveLength(2);
+    expect(functionResponses?.map((response) => response?.name)).toEqual([
+      "fillUsername",
+      "click_at",
+    ]);
+    expect(
+      functionResponses?.map(
+        (response) => response?.parts?.[0]?.inlineData?.data,
+      ),
+    ).toEqual(["shared-screenshot-base64", "shared-screenshot-base64"]);
+  });
+});

--- a/packages/core/tests/unit/openai-cua-client.test.ts
+++ b/packages/core/tests/unit/openai-cua-client.test.ts
@@ -87,6 +87,54 @@ describe("OpenAICUAClient", () => {
     ]);
   });
 
+  it("returns a success result when a custom tool completes with undefined", async () => {
+    const client = createClient();
+    const toolExecute = vi.fn(async () => undefined);
+
+    (
+      client as unknown as {
+        tools: Record<
+          string,
+          {
+            execute: typeof toolExecute;
+          }
+        >;
+      }
+    ).tools = {
+      fillUsername: {
+        execute: toolExecute,
+      },
+    };
+
+    const result = await (
+      client as unknown as {
+        takeAction: (
+          output: unknown[],
+          logger: (msg: unknown) => void,
+        ) => Promise<unknown[]>;
+      }
+    ).takeAction(
+      [
+        {
+          type: "function_call",
+          name: "fillUsername",
+          call_id: "call-1",
+          arguments: "{}",
+        },
+      ],
+      vi.fn(),
+    );
+
+    expect(toolExecute).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([
+      {
+        type: "function_call_output",
+        call_id: "call-1",
+        output: "Tool executed successfully",
+      },
+    ]);
+  });
+
   it("does NOT auto-continue follow-up questions without a captcha context", async () => {
     const client = createClient();
     // No captcha context note — no tool should be exposed


### PR DESCRIPTION
## Summary

Fixes stale visual feedback after Google CUA custom tools by attaching a fresh screenshot to custom tool function responses.

Also normalizes side-effect-only custom tool results so tools like Playwright `fill()` no longer report `undefined` back to the model, and keeps the CUA client's current URL synchronized whenever the screenshot provider captures the active page.

## Motivation

In #1635, custom tools can mutate the page successfully, but the next Google CUA turn may not receive a fresh visual observation. That can make the model conclude that a tool did nothing and then retry the same work with lower-level computer actions.

The repro also uses tools whose implementations return `undefined`, which is common for side-effect-only browser operations. Passing that raw value back makes a successful action look ambiguous in the model transcript.

## Changes

- Attach one post-action screenshot to Google custom tool `functionResponse` parts.
- Reuse that screenshot when a step includes both custom tools and computer-use function calls, avoiding duplicate screenshots for the same post-action state.
- Add a shared custom tool result formatter so `undefined` becomes `Tool executed successfully` across Google, OpenAI, and Anthropic CUA clients.
- Update the V3 CUA screenshot provider to refresh the client URL from the active page whenever it captures a screenshot.
- Add unit coverage for Google custom tool screenshots, undefined custom tool results, mixed custom/computer-use responses, and screenshot-provider URL synchronization.

## Test Plan

```bash
corepack pnpm --filter @browserbasehq/stagehand run build:esm
corepack pnpm --dir packages/core exec vitest run --config vitest.esm.config.mjs dist/esm/tests/unit/google-cua-client.test.js dist/esm/tests/unit/openai-cua-client.test.js dist/esm/tests/unit/anthropic-cua-client.test.js dist/esm/tests/unit/agent-captcha-hooks.test.js dist/esm/tests/unit/safety-confirmation.test.js --reporter=default
corepack pnpm --dir packages/core exec prettier --check lib/v3/agent/GoogleCUAClient.ts lib/v3/agent/OpenAICUAClient.ts lib/v3/agent/AnthropicCUAClient.ts lib/v3/agent/utils/googleCustomToolHandler.ts lib/v3/agent/utils/customToolResult.ts lib/v3/handlers/v3CuaAgentHandler.ts tests/unit/google-cua-client.test.ts tests/unit/openai-cua-client.test.ts tests/unit/anthropic-cua-client.test.ts tests/unit/agent-captcha-hooks.test.ts
git diff --check
```

Result: build passed; 5 unit test files passed with 23 tests; Prettier passed; `git diff --check` passed.

## Risk

The Google CUA path now includes an image in custom tool function responses, which is the intended behavior for this issue but may slightly increase payload size after custom tools. The screenshot is captured once per post-action state and reused for mixed responses to keep that cost bounded.

For OpenAI and Anthropic, this PR only normalizes successful `undefined` custom tool results; it does not add screenshots to their custom tool outputs.

## Related Issue

Fixes #1635


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale screenshots in Google CUA after custom tools by attaching a fresh post-action screenshot and reusing it within the step. Also normalizes side-effect-only tool results and keeps the client URL in sync when screenshots are captured.

- Bug Fixes
  - Google CUA: Attach one post-action screenshot to custom tool `functionResponse`, and reuse it for any computer-use responses in the same step.
  - Custom tools: Convert undefined returns to "Tool executed successfully" across Google, OpenAI, and Anthropic via a shared formatter.
  - Screenshot provider: Update the CUA client’s current URL from the active page on each capture.

<sup>Written for commit 7350c8652df69ab0986adfd87fddf21632a430e4. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2061?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

