### PR TITLE
Fix SDK API reference parameter labels

### DIFF
--- a/packages/docs/sdk-api-reference-labels.js
+++ b/packages/docs/sdk-api-reference-labels.js
@@ -1,0 +1,202 @@
+// Re-label generated OpenAPI schema fields on SDK-flavored API reference pages.
+//
+// Mintlify renders these pages from the OpenAPI wire schema, so body fields use
+// camelCase even when the selected SDK accepts snake_case parameters. Stainless
+// already emits language-correct code samples; this small client-side patch keeps
+// the visible parameter labels aligned with the Python and Ruby SDK snippets.
+(function () {
+  const SNAKE_CASE_PARAM_LABELS = {
+    acceptDownloads: "accept_downloads",
+    actTimeoutMs: "act_timeout_ms",
+    actionDescription: "action_description",
+    actionId: "action_id",
+    advancedStealth: "advanced_stealth",
+    agentConfig: "agent_config",
+    apiKey: "api_key",
+    backendNodeId: "backend_node_id",
+    baseURL: "base_url",
+    blockAds: "block_ads",
+    browserSettings: "browser_settings",
+    browserbaseAPIKey: "browserbase_api_key",
+    browserbaseProjectID: "browserbase_project_id",
+    browserbaseSessionCreateParams: "browserbase_session_create_params",
+    browserbaseSessionID: "browserbase_session_id",
+    cacheEntry: "cache_entry",
+    cacheKey: "cache_key",
+    captchaImageSelector: "captcha_image_selector",
+    captchaInputSelector: "captcha_input_selector",
+    cdpHeaders: "cdp_headers",
+    cdpUrl: "cdp_url",
+    cdpURL: "cdp_url",
+    chromiumSandbox: "chromium_sandbox",
+    clientLanguage: "client_language",
+    connectTimeoutMs: "connect_timeout_ms",
+    deviceScaleFactor: "device_scale_factor",
+    domSettleTimeoutMs: "dom_settle_timeout_ms",
+    domainPattern: "domain_pattern",
+    downloadsPath: "downloads_path",
+    endTime: "end_time",
+    executablePath: "executable_path",
+    executeOptions: "execute_options",
+    executionModel: "execution_model",
+    extensionId: "extension_id",
+    extensionID: "extension_id",
+    frameId: "frame_id",
+    frameID: "frame_id",
+    googleAuthOptions: "google_auth_options",
+    hasTouch: "has_touch",
+    highlightCursor: "highlight_cursor",
+    httpVersion: "http_version",
+    ignoreDefaultArgs: "ignore_default_args",
+    ignoreHTTPSErrors: "ignore_https_errors",
+    ignoreSelectors: "ignore_selectors",
+    inputTokens: "input_tokens",
+    keepAlive: "keep_alive",
+    launchOptions: "launch_options",
+    logSession: "log_session",
+    maxHeight: "max_height",
+    maxSteps: "max_steps",
+    maxWidth: "max_width",
+    minHeight: "min_height",
+    minWidth: "min_width",
+    modelAPIKey: "model_api_key",
+    modelName: "model_name",
+    operatingSystems: "operating_systems",
+    outputTokens: "output_tokens",
+    pageText: "page_text",
+    pageUrl: "page_url",
+    preserveUserDataDir: "preserve_user_data_dir",
+    projectId: "project_id",
+    projectID: "project_id",
+    recordSession: "record_session",
+    rememberMe: "remember_me",
+    selfHeal: "self_heal",
+    sessionId: "session_id",
+    shouldCache: "should_cache",
+    solveCaptchas: "solve_captchas",
+    streamResponse: "stream_response",
+    systemPrompt: "system_prompt",
+    taskCompleted: "task_completed",
+    timeMs: "time_ms",
+    tokenUsage: "token_usage",
+    toolTimeout: "tool_timeout",
+    universeDomain: "universe_domain",
+    useSearch: "use_search",
+    userDataDir: "user_data_dir",
+    userMetadata: "user_metadata",
+    waitForCaptchaSolves: "wait_for_captcha_solves",
+    waitUntil: "wait_until",
+    xStreamResponse: "x_stream_response",
+  };
+
+  const SDK_PARAM_LABELS = {
+    python: SNAKE_CASE_PARAM_LABELS,
+    ruby: SNAKE_CASE_PARAM_LABELS,
+  };
+
+  const CONTENT_SCOPE_SELECTOR = [
+    "#content-area",
+    "#api-playground-input",
+    "api-section",
+    "field",
+  ].join(",");
+
+  const SKIP_SELECTOR = [
+    "code",
+    "input",
+    "pre",
+    "script",
+    "style",
+    "textarea",
+    '[contenteditable="true"]',
+  ].join(",");
+
+  let rewriteTimer = null;
+  let lastPath = window.location.pathname;
+
+  function currentSdkLanguage() {
+    const match = window.location.pathname.match(
+      /^\/v3\/api-reference\/([^/]+)(?:\/|$)/,
+    );
+    return match ? match[1] : null;
+  }
+
+  function escapeRegExp(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  }
+
+  function buildPattern(labels) {
+    return new RegExp(
+      `\\b(${Object.keys(labels).map(escapeRegExp).join("|")})\\b`,
+      "g",
+    );
+  }
+
+  function shouldRewriteTextNode(node, pattern) {
+    if (!node.nodeValue) return false;
+
+    const parent = node.parentElement;
+    if (!parent) return false;
+    if (parent.closest(SKIP_SELECTOR)) return false;
+    if (!parent.closest(CONTENT_SCOPE_SELECTOR)) return false;
+
+    pattern.lastIndex = 0;
+    return pattern.test(node.nodeValue);
+  }
+
+  function rewriteLabels(root) {
+    const labels = SDK_PARAM_LABELS[currentSdkLanguage()];
+    if (!labels) return;
+
+    const pattern = buildPattern(labels);
+    const walker = document.createTreeWalker(
+      root || document.body,
+      NodeFilter.SHOW_TEXT,
+      {
+        acceptNode(node) {
+          return shouldRewriteTextNode(node, pattern)
+            ? NodeFilter.FILTER_ACCEPT
+            : NodeFilter.FILTER_REJECT;
+        },
+      },
+    );
+
+    const nodes = [];
+    while (walker.nextNode()) nodes.push(walker.currentNode);
+
+    for (const node of nodes) {
+      pattern.lastIndex = 0;
+      node.nodeValue = node.nodeValue.replace(pattern, (name) => labels[name]);
+    }
+  }
+
+  function scheduleRewrite(root) {
+    if (rewriteTimer) window.clearTimeout(rewriteTimer);
+    rewriteTimer = window.setTimeout(() => {
+      rewriteTimer = null;
+      window.requestAnimationFrame(() => rewriteLabels(root || document.body));
+    }, 50);
+  }
+
+  scheduleRewrite();
+
+  const observer = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      for (const node of mutation.addedNodes) {
+        if (node.nodeType === Node.ELEMENT_NODE) {
+          scheduleRewrite(node);
+          return;
+        }
+      }
+    }
+  });
+
+  observer.observe(document.body, { childList: true, subtree: true });
+
+  window.setInterval(() => {
+    if (window.location.pathname !== lastPath) {
+      lastPath = window.location.pathname;
+      scheduleRewrite();
+    }
+  }, 250);
+})();


