### PR TITLE
[STG-2265] feat(cli): add --verified/--proxies to remote driver sessions

### DIFF
--- a/.changeset/curvy-mangos-attend.md
+++ b/.changeset/curvy-mangos-attend.md
@@ -1,5 +1,5 @@
 ---
-"browse": minor
+"browse": patch
 ---
 
 Add `--verified` and `--proxies` to remote driver sessions so `browse open <url> --remote --verified --proxies` opens a Verified and/or proxied Browserbase session in one command — no more create-then-attach with `--cdp`.

--- a/.changeset/curvy-mangos-attend.md
+++ b/.changeset/curvy-mangos-attend.md
@@ -1,0 +1,9 @@
+---
+"browse": minor
+---
+
+Add `--verified` and `--proxies` to remote driver sessions so `browse open <url> --remote --verified --proxies` opens a Verified and/or proxied Browserbase session in one command — no more create-then-attach with `--cdp`.
+
+- The flags are valid only with `--remote` (they are never implied, since that would silently switch to billed cloud sessions) and are sticky for the session's lifetime like `--headed`/`--headless`: a re-open requesting different settings fails with the usual stop-and-reopen error.
+- Because the session is created through the normal remote path (not a raw `--cdp` attach), it keeps its Browserbase identity and the `browse_cli` attribution tag. `browse status` and `browse doctor` now surface the Browserbase session ID, the dashboard URL, the live-view (debug) URL, and the verified/proxies state.
+- `--verified` requires a Browserbase Scale plan.

--- a/packages/cli/skills/browse/SKILL.md
+++ b/packages/cli/skills/browse/SKILL.md
@@ -57,12 +57,15 @@ Browser driver commands auto-start the browse daemon when needed. Choose the bro
 browse open https://example.com --local
 browse open https://example.com --local --headed
 browse open https://example.com --remote
+browse open https://example.com --remote --verified --proxies
 browse open https://example.com --auto-connect
 browse open https://example.com --cdp 9222
 browse open https://example.com --cdp ws://127.0.0.1:9222/devtools/browser/<id>
 ```
 
 Use local mode for development, localhost, trusted sites, and fast iteration. Use `--auto-connect` only when the user explicitly wants to attach to an already-running debuggable Chrome session with existing cookies or login state; use `--local` when no debuggable Chrome is available. Use remote mode when Browserbase credentials are available and the site needs hosted browser infrastructure, Verified browser mode, CAPTCHA solving, proxies, or session persistence.
+
+For a Verified and/or proxied remote session, add `--verified` and/or `--proxies` to `--remote` — a single command that keeps the Browserbase session identity, so `browse status` and `browse doctor` report the session ID and live-view URL. `--verified` requires a Browserbase Scale plan. These flags only apply to `--remote` and are sticky for the session's lifetime, like `--headed`. Reach for `browse cloud sessions create` + `--cdp` only when you need session options `open` doesn't expose (region, keep-alive, contexts).
 
 Choose headed/headless and local/remote mode when starting a session. A running session keeps its mode: passing a conflicting flag such as `--headed` to an already-running headless session fails until you run `browse stop --session <name>` or target a different session.
 
@@ -237,7 +240,7 @@ For remote sessions with context persistence:
 browse cloud sessions create --context-id <context-id> --persist
 ```
 
-Use `--verified` when the task needs Browserbase Verified browser mode.
+Use `--verified` when the task needs Browserbase Verified browser mode. To drive a Verified/proxied session directly, prefer `browse open <url> --remote --verified --proxies` over create-then-attach — it keeps the session identity so `browse status`/`browse doctor` can report it. Use `browse cloud sessions create` for session options the driver flags don't cover (region, keep-alive, contexts, full `--stdin` body).
 
 Use `browse cloud fetch` when the user needs a simple HTTP fetch without browser interaction. It returns markdown-formatted page content by default; pass `--format raw` for the original response body or `--format json --schema <schema>` for structured extraction. Use `browse cloud search` when the user asks for web search results.
 

