### PR TITLE
chore: add changeset for new CUA models

### DIFF
--- a/.changeset/update-supported-cua-models.md
+++ b/.changeset/update-supported-cua-models.md
@@ -2,4 +2,4 @@
 "@browserbasehq/stagehand": patch
 ---
 
-Add support for new CUA models: openai/gpt-5.4-mini, openai/gpt-5.5, and anthropic/claude-haiku-4-5
+Add support for CUA models: openai/gpt-5.4-mini, openai/gpt-5.5, and anthropic/claude-haiku-4-5

--- a/.changeset/update-supported-cua-models.md
+++ b/.changeset/update-supported-cua-models.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Add support for new CUA models: openai/gpt-5.4-mini, openai/gpt-5.5, and anthropic/claude-haiku-4-5


### PR DESCRIPTION
# why

# what changed

# test plan

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a changeset to release support for new CUA models in `@browserbasehq/stagehand`: `openai/gpt-5.4-mini`, `openai/gpt-5.5`, and `anthropic/claude-haiku-4-5`. This triggers a patch release and enables selecting these models in CUA.

<sup>Written for commit e7e09105c90422d5303b365cc9772566295f7794. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2066?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

