### PR TITLE
[STG-2333] fix(cli): stop headed local sessions from stealing OS focus on every command

### DIFF
--- a/.changeset/cli-headed-focus-steal.md
+++ b/.changeset/cli-headed-focus-steal.md
@@ -1,0 +1,7 @@
+---
+"browse": patch
+---
+
+Stop headed local sessions from stealing OS focus on every command.
+
+In headed managed-local mode the browse daemon re-resolved the active page on every subcommand and called `setActivePage()` unconditionally, which ends in a CDP `Target.activateTarget`. On macOS that raises the whole Chrome app to the OS foreground, stealing keyboard focus from the editor/terminal on each `browse navigate/snapshot/get/…` — making the CLI nearly unusable alongside a coding agent and impossible to parallelize. The active tab is now re-activated only when it actually changes; explicit `tab new` / `tab select` still foreground intentionally.

--- a/packages/cli/src/lib/driver/session-manager.ts
+++ b/packages/cli/src/lib/driver/session-manager.ts
@@ -179,21 +179,21 @@ export class DriverSessionManager {
           `Target ${target.targetId} was not found in the attached browser.`,
         );
       }
-      this.context.setActivePage(page);
+      this.activateIfNeeded(page);
       this.selectedTargetId = page.targetId();
       return page;
     }
 
     const existingPage = this.activePageIfPresent() ?? this.context.pages()[0];
     if (existingPage) {
-      this.context.setActivePage(existingPage);
+      this.activateIfNeeded(existingPage);
       this.selectedTargetId = existingPage.targetId();
       return existingPage;
     }
 
     if (options.createIfMissing) {
       const page = await this.context.newPage();
-      this.context.setActivePage(page);
+      this.activateIfNeeded(page);
       this.selectedTargetId = page.targetId();
       return page;
     }
@@ -208,6 +208,22 @@ export class DriverSessionManager {
       return this.context?.activePage() ?? undefined;
     } catch {
       return undefined;
+    }
+  }
+
+  /**
+   * Mark `page` active only when it isn't already the active page.
+   *
+   * `setActivePage` ends in a CDP `Target.activateTarget`, which on macOS
+   * raises the whole Chrome app to the OS foreground and steals keyboard focus.
+   * The daemon resolves the active page on every subcommand, so calling this
+   * unconditionally yanks focus away from the user's editor/terminal on each
+   * command in headed local mode. Skipping the redundant re-activation keeps a
+   * headed session usable alongside a coding agent.
+   */
+  private activateIfNeeded(page: DriverPage): void {
+    if (page !== this.activePageIfPresent()) {
+      this.context?.setActivePage(page);
     }
   }
 


### PR DESCRIPTION
## Summary

In **headed managed-local** mode, the `browse` CLI stole macOS keyboard focus on **every** subcommand, making it nearly unusable next to a coding agent and impossible to parallelize.

**Root cause:** the browse daemon resolves the active page on every subcommand via `ensurePage()`, which called `context.setActivePage()` unconditionally. In core, `setActivePage` ends in a CDP `Target.activateTarget` (`packages/core/lib/v3/understudy/context.ts`), and on macOS `Target.activateTarget` raises the whole Chrome app to the OS foreground — yanking focus away from your editor/terminal on each `browse navigate / snapshot / get / …`.

**Fix:** route the three `ensurePage()` activation sites through a new `activateIfNeeded()` helper that only re-activates when the target page isn't already the active one. Redundant re-activation (the common single-tab case) is skipped, so focus stays put. Explicit tab switches (`tabs.ts`) still call `setActivePage` directly, so intentional foregrounding (`tab new` / `tab select`) is preserved.

Scoped entirely to `packages/cli`; no core changes.

## E2E Test Matrix

Run against **real headed Chrome** (managed-local) on macOS. Instrumentation (env-gated, not committed) counted `setActivePage` → `Target.activateTarget` sends across a 5-command sequence: `open` → `open` (navigate) → `snapshot` → `get url` → `screenshot`.

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| 5-command headed session, **old** unconditional behavior (env toggle) | `setActivePage (activateTarget → FOCUS STEAL)` × **5**, skips: 0 | Reproduces the bug: every command re-activates → macOS focus steal. |
| 5-command headed session, **with fix** | `SKIP (no focus steal)` × **5**, activations: **0** | Proves the fix eliminates per-command focus theft for the normal single-tab flow. |
| `browse open https://example.com --local --headed` then navigate to `example.org`, then `screenshot` (clean build, no instrumentation) | `"url": "https://example.org/"`, screenshot saved (`16125` bytes) | Real headed Chrome still navigates/snapshots/screenshots correctly after the change — no functional regression. |
| `pnpm check` (tsc), `pnpm eslint`, `pnpm format:check` | All pass on `session-manager.ts` | Type-safe, lint-clean, formatted. |

**Not changed:** explicit tab switching still activates the target tab (verified the change only touches `ensurePage()` resolution; `tabs.ts` calls `setActivePage` directly). The one-time activation from `chrome-launcher` at browser launch is unchanged (expected — opening the browser once is fine).

Closes STG-2333

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop headed managed-local sessions from stealing macOS keyboard focus on every `browse` subcommand. We now activate a page only when it isn’t already active, addressing STG-2333.

- **Bug Fixes**
  - Added `activateIfNeeded()` and routed three `ensurePage()` calls through it to skip redundant `Target.activateTarget`.
  - Kept intentional tab foregrounding (`tab new`, `tab select`) by leaving direct `setActivePage` calls.
  - Scoped to `packages/cli`; released as a `browse` patch via changeset; verified on real headed Chrome: 5-command flow went from 5 focus steals to 0 with no regressions.

<sup>Written for commit 70b0ffb2503dbc03633587ff3f02bff1280e91e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

