### PR TITLE
[STG-2007] Set structuredOutputMode for anthropic provider

### DIFF
--- a/packages/core/lib/v3/llm/aisdk.ts
+++ b/packages/core/lib/v3/llm/aisdk.ts
@@ -210,6 +210,27 @@ export class AISdkClient extends LLMClient {
           strictJsonSchema: true,
         };
         break;
+      case "anthropic":
+        // @ai-sdk/anthropic defaults to "jsonTool" for structured output, which
+        // returns empty input objects on newer Claude models (e.g. Opus 4.7).
+        // "auto" lets the provider pick the modern outputFormat path on models
+        // that support it while preserving jsonTool for older ones.
+        providerOptions.anthropic = {
+          structuredOutputMode: "auto",
+        };
+        break;
+    }
+
+    // Fallback for bare "claude-..." modelIds (no "anthropic/" prefix): the
+    // inferred provider name above won't match "anthropic", so apply the same
+    // structuredOutputMode opt-in here.
+    if (
+      this.model.modelId.startsWith("claude-") &&
+      !providerOptions.anthropic
+    ) {
+      providerOptions.anthropic = {
+        structuredOutputMode: "auto",
+      };
     }
 
     if (options.response_model) {

--- a/packages/core/tests/unit/aisdk-clients.test.ts
+++ b/packages/core/tests/unit/aisdk-clients.test.ts
@@ -47,6 +47,18 @@ describe("AISdkClient structured output provider options", () => {
       "mistral/mistral-large-latest",
       { mistral: { structuredOutputs: true, strictJsonSchema: true } },
     ],
+    [
+      "anthropic/claude-opus-4-7",
+      { anthropic: { structuredOutputMode: "auto" } },
+    ],
+    [
+      "anthropic/claude-sonnet-4-5",
+      { anthropic: { structuredOutputMode: "auto" } },
+    ],
+    [
+      "claude-opus-4-7",
+      { anthropic: { structuredOutputMode: "auto" } },
+    ],
   ])(
     "passes provider structured-output options for %s",
     async (modelId, providerOptions) => {


### PR DESCRIPTION
## Summary

`stagehand.extract()` calls against Claude Opus 4.7 return `tool_use { input: {} }`, which fails schema validation. Claude 4.5 and 4.6 work on the same code path.

## Root cause

`@ai-sdk/anthropic` supports two protocols for structured JSON: the legacy `jsonTool` path and the newer `outputFormat` (json_schema) path. Opus 4.7 was built for the new path and returns empty input objects when handed the old one.

The path is controlled by:

```ts
providerOptions: { anthropic: { structuredOutputMode: "auto" | "jsonTool" | "outputFormat" } }
```

`@ai-sdk/anthropic` defaults to `jsonTool`. The provider switch in `packages/core/lib/v3/llm/aisdk.ts` sets correct structured-output opt-ins for every other provider (`openai`/`azure` → `strictJsonSchema: true`, `google`/`vertex`/`groq`/`mistral` → `structuredOutputs: true`, etc.) but had no entry for `anthropic` — so the broken default kicks in.

## Fix

- Added an `anthropic` case to the provider switch that sets `structuredOutputMode: "auto"`. `"auto"` lets the AI SDK pick `outputFormat` on models that support it (Opus 4.7+) while preserving `jsonTool` behavior on older models.
- Added a fallback for bare `claude-...` modelIds (no `anthropic/` prefix) — `inferProviderName` returns the full string in that case, so the switch wouldn't match. Mirrors how `isOpus47` already handles both shapes a few lines above.

## Test plan

- Extended the parameterized test in `packages/core/tests/unit/aisdk-clients.test.ts` to cover `anthropic/claude-opus-4-7`, `anthropic/claude-sonnet-4-5`, and bare `claude-opus-4-7`.
- Verified locally by the reporter that the empty-extract issue is gone on Opus 4.7.

Requested by: chris@browserbase.com
Linear: https://linear.app/browserbase/issue/STG-2007/stagehandextract-returns-empty-input-on-claude-opus-47-via-ai-sdk