### PR TITLE
[chore]: enable branch installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,20 @@ cp .env.example .env
 nano .env # Edit the .env file to add API keys
 ```
 
+### Installing from a branch
+
+To install Stagehand directly from a GitHub branch, install the core package subdirectory:
+
+```bash
+pnpm add "github:browserbase/stagehand#<branchName>&path:/packages/core"
+```
+
+Or set it in your project's `package.json`:
+
+```json
+"@browserbasehq/stagehand": "github:browserbase/stagehand#<branchName>&path:/packages/core"
+```
+
 ## Contributing
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -125,16 +125,6 @@ cp .env.example .env
 nano .env # Edit the .env file to add API keys
 ```
 
-### Installing from a branch
-
-You can install and build Stagehand directly from a github branch using [gitpkg](https://github.com/EqualMa/gitpkg)
-
-In your project's `package.json` set:
-```json
-"@browserbasehq/stagehand": "https://gitpkg.now.sh/browserbase/stagehand/packages/core?<branchName>",
-```
-
-
 ## Contributing
 
 > [!NOTE]

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -124,6 +124,20 @@ cp .env.example .env
 nano .env # Edit the .env file to add API keys
 ```
 
+### Installing from a branch
+
+To install Stagehand directly from a GitHub branch, install the core package subdirectory:
+
+```bash
+pnpm add "github:browserbase/stagehand#<branchName>&path:/packages/core"
+```
+
+Or set it in your project's `package.json`:
+
+```json
+"@browserbasehq/stagehand": "github:browserbase/stagehand#<branchName>&path:/packages/core"
+```
+
 ## Contributing
 
 > [!NOTE]

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -124,16 +124,6 @@ cp .env.example .env
 nano .env # Edit the .env file to add API keys
 ```
 
-### Installing from a branch
-
-You can install and build Stagehand directly from a github branch using [gitpkg](https://github.com/EqualMa/gitpkg)
-
-In your project's `package.json` set:
-
-```json
-"@browserbasehq/stagehand": "https://gitpkg.now.sh/browserbase/stagehand/packages/core?<branchName>",
-```
-
 ## Contributing
 
 > [!NOTE]

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,7 +36,7 @@
     "build:cjs": "tsx scripts/build-cjs.ts",
     "build:esm": "tsx scripts/build-esm.ts",
     "build": "pnpm --filter @browserbasehq/stagehand run --parallel \"/^build:(esm|cjs)$/\"",
-    "prepack": "pnpm build",
+    "prepack": "pnpm -w --dir ../.. exec turbo run build --filter=@browserbasehq/stagehand",
     "example": "node --import tsx -e \"const args=process.argv.slice(1).filter(a=>a!=='--'); const [p]=args; const n=(p||'example').replace(/^\\.\\//,'').replace(/\\.ts$/i,''); import('node:path').then(path=>import(new URL(path.resolve('examples', n + '.ts'), 'file:')));\" --",
     "test": "pnpm -w --dir ../.. exec turbo run test:core test:e2e --filter=@browserbasehq/stagehand --",
     "test:core": "tsx scripts/test-core.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,6 +36,7 @@
     "build:cjs": "tsx scripts/build-cjs.ts",
     "build:esm": "tsx scripts/build-esm.ts",
     "build": "pnpm --filter @browserbasehq/stagehand run --parallel \"/^build:(esm|cjs)$/\"",
+    "prepack": "pnpm build",
     "example": "node --import tsx -e \"const args=process.argv.slice(1).filter(a=>a!=='--'); const [p]=args; const n=(p||'example').replace(/^\\.\\//,'').replace(/\\.ts$/i,''); import('node:path').then(path=>import(new URL(path.resolve('examples', n + '.ts'), 'file:')));\" --",
     "test": "pnpm -w --dir ../.. exec turbo run test:core test:e2e --filter=@browserbasehq/stagehand --",
     "test:core": "tsx scripts/test-core.ts",


### PR DESCRIPTION
# why
- branch installs were not working for the monorepo
# what changed
- added a prepack step so that the core package can be built when installing from a branch
- updated the incorrect branch install instructions
# test plan
- tested by installing from this branch

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables installing `@browserbasehq/stagehand` from GitHub branches in the monorepo by building the core package during pack and correcting the branch install docs.

- **Bug Fixes**
  - Added `prepack` in `packages/core/package.json` to build core when installed from a branch.
  - Updated branch install instructions to use `github:browserbase/stagehand#<branch>&path:/packages/core` (works via pnpm or `package.json`).

<sup>Written for commit 5ad6d434b619c4eaec08a16a856d9f61fbd0ee5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

