### PR TITLE
[STG-2457] fix(evals): update browse eval harness to CLI v0.9.1 contract

### DIFF
--- a/packages/evals/core/tools/browse_cli.ts
+++ b/packages/evals/core/tools/browse_cli.ts
@@ -106,30 +106,18 @@ type BrowseCliPagesResult = {
   }>;
 };
 
-// The mode flag selects the environment when the daemon is first started and
-// must be explicit so a set BROWSERBASE_API_KEY does not silently auto-select
-// remote. It is only accepted by the driver commands, so it is skipped for the
-// subcommands that reject it. The session name is safe on every command.
-const BROWSE_MODELESS_COMMANDS = new Set(["stop", "status"]);
-
 class BrowseCliRuntime {
-  constructor(
-    private readonly session: string,
-    private readonly modeFlag: "--local" | "--remote",
-  ) {}
+  constructor(private readonly session: string) {}
 
   async runJson<T>(args: string[]): Promise<T> {
-    const modeArgs = BROWSE_MODELESS_COMMANDS.has(args[0])
-      ? []
-      : [this.modeFlag];
     const { stdout, stderr } = await execFileAsync(
       process.execPath,
       [
         resolveBrowseCliEntrypoint(),
-        ...args,
-        ...modeArgs,
+        "--json",
         "--session",
         this.session,
+        ...args,
       ],
       {
         cwd: getRepoRootDir(),
@@ -662,11 +650,8 @@ class BrowseCliSession implements CoreSession {
   private activePageId: string | null = null;
   private closed = false;
 
-  constructor(
-    private readonly sessionName: string,
-    modeFlag: "--local" | "--remote",
-  ) {
-    this.runtime = new BrowseCliRuntime(sessionName, modeFlag);
+  constructor(private readonly sessionName: string) {
+    this.runtime = new BrowseCliRuntime(sessionName);
   }
 
   private wrap(page: { targetId: string; url: string }): BrowseCliPageHandle {
@@ -843,10 +828,11 @@ export class BrowseCliTool implements CoreTool {
       );
     }
 
-    const session = new BrowseCliSession(
-      createSessionName(),
-      input.environment === "BROWSERBASE" ? "--remote" : "--local",
-    );
+    const session = new BrowseCliSession(createSessionName());
+    await session.runtime.runJson([
+      "env",
+      input.environment === "BROWSERBASE" ? "remote" : "local",
+    ]);
 
     return {
       session,

--- a/packages/evals/core/tools/browse_cli.ts
+++ b/packages/evals/core/tools/browse_cli.ts
@@ -106,18 +106,30 @@ type BrowseCliPagesResult = {
   }>;
 };
 
+// The mode flag selects the environment when the daemon is first started and
+// must be explicit so a set BROWSERBASE_API_KEY does not silently auto-select
+// remote. It is only accepted by the driver commands, so it is skipped for the
+// subcommands that reject it. The session name is safe on every command.
+const BROWSE_MODELESS_COMMANDS = new Set(["stop", "status"]);
+
 class BrowseCliRuntime {
-  constructor(private readonly session: string) {}
+  constructor(
+    private readonly session: string,
+    private readonly modeFlag: "--local" | "--remote",
+  ) {}
 
   async runJson<T>(args: string[]): Promise<T> {
+    const modeArgs = BROWSE_MODELESS_COMMANDS.has(args[0])
+      ? []
+      : [this.modeFlag];
     const { stdout, stderr } = await execFileAsync(
       process.execPath,
       [
         resolveBrowseCliEntrypoint(),
-        "--json",
+        ...args,
+        ...modeArgs,
         "--session",
         this.session,
-        ...args,
       ],
       {
         cwd: getRepoRootDir(),
@@ -650,8 +662,11 @@ class BrowseCliSession implements CoreSession {
   private activePageId: string | null = null;
   private closed = false;
 
-  constructor(private readonly sessionName: string) {
-    this.runtime = new BrowseCliRuntime(sessionName);
+  constructor(
+    private readonly sessionName: string,
+    modeFlag: "--local" | "--remote",
+  ) {
+    this.runtime = new BrowseCliRuntime(sessionName, modeFlag);
   }
 
   private wrap(page: { targetId: string; url: string }): BrowseCliPageHandle {
@@ -828,11 +843,10 @@ export class BrowseCliTool implements CoreTool {
       );
     }
 
-    const session = new BrowseCliSession(createSessionName());
-    await session.runtime.runJson([
-      "env",
-      input.environment === "BROWSERBASE" ? "remote" : "local",
-    ]);
+    const session = new BrowseCliSession(
+      createSessionName(),
+      input.environment === "BROWSERBASE" ? "--remote" : "--local",
+    );
 
     return {
       session,

--- a/packages/evals/framework/claudeCodeToolAdapter.ts
+++ b/packages/evals/framework/claudeCodeToolAdapter.ts
@@ -326,18 +326,27 @@ export async function prepareBrowseCliHarnessAdapter(
     PATH: `${cwd}${path.delimiter}${process.env.PATH ?? ""}`,
   } as Record<string, string>;
 
+  const modeFlag = input.environment === "BROWSERBASE" ? "--remote" : "--local";
   await fsp.writeFile(
     wrapperPath,
     [
       "#!/usr/bin/env bash",
       "set -euo pipefail",
-      `exec ${JSON.stringify(process.execPath)} ${JSON.stringify(BROWSE_CLI_ENTRYPOINT)} --json --session ${JSON.stringify(session)} "$@"`,
+      // The mode flag (--local/--remote) selects the environment when the daemon
+      // is first started and must be explicit so a set BROWSERBASE_API_KEY does
+      // not silently auto-select remote. It is only accepted by the driver
+      // commands, so skip it for the few subcommands that reject it (stop,
+      // status). The session name is safe on every command.
+      "cmd=${1:-}",
+      "mode=()",
+      'if [[ "$cmd" != "stop" && "$cmd" != "status" ]]; then',
+      `  mode=(${JSON.stringify(modeFlag)})`,
+      "fi",
+      `exec ${JSON.stringify(process.execPath)} ${JSON.stringify(BROWSE_CLI_ENTRYPOINT)} "$@" "\${mode[@]+\${mode[@]}}" --session ${JSON.stringify(session)}`,
       "",
     ].join("\n"),
     { mode: 0o755 },
   );
-
-  await runBrowseSetup(wrapperPath, input.environment, input.logger, env, cwd);
 
   return {
     toolSurface: "browse_cli",
@@ -1068,22 +1077,6 @@ function buildCdpCodePromptInstructions(plan: ExternalHarnessTaskPlan): string {
     "Do not edit repository files.",
     "Return useful JSON-serializable values from run snippets so you can inspect progress.",
   ].join("\n");
-}
-
-async function runBrowseSetup(
-  wrapperPath: string,
-  environment: "LOCAL" | "BROWSERBASE",
-  logger: EvalLogger,
-  env: Record<string, string>,
-  cwd: string,
-): Promise<void> {
-  await runBrowseCommand(
-    wrapperPath,
-    ["env", environment === "BROWSERBASE" ? "remote" : "local"],
-    logger,
-    env,
-    cwd,
-  );
 }
 
 function buildBrowseCliPromptInstructions(


### PR DESCRIPTION
## Summary

> **Scope note (2026-07-06):** this PR has been slimmed down to **only the browse CLI contract fix**. The V3Evaluator verifier wiring that previously lived here is superseded by #2138, which consolidates verifier grading for both the `claude_code` and `codex` harnesses (shared `verifierAdapter` helpers + Braintrust spans). The two PRs are independent and merge-order agnostic: this one fixes whether the agent can drive the browser at all; #2138 fixes how finished runs are graded.

> **Scope note (2026-07-07):** per [Miguel's review](https://github.com/browserbase/stagehand/pull/2299#discussion_r3539933777), this PR is now scoped to the `bench` path only (`claudeCodeToolAdapter.ts`, shared by the `claude_code`/`codex` external harnesses). The `core/tools/browse_cli.ts` change is reverted — that file is a separate, independently-hardcoded consumer of the browse CLI used only by the deterministic `core` tool-vs-tool comparison suite, and its contract drift runs deeper than this PR's scope (`newpage` vs `tab new`, `click_xy` vs `mouse click`, `-t`/`-s` vs `--timeout`/`--state`, etc.). That gets a full sweep in a separate follow-up PR rather than a partial fix here.

### Contract fix — browse CLI v0.9.1 (bench harnesses)

The harness drove browse with a stale contract (`browse --json … env local`). browse CLI **v0.9.1 dropped the `env` subcommand and the global `--json` flag**, so every browse invocation in the harness was broken. Fixed to:

- Per-command mode selection: `--local` / `--remote` instead of the removed `env` subcommand.
- `--session <name>` on every command to pin the eval's daemon.
- Rely on the CLI's JSON-by-default output (no `--json`).
- The mode flag is only appended to commands that accept it (skipped for `stop` / `status`) and is **explicit** so a set `BROWSERBASE_API_KEY` cannot silently auto-select remote when we asked for local.
- `runBrowseSetup` (which ran `browse env …` at adapter-prepare time) is deleted — the daemon now starts lazily on the first driver command, so adapter preparation no longer launches a browser at all.

Because `codexToolAdapter` delegates to the same `prepareBrowseCliHarnessAdapter`, the fix propagates to **both** external harnesses.

Files: `packages/evals/framework/claudeCodeToolAdapter.ts`.

No changeset: `@browserbasehq/stagehand-evals` is `private: true` (never published), so it does not trigger a release.

## E2E Test Matrix

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `pnpm --dir packages/evals build` + `typecheck` | build `Done` (esm + cli), `tsc --noEmit` exit 0 | Proves the changed file compiles and typechecks against current core. |
| `pnpm --dir packages/evals test:unit` (`vitest run`) | **345 passed** across 46 test files, 0 failed | Full unit suite green on this branch, including after the `core/tools/browse_cli.ts` revert. |
| Adapter E2E smoke — real `prepareBrowseCliHarnessAdapter` (LOCAL) against `<local build>` of `packages/cli`, driving its generated wrapper script | `open https://example.com` → JSON `{"mode":"managed-local","pages":[…"url":"https://example.com/"…]}`; `snapshot` → parsed JSON `tree`; `status` (modeless) → JSON OK; `cleanup()` → `{"stopped":true}` on the pinned session | Proves the exact wrapper the agent receives works end-to-end on the current CLI contract: explicit `--local`, pinned `--session`, JSON-by-default, and the modeless skip for `stop`/`status`. |
| Negative control — `browse status --local` invoked directly against `<local build>` | `Error: Nonexistent flag: --local` (non-zero exit) | Proves the wrapper's modeless skip is load-bearing: passing the mode flag to `status`/`stop` would hard-fail. |
| Compatibility with #2138 — throwaway local merge of `miguelgonzalez/verifier-10-benchmark-instrumentation` into this branch | Merge clean (**0 conflicts** — the PRs share no files), `typecheck` exit 0, `vitest` **355 passed** across 48 files (including #2138's new suites) | Proves the two PRs land independently, in either order, with no interaction. |

## Linear

STG-2457 — https://linear.app/browserbase/issue/STG-2457/repair-claude-code-browse-eval-harness-rubric-score-via-v3evaluator

Follow-up (full `core/tools/browse_cli.ts` contract sweep) to be filed as a separate ticket/PR per Miguel's review.
