### PR TITLE
fix: add allowSystemInMessages to all AI SDK call sites

### DIFF
--- a/packages/core/lib/v3/external_clients/aisdk.ts
+++ b/packages/core/lib/v3/external_clients/aisdk.ts
@@ -86,6 +86,7 @@ export class AISdkClient extends LLMClient {
         model: this.model,
         messages: formattedMessages,
         schema: options.response_model.schema,
+        allowSystemInMessages: true,
       });
 
       return {
@@ -113,6 +114,7 @@ export class AISdkClient extends LLMClient {
       model: this.model,
       messages: formattedMessages,
       tools,
+      allowSystemInMessages: true,
     });
 
     return {

--- a/packages/core/lib/v3/handlers/v3AgentHandler.ts
+++ b/packages/core/lib/v3/handlers/v3AgentHandler.ts
@@ -374,7 +374,7 @@ export class V3AgentHandler {
         tools: allTools,
         stopWhen: (result) => this.handleStop(result, maxSteps),
         toolChoice: "auto",
-
+        allowSystemInMessages: true,
         prepareStep: this.createPrepareStep(
           callbacks?.prepareStep,
           captchaSolver,
@@ -511,6 +511,7 @@ export class V3AgentHandler {
         tools: allTools,
         stopWhen: (result) => this.handleStop(result, maxSteps),
         toolChoice: "auto",
+        allowSystemInMessages: true,
         prepareStep: this.createPrepareStep(
           callbacks?.prepareStep,
           captchaSolver,

--- a/packages/core/lib/v3/llm/aisdk.ts
+++ b/packages/core/lib/v3/llm/aisdk.ts
@@ -248,6 +248,7 @@ You must respond in JSON format. respond WITH JSON. Do not include any other tex
           messages: formattedMessages,
           schema: options.response_model.schema,
           temperature,
+          allowSystemInMessages: true,
           ...(Object.keys(providerOptions).length > 0
             ? { providerOptions }
             : {}),
@@ -379,6 +380,7 @@ You must respond in JSON format. respond WITH JSON. Do not include any other tex
                 : "auto"
             : undefined,
         temperature,
+        allowSystemInMessages: true,
       });
     } catch (err) {
       // Log error response to maintain request/response pairing

--- a/packages/evals/lib/AISdkClientWrapped.ts
+++ b/packages/evals/lib/AISdkClientWrapped.ts
@@ -180,6 +180,7 @@ You must respond in JSON format. respond WITH JSON. Do not include any other tex
           messages: formattedMessages,
           schema: options.response_model.schema,
           temperature,
+          allowSystemInMessages: true,
           providerOptions: resolvedReasoningEffort
             ? {
                 openai: {
@@ -289,6 +290,7 @@ You must respond in JSON format. respond WITH JSON. Do not include any other tex
                 : "auto"
             : undefined,
         temperature,
+        allowSystemInMessages: true,
       });
 
     // Transform AI SDK response to match LLMResponse format expected by operator handler.


### PR DESCRIPTION
## Problem

`@browserbasehq/stagehand@3.4.0` declares `"ai": "^5.0.133"` as a peer dependency. The Vercel AI SDK introduced a **breaking change** in [PR #14752](https://github.com/vercel/ai/pull/14752) (merged April 28, 2026): passing a `role: "system"` message inside the `messages` array now throws an `InvalidPromptError` by default:

```
System messages are not allowed in the prompt or messages fields.
Use the instructions option instead.
```

The repo lockfile pins `ai@5.0.133` (pre-break, October 2025), so developers working directly in this repo don't see the error. However, end users installing `@browserbasehq/stagehand` resolve `^5.0.133` → `ai@5.0.188` (the latest stable 5.x, published May 12 2026, post-break), and hit the error on **every LLM call**.

## Why Stagehand passes system messages in `messages`

Stagehand intentionally passes system messages inside the `messages` array (rather than using the `system` parameter) in order to attach Anthropic prompt-caching directives via `providerOptions`:

```ts
{
  role: "system",
  content: systemPrompt,
  providerOptions: {
    anthropic: { cacheControl: { type: "ephemeral" } },
  },
}
```

This pattern is deliberate and correct — it cannot be replaced by the `system` parameter in the current AI SDK version without losing caching support.

## Fix

The AI SDK provides `allowSystemInMessages: true` as an explicit opt-in for exactly this use case. This PR adds it to all 8 affected call sites across 4 files:

| File | Call sites |
|------|-----------|
| `packages/core/lib/v3/llm/aisdk.ts` | `generateObject`, `generateText` |
| `packages/core/lib/v3/external_clients/aisdk.ts` | `generateObject`, `generateText` |
| `packages/core/lib/v3/handlers/v3AgentHandler.ts` | `generateText` (non-streaming), `streamText` |
| `packages/evals/lib/AISdkClientWrapped.ts` | `generateObject`, `generateText` |

`packages/core/lib/v3/agent/utils/handleDoneToolCall.ts` is correctly excluded — it already uses the `system:` parameter and does not put system messages in the `messages` array.

## Test plan

- [ ] Install `ai@5.0.188` (or latest `^5.0.133`) and run any Stagehand script that exercises `act`, `extract`, or `agent` — confirm no `InvalidPromptError` is thrown
- [ ] Confirm Anthropic prompt caching still works (system message `providerOptions` are preserved)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Opt in to allowSystemInMessages at all AI SDK call sites to prevent InvalidPromptError with newer `ai` versions. Keeps system prompts in the messages array so Anthropic caching continues to work for `@browserbasehq/stagehand` users.

- **Bug Fixes**
  - Added allowSystemInMessages: true to generateObject, generateText, and streamText paths (8 sites across 4 files), excluding code that already uses the system param.
  - Compatible with `ai@>=5.0.168` and older `^5.x`.
  - No prompt behavior changes; Anthropic cache-control directives are preserved.

<sup>Written for commit 9a4bb32714065b5a8ee8ad02dc33e9d7ce4dd72e. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2141?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

