### PR TITLE
[STG-2463] fix: silence AI SDK "system message in messages" warning on agent.execute()

### DIFF
--- a/.changeset/aisdk-allow-system-in-messages.md
+++ b/.changeset/aisdk-allow-system-in-messages.md
@@ -2,6 +2,4 @@
 "@browserbasehq/stagehand": patch
 ---
 
-Silence the AI SDK "System messages in the prompt or messages fields can be a security risk" warning emitted on every hybrid/DOM `agent.execute()` call.
-
-The agent loop intentionally supplies its system prompt as a system-role message (rather than the top-level `system` param) so it can carry Anthropic ephemeral cache-control via `providerOptions`. AI SDK v5 warns whenever it sees a system message inside `messages`, since it can't tell a trusted system prompt from untrusted input. Because the prompt is Stagehand's own, we now pass `allowSystemInMessages: true` to the `generateText`/`streamText` calls, which keeps prompt caching intact and removes the noisy warning. Bumps the `ai` floor to `^5.0.185`, where this option is available.
+Remove the noisy AI SDK "system message in messages" warning logged on every hybrid/DOM `agent.execute()` call.

--- a/.changeset/aisdk-allow-system-in-messages.md
+++ b/.changeset/aisdk-allow-system-in-messages.md
@@ -1,0 +1,7 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Silence the AI SDK "System messages in the prompt or messages fields can be a security risk" warning emitted on every hybrid/DOM `agent.execute()` call.
+
+The agent loop intentionally supplies its system prompt as a system-role message (rather than the top-level `system` param) so it can carry Anthropic ephemeral cache-control via `providerOptions`. AI SDK v5 warns whenever it sees a system message inside `messages`, since it can't tell a trusted system prompt from untrusted input. Because the prompt is Stagehand's own, we now pass `allowSystemInMessages: true` to the `generateText`/`streamText` calls, which keeps prompt caching intact and removes the noisy warning. Bumps the `ai` floor to `^5.0.185`, where this option is available.

