### PR TITLE
[fix]: rm timeout from `clipboard` APIs

### DIFF
--- a/packages/core/lib/v3/types/public/clipboard.ts
+++ b/packages/core/lib/v3/types/public/clipboard.ts
@@ -2,7 +2,6 @@ import type { Page } from "../../understudy/page.js";
 
 export interface ClipboardOptions {
   page?: Page;
-  timeout?: number;
 }
 
 export interface ClipboardPasteOptions extends ClipboardOptions {

--- a/packages/core/tests/unit/public-api/public-types.test.ts
+++ b/packages/core/tests/unit/public-api/public-types.test.ts
@@ -104,6 +104,10 @@ type ExpectedExportedTypes = {
   Cookie: Stagehand.Cookie;
   CookieParam: Stagehand.CookieParam;
   ClearCookieOptions: Stagehand.ClearCookieOptions;
+  // Types from clipboard.ts
+  ClipboardOptions: Stagehand.ClipboardOptions;
+  ClipboardPasteOptions: Stagehand.ClipboardPasteOptions;
+  BrowserClipboard: Stagehand.BrowserClipboard;
 };
 
 describe("Stagehand public API types", () => {
@@ -198,6 +202,45 @@ describe("Stagehand public API types", () => {
 
     it("matches expected type shape", () => {
       expectTypeOf<Stagehand.Action>().toEqualTypeOf<ExpectedAction>();
+    });
+  });
+
+  describe("ClipboardOptions", () => {
+    type ExpectedClipboardOptions = {
+      page?: Stagehand.Page;
+    };
+
+    it("matches expected type shape", () => {
+      expectTypeOf<Stagehand.ClipboardOptions>().toEqualTypeOf<ExpectedClipboardOptions>();
+    });
+  });
+
+  describe("ClipboardPasteOptions", () => {
+    type ExpectedClipboardPasteOptions = {
+      page?: Stagehand.Page;
+      shortcut?: "ControlOrMeta+V" | "Meta+V" | "Control+V";
+    };
+
+    it("matches expected type shape", () => {
+      expectTypeOf<Stagehand.ClipboardPasteOptions>().toEqualTypeOf<ExpectedClipboardPasteOptions>();
+    });
+  });
+
+  describe("BrowserClipboard", () => {
+    type ExpectedBrowserClipboard = {
+      readText(options?: Stagehand.ClipboardOptions): Promise<string>;
+      writeText(
+        text: string,
+        options?: Stagehand.ClipboardOptions,
+      ): Promise<void>;
+      clear(options?: Stagehand.ClipboardOptions): Promise<void>;
+      paste(options?: Stagehand.ClipboardPasteOptions): Promise<void>;
+      copy(options?: Stagehand.ClipboardOptions): Promise<void>;
+      cut(options?: Stagehand.ClipboardOptions): Promise<void>;
+    };
+
+    it("matches expected type shape", () => {
+      expectTypeOf<Stagehand.BrowserClipboard>().toEqualTypeOf<ExpectedBrowserClipboard>();
     });
   });
 


### PR DESCRIPTION
# why
- the `timeout` param was mistakenly left in various `clipboard` APIs
- this param had no affect. this PR removes the param before it goes into an official release.
# what changed
- removed the `timeout` param from `clipboard` APIs
# test plan
- updated public export tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the no-op timeout field from the public clipboard API types to keep the API clean before release. Updated public type tests to validate ClipboardOptions, ClipboardPasteOptions, and BrowserClipboard shapes.

<sup>Written for commit fdf1304ce337fe411db9dc0879c9cefebb8cfb27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

