### PR TITLE
Evals TUI tree traversal

### DIFF
--- a/packages/evals/cli.ts
+++ b/packages/evals/cli.ts
@@ -50,6 +50,7 @@ await (async () => {
 
 import { red } from "./tui/format.js";
 import { getCurrentDirPath, getRuntimeTasksRoot } from "./runtimePaths.js";
+import type { TaskRegistry } from "./framework/types.js";
 
 /**
  * Directory of the running entry module. Differs between source and
@@ -60,13 +61,6 @@ const ENTRY_DIR = getCurrentDirPath();
 const args = process.argv.slice(2);
 
 (async () => {
-  // Keep heavy command modules behind their command branches. The run stack
-  // imports Braintrust transitively, and importing it for `help`/`config path`
-  // makes quiet commands print optional OpenTelemetry warnings.
-  const { printHelp, printRunHelp, printListHelp, printNewHelp } = await import(
-    "./tui/commands/help.js"
-  );
-
   // Best-effort shutdown: flush Braintrust telemetry and exit with the
   // conventional signal code. Does not guarantee in-flight task
   // cancellation upstream; the goal is clean process shutdown with no
@@ -123,32 +117,6 @@ const args = process.argv.slice(2);
     };
   }
 
-  async function executeRun(tokens: string[]): Promise<void> {
-    const { readConfig } = await import("./tui/commands/config.js");
-    const { runCommand } = await import("./tui/commands/run.js");
-    const { parseRunArgs, resolveRunOptions } = await import(
-      "./tui/commands/parse.js"
-    );
-    const flags = parseRunArgs(tokens);
-    const configFile = readConfig(ENTRY_DIR);
-    const resolved = resolveRunOptions(
-      flags,
-      configFile.defaults,
-      process.env,
-      configFile.core,
-    );
-
-    if (flags.legacy) {
-      const { runLegacy } = await import("./tui/commands/legacy.js");
-      const { discoverTasks } = await import("./framework/discovery.js");
-      const registry = await discoverTasks(getRuntimeTasksRoot(), false);
-      await runLegacy(resolved, flags, registry);
-      return; // unreachable — runLegacy calls process.exit
-    }
-
-    await runCommand(resolved);
-  }
-
   try {
     if (args.length === 0) {
       const { startRepl } = await import("./tui/repl.js");
@@ -156,77 +124,31 @@ const args = process.argv.slice(2);
       return;
     }
 
-    const command = args[0].toLowerCase();
-    const subArgs = args.slice(1);
-    // Help is only triggered when `--help`/`-h`/`help` sits immediately
-    // after the command. Later positions are arguments or flag values and
-    // must not be swallowed (e.g. `evals run act --help` would otherwise
-    // print run help instead of erroring on the unknown `--help` flag).
-    const wantsHelp =
-      subArgs[0] === "--help" || subArgs[0] === "-h" || subArgs[0] === "help";
+    const { buildCommandTree, dispatch, tokenizeArgv } = await import(
+      "./tui/commandTree.js"
+    );
 
-    switch (command) {
-      case "run": {
-        if (wantsHelp) {
-          printRunHelp();
-          return;
-        }
-        await executeRun(subArgs);
-        return;
-      }
-
-      case "list": {
-        if (wantsHelp) {
-          printListHelp();
-          return;
-        }
-        const detailed =
-          subArgs.includes("--detailed") || subArgs.includes("-d");
-        const tierFilter = subArgs.find((a) => !a.startsWith("-"));
-        const tasksRoot = getRuntimeTasksRoot();
+    let registry: TaskRegistry | null = null;
+    const getRegistry = async (): Promise<TaskRegistry> => {
+      if (!registry) {
         const { discoverTasks } = await import("./framework/discovery.js");
-        const { printList } = await import("./tui/commands/list.js");
-        const registry = await discoverTasks(tasksRoot, false);
-        printList(registry, tierFilter, detailed);
-        return;
+        registry = await discoverTasks(getRuntimeTasksRoot(), false);
       }
+      return registry;
+    };
 
-      case "config": {
-        const { handleConfig } = await import("./tui/commands/config.js");
-        await handleConfig(subArgs, ENTRY_DIR);
-        return;
-      }
+    const tree = buildCommandTree();
 
-      case "experiments": {
-        const { handleExperiments } = await import(
-          "./tui/commands/experiments.js"
-        );
-        await handleExperiments(subArgs);
-        return;
-      }
-
-      case "new": {
-        if (wantsHelp) {
-          printNewHelp();
-          return;
-        }
-        const { scaffoldTask } = await import("./tui/commands/new.js");
-        scaffoldTask(subArgs);
-        return;
-      }
-
-      case "help":
-      case "--help":
-      case "-h":
-        printHelp();
-        return;
-
-      default: {
-        // Unknown first arg → treat as run target: `evals act` == `evals run act`
-        await executeRun(args);
-        return;
-      }
-    }
+    const tokens = tokenizeArgv(args);
+    await dispatch(tree, tokens, {
+      entryDir: ENTRY_DIR,
+      getRegistry,
+      setRegistry: (r) => {
+        registry = r;
+      },
+      abortRef: null,
+      contextPath: null,
+    });
   } catch (err) {
     console.error(red(`Error: ${(err as Error).message}`));
     process.exitCode = 1;

--- a/packages/evals/tests/cli.test.ts
+++ b/packages/evals/tests/cli.test.ts
@@ -239,6 +239,29 @@ describe("CLI entrypoint", () => {
       path.join(repoRoot, "packages", "evals", "evals.config.json"),
     );
   });
+
+  it("treats `>` as equivalent to a space separator (argv form)", async () => {
+    const direct = await runCli(["config", "path"]);
+    const piped = await runCli(["config", ">", "path"]);
+    expect(piped.code).toBe(0);
+    expect(piped.stdout).toBe(direct.stdout);
+  });
+
+  it("supports `>` chaining across multiple levels", async () => {
+    const direct = await runCli(["config", "core", "path"]);
+    const piped = await runCli(["config", ">", "core", ">", "path"]);
+    expect(piped.code).toBe(0);
+    expect(piped.stdout).toBe(direct.stdout);
+  });
+
+  it("strips a leading `evals` sigil token (no-op at root)", async () => {
+    // From a shell, `evals evals run act --dry-run` should resolve like
+    // `evals run act --dry-run` — the leading `evals` arg is the sigil.
+    const { stdout, code } = await runCli(["evals", "run", "act", "--dry-run"]);
+    expect(code).toBe(0);
+    const payload = JSON.parse(stdout);
+    expect(payload.normalizedTarget).toBe("act");
+  });
 });
 
 describe.sequential("core config", () => {

--- a/packages/evals/tests/tui/commandTree.test.ts
+++ b/packages/evals/tests/tui/commandTree.test.ts
@@ -396,6 +396,14 @@ describe("dispatch", () => {
     expect(h.run).toHaveBeenCalledWith(["act"], ctx);
   });
 
+  it("strips the `evals` sigil before falling back to run", async () => {
+    const h = makeHandlers();
+    const tree = makeTree(h);
+    const ctx = makeCtx();
+    await dispatch(tree, ["evals", "act"], ctx);
+    expect(h.run).toHaveBeenCalledWith(["act"], ctx);
+  });
+
   it("rejects REPL-only metas in argv mode", async () => {
     const h = makeHandlers();
     const tree = makeTree(h);

--- a/packages/evals/tests/tui/commandTree.test.ts
+++ b/packages/evals/tests/tui/commandTree.test.ts
@@ -1,0 +1,435 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  dispatch,
+  findChild,
+  resolveCommand,
+  tokenizeArgv,
+  walkPath,
+  type CommandContext,
+  type CommandNode,
+} from "../../tui/commandTree.js";
+import { tokenize } from "../../tui/tokenize.js";
+import type { TaskRegistry } from "../../framework/types.js";
+
+// ---------------------------------------------------------------------------
+// Fake tree — keeps tests independent of the real handlers.
+// ---------------------------------------------------------------------------
+
+function makeTree(
+  handlers: Record<string, ReturnType<typeof vi.fn>>,
+): CommandNode {
+  const compare: CommandNode = {
+    name: "compare",
+    summary: "compare experiments",
+    handler: handlers.compare,
+  };
+  const list: CommandNode = {
+    name: "list",
+    summary: "list experiments",
+    handler: handlers.expList,
+  };
+  const experiments: CommandNode = {
+    name: "experiments",
+    summary: "experiments namespace",
+    handler: handlers.experiments,
+    children: [list, compare],
+  };
+  const configPath: CommandNode = {
+    name: "path",
+    summary: "config path",
+    handler: handlers.configPath,
+  };
+  const configCorePath: CommandNode = {
+    name: "path",
+    summary: "core path",
+    handler: handlers.corePath,
+  };
+  const configCore: CommandNode = {
+    name: "core",
+    summary: "config core",
+    handler: handlers.configCore,
+    children: [configCorePath],
+  };
+  const config: CommandNode = {
+    name: "config",
+    summary: "config namespace",
+    handler: handlers.config,
+    children: [configPath, configCore],
+  };
+  const run: CommandNode = {
+    name: "run",
+    summary: "run evals",
+    handler: handlers.run,
+  };
+  const rootHelp = handlers.rootHelp;
+  return {
+    name: "evals",
+    summary: "root",
+    printHelp: rootHelp,
+    children: [run, config, experiments],
+  };
+}
+
+function makeCtx(overrides: Partial<CommandContext> = {}): CommandContext {
+  const contextPath: string[] = [];
+  return {
+    entryDir: "/tmp/fake",
+    getRegistry: async () => ({ tasks: [] }) as unknown as TaskRegistry,
+    setRegistry: () => {},
+    abortRef: { current: null },
+    contextPath,
+    pushContext: (s) => contextPath.push(s),
+    popContext: () => {
+      contextPath.pop();
+    },
+    setContextPath: (path) => {
+      contextPath.length = 0;
+      for (const p of path) contextPath.push(p);
+    },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// tokenize
+// ---------------------------------------------------------------------------
+
+describe("tokenize", () => {
+  it("splits on whitespace", () => {
+    expect(tokenize("run act --trials 3")).toEqual([
+      "run",
+      "act",
+      "--trials",
+      "3",
+    ]);
+  });
+
+  it("treats `>` as a separator outside quotes", () => {
+    expect(tokenize("experiments > list")).toEqual(["experiments", "list"]);
+    expect(tokenize("experiments>list")).toEqual(["experiments", "list"]);
+    expect(tokenize("config > core > path")).toEqual([
+      "config",
+      "core",
+      "path",
+    ]);
+  });
+
+  it("collapses runs of `>` and whitespace", () => {
+    expect(tokenize("experiments > > list")).toEqual(["experiments", "list"]);
+    expect(tokenize("  experiments   >   list  ")).toEqual([
+      "experiments",
+      "list",
+    ]);
+  });
+
+  it("preserves `>` inside quoted strings", () => {
+    expect(tokenize(`run "foo > bar" --extra`)).toEqual([
+      "run",
+      "foo > bar",
+      "--extra",
+    ]);
+    expect(tokenize(`run 'a>b'`)).toEqual(["run", "a>b"]);
+  });
+
+  it("returns an empty array for empty input or pure separators", () => {
+    expect(tokenize("")).toEqual([]);
+    expect(tokenize("   ")).toEqual([]);
+    expect(tokenize(" > > ")).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tokenizeArgv
+// ---------------------------------------------------------------------------
+
+describe("tokenizeArgv", () => {
+  it("passes through args without `>`", () => {
+    expect(tokenizeArgv(["run", "act", "--trials", "3"])).toEqual([
+      "run",
+      "act",
+      "--trials",
+      "3",
+    ]);
+  });
+
+  it("drops standalone `>` tokens", () => {
+    expect(tokenizeArgv(["experiments", ">", "list"])).toEqual([
+      "experiments",
+      "list",
+    ]);
+  });
+
+  it("splits args containing `>`", () => {
+    expect(tokenizeArgv(["experiments>list"])).toEqual(["experiments", "list"]);
+    expect(tokenizeArgv(["config>core>path"])).toEqual([
+      "config",
+      "core",
+      "path",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findChild + walkPath
+// ---------------------------------------------------------------------------
+
+describe("findChild + walkPath", () => {
+  const tree = makeTree({} as never);
+
+  it("finds children by name", () => {
+    expect(findChild(tree, "experiments")?.name).toBe("experiments");
+    expect(findChild(tree, "EXPERIMENTS")?.name).toBe("experiments");
+    expect(findChild(tree, "missing")).toBeUndefined();
+  });
+
+  it("walks a path of segments", () => {
+    expect(walkPath(tree, []).name).toBe("evals");
+    expect(walkPath(tree, ["experiments"]).name).toBe("experiments");
+    expect(walkPath(tree, ["config", "core"]).name).toBe("core");
+  });
+
+  it("returns the deepest valid node for partial paths", () => {
+    // "missing" doesn't exist as a child of "config" — bail at config.
+    expect(walkPath(tree, ["config", "missing"]).name).toBe("config");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveCommand
+// ---------------------------------------------------------------------------
+
+describe("resolveCommand", () => {
+  const tree = makeTree({} as never);
+
+  it("returns noop on empty tokens", () => {
+    expect(resolveCommand(tree, [], [])).toEqual({ kind: "noop" });
+  });
+
+  it("recognizes meta tokens at any depth", () => {
+    expect(resolveCommand(tree, [], [".."])).toEqual({
+      kind: "meta",
+      name: "back",
+      args: [],
+    });
+    expect(resolveCommand(tree, ["experiments"], ["help"])).toMatchObject({
+      kind: "meta",
+      name: "help",
+    });
+    expect(resolveCommand(tree, [], ["?"])).toMatchObject({
+      kind: "meta",
+      name: "help-q",
+    });
+    expect(resolveCommand(tree, [], ["exit"])).toMatchObject({
+      kind: "meta",
+      name: "exit",
+    });
+    expect(resolveCommand(tree, [], ["--help"])).toMatchObject({
+      kind: "meta",
+      name: "help",
+    });
+  });
+
+  it("resolves relative to the current context", () => {
+    const r = resolveCommand(tree, ["experiments"], ["list"]);
+    expect(r).toMatchObject({
+      kind: "run",
+      absolutePath: ["experiments", "list"],
+    });
+  });
+
+  it("strips the `evals` sigil and resolves from root", () => {
+    const r = resolveCommand(
+      tree,
+      ["experiments"],
+      ["evals", "config", "path"],
+    );
+    expect(r).toMatchObject({
+      kind: "run",
+      absolutePath: ["config", "path"],
+    });
+  });
+
+  it("treats bare `evals` as to-root meta", () => {
+    expect(resolveCommand(tree, ["experiments"], ["evals"])).toMatchObject({
+      kind: "meta",
+      name: "to-root",
+    });
+  });
+
+  it("returns unknown when context-only resolution fails", () => {
+    // `config` is a root child but not a child of `experiments` → unknown
+    // at depth, no Pass 2 fallback.
+    const r = resolveCommand(tree, ["experiments"], ["config", "path"]);
+    expect(r).toMatchObject({
+      kind: "unknown",
+      token: "config",
+      context: ["experiments"],
+    });
+  });
+
+  it("returns unknown for unknown tokens at root", () => {
+    const r = resolveCommand(tree, [], ["nope"]);
+    expect(r).toMatchObject({ kind: "unknown", token: "nope", context: [] });
+  });
+
+  it("yields remaining args for partial path matches", () => {
+    const r = resolveCommand(
+      tree,
+      [],
+      ["experiments", "compare", "exp1", "exp2"],
+    );
+    expect(r).toMatchObject({
+      kind: "run",
+      args: ["exp1", "exp2"],
+      absolutePath: ["experiments", "compare"],
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dispatch
+// ---------------------------------------------------------------------------
+
+describe("dispatch", () => {
+  function makeHandlers() {
+    return {
+      run: vi.fn(),
+      config: vi.fn(),
+      configPath: vi.fn(),
+      configCore: vi.fn(),
+      corePath: vi.fn(),
+      experiments: vi.fn(),
+      expList: vi.fn(),
+      compare: vi.fn(),
+      rootHelp: vi.fn(),
+    };
+  }
+
+  it("runs a leaf with the remaining args", async () => {
+    const h = makeHandlers();
+    const tree = makeTree(h);
+    const ctx = makeCtx();
+    await dispatch(tree, ["experiments", "compare", "exp1"], ctx);
+    expect(h.compare).toHaveBeenCalledWith(["exp1"], ctx);
+  });
+
+  it("treats `experiments > list` identically to `experiments list`", async () => {
+    const h = makeHandlers();
+    const tree = makeTree(h);
+    await dispatch(tree, tokenize("experiments > list"), makeCtx());
+    expect(h.expList).toHaveBeenCalledOnce();
+  });
+
+  it("auto-descends on bare invocation of a descendable node (REPL)", async () => {
+    const h = makeHandlers();
+    const tree = makeTree(h);
+    const ctx = makeCtx();
+    await dispatch(tree, ["experiments"], ctx);
+    expect(h.experiments).toHaveBeenCalledOnce();
+    expect(ctx.contextPath).toEqual(["experiments"]);
+  });
+
+  it("does not auto-descend in argv mode (contextPath null)", async () => {
+    const h = makeHandlers();
+    const tree = makeTree(h);
+    const ctx = makeCtx({ contextPath: null });
+    await dispatch(tree, ["experiments"], ctx);
+    expect(h.experiments).toHaveBeenCalledOnce();
+    expect(ctx.contextPath).toBeNull();
+  });
+
+  it("descends to the absolute path even when invoked from depth", async () => {
+    const h = makeHandlers();
+    const tree = makeTree(h);
+    const ctx = makeCtx();
+    ctx.setContextPath?.(["experiments"]);
+    // Inside experiments, `evals config` should set context to ["config"].
+    await dispatch(tree, ["evals", "config"], ctx);
+    expect(ctx.contextPath).toEqual(["config"]);
+  });
+
+  it("`..` pops one level", async () => {
+    const h = makeHandlers();
+    const tree = makeTree(h);
+    const ctx = makeCtx();
+    ctx.setContextPath?.(["config", "core"]);
+    await dispatch(tree, [".."], ctx);
+    expect(ctx.contextPath).toEqual(["config"]);
+  });
+
+  it("`..` at root prints a hint and is a no-op", async () => {
+    const h = makeHandlers();
+    const tree = makeTree(h);
+    const ctx = makeCtx();
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    await dispatch(tree, [".."], ctx);
+    expect(ctx.contextPath).toEqual([]);
+    expect(log).toHaveBeenCalled();
+    log.mockRestore();
+  });
+
+  it("bare `evals` pops all context to root", async () => {
+    const h = makeHandlers();
+    const tree = makeTree(h);
+    const ctx = makeCtx();
+    ctx.setContextPath?.(["config", "core"]);
+    await dispatch(tree, ["evals"], ctx);
+    expect(ctx.contextPath).toEqual([]);
+  });
+
+  it("rejects unknown tokens at depth (no run-shorthand fallback)", async () => {
+    const h = makeHandlers();
+    const tree = makeTree(h);
+    const ctx = makeCtx();
+    ctx.setContextPath?.(["experiments"]);
+    await expect(dispatch(tree, ["nope"], ctx)).rejects.toThrow(
+      /Unknown command "nope"/,
+    );
+    expect(h.run).not.toHaveBeenCalled();
+  });
+
+  it("falls back to run for unknown tokens at root", async () => {
+    const h = makeHandlers();
+    const tree = makeTree(h);
+    const ctx = makeCtx();
+    await dispatch(tree, ["act"], ctx);
+    expect(h.run).toHaveBeenCalledWith(["act"], ctx);
+  });
+
+  it("rejects REPL-only metas in argv mode", async () => {
+    const h = makeHandlers();
+    const tree = makeTree(h);
+    const ctx = makeCtx({ contextPath: null });
+    await expect(dispatch(tree, [".."], ctx)).rejects.toThrow(
+      /not available outside the REPL/,
+    );
+  });
+
+  it("routes `--help` after a leaf to that leaf's printHelp", async () => {
+    const h = makeHandlers();
+    const tree = makeTree(h);
+    // Add a printHelp to compare for this test.
+    const compare = tree.children![2].children![1];
+    const printCompareHelp = vi.fn();
+    (compare as { printHelp?: (s: readonly string[]) => void }).printHelp =
+      printCompareHelp;
+    await dispatch(tree, ["experiments", "compare", "--help"], makeCtx());
+    expect(printCompareHelp).toHaveBeenCalled();
+    expect(h.compare).not.toHaveBeenCalled();
+  });
+
+  it("routes bare `help` to the current context's printHelp", async () => {
+    const h = makeHandlers();
+    const tree = makeTree(h);
+    const printExperimentsHelp = vi.fn();
+    (
+      tree.children![2] as {
+        printHelp?: (s: readonly string[]) => void;
+      }
+    ).printHelp = printExperimentsHelp;
+    const ctx = makeCtx();
+    ctx.setContextPath?.(["experiments"]);
+    await dispatch(tree, ["help"], ctx);
+    expect(printExperimentsHelp).toHaveBeenCalled();
+  });
+});

--- a/packages/evals/tui/banner.ts
+++ b/packages/evals/tui/banner.ts
@@ -17,6 +17,6 @@ ${c.bbBold}╚══════╝  ╚═══╝  ╚═╝  ╚═╝╚═
 export function printBanner(): void {
   console.log(BANNER_ART);
   console.log(
-    `${c.dim}  Type ${c.reset}help${c.dim} for commands, ${c.reset}exit${c.dim} to quit${c.reset}\n`,
+    `${c.dim}  Type ${c.reset}help${c.dim} for commands, ${c.reset}..${c.dim} to leave a context, ${c.reset}exit${c.dim} to quit${c.reset}\n`,
   );
 }

--- a/packages/evals/tui/commandTree.ts
+++ b/packages/evals/tui/commandTree.ts
@@ -272,7 +272,11 @@ export async function dispatch(
       if (result.context.length === 0) {
         const runNode = findChild(root, "run");
         if (runNode?.handler) {
-          await runNode.handler(tokens, ctx);
+          // Strip a leading "evals" sigil so parseRunArgs doesn't
+          // misinterpret it as a target or flag.
+          const forwarded =
+            tokens[0]?.toLowerCase() === "evals" ? tokens.slice(1) : tokens;
+          await runNode.handler(forwarded, ctx);
           return;
         }
       }

--- a/packages/evals/tui/commandTree.ts
+++ b/packages/evals/tui/commandTree.ts
@@ -1,0 +1,660 @@
+/**
+ * Command tree for the evals TUI.
+ *
+ * Models the user-visible command surface as a tree:
+ *   root → run, list, new, config{path,set,reset,core{path,set,reset,setup}},
+ *          experiments{list,show,open,compare}
+ *
+ * Both the REPL (tui/repl.ts) and argv mode (cli.ts) build the same tree
+ * via `buildCommandTree()` and dispatch user input through it. This is the
+ * single source of truth for which commands exist and how they nest.
+ *
+ * Resolution rules (see resolveCommand):
+ *   - Commands resolve relative to the current context (REPL contextPath).
+ *   - The leading sigil `evals` strips itself and resolves the remainder
+ *     from root — mirrors `evals X Y` from the shell.
+ *   - Bare `evals` pops all context to root.
+ *   - Meta commands (.., help, ?, exit/quit/q, clear, --help/-h) short-
+ *     circuit before tree resolution and work at any depth.
+ *
+ * Existing handlers in tui/commands/* are wrapped, never rewritten.
+ */
+
+import process from "node:process";
+import type { TaskRegistry } from "../framework/types.js";
+import { tokenize } from "./tokenize.js";
+import { bb, cyan, dim } from "./format.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type CommandHandler = (
+  args: string[],
+  ctx: CommandContext,
+) => Promise<void> | void;
+
+export type CommandNode = {
+  /** Canonical lowercase name. */
+  name: string;
+  aliases?: readonly string[];
+  summary: string;
+  /** If present, executable as a leaf with the given args. */
+  handler?: CommandHandler;
+  /** If present, descendable as a namespace. */
+  children?: readonly CommandNode[];
+  /** Per-node help printer. Receives the absolute path that was resolved. */
+  printHelp?: (subPath: readonly string[]) => void | Promise<void>;
+  /** Hidden from auto-listings (still resolvable). */
+  hidden?: boolean;
+};
+
+export type CommandContext = {
+  entryDir: string;
+  /** Lazy registry accessor — REPL caches, argv discovers on first call. */
+  getRegistry: () => Promise<TaskRegistry>;
+  setRegistry: (r: TaskRegistry) => void;
+  /** Mutable in REPL (the run leaf assigns/clears); null in argv. */
+  abortRef: { current: AbortController | null } | null;
+  /** Mutable string[] in REPL; null in argv. Mutated via the helpers below. */
+  contextPath: string[] | null;
+  pushContext?: (segment: string) => void;
+  popContext?: () => void;
+  setContextPath?: (path: readonly string[]) => void;
+};
+
+export type Resolution =
+  | { kind: "noop" }
+  | { kind: "meta"; name: MetaName; args: string[] }
+  | { kind: "run"; node: CommandNode; args: string[]; absolutePath: string[] }
+  | { kind: "unknown"; token: string; context: readonly string[] };
+
+export type MetaName =
+  | "back"
+  | "to-root"
+  | "exit"
+  | "clear"
+  | "help"
+  | "help-q";
+
+const META_NAMES: Record<string, MetaName> = {
+  "..": "back",
+  exit: "exit",
+  quit: "exit",
+  q: "exit",
+  clear: "clear",
+  help: "help",
+  "?": "help-q",
+  "--help": "help",
+  "-h": "help",
+};
+
+// ---------------------------------------------------------------------------
+// Tree walking + resolution
+// ---------------------------------------------------------------------------
+
+export function findChild(
+  node: CommandNode,
+  token: string,
+): CommandNode | undefined {
+  if (!node.children) return undefined;
+  const lower = token.toLowerCase();
+  return node.children.find(
+    (c) =>
+      c.name.toLowerCase() === lower ||
+      (c.aliases?.some((a) => a.toLowerCase() === lower) ?? false),
+  );
+}
+
+export function walkPath(
+  root: CommandNode,
+  path: readonly string[],
+): CommandNode {
+  let node = root;
+  for (const seg of path) {
+    const child = findChild(node, seg);
+    if (!child) return node;
+    node = child;
+  }
+  return node;
+}
+
+type Match = {
+  node: CommandNode;
+  matchedNames: string[];
+  remaining: string[];
+};
+
+/**
+ * Greedy walk: consume each leading token that matches a child of the
+ * current node. Stop at the first non-match — those tokens become args
+ * for the deepest matched node's handler.
+ */
+function matchPath(start: CommandNode, tokens: readonly string[]): Match {
+  let node = start;
+  const matched: string[] = [];
+  let i = 0;
+  while (i < tokens.length) {
+    const child = findChild(node, tokens[i]);
+    if (!child) break;
+    node = child;
+    matched.push(child.name);
+    i++;
+  }
+  return { node, matchedNames: matched, remaining: tokens.slice(i) };
+}
+
+export function resolveCommand(
+  root: CommandNode,
+  contextPath: readonly string[],
+  tokens: readonly string[],
+): Resolution {
+  if (tokens.length === 0) return { kind: "noop" };
+
+  const first = tokens[0].toLowerCase();
+  const meta = META_NAMES[first];
+  if (meta) {
+    return { kind: "meta", name: meta, args: tokens.slice(1) };
+  }
+
+  // Leading sigil: `evals` strips itself and resolves the remainder
+  // from root, regardless of current context.
+  if (first === "evals") {
+    const rest = tokens.slice(1);
+    if (rest.length === 0) {
+      return { kind: "meta", name: "to-root", args: [] };
+    }
+    const m = matchPath(root, rest);
+    if (m.matchedNames.length > 0) {
+      return {
+        kind: "run",
+        node: m.node,
+        args: m.remaining,
+        absolutePath: m.matchedNames,
+      };
+    }
+    return { kind: "unknown", token: rest[0], context: [] };
+  }
+
+  // Relative — match against the current context, no root fallback.
+  const current = walkPath(root, contextPath);
+  const m = matchPath(current, tokens);
+  if (m.matchedNames.length > 0) {
+    return {
+      kind: "run",
+      node: m.node,
+      args: m.remaining,
+      absolutePath: [...contextPath, ...m.matchedNames],
+    };
+  }
+
+  return { kind: "unknown", token: tokens[0], context: contextPath };
+}
+
+// ---------------------------------------------------------------------------
+// Prompt rendering
+// ---------------------------------------------------------------------------
+
+export function renderPrompt(contextPath: readonly string[]): string {
+  const segs = contextPath.map((p) => `${cyan(p)} ${dim(">")} `).join("");
+  return `${bb("evals")} ${dim(">")} ${segs}`;
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve `tokens` against the tree and execute the result. Caller owns
+ * error handling and prompt reprinting.
+ */
+export async function dispatch(
+  root: CommandNode,
+  tokens: string[],
+  ctx: CommandContext,
+): Promise<void> {
+  const result = resolveCommand(root, ctx.contextPath ?? [], tokens);
+
+  switch (result.kind) {
+    case "noop":
+      return;
+
+    case "meta":
+      await runMeta(result.name, result.args, root, ctx);
+      return;
+
+    case "run": {
+      // Help is only triggered when `help` / `--help` / `-h` sits IMMEDIATELY
+      // after the matched path. Later positions are arguments or flag values
+      // and must reach the handler unchanged (e.g. `config set trials --help`
+      // must surface a parse error, not silently print help).
+      const first = result.args[0];
+      const wantsHelp =
+        first === "help" || first === "--help" || first === "-h";
+      if (wantsHelp && result.node.printHelp) {
+        await result.node.printHelp(result.absolutePath);
+        return;
+      }
+
+      if (result.node.handler) {
+        await result.node.handler(result.args, ctx);
+      } else if (result.args.length > 0) {
+        throw new Error(
+          `Unknown subcommand "${result.args[0]}" in ${pretty(
+            result.absolutePath,
+          )}`,
+        );
+      } else if (result.node.printHelp) {
+        await result.node.printHelp(result.absolutePath);
+      }
+
+      // Descend on bare (REPL only). `config` and `config core` already
+      // printed via their handler; `experiments` printed via printHelp.
+      if (
+        ctx.contextPath !== null &&
+        result.node.children &&
+        result.args.length === 0
+      ) {
+        const target = result.absolutePath;
+        const same =
+          target.length === ctx.contextPath.length &&
+          target.every((s, i) => s === ctx.contextPath![i]);
+        if (!same) {
+          ctx.setContextPath?.(target);
+        }
+      }
+      return;
+    }
+
+    case "unknown": {
+      // Unknown-token shorthand at root: hand off to the run leaf so
+      // `evals act` keeps working. Only at root — at depth this errors.
+      if (result.context.length === 0) {
+        const runNode = findChild(root, "run");
+        if (runNode?.handler) {
+          await runNode.handler(tokens, ctx);
+          return;
+        }
+      }
+      throw new Error(unknownMessage(result.token, result.context));
+    }
+  }
+}
+
+async function runMeta(
+  name: MetaName,
+  args: string[],
+  root: CommandNode,
+  ctx: CommandContext,
+): Promise<void> {
+  switch (name) {
+    case "back": {
+      if (ctx.contextPath === null) {
+        throw new Error('".." is not available outside the REPL');
+      }
+      if (ctx.contextPath.length === 0) {
+        console.log(dim("  Already at root."));
+        return;
+      }
+      ctx.popContext?.();
+      return;
+    }
+
+    case "to-root": {
+      // Bare `evals` mid-line. In REPL, pop all context. In argv, no-op.
+      if (ctx.contextPath === null) return;
+      ctx.setContextPath?.([]);
+      return;
+    }
+
+    case "exit": {
+      if (ctx.contextPath === null) {
+        throw new Error("`exit` is not available outside the REPL");
+      }
+      console.log(dim("\n  Goodbye.\n"));
+      process.exit(0);
+    }
+    // eslint-disable-next-line no-fallthrough -- exit terminates
+    case "clear": {
+      if (ctx.contextPath === null) {
+        throw new Error("`clear` is not available outside the REPL");
+      }
+      console.clear();
+      return;
+    }
+
+    case "help":
+    case "help-q": {
+      const path = ctx.contextPath ?? [];
+      const current = walkPath(root, path);
+
+      if (args.length > 0) {
+        // `help <child>` — resolve relative to current context.
+        const m = matchPath(current, args);
+        if (m.matchedNames.length > 0 && m.node.printHelp) {
+          await m.node.printHelp([...path, ...m.matchedNames]);
+          return;
+        }
+      }
+
+      if (current.printHelp) {
+        await current.printHelp(path);
+        return;
+      }
+      if (root.printHelp) {
+        await root.printHelp([]);
+      }
+      return;
+    }
+  }
+}
+
+function pretty(path: readonly string[]): string {
+  return path.length === 0 ? "evals >" : `evals > ${path.join(" > ")}`;
+}
+
+function unknownMessage(token: string, context: readonly string[]): string {
+  if (context.length === 0) {
+    return `Unknown command "${token}". Type "help" for the command list.`;
+  }
+  return `Unknown command "${token}" in ${pretty(
+    context,
+  )}. Type "evals ${token} …" to run from root, "help" to see subcommands here, or ".." to leave the context.`;
+}
+
+// ---------------------------------------------------------------------------
+// Tree factory — wraps existing handlers as leaf nodes.
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the canonical command tree. The factory is parameter-less because
+ * leaves close over the `CommandContext` they receive at dispatch time —
+ * the same tree instance can serve REPL (with abortRef + contextPath) and
+ * argv (both null) contexts.
+ */
+export function buildCommandTree(): CommandNode {
+  // Help printers are imported lazily to avoid pulling braintrust into
+  // quiet commands like `config path`.
+  const help = async () => import("./commands/help.js");
+
+  const runNode: CommandNode = {
+    name: "run",
+    summary: "Run evals",
+    printHelp: async () => (await help()).printRunHelp(),
+    handler: async (args, ctx) => {
+      const { parseRunArgs, resolveRunOptions } = await import(
+        "./commands/parse.js"
+      );
+      const { readConfig } = await import("./commands/config.js");
+      const { runCommand } = await import("./commands/run.js");
+
+      const flags = parseRunArgs(args);
+      const configFile = readConfig(ctx.entryDir);
+      const resolved = resolveRunOptions(
+        flags,
+        configFile.defaults,
+        process.env,
+        configFile.core,
+      );
+
+      // Argv mode (no abortRef): handle --legacy here, mirroring cli.ts.
+      if (ctx.abortRef === null) {
+        if (flags.legacy) {
+          const { runLegacy } = await import("./commands/legacy.js");
+          const { discoverTasks } = await import("../framework/discovery.js");
+          const { getRuntimeTasksRoot } = await import("../runtimePaths.js");
+          const registry = await discoverTasks(getRuntimeTasksRoot(), false);
+          await runLegacy(resolved, flags, registry);
+          return;
+        }
+        await runCommand(resolved);
+        return;
+      }
+
+      // REPL mode: pass abort signal so Esc can cancel.
+      const registry = await ctx.getRegistry();
+      ctx.abortRef.current = new AbortController();
+      try {
+        await runCommand(resolved, registry, ctx.abortRef.current.signal);
+      } finally {
+        ctx.abortRef.current = null;
+      }
+    },
+  };
+
+  const listNode: CommandNode = {
+    name: "list",
+    summary: "List tasks and categories",
+    printHelp: async () => (await help()).printListHelp(),
+    handler: async (args, ctx) => {
+      const { printList } = await import("./commands/list.js");
+      const detailed = args.includes("--detailed") || args.includes("-d");
+      const tierFilter = args.find((a) => !a.startsWith("-"));
+      const registry = await ctx.getRegistry();
+      printList(registry, tierFilter, detailed);
+    },
+  };
+
+  const newNode: CommandNode = {
+    name: "new",
+    summary: "Scaffold a new task",
+    printHelp: async () => (await help()).printNewHelp(),
+    handler: async (args, ctx) => {
+      const { scaffoldTask } = await import("./commands/new.js");
+      const task = scaffoldTask(args);
+      // REPL: re-discover so the new task is immediately resolvable.
+      if (task && ctx.abortRef !== null) {
+        const { discoverTasks } = await import("../framework/discovery.js");
+        const { getRuntimeTasksRoot } = await import("../runtimePaths.js");
+        const registry = await discoverTasks(getRuntimeTasksRoot(), false);
+        ctx.setRegistry(registry);
+      }
+    },
+  };
+
+  // ---- config (leaf + children) ----
+  // All `config core` leaves share the same help page (printConfigCoreHelp);
+  // all `config` leaves share printConfigHelp. Setting printHelp on each leaf
+  // makes `evals config core <leaf> help` resolve here in dispatch — leaves
+  // never hand a stray "help" token to their wrapped handler.
+  const printConfigCoreHelpThunk = async () =>
+    (await help()).printConfigCoreHelp();
+  const printConfigHelpThunk = async () => (await help()).printConfigHelp();
+
+  const configCorePath: CommandNode = {
+    name: "path",
+    summary: "Print the config file path",
+    printHelp: printConfigCoreHelpThunk,
+    handler: async (_args, ctx) => {
+      const { handleCore } = await import("./commands/core.js");
+      await handleCore(["path"], ctx.entryDir);
+    },
+  };
+  const configCoreSet: CommandNode = {
+    name: "set",
+    summary: "Set core tool/startup",
+    printHelp: printConfigCoreHelpThunk,
+    handler: async (args, ctx) => {
+      const { handleCore } = await import("./commands/core.js");
+      await handleCore(["set", ...args], ctx.entryDir);
+    },
+  };
+  const configCoreReset: CommandNode = {
+    name: "reset",
+    summary: "Reset core configuration",
+    printHelp: printConfigCoreHelpThunk,
+    handler: async (args, ctx) => {
+      const { handleCore } = await import("./commands/core.js");
+      await handleCore(["reset", ...args], ctx.entryDir);
+    },
+  };
+  const configCoreSetup: CommandNode = {
+    name: "setup",
+    summary: "Interactive wizard (coming soon)",
+    printHelp: printConfigCoreHelpThunk,
+    handler: async (_args, ctx) => {
+      const { handleCore } = await import("./commands/core.js");
+      await handleCore(["setup"], ctx.entryDir);
+    },
+  };
+
+  const configCore: CommandNode = {
+    name: "core",
+    summary: "Configure core tier defaults",
+    printHelp: async () => (await help()).printConfigCoreHelp(),
+    handler: async (args, ctx) => {
+      const { handleCore } = await import("./commands/core.js");
+      await handleCore(args, ctx.entryDir);
+    },
+    children: [configCorePath, configCoreSet, configCoreReset, configCoreSetup],
+  };
+
+  const configPath: CommandNode = {
+    name: "path",
+    summary: "Print the evals.config.json file path",
+    printHelp: printConfigHelpThunk,
+    handler: async (_args, ctx) => {
+      const { handleConfig } = await import("./commands/config.js");
+      await handleConfig(["path"], ctx.entryDir);
+    },
+  };
+  const configSet: CommandNode = {
+    name: "set",
+    summary: "Set a default value",
+    printHelp: printConfigHelpThunk,
+    handler: async (args, ctx) => {
+      const { handleConfig } = await import("./commands/config.js");
+      await handleConfig(["set", ...args], ctx.entryDir);
+    },
+  };
+  const configReset: CommandNode = {
+    name: "reset",
+    summary: "Reset one key or all defaults",
+    printHelp: printConfigHelpThunk,
+    handler: async (args, ctx) => {
+      const { handleConfig } = await import("./commands/config.js");
+      await handleConfig(["reset", ...args], ctx.entryDir);
+    },
+  };
+
+  const configNode: CommandNode = {
+    name: "config",
+    summary: "Get/set default run configuration",
+    printHelp: async () => (await help()).printConfigHelp(),
+    handler: async (args, ctx) => {
+      // matchPath strips known children (path/set/reset/core) before
+      // we get here, so any args remaining are unknown subcommands —
+      // delegate to handleConfig which prints the right error.
+      const { handleConfig, printConfig } = await import(
+        "./commands/config.js"
+      );
+      if (args.length === 0) {
+        printConfig(ctx.entryDir);
+        return;
+      }
+      await handleConfig(args, ctx.entryDir);
+    },
+    children: [configPath, configSet, configReset, configCore],
+  };
+
+  // ---- experiments (pure namespace) ----
+  const experimentsList: CommandNode = {
+    name: "list",
+    summary: "Show recent runs",
+    printHelp: async () => (await help()).printExperimentsHelp("list"),
+    handler: async (args) => {
+      const { handleExperiments } = await import("./commands/experiments.js");
+      await handleExperiments(["list", ...args]);
+    },
+  };
+  const experimentsShow: CommandNode = {
+    name: "show",
+    summary: "Show one experiment",
+    printHelp: async () => (await help()).printExperimentsHelp("show"),
+    handler: async (args) => {
+      const { handleExperiments } = await import("./commands/experiments.js");
+      await handleExperiments(["show", ...args]);
+    },
+  };
+  const experimentsOpen: CommandNode = {
+    name: "open",
+    summary: "Open one experiment in the browser",
+    printHelp: async () => (await help()).printExperimentsHelp("open"),
+    handler: async (args) => {
+      const { handleExperiments } = await import("./commands/experiments.js");
+      await handleExperiments(["open", ...args]);
+    },
+  };
+  const experimentsCompare: CommandNode = {
+    name: "compare",
+    summary: "Generate an HTML comparison report",
+    printHelp: async () => (await help()).printExperimentsHelp("compare"),
+    handler: async (args) => {
+      const { handleExperiments } = await import("./commands/experiments.js");
+      await handleExperiments(["compare", ...args]);
+    },
+  };
+
+  const experimentsNode: CommandNode = {
+    name: "experiments",
+    summary: "Inspect Braintrust experiment runs",
+    printHelp: async () => (await help()).printExperimentsHelp(),
+    handler: async (args) => {
+      // Bare invocation prints help (preserves today's `evals experiments`
+      // behavior). With an unknown trailing token, error out.
+      if (args.length > 0) {
+        throw new Error(`Unknown experiments subcommand "${args[0]}"`);
+      }
+      const { printExperimentsHelp } = await import("./commands/help.js");
+      printExperimentsHelp();
+    },
+    children: [
+      experimentsList,
+      experimentsShow,
+      experimentsOpen,
+      experimentsCompare,
+    ],
+  };
+
+  const root: CommandNode = {
+    name: "evals",
+    summary: "Stagehand evals CLI",
+    printHelp: async () => (await help()).printHelp(),
+    children: [runNode, listNode, configNode, experimentsNode, newNode],
+  };
+
+  return root;
+}
+
+// ---------------------------------------------------------------------------
+// Argv tokenization: re-split args that contain `>` (e.g. from `\>` in shell).
+// ---------------------------------------------------------------------------
+
+/**
+ * Re-tokenize a shell-split argv array on `>` boundaries.
+ *
+ * The shell consumes unescaped `>` as a redirect, so users who want
+ * `evals experiments > list` from a terminal must escape (`\>`) or quote
+ * the chunk. Either way the `>` survives in argv and we split on it here.
+ *
+ * Caveat: a quoted arg containing `>` (e.g. `"foo > bar"`) will also be
+ * split. That's fine for known subcommand surfaces — none of our targets
+ * or option values legitimately contain `>` characters.
+ */
+export function tokenizeArgv(args: readonly string[]): string[] {
+  const out: string[] = [];
+  for (const arg of args) {
+    if (arg === ">") continue;
+    if (!arg.includes(">")) {
+      out.push(arg);
+      continue;
+    }
+    for (const piece of arg.split(">")) {
+      if (piece) out.push(piece);
+    }
+  }
+  return out;
+}
+
+// Re-export tokenize so callers only import from one place.
+export { tokenize };

--- a/packages/evals/tui/repl.ts
+++ b/packages/evals/tui/repl.ts
@@ -2,55 +2,22 @@
  * Interactive REPL for the evals CLI.
  *
  * Shares all parsing + dispatch with the single-shot argv path in
- * cli.ts via tui/commands/parse.ts and tui/commands/*.
+ * cli.ts via tui/commandTree.ts and tui/commands/*.
  */
 
 import * as readline from "node:readline";
 import { printBanner } from "./banner.js";
-import { bb, dim, red, yellow } from "./format.js";
+import { dim, red, yellow } from "./format.js";
 import {
-  printHelp,
-  printRunHelp,
-  printListHelp,
-  printNewHelp,
-} from "./commands/help.js";
-import { printList } from "./commands/list.js";
-import { handleConfig } from "./commands/config.js";
-import { handleExperiments } from "./commands/experiments.js";
-import { runCommand } from "./commands/run.js";
-import { scaffoldTask } from "./commands/new.js";
-import { parseRunArgs, resolveRunOptions } from "./commands/parse.js";
-import { readConfig } from "./commands/config.js";
+  buildCommandTree,
+  dispatch,
+  renderPrompt,
+  tokenize,
+  type CommandContext,
+} from "./commandTree.js";
 import { discoverTasks } from "../framework/discovery.js";
 import type { TaskRegistry } from "../framework/types.js";
 import { getRuntimeTasksRoot } from "../runtimePaths.js";
-
-function tokenize(input: string): string[] {
-  const tokens: string[] = [];
-  let current = "";
-  let inQuote: string | null = null;
-
-  for (const ch of input) {
-    if (inQuote) {
-      if (ch === inQuote) {
-        inQuote = null;
-      } else {
-        current += ch;
-      }
-    } else if (ch === '"' || ch === "'") {
-      inQuote = ch;
-    } else if (ch === " " || ch === "\t") {
-      if (current) {
-        tokens.push(current);
-        current = "";
-      }
-    } else {
-      current += ch;
-    }
-  }
-  if (current) tokens.push(current);
-  return tokens;
-}
 
 export async function startRepl(entryDir: string): Promise<void> {
   printBanner();
@@ -65,16 +32,40 @@ export async function startRepl(entryDir: string): Promise<void> {
     process.exit(1);
   }
 
+  const contextPath: string[] = [];
+  const abortRef = { current: null as AbortController | null };
+
+  const tree = buildCommandTree();
+
+  const ctx: CommandContext = {
+    entryDir,
+    getRegistry: async () => registry,
+    setRegistry: (r) => {
+      registry = r;
+    },
+    abortRef,
+    contextPath,
+    pushContext: (seg) => {
+      contextPath.push(seg);
+    },
+    popContext: () => {
+      contextPath.pop();
+    },
+    setContextPath: (path) => {
+      contextPath.length = 0;
+      for (const p of path) contextPath.push(p);
+    },
+  };
+
   const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout,
-    prompt: `${bb("evals")} ${dim(">")} `,
+    prompt: renderPrompt(contextPath),
   });
 
