### PR TITLE
test(cli): cover browse screenshot default-path reservation and cleanup

### DIFF
--- a/packages/cli/src/commands/screenshot.ts
+++ b/packages/cli/src/commands/screenshot.ts
@@ -94,7 +94,7 @@ const MAX_RESERVE_ATTEMPTS = 1000;
  * driver should return base64 (explicit --path is handled separately; --base64
  * opts out of a file entirely).
  */
-function getDefaultPathFromFlags(flags: {
+export function getDefaultPathFromFlags(flags: {
   path?: string;
   base64?: boolean;
   type?: string;
@@ -110,7 +110,7 @@ function getDefaultPathFromFlags(flags: {
  * the name already exists, so two concurrent runs can never claim the same
  * file. On EEXIST we advance the counter and try the next name.
  */
-function reserveDefaultScreenshotPath(type: string | undefined): string {
+export function reserveDefaultScreenshotPath(type: string | undefined): string {
   const now = new Date();
   const pad = (value: number) => String(value).padStart(2, "0");
   const stamp =
@@ -137,7 +137,7 @@ function reserveDefaultScreenshotPath(type: string | undefined): string {
 // Removes the reserved placeholder when the screenshot failed before the driver
 // wrote to it. `path` is always a file we created via openSync above, so the
 // isFile guard is just defensive against an unexpected directory/symlink.
-function removeIfEmpty(path: string): void {
+export function removeIfEmpty(path: string): void {
   try {
     const stats = statSync(path);
     if (stats.isFile() && stats.size === 0) unlinkSync(path);

--- a/packages/cli/tests/screenshot-default-path.test.ts
+++ b/packages/cli/tests/screenshot-default-path.test.ts
@@ -1,0 +1,98 @@
+import {
+  closeSync,
+  existsSync,
+  mkdtempSync,
+  openSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getDefaultPathFromFlags,
+  removeIfEmpty,
+  reserveDefaultScreenshotPath,
+} from "../src/commands/screenshot.js";
+
+/**
+ * Coverage for the default screenshot path behavior added in #2246 (browse
+ * screenshot now writes a file by default with a collision counter, cleaning up
+ * the reserved placeholder on failure). The command shipped without tests.
+ */
+describe("browse screenshot default-path handling", () => {
+  let tmp: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    tmp = mkdtempSync(join(tmpdir(), "browse-screenshot-"));
+    process.chdir(tmp);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    process.chdir(originalCwd);
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  describe("getDefaultPathFromFlags", () => {
+    it("returns undefined when --path is set (driver writes the explicit file)", () => {
+      expect(getDefaultPathFromFlags({ path: "out.png" })).toBeUndefined();
+    });
+
+    it("returns undefined when --base64 is set (nothing written to disk)", () => {
+      expect(getDefaultPathFromFlags({ base64: true })).toBeUndefined();
+    });
+
+    it("reserves a default .png path for a bare invocation", () => {
+      const reserved = getDefaultPathFromFlags({});
+      expect(reserved).toMatch(/screenshot-\d{8}-\d{6}\.png$/);
+      // The path is reserved by creating an empty placeholder.
+      expect(existsSync(reserved as string)).toBe(true);
+    });
+
+    it("uses the .jpeg extension when --type jpeg", () => {
+      const reserved = getDefaultPathFromFlags({ type: "jpeg" });
+      expect(reserved).toMatch(/screenshot-\d{8}-\d{6}\.jpeg$/);
+    });
+  });
+
+  describe("reserveDefaultScreenshotPath", () => {
+    it("advances the collision counter instead of overwriting an existing file", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2026, 6, 1, 15, 30, 45)); // 2026-07-01 15:30:45 local
+
+      const first = reserveDefaultScreenshotPath(undefined);
+      const second = reserveDefaultScreenshotPath(undefined);
+
+      expect(first).toMatch(/screenshot-20260701-153045\.png$/);
+      expect(second).toMatch(/screenshot-20260701-153045-2\.png$/);
+      expect(first).not.toBe(second);
+      expect(existsSync(first)).toBe(true);
+      expect(existsSync(second)).toBe(true);
+    });
+  });
+
+  describe("removeIfEmpty", () => {
+    it("removes a zero-byte placeholder left by a failed capture", () => {
+      const path = join(tmp, "placeholder.png");
+      closeSync(openSync(path, "w")); // 0 bytes
+      removeIfEmpty(path);
+      expect(existsSync(path)).toBe(false);
+    });
+
+    it("keeps a file that already has bytes (a real screenshot)", () => {
+      const path = join(tmp, "real.png");
+      writeFileSync(path, "not empty");
+      removeIfEmpty(path);
+      expect(existsSync(path)).toBe(true);
+    });
+
+    it("does not throw when the path is already gone", () => {
+      expect(() => removeIfEmpty(join(tmp, "missing.png"))).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## why

`browse screenshot`'s default-path behavior (added in #2246 — write a file by default, advance a collision counter instead of overwriting, clean up the reserved placeholder if capture fails) shipped without any tests. `driver-commands.test.ts` only asserts the command name is registered.

## what changed

Adds `tests/screenshot-default-path.test.ts` covering the three helpers in `src/commands/screenshot.ts`:

- **`getDefaultPathFromFlags`** — `--path` and `--base64` both opt out of a reserved default; a bare invocation reserves a `.png` (and `.jpeg` with `--type jpeg`).
- **`reserveDefaultScreenshotPath`** — advances the `-N` collision counter instead of overwriting an existing file (fake-timer-pinned timestamp so the collision is deterministic).
- **`removeIfEmpty`** — deletes the zero-byte placeholder from a failed capture, keeps a file that already has bytes, and no-ops when the path is already gone.

Test-only, plus a one-line `export` on each of the three helpers so they can be unit-tested directly. This matches the existing convention of importing pure driver functions from `src/` in tests (e.g. `driver-commands.test.ts` imports `resolveSelector`, `formatSnapshotTree`, `runtimeHandlers`). Happy to relocate the helpers into `src/lib/` instead if you'd prefer them out of the command file.

## testing

`vitest run tests/screenshot-default-path.test.ts` → 8 passing. Adjacent suites (`driver-commands`, `cli-surface`) still green; `tsc -p tsconfig.json` clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests for the `browse screenshot` default-path behavior: reserve a file by default, increment `-N` on collisions, and clean up empty placeholders on failure. Exported helpers to allow direct unit testing.

- **Refactors**
  - Exported `getDefaultPathFromFlags`, `reserveDefaultScreenshotPath`, and `removeIfEmpty` from `src/commands/screenshot.ts` for testability.

<sup>Written for commit 304218814fe3450b4519468088f7b88a06557d55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

