### PR TITLE
[STG-2407] fix(cli): honor BROWSERBASE_API_KEY passed to an already-running daemon

### DIFF
--- a/.changeset/honor-forwarded-daemon-api-key.md
+++ b/.changeset/honor-forwarded-daemon-api-key.md
@@ -1,0 +1,5 @@
+---
+"browse": patch
+---
+
+Honor `BROWSERBASE_API_KEY` passed to an already-running driver daemon. Previously, if the first remote command started the daemon without a key, a later `BROWSERBASE_API_KEY=… browse open <url> --remote` (or an exported key in a new shell) kept failing with "Missing BROWSERBASE_API_KEY" because the detached daemon captured `process.env` once at spawn time and never saw the new key. The client now forwards the caller's key over the (localhost, owner-only) driver socket with every command, and the daemon threads it straight into the Stagehand constructor when it creates the session — so an inline or exported key works without a manual `browse stop` and restart. The forwarded key is never written back into the daemon's `process.env`; its only home is the live session. Already-initialized warm sessions are untouched; the forwarded key only takes effect at session init. The local-only (CDP-only) build forwards nothing and remains free of any API-key code path.

--- a/packages/cli/src/lib/driver/daemon/client.ts
+++ b/packages/cli/src/lib/driver/daemon/client.ts
@@ -14,6 +14,7 @@ import {
   getSocketPath,
   PRIVATE_FILE_MODE,
 } from "./paths.js";
+import { collectClientCredentials } from "./credentials.js";
 import { isProcessAlive } from "./process.js";
 import { ResponseSchema, type DriverRequest } from "./protocol.js";
 
