### PR TITLE
[STG-1756] forward Vertex model config

### DIFF
--- a/.changeset/vertex-model-forwarding.md
+++ b/.changeset/vertex-model-forwarding.md
@@ -1,0 +1,6 @@
+---
+"@browserbasehq/stagehand": patch
+"@browserbasehq/stagehand-server-v3": patch
+---
+
+Forward constructor and request model configuration when initializing API-backed sessions.

--- a/.changeset/vertex-model-forwarding.md
+++ b/.changeset/vertex-model-forwarding.md
@@ -1,6 +1,6 @@
 ---
-"@browserbasehq/stagehand": patch
-"@browserbasehq/stagehand-server-v3": patch
+"@browserbasehq/stagehand": minor
+"@browserbasehq/stagehand-server-v3": minor
 ---
 
 Forward constructor and request model configuration when initializing API-backed sessions.

--- a/packages/core/lib/v3/api.ts
+++ b/packages/core/lib/v3/api.ts
@@ -418,9 +418,14 @@ export class StagehandAPIClient {
     options?: Api.NavigateRequest["options"],
     frameId?: string,
   ): Promise<SerializableResponse | null> {
+    const publicOptions = { ...(options ?? {}) } as NonNullable<
+      Api.NavigateRequest["options"]
+    > & { model?: unknown };
+    delete publicOptions.model;
+
     const wireOptions = {
-      ...(options ?? {}),
-      ...(this.defaultModelConfig && !(options as { model?: unknown })?.model
+      ...publicOptions,
+      ...(this.defaultModelConfig
         ? { model: this.getDefaultModelConfig() }
         : {}),
     };

--- a/packages/core/lib/v3/api.ts
+++ b/packages/core/lib/v3/api.ts
@@ -653,38 +653,49 @@ export class StagehandAPIClient {
   private prepareModelConfig(model: ModelConfiguration): PreparedModelConfig {
     if (typeof model === "string") {
       // Extract provider from model string (e.g., "openai/gpt-5-nano" -> "openai")
-      const provider = model.includes("/") ? model.split("/")[0] : undefined;
+      const provider = this.getModelProvider(model);
+      const inheritedDefault =
+        provider && provider === this.modelProvider
+          ? this.getDefaultModelConfig()
+          : undefined;
       const apiKey =
         provider && provider !== this.modelProvider
           ? (loadApiKeyFromEnv(provider, this.logger) ?? this.modelApiKey)
           : this.modelApiKey;
       return {
+        ...inheritedDefault,
         modelName: model,
         ...(apiKey ? { apiKey } : {}),
       };
     }
 
-    if (!model.apiKey) {
-      const provider = model.modelName?.includes("/")
-        ? model.modelName.split("/")[0]
+    const provider = this.getModelProvider(model.modelName);
+    const inheritedDefault =
+      provider && provider === this.modelProvider
+        ? this.getDefaultModelConfig()
         : undefined;
-      const apiKey =
-        provider && provider !== this.modelProvider
-          ? (loadApiKeyFromEnv(provider, this.logger) ?? this.modelApiKey)
-          : this.modelApiKey;
-      return {
-        ...model,
-        ...(apiKey ? { apiKey } : {}),
-      };
-    }
+    const apiKey =
+      !model.apiKey && provider && provider !== this.modelProvider
+        ? (loadApiKeyFromEnv(provider, this.logger) ?? this.modelApiKey)
+        : !model.apiKey
+          ? this.modelApiKey
+          : undefined;
 
-    return model as PreparedModelConfig;
+    return {
+      ...inheritedDefault,
+      ...model,
+      ...(apiKey ? { apiKey } : {}),
+    } as PreparedModelConfig;
   }
 
   private getDefaultModelConfig(): PreparedModelConfig | undefined {
     return this.defaultModelConfig
       ? ({ ...this.defaultModelConfig } as PreparedModelConfig)
       : undefined;
+  }
+
+  private getModelProvider(modelName: string | undefined): string | undefined {
+    return modelName?.includes("/") ? modelName.split("/")[0] : undefined;
   }
 
   private consumeFinishedEventData<T>(): T | null {

--- a/packages/core/lib/v3/api.ts
+++ b/packages/core/lib/v3/api.ts
@@ -106,6 +106,8 @@ interface ClientSessionStartParams extends Api.SessionStartRequest {
    *  Optional: when omitted, requests are sent without the x-model-api-key header
    *  and the server is expected to handle model authentication on its own. */
   modelApiKey?: string;
+  /** Default model config for later action requests. Not sent to /sessions/start. */
+  defaultModelConfig?: ModelConfiguration;
 }
 
 /**
@@ -114,6 +116,11 @@ interface ClientSessionStartParams extends Api.SessionStartRequest {
 type ApiResponse<T> =
   | { success: true; data: T }
   | { success: false; message: string };
+
+type PreparedModelConfig = { modelName: string; apiKey?: string } & Record<
+  string,
+  unknown
+>;
 
 /**
  * Union of all API request body types for type-safe execute() calls
@@ -180,6 +187,7 @@ export class StagehandAPIClient {
   private sessionId?: string;
   private modelApiKey?: string;
   private modelProvider?: string;
+  private defaultModelConfig?: PreparedModelConfig;
   private region?: BrowserbaseRegion;
   private logger: (message: LogLine) => void;
   private fetchWithCookies;
@@ -205,6 +213,7 @@ export class StagehandAPIClient {
   async init({
     modelName,
     modelApiKey,
+    defaultModelConfig,
     domSettleTimeoutMs,
     verbose,
     systemPrompt,
@@ -217,6 +226,9 @@ export class StagehandAPIClient {
     // Extract provider from modelName (e.g., "openai/gpt-5-nano" -> "openai")
     this.modelProvider = modelName?.includes("/")
       ? modelName.split("/")[0]
+      : undefined;
+    this.defaultModelConfig = defaultModelConfig
+      ? this.prepareModelConfig(defaultModelConfig)
       : undefined;
 
     // Store the region for multi-region API URL resolution
@@ -288,12 +300,18 @@ export class StagehandAPIClient {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { page: _, serverCache: enableCache, ...restOptions } = options;
       serverCache = enableCache;
+      if (restOptions.model) {
+        restOptions.model = this.prepareModelConfig(restOptions.model);
+      } else if (this.defaultModelConfig) {
+        restOptions.model = this.getDefaultModelConfig();
+      }
       if (Object.keys(restOptions).length > 0) {
-        if (restOptions.model) {
-          restOptions.model = this.prepareModelConfig(restOptions.model);
-        }
         wireOptions = restOptions as unknown as Api.ActRequest["options"];
       }
+    } else if (this.defaultModelConfig) {
+      wireOptions = {
+        model: this.getDefaultModelConfig(),
+      } as unknown as Api.ActRequest["options"];
     }
 
     // Build wire-format request body
@@ -326,12 +344,18 @@ export class StagehandAPIClient {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { page: _, serverCache: enableCache, ...restOptions } = options;
       serverCache = enableCache;
+      if (restOptions.model) {
+        restOptions.model = this.prepareModelConfig(restOptions.model);
+      } else if (this.defaultModelConfig) {
+        restOptions.model = this.getDefaultModelConfig();
+      }
       if (Object.keys(restOptions).length > 0) {
-        if (restOptions.model) {
-          restOptions.model = this.prepareModelConfig(restOptions.model);
-        }
         wireOptions = restOptions as unknown as Api.ExtractRequest["options"];
       }
+    } else if (this.defaultModelConfig) {
+      wireOptions = {
+        model: this.getDefaultModelConfig(),
+      } as unknown as Api.ExtractRequest["options"];
     }
 
     // Build wire-format request body
@@ -361,12 +385,18 @@ export class StagehandAPIClient {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { page: _, serverCache: enableCache, ...restOptions } = options;
       serverCache = enableCache;
+      if (restOptions.model) {
+        restOptions.model = this.prepareModelConfig(restOptions.model);
+      } else if (this.defaultModelConfig) {
+        restOptions.model = this.getDefaultModelConfig();
+      }
       if (Object.keys(restOptions).length > 0) {
-        if (restOptions.model) {
-          restOptions.model = this.prepareModelConfig(restOptions.model);
-        }
         wireOptions = restOptions as unknown as Api.ObserveRequest["options"];
       }
+    } else if (this.defaultModelConfig) {
+      wireOptions = {
+        model: this.getDefaultModelConfig(),
+      } as unknown as Api.ObserveRequest["options"];
     }
 
     // Build wire-format request body
@@ -388,7 +418,17 @@ export class StagehandAPIClient {
     options?: Api.NavigateRequest["options"],
     frameId?: string,
   ): Promise<SerializableResponse | null> {
-    const requestBody: Api.NavigateRequest = { url, options, frameId };
+    const wireOptions = {
+      ...(options ?? {}),
+      ...(this.defaultModelConfig && !(options as { model?: unknown })?.model
+        ? { model: this.getDefaultModelConfig() }
+        : {}),
+    };
+    const requestBody: Api.NavigateRequest = {
+      url,
+      options: Object.keys(wireOptions).length > 0 ? wireOptions : undefined,
+      frameId,
+    };
 
     return this.execute<SerializableResponse | null>({
       method: "navigate",
@@ -425,7 +465,7 @@ export class StagehandAPIClient {
       cua: agentConfig.mode === undefined ? agentConfig.cua : undefined,
       model: agentConfig.model
         ? this.prepareModelConfig(agentConfig.model)
-        : undefined,
+        : this.getDefaultModelConfig(),
       executionModel: agentConfig.executionModel
         ? this.prepareModelConfig(agentConfig.executionModel)
         : undefined,
@@ -605,9 +645,7 @@ export class StagehandAPIClient {
    * In API mode, we only attempt to load an API key from env vars when the
    * model provider differs from the one used to init the session.
    */
-  private prepareModelConfig(
-    model: ModelConfiguration,
-  ): { modelName: string; apiKey?: string } & Record<string, unknown> {
+  private prepareModelConfig(model: ModelConfiguration): PreparedModelConfig {
     if (typeof model === "string") {
       // Extract provider from model string (e.g., "openai/gpt-5-nano" -> "openai")
       const provider = model.includes("/") ? model.split("/")[0] : undefined;
@@ -635,10 +673,13 @@ export class StagehandAPIClient {
       };
     }
 
-    return model as { modelName: string; apiKey: string } & Record<
-      string,
-      unknown
-    >;
+    return model as PreparedModelConfig;
+  }
+
+  private getDefaultModelConfig(): PreparedModelConfig | undefined {
+    return this.defaultModelConfig
+      ? ({ ...this.defaultModelConfig } as PreparedModelConfig)
+      : undefined;
   }
 
   private consumeFinishedEventData<T>(): T | null {

--- a/packages/core/lib/v3/llm/LLMProvider.ts
+++ b/packages/core/lib/v3/llm/LLMProvider.ts
@@ -69,6 +69,37 @@ const AISDKProvidersWithAPIKey: Record<string, AISDKCustomProvider> = {
   gateway: createGateway,
 };
 
+type AISDKProviderClientOptions = ClientOptions & Record<string, unknown>;
+
+export function toAISDKClientOptions(
+  subProvider: string,
+  clientOptions?: ClientOptions,
+): AISDKProviderClientOptions | undefined {
+  if (!clientOptions || subProvider !== "vertex") {
+    return clientOptions as AISDKProviderClientOptions | undefined;
+  }
+
+  const { auth, providerOptions, ...rest } = clientOptions;
+  const vertexOptions = providerOptions?.vertex;
+
+  return {
+    ...rest,
+    ...(vertexOptions ?? {}),
+    ...(auth?.type === "googleServiceAccount"
+      ? {
+          googleAuthOptions: {
+            credentials: auth.credentials,
+            ...(auth.scopes ? { scopes: auth.scopes } : {}),
+            ...(auth.projectId ? { projectId: auth.projectId } : {}),
+            ...(auth.universeDomain
+              ? { universeDomain: auth.universeDomain }
+              : {}),
+          },
+        }
+      : {}),
+  };
+}
+
 const modelToProviderMap: { [key in AvailableModel]: ModelProvider } = {
   "gpt-4.1": "openai",
   "gpt-4.1-mini": "openai",
@@ -105,9 +136,12 @@ export function getAISDKLanguageModel(
   clientOptions?: ClientOptions,
   middleware?: LanguageModelV2Middleware,
 ) {
+  const aiSdkClientOptions = toAISDKClientOptions(subProvider, clientOptions);
   const hasValidOptions =
-    clientOptions &&
-    Object.values(clientOptions).some((v) => v !== undefined && v !== null);
+    aiSdkClientOptions &&
+    Object.values(aiSdkClientOptions).some(
+      (v) => v !== undefined && v !== null,
+    );
 
   let model;
   if (hasValidOptions) {
@@ -118,7 +152,7 @@ export function getAISDKLanguageModel(
         Object.keys(AISDKProvidersWithAPIKey),
       );
     }
-    const provider = creator(clientOptions);
+    const provider = creator(aiSdkClientOptions as ClientOptions);
     model = provider(subModelName);
   } else {
     const provider = AISDKProviders[subProvider];

--- a/packages/core/lib/v3/llm/LLMProvider.ts
+++ b/packages/core/lib/v3/llm/LLMProvider.ts
@@ -1,6 +1,5 @@
 import type { LanguageModelV2Middleware } from "@ai-sdk/provider";
 import {
-  ExperimentalNotConfiguredError,
   UnsupportedAISDKModelProviderError,
   UnsupportedModelError,
   UnsupportedModelProviderError,
@@ -163,13 +162,6 @@ export class LLMProvider {
       const firstSlashIndex = modelName.indexOf("/");
       const subProvider = modelName.substring(0, firstSlashIndex);
       const subModelName = modelName.substring(firstSlashIndex + 1);
-      if (
-        subProvider === "vertex" &&
-        !options?.disableAPI &&
-        !options?.experimental
-      ) {
-        throw new ExperimentalNotConfiguredError("Vertex provider");
-      }
 
       const effectiveMiddleware = options?.middleware ?? this.middleware;
       const languageModel = getAISDKLanguageModel(

--- a/packages/core/lib/v3/types/public/api.ts
+++ b/packages/core/lib/v3/types/public/api.ts
@@ -858,6 +858,10 @@ export const AgentExecuteResponseSchema = wrapResponse(
 
 export const NavigateOptionsSchema = z
   .object({
+    model: z.union([ModelConfigSchema, z.string()]).optional().meta({
+      description:
+        "Model configuration object or model name string used to initialize API-backed sessions before navigation",
+    }),
     referer: z.string().optional().meta({
       description: "Referer header to send with the request",
     }),

--- a/packages/core/lib/v3/types/public/api.ts
+++ b/packages/core/lib/v3/types/public/api.ts
@@ -125,30 +125,15 @@ export const VertexProviderOptionsSchema = z
 
 export const ModelProviderOptionsSchema = z
   .object({
-    vertex: VertexProviderOptionsSchema.optional().meta({
+    vertex: VertexProviderOptionsSchema.meta({
       description: "Vertex AI provider-specific settings",
     }),
   })
   .strict()
   .meta({ id: "ModelProviderOptions" });
 
-const getModelConfigProvider = (model: {
-  provider?: string;
-  modelName?: string;
-}): string | undefined =>
-  model.provider ??
-  (model.modelName?.includes("/") ? model.modelName.split("/")[0] : undefined);
-
-export const ModelConfigObjectSchema = z
+const ModelConfigBaseSchema = z
   .object({
-    provider: z
-      .enum(["openai", "anthropic", "google", "microsoft", "bedrock", "vertex"])
-      .optional()
-      .meta({
-        description:
-          "AI provider for the model (or provide a baseURL endpoint instead)",
-        example: "openai",
-      }),
     modelName: z.string().meta({
       description:
         "Model name string with provider prefix (e.g., 'openai/gpt-5-nano')",
@@ -166,31 +151,49 @@ export const ModelConfigObjectSchema = z
       description:
         "Custom headers sent with every request to the model provider",
     }),
-    auth: ModelAuthSchema.optional().meta({
-      description: "Provider authentication configuration",
-    }),
-    providerOptions: ModelProviderOptionsSchema.optional().meta({
-      description: "Provider-specific model configuration",
-    }),
   })
+  .strict();
+
+export const GenericModelConfigObjectSchema = ModelConfigBaseSchema.extend({
+  provider: z
+    .enum(["openai", "anthropic", "google", "microsoft", "bedrock"])
+    .optional()
+    .meta({
+      description:
+        "AI provider for the model (or provide a baseURL endpoint instead)",
+      example: "openai",
+    }),
+})
   .strict()
+  .meta({ id: "GenericModelConfigObject" });
+
+export const VertexModelConfigObjectSchema = ModelConfigBaseSchema.extend({
+  provider: z.literal("vertex").meta({
+    description: "Vertex AI model provider",
+  }),
+  auth: ModelAuthSchema.meta({
+    description: "Vertex provider authentication configuration",
+  }),
+  providerOptions: ModelProviderOptionsSchema.meta({
+    description: "Vertex provider-specific model configuration",
+  }),
+})
+  .strict()
+  .meta({ id: "VertexModelConfigObject" });
+
+export const ModelConfigObjectSchema = z
+  .union([VertexModelConfigObjectSchema, GenericModelConfigObjectSchema])
   .superRefine((model, ctx) => {
-    const provider = getModelConfigProvider(model);
-
-    if (model.auth?.type === "googleServiceAccount" && provider !== "vertex") {
+    if (
+      model.provider === undefined &&
+      model.modelName.startsWith("vertex/") &&
+      ("auth" in model || "providerOptions" in model)
+    ) {
       ctx.addIssue({
         code: "custom",
-        path: ["auth"],
+        path: ["provider"],
         message:
-          "googleServiceAccount auth is only supported for Vertex models.",
-      });
-    }
-
-    if (model.providerOptions?.vertex && provider !== "vertex") {
-      ctx.addIssue({
-        code: "custom",
-        path: ["providerOptions", "vertex"],
-        message: "providerOptions.vertex is only supported for Vertex models.",
+          'provider: "vertex" is required when passing Vertex auth or provider options.',
       });
     }
   })
@@ -1221,6 +1224,12 @@ export const Operations = {
 // Shared types
 export type Action = z.infer<typeof ActionSchema>;
 export type ModelConfig = z.infer<typeof ModelConfigSchema>;
+export type GenericModelConfigObject = z.infer<
+  typeof GenericModelConfigObjectSchema
+>;
+export type VertexModelConfigObject = z.infer<
+  typeof VertexModelConfigObjectSchema
+>;
 export type GoogleServiceAccountCredentials = z.infer<
   typeof GoogleServiceAccountCredentialsSchema
 >;

--- a/packages/core/lib/v3/types/public/api.ts
+++ b/packages/core/lib/v3/types/public/api.ts
@@ -858,10 +858,6 @@ export const AgentExecuteResponseSchema = wrapResponse(
 
 export const NavigateOptionsSchema = z
   .object({
-    model: z.union([ModelConfigSchema, z.string()]).optional().meta({
-      description:
-        "Model configuration object or model name string used to initialize API-backed sessions before navigation",
-    }),
     referer: z.string().optional().meta({
       description: "Referer header to send with the request",
     }),

--- a/packages/core/lib/v3/types/public/api.ts
+++ b/packages/core/lib/v3/types/public/api.ts
@@ -73,9 +73,13 @@ export const GoogleServiceAccountCredentialsSchema = z
   .strict()
   .meta({ id: "GoogleServiceAccountCredentials" });
 
-export const GoogleAuthOptionsSchema = z
+export const GoogleServiceAccountAuthSchema = z
   .object({
-    credentials: GoogleServiceAccountCredentialsSchema.optional().meta({
+    type: z.literal("googleServiceAccount").meta({
+      description:
+        "Use inline Google Cloud service account credentials for provider authentication",
+    }),
+    credentials: GoogleServiceAccountCredentialsSchema.meta({
       description: "Google Cloud service account credentials",
     }),
     scopes: z
@@ -92,7 +96,48 @@ export const GoogleAuthOptionsSchema = z
     }),
   })
   .strict()
-  .meta({ id: "GoogleAuthOptions" });
+  .meta({ id: "GoogleServiceAccountAuth" });
+
+export const ModelAuthSchema = z
+  .discriminatedUnion("type", [GoogleServiceAccountAuthSchema])
+  .meta({ id: "ModelAuth" });
+
+export const VertexProviderOptionsSchema = z
+  .object({
+    project: z.string().meta({
+      description: "Google Cloud project ID for Vertex AI models",
+      example: "my-gcp-project",
+    }),
+    location: z.string().meta({
+      description: "Google Cloud location for Vertex AI models",
+      example: "us-central1",
+    }),
+    baseURL: z.string().url().optional().meta({
+      description: "Base URL for the Vertex AI provider",
+    }),
+    headers: z.record(z.string(), z.string()).optional().meta({
+      description:
+        "Custom headers sent with every request to the Vertex AI provider",
+    }),
+  })
+  .strict()
+  .meta({ id: "VertexProviderOptions" });
+
+export const ModelProviderOptionsSchema = z
+  .object({
+    vertex: VertexProviderOptionsSchema.optional().meta({
+      description: "Vertex AI provider-specific settings",
+    }),
+  })
+  .strict()
+  .meta({ id: "ModelProviderOptions" });
+
+const getModelConfigProvider = (model: {
+  provider?: string;
+  modelName?: string;
+}): string | undefined =>
+  model.provider ??
+  (model.modelName?.includes("/") ? model.modelName.split("/")[0] : undefined);
 
 export const ModelConfigObjectSchema = z
   .object({
@@ -121,18 +166,33 @@ export const ModelConfigObjectSchema = z
       description:
         "Custom headers sent with every request to the model provider",
     }),
-    project: z.string().optional().meta({
-      description: "Google Cloud project ID for Vertex AI models",
-      example: "my-gcp-project",
+    auth: ModelAuthSchema.optional().meta({
+      description: "Provider authentication configuration",
     }),
-    location: z.string().optional().meta({
-      description: "Google Cloud location for Vertex AI models",
-      example: "us-central1",
+    providerOptions: ModelProviderOptionsSchema.optional().meta({
+      description: "Provider-specific model configuration",
     }),
-    googleAuthOptions: GoogleAuthOptionsSchema.optional().meta({
-      description:
-        "google-auth-library options used to authenticate Vertex AI models",
-    }),
+  })
+  .strict()
+  .superRefine((model, ctx) => {
+    const provider = getModelConfigProvider(model);
+
+    if (model.auth?.type === "googleServiceAccount" && provider !== "vertex") {
+      ctx.addIssue({
+        code: "custom",
+        path: ["auth"],
+        message:
+          "googleServiceAccount auth is only supported for Vertex models.",
+      });
+    }
+
+    if (model.providerOptions?.vertex && provider !== "vertex") {
+      ctx.addIssue({
+        code: "custom",
+        path: ["providerOptions", "vertex"],
+        message: "providerOptions.vertex is only supported for Vertex models.",
+      });
+    }
   })
   .meta({ id: "ModelConfigObject" });
 
@@ -1161,6 +1221,15 @@ export const Operations = {
 // Shared types
 export type Action = z.infer<typeof ActionSchema>;
 export type ModelConfig = z.infer<typeof ModelConfigSchema>;
+export type GoogleServiceAccountCredentials = z.infer<
+  typeof GoogleServiceAccountCredentialsSchema
+>;
+export type GoogleServiceAccountAuth = z.infer<
+  typeof GoogleServiceAccountAuthSchema
+>;
+export type ModelAuth = z.infer<typeof ModelAuthSchema>;
+export type VertexProviderOptions = z.infer<typeof VertexProviderOptionsSchema>;
+export type ModelProviderOptions = z.infer<typeof ModelProviderOptionsSchema>;
 export type BrowserConfig = z.infer<typeof BrowserConfigSchema>;
 export type SessionIdParams = z.infer<typeof SessionIdParamsSchema>;
 

--- a/packages/core/lib/v3/types/public/api.ts
+++ b/packages/core/lib/v3/types/public/api.ts
@@ -183,20 +183,6 @@ export const VertexModelConfigObjectSchema = ModelConfigBaseSchema.extend({
 
 export const ModelConfigObjectSchema = z
   .union([VertexModelConfigObjectSchema, GenericModelConfigObjectSchema])
-  .superRefine((model, ctx) => {
-    if (
-      model.provider === undefined &&
-      model.modelName.startsWith("vertex/") &&
-      ("auth" in model || "providerOptions" in model)
-    ) {
-      ctx.addIssue({
-        code: "custom",
-        path: ["provider"],
-        message:
-          'provider: "vertex" is required when passing Vertex auth or provider options.',
-      });
-    }
-  })
   .meta({ id: "ModelConfigObject" });
 
 /** Model configuration */

--- a/packages/core/lib/v3/types/public/model.ts
+++ b/packages/core/lib/v3/types/public/model.ts
@@ -48,7 +48,7 @@ export interface VertexProviderOptions {
 }
 
 export interface ModelProviderOptions {
-  vertex?: VertexProviderOptions;
+  vertex: VertexProviderOptions;
 }
 
 export type AnthropicJsonSchemaObject = {

--- a/packages/core/lib/v3/types/public/model.ts
+++ b/packages/core/lib/v3/types/public/model.ts
@@ -1,5 +1,4 @@
 import type { ClientOptions as AnthropicClientOptionsBase } from "@anthropic-ai/sdk";
-import type { GoogleVertexProviderSettings as GoogleVertexProviderSettingsBase } from "@ai-sdk/google-vertex";
 import type {
   LanguageModelV2,
   LanguageModelV2Middleware,
@@ -31,19 +30,26 @@ export interface GoogleServiceAccountCredentials {
   universe_domain?: string;
 }
 
-export interface GoogleVertexAuthOptions {
-  credentials?: GoogleServiceAccountCredentials;
+export interface GoogleServiceAccountAuth {
+  type: "googleServiceAccount";
+  credentials: GoogleServiceAccountCredentials;
   scopes?: string | string[];
   projectId?: string;
   universeDomain?: string;
 }
 
-export type GoogleVertexProviderSettings = Pick<
-  GoogleVertexProviderSettingsBase,
-  "project" | "location" | "headers" | "baseURL"
-> & {
-  googleAuthOptions?: GoogleVertexAuthOptions;
-};
+export type ModelAuth = GoogleServiceAccountAuth;
+
+export interface VertexProviderOptions {
+  project: string;
+  location: string;
+  baseURL?: string;
+  headers?: Record<string, string>;
+}
+
+export interface ModelProviderOptions {
+  vertex?: VertexProviderOptions;
+}
 
 export type AnthropicJsonSchemaObject = {
   definitions?: {
@@ -113,13 +119,11 @@ export type ModelProvider =
  */
 export type ThinkingEffort = "none" | "low" | "medium" | "high" | "max";
 
-export type ClientOptions = (
-  | OpenAIClientOptions
-  | AnthropicClientOptions
-  | GoogleVertexProviderSettings
-) & {
+export type ClientOptions = (OpenAIClientOptions | AnthropicClientOptions) & {
   apiKey?: string;
   provider?: AgentProviderType;
+  auth?: ModelAuth;
+  providerOptions?: ModelProviderOptions;
   baseURL?: string;
   /** OpenAI organization ID */
   organization?: string;

--- a/packages/core/lib/v3/v3.ts
+++ b/packages/core/lib/v3/v3.ts
@@ -538,6 +538,26 @@ export class V3 {
     );
   }
 
+  private getApiDefaultModelConfig(): ModelConfiguration | undefined {
+    const clientOptions = Object.fromEntries(
+      Object.entries(this.modelClientOptions).filter(
+        ([key, value]) => key !== "apiKey" && value !== undefined,
+      ),
+    );
+
+    if (Object.keys(clientOptions).length === 0) {
+      return undefined;
+    }
+
+    return {
+      modelName: this.modelName,
+      ...clientOptions,
+      ...((this.modelClientOptions as { apiKey?: string }).apiKey
+        ? { apiKey: (this.modelClientOptions as { apiKey?: string }).apiKey }
+        : {}),
+    } as ModelConfiguration;
+  }
+
   private resolveLlmClient(model?: ModelConfiguration): LLMClient {
     if (!model) {
       return this.llmClient;
@@ -1043,6 +1063,7 @@ export class V3 {
             const { sessionId, available } = await this.apiClient.init({
               modelName: this.modelName,
               modelApiKey: this.modelClientOptions.apiKey,
+              defaultModelConfig: this.getApiDefaultModelConfig(),
               domSettleTimeoutMs: this.domSettleTimeoutMs,
               verbose: this.verbose,
               systemPrompt: this.opts.systemPrompt,

--- a/packages/core/tests/unit/api-client-default-model-config.test.ts
+++ b/packages/core/tests/unit/api-client-default-model-config.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { StagehandAPIClient } from "../../lib/v3/api.js";
+import type { ModelConfiguration } from "../../lib/v3/types/public/model.js";
+
+const vertexModel = {
+  provider: "vertex",
+  modelName: "vertex/gemini-2.5-flash",
+  project: "test-gcp-project",
+  location: "us-central1",
+  googleAuthOptions: {
+    credentials: {
+      client_email: "vertex@example.iam.gserviceaccount.com",
+      private_key:
+        "-----BEGIN PRIVATE KEY-----\\ntest\\n-----END PRIVATE KEY-----",
+    },
+  },
+} as unknown as ModelConfiguration;
+
+function createClientWithExecuteMock() {
+  const client = new StagehandAPIClient({
+    apiKey: "bb-test",
+    logger: vi.fn(),
+  });
+  const executeMock = vi.fn().mockResolvedValue({});
+
+  (
+    client as unknown as {
+      execute: typeof executeMock;
+    }
+  ).execute = executeMock;
+
+  return { client, executeMock };
+}
+
+describe("StagehandAPIClient default model config", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          success: true,
+          data: { sessionId: "sess-default-model", available: true },
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("sends constructor Vertex model config on navigate, act, observe, extract, and agent execute requests", async () => {
+    const { client, executeMock } = createClientWithExecuteMock();
+
+    await client.init({
+      modelName: "vertex/gemini-2.5-flash",
+      defaultModelConfig: vertexModel,
+    });
+
+    await client.goto("https://example.com");
+    await client.act({ input: "click the login button" });
+    await client.observe({ instruction: "find the login button" });
+    await client.extract({ instruction: "extract the headline" });
+    await client.agentExecute({ mode: "dom" }, "click the login button");
+
+    expect(executeMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        method: "navigate",
+        args: expect.objectContaining({
+          options: {
+            model: expect.objectContaining({
+              modelName: "vertex/gemini-2.5-flash",
+              project: "test-gcp-project",
+              location: "us-central1",
+              googleAuthOptions: expect.any(Object),
+            }),
+          },
+        }),
+      }),
+    );
+    expect(executeMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        method: "act",
+        args: expect.objectContaining({
+          options: {
+            model: expect.objectContaining({
+              modelName: "vertex/gemini-2.5-flash",
+              project: "test-gcp-project",
+              location: "us-central1",
+              googleAuthOptions: expect.any(Object),
+            }),
+          },
+        }),
+      }),
+    );
+    expect(executeMock).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        method: "observe",
+        args: expect.objectContaining({
+          options: expect.objectContaining({
+            model: expect.objectContaining({
+              modelName: "vertex/gemini-2.5-flash",
+              project: "test-gcp-project",
+              location: "us-central1",
+            }),
+          }),
+        }),
+      }),
+    );
+    expect(executeMock).toHaveBeenNthCalledWith(
+      4,
+      expect.objectContaining({
+        method: "extract",
+        args: expect.objectContaining({
+          options: expect.objectContaining({
+            model: expect.objectContaining({
+              modelName: "vertex/gemini-2.5-flash",
+              project: "test-gcp-project",
+              location: "us-central1",
+            }),
+          }),
+        }),
+      }),
+    );
+    expect(executeMock).toHaveBeenNthCalledWith(
+      5,
+      expect.objectContaining({
+        method: "agentExecute",
+        args: expect.objectContaining({
+          agentConfig: expect.objectContaining({
+            model: expect.objectContaining({
+              modelName: "vertex/gemini-2.5-flash",
+              project: "test-gcp-project",
+              location: "us-central1",
+            }),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("prefers a per-call model over the constructor default model config", async () => {
+    const { client, executeMock } = createClientWithExecuteMock();
+
+    await client.init({
+      modelName: "vertex/gemini-2.5-flash",
+      defaultModelConfig: vertexModel,
+    });
+
+    await client.act({
+      input: "click the login button",
+      options: {
+        model: {
+          modelName: "openai/gpt-4.1-mini",
+          apiKey: "sk-per-call",
+        },
+      },
+    });
+
+    expect(executeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        args: expect.objectContaining({
+          options: expect.objectContaining({
+            model: {
+              modelName: "openai/gpt-4.1-mini",
+              apiKey: "sk-per-call",
+            },
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("does not add a body model config when the constructor only provides a model API key", async () => {
+    const { client, executeMock } = createClientWithExecuteMock();
+
+    await client.init({
+      modelName: "openai/gpt-4.1-mini",
+      modelApiKey: "sk-header-only",
+    });
+
+    await client.act({ input: "click the login button" });
+
+    expect(executeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        args: expect.objectContaining({
+          options: undefined,
+        }),
+      }),
+    );
+  });
+});

--- a/packages/core/tests/unit/api-client-default-model-config.test.ts
+++ b/packages/core/tests/unit/api-client-default-model-config.test.ts
@@ -6,13 +6,18 @@ import type { ModelConfiguration } from "../../lib/v3/types/public/model.js";
 const vertexModel = {
   provider: "vertex",
   modelName: "vertex/gemini-2.5-flash",
-  project: "test-gcp-project",
-  location: "us-central1",
-  googleAuthOptions: {
+  auth: {
+    type: "googleServiceAccount",
     credentials: {
       client_email: "vertex@example.iam.gserviceaccount.com",
       private_key:
         "-----BEGIN PRIVATE KEY-----\\ntest\\n-----END PRIVATE KEY-----",
+    },
+  },
+  providerOptions: {
+    vertex: {
+      project: "test-gcp-project",
+      location: "us-central1",
     },
   },
 } as unknown as ModelConfiguration;
@@ -57,7 +62,7 @@ describe("StagehandAPIClient default model config", () => {
     vi.restoreAllMocks();
   });
 
-  it("sends constructor Vertex model config on navigate, act, observe, extract, and agent execute requests", async () => {
+  it("sends constructor Vertex model config on navigate bootstrap, act, observe, extract, and agent execute requests", async () => {
     const { client, executeMock } = createClientWithExecuteMock();
 
     await client.init({
@@ -79,9 +84,15 @@ describe("StagehandAPIClient default model config", () => {
           options: {
             model: expect.objectContaining({
               modelName: "vertex/gemini-2.5-flash",
-              project: "test-gcp-project",
-              location: "us-central1",
-              googleAuthOptions: expect.any(Object),
+              auth: expect.objectContaining({
+                type: "googleServiceAccount",
+              }),
+              providerOptions: {
+                vertex: expect.objectContaining({
+                  project: "test-gcp-project",
+                  location: "us-central1",
+                }),
+              },
             }),
           },
         }),
@@ -95,9 +106,15 @@ describe("StagehandAPIClient default model config", () => {
           options: {
             model: expect.objectContaining({
               modelName: "vertex/gemini-2.5-flash",
-              project: "test-gcp-project",
-              location: "us-central1",
-              googleAuthOptions: expect.any(Object),
+              auth: expect.objectContaining({
+                type: "googleServiceAccount",
+              }),
+              providerOptions: {
+                vertex: expect.objectContaining({
+                  project: "test-gcp-project",
+                  location: "us-central1",
+                }),
+              },
             }),
           },
         }),
@@ -111,8 +128,15 @@ describe("StagehandAPIClient default model config", () => {
           options: expect.objectContaining({
             model: expect.objectContaining({
               modelName: "vertex/gemini-2.5-flash",
-              project: "test-gcp-project",
-              location: "us-central1",
+              auth: expect.objectContaining({
+                type: "googleServiceAccount",
+              }),
+              providerOptions: {
+                vertex: expect.objectContaining({
+                  project: "test-gcp-project",
+                  location: "us-central1",
+                }),
+              },
             }),
           }),
         }),
@@ -126,8 +150,15 @@ describe("StagehandAPIClient default model config", () => {
           options: expect.objectContaining({
             model: expect.objectContaining({
               modelName: "vertex/gemini-2.5-flash",
-              project: "test-gcp-project",
-              location: "us-central1",
+              auth: expect.objectContaining({
+                type: "googleServiceAccount",
+              }),
+              providerOptions: {
+                vertex: expect.objectContaining({
+                  project: "test-gcp-project",
+                  location: "us-central1",
+                }),
+              },
             }),
           }),
         }),
@@ -141,8 +172,15 @@ describe("StagehandAPIClient default model config", () => {
           agentConfig: expect.objectContaining({
             model: expect.objectContaining({
               modelName: "vertex/gemini-2.5-flash",
-              project: "test-gcp-project",
-              location: "us-central1",
+              auth: expect.objectContaining({
+                type: "googleServiceAccount",
+              }),
+              providerOptions: {
+                vertex: expect.objectContaining({
+                  project: "test-gcp-project",
+                  location: "us-central1",
+                }),
+              },
             }),
           }),
         }),
@@ -182,6 +220,44 @@ describe("StagehandAPIClient default model config", () => {
     );
   });
 
+  it("inherits constructor Vertex auth for a same-provider string model override", async () => {
+    const { client, executeMock } = createClientWithExecuteMock();
+
+    await client.init({
+      modelName: "vertex/gemini-2.5-flash",
+      defaultModelConfig: vertexModel,
+    });
+
+    await client.observe({
+      instruction: "find the login button",
+      options: {
+        model: "vertex/gemini-2.0-flash",
+      },
+    });
+
+    expect(executeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "observe",
+        args: expect.objectContaining({
+          options: expect.objectContaining({
+            model: expect.objectContaining({
+              modelName: "vertex/gemini-2.0-flash",
+              auth: expect.objectContaining({
+                type: "googleServiceAccount",
+              }),
+              providerOptions: {
+                vertex: expect.objectContaining({
+                  project: "test-gcp-project",
+                  location: "us-central1",
+                }),
+              },
+            }),
+          }),
+        }),
+      }),
+    );
+  });
+
   it("does not treat model as a public navigate option", async () => {
     const { client, executeMock } = createClientWithExecuteMock();
 
@@ -202,6 +278,44 @@ describe("StagehandAPIClient default model config", () => {
         method: "navigate",
         args: expect.objectContaining({
           options: undefined,
+        }),
+      }),
+    );
+  });
+
+  it("keeps constructor bootstrap config when a caller passes an unsupported navigate model", async () => {
+    const { client, executeMock } = createClientWithExecuteMock();
+
+    await client.init({
+      modelName: "vertex/gemini-2.5-flash",
+      defaultModelConfig: vertexModel,
+    });
+
+    await client.goto("https://example.com", {
+      model: {
+        modelName: "openai/gpt-4o",
+        apiKey: "sk-per-call",
+      },
+    } as unknown as Parameters<StagehandAPIClient["goto"]>[1]);
+
+    expect(executeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "navigate",
+        args: expect.objectContaining({
+          options: {
+            model: expect.objectContaining({
+              modelName: "vertex/gemini-2.5-flash",
+              auth: expect.objectContaining({
+                type: "googleServiceAccount",
+              }),
+              providerOptions: {
+                vertex: expect.objectContaining({
+                  project: "test-gcp-project",
+                  location: "us-central1",
+                }),
+              },
+            }),
+          },
         }),
       }),
     );

--- a/packages/core/tests/unit/api-client-default-model-config.test.ts
+++ b/packages/core/tests/unit/api-client-default-model-config.test.ts
@@ -182,6 +182,31 @@ describe("StagehandAPIClient default model config", () => {
     );
   });
 
+  it("does not treat model as a public navigate option", async () => {
+    const { client, executeMock } = createClientWithExecuteMock();
+
+    await client.init({
+      modelName: "openai/gpt-4.1-mini",
+      modelApiKey: "sk-header-only",
+    });
+
+    await client.goto("https://example.com", {
+      model: {
+        modelName: "openai/gpt-4o",
+        apiKey: "sk-per-call",
+      },
+    } as unknown as Parameters<StagehandAPIClient["goto"]>[1]);
+
+    expect(executeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "navigate",
+        args: expect.objectContaining({
+          options: undefined,
+        }),
+      }),
+    );
+  });
+
   it("does not add a body model config when the constructor only provides a model API key", async () => {
     const { client, executeMock } = createClientWithExecuteMock();
 

--- a/packages/core/tests/unit/api-variables-schema.test.ts
+++ b/packages/core/tests/unit/api-variables-schema.test.ts
@@ -188,6 +188,33 @@ describe("API model config schemas", () => {
     }
   });
 
+  it("requires provider vertex when passing Vertex auth and provider options", () => {
+    const result = Api.ActRequestSchema.safeParse({
+      input: "click the search button",
+      options: {
+        model: {
+          modelName: "vertex/gemini-2.5-flash",
+          auth: {
+            type: "googleServiceAccount",
+            credentials: {
+              client_email: "vertex@example.iam.gserviceaccount.com",
+              private_key:
+                "-----BEGIN PRIVATE KEY-----\\ntest\\n-----END PRIVATE KEY-----",
+            },
+          },
+          providerOptions: {
+            vertex: {
+              project: "test-gcp-project",
+              location: "us-central1",
+            },
+          },
+        },
+      },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
   it("preserves Vertex auth params for agent model configs", () => {
     const result = Api.AgentExecuteRequestSchema.safeParse({
       agentConfig: {

--- a/packages/core/tests/unit/api-variables-schema.test.ts
+++ b/packages/core/tests/unit/api-variables-schema.test.ts
@@ -141,6 +141,9 @@ describe("API model config schemas", () => {
     if (typeof parsedModel !== "object" || parsedModel === null) {
       throw new Error("Expected object model config");
     }
+    if (!("auth" in parsedModel)) {
+      throw new Error("Expected Vertex auth config");
+    }
     expect(parsedModel.auth).toEqual({
       type: "googleServiceAccount",
       credentials: {
@@ -149,6 +152,40 @@ describe("API model config schemas", () => {
           "-----BEGIN PRIVATE KEY-----\\ntest\\n-----END PRIVATE KEY-----",
       },
     });
+  });
+
+  it("requires explicit Vertex provider configs to include service account auth and provider options", () => {
+    for (const model of [
+      {
+        provider: "vertex",
+        modelName: "vertex/gemini-2.5-flash",
+        providerOptions: {
+          vertex: {
+            project: "test-gcp-project",
+            location: "us-central1",
+          },
+        },
+      },
+      {
+        provider: "vertex",
+        modelName: "vertex/gemini-2.5-flash",
+        auth: {
+          type: "googleServiceAccount",
+          credentials: {
+            client_email: "vertex@example.iam.gserviceaccount.com",
+            private_key:
+              "-----BEGIN PRIVATE KEY-----\\ntest\\n-----END PRIVATE KEY-----",
+          },
+        },
+      },
+    ]) {
+      const result = Api.ActRequestSchema.safeParse({
+        input: "click the search button",
+        options: { model },
+      });
+
+      expect(result.success).toBe(false);
+    }
   });
 
   it("preserves Vertex auth params for agent model configs", () => {

--- a/packages/core/tests/unit/api-variables-schema.test.ts
+++ b/packages/core/tests/unit/api-variables-schema.test.ts
@@ -73,9 +73,8 @@ describe("API model config schemas", () => {
   const vertexModel = {
     provider: "vertex",
     modelName: "vertex/gemini-2.5-flash",
-    project: "test-gcp-project",
-    location: "us-central1",
-    googleAuthOptions: {
+    auth: {
+      type: "googleServiceAccount",
       credentials: {
         type: "service_account",
         project_id: "test-gcp-project",
@@ -88,6 +87,12 @@ describe("API model config schemas", () => {
       scopes: ["https://www.googleapis.com/auth/cloud-platform"],
       projectId: "test-gcp-project",
       universeDomain: "googleapis.com",
+    },
+    providerOptions: {
+      vertex: {
+        project: "test-gcp-project",
+        location: "us-central1",
+      },
     },
   };
 
@@ -111,13 +116,18 @@ describe("API model config schemas", () => {
         model: {
           provider: "vertex",
           modelName: "vertex/gemini-2.5-flash",
-          project: "test-gcp-project",
-          location: "us-central1",
-          googleAuthOptions: {
+          auth: {
+            type: "googleServiceAccount",
             credentials: {
               client_email: "vertex@example.iam.gserviceaccount.com",
               private_key:
                 "-----BEGIN PRIVATE KEY-----\\ntest\\n-----END PRIVATE KEY-----",
+            },
+          },
+          providerOptions: {
+            vertex: {
+              project: "test-gcp-project",
+              location: "us-central1",
             },
           },
         },
@@ -131,7 +141,8 @@ describe("API model config schemas", () => {
     if (typeof parsedModel !== "object" || parsedModel === null) {
       throw new Error("Expected object model config");
     }
-    expect(parsedModel.googleAuthOptions).toEqual({
+    expect(parsedModel.auth).toEqual({
+      type: "googleServiceAccount",
       credentials: {
         client_email: "vertex@example.iam.gserviceaccount.com",
         private_key:
@@ -158,6 +169,20 @@ describe("API model config schemas", () => {
   });
 
   it("rejects Vertex key file paths and external credential sources", () => {
+    const topLevelLegacyShape = Api.ActRequestSchema.safeParse({
+      input: "click the search button",
+      options: {
+        model: {
+          provider: "vertex",
+          modelName: "vertex/gemini-2.5-flash",
+          project: "test-gcp-project",
+          location: "us-central1",
+          googleAuthOptions: {},
+        },
+      },
+    });
+    expect(topLevelLegacyShape.success).toBe(false);
+
     for (const blockedAuthOptions of [
       { keyFilename: "/etc/passwd" },
       { keyFile: "/etc/passwd" },
@@ -169,7 +194,7 @@ describe("API model config schemas", () => {
           model: {
             provider: "vertex",
             modelName: "vertex/gemini-2.5-flash",
-            googleAuthOptions: blockedAuthOptions,
+            auth: blockedAuthOptions,
           },
         },
       });
@@ -183,7 +208,8 @@ describe("API model config schemas", () => {
         model: {
           provider: "vertex",
           modelName: "vertex/gemini-2.5-flash",
-          googleAuthOptions: {
+          auth: {
+            type: "googleServiceAccount",
             credentials: {
               type: "external_account",
               credential_source: {

--- a/packages/core/tests/unit/llm-provider.test.ts
+++ b/packages/core/tests/unit/llm-provider.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { getAISDKLanguageModel } from "../../lib/v3/llm/LLMProvider.js";
+import {
+  getAISDKLanguageModel,
+  LLMProvider,
+} from "../../lib/v3/llm/LLMProvider.js";
 
 describe("getAISDKLanguageModel", () => {
   describe("ollama provider", () => {
@@ -66,5 +69,29 @@ describe("getAISDKLanguageModel", () => {
       });
       expect(model).toBeDefined();
     });
+  });
+});
+
+describe("LLMProvider", () => {
+  it("allows Vertex models without experimental mode", () => {
+    const provider = new LLMProvider(() => {});
+
+    expect(() =>
+      provider.getClient(
+        "vertex/gemini-2.5-flash" as never,
+        {
+          project: "test-project",
+          location: "us-central1",
+          googleAuthOptions: {
+            credentials: {
+              client_email: "stagehand@example.iam.gserviceaccount.com",
+              private_key:
+                "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----\n",
+            },
+          },
+        } as never,
+        { experimental: false, disableAPI: false },
+      ),
+    ).not.toThrow();
   });
 });

--- a/packages/core/tests/unit/llm-provider.test.ts
+++ b/packages/core/tests/unit/llm-provider.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   getAISDKLanguageModel,
   LLMProvider,
+  toAISDKClientOptions,
 } from "../../lib/v3/llm/LLMProvider.js";
 
 describe("getAISDKLanguageModel", () => {
@@ -80,18 +81,58 @@ describe("LLMProvider", () => {
       provider.getClient(
         "vertex/gemini-2.5-flash" as never,
         {
-          project: "test-project",
-          location: "us-central1",
-          googleAuthOptions: {
+          auth: {
+            type: "googleServiceAccount",
             credentials: {
               client_email: "stagehand@example.iam.gserviceaccount.com",
               private_key:
                 "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----\n",
             },
           },
+          providerOptions: {
+            vertex: {
+              project: "test-project",
+              location: "us-central1",
+            },
+          },
         } as never,
         { experimental: false, disableAPI: false },
       ),
     ).not.toThrow();
+  });
+
+  it("adapts canonical Vertex auth into AI SDK googleAuthOptions", () => {
+    expect(
+      toAISDKClientOptions("vertex", {
+        auth: {
+          type: "googleServiceAccount",
+          credentials: {
+            client_email: "stagehand@example.iam.gserviceaccount.com",
+            private_key:
+              "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----\n",
+          },
+          projectId: "test-project",
+          universeDomain: "googleapis.com",
+        },
+        providerOptions: {
+          vertex: {
+            project: "test-project",
+            location: "us-central1",
+          },
+        },
+      }),
+    ).toEqual({
+      project: "test-project",
+      location: "us-central1",
+      googleAuthOptions: {
+        credentials: {
+          client_email: "stagehand@example.iam.gserviceaccount.com",
+          private_key:
+            "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----\n",
+        },
+        projectId: "test-project",
+        universeDomain: "googleapis.com",
+      },
+    });
   });
 });

--- a/packages/core/tests/unit/public-api/llm-and-agents.test.ts
+++ b/packages/core/tests/unit/public-api/llm-and-agents.test.ts
@@ -3,17 +3,21 @@ import * as Stagehand from "@browserbasehq/stagehand";
 
 describe("LLM and Agents public API types", () => {
   describe("ModelConfiguration", () => {
-    it("accepts Vertex headers in model config", () => {
-      const googleConfig = {
-        modelName: "google/gemini-3-flash-preview",
-        project: "test-project",
-        location: "global",
+    it("accepts Vertex provider options in model config", () => {
+      const vertexConfig = {
+        modelName: "vertex/gemini-3-flash-preview",
         headers: {
           "X-Goog-Priority": "high",
         },
+        providerOptions: {
+          vertex: {
+            project: "test-project",
+            location: "global",
+          },
+        },
       } satisfies Stagehand.ModelConfiguration;
 
-      void googleConfig;
+      void vertexConfig;
     });
   });
 

--- a/packages/core/tests/unit/public-api/llm-and-agents.test.ts
+++ b/packages/core/tests/unit/public-api/llm-and-agents.test.ts
@@ -5,9 +5,18 @@ describe("LLM and Agents public API types", () => {
   describe("ModelConfiguration", () => {
     it("accepts Vertex provider options in model config", () => {
       const vertexConfig = {
+        provider: "vertex",
         modelName: "vertex/gemini-3-flash-preview",
         headers: {
           "X-Goog-Priority": "high",
+        },
+        auth: {
+          type: "googleServiceAccount",
+          credentials: {
+            client_email: "vertex@example.iam.gserviceaccount.com",
+            private_key:
+              "-----BEGIN PRIVATE KEY-----\\ntest\\n-----END PRIVATE KEY-----",
+          },
         },
         providerOptions: {
           vertex: {

--- a/packages/server-v3/openapi.v3.yaml
+++ b/packages/server-v3/openapi.v3.yaml
@@ -688,6 +688,11 @@ components:
           type: array
           items:
             type: string
+        screenshot:
+          description: When true, include a screenshot of the current viewport in the
+            extraction LLM call. Defaults to false.
+          example: false
+          type: boolean
     ExtractRequest:
       type: object
       properties:
@@ -751,6 +756,16 @@ components:
           description: CSS selector to scope observation to a specific element
           example: nav
           type: string
+        ignoreSelectors:
+          description: Selectors for elements and subtrees that should be excluded from
+            observation
+          example:
+            - nav
+            - .cookie-banner
+            - "#sidebar-ads"
+          type: array
+          items:
+            type: string
     ObserveRequest:
       type: object
       properties:
@@ -968,12 +983,6 @@ components:
     NavigateOptions:
       type: object
       properties:
-        model:
-          description: Model configuration object or model name string used to initialize
-            API-backed sessions before navigation
-          anyOf:
-            - $ref: "#/components/schemas/ModelConfig"
-            - type: string
         referer:
           description: Referer header to send with the request
           type: string
@@ -1704,6 +1713,11 @@ components:
           type: array
           items:
             type: string
+        screenshot:
+          description: When true, include a screenshot of the current viewport in the
+            extraction LLM call. Defaults to false.
+          example: false
+          type: boolean
       additionalProperties: false
     ExtractResultOutput:
       type: object
@@ -1745,6 +1759,16 @@ components:
           description: CSS selector to scope observation to a specific element
           example: nav
           type: string
+        ignoreSelectors:
+          description: Selectors for elements and subtrees that should be excluded from
+            observation
+          example:
+            - nav
+            - .cookie-banner
+            - "#sidebar-ads"
+          type: array
+          items:
+            type: string
       additionalProperties: false
     ObserveResultOutput:
       type: object
@@ -1902,12 +1926,6 @@ components:
     NavigateOptionsOutput:
       type: object
       properties:
-        model:
-          description: Model configuration object or model name string used to initialize
-            API-backed sessions before navigation
-          anyOf:
-            - $ref: "#/components/schemas/ModelConfigOutput"
-            - type: string
         referer:
           description: Referer header to send with the request
           type: string

--- a/packages/server-v3/openapi.v3.yaml
+++ b/packages/server-v3/openapi.v3.yaml
@@ -202,9 +202,14 @@ components:
         - private_key
         - client_email
       additionalProperties: false
-    GoogleAuthOptions:
+    GoogleServiceAccountAuth:
       type: object
       properties:
+        type:
+          description: Use inline Google Cloud service account credentials for provider
+            authentication
+          type: string
+          const: googleServiceAccount
         credentials:
           description: Google Cloud service account credentials
           $ref: "#/components/schemas/GoogleServiceAccountCredentials"
@@ -221,6 +226,50 @@ components:
         universeDomain:
           description: Google Cloud universe domain
           type: string
+      required:
+        - type
+        - credentials
+      additionalProperties: false
+    ModelAuth:
+      oneOf:
+        - $ref: "#/components/schemas/GoogleServiceAccountAuth"
+      type: object
+      discriminator:
+        propertyName: type
+        mapping:
+          googleServiceAccount: "#/components/schemas/GoogleServiceAccountAuth"
+    VertexProviderOptions:
+      type: object
+      properties:
+        project:
+          description: Google Cloud project ID for Vertex AI models
+          example: my-gcp-project
+          type: string
+        location:
+          description: Google Cloud location for Vertex AI models
+          example: us-central1
+          type: string
+        baseURL:
+          description: Base URL for the Vertex AI provider
+          type: string
+          format: uri
+        headers:
+          description: Custom headers sent with every request to the Vertex AI provider
+          type: object
+          propertyNames:
+            type: string
+          additionalProperties:
+            type: string
+      required:
+        - project
+        - location
+      additionalProperties: false
+    ModelProviderOptions:
+      type: object
+      properties:
+        vertex:
+          description: Vertex AI provider-specific settings
+          $ref: "#/components/schemas/VertexProviderOptions"
       additionalProperties: false
     ModelConfigObject:
       type: object
@@ -256,19 +305,15 @@ components:
             type: string
           additionalProperties:
             type: string
-        project:
-          description: Google Cloud project ID for Vertex AI models
-          example: my-gcp-project
-          type: string
-        location:
-          description: Google Cloud location for Vertex AI models
-          example: us-central1
-          type: string
-        googleAuthOptions:
-          description: google-auth-library options used to authenticate Vertex AI models
-          $ref: "#/components/schemas/GoogleAuthOptions"
+        auth:
+          description: Provider authentication configuration
+          $ref: "#/components/schemas/ModelAuth"
+        providerOptions:
+          description: Provider-specific model configuration
+          $ref: "#/components/schemas/ModelProviderOptions"
       required:
         - modelName
+      additionalProperties: false
     ModelConfig:
       $ref: "#/components/schemas/ModelConfigObject"
     Action:
@@ -1319,56 +1364,6 @@ components:
         acceptDownloads:
           type: boolean
       additionalProperties: false
-    ModelConfigObjectOutput:
-      type: object
-      properties:
-        provider:
-          description: AI provider for the model (or provide a baseURL endpoint instead)
-          example: openai
-          type: string
-          enum:
-            - openai
-            - anthropic
-            - google
-            - microsoft
-            - bedrock
-            - vertex
-        modelName:
-          description: Model name string with provider prefix (e.g., 'openai/gpt-5-nano')
-          example: openai/gpt-5.4-mini
-          type: string
-        apiKey:
-          description: API key for the model provider
-          example: sk-some-openai-api-key
-          type: string
-        baseURL:
-          description: Base URL for the model provider
-          example: https://api.openai.com/v1
-          type: string
-          format: uri
-        headers:
-          description: Custom headers sent with every request to the model provider
-          type: object
-          propertyNames:
-            type: string
-          additionalProperties:
-            type: string
-        project:
-          description: Google Cloud project ID for Vertex AI models
-          example: my-gcp-project
-          type: string
-        location:
-          description: Google Cloud location for Vertex AI models
-          example: us-central1
-          type: string
-        googleAuthOptions:
-          description: google-auth-library options used to authenticate Vertex AI models
-          $ref: "#/components/schemas/GoogleAuthOptions"
-      required:
-        - modelName
-      additionalProperties: false
-    ModelConfigOutput:
-      $ref: "#/components/schemas/ModelConfigObjectOutput"
     ActionOutput:
       description: Action object returned by observe and used by act
       type: object
@@ -1633,7 +1628,7 @@ components:
           description: Model configuration object or model name string (e.g.,
             'openai/gpt-5-nano')
           anyOf:
-            - $ref: "#/components/schemas/ModelConfigOutput"
+            - $ref: "#/components/schemas/ModelConfig"
             - type: string
         variables:
           description: Variables to substitute in the action instruction. Accepts flat
@@ -1693,7 +1688,7 @@ components:
           description: Model configuration object or model name string (e.g.,
             'openai/gpt-5-nano')
           anyOf:
-            - $ref: "#/components/schemas/ModelConfigOutput"
+            - $ref: "#/components/schemas/ModelConfig"
             - type: string
         timeout:
           description: Timeout in ms for the extraction
@@ -1738,7 +1733,7 @@ components:
           description: Model configuration object or model name string (e.g.,
             'openai/gpt-5-nano')
           anyOf:
-            - $ref: "#/components/schemas/ModelConfigOutput"
+            - $ref: "#/components/schemas/ModelConfig"
             - type: string
         variables:
           description: Variables whose names are exposed to the model so observe() returns
@@ -1801,7 +1796,7 @@ components:
           description: Model configuration object or model name string (e.g.,
             'openai/gpt-5-nano')
           anyOf:
-            - $ref: "#/components/schemas/ModelConfigOutput"
+            - $ref: "#/components/schemas/ModelConfig"
             - type: string
         systemPrompt:
           description: Custom system prompt for the agent
@@ -1825,7 +1820,7 @@ components:
             agent tools). If not specified, inherits from the main model
             configuration.
           anyOf:
-            - $ref: "#/components/schemas/ModelConfigOutput"
+            - $ref: "#/components/schemas/ModelConfig"
             - type: string
       additionalProperties: false
     AgentUsageOutput:

--- a/packages/server-v3/openapi.v3.yaml
+++ b/packages/server-v3/openapi.v3.yaml
@@ -688,11 +688,6 @@ components:
           type: array
           items:
             type: string
-        screenshot:
-          description: When true, include a screenshot of the current viewport in the
-            extraction LLM call. Defaults to false.
-          example: false
-          type: boolean
     ExtractRequest:
       type: object
       properties:
@@ -756,16 +751,6 @@ components:
           description: CSS selector to scope observation to a specific element
           example: nav
           type: string
-        ignoreSelectors:
-          description: Selectors for elements and subtrees that should be excluded from
-            observation
-          example:
-            - nav
-            - .cookie-banner
-            - "#sidebar-ads"
-          type: array
-          items:
-            type: string
     ObserveRequest:
       type: object
       properties:
@@ -983,6 +968,12 @@ components:
     NavigateOptions:
       type: object
       properties:
+        model:
+          description: Model configuration object or model name string used to initialize
+            API-backed sessions before navigation
+          anyOf:
+            - $ref: "#/components/schemas/ModelConfig"
+            - type: string
         referer:
           description: Referer header to send with the request
           type: string
@@ -1713,11 +1704,6 @@ components:
           type: array
           items:
             type: string
-        screenshot:
-          description: When true, include a screenshot of the current viewport in the
-            extraction LLM call. Defaults to false.
-          example: false
-          type: boolean
       additionalProperties: false
     ExtractResultOutput:
       type: object
@@ -1759,16 +1745,6 @@ components:
           description: CSS selector to scope observation to a specific element
           example: nav
           type: string
-        ignoreSelectors:
-          description: Selectors for elements and subtrees that should be excluded from
-            observation
-          example:
-            - nav
-            - .cookie-banner
-            - "#sidebar-ads"
-          type: array
-          items:
-            type: string
       additionalProperties: false
     ObserveResultOutput:
       type: object
@@ -1926,6 +1902,12 @@ components:
     NavigateOptionsOutput:
       type: object
       properties:
+        model:
+          description: Model configuration object or model name string used to initialize
+            API-backed sessions before navigation
+          anyOf:
+            - $ref: "#/components/schemas/ModelConfigOutput"
+            - type: string
         referer:
           description: Referer header to send with the request
           type: string

--- a/packages/server-v3/openapi.v3.yaml
+++ b/packages/server-v3/openapi.v3.yaml
@@ -233,11 +233,6 @@ components:
     ModelAuth:
       oneOf:
         - $ref: "#/components/schemas/GoogleServiceAccountAuth"
-      type: object
-      discriminator:
-        propertyName: type
-        mapping:
-          googleServiceAccount: "#/components/schemas/GoogleServiceAccountAuth"
     VertexProviderOptions:
       type: object
       properties:
@@ -270,21 +265,12 @@ components:
         vertex:
           description: Vertex AI provider-specific settings
           $ref: "#/components/schemas/VertexProviderOptions"
+      required:
+        - vertex
       additionalProperties: false
-    ModelConfigObject:
+    GenericModelConfigObject:
       type: object
       properties:
-        provider:
-          description: AI provider for the model (or provide a baseURL endpoint instead)
-          example: openai
-          type: string
-          enum:
-            - openai
-            - anthropic
-            - google
-            - microsoft
-            - bedrock
-            - vertex
         modelName:
           description: Model name string with provider prefix (e.g., 'openai/gpt-5-nano')
           example: openai/gpt-5.4-mini
@@ -305,15 +291,62 @@ components:
             type: string
           additionalProperties:
             type: string
-        auth:
-          description: Provider authentication configuration
-          $ref: "#/components/schemas/ModelAuth"
-        providerOptions:
-          description: Provider-specific model configuration
-          $ref: "#/components/schemas/ModelProviderOptions"
+        provider:
+          description: AI provider for the model (or provide a baseURL endpoint instead)
+          example: openai
+          type: string
+          enum:
+            - openai
+            - anthropic
+            - google
+            - microsoft
+            - bedrock
       required:
         - modelName
       additionalProperties: false
+    VertexModelConfigObject:
+      type: object
+      properties:
+        modelName:
+          description: Model name string with provider prefix (e.g., 'openai/gpt-5-nano')
+          example: openai/gpt-5.4-mini
+          type: string
+        apiKey:
+          description: API key for the model provider
+          example: sk-some-openai-api-key
+          type: string
+        baseURL:
+          description: Base URL for the model provider
+          example: https://api.openai.com/v1
+          type: string
+          format: uri
+        headers:
+          description: Custom headers sent with every request to the model provider
+          type: object
+          propertyNames:
+            type: string
+          additionalProperties:
+            type: string
+        provider:
+          description: Vertex AI model provider
+          type: string
+          const: vertex
+        auth:
+          description: Vertex provider authentication configuration
+          $ref: "#/components/schemas/ModelAuth"
+        providerOptions:
+          description: Vertex provider-specific model configuration
+          $ref: "#/components/schemas/ModelProviderOptions"
+      required:
+        - modelName
+        - provider
+        - auth
+        - providerOptions
+      additionalProperties: false
+    ModelConfigObject:
+      anyOf:
+        - $ref: "#/components/schemas/VertexModelConfigObject"
+        - $ref: "#/components/schemas/GenericModelConfigObject"
     ModelConfig:
       $ref: "#/components/schemas/ModelConfigObject"
     Action:

--- a/packages/server-v3/scripts/gen-openapi.ts
+++ b/packages/server-v3/scripts/gen-openapi.ts
@@ -44,7 +44,10 @@ async function main() {
       LocalBrowserLaunchOptions: Api.LocalBrowserLaunchOptionsSchema,
       GoogleServiceAccountCredentials:
         Api.GoogleServiceAccountCredentialsSchema,
-      GoogleAuthOptions: Api.GoogleAuthOptionsSchema,
+      GoogleServiceAccountAuth: Api.GoogleServiceAccountAuthSchema,
+      ModelAuth: Api.ModelAuthSchema,
+      VertexProviderOptions: Api.VertexProviderOptionsSchema,
+      ModelProviderOptions: Api.ModelProviderOptionsSchema,
       ModelConfigObject: Api.ModelConfigObjectSchema,
       ModelConfig: Api.ModelConfigSchema,
       Action: Api.ActionSchema,

--- a/packages/server-v3/scripts/gen-openapi.ts
+++ b/packages/server-v3/scripts/gen-openapi.ts
@@ -48,6 +48,8 @@ async function main() {
       ModelAuth: Api.ModelAuthSchema,
       VertexProviderOptions: Api.VertexProviderOptionsSchema,
       ModelProviderOptions: Api.ModelProviderOptionsSchema,
+      GenericModelConfigObject: Api.GenericModelConfigObjectSchema,
+      VertexModelConfigObject: Api.VertexModelConfigObjectSchema,
       ModelConfigObject: Api.ModelConfigObjectSchema,
       ModelConfig: Api.ModelConfigSchema,
       Action: Api.ActionSchema,

--- a/packages/server-v3/src/lib/InMemorySessionStore.ts
+++ b/packages/server-v3/src/lib/InMemorySessionStore.ts
@@ -208,10 +208,17 @@ export class InMemorySessionStore implements SessionStore {
 
     const options: V3Options = {
       env: isBrowserbase ? "BROWSERBASE" : "LOCAL",
-      model: {
-        modelName: params.modelName,
-        apiKey: ctx.modelApiKey,
-      },
+      model: ctx.requestModelConfig
+        ? {
+            ...ctx.requestModelConfig,
+            ...(ctx.requestModelConfig.apiKey
+              ? {}
+              : { apiKey: ctx.modelApiKey }),
+          }
+        : {
+            modelName: params.modelName,
+            apiKey: ctx.modelApiKey,
+          },
       verbose: params.verbose,
       systemPrompt: params.systemPrompt,
       selfHeal: params.selfHeal,

--- a/packages/server-v3/src/lib/SessionStore.ts
+++ b/packages/server-v3/src/lib/SessionStore.ts
@@ -67,6 +67,8 @@ export interface CreateSessionParams {
 export interface RequestContext {
   /** Model API key (from x-model-api-key header) */
   modelApiKey?: string;
+  /** Structured model config from the current request body */
+  requestModelConfig?: Api.ModelConfig;
   /** Logger function for this request */
   logger?: (message: LogLine) => void;
 }

--- a/packages/server-v3/src/lib/header.ts
+++ b/packages/server-v3/src/lib/header.ts
@@ -77,13 +77,12 @@ const normalizeModel = (
  *
  * V3:
  * - act/observe/extract: body.options.model
- * - agentExecute: body.agentConfig.model
  */
 export function getRequestModelConfig(
   request: FastifyRequest,
 ): RequestModelConfig {
   const body = requestModelEnvelopeSchema.parse(request.body ?? {});
-  const model = normalizeModel(body.options?.model ?? body.agentConfig?.model);
+  const model = normalizeModel(body.options?.model);
 
   return requestModelConfigSchema.parse({
     model,
@@ -91,6 +90,31 @@ export function getRequestModelConfig(
     apiKey:
       getNonEmptyString(model?.apiKey) ??
       getOptionalHeader(request, "x-model-api-key"),
+  });
+}
+
+/**
+ * Extracts the structured model config that can be used to initialize a
+ * Stagehand session for this request. Unlike getRequestModelConfig, this may
+ * read agentConfig.model, but it does not promote agent model credentials to
+ * the request-level API key.
+ */
+export function getSessionBootstrapModelConfig(
+  request: FastifyRequest,
+): RequestModelConfig {
+  const requestModelConfig = getRequestModelConfig(request);
+  if (requestModelConfig.model) {
+    return requestModelConfig;
+  }
+
+  const body = requestModelEnvelopeSchema.parse(request.body ?? {});
+  const agentModel = normalizeModel(body.agentConfig?.model);
+
+  return requestModelConfigSchema.parse({
+    model: agentModel,
+    modelName:
+      getNonEmptyString(agentModel?.modelName) ?? requestModelConfig.modelName,
+    apiKey: requestModelConfig.apiKey,
   });
 }
 

--- a/packages/server-v3/src/lib/header.ts
+++ b/packages/server-v3/src/lib/header.ts
@@ -41,81 +41,134 @@ export const getOptionalHeader = (
   return headerValue;
 };
 
-const requestModelSchema = z.union([Api.ModelConfigSchema, z.string()]);
+const emptyStringSchema = z.literal("").transform((): undefined => undefined);
+const requiredStringSchema = z.string().min(1);
+const optionalStringSchema = z
+  .union([emptyStringSchema, z.string()])
+  .optional();
+
+const requestModelInputSchema = z
+  .union([
+    emptyStringSchema,
+    requiredStringSchema.transform(
+      (modelName): Api.ModelConfig => ({ modelName }),
+    ),
+    Api.ModelConfigSchema,
+  ])
+  .optional();
 const requestModelCarrierSchema = z
   .object({
-    model: requestModelSchema.optional(),
+    model: requestModelInputSchema,
+  })
+  .passthrough();
+const unparsedModelCarrierSchema = z
+  .object({
+    model: z.unknown().optional(),
   })
   .passthrough();
 const requestModelEnvelopeSchema = z
   .object({
     options: requestModelCarrierSchema.optional(),
+    agentConfig: unparsedModelCarrierSchema.optional(),
+    modelName: optionalStringSchema,
+  })
+  .passthrough();
+const stagehandInitModelEnvelopeSchema = z
+  .object({
+    options: requestModelCarrierSchema.optional(),
     agentConfig: requestModelCarrierSchema.optional(),
-    modelName: z.string().optional(),
+    modelName: optionalStringSchema,
   })
   .passthrough();
 const requestModelConfigSchema = z
   .object({
     model: Api.ModelConfigSchema.optional(),
-    modelName: z.string().optional(),
-    apiKey: z.string().optional(),
+    modelName: optionalStringSchema,
+    apiKey: optionalStringSchema,
   })
   .strict();
 
 export type RequestModelConfig = z.infer<typeof requestModelConfigSchema>;
-
-const getNonEmptyString = (value?: string): string | undefined =>
-  value ? value : undefined;
-
-const normalizeModel = (
-  model: z.infer<typeof requestModelSchema> | undefined,
-): Api.ModelConfig | undefined =>
-  typeof model === "string" ? { modelName: model } : model;
+type RequestModelConfigResult =
+  | { success: true; data: RequestModelConfig }
+  | { success: false; error: z.ZodError };
 
 /**
- * Extracts model config from request body.
+ * Extracts request-level model config with precedence.
  *
- * V3:
- * - act/observe/extract: body.options.model
+ * Model name:
+ * 1. body.options.model.modelName or body.options.model string
+ * 2. Legacy body.modelName fallback
+ *
+ * API key:
+ * 1. body.options.model.apiKey
+ * 2. x-model-api-key header
+ *
+ * agentConfig.model is parsed separately for Stagehand initialization. Its
+ * credentials are scoped to the agent main model and must not become the
+ * request-level API key fallback used by action/execution models.
  */
 export function getRequestModelConfig(
   request: FastifyRequest,
-): RequestModelConfig {
-  const body = requestModelEnvelopeSchema.parse(request.body ?? {});
-  const model = normalizeModel(body.options?.model);
+): RequestModelConfigResult {
+  const bodyResult = requestModelEnvelopeSchema.safeParse(request.body ?? {});
+  if (!bodyResult.success) {
+    return bodyResult;
+  }
 
-  return requestModelConfigSchema.parse({
+  const body = bodyResult.data;
+  const model = body.options?.model;
+  const configResult = requestModelConfigSchema.safeParse({
     model,
-    modelName: getNonEmptyString(model?.modelName) ?? body.modelName,
-    apiKey:
-      getNonEmptyString(model?.apiKey) ??
-      getOptionalHeader(request, "x-model-api-key"),
+    modelName: model?.modelName ?? body.modelName,
+    apiKey: model?.apiKey ?? getOptionalHeader(request, "x-model-api-key"),
   });
+  if (!configResult.success) {
+    return configResult;
+  }
+
+  return configResult;
 }
 
 /**
- * Extracts the structured model config that can be used to initialize a
- * Stagehand session for this request. Unlike getRequestModelConfig, this may
- * read agentConfig.model, but it does not promote agent model credentials to
- * the request-level API key.
+ * Extracts the structured model config used when creating a Stagehand instance
+ * for this request. This can read agentConfig.model for agentExecute startup,
+ * but it does not promote agent model credentials to the request-level API key.
  */
-export function getSessionBootstrapModelConfig(
+export function getStagehandInitModelConfig(
   request: FastifyRequest,
-): RequestModelConfig {
-  const requestModelConfig = getRequestModelConfig(request);
-  if (requestModelConfig.model) {
-    return requestModelConfig;
+  requestModelConfig?: RequestModelConfig,
+): RequestModelConfigResult {
+  const baseConfigResult = requestModelConfig
+    ? requestModelConfigSchema.safeParse(requestModelConfig)
+    : getRequestModelConfig(request);
+  if (!baseConfigResult.success) {
+    return baseConfigResult;
   }
 
-  const body = requestModelEnvelopeSchema.parse(request.body ?? {});
-  const agentModel = normalizeModel(body.agentConfig?.model);
+  const baseConfig = baseConfigResult.data;
+  if (baseConfig.model) {
+    return baseConfigResult;
+  }
 
-  return requestModelConfigSchema.parse({
+  const bodyResult = stagehandInitModelEnvelopeSchema.safeParse(
+    request.body ?? {},
+  );
+  if (!bodyResult.success) {
+    return bodyResult;
+  }
+
+  const agentModel = bodyResult.data.agentConfig?.model;
+  const configResult = requestModelConfigSchema.safeParse({
     model: agentModel,
-    modelName:
-      getNonEmptyString(agentModel?.modelName) ?? requestModelConfig.modelName,
-    apiKey: requestModelConfig.apiKey,
+    modelName: agentModel?.modelName ?? baseConfig.modelName,
+    apiKey: baseConfig.apiKey,
   });
+  if (!configResult.success) {
+    return configResult;
+  }
+
+  return configResult;
 }
 
 /**

--- a/packages/server-v3/src/lib/header.ts
+++ b/packages/server-v3/src/lib/header.ts
@@ -1,4 +1,6 @@
 import type { FastifyRequest } from "fastify";
+import { Api } from "@browserbasehq/stagehand";
+import { z } from "zod/v4";
 
 import { MissingHeaderError } from "../types/error.js";
 
@@ -39,41 +41,57 @@ export const getOptionalHeader = (
   return headerValue;
 };
 
+const requestModelSchema = z.union([Api.ModelConfigSchema, z.string()]);
+const requestModelCarrierSchema = z
+  .object({
+    model: requestModelSchema.optional(),
+  })
+  .passthrough();
+const requestModelEnvelopeSchema = z
+  .object({
+    options: requestModelCarrierSchema.optional(),
+    agentConfig: requestModelCarrierSchema.optional(),
+    modelName: z.string().optional(),
+  })
+  .passthrough();
+const requestModelConfigSchema = z
+  .object({
+    model: Api.ModelConfigSchema.optional(),
+    modelName: z.string().optional(),
+    apiKey: z.string().optional(),
+  })
+  .strict();
+
+export type RequestModelConfig = z.infer<typeof requestModelConfigSchema>;
+
+const getNonEmptyString = (value?: string): string | undefined =>
+  value ? value : undefined;
+
+const normalizeModel = (
+  model: z.infer<typeof requestModelSchema> | undefined,
+): Api.ModelConfig | undefined =>
+  typeof model === "string" ? { modelName: model } : model;
+
 /**
- * Extracts model name from request body, supporting V3 structure.
- * - V3: body.options.model.modelName
+ * Extracts model config from request body.
+ *
+ * V3:
+ * - act/observe/extract: body.options.model
+ * - agentExecute: body.agentConfig.model
  */
-export function getModelName(request: FastifyRequest): string | undefined {
-  const body = request.body as Record<string, unknown> | undefined;
-  const options = body?.options as Record<string, unknown> | undefined;
-  const model = options?.model as Record<string, unknown> | undefined;
+export function getRequestModelConfig(
+  request: FastifyRequest,
+): RequestModelConfig {
+  const body = requestModelEnvelopeSchema.parse(request.body ?? {});
+  const model = normalizeModel(body.options?.model ?? body.agentConfig?.model);
 
-  if (typeof model?.modelName === "string" && model.modelName) {
-    return model.modelName;
-  }
-
-  if (typeof body?.modelName === "string" && body.modelName) {
-    return body.modelName;
-  }
-
-  return undefined;
-}
-
-/**
- * Extracts the model API key with precedence:
- * 1. Per-request body apiKey (V3: body.options.model.apiKey)
- * 2. Per-request header x-model-api-key
- */
-export function getModelApiKey(request: FastifyRequest): string | undefined {
-  const body = request.body as Record<string, unknown> | undefined;
-  const options = body?.options as Record<string, unknown> | undefined;
-  const model = options?.model as Record<string, unknown> | undefined;
-
-  if (typeof model?.apiKey === "string" && model.apiKey) {
-    return model.apiKey;
-  }
-
-  return getOptionalHeader(request, "x-model-api-key");
+  return requestModelConfigSchema.parse({
+    model,
+    modelName: getNonEmptyString(model?.modelName) ?? body.modelName,
+    apiKey:
+      getNonEmptyString(model?.apiKey) ??
+      getOptionalHeader(request, "x-model-api-key"),
+  });
 }
 
 /**

--- a/packages/server-v3/src/lib/stream.ts
+++ b/packages/server-v3/src/lib/stream.ts
@@ -8,8 +8,9 @@ import { AppError } from "./errorHandler.js";
 import {
   getOptionalHeader,
   getRequestModelConfig,
-  getSessionBootstrapModelConfig,
+  getStagehandInitModelConfig,
   shouldRespondWithSSE,
+  type RequestModelConfig,
 } from "./header.js";
 import { error, success } from "./response.js";
 import { getSessionStore } from "./sessionStoreManager.js";
@@ -34,6 +35,13 @@ type StreamEventName =
   | "finished"
   | "error";
 type StreamPayloadType = "system" | "log";
+
+function formatZodIssues(err: z.ZodError) {
+  return err.issues.map((issue) => ({
+    path: issue.path[0] ?? "unknown",
+    message: issue.message,
+  }));
+}
 
 export async function createStreamingResponse<TV3>({
   sessionId,
@@ -126,19 +134,45 @@ export async function createStreamingResponse<TV3>({
   const actionId = v4();
 
   sendData("starting", "system", { status: "starting" });
-  const requestModelConfig = getRequestModelConfig(request);
-  const bootstrapModelConfig = getSessionBootstrapModelConfig(request);
+  const sendZodValidationError = (err: z.ZodError) => {
+    const validationIssues = formatZodIssues(err);
+    if (shouldStreamResponse) {
+      sendData("error", "system", {
+        status: "error",
+        error: validationIssues,
+      });
+      reply.raw.end();
+      return reply;
+    }
+
+    return reply.status(StatusCodes.BAD_REQUEST).send({
+      error: validationIssues,
+    });
+  };
+
+  const requestModelConfigResult = getRequestModelConfig(request);
+  if (requestModelConfigResult.success === false) {
+    return sendZodValidationError(requestModelConfigResult.error);
+  }
+
+  const requestModelConfig: RequestModelConfig = requestModelConfigResult.data;
+  const stagehandInitModelConfigResult = getStagehandInitModelConfig(
+    request,
+    requestModelConfig,
+  );
+  if (stagehandInitModelConfigResult.success === false) {
+    return sendZodValidationError(stagehandInitModelConfigResult.error);
+  }
+
+  const stagehandInitModelConfig = stagehandInitModelConfigResult.data;
   const modelApiKey = requestModelConfig.apiKey;
+  const parsedRequestModelConfig = stagehandInitModelConfig.model?.modelName
+    ? stagehandInitModelConfig.model
+    : undefined;
 
   const requestContext: RequestContext = {
     modelApiKey,
-    requestModelConfig:
-      bootstrapModelConfig.model && bootstrapModelConfig.modelName
-        ? {
-            ...bootstrapModelConfig.model,
-            modelName: bootstrapModelConfig.modelName,
-          }
-        : undefined,
+    requestModelConfig: parsedRequestModelConfig,
     logger: shouldStreamResponse
       ? (message) => {
           sendData("running", "log", { status: "running", message });

--- a/packages/server-v3/src/lib/stream.ts
+++ b/packages/server-v3/src/lib/stream.ts
@@ -6,9 +6,8 @@ import { z } from "zod/v4";
 
 import { AppError } from "./errorHandler.js";
 import {
-  getModelApiKey,
-  getModelName,
   getOptionalHeader,
+  getRequestModelConfig,
   shouldRespondWithSSE,
 } from "./header.js";
 import { error, success } from "./response.js";
@@ -44,7 +43,6 @@ export async function createStreamingResponse<TV3>({
   operation,
 }: StreamingResponseOptions<TV3>) {
   const shouldStreamResponse = shouldRespondWithSSE(request);
-  const modelApiKey = getModelApiKey(request);
 
   const sessionStore = getSessionStore();
   const sessionConfig = await sessionStore.getSessionConfig(sessionId);
@@ -127,9 +125,18 @@ export async function createStreamingResponse<TV3>({
   const actionId = v4();
 
   sendData("starting", "system", { status: "starting" });
+  const requestModelConfig = getRequestModelConfig(request);
+  const modelApiKey = requestModelConfig.apiKey;
 
   const requestContext: RequestContext = {
     modelApiKey,
+    requestModelConfig:
+      requestModelConfig.model && requestModelConfig.modelName
+        ? {
+            ...requestModelConfig.model,
+            modelName: requestModelConfig.modelName,
+          }
+        : undefined,
     logger: shouldStreamResponse
       ? (message) => {
           sendData("running", "log", { status: "running", message });
@@ -177,7 +184,7 @@ export async function createStreamingResponse<TV3>({
         operation: operation ?? "operation",
         sessionId,
         browserType,
-        modelName: getModelName(request),
+        modelName: requestModelConfig.modelName,
         hasModelApiKey: Boolean(modelApiKey),
         hasBrowserbaseApiKey: Boolean(browserbaseApiKey),
         hasBrowserbaseProjectId: Boolean(browserbaseProjectId),

--- a/packages/server-v3/src/lib/stream.ts
+++ b/packages/server-v3/src/lib/stream.ts
@@ -8,6 +8,7 @@ import { AppError } from "./errorHandler.js";
 import {
   getOptionalHeader,
   getRequestModelConfig,
+  getSessionBootstrapModelConfig,
   shouldRespondWithSSE,
 } from "./header.js";
 import { error, success } from "./response.js";
@@ -126,15 +127,16 @@ export async function createStreamingResponse<TV3>({
 
   sendData("starting", "system", { status: "starting" });
   const requestModelConfig = getRequestModelConfig(request);
+  const bootstrapModelConfig = getSessionBootstrapModelConfig(request);
   const modelApiKey = requestModelConfig.apiKey;
 
   const requestContext: RequestContext = {
     modelApiKey,
     requestModelConfig:
-      requestModelConfig.model && requestModelConfig.modelName
+      bootstrapModelConfig.model && bootstrapModelConfig.modelName
         ? {
-            ...requestModelConfig.model,
-            modelName: requestModelConfig.modelName,
+            ...bootstrapModelConfig.model,
+            modelName: bootstrapModelConfig.modelName,
           }
         : undefined,
     logger: shouldStreamResponse

--- a/packages/server-v3/src/routes/v1/sessions/_id/navigate.ts
+++ b/packages/server-v3/src/routes/v1/sessions/_id/navigate.ts
@@ -47,6 +47,7 @@ const navigateRouteHandler: RouteHandlerMethod = withErrorHandling(
         }
 
         const { timeout, ...restOptions } = data.options ?? {};
+        delete restOptions.model;
         const gotoOptions = {
           ...restOptions,
           ...(timeout === undefined ? {} : { timeoutMs: timeout }),

--- a/packages/server-v3/src/routes/v1/sessions/_id/navigate.ts
+++ b/packages/server-v3/src/routes/v1/sessions/_id/navigate.ts
@@ -47,7 +47,6 @@ const navigateRouteHandler: RouteHandlerMethod = withErrorHandling(
         }
 
         const { timeout, ...restOptions } = data.options ?? {};
-        delete restOptions.model;
         const gotoOptions = {
           ...restOptions,
           ...(timeout === undefined ? {} : { timeoutMs: timeout }),

--- a/packages/server-v3/src/routes/v1/sessions/start.ts
+++ b/packages/server-v3/src/routes/v1/sessions/start.ts
@@ -113,11 +113,30 @@ const startRouteHandler: RouteHandler = withErrorHandling(
     }
 
     const browserType = browser?.type ?? "browserbase";
+    const localBrowserLaunchOptions =
+      browserType === "local" && browser?.launchOptions && !browser?.cdpUrl
+        ? browser.launchOptions
+        : undefined;
 
     let bbApiKey: string | undefined;
     let browserbaseProjectId: string | undefined;
     let browserbaseSessionId: string | undefined;
     let connectUrl: string | undefined;
+    let localBrowserModelApiKey: string | undefined;
+
+    if (localBrowserLaunchOptions) {
+      const requestModelConfigResult = getRequestModelConfig(request);
+      if (requestModelConfigResult.success === false) {
+        return reply.status(StatusCodes.BAD_REQUEST).send({
+          error: requestModelConfigResult.error.issues.map((issue) => ({
+            path: issue.path[0] ?? "unknown",
+            message: issue.message,
+          })),
+        });
+      }
+
+      localBrowserModelApiKey = requestModelConfigResult.data.apiKey;
+    }
 
     if (browserType === "browserbase") {
       bbApiKey = getOptionalHeader(request, "x-bb-api-key");
@@ -213,22 +232,11 @@ const startRouteHandler: RouteHandler = withErrorHandling(
     // For local browsers with launchOptions (no explicit cdpUrl), eagerly
     // initialize the browser so we can return the actual CDP URL
     let finalCdpUrl = connectUrl ?? session.cdpUrl ?? "";
-    if (browserType === "local" && browser?.launchOptions && !browser?.cdpUrl) {
-      const requestModelConfigResult = getRequestModelConfig(request);
-      if (requestModelConfigResult.success === false) {
-        return reply.status(StatusCodes.BAD_REQUEST).send({
-          error: requestModelConfigResult.error.issues.map((issue) => ({
-            path: issue.path[0] ?? "unknown",
-            message: issue.message,
-          })),
-        });
-      }
-
-      const modelApiKey = requestModelConfigResult.data.apiKey;
+    if (localBrowserLaunchOptions) {
       try {
         const stagehand = await sessionStore.getOrCreateStagehand(
           session.sessionId,
-          { modelApiKey },
+          { modelApiKey: localBrowserModelApiKey },
         );
         finalCdpUrl = stagehand.connectURL();
       } catch (err) {
@@ -239,12 +247,12 @@ const startRouteHandler: RouteHandler = withErrorHandling(
             browserType,
             chromePathEnv: process.env.CHROME_PATH,
             launchOptions: {
-              executablePath: browser.launchOptions.executablePath,
-              argsCount: browser.launchOptions.args?.length ?? 0,
-              headless: browser.launchOptions.headless,
-              hasUserDataDir: Boolean(browser.launchOptions.userDataDir),
-              port: browser.launchOptions.port,
-              connectTimeoutMs: browser.launchOptions.connectTimeoutMs,
+              executablePath: localBrowserLaunchOptions.executablePath,
+              argsCount: localBrowserLaunchOptions.args?.length ?? 0,
+              headless: localBrowserLaunchOptions.headless,
+              hasUserDataDir: Boolean(localBrowserLaunchOptions.userDataDir),
+              port: localBrowserLaunchOptions.port,
+              connectTimeoutMs: localBrowserLaunchOptions.connectTimeoutMs,
             },
           },
           "Failed to initialize local browser session in /v1/sessions/start",

--- a/packages/server-v3/src/routes/v1/sessions/start.ts
+++ b/packages/server-v3/src/routes/v1/sessions/start.ts
@@ -214,7 +214,17 @@ const startRouteHandler: RouteHandler = withErrorHandling(
     // initialize the browser so we can return the actual CDP URL
     let finalCdpUrl = connectUrl ?? session.cdpUrl ?? "";
     if (browserType === "local" && browser?.launchOptions && !browser?.cdpUrl) {
-      const modelApiKey = getRequestModelConfig(request).apiKey;
+      const requestModelConfigResult = getRequestModelConfig(request);
+      if (requestModelConfigResult.success === false) {
+        return reply.status(StatusCodes.BAD_REQUEST).send({
+          error: requestModelConfigResult.error.issues.map((issue) => ({
+            path: issue.path[0] ?? "unknown",
+            message: issue.message,
+          })),
+        });
+      }
+
+      const modelApiKey = requestModelConfigResult.data.apiKey;
       try {
         const stagehand = await sessionStore.getOrCreateStagehand(
           session.sessionId,

--- a/packages/server-v3/src/routes/v1/sessions/start.ts
+++ b/packages/server-v3/src/routes/v1/sessions/start.ts
@@ -8,7 +8,10 @@ import { z } from "zod/v4";
 
 import { authMiddleware } from "../../../lib/auth.js";
 import { withErrorHandling } from "../../../lib/errorHandler.js";
-import { getModelApiKey, getOptionalHeader } from "../../../lib/header.js";
+import {
+  getOptionalHeader,
+  getRequestModelConfig,
+} from "../../../lib/header.js";
 import { error, success } from "../../../lib/response.js";
 import { getSessionStore } from "../../../lib/sessionStoreManager.js";
 import { AISDK_PROVIDERS } from "../../../types/model.js";
@@ -211,7 +214,7 @@ const startRouteHandler: RouteHandler = withErrorHandling(
     // initialize the browser so we can return the actual CDP URL
     let finalCdpUrl = connectUrl ?? session.cdpUrl ?? "";
     if (browserType === "local" && browser?.launchOptions && !browser?.cdpUrl) {
-      const modelApiKey = getModelApiKey(request);
+      const modelApiKey = getRequestModelConfig(request).apiKey;
       try {
         const stagehand = await sessionStore.getOrCreateStagehand(
           session.sessionId,

--- a/packages/server-v3/tests/unit/requestModelConfig.test.ts
+++ b/packages/server-v3/tests/unit/requestModelConfig.test.ts
@@ -5,7 +5,8 @@ import type { FastifyRequest } from "fastify";
 
 import {
   getRequestModelConfig,
-  getSessionBootstrapModelConfig,
+  getStagehandInitModelConfig,
+  type RequestModelConfig,
 } from "../../src/lib/header.js";
 
 function createRequest({
@@ -19,6 +20,16 @@ function createRequest({
     body,
     headers,
   } as FastifyRequest;
+}
+
+function assertSuccess(
+  result: ReturnType<typeof getRequestModelConfig>,
+): RequestModelConfig {
+  if (result.success === false) {
+    throw result.error;
+  }
+  assert.equal(result.success, true);
+  return result.data;
 }
 
 describe("getRequestModelConfig", () => {
@@ -50,7 +61,7 @@ describe("getRequestModelConfig", () => {
       },
     });
 
-    const config = getRequestModelConfig(request);
+    const config = assertSuccess(getRequestModelConfig(request));
 
     assert.equal(config.modelName, "vertex/gemini-2.5-flash");
     assert.equal(config.apiKey, "sk-header");
@@ -64,7 +75,7 @@ describe("getRequestModelConfig", () => {
       },
     });
 
-    assert.deepEqual(getRequestModelConfig(request), {
+    assert.deepEqual(assertSuccess(getRequestModelConfig(request)), {
       model: undefined,
       modelName: undefined,
       apiKey: undefined,
@@ -78,10 +89,32 @@ describe("getRequestModelConfig", () => {
       },
     });
 
-    assert.deepEqual(getSessionBootstrapModelConfig(request), {
+    assert.deepEqual(assertSuccess(getStagehandInitModelConfig(request)), {
       model: { modelName: "google/gemini-2.5-flash" },
       modelName: "google/gemini-2.5-flash",
       apiKey: undefined,
     });
+  });
+
+  it("returns a validation result instead of throwing when agent bootstrap model config is invalid", () => {
+    const request = createRequest({
+      body: {
+        agentConfig: {
+          model: {
+            provider: "vertex",
+            modelName: "vertex/gemini-2.5-flash",
+          },
+        },
+      },
+    });
+
+    assert.deepEqual(assertSuccess(getRequestModelConfig(request)), {
+      model: undefined,
+      modelName: undefined,
+      apiKey: undefined,
+    });
+
+    const result = getStagehandInitModelConfig(request);
+    assert.equal(result.success, false);
   });
 });

--- a/packages/server-v3/tests/unit/requestModelConfig.test.ts
+++ b/packages/server-v3/tests/unit/requestModelConfig.test.ts
@@ -3,7 +3,10 @@ import { describe, it } from "node:test";
 
 import type { FastifyRequest } from "fastify";
 
-import { getRequestModelConfig } from "../../src/lib/header.js";
+import {
+  getRequestModelConfig,
+  getSessionBootstrapModelConfig,
+} from "../../src/lib/header.js";
 
 function createRequest({
   body,
@@ -23,13 +26,18 @@ describe("getRequestModelConfig", () => {
     const model = {
       provider: "vertex",
       modelName: "vertex/gemini-2.5-flash",
-      project: "test-gcp-project",
-      location: "us-central1",
-      googleAuthOptions: {
+      auth: {
+        type: "googleServiceAccount",
         credentials: {
           client_email: "vertex@example.iam.gserviceaccount.com",
           private_key:
             "-----BEGIN PRIVATE KEY-----\\ntest\\n-----END PRIVATE KEY-----",
+        },
+      },
+      providerOptions: {
+        vertex: {
+          project: "test-gcp-project",
+          location: "us-central1",
         },
       },
     };
@@ -49,7 +57,7 @@ describe("getRequestModelConfig", () => {
     assert.deepEqual(config.model, model);
   });
 
-  it("normalizes an agent string model into request model config for local server session bootstrap", () => {
+  it("does not read agentConfig.model as a request-level model config", () => {
     const request = createRequest({
       body: {
         agentConfig: { model: "google/gemini-2.5-flash" },
@@ -57,6 +65,20 @@ describe("getRequestModelConfig", () => {
     });
 
     assert.deepEqual(getRequestModelConfig(request), {
+      model: undefined,
+      modelName: undefined,
+      apiKey: undefined,
+    });
+  });
+
+  it("normalizes an agent string model into the session bootstrap model config", () => {
+    const request = createRequest({
+      body: {
+        agentConfig: { model: "google/gemini-2.5-flash" },
+      },
+    });
+
+    assert.deepEqual(getSessionBootstrapModelConfig(request), {
       model: { modelName: "google/gemini-2.5-flash" },
       modelName: "google/gemini-2.5-flash",
       apiKey: undefined,

--- a/packages/server-v3/tests/unit/requestModelConfig.test.ts
+++ b/packages/server-v3/tests/unit/requestModelConfig.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import type { FastifyRequest } from "fastify";
+
+import { getRequestModelConfig } from "../../src/lib/header.js";
+
+function createRequest({
+  body,
+  headers = {},
+}: {
+  body?: Record<string, unknown>;
+  headers?: Record<string, string>;
+}): FastifyRequest {
+  return {
+    body,
+    headers,
+  } as FastifyRequest;
+}
+
+describe("getRequestModelConfig", () => {
+  it("preserves a Vertex model config from an action request so auth fields reach session initialization", () => {
+    const model = {
+      provider: "vertex",
+      modelName: "vertex/gemini-2.5-flash",
+      project: "test-gcp-project",
+      location: "us-central1",
+      googleAuthOptions: {
+        credentials: {
+          client_email: "vertex@example.iam.gserviceaccount.com",
+          private_key:
+            "-----BEGIN PRIVATE KEY-----\\ntest\\n-----END PRIVATE KEY-----",
+        },
+      },
+    };
+    const request = createRequest({
+      body: {
+        options: { model },
+      },
+      headers: {
+        "x-model-api-key": "sk-header",
+      },
+    });
+
+    const config = getRequestModelConfig(request);
+
+    assert.equal(config.modelName, "vertex/gemini-2.5-flash");
+    assert.equal(config.apiKey, "sk-header");
+    assert.deepEqual(config.model, model);
+  });
+
+  it("normalizes an agent string model into request model config for local server session bootstrap", () => {
+    const request = createRequest({
+      body: {
+        agentConfig: { model: "google/gemini-2.5-flash" },
+      },
+    });
+
+    assert.deepEqual(getRequestModelConfig(request), {
+      model: { modelName: "google/gemini-2.5-flash" },
+      modelName: "google/gemini-2.5-flash",
+      apiKey: undefined,
+    });
+  });
+});


### PR DESCRIPTION
## Why
Vertex model credentials need a typed public shape and must be forwarded from the TypeScript client to API-backed Stagehand requests without persisting secrets server-side.

## What changed
- Define a canonical Vertex model config shape using `provider: "vertex"`, `auth`, and `providerOptions.vertex`, while preserving existing generic model string/object support.
- Forward constructor model config through API-backed act/observe/extract/agentExecute requests, with per-call model config still taking precedence.
- Keep navigate/goto from exposing a public per-call model option, while still allowing constructor config to bootstrap API-backed sessions internally.
- Sync server-v3 request parsing with the hosted API approach: Zod-first safe parsing, separate request model config from Stagehand init model config, and clean SSE validation errors.
- Regenerate server-v3 OpenAPI from the Stagehand Zod source so Stainless can pick up the canonical shape.

TODO before final hosted API merge: swap core to the Orca build produced from this Stagehand change.