### PR TITLE
[STG-2192] fix(cli): make browse skills add failures diagnosable + fail cleanly on unknown skill

### DIFF
--- a/.changeset/skills-add-failure-telemetry.md
+++ b/.changeset/skills-add-failure-telemetry.md
@@ -1,0 +1,10 @@
+---
+"browse": patch
+---
+
+Make `browse skills add` failures diagnosable and fail cleanly on unknown skills.
+
+- Unknown (non-generated) skill ids now fail fast with an actionable "not found in the catalog" message pointing at `browse skills find`/`browse skills list`, instead of silently git-cloning the entire browse.sh repo and exiting with an opaque error.
+- The `npx skills add` child's output is now buffered (tail) while still streaming live to the terminal, so a nonzero exit surfaces the real reason instead of a bare exit code.
+- Failures now record distinct telemetry result codes (`skill_not_found`, `invalid_skill_id`, `npx_missing`, `skill_install_failed`) so the failure modes are measurable.
+- `browse skills add` with no argument now prints actionable guidance (the `<domain>/<task>` form plus `browse skills find`) instead of oclif's bare "Missing 1 required arg".

--- a/packages/cli/src/commands/skills/add.ts
+++ b/packages/cli/src/commands/skills/add.ts
@@ -1,6 +1,7 @@
 import { Args } from "@oclif/core";
 
 import { BrowseCommand } from "../../base.js";
+import { fail } from "../../lib/errors.js";
 import { installSkill } from "../../lib/skills/install.js";
 
 export default class SkillsAdd extends BrowseCommand {
@@ -12,17 +13,23 @@ export default class SkillsAdd extends BrowseCommand {
   ];
 
   static override args = {
+    // Intentionally optional so we can emit actionable guidance instead of
+    // oclif's bare "Missing 1 required arg" error.
     skill: Args.string({
-      required: true,
+      required: false,
       description: "Skill id in the form <domain>/<task>.",
     }),
   };
 
   async run(): Promise<void> {
     const { args } = await this.parse(SkillsAdd);
-    const exitCode = await installSkill(args.skill);
-    if (exitCode !== 0) {
-      this.exit(exitCode);
+    if (!args.skill) {
+      fail(
+        "Missing skill id. Pass a skill in the form <domain>/<task>, e.g. `browse skills add yelp.com/extract-reviews`. Run `browse skills find <query>` to discover skills.",
+        2,
+        { resultCode: "invalid_skill_id" },
+      );
     }
+    await installSkill(args.skill);
   }
 }

--- a/packages/cli/src/commands/skills/install.ts
+++ b/packages/cli/src/commands/skills/install.ts
@@ -7,9 +7,6 @@ export default class SkillsInstall extends BrowseCommand {
   static override examples = ["browse skills install"];
 
   async run(): Promise<void> {
-    const exitCode = await installBundledCliSkill();
-    if (exitCode !== 0) {
-      this.exit(exitCode);
-    }
+    await installBundledCliSkill();
   }
 }

--- a/packages/cli/src/lib/skills/install.ts
+++ b/packages/cli/src/lib/skills/install.ts
@@ -47,15 +47,36 @@ type SkillFilesApiResult =
       status: "not_found" | "unavailable";
     };
 
