### PR TITLE
[feat]: add `ignoreSelectors` to `observe()`

### DIFF
--- a/.changeset/gold-carrots-brush.md
+++ b/.changeset/gold-carrots-brush.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": minor
+---
+
+add ignoreSelectors to observe()

--- a/packages/core/lib/v3/handlers/observeHandler.ts
+++ b/packages/core/lib/v3/handlers/observeHandler.ts
@@ -64,7 +64,15 @@ export class ObserveHandler {
   }
 
   async observe(params: ObserveHandlerParams): Promise<Action[]> {
-    const { instruction, page, timeout, selector, model, variables } = params;
+    const {
+      instruction,
+      page,
+      timeout,
+      selector,
+      ignoreSelectors,
+      model,
+      variables,
+    } = params;
 
     const llmClient = this.resolveLlmClient(model);
 
@@ -95,6 +103,7 @@ export class ObserveHandler {
     const snapshot = await captureHybridSnapshot(page, {
       experimental: this.experimental,
       focusSelector: focusSelector || undefined,
+      ignoreSelectors,
     });
 
     const combinedTree = snapshot.combinedTree;

--- a/packages/core/lib/v3/types/private/handlers.ts
+++ b/packages/core/lib/v3/types/private/handlers.ts
@@ -27,6 +27,7 @@ export interface ObserveHandlerParams {
   variables?: Variables;
   timeout?: number;
   selector?: string;
+  ignoreSelectors?: string[];
   page: Page;
 }
 

--- a/packages/core/lib/v3/types/public/api.ts
+++ b/packages/core/lib/v3/types/public/api.ts
@@ -589,6 +589,14 @@ export const ObserveOptionsSchema = z
       description: "CSS selector to scope observation to a specific element",
       example: "nav",
     }),
+    ignoreSelectors: z
+      .array(z.string())
+      .optional()
+      .meta({
+        description:
+          "Selectors for elements and subtrees that should be excluded from observation",
+        example: ["nav", ".cookie-banner", "#sidebar-ads"],
+      }),
   })
   .optional()
   .meta({ id: "ObserveOptions" });

