### PR TITLE
remove experimental requirement on agent variables

### DIFF
--- a/.changeset/agent-execute-variables.md
+++ b/.changeset/agent-execute-variables.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Add variables support to v3 agentExecute API schema and remove experimental requirement

--- a/packages/core/lib/v3/agent/utils/validateExperimentalFeatures.ts
+++ b/packages/core/lib/v3/agent/utils/validateExperimentalFeatures.ts
@@ -115,12 +115,6 @@ export function validateExperimentalFeatures(
     if (executeOptions.output) {
       features.push("output schema");
     }
-    if (
-      executeOptions.variables &&
-      Object.keys(executeOptions.variables).length > 0
-    ) {
-      features.push("variables");
-    }
   }
 
   if (features.length > 0) {

--- a/packages/core/lib/v3/types/public/agent.ts
+++ b/packages/core/lib/v3/types/public/agent.ts
@@ -377,9 +377,8 @@ export interface AgentExecuteOptionsBase {
    *
    * Accepts both simple values and rich objects with descriptions (same type as `act`).
    *
-   * **Note:** Not supported in CUA mode (`mode: "cua"`). Requires `experimental: true`.
+   * **Note:** Not supported in CUA mode (`mode: "cua"`).
    *
-   * @experimental
    * @example
    * ```typescript
    * // Simple values

--- a/packages/core/lib/v3/types/public/api.ts
+++ b/packages/core/lib/v3/types/public/api.ts
@@ -740,6 +740,10 @@ export const AgentExecuteOptionsSchema = z
       description: "Timeout in milliseconds for each agent tool call",
       example: 30000,
     }),
+    variables: VariablesSchema.optional().meta({
+      description:
+        "Variables available to the agent via %variableName% syntax in supported tools",
+    }),
   })
   .meta({ id: "AgentExecuteOptions" });
 

--- a/packages/core/tests/unit/agent-variables-validation.test.ts
+++ b/packages/core/tests/unit/agent-variables-validation.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { validateExperimentalFeatures } from "../../lib/v3/agent/utils/validateExperimentalFeatures.js";
+import { StagehandInvalidArgumentError } from "../../lib/v3/types/public/sdkErrors.js";
+
+describe("agent variable experimental validation", () => {
+  it("allows variables without experimental mode", () => {
+    expect(() =>
+      validateExperimentalFeatures({
+        isExperimental: false,
+        agentConfig: { mode: "dom" },
+        executeOptions: {
+          instruction: "fill %username%",
+          variables: { username: "john@example.com" },
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it("allows rich variables without experimental mode", () => {
+    expect(() =>
+      validateExperimentalFeatures({
+        isExperimental: false,
+        agentConfig: { mode: "dom" },
+        executeOptions: {
+          instruction: "fill %username%",
+          variables: {
+            username: {
+              value: "john@example.com",
+              description: "The login email",
+            },
+          },
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it("continues to reject variables in CUA mode", () => {
+    expect(() =>
+      validateExperimentalFeatures({
+        isExperimental: true,
+        agentConfig: { mode: "cua" },
+        executeOptions: {
+          instruction: "fill %username%",
+          variables: { username: "john@example.com" },
+        },
+      }),
+    ).toThrow(StagehandInvalidArgumentError);
+  });
+});

--- a/packages/core/tests/unit/api-client-observe-variables.test.ts
+++ b/packages/core/tests/unit/api-client-observe-variables.test.ts
@@ -96,4 +96,62 @@ describe("StagehandAPIClient variable serialization", () => {
       serverCache: undefined,
     });
   });
+
+  it("preserves rich variables when sending the agentExecute request", async () => {
+    const client = new StagehandAPIClient({
+      apiKey: "bb-test",
+      logger: vi.fn(),
+    });
+    const executeMock = vi.fn().mockResolvedValue({
+      success: true,
+      message: "ok",
+      actions: [],
+      completed: true,
+    });
+
+    (
+      client as unknown as {
+        execute: typeof executeMock;
+      }
+    ).execute = executeMock;
+
+    await client.agentExecute(
+      { mode: "dom" },
+      {
+        instruction: "fill the form with %username% and %password%",
+        variables: {
+          username: "john@example.com",
+          password: {
+            value: "secret",
+            description: "The login password",
+          },
+        },
+      },
+    );
+
+    expect(executeMock).toHaveBeenCalledWith({
+      method: "agentExecute",
+      args: {
+        agentConfig: {
+          systemPrompt: undefined,
+          mode: "dom",
+          cua: undefined,
+          model: undefined,
+          executionModel: undefined,
+        },
+        executeOptions: {
+          instruction: "fill the form with %username% and %password%",
+          variables: {
+            username: "john@example.com",
+            password: {
+              value: "secret",
+              description: "The login password",
+            },
+          },
+        },
+        frameId: undefined,
+        shouldCache: undefined,
+      },
+    });
+  });
 });

--- a/packages/core/tests/unit/api-variables-schema.test.ts
+++ b/packages/core/tests/unit/api-variables-schema.test.ts
@@ -35,4 +35,30 @@ describe("API variable schemas", () => {
 
     expect(result.success).toBe(true);
   });
+
+  it("preserves variables for agent execute requests", () => {
+    const result = Api.AgentExecuteRequestSchema.safeParse({
+      agentConfig: { mode: "dom" },
+      executeOptions: {
+        instruction: "fill the form with %username% and %password%",
+        variables: {
+          username: "john@example.com",
+          password: {
+            value: "secret-password",
+            description: "The login password",
+          },
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw result.error;
+    expect(result.data.executeOptions.variables).toEqual({
+      username: "john@example.com",
+      password: {
+        value: "secret-password",
+        description: "The login password",
+      },
+    });
+  });
 });

--- a/packages/server-v3/openapi.v3.yaml
+++ b/packages/server-v3/openapi.v3.yaml
@@ -847,6 +847,9 @@ components:
           description: Timeout in milliseconds for each agent tool call
           example: 30000
           type: number
+        variables:
+          description: Variables available to the agent via %variableName% syntax in supported tools
+          $ref: "#/components/schemas/Variables"
       required:
         - instruction
     AgentExecuteRequest:
@@ -1767,6 +1770,9 @@ components:
           description: Timeout in milliseconds for each agent tool call
           example: 30000
           type: number
+        variables:
+          description: Variables available to the agent via %variableName% syntax in supported tools
+          $ref: "#/components/schemas/Variables"
       required:
         - instruction
       additionalProperties: false


### PR DESCRIPTION
# why

# what changed

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable variables in v3 `agentExecute` without requiring experimental mode, and update API schemas to preserve both simple and rich variable shapes. CUA mode remains unsupported for variables.

- **New Features**
  - Added `variables` to `AgentExecuteOptionsSchema` and server OpenAPI so values pass through unchanged.
  - Removed the experimental-feature check for variables in `validateExperimentalFeatures`; CUA-mode rejection stays.
  - Updated JSDoc on `AgentExecuteOptionsBase.variables` and added unit tests for validation, schema parsing, and client serialization.

<sup>Written for commit 65b3c75eb541f78a897ce91cb9688fa959f05c0d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

