### PR TITLE
Add `screenshot` option to Extract

### DIFF
--- a/.changeset/extract-screenshot-option.md
+++ b/.changeset/extract-screenshot-option.md
@@ -2,4 +2,4 @@
 "@browserbasehq/stagehand": minor
 ---
 
-Add a `screenshot` option to `extract()` that sends the current viewport screenshot with the accessibility tree for AI SDK LLM extraction.
+Added a `screenshot` option to `extract()` that sends the current viewport screenshot with the a11y tree for extraction.

--- a/.changeset/extract-screenshot-option.md
+++ b/.changeset/extract-screenshot-option.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": minor
+---
+
+Add a `screenshot` option to `extract()` that sends the current viewport screenshot with the accessibility tree for AI SDK LLM extraction.

--- a/packages/core/lib/inference.ts
+++ b/packages/core/lib/inference.ts
@@ -18,6 +18,7 @@ import type {
 } from "./v3/zodCompat.js";
 import { SupportedUnderstudyAction } from "./v3/types/private/handlers.js";
 import type { Variables } from "./v3/types/public/agent.js";
+import { StagehandInvalidArgumentError } from "./v3/types/public/sdkErrors.js";
 
 // Re-export for backward compatibility
 export type { LLMParsedResponse, LLMUsage } from "./v3/llm/LLMClient.js";
