### PR TITLE
feat: simplify LLMClient with auto-injected model for generateText/generateObject/streamText/streamObject

### DIFF
--- a/packages/core/lib/v3/llm/LLMClient.ts
+++ b/packages/core/lib/v3/llm/LLMClient.ts
@@ -114,6 +114,26 @@ export interface LLMParsedResponse<T> {
   usage?: LLMUsage;
 }
 
+/**
+ * Resolve the language model for convenience wrappers.
+ * Prefers the explicitly provided model, falls back to the client's
+ * `getLanguageModel()`, and throws a helpful error if neither is available.
+ */
+function resolveModel(
+  client: LLMClient,
+  model?: LanguageModelV2,
+): LanguageModelV2 {
+  const resolved = model ?? client.getLanguageModel?.();
+  if (!resolved) {
+    throw new Error(
+      "No language model available. This LLMClient does not implement getLanguageModel(). " +
+        "Please pass a `model` parameter explicitly, or use a model name with '/' prefix " +
+        '(e.g. "openai/gpt-4.1") so Stagehand can create an AI SDK-backed client.',
+    );
+  }
+  return resolved;
+}
+
 export abstract class LLMClient {
   public type: "openai" | "anthropic" | "cerebras" | "groq" | (string & {});
   public modelName: AvailableModel | (string & {});
@@ -140,10 +160,89 @@ export abstract class LLMClient {
     options: CreateChatCompletionOptions,
   ): Promise<T>;
 
-  public generateObject = generateObject;
-  public generateText = generateText;
-  public streamText = streamText;
-  public streamObject = streamObject;
+  /**
+   * Generate text using the Vercel AI SDK, with the client's model
+   * automatically injected. You can still override by passing `model`.
+   *
+   * @example
+   * ```ts
+   * const { text } = await stagehand.llmClient.generateText({
+   *   prompt: "Summarize the page content",
+   * });
+   * ```
+   */
+  public generateText(
+    ...args: Parameters<typeof generateText>
+  ): ReturnType<typeof generateText> {
+    const [params] = args;
+    return generateText({
+      ...params,
+      model: resolveModel(this, params.model),
+    });
+  }
+
+  /**
+   * Generate a structured object using the Vercel AI SDK, with the
+   * client's model automatically injected. You can still override by
+   * passing `model`.
+   *
+   * @example
+   * ```ts
+   * const { object } = await stagehand.llmClient.generateObject({
+   *   schema: myZodSchema,
+   *   prompt: "Extract the product details",
+   * });
+   * ```
+   */
+  public generateObject(
+    ...args: Parameters<typeof generateObject>
+  ): ReturnType<typeof generateObject> {
+    const [params] = args;
+    return generateObject({
+      ...params,
+      model: resolveModel(this, params.model),
+    });
+  }
+
+  /**
+   * Stream text using the Vercel AI SDK, with the client's model
+   * automatically injected. You can still override by passing `model`.
+   *
+   * @example
+   * ```ts
+   * const { textStream } = await stagehand.llmClient.streamText({
+   *   prompt: "Write a long story",
+   * });
+   * for await (const chunk of textStream) {
+   *   process.stdout.write(chunk);
+   * }
+   * ```
+   */
+  public streamText(
+    ...args: Parameters<typeof streamText>
+  ): ReturnType<typeof streamText> {
+    const [params] = args;
+    return streamText({
+      ...params,
+      model: resolveModel(this, params.model),
+    });
+  }
+
+  /**
+   * Stream a structured object using the Vercel AI SDK, with the
+   * client's model automatically injected. You can still override by
+   * passing `model`.
+   */
+  public streamObject(
+    ...args: Parameters<typeof streamObject>
+  ): ReturnType<typeof streamObject> {
+    const [params] = args;
+    return streamObject({
+      ...params,
+      model: resolveModel(this, params.model),
+    });
+  }
+
   public generateImage = experimental_generateImage;
   public embed = embed;
   public embedMany = embedMany;


### PR DESCRIPTION
## Summary

Makes `stagehand.llmClient.generateText()`, `.generateObject()`, `.streamText()`, and `.streamObject()` automatically use the client's language model — no need to pass `model` manually.

Closes #666

## Problem

Currently, the LLMClient exposes `generateText`, `generateObject`, etc. as bare re-exports of the Vercel AI SDK functions. Users must still provide the `model` parameter:

```ts
// Before: verbose — you must find and pass the model yourself
const { text } = await stagehand.llmClient.generateText({
  model: someLanguageModel,
  prompt: 'What should I type next?'
});
```

This is awkward because the LLMClient *already knows* its model.

## Solution

Convert the four AI SDK convenience methods from direct function references into **wrapper methods** that auto-resolve the model via `getLanguageModel()`:

```ts
// After: just works — model is auto-injected from the client
const { text } = await stagehand.llmClient.generateText({
  prompt: 'What should I type next?'
});

// Structured output too
const { object } = await stagehand.llmClient.generateObject({
  schema: myZodSchema,
  prompt: 'Extract the product details'
});

// Streaming
const { textStream } = await stagehand.llmClient.streamText({
  prompt: 'Write a long story'
});
```

If `getLanguageModel()` is not available (legacy non-AI-SDK clients), a clear error is thrown with guidance on how to fix it.

Explicit `model` overrides still work for advanced use cases.

## Changes

**`packages/core/lib/v3/llm/LLMClient.ts`**:
- Add `resolveModel()` helper that prefers an explicit `model` param, falls back to `getLanguageModel()`, and throws a descriptive error if neither is available
- Replace `public generateText = generateText;` (and similar) with proper wrapper methods that call `resolveModel()` before delegating to the AI SDK function
- `generateImage`, `embed`, `embedMany`, `transcribe`, `generateSpeech` remain as direct references (they use different model types)
- Full JSDoc with `@example` blocks on each new method

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-injects the client’s language model into `generateText`, `generateObject`, `streamText`, and `streamObject` so you don’t need to pass `model`. Overrides still work, and legacy clients get a clear error with guidance.

- **New Features**
  - Added `resolveModel()` to prefer an explicit `model`, else use `getLanguageModel()`, otherwise throw a helpful error.
  - Wrapped the four methods to inject the model before calling the Vercel AI SDK.
  - Left `generateImage`, `embed`, `embedMany`, `transcribe`, and `generateSpeech` unchanged.

<sup>Written for commit 0852de7394df24788ac45d9ccc9e420c7d6f62f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

