### PR TITLE
[chore]: use allowlist for published files

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,10 +46,15 @@
     "lint": "cd ../.. && prettier --check packages/core && cd packages/core && pnpm run eslint && pnpm run typecheck"
   },
   "files": [
-    "dist/esm",
-    "dist/cjs",
-    "!dist/esm/tests",
-    "!dist/cjs/tests"
+    "dist/esm/index.d.ts",
+    "dist/esm/index.js",
+    "dist/esm/lib",
+    "dist/esm/package.json",
+    "dist/cjs/cli.js",
+    "dist/cjs/index.d.ts",
+    "dist/cjs/index.js",
+    "dist/cjs/lib",
+    "dist/cjs/package.json"
   ],
   "keywords": [
     "ai",


### PR DESCRIPTION
# why
- the previous file pattern negations (in this PR #2122) worked for npm publish, but not pnpm publish
- this means test files were leaking into the published package
# what changed
- used file allow list instead of specific negations
# test plan
- tested with pnpm pack & npm pack