### PR TITLE
fix(core): fall back to zod/v4 JSON schema converter

### DIFF
--- a/.changeset/zod-v4-json-schema-fallback.md
+++ b/.changeset/zod-v4-json-schema-fallback.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Use the Zod v4 subpath JSON schema converter when root zod does not expose `toJSONSchema`.

--- a/packages/core/lib/v3/zodCompat.ts
+++ b/packages/core/lib/v3/zodCompat.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { z as zodV4 } from "zod/v4";
 import type {
   ZodObject as Zod4Object,
   ZodRawShape as Zod4RawShape,
@@ -35,15 +36,18 @@ export function toJsonSchema(schema: StagehandZodSchema): JsonSchemaDocument {
     return zodToJsonSchema(schema);
   }
 
-  // For v4 schemas, use built-in z.toJSONSchema() method
-  const zodWithJsonSchema = z as typeof z & {
-    toJSONSchema?: (schema: Zod4TypeAny) => JsonSchemaDocument;
-  };
+  const converters = [zodV4, z] as Array<
+    typeof z & {
+      toJSONSchema?: (schema: Zod4TypeAny) => JsonSchemaDocument;
+    }
+  >;
 
-  if (zodWithJsonSchema.toJSONSchema) {
-    return zodWithJsonSchema.toJSONSchema(schema as Zod4TypeAny);
+  for (const zodWithJsonSchema of converters) {
+    if (zodWithJsonSchema.toJSONSchema) {
+      return zodWithJsonSchema.toJSONSchema(schema as Zod4TypeAny);
+    }
   }
 
-  // This should never happen with Zod v4.1+
+  // This should never happen with Zod v4.1+ or transitional Zod v3.25+ packages.
   throw new Error("Zod v4 toJSONSchema method not found");
 }

--- a/packages/core/tests/unit/zod-compat.test.ts
+++ b/packages/core/tests/unit/zod-compat.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("zodCompat", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock("zod");
+    vi.doUnmock("zod/v4");
+    vi.doUnmock("zod-to-json-schema");
+  });
+
+  it("uses zod/v4 JSON schema conversion when root zod lacks toJSONSchema", async () => {
+    const schema = { _zod: { def: { type: "object" } } };
+    const jsonSchema = {
+      type: "object",
+      properties: { ok: { type: "boolean" } },
+    };
+    const toJSONSchema = vi.fn(() => jsonSchema);
+
+    vi.doMock("zod", () => ({ z: {} }));
+    vi.doMock("zod/v4", () => ({ z: { toJSONSchema } }));
+    vi.doMock("zod-to-json-schema", () => ({ default: vi.fn() }));
+
+    const { toJsonSchema } = await import("../../lib/v3/zodCompat.js");
+
+    expect(toJsonSchema(schema as never)).toBe(jsonSchema);
+    expect(toJSONSchema).toHaveBeenCalledWith(schema);
+  });
+});


### PR DESCRIPTION
## why

Fixes #1845. Stagehand detects v4-shaped schemas by `_zod`, but `toJsonSchema()` assumed the root `zod` import always exposes `toJSONSchema()`. In bundled/deployed environments where root `zod` resolves to the transitional v3 surface while user schemas come from `zod/v4`, extraction can throw `Zod v4 toJSONSchema method not found`.

## what changed

- Import the `zod/v4` subpath converter and try it before the root `zod` converter for v4 schemas.
- Keep the existing v3 `zod-to-json-schema` path unchanged.
- Add a unit test that mocks root `zod` without `toJSONSchema()` while `zod/v4` provides it.
- Add a patch changeset for `@browserbasehq/stagehand`.

## test plan

- `pnpm --filter @browserbasehq/stagehand run build:esm`
- `pnpm exec vitest run --config vitest.esm.config.mjs dist/esm/tests/unit/zod-compat.test.js` from `packages/core`
- `pnpm --filter @browserbasehq/stagehand run typecheck`
- `pnpm --filter @browserbasehq/stagehand exec eslint lib/v3/zodCompat.ts tests/unit/zod-compat.test.ts`
- `pnpm --filter @browserbasehq/stagehand exec prettier --check lib/v3/zodCompat.ts tests/unit/zod-compat.test.ts ../../.changeset/zod-v4-json-schema-fallback.md`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a fallback to the `zod/v4` JSON schema converter when the root `zod` lacks `toJSONSchema`, preventing “Zod v4 toJSONSchema method not found” errors in bundled builds. Fixes #1845.

- **Bug Fixes**
  - Use `zod/v4`’s `toJSONSchema` before the root `zod` for v4-shaped schemas.
  - Keep the v3 `zod-to-json-schema` path unchanged.
  - Add a unit test that mocks root `zod` without `toJSONSchema` and verifies the `zod/v4` path.
  - Add a patch changeset for `@browserbasehq/stagehand`.

<sup>Written for commit c065d0f2901609b817eea0e133cedac4617d368c. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2140?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

