### PR TITLE
[STG-2278] feat(cli): did-you-mean + telemetry for unknown commands

### DIFF
--- a/.changeset/command-not-found-suggestions.md
+++ b/.changeset/command-not-found-suggestions.md
@@ -1,0 +1,9 @@
+---
+"browse": patch
+---
+
+Add did-you-mean suggestions and telemetry for unknown commands.
+
+- Unknown commands (e.g. `browse sessions`, `browse search`, `browse auth status` — old Commander-era syntax — plus plain typos like `browse opne`) now print an actionable suggestion on stderr: an explicit alias table maps old syntax to the current command tree, with a Levenshtein nearest-match fallback for typos. The clause is omitted when there is no decent match.
+- A new `cli.command_not_found` telemetry event makes this failure class measurable. Privacy: only the sanitized attempted command id and the computed suggestion are sent — never raw argv, which can contain URLs, selectors, or secrets.
+- oclif's standard "command not found" error and exit code 2 are preserved; no new runtime dependency (deliberately avoids `@oclif/plugin-not-found`, which prompts interactively and is agent-hostile).

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -108,6 +108,7 @@
     "archiver": "^7.0.1",
     "deepmerge": "^4.3.1",
     "dotenv": "^16.5.0",
+    "fastest-levenshtein": "^1.0.16",
     "ignore": "^7.0.5",
     "node-html-markdown": "^1.3.0",
     "semver": "^7.7.4",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,7 +27,8 @@
     "hooks": {
       "init": "./dist/hooks/init.js",
       "prerun": "./dist/hooks/prerun.js",
-      "finally": "./dist/hooks/finally.js"
+      "finally": "./dist/hooks/finally.js",
+      "command_not_found": "./dist/hooks/command-not-found.js"
     },
     "topicSeparator": " ",
     "topics": {

--- a/packages/cli/src/hooks/command-not-found.ts
+++ b/packages/cli/src/hooks/command-not-found.ts
@@ -1,0 +1,55 @@
+import { Errors, type Hook } from "@oclif/core";
+
+import { suggestCommand } from "../lib/command-suggestions.js";
+import { captureCommandNotFound } from "../lib/telemetry.js";
+
+function toSpaced(commandId: string): string {
+  return commandId.replaceAll(":", " ");
+}
+
+const hook: Hook.CommandNotFound = async function ({ config, id }) {
+  let attempted = "";
+  let suggestion: string | null = null;
+
+  try {
+    const commandIds = config.commands
+      .filter((command) => !command.hidden)
+      .map((command) => command.id);
+    const result = suggestCommand(id, commandIds);
+    attempted = result.attempted;
+    suggestion = result.suggestion;
+    if (
+      suggestion &&
+      !config.findCommand(suggestion) &&
+      !config.findTopic(suggestion)
+    ) {
+      // Guards against alias targets drifting out of the command tree.
+      suggestion = null;
+    }
+
+    const displayAttempted = toSpaced(attempted || (id.split(":")[0] ?? id));
+    const didYouMean = suggestion
+      ? ` Did you mean "${config.bin} ${toSpaced(suggestion)}"?`
+      : "";
+    process.stderr.write(
+      `"${config.bin} ${displayAttempted}" is not a ${config.bin} command.${didYouMean} Run ${config.bin} --help for all commands.\n`,
+    );
+  } catch {
+    // Suggestions are best-effort and must never mask the not-found error.
+  }
+
+  try {
+    // Awaited so the event is delivered before the process exits; the
+    // transport aborts after a short timeout, so this cannot hang the CLI.
+    await captureCommandNotFound(config.version, attempted || null, suggestion);
+  } catch {
+    // Best-effort telemetry should never affect CLI behavior.
+  }
+
+  // Re-throw oclif's standard not-found error. Returning normally from a
+  // command_not_found hook makes oclif treat the invocation as handled
+  // (exit 0), so this throw preserves the default error and exit code 2.
+  throw new Errors.CLIError(`command ${id} not found`);
+};
+
+export default hook;

--- a/packages/cli/src/lib/command-suggestions.ts
+++ b/packages/cli/src/lib/command-suggestions.ts
@@ -14,9 +14,6 @@
  * also be topics (e.g. `cloud:contexts`, which prints topic help).
  */
 export const aliasSuggestions: ReadonlyMap<string, string> = new Map([
-  ["auth", "doctor"],
-  ["auth:status", "doctor"],
-  ["login", "doctor"],
   ["sessions", "cloud:sessions:list"],
   ["sessions:list", "cloud:sessions:list"],
   ["sessions:create", "cloud:sessions:create"],

--- a/packages/cli/src/lib/command-suggestions.ts
+++ b/packages/cli/src/lib/command-suggestions.ts
@@ -84,11 +84,38 @@ export function levenshtein(a: string, b: string): number {
   return previous[b.length] ?? 0;
 }
 
-function suggestionThreshold(attempted: string): number {
-  return Math.min(
-    Math.max(2, Math.floor(attempted.length / 3)),
-    maxSuggestionDistance,
-  );
+function tokenThreshold(token: string): number {
+  return Math.max(2, Math.floor(token.length / 3));
+}
+
+/**
+ * Segment-aligned fuzzy distance between a token prefix and a command id.
+ * Only command ids with the same number of segments are considered, and every
+ * token must be within its own edit-distance threshold of the corresponding
+ * segment. This means a trailing token can only ever be retained in the
+ * attempted command when it itself looks like a typo of a real command
+ * segment — free-form user values can never ride along.
+ */
+function prefixDistance(
+  tokens: readonly string[],
+  commandId: string,
+): number | null {
+  const segments = commandId.split(":");
+  if (segments.length !== tokens.length) {
+    return null;
+  }
+
+  let total = 0;
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i] ?? "";
+    const distance = levenshtein(token, segments[i] ?? "");
+    if (distance > tokenThreshold(token)) {
+      return null;
+    }
+    total += distance;
+  }
+
+  return total > maxSuggestionDistance ? null : total;
 }
 
 /**
@@ -117,14 +144,11 @@ export function suggestCommand(
 
   let best: (CommandSuggestion & { distance: number }) | undefined;
   for (let length = tokens.length; length >= 1; length--) {
-    const attempted = tokens.slice(0, length).join(":");
+    const prefix = tokens.slice(0, length);
     for (const commandId of commandIds) {
-      const distance = levenshtein(attempted, commandId);
-      if (
-        distance <= suggestionThreshold(attempted) &&
-        (!best || distance < best.distance)
-      ) {
-        best = { attempted, suggestion: commandId, distance };
+      const distance = prefixDistance(prefix, commandId);
+      if (distance !== null && (!best || distance < best.distance)) {
+        best = { attempted: prefix.join(":"), suggestion: commandId, distance };
       }
     }
   }

--- a/packages/cli/src/lib/command-suggestions.ts
+++ b/packages/cli/src/lib/command-suggestions.ts
@@ -1,0 +1,137 @@
+/**
+ * Suggestion engine for unknown commands.
+ *
+ * oclif's spaced-topic parsing glues unknown leading argv tokens into the
+ * attempted command id (e.g. `browse opne https://example.com` arrives as
+ * `opne:https://example.com`), so the id may contain user-provided values.
+ * Everything here works on a sanitized token prefix and never returns raw
+ * argv content beyond the tokens that matched a known command shape.
+ */
+
+/**
+ * Old Commander-era syntax (and common agent guesses) mapped to the current
+ * command tree. Keys and values are colon-separated oclif ids; values may
+ * also be topics (e.g. `cloud:contexts`, which prints topic help).
+ */
+export const aliasSuggestions: ReadonlyMap<string, string> = new Map([
+  ["auth", "doctor"],
+  ["auth:status", "doctor"],
+  ["login", "doctor"],
+  ["sessions", "cloud:sessions:list"],
+  ["sessions:list", "cloud:sessions:list"],
+  ["sessions:create", "cloud:sessions:create"],
+  ["sessions:get", "cloud:sessions:get"],
+  ["projects", "cloud:projects:list"],
+  ["projects:list", "cloud:projects:list"],
+  ["contexts", "cloud:contexts"],
+  ["extensions", "cloud:extensions"],
+  ["search", "cloud:search"],
+  ["fetch", "cloud:fetch"],
+  ["goto", "open"],
+  ["navigate", "open"],
+]);
+
+const safeTokenPattern = /^[A-Za-z][A-Za-z0-9_-]*$/;
+const maxCommandTokens = 4;
+const maxSuggestionDistance = 5;
+
+export interface CommandSuggestion {
+  /** Sanitized colon-separated tokens treated as the attempted command. */
+  attempted: string;
+  /** Colon-separated suggested command or topic, when a decent match exists. */
+  suggestion: string | null;
+}
+
+/**
+ * Extracts the leading command-shaped tokens from an attempted id, stopping
+ * at the first token that does not look like a command word (URLs, selectors,
+ * flags, and other argument-like values).
+ */
+export function extractCommandTokens(id: string): string[] {
+  const tokens: string[] = [];
+  for (const token of id.split(":")) {
+    if (tokens.length >= maxCommandTokens || !safeTokenPattern.test(token)) {
+      break;
+    }
+    tokens.push(token.toLowerCase());
+  }
+  return tokens;
+}
+
+export function levenshtein(a: string, b: string): number {
+  if (a === b) {
+    return 0;
+  }
+  if (a.length === 0 || b.length === 0) {
+    return a.length || b.length;
+  }
+
+  let previous = Array.from({ length: b.length + 1 }, (_, index) => index);
+  let current = new Array<number>(b.length + 1).fill(0);
+
+  for (let i = 1; i <= a.length; i++) {
+    current[0] = i;
+    for (let j = 1; j <= b.length; j++) {
+      const deletion = (previous[j] ?? 0) + 1;
+      const insertion = (current[j - 1] ?? 0) + 1;
+      const substitution =
+        (previous[j - 1] ?? 0) + (a[i - 1] === b[j - 1] ? 0 : 1);
+      current[j] = Math.min(deletion, insertion, substitution);
+    }
+    [previous, current] = [current, previous];
+  }
+
+  return previous[b.length] ?? 0;
+}
+
+function suggestionThreshold(attempted: string): number {
+  return Math.min(
+    Math.max(2, Math.floor(attempted.length / 3)),
+    maxSuggestionDistance,
+  );
+}
+
+/**
+ * Computes a suggestion for an unknown command id. Explicit aliases win over
+ * fuzzy matches, and longer token prefixes win over shorter ones so that
+ * `auth status` resolves before `auth`. Returns only the matched prefix as
+ * `attempted` (or the first token when nothing matches) so user-provided
+ * values never escape into messaging or telemetry.
+ */
+export function suggestCommand(
+  id: string,
+  commandIds: readonly string[],
+): CommandSuggestion {
+  const tokens = extractCommandTokens(id);
+  if (tokens.length === 0) {
+    return { attempted: "", suggestion: null };
+  }
+
+  for (let length = tokens.length; length >= 1; length--) {
+    const attempted = tokens.slice(0, length).join(":");
+    const alias = aliasSuggestions.get(attempted);
+    if (alias) {
+      return { attempted, suggestion: alias };
+    }
+  }
+
+  let best: (CommandSuggestion & { distance: number }) | undefined;
+  for (let length = tokens.length; length >= 1; length--) {
+    const attempted = tokens.slice(0, length).join(":");
+    for (const commandId of commandIds) {
+      const distance = levenshtein(attempted, commandId);
+      if (
+        distance <= suggestionThreshold(attempted) &&
+        (!best || distance < best.distance)
+      ) {
+        best = { attempted, suggestion: commandId, distance };
+      }
+    }
+  }
+
+  if (best) {
+    return { attempted: best.attempted, suggestion: best.suggestion };
+  }
+
+  return { attempted: tokens[0] ?? "", suggestion: null };
+}

--- a/packages/cli/src/lib/command-suggestions.ts
+++ b/packages/cli/src/lib/command-suggestions.ts
@@ -8,6 +8,8 @@
  * argv content beyond the tokens that matched a known command shape.
  */
 
+import { distance } from "fastest-levenshtein";
+
 /**
  * Old Commander-era syntax (and common agent guesses) mapped to the current
  * command tree. Keys and values are colon-separated oclif ids; values may
@@ -55,32 +57,6 @@ export function extractCommandTokens(id: string): string[] {
   return tokens;
 }
 
-export function levenshtein(a: string, b: string): number {
-  if (a === b) {
-    return 0;
-  }
-  if (a.length === 0 || b.length === 0) {
-    return a.length || b.length;
-  }
-
-  let previous = Array.from({ length: b.length + 1 }, (_, index) => index);
-  let current = new Array<number>(b.length + 1).fill(0);
-
-  for (let i = 1; i <= a.length; i++) {
-    current[0] = i;
-    for (let j = 1; j <= b.length; j++) {
-      const deletion = (previous[j] ?? 0) + 1;
-      const insertion = (current[j - 1] ?? 0) + 1;
-      const substitution =
-        (previous[j - 1] ?? 0) + (a[i - 1] === b[j - 1] ? 0 : 1);
-      current[j] = Math.min(deletion, insertion, substitution);
-    }
-    [previous, current] = [current, previous];
-  }
-
-  return previous[b.length] ?? 0;
-}
-
 function tokenThreshold(token: string): number {
   return Math.max(2, Math.floor(token.length / 3));
 }
@@ -105,11 +81,11 @@ function prefixDistance(
   let total = 0;
   for (let i = 0; i < tokens.length; i++) {
     const token = tokens[i] ?? "";
-    const distance = levenshtein(token, segments[i] ?? "");
-    if (distance > tokenThreshold(token)) {
+    const segmentDistance = distance(token, segments[i] ?? "");
+    if (segmentDistance > tokenThreshold(token)) {
       return null;
     }
-    total += distance;
+    total += segmentDistance;
   }
 
   return total > maxSuggestionDistance ? null : total;
@@ -143,9 +119,13 @@ export function suggestCommand(
   for (let length = tokens.length; length >= 1; length--) {
     const prefix = tokens.slice(0, length);
     for (const commandId of commandIds) {
-      const distance = prefixDistance(prefix, commandId);
-      if (distance !== null && (!best || distance < best.distance)) {
-        best = { attempted: prefix.join(":"), suggestion: commandId, distance };
+      const prefixDist = prefixDistance(prefix, commandId);
+      if (prefixDist !== null && (!best || prefixDist < best.distance)) {
+        best = {
+          attempted: prefix.join(":"),
+          suggestion: commandId,
+          distance: prefixDist,
+        };
       }
     }
   }

--- a/packages/cli/src/lib/telemetry.ts
+++ b/packages/cli/src/lib/telemetry.ts
@@ -18,7 +18,10 @@ const browserbaseTelemetryProjectToken =
 type TelemetryPrimitive = string | number | boolean | null;
 type TelemetryProperties = Record<string, TelemetryPrimitive>;
 
-type CliTelemetryEvent = "cli.command_invoked" | "cli.command_completed";
+type CliTelemetryEvent =
+  | "cli.command_invoked"
+  | "cli.command_completed"
+  | "cli.command_not_found";
 type CliTelemetryErrorType = "oclif" | "runtime";
 
 interface CliTelemetry {
@@ -131,6 +134,30 @@ export async function captureCommandCompleted(
     state.pendingInvokedCapture ?? Promise.resolve(),
     completionCapture,
   ]);
+}
+
+/**
+ * Captures a `cli.command_not_found` event. Privacy: only the sanitized
+ * attempted command id and the computed suggestion are sent — never raw argv,
+ * which can contain URLs, selectors, or secrets.
+ */
+export async function captureCommandNotFound(
+  cliVersion: string,
+  attemptedCommand: string | null,
+  suggestedCommand: string | null,
+): Promise<void> {
+  await getCliTelemetry(cliVersion)
+    .capture("cli.command_not_found", {
+      attempted_command: attemptedCommand
+        ? resolveCommandPath(attemptedCommand)
+        : null,
+      suggested_command: suggestedCommand
+        ? resolveCommandPath(suggestedCommand)
+        : null,
+    })
+    .catch(() => {
+      // Best-effort telemetry should never affect CLI behavior.
+    });
 }
 
 function createCliTelemetry(options: CreateCliTelemetryOptions): CliTelemetry {

--- a/packages/cli/tests/cli-command-not-found.integration.test.ts
+++ b/packages/cli/tests/cli-command-not-found.integration.test.ts
@@ -1,0 +1,138 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  jsonResponse,
+  startFakeBrowserbaseServer,
+  type FakeBrowserbaseServer,
+} from "./helpers/fake-browserbase-server.js";
+import { runCli } from "./helpers/run-cli.js";
+
+// Integration coverage: these exercise the built CLI end-to-end (real
+// command_not_found hook, real telemetry transport against a dummy server),
+// as opposed to the pure-function unit tests in cli-command-not-found.test.ts.
+
+const cleanupPaths: string[] = [];
+
+afterEach(async () => {
+  while (cleanupPaths.length > 0) {
+    const path = cleanupPaths.pop();
+    if (!path) continue;
+    await rm(path, { recursive: true, force: true });
+  }
+});
+
+describe("command_not_found hook (built CLI)", () => {
+  it("prints a did-you-mean suggestion and preserves exit code 2", async () => {
+    const result = await runCli(["sessions"]);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain(
+      '"browse sessions" is not a browse command. Did you mean "browse cloud sessions list"? Run browse --help for all commands.',
+    );
+    expect(result.stderr).toContain("command sessions not found");
+  });
+
+  it("omits the did-you-mean clause when no decent match exists", async () => {
+    const result = await runCli(["frobnicate"]);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain(
+      '"browse frobnicate" is not a browse command. Run browse --help for all commands.',
+    );
+    expect(result.stderr).not.toContain("Did you mean");
+  });
+
+  it("emits cli.command_not_found telemetry before the process exits", async () => {
+    const telemetryServer = await startTelemetryServer();
+
+    try {
+      const installIdFile = await tempInstallIdFile("browse-notfound-");
+      const result = await runCli(["sessions", "list"], {
+        env: telemetryEnv(telemetryServer, installIdFile),
+      });
+
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr).toContain(
+        'Did you mean "browse cloud sessions list"?',
+      );
+
+      const payload = telemetryServer.requests
+        .filter((request) => request.path === "/i/v0/e/")
+        .map(
+          (request) =>
+            request.jsonBody as {
+              event?: string;
+              properties?: Record<string, unknown>;
+            },
+        )
+        .find((body) => body.event === "cli.command_not_found");
+
+      expect(payload).toBeDefined();
+      expect(payload?.properties?.attempted_command).toBe("sessions.list");
+      expect(payload?.properties?.suggested_command).toBe(
+        "cloud.sessions.list",
+      );
+      expect(payload?.properties?.source).toBe("cli");
+    } finally {
+      await telemetryServer.close();
+    }
+  });
+
+  it("never sends raw argv values in not-found telemetry", async () => {
+    const telemetryServer = await startTelemetryServer();
+
+    try {
+      const installIdFile = await tempInstallIdFile("browse-notfound-priv-");
+      const result = await runCli(
+        ["opne", "https://example.com/?token=supersecret"],
+        { env: telemetryEnv(telemetryServer, installIdFile) },
+      );
+
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr).toContain('Did you mean "browse open"?');
+
+      const serialized = JSON.stringify(
+        telemetryServer.requests.map((request) => request.jsonBody),
+      );
+      expect(serialized).toContain("cli.command_not_found");
+      expect(serialized).not.toContain("example.com");
+      expect(serialized).not.toContain("supersecret");
+    } finally {
+      await telemetryServer.close();
+    }
+  });
+
+  it("does not affect valid commands", async () => {
+    const result = await runCli(["status"]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).not.toContain("is not a browse command");
+  });
+});
+
+async function startTelemetryServer(): Promise<FakeBrowserbaseServer> {
+  return startFakeBrowserbaseServer((_request, response) => {
+    jsonResponse(response, 200, { ok: true });
+  });
+}
+
+function telemetryEnv(
+  telemetryServer: FakeBrowserbaseServer,
+  installIdFile: string,
+): NodeJS.ProcessEnv {
+  return {
+    BROWSERBASE_TELEMETRY_HOST: telemetryServer.baseUrl,
+    BROWSERBASE_TELEMETRY_INSTALL_ID_FILE: installIdFile,
+    CI: "",
+  };
+}
+
+async function tempInstallIdFile(prefix: string): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), prefix));
+  cleanupPaths.push(directory);
+  return join(directory, "telemetry-id");
+}

