### PR TITLE
[STG-2014] fix: mark project id optional in docs

### DIFF
--- a/.changeset/fix-stagehand-project-id-docs.md
+++ b/.changeset/fix-stagehand-project-id-docs.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand-server-v3": patch
+---
+
+Mark the deprecated Browserbase project ID header as optional in generated API docs.

--- a/packages/server-v3/openapi.v3.yaml
+++ b/packages/server-v3/openapi.v3.yaml
@@ -2313,4 +2313,3 @@ servers:
   - url: https://api.stagehand.browserbase.com
 security:
   - BrowserbaseApiKey: []
-    BrowserbaseProjectId: []

--- a/packages/server-v3/scripts/gen-openapi.ts
+++ b/packages/server-v3/scripts/gen-openapi.ts
@@ -145,7 +145,7 @@ Please try it and give us your feedback, stay tuned for upcoming release announc
         securitySchemes: Api.openApiSecuritySchemes,
         links: Api.openApiLinks,
       },
-      security: [{ BrowserbaseApiKey: [], BrowserbaseProjectId: [] }],
+      security: [{ BrowserbaseApiKey: [] }],
     },
     ...fastifyZodOpenApiTransformers,
   });

--- a/stainless.yml
+++ b/stainless.yml
@@ -231,8 +231,7 @@ client_settings:
       read_env: BROWSERBASE_PROJECT_ID
       description: Deprecated. Browserbase API keys are now project-scoped, so this value is no longer required.
       nullable: true
-      auth:
-        security_scheme: BBProjectIdAuth
+      send_in_header: x-bb-project-id
     MODEL_API_KEY:
       type: string
       read_env: MODEL_API_KEY
@@ -246,10 +245,6 @@ security_schemes:
     type: apiKey
     in: header
     name: x-bb-api-key
-  BBProjectIdAuth:
-    type: apiKey
-    in: header
-    name: x-bb-project-id
   LLMModelApiKeyAuth:
     type: apiKey
     in: header
@@ -257,7 +252,6 @@ security_schemes:
 
 security:
   - BBApiKeyAuth: []
-    BBProjectIdAuth: []
     LLMModelApiKeyAuth: []
 
 # `readme` is used to configure the code snippets that will be rendered in the


### PR DESCRIPTION
## Summary

- mark deprecated Browserbase project ID as optional in generated API docs
- remove project ID from required v3 OpenAPI/Stainless auth requirements
- keep project ID available as an optional deprecated header value

Linear: https://linear.app/browserbase/issue/STG-2014/mark-project-id-optional-in-stagehand-api-docs

## Verification

- pnpm --filter @browserbasehq/stagehand-server-v3 gen:openapi
- pnpm --filter @browserbasehq/stagehand-server-v3 typecheck
- pnpm -w exec prettier --check packages/server-v3/scripts/gen-openapi.ts stainless.yml .changeset/fix-stagehand-project-id-docs.md packages/server-v3/openapi.v3.yaml


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Browserbase project ID optional in Stagehand v3 API docs and security. Removes it from required auth in OpenAPI/Stainless and keeps `x-bb-project-id` as a deprecated optional header. Aligns with Linear STG-2014.

- **Migration**
  - No action needed.
  - You can remove the `x-bb-project-id` header; it’s still accepted but deprecated.

<sup>Written for commit 32a13f1395eea10c23a58e31f84a8b6fe1fad6bc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

