### PR TITLE
[STG-2274] docs(cli): add 401 playbook + anti-retry guidance to bundled browse skill

### DIFF
--- a/packages/cli/skills/browse/SKILL.md
+++ b/packages/cli/skills/browse/SKILL.md
@@ -139,8 +139,8 @@ browse get html "#main"
 browse get value "#email"
 browse get markdown body                   # page/element content as markdown
 browse eval "document.title"              # run JavaScript in the active page
-browse screenshot                         # print base64 JSON
-browse screenshot --path page.png
+browse screenshot --path page.png         # write the image to a file (recommended)
+browse screenshot                         # prints ~22KB of base64 to stdout — avoid in agent loops
 ```
 
 Interaction:
@@ -333,14 +333,17 @@ JSON output includes every match with full descriptions and ignores `--limit`; `
 6. Use a distinct `--session <name>` for each parallel or long-running task; commands without the flag share the `default` session.
 7. Use `--auto-connect` only when attaching to an existing debuggable local Chrome session is intended.
 8. Use `browse doctor` when session startup, browser discovery, CDP attach, or Browserbase auth looks wrong.
-9. Use `browse stop` (or `browse stop --session <name>`) when finished to clean up daemon state.
-10. For unfamiliar command details, run `browse <topic> --help` and follow the exact dash-case flags.
+9. Never retry a failing command unchanged. If the same command fails twice with the same error, stop — run `browse doctor --json`, then change approach (fix the key, switch `--local`/`--remote`, or `browse stop --force` and start fresh). Repeating an identical failing command will keep failing.
+10. Use `browse stop` (or `browse stop --session <name>`) when finished to clean up daemon state.
+11. For unfamiliar command details, run `browse <topic> --help` and follow the exact dash-case flags.
 
 ## Troubleshooting
 
 - "No active page": run `browse status --session <name>`, then `browse open <url> --session <name>` or `browse tab new <url> --session <name>`; use `browse stop --force` if the daemon is stale.
 - Chrome not found: use `--remote` with Browserbase credentials, install Chrome, or attach with `--cdp`.
 - Action fails: run `browse snapshot` and use a visible ref from the current page state.
+- 401 Unauthorized on `open`, `get`, or other driver commands: a set `BROWSERBASE_API_KEY` makes `browse` default to remote mode. Fix the key at https://browserbase.com/settings, unset it, or pass `--local` to run a managed local browser (no key needed).
+- Same command fails twice with the same error: stop retrying — never retry a failing command unchanged. Init failures are cached for several seconds, so instant retries return identical errors. Run `browse doctor --json`, then change approach: fix the key, switch `--local`/`--remote`, or `browse stop --force` and start fresh.
 - Remote command fails: verify `BROWSERBASE_API_KEY` and inspect `browse cloud projects list`.
 - Session setup is unclear: run `browse doctor` or `browse doctor --json`.
 - Protected site blocks local mode: retry with `--remote`.

--- a/packages/cli/skills/browse/SKILL.md
+++ b/packages/cli/skills/browse/SKILL.md
@@ -139,8 +139,8 @@ browse get html "#main"
 browse get value "#email"
 browse get markdown body                   # page/element content as markdown
 browse eval "document.title"              # run JavaScript in the active page
-browse screenshot --path page.png         # write the image to a file (recommended)
-browse screenshot                         # prints ~22KB of base64 to stdout — avoid in agent loops
+browse screenshot                         # print base64 JSON
+browse screenshot --path page.png
 ```
 
 Interaction:


### PR DESCRIPTION
## Summary

Linear: https://linear.app/browserbase/issue/STG-2274/add-death-loop-prevention-guidance-to-bundled-browse-skill

Adds death-loop prevention guidance to the bundled browse skill (`packages/cli/skills/browse/SKILL.md`) — the skill agents install via `browse skills install`.

## Impact if merged

Most agent traffic reaches the CLI through this bundled skill — it is the agent interface. The current text has no 401/invalid-key playbook and no anti-retry rule, the two behaviors behind the death-loop population: 71 installs generating 92.3% of all CLI telemetry (~5.5M events/30d) retrying `get`/`screenshot`, including ~375k events from tagged claude-code/codex agents — the core ICP. Docs-only, zero runtime risk; pairs with the in-flight driver-error remediation PR (the code-side fix for the same loops).

## Changes

1. **401 playbook** (Troubleshooting): a set `BROWSERBASE_API_KEY` makes `browse` default to remote mode (`src/lib/driver/remote.ts` `defaultRemoteTarget`), so an invalid key turns every driver command into a 401. New entry tells agents to fix the key at https://browserbase.com/settings, unset it, or pass `--local`.
2. **Anti-retry rule** (Best Practices #9 + Troubleshooting): never retry a failing command unchanged — if the same command fails twice with the same error, stop, run `browse doctor --json`, then change approach. Init failures are cached in the daemon for several seconds (`INIT_FAILURE_RETRY_MS` in `session-manager.ts`), so instant retries return identical errors.
~~3. Screenshot guidance~~ — moved to #2246 per review, where it documents the new file-by-default behavior that PR ships (reverted here in cb6e0c6db).

No changeset: docs/prompt-text only — ships with the next regular `browse` release, no version bump needed.

## E2E Test Matrix

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `<local build>`: `pnpm turbo run build --filter=browse...` then `node bin/run.js skills install` | Installed from `<worktree>/packages/cli/skills/browse` to `~/.agents/skills/browse` across 71 agents (universal + symlinked) | Proves the bundled skill file under review is exactly what `skills install` ships |
| `grep -n "401 Unauthorized\|Never retry a failing command\|stop retrying" ~/.agents/skills/browse/SKILL.md` | 3 hits: Best Practices #9 (anti-retry), 401 troubleshooting entry, Troubleshooting anti-retry rule | Proves both remaining additions are present in the installed copy agents actually read (screenshot row moved to #2246) |
| `npx vitest run tests/skills.test.ts tests/skills-install.test.ts` | 22/22 passed | Skill packaging/install tests cover the edited file's frontmatter and install path |
| `npx vitest run` (full packages/cli suite) | 213/213 passed, 15 files | Supporting — proves no CLI breakage; this PR touches no TS |
| `npx prettier --check packages/cli/skills/browse/SKILL.md` | "All matched files use Prettier code style!" | Formatting matches repo style |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a 401 troubleshooting playbook and an anti-retry rule to the bundled `browse` skill docs to prevent agent death-loops and reduce noisy telemetry. Addresses Linear STG-2274; docs-only change in `packages/cli/skills/browse/SKILL.md`.

- **Docs**
  - 401 Unauthorized playbook for invalid `BROWSERBASE_API_KEY` (fix the key, unset it, or use `--local`).
  - Anti-retry rule: never repeat an unchanged failing command. If it fails twice, stop, run `browse doctor --json`, then change approach (fix key, switch `--local`/`--remote`, or `browse stop --force`). Init failures can be cached for a few seconds, so instant retries re-fail.

<sup>Written for commit cb6e0c6db08024844ed3c45bcd8f47060db6a89f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


