### PR TITLE
feat(eval): add clawbench as a evaluation benchmark

### DIFF
--- a/.changeset/spicy-teams-follow.md
+++ b/.changeset/spicy-teams-follow.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand-evals": minor
+---
+
+Adds ClawBench as a evaluation benchmark option

--- a/packages/evals/README.md
+++ b/packages/evals/README.md
@@ -1,6 +1,6 @@
 # Stagehand Evals
 
-Agent benchmarks for Stagehand — `act`, `extract`, `observe`, `agent`, `combination`, plus dataset-backed suites (WebVoyager, OnlineMind2Web, WebTailBench, GAIA).
+Agent benchmarks for Stagehand — `act`, `extract`, `observe`, `agent`, `combination`, plus dataset-backed suites (WebVoyager, OnlineMind2Web, WebTailBench, GAIA, ClawBench).
 
 Driven by an interactive TUI (`evals`) or single-shot CLI (`evals run …`). Tasks are auto-discovered from `tasks/bench/<category>/` — no registration step.
 
@@ -56,7 +56,7 @@ Use `Esc` to abort an in-flight run without exiting the REPL.
 | `bench` | Entire bench tier |
 | `act` / `extract` / `observe` / `agent` / `combination` | A category |
 | `extract/extract_text` | A specific task |
-| `b:webvoyager` / `b:onlineMind2Web` / `b:webtailbench` | Dataset-backed benchmark suite |
+| `b:webvoyager` / `b:onlineMind2Web` / `b:webtailbench` / `b:clawbench` | Dataset-backed benchmark suite |
 
 `evals list` shows everything that's been discovered:
 

--- a/packages/evals/clawbench/apiTypes.ts
+++ b/packages/evals/clawbench/apiTypes.ts
@@ -1,0 +1,23 @@
+import type { ClawBenchModelConfig } from "./types.js";
+
+export type ClawBenchProvider = "anthropic" | "google" | "openai";
+
+export function providerForApiType(
+  apiType: ClawBenchModelConfig["api_type"],
+): ClawBenchProvider {
+  switch (apiType) {
+    case "anthropic-messages":
+      return "anthropic";
+    case "google-generative-ai":
+      return "google";
+    case "openai-completions":
+    case "openai-responses":
+      return "openai";
+  }
+}
+
+export function toClawBenchStagehandModelName(
+  config: ClawBenchModelConfig,
+): string {
+  return `${providerForApiType(config.api_type)}/${config.model}`;
+}

--- a/packages/evals/clawbench/judge.ts
+++ b/packages/evals/clawbench/judge.ts
@@ -1,0 +1,198 @@
+import { generateText } from "ai";
+import type { ClawBenchJudgeVerdict, ClawBenchModelConfig } from "./types.js";
+import { getClawBenchLanguageModel } from "./languageModel.js";
+
+const LENIENT_SYSTEM = `You are a lenient evaluator for a web-agent benchmark.
+
+A user gave a natural-language INSTRUCTION to an autonomous browser agent.
+The agent navigated a real website and finally produced a single HTTP request
+(URL + method + body) that we INTERCEPTED before it was sent to the server.
+
+You decide whether this intercepted request ALIGNS with the user's instruction.
+
+# Rubric (CRITICAL — read carefully)
+
+match = TRUE if there is NO EXPLICIT CONTRADICTION between the request and
+the instruction. The default verdict is TRUE.
+
+match = FALSE only if the request EXPLICITLY contradicts a field the user
+EXPLICITLY specified in the instruction. Examples of contradiction:
+- Instruction says "red shirt", request body shows "color: blue"
+- Instruction says "quantity 2", request body shows "qty: 5"
+- Instruction says "deliver to home", request body shows "deliver to work"
+- Instruction asks to enroll in CS50, request enrolls in CS61
+
+# What is NOT a contradiction (default to match = TRUE)
+
+- Instruction did not specify a field, request omits or has any value for it
+  → MATCH (the user did not constrain it)
+- Instruction said "3pm", request body has no time field at all
+  → MATCH (info absent, not contradicted)
+- PDF resume left blank where instruction did not require content
+  → MATCH
+- Cosmetic differences (timestamps, session IDs, affiliate codes, currency
+  symbols, formatting) → MATCH
+- Ambiguous wording where multiple interpretations work → MATCH
+- Agent picked a reasonable default for unspecified options → MATCH
+- Color, size, time, quantity not mentioned in instruction → MATCH
+
+# Output
+
+Reply with ONLY a single-line JSON object, no markdown fences, no extra prose:
+{"match": true|false, "reason": "<one short sentence>"}
+
+Default is true. Only return false when you can name a SPECIFIC explicit
+field from the instruction that the request EXPLICITLY contradicts.
+`;
+
+const STRICT_SYSTEM = `You are a strict evaluator for a web-agent benchmark.
+
+A user gave a natural-language INSTRUCTION to an autonomous browser agent.
+The agent navigated a real website and finally produced a single HTTP request
+(URL + method + body) that we INTERCEPTED before it was sent to the server.
+
+Decide whether this intercepted request, if it had been sent, would correctly
+fulfill the user's instruction.
+
+Rules:
+- Match = the request would do what the user asked (right item, right action,
+  right target, right quantity). Cosmetic differences (timestamps, session IDs,
+  affiliate codes, etc.) are OK.
+- Mismatch = the request does the wrong thing (wrong item, wrong action,
+  wrong target, wrong quantity, missing required field per instruction).
+- If the request is ambiguous or only partially correct, mark as mismatch.
+
+Reply with ONLY a single-line JSON object, no markdown fences, no extra prose:
+{"match": true|false, "reason": "<one short sentence>"}
+`;
+
+function contextText(judgeContext?: Record<string, unknown>): string {
+  if (!judgeContext) return "";
+  const parts: string[] = [];
+  const rubric = judgeContext.rubric;
+  if (typeof rubric === "string" && rubric.trim()) {
+    parts.push(`Rubric:\n${rubric.trim().slice(0, 6000)}`);
+  }
+  const reference = judgeContext.reference_solution;
+  if (typeof reference === "string" && reference.trim()) {
+    parts.push(`Reference solution:\n${reference.trim().slice(0, 6000)}`);
+  }
+  const source = judgeContext.source_task_yaml;
+  if (typeof source === "string" && source.trim()) {
+    parts.push(`Source task YAML:\n${source.trim().slice(0, 6000)}`);
+  }
+  if (parts.length === 0) return "";
+  return (
+    "\n\nHIDDEN JUDGE CONTEXT (not shown to the agent; use only for grading):\n" +
+    parts.join("\n\n")
+  );
+}
+
+function buildUserMessage(
+  instruction: string,
+  interception: Record<string, unknown>,
+  judgeContext?: Record<string, unknown>,
+  rubric: "lenient" | "strict" = "lenient",
+): string {
+  const req =
+    interception.request &&
+    typeof interception.request === "object" &&
+    !Array.isArray(interception.request)
+      ? (interception.request as Record<string, unknown>)
+      : {};
+  const body = req.body;
+  const bodyText =
+    body && typeof body === "object"
+      ? JSON.stringify(body, null, 2).slice(0, 6000)
+      : String(body ?? "(empty)").slice(0, 6000);
+  const base =
+    `INSTRUCTION:\n${instruction}\n\n` +
+    `INTERCEPTED REQUEST:\n` +
+    `  url: ${String(req.url ?? "")}\n` +
+    `  method: ${String(req.method ?? "")}\n` +
+    `  body:\n${bodyText}\n`;
+  if (rubric === "lenient") return base;
+  return base + `${contextText(judgeContext)}\n`;
+}
+
+async function callJudgeModel(
+  cfg: ClawBenchModelConfig,
+  system: string,
+  user: string,
+): Promise<string> {
+  const response = await generateText({
+    model: getClawBenchLanguageModel(cfg),
+    system,
+    prompt: user,
+    maxOutputTokens: cfg.max_tokens ?? 800,
+    temperature: cfg.temperature ?? 0,
+  });
+  return response.text;
+}
+
+export function parseClawBenchJudgeVerdict(
+  raw: string,
+  rubric: "lenient" | "strict",
+): { match: boolean | null; reason: string } {
+  const trimmed = raw
+    .trim()
+    .replace(/^```(?:json)?\s*/i, "")
+    .replace(/```$/, "");
+  try {
+    const start = trimmed.indexOf("{");
+    const end = trimmed.lastIndexOf("}");
+    const parsed = JSON.parse(trimmed.slice(start, end + 1)) as {
+      match?: unknown;
+      reason?: unknown;
+    };
+    if (typeof parsed.match === "boolean") {
+      return { match: parsed.match, reason: String(parsed.reason ?? "") };
+    }
+  } catch {
+    // fall through
+  }
+  if (rubric === "lenient") {
+    return { match: true, reason: raw.slice(0, 200) };
+  }
+  return { match: null, reason: raw.slice(0, 200) || "unparseable" };
+}
+
+export async function judgeClawBenchInterception(input: {
+  modelConfig: ClawBenchModelConfig;
+  judgeModelName: string;
+  instruction: string;
+  interception: Record<string, unknown>;
+  judgeContext?: Record<string, unknown>;
+  rubric?: "lenient" | "strict";
+}): Promise<ClawBenchJudgeVerdict> {
+  const rubric = input.rubric ?? "lenient";
+  const system = rubric === "strict" ? STRICT_SYSTEM : LENIENT_SYSTEM;
+  const user = buildUserMessage(
+    input.instruction,
+    input.interception,
+    input.judgeContext,
+    rubric,
+  );
+
+  try {
+    const raw = await callJudgeModel(input.modelConfig, system, user);
+    const parsed = parseClawBenchJudgeVerdict(raw, rubric);
+    return {
+      match: parsed.match,
+      reason: parsed.reason,
+      judge_model: input.judgeModelName,
+      raw: raw.slice(0, 500),
+      error: null,
+      rubric,
+    };
+  } catch (error) {
+    return {
+      match: null,
+      reason: `judge_call_failed: ${error instanceof Error ? error.message : String(error)}`,
+      judge_model: input.judgeModelName,
+      raw: null,
+      error: error instanceof Error ? error.message : String(error),
+      rubric,
+    };
+  }
+}

--- a/packages/evals/clawbench/languageModel.ts
+++ b/packages/evals/clawbench/languageModel.ts
@@ -1,0 +1,15 @@
+import type { LanguageModelV2 } from "@ai-sdk/provider";
+import { getAISDKLanguageModel } from "@browserbasehq/stagehand";
+import { providerForApiType } from "./apiTypes.js";
+import type { ClawBenchModelConfig } from "./types.js";
+
+export function getClawBenchLanguageModel(
+  config: ClawBenchModelConfig,
+): LanguageModelV2 {
+  const provider = providerForApiType(config.api_type);
+
+  return getAISDKLanguageModel(provider, config.model, {
+    apiKey: config.api_key,
+    baseURL: config.base_url,
+  });
+}

--- a/packages/evals/clawbench/modelConfig.ts
+++ b/packages/evals/clawbench/modelConfig.ts
@@ -1,0 +1,171 @@
+import fs from "node:fs";
+import { EvalsError } from "../errors.js";
+import { toClawBenchStagehandModelName } from "./apiTypes.js";
+import { resolveClawBenchModelsYaml } from "./paths.js";
+import type { ClawBenchModelConfig } from "./types.js";
+
+const DEFAULT_AGENT_MODEL = "deepseek-v4-flash";
+const DEFAULT_JUDGE_MODEL = "deepseek-v4-pro";
+const SUPPORTED_API_TYPES = [
+  "anthropic-messages",
+  "openai-responses",
+  "openai-completions",
+  "google-generative-ai",
+] as const;
+
+function isSupportedApiType(
+  value: unknown,
+): value is ClawBenchModelConfig["api_type"] {
+  return (
+    typeof value === "string" &&
+    (SUPPORTED_API_TYPES as readonly string[]).includes(value)
+  );
+}
+
+function parseScalar(raw: string): unknown {
+  const trimmed = raw.trim();
+  if (!trimmed) return "";
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  if (trimmed === "true") return true;
+  if (trimmed === "false") return false;
+  if (/^-?\d+(\.\d+)?$/.test(trimmed)) return Number(trimmed);
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+    return trimmed
+      .slice(1, -1)
+      .split(",")
+      .map((part) => String(parseScalar(part)))
+      .filter(Boolean);
+  }
+  return trimmed;
+}
+
+function parseSimpleModelsYaml(content: string): Record<string, unknown> {
+  const models: Record<string, Record<string, unknown>> = {};
+  let current: string | null = null;
+
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.replace(/\s+#.*$/, "");
+    if (!line.trim() || line.trimStart().startsWith("#")) continue;
+
+    const top = line.match(/^([A-Za-z0-9_./:-]+):\s*$/);
+    if (top) {
+      current = top[1];
+      models[current] = {};
+      continue;
+    }
+
+    const prop = line.match(/^\s+([A-Za-z0-9_./:-]+):\s*(.*?)\s*$/);
+    if (prop && current) {
+      models[current][prop[1]] = parseScalar(prop[2]);
+    }
+  }
+
+  return models;
+}
+
+function readModelsFile(): Record<string, unknown> {
+  const modelsYaml = resolveClawBenchModelsYaml();
+  if (!fs.existsSync(modelsYaml)) {
+    throw new EvalsError(
+      `ClawBench models file not found at ${modelsYaml}. Set EVAL_CLAWBENCH_MODELS_YAML to your ClawBench models/models.yaml.`,
+    );
+  }
+  return parseSimpleModelsYaml(fs.readFileSync(modelsYaml, "utf-8"));
+}
+
+function normalizeModelConfig(
+  name: string,
+  raw: unknown,
+): ClawBenchModelConfig {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new EvalsError(`ClawBench model "${name}" must be a YAML object.`);
+  }
+  const cfg = { ...(raw as Record<string, unknown>) };
+  const baseUrl = cfg.base_url;
+  const apiType = cfg.api_type;
+  if (typeof baseUrl !== "string" || !baseUrl) {
+    throw new EvalsError(`ClawBench model "${name}" is missing base_url.`);
+  }
+  if (!isSupportedApiType(apiType)) {
+    throw new EvalsError(
+      `ClawBench model "${name}" api_type must be one of: ${SUPPORTED_API_TYPES.join(", ")}.`,
+    );
+  }
+
+  const apiKeys = Array.isArray(cfg.api_keys)
+    ? cfg.api_keys.map(String).filter(Boolean)
+    : undefined;
+  const apiKey =
+    apiKeys?.[0] ??
+    (typeof cfg.api_key === "string" && cfg.api_key ? cfg.api_key : undefined);
+  if (!apiKey) {
+    throw new EvalsError(`ClawBench model "${name}" is missing api_key.`);
+  }
+
+  return {
+    model: name,
+    base_url: baseUrl,
+    api_type: apiType,
+    api_key: apiKey,
+    api_keys: apiKeys ?? [apiKey],
+    thinking_level:
+      typeof cfg.thinking_level === "string" ? cfg.thinking_level : undefined,
+    temperature:
+      typeof cfg.temperature === "number" ? cfg.temperature : undefined,
+    max_tokens: typeof cfg.max_tokens === "number" ? cfg.max_tokens : undefined,
+  };
+}
+
+export function resolveClawBenchModelName(requested?: string): string {
+  return requested || process.env.EVAL_CLAWBENCH_MODEL || DEFAULT_AGENT_MODEL;
+}
+
+export function resolveClawBenchJudgeModelName(): string {
+  return process.env.EVAL_CLAWBENCH_JUDGE_MODEL || DEFAULT_JUDGE_MODEL;
+}
+
+export function loadClawBenchModelConfig(name: string): ClawBenchModelConfig {
+  const allModels = readModelsFile();
+  const raw = allModels[name];
+  if (!raw) {
+    throw new EvalsError(
+      `ClawBench model "${name}" not found in ${resolveClawBenchModelsYaml()}. Available: ${Object.keys(allModels).join(", ")}`,
+    );
+  }
+  return normalizeModelConfig(name, raw);
+}
+
+export function toStagehandModelConfig(config: ClawBenchModelConfig): {
+  modelName: string;
+  apiKey: string;
+  baseURL: string;
+  temperature?: number;
+  reasoningEffort?: string;
+} {
+  return {
+    modelName: toClawBenchStagehandModelName(config),
+    apiKey: config.api_key ?? "",
+    baseURL: config.base_url,
+    temperature: config.temperature,
+    reasoningEffort: config.thinking_level,
+  };
+}
+
+export function redactClawBenchModelConfig(config: ClawBenchModelConfig): Omit<
+  ClawBenchModelConfig,
+  "api_key" | "api_keys"
+> & {
+  api_key: "[REDACTED]";
+  api_keys: "[REDACTED]";
+} {
+  return {
+    ...config,
+    api_key: "[REDACTED]",
+    api_keys: "[REDACTED]",
+  };
+}

--- a/packages/evals/clawbench/paths.ts
+++ b/packages/evals/clawbench/paths.ts
@@ -1,0 +1,39 @@
+import fs from "node:fs";
+import path from "node:path";
+import { getPackageRootDir } from "../runtimePaths.js";
+
+export function getClawBenchDatasetRoot(): string {
+  return path.join(getPackageRootDir(), "datasets", "clawbench");
+}
+
+export function getClawBenchCasesRoot(): string {
+  return path.join(getClawBenchDatasetRoot(), "test-cases");
+}
+
+export function getClawBenchRuntimeRoot(): string {
+  return path.join(getClawBenchDatasetRoot(), "runtime");
+}
+
+export function resolveClawBenchModelsYaml(): string {
+  const explicit =
+    process.env.EVAL_CLAWBENCH_MODELS_YAML ?? process.env.CLAWBENCH_MODELS_YAML;
+  if (explicit) return path.resolve(explicit);
+
+  const candidates = [
+    path.join(getClawBenchDatasetRoot(), "models", "models.yaml"),
+    path.resolve(process.cwd(), "../ClawBench/models/models.yaml"),
+    path.resolve(process.cwd(), "models/models.yaml"),
+    path.resolve(
+      getPackageRootDir(),
+      "..",
+      "..",
+      "..",
+      "ClawBench",
+      "models",
+      "models.yaml",
+    ),
+  ];
+
+  const found = candidates.find((candidate) => fs.existsSync(candidate));
+  return found ?? candidates[0];
+}

