### PR TITLE
STG-2196 Shadow DOM fix

### DIFF
--- a/.changeset/ready-heads-dream.md
+++ b/.changeset/ready-heads-dream.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Fix Stagehand-generated shadow-root XPath resolution so deterministic actions can target elements inside web components.

--- a/packages/core/lib/v3/dom/locatorScripts/xpathResolver.ts
+++ b/packages/core/lib/v3/dom/locatorScripts/xpathResolver.ts
@@ -5,6 +5,7 @@ import {
 } from "./xpathParser.js";
 
 type ClosedRootGetter = (host: Element) => ShadowRoot | null;
+type TraversalRoot = Document | Element | ShadowRoot | DocumentFragment;
 
 export type XPathResolveOptions = {
   pierceShadow?: boolean;
@@ -105,16 +106,13 @@ export function resolveXPathComposedMatches(
 
   const closedRoot = getClosedRoot ?? null;
 
-  let current: Array<Document | Element | ShadowRoot | DocumentFragment> = [
-    document,
-  ];
+  let current: TraversalRoot[] = [document];
 
   for (const step of steps) {
     const next: Element[] = [];
     const seen = new Set<Element>();
 
     for (const root of current) {
-      if (!root) continue;
       const pool =
         step.axis === "child"
           ? composedChildren(root, closedRoot)
@@ -154,9 +152,7 @@ function resolveStagehandShadowHopMatches(
   }
 
   const closedRoot = getClosedRoot ?? null;
-  let current: Array<Document | Element | ShadowRoot | DocumentFragment> = [
-    document,
-  ];
+  let current: TraversalRoot[] = [document];
 
   for (let i = 0; i < steps.length; i += 1) {
     const step = steps[i]!;
@@ -164,7 +160,6 @@ function resolveStagehandShadowHopMatches(
     const seen = new Set<Element>();
 
     for (const root of current) {
-      if (!root) continue;
       const pool =
         step.axis === "child"
           ? domChildren(root)
@@ -243,11 +238,10 @@ function getShadowContext(): ShadowContext {
 }
 
 function composedChildren(
-  node: Node | null | undefined,
+  node: TraversalRoot,
   getClosedRoot: ClosedRootGetter | null,
 ): Element[] {
   const out: Element[] = [];
-  if (!node) return out;
 
   if (node instanceof Document) {
     if (node.documentElement) out.push(node.documentElement);
@@ -273,9 +267,8 @@ function composedChildren(
   return out;
 }
 
-function domChildren(node: Node | null | undefined): Element[] {
+function domChildren(node: TraversalRoot): Element[] {
   const out: Element[] = [];
-  if (!node) return out;
 
   if (node instanceof Document) {
     if (node.documentElement) out.push(node.documentElement);
@@ -296,7 +289,7 @@ function domChildren(node: Node | null | undefined): Element[] {
 }
 
 function shadowRootChildren(
-  node: Node | null | undefined,
+  node: TraversalRoot,
   getClosedRoot: ClosedRootGetter | null,
 ): Element[] {
   const out: Element[] = [];
@@ -313,7 +306,7 @@ function shadowRootChildren(
 }
 
 function composedDescendants(
-  node: Node | null | undefined,
+  node: TraversalRoot,
   getClosedRoot: ClosedRootGetter | null,
 ): Element[] {
   const out: Element[] = [];
@@ -321,8 +314,8 @@ function composedDescendants(
   const stack = [...composedChildren(node, getClosedRoot)].reverse();
 
   while (stack.length) {
-    const next = stack.pop();
-    if (!next || seen.has(next)) continue;
+    const next = stack.pop()!;
+    if (seen.has(next)) continue;
     seen.add(next);
     out.push(next);
 

--- a/packages/core/lib/v3/dom/locatorScripts/xpathResolver.ts
+++ b/packages/core/lib/v3/dom/locatorScripts/xpathResolver.ts
@@ -53,7 +53,15 @@ export function resolveXPathAtIndex(
   }
 
   const composed = resolveXPathComposedMatches(xp, shadowCtx.getClosedRoot);
-  return composed[targetIndex] ?? null;
+  if (composed.length > 0) {
+    return composed[targetIndex] ?? null;
+  }
+
+  const shadowHopMatches = resolveStagehandShadowHopMatches(
+    xp,
+    shadowCtx.getClosedRoot,
+  );
+  return shadowHopMatches[targetIndex] ?? null;
 }
 
 export function countXPathMatches(
@@ -76,7 +84,13 @@ export function countXPathMatches(
     return resolveXPathComposedMatches(xp, shadowCtx?.getClosedRoot).length;
   }
 
-  return resolveXPathComposedMatches(xp, shadowCtx.getClosedRoot).length;
+  const composedCount = resolveXPathComposedMatches(
+    xp,
+    shadowCtx.getClosedRoot,
+  ).length;
+  if (composedCount > 0) return composedCount;
+
+  return resolveStagehandShadowHopMatches(xp, shadowCtx.getClosedRoot).length;
 }
 
 export function resolveXPathComposedMatches(
@@ -105,6 +119,58 @@ export function resolveXPathComposedMatches(
         step.axis === "child"
           ? composedChildren(root, closedRoot)
           : composedDescendants(root, closedRoot);
+      if (!pool.length) continue;
+
+      const tagMatches = pool.filter((candidate) =>
+        matchesTag(candidate, step),
+      );
+      const matches = applyPredicates(tagMatches, step.predicates);
+
+      for (const candidate of matches) {
+        if (!seen.has(candidate)) {
+          seen.add(candidate);
+          next.push(candidate);
+        }
+      }
+    }
+
+    if (!next.length) return [];
+    current = next;
+  }
+
+  return current as Element[];
+}
+
+function resolveStagehandShadowHopMatches(
+  rawXp: string,
+  getClosedRoot?: ClosedRootGetter | null,
+): Element[] {
+  const xp = normalizeXPath(rawXp);
+  if (!xp) return [];
+
+  const steps = parseXPathSteps(xp);
+  if (!steps.some((step, index) => step.axis === "desc" && index > 0)) {
+    return [];
+  }
+
+  const closedRoot = getClosedRoot ?? null;
+  let current: Array<Document | Element | ShadowRoot | DocumentFragment> = [
+    document,
+  ];
+
+  for (let i = 0; i < steps.length; i += 1) {
+    const step = steps[i]!;
+    const next: Element[] = [];
+    const seen = new Set<Element>();
+
+    for (const root of current) {
+      if (!root) continue;
+      const pool =
+        step.axis === "child"
+          ? domChildren(root)
+          : i === 0
+            ? composedDescendants(root, closedRoot)
+            : shadowRootChildren(root, closedRoot);
       if (!pool.length) continue;
 
       const tagMatches = pool.filter((candidate) =>
@@ -202,6 +268,45 @@ function composedChildren(
       if (closed) out.push(...Array.from(closed.children ?? []));
     }
     return out;
+  }
+
+  return out;
+}
+
+function domChildren(node: Node | null | undefined): Element[] {
+  const out: Element[] = [];
+  if (!node) return out;
+
+  if (node instanceof Document) {
+    if (node.documentElement) out.push(node.documentElement);
+    return out;
+  }
+
+  if (node instanceof ShadowRoot || node instanceof DocumentFragment) {
+    out.push(...Array.from(node.children ?? []));
+    return out;
+  }
+
+  if (node instanceof Element) {
+    out.push(...Array.from(node.children ?? []));
+    return out;
+  }
+
+  return out;
+}
+
+function shadowRootChildren(
+  node: Node | null | undefined,
+  getClosedRoot: ClosedRootGetter | null,
+): Element[] {
+  const out: Element[] = [];
+  if (!(node instanceof Element)) return out;
+
+  const open = node.shadowRoot;
+  if (open) out.push(...Array.from(open.children ?? []));
+  if (getClosedRoot) {
+    const closed = getClosedRoot(node);
+    if (closed) out.push(...Array.from(closed.children ?? []));
   }
 
   return out;

--- a/packages/core/tests/unit/xpath-resolver.test.ts
+++ b/packages/core/tests/unit/xpath-resolver.test.ts
@@ -74,11 +74,11 @@ describe("xpathResolver composed traversal", () => {
     document.body.innerHTML = "";
   });
 
-  it("counts matches across light + shadow DOM without double counting", () => {
+  it("counts matches across regular and shadow DOM without double counting", () => {
     document.body.innerHTML =
-      '<div id="light-1"></div>' +
+      '<div id="regular-1"></div>' +
       '<shadow-host id="host"></shadow-host>' +
-      '<div id="light-2"></div>';
+      '<div id="regular-2"></div>';
 
     const host = document.getElementById("host") as HTMLElement;
     const shadow = host.attachShadow({ mode: "open" });
@@ -89,17 +89,74 @@ describe("xpathResolver composed traversal", () => {
 
   it("resolves nth over composed tree in document-order DFS", () => {
     document.body.innerHTML =
-      '<div id="light-1"></div>' +
+      '<div id="regular-1"></div>' +
       '<shadow-host id="host"></shadow-host>' +
-      '<div id="light-2"></div>';
+      '<div id="regular-2"></div>';
 
     const host = document.getElementById("host") as HTMLElement;
     const shadow = host.attachShadow({ mode: "open" });
     shadow.innerHTML = '<div id="shadow-1"></div><div id="shadow-2"></div>';
 
-    expect(resolveXPathAtIndex("//div", 0)?.id).toBe("light-1");
+    expect(resolveXPathAtIndex("//div", 0)?.id).toBe("regular-1");
     expect(resolveXPathAtIndex("//div", 1)?.id).toBe("shadow-1");
     expect(resolveXPathAtIndex("//div", 2)?.id).toBe("shadow-2");
-    expect(resolveXPathAtIndex("//div", 3)?.id).toBe("light-2");
+    expect(resolveXPathAtIndex("//div", 3)?.id).toBe("regular-2");
+  });
+
+  it("resolves Stagehand shadow-hop paths when the host has DOM children", () => {
+    document.body.innerHTML =
+      '<shadow-host id="host"><div id="regular-child"></div></shadow-host>';
+
+    const host = document.getElementById("host") as HTMLElement;
+    const shadow = host.attachShadow({ mode: "open" });
+    shadow.innerHTML =
+      '<div id="shadow-wrapper"><div><select id="target"></select></div></div>';
+
+    const selector = "/html[1]/body[1]/shadow-host[1]//div[1]/div[1]/select[1]";
+
+    expect(countXPathMatches(selector)).toBe(1);
+    expect(resolveXPathAtIndex(selector, 0)?.id).toBe("target");
+  });
+
+  it("keeps standard descendant-axis XPath behavior for non-shadow paths", () => {
+    document.body.innerHTML =
+      "<section><article><button id='target'>Go</button></article></section>";
+
+    const selector = "/html[1]/body[1]/section[1]//button[1]";
+
+    expect(countXPathMatches(selector)).toBe(1);
+    expect(resolveXPathAtIndex(selector, 0)?.id).toBe("target");
+  });
+
+  it("preserves descendant-axis matches when both interpretations are possible", () => {
+    document.body.innerHTML =
+      "<section><article><button id='regular-target'>Go</button></article></section>";
+
+    const section = document.querySelector("section") as HTMLElement;
+    const shadow = section.attachShadow({ mode: "open" });
+    shadow.innerHTML = "<button id='shadow-target'>Shadow</button>";
+
+    const selector = "/html[1]/body[1]/section[1]//button[1]";
+
+    expect(countXPathMatches(selector)).toBe(1);
+    expect(resolveXPathAtIndex(selector, 0)?.id).toBe("regular-target");
+  });
+
+  it("returns null for indexes outside the composed match set", () => {
+    document.body.innerHTML =
+      '<shadow-host><div><span id="regular-target"></span></div></shadow-host>' +
+      "<shadow-host><div></div></shadow-host>";
+
+    const hosts = Array.from(document.querySelectorAll("shadow-host"));
+    hosts.forEach((host, index) => {
+      const shadow = host.attachShadow({ mode: "open" });
+      shadow.innerHTML = `<div><span id="shadow-${index}"></span></div>`;
+    });
+
+    const selector = "/html[1]/body[1]/shadow-host//div[1]/span[1]";
+
+    expect(countXPathMatches(selector)).toBe(1);
+    expect(resolveXPathAtIndex(selector, 0)?.id).toBe("regular-target");
+    expect(resolveXPathAtIndex(selector, 1)).toBeNull();
   });
 });


### PR DESCRIPTION
# why

Before this PR, if we passed a Stagehand selector like `/html[1]/body[1]/shadow-host[1]//div[1]/div[1]/select[1]`, it could return no match when the shadow host also had a regular DOM `<div>`. In that case, `countXPathMatches` returned `0` and `resolveXPathAtIndex` returned `null`, even though the target `<select>` existed inside the host's shadow root.

This matters because Stagehand-generated selectors use non-leading `//` to represent entering a shadow root. When resolution fails there, deterministic actions like `selectOptionFromDropdown` can fail with element-not-found.

# what changed

Added a regression test for that selector shape. Then changed the XPath resolver so it keeps the existing descendant-axis behavior when that resolves, but if that path finds nothing, it resolves the non-leading `//` as a Stagehand shadow-root hop. With the same selector now, `countXPathMatches` returns `1` and `resolveXPathAtIndex` returns `#target`.

# test plan

- `pnpm --filter @browserbasehq/stagehand run lint`
- `pnpm --filter @browserbasehq/stagehand run build-dom-scripts && pnpm --filter @browserbasehq/stagehand run build:esm`
- `pnpm --filter @browserbasehq/stagehand exec vitest run --config /Users/samfinton/code/browserbase/stagehand/packages/core/vitest.esm.config.mjs /Users/samfinton/code/browserbase/stagehand/packages/core/dist/esm/tests/unit/xpath-resolver.test.js`
