### PR TITLE
[STG-2276] feat(cli): once-per-install open nudge after cloud search/fetch

### DIFF
--- a/.changeset/cloud-open-nudge.md
+++ b/.changeset/cloud-open-nudge.md
@@ -1,0 +1,5 @@
+---
+"browse": patch
+---
+
+Nudge cloud search/fetch users toward `browse open`. After a successful `browse cloud search` or `browse cloud fetch`, the CLI prints a one-line, once-per-install tip to stderr pointing at `browse open <url>` — stdout stays machine-clean, the tip never fires on failures, and it can be disabled with `BROWSE_DISABLE_OPEN_NUDGE=1` (also skipped in CI and tests). The once-per-install marker lives in the CLI cache dir (`open-nudge.json`), mirroring the existing update-check/skill-nudge cache-file pattern.

--- a/packages/cli/src/commands/cloud/fetch.ts
+++ b/packages/cli/src/commands/cloud/fetch.ts
@@ -10,6 +10,7 @@ import {
 import { apiCommonFlags, toApiOptions } from "../../lib/cloud/flags.js";
 import { BrowseCommand } from "../../base.js";
 import { fail } from "../../lib/errors.js";
+import { writeOpenNudge } from "../../lib/open-nudge.js";
 
 const fetchFormats = ["raw", "markdown", "json"] as const;
 type FetchFormat = (typeof fetchFormats)[number];
@@ -86,10 +87,11 @@ export default class Fetch extends BrowseCommand {
         statusCode: result.statusCode,
         sizeBytes: Buffer.byteLength(contents, "utf8"),
       });
-      return;
+    } else {
+      outputJson(result);
     }
 
-    outputJson(result);
+    await writeOpenNudge(this.config.cacheDir);
   }
 }
 

--- a/packages/cli/src/commands/cloud/search.ts
+++ b/packages/cli/src/commands/cloud/search.ts
@@ -7,6 +7,7 @@ import {
 } from "../../lib/cloud/api.js";
 import { apiCommonFlags, toApiOptions } from "../../lib/cloud/flags.js";
 import { BrowseCommand } from "../../base.js";
+import { writeOpenNudge } from "../../lib/open-nudge.js";
 import {
   outputFormatFlags,
   outputTable,
@@ -80,25 +81,22 @@ export default class Search extends BrowseCommand {
         console.log(
           `Wrote ${result.results.length} results for "${result.query}" to ${flags.output}.`,
         );
-        return;
+      } else {
+        outputJson({
+          ok: true,
+          outputPath: flags.output,
+          requestId: result.requestId,
+          query: result.query,
+          resultCount: result.results.length,
+        });
       }
-
-      outputJson({
-        ok: true,
-        outputPath: flags.output,
-        requestId: result.requestId,
-        query: result.query,
-        resultCount: result.results.length,
-      });
-      return;
-    }
-
-    if (outputFormat === "table") {
+    } else if (outputFormat === "table") {
       outputSearchTable(result.results, { wide: flags.wide });
-      return;
+    } else {
+      outputJson(result);
     }
 
-    outputJson(result);
+    await writeOpenNudge(this.config.cacheDir);
   }
 }
 

--- a/packages/cli/src/lib/open-nudge.ts
+++ b/packages/cli/src/lib/open-nudge.ts
@@ -35,8 +35,9 @@ export async function maybeNudgeOpen(
     return null;
   }
 
