### PR TITLE
[STG-2275] feat(cli): default screenshot to file output (--base64 for legacy stdout)

### DIFF
--- a/.changeset/screenshot-default-file.md
+++ b/.changeset/screenshot-default-file.md
@@ -1,5 +1,5 @@
 ---
-"browse": patch
+"browse": minor
 ---
 
 `browse screenshot` now writes a file by default instead of printing base64 to stdout. Bare invocations save to `screenshot-<yyyymmdd-hhmmss>.<type>` in the current directory (with a collision counter instead of overwriting) and print `{ "saved": "<path>" }`. A new `--base64` flag preserves the legacy behavior of printing `{ "base64": "..." }` to stdout; it is mutually exclusive with `--path`. `--path` behavior is unchanged.

--- a/.changeset/screenshot-default-file.md
+++ b/.changeset/screenshot-default-file.md
@@ -1,7 +1,7 @@
 ---
-"browse": minor
+"browse": patch
 ---
 
 `browse screenshot` now writes a file by default instead of printing base64 to stdout. Bare invocations save to `screenshot-<yyyymmdd-hhmmss>.<type>` in the current directory (with a collision counter instead of overwriting) and print `{ "saved": "<path>" }`. A new `--base64` flag preserves the legacy behavior of printing `{ "base64": "..." }` to stdout; it is mutually exclusive with `--path`. `--path` behavior is unchanged.
 
-This is a minor (not patch) bump because bare `browse screenshot` changes its stdout contract from `{ base64 }` to `{ saved }` — scripts that parsed the base64 output must now pass `--base64`.
+Note for scripts that parsed the bare-invocation base64 output: pass `--base64` to keep the old stdout contract.

--- a/.changeset/screenshot-default-file.md
+++ b/.changeset/screenshot-default-file.md
@@ -1,0 +1,7 @@
+---
+"browse": minor
+---
+
+`browse screenshot` now writes a file by default instead of printing base64 to stdout. Bare invocations save to `screenshot-<yyyymmdd-hhmmss>.<type>` in the current directory (with a collision counter instead of overwriting) and print `{ "saved": "<path>" }`. A new `--base64` flag preserves the legacy behavior of printing `{ "base64": "..." }` to stdout; it is mutually exclusive with `--path`. `--path` behavior is unchanged.
+
+This is a minor (not patch) bump because bare `browse screenshot` changes its stdout contract from `{ base64 }` to `{ saved }` — scripts that parsed the base64 output must now pass `--base64`.

--- a/packages/cli/skills/browse/SKILL.md
+++ b/packages/cli/skills/browse/SKILL.md
@@ -139,8 +139,9 @@ browse get html "#main"
 browse get value "#email"
 browse get markdown body                   # page/element content as markdown
 browse eval "document.title"              # run JavaScript in the active page
