### PR TITLE
Chromie/test can you commit an update to th

### DIFF
--- a/packages/core/lib/v3/llm/CerebrasClient.ts
+++ b/packages/core/lib/v3/llm/CerebrasClient.ts
@@ -142,7 +142,7 @@ export class CerebrasClient extends LLMClient {
               ]
             : []),
         ],
-        temperature: options.temperature || 0.7,
+        temperature: options.temperature,
         max_tokens: options.maxOutputTokens,
         tools: tools,
         tool_choice: options.tool_choice || "auto",

--- a/packages/core/lib/v3/llm/CerebrasClient.ts
+++ b/packages/core/lib/v3/llm/CerebrasClient.ts
@@ -142,7 +142,7 @@ export class CerebrasClient extends LLMClient {
               ]
             : []),
         ],
-        temperature: options.temperature,
+        temperature: options.temperature ?? 0.7,
         max_tokens: options.maxOutputTokens,
         tools: tools,
         tool_choice: options.tool_choice || "auto",

--- a/packages/core/lib/v3/llm/GroqClient.ts
+++ b/packages/core/lib/v3/llm/GroqClient.ts
@@ -142,7 +142,7 @@ export class GroqClient extends LLMClient {
               ]
             : []),
         ],
-        temperature: options.temperature || 0.7,
+        temperature: options.temperature,
         max_tokens: options.maxOutputTokens,
         tools: tools,
         tool_choice: options.tool_choice || "auto",

--- a/packages/core/lib/v3/llm/GroqClient.ts
+++ b/packages/core/lib/v3/llm/GroqClient.ts
@@ -142,7 +142,7 @@ export class GroqClient extends LLMClient {
               ]
             : []),
         ],
-        temperature: options.temperature,
+        temperature: options.temperature ?? 0.7,
         max_tokens: options.maxOutputTokens,
         tools: tools,
         tool_choice: options.tool_choice || "auto",

--- a/packages/core/tests/unit/openai-compatible-temperature.test.ts
+++ b/packages/core/tests/unit/openai-compatible-temperature.test.ts
@@ -70,7 +70,7 @@ describe.each([
       }),
   ],
 ])("%s temperature handling", (_name, createClient) => {
-  it("does not replace missing temperature with a provider default", async () => {
+  it("falls back to 0.7 when temperature is not provided", async () => {
     const client = createClient();
     const create = installMockClient(client);
 
@@ -83,7 +83,7 @@ describe.each([
 
     expect(create).toHaveBeenCalledWith(
       expect.objectContaining({
-        temperature: undefined,
+        temperature: 0.7,
       }),
     );
   });


### PR DESCRIPTION
# why

# what changed

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the 0.7 default temperature for `CerebrasClient` and `GroqClient` while preserving explicit temperature: 0 by using nullish coalescing. Updated the unit test to match the fallback behavior.

- **Bug Fixes**
  - Use `options.temperature ?? 0.7` in `CerebrasClient` and `GroqClient` to keep the legacy default without overriding 0.
  - Update `openai-compatible-temperature` test to expect a 0.7 fallback when temperature is not provided.

<sup>Written for commit edab84ef36ed02cf63ea5006587f41585181c5ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

