### PR TITLE
[STG-2145] Update MCP docs for bearer auth

### DIFF
--- a/packages/docs/v2/integrations/mcp/setup.mdx
+++ b/packages/docs/v2/integrations/mcp/setup.mdx
@@ -6,11 +6,11 @@ description: "Add the Browserbase MCP Server to your MCP client"
 
 ## Quick Installation
 
-<Card title="Install with Cursor" icon="arrow-pointer" href="cursor://anysphere.cursor-deeplink/mcp/install?name=browserbase&config=eyJ1cmwiOiJodHRwczovL21jcC5icm93c2VyYmFzZS5jb20vbWNwP2Jyb3dzZXJiYXNlQXBpS2V5PVlPVVJfQlJPV1NFUkJBU0VfQVBJX0tFWSJ9">
+<Card title="Install with Cursor" icon="arrow-pointer" href="cursor://anysphere.cursor-deeplink/mcp/install?name=browserbase&config=eyJ1cmwiOiJodHRwczovL21jcC5icm93c2VyYmFzZS5jb20vbWNwIiwiaGVhZGVycyI6eyJBdXRob3JpemF0aW9uIjoiQmVhcmVyIFlPVVJfQlJPV1NFUkJBU0VfQVBJX0tFWSJ9fQ==">
   One-click installation directly in Cursor
 </Card>
 
-You can also add Browserbase MCP to Claude Code with a single command:
+You can also add Browserbase MCP to Claude Code with a single command. If your client supports HTTP request headers, prefer `Authorization: Bearer YOUR_BROWSERBASE_API_KEY`; otherwise, use the legacy query-parameter fallback:
 
 ```bash
 claude mcp add --transport http browserbase "https://mcp.browserbase.com/mcp?browserbaseApiKey=YOUR_BROWSERBASE_API_KEY"
@@ -40,15 +40,21 @@ Then copy your API Key directly from the input.
 </Step>
 </Steps>
 
-## Query Parameters (Hosted [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http))
+## Authentication and Query Parameters (Hosted [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http))
 
 ### Required for tool calls
 
 <CardGroup cols={1}>
-<Card title="browserbaseApiKey" icon="key">
-Browserbase API key.
+<Card title="Authorization" icon="key">
+Pass your Browserbase API key as an HTTP authorization header: `Authorization: Bearer YOUR_BROWSERBASE_API_KEY`.
 </Card>
 </CardGroup>
+
+<Note>
+  The hosted server also accepts `x-bb-api-key: YOUR_BROWSERBASE_API_KEY`.
+  The `browserbaseApiKey` query parameter remains supported as a deprecated
+  compatibility fallback for clients that cannot set request headers.
+</Note>
 
 ### Optional
 
@@ -146,7 +152,10 @@ Use your MCP client config:
 {
   "mcpServers": {
     "browserbase": {
-      "url": "https://mcp.browserbase.com/mcp?browserbaseApiKey=YOUR_BROWSERBASE_API_KEY"
+      "url": "https://mcp.browserbase.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_BROWSERBASE_API_KEY"
+      }
     }
   }
 }
@@ -158,7 +167,10 @@ For custom models, include `modelName` and `modelApiKey`:
 {
   "mcpServers": {
     "browserbase": {
-      "url": "https://mcp.browserbase.com/mcp?browserbaseApiKey=YOUR_BROWSERBASE_API_KEY&modelName=openai/gpt-4.1&modelApiKey=YOUR_MODEL_API_KEY"
+      "url": "https://mcp.browserbase.com/mcp?modelName=openai/gpt-4.1&modelApiKey=YOUR_MODEL_API_KEY",
+      "headers": {
+        "Authorization": "Bearer YOUR_BROWSERBASE_API_KEY"
+      }
     }
   }
 }

--- a/packages/docs/v3/integrations/mcp/setup.mdx
+++ b/packages/docs/v3/integrations/mcp/setup.mdx
@@ -9,11 +9,11 @@ import { V3Banner } from '/snippets/v3-banner.mdx';
 
 ## Quick Installation
 
-<Card title="Install with Cursor" icon="arrow-pointer" href="cursor://anysphere.cursor-deeplink/mcp/install?name=browserbase&config=eyJ1cmwiOiJodHRwczovL21jcC5icm93c2VyYmFzZS5jb20vbWNwP2Jyb3dzZXJiYXNlQXBpS2V5PVlPVVJfQlJPV1NFUkJBU0VfQVBJX0tFWSJ9">
+<Card title="Install with Cursor" icon="arrow-pointer" href="cursor://anysphere.cursor-deeplink/mcp/install?name=browserbase&config=eyJ1cmwiOiJodHRwczovL21jcC5icm93c2VyYmFzZS5jb20vbWNwIiwiaGVhZGVycyI6eyJBdXRob3JpemF0aW9uIjoiQmVhcmVyIFlPVVJfQlJPV1NFUkJBU0VfQVBJX0tFWSJ9fQ==">
   One-click installation directly in Cursor
 </Card>
 
-You can also add Browserbase MCP to Claude Code with a single command:
+You can also add Browserbase MCP to Claude Code with a single command. If your client supports HTTP request headers, prefer `Authorization: Bearer YOUR_BROWSERBASE_API_KEY`; otherwise, use the legacy query-parameter fallback:
 
 ```bash
 claude mcp add --transport http browserbase "https://mcp.browserbase.com/mcp?browserbaseApiKey=YOUR_BROWSERBASE_API_KEY"
