### PR TITLE
fix(ci): strip trailing .0 from manual-evals numeric inputs

### DIFF
--- a/.github/workflows/manual-evals.yml
+++ b/.github/workflows/manual-evals.yml
@@ -193,6 +193,14 @@ jobs:
         run: |
           set +e
 
+          # The GitHub iOS app serializes `type: number` workflow_dispatch
+          # inputs as doubles ("1.0"/"50.0") regardless of whether the
+          # workflow needs an integer. The evals CLI's `parsePositiveInteger`
+          # (regex /^[0-9]+$/) rejects the decimal form, so strip a single
+          # trailing `.0` here before passing the values along.
+          EVAL_TRIALS="${EVAL_TRIALS%.0}"
+          EVAL_CONCURRENCY="${EVAL_CONCURRENCY%.0}"
+
           agent_mode_args=()
           if [[ -n "${EVAL_AGENT_MODE:-}" && "$EVAL_AGENT_MODE" != "auto" ]]; then
             agent_mode_args=(--agent-mode "$EVAL_AGENT_MODE")


### PR DESCRIPTION
The GitHub iOS app dispatches workflows with numeric inputs serialized as doubles ("1.0"/"50.0") even when the receiving field is declared `type: number` for an integer. GitHub accepts the float and threads it into the run, so the workflow triggers, but the evals CLI's `parsePositiveInteger` (regex /^[0-9]+$/) then rejects the value and the job fails immediately.

Strip a single trailing `.0` from `EVAL_TRIALS` and `EVAL_CONCURRENCY` in the dispatch shell before forwarding them to the eval CLI. Integers and non-zero decimals are passed through unchanged, so behaviour for the web UI / API callers is identical.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strip a trailing `.0` from `EVAL_TRIALS` and `EVAL_CONCURRENCY` in the manual-evals workflow so the evals CLI accepts integer inputs. Prevents job failures when the GitHub iOS app sends numeric inputs as doubles (e.g., "1.0", "50.0").

<sup>Written for commit c6c1d73106b43c07e52ea28e42c78ceb15aaefb1. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2154?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

