### PR TITLE
fix: simplify LLMClient AI SDK helpers

### DIFF
--- a/.changeset/warm-models-simplify.md
+++ b/.changeset/warm-models-simplify.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Allow LLMClient AI SDK helpers to use the client's configured language model when `model` is omitted.

--- a/packages/core/lib/v3/llm/LLMClient.ts
+++ b/packages/core/lib/v3/llm/LLMClient.ts
@@ -114,6 +114,48 @@ export interface LLMParsedResponse<T> {
   usage?: LLMUsage;
 }
 
+type OptionalModelOptions<TOptions> = TOptions extends { model: infer TModel }
+  ? Omit<TOptions, "model"> & { model?: TModel }
+  : TOptions;
+
+type GenerateTextOptions = OptionalModelOptions<
+  Parameters<typeof generateText>[0]
+>;
+type GenerateObjectOptions = OptionalModelOptions<
+  Parameters<typeof generateObject>[0]
+>;
+type StreamTextOptions = OptionalModelOptions<Parameters<typeof streamText>[0]>;
+type StreamObjectOptions = OptionalModelOptions<
+  Parameters<typeof streamObject>[0]
+>;
+
+function resolveLanguageModel<TModel>(
+  client: LLMClient,
+  model: TModel | undefined,
+): TModel {
+  const resolvedModel = model ?? client.getLanguageModel?.();
+
+  if (!resolvedModel) {
+    throw new Error(
+      "No language model available. Pass a `model` option explicitly or use an LLMClient that implements getLanguageModel().",
+    );
+  }
+
+  return resolvedModel as TModel;
+}
+
+function withResolvedLanguageModel<TOptions extends object>(
+  client: LLMClient,
+  options: TOptions,
+): TOptions {
+  const model = "model" in options ? options.model : undefined;
+
+  return {
+    ...options,
+    model: resolveLanguageModel(client, model),
+  } as TOptions;
+}
+
 export abstract class LLMClient {
   public type: "openai" | "anthropic" | "cerebras" | "groq" | (string & {});
   public modelName: AvailableModel | (string & {});
@@ -140,10 +182,43 @@ export abstract class LLMClient {
     options: CreateChatCompletionOptions,
   ): Promise<T>;
 
-  public generateObject = generateObject;
-  public generateText = generateText;
-  public streamText = streamText;
-  public streamObject = streamObject;
+  public generateObject(
+    options: GenerateObjectOptions,
+  ): ReturnType<typeof generateObject> {
+    return generateObject(
+      withResolvedLanguageModel(this, options) as Parameters<
+        typeof generateObject
+      >[0],
+    );
+  }
+
+  public generateText(
+    options: GenerateTextOptions,
+  ): ReturnType<typeof generateText> {
+    return generateText(
+      withResolvedLanguageModel(this, options) as Parameters<
+        typeof generateText
+      >[0],
+    );
+  }
+
+  public streamText(options: StreamTextOptions): ReturnType<typeof streamText> {
+    return streamText(
+      withResolvedLanguageModel(this, options) as Parameters<
+        typeof streamText
+      >[0],
+    );
+  }
+
+  public streamObject(
+    options: StreamObjectOptions,
+  ): ReturnType<typeof streamObject> {
+    return streamObject(
+      withResolvedLanguageModel(this, options) as Parameters<
+        typeof streamObject
+      >[0],
+    );
+  }
   public generateImage = experimental_generateImage;
   public embed = embed;
   public embedMany = embedMany;

--- a/packages/core/lib/v3/llm/LLMClient.ts
+++ b/packages/core/lib/v3/llm/LLMClient.ts
@@ -133,7 +133,9 @@ function resolveLanguageModel<TModel>(
   client: LLMClient,
   model: TModel | undefined,
 ): TModel {
-  const resolvedModel = model ?? client.getLanguageModel?.();
+  const resolvedModel = (model ?? client.getLanguageModel?.()) as
+    | TModel
+    | undefined;
 
   if (!resolvedModel) {
     throw new Error(
@@ -141,7 +143,7 @@ function resolveLanguageModel<TModel>(
     );
   }
 
-  return resolvedModel as TModel;
+  return resolvedModel;
 }
 
 function withResolvedLanguageModel<TOptions extends object>(

--- a/packages/core/tests/unit/llmclient-ai-sdk-helpers.test.ts
+++ b/packages/core/tests/unit/llmclient-ai-sdk-helpers.test.ts
@@ -1,0 +1,118 @@
+import type { LanguageModelV2 } from "@ai-sdk/provider";
+import { generateObject, generateText, streamObject, streamText } from "ai";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { LLMClient } from "../../lib/v3/llm/LLMClient.js";
+import type {
+  AvailableModel,
+  ClientOptions,
+} from "../../lib/v3/types/public/model.js";
+
+vi.mock("ai", async () => {
+  const actual = await vi.importActual<typeof import("ai")>("ai");
+  return {
+    ...actual,
+    generateObject: vi.fn(),
+    generateText: vi.fn(),
+    streamObject: vi.fn(),
+    streamText: vi.fn(),
+  };
+});
+
+const mockGenerateObject = vi.mocked(generateObject);
+const mockGenerateText = vi.mocked(generateText);
+const mockStreamObject = vi.mocked(streamObject);
+const mockStreamText = vi.mocked(streamText);
+
+function createModel(modelId: string) {
+  return {
+    modelId,
+    specificationVersion: "v2",
+  } as unknown as LanguageModelV2;
+}
+
+class TestLLMClient extends LLMClient {
+  public type = "test";
+  public hasVision = false;
+  public clientOptions = {} as ClientOptions;
+
+  constructor(private readonly model: LanguageModelV2) {
+    super(model.modelId as AvailableModel);
+  }
+
+  public getLanguageModel(): LanguageModelV2 {
+    return this.model;
+  }
+
+  async createChatCompletion<T>(): Promise<T> {
+    return {} as T;
+  }
+}
+
+class LegacyLLMClient extends LLMClient {
+  public type = "test";
+  public hasVision = false;
+  public clientOptions = {} as ClientOptions;
+
+  constructor() {
+    super("test/model" as AvailableModel);
+  }
+
+  async createChatCompletion<T>(): Promise<T> {
+    return {} as T;
+  }
+}
+
+describe("LLMClient AI SDK helpers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGenerateObject.mockResolvedValue({ object: {} } as never);
+    mockGenerateText.mockResolvedValue({ text: "" } as never);
+    mockStreamObject.mockReturnValue({} as never);
+    mockStreamText.mockReturnValue({} as never);
+  });
+
+  it("injects the client language model when helper calls omit model", async () => {
+    const model = createModel("openai/gpt-4.1");
+    const client = new TestLLMClient(model);
+
+    await client.generateText({ prompt: "hello" });
+    await client.generateObject({ prompt: "hello", schema: {} as never });
+    client.streamText({ prompt: "hello" });
+    client.streamObject({ prompt: "hello", schema: {} as never });
+
+    expect(mockGenerateText).toHaveBeenCalledWith(
+      expect.objectContaining({ model }),
+    );
+    expect(mockGenerateObject).toHaveBeenCalledWith(
+      expect.objectContaining({ model }),
+    );
+    expect(mockStreamText).toHaveBeenCalledWith(
+      expect.objectContaining({ model }),
+    );
+    expect(mockStreamObject).toHaveBeenCalledWith(
+      expect.objectContaining({ model }),
+    );
+  });
+
+  it("keeps explicit model overrides", async () => {
+    const client = new TestLLMClient(createModel("openai/gpt-4.1"));
+    const overrideModel = createModel("anthropic/claude-sonnet-4-5");
+
+    await client.generateText({
+      model: overrideModel,
+      prompt: "hello",
+    });
+
+    expect(mockGenerateText).toHaveBeenCalledWith(
+      expect.objectContaining({ model: overrideModel }),
+    );
+  });
+
+  it("throws a clear error when no model can be resolved", () => {
+    const client = new LegacyLLMClient();
+
+    expect(() => client.streamText({ prompt: "hello" })).toThrow(
+      "No language model available",
+    );
+  });
+});


