### PR TITLE
Add CrawlDex preflight reporting example

### DIFF
--- a/packages/core/examples/integrations/crawldex-preflight-report.ts
+++ b/packages/core/examples/integrations/crawldex-preflight-report.ts
@@ -1,0 +1,79 @@
+import { Stagehand } from "../../lib/v3/index.js";
+import { createReporter } from "crawldex-report";
+import { reportStagehandRun } from "crawldex-report/stagehand";
+
+type CrawlDexConfig = {
+  crawldex: boolean;
+  site: string;
+  task: string;
+  reportUrl?: string;
+  agentKey?: string;
+};
+
+const crawldex: CrawlDexConfig = {
+  crawldex: true,
+  site: "example.com",
+  task: "subscriptions.cancel",
+  reportUrl: process.env.CRAWLDEX_REPORT_URL,
+  agentKey: process.env.CRAWLDEX_AGENT_KEY,
+};
+
+export async function runSubscriptionCancellation(stagehand: Stagehand) {
+  const page = stagehand.context.pages()[0];
+  const reporter = createReporter({
+    reportUrl: crawldex.reportUrl,
+    agentKey: crawldex.agentKey,
+  });
+
+  if (crawldex.crawldex) {
+    const preflight = await reporter.preflight(crawldex.site, crawldex.task);
+    if (preflight.warning) {
+      console.warn(`CrawlDex preflight warning: ${preflight.warning}`);
+    }
+    if (
+      preflight.verdict === "avoid_until_fresh_evidence" ||
+      preflight.verdict === "collect_evidence_first"
+    ) {
+      console.warn(
+        `CrawlDex recommends caution for ${crawldex.site} ${crawldex.task}`,
+      );
+    }
+  }
+
+  if (!crawldex.crawldex) {
+    await page.goto("https://example.com/account");
+    await stagehand.act("Open subscription settings", { page });
+    await stagehand.act(
+      "Start cancellation and stop before final confirmation",
+      { page },
+    );
+    return { outcome: "success_with_handoff" as const };
+  }
+
+  return reportStagehandRun({
+    reporter,
+    stagehand: { page },
+    site: crawldex.site,
+    task: crawldex.task,
+    agentProfile: {
+      stack: "stagehand",
+      browser_runtime: "chromium",
+    },
+    async run({ page: runPage, mark }) {
+      const activePage = runPage as typeof page;
+      await activePage.goto("https://example.com/account");
+      await stagehand.act("Open subscription settings", { page: activePage });
+      mark("subscription_settings_visible");
+      await stagehand.act(
+        "Start cancellation and stop before final confirmation",
+        { page: activePage },
+      );
+      mark("cancel_flow_reached");
+      return {
+        outcome: "success_with_handoff",
+        friction: ["final_confirmation_user_present"],
+        evidenceSignals: ["handoff_before_final_submit"],
+      };
+    },
+  });
+}


### PR DESCRIPTION
# PR: Add opt-in CrawlDex preflight and redacted reporting example

## Summary

This PR adds a Stagehand example for users who want to set `crawldex: true`, preflight a web task against CrawlDex, and optionally submit a redacted outcome report after the run.

## Why

CrawlDex is a public reliability index for AI agents using websites. The current corpus has 2,354 accepted observations across 17 categories, with roughly 60% of common web tasks requiring a human handoff. Stagehand is a natural place to make that signal available before an agent acts.

## What changes

- Adds `packages/core/examples/integrations/crawldex-preflight-report.ts`.
- Demonstrates `createReporter(...)`, `preflight(site, task)`, and `reportStagehandRun(...)`.
- Keeps the integration off unless `crawldex: true` is set by the caller.

## Safety

- Fail-open: CrawlDex warnings never break the Stagehand task.
- Evidence is summarized into redacted signals; raw prompts, screenshots, page text, cookies, storage, and form values are not uploaded.
- Self-registered reports are attributed but score-neutral until CrawlDex verifies the reporter.
- The example stops before final confirmation and includes no bypass instructions for CAPTCHA, MFA, anti-bot controls, paywalls, or account controls.

## Test plan

- `git apply --check docs/integrations/stagehand.patch` against Stagehand commit `4ee8d99`.
- `npx --yes prettier@3.2.5 --check packages/core/examples/integrations/crawldex-preflight-report.ts`.
- Verified `crawldex-report@0.1.0` is live on npm and clean-imports the Stagehand adapter.
- Additive example only; no production behavior changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt‑in example that preflights Stagehand tasks with CrawlDex and optionally submits a redacted outcome report. It’s fail‑open and does not change production behavior.

- **New Features**
  - Adds `packages/core/examples/integrations/crawldex-preflight-report.ts`.
  - Demonstrates `createReporter(...)`, `preflight(site, task)`, and `reportStagehandRun(...)` from `crawldex-report`.
  - Opt-in via `crawldex: true`; warnings are logged and never block runs.
  - Reporting sends redacted signals only; no raw prompts/screenshots/page text.
  - Sample flow stops before final confirmation; no CAPTCHA/MFA/paywall bypass.

<sup>Written for commit a16890e1932a14afaa101085edeb3d199cabce43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

