### PR TITLE
[chore]: commit updated spec

### DIFF
--- a/packages/server-v3/openapi.v3.yaml
+++ b/packages/server-v3/openapi.v3.yaml
@@ -862,7 +862,8 @@ components:
           example: 30000
           type: number
         variables:
-          description: Variables available to the agent via %variableName% syntax in supported tools
+          description: Variables available to the agent via %variableName% syntax in
+            supported tools
           $ref: "#/components/schemas/Variables"
       required:
         - instruction
@@ -1798,7 +1799,8 @@ components:
           example: 30000
           type: number
         variables:
-          description: Variables available to the agent via %variableName% syntax in supported tools
+          description: Variables available to the agent via %variableName% syntax in
+            supported tools
           $ref: "#/components/schemas/Variables"
       required:
         - instruction

--- a/packages/server-v4/openapi.v4.yaml
+++ b/packages/server-v4/openapi.v4.yaml
@@ -33,7 +33,8 @@ components:
       type: apiKey
       in: header
       name: x-bb-project-id
-      description: Browserbase project ID
+      description: Deprecated. Browserbase API keys are now project-scoped, so this
+        header is no longer required.
     ModelApiKey:
       type: apiKey
       in: header
@@ -832,6 +833,9 @@ components:
       type: object
       properties:
         projectId:
+          deprecated: true
+          description: Deprecated. Browserbase API keys are now project-scoped, so this
+            field is no longer required.
           type: string
         browserSettings:
           $ref: "#/components/schemas/BrowserbaseBrowserSettings"
@@ -6448,6 +6452,9 @@ components:
       type: object
       properties:
         projectId:
+          deprecated: true
+          description: Deprecated. Browserbase API keys are now project-scoped, so this
+            field is no longer required.
           type: string
         browserSettings:
           $ref: "#/components/schemas/BrowserbaseBrowserSettingsOutput"


### PR DESCRIPTION
# why
- schema descriptions changed which means spec yaml files need to be regenerated
- the regenerated yaml files were uncommitted
# what changed
- added the regenerated yaml files


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Regenerated OpenAPI specs for `packages/server-v3` and `packages/server-v4` to align with schema description updates. In v4, the `x-bb-project-id` header and related `projectId` fields are now deprecated since API keys are project-scoped.

- **Migration**
  - Stop sending the `x-bb-project-id` header.
  - Omit `projectId` in v4 session payloads and ignore it in responses.

<sup>Written for commit 8dd382e1833337e8ea52021f8ca66f9284e01061. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

