### PR TITLE
[docs]: fix typo in AI Gateway Anthropic model name

### DIFF
--- a/packages/docs/v3/configuration/models.mdx
+++ b/packages/docs/v3/configuration/models.mdx
@@ -785,7 +785,7 @@ Works with any model available on the gateway:
 
 ```typescript
 // Anthropic via gateway
-model: "gateway/anthropic/claude-sonnet-4.5"
+model: "gateway/anthropic/claude-sonnet-4-5-20250929"
 
 // Google via gateway
 model: "gateway/google/gemini-3-flash-preview"


### PR DESCRIPTION
## why

`packages/docs/v3/configuration/models.mdx:788` uses `gateway/anthropic/claude-sonnet-4.5` with dotted version notation. Every other Anthropic model reference in the docs (and in the rest of this same file) uses Anthropic's canonical hyphenated form (`claude-sonnet-4-6`, `claude-sonnet-4-5-20250929`, etc.). A reader who copies this line as-is will hit a model-not-found from the upstream provider.

## what changed

One-line fix: `claude-sonnet-4.5` → `claude-sonnet-4-5-20250929`. Picked the dated snapshot used elsewhere for the Sonnet 4.5 family rather than swapping to a different model, to preserve the author's intent.

## test plan

- [x] grep across `packages/docs/**/*.mdx` confirms this was the only dotted-notation Anthropic model name; all other Claude references use hyphenated form.
- [x] No code paths touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed an incorrect Anthropic model name in the gateway docs to use the canonical hyphenated, dated snapshot and avoid model-not-found errors. Updated `gateway/anthropic/claude-sonnet-4.5` to `gateway/anthropic/claude-sonnet-4-5-20250929`.

<sup>Written for commit ed430f893179651465e5c54e4e4dad358d0e2d0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

