### PR TITLE
[STG-2450] feat(cli): browse snapshot lean by default, add --full for ref maps

### DIFF
--- a/.changeset/lean-browse-snapshot.md
+++ b/.changeset/lean-browse-snapshot.md
@@ -2,6 +2,4 @@
 "browse": patch
 ---
 
-`browse snapshot` is now lean by default: it prints the formatted accessibility tree only, omitting the `xpathMap`/`urlMap` ref maps (~217KB / ~60K tokens on a content-heavy page) that were previously included on every snapshot.
-
-Ref-based element commands (`click`, `fill`, `select`, etc.) are unaffected — the ref maps are still captured and cached server-side, so refs resolve exactly as before. To get the maps in the output, pass the new `--full` flag. The `--compact` flag is now a deprecated no-op alias of the default (it prints a stderr-only, TTY-gated deprecation notice).
+`browse snapshot` now prints the accessibility tree only by default, omitting the `xpathMap`/`urlMap` ref maps. Pass `--full` to include them. Ref-based element commands are unaffected.

--- a/.changeset/lean-browse-snapshot.md
+++ b/.changeset/lean-browse-snapshot.md
@@ -1,0 +1,7 @@
+---
+"browse": patch
+---
+
+`browse snapshot` is now lean by default: it prints the formatted accessibility tree only, omitting the `xpathMap`/`urlMap` ref maps (~217KB / ~60K tokens on a content-heavy page) that were previously included on every snapshot.
+
+Ref-based element commands (`click`, `fill`, `select`, etc.) are unaffected — the ref maps are still captured and cached server-side, so refs resolve exactly as before. To get the maps in the output, pass the new `--full` flag. The `--compact` flag is now a deprecated no-op alias of the default (it prints a stderr-only, TTY-gated deprecation notice).

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -33,7 +33,7 @@ npm install -g browse
 npm install -g browse
 
 browse open https://example.com
-browse snapshot --compact
+browse snapshot
 browse click @0-12
 browse fill @0-8 "hello"
 browse get title
@@ -89,8 +89,8 @@ browse forward        # Navigate forward
 The accessibility snapshot is the recommended way for agents to discover elements. It prints a tree of refs like `@0-12` that the element commands accept directly.
 
 ```bash
-browse snapshot                 # Accessibility snapshot + cached refs
-browse snapshot --compact       # Tree only, no ref maps
+browse snapshot                 # Accessibility tree + cached refs (lean by default)
+browse snapshot --full          # Also include the ref maps (xpathMap, urlMap)
 browse snapshot --filter submit # Filter lines by text or /regex/, keeping ancestors
 browse snapshot --max-depth 4   # Trim output deeper than this depth
 ```

