### PR TITLE
[STG-2029] docs(cli): improve browse skill session guidance

### DIFF
--- a/packages/cli/skills/browse/SKILL.md
+++ b/packages/cli/skills/browse/SKILL.md
@@ -64,6 +64,15 @@ browse open https://example.com --cdp ws://127.0.0.1:9222/devtools/browser/<id>
 
 Use local mode for development, localhost, trusted sites, and fast iteration. Use `--auto-connect` only when the user explicitly wants to attach to an already-running debuggable Chrome session with existing cookies or login state; use `--local` when no debuggable Chrome is available. Use remote mode when Browserbase credentials are available and the site needs hosted browser infrastructure, Verified browser mode, CAPTCHA solving, proxies, or session persistence.
 
+Choose headed/headless and local/remote mode when starting a session. A running session keeps its mode: passing a conflicting flag such as `--headed` to an already-running headless session fails until you run `browse stop --session <name>` or target a different session.
+
+Use named sessions for any non-trivial work, especially when multiple agents or parallel tasks may run at once. Every browser command accepts `--session <name>` (or `-s <name>`); the `BROWSE_SESSION` env var sets the default, and commands without either share the `default` session.
+
+```bash
+browse open https://example.com --session research --local
+browse snapshot --session research
+```
+
 Remote browser and cloud API commands require:
 
 ```bash
@@ -75,15 +84,34 @@ export BROWSERBASE_API_KEY=...
 Start by opening the page, then inspect state, act, and verify.
 
 ```bash
-browse open https://example.com --local
-browse snapshot
-browse click @0-5
-browse type "hello"
-browse snapshot
-browse stop
+browse open https://example.com --session research --local
+browse snapshot --session research
+browse click @0-5 --session research
+browse type "hello" --session research
+browse snapshot --session research
+browse stop --session research
 ```
 
 Prefer `browse snapshot` over screenshots for most browser work. It is structured, fast, and returns refs like `@0-5` for reliable element interaction. Use screenshots when visual layout, images, or pixel-level state matter.
+
+Refs are refreshed on every snapshot. After clicks, form submits, navigation, or UI re-renders, take a new snapshot before using another ref.
+
+## Parallel Browser Work
+
+Use a different `--session` value for each independent browser task. Sessions isolate tabs, cookies, refs, and daemon state; parallel tasks that omit `--session` share the `default` session and overwrite each other's active page.
+
+```bash
+browse open https://example.com/search-a --session search-a --local
+browse open https://example.com/search-b --session search-b --local
+browse snapshot --session search-a
+browse snapshot --session search-b
+```
+
+When a task is complete, stop only that task's session:
+
+```bash
+browse stop --session search-a
+```
 
 ## Core Browser Commands
 
@@ -164,6 +192,15 @@ browse stop --force
 ```
 
 Use `browse doctor` before debugging a broken browser session. Use `browse doctor --json` when another agent or CI needs structured diagnostics.
+
+If a page command reports that no active page is available, inspect and recover the named session:
+
+```bash
+browse status --session research
+browse tab list --session research
+browse tab new https://example.com --session research
+browse open https://example.com --session research
+```
 
 ## Cloud APIs
 
