### PR TITLE
fix(server-v3): Prevent evicting in-use sessions mid-request

### DIFF
--- a/.changeset/spicy-sessions-pin.md
+++ b/.changeset/spicy-sessions-pin.md
@@ -1,0 +1,7 @@
+---
+"@browserbasehq/stagehand-server-v3": patch
+---
+
+Prevent long-running agent runs from having their sessions ended early.
+
+The hosted API's session store could LRU-evict or TTL-expire a session while a request was still using it, surfacing as a "Stagehand session was closed" error on an action that had already succeeded. Sessions are now pinned for the full duration of a request (via a `withSession` wrapper and an `inUse` refcount) and excluded from eviction/expiry while in use. The pin is taken before lazy `init()`, released only after the handler settles, and unmatched releases are ignored.

--- a/.changeset/spicy-sessions-pin.md
+++ b/.changeset/spicy-sessions-pin.md
@@ -2,6 +2,4 @@
 "@browserbasehq/stagehand-server-v3": patch
 ---
 
-Prevent long-running agent runs from having their sessions ended early.
-
-The hosted API's session store could LRU-evict or TTL-expire a session while a request was still using it, surfacing as a "Stagehand session was closed" error on an action that had already succeeded. Sessions are now pinned for the full duration of a request (via a `withSession` wrapper and an `inUse` refcount) and excluded from eviction/expiry while in use. The pin is taken before lazy `init()`, released only after the handler settles, and unmatched releases are ignored.
+Fix long-running requests (e.g. `agentExecute`) sometimes failing with "Stagehand session was closed" even though the action had already completed.

--- a/packages/server-v3/src/lib/InMemorySessionStore.ts
+++ b/packages/server-v3/src/lib/InMemorySessionStore.ts
@@ -372,16 +372,18 @@ export class InMemorySessionStore implements SessionStore {
         throw new Error("Max capacity must be greater than 0");
       }
       const previousCapacity = this.maxCapacity;
-      this.maxCapacity = config.maxCapacity;
 
