### PR TITLE
fix: preserve OOPIF frame registry parent edge

### DIFF
--- a/.changeset/cool-parrots-start.md
+++ b/.changeset/cool-parrots-start.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Fix frame registry handling for OOPIF pages

--- a/packages/core/lib/v3/understudy/frameRegistry.ts
+++ b/packages/core/lib/v3/understudy/frameRegistry.ts
@@ -219,13 +219,27 @@ export class FrameRegistry {
   ): void {
     const walk = (tree: Protocol.Page.FrameTree, parent: FrameId | null) => {
       this.ensureNode(tree.frame.id);
+      const info = this.frames.get(tree.frame.id)!;
+      const previousParent = info.parentId;
+      const nextParent =
+        parent ?? tree.frame.parentId ?? previousParent ?? null;
+
       // topology
-      this.frames.get(tree.frame.id)!.parentId = parent;
-      if (parent) this.frames.get(parent)!.children.add(tree.frame.id);
+      if (previousParent && previousParent !== nextParent) {
+        this.frames.get(previousParent)?.children.delete(tree.frame.id);
+      }
+      info.parentId = nextParent;
+      if (nextParent) {
+        this.ensureNode(nextParent);
+        this.frames.get(nextParent)!.children.add(tree.frame.id);
+      }
       // last-seen frame
-      this.frames.get(tree.frame.id)!.lastSeen = tree.frame;
+      info.lastSeen =
+        nextParent && !tree.frame.parentId
+          ? { ...tree.frame, parentId: nextParent }
+          : tree.frame;
       // ownership (only if unknown)
-      if (!this.frames.get(tree.frame.id)!.ownerSessionId) {
+      if (!info.ownerSessionId) {
         this.setOwnerSessionIdInternal(tree.frame.id, sessionId);
       }
       for (const c of tree.childFrames ?? []) walk(c, tree.frame.id);

--- a/packages/core/tests/unit/frame-registry-oopif-adoption.test.ts
+++ b/packages/core/tests/unit/frame-registry-oopif-adoption.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import type { Protocol } from "devtools-protocol";
+
+import { FrameRegistry } from "../../lib/v3/understudy/frameRegistry.js";
+
+describe("FrameRegistry OOPIF adoption ordering", () => {
+  it("keeps child-session ownership when parent frameAttached arrives before child target adoption", () => {
+    const registry = new FrameRegistry("target-1", "root-frame");
+
+    registry.onFrameAttached("child-frame", "root-frame", "parent-session");
+    registry.adoptChildSession("child-session", "child-frame");
+
+    expect(registry.listAllFrames()).toEqual(["root-frame", "child-frame"]);
+    expect(registry.getParent("child-frame")).toBe("root-frame");
+    expect(registry.getOwnerSessionId("child-frame")).toBe("child-session");
+    expect(registry.framesForSession("parent-session")).toEqual([]);
+    expect(registry.framesForSession("child-session")).toEqual(["child-frame"]);
+  });
+
+  it("keeps child-session ownership when child target adoption is staged before parent frameAttached", () => {
+    const registry = new FrameRegistry("target-1", "root-frame");
+
+    registry.adoptChildSession("child-session", "child-frame");
+    registry.onFrameAttached("child-frame", "root-frame", "parent-session");
+    registry.adoptChildSession("child-session", "child-frame");
+
+    expect(registry.listAllFrames()).toEqual(["root-frame", "child-frame"]);
+    expect(registry.getParent("child-frame")).toBe("root-frame");
+    expect(registry.getOwnerSessionId("child-frame")).toBe("child-session");
+    expect(registry.framesForSession("parent-session")).toEqual([]);
+    expect(registry.framesForSession("child-session")).toEqual(["child-frame"]);
+  });
+
+  it("preserves the known parent edge when seeding an adopted OOPIF child frame tree", () => {
+    const registry = new FrameRegistry("target-1", "root-frame");
+
+    registry.onFrameAttached("child-frame", "root-frame", "parent-session");
+    registry.adoptChildSession("child-session", "child-frame");
+    registry.seedFromFrameTree("child-session", {
+      frame: {
+        id: "child-frame",
+        loaderId: "loader-1",
+        name: "payment-frame",
+        url: "https://js.stripe.com/v3/elements-inner-payment.html",
+        domainAndRegistry: "stripe.com",
+        securityOrigin: "https://js.stripe.com",
+        mimeType: "text/html",
+        secureContextType: "Secure",
+        crossOriginIsolatedContextType: "NotIsolated",
+        gatedAPIFeatures: [],
+      },
+    } satisfies Protocol.Page.FrameTree);
+
+    expect(registry.getParent("child-frame")).toBe("root-frame");
+    expect(registry.asProtocolFrameTree("root-frame")).toMatchObject({
+      frame: { id: "root-frame" },
+      childFrames: [
+        {
+          frame: {
+            id: "child-frame",
+            parentId: "root-frame",
+            url: "https://js.stripe.com/v3/elements-inner-payment.html",
+          },
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
# why

Stagehand could lose a known parent-child frame relationship after adopting an OOPIF child session. In practice, that meant the registry could forget that a child frame still belonged under the top-level page, leaving later iframe resolution with an incomplete frame tree.

# what changed

Added a deterministic FrameRegistry unit test for the OOPIF adoption ordering. Updated `seedFromFrameTree()` to preserve an already-known parent when a child frame tree snapshot does not include parent metadata.

# test plan

Before the fix, the new test failed with `expected null to be 'root-frame'`. After the fix, this passes:

`pnpm --dir packages/core run build:esm && pnpm --dir packages/core run test:core -- packages/core/dist/esm/tests/unit/frame-registry-oopif-adoption.test.js`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where the frame registry could lose a known parent-child link after adopting an OOPIF child session. Preserves the parent edge when seeding from a child frame tree that lacks parent metadata to keep the iframe tree complete.

- Bug Fixes
  - Updated `FrameRegistry.seedFromFrameTree()` to retain an existing parent when `parentId` is missing and to sync child sets accordingly.
  - Added a unit test for OOPIF adoption ordering and seeding to prevent regressions, and a changeset for `@browserbasehq/stagehand` patch release.

<sup>Written for commit 1e50e9c3ed4d56c158c1b694bbd04d2aac55821c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

