### PR TITLE
feat(cli): allow local Chrome launch args

### DIFF
--- a/.changeset/local-chrome-args.md
+++ b/.changeset/local-chrome-args.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/browse-cli": patch
+---
+
+Add a `browse env local --chrome-arg` option for isolated local browser launches.

--- a/.changeset/local-chrome-args.md
+++ b/.changeset/local-chrome-args.md
@@ -2,4 +2,4 @@
 "@browserbasehq/browse-cli": patch
 ---
 
-Add a `browse env local --chrome-arg` option for isolated local browser launches.
+Add a `browse env local --chrome-args` option for isolated local browser launches.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -188,6 +188,9 @@ falls back to launching an isolated browser.
 # Use a clean isolated browser (default)
 browse env local
 
+# Add Chromium launch args for isolated local browsers
+browse env local --chrome-arg=--no-focus-on-navigate
+
 # Auto-discover local Chrome, fallback to isolated
 browse env local --auto-connect
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -189,7 +189,7 @@ falls back to launching an isolated browser.
 browse env local
 
 # Add Chromium launch args for isolated local browsers
-browse env local --chrome-arg=--no-focus-on-navigate
+browse env local --chrome-args='["--no-focus-on-navigate"]'
 
 # Auto-discover local Chrome, fallback to isolated
 browse env local --auto-connect

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -241,6 +241,25 @@ function logLocalModeHint(
   }
 }
 
