### PR TITLE
Pin github action/workflow versions

### DIFF
--- a/.github/actions/setup-node-pnpm-turbo/action.yml
+++ b/.github/actions/setup-node-pnpm-turbo/action.yml
@@ -17,10 +17,10 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@v4
+    - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
     - name: Set up Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ inputs.node-version }}
         cache: 'pnpm'
@@ -28,7 +28,7 @@ runs:
 
     - name: Restore Turbo cache
       if: ${{ inputs.restore-turbo-cache == 'true' }}
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: .turbo
         key: ${{ runner.os }}-turbo-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'package.json', 'turbo.json') }}-${{ github.sha }}
@@ -41,7 +41,7 @@ runs:
   
     - name: Download build artifacts
       if: ${{ inputs.use-prebuilt-artifacts == 'true' }}
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: build-artifacts
         path: .

--- a/.github/actions/upload-ctrf-report/action.yml
+++ b/.github/actions/upload-ctrf-report/action.yml
@@ -25,7 +25,7 @@ runs:
         fi
 
     - name: Upload CTRF report artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: ${{ steps.normalize.outputs.name }}
         # package.json anchors uploaded paths to the repository root.

--- a/.github/actions/upload-v8-coverage/action.yml
+++ b/.github/actions/upload-v8-coverage/action.yml
@@ -25,7 +25,7 @@ runs:
         fi
 
     - name: Upload coverage artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: ${{ steps.normalize.outputs.name }}
         # package.json anchors uploaded paths to the repository root.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       docs-only: ${{ steps.filter.outputs.docs-only }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Log GitHub API rate limit
         env:
@@ -82,7 +82,7 @@ jobs:
             exit 1
           fi
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         id: filter
         with:
           filters: |
@@ -129,7 +129,7 @@ jobs:
       label_agent: ${{ steps.load.outputs.label_agent }}
     steps:
       - id: load
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -247,7 +247,7 @@ jobs:
     needs: [run-build]
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - uses: ./.github/actions/setup-node-pnpm-turbo
         with:
@@ -280,7 +280,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - uses: ./.github/actions/setup-node-pnpm-turbo
         with:
@@ -292,13 +292,13 @@ jobs:
 
       - name: Save Turbo cache
         if: always()
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'package.json', 'turbo.json') }}-${{ github.sha }}
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: build-artifacts
           include-hidden-files: true
@@ -323,7 +323,7 @@ jobs:
     needs: [run-build, determine-changes]
     if: needs.determine-changes.outputs.cli == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
 
@@ -341,7 +341,7 @@ jobs:
     needs: [run-build, determine-changes]
     if: needs.determine-changes.outputs.evals == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
 
