### PR TITLE
[STG-2184] fix: lead-with-local onboarding for browse CLI

### DIFF
--- a/.changeset/lead-with-local.md
+++ b/.changeset/lead-with-local.md
@@ -1,0 +1,5 @@
+---
+"browse": patch
+---
+
+Lead-with-local onboarding: the missing-API-key error on cloud commands now tells users that local browser automation needs no key and points them to `browse open <url> --local`. The remote-mode driver error is clearer about when a key is required versus when local mode works without one.

--- a/packages/cli/src/lib/cloud/api.ts
+++ b/packages/cli/src/lib/cloud/api.ts
@@ -31,8 +31,11 @@ export function resolveApiKey(args: { apiKey?: string }): string {
     apiKey ||
     fail(
       [
-        "Missing Browserbase API key. Set BROWSERBASE_API_KEY or pass --api-key.",
-        `You can find your API key at ${browserbaseSettingsUrl}.`,
+        "Missing Browserbase API key. Cloud commands (search, fetch, sessions, functions, ...) need one.",
+        "Set BROWSERBASE_API_KEY or pass --api-key.",
+        `Get a key at ${browserbaseSettingsUrl}.`,
+        "",
+        "No key? Local browser automation needs none. Try: browse open <url> --local",
       ].join("\n"),
       1,
       {

--- a/packages/cli/src/lib/driver/remote.ts
+++ b/packages/cli/src/lib/driver/remote.ts
@@ -22,7 +22,7 @@ export function remoteStagehandOptions(): StagehandConstructorOptions {
   const apiKey = process.env.BROWSERBASE_API_KEY;
   if (!apiKey) {
     throw new Error(
-      "Missing BROWSERBASE_API_KEY. Set it or pass --local for a managed local browser.",
+      "Missing BROWSERBASE_API_KEY for remote mode. Pass --local to run a managed local browser (no key needed), or set BROWSERBASE_API_KEY for cloud sessions.",
     );
   }
 


### PR DESCRIPTION
## Summary

Migrates [browserbase/cli#141](https://github.com/browserbase/cli/pull/141) into the monorepo now that the oclif `browse` CLI lives in `packages/cli`.

Cloud commands (`cloud search`, `cloud fetch`, etc.) hard-fail when `BROWSERBASE_API_KEY` is missing — data showed this is the #1 cause of first-run failure (~74% of installs fail their first command; ~94% of those are missing-key failures on cloud commands). Local browser automation (`open`/`get`/`click`/…) needs no key and is what recurring users overwhelmingly use.

This PR "leads with local" by making the missing-key error friendly and actionable: it now states that cloud commands need a key **and** that local automation needs none, pointing to `browse open <url> --local`.

**No driver behavior change.** Driver commands already default to managed-local when no key is set, so `browse open <url>` already launches a local browser and succeeds. This is a message-only change.

Changes:
- `packages/cli/src/lib/cloud/api.ts` — enriched `resolveApiKey()` missing-key message. Still starts with `Missing Browserbase API key` (telemetry test substring + `missing_api_key` result code unchanged); clean `CommandFailure` exit preserved.
- `packages/cli/src/lib/driver/remote.ts` — clearer remote-mode error distinguishing when a key is required vs. when `--local` works without one. (In the monorepo this string lives in `remote.ts`; in the standalone repo it was `session-manager.ts`.)
- `.changeset/lead-with-local.md` — `"browse": patch`, consumed by the decoupled `release-cli` workflow.

Linear: [STG-2184](https://linear.app/browserbase/issue/STG-2184)

## E2E Test Matrix

Built the workspace locally (`pnpm install` + turbo build of `@browserbasehq/stagehand` + `pnpm --filter browse build`) and ran the built `bin/run.js` with `BROWSERBASE_API_KEY` unset (`env -u BROWSERBASE_API_KEY`).

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `browse cloud search "test query"` (no key) | `Missing Browserbase API key. Cloud commands (search, fetch, sessions, functions, ...) need one.` / `Set BROWSERBASE_API_KEY or pass --api-key.` / `Get a key at https://browserbase.com/settings.` / blank / `No key? Local browser automation needs none. Try: browse open <url> --local` — exit 1 | Proves the enriched, actionable message ships on the highest-volume failure path. Clean exit-1, no stack trace. |
| `browse cloud fetch https://example.com` (no key) | Same enriched message | Confirms all cloud commands share the improved guidance via `resolveApiKey`. |
| `browse open https://example.com --local` (no key) | `{"mode":"managed-local", ...}` — exit 0 | Proves local automation works with zero config; no code change needed here. |
| `browse open https://example.com --remote` (no key) | `Error: Missing BROWSERBASE_API_KEY for remote mode. Pass --local to run a managed local browser (no key needed), or set BROWSERBASE_API_KEY for cloud sessions.` | Proves the enriched remote-mode driver error ships. |
| `browse stop` | `{"stopped":true,...}` | Local daemon cleans up. |
| `pnpm lint` (prettier + eslint + tsc --noEmit) | All pass | Formatting, lint, and typecheck clean. |
| `pnpm test` (vitest, 15 files) | `Tests 209 passed (209)` | Full suite green, including `cli-telemetry` asserting stderr contains `Missing Browserbase API key` and `result_code === "missing_api_key"`. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves onboarding for the `browse` CLI by making missing-key errors lead with local mode: cloud commands now say they require a key and suggest `browse open <url> --local`, and the remote-mode error explains when a key is required. Message-only change that preserves telemetry ("Missing Browserbase API key", result_code `missing_api_key`) and leaves driver behavior unchanged; addresses Linear STG-2184.

<sup>Written for commit ff579aadbf47cb90cd0ddb47d95be3ab5b461102. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

