### PR TITLE
feat: forward ignoreDefaultArgs to chrome-launcher

### DIFF
--- a/.changeset/forward-ignore-default-args.md
+++ b/.changeset/forward-ignore-default-args.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": minor
+---
+
+Add `ignoreDefaultArgs` option to selectively remove chrome-launcher's built-in default flags (e.g. `--disable-extensions`) when running locally

--- a/packages/core/lib/v3/launch/local.ts
+++ b/packages/core/lib/v3/launch/local.ts
@@ -17,8 +17,8 @@ interface LaunchLocalOptions {
    * - `true`  — drop **all** chrome-launcher defaults (only Stagehand's own
    *   flags and user-supplied `chromeFlags` will be used).
    * - `string[]` — drop only the listed flags from chrome-launcher defaults.
-   *   Matching is substring-based so `"--disable-extensions"` also removes
-   *   `"--disable-extensions-except-for-..."` if such a flag existed.
+   *   Matching is exact (e.g. `["--disable-extensions"]` removes only that
+   *   flag, not `--disable-extensions-file-access-from-files`).
    */
   ignoreDefaultArgs?: boolean | string[];
 }
@@ -58,9 +58,7 @@ export async function launchLocalChrome(
     ignoreDefaultFlags = true;
     const excludeArgs = opts.ignoreDefaultArgs;
     const clDefaults = Launcher.defaultFlags?.() ?? [];
-    const kept = clDefaults.filter(
-      (f) => !excludeArgs.some((ex) => f.includes(ex)),
-    );
+    const kept = clDefaults.filter((f) => !excludeArgs.includes(f));
     chromeFlags.unshift(...kept);
   }
 

--- a/packages/core/lib/v3/launch/local.ts
+++ b/packages/core/lib/v3/launch/local.ts
@@ -1,4 +1,4 @@
-import { launch, LaunchedChrome } from "chrome-launcher";
+import { launch, Launcher, LaunchedChrome } from "chrome-launcher";
 import WebSocket from "ws";
 import { ConnectionTimeoutError } from "../types/public/sdkErrors.js";
 
