### PR TITLE
[docs]: add docs for `ignoreDefaultArgs`

### DIFF
--- a/packages/docs/v3/configuration/browser.mdx
+++ b/packages/docs/v3/configuration/browser.mdx
@@ -232,6 +232,9 @@ const stagehand = new Stagehand({
     viewport: { width: 1280, height: 720 },
     executablePath: '/opt/google/chrome/chrome', // Custom Chrome path
     port: 9222, // Fixed CDP debugging port
+    ignoreDefaultArgs: [
+      '--site-per-process',
+    ], // Remove specific default launch args
     args: [
       '--no-sandbox',
       '--disable-setuid-sandbox',
@@ -257,6 +260,37 @@ const stagehand = new Stagehand({
 
 await stagehand.init();
 ```
+
+#### Default Local Launch Arguments
+
+When Stagehand launches a local browser, it adds the following Chrome arguments before any values in `localBrowserLaunchOptions.args`:
+
+```typescript
+[
+  "--remote-allow-origins=*",
+  "--no-first-run",
+  "--no-default-browser-check",
+  "--disable-dev-shm-usage",
+  "--site-per-process",
+]
+```
+
+Chrome Launcher also adds its own default arguments. To remove default arguments, set `localBrowserLaunchOptions.ignoreDefaultArgs`:
+
+```typescript
+const stagehand = new Stagehand({
+  env: "LOCAL",
+  localBrowserLaunchOptions: {
+    ignoreDefaultArgs: ["--site-per-process"],
+    args: [
+      "--disable-features=site-per-process,IsolateOrigins",
+      "--renderer-process-limit=6",
+    ],
+  },
+});
+```
+
+Use `ignoreDefaultArgs: true` to remove all default arguments. Use a string array to remove only exact matches while preserving the rest.
 
 ## Advanced Configuration
 

--- a/packages/docs/v3/references/stagehand.mdx
+++ b/packages/docs/v3/references/stagehand.mdx
@@ -120,6 +120,16 @@ interface V3Options {
       Additional Chrome launch arguments.
     </ParamField>
 
+    <ParamField path="ignoreDefaultArgs" type="boolean | string[]" optional>
+      Remove default Chrome launch arguments when launching a local browser.
+
+      Pass `true` to remove all default arguments. Pass an array of exact argument strings to remove only those defaults while keeping the rest.
+
+      Stagehand adds these default arguments before your `args`: `--remote-allow-origins=*`, `--no-first-run`, `--no-default-browser-check`, `--disable-dev-shm-usage`, and `--site-per-process`. Chrome Launcher also adds its own default arguments.
+
+      **Default:** `false`
+    </ParamField>
+
     <ParamField path="userDataDir" type="string" optional>
       Path to user data directory for browser profile.
     </ParamField>


### PR DESCRIPTION
# what changed
- adds documentation for the `localBrowserLaunchOptions.ignoreDefaultArgs` param

<img width="1203" height="713" alt="Screenshot 2026-06-09 at 1 02 20 PM" src="https://github.com/user-attachments/assets/5f3b2ff1-d8d1-41b9-81f3-4c6b9dcbea48" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented `localBrowserLaunchOptions.ignoreDefaultArgs` and listed the default Chrome args Stagehand adds for local launches. Added examples for removing all defaults or specific args using `ignoreDefaultArgs: true` or a string array (STG-2213).

<sup>Written for commit 9479f035e9a02f6cbafcda08473c93884cc5ce86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

