### PR TITLE
Respect shadow piercer debug option

### DIFF
--- a/packages/core/lib/v3/dom/piercer.runtime.ts
+++ b/packages/core/lib/v3/dom/piercer.runtime.ts
@@ -31,8 +31,7 @@ declare global {
 }
 
 export function installV3ShadowPiercer(opts: V3ShadowPatchOptions = {}): void {
-  // hardcoded debug (remove later if desired)
-  const DEBUG = true;
+  const DEBUG = opts.debug ?? false;
 
   type PatchedFn = Element["attachShadow"] & {
     __v3Patched?: boolean;

--- a/packages/core/tests/unit/shadow-piercer-debug.test.ts
+++ b/packages/core/tests/unit/shadow-piercer-debug.test.ts
@@ -1,0 +1,81 @@
+import { JSDOM } from "jsdom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { installV3ShadowPiercer } from "../../lib/v3/dom/piercer.runtime.js";
+
+const originalGlobals = {
+  window: globalThis.window,
+  document: globalThis.document,
+  Element: globalThis.Element,
+  NodeFilter: globalThis.NodeFilter,
+  location: globalThis.location,
+};
+
+function installDom() {
+  const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+    url: "https://example.com/",
+  });
+
+  vi.stubGlobal("window", dom.window);
+  vi.stubGlobal("document", dom.window.document);
+  vi.stubGlobal("Element", dom.window.Element);
+  vi.stubGlobal("NodeFilter", dom.window.NodeFilter);
+  vi.stubGlobal("location", dom.window.location);
+
+  return dom;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+
+  for (const [key, value] of Object.entries(originalGlobals)) {
+    if (value === undefined) {
+      Reflect.deleteProperty(globalThis, key);
+    } else {
+      Reflect.set(globalThis, key, value);
+    }
+  }
+});
+
+describe("installV3ShadowPiercer debug option", () => {
+  it("does not log by default", () => {
+    installDom();
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    installV3ShadowPiercer();
+    document.createElement("div").attachShadow({ mode: "closed" });
+
+    expect(info).not.toHaveBeenCalled();
+  });
+
+  it("logs install and attachShadow events when debug is true", () => {
+    installDom();
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    installV3ShadowPiercer({ debug: true });
+    document.createElement("div").attachShadow({ mode: "open" });
+
+    expect(info).toHaveBeenCalledWith(
+      "[v3-piercer] installed",
+      expect.objectContaining({ url: "https://example.com/" }),
+    );
+    expect(info).toHaveBeenCalledWith(
+      "[v3-piercer] attachShadow",
+      expect.objectContaining({ tag: "div", mode: "open" }),
+    );
+  });
+
+  it("updates debug state on repeated install calls", () => {
+    installDom();
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    installV3ShadowPiercer({ debug: true });
+    installV3ShadowPiercer({ debug: false });
+    info.mockClear();
+
+    document.createElement("div").attachShadow({ mode: "closed" });
+
+    expect(info).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- make `installV3ShadowPiercer()` use `opts.debug ?? false` instead of hardcoding debug logging on
- keep repeated install calls able to update the shared patched-state debug flag
- add unit coverage for default quiet mode, debug logging, and toggling debug off after re-entry

## Why
Fixes #1996. The public `V3ShadowPatchOptions.debug` option was effectively a no-op, so every `attachShadow` call emitted `[v3-piercer]` logs even when callers did not request debug output.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @browserbasehq/stagehand run test:core -- packages/core/dist/esm/tests/unit/shadow-piercer-debug.test.js`
  - Vitest: 3 tests passed
  - Note: the post-test CTRF conversion printed a Node 24 `glob`/`minimatch` export warning, but the command exited 0 and the focused Vitest test passed.
- `pnpm --filter @browserbasehq/stagehand run lint`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect the `V3ShadowPatchOptions.debug` flag in `installV3ShadowPiercer()`. Debug logs are now off by default and can be toggled via repeated installs.

- **Bug Fixes**
  - Use `opts.debug ?? false` instead of hardcoded debug on.
  - Allow re-install to update the shared debug state.
  - Add unit tests for default quiet mode, debug logging, and toggling debug off.

<sup>Written for commit 7fab78193146bf2548e79fc404e8b106dde139e0. Summary will update on new commits. <a href="https://cubic.dev/pr/browserbase/stagehand/pull/2166?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

