### PR TITLE
fix(core): normalize URLs in ActCache key derivation

### DIFF
--- a/.changeset/fix-actcache-url-normalize.md
+++ b/.changeset/fix-actcache-url-normalize.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Normalize URLs in `ActCache` key derivation by sorting query parameters before hashing. Semantically equivalent URLs that differ only in parameter order (e.g. `?utm_source=email&id=42` vs `?id=42&utm_source=email`) now hit the cache instead of silently missing. Fragments and duplicate keys are preserved.

--- a/packages/core/lib/v3/cache/ActCache.ts
+++ b/packages/core/lib/v3/cache/ActCache.ts
@@ -4,7 +4,11 @@ import type { LLMClient } from "../llm/LLMClient.js";
 import type { Action, ActResult, Logger } from "../types/public/index.js";
 import type { Page } from "../understudy/page.js";
 import { CacheStorage } from "./CacheStorage.js";
-import { safeGetPageUrl, waitForCachedSelector } from "./utils.js";
+import {
+  normalizeUrlForCacheKey,
+  safeGetPageUrl,
+  waitForCachedSelector,
+} from "./utils.js";
 import {
   ActCacheContext,
   ActCacheDeps,
@@ -52,7 +56,7 @@ export class ActCache {
     const pageUrl = await safeGetPageUrl(page);
     const cacheKey = this.buildActCacheKey(
       sanitizedInstruction,
-      pageUrl,
+      normalizeUrlForCacheKey(pageUrl),
       variableKeys,
     );
     return {

--- a/packages/core/lib/v3/cache/utils.ts
+++ b/packages/core/lib/v3/cache/utils.ts
@@ -16,6 +16,23 @@ export async function safeGetPageUrl(page: Page): Promise<string> {
 }
 
 /**
+ * Normalizes a URL for use in cache key derivation: parses the URL and
+ * sorts its query parameters so that equivalent URLs that differ only in
+ * parameter order produce the same cache key. Returns the input unchanged
+ * if it isn't a parseable URL (e.g. empty string, `about:blank`).
+ */
+export function normalizeUrlForCacheKey(rawUrl: string): string {
+  if (!rawUrl) return rawUrl;
+  try {
+    const url = new URL(rawUrl);
+    url.searchParams.sort();
+    return url.toString();
+  } catch {
+    return rawUrl;
+  }
+}
+
+/**
  * Waits for a cached action's selector to be attached to the DOM before executing.
  * Logs a warning and proceeds if the wait times out (non-blocking).
  */

--- a/packages/core/tests/unit/act-cache-url-normalize.test.ts
+++ b/packages/core/tests/unit/act-cache-url-normalize.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { normalizeUrlForCacheKey } from "../../lib/v3/cache/utils.js";
+
+describe("normalizeUrlForCacheKey", () => {
+  it("returns the input unchanged when there are no query parameters", () => {
+    const input = "https://example.com/products";
+    expect(normalizeUrlForCacheKey(input)).toBe(input);
+  });
+
+  it("sorts query parameters alphabetically", () => {
+    expect(normalizeUrlForCacheKey("https://example.com/?b=2&a=1&c=3")).toBe(
+      "https://example.com/?a=1&b=2&c=3",
+    );
+  });
+
+  it("produces identical output for URLs that differ only in parameter order", () => {
+    const a = normalizeUrlForCacheKey(
+      "https://shop.example.com/cart?utm_source=email&id=42",
+    );
+    const b = normalizeUrlForCacheKey(
+      "https://shop.example.com/cart?id=42&utm_source=email",
+    );
+    expect(a).toBe(b);
+  });
+
+  it("preserves duplicate keys in their original order", () => {
+    // `?a=1&a=2` and `?a=2&a=1` are semantically distinct (different value
+    // lists), so duplicates must keep their relative order even after sort.
+    expect(normalizeUrlForCacheKey("https://example.com/?a=1&a=2")).toBe(
+      "https://example.com/?a=1&a=2",
+    );
+    expect(normalizeUrlForCacheKey("https://example.com/?a=2&a=1")).toBe(
+      "https://example.com/?a=2&a=1",
+    );
+  });
+
+  it("preserves the URL fragment", () => {
+    // Fragments often indicate distinct views in SPAs, so we deliberately
+    // do not strip them.
+    expect(
+      normalizeUrlForCacheKey("https://docs.example.com/guide#install"),
+    ).toBe("https://docs.example.com/guide#install");
+  });
+
+  it("preserves path and origin", () => {
+    expect(
+      normalizeUrlForCacheKey("https://sub.example.com:8443/a/b/c?z=1&a=2"),
+    ).toBe("https://sub.example.com:8443/a/b/c?a=2&z=1");
+  });
+
+  it("returns the input unchanged for an empty string", () => {
+    expect(normalizeUrlForCacheKey("")).toBe("");
+  });
+
+  it("returns the input unchanged for an unparseable URL", () => {
+    expect(normalizeUrlForCacheKey("not a url")).toBe("not a url");
+  });
+
+  it("returns the input unchanged for browser-internal URLs", () => {
+    expect(normalizeUrlForCacheKey("about:blank")).toBe("about:blank");
+  });
+});


### PR DESCRIPTION
Closes #2189.

## why

`ActCache.buildActCacheKey` (`packages/core/lib/v3/cache/ActCache.ts:184`) hashes the page URL verbatim from `page.url()` with no normalization. URLs that are semantically equivalent — same origin, path, and set of query parameters — produce different cache keys whenever the parameters appear in a different order. The cache silently misses, triggering an LLM call where one shouldn't be needed.

This is pervasive on real-world URLs: e-commerce links, ad funnels, anywhere `utm_*` / session params drift between visits.

| First run | Second run | Same page? | Cache hits today? |
| --- | --- | --- | --- |
| `?id=42&utm_source=email` | `?utm_source=email&id=42` | yes | no |
| `?ref=home&page=2` | `?page=2&ref=home` | yes | no |

## what changed

- New `normalizeUrlForCacheKey` in `cache/utils.ts`: parses the URL, calls `URLSearchParams.sort()`, reserializes. Falls back to the raw input if the URL is unparseable (`""`, `about:blank`-like values).
- `ActCache.prepareContext` passes the normalized URL into `buildActCacheKey` while the stored `entry.url` still holds the raw URL (so on-disk cache files remain debuggable).
- New unit test `packages/core/tests/unit/act-cache-url-normalize.test.ts` covering: sort behavior, equivalent URLs producing identical output, fragment preservation, duplicate-key relative-order preservation, fallback paths.

## design notes

The normalizer is intentionally conservative — **only** sorts parameters. Out of scope here, but candidates for follow-ups:

- **Tracking-param stripping** (`utm_*`, `fbclid`, `gclid`, etc.) — requires opinions on what counts as tracking; could break intentional differentiation, e.g. a customer that uses `?ref=X` as a meaningful state.
- **Fragment stripping** — fragments often indicate distinct views in SPAs, so removing them could lose intent.
- **Trailing-slash normalization** — some servers treat them differently.

Each of those could land separately once the conservative pass is in.

## compatibility

Strict superset of current cache hits — no URL that hits the cache today will miss after this change. URLs that miss today because of param reordering will now hit. The on-disk cache key for any URL containing query params changes; old entries become unreachable (don't break anything, just don't get used), and the next run rewrites them with the new key.

## test plan

- [x] `pnpm run build:esm && pnpm exec vitest run --config vitest.esm.config.mjs dist/esm/tests/unit/act-cache-url-normalize.test.js` — 9/9 pass.
- [x] No public API changes; `normalizeUrlForCacheKey` is exported for testability but lives under `cache/` and isn't re-exported from the SDK root.
- [x] Changeset bundled (`@browserbasehq/stagehand` patch).

Found while reading `ActCache.ts` to understand the self-healing flow — happy to follow up with the tracking-param strip or fragment handling as a separate PR once this lands.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize URLs in `ActCache` key derivation so query-parameter order no longer creates different cache keys, increasing hit rate and avoiding extra LLM calls. Closes #2189.

- **Bug Fixes**
  - Added `normalizeUrlForCacheKey` in `cache/utils.ts` to sort query params via `URLSearchParams.sort()`.
  - `prepareContext` now hashes the normalized URL; stored `entry.url` stays raw for debugging.
  - Preserves fragments and duplicate-key order; passes through empty/unparseable/`about:blank` URLs.
  - Added unit tests for sort behavior and equivalence cases.

- **Migration**
  - Cache keys for URLs with query params change; existing on-disk entries won’t be used and will regenerate on next run.

<sup>Written for commit b98838ed1247597e2a9072fe2ea887974fcdfc18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

