### PR TITLE
[STG-2257] fix(ci): skip Stainless jobs for fork PRs

### DIFF
--- a/.github/workflows/stainless.yml
+++ b/.github/workflows/stainless.yml
@@ -19,7 +19,8 @@ env:
 
 jobs:
   preview:
-    if: github.event.action != 'closed'
+    # Fork PRs don't receive repo vars/secrets, so the Stainless action can only fail there
+    if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -40,7 +41,7 @@ jobs:
           config_path: stainless.yml
 
   merge:
-    if: github.event.action == 'closed' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+    if: github.event.action == 'closed' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Fork-triggered `pull_request` workflow runs don't receive repo configuration variables or secrets, so `STAINLESS_ORG`/`STAINLESS_PROJECT` arrive empty and the Stainless action dies immediately with `Input required and not supplied: project` on every external-contributor PR. Seen on #2241 (claimed copy of #2240): the fork PR's failing `preview` check attached to the shared head SHA, leaving the claimed PR red through no fault of its own.

This guards both jobs on `github.event.pull_request.head.repo.full_name == github.repository`:

- `preview` — skips on fork PRs instead of failing. Claimed copies of external PRs run in-repo, so SDK preview coverage is preserved.
- `merge` — same defect: a directly-merged fork PR would trigger a guaranteed-failing merge build (still no vars/secrets on the `closed` event). Skipping is strictly better than failing; the claim flow means merged external work is always in-repo anyway.

The `full_name` comparison is used instead of `!head.repo.fork` so a deleted fork repo (`head.repo == null`) skips rather than runs-and-fails.

Linear: [STG-2257](https://linear.app/browserbase/issue/STG-2257/fixci-skip-stainless-sdk-jobs-for-fork-prs)

## E2E Test Matrix

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| Failing fork run: [actions/runs/27375420406](https://github.com/browserbase/stagehand/actions/runs/27375420406/job/80903332001) (triggered by fork PR #2240) | Env dump shows `STAINLESS_ORG:` and `STAINLESS_PROJECT:` empty; action exits with `Error: Input required and not supplied: project` | Proves the root cause is withheld vars on fork runs, not the spec or config — exactly the case the new guard skips |
| `actionlint .github/workflows/stainless.yml` on this branch | Exit 0, no findings | Validates workflow schema and the new `if:` expression syntax |
| `preview` check on **this PR** (in-repo branch) | See checks below — job runs (guard evaluates true for same-repo PRs) and builds SDK previews | Live proof the guard doesn't skip in-repo PRs; the fork-skip path can only be exercised by the next real fork PR |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip Stainless CI jobs for fork-origin PRs to avoid failures from missing repo vars/secrets. Keeps external PRs green while coverage runs on in-repo “claimed” copies. Addresses Linear STG-2257.

- **Bug Fixes**
  - Skip `preview` and `merge` unless `github.event.pull_request.head.repo.full_name == github.repository`; `merge` still requires closed+merged into `main`.
  - Use the `full_name` check to safely skip deleted forks (`head.repo` can be null).

<sup>Written for commit 58c58917056a031241c4e4a32c93b785b91b84a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

