### PR TITLE
remove wait for page load in caching best practices

### DIFF
--- a/packages/docs/v3/best-practices/caching.mdx
+++ b/packages/docs/v3/best-practices/caching.mdx
@@ -76,26 +76,6 @@ console.log(actResult.cacheStatus); // "HIT" or "MISS"
 
 <AccordionGroup>
 
-<Accordion title="Wait for the page to finish loading">
-If you call a Stagehand method immediately after `page.goto()`, the page content may still be streaming in. This means the accessibility tree captured for the cache key is shorter than what the page will eventually render — so subsequent calls on the fully-loaded page will produce a different hash and miss the cache. Call `page.waitForLoadState("networkidle")` first to ensure the full tree is stable before Stagehand snapshots it.
-
-```typescript
-async function example(stagehand: Stagehand) {
-  const page = stagehand.context.pages()[0];
-  await page.goto("https://www.google.com/search?q=browserbase");
-
-  await page.waitForLoadState("networkidle");
-
-  // All content is loaded — consistent hash across runs
-  const result1 = await stagehand.observe("click the first search result");
-  // MISS
-
-  const result2 = await stagehand.observe("click the first search result");
-  // HIT
-}
-```
-</Accordion>
-
 <Accordion title="Scope by selector">
 When targeting a specific part of a page, pass a `selector` to scope the accessibility tree snapshot to that container. This reduces token costs, speeds up inference, and — crucially for caching — means that changes *outside* the container don't affect the cache key.
 


### PR DESCRIPTION
# why

# what changed

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed outdated advice to wait for full page load in caching best practices. This deletes the “Wait for the page to finish loading” section and its example using `page.waitForLoadState("networkidle")` after `page.goto()`, to avoid recommending unnecessary waits.

<sup>Written for commit 8b0a6addb469395f4a39c3d90cf84ed1ef96f415. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

