### PR TITLE
fix(core): press CUA keypress combinations as a single chord (#2266)

### DIFF
--- a/.changeset/fix-cua-keypress-chord.md
+++ b/.changeset/fix-cua-keypress-chord.md
@@ -2,4 +2,4 @@
 "@browserbasehq/stagehand": patch
 ---
 
-Fix CUA `keypress` actions to press key combinations as a single chord. Previously each key in the array was pressed separately, releasing modifiers before the main key — so combinations like `["Control", "A"]` sent Ctrl on its own and then typed a literal `a` instead of select-all. This affected the OpenAI, Google (`key_combination`), and Microsoft computer-use clients, which emit multi-element key arrays; Anthropic (which sends a single `+`-joined string) was unaffected.
+Fix CUA `keypress` actions to press key combinations as a single chord.

--- a/.changeset/fix-cua-keypress-chord.md
+++ b/.changeset/fix-cua-keypress-chord.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Fix CUA `keypress` actions to press key combinations as a single chord. Previously each key in the array was pressed separately, releasing modifiers before the main key — so combinations like `["Control", "A"]` sent Ctrl on its own and then typed a literal `a` instead of select-all. This affected the OpenAI, Google (`key_combination`), and Microsoft computer-use clients, which emit multi-element key arrays; Anthropic (which sends a single `+`-joined string) was unaffected.

--- a/packages/core/lib/v3/handlers/v3CuaAgentHandler.ts
+++ b/packages/core/lib/v3/handlers/v3CuaAgentHandler.ts
@@ -452,28 +452,32 @@ export class V3CuaAgentHandler {
       case "keypress": {
         const { keys } = action;
         const keyList = Array.isArray(keys) ? keys : [keys];
-        const stagehandActions: Action[] = [];
-        for (const rawKey of keyList) {
-          const mapped = mapKeyToPlaywright(String(rawKey ?? ""));
+        if (keyList.length > 0) {
+          // CUA "keypress" actions describe a single key *chord* (modifiers held
+          // down for the main key), not a sequence of independent presses.
+          // Pressing each key separately released modifiers before the main key,
+          // so combinations like ["Control", "A"] sent Ctrl on its own and then
+          // typed a literal "a" instead of select-all. Join into one
+          // "+"-delimited combination so page.keyPress holds the modifiers down.
+          // page.keyPress already handles the literal "+" key correctly.
+          const mapped = keyList
+            .map((rawKey) => mapKeyToPlaywright(String(rawKey ?? "")))
+            .join("+");
           await page.keyPress(mapped);
           if (recording) {
-            stagehandActions.push({
-              selector: "xpath=/html",
-              description: `press ${mapped}`,
-              method: "press",
-              arguments: [mapped],
-            });
+            this.recordCuaActStep(
+              action,
+              [
+                {
+                  selector: "xpath=/html",
+                  description: `press ${mapped}`,
+                  method: "press",
+                  arguments: [mapped],
+                },
+              ],
+              `press ${mapped}`,
+            );
           }
-        }
-        if (recording && stagehandActions.length > 0) {
-          this.recordCuaActStep(
-            action,
-            stagehandActions,
-            stagehandActions
-              .map((a) => a.description)
-              .filter(Boolean)
-              .join(", ") || "keypress",
-          );
         }
         return { success: true };
       }

--- a/packages/core/tests/unit/cua-keypress-chord.test.ts
+++ b/packages/core/tests/unit/cua-keypress-chord.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { V3CuaAgentHandler } from "../../lib/v3/handlers/v3CuaAgentHandler.js";
+import type { V3 } from "../../lib/v3/v3.js";
+import type { AgentAction } from "../../lib/v3/types/public/agent.js";
+
+/**
+ * Regression coverage for CUA "keypress" chord handling.
+ *
+ * A keypress action describes a single key combination (modifiers held down for
+ * the main key). The handler used to press each key in the array separately,
+ * which released modifiers early — so ["Control", "A"] sent Ctrl alone and then
+ * typed a literal "a" instead of select-all. This broke Google's
+ * `key_combination`, OpenAI's `keypress`, and Microsoft's `keypress` (all of
+ * which emit a multi-element keys array), while Anthropic (single "+"-joined
+ * string) happened to work.
+ */
+describe("V3CuaAgentHandler keypress chord handling", () => {
+  let handler: V3CuaAgentHandler;
+  let keyPress: ReturnType<typeof vi.fn>;
+
+  // executeAction is private; expose it through a typed accessor for the test.
+  const execute = (action: AgentAction) =>
+    (
+      handler as unknown as {
+        executeAction: (a: AgentAction) => Promise<unknown>;
+      }
+    ).executeAction(action);
+
+  beforeEach(() => {
+    keyPress = vi.fn().mockResolvedValue(undefined);
+    const mockPage = {
+      keyPress,
+      url: () => "https://example.com",
+    };
+    const mockV3 = {
+      context: {
+        awaitActivePage: vi.fn().mockResolvedValue(mockPage),
+      },
+      isAgentReplayActive: () => false,
+    } as unknown as V3;
+
+    handler = new V3CuaAgentHandler(mockV3, vi.fn(), {
+      modelName: "claude-sonnet-4-5-20250929",
+      clientOptions: { apiKey: "test-key" },
+    });
+  });
+
+  it("presses a multi-key combination as a single chord", async () => {
+    await execute({ type: "keypress", keys: ["Control", "A"] } as AgentAction);
+
+    expect(keyPress).toHaveBeenCalledTimes(1);
+    expect(keyPress).toHaveBeenCalledWith("Control+A");
+  });
+
+  it("normalizes provider key aliases before chording (CTRL -> Control)", async () => {
+    await execute({ type: "keypress", keys: ["CTRL", "A"] } as AgentAction);
+
+    expect(keyPress).toHaveBeenCalledTimes(1);
+    expect(keyPress).toHaveBeenCalledWith("Control+A");
+  });
+
+  it("still presses a single key correctly", async () => {
+    await execute({ type: "keypress", keys: ["Enter"] } as AgentAction);
+
+    expect(keyPress).toHaveBeenCalledTimes(1);
+    expect(keyPress).toHaveBeenCalledWith("Enter");
+  });
+
+  it("preserves an already-combined key string (Anthropic shape)", async () => {
+    await execute({ type: "keypress", keys: ["ctrl+s"] } as AgentAction);
+
+    expect(keyPress).toHaveBeenCalledTimes(1);
+    expect(keyPress).toHaveBeenCalledWith("ctrl+s");
+  });
+
+  it("does not press anything for an empty keys array", async () => {
+    await execute({ type: "keypress", keys: [] } as AgentAction);
+
+    expect(keyPress).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
thanks @yawbtng for the contribution here!!

## why

CUA `keypress` actions describe a single key **chord** (modifiers held down while the main key is pressed), but
`V3CuaAgentHandler.executeAction` pressed each key in the array **separately**. `page.keyPress(modifier)` presses and *releases* the modifier, so by the time the main key was pressed the modifier was already up.

The concrete failure: a `["Control", "A"]` keypress sends `Control` on its own (a no-op) and then `A` through the plain typing path — so instead of select-all, the agent **types a literal `a` into the focused field**. Any select-all / copy / paste / cut / shortcut pattern silently fails *and* corrupts input. Because the agent-replay cache recorded the broken per-key sequence, replays reproduced the bug too.

This is provider-dependent, based on the shape each client emits:

| Provider | emits for a combo | old behavior | status | | --- | --- | --- | --- |
| OpenAI | `keys: ["CTRL", "A"]` | `Ctrl` then literal `a` | ❌ broken | | Google (`key_combination`) | `.split("+")` → `["Control", "A"]` | `Ctrl` then literal `a` | ❌ broken |
| Microsoft (`fara-7b`) | `keys: string[]` (per-key) | `Ctrl` then literal `a` | ❌ broken |
| Anthropic | `keys: ["ctrl+s"]` (single `+`-joined string) | chorded correctly | ✅ unaffected |

Anthropic only worked by accident — it pre-joins with `+`, which `page.keyPress` already chords internally.

## what changed

`packages/core/lib/v3/handlers/v3CuaAgentHandler.ts` — in the `keypress` case, map each key and **join into one `+`-delimited combination**, then call `page.keyPress` once. `page.keyPress` already holds modifiers down for the final key and already special-cases the literal `+` key, so single keys, already-combined strings, and `Ctrl++`-style inputs all stay correct. `mapKeyToPlaywright` is idempotent (`CTRL`/`Control` → `Control`), so Google's pre-mapped arrays and Anthropic's combined string are unchanged. The recorded replay step is now a single `press Control+A` instead of the broken `press Control, press A`.

## test plan

New `packages/core/tests/unit/cua-keypress-chord.test.ts` (5 cases, all passing):
- `["Control", "A"]` → single `keyPress("Control+A")`
- alias normalization: `["CTRL", "A"]` → `keyPress("Control+A")`
- single key `["Enter"]` → `keyPress("Enter")` (unchanged)
- already-combined `["ctrl+s"]` → `keyPress("ctrl+s")` (Anthropic shape, unchanged)
- empty `[]` → no `keyPress` call

Existing CUA suites (`anthropic-cua-triple-click`, `openai-cua-client`, `microsoft-cua-client`, `anthropic-cua-adaptive-thinking`) — 25 tests still green.

---

Related: this is exactly the class of provider-specific CUA regression that #2188 proposes catching with a deterministic bench task.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CUA keypress combos by pressing them as one chord. Shortcuts like Ctrl+A now work across OpenAI, Google `key_combination`, and Microsoft clients instead of typing letters.

- **Bug Fixes**
  - Map keys, join with "+", and call `page.keyPress` once; supports arrays, already-joined strings, and the literal "+" key.
  - Normalize aliases (`CTRL` → `Control`) and record a single `press Control+A` step for replays.
  - Added unit tests for combos, alias normalization, single key, already-combined, and empty input.

<sup>Written for commit c966475d9605fb962be252f74c8f7749bef8cd57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


