### PR TITLE
[docs]: add `ignoreSelectors` to docs for `extract()`

### DIFF
--- a/packages/docs/v3/basics/extract.mdx
+++ b/packages/docs/v3/basics/extract.mdx
@@ -204,6 +204,25 @@ const tableData = await stagehand.extract(
 );
 ```
 
+You can also exclude specific nodes (including their descendant nodes) with `ignoreSelectors`.
+
+```typescript
+const article = await stagehand.extract(
+  "extract the article title and body",
+  z.object({
+    title: z.string(),
+    body: z.string()
+  }),
+  {
+    ignoreSelectors: [".ad", ".newsletter-modal", "nav.related-posts"]
+  }
+);
+```
+
+<Note>
+  `ignoreSelectors` removes all matches for each selector, along with each matched node's descendants. `selector` still scopes extraction to a single resolved subtree.
+</Note>
+
 
 ## Best practices
 

--- a/packages/docs/v3/references/extract.mdx
+++ b/packages/docs/v3/references/extract.mdx
@@ -43,6 +43,7 @@ interface ExtractOptions {
   model?: ModelConfiguration;
   timeout?: number;
   selector?: string;
+  ignoreSelectors?: string[];
   page?: PlaywrightPage | PuppeteerPage | PatchrightPage | Page;
   serverCache?: boolean;
 }
@@ -98,12 +99,20 @@ type ModelConfiguration =
   Optional selector (XPath, CSS selector, etc.) to limit extraction scope to a specific part of the page. Reduces token usage and improves accuracy.
 </ParamField>
 
+<ParamField path="ignoreSelectors" type="string[]" optional>
+  Optional list of selectors to exclude from the extracted snapshot before extraction runs. Each selector removes all matching elements and their descendants.
+
+  <Note>
+    `ignoreSelectors` applies to all matches for each selector. `selector` keeps its single-target scoping behavior.
+  </Note>
+</ParamField>
+
 <ParamField path="page" type="PlaywrightPage | PuppeteerPage | PatchrightPage | Page" optional>
   Optional: Specify which page to perform the extraction on. Supports multiple browser automation libraries:
-  - **Playwright**: Native Playwright Page objects
+  - **Stagehand Page**: Native Stagehand Page objects
+  - **Playwright**: Playwright Page objects
   - **Puppeteer**: Puppeteer Page objects
   - **Patchright**: Patchright Page objects
-  - **Stagehand Page**: Stagehand's wrapped Page object
 
   If not specified, defaults to the current "active" page in your Stagehand instance.
 </ParamField>


### PR DESCRIPTION
# what changed
- adds new param to reference section
- adds example to "targeted extract" section


<img width="723" height="974" alt="Screenshot 2026-05-06 at 10 36 25 AM" src="https://github.com/user-attachments/assets/35d676c6-48f0-46c7-8b76-cf319fa7af5e" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented the new `ignoreSelectors` option for `extract()` to exclude elements (and their descendants) from the snapshot. Added a targeted-extract example and clarified how it interacts with `selector`, plus minor wording updates for supported page types.

<sup>Written for commit f039e4503888986e418a3fb4688e11af6551698b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

