### PR TITLE
[STG-2449] ci: publish browserbase/browse Docker image on browse release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,19 +147,6 @@ jobs:
           git tag "$TAG"
           git push origin "$TAG"
 
-      - name: Check Docker Hub credentials
-        id: dockerhub
-        if: steps.browse_cli.outputs.should_publish == 'true' && steps.browse_cli.outputs.already_published != 'true'
-        env:
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        run: |
-          if [ -n "$DOCKERHUB_TOKEN" ]; then
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::DOCKERHUB_TOKEN not set — pushing browse image to GHCR only. Set DOCKERHUB_USERNAME + DOCKERHUB_TOKEN to also publish browserbase/browse on Docker Hub."
-          fi
-
       - name: Set up QEMU
         if: steps.browse_cli.outputs.should_publish == 'true' && steps.browse_cli.outputs.already_published != 'true'
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
@@ -176,30 +163,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Log in to Docker Hub
-        if: steps.dockerhub.outputs.enabled == 'true'
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Compute browse image tags
-        id: image_tags
-        if: steps.browse_cli.outputs.should_publish == 'true' && steps.browse_cli.outputs.already_published != 'true'
-        run: |
-          V="${{ steps.browse_cli.outputs.version }}"
-          {
-            echo "tags<<EOF"
-            echo "ghcr.io/browserbase/browse:${V}"
-            echo "ghcr.io/browserbase/browse:latest"
-            if [ "${{ steps.dockerhub.outputs.enabled }}" = "true" ]; then
-              echo "browserbase/browse:${V}"
-              echo "browserbase/browse:latest"
-            fi
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Build and push browse image
+      - name: Build and push browse image to GHCR
         if: steps.browse_cli.outputs.should_publish == 'true' && steps.browse_cli.outputs.already_published != 'true'
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
@@ -210,7 +174,9 @@ jobs:
           provenance: false
           build-args: |
             BROWSE_VERSION=${{ steps.browse_cli.outputs.version }}
-          tags: ${{ steps.image_tags.outputs.tags }}
+          tags: |
+            ghcr.io/browserbase/browse:${{ steps.browse_cli.outputs.version }}
+            ghcr.io/browserbase/browse:latest
 
       - name: Publish browse canary
         if: github.ref == 'refs/heads/main' && steps.browse_cli.outputs.should_publish != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,11 +147,6 @@ jobs:
           git tag "$TAG"
           git push origin "$TAG"
 
-      # --- Publish the browse CLI as a Docker image, pinned to the npm version ---
-      # GHCR (ghcr.io/browserbase/browse) always publishes via the built-in
-      # GITHUB_TOKEN. Docker Hub (browserbase/browse) additionally publishes
-      # when DOCKERHUB_USERNAME + DOCKERHUB_TOKEN secrets are configured, so a
-      # missing secret degrades to GHCR-only instead of failing the release.
       - name: Check Docker Hub credentials
         id: dockerhub
         if: steps.browse_cli.outputs.should_publish == 'true' && steps.browse_cli.outputs.already_published != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ permissions:
   contents: write
   pull-requests: write
   id-token: write
+  packages: write
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -145,6 +146,76 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag "$TAG"
           git push origin "$TAG"
+
+      # --- Publish the browse CLI as a Docker image, pinned to the npm version ---
+      # GHCR (ghcr.io/browserbase/browse) always publishes via the built-in
+      # GITHUB_TOKEN. Docker Hub (browserbase/browse) additionally publishes
+      # when DOCKERHUB_USERNAME + DOCKERHUB_TOKEN secrets are configured, so a
+      # missing secret degrades to GHCR-only instead of failing the release.
+      - name: Check Docker Hub credentials
+        id: dockerhub
+        if: steps.browse_cli.outputs.should_publish == 'true' && steps.browse_cli.outputs.already_published != 'true'
+        env:
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          if [ -n "$DOCKERHUB_TOKEN" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::DOCKERHUB_TOKEN not set — pushing browse image to GHCR only. Set DOCKERHUB_USERNAME + DOCKERHUB_TOKEN to also publish browserbase/browse on Docker Hub."
+          fi
+
+      - name: Set up QEMU
+        if: steps.browse_cli.outputs.should_publish == 'true' && steps.browse_cli.outputs.already_published != 'true'
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+
+      - name: Set up Docker Buildx
+        if: steps.browse_cli.outputs.should_publish == 'true' && steps.browse_cli.outputs.already_published != 'true'
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Log in to GitHub Container Registry
+        if: steps.browse_cli.outputs.should_publish == 'true' && steps.browse_cli.outputs.already_published != 'true'
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        if: steps.dockerhub.outputs.enabled == 'true'
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Compute browse image tags
+        id: image_tags
+        if: steps.browse_cli.outputs.should_publish == 'true' && steps.browse_cli.outputs.already_published != 'true'
+        run: |
+          V="${{ steps.browse_cli.outputs.version }}"
+          {
+            echo "tags<<EOF"
+            echo "ghcr.io/browserbase/browse:${V}"
+            echo "ghcr.io/browserbase/browse:latest"
+            if [ "${{ steps.dockerhub.outputs.enabled }}" = "true" ]; then
+              echo "browserbase/browse:${V}"
+              echo "browserbase/browse:latest"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and push browse image
+        if: steps.browse_cli.outputs.should_publish == 'true' && steps.browse_cli.outputs.already_published != 'true'
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: packages/cli
+          file: packages/cli/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          provenance: false
+          build-args: |
+            BROWSE_VERSION=${{ steps.browse_cli.outputs.version }}
+          tags: ${{ steps.image_tags.outputs.tags }}
 
       - name: Publish browse canary
         if: github.ref == 'refs/heads/main' && steps.browse_cli.outputs.should_publish != 'true'

--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -1,19 +1,10 @@
-# Minimal image that ships the `browse` CLI for use inside code sandboxes
-# (E2B, Modal, Daytona, Vercel, ...). No browser is bundled on purpose:
-# `browse` connects out to a Browserbase cloud browser over CDP, so the
-# image stays small and the sandbox stays a thin client.
-#
-# Published automatically by .github/workflows/release.yml on every browse
-# release, pinned 1:1 to the npm version:
-#   docker build --build-arg BROWSE_VERSION=<version> -t browserbase/browse .
-ARG NODE_VERSION=24
-FROM node:${NODE_VERSION}-slim
+# No browser is bundled: browse drives a remote Browserbase cloud browser over
+# CDP, so the image stays a thin client.
+FROM node:20-slim
 
-# Pin to the exact published version so the image matches the npm release.
 ARG BROWSE_VERSION
 RUN test -n "$BROWSE_VERSION" \
   && npm install -g "browse@${BROWSE_VERSION}" \
   && npm cache clean --force
 
-WORKDIR /work
 CMD ["browse", "--help"]

--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -1,0 +1,19 @@
+# Minimal image that ships the `browse` CLI for use inside code sandboxes
+# (E2B, Modal, Daytona, Vercel, ...). No browser is bundled on purpose:
+# `browse` connects out to a Browserbase cloud browser over CDP, so the
+# image stays small and the sandbox stays a thin client.
+#
+# Published automatically by .github/workflows/release.yml on every browse
+# release, pinned 1:1 to the npm version:
+#   docker build --build-arg BROWSE_VERSION=<version> -t browserbase/browse .
+ARG NODE_VERSION=24
+FROM node:${NODE_VERSION}-slim
+
+# Pin to the exact published version so the image matches the npm release.
+ARG BROWSE_VERSION
+RUN test -n "$BROWSE_VERSION" \
+  && npm install -g "browse@${BROWSE_VERSION}" \
+  && npm cache clean --force
+
+WORKDIR /work
+CMD ["browse", "--help"]


### PR DESCRIPTION
## What

Publish the `browse` CLI as a Docker image to **GHCR** on every release, pinned 1:1 to the npm version, so code sandboxes can consume it by image reference.

- **`ghcr.io/browserbase/browse:<version>` + `:latest`**, pushed via the built-in `GITHUB_TOKEN` (no new secrets).
- Multi-arch `linux/amd64,linux/arm64` (amd64 is required — sandbox runtimes are amd64).
- **No browser is bundled.** `browse` connects out to a Browserbase cloud browser over CDP, so the image stays a thin client (~481 MB on `node:20-slim`).

Docker Hub (`browserbase/browse`) is intentionally **out of scope here** — the `browserbase` Docker Hub namespace isn't ours yet, so shipping those steps would be dead code. It's tracked as a follow-up (see below).

## Why

Most sandbox providers (E2B, Modal, Daytona) have no public template registry — but they can all pull a public image by reference, so one published image makes `browse` consumable with no Dockerfile:

```dockerfile
# E2B / any OCI sandbox
FROM ghcr.io/browserbase/browse
```
```python
# Modal
image = modal.Image.from_registry("ghcr.io/browserbase/browse")
```
```bash
# Daytona
daytona snapshot create browse --image ghcr.io/browserbase/browse
```

## How it hooks in

Reuses the existing `Check if browse publish is needed` gate in `release.yml` (`should_publish` / `version` outputs) — the Docker steps run under the **same condition** as `Publish browse to npm`, right after the npm publish + tag. No new version-detection logic. Image version is pinned via `--build-arg BROWSE_VERSION=<version>`.

## Conventions

- `node:20-slim` to match the repo's node 20.x standard (engines `^20.19.0 || >=22.12.0`).
- Actions SHA-pinned with `# vX.Y.Z` comments, matching the repo's existing style.
- No `WORKDIR` / `ENTRYPOINT` — sandbox runtimes set their own working dir and exec their own commands.
- `Dockerfile` lives in `packages/cli/` but is excluded from the npm tarball by the package's `files` allowlist.

## Prerequisite (one-time, maintainer)

GHCR packages default to **private**. After the first release pushes the package, set `ghcr.io/browserbase/browse` visibility to **Public** in the org package settings so sandboxes can pull it anonymously. (Requires the release job's `packages: write` permission, added here.)

## Follow-up (not in this PR) — STG-2449

Publish `browse` to **Docker Hub** for the clean bare-name reference (`browserbase/browse`, which resolves to Docker Hub by default). Blocked on claiming the namespace: the `browserbase` name on Docker Hub is already taken by an org with no public repos and unknown owner. Options: recover it if it's an old Browserbase registration, dispute it via Docker support (trademark), or fall back to `browserbasehq`. Once the namespace + a `DOCKERHUB_*` token exist, adding Docker Hub tags is a small follow-up.

## E2E Test Matrix

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `docker buildx build --platform linux/amd64 --build-arg BROWSE_VERSION=0.9.1` | image built under QEMU; `browse --version` → `browse/0.9.1 linux-x64 node-v20.20.2`; ~481 MB | Proves the **mandatory sandbox arch (amd64)** builds and `browse` runs on `node:20-slim` |
| `docker build` (native arm64) | image built; `browse --version` → `browse/0.9.1 linux-arm64`; `browse --help` renders | Proves the second published arch builds and runs |
| `actionlint .github/workflows/release.yml` | exit 0, no findings | Workflow YAML + `${{ }}` expressions are valid and well-formed |

Not yet exercised (requires a real release run): the live GHCR push, the `should_publish` gate firing on a tagged release, and GHCR org-package first-push permission.

---
Linear: [STG-2449](https://linear.app/browserbase/issue/STG-2449/publish-browserbasebrowse-docker-image-on-browse-release)
