### PR TITLE
[STG-2183] fix(cli): list full template catalog (send scope=all)

### DIFF
--- a/.changeset/cli-templates-scope-all.md
+++ b/.changeset/cli-templates-scope-all.md
@@ -1,0 +1,5 @@
+---
+"browse": patch
+---
+
+fix(cli): request the full template catalog via scope=all so `browse templates list` returns all templates, not just playground-runnable ones

--- a/packages/cli/src/lib/templates/api.ts
+++ b/packages/cli/src/lib/templates/api.ts
@@ -21,13 +21,20 @@ export interface ListTemplatesOptions {
   tag?: string;
 }
 
+interface TemplatesApiParams extends ListTemplatesOptions {
+  scope?: string;
+}
+
 export type TemplateLanguage = "typescript" | "python";
 
 export async function listTemplates(
   options: ListTemplatesOptions = {},
 ): Promise<Template[]> {
   const payload = await requestTemplatesJson(
-    templatesApiUrl(undefined, options),
+    // The CLI always requests the full template catalog. The templates API defaults to
+    // returning only `playgroundRunnable` templates — a website-playground concept that
+    // does not apply to the CLI — so we always opt out via `scope=all`.
+    templatesApiUrl(undefined, { ...options, scope: "all" }),
   );
   return parseTemplatesResponse(payload);
 }
@@ -50,10 +57,7 @@ export async function getTemplateIfExists(
   return parseTemplateResponse(payload, slug);
 }
 
-function templatesApiUrl(
-  path?: string,
-  params: ListTemplatesOptions = {},
-): URL {
+function templatesApiUrl(path?: string, params: TemplatesApiParams = {}): URL {
   const baseUrl =
     process.env.BROWSERBASE_TEMPLATES_API ?? defaultTemplatesApiUrl;
   const url = path

--- a/packages/cli/tests/cli-templates.test.ts
+++ b/packages/cli/tests/cli-templates.test.ts
@@ -86,7 +86,7 @@ describe("templates commands", () => {
       expect(result.exitCode).toBe(0);
       expect(requests).toHaveLength(1);
       expect(requests[0]?.method).toBe("GET");
-      expect(requests[0]?.path).toBe("/");
+      expect(requests[0]?.path).toBe("/?scope=all");
       expect(result.stdout).toContain("Template");
       expect(result.stdout).toContain("Title");
       expect(result.stdout).toContain("Source");
@@ -210,7 +210,10 @@ describe("templates commands", () => {
       );
 
       expect(result.exitCode).toBe(0);
-      expect(requests.map((request) => request.path)).toEqual(["/amazon", "/"]);
+      expect(requests.map((request) => request.path)).toEqual([
+        "/amazon",
+        "/?scope=all",
+      ]);
       expect(result.stdout).toContain('Templates matching "amazon" (1)');
       expect(result.stdout).toContain("Template");
       expect(result.stdout).toContain("amazon-product-scraping");


### PR DESCRIPTION
## Summary

Ports **STG-2183** from the deprecated [`browserbase/cli#140`](https://github.com/browserbase/cli/pull/140) into the monorepo (`packages/cli`), now that `browserbase/cli` is deprecated.

The website PR [browserbase/browserbase-website#169](https://github.com/browserbase/browserbase-website/pull/169) (merged) added a `?scope=all` query param to `GET /api/templates` that returns the full template catalog. The default response still returns only the 12 `playgroundRunnable` templates — a website-playground concept that does not apply to the CLI. Previously `browse templates list` sent no scope param, so it only ever showed those 12. This change makes the CLI always request the full catalog via `scope=all`.

## Changes

- `packages/cli/src/lib/templates/api.ts`: add `TemplatesApiParams` (extends `ListTemplatesOptions` with `scope?`), inject `scope: "all"` in `listTemplates()`, and widen `templatesApiUrl`'s `params` type.
- `packages/cli/tests/cli-templates.test.ts`: update the recorded request paths to `/?scope=all` for the `templates list` and `templates find amazon` cases.
- Changeset (`browse` patch): published CLI runtime behavior change.

`find.ts` calls `listTemplates()` with no args, so it inherits `scope=all` automatically. The `[slug]` route (`getTemplateIfExists`) is untouched — matching the website side. Default API behavior is unchanged.

## E2E Test Matrix

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `npx vitest run tests/cli-templates.test.ts` (against local build) | `Test Files 1 passed (1)` / `Tests 12 passed (12)` | Proves the CLI now sends `scope=all` and all templates behavior (list/find/clone/JSON) still passes. |
| `pnpm check` (tsc --noEmit) | clean, no errors | Type-safety of the new `TemplatesApiParams` type and call sites. |
| `eslint src/lib/templates/api.ts tests/cli-templates.test.ts` | exit 0, no warnings | Lint clean on changed files. |
| `node bin/run.js templates list --json \| jq '.templates \| length'` (local build, live API) | `41` | The local CLI build hits prod and gets the FULL catalog (was 12 before). |
| `curl -s 'https://www.browserbase.com/api/templates' \| jq '.templates\|length'` | `12` | Live default API still returns only playground-runnable templates. |
| `curl -s 'https://www.browserbase.com/api/templates?scope=all' \| jq '.templates\|length'` | `41` | Live API with `scope=all` returns the full catalog — matches the CLI output exactly. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always request the full template catalog in the CLI by sending scope=all to /api/templates, so list/find show all templates instead of the 12 playground-only ones. Addresses STG-2183.

- **Bug Fixes**
  - Send `scope=all` in `listTemplates()`; `find` inherits this; `[slug]` route unchanged.
  - Added `TemplatesApiParams` and widened `templatesApiUrl` param type.
  - Updated tests to expect `/?scope=all`; added a patch changeset for `browse`.

<sup>Written for commit 4a4739197eba82f532663390d3ffd95230564d8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

