### PR TITLE
STG-1746 Add SEA --version flag

### DIFF
--- a/.changeset/true-pillows-prove.md
+++ b/.changeset/true-pillows-prove.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand-server-v3": patch
+---
+
+Add SEA binary --version build metadata output.

--- a/packages/server-v3/scripts/build-sea.ts
+++ b/packages/server-v3/scripts/build-sea.ts
@@ -12,7 +12,7 @@
  *      SEA_INCLUDE_SOURCEMAPS.
  * Example: pnpm run build:sea:cjs -- --target-platform=linux --target-arch=arm64
  */
-import { spawnSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
@@ -86,6 +86,17 @@ const includeSourcemaps = parseBoolean(
   argValue("include-sourcemaps") ?? process.env.SEA_INCLUDE_SOURCEMAPS,
   false,
 );
+
+const gitOutput = (args: string[]) =>
+  execFileSync("git", args, { cwd: repoDir, encoding: "utf8" }).trim();
+const buildCommit = gitOutput(["rev-parse", "HEAD"]);
+const seaVersion = [
+  `commit: ${buildCommit}`,
+  `timestamp: ${gitOutput(["show", "-s", "--format=%cI", buildCommit])}`,
+].join("\n");
+const seaBuildDefine = {
+  __STAGEHAND_SERVER_VERSION__: JSON.stringify(seaVersion),
+};
 
 const run = (cmd: string, args: string[], opts: { cwd?: string } = {}) => {
   const result = spawnSync(cmd, args, { stdio: "inherit", ...opts });
@@ -273,6 +284,7 @@ const buildCjsBundle = () => {
     platform: "node",
     format: "cjs",
     outfile: bundlePath,
+    define: seaBuildDefine,
     logLevel: "warning",
     absWorkingDir: repoDir,
   });
@@ -295,6 +307,7 @@ const buildEsmBundle = () => {
     format: "esm",
     treeShaking: false,
     outfile: appBundlePath,
+    define: seaBuildDefine,
     alias: {
       "@browserbasehq/stagehand": `${repoDir}/packages/core/dist/esm/index.js`,
     },
@@ -412,6 +425,15 @@ const { pathToFileURL } = require("node:url");
 const bundleBase64 = ${JSON.stringify(appBytes.toString("base64"))};
 const bundleLength = ${appBytes.length};
 const bundleHash = ${JSON.stringify(bundleHash)};
+const versionOutput = ${JSON.stringify(seaVersion)};
+
+const argv = process.argv.slice(1);
+const normalizedArgv = argv[0]?.startsWith("--") ? argv : argv.slice(1);
+
+if (normalizedArgv.includes("--version")) {
+  console.log(versionOutput);
+  process.exit(0);
+}
 
 const cacheRoot =
   process.env.STAGEHAND_SEA_CACHE_DIR ||

--- a/packages/server-v3/src/sea-entry.ts
+++ b/packages/server-v3/src/sea-entry.ts
@@ -1,15 +1,23 @@
-import { __internalMaybeRunShutdownSupervisorFromArgv } from "@browserbasehq/stagehand";
+declare const __STAGEHAND_SERVER_VERSION__: string;
 
-// if SEA binary is launched with --supervisor, it will run the shutdown supervisor only
 const argv = process.argv.slice(1);
 const normalizedArgv = argv[0]?.startsWith("--") ? argv : argv.slice(1);
 
-// otherwise, start the stagehand/server
-if (!__internalMaybeRunShutdownSupervisorFromArgv(normalizedArgv)) {
-  // Force flow logs on before the server module loads Stagehand core.
-  process.env.BROWSERBASE_FLOW_LOGS = "1";
-  void import("./server.js").catch((err) => {
+if (normalizedArgv.includes("--version")) {
+  console.log(__STAGEHAND_SERVER_VERSION__);
+  process.exit(0);
+}
+
+void import("@browserbasehq/stagehand")
+  .then(async ({ __internalMaybeRunShutdownSupervisorFromArgv }) => {
+    if (__internalMaybeRunShutdownSupervisorFromArgv(normalizedArgv)) {
+      return;
+    }
+
+    process.env.BROWSERBASE_FLOW_LOGS = "1";
+    await import("./server.js");
+  })
+  .catch((err) => {
     console.error("Failed to start server:", err);
     process.exit(1);
   });
-}


### PR DESCRIPTION
# why

The SEA binary needs a lightweight way to report the commit and timestamp it was built from.

# what changed

Added a `--version` path that prints build metadata baked into the SEA binary during build.
