### PR TITLE
[STG-2186] ci: fix browse release-cli ignore list

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -75,11 +75,14 @@ jobs:
             if (pkg.devDependencies) delete pkg.devDependencies['@browserbasehq/stagehand'];
             fs.writeFileSync('packages/cli/package.json', JSON.stringify(pkg, null, 2) + '\n');
 
+            // Ignore every workspace package except browse so 'changeset version'
+            // only bumps browse. Keep this list in sync with the packages that
+            // actually exist on disk -- changeset validation fails if an entry
+            // here doesn't resolve to a real package.
             const config = JSON.parse(fs.readFileSync('.changeset/config.json', 'utf8'));
             config.ignore = [
               '@browserbasehq/stagehand',
               '@browserbasehq/stagehand-server-v3',
-              '@browserbasehq/stagehand-server-v4',
               '@browserbasehq/stagehand-evals',
               '@browserbasehq/stagehand-docs'
             ];


### PR DESCRIPTION
## Summary

The `Prepare CLI Release` workflow (`release-cli.yml`) fails on its **Version browse** step whenever a `browse` changeset lands on `main`.

[Failing run](https://github.com/browserbase/stagehand/actions/runs/27041877304/job/79819532597):

```
🦋  error ValidationError: Some errors occurred when validating the changesets config:
🦋  error The package or glob expression "@browserbasehq/stagehand-server-v4" is specified
        in the `ignore` option but it is not found in the project.
```

The step rewrites the changeset `ignore` list to a hardcoded array that includes `@browserbasehq/stagehand-server-v4`. That name is declared in `pnpm-workspace.yaml` but has **no package on disk** (the materialized workspace is `core`, `docs`, `evals`, `server-v3`, and `cli`/`browse`). `changeset version` validates that every ignored entry resolves to a real package, so it throws before versioning browse.

This was latent until the first browse changeset reached `main` (PR #2192 / STG-2184), which triggered the workflow and surfaced the bug.

## Fix

Drop the nonexistent `@browserbasehq/stagehand-server-v4` entry; ignore only the packages that actually exist (`core`, `server-v3`, `evals`, `docs`). Added a comment noting this list must track the on-disk packages.

## E2E Test Matrix

Replayed the exact **Version browse** step locally against `origin/main` (which carries the merged `lead-with-local` browse changeset), using `GITHUB_TOKEN=$(gh auth token)` for changelog generation.

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `pnpm changeset version` (old list w/ server-v4) | `ValidationError: ... "@browserbasehq/stagehand-server-v4" ... is specified in the ignore option but it is not found` | Reproduces the CI failure locally. |
| `pnpm changeset version` (fixed list) | `🦋 All files have been updated.` — `browse` `0.8.2` → `0.8.3`, `lead-with-local.md` consumed, `packages/cli/CHANGELOG.md` gets the `## 0.8.3` entry linking PR #2192 | Proves the step completes end-to-end and produces the intended release metadata. |

CI-only change — no changeset (does not affect published package behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