### PR DESCRIPTION
## Changes

- Wrap LLMClient AI SDK helpers so generateText, generateObject, streamText, and streamObject use the client's configured language model when the caller omits model.
- Preserve explicit model overrides for advanced callers.
- Add unit coverage for model injection, overrides, and the no-model error path.
- Add a patch changeset for @browserbasehq/stagehand.

## Context

Closes #666

## AI assistance disclosure

- [x] Yes — substantive assistance (implemented with OpenAI Codex / GPT-5, with targeted local validation).

## Documentation

- [x] No documentation update is required

## How I've tested my work

- [x] Newly added/modified unit tests

Validation run locally:

- corepack pnpm exec tsc -p packages/core/tsconfig.json --noEmit
- corepack pnpm --filter @browserbasehq/stagehand run build:esm
- node_modules\\.bin\\vitest.CMD run --config vitest.esm.config.mjs dist/esm/tests/unit/llmclient-ai-sdk-helpers.test.js --coverage false
- corepack pnpm exec prettier --write packages/core/lib/v3/llm/LLMClient.ts packages/core/tests/unit/llmclient-ai-sdk-helpers.test.ts .changeset/warm-models-simplify.md
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default the LLMClient AI SDK helpers (`generateText`, `generateObject`, `streamText`, `streamObject`) to use the client’s configured language model when `model` is omitted. Explicit `model` overrides still work, and a clear error is thrown if no model can be resolved (per Linear #666).

<sup>Written for commit afd8e07d49456c9f992610d73c7423855045e449. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

