### PR TITLE
fix(agent): enable prompt caching for the Anthropic CUA system prompt

### DIFF
--- a/packages/core/lib/v3/agent/AnthropicCUAClient.ts
+++ b/packages/core/lib/v3/agent/AnthropicCUAClient.ts
@@ -554,9 +554,16 @@ export class AnthropicCUAClient extends AgentClient {
         ];
       }
 
-      // Add system parameter if provided
+      // Add system parameter if provided, with cache control so the
+      // tools + system prefix is cached across agent steps
       if (this.userProvidedInstructions) {
-        requestParams.system = this.userProvidedInstructions;
+        requestParams.system = [
+          {
+            type: "text",
+            text: this.userProvidedInstructions,
+            cache_control: { type: "ephemeral" },
+          },
+        ];
       }
 
       // Add thinking parameter if available

--- a/packages/core/tests/unit/anthropic-cua-system-prompt-caching.test.ts
+++ b/packages/core/tests/unit/anthropic-cua-system-prompt-caching.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { AnthropicCUAClient } from "../../lib/v3/agent/AnthropicCUAClient.js";
+import Anthropic from "@anthropic-ai/sdk";
+
+// Mock the Anthropic SDK's beta.messages.create method
+vi.mock("@anthropic-ai/sdk", () => {
+  const mockCreate = vi.fn().mockResolvedValue({
+    id: "test-id",
+    content: [{ type: "text", text: "test response" }],
+    usage: { input_tokens: 10, output_tokens: 20 },
+  });
+
+  return {
+    default: class MockAnthropic {
+      beta = {
+        messages: {
+          create: mockCreate,
+        },
+      };
+    },
+  };
+});
+
+describe("AnthropicCUAClient system prompt caching", () => {
+  let mockCreate: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Get the mock create function from a new instance
+    const anthropic = new Anthropic({ apiKey: "test" });
+    mockCreate = anthropic.beta.messages.create as ReturnType<typeof vi.fn>;
+    mockCreate.mockResolvedValue({
+      id: "test-id",
+      content: [{ type: "text", text: "test response" }],
+      usage: { input_tokens: 10, output_tokens: 20 },
+    });
+  });
+
+  it("should send the system prompt as a content block array with cache_control", async () => {
+    const instructions = "You are a helpful browser automation assistant.";
+    const client = new AnthropicCUAClient(
+      "anthropic",
+      "claude-opus-4-6",
+      instructions,
+      {
+        apiKey: "test-key",
+      },
+    );
+    client.setViewport(1280, 720);
+
+    await client.getAction([{ role: "user", content: "test" }]);
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        system: [
+          {
+            type: "text",
+            text: instructions,
+            cache_control: { type: "ephemeral" },
+          },
+        ],
+      }),
+    );
+  });
+
+  it("should not set the system parameter when no instructions are provided", async () => {
+    const client = new AnthropicCUAClient(
+      "anthropic",
+      "claude-opus-4-6",
+      undefined,
+      {
+        apiKey: "test-key",
+      },
+    );
+    client.setViewport(1280, 720);
+
+    await client.getAction([{ role: "user", content: "test" }]);
+
+    const callArgs = mockCreate.mock.calls[0][0];
+    expect(callArgs.system).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Why

In `AnthropicCUAClient.getAction()`, the system prompt was sent as a plain string:

```ts
requestParams.system = this.userProvidedInstructions;
```

A CUA agent loop re-sends the identical tools + system prefix on every step, so without a cache breakpoint the full prefix is re-processed at full input price each step.

## What changed

The system prompt is now sent as a content block array with `cache_control`:

```ts
requestParams.system = [
  {
    type: "text",
    text: this.userProvidedInstructions,
    cache_control: { type: "ephemeral" },
  },
];
```

Since the Anthropic API renders the prompt as `tools` → `system` → `messages`, this single breakpoint caches the computer-use tool definition and the system prompt together across steps. Cache reads bill at ~0.1× input price (writes at 1.25×), so this pays for itself from the second step of any run. If the prefix is below the model's minimum cacheable size, the marker is silently ignored — no error, no premium.

Caching is transparent to model behavior; outputs are unchanged.

## Testing

- `tsc --noEmit` on `packages/core` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable prompt caching for Anthropic CUA by sending the system prompt as a content block array with `cache_control: { type: "ephemeral" }` in getAction(). This caches the tools + system prefix across agent steps to cut input cost and latency, and adds a unit test to verify the `system` payload shape (cached array when instructions exist, omitted otherwise).

<sup>Written for commit b6feabf8c90dc91802a1b35c17cd0bb29a744112. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