@@ -74,6 +75,7 @@ export async function openViaDaemon(
 ): Promise<OpenResult> {
   return sendDriverRequest<OpenResult>(session, {
     ...options,
+    credentials: await collectClientCredentials(),
     id: requestId(),
     type: "open",
     url,
@@ -87,6 +89,7 @@ export async function runDriverCommandViaDaemon(
 ): Promise<unknown> {
   return sendDriverRequest(session, {
     command,
+    credentials: await collectClientCredentials(),
     id: requestId(),
     params,
     type: "command",

--- a/packages/cli/src/lib/driver/daemon/client.ts
+++ b/packages/cli/src/lib/driver/daemon/client.ts
@@ -14,7 +14,7 @@ import {
   getSocketPath,
   PRIVATE_FILE_MODE,
 } from "./paths.js";
-import { collectClientCredentials } from "./credentials.js";
+import { collectForwardedEnv } from "./forwarded-env.js";
 import { isProcessAlive } from "./process.js";
 import { ResponseSchema, type DriverRequest } from "./protocol.js";
 
@@ -75,7 +75,7 @@ export async function openViaDaemon(
 ): Promise<OpenResult> {
   return sendDriverRequest<OpenResult>(session, {
     ...options,
-    credentials: await collectClientCredentials(),
+    forwardedEnv: await collectForwardedEnv(),
     id: requestId(),
     type: "open",
     url,
@@ -89,7 +89,7 @@ export async function runDriverCommandViaDaemon(
 ): Promise<unknown> {
   return sendDriverRequest(session, {
     command,
-    credentials: await collectClientCredentials(),
+    forwardedEnv: await collectForwardedEnv(),
     id: requestId(),
     params,
     type: "command",

--- a/packages/cli/src/lib/driver/daemon/credentials.ts
+++ b/packages/cli/src/lib/driver/daemon/credentials.ts
@@ -1,0 +1,65 @@
+import { createHash } from "node:crypto";
+
+import { getRemote } from "../remote-binding.js";
+
+/**
+ * Credentials the client forwards to a running daemon so that an inline or
+ * exported API key set *after* the daemon started is still honored.
+ *
+ * The daemon is a detached background process whose `process.env` is captured
+ * once at spawn time. A key set on a *later* client invocation never reaches
+ * that process on its own, so the client ships the relevant credentials over
+ * the (localhost, owner-only) driver socket with every command. The daemon
+ * threads them straight into the Stagehand constructor at init — it never
+ * writes them back into its own `process.env`, so the key's only home is the
+ * live session, not the daemon's global environment.
+ *
+ * The *list* of forwardable keys is Browserbase-specific and therefore lives
+ * behind the remote capability (`remote.ts`), which the local-only build
+ * excludes. That keeps the literal key names out of the CDP-only artifact, the
+ * same security contract that confines `BROWSERBASE_API_KEY` reads to
+ * `remote.ts`. The signature side iterates the received object's own keys, so
+ * it needs no key list and stays key-name-free.
+ */
+export type ForwardedCredentials = Record<string, string>;
+
+/** Collect the forwardable credentials that are set in the caller's env. */
+export async function collectClientCredentials(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<ForwardedCredentials | undefined> {
+  const keys = (await getRemote()).forwardedCredentialKeys();
+  const credentials: ForwardedCredentials = {};
+  for (const key of keys) {
+    const value = env[key];
+    if (typeof value === "string" && value.length > 0) {
+      credentials[key] = value;
+    }
+  }
+  return Object.keys(credentials).length > 0 ? credentials : undefined;
+}
+
+/**
+ * Stable, secret-free fingerprint of a forwarded credential set, used only to
+ * detect whether the caller's credentials changed between requests (so a cold
+ * session can bust its cached init-failure backoff and retry with the new key).
+ * Hashing keeps the raw key out of any retained field. Iterates the received
+ * object's own keys — the client already filtered to the forwardable set — so
+ * this carries no literal key names. Returns "" for an empty/absent set.
+ */
+export function credentialSignature(
+  credentials: ForwardedCredentials | undefined,
+): string {
+  if (!credentials) return "";
+  const entries = Object.entries(credentials)
+    .filter(([, value]) => typeof value === "string" && value.length > 0)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  if (entries.length === 0) return "";
+  const hash = createHash("sha256");
+  for (const [key, value] of entries) {
+    hash.update(key);
+    hash.update("\0");
+    hash.update(value);
+    hash.update("\0");
+  }
+  return hash.digest("hex");
+}

--- a/packages/cli/src/lib/driver/daemon/forwarded-env.ts
+++ b/packages/cli/src/lib/driver/daemon/forwarded-env.ts
@@ -3,12 +3,12 @@ import { createHash } from "node:crypto";
 import { getRemote } from "../remote-binding.js";
 
 /**
- * Credentials the client forwards to a running daemon so that an inline or
+ * Env vars the client forwards to a running daemon so that an inline or
  * exported API key set *after* the daemon started is still honored.
  *
  * The daemon is a detached background process whose `process.env` is captured
  * once at spawn time. A key set on a *later* client invocation never reaches
- * that process on its own, so the client ships the relevant credentials over
+ * that process on its own, so the client ships the relevant env vars over
  * the (localhost, owner-only) driver socket with every command. The daemon
  * threads them straight into the Stagehand constructor at init — it never
  * writes them back into its own `process.env`, so the key's only home is the
@@ -21,36 +21,36 @@ import { getRemote } from "../remote-binding.js";
  * `remote.ts`. The signature side iterates the received object's own keys, so
  * it needs no key list and stays key-name-free.
  */
-export type ForwardedCredentials = Record<string, string>;
+export type ForwardedEnv = Record<string, string>;
 
-/** Collect the forwardable credentials that are set in the caller's env. */
-export async function collectClientCredentials(
+/** Collect the forwardable env vars that are set in the caller's env. */
+export async function collectForwardedEnv(
   env: NodeJS.ProcessEnv = process.env,
-): Promise<ForwardedCredentials | undefined> {
-  const keys = (await getRemote()).forwardedCredentialKeys();
-  const credentials: ForwardedCredentials = {};
+): Promise<ForwardedEnv | undefined> {
+  const keys = (await getRemote()).forwardedEnvKeys();
+  const forwardedEnv: ForwardedEnv = {};
   for (const key of keys) {
     const value = env[key];
     if (typeof value === "string" && value.length > 0) {
-      credentials[key] = value;
+      forwardedEnv[key] = value;
     }
   }
-  return Object.keys(credentials).length > 0 ? credentials : undefined;
+  return Object.keys(forwardedEnv).length > 0 ? forwardedEnv : undefined;
 }
 
 /**
- * Stable, secret-free fingerprint of a forwarded credential set, used only to
- * detect whether the caller's credentials changed between requests (so a cold
+ * Stable, secret-free fingerprint of a forwarded env set, used only to
+ * detect whether the caller's forwarded env changed between requests (so a cold
  * session can bust its cached init-failure backoff and retry with the new key).
  * Hashing keeps the raw key out of any retained field. Iterates the received
  * object's own keys — the client already filtered to the forwardable set — so
  * this carries no literal key names. Returns "" for an empty/absent set.
  */
-export function credentialSignature(
-  credentials: ForwardedCredentials | undefined,
+export function forwardedEnvSignature(
+  forwardedEnv: ForwardedEnv | undefined,
 ): string {
-  if (!credentials) return "";
-  const entries = Object.entries(credentials)
+  if (!forwardedEnv) return "";
+  const entries = Object.entries(forwardedEnv)
     .filter(([, value]) => typeof value === "string" && value.length > 0)
     .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
   if (entries.length === 0) return "";

--- a/packages/cli/src/lib/driver/daemon/protocol.ts
+++ b/packages/cli/src/lib/driver/daemon/protocol.ts
@@ -4,6 +4,9 @@ import { DriverCommandNameSchema } from "../commands/types.js";
 
 const RequestBaseSchema = z.object({
   id: z.string().min(1),
+  // Credentials forwarded from the caller's env so a key set after the daemon
+  // started is still honored. See ./credentials.ts.
+  credentials: z.record(z.string(), z.string()).optional(),
 });
 
 export const OpenRequestSchema = RequestBaseSchema.extend({

--- a/packages/cli/src/lib/driver/daemon/protocol.ts
+++ b/packages/cli/src/lib/driver/daemon/protocol.ts
@@ -4,9 +4,9 @@ import { DriverCommandNameSchema } from "../commands/types.js";
 
 const RequestBaseSchema = z.object({
   id: z.string().min(1),
-  // Credentials forwarded from the caller's env so a key set after the daemon
-  // started is still honored. See ./credentials.ts.
-  credentials: z.record(z.string(), z.string()).optional(),
+  // Env vars forwarded from the caller's env so a key set after the daemon
+  // started is still honored. See ./forwarded-env.ts.
+  forwardedEnv: z.record(z.string(), z.string()).optional(),
 });
 
 export const OpenRequestSchema = RequestBaseSchema.extend({

--- a/packages/cli/src/lib/driver/daemon/server.ts
+++ b/packages/cli/src/lib/driver/daemon/server.ts
@@ -132,6 +132,7 @@ async function handleLine(
 
   try {
     if (request.type === "open") {
+      manager.applyForwardedCredentials(request.credentials);
       await writeResponse(socket, {
         data: await manager.execute("open", {
           timeoutMs: request.timeoutMs,
@@ -145,6 +146,7 @@ async function handleLine(
     }
 
     if (request.type === "command") {
+      manager.applyForwardedCredentials(request.credentials);
       await writeResponse(socket, {
         data: await manager.execute(request.command, request.params),
         id: request.id,

--- a/packages/cli/src/lib/driver/daemon/server.ts
+++ b/packages/cli/src/lib/driver/daemon/server.ts
@@ -132,7 +132,7 @@ async function handleLine(
 
   try {
     if (request.type === "open") {
-      manager.applyForwardedCredentials(request.credentials);
+      manager.applyForwardedEnv(request.forwardedEnv);
       await writeResponse(socket, {
         data: await manager.execute("open", {
           timeoutMs: request.timeoutMs,
@@ -146,7 +146,7 @@ async function handleLine(
     }
 
     if (request.type === "command") {
-      manager.applyForwardedCredentials(request.credentials);
+      manager.applyForwardedEnv(request.forwardedEnv);
       await writeResponse(socket, {
         data: await manager.execute(request.command, request.params),
         id: request.id,

--- a/packages/cli/src/lib/driver/remote-types.ts
+++ b/packages/cli/src/lib/driver/remote-types.ts
@@ -1,5 +1,6 @@
 import type { Stagehand } from "@browserbasehq/stagehand";
 
+import type { ForwardedCredentials } from "./daemon/credentials.js";
 import type { DriverModeFlags } from "./mode.js";
 import type { ConnectionTarget } from "./types.js";
 
@@ -42,8 +43,20 @@ export interface RemoteCapability {
   resolveExplicitRemoteTarget(flags: DriverModeFlags): ConnectionTarget;
   /** Auto-select remote when an API key is present; null otherwise. */
   autoSelectRemoteTarget(): ConnectionTarget | null;
-  /** Stagehand options for a remote (BROWSERBASE) session. */
-  remoteStagehandOptions(): Promise<StagehandConstructorOptions>;
+  /**
+   * Env var names the client forwards to a running daemon (e.g. the API key)
+   * so a key set after the daemon started is honored. Empty in the local-only
+   * build, which never reaches the cloud.
+   */
+  forwardedCredentialKeys(): readonly string[];
+  /**
+   * Stagehand options for a remote (BROWSERBASE) session. Forwarded
+   * credentials (if any) are threaded into the constructor here so a key set
+   * after the daemon started is honored without touching `process.env`.
+   */
+  remoteStagehandOptions(
+    credentials?: ForwardedCredentials,
+  ): Promise<StagehandConstructorOptions>;
   /** Map a failed remote `stagehand.init()` to an actionable message + code. */
   classifyRemoteInitError(error: unknown): RemoteInitErrorClassification;
   /** Remediation strings for driver init failures. */

--- a/packages/cli/src/lib/driver/remote-types.ts
+++ b/packages/cli/src/lib/driver/remote-types.ts
@@ -1,6 +1,6 @@
 import type { Stagehand } from "@browserbasehq/stagehand";
 
-import type { ForwardedCredentials } from "./daemon/credentials.js";
+import type { ForwardedEnv } from "./daemon/forwarded-env.js";
 import type { DriverModeFlags } from "./mode.js";
 import type { ConnectionTarget, RemoteConnectionTarget } from "./types.js";
 
@@ -48,16 +48,16 @@ export interface RemoteCapability {
    * so a key set after the daemon started is honored. Empty in the local-only
    * build, which never reaches the cloud.
    */
-  forwardedCredentialKeys(): readonly string[];
+  forwardedEnvKeys(): readonly string[];
   /**
    * Stagehand options for a remote (BROWSERBASE) session. The target carries
-   * the optional verified/proxies flags. Forwarded credentials (if any) are
+   * the optional verified/proxies flags. Forwarded env vars (if any) are
    * threaded into the constructor here so a key set after the daemon started is
    * honored without touching `process.env`.
    */
   remoteStagehandOptions(
     target?: RemoteConnectionTarget,
-    credentials?: ForwardedCredentials,
+    forwardedEnv?: ForwardedEnv,
   ): Promise<StagehandConstructorOptions>;
   /** Map a failed remote `stagehand.init()` to an actionable message + code. */
   classifyRemoteInitError(error: unknown): RemoteInitErrorClassification;

--- a/packages/cli/src/lib/driver/remote.disabled.ts
+++ b/packages/cli/src/lib/driver/remote.disabled.ts
@@ -23,14 +23,14 @@ export function autoSelectRemoteTarget(): ConnectionTarget | null {
   return null;
 }
 
-export function forwardedCredentialKeys(): readonly string[] {
+export function forwardedEnvKeys(): readonly string[] {
   // The local-only build never reaches the cloud, so there is nothing to
   // forward — and no API-key names may appear in this artifact.
   return [];
 }
 
 export async function remoteStagehandOptions(): Promise<StagehandConstructorOptions> {
-  // Accepts the forwarded-credentials arg structurally (fewer params is
+  // Accepts the forwarded-env arg structurally (fewer params is
   // assignable) without naming it, keeping this stub key-name-free.
   throw new Error(DISABLED_MESSAGE);
 }

--- a/packages/cli/src/lib/driver/remote.disabled.ts
+++ b/packages/cli/src/lib/driver/remote.disabled.ts
@@ -23,7 +23,15 @@ export function autoSelectRemoteTarget(): ConnectionTarget | null {
   return null;
 }
 
+export function forwardedCredentialKeys(): readonly string[] {
+  // The local-only build never reaches the cloud, so there is nothing to
+  // forward — and no API-key names may appear in this artifact.
+  return [];
+}
+
 export async function remoteStagehandOptions(): Promise<StagehandConstructorOptions> {
+  // Accepts the forwarded-credentials arg structurally (fewer params is
+  // assignable) without naming it, keeping this stub key-name-free.
   throw new Error(DISABLED_MESSAGE);
 }
 

--- a/packages/cli/src/lib/driver/remote.ts
+++ b/packages/cli/src/lib/driver/remote.ts
@@ -5,6 +5,7 @@ import {
   resolveInstallId,
   toMetadataValue,
 } from "../identity.js";
+import type { ForwardedCredentials } from "./daemon/credentials.js";
 import type {
   DriverInitHints,
   RemoteDoctorResult,
@@ -27,8 +28,26 @@ export function autoSelectRemoteTarget(): ConnectionTarget | null {
   return process.env.BROWSERBASE_API_KEY ? { kind: "remote" } : null;
 }
 
-export async function remoteStagehandOptions(): Promise<StagehandConstructorOptions> {
-  const apiKey = process.env.BROWSERBASE_API_KEY;
+/**
+ * Credentials the client forwards to a running daemon. Only the API key needs
+ * forwarding: the Browserbase backend infers the project from the key, so a
+ * project id is not required for session creation. (A multi-project key that
+ * wants to pin a non-default project via BROWSERBASE_PROJECT_ID is a rare edge
+ * case; that still resolves from the daemon's own env, not the forwarded set.)
+ */
+export function forwardedCredentialKeys(): readonly string[] {
+  return ["BROWSERBASE_API_KEY"];
+}
+
+export async function remoteStagehandOptions(
+  credentials?: ForwardedCredentials,
+): Promise<StagehandConstructorOptions> {
+  // Prefer the caller's forwarded key; fall back to the daemon's own spawn-time
+  // env (e.g. a daemon that was started with a key). Threading the value here
+  // avoids writing the key back into the daemon's `process.env`. The project id
+  // is left to Stagehand to resolve (constructor opt → env → inferred from key).
+  const apiKey =
+    credentials?.BROWSERBASE_API_KEY ?? process.env.BROWSERBASE_API_KEY;
   if (!apiKey) {
     throw new Error(
       "Missing BROWSERBASE_API_KEY for remote mode. Pass --local to run a managed local browser (no key needed), or set BROWSERBASE_API_KEY for cloud sessions.",

--- a/packages/cli/src/lib/driver/remote.ts
+++ b/packages/cli/src/lib/driver/remote.ts
@@ -5,7 +5,7 @@ import {
   resolveInstallId,
   toMetadataValue,
 } from "../identity.js";
-import type { ForwardedCredentials } from "./daemon/credentials.js";
+import type { ForwardedEnv } from "./daemon/forwarded-env.js";
 import type { DriverModeFlags } from "./mode.js";
 import type {
   DriverInitHints,
@@ -36,26 +36,26 @@ export function autoSelectRemoteTarget(): ConnectionTarget | null {
 }
 
 /**
- * Credentials the client forwards to a running daemon. Only the API key needs
+ * Env vars the client forwards to a running daemon. Only the API key needs
  * forwarding: the Browserbase backend infers the project from the key, so a
  * project id is not required for session creation. (A multi-project key that
  * wants to pin a non-default project via BROWSERBASE_PROJECT_ID is a rare edge
  * case; that still resolves from the daemon's own env, not the forwarded set.)
  */
-export function forwardedCredentialKeys(): readonly string[] {
+export function forwardedEnvKeys(): readonly string[] {
   return ["BROWSERBASE_API_KEY"];
 }
 
 export async function remoteStagehandOptions(
   target?: RemoteConnectionTarget,
-  credentials?: ForwardedCredentials,
+  forwardedEnv?: ForwardedEnv,
 ): Promise<StagehandConstructorOptions> {
   // Prefer the caller's forwarded key; fall back to the daemon's own spawn-time
   // env (e.g. a daemon that was started with a key). Threading the value here
   // avoids writing the key back into the daemon's `process.env`. The project id
   // is left to Stagehand to resolve (constructor opt → env → inferred from key).
   const apiKey =
-    credentials?.BROWSERBASE_API_KEY ?? process.env.BROWSERBASE_API_KEY;
+    forwardedEnv?.BROWSERBASE_API_KEY ?? process.env.BROWSERBASE_API_KEY;
   if (!apiKey) {
     throw new Error(
       "Missing BROWSERBASE_API_KEY for remote mode. Pass --local to run a managed local browser (no key needed), or set BROWSERBASE_API_KEY for cloud sessions.",

--- a/packages/cli/src/lib/driver/session-manager.ts
+++ b/packages/cli/src/lib/driver/session-manager.ts
@@ -8,9 +8,9 @@ import {
 import { executeDriverCommand } from "./commands/registry.js";
 import type { DriverCommandName } from "./commands/types.js";
 import {
-  credentialSignature,
-  type ForwardedCredentials,
-} from "./daemon/credentials.js";
+  forwardedEnvSignature,
+  type ForwardedEnv,
+} from "./daemon/forwarded-env.js";
 import { DriverError } from "./errors.js";
 import { discoverLocalCdp } from "./local-cdp-discovery.js";
 import { NetworkCapture } from "./network-capture.js";
@@ -71,8 +71,8 @@ export class DriverSessionManager {
 
   private consecutiveInitFailures = 0;
   private context: DriverContext | null = null;
-  private lastCredentialSignature: string | null = null;
-  private pendingCredentials: ForwardedCredentials | undefined;
+  private lastForwardedEnvSignature: string | null = null;
+  private pendingEnv: ForwardedEnv | undefined;
   private initFailure: InitFailure | null = null;
   private initPromise: Promise<void> | null = null;
   private refMaps: RefMaps = emptyRefMaps();
@@ -98,29 +98,27 @@ export class DriverSessionManager {
   }
 
   /**
-   * Apply credentials forwarded by the client (e.g. an inline or exported API
+   * Apply env vars forwarded by the client (e.g. an inline or exported API
    * key set after the daemon started). Honoring a late key without a manual
    * restart is the whole point of forwarding.
    *
-   * The credentials are stashed for the next `init()`, which threads them
+   * The forwarded env is stashed for the next `init()`, which threads it
    * straight into the Stagehand constructor — never into `process.env` — so the
    * key's only home is the live session. A live, already-initialized session
-   * keeps its existing browser (credentials only matter at init), so the
-   * warm-daemon fast path is untouched. When the credentials change *before* a
-   * successful init (the common case: a first key-less `open` failed, then a
+   * keeps its existing browser (forwarded env only matters at init), so the
+   * warm-daemon fast path is untouched. When the forwarded env changes *before*
+   * a successful init (the common case: a first key-less `open` failed, then a
    * key is supplied), clear the cached init failure and backoff so the retry
    * runs immediately with the new key instead of replaying the stale
    * missing-key error.
    */
-  applyForwardedCredentials(
-    credentials: ForwardedCredentials | undefined,
-  ): void {
-    // Keep the caller's latest credentials available to the next init.
-    this.pendingCredentials = credentials;
+  applyForwardedEnv(forwardedEnv: ForwardedEnv | undefined): void {
+    // Keep the caller's latest forwarded env available to the next init.
+    this.pendingEnv = forwardedEnv;
 
-    const signature = credentialSignature(credentials);
-    if (signature === this.lastCredentialSignature) return;
-    this.lastCredentialSignature = signature;
+    const signature = forwardedEnvSignature(forwardedEnv);
+    if (signature === this.lastForwardedEnvSignature) return;
+    this.lastForwardedEnvSignature = signature;
 
     if (this.stagehand && this.context) return;
     this.initFailure = null;
@@ -404,7 +402,7 @@ export class DriverSessionManager {
     if (target.kind === "remote") {
       return await (
         await getRemote()
-      ).remoteStagehandOptions(target, this.pendingCredentials);
+      ).remoteStagehandOptions(target, this.pendingEnv);
     }
 
     if (target.kind === "managed-local") {

--- a/packages/cli/src/lib/driver/session-manager.ts
+++ b/packages/cli/src/lib/driver/session-manager.ts
@@ -7,6 +7,10 @@ import {
 } from "./commands/selectors.js";
 import { executeDriverCommand } from "./commands/registry.js";
 import type { DriverCommandName } from "./commands/types.js";
+import {
+  credentialSignature,
+  type ForwardedCredentials,
+} from "./daemon/credentials.js";
 import { DriverError } from "./errors.js";
 import { discoverLocalCdp } from "./local-cdp-discovery.js";
 import { NetworkCapture } from "./network-capture.js";
@@ -66,6 +70,8 @@ export class DriverSessionManager {
 
   private consecutiveInitFailures = 0;
   private context: DriverContext | null = null;
+  private lastCredentialSignature: string | null = null;
+  private pendingCredentials: ForwardedCredentials | undefined;
   private initFailure: InitFailure | null = null;
   private initPromise: Promise<void> | null = null;
   private refMaps: RefMaps = emptyRefMaps();
@@ -88,6 +94,36 @@ export class DriverSessionManager {
     params?: unknown,
   ): Promise<unknown> {
     return executeDriverCommand(this, command, params);
+  }
+
+  /**
+   * Apply credentials forwarded by the client (e.g. an inline or exported API
+   * key set after the daemon started). Honoring a late key without a manual
+   * restart is the whole point of forwarding.
+   *
+   * The credentials are stashed for the next `init()`, which threads them
+   * straight into the Stagehand constructor — never into `process.env` — so the
+   * key's only home is the live session. A live, already-initialized session
+   * keeps its existing browser (credentials only matter at init), so the
+   * warm-daemon fast path is untouched. When the credentials change *before* a
+   * successful init (the common case: a first key-less `open` failed, then a
+   * key is supplied), clear the cached init failure and backoff so the retry
+   * runs immediately with the new key instead of replaying the stale
+   * missing-key error.
+   */
+  applyForwardedCredentials(
+    credentials: ForwardedCredentials | undefined,
+  ): void {
+    // Keep the caller's latest credentials available to the next init.
+    this.pendingCredentials = credentials;
+
+    const signature = credentialSignature(credentials);
+    if (signature === this.lastCredentialSignature) return;
+    this.lastCredentialSignature = signature;
+
+    if (this.stagehand && this.context) return;
+    this.initFailure = null;
+    this.consecutiveInitFailures = 0;
   }
 
   async activePage(): Promise<DriverPage> {
@@ -339,7 +375,9 @@ export class DriverSessionManager {
     target: ConnectionTarget,
   ): Promise<ConstructorParameters<typeof Stagehand>[0]> {
     if (target.kind === "remote") {
-      return await (await getRemote()).remoteStagehandOptions();
+      return await (
+        await getRemote()
+      ).remoteStagehandOptions(this.pendingCredentials);
     }
 
     if (target.kind === "managed-local") {

--- a/packages/cli/tests/daemon-forwarded-env-drift.test.ts
+++ b/packages/cli/tests/daemon-forwarded-env-drift.test.ts
@@ -1,0 +1,126 @@
+import { readFile, readdir } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { forwardedEnvKeys } from "../src/lib/driver/remote.js";
+
+/**
+ * Drift guard for daemon/driver-path env reads.
+ *
+ * The daemon is a detached background process: its `process.env` is frozen at
+ * spawn time. Some env vars (the API key) must be *forwarded* from a later
+ * client invocation so a key set after the daemon started is still honored;
+ * others are daemon-local and intentionally NOT forwarded. This test scans the
+ * whole driver path (`src/lib/driver/**`) for `process.env.NAME` reads and
+ * requires every discovered NAME to be explicitly categorized as either
+ * FORWARDED_ENV or DAEMON_LOCAL_ENV below. A new, uncategorized env read fails
+ * this test — forcing the author to make a conscious "forward or not" decision
+ * rather than silently adding a read the daemon can never see updated.
+ */
+
+const driverDir = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../src/lib/driver",
+);
+
+/**
+ * Env vars the daemon forwards from the caller so a value set after the daemon
+ * started is honored. Seeded with the API key; kept in sync with the runtime
+ * source of truth (`forwardedEnvKeys()` in remote.ts) by an assertion below.
+ */
+const FORWARDED_ENV = new Set<string>(["BROWSERBASE_API_KEY"]);
+
+/**
+ * Env vars the driver path reads but intentionally does NOT forward: they are
+ * daemon-local process configuration, not per-client session identity.
+ */
+const DAEMON_LOCAL_ENV = new Set<string>([
+  "BROWSE_DAEMON_DIR",
+  "BROWSE_SESSION",
+]);
+
+/** Matches `process.env.NAME`, `process.env["NAME"]`, and `process.env['NAME']`. */
+const ENV_READ =
+  /process\.env(?:\.([A-Za-z_][A-Za-z0-9_]*)|\[\s*(["'])([A-Za-z_][A-Za-z0-9_]*)\2\s*\])/g;
+
+async function collectTsFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const nested = await Promise.all(
+    entries.map(async (entry) => {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) return collectTsFiles(full);
+      // Only source files; a stray test in this tree must not be scanned.
+      if (entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+        return [full];
+      }
+      return [];
+    }),
+  );
+  return nested.flat().sort();
+}
+
+async function collectEnvReads(): Promise<Map<string, string[]>> {
+  const files = await collectTsFiles(driverDir);
+  const byName = new Map<string, string[]>();
+  for (const file of files) {
+    const contents = await readFile(file, "utf8");
+    for (const match of contents.matchAll(ENV_READ)) {
+      const name = match[1] ?? match[3];
+      if (!name) continue;
+      const rel = file.slice(driverDir.length + 1);
+      const existing = byName.get(name);
+      if (existing) {
+        if (!existing.includes(rel)) existing.push(rel);
+      } else {
+        byName.set(name, [rel]);
+      }
+    }
+  }
+  return byName;
+}
+
+describe("daemon forwarded-env drift guard", () => {
+  it("keeps FORWARDED_ENV in sync with remote.ts forwardedEnvKeys()", () => {
+    expect([...FORWARDED_ENV].sort()).toEqual([...forwardedEnvKeys()].sort());
+  });
+
+  it("declares the two sets as disjoint", () => {
+    const overlap = [...FORWARDED_ENV].filter((name) =>
+      DAEMON_LOCAL_ENV.has(name),
+    );
+    expect(overlap).toEqual([]);
+  });
+
+  it("categorizes every driver-path env read as forwarded or daemon-local", async () => {
+    const reads = await collectEnvReads();
+    // Sanity: the scan must find the seeded reads, else the regex/path drifted.
+    expect(reads.size).toBeGreaterThan(0);
+
+    const uncategorized = [...reads.entries()]
+      .filter(
+        ([name]) => !FORWARDED_ENV.has(name) && !DAEMON_LOCAL_ENV.has(name),
+      )
+      .map(([name, files]) => `${name} (read in: ${files.join(", ")})`);
+
+    expect(
+      uncategorized,
+      uncategorized.length === 0
+        ? undefined
+        : [
+            "New driver-path env read(s) are uncategorized:",
+            ...uncategorized.map((entry) => `  - ${entry}`),
+            "",
+            "The daemon captures process.env once at spawn time, so a new env",
+            "read must be a conscious decision:",
+            "  • If it is per-client session identity that should be honored on a",
+            "    running daemon, add it to forwardedEnvKeys() in",
+            "    src/lib/driver/remote.ts (the FORWARDED_ENV set here stays in",
+            "    sync via the assertion above).",
+            "  • If it is daemon-local process config that must NOT be forwarded,",
+            "    add it to DAEMON_LOCAL_ENV in this test.",
+          ].join("\n"),
+    ).toEqual([]);
+  });
+});

--- a/packages/cli/tests/driver-foundation.test.ts
+++ b/packages/cli/tests/driver-foundation.test.ts
@@ -24,9 +24,9 @@ import {
   openViaDaemon,
 } from "../src/lib/driver/daemon/client.js";
 import {
-  collectClientCredentials,
-  credentialSignature,
-} from "../src/lib/driver/daemon/credentials.js";
+  collectForwardedEnv,
+  forwardedEnvSignature,
+} from "../src/lib/driver/daemon/forwarded-env.js";
 import { runDriverDaemon } from "../src/lib/driver/daemon/server.js";
 import { resolveWsTarget } from "../src/lib/driver/resolve-ws.js";
 import { DriverSessionManager } from "../src/lib/driver/session-manager.js";
@@ -938,10 +938,10 @@ describe("driver foundation", () => {
     );
   });
 
-  it("collects forwardable credentials from the caller's env", async () => {
+  it("collects forwardable env vars from the caller's env", async () => {
     // Only the API key is forwarded; the project is inferred from the key.
     await expect(
-      collectClientCredentials({
+      collectForwardedEnv({
         BROWSERBASE_API_KEY: "client-key",
         BROWSERBASE_PROJECT_ID: "client-project",
         UNRELATED: "ignored",
@@ -949,28 +949,28 @@ describe("driver foundation", () => {
     ).resolves.toEqual({
       BROWSERBASE_API_KEY: "client-key",
     });
-    await expect(collectClientCredentials({})).resolves.toBeUndefined();
+    await expect(collectForwardedEnv({})).resolves.toBeUndefined();
     await expect(
-      collectClientCredentials({ BROWSERBASE_API_KEY: "" }),
+      collectForwardedEnv({ BROWSERBASE_API_KEY: "" }),
     ).resolves.toBeUndefined();
   });
 
-  it("produces a stable, secret-free credential signature", () => {
-    const sig = credentialSignature({ BROWSERBASE_API_KEY: "forwarded-key" });
+  it("produces a stable, secret-free forwarded-env signature", () => {
+    const sig = forwardedEnvSignature({ BROWSERBASE_API_KEY: "forwarded-key" });
     // A non-empty hash that does not leak the raw key value.
     expect(sig).toMatch(/^[a-f0-9]{64}$/);
     expect(sig).not.toContain("forwarded-key");
     // Stable for the same input, distinct for a different key.
-    expect(credentialSignature({ BROWSERBASE_API_KEY: "forwarded-key" })).toBe(
-      sig,
-    );
-    expect(credentialSignature({ BROWSERBASE_API_KEY: "other-key" })).not.toBe(
-      sig,
-    );
+    expect(
+      forwardedEnvSignature({ BROWSERBASE_API_KEY: "forwarded-key" }),
+    ).toBe(sig);
+    expect(
+      forwardedEnvSignature({ BROWSERBASE_API_KEY: "other-key" }),
+    ).not.toBe(sig);
     // Empty / absent sets collapse to "".
-    expect(credentialSignature(undefined)).toBe("");
-    expect(credentialSignature({})).toBe("");
-    expect(credentialSignature({ BROWSERBASE_API_KEY: "" })).toBe("");
+    expect(forwardedEnvSignature(undefined)).toBe("");
+    expect(forwardedEnvSignature({})).toBe("");
+    expect(forwardedEnvSignature({ BROWSERBASE_API_KEY: "" })).toBe("");
   });
 
   it("retries init with a forwarded key after a key-less failure", async () => {
@@ -989,7 +989,7 @@ describe("driver foundation", () => {
 
     // A new key forwarded before init clears the cached failure so the retry
     // runs immediately instead of replaying the stale error.
-    manager.applyForwardedCredentials({ BROWSERBASE_API_KEY: "late-key" });
+    manager.applyForwardedEnv({ BROWSERBASE_API_KEY: "late-key" });
     expect(
       (manager as unknown as { initFailure: unknown }).initFailure,
     ).toBeNull();
@@ -999,35 +999,34 @@ describe("driver foundation", () => {
     ).toBe(0);
     // The key is stashed for the next init (threaded into the constructor),
     // never written back into process.env.
-    expect(
-      (manager as unknown as { pendingCredentials: unknown })
-        .pendingCredentials,
-    ).toEqual({ BROWSERBASE_API_KEY: "late-key" });
+    expect((manager as unknown as { pendingEnv: unknown }).pendingEnv).toEqual({
+      BROWSERBASE_API_KEY: "late-key",
+    });
     expect(process.env.BROWSERBASE_API_KEY).not.toBe("late-key");
     expect(
-      (manager as unknown as { lastCredentialSignature: string })
-        .lastCredentialSignature,
-    ).toBe(credentialSignature({ BROWSERBASE_API_KEY: "late-key" }));
+      (manager as unknown as { lastForwardedEnvSignature: string })
+        .lastForwardedEnvSignature,
+    ).toBe(forwardedEnvSignature({ BROWSERBASE_API_KEY: "late-key" }));
 
-    // Re-applying the same credentials is a no-op (idempotent).
+    // Re-applying the same forwarded env is a no-op (idempotent).
     Object.assign(manager, {
       initFailure: { error: new Error("x"), retryAt: Date.now() + 60_000 },
     });
-    manager.applyForwardedCredentials({ BROWSERBASE_API_KEY: "late-key" });
+    manager.applyForwardedEnv({ BROWSERBASE_API_KEY: "late-key" });
     expect(
       (manager as unknown as { initFailure: unknown }).initFailure,
     ).not.toBeNull();
   });
 
-  it("does not disturb an already-initialized session when credentials change", () => {
+  it("does not disturb an already-initialized session when forwarded env changes", () => {
     const manager = new DriverSessionManager("warm-session", {
       kind: "remote",
     });
     Object.assign(manager, { stagehand: {}, context: {} });
 
-    manager.applyForwardedCredentials({ BROWSERBASE_API_KEY: "new-key" });
+    manager.applyForwardedEnv({ BROWSERBASE_API_KEY: "new-key" });
 
-    // The warm session is preserved: forwarded credentials only matter at init.
+    // The warm session is preserved: forwarded env only matters at init.
     expect(
       (manager as unknown as { stagehand: unknown }).stagehand,
     ).not.toBeNull();

--- a/packages/cli/tests/driver-foundation.test.ts
+++ b/packages/cli/tests/driver-foundation.test.ts
@@ -23,6 +23,10 @@ import {
   getDriverStatus,
   openViaDaemon,
 } from "../src/lib/driver/daemon/client.js";
+import {
+  collectClientCredentials,
+  credentialSignature,
+} from "../src/lib/driver/daemon/credentials.js";
 import { runDriverDaemon } from "../src/lib/driver/daemon/server.js";
 import { resolveWsTarget } from "../src/lib/driver/resolve-ws.js";
 import { DriverSessionManager } from "../src/lib/driver/session-manager.js";
@@ -861,6 +865,102 @@ describe("driver foundation", () => {
     await expect(manager.open("https://example.com")).rejects.toThrow(
       "Target missing-target was not found in the attached browser.",
     );
+  });
+
+  it("collects forwardable credentials from the caller's env", async () => {
+    // Only the API key is forwarded; the project is inferred from the key.
+    await expect(
+      collectClientCredentials({
+        BROWSERBASE_API_KEY: "client-key",
+        BROWSERBASE_PROJECT_ID: "client-project",
+        UNRELATED: "ignored",
+      }),
+    ).resolves.toEqual({
+      BROWSERBASE_API_KEY: "client-key",
+    });
+    await expect(collectClientCredentials({})).resolves.toBeUndefined();
+    await expect(
+      collectClientCredentials({ BROWSERBASE_API_KEY: "" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("produces a stable, secret-free credential signature", () => {
+    const sig = credentialSignature({ BROWSERBASE_API_KEY: "forwarded-key" });
+    // A non-empty hash that does not leak the raw key value.
+    expect(sig).toMatch(/^[a-f0-9]{64}$/);
+    expect(sig).not.toContain("forwarded-key");
+    // Stable for the same input, distinct for a different key.
+    expect(credentialSignature({ BROWSERBASE_API_KEY: "forwarded-key" })).toBe(
+      sig,
+    );
+    expect(credentialSignature({ BROWSERBASE_API_KEY: "other-key" })).not.toBe(
+      sig,
+    );
+    // Empty / absent sets collapse to "".
+    expect(credentialSignature(undefined)).toBe("");
+    expect(credentialSignature({})).toBe("");
+    expect(credentialSignature({ BROWSERBASE_API_KEY: "" })).toBe("");
+  });
+
+  it("retries init with a forwarded key after a key-less failure", async () => {
+    const manager = new DriverSessionManager("forwarded-key-retry", {
+      kind: "remote",
+    });
+
+    // Simulate the repro: the first key-less init failed and cached a backoff.
+    Object.assign(manager, {
+      consecutiveInitFailures: 1,
+      initFailure: {
+        error: new Error("Missing key"),
+        retryAt: Date.now() + 60_000,
+      },
+    });
+
+    // A new key forwarded before init clears the cached failure so the retry
+    // runs immediately instead of replaying the stale error.
+    manager.applyForwardedCredentials({ BROWSERBASE_API_KEY: "late-key" });
+    expect(
+      (manager as unknown as { initFailure: unknown }).initFailure,
+    ).toBeNull();
+    expect(
+      (manager as unknown as { consecutiveInitFailures: number })
+        .consecutiveInitFailures,
+    ).toBe(0);
+    // The key is stashed for the next init (threaded into the constructor),
+    // never written back into process.env.
+    expect(
+      (manager as unknown as { pendingCredentials: unknown })
+        .pendingCredentials,
+    ).toEqual({ BROWSERBASE_API_KEY: "late-key" });
+    expect(process.env.BROWSERBASE_API_KEY).not.toBe("late-key");
+    expect(
+      (manager as unknown as { lastCredentialSignature: string })
+        .lastCredentialSignature,
+    ).toBe(credentialSignature({ BROWSERBASE_API_KEY: "late-key" }));
+
+    // Re-applying the same credentials is a no-op (idempotent).
+    Object.assign(manager, {
+      initFailure: { error: new Error("x"), retryAt: Date.now() + 60_000 },
+    });
+    manager.applyForwardedCredentials({ BROWSERBASE_API_KEY: "late-key" });
+    expect(
+      (manager as unknown as { initFailure: unknown }).initFailure,
+    ).not.toBeNull();
+  });
+
+  it("does not disturb an already-initialized session when credentials change", () => {
+    const manager = new DriverSessionManager("warm-session", {
+      kind: "remote",
+    });
+    Object.assign(manager, { stagehand: {}, context: {} });
+
+    manager.applyForwardedCredentials({ BROWSERBASE_API_KEY: "new-key" });
+
+    // The warm session is preserved: forwarded credentials only matter at init.
+    expect(
+      (manager as unknown as { stagehand: unknown }).stagehand,
+    ).not.toBeNull();
+    expect((manager as unknown as { context: unknown }).context).not.toBeNull();
   });
 });
 

--- a/packages/cli/tests/remote-disabled.test.ts
+++ b/packages/cli/tests/remote-disabled.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   autoSelectRemoteTarget,
-  forwardedCredentialKeys,
+  forwardedEnvKeys,
   remoteDoctorCheck,
   remoteStagehandOptions,
   resolveExplicitRemoteTarget,
@@ -30,8 +30,8 @@ describe("remote.disabled (local-only capability)", () => {
     expect(result.message).toMatch(/disabled/i);
   });
 
-  it("forwards no credential keys (local-only never reaches the cloud)", () => {
-    expect(forwardedCredentialKeys()).toEqual([]);
+  it("forwards no env keys (local-only never reaches the cloud)", () => {
+    expect(forwardedEnvKeys()).toEqual([]);
   });
 
   it("contains no BROWSERBASE_API_KEY reference in its source", async () => {

--- a/packages/cli/tests/remote-disabled.test.ts
+++ b/packages/cli/tests/remote-disabled.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   autoSelectRemoteTarget,
+  forwardedCredentialKeys,
   remoteDoctorCheck,
   remoteStagehandOptions,
   resolveExplicitRemoteTarget,
@@ -27,6 +28,10 @@ describe("remote.disabled (local-only capability)", () => {
     const result = remoteDoctorCheck();
     expect(result.ok).toBe(true);
     expect(result.message).toMatch(/disabled/i);
+  });
+
+  it("forwards no credential keys (local-only never reaches the cloud)", () => {
+    expect(forwardedCredentialKeys()).toEqual([]);
   });
 
   it("contains no BROWSERBASE_API_KEY reference in its source", async () => {


### PR DESCRIPTION
## TL;DR

`BROWSERBASE_API_KEY=xxx browse open <url> --remote` was **silently ignored** when the driver daemon was already running, so the CLI kept printing `Missing BROWSERBASE_API_KEY`. The daemon froze a copy of `process.env` at spawn time and never saw the late key. Fix: the client now **forwards the key with every command**, and the daemon **threads it straight into the Stagehand session at init** — no restart, no `browse stop`, warm sessions untouched.

Closes STG-2407. Reported via the partner AX update (partner-2027dev, Jun 22); confirmed still live on `main`.

---

## Symptom

```console
$ browse open https://example.com --remote          # no key set → starts the daemon, fails
Missing BROWSERBASE_API_KEY

$ BROWSERBASE_API_KEY=bb_live_… browse open https://example.com --remote   # key set, SAME daemon
Missing BROWSERBASE_API_KEY                          # ❌ ignored — only `browse stop` + retry worked
```

This burns 3–4 retries per session and blocks the documented recover-after-interruption flow.

## Root cause

The CLI is a thin client that talks to a long-lived background **daemon** (which holds the warm browser session). The key never reached that daemon:

1. **Frozen env.** The daemon is spawned `detached` with `env: process.env` captured **once** at spawn time (`daemon/client.ts`). A key exported/inlined in a *later* shell never propagates to it.
2. **Key read daemon-side.** The remote session is created inside the daemon, which read `process.env.BROWSERBASE_API_KEY` *there* (`remote.ts` → `session-manager.ts`).
3. **Protocol carried no credentials.** Requests had no way to deliver a key to an already-running daemon (`daemon/protocol.ts`). Since `--remote` is explicit, the client never blocked on the key — so it happily started a doomed key-less daemon.
4. **Stale backoff.** A cached init-failure backoff (5s→60s) replayed the *old* "missing key" error even on an immediate retry.

## The fix

**Make the client the source of truth for the key; never trust the daemon's frozen env.**

```
 client (fresh env each call)                      daemon (long-lived)
 ────────────────────────────                      ───────────────────
 collectForwardedEnv()       ──{API_KEY}──▶        stash on session manager
   reads caller's env, over the owner-only socket    │
                                                     ▼  at init only:
                                                   remoteStagehandOptions(forwardedEnv)
                                                     └▶ new Stagehand({ apiKey })
                                                          (key's only home = live session;
                                                           never written back to process.env)
```

- **`daemon/forwarded-env.ts`** (new) — `collectForwardedEnv()` reads the caller's env; `forwardedEnvSignature()` is a secret-free `sha256` fingerprint used only to detect key changes.
- **`protocol.ts` / `client.ts`** — every `open`/`command` request carries the caller's `forwardedEnv`.
- **`server.ts` / `session-manager.ts`** — the daemon threads the forwarded key **into the Stagehand constructor at init**. It is **never written into the daemon's `process.env`**. When the fingerprint changes on a *cold* session, the stale init backoff is cleared so the retry runs immediately.
- **Warm sessions are untouched** — an already-initialized session returns early and keeps its browser; the key only matters at init.

> **Only the API key is forwarded.** The Browserbase backend infers the project from the key, so `BROWSERBASE_PROJECT_ID` isn't needed for session creation — verified end-to-end with no project id set anywhere. (A multi-project key pinning a non-default project via `BROWSERBASE_PROJECT_ID` is a rare edge; that still resolves from the daemon's own env, exactly as before.)

### Naming + drift guard (per review)

The mechanism is named generically as **forwarded env vars**, not "credentials" (`ForwardedEnv`, `collectForwardedEnv` / `applyForwardedEnv` / `forwardedEnvKeys`, request field `forwardedEnv`, module `daemon/forwarded-env.ts`). It stays a **curated allowlist** (today just `BROWSERBASE_API_KEY`) rather than the whole `process.env`, because: (1) `Object.assign`-ing the full env into an already-running daemon silently no-ops for anything its modules read at import; (2) the caller's env also holds the daemon's own operational vars (`PATH`/`HOME`/`BROWSE_DAEMON_DIR`), so forwarding it wholesale risks clobbering the daemon and can't represent an unset; (3) the driver path has no AI ops, so no model keys are ever read — the API key is the only env-delivered session input. A new test, `tests/daemon-forwarded-env-drift.test.ts`, fails if any new daemon-path `process.env` read is left uncategorized (forward vs daemon-local), so the allowlist can't silently drift.

<details>
<summary>Why thread into the constructor instead of writing <code>process.env</code>?</summary>

The key is read exactly once per session (at init); afterward the live `Stagehand` instance holds it. Writing it into the daemon's global env would leave a stray secret with no reader. Threading keeps the credential scoped to the session, and the change-detector is hashed so the raw key isn't kept in a second field. There's no perf cost — forwarding ~100 bytes is free next to cloud session creation; the only thing cached for speed is the warm session, which is independent of the key value.

**Rejected alternatives:** writing the key into the daemon's env (stray secret, one-way env accumulation); auto-restarting the daemon (kills warm sessions, racy); a mere actionable error (the ask is for it to *work*, not just guide).
</details>

## Security contract (local-only build)

`BROWSERBASE_API_KEY` must not appear in the CDP-only artifact. The forwardable-key *list* is capability-gated: `forwardedEnvKeys()` returns the key in the full build (`remote.ts`) and `[]` in `remote.disabled.ts`. `collectForwardedEnv` / `forwardedEnvSignature` iterate the received object's own keys, so they stay key-name-free. Net: the literal lives only in `dist/lib/driver/remote.js`, and `tests/local-only-build.test.ts` still passes.

## Testing

Local full build (`pnpm build`) of the code under review, real Browserbase key, exercising the exact repro against an already-running key-less daemon.

| Step | Command / flow | Result | Proves |
| --- | --- | --- | --- |
| 1 | Key-less `open … --remote` (spawns daemon) | `Missing BROWSERBASE_API_KEY` (daemon stays up) | Reproduces the stranded key-less daemon |
| 2 | Inline `BROWSERBASE_API_KEY=… open … --remote`, **same** daemon, **no project id anywhere** | ✅ `SUCCESS` — `"title": "Example Domain"`, `"url": "https://example.com/"` | The inline key reaches the running daemon (the fix); project inferred from the key |
| 3 | Warm reuse: `open https://www.iana.org --remote` | ✅ `SUCCESS` — `"Internet Assigned Numbers Authority"`, same `targetId` | Warm-session fast path preserved |
| 4 | `vitest` driver-foundation + remote-disabled + local-only + drift | ✅ 45 pass (4 files) | Unit coverage; asserts the key is **not** written to `process.env` |
| 5 | `tsc -p tsconfig.local-only.json` + local-only-build test | ✅ typecheck clean | Security contract held (no key name in CDP-only build) |
| 6 | `pnpm lint` | ✅ format + eslint + tsc clean | No regressions |
| 7 | Drift guard: inject an uncategorized `process.env.X` on the daemon path | ✅ test goes red with "forward vs daemon-local" guidance, green after revert | The guard is non-vacuous — a new daemon-path env read can't slip through |

## Follow-ups (not in this PR)

- **`browse open` ECONNREFUSED** (also AX-flagged): `sendDriverRequest` (`client.ts`) has no connect-retry, so a transient `ECONNREFUSED`/`ENOENT` (stale socket / daemon mid-shutdown) propagates raw. Couldn't reproduce under load — tracking separately rather than shipping unverified.
- **Fail-fast `--remote` guard** (defense in depth): make explicit `--remote` resolve the key client-side like `autoSelectRemoteTarget` already does, so a key-less first call fails fast instead of spawning a doomed daemon. Forwarding alone fixes the reported bug; the guard would just improve the first-call error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