@@ -262,14 +299,15 @@ Use `browse skills find` when the exact skill slug is uncertain. Use `browse ski
 3. Re-run `browse snapshot` after navigation or DOM-changing actions because refs can change.
 4. Prefer refs from snapshots for clicks and uploads; use selectors or XPath when refs are unavailable.
 5. Use `--local` for localhost and repeatable development; use `--remote` for protected sites or Browserbase-specific behavior.
-6. Use `--auto-connect` only when attaching to an existing debuggable local Chrome session is intended.
-7. Use `browse doctor` when session startup, browser discovery, CDP attach, or Browserbase auth looks wrong.
-8. Use `browse stop` when finished to clean up daemon state.
-9. For unfamiliar command details, run `browse <topic> --help` and follow the exact dash-case flags.
+6. Use a distinct `--session <name>` for each parallel or long-running task; commands without the flag share the `default` session.
+7. Use `--auto-connect` only when attaching to an existing debuggable local Chrome session is intended.
+8. Use `browse doctor` when session startup, browser discovery, CDP attach, or Browserbase auth looks wrong.
+9. Use `browse stop` (or `browse stop --session <name>`) when finished to clean up daemon state.
+10. For unfamiliar command details, run `browse <topic> --help` and follow the exact dash-case flags.
 
 ## Troubleshooting
 
-- "No active page": run `browse status`, then `browse open <url>` or `browse stop --force` if the daemon is stale.
+- "No active page": run `browse status --session <name>`, then `browse open <url> --session <name>` or `browse tab new <url> --session <name>`; use `browse stop --force` if the daemon is stale.
 - Chrome not found: use `--remote` with Browserbase credentials, install Chrome, or attach with `--cdp`.
 - Action fails: run `browse snapshot` and use a visible ref from the current page state.
 - Remote command fails: verify `BROWSERBASE_API_KEY` and inspect `browse cloud projects list`.


### PR DESCRIPTION
Linear: https://linear.app/browserbase/issue/STG-2029/improve-browse-skill-session-guidance

Port of https://github.com/browserbase/cli/pull/108 from the deprecated standalone CLI repo, adapted for the current CLI rather than copied verbatim.

## Summary
- Default non-trivial workflows to named `--session` usage; document the `-s` shorthand and `BROWSE_SESSION` env fallback (both exist in `src/lib/driver/flags.ts` but were undocumented).
- Add a **Parallel Browser Work** section: distinct `--session` per independent task, selective `browse stop --session <name>`.
- Document that a running session locks its mode — flipping `--headed`/`--headless` on a live session hard-fails (`daemon/client.ts` `assertCompatibleTarget`) until the session is stopped. The original PR said this "creates a different browser session", which is no longer accurate.
- Add a no-active-page recovery flow (`status`, `tab list`, `tab new`, `open` with `--session`), matching the CLI's own error message in `session-manager.ts`.
- Inline the ref-refresh guidance in the workflow section; session-scope the existing "No active page" troubleshooting line.

## Why
Two parallel agents that omit `--session` share the `default` daemon and overwrite each other's active page. This is inherent to the daemon-per-named-session model — agent-browser and browser-use have the identical behavior (verified empirically) — and the category-wide mitigation is skill-level guidance, which agent-browser's bundled skill already ships and ours lacked.

No changeset: skill-text-only change, ships with the next regular `browse` release.

## E2E Test Matrix

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `<local build>`: task1 `open example.com --local`, task2 `open example.org --local` (no `--session`), task1 `get url` | task1's `get url` returned `https://example.org/` — active page clobbered by task2 | Proves the failure mode the new guidance prevents exists on this exact build |
| Same flow with `--session task-a` / `--session task-b`, then `stop --session task-a` | Each session returned its own URL; task-b alive and correct after task-a stopped | Proves named-session isolation + selective stop work as documented |
| `open --session task-a --local --headed` while task-a runs headless | `Session "task-a" is already running in managed-local mode. Run browse stop --session task-a before changing modes.` | Proves the mode-lock paragraph matches real CLI behavior |
| `tab list --session ghost` → `tab new https://example.com --session ghost` | Empty `"tabs": []`, then recovered to `https://example.com/` | Proves the documented recovery flow works on a fresh/empty session |
| `npx vitest run tests/skills.test.ts tests/skills-install.test.ts` | 22/22 passed | Skill packaging/install tests cover the edited file |
| `pnpm check` (tsc --noEmit) | Clean | Supporting only — no TS changes in this PR |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve `browse` skill docs to recommend named `--session` (with `-s` and `BROWSE_SESSION`), show parallel work with separate sessions and selective `browse stop --session`, clarify session mode-lock, and add a quick "no active page" recovery flow. Aligns with CLI behavior and prevents parallel agents from clobbering the `default` session (Linear STG-2029).

<sup>Written for commit 07a79d99b4d70a6cd372fd0394c483f115e37318. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