@@ -38,6 +39,7 @@ export async function extract<T extends StagehandZodObject>({
   logger,
   userProvidedInstructions,
   logInferenceToFile = false,
+  screenshot,
 }: {
   instruction: string;
   domElements: string;
@@ -46,6 +48,7 @@ export async function extract<T extends StagehandZodObject>({
   userProvidedInstructions?: string;
   logger: (message: LogLine) => void;
   logInferenceToFile?: boolean;
+  screenshot?: Buffer;
 }) {
   const metadataSchema = z.object({
     progress: z
@@ -64,10 +67,27 @@ export async function extract<T extends StagehandZodObject>({
   type MetadataResponse = z.infer<typeof metadataSchema>;
 
   const isUsingAnthropic = llmClient.type === "anthropic";
+  if (screenshot && llmClient.type !== "aisdk") {
+    throw new StagehandInvalidArgumentError(
+      "extract({ screenshot: true }) is only supported with AI SDK clients.",
+    );
+  }
+  const screenshotDataUrl = screenshot
+    ? `data:image/png;base64,${screenshot.toString("base64")}`
+    : undefined;
 
   const extractCallMessages: ChatMessage[] = [
-    buildExtractSystemPrompt(isUsingAnthropic, userProvidedInstructions),
-    buildExtractUserPrompt(instruction, domElements, isUsingAnthropic),
+    buildExtractSystemPrompt(
+      isUsingAnthropic,
+      userProvidedInstructions,
+      Boolean(screenshotDataUrl),
+    ),
+    buildExtractUserPrompt(
+      instruction,
+      domElements,
+      isUsingAnthropic,
+      screenshotDataUrl,
+    ),
   ];
 
   let extractCallFile = "";

--- a/packages/core/lib/prompt.ts
+++ b/packages/core/lib/prompt.ts
@@ -21,6 +21,7 @@ ${userProvidedInstructions}`;
 export function buildExtractSystemPrompt(
   isUsingPrintExtractedDataTool: boolean = false,
   userProvidedInstructions?: string,
+  includeScreenshot: boolean = false,
 ): ChatMessage {
   const baseContent = `You are extracting content on behalf of a user.
   If a user asks you to extract a 'list' of information, or 'all' information, 
@@ -30,7 +31,9 @@ export function buildExtractSystemPrompt(
 1. An instruction
 2. `;
 
-  const contentDetail = `A list of DOM elements to extract from.`;
+  const contentDetail = includeScreenshot
+    ? `A hierarchical accessibility tree and a screenshot of the current viewport to extract from. Use them together to extract content from the page.`
+    : `A list of DOM elements to extract from.`;
 
   const instructions = `
 Print the exact text from the DOM elements with all symbols, characters, and endlines as is.
@@ -67,14 +70,29 @@ export function buildExtractUserPrompt(
   instruction: string,
   domElements: string,
   isUsingPrintExtractedDataTool: boolean = false,
+  screenshotDataUrl?: string,
 ): ChatMessage {
-  let content = `Instruction: ${instruction}
+  let content = screenshotDataUrl
+    ? `Instruction: ${instruction}
+Accessibility Tree: ${domElements}
+Use the screenshot of the current viewport together with the accessibility tree to extract content from the page.`
+    : `Instruction: ${instruction}
 DOM: ${domElements}`;
 
   if (isUsingPrintExtractedDataTool) {
     content += `
 ONLY print the content using the print_extracted_data tool provided.
 ONLY print the content using the print_extracted_data tool provided.`;
+  }
+
+  if (screenshotDataUrl) {
+    return {
+      role: "user",
+      content: [
+        { type: "text", text: content },
+        { type: "image_url", image_url: { url: screenshotDataUrl } },
+      ],
+    };
   }
 
   return {

--- a/packages/core/lib/prompt.ts
+++ b/packages/core/lib/prompt.ts
@@ -74,7 +74,7 @@ export function buildExtractUserPrompt(
 ): ChatMessage {
   let content = screenshotDataUrl
     ? `Instruction: ${instruction}
-Accessibility Tree: ${domElements}
+DOM: ${domElements}
 Use the screenshot of the current viewport together with the accessibility tree to extract content from the page.`
     : `Instruction: ${instruction}
 DOM: ${domElements}`;

--- a/packages/core/lib/prompt.ts
+++ b/packages/core/lib/prompt.ts
@@ -32,7 +32,7 @@ export function buildExtractSystemPrompt(
 2. `;
 
   const contentDetail = includeScreenshot
-    ? `A hierarchical accessibility tree and a screenshot of the current viewport to extract from. Use them together to extract content from the page.`
+    ? `A list of DOM elements to extract from and a screenshot of the current viewport to extract from. Use them together to extract content from the page.`
     : `A list of DOM elements to extract from.`;
 
   const instructions = `

--- a/packages/core/lib/v3/handlers/extractHandler.ts
+++ b/packages/core/lib/v3/handlers/extractHandler.ts
@@ -117,6 +117,7 @@ export class ExtractHandler {
       ignoreSelectors,
       timeout,
       model,
+      screenshot,
     } = params;
 
     const llmClient = this.resolveLlmClient(model);
@@ -149,6 +150,12 @@ export class ExtractHandler {
       );
     }
 
+    if (screenshot && llmClient.type !== "aisdk") {
+      throw new StagehandInvalidArgumentError(
+        "extract({ screenshot: true }) is only supported with AI SDK clients.",
+      );
+    }
+
     const focusSelector = selector?.replace(/^xpath=/, "") ?? "";
 
     // Build the hybrid snapshot (includes combinedTree; combinedUrlMap optional)
@@ -159,9 +166,23 @@ export class ExtractHandler {
       ignoreSelectors,
     });
 
+    const screenshotBuffer = screenshot
+      ? await (async () => {
+          ensureTimeRemaining();
+          const buffer = await page.screenshot({
+            fullPage: false,
+            type: "png",
+          });
+          ensureTimeRemaining();
+          return buffer;
+        })()
+      : undefined;
+
     v3Logger({
       category: "extraction",
-      message: "Starting extraction using a11y snapshot",
+      message: screenshot
+        ? "Starting extraction using a11y snapshot and viewport screenshot"
+        : "Starting extraction using a11y snapshot",
       level: 1,
       auxiliary: instruction
         ? { instruction: { value: instruction, type: "string" } }
@@ -194,6 +215,7 @@ export class ExtractHandler {
         userProvidedInstructions: this.systemPrompt,
         logger: v3Logger,
         logInferenceToFile: this.logInferenceToFile,
+        screenshot: screenshotBuffer,
       });
 
     const {

--- a/packages/core/lib/v3/types/private/handlers.ts
+++ b/packages/core/lib/v3/types/private/handlers.ts
@@ -18,6 +18,7 @@ export interface ExtractHandlerParams<T extends StagehandZodSchema> {
   timeout?: number;
   selector?: string;
   ignoreSelectors?: string[];
+  screenshot?: boolean;
   page: Page;
 }
 

--- a/packages/core/lib/v3/types/public/api.ts
+++ b/packages/core/lib/v3/types/public/api.ts
@@ -517,6 +517,11 @@ export const ExtractOptionsSchema = z
           "Selectors for elements and subtrees that should be excluded from extraction",
         example: ["nav", ".cookie-banner", "#sidebar-ads"],
       }),
+    screenshot: z.boolean().optional().meta({
+      description:
+        "When true, include a screenshot of the current viewport in the extraction LLM call. Defaults to false.",
+      example: false,
+    }),
   })
   .optional()
   .meta({ id: "ExtractOptions" });

--- a/packages/core/lib/v3/types/public/methods.ts
+++ b/packages/core/lib/v3/types/public/methods.ts
@@ -55,6 +55,7 @@ export interface ExtractOptions {
   timeout?: number;
   selector?: string;
   ignoreSelectors?: string[];
+  screenshot?: boolean;
   page?: PlaywrightPage | PuppeteerPage | PatchrightPage | Page;
   /**
    * Override the instance-level serverCache setting for this request.

--- a/packages/core/lib/v3/v3.ts
+++ b/packages/core/lib/v3/v3.ts
@@ -1396,7 +1396,7 @@ export class V3 {
         timeout: options?.timeout,
         selector: options?.selector,
         ignoreSelectors: options?.ignoreSelectors,
-        screenshot: options?.screenshot ?? false,
+        screenshot: options?.screenshot,
         page,
       };
       let result: z.infer<typeof effectiveSchema> | { pageText: string };

--- a/packages/core/lib/v3/v3.ts
+++ b/packages/core/lib/v3/v3.ts
@@ -1396,6 +1396,7 @@ export class V3 {
         timeout: options?.timeout,
         selector: options?.selector,
         ignoreSelectors: options?.ignoreSelectors,
+        screenshot: options?.screenshot ?? false,
         page,
       };
       let result: z.infer<typeof effectiveSchema> | { pageText: string };
@@ -1420,6 +1421,7 @@ export class V3 {
           instruction,
           selector: options?.selector,
           ignoreSelectors: options?.ignoreSelectors,
+          screenshot: options?.screenshot,
           timeout: options?.timeout,
           schema: historySchemaDescriptor,
         },

--- a/packages/core/tests/unit/api-client-observe-variables.test.ts
+++ b/packages/core/tests/unit/api-client-observe-variables.test.ts
@@ -69,7 +69,6 @@ describe("StagehandAPIClient variable serialization", () => {
       instruction: "extract the title",
       options: {
         screenshot: true,
-        serverCache: true,
       },
     });
 

--- a/packages/core/tests/unit/api-client-observe-variables.test.ts
+++ b/packages/core/tests/unit/api-client-observe-variables.test.ts
@@ -52,6 +52,41 @@ describe("StagehandAPIClient variable serialization", () => {
     });
   });
 
+  it("preserves screenshot when sending the extract request", async () => {
+    const client = new StagehandAPIClient({
+      apiKey: "bb-test",
+      logger: vi.fn(),
+    });
+    const executeMock = vi.fn().mockResolvedValue({ title: "ok" });
+
+    (
+      client as unknown as {
+        execute: typeof executeMock;
+      }
+    ).execute = executeMock;
+
+    await client.extract({
+      instruction: "extract the title",
+      options: {
+        screenshot: true,
+        serverCache: true,
+      },
+    });
+
+    expect(executeMock).toHaveBeenCalledWith({
+      method: "extract",
+      args: {
+        instruction: "extract the title",
+        schema: undefined,
+        options: {
+          screenshot: true,
+        },
+        frameId: undefined,
+      },
+      serverCache: true,
+    });
+  });
+
   it("preserves rich variables when sending the observe request", async () => {
     const client = new StagehandAPIClient({
       apiKey: "bb-test",

--- a/packages/core/tests/unit/api-client-serialization.test.ts
+++ b/packages/core/tests/unit/api-client-serialization.test.ts
@@ -82,7 +82,7 @@ describe("StagehandAPIClient variable serialization", () => {
         },
         frameId: undefined,
       },
-      serverCache: true,
+      serverCache: undefined,
     });
   });
 

--- a/packages/core/tests/unit/extract-screenshot.test.ts
+++ b/packages/core/tests/unit/extract-screenshot.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { extract as runExtract } from "../../lib/inference.js";
+import type {
+  CreateChatCompletionOptions,
+  LLMClient,
+} from "../../lib/v3/llm/LLMClient.js";
+import { StagehandInvalidArgumentError } from "../../lib/v3/types/public/sdkErrors.js";
+
+describe("extract screenshot prompt", () => {
+  it("sends the viewport screenshot with the accessibility tree on the extraction LLM call", async () => {
+    const createChatCompletion = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: { title: "Visible title" },
+        usage: {
+          prompt_tokens: 10,
+          completion_tokens: 3,
+          total_tokens: 13,
+        },
+      })
+      .mockResolvedValueOnce({
+        data: { completed: true, progress: "done" },
+        usage: {
+          prompt_tokens: 4,
+          completion_tokens: 2,
+          total_tokens: 6,
+        },
+      });
+
+    const llmClient = {
+      type: "aisdk",
+      modelName: "gpt-4o",
+      createChatCompletion,
+    } as unknown as LLMClient;
+
+    await runExtract({
+      instruction: "extract the visible title",
+      domElements: "RootWebArea [0-0] title",
+      schema: z.object({ title: z.string() }),
+      llmClient,
+      logger: vi.fn(),
+      screenshot: Buffer.from("viewport-image"),
+    });
+
+    const firstCall = createChatCompletion.mock
+      .calls[0][0] as CreateChatCompletionOptions;
+    const userMessage = firstCall.options.messages[1];
+
+    expect(Array.isArray(userMessage.content)).toBe(true);
+    if (!Array.isArray(userMessage.content)) {
+      throw new Error("Expected multimodal user content");
+    }
+
+    expect(userMessage.content).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "text",
+          text: expect.stringContaining("Accessibility Tree"),
+        }),
+        expect.objectContaining({
+          type: "image_url",
+          image_url: {
+            url: `data:image/png;base64,${Buffer.from(
+              "viewport-image",
+            ).toString("base64")}`,
+          },
+        }),
+      ]),
+    );
+    expect(userMessage.content[0]).toEqual(
+      expect.objectContaining({
+        text: expect.stringContaining("current viewport"),
+      }),
+    );
+  });
+
+  it("rejects screenshot payloads for non-AI SDK clients", async () => {
+    const createChatCompletion = vi.fn();
+    const llmClient = {
+      type: "openai",
+      modelName: "gpt-4o",
+      createChatCompletion,
+    } as unknown as LLMClient;
+
+    await expect(
+      runExtract({
+        instruction: "extract the visible title",
+        domElements: "RootWebArea [0-0] title",
+        schema: z.object({ title: z.string() }),
+        llmClient,
+        logger: vi.fn(),
+        screenshot: Buffer.from("viewport-image"),
+      }),
+    ).rejects.toThrow(StagehandInvalidArgumentError);
+
+    expect(createChatCompletion).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/tests/unit/extract-screenshot.test.ts
+++ b/packages/core/tests/unit/extract-screenshot.test.ts
@@ -8,7 +8,7 @@ import type {
 import { StagehandInvalidArgumentError } from "../../lib/v3/types/public/sdkErrors.js";
 
 describe("extract screenshot prompt", () => {
-  it("sends the viewport screenshot with the accessibility tree on the extraction LLM call", async () => {
+  it("sends the viewport screenshot with the DOM tree on the extraction LLM call", async () => {
     const createChatCompletion = vi
       .fn()
       .mockResolvedValueOnce({
@@ -56,7 +56,7 @@ describe("extract screenshot prompt", () => {
       expect.arrayContaining([
         expect.objectContaining({
           type: "text",
-          text: expect.stringContaining("Accessibility Tree"),
+          text: expect.stringContaining("DOM"),
         }),
         expect.objectContaining({
           type: "image_url",

--- a/packages/core/tests/unit/public-api/public-types.test.ts
+++ b/packages/core/tests/unit/public-api/public-types.test.ts
@@ -153,6 +153,7 @@ describe("Stagehand public API types", () => {
       timeout?: number;
       selector?: string;
       ignoreSelectors?: string[];
+      screenshot?: boolean;
       page?: Stagehand.AnyPage;
       serverCache?: boolean;
     };

--- a/packages/core/tests/unit/timeout-handlers.test.ts
+++ b/packages/core/tests/unit/timeout-handlers.test.ts
@@ -12,6 +12,7 @@ import {
   ActTimeoutError,
   ExtractTimeoutError,
   ObserveTimeoutError,
+  StagehandInvalidArgumentError,
 } from "../../lib/v3/types/public/sdkErrors.js";
 import {
   act as actInference,
@@ -842,6 +843,128 @@ describe("No-timeout success paths", () => {
     );
   });
 
+  it("extract() captures the current viewport when screenshot is enabled", async () => {
+    const captureHybridSnapshotMock = vi.mocked(captureHybridSnapshot);
+    captureHybridSnapshotMock.mockResolvedValue({
+      combinedTree: "tree content",
+      combinedXpathMap: {},
+      combinedUrlMap: {},
+    });
+
+    const screenshotBuffer = Buffer.from("viewport-screenshot");
+    const extractInferenceMock = vi.mocked(extractInference);
+    extractInferenceMock.mockResolvedValue({
+      title: "Test Title",
+      metadata: { completed: true, progress: "100%" },
+      prompt_tokens: 200,
+      completion_tokens: 100,
+      reasoning_tokens: 20,
+      cached_input_tokens: 10,
+      inference_time_ms: 800,
+    } as ReturnType<typeof extractInference> extends Promise<infer T>
+      ? T
+      : never);
+
+    vi.mocked(createTimeoutGuard).mockImplementation(() => {
+      return vi.fn(() => {});
+    });
+
+    const handler = buildExtractHandler({ llmType: "aisdk" });
+    const fakePage = {
+      mainFrame: vi.fn().mockReturnValue({}),
+      screenshot: vi.fn().mockResolvedValue(screenshotBuffer),
+    } as unknown as Page;
+
+    await handler.extract({
+      instruction: "extract title",
+      page: fakePage,
+      screenshot: true,
+    });
+
+    expect(
+      (fakePage as unknown as { screenshot: ReturnType<typeof vi.fn> })
+        .screenshot,
+    ).toHaveBeenCalledWith({ fullPage: false, type: "png" });
+    expect(extractInferenceMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        screenshot: screenshotBuffer,
+      }),
+    );
+  });
+
+  it("extract() does not capture a screenshot by default", async () => {
+    const captureHybridSnapshotMock = vi.mocked(captureHybridSnapshot);
+    captureHybridSnapshotMock.mockResolvedValue({
+      combinedTree: "tree content",
+      combinedXpathMap: {},
+      combinedUrlMap: {},
+    });
+
+    const extractInferenceMock = vi.mocked(extractInference);
+    extractInferenceMock.mockResolvedValue({
+      title: "Test Title",
+      metadata: { completed: true, progress: "100%" },
+      prompt_tokens: 200,
+      completion_tokens: 100,
+      reasoning_tokens: 20,
+      cached_input_tokens: 10,
+      inference_time_ms: 800,
+    } as ReturnType<typeof extractInference> extends Promise<infer T>
+      ? T
+      : never);
+
+    vi.mocked(createTimeoutGuard).mockImplementation(() => {
+      return vi.fn(() => {});
+    });
+
+    const fakePage = {
+      mainFrame: vi.fn().mockReturnValue({}),
+      screenshot: vi.fn(),
+    } as unknown as Page;
+
+    const handler = buildExtractHandler();
+    await handler.extract({
+      instruction: "extract title",
+      page: fakePage,
+    });
+
+    expect(
+      (fakePage as unknown as { screenshot: ReturnType<typeof vi.fn> })
+        .screenshot,
+    ).not.toHaveBeenCalled();
+    expect(extractInferenceMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        screenshot: undefined,
+      }),
+    );
+  });
+
+  it("extract() rejects screenshot with non-AI SDK clients", async () => {
+    vi.mocked(createTimeoutGuard).mockImplementation(() => {
+      return vi.fn(() => {});
+    });
+
+    const fakePage = {
+      mainFrame: vi.fn().mockReturnValue({}),
+      screenshot: vi.fn(),
+    } as unknown as Page;
+
+    const handler = buildExtractHandler({ llmType: "openai" });
+    await expect(
+      handler.extract({
+        instruction: "extract title",
+        page: fakePage,
+        screenshot: true,
+      }),
+    ).rejects.toThrow(StagehandInvalidArgumentError);
+
+    expect(
+      (fakePage as unknown as { screenshot: ReturnType<typeof vi.fn> })
+        .screenshot,
+    ).not.toHaveBeenCalled();
+    expect(vi.mocked(captureHybridSnapshot)).not.toHaveBeenCalled();
+  });
+
   it("observe() completes successfully without timeout and records metrics", async () => {
     const captureHybridSnapshotMock = vi.mocked(captureHybridSnapshot);
     captureHybridSnapshotMock.mockResolvedValue({
@@ -1151,6 +1274,7 @@ function buildActHandler(options: BuildActHandlerOptions = {}): ActHandler {
 }
 
 interface BuildExtractHandlerOptions {
+  llmType?: LLMClient["type"];
   onMetrics?: (
     functionName: V3FunctionName,
     promptTokens: number,
@@ -1166,7 +1290,7 @@ function buildExtractHandler(
 ): ExtractHandler {
   const defaultClientOptions = {} as ClientOptions;
   const fakeClient = {
-    type: "openai",
+    type: options.llmType ?? "openai",
     modelName: "gpt-4o",
     clientOptions: defaultClientOptions,
   } as LLMClient;

--- a/packages/server-v3/openapi.v3.yaml
+++ b/packages/server-v3/openapi.v3.yaml
@@ -622,6 +622,11 @@ components:
           type: array
           items:
             type: string
+        screenshot:
+          description: When true, include a screenshot of the current viewport in the
+            extraction LLM call. Defaults to false.
+          example: false
+          type: boolean
     ExtractRequest:
       type: object
       properties:
@@ -1630,6 +1635,11 @@ components:
           type: array
           items:
             type: string
+        screenshot:
+          description: When true, include a screenshot of the current viewport in the
+            extraction LLM call. Defaults to false.
+          example: false
+          type: boolean
       additionalProperties: false
     ExtractResultOutput:
       type: object


### PR DESCRIPTION
# why
Some pages do not properly encapsulate the necessary information required to extract the content requested by the user, and can benefit from a hybrid approach with vision.

# what changed
- New `extract({ options: { screenshot: true } })` flag. Captures the current viewport as PNG and sends it as an `image_url` part alongside the a11y tree text in the extraction LLM call.
- Default is `false` — existing callers see no behavior change.
- Gated to AI SDK clients; throws `StagehandInvalidArgumentError` otherwise (validated in both the handler and `inference.extract`, with the handler check running before the screenshot is taken).
- Screenshot capture is bracketed by `ensureTimeRemaining()` so it respects the extract timeout.
- Wired end-to-end: public `ExtractOptions` type, `ExtractOptionsSchema`, OpenAPI `ExtractOptions`, `StagehandAPIClient.extract` wire payload, `V3.extract` → `ExtractHandler` → `inference.extract` → `buildExtract{System,User}Prompt`.

# test plan
- `extract-screenshot.test.ts` (new) — multimodal message shape on happy path; rejection for non-AI SDK clients.
- `timeout-handlers.test.ts` — handler captures viewport when enabled, skips capture by default, rejects screenshot + non-AI SDK client without touching `page.screenshot` or the snapshot pipeline.
- `api-client-serialization.test.ts` (renamed from `api-client-observe-variables.test.ts`) — wire payload preserves `options.screenshot`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a screenshot option to `extract()` that sends the current viewport screenshot with the accessibility tree to improve results on visually-driven pages.

- New Features
  - `extract({ options: { screenshot: boolean } })` captures a PNG of the current viewport and includes it with the accessibility tree; defaults to false; only supported with `aisdk` clients (throws `StagehandInvalidArgumentError` otherwise).
  - Prompts are consolidated and multimodal when enabled: system and user prompts mention the screenshot and using it with the accessibility tree; attaches an `image_url` data URI; logs when a screenshot is used.
  - Public API, types, and OpenAPI updated (`ExtractOptions.screenshot`); the API client forwards the flag; tests cover prompt shape, viewport capture, default-off behavior, timeout guards, client-type validation, and serialization.

<sup>Written for commit d0c75002884eb42fcebb132c0d333259e8d9efbf. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2149?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->