--- a/packages/cli/tests/cli-command-not-found.test.ts
+++ b/packages/cli/tests/cli-command-not-found.test.ts
@@ -1,48 +1,27 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { readFile } from "node:fs/promises";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import {
   aliasSuggestions,
   extractCommandTokens,
   suggestCommand,
 } from "../src/lib/command-suggestions.js";
-import {
-  jsonResponse,
-  startFakeBrowserbaseServer,
-  type FakeBrowserbaseServer,
-} from "./helpers/fake-browserbase-server.js";
-import { runCli } from "./helpers/run-cli.js";
-
-const cleanupPaths: string[] = [];
-
-afterEach(async () => {
-  while (cleanupPaths.length > 0) {
-    const path = cleanupPaths.pop();
-    if (!path) continue;
-    await rm(path, { recursive: true, force: true });
-  }
-});
 
 describe("extractCommandTokens", () => {
-  it("keeps leading command-shaped tokens and lowercases them", () => {
-    expect(extractCommandTokens("auth:status")).toEqual(["auth", "status"]);
-    expect(extractCommandTokens("Sessions")).toEqual(["sessions"]);
-  });
-
-  it("stops at argument-like tokens", () => {
-    expect(extractCommandTokens("opne:https://example.com")).toEqual([
-      "opne",
-      "https",
-    ]);
-    expect(extractCommandTokens("--badflag")).toEqual([]);
-    expect(extractCommandTokens("fill:#password")).toEqual(["fill"]);
-  });
-
-  it("caps the number of tokens", () => {
-    expect(extractCommandTokens("a:b:c:d:e:f")).toEqual(["a", "b", "c", "d"]);
+  it.each([
+    [
+      "lowercases colon-separated command tokens",
+      "auth:status",
+      ["auth", "status"],
+    ],
+    ["lowercases a single token", "Sessions", ["sessions"]],
+    ["stops at URL-like tokens", "opne:https://example.com", ["opne", "https"]],
+    ["drops a leading flag", "--badflag", []],
+    ["stops at selector-like tokens", "fill:#password", ["fill"]],
+    ["caps the number of tokens at four", "a:b:c:d:e:f", ["a", "b", "c", "d"]],
+  ])("%s", (_label, input, expected) => {
+    expect(extractCommandTokens(input)).toEqual(expected);
   });
 });
 
@@ -56,26 +35,68 @@ describe("suggestCommand", () => {
     "cloud:sessions:create",
   ];
 
-  it("prefers explicit aliases over fuzzy matches", () => {
-    expect(suggestCommand("sessions", commandIds)).toEqual({
-      attempted: "sessions",
-      suggestion: "cloud:sessions:list",
-    });
-    expect(suggestCommand("search:test", commandIds)).toEqual({
-      attempted: "search",
-      suggestion: "cloud:search",
-    });
-  });
-
-  it("matches the longest alias prefix first", () => {
-    expect(suggestCommand("sessions:create", commandIds)).toEqual({
-      attempted: "sessions:create",
-      suggestion: "cloud:sessions:create",
-    });
-    expect(suggestCommand("sessions", commandIds)).toEqual({
-      attempted: "sessions",
-      suggestion: "cloud:sessions:list",
-    });
+  // attempted/suggestion are colon-separated ids. The "attempted" field is what
+  // gets surfaced in messaging + telemetry, so the trailing-token rows below
+  // double as the privacy guard: a free-form user value must never be retained
+  // unless it itself looks like a typo of a real command segment.
+  it.each<[string, string, { attempted: string; suggestion: string | null }]>([
+    [
+      "prefers an explicit alias over a fuzzy match",
+      "sessions",
+      { attempted: "sessions", suggestion: "cloud:sessions:list" },
+    ],
+    [
+      "strips trailing args before the alias lookup",
+      "search:test",
+      { attempted: "search", suggestion: "cloud:search" },
+    ],
+    [
+      "matches the longest alias prefix first",
+      "sessions:create",
+      { attempted: "sessions:create", suggestion: "cloud:sessions:create" },
+    ],
+    [
+      "falls back to the nearest command by edit distance",
+      "opne",
+      { attempted: "opne", suggestion: "open" },
+    ],
+    [
+      "fuzzy-matches a misspelled deep command",
+      "cloud:sesions:list",
+      { attempted: "cloud:sesions:list", suggestion: "cloud:sessions:list" },
+    ],
+    [
+      "omits a suggestion beyond the distance threshold",
+      "frobnicate",
+      { attempted: "frobnicate", suggestion: null },
+    ],
+    [
+      "drops a trailing user token that does not align with a command segment",
+      "stat:s",
+      { attempted: "stat", suggestion: "status" },
+    ],
+    [
+      "retains a trailing token that looks like a command-word typo",
+      "cloud:sessions:lst",
+      { attempted: "cloud:sessions:lst", suggestion: "cloud:sessions:list" },
+    ],
+    [
+      "never retains an argument-like trailing token",
+      "opne:https://example.com/?token=secret",
+      { attempted: "opne", suggestion: "open" },
+    ],
+    [
+      "returns no suggestion for an unknown command with an argument",
+      "frobnicate:somevalue",
+      { attempted: "frobnicate", suggestion: null },
+    ],
+    [
+      "handles ids with no command-shaped tokens",
+      "--badflag",
+      { attempted: "", suggestion: null },
+    ],
+  ])("%s", (_label, input, expected) => {
+    expect(suggestCommand(input, commandIds)).toEqual(expected);
   });
 
   it("does not map auth/login to unrelated commands", () => {
@@ -83,60 +104,6 @@ describe("suggestCommand", () => {
       "doctor",
     );
     expect(suggestCommand("login", commandIds)?.suggestion).not.toBe("doctor");
-  });
-
-  it("falls back to nearest command by edit distance", () => {
-    expect(suggestCommand("opne", commandIds)).toEqual({
-      attempted: "opne",
-      suggestion: "open",
-    });
-    expect(suggestCommand("cloud:sesions:list", commandIds)).toEqual({
-      attempted: "cloud:sesions:list",
-      suggestion: "cloud:sessions:list",
-    });
-  });
-
-  it("omits suggestions beyond the distance threshold", () => {
-    expect(suggestCommand("frobnicate", commandIds)).toEqual({
-      attempted: "frobnicate",
-      suggestion: null,
-    });
-  });
-
-  it("never includes trailing argument-like tokens in the attempted command", () => {
-    const result = suggestCommand(
-      "opne:https://example.com/?token=secret",
-      commandIds,
-    );
-    expect(result.attempted).toBe("opne");
-    expect(result.suggestion).toBe("open");
-
-    const noMatch = suggestCommand("frobnicate:somevalue", commandIds);
-    expect(noMatch.attempted).toBe("frobnicate");
-    expect(noMatch.suggestion).toBe(null);
-  });
-
-  it("drops trailing user tokens that do not align with command segments", () => {
-    // "stat:s" must not fuzzy-match "status" as a whole string, which would
-    // retain the user-provided "s" in the attempted command and telemetry.
-    expect(suggestCommand("stat:s", commandIds)).toEqual({
-      attempted: "stat",
-      suggestion: "status",
-    });
-
-    // Per-segment matching still retains tokens that look like command-word
-    // typos of the aligned segment.
-    expect(suggestCommand("cloud:sessions:lst", commandIds)).toEqual({
-      attempted: "cloud:sessions:lst",
-      suggestion: "cloud:sessions:list",
-    });
-  });
-
-  it("handles ids with no command-shaped tokens", () => {
-    expect(suggestCommand("--badflag", commandIds)).toEqual({
-      attempted: "",
-      suggestion: null,
-    });
   });
 });
 
@@ -158,115 +125,3 @@ describe("alias table", () => {
     }
   });
 });
-
-describe("command_not_found hook (built CLI)", () => {
-  it("prints a did-you-mean suggestion and preserves exit code 2", async () => {
-    const result = await runCli(["sessions"]);
-
-    expect(result.exitCode).toBe(2);
-    expect(result.stderr).toContain(
-      '"browse sessions" is not a browse command. Did you mean "browse cloud sessions list"? Run browse --help for all commands.',
-    );
-    expect(result.stderr).toContain("command sessions not found");
-  });
-
-  it("omits the did-you-mean clause when no decent match exists", async () => {
-    const result = await runCli(["frobnicate"]);
-
-    expect(result.exitCode).toBe(2);
-    expect(result.stderr).toContain(
-      '"browse frobnicate" is not a browse command. Run browse --help for all commands.',
-    );
-    expect(result.stderr).not.toContain("Did you mean");
-  });
-
-  it("emits cli.command_not_found telemetry before the process exits", async () => {
-    const telemetryServer = await startTelemetryServer();
-
-    try {
-      const installIdFile = await tempInstallIdFile("browse-notfound-");
-      const result = await runCli(["sessions", "list"], {
-        env: telemetryEnv(telemetryServer, installIdFile),
-      });
-
-      expect(result.exitCode).toBe(2);
-      expect(result.stderr).toContain(
-        'Did you mean "browse cloud sessions list"?',
-      );
-
-      const payload = telemetryServer.requests
-        .filter((request) => request.path === "/i/v0/e/")
-        .map(
-          (request) =>
-            request.jsonBody as {
-              event?: string;
-              properties?: Record<string, unknown>;
-            },
-        )
-        .find((body) => body.event === "cli.command_not_found");
-
-      expect(payload).toBeDefined();
-      expect(payload?.properties?.attempted_command).toBe("sessions.list");
-      expect(payload?.properties?.suggested_command).toBe(
-        "cloud.sessions.list",
-      );
-      expect(payload?.properties?.source).toBe("cli");
-    } finally {
-      await telemetryServer.close();
-    }
-  });
-
-  it("never sends raw argv values in not-found telemetry", async () => {
-    const telemetryServer = await startTelemetryServer();
-
-    try {
-      const installIdFile = await tempInstallIdFile("browse-notfound-priv-");
-      const result = await runCli(
-        ["opne", "https://example.com/?token=supersecret"],
-        { env: telemetryEnv(telemetryServer, installIdFile) },
-      );
-
-      expect(result.exitCode).toBe(2);
-      expect(result.stderr).toContain('Did you mean "browse open"?');
-
-      const serialized = JSON.stringify(
-        telemetryServer.requests.map((request) => request.jsonBody),
-      );
-      expect(serialized).toContain("cli.command_not_found");
-      expect(serialized).not.toContain("example.com");
-      expect(serialized).not.toContain("supersecret");
-    } finally {
-      await telemetryServer.close();
-    }
-  });
-
-  it("does not affect valid commands", async () => {
-    const result = await runCli(["status"]);
-
-    expect(result.exitCode).toBe(0);
-    expect(result.stderr).not.toContain("is not a browse command");
-  });
-});
-
-async function startTelemetryServer(): Promise<FakeBrowserbaseServer> {
-  return startFakeBrowserbaseServer((_request, response) => {
-    jsonResponse(response, 200, { ok: true });
-  });
-}
-
-function telemetryEnv(
-  telemetryServer: FakeBrowserbaseServer,
-  installIdFile: string,
-): NodeJS.ProcessEnv {
-  return {
-    BROWSERBASE_TELEMETRY_HOST: telemetryServer.baseUrl,
-    BROWSERBASE_TELEMETRY_INSTALL_ID_FILE: installIdFile,
-    CI: "",
-  };
-}
-
-async function tempInstallIdFile(prefix: string): Promise<string> {
-  const directory = await mkdtemp(join(tmpdir(), prefix));
-  cleanupPaths.push(directory);
-  return join(directory, "telemetry-id");
-}

--- a/packages/cli/tests/cli-command-not-found.test.ts
+++ b/packages/cli/tests/cli-command-not-found.test.ts
@@ -7,7 +7,6 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   aliasSuggestions,
   extractCommandTokens,
-  levenshtein,
   suggestCommand,
 } from "../src/lib/command-suggestions.js";
 import {
@@ -25,16 +24,6 @@ afterEach(async () => {
     if (!path) continue;
     await rm(path, { recursive: true, force: true });
   }
-});
-
-describe("levenshtein", () => {
-  it("computes edit distances", () => {
-    expect(levenshtein("open", "open")).toBe(0);
-    expect(levenshtein("opne", "open")).toBe(2);
-    expect(levenshtein("", "open")).toBe(4);
-    expect(levenshtein("open", "")).toBe(4);
-    expect(levenshtein("kitten", "sitting")).toBe(3);
-  });
 });
 
 describe("extractCommandTokens", () => {

--- a/packages/cli/tests/cli-command-not-found.test.ts
+++ b/packages/cli/tests/cli-command-not-found.test.ts
@@ -79,14 +79,21 @@ describe("suggestCommand", () => {
   });
 
   it("matches the longest alias prefix first", () => {
-    expect(suggestCommand("auth:status", commandIds)).toEqual({
-      attempted: "auth:status",
-      suggestion: "doctor",
+    expect(suggestCommand("sessions:create", commandIds)).toEqual({
+      attempted: "sessions:create",
+      suggestion: "cloud:sessions:create",
     });
-    expect(suggestCommand("auth", commandIds)).toEqual({
-      attempted: "auth",
-      suggestion: "doctor",
+    expect(suggestCommand("sessions", commandIds)).toEqual({
+      attempted: "sessions",
+      suggestion: "cloud:sessions:list",
     });
+  });
+
+  it("does not map auth/login to unrelated commands", () => {
+    expect(suggestCommand("auth:status", commandIds)?.suggestion).not.toBe(
+      "doctor",
+    );
+    expect(suggestCommand("login", commandIds)?.suggestion).not.toBe("doctor");
   });
 
   it("falls back to nearest command by edit distance", () => {
@@ -189,12 +196,14 @@ describe("command_not_found hook (built CLI)", () => {
 
     try {
       const installIdFile = await tempInstallIdFile("browse-notfound-");
-      const result = await runCli(["auth", "status"], {
+      const result = await runCli(["sessions", "list"], {
         env: telemetryEnv(telemetryServer, installIdFile),
       });
 
       expect(result.exitCode).toBe(2);
-      expect(result.stderr).toContain('Did you mean "browse doctor"?');
+      expect(result.stderr).toContain(
+        'Did you mean "browse cloud sessions list"?',
+      );
 
       const payload = telemetryServer.requests
         .filter((request) => request.path === "/i/v0/e/")
@@ -208,8 +217,10 @@ describe("command_not_found hook (built CLI)", () => {
         .find((body) => body.event === "cli.command_not_found");
 
       expect(payload).toBeDefined();
-      expect(payload?.properties?.attempted_command).toBe("auth.status");
-      expect(payload?.properties?.suggested_command).toBe("doctor");
+      expect(payload?.properties?.attempted_command).toBe("sessions.list");
+      expect(payload?.properties?.suggested_command).toBe(
+        "cloud.sessions.list",
+      );
       expect(payload?.properties?.source).toBe("cli");
     } finally {
       await telemetryServer.close();

--- a/packages/cli/tests/cli-command-not-found.test.ts
+++ b/packages/cli/tests/cli-command-not-found.test.ts
@@ -120,6 +120,22 @@ describe("suggestCommand", () => {
     expect(noMatch.suggestion).toBe(null);
   });
 
+  it("drops trailing user tokens that do not align with command segments", () => {
+    // "stat:s" must not fuzzy-match "status" as a whole string, which would
+    // retain the user-provided "s" in the attempted command and telemetry.
+    expect(suggestCommand("stat:s", commandIds)).toEqual({
+      attempted: "stat",
+      suggestion: "status",
+    });
+
+    // Per-segment matching still retains tokens that look like command-word
+    // typos of the aligned segment.
+    expect(suggestCommand("cloud:sessions:lst", commandIds)).toEqual({
+      attempted: "cloud:sessions:lst",
+      suggestion: "cloud:sessions:list",
+    });
+  });
+
   it("handles ids with no command-shaped tokens", () => {
     expect(suggestCommand("--badflag", commandIds)).toEqual({
       attempted: "",

--- a/packages/cli/tests/cli-command-not-found.test.ts
+++ b/packages/cli/tests/cli-command-not-found.test.ts
@@ -1,0 +1,256 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  aliasSuggestions,
+  extractCommandTokens,
+  levenshtein,
+  suggestCommand,
+} from "../src/lib/command-suggestions.js";
+import {
+  jsonResponse,
+  startFakeBrowserbaseServer,
+  type FakeBrowserbaseServer,
+} from "./helpers/fake-browserbase-server.js";
+import { runCli } from "./helpers/run-cli.js";
+
+const cleanupPaths: string[] = [];
+
+afterEach(async () => {
+  while (cleanupPaths.length > 0) {
+    const path = cleanupPaths.pop();
+    if (!path) continue;
+    await rm(path, { recursive: true, force: true });
+  }
+});
+
+describe("levenshtein", () => {
+  it("computes edit distances", () => {
+    expect(levenshtein("open", "open")).toBe(0);
+    expect(levenshtein("opne", "open")).toBe(2);
+    expect(levenshtein("", "open")).toBe(4);
+    expect(levenshtein("open", "")).toBe(4);
+    expect(levenshtein("kitten", "sitting")).toBe(3);
+  });
+});
+
+describe("extractCommandTokens", () => {
+  it("keeps leading command-shaped tokens and lowercases them", () => {
+    expect(extractCommandTokens("auth:status")).toEqual(["auth", "status"]);
+    expect(extractCommandTokens("Sessions")).toEqual(["sessions"]);
+  });
+
+  it("stops at argument-like tokens", () => {
+    expect(extractCommandTokens("opne:https://example.com")).toEqual([
+      "opne",
+      "https",
+    ]);
+    expect(extractCommandTokens("--badflag")).toEqual([]);
+    expect(extractCommandTokens("fill:#password")).toEqual(["fill"]);
+  });
+
+  it("caps the number of tokens", () => {
+    expect(extractCommandTokens("a:b:c:d:e:f")).toEqual(["a", "b", "c", "d"]);
+  });
+});
+
+describe("suggestCommand", () => {
+  const commandIds = [
+    "open",
+    "doctor",
+    "status",
+    "cloud:search",
+    "cloud:sessions:list",
+    "cloud:sessions:create",
+  ];
+
+  it("prefers explicit aliases over fuzzy matches", () => {
+    expect(suggestCommand("sessions", commandIds)).toEqual({
+      attempted: "sessions",
+      suggestion: "cloud:sessions:list",
+    });
+    expect(suggestCommand("search:test", commandIds)).toEqual({
+      attempted: "search",
+      suggestion: "cloud:search",
+    });
+  });
+
+  it("matches the longest alias prefix first", () => {
+    expect(suggestCommand("auth:status", commandIds)).toEqual({
+      attempted: "auth:status",
+      suggestion: "doctor",
+    });
+    expect(suggestCommand("auth", commandIds)).toEqual({
+      attempted: "auth",
+      suggestion: "doctor",
+    });
+  });
+
+  it("falls back to nearest command by edit distance", () => {
+    expect(suggestCommand("opne", commandIds)).toEqual({
+      attempted: "opne",
+      suggestion: "open",
+    });
+    expect(suggestCommand("cloud:sesions:list", commandIds)).toEqual({
+      attempted: "cloud:sesions:list",
+      suggestion: "cloud:sessions:list",
+    });
+  });
+
+  it("omits suggestions beyond the distance threshold", () => {
+    expect(suggestCommand("frobnicate", commandIds)).toEqual({
+      attempted: "frobnicate",
+      suggestion: null,
+    });
+  });
+
+  it("never includes trailing argument-like tokens in the attempted command", () => {
+    const result = suggestCommand(
+      "opne:https://example.com/?token=secret",
+      commandIds,
+    );
+    expect(result.attempted).toBe("opne");
+    expect(result.suggestion).toBe("open");
+
+    const noMatch = suggestCommand("frobnicate:somevalue", commandIds);
+    expect(noMatch.attempted).toBe("frobnicate");
+    expect(noMatch.suggestion).toBe(null);
+  });
+
+  it("handles ids with no command-shaped tokens", () => {
+    expect(suggestCommand("--badflag", commandIds)).toEqual({
+      attempted: "",
+      suggestion: null,
+    });
+  });
+});
+
+describe("alias table", () => {
+  it("only maps to commands or topics that exist in the manifest", async () => {
+    const manifestRaw = await readFile(
+      new URL("../oclif.manifest.json", import.meta.url),
+      "utf8",
+    );
+    const manifest = JSON.parse(manifestRaw) as {
+      commands: Record<string, unknown>;
+    };
+    const ids = Object.keys(manifest.commands);
+
+    for (const target of aliasSuggestions.values()) {
+      const isCommand = ids.includes(target);
+      const isTopic = ids.some((id) => id.startsWith(`${target}:`));
+      expect(isCommand || isTopic, `alias target "${target}"`).toBe(true);
+    }
+  });
+});
+
+describe("command_not_found hook (built CLI)", () => {
+  it("prints a did-you-mean suggestion and preserves exit code 2", async () => {
+    const result = await runCli(["sessions"]);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain(
+      '"browse sessions" is not a browse command. Did you mean "browse cloud sessions list"? Run browse --help for all commands.',
+    );
+    expect(result.stderr).toContain("command sessions not found");
+  });
+
+  it("omits the did-you-mean clause when no decent match exists", async () => {
+    const result = await runCli(["frobnicate"]);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain(
+      '"browse frobnicate" is not a browse command. Run browse --help for all commands.',
+    );
+    expect(result.stderr).not.toContain("Did you mean");
+  });
+
+  it("emits cli.command_not_found telemetry before the process exits", async () => {
+    const telemetryServer = await startTelemetryServer();
+
+    try {
+      const installIdFile = await tempInstallIdFile("browse-notfound-");
+      const result = await runCli(["auth", "status"], {
+        env: telemetryEnv(telemetryServer, installIdFile),
+      });
+
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr).toContain('Did you mean "browse doctor"?');
+
+      const payload = telemetryServer.requests
+        .filter((request) => request.path === "/i/v0/e/")
+        .map(
+          (request) =>
+            request.jsonBody as {
+              event?: string;
+              properties?: Record<string, unknown>;
+            },
+        )
+        .find((body) => body.event === "cli.command_not_found");
+
+      expect(payload).toBeDefined();
+      expect(payload?.properties?.attempted_command).toBe("auth.status");
+      expect(payload?.properties?.suggested_command).toBe("doctor");
+      expect(payload?.properties?.source).toBe("cli");
+    } finally {
+      await telemetryServer.close();
+    }
+  });
+
+  it("never sends raw argv values in not-found telemetry", async () => {
+    const telemetryServer = await startTelemetryServer();
+
+    try {
+      const installIdFile = await tempInstallIdFile("browse-notfound-priv-");
+      const result = await runCli(
+        ["opne", "https://example.com/?token=supersecret"],
+        { env: telemetryEnv(telemetryServer, installIdFile) },
+      );
+
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr).toContain('Did you mean "browse open"?');
+
+      const serialized = JSON.stringify(
+        telemetryServer.requests.map((request) => request.jsonBody),
+      );
+      expect(serialized).toContain("cli.command_not_found");
+      expect(serialized).not.toContain("example.com");
+      expect(serialized).not.toContain("supersecret");
+    } finally {
+      await telemetryServer.close();
+    }
+  });
+
+  it("does not affect valid commands", async () => {
+    const result = await runCli(["status"]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).not.toContain("is not a browse command");
+  });
+});
+
+async function startTelemetryServer(): Promise<FakeBrowserbaseServer> {
+  return startFakeBrowserbaseServer((_request, response) => {
+    jsonResponse(response, 200, { ok: true });
+  });
+}
+
+function telemetryEnv(
+  telemetryServer: FakeBrowserbaseServer,
+  installIdFile: string,
+): NodeJS.ProcessEnv {
+  return {
+    BROWSERBASE_TELEMETRY_HOST: telemetryServer.baseUrl,
+    BROWSERBASE_TELEMETRY_INSTALL_ID_FILE: installIdFile,
+    CI: "",
+  };
+}
+
+async function tempInstallIdFile(prefix: string): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), prefix));
+  cleanupPaths.push(directory);
+  return join(directory, "telemetry-id");
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       dotenv:
         specifier: ^16.5.0
         version: 16.6.1
+      fastest-levenshtein:
+        specifier: ^1.0.16
+        version: 1.0.16
       ignore:
         specifier: ^7.0.5
         version: 7.0.5


### PR DESCRIPTION
## Summary

Linear: https://linear.app/browserbase/issue/STG-2278/add-did-you-mean-suggestions-and-telemetry-for-unknown-browse-commands

Adds a `command_not_found` oclif hook to the browse CLI that prints a did-you-mean suggestion for unknown commands and emits a new `cli.command_not_found` telemetry event, while preserving oclif's standard "command not found" error and exit code 2.

## Impact if merged

Unknown commands (`browse sessions` / `search` / `contexts` / `auth status` — the old Commander-era syntax that agents were trained on, plus plain typos) currently exit 2 with no suggestion and emit NO telemetry event, so this failure class is invisible by construction. Old-binary telemetry shows the pattern is real (1,310 commander-error events from `sessions.list` alone in 30d; 115 from `search`). It's a failed-first-command class, and a failed first command cuts 7-day retention 12.4x (0.42% vs 5.21%). Did-you-mean turns an agent guess-loop into a one-turn recovery, and the new `cli.command_not_found` event finally lets us size and rank the dead ends. No new dependency — deliberately avoids `@oclif/plugin-not-found`, which prompts interactively (agent-hostile).

## Implementation notes

- **New hook** `src/hooks/command-not-found.ts`, registered in the `oclif.hooks` config. Suggestion order: explicit alias table first (old-CLI syntax → current tree, e.g. `sessions` → `cloud sessions list`, `auth status` → `doctor`, `search` → `cloud search`), then nearest match by Levenshtein over `config.commandIDs` with a distance threshold (the did-you-mean clause is omitted when nothing decent matches). Alias targets are validated against the live command tree at runtime and against `oclif.manifest.json` in tests, so they can't silently drift.
- **Privacy: id + suggestion only, never argv.** oclif's spaced-topic parsing glues unknown leading argv tokens into the attempted id (e.g. `browse opne https://example.com` arrives as `opne:https://example.com`), so the hook sanitizes down to leading command-shaped tokens and reports only the matched prefix (or the first token when nothing matches). The telemetry payload carries exactly `attempted_command` and `suggested_command` — URLs, selectors, queries, and secrets never leave the machine. Covered by a dedicated test asserting argv values are absent from captured payloads.
- **Exit semantics preserved.** A `command_not_found` hook that returns normally makes oclif treat the invocation as handled (exit 0), silently swallowing the failure. The hook therefore re-throws oclif's standard `CLIError("command <id> not found")` after printing the suggestion, keeping stderr output and exit code 2 byte-identical to current behavior.
- **Telemetry can't hang or get lost.** The event reuses the existing PostHog transport (400ms abort timeout, best-effort catch) and is awaited inside the hook before the error is thrown, so it is delivered before process exit but cannot delay it beyond the transport timeout. The `finally`-hook completion path early-returns for unknown commands (prerun never fires), so there is no double counting.
- No new runtime dependency; ~140 LOC of source plus tests.

## E2E Test Matrix

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `node bin/run.js sessions` (local build) | stderr: `"browse sessions" is not a browse command. Did you mean "browse cloud sessions list"? Run browse --help for all commands.` then `Error: command sessions not found`; `echo $?` → `2` | Proves alias suggestion + preserved exit code on the highest-volume old-syntax pattern |
| `node bin/run.js auth status` | stderr: `"browse auth status" is not a browse command. Did you mean "browse doctor"? ...`; exit `2` | Proves multi-token alias matching (`auth:status` → `doctor`) |
| `node bin/run.js search "test"` | stderr: `"browse search" is not a browse command. Did you mean "browse cloud search"? ...`; exit `2`; the query token is not shown as part of the attempted command | Proves alias prefix matching strips trailing user args from messaging |
| `node bin/run.js opne https://example.com` | stderr: `"browse opne" is not a browse command. Did you mean "browse open"? ...`; exit `2` | Proves Levenshtein typo fallback; URL excluded from the attempted command |
| `node bin/run.js open https://example.com --local` | JSON result `{"mode": "managed-local", ..., "title": "Example Domain", "url": "https://example.com/"}`; exit `0`; no suggestion output | Proves valid commands are completely unaffected (hook never fires) |
| Live telemetry capture: `BROWSERBASE_TELEMETRY_HOST=<local capture server>` + `node bin/run.js auth status` | Capture server logged `POST /i/v0/e/` with `"event": "cli.command_not_found"`, `"attempted_command": "auth.status"`, `"suggested_command": "doctor"` plus standard env/version props; payload received before CLI exit `2`; no argv content in payload | Proves the event actually sends, flushes before process exit, and carries only id + suggestion |
| `pnpm test` (builds then vitest) | `Test Files 16 passed (16), Tests 229 passed (229)` — includes 13 new unit/integration tests (alias table validity vs manifest, Levenshtein, thresholds, token sanitization, built-CLI suggestion/exit-code/telemetry/privacy) | Full regression sweep; existing telemetry suite still green |
| `pnpm lint` | prettier + eslint + `tsc --noEmit` all pass | Supporting evidence only |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds did-you-mean suggestions and privacy-safe telemetry for unknown `browse` CLI commands, while keeping the standard error output and exit code 2. Addresses Linear STG-2278 by helping users recover from old syntax and typos; typo matching now uses `fastest-levenshtein`.

- **New Features**
  - Added a `command_not_found` hook that prints a suggestion using an alias table for old syntax, with segment-aligned Levenshtein fallback for typos; omitted when no good match.
  - Sends `cli.command_not_found` telemetry with strict privacy: only the sanitized attempted command id and the suggested command, never raw argv.
  - Preserves default behavior by rethrowing the not-found error (stderr unchanged, exit code 2) and avoids `@oclif/plugin-not-found`.
  - Removed misleading `auth`/`login` → `doctor` suggestions.

<sup>Written for commit bcee6ed466b57053cddcba1a4610068503431d4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

