### PR TITLE
STG-1806 Make model API key optional in OpenAPI

### DIFF
--- a/.changeset/violet-cases-admire.md
+++ b/.changeset/violet-cases-admire.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand-server-v3": patch
+---
+
+Make the model API key optional in the v3 OpenAPI security requirements.

--- a/packages/server-v3/openapi.v3.yaml
+++ b/packages/server-v3/openapi.v3.yaml
@@ -2292,4 +2292,3 @@ servers:
 security:
   - BrowserbaseApiKey: []
     BrowserbaseProjectId: []
-    ModelApiKey: []

--- a/packages/server-v3/scripts/gen-openapi.ts
+++ b/packages/server-v3/scripts/gen-openapi.ts
@@ -145,9 +145,7 @@ Please try it and give us your feedback, stay tuned for upcoming release announc
         securitySchemes: Api.openApiSecuritySchemes,
         links: Api.openApiLinks,
       },
-      security: [
-        { BrowserbaseApiKey: [], BrowserbaseProjectId: [], ModelApiKey: [] },
-      ],
+      security: [{ BrowserbaseApiKey: [], BrowserbaseProjectId: [] }],
     },
     ...fastifyZodOpenApiTransformers,
   });


### PR DESCRIPTION
## Summary
- remove ModelApiKey from the server-v3 OpenAPI global security requirement
- update the checked-in v3 OpenAPI spec so Stainless no longer treats model API key as required client auth

## Verification
- pnpm --filter @browserbasehq/stagehand-server-v3 run lint
- pnpm --filter @browserbasehq/stagehand-server-v3 run build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the model API key optional by removing `ModelApiKey` from server v3 OpenAPI global security (STG-1806). Update the spec/generator in `@browserbasehq/stagehand-server-v3` and add a patch changeset so Stainless clients no longer require a model key.

- **Migration**
  - Regenerate clients from the v3 OpenAPI (e.g., Stainless) to drop `ModelApiKey` as required auth.

<sup>Written for commit 3c74893febe6a3501f26eaa700ba2290c02cad56. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

