### PR TITLE
[docs]: add docs for `ignoreSelectors`

### DIFF
--- a/packages/docs/v3/basics/observe.mdx
+++ b/packages/docs/v3/basics/observe.mdx
@@ -101,7 +101,7 @@ await stagehand.observe("what is the page title?");
 
 ## Advanced Configuration
 
-You can pass additional options to configure the model, timeout, selector scope, and placeholder variables:
+You can pass additional options to configure the model, timeout, selector scope, ignored page regions, and placeholder variables:
 
 ```typescript
 // Custom model configuration
@@ -111,6 +111,22 @@ const actions = await stagehand.observe("find navigation links", {
   selector: "//header" // Focus on specific area
 });
 ```
+
+You can also exclude specific nodes, including their descendant nodes, with `ignoreSelectors`.
+
+```typescript
+const actions = await stagehand.observe("find the main call-to-action buttons", {
+  ignoreSelectors: [
+    "//aside[contains(@class, 'promo-rail')]",
+    "//div[@id='floating-chat-launcher']",
+    "//section[@aria-label='recommended articles']"
+  ]
+});
+```
+
+<Note>
+  `ignoreSelectors` removes all matches for each selector, along with each matched node's descendants. `selector` still scopes observation to a single resolved subtree.
+</Note>
 
 ### Validate Then Act with Variables
 

--- a/packages/docs/v3/references/observe.mdx
+++ b/packages/docs/v3/references/observe.mdx
@@ -34,6 +34,7 @@ interface ObserveOptions {
   variables?: Record<string, VariableValue>;
   timeout?: number;
   selector?: string;
+  ignoreSelectors?: string[];
   page?: PlaywrightPage | PuppeteerPage | PatchrightPage | Page;
   serverCache?: boolean;
 }
@@ -95,6 +96,14 @@ type ModelConfiguration =
 
 <ParamField path="selector" type="string" optional>
   Optional XPath selector to focus the observation on a specific part of the page. Useful for narrowing down the search area.
+</ParamField>
+
+<ParamField path="ignoreSelectors" type="string[]" optional>
+  Optional list of selectors to exclude from the observed snapshot before observation runs. Each selector removes all matching elements and their descendants.
+
+  <Note>
+    `ignoreSelectors` applies to all matches for each selector. `selector` keeps its single-target scoping behavior.
+  </Note>
 </ParamField>
 
 <ParamField path="page" type="PlaywrightPage | PuppeteerPage | PatchrightPage | Page" optional>
@@ -225,6 +234,20 @@ const actions = await stagehand.observe("find navigation links", {
 // Focus observation on a specific part of the page
 const tableActions = await stagehand.observe("find all table rows", {
   selector: "/html/body/main/table"
+});
+```
+
+</Tab>
+<Tab title="Ignore Elements">
+
+```typescript
+// Exclude parts of the page you do not want observe() to consider
+const actions = await stagehand.observe("find the main call-to-action buttons", {
+  ignoreSelectors: [
+    "//aside[contains(@class, 'promo-rail')]",
+    "//div[@id='floating-chat-launcher']",
+    "//section[@aria-label='recommended articles']"
+  ]
 });
 ```
 


### PR DESCRIPTION
# why
- to add docs for new `ignoreSelectors` param in `observe()`
# what changed
- adds new param to reference section 
- adds an example snippet in 'the basics' section

<img width="761" height="792" alt="Screenshot 2026-05-07 at 11 41 26 AM" src="https://github.com/user-attachments/assets/8e6c636a-a9ed-4c56-ad28-9030c532d995" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added docs for the new `ignoreSelectors` option in `observe()` to let users exclude page regions from observation. Updated the reference with type and behavior, plus a basics example using XPath and a note on how it interacts with `selector`.

<sup>Written for commit 35f9577986ff7ec134fbe8c3927f605d39128eb6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

