### PR TITLE
[docs]: add docs for `setDomainPolicy`

### DIFF
--- a/packages/docs/v3/references/context.mdx
+++ b/packages/docs/v3/references/context.mdx
@@ -201,8 +201,10 @@ await context.setDomainPolicy(policy: DomainPolicy | null): Promise<void>
   </Expandable>
 </ParamField>
 
-<Note>
 Domain policy applies to HTTP and HTTPS requests across existing and future pages, attached child targets, iframes, and subresource loads. It is not limited to top-level page navigations. Non-HTTP(S) URLs such as `data:` and `file:` are not blocked by this policy.
+
+<Note>
+For newly opened targets, such as popups opened via `window.open()`, domain blocking can be race-sensitive. If Stagehand cannot guarantee that a disallowed target was intercepted in time, it closes that target.
 </Note>
 
 Calling `setDomainPolicy()` replaces the previous policy. To clear the policy, pass `null`, `{}`, or empty arrays:

--- a/packages/docs/v3/references/context.mdx
+++ b/packages/docs/v3/references/context.mdx
@@ -179,6 +179,74 @@ await context.setExtraHTTPHeaders({
 const page = await context.newPage("https://example.com");
 ```
 
+### setDomainPolicy()
+
+Set a context-wide network domain policy that allows or blocks HTTP(S) requests by hostname.
+
+```typescript
+await context.setDomainPolicy(policy: DomainPolicy | null): Promise<void>
+```
+
+<ParamField path="policy" type="DomainPolicy | null" required>
+  A domain policy with `allowedDomains`, `blockedDomains`, or both.
+
+  <Expandable title="DomainPolicy">
+    <ParamField path="allowedDomains" type="string[]" optional>
+      Domain-only allow patterns. When provided, HTTP(S) requests to non-matching domains are blocked.
+    </ParamField>
+
+    <ParamField path="blockedDomains" type="string[]" optional>
+      Domain-only block patterns. Matching HTTP(S) requests are blocked.
+    </ParamField>
+  </Expandable>
+</ParamField>
+
+<Note>
+Domain policy applies to HTTP and HTTPS requests across existing and future pages, attached child targets, iframes, and subresource loads. It is not limited to top-level page navigations. Non-HTTP(S) URLs such as `data:` and `file:` are not blocked by this policy.
+</Note>
+
+Calling `setDomainPolicy()` replaces the previous policy. To clear the policy, pass `null`, `{}`, or empty arrays:
+
+```typescript
+await context.setDomainPolicy(null);
+```
+
+Domain patterns must be domain-only values:
+- Use `"example.com"` for an exact hostname match
+- Use `"*.example.com"` to match subdomains such as `"app.example.com"` and `"deep.app.example.com"`
+- `"*.example.com"` does not match the apex domain `"example.com"`; include both patterns if you need both
+- Do not include a scheme, path, port, query string, or fragment
+- Matching is case-insensitive, and duplicate normalized patterns are ignored
+
+<Note>
+When both `blockedDomains` and `allowedDomains` are provided, `blockedDomains` takes precedence. Blocked requests fail with Chrome's `BlockedByClient` network error.
+</Note>
+
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const stagehand = new Stagehand({ env: "LOCAL" });
+await stagehand.init();
+const context = stagehand.context;
+
+await context.setDomainPolicy({
+  allowedDomains: ["example.com", "*.example.com"],
+  blockedDomains: ["ads.example.com", "*.tracking.example.com"],
+});
+
+const page = await context.newPage("https://example.com");
+```
+
+### getDomainPolicy()
+
+Get the currently configured context-wide domain policy.
+
+```typescript
+context.getDomainPolicy(): DomainPolicy | null
+```
+
+**Returns:** `DomainPolicy | null` - The active domain policy, or `null` when no policy is configured.
+
 ### cookies()
 
 Retrieve browser cookies, optionally filtered by URL(s).
@@ -512,6 +580,34 @@ await stagehand.close();
 ```
 
 </Tab>
+<Tab title="Domain Policy">
+
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const stagehand = new Stagehand({ env: "LOCAL" });
+await stagehand.init();
+const context = stagehand.context;
+
+// Allow only example.com and its subdomains, while blocking ad traffic
+await context.setDomainPolicy({
+  allowedDomains: ["example.com", "*.example.com"],
+  blockedDomains: ["ads.example.com", "*.tracking.example.com"],
+});
+
+const page = await context.newPage("https://example.com");
+await page.goto("https://example.com/dashboard");
+
+// Read the active policy
+console.log(context.getDomainPolicy());
+
+// Clear the policy
+await context.setDomainPolicy(null);
+
+await stagehand.close();
+```
+
+</Tab>
 <Tab title="Cookie Management">
 
 ```typescript
@@ -660,6 +756,8 @@ Context methods may throw the following errors:
 - **CDP errors** - Connection errors with Chrome DevTools Protocol
 - **Invalid page errors** - Attempting to set an active page that doesn't exist in the context
 - **StagehandSetExtraHTTPHeadersError** - `setExtraHTTPHeaders()` failed to apply headers to one or more sessions. The error includes a `failures` array with per-session details
+- **StagehandInvalidArgumentError** - `setDomainPolicy()` received an invalid policy, such as a URL instead of a domain-only pattern
+- **StagehandSetDomainPolicyError** - `setDomainPolicy()` failed to enable or disable enforcement for one or more sessions. The error includes a `failures` array with per-session details
 
 Always handle errors appropriately:
 
@@ -680,10 +778,20 @@ interface V3Context {
   activePage(): Page | undefined;
   setActivePage(page: Page): void;
   setExtraHTTPHeaders(headers: Record<string, string>): Promise<void>;
+  setDomainPolicy(policy: DomainPolicy | null): Promise<void>;
+  getDomainPolicy(): DomainPolicy | null;
   cookies(urls?: string | string[]): Promise<Cookie[]>;
   addCookies(cookies: CookieParam[]): Promise<void>;
   clearCookies(options?: ClearCookieOptions): Promise<void>;
   close(): Promise<void>;
+}
+
+interface DomainPolicy {
+  /** Domain-only allow patterns, e.g. "example.com" or "*.example.com". */
+  allowedDomains?: string[];
+
+  /** Domain-only block patterns, e.g. "example.com" or "*.example.com". */
+  blockedDomains?: string[];
 }
 
 interface Cookie {


### PR DESCRIPTION
# why
- adds documentation for `setDomainPolicy()`
# what changed

<img width="1288" height="955" alt="Screenshot 2026-07-13 at 11 07 35 AM" src="https://github.com/user-attachments/assets/3d02d0b2-f7e2-4c33-af88-9469d97d041f" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds docs for `context.setDomainPolicy()` and `context.getDomainPolicy()` to control HTTP(S) requests by domain across a context, with examples and error details. Addresses Linear STG-2426.

- **New Features**
  - Documented `setDomainPolicy(policy: DomainPolicy | null)` and `getDomainPolicy()` with TypeScript signatures, behavior, scope (pages, iframes, subresources), and how to clear.
  - Clarified domain-only patterns: exact vs wildcard, subdomain rules (`*.example.com` doesn’t match `example.com`), case-insensitive matching, duplicate patterns ignored, and no schemes/paths/ports; `blockedDomains` overrides `allowedDomains`; non-HTTP(S) unaffected; blocked requests show Chrome “BlockedByClient”.
  - Added a “Domain Policy” example tab using `@browserbasehq/stagehand`, and updated API reference with new errors (`StagehandInvalidArgumentError`, `StagehandSetDomainPolicyError`) plus `V3Context` and `DomainPolicy` interface snippets.

<sup>Written for commit 644f32eeb57ce735911102c40301fd820f216fbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

