### PR TITLE
[fix]: bump bb sdk version

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -101,7 +101,7 @@
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {
-    "@browserbasehq/sdk": "^2.12.0",
+    "@browserbasehq/sdk": "^2.14.0",
     "@browserbasehq/stagehand": "workspace:*",
     "@oclif/core": "^4.11.0",
     "@vercel/detect-agent": "^1.2.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -86,7 +86,7 @@
   "dependencies": {
     "@ai-sdk/provider": "^2.0.0",
     "@anthropic-ai/sdk": "0.39.0",
-    "@browserbasehq/sdk": "^2.10.0",
+    "@browserbasehq/sdk": "^2.14.0",
     "@google/genai": "^1.22.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "ai": "^5.0.133",

--- a/packages/server-v3/package.json
+++ b/packages/server-v3/package.json
@@ -22,7 +22,7 @@
     "gen:openapi": "tsx scripts/gen-openapi.ts"
   },
   "dependencies": {
-    "@browserbasehq/sdk": "^2.10.0",
+    "@browserbasehq/sdk": "^2.14.0",
     "@browserbasehq/stagehand": "workspace:*",
     "@fastify/cors": "^11.0.1",
     "@fastify/swagger": "^9.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,8 +84,8 @@ importers:
   packages/cli:
     dependencies:
       '@browserbasehq/sdk':
-        specifier: ^2.12.0
-        version: 2.12.0
+        specifier: ^2.14.0
+        version: 2.14.1
       '@browserbasehq/stagehand':
         specifier: workspace:*
         version: link:../core
@@ -178,8 +178,8 @@ importers:
         specifier: 0.39.0
         version: 0.39.0
       '@browserbasehq/sdk':
-        specifier: ^2.10.0
-        version: 2.10.0
+        specifier: ^2.14.0
+        version: 2.14.1
       '@google/genai':
         specifier: ^1.22.0
         version: 1.24.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.2.1))(bufferutil@4.0.9)
@@ -388,8 +388,8 @@ importers:
   packages/server-v3:
     dependencies:
       '@browserbasehq/sdk':
-        specifier: ^2.10.0
-        version: 2.10.0
+        specifier: ^2.14.0
+        version: 2.14.1
       '@browserbasehq/stagehand':
         specifier: workspace:*
         version: link:../core
@@ -885,11 +885,8 @@ packages:
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
 
-  '@browserbasehq/sdk@2.10.0':
-    resolution: {integrity: sha512-pOL4yW8P8AI2+N5y6zEP6XXKqIXtYyKunr1JXppqQDOyKLxxvZEDqQCHJXWUzqgx3R1tGWpn7m9AjXN7MeYInA==}
-
-  '@browserbasehq/sdk@2.12.0':
-    resolution: {integrity: sha512-bwgVjjYc4O54Cvkc5POfZUv0Gl92n1nNfAPueRLQVFsDoPRTw0FS8wKo9/bQCQuyzAg9+RQUDqvUC241ogLRTQ==}
+  '@browserbasehq/sdk@2.14.1':
+    resolution: {integrity: sha512-Ahmzb5+82ePgSGwouKEoAhiGy8mJ3RbCl+uigfGfVc60zseYIftcMiDPXSmrTQr1NHaATRx4cJlynP8ZUweXtg==}
 
   '@canvas/image-data@1.1.0':
     resolution: {integrity: sha512-QdObRRjRbcXGmM1tmJ+MrHcaz1MftF2+W7YI+MsphnsCrmtyfS0d5qJbk0MeSbUeyM/jCb0hmnkXPsy026L7dA==}
@@ -8158,19 +8155,7 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
-  '@browserbasehq/sdk@2.10.0':
-    dependencies:
-      '@types/node': 18.19.130
-      '@types/node-fetch': 2.6.13
-      abort-controller: 3.0.0
-      agentkeepalive: 4.6.0
-      form-data-encoder: 1.7.2
-      formdata-node: 4.4.1
-      node-fetch: 2.7.0
-    transitivePeerDependencies:
-      - encoding
-
-  '@browserbasehq/sdk@2.12.0':
+  '@browserbasehq/sdk@2.14.1':
     dependencies:
       '@types/node': 18.19.130
       '@types/node-fetch': 2.6.13


### PR DESCRIPTION
# why
- node 22.17.0 introduced a compatibility issue with node-fetch which broke the browserbase sdk when running on 22.17.0
- addresses #2291 
# what changed
- bumped the browserbase sdk version to ^2.14.0 which fixes the issue
# test plan
- tested locally by running node 22.17.0, observing the issue. the issue is resolved after bumping the browserbase sdk version

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `@browserbasehq/sdk` to ^2.14.0 to restore compatibility with Node 22.17.0 by resolving the `node-fetch` issue. Fixes #2291.

- **Bug Fixes**
  - Bumped `@browserbasehq/sdk` to ^2.14.0 in `packages/cli`, `packages/core`, and `packages/server-v3`; updated `pnpm-lock.yaml`.
  - Prevents runtime failures when running on Node 22.17.0.

<sup>Written for commit 78ffe3488e35a44f1dc344de21344de7c51d0078. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