--- a/packages/cli/skills/browse/SKILL.md
+++ b/packages/cli/skills/browse/SKILL.md
@@ -132,8 +132,8 @@ browse wait selector "#result"
 Page state:
 
 ```bash
-browse snapshot
-browse snapshot --compact
+browse snapshot                            # formatted tree only
+browse snapshot --full                     # also include ref maps (xpathMap, urlMap)
 browse get url
 browse get title
 browse get text body

--- a/packages/cli/src/commands/snapshot.ts
+++ b/packages/cli/src/commands/snapshot.ts
@@ -8,7 +8,7 @@ import {
 
 export default class Snapshot extends BrowseCommand {
   static override description =
-    "Print the active page accessibility snapshot and cache refs for element commands. Pass --full to also include the ref maps (xpathMap, urlMap), or run `browse refs` to print them.";
+    "Print the active page accessibility snapshot and cache refs for element commands. Pass --full to also include the ref maps (xpathMap, urlMap).";
 
   static override examples = [
     "browse snapshot",

--- a/packages/cli/src/commands/snapshot.ts
+++ b/packages/cli/src/commands/snapshot.ts
@@ -8,19 +8,24 @@ import {
 
 export default class Snapshot extends BrowseCommand {
   static override description =
-    "Print the active page accessibility snapshot and cache refs for element commands.";
+    "Print the active page accessibility snapshot and cache refs for element commands. Lean by default (formatted tree only); pass --full to also include the ref maps (xpathMap, urlMap). The ref maps are always cached for element commands regardless, and can be printed on demand with `browse refs`.";
 
   static override examples = [
     "browse snapshot",
-    "browse snapshot --compact",
+    "browse snapshot --full",
     "browse snapshot --filter submit",
     "browse snapshot --max-depth 4",
   ];
 
   static override flags = {
     ...driverCommandFlags,
+    full: Flags.boolean({
+      description:
+        "Include the ref maps (xpathMap, urlMap) in addition to the formatted tree. Restores the pre-lean default output.",
+    }),
     compact: Flags.boolean({
-      description: "Print only the formatted tree, without ref maps.",
+      description:
+        "Deprecated: snapshots are lean by default, so this flag has no effect. Use --full to include the ref maps.",
     }),
     filter: Flags.string({
       description:
@@ -35,10 +40,20 @@ export default class Snapshot extends BrowseCommand {
 
   async run(): Promise<void> {
     const { flags } = await this.parse(Snapshot);
+    // `--compact` is now the default. Keep accepting it as a no-op alias so
+    // existing callers don't break, but nudge interactive users toward --full.
+    // Warn on stderr only, gated on a TTY, so agents parsing stdout JSON (or
+    // capturing stderr) get no extra noise.
+    if (flags.compact && process.stderr.isTTY) {
+      this.warn(
+        "`--compact` is deprecated: `browse snapshot` is lean by default. Use `--full` to include the ref maps.",
+      );
+    }
     await runDriverCommandFromFlags(
       "snapshot",
       {
-        compact: flags.compact,
+        // Lean (no ref maps) unless --full is requested.
+        compact: !flags.full,
         filter: flags.filter,
         maxDepth: flags["max-depth"],
       },

--- a/packages/cli/src/commands/snapshot.ts
+++ b/packages/cli/src/commands/snapshot.ts
@@ -8,7 +8,7 @@ import {
 
 export default class Snapshot extends BrowseCommand {
   static override description =
-    "Print the active page accessibility snapshot and cache refs for element commands. Lean by default (formatted tree only); pass --full to also include the ref maps (xpathMap, urlMap). The ref maps are always cached for element commands regardless, and can be printed on demand with `browse refs`.";
+    "Print the active page accessibility snapshot and cache refs for element commands. Pass --full to also include the ref maps (xpathMap, urlMap), or run `browse refs` to print them.";
 
   static override examples = [
     "browse snapshot",
@@ -20,12 +20,11 @@ export default class Snapshot extends BrowseCommand {
   static override flags = {
     ...driverCommandFlags,
     full: Flags.boolean({
-      description:
-        "Include the ref maps (xpathMap, urlMap) in addition to the formatted tree. Restores the pre-lean default output.",
+      description: "Also include the ref maps (xpathMap, urlMap).",
     }),
     compact: Flags.boolean({
       description:
-        "Deprecated: snapshots are lean by default, so this flag has no effect. Use --full to include the ref maps.",
+        "Deprecated and has no effect; use --full to include the ref maps.",
     }),
     filter: Flags.string({
       description:
@@ -40,20 +39,15 @@ export default class Snapshot extends BrowseCommand {
 
   async run(): Promise<void> {
     const { flags } = await this.parse(Snapshot);
-    // `--compact` is now the default. Keep accepting it as a no-op alias so
-    // existing callers don't break, but nudge interactive users toward --full.
-    // Warn on stderr only, gated on a TTY, so agents parsing stdout JSON (or
-    // capturing stderr) get no extra noise.
     if (flags.compact && process.stderr.isTTY) {
       this.warn(
-        "`--compact` is deprecated: `browse snapshot` is lean by default. Use `--full` to include the ref maps.",
+        "`--compact` is deprecated and has no effect; use `--full` to include the ref maps.",
       );
     }
     await runDriverCommandFromFlags(
       "snapshot",
       {
-        // Lean (no ref maps) unless --full is requested.
-        compact: !flags.full,
+        full: flags.full,
         filter: flags.filter,
         maxDepth: flags["max-depth"],
       },

--- a/packages/cli/src/lib/driver/commands/snapshot.ts
+++ b/packages/cli/src/lib/driver/commands/snapshot.ts
@@ -5,9 +5,9 @@ import type { DriverCommandHandlers } from "./types.js";
 
 export const snapshotHandlers: DriverCommandHandlers = {
   async snapshot(manager, params) {
-    const { compact, filter, maxDepth } = z
+    const { full, filter, maxDepth } = z
       .object({
-        compact: z.boolean().optional(),
+        full: z.boolean().optional(),
         filter: z.string().optional(),
         maxDepth: z.number().int().nonnegative().optional(),
       })
@@ -20,18 +20,17 @@ export const snapshotHandlers: DriverCommandHandlers = {
     });
 
     const tree = formatSnapshotTree(snapshot.formattedTree, {
-      compact,
       filter,
       maxDepth,
     });
-    if (compact) {
-      return { tree };
+    if (full) {
+      return {
+        tree,
+        urlMap: snapshot.urlMap,
+        xpathMap: snapshot.xpathMap,
+      };
     }
 
-    return {
-      tree,
-      urlMap: snapshot.urlMap,
-      xpathMap: snapshot.xpathMap,
-    };
+    return { tree };
   },
 };

--- a/packages/cli/tests/driver-commands.test.ts
+++ b/packages/cli/tests/driver-commands.test.ts
@@ -353,17 +353,18 @@ describe("driver commands", () => {
     const lean = await snapshotHandlers.snapshot!(manager, {});
     expect(lean).not.toHaveProperty("xpathMap");
     expect(lean).not.toHaveProperty("urlMap");
+    expect(setRefMaps).toHaveBeenCalledTimes(1);
+    expect(setRefMaps).toHaveBeenLastCalledWith({
+      urlMap: snap.urlMap,
+      xpathMap: snap.xpathMap,
+    });
 
     const full = await snapshotHandlers.snapshot!(manager, { full: true });
     expect(full).toMatchObject({
       urlMap: snap.urlMap,
       xpathMap: snap.xpathMap,
     });
-
-    expect(setRefMaps).toHaveBeenCalledWith({
-      urlMap: snap.urlMap,
-      xpathMap: snap.xpathMap,
-    });
+    expect(setRefMaps).toHaveBeenCalledTimes(2);
   });
 
   it("exposes descriptive help for the new driver command surface", async () => {

--- a/packages/cli/tests/driver-commands.test.ts
+++ b/packages/cli/tests/driver-commands.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { resolveSelector } from "../src/lib/driver/commands/selectors.js";
 import { formatSnapshotTree } from "../src/lib/driver/commands/snapshot-format.js";
+import { snapshotHandlers } from "../src/lib/driver/commands/snapshot.js";
 import { runtimeHandlers } from "../src/lib/driver/commands/runtime.js";
 import { tabHandlers } from "../src/lib/driver/commands/tabs.js";
 import { DRIVER_COMMAND_NAMES } from "../src/lib/driver/commands/types.js";
@@ -333,6 +334,36 @@ describe("driver commands", () => {
         "    - button [0-2]: Submit order",
       ].join("\n"),
     );
+  });
+
+  it("omits ref maps by default and includes them with --full", async () => {
+    const snap = {
+      formattedTree: "[0-1] RootWebArea: Test\n  [0-2] button: Go",
+      urlMap: { "0-2": "https://example.com/go" },
+      xpathMap: { "0-1": "/", "0-2": "/button[1]" },
+    };
+    const setRefMaps = vi.fn();
+    const manager = {
+      activePage: async () => ({ snapshot: async () => snap }),
+      setRefMaps,
+    } as unknown as Parameters<
+      NonNullable<(typeof snapshotHandlers)["snapshot"]>
+    >[0];
+
+    const lean = await snapshotHandlers.snapshot!(manager, {});
+    expect(lean).not.toHaveProperty("xpathMap");
+    expect(lean).not.toHaveProperty("urlMap");
+
+    const full = await snapshotHandlers.snapshot!(manager, { full: true });
+    expect(full).toMatchObject({
+      urlMap: snap.urlMap,
+      xpathMap: snap.xpathMap,
+    });
+
+    expect(setRefMaps).toHaveBeenCalledWith({
+      urlMap: snap.urlMap,
+      xpathMap: snap.xpathMap,
+    });
   });
 
   it("exposes descriptive help for the new driver command surface", async () => {

--- a/packages/evals/core/tools/browse_cli.ts
+++ b/packages/evals/core/tools/browse_cli.ts
@@ -619,11 +619,15 @@ class BrowseCliPageHandle implements CorePageHandle {
   }
 
   async represent(): Promise<PageRepresentation> {
+    // A/B toggle for the lean-vs-full snapshot eval. `browse snapshot` is now
+    // lean by default (formatted tree only, no ref maps); set
+    // BROWSE_SNAPSHOT_FULL=1 to restore the pre-lean full output (tree + maps).
+    const full = process.env.BROWSE_SNAPSHOT_FULL === "1";
     const snapshot = await this.runCommandAfterSelecting<{
       tree: string;
       xpathMap?: Record<string, string>;
       urlMap?: Record<string, string>;
-    }>(["snapshot"]);
+    }>(full ? ["snapshot", "--full"] : ["snapshot"]);
     const content = snapshot.tree;
 
     return {
@@ -632,7 +636,11 @@ class BrowseCliPageHandle implements CorePageHandle {
       metadata: {
         bytes: Buffer.byteLength(content, "utf8"),
         tokenEstimate: Math.ceil(content.length / 4),
-        refCount: Object.keys(snapshot.xpathMap ?? {}).length,
+        // xpathMap is only present with --full; otherwise derive the count from
+        // the formatted tree so this metric stays mode-independent.
+        refCount: snapshot.xpathMap
+          ? Object.keys(snapshot.xpathMap).length
+          : (content.match(/\[\d+-\d+\]/g)?.length ?? 0),
       },
       raw: snapshot,
     };

--- a/packages/evals/core/tools/browse_cli.ts
+++ b/packages/evals/core/tools/browse_cli.ts
@@ -619,9 +619,7 @@ class BrowseCliPageHandle implements CorePageHandle {
   }
 
   async represent(): Promise<PageRepresentation> {
-    // A/B toggle for the lean-vs-full snapshot eval. `browse snapshot` is now
-    // lean by default (formatted tree only, no ref maps); set
-    // BROWSE_SNAPSHOT_FULL=1 to restore the pre-lean full output (tree + maps).
+    // BROWSE_SNAPSHOT_FULL=1 includes the ref maps in the snapshot.
     const full = process.env.BROWSE_SNAPSHOT_FULL === "1";
     const snapshot = await this.runCommandAfterSelecting<{
       tree: string;
@@ -636,8 +634,7 @@ class BrowseCliPageHandle implements CorePageHandle {
       metadata: {
         bytes: Buffer.byteLength(content, "utf8"),
         tokenEstimate: Math.ceil(content.length / 4),
-        // xpathMap is only present with --full; otherwise derive the count from
-        // the formatted tree so this metric stays mode-independent.
+        // Count refs from xpathMap when present, else from the tree.
         refCount: snapshot.xpathMap
           ? Object.keys(snapshot.xpathMap).length
           : (content.match(/\[\d+-\d+\]/g)?.length ?? 0),


### PR DESCRIPTION
## Summary

`browse snapshot` now prints the formatted accessibility tree only by default, omitting the `xpathMap`/`urlMap` ref maps that were previously included on **every** call.

- **`browse snapshot`** (default): formatted tree only (~14KB on a content-heavy page).
- **`browse snapshot --full`**: tree + `xpathMap` + `urlMap`.
- **`browse snapshot --compact`**: deprecated no-op alias of the default (prints a stderr-only, TTY-gated deprecation notice).
- **`browse refs`**: prints the cached maps on demand.

Ref-based element commands (`click`, `fill`, `select`, …) are **unaffected** — the maps are still captured and cached server-side, so refs resolve exactly as before.

## Why

The default snapshot emitted **~241KB (~60K tokens)** on a content-heavy page, of which **~217KB (90%) is the `xpathMap`** (a ref→XPath entry for every node) + `urlMap`. The tree an agent actually reasons over is only ~13.5KB.

Because refs resolve from a **server-side cache** (not from stdout), the printed maps were dead weight in the context of any agent consuming `browse snapshot` output. Making the tree lean by default cuts the default payload ~17× with no loss to element interaction; `--full` and `browse refs` recover the maps when needed.

## E2E Test Matrix

### Behavior + size (local build, live session on capeair.com)

Verified against `packages/cli/bin/run.js` (the local build), not the published `browse`.

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `browse snapshot` (default) | `13,845` bytes, keys = `tree` only, `hasMaps=false` | Lean default; ~17× smaller than before |
| `browse snapshot --full` | `241,104` bytes, keys = `tree,urlMap,xpathMap` (1,640 entries) | `--full` returns the full tree + maps |
| `browse snapshot --compact` (piped) | `13,868` bytes, `hasMaps=false`, **0 bytes stderr** | Deprecated alias == default; no noise on non-TTY |
| `browse refs` | `count=1640` | Maps still captured + retrievable on demand |
| `browse click @0-1588` after a **lean** snapshot | `{"clicked": true}` → navigated to `/about_us/` | Ref interaction unaffected by dropping maps from stdout |
| default tree vs `--full` tree | identical (341 lines both) | Lean mode omits **only** the maps; it does not prune tree content |
| `pnpm --dir packages/cli build` (`tsc`) + evals `tsc --noEmit` | success / clean | Typechecks |
| `driver-commands` unit test | 15/15 pass | Locks in: default omits maps, `--full` includes them, maps cached in both modes |

### Agent task-success A/B (lean vs full)

Controlled A/B — same task / model (Sonnet) / session per pair; **the only variable is snapshot mode** (`--full` = maps vs default = lean), against the local build.

| Task | Arm | Outcome | Snapshots | Agent tokens |
| --- | --- | --- | --- | --- |
| capeair (regional booking) | full (maps) | ✅ SUCCESS | 9 | 109.8K |
| capeair | **lean** | ✅ SUCCESS | 8 | 93.5K |
| Google Flights | full (maps) | ✅ SUCCESS | 15 | 85.3K |
| Google Flights | **lean** | ✅ SUCCESS | 15 | 86.4K |

**4/4 success — lean-by-default held task success with zero capability loss.** (A standard-benchmark A/B via the evals package is in progress and will be added here.)

## What's in the diff

- `packages/cli/src/commands/snapshot.ts` — lean default (`compact` decoupled from map omission); add `--full`; deprecate `--compact`.
- `packages/cli/src/lib/driver/commands/snapshot.ts` — driver handler emits the full tree and includes ref maps only when `full` is requested.
- `packages/cli/skills/browse/SKILL.md` — document lean default + `--full`.
- `packages/cli/tests/driver-commands.test.ts` — test the default/`--full`/caching behavior.
- `packages/evals/core/tools/browse_cli.ts` — derive `refCount` from the tree when maps are absent.
- `.changeset/lean-browse-snapshot.md` — `browse` patch.

Linear: [STG-2450](https://linear.app/browserbase/issue/STG-2450)