-  await writeNudgeMarker(cachePath);
-  return OPEN_NUDGE_HINT;
+  // Only nudge when the marker actually lands, so an unwritable cache dir
+  // can't cause the "once-per-install" tip to fire on every run.
+  return (await writeNudgeMarker(cachePath)) ? OPEN_NUDGE_HINT : null;
 }
 
 /**
@@ -97,7 +98,7 @@ async function markerExists(cachePath: string): Promise<boolean> {
   }
 }
 
-async function writeNudgeMarker(cachePath: string): Promise<void> {
+async function writeNudgeMarker(cachePath: string): Promise<boolean> {
   try {
     await mkdir(dirname(cachePath), { recursive: true });
     await writeFile(
@@ -105,7 +106,9 @@ async function writeNudgeMarker(cachePath: string): Promise<void> {
       `${JSON.stringify({ shownAt: new Date().toISOString() })}\n`,
       "utf8",
     );
+    return true;
   } catch {
     // Best-effort marker writes should never affect CLI behavior.
+    return false;
   }
 }

--- a/packages/cli/src/lib/open-nudge.ts
+++ b/packages/cli/src/lib/open-nudge.ts
@@ -1,0 +1,111 @@
+import { constants } from "node:fs";
+import { access, mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+export const OPEN_NUDGE_HINT =
+  "Tip: open any of these in a live browser — browse open <url> (no API key needed locally).";
+
+const OPEN_NUDGE_MARKER_FILE = "open-nudge.json";
+
+interface OpenNudgeOptions {
+  cacheFile?: string;
+}
+
+/**
+ * Once-per-install nudge from a successful `cloud search`/`cloud fetch`
+ * toward `browse open`. Returns the hint the first time it fires — the caller
+ * prints it to stderr so machine-readable stdout stays clean — and null once
+ * the install marker exists. Best-effort: any failure yields null so it can
+ * never affect CLI behavior.
+ */
+export async function maybeNudgeOpen(
+  options: OpenNudgeOptions = {},
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<string | null> {
+  if (isNudgeDisabled(env)) {
+    return null;
+  }
+
+  const cachePath = options.cacheFile;
+  if (!cachePath) {
+    return null;
+  }
+
+  if (await markerExists(cachePath)) {
+    return null;
+  }
+
+  await writeNudgeMarker(cachePath);
+  return OPEN_NUDGE_HINT;
+}
+
+/**
+ * Print the once-per-install `browse open` hint to stderr, keyed on a marker
+ * file in the CLI cache dir. Called by cloud commands after successful output.
+ */
+export async function writeOpenNudge(
+  cacheDir: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+  try {
+    const hint = await maybeNudgeOpen(
+      { cacheFile: join(cacheDir, OPEN_NUDGE_MARKER_FILE) },
+      env,
+    );
+    if (hint) {
+      process.stderr.write(`\n${hint}\n`);
+    }
+  } catch {
+    // Best-effort nudges should never affect command output.
+  }
+}
+
+function isNudgeDisabled(env: NodeJS.ProcessEnv): boolean {
+  if (
+    env.BROWSE_DISABLE_OPEN_NUDGE === "1" ||
+    env.BB_DISABLE_OPEN_NUDGE === "1"
+  ) {
+    return true;
+  }
+  if (env.NODE_ENV === "test") {
+    return true;
+  }
+  return isCiEnvironment(env);
+}
+
+function isCiEnvironment(env: NodeJS.ProcessEnv): boolean {
+  const value = env.CI;
+  if (!value) {
+    return false;
+  }
+  const normalized = value.trim().toLowerCase();
+  return !(
+    normalized === "" ||
+    normalized === "0" ||
+    normalized === "false" ||
+    normalized === "no" ||
+    normalized === "off"
+  );
+}
+
+async function markerExists(cachePath: string): Promise<boolean> {
+  try {
+    await access(cachePath, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function writeNudgeMarker(cachePath: string): Promise<void> {
+  try {
+    await mkdir(dirname(cachePath), { recursive: true });
+    await writeFile(
+      cachePath,
+      `${JSON.stringify({ shownAt: new Date().toISOString() })}\n`,
+      "utf8",
+    );
+  } catch {
+    // Best-effort marker writes should never affect CLI behavior.
+  }
+}

--- a/packages/cli/tests/open-nudge.test.ts
+++ b/packages/cli/tests/open-nudge.test.ts
@@ -1,0 +1,70 @@
+import { access } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { maybeNudgeOpen, OPEN_NUDGE_HINT } from "../src/lib/open-nudge.js";
+
+const cleanupPaths: string[] = [];
+
+afterEach(async () => {
+  while (cleanupPaths.length > 0) {
+    const path = cleanupPaths.pop();
+    if (!path) continue;
+    await rm(path, { recursive: true, force: true });
+  }
+});
+
+async function freshCacheFile(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "browse-open-nudge-"));
+  cleanupPaths.push(dir);
+  return join(dir, "open-nudge.json");
+}
+
+const enabledEnv: NodeJS.ProcessEnv = { NODE_ENV: "development", CI: "" };
+
+describe("maybeNudgeOpen", () => {
+  it("returns the hint once, then honors the install marker", async () => {
+    const cacheFile = await freshCacheFile();
+    expect(await maybeNudgeOpen({ cacheFile }, enabledEnv)).toBe(
+      OPEN_NUDGE_HINT,
+    );
+    await expect(access(cacheFile)).resolves.toBeUndefined();
+    expect(await maybeNudgeOpen({ cacheFile }, enabledEnv)).toBeNull();
+  });
+
+  it("respects BROWSE_DISABLE_OPEN_NUDGE and BB_DISABLE_OPEN_NUDGE", async () => {
+    const cacheFile = await freshCacheFile();
+    expect(
+      await maybeNudgeOpen(
+        { cacheFile },
+        { ...enabledEnv, BROWSE_DISABLE_OPEN_NUDGE: "1" },
+      ),
+    ).toBeNull();
+    expect(
+      await maybeNudgeOpen(
+        { cacheFile },
+        { ...enabledEnv, BB_DISABLE_OPEN_NUDGE: "1" },
+      ),
+    ).toBeNull();
+  });
+
+  it("does not nudge in CI or test environments", async () => {
+    const cacheFile = await freshCacheFile();
+    expect(
+      await maybeNudgeOpen(
+        { cacheFile },
+        { NODE_ENV: "development", CI: "true" },
+      ),
+    ).toBeNull();
+    expect(
+      await maybeNudgeOpen({ cacheFile }, { NODE_ENV: "test", CI: "" }),
+    ).toBeNull();
+  });
+
+  it("returns null when no cache file is configured", async () => {
+    expect(await maybeNudgeOpen({}, enabledEnv)).toBeNull();
+  });
+});

--- a/packages/cli/tests/open-nudge.test.ts
+++ b/packages/cli/tests/open-nudge.test.ts
@@ -1,5 +1,4 @@
-import { access } from "node:fs/promises";
-import { mkdtemp, rm } from "node:fs/promises";
+import { access, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -66,5 +65,13 @@ describe("maybeNudgeOpen", () => {
 
   it("returns null when no cache file is configured", async () => {
     expect(await maybeNudgeOpen({}, enabledEnv)).toBeNull();
+  });
+
+  it("returns null when the marker cannot be written", async () => {
+    // Parent "directory" is a regular file, so mkdir/writeFile must fail.
+    const blocker = await freshCacheFile();
+    await writeFile(blocker, "not a directory\n", "utf8");
+    const cacheFile = join(blocker, "open-nudge.json");
+    expect(await maybeNudgeOpen({ cacheFile }, enabledEnv)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Linear: https://linear.app/browserbase/issue/STG-2276/nudge-cloud-searchfetch-users-toward-browse-open

After a successful `browse cloud search` or `browse cloud fetch`, the CLI now prints a one-line, **once-per-install** tip to **stderr**:

```
Tip: open any of these in a live browser — browse open <url> (no API key needed locally).
```

This mirrors the in-flight #2200 skill-nudge mechanism (cache file in oclif `config.cacheDir`, stderr-only, best-effort try/catch, same `BROWSE_DISABLE_*`/`BB_DISABLE_*` + CI/`NODE_ENV=test` gating) so the two nudges feel like one system — if #2200 lands first this should rebase trivially (no shared files beyond the same conventions).

## Impact if merged

The single largest activation gap in the funnel: 58% of real users (3,335 of 5,822/30d) never attempt a browser session — they arrive through cloud.search/cloud.fetch (the #1 and #6 commands by real-user adoption) and leave. The data says getting them to one successful open is decisive: 79% of users who get one successful open chain 3+ more successful commands within the hour, local-browser users retain 29x better than cloud-only users (10.5% vs 0.36% multi-day), and a failed first command cuts 7-day retention 12.4x. One stderr-only, once-per-install line after a successful cloud call is the lowest-LOC lever on that 58%: zero stdout pollution for scripts/agents, fires exactly once.

## Implementation notes

- New `packages/cli/src/lib/open-nudge.ts`: `maybeNudgeOpen({ cacheFile })` returns the hint and writes the marker if absent, else `null`; `writeOpenNudge(cacheDir)` is the command-side wrapper that resolves `open-nudge.json` under `config.cacheDir` and prints to stderr.
- Called at the end of the success path of `cloud/search.ts` and `cloud/fetch.ts` only — API failures throw before the call, so the tip can never fire on errors.
- Opt-out follows the existing convention (`BROWSE_DISABLE_UPDATE_CHECK` / #2200's `BROWSE_DISABLE_SKILL_NUDGE`): `BROWSE_DISABLE_OPEN_NUDGE=1` / `BB_DISABLE_OPEN_NUDGE=1`, plus skipped in CI and `NODE_ENV=test` (mirroring #2200's gates verbatim).
- Marker is a tiny JSON (`{"shownAt": ...}`) matching the `update-check.json` / `skill-nudge.json` cache-file family.
- Unit test `tests/open-nudge.test.ts` follows #2200's `skill-nudge.test.ts` pattern (temp cache file, env injected explicitly).
- Changeset: patch bump for `browse`, same shape as #2210's.

## E2E Test Matrix

All rows ran against the local build (`pnpm turbo run build --filter=browse`, then `node packages/cli/bin/run.js`) with real Browserbase credentials, `NODE_ENV=production`, `CI` unset, and `BROWSE_CACHE_DIR` pointed at a fresh temp dir per scenario.

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `BROWSE_CACHE_DIR=<fresh temp dir> node bin/run.js cloud search "weather today" 1><out.json> 2><err.txt>` (live Search API) | exit 0; stderr: `Tip: open any of these in a live browser — browse open <url> (no API key needed locally).`; `jq -r '.results[0].url' <out.json>` → `https://www.weather.gov/` (stdout parses as pure JSON); marker written: `open-nudge.json` = `{"shownAt":"2026-06-12T19:29:34.435Z"}` | Proves the core feature end-to-end on the live API: tip on stderr, stdout machine-clean (jq parse is the purity proof), marker created. |
| Same `cloud search` command again, same cache dir | exit 0; **stderr 0 bytes**; stdout still parses (`jq -r '.query'` → `weather today`) | Proves once-per-install: marker honored, second run completely silent on stderr. |
| `BROWSE_CACHE_DIR=<fresh temp dir> node bin/run.js cloud fetch https://example.com` (live Fetch API), then run again | 1st run: exit 0, `jq -r '.statusCode'` → `200`, tip on stderr; 2nd run: exit 0, stderr 0 bytes | Proves the nudge fires from `cloud fetch` too and shares the same marker semantics. |
| `cloud search` with `BROWSERBASE_API_KEY` unset, fresh cache dir | exit 1; stderr is only the existing missing-key error (`Missing Browserbase API key. ...`); **no tip**; stdout 0 bytes; **no marker file created** | Proves failure paths never nudge and never consume the once-per-install marker. |
| Post-review-fix re-smoke: fresh cache dir, live `cloud search` twice (commit 8d70661) | 1st run: exit 0, tip on stderr, `jq -r '.results[0].url'` → `https://www.weather.gov/`; 2nd run: exit 0, stderr 0 bytes | Proves the cubic fix (marker-write success gating) didn't regress the live happy path. |
| `pnpm vitest run` (packages/cli) | 16 files, 217 tests passed pre-fix; `tests/open-nudge.test.ts` now 5 tests post-fix (marker, opt-out envs, CI/test gating, missing cache file, unwritable marker → no nudge) | Supporting: no regressions across the CLI suite; unit-covers the gating matrix the live runs don't (CI, opt-out envs, unwritable cache dir). |
| `pnpm run lint` (packages/cli: prettier + eslint + tsc --noEmit) | exit 0 | Supporting only. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