+function parseChromeArgs(rawChromeArgs?: string): string[] | undefined {
+  if (!rawChromeArgs) {
+    return undefined;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawChromeArgs);
+  } catch {
+    throw new Error("--chrome-args must be a JSON array of strings.");
+  }
+
+  if (!Array.isArray(parsed) || parsed.some((arg) => typeof arg !== "string")) {
+    throw new Error("--chrome-args must be a JSON array of strings.");
+  }
+
+  return parsed.length ? parsed : undefined;
+}
+
 type BrowseMode = "browserbase" | "local";
 
 function hasBrowserbaseCredentials(): boolean {
@@ -1620,10 +1639,6 @@ function isHeadless(opts: GlobalOpts): boolean {
   return opts.headless === true && opts.headed !== true;
 }
 
-function collectValues(value: string, previous: string[] = []): string[] {
-  return [...previous, value];
-}
-
 function buildSessionParamsFromOpts(
   opts: GlobalOpts,
 ): Record<string, unknown> | null {
@@ -1883,7 +1898,7 @@ program
 
 const envUsage =
   "Usage: browse env [local|remote]\n" +
-  "  browse env local [--auto-connect|<port|url>] [--chrome-arg <arg>]";
+  "  browse env local [--auto-connect|<port|url>] [--chrome-args <json-array>]";
 
 const envCommand = program
   .command("env [target] [cdpTarget]")
@@ -1892,7 +1907,7 @@ const envCommand = program
       "  browse env                    Show current environment\n" +
       "  browse env local              Use clean isolated local browser (default)\n" +
       "  browse env local --auto-connect  Auto-discover local Chrome, fallback to isolated\n" +
-      "  browse env local --chrome-arg=--no-focus-on-navigate  Add Chrome launch arg\n" +
+      "  browse env local --chrome-args='[\"--no-focus-on-navigate\"]'  Add Chrome launch args\n" +
       "  browse env local <port|url>   Attach to specific CDP target\n" +
       "  browse env remote             Use Browserbase (requires API key)",
   )
@@ -1901,10 +1916,8 @@ const envCommand = program
     "Auto-discover an existing local Chrome instance via CDP",
   )
   .option(
-    "--chrome-arg <arg>",
-    "Additional Chrome launch arg for isolated local browsers",
-    collectValues,
-    [],
+    "--chrome-args <json-array>",
+    "Additional Chrome launch args as a JSON array for isolated local browsers",
   );
 
 envCommand.addOption(
@@ -1921,7 +1934,7 @@ envCommand.action(
     cmdOpts: {
       autoConnect?: boolean;
       isolated?: boolean;
-      chromeArg?: string[];
+      chromeArgs?: string;
     },
   ) => {
     const opts = program.opts<GlobalOpts>();
@@ -1973,9 +1986,14 @@ envCommand.action(
 
     let localConfig: LocalConfig = { ...DEFAULT_LOCAL_CONFIG };
     if (mapped === "local") {
-      const launchArgs = cmdOpts.chromeArg?.length
-        ? cmdOpts.chromeArg
-        : undefined;
+      let launchArgs: string[] | undefined;
+      try {
+        launchArgs = parseChromeArgs(cmdOpts.chromeArgs);
+      } catch (err) {
+        console.error(envUsage);
+        console.error(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
       const selectedLocalStrategies = [
         Boolean(cmdOpts.autoConnect),
         Boolean(cmdOpts.isolated),
@@ -1993,7 +2011,7 @@ envCommand.action(
       if (cdpTarget && launchArgs?.length) {
         console.error(envUsage);
         console.error(
-          "--chrome-arg only applies when launching a local browser.",
+          "--chrome-args only applies when launching a local browser.",
         );
         process.exit(1);
       }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1620,6 +1620,10 @@ function isHeadless(opts: GlobalOpts): boolean {
   return opts.headless === true && opts.headed !== true;
 }
 
+function collectValues(value: string, previous: string[] = []): string[] {
+  return [...previous, value];
+}
+
 function buildSessionParamsFromOpts(
   opts: GlobalOpts,
 ): Record<string, unknown> | null {
@@ -1852,6 +1856,9 @@ program
         logLocalModeHint(localConfig, localInfo);
         localDetails = {
           localStrategy: localConfig.strategy,
+          ...(localConfig.launchArgs?.length
+            ? { localChromeArgs: localConfig.launchArgs }
+            : {}),
           ...(localInfo ?? {}),
         };
       }
@@ -1876,7 +1883,7 @@ program
 
 const envUsage =
   "Usage: browse env [local|remote]\n" +
-  "  browse env local [--auto-connect|<port|url>]";
+  "  browse env local [--auto-connect|<port|url>] [--chrome-arg <arg>]";
 
 const envCommand = program
   .command("env [target] [cdpTarget]")
@@ -1885,12 +1892,19 @@ const envCommand = program
       "  browse env                    Show current environment\n" +
       "  browse env local              Use clean isolated local browser (default)\n" +
       "  browse env local --auto-connect  Auto-discover local Chrome, fallback to isolated\n" +
+      "  browse env local --chrome-arg=--no-focus-on-navigate  Add Chrome launch arg\n" +
       "  browse env local <port|url>   Attach to specific CDP target\n" +
       "  browse env remote             Use Browserbase (requires API key)",
   )
   .option(
     "--auto-connect",
     "Auto-discover an existing local Chrome instance via CDP",
+  )
+  .option(
+    "--chrome-arg <arg>",
+    "Additional Chrome launch arg for isolated local browsers",
+    collectValues,
+    [],
   );
 
 envCommand.addOption(
@@ -1904,7 +1918,11 @@ envCommand.action(
   async (
     target: string | undefined,
     cdpTarget: string | undefined,
-    cmdOpts: { autoConnect?: boolean; isolated?: boolean },
+    cmdOpts: {
+      autoConnect?: boolean;
+      isolated?: boolean;
+      chromeArg?: string[];
+    },
   ) => {
     const opts = program.opts<GlobalOpts>();
     const session = getSession(opts);
@@ -1925,6 +1943,9 @@ envCommand.action(
           ...(desiredMode === "local"
             ? {
                 localStrategy: localConfig.strategy,
+                ...(localConfig.launchArgs?.length
+                  ? { localChromeArgs: localConfig.launchArgs }
+                  : {}),
                 ...(localInfo ?? {}),
               }
             : {}),
@@ -1952,6 +1973,9 @@ envCommand.action(
 
     let localConfig: LocalConfig = { ...DEFAULT_LOCAL_CONFIG };
     if (mapped === "local") {
+      const launchArgs = cmdOpts.chromeArg?.length
+        ? cmdOpts.chromeArg
+        : undefined;
       const selectedLocalStrategies = [
         Boolean(cmdOpts.autoConnect),
         Boolean(cmdOpts.isolated),
@@ -1966,10 +1990,20 @@ envCommand.action(
         process.exit(1);
       }
 
+      if (cdpTarget && launchArgs?.length) {
+        console.error(envUsage);
+        console.error(
+          "--chrome-arg only applies when launching a local browser.",
+        );
+        process.exit(1);
+      }
+
       if (cmdOpts.autoConnect) {
-        localConfig = { strategy: "auto" };
+        localConfig = { strategy: "auto", launchArgs };
       } else if (cdpTarget) {
         localConfig = { strategy: "cdp", cdpTarget };
+      } else {
+        localConfig = { strategy: "isolated", launchArgs };
       }
 
       await writeLocalConfig(session, localConfig);
@@ -2007,7 +2041,14 @@ envCommand.action(
         mode: toModeTarget(mapped),
         session,
         restarted: true,
-        ...(mapped === "local" ? { localStrategy: localConfig.strategy } : {}),
+        ...(mapped === "local"
+          ? {
+              localStrategy: localConfig.strategy,
+              ...(localConfig.launchArgs?.length
+                ? { localChromeArgs: localConfig.launchArgs }
+                : {}),
+            }
+          : {}),
       }),
     );
   },

--- a/packages/cli/src/local-strategy.ts
+++ b/packages/cli/src/local-strategy.ts
@@ -3,6 +3,7 @@ export type LocalStrategy = "auto" | "isolated" | "cdp";
 export interface LocalConfig {
   strategy: LocalStrategy;
   cdpTarget?: string;
+  launchArgs?: string[];
 }
 
 export interface LocalInfo {
@@ -16,6 +17,7 @@ export interface LocalInfo {
 }
 
 export interface LocalBrowserLaunchOptions {
+  args?: string[];
   cdpUrl?: string;
   headless?: boolean;
   viewport?: {
@@ -46,6 +48,18 @@ export interface ResolvedLocalStrategy {
 }
 
 export const DEFAULT_LOCAL_CONFIG: LocalConfig = { strategy: "isolated" };
+
+function buildIsolatedLaunchOptions(
+  localConfig: LocalConfig,
+  headless: boolean,
+  defaultViewport: { width: number; height: number },
+): LocalBrowserLaunchOptions {
+  return {
+    headless,
+    viewport: defaultViewport,
+    ...(localConfig.launchArgs?.length ? { args: localConfig.launchArgs } : {}),
+  };
+}
 
 const ISOLATED_MODE_HINT =
   "Hint: Run `browse env local --auto-connect` to reuse your local browsing credentials and cookies.";
@@ -87,7 +101,11 @@ export async function resolveLocalStrategy({
 }: ResolveLocalStrategyOptions): Promise<ResolvedLocalStrategy> {
   if (localConfig.strategy === "isolated") {
     return {
-      localLaunchOptions: { headless, viewport: defaultViewport },
+      localLaunchOptions: buildIsolatedLaunchOptions(
+        localConfig,
+        headless,
+        defaultViewport,
+      ),
       localInfo: { localSource: "isolated" },
     };
   }
@@ -119,7 +137,11 @@ export async function resolveLocalStrategy({
   }
 
   return {
-    localLaunchOptions: { headless, viewport: defaultViewport },
+    localLaunchOptions: buildIsolatedLaunchOptions(
+      localConfig,
+      headless,
+      defaultViewport,
+    ),
     localInfo: {
       localSource: "isolated-fallback",
       fallbackReason: "no debuggable local browser found",

--- a/packages/cli/tests/local-strategy.test.ts
+++ b/packages/cli/tests/local-strategy.test.ts
@@ -29,6 +29,31 @@ describe("resolveLocalStrategy", () => {
     expect(resolveWsTarget).not.toHaveBeenCalled();
   });
 
+  it("passes Chrome args to isolated browser launches", async () => {
+    const discoverLocalCdp = vi.fn().mockResolvedValue(null);
+    const resolveWsTarget = vi.fn();
+
+    const result = await resolveLocalStrategy({
+      localConfig: {
+        strategy: "isolated",
+        launchArgs: ["--no-focus-on-navigate"],
+      },
+      headless: false,
+      defaultViewport: DEFAULT_VIEWPORT,
+      discoverLocalCdp,
+      resolveWsTarget,
+    });
+
+    expect(result.localLaunchOptions).toEqual({
+      args: ["--no-focus-on-navigate"],
+      headless: false,
+      viewport: DEFAULT_VIEWPORT,
+    });
+    expect(result.localInfo).toEqual({ localSource: "isolated" });
+    expect(discoverLocalCdp).not.toHaveBeenCalled();
+    expect(resolveWsTarget).not.toHaveBeenCalled();
+  });
+
   it("auto-connects to a discovered local browser when requested", async () => {
     const discoverLocalCdp = vi.fn().mockResolvedValue({
       wsUrl: "ws://127.0.0.1:9222/devtools/browser/abc123",
@@ -60,7 +85,7 @@ describe("resolveLocalStrategy", () => {
     const resolveWsTarget = vi.fn();
 
     const result = await resolveLocalStrategy({
-      localConfig: { strategy: "auto" },
+      localConfig: { strategy: "auto", launchArgs: ["--no-focus-on-navigate"] },
       headless: false,
       defaultViewport: DEFAULT_VIEWPORT,
       discoverLocalCdp,
@@ -68,6 +93,7 @@ describe("resolveLocalStrategy", () => {
     });
 
     expect(result.localLaunchOptions).toEqual({
+      args: ["--no-focus-on-navigate"],
       headless: false,
       viewport: DEFAULT_VIEWPORT,
     });

--- a/packages/cli/tests/mode.test.ts
+++ b/packages/cli/tests/mode.test.ts
@@ -131,7 +131,7 @@ describe("Browse CLI env command", () => {
 
   it("stores Chrome args for isolated local launches", async () => {
     const result = await browse(
-      "env local --chrome-arg=--no-focus-on-navigate --chrome-arg=--disable-features=CalculateNativeWinOcclusion",
+      'env local --chrome-args=\'["--no-focus-on-navigate","--disable-features=CalculateNativeWinOcclusion"]\'',
     );
     expect(result.exitCode).toBe(0);
 
@@ -228,11 +228,21 @@ describe("Browse CLI env command", () => {
 
   it("rejects Chrome args with an explicit CDP target", async () => {
     const result = await browse(
-      "env local 9222 --chrome-arg=--no-focus-on-navigate",
+      "env local 9222 --chrome-args='[\"--no-focus-on-navigate\"]'",
     );
     expect(result.exitCode).not.toBe(0);
     expect(result.stderr).toContain(
-      "--chrome-arg only applies when launching a local browser",
+      "--chrome-args only applies when launching a local browser",
+    );
+  });
+
+  it("rejects Chrome args that are not a JSON array", async () => {
+    const result = await browse(
+      "env local --chrome-args=--no-focus-on-navigate",
+    );
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain(
+      "--chrome-args must be a JSON array of strings",
     );
   });
 });

--- a/packages/cli/tests/mode.test.ts
+++ b/packages/cli/tests/mode.test.ts
@@ -129,6 +129,36 @@ describe("Browse CLI env command", () => {
     expect(status.localStrategy).toBe("isolated");
   });
 
+  it("stores Chrome args for isolated local launches", async () => {
+    const result = await browse(
+      "env local --chrome-arg=--no-focus-on-navigate --chrome-arg=--disable-features=CalculateNativeWinOcclusion",
+    );
+    expect(result.exitCode).toBe(0);
+
+    const data = parseJson(result.stdout);
+    expect(data.mode).toBe("local");
+    expect(data.localStrategy).toBe("isolated");
+    expect(data.localChromeArgs).toEqual([
+      "--no-focus-on-navigate",
+      "--disable-features=CalculateNativeWinOcclusion",
+    ]);
+
+    const tmpDir = os.tmpdir();
+    const localConfig = parseJson(
+      await fs.readFile(
+        path.join(tmpDir, `browse-${TEST_SESSION}.local-config`),
+        "utf-8",
+      ),
+    );
+    expect(localConfig).toEqual({
+      strategy: "isolated",
+      launchArgs: [
+        "--no-focus-on-navigate",
+        "--disable-features=CalculateNativeWinOcclusion",
+      ],
+    });
+  });
+
   it("uses auto strategy only when --auto-connect is passed", async () => {
     const result = await browse("env local --auto-connect");
     expect(result.exitCode).toBe(0);
@@ -194,5 +224,15 @@ describe("Browse CLI env command", () => {
     const withTarget = await browse("env local --auto-connect 9222");
     expect(withTarget.exitCode).not.toBe(0);
     expect(withTarget.stderr).toContain("Use only one of");
+  });
+
+  it("rejects Chrome args with an explicit CDP target", async () => {
+    const result = await browse(
+      "env local 9222 --chrome-arg=--no-focus-on-navigate",
+    );
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain(
+      "--chrome-arg only applies when launching a local browser",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add `browse env local --chrome-arg` for isolated local Chrome launches
- persist args in local env config and pass them into local launch options
- document the flag and cover isolated/auto-fallback behavior

Addresses #2148.

## Checks
- `pnpm exec prettier --check packages/cli/README.md packages/cli/src/index.ts packages/cli/src/local-strategy.ts packages/cli/tests/local-strategy.test.ts packages/cli/tests/mode.test.ts .changeset/local-chrome-args.md`
- `pnpm --filter @browserbasehq/browse-cli run typecheck`
- `pnpm --filter @browserbasehq/browse-cli run build`
- `pnpm exec vitest run tests/local-strategy.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Chrome launch args to isolated local sessions in `@browserbasehq/browse-cli` via a new --chrome-args JSON array flag. Args are saved to local config and applied on launch, improving control for local testing. Addresses Linear #2148.

- **New Features**
  - New flag: --chrome-args <json-array> for `browse env local`; used only when launching an isolated browser (including auto-connect fallback).
  - Persists args to local config (launchArgs) and exposes them in `env` status output as localChromeArgs.
  - Validates input: requires a JSON array of strings; rejects --chrome-args when a CDP target is provided; updates usage/help and README.

<sup>Written for commit 84ac7999101ba5d4dd45b4952544ec0e72a5637e. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2150?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

