### PR TITLE
[feat]: add `clipboard` API

### DIFF
--- a/.changeset/witty-ears-dream.md
+++ b/.changeset/witty-ears-dream.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": minor
+---
+
+add native clipboard API

--- a/packages/core/examples/clipboard.ts
+++ b/packages/core/examples/clipboard.ts
@@ -1,0 +1,33 @@
+import { Stagehand } from "../lib/v3/index.js";
+
+async function example(stagehand: Stagehand) {
+  const page = stagehand.context.pages()[0];
+  await page.goto("https://example.com");
+
+  await new Promise((resolve) => setTimeout(resolve, 3000));
+  await page.sendCDP("Runtime.evaluate", {
+    expression: `
+      document.body.innerHTML = "<textarea autofocus style='width:400px;height:120px'></textarea>";
+      document.querySelector("textarea").focus();
+    `,
+  });
+
+  await stagehand.context.clipboard.writeText("Hello from Stagehand");
+  await stagehand.context.clipboard.paste();
+
+  await page.keyPress("ControlOrMeta+A");
+  const copied = await stagehand.context.clipboard.copySelection();
+  console.log(copied);
+
+  await stagehand.context.clipboard.clear();
+}
+
+(async () => {
+  const stagehand = new Stagehand({
+    env: "BROWSERBASE",
+    model: "openai/gpt-5",
+    verbose: 2,
+  });
+  await stagehand.init();
+  await example(stagehand);
+})();

--- a/packages/core/examples/clipboard.ts
+++ b/packages/core/examples/clipboard.ts
@@ -16,7 +16,8 @@ async function example(stagehand: Stagehand) {
   await stagehand.context.clipboard.paste();
 
   await page.keyPress("ControlOrMeta+A");
-  const copied = await stagehand.context.clipboard.copySelection();
+  await stagehand.context.clipboard.copy();
+  const copied = await stagehand.context.clipboard.readText();
   console.log(copied);
 
   await stagehand.context.clipboard.clear();

--- a/packages/core/examples/clipboard.ts
+++ b/packages/core/examples/clipboard.ts
@@ -28,6 +28,10 @@ async function example(stagehand: Stagehand) {
     model: "openai/gpt-5",
     verbose: 2,
   });
-  await stagehand.init();
-  await example(stagehand);
+  try {
+    await stagehand.init();
+    await example(stagehand);
+  } finally {
+    await stagehand.close();
+  }
 })();

