### PR TITLE
remove variables from experimental on agent

### DIFF
--- a/.changeset/legal-coats-give.md
+++ b/.changeset/legal-coats-give.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Remove agent variables from experimental gate

--- a/packages/core/lib/v3/agent/tools/fillFormVision.ts
+++ b/packages/core/lib/v3/agent/tools/fillFormVision.ts
@@ -64,9 +64,12 @@ MANDATORY USE CASES (always use fillFormVision for these):
       try {
         const page = await v3.context.awaitActivePage();
 
-        // Process coordinates and substitute variables for each field
-        // Keep original values (with %tokens%) for logging/caching, substituted values for typing
-        const processedFields = fields.map((field) => {
+        // Process coordinates per field. Keep the original `value` (with any
+        // `%variableName%` tokens) so substituted secrets never leak through
+        // the tool result, replay cache, returned AgentResult.actions, or
+        // anything that logs the action. Variables are substituted only at
+        // typing time below.
+        const safeFields = fields.map((field) => {
           const processed = processCoordinates(
             field.coordinates.x,
             field.coordinates.y,
@@ -74,9 +77,8 @@ MANDATORY USE CASES (always use fillFormVision for these):
             v3,
           );
           return {
-            ...field,
-            originalValue: field.value, // Keep original with %tokens% for cache
-            value: substituteVariables(field.value, variables),
+            action: field.action,
+            value: field.value,
             coordinates: { x: processed.x, y: processed.y },
           };
         });
@@ -97,7 +99,7 @@ MANDATORY USE CASES (always use fillFormVision for these):
         const shouldCollectXpath = v3.isAgentReplayActive();
         const actions: Action[] = [];
 
-        for (const field of processedFields) {
+        for (const field of safeFields) {
           // Click the field, only requesting XPath when caching is enabled
           const xpath = await page.click(
             field.coordinates.x,
@@ -106,10 +108,12 @@ MANDATORY USE CASES (always use fillFormVision for these):
               returnXpath: shouldCollectXpath,
             },
           );
-          await page.type(field.value);
+          // Substitute variables only at the moment of typing so the resolved
+          // value never leaves this scope.
+          await page.type(substituteVariables(field.value, variables));
 
-          // Build Action with XPath for deterministic replay (only when caching)
-          // Use originalValue (with %tokens%) so cache stores references, not sensitive values
+          // Build Action with XPath for deterministic replay (only when caching).
+          // Store the placeholder value so cache entries don't contain secrets.
           if (shouldCollectXpath) {
             const normalizedXpath = ensureXPath(xpath);
             if (normalizedXpath) {
@@ -117,7 +121,7 @@ MANDATORY USE CASES (always use fillFormVision for these):
                 selector: normalizedXpath,
                 description: field.action,
                 method: "type",
-                arguments: [field.originalValue],
+                arguments: [field.value],
               });
             }
           }
@@ -140,7 +144,7 @@ MANDATORY USE CASES (always use fillFormVision for these):
 
         return {
           success: true,
-          playwrightArguments: processedFields,
+          playwrightArguments: safeFields,
           screenshotBase64,
         };
       } catch (error) {

--- a/packages/core/lib/v3/agent/utils/validateExperimentalFeatures.ts
+++ b/packages/core/lib/v3/agent/utils/validateExperimentalFeatures.ts
@@ -115,12 +115,6 @@ export function validateExperimentalFeatures(
     if (executeOptions.output) {
       features.push("output schema");
     }
-    if (
-      executeOptions.variables &&
-      Object.keys(executeOptions.variables).length > 0
-    ) {
-      features.push("variables");
-    }
   }
 
   if (features.length > 0) {

--- a/packages/core/tests/unit/fillFormVision-variables.test.ts
+++ b/packages/core/tests/unit/fillFormVision-variables.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import { fillFormVisionTool } from "../../lib/v3/agent/tools/fillFormVision.js";
+import type { V3 } from "../../lib/v3/v3.js";
+
+describe("fillFormVisionTool variable redaction", () => {
+  it("returns playwrightArguments with %tokens%, never substituted secret values", async () => {
+    const typedValues: string[] = [];
+    const fakePage = {
+      click: vi.fn().mockResolvedValue("xpath=/html/body"),
+      type: vi.fn(async (text: string) => {
+        typedValues.push(text);
+      }),
+      waitForTimeout: vi.fn().mockResolvedValue(undefined),
+      screenshot: vi.fn().mockResolvedValue(Buffer.from("png")),
+    };
+
+    const fakeV3 = {
+      context: { awaitActivePage: async () => fakePage },
+      logger: () => {},
+      isAgentReplayActive: () => false,
+      recordAgentReplayStep: () => {},
+    } as unknown as V3;
+
+    const variables = {
+      username: { value: "john@example.com", description: "login email" },
+      password: "s3cret!",
+    };
+
+    const tool = fillFormVisionTool(fakeV3, undefined, variables);
+
+    const result = (await tool.execute(
+      {
+        fields: [
+          {
+            action: "type %username% into the email field",
+            value: "%username%",
+            coordinates: { x: 10, y: 20 },
+          },
+          {
+            action: "type %password% into the password field",
+            value: "%password%",
+            coordinates: { x: 30, y: 40 },
+          },
+        ],
+      },
+      {} as Parameters<typeof tool.execute>[1],
+    )) as {
+      success: boolean;
+      playwrightArguments?: Array<{
+        action: string;
+        value: string;
+        coordinates: { x: number; y: number };
+      }>;
+    };
+
+    expect(result.success).toBe(true);
+    expect(result.playwrightArguments).toBeDefined();
+
+    // The page must have received the substituted values for actual typing.
+    expect(typedValues).toEqual(["john@example.com", "s3cret!"]);
+
+    // The returned tool result must keep placeholder tokens, never raw secrets.
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("john@example.com");
+    expect(serialized).not.toContain("s3cret!");
+    expect(serialized).not.toContain("originalValue");
+
+    for (const field of result.playwrightArguments ?? []) {
+      expect(field.value.startsWith("%")).toBe(true);
+      expect(field.value.endsWith("%")).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
# why

currently, variables are behind experimental.

# what changed

- variables are no longer experimental as they have been used reliably for a while now 
- updated fillformVision to ensure variables are never logged / added to local cache consistent with all other tools. 

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Agent variables are now enabled by default. `fillFormVision` now substitutes variables only at typing time and keeps placeholder tokens in results/replay to prevent leaking secrets.

- **Refactors**
  - Removed the experimental gate for variables in agent validation.
  - Updated `fillFormVision` to preserve `%tokens%` in `playwrightArguments` and replay actions; secrets are only used when typing.

<sup>Written for commit f690c5bd945b49247e903b9f77472e4a10634f90. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

