### PR TITLE
[STG-2188] docs(cli): document full browse command surface + fix license badge

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -6,7 +6,7 @@
 
 [![npm version](https://img.shields.io/npm/v/browse.svg?style=flat-square&color=000000)](https://www.npmjs.com/package/browse)
 [![npm downloads](https://img.shields.io/npm/dm/browse.svg?style=flat-square&color=000000)](https://www.npmjs.com/package/browse)
-[![license](https://img.shields.io/npm/l/browse.svg?style=flat-square&color=000000)](https://github.com/browserbase/stagehand/blob/main/packages/cli/LICENSE)
+[![license](https://img.shields.io/badge/license-MIT-000000?style=flat-square)](https://github.com/browserbase/stagehand/blob/main/packages/cli/LICENSE)
 
 ```bash
 npm install -g browse
@@ -22,7 +22,7 @@ npm install -g browse
 
 ## Why browse
 
-- **Browser interactions** — Navigate tricky, complex websites with `browse click`, `browse mouse scroll`, `browse type`, `browse select`, and 20+ more DOM commands.
+- **Browser interactions** — Navigate tricky, complex websites with `browse click`, `browse mouse scroll`, `browse type`, `browse select`, and 30+ more DOM commands.
 - **Open web skills catalog** — `browse` is the official CLI for [browse.sh](https://browse.sh), the largest open web catalog. Run `browse skills add apartments.com` and your agent learns how to use that site and its APIs.
 - **Rich debugging** — Arm your agents with network, console, and other web telemetry.
 - **Cloud features** — Optionally use Browserbase cloud: load cookies via saved [Contexts](https://docs.browserbase.com/platform/browser/core-features/contexts), use [Verified Browsers](https://www.browserbase.com/verified), and call the [Fetch and Search APIs](https://www.browserbase.com/search).
@@ -41,35 +41,153 @@ browse screenshot --path page.png
 browse stop
 ```
 
-## Driver commands
+## How it works
 
-Drive a real browser from the terminal — locally, over CDP, or on a remote Browserbase session.
+`browse` runs a lightweight per-session daemon. The first command starts it, and subsequent commands reuse the same browser — so cookies, tabs, and snapshot refs persist between invocations. Run multiple isolated browsers at once with `--session <name>` (or the `BROWSE_SESSION` env var), and shut a session down with `browse stop`.
+
+### Browser targets
+
+Every driver command accepts the same flags to pick where the browser runs. Mix and match per command:
+
+| Flag | Target |
+|------|--------|
+| _(default)_ | Managed local browser, or remote when `BROWSERBASE_API_KEY` is set |
+| `--local` | Managed local browser (add `--headed` / `--headless`) |
+| `--remote` | Remote Browserbase session (uses `BROWSERBASE_API_KEY`) |
+| `--auto-connect` | Auto-discover and attach to a local Chrome with remote debugging enabled |
+| `--cdp <url\|port>` | Attach directly to a CDP endpoint (port, `http(s)://`, or `ws(s)://`) |
+| `--target-id <id>` | Select a specific CDP target when attaching to an existing browser |
 
 ```bash
-browse open https://example.com
+browse open https://example.com                 # default target
 browse open https://example.com --local --headed
 browse open https://example.com --remote
 browse open https://example.com --auto-connect
 browse open https://example.com --cdp 9222
 browse open https://example.com --cdp ws://127.0.0.1:9222/devtools/browser/<id> --target-id <target-id>
-browse snapshot --compact
-browse click @0-12
-browse fill @0-8 "hello"
-browse mouse click 240 320
-browse get title
-browse screenshot --path page.png
-browse tab list
-browse tab switch <target-id>
-browse network on
-browse cdp 9222 --pretty
-browse status
-browse stop
 ```
 
-Use `--local`, `--remote`, `--auto-connect`, or `--cdp <url|port>` per command to choose the browser target. Use `--target-id <id>` with `--cdp` when attaching to a specific CDP target. Driver commands use `BROWSERBASE_API_KEY` for remote Browserbase sessions.
+Run `browse doctor` to diagnose session and browser-connection prerequisites for any target.
+
+## Commands
+
+### Navigation
+
+```bash
+browse open <url>     # Open a URL (--wait load|domcontentloaded|networkidle, --timeout <ms>)
+browse reload         # Reload the active page
+browse back           # Navigate backward
+browse forward        # Navigate forward
+```
+
+### Snapshot & refs
+
+The accessibility snapshot is the recommended way for agents to discover elements. It prints a tree of refs like `@0-12` that the element commands accept directly.
+
+```bash
+browse snapshot                 # Accessibility snapshot + cached refs
+browse snapshot --compact       # Tree only, no ref maps
+browse snapshot --filter submit # Filter lines by text or /regex/, keeping ancestors
+browse snapshot --max-depth 4   # Trim output deeper than this depth
+browse refs                     # Show refs cached from the last snapshot
+```
+
+### Element actions
+
+Targets accept a snapshot ref (`@0-12`), an XPath, or a CSS selector.
+
+```bash
+browse click @0-12                          # Click (also accepts selectors)
+browse fill @0-8 "hello"                     # Fill an input (--press-enter to submit)
+browse select @0-9 "CA"                       # Select an option (--value for <option value>)
+browse type "hello world"                     # Type at the current focus (--delay, --mistakes)
+browse press Enter                            # Press a key (alias: browse key) e.g. Meta+K, Escape
+browse upload @0-4 ./resume.pdf               # Upload file(s) (repeat --file for more)
+browse highlight @0-12                         # Highlight an element (--duration <ms>)
+```
+
+### Mouse (raw coordinates)
+
+Use these when you need pixel coordinates instead of a ref. Add `--return-xpath` to get the XPath under the cursor.
+
+```bash
+browse mouse click 240 320      # Click coordinates (--button, --click-count)
+browse mouse hover 240 320      # Move the mouse
+browse mouse scroll 400 500 0 600   # Scroll from a point by (dx, dy)
+browse mouse drag 100 100 400 400   # Drag between two points (--steps, --delay)
+```
+
+### Page info & state
+
+```bash
+browse get url          # Read page data / element state:
+browse get title        #   url, title, text, html, value, box,
+browse get text @0-12   #   visible, checked, markdown
+browse get markdown body
+browse get box 'button[type=submit]'
+browse is visible @0-12       # Check element state: visible, checked
+browse eval 'document.title'  # Evaluate JavaScript in the page
+browse viewport 1280 720      # Set viewport size (--scale for device pixel ratio)
+browse cursor                 # Enable a visible cursor overlay
+browse screenshot --path page.png   # Screenshot (--full-page, --type, --quality, --clip)
+```
+
+### Waiting
+
+```bash
+browse wait load                          # Wait for a load state
+browse wait load networkidle --timeout 45000
+browse wait selector @0-12 --state visible  # visible|hidden|attached|detached
+browse wait timeout 1000                  # Wait a fixed number of ms
+```
+
+### Tabs
+
+```bash
+browse tab list             # List tabs (with stable targetIds)
+browse tab new [url]        # Open a new tab and make it active
+browse tab switch <target-id>  # Switch active tab (index or targetId)
+browse tab close [target-id]   # Close a tab (defaults to the active tab)
+```
+
+Prefer the `targetId` from `browse tab list` over the index for stable agent workflows.
+
+### Network capture
+
+Capture request/response traffic for the active session to a local directory.
+
+```bash
+browse network on       # Start capturing
+browse network off      # Stop capturing
+browse network path     # Print the capture directory
+browse network clear    # Clear captured requests
+```
 
 > [!NOTE]
 > `browse network on` writes request/response headers and bodies to a local owner-only capture directory. These files can include cookies, authorization headers, and other secrets — use network capture only on trusted machines and run `browse network clear` when done.
+
+### Session & daemon
+
+```bash
+browse status      # Show daemon status for a session
+browse stop        # Stop the daemon (--force to kill an unresponsive browser)
+browse doctor      # Diagnose session and browser-connection prerequisites
+browse cdp 9222    # Attach to a CDP endpoint and stream DevTools events (--domain, --pretty)
+```
+
+### Global flags
+
+These apply across driver commands:
+
+| Flag | Description |
+|------|-------------|
+| `-s, --session <name>` | Named browser session (or `BROWSE_SESSION` env var) |
+| `--local` / `--remote` | Choose a managed local or remote Browserbase browser |
+| `--headed` / `--headless` | Window visibility for managed local sessions |
+| `--auto-connect` | Attach to a local Chrome with remote debugging enabled |
+| `--cdp <url\|port>` | Attach directly to a CDP endpoint |
+| `--target-id <id>` | Select a specific CDP target |
+| `--json` | Emit machine-readable JSON (available on most commands) |
 
 ## Open web skills catalog
 
@@ -78,6 +196,7 @@ Use [browse.sh](https://browse.sh), the largest open-source catalog of skills to
 ```bash
 browse skills install                                       # install the bundled browse CLI skill
 browse skills list                                          # list the public Browse.sh catalog
+browse skills list --all                                    # include every catalog entry
 browse skills find reviews                                  # search by slug, domain, title, tag…
 browse skills find yelp.com/extract-reviews
 browse skills add yelp.com/extract-reviews                  # install a catalog skill
@@ -86,23 +205,37 @@ browse skills add mcdonalds.order.online/order-delivery-42q71n
 
 ## Browserbase cloud commands
 
-Manage projects, sessions, contexts, and extensions, or call the Fetch and Search APIs directly.
+Manage projects, sessions, contexts, and extensions, or call the Fetch and Search APIs directly. These commands use `BROWSERBASE_API_KEY`.
 
 ```bash
+# Projects
 browse cloud projects list
 browse cloud projects get <project-id>
 browse cloud projects usage <project-id>
-browse cloud sessions list
+
+# Sessions
+browse cloud sessions list                       # --limit, --status, --json
 browse cloud sessions get <session-id>
-browse cloud sessions create
-browse cloud sessions debug <session-id>
+browse cloud sessions create                     # --proxies, --verified, --region, --solve-captchas…
+browse cloud sessions update <session-id> --status REQUEST_RELEASE
+browse cloud sessions debug <session-id>         # live debugger URLs
 browse cloud sessions logs <session-id>
-browse cloud sessions downloads get <session-id>
-browse cloud sessions uploads create <session-id> <file>
+browse cloud sessions downloads get <session-id> # --output ./downloads.zip
+browse cloud sessions uploads create <session-id> ./file.pdf
+
+# Contexts
 browse cloud contexts create
 browse cloud contexts get <context-id>
-browse cloud extensions upload <file>
-browse cloud fetch <url>
+browse cloud contexts update <context-id>        # refresh the upload URL
+browse cloud contexts delete <context-id>
+
+# Extensions
+browse cloud extensions upload ./extension.zip
+browse cloud extensions get <extension-id>
+browse cloud extensions delete <extension-id>
+
+# Fetch & Search APIs
+browse cloud fetch <url>                          # markdown by default
 browse cloud search <query>
 ```
 
@@ -113,12 +246,22 @@ browse cloud search <query>
 Browserbase [Functions](https://docs.browserbase.com/platform/runtime/overview) let you deploy browser agents and automation scripts directly onto Browserbase's infrastructure. Build locally, test instantly, and deploy as APIs.
 
 ```bash
-browse functions init my-function
-browse functions dev index.ts
-browse functions publish index.ts
-browse functions publish index.ts --dry-run
+browse functions init my-function          # scaffold a new project (--package-manager)
+browse functions dev index.ts              # local development server (--port, --verbose)
+browse functions publish index.ts          # package and upload (--dry-run to preview)
 browse functions invoke <function-id> --params '{"url":"https://example.com"}'
 browse functions invoke --check-status <invocation-id>
+```
+
+## Templates
+
+Discover and scaffold ready-to-run Browserbase example projects.
+
+```bash
+browse templates list                      # --tag, --source, --wide, --json
+browse templates find amazon               # search by slug, title, category, or tag
+browse templates clone google-trends-keywords
+browse templates clone amazon-product-scraping --language python ./my-scraper
 ```
 
 ## Configuration
@@ -131,6 +274,11 @@ export BROWSERBASE_API_KEY=bb_live_...
 
 Local driver commands (`--local`) work without an API key.
 
+| Variable | Description |
+|----------|-------------|
+| `BROWSERBASE_API_KEY` | Enables `--remote` sessions and all `browse cloud` / `functions` commands |
+| `BROWSE_SESSION` | Default session name (alternative to `-s, --session`) |
+
 ## Links
 
 - [browse.sh](https://browse.sh) — open web skills catalog
@@ -140,3 +288,5 @@ Local driver commands (`--local`) work without an API key.
 ## License
 
 [MIT](https://github.com/browserbase/stagehand/blob/main/packages/cli/LICENSE)
+</content>
+</invoke>

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -288,5 +288,3 @@ Local driver commands (`--local`) work without an API key.
 ## License
 
 [MIT](https://github.com/browserbase/stagehand/blob/main/packages/cli/LICENSE)
-</content>
-</invoke>

--- a/packages/cli/skills/browse/SKILL.md
+++ b/packages/cli/skills/browse/SKILL.md
@@ -109,6 +109,8 @@ browse get title
 browse get text body
 browse get html "#main"
 browse get value "#email"
+browse get markdown body                   # page/element content as markdown
+browse eval "document.title"              # run JavaScript in the active page
 browse screenshot                         # print base64 JSON
 browse screenshot --path page.png
 ```
@@ -134,6 +136,7 @@ browse mouse hover 240 320
 browse mouse drag 80 80 310 100
 browse mouse scroll 500 300 0 600
 browse viewport 1280 720
+browse cursor                             # show a visible cursor overlay
 ```
 
 Tabs, network, and CDP:
@@ -144,6 +147,7 @@ browse tab new https://example.com
 browse tab switch <target-id>
 browse tab close <target-id>              # refuses to close the last tab
 browse network on
+browse network off
 browse network path
 browse network clear
 browse cdp 9222 --pretty


### PR DESCRIPTION
## Summary

Rewrites the `browse` CLI README to document the **full command surface**, fixes the license badge that rendered as "missing", and fills small gaps in the bundled agent skill.

The README previously listed only a curated subset of commands. The CLI now ships dozens of commands across browser driving, the Browse.sh skills catalog, Browserbase cloud, Functions, and templates — but most weren't documented. This restructures the README into grouped reference sections (modeled on the agent-browser README) covering every command.

### README changes
- **Full command reference**, grouped: Navigation, Snapshot & refs, Element actions, Mouse (raw coordinates), Page info & state, Waiting, Tabs, Network capture, Session & daemon.
- **Browser-target table** (`--local` / `--remote` / `--auto-connect` / `--cdp` / `--target-id`) plus a **global flags table**.
- Expanded **Skills catalog**, **Browserbase cloud** (projects/sessions/contexts/extensions/fetch/search), **Functions**, and a new **Templates** section.
- Env var table for `BROWSERBASE_API_KEY` and `BROWSE_SESSION`.
- Every command/flag was sourced directly from `src/commands/**` (descriptions, args, examples) — not invented.

### License badge fix
The license badge used `img.shields.io/npm/l/browse`, which derives the license from the npm registry. That endpoint intermittently renders **"license: missing"** when shields' cache lags behind the registry. Swapped it for a static `badge/license-MIT` badge that always resolves. The `LICENSE` file is present and the package is MIT.

### Bundled skill (`packages/cli/skills/browse/SKILL.md`)
The agent skill was already broadly current, but was missing four shipped commands. Added: `browse get markdown`, `browse eval`, `browse cursor`, and `browse network off`.

## E2E Test Matrix

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `npx prettier --check packages/cli/README.md packages/cli/skills/browse/SKILL.md` | `All matched files use Prettier code style!` | Proves both docs pass the package's `format:check` CI gate. |
| Cross-checked every documented command against `src/commands/**` (parsed `static override description` / `examples` / `args` / `flags`) | All commands and flags (`--press-enter`, `--return-xpath`, `--proxies`, `--verified`, `--region`, `--solve-captchas`, `--context-id`, `--persist`, `--source`, `--package-manager`, etc.) exist in source | Confirms the reference is accurate to the shipped CLI, not aspirational. |
| Diffed SKILL.md command list vs `src/commands/**` | Surfaced exactly 4 absent commands (`get markdown`, `eval`, `cursor`, `network off`), now added | Confirms SKILL is complete relative to the CLI. |

Docs/skill-text only — no changeset.

Closes STG-2188