--- a/packages/core/lib/v3/types/public/methods.ts
+++ b/packages/core/lib/v3/types/public/methods.ts
@@ -77,6 +77,7 @@ export interface ObserveOptions {
   variables?: Variables;
   timeout?: number;
   selector?: string;
+  ignoreSelectors?: string[];
   page?: PlaywrightPage | PuppeteerPage | PatchrightPage | Page;
   /**
    * Override the instance-level serverCache setting for this request.

--- a/packages/core/lib/v3/v3.ts
+++ b/packages/core/lib/v3/v3.ts
@@ -1516,6 +1516,7 @@ export class V3 {
         variables: options?.variables,
         timeout: options?.timeout,
         selector: options?.selector,
+        ignoreSelectors: options?.ignoreSelectors,
         page: page!,
       };
 
@@ -1537,6 +1538,8 @@ export class V3 {
         {
           instruction,
           variables: options?.variables,
+          selector: options?.selector,
+          ignoreSelectors: options?.ignoreSelectors,
           timeout: options?.timeout,
         },
         results,

--- a/packages/core/tests/unit/api-client-observe-variables.test.ts
+++ b/packages/core/tests/unit/api-client-observe-variables.test.ts
@@ -75,6 +75,7 @@ describe("StagehandAPIClient variable serialization", () => {
           },
           password: "secret",
         },
+        ignoreSelectors: [".cookie-banner"],
       },
     });
 
@@ -90,6 +91,7 @@ describe("StagehandAPIClient variable serialization", () => {
             },
             password: "secret",
           },
+          ignoreSelectors: [".cookie-banner"],
         },
         frameId: undefined,
       },

--- a/packages/core/tests/unit/api-variables-schema.test.ts
+++ b/packages/core/tests/unit/api-variables-schema.test.ts
@@ -30,10 +30,16 @@ describe("API variable schemas", () => {
           },
           rememberMe: true,
         },
+        ignoreSelectors: [".cookie-banner", "#sidebar-ads"],
       },
     });
 
     expect(result.success).toBe(true);
+    if (!result.success) throw result.error;
+    expect(result.data.options?.ignoreSelectors).toEqual([
+      ".cookie-banner",
+      "#sidebar-ads",
+    ]);
   });
 
   it("preserves variables for agent execute requests", () => {

--- a/packages/core/tests/unit/public-api/public-types.test.ts
+++ b/packages/core/tests/unit/public-api/public-types.test.ts
@@ -168,6 +168,7 @@ describe("Stagehand public API types", () => {
       variables?: Stagehand.Variables;
       timeout?: number;
       selector?: string;
+      ignoreSelectors?: string[];
       page?: Stagehand.AnyPage;
       serverCache?: boolean;
     };

--- a/packages/core/tests/unit/timeout-handlers.test.ts
+++ b/packages/core/tests/unit/timeout-handlers.test.ts
@@ -958,6 +958,50 @@ describe("No-timeout success paths", () => {
     expect(result[0]?.arguments).toEqual(["%username%"]);
   });
 
+  it("observe() forwards ignoreSelectors to snapshot capture", async () => {
+    const captureHybridSnapshotMock = vi.mocked(captureHybridSnapshot);
+    captureHybridSnapshotMock.mockResolvedValue({
+      combinedTree: "tree content",
+      combinedXpathMap: { "1-0": "/html/body/button" },
+      combinedUrlMap: {},
+    });
+
+    const observeInferenceMock = vi.mocked(observeInference);
+    observeInferenceMock.mockResolvedValue({
+      elements: [
+        {
+          elementId: "1-0",
+          description: "Submit button",
+        },
+      ],
+    } as ReturnType<typeof observeInference> extends Promise<infer T>
+      ? T
+      : never);
+
+    vi.mocked(createTimeoutGuard).mockImplementation(() => {
+      return vi.fn(() => {
+        // No-op - never throws
+      });
+    });
+
+    const handler = buildObserveHandler();
+    const fakePage = {
+      mainFrame: vi.fn().mockReturnValue({}),
+    } as unknown as Page;
+
+    await handler.observe({
+      instruction: "find buttons",
+      ignoreSelectors: [".cookie-banner", "#sidebar-ads"],
+      page: fakePage,
+    });
+
+    expect(captureHybridSnapshotMock).toHaveBeenCalledWith(fakePage, {
+      experimental: false,
+      focusSelector: undefined,
+      ignoreSelectors: [".cookie-banner", "#sidebar-ads"],
+    });
+  });
+
   it("act() with zero timeout behaves as no timeout", async () => {
     const waitForDomNetworkQuietMock = vi.mocked(waitForDomNetworkQuiet);
     waitForDomNetworkQuietMock.mockResolvedValue(undefined);

--- a/packages/server-v3/openapi.v3.yaml
+++ b/packages/server-v3/openapi.v3.yaml
@@ -685,6 +685,16 @@ components:
           description: CSS selector to scope observation to a specific element
           example: nav
           type: string
+        ignoreSelectors:
+          description: Selectors for elements and subtrees that should be excluded from
+            observation
+          example:
+            - nav
+            - .cookie-banner
+            - "#sidebar-ads"
+          type: array
+          items:
+            type: string
     ObserveRequest:
       type: object
       properties:
@@ -1661,6 +1671,16 @@ components:
           description: CSS selector to scope observation to a specific element
           example: nav
           type: string
+        ignoreSelectors:
+          description: Selectors for elements and subtrees that should be excluded from
+            observation
+          example:
+            - nav
+            - .cookie-banner
+            - "#sidebar-ads"
+          type: array
+          items:
+            type: string
       additionalProperties: false
     ObserveResultOutput:
       type: object


### PR DESCRIPTION
# why
- to let users exclude parts of the page from the snapshot that `observe()` sends to the model, the same way they can with `extract()`

# what changed
- this PR is just wiring the added param through observe & updating types. it uses the same underlying functionality that was added in #2084 when adding `ignoreSelectors` to `extract()`
- `packages/core/lib/v3/types/public/methods.ts`, `packages/core/lib/v3/types/private/handlers.ts`, & `packages/core/lib/v3/types/public/api.ts`:
  - added the `ignoreSelectors` option to the public api, internal handler params, & request schema
- `packages/core/lib/v3/v3.ts` & `packages/core/lib/v3/handlers/observeHandler.ts`:
  - passed `ignoreSelectors` through the observe path into `captureHybridSnapshot()`

# test plan
- updated `packages/core/tests/unit/public-api/public-types.test.ts` to cover the new `ignoreSelectors` param
- updated `packages/core/tests/unit/api-variables-schema.test.ts` & `packages/core/tests/unit/api-client-observe-variables.test.ts` to cover request validation and serialization for `observe({ ignoreSelectors })`
- updated `packages/core/tests/unit/timeout-handlers.test.ts` to cover `ObserveHandler` passing `ignoreSelectors` into `captureHybridSnapshot()`

### notes
- the test file placement is a little weird right now: 
  - `timeout-handlers.test.ts` already contains broader parameter threading tests, so this was the smallest change for now
  - this can be cleaned up in a later refactor


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `ignoreSelectors` to `observe()` so you can exclude elements from the snapshot sent to the model. Brings `observe()` to parity with `extract()`.

- **New Features**
  - Support `observe({ ignoreSelectors: ["nav", ".cookie-banner"] })` to skip elements and subtrees during snapshot capture.
  - Plumbed through public types, internal handler params, and `captureHybridSnapshot()` call path.
  - Request schema and `packages/server-v3/openapi.v3.yaml` updated; client serialization and validation covered by tests.
  - Published as a minor for `@browserbasehq/stagehand`.

<sup>Written for commit c7b538c04d439b13d28db843a12344529171219b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

