### PR TITLE
docs: clarify Node version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ Visit [docs.stagehand.dev](https://docs.stagehand.dev) to view the full document
 
 ### Build and Run from Source
 
+Stagehand requires Node.js `^20.19.0 || >=22.12.0` and pnpm.
+
 ```bash
 git clone https://github.com/browserbase/stagehand.git
 cd stagehand

--- a/packages/server-v4/README.md
+++ b/packages/server-v4/README.md
@@ -6,7 +6,7 @@ The Stagehand  is a powerful service that provides a RESTful interface for brows
 
 To run the Stagehand API locally, ensure you have the following installed:
 
-- Node.js
+- Node.js `^20.19.0 || >=22.12.0`
 - pnpm
 
 ## 🛠 Installation
@@ -33,4 +33,3 @@ cp .env.example .env
 4. Configure your `.env` file with the environment variables required by `src/lib/env.ts` (BB environment, API base URLs, etc.).
 
 5. `pnpm dev`
-


### PR DESCRIPTION
## why

The root package already declares the supported Node range as `^20.19.0 || >=22.12.0`, but the source-build docs only said `Node.js`. That leaves contributors guessing which Node versions match the package engines, especially around the Node support discussion in #1995.

## what changed

- added the existing package engine range to the root source-build instructions
- added the same Node range to the server-v4 local API prerequisites

## test plan

- `git diff --check`

No runtime tests; docs-only change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified `Node.js` version support in the docs to match our engines. Added `^20.19.0 || >=22.12.0` to the root build-from-source instructions and the server-v4 local API prerequisites.

<sup>Written for commit 811f3c71d19e9fe2e886b69a9761d3d7671b6311. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2128?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