--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -15,6 +15,7 @@ export default class Open extends BrowseCommand {
     "browse open https://example.com",
     "browse open https://example.com --local --headed",
     "browse open https://example.com --remote",
+    "browse open https://example.com --remote --verified --proxies",
     "browse open https://example.com --auto-connect",
     "browse open https://example.com --cdp 9222",
     "browse open https://example.com --cdp ws://127.0.0.1:9222/devtools/browser/<id> --target-id <target-id>",

--- a/packages/cli/src/lib/driver/command-cli.ts
+++ b/packages/cli/src/lib/driver/command-cli.ts
@@ -10,10 +10,12 @@ import {
   ignoreDefaultChromeArgFlag,
   localFlag,
   noDefaultChromeArgsFlag,
+  proxiesFlag,
   remoteFlag,
   sessionFlag,
   sessionName,
   targetIdFlag,
+  verifiedFlag,
 } from "./flags.js";
 import { getDriverStatus } from "./daemon/client.js";
 import {
@@ -34,9 +36,11 @@ export const driverCommandFlags = {
   "ignore-default-chrome-arg": ignoreDefaultChromeArgFlag,
   local: localFlag,
   "no-default-chrome-args": noDefaultChromeArgsFlag,
+  proxies: proxiesFlag,
   remote: remoteFlag,
   session: sessionFlag,
   "target-id": targetIdFlag,
+  verified: verifiedFlag,
 };
 
 export const waitUntilFlag = Flags.string({
@@ -102,7 +106,9 @@ export function hasExplicitDriverTarget(flags: DriverFlags): boolean {
       hasChromeArgFlags(flags) ||
       flags["target-id"] ||
       flags.headed ||
-      flags.headless,
+      flags.headless ||
+      flags.verified ||
+      flags.proxies,
   );
 }
 
@@ -115,6 +121,8 @@ function hasModeOnlyFlag(flags: DriverFlags): boolean {
       !flags["target-id"] &&
       !flags.headed &&
       !flags.headless &&
+      !flags.verified &&
+      !flags.proxies &&
       flags.local !== flags.remote,
   );
 }

--- a/packages/cli/src/lib/driver/doctor.ts
+++ b/packages/cli/src/lib/driver/doctor.ts
@@ -112,19 +112,26 @@ export async function buildDoctorReport(
   }
 
   if (status?.browserbaseSessionId) {
+    const { browserbaseSessionId, browserbaseSessionUrl, browserbaseDebugUrl } =
+      status;
+
+    const details: Record<string, unknown> = {
+      sessionId: browserbaseSessionId,
+    };
+    if (browserbaseSessionUrl) {
+      details.sessionUrl = browserbaseSessionUrl;
+    }
+    if (browserbaseDebugUrl) {
+      details.liveViewUrl = browserbaseDebugUrl;
+    }
+
+    const message = browserbaseSessionUrl
+      ? `session ${browserbaseSessionId} — ${browserbaseSessionUrl}`
+      : `session ${browserbaseSessionId}`;
+
     checks.push({
-      details: {
-        sessionId: status.browserbaseSessionId,
-        ...(status.browserbaseSessionUrl
-          ? { sessionUrl: status.browserbaseSessionUrl }
-          : {}),
-        ...(status.browserbaseDebugUrl
-          ? { liveViewUrl: status.browserbaseDebugUrl }
-          : {}),
-      },
-      message: status.browserbaseSessionUrl
-        ? `session ${status.browserbaseSessionId} — ${status.browserbaseSessionUrl}`
-        : `session ${status.browserbaseSessionId}`,
+      details,
+      message,
       name: "browserbase",
       status: "ok",
     });

--- a/packages/cli/src/lib/driver/doctor.ts
+++ b/packages/cli/src/lib/driver/doctor.ts
@@ -111,6 +111,25 @@ export async function buildDoctorReport(
     checks.push(await daemonCheck(options.session, status, paths, deps));
   }
 
+  if (status?.browserbaseSessionId) {
+    checks.push({
+      details: {
+        sessionId: status.browserbaseSessionId,
+        ...(status.browserbaseSessionUrl
+          ? { sessionUrl: status.browserbaseSessionUrl }
+          : {}),
+        ...(status.browserbaseDebugUrl
+          ? { liveViewUrl: status.browserbaseDebugUrl }
+          : {}),
+      },
+      message: status.browserbaseSessionUrl
+        ? `session ${status.browserbaseSessionId} — ${status.browserbaseSessionUrl}`
+        : `session ${status.browserbaseSessionId}`,
+      name: "browserbase",
+      status: "ok",
+    });
+  }
+
   const explicitTarget = hasExplicitDriverTarget(options.flags);
   let target: ConnectionTarget | undefined;
   let targetFailed = false;
@@ -398,7 +417,11 @@ function nextStep(
   }
 
   const parts = ["browse open", DEFAULT_URL];
-  if (target.kind === "remote") parts.push("--remote");
+  if (target.kind === "remote") {
+    parts.push("--remote");
+    if (target.verified) parts.push("--verified");
+    if (target.proxies) parts.push("--proxies");
+  }
   if (target.kind === "auto-connect") parts.push("--auto-connect");
   if (target.kind === "cdp") {
     parts.push("--cdp", flags.cdp ?? target.endpoint);
@@ -427,6 +450,13 @@ function formatTarget(target: ConnectionTarget): string {
     return `managed-local, ${target.headless ? "headless" : "headed"}`;
   if (target.kind === "cdp")
     return target.targetId ? `cdp, target ${target.targetId}` : "cdp";
+  if (target.kind === "remote") {
+    const settings = [
+      target.verified ? "verified" : null,
+      target.proxies ? "proxies" : null,
+    ].filter((setting): setting is string => Boolean(setting));
+    return settings.length > 0 ? `remote (${settings.join(", ")})` : "remote";
+  }
   return target.kind;
 }
 

--- a/packages/cli/src/lib/driver/flags.ts
+++ b/packages/cli/src/lib/driver/flags.ts
@@ -23,6 +23,16 @@ export const remoteFlag = Flags.boolean({
   description: "Use a remote Browserbase browser session.",
 });
 
+export const verifiedFlag = Flags.boolean({
+  description:
+    "Open the remote session as a Verified (advanced-stealth) browser. Requires --remote and a Browserbase Scale plan.",
+});
+
+export const proxiesFlag = Flags.boolean({
+  description:
+    "Route the remote session through Browserbase proxies. Requires --remote.",
+});
+
 export const autoConnectFlag = Flags.boolean({
   description:
     "Auto-discover and attach to a local browser with remote debugging enabled.",

--- a/packages/cli/src/lib/driver/mode.ts
+++ b/packages/cli/src/lib/driver/mode.ts
@@ -14,8 +14,10 @@ export interface DriverModeFlags {
   "ignore-default-chrome-arg"?: string[];
   local?: boolean;
   "no-default-chrome-args"?: boolean;
+  proxies?: boolean;
   remote?: boolean;
   "target-id"?: string;
+  verified?: boolean;
 }
 
 interface ResolvedChromeArgs {
@@ -48,10 +50,28 @@ function chromeArgFlagsInUse(flags: DriverModeFlags): string[] {
   return names;
 }
 
+export function remoteOnlyFlagsInUse(flags: DriverModeFlags): string[] {
+  const names: string[] = [];
+  if (flags.verified) names.push("--verified");
+  if (flags.proxies) names.push("--proxies");
+  return names;
+}
+
 export async function resolveConnectionTarget(
   flags: DriverModeFlags,
 ): Promise<ConnectionTarget> {
   const chromeArgFlags = chromeArgFlagsInUse(flags);
+
+  // --verified / --proxies configure a Browserbase session at creation time, so
+  // they only mean something for an explicit --remote session. We deliberately
+  // do NOT let them imply --remote: that would silently switch the user to
+  // API-key (billed) cloud sessions. Require the mode to be stated explicitly.
+  const remoteOnlyFlags = remoteOnlyFlagsInUse(flags);
+  if (remoteOnlyFlags.length > 0 && !flags.remote) {
+    fail(
+      `${remoteOnlyFlags.join(" and ")} require --remote. Try: browse open <url> --remote ${remoteOnlyFlags.join(" ")}`,
+    );
+  }
 
   if (flags.cdp) {
     failOnConflictingFlags("--cdp", [
@@ -175,6 +195,15 @@ export function targetsCompatible(
     );
   if (left.kind === "cdp" && right.kind === "cdp") {
     return left.endpoint === right.endpoint && left.targetId === right.targetId;
+  }
+  if (left.kind === "remote" && right.kind === "remote") {
+    // verified/proxies are baked in at session creation, so a re-open that asks
+    // for different settings can't reuse the running session — make them sticky
+    // like headless, forcing an explicit stop-and-reopen.
+    return (
+      Boolean(left.verified) === Boolean(right.verified) &&
+      Boolean(left.proxies) === Boolean(right.proxies)
+    );
   }
   return true;
 }

--- a/packages/cli/src/lib/driver/mode.ts
+++ b/packages/cli/src/lib/driver/mode.ts
@@ -68,8 +68,9 @@ export async function resolveConnectionTarget(
   // API-key (billed) cloud sessions. Require the mode to be stated explicitly.
   const remoteOnlyFlags = remoteOnlyFlagsInUse(flags);
   if (remoteOnlyFlags.length > 0 && !flags.remote) {
+    const verb = remoteOnlyFlags.length === 1 ? "requires" : "require";
     fail(
-      `${remoteOnlyFlags.join(" and ")} require --remote. Try: browse open <url> --remote ${remoteOnlyFlags.join(" ")}`,
+      `${remoteOnlyFlags.join(" and ")} ${verb} --remote. Try: browse open <url> --remote ${remoteOnlyFlags.join(" ")}`,
     );
   }
 

--- a/packages/cli/src/lib/driver/remote-types.ts
+++ b/packages/cli/src/lib/driver/remote-types.ts
@@ -1,7 +1,7 @@
 import type { Stagehand } from "@browserbasehq/stagehand";
 
 import type { DriverModeFlags } from "./mode.js";
-import type { ConnectionTarget } from "./types.js";
+import type { ConnectionTarget, RemoteConnectionTarget } from "./types.js";
 
 export type StagehandConstructorOptions = ConstructorParameters<
   typeof Stagehand
@@ -43,7 +43,9 @@ export interface RemoteCapability {
   /** Auto-select remote when an API key is present; null otherwise. */
   autoSelectRemoteTarget(): ConnectionTarget | null;
   /** Stagehand options for a remote (BROWSERBASE) session. */
-  remoteStagehandOptions(): Promise<StagehandConstructorOptions>;
+  remoteStagehandOptions(
+    target?: RemoteConnectionTarget,
+  ): Promise<StagehandConstructorOptions>;
   /** Map a failed remote `stagehand.init()` to an actionable message + code. */
   classifyRemoteInitError(error: unknown): RemoteInitErrorClassification;
   /** Remediation strings for driver init failures. */

--- a/packages/cli/src/lib/driver/remote.ts
+++ b/packages/cli/src/lib/driver/remote.ts
@@ -5,13 +5,14 @@ import {
   resolveInstallId,
   toMetadataValue,
 } from "../identity.js";
+import type { DriverModeFlags } from "./mode.js";
 import type {
   DriverInitHints,
   RemoteDoctorResult,
   RemoteInitErrorClassification,
   StagehandConstructorOptions,
 } from "./remote-types.js";
-import type { ConnectionTarget } from "./types.js";
+import type { ConnectionTarget, RemoteConnectionTarget } from "./types.js";
 
 /**
  * Real Browserbase capability. This is the ONLY module that reads
@@ -19,15 +20,23 @@ import type { ConnectionTarget } from "./types.js";
  * local-only artifacts cannot reach Browserbase.
  */
 
-export function resolveExplicitRemoteTarget(): ConnectionTarget {
-  return { kind: "remote" };
+export function resolveExplicitRemoteTarget(
+  flags: DriverModeFlags,
+): ConnectionTarget {
+  return {
+    kind: "remote",
+    ...(flags.verified ? { verified: true } : {}),
+    ...(flags.proxies ? { proxies: true } : {}),
+  };
 }
 
 export function autoSelectRemoteTarget(): ConnectionTarget | null {
   return process.env.BROWSERBASE_API_KEY ? { kind: "remote" } : null;
 }
 
-export async function remoteStagehandOptions(): Promise<StagehandConstructorOptions> {
+export async function remoteStagehandOptions(
+  target?: RemoteConnectionTarget,
+): Promise<StagehandConstructorOptions> {
   const apiKey = process.env.BROWSERBASE_API_KEY;
   if (!apiKey) {
     throw new Error(
@@ -51,6 +60,8 @@ export async function remoteStagehandOptions(): Promise<StagehandConstructorOpti
     apiKey,
     browserbaseSessionCreateParams: {
       userMetadata,
+      ...(target?.proxies ? { proxies: true } : {}),
+      ...(target?.verified ? { browserSettings: { verified: true } } : {}),
     },
     disableAPI: true,
     disablePino: true,

--- a/packages/cli/src/lib/driver/session-manager.ts
+++ b/packages/cli/src/lib/driver/session-manager.ts
@@ -156,18 +156,20 @@ export class DriverSessionManager {
    */
   private browserbaseIdentity(): BrowserbaseIdentity {
     if (this.target.kind !== "remote" || !this.stagehand) return {};
-    const stagehand = this.stagehand;
-    return {
-      ...(stagehand.browserbaseSessionID
-        ? { browserbaseSessionId: stagehand.browserbaseSessionID }
-        : {}),
-      ...(stagehand.browserbaseSessionURL
-        ? { browserbaseSessionUrl: stagehand.browserbaseSessionURL }
-        : {}),
-      ...(stagehand.browserbaseDebugURL
-        ? { browserbaseDebugUrl: stagehand.browserbaseDebugURL }
-        : {}),
-    };
+    const { browserbaseSessionID, browserbaseSessionURL, browserbaseDebugURL } =
+      this.stagehand;
+
+    const identity: BrowserbaseIdentity = {};
+    if (browserbaseSessionID) {
+      identity.browserbaseSessionId = browserbaseSessionID;
+    }
+    if (browserbaseSessionURL) {
+      identity.browserbaseSessionUrl = browserbaseSessionURL;
+    }
+    if (browserbaseDebugURL) {
+      identity.browserbaseDebugUrl = browserbaseDebugURL;
+    }
+    return identity;
   }
 
   async close(): Promise<void> {

--- a/packages/cli/src/lib/driver/session-manager.ts
+++ b/packages/cli/src/lib/driver/session-manager.ts
@@ -12,6 +12,7 @@ import { discoverLocalCdp } from "./local-cdp-discovery.js";
 import { NetworkCapture } from "./network-capture.js";
 import { getRemote } from "./remote-binding.js";
 import type {
+  BrowserbaseIdentity,
   ConnectionTarget,
   DriverStatus,
   OpenResult,
@@ -133,6 +134,7 @@ export class DriverSessionManager {
     const page = this.activePageIfPresent();
     const pages = await this.pageSummaries();
     return {
+      ...this.browserbaseIdentity(),
       browserConnected: true,
       initialized: true,
       mode: this.target.kind,
@@ -143,6 +145,28 @@ export class DriverSessionManager {
       target: this.target,
       title: page ? await safeTitle(page) : undefined,
       url: page?.url(),
+    };
+  }
+
+  /**
+   * Browserbase session identity (id, dashboard URL, live-view/debug URL) for a
+   * live remote session. Lets `status`/`open`/`doctor` reason about the cloud
+   * session instead of losing it the way a raw `--cdp` attach does. Empty for
+   * non-remote targets or before the driver has initialized.
+   */
+  private browserbaseIdentity(): BrowserbaseIdentity {
+    if (this.target.kind !== "remote" || !this.stagehand) return {};
+    const stagehand = this.stagehand;
+    return {
+      ...(stagehand.browserbaseSessionID
+        ? { browserbaseSessionId: stagehand.browserbaseSessionID }
+        : {}),
+      ...(stagehand.browserbaseSessionURL
+        ? { browserbaseSessionUrl: stagehand.browserbaseSessionURL }
+        : {}),
+      ...(stagehand.browserbaseDebugURL
+        ? { browserbaseDebugUrl: stagehand.browserbaseDebugURL }
+        : {}),
     };
   }
 
@@ -172,6 +196,7 @@ export class DriverSessionManager {
 
   async openResult(page: DriverPage): Promise<OpenResult> {
     return {
+      ...this.browserbaseIdentity(),
       mode: this.target.kind,
       pages: await this.pageSummaries(),
       selectedTargetId: page.targetId(),
@@ -339,7 +364,7 @@ export class DriverSessionManager {
     target: ConnectionTarget,
   ): Promise<ConstructorParameters<typeof Stagehand>[0]> {
     if (target.kind === "remote") {
-      return await (await getRemote()).remoteStagehandOptions();
+      return await (await getRemote()).remoteStagehandOptions(target);
     }
 
     if (target.kind === "managed-local") {

--- a/packages/cli/src/lib/driver/types.ts
+++ b/packages/cli/src/lib/driver/types.ts
@@ -5,9 +5,24 @@ export type ConnectionTarget =
       kind: "managed-local";
       headless: boolean;
     }
-  | { kind: "remote" }
+  | { kind: "remote"; verified?: boolean; proxies?: boolean }
   | { kind: "auto-connect" }
   | { kind: "cdp"; endpoint: string; targetId?: string };
+
+export type RemoteConnectionTarget = Extract<
+  ConnectionTarget,
+  { kind: "remote" }
+>;
+
+/**
+ * Browserbase session identity for a live remote session. Populated only once a
+ * remote driver has initialized; absent for local/cdp/auto-connect targets.
+ */
+export interface BrowserbaseIdentity {
+  browserbaseSessionId?: string;
+  browserbaseSessionUrl?: string;
+  browserbaseDebugUrl?: string;
+}
 
 export interface PageSummary {
   index: number;
@@ -16,7 +31,7 @@ export interface PageSummary {
   url: string;
 }
 
-export interface DriverStatus {
+export interface DriverStatus extends BrowserbaseIdentity {
   browserConnected: boolean;
   initialized: boolean;
   mode: ConnectionTarget["kind"];
@@ -29,7 +44,7 @@ export interface DriverStatus {
   url?: string;
 }
 
-export interface OpenResult {
+export interface OpenResult extends BrowserbaseIdentity {
   mode: ConnectionTarget["kind"];
   pages: PageSummary[];
   selectedTargetId?: string;

--- a/packages/cli/tests/doctor.test.ts
+++ b/packages/cli/tests/doctor.test.ts
@@ -316,6 +316,75 @@ describe("doctor report builder", () => {
       restoreEnv("BROWSE_DAEMON_DIR", previousDaemonDir);
     }
   });
+
+  it("surfaces the live Browserbase session identity and settings", async () => {
+    const report = await buildDoctorReport(
+      { flags: {}, session: "default" },
+      {
+        env: { BROWSERBASE_API_KEY: "test-key" },
+        getDriverStatus: async () => ({
+          browserbaseDebugUrl: "https://www.browserbase.com/live/sess-123",
+          browserbaseSessionId: "sess-123",
+          browserbaseSessionUrl:
+            "https://www.browserbase.com/sessions/sess-123",
+          browserConnected: true,
+          initialized: true,
+          mode: "remote",
+          pages: [],
+          pid: process.pid,
+          session: "default",
+          target: { kind: "remote", proxies: true, verified: true },
+        }),
+        readPackageVersion: async () => "0.0.0-test",
+      },
+    );
+
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          details: expect.objectContaining({
+            liveViewUrl: "https://www.browserbase.com/live/sess-123",
+            sessionId: "sess-123",
+          }),
+          message:
+            "session sess-123 — https://www.browserbase.com/sessions/sess-123",
+          name: "browserbase",
+          status: "ok",
+        }),
+        expect.objectContaining({
+          message: "reusing remote (verified, proxies)",
+          name: "target",
+        }),
+      ]),
+    );
+  });
+
+  it("includes --verified/--proxies in the suggested remote open command", async () => {
+    const report = await buildDoctorReport(
+      {
+        flags: { proxies: true, remote: true, verified: true },
+        session: "default",
+      },
+      {
+        env: { BROWSERBASE_API_KEY: "test-key" },
+        getDriverStatus: async () => null,
+        readPackageVersion: async () => "0.0.0-test",
+      },
+    );
+
+    expect(report.verdict).toBe("ok");
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          message: "remote (verified, proxies)",
+          name: "target",
+        }),
+      ]),
+    );
+    expect(report.next).toBe(
+      "browse open https://example.com --remote --verified --proxies",
+    );
+  });
 });
 
 async function tempDaemonDir(): Promise<string> {

--- a/packages/cli/tests/driver-foundation.test.ts
+++ b/packages/cli/tests/driver-foundation.test.ts
@@ -215,6 +215,76 @@ describe("driver foundation", () => {
     }
   });
 
+  it("resolves --remote with --verified and --proxies", async () => {
+    await expect(resolveConnectionTarget({ remote: true })).resolves.toEqual({
+      kind: "remote",
+    });
+    await expect(
+      resolveConnectionTarget({ remote: true, verified: true }),
+    ).resolves.toEqual({ kind: "remote", verified: true });
+    await expect(
+      resolveConnectionTarget({ proxies: true, remote: true }),
+    ).resolves.toEqual({ kind: "remote", proxies: true });
+    await expect(
+      resolveConnectionTarget({ proxies: true, remote: true, verified: true }),
+    ).resolves.toEqual({ kind: "remote", proxies: true, verified: true });
+  });
+
+  it("requires --remote for --verified and --proxies", async () => {
+    await expect(resolveConnectionTarget({ verified: true })).rejects.toThrow(
+      "--verified require --remote",
+    );
+    await expect(resolveConnectionTarget({ proxies: true })).rejects.toThrow(
+      "--proxies require --remote",
+    );
+    await expect(
+      resolveConnectionTarget({ proxies: true, verified: true }),
+    ).rejects.toThrow("--verified and --proxies require --remote");
+    // verified/proxies must be explicit about remote even when --cdp/--local is set
+    await expect(
+      resolveConnectionTarget({ cdp: "9222", verified: true }),
+    ).rejects.toThrow("--verified require --remote");
+    await expect(
+      resolveConnectionTarget({ local: true, proxies: true }),
+    ).rejects.toThrow("--proxies require --remote");
+  });
+
+  it("does not let --verified/--proxies imply remote from an API key", async () => {
+    const previousApiKey = process.env.BROWSERBASE_API_KEY;
+    process.env.BROWSERBASE_API_KEY = "test-key";
+    try {
+      await expect(resolveConnectionTarget({ verified: true })).rejects.toThrow(
+        "--verified require --remote",
+      );
+    } finally {
+      restoreEnv("BROWSERBASE_API_KEY", previousApiKey);
+    }
+  });
+
+  it("makes remote verified/proxies sticky for session reuse", () => {
+    expect(targetsCompatible({ kind: "remote" }, { kind: "remote" })).toBe(
+      true,
+    );
+    expect(
+      targetsCompatible(
+        { kind: "remote", verified: true, proxies: true },
+        { kind: "remote", verified: true, proxies: true },
+      ),
+    ).toBe(true);
+    expect(
+      targetsCompatible({ kind: "remote" }, { kind: "remote", verified: true }),
+    ).toBe(false);
+    expect(
+      targetsCompatible({ kind: "remote", proxies: true }, { kind: "remote" }),
+    ).toBe(false);
+    expect(
+      targetsCompatible(
+        { kind: "remote", verified: true },
+        { kind: "remote", verified: true, proxies: true },
+      ),
+    ).toBe(false);
+  });
+
   it("only reuses daemon sessions for matching launch targets", () => {
     expect(
       targetsCompatible(

--- a/packages/cli/tests/driver-foundation.test.ts
+++ b/packages/cli/tests/driver-foundation.test.ts
@@ -232,21 +232,22 @@ describe("driver foundation", () => {
 
   it("requires --remote for --verified and --proxies", async () => {
     await expect(resolveConnectionTarget({ verified: true })).rejects.toThrow(
-      "--verified require --remote",
+      "--verified requires --remote",
     );
     await expect(resolveConnectionTarget({ proxies: true })).rejects.toThrow(
-      "--proxies require --remote",
+      "--proxies requires --remote",
     );
+    // plural subject keeps the plural verb
     await expect(
       resolveConnectionTarget({ proxies: true, verified: true }),
     ).rejects.toThrow("--verified and --proxies require --remote");
     // verified/proxies must be explicit about remote even when --cdp/--local is set
     await expect(
       resolveConnectionTarget({ cdp: "9222", verified: true }),
-    ).rejects.toThrow("--verified require --remote");
+    ).rejects.toThrow("--verified requires --remote");
     await expect(
       resolveConnectionTarget({ local: true, proxies: true }),
-    ).rejects.toThrow("--proxies require --remote");
+    ).rejects.toThrow("--proxies requires --remote");
   });
 
   it("does not let --verified/--proxies imply remote from an API key", async () => {
@@ -254,7 +255,7 @@ describe("driver foundation", () => {
     process.env.BROWSERBASE_API_KEY = "test-key";
     try {
       await expect(resolveConnectionTarget({ verified: true })).rejects.toThrow(
-        "--verified require --remote",
+        "--verified requires --remote",
       );
     } finally {
       restoreEnv("BROWSERBASE_API_KEY", previousApiKey);

--- a/packages/cli/tests/remote-options.test.ts
+++ b/packages/cli/tests/remote-options.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  remoteStagehandOptions,
+  resolveExplicitRemoteTarget,
+} from "../src/lib/driver/remote.js";
+
+// The real Browserbase capability: --verified/--proxies must reach the
+// session-create params so the cloud session is actually Verified/proxied,
+// while keeping the browse_cli attribution tag that --cdp attach loses.
+describe("remote.ts (Browserbase capability)", () => {
+  const previousApiKey = process.env.BROWSERBASE_API_KEY;
+
+  beforeEach(() => {
+    process.env.BROWSERBASE_API_KEY = "test-key";
+  });
+
+  afterEach(() => {
+    if (previousApiKey === undefined) {
+      delete process.env.BROWSERBASE_API_KEY;
+    } else {
+      process.env.BROWSERBASE_API_KEY = previousApiKey;
+    }
+  });
+
+  it("carries --verified/--proxies into the explicit remote target", () => {
+    expect(resolveExplicitRemoteTarget({ remote: true })).toEqual({
+      kind: "remote",
+    });
+    expect(
+      resolveExplicitRemoteTarget({
+        proxies: true,
+        remote: true,
+        verified: true,
+      }),
+    ).toEqual({ kind: "remote", proxies: true, verified: true });
+  });
+
+  it("keeps the browse_cli tag and adds no session settings by default", () => {
+    const options = remoteStagehandOptions({ kind: "remote" });
+    expect(options.browserbaseSessionCreateParams).toEqual({
+      userMetadata: { browse_cli: "true" },
+    });
+  });
+
+  it("threads proxies and verified into session-create params", () => {
+    const options = remoteStagehandOptions({
+      kind: "remote",
+      proxies: true,
+      verified: true,
+    });
+    expect(options.browserbaseSessionCreateParams).toEqual({
+      browserSettings: { verified: true },
+      proxies: true,
+      userMetadata: { browse_cli: "true" },
+    });
+  });
+
+  it("requires an API key", () => {
+    delete process.env.BROWSERBASE_API_KEY;
+    expect(() => remoteStagehandOptions({ kind: "remote" })).toThrow(
+      /BROWSERBASE_API_KEY/,
+    );
+  });
+});

--- a/packages/cli/tests/remote-options.test.ts
+++ b/packages/cli/tests/remote-options.test.ts
@@ -36,29 +36,50 @@ describe("remote.ts (Browserbase capability)", () => {
     ).toEqual({ kind: "remote", proxies: true, verified: true });
   });
 
-  it("keeps the browse_cli tag and adds no session settings by default", () => {
-    const options = remoteStagehandOptions({ kind: "remote" });
-    expect(options.browserbaseSessionCreateParams).toEqual({
-      userMetadata: { browse_cli: "true" },
-    });
+  // userMetadata content (browse_cli/cli_version/install_id) is owned and
+  // verified by identity-attribution.test.ts; here we assert only that the
+  // attribution tag survives and that --verified/--proxies are threaded.
+  it("keeps the browse_cli tag and adds no session settings by default", async () => {
+    const params = (await remoteStagehandOptions({ kind: "remote" }))
+      .browserbaseSessionCreateParams;
+    expect((params?.userMetadata as Record<string, string>).browse_cli).toBe(
+      "true",
+    );
+    expect(params).not.toHaveProperty("proxies");
+    expect(params).not.toHaveProperty("browserSettings");
   });
 
-  it("threads proxies and verified into session-create params", () => {
-    const options = remoteStagehandOptions({
-      kind: "remote",
-      proxies: true,
-      verified: true,
-    });
-    expect(options.browserbaseSessionCreateParams).toEqual({
-      browserSettings: { verified: true },
-      proxies: true,
-      userMetadata: { browse_cli: "true" },
-    });
+  it("threads proxies alone without touching browserSettings", async () => {
+    const params = (
+      await remoteStagehandOptions({ kind: "remote", proxies: true })
+    ).browserbaseSessionCreateParams;
+    expect(params?.proxies).toBe(true);
+    expect(params).not.toHaveProperty("browserSettings");
   });
 
-  it("requires an API key", () => {
+  it("threads verified alone into browserSettings without proxies", async () => {
+    const params = (
+      await remoteStagehandOptions({ kind: "remote", verified: true })
+    ).browserbaseSessionCreateParams;
+    expect(params?.browserSettings).toEqual({ verified: true });
+    expect(params).not.toHaveProperty("proxies");
+  });
+
+  it("threads proxies and verified together into session-create params", async () => {
+    const params = (
+      await remoteStagehandOptions({
+        kind: "remote",
+        proxies: true,
+        verified: true,
+      })
+    ).browserbaseSessionCreateParams;
+    expect(params?.proxies).toBe(true);
+    expect(params?.browserSettings).toEqual({ verified: true });
+  });
+
+  it("requires an API key", async () => {
     delete process.env.BROWSERBASE_API_KEY;
-    expect(() => remoteStagehandOptions({ kind: "remote" })).toThrow(
+    await expect(remoteStagehandOptions({ kind: "remote" })).rejects.toThrow(
       /BROWSERBASE_API_KEY/,
     );
   });


### PR DESCRIPTION
## Summary

Adds `--verified` and `--proxies` to remote driver sessions so a Verified and/or proxied Browserbase session opens in **one command**:

```bash
browse open <url> --remote --verified --proxies
```

Before this, the `browse` **driver** (`open`) had no way to request Verified/proxies — only `browse cloud sessions create --verified --proxies` (session **management**) could make such a session. So *driving* one took two steps: create it, then attach the driver via raw `--cdp`. That raw attach loses session identity for the whole lifetime (`browse status` reports `mode: cdp` with no Browserbase session ID; `doctor` can't reason about it) and, bypassing the normal remote path, never gets the `browse_cli` attribution tag — so Verified/proxied power users were invisible to browse-CLI telemetry. (Plain `browse open --remote` already worked in one step; it just couldn't ask for Verified/proxies.) Closes [STG-2265](https://linear.app/browserbase/issue/STG-2265/add-verified-proxies-to-browse-open-remote-and-attach-by-session-id) (Tier 1).

## What changed (CLI-only)

- **New flags** `--verified` / `--proxies` on the shared driver flag set (so `open`, `doctor`, etc. accept them). Valid **only with `--remote`** — never implied, because implying it would silently switch the user to billed cloud sessions. Without `--remote` they hard-error with a hint.
- **Threaded into session creation**: the remote `ConnectionTarget` carries the settings, and `remoteStagehandOptions` maps them onto `browserbaseSessionCreateParams` (`proxies: true`, `browserSettings.verified: true`) while keeping `userMetadata.browse_cli`.
- **Sticky per session** like `--headed`/`--headless`: the settings join the mode-equality check, so a re-open requesting different settings fails with the usual stop-and-reopen error.
- **`status` / `doctor` surface identity**: Browserbase session ID, dashboard URL, live-view (debug) URL, and verified/proxies state — read from the existing Stagehand getters, no extra API call.
- Bundled browse skill updated to document the one-command form.
- `--verified` requires a Browserbase Scale plan.

## Tier 2 (follow-up, intentionally not in this PR)

`browse open <url> --remote --session-id <id>` (attach-by-ID for the create-then-attach long tail: regions, keep-alive, contexts, `--stdin` body). Kept separate to keep this PR atomic; the skill already points there as the bridge.

## E2E Test Matrix

Run against live Browserbase with a local build (`node bin/run.js …`). Session IDs are ephemeral; the live-view URL is signed and redacted.

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `open <url> --verified` (no `--remote`) | `--verified require --remote. Try: browse open <url> --remote --verified` | Guard works; flag is never silently implied. |
| `open <url> --proxies` (no `--remote`) | `--proxies require --remote. Try: browse open <url> --remote --proxies` | Same, for `--proxies`. Also verified it errors even with `BROWSERBASE_API_KEY` set (no auto-implied remote). |
| `open "https://api.ipify.org?format=json" --remote --proxies` | `{ mode: "remote", browserbaseSessionId: "c64ca54b…", browserbaseSessionUrl: "https://www.browserbase.com/sessions/c64ca54b…", hasDebugUrl: true }` | Session identity (id + dashboard + live-view URL) is surfaced right on `open`, not lost like `--cdp`. |
| `eval` egress IP: proxied vs non-proxied | proxied `8.28.99.210` vs non-proxied `44.248.86.34` → **different routes** | `--proxies` actually routes egress through Browserbase proxies (not just accepted). |
| `status -s <proxied>` | `{ mode: "remote", browserbaseSessionId: "c64ca54b…", target: { kind: "remote", proxies: true } }` | `status` surfaces the session ID and proxies/verified state. |
| `doctor --json -s <proxied>` | browserbase check: `session c64ca54b… — https://www.browserbase.com/sessions/c64ca54b…`; target: `reusing remote (proxies)` | `doctor` reasons about the live session + settings. |
| Sticky: plain remote running, re-open `--remote --proxies` (and `--remote --verified`) | `Session "s" is already running in remote mode. Run browse stop --session s before changing modes.` | Settings are sticky; conflicting re-open fails like `--headed`. |
| `open <url> --remote --verified` (live) | `{ mode: "remote", browserbaseSessionId: "e2f0ce9f…", target: { kind: "remote", verified: true } }` | Verified session is actually created (this key is on Scale). |
| `pnpm test` | `Test Files 19 passed (19) · Tests 278 passed (278)` | Unit coverage incl. new resolution/guard/sticky tests + `remote-options` create-params threading. |
| `pnpm lint` | prettier + eslint + `tsc --noEmit` clean | Format/lint/types green. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `--verified` and `--proxies` to remote driver sessions so you can open a Verified and/or proxied Browserbase session in one command: `browse open <url> --remote --verified --proxies`. This preserves session identity and makes `browse status` and `browse doctor` show the Browserbase session ID and links. Closes STG-2265.

- **New Features**
  - `--verified` and `--proxies` are valid only with `--remote`; they are never implied. `--verified` requires a Browserbase Scale plan.
  - Settings are sticky for the session; changing them requires stopping and reopening the session.
  - `status` and `doctor` now show the Browserbase session ID, dashboard URL, live-view URL, and whether verified/proxies are enabled. `doctor` also suggests the correct `open` command with `--verified/--proxies` when relevant.
  - Flags are threaded into Browserbase session create params while keeping the `browse_cli` attribution tag.

- **Bug Fixes**
  - The `--remote` guard message uses correct singular/plural grammar (“requires”/“require”).

<sup>Written for commit d1806c9b8cb0fa10e9608b7a91ef90638c075d4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