### PR DESCRIPTION
## Summary
- add a Mintlify custom script that rewrites generated SDK API reference schema labels from OpenAPI camelCase to SDK snake_case on Python and Ruby pages
- keep code/pre/input/script/style content untouched so generated code samples stay language-correct
- leave Java/Go/TypeScript routes unchanged for now

## Why
Mintlify renders these language-scoped API reference pages from the Stainless documented OpenAPI spec, so visible schema labels use wire-format camelCase even when the Python and Ruby SDK snippets use snake_case.

## Validation
- `pnpm --dir packages/docs exec prettier --check sdk-api-reference-labels.js`
- `node --check packages/docs/sdk-api-reference-labels.js`
- confirmed Mintlify embeds root-level docs JS by checking the existing custom script in local/prod HTML and the new script in local HTML
- browser fixture served at `/v3/api-reference/{python,ruby,java}/...`: Python/Ruby labels rewrote to snake_case, code blocks stayed camelCase, and Java remained unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mismatched parameter labels on Python and Ruby SDK API reference pages by rewriting OpenAPI camelCase labels to SDK snake_case. Code samples and inputs remain unchanged; other languages are unaffected.

- **Bug Fixes**
  - Added `packages/docs/sdk-api-reference-labels.js` to relabel visible schema fields for Python and Ruby only.
  - Skips `code`, `pre`, `input`, `script`, `style`, and editable elements to preserve language-correct snippets.
  - Reacts to SPA route changes and DOM mutations to keep labels consistent.
  - Leaves Java/Go/TypeScript pages unchanged.

<sup>Written for commit ea143a674cc1a8b55cf39351506e93ecf0d70016. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2164?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

