### PR TITLE
fix(core): respect v3 piercer debug option

### DIFF
--- a/.changeset/fix-piercer-debug.md
+++ b/.changeset/fix-piercer-debug.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+fix(core): respect v3 piercer debug option

--- a/packages/core/lib/v3/dom/piercer.runtime.ts
+++ b/packages/core/lib/v3/dom/piercer.runtime.ts
@@ -31,8 +31,7 @@ declare global {
 }
 
 export function installV3ShadowPiercer(opts: V3ShadowPatchOptions = {}): void {
-  // hardcoded debug (remove later if desired)
-  const DEBUG = true;
+  const DEBUG = opts.debug ?? false;
 
   type PatchedFn = Element["attachShadow"] & {
     __v3Patched?: boolean;

--- a/packages/core/tests/unit/v3-piercer-debug.test.ts
+++ b/packages/core/tests/unit/v3-piercer-debug.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { installV3ShadowPiercer } from "../../lib/v3/dom/piercer.runtime";
+
+class TestElement {
+  tagName = "TEST-ELEMENT";
+
+  attachShadow(_init: ShadowRootInit): ShadowRoot {
+    return {} as ShadowRoot;
+  }
+}
+
+function installDomGlobals() {
+  vi.stubGlobal("Element", TestElement);
+  vi.stubGlobal("location", { href: "https://example.com" });
+  vi.stubGlobal("window", {
+    top: undefined,
+    __stagehandV3Injected: undefined,
+    __stagehandV3__: undefined,
+  });
+  window.top = window;
+}
+
+describe("installV3ShadowPiercer debug logging", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("does not log by default", () => {
+    installDomGlobals();
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    installV3ShadowPiercer();
+    new TestElement().attachShadow({ mode: "closed" });
+
+    expect(info).not.toHaveBeenCalled();
+  });
+
+  it("logs when debug is enabled", () => {
+    installDomGlobals();
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    installV3ShadowPiercer({ debug: true });
+    new TestElement().attachShadow({ mode: "closed" });
+
+    expect(info).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Uses `opts.debug ?? false` instead of always enabling V3 piercer debug logging
- Adds regression coverage for default-silent and debug-enabled behavior

Fixes #1996.

## Verification
- pnpm --filter @browserbasehq/stagehand run build
- pnpm --dir packages/core exec vitest run --config vitest.config.ts dist/esm/tests/unit/v3-piercer-debug.test.js

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes v3 shadow piercer logging to respect `debug`; default is silent unless `debug: true`. Adds a patch changeset for `@browserbasehq/stagehand`.

- **Bug Fixes**
  - Use `opts.debug ?? false` in `installV3ShadowPiercer`.
  - Add unit tests for default silent mode and debug-enabled logging.

<sup>Written for commit eb9315f5c81af8203b37b83fd03f66750d572e24. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2083?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

