### PR TITLE
fix(cli): surface no-match failures in browse click/fill

### DIFF
--- a/.changeset/fix-cli-click-fill-nomatch.md
+++ b/.changeset/fix-cli-click-fill-nomatch.md
@@ -1,0 +1,5 @@
+---
+"browse": patch
+---
+
+`browse click` and `browse fill` now exit non-zero and report the error when their selector matches no element, instead of printing `{ "clicked": true }` / `{ "filled": true }` and exiting 0. Both commands run through `act()`, which reports a missing element via `success:false` rather than throwing, so the failure was previously swallowed — unlike `select`/`upload`, which already error via `deepLocator`. This makes the false-positive success visible to scripts and agents.

--- a/packages/cli/src/lib/driver/commands/elements.ts
+++ b/packages/cli/src/lib/driver/commands/elements.ts
@@ -8,12 +8,17 @@ export const elementsHandlers: DriverCommandHandlers = {
       .object({ selector: z.string().min(1) })
       .parse(params);
     const stagehand = await manager.stagehandInstance();
-    await stagehand.act({
+    // act() reports a failed action (e.g. a selector that matches nothing) by
+    // returning success:false rather than throwing, so surface it as an error
+    // instead of reporting { clicked: true } — matching select/upload, which
+    // throw via deepLocator when the element is missing.
+    const result = await stagehand.act({
       arguments: [],
       description: "click element",
       method: "click",
       selector: manager.resolveSelector(selector),
     } as never);
+    if (!result.success) throw new Error(result.message);
     return { clicked: true };
   },
 
@@ -26,12 +31,13 @@ export const elementsHandlers: DriverCommandHandlers = {
       })
       .parse(params);
     const stagehand = await manager.stagehandInstance();
-    await stagehand.act({
+    const result = await stagehand.act({
       arguments: [value],
       description: "fill element",
       method: "fill",
       selector: manager.resolveSelector(selector),
     } as never);
+    if (!result.success) throw new Error(result.message);
     if (pressEnter) {
       const page = await manager.activePage();
       await page.keyPress("Enter");

--- a/packages/cli/tests/element-command-failures.test.ts
+++ b/packages/cli/tests/element-command-failures.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { elementsHandlers } from "../src/lib/driver/commands/elements.js";
+
+/**
+ * Regression coverage: `browse click` / `browse fill` used to return
+ * { clicked: true } / { filled: true } (exit 0) even when the selector matched
+ * no element, because act() reports failure via success:false instead of
+ * throwing. The sibling commands (select/upload) already throw via deepLocator.
+ * These tests lock in that click/fill now surface the failure.
+ */
+type ClickManager = Parameters<
+  NonNullable<(typeof elementsHandlers)["click"]>
+>[0];
+
+function managerWithActResult(actResult: {
+  success: boolean;
+  message: string;
+}) {
+  const act = vi.fn().mockResolvedValue(actResult);
+  const keyPress = vi.fn();
+  const manager = {
+    stagehandInstance: async () => ({ act }),
+    resolveSelector: (selector: string) => selector,
+    activePage: async () => ({ keyPress }),
+  } as unknown as ClickManager;
+  return { manager, act, keyPress };
+}
+
+const NO_MATCH = {
+  success: false,
+  message: "Could not find an element for the given xPath(s): #missing",
+};
+
+describe("browse click/fill surface act failures instead of reporting success", () => {
+  it("click throws when the underlying act reports failure (no-match selector)", async () => {
+    const { manager } = managerWithActResult(NO_MATCH);
+    await expect(
+      elementsHandlers.click!(manager, { selector: "#missing" }),
+    ).rejects.toThrow("Could not find an element");
+  });
+
+  it("click resolves { clicked: true } when the action succeeds", async () => {
+    const { manager } = managerWithActResult({ success: true, message: "" });
+    await expect(
+      elementsHandlers.click!(manager, { selector: "#ok" }),
+    ).resolves.toEqual({ clicked: true });
+  });
+
+  it("fill throws when the underlying act reports failure (no-match selector)", async () => {
+    const { manager } = managerWithActResult(NO_MATCH);
+    await expect(
+      elementsHandlers.fill!(manager, { selector: "#missing", value: "hi" }),
+    ).rejects.toThrow("Could not find an element");
+  });
+
+  it("fill resolves and does not press Enter when the action succeeds", async () => {
+    const { manager, keyPress } = managerWithActResult({
+      success: true,
+      message: "",
+    });
+    await expect(
+      elementsHandlers.fill!(manager, { selector: "#ok", value: "hi" }),
+    ).resolves.toEqual({ filled: true, pressedEnter: false });
+    expect(keyPress).not.toHaveBeenCalled();
+  });
+
+  it("fill does not press Enter when the action failed", async () => {
+    const { manager, keyPress } = managerWithActResult(NO_MATCH);
+    await expect(
+      elementsHandlers.fill!(manager, {
+        selector: "#missing",
+        value: "hi",
+        pressEnter: true,
+      }),
+    ).rejects.toThrow("Could not find an element");
+    expect(keyPress).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## why

`browse click` and `browse fill` report success on a selector that matches **nothing**. Reproduced on `browse@0.9.1` against a real page:

```
$ browse click "#this-element-does-not-exist-xyz"
{ "clicked": true }
$ echo $?
0

$ browse fill "#this-element-does-not-exist-xyz" "hello"
{ "filled": true, "pressedEnter": false }
$ echo $?
0
```

Every other element command errors correctly on the same no-match selector:

```
$ browse is visible "#missing"   →  exit 1  "Could not find an element for the given xPath(s): #missing"
$ browse get text "#missing"     →  exit 1  "Could not find an element ..."
$ browse select "#missing" ...   →  exit 1  (throws via deepLocator)
$ browse upload "#missing" ...    →  exit 1  (throws via deepLocator)
```

`click`/`fill` are the only outliers. They run through `stagehand.act()`, which reports a missing element via `success:false` **rather than throwing** (`actHandler.ts`), and the handlers discard that result — so a script or agent driving the CLI proceeds on a false premise.

## what changed

`packages/cli/src/lib/driver/commands/elements.ts` — `click` and `fill` now check the `act()` result and `throw new Error(result.message)` when `success` is false, so they exit non-zero and print the same "Could not find an element" error as their siblings. A failed `fill` no longer presses Enter afterward.

## test plan

Adds `tests/element-command-failures.test.ts` (5 cases, mock manager per the existing `driver-commands.test.ts` pattern): click/fill throw on `success:false`, resolve on success, and a failed fill never presses Enter. Adjacent suites (`driver-commands`, `driver-foundation`) still green; `tsc -p tsconfig.json` clean.

The pre-fix behavior above was reproduced live; the fix is covered by the unit tests (a full end-to-end run needs a driver session).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `browse` CLI so `browse click` and `browse fill` fail with a clear error and non-zero exit when the selector matches no element, aligning with other element commands.

- **Bug Fixes**
  - Throw the `act()` error message when `success:false` instead of reporting success.
  - `fill` no longer presses Enter after a failed action.

<sup>Written for commit aee59f50d01ab54ba93d2742f1814ee5bda9efe5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

