### PR TITLE
Fix `structuredOutputMode` for newer Anthropic models

### DIFF
--- a/.changeset/little-apples-watch.md
+++ b/.changeset/little-apples-watch.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Fix structuredOutputMode for newer Anthropic models

--- a/packages/core/lib/v3/llm/aisdk.ts
+++ b/packages/core/lib/v3/llm/aisdk.ts
@@ -179,6 +179,11 @@ export class AISdkClient extends LLMClient {
             : {}),
         };
         break;
+      case "anthropic":
+        providerOptions.anthropic = {
+          structuredOutputMode: "auto",
+        };
+        break;
       case "azure":
         providerOptions.azure = {
           strictJsonSchema: true,


### PR DESCRIPTION
# why
New output mode `output_format` from anthropic breaks compat with older `jsonTool`. Opus 4.7 defaults to the new format so it breaks with strict mode settings enabled

# what changed
On `aisdk.ts` ensured `structuredOutputMode` defaults to `auto`. 

# test plan
- [x] tested with `env:LOCAL` and extract with custom schema

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `providerOptions.anthropic.structuredOutputMode` to `auto` for the `anthropic` provider to align with newer Anthropic models. Restores structured outputs and prevents schema/response errors when generating JSON, and adds a patch changeset for `@browserbasehq/stagehand`.

<sup>Written for commit 6ef214890b3cba6db15870e53f484dd28e208522. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

