### PR TITLE
[STG-2187] ci: single changeset publish in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,9 +65,11 @@ jobs:
             done
           done
 
-          # Skip only when ALL pending changesets target ignored packages.
-          # When there are no changesets at all, the action must still run
-          # so it can publish freshly-versioned packages.
+          # Gates the changesets action (Version Packages PR creation) only.
+          # Publishing is handled by the dedicated "Publish to npm" step below,
+          # independent of this flag. Skip the PR step only when every pending
+          # changeset targets an ignored package (e.g. browse), since the action
+          # would produce an empty/no-op PR in that case.
           if [ "$HAS_ANY" = "true" ] && [ "$HAS_ACTIONABLE" = "false" ]; then
             echo "All pending changesets target ignored packages — skipping changesets action."
             echo "should_run=false" >> "$GITHUB_OUTPUT"
@@ -75,84 +77,56 @@ jobs:
             echo "should_run=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Create Release Pull Request or Publish to npm
+      # ---------- Sole publisher ----------
+      # Publish BEFORE the changesets action opens the Version Packages PR (which
+      # switches branches), on the clean pushed commit. `changeset publish` only
+      # publishes packages whose local version is ahead of npm, so this is a
+      # no-op on ordinary pushes and publishes whatever was just versioned --
+      # core (after a Version Packages PR merges) or browse (after a
+      # release/browse PR merges) -- exactly once, with provenance via Trusted
+      # Publishing. It intentionally does not consult the changeset `ignore`
+      # list: `ignore` governs versioning, not publishing, so browse is published
+      # here like any other public package. This replaces the bespoke
+      # pnpm-pack/npm-publish browse steps that used to race this same command.
+      - name: Publish to npm
+        if: github.ref == 'refs/heads/main'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          pnpm run release
+          # changeset publish creates local git tags (e.g. browse@x,
+          # @browserbasehq/stagehand@y); push them (the changesets action did this
+          # when it owned publishing). No-op when nothing new was published.
+          git push origin --tags
+
+      - name: Create Release Pull Request
         id: changesets
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         if: steps.check_changesets.outputs.should_run == 'true'
-        with:
-          publish: pnpm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Publish already-versioned packages
-        if: steps.check_changesets.outputs.should_run != 'true'
-        run: pnpm run release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check if browse publish is needed
-        if: github.ref == 'refs/heads/main'
-        id: browse_cli
-        run: |
-          # Restore working tree — changesets/action may have switched branches
-          git checkout ${{ github.sha }}
-
-          if git diff --quiet ${{ github.sha }}^ ${{ github.sha }} -- packages/cli/package.json; then
-            echo "browse version did not change on this push."
-            echo "should_publish=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          OLD_VERSION=$(git show ${{ github.sha }}^:packages/cli/package.json | node -pe "JSON.parse(require('fs').readFileSync(0, 'utf8')).version")
-          NEW_VERSION=$(git show ${{ github.sha }}:packages/cli/package.json | node -pe "JSON.parse(require('fs').readFileSync(0, 'utf8')).version")
-          echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
-
-          if [ "$OLD_VERSION" = "$NEW_VERSION" ]; then
-            echo "browse version did not change on this push."
-            echo "should_publish=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "should_publish=true" >> "$GITHUB_OUTPUT"
-
-          if npm view "browse@${NEW_VERSION}" version >/dev/null 2>&1; then
-            echo "browse ${NEW_VERSION} is already published."
-            echo "already_published=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "already_published=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Publish browse to npm
-        if: steps.browse_cli.outputs.should_publish == 'true' && steps.browse_cli.outputs.already_published != 'true'
-        run: |
-          cd packages/cli
-          PACK_DIR=$(mktemp -d)
-          trap 'rm -rf "$PACK_DIR"' EXIT
-
-          TARBALL=$(pnpm pack --json --pack-destination "$PACK_DIR" | node -pe "JSON.parse(require('fs').readFileSync(0, 'utf8')).filename")
-          npm publish "$TARBALL" --provenance --access public --tag latest
-
-      - name: Tag browse release
-        if: github.ref == 'refs/heads/main' && steps.browse_cli.outputs.should_publish == 'true' && steps.browse_cli.outputs.already_published != 'true'
-        run: |
-          TAG="browse@${{ steps.browse_cli.outputs.version }}"
-          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
-            echo "Tag ${TAG} already exists."
-            exit 0
-          fi
-
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag "$TAG"
-          git push origin "$TAG"
 
       - name: Publish browse canary
-        if: github.ref == 'refs/heads/main' && steps.browse_cli.outputs.should_publish != 'true'
+        if: github.ref == 'refs/heads/main'
         run: |
-          # Skip if no browse files changed in this push
+          # The changesets action above may have switched branches.
+          git checkout ${{ github.sha }}
+
+          # Skip if no browse files changed in this push.
           if git diff --quiet ${{ github.sha }}^ ${{ github.sha }} -- packages/cli/; then
             echo "No browse changes in this push, skipping canary."
             exit 0
