### PR TITLE
fix(evals): strip evals sigil before root fallback to run handler

### DIFF
--- a/packages/evals/tests/tui/commandTree.test.ts
+++ b/packages/evals/tests/tui/commandTree.test.ts
@@ -396,6 +396,14 @@ describe("dispatch", () => {
     expect(h.run).toHaveBeenCalledWith(["act"], ctx);
   });
 
+  it("strips the `evals` sigil before falling back to run", async () => {
+    const h = makeHandlers();
+    const tree = makeTree(h);
+    const ctx = makeCtx();
+    await dispatch(tree, ["evals", "act"], ctx);
+    expect(h.run).toHaveBeenCalledWith(["act"], ctx);
+  });
+
   it("rejects REPL-only metas in argv mode", async () => {
     const h = makeHandlers();
     const tree = makeTree(h);

--- a/packages/evals/tui/commandTree.ts
+++ b/packages/evals/tui/commandTree.ts
@@ -272,7 +272,11 @@ export async function dispatch(
       if (result.context.length === 0) {
         const runNode = findChild(root, "run");
         if (runNode?.handler) {
-          await runNode.handler(tokens, ctx);
+          // Strip a leading "evals" sigil so parseRunArgs doesn't
+          // misinterpret it as a target or flag.
+          const forwarded =
+            tokens[0]?.toLowerCase() === "evals" ? tokens.slice(1) : tokens;
+          await runNode.handler(forwarded, ctx);
           return;
         }
       }


### PR DESCRIPTION
When user input like `evals act` hits the unknown-token root fallback, the full tokens array (including the leading "evals") was forwarded to the run handler. parseRunArgs would then misinterpret "evals" as a target or flag.

Strip the leading "evals" token before delegating to the run handler so only the intended arguments are forwarded.

Addresses cubic-dev-ai review comment on PR #2100.

# why

# what changed

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a parsing bug where inputs like `evals act` were sent to the `run` handler with the `evals` sigil included, causing `parseRunArgs` to misinterpret it. We now strip the leading `evals` token before delegating so only the intended args are passed.

- **Bug Fixes**
  - Strip leading `evals` token in the root fallback before invoking the `run` handler.
  - Added a test to ensure `["evals", "act"]` dispatch forwards `["act"]`.

<sup>Written for commit 9a6fab583aec9aea3a3c3ca248504b6496d179ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

