### PR TITLE
[chore]: rm deepmerge from peer deps

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -61,7 +61,6 @@
   "author": "Browserbase",
   "license": "MIT",
   "peerDependencies": {
-    "deepmerge": "^4.3.1",
     "patchright-core": "^1.55.2",
     "playwright-core": "^1.55.1",
     "puppeteer-core": "^24.43.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,9 +146,6 @@ importers:
       ai:
         specifier: ^5.0.133
         version: 5.0.133(zod@4.2.1)
-      deepmerge:
-        specifier: ^4.3.1
-        version: 4.3.1
       devtools-protocol:
         specifier: ^0.0.1464554
         version: 0.0.1464554
@@ -3948,10 +3945,6 @@ packages:
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
-
-  deepmerge@4.3.1:
-    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
-    engines: {node: '>=0.10.0'}
 
   default-browser-id@5.0.1:
     resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
@@ -11658,8 +11651,6 @@ snapshots:
     optional: true
 
   deep-is@0.1.4: {}
-
-  deepmerge@4.3.1: {}
 
   default-browser-id@5.0.1: {}
 


### PR DESCRIPTION
# why
- unused peer dep
# what changed
- removed `deepmerge` from peer deps


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused peer dependency `deepmerge` from `packages/core`. This simplifies installs and removes unnecessary peer warnings.

<sup>Written for commit 50652b85227a06627d557c1c431b33c96470555c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

