### PR TITLE
[STG-2299] Document Azure Entra model auth

### DIFF
--- a/packages/docs/v3/configuration/models.mdx
+++ b/packages/docs/v3/configuration/models.mdx
@@ -260,7 +260,7 @@ await stagehand.init();
 ```
 </CodeGroup>
 
-For Microsoft Entra ID authentication, pass an Azure model object with `auth.type: "azureEntraId"` and your Azure OpenAI `resourceName`.
+For Microsoft Entra ID authentication, pass the bearer token explicitly in `auth.token`. The `providerOptions.azure.resourceName` identifies the Azure OpenAI resource to call.
 
 [View all supported Azure models →](https://ai.azure.com/catalog)
 </Tab>
@@ -958,7 +958,7 @@ The following models work without the `provider/` prefix in the model parameter 
 | Vertex | Service account credentials (see [setup](#first-class-models)) |
 | Anthropic  | `ANTHROPIC_API_KEY`            |
 | OpenAI     | `OPENAI_API_KEY`               |
-| Azure      | `AZURE_API_KEY` or `auth.token` for Microsoft Entra ID |
+| Azure      | `AZURE_API_KEY`                |
 | Cerebras   | `CEREBRAS_API_KEY`             |
 | DeepSeek   | `DEEPSEEK_API_KEY`             |
 | Groq       | `GROQ_API_KEY`                 |

--- a/packages/docs/v3/configuration/models.mdx
+++ b/packages/docs/v3/configuration/models.mdx
@@ -221,19 +221,47 @@ await stagehand.init();
 <Tab title="Azure">
 
 <CodeGroup>
-```typescript TypeScript
+```typescript API Key
 import { Stagehand } from "@browserbasehq/stagehand";
 
 const stagehand = new Stagehand({
   env: "BROWSERBASE",
-  model: "azure/gpt-5"
+  model: "azure/gpt-5",
   // API key auto-loads from AZURE_API_KEY - set in your .env
 });
 
 await stagehand.init();
 
 ```
+
+```typescript Microsoft Entra ID
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const stagehand = new Stagehand({
+  env: "BROWSERBASE",
+  model: {
+    provider: "azure",
+    modelName: "azure/gpt-5",
+    auth: {
+      type: "azureEntraId",
+      token: process.env.AZURE_ENTRA_ID_TOKEN,
+    },
+    providerOptions: {
+      azure: {
+        resourceName: "your-azure-openai-resource",
+        apiVersion: "2024-10-01-preview",
+      },
+    },
+  },
+});
+
+await stagehand.init();
+
+```
 </CodeGroup>
+
+For Microsoft Entra ID authentication, pass an Azure model object with `auth.type: "azureEntraId"` and your Azure OpenAI `resourceName`.
+
 [View all supported Azure models →](https://ai.azure.com/catalog)
 </Tab>
 
@@ -930,7 +958,7 @@ The following models work without the `provider/` prefix in the model parameter 
 | Vertex | Service account credentials (see [setup](#first-class-models)) |
 | Anthropic  | `ANTHROPIC_API_KEY`            |
 | OpenAI     | `OPENAI_API_KEY`               |
-| Azure      | `AZURE_API_KEY`                |
+| Azure      | `AZURE_API_KEY` or `auth.token` for Microsoft Entra ID |
 | Cerebras   | `CEREBRAS_API_KEY`             |
 | DeepSeek   | `DEEPSEEK_API_KEY`             |
 | Groq       | `GROQ_API_KEY`                 |


### PR DESCRIPTION
## What changed

Document the Azure OpenAI Microsoft Entra ID model config shape in the v3 model docs.

## Before

```ts
const stagehand = new Stagehand({
  env: "BROWSERBASE",
  model: "azure/gpt-5",
});
```

## After

```ts
const stagehand = new Stagehand({
  env: "BROWSERBASE",
  model: {
    provider: "azure",
    modelName: "azure/gpt-5",
    auth: {
      type: "azureEntraId",
      token: process.env.AZURE_ENTRA_ID_TOKEN,
    },
    providerOptions: {
      azure: {
        resourceName: "your-azure-openai-resource",
        apiVersion: "2024-10-01-preview",
      },
    },
  },
});
```

Validation: `pnpm exec prettier --check packages/docs/v3/configuration/models.mdx`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents Microsoft Entra ID auth for Azure OpenAI models in the v3 model config docs (STG-2299). Adds separate Azure code samples for API Key and Microsoft Entra ID, and clarifies that Entra ID requires a bearer token in `auth.token` plus `providerOptions.azure.resourceName/apiVersion`.

<sup>Written for commit b2bdf6cf428c2ad95f1a6e2b54751735fe26ef72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

