### PR TITLE
evals(cua): add a deterministic CUA agent regression task

### DIFF
--- a/packages/evals/tasks/bench/agent/cua_amazon_checkout.ts
+++ b/packages/evals/tasks/bench/agent/cua_amazon_checkout.ts
@@ -1,0 +1,81 @@
+import { defineBenchTask } from "../../../framework/defineTask.js";
+
+/**
+ * Deterministic CUA agent regression task (see #2188).
+ *
+ * Unlike the rubric-graded agent benchmarks, this task runs against a pinned
+ * static fixture and passes only when the agent reaches an exact, known URL.
+ * A failure is therefore attributable to a real provider/plumbing regression
+ * rather than to page drift or LLM-judge noise. It exercises the full
+ * computer-use loop (provider function-response decoding -> browser action)
+ * end to end — the path that broke in #2046 (fixed by #2159) and #2035, and
+ * which is otherwise only covered transitively by the heavyweight
+ * WebVoyager / OnlineMind2Web suites.
+ *
+ * The task is mode-agnostic; point it at a CUA model to exercise the CUA path:
+ *   evals run agent/cua_amazon_checkout --agent-mode cua \
+ *     --model google/gemini-2.5-computer-use-preview-10-2025
+ *
+ * To keep failures easy to attribute (per review discussion on #2188), the
+ * result records the model/agent-mode path that ran and whether the agent ever
+ * left the start page — i.e. whether a failure occurred before or after the
+ * first browser action. Finer-grained path attribution (function-response vs
+ * browser-execution) lives in the per-step trajectory logged below.
+ */
+export default defineBenchTask(
+  { name: "agent/cua_amazon_checkout" },
+  async ({ debugUrl, sessionUrl, logger, agent, v3, input, modelName }) => {
+    const startUrl =
+      "https://browserbase.github.io/stagehand-eval-sites/sites/amazon/";
+    const expectedUrl =
+      "https://browserbase.github.io/stagehand-eval-sites/sites/amazon/sign-in.html";
+
+    try {
+      if (!agent) {
+        throw new Error(
+          "agent/cua_amazon_checkout requires an agent instance — run it under an agent mode (e.g. --agent-mode cua).",
+        );
+      }
+
+      const page = v3.context.pages()[0];
+      await page.goto(startUrl);
+
+      const agentResult = await agent.execute({
+        instruction:
+          "Add the product to the cart and proceed to checkout. Stop when you reach the sign-in page.",
+        maxSteps: Number(process.env.AGENT_EVAL_MAX_STEPS) || 10,
+      });
+      logger.log(agentResult);
+
+      const currentUrl = page.url();
+
+      return {
+        _success: currentUrl === expectedUrl,
+        currentUrl,
+        expectedUrl,
+        // Attribution context (see #2188): which provider/model path ran, and
+        // whether the agent got past the initial page before failing.
+        modelName,
+        agentMode: input.agentMode,
+        isCUA: input.isCUA,
+        leftStartPage: currentUrl !== startUrl,
+        debugUrl,
+        sessionUrl,
+        logs: logger.getLogs(),
+      };
+    } catch (error) {
+      return {
+        _success: false,
+        error,
+        modelName,
+        agentMode: input.agentMode,
+        isCUA: input.isCUA,
+        debugUrl,
+        sessionUrl,
+        logs: logger.getLogs(),
+      };
+    } finally {
+      await v3.close();
+    }
+  },
+);


### PR DESCRIPTION
## why

`mode: "cua"` is only exercised today inside the heavyweight WebVoyager / OnlineMind2Web suites — too slow for quick CI signal and too non-deterministic to attribute a failure to a specific provider. So provider-specific function-response regressions (#2046, fixed by #2159; #2035) slip through, because they only break outside the PNG / happy-path that the `act`-tier tests cover.

This adds the small, deterministic regression check proposed in #2188: a fixture-backed agent task that answers "does the CUA function-response → browser-action loop still work end to end?" without LLM-judge noise or page drift.

## what changed

One new bench task: `packages/evals/tasks/bench/agent/cua_amazon_checkout.ts`.

- **Fixture**: the pinned static mirror `browserbase.github.io/stagehand-eval-sites/sites/amazon/` — already used by `act/amazon_add_to_cart`, so the page is known-stable.
- **Flow**: `agent.execute(...)` to add the product to the cart and proceed to checkout.
- **Pass criterion**: `page.url() === .../amazon/sign-in.html` — the exact deterministic check the existing `act` task uses. No rubric, no screenshot/coordinate comparison.
- **Pattern**: mirrors the existing deterministic-URL agent task `agent/sign_in.ts`; adds no new framework surface and no dependencies.

Mode-agnostic — point it at a CUA model to exercise the CUA path:

```
evals run agent/cua_amazon_checkout --agent-mode cua \
  --model google/gemini-2.5-computer-use-preview-10-2025
```

## attribution context

Per review discussion on #2188 (keeping failures narrowly attributable), the result records the model/agent-mode path that ran and whether the agent ever left the start page — i.e. whether a failure happened before or after the first browser action. Finer-grained path attribution (function-response vs browser-execution) is preserved in the per-step trajectory logged from `agent.execute`.

## testing

`pnpm --filter @browserbasehq/stagehand-evals run lint` (prettier + eslint + typecheck) passes, and the task is picked up by directory auto-discovery. I haven't run it against a live CUA model (needs provider keys + budget) — happy to share a run if there's a preferred model. Open to a different fixture, instruction, or pass-criterion shape.

Closes #2188.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a small, deterministic CUA agent regression task to verify the end-to-end function-response → browser-action loop on a pinned Amazon mirror. Provides fast, stable CI signal and isolates provider/plumbing regressions (addresses #2188).

- **New Features**
  - Adds `agent/cua_amazon_checkout` in `packages/evals/tasks/bench/agent/cua_amazon_checkout.ts`.
  - Uses the static fixture at `https://browserbase.github.io/stagehand-eval-sites/sites/amazon/`.
  - Passes only when `page.url()` matches the known sign-in URL; no rubric or screenshots.
  - Captures `modelName`, `agentMode`, `isCUA`, and whether the agent left the start page, plus logs and debug/session URLs.
  - Mirrors the existing deterministic-URL agent pattern; no new dependencies.

<sup>Written for commit 18c0f0329219d2914dea9a3422bbd524ac10e256. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

