### PR TITLE
[fix]: clean up cdp session event handlers

### DIFF
--- a/.changeset/petite-rocks-lead.md
+++ b/.changeset/petite-rocks-lead.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+clean up cdp session event handlers on target detach

--- a/packages/core/lib/v3/understudy/cdp.ts
+++ b/packages/core/lib/v3/understudy/cdp.ts
@@ -208,6 +208,15 @@ export class CdpConnection implements CDPSessionLike {
     }
   }
 
+  private clearSessionEventHandlers(sessionId: string): void {
+    const prefix = `${sessionId}:`;
+    for (const key of Array.from(this.eventHandlers.keys())) {
+      if (key.startsWith(prefix)) {
+        this.eventHandlers.delete(key);
+      }
+    }
+  }
+
   getSession(sessionId: string): CdpSession | undefined {
     return this.sessions.get(sessionId);
   }
@@ -353,6 +362,7 @@ export class CdpConnection implements CDPSessionLike {
             );
           }
         }
+        this.clearSessionEventHandlers(p.sessionId);
         this.sessions.delete(p.sessionId);
         this.sessionToTarget.delete(p.sessionId);
         this.latestCdpCallEvent.delete(p.sessionId);
@@ -361,6 +371,7 @@ export class CdpConnection implements CDPSessionLike {
         // Remove any session mapping for this target
         for (const [sessionId, targetId] of this.sessionToTarget.entries()) {
           if (targetId === p.targetId) {
+            this.clearSessionEventHandlers(sessionId);
             this.sessionToTarget.delete(sessionId);
             this.latestCdpCallEvent.delete(sessionId);
             break;

--- a/packages/core/lib/v3/understudy/cdp.ts
+++ b/packages/core/lib/v3/understudy/cdp.ts
@@ -375,7 +375,6 @@ export class CdpConnection implements CDPSessionLike {
             this.sessions.delete(sessionId);
             this.sessionToTarget.delete(sessionId);
             this.latestCdpCallEvent.delete(sessionId);
-            break;
           }
         }
       }

--- a/packages/core/lib/v3/understudy/cdp.ts
+++ b/packages/core/lib/v3/understudy/cdp.ts
@@ -372,6 +372,7 @@ export class CdpConnection implements CDPSessionLike {
         for (const [sessionId, targetId] of this.sessionToTarget.entries()) {
           if (targetId === p.targetId) {
             this.clearSessionEventHandlers(sessionId);
+            this.sessions.delete(sessionId);
             this.sessionToTarget.delete(sessionId);
             this.latestCdpCallEvent.delete(sessionId);
             break;

--- a/packages/core/lib/v3/understudy/cdp.ts
+++ b/packages/core/lib/v3/understudy/cdp.ts
@@ -217,6 +217,31 @@ export class CdpConnection implements CDPSessionLike {
     }
   }
 
+  private rejectSessionPendingWork(
+    sessionId: string,
+    targetId: string | null,
+  ): void {
+    for (const [id, entry] of this.inflight.entries()) {
+      if (entry.sessionId === sessionId) {
+        entry.reject(
+          new PageNotFoundError(
+            `target closed before CDP response (sessionId=${sessionId}, targetId=${targetId})`,
+          ),
+        );
+        this.inflight.delete(id);
+      }
+    }
+    for (const waiter of Array.from(this.sessionDispatchWaiters)) {
+      if (waiter.sessionId === sessionId) {
+        waiter.reject(
+          new PageNotFoundError(
+            `target closed before CDP send (sessionId=${sessionId}, targetId=${targetId})`,
+          ),
+        );
+      }
+    }
+  }
+
   getSession(sessionId: string): CdpSession | undefined {
     return this.sessions.get(sessionId);
   }
@@ -343,25 +368,7 @@ export class CdpConnection implements CDPSessionLike {
       } else if (msg.method === "Target.detachedFromTarget") {
         const p = (msg as { params: Protocol.Target.DetachedFromTargetEvent })
           .params;
-        for (const [id, entry] of this.inflight.entries()) {
-          if (entry.sessionId === p.sessionId) {
-            entry.reject(
-              new PageNotFoundError(
-                `target closed before CDP response (sessionId=${p.sessionId}, targetId=${p.targetId})`,
-              ),
-            );
-            this.inflight.delete(id);
-          }
-        }
-        for (const waiter of Array.from(this.sessionDispatchWaiters)) {
-          if (waiter.sessionId === p.sessionId) {
-            waiter.reject(
-              new PageNotFoundError(
-                `target closed before CDP send (sessionId=${p.sessionId}, targetId=${p.targetId})`,
-              ),
-            );
-          }
-        }
+        this.rejectSessionPendingWork(p.sessionId, p.targetId ?? null);
         this.clearSessionEventHandlers(p.sessionId);
         this.sessions.delete(p.sessionId);
         this.sessionToTarget.delete(p.sessionId);
@@ -371,6 +378,7 @@ export class CdpConnection implements CDPSessionLike {
         // Remove any session mapping for this target
         for (const [sessionId, targetId] of this.sessionToTarget.entries()) {
           if (targetId === p.targetId) {
+            this.rejectSessionPendingWork(sessionId, p.targetId);
             this.clearSessionEventHandlers(sessionId);
             this.sessions.delete(sessionId);
             this.sessionToTarget.delete(sessionId);

--- a/packages/core/tests/unit/cdp-connection-close.test.ts
+++ b/packages/core/tests/unit/cdp-connection-close.test.ts
@@ -57,6 +57,29 @@ async function sendCdpEvent(
   await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
+async function waitForSession(
+  conn: CdpConnection,
+  sessionId: string,
+): Promise<ReturnType<CdpConnection["getSession"]>> {
+  const session = await raceTimeout(
+    new Promise<ReturnType<CdpConnection["getSession"]>>((resolve) => {
+      const check = () => {
+        const found = conn.getSession(sessionId);
+        if (found) {
+          resolve(found);
+          return;
+        }
+        setTimeout(check, 0);
+      };
+      check();
+    }),
+    3_000,
+  );
+
+  expect(session).not.toBe("timeout");
+  return session as ReturnType<CdpConnection["getSession"]>;
+}
+
 describe("CdpConnection", () => {
   let wss: WebSocketServer | null = null;
 
@@ -139,8 +162,7 @@ describe("CdpConnection", () => {
         },
       });
 
-      const session = pair.conn.getSession("session-a");
-      expect(session).toBeDefined();
+      const session = await waitForSession(pair.conn, "session-a");
 
       const fetchHandlerA = vi.fn();
       const fetchHandlerB = vi.fn();
@@ -163,8 +185,7 @@ describe("CdpConnection", () => {
         },
       });
 
-      const otherSession = pair.conn.getSession("session-b");
-      expect(otherSession).toBeDefined();
+      const otherSession = await waitForSession(pair.conn, "session-b");
       otherSession!.on("Fetch.requestPaused", () => {});
 
       const rootHandler = vi.fn();
@@ -229,8 +250,7 @@ describe("CdpConnection", () => {
         },
       });
 
-      const session = pair.conn.getSession("session-a");
-      expect(session).toBeDefined();
+      const session = await waitForSession(pair.conn, "session-a");
       session!.on("Fetch.requestPaused", () => {});
 
       const eventHandlers = (pair.conn as unknown as ConnectionInternals)
@@ -268,10 +288,8 @@ describe("CdpConnection", () => {
         });
       }
 
-      const sessionA = pair.conn.getSession("session-a");
-      const sessionB = pair.conn.getSession("session-b");
-      expect(sessionA).toBeDefined();
-      expect(sessionB).toBeDefined();
+      const sessionA = await waitForSession(pair.conn, "session-a");
+      const sessionB = await waitForSession(pair.conn, "session-b");
 
       sessionA!.on("Fetch.requestPaused", () => {});
       sessionB!.on("Fetch.requestPaused", () => {});
@@ -311,8 +329,7 @@ describe("CdpConnection", () => {
         },
       });
 
-      const session = pair.conn.getSession("session-a");
-      expect(session).toBeDefined();
+      const session = await waitForSession(pair.conn, "session-a");
 
       const pending = session!.send("Runtime.evaluate", {
         expression: "1+1",

--- a/packages/core/tests/unit/cdp-connection-close.test.ts
+++ b/packages/core/tests/unit/cdp-connection-close.test.ts
@@ -237,5 +237,50 @@ describe("CdpConnection", () => {
 
       expect(eventHandlers.has("session-a:Fetch.requestPaused")).toBe(false);
     });
+
+    it("removes all session-scoped event handlers for a destroyed target", async () => {
+      const pair = await createPair();
+      wss = pair.wss;
+
+      for (const sessionId of ["session-a", "session-b"]) {
+        await sendCdpEvent(pair.serverSocket, {
+          method: "Target.attachedToTarget",
+          params: {
+            sessionId,
+            targetInfo: {
+              targetId: "target-a",
+              type: "page",
+              title: "",
+              url: "about:blank",
+              attached: true,
+              canAccessOpener: false,
+            },
+          },
+        });
+      }
+
+      const sessionA = pair.conn.getSession("session-a");
+      const sessionB = pair.conn.getSession("session-b");
+      expect(sessionA).toBeDefined();
+      expect(sessionB).toBeDefined();
+
+      sessionA!.on("Fetch.requestPaused", () => {});
+      sessionB!.on("Fetch.requestPaused", () => {});
+
+      const eventHandlers = (pair.conn as unknown as ConnectionInternals)
+        .eventHandlers;
+      expect(eventHandlers.has("session-a:Fetch.requestPaused")).toBe(true);
+      expect(eventHandlers.has("session-b:Fetch.requestPaused")).toBe(true);
+
+      await sendCdpEvent(pair.serverSocket, {
+        method: "Target.targetDestroyed",
+        params: {
+          targetId: "target-a",
+        },
+      });
+
+      expect(eventHandlers.has("session-a:Fetch.requestPaused")).toBe(false);
+      expect(eventHandlers.has("session-b:Fetch.requestPaused")).toBe(false);
+    });
   });
 });

--- a/packages/core/tests/unit/cdp-connection-close.test.ts
+++ b/packages/core/tests/unit/cdp-connection-close.test.ts
@@ -48,7 +48,12 @@ async function sendCdpEvent(
   serverSocket: ServerWebSocket,
   message: Record<string, unknown>,
 ): Promise<void> {
-  serverSocket.send(JSON.stringify(message));
+  await new Promise<void>((resolve, reject) => {
+    serverSocket.send(JSON.stringify(message), (error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
   await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
@@ -285,6 +290,86 @@ describe("CdpConnection", () => {
 
       expect(eventHandlers.has("session-a:Fetch.requestPaused")).toBe(false);
       expect(eventHandlers.has("session-b:Fetch.requestPaused")).toBe(false);
+    });
+
+    it("rejects in-flight session sends when a target is destroyed", async () => {
+      const pair = await createPair();
+      wss = pair.wss;
+
+      await sendCdpEvent(pair.serverSocket, {
+        method: "Target.attachedToTarget",
+        params: {
+          sessionId: "session-a",
+          targetInfo: {
+            targetId: "target-a",
+            type: "page",
+            title: "",
+            url: "about:blank",
+            attached: true,
+            canAccessOpener: false,
+          },
+        },
+      });
+
+      const session = pair.conn.getSession("session-a");
+      expect(session).toBeDefined();
+
+      const pending = session!.send("Runtime.evaluate", {
+        expression: "1+1",
+      });
+      const resultPromise = pending
+        .then(() => "resolved")
+        .catch(() => "rejected");
+
+      await sendCdpEvent(pair.serverSocket, {
+        method: "Target.targetDestroyed",
+        params: {
+          targetId: "target-a",
+        },
+      });
+
+      const result = await raceTimeout(resultPromise, 3_000);
+
+      expect(result).toBe("rejected");
+    });
+
+    it("rejects session dispatch waiters when a target is destroyed", async () => {
+      const pair = await createPair();
+      wss = pair.wss;
+
+      await sendCdpEvent(pair.serverSocket, {
+        method: "Target.attachedToTarget",
+        params: {
+          sessionId: "session-a",
+          targetInfo: {
+            targetId: "target-a",
+            type: "page",
+            title: "",
+            url: "about:blank",
+            attached: true,
+            canAccessOpener: false,
+          },
+        },
+      });
+
+      const pending = pair.conn.waitForSessionDispatch(
+        "session-a",
+        "Fetch.enable",
+      );
+      const resultPromise = pending
+        .then(() => "resolved")
+        .catch(() => "rejected");
+
+      await sendCdpEvent(pair.serverSocket, {
+        method: "Target.targetDestroyed",
+        params: {
+          targetId: "target-a",
+        },
+      });
+
+      const result = await raceTimeout(resultPromise, 3_000);
+
+      expect(result).toBe("rejected");
     });
   });
 });

--- a/packages/core/tests/unit/cdp-connection-close.test.ts
+++ b/packages/core/tests/unit/cdp-connection-close.test.ts
@@ -1,6 +1,10 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { WebSocketServer, type WebSocket as ServerWebSocket } from "ws";
 import { CdpConnection } from "../../lib/v3/understudy/cdp.js";
+
+type ConnectionInternals = {
+  eventHandlers: Map<string, Set<unknown>>;
+};
 
 /**
  * Races a promise against a timeout. Returns "resolved" if the promise
@@ -40,11 +44,22 @@ async function createPair(): Promise<{
   return { conn, serverSocket, wss };
 }
 
+async function sendCdpEvent(
+  serverSocket: ServerWebSocket,
+  message: Record<string, unknown>,
+): Promise<void> {
+  serverSocket.send(JSON.stringify(message));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 describe("CdpConnection", () => {
   let wss: WebSocketServer | null = null;
 
   afterEach(async () => {
     if (wss) {
+      for (const client of wss.clients) {
+        client.terminate();
+      }
       await new Promise<void>((resolve) => wss!.close(() => resolve()));
       wss = null;
     }
@@ -96,6 +111,131 @@ describe("CdpConnection", () => {
       );
 
       expect(result).toBe("rejected");
+    });
+  });
+
+  describe("session event listener cleanup", () => {
+    it("removes session-scoped event handlers when a target detaches", async () => {
+      const pair = await createPair();
+      wss = pair.wss;
+
+      await sendCdpEvent(pair.serverSocket, {
+        method: "Target.attachedToTarget",
+        params: {
+          sessionId: "session-a",
+          targetInfo: {
+            targetId: "target-a",
+            type: "page",
+            title: "",
+            url: "about:blank",
+            attached: true,
+            canAccessOpener: false,
+          },
+        },
+      });
+
+      const session = pair.conn.getSession("session-a");
+      expect(session).toBeDefined();
+
+      session!.on("Fetch.requestPaused", () => {});
+      session!.on("Network.requestWillBeSent", () => {});
+
+      await sendCdpEvent(pair.serverSocket, {
+        method: "Target.attachedToTarget",
+        params: {
+          sessionId: "session-b",
+          targetInfo: {
+            targetId: "target-b",
+            type: "iframe",
+            title: "",
+            url: "about:blank",
+            attached: true,
+            canAccessOpener: false,
+          },
+        },
+      });
+
+      const otherSession = pair.conn.getSession("session-b");
+      expect(otherSession).toBeDefined();
+      otherSession!.on("Fetch.requestPaused", () => {});
+
+      const rootHandler = vi.fn();
+      pair.conn.on("Target.targetCreated", rootHandler);
+
+      const eventHandlers = (pair.conn as unknown as ConnectionInternals)
+        .eventHandlers;
+      expect(eventHandlers.has("session-a:Fetch.requestPaused")).toBe(true);
+      expect(eventHandlers.has("session-a:Network.requestWillBeSent")).toBe(
+        true,
+      );
+      expect(eventHandlers.has("session-b:Fetch.requestPaused")).toBe(true);
+
+      await sendCdpEvent(pair.serverSocket, {
+        method: "Target.detachedFromTarget",
+        params: {
+          sessionId: "session-a",
+          targetId: "target-a",
+        },
+      });
+
+      await sendCdpEvent(pair.serverSocket, {
+        method: "Target.targetCreated",
+        params: {
+          targetInfo: {
+            targetId: "target-b",
+            type: "page",
+            title: "",
+            url: "about:blank",
+            attached: false,
+            canAccessOpener: false,
+          },
+        },
+      });
+
+      expect(eventHandlers.has("session-a:Fetch.requestPaused")).toBe(false);
+      expect(eventHandlers.has("session-a:Network.requestWillBeSent")).toBe(
+        false,
+      );
+      expect(eventHandlers.has("session-b:Fetch.requestPaused")).toBe(true);
+      expect(eventHandlers.has("Target.targetCreated")).toBe(true);
+      expect(rootHandler).toHaveBeenCalledOnce();
+    });
+
+    it("removes session-scoped event handlers when a target is destroyed", async () => {
+      const pair = await createPair();
+      wss = pair.wss;
+
+      await sendCdpEvent(pair.serverSocket, {
+        method: "Target.attachedToTarget",
+        params: {
+          sessionId: "session-a",
+          targetInfo: {
+            targetId: "target-a",
+            type: "page",
+            title: "",
+            url: "about:blank",
+            attached: true,
+            canAccessOpener: false,
+          },
+        },
+      });
+
+      const session = pair.conn.getSession("session-a");
+      expect(session).toBeDefined();
+      session!.on("Fetch.requestPaused", () => {});
+
+      const eventHandlers = (pair.conn as unknown as ConnectionInternals)
+        .eventHandlers;
+      expect(eventHandlers.has("session-a:Fetch.requestPaused")).toBe(true);
+
+      await sendCdpEvent(pair.serverSocket, {
+        method: "Target.targetDestroyed",
+        params: {
+          targetId: "target-a",
+        },
+      });
+
+      expect(eventHandlers.has("session-a:Fetch.requestPaused")).toBe(false);
     });
   });
 });

--- a/packages/core/tests/unit/cdp-connection-close.test.ts
+++ b/packages/core/tests/unit/cdp-connection-close.test.ts
@@ -137,7 +137,10 @@ describe("CdpConnection", () => {
       const session = pair.conn.getSession("session-a");
       expect(session).toBeDefined();
 
-      session!.on("Fetch.requestPaused", () => {});
+      const fetchHandlerA = vi.fn();
+      const fetchHandlerB = vi.fn();
+      session!.on("Fetch.requestPaused", fetchHandlerA);
+      session!.on("Fetch.requestPaused", fetchHandlerB);
       session!.on("Network.requestWillBeSent", () => {});
 
       await sendCdpEvent(pair.serverSocket, {
@@ -165,6 +168,7 @@ describe("CdpConnection", () => {
       const eventHandlers = (pair.conn as unknown as ConnectionInternals)
         .eventHandlers;
       expect(eventHandlers.has("session-a:Fetch.requestPaused")).toBe(true);
+      expect(eventHandlers.get("session-a:Fetch.requestPaused")?.size).toBe(2);
       expect(eventHandlers.has("session-a:Network.requestWillBeSent")).toBe(
         true,
       );


### PR DESCRIPTION
# why

`CdpSession.on(...)` stores session scoped listeners on the root `CdpConnection` under keys like `${sessionId}:${event}`. when chrome sends `Target.detachedFromTarget`, `CdpConnection` removes session metadata, but the actual event handlers were not being removed

this was problematic because stale handler functions remained reachable for the lifetime of the root connection. this could cause memory to grow, particularly for long sessions with a lot of attach/detach churn

# what changed

added `CdpConnection.clearSessionEventHandlers(sessionId)`, which:
- clears session scoped handlers when `Target.detachedFromTarget` or `Target.targetDestroyed` fires

# test plan

added tests in `packages/core/dist/esm/tests/unit/cdp-connection-close.test.js`, which verify:
- detached session handlers are removed
- multiple handlers for the same detached session are removed
- handlers for other live sessions are preserved
- root-level handlers are preserved
- stale session handlers are removed when `Target.targetDestroyed` fires

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes memory leaks and prevents hangs by cleaning up CDP session event handlers and rejecting pending work when targets detach or are destroyed. Aligns with Linear STG-2415.

- **Bug Fixes**
  - Added `clearSessionEventHandlers(sessionId)` to remove `${sessionId}:*` listeners.
  - Added `rejectSessionPendingWork(sessionId, targetId)` to reject in-flight `.send` calls and session dispatch waiters with `PageNotFoundError`.
  - On `Target.detachedFromTarget` and `Target.targetDestroyed`: call both methods and delete affected sessions/mappings (for destroyed targets, all sessions mapped to the target). Tests cover cleanup across detach/destroy, multiple sessions per target, rejection of pending work, and preservation of other sessions and root-level handlers.

<sup>Written for commit 5e7d04a34062f0afd2313701eb6b020fa4863e6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

