### PR TITLE
fix: respect opts.debug in installV3ShadowPiercer (fixes #1996)

### DIFF
--- a/.changeset/fix-shadow-piercer-debug.md
+++ b/.changeset/fix-shadow-piercer-debug.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Respect `opts.debug` in `installV3ShadowPiercer` instead of hardcoding `DEBUG = true`

--- a/packages/core/lib/v3/dom/piercer.runtime.ts
+++ b/packages/core/lib/v3/dom/piercer.runtime.ts
@@ -31,8 +31,7 @@ declare global {
 }
 
 export function installV3ShadowPiercer(opts: V3ShadowPatchOptions = {}): void {
-  // hardcoded debug (remove later if desired)
-  const DEBUG = true;
+  const DEBUG = opts.debug ?? false;
 
   type PatchedFn = Element["attachShadow"] & {
     __v3Patched?: boolean;


### PR DESCRIPTION
## Problem

`installV3ShadowPiercer` declares a `debug?: boolean` option in `V3ShadowPatchOptions`, but ignores it — `DEBUG` is hardcoded to `true`:

```ts
// hardcoded debug (remove later if desired)
const DEBUG = true;
```

This means `console.info("[v3-piercer] attachShadow", ...)` fires on every `attachShadow` call regardless of what the caller passes, and the `debug` field in `V3ShadowPatchOptions` is effectively dead API.

## Fix

```ts
const DEBUG = opts.debug ?? false;
```

One-line change. Defaults to `false` (no debug noise) and respects the caller's choice when explicitly set.

Closes #1996.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect `opts.debug` in `installV3ShadowPiercer` by replacing the hardcoded `DEBUG = true` with `const DEBUG = opts.debug ?? false`. This removes noisy logs by default and lets callers enable debugging when needed (fixes #1996).

<sup>Written for commit 5c2f895b7111f03c3bf2fb779c542b9e2aefe066. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2069?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

