### PR TITLE
[STG-2216] fix: support models that reject forced tool use (Fable 5)

### DIFF
--- a/.changeset/fable5-forced-tool-use.md
+++ b/.changeset/fable5-forced-tool-use.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Support models that reject forced tool use (e.g. Claude Fable 5) across `act`/`extract`/`observe` and the agent. The AI SDK emulates `generateObject` for Anthropic with a forced `json` tool, and the agent forces a final `done` tool call — both of which these models reject with "tool_choice forces tool use is not compatible with this model". We now detect that error and retry: `generateObject` falls back to Anthropic's native structured outputs (`structuredOutputMode: "outputFormat"`) with a strict JSON schema, and the agent's `done` call retries with `toolChoice: "auto"`. The structured-output fallback is cached per model so subsequent calls skip the failed forced attempt.

--- a/packages/core/lib/v3/agent/utils/handleDoneToolCall.ts
+++ b/packages/core/lib/v3/agent/utils/handleDoneToolCall.ts
@@ -101,17 +101,39 @@ Call the "done" tool with:
       : "Provide your final assessment.",
   };
 
-  const result = await generateText({
+  // Force a final "done" tool call. Some models (e.g. claude-fable-5) reject
+  // forced tool use with "tool_choice forces tool use is not compatible with
+  // this model". Try forced first; on that specific error, retry with toolChoice
+  // "auto" — the prompt already instructs the model to call "done", and the
+  // no-tool-call branch below handles a plain-text answer.
+  const baseRequest = {
     model,
     system: systemPrompt,
     messages: [...inputMessages, userPrompt],
     tools: { done: doneTool } as ToolSet,
-    toolChoice: { type: "tool", toolName: "done" },
     providerOptions: {
       google: { mediaResolution: "MEDIA_RESOLUTION_HIGH" },
       openai: { store: false },
     },
-  });
+  } satisfies Omit<Parameters<typeof generateText>[0], "toolChoice">;
+
+  let result: Awaited<ReturnType<typeof generateText>>;
+  try {
+    result = await generateText({
+      ...baseRequest,
+      toolChoice: { type: "tool", toolName: "done" },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    // Only swallow the tool_choice incompatibility — rethrow anything else.
+    if (!/tool_choice|tool choice/i.test(message)) throw error;
+    logger({
+      category: "agent",
+      message: `Forced "done" tool call rejected; retrying with toolChoice "auto" (${message})`,
+      level: 1,
+    });
+    result = await generateText({ ...baseRequest, toolChoice: "auto" });
+  }
 
   const doneToolCall = result.toolCalls.find((tc) => tc.toolName === "done");
   const outputMessages: ModelMessage[] = [

--- a/packages/core/lib/v3/llm/aisdk.ts
+++ b/packages/core/lib/v3/llm/aisdk.ts
@@ -263,9 +263,18 @@ You must respond in JSON format. respond WITH JSON. Do not include any other tex
           | ReturnType<typeof jsonSchema> = options.response_model.schema;
         let resolvedProviderOptions = providerOptions;
         if (useNativeStructuredOutput) {
-          objectSchema = jsonSchema(
-            toJsonSchema(options.response_model.schema),
-          );
+          // Pre-built JSON schema bypasses the AI SDK's own zod validation, so
+          // re-attach it via `validate` to keep parity with the forced-tool path
+          // (refinements/transforms/coercions still run on the model output).
+          const zodSchema = options.response_model.schema;
+          objectSchema = jsonSchema(toJsonSchema(zodSchema), {
+            validate: (value) => {
+              const parsed = zodSchema.safeParse(value);
+              return parsed.success
+                ? { success: true, value: parsed.data }
+                : { success: false, error: parsed.error };
+            },
+          });
           resolvedProviderOptions = {
             ...providerOptions,
             anthropic: {

--- a/packages/core/lib/v3/llm/aisdk.ts
+++ b/packages/core/lib/v3/llm/aisdk.ts
@@ -268,8 +268,10 @@ You must respond in JSON format. respond WITH JSON. Do not include any other tex
           // (refinements/transforms/coercions still run on the model output).
           const zodSchema = options.response_model.schema;
           objectSchema = jsonSchema(toJsonSchema(zodSchema), {
-            validate: (value) => {
-              const parsed = zodSchema.safeParse(value);
+            // async so schemas with async refinements/transforms validate
+            // correctly (safeParse throws on those; safeParseAsync handles both).
+            validate: async (value) => {
+              const parsed = await zodSchema.safeParseAsync(value);
               return parsed.success
                 ? { success: true, value: parsed.data }
                 : { success: false, error: parsed.error };

--- a/packages/core/lib/v3/llm/aisdk.ts
+++ b/packages/core/lib/v3/llm/aisdk.ts
@@ -5,6 +5,7 @@ import {
   CoreUserMessage,
   generateObject,
   generateText,
+  jsonSchema,
   ImagePart,
   NoObjectGeneratedError,
   TextPart,
@@ -30,6 +31,12 @@ function inferProviderName(modelId: string): string | undefined {
   const [providerName] = modelId.split("/");
   return providerName || undefined;
 }
+
+// Anthropic model IDs observed (this process) to reject forced tool use, i.e.
+// "tool_choice forces tool use is not compatible with this model" (e.g.
+// claude-fable-5). Cached so structured-output calls for these models skip the
+// doomed forced attempt instead of eating a 400 every time.
+const forcedToolUseUnsupportedModels = new Set<string>();
 
 export class AISdkClient extends LLMClient {
   public type = "aisdk" as const;
@@ -242,16 +249,64 @@ You must respond in JSON format. respond WITH JSON. Do not include any other tex
         });
       }
 
-      try {
-        objectResponse = await generateObject({
+      // The AI SDK emulates generateObject for Anthropic via a forced `json` tool
+      // (tool_choice: {type:"tool"}). Some models (e.g. claude-fable-5) reject
+      // forced tool use. For those, fall back to Anthropic's native structured
+      // outputs (structuredOutputMode:"outputFormat"),
+      // which additionally require a strict JSON schema (additionalProperties:false
+      // on every object) — the AI SDK's converter doesn't add that for Stagehand's
+      // Standard-Schema-wrapped zod, so we hand it a pre-built strict schema.
+      const isAnthropic = this.model.provider?.startsWith("anthropic") ?? false;
+      const runGenerateObject = (useNativeStructuredOutput: boolean) => {
+        let objectSchema:
+          | typeof options.response_model.schema
+          | ReturnType<typeof jsonSchema> = options.response_model.schema;
+        let resolvedProviderOptions = providerOptions;
+        if (useNativeStructuredOutput) {
+          objectSchema = jsonSchema(
+            toJsonSchema(options.response_model.schema),
+          );
+          resolvedProviderOptions = {
+            ...providerOptions,
+            anthropic: {
+              ...providerOptions.anthropic,
+              structuredOutputMode: "outputFormat",
+            },
+          };
+        }
+        return generateObject({
           model: this.model,
           messages: formattedMessages,
-          schema: options.response_model.schema,
+          schema: objectSchema,
           temperature,
-          ...(Object.keys(providerOptions).length > 0
-            ? { providerOptions }
+          ...(Object.keys(resolvedProviderOptions).length > 0
+            ? { providerOptions: resolvedProviderOptions }
             : {}),
         });
+      };
+
+      try {
+        // Skip the doomed forced attempt if this model already rejected it once.
+        const skipForcedToolUse =
+          isAnthropic && forcedToolUseUnsupportedModels.has(this.model.modelId);
+        try {
+          objectResponse = await runGenerateObject(skipForcedToolUse);
+        } catch (forcedErr) {
+          const message =
+            forcedErr instanceof Error ? forcedErr.message : String(forcedErr);
+          const isForcedToolRejection =
+            isAnthropic &&
+            !skipForcedToolUse &&
+            /tool_choice|tool choice/i.test(message);
+          if (!isForcedToolRejection) throw forcedErr;
+          forcedToolUseUnsupportedModels.add(this.model.modelId);
+          this.logger?.({
+            category: "aisdk",
+            message: `Model ${this.model.modelId} rejected forced tool use; retrying with native structured outputs`,
+            level: 1,
+          });
+          objectResponse = await runGenerateObject(true);
+        }
       } catch (err) {
         // Log error response to maintain request/response pairing
         FlowLogger.logLlmResponse({

--- a/packages/core/lib/v3/llm/aisdk.ts
+++ b/packages/core/lib/v3/llm/aisdk.ts
@@ -32,12 +32,6 @@ function inferProviderName(modelId: string): string | undefined {
   return providerName || undefined;
 }
 
-// Anthropic model IDs observed (this process) to reject forced tool use, i.e.
-// "tool_choice forces tool use is not compatible with this model" (e.g.
-// claude-fable-5). Cached so structured-output calls for these models skip the
-// doomed forced attempt instead of eating a 400 every time.
-const forcedToolUseUnsupportedModels = new Set<string>();
-
 export class AISdkClient extends LLMClient {
   public type = "aisdk" as const;
   private model: LanguageModelV2;
@@ -297,20 +291,14 @@ You must respond in JSON format. respond WITH JSON. Do not include any other tex
       };
 
       try {
-        // Skip the doomed forced attempt if this model already rejected it once.
-        const skipForcedToolUse =
-          isAnthropic && forcedToolUseUnsupportedModels.has(this.model.modelId);
         try {
-          objectResponse = await runGenerateObject(skipForcedToolUse);
+          objectResponse = await runGenerateObject(false);
         } catch (forcedErr) {
           const message =
             forcedErr instanceof Error ? forcedErr.message : String(forcedErr);
           const isForcedToolRejection =
-            isAnthropic &&
-            !skipForcedToolUse &&
-            /tool_choice|tool choice/i.test(message);
+            isAnthropic && /tool_choice|tool choice/i.test(message);
           if (!isForcedToolRejection) throw forcedErr;
-          forcedToolUseUnsupportedModels.add(this.model.modelId);
           this.logger?.({
             category: "aisdk",
             message: `Model ${this.model.modelId} rejected forced tool use; retrying with native structured outputs`,


### PR DESCRIPTION
## What

Stagehand fails on Claude **Fable 5** because the model rejects *forced* tool use. There are two forced-tool sites:

1. **`generateObject`** (powers `act`/`extract`/`observe`) — the AI SDK's `@ai-sdk/anthropic` provider emulates structured output with a forced `json` tool (`tool_choice: {type:"tool"}`).
2. **The agent's `done` tool** — `handleDoneToolCall` forces `toolChoice: {type:"tool", toolName:"done"}` for the final assessment.

Both return `400 tool_choice forces tool use is not compatible with this model`, so direct primitives **and** `agent.execute()` break on these models. (Current Claude models are unaffected — they accept forced tool use.)

## Fix

Reactive and model-agnostic (no hardcoded model list — covers any model that rejects forcing):

- **`generateObject`** (`aisdk.ts`): try the normal (forced-tool) path; on a `/tool_choice/i` error from an Anthropic model, retry with Anthropic's **native structured outputs** (`structuredOutputMode: "outputFormat"`) + a strict JSON schema (`additionalProperties:false`, which the AI SDK's converter omits for Stagehand's Standard-Schema-wrapped zod). The rejecting model is **cached** so subsequent structured calls skip the doomed forced attempt — one wasted 400 per model, not per call.
- **Agent `done`** (`handleDoneToolCall.ts`): try forced; on `/tool_choice/i`, retry with `toolChoice: "auto"`. The prompt already instructs the model to call `done`, and the existing no-tool-call branch handles a plain-text answer.

Narrow `/tool_choice/i` catch so any other error still surfaces.

## E2E Test Matrix

LOCAL env, real `ANTHROPIC_API_KEY`, real Chromium, against `browserbase.github.io/stagehand-eval-sites/sites/google/`. Built from this branch's source.

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `observe` + `act` + 2× `extract` on `anthropic/claude-fable-5` | `✅ observe=1 extract="browserbase"` | Proves the primitives path end-to-end. Before this PR → `400 tool_choice forces tool use`. |
| Same run, retry-log count | exactly **1** `rejected forced tool use; retrying with native structured outputs` across 4 structured calls | Proves the per-model cache: one wasted forced 400, then native for all later calls. |
| `agent.execute()` **DOM**, `anthropic/claude-fable-5` | `✅ completed=true, 3 actions` | Exercises the agent loop + forced `done` fallback. |
| `agent.execute()` **hybrid** (`experimental:true`), `anthropic/claude-fable-5` | `✅ completed=true, 3 actions` | The hybrid path; typed "browserbase" confirmed via screenshot. |
| `extract` on `anthropic/claude-haiku-4-5` (regression) | `✅ extract="browserbase"` | Non-rejecting models keep the existing forced-tool path untouched — no retry triggered. |
| `tsc --noEmit` + `eslint` + `prettier` on changed files | clean | Supporting checks. |

## Linear

STG-2216