-      // Evict excess if new capacity is smaller
-      if (this.maxCapacity < previousCapacity) {
-        const excess = this.items.size - this.maxCapacity;
+      // Evict before lowering capacity. Pinned (in-use) sessions can't be
+      // evicted, so the cache may briefly exceed the new capacity and converge
+      // as those requests finish — that's expected, not an error.
+      if (config.maxCapacity < previousCapacity) {
+        const excess = this.items.size - config.maxCapacity;
         for (let i = 0; i < excess; i++) {
           // Fire and forget - don't await to match cloud behavior
           this.evictLru().catch(console.error);
         }
       }
+      this.maxCapacity = config.maxCapacity;
     }
 
     if (config.ttlMs !== undefined) {

--- a/packages/server-v3/src/lib/InMemorySessionStore.ts
+++ b/packages/server-v3/src/lib/InMemorySessionStore.ts
@@ -201,9 +201,11 @@ export class InMemorySessionStore implements SessionStore {
       node.loggerRef.current = ctx.logger;
     }
 
+    // Pin before any await so the node can't be evicted or TTL-expired during a lazy init()
+    node.inUse += 1;
+
     // If V3 instance exists, return it
     if (node.stagehand) {
-      node.inUse += 1;
       return node.stagehand;
     }
 
@@ -213,6 +215,9 @@ export class InMemorySessionStore implements SessionStore {
     try {
       await stagehand.init();
     } catch (error) {
+      // Undo the pin taken above; the node stays (stagehand still null) so a
+      // later request can retry init.
+      node.inUse -= 1;
       try {
         await stagehand.close();
       } catch {
@@ -221,7 +226,6 @@ export class InMemorySessionStore implements SessionStore {
       throw error;
     }
     node.stagehand = stagehand;
-    node.inUse += 1;
     return stagehand;
   }
 
@@ -229,9 +233,11 @@ export class InMemorySessionStore implements SessionStore {
     const node = this.items.get(sessionId);
     if (!node) return;
 
-    if (node.inUse > 0) {
-      node.inUse -= 1;
-    }
+    // Ignore unmatched/double releases: never go negative, and don't refresh
+    // the TTL of an already-idle session
+    if (node.inUse === 0) return;
+
+    node.inUse -= 1;
 
     if (this.ttlMs > 0) {
       node.expiry = Date.now() + this.ttlMs;

--- a/packages/server-v3/src/lib/InMemorySessionStore.ts
+++ b/packages/server-v3/src/lib/InMemorySessionStore.ts
@@ -21,6 +21,8 @@ interface LruNode {
   stagehand: V3 | null;
   loggerRef: { current?: (message: LogLine) => void };
   expiry: number;
+  /** Number of in-flight requests using this session's V3 instance. */
+  inUse: number;
   prev: LruNode | null;
   next: LruNode | null;
 }
@@ -91,7 +93,8 @@ export class InMemorySessionStore implements SessionStore {
     const expiredIds: string[] = [];
 
     for (const [sessionId, node] of this.items.entries()) {
-      if (this.ttlMs > 0 && node.expiry <= now) {
+      // Never expire a session that is actively serving a request.
+      if (this.ttlMs > 0 && node.expiry <= now && node.inUse === 0) {
         expiredIds.push(sessionId);
       }
     }
@@ -129,13 +132,18 @@ export class InMemorySessionStore implements SessionStore {
   }
 
   /**
-   * Evict the least recently used session
+   * Evict the least recently used session that is not actively serving a
+   * request. If every cached session is in use, skip eviction rather than
+   * tear down a live request's browser context.
    */
   private async evictLru(): Promise<void> {
-    const lruNode = this.first;
-    if (!lruNode) return;
+    let node = this.first;
+    while (node && node.inUse > 0) {
+      node = node.next;
+    }
+    if (!node) return;
 
-    await this.deleteSession(lruNode.sessionId);
+    await this.deleteSession(node.sessionId);
   }
 
   async startSession(params: CreateSessionParams): Promise<SessionStartResult> {
@@ -160,8 +168,8 @@ export class InMemorySessionStore implements SessionStore {
     const node = this.items.get(sessionId);
     if (!node) return false;
 
-    // Check if expired
-    if (this.ttlMs > 0 && node.expiry <= Date.now()) {
+    // Check if expired, but don't expire a session that is actively serving a request
+    if (this.ttlMs > 0 && node.expiry <= Date.now() && node.inUse === 0) {
       await this.deleteSession(sessionId);
       return false;
     }
@@ -180,7 +188,7 @@ export class InMemorySessionStore implements SessionStore {
     }
 
     // Check if expired
-    if (this.ttlMs > 0 && node.expiry <= Date.now()) {
+    if (this.ttlMs > 0 && node.expiry <= Date.now() && node.inUse === 0) {
       await this.deleteSession(sessionId);
       throw new Error(`Session expired: ${sessionId}`);
     }
@@ -195,6 +203,7 @@ export class InMemorySessionStore implements SessionStore {
 
     // If V3 instance exists, return it
     if (node.stagehand) {
+      node.inUse += 1;
       return node.stagehand;
     }
 
@@ -212,7 +221,21 @@ export class InMemorySessionStore implements SessionStore {
       throw error;
     }
     node.stagehand = stagehand;
+    node.inUse += 1;
     return stagehand;
+  }
+
+  async releaseSession(sessionId: string): Promise<void> {
+    const node = this.items.get(sessionId);
+    if (!node) return;
+
+    if (node.inUse > 0) {
+      node.inUse -= 1;
+    }
+
+    if (this.ttlMs > 0) {
+      node.expiry = Date.now() + this.ttlMs;
+    }
   }
 
   /**
@@ -286,6 +309,7 @@ export class InMemorySessionStore implements SessionStore {
       stagehand: null, // Lazy initialization
       loggerRef: {},
       expiry: this.ttlMs > 0 ? Date.now() + this.ttlMs : Infinity,
+      inUse: 0,
       prev: this.last,
       next: null,
     };

--- a/packages/server-v3/src/lib/InMemorySessionStore.ts
+++ b/packages/server-v3/src/lib/InMemorySessionStore.ts
@@ -378,10 +378,18 @@ export class InMemorySessionStore implements SessionStore {
       // as those requests finish — that's expected, not an error.
       if (config.maxCapacity < previousCapacity) {
         const excess = this.items.size - config.maxCapacity;
-        for (let i = 0; i < excess; i++) {
-          // Fire and forget - don't await to match cloud behavior
-          this.evictLru().catch(console.error);
-        }
+        // Evict sequentially: deleteSession removes the node only after awaiting
+        // close, so firing these concurrently would make every call target the
+        // same LRU node. The batch stays fire-and-forget to match cloud behavior.
+        void (async () => {
+          for (let i = 0; i < excess; i++) {
+            try {
+              await this.evictLru();
+            } catch (err) {
+              console.error(err);
+            }
+          }
+        })();
       }
       this.maxCapacity = config.maxCapacity;
     }

--- a/packages/server-v3/src/lib/SessionStore.ts
+++ b/packages/server-v3/src/lib/SessionStore.ts
@@ -138,12 +138,31 @@ export interface SessionStore {
    * - On cache miss: loading config, creating V3, caching it
    * - Updating the logger reference for streaming
    *
+   * Acquire/release contract: this call PINS the session. Implementations MUST
+   * NOT evict or TTL-expire a session between a getOrCreateStagehand and its
+   * matching releaseSession — otherwise a long-running request (e.g. an
+   * agentExecute that spends tens of seconds in agent "think time" with no CDP
+   * traffic) can have its browser context torn out mid-flight. Always use this
+   * via the withSession() wrapper, which guarantees the matching release.
+   *
    * @param sessionId - The session identifier
    * @param ctx - Request-time context containing values from headers
    * @returns The V3 instance ready for use
    * @throws Error if session not found
    */
   getOrCreateStagehand(sessionId: string, ctx: RequestContext): Promise<V3>;
+
+  /**
+   * Release a session previously pinned by getOrCreateStagehand.
+   *
+   * Decrements the in-use count so the session becomes eligible for eviction/
+   * TTL again once no requests hold it. MUST clamp at zero (a release without a
+   * matching acquire is a no-op, never a negative count). Prefer calling this
+   * via withSession() rather than directly.
+   *
+   * @param sessionId - The session identifier
+   */
+  releaseSession(sessionId: string): void | Promise<void>;
 
   /**
    * Create a new session with the given parameters.

--- a/packages/server-v3/src/lib/stream.ts
+++ b/packages/server-v3/src/lib/stream.ts
@@ -15,6 +15,7 @@ import {
 import { error, success } from "./response.js";
 import { getSessionStore } from "./sessionStoreManager.js";
 import type { RequestContext } from "./SessionStore.js";
+import { withSession } from "./withSession.js";
 
 interface StreamingResponseOptions<TV3> {
   sessionId: string;
@@ -180,38 +181,23 @@ export async function createStreamingResponse<TV3>({
       : undefined,
   };
 
-  let stagehand: V3Stagehand;
-  try {
-    stagehand = (await sessionStore.getOrCreateStagehand(
-      sessionId,
-      requestContext,
-    )) as V3Stagehand;
-  } catch (err) {
-    const loadError = err instanceof Error ? err : new Error(String(err));
-
-    sendData("error", "system", { status: "error", error: loadError.message });
-
-    if (shouldStreamResponse) {
-      reply.raw.end();
-      return reply;
-    }
-
-    return error(
-      reply,
-      loadError.message,
-      loadError instanceof AppError
-        ? loadError.statusCode
-        : StatusCodes.INTERNAL_SERVER_ERROR,
-    );
-  }
-
-  sendData("connected", "system", { status: "connected" });
-
   let result: Awaited<ReturnType<typeof handler>> | null = null;
   let handlerError: Error | null = null;
 
+  // withSession pins the session for the duration of the handler so it can't be
+  // evicted or TTL-expired mid-request, and guarantees release (incl. on abort).
+  // Acquire failures (session not found/expired) surface here too and are
+  // rendered as an error response below, same as handler failures.
   try {
-    result = await handler({ stagehand, data: parsedData });
+    result = await withSession(
+      sessionId,
+      requestContext,
+      request,
+      (stagehand) => {
+        sendData("connected", "system", { status: "connected" });
+        return handler({ stagehand, data: parsedData });
+      },
+    );
   } catch (err) {
     handlerError = err instanceof Error ? err : new Error("Unknown error");
     request.log.error(

--- a/packages/server-v3/src/lib/stream.ts
+++ b/packages/server-v3/src/lib/stream.ts
@@ -184,20 +184,15 @@ export async function createStreamingResponse<TV3>({
   let result: Awaited<ReturnType<typeof handler>> | null = null;
   let handlerError: Error | null = null;
 
-  // withSession pins the session for the duration of the handler so it can't be
-  // evicted or TTL-expired mid-request, and guarantees release (incl. on abort).
-  // Acquire failures (session not found/expired) surface here too and are
-  // rendered as an error response below, same as handler failures.
+  // withSession pins the session for the whole handler so it can't be evicted
+  // or TTL-expired mid-request, and releases once the handler settles. Acquire
+  // failures (session not found/expired) surface here too and are rendered as
+  // an error response below, same as handler failures.
   try {
-    result = await withSession(
-      sessionId,
-      requestContext,
-      request,
-      (stagehand) => {
-        sendData("connected", "system", { status: "connected" });
-        return handler({ stagehand, data: parsedData });
-      },
-    );
+    result = await withSession(sessionId, requestContext, (stagehand) => {
+      sendData("connected", "system", { status: "connected" });
+      return handler({ stagehand, data: parsedData });
+    });
   } catch (err) {
     handlerError = err instanceof Error ? err : new Error("Unknown error");
     request.log.error(

--- a/packages/server-v3/src/lib/withSession.ts
+++ b/packages/server-v3/src/lib/withSession.ts
@@ -1,27 +1,33 @@
-import type { FastifyRequest } from "fastify";
 import type { Stagehand as V3Stagehand } from "@browserbasehq/stagehand";
 
 import { getSessionStore } from "./sessionStoreManager.js";
 import type { RequestContext } from "./SessionStore.js";
 
 /**
- * Acquire a session's V3 instance, run `fn`, and guarantee exactly one release.
+ * Acquire a session's V3 instance, run `fn`, and release exactly once when
+ * `fn` settles.
  *
  * The session is pinned — excluded from LRU eviction and TTL expiry — for the
- * full duration of `fn`, including agent "think time" when no CDP traffic flows.
+ * full duration of `fn`, including agent "think time" when no CDP traffic
+ * flows. Release happens only in the `finally`, i.e. strictly AFTER `fn`
+ * settles, so the session can never be evicted while the handler is still
+ * using its Stagehand instance.
+ *
+ * Note: we intentionally do NOT release on client disconnect. If the client
+ * goes away, the handler keeps running server-side (and may still be driving
+ * the browser — e.g. completing a payment); releasing then would let the
+ * session be evicted mid-operation, the exact bug this pinning prevents. The
+ * handler is bounded by its own step/timeout limits, so the `finally` always
+ * runs and the pin is released when the work actually finishes.
+ *
  * This is the only supported way to use a session's V3 instance for a request:
  * callers must never hold a stagehand reference past the end of `fn`.
- *
- * Release fires from both the `finally` and the request "close" event, guarded
- * so it runs at most once. `close` (unlike `onResponse`) also fires on client
- * abort / socket teardown, so an aborted request can't leak a permanent pin.
  *
  * Acquire failures propagate to the caller before any pin is taken.
  */
 export async function withSession<T>(
   sessionId: string,
   ctx: RequestContext,
-  request: FastifyRequest,
   fn: (stagehand: V3Stagehand) => Promise<T>,
 ): Promise<T> {
   const sessionStore = getSessionStore();
@@ -30,20 +36,13 @@ export async function withSession<T>(
     ctx,
   )) as V3Stagehand;
 
-  let released = false;
-  const release = () => {
-    if (released) return;
-    released = true;
-    request.raw.off("close", release);
-    void Promise.resolve(sessionStore.releaseSession(sessionId)).catch(() => {
-      // best-effort release
-    });
-  };
-  request.raw.once("close", release);
-
   try {
     return await fn(stagehand);
   } finally {
-    release();
+    try {
+      await sessionStore.releaseSession(sessionId);
+    } catch {
+      // best-effort release
+    }
   }
 }

--- a/packages/server-v3/src/lib/withSession.ts
+++ b/packages/server-v3/src/lib/withSession.ts
@@ -41,8 +41,14 @@ export async function withSession<T>(
   } finally {
     try {
       await sessionStore.releaseSession(sessionId);
-    } catch {
-      // best-effort release
+    } catch (err) {
+      // A failed release leaves the session pinned (inUse not decremented),
+      // which leaks capacity. Don't rethrow (that would clobber the handler's
+      // result/error in a finally) — record it so the leak is detectable.
+      console.error(
+        `Failed to release session ${sessionId}; it may remain pinned:`,
+        err,
+      );
     }
   }
 }

--- a/packages/server-v3/src/lib/withSession.ts
+++ b/packages/server-v3/src/lib/withSession.ts
@@ -1,0 +1,49 @@
+import type { FastifyRequest } from "fastify";
+import type { Stagehand as V3Stagehand } from "@browserbasehq/stagehand";
+
+import { getSessionStore } from "./sessionStoreManager.js";
+import type { RequestContext } from "./SessionStore.js";
+
+/**
+ * Acquire a session's V3 instance, run `fn`, and guarantee exactly one release.
+ *
+ * The session is pinned — excluded from LRU eviction and TTL expiry — for the
+ * full duration of `fn`, including agent "think time" when no CDP traffic flows.
+ * This is the only supported way to use a session's V3 instance for a request:
+ * callers must never hold a stagehand reference past the end of `fn`.
+ *
+ * Release fires from both the `finally` and the request "close" event, guarded
+ * so it runs at most once. `close` (unlike `onResponse`) also fires on client
+ * abort / socket teardown, so an aborted request can't leak a permanent pin.
+ *
+ * Acquire failures propagate to the caller before any pin is taken.
+ */
+export async function withSession<T>(
+  sessionId: string,
+  ctx: RequestContext,
+  request: FastifyRequest,
+  fn: (stagehand: V3Stagehand) => Promise<T>,
+): Promise<T> {
+  const sessionStore = getSessionStore();
+  const stagehand = (await sessionStore.getOrCreateStagehand(
+    sessionId,
+    ctx,
+  )) as V3Stagehand;
+
+  let released = false;
+  const release = () => {
+    if (released) return;
+    released = true;
+    request.raw.off("close", release);
+    void Promise.resolve(sessionStore.releaseSession(sessionId)).catch(() => {
+      // best-effort release
+    });
+  };
+  request.raw.once("close", release);
+
+  try {
+    return await fn(stagehand);
+  } finally {
+    release();
+  }
+}

--- a/packages/server-v3/src/routes/v1/sessions/start.ts
+++ b/packages/server-v3/src/routes/v1/sessions/start.ts
@@ -238,7 +238,6 @@ const startRouteHandler: RouteHandler = withErrorHandling(
         finalCdpUrl = await withSession(
           session.sessionId,
           { modelApiKey: localBrowserModelApiKey },
-          request,
           (stagehand) => Promise.resolve(stagehand.connectURL()),
         );
       } catch (err) {

--- a/packages/server-v3/src/routes/v1/sessions/start.ts
+++ b/packages/server-v3/src/routes/v1/sessions/start.ts
@@ -14,6 +14,7 @@ import {
 } from "../../../lib/header.js";
 import { error, success } from "../../../lib/response.js";
 import { getSessionStore } from "../../../lib/sessionStoreManager.js";
+import { withSession } from "../../../lib/withSession.js";
 import { AISDK_PROVIDERS } from "../../../types/model.js";
 
 // Extended schema with custom refinement for local browser validation
@@ -234,11 +235,12 @@ const startRouteHandler: RouteHandler = withErrorHandling(
     let finalCdpUrl = connectUrl ?? session.cdpUrl ?? "";
     if (localBrowserLaunchOptions) {
       try {
-        const stagehand = await sessionStore.getOrCreateStagehand(
+        finalCdpUrl = await withSession(
           session.sessionId,
           { modelApiKey: localBrowserModelApiKey },
+          request,
+          (stagehand) => Promise.resolve(stagehand.connectURL()),
         );
-        finalCdpUrl = stagehand.connectURL();
       } catch (err) {
         request.log.error(
           {

--- a/packages/server-v3/tests/unit/sessionPinning.test.ts
+++ b/packages/server-v3/tests/unit/sessionPinning.test.ts
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { describe, it } from "node:test";
+
+import type { FastifyRequest } from "fastify";
+import type { V3 } from "@browserbasehq/stagehand";
+
+import { InMemorySessionStore } from "../../src/lib/InMemorySessionStore.js";
+import type { CreateSessionParams } from "../../src/lib/SessionStore.js";
+import {
+  destroySessionStore,
+  initializeSessionStore,
+} from "../../src/lib/sessionStoreManager.js";
+import { withSession } from "../../src/lib/withSession.js";
+
+const PARAMS: CreateSessionParams = {
+  browserType: "local",
+  modelName: "openai/gpt-4o",
+};
+
+/**
+ * Inject a fake V3 instance onto a session node so getOrCreateStagehand returns
+ * it without launching a real browser. Returns a `closed` probe.
+ */
+function injectFakeStagehand(
+  store: InMemorySessionStore,
+  sessionId: string,
+): { wasClosed: () => boolean } {
+  let closed = false;
+  const fake = {
+    close: async () => {
+      closed = true;
+    },
+    connectURL: () => "ws://fake",
+  } as unknown as V3;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (store as any).items.get(sessionId).stagehand = fake;
+  return { wasClosed: () => closed };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const node = (store: InMemorySessionStore, id: string): any =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (store as any).items.get(id);
+
+describe("session pinning", () => {
+  it("does not evict an in-use session under capacity pressure", async () => {
+    const store = new InMemorySessionStore({ maxCapacity: 1 });
+    await store.createSession("A", PARAMS);
+    injectFakeStagehand(store, "A");
+    await store.getOrCreateStagehand("A", {}); // pin A (inUse = 1)
+
+    // Capacity is 1, but A is pinned: creating B must NOT tear down A.
+    await store.createSession("B", PARAMS);
+    assert.equal(await store.hasSession("A"), true);
+    assert.equal(await store.hasSession("B"), true);
+
+    // Once released, A becomes evictable again.
+    await store.releaseSession("A");
+    await store.createSession("C", PARAMS);
+    assert.equal(await store.hasSession("A"), false);
+  });
+
+  it("does not TTL-expire an in-use session", async () => {
+    const store = new InMemorySessionStore({ maxCapacity: 100, ttlMs: 1000 });
+    await store.createSession("A", PARAMS);
+    injectFakeStagehand(store, "A");
+    await store.getOrCreateStagehand("A", {}); // pin
+
+    node(store, "A").expiry = Date.now() - 1; // force expired
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (store as any).cleanupExpired();
+    assert.equal(await store.hasSession("A"), true); // survives: in use
+
+    await store.releaseSession("A"); // unpin; expiry refreshed
+    node(store, "A").expiry = Date.now() - 1; // force expired again
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (store as any).cleanupExpired();
+    assert.equal(node(store, "A"), undefined); // now reaped
+  });
+
+  it("requires all concurrent holders to release before eviction, never going negative", async () => {
+    const store = new InMemorySessionStore({ maxCapacity: 1 });
+    await store.createSession("A", PARAMS);
+    injectFakeStagehand(store, "A");
+    await store.getOrCreateStagehand("A", {});
+    await store.getOrCreateStagehand("A", {}); // inUse = 2
+    assert.equal(node(store, "A").inUse, 2);
+
+    await store.createSession("B", PARAMS);
+    await store.releaseSession("A"); // inUse = 1, still pinned
+    await store.createSession("C", PARAMS);
+    assert.equal(await store.hasSession("A"), true);
+
+    // Extra releases must clamp at 0, not go negative.
+    await store.releaseSession("A");
+    await store.releaseSession("A");
+    assert.equal(node(store, "A").inUse, 0);
+
+    await store.createSession("D", PARAMS);
+    assert.equal(await store.hasSession("A"), false); // now evicted
+  });
+
+  it("explicit endSession closes a session even while in use", async () => {
+    const store = new InMemorySessionStore();
+    await store.createSession("A", PARAMS);
+    const probe = injectFakeStagehand(store, "A");
+    await store.getOrCreateStagehand("A", {}); // pin
+
+    await store.endSession("A");
+    assert.equal(probe.wasClosed(), true);
+    assert.equal(node(store, "A"), undefined);
+  });
+});
+
+describe("withSession", () => {
+  it("releases exactly once when the request aborts before the handler finishes", async () => {
+    const store = initializeSessionStore();
+    try {
+      await store.createSession("A", PARAMS);
+      injectFakeStagehand(store as InMemorySessionStore, "A");
+
+      let releaseCount = 0;
+      const origRelease = store.releaseSession.bind(store);
+      store.releaseSession = (id: string) => {
+        releaseCount += 1;
+        return origRelease(id);
+      };
+
+      const raw = new EventEmitter();
+      const request = { raw } as unknown as FastifyRequest;
+
+      let finishHandler: () => void = () => {};
+      const handlerDone = new Promise<void>((resolve) => {
+        finishHandler = resolve;
+      });
+
+      const p = withSession("A", {}, request, async () => {
+        await handlerDone; // still running...
+        return "ok";
+      });
+
+      // Let withSession finish acquiring and register its "close" listener
+      // (it suspends at the async acquire before attaching the handler).
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      raw.emit("close"); // client aborts mid-handler
+      assert.equal(releaseCount, 1, "abort should release the pin immediately");
+      assert.equal(node(store as InMemorySessionStore, "A").inUse, 0);
+
+      finishHandler();
+      assert.equal(await p, "ok");
+      // The finally path must not double-release.
+      assert.equal(releaseCount, 1);
+    } finally {
+      await destroySessionStore();
+    }
+  });
+});

--- a/packages/server-v3/tests/unit/sessionPinning.test.ts
+++ b/packages/server-v3/tests/unit/sessionPinning.test.ts
@@ -116,16 +116,20 @@ describe("session pinning", () => {
     await store.createSession("A", PARAMS);
     await store.createSession("B", PARAMS);
     await store.createSession("C", PARAMS);
-    injectFakeStagehand(store, "A");
-    injectFakeStagehand(store, "B");
-    injectFakeStagehand(store, "C");
+    const a = injectFakeStagehand(store, "A");
+    const b = injectFakeStagehand(store, "B");
+    const c = injectFakeStagehand(store, "C");
 
     store.updateCacheConfig({ maxCapacity: 1 });
     await new Promise((resolve) => setTimeout(resolve, 20)); // let evictions run
 
-    // A and B (the two LRU) must both be evicted — not the same node twice.
+    // A and B (the two LRU) must both be evicted and closed — not the same
+    // node twice — while the most-recent C survives.
     assert.equal(store.size, 1);
     assert.equal(await store.hasSession("C"), true);
+    assert.equal(a.wasClosed(), true);
+    assert.equal(b.wasClosed(), true);
+    assert.equal(c.wasClosed(), false);
   });
 
   it("explicit endSession closes a session even while in use", async () => {

--- a/packages/server-v3/tests/unit/sessionPinning.test.ts
+++ b/packages/server-v3/tests/unit/sessionPinning.test.ts
@@ -1,8 +1,6 @@
 import assert from "node:assert/strict";
-import { EventEmitter } from "node:events";
 import { describe, it } from "node:test";
 
-import type { FastifyRequest } from "fastify";
 import type { V3 } from "@browserbasehq/stagehand";
 
 import { InMemorySessionStore } from "../../src/lib/InMemorySessionStore.js";
@@ -101,6 +99,18 @@ describe("session pinning", () => {
     assert.equal(await store.hasSession("A"), false); // now evicted
   });
 
+  it("ignores an unmatched release without refreshing TTL", async () => {
+    const store = new InMemorySessionStore({ maxCapacity: 100, ttlMs: 1000 });
+    await store.createSession("A", PARAMS);
+    node(store, "A").expiry = 12345; // sentinel
+
+    // No matching acquire: a stray release must be a complete no-op.
+    await store.releaseSession("A");
+
+    assert.equal(node(store, "A").inUse, 0);
+    assert.equal(node(store, "A").expiry, 12345, "TTL must not be refreshed");
+  });
+
   it("explicit endSession closes a session even while in use", async () => {
     const store = new InMemorySessionStore();
     await store.createSession("A", PARAMS);
@@ -114,7 +124,7 @@ describe("session pinning", () => {
 });
 
 describe("withSession", () => {
-  it("releases exactly once when the request aborts before the handler finishes", async () => {
+  it("keeps the session pinned until fn settles, then releases exactly once", async () => {
     const store = initializeSessionStore();
     try {
       await store.createSession("A", PARAMS);
@@ -127,31 +137,43 @@ describe("withSession", () => {
         return origRelease(id);
       };
 
-      const raw = new EventEmitter();
-      const request = { raw } as unknown as FastifyRequest;
-
       let finishHandler: () => void = () => {};
       const handlerDone = new Promise<void>((resolve) => {
         finishHandler = resolve;
       });
 
-      const p = withSession("A", {}, request, async () => {
+      const p = withSession("A", {}, async () => {
         await handlerDone; // still running...
         return "ok";
       });
 
-      // Let withSession finish acquiring and register its "close" listener
-      // (it suspends at the async acquire before attaching the handler).
+      // While fn is in flight the session must stay pinned and unreleased.
       await new Promise((resolve) => setTimeout(resolve, 0));
-
-      raw.emit("close"); // client aborts mid-handler
-      assert.equal(releaseCount, 1, "abort should release the pin immediately");
-      assert.equal(node(store as InMemorySessionStore, "A").inUse, 0);
+      assert.equal(releaseCount, 0, "must not release while fn is running");
+      assert.equal(node(store as InMemorySessionStore, "A").inUse, 1);
 
       finishHandler();
       assert.equal(await p, "ok");
-      // The finally path must not double-release.
-      assert.equal(releaseCount, 1);
+      assert.equal(releaseCount, 1, "releases exactly once after fn settles");
+      assert.equal(node(store as InMemorySessionStore, "A").inUse, 0);
+    } finally {
+      await destroySessionStore();
+    }
+  });
+
+  it("releases the pin when fn throws", async () => {
+    const store = initializeSessionStore();
+    try {
+      await store.createSession("A", PARAMS);
+      injectFakeStagehand(store as InMemorySessionStore, "A");
+
+      await assert.rejects(
+        withSession("A", {}, async () => {
+          throw new Error("boom");
+        }),
+        /boom/,
+      );
+      assert.equal(node(store as InMemorySessionStore, "A").inUse, 0);
     } finally {
       await destroySessionStore();
     }

--- a/packages/server-v3/tests/unit/sessionPinning.test.ts
+++ b/packages/server-v3/tests/unit/sessionPinning.test.ts
@@ -161,6 +161,31 @@ describe("withSession", () => {
     }
   });
 
+  it("surfaces a release failure instead of swallowing it", async () => {
+    const store = initializeSessionStore();
+    const originalConsoleError = console.error;
+    let errorLogs = 0;
+    console.error = () => {
+      errorLogs += 1;
+    };
+    try {
+      await store.createSession("A", PARAMS);
+      injectFakeStagehand(store as InMemorySessionStore, "A");
+      store.releaseSession = () => {
+        throw new Error("release boom");
+      };
+
+      // The handler result is still returned; the release failure is recorded,
+      // not thrown (a throw from finally would clobber the result).
+      const result = await withSession("A", {}, async () => "ok");
+      assert.equal(result, "ok");
+      assert.equal(errorLogs, 1, "release failure should be recorded");
+    } finally {
+      console.error = originalConsoleError;
+      await destroySessionStore();
+    }
+  });
+
   it("releases the pin when fn throws", async () => {
     const store = initializeSessionStore();
     try {

--- a/packages/server-v3/tests/unit/sessionPinning.test.ts
+++ b/packages/server-v3/tests/unit/sessionPinning.test.ts
@@ -111,6 +111,23 @@ describe("session pinning", () => {
     assert.equal(node(store, "A").expiry, 12345, "TTL must not be refreshed");
   });
 
+  it("downsizing capacity evicts all excess entries, not just one", async () => {
+    const store = new InMemorySessionStore({ maxCapacity: 3 });
+    await store.createSession("A", PARAMS);
+    await store.createSession("B", PARAMS);
+    await store.createSession("C", PARAMS);
+    injectFakeStagehand(store, "A");
+    injectFakeStagehand(store, "B");
+    injectFakeStagehand(store, "C");
+
+    store.updateCacheConfig({ maxCapacity: 1 });
+    await new Promise((resolve) => setTimeout(resolve, 20)); // let evictions run
+
+    // A and B (the two LRU) must both be evicted — not the same node twice.
+    assert.equal(store.size, 1);
+    assert.equal(await store.hasSession("C"), true);
+  });
+
   it("explicit endSession closes a session even while in use", async () => {
     const store = new InMemorySessionStore();
     await store.createSession("A", PARAMS);


### PR DESCRIPTION
# why

A long-running agent runs (60s+) could have their sessions ended early via LRU eviction or TTL cleanup. This surfaces as a "Stagehand session was closed" response on actions that have actually succeed.

The root cause was that the session store only refreshed a session's LRU/TTL at request start, which would cause long requests to reach eviction age while still running.

# what changed

To fix, we can mark these long running sessions as "in use" to prevent it from expiring while in flight.

The new `inUse` is a refcount (not a boolean) because concurrent requests can share one session.

# test plan

New tests/unit/sessionPinning.test.ts: eviction-skip under capacity, TTL-skip, concurrent holders + non-negative clamp, explicit-end-still-closes, and release-exactly-once-on-abort


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent in-use sessions from being evicted or TTL-expired mid-request, fixing intermittent “Stagehand session was closed” errors on long agent runs. Adds session pinning with a refcount and a `withSession` helper, and fixes capacity downsizing to evict all excess entries safely.

- **Bug Fixes**
  - Added an `inUse` refcount; TTL cleanup, `hasSession`, and LRU eviction skip pinned sessions (eviction walks past in-use nodes). `getOrCreateStagehand` pins before lazy `init()` and unpins on failure; new `releaseSession(sessionId)` decrements (clamped at zero) and refreshes TTL, ignoring unmatched releases.
  - When lowering `maxCapacity`, evict before applying the new limit and do it sequentially so all excess entries are removed; pinned sessions are skipped, so the cache can briefly exceed capacity until requests finish. Updated streaming and session start to use `withSession(...)`, which releases exactly once after the handler settles and logs release failures via `console.error`. Unit tests cover eviction/TTL skips, capacity downsizing, concurrent holders, unmatched releases, explicit end, release-once semantics, and release-failure logging.

- **Migration**
  - Custom `SessionStore` implementations must add `releaseSession(sessionId)` and follow the acquire/release contract.
  - Use `withSession(...)` instead of manually holding a V3 instance; do not release on client disconnect.

<sup>Written for commit 9edfcdbead34272e9815cd6553f825ec9db35c37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

