### PR TITLE
[docs]: rm director references

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,18 +43,6 @@ If you're looking for the Python implementation, you can find it
 <a href="https://github.com/browserbase/stagehand-python"> here</a>
 </p>
 
-<div align="center" style="display: flex; align-items: center; justify-content: center; gap: 4px; margin-bottom: 0;">
-  <b>Vibe code</b>
-  <span style="font-size: 1.05em;"> Stagehand with </span>
-  <a href="https://director.ai" style="display: flex; align-items: center;">
-    <span>Director</span>
-  </a>
-  <span> </span>
-  <picture>
-    <img alt="Director" src="media/director_icon.svg" width="25" />
-  </picture>
-</div>
-
 ## What is Stagehand?
 
 Stagehand is a browser automation framework used to control web browsers with natural language and code. By combining the power of AI with the precision of code, Stagehand makes web automation flexible, maintainable, and actually reliable.

--- a/media/director_icon.svg
+++ b/media/director_icon.svg
@@ -1,5 +1,0 @@
-<svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect x="39" y="44" width="136" height="129" fill="white"/>
-<path d="M103.588 80.1465V120.146H96.5879V80.1465H103.588Z" fill="#00B0FF"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M200 200H0V0H200V200ZM56.0684 52.2988V147.945H119.938L145.589 122.301V77.25L120.631 52.2988H56.0684Z" fill="#00B0FF"/>
-</svg>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -43,18 +43,6 @@ If you're looking for the Python implementation, you can find it
 <a href="https://github.com/browserbase/stagehand-python"> here</a>
 </p>
 
-<div align="center" style="display: flex; align-items: center; justify-content: center; gap: 4px; margin-bottom: 0;">
-  <b>Vibe code</b>
-  <span style="font-size: 1.05em;"> Stagehand with </span>
-  <a href="https://director.ai" style="display: flex; align-items: center;">
-    <span>Director</span>
-  </a>
-  <span> </span>
-  <picture>
-    <img alt="Director" src="../../media/director_icon.svg" width="25" />
-  </picture>
-</div>
-
 ## What is Stagehand?
 
 Stagehand is a browser automation framework used to control web browsers with natural language and code. By combining the power of AI with the precision of code, Stagehand makes web automation flexible, maintainable, and actually reliable.

--- a/packages/docs/v2/first-steps/introduction.mdx
+++ b/packages/docs/v2/first-steps/introduction.mdx
@@ -115,13 +115,6 @@ Stagehand is designed for developers building production browser automations and
     Build your first automation in under a minute
   </Card>
   <Card
-    title="Try Director"
-    icon="wand-magic-sparkles"
-    href="https://www.director.ai"
-  >
-    Generate Stagehand scripts with AI
-  </Card>
-  <Card
     title="View Templates"
     icon="code"
     href="https://www.browserbase.com/templates"

--- a/packages/docs/v2/first-steps/introduction.mdx
+++ b/packages/docs/v2/first-steps/introduction.mdx
@@ -128,4 +128,11 @@ Stagehand is designed for developers building production browser automations and
   >
     Get help from the community
   </Card>
+  <Card
+    title="Installation"
+    icon="download"
+    href="/v2/first-steps/installation"
+  >
+    Add Stagehand to your project
+  </Card>
 </CardGroup>

--- a/packages/docs/v2/first-steps/quickstart.mdx
+++ b/packages/docs/v2/first-steps/quickstart.mdx
@@ -3,9 +3,7 @@ title: Quickstart
 description: 'Stagehand allows you to build web automations with natural language and code.'
 ---
 
