### PR TITLE
[fix]: launch local browser with webmcp flags by default

### DIFF
--- a/.changeset/quiet-mangos-sing.md
+++ b/.changeset/quiet-mangos-sing.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+launch local browser with --enable-features=WebMCPTesting,DevToolsWebMCPSupport by default

--- a/packages/core/examples/webmcp.ts
+++ b/packages/core/examples/webmcp.ts
@@ -39,9 +39,6 @@ async function example(stagehand: Stagehand) {
   const stagehand = new Stagehand({
     env: "LOCAL",
     verbose: 2,
-    localBrowserLaunchOptions: {
-      args: ["--enable-features=WebMCPTesting,DevToolsWebMCPSupport"],
-    },
   });
   try {
     await stagehand.init();

--- a/packages/core/lib/v3/launch/local.ts
+++ b/packages/core/lib/v3/launch/local.ts
@@ -13,6 +13,7 @@ const STAGEHAND_DEFAULT_FLAGS = [
   "--no-default-browser-check",
   "--disable-dev-shm-usage",
   "--site-per-process",
+  "--enable-features=WebMCPTesting,DevToolsWebMCPSupport",
 ];
 
 export async function launchLocalChrome(

--- a/packages/core/lib/v3/understudy/page.ts
+++ b/packages/core/lib/v3/understudy/page.ts
@@ -84,7 +84,7 @@ const LIFECYCLE_NAME: Record<LoadState, string> = {
 };
 
 const WEB_MCP_SUPPORT_MESSAGE =
-  "Make sure you are using Chrome/Chromium newer than version 149 and that it is launched with --enable-features=WebMCPTesting,DevToolsWebMCPSupport.";
+  "Make sure you are using Chrome/Chromium newer than version 149. Stagehand's local Chrome launcher enables WebMCP flags by default; if you are connecting to an existing browser or remote CDP endpoint, launch it with --enable-features=WebMCPTesting,DevToolsWebMCPSupport.";
 
 type Deferred<T> = {
   promise: Promise<T>;

--- a/packages/core/tests/unit/launch-local-ignore-default-args.test.ts
+++ b/packages/core/tests/unit/launch-local-ignore-default-args.test.ts
@@ -156,6 +156,9 @@ describe("launchLocalChrome ignoreDefaultArgs", () => {
     // so this test doesn't break if Stagehand adds/removes its own flags.
     expect(args.chromeFlags).toContain("--remote-allow-origins=*");
     expect(args.chromeFlags).toContain("--no-first-run");
+    expect(args.chromeFlags).toContain(
+      "--enable-features=WebMCPTesting,DevToolsWebMCPSupport",
+    );
 
     expect(args.chromeFlags).not.toContain("--mute-audio");
     expect(args.chromeFlags).toContain("--disable-extensions");

--- a/packages/core/tests/unit/page-webmcp.test.ts
+++ b/packages/core/tests/unit/page-webmcp.test.ts
@@ -145,6 +145,9 @@ describe("Page WebMCP", () => {
     await expect(page.listWebMCPTools({ timeoutMs: 1 })).rejects.toThrow(
       "Chrome/Chromium newer than version 149",
     );
+    await expect(page.listWebMCPTools({ timeoutMs: 1 })).rejects.toThrow(
+      "Stagehand's local Chrome launcher enables WebMCP flags by default",
+    );
   });
 
   it("invokes a tool with an explicit frameId and resolves the response event", async () => {


### PR DESCRIPTION
# why
- webmcp tools are a core primitive now, & users should be able to use them without worrying about adding chrome flags
# what changed
- this PR adds `--enable-features=WebMCPTesting,DevToolsWebMCPSupport` to the list of existing default flags
- updated webmcp example to not include the flags since they are provided by default
# test plan
- added a test to check whether the new default flags propagate

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Local Chrome launches now enable WebMCP by default so tools work out of the box. You no longer need to pass `--enable-features=WebMCPTesting,DevToolsWebMCPSupport` in app code.

- **New Features**
  - Added WebMCP flags to default launch args.
  - Updated the webmcp example, help text, and tests to match the new default.

- **Migration**
  - No action needed for local launches.
  - If connecting to an existing or remote browser, launch it with `--enable-features=WebMCPTesting,DevToolsWebMCPSupport`.

<sup>Written for commit c7af448b73289749cce23c7cfd7eeece836c6bcc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

