### PR TITLE
[chore]: rm evals changeset

### DIFF
--- a/.changeset/curly-walls-add.md
+++ b/.changeset/curly-walls-add.md
@@ -1,7 +1,6 @@
 ---
 "@browserbasehq/stagehand-server-v3": patch
 "@browserbasehq/stagehand-server-v4": patch
-"@browserbasehq/stagehand-evals": patch
 "@browserbasehq/stagehand": patch
 ---
 


### PR DESCRIPTION
# why
- changsets are not properly set up in evals workspace, & this package is not yet published on npm
# what changed
- removed patch changeset for evals pkg


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the patch changeset for `@browserbasehq/stagehand-evals` to prevent an accidental release. The evals workspace isn’t configured for Changesets and the package isn’t published to npm.

<sup>Written for commit 86a520040ad50a933ea18d2defe0a2f8c17c9ba9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

