### PR TITLE
[STG-2464] ci: gate v3 SEA binary build on server changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -468,7 +468,8 @@ jobs:
   build-server-sea:
     name: Build SEA binary (tests, v3)
     uses: ./.github/workflows/stagehand-server-v3-sea-build.yml
-    needs: [run-build]
+    needs: [run-build, determine-changes]
+    if: needs.determine-changes.outputs.server == 'true'
     with:
       matrix: |
         [


### PR DESCRIPTION
## What & why

`build-server-sea` (`Build SEA binary (tests, v3)`) was the only package-scoped job in `ci.yml` without a path-filter gate. It only declared `needs: [run-build]`, so it compiled the `stagehand-server-v3` single-executable (SEA) across all 6 platforms + a sourcemap build on **every** PR — including metadata-only release PRs that touch zero server code (e.g. the browse version-bump PR #2287, where core / server-integration / e2e / evals all correctly skipped but the SEA build still ran).

This adds the same gate its siblings already use:

```yaml
  build-server-sea:
    needs: [run-build, determine-changes]
    if: needs.determine-changes.outputs.server == 'true'
```

The `server` filter matches `packages/server-v3/**`, `packages/server-v4/**`, `packages/core/**`, root `package.json`, the lockfile, `pnpm-workspace.yaml`, and `ci.yml` — so genuine server changes still build. The only downstream consumer, `server-integration-tests`, already runs solely when `server == true` (via `discover-server-tests`), so gating is safe: when server is unchanged, both skip together; a skipped job passes branch protection.

Linear: [STG-2464](https://linear.app/browserbase/issue/STG-2464/gate-v3-sea-binary-build-on-server-changes-in-ci)

## E2E Test Matrix

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `ruby -ryaml -e "YAML.load_file('.github/workflows/ci.yml')"` | `YAML OK` | Proves the workflow still parses after the edit. |
| `git diff --stat origin/main..HEAD` | `.github/workflows/ci.yml \| 3 ++-` (1 file, +2/-1) | Confirms the change is scoped to a single job, no collateral edits. |
| This PR's own CI run | `build-server-sea` **runs** (not skipped) | Live proof the gate doesn't over-skip: `ci.yml` is itself in the `server` filter, so `server == true` here and the SEA build correctly fires. |
| Cross-check vs PR #2287 (browse@0.9.2, metadata-only) | On #2287 `determine-changes.server == false` — evidenced by core / server-integration / e2e / evals all showing **skipped** while SEA still built | Establishes the exact scenario this fixes; after merge, such a PR would skip `build-server-sea` too. Not directly runnable pre-merge (would need the merged workflow on a metadata-only PR). |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gated the `build-server-sea` job to run only when `server` changes are detected. This stops unnecessary multi-platform SEA builds on metadata-only PRs and stays aligned with sibling jobs; `server-integration-tests` remains in lockstep. Linear: STG-2464.

- **Bug Fixes**
  - In `.github/workflows/ci.yml`, updated `build-server-sea` to `needs: [run-build, determine-changes]` and added `if: needs.determine-changes.outputs.server == 'true'`.

<sup>Written for commit 8cda7c38f2e64f1b325ce7847d26f81057c9e02f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

