### PR TITLE
feat: Add Claude Opus 4.8 CUA support

### DIFF
--- a/.changeset/opus-4-8-cua.md
+++ b/.changeset/opus-4-8-cua.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Add Claude Opus 4.8 to the supported CUA model whitelist.

--- a/packages/core/lib/v3/agent/AgentProvider.ts
+++ b/packages/core/lib/v3/agent/AgentProvider.ts
@@ -23,6 +23,7 @@ export const modelToAgentProviderMap: Record<string, AgentProviderType> = {
   "claude-sonnet-4-5-20250929": "anthropic",
   "claude-opus-4-5-20251101": "anthropic",
   "claude-opus-4-6": "anthropic",
+  "claude-opus-4-8": "anthropic",
   "claude-sonnet-4-6": "anthropic",
   "claude-haiku-4-5": "anthropic",
   "claude-haiku-4-5-20251001": "anthropic",

--- a/packages/core/lib/v3/agent/AnthropicCUAClient.ts
+++ b/packages/core/lib/v3/agent/AnthropicCUAClient.ts
@@ -453,6 +453,7 @@ export class AnthropicCUAClient extends AgentClient {
 
       // Check if this is a Claude 4.6+ model that supports adaptive thinking
       const isAdaptiveThinkingModel = [
+        "claude-opus-4-8",
         "claude-opus-4-6",
         "claude-sonnet-4-6",
       ].includes(modelBase);

--- a/packages/core/lib/v3/types/public/agent.ts
+++ b/packages/core/lib/v3/types/public/agent.ts
@@ -456,6 +456,7 @@ export const AVAILABLE_CUA_MODELS = [
   "openai/computer-use-preview-2025-03-11",
   "anthropic/claude-opus-4-5-20251101",
   "anthropic/claude-opus-4-6",
+  "anthropic/claude-opus-4-8",
   "anthropic/claude-sonnet-4-6",
   "anthropic/claude-haiku-4-5",
   "anthropic/claude-haiku-4-5-20251001",

--- a/packages/core/tests/unit/anthropic-cua-adaptive-thinking.test.ts
+++ b/packages/core/tests/unit/anthropic-cua-adaptive-thinking.test.ts
@@ -36,7 +36,30 @@ describe("AnthropicCUAClient adaptive thinking", () => {
     });
   });
 
-  describe("Claude 4.6 models (adaptive thinking)", () => {
+  describe("Claude 4.6+ models (adaptive thinking)", () => {
+    it("should use thinking.type: 'adaptive' for claude-opus-4-8 when thinkingEffort is set", async () => {
+      const client = new AnthropicCUAClient(
+        "anthropic",
+        "claude-opus-4-8",
+        undefined,
+        {
+          apiKey: "test-key",
+          thinkingEffort: "high",
+        },
+      );
+      client.setViewport(1280, 720);
+
+      await client.getAction([{ role: "user", content: "test" }]);
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          thinking: { type: "adaptive" },
+          output_config: { effort: "high" },
+          temperature: 1,
+        }),
+      );
+    });
+
     it("should use thinking.type: 'adaptive' for claude-opus-4-6 when thinkingEffort is set", async () => {
       const client = new AnthropicCUAClient(
         "anthropic",

--- a/packages/core/tests/unit/public-api/llm-and-agents.test.ts
+++ b/packages/core/tests/unit/public-api/llm-and-agents.test.ts
@@ -44,6 +44,7 @@ describe("LLM and Agents public API types", () => {
       "openai/gpt-5.5",
       "anthropic/claude-opus-4-5-20251101",
       "anthropic/claude-opus-4-6",
+      "anthropic/claude-opus-4-8",
       "anthropic/claude-sonnet-4-6",
       "anthropic/claude-haiku-4-5",
       "anthropic/claude-haiku-4-5-20251001",
@@ -60,6 +61,12 @@ describe("LLM and Agents public API types", () => {
         (typeof expectedModels)[number]
       >();
       void expectedModels; // Mark as used to satisfy ESLint
+    });
+
+    it("includes Claude Opus 4.8 at runtime", () => {
+      expect(Stagehand.AVAILABLE_CUA_MODELS).toContain(
+        "anthropic/claude-opus-4-8",
+      );
     });
   });
 
@@ -273,6 +280,12 @@ describe("LLM and Agents public API types", () => {
       expectTypeOf<
         typeof Stagehand.modelToAgentProviderMap
       >().toExtend<ExpectedModelToAgentProviderMap>();
+    });
+
+    it("routes Claude Opus 4.8 to Anthropic", () => {
+      expect(Stagehand.modelToAgentProviderMap["claude-opus-4-8"]).toBe(
+        "anthropic",
+      );
     });
   });
 

--- a/packages/docs/v3/configuration/models.mdx
+++ b/packages/docs/v3/configuration/models.mdx
@@ -669,6 +669,7 @@ const agent = stagehand.agent({
 | Anthropic | `anthropic/claude-sonnet-4-5-20250929` |
 | Anthropic | `anthropic/claude-opus-4-5-20251101` |
 | Anthropic | `anthropic/claude-opus-4-6` |
+| Anthropic | `anthropic/claude-opus-4-8` |
 | Google   | `google/gemini-2.5-computer-use-preview-10-2025` |
 | Google   | `google/gemini-3-flash-preview` |
 | Google   | `google/gemini-3-pro-preview` |

--- a/packages/docs/v3/references/agent.mdx
+++ b/packages/docs/v3/references/agent.mdx
@@ -72,6 +72,7 @@ interface AgentInstance {
   - `"anthropic/claude-sonnet-4-5-20250929"`
   - `"anthropic/claude-opus-4-5-20251101"`
   - `"anthropic/claude-opus-4-6"`
+  - `"anthropic/claude-opus-4-8"`
   - `"google/gemini-2.5-computer-use-preview-10-2025"`
   - `"google/gemini-3-flash-preview"`
   - `"google/gemini-3-pro-preview"`


### PR DESCRIPTION
## Summary
- Add `anthropic/claude-opus-4-8` to the CUA model whitelist.
- Route bare `claude-opus-4-8` model names to the Anthropic CUA client.
- Treat Claude Opus 4.8 as a Claude 4.6+ adaptive-thinking CUA model and document it in the supported CUA model lists.

## Validation
- `pnpm --filter @browserbasehq/stagehand run typecheck`
- `pnpm run test:core -- packages/core/dist/esm/tests/unit/public-api/llm-and-agents.test.js packages/core/dist/esm/tests/unit/anthropic-cua-adaptive-thinking.test.js`

Note: the focused test command passed 38 tests, then the test wrapper printed a non-fatal CTRF conversion warning from `glob/minimatch` under Node 22.