@@ -10,6 +10,17 @@ interface LaunchLocalOptions {
   port?: number;
   connectTimeoutMs?: number;
   handleSIGINT?: boolean;
+  /**
+   * When provided, selectively removes flags from chrome-launcher's built-in
+   * defaults (e.g. `--disable-extensions`).
+   *
+   * - `true`  — drop **all** chrome-launcher defaults (only Stagehand's own
+   *   flags and user-supplied `chromeFlags` will be used).
+   * - `string[]` — drop only the listed flags from chrome-launcher defaults.
+   *   Matching is substring-based so `"--disable-extensions"` also removes
+   *   `"--disable-extensions-except-for-..."` if such a flag existed.
+   */
+  ignoreDefaultArgs?: boolean | string[];
 }
 
 export async function launchLocalChrome(
@@ -33,12 +44,33 @@ export async function launchLocalChrome(
     ...(opts.chromeFlags ?? []),
   ].filter((f): f is string => typeof f === "string");
 
+  // Handle ignoreDefaultArgs: selectively remove chrome-launcher's built-in
+  // defaults while keeping Stagehand's own flags (already in chromeFlags).
+  let ignoreDefaultFlags = false;
+  if (opts.ignoreDefaultArgs === true) {
+    ignoreDefaultFlags = true;
+  } else if (
+    Array.isArray(opts.ignoreDefaultArgs) &&
+    opts.ignoreDefaultArgs.length > 0
+  ) {
+    // Tell chrome-launcher to skip ALL its defaults, then re-add the ones
+    // the user did NOT ask to exclude.
+    ignoreDefaultFlags = true;
+    const excludeArgs = opts.ignoreDefaultArgs;
+    const clDefaults = Launcher.defaultFlags?.() ?? [];
+    const kept = clDefaults.filter(
+      (f) => !excludeArgs.some((ex) => f.includes(ex)),
+    );
+    chromeFlags.unshift(...kept);
+  }
+
   const chrome = await launch({
     chromePath: opts.chromePath,
     chromeFlags,
     port: opts.port,
     userDataDir: opts.userDataDir,
     handleSIGINT: opts.handleSIGINT,
+    ignoreDefaultFlags,
     connectionPollInterval,
     maxConnectionRetries,
   });

--- a/packages/core/lib/v3/v3.ts
+++ b/packages/core/lib/v3/v3.ts
@@ -1001,6 +1001,7 @@ export class V3 {
             userDataDir,
             connectTimeoutMs: lbo.connectTimeoutMs,
             handleSIGINT: !keepAlive,
+            ignoreDefaultArgs: lbo.ignoreDefaultArgs,
           });
           if (keepAlive) {
             try {

--- a/packages/core/tests/unit/launch-local-ignore-default-args.test.ts
+++ b/packages/core/tests/unit/launch-local-ignore-default-args.test.ts
@@ -1,0 +1,175 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from "vitest";
+
+/**
+ * Unit tests for the `ignoreDefaultArgs` option in `launchLocalChrome`.
+ *
+ * Strategy: mock `chrome-launcher` and `ws` so `launchLocalChrome` returns
+ * immediately, then assert the flags passed to `chrome-launcher.launch()`.
+ */
+
+const FAKE_WS_URL = "ws://127.0.0.1:9222/devtools/browser/fake";
+const FAKE_CHROME_LAUNCHER_DEFAULTS = [
+  "--disable-extensions",
+  "--disable-component-extensions-with-background-pages",
+  "--disable-background-networking",
+  "--disable-sync",
+  "--mute-audio",
+];
+
+vi.mock("chrome-launcher", () => ({
+  launch: vi.fn().mockResolvedValue({
+    port: 9222,
+    kill: vi.fn(),
+    pid: 12345,
+  }),
+  Launcher: {
+    defaultFlags: () => [...FAKE_CHROME_LAUNCHER_DEFAULTS],
+  },
+}));
+
+// Mock ws: the probe calls `new WebSocket(url)` then `.once("open", cb)`.
+// Use EventEmitter so "open" fires after the listener is attached.
+vi.mock("ws", async () => {
+  const { EventEmitter } =
+    await vi.importActual<typeof import("node:events")>("node:events");
+
+  class MockWebSocket extends EventEmitter {
+    constructor() {
+      super();
+      process.nextTick(() => this.emit("open"));
+    }
+    terminate() {}
+  }
+  return { default: MockWebSocket, WebSocket: MockWebSocket };
+});
+
+let launchMock: Mock;
+
+beforeEach(async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ webSocketDebuggerUrl: FAKE_WS_URL }),
+    }),
+  );
+
+  const chromeLauncher = await import("chrome-launcher");
+  launchMock = chromeLauncher.launch as Mock;
+  launchMock.mockClear();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+async function getLaunchArgs(
+  opts: Record<string, unknown>,
+): Promise<{ chromeFlags: string[]; ignoreDefaultFlags: boolean }> {
+  const { launchLocalChrome } = await import("../../lib/v3/launch/local.js");
+  await launchLocalChrome(opts);
+  return launchMock.mock.calls[0][0];
+}
+
+describe("launchLocalChrome ignoreDefaultArgs", () => {
+  it("does not set ignoreDefaultFlags when ignoreDefaultArgs is omitted", async () => {
+    const args = await getLaunchArgs({});
+    expect(args.ignoreDefaultFlags).toBe(false);
+  });
+
+  it("does not set ignoreDefaultFlags when ignoreDefaultArgs is false", async () => {
+    const args = await getLaunchArgs({ ignoreDefaultArgs: false });
+    expect(args.ignoreDefaultFlags).toBe(false);
+  });
+
+  it("sets ignoreDefaultFlags=true when ignoreDefaultArgs is true", async () => {
+    const args = await getLaunchArgs({ ignoreDefaultArgs: true });
+    expect(args.ignoreDefaultFlags).toBe(true);
+    // No chrome-launcher defaults should be prepended
+    for (const flag of FAKE_CHROME_LAUNCHER_DEFAULTS) {
+      expect(args.chromeFlags).not.toContain(flag);
+    }
+  });
+
+  it("selectively removes only the listed flag", async () => {
+    const args = await getLaunchArgs({
+      ignoreDefaultArgs: ["--disable-extensions"],
+    });
+
+    expect(args.ignoreDefaultFlags).toBe(true);
+    expect(args.chromeFlags).not.toContain("--disable-extensions");
+
+    // Other defaults should be preserved (exact match, not substring)
+    expect(args.chromeFlags).toContain(
+      "--disable-component-extensions-with-background-pages",
+    );
+    expect(args.chromeFlags).toContain("--disable-background-networking");
+    expect(args.chromeFlags).toContain("--disable-sync");
+    expect(args.chromeFlags).toContain("--mute-audio");
+  });
+
+  it("uses exact matching, not substring matching", async () => {
+    // "--disable-component" is a substring of
+    // "--disable-component-extensions-with-background-pages",
+    // but exact matching should NOT remove it
+    const args = await getLaunchArgs({
+      ignoreDefaultArgs: ["--disable-component"],
+    });
+
+    expect(args.chromeFlags).toContain(
+      "--disable-component-extensions-with-background-pages",
+    );
+    expect(args.chromeFlags).toContain("--disable-extensions");
+    expect(args.chromeFlags).toContain("--mute-audio");
+  });
+
+  it("preserves all defaults when ignoreDefaultArgs is an empty array", async () => {
+    const args = await getLaunchArgs({ ignoreDefaultArgs: [] });
+    expect(args.ignoreDefaultFlags).toBe(false);
+  });
+
+  it("keeps Stagehand's own flags when selectively removing defaults", async () => {
+    const args = await getLaunchArgs({
+      ignoreDefaultArgs: ["--mute-audio"],
+    });
+
+    // Spot-check a couple of Stagehand's flags — not the full list,
+    // so this test doesn't break if Stagehand adds/removes its own flags.
+    expect(args.chromeFlags).toContain("--remote-allow-origins=*");
+    expect(args.chromeFlags).toContain("--no-first-run");
+
+    expect(args.chromeFlags).not.toContain("--mute-audio");
+    expect(args.chromeFlags).toContain("--disable-extensions");
+  });
+
+  it("merges user chromeFlags with re-added defaults", async () => {
+    const args = await getLaunchArgs({
+      chromeFlags: ["--custom-flag"],
+      ignoreDefaultArgs: ["--disable-sync"],
+    });
+
+    expect(args.chromeFlags).toContain("--custom-flag");
+    expect(args.chromeFlags).not.toContain("--disable-sync");
+    // Other defaults should still be present
+    expect(args.chromeFlags).toContain("--disable-extensions");
+  });
+
+  it("does not deduplicate when user chromeFlags overlap with defaults", async () => {
+    const args = await getLaunchArgs({
+      chromeFlags: ["--disable-sync"],
+      ignoreDefaultArgs: ["--mute-audio"],
+    });
+
+    // "--disable-sync" appears in both user flags and re-added defaults
+    const count = args.chromeFlags.filter((f) => f === "--disable-sync").length;
+    expect(count).toBe(2);
+  });
+});