@@ -43,15 +43,21 @@ Then copy your API Key directly from the input.
 </Step>
 </Steps>
 
-## Query Parameters (Hosted [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http))
+## Authentication and Query Parameters (Hosted [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http))
 
 ### Required for tool calls
 
 <CardGroup cols={1}>
-<Card title="browserbaseApiKey" icon="key">
-Browserbase API key.
+<Card title="Authorization" icon="key">
+Pass your Browserbase API key as an HTTP authorization header: `Authorization: Bearer YOUR_BROWSERBASE_API_KEY`.
 </Card>
 </CardGroup>
+
+<Note>
+  The hosted server also accepts `x-bb-api-key: YOUR_BROWSERBASE_API_KEY`.
+  The `browserbaseApiKey` query parameter remains supported as a deprecated
+  compatibility fallback for clients that cannot set request headers.
+</Note>
 
 ### Optional
 
@@ -151,7 +157,10 @@ Use your MCP client config:
 {
   "mcpServers": {
     "browserbase": {
-      "url": "https://mcp.browserbase.com/mcp?browserbaseApiKey=YOUR_BROWSERBASE_API_KEY"
+      "url": "https://mcp.browserbase.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_BROWSERBASE_API_KEY"
+      }
     }
   }
 }
@@ -163,7 +172,10 @@ For custom models, include `modelName` and `modelApiKey`:
 {
   "mcpServers": {
     "browserbase": {
-      "url": "https://mcp.browserbase.com/mcp?browserbaseApiKey=YOUR_BROWSERBASE_API_KEY&modelName=openai/gpt-4.1&modelApiKey=YOUR_MODEL_API_KEY"
+      "url": "https://mcp.browserbase.com/mcp?modelName=openai/gpt-4.1&modelApiKey=YOUR_MODEL_API_KEY",
+      "headers": {
+        "Authorization": "Bearer YOUR_BROWSERBASE_API_KEY"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Update hosted Browserbase MCP setup docs to prefer `Authorization: Bearer <Browserbase API key>`
- Keep `browserbaseApiKey` query-param auth documented as a deprecated compatibility fallback
- Update v2 and v3 docs examples so hosted URLs no longer put the Browserbase API key in the URL by default

## Validation
- `pnpm exec prettier packages/docs/v2/integrations/mcp/setup.mdx packages/docs/v3/integrations/mcp/setup.mdx --check`

## Related
- Companion Core implementation PR: https://github.com/browserbase/core/pull/9653


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates MCP setup docs (v2 and v3) to prefer header-based auth for the hosted Browserbase MCP. Addresses STG-2145; examples and one-click install now use `Authorization: Bearer <key>`, with `browserbaseApiKey` kept as a deprecated fallback.

- **Migration**
  - Use `https://mcp.browserbase.com/mcp` and set `Authorization: Bearer YOUR_BROWSERBASE_API_KEY` (or `x-bb-api-key`).
  - Keep `modelName` and `modelApiKey` in the URL if needed; put Browserbase auth in headers.
  - Legacy `?browserbaseApiKey=...` remains supported for clients without header support.

<sup>Written for commit d5bfee5e8016ec74c04898939bbd4f203f9e4eaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

