### PR TITLE
feat(cli): add --chrome-arg flag for extra Chromium flags (fixes #2148)

### DIFF
--- a/.changeset/expose-chrome-args-cli.md
+++ b/.changeset/expose-chrome-args-cli.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/browse-cli": patch
+---
+
+Add `--chrome-arg` global flag to pass extra Chromium flags to the local browser. The flag is repeatable (e.g. `--chrome-arg=--no-focus-on-navigate --chrome-arg=--disable-backgrounding-occluded-windows`) and forwarded through daemon spawn, direct `--ws` connections, and local strategy resolution. Fixes #2148.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -378,7 +378,7 @@ interface DaemonResponse {
 // Default viewport matching Stagehand core
 const DEFAULT_VIEWPORT = { width: 1288, height: 711 };
 
-async function runDaemon(session: string, headless: boolean): Promise<void> {
+async function runDaemon(session: string, headless: boolean, chromeArgs: string[] = []): Promise<void> {
   // Only clean daemon state files (socket, pid, etc.), not client-written config (context)
   await cleanupDaemonStateFiles(session);
 
@@ -455,6 +455,7 @@ async function runDaemon(session: string, headless: boolean): Promise<void> {
           localConfig: await readLocalConfig(session),
           headless,
           defaultViewport: DEFAULT_VIEWPORT,
+          extraArgs: chromeArgs.length ? chromeArgs : undefined,
           discoverLocalCdp,
           resolveWsTarget,
         });
@@ -1452,6 +1453,7 @@ async function sendCommand(
   command: string,
   args: unknown[],
   headless: boolean = false,
+  chromeArgs: string[] = [],
 ): Promise<unknown> {
   const maxRetries = 3;
 
@@ -1482,14 +1484,14 @@ async function sendCommand(
 
       // Attempt 1: Try to restart daemon without cleanup
       if (attempt === 1) {
-        await ensureDaemon(session, headless);
+        await ensureDaemon(session, headless, chromeArgs);
         continue;
       }
 
       // Final attempt: Full cleanup and restart
       await killChromeProcesses(session);
       await cleanupStaleFiles(session);
-      await ensureDaemon(session, headless);
+      await ensureDaemon(session, headless, chromeArgs);
     }
   }
 
@@ -1509,7 +1511,7 @@ async function stopDaemonAndCleanup(session: string): Promise<void> {
   await cleanupDaemonStateFiles(session);
 }
 
-async function ensureDaemon(session: string, headless: boolean): Promise<void> {
+async function ensureDaemon(session: string, headless: boolean, chromeArgs: string[] = []): Promise<void> {
   const wantMode = await getDesiredMode(session);
   assertModeSupported(wantMode);
 
@@ -1540,6 +1542,7 @@ async function ensureDaemon(session: string, headless: boolean): Promise<void> {
 
     const args = ["--session", session, "daemon"];
     if (headless) args.push("--headless");
+    for (const ca of chromeArgs) args.push("--chrome-arg", ca);
 
     const child = spawn(process.argv[0], [process.argv[1], ...args], {
       detached: true,
@@ -1602,6 +1605,7 @@ interface GlobalOpts {
   json?: boolean;
   session?: string;
   connect?: string;
+  chromeArg?: string[];
   // Session creation flags (remote only)
   proxies?: boolean;
   advancedStealth?: boolean;
@@ -1659,6 +1663,7 @@ async function runCommand(command: string, args: unknown[]): Promise<unknown> {
   const opts = program.opts<GlobalOpts>();
   const session = getSession(opts);
   const headless = isHeadless(opts);
+  const chromeArgs = opts.chromeArg ?? [];
   // If --ws provided, bypass daemon and connect directly
   if (opts.ws) {
     const cdpUrl = await resolveWsTarget(opts.ws);
@@ -1668,6 +1673,7 @@ async function runCommand(command: string, args: unknown[]): Promise<unknown> {
       disablePino: true,
       localBrowserLaunchOptions: {
         cdpUrl,
+        ...(chromeArgs.length ? { args: chromeArgs } : {}),
       },
     });
     await stagehand.init();
@@ -1738,8 +1744,8 @@ async function runCommand(command: string, args: unknown[]): Promise<unknown> {
     }
   }
 
-  await ensureDaemon(session, headless);
-  return sendCommand(session, command, args, headless);
+  await ensureDaemon(session, headless, chromeArgs);
+  return sendCommand(session, command, args, headless, chromeArgs);
 }
 
 program
@@ -1752,6 +1758,12 @@ program
   )
   .option("--headless", "Run Chrome in headless mode")
   .option("--headed", "Run Chrome with visible window (default)")
+  .option(
+    "--chrome-arg <arg>",
+    "Extra Chromium flag for the local browser (repeatable, e.g. --chrome-arg=--no-focus-on-navigate)",
+    (val: string, prev: string[]) => prev.concat(val),
+    [] as string[],
+  )
   .option("--json", "Output as JSON", false)
   .option(
     "--session <name>",
@@ -1795,7 +1807,7 @@ program
       console.log(JSON.stringify({ status: "already running", session }));
       return;
     }
-    await ensureDaemon(session, isHeadless(opts));
+    await ensureDaemon(session, isHeadless(opts), opts.chromeArg ?? []);
     console.log(JSON.stringify({ status: "started", session }));
   });
 
@@ -1996,7 +2008,7 @@ envCommand.action(
       await stopDaemonAndCleanup(session);
     }
 
-    await ensureDaemon(session, isHeadless(opts));
+    await ensureDaemon(session, isHeadless(opts), opts.chromeArg ?? []);
 
     if (mapped === "local") {
       logLocalModeHint(localConfig, await waitForLocalInfo(session));
@@ -2032,7 +2044,7 @@ program
   .description("Run as daemon (internal use)")
   .action(async () => {
     const opts = program.opts<GlobalOpts>();
-    await runDaemon(getSession(opts), isHeadless(opts));
+    await runDaemon(getSession(opts), isHeadless(opts), opts.chromeArg ?? []);
   });
 
 // ==================== NAVIGATION ====================

--- a/packages/cli/src/local-strategy.ts
+++ b/packages/cli/src/local-strategy.ts
@@ -18,6 +18,7 @@ export interface LocalInfo {
 export interface LocalBrowserLaunchOptions {
   cdpUrl?: string;
   headless?: boolean;
+  args?: string[];
   viewport?: {
     width: number;
     height: number;
@@ -36,6 +37,7 @@ interface ResolveLocalStrategyOptions {
     width: number;
     height: number;
   };
+  extraArgs?: string[];
   discoverLocalCdp: () => Promise<LocalCdpDiscovery | null>;
   resolveWsTarget: (input: string) => Promise<string>;
 }
@@ -82,12 +84,15 @@ export async function resolveLocalStrategy({
   localConfig,
   headless,
   defaultViewport,
+  extraArgs,
   discoverLocalCdp,
   resolveWsTarget,
 }: ResolveLocalStrategyOptions): Promise<ResolvedLocalStrategy> {
+  const argsOption = extraArgs?.length ? { args: extraArgs } : {};
+
   if (localConfig.strategy === "isolated") {
     return {
-      localLaunchOptions: { headless, viewport: defaultViewport },
+      localLaunchOptions: { headless, viewport: defaultViewport, ...argsOption },
       localInfo: { localSource: "isolated" },
     };
   }
@@ -119,7 +124,7 @@ export async function resolveLocalStrategy({
   }
 
   return {
-    localLaunchOptions: { headless, viewport: defaultViewport },
+    localLaunchOptions: { headless, viewport: defaultViewport, ...argsOption },
     localInfo: {
       localSource: "isolated-fallback",
       fallbackReason: "no debuggable local browser found",


### PR DESCRIPTION
## Summary

Add a repeatable `--chrome-arg` global flag to the `browse` CLI so users can pass extra Chromium flags to the local browser.

Closes #2148

## Problem

The `browse` CLI's headed mode steals window focus on every command because there is no way to pass Chromium flags like `--no-focus-on-navigate` or `--disable-backgrounding-occluded-windows`. The core `LocalBrowserLaunchOptionsSchema` already supports an `args` array, and `launch/local.ts` already spreads `opts.args` into `chromeFlags` — but the CLI layer never exposes this to end users.

## Changes

### `packages/cli/src/local-strategy.ts`
- Add `args?: string[]` to the CLI's `LocalBrowserLaunchOptions` interface
- Add `extraArgs?: string[]` to `ResolveLocalStrategyOptions`
- Forward `extraArgs` into `localLaunchOptions` for the `isolated` and `isolated-fallback` paths (CDP-attach paths are unaffected — args are irrelevant when attaching to an existing browser)

### `packages/cli/src/index.ts`
- Add `chromeArg?: string[]` to `GlobalOpts`
- Add `--chrome-arg <arg>` repeatable option to the program
- Thread chrome args through `runCommand` → `ensureDaemon` → daemon spawn → `runDaemon` → `resolveLocalStrategy`
- Also forward args in the direct `--ws` connection path

### `.changeset/expose-chrome-args-cli.md`
- Patch changeset for the CLI package

## Usage

```bash
# Suppress focus stealing in headed mode
browse open https://example.com --headed \
  --chrome-arg=--no-focus-on-navigate \
  --chrome-arg=--disable-backgrounding-occluded-windows

# Pass any Chromium flag
browse snapshot --chrome-arg=--disable-gpu
```

## Testing

- Code review: every changed line traces to the issue
- The flag plumbing was verified by tracing all code paths: `runCommand` → `ensureDaemon` (spawn with `--chrome-arg` forwarded) → `runDaemon` → `resolveLocalStrategy` → `localLaunchOptions.args` → core's `launchLocalChrome` → `chromeFlags` array
- No existing tests are affected (the change is additive — new optional parameter with empty-array default everywhere)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a repeatable `--chrome-arg` flag to the `browse` CLI to pass extra Chromium flags to the local browser. This helps stop window focus stealing in headed mode and allows other Chrome tuning.

- **New Features**
  - `--chrome-arg <arg>` is repeatable and forwarded through the daemon, direct `--ws` connections, and local strategy resolution.
  - Flags are injected into local launch options (`args`), enabling options like `--no-focus-on-navigate` and `--disable-backgrounding-occluded-windows`.

<sup>Written for commit 0b5750411c4581c9fbfdfccde28015aaeaf59177. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2162?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

