### PR TITLE
docs(sdk): clarify regional baseUrl usage and deprecate request region

### DIFF
--- a/packages/core/lib/v3/types/public/api.ts
+++ b/packages/core/lib/v3/types/public/api.ts
@@ -357,7 +357,11 @@ export const BrowserbaseSessionCreateParamsSchema = z
     extensionId: z.string().optional(),
     keepAlive: z.boolean().optional(),
     proxies: z.union([z.boolean(), z.array(ProxyConfigSchema)]).optional(),
-    region: BrowserbaseRegionSchema.optional(),
+    region: BrowserbaseRegionSchema.optional().meta({
+      description:
+        "Deprecated. On hosted Stagehand API, the Browserbase session region is determined by the Stagehand API base URL you call. Prefer selecting the regional endpoint via the SDK client's baseUrl.",
+      example: "eu-central-1",
+    }),
     timeout: z.number().optional(),
     userMetadata: z.record(z.string(), z.unknown()).optional(),
   })

--- a/packages/docs/v3/sdk/go.mdx
+++ b/packages/docs/v3/sdk/go.mdx
@@ -223,6 +223,24 @@ go run examples/basic.go
 
 The example demonstrates the full Stagehand workflow: starting a session, navigating to a page, observing actions, clicking elements, extracting data, and running an autonomous agent.
 