--- a/packages/evals/clawbench/personalInfo.ts
+++ b/packages/evals/clawbench/personalInfo.ts
@@ -1,0 +1,313 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { getClawBenchDatasetRoot } from "./paths.js";
+import type { ClawBenchExtraInfo, ClawBenchRunParams } from "./types.js";
+
+const PURELYMAIL_API = "https://purelymail.com/api/v0";
+
+export interface ClawBenchPersonalInfo {
+  email: string;
+  password: string;
+  personalInfoPath: string;
+  emailCredentialsPath: string;
+  personalInfoJson: string;
+  resumePath: string;
+  extraFiles: Array<{
+    name: string;
+    path: string;
+    description: string;
+    content?: string;
+  }>;
+}
+
+async function purelymailRequest(
+  endpoint: string,
+  body: Record<string, unknown>,
+  apiKey: string,
+): Promise<void> {
+  const response = await fetch(`${PURELYMAIL_API}/${endpoint}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Purelymail-Api-Token": apiKey,
+    },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `PurelyMail ${endpoint} failed: ${response.status} ${response.statusText}`,
+    );
+  }
+}
+
+export async function createClawBenchEmail(): Promise<{
+  email: string;
+  password: string;
+  cleanup: () => Promise<void>;
+}> {
+  const apiKey = process.env.PURELY_MAIL_API_KEY;
+  const domain = process.env.PURELY_MAIL_DOMAIN;
+  if (!apiKey || !domain) {
+    throw new Error(
+      "ClawBench requires PURELY_MAIL_API_KEY and PURELY_MAIL_DOMAIN.",
+    );
+  }
+  const local = `cb${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+  const password = crypto.randomBytes(18).toString("base64url");
+  await purelymailRequest(
+    "createUser",
+    {
+      userName: local,
+      domainName: domain,
+      password,
+      enablePasswordReset: false,
+      sendWelcomeEmail: false,
+    },
+    apiKey,
+  );
+  const email = `${local}@${domain}`;
+  return {
+    email,
+    password,
+    cleanup: async () => {
+      await purelymailRequest("deleteUser", { userName: email }, apiKey).catch(
+        () => {},
+      );
+    },
+  };
+}
+
+function escapePdfText(text: string): string {
+  return text
+    .replace(/\\/g, "\\\\")
+    .replace(/\(/g, "\\(")
+    .replace(/\)/g, "\\)");
+}
+
+async function writeSimplePdf(
+  filePath: string,
+  lines: string[],
+): Promise<void> {
+  const content = lines
+    .slice(0, 34)
+    .map(
+      (line, index) =>
+        `BT /F1 10 Tf 50 ${760 - index * 18} Td (${escapePdfText(line.slice(0, 100))}) Tj ET`,
+    )
+    .join("\n");
+  const objects = [
+    "1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj\n",
+    "2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj\n",
+    "3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >> endobj\n",
+    "4 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj\n",
+    `5 0 obj << /Length ${Buffer.byteLength(content)} >> stream\n${content}\nendstream endobj\n`,
+  ];
+  let pdf = "%PDF-1.4\n";
+  const offsets = [0];
+  for (const object of objects) {
+    offsets.push(Buffer.byteLength(pdf));
+    pdf += object;
+  }
+  const xref = Buffer.byteLength(pdf);
+  pdf += `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`;
+  for (const offset of offsets.slice(1)) {
+    pdf += `${String(offset).padStart(10, "0")} 00000 n \n`;
+  }
+  pdf += `trailer << /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xref}\n%%EOF\n`;
+  await fs.writeFile(filePath, pdf);
+}
+
+async function readPersonalInfo(email: string): Promise<string> {
+  const personalInfoPath = path.join(
+    getClawBenchDatasetRoot(),
+    "runtime",
+    "shared",
+    "alex_green_personal_info.json",
+  );
+  const parsed = JSON.parse(await fs.readFile(personalInfoPath, "utf-8")) as {
+    contact?: { email?: string };
+    online_accounts?: unknown;
+  };
+  if (parsed.contact) parsed.contact.email = email;
+  delete parsed.online_accounts;
+  return JSON.stringify(parsed, null, 2);
+}
+
+async function copyExtraFiles(
+  params: ClawBenchRunParams,
+  runDir: string,
+): Promise<ClawBenchPersonalInfo["extraFiles"]> {
+  const files: ClawBenchPersonalInfo["extraFiles"] = [];
+  for (const item of params.extraInfo ?? []) {
+    if (!item.path) continue;
+    const source = path.join(params.taskDir, item.path);
+    const name = path.basename(source);
+    const dest = path.join(runDir, name);
+    await fs.copyFile(source, dest);
+    let content: string | undefined;
+    const stat = await fs.stat(source);
+    if (stat.size <= 16 * 1024) {
+      content = await fs
+        .readFile(source, "utf-8")
+        .catch((): undefined => undefined);
+      if (content && path.extname(source).toLowerCase() === ".json") {
+        try {
+          content = JSON.stringify(JSON.parse(content), null, 2);
+        } catch {
+          // Keep the original text for malformed JSON task fixtures.
+        }
+      }
+    }
+    files.push({ name, path: dest, description: item.description, content });
+  }
+  return files;
+}
+
+function extraNotes(extraInfo: ClawBenchExtraInfo[] | undefined): string[] {
+  return (extraInfo ?? [])
+    .filter((item) => !item.path)
+    .map((item) => item.description)
+    .filter(Boolean);
+}
+
+export async function prepareClawBenchPersonalInfo(
+  params: ClawBenchRunParams,
+  runDir: string,
+): Promise<{ info: ClawBenchPersonalInfo; cleanup: () => Promise<void> }> {
+  const email = await createClawBenchEmail();
+  const personalInfoJson = await readPersonalInfo(email.email);
+  const personalInfoPath = path.join(runDir, "alex_green_personal_info.json");
+  const credentialsPath = path.join(runDir, "email_credentials.json");
+  const resumePath = path.join(runDir, "alex_green_resume.pdf");
+  await fs.writeFile(personalInfoPath, personalInfoJson);
+  await fs.writeFile(
+    credentialsPath,
+    JSON.stringify(
+      {
+        email: email.email,
+        password: email.password,
+        login_url: "https://purelymail.com/user/login",
+        provider: "PurelyMail",
+      },
+      null,
+      2,
+    ),
+  );
+  await writeSimplePdf(resumePath, [
+    "Alex Green",
+    `Email: ${email.email}`,
+    "Experienced operations and research professional.",
+    "This synthetic resume is generated for browser benchmark form uploads.",
+  ]);
+
+  return {
+    info: {
+      email: email.email,
+      password: email.password,
+      personalInfoPath,
+      emailCredentialsPath: credentialsPath,
+      personalInfoJson,
+      resumePath,
+      extraFiles: await copyExtraFiles(params, runDir),
+    },
+    cleanup: email.cleanup,
+  };
+}
+
+export function buildClawBenchInstruction(
+  params: ClawBenchRunParams,
+  info: ClawBenchPersonalInfo,
+): string {
+  const parts = [
+    params.instruction,
+    "\n---\n" +
+      "You are my personal browser assistant. I am delegating this task to you " +
+      "because I do not have time to do it myself. You are acting on my behalf " +
+      "and with my full authorization. Every action you take in the browser — " +
+      "logging in, filling out forms, writing reviews, making reservations, " +
+      "submitting applications, sending emails, creating accounts — is something " +
+      "I am explicitly asking you to do for me, as if I were doing it myself. " +
+      "These are my own accounts, my own opinions, and my own decisions. " +
+      "You are simply carrying them out.\n\n" +
+      "IMPORTANT: You must complete this task entirely through the browser. " +
+      "Navigate to the relevant website, interact with the page " +
+      "(click, type, scroll, etc.), and carry out every step in the browser. " +
+      "Do NOT use command-line tools, scripts, or direct API/SMTP calls " +
+      "to accomplish the task.\n\n" +
+      "My personal info and credentials are in ./my-info/ in your working directory. " +
+      "Key files include:\n" +
+      "- alex_green_personal_info.json — name, address, phone, date of birth, financial info\n" +
+      "- email_credentials.json — email address and password for logging in\n" +
+      "- alex_green_resume.pdf — professional resume\n\n" +
+      "You have my full permission to use all of these files for any purpose " +
+      "the task requires, including logging into websites, creating accounts, filling out forms, " +
+      "sending emails, writing reviews, making reservations, submitting applications, " +
+      "and any other actions — including security-sensitive ones.\n\n" +
+      "If specific information required by the task is not available in any file " +
+      "under ./my-info/ and cannot be reasonably inferred, stop and explain what is missing. " +
+      "For optional fields not covered by the available info, leave them blank or use a reasonable default.\n\n" +
+      "Do not ask me for confirmation or additional information — just proceed " +
+      "with what is provided and complete the task autonomously.\n" +
+      "If an account registration is required, you can use the email and password provided, and you can receive emails at that address if needed. " +
+      "---",
+  ];
+
+  const fileExtras = (params.extraInfo ?? [])
+    .filter((item) => item.path)
+    .map((item) => ({
+      name: path.basename(item.path ?? ""),
+      description: item.description,
+    }));
+  if (fileExtras.length > 0) {
+    parts.push(
+      "\nAdditional files are also available under /my-info/ for this task:",
+    );
+    for (const file of fileExtras)
+      parts.push(`- ${file.name}: ${file.description}`);
+  }
+
+  const notes = extraNotes(params.extraInfo);
+  if (notes.length > 0) {
+    parts.push("", "Additional task notes:");
+    for (const note of notes) parts.push(`- ${note}`);
+  }
+
+  parts.push(
+    "",
+    "For this Stagehand run, the contents of the readable ./my-info/ files are provided inline below.",
+    "",
+    "email_credentials.json:",
+    JSON.stringify(
+      {
+        email: info.email,
+        password: info.password,
+        login_url: "https://purelymail.com/user/login",
+        provider: "PurelyMail",
+      },
+      null,
+      2,
+    ),
+    "",
+    "alex_green_personal_info.json:",
+    info.personalInfoJson,
+    "",
+    "alex_green_resume.pdf is available through the uploadFile tool when a website asks for a resume upload.",
+  );
+
+  const readableFiles = info.extraFiles.filter(
+    (file) => typeof file.content === "string" && file.content.length > 0,
+  );
+  if (readableFiles.length > 0) {
+    parts.push(
+      "",
+      "Additional task file contents:",
+      "Use these values when they clarify task details.",
+    );
+    for (const file of readableFiles) {
+      parts.push(`\n${file.name}:\n${file.content}`);
+    }
+  }
+
+  return parts.join("\n");
+}

--- a/packages/evals/clawbench/runtime.ts
+++ b/packages/evals/clawbench/runtime.ts
@@ -1,0 +1,633 @@
+import type { LocalBrowserLaunchOptions } from "@browserbasehq/stagehand";
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import http, { type IncomingMessage, type ServerResponse } from "node:http";
+import net from "node:net";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { getClawBenchRuntimeRoot } from "./paths.js";
+import type { ClawBenchEvalSchema, ClawBenchRunParams } from "./types.js";
+
+type CdpMessage = {
+  id?: number;
+  method?: string;
+  params?: Record<string, unknown>;
+  result?: unknown;
+  sessionId?: string;
+  error?: unknown;
+};
+
+export interface ClawBenchRuntime {
+  runDir: string;
+  dataDir: string;
+  serverPort: number;
+  cdpPort: number;
+  extensionDir: string;
+  launchOptions: Partial<LocalBrowserLaunchOptions>;
+  startCdpInterceptor: () => Promise<void>;
+  recordAction: (action: unknown) => Promise<void>;
+  recordAgentMessage: (message: unknown) => Promise<void>;
+  readInterception: () => Promise<Record<string, unknown> | null>;
+  stop: () => Promise<void>;
+}
+
+async function pickFreePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      server.close(() => {
+        if (address && typeof address === "object") resolve(address.port);
+        else reject(new Error("Unable to allocate port"));
+      });
+    });
+    server.on("error", reject);
+  });
+}
+
+async function readBody(req: IncomingMessage): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+function sendJson(
+  res: ServerResponse,
+  status: number,
+  body: Record<string, unknown>,
+): void {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(body));
+}
+
+function submitHtml(): string {
+  return `<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Submit Final Answer</title></head>
+<body>
+  <main style="max-width:820px;margin:40px auto;font-family:sans-serif">
+    <h1>Submit Final Answer</h1>
+    <form id="answer-form">
+      <textarea id="answer" style="width:100%;min-height:340px"></textarea>
+      <button type="submit">Submit</button>
+      <div id="status"></div>
+    </form>
+  </main>
+  <script>
+    const form = document.getElementById("answer-form");
+    const answer = document.getElementById("answer");
+    const status = document.getElementById("status");
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      status.textContent = "Submitting...";
+      try {
+        await fetch("/api/task-submit", {
+          method: "POST",
+          headers: {"Content-Type": "application/json"},
+          body: JSON.stringify({answer: answer.value})
+        });
+      } catch (_) {}
+      status.textContent = "Submitted.";
+    });
+  </script>
+</body>
+</html>`;
+}
+
+async function appendJsonl(filePath: string, value: unknown): Promise<void> {
+  await fs.appendFile(filePath, `${JSON.stringify(value)}\n`);
+}
+
+function sanitizeArtifactValue(
+  value: unknown,
+  seen = new WeakSet<object>(),
+  depth = 0,
+): unknown {
+  if (depth > 8) return "[TRUNCATED_DEPTH]";
+  if (typeof value === "string") {
+    if (value.startsWith("data:image/")) return "[IMAGE_REDACTED]";
+    if (value.length > 20000) return `${value.slice(0, 20000)}...[TRUNCATED]`;
+    return value;
+  }
+  if (
+    value === null ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+  if (typeof value === "bigint") return value.toString();
+  if (typeof value === "undefined") return undefined;
+  if (typeof value === "function" || typeof value === "symbol") {
+    return `[${typeof value}]`;
+  }
+  if (Array.isArray(value)) {
+    return value
+      .slice(0, 200)
+      .map((item) => sanitizeArtifactValue(item, seen, depth + 1));
+  }
+  if (typeof value !== "object") return String(value);
+  if (seen.has(value)) return "[Circular]";
+  seen.add(value);
+
+  const output: Record<string, unknown> = {};
+  for (const [key, nested] of Object.entries(value)) {
+    const lowered = key.toLowerCase();
+    if (
+      lowered.includes("api_key") ||
+      lowered.includes("apikey") ||
+      lowered.includes("authorization") ||
+      lowered.includes("cookie") ||
+      lowered.includes("token") ||
+      lowered.includes("secret")
+    ) {
+      output[key] = "[REDACTED]";
+      continue;
+    }
+    if (lowered.includes("screenshot") || lowered === "image") {
+      output[key] = "[IMAGE_REDACTED]";
+      continue;
+    }
+    output[key] = sanitizeArtifactValue(nested, seen, depth + 1);
+  }
+  return output;
+}
+
+function withTimestamp(value: unknown): Record<string, unknown> {
+  const sanitized = sanitizeArtifactValue(value);
+  if (sanitized && typeof sanitized === "object" && !Array.isArray(sanitized)) {
+    return {
+      timestamp: Date.now() / 1000,
+      ...(sanitized as Record<string, unknown>),
+    };
+  }
+  return { timestamp: Date.now() / 1000, value: sanitized };
+}
+
+function parseBody(raw?: string): unknown {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    const params = new URLSearchParams(raw);
+    if ([...params.keys()].length > 0) {
+      const obj: Record<string, string | string[]> = {};
+      for (const [key, value] of params.entries()) {
+        const existing = obj[key];
+        if (existing === undefined) obj[key] = value;
+        else if (Array.isArray(existing)) existing.push(value);
+        else obj[key] = [existing, value];
+      }
+      return obj;
+    }
+    return raw;
+  }
+}
+
+function constFieldsMatch(expected: unknown, actual: unknown): boolean {
+  if (!expected || typeof expected !== "object") return true;
+  if (Array.isArray(actual)) {
+    return actual.some((item) => constFieldsMatch(expected, item));
+  }
+  if (!actual || typeof actual !== "object" || Array.isArray(actual)) {
+    return false;
+  }
+  const actualObj = actual as Record<string, unknown>;
+  return Object.entries(expected as Record<string, unknown>).every(
+    ([key, value]) => actualObj[key] === value,
+  );
+}
+
+export function matchesClawBenchEvalSchema(
+  schema: ClawBenchEvalSchema,
+  request: {
+    url: string;
+    method: string;
+    body?: unknown;
+    params?: Record<string, string | string[]>;
+  },
+): boolean {
+  return (
+    new RegExp(schema.url_pattern).test(request.url) &&
+    request.method === schema.method &&
+    constFieldsMatch(schema.body, request.body) &&
+    constFieldsMatch(schema.params, request.params ?? queryParams(request.url))
+  );
+}
+
+function queryParams(url: string): Record<string, string | string[]> {
+  const parsed = new URL(url);
+  const out: Record<string, string | string[]> = {};
+  for (const [key, value] of parsed.searchParams.entries()) {
+    const existing = out[key];
+    if (existing === undefined) out[key] = value;
+    else if (Array.isArray(existing)) existing.push(value);
+    else out[key] = [existing, value];
+  }
+  return out;
+}
+
+function shouldFilterUrl(url: string): boolean {
+  return (
+    url.startsWith("chrome-extension://") ||
+    url.startsWith("devtools://") ||
+    url.startsWith("chrome://") ||
+    /127\.0\.0\.1:\d+/.test(url) ||
+    /localhost:\d+/.test(url)
+  );
+}
+
+async function copyExtension(sourceDir: string, destDir: string, port: number) {
+  await fs.cp(sourceDir, destDir, { recursive: true });
+  const backgroundPath = path.join(destDir, "background.js");
+  const background = await fs.readFile(backgroundPath, "utf-8");
+  await fs.writeFile(
+    backgroundPath,
+    background.replace(
+      'const SERVER = "http://localhost:7878";',
+      `const SERVER = "http://localhost:${port}";`,
+    ),
+  );
+}
+
+class CdpInterceptor {
+  private ws: WebSocket | null = null;
+  private msgId = 1;
+  private fetchSessions = new Set<string>();
+  private pending = new Map<
+    number,
+    {
+      resolve: (value: unknown) => void;
+      reject: (error: Error) => void;
+      timeout: NodeJS.Timeout;
+    }
+  >();
+
+  constructor(
+    private readonly cdpPort: number,
+    private readonly dataDir: string,
+    private readonly schema: ClawBenchEvalSchema,
+  ) {}
+
+  async start(): Promise<void> {
+    const version = (await this.waitForJsonVersion()) as {
+      webSocketDebuggerUrl?: string;
+    };
+    if (!version.webSocketDebuggerUrl) {
+      throw new Error("Chrome CDP did not expose webSocketDebuggerUrl");
+    }
+    if (typeof WebSocket === "undefined") {
+      throw new Error("Global WebSocket is not available in this Node runtime");
+    }
+
+    this.ws = await new Promise<WebSocket>((resolve, reject) => {
+      const socket = new WebSocket(version.webSocketDebuggerUrl!);
+      socket.addEventListener("open", () => resolve(socket), { once: true });
+      socket.addEventListener(
+        "error",
+        () => reject(new Error("CDP websocket failed to open")),
+        { once: true },
+      );
+    });
+
+    this.ws.addEventListener("message", (event) => {
+      void this.handleMessage(String(event.data)).catch(() => {});
+    });
+    await this.request("Target.setAutoAttach", {
+      autoAttach: true,
+      waitForDebuggerOnStart: true,
+      flatten: true,
+    });
+    const targets = (await this.request("Target.getTargets")) as {
+      targetInfos?: Array<Record<string, unknown>>;
+    };
+    for (const target of targets.targetInfos ?? []) {
+      if (target.type !== "page" || !target.targetId) continue;
+      const attached = (await this.request("Target.attachToTarget", {
+        targetId: target.targetId,
+        flatten: true,
+      }).catch((): null => null)) as {
+        sessionId?: string;
+      } | null;
+      if (attached?.sessionId) {
+        this.enableFetch(attached.sessionId);
+        this.send("Runtime.runIfWaitingForDebugger", {}, attached.sessionId);
+      }
+    }
+  }
+
+  close(): void {
+    this.ws?.close();
+    this.ws = null;
+  }
+
+  private async waitForJsonVersion(): Promise<unknown> {
+    const deadline = Date.now() + 20_000;
+    let lastError = "";
+    while (Date.now() < deadline) {
+      try {
+        const response = await fetch(
+          `http://127.0.0.1:${this.cdpPort}/json/version`,
+        );
+        if (response.ok) return await response.json();
+        lastError = `${response.status} ${response.statusText}`;
+      } catch (error) {
+        lastError = error instanceof Error ? error.message : String(error);
+      }
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+    throw new Error(`Timed out waiting for Chrome CDP: ${lastError}`);
+  }
+
+  private send(
+    method: string,
+    params: Record<string, unknown> = {},
+    sessionId?: string,
+  ): void {
+    this.ws?.send(
+      JSON.stringify({
+        id: this.msgId++,
+        method,
+        params,
+        ...(sessionId && { sessionId }),
+      }),
+    );
+  }
+
+  private request(
+    method: string,
+    params: Record<string, unknown> = {},
+    sessionId?: string,
+  ): Promise<unknown> {
+    const id = this.msgId++;
+    const payload = { id, method, params, ...(sessionId && { sessionId }) };
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`CDP request timed out: ${method}`));
+      }, 10_000);
+      this.pending.set(id, { resolve, reject, timeout });
+      this.ws?.send(JSON.stringify(payload));
+    });
+  }
+
+  private enableFetch(sessionId: string): void {
+    if (this.fetchSessions.has(sessionId)) return;
+    this.send(
+      "Fetch.enable",
+      { patterns: [{ urlPattern: "*", requestStage: "Request" }] },
+      sessionId,
+    );
+    this.fetchSessions.add(sessionId);
+  }
+
+  private async handleMessage(raw: string): Promise<void> {
+    const msg = JSON.parse(raw) as CdpMessage;
+    if (msg.id !== undefined && this.pending.has(msg.id)) {
+      const pending = this.pending.get(msg.id)!;
+      this.pending.delete(msg.id);
+      clearTimeout(pending.timeout);
+      if (msg.error) {
+        pending.reject(new Error(JSON.stringify(msg.error)));
+      } else {
+        pending.resolve(msg.result);
+      }
+    }
+
+    if (msg.method === "Target.attachedToTarget") {
+      const params = msg.params ?? {};
+      const childSession = String(params.sessionId ?? "");
+      const targetInfo = params.targetInfo as
+        | Record<string, unknown>
+        | undefined;
+      if (
+        targetInfo?.type === "page" &&
+        !this.fetchSessions.has(childSession)
+      ) {
+        this.enableFetch(childSession);
+      }
+      this.send("Runtime.runIfWaitingForDebugger", {}, childSession);
+      return;
+    }
+
+    if (msg.method !== "Fetch.requestPaused") return;
+    const params = msg.params ?? {};
+    const request = params.request as Record<string, unknown> | undefined;
+    const requestId = String(params.requestId ?? "");
+    const sessionId = msg.sessionId;
+    const url = String(request?.url ?? "");
+    const method = String(request?.method ?? "");
+    const body = parseBody(
+      typeof request?.postData === "string" ? request.postData : undefined,
+    );
+    const paramsObj = queryParams(url);
+
+    if (!shouldFilterUrl(url)) {
+      await appendJsonl(path.join(this.dataDir, "requests.jsonl"), {
+        timestamp: Date.now() / 1000,
+        url,
+        method,
+        headers: request?.headers ?? {},
+        body,
+        query_params: paramsObj,
+        resource_type: params.resourceType ?? "Other",
+      });
+    }
+
+    if (!this.matches(url, method, body, paramsObj)) {
+      this.send("Fetch.continueRequest", { requestId }, sessionId);
+      return;
+    }
+
+    this.send(
+      "Fetch.failRequest",
+      { requestId, errorReason: "BlockedByClient" },
+      sessionId,
+    );
+    const interceptionPath = path.join(this.dataDir, "interception.json");
+    if (!fsSync.existsSync(interceptionPath)) {
+      await fs.writeFile(
+        interceptionPath,
+        JSON.stringify(
+          {
+            intercepted: true,
+            request: { url, method, params: paramsObj, body },
+            schema: this.schema,
+          },
+          null,
+          2,
+        ),
+      );
+    }
+    await fs.writeFile(path.join(this.dataDir, ".stop-requested"), "");
+  }
+
+  private matches(
+    url: string,
+    method: string,
+    body: unknown,
+    params: Record<string, string | string[]>,
+  ): boolean {
+    return matchesClawBenchEvalSchema(this.schema, {
+      url,
+      method,
+      body,
+      params,
+    });
+  }
+}
+
+export async function prepareClawBenchRuntime(
+  params: ClawBenchRunParams,
+): Promise<ClawBenchRuntime> {
+  const serverPort = await pickFreePort();
+  const cdpPort = await pickFreePort();
+  const runRoot =
+    process.env.EVAL_CLAWBENCH_OUTPUT_DIR ??
+    path.join(process.cwd(), "tmp", "evals", "clawbench");
+  await fs.mkdir(runRoot, { recursive: true });
+  const runDir = await fs.mkdtemp(
+    path.join(runRoot, `${params.caseName.replace(/[^A-Za-z0-9_.-]/g, "_")}-`),
+  );
+  const dataDir = path.join(runDir, "data");
+  await fs.mkdir(path.join(dataDir, "screenshots"), { recursive: true });
+  await fs.writeFile(path.join(dataDir, "actions.jsonl"), "");
+  await fs.writeFile(path.join(dataDir, "agent-messages.jsonl"), "");
+  await fs.writeFile(path.join(dataDir, "requests.jsonl"), "");
+
+  const extensionDir = path.join(runDir, "chrome-extension");
+  await copyExtension(
+    path.join(getClawBenchRuntimeRoot(), "chrome-extension"),
+    extensionDir,
+    serverPort,
+  );
+
+  const server = http.createServer((req, res) => {
+    void handleRuntimeRequest(req, res, dataDir).catch((error) => {
+      sendJson(res, 500, {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.listen(serverPort, "127.0.0.1", resolve);
+    server.once("error", reject);
+  });
+
+  const interceptor = new CdpInterceptor(cdpPort, dataDir, params.evalSchema);
+
+  return {
+    runDir,
+    dataDir,
+    serverPort,
+    cdpPort,
+    extensionDir,
+    launchOptions: {
+      port: cdpPort,
+      headless: false,
+      viewport: { width: 1920, height: 1080 },
+      args: [
+        `--load-extension=${extensionDir}`,
+        `--disable-extensions-except=${extensionDir}`,
+        "--disable-blink-features=AutomationControlled",
+      ],
+    },
+    startCdpInterceptor: async () => {
+      await interceptor.start();
+    },
+    recordAction: async (action: unknown) => {
+      await appendJsonl(path.join(dataDir, "actions.jsonl"), {
+        timestamp: Date.now() / 1000,
+        source: "stagehand_agent",
+        action,
+      });
+    },
+    recordAgentMessage: async (message: unknown) => {
+      await appendJsonl(
+        path.join(dataDir, "agent-messages.jsonl"),
+        withTimestamp(message),
+      );
+    },
+    readInterception: async () => {
+      const filePath = path.join(dataDir, "interception.json");
+      if (!fsSync.existsSync(filePath)) return null;
+      return JSON.parse(await fs.readFile(filePath, "utf-8")) as Record<
+        string,
+        unknown
+      >;
+    },
+    stop: async () => {
+      interceptor.close();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+async function handleRuntimeRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  dataDir: string,
+): Promise<void> {
+  const url = new URL(req.url ?? "/", "http://127.0.0.1");
+  if (req.method === "GET" && url.pathname === "/api/status") {
+    sendJson(res, 200, { status: "ok", eval_interceptor_ready: true });
+    return;
+  }
+  if (req.method === "GET" && url.pathname === "/submit") {
+    res.writeHead(200, { "Content-Type": "text/html" });
+    res.end(submitHtml());
+    return;
+  }
+  if (req.method === "POST" && url.pathname === "/api/action") {
+    const body = JSON.parse((await readBody(req)).toString("utf-8") || "{}");
+    await appendJsonl(path.join(dataDir, "actions.jsonl"), body);
+    sendJson(res, 200, { status: "ok" });
+    return;
+  }
+  if (req.method === "POST" && url.pathname === "/api/screenshot") {
+    const body = JSON.parse(
+      (await readBody(req)).toString("utf-8") || "{}",
+    ) as {
+      timestamp?: number;
+      data?: string;
+    };
+    if (body.data) {
+      await fs.writeFile(
+        path.join(
+          dataDir,
+          "screenshots",
+          `${body.timestamp ?? Date.now()}.png`,
+        ),
+        Buffer.from(body.data, "base64"),
+      );
+    }
+    sendJson(res, 200, { status: "ok" });
+    return;
+  }
+  if (req.method === "POST" && url.pathname === "/api/task-submit") {
+    const body = JSON.parse((await readBody(req)).toString("utf-8") || "{}");
+    const submission = { timestamp: Date.now() / 1000, body };
+    await fs.writeFile(
+      path.join(dataDir, "submission.json"),
+      JSON.stringify(submission, null, 2),
+    );
+    await appendJsonl(path.join(dataDir, "actions.jsonl"), {
+      type: "task_submit",
+      ...submission,
+    });
+    sendJson(res, 200, { status: "received" });
+    return;
+  }
+  if (req.method === "POST" && url.pathname === "/api/stop") {
+    await fs.writeFile(path.join(dataDir, ".stop-requested"), "");
+    sendJson(res, 200, { status: "stopped" });
+    return;
+  }
+  sendJson(res, 404, { error: "not found" });
+}
+
+export function runtimeFileUrl(filePath: string): string {
+  return pathToFileURL(filePath).href;
+}

--- a/packages/evals/clawbench/suite.ts
+++ b/packages/evals/clawbench/suite.ts
@@ -1,0 +1,280 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { AvailableModel } from "@browserbasehq/stagehand";
+import type { AgentModelEntry, EvalInput, Testcase } from "../types/evals.js";
+import { applySampling, normalizeAgentModelEntries } from "../utils.js";
+import { getClawBenchCasesRoot } from "./paths.js";
+import {
+  resolveClawBenchModelName,
+  loadClawBenchModelConfig,
+  redactClawBenchModelConfig,
+} from "./modelConfig.js";
+import type {
+  ClawBenchCase,
+  ClawBenchExtraInfo,
+  ClawBenchRunParams,
+  ClawBenchTaskData,
+} from "./types.js";
+
+function caseId(casePath: string): number | null {
+  const stem = path.basename(casePath).replace(/\.json$/, "");
+  const match = /^(?:v\d+-|ce-)?[A-Za-z]?(\d+)/.exec(stem);
+  return match ? Number(match[1]) : null;
+}
+
+function caseSortKey(casePath: string): [number, number, string] {
+  const id = caseId(casePath);
+  return id === null
+    ? [1, Number.MAX_SAFE_INTEGER, path.basename(casePath)]
+    : [0, id, path.basename(casePath)];
+}
+
+function compareCases(a: string, b: string): number {
+  const ak = caseSortKey(a);
+  const bk = caseSortKey(b);
+  return ak[0] - bk[0] || ak[1] - bk[1] || ak[2].localeCompare(bk[2]);
+}
+
+function normalizeExtraInfo(raw: unknown): ClawBenchExtraInfo[] {
+  if (!raw) return [];
+  const entries = Array.isArray(raw) ? raw : [raw];
+  return entries
+    .map((entry): ClawBenchExtraInfo | null => {
+      if (typeof entry === "string") {
+        return entry.trim() ? { description: entry.trim() } : null;
+      }
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+        return null;
+      }
+      const obj = entry as Record<string, unknown>;
+      const description =
+        typeof obj.description === "string"
+          ? obj.description
+          : typeof obj.note === "string"
+            ? obj.note
+            : "Additional task information";
+      const normalized: ClawBenchExtraInfo = { description };
+      if (typeof obj.path === "string" && obj.path) normalized.path = obj.path;
+      return normalized;
+    })
+    .filter((entry): entry is ClawBenchExtraInfo => entry !== null);
+}
+
+function validateTask(task: unknown, filePath: string): ClawBenchTaskData {
+  if (!task || typeof task !== "object" || Array.isArray(task)) {
+    throw new Error(`${filePath} must contain a JSON object`);
+  }
+  const obj = task as Record<string, unknown>;
+  if (typeof obj.instruction !== "string" || !obj.instruction.trim()) {
+    throw new Error(`${filePath} is missing instruction`);
+  }
+  if (!obj.eval_schema || typeof obj.eval_schema !== "object") {
+    throw new Error(`${filePath} is missing eval_schema`);
+  }
+  const schema = obj.eval_schema as Record<string, unknown>;
+  if (typeof schema.url_pattern !== "string") {
+    throw new Error(`${filePath} eval_schema.url_pattern must be a string`);
+  }
+  if (typeof schema.method !== "string") {
+    throw new Error(`${filePath} eval_schema.method must be a string`);
+  }
+  if (typeof obj.time_limit !== "number") {
+    throw new Error(`${filePath} time_limit must be a number`);
+  }
+  return obj as unknown as ClawBenchTaskData;
+}
+
+const SUPPORTED_CLAWBENCH_CORPUS = "v2";
+
+function assertSupportedCorpus(corpus: string): void {
+  if (corpus !== SUPPORTED_CLAWBENCH_CORPUS) {
+    throw new Error(
+      `Unsupported ClawBench corpus "${corpus}". Stagehand currently vendors and runs only ClawBench V2.`,
+    );
+  }
+}
+
+export function loadClawBenchCases(
+  corpus = SUPPORTED_CLAWBENCH_CORPUS,
+): ClawBenchCase[] {
+  assertSupportedCorpus(corpus);
+  const corpusDir = path.join(getClawBenchCasesRoot(), corpus);
+  if (!fs.existsSync(corpusDir)) {
+    throw new Error(`Unknown ClawBench corpus "${corpus}" at ${corpusDir}`);
+  }
+
+  const entries = fs.readdirSync(corpusDir, { withFileTypes: true });
+  const taskFiles: string[] = [];
+  for (const entry of entries) {
+    const fullPath = path.join(corpusDir, entry.name);
+    if (entry.isDirectory()) {
+      const taskFile = path.join(fullPath, "task.json");
+      if (fs.existsSync(taskFile)) taskFiles.push(taskFile);
+    } else if (
+      entry.isFile() &&
+      entry.name.endsWith(".json") &&
+      entry.name !== "eligibility-report.json"
+    ) {
+      taskFiles.push(fullPath);
+    }
+  }
+
+  return taskFiles.sort(compareCases).map((taskFile) => {
+    const task = validateTask(
+      JSON.parse(fs.readFileSync(taskFile, "utf-8")),
+      taskFile,
+    );
+    const taskDir = path.dirname(taskFile);
+    return {
+      corpus,
+      caseName:
+        path.basename(taskFile) === "task.json"
+          ? path.basename(taskDir)
+          : path.basename(taskFile, ".json"),
+      taskFile,
+      taskDir,
+      task,
+    };
+  });
+}
+
+function parseCaseRange(raw?: string): [number, number] | undefined {
+  if (!raw) return undefined;
+  const match = /^(\d+)-(\d+)$/.exec(raw.trim());
+  if (!match) throw new Error("EVAL_CLAWBENCH_CASE_RANGE must be START-END");
+  const lo = Number(match[1]);
+  const hi = Number(match[2]);
+  if (lo > hi)
+    throw new Error("EVAL_CLAWBENCH_CASE_RANGE start must be <= end");
+  return [lo, hi];
+}
+
+function filterCases(cases: ClawBenchCase[]): ClawBenchCase[] {
+  const wantedCases = (process.env.EVAL_CLAWBENCH_CASES ?? "")
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+  const wanted = new Set(wantedCases);
+  const range = parseCaseRange(process.env.EVAL_CLAWBENCH_CASE_RANGE);
+
+  return cases.filter((testCase) => {
+    if (wanted.size > 0) {
+      const id = testCase.task.metadata?.task_id;
+      return (
+        wanted.has(testCase.caseName) ||
+        (typeof id === "number" && wanted.has(String(id)))
+      );
+    }
+    if (range) {
+      const id = testCase.task.metadata?.task_id;
+      return typeof id === "number" && id >= range[0] && id <= range[1];
+    }
+    return true;
+  });
+}
+
+function maxCases(): number {
+  if (process.env.EVAL_MAX_K) return Number(process.env.EVAL_MAX_K);
+  if (process.env.EVAL_CLAWBENCH_LIMIT) {
+    return Number(process.env.EVAL_CLAWBENCH_LIMIT);
+  }
+  return Number.MAX_SAFE_INTEGER;
+}
+
+function sampleCount(): number | undefined {
+  return process.env.EVAL_CLAWBENCH_SAMPLE
+    ? Number(process.env.EVAL_CLAWBENCH_SAMPLE)
+    : undefined;
+}
+
+function buildParams(testCase: ClawBenchCase): ClawBenchRunParams {
+  return {
+    corpus: testCase.corpus,
+    caseName: testCase.caseName,
+    taskFile: testCase.taskFile,
+    taskDir: testCase.taskDir,
+    taskId: testCase.task.metadata?.task_id,
+    instruction: testCase.task.instruction,
+    evalSchema: testCase.task.eval_schema,
+    timeLimitMinutes: testCase.task.time_limit,
+    metadata: testCase.task.metadata,
+    extraInfo: normalizeExtraInfo(testCase.task.extra_info),
+    judgeContext: testCase.task.judge_context,
+  };
+}
+
+export function buildClawBenchTestcases(
+  models: string[] | AgentModelEntry[],
+): Testcase[] {
+  const corpus =
+    process.env.EVAL_CLAWBENCH_CORPUS || SUPPORTED_CLAWBENCH_CORPUS;
+  assertSupportedCorpus(corpus);
+  const cases = applySampling(
+    filterCases(loadClawBenchCases(corpus)),
+    sampleCount(),
+    maxCases(),
+  );
+  const modelEntries = normalizeAgentModelEntries(
+    models.length > 0
+      ? models
+      : [
+          {
+            modelName: resolveClawBenchModelName(),
+            mode: "hybrid",
+            cua: false,
+          },
+        ],
+  );
+
+  const testcases: Testcase[] = [];
+  for (const entry of modelEntries) {
+    const modelConfig = loadClawBenchModelConfig(entry.modelName);
+    for (const testCase of cases) {
+      const params = buildParams(testCase);
+      const input: EvalInput = {
+        name: "agent/clawbench",
+        modelName: entry.modelName as AvailableModel,
+        agentMode: entry.mode,
+        isCUA: entry.mode === "cua",
+        params: {
+          ...params,
+          modelConfig: redactClawBenchModelConfig(modelConfig),
+        },
+      };
+
+      testcases.push({
+        input,
+        name: input.name,
+        tags: [
+          entry.modelName,
+          entry.mode,
+          "clawbench",
+          `clawbench/${corpus}`,
+          `case/${testCase.caseName}`,
+        ],
+        metadata: {
+          model: entry.modelName as AvailableModel,
+          test: `${input.name}:${testCase.caseName}`,
+          tier: "bench",
+          task: input.name,
+          category: "external_agent_benchmarks",
+          categories: ["external_agent_benchmarks"],
+          dataset: "clawbench",
+          task_id:
+            typeof params.taskId === "number"
+              ? String(params.taskId)
+              : testCase.caseName,
+          website: params.metadata?.platform,
+          difficulty:
+            typeof params.metadata?.source_difficulty === "string"
+              ? params.metadata.source_difficulty
+              : undefined,
+          task_category: params.metadata?.metaclass,
+        },
+        expected: true,
+      });
+    }
+  }
+
+  return testcases;
+}

--- a/packages/evals/clawbench/types.ts
+++ b/packages/evals/clawbench/types.ts
@@ -1,0 +1,76 @@
+export interface ClawBenchEvalSchema {
+  url_pattern: string;
+  method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+  body?: Record<string, unknown>;
+  params?: Record<string, unknown>;
+}
+
+export interface ClawBenchTaskMetadata {
+  task_id?: number;
+  metaclass?: string;
+  class?: string;
+  description?: string;
+  sites_involved?: string[];
+  platform?: string;
+  [key: string]: unknown;
+}
+
+export interface ClawBenchExtraInfo {
+  path?: string;
+  description: string;
+}
+
+export interface ClawBenchTaskData {
+  metadata?: ClawBenchTaskMetadata;
+  instruction: string;
+  eval_schema: ClawBenchEvalSchema;
+  time_limit: number;
+  extra_info?: ClawBenchExtraInfo[] | ClawBenchExtraInfo | string;
+  judge_context?: Record<string, unknown>;
+}
+
+export interface ClawBenchCase {
+  corpus: string;
+  caseName: string;
+  taskFile: string;
+  taskDir: string;
+  task: ClawBenchTaskData;
+}
+
+export interface ClawBenchRunParams {
+  corpus: string;
+  caseName: string;
+  taskFile: string;
+  taskDir: string;
+  taskId?: number;
+  instruction: string;
+  evalSchema: ClawBenchEvalSchema;
+  timeLimitMinutes: number;
+  metadata?: ClawBenchTaskMetadata;
+  extraInfo?: ClawBenchExtraInfo[];
+  judgeContext?: Record<string, unknown>;
+}
+
+export interface ClawBenchModelConfig {
+  model: string;
+  base_url: string;
+  api_type:
+    | "anthropic-messages"
+    | "openai-responses"
+    | "openai-completions"
+    | "google-generative-ai";
+  api_key?: string;
+  api_keys?: string[];
+  thinking_level?: string;
+  temperature?: number;
+  max_tokens?: number;
+}
+
+export interface ClawBenchJudgeVerdict {
+  match: boolean | null;
+  reason: string;
+  judge_model: string;
+  raw?: string | null;
+  error?: string | null;
+  rubric?: string;
+}

--- a/packages/evals/datasets/clawbench/models/.gitignore
+++ b/packages/evals/datasets/clawbench/models/.gitignore
@@ -1,0 +1,1 @@
+models.yaml

--- a/packages/evals/datasets/clawbench/models/model.schema.json
+++ b/packages/evals/datasets/clawbench/models/model.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Schema for a single model entry in models/models.yaml. The YAML key is the model name.",
+  "type": "object",
+  "required": ["base_url", "api_type"],
+  "properties": {
+    "api_key": {
+      "type": "string",
+      "description": "API key for the provider"
+    },
+    "api_keys": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Multiple API keys for round-robin rotation (takes precedence over api_key)"
+    },
+    "thinking_level": {
+      "type": "string",
+      "enum": ["off", "minimal", "low", "medium", "high", "xhigh", "adaptive"],
+      "description": "Reasoning depth for the model"
+    },
+    "temperature": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 2,
+      "description": "Sampling temperature"
+    },
+    "max_tokens": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Maximum output tokens"
+    },
+    "base_url": {
+      "type": "string",
+      "format": "uri",
+      "description": "API base URL (e.g. https://api.openai.com/v1)"
+    },
+    "api_type": {
+      "type": "string",
+      "enum": ["anthropic-messages", "openai-responses", "openai-completions", "google-generative-ai"],
+      "description": "API type for the provider endpoint"
+    }
+  },
+  "additionalProperties": false
+}

--- a/packages/evals/datasets/clawbench/models/models.example.yaml
+++ b/packages/evals/datasets/clawbench/models/models.example.yaml
@@ -1,0 +1,16 @@
+# Copy to models/models.yaml and fill in your API keys.
+# Each top-level key is the model name (passed as MODEL_NAME to the container).
+
+qwen3.5-397b-a17b:
+  api_key: "sk-or-v1-..."
+  base_url: https://openrouter.ai/api/v1
+  api_type: openai-completions
+  thinking_level: medium # optional
+
+# For multiple API keys (round-robin), use api_keys instead of api_key:
+# some-model:
+#   api_keys:
+#     - "key1"
+#     - "key2"
+#   base_url: https://api.openai.com/v1
+#   api_type: openai-completions

--- a/packages/evals/datasets/clawbench/runner/run_support/resume_template.json
+++ b/packages/evals/datasets/clawbench/runner/run_support/resume_template.json
@@ -1,0 +1,104 @@
+{
+  "// NOTE": "All overlapping fields MUST match personal_info.json exactly.",
+  "header": {
+    "name": "Alex Green",
+    "title": "Senior Software Engineer",
+    "email": "dummy_email",
+    "location": "Toronto, ON, Canada"
+  },
+  "summary": "Senior Software Engineer with 23+ years of experience in full-stack development, distributed systems, and cloud infrastructure. PhD in Computer Science from the University of Toronto. Currently leading a backend team at Pinecrest Technologies Inc., building enterprise data pipeline solutions. Previously built real-time transaction processing systems in FinTech. AWS and Kubernetes certified.",
+  "experience": [
+    {
+      "title": "Senior Software Engineer",
+      "company": "Pinecrest Technologies Inc.",
+      "location": "Toronto, ON",
+      "dates": "Mar 2019 – Present",
+      "bullets": [
+        "Lead backend team of 5 engineers building distributed data pipelines for enterprise SaaS platform",
+        "Design and implement RESTful APIs serving 2M+ daily requests with sub-100ms p99 latency",
+        "Mentor junior developers and conduct code reviews, improving team velocity by 30%"
+      ]
+    },
+    {
+      "title": "Software Engineer",
+      "company": "Crestridge Digital Corp.",
+      "location": "Toronto, ON",
+      "dates": "Jun 2012 - Feb 2019",
+      "bullets": [
+        "Developed real-time transaction processing systems handling $50M+ daily volume in FinTech",
+        "Built automated testing frameworks reducing QA cycle by 40%",
+        "Collaborated with product team on mobile banking features serving 500K+ users"
+      ]
+    },
+    {
+      "title": "Software Developer",
+      "company": "Cedarbrook Solutions Ltd.",
+      "location": "Toronto, ON",
+      "dates": "Sep 2002 - May 2012",
+      "bullets": [
+        "Full-stack web development for enterprise clients across multiple industries",
+        "Database administration and performance optimization for high-traffic applications",
+        "Part-time during graduate studies (2002-2010); full-time from 2010"
+      ]
+    }
+  ],
+  "education": [
+    {
+      "degree": "Ph.D. in Computer Science",
+      "institution": "University of Toronto",
+      "dates": "2004 - 2010",
+      "detail": "Dissertation: Scalable Real-Time Data Pipeline Architectures for High-Throughput Transaction Processing"
+    },
+    {
+      "degree": "M.Sc. in Computer Science",
+      "institution": "University of Toronto",
+      "dates": "2002 - 2004",
+      "detail": "GPA: 3.8/4.0 | Thesis: Efficient Query Processing in Distributed Database Systems"
+    },
+    {
+      "degree": "B.Sc. in Computer Science",
+      "institution": "University of Toronto",
+      "dates": "1998 - 2002",
+      "detail": "GPA: 3.6/4.0 | Dean's List (2001, 2002)"
+    }
+  ],
+  "skills": {
+    "languages": [
+      "Python",
+      "Java",
+      "TypeScript",
+      "Go"
+    ],
+    "databases": [
+      "PostgreSQL",
+      "Redis"
+    ],
+    "cloud_devops": [
+      "AWS",
+      "Docker",
+      "Kubernetes",
+      "Terraform",
+      "CI/CD"
+    ],
+    "frameworks": [
+      "React",
+      "Node.js",
+      "GraphQL",
+      "REST API Design"
+    ]
+  },
+  "certifications": [
+    "AWS Solutions Architect – Associate (2024)",
+    "Certified Kubernetes Administrator – CKA (2025)"
+  ],
+  "languages": [
+    {
+      "language": "English",
+      "proficiency": "Native"
+    },
+    {
+      "language": "French",
+      "proficiency": "Intermediate (B1)"
+    }
+  ]
+}

--- a/packages/evals/datasets/clawbench/runtime/chrome-extension/README.md
+++ b/packages/evals/datasets/clawbench/runtime/chrome-extension/README.md
@@ -1,0 +1,127 @@
+# ClawBench Chrome Extension
+
+This is the source code for the ClawBench Chrome Extension, which acts as the client for the ClawBench benchmarking framework.
+
+The extension is responsible for the following tasks:
+
+- Collecting every browser action performed by the user or agent and sending it to the ClawBench server.
+- Taking screenshots after browser actions, with high-frequency events throttled.
+- Keeping the active tab aligned with the agent's work so server-side screen recording and screenshots capture the right browser state.
+
+The extension should auto start when any non-built-in page is loaded, and should stop when the browser is closed. No UI or configuration is needed for the extension, as all configuration is done on the server side.
+
+A `setup.sh` script is provided to load the extension into Chrome. Linux and macOS are supported.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `manifest.json` | Manifest V3 extension definition. Permissions: `activeTab`, `tabs`. Content scripts injected on all URLs. |
+| `stealth.js` | Anti-bot-detection patches. Runs at `document_start` in `MAIN` world. Overrides `navigator.webdriver`, plugins, WebGL, permissions, etc. |
+| `content.js` | Injected into every non-chrome:// page. Listens for DOM events, extracts metadata, sends to background. Runs at `document_idle` in `ISOLATED` world. |
+| `background.js` | Service worker. Relays actions to server via HTTP POST. Captures screenshots with `chrome.tabs.captureVisibleTab`. |
+| `setup.sh` | Detects Chrome/Chromium binary on macOS or Linux and launches with `--load-extension` and remote debugging enabled. |
+
+## Event Capture
+
+### Captured Events
+
+`click`, `keydown`, `keyup`, `input`, `scroll`, `change`, `submit`, plus a synthetic `pageLoad` on each navigation.
+
+### Throttling
+
+High-frequency events (`scroll`, `input`) are throttled to one every 500ms. Screenshots are also throttled to one every 500ms.
+
+### Action Payload
+
+Each action sent to the server contains:
+
+```json
+{
+  "type": "click",
+  "timestamp": 1710000001234,
+  "url": "https://example.com/",
+  "target": {
+    "tagName": "BUTTON",
+    "id": "submit-btn",
+    "className": "btn primary",
+    "textContent": "Submit",
+    "xpath": "/html[1]/body[1]/form[1]/button[1]"
+  },
+  "x": 255,
+  "y": 245
+}
+```
+
+Additional fields by event type:
+- **click**: `x`, `y` (coordinates)
+- **keydown/keyup**: `key` (key name)
+- **input/change**: `value` (truncated to 200 chars)
+- **scroll**: `scrollX`, `scrollY`
+- **pageLoad**: `title`
+
+## Anti-Bot-Detection (Stealth)
+
+The extension includes `stealth.js`, a content script injected at `document_start` in the `MAIN` world — meaning it runs before any page JavaScript and patches the page's actual `window`/`navigator` objects (not the extension's isolated world). This reduces the chance of being blocked by reCAPTCHA, Cloudflare Turnstile, and similar bot-detection systems.
+
+The stealth measures are split across three layers:
+
+### Layer 1: Chrome Launch Flags (`entrypoint.sh`)
+
+| Flag | What it does |
+|------|-------------|
+| Removed `--enable-automation` | Was explicitly telling Chrome to set `navigator.webdriver = true` and show the "controlled by automated software" infobar. Removing it eliminates both signals. |
+| Removed `--disable-gpu` | Was disabling all GPU/WebGL rendering. Sites that fingerprint WebGL would see no renderer — a strong headless signal. |
+| `--disable-blink-features=AutomationControlled` | Tells Blink not to set `navigator.webdriver = true`, even if CDP is attached. Belt-and-suspenders with the flag removal. |
+| `--use-gl=angle --use-angle=swiftshader` | Enables software-rendered WebGL via SwiftShader through the ANGLE backend. This makes WebGL available with realistic renderer strings without a real GPU. Trade-off: higher CPU usage since all GL operations run in software. |
+| `--enable-webgl` | Explicitly ensures WebGL contexts can be created. |
+| `--remote-debugging-address=127.0.0.1` | CDP was previously bound to `0.0.0.0` (all interfaces). Now only accessible internally. External access still works through the `socat` forwarder on port 9223. Prevents page JavaScript from detecting CDP by probing network ports. |
+
+### Layer 2: Chrome Profile (`entrypoint.sh`)
+
+An empty Chrome profile with no bookmarks, no history, and no preferences is a strong signal of a freshly-created automated browser. The entrypoint now pre-populates:
+
+- **Preferences**: `accept_languages`, `safebrowsing`, `dns_prefetching`, `window_placement`, `skip_first_run_ui`, etc.
+- **Bookmarks**: Three common entries (Google, YouTube, Wikipedia).
+- **Local State**: Profile metadata with a named profile ("Person 1").
+
+### Layer 3: JavaScript Patches (`stealth.js`)
+
+| # | Patch | Why |
+|---|-------|-----|
+| 1 | `navigator.webdriver → false` | The #1 bot detection signal. Real Chrome returns `false`; automated Chrome returns `true`. Even with the Blink flag, CDP attachment can re-enable it. |
+| 2 | `navigator.languages → ['en-US', 'en']` | Ensures consistent locale regardless of container environment. |
+| 3 | `navigator.plugins` — fake Chrome PDF Plugin, Chrome PDF Viewer, Native Client | Headless/automated Chrome reports an empty `PluginArray` (length 0). Real Chrome always has PDF and NaCl plugins. |
+| 4 | `navigator.mimeTypes` — fake `application/pdf` entries | Must match the fake plugins. Empty mimeTypes = headless signal. |
+| 5 | WebGL `getParameter()` — return SwiftShader vendor/renderer | Even with SwiftShader actually running, this ensures consistent, known-good strings across Chromium versions. Intercepts `UNMASKED_VENDOR_WEBGL` (0x9245) and `UNMASKED_RENDERER_WEBGL` (0x9246). |
+| 6 | `Permissions.query({name:'notifications'})` → `'prompt'`, `Notification.permission` → `'default'` | Automated browsers deny all permissions by default. Real browsers return `'prompt'`/`'default'` for notifications. |
+| 7 | `window.chrome.runtime` — ensure object exists | Some bot detectors check `if (!window.chrome \|\| !window.chrome.runtime)` to distinguish headless Chrome from real Chrome. |
+| 8 | Remove `$cdc_`/`cdc_` properties on `document` | Chromedriver injects these properties. Not used by CDP directly, but removed as a precaution. |
+| 9 | `navigator.hardwareConcurrency` → 8 (if < 4) | Docker containers with limited CPUs may report 1-2, which is suspicious for a desktop browser. |
+| 10 | `navigator.deviceMemory` → 8 (if < 4) | Same — low memory is suspicious for desktop. |
+| 11 | Iframe `navigator.webdriver` patching | Advanced fingerprinters create iframes and check `navigator.webdriver` inside them to bypass page-level overrides. We hook `document.createElement('iframe')` and patch the iframe's navigator on load. |
+
+### Layer 4: Dockerfile
+
+`libegl1` and `libgbm1` are installed to provide the EGL and GBM libraries that Chrome's ANGLE/SwiftShader backend needs. Without them, `--use-gl=angle` silently falls back to no-GPU mode.
+
+### Test Results
+
+Verified against bot-detection sites (2026-03-28):
+
+| Test | Result |
+|------|--------|
+| bot.sannysoft.com | 10/11 main tests pass (only "WebDriver New" orange — CDP attachment quirk; "WebDriver Advanced" passes) |
+| intoli headless detection | "You are not Chrome headless" |
+| Cloudflare (nowsecure.nl) | Soft Turnstile challenge (not hard-blocked) |
+| CreepJS | Fingerprint generated without bot flag |
+
+## Local Development
+
+Run Chrome with the extension loaded:
+
+```bash
+./setup.sh https://example.com
+```
+
+The server must be running on `http://localhost:7878` for the extension to send data.

