### PR TITLE
[docs]: update `extract` docs w/ new `screenshot` param

### DIFF
--- a/packages/docs/v3/basics/extract.mdx
+++ b/packages/docs/v3/basics/extract.mdx
@@ -153,7 +153,7 @@ This returns the accessibility tree representation of the page without LLM proce
 
 ## Advanced Configuration
 
-You can pass additional options to configure the model, timeout, and selector scope:
+You can pass additional options to configure the model, timeout, selector scope, and whether to include a screenshot:
 ```typescript
 const result = await stagehand.extract("extract the repository name", {
   model: "anthropic/claude-sonnet-4-5",
@@ -221,6 +221,26 @@ const article = await stagehand.extract(
 
 <Note>
   `ignoreSelectors` removes all matches for each selector, along with each matched node's descendants. `selector` still scopes extraction to a single resolved subtree.
+</Note>
+
+### Visual Extract
+
+Set `screenshot: true` when the extraction needs visual information from the current viewport in addition to the page accessibility tree.
+
+```typescript
+const saleBadge = await stagehand.extract(
+  "extract the text shown in the visible sale badge",
+  z.object({
+    text: z.string()
+  }),
+  {
+    screenshot: true
+  }
+);
+```
+
+<Note>
+  `screenshot: true` captures the current viewport, not the full page. It is only supported with AI SDK clients.
 </Note>
 
 

--- a/packages/docs/v3/references/extract.mdx
+++ b/packages/docs/v3/references/extract.mdx
@@ -44,6 +44,7 @@ interface ExtractOptions {
   timeout?: number;
   selector?: string;
   ignoreSelectors?: string[];
+  screenshot?: boolean;
   page?: PlaywrightPage | PuppeteerPage | PatchrightPage | Page;
   serverCache?: boolean;
 }
@@ -104,6 +105,14 @@ type ModelConfiguration =
 
   <Note>
     `ignoreSelectors` applies to all matches for each selector. `selector` keeps its single-target scoping behavior.
+  </Note>
+</ParamField>
+
+<ParamField path="screenshot" type="boolean" optional>
+  When `true`, includes a PNG screenshot of the current viewport in the extraction LLM call along with the page accessibility tree. Defaults to `false`.
+
+  <Note>
+    `screenshot: true` captures the current viewport, not the full page. It is only supported with AI SDK clients.
   </Note>
 </ParamField>
 
@@ -290,6 +299,30 @@ const data = await stagehand.extract(
   "name": "Product Name",
   "price": 100,
   "description": "Product description"
+}
+```
+
+</Tab>
+<Tab title="Screenshot">
+
+```typescript
+import { z } from 'zod';
+
+const BadgeSchema = z.object({
+  text: z.string()
+});
+
+const badge = await stagehand.extract(
+  "extract the text shown in the visible sale badge",
+  BadgeSchema,
+  { screenshot: true }
+);
+```
+
+#### Example Response
+```json
+{
+  "text": "25% off"
 }
 ```
 


### PR DESCRIPTION
# why
- `extract` got a new optional `screenshot: boolean` param
- this adds the docs for it
# what changed

<img width="813" height="544" alt="Screenshot 2026-06-03 at 2 19 58 PM" src="https://github.com/user-attachments/assets/9ef37760-d312-4d83-8b2f-fa12128cb730" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `extract` docs to include the new `screenshot: boolean` option with examples in both Basics and API Reference. Explains that it captures the current viewport (not full page) and is only supported with AI SDK clients.

<sup>Written for commit 8fdc3745e7d8101fdf7108dabd7f920eda2628c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