-  // Esc → abort the in-flight run (cooperative). A second Esc within the
-  // double-press window escalates to aggressive: the runner closes V3
-  // sessions immediately so the in-flight task throws.
-  let currentAbort: AbortController | null = null;
+  // Esc → either pop one context level (idle) or abort the in-flight run
+  // (cooperative; double-press escalates to aggressive — the runner closes
+  // V3 sessions immediately so the in-flight task throws).
   let lastEscAt = 0;
   const DOUBLE_ESC_WINDOW_MS = 1500;
 
@@ -83,20 +74,29 @@ export async function startRepl(entryDir: string): Promise<void> {
     key: { name?: string; ctrl?: boolean } | undefined,
   ): void => {
     if (!key || key.name !== "escape") return;
-    if (!currentAbort) return; // no run in flight; let readline handle Esc
+    if (!abortRef.current) {
+      // Idle Esc: pop one level if we're inside a context.
+      if (contextPath.length > 0) {
+        contextPath.pop();
+        rl.setPrompt(renderPrompt(contextPath));
+        process.stdout.write("\n");
+        rl.prompt();
+      }
+      return;
+    }
     const now = Date.now();
     const isDouble = now - lastEscAt < DOUBLE_ESC_WINDOW_MS;
     lastEscAt = now;
     if (isDouble) {
       console.log(red("\n  ✗ Aborting immediately…"));
-      currentAbort.abort("aggressive");
+      abortRef.current.abort("aggressive");
     } else {
       console.log(
         yellow(
           "\n  ⚠ Aborting after current task… (press Esc again to abort immediately)",
         ),
       );
-      currentAbort.abort("cooperative");
+      abortRef.current.abort("cooperative");
     }
   };
   process.stdin.on("keypress", onKeypress);
