### PR TITLE
[STG-2405] fix: agent({ integrations }) with an MCP Client throws circular-structure JSON

### DIFF
--- a/.changeset/mcp-integrations-circular-json.md
+++ b/.changeset/mcp-integrations-circular-json.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Fix `TypeError: Converting circular structure to JSON` when creating an agent with MCP `integrations` that include a `Client` instance (e.g. a local/stdio server from `connectToMCPServer`). The agent-creation log serialized the raw `integrations` array, and a live MCP `Client` is circular. It now logs a safe descriptor (URL strings kept, client instances summarized) so `agent({ integrations: [client] })` works.

--- a/packages/core/lib/v3/v3.ts
+++ b/packages/core/lib/v3/v3.ts
@@ -1989,7 +1989,14 @@ export class V3 {
         tools: { value: JSON.stringify(options?.tools ?? {}), type: "object" },
         ...(options?.integrations && {
           integrations: {
-            value: JSON.stringify(options.integrations),
+            // Integrations may contain live MCP `Client` instances (from
+            // connectToMCPServer), which are circular and throw in JSON.stringify.
+            // Log a safe descriptor instead: keep URL strings, summarize clients.
+            value: JSON.stringify(
+              options.integrations.map((integration) =>
+                typeof integration === "string" ? integration : "[mcp client]",
+              ),
+            ),
             type: "object",
           },
         }),


### PR DESCRIPTION
## What & why

`stagehand.agent({ integrations })` is unusable with a local/stdio MCP server. `agent()` logs its config as auxiliary metadata via `JSON.stringify(options.integrations)`, but an MCP `Client` instance (what `connectToMCPServer({ command, args })` returns) is a **circular object** — so the call throws **`TypeError: Converting circular structure to JSON`** *before the agent ever runs*.

This blocks the documented stdio-MCP path entirely (URL-string integrations are unaffected, since a string serializes fine).

## The fix

`packages/core/lib/v3/v3.ts` — in the agent-creation log, serialize a **safe descriptor** instead of the raw array: keep URL strings, summarize `Client` instances as `"[mcp client]"`. One site; it runs for all agent modes (dom/hybrid/cua). No public API change. Patch changeset added.

```ts
// before
value: JSON.stringify(options.integrations),
// after
value: JSON.stringify(
  options.integrations.map((i) => (typeof i === "string" ? i : "[mcp client]")),
),
```

## E2E Test Matrix

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| **Before fix** (published `3.6.0`): `agent({ integrations: [connectToMCPServer({command:"npx", args:[…filesystem MCP…]})] })` run on live Browserbase | `TypeError: Converting circular structure to JSON … at V3.agent` — crashes **before** the agent starts. Reproduced on a **second** MCP server (`@modelcontextprotocol/server-everything`) → not server-specific. | Proves the bug and that it's general to any `Client` integration. |
| **After fix** (local build copied into a scratch project), same script on live Browserbase | exit 0, **no circular error**; agent connected to the MCP server (`Secure MCP Filesystem Server running on stdio`) and **invoked its tools** (got a real tool response). | Proves the fix unblocks `agent({ integrations: [client] })` end-to-end. |
| `pnpm build:esm` (core) + grep built `v3.js` | build exit 0; built output contains the safe descriptor, no `JSON.stringify(options.integrations)`. | Fix compiles and is present in the artifact under test. |

> Note: server-side ingestion is irrelevant here — this is a pure client-side serialization crash; the matrix exercises the exact throwing call path before and after.

Closes STG-2405.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a circular-JSON crash when creating an agent with MCP `Client` integrations (e.g., from `connectToMCPServer`). We now log a safe descriptor for `integrations`, so `agent({ integrations: [client] })` works with local/stdio MCP servers across all modes. Addresses STG-2405.

<sup>Written for commit 01323a58971bfd737c742f6652d18308ae736b8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

