### PR TITLE
Evals man help

### DIFF
--- a/packages/evals/cli.ts
+++ b/packages/evals/cli.ts
@@ -158,12 +158,12 @@ const args = process.argv.slice(2);
 
     const command = args[0].toLowerCase();
     const subArgs = args.slice(1);
-    // `help` as the leading positional is an alias for `--help` so it stays
-    // consistent across every command (`evals run help` ≡ `evals run --help`).
+    // Help is only triggered when `--help`/`-h`/`help` sits immediately
+    // after the command. Later positions are arguments or flag values and
+    // must not be swallowed (e.g. `evals run act --help` would otherwise
+    // print run help instead of erroring on the unknown `--help` flag).
     const wantsHelp =
-      subArgs.includes("--help") ||
-      subArgs.includes("-h") ||
-      subArgs[0] === "help";
+      subArgs[0] === "--help" || subArgs[0] === "-h" || subArgs[0] === "help";
 
     switch (command) {
       case "run": {

--- a/packages/evals/cli.ts
+++ b/packages/evals/cli.ts
@@ -63,14 +63,9 @@ const args = process.argv.slice(2);
   // Keep heavy command modules behind their command branches. The run stack
   // imports Braintrust transitively, and importing it for `help`/`config path`
   // makes quiet commands print optional OpenTelemetry warnings.
-  const {
-    printHelp,
-    printRunHelp,
-    printListHelp,
-    printNewHelp,
-    printConfigHelp,
-    printExperimentsHelp,
-  } = await import("./tui/commands/help.js");
+  const { printHelp, printRunHelp, printListHelp, printNewHelp } = await import(
+    "./tui/commands/help.js"
+  );
 
   // Best-effort shutdown: flush Braintrust telemetry and exit with the
   // conventional signal code. Does not guarantee in-flight task
@@ -163,7 +158,12 @@ const args = process.argv.slice(2);
 
     const command = args[0].toLowerCase();
     const subArgs = args.slice(1);
-    const wantsHelp = subArgs.includes("--help") || subArgs.includes("-h");
+    // `help` as the leading positional is an alias for `--help` so it stays
+    // consistent across every command (`evals run help` ≡ `evals run --help`).
+    const wantsHelp =
+      subArgs.includes("--help") ||
+      subArgs.includes("-h") ||
+      subArgs[0] === "help";
 
     switch (command) {
       case "run": {
@@ -192,20 +192,12 @@ const args = process.argv.slice(2);
       }
 
       case "config": {
-        if (wantsHelp) {
-          printConfigHelp();
-          return;
-        }
         const { handleConfig } = await import("./tui/commands/config.js");
         await handleConfig(subArgs, ENTRY_DIR);
         return;
       }
 
       case "experiments": {
-        if (wantsHelp && subArgs.length === 0) {
-          printExperimentsHelp();
-          return;
-        }
         const { handleExperiments } = await import(
           "./tui/commands/experiments.js"
         );

--- a/packages/evals/tests/cli.test.ts
+++ b/packages/evals/tests/cli.test.ts
@@ -141,6 +141,22 @@ describe("CLI entrypoint", () => {
     },
   );
 
+  // Regression: help interception must not reach into value positions.
+  // `config set <key> <value>` must surface a parse/value error, not silently
+  // print help — otherwise `--help` would be a magical sentinel anywhere.
+  it("does not swallow `--help` as a value in `config set`", async () => {
+    const { stdout, stderr, code } = await runCli([
+      "config",
+      "set",
+      "trials",
+      "--help",
+    ]);
+    expect(code).toBe(1);
+    const output = stdout + stderr;
+    expect(output).not.toContain("Commands:");
+    expect(output).toContain("trials must be a positive integer");
+  });
+
   it("exports resolved bench flags into env overrides during dry-run", async () => {
     const { stdout, code } = await runCli([
       "run",

--- a/packages/evals/tests/cli.test.ts
+++ b/packages/evals/tests/cli.test.ts
@@ -67,6 +67,80 @@ describe("CLI entrypoint", () => {
     expect(stdout).toContain("--out");
   });
 
+  // Help is reachable three ways at every level: `--help`, `-h`, and the
+  // bare word `help` as the first positional after the verb. Each row pairs
+  // an argv with a substring that must appear in the resulting help output.
+  const helpCases: Array<{ args: string[]; contains: string }> = [
+    { args: ["help"], contains: "Commands:" },
+    { args: ["--help"], contains: "Commands:" },
+    { args: ["-h"], contains: "Commands:" },
+    { args: ["run", "help"], contains: "evals run" },
+    { args: ["run", "--help"], contains: "evals run" },
+    { args: ["run", "-h"], contains: "evals run" },
+    { args: ["list", "help"], contains: "evals list" },
+    { args: ["list", "--help"], contains: "evals list" },
+    { args: ["list", "-h"], contains: "evals list" },
+    { args: ["new", "help"], contains: "evals new" },
+    { args: ["new", "--help"], contains: "evals new" },
+    { args: ["new", "-h"], contains: "evals new" },
+    { args: ["config", "help"], contains: "evals config" },
+    { args: ["config", "--help"], contains: "evals config" },
+    { args: ["config", "-h"], contains: "evals config" },
+    { args: ["config", "set", "help"], contains: "evals config" },
+    { args: ["config", "set", "--help"], contains: "evals config" },
+    { args: ["config", "reset", "help"], contains: "evals config" },
+    { args: ["config", "path", "help"], contains: "evals config" },
+    { args: ["config", "core", "help"], contains: "evals config core" },
+    { args: ["config", "core", "--help"], contains: "evals config core" },
+    { args: ["config", "core", "-h"], contains: "evals config core" },
+    { args: ["config", "core", "set", "help"], contains: "evals config core" },
+    {
+      args: ["config", "core", "set", "--help"],
+      contains: "evals config core",
+    },
+    {
+      args: ["config", "core", "reset", "help"],
+      contains: "evals config core",
+    },
+    { args: ["config", "core", "path", "help"], contains: "evals config core" },
+    {
+      args: ["config", "core", "setup", "help"],
+      contains: "evals config core",
+    },
+    { args: ["experiments", "help"], contains: "evals experiments" },
+    { args: ["experiments", "--help"], contains: "evals experiments" },
+    { args: ["experiments", "-h"], contains: "evals experiments" },
+    {
+      args: ["experiments", "list", "help"],
+      contains: "evals experiments list",
+    },
+    {
+      args: ["experiments", "list", "--help"],
+      contains: "evals experiments list",
+    },
+    {
+      args: ["experiments", "show", "help"],
+      contains: "evals experiments show",
+    },
+    {
+      args: ["experiments", "open", "help"],
+      contains: "evals experiments open",
+    },
+    {
+      args: ["experiments", "compare", "help"],
+      contains: "evals experiments compare",
+    },
+  ];
+
+  it.each(helpCases)(
+    "accepts $args as a help invocation",
+    async ({ args, contains }) => {
+      const { stdout, code } = await runCli(args);
+      expect(code).toBe(0);
+      expect(stdout).toContain(contains);
+    },
+  );
+
   it("exports resolved bench flags into env overrides during dry-run", async () => {
     const { stdout, code } = await runCli([
       "run",

--- a/packages/evals/tui/commands/config.ts
+++ b/packages/evals/tui/commands/config.ts
@@ -173,12 +173,11 @@ export async function handleConfig(
     return;
   }
 
-  // Per-sub `--help`/`-h`/`help` falls back to the top-level config help
-  // (which already documents every leaf subcommand). Core has its own help
-  // and is handled above. We only treat `help` as a help indicator when it's
-  // the verb's first argument — leaf values like `set provider help` aren't
-  // intercepted.
-  if (args.includes("--help") || args.includes("-h") || args[1] === "help") {
+  // Per-sub help. We only intercept when the help token is at args[1] —
+  // immediately after the verb — so leaf values at args[2+] (e.g.
+  // `set model --help`) are never swallowed as help and reach `parseValue`
+  // unchanged. Core has its own help and is handled above.
+  if (args[1] === "--help" || args[1] === "-h" || args[1] === "help") {
     const { printConfigHelp } = await import("./help.js");
     printConfigHelp();
     return;

--- a/packages/evals/tui/commands/config.ts
+++ b/packages/evals/tui/commands/config.ts
@@ -161,9 +161,26 @@ export async function handleConfig(
 
   const sub = args[0];
 
+  if (sub === "help" || sub === "-h" || sub === "--help") {
+    const { printConfigHelp } = await import("./help.js");
+    printConfigHelp();
+    return;
+  }
+
   if (sub === "core") {
     const { handleCore } = await import("./core.js");
     await handleCore(args.slice(1), entryDir);
+    return;
+  }
+
+  // Per-sub `--help`/`-h`/`help` falls back to the top-level config help
+  // (which already documents every leaf subcommand). Core has its own help
+  // and is handled above. We only treat `help` as a help indicator when it's
+  // the verb's first argument — leaf values like `set provider help` aren't
+  // intercepted.
+  if (args.includes("--help") || args.includes("-h") || args[1] === "help") {
+    const { printConfigHelp } = await import("./help.js");
+    printConfigHelp();
     return;
   }
 

--- a/packages/evals/tui/commands/core.ts
+++ b/packages/evals/tui/commands/core.ts
@@ -40,6 +40,20 @@ export async function handleCore(
     return;
   }
 
+  if (sub === "help" || sub === "-h" || sub === "--help") {
+    const { printConfigCoreHelp } = await import("./help.js");
+    printConfigCoreHelp();
+    return;
+  }
+
+  // Per-sub `--help`/`-h`/`help` (as verb's first argument) → core help.
+  // Leaf values like `set tool help` are not intercepted.
+  if (args.includes("--help") || args.includes("-h") || args[1] === "help") {
+    const { printConfigCoreHelp } = await import("./help.js");
+    printConfigCoreHelp();
+    return;
+  }
+
   if (sub === "path") {
     console.log(resolveConfigPath(entryDir));
     return;

--- a/packages/evals/tui/commands/core.ts
+++ b/packages/evals/tui/commands/core.ts
@@ -46,9 +46,9 @@ export async function handleCore(
     return;
   }
 
-  // Per-sub `--help`/`-h`/`help` (as verb's first argument) → core help.
-  // Leaf values like `set tool help` are not intercepted.
-  if (args.includes("--help") || args.includes("-h") || args[1] === "help") {
+  // Per-sub help. Only intercepted at args[1] (immediately after the verb)
+  // so leaf values like `set tool --help` aren't swallowed as help.
+  if (args[1] === "--help" || args[1] === "-h" || args[1] === "help") {
     const { printConfigCoreHelp } = await import("./help.js");
     printConfigCoreHelp();
     return;

--- a/packages/evals/tui/commands/experiments.ts
+++ b/packages/evals/tui/commands/experiments.ts
@@ -75,13 +75,11 @@ export async function handleExperiments(args: string[]): Promise<void> {
     return;
   }
 
-  // `help` as the leading positional after a verb is treated as a help
-  // request (`experiments list help` ≡ `experiments list --help`). Leaf
-  // values like `experiments show help` (an experiment literally named
-  // "help") would also intercept — but no such experiment exists, and the
-  // consistent surface is worth the trade.
+  // Help is only intercepted at rest[0] — immediately after the verb — so
+  // leaf positionals (e.g. a second experiment id in `compare a b --help`)
+  // and option values are never swallowed as help.
   const wantsSubHelp =
-    rest.includes("-h") || rest.includes("--help") || rest[0] === "help";
+    rest[0] === "--help" || rest[0] === "-h" || rest[0] === "help";
 
   switch (subcommand) {
     case "list": {

--- a/packages/evals/tui/commands/experiments.ts
+++ b/packages/evals/tui/commands/experiments.ts
@@ -75,9 +75,17 @@ export async function handleExperiments(args: string[]): Promise<void> {
     return;
   }
 
+  // `help` as the leading positional after a verb is treated as a help
+  // request (`experiments list help` ≡ `experiments list --help`). Leaf
+  // values like `experiments show help` (an experiment literally named
+  // "help") would also intercept — but no such experiment exists, and the
+  // consistent surface is worth the trade.
+  const wantsSubHelp =
+    rest.includes("-h") || rest.includes("--help") || rest[0] === "help";
+
   switch (subcommand) {
     case "list": {
-      if (rest.includes("-h") || rest.includes("--help")) {
+      if (wantsSubHelp) {
         const { printExperimentsHelp } = await import("./help.js");
         printExperimentsHelp("list");
         return;
@@ -86,7 +94,7 @@ export async function handleExperiments(args: string[]): Promise<void> {
       return;
     }
     case "show": {
-      if (rest.includes("-h") || rest.includes("--help")) {
+      if (wantsSubHelp) {
         const { printExperimentsHelp } = await import("./help.js");
         printExperimentsHelp("show");
         return;
@@ -95,7 +103,7 @@ export async function handleExperiments(args: string[]): Promise<void> {
       return;
     }
     case "open": {
-      if (rest.includes("-h") || rest.includes("--help")) {
+      if (wantsSubHelp) {
         const { printExperimentsHelp } = await import("./help.js");
         printExperimentsHelp("open");
         return;
@@ -104,7 +112,7 @@ export async function handleExperiments(args: string[]): Promise<void> {
       return;
     }
     case "compare": {
-      if (rest.includes("-h") || rest.includes("--help")) {
+      if (wantsSubHelp) {
         const { printExperimentsHelp } = await import("./help.js");
         printExperimentsHelp("compare");
         return;

--- a/packages/evals/tui/commands/help.ts
+++ b/packages/evals/tui/commands/help.ts
@@ -212,6 +212,38 @@ export function printConfigHelp(): void {
   ]);
 }
 
+export function printConfigCoreHelp(): void {
+  print([
+    "",
+    `  ${dustyCyanHeader("evals config core")} ${dim("[subcommand]")}`,
+    "",
+    "  Configure core tier tool + startup defaults.",
+    "",
+    `  ${bold("Subcommands:")}`,
+    "",
+    row(dim("(none)"), "Print current core configuration"),
+    row(cyan("path"), "Print the config file path"),
+    row(
+      `${cyan("set")} ${dim("<tool|startup> <value>")}`,
+      `Set core ${cyan("tool")} or ${cyan("startup")}`,
+    ),
+    row(
+      `${cyan("reset")} ${dim("[key]")}`,
+      "Reset one key or the whole core section",
+    ),
+    row(cyan("setup"), `Interactive wizard ${gray("(coming soon)")}`),
+    "",
+    `  ${bold("Valid core tools:")} ${gray("understudy_code, playwright_code, cdp_code, playwright_mcp, chrome_devtools_mcp, browse_cli")}`,
+    "",
+    `  ${bold("Examples:")}`,
+    "",
+    `    ${dim("$")} evals config core set tool understudy_code`,
+    `    ${dim("$")} evals config core set startup tool_launch_local`,
+    `    ${dim("$")} evals config core reset`,
+    "",
+  ]);
+}
+
 export function printExperimentsHelp(
   subcommand?: "list" | "show" | "open" | "compare",
 ): void {

--- a/packages/evals/tui/repl.ts
+++ b/packages/evals/tui/repl.ts
@@ -13,8 +13,6 @@ import {
   printRunHelp,
   printListHelp,
   printNewHelp,
-  printConfigHelp,
-  printExperimentsHelp,
 } from "./commands/help.js";
 import { printList } from "./commands/list.js";
 import { handleConfig } from "./commands/config.js";
@@ -115,7 +113,10 @@ export async function startRepl(entryDir: string): Promise<void> {
     const tokens = tokenize(trimmed);
     const command = tokens[0].toLowerCase();
     const args = tokens.slice(1);
-    const wantsHelp = args.includes("--help") || args.includes("-h");
+    // `help` as the leading positional is an alias for `--help` so it stays
+    // consistent across every command (`run help` ≡ `run --help`).
+    const wantsHelp =
+      args.includes("--help") || args.includes("-h") || args[0] === "help";
 
     try {
       switch (command) {
@@ -153,19 +154,11 @@ export async function startRepl(entryDir: string): Promise<void> {
         }
 
         case "config": {
-          if (wantsHelp) {
-            printConfigHelp();
-            break;
-          }
           await handleConfig(args, entryDir);
           break;
         }
 
         case "experiments": {
-          if (wantsHelp && args.length === 0) {
-            printExperimentsHelp();
-            break;
-          }
           await handleExperiments(args);
           break;
         }

--- a/packages/evals/tui/repl.ts
+++ b/packages/evals/tui/repl.ts
@@ -113,10 +113,11 @@ export async function startRepl(entryDir: string): Promise<void> {
     const tokens = tokenize(trimmed);
     const command = tokens[0].toLowerCase();
     const args = tokens.slice(1);
-    // `help` as the leading positional is an alias for `--help` so it stays
-    // consistent across every command (`run help` ≡ `run --help`).
+    // Help is only triggered when `--help`/`-h`/`help` sits immediately
+    // after the command. Later positions are arguments or flag values and
+    // must not be swallowed.
     const wantsHelp =
-      args.includes("--help") || args.includes("-h") || args[0] === "help";
+      args[0] === "--help" || args[0] === "-h" || args[0] === "help";
 
     try {
       switch (command) {


### PR DESCRIPTION
# Why

Help discovery was inconsistent across the evals CLI.

- `--help` / `-h` worked everywhere.
- The bare word `help` only worked at the top level and on three dispatcher commands.
- `config core` had no dedicated help page at all — `evals config core --help` was intercepted upstream and printed the parent `config` help instead.

# What Changed

- Added `printConfigCoreHelp` documenting:
  - `evals config core`
  - `path`
  - `set`
  - `reset`
  - `setup`

- Standardized `help` as a positional alias for `--help` at every level:
  - Top-level dispatchers:
    - `run`
    - `list`
    - `new`
    - `config`
    - `experiments`
  - Nested dispatchers:
    - `config core`
  - Leaf verbs:
    - `set`
    - `reset`
    - `path`
    - `setup`
    - `list`
    - `show`
    - `open`
    - `compare`

- Removed the early `wantsHelp → printConfigHelp()` interception in:
  - `cli.ts`
  - `repl.ts`

  This allows `config core --help` to correctly reach the core-specific help page.

- Cleaned up:
  - unused imports
  - dead experiments help branch

- Help interception now only occurs when `help` appears as the first argument to a verb, so legitimate values such as  `evals config set provider help` continue to work properly. 

# Tests

- [x] Added 35 parameterized `it.each` cases in `tests/cli.test.ts` covering:
  - `help`
  - `--help`
  - `-h`
across every command and subcommand level.

- [x] Full evals unit suite:
  - `251 / 251` passing

- [x] Verified built CLI prints correct help for:
  - `config core help`
  - `experiments compare help`
  - `run help`
