### PR TITLE
[STG-2408] feat(cli): default local managed sessions to headed when run interactively

### DIFF
--- a/.changeset/cli-headed-default-when-interactive.md
+++ b/.changeset/cli-headed-default-when-interactive.md
@@ -1,0 +1,5 @@
+---
+"browse": patch
+---
+
+Local managed sessions now default to headed when run interactively with a display; headless for agents/CI/no-display/non-TTY. Pass `--headed`/`--headless` to override.

--- a/.changeset/cli-headed-default-when-interactive.md
+++ b/.changeset/cli-headed-default-when-interactive.md
@@ -3,3 +3,5 @@
 ---
 
 Local managed sessions now default to headed when run interactively with a display; headless for agents/CI/no-display/non-TTY. Pass `--headed`/`--headless` to override.
+
+Telemetry now records the resolved `session_mode` and `headless` choice on `cli.command_completed`, so headed-vs-headless usage is observable.

--- a/packages/cli/src/lib/agent.ts
+++ b/packages/cli/src/lib/agent.ts
@@ -15,3 +15,42 @@ export async function detectAgent(): Promise<string | null> {
     return null;
   }
 }
+
+/**
+ * Synchronous best-effort check for whether the CLI is being driven by a coding
+ * agent (Claude Code, Cursor, Codex, Gemini, etc.) rather than a human at a
+ * terminal.
+ *
+ * This mirrors the env-marker checks used by {@link detectAgent} and
+ * `@vercel/detect-agent`'s `determineAgent`, which are themselves almost
+ * entirely synchronous env reads. We deliberately omit the one async branch in
+ * `determineAgent` (a filesystem probe for Devin) so callers that must stay
+ * synchronous — e.g. headed/headless mode resolution — can use this without
+ * becoming async. The result is used only as a heuristic to bias the default
+ * window mode toward headless for agents; the authoritative async
+ * {@link detectAgent} still drives telemetry.
+ */
+export function isAgentContext(): boolean {
+  const env = process.env;
+  return Boolean(
+    env.HERMES_SESSION_PLATFORM ||
+      env.OPENCLAW_SHELL ||
+      env.AI_AGENT ||
+      env.CURSOR_TRACE_ID ||
+      env.CURSOR_AGENT ||
+      env.CURSOR_EXTENSION_HOST_ROLE === "agent-exec" ||
+      env.GEMINI_CLI ||
+      env.CODEX_SANDBOX ||
+      env.CODEX_CI ||
+      env.CODEX_THREAD_ID ||
+      env.ANTIGRAVITY_AGENT ||
+      env.AUGMENT_AGENT ||
+      env.OPENCODE_CLIENT ||
+      env.CLAUDECODE ||
+      env.CLAUDE_CODE ||
+      env.REPL_ID ||
+      env.COPILOT_MODEL ||
+      env.COPILOT_ALLOW_ALL ||
+      env.COPILOT_GITHUB_TOKEN,
+  );
+}

--- a/packages/cli/src/lib/driver/command-cli.ts
+++ b/packages/cli/src/lib/driver/command-cli.ts
@@ -23,6 +23,7 @@ import {
 } from "./mode.js";
 import type { ConnectionTarget } from "./types.js";
 import { outputJson } from "../output.js";
