### PR TITLE
[docs]: add documentation for WebMCP

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -46,6 +46,7 @@
                   "v3/basics/act",
                   "v3/basics/extract",
                   "v3/basics/observe",
+                  "v3/basics/webmcp",
                   "v3/basics/evals"
                 ]
               },

--- a/packages/docs/v3/basics/webmcp.mdx
+++ b/packages/docs/v3/basics/webmcp.mdx
@@ -78,7 +78,7 @@ console.log(result.output);
 ```
 
 <Tip>
-Pass `frameId` from `listWebMCPTools()` when invoking a tool. If you omit it, Stagehand resolves the frame automatically only when exactly one registered tool has that name.
+Pass `frameId` from `listWebMCPTools()` when invoking a tool. If you omitted, Stagehand resolves the frame automatically, but only if exactly one registered tool has that name.
 </Tip>
 
 ## Handling Results
@@ -126,7 +126,7 @@ console.log(result.status); // "Canceled"
 Both WebMCP methods accept a `timeoutMs` option:
 
 - `listWebMCPTools({ timeoutMs })` waits for the page's tool snapshot. Default: `1000`
-- `invokeWebMCPTool(name, input, { timeoutMs })` waits for the invocation result. Default: `30000`
+- `invokeWebMCPTool(name, input, { timeoutMs })` sets how long `invocation.result` waits for the tool response. Default: `30000`
 
 If the browser does not support WebMCP, Stagehand throws a `StagehandUnsupportedBrowserFeatureError` with instructions for enabling the required Chrome flags.
 

--- a/packages/docs/v3/basics/webmcp.mdx
+++ b/packages/docs/v3/basics/webmcp.mdx
@@ -1,0 +1,135 @@
+---
+title: WebMCP
+sidebarTitle: WebMCP
+description: 'List and invoke tools registered by the current web page'
+---
+import { V3Banner } from '/snippets/v3-banner.mdx';
+
+<V3Banner />
+
+## What is WebMCP?
+
+WebMCP lets a web page expose tools that Stagehand can discover and invoke through Chrome's WebMCP DevTools Protocol support. Use it when the page itself registers structured tools for workflows like search, booking, calculation, or support requests.
+
+<Info>
+WebMCP is different from Stagehand agent MCP integrations. Agent MCP integrations connect your agent to external MCP servers. WebMCP tools are registered by the current web page and are invoked through the `page` object.
+</Info>
+
+## Browser Support
+
+WebMCP requires Chrome or Chromium newer than version 149, and it must be launched with `--enable-features=WebMCPTesting,DevToolsWebMCPSupport`. Stagehand launches browsers with those flags by default.
+
+## Listing Tools
+
+Use `page.listWebMCPTools()` after navigating to a page that registers WebMCP tools.
+
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const stagehand = new Stagehand({ env: "LOCAL" });
+await stagehand.init();
+
+const page = stagehand.context.pages()[0];
+await page.goto(
+  "https://googlechromelabs.github.io/webmcp-tools/demos/react-flightsearch/",
+  { waitUntil: "load" },
+);
+
+const tools = await page.listWebMCPTools();
+console.log(tools);
+
+await stagehand.close();
+```
+
+Each tool includes its `name`, optional `description`, optional `inputSchema`, optional `annotations`, and the `frameId` where it was registered.
+
+<Note>
+`listWebMCPTools()` returns a fresh snapshot from the browser on each call. It does not reuse tools from previous pages or previous calls.
+</Note>
+
+## Invoking Tools
+
+Use `page.invokeWebMCPTool()` with the tool name and a JSON-serializable input object. The method returns an invocation immediately; await `invocation.result` for the tool's final response.
+
+```typescript
+const tools = await page.listWebMCPTools();
+const flightSearch = tools.find((tool) => tool.name === "searchFlights");
+
+if (!flightSearch) {
+  throw new Error("searchFlights was not registered on this page");
+}
+
+const invocation = await page.invokeWebMCPTool(
+  flightSearch.name,
+  {
+    origin: "SFO",
+    destination: "JFK",
+    tripType: "round-trip",
+    outboundDate: "2026-06-10",
+    inboundDate: "2026-06-17",
+    passengers: 1,
+  },
+  { frameId: flightSearch.frameId },
+);
+
+const result = await invocation.result;
+console.log(result.status);
+console.log(result.output);
+```
+
+<Tip>
+Pass `frameId` from `listWebMCPTools()` when invoking a tool. If you omit it, Stagehand resolves the frame automatically only when exactly one registered tool has that name.
+</Tip>
+
+## Handling Results
+
+WebMCP invocation results have one of three statuses:
+
+```typescript
+type WebMCPToolInvocationStatus = "Completed" | "Canceled" | "Error";
+```
+
+A completed tool may include `output`. A failed tool may include `errorText` or `exception`.
+
+```typescript
+const invocation = await page.invokeWebMCPTool(
+  "calculateSum",
+  { a: 19, b: 23 },
+  { frameId: tool.frameId, timeoutMs: 5_000 },
+);
+
+const result = await invocation.result;
+
+if (result.status === "Completed") {
+  console.log(result.output);
+} else {
+  console.error(result.errorText ?? result.exception);
+}
+```
+
+To cancel a pending invocation, call `invocation.cancel()`. The invocation result still resolves when the browser sends the cancellation response.
+
+```typescript
+const invocation = await page.invokeWebMCPTool(
+  "longRunningTool",
+  {},
+  { frameId: tool.frameId },
+);
+
+await invocation.cancel();
+const result = await invocation.result;
+console.log(result.status); // "Canceled"
+```
+
+## Timeouts
+
+Both WebMCP methods accept a `timeoutMs` option:
+
+- `listWebMCPTools({ timeoutMs })` waits for the page's tool snapshot. Default: `1000`
+- `invokeWebMCPTool(name, input, { timeoutMs })` waits for the invocation result. Default: `30000`
+
+If the browser does not support WebMCP, Stagehand throws a `StagehandUnsupportedBrowserFeatureError` with instructions for enabling the required Chrome flags.
+
+## API Reference
+
+See the [Page reference](/v3/references/page#webmcp) for method signatures and type definitions.

--- a/packages/docs/v3/references/page.mdx
+++ b/packages/docs/v3/references/page.mdx
@@ -655,6 +655,107 @@ console.log(urlMap[linkId]); // e.g., "https://www.example.com"
 const mainDocumentSnapshot = await page.snapshot({ includeIframes: false });
 ```
 
+## WebMCP
+
+### listWebMCPTools()
+
+List WebMCP tools registered by the current page.
+
+```typescript
+await page.listWebMCPTools(options?: WebMCPListToolsOptions): Promise<WebMCPTool[]>
+```
+
+<ParamField path="options" type="WebMCPListToolsOptions" optional>
+  Optional configuration for collecting the current page's tool snapshot.
+
+  <Expandable title="WebMCPListToolsOptions">
+    <ParamField path="timeoutMs" type="number" optional>
+      Maximum time in milliseconds to wait for the tool snapshot.
+
+      **Default:** `1000`
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+**Returns:** A fresh `Promise<WebMCPTool[]>` snapshot from the browser. Each tool is identified by its `name` and `frameId`.
+
+<Note>
+WebMCP requires Chrome or Chromium newer than version 149, and it must be launched with `--enable-features=WebMCPTesting,DevToolsWebMCPSupport`. Stagehand launches browsers with those flags by default.
+</Note>
+
+### invokeWebMCPTool()
+
+Invoke a WebMCP tool registered by the current page.
+
+```typescript
+await page.invokeWebMCPTool(
+  toolName: string,
+  input: Record<string, unknown>,
+  options?: WebMCPToolInvocationOptions,
+): Promise<WebMCPToolInvocation>
+```
+
+<ParamField path="toolName" type="string" required>
+  Name of the registered WebMCP tool to invoke.
+</ParamField>
+
+<ParamField path="input" type="Record<string, unknown>" required>
+  JSON-serializable input passed to the tool.
+</ParamField>
+
+<ParamField path="options" type="WebMCPToolInvocationOptions" optional>
+  Optional frame targeting and timeout configuration.
+
+  <Expandable title="WebMCPToolInvocationOptions">
+    <ParamField path="frameId" type="string" optional>
+      Frame ID where the tool was registered. Use the `frameId` returned by `listWebMCPTools()`.
+
+      If omitted, Stagehand looks up tools by `toolName`. It throws when no matching tool exists or when multiple frames registered a tool with the same name.
+    </ParamField>
+
+    <ParamField path="timeoutMs" type="number" optional>
+      Maximum time in milliseconds to wait for the invocation result.
+
+      **Default:** `30000`
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+**Returns:** A `Promise<WebMCPToolInvocation>`. The invocation object includes the browser `invocationId`, resolved `toolName`, resolved `frameId`, a `result` promise, and a `cancel()` function.
+
+```typescript
+const tools = await page.listWebMCPTools();
+const calculateSum = tools.find((tool) => tool.name === "calculateSum");
+
+if (!calculateSum) {
+  throw new Error("calculateSum was not registered on this page");
+}
+
+const invocation = await page.invokeWebMCPTool(
+  "calculateSum",
+  { a: 19, b: 23 },
+  { frameId: calculateSum.frameId, timeoutMs: 5_000 },
+);
+
+const result = await invocation.result;
+console.log(result.status); // "Completed"
+console.log(result.output); // { a: 19, b: 23, sum: 42 }
+```
+
+Call `cancel()` to request cancellation for a pending invocation:
+
+```typescript
+const invocation = await page.invokeWebMCPTool(
+  "longRunningTool",
+  {},
+  { frameId: tool.frameId },
+);
+
+await invocation.cancel();
+const result = await invocation.result;
+console.log(result.status); // "Canceled"
+```
+
 ## Viewport
 
 ### setViewportSize()
@@ -1059,6 +1160,32 @@ const mainPageOnly = await page.snapshot({ includeIframes: false });
 ```
 
 </Tab>
+<Tab title="WebMCP">
+
+```typescript
+await page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/webmcp-test/", {
+  waitUntil: "load",
+});
+
+const tools = await page.listWebMCPTools({ timeoutMs: 5_000 });
+const calculateSum = tools.find((tool) => tool.name === "calculateSum");
+
+if (!calculateSum) {
+  throw new Error("calculateSum was not registered on this page");
+}
+
+const invocation = await page.invokeWebMCPTool(
+  "calculateSum",
+  { a: 19, b: 23 },
+  { frameId: calculateSum.frameId, timeoutMs: 5_000 },
+);
+
+const result = await invocation.result;
+console.log(result.status);
+console.log(result.output);
+```
+
+</Tab>
 </Tabs>
 
 ## Types
@@ -1141,6 +1268,88 @@ type SnapshotResult = {
 - **`xpathMap`** - A mapping from encoded element IDs to their absolute XPath selectors
 - **`urlMap`** - A mapping from encoded element IDs to their associated URLs (for links and other navigable elements)
 
+### WebMCPTool
+
+```typescript
+type WebMCPTool = {
+  name: string;
+  description?: string;
+  inputSchema?: string | Record<string, unknown>;
+  annotations?: Record<string, unknown>;
+  frameId: string;
+};
+```
+
+- **`name`** - Tool name registered by the page
+- **`description`** - Optional description registered by the page
+- **`inputSchema`** - Optional input schema registered by the page
+- **`annotations`** - Optional annotations registered by the page
+- **`frameId`** - Browser frame ID where the tool was registered
+
+### WebMCPToolInvocationStatus
+
+```typescript
+type WebMCPToolInvocationStatus = "Completed" | "Canceled" | "Error";
+```
+
+### WebMCPToolResult
+
+```typescript
+type WebMCPToolResult = {
+  invocationId: string;
+  status: WebMCPToolInvocationStatus;
+  output?: unknown;
+  errorText?: string;
+  exception?: unknown;
+};
+```
+
+- **`invocationId`** - Browser invocation ID for the tool call
+- **`status`** - Final invocation status
+- **`output`** - Optional tool output
+- **`errorText`** - Optional error text returned by the browser
+- **`exception`** - Optional exception returned by the browser
+
+### WebMCPToolInvocation
+
+```typescript
+type WebMCPToolInvocation = {
+  invocationId: string;
+  toolName: string;
+  frameId: string;
+  result: Promise<WebMCPToolResult>;
+  cancel: () => Promise<void>;
+};
+```
+
+- **`invocationId`** - Browser invocation ID for the tool call
+- **`toolName`** - Tool name passed to `invokeWebMCPTool()`
+- **`frameId`** - Frame ID used for the invocation
+- **`result`** - Promise that resolves with the final tool result or rejects on timeout/disposal
+- **`cancel`** - Sends `WebMCP.cancelInvocation` for the pending invocation
+
+### WebMCPListToolsOptions
+
+```typescript
+type WebMCPListToolsOptions = {
+  timeoutMs?: number;
+};
+```
+
+- **`timeoutMs`** - Maximum time in milliseconds to wait for the tool snapshot. Defaults to `1000`
+
+### WebMCPToolInvocationOptions
+
+```typescript
+type WebMCPToolInvocationOptions = {
+  frameId?: string;
+  timeoutMs?: number;
+};
+```
+
+- **`frameId`** - Frame ID where the tool was registered
+- **`timeoutMs`** - Maximum time in milliseconds to wait for the invocation result. Defaults to `30000`
+
 ## Error Handling
 
 Page methods may throw the following errors:
@@ -1149,6 +1358,7 @@ Page methods may throw the following errors:
 - **Evaluation Errors** - JavaScript execution errors in `evaluate()`
 - **Interaction Errors** - Failed clicks or typing operations
 - **Screenshot Errors** - Issues capturing screenshots
+- **WebMCP Errors** - Unsupported browser features, ambiguous tool names across frames, invocation result timeouts, or disposed pending invocations
 
 All errors should be caught and handled appropriately:
 


### PR DESCRIPTION
# why
- to add documentation for new webmcp related functions/behaviour


<img width="1330" height="782" alt="Screenshot 2026-06-18 at 10 57 58 AM" src="https://github.com/user-attachments/assets/2952f136-4d01-445c-95e4-c4a81e4ec289" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds WebMCP docs to v3. Introduces a new Basics page and expands the `Page` API reference so users can list and invoke page-registered tools in Chrome.

- **New Features**
  - Added a Basics page: overview; Chrome/Chromium 149+ and flags `--enable-features=WebMCPTesting,DevToolsWebMCPSupport`; how to list/invoke tools; frameId targeting; results, cancel, and timeout defaults; examples with `@browserbasehq/stagehand`.
  - Updated the `Page` reference with `listWebMCPTools()` and `invokeWebMCPTool()` signatures, options (`timeoutMs`, `frameId`), return shape (`result`, `cancel()`), examples, types (`WebMCPTool`, `WebMCPToolInvocationStatus`, `WebMCPToolResult`, `WebMCPToolInvocation`), and error cases (unsupported browser, ambiguous tool names, result timeouts, disposed invocations).
  - Included WebMCP in the docs sidebar navigation.

<sup>Written for commit 43188ab9a2933dc0af46971f5262163f342a6d7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