+type SkillFilesResult =
+  | {
+      status: "found";
+      files: SkillFileSource[];
+    }
+  | {
+      // The catalog responded with a definitive 404 for a non-generated id.
+      status: "not_found";
+    }
+  | {
+      // Either the API was unavailable or the id is suffix-shaped (generated)
+      // and may still resolve through the browse.sh GitHub clone fallback.
+      status: "fallback";
+    };
+
+const maxCapturedOutputBytes = 2048;
+
 export function parseSkillId(rawSkillId: string): ParsedSkillId {
   const parts = rawSkillId.split("/");
   if (parts.length !== 2) {
-    fail("Skill must be in the form <domain>/<task>.");
+    fail("Skill must be in the form <domain>/<task>.", 1, {
+      resultCode: "invalid_skill_id",
+    });
   }
 
   const [domain, task] = parts;
   if (!domain || !task) {
-    fail("Skill must be in the form <domain>/<task>.");
+    fail("Skill must be in the form <domain>/<task>.", 1, {
+      resultCode: "invalid_skill_id",
+    });
   }
 
   if (
@@ -67,7 +88,9 @@ export function parseSkillId(rawSkillId: string): ParsedSkillId {
     !domainPattern.test(domain) ||
     !taskPattern.test(task)
   ) {
-    fail(`Invalid skill id "${rawSkillId}". Use <domain>/<task>.`);
+    fail(`Invalid skill id "${rawSkillId}". Use <domain>/<task>.`, 1, {
+      resultCode: "invalid_skill_id",
+    });
   }
 
   return {
@@ -81,30 +104,43 @@ export function isBlobSkillId(skillId: ParsedSkillId): boolean {
   return generatedSkillSuffixPattern.test(skillId.task);
 }
 
-export async function installSkill(rawSkillId: string): Promise<number> {
+export async function installSkill(rawSkillId: string): Promise<void> {
   const skillId = parseSkillId(rawSkillId);
   const npxPath = await findExecutable("npx");
   if (!npxPath) {
     fail(
       "`npx` is not installed. Install Node.js from https://nodejs.org, then rerun `browse skills add`.",
+      1,
+      { resultCode: "npx_missing" },
     );
   }
 
   const files = await fetchSkillFiles(skillId);
-  if (files) {
-    const result = await downloadBlobSkill(skillId, files);
+  if (files.status === "found") {
+    const result = await downloadBlobSkill(skillId, files.files);
     process.stdout.write(
       `Downloaded ${result.fileCount} skill file${result.fileCount === 1 ? "" : "s"} to ${result.installPath}\n`,
     );
-    return await spawnPassthrough(npxPath, [
+    await runSkillsInstall(npxPath, [
       "--yes",
       "skills",
       "add",
       result.installPath,
     ]);
+    return;
   }
 
-  return await spawnPassthrough(npxPath, [
+  if (files.status === "not_found") {
+    fail(
+      `Skill "${skillId.id}" not found in the catalog. Run \`browse skills find ${skillId.domain}\` to discover available skills, or \`browse skills list\` to browse them.`,
+      1,
+      { resultCode: "skill_not_found" },
+    );
+  }
+
+  // Suffix-shaped (generated) ids, or a temporarily unavailable catalog, may
+  // still resolve through the browse.sh GitHub repo.
+  await runSkillsInstall(npxPath, [
     "--yes",
     "skills",
     "add",
@@ -114,15 +150,17 @@ export async function installSkill(rawSkillId: string): Promise<number> {
   ]);
 }
 
-export async function installBundledCliSkill(): Promise<number> {
+export async function installBundledCliSkill(): Promise<void> {
   const npxPath = await findExecutable("npx");
   if (!npxPath) {
     fail(
       "`npx` is not installed. Install Node.js from https://nodejs.org, then rerun `browse skills install`.",
+      1,
+      { resultCode: "npx_missing" },
     );
   }
 
-  return await spawnPassthrough(npxPath, [
+  await runSkillsInstall(npxPath, [
     "--yes",
     "skills",
     "add",
@@ -134,13 +172,38 @@ export async function installBundledCliSkill(): Promise<number> {
   ]);
 }
 
+// Runs `npx skills add ...` with live passthrough, but fails with a diagnostic
+// message (including a tail of the child's output) when the child exits nonzero
+// so the failure is recorded in telemetry instead of an opaque exit code.
+async function runSkillsInstall(
+  npxPath: string,
+  args: string[],
+): Promise<void> {
+  const result = await spawnPassthrough(npxPath, args);
+  if (result.exitCode === 0) {
+    return;
+  }
+
+  const detail = result.output.trim();
+  const reason = detail
+    ? `: ${detail}`
+    : " (see the output above for details).";
+  fail(`Could not install skill${reason}`, result.exitCode || 1, {
+    resultCode: "skill_install_failed",
+  });
+}
+
 export async function downloadBlobSkill(
   skillId: ParsedSkillId,
   files?: SkillFileSource[],
 ): Promise<BlobDownloadResult> {
-  const filesToDownload = files ?? (await fetchSkillFiles(skillId));
+  let filesToDownload = files;
   if (!filesToDownload) {
-    fail(`Skill ${skillId.id} was not found as a generated skill.`);
+    const resolved = await fetchSkillFiles(skillId);
+    if (resolved.status !== "found") {
+      fail(`Skill ${skillId.id} was not found as a generated skill.`);
+    }
+    filesToDownload = resolved.files;
   }
 
   const installPath = localSkillPath(skillId);
@@ -193,10 +256,10 @@ function packageRoot(): string {
 
 async function fetchSkillFiles(
   skillId: ParsedSkillId,
-): Promise<SkillFileSource[] | null> {
+): Promise<SkillFilesResult> {
   const apiResult = await fetchSkillFilesFromApi(skillId);
   if (apiResult.status === "found") {
-    return apiResult.files;
+    return { status: "found", files: apiResult.files };
   }
 
   if (
@@ -204,15 +267,26 @@ async function fetchSkillFiles(
     isBlobSkillId(skillId) &&
     (await directBlobSkillExists(skillId))
   ) {
-    return [
-      {
-        path: "SKILL.md",
-        url: skillBlobUrl(skillId, "SKILL.md"),
-      },
-    ];
+    return {
+      status: "found",
+      files: [
+        {
+          path: "SKILL.md",
+          url: skillBlobUrl(skillId, "SKILL.md"),
+        },
+      ],
+    };
   }
 
-  return null;
+  // Suffix-shaped ids correspond to generated catalog skills that live in the
+  // browse.sh repo even when the file API can't serve them directly, so keep
+  // the GitHub clone fallback for those. A plain 404 for a non-generated id is
+  // a definitive miss and should fail cleanly instead of cloning the repo.
+  if (apiResult.status === "not_found" && !isBlobSkillId(skillId)) {
+    return { status: "not_found" };
+  }
+
+  return { status: "fallback" };
 }
 
 async function fetchSkillFilesFromApi(
@@ -444,23 +518,47 @@ async function findExecutable(command: string): Promise<string | null> {
   return null;
 }
 
+interface SpawnPassthroughResult {
+  exitCode: number;
+  output: string;
+}
+
+// Like `stdio: "inherit"` for the human watching, but the child's stdout/stderr
+// are also buffered (tail only) so a nonzero exit can surface a real reason to
+// telemetry instead of a bare exit code.
 async function spawnPassthrough(
   command: string,
   args: string[],
-): Promise<number> {
-  return await new Promise<number>((resolvePromise, reject) => {
+): Promise<SpawnPassthroughResult> {
+  return await new Promise<SpawnPassthroughResult>((resolvePromise, reject) => {
     const child = spawn(command, args, {
-      stdio: "inherit",
+      stdio: ["inherit", "pipe", "pipe"],
       shell: shouldUseWindowsShell(command),
+    });
+
+    let captured = "";
+    const capture = (chunk: Buffer): void => {
+      captured += chunk.toString();
+      if (captured.length > maxCapturedOutputBytes) {
+        captured = captured.slice(-maxCapturedOutputBytes);
+      }
+    };
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      process.stdout.write(chunk);
+      capture(chunk);
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      process.stderr.write(chunk);
+      capture(chunk);
     });
 
     child.on("error", reject);
     child.on("close", (exitCode, signal) => {
-      if (signal) {
-        resolvePromise(1);
-        return;
-      }
-      resolvePromise(exitCode ?? 0);
+      resolvePromise({
+        exitCode: signal ? 1 : (exitCode ?? 0),
+        output: captured,
+      });
     });
   });
 }

--- a/packages/cli/src/lib/skills/install.ts
+++ b/packages/cli/src/lib/skills/install.ts
@@ -530,7 +530,7 @@ async function spawnPassthrough(
   command: string,
   args: string[],
 ): Promise<SpawnPassthroughResult> {
-  return await new Promise<SpawnPassthroughResult>((resolvePromise, reject) => {
+  return await new Promise<SpawnPassthroughResult>((resolvePromise) => {
     const child = spawn(command, args, {
       stdio: ["inherit", "pipe", "pipe"],
       shell: shouldUseWindowsShell(command),
@@ -553,7 +553,16 @@ async function spawnPassthrough(
       capture(chunk);
     });
 
-    child.on("error", reject);
+    // Resolve (not reject) on spawn errors so the failure is classified as
+    // `skill_install_failed` by runSkillsInstall instead of escaping as an
+    // unclassified runtime error.
+    child.on("error", (error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      resolvePromise({
+        exitCode: 1,
+        output: captured ? `${captured}\n${message}` : message,
+      });
+    });
     child.on("close", (exitCode, signal) => {
       resolvePromise({
         exitCode: signal ? 1 : (exitCode ?? 0),

--- a/packages/cli/tests/skills.test.ts
+++ b/packages/cli/tests/skills.test.ts
@@ -298,24 +298,33 @@ describe("skills", () => {
     );
   });
 
-  it("installs catalog skills from GitHub", async () => {
-    const stubDir = await createTempDir("browse-skills-github-bin-");
+  it("fails cleanly when a non-generated skill is missing from the catalog", async () => {
+    const stubDir = await createTempDir("browse-skills-missing-bin-");
     const logPath = join(stubDir, "npx.log");
     await writeNpxStub(stubDir, logPath);
+    // Empty server: the file API returns 404 for the requested id.
     const { server, baseUrl } = await startFakeSkillServer({});
     cleanupServers.push(server);
 
-    const result = await runCli(["skills", "add", "yelp.com/extract-reviews"], {
-      env: {
-        BROWSE_SKILLS_API_BASE_URL: baseUrl,
-        PATH: stubDir,
+    const result = await runCli(
+      ["skills", "add", "amazon.com/buy-something-fake"],
+      {
+        env: {
+          BROWSE_SKILLS_API_BASE_URL: baseUrl,
+          PATH: stubDir,
+        },
       },
-    });
-
-    expect(result.exitCode).toBe(0);
-    await expect(readFile(logPath, "utf8")).resolves.toContain(
-      "--yes skills add browserbase/browse.sh --skill yelp.com/extract-reviews",
     );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain(
+      'Skill "amazon.com/buy-something-fake" not found in the catalog',
+    );
+    expect(result.stderr).toContain("browse skills find amazon.com");
+    // It must NOT have shelled out to clone the browse.sh repo.
+    await expect(
+      readFile(logPath, "utf8").catch(() => ""),
+    ).resolves.not.toContain("browserbase/browse.sh");
   });
 
   it("installs suffix-shaped catalog skills from GitHub when the file API returns 404", async () => {
@@ -502,6 +511,15 @@ describe("skills", () => {
 
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain("Invalid skill id");
+  });
+
+  it("guides the user when the skill id is missing", async () => {
+    const result = await runCli(["skills", "add"]);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain("Missing skill id");
+    expect(result.stderr).toContain("<domain>/<task>");
+    expect(result.stderr).toContain("browse skills find");
   });
 
   it("rejects unsafe API file paths", async () => {


### PR DESCRIPTION
## Summary

`browse skills add <domain>/<task>` fails for a large share of users with an opaque `EEXIT 1` and no diagnostic detail. Root cause: when the catalog file API returns 404, the CLI silently fell back to git-cloning the **entire** browse.sh repo, found no matching skill, printed "No matching skills found" and exited 1 — and because the child was spawned with `stdio: "inherit"`, the real error text was never captured, so telemetry recorded a bare numeric exit code.

This PR makes those failures **measurable** and **friendlier**:

- **Capture child output.** `spawnPassthrough` now pipes + echoes the `npx skills add` child's stdout/stderr to the terminal (live UX preserved) while buffering the last ~2KB. On a nonzero exit, that tail flows into the error message and telemetry instead of a bare exit code.
- **Fail cleanly on unknown skills.** A definitive 404 for a non-generated id now fails fast with an actionable message (`Skill "<id>" not found in the catalog. Run \`browse skills find <domain>\` ...`) — no more cloning the whole repo. Suffix-shaped (generated) ids and unavailable-catalog cases keep the browse.sh clone fallback (still covered by existing tests).
- **Distinct telemetry result codes:** `skill_not_found`, `invalid_skill_id`, `npx_missing`, `skill_install_failed`.
- **Better missing-arg UX.** `browse skills add` with no arg now prints guidance pointing at the `<domain>/<task>` form and `browse skills find`, instead of oclif's bare "Missing 1 required arg".

`result_code` was already wired through `base.ts` → `recordCommandError` → `commandCompletedProperties`; the gap was that the failing paths never set a meaningful code (they returned a numeric exit that surfaced as a generic oclif usage error). This PR routes each failure through `fail(msg, exitCode, { resultCode })` so the codes are populated.

Linear: https://linear.app/browserbase/issue/STG-2192

## E2E Test Matrix

Run against the locally built `browse` (`node packages/cli/bin/run.js`) with a local PostHog capture server (`BROWSERBASE_TELEMETRY_HOST=http://127.0.0.1:<port>`). result_code values are the real captured `cli.command_completed` properties.

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `browse skills add amazon.com/buy-something-fake` (hits real browse.sh, 404) | exit 1; stderr: `Skill "amazon.com/buy-something-fake" not found in the catalog. Run \`browse skills find amazon.com\` ...`; telemetry `result_code=skill_not_found`, `error_type=runtime`; **no git clone** | Proves the core fix: clean message + distinct code, no opaque clone. Hits the live API. |
| `browse skills add` (no arg) | exit 2; stderr: `Missing skill id. Pass a skill in the form <domain>/<task>, e.g. \`browse skills add yelp.com/extract-reviews\`. Run \`browse skills find <query>\` ...`; telemetry `result_code=invalid_skill_id` | Proves the improved missing-arg UX + code. |
| `browse skills add ../bad` | exit 1; stderr: `Invalid skill id "../bad". Use <domain>/<task>.`; telemetry `result_code=invalid_skill_id` | Proves parse-failure code wiring. |
| `browse skills add yelp.com/extract-reviews-2ikb22` with stub `npx` exiting 7 | exit 7; live stderr `npx says: simulated registry boom` passed through; `fail()` message `Could not install skill: npx says: simulated registry boom`; telemetry `result_code=skill_install_failed`, `success=false` | Proves child output is captured (not discarded) AND flows into telemetry with the correct code while exit code is preserved. |
| `browse skills add yelp.com/extract-reviews-2ikb22` (real npx, isolated `HOME`/`XDG_CONFIG_HOME`) | `Downloaded 1 skill file to <temp>/browserbase/skills/yelp.com/extract-reviews-2ikb22` (SKILL.md present); `npx skills add <localpath>` then failed only due to this machine's unreachable npm registry mirror (`socket-firewall...` ENOTFOUND) — surfaced via the new `skill_install_failed` path | Proves the real browse.sh download stage works end-to-end against the live API; the `npx skills add <localpath>` step is independently covered by the passing vitest stub test. |
| `pnpm --filter browse test` (vitest) | 210 passed (15 files), incl. new `skill_not_found` and missing-arg tests | Full suite green, no happy-path regression (download test still asserts `--yes skills add <installPath>`). |
| `pnpm --filter browse lint` (prettier + eslint + tsc) | clean | Supporting: format/lint/typecheck pass. |

## Changeset

`.changeset/skills-add-failure-telemetry.md` → `"browse": patch` (consumed by the dedicated `release-cli.yml` CLI release flow, which scans for `"browse"` changesets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves `browse skills add <domain>/<task>` with clear, actionable errors and measurable telemetry, and stops cloning the entire repo on unknown skills. Addresses Linear STG-2192.

- **Bug Fixes**
  - Streams and buffers the last ~2KB of `npx skills add` output; on nonzero exit or spawn errors, includes the tail/OS error in the message and telemetry as `skill_install_failed`.
  - Treats catalog 404s for non-generated IDs as a clean failure with guidance (e.g., use `browse skills find <domain>`), avoiding cloning `browserbase/browse.sh`.
  - Keeps GitHub fallback for suffix-shaped IDs or when the catalog API is unavailable.
  - Adds distinct telemetry result codes: `skill_not_found`, `invalid_skill_id`, `npx_missing`, `skill_install_failed`.
  - Replaces the generic missing-arg error with guidance on `<domain>/<task>` and `browse skills find`.

<sup>Written for commit 84d9040cc22c5776e045a9b497f1ef7722f12d68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

