### PR TITLE
[STG-2468] chore(cli): release browse 0.9.3 to publish the Docker image

### DIFF
--- a/.changeset/browse-docker-image.md
+++ b/.changeset/browse-docker-image.md
@@ -1,0 +1,5 @@
+---
+"browse": patch
+---
+
+browse is now also distributed as a Docker image: `ghcr.io/browserbase/browse` (multi-arch `linux/amd64,linux/arm64`, pinned to each release). Lets code sandboxes consume the CLI by image reference without a Dockerfile.


### PR DESCRIPTION
## What

Changeset-only patch bump (`browse` 0.9.2 → 0.9.3) to trigger the **first browse release that publishes the Docker image** added in #2295.

`browse@0.9.2` shipped *before* the GHCR publish step existed, so no image is on the registry yet. The Docker step only runs when browse's version changes (`should_publish`), so a release is required to produce it.

This PR contains **only** a changeset — no code changes.

## Release path (after this merges)

1. Merge this PR → the `browse` changeset lands on `main`.
2. Run the **Prepare CLI Release** workflow → it opens a `Release browse@0.9.3` PR.
3. Merge that PR → the **Release** workflow publishes `browse@0.9.3` to npm **and** builds/pushes `ghcr.io/browserbase/browse` (multi-arch, pinned).

## One-time follow-up

GHCR packages default to private — after the first push, set `ghcr.io/browserbase/browse` visibility to **Public** so sandboxes can pull it anonymously.

---
Linear: [STG-2468](https://linear.app/browserbase/issue/STG-2468/release-browse-093-to-publish-the-docker-image-ghcriobrowserbasebrowse)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Patch bump for `browse` 0.9.3 to trigger the first Docker image publish to `ghcr.io/browserbase/browse` (multi-arch, pinned per release). No code changes; adds a changeset so the release builds and pushes the image. Addresses Linear STG-2468.

- **Migration**
  - After the first publish, set `ghcr.io/browserbase/browse` visibility to Public so sandboxes can pull without auth.

<sup>Written for commit 09b8f9d8285b7b070fddac0421e18c66eeabbc01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

