### PR TITLE
[STG-2404] feat(cli): attribute usage via install_id + cli_version on sessions and cloud API headers

### DIFF
--- a/.changeset/cli-install-id-attribution.md
+++ b/.changeset/cli-install-id-attribution.md
@@ -1,0 +1,5 @@
+---
+"browse": patch
+---
+
+Attribute CLI-driven Browserbase usage to an anonymous install. Remote browser sessions now stamp `install_id` and `cli_version` (alongside `browse_cli`) onto `userMetadata`, and cloud Search/Fetch requests send `x-bb-client` and `x-bb-install-id` headers. The install id reuses the existing anonymous telemetry marker; resolution is best-effort and never blocks or fails a command.

--- a/packages/cli/src/base.ts
+++ b/packages/cli/src/base.ts
@@ -1,9 +1,20 @@
 import { Command } from "@oclif/core";
 
 import { CommandFailure } from "./lib/errors.js";
+import { setCliVersion } from "./lib/identity.js";
 import { recordCommandError } from "./lib/telemetry.js";
 
 export abstract class BrowseCommand extends Command {
+  public override async init(): Promise<void> {
+    await super.init();
+    // Seed the CLI version from oclif's Config (the single source of truth) so
+    // non-command contexts — remote session userMetadata and cloud API headers
+    // — can stamp the real version without any filesystem read. This runs in
+    // every process before run(), including the background `browse daemon` that
+    // creates Browserbase sessions, so cli_version never regresses to "unknown".
+    setCliVersion(this.config.version);
+  }
+
   protected override async catch(
     err: Error & { exitCode?: number },
   ): Promise<unknown> {

--- a/packages/cli/src/commands/cloud/sessions/create.ts
+++ b/packages/cli/src/commands/cloud/sessions/create.ts
@@ -106,10 +106,16 @@ function buildSessionCreateBody(
 async function applyCliAttribution(
   body: Record<string, unknown>,
 ): Promise<void> {
-  const existing =
+  const rawExisting =
     body.userMetadata && typeof body.userMetadata === "object"
       ? (body.userMetadata as Record<string, unknown>)
       : {};
+
+  // Strip any caller-supplied install_id before merging so it cannot be
+  // spoofed when resolution fails (our authoritative value is set below).
+  const existing = Object.fromEntries(
+    Object.entries(rawExisting).filter(([k]) => k !== "install_id"),
+  );
 
   const userMetadata: Record<string, unknown> = {
     ...existing,

--- a/packages/cli/src/commands/cloud/sessions/create.ts
+++ b/packages/cli/src/commands/cloud/sessions/create.ts
@@ -9,6 +9,11 @@ import {
 } from "../../../lib/cloud/api.js";
 import { apiCommonFlags, toApiOptions } from "../../../lib/cloud/flags.js";
 import { fail } from "../../../lib/errors.js";
+import {
+  getCliVersion,
+  resolveInstallId,
+  toMetadataValue,
+} from "../../../lib/identity.js";
 import { BrowseCommand } from "../../../base.js";
 
 const REGIONS = [
@@ -84,6 +89,43 @@ function buildSessionCreateBody(
   }
 
   return body;
+}
+
+/**
+ * Stamp anonymous CLI attribution onto the session-create `userMetadata` so
+ * every CLI-created cloud session is attributable to the CLI (matching the
+ * driver `open --remote` path). Any user-supplied `userMetadata` (via --body or
+ * --stdin) is preserved; our attribution keys (browse_cli/install_id/
+ * cli_version) are authoritative and override caller values for those keys.
+ *
+ * Resolving the install id is best-effort and never throws; if it can't be
+ * resolved we still send browse_cli + cli_version. Values are run through
+ * toMetadataValue() so the session-create validator never 400s on a stray
+ * character or an over-length value.
+ */
+async function applyCliAttribution(
+  body: Record<string, unknown>,
+): Promise<void> {
+  const existing =
+    body.userMetadata && typeof body.userMetadata === "object"
+      ? (body.userMetadata as Record<string, unknown>)
+      : {};
+
+  const userMetadata: Record<string, unknown> = {
+    ...existing,
+    browse_cli: "true",
+    cli_version: toMetadataValue(getCliVersion()),
+  };
+
+  const installId = await resolveInstallId(process.env).catch(() => undefined);
+  if (installId) {
+    const sanitized = toMetadataValue(installId);
+    if (sanitized) {
+      userMetadata.install_id = sanitized;
+    }
+  }
+
+  body.userMetadata = userMetadata;
 }
 
 export default class SessionsCreate extends BrowseCommand {
@@ -172,6 +214,7 @@ export default class SessionsCreate extends BrowseCommand {
       });
       const flagBody = buildSessionCreateBody(flags);
       const body = deepMerge(jsonBody, flagBody);
+      await applyCliAttribution(body);
       outputJson(await client.sessions.create(body));
     });
   }

--- a/packages/cli/src/lib/cloud/api.ts
+++ b/packages/cli/src/lib/cloud/api.ts
@@ -9,12 +9,34 @@ import { dirname, resolve } from "node:path";
 import { Readable } from "node:stream";
 
 import { CommandFailure, fail } from "../errors.js";
+import { getCliVersion, peekInstallId, resolveInstallId } from "../identity.js";
 import { setRunTelemetryCompletion } from "../run-telemetry.js";
 
 export { outputJson } from "../output.js";
 
 const defaultBrowserbaseApiUrl = "https://api.browserbase.com";
 const browserbaseSettingsUrl = "https://browserbase.com/settings";
+
+// Kick off install-id resolution at module load so the value is usually cached
+// by the time a cloud request runs. Resolution is best-effort and never throws.
+void resolveInstallId(process.env).catch(() => undefined);
+
+/**
+ * Attribution headers stamped onto cloud (Search/Fetch) requests so CLI usage
+ * is attributable to an install. `x-bb-client` is always sent;
+ * `x-bb-install-id` is included only when already resolved (we never block a
+ * request on disk I/O) and never sent as an empty string.
+ */
+function attributionHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    "x-bb-client": `browse-cli/${getCliVersion()}`,
+  };
+  const installId = peekInstallId();
+  if (installId) {
+    headers["x-bb-install-id"] = installId;
+  }
+  return headers;
+}
 
 export type BrowserbaseApiCommand =
   | "fetch"
@@ -61,6 +83,7 @@ export function createBrowserbaseClient(args: {
   return new Browserbase({
     apiKey: resolveApiKey(args),
     baseURL: resolveBaseUrl(args),
+    defaultHeaders: attributionHeaders(),
   });
 }
 
@@ -154,6 +177,7 @@ export async function requestBrowserbase(
       ...init,
       headers: {
         "x-bb-api-key": resolveApiKey(args),
+        ...attributionHeaders(),
         ...(init.headers ?? {}),
       },
     });