+          fi
+
+          # Skip if browse was released on this push -- the Publish step already
+          # shipped the real version, so no canary is needed.
+          if ! git diff --quiet ${{ github.sha }}^ ${{ github.sha }} -- packages/cli/package.json; then
+            OLD_VERSION=$(git show ${{ github.sha }}^:packages/cli/package.json | node -pe "JSON.parse(require('fs').readFileSync(0, 'utf8')).version")
+            NEW_VERSION=$(git show ${{ github.sha }}:packages/cli/package.json | node -pe "JSON.parse(require('fs').readFileSync(0, 'utf8')).version")
+            if [ "$OLD_VERSION" != "$NEW_VERSION" ]; then
+              echo "browse version bumped (${OLD_VERSION} -> ${NEW_VERSION}); release already published, skipping canary."
+              exit 0
+            fi
           fi
 
           cd packages/cli


### PR DESCRIPTION
## Summary

The `Release` workflow had **two publishers** for `browse`, and they raced — surfaced by [run 27043820691](https://github.com/browserbase/stagehand/actions/runs/27043820691/job/79825532677) failing with `403 cannot publish over the previously published versions: 0.8.3` (browse@0.8.3 still shipped fine; the duplicate attempt is what went red, and it skipped the downstream core canary).

**Root cause:** the changesets action ran `publish: pnpm run release` (= `changeset publish`), and `changeset publish` **does not honor the `ignore` list** (`ignore` governs *versioning*, not publishing) — so it published `browse` like any other public package. A separate bespoke `pnpm pack` / `npm publish` step then published `browse` again. When no core changesets were pending, both fired on the same browse-release commit; npm's read-after-write lag defeated the bespoke step's `npm view` guard, yielding the 403.

## Fix — one publisher

Collapse to a single `changeset publish`:

- New **"Publish to npm"** step runs `pnpm run release` once, *before* the changesets action (which switches branches to open the Version-Packages PR), on the clean pushed commit. It publishes whatever was just versioned — core (after a Version-Packages PR merges) or browse (after a `release/browse` PR merges) — exactly once, then pushes the tags `changeset publish` creates.
- The changesets action is reduced to **Version-Packages-PR creation only** (`publish:` input removed).
- The bespoke browse publish + tag + detection steps are **removed**. The browse canary is re-gated inline (fires on CLI changes that aren't a version bump).

**Core's publish path is unchanged in substance** — it already went through `changeset publish`; this just relocates that command to its own step and adds an explicit tag push (the action used to push tags).

## Why this is safe (verified empirically)

| Assumption | Result | Evidence |
| --- | --- | --- |
| `changeset publish` makes a correct browse pkg | ✅ | published `browse@0.8.3` has `@browserbasehq/stagehand: "3.5.0"` — `workspace:*` rewritten by pnpm |
| Provenance preserved without `--provenance` | ✅ | 0.8.3 carries an SLSA attestation; auth is pure Trusted Publishing / OIDC (no `NPM_TOKEN` anywhere), so provenance is automatic |
| Tags still created/pushed | ✅ | `changeset publish` tags by default; core tags `@browserbasehq/stagehand@3.5.0` already exist; step adds `git push origin --tags` |
| Always-on publish won't misfire | ✅ | every publishable pkg's current version is already on npm → `changeset publish` is a no-op right now; `evals`/`server-v3` are `private` → auto-skipped |
| Tag push needs no extra token | ✅ | the old "Tag browse release" step pushed tags with the checkout-persisted credential and no `GITHUB_TOKEN` env |

## E2E Test Matrix

| Check | Observed | Sufficiency |
| --- | --- | --- |
| `yaml.safe_load` of the workflow | parses; 10 steps in intended order (`Publish to npm` → `Create Release Pull Request` → canaries) | Confirms valid syntax + ordering (publish before the branch-switching action). |
| Diff scope | only `.github/workflows/release.yml`, +42/-68 | No code/package changes; CI-only. |
| `changeset publish` dry state on current main | all publishable versions already on npm → would no-op | Confirms the always-on publisher is safe when nothing is pending. |

**Staged rollout (the one thing inspection can't prove — a live publish):** after merge, the next **browse** release (a low-stakes, independent bump) exercises the exact `changeset publish` path core will use. A green browse release de-risks the next core release by construction; core is never the first to traverse the new path.

CI-only change — no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the Release workflow to a single publisher using `changeset publish` to prevent duplicate `browse` releases and 403 errors. Addresses STG-2187.

- **Bug Fixes**
  - Remove the bespoke `pnpm pack`/`npm publish` path for `browse` that raced `changeset publish`.
  - Prevent 403 “cannot publish over the previously published versions” and avoid skipping downstream canaries.

- **Refactors**
  - Add a dedicated “Publish to npm” step that runs `pnpm run release` on `main` before the changesets action and pushes tags.
  - Reduce `changesets/action` to Version-Packages PR creation only (no `publish:` input).
  - Re-gate the `browse` canary to run only on CLI changes that aren’t a version bump.

<sup>Written for commit 1a640af4d4375e0cc050dc9eee1bb6696ebcc7c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

