### PR TITLE
Pass local launch options when attaching over CDP

### DIFF
--- a/.changeset/cdp-attach-launch-options.md
+++ b/.changeset/cdp-attach-launch-options.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Pass local browser launch options through when attaching over CDP so explicit viewport settings are respected.

--- a/packages/core/lib/v3/v3.ts
+++ b/packages/core/lib/v3/v3.ts
@@ -912,6 +912,7 @@ export class V3 {
             this.ctx = await V3Context.create(lbo.cdpUrl, {
               env: "LOCAL",
               cdpHeaders: lbo.cdpHeaders,
+              localBrowserLaunchOptions: lbo,
             });
             this.ctx.conn.flowLoggerContext = this.flowLoggerContext;
             this.ctx.conn.onTransportClosed(this._onCdpClosed);

--- a/packages/core/tests/unit/browserbase-session-accessors.test.ts
+++ b/packages/core/tests/unit/browserbase-session-accessors.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { V3 } from "../../lib/v3/v3.js";
+import { V3Context } from "../../lib/v3/understudy/context.js";
 
 const MOCK_SESSION_ID = "session-123";
 const MOCK_SESSION_URL = `https://www.browserbase.com/sessions/${MOCK_SESSION_ID}`;
@@ -13,9 +14,7 @@ vi.mock("../../lib/v3/understudy/context", () => {
   }
 
   class MockV3Context {
-    static async create(): Promise<MockV3Context> {
-      return new MockV3Context();
-    }
+    static create = vi.fn(async () => new MockV3Context());
 
     conn = new MockConnection();
 
@@ -151,6 +150,42 @@ describe("local accessors", () => {
       await v3.init();
       expect(v3.browserbaseSessionURL).toBeUndefined();
       expect(v3.browserbaseDebugURL).toBeUndefined();
+    } finally {
+      await v3.close().catch(() => {});
+    }
+  });
+
+  it("passes local launch options to the CDP attach context", async () => {
+    const localBrowserLaunchOptions = {
+      cdpUrl: "ws://local-existing-session",
+      cdpHeaders: {
+        "x-stagehand-test": "yes",
+      },
+      viewport: {
+        width: 800,
+        height: 600,
+      },
+      deviceScaleFactor: 2,
+    };
+
+    const v3 = new V3({
+      env: "LOCAL",
+      disableAPI: true,
+      verbose: 0,
+      localBrowserLaunchOptions,
+    });
+
+    try {
+      await v3.init();
+
+      expect(V3Context.create).toHaveBeenCalledWith(
+        localBrowserLaunchOptions.cdpUrl,
+        {
+          env: "LOCAL",
+          cdpHeaders: localBrowserLaunchOptions.cdpHeaders,
+          localBrowserLaunchOptions,
+        },
+      );
     } finally {
       await v3.close().catch(() => {});
     }


### PR DESCRIPTION
## Summary
- Pass `localBrowserLaunchOptions` into `V3Context.create()` when LOCAL mode attaches to an existing browser via `cdpUrl`.
- Add a regression test that verifies the CDP attach path forwards viewport, device scale factor, and CDP headers through context creation.
- Add a patch changeset for the published Stagehand runtime behavior change.

## Why
The launch path already passes local browser options into `V3Context`, which lets `Page.create()` apply the configured viewport and `deviceScaleFactor`. The CDP attach path only forwarded `env` and `cdpHeaders`, so attached local sessions skipped that Page-level viewport setup.

## E2E Test Matrix

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `pnpm install --frozen-lockfile` | Installed all 7 workspace projects from the lockfile; completed with `Done in 13.9s`. | Confirms the fresh PR worktree can resolve dependencies exactly from the committed lockfile. |
| `pnpm exec turbo run build:esm --filter=@browserbasehq/stagehand` | Turbo ran `gen-version`, `build-dom-scripts`, and `build:esm`; output ended with `Tasks: 3 successful, 3 total`. | Builds the exact local package under review, including generated runtime artifacts needed by the ESM output. |
| `pnpm --filter @browserbasehq/stagehand exec vitest run --config vitest.esm.config.mjs dist/esm/tests/unit/browserbase-session-accessors.test.js` | Vitest output: `Test Files 1 passed (1)`, `Tests 6 passed (6)`. | Confirms the regression test and nearby Browserbase/LOCAL accessor tests pass against the built ESM output. |
| `node --input-type=module <inline LOCAL CDP attach viewport smoke>` | Launched local Stagehand, reattached via `cdpUrl` with `viewport: { width: 1440, height: 900 }`, and printed `{"status":"pass","cdpAttachViewport":{"innerWidth":1440,"innerHeight":900,"devicePixelRatio":1,"bottomRightHit":"target"}}`. | Exercises the real built Stagehand package against a real local Chrome CDP session. Proves explicit CDP attach viewport settings control browser CSS viewport and bottom-right coordinate hit-testing; does not exercise kernel.sh specifically. |
| `pnpm exec changeset status --since=origin/main` | Changesets reported patch bumps for `@browserbasehq/stagehand` and dependent workspace packages. | Confirms the new changeset is detected as a release-triggering patch for this runtime behavior fix. |
