### PR TITLE
[feat]: add domain allowlist

### DIFF
--- a/.changeset/itchy-actors-kneel.md
+++ b/.changeset/itchy-actors-kneel.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": minor
+---
+
+add `context.setDomainPolicy({ allowedDomains: ["allowed.domain"] })` which allows users to define a set of domains that are accessible to stagehand

--- a/packages/core/lib/v3/types/public/context.ts
+++ b/packages/core/lib/v3/types/public/context.ts
@@ -35,6 +35,9 @@ export interface ClearCookieOptions {
 
 /** Context-wide network domain policy. */
 export interface DomainPolicy {
+  /** Domain-only allow patterns, e.g. "example.com" or "*.example.com". */
+  allowedDomains?: string[];
+
   /** Domain-only block patterns, e.g. "example.com" or "*.example.com". */
   blockedDomains?: string[];
 }

--- a/packages/core/lib/v3/understudy/context.ts
+++ b/packages/core/lib/v3/understudy/context.ts
@@ -32,7 +32,10 @@ import {
   CookieParam,
   DomainPolicy,
 } from "../types/public/context.js";
-import { normalizeDomainPolicy, shouldBlockUrl } from "./domainPolicy.js";
+import {
+  getDomainPolicyDecision,
+  normalizeDomainPolicy,
+} from "./domainPolicy.js";
 import type { NormalizedDomainPolicy } from "./domainPolicy.js";
 
 type TargetId = string;
@@ -437,7 +440,14 @@ export class V3Context {
 
   public getDomainPolicy(): DomainPolicy | null {
     if (!this.domainPolicy) return null;
-    return { blockedDomains: [...this.domainPolicy.blockedDomains] };
+    return {
+      ...(this.domainPolicy.allowedDomains.length
+        ? { allowedDomains: [...this.domainPolicy.allowedDomains] }
+        : {}),
+      ...(this.domainPolicy.blockedDomains.length
+        ? { blockedDomains: [...this.domainPolicy.blockedDomains] }
+        : {}),
+    };
   }
 
   public async setDomainPolicy(policy: DomainPolicy | null): Promise<void> {
@@ -538,9 +548,12 @@ export class V3Context {
     session: CDPSessionLike,
     evt: Protocol.Fetch.RequestPausedEvent,
   ): Promise<void> {
-    const policy = this.domainPolicy;
+    const decision = getDomainPolicyDecision(
+      evt.request.url,
+      this.domainPolicy,
+    );
 
-    if (!policy || !shouldBlockUrl(evt.request.url, policy)) {
+    if (decision.action === "continue") {
       await session
         .send("Fetch.continueRequest", { requestId: evt.requestId })
         .catch(() => {});
@@ -560,7 +573,7 @@ export class V3Context {
       level: 2,
       auxiliary: {
         hostname: { value: hostname, type: "string" },
-        ruleType: { value: "blockedDomains", type: "string" },
+        ruleType: { value: decision.reason, type: "string" },
       },
     });
 

--- a/packages/core/lib/v3/understudy/domainPolicy.ts
+++ b/packages/core/lib/v3/understudy/domainPolicy.ts
@@ -25,22 +25,16 @@ function canonicalizeHostname(hostname: string): string {
   return hostname.toLowerCase().replace(/\.+$/, "");
 }
 
-function policyFieldLabel(kind: "allowedDomains" | "blockedDomains"): string {
-  return kind === "allowedDomains" ? "Allowed" : "Blocked";
-}
-
-function policyRuleLabel(kind: "allowedDomains" | "blockedDomains"): string {
-  return kind === "allowedDomains" ? "allowed" : "blocked";
-}
-
 function validateHostname(
   hostname: string,
   original: string,
   kind: "allowedDomains" | "blockedDomains",
 ): void {
+  const label = kind === "allowedDomains" ? "allowed" : "blocked";
+
   if (!hostname || hostname.length > 253) {
     throw new StagehandInvalidArgumentError(
-      `Invalid ${policyRuleLabel(kind)} domain pattern: "${original}"`,
+      `Invalid ${label} domain pattern: "${original}"`,
     );
   }
 
@@ -50,7 +44,7 @@ function validateHostname(
     labels.some((label) => !DOMAIN_LABEL_RE.test(label))
   ) {
     throw new StagehandInvalidArgumentError(
-      `Invalid ${policyRuleLabel(kind)} domain pattern: "${original}"`,
+      `Invalid ${label} domain pattern: "${original}"`,
     );
   }
 }
@@ -59,9 +53,12 @@ function normalizeDomainPattern(
   pattern: unknown,
   kind: "allowedDomains" | "blockedDomains",
 ): DomainRule {
+  const label = kind === "allowedDomains" ? "allowed" : "blocked";
+  const capitalizedLabel = kind === "allowedDomains" ? "Allowed" : "Blocked";
+
   if (typeof pattern !== "string") {
     throw new StagehandInvalidArgumentError(
-      `${policyFieldLabel(kind)} domain patterns must be strings`,
+      `${capitalizedLabel} domain patterns must be strings`,
     );
   }
 
@@ -70,7 +67,7 @@ function normalizeDomainPattern(
 
   if (!normalized) {
     throw new StagehandInvalidArgumentError(
-      `Invalid ${policyRuleLabel(kind)} domain pattern: "${original}"`,
+      `Invalid ${label} domain pattern: "${original}"`,
     );
   }
 
@@ -82,7 +79,7 @@ function normalizeDomainPattern(
     normalized.includes("#")
   ) {
     throw new StagehandInvalidArgumentError(
-      `${policyFieldLabel(kind)} domain patterns must be domain-only values: "${original}"`,
+      `${capitalizedLabel} domain patterns must be domain-only values: "${original}"`,
     );
   }
 
@@ -171,7 +168,6 @@ export function normalizeDomainPolicy(
     policy.blockedDomains,
     "blockedDomains",
   );
-  if (!allowedDomainRules.length && !blockedDomainRules.length) return null;
 
   return {
     allowedDomains: allowedDomainRules.map(patternHost),
@@ -194,13 +190,6 @@ function hostnameFromHttpUrl(url: string): string | null {
   } catch {
     return null;
   }
-}
-
-export function shouldBlockUrl(
-  url: string,
-  policy: NormalizedDomainPolicy | null,
-): boolean {
-  return getDomainPolicyDecision(url, policy).action === "block";
 }
 
 function matchesDomainRules(hostname: string, rules: DomainRule[]): boolean {

--- a/packages/core/lib/v3/understudy/domainPolicy.ts
+++ b/packages/core/lib/v3/understudy/domainPolicy.ts
@@ -2,26 +2,45 @@ import type { Protocol } from "devtools-protocol";
 import { StagehandInvalidArgumentError } from "../types/public/sdkErrors.js";
 import type { DomainPolicy } from "../types/public/context.js";
 
-type BlockedDomainRule =
+type DomainRule =
   | { type: "exact"; hostname: string }
   | { type: "wildcard"; hostname: string };
 
 export type NormalizedDomainPolicy = {
+  allowedDomains: string[];
   blockedDomains: string[];
-  blockedDomainRules: BlockedDomainRule[];
+  allowedDomainRules: DomainRule[];
+  blockedDomainRules: DomainRule[];
   fetchPatterns: Protocol.Fetch.RequestPattern[];
 };
 
+export type DomainPolicyDecision =
+  | { action: "continue" }
+  | { action: "block"; reason: "allowedDomains" | "blockedDomains" };
+
 const DOMAIN_LABEL_RE = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+const HTTP_SCHEMES = ["http", "https"] as const;
 
 function canonicalizeHostname(hostname: string): string {
   return hostname.toLowerCase().replace(/\.+$/, "");
 }
 
-function validateHostname(hostname: string, original: string): void {
+function policyFieldLabel(kind: "allowedDomains" | "blockedDomains"): string {
+  return kind === "allowedDomains" ? "Allowed" : "Blocked";
+}
+
+function policyRuleLabel(kind: "allowedDomains" | "blockedDomains"): string {
+  return kind === "allowedDomains" ? "allowed" : "blocked";
+}
+
+function validateHostname(
+  hostname: string,
+  original: string,
+  kind: "allowedDomains" | "blockedDomains",
+): void {
   if (!hostname || hostname.length > 253) {
     throw new StagehandInvalidArgumentError(
-      `Invalid blocked domain pattern: "${original}"`,
+      `Invalid ${policyRuleLabel(kind)} domain pattern: "${original}"`,
     );
   }
 
@@ -31,15 +50,18 @@ function validateHostname(hostname: string, original: string): void {
     labels.some((label) => !DOMAIN_LABEL_RE.test(label))
   ) {
     throw new StagehandInvalidArgumentError(
-      `Invalid blocked domain pattern: "${original}"`,
+      `Invalid ${policyRuleLabel(kind)} domain pattern: "${original}"`,
     );
   }
 }
 
-function normalizeBlockedDomainPattern(pattern: unknown): BlockedDomainRule {
+function normalizeDomainPattern(
+  pattern: unknown,
+  kind: "allowedDomains" | "blockedDomains",
+): DomainRule {
   if (typeof pattern !== "string") {
     throw new StagehandInvalidArgumentError(
-      `Blocked domain patterns must be strings`,
+      `${policyFieldLabel(kind)} domain patterns must be strings`,
     );
   }
 
@@ -48,7 +70,7 @@ function normalizeBlockedDomainPattern(pattern: unknown): BlockedDomainRule {
 
   if (!normalized) {
     throw new StagehandInvalidArgumentError(
-      `Invalid blocked domain pattern: "${original}"`,
+      `Invalid ${policyRuleLabel(kind)} domain pattern: "${original}"`,
     );
   }
 
@@ -60,13 +82,13 @@ function normalizeBlockedDomainPattern(pattern: unknown): BlockedDomainRule {
     normalized.includes("#")
   ) {
     throw new StagehandInvalidArgumentError(
-      `Blocked domain patterns must be domain-only values: "${original}"`,
+      `${policyFieldLabel(kind)} domain patterns must be domain-only values: "${original}"`,
     );
   }
 
   if (normalized.startsWith("*.")) {
     const hostname = normalized.slice(2);
-    validateHostname(hostname, original);
+    validateHostname(hostname, original, kind);
     return { type: "wildcard", hostname };
   }
 
@@ -76,27 +98,42 @@ function normalizeBlockedDomainPattern(pattern: unknown): BlockedDomainRule {
     );
   }
 
-  validateHostname(normalized, original);
+  validateHostname(normalized, original, kind);
   return { type: "exact", hostname: normalized };
 }
 
-function patternHost(rule: BlockedDomainRule): string {
+function normalizeDomainPatterns(
+  patterns: unknown[] | undefined,
+  kind: "allowedDomains" | "blockedDomains",
+): DomainRule[] {
+  if (!patterns?.length) return [];
+
+  const rulesByKey = new Map<string, DomainRule>();
+  for (const pattern of patterns) {
+    const rule = normalizeDomainPattern(pattern, kind);
+    rulesByKey.set(`${rule.type}:${rule.hostname}`, rule);
+  }
+
+  return Array.from(rulesByKey.values());
+}
+
+function patternHost(rule: DomainRule): string {
   return rule.type === "wildcard" ? `*.${rule.hostname}` : rule.hostname;
 }
 
-function fetchPatternHosts(rule: BlockedDomainRule): string[] {
+function fetchPatternHosts(rule: DomainRule): string[] {
   const host = patternHost(rule);
   return [host, `${host}.`];
 }
 
-function toFetchPatterns(
-  rules: BlockedDomainRule[],
+function toBlocklistFetchPatterns(
+  rules: DomainRule[],
 ): Protocol.Fetch.RequestPattern[] {
   const patterns: Protocol.Fetch.RequestPattern[] = [];
 
   for (const rule of rules) {
     for (const host of fetchPatternHosts(rule)) {
-      for (const scheme of ["http", "https"]) {
+      for (const scheme of HTTP_SCHEMES) {
         patterns.push({
           urlPattern: `${scheme}://${host}/*`,
           requestStage: "Request",
@@ -112,24 +149,38 @@ function toFetchPatterns(
   return patterns;
 }
 
+function toAllowlistFetchPatterns(): Protocol.Fetch.RequestPattern[] {
+  return HTTP_SCHEMES.map((scheme) => ({
+    urlPattern: `${scheme}://*/*`,
+    requestStage: "Request",
+  }));
+}
+
 export function normalizeDomainPolicy(
   policy: DomainPolicy | null,
 ): NormalizedDomainPolicy | null {
-  if (!policy?.blockedDomains?.length) return null;
-
-  const rulesByKey = new Map<string, BlockedDomainRule>();
-  for (const domain of policy.blockedDomains) {
-    const rule = normalizeBlockedDomainPattern(domain);
-    rulesByKey.set(`${rule.type}:${rule.hostname}`, rule);
+  if (!policy?.allowedDomains?.length && !policy?.blockedDomains?.length) {
+    return null;
   }
 
-  const blockedDomainRules = Array.from(rulesByKey.values());
-  if (!blockedDomainRules.length) return null;
+  const allowedDomainRules = normalizeDomainPatterns(
+    policy.allowedDomains,
+    "allowedDomains",
+  );
+  const blockedDomainRules = normalizeDomainPatterns(
+    policy.blockedDomains,
+    "blockedDomains",
+  );
+  if (!allowedDomainRules.length && !blockedDomainRules.length) return null;
 
   return {
+    allowedDomains: allowedDomainRules.map(patternHost),
     blockedDomains: blockedDomainRules.map(patternHost),
+    allowedDomainRules,
     blockedDomainRules,
-    fetchPatterns: toFetchPatterns(blockedDomainRules),
+    fetchPatterns: allowedDomainRules.length
+      ? toAllowlistFetchPatterns()
+      : toBlocklistFetchPatterns(blockedDomainRules),
   };
 }
 
@@ -149,15 +200,37 @@ export function shouldBlockUrl(
   url: string,
   policy: NormalizedDomainPolicy | null,
 ): boolean {
-  if (!policy) return false;
+  return getDomainPolicyDecision(url, policy).action === "block";
+}
 
-  const hostname = hostnameFromHttpUrl(url);
-  if (!hostname) return false;
-
-  return policy.blockedDomainRules.some((rule) => {
+function matchesDomainRules(hostname: string, rules: DomainRule[]): boolean {
+  return rules.some((rule) => {
     if (rule.type === "exact") {
       return hostname === rule.hostname;
     }
     return hostname.endsWith(`.${rule.hostname}`);
   });
+}
+
+export function getDomainPolicyDecision(
+  url: string,
+  policy: NormalizedDomainPolicy | null,
+): DomainPolicyDecision {
+  if (!policy) return { action: "continue" };
+
+  const hostname = hostnameFromHttpUrl(url);
+  if (!hostname) return { action: "continue" };
+
+  if (matchesDomainRules(hostname, policy.blockedDomainRules)) {
+    return { action: "block", reason: "blockedDomains" };
+  }
+
+  if (
+    policy.allowedDomainRules.length &&
+    !matchesDomainRules(hostname, policy.allowedDomainRules)
+  ) {
+    return { action: "block", reason: "allowedDomains" };
+  }
+
+  return { action: "continue" };
 }

--- a/packages/core/lib/v3/understudy/domainPolicy.ts
+++ b/packages/core/lib/v3/understudy/domainPolicy.ts
@@ -20,6 +20,7 @@ export type DomainPolicyDecision =
 
 const DOMAIN_LABEL_RE = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
 const HTTP_SCHEMES = ["http", "https"] as const;
+type DomainPolicyKey = "allowedDomains" | "blockedDomains";
 
 function canonicalizeHostname(hostname: string): string {
   return hostname.toLowerCase().replace(/\.+$/, "");
@@ -101,7 +102,7 @@ function normalizeDomainPattern(
 
 function normalizeDomainPatterns(
   patterns: unknown[] | undefined,
-  kind: "allowedDomains" | "blockedDomains",
+  kind: DomainPolicyKey,
 ): DomainRule[] {
   if (!patterns?.length) return [];
 
@@ -112,6 +113,34 @@ function normalizeDomainPatterns(
   }
 
   return Array.from(rulesByKey.values());
+}
+
+function getDomainPatterns(
+  policy: DomainPolicy | null | undefined,
+  key: DomainPolicyKey,
+): string[] {
+  if (policy === null) return [];
+
+  // Passing undefined usually means the caller accidentally omitted the policy
+  // argument or passed through an unset variable. Clearing must be explicit.
+  if (policy === undefined) {
+    throw new StagehandInvalidArgumentError(
+      "Domain policy must be an object or null",
+    );
+  }
+
+  const patterns = policy[key];
+  if (patterns === undefined) return [];
+
+  // Empty arrays intentionally clear that side of the policy, but malformed
+  // runtime values should fail fast rather than silently disabling interception.
+  if (!Array.isArray(patterns)) {
+    throw new StagehandInvalidArgumentError(
+      `${key} must be an array of strings`,
+    );
+  }
+
+  return patterns;
 }
 
 function patternHost(rule: DomainRule): string {
@@ -154,18 +183,19 @@ function toAllowlistFetchPatterns(): Protocol.Fetch.RequestPattern[] {
 }
 
 export function normalizeDomainPolicy(
-  policy: DomainPolicy | null,
+  policy: DomainPolicy | null | undefined,
 ): NormalizedDomainPolicy | null {
-  if (!policy?.allowedDomains?.length && !policy?.blockedDomains?.length) {
-    return null;
-  }
+  const allowedDomains = getDomainPatterns(policy, "allowedDomains");
+  const blockedDomains = getDomainPatterns(policy, "blockedDomains");
+
+  if (!allowedDomains.length && !blockedDomains.length) return null;
 
   const allowedDomainRules = normalizeDomainPatterns(
-    policy.allowedDomains,
+    allowedDomains,
     "allowedDomains",
   );
   const blockedDomainRules = normalizeDomainPatterns(
-    policy.blockedDomains,
+    blockedDomains,
     "blockedDomains",
   );
 

--- a/packages/core/tests/integration/context-domain-policy.spec.ts
+++ b/packages/core/tests/integration/context-domain-policy.spec.ts
@@ -1,11 +1,17 @@
 import { test, expect } from "@playwright/test";
 import type { Protocol } from "devtools-protocol";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
 import { V3 } from "../../lib/v3/v3.js";
 import { v3TestConfig } from "./v3.config.js";
 import { closeV3 } from "./testUtils.js";
 
 const BLOCKED_HOST = "example.com";
 const BLOCKED_URL = `https://${BLOCKED_HOST}/stagehand-domain-policy.png`;
+const ALLOWED_HOST = "127.0.0.1";
+const DISALLOWED_HOST = "127.0.0.2";
+let localServer: Server | null = null;
+let localServerPort = 0;
 
 type InternalPage = {
   mainSession: {
@@ -20,32 +26,72 @@ type InternalPage = {
 };
 
 function pageWithBlockedImage(): string {
+  return pageWithImages([BLOCKED_URL]);
+}
+
+function pageWithImages(urls: string[]): string {
   return `data:text/html,${encodeURIComponent(
-    `<html><body><img src="${BLOCKED_URL}" /></body></html>`,
+    `<html><body>${urls.map((url) => `<img src="${url}" />`).join("")}</body></html>`,
   )}`;
 }
 
+function localUrl(hostname: string, path: string): string {
+  return `http://${hostname}:${localServerPort}${path}`;
+}
+
 async function waitForBlockedRequest(page: InternalPage): Promise<void> {
+  const outcomes = await waitForRequestOutcomes(page, pageWithBlockedImage(), [
+    BLOCKED_URL,
+  ]);
+  expectBlockedByClient(outcomes.get(BLOCKED_URL));
+}
+
+type RequestOutcome =
+  | { type: "finished" }
+  | { type: "failed"; errorText: string };
+
+async function waitForRequestOutcomes(
+  page: InternalPage,
+  pageUrl: string,
+  expectedUrls: string[],
+): Promise<Map<string, RequestOutcome>> {
   await page.mainSession.send("Network.enable");
 
-  await new Promise<void>((resolve, reject) => {
+  return await new Promise<Map<string, RequestOutcome>>((resolve, reject) => {
     const requestUrls = new Map<string, string>();
+    const expected = new Set(expectedUrls);
+    const outcomes = new Map<string, RequestOutcome>();
     let settled = false;
     const timeout = setTimeout(() => {
-      finish(() => reject(new Error("Timed out waiting for blocked request")));
+      finish(() =>
+        reject(
+          new Error(
+            `Timed out waiting for request outcomes: ${Array.from(expected).join(", ")}`,
+          ),
+        ),
+      );
     }, 5000);
 
     const cleanup = () => {
       clearTimeout(timeout);
       page.mainSession.off("Network.requestWillBeSent", onRequest);
+      page.mainSession.off("Network.loadingFinished", onLoadingFinished);
       page.mainSession.off("Network.loadingFailed", onLoadingFailed);
     };
 
-    const finish = (settle: () => void) => {
+    const finish = (settle: () => void): void => {
       if (settled) return;
       settled = true;
       cleanup();
       settle();
+    };
+
+    const recordOutcome = (url: string, outcome: RequestOutcome) => {
+      if (!expected.has(url) || outcomes.has(url)) return;
+      outcomes.set(url, outcome);
+      if (outcomes.size === expected.size) {
+        finish(() => resolve(outcomes));
+      }
     };
 
     const onRequest = (params: unknown) => {
@@ -53,23 +99,26 @@ async function waitForBlockedRequest(page: InternalPage): Promise<void> {
       requestUrls.set(evt.requestId, String(evt.request?.url ?? ""));
     };
 
+    const onLoadingFinished = (params: unknown) => {
+      const evt = params as Protocol.Network.LoadingFinishedEvent;
+      const url = requestUrls.get(evt.requestId);
+      if (!url) return;
+      recordOutcome(url, { type: "finished" });
+    };
+
     const onLoadingFailed = (params: unknown) => {
       const evt = params as Protocol.Network.LoadingFailedEvent;
       const url = requestUrls.get(evt.requestId);
-      if (url !== BLOCKED_URL) return;
-      try {
-        expect(evt.errorText).toContain("ERR_BLOCKED_BY_CLIENT");
-        finish(resolve);
-      } catch (error) {
-        finish(() => reject(error));
-      }
+      if (!url) return;
+      recordOutcome(url, { type: "failed", errorText: evt.errorText });
     };
 
     page.mainSession.on("Network.requestWillBeSent", onRequest);
+    page.mainSession.on("Network.loadingFinished", onLoadingFinished);
     page.mainSession.on("Network.loadingFailed", onLoadingFailed);
 
     void page
-      .goto(pageWithBlockedImage(), {
+      .goto(pageUrl, {
         waitUntil: "load",
         timeoutMs: 5000,
       })
@@ -79,8 +128,56 @@ async function waitForBlockedRequest(page: InternalPage): Promise<void> {
   });
 }
 
+function expectBlockedByClient(outcome: RequestOutcome | undefined): void {
+  expect(outcome?.type).toBe("failed");
+  expect((outcome as { errorText?: string } | undefined)?.errorText).toContain(
+    "ERR_BLOCKED_BY_CLIENT",
+  );
+}
+
+function expectNotBlockedByClient(outcome: RequestOutcome | undefined): void {
+  expect(outcome).toBeTruthy();
+  if (outcome?.type === "failed") {
+    expect(outcome.errorText).not.toContain("ERR_BLOCKED_BY_CLIENT");
+  }
+}
+
 test.describe("context.setDomainPolicy", () => {
   let v3: V3;
+
+  test.beforeAll(async () => {
+    localServer = createServer((_, res) => {
+      res.writeHead(200, {
+        "content-type": "image/svg+xml",
+        "cache-control": "no-store",
+      });
+      res.end(
+        `<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"></svg>`,
+      );
+    });
+
+    await new Promise<void>((resolve) => {
+      localServer?.listen(0, ALLOWED_HOST, () => {
+        localServerPort = (localServer?.address() as AddressInfo).port;
+        resolve();
+      });
+    });
+  });
+
+  test.afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      if (!localServer) {
+        resolve();
+        return;
+      }
+      localServer.close((error) => {
+        if (error) reject(error);
+        else resolve();
+      });
+    });
+    localServer = null;
+    localServerPort = 0;
+  });
 
   test.beforeEach(async () => {
     v3 = new V3(v3TestConfig);
@@ -112,5 +209,62 @@ test.describe("context.setDomainPolicy", () => {
     const page = (await ctx.newPage()) as unknown as InternalPage;
 
     await waitForBlockedRequest(page);
+  });
+
+  test("allows matching requests and blocks non-matching requests", async () => {
+    const ctx = v3.context;
+    const page = (await ctx.awaitActivePage()) as unknown as InternalPage;
+    const allowedUrl = localUrl(ALLOWED_HOST, "/allowed.png");
+    const disallowedUrl = localUrl(DISALLOWED_HOST, "/disallowed.png");
+
+    await ctx.setDomainPolicy({
+      allowedDomains: [ALLOWED_HOST],
+    });
+
+    const outcomes = await waitForRequestOutcomes(
+      page,
+      pageWithImages([allowedUrl, disallowedUrl]),
+      [allowedUrl, disallowedUrl],
+    );
+
+    expectNotBlockedByClient(outcomes.get(allowedUrl));
+    expectBlockedByClient(outcomes.get(disallowedUrl));
+  });
+
+  test("blocked domains take precedence over allowed domains", async () => {
+    const ctx = v3.context;
+    const page = (await ctx.awaitActivePage()) as unknown as InternalPage;
+
+    await ctx.setDomainPolicy({
+      allowedDomains: [ALLOWED_HOST],
+      blockedDomains: [ALLOWED_HOST],
+    });
+
+    const blockedUrl = localUrl(ALLOWED_HOST, "/blocked-by-precedence.png");
+    const outcomes = await waitForRequestOutcomes(
+      page,
+      pageWithImages([blockedUrl]),
+      [blockedUrl],
+    );
+
+    expectBlockedByClient(outcomes.get(blockedUrl));
+  });
+
+  test("allowed domains apply to pages created after setting the policy", async () => {
+    const ctx = v3.context;
+    const disallowedUrl = localUrl(DISALLOWED_HOST, "/new-page-disallowed.png");
+
+    await ctx.setDomainPolicy({
+      allowedDomains: [ALLOWED_HOST],
+    });
+
+    const page = (await ctx.newPage()) as unknown as InternalPage;
+    const outcomes = await waitForRequestOutcomes(
+      page,
+      pageWithImages([disallowedUrl]),
+      [disallowedUrl],
+    );
+
+    expectBlockedByClient(outcomes.get(disallowedUrl));
   });
 });

--- a/packages/core/tests/unit/context-domain-policy.test.ts
+++ b/packages/core/tests/unit/context-domain-policy.test.ts
@@ -32,6 +32,11 @@ const flushAsyncHandlers = async () => {
   await new Promise((resolve) => setTimeout(resolve, 0));
 };
 
+const ALLOWLIST_FETCH_PATTERNS = [
+  { urlPattern: "http://*/*", requestStage: "Request" },
+  { urlPattern: "https://*/*", requestStage: "Request" },
+];
+
 describe("V3Context.setDomainPolicy", () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -100,13 +105,49 @@ describe("V3Context.setDomainPolicy", () => {
     });
     await setDomainPolicy.call(ctx, null);
     await setDomainPolicy.call(ctx, { blockedDomains: [] });
+    await setDomainPolicy.call(ctx, { allowedDomains: [] });
 
     for (const session of [sessionA, sessionB]) {
-      expect(session.callsFor("Fetch.disable").length).toBe(2);
+      expect(session.callsFor("Fetch.disable").length).toBe(3);
       expect(session.listenerCount("Fetch.requestPaused")).toBe(0);
     }
 
     expect(getDomainPolicy.call(ctx)).toBeNull();
+  });
+
+  it("sends broad Fetch patterns when allowed domains are set", async () => {
+    const session = new MockCDPSession({}, "session-a");
+    const ctx = makeContext([session]);
+
+    await setDomainPolicy.call(ctx, {
+      allowedDomains: ["example.com", "*.example.com"],
+    });
+
+    expect(session.listenerCount("Fetch.requestPaused")).toBe(1);
+    expect(session.callsFor("Fetch.enable")[0]?.params).toEqual({
+      patterns: ALLOWLIST_FETCH_PATTERNS,
+    });
+    expect(getDomainPolicy.call(ctx)).toEqual({
+      allowedDomains: ["example.com", "*.example.com"],
+    });
+  });
+
+  it("sends broad Fetch patterns when allowed and blocked domains are set", async () => {
+    const session = new MockCDPSession({}, "session-a");
+    const ctx = makeContext([session]);
+
+    await setDomainPolicy.call(ctx, {
+      allowedDomains: ["example.com"],
+      blockedDomains: ["ads.example.com"],
+    });
+
+    expect(session.callsFor("Fetch.enable")[0]?.params).toEqual({
+      patterns: ALLOWLIST_FETCH_PATTERNS,
+    });
+    expect(getDomainPolicy.call(ctx)).toEqual({
+      allowedDomains: ["example.com"],
+      blockedDomains: ["ads.example.com"],
+    });
   });
 
   it("keeps its requestPaused listener when Fetch.disable fails", async () => {
@@ -226,6 +267,67 @@ describe("V3Context.setDomainPolicy", () => {
 
     expect(session.callsFor("Fetch.continueRequest")[0]?.params).toEqual({
       requestId: "request-1",
+    });
+  });
+
+  it("continues allowed paused requests", async () => {
+    const session = new MockCDPSession({}, "session-a");
+    const ctx = makeContext([session]);
+
+    await setDomainPolicy.call(ctx, {
+      allowedDomains: ["example.com", "*.example.com"],
+    });
+
+    session.emit("Fetch.requestPaused", {
+      requestId: "request-1",
+      request: { url: "https://app.example.com/" },
+    });
+    await flushAsyncHandlers();
+
+    expect(session.callsFor("Fetch.continueRequest")[0]?.params).toEqual({
+      requestId: "request-1",
+    });
+    expect(session.callsFor("Fetch.failRequest").length).toBe(0);
+  });
+
+  it("fails disallowed paused requests", async () => {
+    const session = new MockCDPSession({}, "session-a");
+    const ctx = makeContext([session]);
+
+    await setDomainPolicy.call(ctx, {
+      allowedDomains: ["example.com"],
+    });
+
+    session.emit("Fetch.requestPaused", {
+      requestId: "request-1",
+      request: { url: "https://other.test/" },
+    });
+    await flushAsyncHandlers();
+
+    expect(session.callsFor("Fetch.failRequest")[0]?.params).toEqual({
+      requestId: "request-1",
+      errorReason: "BlockedByClient",
+    });
+  });
+
+  it("fails blocked requests even when they are also allowed", async () => {
+    const session = new MockCDPSession({}, "session-a");
+    const ctx = makeContext([session]);
+
+    await setDomainPolicy.call(ctx, {
+      allowedDomains: ["example.com", "*.example.com"],
+      blockedDomains: ["ads.example.com"],
+    });
+
+    session.emit("Fetch.requestPaused", {
+      requestId: "request-1",
+      request: { url: "https://ads.example.com/script.js" },
+    });
+    await flushAsyncHandlers();
+
+    expect(session.callsFor("Fetch.failRequest")[0]?.params).toEqual({
+      requestId: "request-1",
+      errorReason: "BlockedByClient",
     });
   });
 

--- a/packages/core/tests/unit/domain-policy.test.ts
+++ b/packages/core/tests/unit/domain-policy.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import {
   getDomainPolicyDecision,
   normalizeDomainPolicy,
-  shouldBlockUrl,
 } from "../../lib/v3/understudy/domainPolicy.js";
 import { StagehandInvalidArgumentError } from "../../lib/v3/types/public/sdkErrors.js";
 
@@ -70,28 +69,39 @@ describe("domain policy helpers", () => {
       blockedDomains: ["ads.example.com", "*.tracking.example.com"],
     });
 
-    expect(shouldBlockUrl("https://ads.example.com/script.js", policy)).toBe(
-      true,
-    );
     expect(
-      shouldBlockUrl("https://a.tracking.example.com/pixel.gif", policy),
-    ).toBe(true);
+      getDomainPolicyDecision("https://ads.example.com/script.js", policy),
+    ).toMatchObject({ action: "block" });
     expect(
-      shouldBlockUrl("https://deep.a.tracking.example.com/pixel.gif", policy),
-    ).toBe(true);
-    expect(shouldBlockUrl("https://ads.example.com./script.js", policy)).toBe(
-      true,
-    );
+      getDomainPolicyDecision(
+        "https://a.tracking.example.com/pixel.gif",
+        policy,
+      ),
+    ).toMatchObject({ action: "block" });
     expect(
-      shouldBlockUrl("https://a.tracking.example.com./pixel.gif", policy),
-    ).toBe(true);
-    expect(shouldBlockUrl("https://tracking.example.com/", policy)).toBe(false);
-    expect(shouldBlockUrl("https://badtracking.example.com/", policy)).toBe(
-      false,
-    );
-    expect(shouldBlockUrl("https://ads.example.com.evil.test/", policy)).toBe(
-      false,
-    );
+      getDomainPolicyDecision(
+        "https://deep.a.tracking.example.com/pixel.gif",
+        policy,
+      ),
+    ).toMatchObject({ action: "block" });
+    expect(
+      getDomainPolicyDecision("https://ads.example.com./script.js", policy),
+    ).toMatchObject({ action: "block" });
+    expect(
+      getDomainPolicyDecision(
+        "https://a.tracking.example.com./pixel.gif",
+        policy,
+      ),
+    ).toMatchObject({ action: "block" });
+    expect(
+      getDomainPolicyDecision("https://tracking.example.com/", policy),
+    ).toEqual({ action: "continue" });
+    expect(
+      getDomainPolicyDecision("https://badtracking.example.com/", policy),
+    ).toEqual({ action: "continue" });
+    expect(
+      getDomainPolicyDecision("https://ads.example.com.evil.test/", policy),
+    ).toEqual({ action: "continue" });
   });
 
   it("generates broad HTTP and HTTPS Fetch patterns for allowed domains", () => {
@@ -122,10 +132,23 @@ describe("domain policy helpers", () => {
       allowedDomains: ["example.com", "*.example.com"],
     });
 
-    expect(shouldBlockUrl("https://example.com/", policy)).toBe(false);
-    expect(shouldBlockUrl("https://app.example.com/", policy)).toBe(false);
-    expect(shouldBlockUrl("https://deep.app.example.com/", policy)).toBe(false);
-    expect(shouldBlockUrl("https://other.test/", policy)).toBe(true);
+    expect(getDomainPolicyDecision("https://example.com/", policy)).toEqual({
+      action: "continue",
+    });
+    expect(getDomainPolicyDecision("https://app.example.com/", policy)).toEqual(
+      {
+        action: "continue",
+      },
+    );
+    expect(
+      getDomainPolicyDecision("https://deep.app.example.com/", policy),
+    ).toEqual({
+      action: "continue",
+    });
+    expect(getDomainPolicyDecision("https://other.test/", policy)).toEqual({
+      action: "block",
+      reason: "allowedDomains",
+    });
   });
 
   it("does not let wildcard allowed domains match the apex domain", () => {
@@ -133,8 +156,15 @@ describe("domain policy helpers", () => {
       allowedDomains: ["*.example.com"],
     });
 
-    expect(shouldBlockUrl("https://app.example.com/", policy)).toBe(false);
-    expect(shouldBlockUrl("https://example.com/", policy)).toBe(true);
+    expect(getDomainPolicyDecision("https://app.example.com/", policy)).toEqual(
+      {
+        action: "continue",
+      },
+    );
+    expect(getDomainPolicyDecision("https://example.com/", policy)).toEqual({
+      action: "block",
+      reason: "allowedDomains",
+    });
   });
 
   it("lets blocked domains win over allowed domains", () => {
@@ -163,12 +193,12 @@ describe("domain policy helpers", () => {
       blockedDomains: ["ADS.EXAMPLE.COM"],
     });
 
-    expect(shouldBlockUrl("https://ads.example.com/script.js", policy)).toBe(
-      true,
-    );
-    expect(shouldBlockUrl("https://ADS.EXAMPLE.COM/script.js", policy)).toBe(
-      true,
-    );
+    expect(
+      getDomainPolicyDecision("https://ads.example.com/script.js", policy),
+    ).toMatchObject({ action: "block" });
+    expect(
+      getDomainPolicyDecision("https://ADS.EXAMPLE.COM/script.js", policy),
+    ).toMatchObject({ action: "block" });
   });
 
   it("continues malformed and non-HTTP URLs", () => {
@@ -177,9 +207,17 @@ describe("domain policy helpers", () => {
       blockedDomains: ["ads.example.com"],
     });
 
-    expect(shouldBlockUrl("not a url", policy)).toBe(false);
-    expect(shouldBlockUrl("data:text/plain,hello", policy)).toBe(false);
-    expect(shouldBlockUrl("file:///tmp/example.html", policy)).toBe(false);
+    expect(getDomainPolicyDecision("not a url", policy)).toEqual({
+      action: "continue",
+    });
+    expect(getDomainPolicyDecision("data:text/plain,hello", policy)).toEqual({
+      action: "continue",
+    });
+    expect(getDomainPolicyDecision("file:///tmp/example.html", policy)).toEqual(
+      {
+        action: "continue",
+      },
+    );
   });
 
   it("rejects invalid blocked domain patterns", () => {

--- a/packages/core/tests/unit/domain-policy.test.ts
+++ b/packages/core/tests/unit/domain-policy.test.ts
@@ -220,6 +220,42 @@ describe("domain policy helpers", () => {
     );
   });
 
+  it("treats null, empty objects, and empty arrays as disabled policies", () => {
+    expect(normalizeDomainPolicy(null)).toBeNull();
+    expect(normalizeDomainPolicy({})).toBeNull();
+    expect(normalizeDomainPolicy({ allowedDomains: [] })).toBeNull();
+    expect(normalizeDomainPolicy({ blockedDomains: [] })).toBeNull();
+    expect(
+      normalizeDomainPolicy({ allowedDomains: [], blockedDomains: [] }),
+    ).toBeNull();
+  });
+
+  it("rejects omitted policy and non-array domain fields", () => {
+    expect(() => normalizeDomainPolicy(undefined)).toThrow(
+      StagehandInvalidArgumentError,
+    );
+    expect(() =>
+      normalizeDomainPolicy({
+        allowedDomains: "example.com" as unknown as string[],
+      }),
+    ).toThrow(StagehandInvalidArgumentError);
+    expect(() =>
+      normalizeDomainPolicy({
+        allowedDomains: new Set(["example.com"]) as unknown as string[],
+      }),
+    ).toThrow(StagehandInvalidArgumentError);
+    expect(() =>
+      normalizeDomainPolicy({
+        blockedDomains: "ads.example.com" as unknown as string[],
+      }),
+    ).toThrow(StagehandInvalidArgumentError);
+    expect(() =>
+      normalizeDomainPolicy({
+        blockedDomains: new Set(["ads.example.com"]) as unknown as string[],
+      }),
+    ).toThrow(StagehandInvalidArgumentError);
+  });
+
   it("rejects invalid blocked domain patterns", () => {
     expect(() =>
       normalizeDomainPolicy({ blockedDomains: ["https://example.com"] }),

--- a/packages/core/tests/unit/domain-policy.test.ts
+++ b/packages/core/tests/unit/domain-policy.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  getDomainPolicyDecision,
   normalizeDomainPolicy,
   shouldBlockUrl,
 } from "../../lib/v3/understudy/domainPolicy.js";
@@ -93,6 +94,70 @@ describe("domain policy helpers", () => {
     );
   });
 
+  it("generates broad HTTP and HTTPS Fetch patterns for allowed domains", () => {
+    const policy = normalizeDomainPolicy({
+      allowedDomains: ["example.com"],
+    });
+
+    expect(policy?.fetchPatterns).toEqual([
+      { urlPattern: "http://*/*", requestStage: "Request" },
+      { urlPattern: "https://*/*", requestStage: "Request" },
+    ]);
+  });
+
+  it("uses broad Fetch patterns when allowed and blocked domains are combined", () => {
+    const policy = normalizeDomainPolicy({
+      allowedDomains: ["example.com"],
+      blockedDomains: ["ads.example.com"],
+    });
+
+    expect(policy?.fetchPatterns).toEqual([
+      { urlPattern: "http://*/*", requestStage: "Request" },
+      { urlPattern: "https://*/*", requestStage: "Request" },
+    ]);
+  });
+
+  it("allows matching exact and wildcard allowed domains", () => {
+    const policy = normalizeDomainPolicy({
+      allowedDomains: ["example.com", "*.example.com"],
+    });
+
+    expect(shouldBlockUrl("https://example.com/", policy)).toBe(false);
+    expect(shouldBlockUrl("https://app.example.com/", policy)).toBe(false);
+    expect(shouldBlockUrl("https://deep.app.example.com/", policy)).toBe(false);
+    expect(shouldBlockUrl("https://other.test/", policy)).toBe(true);
+  });
+
+  it("does not let wildcard allowed domains match the apex domain", () => {
+    const policy = normalizeDomainPolicy({
+      allowedDomains: ["*.example.com"],
+    });
+
+    expect(shouldBlockUrl("https://app.example.com/", policy)).toBe(false);
+    expect(shouldBlockUrl("https://example.com/", policy)).toBe(true);
+  });
+
+  it("lets blocked domains win over allowed domains", () => {
+    const policy = normalizeDomainPolicy({
+      allowedDomains: ["example.com", "*.example.com"],
+      blockedDomains: ["ads.example.com"],
+    });
+
+    expect(getDomainPolicyDecision("https://example.com/", policy)).toEqual({
+      action: "continue",
+    });
+    expect(
+      getDomainPolicyDecision("https://ads.example.com/script.js", policy),
+    ).toEqual({
+      action: "block",
+      reason: "blockedDomains",
+    });
+    expect(getDomainPolicyDecision("https://other.test/", policy)).toEqual({
+      action: "block",
+      reason: "allowedDomains",
+    });
+  });
+
   it("matches domains case-insensitively", () => {
     const policy = normalizeDomainPolicy({
       blockedDomains: ["ADS.EXAMPLE.COM"],
@@ -108,6 +173,7 @@ describe("domain policy helpers", () => {
 
   it("continues malformed and non-HTTP URLs", () => {
     const policy = normalizeDomainPolicy({
+      allowedDomains: ["example.com"],
       blockedDomains: ["ads.example.com"],
     });
 
@@ -131,5 +197,32 @@ describe("domain policy helpers", () => {
         blockedDomains: [123] as unknown as string[],
       }),
     ).toThrow(StagehandInvalidArgumentError);
+  });
+
+  it("rejects invalid allowed domain patterns", () => {
+    expect(() =>
+      normalizeDomainPolicy({ allowedDomains: ["https://example.com"] }),
+    ).toThrow(StagehandInvalidArgumentError);
+    expect(() =>
+      normalizeDomainPolicy({ allowedDomains: ["*example.com"] }),
+    ).toThrow(StagehandInvalidArgumentError);
+    expect(() =>
+      normalizeDomainPolicy({ allowedDomains: ["example"] }),
+    ).toThrow(StagehandInvalidArgumentError);
+    expect(() =>
+      normalizeDomainPolicy({
+        allowedDomains: [123] as unknown as string[],
+      }),
+    ).toThrow(StagehandInvalidArgumentError);
+  });
+
+  it("dedupes normalized allowed and blocked domains", () => {
+    const policy = normalizeDomainPolicy({
+      allowedDomains: ["EXAMPLE.COM", "example.com."],
+      blockedDomains: ["*.ADS.EXAMPLE.COM", "*.ads.example.com."],
+    });
+
+    expect(policy?.allowedDomains).toEqual(["example.com"]);
+    expect(policy?.blockedDomains).toEqual(["*.ads.example.com"]);
   });
 });


### PR DESCRIPTION
# why

users need a way to restrict browser sessions to known domains. addresses #2272 

# what changed

- users can now call `stagehand.context.setDomainPolicy({ allowedDomains })` to block HTTP(S) requests that do not match the allowed domains
- `DomainPolicy` now supports both `allowedDomains` & `blockedDomains`
- blocked domains take precedence over allowed domains when both are provided
- allowlist policies use broad HTTP(S) `Fetch` request patterns because allowlists require checking every HTTP(S) request
- blocklist-only policies keep the existing optimized behavior of only pausing requests that match generated blocklist patterns
- domain policy matching also returns a decision with the block reason, so logs can distinguish `allowedDomains` blocks from `blockedDomains` blocks

### behavioural notes

- `setDomainPolicy({ allowedDomains: [...] })` applies to active context sessions & future pages/targets
- exact domains like `example.com` allow only that hostname
- wildcard domains like `*.example.com` allow subdomains, but not the apex domain
- requests to domains outside `allowedDomains` are failed with `BlockedByClient`
- if a request matches `blockedDomains`, it is blocked even if it also matches `allowedDomains`
- non-HTTP(S) urls continue instead of being blocked by the domain policy
- `setDomainPolicy()` replaces the current policy; callers should pass both `allowedDomains` & `blockedDomains` in the same call when they want both
- clearing with `setDomainPolicy(null)`, `{ allowedDomains: [] }`, or an otherwise empty policy disables the policy when no blocked domains are present

# test plan

- `packages/core/tests/unit/domain-policy.test.ts` validates allowlist normalization, exact/wildcard matching, invalid allowed domain rejection, block-over-allow precedence, non-HTTP(S) continuation & broad HTTP(S) `Fetch.RequestPattern` generation
- `packages/core/tests/unit/context-domain-policy.test.ts` validates `context.setDomainPolicy()` enables broad HTTP(S) interception for allowlists, preserves precise blocklist-only interception, returns normalized policy state, continues allowed paused requests & fails disallowed paused requests
- `packages/core/tests/integration/context-domain-policy.spec.ts` validates allowed-domain requests are not blocked, non-matching requests fail with `ERR_BLOCKED_BY_CLIENT`, blocked domains take precedence over allowed domains & allowlist policies apply to pages created after the policy is set



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a context-wide domain policy to control which HTTP(S) requests Stagehand can access. You can allow specific domains or block known hosts, with strict enforcement across existing and new pages.

- **New Features**
  - Added `context.setDomainPolicy({ allowedDomains?: string[], blockedDomains?: string[] })` and `context.getDomainPolicy()`. Domain-only patterns; exact or `*.example.com` (wildcards do not match the apex). HTTP(S) only. Applies to current and future pages. Clear with `null` or empty arrays; `getDomainPolicy()` returns only set fields.
  - Enforcement: `blockedDomains` take precedence over `allowedDomains`. Allowlists use broad HTTP(S) `Fetch` interception; blocklist-only policies keep precise patterns. Logs include the block reason (`allowedDomains` vs `blockedDomains`).
  - Errors & validation: Added `StagehandSetDomainPolicyError` when enforcement can’t be guaranteed during target attach. Added runtime validation; malformed inputs (omitted policy, non-array fields, non-string or non-domain patterns) throw `StagehandInvalidArgumentError`.

<sup>Written for commit 60bafc3cefd2d2ba257dbeb8acfda1246e148b7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



