### PR TITLE
[codex] Fix shadow XPath selector resolution

### DIFF
--- a/packages/core/lib/v3/dom/locatorScripts/xpathResolver.ts
+++ b/packages/core/lib/v3/dom/locatorScripts/xpathResolver.ts
@@ -53,7 +53,15 @@ export function resolveXPathAtIndex(
   }
 
   const composed = resolveXPathComposedMatches(xp, shadowCtx.getClosedRoot);
-  return composed[targetIndex] ?? null;
+  if (composed[targetIndex]) {
+    return composed[targetIndex] ?? null;
+  }
+
+  const shadowHopMatches = resolveXPathShadowHopMatches(
+    xp,
+    shadowCtx.getClosedRoot,
+  );
+  return shadowHopMatches[targetIndex] ?? null;
 }
 
 export function countXPathMatches(
@@ -76,7 +84,13 @@ export function countXPathMatches(
     return resolveXPathComposedMatches(xp, shadowCtx?.getClosedRoot).length;
   }
 
-  return resolveXPathComposedMatches(xp, shadowCtx.getClosedRoot).length;
+  const composedCount = resolveXPathComposedMatches(
+    xp,
+    shadowCtx.getClosedRoot,
+  ).length;
+  if (composedCount > 0) return composedCount;
+
+  return resolveXPathShadowHopMatches(xp, shadowCtx.getClosedRoot).length;
 }
 
 export function resolveXPathComposedMatches(
@@ -105,6 +119,58 @@ export function resolveXPathComposedMatches(
         step.axis === "child"
           ? composedChildren(root, closedRoot)
           : composedDescendants(root, closedRoot);
+      if (!pool.length) continue;
+
+      const tagMatches = pool.filter((candidate) =>
+        matchesTag(candidate, step),
+      );
+      const matches = applyPredicates(tagMatches, step.predicates);
+
+      for (const candidate of matches) {
+        if (!seen.has(candidate)) {
+          seen.add(candidate);
+          next.push(candidate);
+        }
+      }
+    }
+
+    if (!next.length) return [];
+    current = next;
+  }
+
+  return current as Element[];
+}
+
+function resolveXPathShadowHopMatches(
+  rawXp: string,
+  getClosedRoot?: ClosedRootGetter | null,
+): Element[] {
+  const xp = normalizeXPath(rawXp);
+  if (!xp) return [];
+
+  const steps = parseXPathSteps(xp);
+  if (!steps.some((step, index) => step.axis === "desc" && index > 0)) {
+    return [];
+  }
+
+  const closedRoot = getClosedRoot ?? null;
+  let current: Array<Document | Element | ShadowRoot | DocumentFragment> = [
+    document,
+  ];
+
+  for (let i = 0; i < steps.length; i += 1) {
+    const step = steps[i]!;
+    const next: Element[] = [];
+    const seen = new Set<Element>();
+
+    for (const root of current) {
+      if (!root) continue;
+      const pool =
+        step.axis === "child"
+          ? lightDomChildren(root)
+          : i === 0
+            ? composedDescendants(root, closedRoot)
+            : shadowRootChildren(root, closedRoot);
       if (!pool.length) continue;
 
       const tagMatches = pool.filter((candidate) =>
@@ -202,6 +268,45 @@ function composedChildren(
       if (closed) out.push(...Array.from(closed.children ?? []));
     }
     return out;
+  }
+
+  return out;
+}
+
+function lightDomChildren(node: Node | null | undefined): Element[] {
+  const out: Element[] = [];
+  if (!node) return out;
+
+  if (node instanceof Document) {
+    if (node.documentElement) out.push(node.documentElement);
+    return out;
+  }
+
+  if (node instanceof ShadowRoot || node instanceof DocumentFragment) {
+    out.push(...Array.from(node.children ?? []));
+    return out;
+  }
+
+  if (node instanceof Element) {
+    out.push(...Array.from(node.children ?? []));
+    return out;
+  }
+
+  return out;
+}
+
+function shadowRootChildren(
+  node: Node | null | undefined,
+  getClosedRoot: ClosedRootGetter | null,
+): Element[] {
+  const out: Element[] = [];
+  if (!(node instanceof Element)) return out;
+
+  const open = node.shadowRoot;
+  if (open) out.push(...Array.from(open.children ?? []));
+  if (getClosedRoot) {
+    const closed = getClosedRoot(node);
+    if (closed) out.push(...Array.from(closed.children ?? []));
   }
 
   return out;

--- a/packages/core/tests/unit/xpath-resolver.test.ts
+++ b/packages/core/tests/unit/xpath-resolver.test.ts
@@ -102,4 +102,43 @@ describe("xpathResolver composed traversal", () => {
     expect(resolveXPathAtIndex("//div", 2)?.id).toBe("shadow-2");
     expect(resolveXPathAtIndex("//div", 3)?.id).toBe("light-2");
   });
+
+  it("resolves Stagehand shadow-hop paths when the host has light DOM children", () => {
+    document.body.innerHTML =
+      '<shadow-host id="host"><div id="light-child"></div></shadow-host>';
+
+    const host = document.getElementById("host") as HTMLElement;
+    const shadow = host.attachShadow({ mode: "open" });
+    shadow.innerHTML =
+      '<div id="shadow-wrapper"><div><select id="target"></select></div></div>';
+
+    const selector = "/html[1]/body[1]/shadow-host[1]//div[1]/div[1]/select[1]";
+
+    expect(countXPathMatches(selector)).toBe(1);
+    expect(resolveXPathAtIndex(selector, 0)?.id).toBe("target");
+  });
+
+  it("falls back to descendant-axis XPath when non-leading // is not a shadow hop", () => {
+    document.body.innerHTML =
+      "<section><article><button id='target'>Go</button></article></section>";
+
+    const selector = "/html[1]/body[1]/section[1]//button[1]";
+
+    expect(countXPathMatches(selector)).toBe(1);
+    expect(resolveXPathAtIndex(selector, 0)?.id).toBe("target");
+  });
+
+  it("preserves descendant-axis matches before trying shadow-hop fallback", () => {
+    document.body.innerHTML =
+      "<section><article><button id='light-target'>Go</button></article></section>";
+
+    const section = document.querySelector("section") as HTMLElement;
+    const shadow = section.attachShadow({ mode: "open" });
+    shadow.innerHTML = "<button id='shadow-target'>Shadow</button>";
+
+    const selector = "/html[1]/body[1]/section[1]//button[1]";
+
+    expect(countXPathMatches(selector)).toBe(1);
+    expect(resolveXPathAtIndex(selector, 0)?.id).toBe("light-target");
+  });
 });


### PR DESCRIPTION
# why

Before this PR, if we passed a Stagehand shadow-hop selector like `/html[1]/body[1]/shadow-host[1]//div[1]/div[1]/select[1]` for a host that also had a light-DOM `<div>`, `countXPathMatches` returned `0` and `resolveXPathAtIndex` returned `null`. That made deterministic dropdown actions like `selectOptionFromDropdown` fail with element-not-found even though the shadow-root `<select>` existed.

This matters because Stagehand-generated selectors use non-leading `//` to enter shadow roots, including form controls inside web components.

# what changed

Added a regression test that proves that old behavior: the selector above should resolve to the shadow-root `<select id="target">`. Then changed the XPath resolver so it first preserves the existing composed traversal result, but if that finds nothing, it treats non-leading `//` as a Stagehand shadow-root hop through open or closed shadow-root children. With the same selector now, `countXPathMatches` returns `1` and `resolveXPathAtIndex` returns `#target`.

# test plan

- `pnpm --filter @browserbasehq/stagehand run lint`
- `pnpm --filter @browserbasehq/stagehand run build-dom-scripts && pnpm --filter @browserbasehq/stagehand run build:esm`
- `pnpm --filter @browserbasehq/stagehand exec vitest run --config /Users/samfinton/code/browserbase/stagehand/packages/core/vitest.esm.config.mjs /Users/samfinton/code/browserbase/stagehand/packages/core/dist/esm/tests/unit/xpath-resolver.test.js`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes XPath resolution for Stagehand shadow-hop selectors in `@browserbasehq/stagehand` by falling back to shadow-root traversal when composed traversal finds nothing. This restores correct matching for elements in open or closed shadow roots and prevents false element-not-found errors (e.g., dropdown selects).

- **Bug Fixes**
  - Interpret non-leading `//` as a shadow-root hop when no composed matches; supports open and closed roots.
  - Preserve standard descendant-axis behavior; only use shadow-hop fallback if composed count is 0.
  - Added tests for hosts with light DOM, descendant-axis-only selectors, and precedence; `countXPathMatches` and `resolveXPathAtIndex` now return expected results.

<sup>Written for commit 17121e36d8a207d69b0634635ce446f58fb45f5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

