### PR TITLE
Enable Gemini-3.5-flash cua

### DIFF
--- a/.changeset/gemini-3-5-flash-cua.md
+++ b/.changeset/gemini-3-5-flash-cua.md
@@ -1,5 +1,5 @@
 ---
-"@browserbasehq/stagehand": minor
+"@browserbasehq/stagehand": patch
 ---
 
 Add support for the new`google/gemini-3.5-flash` computer-use tools model

--- a/.changeset/gemini-3-5-flash-cua.md
+++ b/.changeset/gemini-3-5-flash-cua.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": minor
+---
+
+Add support for the `google/gemini-3.5-flash` computer-use agent model. The Google CUA client now maps Gemini 3.x predefined function names onto the canonical 2.5 handlers, tolerates the 3.x argument shapes (coordinate-less type, keys arrays, scroll magnitude, drag start/end pairs), treats take_screenshot as a no-op, and always returns a screenshot observation even on a turn with no executable actions.

--- a/.changeset/gemini-3-5-flash-cua.md
+++ b/.changeset/gemini-3-5-flash-cua.md
@@ -2,4 +2,4 @@
 "@browserbasehq/stagehand": patch
 ---
 
-Add support for the new`google/gemini-3.5-flash` computer-use tools model
+Add support for the new `google/gemini-3.5-flash` computer-use tools model

--- a/.changeset/gemini-3-5-flash-cua.md
+++ b/.changeset/gemini-3-5-flash-cua.md
@@ -2,4 +2,4 @@
 "@browserbasehq/stagehand": minor
 ---
 
-Add support for the `google/gemini-3.5-flash` computer-use agent model. The Google CUA client now maps Gemini 3.x predefined function names onto the canonical 2.5 handlers, tolerates the 3.x argument shapes (coordinate-less type, keys arrays, scroll magnitude, drag start/end pairs), treats take_screenshot as a no-op, and always returns a screenshot observation even on a turn with no executable actions.
+Add support for the new`google/gemini-3.5-flash` computer-use tools model

--- a/packages/core/lib/v3/agent/AgentProvider.ts
+++ b/packages/core/lib/v3/agent/AgentProvider.ts
@@ -31,6 +31,7 @@ export const modelToAgentProviderMap: Record<string, AgentProviderType> = {
   "claude-fable-5": "anthropic",
   "gemini-2.5-computer-use-preview-10-2025": "google",
   "gemini-3-flash-preview": "google",
+  "gemini-3.5-flash": "google",
   "gemini-3-pro-preview": "google",
   "fara-7b": "microsoft",
 };