@@ -362,7 +362,7 @@ jobs:
       has-core-tests: ${{ steps.set-matrix.outputs.has-core-tests }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
 
@@ -401,7 +401,7 @@ jobs:
         test: ${{ fromJson(needs.discover-core-tests.outputs.core-tests) }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
 
@@ -433,7 +433,7 @@ jobs:
       has-integration-tests: ${{ steps.set-matrix.outputs.has-integration-tests }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
 
@@ -500,7 +500,7 @@ jobs:
       BROWSERBASE_PROJECT_ID: ${{ secrets.BROWSERBASE_PROJECT_ID }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
 
@@ -510,7 +510,7 @@ jobs:
           restore-turbo-cache: "false"
 
       - name: Download SEA binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: stagehand-server-v3-linux-x64-sourcemap
           path: .
@@ -524,7 +524,7 @@ jobs:
 
       - name: Set up Chrome
         id: setup-chrome-server
-        uses: browser-actions/setup-chrome@v2
+        uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd # v2.1.2
         with:
           chrome-version: stable
           install-dependencies: true
@@ -562,7 +562,7 @@ jobs:
       has-e2e-tests: ${{ steps.set-matrix.outputs.has-e2e-tests }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
 
@@ -609,7 +609,7 @@ jobs:
         test: ${{ fromJson(needs.discover-e2e-tests.outputs.e2e-tests) }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - uses: ./.github/actions/setup-node-pnpm-turbo
         with:
@@ -618,7 +618,7 @@ jobs:
 
       - name: Set up Chrome
         id: setup-chrome-local-e2e
-        uses: browser-actions/setup-chrome@v2
+        uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd # v2.1.2
         with:
           chrome-version: stable
           install-dependencies: true
@@ -669,7 +669,7 @@ jobs:
         test: ${{ fromJson(needs.discover-e2e-tests.outputs.e2e-tests) }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - uses: ./.github/actions/setup-node-pnpm-turbo
         with:
@@ -725,7 +725,7 @@ jobs:
       STAGEHAND_SERVER_TARGET: local
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - uses: ./.github/actions/setup-node-pnpm-turbo
         with:
@@ -825,7 +825,7 @@ jobs:
     # if: always()
     if: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
 
@@ -835,7 +835,7 @@ jobs:
           restore-turbo-cache: "false"
 
       - name: Download V8 coverage artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         continue-on-error: true
         with:
           pattern: coverage-*
@@ -843,7 +843,7 @@ jobs:
           merge-multiple: true
 
       - name: Download CTRF artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         continue-on-error: true
         with:
           pattern: ctrf-*
@@ -857,7 +857,7 @@ jobs:
       - name: Upload merged coverage report
         if: always()
         id: upload-coverage-artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage-merged
           # package.json is included to anchor artifact paths at repo root.
@@ -885,7 +885,7 @@ jobs:
 
       - name: Publish merged CTRF report
         if: always()
-        uses: ctrf-io/github-test-reporter@v1
+        uses: ctrf-io/github-test-reporter@0f299074936c32ccaab5be5230511f6b2b9080aa # v1.0.28
         with:
           report-path: './ctrf/**/*.json'
           summary: true

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,7 +29,7 @@ jobs:
       actions: write # Required for Claude to read CI results on PRs / rerun actions that failed
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
@@ -45,7 +45,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@86eb26bf0139bdd75acd15ea5f00f45ee0a284c2 # v1.0.122
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 

--- a/.github/workflows/external-contributor-pr-approval-handoff.yml
+++ b/.github/workflows/external-contributor-pr-approval-handoff.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Write approval handoff payload
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -36,7 +36,7 @@ jobs:
             fs.writeFileSync('approval-handoff.json', JSON.stringify(payload));
 
       - name: Upload approval handoff artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: approved-review
           path: approval-handoff.json

--- a/.github/workflows/external-contributor-pr.yml
+++ b/.github/workflows/external-contributor-pr.yml
@@ -433,7 +433,7 @@ jobs:
     steps:
       - name: Sync external PR lifecycle
         if: github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'synchronize'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -445,7 +445,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download approval handoff artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: approved-review
           path: approval-handoff
@@ -455,7 +455,7 @@ jobs:
 
       - name: Prepare approved claim
         id: prepare-claim
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -464,7 +464,7 @@ jobs:
 
       - name: Checkout repository for branch operations
         if: steps.prepare-claim.outputs.should-claim == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           persist-credentials: true
@@ -566,7 +566,7 @@ jobs:
       - name: Finalize approved claim
         id: finalize-claim
         if: always() && steps.prepare-claim.outputs.should-claim == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -592,7 +592,7 @@ jobs:
 
       - name: Trigger claimed PR CI
         if: steps.finalize-claim.outputs.claimed == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -611,7 +611,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Sync mirrored PR lifecycle
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/feature-parity.yml
+++ b/.github/workflows/feature-parity.yml
@@ -20,10 +20,10 @@ jobs:
       issues: write
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Check user permissions
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -59,7 +59,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: generate-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         with:
           app-id: ${{ secrets.PARITY_APP_ID }}
           private-key: ${{ secrets.PARITY_APP_PRIVATE_KEY }}
@@ -67,7 +67,7 @@ jobs:
           repositories: stagehand
 
       - name: Create issue in Python SDK repository
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |

--- a/.github/workflows/manual-evals.yml
+++ b/.github/workflows/manual-evals.yml
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - uses: ./.github/actions/setup-node-pnpm-turbo
         with:
@@ -125,13 +125,13 @@ jobs:
 
       - name: Save Turbo cache
         if: always()
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'package.json', 'turbo.json') }}-${{ github.sha }}
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: build-artifacts
           include-hidden-files: true
@@ -167,7 +167,7 @@ jobs:
       STAGEHAND_SERVER_TARGET: local
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - uses: ./.github/actions/setup-node-pnpm-turbo
         with:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -27,7 +27,7 @@ jobs:
           use-prebuilt-artifacts: "false"
 
       - name: Configure npm registry for Trusted Publishing
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20.x
           registry-url: "https://registry.npmjs.org"
@@ -77,7 +77,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         if: steps.check_changesets.outputs.should_run == 'true'
         with:
           publish: pnpm run release

--- a/.github/workflows/stagehand-server-v3-release.yml
+++ b/.github/workflows/stagehand-server-v3-release.yml
@@ -27,7 +27,7 @@ jobs:
       tag: ${{ steps.meta.outputs.tag }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
           fetch-tags: true
@@ -267,7 +267,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
           fetch-tags: false
@@ -281,7 +281,7 @@ jobs:
           cp "${{ env.OAS_PATH }}" "release-assets/openapi.v3.stagehand-server-v3-${{ needs.detect.outputs.version }}.yaml"
 
       - name: Download SEA binary artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: stagehand-server-v3-*
           path: .
@@ -315,7 +315,7 @@ jobs:
           fi
 
       - name: Publish stagehand/server-v3 GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ needs.detect.outputs.tag }}
           name: stagehand/server-v3 v${{ needs.detect.outputs.version }}

--- a/.github/workflows/stagehand-server-v3-sea-build.yml
+++ b/.github/workflows/stagehand-server-v3-sea-build.yml
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           fetch-tags: false
@@ -169,7 +169,7 @@ jobs:
           fi
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: ${{ inputs.upload-only-binary == '' || matrix.binary_name == inputs.upload-only-binary }}
         with:
           name: ${{ matrix.binary_name }}

--- a/.github/workflows/stagehand-server-v4-release.yml
+++ b/.github/workflows/stagehand-server-v4-release.yml
@@ -27,7 +27,7 @@ jobs:
       tag: ${{ steps.meta.outputs.tag }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
           fetch-tags: true
@@ -267,7 +267,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
           fetch-tags: false
@@ -281,7 +281,7 @@ jobs:
           cp "${{ env.OAS_PATH }}" "release-assets/openapi.v4.stagehand-server-v4-${{ needs.detect.outputs.version }}.yaml"
 
       - name: Download SEA binary artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: stagehand-server-v4-*
           path: .
@@ -315,7 +315,7 @@ jobs:
           fi
 
       - name: Publish stagehand/server-v4 GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ needs.detect.outputs.tag }}
           name: stagehand/server-v4 v${{ needs.detect.outputs.version }}

--- a/.github/workflows/stagehand-server-v4-sea-build.yml
+++ b/.github/workflows/stagehand-server-v4-sea-build.yml
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           fetch-tags: false
@@ -169,7 +169,7 @@ jobs:
           fi
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: ${{ inputs.upload-only-binary == '' || matrix.binary_name == inputs.upload-only-binary }}
         with:
           name: ${{ matrix.binary_name }}

--- a/.github/workflows/stainless.yml
+++ b/.github/workflows/stainless.yml
@@ -26,12 +26,12 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 2
 
       - name: Run preview builds
-        uses: stainless-api/upload-openapi-spec-action/preview@v1
+        uses: stainless-api/upload-openapi-spec-action/preview@fd70a2b6f380b00cad97b74ab14ab74918f96a65 # v1.13.3
         with:
           stainless_api_key: ${{ secrets.STAINLESS_API_KEY }}
           org: ${{ env.STAINLESS_ORG }}
@@ -47,11 +47,11 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 2
       - name: Run merge build
-        uses: stainless-api/upload-openapi-spec-action/merge@v1
+        uses: stainless-api/upload-openapi-spec-action/merge@fd70a2b6f380b00cad97b74ab14ab74918f96a65 # v1.13.3
         with:
           stainless_api_key: ${{ secrets.STAINLESS_API_KEY }}
           org: ${{ env.STAINLESS_ORG }}


### PR DESCRIPTION
# why

# what changed

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned all GitHub Actions and composite action dependencies to exact commit SHAs to improve supply-chain security and ensure reproducible CI/release runs. No behavior changes expected.

- **Dependencies**
  - Replaced version tags with pinned SHAs for `actions/checkout`, `actions/setup-node`, `actions/cache`, `actions/download-artifact`, `actions/upload-artifact`, `dorny/paths-filter`, `browser-actions/setup-chrome`, `changesets/action`, `softprops/action-gh-release`, `stainless-api/upload-openapi-spec-action`, `anthropics/claude-code-action`, `ctrf-io/github-test-reporter`, and others.
  - Added inline comments with the corresponding tag (e.g., v4.3.1) to simplify future updates.

<sup>Written for commit bfa9341dc8226b35c8133dde3e1792d9da89e0e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