--- a/packages/evals/datasets/clawbench/runtime/chrome-extension/background.js
+++ b/packages/evals/datasets/clawbench/runtime/chrome-extension/background.js
@@ -1,0 +1,56 @@
+const SERVER = "http://localhost:7878";
+const SCREENSHOT_THROTTLE_MS = 500; // debouncing; otherwise one field input (multi input event) can trigger many screenshots
+
+let lastScreenshot = 0;
+
+// Auto-focus newly created tabs so the agent's working tab is always visible
+chrome.tabs.onCreated.addListener((tab) => {
+  if (tab.id) {
+    chrome.tabs.update(tab.id, { active: true });
+  }
+});
+
+// Receive events from content script
+chrome.runtime.onMessage.addListener((msg, sender) => {
+  if (msg.type === "action") {
+    // Bring the tab where the action occurred to front so the screen recording
+    // and captureVisibleTab always show the tab the agent is working on.
+    if (sender.tab && sender.tab.id) {
+      chrome.tabs.update(sender.tab.id, { active: true });
+    }
+    postAction(msg.data);
+    captureScreenshot();
+  }
+});
+
+async function postAction(data) {
+  try {
+    await fetch(`${SERVER}/api/action`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    });
+  } catch (e) {
+    console.error("[clawbench] postAction failed:", e);
+  }
+}
+
+async function captureScreenshot() {
+  const now = Date.now();
+  if (now - lastScreenshot < SCREENSHOT_THROTTLE_MS) return;
+  lastScreenshot = now;
+
+  try {
+    const dataUrl = await chrome.tabs.captureVisibleTab(null, {
+      format: "png",
+    });
+    const base64 = dataUrl.replace(/^data:image\/png;base64,/, "");
+    await fetch(`${SERVER}/api/screenshot`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ timestamp: now, data: base64 }),
+    });
+  } catch (e) {
+    console.error("[clawbench] captureScreenshot failed:", e);
+  }
+}

--- a/packages/evals/datasets/clawbench/runtime/chrome-extension/content.js
+++ b/packages/evals/datasets/clawbench/runtime/chrome-extension/content.js
@@ -1,0 +1,77 @@
+const THROTTLE_MS = 500;
+const lastSent = {};
+
+function getXPath(el) {
+  if (!el || el.nodeType !== 1) return "";
+  const parts = [];
+  while (el && el.nodeType === 1) {
+    let idx = 1;
+    for (
+      let sib = el.previousElementSibling;
+      sib;
+      sib = sib.previousElementSibling
+    ) {
+      if (sib.tagName === el.tagName) idx++;
+    }
+    parts.unshift(`${el.tagName.toLowerCase()}[${idx}]`);
+    el = el.parentElement;
+  }
+  return "/" + parts.join("/");
+}
+
+function buildPayload(type, e) {
+  const target = e.target || {};
+  const payload = {
+    type,
+    timestamp: Date.now(),
+    url: location.href,
+    target: {
+      tagName: target.tagName || "",
+      id: target.id || "",
+      className: target.className || "",
+      textContent: (target.textContent || "").slice(0, 100),
+      xpath: getXPath(target),
+    },
+  };
+  if (e.clientX !== undefined) {
+    payload.x = e.clientX;
+    payload.y = e.clientY;
+  }
+  if (e.key) payload.key = e.key;
+  if (target.value !== undefined)
+    payload.value = String(target.value).slice(0, 200);
+  if (type === "scroll") {
+    payload.scrollX = window.scrollX;
+    payload.scrollY = window.scrollY;
+  }
+  return payload;
+}
+
+function throttled(type) {
+  return type === "scroll" || type === "input";
+}
+
+function send(type, e) {
+  if (throttled(type)) {
+    const now = Date.now();
+    if (lastSent[type] && now - lastSent[type] < THROTTLE_MS) return;
+    lastSent[type] = now;
+  }
+  chrome.runtime.sendMessage({ type: "action", data: buildPayload(type, e) });
+}
+
+["click", "keydown", "keyup", "input", "scroll", "change", "submit"].forEach(
+  (evt) => {
+    document.addEventListener(evt, (e) => send(evt, e), true);
+  },
+);
+
+chrome.runtime.sendMessage({
+  type: "action",
+  data: {
+    type: "pageLoad",
+    timestamp: Date.now(),
+    url: location.href,
+    title: document.title,
+  },
+});

--- a/packages/evals/datasets/clawbench/runtime/chrome-extension/manifest.json
+++ b/packages/evals/datasets/clawbench/runtime/chrome-extension/manifest.json
@@ -1,0 +1,25 @@
+{
+  "manifest_version": 3,
+  "name": "ClawBench",
+  "version": "1.0",
+  "description": "Browser action recording for benchmarking",
+  "permissions": ["activeTab", "tabs"],
+  "host_permissions": ["<all_urls>"],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["stealth.js"],
+      "run_at": "document_start",
+      "world": "MAIN"
+    },
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "run_at": "document_idle",
+      "all_frames": true
+    }
+  ]
+}

--- a/packages/evals/datasets/clawbench/runtime/chrome-extension/setup.sh
+++ b/packages/evals/datasets/clawbench/runtime/chrome-extension/setup.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+EXT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Detect Chrome binary
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+elif command -v google-chrome-stable &>/dev/null; then
+  CHROME="google-chrome-stable"
+elif command -v google-chrome &>/dev/null; then
+  CHROME="google-chrome"
+elif command -v chromium-browser &>/dev/null; then
+  CHROME="chromium-browser"
+elif command -v chromium &>/dev/null; then
+  CHROME="chromium"
+else
+  echo "Chrome not found" && exit 1
+fi
+
+"$CHROME" \
+  --no-first-run \
+  --disable-default-apps \
+  --remote-debugging-port=9222 \
+  --load-extension="$EXT_DIR" \
+  --disable-extensions-except="$EXT_DIR" \
+  "$@"

--- a/packages/evals/datasets/clawbench/runtime/chrome-extension/stealth.js
+++ b/packages/evals/datasets/clawbench/runtime/chrome-extension/stealth.js
@@ -1,0 +1,233 @@
+/**
+ * stealth.js — Anti-bot-detection patches.
+ *
+ * Injected at document_start in the MAIN world (see manifest.json).
+ * Must run before any page script to reliably override browser fingerprints.
+ */
+
+(function () {
+  "use strict";
+
+  // 1. navigator.webdriver → false (real Chrome returns false, not undefined)
+  try {
+    Object.defineProperty(navigator, "webdriver", {
+      get: () => false,
+      configurable: true,
+    });
+  } catch (_) {}
+
+  // 2. navigator.languages — ensure realistic value
+  try {
+    Object.defineProperty(navigator, "languages", {
+      get: () => ["en-US", "en"],
+      configurable: true,
+    });
+  } catch (_) {}
+
+  // 3. navigator.plugins — fake standard Chrome plugins
+  try {
+    const fakePlugins = [
+      {
+        name: "Chrome PDF Plugin",
+        filename: "internal-pdf-viewer",
+        description: "Portable Document Format",
+      },
+      {
+        name: "Chrome PDF Viewer",
+        filename: "mhjfbmdgcfjbbpaeojofohoefgiehjai",
+        description: "",
+      },
+      {
+        name: "Native Client",
+        filename: "internal-nacl-plugin",
+        description: "",
+      },
+    ];
+
+    const pluginArray = Object.create(PluginArray.prototype);
+    fakePlugins.forEach((p, i) => {
+      const plugin = Object.create(Plugin.prototype);
+      Object.defineProperties(plugin, {
+        name: { get: () => p.name },
+        filename: { get: () => p.filename },
+        description: { get: () => p.description },
+        length: { get: () => 0 },
+      });
+      Object.defineProperty(pluginArray, i, {
+        get: () => plugin,
+        enumerable: true,
+      });
+    });
+    Object.defineProperty(pluginArray, "length", {
+      get: () => fakePlugins.length,
+    });
+    pluginArray.item = (i) => pluginArray[i] || null;
+    pluginArray.namedItem = (name) => {
+      const idx = fakePlugins.findIndex((p) => p.name === name);
+      return idx >= 0 ? pluginArray[idx] : null;
+    };
+    pluginArray.refresh = () => {};
+    pluginArray[Symbol.iterator] = function* () {
+      for (let i = 0; i < fakePlugins.length; i++) yield pluginArray[i];
+    };
+
+    Object.defineProperty(navigator, "plugins", {
+      get: () => pluginArray,
+      configurable: true,
+    });
+  } catch (_) {}
+
+  // 4. navigator.mimeTypes — match the fake plugins
+  try {
+    const fakeMimeTypes = [
+      {
+        type: "application/pdf",
+        suffixes: "pdf",
+        description: "Portable Document Format",
+      },
+      {
+        type: "application/x-google-chrome-pdf",
+        suffixes: "pdf",
+        description: "Portable Document Format",
+      },
+    ];
+
+    const mimeTypeArray = Object.create(MimeTypeArray.prototype);
+    fakeMimeTypes.forEach((m, i) => {
+      const mimeType = Object.create(MimeType.prototype);
+      Object.defineProperties(mimeType, {
+        type: { get: () => m.type },
+        suffixes: { get: () => m.suffixes },
+        description: { get: () => m.description },
+        enabledPlugin: { get: () => null },
+      });
+      Object.defineProperty(mimeTypeArray, i, {
+        get: () => mimeType,
+        enumerable: true,
+      });
+    });
+    Object.defineProperty(mimeTypeArray, "length", {
+      get: () => fakeMimeTypes.length,
+    });
+    mimeTypeArray.item = (i) => mimeTypeArray[i] || null;
+    mimeTypeArray.namedItem = (name) => {
+      const idx = fakeMimeTypes.findIndex((m) => m.type === name);
+      return idx >= 0 ? mimeTypeArray[idx] : null;
+    };
+    mimeTypeArray[Symbol.iterator] = function* () {
+      for (let i = 0; i < fakeMimeTypes.length; i++) yield mimeTypeArray[i];
+    };
+
+    Object.defineProperty(navigator, "mimeTypes", {
+      get: () => mimeTypeArray,
+      configurable: true,
+    });
+  } catch (_) {}
+
+  // 5. WebGL renderer/vendor spoofing
+  try {
+    const WEBGL_VENDOR = "Google Inc. (Google)";
+    const WEBGL_RENDERER =
+      "ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (Subzero) (0x0000C0DE)), SwiftShader driver)";
+
+    const originalGetParameter = WebGLRenderingContext.prototype.getParameter;
+    WebGLRenderingContext.prototype.getParameter = function (param) {
+      if (param === 0x9245) return WEBGL_VENDOR;
+      if (param === 0x9246) return WEBGL_RENDERER;
+      return originalGetParameter.call(this, param);
+    };
+
+    if (typeof WebGL2RenderingContext !== "undefined") {
+      const originalGetParameter2 =
+        WebGL2RenderingContext.prototype.getParameter;
+      WebGL2RenderingContext.prototype.getParameter = function (param) {
+        if (param === 0x9245) return WEBGL_VENDOR;
+        if (param === 0x9246) return WEBGL_RENDERER;
+        return originalGetParameter2.call(this, param);
+      };
+    }
+  } catch (_) {}
+
+  // 6. Permissions API — notifications should return 'prompt', not 'denied'
+  try {
+    const originalQuery = Permissions.prototype.query;
+    Permissions.prototype.query = function (descriptor) {
+      if (descriptor && descriptor.name === "notifications") {
+        return Promise.resolve({ state: "prompt", onchange: null });
+      }
+      return originalQuery.call(this, descriptor);
+    };
+  } catch (_) {}
+
+  try {
+    Object.defineProperty(Notification, "permission", {
+      get: () => "default",
+      configurable: true,
+    });
+  } catch (_) {}
+
+  // 7. window.chrome.runtime — ensure it exists
+  try {
+    if (!window.chrome) {
+      window.chrome = {};
+    }
+    if (!window.chrome.runtime) {
+      window.chrome.runtime = {
+        connect: function () {
+          return {};
+        },
+        sendMessage: function () {},
+      };
+    }
+  } catch (_) {}
+
+  // 8. Remove Chromedriver artifacts
+  try {
+    for (const prop of Object.getOwnPropertyNames(document)) {
+      if (prop.startsWith("$cdc_") || prop.startsWith("cdc_")) {
+        delete document[prop];
+      }
+    }
+  } catch (_) {}
+
+  // 9. navigator.hardwareConcurrency — ensure a reasonable value
+  try {
+    if (navigator.hardwareConcurrency < 4) {
+      Object.defineProperty(navigator, "hardwareConcurrency", {
+        get: () => 8,
+        configurable: true,
+      });
+    }
+  } catch (_) {}
+
+  // 10. navigator.deviceMemory — ensure a reasonable value
+  try {
+    if (!navigator.deviceMemory || navigator.deviceMemory < 4) {
+      Object.defineProperty(navigator, "deviceMemory", {
+        get: () => 8,
+        configurable: true,
+      });
+    }
+  } catch (_) {}
+
+  // 11. Patch iframe contentWindow.navigator to match parent
+  try {
+    const originalCreateElement = document.createElement.bind(document);
+    document.createElement = function (tagName, options) {
+      const el = originalCreateElement(tagName, options);
+      if (tagName.toLowerCase() === "iframe") {
+        el.addEventListener("load", function () {
+          try {
+            if (el.contentWindow && el.contentWindow.navigator) {
+              Object.defineProperty(el.contentWindow.navigator, "webdriver", {
+                get: () => false,
+                configurable: true,
+              });
+            }
+          } catch (_) {}
+        });
+      }
+      return el;
+    };
+  } catch (_) {}
+})();