--- a/packages/core/lib/v3/handlers/v3AgentHandler.ts
+++ b/packages/core/lib/v3/handlers/v3AgentHandler.ts
@@ -458,6 +458,7 @@ export class V3AgentHandler {
       const result = await this.llmClient.generateText({
         model: wrappedModel,
         messages: prependSystemMessage(systemPrompt, messages),
+        allowSystemInMessages: true,
         tools: allTools,
         stopWhen: (result) => this.handleStop(result, maxSteps),
         toolChoice: "auto",
@@ -616,6 +617,7 @@ export class V3AgentHandler {
       streamResult = this.llmClient.streamText({
         model: wrappedModel,
         messages: prependSystemMessage(systemPrompt, messages),
+        allowSystemInMessages: true,
         tools: allTools,
         stopWhen: (result) => this.handleStop(result, maxSteps),
         toolChoice: "auto",

--- a/packages/core/lib/v3/llm/LLMProvider.ts
+++ b/packages/core/lib/v3/llm/LLMProvider.ts
@@ -1,4 +1,7 @@
-import type { LanguageModelV2Middleware } from "@ai-sdk/provider";
+import type {
+  LanguageModelV2,
+  LanguageModelV2Middleware,
+} from "@ai-sdk/provider";
 import {
   UnsupportedAISDKModelProviderError,
   UnsupportedModelError,
@@ -156,7 +159,7 @@ export function getAISDKLanguageModel(
   subModelName: string,
   clientOptions?: ClientOptions,
   middleware?: LanguageModelV2Middleware,
-) {
+): LanguageModelV2 {
   const aiSdkClientOptions = toAISDKClientOptions(subProvider, clientOptions);
   const hasValidOptions =
     aiSdkClientOptions &&

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -89,7 +89,7 @@
     "@browserbasehq/sdk": "^2.10.0",
     "@google/genai": "^1.22.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "ai": "^5.0.133",
+    "ai": "^5.0.185",
     "devtools-protocol": "^0.0.1642743",
     "fetch-cookie": "^3.1.0",
     "openai": "^4.104.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,8 +187,8 @@ importers:
         specifier: ^1.29.0
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.2.1)
       ai:
-        specifier: ^5.0.133
-        version: 5.0.133(zod@4.2.1)
+        specifier: ^5.0.185
+        version: 5.0.209(zod@4.2.1)
       devtools-protocol:
         specifier: ^0.0.1642743
         version: 0.0.1642743
@@ -514,6 +514,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/gateway@2.0.108':
+    resolution: {integrity: sha512-86SG+gvko20aD6aM2Z4Mx8rEJYHpC2E2QrrEQzerXkEtruMWJCKwFfeaOKDLn8axN18Lln+HvYbS6cOiRA1J0g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/gateway@2.0.39':
     resolution: {integrity: sha512-ULnefGmRHG0/tRrf+dtDwgQYAttGi/TR0FmASAzTs1dtpeZp4Xoh1VyWrX3Z1bM3WDs9RM3ZeSE77kQT/jbfjw==}
     engines: {node: '>=18'}
@@ -600,6 +606,12 @@ packages:
 
   '@ai-sdk/provider-utils@3.0.25':
     resolution: {integrity: sha512-CvsRu+32Y8a167s+lrIBtsybvgTHp8j9y+6BeTvLeoW3Q+okw/b4CnNUFOLIXsRaKHQKAH+IHNJPYWywfpw0LA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@3.0.28':
+    resolution: {integrity: sha512-bXlX1WX7E50a2N+AJW+1a/x63m52aPhm+6xYe5THxWrx9vW9NR7E2Ay+1G1ndlCdMdYKo2Fnsd7kBhuyQPaphw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -2926,6 +2938,12 @@ packages:
 
   ai@5.0.133:
     resolution: {integrity: sha512-N6KnwSWKcXEWPnAri3anRuzRvcrvtDz1W1JG9CvMrQ0Xdp8Vu8ZToNW/eHt63CmrbmzTwVw/HaCtJuO+MYtS7A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  ai@5.0.209:
+    resolution: {integrity: sha512-M5iPINrFG/7fJamY4ibnuj+/1e8g3zMJj7f0EEoq25LTlgmqJqeVsRz2u7x7X4E+KvJuOWIJFAcwHVb6Nr9UfA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -7582,6 +7600,13 @@ snapshots:
       zod: 4.2.1
     optional: true
 
+  '@ai-sdk/gateway@2.0.108(zod@4.2.1)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.3
+      '@ai-sdk/provider-utils': 3.0.28(zod@4.2.1)
+      '@vercel/oidc': 3.1.0
+      zod: 4.2.1
+
   '@ai-sdk/gateway@2.0.39(zod@4.2.1)':
     dependencies:
       '@ai-sdk/provider': 2.0.1
@@ -7696,6 +7721,13 @@ snapshots:
       zod: 4.2.1
     optional: true
 
+  '@ai-sdk/provider-utils@3.0.28(zod@4.2.1)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.3
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.2.1
+
   '@ai-sdk/provider@1.1.3':
     dependencies:
       json-schema: 0.4.0
@@ -7712,7 +7744,6 @@ snapshots:
   '@ai-sdk/provider@2.0.3':
     dependencies:
       json-schema: 0.4.0
-    optional: true
 
   '@ai-sdk/togetherai@1.0.23(zod@4.2.1)':
     dependencies:
@@ -10765,6 +10796,14 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       zod: 4.2.1
 
+  ai@5.0.209(zod@4.2.1):
+    dependencies:
+      '@ai-sdk/gateway': 2.0.108(zod@4.2.1)
+      '@ai-sdk/provider': 2.0.3
+      '@ai-sdk/provider-utils': 3.0.28(zod@4.2.1)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.2.1
+
   ajv-draft-04@1.0.0(ajv@8.20.0):
     optionalDependencies:
       ajv: 8.20.0
@@ -12076,8 +12115,7 @@ snapshots:
 
   eventsource-parser@3.0.6: {}
 
-  eventsource-parser@3.1.0:
-    optional: true
+  eventsource-parser@3.1.0: {}
 
   eventsource@3.0.7:
     dependencies:


### PR DESCRIPTION
## What & why

Every hybrid/DOM `agent.execute()` call prints this AI SDK v5 warning to the console:

> AI SDK Warning: System messages in the prompt or messages fields can be a security risk because they may enable prompt injection attacks. Use the system option instead when possible. Set allowSystemInMessages to true to suppress this warning, or false to throw an error.

It's cosmetic (a warning, not an error), but it fires on essentially every agent run, and the "prompt injection" wording reads alarmingly enough to generate support tickets — it did (a customer reported it).

### Root cause
The agent loop builds its system prompt as a **system-role message inside the `messages` array** (`prependSystemMessage()` in `v3AgentHandler.ts`) rather than the top-level `system` param. This is deliberate: it lets the system prompt carry Anthropic **ephemeral cache-control** via `providerOptions` (see the function's own comment). AI SDK v5 warns whenever it sees a system message in `messages`, since it can't distinguish a trusted, library-authored system prompt from untrusted input.

The committed lockfile pinned `ai@5.0.133`, which predates this warning — so the repo build never saw it, but the `^5.0.133` range means real installs resolve to newer 5.0.x (e.g. `5.0.209`) that **do** warn. That's why users hit it and CI didn't.

### Fix
- Pass `allowSystemInMessages: true` to the `generateText` / `streamText` calls in the agent loop. This is the AI-SDK-sanctioned opt-out for an intentional system-in-messages structure, and it **keeps prompt caching intact** (vs. moving to top-level `system:`, which cannot carry per-message `providerOptions` and would regress Anthropic cache-control).
- Bump the `ai` floor `^5.0.133 → ^5.0.185`, where `allowSystemInMessages` is a typed option.
- Add an explicit return type (`LanguageModelV2`) to `getAISDKLanguageModel`. The `ai` bump pulls a newer `@ai-sdk/provider`, and without the annotation tsc emits `TS2742` ("inferred type … not portable").

## E2E Test Matrix

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| **BEFORE** — published `@browserbasehq/stagehand@3.6.0` (resolves `ai@5.0.209`), hybrid `agent.execute()` on a real Browserbase session, console captured | `AI SDK system-in-messages warning emitted: YES (1)` — full "…security risk…prompt injection…" text | Reproduces the customer's exact symptom on the version they run. |
| **AFTER** — local patched build (this branch, same `ai@5.0.209`), identical hybrid `agent.execute()` flow, same model, real Browserbase session | `AI SDK system-in-messages warning emitted: NO (0)`; run exits cleanly | Proves the fix removes the warning without breaking the agent run. Same harness as BEFORE → clean A/B. |
| `pnpm turbo run build --filter @browserbasehq/stagehand` | `Tasks: 3 successful, 3 total` (fails with `TS2742` before the `LLMProvider` annotation) | Typecheck + emit green; confirms the `ai` bump + annotation compile. |
| `prettier --check` + `eslint` on changed files | `All matched files use Prettier code style!`, eslint clean | Style/lint gates pass. |

A/B model: `anthropic/claude-haiku-4-5-20251001`. Both runs used identical `mode: "hybrid"` + `systemPrompt` config (the customer's shape).

Closes STG-2463.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Silences the AI SDK v5 “system message in messages” warning during hybrid/DOM `agent.execute()` runs while preserving Anthropic cache-control. Addresses STG-2463.

- **Bug Fixes**
  - Pass `allowSystemInMessages: true` to `generateText`/`streamText` so the agent’s system prompt in `messages` does not warn and caching stays intact.

- **Dependencies**
  - Bump `ai` to `^5.0.185` (lock resolves to `5.0.209`).
  - Add explicit `LanguageModelV2` return type in `getAISDKLanguageModel` to avoid `TS2742` with newer `@ai-sdk/provider`.

<sup>Written for commit bfc10af9413bd083e239422dde63de9957f5ff33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


