### PR TITLE
test: cover disabling --site-per-process default

### DIFF
--- a/packages/core/tests/unit/launch-local-ignore-default-args.test.ts
+++ b/packages/core/tests/unit/launch-local-ignore-default-args.test.ts
@@ -193,4 +193,22 @@ describe("launchLocalChrome ignoreDefaultArgs", () => {
     expect(args.chromeFlags).toContain("--remote-allow-origins=*");
     expect(args.chromeFlags).toContain("--disable-extensions");
   });
+
+  it("allows users to disable the Stagehand --site-per-process default", async () => {
+    const args = await getLaunchArgs({
+      args: [
+        "--disable-features=site-per-process,IsolateOrigins",
+        "--renderer-process-limit=6",
+      ],
+      ignoreDefaultArgs: ["--site-per-process"],
+    });
+
+    expect(args.ignoreDefaultFlags).toBe(true);
+    expect(args.chromeFlags).not.toContain("--site-per-process");
+    expect(args.chromeFlags).toContain(
+      "--disable-features=site-per-process,IsolateOrigins",
+    );
+    expect(args.chromeFlags).toContain("--renderer-process-limit=6");
+    expect(args.chromeFlags).toContain("--remote-allow-origins=*");
+  });
 });


### PR DESCRIPTION
# why

`--site-per-process` is a Stagehand local-browser default, so users need a reliable regression test that `localBrowserLaunchOptions.ignoreDefaultArgs` can remove it. Refs #2193.

# what changed

Added unit coverage for `launchLocalChrome` verifying that `ignoreDefaultArgs: ["--site-per-process"]` removes the Stagehand default while preserving user-provided Chromium flags such as `--disable-features=site-per-process,IsolateOrigins` and `--renderer-process-limit=6`.

# test plan

- `pnpm --dir packages/core exec vitest run --config vitest.esm.config.mjs dist/esm/tests/unit/launch-local-ignore-default-args.test.js`
- `pnpm --filter @browserbasehq/stagehand run typecheck`
- `pnpm exec prettier --check packages/core/tests/unit/launch-local-ignore-default-args.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a unit test to ensure `localBrowserLaunchOptions.ignoreDefaultArgs: ['--site-per-process']` disables Stagehand’s `--site-per-process` default in local Chrome while preserving user flags (`--disable-features=site-per-process,IsolateOrigins`, `--renderer-process-limit=6`, `--remote-allow-origins=*`). Refs #2193.

<sup>Written for commit 8dd9cbfecefbd7aba2bfdac4347bd9f9d695ef75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