+import { setRunTelemetryCompletion } from "../run-telemetry.js";
 import { runDriverCommandWithTarget } from "./runtime.js";
 
 export const driverCommandFlags = {
@@ -79,6 +80,19 @@ export async function resolveTargetForCommand(
   session: string,
   flags: DriverFlags,
 ) {
+  const target = await selectTargetForCommand(session, flags);
+  // Record the effective session mode (and, for managed-local, the resolved
+  // headed/headless choice) so it rides along on cli.command_completed. This is
+  // the only place every driver command resolves a target, and it captures the
+  // reused-session case too — i.e. the mode the command actually ran in.
+  setRunTelemetryCompletion({
+    sessionMode: target.kind,
+    ...(target.kind === "managed-local" ? { headless: target.headless } : {}),
+  });
+  return target;
+}
+
+async function selectTargetForCommand(session: string, flags: DriverFlags) {
   const hasExplicitTarget = hasExplicitDriverTarget(flags);
   if (!hasExplicitTarget || hasModeOnlyFlag(flags)) {
     const status = await getDriverStatus(session);

--- a/packages/cli/src/lib/driver/flags.ts
+++ b/packages/cli/src/lib/driver/flags.ts
@@ -8,11 +8,13 @@ export const sessionFlag = Flags.string({
 });
 
 export const headedFlag = Flags.boolean({
-  description: "Show a visible browser window for managed local sessions.",
+  description:
+    "Show a visible browser window for managed local sessions. Managed local sessions default to headed when run interactively with a display; headless otherwise. Use --headless/--headed to force.",
 });
 
 export const headlessFlag = Flags.boolean({
-  description: "Run managed local sessions in headless mode.",
+  description:
+    "Run managed local sessions in headless mode. Managed local sessions default to headed when run interactively with a display; headless otherwise. Use --headless/--headed to force.",
 });
 
 export const localFlag = Flags.boolean({

--- a/packages/cli/src/lib/driver/mode.ts
+++ b/packages/cli/src/lib/driver/mode.ts
@@ -1,5 +1,6 @@
 import { isDeepStrictEqual } from "node:util";
 
+import { isAgentContext } from "../agent.js";
 import { fail } from "../errors.js";
 import { getRemote } from "./remote-binding.js";
 import { resolveWsTarget } from "./resolve-ws.js";
@@ -23,7 +24,7 @@ interface ResolvedChromeArgs {
   ignoreDefaultArgs?: boolean | string[];
 }
 
-function resolveHeadless(
+export function resolveHeadless(
   flags: Pick<DriverModeFlags, "headed" | "headless">,
 ): boolean {
   if (flags.headed && flags.headless) {
@@ -32,7 +33,33 @@ function resolveHeadless(
 
   if (flags.headed) return false;
   if (flags.headless) return true;
+  // no explicit flag → default headed for an interactive human with a display, else headless
+  return !shouldDefaultHeaded();
+}
+
+/**
+ * Decide whether a managed local session should default to a visible (headed)
+ * window when neither --headed nor --headless was passed.
+ *
+ * The "wow moment" of `browse open` is a human watching a real browser drive
+ * itself, so an interactive human at a terminal with a display gets a headed
+ * window. Agents, CI, piped/non-interactive shells, and machines without a
+ * display server stay headless so automation never spawns a stray window or
+ * breaks where no display exists.
+ */
+export function shouldDefaultHeaded(): boolean {
+  if (isAgentContext()) return false; // agent-driven → headless
+  if (!process.stdout.isTTY) return false; // piped / non-interactive / CI → headless
+  if (process.env.CI) return false; // CI → headless
+  if (!hasDisplay()) return false; // no display server → headless
   return true;
+}
+
+export function hasDisplay(): boolean {
+  if (process.platform === "darwin" || process.platform === "win32")
+    return true;
+  // linux/other: require an X11 or Wayland display server
+  return Boolean(process.env.DISPLAY || process.env.WAYLAND_DISPLAY);
 }
 
 export function hasChromeArgFlags(flags: DriverModeFlags): boolean {

--- a/packages/cli/src/lib/driver/mode.ts
+++ b/packages/cli/src/lib/driver/mode.ts
@@ -55,6 +55,15 @@ export function shouldDefaultHeaded(): boolean {
   return true;
 }
 
+/**
+ * Best-effort check for whether a GUI can be shown. On Linux we read the X11 /
+ * Wayland display vars, which is the canonical signal. macOS/Windows have no
+ * such env var, so we assume a display is present — this is right for the
+ * overwhelming common case (a dev on a laptop) but can be a false positive for
+ * a human SSH'd into a headless macOS/Windows box with no console session,
+ * where headed Chrome may fail to launch. That case is rare and recoverable
+ * with an explicit `--headless`; if it shows up in telemetry we can revisit.
+ */
 export function hasDisplay(): boolean {
   if (process.platform === "darwin" || process.platform === "win32")
     return true;

--- a/packages/cli/src/lib/run-telemetry.ts
+++ b/packages/cli/src/lib/run-telemetry.ts
@@ -3,6 +3,10 @@ export interface RunTelemetryState {
   httpStatus?: number;
   requestHadHttpResponse?: boolean;
   skillId?: string;
+  /** Resolved driver session kind, e.g. "managed-local" | "remote" | "cdp". */
+  sessionMode?: string;
+  /** For managed-local sessions, whether the resolved window mode was headless. */
+  headless?: boolean;
 }
 
 let currentRunTelemetry: RunTelemetryState = {};

--- a/packages/cli/src/lib/telemetry.ts
+++ b/packages/cli/src/lib/telemetry.ts
@@ -283,6 +283,8 @@ function commandCompletedProperties(
       runTelemetry.requestHadHttpResponse ??
       null,
     skill_id: runTelemetry.skillId ?? null,
+    session_mode: runTelemetry.sessionMode ?? null,
+    headless: runTelemetry.headless ?? null,
   };
 }
 

--- a/packages/cli/tests/cli-telemetry.test.ts
+++ b/packages/cli/tests/cli-telemetry.test.ts
@@ -65,6 +65,9 @@ describe("CLI telemetry", () => {
       expect(completedPayload.properties.http_status).toBe(null);
       expect(completedPayload.properties.request_had_http_response).toBe(null);
       expect(completedPayload.properties.skill_id).toBe(null);
+      // status is not a driver command, so no session mode is resolved.
+      expect(completedPayload.properties.session_mode).toBe(null);
+      expect(completedPayload.properties.headless).toBe(null);
     } finally {
       await telemetryServer.close();
     }

--- a/packages/cli/tests/driver-commands.test.ts
+++ b/packages/cli/tests/driver-commands.test.ts
@@ -109,6 +109,49 @@ describe("driver commands", () => {
     }
   });
 
+  it("records the resolved session mode and headless choice in run telemetry", async () => {
+    vi.resetModules();
+    // No existing daemon → every command resolves a fresh target, and explicit
+    // --headed/--headless make the resolution display-independent.
+    const getDriverStatus = vi.fn().mockResolvedValue(undefined);
+    vi.doMock("../src/lib/driver/daemon/client.js", () => ({
+      getDriverStatus,
+    }));
+
+    try {
+      const { resolveTargetForCommand } = await import(
+        "../src/lib/driver/command-cli.js"
+      );
+      const { getRunTelemetry, resetRunTelemetry } = await import(
+        "../src/lib/run-telemetry.js"
+      );
+
+      resetRunTelemetry();
+      await resolveTargetForCommand("tele", { headless: true, local: true });
+      expect(getRunTelemetry()).toMatchObject({
+        sessionMode: "managed-local",
+        headless: true,
+      });
+
+      resetRunTelemetry();
+      await resolveTargetForCommand("tele", { headed: true, local: true });
+      expect(getRunTelemetry()).toMatchObject({
+        sessionMode: "managed-local",
+        headless: false,
+      });
+
+      resetRunTelemetry();
+      await resolveTargetForCommand("tele", { remote: true });
+      const remoteTelemetry = getRunTelemetry();
+      expect(remoteTelemetry.sessionMode).toBe("remote");
+      // headless only applies to managed-local; remote leaves it unset.
+      expect(remoteTelemetry.headless).toBeUndefined();
+    } finally {
+      vi.doUnmock("../src/lib/driver/daemon/client.js");
+      vi.resetModules();
+    }
+  });
+
   it("routes CDP targets through the daemon so session state persists", async () => {
     vi.resetModules();
     const ensureDriverDaemon = vi.fn().mockResolvedValue(undefined);

--- a/packages/cli/tests/driver-mode-headed-default.test.ts
+++ b/packages/cli/tests/driver-mode-headed-default.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  hasDisplay,
+  resolveHeadless,
+  shouldDefaultHeaded,
+} from "../src/lib/driver/mode.js";
+
+/**
+ * Tests for the environment-aware headed/headless default introduced for managed
+ * local sessions: a human at an interactive TTY with a display gets a HEADED
+ * window, while agents / CI / piped / no-display contexts stay HEADLESS. Explicit
+ * --headed / --headless always win.
+ */
+
+// Env vars that, if set in the ambient shell, would flip isAgentContext() to true
+// and make the "interactive human" branch impossible to observe. We clear them
+// for the relevant cases and restore afterwards.
+const AGENT_ENV_KEYS = [
+  "HERMES_SESSION_PLATFORM",
+  "OPENCLAW_SHELL",
+  "AI_AGENT",
+  "CURSOR_TRACE_ID",
+  "CURSOR_AGENT",
+  "CURSOR_EXTENSION_HOST_ROLE",
+  "GEMINI_CLI",
+  "CODEX_SANDBOX",
+  "CODEX_CI",
+  "CODEX_THREAD_ID",
+  "ANTIGRAVITY_AGENT",
+  "AUGMENT_AGENT",
+  "OPENCODE_CLIENT",
+  "CLAUDECODE",
+  "CLAUDE_CODE",
+  "REPL_ID",
+  "COPILOT_MODEL",
+  "COPILOT_ALLOW_ALL",
+  "COPILOT_GITHUB_TOKEN",
+] as const;
+
+const DISPLAY_ENV_KEYS = ["DISPLAY", "WAYLAND_DISPLAY"] as const;
+
+const originalPlatform = process.platform;
+const originalIsTTY = process.stdout.isTTY;
+let savedEnv: Record<string, string | undefined> = {};
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", {
+    value: platform,
+    configurable: true,
+  });
+}
+
+function setTTY(value: boolean | undefined): void {
+  Object.defineProperty(process.stdout, "isTTY", {
+    value,
+    configurable: true,
+  });
+}
+
+function clearKeys(keys: readonly string[]): void {
+  for (const key of keys) {
+    delete process.env[key];
+  }
+}
+
+beforeEach(() => {
+  // Snapshot every env key we may mutate so each test starts from a clean,
+  // deterministic baseline regardless of the outer shell (agent, CI, etc.).
+  savedEnv = {};
+  for (const key of [...AGENT_ENV_KEYS, ...DISPLAY_ENV_KEYS, "CI"]) {
+    savedEnv[key] = process.env[key];
+  }
+  clearKeys(AGENT_ENV_KEYS);
+  clearKeys(DISPLAY_ENV_KEYS);
+  delete process.env.CI;
+});
+
+afterEach(() => {
+  setPlatform(originalPlatform);
+  setTTY(originalIsTTY);
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+});
+
+describe("hasDisplay", () => {
+  it("returns true on darwin regardless of DISPLAY", () => {
+    setPlatform("darwin");
+    expect(hasDisplay()).toBe(true);
+  });
+
+  it("returns true on win32 regardless of DISPLAY", () => {
+    setPlatform("win32");
+    expect(hasDisplay()).toBe(true);
+  });
+
+  it("returns false on linux without a display server", () => {
+    setPlatform("linux");
+    expect(hasDisplay()).toBe(false);
+  });
+
+  it("returns true on linux with X11 DISPLAY", () => {
+    setPlatform("linux");
+    process.env.DISPLAY = ":0";
+    expect(hasDisplay()).toBe(true);
+  });
+
+  it("returns true on linux with WAYLAND_DISPLAY", () => {
+    setPlatform("linux");
+    process.env.WAYLAND_DISPLAY = "wayland-0";
+    expect(hasDisplay()).toBe(true);
+  });
+});
+
+describe("shouldDefaultHeaded", () => {
+  it("is true for an interactive human: TTY + display + no CI + no agent (darwin)", () => {
+    setPlatform("darwin");
+    setTTY(true);
+    expect(shouldDefaultHeaded()).toBe(true);
+  });
+
+  it("is true for an interactive human on linux with a display", () => {
+    setPlatform("linux");
+    setTTY(true);
+    process.env.DISPLAY = ":0";
+    expect(shouldDefaultHeaded()).toBe(true);
+  });
+
+  it("is false when stdout is not a TTY (piped / non-interactive)", () => {
+    setPlatform("darwin");
+    setTTY(undefined);
+    expect(shouldDefaultHeaded()).toBe(false);
+  });
+
+  it("is false when CI is set even with a TTY and display", () => {
+    setPlatform("darwin");
+    setTTY(true);
+    process.env.CI = "true";
+    expect(shouldDefaultHeaded()).toBe(false);
+  });
+
+  it("is false on linux without a display even with a TTY", () => {
+    setPlatform("linux");
+    setTTY(true);
+    expect(shouldDefaultHeaded()).toBe(false);
+  });
+
+  it("is false when an agent marker is set even with a TTY and display", () => {
+    setPlatform("darwin");
+    setTTY(true);
+    process.env.CLAUDECODE = "1";
+    expect(shouldDefaultHeaded()).toBe(false);
+  });
+
+  it("treats a falsy CI value (empty string) as not CI", () => {
+    setPlatform("darwin");
+    setTTY(true);
+    process.env.CI = "";
+    expect(shouldDefaultHeaded()).toBe(true);
+  });
+});
+
+describe("resolveHeadless default branch", () => {
+  it("defaults to HEADED for an interactive human (no flags)", () => {
+    setPlatform("darwin");
+    setTTY(true);
+    expect(resolveHeadless({})).toBe(false);
+  });
+
+  it("defaults to HEADLESS when not a TTY (no flags)", () => {
+    setPlatform("darwin");
+    setTTY(undefined);
+    expect(resolveHeadless({})).toBe(true);
+  });
+
+  it("defaults to HEADLESS in CI (no flags)", () => {
+    setPlatform("darwin");
+    setTTY(true);
+    process.env.CI = "1";
+    expect(resolveHeadless({})).toBe(true);
+  });
+
+  it("defaults to HEADLESS for an agent (no flags)", () => {
+    setPlatform("darwin");
+    setTTY(true);
+    process.env.CURSOR_TRACE_ID = "abc";
+    expect(resolveHeadless({})).toBe(true);
+  });
+
+  it("defaults to HEADLESS on linux without a display (no flags)", () => {
+    setPlatform("linux");
+    setTTY(true);
+    expect(resolveHeadless({})).toBe(true);
+  });
+});
+
+describe("resolveHeadless explicit flags still override", () => {
+  it("--headed forces headed even in a headless-default context (non-TTY)", () => {
+    setPlatform("darwin");
+    setTTY(undefined);
+    expect(resolveHeadless({ headed: true })).toBe(false);
+  });
+
+  it("--headless forces headless even in a headed-default context (interactive)", () => {
+    setPlatform("darwin");
+    setTTY(true);
+    expect(resolveHeadless({ headless: true })).toBe(true);
+  });
+
+  it("rejects passing both --headed and --headless", () => {
+    expect(() => resolveHeadless({ headed: true, headless: true })).toThrow(
+      "Pass either --headed or --headless",
+    );
+  });
+});


### PR DESCRIPTION
## What & why

Local managed-browser sessions default to **headless** today — even for a human running `browse open` at their terminal, so they see *nothing*. Watching a real browser drive itself is the activation/"aha" moment (and makes debugging obvious). But "always headed" would break the majority of usage: agents / CI / containers / headless Linux often have **no display server**, where headed Chrome can't launch — and headed steals OS focus (mitigated in #2258).

So: **detect the human, don't flip the global default.**

## The rule

When neither `--headed` nor `--headless` is passed, default to **headed only when run interactively with a display** — otherwise headless. Explicit flags always win.

```ts
shouldDefaultHeaded():
  if (isAgentContext()) return false;        // agent-driven → headless
  if (!process.stdout.isTTY) return false;   // piped / non-interactive / CI → headless
  if (process.env.CI) return false;          // CI → headless
  if (!hasDisplay()) return false;           // no display server → headless
  return true;
// hasDisplay(): darwin/win32 → true; linux/other → DISPLAY || WAYLAND_DISPLAY
```

A dev on a laptop gets a window; agents/CI/scripts stay headless and unbroken.

## Observability (added this round)

We had **no telemetry on headed vs headless** — a 90-day audit of the `cli` PostHog project (8.17M `cli.command_invoked` events) found no property capturing session mode *at all*, so this default would ship blind. This PR closes that gap: `cli.command_completed` now carries

- `session_mode` — the resolved driver kind (`managed-local` | `remote` | `cdp` | `auto-connect`)
- `headless` — for managed-local, the resolved window mode (`true`/`false`; `null` otherwise)

Recorded once at `resolveTargetForCommand` — the single chokepoint every driver command goes through (so it captures reused sessions too: the mode the command *actually ran in*) — via the existing `run-telemetry` accumulator that already feeds `command_completed`. Combined with the existing `agent` and `platform` props, we can now see the headed/headless split by human-vs-agent and OS, and — via `command_completed.success` — whether headed sessions fail to launch more often (the one false positive noted below).

## Design notes / rationale

- **Why agents stay headless even with a display:** the dominant agent traffic is local IDE agents (codex, claude-code) running on a human's own desktop, where a headed window would steal focus on every command. Sandbox agents that *want* headed (e.g. a more realistic fingerprint) can opt in with `--headed`. We deliberately don't auto-flip agents to headed based on display presence — an explicit flag is a guarantee; display-presence is a guess.
- **`hasDisplay()` is the safe primitive, not a hack:** `DISPLAY`/`WAYLAND_DISPLAY` is the canonical X11/Wayland signal, and there's no mature npm lib for it (everyone reads the env var directly). macOS/Windows have no such var, so we assume a display — correct for the common case (laptop dev), with one documented false positive: a human SSH'd into a headless mac/Windows box. Rare, recoverable with `--headless`, and now measurable.
- The default is **conservative by construction**: every gate must pass before going headed, so it fails safe to headless on any doubt — a missed window is a mild letdown; a headed launch that crashes on a server is a real break.

## Implementation notes

- Only the **default branch** of `resolveHeadless` changed (`mode.ts`); explicit `--headed`/`--headless` handling and the both-flags error are untouched, and `resolveHeadless` stays **synchronous**.
- `isAgentContext()` (in `lib/agent.ts`) is a **sync** helper mirroring the env markers the async `detectAgent` keys on (`CLAUDECODE`, `CURSOR_*`, `CODEX_*`, `GEMINI_CLI`, `HERMES_SESSION_PLATFORM`, `OPENCLAW_SHELL`, …), omitting only `detectAgent`'s async Devin filesystem probe — same signal source, no blocking.
- Telemetry: 2 fields added to `RunTelemetryState`; recorded at `resolveTargetForCommand`; emitted in `commandCompletedProperties`. Best-effort — telemetry never affects CLI behavior.

## E2E Test Matrix

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| Real headless session with live telemetry capture: built CLI `open https://example.com --local --headless` → local capture server | `cli.command_completed` payload: `{ session_mode: "managed-local", headless: true, success: true, leaf_command: "open", agent: "claude-code_…" }`; page loaded ("Example Domain") | Proves the new props ride along on a **real** managed-local session end-to-end (real headless Chrome, real PostHog-shaped POST), and that they appear only on `command_completed`, not `command_invoked`. |
| `pnpm test:cli` | **291 passed** (290 baseline + 1 new recording test). New unit test asserts `resolveTargetForCommand` records `session_mode`/`headless` for managed-local **headless**, managed-local **headed** (headless=false), and **remote** (headless unset). | Covers the recording logic across all modes, incl. headed=false — which the headless smoke can't exercise in a non-TTY shell. |
| `cli-telemetry.test.ts` (e2e HTTP capture) | non-driver `status` command → `session_mode: null, headless: null` on the captured `command_completed` | Confirms defaults for commands that never resolve a driver target. |
| `pnpm lint` (eslint + `tsc --noEmit`) | clean | Types + lint. |
| `pnpm build` (turbo, core built first) | success | Compiles against built core. |

## Follow-ups (not in this PR)

- Once data lands: if repeat/power users start passing `--headless`, consider **headed-on-first-run, headless after** (first-run is derivable via `first_time_for_user`).
- Revisit whether specific sandbox agent markers (hermes/openclaw) should be allowed headed when they have a display — decide from real `session_mode` × `agent` × `platform` data rather than guessing now.

Closes STG-2408.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
