### PR TITLE
fix: close local browser launch doc and code gaps

### DIFF
--- a/.changeset/local-browser-launch-gaps.md
+++ b/.changeset/local-browser-launch-gaps.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Wire `chromiumSandbox: false` into local Chromium launches and document `ignoreDefaultArgs` plus site-isolation/renderer-limit guidance.

--- a/.changeset/remove-site-per-process-default.md
+++ b/.changeset/remove-site-per-process-default.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Stop injecting `--site-per-process` into local Chromium launches so user-supplied flags like `--disable-features=site-per-process` and `--renderer-process-limit` take effect.

--- a/packages/core/lib/v3/index.ts
+++ b/packages/core/lib/v3/index.ts
@@ -34,9 +34,11 @@ import {
   shouldPersistTrajectory,
   writeTrajectoryDir,
 } from "./verifier/index.js";
+import { STAGEHAND_DEFAULT_FLAGS } from "./launch/defaults.js";
 
 export { V3 } from "./v3.js";
 export { V3 as Stagehand } from "./v3.js";
+export { STAGEHAND_DEFAULT_FLAGS } from "./launch/defaults.js";
 
 export * from "./types/public/index.js";
 export { AnnotatedScreenshotText, LLMClient } from "./llm/LLMClient.js";
@@ -161,6 +163,7 @@ const StagehandDefault = {
   normalizeRubric,
   redactInlineImagePayloads,
   shouldPersistTrajectory,
+  STAGEHAND_DEFAULT_FLAGS,
   writeTrajectoryDir,
   tool,
   getAISDKLanguageModel,

--- a/packages/core/lib/v3/launch/defaults.ts
+++ b/packages/core/lib/v3/launch/defaults.ts
@@ -1,0 +1,6 @@
+export const STAGEHAND_DEFAULT_FLAGS = [
+  "--remote-allow-origins=*",
+  "--no-first-run",
+  "--no-default-browser-check",
+  "--disable-dev-shm-usage",
+] as const;

--- a/packages/core/lib/v3/launch/local.ts
+++ b/packages/core/lib/v3/launch/local.ts
@@ -12,7 +12,6 @@ const STAGEHAND_DEFAULT_FLAGS = [
   "--no-first-run",
   "--no-default-browser-check",
   "--disable-dev-shm-usage",
-  "--site-per-process",
 ];
 
 export async function launchLocalChrome(

--- a/packages/core/lib/v3/launch/local.ts
+++ b/packages/core/lib/v3/launch/local.ts
@@ -48,8 +48,9 @@ export async function launchLocalChrome(
     ...(opts.args ?? []),
   ].filter((f): f is string => typeof f === "string");
 
-  // Handle ignoreDefaultArgs: selectively remove chrome-launcher's built-in
-  // defaults while keeping Stagehand's own flags (already in chromeFlags).
+  // ignoreDefaultArgs: true skips chrome-launcher defaults entirely.
+  // ignoreDefaultArgs: string[] skips chrome-launcher defaults, then re-adds
+  // unlisted ones. Stagehand default flags are handled separately above.
   let ignoreDefaultFlags = false;
   if (opts.ignoreDefaultArgs === true) {
     ignoreDefaultFlags = true;

--- a/packages/core/lib/v3/launch/local.ts
+++ b/packages/core/lib/v3/launch/local.ts
@@ -1,18 +1,12 @@
 import { launch, Launcher, LaunchedChrome } from "chrome-launcher";
 import WebSocket from "ws";
+import { STAGEHAND_DEFAULT_FLAGS } from "./defaults.js";
 import { ConnectionTimeoutError } from "../types/public/sdkErrors.js";
 import type { LocalBrowserLaunchOptions } from "../types/public/index.js";
 
 interface LaunchLocalOptions extends LocalBrowserLaunchOptions {
   handleSIGINT?: boolean;
 }
-
-const STAGEHAND_DEFAULT_FLAGS = [
-  "--remote-allow-origins=*",
-  "--no-first-run",
-  "--no-default-browser-check",
-  "--disable-dev-shm-usage",
-];
 
 export async function launchLocalChrome(
   opts: LaunchLocalOptions,
@@ -47,6 +41,8 @@ export async function launchLocalChrome(
       : undefined,
     opts.hasTouch ? "--touch-events=enabled" : undefined,
     opts.ignoreHTTPSErrors ? "--ignore-certificate-errors" : undefined,
+    opts.chromiumSandbox === false ? "--no-sandbox" : undefined,
+    opts.chromiumSandbox === false ? "--disable-setuid-sandbox" : undefined,
     opts.proxy?.server ? `--proxy-server=${opts.proxy.server}` : undefined,
     opts.proxy?.bypass ? `--proxy-bypass-list=${opts.proxy.bypass}` : undefined,
     ...(opts.args ?? []),

--- a/packages/core/tests/unit/launch-local-ignore-default-args.test.ts
+++ b/packages/core/tests/unit/launch-local-ignore-default-args.test.ts
@@ -80,6 +80,16 @@ async function getLaunchArgs(
 }
 
 describe("launchLocalChrome ignoreDefaultArgs", () => {
+  it("does not inject --site-per-process by default", async () => {
+    const args = await getLaunchArgs({});
+    expect(args.chromeFlags).not.toContain("--site-per-process");
+  });
+
+  it("allows users to opt in to --site-per-process via args", async () => {
+    const args = await getLaunchArgs({ args: ["--site-per-process"] });
+    expect(args.chromeFlags).toContain("--site-per-process");
+  });
+
   it("does not set ignoreDefaultFlags when ignoreDefaultArgs is omitted", async () => {
     const args = await getLaunchArgs({});
     expect(args.ignoreDefaultFlags).toBe(false);

--- a/packages/core/tests/unit/launch-local-ignore-default-args.test.ts
+++ b/packages/core/tests/unit/launch-local-ignore-default-args.test.ts
@@ -90,6 +90,18 @@ describe("launchLocalChrome ignoreDefaultArgs", () => {
     expect(args.chromeFlags).toContain("--site-per-process");
   });
 
+  it("adds sandbox disable flags when chromiumSandbox is false", async () => {
+    const args = await getLaunchArgs({ chromiumSandbox: false });
+    expect(args.chromeFlags).toContain("--no-sandbox");
+    expect(args.chromeFlags).toContain("--disable-setuid-sandbox");
+  });
+
+  it("does not add sandbox disable flags when chromiumSandbox is omitted", async () => {
+    const args = await getLaunchArgs({});
+    expect(args.chromeFlags).not.toContain("--no-sandbox");
+    expect(args.chromeFlags).not.toContain("--disable-setuid-sandbox");
+  });
+
   it("does not set ignoreDefaultFlags when ignoreDefaultArgs is omitted", async () => {
     const args = await getLaunchArgs({});
     expect(args.ignoreDefaultFlags).toBe(false);

--- a/packages/core/tests/unit/public-api/export-surface.test.ts
+++ b/packages/core/tests/unit/public-api/export-surface.test.ts
@@ -55,6 +55,7 @@ const publicApiShape = {
   providerEnvVarMap: Stagehand.providerEnvVarMap,
   redactInlineImagePayloads: Stagehand.redactInlineImagePayloads,
   shouldPersistTrajectory: Stagehand.shouldPersistTrajectory,
+  STAGEHAND_DEFAULT_FLAGS: Stagehand.STAGEHAND_DEFAULT_FLAGS,
   toGeminiSchema: Stagehand.toGeminiSchema,
   toJsonSchema: Stagehand.toJsonSchema,
   tool: Stagehand.tool,

--- a/packages/docs/v3/configuration/browser.mdx
+++ b/packages/docs/v3/configuration/browser.mdx
@@ -258,6 +258,50 @@ const stagehand = new Stagehand({
 await stagehand.init();
 ```
 
+### Ignoring Default Chrome Flags
+
+Use `ignoreDefaultArgs` to remove chrome-launcher's built-in defaults or Stagehand's own launch flags. This is useful when you need extensions enabled, want finer control over Chromium flags, or are running in environments that require custom sandbox settings.
+
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  localBrowserLaunchOptions: {
+    // Remove only chrome-launcher's --disable-extensions default
+    ignoreDefaultArgs: ["--disable-extensions"],
+  },
+});
+
+await stagehand.init();
+```
+
+Set `ignoreDefaultArgs: true` to drop all chrome-launcher defaults. Stagehand's own flags and your `args` are still applied.
+
+#### Site isolation and renderer limits
+
+Stagehand does not inject `--site-per-process` by default. To disable site isolation or cap renderer processes on multi-origin workloads, pass flags via `args`:
+
+```typescript
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  localBrowserLaunchOptions: {
+    args: [
+      "--disable-features=site-per-process,IsolateOrigins",
+      "--renderer-process-limit=6",
+    ],
+  },
+});
+
+await stagehand.init();
+```
+
+Users who need strict per-site isolation can opt in with `args: ["--site-per-process"]`.
+
+<Tip>
+An explicit `--site-per-process` switch overrides `--disable-features=site-per-process`, regardless of argv order. Avoid passing both.
+</Tip>
+
 ## Advanced Configuration
 
 ### Keep Alive

--- a/packages/docs/v3/configuration/browser.mdx
+++ b/packages/docs/v3/configuration/browser.mdx
@@ -260,7 +260,14 @@ await stagehand.init();
 
 ### Ignoring Default Chrome Flags
 
-Use `ignoreDefaultArgs` to remove chrome-launcher's built-in defaults or Stagehand's own launch flags. This is useful when you need extensions enabled, want finer control over Chromium flags, or are running in environments that require custom sandbox settings.
+Use `ignoreDefaultArgs` to control which launch flags Stagehand and [chrome-launcher](https://github.com/GoogleChrome/chrome-launcher) inject. Stagehand adds its own defaults on top of chrome-launcher's:
+
+- `--remote-allow-origins=*`
+- `--no-first-run`
+- `--no-default-browser-check`
+- `--disable-dev-shm-usage`
+
+**Array** — exclude specific flags by name. Matching entries are removed from Stagehand's defaults above. chrome-launcher's built-in defaults are skipped, then every default *except* the listed flags is re-added. This is useful when you need extensions enabled:
 
 ```typescript
 import { Stagehand } from "@browserbasehq/stagehand";
@@ -276,7 +283,16 @@ const stagehand = new Stagehand({
 await stagehand.init();
 ```
 
-Set `ignoreDefaultArgs: true` to drop all chrome-launcher defaults. Stagehand's own flags and your `args` are still applied.
+**`true`** — drop *both* chrome-launcher defaults and Stagehand's default flags above. Your `args` and option-derived flags (for example `headless`, `chromiumSandbox: false`) are still applied. Re-add any Stagehand defaults you still need via `args`:
+
+```typescript
+localBrowserLaunchOptions: {
+  ignoreDefaultArgs: true,
+  args: ["--remote-allow-origins=*"], // opt back in if CDP connections require it
+},
+```
+
+**Omitted or `false`** — apply all Stagehand and chrome-launcher defaults.
 
 #### Site isolation and renderer limits
 

--- a/packages/evals/core/targets/localChrome.ts
+++ b/packages/evals/core/targets/localChrome.ts
@@ -118,7 +118,6 @@ export async function launchRunnerProvidedLocalChrome(): Promise<{
     "--no-first-run",
     "--no-default-browser-check",
     "--disable-dev-shm-usage",
-    "--site-per-process",
     `--remote-debugging-port=${port}`,
     `--user-data-dir=${userDataDir}`,
     "about:blank",

--- a/packages/evals/core/targets/localChrome.ts
+++ b/packages/evals/core/targets/localChrome.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { mkdtemp, rm } from "node:fs/promises";
 import { spawn, type ChildProcess } from "node:child_process";
+import { STAGEHAND_DEFAULT_FLAGS } from "@browserbasehq/stagehand";
 
 export function resolveLocalChromeExecutablePath(): string | undefined {
   const explicit = process.env.CHROME_PATH;
@@ -114,10 +115,7 @@ export async function launchRunnerProvidedLocalChrome(): Promise<{
   const userDataDir = await mkdtemp(path.join(os.tmpdir(), "stagehand-evals-"));
   const args = [
     "--headless=new",
-    "--remote-allow-origins=*",
-    "--no-first-run",
-    "--no-default-browser-check",
-    "--disable-dev-shm-usage",
+    ...STAGEHAND_DEFAULT_FLAGS,
     `--remote-debugging-port=${port}`,
     `--user-data-dir=${userDataDir}`,
     "about:blank",


### PR DESCRIPTION
# why

After removing the unconditional `--site-per-process` default, a few related gaps remained in the local launch path: `ignoreDefaultArgs` was undocumented, `chromiumSandbox: false` was documented but not wired, and evals duplicated Stagehand's default Chrome flags.

# what changed

- Document `ignoreDefaultArgs` and site-isolation/renderer-limit guidance in `browser.mdx`
- Wire `chromiumSandbox: false` into `launchLocalChrome`
- Extract `STAGEHAND_DEFAULT_FLAGS` and reuse it in evals' local Chrome launcher
- Add unit tests for sandbox flags and update export surface test

# test plan

- [x] `pnpm --filter @browserbasehq/stagehand exec vitest run dist/esm/tests/unit/launch-local-ignore-default-args.test.js` (15/15 passed)
- [x] `pnpm --filter @browserbasehq/stagehand exec vitest run dist/esm/tests/unit/public-api/export-surface.test.js` (62/62 passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix local Chrome launch to respect user flags and sandbox settings. Drops implicit --site-per-process, wires chromiumSandbox:false to add sandbox-disable flags, and clarifies docs for ignoreDefaultArgs and site isolation.

- **Bug Fixes**
  - Stop injecting --site-per-process so user --disable-features=site-per-process and --renderer-process-limit work as intended.
  - Map chromiumSandbox:false to --no-sandbox and --disable-setuid-sandbox.

- **Refactors**
  - Extract and export `STAGEHAND_DEFAULT_FLAGS` from `@browserbasehq/stagehand`; reuse in evals local launcher.
  - Update docs for ignoreDefaultArgs (true removes both chrome-launcher and Stagehand defaults) and site‑isolation/renderer‑limit; add unit tests for sandbox flags and export surface.

<sup>Written for commit c9e4757af6dce1b576034c777f1c5a16b7fcc81c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

