### PR TITLE
remove default temp

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ In your project's `package.json` set:
 
 At a high level, we're focused on improving reliability, extensibility, speed, and cost in that order of priority. If you're interested in contributing, **bug fixes and small improvements are the best way to get started**. For more involved features, we strongly recommend reaching out to [Miguel Gonzalez](https://x.com/miguel_gonzf) or [Paul Klein](https://x.com/pk_iv) in our [Discord community](https://stagehand.dev/discord) before starting to ensure that your contribution aligns with our goals.
 
+
 <!-- For more information, please see our [Contributing Guide](https://docs.stagehand.dev/examples/contributing). -->
 
 ## Acknowledgements

--- a/packages/core/lib/inference.ts
+++ b/packages/core/lib/inference.ts
@@ -64,7 +64,6 @@ export async function extract<T extends StagehandZodObject>({
   type MetadataResponse = z.infer<typeof metadataSchema>;
 
   const isUsingAnthropic = llmClient.type === "anthropic";
-  const isGPT5 = llmClient.modelName.includes("gpt-5"); // TODO: remove this as we update support for gpt-5 configuration options
 
   const extractCallMessages: ChatMessage[] = [
     buildExtractSystemPrompt(isUsingAnthropic, userProvidedInstructions),
@@ -95,7 +94,6 @@ export async function extract<T extends StagehandZodObject>({
           schema,
           name: "Extraction",
         },
-        temperature: isGPT5 ? 1 : 0.1,
         top_p: 1,
         frequency_penalty: 0,
         presence_penalty: 0,
@@ -162,7 +160,6 @@ export async function extract<T extends StagehandZodObject>({
           name: "Metadata",
           schema: metadataSchema,
         },
-        temperature: isGPT5 ? 1 : 0.1,
         top_p: 1,
         frequency_penalty: 0,
         presence_penalty: 0,
@@ -257,8 +254,6 @@ export async function observe({
   supportedActions?: string[];
   variables?: Variables;
 }) {
-  const isGPT5 = llmClient.modelName.includes("gpt-5"); // TODO: remove this as we update support for gpt-5 configuration options
-
   const observeSchema = z.object({
     elements: z
       .array(
@@ -331,7 +326,6 @@ export async function observe({
         schema: observeSchema,
         name: "Observation",
       },
-      temperature: isGPT5 ? 1 : 0.1,
       top_p: 1,
       frequency_penalty: 0,
       presence_penalty: 0,
@@ -408,8 +402,6 @@ export async function act({
   logger: (message: LogLine) => void;
   logInferenceToFile?: boolean;
 }) {
-  const isGPT5 = llmClient.modelName.includes("gpt-5"); // TODO: remove this as we update support for gpt-5 configuration options
-
   const actSchema = z.object({
     action: z
       .object({
@@ -478,7 +470,6 @@ export async function act({
         schema: actSchema,
         name: "act",
       },
-      temperature: isGPT5 ? 1 : 0.1,
       top_p: 1,
       frequency_penalty: 0,
       presence_penalty: 0,

--- a/packages/core/lib/v3/llm/CerebrasClient.ts
+++ b/packages/core/lib/v3/llm/CerebrasClient.ts
@@ -142,7 +142,7 @@ export class CerebrasClient extends LLMClient {
               ]
             : []),
         ],
-        temperature: options.temperature || 0.7,
+        temperature: options.temperature ?? 0.7,
         max_tokens: options.maxOutputTokens,
         tools: tools,
         tool_choice: options.tool_choice || "auto",

--- a/packages/core/lib/v3/llm/CerebrasClient.ts
+++ b/packages/core/lib/v3/llm/CerebrasClient.ts
@@ -142,7 +142,7 @@ export class CerebrasClient extends LLMClient {
               ]
             : []),
         ],
-        temperature: options.temperature,
+        temperature: options.temperature || 0.7,
         max_tokens: options.maxOutputTokens,
         tools: tools,
         tool_choice: options.tool_choice || "auto",

--- a/packages/core/lib/v3/llm/CerebrasClient.ts
+++ b/packages/core/lib/v3/llm/CerebrasClient.ts
@@ -142,7 +142,7 @@ export class CerebrasClient extends LLMClient {
               ]
             : []),
         ],
-        temperature: options.temperature || 0.7,
+        temperature: options.temperature,
         max_tokens: options.maxOutputTokens,
         tools: tools,
         tool_choice: options.tool_choice || "auto",

--- a/packages/core/lib/v3/llm/GroqClient.ts
+++ b/packages/core/lib/v3/llm/GroqClient.ts
@@ -142,7 +142,7 @@ export class GroqClient extends LLMClient {
               ]
             : []),
         ],
-        temperature: options.temperature || 0.7,
+        temperature: options.temperature ?? 0.7,
         max_tokens: options.maxOutputTokens,
         tools: tools,
         tool_choice: options.tool_choice || "auto",

--- a/packages/core/lib/v3/llm/GroqClient.ts
+++ b/packages/core/lib/v3/llm/GroqClient.ts
@@ -142,7 +142,7 @@ export class GroqClient extends LLMClient {
               ]
             : []),
         ],
-        temperature: options.temperature || 0.7,
+        temperature: options.temperature,
         max_tokens: options.maxOutputTokens,
         tools: tools,
         tool_choice: options.tool_choice || "auto",

--- a/packages/core/lib/v3/llm/GroqClient.ts
+++ b/packages/core/lib/v3/llm/GroqClient.ts
@@ -142,7 +142,7 @@ export class GroqClient extends LLMClient {
               ]
             : []),
         ],
-        temperature: options.temperature,
+        temperature: options.temperature || 0.7,
         max_tokens: options.maxOutputTokens,
         tools: tools,
         tool_choice: options.tool_choice || "auto",

--- a/packages/core/tests/unit/inference-temperature.test.ts
+++ b/packages/core/tests/unit/inference-temperature.test.ts
@@ -1,0 +1,85 @@
+import { z } from "zod";
+import { describe, expect, it, vi } from "vitest";
+import { act, extract, observe } from "../../lib/inference.js";
+import type {
+  CreateChatCompletionOptions,
+  LLMClient,
+} from "../../lib/v3/llm/LLMClient.js";
+
+type QueuedResponse = {
+  data: unknown;
+  usage?: Record<string, number>;
+};
+
+function createLlmClient(responses: QueuedResponse[]) {
+  const calls: CreateChatCompletionOptions[] = [];
+  const createChatCompletion = vi.fn(
+    async (request: CreateChatCompletionOptions) => {
+      calls.push(request);
+      const response = responses.shift();
+      if (!response) {
+        throw new Error("Unexpected LLM call");
+      }
+      return response;
+    },
+  );
+
+  const llmClient = {
+    type: "openai",
+    modelName: "openai/gpt-5",
+    createChatCompletion,
+  } as unknown as LLMClient;
+
+  return { llmClient, calls };
+}
+
+describe("shared act/extract/observe inference temperature", () => {
+  it("does not pass temperature for either extract call", async () => {
+    const { llmClient, calls } = createLlmClient([
+      { data: { answer: "42" } },
+      { data: { completed: true, progress: "complete" } },
+    ]);
+
+    await extract({
+      instruction: "extract the answer",
+      domElements: "body",
+      schema: z.object({ answer: z.string() }),
+      llmClient,
+      logger: vi.fn(),
+    });
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0].options).not.toHaveProperty("temperature");
+    expect(calls[1].options).not.toHaveProperty("temperature");
+  });
+
+  it("does not pass temperature for observe", async () => {
+    const { llmClient, calls } = createLlmClient([{ data: { elements: [] } }]);
+
+    await observe({
+      instruction: "find buttons",
+      domElements: "body",
+      llmClient,
+      logger: vi.fn(),
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].options).not.toHaveProperty("temperature");
+  });
+
+  it("does not pass temperature for act", async () => {
+    const { llmClient, calls } = createLlmClient([
+      { data: { action: null, twoStep: false } },
+    ]);
+
+    await act({
+      instruction: "click the button",
+      domElements: "body",
+      llmClient,
+      logger: vi.fn(),
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].options).not.toHaveProperty("temperature");
+  });
+});

--- a/packages/core/tests/unit/openai-compatible-temperature.test.ts
+++ b/packages/core/tests/unit/openai-compatible-temperature.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from "vitest";
+import { CerebrasClient } from "../../lib/v3/llm/CerebrasClient.js";
+import { GroqClient } from "../../lib/v3/llm/GroqClient.js";
+import type { LLMClient } from "../../lib/v3/llm/LLMClient.js";
+import type { LogLine } from "../../lib/v3/types/public/logs.js";
+import type { AvailableModel } from "../../lib/v3/types/public/model.js";
+
+type OpenAICompatibleClient = LLMClient & {
+  client: {
+    chat: {
+      completions: {
+        create: ReturnType<typeof vi.fn>;
+      };
+    };
+  };
+};
+
+function mockCompletionCreate() {
+  return vi.fn().mockResolvedValue({
+    id: "chatcmpl-test",
+    choices: [
+      {
+        message: {
+          role: "assistant",
+          content: "ok",
+          tool_calls: [],
+        },
+        finish_reason: "stop",
+      },
+    ],
+    usage: {
+      prompt_tokens: 1,
+      completion_tokens: 1,
+      total_tokens: 2,
+    },
+  });
+}
+
+function installMockClient(client: LLMClient) {
+  const create = mockCompletionCreate();
+  (client as OpenAICompatibleClient).client = {
+    chat: {
+      completions: {
+        create,
+      },
+    },
+  };
+  return create;
+}
+
+const logger = vi.fn<(message: LogLine) => void>();
+
+describe.each([
+  [
+    "GroqClient",
+    () =>
+      new GroqClient({
+        modelName: "groq-test-model" as AvailableModel,
+        clientOptions: { apiKey: "test-key" },
+        logger,
+      }),
+  ],
+  [
+    "CerebrasClient",
+    () =>
+      new CerebrasClient({
+        modelName: "cerebras-test-model" as AvailableModel,
+        clientOptions: { apiKey: "test-key" },
+        logger,
+      }),
+  ],
+])("%s temperature handling", (_name, createClient) => {
+  it("does not replace missing temperature with a provider default", async () => {
+    const client = createClient();
+    const create = installMockClient(client);
+
+    await client.createChatCompletion({
+      options: {
+        messages: [{ role: "user", content: "hello" }],
+      },
+      logger,
+    });
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        temperature: undefined,
+      }),
+    );
+  });
+
+  it("preserves explicit temperature zero", async () => {
+    const client = createClient();
+    const create = installMockClient(client);
+
+    await client.createChatCompletion({
+      options: {
+        messages: [{ role: "user", content: "hello" }],
+        temperature: 0,
+      },
+      logger,
+    });
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        temperature: 0,
+      }),
+    );
+  });
+});