--- a/packages/evals/datasets/clawbench/runtime/shared/alex_green_personal_info.json
+++ b/packages/evals/datasets/clawbench/runtime/shared/alex_green_personal_info.json
@@ -1,0 +1,451 @@
+{
+  "identity": {
+    "legal_name": {
+      "first": "Alex",
+      "middle": null,
+      "last": "Green"
+    },
+    "preferred_name": "Alex",
+    "date_of_birth": "1980-May-01",
+    "gender": "Female",
+    "pronouns": "she/her",
+    "nationality": "Canadian",
+    "citizenship": [
+      "Canada"
+    ],
+    "marital_status": "Single",
+    "height_cm": 168,
+    "eye_color": "Brown",
+    "mothers_maiden_name": "Campbell",
+    "security_questions": [
+      {
+        "question": "What was the name of your first pet?",
+        "answer": "Buddy"
+      },
+      {
+        "question": "What street did you grow up on?",
+        "answer": "Spadina Ave"
+      },
+      {
+        "question": "What is your favorite book?",
+        "answer": "Designing Data-Intensive Applications"
+      }
+    ],
+    "languages": [
+      {
+        "language": "English",
+        "proficiency": "Native"
+      },
+      {
+        "language": "French",
+        "proficiency": "Intermediate (B1)"
+      }
+    ]
+  },
+  "contact": {
+    "email": "alex.green.uoft@clawbench.cc"
+  },
+  "address": {
+    "home": {
+      "unit": "1208",
+      "street": "664 Spadina Ave",
+      "city": "Toronto",
+      "province": "Ontario",
+      "postal_code": "M5S 2H7",
+      "country": "Canada",
+      "full": "Unit 1208, 664 Spadina Ave, Toronto, ON M5S 2H7, Canada",
+      "residency_since": "1980-05",
+      "previous_addresses": []
+    },
+    "work": {
+      "street": "200 University Ave, Suite 1700",
+      "city": "Toronto",
+      "province": "Ontario",
+      "postal_code": "M5H 3C6",
+      "country": "Canada"
+    },
+    "mailing_same_as_home": true
+  },
+  "education": [
+    {
+      "degree": "Bachelor of Science",
+      "field": "Computer Science",
+      "university": "University of Toronto",
+      "campus": "St. George",
+      "start_date": "1998-09",
+      "graduation_date": "2002-06",
+      "gpa": "3.6/4.0",
+      "honors": "Dean's List (2001, 2002)",
+      "student_id": "1002345674"
+    },
+    {
+      "degree": "Master of Science",
+      "field": "Computer Science",
+      "university": "University of Toronto",
+      "campus": "St. George",
+      "start_date": "2002-09",
+      "graduation_date": "2004-06",
+      "gpa": "3.8/4.0",
+      "thesis": "Efficient Query Processing in Distributed Database Systems",
+      "student_id": "1002345674"
+    },
+    {
+      "degree": "Doctor of Philosophy",
+      "field": "Computer Science",
+      "university": "University of Toronto",
+      "campus": "St. George",
+      "start_date": "2004-09",
+      "graduation_date": "2010-06",
+      "dissertation": "Scalable Real-Time Data Pipeline Architectures for High-Throughput Transaction Processing",
+      "gpa": "3.9/4.0",
+      "supervisor": "Prof. Eldon Marchetti",
+      "student_id": "1002345674"
+    }
+  ],
+  "work_experience": [
+    {
+      "title": "Senior Software Engineer",
+      "company": "Pinecrest Technologies Inc.",
+      "industry": "Enterprise SaaS",
+      "location": "Toronto, ON",
+      "start_date": "2019-03",
+      "end_date": null,
+      "is_current": true,
+      "salary": {
+        "amount": 145000,
+        "currency": "CAD",
+        "period": "annual"
+      },
+      "responsibilities": [
+        "Lead backend team of 5 engineers building distributed data pipelines for enterprise SaaS platform",
+        "Design and implement RESTful APIs serving 2M+ daily requests with sub-100ms p99 latency",
+        "Mentor junior developers and conduct code reviews, improving team velocity by 30%"
+      ],
+      "supervisor": {
+        "name": "Jordan Peters",
+        "title": "VP Engineering",
+        "email": "jordan.peters@pinecresttech.com"
+      }
+    },
+    {
+      "title": "Software Engineer",
+      "company": "Crestridge Digital Corp.",
+      "industry": "FinTech",
+      "location": "Toronto, ON",
+      "start_date": "2012-06",
+      "end_date": "2019-02",
+      "is_current": false,
+      "responsibilities": [
+        "Developed real-time transaction processing systems handling $50M+ daily volume in FinTech",
+        "Built automated testing frameworks reducing QA cycle by 40%",
+        "Collaborated with product team on mobile banking features serving 500K+ users"
+      ],
+      "reason_for_leaving": "Career growth opportunity"
+    },
+    {
+      "title": "Software Developer",
+      "company": "Cedarbrook Solutions Ltd.",
+      "industry": "IT Consulting",
+      "location": "Toronto, ON",
+      "start_date": "2002-09",
+      "end_date": "2012-05",
+      "is_current": false,
+      "note": "Part-time (20 hrs/week) during MSc (2002-2004) and PhD (2004-2010); transitioned to full-time after PhD completion in 2010",
+      "responsibilities": [
+        "Full-stack web development for enterprise clients across multiple industries",
+        "Database administration and performance optimization for high-traffic applications",
+        "Part-time during graduate studies (2002–2010); full-time from 2010"
+      ],
+      "reason_for_leaving": "Seeking specialization in FinTech"
+    }
+  ],
+  "skills": {
+    "technical": [
+      "Python",
+      "Java",
+      "TypeScript",
+      "Go",
+      "PostgreSQL",
+      "Redis",
+      "AWS",
+      "Docker",
+      "Kubernetes",
+      "Terraform",
+      "CI/CD",
+      "REST API Design",
+      "GraphQL",
+      "React",
+      "Node.js"
+    ],
+    "certifications": [
+      {
+        "name": "AWS Solutions Architect – Associate",
+        "issuer": "Amazon Web Services",
+        "date": "2024-08",
+        "expiry": "2027-08",
+        "id": "4GHKL8N2PQRS7T9V"
+      },
+      {
+        "name": "Certified Kubernetes Administrator – CKA",
+        "issuer": "CNCF",
+        "date": "2025-03",
+        "expiry": "2027-03",
+        "id": "LF-k8s7g4m2n1"
+      }
+    ],
+    "soft_skills": [
+      "Team Leadership",
+      "Technical Mentoring",
+      "Cross-functional Collaboration",
+      "Agile/Scrum"
+    ]
+  },
+  "government_ids": {
+    "sin": "472-345-678",
+    "passport": {
+      "number": "JK456789",
+      "country": "Canada",
+      "issue_date": "2021-05-15",
+      "expiry_date": "2031-05-14",
+      "place_of_birth": {
+        "city": "Toronto",
+        "province": "Ontario",
+        "country": "Canada"
+      },
+      "place_of_birth_full": "Toronto, Ontario, Canada"
+    },
+    "drivers_license": {
+      "number": "G4567-89018-05501",
+      "province": "Ontario",
+      "class": "G",
+      "issue_date": "2025-10-01",
+      "expiry_date": "2030-10-01"
+    },
+    "health_card": {
+      "province": "Ontario",
+      "number": "6789-012-345",
+      "version_code": "JG",
+      "expiry_date": "2027-01-01"
+    }
+  },
+  "financial": {
+    "bank_accounts": [
+      {
+        "institution": "TD Canada Trust",
+        "institution_number": "004",
+        "transit_number": "10202",
+        "account_number": "6781234",
+        "type": "Chequing",
+        "is_primary": true
+      },
+      {
+        "institution": "TD Canada Trust",
+        "institution_number": "004",
+        "transit_number": "10202",
+        "account_number": "6785678",
+        "type": "Savings",
+        "is_primary": false
+      }
+    ],
+    "credit_cards": [
+      {
+        "issuer": "TD",
+        "type": "TD Aeroplan Visa Infinite",
+        "number": "4519873424604532",
+        "number_formatted": "4519 8734 2460 4532",
+        "expiry": "2028-09",
+        "expiry_formatted": "09/28",
+        "cvv": "847",
+        "cardholder_name": "ALEX GREEN",
+        "billing_address_same_as_home": true
+      },
+      {
+        "issuer": "CIBC",
+        "type": "CIBC Aventura Visa",
+        "number": "4732001596738901",
+        "number_formatted": "4732 0015 9673 8901",
+        "expiry": "2027-04",
+        "expiry_formatted": "04/27",
+        "cvv": "263",
+        "cardholder_name": "ALEX GREEN",
+        "billing_address_same_as_home": true
+      }
+    ],
+    "annual_income_cad": 145000,
+    "tax_filing_status": "Single",
+    "rrsp_contribution_room": 42000,
+    "tfsa_contribution_room": 64000,
+    "investment_accounts": [
+      {
+        "platform": "Wealthsimple",
+        "account_type": "TFSA",
+        "balance_approx": 45000
+      },
+      {
+        "platform": "Wealthsimple",
+        "account_type": "Personal (Non-registered)",
+        "balance_approx": 22000
+      },
+      {
+        "platform": "Questrade",
+        "account_type": "RRSP",
+        "balance_approx": 120000
+      }
+    ],
+    "investment_profile": {
+      "knowledge_level": "Advanced",
+      "investment_objectives": "Long-term growth",
+      "risk_tolerance": "Medium-High",
+      "time_horizon": "10+ years",
+      "employment_status": "Employed",
+      "years_investing": 15
+    },
+    "net_worth_range": "500K-1M",
+    "liquid_assets_range": "100K-250K"
+  },
+  "insurance": {
+    "health": {
+      "provider": "OHIP (Ontario Health Insurance Plan)",
+      "number": "6789-012-345",
+      "supplementary": {
+        "provider": "Sun Life (via employer)",
+        "group_number": "502341",
+        "member_id": "12345-A",
+        "coverage": [
+          "Dental",
+          "Vision",
+          "Prescription",
+          "Paramedical"
+        ]
+      }
+    },
+    "auto": {
+      "provider": "Aviva Canada",
+      "policy_number": "W20247890",
+      "coverage_type": "Comprehensive",
+      "deductible": 500,
+      "expiry": "2026-07-01"
+    },
+    "home_tenant": {
+      "provider": "Square One Insurance",
+      "policy_number": "SQ1-T-2025-34567",
+      "type": "Tenant",
+      "monthly_premium": 45,
+      "expiry": "2027-04-01"
+    }
+  },
+  "vehicle": {
+    "make": "Honda",
+    "model": "Civic",
+    "year": 2021,
+    "color": "Lunar Silver Metallic",
+    "vin": "2HGFC2F6XMH012345",
+    "plate": "CQXW 234",
+    "province": "Ontario",
+    "fuel_type": "Gasoline",
+    "odometer_km": 38000
+  },
+  "pet": {
+    "name": "Maple",
+    "species": "Dog",
+    "breed": "Golden Retriever",
+    "age_years": 4,
+    "weight_lbs": 65,
+    "sex": "Female (spayed)",
+    "microchip_id": "985121012345678",
+    "vaccinations_up_to_date": true,
+    "date_of_birth": "2022-03-15",
+    "vet": {
+      "name": "Harbord Veterinary Hospital",
+      "address": "599 Harbord St, Toronto, ON"
+    },
+    "dietary_notes": "Grain-free kibble, sensitive stomach"
+  },
+  "medical": {
+    "blood_type": "A+",
+    "allergies": [
+      "Penicillin",
+      "Shellfish"
+    ],
+    "current_medications": [
+      {
+        "name": "Levothyroxine",
+        "dosage": "50mcg",
+        "frequency": "daily",
+        "prescriber": "Dr. Linnea Vanderholt",
+        "rx_number": "RX-2024-08-33741",
+        "din": "02550717"
+      }
+    ],
+    "family_doctor": {
+      "name": "Dr. Linnea Vanderholt",
+      "clinic": "Harbord Health Centre"
+    },
+    "pharmacy": {
+      "name": "Shoppers Drug Mart",
+      "address": "360A Bloor St W, Toronto, ON"
+    },
+    "emergency_contact": {
+      "name": "Emily Green",
+      "relationship": "Sister"
+    }
+  },
+  "preferences": {
+    "dietary": {
+      "restrictions": [
+        "Shellfish allergy"
+      ],
+      "preferences": [
+        "Low sodium",
+        "Mediterranean-style"
+      ],
+      "favorite_cuisines": [
+        "Japanese",
+        "Italian",
+        "Thai"
+      ]
+    },
+    "travel": {
+      "seat_preference": "Window",
+      "meal_preference": "Regular (no shellfish)",
+      "hotel_preferences": [
+        "Non-smoking",
+        "High floor",
+        "Quiet room"
+      ],
+      "loyalty_programs": [
+        {
+          "program": "Aeroplan",
+          "number": "284567890"
+        },
+        {
+          "program": "Marriott Bonvoy",
+          "number": "847293156"
+        },
+        {
+          "program": "Airbnb",
+          "account_linked_to_google": true
+        }
+      ],
+      "passport_country": "Canada",
+      "known_traveller_number": "981234567",
+      "nexus_card": "981234567"
+    },
+    "communication": {
+      "preferred_language": "English",
+      "timezone": "America/Toronto",
+      "preferred_contact_method": "Email",
+      "notification_preferences": "Email + push, no phone calls"
+    },
+    "shopping": {
+      "clothing_size": {
+        "top": "M",
+        "bottom": "8",
+        "shoe": "US 8.5"
+      },
+      "shipping_preference": "Standard (free) when available",
+      "amazon_prime": true
+    }
+  },
+  "professional_summary": "Senior Software Engineer with 23+ years of experience in full-stack development, distributed systems, and cloud infrastructure. PhD in Computer Science from the University of Toronto. Currently leading a backend team at Pinecrest Technologies Inc., building enterprise data pipeline solutions. Previously built real-time transaction processing systems in FinTech. AWS and Kubernetes certified."
+}

