### PR TITLE
[chore]: add undici version override

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
       "form-data": "^4.0.6",
       "tar": "^7.5.16",
       "js-yaml@4.1.1": "4.2.0",
-      "read-yaml-file": "2.1.0"
+      "read-yaml-file": "2.1.0",
+      "undici": "^7.28.0"
     }
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,7 @@ overrides:
   tar: ^7.5.16
   js-yaml@4.1.1: 4.2.0
   read-yaml-file: 2.1.0
+  undici: ^7.28.0
 
 importers:
 
@@ -7076,8 +7077,8 @@ packages:
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
@@ -13394,7 +13395,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.25.0
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -16246,7 +16247,7 @@ snapshots:
 
   undici-types@7.19.2: {}
 
-  undici@7.25.0: {}
+  undici@7.28.0: {}
 
   unified@11.0.5:
     dependencies:


### PR DESCRIPTION
# why
- to fix transitive dependency vuln found in undici
# what changed
- adds override for `undici` transitive dependency


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a pnpm override to force `undici` to `^7.28.0`, fixing a transitive dependency vulnerability and ensuring all consumers use the patched version. Updates `package.json` and `pnpm-lock.yaml` to resolve to the new version.

<sup>Written for commit e743ceb3a27f0ba5d61dc046023455368368de65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

