### PR TITLE
[fix]: close popups that violate domain policy

### DIFF
--- a/.changeset/cozy-yaks-pull.md
+++ b/.changeset/cozy-yaks-pull.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+automatically close popups that violate user defined domain policy

--- a/packages/core/lib/v3/understudy/context.ts
+++ b/packages/core/lib/v3/understudy/context.ts
@@ -137,6 +137,7 @@ export class V3Context {
   private pendingCreatedTargetUrl = new Map<TargetId, string>();
   private pageCreationFailures = new Map<TargetId, Error>();
   private domainPolicyClosingTargets = new Set<TargetId>();
+  private domainPolicyClosePromises = new Map<TargetId, Promise<boolean>>();
   private readonly initScripts: string[] = [];
   private extraHttpHeaders: Record<string, string> | null = null;
   private domainPolicy: NormalizedDomainPolicy | null = null;
@@ -705,6 +706,7 @@ export class V3Context {
     this.pendingCreatedTargetUrl.clear();
     this.pageCreationFailures.clear();
     this.domainPolicyClosingTargets.clear();
+    this.domainPolicyClosePromises.clear();
   }
 
   /**
@@ -1173,10 +1175,14 @@ export class V3Context {
     if (!info.openerId && !info.openerFrameId) return false;
     if (this.domainPolicyClosingTargets.has(info.targetId)) return true;
 
+    const existingClose = this.domainPolicyClosePromises.get(info.targetId);
+    if (existingClose) {
+      return source === "attached" ? await existingClose : true;
+    }
+
     const decision = getDomainPolicyDecision(info.url ?? "", this.domainPolicy);
     if (decision.action === "continue") return false;
 
-    this.domainPolicyClosingTargets.add(info.targetId);
     v3Logger({
       category: "network",
       message:
@@ -1195,13 +1201,18 @@ export class V3Context {
       },
     });
 
-    const closed = await this.closeTargetAfterDomainPolicyViolation(info, {
+    const closePromise = this.closeTargetAfterDomainPolicyViolation(info, {
       failureMessage:
         "Failed to close popup after it reached a disallowed domain",
+    }).then((closed) => {
+      this.domainPolicyClosePromises.delete(info.targetId);
+      if (closed) {
+        this.domainPolicyClosingTargets.add(info.targetId);
+      }
+      return closed;
     });
-    if (!closed) this.domainPolicyClosingTargets.delete(info.targetId);
-    if (!closed) return false;
-    return true;
+    this.domainPolicyClosePromises.set(info.targetId, closePromise);
+    return await closePromise;
   }
 
   private async closeTargetAfterDomainPolicyViolation(

--- a/packages/core/lib/v3/understudy/context.ts
+++ b/packages/core/lib/v3/understudy/context.ts
@@ -141,6 +141,11 @@ export class V3Context {
   private _pageOrder: TargetId[] = [];
   private pendingCreatedTargetUrl = new Map<TargetId, string>();
   private pageCreationFailures = new Map<TargetId, Error>();
+  // Popup close attempts can race targetCreated, targetInfoChanged, and attached.
+  // In-flight promises let attach wait for a close result before deciding whether
+  // to skip normal setup. Successful closes stay deduped for the context lifetime
+  // because Chrome can emit late targetInfoChanged events after targetDestroyed.
+  // Failed closes are not retained so attach can continue and future events may retry.
   private domainPolicyClosingTargets = new Set<TargetId>();
   private domainPolicyClosePromises = new Map<TargetId, Promise<boolean>>();
   private readonly initScripts: string[] = [];

--- a/packages/core/lib/v3/understudy/context.ts
+++ b/packages/core/lib/v3/understudy/context.ts
@@ -136,6 +136,7 @@ export class V3Context {
   private _pageOrder: TargetId[] = [];
   private pendingCreatedTargetUrl = new Map<TargetId, string>();
   private pageCreationFailures = new Map<TargetId, Error>();
+  private domainPolicyClosingTargets = new Set<TargetId>();
   private readonly initScripts: string[] = [];
   private extraHttpHeaders: Record<string, string> | null = null;
   private domainPolicy: NormalizedDomainPolicy | null = null;
@@ -703,6 +704,7 @@ export class V3Context {
     this.typeByTarget.clear();
     this.pendingCreatedTargetUrl.clear();
     this.pageCreationFailures.clear();
+    this.domainPolicyClosingTargets.clear();
   }
 
   /**
@@ -744,7 +746,17 @@ export class V3Context {
         const ti = info;
         if (info.type === "page" && (ti?.openerId || ti?.openerFrameId)) {
           this._notePopupSignal();
+          void this.closePopupIfBlockedByDomainPolicy(info, "targetCreated");
         }
+      },
+    );
+    this.conn.on<Protocol.Target.TargetInfoChangedEvent>(
+      "Target.targetInfoChanged",
+      (evt) => {
+        void this.closePopupIfBlockedByDomainPolicy(
+          evt.targetInfo,
+          "targetInfoChanged",
+        );
       },
     );
 
@@ -779,6 +791,10 @@ export class V3Context {
     info: Protocol.Target.TargetInfo,
     sessionId: SessionId,
   ): Promise<void> {
+    if (await this.closePopupIfBlockedByDomainPolicy(info, "attached")) {
+      return;
+    }
+
     // Skip non-web targets (workers, chrome extensions, background pages, etc.).
     // They still need to be resumed so we don't leave them paused by
     // waitForDebuggerOnStart, but injecting the piercer into these targets
@@ -1146,6 +1162,71 @@ export class V3Context {
       }
     } finally {
       await resume();
+    }
+  }
+
+  private async closePopupIfBlockedByDomainPolicy(
+    info: Protocol.Target.TargetInfo,
+    source: "targetCreated" | "targetInfoChanged" | "attached",
+  ): Promise<boolean> {
+    if (!this.domainPolicy || !isTopLevelPage(info)) return false;
+    if (!info.openerId && !info.openerFrameId) return false;
+    if (this.domainPolicyClosingTargets.has(info.targetId)) return true;
+
+    const decision = getDomainPolicyDecision(info.url ?? "", this.domainPolicy);
+    if (decision.action === "continue") return false;
+
+    this.domainPolicyClosingTargets.add(info.targetId);
+    v3Logger({
+      category: "network",
+      message:
+        "Popup reached a disallowed domain before it could be intercepted; closing it",
+      level: 2,
+      auxiliary: {
+        targetId: { value: String(info.targetId), type: "string" },
+        targetUrl: { value: String(info.url ?? ""), type: "string" },
+        openerId: { value: String(info.openerId ?? ""), type: "string" },
+        openerFrameId: {
+          value: String(info.openerFrameId ?? ""),
+          type: "string",
+        },
+        ruleType: { value: decision.reason, type: "string" },
+        source: { value: source, type: "string" },
+      },
+    });
+
+    const closed = await this.closeTargetAfterDomainPolicyViolation(info, {
+      failureMessage:
+        "Failed to close popup after it reached a disallowed domain",
+    });
+    if (!closed) this.domainPolicyClosingTargets.delete(info.targetId);
+    if (!closed) return false;
+    return true;
+  }
+
+  private async closeTargetAfterDomainPolicyViolation(
+    info: Protocol.Target.TargetInfo,
+    opts: { failureMessage: string },
+  ): Promise<boolean> {
+    try {
+      await this.conn.send("Target.closeTarget", { targetId: info.targetId });
+      return true;
+    } catch (error) {
+      v3Logger({
+        category: "network",
+        message: opts.failureMessage,
+        level: 0,
+        auxiliary: {
+          targetId: { value: String(info.targetId), type: "string" },
+          targetType: { value: String(info.type), type: "string" },
+          targetUrl: { value: String(info.url ?? ""), type: "string" },
+          error: {
+            value: error instanceof Error ? error.message : String(error),
+            type: "string",
+          },
+        },
+      });
+      return false;
     }
   }
 

--- a/packages/core/lib/v3/understudy/context.ts
+++ b/packages/core/lib/v3/understudy/context.ts
@@ -43,6 +43,11 @@ type SessionId = string;
 
 type TargetType = "page" | "iframe" | string;
 
+function isMissingTargetError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /No target with given id found/i.test(message);
+}
+
 /**
  * Returns true when the target's URL points to a document with a real,
  * pierceable HTML DOM.  We allowlist the small set of schemes that carry
@@ -1223,6 +1228,10 @@ export class V3Context {
       await this.conn.send("Target.closeTarget", { targetId: info.targetId });
       return true;
     } catch (error) {
+      if (isMissingTargetError(error)) {
+        return true;
+      }
+
       v3Logger({
         category: "network",
         message: opts.failureMessage,

--- a/packages/core/tests/integration/context-domain-policy.spec.ts
+++ b/packages/core/tests/integration/context-domain-policy.spec.ts
@@ -28,7 +28,6 @@ type InternalPage = {
     options?: { waitUntil?: "load" | "domcontentloaded"; timeoutMs?: number },
   ) => Promise<unknown>;
   locator: (selector: string) => { click: () => Promise<void> };
-  waitForTimeout: (timeoutMs: number) => Promise<void>;
   url: () => string;
 };
 
@@ -147,6 +146,56 @@ function expectNotBlockedByClient(outcome: RequestOutcome | undefined): void {
   if (outcome?.type === "failed") {
     expect(outcome.errorText).not.toContain("ERR_BLOCKED_BY_CLIENT");
   }
+}
+
+async function waitForTargetUrlDestroyed(
+  conn: V3["context"]["conn"],
+  expectedUrl: string,
+  timeoutMs = 5_000,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    let targetId: string | null = null;
+    let settled = false;
+    const timeout = setTimeout(() => {
+      finish(() =>
+        reject(
+          new Error(
+            `Timed out waiting for target URL to close: ${expectedUrl}`,
+          ),
+        ),
+      );
+    }, timeoutMs);
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      conn.off("Target.targetInfoChanged", onTargetInfoChanged);
+      conn.off("Target.targetDestroyed", onTargetDestroyed);
+    };
+
+    const finish = (settle: () => void): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      settle();
+    };
+
+    const onTargetInfoChanged = (params: unknown) => {
+      const evt = params as Protocol.Target.TargetInfoChangedEvent;
+      if (evt.targetInfo.url === expectedUrl) {
+        targetId = evt.targetInfo.targetId;
+      }
+    };
+
+    const onTargetDestroyed = (params: unknown) => {
+      const evt = params as Protocol.Target.TargetDestroyedEvent;
+      if (targetId && evt.targetId === targetId) {
+        finish(resolve);
+      }
+    };
+
+    conn.on("Target.targetInfoChanged", onTargetInfoChanged);
+    conn.on("Target.targetDestroyed", onTargetDestroyed);
+  });
 }
 
 test.describe("context.setDomainPolicy", () => {
@@ -288,8 +337,14 @@ test.describe("context.setDomainPolicy", () => {
       timeoutMs: 10_000,
     });
 
+    const popupClosed = waitForTargetUrlDestroyed(ctx.conn, POPUP_BLOCKED_URL);
     await page.locator("#open-popup").click();
-    await page.waitForTimeout(1_000);
+    await popupClosed;
+    await expect
+      .poll(() => ctx.pages().map((candidate) => candidate.url()), {
+        timeout: 5_000,
+      })
+      .not.toContain(POPUP_BLOCKED_URL);
 
     expect(ctx.pages().map((candidate) => candidate.url())).not.toContain(
       POPUP_BLOCKED_URL,

--- a/packages/core/tests/integration/context-domain-policy.spec.ts
+++ b/packages/core/tests/integration/context-domain-policy.spec.ts
@@ -168,6 +168,7 @@ async function waitForTargetUrlDestroyed(
 
     const cleanup = () => {
       clearTimeout(timeout);
+      conn.off("Target.targetCreated", onTargetCreated);
       conn.off("Target.targetInfoChanged", onTargetInfoChanged);
       conn.off("Target.targetDestroyed", onTargetDestroyed);
     };
@@ -179,11 +180,20 @@ async function waitForTargetUrlDestroyed(
       settle();
     };
 
+    const rememberTarget = (targetInfo: Protocol.Target.TargetInfo) => {
+      if (targetInfo.url === expectedUrl) {
+        targetId = targetInfo.targetId;
+      }
+    };
+
+    const onTargetCreated = (params: unknown) => {
+      const evt = params as Protocol.Target.TargetCreatedEvent;
+      rememberTarget(evt.targetInfo);
+    };
+
     const onTargetInfoChanged = (params: unknown) => {
       const evt = params as Protocol.Target.TargetInfoChangedEvent;
-      if (evt.targetInfo.url === expectedUrl) {
-        targetId = evt.targetInfo.targetId;
-      }
+      rememberTarget(evt.targetInfo);
     };
 
     const onTargetDestroyed = (params: unknown) => {
@@ -193,6 +203,7 @@ async function waitForTargetUrlDestroyed(
       }
     };
 
+    conn.on("Target.targetCreated", onTargetCreated);
     conn.on("Target.targetInfoChanged", onTargetInfoChanged);
     conn.on("Target.targetDestroyed", onTargetDestroyed);
   });

--- a/packages/core/tests/integration/context-domain-policy.spec.ts
+++ b/packages/core/tests/integration/context-domain-policy.spec.ts
@@ -8,6 +8,10 @@ import { closeV3 } from "./testUtils.js";
 
 const BLOCKED_HOST = "example.com";
 const BLOCKED_URL = `https://${BLOCKED_HOST}/stagehand-domain-policy.png`;
+const POPUP_FIXTURE_URL =
+  "https://browserbase.github.io/stagehand-eval-sites/sites/external-popup-button/";
+const POPUP_BLOCKED_HOST = "news.ycombinator.com";
+const POPUP_BLOCKED_URL = `https://${POPUP_BLOCKED_HOST}/`;
 const ALLOWED_HOST = "127.0.0.1";
 const DISALLOWED_HOST = "127.0.0.2";
 let localServer: Server | null = null;
@@ -23,6 +27,9 @@ type InternalPage = {
     url: string,
     options?: { waitUntil?: "load" | "domcontentloaded"; timeoutMs?: number },
   ) => Promise<unknown>;
+  locator: (selector: string) => { click: () => Promise<void> };
+  waitForTimeout: (timeoutMs: number) => Promise<void>;
+  url: () => string;
 };
 
 function pageWithBlockedImage(): string {
@@ -266,5 +273,27 @@ test.describe("context.setDomainPolicy", () => {
     );
 
     expectBlockedByClient(outcomes.get(disallowedUrl));
+  });
+
+  test("closes window.open popups that reach blocked domains before interception", async () => {
+    const ctx = v3.context;
+    const page = (await ctx.awaitActivePage()) as unknown as InternalPage;
+
+    await ctx.setDomainPolicy({
+      blockedDomains: [POPUP_BLOCKED_HOST],
+    });
+
+    await page.goto(POPUP_FIXTURE_URL, {
+      waitUntil: "load",
+      timeoutMs: 10_000,
+    });
+
+    await page.locator("#open-popup").click();
+    await page.waitForTimeout(1_000);
+
+    expect(ctx.pages().map((candidate) => candidate.url())).not.toContain(
+      POPUP_BLOCKED_URL,
+    );
+    expect(page.url()).toBe(POPUP_FIXTURE_URL);
   });
 });

--- a/packages/core/tests/unit/context-domain-policy.test.ts
+++ b/packages/core/tests/unit/context-domain-policy.test.ts
@@ -331,6 +331,270 @@ describe("V3Context.setDomainPolicy", () => {
     });
   });
 
+  it("closes blocked popups even when the opener is not tracked locally", async () => {
+    const closeTargetCalls: unknown[] = [];
+    const ctx = Object.assign(Object.create(V3Context.prototype), {
+      domainPolicy: normalizeDomainPolicy({
+        blockedDomains: ["ads.example.com"],
+      }),
+      domainPolicyClosingTargets: new Set<string>(),
+      conn: {
+        send: async (method: string, params?: unknown) => {
+          if (method === "Target.closeTarget") closeTargetCalls.push(params);
+          return {};
+        },
+      },
+    });
+    const closePopupIfBlockedByDomainPolicy = V3Context.prototype[
+      "closePopupIfBlockedByDomainPolicy" as keyof V3Context
+    ] as unknown as (
+      this: typeof ctx,
+      info: {
+        targetId: string;
+        type: string;
+        title: string;
+        url: string;
+        attached: boolean;
+        openerId?: string;
+        canAccessOpener: boolean;
+      },
+      source: "targetInfoChanged",
+    ) => Promise<boolean>;
+
+    await expect(
+      closePopupIfBlockedByDomainPolicy.call(
+        ctx,
+        {
+          targetId: "popup-target",
+          type: "page",
+          title: "",
+          url: "https://ads.example.com/",
+          attached: false,
+          openerId: "other-target",
+          canAccessOpener: true,
+        },
+        "targetInfoChanged",
+      ),
+    ).resolves.toBe(true);
+
+    expect(closeTargetCalls).toEqual([{ targetId: "popup-target" }]);
+  });
+
+  it("does not attempt to close the same blocked popup twice", async () => {
+    const closeTargetCalls: unknown[] = [];
+    const ctx = Object.assign(Object.create(V3Context.prototype), {
+      domainPolicy: normalizeDomainPolicy({
+        blockedDomains: ["ads.example.com"],
+      }),
+      domainPolicyClosingTargets: new Set<string>(),
+      pagesByTarget: new Map(),
+      conn: {
+        send: async (method: string, params?: unknown) => {
+          if (method === "Target.closeTarget") closeTargetCalls.push(params);
+          return {};
+        },
+      },
+    });
+    const closePopupIfBlockedByDomainPolicy = V3Context.prototype[
+      "closePopupIfBlockedByDomainPolicy" as keyof V3Context
+    ] as unknown as (
+      this: typeof ctx,
+      info: {
+        targetId: string;
+        type: string;
+        title: string;
+        url: string;
+        attached: boolean;
+        openerId?: string;
+        canAccessOpener: boolean;
+      },
+      source: "targetInfoChanged",
+    ) => Promise<boolean>;
+    const targetInfo = {
+      targetId: "popup-target",
+      type: "page",
+      title: "",
+      url: "https://ads.example.com/",
+      attached: false,
+      openerId: "other-target",
+      canAccessOpener: true,
+    };
+
+    await expect(
+      closePopupIfBlockedByDomainPolicy.call(
+        ctx,
+        targetInfo,
+        "targetInfoChanged",
+      ),
+    ).resolves.toBe(true);
+    await expect(
+      closePopupIfBlockedByDomainPolicy.call(
+        ctx,
+        targetInfo,
+        "targetInfoChanged",
+      ),
+    ).resolves.toBe(true);
+
+    expect(closeTargetCalls).toEqual([{ targetId: "popup-target" }]);
+  });
+
+  it("does not retry a blocked popup close after target cleanup", async () => {
+    const closeTargetCalls: unknown[] = [];
+    const ctx = Object.assign(Object.create(V3Context.prototype), {
+      domainPolicy: normalizeDomainPolicy({
+        blockedDomains: ["ads.example.com"],
+      }),
+      domainPolicyClosingTargets: new Set<string>(),
+      pagesByTarget: new Map(),
+      conn: {
+        send: async (method: string, params?: unknown) => {
+          if (method === "Target.closeTarget") closeTargetCalls.push(params);
+          return {};
+        },
+      },
+    });
+    const closePopupIfBlockedByDomainPolicy = V3Context.prototype[
+      "closePopupIfBlockedByDomainPolicy" as keyof V3Context
+    ] as unknown as (
+      this: typeof ctx,
+      info: {
+        targetId: string;
+        type: string;
+        title: string;
+        url: string;
+        attached: boolean;
+        openerId?: string;
+        canAccessOpener: boolean;
+      },
+      source: "targetInfoChanged",
+    ) => Promise<boolean>;
+    const cleanupByTarget = V3Context.prototype[
+      "cleanupByTarget" as keyof V3Context
+    ] as unknown as (this: typeof ctx, targetId: string) => void;
+    const targetInfo = {
+      targetId: "popup-target",
+      type: "page",
+      title: "",
+      url: "https://ads.example.com/",
+      attached: false,
+      openerId: "other-target",
+      canAccessOpener: true,
+    };
+
+    await expect(
+      closePopupIfBlockedByDomainPolicy.call(
+        ctx,
+        targetInfo,
+        "targetInfoChanged",
+      ),
+    ).resolves.toBe(true);
+    cleanupByTarget.call(ctx, "popup-target");
+    await expect(
+      closePopupIfBlockedByDomainPolicy.call(
+        ctx,
+        targetInfo,
+        "targetInfoChanged",
+      ),
+    ).resolves.toBe(true);
+
+    expect(closeTargetCalls).toEqual([{ targetId: "popup-target" }]);
+  });
+
+  it("does not close non-popup targets through the popup fallback", async () => {
+    const closeTargetCalls: unknown[] = [];
+    const ctx = Object.assign(Object.create(V3Context.prototype), {
+      domainPolicy: normalizeDomainPolicy({
+        blockedDomains: ["ads.example.com"],
+      }),
+      domainPolicyClosingTargets: new Set<string>(),
+      conn: {
+        send: async (method: string, params?: unknown) => {
+          if (method === "Target.closeTarget") closeTargetCalls.push(params);
+          return {};
+        },
+      },
+    });
+    const closePopupIfBlockedByDomainPolicy = V3Context.prototype[
+      "closePopupIfBlockedByDomainPolicy" as keyof V3Context
+    ] as unknown as (
+      this: typeof ctx,
+      info: {
+        targetId: string;
+        type: string;
+        title: string;
+        url: string;
+        attached: boolean;
+        canAccessOpener: boolean;
+      },
+      source: "targetInfoChanged",
+    ) => Promise<boolean>;
+
+    await expect(
+      closePopupIfBlockedByDomainPolicy.call(
+        ctx,
+        {
+          targetId: "page-target",
+          type: "page",
+          title: "",
+          url: "https://ads.example.com/",
+          attached: false,
+          canAccessOpener: false,
+        },
+        "targetInfoChanged",
+      ),
+    ).resolves.toBe(false);
+
+    expect(closeTargetCalls).toEqual([]);
+  });
+
+  it("returns false when closing a blocked popup fails", async () => {
+    const ctx = Object.assign(Object.create(V3Context.prototype), {
+      domainPolicy: normalizeDomainPolicy({
+        blockedDomains: ["ads.example.com"],
+      }),
+      domainPolicyClosingTargets: new Set<string>(),
+      conn: {
+        send: async (method: string) => {
+          if (method === "Target.closeTarget") {
+            throw new Error("close failed");
+          }
+          return {};
+        },
+      },
+    });
+    const closePopupIfBlockedByDomainPolicy = V3Context.prototype[
+      "closePopupIfBlockedByDomainPolicy" as keyof V3Context
+    ] as unknown as (
+      this: typeof ctx,
+      info: {
+        targetId: string;
+        type: string;
+        title: string;
+        url: string;
+        attached: boolean;
+        openerId?: string;
+        canAccessOpener: boolean;
+      },
+      source: "targetInfoChanged",
+    ) => Promise<boolean>;
+
+    await expect(
+      closePopupIfBlockedByDomainPolicy.call(
+        ctx,
+        {
+          targetId: "popup-target",
+          type: "page",
+          title: "",
+          url: "https://ads.example.com/",
+          attached: false,
+          openerId: "opener-target",
+          canAccessOpener: true,
+        },
+        "targetInfoChanged",
+      ),
+    ).resolves.toBe(false);
+  });
+
   it("closes new targets when Fetch.enable fails with an active policy", async () => {
     const session = new MockCDPSession(
       {

--- a/packages/core/tests/unit/context-domain-policy.test.ts
+++ b/packages/core/tests/unit/context-domain-policy.test.ts
@@ -669,6 +669,56 @@ describe("V3Context.setDomainPolicy", () => {
     ).resolves.toBe(false);
   });
 
+  it("treats already-closed popup targets as successful policy closes", async () => {
+    const ctx = Object.assign(Object.create(V3Context.prototype), {
+      domainPolicy: normalizeDomainPolicy({
+        blockedDomains: ["ads.example.com"],
+      }),
+      domainPolicyClosingTargets: new Set<string>(),
+      domainPolicyClosePromises: new Map<string, Promise<boolean>>(),
+      conn: {
+        send: async (method: string) => {
+          if (method === "Target.closeTarget") {
+            throw new Error("-32602 No target with given id found");
+          }
+          return {};
+        },
+      },
+    });
+    const closePopupIfBlockedByDomainPolicy = V3Context.prototype[
+      "closePopupIfBlockedByDomainPolicy" as keyof V3Context
+    ] as unknown as (
+      this: typeof ctx,
+      info: {
+        targetId: string;
+        type: string;
+        title: string;
+        url: string;
+        attached: boolean;
+        openerId?: string;
+        canAccessOpener: boolean;
+      },
+      source: "targetInfoChanged",
+    ) => Promise<boolean>;
+
+    await expect(
+      closePopupIfBlockedByDomainPolicy.call(
+        ctx,
+        {
+          targetId: "popup-target",
+          type: "page",
+          title: "",
+          url: "https://ads.example.com/",
+          attached: false,
+          openerId: "opener-target",
+          canAccessOpener: true,
+        },
+        "targetInfoChanged",
+      ),
+    ).resolves.toBe(true);
+    expect(ctx.domainPolicyClosingTargets.has("popup-target")).toBe(true);
+  });
+
   it("closes new targets when Fetch.enable fails with an active policy", async () => {
     const session = new MockCDPSession(
       {

--- a/packages/core/tests/unit/context-domain-policy.test.ts
+++ b/packages/core/tests/unit/context-domain-policy.test.ts
@@ -338,6 +338,7 @@ describe("V3Context.setDomainPolicy", () => {
         blockedDomains: ["ads.example.com"],
       }),
       domainPolicyClosingTargets: new Set<string>(),
+      domainPolicyClosePromises: new Map<string, Promise<boolean>>(),
       conn: {
         send: async (method: string, params?: unknown) => {
           if (method === "Target.closeTarget") closeTargetCalls.push(params);
@@ -387,6 +388,7 @@ describe("V3Context.setDomainPolicy", () => {
         blockedDomains: ["ads.example.com"],
       }),
       domainPolicyClosingTargets: new Set<string>(),
+      domainPolicyClosePromises: new Map<string, Promise<boolean>>(),
       pagesByTarget: new Map(),
       conn: {
         send: async (method: string, params?: unknown) => {
@@ -445,6 +447,7 @@ describe("V3Context.setDomainPolicy", () => {
         blockedDomains: ["ads.example.com"],
       }),
       domainPolicyClosingTargets: new Set<string>(),
+      domainPolicyClosePromises: new Map<string, Promise<boolean>>(),
       pagesByTarget: new Map(),
       conn: {
         send: async (method: string, params?: unknown) => {
@@ -507,6 +510,7 @@ describe("V3Context.setDomainPolicy", () => {
         blockedDomains: ["ads.example.com"],
       }),
       domainPolicyClosingTargets: new Set<string>(),
+      domainPolicyClosePromises: new Map<string, Promise<boolean>>(),
       conn: {
         send: async (method: string, params?: unknown) => {
           if (method === "Target.closeTarget") closeTargetCalls.push(params);
@@ -547,12 +551,82 @@ describe("V3Context.setDomainPolicy", () => {
     expect(closeTargetCalls).toEqual([]);
   });
 
+  it("does not skip attached handling when an in-flight popup close fails", async () => {
+    let rejectClose!: (error: Error) => void;
+    let resolveCloseStarted!: () => void;
+    const closeStarted = new Promise<void>((resolve) => {
+      resolveCloseStarted = resolve;
+    });
+    const closePromise = new Promise<never>((_, reject) => {
+      rejectClose = reject;
+    });
+    const ctx = Object.assign(Object.create(V3Context.prototype), {
+      domainPolicy: normalizeDomainPolicy({
+        blockedDomains: ["ads.example.com"],
+      }),
+      domainPolicyClosingTargets: new Set<string>(),
+      domainPolicyClosePromises: new Map<string, Promise<boolean>>(),
+      conn: {
+        send: async (method: string) => {
+          if (method === "Target.closeTarget") {
+            resolveCloseStarted();
+            return await closePromise;
+          }
+          return {};
+        },
+      },
+    });
+    const closePopupIfBlockedByDomainPolicy = V3Context.prototype[
+      "closePopupIfBlockedByDomainPolicy" as keyof V3Context
+    ] as unknown as (
+      this: typeof ctx,
+      info: {
+        targetId: string;
+        type: string;
+        title: string;
+        url: string;
+        attached: boolean;
+        openerId?: string;
+        canAccessOpener: boolean;
+      },
+      source: "targetCreated" | "attached",
+    ) => Promise<boolean>;
+    const targetInfo = {
+      targetId: "popup-target",
+      type: "page",
+      title: "",
+      url: "https://ads.example.com/",
+      attached: false,
+      openerId: "opener-target",
+      canAccessOpener: true,
+    };
+
+    const targetCreatedClose = closePopupIfBlockedByDomainPolicy.call(
+      ctx,
+      targetInfo,
+      "targetCreated",
+    );
+    await closeStarted;
+
+    const attachedClose = closePopupIfBlockedByDomainPolicy.call(
+      ctx,
+      targetInfo,
+      "attached",
+    );
+
+    rejectClose(new Error("close failed"));
+
+    await expect(targetCreatedClose).resolves.toBe(false);
+    await expect(attachedClose).resolves.toBe(false);
+  });
+
   it("returns false when closing a blocked popup fails", async () => {
     const ctx = Object.assign(Object.create(V3Context.prototype), {
       domainPolicy: normalizeDomainPolicy({
         blockedDomains: ["ads.example.com"],
       }),
       domainPolicyClosingTargets: new Set<string>(),
+      domainPolicyClosePromises: new Map<string, Promise<boolean>>(),
       conn: {
         send: async (method: string) => {
           if (method === "Target.closeTarget") {

--- a/packages/core/tests/unit/context-domain-policy.test.ts
+++ b/packages/core/tests/unit/context-domain-policy.test.ts
@@ -440,7 +440,7 @@ describe("V3Context.setDomainPolicy", () => {
     expect(closeTargetCalls).toEqual([{ targetId: "popup-target" }]);
   });
 
-  it("does not retry a blocked popup close after target cleanup", async () => {
+  it("retains successful popup close dedupe for late target events", async () => {
     const closeTargetCalls: unknown[] = [];
     const ctx = Object.assign(Object.create(V3Context.prototype), {
       domainPolicy: normalizeDomainPolicy({


### PR DESCRIPTION
# why

domain policy enforcement currently relies on `Fetch.requestPaused`, but popups opened with `window.open()` can reach their destination before Fetch interception is installed on the new target. in that race, the blocked popup may successfully open, & therefore break the domain policy

# what changed

this PR adds a fallback close path for popup targets whose URL violates the active domain policy:

- this PR adds listening for `Target.targetCreated`, `Target.targetInfoChanged`, and attach-time target metadata for popup targets
- if a popup reaches a blocked/disallowed domain before request interception catches it, the popup gets closed via Target.closeTarget`

# test plan

- added unit coverage for closing popup targets that already reached a blocked domain, including popups whose opener target is not locally tracked
- added unit coverage for duplicate and late target events so a successfully closed popup is not closed/logged repeatedly
- added unit coverage for the attach race where a `targetCreated` close is still in flight when `attached` handling runs; attach now continues if the close fails
- added unit coverage for close failures, including treating `No target with given id found` as a successful already-closed outcome for this domain-policy fallback only
- added integration coverage using the existing external popup fixture to verify a `window.open()` popup that reaches `news.ycombinator.com` is closed and not retained in `context.pages()`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race where `window.open()` popups could reach blocked domains before interception by closing them immediately when their URL violates the active domain policy. Prevents blocked popups from appearing or lingering in `context.pages()`.

- **Bug Fixes**
  - Listen to `Target.targetCreated`, `Target.targetInfoChanged`, and at attach-time; close popup via `Target.closeTarget` if its URL is disallowed.
  - Deduplicate close attempts across events and let attach wait for an in-flight close; continue attach if the close fails.
  - Treat “No target with given id found” as a successful already-closed outcome for this fallback; improve logging with rule reason and source.
  - Skip non-popup targets and persist successful close dedupe across late events.

- **Dependencies**
  - Add changeset to publish a patch for `@browserbasehq/stagehand`.

<sup>Written for commit a0dae3be411451342d93b4bcd4ff82d9845ab6b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