--- a/packages/evals/datasets/clawbench/test-cases/task.schema.json
+++ b/packages/evals/datasets/clawbench/test-cases/task.schema.json
@@ -1,0 +1,151 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "task.schema.json",
+  "title": "ClawBench Test Case",
+  "description": "Schema for ClawBench test case task.json files",
+  "type": "object",
+  "properties": {
+    "$schema": true,
+    "metadata": {
+      "type": "object",
+      "description": "Human-readable metadata for documentation purposes (not read by the agent)",
+      "properties": {
+        "task_id": {
+          "type": "integer",
+          "description": "Unique numeric identifier for the test case"
+        },
+        "metaclass": {
+          "type": "string",
+          "description": "High-level category of the test case"
+        },
+        "class": {
+          "type": "string",
+          "description": "Granular sub-category of the test case"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of the test case"
+        },
+        "sites_involved": {
+          "type": "array",
+          "description": "Site domains involved in the test case (e.g., google.com, uber.com, github.com, etc.)",
+          "items": {
+            "type": "string"
+          }
+        },
+        "platform": {
+          "type": "string",
+          "description": "Platform involved in the test case (e.g., google, uber, github, etc.)"
+        },
+        "common_info": {
+          "type": "object",
+          "description": "Common information that is shared among all test cases",
+          "properties": {
+            "email_credentials": {
+              "const": "credentials to use the assigned disposable email account"
+            },
+            "user_info": {
+              "const": "alex_green_personal_info.json; the dummy user's personal information"
+            },
+            "user_resume": {
+              "const": "PDF resume with disposable email account injected"
+            }
+          },
+          "required": ["email_credentials", "user_info", "user_resume"],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": true,
+      "required": [
+        "task_id",
+        "metaclass",
+        "class",
+        "description",
+        "sites_involved",
+        "platform",
+        "common_info"
+      ]
+    },
+    "instruction": {
+      "type": "string",
+      "description": "Task prompt sent to the agent"
+    },
+    "eval_schema": {
+      "type": "object",
+      "description": "Configuration for the request interceptor. The interceptor blocks HTTP requests matching the URL pattern, method, and optional body/params filters, preventing irreversible actions (checkout, submission, etc.) from reaching the server.",
+      "properties": {
+        "url_pattern": {
+          "type": "string",
+          "description": "Regex pattern the request URL must match to be blocked by the interceptor"
+        },
+        "method": {
+          "type": "string",
+          "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"],
+          "description": "HTTP method the request must match to be blocked"
+        },
+        "body": {
+          "type": "object",
+          "description": "Key-value pairs that must match exactly in the request body. Used to disambiguate when URL + method alone isn't specific enough (e.g., same endpoint for login vs send)."
+        },
+        "params": {
+          "type": "object",
+          "description": "Key-value pairs that must match exactly in the URL query parameters. Used to disambiguate when URL + method alone isn't specific enough."
+        }
+      },
+      "required": ["url_pattern", "method"],
+      "additionalProperties": false
+    },
+    "time_limit": {
+      "type": "number",
+      "description": "Maximum time in minutes before the driver stops the container",
+      "minimum": 1
+    },
+    "extra_info": {
+      "type": "array",
+      "description": "Additional context injected into the agent prompt",
+      "items": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "Relative path to a file in the test case directory (optional)"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description text injected into the agent prompt"
+          }
+        },
+        "required": [
+          "path",
+          "description"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "judge_context": {
+      "type": "object",
+      "description": "Hidden context used only by the LLM judge; never injected into the agent prompt.",
+      "properties": {
+        "rubric": {
+          "type": "string",
+          "description": "Task-specific judging rubric"
+        },
+        "reference_solution": {
+          "type": "string",
+          "description": "Reference solution or expected answer details"
+        },
+        "source_task_yaml": {
+          "type": "string",
+          "description": "Raw source task.yaml content, when converted from another corpus"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "instruction",
+    "eval_schema",
+    "time_limit"
+  ],
+  "additionalProperties": false
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-047-daily-life-personal-care-taskrabbit/extra_info/address_info.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-047-daily-life-personal-care-taskrabbit/extra_info/address_info.json
@@ -1,0 +1,7 @@
+{
+  "note": "Use home address from alex_green_personal_info.json",
+  "move out address": "Unit 1208, 664 Spadina Ave, Toronto, ON M5S 2H7, Canada",
+  "move in address": "450 Front St W, Toronto, ON M5V 0V7",
+  "Task size": "Large",
+  "Need Vehicle": "Yes, a Car"
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-047-daily-life-personal-care-taskrabbit/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-047-daily-life-personal-care-taskrabbit/task.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 47,
+    "metaclass": "daily-life",
+    "class": "personal-care",
+    "description": "Find a moving helper on TaskRabbit, next Saturday 9am-1pm, 1 bedroom apartment",
+    "sites_involved": [
+      "taskrabbit.com"
+    ],
+    "platform": "taskrabbit",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Find a moving helper on TaskRabbit, next Saturday 9am-1pm, 1 bedroom apartment",
+  "eval_schema": {
+    "url_pattern": "taskrabbit\\.(com|ca)/(api/v\\d+/jobs|book/\\d+/confirm)",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": [
+    {
+      "path": "extra_info/address_info.json",
+      "description": "Address information (references alex_green_personal_info.json)"
+    }
+  ]
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-086-job-search-hr-cv-autofill-greenhouse-meta/extra_info/job_links.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-086-job-search-hr-cv-autofill-greenhouse-meta/extra_info/job_links.json
@@ -1,0 +1,5 @@
+{
+  "job_url": "https://boards.greenhouse.io/example/jobs/1234567",
+  "job_title": "Senior Software Engineer",
+  "company": "Example Corp"
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-086-job-search-hr-cv-autofill-greenhouse-meta/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-086-job-search-hr-cv-autofill-greenhouse-meta/task.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 86,
+    "metaclass": "job-search-hr",
+    "class": "cv-autofill",
+    "description": "Extract information from resume.pdf and fill out the Meta Senior Software Engineer application on Greenhouse",
+    "sites_involved": [
+      "greenhouse.com"
+    ],
+    "platform": "greenhouse-meta",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Register on GreeHouse, Extract information from resume.pdf and fill out the Meta Senior Software Engineer application on Greenhouse",
+  "eval_schema": {
+    "url_pattern": "boards-api\\.greenhouse\\.io/v1/boards/.+/jobs/\\d+|job-boards\\.greenhouse\\.io/.+/jobs/\\d+",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": [
+    {
+      "path": "extra_info/job_links.json",
+      "description": "Job posting URL(s) to apply to"
+    }
+  ]
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-089-job-search-hr-cv-autofill-simplify-jobs/extra_info/job_links.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-089-job-search-hr-cv-autofill-simplify-jobs/extra_info/job_links.json
@@ -1,0 +1,5 @@
+{
+  "job_url": "https://boards.greenhouse.io/example/jobs/1234567",
+  "job_title": "Senior Software Engineer",
+  "company": "Example Corp"
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-089-job-search-hr-cv-autofill-simplify-jobs/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-089-job-search-hr-cv-autofill-simplify-jobs/task.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 89,
+    "metaclass": "job-search-hr",
+    "class": "cv-autofill",
+    "description": "Use Simplify Jobs to one-click auto-fill the Amazon Applied Scientist application",
+    "sites_involved": [
+      "simplify.jobs"
+    ],
+    "platform": "simplify-jobs",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Use Simplify Jobs to one-click auto-fill the Amazon Applied Scientist application",
+  "eval_schema": {
+    "url_pattern": "api\\.simplify\\.jobs/v2/candidate/me/application",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": [
+    {
+      "path": "extra_info/job_links.json",
+      "description": "Job posting URL(s) to apply to"
+    }
+  ]
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-091-job-search-hr-job-apply-indeed/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-091-job-search-hr-job-apply-indeed/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 91,
+    "metaclass": "job-search-hr",
+    "class": "job-apply",
+    "description": "Search \"Senior Software Engineer\" (Toronto) on Indeed, apply to the top-ranked listing",
+    "sites_involved": [
+      "indeed.com"
+    ],
+    "platform": "indeed",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Search \"Senior Software Engineer\" (Toronto) on Indeed, apply to the top-ranked listing",
+  "eval_schema": {
+    "url_pattern": "smartapply\\.indeed\\.com/beta/indeedapply/resumeapply|apply\\.indeed\\.com/indeedapply/postresumeapply|smartapply\\.indeed\\.com/beta/indeedapply/submit",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1010-rating-voting-review-myrecipes/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1010-rating-voting-review-myrecipes/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1010,
+    "metaclass": "rating-voting",
+    "class": "rating",
+    "description": "Rate a Vegan Chocolate Chip Cookies Recipe on MyRecipes with 4 stars and add a helpful tip",
+    "sites_involved": [
+      "myrecipes.com"
+    ],
+    "platform": "myrecipes",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Rate a Vegan Chocolate Chip Cookies Recipe on MyRecipes with 4 stars and add a helpful tip",
+  "eval_schema": {
+    "url_pattern": "myrecipes\\.com/api/v\\d+/review/save",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1033-education-learning-registration-khanacademy/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1033-education-learning-registration-khanacademy/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1033,
+    "metaclass": "education-learning",
+    "class": "registration",
+    "description": "Navigate to the 'World War I: military & diplomacy' lesson on Khan Academy",
+    "sites_involved": [
+      "khanacademy.org"
+    ],
+    "platform": "khanacademy",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Navigate to the 'World War I: military & diplomacy' lesson on Khan Academy",
+  "eval_schema": {
+    "url_pattern": "khanacademy\\.org/humanities/ap-us-history/period-7/apush-world-war-i-military-and-diplomacy-lesson",
+    "method": "GET"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1035-education-learning-enrollment-edx/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1035-education-learning-enrollment-edx/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1035,
+    "metaclass": "education-learning",
+    "class": "enrollment",
+    "description": "Enroll in the free 'Machine Learning with Python: from Linear Models to Deep Learning' course by MIT on edX",
+    "sites_involved": [
+      "edx.org"
+    ],
+    "platform": "edx",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Log into edX and enroll in the free 'Machine Learning with Python: from Linear Models to Deep Learning' course by MIT on edX",
+  "eval_schema": {
+    "url_pattern": "www\\.edx\\.org/(track-select/|learn/)",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1045-weworkremotely/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1045-weworkremotely/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1045,
+    "metaclass": "jobs",
+    "class": "posting",
+    "description": "Go to We Work Remotely (https://weworkremotely.com/remote-jobs/new) and complete the 4-step job posting form to post a remote job listing. Fill in all required fields across all steps and place the order.",
+    "sites_involved": [
+      "weworkremotely.com"
+    ],
+    "platform": "weworkremotely",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Go to We Work Remotely (https://weworkremotely.com/remote-jobs/new) and complete the 4-step job posting form to post a remote job listing. Fill in all required fields across all steps and place the order.",
+  "eval_schema": {
+    "url_pattern": "weworkremotely\\.com/listings",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1065b-daily-life-home-services-handy/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1065b-daily-life-home-services-handy/task.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1065,
+    "metaclass": "daily-life",
+    "class": "home-services",
+    "description": "Navigate to handy.com/services/home-cleaning, fill in ZIP 11201, 3 beds, 2 baths, next Saturday at 9am, 3 hours, then click 'Get a Price'.",
+    "sites_involved": [
+      "handy.com"
+    ],
+    "platform": "handy",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "task_key": "1065b"
+  },
+  "instruction": "Get a price quote on Handy for a house cleaning service for next Saturday at 9am for a 3-bedroom, 2-bathroom apartment in Brooklyn (ZIP 11201). Select 3 hours duration.",
+  "eval_schema": {
+    "url_pattern": "handy\\.com/quotes/\\d+/finalize",
+    "method": "GET"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1088-nonprofit-charity-petition-change/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1088-nonprofit-charity-petition-change/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1088,
+    "metaclass": "nonprofit-charity",
+    "class": "petition",
+    "description": "Start a petition on Change.org to add more late-night bus routes in downtown Toronto",
+    "sites_involved": [
+      "change.org"
+    ],
+    "platform": "change",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Start a petition on Change.org to add more late-night bus routes in downtown Toronto",
+  "eval_schema": {
+    "url_pattern": "change\\.org/api-proxy/graphql.*op=GenerateAiDraft|change\\.org/api-proxy/graphql.*op=CreatePetition|change\\.org/api-proxy/graphql.*op=SAPCreatePetition",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1093-personal-management-travel-tripit/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1093-personal-management-travel-tripit/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1093,
+    "metaclass": "personal-management",
+    "class": "travel",
+    "description": "Create a travel itinerary on TripIt for a 7-day trip to Vancouver from June 15 to June 22 with a flight from SFO",
+    "sites_involved": [
+      "tripit.com"
+    ],
+    "platform": "tripit",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Create a travel itinerary on TripIt for a 7-day trip to Vancouver from June 15 to June 22 with a flight from SFO",
+  "eval_schema": {
+    "url_pattern": "tripit\\.com/api/v\\d+/create",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1095-health-mealplan-eatthismuch/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1095-health-mealplan-eatthismuch/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1095,
+    "metaclass": "health-fitness",
+    "class": "mealplan",
+    "description": "Add a new custom meal type called 'Morning Snack' to your Eat This Much meal layout. Set the meal size to 'Tiny' and the cooking preference to 'No Cooking', then save it.",
+    "sites_involved": [
+      "eatthismuch.com"
+    ],
+    "platform": "eatthismuch",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Add a new custom meal type called 'Morning Snack' to your Eat This Much meal layout. Set the meal size to 'Tiny' and the cooking preference to 'No Cooking', then save it.",
+  "eval_schema": {
+    "url_pattern": "eatthismuch\\.com/api/v\\d+/mealtype/",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1097-beauty-personal-care-shopping-theordinary/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1097-beauty-personal-care-shopping-theordinary/task.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1097,
+    "metaclass": "beauty-personal-care",
+    "class": "shopping",
+    "description": "Add The Ordinary Niacinamide 10% + Zinc 1% and Hyaluronic Acid 2% + B5 (with Ceramides) to cart on The Ordinary website",
+    "sites_involved": [
+      "theordinary.com"
+    ],
+    "platform": "theordinary",
+    "product_urls": [
+      "https://theordinary.com/en-us/niacinamide-10-zinc-1-serum-100436.html",
+      "https://theordinary.com/en-us/hyaluronic-acid-2-b5-serum-with-ceramides-100637.html"
+    ],
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Add The Ordinary Niacinamide 10% + Zinc 1% and Hyaluronic Acid 2% + B5 (with Ceramides) to cart on The Ordinary website",
+  "eval_schema": {
+    "url_pattern": "theordinary\\.com.*Cart-AddProduct",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1100-food-cooking-collection-myrecipes/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1100-food-cooking-collection-myrecipes/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1100,
+    "metaclass": "food-cooking",
+    "class": "collection",
+    "description": "Add Baked Ziti to Want to Try collection on MyRecipes",
+    "sites_involved": [
+      "myrecipes.com"
+    ],
+    "platform": "myrecipes",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Add Baked Ziti to Want to Try collection on MyRecipes",
+  "eval_schema": {
+    "url_pattern": "myrecipes\\.com/collections/bookmarks/save",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1101-hobbies-gaming-discussion-ravelry/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1101-hobbies-gaming-discussion-ravelry/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1101,
+    "metaclass": "hobbies-gaming",
+    "class": "discussion",
+    "description": "Post a fun discussion topic in 'Sock Knitters' group on Ravelry",
+    "sites_involved": [
+      "ravelry.com"
+    ],
+    "platform": "ravelry",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Post a fun discussion topic in 'Sock Knitters' group on Ravelry",
+  "eval_schema": {
+    "url_pattern": "ravelry\\.com/discuss/[^/]+/topics",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1102-fitness-social-post-strava/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1102-fitness-social-post-strava/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1102,
+    "metaclass": "fitness",
+    "class": "social",
+    "description": "Publish a post on Strava with the caption 'Great morning ride!' via the athlete Posts page",
+    "sites_involved": [
+      "strava.com"
+    ],
+    "platform": "strava",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Publish a post on Strava with the caption 'Great morning ride!'",
+  "eval_schema": {
+    "url_pattern": "strava\\.com\\/athletes\\/\\d+\\/posts",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1103-fitness-club-strava/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1103-fitness-club-strava/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1103,
+    "metaclass": "fitness",
+    "class": "club",
+    "description": "Create a cycling club on Strava called 'Portland Weekend Riders' for casual group rides every Saturday morning in Portland, OR",
+    "sites_involved": [
+      "strava.com"
+    ],
+    "platform": "strava",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Create a cycling club on Strava called 'Portland Weekend Riders' for casual group rides every Saturday morning in Portland, OR",
+  "eval_schema": {
+    "url_pattern": "strava\\.com\\/clubs",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1104-fitness-edit-activity-strava/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1104-fitness-edit-activity-strava/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1104,
+    "metaclass": "fitness",
+    "class": "activity-edit",
+    "description": "Navigate to the most recent Strava activity, open the edit form, and save a new description",
+    "sites_involved": [
+      "strava.com"
+    ],
+    "platform": "strava",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Edit the most recent activity on Strava and add the description 'Felt strong today — great tempo throughout.'",
+  "eval_schema": {
+    "url_pattern": "strava\\.com\\/activities\\/\\d+",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1107-hobbies-gaming-forum-boardgamegeek/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1107-hobbies-gaming-forum-boardgamegeek/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1107,
+    "metaclass": "hobbies-gaming",
+    "class": "forum",
+    "description": "Post a question in the 'Ticket to Ride' forum on BoardGameGeek asking about the best strategy for long routes",
+    "sites_involved": [
+      "boardgamegeek.com"
+    ],
+    "platform": "boardgamegeek",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Post a question in the 'Ticket to Ride' forum on BoardGameGeek asking about the best strategy for long routes",
+  "eval_schema": {
+    "url_pattern": "geekdo\\.com/api/thread",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1108-civic-petition-change/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1108-civic-petition-change/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1108,
+    "metaclass": "civic-engagement",
+    "class": "petition",
+    "description": "Start a petition on Change.org to install more bike lanes on Market Street in San Francisco",
+    "sites_involved": [
+      "change.org"
+    ],
+    "platform": "change",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Start a petition on Change.org to install more bike lanes on Market Street in San Francisco",
+  "eval_schema": {
+    "url_pattern": "change\\.org/api-proxy/graphql.*op=GenerateAiDraft|change\\.org/api-proxy/graphql.*op=CreatePetition|change\\.org/api-proxy/graphql.*op=SAPCreatePetition",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1111-civic-petition-change/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1111-civic-petition-change/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1111,
+    "metaclass": "civic-engagement",
+    "class": "petition",
+    "description": "On Change.org, write and publish a petition from scratch (without AI assistance) calling for free public Wi-Fi in all New York City public libraries",
+    "sites_involved": [
+      "change.org"
+    ],
+    "platform": "change",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "On Change.org, write and publish a petition from scratch (without AI assistance) calling for free public Wi-Fi in all New York City public libraries",
+  "eval_schema": {
+    "url_pattern": "change\\.org/api-proxy/graphql.*op=SAPCreatePetition",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1112-nonprofit-petition-update-change/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1112-nonprofit-petition-update-change/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1112,
+    "metaclass": "nonprofit-charity",
+    "class": "petition-management",
+    "description": "On Change.org, find your most recently created petition and post a supporter update announcing that the petition has reached a new milestone and urging followers to keep sharing",
+    "sites_involved": [
+      "change.org"
+    ],
+    "platform": "change",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "On Change.org, find your most recently created petition and post a supporter update announcing that the petition has reached a new milestone and urging followers to keep sharing",
+  "eval_schema": {
+    "url_pattern": "change\\.org/api-proxy/graphql.*op=CreatePetitionUpdate",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1113-health-mealplan-eatthismuch/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1113-health-mealplan-eatthismuch/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1113,
+    "metaclass": "health-fitness",
+    "class": "mealplan",
+    "description": "Set your dietary preferences on Eat This Much to keto with a daily budget of $15, then navigate to the planner and regenerate today's meals.",
+    "sites_involved": [
+      "eatthismuch.com"
+    ],
+    "platform": "eatthismuch",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Set your dietary preferences on Eat This Much to keto with a daily budget of $15, then navigate to the planner and regenerate today's meals.",
+  "eval_schema": {
+    "url_pattern": "eatthismuch\\.com/g/generate/day",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1114-education-enrollment-edx/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1114-education-enrollment-edx/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1114,
+    "metaclass": "education",
+    "class": "enrollment",
+    "description": "Enroll in the free 'Introduction to Computer Science' course by Harvard (CS50) on edX",
+    "sites_involved": [
+      "edx.org"
+    ],
+    "platform": "edx",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Log into edX and enroll in the free 'Introduction to Computer Science' course by Harvard (CS50) on edX",
+  "eval_schema": {
+    "url_pattern": "www\\.edx\\.org/(track-select/|learn/)",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1115-education-enrollment-edx/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1115-education-enrollment-edx/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1115,
+    "metaclass": "education",
+    "class": "enrollment",
+    "description": "Enroll in the free 'Algorithmic Design and Techniques' course by UC San Diego on edX",
+    "sites_involved": [
+      "edx.org"
+    ],
+    "platform": "edx",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Log into edX and enroll in the free 'Algorithmic Design and Techniques' course by UC San Diego on edX",
+  "eval_schema": {
+    "url_pattern": "www\\.edx\\.org/(track-select/|learn/)",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1116-education-enrollment-edx/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1116-education-enrollment-edx/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1116,
+    "metaclass": "education",
+    "class": "enrollment",
+    "description": "Enroll in the free 'Python Basics for Data Science' course by IBM on edX",
+    "sites_involved": [
+      "edx.org"
+    ],
+    "platform": "edx",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Log into edX and enroll in the free 'Python Basics for Data Science' course by IBM on edX",
+  "eval_schema": {
+    "url_pattern": "www\\.edx\\.org/(track-select/|learn/)",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1117/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1117/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1117,
+    "metaclass": "web_task",
+    "class": "registration",
+    "description": "Register for a free recurring wellness meetup event in Austin on Eventbrite",
+    "sites_involved": [
+      "https://www.eventbrite.com"
+    ],
+    "platform": "Eventbrite",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Search for the 'Hearts2Heal Monthly Wellness Meetup' event in Austin, TX on Eventbrite and register for the next available date.\n\nNote: The event is free and held on the 4th Tuesday of each month at Capital Factory, Austin TX. Event URL: https://www.eventbrite.com/e/hearts2heal-monthly-wellness-meetup-tickets-1983102574183",
+  "eval_schema": {
+    "url_pattern": "eventbrite\\.com/purchase-flow-webapp/api/v\\d+/orders/create",
+    "method": "POST"
+  },
+  "time_limit": 120,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1118/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1118/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1118,
+    "metaclass": "web_task",
+    "class": "registration",
+    "description": "Register for 2 free tickets to a Latin food festival in Chicago on Eventbrite",
+    "sites_involved": [
+      "https://www.eventbrite.com"
+    ],
+    "platform": "Eventbrite",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Find the 'Sazón Latin Food Festival 2026: Chicago's Taste of Latin American Food' on Eventbrite and register for 2 General Admission tickets.\n\nNote: The event is free and takes place on Sunday, June 14, 2026, 12 PM – 5 PM at KOVAL Store, Chicago, IL. Event URL: https://www.eventbrite.com/e/sazon-latin-food-festival-2026-chicagos-taste-of-latin-american-food-tickets-1980904085444",
+  "eval_schema": {
+    "url_pattern": "eventbrite\\.com/purchase-flow-webapp/api/v\\d+/orders/create",
+    "method": "POST"
+  },
+  "time_limit": 120,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1120b-services-booking-handy/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1120b-services-booking-handy/task.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1120,
+    "metaclass": "home-services",
+    "class": "booking",
+    "description": "Navigate to handy.com/services/furniture-assembly, enter ZIP 11201, set 1 medium furniture item, add the job description, set date to next Friday at 2pm, then click 'Get a Price'.",
+    "sites_involved": [
+      "handy.com"
+    ],
+    "platform": "handy",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "task_key": "1120b"
+  },
+  "instruction": "Get a price quote on Handy for a furniture assembly service for next Friday at 2pm in Brooklyn (ZIP 11201) for 1 medium furniture item. Add the description 'IKEA KALLAX bookshelf assembly' in the job description field.",
+  "eval_schema": {
+    "url_pattern": "handy\\.com/quotes/\\d+/finalize",
+    "method": "GET"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1121b-services-booking-handy/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1121b-services-booking-handy/task.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1121,
+    "metaclass": "home-services",
+    "class": "booking",
+    "description": "Navigate to handy.com/services/tv-mounting, enter ZIP 11201, set quantity to 1 TV, set date to next Wednesday at 10am, then click 'Get a Price'.",
+    "sites_involved": [
+      "handy.com"
+    ],
+    "platform": "handy",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    },
+    "task_key": "1121b"
+  },
+  "instruction": "Get a price quote on Handy for a TV mounting service for next Wednesday at 10am in Brooklyn (ZIP 11201) for 1 TV.",
+  "eval_schema": {
+    "url_pattern": "handy\\.com/quotes/\\d+/finalize",
+    "method": "GET"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1122-education-course-khanacademy/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1122-education-course-khanacademy/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1122,
+    "metaclass": "education",
+    "class": "course",
+    "description": "Navigate to the Algebra 1 linear equations unit on Khan Academy and submit an answer to the first practice exercise question",
+    "sites_involved": [
+      "khanacademy.org"
+    ],
+    "platform": "khanacademy",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Navigate to the 'Algebra 1' course on Khan Academy, go to the 'Linear equations & graphs' unit, and answer the first question of the 'Solutions to 2-variable equations' practice exercise",
+  "eval_schema": {
+    "url_pattern": "khanacademy\\.org/api/internal/graphql/attemptProblem",
+    "method": "POST"
+  },
+  "time_limit": 60,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1123-education-course-khanacademy/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1123-education-course-khanacademy/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1123,
+    "metaclass": "education",
+    "class": "course",
+    "description": "Navigate to the AP Biology Cell cycle lesson on Khan Academy and submit an answer to the practice exercise",
+    "sites_involved": [
+      "khanacademy.org"
+    ],
+    "platform": "khanacademy",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Navigate to the AP Biology 'Cell Communication and Cell Cycle' unit on Khan Academy, go to the 'Cell cycle' lesson, and answer the first question of the Cell cycle practice exercise",
+  "eval_schema": {
+    "url_pattern": "khanacademy\\.org/api/internal/graphql/attemptProblem",
+    "method": "POST"
+  },
+  "time_limit": 60,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1124-education-course-khanacademy/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1124-education-course-khanacademy/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1124,
+    "metaclass": "education",
+    "class": "course",
+    "description": "Search for 'Organic Chemistry' on Khan Academy and add the course to your learning list",
+    "sites_involved": [
+      "khanacademy.org"
+    ],
+    "platform": "khanacademy",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Search for 'Organic Chemistry' on Khan Academy and add the course to your learning list",
+  "eval_schema": {
+    "url_pattern": "khanacademy\\.org/api/internal/graphql/setUserCourses",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1125-education-course-khanacademy/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1125-education-course-khanacademy/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1125,
+    "metaclass": "education",
+    "class": "course",
+    "description": "Navigate through AP US History to the WWI military and diplomacy practice exercise and submit an answer",
+    "sites_involved": [
+      "khanacademy.org"
+    ],
+    "platform": "khanacademy",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "On Khan Academy, navigate to the AP US History course, go to the 'World War I: military and diplomacy' lesson, and answer the first question of the practice exercise",
+  "eval_schema": {
+    "url_pattern": "khanacademy\\.org/api/internal/graphql/attemptProblem",
+    "method": "POST"
+  },
+  "time_limit": 60,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1126-food-cooking-collection-myrecipes/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1126-food-cooking-collection-myrecipes/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1126,
+    "metaclass": "food-cooking",
+    "class": "collection",
+    "description": "Search for 'chicken soup' on MyRecipes and save the top result to your Want to Try collection",
+    "sites_involved": [
+      "myrecipes.com"
+    ],
+    "platform": "myrecipes",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Search for 'chicken soup' on MyRecipes and save the top result to your Want to Try collection",
+  "eval_schema": {
+    "url_pattern": "myrecipes\\.com/collections/bookmarks/save",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1130-training-class-search-redcross/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1130-training-class-search-redcross/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1130,
+    "metaclass": "charity",
+    "class": "search",
+    "description": "Search for CPR certification classes by zip code on the Red Cross training site",
+    "sites_involved": [
+      "redcross.org"
+    ],
+    "platform": "redcross",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Search for CPR certification classes in zip code 10001 on the Red Cross training website and find the first available in-person class",
+  "eval_schema": {
+    "url_pattern": "redcross\\.org\\/take-a-class\\/search.*(?:q|query|zip|searchtype|location)=",
+    "method": "GET"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1131-training-add-to-cart-redcross/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1131-training-add-to-cart-redcross/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1131,
+    "metaclass": "charity",
+    "class": "training",
+    "description": "Add the Adult First Aid/CPR/AED Online course to the shopping cart without completing purchase",
+    "sites_involved": [
+      "redcross.org"
+    ],
+    "platform": "redcross",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Add the 'Adult First Aid/CPR/AED Online' course to the cart on the Red Cross training website",
+  "eval_schema": {
+    "url_pattern": "redcross\\.org\\/on\\/demandware\\.store\\/Sites-RedCross-Site\\/default\\/Product-Detail",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1132-training-enroll-course-redcross/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1132-training-enroll-course-redcross/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1132,
+    "metaclass": "charity",
+    "class": "training",
+    "description": "Enroll in an online First Aid/CPR certification course on the Red Cross website (cart checkout submission)",
+    "sites_involved": [
+      "redcross.org"
+    ],
+    "platform": "redcross",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Enroll in an online First Aid/CPR certification course on the Red Cross website",
+  "eval_schema": {
+    "url_pattern": "redcross\\.org\\/take-a-class\\/cart\\/checkout-confirmation",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1133-newsletter-signup-redcross/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1133-newsletter-signup-redcross/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1133,
+    "metaclass": "charity",
+    "class": "newsletter",
+    "description": "Sign up for Red Cross training & safety email newsletter",
+    "sites_involved": [
+      "redcross.org"
+    ],
+    "platform": "redcross",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Sign up for the Red Cross training newsletter using the email signup form on their training website",
+  "eval_schema": {
+    "url_pattern": "redcross\\.org\\/on\\/demandware\\.store\\/Sites-RedCross-Site\\/default\\/ExactTargetEmailSignUp",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1134-chapter-finder-redcross/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1134-chapter-finder-redcross/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1134,
+    "metaclass": "charity",
+    "class": "search",
+    "description": "Find the nearest Red Cross local chapter by zip code using the chapter finder tool",
+    "sites_involved": [
+      "redcross.org"
+    ],
+    "platform": "redcross",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Find the nearest Red Cross chapter to zip code 90210 using the local chapter finder on redcross.org",
+  "eval_schema": {
+    "url_pattern": "redcross\\.org\\/find-your-local-chapter",
+    "method": "GET"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1135-events-tickets-ticketmaster/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1135-events-tickets-ticketmaster/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1135,
+    "metaclass": "events",
+    "class": "tickets",
+    "description": "Navigate to Ticketmaster, search for NBA basketball games in a major US city, open an event page, select 2 tickets, and view pricing.",
+    "sites_involved": [
+      "ticketmaster.com"
+    ],
+    "platform": "ticketmaster",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Search for upcoming NBA basketball games on Ticketmaster in a major US city and view available ticket pricing for 2 tickets",
+  "eval_schema": {
+    "url_pattern": "ticketmaster\\.com\\/[^/]+-tickets-[^/]+\\/event\\/[A-Z0-9]+",
+    "method": "GET"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1136-events-tickets-ticketmaster/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1136-events-tickets-ticketmaster/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1136,
+    "metaclass": "events",
+    "class": "tickets",
+    "description": "Find a Broadway or theater show in New York City on Ticketmaster, open the event page for one of the results, and use the 'Best Seats' option to view the top recommended seats for 4 tickets",
+    "sites_involved": [
+      "ticketmaster.com"
+    ],
+    "platform": "ticketmaster",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Find a Broadway or theater show in New York City on Ticketmaster, open the event page for one of the results, and use the 'Best Seats' option to view the top recommended seats for 4 tickets",
+  "eval_schema": {
+    "url_pattern": "services\\.ticketmaster\\.com/api/ismds/event/[A-Z0-9]+/quickpicks.*qty=4.*sort=-quality",
+    "method": "GET"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1137-entertainment-watchlist-trakt/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1137-entertainment-watchlist-trakt/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1137,
+    "metaclass": "entertainment",
+    "class": "rating",
+    "description": "Search for 'The Office' on Trakt.tv and rate it 10 out of 10 stars",
+    "sites_involved": [
+      "trakt.tv"
+    ],
+    "platform": "trakt",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Search for 'The Office' on Trakt.tv and rate it 10 out of 10 stars",
+  "eval_schema": {
+    "url_pattern": "trakt\\.tv.*(sync/ratings)",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1138-entertainment-watchlist-trakt/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1138-entertainment-watchlist-trakt/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1138,
+    "metaclass": "entertainment",
+    "class": "history",
+    "description": "Mark the first 3 episodes of 'Stranger Things' Season 1 as watched on Trakt.tv",
+    "sites_involved": [
+      "trakt.tv"
+    ],
+    "platform": "trakt",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Mark the first 3 episodes of 'Stranger Things' Season 1 as watched on Trakt.tv",
+  "eval_schema": {
+    "url_pattern": "trakt\\.tv.*(sync/history)",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1139-travel-itinerary-tripit/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1139-travel-itinerary-tripit/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1139,
+    "metaclass": "travel",
+    "class": "itinerary",
+    "description": "Create a travel itinerary on TripIt for a 4-day weekend trip to New York from May 23 to May 26 flying from LAX",
+    "sites_involved": [
+      "tripit.com"
+    ],
+    "platform": "tripit",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Create a travel itinerary on TripIt for a 4-day weekend trip to New York from May 23 to May 26 flying from LAX",
+  "eval_schema": {
+    "url_pattern": "tripit\\.com/api/v\\d+/create",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1140-travel-itinerary-tripit/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1140-travel-itinerary-tripit/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1140,
+    "metaclass": "travel",
+    "class": "reservation",
+    "description": "Add a hotel reservation at the Hilton Midtown Manhattan from May 23-26 to your existing New York trip on TripIt",
+    "sites_involved": [
+      "tripit.com"
+    ],
+    "platform": "tripit",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Add a hotel reservation at the Hilton Midtown Manhattan from May 23-26 to your existing New York trip on TripIt",
+  "eval_schema": {
+    "url_pattern": "tripit\\.com/api/v\\d+/create",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1141-travel-itinerary-tripit/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1141-travel-itinerary-tripit/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1141,
+    "metaclass": "travel",
+    "class": "itinerary",
+    "description": "Create a trip on TripIt for a business conference in Seattle from August 10 to August 13 with a flight from SFO",
+    "sites_involved": [
+      "tripit.com"
+    ],
+    "platform": "tripit",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Create a trip on TripIt for a business conference in Seattle from August 10 to August 13 with a flight from SFO",
+  "eval_schema": {
+    "url_pattern": "tripit\\.com/api/v\\d+/create",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1144-weworkremotely/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1144-weworkremotely/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1144,
+    "metaclass": "jobs",
+    "class": "posting",
+    "description": "Go to We Work Remotely (https://weworkremotely.com/remote-jobs/new) and post a remote job listing for a 'Senior Backend Developer' position in the 'Back-End Programming' category. Fill in all required fields across all steps and place the order.",
+    "sites_involved": [
+      "weworkremotely.com"
+    ],
+    "platform": "weworkremotely",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Go to We Work Remotely (https://weworkremotely.com/remote-jobs/new) and post a remote job listing for a 'Senior Backend Developer' position in the 'Back-End Programming' category. Fill in all required fields across all steps and place the order.",
+  "eval_schema": {
+    "url_pattern": "weworkremotely\\.com/listings",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1145-weworkremotely/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1145-weworkremotely/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1145,
+    "metaclass": "jobs",
+    "class": "posting",
+    "description": "Go to We Work Remotely (https://weworkremotely.com/remote-jobs/new) and post a remote job listing for a 'Senior UI/UX Designer' position in the 'Design' category. Fill in all required fields across all steps and place the order.",
+    "sites_involved": [
+      "weworkremotely.com"
+    ],
+    "platform": "weworkremotely",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Go to We Work Remotely (https://weworkremotely.com/remote-jobs/new) and post a remote job listing for a 'Senior UI/UX Designer' position in the 'Design' category. Fill in all required fields across all steps and place the order.",
+  "eval_schema": {
+    "url_pattern": "weworkremotely\\.com/listings",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1146-weworkremotely/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1146-weworkremotely/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1146,
+    "metaclass": "jobs",
+    "class": "posting",
+    "description": "Go to We Work Remotely (https://weworkremotely.com). Find any remote job listing in the 'Back-End Programming' category and save it by clicking the 'Save Job' button on the job detail page.",
+    "sites_involved": [
+      "weworkremotely.com"
+    ],
+    "platform": "weworkremotely",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Go to We Work Remotely (https://weworkremotely.com). Find any remote job listing in the 'Back-End Programming' category and save it by clicking the 'Save Job' button on the job detail page.\n\nNote: The user is already logged in. Any available Back-End Programming job listing works. The 'Save Job' button appears on the individual job detail page. After clicking, the button changes to 'Remove Job' to confirm success.",
+  "eval_schema": {
+    "url_pattern": "weworkremotely\\.com/listings/[^/]+/toggle_save",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1201-beauty-cart-theordinary/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1201-beauty-cart-theordinary/task.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1201,
+    "metaclass": "beauty-personal-care",
+    "class": "cart",
+    "description": "Use the site search to find a retinoid product and add it to cart, testing both the search flow and cart functionality",
+    "sites_involved": [
+      "theordinary.com"
+    ],
+    "platform": "theordinary",
+    "product_urls": [
+      "https://theordinary.com/en-us/granactive-retinoid-2-emulsion-100458.html"
+    ],
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Search for 'retinol' on The Ordinary website, then add the Granactive Retinoid 2% Emulsion to the cart",
+  "eval_schema": {
+    "url_pattern": "theordinary\\.com.*Cart-AddProduct",
+    "method": "POST"
+  },
+  "time_limit": 45,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-1202-beauty-cart-quantity-theordinary/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-1202-beauty-cart-quantity-theordinary/task.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 1202,
+    "metaclass": "beauty-personal-care",
+    "class": "cart",
+    "description": "Navigate to a product page, change the quantity to 2, and add to cart — tests the quantity selector interaction before adding to cart",
+    "sites_involved": [
+      "theordinary.com"
+    ],
+    "platform": "theordinary",
+    "product_urls": [
+      "https://theordinary.com/en-us/multi-peptide-ha-serum-100444.html"
+    ],
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Add 2 units of The Ordinary Multi-Peptide + HA Serum to the cart on The Ordinary website",
+  "eval_schema": {
+    "url_pattern": "theordinary\\.com.*Cart-AddProduct",
+    "method": "POST"
+  },
+  "time_limit": 45,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-179-dev-tech-github-ops-github/extra_info/config.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-179-dev-tech-github-ops-github/extra_info/config.json
@@ -1,0 +1,13 @@
+{
+  "repo_name": "openclaw-agent-benchmark",
+  "visibility": "public",
+  "license": "MIT",
+  "description": "A benchmark for evaluating browser agents on real-world web tasks",
+  "topics": [
+    "benchmark",
+    "browser-agent",
+    "evaluation"
+  ],
+  "has_wiki": false,
+  "has_issues": true
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-179-dev-tech-github-ops-github/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-179-dev-tech-github-ops-github/task.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 179,
+    "metaclass": "dev-tech",
+    "class": "github-ops",
+    "description": "Create repo \"openclaw-agent-benchmark\" on GitHub + README + MIT LICENSE + .gitignore",
+    "sites_involved": [
+      "github.com"
+    ],
+    "platform": "github",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Create repo \"openclaw-agent-benchmark\" on GitHub + README + MIT LICENSE + .gitignore",
+  "eval_schema": {
+    "url_pattern": "github\\.com/repositories$",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": [
+    {
+      "path": "extra_info/config.json",
+      "description": "Configuration details for the task"
+    }
+  ]
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-180-dev-tech-github-ops-github/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-180-dev-tech-github-ops-github/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 180,
+    "metaclass": "dev-tech",
+    "class": "github-ops",
+    "description": "Fork huggingface/transformers on GitHub and create branch \"fix-tokenizer-bug\"",
+    "sites_involved": [
+      "github.com"
+    ],
+    "platform": "github",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Fork huggingface/transformers on GitHub and create branch \"fix-tokenizer-bug\"",
+  "eval_schema": {
+    "url_pattern": "github\\.com/[^/]+/transformers/branches$",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-215-academia-research-paper-tables-overleaf/extra_info/raw_results.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-215-academia-research-paper-tables-overleaf/extra_info/raw_results.json
@@ -1,0 +1,47 @@
+{
+  "models": [
+    "GPT-4o",
+    "Claude 3.5 Sonnet",
+    "Gemini 1.5 Pro",
+    "Llama 3.1 70B",
+    "Mistral Large"
+  ],
+  "metrics": [
+    "Accuracy",
+    "F1-Score",
+    "Latency (ms)",
+    "Cost ($/1K tokens)"
+  ],
+  "results": {
+    "GPT-4o": [
+      0.923,
+      0.918,
+      342,
+      0.015
+    ],
+    "Claude 3.5 Sonnet": [
+      0.931,
+      0.926,
+      298,
+      0.018
+    ],
+    "Gemini 1.5 Pro": [
+      0.908,
+      0.902,
+      410,
+      0.007
+    ],
+    "Llama 3.1 70B": [
+      0.887,
+      0.881,
+      520,
+      0.001
+    ],
+    "Mistral Large": [
+      0.901,
+      0.895,
+      380,
+      0.008
+    ]
+  }
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-215-academia-research-paper-tables-overleaf/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-215-academia-research-paper-tables-overleaf/task.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 215,
+    "metaclass": "academia-research",
+    "class": "paper-tables",
+    "description": "On Overleaf, create a new project and write a LaTeX booktabs table with 5 models x 4 metrics + Average + Delta row. The project must compile without errors and display the formatted table.",
+    "sites_involved": [
+      "overleaf.com"
+    ],
+    "platform": "overleaf",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "On Overleaf, create a new project and write a LaTeX booktabs table with 5 models x 4 metrics + Average + Delta row. The project must compile without errors and display the formatted table.",
+  "eval_schema": {
+    "url_pattern": "overleaf\\.com/project/[a-f0-9]+/compile",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": [
+    {
+      "path": "extra_info/raw_results.json",
+      "description": "Raw benchmark results: 5 models × 4 metrics"
+    }
+  ]
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-234-daily-life-events-ticketmaster/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-234-daily-life-events-ticketmaster/task.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 234,
+    "metaclass": "daily-life",
+    "class": "events",
+    "description": "Find tickets for a live comedy show on Ticketmaster in Los Angeles this Saturday evening",
+    "sites_involved": [
+      "ticketmaster.com",
+      "checkout.ticketmaster.com"
+    ],
+    "platform": "ticketmaster",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Find tickets for a live comedy show on Ticketmaster in Los Angeles this Saturday evening",
+  "eval_schema": {
+    "url_pattern": "checkout\\.ticketmaster\\.com\\/[a-f0-9]+",
+    "method": "GET"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-242-academia-research-research-tools-overleaf/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-242-academia-research-research-tools-overleaf/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 242,
+    "metaclass": "academia-research",
+    "class": "research-tools",
+    "description": "Overleaf: Create project \"CVPR2026_Submission\" using CVPR 2026 template",
+    "sites_involved": [
+      "overleaf.com"
+    ],
+    "platform": "overleaf",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Overleaf: Create project \"CVPR2026_Submission\" using CVPR 2026 template",
+  "eval_schema": {
+    "url_pattern": "overleaf\\.com/project/[a-f0-9]+/settings",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-247-academia-research-research-tools-semantic-scholar/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-247-academia-research-research-tools-semantic-scholar/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 247,
+    "metaclass": "academia-research",
+    "class": "research-tools",
+    "description": "Semantic Scholar: Create feed for \"LLMs\"",
+    "sites_involved": [
+      "semanticscholar.org"
+    ],
+    "platform": "semantic-scholar",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Semantic Scholar: Create feed for \"LLMs\"",
+  "eval_schema": {
+    "url_pattern": "semanticscholar\\.org/api/1/alert",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-265-education-learning-general-coursera/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-265-education-learning-general-coursera/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 265,
+    "metaclass": "education-learning",
+    "class": "general",
+    "description": "On Coursera, enroll in the \"Deep Learning Specialization\" by reaching the checkout or payment page with enrollment details filled in.",
+    "sites_involved": [
+      "coursera.org"
+    ],
+    "platform": "coursera",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "On Coursera, enroll in the \"Deep Learning Specialization\" by reaching the checkout or payment page with enrollment details filled in.",
+  "eval_schema": {
+    "url_pattern": "coursera\\.org/api/subscriptions\\.v1/\\?action=createCart",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-266-education-learning-general-leetcode/extra_info/solution_code.py
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-266-education-learning-general-leetcode/extra_info/solution_code.py
@@ -1,0 +1,9 @@
+class Solution:
+    def twoSum(self, nums: list[int], target: int) -> list[int]:
+        seen = {}
+        for i, num in enumerate(nums):
+            complement = target - num
+            if complement in seen:
+                return [seen[complement], i]
+            seen[num] = i
+        return []

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-266-education-learning-general-leetcode/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-266-education-learning-general-leetcode/task.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 266,
+    "metaclass": "education-learning",
+    "class": "general",
+    "description": "On LeetCode, open the \"Two Sum\" problem, write a correct Python solution in the code editor, and click the Submit button.",
+    "sites_involved": [
+      "leetcode.com"
+    ],
+    "platform": "leetcode",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "On LeetCode, open the \"Two Sum\" problem, write a correct Python solution in the code editor, and click the Submit button.",
+  "eval_schema": {
+    "url_pattern": "leetcode\\.com/problems/two-sum/submit",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": [
+    {
+      "path": "extra_info/solution_code.py",
+      "description": "Python solution for the Two Sum problem"
+    }
+  ]
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-273-education-learning-general-edx/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-273-education-learning-general-edx/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 273,
+    "metaclass": "education-learning",
+    "class": "general",
+    "description": "On edX, enroll in CS50 by selecting the free audit track and completing the enrollment process until the course content or dashboard is accessible.",
+    "sites_involved": [
+      "edx.org"
+    ],
+    "platform": "edx",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Log into edX and enroll in CS50 by selecting the free audit track and completing the enrollment process until the course content or dashboard is accessible.",
+  "eval_schema": {
+    "url_pattern": "www\\.edx\\.org/(track-select/|learn/)",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-274-office-secretary-tasks-calendar-when2meet/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-274-office-secretary-tasks-calendar-when2meet/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 274,
+    "metaclass": "office-secretary-tasks",
+    "class": "calendar",
+    "description": "Create a When2meet event for a 3-person team meeting next week",
+    "sites_involved": [
+      "when2meet.com"
+    ],
+    "platform": "when2meet",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Create a When2meet event for a 3-person team meeting next week",
+  "eval_schema": {
+    "url_pattern": "when2meet\\.com/(SaveNewEvent|SaveTimes|api)",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-284-office-secretary-tasks-calendar-when2meet/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-284-office-secretary-tasks-calendar-when2meet/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 284,
+    "metaclass": "office-secretary-tasks",
+    "class": "calendar",
+    "description": "Use When2meet to schedule a 90-minute Strategy Session with 3 attendees",
+    "sites_involved": [
+      "when2meet.com"
+    ],
+    "platform": "when2meet",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Use When2meet to schedule a 90-minute Strategy Session with 3 attendees",
+  "eval_schema": {
+    "url_pattern": "when2meet\\.com/(SaveNewEvent|SaveTimes|api)",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-369-entertainment-hobbies-general-goodreads/extra_info/book_list.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-369-entertainment-hobbies-general-goodreads/extra_info/book_list.json
@@ -1,0 +1,14 @@
+{
+  "books": [
+    "Deep Learning by Ian Goodfellow",
+    "Pattern Recognition and Machine Learning by Christopher Bishop",
+    "The Hundred-Page Machine Learning Book by Andriy Burkov",
+    "Hands-On Machine Learning with Scikit-Learn, Keras, and TensorFlow by Aur\u00e9lien G\u00e9ron",
+    "Machine Learning: A Probabilistic Perspective by Kevin Murphy",
+    "Reinforcement Learning: An Introduction by Richard Sutton",
+    "Speech and Language Processing by Dan Jurafsky",
+    "Information Theory, Inference and Learning Algorithms by David MacKay",
+    "Probabilistic Graphical Models by Daphne Koller",
+    "The Elements of Statistical Learning by Trevor Hastie"
+  ]
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-369-entertainment-hobbies-general-goodreads/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-369-entertainment-hobbies-general-goodreads/task.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 369,
+    "metaclass": "entertainment-hobbies",
+    "class": "general",
+    "description": "Goodreads: Create a shelf \"ML Must-Reads\" and add 10 books",
+    "sites_involved": [
+      "goodreads.com"
+    ],
+    "platform": "goodreads",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Goodreads: Create a shelf \"ML Must-Reads\" and add 10 books",
+  "eval_schema": {
+    "url_pattern": "goodreads\\.com/shelf/add_to_shelf",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": [
+    {
+      "path": "extra_info/book_list.json",
+      "description": "List of 10 ML books to add to shelf"
+    }
+  ]
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-372-entertainment-hobbies-general-eventbrite/extra_info/event_details.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-372-entertainment-hobbies-general-eventbrite/extra_info/event_details.json
@@ -1,0 +1,10 @@
+{
+  "event_name": "ML Paper Reading Group",
+  "event_type": "free",
+  "date": "2026-04-15",
+  "time": "6:00 PM - 8:00 PM ET",
+  "location": "Online (Zoom)",
+  "description": "Weekly paper reading group focusing on recent ML research. This week: attention mechanisms and transformer architectures. All levels welcome.",
+  "capacity": 50,
+  "organizer": "Alex Green"
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-372-entertainment-hobbies-general-eventbrite/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-372-entertainment-hobbies-general-eventbrite/task.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 372,
+    "metaclass": "entertainment-hobbies",
+    "class": "general",
+    "description": "Eventbrite: Create a free event \"ML Paper Reading Group\"",
+    "sites_involved": [
+      "eventbrite.com"
+    ],
+    "platform": "eventbrite",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Eventbrite: Create a free event \"ML Paper Reading Group\"",
+  "eval_schema": {
+    "url_pattern": "www\\.eventbrite\\.com/api/v3/organizations/\\d+/events/auto-create",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": [
+    {
+      "path": "extra_info/event_details.json",
+      "description": "Event details including name, date, time, location, and description"
+    }
+  ]
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-413-personal-management-personal-tools-todoist/extra_info/task_list.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-413-personal-management-personal-tools-todoist/extra_info/task_list.json
@@ -1,0 +1,52 @@
+{
+  "tasks": [
+    {
+      "name": "Define Q3 OKRs",
+      "assignee": "Alex Green",
+      "due_date": "2026-04-07",
+      "priority": "high"
+    },
+    {
+      "name": "Review architecture RFC",
+      "assignee": "Jordan Peters",
+      "due_date": "2026-04-10",
+      "priority": "high"
+    },
+    {
+      "name": "Set up CI/CD pipeline",
+      "assignee": "Alex Green",
+      "due_date": "2026-04-14",
+      "priority": "medium"
+    },
+    {
+      "name": "Write integration tests",
+      "assignee": "Alex Green",
+      "due_date": "2026-04-18",
+      "priority": "medium"
+    },
+    {
+      "name": "Prepare sprint demo",
+      "assignee": "Jordan Peters",
+      "due_date": "2026-04-21",
+      "priority": "low"
+    },
+    {
+      "name": "Update documentation",
+      "assignee": "Alex Green",
+      "due_date": "2026-04-25",
+      "priority": "low"
+    },
+    {
+      "name": "Security audit review",
+      "assignee": "Alex Green",
+      "due_date": "2026-04-28",
+      "priority": "high"
+    },
+    {
+      "name": "Performance benchmarking",
+      "assignee": "Alex Green",
+      "due_date": "2026-04-30",
+      "priority": "medium"
+    }
+  ]
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-413-personal-management-personal-tools-todoist/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-413-personal-management-personal-tools-todoist/task.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 413,
+    "metaclass": "personal-management",
+    "class": "personal-tools",
+    "description": "Create project \"Q2 Engineering Goals\" with 8 tasks, due dates, and priorities in Todoist",
+    "sites_involved": [
+      "todoist.com"
+    ],
+    "platform": "todoist",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Create project \"Q2 Engineering Goals\" with 8 tasks, due dates, and priorities in Todoist",
+  "eval_schema": {
+    "url_pattern": "app\\.todoist\\.com/api/v1/sync",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": [
+    {
+      "path": "extra_info/task_list.json",
+      "description": "Task list with names, assignees, due dates, and priorities"
+    }
+  ]
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-468-rating-voting-general-glassdoor/extra_info/interview_experience.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-468-rating-voting-general-glassdoor/extra_info/interview_experience.json
@@ -1,0 +1,10 @@
+{
+  "company": "TechCorp Inc.",
+  "position": "Senior Software Engineer",
+  "date": "2026-02-15",
+  "interview_type": "On-site (4 rounds)",
+  "difficulty": "Medium-Hard",
+  "experience": "Positive overall. The team was friendly and the questions were relevant to the role. Had a system design round focusing on distributed caching, two coding rounds (one on graph algorithms, one on API design), and a behavioral round.",
+  "offer_received": true,
+  "would_recommend": true
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-468-rating-voting-general-glassdoor/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-468-rating-voting-general-glassdoor/task.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 468,
+    "metaclass": "rating-voting",
+    "class": "general",
+    "description": "Write an interview review on Glassdoor",
+    "sites_involved": [
+      "glassdoor.com"
+    ],
+    "platform": "glassdoor",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Write an interview review on Glassdoor",
+  "eval_schema": {
+    "url_pattern": "glassdoor\\.com/(graph|api|a/interview)",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": [
+    {
+      "path": "extra_info/interview_experience.json",
+      "description": "Interview experience details for review submission"
+    }
+  ]
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-469-rating-voting-general-tripadvisor/extra_info/review_content.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-469-rating-voting-general-tripadvisor/extra_info/review_content.json
@@ -1,0 +1,6 @@
+{
+  "review_text": "Excellent service and product quality. The user experience is intuitive and well-designed. Would recommend to colleagues.",
+  "rating": 5,
+  "pros": "Easy to use, great customer support, reliable service",
+  "cons": "Pricing could be more competitive for small teams"
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-469-rating-voting-general-tripadvisor/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-469-rating-voting-general-tripadvisor/task.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 469,
+    "metaclass": "rating-voting",
+    "class": "general",
+    "description": "Write a 4-star review for a tour on TripAdvisor",
+    "sites_involved": [
+      "tripadvisor.com"
+    ],
+    "platform": "tripadvisor",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Write a 4-star review for a tour on TripAdvisor",
+  "eval_schema": {
+    "url_pattern": "tripadvisor\\.com/data/graphql/ids",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": [
+    {
+      "path": "extra_info/review_content.json",
+      "description": "Review content for submission"
+    }
+  ]
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-470-rating-voting-general-trustpilot/extra_info/review_content.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-470-rating-voting-general-trustpilot/extra_info/review_content.json
@@ -1,0 +1,6 @@
+{
+  "review_text": "Excellent service and product quality. The user experience is intuitive and well-designed. Would recommend to colleagues.",
+  "rating": 5,
+  "pros": "Easy to use, great customer support, reliable service",
+  "cons": "Pricing could be more competitive for small teams"
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-470-rating-voting-general-trustpilot/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-470-rating-voting-general-trustpilot/task.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 470,
+    "metaclass": "rating-voting",
+    "class": "general",
+    "description": "Write a 5-star review for Wealthsimple on Trustpilot",
+    "sites_involved": [
+      "trustpilot.com"
+    ],
+    "platform": "trustpilot",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Write a 5-star review for Wealthsimple on Trustpilot",
+  "eval_schema": {
+    "url_pattern": "trustpilot\\.com/api/consumer/review",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": [
+    {
+      "path": "extra_info/review_content.json",
+      "description": "Review content for submission"
+    }
+  ]
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-474-rating-voting-general-capterra/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-474-rating-voting-general-capterra/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 474,
+    "metaclass": "rating-voting",
+    "class": "general",
+    "description": "Write a review for Notion on Capterra with overall rating 4 stars and exactly this text: \"Flexible workspace, steep learning curve.\"",
+    "sites_involved": [
+      "capterra.com"
+    ],
+    "platform": "capterra",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Write a review for Notion on Capterra with overall rating 4 stars and exactly this text: \"Flexible workspace, steep learning curve.\"",
+  "eval_schema": {
+    "url_pattern": "reviews\\.capterra\\.com/api/v1/products/[^/]+/partial-review",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-475-rating-voting-general-g2/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-475-rating-voting-general-g2/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 475,
+    "metaclass": "rating-voting",
+    "class": "general",
+    "description": "Write a 4-star review for Jira on G2 with exactly this text: \"Powerful tracking, complex UI.\"",
+    "sites_involved": [
+      "g2.com"
+    ],
+    "platform": "g2",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Write a 4-star review for Jira on G2 with exactly this text: \"Powerful tracking, complex UI.\"",
+  "eval_schema": {
+    "url_pattern": "g2\\.com/survey_responses/.+/autosave_answers\\.json",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-483-creation-init-general-airtable/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-483-creation-init-general-airtable/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 483,
+    "metaclass": "creation-init",
+    "class": "general",
+    "description": "Create an Airtable base \"Conference Tracker\" with schema",
+    "sites_involved": [
+      "airtable.com"
+    ],
+    "platform": "airtable",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Create an Airtable base \"Conference Tracker\" with schema",
+  "eval_schema": {
+    "url_pattern": "airtable\\.com/v0\\.3/application/[^/]+/create",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-485-creation-init-general-webflow/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-485-creation-init-general-webflow/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 485,
+    "metaclass": "creation-init",
+    "class": "general",
+    "description": "Create a portfolio website project on Webflow",
+    "sites_involved": [
+      "webflow.com"
+    ],
+    "platform": "webflow",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Create a portfolio website project on Webflow",
+  "eval_schema": {
+    "url_pattern": "webflow\\.com/api/workspaces/[^/]+/sites",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-486-creation-init-general-mailchimp/extra_info/content.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-486-creation-init-general-mailchimp/extra_info/content.json
@@ -1,0 +1,3 @@
+{
+  "content": "Sharing our latest research on scaling language models \u2014 key findings on training dynamics, emergent capabilities, and practical deployment considerations. #MachineLearning #AI #Research"
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-486-creation-init-general-mailchimp/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-486-creation-init-general-mailchimp/task.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 486,
+    "metaclass": "creation-init",
+    "class": "general",
+    "description": "Create a Mailchimp email campaign with audience set to research newsletter",
+    "sites_involved": [
+      "mailchimp.com"
+    ],
+    "platform": "mailchimp",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Create a Mailchimp email campaign with audience set to research newsletter",
+  "eval_schema": {
+    "url_pattern": "admin\\.mailchimp\\.com/campaigns/(wizard|send|schedule)",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": [
+    {
+      "path": "extra_info/content.json",
+      "description": "Content and links for the task"
+    }
+  ]
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-487-creation-init-general-typeform/extra_info/survey_questions.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-487-creation-init-general-typeform/extra_info/survey_questions.json
@@ -1,0 +1,85 @@
+{
+  "title": "User Research Survey: Developer Productivity",
+  "questions": [
+    {
+      "id": 1,
+      "type": "multiple_choice",
+      "text": "What is your primary programming language?",
+      "options": [
+        "Python",
+        "JavaScript/TypeScript",
+        "Go",
+        "Java",
+        "Rust",
+        "Other"
+      ]
+    },
+    {
+      "id": 2,
+      "type": "rating",
+      "text": "How satisfied are you with your current IDE?",
+      "scale": "1-5"
+    },
+    {
+      "id": 3,
+      "type": "short_text",
+      "text": "What is the biggest bottleneck in your daily workflow?"
+    },
+    {
+      "id": 4,
+      "type": "multiple_choice",
+      "text": "How many hours per week do you spend on code reviews?",
+      "options": [
+        "0-2",
+        "3-5",
+        "6-10",
+        "10+"
+      ]
+    },
+    {
+      "id": 5,
+      "type": "yes_no",
+      "text": "Do you use AI-assisted coding tools?"
+    },
+    {
+      "id": 6,
+      "type": "long_text",
+      "text": "Describe your ideal development environment."
+    },
+    {
+      "id": 7,
+      "type": "multiple_choice",
+      "text": "What deployment method do you use most?",
+      "options": [
+        "Docker/K8s",
+        "Serverless",
+        "VMs",
+        "PaaS",
+        "Other"
+      ]
+    },
+    {
+      "id": 8,
+      "type": "rating",
+      "text": "How would you rate your team's CI/CD pipeline?",
+      "scale": "1-5"
+    },
+    {
+      "id": 9,
+      "type": "short_text",
+      "text": "What tool do you wish existed?"
+    },
+    {
+      "id": 10,
+      "type": "multiple_choice",
+      "text": "How do you prefer to learn new technologies?",
+      "options": [
+        "Documentation",
+        "Video tutorials",
+        "Hands-on projects",
+        "Courses",
+        "Peer learning"
+      ]
+    }
+  ]
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-487-creation-init-general-typeform/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-487-creation-init-general-typeform/task.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 487,
+    "metaclass": "creation-init",
+    "class": "general",
+    "description": "Create a Typeform user research survey with 10 questions",
+    "sites_involved": [
+      "typeform.com"
+    ],
+    "platform": "typeform",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Create a Typeform user research survey with 10 questions",
+  "eval_schema": {
+    "url_pattern": "admin\\.typeform\\.com/bff/bob-the-builder/forms/",
+    "method": "PUT"
+  },
+  "time_limit": 30,
+  "extra_info": [
+    {
+      "path": "extra_info/survey_questions.json",
+      "description": "Survey questions for user research with 10 questions of various types"
+    }
+  ]
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-488-creation-init-general-substack/extra_info/content.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-488-creation-init-general-substack/extra_info/content.json
@@ -1,0 +1,3 @@
+{
+  "content": "Sharing our latest research on scaling language models \u2014 key findings on training dynamics, emergent capabilities, and practical deployment considerations. #MachineLearning #AI #Research"
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-488-creation-init-general-substack/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-488-creation-init-general-substack/task.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 488,
+    "metaclass": "creation-init",
+    "class": "general",
+    "description": "Create a Substack newsletter \"ML Research Roundup\" and publish the first issue",
+    "sites_involved": [
+      "substack.com"
+    ],
+    "platform": "substack",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Create a Substack newsletter \"ML Research Roundup\" and publish the first issue",
+  "eval_schema": {
+    "url_pattern": "substack\\.com/api/v1/drafts/\\d+/publish",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": [
+    {
+      "path": "extra_info/content.json",
+      "description": "Content and links for the task"
+    }
+  ]
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-500-office-secretary-tasks-signup-doodle/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-500-office-secretary-tasks-signup-doodle/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 500,
+    "metaclass": "office-secretary-tasks",
+    "class": "signup",
+    "description": "Create a sign-up sheet on Doodle for volunteers to bring snacks to the office Friday party",
+    "sites_involved": [
+      "doodle.com"
+    ],
+    "platform": "doodle",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Create a sign-up sheet on Doodle for volunteers to bring snacks to the office Friday party",
+  "eval_schema": {
+    "url_pattern": "api\\.doodle\\.com/svc-sign-up-sheet/v[\\d.]+/sheets",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-501-office-secretary-tasks-signup-doodle/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-501-office-secretary-tasks-signup-doodle/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 501,
+    "metaclass": "office-secretary-tasks",
+    "class": "signup",
+    "description": "Create a sign-up sheet on Doodle for team members to pick presentation slots at the quarterly all-hands",
+    "sites_involved": [
+      "doodle.com"
+    ],
+    "platform": "doodle",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Create a sign-up sheet on Doodle for team members to pick presentation slots at the quarterly all-hands",
+  "eval_schema": {
+    "url_pattern": "api\\.doodle\\.com/svc-sign-up-sheet/v[\\d.]+/sheets",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-502-office-secretary-tasks-calendar-doodle/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-502-office-secretary-tasks-calendar-doodle/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 502,
+    "metaclass": "office-secretary-tasks",
+    "class": "calendar",
+    "description": "Create a Doodle group poll for a 1-hour Client Sync on Thursday",
+    "sites_involved": [
+      "doodle.com"
+    ],
+    "platform": "doodle",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Create a Doodle group poll for a 1-hour Client Sync on Thursday",
+  "eval_schema": {
+    "url_pattern": "api\\.doodle\\.com/scheduling/scheduling-attempts",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-503-office-secretary-tasks-calendar-doodle/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-503-office-secretary-tasks-calendar-doodle/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 503,
+    "metaclass": "office-secretary-tasks",
+    "class": "calendar",
+    "description": "Use Doodle to find a time tomorrow for a 30-minute design review in SF",
+    "sites_involved": [
+      "doodle.com"
+    ],
+    "platform": "doodle",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Use Doodle to find a time tomorrow for a 30-minute design review in SF",
+  "eval_schema": {
+    "url_pattern": "api\\.doodle\\.com/scheduling/scheduling-attempts",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-520-shopping-retail-target/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-520-shopping-retail-target/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 520,
+    "metaclass": "shopping",
+    "class": "retail",
+    "description": "Search Target for a 6-piece cotton bath towel set in white and add the highest rated to cart",
+    "sites_involved": [
+      "target.com"
+    ],
+    "platform": "target",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Search Target for a 6-piece cotton bath towel set in white and add the highest rated one to cart",
+  "eval_schema": {
+    "url_pattern": "carts\\.target\\.com/web_checkouts/v\\d+/cart_items",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-521-shopping-retail-target/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-521-shopping-retail-target/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 521,
+    "metaclass": "shopping",
+    "class": "retail",
+    "description": "Search Target for a stainless steel insulated water bottle, sort by best-selling, and add the top result to cart",
+    "sites_involved": [
+      "target.com"
+    ],
+    "platform": "target",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Search Target for a stainless steel insulated water bottle and add the best-selling one to cart",
+  "eval_schema": {
+    "url_pattern": "carts\\.target\\.com/web_checkouts/v\\d+/cart_items",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-522-shopping-retail-target/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-522-shopping-retail-target/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 522,
+    "metaclass": "shopping",
+    "class": "retail",
+    "description": "Search Target for a 12-inch non-stick frying pan, find the highest rated one, and add it to cart",
+    "sites_involved": [
+      "target.com"
+    ],
+    "platform": "target",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Search Target for a non-stick frying pan 12 inch and add the highest rated one to cart",
+  "eval_schema": {
+    "url_pattern": "carts\\.target\\.com/web_checkouts/v\\d+/cart_items",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-523-shopping-retail-target/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-523-shopping-retail-target/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 523,
+    "metaclass": "shopping",
+    "class": "retail",
+    "description": "Search Target for a queen size microfiber bed sheet set in gray, sort by lowest price, and add the top result to cart",
+    "sites_involved": [
+      "target.com"
+    ],
+    "platform": "target",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Search Target for a queen size microfiber bed sheet set in gray and add the lowest priced one to cart",
+  "eval_schema": {
+    "url_pattern": "carts\\.target\\.com/web_checkouts/v\\d+/cart_items",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-530-shopping-marketplace-etsy/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-530-shopping-marketplace-etsy/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 530,
+    "metaclass": "shopping",
+    "class": "marketplace",
+    "description": "Search Etsy for a personalized leather bifold wallet with initials engraving and add it to cart",
+    "sites_involved": [
+      "etsy.com"
+    ],
+    "platform": "etsy",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Search Etsy for a personalized leather bifold wallet with initials engraving and add it to cart",
+  "eval_schema": {
+    "url_pattern": "etsy\\.com/cart/listing",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-531-shopping-marketplace-etsy/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-531-shopping-marketplace-etsy/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 531,
+    "metaclass": "shopping",
+    "class": "marketplace",
+    "description": "Find a leather dog collar with custom name embroidery for a medium-sized dog on Etsy and add to cart",
+    "sites_involved": [
+      "etsy.com"
+    ],
+    "platform": "etsy",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Find a leather dog collar with custom name embroidery for a medium-sized dog on Etsy and add to cart",
+  "eval_schema": {
+    "url_pattern": "etsy\\.com/cart/listing",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-533-daily-life-utilities-inmyarea/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-533-daily-life-utilities-inmyarea/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 533,
+    "metaclass": "daily-life",
+    "class": "utilities",
+    "description": "On InMyArea, enter home address (ZIP 90210), select an internet service plan, click Order Now, then on the provider's signup page fill in personal information and complete the subscription",
+    "sites_involved": [
+      "inmyarea.com"
+    ],
+    "platform": "inmyarea",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "On InMyArea, enter home address (ZIP 90210), select an internet service plan, click Order Now, then on the provider's signup page fill in personal information and complete the subscription",
+  "eval_schema": {
+    "url_pattern": "att\\.com/msapi/salesapi/wireless-sales-eapi/v2/addtocart",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-535-daily-life-shopping-etsy/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-535-daily-life-shopping-etsy/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 535,
+    "metaclass": "daily-life",
+    "class": "shopping",
+    "description": "Search Etsy for a handmade blue ceramic flower vase under $50 and add it to your favorites",
+    "sites_involved": [
+      "etsy.com"
+    ],
+    "platform": "etsy",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Search Etsy for a handmade blue ceramic flower vase under $50 and add it to your favorites",
+  "eval_schema": {
+    "url_pattern": "etsy\\.com/api/v\\d+/ajax/bespoke/member/neu/specs/favoriteConfirmationToast",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-536-daily-life-shopping-etsy/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-536-daily-life-shopping-etsy/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 536,
+    "metaclass": "daily-life",
+    "class": "shopping",
+    "description": "Find a mid-century modern wooden bookshelf on Etsy priced under $300 and add it to your favorites",
+    "sites_involved": [
+      "etsy.com"
+    ],
+    "platform": "etsy",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Find a mid-century modern wooden bookshelf on Etsy priced under $300 and add it to your favorites",
+  "eval_schema": {
+    "url_pattern": "etsy\\.com/api/v\\d+/ajax/bespoke/member/neu/specs/favoriteConfirmationToast",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-560/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-560/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 560,
+    "metaclass": "web_task",
+    "class": "registration",
+    "description": "Register for a free tech networking event in San Francisco on Eventbrite",
+    "sites_involved": [
+      "https://www.eventbrite.com"
+    ],
+    "platform": "Eventbrite",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Search for a free tech networking event in San Francisco on Eventbrite and register for it.\n\nNote: The event is free. Look for a tech networking event in San Francisco and complete the registration flow.",
+  "eval_schema": {
+    "url_pattern": "eventbrite\\.com/purchase-flow-webapp/api/v\\d+/orders/create",
+    "method": "POST"
+  },
+  "time_limit": 120,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-564/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-564/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 564,
+    "metaclass": "web_task",
+    "class": "registration",
+    "description": "Register for 2 tickets to a free startup pitch night in New York on Eventbrite",
+    "sites_involved": [
+      "https://www.eventbrite.com"
+    ],
+    "platform": "Eventbrite",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Search for a free startup pitch night event in New York on Eventbrite and register for 2 tickets.\n\nNote: The event is free. Look for a startup pitch night in New York and register for 2 tickets.",
+  "eval_schema": {
+    "url_pattern": "eventbrite\\.com/purchase-flow-webapp/api/v\\d+/orders/create",
+    "method": "POST"
+  },
+  "time_limit": 120,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-571-job-search-hr-recruitment-mgmt-workable/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-571-job-search-hr-recruitment-mgmt-workable/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 571,
+    "metaclass": "job-search-hr",
+    "class": "recruitment-mgmt",
+    "description": "Sign up for a Workable free trial, create a new job position, and publish it to the Workable careers page",
+    "sites_involved": [
+      "workable.com"
+    ],
+    "platform": "workable",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Sign up for a Workable free trial, create a new job position, and publish it to the Workable careers page",
+  "eval_schema": {
+    "url_pattern": "workable\\.com.*(jobs?/(create|publish|new|draft)|api/(spi|v\\d+)/jobs|careers/publish|/openings)",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-583-office-secretary-tasks-support-tickets-freshdesk/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-583-office-secretary-tasks-support-tickets-freshdesk/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 583,
+    "metaclass": "office-secretary-tasks",
+    "class": "customer-support",
+    "description": "Register a free Freshdesk Sprout account, create a new support ticket with subject \"Invoice Dispute - Order #10042\", describe a billing discrepancy, set priority to High, and assign to a test agent",
+    "sites_involved": [
+      "freshdesk.com"
+    ],
+    "platform": "freshdesk",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Register a free Freshdesk Sprout account, create a new support ticket with subject \"Invoice Dispute - Order #10042\", describe a billing discrepancy, set priority to High, and assign to a test agent",
+  "eval_schema": {
+    "url_pattern": "freshdesk\\.com/api/_/tickets",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-596-daily-life-fitness-strava/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-596-daily-life-fitness-strava/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 596,
+    "metaclass": "daily-life",
+    "class": "fitness",
+    "description": "Add a 20-mile cycling activity to Strava titled 'Morning Ride'",
+    "sites_involved": [
+      "strava.com"
+    ],
+    "platform": "strava",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Add a 20-mile cycling activity to Strava titled 'Morning Ride'",
+  "eval_schema": {
+    "url_pattern": "strava\\.com\\/activities",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-597-daily-life-fitness-strava/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-597-daily-life-fitness-strava/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 597,
+    "metaclass": "daily-life",
+    "class": "fitness",
+    "description": "Log a 45-minute yoga session on Strava from yesterday evening",
+    "sites_involved": [
+      "strava.com"
+    ],
+    "platform": "strava",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Log a 45-minute yoga session on Strava from yesterday evening",
+  "eval_schema": {
+    "url_pattern": "strava\\.com\\/activities",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-598-academia-research-legal-docs-formswift/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-598-academia-research-legal-docs-formswift/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 598,
+    "metaclass": "academia-research",
+    "class": "legal-docs",
+    "description": "On FormSwift, search for a \"Power of Attorney\" template, fill in the principal's name, agent's name, and scope of authority, then download the completed document",
+    "sites_involved": [
+      "formswift.com"
+    ],
+    "platform": "formswift",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "On FormSwift, search for a \"Power of Attorney\" template, fill in the principal's name, agent's name, and scope of authority, then download the completed document",
+  "eval_schema": {
+    "url_pattern": "api\\.formswift\\.com/static/document/save/",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-600-hobbies-crafts-community-ravelry/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-600-hobbies-crafts-community-ravelry/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 600,
+    "metaclass": "hobbies-crafts",
+    "class": "community",
+    "description": "Search for a free beginner knitting pattern for a scarf on Ravelry and add it to your library",
+    "sites_involved": [
+      "ravelry.com"
+    ],
+    "platform": "ravelry",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Search for a free beginner knitting pattern for a scarf on Ravelry and add it to your library",
+  "eval_schema": {
+    "url_pattern": "ravelry\\.com/patterns/library/[^/]+/add_to_library",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-601-hobbies-gaming-reviews-ravelry/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-601-hobbies-gaming-reviews-ravelry/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 601,
+    "metaclass": "hobbies-gaming",
+    "class": "reviews",
+    "description": "Find a highly-rated crochet amigurumi pattern on Ravelry and add it to your favorites",
+    "sites_involved": [
+      "ravelry.com"
+    ],
+    "platform": "ravelry",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Find a highly-rated crochet amigurumi pattern on Ravelry and add it to your favorites",
+  "eval_schema": {
+    "url_pattern": "ravelry\\.com/patterns/library/[^/]+/bookmark",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-602-hobbies-crafts-community-ravelry/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-602-hobbies-crafts-community-ravelry/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 602,
+    "metaclass": "hobbies-crafts",
+    "class": "community",
+    "description": "Search for worsted weight yarn on Ravelry and add the most popular brand to your stash",
+    "sites_involved": [
+      "ravelry.com"
+    ],
+    "platform": "ravelry",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Search for worsted weight yarn on Ravelry and add the most popular result to your stash",
+  "eval_schema": {
+    "url_pattern": "ravelry\\.com/people/[^/]+/stash/[^/]+/quick",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-603-hobbies-crafts-community-ravelry/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-603-hobbies-crafts-community-ravelry/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 603,
+    "metaclass": "hobbies-crafts",
+    "class": "community",
+    "description": "Find a knitting group on Ravelry, join it, and post a greeting message in its chatroom",
+    "sites_involved": [
+      "ravelry.com"
+    ],
+    "platform": "ravelry",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Find a knitting group on Ravelry, join it, and post a greeting message in its chatroom",
+  "eval_schema": {
+    "url_pattern": "ravelry\\.com/chats/\\d+/talk",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-607-hobbies-gaming-reviews-boardgamegeek/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-607-hobbies-gaming-reviews-boardgamegeek/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 607,
+    "metaclass": "hobbies-gaming",
+    "class": "reviews",
+    "description": "Log a play for 'Pandemic' on BoardGameGeek with 4 players and a duration of 60 minutes",
+    "sites_involved": [
+      "boardgamegeek.com"
+    ],
+    "platform": "boardgamegeek",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Log a play for 'Pandemic' on BoardGameGeek with 4 players and a duration of 60 minutes",
+  "eval_schema": {
+    "url_pattern": "boardgamegeek\\.com/(geekplay|api/plays)",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-608-education-learning-kids-courses-outschool/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-608-education-learning-kids-courses-outschool/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 608,
+    "metaclass": "education-learning",
+    "class": "kids-courses",
+    "description": "Search for a Minecraft coding class for kids on Outschool and open the detail page of one of the results to view its description, schedule, and teacher information",
+    "sites_involved": [
+      "outschool.com"
+    ],
+    "platform": "outschool",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Search for a Minecraft coding class for kids on Outschool and open the detail page of one of the results to view its description, schedule, and teacher information",
+  "eval_schema": {
+    "url_pattern": "outschool\\.com/classes/",
+    "method": "GET"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-609-education-learning-meditation-spirit-rock-meditation-center/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-609-education-learning-meditation-spirit-rock-meditation-center/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 609,
+    "metaclass": "education-learning",
+    "class": "meditation",
+    "description": "Browse upcoming weekend retreat offerings on the Spirit Rock Meditation Center website, select one session, and complete the registration",
+    "sites_involved": [
+      "spiritrock.org"
+    ],
+    "platform": "spirit-rock",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Browse upcoming weekend retreat offerings on the Spirit Rock Meditation Center website, select one session, and complete the registration",
+  "eval_schema": {
+    "url_pattern": "spirit-rock\\.secure\\.retreat\\.guru/program/.*\\?form=1",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-610-hobbies-gaming-reviews-boardgamegeek/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-610-hobbies-gaming-reviews-boardgamegeek/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 610,
+    "metaclass": "entertainment-hobbies",
+    "class": "gaming-reviews",
+    "description": "Add yourself as a fan to 'Brass: Birmingham' (2018) on BoardGameGeek",
+    "sites_involved": [
+      "boardgamegeek.com"
+    ],
+    "platform": "boardgamegeek",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Add yourself as a fan to 'Brass: Birmingham' (2018) on BoardGameGeek",
+  "eval_schema": {
+    "url_pattern": "boardgamegeek\\.com/api/fans",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-630-daily-life-productivity-habitica/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-630-daily-life-productivity-habitica/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 630,
+    "metaclass": "daily-life",
+    "class": "productivity",
+    "description": "Add a new daily task on Habitica for 'Drink 8 glasses of water'",
+    "sites_involved": [
+      "habitica.com"
+    ],
+    "platform": "habitica",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Add a new daily task on Habitica for 'Drink 8 glasses of water'",
+  "eval_schema": {
+    "url_pattern": "habitica\\.com/api/v\\d+/tasks/user",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-631-daily-life-productivity-habitica/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-631-daily-life-productivity-habitica/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 631,
+    "metaclass": "daily-life",
+    "class": "productivity",
+    "description": "Create a new habit on Habitica called 'Read 10 pages' and set it to positive only",
+    "sites_involved": [
+      "habitica.com"
+    ],
+    "platform": "habitica",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Create a new habit on Habitica called 'Read 10 pages' and set it to positive only",
+  "eval_schema": {
+    "url_pattern": "habitica\\.com/api/v\\d+/tasks/user",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-633-daily-life-productivity-habitica/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-633-daily-life-productivity-habitica/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 633,
+    "metaclass": "daily-life",
+    "class": "productivity",
+    "description": "Create a daily task called 'Morning Workout' on Habitica and mark it as completed to earn experience points",
+    "sites_involved": [
+      "habitica.com"
+    ],
+    "platform": "habitica",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Create a daily task called 'Morning Workout' on Habitica and mark it as completed to earn experience points",
+  "eval_schema": {
+    "url_pattern": "habitica\\.com/api/v\\d+/tasks/[^/]+/score/up",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-634-daily-life-productivity-habitica/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-634-daily-life-productivity-habitica/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 634,
+    "metaclass": "daily-life",
+    "class": "productivity",
+    "description": "Add a To-Do item on Habitica called 'Buy a birthday gift for Mom' with medium priority and a due date of next Friday",
+    "sites_involved": [
+      "habitica.com"
+    ],
+    "platform": "habitica",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Add a To-Do item on Habitica called 'Buy a birthday gift for Mom' with medium priority and a due date of next Friday",
+  "eval_schema": {
+    "url_pattern": "habitica\\.com/api/v\\d+/tasks/user",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-635-entertainment-tracking-trakt/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-635-entertainment-tracking-trakt/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 635,
+    "metaclass": "entertainment",
+    "class": "tracking",
+    "description": "Search for 'Breaking Bad' on Trakt.tv and add it to your watchlist",
+    "sites_involved": [
+      "trakt.tv"
+    ],
+    "platform": "trakt",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Search for 'Breaking Bad' on Trakt.tv and add it to your watchlist",
+  "eval_schema": {
+    "url_pattern": "trakt\\.tv.*(sync/watchlist)",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-638-entertainment-tracking-trakt/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-638-entertainment-tracking-trakt/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 638,
+    "metaclass": "entertainment",
+    "class": "tracking",
+    "description": "Create a new custom list on Trakt.tv named 'Sci-Fi Favorites'",
+    "sites_involved": [
+      "trakt.tv"
+    ],
+    "platform": "trakt",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Create a new custom list on Trakt.tv named 'Sci-Fi Favorites'",
+  "eval_schema": {
+    "url_pattern": "trakt\\.tv.*(users/me/lists)",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-705-rating-voting-wine-review-vivino/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-705-rating-voting-wine-review-vivino/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 705,
+    "metaclass": "rating-voting",
+    "class": "wine-review",
+    "description": "Submit a 4-star rating for a Pinot Noir on Vivino with exactly this tasting note: \"Light body, cherry notes, smooth finish.\"",
+    "sites_involved": [
+      "vivino.com"
+    ],
+    "platform": "vivino",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Submit a 4-star rating for a Pinot Noir on Vivino with exactly this tasting note: \"Light body, cherry notes, smooth finish.\"",
+  "eval_schema": {
+    "url_pattern": "vivino\\.com/api/vintages/\\d+/reviews",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-706-rating-voting-beer-review-beeradvocate/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-706-rating-voting-beer-review-beeradvocate/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 706,
+    "metaclass": "rating-voting",
+    "class": "beer-review",
+    "description": "Submit a review for an Imperial Stout on BeerAdvocate with all dimension scores filled and exactly this comment: \"Rich malt, roasty aroma, full body.\"",
+    "sites_involved": [
+      "beeradvocate.com"
+    ],
+    "platform": "beeradvocate",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Submit a review for an Imperial Stout on BeerAdvocate with all dimension scores filled and exactly this comment: \"Rich malt, roasty aroma, full body.\"",
+  "eval_schema": {
+    "url_pattern": "beeradvocate\\.com/beer/rate/\\d+",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-707-rating-voting-social-wine-untappd/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-707-rating-voting-social-wine-untappd/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 707,
+    "metaclass": "rating-voting",
+    "class": "social-wine",
+    "description": "Check in an IPA on Untappd with the highest star rating, and check out",
+    "sites_involved": [
+      "untappd.com"
+    ],
+    "platform": "untappd",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Check in an IPA on Untappd with the highest star rating, and check out",
+  "eval_schema": {
+    "url_pattern": "^https://untappd\\.com/api/v2/shop/summaries/\\d+",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-708-rating-voting-professor-review-ratemyprofessors/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-708-rating-voting-professor-review-ratemyprofessors/task.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 708,
+    "metaclass": "rating-voting",
+    "class": "professor-review",
+    "description": "Submit a rating for a Computer Science professor on RateMyProfessors: quality 4, difficulty 3, would take again Yes, with exactly this comment: \"Clear lectures, fair exams.\"",
+    "sites_involved": [
+      "ratemyprofessors.com"
+    ],
+    "platform": "ratemyprofessors",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Submit a rating for a Computer Science professor on RateMyProfessors: quality 4, difficulty 3, would take again Yes, with exactly this comment: \"Clear lectures, fair exams.\"",
+  "eval_schema": {
+    "url_pattern": "ratemyprofessors\\.com/graphql",
+    "method": "POST",
+    "body": {
+      "operationName": "RateTeacherMutation"
+    }
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-711-creation-init-color-design-coolors/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-711-creation-init-color-design-coolors/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 711,
+    "metaclass": "creation-init",
+    "class": "color-design",
+    "description": "On Coolors, generate a 5-color palette, lock one color and adjust it to #FF6B6B, then export the palette to PDF.",
+    "sites_involved": [
+      "coolors.co"
+    ],
+    "platform": "coolors",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "On Coolors, generate a 5-color palette, lock one color and adjust it to #FF6B6B, then export the palette to PDF.",
+  "eval_schema": {
+    "url_pattern": "coolors\\.co/ajax/export-palette",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-735-home-services-maintenance-house-cleaning-bark/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-735-home-services-maintenance-house-cleaning-bark/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 735,
+    "metaclass": "home-services-maintenance",
+    "class": "house-cleaning",
+    "description": "Post a home cleaning project on Bark, fill in the service description, address, and required date, and submit the project",
+    "sites_involved": [
+      "bark.com"
+    ],
+    "platform": "bark",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Post a home cleaning project on Bark, fill in the service description, address, and required date, and submit the project",
+  "eval_schema": {
+    "url_pattern": "api\\.bark\\.com/bark/pre",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-737-home-services-maintenance-kitchen-remodel-lowes/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-737-home-services-maintenance-kitchen-remodel-lowes/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 737,
+    "metaclass": "home-services-maintenance",
+    "class": "kitchen-remodel",
+    "description": "Schedule a free kitchen remodel consultation on Lowe's website",
+    "sites_involved": [
+      "lowes.com"
+    ],
+    "platform": "lowes",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Schedule a free kitchen remodel consultation on Lowe's website",
+  "eval_schema": {
+    "url_pattern": "lowes\\.myhomeprojectcenter\\.com.*/lead|lowes\\.com.*/schedule|lowes\\.com.*/consultation|lowes\\.com.*/install-services|lowes\\.com.*/measurerequest",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-763-automotive-vehicle-services-car-lease-autoslash/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-763-automotive-vehicle-services-car-lease-autoslash/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 763,
+    "metaclass": "automotive-vehicle-services",
+    "class": "car-lease",
+    "description": "Search AutoSlash for the cheapest economy car rental at Miami airport for a 3-day period, and complete the price-tracking registration so it auto-rebooks if prices drop",
+    "sites_involved": [
+      "autoslash.com"
+    ],
+    "platform": "autoslash",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "Search AutoSlash for the cheapest economy car rental at Miami airport for a 3-day period, and complete the price-tracking registration so it auto-rebooks if prices drop",
+  "eval_schema": {
+    "url_pattern": "www\\.autoslash\\.com/quote/contact-info/[0-9a-f-]+",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-774-nonprofit-charity-nonprofit-job-apply-charity-village/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-774-nonprofit-charity-nonprofit-job-apply-charity-village/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 774,
+    "metaclass": "nonprofit-charity",
+    "class": "nonprofit-job-apply",
+    "description": "On Charity Village, create an account and apply for a full-time volunteer coordinator position in the Youth sector in Calgary, upload a resume and fill in a cover letter",
+    "sites_involved": [
+      "charityvillage.com"
+    ],
+    "platform": "charity-village",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "On Charity Village, create an account and apply for a full-time volunteer coordinator position in the Youth sector in Calgary, upload a resume and fill in a cover letter",
+  "eval_schema": {
+    "url_pattern": "www\\.charityvillage\\.com/api/auth/callback/sign-in",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-776-nonprofit-charity-volunteer-signup-idealist/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-776-nonprofit-charity-volunteer-signup-idealist/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 776,
+    "metaclass": "nonprofit-charity",
+    "class": "volunteer-signup",
+    "description": "On Idealist, search for Program Manager positions at nonprofits in Washington DC, select a qualifying position and submit a job application",
+    "sites_involved": [
+      "idealist.org"
+    ],
+    "platform": "idealist",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "On Idealist, search for Program Manager positions at nonprofits in Washington DC, select a qualifying position and submit a job application",
+  "eval_schema": {
+    "url_pattern": "www\\.idealist\\.org/data/userdashboard/missing-info",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-794-beauty-personal-care-salon-booking-styleseat/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-794-beauty-personal-care-salon-booking-styleseat/task.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 794,
+    "metaclass": "beauty-personal-care",
+    "class": "salon-booking",
+    "description": "On StyleSeat, search for hairstylists in your city, select one rated 4.8 stars or above, and book a haircut appointment at the earliest available time slot",
+    "sites_involved": [
+      "styleseat.com"
+    ],
+    "platform": "styleseat",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "On StyleSeat, search for hairstylists in your city, select one rated 4.8 stars or above, and book a haircut appointment at the earliest available time slot",
+  "eval_schema": {
+    "url_pattern": "styleseat\\.com/api/v1/appointment-request/",
+    "method": "POST"
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-815-pet-animal-care-favorite-pet/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-815-pet-animal-care-favorite-pet/task.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 815,
+    "metaclass": "pet-animal-care",
+    "class": "pet-favorite",
+    "description": "Search for adoptable dogs near ZIP 10001, open the first result's profile, and click the heart icon to save it as a favorite (requires login).",
+    "sites_involved": [
+      "petfinder.com"
+    ],
+    "platform": "petfinder",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "On Petfinder, search for adoptable dogs near ZIP code 10001, open the profile of the first dog listed, and save it as a favorite by clicking the heart icon. You will need to sign in or create an account to complete this action.",
+  "eval_schema": {
+    "url_pattern": "psl\\.petfinder\\.com/graphql",
+    "method": "POST",
+    "body": {
+      "operationName": "CreateAnimalFavorite"
+    }
+  },
+  "time_limit": 25,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-816-pet-animal-care-remove-favorite/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-816-pet-animal-care-remove-favorite/task.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 816,
+    "metaclass": "pet-animal-care",
+    "class": "pet-unfavorite",
+    "description": "Search for adoptable cats near ZIP 90210, open the first result, favorite it, then unfavorite it — verifying the RemoveAnimalFavorite mutation fires.",
+    "sites_involved": [
+      "petfinder.com"
+    ],
+    "platform": "petfinder",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "On Petfinder, search for adoptable cats near ZIP code 90210, open the profile of the first result, save it as a favorite, and then immediately remove it from your favorites by clicking the heart icon again.",
+  "eval_schema": {
+    "url_pattern": "psl\\.petfinder\\.com/graphql",
+    "method": "POST",
+    "body": {
+      "operationName": "RemoveAnimalFavorite"
+    }
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-817-pet-animal-care-create-adopter-profile/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-817-pet-animal-care-create-adopter-profile/task.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 817,
+    "metaclass": "pet-animal-care",
+    "class": "adopter-profile",
+    "description": "Navigate to any adoptable dog's profile, click Start Your Inquiry, and complete the adopter profile creation form — verifying the CreateAdopterProfile mutation fires.",
+    "sites_involved": [
+      "petfinder.com"
+    ],
+    "platform": "petfinder",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "On Petfinder, start the process of submitting an adoption inquiry for any adoptable dog. When prompted, complete the adopter profile creation form with your details to proceed.",
+  "eval_schema": {
+    "url_pattern": "psl\\.petfinder\\.com/graphql",
+    "method": "POST",
+    "body": {
+      "operationName": "CreateAdopterProfile"
+    }
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-901-entertainment-imdb-add-to-watchlist/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-901-entertainment-imdb-add-to-watchlist/task.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 901,
+    "metaclass": "entertainment",
+    "class": "watchlist-add",
+    "description": "Search for 'The Dark Knight' on IMDb, navigate to its title page, and click the Watchlist button — verifying the AddIdToWatchlist mutation fires.",
+    "sites_involved": [
+      "imdb.com"
+    ],
+    "platform": "imdb",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "On IMDb, search for the movie 'The Dark Knight', open its title page, and add it to your Watchlist by clicking the '+ Watchlist' button. You will need to be signed in to complete this action.",
+  "eval_schema": {
+    "url_pattern": "api\\.graphql\\.imdb\\.com",
+    "method": "POST",
+    "body": {
+      "operationName": "AddIdToWatchlist"
+    }
+  },
+  "time_limit": 20,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-902-entertainment-imdb-rate-title/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-902-entertainment-imdb-rate-title/task.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 902,
+    "metaclass": "entertainment",
+    "class": "title-rate",
+    "description": "Navigate to Interstellar (2014) on IMDb, click Rate, select 9 stars, and submit — verifying the UpdateTitleRating mutation fires with rating=9.",
+    "sites_involved": [
+      "imdb.com"
+    ],
+    "platform": "imdb",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "On IMDb, open the title page for 'Interstellar' (2014) and give it a rating of 9 out of 10 stars using the Rate button. You will need to be signed in.",
+  "eval_schema": {
+    "url_pattern": "api\\.graphql\\.imdb\\.com",
+    "method": "POST",
+    "body": {
+      "operationName": "UpdateTitleRating"
+    }
+  },
+  "time_limit": 25,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-903-entertainment-imdb-remove-rating/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-903-entertainment-imdb-remove-rating/task.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 903,
+    "metaclass": "entertainment",
+    "class": "title-unrate",
+    "description": "Open any previously rated title on IMDb, click the Rate button, then 'Remove rating' — verifying the DeleteTitleRating mutation fires.",
+    "sites_involved": [
+      "imdb.com"
+    ],
+    "platform": "imdb",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "On IMDb, find any title you have previously rated, open its page, click the Rate button, and then click 'Remove rating' to delete your rating.",
+  "eval_schema": {
+    "url_pattern": "api\\.graphql\\.imdb\\.com",
+    "method": "POST",
+    "body": {
+      "operationName": "DeleteTitleRating"
+    }
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-904-entertainment-imdb-create-list/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-904-entertainment-imdb-create-list/task.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 904,
+    "metaclass": "entertainment",
+    "class": "list-create",
+    "description": "Go to imdb.com/list/create/, fill in the list name 'My Sci-Fi Favorites', and submit — verifying the ListCreate mutation fires.",
+    "sites_involved": [
+      "imdb.com"
+    ],
+    "platform": "imdb",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "On IMDb, navigate to the 'Create a new list' page, enter the name 'My Sci-Fi Favorites', keep the default List Type as 'Titles', set Privacy to 'Private', and click Create.",
+  "eval_schema": {
+    "url_pattern": "api\\.graphql\\.imdb\\.com",
+    "method": "POST",
+    "body": {
+      "operationName": "ListCreate"
+    }
+  },
+  "time_limit": 20,
+  "extra_info": []
+}

--- a/packages/evals/datasets/clawbench/test-cases/v2/v2-905-entertainment-imdb-add-to-list/task.json
+++ b/packages/evals/datasets/clawbench/test-cases/v2/v2-905-entertainment-imdb-add-to-list/task.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "../../task.schema.json",
+  "metadata": {
+    "task_id": 905,
+    "metaclass": "entertainment",
+    "class": "list-item-add",
+    "description": "Navigate to Pulp Fiction (1994) on IMDb, open the 'Add to list' panel via the watchlist dropdown, select an existing custom list — verifying the AddConstToList mutation fires.",
+    "sites_involved": [
+      "imdb.com"
+    ],
+    "platform": "imdb",
+    "common_info": {
+      "email_credentials": "credentials to use the assigned disposable email account",
+      "user_info": "alex_green_personal_info.json; the dummy user's personal information",
+      "user_resume": "PDF resume with disposable email account injected"
+    }
+  },
+  "instruction": "On IMDb, open the title page for 'Pulp Fiction' (1994), click the dropdown chevron next to the Watchlist button, and add it to an existing custom list of yours.\n\nNote: The user must already have at least one custom list created. If not, create one first.",
+  "eval_schema": {
+    "url_pattern": "api\\.graphql\\.imdb\\.com",
+    "method": "POST",
+    "body": {
+      "operationName": "AddConstToList"
+    }
+  },
+  "time_limit": 30,
+  "extra_info": []
+}

--- a/packages/evals/framework/benchHarness.ts
+++ b/packages/evals/framework/benchHarness.ts
@@ -19,6 +19,10 @@ import { prepareClaudeCodeToolAdapter } from "./claudeCodeToolAdapter.js";
 import { runCodexAgent } from "./codexRunner.js";
 import { prepareCodexToolAdapter } from "./codexToolAdapter.js";
 import { buildExternalHarnessTaskPlan } from "./externalHarnessPlan.js";
+import { prepareClawBenchRuntime } from "../clawbench/runtime.js";
+import { loadClawBenchModelConfig } from "../clawbench/modelConfig.js";
+import { getClawBenchLanguageModel } from "../clawbench/languageModel.js";
+import type { ClawBenchRunParams } from "../clawbench/types.js";
 import type { DiscoveredTask, TaskResult } from "./types.js";
 import type { BenchMatrixRow, BenchTaskKind, Harness } from "./benchTypes.js";
 
@@ -80,6 +84,20 @@ function resolveProvider(modelName: AvailableModel): string | undefined {
   }
 }
 
+function createClawBenchLlmClient(modelName: string): LLMClient {
+  const modelConfig = loadClawBenchModelConfig(modelName);
+
+  return new AISdkClientWrapped({
+    model: getClawBenchLanguageModel(modelConfig),
+    clientOptions: {
+      apiKey: modelConfig.api_key,
+      baseURL: modelConfig.base_url,
+      reasoningEffort: modelConfig.thinking_level,
+      temperature: modelConfig.temperature,
+    },
+  });
+}
+
 export const stagehandHarness: BenchHarness = {
   harness: "stagehand",
   supportedTaskKinds: [
@@ -99,85 +117,128 @@ export const stagehandHarness: BenchHarness = {
     verbose,
   }: BenchHarnessStartInput): Promise<StartedBenchHarness> {
     let v3Result: V3InitResult | undefined;
-    const createAgent = isAgentTask(task);
+    const isClawBenchTask = task.name === "agent/clawbench";
+    const createAgent = isAgentTask(task) && !isClawBenchTask;
     if (row.config.harness !== "stagehand") {
       throw new EvalsError(
         `Harness "${row.config.harness}" is not implemented yet. Use --harness stagehand for the current unified runner.`,
       );
     }
     const config = row.config;
-    const agentMode = config.agentMode ?? input.agentMode;
-    const isCUA = config.isCUA ?? input.isCUA;
-
-    if (config.useApi) {
-      const provider = resolveProvider(input.modelName);
-      const logFn = (line: LogLine) => logger.log(line);
-      const apiKey = loadApiKeyFromEnv(provider, logFn);
-      if (!apiKey) {
-        throw new EvalsError(
-          `USE_API=true but no API key found for provider "${provider}".`,
-        );
-      }
-      const { initV3 } = await import("../initV3.js");
-      v3Result = await initV3({
-        logger,
-        modelName: input.modelName,
-        modelClientOptions: { apiKey },
-        createAgent,
-        agentMode,
-        isCUA,
-        verbose,
-        configOverrides: { env: config.environment },
-      });
-    } else {
-      let llmClient: LLMClient | undefined;
-      if (input.modelName.includes("/")) {
-        const firstSlashIndex = input.modelName.indexOf("/");
-        llmClient = new AISdkClientWrapped({
-          model: getAISDKLanguageModel(
-            input.modelName.substring(0, firstSlashIndex),
-            input.modelName.substring(firstSlashIndex + 1),
-          ),
-        });
-      }
-      const { initV3 } = await import("../initV3.js");
-      v3Result = await initV3({
-        logger,
-        llmClient,
-        modelName: input.modelName,
-        createAgent,
-        agentMode,
-        isCUA,
-        verbose,
-        configOverrides: { env: config.environment },
-      });
+    if (isClawBenchTask && config.environment !== "LOCAL") {
+      throw new EvalsError(
+        "ClawBench native runs currently support LOCAL only. Use --env local.",
+      );
+    }
+    if (isClawBenchTask && config.useApi) {
+      throw new EvalsError(
+        "ClawBench native runs do not support --api; they require local Chrome with the ClawBench recorder extension.",
+      );
     }
 
-    return {
-      ctx: {
-        harness: "stagehand",
-        row,
-        logger,
-        v3: v3Result.v3,
-        agent: v3Result.agent,
-        page: v3Result.v3.context.pages()[0],
-        debugUrl: v3Result.debugUrl ?? "",
-        sessionUrl: v3Result.sessionUrl ?? "",
-      },
-      cleanup: async () => {
-        if (v3Result?.v3) {
-          try {
-            await v3Result.v3.close();
-          } catch (closeError) {
-            console.error(
-              `Warning: Error closing V3 instance for ${input.name}:`,
-              closeError,
-            );
-          }
+    let clawbenchRuntime:
+      | Awaited<ReturnType<typeof prepareClawBenchRuntime>>
+      | undefined;
+
+    try {
+      clawbenchRuntime = isClawBenchTask
+        ? await prepareClawBenchRuntime(
+            input.params as unknown as ClawBenchRunParams,
+          )
+        : undefined;
+      if (clawbenchRuntime && input.params) {
+        (input.params as Record<string, unknown>)._clawbenchRuntime =
+          clawbenchRuntime;
+      }
+      const clawbenchLlmClient = isClawBenchTask
+        ? createClawBenchLlmClient(String(input.modelName))
+        : undefined;
+      const initModelName = input.modelName;
+      const agentMode = config.agentMode ?? input.agentMode;
+      const isCUA = config.isCUA ?? input.isCUA;
+
+      if (config.useApi) {
+        const provider = resolveProvider(input.modelName);
+        const logFn = (line: LogLine) => logger.log(line);
+        const apiKey = loadApiKeyFromEnv(provider, logFn);
+        if (!apiKey) {
+          throw new EvalsError(
+            `USE_API=true but no API key found for provider "${provider}".`,
+          );
         }
-        await endBrowserbaseSession(v3Result?.v3);
-      },
-    };
+        const { initV3 } = await import("../initV3.js");
+        v3Result = await initV3({
+          logger,
+          modelName: initModelName,
+          modelClientOptions: { apiKey },
+          createAgent,
+          agentMode,
+          isCUA,
+          verbose,
+          configOverrides: { env: config.environment },
+        });
+      } else {
+        let llmClient: LLMClient | undefined = clawbenchLlmClient;
+        if (!llmClient && input.modelName.includes("/")) {
+          const firstSlashIndex = input.modelName.indexOf("/");
+          llmClient = new AISdkClientWrapped({
+            model: getAISDKLanguageModel(
+              input.modelName.substring(0, firstSlashIndex),
+              input.modelName.substring(firstSlashIndex + 1),
+            ),
+          });
+        }
+        const { initV3 } = await import("../initV3.js");
+        v3Result = await initV3({
+          logger,
+          llmClient,
+          modelName: initModelName,
+          createAgent,
+          agentMode,
+          isCUA,
+          verbose,
+          configOverrides: {
+            env: config.environment,
+            localBrowserLaunchOptions: clawbenchRuntime?.launchOptions,
+            experimental: Boolean(clawbenchRuntime),
+          },
+        });
+      }
+
+      if (clawbenchRuntime) {
+        await clawbenchRuntime.startCdpInterceptor();
+      }
+
+      return {
+        ctx: {
+          harness: "stagehand",
+          row,
+          logger,
+          v3: v3Result.v3,
+          agent: v3Result.agent,
+          page: v3Result.v3.context.pages()[0],
+          debugUrl: v3Result.debugUrl ?? "",
+          sessionUrl: v3Result.sessionUrl ?? "",
+        },
+        cleanup: async () => {
+          if (v3Result?.v3) {
+            try {
+              await v3Result.v3.close();
+            } catch (closeError) {
+              console.error(
+                `Warning: Error closing V3 instance for ${input.name}:`,
+                closeError,
+              );
+            }
+          }
+          await clawbenchRuntime?.stop();
+          await endBrowserbaseSession(v3Result?.v3);
+        },
+      };
+    } catch (error) {
+      await clawbenchRuntime?.stop();
+      throw error;
+    }
   },
 };
 

--- a/packages/evals/framework/benchPlanner.ts
+++ b/packages/evals/framework/benchPlanner.ts
@@ -3,6 +3,8 @@ import { EvalsError } from "../errors.js";
 import { buildOnlineMind2WebTestcases } from "../suites/onlineMind2Web.js";
 import { buildWebTailBenchTestcases } from "../suites/webtailbench.js";
 import { buildWebVoyagerTestcases } from "../suites/webvoyager.js";
+import { buildClawBenchTestcases } from "../clawbench/suite.js";
+import { resolveClawBenchModelName } from "../clawbench/modelConfig.js";
 import {
   getAgentModelEntries,
   getModelList,
@@ -101,17 +103,18 @@ export function resolveBenchModelEntries(
     harness === "stagehand" ? resolveRequestedAgentModes(options) : undefined;
 
   if (options.modelOverride) {
+    const modelOverride = options.modelOverride;
     const baseModes =
       isAgentCategory && requestedAgentModes
         ? requestedAgentModes
         : [
             harness === "stagehand"
-              ? resolveAgentModeForModel(options.modelOverride)
+              ? resolveAgentModeForModel(modelOverride)
               : "hybrid",
           ];
     const modelEntries = uniqueAgentModelEntries(
       baseModes.map((mode) => ({
-        modelName: options.modelOverride,
+        modelName: modelOverride,
         mode,
         cua: mode === "cua",
       })),
@@ -133,6 +136,7 @@ export function resolveBenchModelEntries(
     harness,
     effectiveCategory,
     isAgentCategory,
+    benchTasks,
   );
 
   return {
@@ -201,7 +205,22 @@ function resolveDefaultModelEntries(
   harness: Harness,
   effectiveCategory: string | null,
   isAgentCategory: boolean,
+  benchTasks?: DiscoveredTask[],
 ): AgentModelEntry[] {
+  if (
+    harness === "stagehand" &&
+    benchTasks?.length === 1 &&
+    benchTasks[0].name === "agent/clawbench"
+  ) {
+    return [
+      {
+        modelName: resolveClawBenchModelName(),
+        mode: "hybrid",
+        cua: false,
+      },
+    ];
+  }
+
   if (harness === "claude_code") {
     return readModelListEnv(
       "EVAL_CLAUDE_CODE_MODELS",
@@ -225,7 +244,7 @@ function resolveDefaultModelEntries(
 
   return isAgentCategory
     ? getAgentModelEntries()
-    : getModelList(effectiveCategory).map((modelName) => ({
+    : getModelList(effectiveCategory ?? undefined).map((modelName) => ({
         modelName,
         mode: "hybrid" as const,
         cua: false,
@@ -513,6 +532,7 @@ export function generateSuiteTestcases(
     "agent/webvoyager": (models) => buildWebVoyagerTestcases(models),
     "agent/onlineMind2Web": (models) => buildOnlineMind2WebTestcases(models),
     "agent/webtailbench": (models) => buildWebTailBenchTestcases(models),
+    "agent/clawbench": (models) => buildClawBenchTestcases(models),
   };
   const legacyOnlySuites = new Set(["agent/gaia"]);
 
@@ -528,8 +548,17 @@ export function generateSuiteTestcases(
     const idx = remaining.findIndex((t) => t.name === suiteName);
     if (idx === -1) continue;
     const datasetName = suiteName.split("/").pop();
-    if (!datasetFilter || datasetFilter === datasetName) {
-      const task = remaining[idx];
+    const task = remaining[idx];
+    const isDirectClawBenchTarget =
+      suiteName === "agent/clawbench" &&
+      benchTasks.length === 1 &&
+      task.name === "agent/clawbench";
+    const shouldBuildSuite =
+      suiteName === "agent/clawbench"
+        ? isDirectClawBenchTarget &&
+          (!datasetFilter || datasetFilter === datasetName)
+        : !datasetFilter || datasetFilter === datasetName;
+    if (shouldBuildSuite) {
       testcases.push(
         ...builder(modelEntries).map((testcase) =>
           withBenchMetadata(testcase, task, options),

--- a/packages/evals/framework/discovery.ts
+++ b/packages/evals/framework/discovery.ts
@@ -63,6 +63,7 @@ const CATEGORY_OVERRIDES: Record<string, string[]> = {
   "agent/webvoyager": ["external_agent_benchmarks"],
   "agent/onlineMind2Web": ["external_agent_benchmarks"],
   "agent/webtailbench": ["external_agent_benchmarks"],
+  "agent/clawbench": ["external_agent_benchmarks"],
 };
 
 function getTaskBasename(taskName: string): string {

--- a/packages/evals/taskConfig.ts
+++ b/packages/evals/taskConfig.ts
@@ -139,6 +139,7 @@ const CATEGORY_OVERRIDES: Record<string, string[]> = {
   "agent/webvoyager": ["external_agent_benchmarks"],
   "agent/onlineMind2Web": ["external_agent_benchmarks"],
   "agent/webtailbench": ["external_agent_benchmarks"],
+  "agent/clawbench": ["external_agent_benchmarks"],
 };
 
 /**

--- a/packages/evals/tasks/bench/agent/clawbench.ts
+++ b/packages/evals/tasks/bench/agent/clawbench.ts
@@ -1,0 +1,312 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { tool, type ToolSet } from "ai";
+import { z } from "zod";
+import { defineBenchTask } from "../../../framework/defineTask.js";
+import {
+  loadClawBenchModelConfig,
+  resolveClawBenchJudgeModelName,
+} from "../../../clawbench/modelConfig.js";
+import {
+  buildClawBenchInstruction,
+  prepareClawBenchPersonalInfo,
+} from "../../../clawbench/personalInfo.js";
+import { judgeClawBenchInterception } from "../../../clawbench/judge.js";
+import type { ClawBenchRuntime } from "../../../clawbench/runtime.js";
+import type { ClawBenchRunParams } from "../../../clawbench/types.js";
+
+function readParams(
+  raw: Record<string, unknown> | undefined,
+): ClawBenchRunParams {
+  if (!raw || typeof raw !== "object") {
+    throw new Error("Missing ClawBench params");
+  }
+  return raw as unknown as ClawBenchRunParams;
+}
+
+function getInjectedRuntime(
+  raw: Record<string, unknown> | undefined,
+): ClawBenchRuntime {
+  const runtime = raw?._clawbenchRuntime;
+  if (!runtime || typeof runtime !== "object") {
+    throw new Error(
+      "ClawBench runtime was not initialized. Run agent/clawbench with the stagehand harness in LOCAL mode.",
+    );
+  }
+  return runtime as ClawBenchRuntime;
+}
+
+function createUploadTool(
+  page: unknown,
+  files: Array<{ name: string; path: string; description: string }>,
+): ToolSet {
+  const byName = new Map(files.map((file) => [file.name, file]));
+  return {
+    uploadFile: tool({
+      description:
+        "Upload one of the available local task files to a visible file input on the current page.",
+      inputSchema: z.object({
+        fileName: z
+          .string()
+          .describe(
+            `One of: ${files.map((file) => file.name).join(", ") || "no files"}`,
+          ),
+        selector: z
+          .string()
+          .optional()
+          .describe("Optional CSS selector for the input[type=file] element."),
+      }),
+      execute: async ({ fileName, selector }) => {
+        const selected = byName.get(fileName);
+        if (!selected) {
+          return {
+            success: false,
+            error: `Unknown file "${fileName}". Available: ${[...byName.keys()].join(", ")}`,
+          };
+        }
+        const pageAny = page as {
+          locator?: (selector: string) => {
+            setInputFiles?: (filePath: string) => Promise<void>;
+          };
+        };
+        if (!pageAny.locator) {
+          return { success: false, error: "Current page has no locator API" };
+        }
+        const locator = pageAny.locator(selector ?? 'input[type="file"]');
+        if (!locator.setInputFiles) {
+          return {
+            success: false,
+            error: "Selected element does not support setInputFiles",
+          };
+        }
+        await locator.setInputFiles(selected.path);
+        return { success: true, uploaded: selected.name };
+      },
+    }),
+  };
+}
+
+function summarizeAgentResult(result: unknown): Record<string, unknown> {
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return { message: String(result ?? "") };
+  }
+  const obj = result as Record<string, unknown>;
+  return {
+    success: obj.success,
+    completed: obj.completed,
+    message: obj.message,
+    action_count: Array.isArray(obj.actions) ? obj.actions.length : undefined,
+  };
+}
+
+function summarizeAgentStep(event: {
+  finishReason?: unknown;
+  text?: unknown;
+  reasoning?: unknown;
+  toolCalls?: unknown;
+  toolResults?: unknown;
+  usage?: unknown;
+  response?: { messages?: unknown };
+}): Record<string, unknown> {
+  return {
+    finishReason: event.finishReason,
+    text: event.text,
+    reasoning: event.reasoning,
+    toolCalls: event.toolCalls,
+    toolResults: event.toolResults,
+    usage: event.usage,
+    responseMessages: event.response?.messages,
+  };
+}
+
+export default defineBenchTask(
+  { name: "agent/clawbench" },
+  async ({ v3, logger, debugUrl, sessionUrl, modelName, input }) => {
+    const params = readParams(input.params);
+    const runtime = getInjectedRuntime(input.params);
+    const judgeModelName = resolveClawBenchJudgeModelName();
+    const judgeConfig = loadClawBenchModelConfig(judgeModelName);
+    let emailCleanup: (() => Promise<void>) | undefined;
+
+    try {
+      const prepared = await prepareClawBenchPersonalInfo(
+        params,
+        runtime.runDir,
+      );
+      emailCleanup = prepared.cleanup;
+      const uploadFiles = [
+        {
+          name: "alex_green_resume.pdf",
+          path: prepared.info.resumePath,
+          description: "Synthetic resume for Alex Green",
+        },
+        ...prepared.info.extraFiles,
+      ];
+      const instruction = buildClawBenchInstruction(params, prepared.info);
+      const page = v3.context.pages()[0];
+      const agent = v3.agent({
+        mode: input.agentMode ?? (input.isCUA ? "cua" : "hybrid"),
+        tools: createUploadTool(page, uploadFiles),
+      });
+
+      const maxSteps =
+        Number(process.env.AGENT_EVAL_MAX_STEPS) ||
+        Math.max(30, Math.ceil(params.timeLimitMinutes * 2));
+      await runtime.recordAgentMessage({
+        type: "execute_start",
+        source: "stagehand_agent",
+        caseName: params.caseName,
+        taskId: params.taskId,
+        model: modelName,
+        mode: input.agentMode ?? (input.isCUA ? "cua" : "hybrid"),
+        maxSteps,
+        instruction,
+      });
+      let agentStep = 0;
+      const agentMode = input.agentMode ?? (input.isCUA ? "cua" : "hybrid");
+      const agentResult = await agent.execute({
+        instruction,
+        maxSteps,
+        excludeTools: agentMode === "cua" ? undefined : ["screenshot"],
+        callbacks: {
+          onStepFinish: async (event) => {
+            agentStep += 1;
+            await runtime.recordAgentMessage({
+              type: "step_finish",
+              source: "stagehand_agent",
+              step: agentStep,
+              ...summarizeAgentStep(event),
+            });
+          },
+        },
+      });
+      await runtime.recordAgentMessage({
+        type: "execute_result",
+        source: "stagehand_agent",
+        ...summarizeAgentResult(agentResult),
+        usage: agentResult.usage,
+        output: agentResult.output,
+        messages: agentResult.messages,
+      });
+      if (Array.isArray(agentResult.actions)) {
+        for (const action of agentResult.actions) {
+          await runtime.recordAction(action);
+        }
+      }
+      logger.log({
+        category: "evaluation",
+        message: `ClawBench agent finished for ${params.caseName}`,
+        level: 1,
+        auxiliary: {
+          message: {
+            value: String(agentResult.message ?? ""),
+            type: "string",
+          },
+        },
+      });
+
+      const interception = await runtime.readInterception();
+      const judge =
+        interception && interception.intercepted
+          ? await judgeClawBenchInterception({
+              modelConfig: judgeConfig,
+              judgeModelName,
+              instruction: params.instruction,
+              interception,
+              judgeContext: params.judgeContext,
+              rubric:
+                process.env.EVAL_CLAWBENCH_JUDGE_RUBRIC === "strict"
+                  ? "strict"
+                  : "lenient",
+            })
+          : null;
+      const success = Boolean(
+        interception?.intercepted && judge?.match === true,
+      );
+      const runMeta = {
+        test_case: params.caseName,
+        task_id: params.taskId,
+        corpus: params.corpus,
+        instruction: params.instruction,
+        metadata: params.metadata,
+        agent_result: summarizeAgentResult(agentResult),
+        intercepted: Boolean(interception?.intercepted),
+        judge,
+        pass: success,
+        model: modelName,
+        output_dir: runtime.runDir,
+        debugUrl,
+        sessionUrl,
+      };
+      await fs.writeFile(
+        path.join(runtime.runDir, "run-meta.json"),
+        JSON.stringify(runMeta, null, 2),
+      );
+      if (judge) {
+        await fs.writeFile(
+          path.join(
+            runtime.runDir,
+            judge.rubric === "strict" ? "judge.json" : "judge_llm.json",
+          ),
+          JSON.stringify(judge, null, 2),
+        );
+      }
+
+      return {
+        _success: success,
+        intercepted: Boolean(interception?.intercepted),
+        judge,
+        artifactPath: runtime.runDir,
+        caseName: params.caseName,
+        taskId: params.taskId,
+        debugUrl,
+        sessionUrl,
+        logs: logger.getLogs(),
+      };
+    } catch (error) {
+      await runtime
+        .recordAgentMessage({
+          type: "execute_error",
+          source: "stagehand_agent",
+          error: error instanceof Error ? error.message : String(error),
+        })
+        .catch(() => {});
+      await fs
+        .writeFile(
+          path.join(runtime.runDir, "run-meta.json"),
+          JSON.stringify(
+            {
+              test_case: params.caseName,
+              task_id: params.taskId,
+              corpus: params.corpus,
+              instruction: params.instruction,
+              metadata: params.metadata,
+              intercepted: false,
+              judge: null,
+              pass: false,
+              model: modelName,
+              output_dir: runtime.runDir,
+              debugUrl,
+              sessionUrl,
+              error: error instanceof Error ? error.message : String(error),
+            },
+            null,
+            2,
+          ),
+        )
+        .catch(() => {});
+      return {
+        _success: false,
+        error: error instanceof Error ? error.message : String(error),
+        artifactPath: runtime.runDir,
+        caseName: params.caseName,
+        taskId: params.taskId,
+        debugUrl,
+        sessionUrl,
+        logs: logger.getLogs(),
+      };
+    } finally {
+      await emailCleanup?.();
+    }
+  },
+);

--- a/packages/evals/tests/framework/discovery.test.ts
+++ b/packages/evals/tests/framework/discovery.test.ts
@@ -84,6 +84,20 @@ describe("discovery", () => {
     expect(tasks[0].categories).toEqual(["observe", "regression"]);
   });
 
+  it("classifies ClawBench as an external agent benchmark", async () => {
+    const root = makeTempRoot();
+    const tasksRoot = path.join(root, "tasks");
+
+    writeFile(path.join(tasksRoot, "bench", "agent", "clawbench.ts"));
+
+    const registry = await discoverTasks(tasksRoot, false);
+    const task = registry.byName.get("agent/clawbench");
+
+    expect(task).toBeDefined();
+    expect(task?.categories).toEqual(["external_agent_benchmarks"]);
+    expect(task?.primaryCategory).toBe("external_agent_benchmarks");
+  });
+
   it("rejects empty tier-qualified category targets", async () => {
     const root = makeTempRoot();
     const tasksRoot = path.join(root, "tasks");

--- a/packages/evals/tests/taskConfig.test.ts
+++ b/packages/evals/tests/taskConfig.test.ts
@@ -204,6 +204,10 @@ describe("cross-cutting categories", () => {
     expect(wv).toBeDefined();
     expect(wv.categories).toContain("external_agent_benchmarks");
     expect(wv.categories).not.toContain("agent");
+    const clawbench = tasksByName["agent/clawbench"];
+    expect(clawbench).toBeDefined();
+    expect(clawbench.categories).toContain("external_agent_benchmarks");
+    expect(clawbench.categories).not.toContain("agent");
   });
 
   it("does not expose core tier tasks", async () => {

--- a/packages/evals/tests/tui/parse.test.ts
+++ b/packages/evals/tests/tui/parse.test.ts
@@ -98,6 +98,11 @@ describe("resolveRunOptions", () => {
     expect(webtailbench.target).toBe("agent/webtailbench");
     expect(webtailbench.datasetFilter).toBe("webtailbench");
     expect(webtailbench.envOverrides.EVAL_WEBTAILBENCH_LIMIT).toBe("2");
+
+    const clawbench = applyBenchmarkShorthand("b:clawbench", { limit: 1 });
+    expect(clawbench.target).toBe("agent/clawbench");
+    expect(clawbench.datasetFilter).toBe("clawbench");
+    expect(clawbench.envOverrides.EVAL_CLAWBENCH_LIMIT).toBe("1");
   });
 
   it("marks GAIA as legacy-only in the unified runner", () => {

--- a/packages/evals/tui/commands/parse.ts
+++ b/packages/evals/tui/commands/parse.ts
@@ -79,6 +79,7 @@ export interface ResolvedRunOptions {
  * WebBench never had a unified suite implementation.
  */
 const SUPPORTED_BENCHMARKS = new Set([
+  "clawbench",
   "webvoyager",
   "onlineMind2Web",
   "webtailbench",


### PR DESCRIPTION
- ClawBench: https://github.com/TIGER-AI-Lab/ClawBench

# why
Add native support for [ClawBench](https://github.com/TIGER-AI-Lab/ClawBench) V2, a benchmark for evaluating agent browser capabilities on real-world web tasks.

ClawBench uses request interception to prevent the agent from committing dangerous, irreversible actions and uses LLM-as-judge to determine task correctness. 

# what changed
- Integrate ClawBench into the current `evals` package with ported request interceptors and LLM judge. 
- Each task is defined as a JSON file under `packages/evals/datasets/clawbench/test-cases/v2`.
- Current implementation restricts ClawBench eval to local execution only. 

# test plan
- Test cases have been added/appended to the existing test suite. 
```
pnpm --filter @browserbasehq/stagehand-evals exec tsx cli.ts run b:clawbench --preview
pnpm --filter @browserbasehq/stagehand-evals run typecheck
pnpm --filter @browserbasehq/stagehand-evals run test:unit
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ClawBench v2 as a dataset-backed benchmark in `@browserbasehq/stagehand-evals`, enabling local, safe evaluation of browser agents on real web tasks with request interception and LLM judging.

- New Features
  - New `b:clawbench` suite with v2 tasks under `packages/evals/datasets/clawbench/test-cases/v2`.
  - Request interception to block irreversible actions; lenient/diligent LLM judge for correctness.
  - Local runtime with CDP proxy and a Chrome extension for action and screenshot capture.
  - Model config loader (`models/models.yaml`) with OpenAI/Anthropic/Google support and provider mapping.
  - Local-only execution; README updated to list `b:clawbench`.
  - Changeset added for a minor release of `@browserbasehq/stagehand-evals`.

- Migration
  - Create `packages/evals/datasets/clawbench/models/models.yaml` from `models.example.yaml` and add API keys (or set `EVAL_CLAWBENCH_MODELS_YAML`).
  - Run: `pnpm --filter @browserbasehq/stagehand-evals exec tsx cli.ts run b:clawbench --preview`.
  - Ensure Chrome is installed; the extension loads automatically via the runtime.

<sup>Written for commit 98dab57199442dbff283cd7c7e289b2929ccea19. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2161?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

