### PR TITLE
fix(core): parse screenshot MIME in GoogleCUAClient function responses

### DIFF
--- a/.changeset/fix-google-cua-mime-type.md
+++ b/.changeset/fix-google-cua-mime-type.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Parse screenshot MIME type from data URL in `GoogleCUAClient` function responses. Previously, `inlineData.mimeType` was hardcoded to `image/png` and the data URL prefix was stripped with a PNG-only regex, which would mishandle JPEG or WebP screenshots. The MIME type is now derived from the data URL with a PNG fallback for raw base64 input.

--- a/packages/core/lib/v3/agent/GoogleCUAClient.ts
+++ b/packages/core/lib/v3/agent/GoogleCUAClient.ts
@@ -40,6 +40,25 @@ import {
 } from "../flowlogger/FlowLogger.js";
 import { v7 as uuidv7 } from "uuid";
 
+const IMAGE_DATA_URL_PATTERN = /^data:(image\/[a-zA-Z0-9.+-]+);base64,(.*)$/;
+
+/**
+ * Parse an image data URL into its MIME type and base64 payload.
+ * Falls back to `image/png` and the input string when the value is raw
+ * base64 or otherwise not a recognized image data URL — preserving prior
+ * behavior for callers that already pass raw bytes.
+ */
+export function parseImageDataUrl(input: string): {
+  mimeType: string;
+  data: string;
+} {
+  const match = input.match(IMAGE_DATA_URL_PATTERN);
+  if (match) {
+    return { mimeType: match[1], data: match[2] };
+  }
+  return { mimeType: "image/png", data: input };
+}
+
 /**
  * Client for Google's Computer Use Assistant API
  * This implementation uses the Google Generative AI SDK for Computer Use
@@ -576,10 +595,8 @@ export class GoogleCUAClient extends AgentClient {
               });
 
               const screenshot = await this.captureScreenshot();
-              const base64Data = screenshot.replace(
-                /^data:image\/png;base64,/,
-                "",
-              );
+              const { mimeType, data: base64Data } =
+                parseImageDataUrl(screenshot);
 
               // Create one function response for each computer use function call
               // Following Python SDK pattern: FunctionResponse with parts containing inline_data
@@ -606,7 +623,7 @@ export class GoogleCUAClient extends AgentClient {
                     parts: [
                       {
                         inlineData: {
-                          mimeType: "image/png",
+                          mimeType,
                           data: base64Data,
                         },
                       },

--- a/packages/core/lib/v3/agent/GoogleCUAClient.ts
+++ b/packages/core/lib/v3/agent/GoogleCUAClient.ts
@@ -40,7 +40,8 @@ import {
 } from "../flowlogger/FlowLogger.js";
 import { v7 as uuidv7 } from "uuid";
 
-const IMAGE_DATA_URL_PATTERN = /^data:(image\/[a-zA-Z0-9.+-]+);base64,(.*)$/;
+const IMAGE_DATA_URL_PATTERN =
+  /^data:(image\/[a-zA-Z0-9.+-]+);base64,([\s\S]*)$/;
 
 /**
  * Parse an image data URL into its MIME type and base64 payload.

--- a/packages/core/tests/unit/google-cua-client.test.ts
+++ b/packages/core/tests/unit/google-cua-client.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { parseImageDataUrl } from "../../lib/v3/agent/GoogleCUAClient.js";
+
+describe("parseImageDataUrl", () => {
+  it("parses a PNG data URL into mimeType and base64 payload", () => {
+    const result = parseImageDataUrl("data:image/png;base64,iVBORw0KGgo=");
+    expect(result).toEqual({
+      mimeType: "image/png",
+      data: "iVBORw0KGgo=",
+    });
+  });
+
+  it("parses a JPEG data URL into mimeType and base64 payload", () => {
+    const result = parseImageDataUrl("data:image/jpeg;base64,/9j/4AAQSkZJRg==");
+    expect(result).toEqual({
+      mimeType: "image/jpeg",
+      data: "/9j/4AAQSkZJRg==",
+    });
+  });
+
+  it("parses a WebP data URL into mimeType and base64 payload", () => {
+    const result = parseImageDataUrl("data:image/webp;base64,UklGRiQAAABXRUJQ");
+    expect(result).toEqual({
+      mimeType: "image/webp",
+      data: "UklGRiQAAABXRUJQ",
+    });
+  });
+
+  it("falls back to image/png for raw base64 input (preserving prior behavior)", () => {
+    const raw = "iVBORw0KGgoAAAANSUhEUgAA";
+    const result = parseImageDataUrl(raw);
+    expect(result).toEqual({
+      mimeType: "image/png",
+      data: raw,
+    });
+  });
+
+  it("falls back to image/png for non-image data URLs", () => {
+    const input = "data:text/plain;base64,SGVsbG8=";
+    const result = parseImageDataUrl(input);
+    expect(result).toEqual({
+      mimeType: "image/png",
+      data: input,
+    });
+  });
+});

--- a/packages/core/tests/unit/google-cua-client.test.ts
+++ b/packages/core/tests/unit/google-cua-client.test.ts
@@ -26,6 +26,15 @@ describe("parseImageDataUrl", () => {
     });
   });
 
+  it("parses a PNG data URL with newline-wrapped base64 (MIME-style)", () => {
+    const wrapped = "iVBORw0KGgo=\nAAAANSUhEUgAA\nAAEAAAABCAYAAAA=";
+    const result = parseImageDataUrl(`data:image/png;base64,${wrapped}`);
+    expect(result).toEqual({
+      mimeType: "image/png",
+      data: wrapped,
+    });
+  });
+
   it("falls back to image/png for raw base64 input (preserving prior behavior)", () => {
     const raw = "iVBORw0KGgoAAAANSUhEUgAA";
     const result = parseImageDataUrl(raw);


### PR DESCRIPTION
# why
Closes #2046. `GoogleCUAClient` builds function-response image parts with `inlineData.mimeType = "image/png"` and strips the data URL prefix using a PNG-only regex. If a screenshot is JPEG/WebP (or anything non-PNG), the metadata is wrong and the regex no-ops — the whole data URL ends up as the payload.

# what changed
- Added `parseImageDataUrl(input)` helper that extracts `{ mimeType, data }` from an `image/<type>` data URL, falling back to `image/png` + the raw input for unrecognized formats (preserves prior behavior).
- Replaced the hardcoded PNG strip + hardcoded `mimeType` at the function-response call site with the helper's parsed values.
- No change to `captureScreenshot()` — it still normalizes raw provider input to PNG data URLs, matching the issue's stated current contract.

# test plan
New `packages/core/tests/unit/google-cua-client.test.ts` covering:
- PNG data URL → `image/png` + base64 payload
- JPEG data URL → `image/jpeg` + base64 payload
- WebP data URL → `image/webp` + base64 payload
- Raw base64 → fallback to `image/png` with the input as data
- Non-image data URL (e.g. `text/plain`) → fallback to `image/png`

Also ran `pnpm run typecheck` and `pnpm run eslint` in `packages/core` — both clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes screenshot MIME parsing in `GoogleCUAClient` function responses by deriving the type and base64 payload from image data URLs, including newline-wrapped payloads. Addresses Linear issue #2046 and ensures JPEG/WebP screenshots set the correct `inlineData.mimeType`, with a PNG fallback for raw inputs.

- **Bug Fixes**
  - Added `parseImageDataUrl(input)` to extract `{ mimeType, data }` from `data:image/*;base64,...`, handling newline-wrapped base64.
  - Replaced PNG-only strip and hardcoded `mimeType` with parsed values.
  - Added unit tests for PNG, JPEG, WebP, newline-wrapped data, raw base64, and non-image data URLs.

<sup>Written for commit 246ef50875bef98c4198625718ab2330f7bc91c1. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2159?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

