### PR TITLE
[STG-2244] docs(cli): embed Browse.sh skill discovery guidance in browse skill

### DIFF
--- a/packages/cli/skills/browse/SKILL.md
+++ b/packages/cli/skills/browse/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: browse
-description: Use the browse CLI for Browserbase browser automation, Browserbase cloud APIs, Browserbase Functions, templates, web fetch/search, diagnostics, and Browse.sh skill discovery/installation. Use when the user asks to navigate pages, inspect browser state, run local or remote browser sessions, manage Browserbase resources, call Browserbase Functions, browse or scaffold Browserbase templates, fetch or search web content, diagnose browse setup, discover site-specific Browse.sh skills, or install/refresh this browse skill.
+description: Use the browse CLI for Browserbase browser automation, Browserbase cloud APIs, Browserbase Functions, templates, web fetch/search, diagnostics, and Browse.sh skill discovery/installation. Use when the user asks to navigate pages, inspect browser state, run local or remote browser sessions, manage Browserbase resources, call Browserbase Functions, browse or scaffold Browserbase templates, fetch or search web content, diagnose browse setup, find or install a skill for a website task, discover site-specific Browse.sh skills, or install/refresh this browse skill.
 compatibility: "Requires the browse CLI (`npm install -g browse`). Remote Browserbase sessions and cloud API commands require `BROWSERBASE_API_KEY`. Local mode uses Chrome/Chromium on the machine."
 license: MIT
 allowed-tools: Bash
@@ -242,18 +242,49 @@ Install or refresh this bundled CLI skill:
 browse skills install
 ```
 
-Discover and install site-specific Browse.sh skills:
+### Discovering Browse.sh Skills
+
+Browse.sh (https://browse.sh) is a catalog of site-specific browser automation skills. Each skill is scoped to one task on one website and identified by a `<domain>/<task>` slug. An installed skill encodes a proven strategy for that site — API endpoints, selectors, anti-bot handling — so it completes the task faster and more reliably than exploring the site from scratch.
+
+Search the catalog proactively when:
+
+- the user asks to complete a task on a specific website — search the domain before automating it by hand
+- the user asks for a task in a common category like flights, food delivery, reviews, recipes, tickets, jobs, or shopping — search the keyword
+- the user asks "is there a skill for X" or wants new capabilities
 
 ```bash
-browse skills list
-browse skills list --json
-browse skills find reviews
-browse skills find yelp.com/extract-reviews
-browse skills find "restaurant reviews" --json
-browse skills add yelp.com/extract-reviews
+browse skills list                              # browse the catalog
+browse skills find <query>                      # search by slug, domain, title, description, category, alias, or tag
+browse skills add <domain>/<task>               # install an exact slug
 ```
 
-Use `browse skills find` when the exact skill slug is uncertain. Use `browse skills add <domain>/<task>` only after choosing an exact slug from `list` or `find`.
+### Search Strategy
+
+Search the domain first, then the task, then broaden:
+
+```bash
+browse skills find yelp.com                     # 1. exact domain
+browse skills find yelp                         # 2. site name
+browse skills find reviews                      # 3. task keyword
+browse skills find "restaurant reviews"         # 4. multi-word query
+browse skills find food --limit 5               # 5. category keyword, capped
+```
+
+- Querying an exact slug (`browse skills find yelp.com/extract-reviews-2ikb22`) prints a detail view with the full description and install command.
+- If a search returns nothing, try synonyms (`flights` vs `travel`, `food` vs `restaurants`) before concluding no skill exists.
+- Each result shows a recommended method — `api`, `fetch`, `browser`, or `hybrid` — indicating how the skill drives the site. Install counts signal which skills are proven.
+- Slugs end in a generated suffix (`-2ikb22`), so never guess them. Install only with an exact slug copied from `list` or `find` output: `browse skills add yelp.com/extract-reviews-2ikb22`. The installed skill becomes available to the agent as a regular skill; a new agent session may be needed to pick it up.
+
+### Output Formats
+
+Output is a table in a terminal and JSON when piped, so agents get structured JSON by default. Force a format with `--format table|json` or `--json`.
+
+```bash
+browse skills find food --format table --limit 10
+browse skills find food --json | jq -r '.skills[] | "\(.slug)\t\(.title)"'
+```
+
+JSON output includes every match with full descriptions and ignores `--limit`; `browse skills list --json` returns the entire catalog, which is large. Prefer `browse skills find <query>` to narrow first, or `--format table --limit <n>` for a compact view.
 
 ## Best Practices
 
@@ -275,3 +306,6 @@ Use `browse skills find` when the exact skill slug is uncertain. Use `browse ski
 - Remote command fails: verify `BROWSERBASE_API_KEY` and inspect `browse cloud projects list`.
 - Session setup is unclear: run `browse doctor` or `browse doctor --json`.
 - Protected site blocks local mode: retry with `--remote`.
+- `browse skills find` returns nothing: broaden the query — bare domain, then site name, then a task keyword or synonym.
+- `browse skills add` fails on `npx`: install Node.js from https://nodejs.org, then rerun.
+- Newly added skill is not available: it installs for future sessions; list installed skills or start a new agent session.

