### PR TITLE
fix(core): gracefully handle runtimes that omit AsyncLocalStorage.enterWith() (fixes #2055)

### DIFF
--- a/packages/core/lib/v3/flowlogger/FlowLogger.ts
+++ b/packages/core/lib/v3/flowlogger/FlowLogger.ts
@@ -413,7 +413,15 @@ export class FlowLogger {
       parentEvents: [],
     };
 
-    loggerContext.enterWith(ctx);
+    try {
+      loggerContext.enterWith(ctx);
+    } catch {
+      // Some runtimes (e.g. Cloudflare Workers) do not implement enterWith()
+      // because it mutates context across concurrent requests, which is unsafe
+      // in that environment. Fall through: the context is still returned and
+      // callers that need ALS can use loggerContext.run() via runWithLogging()
+      // or withContext().
+    }
     return ctx;
   }
 

--- a/packages/core/tests/unit/flowlogger-capturing-llm.test.ts
+++ b/packages/core/tests/unit/flowlogger-capturing-llm.test.ts
@@ -1,5 +1,7 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { describe, expect, it } from "vitest";
 import { FlowLogger } from "../../lib/v3/flowlogger/FlowLogger.js";
+import { EventEmitterWithWildcardSupport } from "../../lib/v3/flowlogger/EventEmitter.js";
 
 describe("flow logger llm logging", () => {
   it("no-ops direct llm logging calls when no flow context is active", () => {
@@ -46,5 +48,31 @@ describe("flow logger llm logging", () => {
     ).resolves.toMatchObject({
       text: "done",
     });
+  });
+
+  it("FlowLogger.init() does not throw when enterWith() is not implemented (e.g. Cloudflare Workers)", () => {
+    // Simulate a runtime that omits enterWith() from AsyncLocalStorage.
+    const originalEnterWith = AsyncLocalStorage.prototype.enterWith;
+    Object.defineProperty(AsyncLocalStorage.prototype, "enterWith", {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+
+    try {
+      const bus = new EventEmitterWithWildcardSupport();
+      let ctx: ReturnType<typeof FlowLogger.init> | undefined;
+      expect(() => {
+        ctx = FlowLogger.init("session-cloudflare", bus);
+      }).not.toThrow();
+      // The returned context must still be valid even without ALS support.
+      expect(ctx).toMatchObject({ sessionId: "session-cloudflare" });
+    } finally {
+      Object.defineProperty(AsyncLocalStorage.prototype, "enterWith", {
+        value: originalEnterWith,
+        configurable: true,
+        writable: true,
+      });
+    }
   });
 });


### PR DESCRIPTION
Fixes #2055

## Problem

Since v3.2.0, `FlowLogger.init()` calls `AsyncLocalStorage.enterWith()` to set the session-wide logging context. Cloudflare Workers intentionally omits `enterWith()` from their `AsyncLocalStorage` implementation — calling it throws `asyncLocalStorage.enterWith() is not implemented`, which crashes Stagehand immediately during `init()` before any browser interaction occurs.

## Solution

Wrap the `enterWith()` call in a `try/catch`. If the runtime does not support `enterWith()`, we fall through silently. The `FlowLoggerContext` is still created and returned, so it can be stored by the caller (`this.flowLoggerContext` in v3.ts). All other ALS usage inside FlowLogger already uses `loggerContext.run()` (in `runWithLogging()`, `withContext()`, `logCdpEvent()`, etc.), which is supported everywhere — so the logging pipeline continues to work through the explicit-context path on runtimes without `enterWith()`.

## Testing

Added a unit test that simulates a runtime without `enterWith()` (by temporarily setting `AsyncLocalStorage.prototype.enterWith = undefined`) and asserts that `FlowLogger.init()` completes without throwing and returns a valid context.

```
✓ FlowLogger.init() does not throw when enterWith() is not implemented (e.g. Cloudflare Workers)
```

All existing flowlogger unit tests continue to pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2055. Prevents crashes on runtimes that omit `AsyncLocalStorage.enterWith()` (e.g., Cloudflare Workers) by safely initializing `FlowLogger`. Logging continues via `loggerContext.run()` paths.

- **Bug Fixes**
  - Wrap `enterWith()` in try/catch in `FlowLogger.init()`; fall through when missing.
  - Add a unit test that simulates missing `enterWith()` and verifies init succeeds and returns a valid `FlowLoggerContext`.

<sup>Written for commit 7211ad50befdcd3d9fbc1709b2ee460e703d7090. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2062?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

