### PR TITLE
[STG-1427] feat: per-method serverCache threshold configuration

### DIFF
--- a/.changeset/slow-insects-lie.md
+++ b/.changeset/slow-insects-lie.md
@@ -1,5 +1,5 @@
 ---
-"@browserbasehq/stagehand": patch
+"@browserbasehq/stagehand": minor
 ---
 
 Add per-method `serverCache` threshold configuration. The `serverCache` option on `Stagehand` and on `act()` / `extract()` / `observe()` now accepts `boolean | { threshold: number }`, letting callers tune the minimum hit count required before cached results are returned. The constructor option additionally accepts a per-method object (`{ act, extract, observe }`) for fine-grained control. Method-level options take precedence over constructor-level defaults.

--- a/.changeset/slow-insects-lie.md
+++ b/.changeset/slow-insects-lie.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Add per-method `serverCache` threshold configuration. The `serverCache` option on `Stagehand` and on `act()` / `extract()` / `observe()` now accepts `boolean | { threshold: number }`, letting callers tune the minimum hit count required before cached results are returned. The constructor option additionally accepts a per-method object (`{ act, extract, observe }`) for fine-grained control. Method-level options take precedence over constructor-level defaults.

--- a/packages/core/lib/v3/api.ts
+++ b/packages/core/lib/v3/api.ts
@@ -12,6 +12,7 @@ import {
 } from "./types/public/index.js";
 import type {
   ActResult,
+  Action,
   AgentConfig,
   AgentExecuteOptions,
   AgentResult,
@@ -143,35 +144,41 @@ interface ExecuteActionParams {
 /**
  * Client parameters for act() method.
  * Derives structure from Api.ActRequest but uses SDK's ActOptions (which includes `page`).
- * Before serialization, `page` is stripped to produce Api.ActRequest wire format.
+ * Before serialization, `page` and `serverCache` are stripped to produce Api.ActRequest wire format.
+ * `cacheThreshold` is sent as a top-level field derived from the `serverCache` option.
  */
 interface ClientActParameters {
   input: Api.ActRequest["input"];
   options?: ActOptions;
   frameId?: Api.ActRequest["frameId"];
+  cacheThreshold?: number;
 }
 
 /**
  * Client parameters for extract() method.
  * Derives structure from Api.ExtractRequest but uses SDK's ExtractOptions (which includes `page`)
  * and accepts Zod schema (converted to JSON schema for wire format).
+ * `cacheThreshold` is sent as a top-level field derived from the `serverCache` option.
  */
 interface ClientExtractParameters {
   instruction?: Api.ExtractRequest["instruction"];
   schema?: StagehandZodSchema;
   options?: ExtractOptions;
   frameId?: Api.ExtractRequest["frameId"];
+  cacheThreshold?: number;
 }
 
 /**
  * Client parameters for observe() method.
  * Derives structure from Api.ObserveRequest but uses SDK's ObserveOptions (which includes `page`).
- * Before serialization, `page` is stripped to produce Api.ObserveRequest wire format.
+ * Before serialization, `page` and `serverCache` are stripped to produce Api.ObserveRequest wire format.
+ * `cacheThreshold` is sent as a top-level field derived from the `serverCache` option.
  */
 interface ClientObserveParameters {
   instruction?: Api.ObserveRequest["instruction"];
   options?: ObserveOptions;
   frameId?: Api.ObserveRequest["frameId"];
+  cacheThreshold?: number;
 }
 
 export class StagehandAPIClient {
@@ -280,14 +287,20 @@ export class StagehandAPIClient {
     input,
     options,
     frameId,
+    cacheThreshold,
   }: ClientActParameters): Promise<ActResult> {
-    // Strip non-serializable `page` and SDK-only fields from options before wire serialization
+    // Strip non-serializable `page` and client-only `serverCache` from options before wire serialization
     let wireOptions: Api.ActRequest["options"];
     let serverCache: boolean | undefined;
     if (options) {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { page: _, serverCache: enableCache, ...restOptions } = options;
-      serverCache = enableCache;
+      const { page: _, serverCache: serverCacheOpt, ...restOptions } = options;
+      // Resolve boolean | { threshold } → boolean for the cache-bypass header.
+      // An object with a threshold means caching is enabled (true).
+      if (serverCacheOpt !== undefined) {
+        serverCache =
+          typeof serverCacheOpt === "object" ? true : serverCacheOpt;
+      }
       if (Object.keys(restOptions).length > 0) {
         if (restOptions.model) {
           restOptions.model = this.prepareModelConfig(restOptions.model);
@@ -301,6 +314,7 @@ export class StagehandAPIClient {
       input,
       options: wireOptions,
       frameId,
+      cacheThreshold,
     };
 
     return this.execute<ActResult>({
@@ -315,17 +329,21 @@ export class StagehandAPIClient {
     schema: zodSchema,
     options,
     frameId,
+    cacheThreshold,
   }: ClientExtractParameters): Promise<ExtractResult<T>> {
     // Convert Zod schema to JSON schema for wire format
     const jsonSchema = zodSchema ? toJsonSchema(zodSchema) : undefined;
 
-    // Strip non-serializable `page` and SDK-only fields from options before wire serialization
+    // Strip non-serializable `page` and client-only `serverCache` from options before wire serialization
     let wireOptions: Api.ExtractRequest["options"];
     let serverCache: boolean | undefined;
     if (options) {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { page: _, serverCache: enableCache, ...restOptions } = options;
-      serverCache = enableCache;
+      const { page: _, serverCache: serverCacheOpt, ...restOptions } = options;
+      if (serverCacheOpt !== undefined) {
+        serverCache =
+          typeof serverCacheOpt === "object" ? true : serverCacheOpt;
+      }
       if (Object.keys(restOptions).length > 0) {
         if (restOptions.model) {
           restOptions.model = this.prepareModelConfig(restOptions.model);
@@ -340,6 +358,7 @@ export class StagehandAPIClient {
       schema: jsonSchema,
       options: wireOptions,
       frameId,
+      cacheThreshold,
     };
 
     return this.execute<ExtractResult<T>>({
@@ -353,14 +372,18 @@ export class StagehandAPIClient {
     instruction,
     options,
     frameId,
+    cacheThreshold,
   }: ClientObserveParameters): Promise<ObserveResult> {
-    // Strip non-serializable `page` and SDK-only fields from options before wire serialization
+    // Strip non-serializable `page` and client-only `serverCache` from options before wire serialization
     let wireOptions: Api.ObserveRequest["options"];
     let serverCache: boolean | undefined;
     if (options) {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { page: _, serverCache: enableCache, ...restOptions } = options;
-      serverCache = enableCache;
+      const { page: _, serverCache: serverCacheOpt, ...restOptions } = options;
+      if (serverCacheOpt !== undefined) {
+        serverCache =
+          typeof serverCacheOpt === "object" ? true : serverCacheOpt;
+      }
       if (Object.keys(restOptions).length > 0) {
         if (restOptions.model) {
           restOptions.model = this.prepareModelConfig(restOptions.model);
@@ -374,6 +397,7 @@ export class StagehandAPIClient {
       instruction,
       options: wireOptions,
       frameId,
+      cacheThreshold,
     };
 
     return this.execute<ObserveResult>({
@@ -896,6 +920,19 @@ export class StagehandAPIClient {
         ...options.headers,
       },
     });
+
+    // Log cache status if present in response headers
+    const cacheStatus = response.headers.get("browserbase-cache-status");
+    if (cacheStatus) {
+      this.logger({
+        category: "api",
+        message: `server cache ${cacheStatus.toLowerCase()}`,
+        level: 2,
+        auxiliary: {
+          "cache-status": { value: cacheStatus, type: "string" },
+        },
+      });
+    }
 
     return response;
   }

--- a/packages/core/lib/v3/handlers/extractHandler.ts
+++ b/packages/core/lib/v3/handlers/extractHandler.ts
@@ -263,6 +263,18 @@ export class ExtractHandler {
         ? resultString.slice(0, resultPreviewLength) + "..."
         : resultString;
 
+    // When extraction did not fully complete, mark the result so callers
+    // (e.g., the stagehand-api cache layer) can skip persisting it.
+    // The property is non-enumerable so it is invisible to JSON.stringify
+    // and never exposed to clients.
+    if (!completed && output !== null && typeof output === "object") {
+      Object.defineProperty(output, "__extractionIncomplete", {
+        value: true,
+        enumerable: false,
+        configurable: true,
+      });
+    }
+
     v3Logger({
       category: "extraction",
       message: completed

--- a/packages/core/lib/v3/types/public/api.ts
+++ b/packages/core/lib/v3/types/public/api.ts
@@ -506,6 +506,11 @@ export const ActRequestSchema = z
       description: "Whether to stream the response via SSE",
       example: true,
     }),
+    cacheThreshold: z.number().optional().meta({
+      description:
+        "Custom cache threshold override. Minimum hit count required before cached results are returned.",
+      example: 5,
+    }),
   })
   .meta({ id: "ActRequest" });
 
@@ -593,6 +598,11 @@ export const ExtractRequestSchema = z
       description: "Whether to stream the response via SSE",
       example: true,
     }),
+    cacheThreshold: z.number().optional().meta({
+      description:
+        "Custom cache threshold override. Minimum hit count required before cached results are returned.",
+      example: 5,
+    }),
   })
   .meta({ id: "ExtractRequest" });
 
@@ -669,6 +679,11 @@ export const ObserveRequestSchema = z
     streamResponse: z.boolean().optional().meta({
       description: "Whether to stream the response via SSE",
       example: true,
+    }),
+    cacheThreshold: z.number().optional().meta({
+      description:
+        "Custom cache threshold override. Minimum hit count required before cached results are returned.",
+      example: 5,
     }),
   })
   .meta({ id: "ObserveRequest" });

--- a/packages/core/lib/v3/types/public/methods.ts
+++ b/packages/core/lib/v3/types/public/methods.ts
@@ -17,10 +17,12 @@ export interface ActOptions {
   page?: PlaywrightPage | PuppeteerPage | PatchrightPage | Page;
   /**
    * Override the instance-level serverCache setting for this request.
-   * When true, enables server-side caching.
-   * When false, disables server-side caching.
+   * When true, enables server-side caching with the default threshold.
+   * When false, disables server-side caching (bypasses cache).
+   * When an object with a threshold, enables caching and overrides the minimum
+   * hit count required before cached results are returned.
    */
-  serverCache?: boolean;
+  serverCache?: boolean | { threshold: number };
 }
 
 export interface ActResult {
@@ -59,10 +61,12 @@ export interface ExtractOptions {
   page?: PlaywrightPage | PuppeteerPage | PatchrightPage | Page;
   /**
    * Override the instance-level serverCache setting for this request.
-   * When true, enables server-side caching.
-   * When false, disables server-side caching.
+   * When true, enables server-side caching with the default threshold.
+   * When false, disables server-side caching (bypasses cache).
+   * When an object with a threshold, enables caching and overrides the minimum
+   * hit count required before cached results are returned.
    */
-  serverCache?: boolean;
+  serverCache?: boolean | { threshold: number };
 }
 
 export const defaultExtractSchema = z.object({
@@ -82,10 +86,12 @@ export interface ObserveOptions {
   page?: PlaywrightPage | PuppeteerPage | PatchrightPage | Page;
   /**
    * Override the instance-level serverCache setting for this request.
-   * When true, enables server-side caching.
-   * When false, disables server-side caching.
+   * When true, enables server-side caching with the default threshold.
+   * When false, disables server-side caching (bypasses cache).
+   * When an object with a threshold, enables caching and overrides the minimum
+   * hit count required before cached results are returned.
    */
-  serverCache?: boolean;
+  serverCache?: boolean | { threshold: number };
 }
 
 /**

--- a/packages/core/lib/v3/types/public/options.ts
+++ b/packages/core/lib/v3/types/public/options.ts
@@ -62,10 +62,21 @@ export interface V3Options {
   domSettleTimeout?: number;
   disableAPI?: boolean;
   /**
-   * When true, enables server-side caching for API requests.
-   * When false, disables server-side caching.
-   * Defaults to true (caching enabled).
-   * Can be overridden per-method in act(), extract(), and observe() options.
+   * Controls server-side caching for API requests.
+   * - `false` disables caching globally for all methods (sends bypass header).
+   * - `true` enables caching with the default LaunchDarkly threshold.
+   * - An object enables per-method threshold configuration: each method can be
+   *   set to `true` (default threshold), `false` (disabled), or
+   *   `{ threshold: number }` (custom minimum hit count before cached results
+   *   are returned). Method-level serverCache options take precedence over
+   *   these constructor values.
+   * Defaults to `true` (caching enabled).
    */
-  serverCache?: boolean;
+  serverCache?:
+    | boolean
+    | {
+        act?: boolean | { threshold: number };
+        extract?: boolean | { threshold: number };
+        observe?: boolean | { threshold: number };
+      };
 }

--- a/packages/core/lib/v3/v3.ts
+++ b/packages/core/lib/v3/v3.ts
@@ -538,6 +538,62 @@ export class V3 {
     );
   }
 
+  /**
+   * Resolves the effective server cache threshold for a method call.
+   * Method-level serverCache takes precedence over constructor-level serverCache.
+   * Returns the threshold number if the effective serverCache is an object with threshold,
+   * or undefined if it's a boolean or unset (letting LaunchDarkly handle it).
+   */
+  private resolveServerCacheThreshold(
+    method: "act" | "extract" | "observe",
+    methodLevelCache?: boolean | { threshold: number },
+  ): number | undefined {
+    // When serverCache is a boolean it's a global enable/disable flag with no
+    // per-method threshold, so only index into it when it's an object.
+    const constructorMethodCache =
+      typeof this.opts.serverCache === "object"
+        ? this.opts.serverCache[method]
+        : undefined;
+    const effective =
+      methodLevelCache !== undefined
+        ? methodLevelCache
+        : constructorMethodCache;
+
+    if (typeof effective === "object" && effective !== null) {
+      return effective.threshold;
+    }
+    return undefined;
+  }
+
+  /**
+   * Resolves the effective serverCache boolean for the cache-bypass header.
+   * Method-level takes precedence over constructor-level per-method settings.
+   * Returns false when caching should be bypassed, true when it should be
+   * explicitly enabled, or undefined to let the APIClient use its default.
+   */
+  private resolveServerCacheBoolean(
+    method: "act" | "extract" | "observe",
+    methodLevelCache?: boolean | { threshold: number },
+  ): boolean | undefined {
+    // Method-level is always highest priority
+    if (methodLevelCache !== undefined) {
+      // { threshold } means enabled; boolean passes through
+      return typeof methodLevelCache === "object" ? true : methodLevelCache;
+    }
+    // Constructor-level global boolean (stg-1182 use-case: serverCache: false)
+    if (typeof this.opts.serverCache === "boolean") {
+      return this.opts.serverCache;
+    }
+    // Constructor-level per-method object
+    if (typeof this.opts.serverCache === "object") {
+      const methodSetting = this.opts.serverCache[method];
+      if (methodSetting !== undefined) {
+        return typeof methodSetting === "object" ? true : methodSetting;
+      }
+    }
+    return undefined;
+  }
+
   private resolveLlmClient(model?: ModelConfiguration): LLMClient {
     if (!model) {
       return this.llmClient;
@@ -1016,7 +1072,15 @@ export class V3 {
               apiKey,
               projectId,
               logger: this.logger,
-              serverCache: this.opts.serverCache,
+              // V3Options.serverCache can be boolean | object; APIClient only needs
+              // a boolean (for the global cache-bypass header). When serverCache is
+              // an object (per-method threshold config), pass undefined so the
+              // client defaults to caching enabled; per-method settings are
+              // handled via cacheThreshold in each individual request.
+              serverCache:
+                typeof this.opts.serverCache === "boolean"
+                  ? this.opts.serverCache
+                  : undefined,
             });
             const {
               projectId: overrideProjectId,
@@ -1200,10 +1264,21 @@ export class V3 {
         // Use selector as provided to support XPath, CSS, and other engines
         const selector = input.selector;
         if (this.apiClient) {
+          const resolvedServerCache = this.resolveServerCacheBoolean(
+            "act",
+            options?.serverCache,
+          );
           actResult = await this.apiClient.act({
             input,
-            options,
+            options:
+              resolvedServerCache !== undefined
+                ? { ...options, serverCache: resolvedServerCache }
+                : options,
             frameId: v3Page.mainFrameId(),
+            cacheThreshold: this.resolveServerCacheThreshold(
+              "act",
+              options?.serverCache,
+            ),
           });
         } else {
           const ensureTimeRemaining = createTimeoutGuard(
@@ -1288,7 +1363,22 @@ export class V3 {
       };
       if (this.apiClient) {
         const frameId = page.mainFrameId();
-        actResult = await this.apiClient.act({ input, options, frameId });
+        const resolvedServerCache = this.resolveServerCacheBoolean(
+          "act",
+          options?.serverCache,
+        );
+        actResult = await this.apiClient.act({
+          input,
+          options:
+            resolvedServerCache !== undefined
+              ? { ...options, serverCache: resolvedServerCache }
+              : options,
+          frameId,
+          cacheThreshold: this.resolveServerCacheThreshold(
+            "act",
+            options?.serverCache,
+          ),
+        });
       } else {
         actResult = await this.actHandler.act(handlerParams);
       }
@@ -1402,11 +1492,22 @@ export class V3 {
       let result: z.infer<typeof effectiveSchema> | { pageText: string };
       if (this.apiClient) {
         const frameId = page.mainFrameId();
+        const resolvedServerCache = this.resolveServerCacheBoolean(
+          "extract",
+          options?.serverCache,
+        );
         result = await this.apiClient.extract({
           instruction: handlerParams.instruction,
           schema: handlerParams.schema,
-          options,
+          options:
+            resolvedServerCache !== undefined
+              ? { ...options, serverCache: resolvedServerCache }
+              : options,
           frameId,
+          cacheThreshold: this.resolveServerCacheThreshold(
+            "extract",
+            options?.serverCache,
+          ),
         });
       } else {
         result =
@@ -1478,10 +1579,21 @@ export class V3 {
       let results: Action[];
       if (this.apiClient) {
         const frameId = page.mainFrameId();
+        const resolvedServerCache = this.resolveServerCacheBoolean(
+          "observe",
+          options?.serverCache,
+        );
         results = await this.apiClient.observe({
           instruction,
-          options,
+          options:
+            resolvedServerCache !== undefined
+              ? { ...options, serverCache: resolvedServerCache }
+              : options,
           frameId,
+          cacheThreshold: this.resolveServerCacheThreshold(
+            "observe",
+            options?.serverCache,
+          ),
         });
       } else {
         results = await this.observeHandler.observe(handlerParams);

--- a/packages/core/tests/unit/public-api/public-types.test.ts
+++ b/packages/core/tests/unit/public-api/public-types.test.ts
@@ -125,7 +125,7 @@ describe("Stagehand public API types", () => {
       variables?: Stagehand.Variables;
       timeout?: number;
       page?: Stagehand.AnyPage;
-      serverCache?: boolean;
+      serverCache?: boolean | { threshold: number };
     };
 
     it("matches expected type shape", () => {
@@ -155,7 +155,7 @@ describe("Stagehand public API types", () => {
       ignoreSelectors?: string[];
       screenshot?: boolean;
       page?: Stagehand.AnyPage;
-      serverCache?: boolean;
+      serverCache?: boolean | { threshold: number };
     };
 
     it("matches expected type shape", () => {
@@ -171,7 +171,7 @@ describe("Stagehand public API types", () => {
       selector?: string;
       ignoreSelectors?: string[];
       page?: Stagehand.AnyPage;
-      serverCache?: boolean;
+      serverCache?: boolean | { threshold: number };
     };
 
     it("matches expected type shape", () => {

--- a/packages/server-v3/openapi.v3.yaml
+++ b/packages/server-v3/openapi.v3.yaml
@@ -624,6 +624,11 @@ components:
           description: Whether to stream the response via SSE
           example: true
           type: boolean
+        cacheThreshold:
+          description: Custom cache threshold override. Minimum hit count required
+            before cached results are returned.
+          example: 5
+          type: number
       required:
         - input
     ActResultData:
@@ -717,6 +722,11 @@ components:
           description: Whether to stream the response via SSE
           example: true
           type: boolean
+        cacheThreshold:
+          description: Custom cache threshold override. Minimum hit count required
+            before cached results are returned.
+          example: 5
+          type: number
     ExtractResult:
       type: object
       properties:
@@ -784,6 +794,11 @@ components:
           description: Whether to stream the response via SSE
           example: true
           type: boolean
+        cacheThreshold:
+          description: Custom cache threshold override. Minimum hit count required
+            before cached results are returned.
+          example: 5
+          type: number
     ObserveResult:
       type: object
       properties:


### PR DESCRIPTION
## What
Extends `serverCache` to accept `boolean | { threshold: number }` on `act()` / `extract()` / `observe()` options and on the `Stagehand` constructor. The constructor additionally accepts a per-method object for fine-grained control:

```ts
new Stagehand({
  serverCache: {
    act: { threshold: 5 },
    extract: false,
    observe: true,
  },
});

await stagehand.act("click login", { serverCache: { threshold: 10 } });
```

Method-level options take precedence over constructor-level defaults.

## How
- New `resolveServerCacheBoolean()` + `resolveServerCacheThreshold()` helpers in `V3` collapse the constructor + per-call config to a `boolean` (for the cache-bypass header) and an optional `number` (for the new `cacheThreshold` wire field) on each request.
- `ActRequestSchema` / `ExtractRequestSchema` / `ObserveRequestSchema` gain an optional `cacheThreshold` field; matching entries added to `packages/server-v3/openapi.v3.yaml`.
- `extractHandler` marks incomplete extractions with a non-enumerable `__extractionIncomplete` property so the server-side cache layer can skip persisting them.
- `APIClient` constructor only receives `serverCache` when it's a plain `boolean` — the per-method object form is handled per-request via `cacheThreshold`.

## Note
Picks up [#1732](https://github.com/browserbase/stagehand/pull/1732) by @sameelarif. PR went stale (~3 months) and had conflicts with `main` after the STG-1182 was added through #1581. Rebased onto current `main` and resolved conflicts so that this PR is purely the *threshold* layer on top of the already-merged on/off cache toggle.

Notable resolutions:
- Took main's improved cache-status suppression logic in `api.ts` (suppresses MISS log/surface when caching was bypassed).
- Kept main's `cache-variables.test.ts` and `caching.mdx` (both already shipped via #1581, the PR's older versions would have regressed them).
- Used `expectTypeOf().toExtend()` in the `ObserveResult` type test (main's pattern). The strict `toEqualTypeOf` against an intersection type is brittle.




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-method server cache thresholds so you can tune when cached results are returned for `act`, `extract`, and `observe`. Implements STG-1427; method-level options override constructor defaults without breaking the on/off toggle.

- **New Features**
  - `serverCache` now accepts `boolean | { threshold: number }` in `Stagehand` and per-method options; the constructor also supports `{ act, extract, observe }`.
  - Resolved settings send a cache-bypass boolean and a `cacheThreshold` per request; method options take precedence over constructor values.
  - Added `cacheThreshold` to `ActRequest`, `ExtractRequest`, and `ObserveRequest` schemas and updated `openapi.v3.yaml`; API client logs `browserbase-cache-status` when present.
  - Incomplete extractions are marked with a non-enumerable `__extractionIncomplete` so the server cache skips persisting them.

<sup>Written for commit 9b6d85999e67f5a01f3a6c5b2a652e3b3adb5970. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2155?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