--- a/packages/core/tests/unit/openai-compatible-temperature.test.ts
+++ b/packages/core/tests/unit/openai-compatible-temperature.test.ts
@@ -70,7 +70,7 @@ describe.each([
       }),
   ],
 ])("%s temperature handling", (_name, createClient) => {
-  it("does not replace missing temperature with a provider default", async () => {
+  it("falls back to 0.7 when temperature is not provided", async () => {
     const client = createClient();
     const create = installMockClient(client);
 
@@ -83,7 +83,7 @@ describe.each([
 
     expect(create).toHaveBeenCalledWith(
       expect.objectContaining({
-        temperature: undefined,
+        temperature: 0.7,
       }),
     );
   });


### PR DESCRIPTION
 # why

  Stagehand v3 was setting hard-coded temperature defaults for standard act, extract, and observe inference calls. This forced provider
  behavior instead of letting model/provider defaults apply.

  # what changed

  Removed the hard-coded temperature: isGPT5 ? 1 : 0.1 defaults from shared act, extract, and observe inference.

  Removed the unused GPT-5 temperature branching in that path.

  Updated Groq and Cerebras clients to pass through options.temperature directly instead of defaulting missing values to 0.7, while preserving
  explicit temperature: 0.

  Added regression tests covering:

  - act, extract, and observe no longer pass temperature by default
  - Groq/Cerebras do not inject default temperature
  - Groq/Cerebras preserve explicit zero temperature

  # test plan

  - pnpm --filter @browserbasehq/stagehand run typecheck
  - pnpm --filter @browserbasehq/stagehand exec prettier --check lib/inference.ts lib/v3/llm/GroqClient.ts lib/v3/llm/CerebrasClient.ts tests/
    unit/inference-temperature.test.ts tests/unit/openai-compatible-temperature.test.ts
  - pnpm --filter @browserbasehq/stagehand run build:esm
  - pnpm --filter @browserbasehq/stagehand run test:core -- packages/core/dist/esm/tests/unit/inference-temperature.test.js packages/core/
    dist/esm/tests/unit/openai-compatible-temperature.test.js packages/core/dist/esm/tests/unit/aisdk-clients.test.js packages/core/dist/esm/
    tests/unit/anthropic-cua-adaptive-thinking.test.js