--- a/packages/core/lib/v3/agent/GoogleCUAClient.ts
+++ b/packages/core/lib/v3/agent/GoogleCUAClient.ts
@@ -241,6 +241,8 @@ export class GoogleCUAClient extends AgentClient {
 
     let totalInputTokens = 0;
     let totalOutputTokens = 0;
+    let totalReasoningTokens = 0;
+    let totalCachedInputTokens = 0;
     let totalInferenceTime = 0;
 
     try {
@@ -257,6 +259,8 @@ export class GoogleCUAClient extends AgentClient {
         const result = await this.executeStep(logger);
         totalInputTokens += result.usage.input_tokens;
         totalOutputTokens += result.usage.output_tokens;
+        totalReasoningTokens += result.usage.reasoning_tokens;
+        totalCachedInputTokens += result.usage.cached_input_tokens;
         totalInferenceTime += result.usage.inference_time_ms;
 
         // Add actions to the list
@@ -284,6 +288,8 @@ export class GoogleCUAClient extends AgentClient {
         usage: {
           input_tokens: totalInputTokens,
           output_tokens: totalOutputTokens,
+          reasoning_tokens: totalReasoningTokens,
+          cached_input_tokens: totalCachedInputTokens,
           inference_time_ms: totalInferenceTime,
         },
       };
@@ -304,6 +310,8 @@ export class GoogleCUAClient extends AgentClient {
         usage: {
           input_tokens: totalInputTokens,
           output_tokens: totalOutputTokens,
+          reasoning_tokens: totalReasoningTokens,
+          cached_input_tokens: totalCachedInputTokens,
           inference_time_ms: totalInferenceTime,
         },
       };
@@ -349,6 +357,8 @@ export class GoogleCUAClient extends AgentClient {
     usage: {
       input_tokens: number;
       output_tokens: number;
+      reasoning_tokens: number;
+      cached_input_tokens: number;
       inference_time_ms: number;
     };
   }> {
@@ -657,8 +667,14 @@ export class GoogleCUAClient extends AgentClient {
         message: result.message,
         completed: result.completed,
         usage: {
+          // promptTokenCount is the TOTAL input and already includes the
+          // cached portion; cachedContentTokenCount is the cache-hit subset
+          // (tracked separately for visibility, not additive). thoughtsTokenCount
+          // is Gemini's thinking/reasoning output.
           input_tokens: usageMetadata?.promptTokenCount || 0,
           output_tokens: usageMetadata?.candidatesTokenCount || 0,
+          reasoning_tokens: usageMetadata?.thoughtsTokenCount || 0,
+          cached_input_tokens: usageMetadata?.cachedContentTokenCount || 0,
           inference_time_ms: elapsedMs,
         },
       };

--- a/packages/core/lib/v3/agent/GoogleCUAClient.ts
+++ b/packages/core/lib/v3/agent/GoogleCUAClient.ts
@@ -842,11 +842,15 @@ export class GoogleCUAClient extends AgentClient {
     // NOTE: click and take_screenshot are confirmed from live gemini-3.5-flash
     // traffic; the rest are inferred from the same drop-the-qualifier pattern
     // and are safe aliases (any unmapped name still hits the warning below).
+    // gemini-3.x renamed several predefined functions vs gemini-2.5. Alias the
+    // 3.x names whose behavior maps cleanly onto a 2.5 canonical handler. Click
+    // variants that carry distinct semantics (double/triple/right/middle click,
+    // move) are NOT aliased here — they have dedicated cases below so the click
+    // count and button are preserved. 2.5 never emits any of these names, so
+    // the 2.5 handlers are unaffected.
     const NAME_ALIASES: Record<string, string> = {
       click: "click_at",
       left_click: "click_at",
-      double_click: "click_at",
-      triple_click: "click_at",
       type: "type_text_at",
       type_text: "type_text_at",
       hover: "hover_at",
@@ -891,6 +895,40 @@ export class GoogleCUAClient extends AgentClient {
           y,
           button: args.button || "left",
         };
+      }
+
+      // gemini-3.x click family. The executor natively supports double/triple
+      // click and right/middle button, so preserve those semantics rather than
+      // collapsing to a single left click.
+      case "double_click":
+      case "triple_click": {
+        const { x, y } = this.normalizeCoordinates(
+          args.x as number,
+          args.y as number,
+        );
+        return { type: name, x, y };
+      }
+
+      case "right_click":
+      case "middle_click": {
+        const { x, y } = this.normalizeCoordinates(
+          args.x as number,
+          args.y as number,
+        );
+        return {
+          type: "click",
+          x,
+          y,
+          button: name === "right_click" ? "right" : "middle",
+        };
+      }
+
+      case "move": {
+        const { x, y } = this.normalizeCoordinates(
+          args.x as number,
+          args.y as number,
+        );
+        return { type: "move", x, y };
       }
 
       case "type_text_at": {

--- a/packages/core/lib/v3/agent/GoogleCUAClient.ts
+++ b/packages/core/lib/v3/agent/GoogleCUAClient.ts
@@ -900,10 +900,12 @@ export class GoogleCUAClient extends AgentClient {
         };
 
       case "click_at": {
-        const { x, y } = this.normalizeCoordinates(
-          args.x as number,
-          args.y as number,
-        );
+        // x/y are required; reject a malformed call rather than normalizing
+        // undefined into NaN coordinates. (gemini-3.x `click` aliases here.)
+        if (typeof args.x !== "number" || typeof args.y !== "number") {
+          return null;
+        }
+        const { x, y } = this.normalizeCoordinates(args.x, args.y);
         return {
           type: "click",
           x,

--- a/packages/core/lib/v3/agent/GoogleCUAClient.ts
+++ b/packages/core/lib/v3/agent/GoogleCUAClient.ts
@@ -899,36 +899,30 @@ export class GoogleCUAClient extends AgentClient {
 
       // gemini-3.x click family. The executor natively supports double/triple
       // click and right/middle button, so preserve those semantics rather than
-      // collapsing to a single left click.
+      // collapsing to a single left click. All require integer coordinates;
+      // drop the call (return null) on a malformed payload so the executor is
+      // never handed NaN.
       case "double_click":
-      case "triple_click": {
-        const { x, y } = this.normalizeCoordinates(
-          args.x as number,
-          args.y as number,
-        );
-        return { type: name, x, y };
-      }
-
+      case "triple_click":
       case "right_click":
-      case "middle_click": {
-        const { x, y } = this.normalizeCoordinates(
-          args.x as number,
-          args.y as number,
-        );
+      case "middle_click":
+      case "move": {
+        if (typeof args.x !== "number" || typeof args.y !== "number") {
+          return null;
+        }
+        const { x, y } = this.normalizeCoordinates(args.x, args.y);
+        if (name === "move") {
+          return { type: "move", x, y };
+        }
+        if (name === "double_click" || name === "triple_click") {
+          return { type: name, x, y };
+        }
         return {
           type: "click",
           x,
           y,
           button: name === "right_click" ? "right" : "middle",
         };
-      }
-
-      case "move": {
-        const { x, y } = this.normalizeCoordinates(
-          args.x as number,
-          args.y as number,
-        );
-        return { type: "move", x, y };
       }
 
       case "type_text_at": {

--- a/packages/core/lib/v3/agent/GoogleCUAClient.ts
+++ b/packages/core/lib/v3/agent/GoogleCUAClient.ts
@@ -484,10 +484,15 @@ export class GoogleCUAClient extends AgentClient {
       // Execute actions and collect function responses
       const functionResponses: Part[] = [];
 
-      if (result.actions.length > 0) {
+      // Always process the model's response, even when it produced no
+      // executable action (e.g. a standalone take_screenshot). The model
+      // expects exactly one function response — a fresh screenshot — per
+      // computer-use call; skipping it when there are 0 actions leaves the
+      // model blind and it gives up after one empty turn.
+      {
         let hasError = false;
 
-        // Execute all actions
+        // Execute all actions (a no-op when there are none).
         for (let i = 0; i < result.actions.length; i++) {
           const action = result.actions[i];
 
@@ -504,6 +509,14 @@ export class GoogleCUAClient extends AgentClient {
             logger({
               category: "agent",
               message: "Skipping open_web_browser action",
+              level: 2,
+            });
+          } else if (action.type === "screenshot") {
+            // No interaction to perform — the screenshot captured below is
+            // returned to the model as this call's function response.
+            logger({
+              category: "agent",
+              message: "take_screenshot: capturing current page",
               level: 2,
             });
           } else if (action.type === "custom_tool") {
@@ -716,23 +729,24 @@ export class GoogleCUAClient extends AgentClient {
         // Convert function call to action(s)
         const action = this.convertFunctionCallToAction(part.functionCall);
         if (action) {
-          // Special handling for type_text_at - we need to click first
-          if (
-            part.functionCall.name === "type_text_at" &&
-            action.type === "type"
-          ) {
+          // Special handling for type actions. gemini-2.5 type_text_at carries
+          // coordinates (click the field first); gemini-3.x `type` has none and
+          // types into the element the model already focused.
+          if (action.type === "type") {
             logger({
               category: "agent",
               message: `Adding action: ${JSON.stringify(action)}`,
               level: 2,
             });
-            // First add a click action at the same coordinates
-            actions.push({
-              type: "click",
-              x: action.x,
-              y: action.y,
-              button: "left",
-            });
+            // Click the target first only when coordinates are provided.
+            if (typeof action.x === "number" && typeof action.y === "number") {
+              actions.push({
+                type: "click",
+                x: action.x,
+                y: action.y,
+                button: "left",
+              });
+            }
 
             // If clear_before_typing is true (default), add a select all
             if (action.clearBeforeTyping) {
@@ -794,16 +808,59 @@ export class GoogleCUAClient extends AgentClient {
   private convertFunctionCallToAction(
     functionCall: FunctionCall,
   ): AgentAction | null {
-    const { name, args } = functionCall;
+    const { name: rawName } = functionCall;
+    // Default args to an empty object so no-argument predefined functions
+    // (e.g. take_screenshot, go_back) are not rejected by the guard below.
+    const args = functionCall.args ?? {};
 
-    if (!name || !args) {
+    if (!rawName) {
       return null;
     }
+
+    // The gemini-3.x computer-use tool renamed several of the predefined
+    // functions that gemini-2.5-computer-use-preview used, and adds a
+    // descriptive `intent` arg to every call. The argument fields are otherwise
+    // unchanged (confirmed for click/navigate). Normalize the 3.x names to the
+    // canonical 2.5 names so a single set of handlers serves both generations;
+    // `intent` is ignored since handlers only read the args they need.
+    // NOTE: click and take_screenshot are confirmed from live gemini-3.5-flash
+    // traffic; the rest are inferred from the same drop-the-qualifier pattern
+    // and are safe aliases (any unmapped name still hits the warning below).
+    const NAME_ALIASES: Record<string, string> = {
+      click: "click_at",
+      left_click: "click_at",
+      double_click: "click_at",
+      triple_click: "click_at",
+      type: "type_text_at",
+      type_text: "type_text_at",
+      hover: "hover_at",
+      scroll: "scroll_at",
+      drag: "drag_and_drop",
+      key: "key_combination",
+      keys: "key_combination",
+      key_press: "key_combination",
+      press_key: "key_combination",
+      press_keys: "key_combination",
+      hotkey: "key_combination",
+      screenshot: "take_screenshot",
+      wait: "wait_5_seconds",
+    };
+    const name = NAME_ALIASES[rawName] ?? rawName;
 
     switch (name) {
       case "open_web_browser":
         return {
           type: "open_web_browser",
+          timestamp: Date.now(),
+        };
+
+      case "take_screenshot":
+        // No UI interaction. The step loop captures a fresh screenshot and
+        // returns it to the model as this call's function response; marked as a
+        // recognized action (not null) so it isn't dropped, and skipped in the
+        // executor like open_web_browser.
+        return {
+          type: "screenshot",
           timestamp: Date.now(),
         };
 
@@ -821,32 +878,42 @@ export class GoogleCUAClient extends AgentClient {
       }
 
       case "type_text_at": {
-        const { x, y } = this.normalizeCoordinates(
-          args.x as number,
-          args.y as number,
-        );
-        // Google's type_text_at includes press_enter and clear_before_typing parameters
+        // press_enter and clear_before_typing are shared across generations.
         const pressEnter = (args.press_enter as boolean) ?? false;
         const clearBeforeTyping = (args.clear_before_typing as boolean) ?? true;
-
-        // For type_text_at, we need to click first then type
-        // This matches the behavior expected by Google's CUA
-        // We'll handle this in the executeStep method by converting to two actions
-        return {
-          type: "type",
+        const base = {
+          type: "type" as const,
           text: args.text as string,
-          x,
-          y,
           pressEnter,
           clearBeforeTyping,
         };
+
+        // gemini-2.5 type_text_at carries x/y (click the field, then type).
+        // gemini-3.x `type` has no coordinates and types into the element the
+        // model already focused with a preceding click. Only attach coords when
+        // present so the executor doesn't click at NaN.
+        if (typeof args.x === "number" && typeof args.y === "number") {
+          const { x, y } = this.normalizeCoordinates(args.x, args.y);
+          return { ...base, x, y };
+        }
+        return base;
       }
 
       case "key_combination": {
-        const keys = (args.keys as string)
-          .split("+")
-          .map((key: string) => key.trim())
-          .map((key: string) => mapKeyToPlaywright(key));
+        // gemini-2.5 key_combination sends `keys` as a "+"-joined string;
+        // gemini-3.x `hotkey` sends a `keys` array, and `press_key` sends a
+        // single `key`. Accept all three.
+        const raw = args.keys !== undefined ? args.keys : args.key;
+        const parts = Array.isArray(raw)
+          ? (raw as string[])
+          : String(raw ?? "").split("+");
+        const keys = parts
+          .map((key) => String(key).trim())
+          .filter(Boolean)
+          .map((key) => mapKeyToPlaywright(key));
+        if (keys.length === 0) {
+          return null;
+        }
         return {
           type: "keypress",
           keys,
@@ -862,13 +929,26 @@ export class GoogleCUAClient extends AgentClient {
       }
 
       case "scroll_at": {
+        // A coordinate-less `scroll` alias (gemini-3.x) scrolls the document.
+        if (typeof args.x !== "number" || typeof args.y !== "number") {
+          const dir = ((args.direction as string) || "down").toLowerCase();
+          return {
+            type: "keypress",
+            keys: [dir === "up" ? "PageUp" : "PageDown"],
+          };
+        }
         const { x, y } = this.normalizeCoordinates(
           args.x as number,
           args.y as number,
         );
         const direction = ((args.direction as string) || "down").toLowerCase();
+        // 2.5 uses `magnitude`; gemini-3.x `scroll` uses `magnitude_in_pixels`.
         const magnitude =
-          typeof args.magnitude === "number" ? (args.magnitude as number) : 800;
+          typeof args.magnitude === "number"
+            ? (args.magnitude as number)
+            : typeof args.magnitude_in_pixels === "number"
+              ? (args.magnitude_in_pixels as number)
+              : 800;
 
         let scroll_x = 0;
         let scroll_y = 0;
@@ -935,14 +1015,22 @@ export class GoogleCUAClient extends AgentClient {
         };
 
       case "drag_and_drop": {
-        const startPoint = this.normalizeCoordinates(
-          args.x as number,
-          args.y as number,
-        );
-        const endPoint = this.normalizeCoordinates(
-          args.destination_x as number,
-          args.destination_y as number,
-        );
+        // 2.5 uses x/y + destination_x/destination_y; gemini-3.x `drag_and_drop`
+        // uses start_x/start_y + end_x/end_y. Accept either.
+        const sx = (args.x ?? args.start_x) as number;
+        const sy = (args.y ?? args.start_y) as number;
+        const ex = (args.destination_x ?? args.end_x) as number;
+        const ey = (args.destination_y ?? args.end_y) as number;
+        if (
+          typeof sx !== "number" ||
+          typeof sy !== "number" ||
+          typeof ex !== "number" ||
+          typeof ey !== "number"
+        ) {
+          return null;
+        }
+        const startPoint = this.normalizeCoordinates(sx, sy);
+        const endPoint = this.normalizeCoordinates(ex, ey);
         return {
           type: "drag",
           path: [

--- a/packages/core/lib/v3/agent/GoogleCUAClient.ts
+++ b/packages/core/lib/v3/agent/GoogleCUAClient.ts
@@ -743,7 +743,10 @@ export class GoogleCUAClient extends AgentClient {
         });
 
         // Convert function call to action(s)
-        const action = this.convertFunctionCallToAction(part.functionCall);
+        const action = this.convertFunctionCallToAction(
+          part.functionCall,
+          logger,
+        );
         if (action) {
           // Special handling for type actions. gemini-2.5 type_text_at carries
           // coordinates (click the field first); gemini-3.x `type` has none and
@@ -823,6 +826,7 @@ export class GoogleCUAClient extends AgentClient {
    */
   private convertFunctionCallToAction(
     functionCall: FunctionCall,
+    logger?: (message: LogLine) => void,
   ): AgentAction | null {
     const { name: rawName } = functionCall;
     // Default args to an empty object so no-argument predefined functions
@@ -866,6 +870,17 @@ export class GoogleCUAClient extends AgentClient {
       wait: "wait_5_seconds",
     };
     const name = NAME_ALIASES[rawName] ?? rawName;
+
+    // Predefined computer-use tools take precedence over custom tools. If a
+    // custom tool was registered under a reserved (aliased) name, note that the
+    // predefined tool wins rather than silently dropping the custom one.
+    if (rawName in NAME_ALIASES && isCustomTool(functionCall, this.tools)) {
+      logger?.({
+        category: "agent",
+        message: `Custom tool "${rawName}" collides with a predefined Google CUA function; using the predefined tool. Rename the custom tool to avoid the conflict.`,
+        level: 2,
+      });
+    }
 
     switch (name) {
       case "open_web_browser":
@@ -926,6 +941,11 @@ export class GoogleCUAClient extends AgentClient {
       }
 
       case "type_text_at": {
+        // text is required; reject a malformed call rather than typing
+        // "undefined". An empty string is valid (e.g. clear the field).
+        if (typeof args.text !== "string") {
+          return null;
+        }
         // press_enter and clear_before_typing are shared across generations.
         const pressEnter = (args.press_enter as boolean) ?? false;
         const clearBeforeTyping = (args.clear_before_typing as boolean) ?? true;
@@ -1023,9 +1043,14 @@ export class GoogleCUAClient extends AgentClient {
       }
 
       case "navigate":
+        // url is required; reject a malformed call rather than navigating to
+        // "undefined".
+        if (typeof args.url !== "string" || args.url.length === 0) {
+          return null;
+        }
         return {
           type: "goto",
-          url: args.url as string,
+          url: args.url,
         };
 
       case "go_back":

--- a/packages/core/lib/v3/agent/GoogleCUAClient.ts
+++ b/packages/core/lib/v3/agent/GoogleCUAClient.ts
@@ -901,8 +901,12 @@ export class GoogleCUAClient extends AgentClient {
 
       case "click_at": {
         // x/y are required; reject a malformed call rather than normalizing
-        // undefined into NaN coordinates. (gemini-3.x `click` aliases here.)
-        if (typeof args.x !== "number" || typeof args.y !== "number") {
+        // undefined/NaN/Infinity into bad coordinates. (gemini-3.x `click`
+        // aliases here.)
+        if (
+          !GoogleCUAClient.isFiniteCoord(args.x) ||
+          !GoogleCUAClient.isFiniteCoord(args.y)
+        ) {
           return null;
         }
         const { x, y } = this.normalizeCoordinates(args.x, args.y);
@@ -924,7 +928,10 @@ export class GoogleCUAClient extends AgentClient {
       case "right_click":
       case "middle_click":
       case "move": {
-        if (typeof args.x !== "number" || typeof args.y !== "number") {
+        if (
+          !GoogleCUAClient.isFiniteCoord(args.x) ||
+          !GoogleCUAClient.isFiniteCoord(args.y)
+        ) {
           return null;
         }
         const { x, y } = this.normalizeCoordinates(args.x, args.y);
@@ -999,26 +1006,26 @@ export class GoogleCUAClient extends AgentClient {
       }
 
       case "scroll_at": {
-        // A coordinate-less `scroll` alias (gemini-3.x) scrolls the document.
-        if (typeof args.x !== "number" || typeof args.y !== "number") {
+        // A coordinate-less (or malformed) `scroll` alias (gemini-3.x) scrolls
+        // the document via PageUp/PageDown.
+        if (
+          !GoogleCUAClient.isFiniteCoord(args.x) ||
+          !GoogleCUAClient.isFiniteCoord(args.y)
+        ) {
           const dir = ((args.direction as string) || "down").toLowerCase();
           return {
             type: "keypress",
             keys: [dir === "up" ? "PageUp" : "PageDown"],
           };
         }
-        const { x, y } = this.normalizeCoordinates(
-          args.x as number,
-          args.y as number,
-        );
+        const { x, y } = this.normalizeCoordinates(args.x, args.y);
         const direction = ((args.direction as string) || "down").toLowerCase();
         // 2.5 uses `magnitude`; gemini-3.x `scroll` uses `magnitude_in_pixels`.
-        const magnitude =
-          typeof args.magnitude === "number"
-            ? (args.magnitude as number)
-            : typeof args.magnitude_in_pixels === "number"
-              ? (args.magnitude_in_pixels as number)
-              : 800;
+        const magnitude = GoogleCUAClient.isFiniteCoord(args.magnitude)
+          ? args.magnitude
+          : GoogleCUAClient.isFiniteCoord(args.magnitude_in_pixels)
+            ? args.magnitude_in_pixels
+            : 800;
 
         let scroll_x = 0;
         let scroll_y = 0;
@@ -1092,15 +1099,15 @@ export class GoogleCUAClient extends AgentClient {
       case "drag_and_drop": {
         // 2.5 uses x/y + destination_x/destination_y; gemini-3.x `drag_and_drop`
         // uses start_x/start_y + end_x/end_y. Accept either.
-        const sx = (args.x ?? args.start_x) as number;
-        const sy = (args.y ?? args.start_y) as number;
-        const ex = (args.destination_x ?? args.end_x) as number;
-        const ey = (args.destination_y ?? args.end_y) as number;
+        const sx = args.x ?? args.start_x;
+        const sy = args.y ?? args.start_y;
+        const ex = args.destination_x ?? args.end_x;
+        const ey = args.destination_y ?? args.end_y;
         if (
-          typeof sx !== "number" ||
-          typeof sy !== "number" ||
-          typeof ex !== "number" ||
-          typeof ey !== "number"
+          !GoogleCUAClient.isFiniteCoord(sx) ||
+          !GoogleCUAClient.isFiniteCoord(sy) ||
+          !GoogleCUAClient.isFiniteCoord(ex) ||
+          !GoogleCUAClient.isFiniteCoord(ey)
         ) {
           return null;
         }
@@ -1128,6 +1135,15 @@ export class GoogleCUAClient extends AgentClient {
         console.warn(`Unsupported Google CUA function: ${name}`);
         return null;
     }
+  }
+
+  /**
+   * True only for a usable coordinate/number: rejects undefined, non-numbers,
+   * and the numeric edge cases NaN and Infinity (both `typeof "number"`), so
+   * malformed function calls are dropped instead of normalizing into NaN.
+   */
+  private static isFiniteCoord(value: unknown): value is number {
+    return typeof value === "number" && Number.isFinite(value);
   }
 
   /**

--- a/packages/core/lib/v3/llm/LLMProvider.ts
+++ b/packages/core/lib/v3/llm/LLMProvider.ts
@@ -148,6 +148,7 @@ const modelToProviderMap: { [key in AvailableModel]: ModelProvider } = {
   "gemini-2.0-flash": "google",
   "gemini-2.5-flash-preview-04-17": "google",
   "gemini-2.5-pro-preview-03-25": "google",
+  "gemini-3.5-flash": "google",
 };
 
 export function getAISDKLanguageModel(

--- a/packages/core/lib/v3/types/public/agent.ts
+++ b/packages/core/lib/v3/types/public/agent.ts
@@ -472,6 +472,7 @@ export const AVAILABLE_CUA_MODELS = [
   "anthropic/claude-fable-5",
   "google/gemini-2.5-computer-use-preview-10-2025",
   "google/gemini-3-flash-preview",
+  "google/gemini-3.5-flash",
   "google/gemini-3-pro-preview",
   "microsoft/fara-7b",
 ] as const;

--- a/packages/core/tests/unit/google-cua-click-conversion.test.ts
+++ b/packages/core/tests/unit/google-cua-click-conversion.test.ts
@@ -70,6 +70,8 @@ describe("GoogleCUAClient gemini-3.x click-family conversion", () => {
 
   it("returns null (no NaN) when click-family coordinates are missing", () => {
     for (const name of [
+      "click", // aliases to click_at — the most common path
+      "click_at",
       "double_click",
       "triple_click",
       "right_click",

--- a/packages/core/tests/unit/google-cua-click-conversion.test.ts
+++ b/packages/core/tests/unit/google-cua-click-conversion.test.ts
@@ -86,3 +86,21 @@ describe("GoogleCUAClient gemini-3.x click-family conversion", () => {
     expect(action?.button).toBe("left");
   });
 });
+
+describe("GoogleCUAClient arg-required handler guards", () => {
+  it("rejects navigate without a url, maps it when present", () => {
+    expect(run("navigate", { intent: "go" })).toBeNull();
+    expect(run("navigate", { url: "" })).toBeNull();
+    expect(run("navigate", { url: "https://example.com" })).toEqual({
+      type: "goto",
+      url: "https://example.com",
+    });
+  });
+
+  it("rejects type without text, allows an empty string (clear field)", () => {
+    expect(run("type", { intent: "type" })).toBeNull();
+    expect(run("type_text_at", { intent: "type" })).toBeNull();
+    expect(run("type", { text: "hello" })?.type).toBe("type");
+    expect(run("type", { text: "" })?.type).toBe("type");
+  });
+});

--- a/packages/core/tests/unit/google-cua-click-conversion.test.ts
+++ b/packages/core/tests/unit/google-cua-click-conversion.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import type { FunctionCall } from "@google/genai";
+
+import { GoogleCUAClient } from "../../lib/v3/agent/GoogleCUAClient.js";
+import type { AgentAction } from "../../lib/v3/types/public/agent.js";
+
+// Reach the private converter the same way safety-confirmation.test.ts reaches
+// handleSafetyConfirmation — via the prototype, typed through `unknown`.
+const convert = (
+  GoogleCUAClient.prototype as unknown as {
+    convertFunctionCallToAction: (
+      this: GoogleCUAClient,
+      functionCall: FunctionCall,
+    ) => AgentAction | null;
+  }
+).convertFunctionCallToAction;
+
+function createGoogleClient(): GoogleCUAClient {
+  return new GoogleCUAClient(
+    "google",
+    "google/gemini-3.5-flash",
+    "test instructions",
+    { apiKey: "test" },
+  );
+}
+
+function run(name: string, args: Record<string, unknown>): AgentAction | null {
+  return convert.call(createGoogleClient(), { name, args } as FunctionCall);
+}
+
+// gemini-3.x sends coordinates on a 0-999 grid; the 1288x711 default viewport
+// maps (500,500) -> (644, 355). We assert finite numbers rather than the exact
+// mapping so the tests don't couple to normalizeCoordinates internals.
+const COORDS = { x: 500, y: 500, intent: "interact with the element" };
+
+describe("GoogleCUAClient gemini-3.x click-family conversion", () => {
+  it("maps click to a left click (backcompat with 2.5 click_at)", () => {
+    const action = run("click", COORDS);
+    expect(action?.type).toBe("click");
+    expect(action?.button).toBe("left");
+    expect(Number.isFinite(action?.x as number)).toBe(true);
+    expect(Number.isFinite(action?.y as number)).toBe(true);
+  });
+
+  it("preserves double_click as a double click", () => {
+    expect(run("double_click", COORDS)?.type).toBe("double_click");
+  });
+
+  it("preserves triple_click as a triple click", () => {
+    expect(run("triple_click", COORDS)?.type).toBe("triple_click");
+  });
+
+  it("maps right_click to a click with the right button", () => {
+    const action = run("right_click", COORDS);
+    expect(action?.type).toBe("click");
+    expect(action?.button).toBe("right");
+  });
+
+  it("maps middle_click to a click with the middle button", () => {
+    const action = run("middle_click", COORDS);
+    expect(action?.type).toBe("click");
+    expect(action?.button).toBe("middle");
+  });
+
+  it("maps move to a cursor move", () => {
+    const action = run("move", COORDS);
+    expect(action?.type).toBe("move");
+    expect(Number.isFinite(action?.x as number)).toBe(true);
+  });
+
+  it("returns null (no NaN) when click-family coordinates are missing", () => {
+    for (const name of [
+      "double_click",
+      "triple_click",
+      "right_click",
+      "middle_click",
+      "move",
+    ]) {
+      expect(run(name, { intent: "no coords" })).toBeNull();
+    }
+  });
+
+  it("still maps the gemini-2.5 click_at handler unchanged", () => {
+    const action = run("click_at", { x: 100, y: 200 });
+    expect(action?.type).toBe("click");
+    expect(action?.button).toBe("left");
+  });
+});

--- a/packages/core/tests/unit/google-cua-click-conversion.test.ts
+++ b/packages/core/tests/unit/google-cua-click-conversion.test.ts
@@ -82,6 +82,17 @@ describe("GoogleCUAClient gemini-3.x click-family conversion", () => {
     }
   });
 
+  it("returns null when click-family coordinates are NaN or Infinity", () => {
+    for (const name of ["click", "double_click", "right_click", "move"]) {
+      expect(run(name, { x: NaN, y: 10 })).toBeNull();
+      expect(run(name, { x: 10, y: Infinity })).toBeNull();
+    }
+    // drag_and_drop validates all four points
+    expect(
+      run("drag_and_drop", { start_x: NaN, start_y: 1, end_x: 2, end_y: 3 }),
+    ).toBeNull();
+  });
+
   it("still maps the gemini-2.5 click_at handler unchanged", () => {
     const action = run("click_at", { x: 100, y: 200 });
     expect(action?.type).toBe("click");

--- a/packages/core/tests/unit/public-api/llm-and-agents.test.ts
+++ b/packages/core/tests/unit/public-api/llm-and-agents.test.ts
@@ -85,6 +85,7 @@ describe("LLM and Agents public API types", () => {
       "anthropic/claude-fable-5",
       "google/gemini-2.5-computer-use-preview-10-2025",
       "google/gemini-3-flash-preview",
+      "google/gemini-3.5-flash",
       "google/gemini-3-pro-preview",
       "microsoft/fara-7b",
     ] as const;


### PR DESCRIPTION
# why
New model dropped

# what changed
Added support for the Gemini 3.5 Flash Computer Use updated toolset in `GoogleCUAClient.ts`, with all new tool formats correctly mapped. 

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for the `google/gemini-3.5-flash` computer-use agent. Normalizes Gemini 3.x tool names/args to 2.5 handlers, preserves click semantics, validates coordinates (rejects missing/NaN/Infinity), always returns a fresh screenshot, and surfaces reasoning/cached tokens.

- **New Features**
  - Enable `google/gemini-3.5-flash` in agent/LLM provider maps and public types; update tests.
  - Map 3.x functions to 2.5 handlers and accept new arg shapes: coordinate-less `type`, `keys` array or single `key`, `magnitude_in_pixels` for `scroll`, drag start/end pairs; recognize `screenshot`/`take_screenshot`; coordinate-less `scroll` falls back to PageUp/PageDown; alias `wait` to `wait_5_seconds`.
  - Always return a screenshot function response even when no executable actions are produced.

- **Bug Fixes**
  - Track `reasoning_tokens` and `cached_input_tokens` in Google CUA usage (per step and aggregated).
  - Preserve 3.x click-family semantics (`double_click`, `triple_click`, `right_click`, `middle_click`, `move`) and drop calls with missing or non‑finite coordinates; add explicit `click_at` guard and a shared finite-number check; add unit tests for conversion/guards.
  - Guard required args and log custom‑tool collisions: reject `navigate` without `url` and `type`/`type_text_at` without `text` (empty allowed); log when a custom tool name conflicts with a predefined function (predefined wins).

<sup>Written for commit eb1e3a789fd02b92fb4613f14fff2b53c2164db5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