--- a/packages/cli/skills/browse/SKILL.md
+++ b/packages/cli/skills/browse/SKILL.md
@@ -273,7 +273,7 @@ browse skills find food --limit 5               # 5. category keyword, capped
 - Querying an exact slug (`browse skills find yelp.com/extract-reviews-2ikb22`) prints a detail view with the full description and install command.
 - If a search returns nothing, try synonyms (`flights` vs `travel`, `food` vs `restaurants`) before concluding no skill exists.
 - Each result shows a recommended method — `api`, `fetch`, `browser`, or `hybrid` — indicating how the skill drives the site. Install counts signal which skills are proven.
-- Slugs end in a generated suffix (`-2ikb22`), so never guess them. Install only with an exact slug copied from `list` or `find` output: `browse skills add yelp.com/extract-reviews-2ikb22`. The installed skill becomes available to the agent as a regular skill; a new agent session may be needed to pick it up.
+- Many slugs end in a generated suffix (`-2ikb22`), so never guess or construct them. Install only with an exact slug copied from `list` or `find` output: `browse skills add yelp.com/extract-reviews-2ikb22`. The installed skill becomes available to the agent as a regular skill; a new agent session may be needed to pick it up.
 
 ### Output Formats
 


### PR DESCRIPTION
## Summary

Expands the bundled browse skill's `## Skills` section so agents that install it via `browse skills install` know to **proactively discover Browse.sh catalog skills** instead of hand-rolling browser automation:

- **When to search**: before automating a known site (domain-first), for task categories (keyword search), or when the user asks for a capability.
- **Search strategy**: domain → site name → task keyword → multi-word query, with synonym fallbacks, modeled loosely on the structure of skills.sh's `find-skills` skill.
- **Output formats**: documents that output is a table in a TTY and JSON when piped (what agents actually see), `--format table|json`, and that JSON ignores `--limit` (so `skills list --json` returns the entire catalog) — with a `jq` slicing example.
- **Exact slugs**: catalog slugs end in a generated suffix (e.g. `yelp.com/extract-reviews-2ikb22`), so the guidance tells agents to never guess slugs and only `skills add` from `list`/`find` output. This also fixes the stale suffix-less slug example.
- **Troubleshooting**: three new entries for empty search results, missing `npx`, and newly installed skills not being picked up until a new agent session.

Also adds "find or install a skill for a website task" to the frontmatter description so agent skill-routing triggers on discovery intents.

Linear: [STG-2244](https://linear.app/browserbase/issue/STG-2244/embed-browsesh-skill-discovery-guidance-in-bundled-browse-skill)

## E2E Test Matrix

All rows ran against the local build of this branch (`pnpm build` then `./bin/run.js`), not the published package.

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `<local build> skills find yelp.com --format table` | Table of 4 yelp.com skills with Method/Installs/Tags columns and `Install with: browse skills add <skill>` footer | Proves the documented domain-first search and table columns match real CLI behavior |
| `<local build> skills find yelp.com/extract-reviews-2ikb22 --format table` | Detail view: title, slug, method `browser`, installs, tags, full description, `Install: browse skills add yelp.com/extract-reviews-2ikb22` | Proves the documented exact-slug detail view, and that the suffixed slug in the doc is the real catalog slug |
| `<local build> skills find food --json \| jq -r '.skills[] \| "\(.slug)\t\(.title)"'` | 11 slug+title lines (allrecipes.com, drugs.com, mcdonalds.order.online, …) | Proves the documented jq pipe example verbatim |
| `browse skills list` piped (non-TTY) | Full-catalog JSON (~650KB) | Proves the documented warning that piped `list` JSON returns the entire catalog and ignores `--limit` |
| `<local build> skills install` | `npx skills add` ran; updated SKILL.md landed in the agent skills pool — new "Search Strategy" section and suffixed-slug guidance present in the installed copy; the running agent session picked up the updated skill description | Proves the changed skill text ships end-to-end through the real install path (one unrelated pre-existing failure: the `npx skills` "PromptScript" agent target rejects global installs) |
| `prettier skills/browse/SKILL.md --check` + `pnpm build` (core + cli) | Format check passed; both builds green | Supporting only — formatting/build hygiene |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Embeds Browse.sh skill discovery guidance in the bundled `browse` skill so agents search the catalog first and install exact slugs. Also updates frontmatter to include “find or install a skill for a website task” for better intent routing; aligns with Linear STG-2244.

- **New Features**
  - When to search: before automating a known site, for task/category keywords, or when users ask for capabilities.
  - Search flow: domain → site name → task keyword → multi-word; try synonyms; exact slug shows a detail view.
  - Output formats: table in TTY, JSON when piped; supports `--format table|json`/`--json`; JSON ignores `--limit` and `list --json` returns the full catalog (recommend narrowing with `find` or using table with `--limit`).
  - Install exact slugs only. Many slugs include a generated suffix; don’t guess or construct slugs. New installs may need a new agent session; adds troubleshooting for empty results and missing `npx`.

<sup>Written for commit a221e0d038c0d37ca00d06e640385b0a0618bf65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

