### PR TITLE
Add TrustedRouter as a supported model provider

### DIFF
--- a/.changeset/trustedrouter-provider.md
+++ b/.changeset/trustedrouter-provider.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": minor
+---
+
+Add TrustedRouter as a supported model provider (trustedrouter/<model> via its OpenAI-compatible API, with TRUSTEDROUTER_API_KEY auto-loading)

--- a/packages/core/lib/utils.ts
+++ b/packages/core/lib/utils.ts
@@ -698,6 +698,7 @@ export const providerEnvVarMap: Partial<
   groq: "GROQ_API_KEY",
   cerebras: "CEREBRAS_API_KEY",
   togetherai: "TOGETHER_AI_API_KEY",
+  trustedrouter: "TRUSTEDROUTER_API_KEY",
   mistral: "MISTRAL_API_KEY",
   deepseek: "DEEPSEEK_API_KEY",
   perplexity: "PERPLEXITY_API_KEY",

--- a/packages/core/lib/v3/llm/LLMProvider.ts
+++ b/packages/core/lib/v3/llm/LLMProvider.ts
@@ -37,6 +37,24 @@ import { ollama, createOllama } from "ollama-ai-provider-v2";
 import { gateway, createGateway, wrapLanguageModel } from "ai";
 import { AISDKProvider, AISDKCustomProvider } from "../types/public/model.js";
 
+const TRUSTEDROUTER_BASE_URL = "https://api.trustedrouter.com/v1";
+
+// TrustedRouter is an attested OpenAI-compatible router; it speaks the Chat
+// Completions API, so its models are created via the openai provider's .chat().
+const trustedrouter: AISDKProvider = (modelName: string) =>
+  createOpenAI({
+    baseURL: TRUSTEDROUTER_BASE_URL,
+    apiKey: process.env.TRUSTEDROUTER_API_KEY,
+  }).chat(modelName);
+
+const createTrustedRouter: AISDKCustomProvider = (options: ClientOptions) => {
+  const provider = createOpenAI({
+    baseURL: TRUSTEDROUTER_BASE_URL,
+    ...options,
+  });
+  return (modelName: string) => provider.chat(modelName);
+};
+
 const AISDKProviders: Record<string, AISDKProvider> = {
   openai,
   bedrock,
@@ -53,6 +71,7 @@ const AISDKProviders: Record<string, AISDKProvider> = {
   ollama,
   vertex,
   gateway,
+  trustedrouter,
 };
 const AISDKProvidersWithAPIKey: Record<string, AISDKCustomProvider> = {
   openai: createOpenAI,
@@ -70,6 +89,7 @@ const AISDKProvidersWithAPIKey: Record<string, AISDKCustomProvider> = {
   perplexity: createPerplexity,
   ollama: createOllama,
   gateway: createGateway,
+  trustedrouter: createTrustedRouter,
 };
 
 type AISDKProviderClientOptions = ClientOptions & Record<string, unknown>;

--- a/packages/docs/v3/configuration/models.mdx
+++ b/packages/docs/v3/configuration/models.mdx
@@ -453,6 +453,23 @@ await stagehand.init();
 </CodeGroup>
 [View all supported Perplexity models →](https://docs.perplexity.ai/getting-started/models)
 </Tab>
+<Tab title="TrustedRouter">
+<CodeGroup>
+```typescript TypeScript
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const stagehand = new Stagehand({
+  env: "BROWSERBASE",
+  model: "trustedrouter/auto"
+  // API key auto-loads from TRUSTEDROUTER_API_KEY - set in your .env
+});
+
+await stagehand.init();
+```
+
+</CodeGroup>
+[View all supported TrustedRouter models →](https://trustedrouter.com/models)
+</Tab>
 <Tab title="TogetherAI">
 <CodeGroup>
 ```typescript TypeScript


### PR DESCRIPTION
Adds TrustedRouter (attested OpenAI-compatible router) as a first-class model provider:

- `trustedrouter` entries in `AISDKProviders` and `AISDKProvidersWithAPIKey` (`packages/core/lib/v3/llm/LLMProvider.ts`) — models are created via the openai provider's `.chat()` since TrustedRouter speaks Chat Completions; usage is `model: "trustedrouter/auto"` (or `zdr`/`e2e`, or any provider-prefixed model id it routes)
- `TRUSTEDROUTER_API_KEY` auto-loading via `providerEnvVarMap` (`packages/core/lib/utils.ts`)
- models docs tab + changeset

`tsc --noEmit` on packages/core is clean.

This reworks the earlier docs-only custom-client example version of this PR into a code integration.