+## Client configuration
+
+Use `option.WithBaseURL()` to select the Stagehand API region:
+
+```go
+client := stagehand.NewClient(
+	option.WithBrowserbaseAPIKey("My Browserbase API Key"),
+	option.WithBrowserbaseProjectID("My Browserbase Project ID"),
+	option.WithModelAPIKey("My Model API Key"),
+	option.WithBaseURL("https://api.euc1.stagehand.browserbase.com"),
+)
+```
+
+For hosted Stagehand API, prefer selecting the regional endpoint with `option.WithBaseURL()`.
+The request-level `region` field is retained for compatibility, but the hosted
+API determines the actual browser region from the Stagehand API endpoint you
+call.
+
 ### Request fields
 
 The stagehand library uses the [`omitzero`](https://tip.golang.org/doc/go1.24#encodingjsonpkgencodingjson)

--- a/packages/docs/v3/sdk/java.mdx
+++ b/packages/docs/v3/sdk/java.mdx
@@ -248,6 +248,25 @@ See this table for the available options:
 
 System properties take precedence over environment variables.
 
+Use `baseUrl` to select the Stagehand API region:
+
+```java
+import com.browserbase.api.client.StagehandClient;
+import com.browserbase.api.client.okhttp.StagehandOkHttpClient;
+
+StagehandClient client = StagehandOkHttpClient.builder()
+    .browserbaseApiKey("My Browserbase API Key")
+    .browserbaseProjectId("My Browserbase Project ID")
+    .modelApiKey("My Model API Key")
+    .baseUrl("https://api.euc1.stagehand.browserbase.com")
+    .build();
+```
+
+For hosted Stagehand API, prefer selecting the regional endpoint with `baseUrl`.
+The request-level `region` field is retained for compatibility, but the hosted
+API determines the actual browser region from the Stagehand API endpoint you
+call.
+
 > [!TIP]
 > Don't create more than one client in the same application. Each client has a connection pool and
 > thread pools, which are more efficient to share between requests.

--- a/packages/docs/v3/sdk/python.mdx
+++ b/packages/docs/v3/sdk/python.mdx
@@ -225,6 +225,24 @@ See this table for the available options:
 
 Keyword arguments take precedence over environment variables.
 
+Use `base_url` to select the Stagehand API region:
+
+```python
+from stagehand import AsyncStagehand
+
+client = AsyncStagehand(
+    browserbase_api_key="My Browserbase API Key",
+    browserbase_project_id="My Browserbase Project ID",
+    model_api_key="My Model API Key",
+    base_url="https://api.euc1.stagehand.browserbase.com",
+)
+```
+
+For hosted Stagehand API, prefer selecting the regional endpoint with `base_url`.
+The request-level `region` field is retained for compatibility, but the hosted
+API determines the actual browser region from the Stagehand API endpoint you
+call.
+
 > [!TIP]
 > Don't create more than one client in the same application. Each client has a connection pool, which is more efficient to share between requests.
 

--- a/packages/docs/v3/sdk/ruby.mdx
+++ b/packages/docs/v3/sdk/ruby.mdx
@@ -144,6 +144,24 @@ bundle install
 bundle exec ruby examples/basic.rb
 ```
 
+### Client configuration
+
+Use `base_url` to select the Stagehand API region:
+
+```ruby
+client = Stagehand::Client.new(
+  browserbase_api_key: "My Browserbase API Key",
+  browserbase_project_id: "My Browserbase Project ID",
+  model_api_key: "My Model API Key",
+  base_url: "https://api.euc1.stagehand.browserbase.com"
+)
+```
+
+For hosted Stagehand API, prefer selecting the regional endpoint with `base_url`.
+The request-level `region` field is retained for compatibility, but the hosted
+API determines the actual browser region from the Stagehand API endpoint you
+call.
+
 ### Streaming
 
 We provide support for streaming responses using Server-Sent Events (SSE).

--- a/packages/server-v3/openapi.v3.yaml
+++ b/packages/server-v3/openapi.v3.yaml
@@ -512,6 +512,10 @@ components:
               items:
                 $ref: "#/components/schemas/ProxyConfig"
         region:
+          description: Deprecated. On hosted Stagehand API, the Browserbase session region
+            is determined by the Stagehand API base URL you call. Prefer
+            selecting the regional endpoint via the SDK client's baseUrl.
+          example: eu-central-1
           $ref: "#/components/schemas/BrowserbaseRegion"
         timeout:
           type: number
@@ -1597,6 +1601,10 @@ components:
               items:
                 $ref: "#/components/schemas/ProxyConfigOutput"
         region:
+          description: Deprecated. On hosted Stagehand API, the Browserbase session region
+            is determined by the Stagehand API base URL you call. Prefer
+            selecting the regional endpoint via the SDK client's baseUrl.
+          example: eu-central-1
           $ref: "#/components/schemas/BrowserbaseRegion"
         timeout:
           type: number
@@ -2399,6 +2407,13 @@ paths:
                 $ref: "#/components/schemas/AgentExecuteResponse"
 servers:
   - url: https://api.stagehand.browserbase.com
+    description: Default us-west-2 Stagehand API endpoint
+  - url: https://api.use1.stagehand.browserbase.com
+    description: us-east-1 Stagehand API endpoint
+  - url: https://api.euc1.stagehand.browserbase.com
+    description: eu-central-1 Stagehand API endpoint
+  - url: https://api.apse1.stagehand.browserbase.com
+    description: ap-southeast-1 Stagehand API endpoint
 security:
   - BrowserbaseApiKey: []
     BrowserbaseProjectId: []

--- a/packages/server-v3/scripts/gen-openapi.ts
+++ b/packages/server-v3/scripts/gen-openapi.ts
@@ -142,6 +142,19 @@ Please try it and give us your feedback, stay tuned for upcoming release announc
       servers: [
         {
           url: "https://api.stagehand.browserbase.com",
+          description: "Default us-west-2 Stagehand API endpoint",
+        },
+        {
+          url: "https://api.use1.stagehand.browserbase.com",
+          description: "us-east-1 Stagehand API endpoint",
+        },
+        {
+          url: "https://api.euc1.stagehand.browserbase.com",
+          description: "eu-central-1 Stagehand API endpoint",
+        },
+        {
+          url: "https://api.apse1.stagehand.browserbase.com",
+          description: "ap-southeast-1 Stagehand API endpoint",
         },
       ],
       components: {

--- a/packages/server-v4/openapi.v4.yaml
+++ b/packages/server-v4/openapi.v4.yaml
@@ -850,6 +850,10 @@ components:
               items:
                 $ref: "#/components/schemas/ProxyConfig"
         region:
+          description: Deprecated. On hosted Stagehand API, the Browserbase session region
+            is determined by the Stagehand API base URL you call. Prefer
+            selecting the regional endpoint via the SDK client's baseUrl.
+          example: eu-central-1
           $ref: "#/components/schemas/BrowserbaseRegion"
         timeout:
           type: number
@@ -6469,6 +6473,10 @@ components:
               items:
                 $ref: "#/components/schemas/ProxyConfigOutput"
         region:
+          description: Deprecated. On hosted Stagehand API, the Browserbase session region
+            is determined by the Stagehand API base URL you call. Prefer
+            selecting the regional endpoint via the SDK client's baseUrl.
+          example: eu-central-1
           $ref: "#/components/schemas/BrowserbaseRegion"
         timeout:
           type: number
@@ -11567,6 +11575,13 @@ paths:
                 $ref: "#/components/schemas/V4ErrorResponse"
 servers:
   - url: https://api.stagehand.browserbase.com
+    description: Default us-west-2 Stagehand API endpoint
+  - url: https://api.use1.stagehand.browserbase.com
+    description: us-east-1 Stagehand API endpoint
+  - url: https://api.euc1.stagehand.browserbase.com
+    description: eu-central-1 Stagehand API endpoint
+  - url: https://api.apse1.stagehand.browserbase.com
+    description: ap-southeast-1 Stagehand API endpoint
 security:
   - BrowserbaseApiKey: []
     BrowserbaseProjectId: []

--- a/packages/server-v4/scripts/gen-openapi.ts
+++ b/packages/server-v4/scripts/gen-openapi.ts
@@ -66,6 +66,19 @@ Please try it and give us your feedback, stay tuned for upcoming release announc
       servers: [
         {
           url: "https://api.stagehand.browserbase.com",
+          description: "Default us-west-2 Stagehand API endpoint",
+        },
+        {
+          url: "https://api.use1.stagehand.browserbase.com",
+          description: "us-east-1 Stagehand API endpoint",
+        },
+        {
+          url: "https://api.euc1.stagehand.browserbase.com",
+          description: "eu-central-1 Stagehand API endpoint",
+        },
+        {
+          url: "https://api.apse1.stagehand.browserbase.com",
+          description: "ap-southeast-1 Stagehand API endpoint",
         },
       ],
       components: {

--- a/stainless.yml
+++ b/stainless.yml
@@ -153,6 +153,18 @@ openapi:
         target: "$.components.schemas.StreamEventSystemDataOutput.properties.result"
         value:
           x-stainless-any: true
+    - command: merge
+      reason: Mark hosted-region compatibility field as deprecated
+      args:
+        target: "$.components.schemas.BrowserbaseSessionCreateParams.properties.region"
+        value:
+          deprecated: true
+    - command: merge
+      reason: Mark hosted-region compatibility field as deprecated
+      args:
+        target: "$.components.schemas.BrowserbaseSessionCreateParamsOutput.properties.region"
+        value:
+          deprecated: true
 
 # `resources` define the structure and organization for your API, such as how
 # methods and models are grouped together and accessed. See the [configuration


### PR DESCRIPTION
## What
Adds clearer documentation for using `baseUrl` / `base_url` / `option.WithBaseURL()` to select a regional Stagehand API endpoint in the generated Go, Java, Python, and Ruby SDK docs. Marks `browserbaseSessionCreateParams.region` as deprecated in the generated OpenAPI spec.

## Why
For hosted Stagehand, the API endpoint the client calls is what determines the pod region. The hosted server overrides any client-provided `browserbaseSessionCreateParams.region` with the API instance's `AWS_REGION`, so `baseUrl` is the correct user-facing mechanism to document.

## Changes
- Add `Client configuration` / `baseUrl` examples to Go, Java, Python, and Ruby SDK docs
- Add deprecation description + example for `region` in `BrowserbaseSessionCreateParamsSchema`
- Add the four regional Stagehand API endpoints to OpenAPI `servers` (us-west-2 default, us-east-1, eu-central-1, ap-southeast-1) for both server-v3 and server-v4
- Apply `deprecated: true` to `region` via Stainless patches so generated SDKs reflect the deprecation

## Note
This is a revive of [#1820](https://github.com/browserbase/stagehand/pull/1820) by @monadoid.  Original PR was approved but went stale and conflicts with `main`. Rebased onto current `main` and resolved conflicts in `packages/server-v4/openapi.v4.yaml` (the schema layout shifted but the region field changes apply cleanly to both `BrowserbaseSessionCreateParams` and `BrowserbaseSessionCreateParamsOutput`).

Authorship preserved via `git commit --author`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies how to choose a Stagehand region via the client `baseUrl` and deprecates the request-level `region` for Browserbase sessions. OpenAPI now lists regional endpoints so generated SDKs and docs reflect endpoint-based routing.

- **New Features**
  - SDK docs (Go, Java, Python, Ruby) now show `option.WithBaseURL()`, `baseUrl`, and `base_url` examples for regional endpoints.
  - OpenAPI servers include us-west-2 (default), us-east-1, eu-central-1, and ap-southeast-1 endpoints.

- **Migration**
  - Use the client `baseUrl` to pick a region; stop relying on request `region` (deprecated and ignored on hosted Stagehand).
  - Endpoints: https://api.stagehand.browserbase.com (us-west-2), https://api.use1.stagehand.browserbase.com (us-east-1), https://api.euc1.stagehand.browserbase.com (eu-central-1), https://api.apse1.stagehand.browserbase.com (ap-southeast-1).

<sup>Written for commit 3cb8fd465f0818f4213a05a0f969f4bb8c138113. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2152?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