--- a/packages/cli/src/lib/driver/remote-types.ts
+++ b/packages/cli/src/lib/driver/remote-types.ts
@@ -43,7 +43,7 @@ export interface RemoteCapability {
   /** Auto-select remote when an API key is present; null otherwise. */
   autoSelectRemoteTarget(): ConnectionTarget | null;
   /** Stagehand options for a remote (BROWSERBASE) session. */
-  remoteStagehandOptions(): StagehandConstructorOptions;
+  remoteStagehandOptions(): Promise<StagehandConstructorOptions>;
   /** Map a failed remote `stagehand.init()` to an actionable message + code. */
   classifyRemoteInitError(error: unknown): RemoteInitErrorClassification;
   /** Remediation strings for driver init failures. */

--- a/packages/cli/src/lib/driver/remote.disabled.ts
+++ b/packages/cli/src/lib/driver/remote.disabled.ts
@@ -23,7 +23,7 @@ export function autoSelectRemoteTarget(): ConnectionTarget | null {
   return null;
 }
 
-export function remoteStagehandOptions(): Promise<StagehandConstructorOptions> {
+export async function remoteStagehandOptions(): Promise<StagehandConstructorOptions> {
   throw new Error(DISABLED_MESSAGE);
 }
 

--- a/packages/cli/src/lib/driver/remote.disabled.ts
+++ b/packages/cli/src/lib/driver/remote.disabled.ts
@@ -23,7 +23,7 @@ export function autoSelectRemoteTarget(): ConnectionTarget | null {
   return null;
 }
 
-export function remoteStagehandOptions(): StagehandConstructorOptions {
+export function remoteStagehandOptions(): Promise<StagehandConstructorOptions> {
   throw new Error(DISABLED_MESSAGE);
 }
 

--- a/packages/cli/src/lib/driver/remote.ts
+++ b/packages/cli/src/lib/driver/remote.ts
@@ -1,6 +1,10 @@
 import { StatusCodes } from "http-status-codes";
 
-import { getCliVersion, resolveInstallId } from "../identity.js";
+import {
+  getCliVersion,
+  resolveInstallId,
+  toMetadataValue,
+} from "../identity.js";
 import type {
   DriverInitHints,
   RemoteDoctorResult,
@@ -36,11 +40,11 @@ export async function remoteStagehandOptions(): Promise<StagehandConstructorOpti
   // browse_cli + cli_version so the session stays attributable to the CLI.
   const userMetadata: Record<string, string> = {
     browse_cli: "true",
-    cli_version: getCliVersion(),
+    cli_version: toMetadataValue(getCliVersion()),
   };
   const installId = await resolveInstallId(process.env).catch(() => undefined);
   if (installId) {
-    userMetadata.install_id = installId;
+    userMetadata.install_id = toMetadataValue(installId);
   }
 
   return {

--- a/packages/cli/src/lib/driver/remote.ts
+++ b/packages/cli/src/lib/driver/remote.ts
@@ -1,5 +1,6 @@
 import { StatusCodes } from "http-status-codes";
 
+import { getCliVersion, resolveInstallId } from "../identity.js";
 import type {
   DriverInitHints,
   RemoteDoctorResult,
@@ -22,7 +23,7 @@ export function autoSelectRemoteTarget(): ConnectionTarget | null {
   return process.env.BROWSERBASE_API_KEY ? { kind: "remote" } : null;
 }
 
-export function remoteStagehandOptions(): StagehandConstructorOptions {
+export async function remoteStagehandOptions(): Promise<StagehandConstructorOptions> {
   const apiKey = process.env.BROWSERBASE_API_KEY;
   if (!apiKey) {
     throw new Error(
@@ -30,10 +31,22 @@ export function remoteStagehandOptions(): StagehandConstructorOptions {
     );
   }
 
+  // Stamp anonymous attribution onto the session. Resolving the install id is
+  // best-effort and never throws; if it can't be resolved we still send
+  // browse_cli + cli_version so the session stays attributable to the CLI.
+  const userMetadata: Record<string, string> = {
+    browse_cli: "true",
+    cli_version: getCliVersion(),
+  };
+  const installId = await resolveInstallId(process.env).catch(() => undefined);
+  if (installId) {
+    userMetadata.install_id = installId;
+  }
+
   return {
     apiKey,
     browserbaseSessionCreateParams: {
-      userMetadata: { browse_cli: "true" },
+      userMetadata,
     },
     disableAPI: true,
     disablePino: true,

--- a/packages/cli/src/lib/driver/session-manager.ts
+++ b/packages/cli/src/lib/driver/session-manager.ts
@@ -339,7 +339,7 @@ export class DriverSessionManager {
     target: ConnectionTarget,
   ): Promise<ConstructorParameters<typeof Stagehand>[0]> {
     if (target.kind === "remote") {
-      return (await getRemote()).remoteStagehandOptions();
+      return await (await getRemote()).remoteStagehandOptions();
     }
 
     if (target.kind === "managed-local") {

--- a/packages/cli/src/lib/identity.ts
+++ b/packages/cli/src/lib/identity.ts
@@ -11,6 +11,13 @@ import { dirname, join } from "node:path";
  * `userMetadata`, and (c) cloud API request headers so that CLI-driven usage is
  * attributable to a single install without identifying the user.
  *
+ * The marker lives in the standardized Browserbase config dir on every platform
+ * (`(XDG_CONFIG_HOME||~/.config)/browserbase/install-id`, honoring
+ * `BROWSERBASE_CONFIG_DIR`), matching where core and the CLI's own
+ * skills/sessions already live. An earlier build wrote per-OS marker paths; the
+ * id is forward-migrated from those legacy locations on first resolution so an
+ * install keeps its stable id across the path change.
+ *
  * Resolution is best-effort and must never throw: a read/write failure falls
  * back to an in-memory UUID. After the first async resolution, the value is
  * cached so it can be read synchronously via {@link peekInstallId}.
@@ -21,9 +28,9 @@ let inFlightResolution: Promise<string> | undefined;
 
 /**
  * Resolve the anonymous install id, reading (or creating) the marker file.
- * Memoizes the result so repeated calls share one resolution. Behavior matches
- * the original telemetry implementation byte-for-byte: same marker path, a
- * UUID on miss, and swallowed write failures.
+ * Memoizes the result so repeated calls share one resolution. Reads the
+ * canonical marker, forward-migrates an id from a legacy per-OS marker if one
+ * exists, mints a UUID on a true miss, and swallows write failures.
  */
 export async function resolveInstallId(
   env: NodeJS.ProcessEnv,
@@ -81,6 +88,17 @@ async function resolveAnonymousInstallId(
   const installIdPath = resolveInstallIdPath(env);
   const installId = fallbackId ?? randomUUID();
 
+  // Carry an existing id forward from a legacy per-OS marker before minting a
+  // new one, so the path change never resets a stable install id. An explicit
+  // path override short-circuits migration entirely (tests / callers pinning a
+  // specific marker should not silently inherit a legacy id).
+  if (!env.BROWSERBASE_TELEMETRY_INSTALL_ID_FILE) {
+    const migrated = await migrateLegacyInstallId(env, installIdPath);
+    if (migrated) {
+      return migrated;
+    }
+  }
+
   for (let attempt = 0; attempt < INSTALL_ID_MAX_ATTEMPTS; attempt++) {
     // 1. Prefer an already-persisted, non-empty id.
     try {
@@ -131,28 +149,106 @@ function delay(ms: number): Promise<void> {
 export function resolveInstallIdPath(env: NodeJS.ProcessEnv): string {
   const overriddenPath = env.BROWSERBASE_TELEMETRY_INSTALL_ID_FILE;
   if (overriddenPath) {
+    // An explicit override short-circuits everything, including migration.
     return overriddenPath;
   }
+  return join(resolveConfigDir(env), "install-id");
+}
 
+/**
+ * The shared Browserbase config dir, matching core (`BROWSERBASE_CONFIG_DIR`)
+ * and the CLI's own skills/sessions locations. Honors BROWSERBASE_CONFIG_DIR
+ * when set (already includes the `browserbase` segment, e.g. `~/.config/browserbase`);
+ * otherwise `(XDG_CONFIG_HOME||~/.config)/browserbase` on every platform.
+ */
+function resolveConfigDir(env: NodeJS.ProcessEnv): string {
+  if (env.BROWSERBASE_CONFIG_DIR) {
+    return env.BROWSERBASE_CONFIG_DIR;
+  }
+  const xdg = env.XDG_CONFIG_HOME ?? join(homedir(), ".config");
+  return join(xdg, "browserbase");
+}
+
+/**
+ * The OLD per-platform marker locations the install id used to live in, in
+ * priority order. We always include the XDG-style legacy path on every platform
+ * (it makes the migration unit-testable via XDG_CONFIG_HOME), plus the
+ * platform-specific one. Deduped so linux (platform path == xdg path) yields one
+ * entry.
+ */
+function legacyInstallIdPaths(env: NodeJS.ProcessEnv): string[] {
+  const paths: string[] = [];
   if (process.platform === "win32") {
     const baseDir =
       env.APPDATA ?? env.LOCALAPPDATA ?? join(homedir(), "AppData", "Roaming");
-    return join(baseDir, "Browserbase", "cli", "telemetry-id");
-  }
-
-  if (process.platform === "darwin") {
-    return join(
-      homedir(),
-      "Library",
-      "Application Support",
-      "Browserbase",
-      "cli",
-      "telemetry-id",
+    paths.push(join(baseDir, "Browserbase", "cli", "telemetry-id"));
+  } else if (process.platform === "darwin") {
+    paths.push(
+      join(
+        homedir(),
+        "Library",
+        "Application Support",
+        "Browserbase",
+        "cli",
+        "telemetry-id",
+      ),
     );
   }
+  const xdg = env.XDG_CONFIG_HOME ?? join(homedir(), ".config");
+  paths.push(join(xdg, "browserbase", "cli", "telemetry-id"));
+  return [...new Set(paths)];
+}
 
-  const baseDir = env.XDG_CONFIG_HOME ?? join(homedir(), ".config");
-  return join(baseDir, "browserbase", "cli", "telemetry-id");
+/**
+ * One-time path migration. If the canonical marker already exists, return its
+ * id. Otherwise, if a legacy per-platform marker holds an id, copy that id
+ * forward to the canonical path (best-effort, atomic exclusive-create) and
+ * return it, so the install keeps its stable id across the path change. Returns
+ * `undefined` when no id exists anywhere (truly first run) — the caller's create
+ * loop then mints a fresh id. Never throws. The legacy file is left in place
+ * (harmless, avoids a destructive op).
+ */
+async function migrateLegacyInstallId(
+  env: NodeJS.ProcessEnv,
+  canonicalPath: string,
+): Promise<string | undefined> {
+  try {
+    const existing = (await readFile(canonicalPath, "utf8")).trim();
+    if (existing) {
+      return existing;
+    }
+  } catch {
+    // Canonical marker missing — fall through to the legacy lookup.
+  }
+
+  for (const legacyPath of legacyInstallIdPaths(env)) {
+    if (legacyPath === canonicalPath) {
+      continue;
+    }
+    let legacyId: string;
+    try {
+      legacyId = (await readFile(legacyPath, "utf8")).trim();
+    } catch {
+      continue;
+    }
+    if (!legacyId) {
+      continue;
+    }
+    try {
+      await mkdir(dirname(canonicalPath), { recursive: true });
+      const fh = await open(canonicalPath, "wx");
+      try {
+        await fh.writeFile(`${legacyId}\n`, "utf8");
+      } finally {
+        await fh.close();
+      }
+    } catch {
+      // Race lost or FS unwritable — returning the legacy id still keeps it
+      // stable for this run.
+    }
+    return legacyId;
+  }
+  return undefined;
 }
 
 /**

--- a/packages/cli/src/lib/identity.ts
+++ b/packages/cli/src/lib/identity.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import { readFileSync } from "node:fs";
 import { mkdir, open, readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
@@ -170,23 +169,25 @@ export function toMetadataValue(v: string, max = 64): string {
 let cachedCliVersion: string | undefined;
 
 /**
- * The CLI version, read once from the package's own `package.json`. This is the
- * same source oclif uses for `config.version`; it is read here so non-command
- * contexts (remote session options, cloud API headers) can stamp the version
- * without an oclif `Config` in hand.
+ * Seed the CLI version from oclif's `Config.version` (the single source of
+ * truth). This is called once at startup from `BrowseCommand.init()` in base.ts
+ * — and because every command (including the background `browse daemon` that
+ * creates Browserbase sessions) extends `BrowseCommand`, the cache is populated
+ * in whichever process builds a session/header. Only truthy values are stored
+ * so a missing version leaves the `"unknown"` fallback intact.
+ */
+export function setCliVersion(version: string): void {
+  if (version) {
+    cachedCliVersion = version;
+  }
+}
+
+/**
+ * The CLI version for non-command contexts (remote session `userMetadata`,
+ * cloud API headers). It is seeded once from `Config.version` in base.ts at
+ * startup via {@link setCliVersion}; this reads back the cached value with no
+ * filesystem access. Falls back to `"unknown"` if it was never seeded.
  */
 export function getCliVersion(): string {
-  if (cachedCliVersion !== undefined) {
-    return cachedCliVersion;
-  }
-  try {
-    const pkg = JSON.parse(
-      readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
-    ) as { version?: unknown };
-    cachedCliVersion =
-      typeof pkg.version === "string" ? pkg.version : "unknown";
-  } catch {
-    cachedCliVersion = "unknown";
-  }
-  return cachedCliVersion;
+  return cachedCliVersion ?? "unknown";
 }

--- a/packages/cli/src/lib/identity.ts
+++ b/packages/cli/src/lib/identity.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, open, readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -70,9 +70,28 @@ async function resolveAnonymousInstallId(
 
   try {
     await mkdir(dirname(installIdPath), { recursive: true });
-    await writeFile(installIdPath, `${installId}\n`, "utf8");
-  } catch {
-    // If persistence fails, continue with an in-memory anonymous ID.
+    // Use exclusive-create ('wx') so that only one concurrent first-run process
+    // wins the write. If another process already created the file (EEXIST), read
+    // back whatever it wrote so both processes converge on the same stable id.
+    const fh = await open(installIdPath, "wx");
+    try {
+      await fh.writeFile(`${installId}\n`, "utf8");
+    } finally {
+      await fh.close();
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "EEXIST") {
+      // Another concurrent first-run wrote the file first — use its id.
+      try {
+        const raced = (await readFile(installIdPath, "utf8")).trim();
+        if (raced) {
+          return raced;
+        }
+      } catch {
+        // If the re-read also fails, fall through and return the in-memory id.
+      }
+    }
+    // Any other error (e.g. permissions): continue with an in-memory id.
   }
 
   return installId;

--- a/packages/cli/src/lib/identity.ts
+++ b/packages/cli/src/lib/identity.ts
@@ -1,0 +1,130 @@
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+/**
+ * Shared anonymous-install identity for the CLI.
+ *
+ * The install id is a stable, per-machine anonymous UUID persisted to a marker
+ * file. It is reused for (a) telemetry, (b) remote browser session
+ * `userMetadata`, and (c) cloud API request headers so that CLI-driven usage is
+ * attributable to a single install without identifying the user.
+ *
+ * Resolution is best-effort and must never throw: a read/write failure falls
+ * back to an in-memory UUID. After the first async resolution, the value is
+ * cached so it can be read synchronously via {@link peekInstallId}.
+ */
+
+let cachedInstallId: string | undefined;
+let inFlightResolution: Promise<string> | undefined;
+
+/**
+ * Resolve the anonymous install id, reading (or creating) the marker file.
+ * Memoizes the result so repeated calls share one resolution. Behavior matches
+ * the original telemetry implementation byte-for-byte: same marker path, a
+ * UUID on miss, and swallowed write failures.
+ */
+export async function resolveInstallId(
+  env: NodeJS.ProcessEnv,
+  fallbackId?: string,
+): Promise<string> {
+  if (cachedInstallId !== undefined) {
+    return cachedInstallId;
+  }
+  inFlightResolution ??= resolveAnonymousInstallId(env, fallbackId).then(
+    (id) => {
+      cachedInstallId = id;
+      return id;
+    },
+  );
+  return inFlightResolution;
+}
+
+/**
+ * Read the install id synchronously if it has already been resolved. Returns
+ * `undefined` when resolution has not completed yet — callers must not block on
+ * it (e.g. cloud API headers omit the id rather than wait for disk I/O).
+ */
+export function peekInstallId(): string | undefined {
+  return cachedInstallId;
+}
+
+async function resolveAnonymousInstallId(
+  env: NodeJS.ProcessEnv,
+  fallbackId?: string,
+): Promise<string> {
+  const installIdPath = resolveInstallIdPath(env);
+
+  try {
+    const existing = (await readFile(installIdPath, "utf8")).trim();
+    if (existing) {
+      return existing;
+    }
+  } catch {
+    // Fall through and create a new anonymous install ID.
+  }
+
+  const installId = fallbackId ?? randomUUID();
+
+  try {
+    await mkdir(dirname(installIdPath), { recursive: true });
+    await writeFile(installIdPath, `${installId}\n`, "utf8");
+  } catch {
+    // If persistence fails, continue with an in-memory anonymous ID.
+  }
+
+  return installId;
+}
+
+export function resolveInstallIdPath(env: NodeJS.ProcessEnv): string {
+  const overriddenPath = env.BROWSERBASE_TELEMETRY_INSTALL_ID_FILE;
+  if (overriddenPath) {
+    return overriddenPath;
+  }
+
+  if (process.platform === "win32") {
+    const baseDir =
+      env.APPDATA ?? env.LOCALAPPDATA ?? join(homedir(), "AppData", "Roaming");
+    return join(baseDir, "Browserbase", "cli", "telemetry-id");
+  }
+
+  if (process.platform === "darwin") {
+    return join(
+      homedir(),
+      "Library",
+      "Application Support",
+      "Browserbase",
+      "cli",
+      "telemetry-id",
+    );
+  }
+
+  const baseDir = env.XDG_CONFIG_HOME ?? join(homedir(), ".config");
+  return join(baseDir, "browserbase", "cli", "telemetry-id");
+}
+
+let cachedCliVersion: string | undefined;
+
+/**
+ * The CLI version, read once from the package's own `package.json`. This is the
+ * same source oclif uses for `config.version`; it is read here so non-command
+ * contexts (remote session options, cloud API headers) can stamp the version
+ * without an oclif `Config` in hand.
+ */
+export function getCliVersion(): string {
+  if (cachedCliVersion !== undefined) {
+    return cachedCliVersion;
+  }
+  try {
+    const pkg = JSON.parse(
+      readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
+    ) as { version?: unknown };
+    cachedCliVersion =
+      typeof pkg.version === "string" ? pkg.version : "unknown";
+  } catch {
+    cachedCliVersion = "unknown";
+  }
+  return cachedCliVersion;
+}

--- a/packages/cli/src/lib/identity.ts
+++ b/packages/cli/src/lib/identity.ts
@@ -105,6 +105,17 @@ export function resolveInstallIdPath(env: NodeJS.ProcessEnv): string {
   return join(baseDir, "browserbase", "cli", "telemetry-id");
 }
 
+/**
+ * Sanitize a value for use in Browserbase `userMetadata`. The session-create
+ * validator only accepts characters matching `[\w\-_,;:.()&$%#@!?~]` and
+ * enforces a total length limit; this function strips everything else and
+ * truncates to `max` characters (default 64) so a semver `+build` suffix or
+ * any other unexpected character cannot cause a 400 on every remote session.
+ */
+export function toMetadataValue(v: string, max = 64): string {
+  return v.replace(/[^\w\-_,;:.()&$%#@!?~]/g, "").slice(0, max);
+}
+
 let cachedCliVersion: string | undefined;
 
 /**

--- a/packages/cli/src/lib/identity.ts
+++ b/packages/cli/src/lib/identity.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
-import { mkdir, open, readFile } from "node:fs/promises";
+import { mkdir, open, readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -51,50 +51,82 @@ export function peekInstallId(): string | undefined {
   return cachedInstallId;
 }
 
+const INSTALL_ID_MAX_ATTEMPTS = 5;
+
+/**
+ * Resolve (or create) the anonymous install id with a bounded, race-safe loop.
+ *
+ * The contract is: never return an id that wasn't persisted, and converge so
+ * concurrent first-run processes all settle on a single stable id. Resolution
+ * is best-effort and never throws — a hard FS failure (e.g. read-only volume)
+ * falls back to an in-memory id.
+ *
+ * Each attempt:
+ *  1. Read the marker; if it holds a non-empty id, that id won — use it.
+ *  2. Try an exclusive create (`open(path, "wx")`) and write our id; if the
+ *     create succeeds we won the race — persist and return our id.
+ *  3. On EEXIST the file exists but was empty (another process created it and
+ *     hasn't written yet, or a stale empty marker). Back off briefly and loop
+ *     so the next read can pick up the winner's id.
+ *  4. On any non-EEXIST `open` error (e.g. EACCES/EROFS), the FS is unwritable;
+ *     return the in-memory id without throwing.
+ *
+ * If every attempt sees an empty marker (no one ever wrote), we take ownership
+ * after the loop with a truncating `writeFile` so we still return a persisted
+ * id rather than a non-persistent one.
+ */
 async function resolveAnonymousInstallId(
   env: NodeJS.ProcessEnv,
   fallbackId?: string,
 ): Promise<string> {
   const installIdPath = resolveInstallIdPath(env);
-
-  try {
-    const existing = (await readFile(installIdPath, "utf8")).trim();
-    if (existing) {
-      return existing;
-    }
-  } catch {
-    // Fall through and create a new anonymous install ID.
-  }
-
   const installId = fallbackId ?? randomUUID();
 
-  try {
-    await mkdir(dirname(installIdPath), { recursive: true });
-    // Use exclusive-create ('wx') so that only one concurrent first-run process
-    // wins the write. If another process already created the file (EEXIST), read
-    // back whatever it wrote so both processes converge on the same stable id.
-    const fh = await open(installIdPath, "wx");
+  for (let attempt = 0; attempt < INSTALL_ID_MAX_ATTEMPTS; attempt++) {
+    // 1. Prefer an already-persisted, non-empty id.
     try {
-      await fh.writeFile(`${installId}\n`, "utf8");
-    } finally {
-      await fh.close();
-    }
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "EEXIST") {
-      // Another concurrent first-run wrote the file first — use its id.
-      try {
-        const raced = (await readFile(installIdPath, "utf8")).trim();
-        if (raced) {
-          return raced;
-        }
-      } catch {
-        // If the re-read also fails, fall through and return the in-memory id.
+      const existing = (await readFile(installIdPath, "utf8")).trim();
+      if (existing) {
+        return existing;
       }
+    } catch {
+      // No readable file yet — fall through to attempt an exclusive create.
     }
-    // Any other error (e.g. permissions): continue with an in-memory id.
+
+    // 2. Try to win the create race with an exclusive-create write.
+    try {
+      await mkdir(dirname(installIdPath), { recursive: true });
+      const fh = await open(installIdPath, "wx");
+      try {
+        await fh.writeFile(`${installId}\n`, "utf8");
+      } finally {
+        await fh.close();
+      }
+      return installId;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
+        // 4. FS is unwritable (permissions, read-only) — best-effort fallback.
+        return installId;
+      }
+      // 3. File exists but was empty on our read. Another process is about to
+      //    write it; back off and loop so the next read picks up its id.
+      await delay(1 << attempt); // ~1, 2, 4, 8 ms
+    }
   }
 
+  // 5. The marker exists but stayed empty across every attempt (no winner ever
+  //    wrote). Take ownership with a truncating write so we never return a
+  //    non-persisted id.
+  try {
+    await writeFile(installIdPath, `${installId}\n`, "utf8");
+  } catch {
+    // If even this fails, return the in-memory id without throwing.
+  }
   return installId;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export function resolveInstallIdPath(env: NodeJS.ProcessEnv): string {

--- a/packages/cli/src/lib/telemetry.ts
+++ b/packages/cli/src/lib/telemetry.ts
@@ -1,11 +1,7 @@
-import { randomUUID } from "node:crypto";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
-import { dirname, join } from "node:path";
-
 import type { Command } from "@oclif/core";
 
 import { detectAgent } from "./agent.js";
+import { resolveInstallId } from "./identity.js";
 import { getRunTelemetry, resetRunTelemetry } from "./run-telemetry.js";
 import type { CommandFailureTelemetry } from "./errors.js";
 
@@ -165,7 +161,7 @@ function createCliTelemetry(options: CreateCliTelemetryOptions): CliTelemetry {
   const transport = resolveTransportConfig(env);
   const telemetryEnabled = !isTelemetryDisabled(env);
   const distinctIdPromise = telemetryEnabled
-    ? resolveAnonymousInstallId(env, options.sessionId)
+    ? resolveInstallId(env, options.sessionId)
     : Promise.resolve("");
   const agentPromise = telemetryEnabled ? detectAgent() : Promise.resolve(null);
 
@@ -379,60 +375,6 @@ function parseTimeoutMs(value: string | undefined): number {
 
 function normalizeHost(host: string): string {
   return host.endsWith("/") ? host.slice(0, -1) : host;
-}
-
-async function resolveAnonymousInstallId(
-  env: NodeJS.ProcessEnv,
-  fallbackId?: string,
-): Promise<string> {
-  const installIdPath = resolveInstallIdPath(env);
-
-  try {
-    const existing = (await readFile(installIdPath, "utf8")).trim();
-    if (existing) {
-      return existing;
-    }
-  } catch {
-    // Fall through and create a new anonymous install ID.
-  }
-
-  const installId = fallbackId ?? randomUUID();
-
-  try {
-    await mkdir(dirname(installIdPath), { recursive: true });
-    await writeFile(installIdPath, `${installId}\n`, "utf8");
-  } catch {
-    // If persistence fails, continue with an in-memory anonymous ID.
-  }
-
-  return installId;
-}
-
-function resolveInstallIdPath(env: NodeJS.ProcessEnv): string {
-  const overriddenPath = env.BROWSERBASE_TELEMETRY_INSTALL_ID_FILE;
-  if (overriddenPath) {
-    return overriddenPath;
-  }
-
-  if (process.platform === "win32") {
-    const baseDir =
-      env.APPDATA ?? env.LOCALAPPDATA ?? join(homedir(), "AppData", "Roaming");
-    return join(baseDir, "Browserbase", "cli", "telemetry-id");
-  }
-
-  if (process.platform === "darwin") {
-    return join(
-      homedir(),
-      "Library",
-      "Application Support",
-      "Browserbase",
-      "cli",
-      "telemetry-id",
-    );
-  }
-
-  const baseDir = env.XDG_CONFIG_HOME ?? join(homedir(), ".config");
-  return join(baseDir, "browserbase", "cli", "telemetry-id");
 }
 
 function isTelemetryDisabled(env: NodeJS.ProcessEnv): boolean {

--- a/packages/cli/tests/cli-cloud-contract.test.ts
+++ b/packages/cli/tests/cli-cloud-contract.test.ts
@@ -1141,6 +1141,78 @@ describe("cloud API contracts", () => {
     );
   });
 
+  it("sessions create tags userMetadata with browse_cli, cli_version, and install_id", async () => {
+    const idDir = await createTempDir("browse-create-install-id-");
+    const installIdFile = join(idDir, "telemetry-id");
+    await writeFile(installIdFile, "create-install-uuid-123\n", "utf8");
+
+    await withServer(
+      async (_request, response) => {
+        jsonResponse(response, 200, { id: "sess_123" });
+      },
+      async ({ baseUrl, requests }) => {
+        const result = await runCli(
+          [
+            "cloud",
+            "sessions",
+            "create",
+            "--api-key",
+            "test-key",
+            "--base-url",
+            baseUrl,
+          ],
+          { env: { BROWSERBASE_TELEMETRY_INSTALL_ID_FILE: installIdFile } },
+        );
+
+        expect(result.exitCode).toBe(0);
+        expectRequest(requests[0], "POST", "/v1/sessions", "test-key");
+        const body = requests[0]?.jsonBody as {
+          userMetadata?: Record<string, string>;
+        };
+        expect(body.userMetadata).toBeDefined();
+        expect(body.userMetadata?.browse_cli).toBe("true");
+        // Seeded from oclif Config.version in BrowseCommand.init(); never "unknown".
+        expect(body.userMetadata?.cli_version).toBeDefined();
+        expect(body.userMetadata?.cli_version).not.toBe("unknown");
+        expect(body.userMetadata?.install_id).toBe("create-install-uuid-123");
+      },
+    );
+  });
+
+  it("sessions create preserves user-supplied metadata but keeps attribution keys authoritative", async () => {
+    await withServer(
+      async (_request, response) => {
+        jsonResponse(response, 200, { id: "sess_123" });
+      },
+      async ({ baseUrl, requests }) => {
+        const result = await runCli([
+          "cloud",
+          "sessions",
+          "create",
+          // User-supplied metadata: a custom key is kept; an attempt to override
+          // browse_cli must lose to our authoritative attribution value.
+          "--body",
+          '{"userMetadata":{"env":"staging","browse_cli":"false"}}',
+          "--api-key",
+          "test-key",
+          "--base-url",
+          baseUrl,
+        ]);
+
+        expect(result.exitCode).toBe(0);
+        expectRequest(requests[0], "POST", "/v1/sessions", "test-key");
+        const body = requests[0]?.jsonBody as {
+          userMetadata?: Record<string, string>;
+        };
+        // User's custom key survives.
+        expect(body.userMetadata?.env).toBe("staging");
+        // Attribution keys are authoritative — caller cannot spoof browse_cli.
+        expect(body.userMetadata?.browse_cli).toBe("true");
+        expect(body.userMetadata?.cli_version).not.toBe("unknown");
+      },
+    );
+  });
+
   it("sessions update merges an explicit status flag into the request body", async () => {
     await withServer(
       async (_request, response) => {

--- a/packages/cli/tests/cli-cloud-contract.test.ts
+++ b/packages/cli/tests/cli-cloud-contract.test.ts
@@ -1213,6 +1213,41 @@ describe("cloud API contracts", () => {
     );
   });
 
+  it("sessions create strips caller-supplied install_id to prevent spoofing when resolution fails", async () => {
+    await withServer(
+      async (_request, response) => {
+        jsonResponse(response, 200, { id: "sess_123" });
+      },
+      async ({ baseUrl, requests }) => {
+        const result = await runCli(
+          [
+            "cloud",
+            "sessions",
+            "create",
+            "--body",
+            '{"userMetadata":{"install_id":"spoofed-id","env":"test"}}',
+            "--api-key",
+            "test-key",
+            "--base-url",
+            baseUrl,
+          ],
+          // Point to a non-existent file so install_id resolution fails.
+          { env: { BROWSERBASE_TELEMETRY_INSTALL_ID_FILE: "/tmp/no-such-file-browse-test" } },
+        );
+
+        expect(result.exitCode).toBe(0);
+        expectRequest(requests[0], "POST", "/v1/sessions", "test-key");
+        const body = requests[0]?.jsonBody as {
+          userMetadata?: Record<string, string>;
+        };
+        // User's non-attribution key survives.
+        expect(body.userMetadata?.env).toBe("test");
+        // Caller cannot spoof install_id when resolution fails — it must not be "spoofed-id".
+        expect(body.userMetadata?.install_id).not.toBe("spoofed-id");
+      },
+    );
+  });
+
   it("sessions update merges an explicit status flag into the request body", async () => {
     await withServer(
       async (_request, response) => {

--- a/packages/cli/tests/cli-cloud-contract.test.ts
+++ b/packages/cli/tests/cli-cloud-contract.test.ts
@@ -1232,7 +1232,12 @@ describe("cloud API contracts", () => {
             baseUrl,
           ],
           // Point to a non-existent file so install_id resolution fails.
-          { env: { BROWSERBASE_TELEMETRY_INSTALL_ID_FILE: "/tmp/no-such-file-browse-test" } },
+          {
+            env: {
+              BROWSERBASE_TELEMETRY_INSTALL_ID_FILE:
+                "/tmp/no-such-file-browse-test",
+            },
+          },
         );
 
         expect(result.exitCode).toBe(0);

--- a/packages/cli/tests/cli-cloud-contract.test.ts
+++ b/packages/cli/tests/cli-cloud-contract.test.ts
@@ -1213,7 +1213,7 @@ describe("cloud API contracts", () => {
     );
   });
 
-  it("sessions create strips caller-supplied install_id to prevent spoofing when resolution fails", async () => {
+  it("sessions create strips caller-supplied install_id to prevent spoofing", async () => {
     await withServer(
       async (_request, response) => {
         jsonResponse(response, 200, { id: "sess_123" });
@@ -1231,7 +1231,10 @@ describe("cloud API contracts", () => {
             "--base-url",
             baseUrl,
           ],
-          // Point to a non-existent file so install_id resolution fails.
+          // Override install-id resolution to a throwaway path with no
+          // pre-existing id: resolveInstallId just creates it and returns a
+          // fresh UUID. The point of this test is that the caller-supplied
+          // install_id is stripped regardless and never survives as the spoof.
           {
             env: {
               BROWSERBASE_TELEMETRY_INSTALL_ID_FILE:

--- a/packages/cli/tests/identity-attribution.test.ts
+++ b/packages/cli/tests/identity-attribution.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Focused unit tests for:
+ * 1. toMetadataValue — sanitizes userMetadata values for the session-create validator
+ * 2. attributionHeaders (via api.ts) — always sends x-bb-client; conditionally x-bb-install-id
+ * 3. remoteStagehandOptions — always includes browse_cli + cli_version; includes install_id only when resolved
+ */
+
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { toMetadataValue } from "../src/lib/identity.js";
+
+// ---------------------------------------------------------------------------
+// toMetadataValue
+// ---------------------------------------------------------------------------
+
+describe("toMetadataValue", () => {
+  it("preserves fully-allowed characters unchanged", () => {
+    // Allowed: word chars, hyphen, plus underscore (via \w), and the extras
+    const allowed = "0.9.0-alpha_1,foo;bar:.ok()&$%#@!?~";
+    expect(toMetadataValue(allowed)).toBe(allowed);
+  });
+
+  it("strips characters outside the allowed set", () => {
+    // The '+' in a semver build suffix (+build.sha) is NOT in the validator set
+    expect(toMetadataValue("0.9.0+build.123")).toBe("0.9.0build.123");
+  });
+
+  it("strips spaces and slashes", () => {
+    expect(toMetadataValue("hello world/foo")).toBe("helloworldfoo");
+  });
+
+  it("truncates to the default max of 64 characters", () => {
+    const long = "a".repeat(100);
+    expect(toMetadataValue(long)).toHaveLength(64);
+  });
+
+  it("truncates to a custom max", () => {
+    expect(toMetadataValue("abcdef", 3)).toBe("abc");
+  });
+
+  it("returns an empty string for an all-disallowed input", () => {
+    expect(toMetadataValue(" / \\")).toBe("");
+  });
+
+  it("returns an empty string for an empty input", () => {
+    expect(toMetadataValue("")).toBe("");
+  });
+
+  it("handles a realistic semver with build metadata", () => {
+    // Typical semver: "1.2.3" stays intact; "1.2.3+abc" loses the '+'
+    expect(toMetadataValue("1.2.3+abc.def")).toBe("1.2.3abc.def");
+  });
+
+  it("handles a UUID without stripping characters", () => {
+    const uuid = "f47ac10b-58cc-4372-a567-0e02b2c3d479";
+    expect(toMetadataValue(uuid)).toBe(uuid);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// remoteStagehandOptions — userMetadata paths
+// ---------------------------------------------------------------------------
+
+const cleanupPaths: string[] = [];
+
+afterEach(async () => {
+  // Reset module-level cache between tests by re-importing via a fresh key.
+  // We can't easily reset the ESM cache, so we use env overrides instead.
+  vi.restoreAllMocks();
+  while (cleanupPaths.length > 0) {
+    const p = cleanupPaths.pop();
+    if (p) await rm(p, { recursive: true, force: true });
+  }
+});
+
+describe("remoteStagehandOptions — userMetadata", () => {
+  let tmpDir: string;
+  let installIdFile: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "browse-identity-test-"));
+    cleanupPaths.push(tmpDir);
+    installIdFile = join(tmpDir, "telemetry-id");
+  });
+
+  it("always includes browse_cli and cli_version", async () => {
+    process.env.BROWSERBASE_API_KEY = "bb_test";
+    process.env.BROWSERBASE_TELEMETRY_INSTALL_ID_FILE = installIdFile;
+
+    try {
+      // Dynamic import so each test gets a fresh module resolution path
+      const { remoteStagehandOptions } = await import(
+        "../src/lib/driver/remote.js"
+      );
+      const opts = await remoteStagehandOptions();
+      const meta = opts.browserbaseSessionCreateParams?.userMetadata as Record<
+        string,
+        string
+      >;
+
+      expect(meta).toBeDefined();
+      expect(meta.browse_cli).toBe("true");
+      expect(typeof meta.cli_version).toBe("string");
+      expect(meta.cli_version.length).toBeGreaterThan(0);
+    } finally {
+      delete process.env.BROWSERBASE_API_KEY;
+      delete process.env.BROWSERBASE_TELEMETRY_INSTALL_ID_FILE;
+    }
+  });
+
+  it("includes install_id when resolution succeeds", async () => {
+    process.env.BROWSERBASE_API_KEY = "bb_test";
+    process.env.BROWSERBASE_TELEMETRY_INSTALL_ID_FILE = installIdFile;
+
+    // Pre-seed the install id so resolution succeeds without race
+    await writeFile(installIdFile, "test-install-uuid-123\n", "utf8");
+
+    try {
+      const { remoteStagehandOptions } = await import(
+        "../src/lib/driver/remote.js"
+      );
+      const opts = await remoteStagehandOptions();
+      const meta = opts.browserbaseSessionCreateParams?.userMetadata as Record<
+        string,
+        string
+      >;
+
+      expect(meta.install_id).toBeDefined();
+      // Only allowed chars; UUID hyphens are fine
+      expect(meta.install_id).toMatch(/^[\w\-_,;:.()&$%#@!?~]+$/);
+    } finally {
+      delete process.env.BROWSERBASE_API_KEY;
+      delete process.env.BROWSERBASE_TELEMETRY_INSTALL_ID_FILE;
+    }
+  });
+
+  it("omits install_id when not resolvable but still returns valid metadata", async () => {
+    process.env.BROWSERBASE_API_KEY = "bb_test";
+    // Point to a file that cannot be created (non-existent parent dir in a
+    // read-only location). Simplest: unset the override and use a mock.
+    delete process.env.BROWSERBASE_TELEMETRY_INSTALL_ID_FILE;
+
+    // Spy on resolveInstallId to simulate rejection
+    const identityModule = await import("../src/lib/identity.js");
+    vi.spyOn(identityModule, "resolveInstallId").mockRejectedValue(
+      new Error("disk failure"),
+    );
+
+    try {
+      const { remoteStagehandOptions } = await import(
+        "../src/lib/driver/remote.js"
+      );
+      const opts = await remoteStagehandOptions();
+      const meta = opts.browserbaseSessionCreateParams?.userMetadata as Record<
+        string,
+        string
+      >;
+
+      expect(meta.browse_cli).toBe("true");
+      expect(typeof meta.cli_version).toBe("string");
+      // install_id must NOT be present (never send an undefined/empty value)
+      expect(Object.prototype.hasOwnProperty.call(meta, "install_id")).toBe(
+        false,
+      );
+    } finally {
+      delete process.env.BROWSERBASE_API_KEY;
+    }
+  });
+});

--- a/packages/cli/tests/identity-attribution.test.ts
+++ b/packages/cli/tests/identity-attribution.test.ts
@@ -8,6 +8,7 @@
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -287,5 +288,45 @@ describe("getCliVersion / setCliVersion", () => {
     setCliVersion("1.4.2");
     setCliVersion("");
     expect(getCliVersion()).toBe("1.4.2");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BrowseCommand.init() — seeds getCliVersion from Config.version at the
+// command lifecycle boundary (the real path used by the foreground command
+// and the background `browse daemon` process that creates sessions).
+// ---------------------------------------------------------------------------
+
+describe("BrowseCommand.init() — version seeding at lifecycle boundary", () => {
+  beforeEach(() => {
+    // Fresh module so getCliVersion starts unseeded ("unknown") before init.
+    vi.resetModules();
+  });
+
+  it("seeds getCliVersion() from this.config.version when init() runs", async () => {
+    const { Config } = await import("@oclif/core");
+    const { BrowseCommand } = await import("../src/base.js");
+    const { getCliVersion } = await import("../src/lib/identity.js");
+
+    // Load the package's real oclif Config (this is the same Config oclif
+    // hands every command; its .version comes from package.json => 0.9.0).
+    // fileURLToPath keeps this correct on Windows (no leading-slash artifact).
+    const config = await Config.load(
+      fileURLToPath(new URL("..", import.meta.url)),
+    );
+
+    // Sanity: unseeded before any command init runs.
+    expect(getCliVersion()).toBe("unknown");
+
+    // A minimal concrete BrowseCommand subclass; run the real init() lifecycle.
+    class TestCommand extends BrowseCommand {
+      async run(): Promise<void> {}
+    }
+    const command = new TestCommand([], config);
+    await command.init();
+
+    // After init(), getCliVersion() reflects Config.version — never "unknown".
+    expect(getCliVersion()).toBe(config.version);
+    expect(getCliVersion()).not.toBe("unknown");
   });
 });

--- a/packages/cli/tests/identity-attribution.test.ts
+++ b/packages/cli/tests/identity-attribution.test.ts
@@ -5,7 +5,7 @@
  * 3. remoteStagehandOptions — always includes browse_cli + cli_version; includes install_id only when resolved
  */
 
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -168,6 +168,79 @@ describe("remoteStagehandOptions — userMetadata", () => {
       );
     } finally {
       delete process.env.BROWSERBASE_API_KEY;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveInstallId — persistence + convergence (race-safe marker handling)
+// ---------------------------------------------------------------------------
+
+describe("resolveInstallId — persistence", () => {
+  let tmpDir: string;
+  let installIdFile: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "browse-install-id-test-"));
+    cleanupPaths.push(tmpDir);
+    installIdFile = join(tmpDir, "telemetry-id");
+    // Each test needs a fresh module so the module-level install-id cache is
+    // reset; resetModules() forces the next dynamic import to re-evaluate.
+    vi.resetModules();
+  });
+
+  it("takes ownership of an EMPTY marker file: returns a non-empty, persisted id", async () => {
+    process.env.BROWSERBASE_TELEMETRY_INSTALL_ID_FILE = installIdFile;
+    // Pre-create an EMPTY marker (simulates a process that created the file via
+    // 'wx' but crashed/raced before writing, or a stale empty marker).
+    await writeFile(installIdFile, "", "utf8");
+
+    try {
+      const { resolveInstallId } = await import("../src/lib/identity.js");
+      const id = await resolveInstallId(process.env);
+
+      // Must return a non-empty id...
+      expect(typeof id).toBe("string");
+      expect(id.length).toBeGreaterThan(0);
+
+      // ...AND that id must now be persisted to the (previously empty) file.
+      const persisted = (await readFile(installIdFile, "utf8")).trim();
+      expect(persisted.length).toBeGreaterThan(0);
+      expect(persisted).toBe(id);
+    } finally {
+      delete process.env.BROWSERBASE_TELEMETRY_INSTALL_ID_FILE;
+    }
+  });
+
+  it("returns the existing non-empty id without overwriting it", async () => {
+    process.env.BROWSERBASE_TELEMETRY_INSTALL_ID_FILE = installIdFile;
+    await writeFile(installIdFile, "existing-stable-id-abc\n", "utf8");
+
+    try {
+      const { resolveInstallId } = await import("../src/lib/identity.js");
+      const id = await resolveInstallId(process.env);
+
+      expect(id).toBe("existing-stable-id-abc");
+      const persisted = (await readFile(installIdFile, "utf8")).trim();
+      expect(persisted).toBe("existing-stable-id-abc");
+    } finally {
+      delete process.env.BROWSERBASE_TELEMETRY_INSTALL_ID_FILE;
+    }
+  });
+
+  it("creates and persists a new id when no marker exists", async () => {
+    process.env.BROWSERBASE_TELEMETRY_INSTALL_ID_FILE = installIdFile;
+    // Note: installIdFile does not exist yet (only tmpDir does).
+
+    try {
+      const { resolveInstallId } = await import("../src/lib/identity.js");
+      const id = await resolveInstallId(process.env);
+
+      expect(id.length).toBeGreaterThan(0);
+      const persisted = (await readFile(installIdFile, "utf8")).trim();
+      expect(persisted).toBe(id);
+    } finally {
+      delete process.env.BROWSERBASE_TELEMETRY_INSTALL_ID_FILE;
     }
   });
 });

--- a/packages/cli/tests/identity-attribution.test.ts
+++ b/packages/cli/tests/identity-attribution.test.ts
@@ -87,12 +87,16 @@ describe("remoteStagehandOptions — userMetadata", () => {
     installIdFile = join(tmpDir, "telemetry-id");
   });
 
-  it("always includes browse_cli and cli_version", async () => {
+  it("always includes browse_cli and the seeded cli_version", async () => {
     process.env.BROWSERBASE_API_KEY = "bb_test";
     process.env.BROWSERBASE_TELEMETRY_INSTALL_ID_FILE = installIdFile;
 
     try {
       // Dynamic import so each test gets a fresh module resolution path
+      const identityModule = await import("../src/lib/identity.js");
+      // Seed the version the way base.ts does from Config.version at startup.
+      identityModule.setCliVersion("1.2.3");
+
       const { remoteStagehandOptions } = await import(
         "../src/lib/driver/remote.js"
       );
@@ -104,8 +108,8 @@ describe("remoteStagehandOptions — userMetadata", () => {
 
       expect(meta).toBeDefined();
       expect(meta.browse_cli).toBe("true");
-      expect(typeof meta.cli_version).toBe("string");
-      expect(meta.cli_version.length).toBeGreaterThan(0);
+      // cli_version reflects the seeded oclif version, never "unknown".
+      expect(meta.cli_version).toBe("1.2.3");
     } finally {
       delete process.env.BROWSERBASE_API_KEY;
       delete process.env.BROWSERBASE_TELEMETRY_INSTALL_ID_FILE;
@@ -242,5 +246,46 @@ describe("resolveInstallId — persistence", () => {
     } finally {
       delete process.env.BROWSERBASE_TELEMETRY_INSTALL_ID_FILE;
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getCliVersion / setCliVersion — seeded from Config.version, no fs
+// ---------------------------------------------------------------------------
+
+describe("getCliVersion / setCliVersion", () => {
+  beforeEach(() => {
+    // Fresh module per test so the module-level version cache starts unset.
+    vi.resetModules();
+  });
+
+  it("returns 'unknown' when never seeded (no filesystem fallback)", async () => {
+    const { getCliVersion } = await import("../src/lib/identity.js");
+    expect(getCliVersion()).toBe("unknown");
+  });
+
+  it("returns the value seeded via setCliVersion", async () => {
+    const { getCliVersion, setCliVersion } = await import(
+      "../src/lib/identity.js"
+    );
+    setCliVersion("0.9.0");
+    expect(getCliVersion()).toBe("0.9.0");
+  });
+
+  it("ignores an empty seed, leaving the 'unknown' fallback intact", async () => {
+    const { getCliVersion, setCliVersion } = await import(
+      "../src/lib/identity.js"
+    );
+    setCliVersion("");
+    expect(getCliVersion()).toBe("unknown");
+  });
+
+  it("keeps a previously-seeded version when later seeded with empty", async () => {
+    const { getCliVersion, setCliVersion } = await import(
+      "../src/lib/identity.js"
+    );
+    setCliVersion("1.4.2");
+    setCliVersion("");
+    expect(getCliVersion()).toBe("1.4.2");
   });
 });

--- a/packages/cli/tests/identity-attribution.test.ts
+++ b/packages/cli/tests/identity-attribution.test.ts
@@ -5,7 +5,7 @@
  * 3. remoteStagehandOptions — always includes browse_cli + cli_version; includes install_id only when resolved
  */
 
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -247,6 +247,122 @@ describe("resolveInstallId — persistence", () => {
     } finally {
       delete process.env.BROWSERBASE_TELEMETRY_INSTALL_ID_FILE;
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveInstallIdPath / migration — standardized config dir + legacy carry-forward
+// ---------------------------------------------------------------------------
+
+describe("resolveInstallIdPath — standardized config dir", () => {
+  beforeEach(() => {
+    // Fresh module so the module-level install-id cache starts clear.
+    vi.resetModules();
+  });
+
+  it("uses <BROWSERBASE_CONFIG_DIR>/install-id when that env is set", async () => {
+    const { resolveInstallIdPath } = await import("../src/lib/identity.js");
+    const configDir = "/tmp/explicit-bb-config";
+    expect(resolveInstallIdPath({ BROWSERBASE_CONFIG_DIR: configDir })).toBe(
+      join(configDir, "install-id"),
+    );
+  });
+
+  it("uses <XDG_CONFIG_HOME>/browserbase/install-id when only XDG is set", async () => {
+    const { resolveInstallIdPath } = await import("../src/lib/identity.js");
+    const xdg = "/tmp/xdg-config-home";
+    expect(resolveInstallIdPath({ XDG_CONFIG_HOME: xdg })).toBe(
+      join(xdg, "browserbase", "install-id"),
+    );
+  });
+
+  it("override (BROWSERBASE_TELEMETRY_INSTALL_ID_FILE) short-circuits the config dir", async () => {
+    const { resolveInstallIdPath } = await import("../src/lib/identity.js");
+    const override = "/tmp/override/some-file";
+    expect(
+      resolveInstallIdPath({
+        BROWSERBASE_TELEMETRY_INSTALL_ID_FILE: override,
+        BROWSERBASE_CONFIG_DIR: "/tmp/ignored",
+        XDG_CONFIG_HOME: "/tmp/also-ignored",
+      }),
+    ).toBe(override);
+  });
+});
+
+describe("resolveInstallId — legacy path migration", () => {
+  let tmpDir: string;
+  let savedHome: string | undefined;
+  let savedUserProfile: string | undefined;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "browse-install-id-migrate-"));
+    cleanupPaths.push(tmpDir);
+    // Isolate homedir() so the platform-specific legacy markers (macOS
+    // ~/Library/..., Windows AppData) resolve INSIDE the temp dir and only
+    // exist when this test seeds them — never the host machine's real marker.
+    savedHome = process.env.HOME;
+    savedUserProfile = process.env.USERPROFILE;
+    process.env.HOME = tmpDir;
+    process.env.USERPROFILE = tmpDir;
+    // Fresh module per test so the module-level cache is reset.
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (savedHome === undefined) delete process.env.HOME;
+    else process.env.HOME = savedHome;
+    if (savedUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = savedUserProfile;
+  });
+
+  it("forward-migrates the id from the legacy XDG telemetry-id marker", async () => {
+    const knownId = "11111111-2222-3333-4444-555555555555";
+    const legacyDir = join(tmpDir, "browserbase", "cli");
+    await mkdir(legacyDir, { recursive: true });
+    await writeFile(join(legacyDir, "telemetry-id"), `${knownId}\n`, "utf8");
+
+    const { resolveInstallId } = await import("../src/lib/identity.js");
+    const id = await resolveInstallId({ XDG_CONFIG_HOME: tmpDir });
+
+    // The stable id is carried forward, not reset.
+    expect(id).toBe(knownId);
+
+    // ...and it now lives at the canonical install-id path.
+    const canonical = join(tmpDir, "browserbase", "install-id");
+    const persisted = (await readFile(canonical, "utf8")).trim();
+    expect(persisted).toBe(knownId);
+  });
+
+  it("prefers the canonical install-id over a legacy marker (no clobber)", async () => {
+    const canonicalId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+    const legacyId = "99999999-8888-7777-6666-555555555555";
+
+    const bbDir = join(tmpDir, "browserbase");
+    const legacyDir = join(bbDir, "cli");
+    await mkdir(legacyDir, { recursive: true });
+    await writeFile(join(bbDir, "install-id"), `${canonicalId}\n`, "utf8");
+    await writeFile(join(legacyDir, "telemetry-id"), `${legacyId}\n`, "utf8");
+
+    const { resolveInstallId } = await import("../src/lib/identity.js");
+    const id = await resolveInstallId({ XDG_CONFIG_HOME: tmpDir });
+
+    expect(id).toBe(canonicalId);
+    // The canonical marker is untouched.
+    const persisted = (
+      await readFile(join(bbDir, "install-id"), "utf8")
+    ).trim();
+    expect(persisted).toBe(canonicalId);
+  });
+
+  it("mints a fresh id at the canonical path on a true first run", async () => {
+    // Neither a canonical nor a legacy marker exists under tmpDir.
+    const { resolveInstallId } = await import("../src/lib/identity.js");
+    const id = await resolveInstallId({ XDG_CONFIG_HOME: tmpDir });
+
+    expect(id.length).toBeGreaterThan(0);
+    const canonical = join(tmpDir, "browserbase", "install-id");
+    const persisted = (await readFile(canonical, "utf8")).trim();
+    expect(persisted).toBe(id);
   });
 });
 

--- a/packages/cli/tests/remote-disabled.test.ts
+++ b/packages/cli/tests/remote-disabled.test.ts
@@ -19,8 +19,8 @@ describe("remote.disabled (local-only capability)", () => {
     expect(() => resolveExplicitRemoteTarget()).toThrow(/disabled/i);
   });
 
-  it("refuses to build remote Stagehand options", () => {
-    expect(() => remoteStagehandOptions()).toThrow(/disabled/i);
+  it("refuses to build remote Stagehand options", async () => {
+    await expect(remoteStagehandOptions()).rejects.toThrow(/disabled/i);
   });
 
   it("reports remote as disabled in doctor without reading any key", () => {


### PR DESCRIPTION
## What & why

CLI-driven Browserbase usage isn't fully attributable today:
- Remote **browser sessions** the CLI creates are tagged `userMetadata.browse_cli:"true"`, but carry no install/version, so we can't tie usage to an install or correlate with the CLI's anonymous PostHog telemetry.
- `browse cloud search` (`/v1/search`) and `browse cloud fetch` create **no session at all**, so they're invisible in session metadata.

This PR stamps a stable anonymous **`install_id`** + **`cli_version`** onto both paths.

## Changes (`packages/cli` only)

- **New `src/lib/identity.ts`** — single source for install identity: `resolveInstallId` (async, memoized, **atomic** write via exclusive-create + EEXIST re-read), `peekInstallId` (sync, never blocks), `getCliVersion`, and `toMetadataValue` (sanitizes session-metadata values). install-id logic moved verbatim out of `telemetry.ts`; its tests pass unchanged.
- **Sessions** — `driver/remote.ts` `remoteStagehandOptions()` adds sanitized `install_id` + `cli_version` to `userMetadata` (made async; resolver awaited with a safe fallback so telemetry never throws). Interface, local-only stub (now properly async so `.catch` works), and the call site updated.
- **Cloud headers** — `lib/cloud/api.ts` sends `x-bb-client: browse-cli/<version>` (+ `x-bb-install-id` when resolved) on **both** transports: the raw `requestBrowserbaseJson` helper (covers `search`, sessions, contexts, projects, extensions) and `createBrowserbaseClient()` `defaultHeaders` (covers `fetch`, functions). Never emits empty-value headers.
- Patch **changeset**.

## Why sanitize values

Browserbase session-create runs `validateMetadataObject` — values must match `[\w\-_,;:.()&$%#@!?~]` and total ≤512 chars. A `+build` semver would otherwise **400 every remote session**, so `cli_version`/`install_id` are passed through `toMetadataValue()` before reaching `userMetadata`. (HTTP headers are unconstrained, so the full version stays in `x-bb-client`.)

## E2E Test Matrix

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `<local build> open https://example.com --remote` → `cloud sessions list --status RUNNING` | session `userMetadata` = `{stagehand:"true", browse_cli:"true", install_id:"<uuid>", cli_version:"0.9.0"}` | All 3 attribution keys land on a driver-created remote session; `install_id` equals the on-disk marker. (Server-side ingestion out of scope.) |
| `cloud search "..."` and `cloud fetch https://example.com` against a local capture server (`--base-url`) | `/v1/search` and `/v1/fetch` each received `x-bb-client: browse-cli/0.9.0` + `x-bb-install-id: <uuid>` | Exact outgoing headers confirmed on **both** the raw-helper (search) and SDK (fetch) paths. |
| `cloud search "..."` and `cloud fetch https://example.com` (live API) | real results JSON; fetch `200` + markdown | New headers don't break live calls. |
| Migration smoke against built `dist/lib/identity.js`: seed legacy `~/…/cli/telemetry-id` = `1111…5555`, then `resolveInstallId` with `XDG_CONFIG_HOME` pointed at a temp dir | returned `1111…5555`; new `<tmp>/browserbase/install-id` contains `1111…5555` (fresh-dir case mints a new uuid instead) | Legacy id is carried forward to the new canonical path, not reset; first-run still mints. Also confirmed on real disk: existing `~/Library/.../telemetry-id` id copied to `~/.config/browserbase/install-id`, legacy file intact. |
| Read-only-FS / Lambda resilience against built `dist`: (a) `HOME=/tmp/...` writable, (b) read-only `0555` dir, (c) `ENOTDIR` under `/dev/null`, (d) unwritable `HOME=/var/empty`, plus real `browse --version` and `browse cloud sessions list` under unwritable `HOME` | (a) persists to `/tmp/.../.config/browserbase/install-id`; (b)(c)(d) return a valid in-memory UUID, **nothing written, no throw**; real CLI exits cleanly (version prints; cloud cmd returns a clean `401`, not an FS crash); no illegal writes under `/var/empty` | install-id resolution + migration are best-effort: every read/mkdir/write is guarded and all 4 callers wrap in `.catch`. On Lambda (`HOME=/tmp`) it persists; if the dir/file is unwritable it degrades to a per-invocation in-memory id without failing the command. |
| `turbo run build --filter=browse` · `pnpm lint` · `pnpm test:cli` | build + lint clean · **299/299** tests pass (+7 path-resolution / migration tests over the prior 292) | No regressions; path change + migration covered. |

## Review follow-ups (addressed)

All 5 Cubic threads resolved: async local-only stub (so `.catch` works), atomic install-id write (race-safe on concurrent first runs — pre-existing behavior, hardened), and 12 focused unit tests for `toMetadataValue` (allowed-char filtering, `+build` stripping, truncation, UUID round-trip), the attribution headers, and the `remoteStagehandOptions` success + fallback paths.

## Dependency / follow-up (not in this PR)

Session `userMetadata` is queryable in our internal analytics today. The **search/fetch headers** only become useful once Platform logs `x-bb-client` / `x-bb-install-id` on those endpoints — tracked as a server-side follow-up.

## Update — also tags `cloud sessions create`

Extended attribution to the `browse cloud sessions create` path too (previously only the driver `open --remote` path carried it): its `userMetadata` now includes `browse_cli` + `install_id` + `cli_version` (sanitized via `toMetadataValue`), merged with any user-supplied `--body` metadata while keeping the attribution keys authoritative — a user can't spoof `browse_cli` to `"false"`. **So every CLI-created session is attributable — driver *and* `cloud sessions create`.** Verified live: `cloud sessions create` → readback `userMetadata: { browse_cli:"true", install_id:"…", cli_version:"0.9.0" }` → released. +2 tests (292 total cli tests).

## Update — standardized install-id path (review follow-up)

Per review (thanks @pirate), moved the anonymous install-id marker off the bespoke per-OS path (`~/Library/Application Support/Browserbase/cli/telemetry-id`, `%APPDATA%/Browserbase/cli/telemetry-id`, `<xdg>/browserbase/cli/telemetry-id`) to the **standardized `~/.config/browserbase/install-id`** — consistent with core (`BROWSERBASE_CONFIG_DIR`) and the CLI's own `~/.config/browserbase/skills`. Honors `BROWSERBASE_CONFIG_DIR`, falls back to `XDG_CONFIG_HOME`/`~/.config` on every platform; the `BROWSERBASE_TELEMETRY_INSTALL_ID_FILE` override still short-circuits everything (incl. migration).

**Backwards-compatible:** if the canonical file is absent but a legacy marker exists, its UUID is copied forward so existing installs keep their stable id — no attribution reset; the legacy file is left intact. Renamed `telemetry-id` → `install-id` since it's no longer telemetry-only (and `install-id`, not `device-id`, because it's a per-install id, not a hardware fingerprint). Considered and declined `node-machine-id`: a cross-app hardware id doesn't fix ephemeral-fleet counting (unpredictable across customer image strategies) and conflicts with the anonymous, install-scoped intent.

Closes STG-2404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