--- a/packages/core/examples/clipboard.ts
+++ b/packages/core/examples/clipboard.ts
@@ -5,11 +5,10 @@ async function example(stagehand: Stagehand) {
   await page.goto("https://example.com");
 
   await new Promise((resolve) => setTimeout(resolve, 3000));
-  await page.sendCDP("Runtime.evaluate", {
-    expression: `
-      document.body.innerHTML = "<textarea autofocus style='width:400px;height:120px'></textarea>";
-      document.querySelector("textarea").focus();
-    `,
+  await page.evaluate(() => {
+    document.body.innerHTML =
+      "<textarea autofocus style='width:400px;height:120px'></textarea>";
+    document.querySelector("textarea")?.focus();
   });
 
   await stagehand.context.clipboard.writeText("Hello from Stagehand");

--- a/packages/core/lib/v3/types/public/clipboard.ts
+++ b/packages/core/lib/v3/types/public/clipboard.ts
@@ -1,0 +1,19 @@
+import type { Page } from "../../understudy/page.js";
+
+export interface ClipboardOptions {
+  page?: Page;
+  timeout?: number;
+}
+
+export interface ClipboardPasteOptions extends ClipboardOptions {
+  shortcut?: "ControlOrMeta+V" | "Meta+V" | "Control+V";
+}
+
+export interface BrowserClipboard {
+  readText(options?: ClipboardOptions): Promise<string>;
+  writeText(text: string, options?: ClipboardOptions): Promise<void>;
+  clear(options?: ClipboardOptions): Promise<void>;
+  paste(options?: ClipboardPasteOptions): Promise<void>;
+  copySelection(options?: ClipboardOptions): Promise<string>;
+  cutSelection(options?: ClipboardOptions): Promise<string>;
+}

--- a/packages/core/lib/v3/types/public/clipboard.ts
+++ b/packages/core/lib/v3/types/public/clipboard.ts
@@ -14,6 +14,6 @@ export interface BrowserClipboard {
   writeText(text: string, options?: ClipboardOptions): Promise<void>;
   clear(options?: ClipboardOptions): Promise<void>;
   paste(options?: ClipboardPasteOptions): Promise<void>;
-  copySelection(options?: ClipboardOptions): Promise<string>;
-  cutSelection(options?: ClipboardOptions): Promise<string>;
+  copy(options?: ClipboardOptions): Promise<void>;
+  cut(options?: ClipboardOptions): Promise<void>;
 }

--- a/packages/core/lib/v3/types/public/index.ts
+++ b/packages/core/lib/v3/types/public/index.ts
@@ -5,6 +5,7 @@ export * as Api from "./api.js";
 // Also export BrowserbaseRegion directly for convenience
 export type { BrowserbaseRegion } from "./api.js";
 export * from "./apiErrors.js";
+export * from "./clipboard.js";
 export * from "./logs.js";
 export * from "./methods.js";
 export * from "./metrics.js";

--- a/packages/core/lib/v3/understudy/clipboard.ts
+++ b/packages/core/lib/v3/understudy/clipboard.ts
@@ -62,18 +62,16 @@ export class ContextClipboard implements BrowserClipboard {
     await page.keyPress(options?.shortcut ?? "ControlOrMeta+V");
   }
 
-  async copySelection(options?: ClipboardOptions): Promise<string> {
+  async copy(options?: ClipboardOptions): Promise<void> {
     const page = await this.resolvePage(options?.page);
     await this.ensurePageFocused(page);
     await page.keyPress("ControlOrMeta+C");
-    return await this.readText({ ...options, page });
   }
 
-  async cutSelection(options?: ClipboardOptions): Promise<string> {
+  async cut(options?: ClipboardOptions): Promise<void> {
     const page = await this.resolvePage(options?.page);
     await this.ensurePageFocused(page);
     await page.keyPress("ControlOrMeta+X");
-    return await this.readText({ ...options, page });
   }
 
   private async resolvePage(page?: Page): Promise<Page> {

--- a/packages/core/lib/v3/understudy/clipboard.ts
+++ b/packages/core/lib/v3/understudy/clipboard.ts
@@ -7,6 +7,7 @@ import type {
   ClipboardPasteOptions,
 } from "../types/public/clipboard.js";
 import { StagehandEvalError } from "../types/public/sdkErrors.js";
+import { FlowLogger } from "../flowlogger/FlowLogger.js";
 
 type ContextClipboardParams = {
   context: V3Context;
@@ -16,6 +17,7 @@ type ContextClipboardParams = {
 export class ContextClipboard implements BrowserClipboard {
   constructor(private readonly params: ContextClipboardParams) {}
 
+  @FlowLogger.wrapWithLogging({ eventType: "ClipboardWriteText" })
   async writeText(text: string, options?: ClipboardOptions): Promise<void> {
     const page = await this.resolvePage(options?.page);
     await this.ensurePageFocused(page);
@@ -33,6 +35,7 @@ export class ContextClipboard implements BrowserClipboard {
     this.throwIfEvaluationFailed("write clipboard text", response);
   }
 
+  @FlowLogger.wrapWithLogging({ eventType: "ClipboardReadText" })
   async readText(options?: ClipboardOptions): Promise<string> {
     const page = await this.resolvePage(options?.page);
     await this.ensurePageFocused(page);
@@ -52,22 +55,26 @@ export class ContextClipboard implements BrowserClipboard {
     return String(response.result?.value ?? "");
   }
 
+  @FlowLogger.wrapWithLogging({ eventType: "ClipboardClear" })
   async clear(options?: ClipboardOptions): Promise<void> {
     await this.writeText("", options);
   }
 
+  @FlowLogger.wrapWithLogging({ eventType: "ClipboardPaste" })
   async paste(options?: ClipboardPasteOptions): Promise<void> {
     const page = await this.resolvePage(options?.page);
     await this.ensurePageFocused(page);
     await page.keyPress(options?.shortcut ?? "ControlOrMeta+V");
   }
 
+  @FlowLogger.wrapWithLogging({ eventType: "ClipboardCopy" })
   async copy(options?: ClipboardOptions): Promise<void> {
     const page = await this.resolvePage(options?.page);
     await this.ensurePageFocused(page);
     await page.keyPress("ControlOrMeta+C");
   }
 
+  @FlowLogger.wrapWithLogging({ eventType: "ClipboardCut" })
   async cut(options?: ClipboardOptions): Promise<void> {
     const page = await this.resolvePage(options?.page);
     await this.ensurePageFocused(page);

--- a/packages/core/lib/v3/understudy/clipboard.ts
+++ b/packages/core/lib/v3/understudy/clipboard.ts
@@ -1,0 +1,132 @@
+import type { Protocol } from "devtools-protocol";
+import type { V3Context } from "./context.js";
+import type { Page } from "./page.js";
+import type {
+  BrowserClipboard,
+  ClipboardOptions,
+  ClipboardPasteOptions,
+} from "../types/public/clipboard.js";
+import { StagehandEvalError } from "../types/public/sdkErrors.js";
+
+type ContextClipboardParams = {
+  context: V3Context;
+  resolvePage: (page?: Page) => Promise<Page>;
+};
+
+export class ContextClipboard implements BrowserClipboard {
+  constructor(private readonly params: ContextClipboardParams) {}
+
+  async writeText(text: string, options?: ClipboardOptions): Promise<void> {
+    const page = await this.resolvePage(options?.page);
+    await this.ensurePageFocused(page);
+    await this.grantClipboardPermissions(page);
+    await page.sendCDP("Runtime.enable").catch(() => {});
+    const response = await page.sendCDP<Protocol.Runtime.EvaluateResponse>(
+      "Runtime.evaluate",
+      {
+        expression: `navigator.clipboard.writeText(${JSON.stringify(text)})`,
+        awaitPromise: true,
+        returnByValue: true,
+        userGesture: true,
+      },
+    );
+    this.throwIfEvaluationFailed("write clipboard text", response);
+  }
+
+  async readText(options?: ClipboardOptions): Promise<string> {
+    const page = await this.resolvePage(options?.page);
+    await this.ensurePageFocused(page);
+    await this.grantClipboardPermissions(page);
+    await page.sendCDP("Runtime.enable").catch(() => {});
+    const response = await page.sendCDP<Protocol.Runtime.EvaluateResponse>(
+      "Runtime.evaluate",
+      {
+        expression: "navigator.clipboard.readText()",
+        awaitPromise: true,
+        returnByValue: true,
+        userGesture: true,
+      },
+    );
+    this.throwIfEvaluationFailed("read clipboard text", response);
+
+    return String(response.result?.value ?? "");
+  }
+
+  async clear(options?: ClipboardOptions): Promise<void> {
+    await this.writeText("", options);
+  }
+
+  async paste(options?: ClipboardPasteOptions): Promise<void> {
+    const page = await this.resolvePage(options?.page);
+    await this.ensurePageFocused(page);
+    await page.keyPress(options?.shortcut ?? "ControlOrMeta+V");
+  }
+
+  async copySelection(options?: ClipboardOptions): Promise<string> {
+    const page = await this.resolvePage(options?.page);
+    await this.ensurePageFocused(page);
+    await page.keyPress("ControlOrMeta+C");
+    return await this.readText({ ...options, page });
+  }
+
+  async cutSelection(options?: ClipboardOptions): Promise<string> {
+    const page = await this.resolvePage(options?.page);
+    await this.ensurePageFocused(page);
+    await page.keyPress("ControlOrMeta+X");
+    return await this.readText({ ...options, page });
+  }
+
+  private async resolvePage(page?: Page): Promise<Page> {
+    return await this.params.resolvePage(page);
+  }
+
+  private async grantClipboardPermissions(page: Page): Promise<void> {
+    const origin = this.originForPage(page);
+    if (!origin) return;
+
+    await this.params.context.conn
+      .send("Browser.grantPermissions", {
+        origin,
+        permissions: ["clipboardReadWrite", "clipboardSanitizedWrite"],
+      })
+      .catch(() => {});
+  }
+
+  private async ensurePageFocused(page: Page): Promise<void> {
+    this.params.context.setActivePage(page);
+    await page.sendCDP("Page.bringToFront").catch(() => {});
+    await page.sendCDP("Runtime.enable").catch(() => {});
+    await page
+      .sendCDP("Runtime.evaluate", {
+        expression: "window.focus()",
+        awaitPromise: true,
+        userGesture: true,
+      })
+      .catch(() => {});
+  }
+
+  private originForPage(page: Page): string | undefined {
+    try {
+      const parsed = new URL(page.url());
+      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+        return undefined;
+      }
+      return parsed.origin;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private throwIfEvaluationFailed(
+    operation: string,
+    response: Protocol.Runtime.EvaluateResponse,
+  ): void {
+    if (!response.exceptionDetails) return;
+
+    const message =
+      response.exceptionDetails.exception?.description ??
+      response.exceptionDetails.text ??
+      "Runtime.evaluate failed";
+    throw new StagehandEvalError(`Failed to ${operation}: ${message}`);
+  }
+}

--- a/packages/core/lib/v3/understudy/clipboard.ts
+++ b/packages/core/lib/v3/understudy/clipboard.ts
@@ -19,6 +19,13 @@ export class ContextClipboard implements BrowserClipboard {
 
   @FlowLogger.wrapWithLogging({ eventType: "ClipboardWriteText" })
   async writeText(text: string, options?: ClipboardOptions): Promise<void> {
+    await this.writeTextInternal(text, options);
+  }
+
+  private async writeTextInternal(
+    text: string,
+    options?: ClipboardOptions,
+  ): Promise<void> {
     const page = await this.resolvePage(options?.page);
     await this.ensurePageFocused(page);
     await this.grantClipboardPermissions(page);
@@ -57,7 +64,7 @@ export class ContextClipboard implements BrowserClipboard {
 
   @FlowLogger.wrapWithLogging({ eventType: "ClipboardClear" })
   async clear(options?: ClipboardOptions): Promise<void> {
-    await this.writeText("", options);
+    await this.writeTextInternal("", options);
   }
 
   @FlowLogger.wrapWithLogging({ eventType: "ClipboardPaste" })

--- a/packages/core/lib/v3/understudy/context.ts
+++ b/packages/core/lib/v3/understudy/context.ts
@@ -8,8 +8,10 @@ import { v3ScriptContent } from "../dom/build/scriptV3Content.js";
 import { executionContexts } from "./executionContextRegistry.js";
 import type { StagehandAPIClient } from "../api.js";
 import { LocalBrowserLaunchOptions } from "../types/public/index.js";
+import type { BrowserClipboard } from "../types/public/clipboard.js";
 import { InitScriptSource } from "../types/private/index.js";
 import { normalizeInitScriptSource } from "./initScripts.js";
+import { ContextClipboard } from "./clipboard.js";
 import {
   TimeoutError,
   CookieSetError,
@@ -124,6 +126,7 @@ export class V3Context {
   private pendingCreatedTargetUrl = new Map<TargetId, string>();
   private readonly initScripts: string[] = [];
   private extraHttpHeaders: Record<string, string> | null = null;
+  private _clipboard?: ContextClipboard;
 
   private installTargetSessionListeners(session: CDPSessionLike): void {
     const sessionId = session.id;
@@ -420,6 +423,18 @@ export class V3Context {
     if (failures.length) {
       throw new StagehandSetExtraHTTPHeadersError(failures);
     }
+  }
+
+  public get clipboard(): BrowserClipboard {
+    return (this._clipboard ??= new ContextClipboard({
+      context: this,
+      resolvePage: async (page) => {
+        if (page) return page;
+        const active = this.activePage();
+        if (!active) throw new PageNotFoundError("active page");
+        return active;
+      },
+    }));
   }
 
   /**

--- a/packages/core/tests/integration/clipboard.spec.ts
+++ b/packages/core/tests/integration/clipboard.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect } from "@playwright/test";
+import { V3 } from "../../lib/v3/v3.js";
+import type { Page } from "../../lib/v3/types/public/page.js";
+import { v3DynamicTestConfig } from "./v3.dynamic.config.js";
+import { closeV3 } from "./testUtils.js";
+
+const TEST_URL =
+  "https://browserbase.github.io/stagehand-eval-sites/sites/example/";
+
+async function setupTextarea(
+  page: Page,
+  options: { id: string; value?: string },
+): Promise<void> {
+  await page.goto(TEST_URL, {
+    waitUntil: "domcontentloaded",
+    timeoutMs: 15000,
+  });
+  await page.evaluate(({ id, value }) => {
+    document.body.innerHTML = `<textarea id="${id}" style="width:400px;height:120px"></textarea>`;
+    const el = document.getElementById(id) as HTMLTextAreaElement;
+    el.value = value ?? "";
+    el.focus();
+  }, options);
+}
+
+async function textareaValue(page: Page, id: string): Promise<string> {
+  return await page.evaluate(
+    (selector) =>
+      (document.querySelector(selector) as HTMLTextAreaElement).value,
+    `#${id}`,
+  );
+}
+
+async function selectTextareaContents(page: Page, id: string): Promise<void> {
+  await page.evaluate((selector) => {
+    const el = document.querySelector(selector) as HTMLTextAreaElement;
+    el.focus();
+    el.setSelectionRange(0, el.value.length);
+  }, `#${id}`);
+}
+
+test.describe("context.clipboard", () => {
+  let v3: V3;
+
+  test.beforeEach(async () => {
+    v3 = new V3(v3DynamicTestConfig);
+    await v3.init();
+  });
+
+  test.afterEach(async () => {
+    await closeV3(v3);
+  });
+
+  test("writeText() then readText()", async () => {
+    const page = await v3.context.awaitActivePage();
+    await setupTextarea(page, { id: "target" });
+
+    await v3.context.clipboard.writeText("hello");
+
+    await expect(v3.context.clipboard.readText()).resolves.toBe("hello");
+  });
+
+  test("paste() inserts clipboard text into the focused textarea", async () => {
+    const page = await v3.context.awaitActivePage();
+    await setupTextarea(page, { id: "target" });
+
+    await v3.context.clipboard.writeText("hello");
+    await v3.context.clipboard.paste();
+
+    await expect(textareaValue(page, "target")).resolves.toBe("hello");
+  });
+
+  test("copy() copies selected textarea text", async () => {
+    const page = await v3.context.awaitActivePage();
+    await setupTextarea(page, { id: "target", value: "copy me" });
+    await selectTextareaContents(page, "target");
+
+    await v3.context.clipboard.copy();
+
+    await expect(v3.context.clipboard.readText()).resolves.toBe("copy me");
+  });
+
+  test("cut() cuts selected textarea text and updates clipboard", async () => {
+    const page = await v3.context.awaitActivePage();
+    await setupTextarea(page, { id: "target", value: "cut me" });
+    await selectTextareaContents(page, "target");
+
+    await v3.context.clipboard.cut();
+
+    await expect(v3.context.clipboard.readText()).resolves.toBe("cut me");
+    await expect(textareaValue(page, "target")).resolves.toBe("");
+  });
+
+  test("defaults actions to the active page", async () => {
+    const page1 = await v3.context.awaitActivePage();
+    await setupTextarea(page1, { id: "first" });
+
+    const page2 = await v3.context.newPage();
+    await setupTextarea(page2, { id: "second" });
+    v3.context.setActivePage(page2);
+
+    await v3.context.clipboard.writeText("active page text");
+    await v3.context.clipboard.paste();
+
+    await expect(textareaValue(page1, "first")).resolves.toBe("");
+    await expect(textareaValue(page2, "second")).resolves.toBe(
+      "active page text",
+    );
+  });
+
+  test("accepts an explicit page option for page-targeted actions", async () => {
+    const page1 = await v3.context.awaitActivePage();
+    await setupTextarea(page1, { id: "first" });
+
+    const page2 = await v3.context.newPage();
+    await setupTextarea(page2, { id: "second" });
+
+    await v3.context.clipboard.writeText("explicit page text", {
+      page: page1,
+    });
+    v3.context.setActivePage(page2);
+    await v3.context.clipboard.paste({ page: page1 });
+
+    await expect(textareaValue(page1, "first")).resolves.toBe(
+      "explicit page text",
+    );
+    await expect(textareaValue(page2, "second")).resolves.toBe("");
+  });
+});


### PR DESCRIPTION
# why

- to give users a first class primitive for basic clipboard functionality: cut, copy, paste, read, write, & clear

# what changed

- added `context.clipboard` which has the following methods:
  - `readText`, `writeText`, `clear`, `paste`, `copy`, & `cut`
- clipboard read/write runs in the active page context, with browser permissions granted for the page origin
- paste/copy/cut focus the target page before dispatching keyboard shortcuts
- clipboard methods use `context.activePage()` by default, but callers can pass `{ page }` to target a specific `Page`
- added an integration spec for text clipboard behavior across active & explicit pages

# test plan

- added `clipboard.spec.ts` to cover `readText`, `writeText`, `paste`, `copy`, & `cut`
- the spec asserts the exact clipboard & textarea values for pasted, copied, cut, & read text
- also verifies clipboard actions use the active page by default
- also verifies passing `{ page }` targets that specific `Page`, even when another page is active

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a native clipboard API to the context for read/write and cut/copy/paste. Defaults to the active page, handles permissions, focuses the target page, and logs actions via FlowLogger without duplicates.

- New Features
  - New `context.clipboard` with `readText`, `writeText`, `clear`, `paste`, `copy`, and `cut`.
  - Grants origin clipboard permissions and brings the page to front before sending shortcuts; emits FlowLogger events for each action.
  - Uses `context.activePage()` by default; pass `{ page }` to target a specific `Page`. `paste` supports a `shortcut` override.
  - Exports public types (`BrowserClipboard`, options), and includes an example and integration tests verifying active vs explicit page behavior.

- Bug Fixes
  - Prevents duplicate FlowLogger events for clipboard actions.

<sup>Written for commit d7103c28ac1ebe8340fe05793ce7fc3a29cb69b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2171?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