@@ -106,115 +106,20 @@ export async function startRepl(entryDir: string): Promise<void> {
   rl.on("line", async (line) => {
     const trimmed = line.trim();
     if (!trimmed) {
+      rl.setPrompt(renderPrompt(contextPath));
       rl.prompt();
       return;
     }
 
     const tokens = tokenize(trimmed);
-    const command = tokens[0].toLowerCase();
-    const args = tokens.slice(1);
-    // Help is only triggered when `--help`/`-h`/`help` sits immediately
-    // after the command. Later positions are arguments or flag values and
-    // must not be swallowed.
-    const wantsHelp =
-      args[0] === "--help" || args[0] === "-h" || args[0] === "help";
 
     try {
-      switch (command) {
-        case "run": {
-          if (wantsHelp) {
-            printRunHelp();
-            break;
-          }
-          const flags = parseRunArgs(args);
-          const configFile = readConfig(entryDir);
-          const resolved = resolveRunOptions(
-            flags,
-            configFile.defaults,
-            process.env,
-            configFile.core,
-          );
-          currentAbort = new AbortController();
-          try {
-            await runCommand(resolved, registry, currentAbort.signal);
-          } finally {
-            currentAbort = null;
-          }
-          break;
-        }
-
-        case "list": {
-          if (wantsHelp) {
-            printListHelp();
-            break;
-          }
-          const detailed = args.includes("--detailed") || args.includes("-d");
-          const tierFilter = args.find((a) => !a.startsWith("-"));
-          printList(registry, tierFilter, detailed);
-          break;
-        }
-
-        case "config": {
-          await handleConfig(args, entryDir);
-          break;
-        }
-
-        case "experiments": {
-          await handleExperiments(args);
-          break;
-        }
-
-        case "new":
-          if (wantsHelp) {
-            printNewHelp();
-            break;
-          }
-          {
-            const task = scaffoldTask(args);
-            if (task) {
-              registry = await discoverTasks(resolvedTasksRoot, false);
-            }
-          }
-          break;
-
-        case "help":
-          printHelp();
-          break;
-
-        case "clear":
-          console.clear();
-          break;
-
-        case "exit":
-        case "quit":
-        case "q":
-          console.log(dim("\n  Goodbye.\n"));
-          process.exit(0);
-          break;
-
-        default: {
-          // Treat unknown first token as a run target
-          const flags = parseRunArgs(tokens);
-          const configFile = readConfig(entryDir);
-          const resolved = resolveRunOptions(
-            flags,
-            configFile.defaults,
-            process.env,
-            configFile.core,
-          );
-          currentAbort = new AbortController();
-          try {
-            await runCommand(resolved, registry, currentAbort.signal);
-          } finally {
-            currentAbort = null;
-          }
-          break;
-        }
-      }
+      await dispatch(tree, tokens, ctx);
     } catch (err) {
       console.error(red(`  Error: ${(err as Error).message}`));
     }
 
+    rl.setPrompt(renderPrompt(contextPath));
     rl.prompt();
   });
 

--- a/packages/evals/tui/tokenize.ts
+++ b/packages/evals/tui/tokenize.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared tokenizer for the evals TUI.
+ *
+ * Splits a line into tokens on whitespace OR `>` (the context-traversal
+ * separator). Inside single- or double-quoted strings, every character
+ * including `>` is preserved literally — so quoted args like
+ * `"foo>bar"` survive intact.
+ *
+ * Used by both the REPL (tui/repl.ts) and argv mode (cli.ts) so that
+ * `evals experiments > list` behaves identically to `evals experiments list`
+ * from the shell, and inside the REPL `experiments > list` is identical
+ * to `experiments list`.
+ */
+export function tokenize(input: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let inQuote: string | null = null;
+
+  for (const ch of input) {
+    if (inQuote) {
+      if (ch === inQuote) {
+        inQuote = null;
+      } else {
+        current += ch;
+      }
+    } else if (ch === '"' || ch === "'") {
+      inQuote = ch;
+    } else if (ch === " " || ch === "\t" || ch === ">") {
+      if (current) {
+        tokens.push(current);
+        current = "";
+      }
+    } else {
+      current += ch;
+    }
+  }
+  if (current) tokens.push(current);
+  return tokens;
+}


### PR DESCRIPTION
# why

# what changed

# test plan

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the Evals TUI/CLI behind a shared command tree with path-style traversal and contextual help. Supports Linear STG-1880 and fixes root fallback parsing by stripping a leading `evals` sigil to improve onboarding and command discovery.

- **New Features**
  - Single `buildCommandTree` powers both REPL and argv dispatch.
  - `>` works as a path separator in REPL and argv; REPL preserves quoted `>`, argv re-splits any arg containing `>`.
  - Context navigation and prompt: `..` goes up; bare `evals` jumps to root; invoking a node with children auto-enters that context in REPL; prompt shows the current path; banner mentions `..`.
  - Help routing: `--help` after a leaf calls that node’s help; `help` shows help for the current context.
  - Root fallback: unknown tokens at root call `run` and now strip a leading `evals` before forwarding (e.g., `evals act`); unknown at depth errors for clarity.
  - REPL quality of life: Esc pops context when idle; Esc still aborts in-flight runs (cooperative/double-press aggressive).

- **Refactors**
  - `cli.ts` and `repl.ts` now resolve and execute via `dispatch` from the shared command tree; added `tokenizeArgv` for argv `>` splitting and `renderPrompt` for context-aware prompts.
  - Moved line tokenization to `tui/tokenize.ts`; added `tui/commandTree.ts` with resolution, prompt rendering, and argv tokenization.
  - Kept command handlers lazy-loaded; added focused tests for the tree, `>` chaining, argv sigil handling, and CLI edge cases.

<sup>Written for commit 2f5c929685407e78762a0938b58f989e831aab6d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