--- a/packages/docs/v3/configuration/browser.mdx
+++ b/packages/docs/v3/configuration/browser.mdx
@@ -241,6 +241,7 @@ const stagehand = new Stagehand({
     userDataDir: './chrome-user-data', // Persist browser data
     preserveUserDataDir: true, // Keep data after closing
     chromiumSandbox: false, // Disable sandbox (adds --no-sandbox)
+    ignoreDefaultArgs: ['--disable-extensions'], // Re-enable Chrome extensions
     ignoreHTTPSErrors: true, // Ignore certificate errors
     locale: 'en-US', // Set browser language
     deviceScaleFactor: 1.0, // Display scaling
@@ -344,6 +345,36 @@ await stagehand.init();
 <Tip>
 If no `port` is specified, a random port will be assigned.
 </Tip>
+
+### Ignoring Default Chrome Flags
+
+By default, the underlying `chrome-launcher` applies a set of flags (like `--disable-extensions` and `--mute-audio`) when starting Chrome. Use `ignoreDefaultArgs` to override this behavior.
+
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+
+// Remove specific default flags (e.g., re-enable Chrome extensions)
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  localBrowserLaunchOptions: {
+    ignoreDefaultArgs: ["--disable-extensions"],
+  },
+});
+
+await stagehand.init();
+```
+
+`ignoreDefaultArgs` accepts:
+
+| Value | Behavior |
+| --- | --- |
+| `true` | Suppress **all** `chrome-launcher` default flags |
+| `string[]` | Suppress only the listed flags; all other defaults are preserved |
+| `false` / omitted | Keep all default flags (normal behavior) |
+
+<Warning>
+Removing default flags may affect browser stability or security. Only exclude flags you specifically need to override.
+</Warning>
 
 ### DOM Settle Timeout
 


### PR DESCRIPTION
# why

When running Stagehand locally, chrome-launcher adds its own set of default flags (e.g. `--disable-extensions`). There's currently no way for consumers to selectively remove these flags — `localBrowserLaunchOptions.chromeFlags` can only *add* flags, not remove chrome-launcher's built-in defaults.

This is needed when users want to run Chrome with extensions enabled, or need to remove other chrome-launcher defaults for their use case.

# what changed

- Added `ignoreDefaultArgs` option to `LaunchLocalOptions` in `local.ts`
- Forwarded `localBrowserLaunchOptions.ignoreDefaultArgs` from `v3.ts` through to `launchLocalChrome()`
- When `true`: drops all chrome-launcher defaults (only Stagehand's own flags and user-supplied `chromeFlags` are used)
- When `string[]`: selectively removes only the listed flags from chrome-launcher defaults, keeping the rest

This mirrors the behavior of Playwright's [`ignoreDefaultArgs`](https://playwright.dev/docs/api/class-browsertype#browser-type-launch-option-ignore-default-args) option.

# test plan

- Verified locally that setting `ignoreDefaultArgs: ["--disable-extensions"]` successfully removes the flag from the launched Chrome instance (confirmed via `chrome://version/`)
- Verified that other chrome-launcher defaults are preserved when using the array form
- Verified that `ignoreDefaultArgs: true` drops all chrome-launcher defaults

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `ignoreDefaultArgs` to local Chrome launch and forwards it to `chrome-launcher` so users can drop all or selected default flags while keeping Stagehand and user flags.

- **New Features**
  - Added `ignoreDefaultArgs` to `LaunchLocalOptions` and wired it through V3 to `launchLocalChrome()`, mapping to `chrome-launcher`’s `ignoreDefaultFlags`.
  - `true` drops all `chrome-launcher` defaults; `string[]` removes only exact-matched defaults and re-adds the rest from `Launcher.defaultFlags()`, preserving Stagehand defaults and user `chromeFlags`.

<sup>Written for commit 1426616bf956a84f29f7260f1a7068b9f885168d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

