### PR TITLE
[feat]: add `ignoreSelectors` to `extract()`

### DIFF
--- a/.changeset/blue-suns-post.md
+++ b/.changeset/blue-suns-post.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": minor
+---
+
+add ignoreSelectors param to extract()

--- a/packages/core/lib/v3/handlers/extractHandler.ts
+++ b/packages/core/lib/v3/handlers/extractHandler.ts
@@ -109,7 +109,15 @@ export class ExtractHandler {
   async extract<T extends StagehandZodSchema>(
     params: ExtractHandlerParams<T>,
   ): Promise<InferStagehandSchema<T> | { pageText: string }> {
-    const { instruction, schema, page, selector, timeout, model } = params;
+    const {
+      instruction,
+      schema,
+      page,
+      selector,
+      ignoreSelectors,
+      timeout,
+      model,
+    } = params;
 
     const llmClient = this.resolveLlmClient(model);
 
@@ -126,6 +134,7 @@ export class ExtractHandler {
       const snap = await captureHybridSnapshot(page, {
         experimental: this.experimental,
         focusSelector: focusSelector || undefined,
+        ignoreSelectors,
       });
       ensureTimeRemaining();
 
@@ -147,6 +156,7 @@ export class ExtractHandler {
     const { combinedTree, combinedUrlMap } = await captureHybridSnapshot(page, {
       experimental: this.experimental,
       focusSelector: focusSelector,
+      ignoreSelectors,
     });
 
     v3Logger({

--- a/packages/core/lib/v3/types/private/handlers.ts
+++ b/packages/core/lib/v3/types/private/handlers.ts
@@ -17,6 +17,7 @@ export interface ExtractHandlerParams<T extends StagehandZodSchema> {
   model?: ModelConfiguration;
   timeout?: number;
   selector?: string;
+  ignoreSelectors?: string[];
   page: Page;
 }
 

--- a/packages/core/lib/v3/types/private/snapshot.ts
+++ b/packages/core/lib/v3/types/private/snapshot.ts
@@ -8,6 +8,11 @@ export type SnapshotOptions = {
    */
   focusSelector?: string;
   /**
+   * Exclude matching elements and their descendants from the captured snapshot.
+   * Each selector may be XPath (prefixed with `xpath=` or starting with `/`) or CSS.
+   */
+  ignoreSelectors?: string[];
+  /**
    * Pierce shadow DOM when calling DOM.getDocument. Defaults to true to retain the
    * existing behaviour.
    */
@@ -54,6 +59,8 @@ export type SessionDomIndex = {
   scrollByBe: Map<number, boolean>;
   docRootOf: Map<number, number>;
   contentDocRootByIframe: Map<number, number>;
+  enterByBe: Map<number, number>;
+  exitByBe: Map<number, number>;
 };
 
 export type FrameDomMaps = {
@@ -104,6 +111,7 @@ export type A11yNode = {
 
 export type A11yOptions = {
   focusSelector?: string;
+  isIgnoredBackendNode?: (backendNodeId: number) => boolean;
   experimental: boolean;
   tagNameMap: Record<string, string>;
   scrollableMap: Record<string, boolean>;

--- a/packages/core/lib/v3/types/public/api.ts
+++ b/packages/core/lib/v3/types/public/api.ts
@@ -505,6 +505,14 @@ export const ExtractOptionsSchema = z
       description: "CSS selector to scope extraction to a specific element",
       example: "#main-content",
     }),
+    ignoreSelectors: z
+      .array(z.string())
+      .optional()
+      .meta({
+        description:
+          "Selectors for elements and subtrees that should be excluded from extraction",
+        example: ["nav", ".cookie-banner", "#sidebar-ads"],
+      }),
   })
   .optional()
   .meta({ id: "ExtractOptions" });

--- a/packages/core/lib/v3/types/public/methods.ts
+++ b/packages/core/lib/v3/types/public/methods.ts
@@ -54,6 +54,7 @@ export interface ExtractOptions {
   model?: ModelConfiguration;
   timeout?: number;
   selector?: string;
+  ignoreSelectors?: string[];
   page?: PlaywrightPage | PuppeteerPage | PatchrightPage | Page;
   /**
    * Override the instance-level serverCache setting for this request.

--- a/packages/core/lib/v3/understudy/a11y/snapshot/a11yTree.ts
+++ b/packages/core/lib/v3/understudy/a11y/snapshot/a11yTree.ts
@@ -42,16 +42,6 @@ export async function a11yForFrame(
     }>("Accessibility.getFullAXTree"));
   }
 
-  const urlMap: Record<string, string> = {};
-  for (const n of nodes) {
-    const be = n.backendDOMNodeId;
-    if (typeof be !== "number") continue;
-    const url = extractUrlFromAXNode(n);
-    if (!url) continue;
-    const enc = opts.encode(be);
-    urlMap[enc] = url;
-  }
-
   let scopeApplied = false;
   const nodesForOutline = await (async () => {
     const sel = opts.focusSelector?.trim();
@@ -92,7 +82,22 @@ export async function a11yForFrame(
     }
   })();
 
-  const decorated = decorateRoles(nodesForOutline, opts);
+  const filteredNodes = nodesForOutline.filter((node) => {
+    const be = node.backendDOMNodeId;
+    return typeof be !== "number" || !opts.isIgnoredBackendNode?.(be);
+  });
+
+  const urlMap: Record<string, string> = {};
+  for (const n of filteredNodes) {
+    const be = n.backendDOMNodeId;
+    if (typeof be !== "number") continue;
+    const url = extractUrlFromAXNode(n);
+    if (!url) continue;
+    const enc = opts.encode(be);
+    urlMap[enc] = url;
+  }
+
+  const decorated = decorateRoles(filteredNodes, opts);
   const { tree } = await buildHierarchicalTree(decorated, opts);
 
   const simplified = tree.map((n) => formatTreeLine(n)).join("\n");

--- a/packages/core/lib/v3/understudy/a11y/snapshot/capture.ts
+++ b/packages/core/lib/v3/understudy/a11y/snapshot/capture.ts
@@ -14,6 +14,8 @@ import { a11yForFrame } from "./a11yTree.js";
 import {
   resolveCssFocusFrameAndTail,
   resolveFocusFrameAndTail,
+  resolveObjectIdForCss,
+  resolveObjectIdForXPath,
 } from "./focusSelectors.js";
 import {
   buildSessionDomIndex,
@@ -23,6 +25,10 @@ import {
 import { injectSubtrees } from "./treeFormatUtils.js";
 import { ownerSession, parentSession } from "./sessions.js";
 import { normalizeXPath, prefixXPath } from "./xpathUtils.js";
+
+type IgnoreRootMap = Map<string, Set<number>>;
+type Interval = { start: number; end: number };
+type ExclusionIntervalsByFrame = Map<string, Interval[]>;
 
 /**
  * Capture a hybrid DOM + Accessibility snapshot for the provided page.
@@ -50,21 +56,34 @@ export async function captureHybridSnapshot(
   const includeIframes = options?.includeIframes !== false;
 
   const context = buildFrameContext(page);
-
-  const scopedSnapshot = await tryScopedSnapshot(
-    page,
-    options,
-    context,
-    pierce,
-  );
-  if (scopedSnapshot) return scopedSnapshot;
-
   const framesInScope = includeIframes ? [...context.frames] : [context.rootId];
   if (!framesInScope.includes(context.rootId)) {
     framesInScope.unshift(context.rootId);
   }
 
   const sessionToIndex = await buildSessionIndexes(page, framesInScope, pierce);
+  const ignoreRootsByFrame = await resolveIgnoreSelectorRoots(
+    page,
+    options?.ignoreSelectors,
+    context,
+    sessionToIndex,
+  );
+  const exclusionIntervalsByFrame = buildFrameExclusionIntervals(
+    page,
+    sessionToIndex,
+    ignoreRootsByFrame,
+  );
+
+  const scopedSnapshot = await tryScopedSnapshot(
+    page,
+    options,
+    context,
+    pierce,
+    sessionToIndex,
+    exclusionIntervalsByFrame,
+  );
+  if (scopedSnapshot) return scopedSnapshot;
+
   const { perFrameMaps, perFrameOutlines } = await collectPerFrameMaps(
     page,
     context,
@@ -72,6 +91,7 @@ export async function captureHybridSnapshot(
     options,
     pierce,
     framesInScope,
+    exclusionIntervalsByFrame,
   );
   const { absPrefix, iframeHostEncByChild } = await computeFramePrefixes(
     page,
@@ -121,6 +141,8 @@ export async function tryScopedSnapshot(
   options: SnapshotOptions | undefined,
   context: FrameContext,
   pierce: boolean,
+  sessionToIndex: Map<string, SessionDomIndex>,
+  exclusionIntervalsByFrame: ExclusionIntervalsByFrame,
 ): Promise<HybridSnapshot | null> {
   const requestedFocus = options?.focusSelector?.trim();
   if (!requestedFocus) return null;
@@ -186,6 +208,11 @@ export async function tryScopedSnapshot(
       targetFrameId,
       {
         focusSelector: tailSelector || undefined,
+        isIgnoredBackendNode: makeIsIgnoredBackendNode(
+          targetFrameId,
+          ownerSessionIndexForFrame(page, targetFrameId, sessionToIndex),
+          exclusionIntervalsByFrame,
+        ),
         tagNameMap,
         experimental: options?.experimental ?? false,
         scrollableMap,
@@ -195,13 +222,34 @@ export async function tryScopedSnapshot(
     );
 
     const scopedXpathMap: Record<string, string> = {};
+    const isIgnoredBackendNode = makeIsIgnoredBackendNode(
+      targetFrameId,
+      ownerSessionIndexForFrame(page, targetFrameId, sessionToIndex),
+      exclusionIntervalsByFrame,
+    );
     const abs = absPrefix ?? "";
     const isRoot = !abs || abs === "/";
     if (isRoot) {
-      Object.assign(scopedXpathMap, xpathMap);
+      for (const [encId, xp] of Object.entries(xpathMap)) {
+        const backendNodeId = parseEncodedBackendNodeId(encId);
+        if (
+          typeof backendNodeId === "number" &&
+          isIgnoredBackendNode?.(backendNodeId)
+        ) {
+          continue;
+        }
+        scopedXpathMap[encId] = xp;
+      }
     } else {
       // Prefix relative XPaths so the scoped result matches the global encoding.
       for (const [encId, xp] of Object.entries(xpathMap)) {
+        const backendNodeId = parseEncodedBackendNodeId(encId);
+        if (
+          typeof backendNodeId === "number" &&
+          isIgnoredBackendNode?.(backendNodeId)
+        ) {
+          continue;
+        }
         scopedXpathMap[encId] = prefixXPath(abs, xp);
       }
     }
@@ -272,6 +320,7 @@ export async function collectPerFrameMaps(
   options: SnapshotOptions | undefined,
   pierce: boolean,
   frameIds: string[],
+  exclusionIntervalsByFrame: ExclusionIntervalsByFrame,
 ): Promise<{
   perFrameMaps: Map<string, FrameDomMaps>;
   perFrameOutlines: Array<{ frameId: string; outline: string }>;
@@ -292,30 +341,28 @@ export async function collectPerFrameMaps(
     const sameSessionAsParent =
       !!parentId && ownerSession(page, parentId) === sess;
     let docRootBe = idx.rootBackend;
-    if (sameSessionAsParent) {
-      try {
-        const { backendNodeId } = await sess.send<{ backendNodeId?: number }>(
-          "DOM.getFrameOwner",
-          { frameId },
-        );
-        if (typeof backendNodeId === "number") {
-          const cdBe = idx.contentDocRootByIframe.get(backendNodeId);
-          if (typeof cdBe === "number") docRootBe = cdBe;
-        }
-      } catch {
-        //
-      }
-    }
+    docRootBe = await resolveFrameDocRootBackendId(
+      page,
+      frameId,
+      idx,
+      sameSessionAsParent,
+    );
 
     const tagNameMap: Record<string, string> = {};
     const xpathMap: Record<string, string> = {};
     const scrollableMap: Record<string, boolean> = {};
+    const isIgnoredBackendNode = makeIsIgnoredBackendNode(
+      frameId,
+      idx,
+      exclusionIntervalsByFrame,
+    );
     const enc = (be: number) => `${page.getOrdinal(frameId)}-${be}`;
     const baseAbs = idx.absByBe.get(docRootBe) ?? "/";
 
     for (const [be, nodeAbs] of idx.absByBe.entries()) {
       const nodeDocRoot = idx.docRootOf.get(be);
       if (nodeDocRoot !== docRootBe) continue;
+      if (isIgnoredBackendNode?.(be)) continue;
 
       // Translate absolute XPaths into document-relative ones for this frame.
       const rel = relativizeXPath(baseAbs, nodeAbs);
@@ -327,6 +374,7 @@ export async function collectPerFrameMaps(
     }
 
     const { outline, urlMap } = await a11yForFrame(sess, frameId, {
+      isIgnoredBackendNode,
       experimental: options?.experimental ?? false,
       tagNameMap,
       scrollableMap,
@@ -338,6 +386,226 @@ export async function collectPerFrameMaps(
   }
 
   return { perFrameMaps, perFrameOutlines };
+}
+
+export async function resolveIgnoreSelectorRoots(
+  page: Page,
+  ignoreSelectors: string[] | undefined,
+  context: FrameContext,
+  sessionToIndex: Map<string, SessionDomIndex>,
+): Promise<IgnoreRootMap> {
+  const rootsByFrame: IgnoreRootMap = new Map();
+
+  for (const rawSelector of ignoreSelectors ?? []) {
+    const selector = rawSelector.trim();
+    if (!selector) continue;
+
+    try {
+      const resolved = await resolveIgnoreSelectorRoot(
+        page,
+        selector,
+        context,
+        sessionToIndex,
+      );
+      if (!resolved) continue;
+      const roots = rootsByFrame.get(resolved.frameId) ?? new Set<number>();
+      roots.add(resolved.backendNodeId);
+      rootsByFrame.set(resolved.frameId, roots);
+    } catch {
+      continue;
+    }
+  }
+
+  return rootsByFrame;
+}
+
+async function resolveIgnoreSelectorRoot(
+  page: Page,
+  selector: string,
+  context: FrameContext,
+  sessionToIndex: Map<string, SessionDomIndex>,
+): Promise<{ frameId: string; backendNodeId: number } | null> {
+  const looksLikeXPath = /^xpath=/i.test(selector) || selector.startsWith("/");
+
+  if (looksLikeXPath) {
+    const hit = await resolveFocusFrameAndTail(
+      page,
+      normalizeXPath(selector),
+      context.parentByFrame,
+      context.rootId,
+    );
+    const targetFrameId = hit.targetFrameId;
+    const tailXPath = hit.tailXPath || "/";
+    const session = ownerSession(page, targetFrameId);
+    if (tailXPath === "/") {
+      const idx = ownerSessionIndexForFrame(
+        page,
+        targetFrameId,
+        sessionToIndex,
+      );
+      if (!idx) return null;
+      const parentId = context.parentByFrame.get(targetFrameId);
+      const sameSessionAsParent =
+        !!parentId &&
+        ownerSession(page, parentId) === ownerSession(page, targetFrameId);
+      const backendNodeId = await resolveFrameDocRootBackendId(
+        page,
+        targetFrameId,
+        idx,
+        sameSessionAsParent,
+      );
+      return { frameId: targetFrameId, backendNodeId };
+    }
+    const objectId = await resolveObjectIdForXPath(
+      session,
+      tailXPath,
+      targetFrameId,
+    );
+    if (!objectId) return null;
+    try {
+      const desc = await session.send<Protocol.DOM.DescribeNodeResponse>(
+        "DOM.describeNode",
+        { objectId },
+      );
+      const backendNodeId = desc.node.backendNodeId;
+      if (typeof backendNodeId !== "number") return null;
+      return { frameId: targetFrameId, backendNodeId };
+    } finally {
+      await session.send("Runtime.releaseObject", { objectId }).catch(() => {});
+    }
+  }
+
+  const hit = await resolveCssFocusFrameAndTail(
+    page,
+    selector,
+    context.parentByFrame,
+    context.rootId,
+  );
+  const targetFrameId = hit.targetFrameId;
+  const session = ownerSession(page, targetFrameId);
+  const objectId = await resolveObjectIdForCss(
+    session,
+    hit.tailSelector || selector,
+    targetFrameId,
+  );
+  if (!objectId) return null;
+  try {
+    const desc = await session.send<Protocol.DOM.DescribeNodeResponse>(
+      "DOM.describeNode",
+      { objectId },
+    );
+    const backendNodeId = desc.node.backendNodeId;
+    if (typeof backendNodeId !== "number") return null;
+    return { frameId: targetFrameId, backendNodeId };
+  } finally {
+    await session.send("Runtime.releaseObject", { objectId }).catch(() => {});
+  }
+}
+
+export function buildFrameExclusionIntervals(
+  page: Page,
+  sessionToIndex: Map<string, SessionDomIndex>,
+  ignoreRootsByFrame: IgnoreRootMap,
+): ExclusionIntervalsByFrame {
+  const intervalsByFrame: ExclusionIntervalsByFrame = new Map();
+
+  for (const [frameId, rootBackendIds] of ignoreRootsByFrame.entries()) {
+    const idx = ownerSessionIndexForFrame(page, frameId, sessionToIndex);
+    if (!idx) continue;
+    const intervals: Interval[] = [];
+
+    for (const backendNodeId of rootBackendIds) {
+      const start = idx.enterByBe.get(backendNodeId);
+      const end = idx.exitByBe.get(backendNodeId);
+      if (typeof start !== "number" || typeof end !== "number") continue;
+      intervals.push({ start, end });
+    }
+
+    if (!intervals.length) continue;
+
+    intervals.sort((a, b) => a.start - b.start || a.end - b.end);
+    const merged: Interval[] = [];
+    for (const interval of intervals) {
+      const prev = merged[merged.length - 1];
+      if (!prev || interval.start > prev.end) {
+        merged.push({ ...interval });
+        continue;
+      }
+      if (interval.end > prev.end) prev.end = interval.end;
+    }
+    intervalsByFrame.set(frameId, merged);
+  }
+
+  return intervalsByFrame;
+}
+
+function makeIsIgnoredBackendNode(
+  frameId: string,
+  idx: SessionDomIndex | undefined,
+  exclusionIntervalsByFrame: ExclusionIntervalsByFrame,
+): ((backendNodeId: number) => boolean) | undefined {
+  if (!idx) return undefined;
+  const intervals = exclusionIntervalsByFrame.get(frameId);
+  if (!intervals?.length) return undefined;
+
+  return (backendNodeId: number): boolean => {
+    const enter = idx.enterByBe.get(backendNodeId);
+    if (typeof enter !== "number") return false;
+
+    let lo = 0;
+    let hi = intervals.length - 1;
+    while (lo <= hi) {
+      const mid = (lo + hi) >> 1;
+      const interval = intervals[mid]!;
+      if (enter < interval.start) {
+        hi = mid - 1;
+      } else if (enter > interval.end) {
+        lo = mid + 1;
+      } else {
+        return true;
+      }
+    }
+    return false;
+  };
+}
+
+function parseEncodedBackendNodeId(encodedId: string): number | undefined {
+  const parts = encodedId.split("-");
+  if (parts.length !== 2) return undefined;
+  const backendNodeId = Number(parts[1]);
+  return Number.isFinite(backendNodeId) ? backendNodeId : undefined;
+}
+
+function ownerSessionIndexForFrame(
+  page: Page,
+  frameId: string,
+  sessionToIndex: Map<string, SessionDomIndex>,
+): SessionDomIndex | undefined {
+  const session = ownerSession(page, frameId);
+  return sessionToIndex.get(session.id ?? "root");
+}
+
+async function resolveFrameDocRootBackendId(
+  page: Page,
+  frameId: string,
+  idx: SessionDomIndex,
+  sameSessionAsParent: boolean,
+): Promise<number> {
+  if (!sameSessionAsParent) return idx.rootBackend;
+  const session = ownerSession(page, frameId);
+  try {
+    const { backendNodeId } = await session.send<{ backendNodeId?: number }>(
+      "DOM.getFrameOwner",
+      { frameId },
+    );
+    if (typeof backendNodeId === "number") {
+      const docRootBe = idx.contentDocRootByIframe.get(backendNodeId);
+      if (typeof docRootBe === "number") return docRootBe;
+    }
+  } catch {
+    //
+  }
+  return idx.rootBackend;
 }
 
 /**

--- a/packages/core/lib/v3/understudy/a11y/snapshot/capture.ts
+++ b/packages/core/lib/v3/understudy/a11y/snapshot/capture.ts
@@ -1,6 +1,12 @@
 import type { Protocol } from "devtools-protocol";
 import type { CDPSessionLike } from "../../cdp.js";
 import { Page } from "../../page.js";
+import { Frame } from "../../frame.js";
+import {
+  FrameSelectorResolver,
+  type ResolvedNode,
+  type SelectorQuery,
+} from "../../selectorResolver.js";
 import { v3Logger } from "../../../logger.js";
 import type {
   FrameContext,
@@ -14,8 +20,7 @@ import { a11yForFrame } from "./a11yTree.js";
 import {
   resolveCssFocusFrameAndTail,
   resolveFocusFrameAndTail,
-  resolveObjectIdForCss,
-  resolveObjectIdForXPath,
+  listChildrenOf,
 } from "./focusSelectors.js";
 import {
   buildSessionDomIndex,
@@ -26,9 +31,11 @@ import { injectSubtrees } from "./treeFormatUtils.js";
 import { ownerSession, parentSession } from "./sessions.js";
 import { normalizeXPath, prefixXPath } from "./xpathUtils.js";
 
-type IgnoreRootMap = Map<string, Set<number>>;
+type IgnoredNodeMap = Map<string, Set<number>>;
 type Interval = { start: number; end: number };
 type ExclusionIntervalsByFrame = Map<string, Interval[]>;
+type ChildFrameHost = { childFrameId: string; hostBackendNodeId: number };
+type ChildFramesByParent = Map<string, ChildFrameHost[]>;
 
 /**
  * Capture a hybrid DOM + Accessibility snapshot for the provided page.
@@ -75,16 +82,17 @@ export async function captureHybridSnapshot(
   }
 
   const sessionToIndex = await buildSessionIndexes(page, framesInScope, pierce);
-  const ignoreRootsByFrame = await resolveIgnoreSelectorRoots(
+  const ignoredNodesByFrame = await resolveIgnoredNodes(
     page,
     options?.ignoreSelectors,
     context,
     sessionToIndex,
   );
-  const exclusionIntervalsByFrame = buildFrameExclusionIntervals(
+  const exclusionIntervalsByFrame = await buildFrameExclusionIntervals(
     page,
+    context,
     sessionToIndex,
-    ignoreRootsByFrame,
+    ignoredNodesByFrame,
   );
   if (hasIgnoreSelectors) {
     const scopedSnapshot = await tryScopedSnapshot(
@@ -402,43 +410,45 @@ export async function collectPerFrameMaps(
   return { perFrameMaps, perFrameOutlines };
 }
 
-export async function resolveIgnoreSelectorRoots(
+export async function resolveIgnoredNodes(
   page: Page,
   ignoreSelectors: string[] | undefined,
   context: FrameContext,
   sessionToIndex: Map<string, SessionDomIndex>,
-): Promise<IgnoreRootMap> {
-  const rootsByFrame: IgnoreRootMap = new Map();
+): Promise<IgnoredNodeMap> {
+  const ignoredNodesByFrame: IgnoredNodeMap = new Map();
 
   for (const rawSelector of ignoreSelectors ?? []) {
     const selector = rawSelector.trim();
     if (!selector) continue;
 
     try {
-      const resolved = await resolveIgnoreSelectorRoot(
+      const resolved = await resolveIgnoredNodesForSelector(
         page,
         selector,
         context,
         sessionToIndex,
       );
-      if (!resolved) continue;
-      const roots = rootsByFrame.get(resolved.frameId) ?? new Set<number>();
-      roots.add(resolved.backendNodeId);
-      rootsByFrame.set(resolved.frameId, roots);
+      for (const match of resolved) {
+        const nodes =
+          ignoredNodesByFrame.get(match.frameId) ?? new Set<number>();
+        nodes.add(match.backendNodeId);
+        ignoredNodesByFrame.set(match.frameId, nodes);
+      }
     } catch {
       continue;
     }
   }
 
-  return rootsByFrame;
+  return ignoredNodesByFrame;
 }
 
-async function resolveIgnoreSelectorRoot(
+async function resolveIgnoredNodesForSelector(
   page: Page,
   selector: string,
   context: FrameContext,
   sessionToIndex: Map<string, SessionDomIndex>,
-): Promise<{ frameId: string; backendNodeId: number } | null> {
+): Promise<Array<{ frameId: string; backendNodeId: number }>> {
   const looksLikeXPath = /^xpath=/i.test(selector) || selector.startsWith("/");
 
   if (looksLikeXPath) {
@@ -450,14 +460,13 @@ async function resolveIgnoreSelectorRoot(
     );
     const targetFrameId = hit.targetFrameId;
     const tailXPath = hit.tailXPath || "/";
-    const session = ownerSession(page, targetFrameId);
     if (tailXPath === "/") {
       const idx = ownerSessionIndexForFrame(
         page,
         targetFrameId,
         sessionToIndex,
       );
-      if (!idx) return null;
+      if (!idx) return [];
       const parentId = context.parentByFrame.get(targetFrameId);
       const sameSessionAsParent =
         !!parentId &&
@@ -468,25 +477,12 @@ async function resolveIgnoreSelectorRoot(
         idx,
         sameSessionAsParent,
       );
-      return { frameId: targetFrameId, backendNodeId };
+      return [{ frameId: targetFrameId, backendNodeId }];
     }
-    const objectId = await resolveObjectIdForXPath(
-      session,
-      tailXPath,
-      targetFrameId,
-    );
-    if (!objectId) return null;
-    try {
-      const desc = await session.send<Protocol.DOM.DescribeNodeResponse>(
-        "DOM.describeNode",
-        { objectId },
-      );
-      const backendNodeId = desc.node.backendNodeId;
-      if (typeof backendNodeId !== "number") return null;
-      return { frameId: targetFrameId, backendNodeId };
-    } finally {
-      await session.send("Runtime.releaseObject", { objectId }).catch(() => {});
-    }
+    return resolveIgnoredNodesInFrame(page, targetFrameId, {
+      kind: "xpath",
+      value: tailXPath,
+    });
   }
 
   const hit = await resolveCssFocusFrameAndTail(
@@ -496,47 +492,127 @@ async function resolveIgnoreSelectorRoot(
     context.rootId,
   );
   const targetFrameId = hit.targetFrameId;
-  const session = ownerSession(page, targetFrameId);
-  const objectId = await resolveObjectIdForCss(
-    session,
-    hit.tailSelector || selector,
-    targetFrameId,
-  );
-  if (!objectId) return null;
-  try {
-    const desc = await session.send<Protocol.DOM.DescribeNodeResponse>(
-      "DOM.describeNode",
-      { objectId },
-    );
-    const backendNodeId = desc.node.backendNodeId;
-    if (typeof backendNodeId !== "number") return null;
-    return { frameId: targetFrameId, backendNodeId };
-  } finally {
-    await session.send("Runtime.releaseObject", { objectId }).catch(() => {});
-  }
+  return resolveIgnoredNodesInFrame(page, targetFrameId, {
+    kind: "css",
+    value: hit.tailSelector || selector,
+  });
 }
 
-export function buildFrameExclusionIntervals(
+async function resolveIgnoredNodesInFrame(
   page: Page,
+  frameId: string,
+  query: SelectorQuery,
+): Promise<Array<{ frameId: string; backendNodeId: number }>> {
+  const session = ownerSession(page, frameId);
+  const frame = new Frame(session, frameId, "", false);
+  const resolver = new FrameSelectorResolver(frame);
+  const resolvedNodes = await resolver.resolveAll(query);
+  if (!resolvedNodes.length) return [];
+
+  const backendNodeIds = await describeResolvedNodes(session, resolvedNodes);
+  return backendNodeIds.map((backendNodeId) => ({ frameId, backendNodeId }));
+}
+
+async function describeResolvedNodes(
+  session: CDPSessionLike,
+  resolvedNodes: ResolvedNode[],
+): Promise<number[]> {
+  const backendNodeIds = new Set<number>();
+
+  try {
+    for (const resolvedNode of resolvedNodes) {
+      const desc = await session.send<Protocol.DOM.DescribeNodeResponse>(
+        "DOM.describeNode",
+        { objectId: resolvedNode.objectId },
+      );
+      const backendNodeId = desc.node.backendNodeId;
+      if (typeof backendNodeId === "number") {
+        backendNodeIds.add(backendNodeId);
+      }
+    }
+  } finally {
+    await Promise.all(
+      resolvedNodes.map((resolvedNode) =>
+        session
+          .send("Runtime.releaseObject", { objectId: resolvedNode.objectId })
+          .catch(() => {}),
+      ),
+    );
+  }
+
+  return [...backendNodeIds];
+}
+
+export async function buildFrameExclusionIntervals(
+  page: Page,
+  context: FrameContext,
   sessionToIndex: Map<string, SessionDomIndex>,
-  ignoreRootsByFrame: IgnoreRootMap,
-): ExclusionIntervalsByFrame {
+  ignoredNodesByFrame: IgnoredNodeMap,
+): Promise<ExclusionIntervalsByFrame> {
   const intervalsByFrame: ExclusionIntervalsByFrame = new Map();
+  if (!ignoredNodesByFrame.size) return intervalsByFrame;
+  const childFramesByParent = await resolveChildFramesByParent(page, context);
+  const excludedFrames = new Set<string>();
 
-  for (const [frameId, rootBackendIds] of ignoreRootsByFrame.entries()) {
+  const pushInterval = (frameId: string, start: number, end: number) => {
+    const intervals = intervalsByFrame.get(frameId) ?? [];
+    intervals.push({ start, end });
+    intervalsByFrame.set(frameId, intervals);
+  };
+
+  const excludeFrameSubtree = async (frameId: string): Promise<void> => {
+    if (excludedFrames.has(frameId)) return;
+    excludedFrames.add(frameId);
+
     const idx = ownerSessionIndexForFrame(page, frameId, sessionToIndex);
-    if (!idx) continue;
-    const intervals: Interval[] = [];
-
-    for (const backendNodeId of rootBackendIds) {
-      const start = idx.enterByBe.get(backendNodeId);
-      const end = idx.exitByBe.get(backendNodeId);
-      if (typeof start !== "number" || typeof end !== "number") continue;
-      intervals.push({ start, end });
+    if (!idx) return;
+    const parentId = context.parentByFrame.get(frameId);
+    const sameSessionAsParent =
+      !!parentId &&
+      ownerSession(page, parentId) === ownerSession(page, frameId);
+    const docRootBe = await resolveFrameDocRootBackendId(
+      page,
+      frameId,
+      idx,
+      sameSessionAsParent,
+    );
+    const start = idx.enterByBe.get(docRootBe);
+    const end = idx.exitByBe.get(docRootBe);
+    if (typeof start === "number" && typeof end === "number") {
+      pushInterval(frameId, start, end);
     }
 
-    if (!intervals.length) continue;
+    for (const childFrameId of listChildrenOf(context.parentByFrame, frameId)) {
+      await excludeFrameSubtree(childFrameId);
+    }
+  };
 
+  const excludeIgnoredNode = async (
+    frameId: string,
+    backendNodeId: number,
+  ): Promise<void> => {
+    const idx = ownerSessionIndexForFrame(page, frameId, sessionToIndex);
+    if (!idx) return;
+    const start = idx.enterByBe.get(backendNodeId);
+    const end = idx.exitByBe.get(backendNodeId);
+    if (typeof start !== "number" || typeof end !== "number") return;
+
+    pushInterval(frameId, start, end);
+    for (const childFrame of childFramesByParent.get(frameId) ?? []) {
+      const hostEnter = idx.enterByBe.get(childFrame.hostBackendNodeId);
+      if (typeof hostEnter !== "number") continue;
+      if (hostEnter < start || hostEnter > end) continue;
+      await excludeFrameSubtree(childFrame.childFrameId);
+    }
+  };
+
+  for (const [frameId, backendNodeIds] of ignoredNodesByFrame.entries()) {
+    for (const backendNodeId of backendNodeIds) {
+      await excludeIgnoredNode(frameId, backendNodeId);
+    }
+  }
+
+  for (const [frameId, intervals] of intervalsByFrame.entries()) {
     intervals.sort((a, b) => a.start - b.start || a.end - b.end);
     const merged: Interval[] = [];
     for (const interval of intervals) {
@@ -551,6 +627,39 @@ export function buildFrameExclusionIntervals(
   }
 
   return intervalsByFrame;
+}
+
+async function resolveChildFramesByParent(
+  page: Page,
+  context: FrameContext,
+): Promise<ChildFramesByParent> {
+  const childFramesByParent: ChildFramesByParent = new Map();
+
+  for (const frameId of context.frames) {
+    const parentId = context.parentByFrame.get(frameId);
+    if (!parentId) continue;
+
+    const session = parentSession(page, context.parentByFrame, frameId);
+    if (!session) continue;
+
+    try {
+      const { backendNodeId } = await session.send<{ backendNodeId?: number }>(
+        "DOM.getFrameOwner",
+        { frameId },
+      );
+      if (typeof backendNodeId !== "number") continue;
+      const childFrames = childFramesByParent.get(parentId) ?? [];
+      childFrames.push({
+        childFrameId: frameId,
+        hostBackendNodeId: backendNodeId,
+      });
+      childFramesByParent.set(parentId, childFrames);
+    } catch {
+      continue;
+    }
+  }
+
+  return childFramesByParent;
 }
 
 function makeIsIgnoredBackendNode(

--- a/packages/core/lib/v3/understudy/a11y/snapshot/capture.ts
+++ b/packages/core/lib/v3/understudy/a11y/snapshot/capture.ts
@@ -54,11 +54,24 @@ export async function captureHybridSnapshot(
 ): Promise<HybridSnapshot> {
   const pierce = options?.pierceShadow ?? true;
   const includeIframes = options?.includeIframes !== false;
+  const hasIgnoreSelectors = (options?.ignoreSelectors?.length ?? 0) > 0;
 
   const context = buildFrameContext(page);
   const framesInScope = includeIframes ? [...context.frames] : [context.rootId];
   if (!framesInScope.includes(context.rootId)) {
     framesInScope.unshift(context.rootId);
+  }
+
+  if (!hasIgnoreSelectors) {
+    const scopedSnapshot = await tryScopedSnapshot(
+      page,
+      options,
+      context,
+      pierce,
+      new Map<string, SessionDomIndex>(),
+      new Map(),
+    );
+    if (scopedSnapshot) return scopedSnapshot;
   }
 
   const sessionToIndex = await buildSessionIndexes(page, framesInScope, pierce);
@@ -73,16 +86,17 @@ export async function captureHybridSnapshot(
     sessionToIndex,
     ignoreRootsByFrame,
   );
-
-  const scopedSnapshot = await tryScopedSnapshot(
-    page,
-    options,
-    context,
-    pierce,
-    sessionToIndex,
-    exclusionIntervalsByFrame,
-  );
-  if (scopedSnapshot) return scopedSnapshot;
+  if (hasIgnoreSelectors) {
+    const scopedSnapshot = await tryScopedSnapshot(
+      page,
+      options,
+      context,
+      pierce,
+      sessionToIndex,
+      exclusionIntervalsByFrame,
+    );
+    if (scopedSnapshot) return scopedSnapshot;
+  }
 
   const { perFrameMaps, perFrameOutlines } = await collectPerFrameMaps(
     page,

--- a/packages/core/lib/v3/understudy/a11y/snapshot/capture.ts
+++ b/packages/core/lib/v3/understudy/a11y/snapshot/capture.ts
@@ -340,8 +340,8 @@ export async function collectPerFrameMaps(
     const parentId = context.parentByFrame.get(frameId);
     const sameSessionAsParent =
       !!parentId && ownerSession(page, parentId) === sess;
-    let docRootBe = idx.rootBackend;
-    docRootBe = await resolveFrameDocRootBackendId(
+
+    const docRootBe = await resolveFrameDocRootBackendId(
       page,
       frameId,
       idx,

--- a/packages/core/lib/v3/understudy/a11y/snapshot/domTree.ts
+++ b/packages/core/lib/v3/understudy/a11y/snapshot/domTree.ts
@@ -266,19 +266,39 @@ export async function buildSessionDomIndex(
   const scrollByBe = new Map<number, boolean>();
   const docRootOf = new Map<number, number>();
   const contentDocRootByIframe = new Map<number, number>();
+  const enterByBe = new Map<number, number>();
+  const exitByBe = new Map<number, number>();
 
-  type Entry = { node: Protocol.DOM.Node; xp: string; docRootBe: number };
+  type Entry = {
+    node: Protocol.DOM.Node;
+    xp: string;
+    docRootBe: number;
+    phase: "enter" | "exit";
+  };
   const rootBe = root.backendNodeId!;
-  const stack: Entry[] = [{ node: root, xp: "/", docRootBe: rootBe }];
+  const stack: Entry[] = [
+    { node: root, xp: "/", docRootBe: rootBe, phase: "enter" },
+  ];
+  let dfsIndex = 0;
 
   while (stack.length) {
-    const { node, xp, docRootBe } = stack.pop()!;
+    const { node, xp, docRootBe, phase } = stack.pop()!;
+    if (phase === "exit") {
+      if (node.backendNodeId) {
+        exitByBe.set(node.backendNodeId, dfsIndex++);
+      }
+      continue;
+    }
+
     if (node.backendNodeId) {
+      enterByBe.set(node.backendNodeId, dfsIndex++);
       absByBe.set(node.backendNodeId, xp || "/");
       tagByBe.set(node.backendNodeId, enrichedTagName(node));
       if (node?.isScrollable === true) scrollByBe.set(node.backendNodeId, true);
       docRootOf.set(node.backendNodeId, docRootBe);
     }
+
+    stack.push({ node, xp, docRootBe, phase: "exit" });
 
     const kids = node.children ?? [];
     if (kids.length) {
@@ -286,18 +306,33 @@ export async function buildSessionDomIndex(
       for (let i = kids.length - 1; i >= 0; i--) {
         const child = kids[i]!;
         const step = segs[i]!;
-        stack.push({ node: child, xp: joinXPath(xp, step), docRootBe });
+        stack.push({
+          node: child,
+          xp: joinXPath(xp, step),
+          docRootBe,
+          phase: "enter",
+        });
       }
     }
 
     for (const sr of node.shadowRoots ?? []) {
-      stack.push({ node: sr, xp: joinXPath(xp, "//"), docRootBe });
+      stack.push({
+        node: sr,
+        xp: joinXPath(xp, "//"),
+        docRootBe,
+        phase: "enter",
+      });
     }
 
     const cd = node.contentDocument as Protocol.DOM.Node | undefined;
     if (cd && typeof cd.backendNodeId === "number") {
       contentDocRootByIframe.set(node.backendNodeId!, cd.backendNodeId);
-      stack.push({ node: cd, xp, docRootBe: cd.backendNodeId });
+      stack.push({
+        node: cd,
+        xp,
+        docRootBe: cd.backendNodeId,
+        phase: "enter",
+      });
     }
   }
 
@@ -308,6 +343,8 @@ export async function buildSessionDomIndex(
     scrollByBe,
     docRootOf,
     contentDocRootByIframe,
+    enterByBe,
+    exitByBe,
   };
 }
 

--- a/packages/core/lib/v3/v3.ts
+++ b/packages/core/lib/v3/v3.ts
@@ -1442,6 +1442,7 @@ export class V3 {
         model: options?.model,
         timeout: options?.timeout,
         selector: options?.selector,
+        ignoreSelectors: options?.ignoreSelectors,
         page,
       };
       let result: z.infer<typeof effectiveSchema> | { pageText: string };
@@ -1465,6 +1466,7 @@ export class V3 {
         {
           instruction,
           selector: options?.selector,
+          ignoreSelectors: options?.ignoreSelectors,
           timeout: options?.timeout,
           schema: historySchemaDescriptor,
         },

--- a/packages/core/tests/unit/public-api/public-types.test.ts
+++ b/packages/core/tests/unit/public-api/public-types.test.ts
@@ -152,6 +152,7 @@ describe("Stagehand public API types", () => {
       model?: Stagehand.ModelConfiguration;
       timeout?: number;
       selector?: string;
+      ignoreSelectors?: string[];
       page?: Stagehand.AnyPage;
       serverCache?: boolean;
     };

--- a/packages/core/tests/unit/snapshot-a11y-resolvers.test.ts
+++ b/packages/core/tests/unit/snapshot-a11y-resolvers.test.ts
@@ -9,6 +9,7 @@ import { tryScopedSnapshot } from "../../lib/v3/understudy/a11y/snapshot/capture
 import type {
   FrameContext,
   A11yOptions,
+  SessionDomIndex,
 } from "../../lib/v3/types/private/index.js";
 import type { Page } from "../../lib/v3/understudy/page.js";
 import * as domTree from "../../lib/v3/understudy/a11y/snapshot/domTree.js";
@@ -146,6 +147,45 @@ describe("a11yForFrame", () => {
     const result = await a11yForFrame(session, "frame-1", opts);
     expect(result.scopeApplied).toBe(false);
   });
+
+  it("filters ignored backend nodes from outline and url map", async () => {
+    const nodes = [
+      ...baseAxNodes(),
+      {
+        nodeId: "3",
+        role: { type: stringType, value: "link" },
+        name: { type: stringType, value: "Ignore me" },
+        backendDOMNodeId: 102,
+        parentId: "1",
+        childIds: [] as string[],
+        properties: [
+          {
+            name: "url",
+            value: { type: stringType, value: "https://ignored.example.com" },
+          },
+        ],
+        ignored: false,
+      },
+    ];
+
+    const session = new MockCDPSession({
+      ...baseHandlers,
+      "Accessibility.getFullAXTree": async () => ({ nodes }),
+    });
+
+    const result = await a11yForFrame(session, "frame-1", {
+      focusSelector: undefined,
+      isIgnoredBackendNode: (backendNodeId) => backendNodeId === 102,
+      experimental: false,
+      tagNameMap: { "enc-100": "#document", "enc-101": "a", "enc-102": "a" },
+      scrollableMap: {},
+      encode: (backend) => `enc-${backend}`,
+    });
+
+    expect(result.outline).toContain("Docs");
+    expect(result.outline).not.toContain("Ignore me");
+    expect(result.urlMap["enc-102"]).toBeUndefined();
+  });
 });
 
 describe("resolveObjectIdForXPath", () => {
@@ -265,6 +305,40 @@ describe("tryScopedSnapshot", () => {
       ["frame-2", "frame-1"],
     ]),
   };
+  const sessionIndex: SessionDomIndex = {
+    rootBackend: 100,
+    absByBe: new Map([
+      [100, "/"],
+      [101, "/html[1]"],
+      [102, "/html[1]/body[1]"],
+      [200, "/html[1]/body[1]/iframe[1]"],
+      [201, "/html[1]/body[1]/iframe[1]/div[1]"],
+    ]),
+    tagByBe: new Map(),
+    scrollByBe: new Map(),
+    docRootOf: new Map([
+      [100, 100],
+      [101, 100],
+      [102, 100],
+      [200, 200],
+      [201, 200],
+    ]),
+    contentDocRootByIframe: new Map(),
+    enterByBe: new Map([
+      [100, 0],
+      [101, 1],
+      [102, 2],
+      [200, 3],
+      [201, 4],
+    ]),
+    exitByBe: new Map([
+      [101, 5],
+      [102, 6],
+      [201, 7],
+      [200, 8],
+      [100, 9],
+    ]),
+  };
 
   const makePage = (session: MockCDPSession, overrides?: Partial<Page>): Page =>
     ({
@@ -308,6 +382,8 @@ describe("tryScopedSnapshot", () => {
       { focusSelector: ".btn" },
       context,
       true,
+      new Map([[session.id, sessionIndex]]),
+      new Map(),
     );
 
     expect(result).not.toBeNull();
@@ -337,6 +413,8 @@ describe("tryScopedSnapshot", () => {
       { focusSelector: ".btn" },
       context,
       false,
+      new Map([[session.id, sessionIndex]]),
+      new Map(),
     );
 
     expect(result).toBeNull();
@@ -349,6 +427,8 @@ describe("tryScopedSnapshot", () => {
       {},
       context,
       true,
+      new Map(),
+      new Map(),
     );
     expect(result).toBeNull();
   });
@@ -376,6 +456,8 @@ describe("tryScopedSnapshot", () => {
       { focusSelector: "xpath=//div" },
       context,
       true,
+      new Map([[session.id, sessionIndex]]),
+      new Map(),
     );
 
     expect(result).not.toBeNull();
@@ -394,9 +476,56 @@ describe("tryScopedSnapshot", () => {
       { focusSelector: ".bad" },
       context,
       true,
+      new Map([[session.id, sessionIndex]]),
+      new Map(),
     );
 
     expect(result).toBeNull();
     expect(loggerSpy).toHaveBeenCalled();
+  });
+
+  it("filters ignored xpath entries in the scoped snapshot", async () => {
+    const session = new MockCDPSession({});
+    vi.spyOn(domTree, "domMapsForSession").mockResolvedValue({
+      tagNameMap: { "1-10": "div", "1-11": "div" },
+      xpathMap: { "1-10": "/div[1]", "1-11": "/div[2]" },
+      scrollableMap: {},
+    });
+    vi.spyOn(a11yTree, "a11yForFrame").mockResolvedValue({
+      outline: "[1-11] div",
+      urlMap: {},
+      scopeApplied: true,
+    } as AccessibilityTreeResult);
+    vi.spyOn(focusSelectors, "resolveCssFocusFrameAndTail").mockResolvedValue({
+      targetFrameId: "frame-2",
+      tailSelector: ".btn-inner",
+      absPrefix: "/html/body/iframe[1]",
+    });
+
+    const scopedIndex: SessionDomIndex = {
+      ...sessionIndex,
+      enterByBe: new Map([
+        [10, 0],
+        [11, 3],
+      ]),
+      exitByBe: new Map([
+        [10, 2],
+        [11, 4],
+      ]),
+    };
+
+    const result = await tryScopedSnapshot(
+      makePage(session),
+      { focusSelector: ".btn" },
+      context,
+      true,
+      new Map([[session.id, scopedIndex]]),
+      new Map([["frame-2", [{ start: 0, end: 2 }]]]),
+    );
+
+    expect(result?.combinedXpathMap["1-10"]).toBeUndefined();
+    expect(result?.combinedXpathMap["1-11"]).toBe(
+      "/html/body/iframe[1]/div[2]",
+    );
   });
 });

--- a/packages/core/tests/unit/snapshot-capture-orchestration.test.ts
+++ b/packages/core/tests/unit/snapshot-capture-orchestration.test.ts
@@ -78,6 +78,22 @@ const makeSessionIndex = (): SessionDomIndex => ({
     [201, 200],
   ]),
   contentDocRootByIframe: new Map([[150, 200]]),
+  enterByBe: new Map([
+    [100, 0],
+    [101, 1],
+    [102, 2],
+    [150, 3],
+    [200, 4],
+    [201, 5],
+  ]),
+  exitByBe: new Map([
+    [101, 6],
+    [102, 7],
+    [201, 8],
+    [200, 9],
+    [150, 10],
+    [100, 11],
+  ]),
 });
 
 beforeEach(() => {
@@ -216,6 +232,7 @@ describe("collectPerFrameMaps", () => {
       { experimental: true },
       true,
       context.frames,
+      new Map(),
     );
 
     expect(result.perFrameOutlines).toEqual([
@@ -265,6 +282,7 @@ describe("collectPerFrameMaps", () => {
       undefined,
       false,
       context.frames,
+      new Map(),
     );
 
     expect(buildSpy).toHaveBeenCalledWith(session, false);
@@ -302,6 +320,7 @@ describe("collectPerFrameMaps", () => {
       undefined,
       true,
       ["frame-1"],
+      new Map(),
     );
 
     expect(a11ySpy).toHaveBeenCalledTimes(1);
@@ -337,9 +356,7 @@ describe("captureHybridSnapshot", () => {
     });
     const buildIndexSpy = vi
       .spyOn(domTree, "buildSessionDomIndex")
-      .mockImplementation(() => {
-        throw new Error("should not build session index when scoped");
-      });
+      .mockResolvedValue(makeSessionIndex());
 
     const result = await capture.captureHybridSnapshot(page, options);
 
@@ -347,7 +364,7 @@ describe("captureHybridSnapshot", () => {
     expect(result.combinedUrlMap["0-100"]).toBe("https://frame-1.test");
     expect(domMapsSpy).toHaveBeenCalled();
     expect(a11ySpy).toHaveBeenCalled();
-    expect(buildIndexSpy).not.toHaveBeenCalled();
+    expect(buildIndexSpy).toHaveBeenCalled();
   });
 
   it("scoped snapshot still succeeds when iframe inclusion is disabled", async () => {
@@ -376,9 +393,7 @@ describe("captureHybridSnapshot", () => {
     });
     const buildIndexSpy = vi
       .spyOn(domTree, "buildSessionDomIndex")
-      .mockImplementation(() => {
-        throw new Error("should not build session index when scoped");
-      });
+      .mockResolvedValue(makeSessionIndex());
 
     const result = await capture.captureHybridSnapshot(page, options);
 
@@ -386,7 +401,57 @@ describe("captureHybridSnapshot", () => {
     expect(result.combinedUrlMap["0-100"]).toBe("https://frame-1.test");
     expect(domMapsSpy).toHaveBeenCalled();
     expect(a11ySpy).toHaveBeenCalled();
-    expect(buildIndexSpy).not.toHaveBeenCalled();
+    expect(buildIndexSpy).toHaveBeenCalled();
+  });
+
+  it("filters ignored nodes out of the merged snapshot artifacts", async () => {
+    const session = new MockCDPSession(
+      {
+        "DOM.getFrameOwner": async () => ({ backendNodeId: 150 }),
+        "DOM.describeNode": async () => ({ node: { backendNodeId: 201 } }),
+      },
+      "session-a",
+    );
+    const page = makePage({
+      asProtocolFrameTree: () =>
+        makeFrameTree("frame-1", [makeFrameTree("frame-2")]),
+      listAllFrameIds: () => ["frame-1", "frame-2"],
+      getSessionForFrame: () => session,
+      getOrdinal: (frameId: string) => (frameId === "frame-1" ? 0 : 1),
+    });
+
+    const idx = makeSessionIndex();
+    vi.spyOn(domTree, "buildSessionDomIndex").mockResolvedValue(idx);
+    vi.spyOn(focusSelectors, "resolveCssFocusFrameAndTail").mockResolvedValue({
+      targetFrameId: "frame-2",
+      tailSelector: ".ad",
+      absPrefix: "/html/body/iframe[1]",
+    });
+    vi.spyOn(focusSelectors, "resolveObjectIdForCss").mockResolvedValue(
+      "ignored-object",
+    );
+    vi.spyOn(a11yTree, "a11yForFrame").mockImplementation(
+      async (_sess, frameId, opts) => ({
+        outline: opts.isIgnoredBackendNode?.(201)
+          ? `outline-${frameId}-filtered`
+          : `outline-${frameId}`,
+        urlMap:
+          frameId === "frame-2" && opts.isIgnoredBackendNode?.(201)
+            ? {}
+            : { [`url-${frameId}`]: `https://${frameId}.test` },
+        scopeApplied: false,
+      }),
+    );
+
+    const snapshot = await capture.captureHybridSnapshot(page, {
+      ignoreSelectors: [".ad"],
+    });
+
+    expect(snapshot.combinedXpathMap["1-201"]).toBeUndefined();
+    expect(snapshot.combinedUrlMap["url-frame-2"]).toBeUndefined();
+    expect(
+      snapshot.perFrame?.find((frame) => frame.frameId === "frame-2")?.outline,
+    ).toContain("filtered");
   });
 
   it("collects per-frame data and merges it when no scoped snapshot is available", async () => {

--- a/packages/core/tests/unit/snapshot-capture-orchestration.test.ts
+++ b/packages/core/tests/unit/snapshot-capture-orchestration.test.ts
@@ -10,6 +10,7 @@ import * as capture from "../../lib/v3/understudy/a11y/snapshot/capture.js";
 import * as a11yTree from "../../lib/v3/understudy/a11y/snapshot/a11yTree.js";
 import * as domTree from "../../lib/v3/understudy/a11y/snapshot/domTree.js";
 import * as focusSelectors from "../../lib/v3/understudy/a11y/snapshot/focusSelectors.js";
+import { FrameSelectorResolver } from "../../lib/v3/understudy/selectorResolver.js";
 import { MockCDPSession } from "./helpers/mockCDPSession.js";
 
 const makeProtocolFrame = (id: string): Protocol.Page.Frame =>
@@ -408,7 +409,16 @@ describe("captureHybridSnapshot", () => {
     const session = new MockCDPSession(
       {
         "DOM.getFrameOwner": async () => ({ backendNodeId: 150 }),
-        "DOM.describeNode": async () => ({ node: { backendNodeId: 201 } }),
+        "DOM.describeNode": async (params) => ({
+          node: {
+            backendNodeId:
+              params?.objectId === "ignored-object-a"
+                ? 201
+                : params?.objectId === "ignored-object-b"
+                  ? 202
+                  : 0,
+          },
+        }),
       },
       "session-a",
     );
@@ -421,22 +431,35 @@ describe("captureHybridSnapshot", () => {
     });
 
     const idx = makeSessionIndex();
+    idx.absByBe.set(202, "/html[1]/body[1]/iframe[1]/aside[1]");
+    idx.tagByBe.set(202, "aside");
+    idx.docRootOf.set(202, 200);
+    idx.enterByBe.set(202, 6);
+    idx.exitByBe.set(202, 7);
+    idx.exitByBe.set(201, 8);
+    idx.exitByBe.set(200, 9);
+    idx.exitByBe.set(150, 10);
+    idx.exitByBe.set(100, 11);
     vi.spyOn(domTree, "buildSessionDomIndex").mockResolvedValue(idx);
     vi.spyOn(focusSelectors, "resolveCssFocusFrameAndTail").mockResolvedValue({
       targetFrameId: "frame-2",
       tailSelector: ".ad",
       absPrefix: "/html/body/iframe[1]",
     });
-    vi.spyOn(focusSelectors, "resolveObjectIdForCss").mockResolvedValue(
-      "ignored-object",
-    );
+    vi.spyOn(FrameSelectorResolver.prototype, "resolveAll").mockResolvedValue([
+      { objectId: "ignored-object-a", nodeId: null },
+      { objectId: "ignored-object-b", nodeId: null },
+    ]);
     vi.spyOn(a11yTree, "a11yForFrame").mockImplementation(
       async (_sess, frameId, opts) => ({
-        outline: opts.isIgnoredBackendNode?.(201)
-          ? `outline-${frameId}-filtered`
-          : `outline-${frameId}`,
+        outline:
+          opts.isIgnoredBackendNode?.(201) && opts.isIgnoredBackendNode?.(202)
+            ? `outline-${frameId}-filtered`
+            : `outline-${frameId}`,
         urlMap:
-          frameId === "frame-2" && opts.isIgnoredBackendNode?.(201)
+          frameId === "frame-2" &&
+          opts.isIgnoredBackendNode?.(201) &&
+          opts.isIgnoredBackendNode?.(202)
             ? {}
             : { [`url-${frameId}`]: `https://${frameId}.test` },
         scopeApplied: false,
@@ -448,10 +471,64 @@ describe("captureHybridSnapshot", () => {
     });
 
     expect(snapshot.combinedXpathMap["1-201"]).toBeUndefined();
+    expect(snapshot.combinedXpathMap["1-202"]).toBeUndefined();
     expect(snapshot.combinedUrlMap["url-frame-2"]).toBeUndefined();
     expect(
       snapshot.perFrame?.find((frame) => frame.frameId === "frame-2")?.outline,
     ).toContain("filtered");
+  });
+
+  it("excludes child frame subtrees when an ignored node is an iframe host", async () => {
+    const session = new MockCDPSession(
+      {
+        "DOM.getFrameOwner": async () => ({ backendNodeId: 150 }),
+        "DOM.describeNode": async (params) => ({
+          node: { backendNodeId: params?.objectId === "iframe-host" ? 150 : 0 },
+        }),
+      },
+      "session-a",
+    );
+    const page = makePage({
+      asProtocolFrameTree: () =>
+        makeFrameTree("frame-1", [makeFrameTree("frame-2")]),
+      listAllFrameIds: () => ["frame-1", "frame-2"],
+      getSessionForFrame: () => session,
+      getOrdinal: (frameId: string) => (frameId === "frame-1" ? 0 : 1),
+    });
+
+    vi.spyOn(domTree, "buildSessionDomIndex").mockResolvedValue(
+      makeSessionIndex(),
+    );
+    vi.spyOn(focusSelectors, "resolveCssFocusFrameAndTail").mockResolvedValue({
+      targetFrameId: "frame-1",
+      tailSelector: "iframe.ad",
+      absPrefix: "",
+    });
+    vi.spyOn(FrameSelectorResolver.prototype, "resolveAll").mockResolvedValue([
+      { objectId: "iframe-host", nodeId: null },
+    ]);
+    vi.spyOn(a11yTree, "a11yForFrame").mockImplementation(
+      async (_sess, frameId, opts) => ({
+        outline:
+          frameId === "frame-2" && opts.isIgnoredBackendNode?.(200)
+            ? ""
+            : `outline-${frameId}`,
+        urlMap:
+          frameId === "frame-2" && opts.isIgnoredBackendNode?.(200)
+            ? {}
+            : { [`url-${frameId}`]: `https://${frameId}.test` },
+        scopeApplied: false,
+      }),
+    );
+
+    const snapshot = await capture.captureHybridSnapshot(page, {
+      ignoreSelectors: ["iframe.ad"],
+    });
+
+    expect(snapshot.combinedXpathMap["1-200"]).toBeUndefined();
+    expect(snapshot.combinedXpathMap["1-201"]).toBeUndefined();
+    expect(snapshot.combinedUrlMap["url-frame-2"]).toBeUndefined();
+    expect(snapshot.combinedTree).not.toContain("outline-frame-2");
   });
 
   it("collects per-frame data and merges it when no scoped snapshot is available", async () => {

--- a/packages/core/tests/unit/snapshot-capture-orchestration.test.ts
+++ b/packages/core/tests/unit/snapshot-capture-orchestration.test.ts
@@ -364,7 +364,7 @@ describe("captureHybridSnapshot", () => {
     expect(result.combinedUrlMap["0-100"]).toBe("https://frame-1.test");
     expect(domMapsSpy).toHaveBeenCalled();
     expect(a11ySpy).toHaveBeenCalled();
-    expect(buildIndexSpy).toHaveBeenCalled();
+    expect(buildIndexSpy).not.toHaveBeenCalled();
   });
 
   it("scoped snapshot still succeeds when iframe inclusion is disabled", async () => {
@@ -401,7 +401,7 @@ describe("captureHybridSnapshot", () => {
     expect(result.combinedUrlMap["0-100"]).toBe("https://frame-1.test");
     expect(domMapsSpy).toHaveBeenCalled();
     expect(a11ySpy).toHaveBeenCalled();
-    expect(buildIndexSpy).toHaveBeenCalled();
+    expect(buildIndexSpy).not.toHaveBeenCalled();
   });
 
   it("filters ignored nodes out of the merged snapshot artifacts", async () => {

--- a/packages/server-v3/openapi.v3.yaml
+++ b/packages/server-v3/openapi.v3.yaml
@@ -608,6 +608,16 @@ components:
           description: CSS selector to scope extraction to a specific element
           example: "#main-content"
           type: string
+        ignoreSelectors:
+          description: Selectors for elements and subtrees that should be excluded from
+            extraction
+          example:
+            - nav
+            - .cookie-banner
+            - "#sidebar-ads"
+          type: array
+          items:
+            type: string
     ExtractRequest:
       type: object
       properties:
@@ -1589,6 +1599,16 @@ components:
           description: CSS selector to scope extraction to a specific element
           example: "#main-content"
           type: string
+        ignoreSelectors:
+          description: Selectors for elements and subtrees that should be excluded from
+            extraction
+          example:
+            - nav
+            - .cookie-banner
+            - "#sidebar-ads"
+          type: array
+          items:
+            type: string
       additionalProperties: false
     ExtractResultOutput:
       type: object


### PR DESCRIPTION
# why
- to allow users to specify selectors whose content should be omitted from the LLM request inside of `extract()`
# what changed
- added `ignoreSelectors` to `extract()` so callers can exclude parts of the page from the extraction snapshot
- `packages/core/lib/v3/understudy/a11y/snapshot/capture.ts`:
  - added `resolveIgnoreSelectorRoots()` to resolve ignore selectors into `frameId + backendNodeId` 
  - added `buildFrameExclusionIntervals()` to turn those roots into per-frame subtree ranges
  - updated `collectPerFrameMaps()` / `tryScopedSnapshot()` to skip ignored nodes when building snapshot data
- `packages/core/lib/v3/understudy/a11y/snapshot/domTree.ts`:
  - updated `buildSessionDomIndex()` to record dfs entry/exit positions for each backend node so ignored subtrees can be filtered by interval membership instead of having to re-traverse the tree
- `packages/core/lib/v3/understudy/a11y/snapshot/a11yTree.ts`: 
  - updated `a11yForFrame()` to accept an ignore predicate and remove ignored nodes from the outline (the stringified tree) and `urlMap`
- `packages/core/lib/v3/handlers/extractHandler.ts` and `packages/core/lib/v3/v3.ts`: 
  - passed `ignoreSelectors` down through the extract path into `captureHybridSnapshot()`
- kept `xpathMap` values based on the original dom structure and only skipped ignored entries, so surviving selectors do not get renumbered

# test plan
- updated `packages/core/tests/unit/public-api/public-types.test.ts` to cover the new `ignoreSelectors` option on `extract()`
- updated `packages/core/tests/unit/snapshot-a11y-resolvers.test.ts` to cover ignored backend nodes being removed from the a11y outline and `urlMap`, and to cover scoped snapshots dropping ignored xpath entries
- updated `packages/core/tests/unit/snapshot-capture-orchestration.test.ts` to cover the new capture flow, including filtered per-frame maps and merged snapshot output when `ignoreSelectors` is used

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `ignoreSelectors` to `extract()` so callers can exclude elements and their subtrees from snapshots and the LLM input. Supports CSS and XPath (with iframe hops) across shadow DOM and iframes, without renumbering existing XPaths; also adds a fast path for scoped snapshots and excludes child frame subtrees when an iframe host is ignored.

- **New Features**
  - `extract({ ignoreSelectors: string[] })`: drops matching nodes and descendants from DOM maps, a11y outline, and `urlMap`; `xpathMap` keeps original values but omits ignored entries.
  - Applies to full-page and scoped snapshots; filters resolved per frame, excludes child frames when their iframe host is ignored, and enforces DFS enter/exit intervals for speed.
  - A11y tree accepts an ignore predicate and filters before building the outline and links.
  - Scoped snapshots return early when only `selector` is provided (no `ignoreSelectors`) for faster capture.
  - Plumbed through `extractHandler`, `v3`, and `captureHybridSnapshot()`; public types and OpenAPI updated in `@browserbasehq/stagehand`; unit tests added.

<sup>Written for commit 0ad2f67d8fe81d15945599c60351ac45f66f1277. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

