### PR TITLE
[STG-1935] fix: strengthen observe element ID prompting

### DIFF
--- a/.changeset/gentle-observe-ids.md
+++ b/.changeset/gentle-observe-ids.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Strengthen observe prompts so LLMs return complete encoded element IDs.

--- a/packages/core/lib/inference.ts
+++ b/packages/core/lib/inference.ts
@@ -267,7 +267,7 @@ export async function observe({
             .string()
             .regex(/^\d+-\d+$/)
             .describe(
-              "the ID string associated with the element. Never include surrounding square brackets. This field must follow the format of 'number-number'.",
+              "the exact ID string associated with the element. Never include surrounding square brackets. This field must follow the format of 'number-number'. For example, if the accessibility tree shows [0-18372], return '0-18372', not '18372'.",
             ),
           description: z
             .string()

--- a/packages/core/lib/prompt.ts
+++ b/packages/core/lib/prompt.ts
@@ -137,7 +137,9 @@ You will be given:
 2. a hierarchical accessibility tree showing the semantic structure of the page. The tree is a hybrid of the DOM and the accessibility tree.
 
 Return an array of elements that match the instruction if they exist, otherwise return an empty array.
-When returning elements, include the appropriate method from the supported actions list.${actionsString}${variablesString}. When choosing non-left click actions, provide right or middle as the argument.`;
+When returning elements, include the appropriate method from the supported actions list.${actionsString}${variablesString}. When choosing non-left click actions, provide right or middle as the argument.
+
+Each element in the accessibility tree has an ID in square brackets, like [0-18372]. The ID has two parts: frame ordinal and backend node ID. Always copy the complete ID exactly as shown inside the brackets into elementId, including the frame ordinal and hyphen. For example, if the tree shows [0-18372], return elementId "0-18372"; never return only "18372".`;
   const content = observeSystemPrompt.replace(/\s+/g, " ");
 
   return {

--- a/packages/core/tests/integration/observe-element-id-format.spec.ts
+++ b/packages/core/tests/integration/observe-element-id-format.spec.ts
@@ -1,0 +1,167 @@
+import { expect, test } from "@playwright/test";
+import type { LanguageModelV2CallOptions } from "@ai-sdk/provider";
+import { V3 } from "../../lib/v3/v3.js";
+import { getV3TestConfig } from "./v3.config.js";
+import {
+  closeV3,
+  createScriptedAisdkTestLlmClient,
+  findLastEncodedId,
+  promptToText,
+} from "./testUtils.js";
+
+const encodedIdPattern = /^\d+-\d+$/;
+const mainFrameEncodedIdPattern = /^0-\d+$/;
+
+function encodeHtml(html: string): string {
+  return `data:text/html,${encodeURIComponent(html)}`;
+}
+
+type MainFrameCase = {
+  name: string;
+  instruction: string;
+  targetText: string;
+  marker: string;
+  html: string;
+};
+
+const filler = Array.from(
+  { length: 80 },
+  (_, index) => `<span hidden data-filler="${index}">filler ${index}</span>`,
+).join("");
+
+const cases: MainFrameCase[] = [
+  {
+    name: "button after hidden filler nodes",
+    instruction: "Find the Target Checkout button",
+    targetText: "Target Checkout",
+    marker: "checkout",
+    html: `
+      <!doctype html>
+      <html>
+        <body>
+          ${filler}
+          <main>
+            <button onclick="document.body.dataset.clicked = 'checkout'">
+              Target Checkout
+            </button>
+          </main>
+        </body>
+      </html>
+    `,
+  },
+  {
+    name: "navigation link",
+    instruction: "Find the Pricing Plans link",
+    targetText: "Pricing Plans",
+    marker: "pricing",
+    html: `
+      <!doctype html>
+      <html>
+        <body>
+          <nav>
+            <a href="#pricing" onclick="document.body.dataset.clicked = 'pricing'">
+              Pricing Plans
+            </a>
+          </nav>
+        </body>
+      </html>
+    `,
+  },
+  {
+    name: "form input",
+    instruction: "Find the Company Email input",
+    targetText: "Company Email",
+    marker: "email",
+    html: `
+      <!doctype html>
+      <html>
+        <body>
+          <form>
+            <label>
+              Company Email
+              <input
+                type="email"
+                onclick="document.body.dataset.clicked = 'email'"
+              />
+            </label>
+          </form>
+        </body>
+      </html>
+    `,
+  },
+];
+
+function observeResponseForTarget(
+  testCase: MainFrameCase,
+  onElementId: (elementId: string, options: LanguageModelV2CallOptions) => void,
+) {
+  return (options: LanguageModelV2CallOptions) => {
+    const promptText = promptToText(options.prompt);
+    expect(promptText).toContain(
+      "Always copy the complete ID exactly as shown inside the brackets into elementId",
+    );
+    expect(promptText).toContain('return elementId "0-18372"');
+
+    expect(promptText).toContain(testCase.targetText);
+
+    const elementId = findLastEncodedId(options);
+    expect(elementId).toMatch(encodedIdPattern);
+    expect(elementId).toMatch(mainFrameEncodedIdPattern);
+    onElementId(elementId, options);
+
+    return {
+      elements: [
+        {
+          elementId,
+          description: testCase.targetText,
+          method: "click",
+          arguments: [] as string[],
+        },
+      ],
+    };
+  };
+}
+
+test.describe("observe main frame element IDs", () => {
+  for (const testCase of cases) {
+    test(`keeps complete 0-ordinal element IDs for ${testCase.name}`, async () => {
+      let observedElementId: string | undefined;
+      const llmClient = createScriptedAisdkTestLlmClient({
+        modelId: "mock/observe-main-frame-element-id-format",
+        jsonResponses: {
+          Observation: observeResponseForTarget(testCase, (elementId) => {
+            observedElementId = elementId;
+          }),
+        },
+      });
+
+      const v3 = new V3(
+        getV3TestConfig({
+          llmClient,
+        }),
+      );
+      await v3.init();
+
+      try {
+        const page = v3.context.pages()[0];
+        await page.goto(encodeHtml(testCase.html));
+
+        const observed = await v3.observe(testCase.instruction);
+
+        expect(observedElementId).toMatch(mainFrameEncodedIdPattern);
+        expect(observed).toHaveLength(1);
+        expect(observed[0].selector).toMatch(/^xpath=/);
+
+        const actResult = await v3.act(observed[0]);
+        expect(actResult.success).toBe(true);
+
+        const clicked = await page.evaluate(
+          () => document.body.dataset.clicked,
+        );
+        expect(clicked).toBe(testCase.marker);
+      } finally {
+        await closeV3(v3);
+      }
+    });
+  }
+});

--- a/packages/core/tests/unit/prompt-observe-variables.test.ts
+++ b/packages/core/tests/unit/prompt-observe-variables.test.ts
@@ -19,4 +19,14 @@ describe("buildObserveSystemPrompt", () => {
       "return the matching %variableName% placeholder",
     );
   });
+
+  it("instructs the model to copy complete bracketed element IDs", () => {
+    const prompt = buildObserveSystemPrompt(undefined, ["click"]);
+
+    expect(prompt.content).toContain(
+      "Always copy the complete ID exactly as shown inside the brackets into elementId",
+    );
+    expect(prompt.content).toContain('return elementId "0-18372"');
+    expect(prompt.content).toContain('never return only "18372"');
+  });
 });

