### PR TITLE
[chore]: prevent publishing of `browse-cli`

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "ignore": [],
+  "ignore": ["@browserbasehq/browse-cli"],
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "access": "public",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@browserbasehq/browse-cli",
   "version": "0.6.1",
+  "private": true,
   "description": "Browser automation CLI for AI agents, built on Stagehand",
   "type": "commonjs",
   "license": "MIT",


### PR DESCRIPTION
# why
- the release workflow picks up on all publishable packages in the monorepo, and the `browse-cli` is now deprecated in favour of the `browse` package
- we should not be publishing the `browse-cli` package anymore
# what changed
- this PR adds the `browse-cli` to the changeset ignore list, which will prevent publish attempts when the release workflow runs
- also marks the package as private, so that publish attempts will error


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent publishing of the deprecated `@browserbasehq/browse-cli` by marking it `private` and adding it to Changesets `ignore`. This makes the release workflow skip it and causes any publish attempts to fail.

<sup>Written for commit 67f411d7f84fff622f35bb0defc78e515995a4ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