-If this is your **first time using Stagehand**, you should try [Director](https://director.ai) first. It's an agent that allows you to build Stagehand workflows using natural language. You can also try Stagehand using our [MCP server](/v2/integrations/mcp/introduction).
-
-Otherwise, the quickest way to start with Stagehand is with our CLI. It scaffolds a ready‑to‑run Stagehand app with sensible defaults, and an example script.
+The quickest way to start with Stagehand is with our CLI. It scaffolds a ready‑to‑run Stagehand app with sensible defaults, and an example script. You can also try Stagehand using our [MCP server](/v2/integrations/mcp/introduction).
 
 <Note>
 This quickstart is for **TypeScript**. For **Python**, see the [installation guide](/v2/first-steps/installation).

--- a/packages/docs/v2/integrations/vercel/configuration.mdx
+++ b/packages/docs/v2/integrations/vercel/configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: Use Stagehand in Next.js
 sidebarTitle: Configuration
-description: Next.js is a popular framework for developing web-based applications in production. It powers Stagehand apps like [Director](https://director.ai), [Brainrot](https://brainrot.run) and [Open Operator](https://operator.browserbase.com).
+description: Next.js is a popular framework for developing web-based applications in production. It powers Stagehand apps like [Brainrot](https://brainrot.run) and [Open Operator](https://operator.browserbase.com).
 ---
 
 <Card

--- a/packages/docs/v3/first-steps/introduction.mdx
+++ b/packages/docs/v3/first-steps/introduction.mdx
@@ -107,4 +107,11 @@ Stagehand is designed for developers building production browser automations and
   >
     Get help from the community
   </Card>
+  <Card
+    title="Installation"
+    icon="download"
+    href="/v3/first-steps/installation"
+  >
+    Add Stagehand to your project
+  </Card>
 </CardGroup>

--- a/packages/docs/v3/first-steps/introduction.mdx
+++ b/packages/docs/v3/first-steps/introduction.mdx
@@ -94,13 +94,6 @@ Stagehand is designed for developers building production browser automations and
     Build your first automation in under a minute
   </Card>
   <Card
-    title="Try Director"
-    icon="wand-magic-sparkles"
-    href="https://www.director.ai"
-  >
-    Generate Stagehand scripts with AI
-  </Card>
-  <Card
     title="View Templates"
     icon="code"
     href="https://www.browserbase.com/templates"

--- a/packages/docs/v3/first-steps/quickstart.mdx
+++ b/packages/docs/v3/first-steps/quickstart.mdx
@@ -7,9 +7,7 @@ import { V3Banner } from '/snippets/v3-banner.mdx';
 <V3Banner />
 
 
-If this is your **first time using Stagehand**, you should try [Director](https://director.ai) first. It's an agent that allows you to build Stagehand workflows using natural language. You can also try Stagehand using our [MCP server](/v3/integrations/mcp/introduction).
-
-Otherwise, the quickest way to start with Stagehand is with our CLI. It scaffolds a ready‑to‑run Stagehand app with sensible defaults, and an example script.
+The quickest way to start with Stagehand is with our CLI. It scaffolds a ready‑to‑run Stagehand app with sensible defaults, and an example script. You can also try Stagehand using our [MCP server](/v3/integrations/mcp/introduction).
 
 <Note>
 This quickstart is for **TypeScript**. For other languages, change the language selector in the top left corner.

--- a/packages/docs/v3/integrations/vercel/configuration.mdx
+++ b/packages/docs/v3/integrations/vercel/configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: Use Stagehand in Next.js
 sidebarTitle: Configuration
-description: Next.js is a popular framework for developing web-based applications in production. It powers Stagehand apps like [Director](https://director.ai), [Brainrot](https://brainrot.run) and [Open Operator](https://operator.browserbase.com).
+description: Next.js is a popular framework for developing web-based applications in production. It powers Stagehand apps like [Brainrot](https://brainrot.run) and [Open Operator](https://operator.browserbase.com).
 ---
 import { V3Banner } from '/snippets/v3-banner.mdx';
 


### PR DESCRIPTION
# why
- clean up stale director references
# what changed
- removed director svg from readme, v2 docs, & v3 docs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed all stale Director references from READMEs and docs to reduce confusion and keep guidance up to date. Added an Installation card to v2/v3 intros and deleted the unused icon asset.

- **Refactors**
  - Removed Director promo block from `README.md` and `packages/core/README.md`.
  - Deleted `media/director_icon.svg`.
  - Updated v2/v3 introductions: removed "Try Director" card and added an "Installation" card.
  - Updated v2/v3 quickstarts to focus on CLI and MCP; removed Director recommendation.
  - Dropped Director mention from Next.js integration descriptions in v2/v3 docs.

<sup>Written for commit 3b9007acfbeb4440fba5242e0de8519b0b53a0d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

