### PR TITLE
[chore]: omit test files from published package

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,7 +47,9 @@
   },
   "files": [
     "dist/esm",
-    "dist/cjs"
+    "dist/cjs",
+    "!dist/esm/tests",
+    "!dist/cjs/tests"
   ],
   "keywords": [
     "ai",


### PR DESCRIPTION
# why
- users don't need to be installing our tests
# what changed
- added explicit negations for `dist/esm/tests` and `dist/cjs/tests` in `packages/core/package.json`
- this keeps our test suite running with the built code in `dist`, while still avoiding publishing test files to npm
# test plan
- verified that test are not included in tarball with `npm pack --dry-run` 
- existing test suite

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop publishing test files with the package to reduce the npm tarball and avoid installing unnecessary files. Updated `packages/core/package.json` to exclude `dist/esm/tests` and `dist/cjs/tests` via the `files` array; tests still run against built code locally and were verified with `npm pack --dry-run`.

<sup>Written for commit ccd7212304bcec1b8a8e32d32c035eb4263cb81e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

