### PR TITLE
 fix: stop injecting --site-per-process into local Chromium launches

### DIFF
--- a/.changeset/remove-site-per-process-default.md
+++ b/.changeset/remove-site-per-process-default.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Stop injecting `--site-per-process` into local Chromium launches so user-supplied flags like `--disable-features=site-per-process` and `--renderer-process-limit` take effect.

--- a/packages/core/lib/v3/launch/local.ts
+++ b/packages/core/lib/v3/launch/local.ts
@@ -12,7 +12,6 @@ const STAGEHAND_DEFAULT_FLAGS = [
   "--no-first-run",
   "--no-default-browser-check",
   "--disable-dev-shm-usage",
-  "--site-per-process",
 ];
 
 export async function launchLocalChrome(

--- a/packages/core/tests/unit/launch-local-ignore-default-args.test.ts
+++ b/packages/core/tests/unit/launch-local-ignore-default-args.test.ts
@@ -80,6 +80,16 @@ async function getLaunchArgs(
 }
 
 describe("launchLocalChrome ignoreDefaultArgs", () => {
+  it("does not inject --site-per-process by default", async () => {
+    const args = await getLaunchArgs({});
+    expect(args.chromeFlags).not.toContain("--site-per-process");
+  });
+
+  it("allows users to opt in to --site-per-process via args", async () => {
+    const args = await getLaunchArgs({ args: ["--site-per-process"] });
+    expect(args.chromeFlags).toContain("--site-per-process");
+  });
+
   it("does not set ignoreDefaultFlags when ignoreDefaultArgs is omitted", async () => {
     const args = await getLaunchArgs({});
     expect(args.ignoreDefaultFlags).toBe(false);

--- a/packages/evals/core/targets/localChrome.ts
+++ b/packages/evals/core/targets/localChrome.ts
@@ -118,7 +118,6 @@ export async function launchRunnerProvidedLocalChrome(): Promise<{
     "--no-first-run",
     "--no-default-browser-check",
     "--disable-dev-shm-usage",
-    "--site-per-process",
     `--remote-debugging-port=${port}`,
     `--user-data-dir=${userDataDir}`,
     "about:blank",


### PR DESCRIPTION
# why

Stagehand unconditionally injected `--site-per-process` when launching local Chromium. That explicit switch overrides `--disable-features=site-per-process` and defeats `--renderer-process-limit` on multi-origin workloads, causing renderer pools to grow unbounded and leading to memory pressure/OOM kills under container limits.

The duplicate injection in `v3.ts` was already removed in #2127; this removes the remaining copy in `launch/local.ts`.

# what changed

- Dropped `--site-per-process` from `STAGEHAND_DEFAULT_FLAGS` in `packages/core/lib/v3/launch/local.ts`
- Dropped the same flag from `packages/evals/core/targets/localChrome.ts`
- Added regression tests in `launch-local-ignore-default-args.test.ts`
- Added a patch changeset for `@browserbasehq/stagehand`

# test plan

- [x] `pnpm --filter @browserbasehq/stagehand exec vitest run dist/esm/tests/unit/launch-local-ignore-default-args.test.js` (13/13 passed)
- [x] Live Chrome launch: parent argv has no standalone `--site-per-process`; user disable/cap flags present
- [x] Full multi-origin SPA repro: renderer count stays near configured `--renderer-process-limit`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop injecting `--site-per-process` into local Chromium launches. This lets user flags like `--disable-features=site-per-process` and `--renderer-process-limit` work and prevents runaway renderer counts.

- **Bug Fixes**
  - Removed the flag from `packages/core/lib/v3/launch/local.ts` and `packages/evals/core/targets/localChrome.ts`.
  - Added regression tests in `packages/core/tests/unit/launch-local-ignore-default-args.test.ts` (includes opt-in via args).
  - Added a patch changeset for `@browserbasehq/stagehand`.

<sup>Written for commit 736539650a7125e2221a7b1b420baaf87f2a1005. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
Fixes #2193 

