### PR TITLE
[docs]: fix copy in WebMCP basics section

### DIFF
--- a/packages/docs/v3/basics/webmcp.mdx
+++ b/packages/docs/v3/basics/webmcp.mdx
@@ -9,7 +9,7 @@ import { V3Banner } from '/snippets/v3-banner.mdx';
 
 ## What is WebMCP?
 
-WebMCP lets a web page expose tools that Stagehand can discover and invoke through Chrome's WebMCP DevTools Protocol support. Use it when the page itself registers structured tools for workflows like search, booking, calculation, or support requests.
+WebMCP lets pages expose typed, first-party tools to Stagehand. Instead of inferring every action from the DOM, agents can use Stagehand to discover available tools and invoke them with structured input.
 
 <Info>
 WebMCP is different from Stagehand agent MCP integrations. Agent MCP integrations connect your agent to external MCP servers. WebMCP tools are registered by the current web page and are invoked through the `page` object.


### PR DESCRIPTION
# why
- changed the copy for clarity/less fluff


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the WebMCP basics doc by updating “What is WebMCP?” to explain that pages can expose typed, first‑party tools that Stagehand discovers and invokes with structured input, reducing reliance on DOM inference.

<sup>Written for commit 0d65589cffeed4c078604124d88e736cd5a0fdc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

