### PR TITLE
[docs]: sync .env.example with providerEnvVarMap and Browserbase essentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,37 @@
+# Stagehand environment variables.
+# Provider API keys are resolved via `providerEnvVarMap` in
+# `packages/core/lib/utils.ts` — that file is the source of truth.
+# Set only the keys you actually need; leave the rest unset.
+
+# --- LLM provider API keys ---
 OPENAI_API_KEY=""
-CEREBRAS_API_KEY=""
-GROQ_API_KEY=""
-BROWSERBASE_API_KEY=""
-BRAINTRUST_API_KEY=""
 ANTHROPIC_API_KEY=""
+# Google: any of these three is accepted (checked in order).
+GEMINI_API_KEY=""
+GOOGLE_GENERATIVE_AI_API_KEY=""
+GOOGLE_API_KEY=""
+GOOGLE_VERTEX_AI_API_KEY=""
+GROQ_API_KEY=""
+CEREBRAS_API_KEY=""
+TOGETHER_AI_API_KEY=""
+MISTRAL_API_KEY=""
+DEEPSEEK_API_KEY=""
+PERPLEXITY_API_KEY=""
+AZURE_API_KEY=""
+XAI_API_KEY=""
+
+# --- Browserbase cloud (required when env: "BROWSERBASE") ---
+BROWSERBASE_API_KEY=""
+# Required for cloud sessions. `BB_API_KEY` and `BB_PROJECT_ID` are
+# accepted as aliases for the two values above.
+BROWSERBASE_PROJECT_ID=""
+
+# --- Runtime ---
 HEADLESS=false
 ENABLE_CACHING=false
+
+# --- Eval harness ---
+BRAINTRUST_API_KEY=""
 EVAL_MODELS="gpt-4o,claude-sonnet-4-6"
 EXPERIMENTAL_EVAL_MODELS="gpt-4o,claude-sonnet-4-6,o1-mini,o1-preview"
 EVAL_CATEGORIES="observe,act,combination,extract,experimental"


### PR DESCRIPTION
## why

`.env.example` lists 7 keys today, but the SDK actually reads 14 provider keys via `providerEnvVarMap` in `packages/core/lib/utils.ts`. New contributors hitting "no API key for provider 'mistral'" have no breadcrumb that `MISTRAL_API_KEY` is the expected name (same for Vertex, TogetherAI, DeepSeek, Perplexity, Azure, XAI, and Google's three accepted aliases).

`BROWSERBASE_PROJECT_ID` is also missing — it's required whenever `env: "BROWSERBASE"` is set, and is referenced in `packages/evals/initV3.ts` and the `doctor` command but never surfaced in the root example.

## what changed

- Added every provider key defined in `providerEnvVarMap` (Vertex, TogetherAI, Mistral, DeepSeek, Perplexity, Azure, XAI, plus Google's three accepted aliases: `GEMINI_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`, `GOOGLE_API_KEY`).
- Added `BROWSERBASE_PROJECT_ID` with a short comment noting `BB_API_KEY` / `BB_PROJECT_ID` are accepted aliases (verified in `packages/evals/core/targets/browserbase.ts` and `packages/evals/tui/welcomeStatus.ts`).
- Grouped existing + new entries under four short headers (LLM provider keys / Browserbase cloud / Runtime / Eval harness) so the file scans.
- Added a one-line header pointing at `packages/core/lib/utils.ts` as the canonical map — so the example survives future provider additions even if it drifts.

## test plan

- [x] No code paths touched; doc-only change.
- [x] Every added key cross-referenced against `providerEnvVarMap` (`packages/core/lib/utils.ts:680`) or a direct `process.env.X` read in the core/evals packages.
- [x] No existing keys' values changed (`EVAL_MODELS`, `EXPERIMENTAL_EVAL_MODELS`, etc. preserved verbatim).

Happy to drop or split anything that feels out of scope.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs `.env.example` with the SDK’s `providerEnvVarMap`, adding missing provider keys (Vertex, TogetherAI, Mistral, DeepSeek, Perplexity, Azure, XAI, and Google aliases `GEMINI_API_KEY`/`GOOGLE_GENERATIVE_AI_API_KEY`/`GOOGLE_API_KEY`) and `BROWSERBASE_PROJECT_ID` for cloud sessions. Groups env vars under short headers, notes `BB_API_KEY`/`BB_PROJECT_ID` aliases, and points to `packages/core/lib/utils.ts` as the source of truth.

<sup>Written for commit bde63f15500bf5877717076837a58f8d169d59bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

