### PR TITLE
fix(core): import ToolSet from ai public export

### DIFF
--- a/.changeset/light-books-dance.md
+++ b/.changeset/light-books-dance.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+fix(core): import ToolSet from ai public export

--- a/packages/core/lib/v3/agent/AgentProvider.ts
+++ b/packages/core/lib/v3/agent/AgentProvider.ts
@@ -1,4 +1,4 @@
-import { ToolSet } from "ai/dist";
+import { ToolSet } from "ai";
 import { AgentProviderType } from "../types/public/agent.js";
 import { LogLine } from "../types/public/logs.js";
 import { ClientOptions } from "../types/public/model.js";


### PR DESCRIPTION
## Summary
- replace the remaining `ai/dist` deep import with the public `ai` package export
- aligns `AgentProvider` with the other Stagehand v3 CUA files that already import `ToolSet` from `ai`

Fixes #1531.

## Verification
- `corepack pnpm install --ignore-scripts --frozen-lockfile`
- `corepack pnpm --filter @browserbasehq/stagehand run gen-version`
- `corepack pnpm --filter @browserbasehq/stagehand run build-dom-scripts`
- `corepack pnpm exec tsc -p packages/core/tsconfig.json --noEmit`
- `corepack pnpm exec prettier --check packages/core/lib/v3/agent/AgentProvider.ts`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch AgentProvider to import ToolSet from the public `ai` export instead of `ai/dist` to prevent deep import breakage. Adds a patch changeset and aligns with other Stagehand v3 CUA files; fixes #1531.

<sup>Written for commit 1c1767582d16ac2333f171ac87dc877dd6d6ba93. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

