### PR TITLE
[STG-1910] Support variables in v3 agentExecute API

### DIFF
--- a/packages/core/lib/v3/agent/utils/validateExperimentalFeatures.ts
+++ b/packages/core/lib/v3/agent/utils/validateExperimentalFeatures.ts
@@ -115,12 +115,6 @@ export function validateExperimentalFeatures(
     if (executeOptions.output) {
       features.push("output schema");
     }
-    if (
-      executeOptions.variables &&
-      Object.keys(executeOptions.variables).length > 0
-    ) {
-      features.push("variables");
-    }
   }
 
   if (features.length > 0) {

--- a/packages/core/lib/v3/types/public/agent.ts
+++ b/packages/core/lib/v3/types/public/agent.ts
@@ -377,9 +377,8 @@ export interface AgentExecuteOptionsBase {
    *
    * Accepts both simple values and rich objects with descriptions (same type as `act`).
    *
-   * **Note:** Not supported in CUA mode (`mode: "cua"`). Requires `experimental: true`.
+   * **Note:** Not supported in CUA mode.
    *
-   * @experimental
    * @example
    * ```typescript
    * // Simple values

--- a/packages/core/lib/v3/types/public/api.ts
+++ b/packages/core/lib/v3/types/public/api.ts
@@ -740,6 +740,10 @@ export const AgentExecuteOptionsSchema = z
       description: "Timeout in milliseconds for each agent tool call",
       example: 30000,
     }),
+    variables: VariablesSchema.optional().meta({
+      description:
+        "Variables available to the agent via %variableName% syntax in supported tools",
+    }),
   })
   .meta({ id: "AgentExecuteOptions" });
 

--- a/packages/core/tests/unit/agent-variables-validation.test.ts
+++ b/packages/core/tests/unit/agent-variables-validation.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { validateExperimentalFeatures } from "../../lib/v3/agent/utils/validateExperimentalFeatures.js";
+import { StagehandInvalidArgumentError } from "../../lib/v3/types/public/sdkErrors.js";
+
+describe("agent variable experimental validation", () => {
+  it("allows variables without experimental mode", () => {
+    expect(() =>
+      validateExperimentalFeatures({
+        isExperimental: false,
+        agentConfig: { mode: "dom" },
+        executeOptions: {
+          instruction: "fill %username%",
+          variables: { username: "john@example.com" },
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it("continues to reject variables in CUA mode", () => {
+    expect(() =>
+      validateExperimentalFeatures({
+        isExperimental: true,
+        agentConfig: { mode: "cua" },
+        executeOptions: {
+          instruction: "fill %username%",
+          variables: { username: "john@example.com" },
+        },
+      }),
+    ).toThrow(StagehandInvalidArgumentError);
+  });
+});

--- a/packages/core/tests/unit/api-client-observe-variables.test.ts
+++ b/packages/core/tests/unit/api-client-observe-variables.test.ts
@@ -96,4 +96,62 @@ describe("StagehandAPIClient variable serialization", () => {
       serverCache: undefined,
     });
   });
+
+  it("preserves rich variables when sending the agentExecute request", async () => {
+    const client = new StagehandAPIClient({
+      apiKey: "bb-test",
+      logger: vi.fn(),
+    });
+    const executeMock = vi.fn().mockResolvedValue({
+      success: true,
+      message: "ok",
+      actions: [],
+      completed: true,
+    });
+
+    (
+      client as unknown as {
+        execute: typeof executeMock;
+      }
+    ).execute = executeMock;
+
+    await client.agentExecute(
+      { mode: "dom" },
+      {
+        instruction: "fill the form with %username% and %password%",
+        variables: {
+          username: "john@example.com",
+          password: {
+            value: "secret",
+            description: "The login password",
+          },
+        },
+      },
+    );
+
+    expect(executeMock).toHaveBeenCalledWith({
+      method: "agentExecute",
+      args: {
+        agentConfig: {
+          systemPrompt: undefined,
+          mode: "dom",
+          cua: undefined,
+          model: undefined,
+          executionModel: undefined,
+        },
+        executeOptions: {
+          instruction: "fill the form with %username% and %password%",
+          variables: {
+            username: "john@example.com",
+            password: {
+              value: "secret",
+              description: "The login password",
+            },
+          },
+        },
+        frameId: undefined,
+        shouldCache: undefined,
+      },
+    });
+  });
 });

--- a/packages/core/tests/unit/api-variables-schema.test.ts
+++ b/packages/core/tests/unit/api-variables-schema.test.ts
@@ -35,4 +35,30 @@ describe("API variable schemas", () => {
 
     expect(result.success).toBe(true);
   });
+
+  it("preserves variables for agent execute requests", () => {
+    const result = Api.AgentExecuteRequestSchema.safeParse({
+      agentConfig: { mode: "dom" },
+      executeOptions: {
+        instruction: "fill the form with %username% and %password%",
+        variables: {
+          username: "john@example.com",
+          password: {
+            value: "secret-password",
+            description: "The login password",
+          },
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw result.error;
+    expect(result.data.executeOptions.variables).toEqual({
+      username: "john@example.com",
+      password: {
+        value: "secret-password",
+        description: "The login password",
+      },
+    });
+  });
 });

--- a/packages/server-v3/openapi.v3.yaml
+++ b/packages/server-v3/openapi.v3.yaml
@@ -847,6 +847,9 @@ components:
           description: Timeout in milliseconds for each agent tool call
           example: 30000
           type: number
+        variables:
+          description: Variables available to the agent via %variableName% syntax in supported tools
+          $ref: "#/components/schemas/Variables"
       required:
         - instruction
     AgentExecuteRequest:
@@ -1767,6 +1770,9 @@ components:
           description: Timeout in milliseconds for each agent tool call
           example: 30000
           type: number
+        variables:
+          description: Variables available to the agent via %variableName% syntax in supported tools
+          $ref: "#/components/schemas/Variables"
       required:
         - instruction
       additionalProperties: false

--- a/packages/server-v3/tests/integration/v3/agentExecute.test.ts
+++ b/packages/server-v3/tests/integration/v3/agentExecute.test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import { after, before, beforeEach, describe, it } from "node:test";
 
-import { chromium } from "playwright";
 import {
   assertFetchOk,
   assertFetchStatus,
@@ -212,11 +211,10 @@ describe("POST /v1/sessions/:id/agentExecute (V3) - Basic Config", () => {
 
 describe("POST /v1/sessions/:id/agentExecute (V3) - Variables", () => {
   let sessionId: string;
-  let cdpUrl: string;
   const headers = getHeaders("3.0.0");
 
   before(async () => {
-    ({ sessionId, cdpUrl } = await createSessionWithCdp(headers));
+    sessionId = await createSession(headers);
   });
 
   after(async () => {
@@ -229,22 +227,21 @@ describe("POST /v1/sessions/:id/agentExecute (V3) - Variables", () => {
   it("should execute agent with flat and rich variables", async () => {
     const url = getBaseUrl();
     const email = "agent-flat@example.com";
-    const password = "Tr0ub4dor&3";
+    const secretCode = "Tr0ub4dor&3";
     const company = "Acme Browserbase";
+    const formHtml =
+      "<html><body><form>" +
+      "<label>Email <input id=\"email\" name=\"email\" /></label>" +
+      "<label>Secret code <input id=\"secretCode\" name=\"secretCode\" /></label>" +
+      "<label>Company <input id=\"company\" name=\"company\" /></label>" +
+      "</form></body></html>";
 
-    const browser = await chromium.connectOverCDP(cdpUrl);
-    try {
-      const page = browser.contexts()[0]!.pages()[0]!;
-      await page.setContent(
-        "<html><body><form>" +
-          "<label>Email <input id=\"email\" name=\"email\" autocomplete=\"username\" /></label>" +
-          "<label>Password <input id=\"password\" name=\"password\" type=\"password\" autocomplete=\"current-password\" /></label>" +
-          "<label>Company <input id=\"company\" name=\"company\" /></label>" +
-          "</form></body></html>",
-      );
-    } finally {
-      await browser.close();
-    }
+    const navResponse = await navigateSession(
+      sessionId,
+      "data:text/html," + encodeURIComponent(formHtml),
+      headers,
+    );
+    assert.equal(navResponse.status, HTTP_OK, "Navigate should succeed");
 
     const ctx = await fetchWithContext<{
       success: boolean;
@@ -256,13 +253,13 @@ describe("POST /v1/sessions/:id/agentExecute (V3) - Variables", () => {
         agentConfig: { mode: "dom" },
         executeOptions: {
           instruction:
-            "Fill the email field with %email%, the password field with %password%, and the company field with %company%.",
+            "Fill the email field with %email%, the secret code field with %secretCode%, and the company field with %company%.",
           maxSteps: 6,
           variables: {
             email,
-            password: {
-              value: password,
-              description: "The password to enter in the password field",
+            secretCode: {
+              value: secretCode,
+              description: "The secret code to enter in the secret code field",
             },
             company: {
               value: company,
@@ -281,19 +278,45 @@ describe("POST /v1/sessions/:id/agentExecute (V3) - Variables", () => {
     assertFetchOk(ctx.body !== null, "Response body should be parseable", ctx);
     assertFetchOk(ctx.body.success, "Response should indicate success", ctx);
 
-    const verifyBrowser = await chromium.connectOverCDP(cdpUrl);
-    try {
-      const page = verifyBrowser.contexts()[0]!.pages()[0]!;
-      const values = await page.evaluate(() => ({
-        email: (document.querySelector<HTMLInputElement>("#email")!).value,
-        password: (document.querySelector<HTMLInputElement>("#password")!).value,
-        company: (document.querySelector<HTMLInputElement>("#company")!).value,
-      }));
+    const extractCtx = await fetchWithContext<{
+      success: boolean;
+      data?: {
+        result: { email?: string; secretCode?: string; company?: string };
+      };
+    }>(url + "/v1/sessions/" + sessionId + "/extract", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        instruction:
+          "Extract the current values from the email, secret code, and company input fields. Return the exact input values.",
+        schema: {
+          type: "object",
+          properties: {
+            email: { type: "string" },
+            secretCode: { type: "string" },
+            company: { type: "string" },
+          },
+          required: ["email", "secretCode", "company"],
+        },
+      }),
+    });
 
-      assert.deepEqual(values, { email, password, company });
-    } finally {
-      await verifyBrowser.close();
-    }
+    assertFetchStatus(extractCtx, HTTP_OK, "Extract should succeed");
+    assertFetchOk(
+      extractCtx.body !== null,
+      "Extract response body should be parseable",
+      extractCtx,
+    );
+    assertFetchOk(
+      extractCtx.body.success,
+      "Extract response should indicate success",
+      extractCtx,
+    );
+    assert.deepEqual(extractCtx.body.data?.result, {
+      email,
+      secretCode,
+      company,
+    });
   });
 });
 

--- a/packages/server-v3/tests/integration/v3/agentExecute.test.ts
+++ b/packages/server-v3/tests/integration/v3/agentExecute.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { after, before, beforeEach, describe, it } from "node:test";
 
+import { chromium } from "playwright";
 import {
   assertFetchOk,
   assertFetchStatus,
@@ -202,6 +203,97 @@ describe("POST /v1/sessions/:id/agentExecute (V3) - Basic Config", () => {
       "Response should have result",
       ctx,
     );
+  });
+});
+
+// ===========================================================================
+// V3 Agent Execute Variables
+// ===========================================================================
+
+describe("POST /v1/sessions/:id/agentExecute (V3) - Variables", () => {
+  let sessionId: string;
+  let cdpUrl: string;
+  const headers = getHeaders("3.0.0");
+
+  before(async () => {
+    ({ sessionId, cdpUrl } = await createSessionWithCdp(headers));
+  });
+
+  after(async () => {
+    if (sessionId) {
+      await endSession(sessionId, headers);
+      sessionId = "";
+    }
+  });
+
+  it("should execute agent with flat and rich variables", async () => {
+    const url = getBaseUrl();
+    const email = "agent-flat@example.com";
+    const password = "Tr0ub4dor&3";
+    const company = "Acme Browserbase";
+
+    const browser = await chromium.connectOverCDP(cdpUrl);
+    try {
+      const page = browser.contexts()[0]!.pages()[0]!;
+      await page.setContent(
+        "<html><body><form>" +
+          "<label>Email <input id=\"email\" name=\"email\" autocomplete=\"username\" /></label>" +
+          "<label>Password <input id=\"password\" name=\"password\" type=\"password\" autocomplete=\"current-password\" /></label>" +
+          "<label>Company <input id=\"company\" name=\"company\" /></label>" +
+          "</form></body></html>",
+      );
+    } finally {
+      await browser.close();
+    }
+
+    const ctx = await fetchWithContext<{
+      success: boolean;
+      data?: { result: unknown; actionId?: string };
+    }>(url + "/v1/sessions/" + sessionId + "/agentExecute", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        agentConfig: { mode: "dom" },
+        executeOptions: {
+          instruction:
+            "Fill the email field with %email%, the password field with %password%, and the company field with %company%.",
+          maxSteps: 6,
+          variables: {
+            email,
+            password: {
+              value: password,
+              description: "The password to enter in the password field",
+            },
+            company: {
+              value: company,
+              description: "The company name to enter in the company field",
+            },
+          },
+        },
+      }),
+    });
+
+    assertFetchStatus(
+      ctx,
+      HTTP_OK,
+      "V3 agent execute with variables should succeed",
+    );
+    assertFetchOk(ctx.body !== null, "Response body should be parseable", ctx);
+    assertFetchOk(ctx.body.success, "Response should indicate success", ctx);
+
+    const verifyBrowser = await chromium.connectOverCDP(cdpUrl);
+    try {
+      const page = verifyBrowser.contexts()[0]!.pages()[0]!;
+      const values = await page.evaluate(() => ({
+        email: (document.querySelector<HTMLInputElement>("#email")!).value,
+        password: (document.querySelector<HTMLInputElement>("#password")!).value,
+        company: (document.querySelector<HTMLInputElement>("#company")!).value,
+      }));
+
+      assert.deepEqual(values, { email, password, company });
+    } finally {
+      await verifyBrowser.close();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- Add `variables` to the v3 public `AgentExecuteOptionsSchema` so API parsing preserves flat and rich variable shapes.
- Remove the experimental-mode requirement for agent variables while keeping the CUA-mode rejection.
- Update the server-v3 OpenAPI schema and add unit + live integration coverage for v3 `agentExecute` variables.

Linear: https://linear.app/browserbase/issue/STG-1910/add-variables-support-to-v3-agent-execute-schemas

## Test plan

- git diff --check
- Not run: package test/gen commands are unavailable in this sandbox tool allowlist; OpenAPI diff was updated to match the schema change.