-browse screenshot                         # print base64 JSON
-browse screenshot --path page.png
+browse screenshot                         # saves screenshot-<timestamp>.png, prints { "saved": "<path>" }
+browse screenshot --path page.png         # choose the output path
+browse screenshot --base64                # legacy: print base64 JSON to stdout (avoid in agent loops)
 ```
 
 Interaction:

--- a/packages/cli/src/commands/screenshot.ts
+++ b/packages/cli/src/commands/screenshot.ts
@@ -48,7 +48,7 @@ export default class Screenshot extends BrowseCommand {
     path: Flags.string({
       char: "p",
       description:
-        "Write the screenshot to this file. Defaults to screenshot-<timestamp>.<type> in the current directory.",
+        "Write the screenshot to this file. Defaults to screenshot-<timestamp>.png (or .jpeg with --type jpeg) in the current directory.",
       helpValue: "<path>",
     }),
     quality: Flags.integer({
@@ -63,10 +63,7 @@ export default class Screenshot extends BrowseCommand {
 
   async run(): Promise<void> {
     const { flags } = await this.parse(Screenshot);
-    const defaultPath =
-      flags.path || flags.base64
-        ? undefined
-        : reserveDefaultScreenshotPath(flags.type);
+    const defaultPath = getDefaultPathFromFlags(flags);
     try {
       await runDriverCommandFromFlags(
         "screenshot",
@@ -88,10 +85,30 @@ export default class Screenshot extends BrowseCommand {
   }
 }
 
+// Generous upper bound on filename-collision retries; far beyond any real
+// same-second burst, it just guarantees the loop below always terminates.
+const MAX_RESERVE_ATTEMPTS = 1000;
+
+/**
+ * Resolves the file the screenshot should be written to, or undefined when the
+ * driver should return base64 (explicit --path is handled separately; --base64
+ * opts out of a file entirely).
+ */
+function getDefaultPathFromFlags(flags: {
+  path?: string;
+  base64?: boolean;
+  type?: string;
+}): string | undefined {
+  if (flags.path || flags.base64) return undefined;
+  return reserveDefaultScreenshotPath(flags.type);
+}
+
 /**
  * Picks the next free screenshot-<timestamp>[-<counter>].<type> name in the
- * current directory and atomically reserves it with an exclusive create, so
- * concurrent invocations can never claim (and overwrite) the same file.
+ * current directory and reserves it. "Reserve" = create the file with an
+ * exclusive open (`wx` → O_CREAT|O_EXCL), which atomically fails with EEXIST if
+ * the name already exists, so two concurrent runs can never claim the same
+ * file. On EEXIST we advance the counter and try the next name.
  */
 function reserveDefaultScreenshotPath(type: string | undefined): string {
   const now = new Date();
@@ -100,21 +117,30 @@ function reserveDefaultScreenshotPath(type: string | undefined): string {
     `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}` +
     `-${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
   const extension = type === "jpeg" ? "jpeg" : "png";
-  for (let counter = 1; ; counter += 1) {
+  for (let counter = 1; counter <= MAX_RESERVE_ATTEMPTS; counter += 1) {
     const suffix = counter === 1 ? "" : `-${counter}`;
     const candidate = resolve(`screenshot-${stamp}${suffix}.${extension}`);
     try {
+      // Exclusive create reserves the name; close immediately since the driver
+      // (re)writes the file. The empty placeholder is cleaned up on failure.
       closeSync(openSync(candidate, "wx"));
       return candidate;
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
     }
   }
+  throw new Error(
+    `Could not reserve a screenshot filename after ${MAX_RESERVE_ATTEMPTS} attempts; pass --path to choose one.`,
+  );
 }
 
+// Removes the reserved placeholder when the screenshot failed before the driver
+// wrote to it. `path` is always a file we created via openSync above, so the
+// isFile guard is just defensive against an unexpected directory/symlink.
 function removeIfEmpty(path: string): void {
   try {
-    if (statSync(path).size === 0) unlinkSync(path);
+    const stats = statSync(path);
+    if (stats.isFile() && stats.size === 0) unlinkSync(path);
   } catch {
     // Best effort: leave the placeholder behind rather than mask the error.
   }

--- a/packages/cli/src/commands/screenshot.ts
+++ b/packages/cli/src/commands/screenshot.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { closeSync, openSync, statSync, unlinkSync } from "node:fs";
 import { resolve } from "node:path";
 
 import { Flags } from "@oclif/core";
@@ -63,35 +63,59 @@ export default class Screenshot extends BrowseCommand {
 
   async run(): Promise<void> {
     const { flags } = await this.parse(Screenshot);
-    const path =
-      flags.path ??
-      (flags.base64 ? undefined : defaultScreenshotPath(flags.type));
-    await runDriverCommandFromFlags(
-      "screenshot",
-      {
-        animations: flags.animations,
-        caret: flags.caret,
-        clip: parseClip(flags.clip),
-        fullPage: flags["full-page"],
-        path,
-        quality: flags.quality,
-        type: flags.type,
-      },
-      flags,
-    );
+    const defaultPath =
+      flags.path || flags.base64
+        ? undefined
+        : reserveDefaultScreenshotPath(flags.type);
+    try {
+      await runDriverCommandFromFlags(
+        "screenshot",
+        {
+          animations: flags.animations,
+          caret: flags.caret,
+          clip: parseClip(flags.clip),
+          fullPage: flags["full-page"],
+          path: flags.path ?? defaultPath,
+          quality: flags.quality,
+          type: flags.type,
+        },
+        flags,
+      );
+    } catch (error) {
+      if (defaultPath) removeIfEmpty(defaultPath);
+      throw error;
+    }
   }
 }
 
-function defaultScreenshotPath(type: string | undefined): string {
+/**
+ * Picks the next free screenshot-<timestamp>[-<counter>].<type> name in the
+ * current directory and atomically reserves it with an exclusive create, so
+ * concurrent invocations can never claim (and overwrite) the same file.
+ */
+function reserveDefaultScreenshotPath(type: string | undefined): string {
   const now = new Date();
   const pad = (value: number) => String(value).padStart(2, "0");
   const stamp =
     `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}` +
     `-${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
   const extension = type === "jpeg" ? "jpeg" : "png";
-  let candidate = resolve(`screenshot-${stamp}.${extension}`);
-  for (let counter = 2; existsSync(candidate); counter += 1) {
-    candidate = resolve(`screenshot-${stamp}-${counter}.${extension}`);
+  for (let counter = 1; ; counter += 1) {
+    const suffix = counter === 1 ? "" : `-${counter}`;
+    const candidate = resolve(`screenshot-${stamp}${suffix}.${extension}`);
+    try {
+      closeSync(openSync(candidate, "wx"));
+      return candidate;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    }
   }
-  return candidate;
+}
+
+function removeIfEmpty(path: string): void {
+  try {
+    if (statSync(path).size === 0) unlinkSync(path);
+  } catch {
+    // Best effort: leave the placeholder behind rather than mask the error.
+  }
 }

--- a/packages/cli/src/commands/screenshot.ts
+++ b/packages/cli/src/commands/screenshot.ts
@@ -1,3 +1,6 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
 import { Flags } from "@oclif/core";
 
 import { BrowseCommand } from "../base.js";
@@ -12,10 +15,12 @@ export default class Screenshot extends BrowseCommand {
     "Capture a screenshot of the active browser page.";
 
   static override examples = [
+    "browse screenshot",
     "browse screenshot --path page.png",
-    "browse screenshot --full-page --path page.png",
+    "browse screenshot --full-page",
     "browse screenshot --type jpeg --quality 80",
     "browse screenshot --clip 0,0,800,600 --path clipped.png",
+    "browse screenshot --base64",
   ];
 
   static override flags = {
@@ -23,6 +28,11 @@ export default class Screenshot extends BrowseCommand {
     animations: Flags.string({
       description: "Whether CSS animations run during capture.",
       options: ["allow", "disabled"],
+    }),
+    base64: Flags.boolean({
+      description:
+        "Print base64 to stdout instead of writing a file (legacy default).",
+      exclusive: ["path"],
     }),
     caret: Flags.string({
       description: "Whether text caret is hidden during capture.",
@@ -38,7 +48,7 @@ export default class Screenshot extends BrowseCommand {
     path: Flags.string({
       char: "p",
       description:
-        "Write the screenshot to a file. Without this flag, base64 is printed.",
+        "Write the screenshot to this file. Defaults to screenshot-<timestamp>.<type> in the current directory.",
       helpValue: "<path>",
     }),
     quality: Flags.integer({
@@ -53,6 +63,9 @@ export default class Screenshot extends BrowseCommand {
 
   async run(): Promise<void> {
     const { flags } = await this.parse(Screenshot);
+    const path =
+      flags.path ??
+      (flags.base64 ? undefined : defaultScreenshotPath(flags.type));
     await runDriverCommandFromFlags(
       "screenshot",
       {
@@ -60,11 +73,25 @@ export default class Screenshot extends BrowseCommand {
         caret: flags.caret,
         clip: parseClip(flags.clip),
         fullPage: flags["full-page"],
-        path: flags.path,
+        path,
         quality: flags.quality,
         type: flags.type,
       },
       flags,
     );
   }
+}
+
+function defaultScreenshotPath(type: string | undefined): string {
+  const now = new Date();
+  const pad = (value: number) => String(value).padStart(2, "0");
+  const stamp =
+    `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}` +
+    `-${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
+  const extension = type === "jpeg" ? "jpeg" : "png";
+  let candidate = resolve(`screenshot-${stamp}.${extension}`);
+  for (let counter = 2; existsSync(candidate); counter += 1) {
+    candidate = resolve(`screenshot-${stamp}-${counter}.${extension}`);
+  }
+  return candidate;
 }


### PR DESCRIPTION
## Summary

Bare `browse screenshot` now writes a file by default — `screenshot-<yyyymmdd-hhmmss>.<type>` in the current directory, never overwriting (atomic collision counter) — and prints the small `{ "saved": "<path>" }` JSON. A new `--base64` flag preserves the legacy stdout contract (`{ "base64": "..." }`); it is mutually exclusive with `--path`. Explicit `--path` behavior is unchanged.

Linear: [STG-2275](https://linear.app/browserbase/issue/STG-2275/default-browse-screenshot-to-file-output-with-base64-legacy-flag)

## Impact if merged

screenshot is one of the two commands in the runaway agent retry loops (the loop population generates 92.3% of all CLI telemetry) and is used by 1,337 users/30d (89.9% success last-7d). Every bare invocation today prints ~22KB of base64 JSON directly into the calling agent's context window — a per-call token tax on exactly the ICP population (claude-code/codex agents driving the CLI; agent-tagged usage is 90%-successful and growing). Defaulting to a file write makes the common case agent-safe at zero cost to `--path` users; `--base64` preserves the old contract for scripts. Stdout contract change for bare invocations is called out in the changeset with a `--base64` migration note (minor bump — the bare-invocation stdout contract changes; `browse` is `<1.0.0` so this is advisory).

## Implementation notes

- **Breaking change (stdout contract):** bare `browse screenshot` now prints `{ "saved": "<path>" }` instead of `{ "base64": "..." }`. **Migration:** pass `--base64` to restore the old output.
- Command-layer only: the driver handler (`runtime.ts`) already supported both branches (`{ saved }` when a path is given, `{ base64 }` otherwise), so the change is confined to `src/commands/screenshot.ts`.
- Default filename respects `--type` (`.jpeg` vs `.png`) and resolves against the invoking shell's cwd (absolute path passed to the driver so a daemon with a different cwd can't misplace the file).
- The default filename is **atomically reserved** via exclusive create (`openSync(path, "wx")`), advancing a `-2`, `-3`, ... counter on `EEXIST` — concurrent same-second invocations can never claim the same file (addresses cubic's race-condition review). If the command fails afterward, the empty placeholder is removed best-effort.
- `--base64` is mutually exclusive with `--path` via oclif's `exclusive` option.
- Changeset: `browse` **minor** (per review) — the bare-invocation stdout contract change is called out in the changeset body with the `--base64` migration note.
- Bundled skill doc: `skills/browse/SKILL.md` screenshot snippet updated in this PR (moved from #2245 per review) to document the new default: bare saves a file, `--path` chooses it, `--base64` is the legacy stdout form.

## E2E Test Matrix

All rows ran against the local build (`pnpm build` in `packages/cli`, invoked as `node bin/run.js`) from a `<scratch dir>`.

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `node bin/run.js open https://example.com` | `{ "title": "Example Domain", "url": "https://example.com/", ... }`, exit 0 | Session setup for the runs below; proves the local build is functional end-to-end. |
| `node bin/run.js screenshot` (bare) | `{ "saved": "<scratch dir>/screenshot-20260612-123732.png" }`, exit 0; `ls -la` shows the file at 15,988 bytes; stdout is the small JSON only | Proves the new default: file written to cwd with timestamped name, no base64 on stdout. |
| `node bin/run.js screenshot --base64 \| head -c 200` | `{ "base64": "iVBORw0KGgoAAAANSUhEUgAABQgAAALH..."` (PNG magic in base64), exit 0 | Proves the legacy stdout contract is fully preserved behind `--base64`. |
| `node bin/run.js screenshot --path /tmp/custom.png` | `{ "saved": "/tmp/custom.png" }`, exit 0; file exists at 15,238 bytes | Proves explicit `--path` behavior is unchanged. |
| Two **concurrent** bare runs (same second, shell `&` + `wait`) | `{ "saved": ".../screenshot-20260612-123741.png" }` and `{ "saved": ".../screenshot-20260612-123741-2.png" }`; both files present and non-empty (4,202 bytes each) | Proves the atomic no-overwrite reservation under true same-second concurrency — the exact race cubic flagged. |
| `node bin/run.js screenshot --cdp http://127.0.0.1:1` (forced failure) | `TypeError: fetch failed`, nonzero exit; directory left empty — no placeholder file | Proves failed runs do not leave empty `screenshot-*.png` placeholders behind. |
| `node bin/run.js screenshot --base64 --path /tmp/x.png` | `Error: --path=/tmp/x.png cannot also be provided when using --base64`, exit 2 | Proves the oclif mutual exclusion works. |
| `node bin/run.js stop` | `{ "stopped": true, "session": "default" }`, exit 0 | Clean session teardown. |
| `pnpm test` (packages/cli) | `Test Files 15 passed (15), Tests 213 passed (213)` — re-run after the race fix | Supporting: no regressions in the existing CLI suite (includes the screenshot `--help` surface test). |
| `pnpm lint` (packages/cli) | tsc/eslint/prettier clean | Supporting only. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


