### PR TITLE
fix(core): honor v3 piercer debug option

### DIFF
--- a/.changeset/quiet-shadows-honor.md
+++ b/.changeset/quiet-shadows-honor.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Honor `installV3ShadowPiercer({ debug })` so piercer console logs stay quiet unless debug mode is enabled.

--- a/packages/core/lib/v3/dom/piercer.runtime.ts
+++ b/packages/core/lib/v3/dom/piercer.runtime.ts
@@ -31,8 +31,7 @@ declare global {
 }
 
 export function installV3ShadowPiercer(opts: V3ShadowPatchOptions = {}): void {
-  // hardcoded debug (remove later if desired)
-  const DEBUG = true;
+  const DEBUG = opts.debug ?? false;
 
   type PatchedFn = Element["attachShadow"] & {
     __v3Patched?: boolean;

--- a/packages/core/tests/unit/v3-shadow-piercer-debug.test.ts
+++ b/packages/core/tests/unit/v3-shadow-piercer-debug.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { installV3ShadowPiercer } from "../../lib/v3/dom/piercer.runtime.js";
+
+function installFakeDom() {
+  class TestElement {
+    tagName: string;
+    shadowRoot?: unknown;
+
+    constructor(tagName = "x-host") {
+      this.tagName = tagName.toUpperCase();
+    }
+
+    attachShadow(init: ShadowRootInit): ShadowRoot {
+      const root = { mode: init.mode ?? "open" };
+      if ((init.mode ?? "open") === "open") {
+        this.shadowRoot = root;
+      }
+      return root as ShadowRoot;
+    }
+  }
+
+  const fakeWindow: Record<string, unknown> = {};
+  fakeWindow.top = fakeWindow;
+
+  vi.stubGlobal("Element", TestElement);
+  vi.stubGlobal("window", fakeWindow);
+  vi.stubGlobal("document", {
+    readyState: "complete",
+    createTreeWalker: vi.fn(),
+  });
+  vi.stubGlobal("location", { href: "https://example.test/" });
+  vi.stubGlobal("NodeFilter", { SHOW_ELEMENT: 1 });
+
+  return { TestElement, fakeWindow };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("installV3ShadowPiercer debug option", () => {
+  it("does not emit piercer console logs when debug is omitted", () => {
+    const { TestElement } = installFakeDom();
+    const consoleInfo = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    installV3ShadowPiercer();
+    new TestElement().attachShadow({ mode: "open" });
+
+    expect(consoleInfo).not.toHaveBeenCalled();
+  });
+
+  it("updates the idempotent install debug state from opts.debug", () => {
+    const { TestElement } = installFakeDom();
+    const consoleInfo = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    installV3ShadowPiercer({ debug: false });
+    installV3ShadowPiercer({ debug: true });
+    new TestElement("x-enabled").attachShadow({ mode: "closed" });
+
+    expect(consoleInfo).toHaveBeenCalledWith(
+      "[v3-piercer] attachShadow",
+      expect.objectContaining({ tag: "x-enabled", mode: "closed" }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Make `installV3ShadowPiercer` derive `DEBUG` from `opts.debug ?? false` instead of hardcoding it to `true`.
- Add regression coverage for omitted `debug` staying silent and for idempotent reinstalls updating the stored debug state.

## Why
`V3ShadowPatchOptions.debug` is currently ignored, so piercer install/`attachShadow` logs emit even when debug is omitted or false. This makes the option ineffective.

Fixes #1996.

## Tests
- `pnpm --filter @browserbasehq/stagehand run gen-version` ✅
- `pnpm --filter @browserbasehq/stagehand run build-dom-scripts` ✅
- `pnpm --filter @browserbasehq/stagehand run build:esm` ✅
- `pnpm --filter @browserbasehq/stagehand test:core packages/core/dist/esm/tests/unit/v3-shadow-piercer-debug.test.js` ✅ (Vitest: 1 file, 2 tests)
- `pnpm exec vitest run --config vitest.esm.config.mjs dist/esm/tests/unit/v3-shadow-piercer-debug.test.js` ✅ (Vitest: 1 file, 2 tests)
- `pnpm exec prettier --check packages/core/lib/v3/dom/piercer.runtime.ts packages/core/tests/unit/v3-shadow-piercer-debug.test.ts` ✅
- `pnpm exec eslint packages/core/lib/v3/dom/piercer.runtime.ts packages/core/tests/unit/v3-shadow-piercer-debug.test.ts` ✅
- `pnpm --filter @browserbasehq/stagehand run typecheck` ✅
- `pnpm changeset status --since origin/main` ✅

## Compatibility / risk
- Default `installV3ShadowPiercer()` is quiet unless `debug: true` is provided, matching the option semantics.
- Existing idempotent installs still reuse state and now correctly update that state's debug flag from `opts.debug`.
- No dependency changes or public API shape changes.