--- a/packages/evals/taskConfig.ts
+++ b/packages/evals/taskConfig.ts
@@ -108,6 +108,7 @@ const EXTRA_CATEGORIES: Record<string, string[]> = {
   wichita: ["regression"],
   extract_memorial_healthcare: ["regression"],
   observe_github: ["regression"],
+  observe_main_frame_element_ids: ["regression"],
   observe_vantechjournal: ["regression"],
   observe_iframes1: ["regression"],
   observe_iframes2: ["regression"],

--- a/packages/evals/tasks/bench/observe/observe_main_frame_element_ids.ts
+++ b/packages/evals/tasks/bench/observe/observe_main_frame_element_ids.ts
@@ -1,0 +1,120 @@
+import { defineBenchTask } from "../../../framework/defineTask.js";
+
+const filler = Array.from(
+  // Keep backend node IDs large enough to exercise Anthropic's bare-id failure mode.
+  { length: 2500 },
+  (_, index) => `<span hidden data-filler="${index}">filler ${index}</span>`,
+).join("");
+
+const cases = [
+  {
+    instruction: "Find the Target Checkout button",
+    marker: "checkout",
+    label: "Target Checkout",
+  },
+  {
+    instruction: "Find the Pricing Plans button",
+    marker: "pricing",
+    label: "Pricing Plans",
+  },
+  {
+    instruction: "Find the Request Demo button",
+    marker: "demo",
+    label: "Request Demo",
+  },
+] as const;
+
+function buildHtml(): string {
+  const buttons = cases
+    .map(
+      ({ marker, label }) => `
+        ${filler}
+        <section>
+          <button onclick="document.body.dataset.clicked = '${marker}'">
+            ${label}
+          </button>
+        </section>
+      `,
+    )
+    .join("");
+
+  return `data:text/html,${encodeURIComponent(`
+    <!doctype html>
+    <html>
+      <body>
+        <main>${buttons}</main>
+      </body>
+    </html>
+  `)}`;
+}
+
+export default defineBenchTask(
+  { name: "observe_main_frame_element_ids" },
+  async ({ debugUrl, sessionUrl, v3, logger }) => {
+    try {
+      const page = v3.context.pages()[0];
+      await page.goto(buildHtml());
+
+      const results = [];
+      for (const testCase of cases) {
+        await page.evaluate(() => {
+          delete document.body.dataset.clicked;
+        });
+
+        const observations = await v3.observe(testCase.instruction);
+        if (observations.length === 0) {
+          return {
+            _success: false,
+            failedInstruction: testCase.instruction,
+            reason: "observe returned no elements",
+            results,
+            debugUrl,
+            sessionUrl,
+            logs: logger.getLogs(),
+          };
+        }
+
+        await v3.act(observations[0]);
+        const clicked = await page.evaluate(
+          () => document.body.dataset.clicked,
+        );
+        results.push({
+          instruction: testCase.instruction,
+          clicked,
+          observations,
+        });
+
+        if (clicked !== testCase.marker) {
+          return {
+            _success: false,
+            failedInstruction: testCase.instruction,
+            expectedClicked: testCase.marker,
+            clicked,
+            results,
+            debugUrl,
+            sessionUrl,
+            logs: logger.getLogs(),
+          };
+        }
+      }
+
+      return {
+        _success: true,
+        results,
+        debugUrl,
+        sessionUrl,
+        logs: logger.getLogs(),
+      };
+    } catch (error) {
+      return {
+        _success: false,
+        error,
+        debugUrl,
+        sessionUrl,
+        logs: logger.getLogs(),
+      };
+    } finally {
+      await v3.close();
+    }
+  },
+);


### PR DESCRIPTION
Linear: https://linear.app/browserbase/issue/STG-1935/strengthen-observe-element-id-prompting

## Summary

- keep the strict `number-number` observe element ID schema intact
- strengthen the observe system prompt to tell the model to copy the full bracketed tree ID, including frame ordinal and hyphen
- strengthen the schema description with the concrete `[0-18372] -> "0-18372", not "18372"` example
- add prompt regression coverage, main-frame `0-...` observe integration coverage, and a patch changeset
- add `observe/observe_main_frame_element_ids` as a regression eval for multiple main-frame targets

## Eval Coverage

Current bench eval count after this PR:

```text
146 total bench evals
12 observe bench evals
```

This PR adds one observe regression eval: `observe/observe_main_frame_element_ids`.

## Validation

- `pnpm --filter @browserbasehq/stagehand run build`
- `pnpm --filter @browserbasehq/stagehand run test:core -- packages/core/dist/esm/tests/unit/prompt-observe-variables.test.js`
- `pnpm --filter @browserbasehq/stagehand run test:e2e -- packages/core/dist/esm/tests/integration/observe-element-id-format.spec.js`
- `pnpm --filter @browserbasehq/stagehand run lint`
- `pnpm --filter @browserbasehq/stagehand-evals run typecheck`
- `pnpm --filter @browserbasehq/stagehand-evals run test:unit -- tests/taskConfig.test.ts`
- `pnpm --filter @browserbasehq/stagehand-evals run lint`
- `env STAGEHAND_E2E_TARGET=BROWSERBASE pnpm exec tsx <scratch project>/index.ts`
- `pnpm --filter @browserbasehq/stagehand-evals exec tsx cli.ts run observe_main_frame_element_ids -e browserbase -t 1 -c 1 -m anthropic/claude-sonnet-4-6`

Real Browserbase E2E used `anthropic/claude-sonnet-4-6` and verified raw model IDs plus click success:

```text
Attempt 1 raw model elementId: 0-5011
Attempt 1 act success: true
Attempt 1 DOM clicked marker: yes
Attempt 2 raw model elementId: 0-5011
Attempt 2 act success: true
Attempt 2 DOM clicked marker: yes
Attempt 3 raw model elementId: 0-5011
Attempt 3 act success: true
Attempt 3 DOM clicked marker: yes
```

The new Browserbase bench eval also passed with `anthropic/claude-sonnet-4-6`:

```text
observe/observe_main_frame_element_ids  anthropic/claude-sonnet-4-6  passed
Results: 1 passed, 0 failed (1 total)
Pass rate: 100%
```
