### PR TITLE
feat(core): wire logInferenceToFile through stagehand.agent()

### DIFF
--- a/.changeset/agent-inference-logging.md
+++ b/.changeset/agent-inference-logging.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Wire `logInferenceToFile` through `stagehand.agent()` for DOM/hybrid and CUA agents, writing per-step inference dumps to `inference_summary/agent_summary/`.

--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,6 @@ packages/core/lib/dom/build/
 packages/core/lib/v3/dom/build/
 packages/evals/public
 *.tgz
-.agents/**
-skills-lock.json
 evals/playground.ts
 tmp/
 eval-summary.json

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ packages/core/lib/dom/build/
 packages/core/lib/v3/dom/build/
 packages/evals/public
 *.tgz
+.agents/**
+skills-lock.json
 evals/playground.ts
 tmp/
 eval-summary.json

--- a/packages/core/lib/v3/agent/AnthropicCUAClient.ts
+++ b/packages/core/lib/v3/agent/AnthropicCUAClient.ts
@@ -33,6 +33,7 @@ import {
 import { stripModelProvider } from "../../utils.js";
 import { v7 as uuidv7 } from "uuid";
 import {
+  getCuaRunStartTools,
   logAgentRunStart,
   runCuaStepWithInferenceLogging,
   sanitizeForInferenceLog,
@@ -138,7 +139,9 @@ export class AnthropicCUAClient extends AgentClient {
       logAgentRunStart({
         instruction,
         modelId: this.modelName,
-        tools: ["computer_use", ...(this.tools ? Object.keys(this.tools) : [])],
+        tools: getCuaRunStartTools(
+          this.tools ? Object.keys(this.tools) : undefined,
+        ),
         agentType: "cua",
       });
     }

--- a/packages/core/lib/v3/agent/AnthropicCUAClient.ts
+++ b/packages/core/lib/v3/agent/AnthropicCUAClient.ts
@@ -35,6 +35,8 @@ import { v7 as uuidv7 } from "uuid";
 import {
   logAgentRunStart,
   runCuaStepWithInferenceLogging,
+  sanitizeForInferenceLog,
+  type CuaStepInferenceContext,
 } from "./utils/agentInferenceLogger.js";
 
 export type ResponseInputItem = AnthropicMessage | AnthropicToolResult;
@@ -136,7 +138,7 @@ export class AnthropicCUAClient extends AgentClient {
       logAgentRunStart({
         instruction,
         modelId: this.modelName,
-        tools: ["computer_use"],
+        tools: ["computer_use", ...(this.tools ? Object.keys(this.tools) : [])],
         agentType: "cua",
       });
     }
@@ -177,8 +179,7 @@ export class AnthropicCUAClient extends AgentClient {
           logInferenceToFile,
           stepIndex,
           modelId: this.modelName,
-          callPayload: { inputItems },
-          executeStep: () => this.executeStep(inputItems, logger),
+          executeStep: (ctx) => this.executeStep(inputItems, logger, ctx),
         });
         totalInputTokens += result.usage.input_tokens;
         totalOutputTokens += result.usage.output_tokens;
@@ -256,6 +257,7 @@ export class AnthropicCUAClient extends AgentClient {
   async executeStep(
     inputItems: ResponseInputItem[],
     logger: (message: LogLine) => void,
+    inferenceCtx?: CuaStepInferenceContext,
   ): Promise<{
     actions: AgentAction[];
     message: string;
@@ -269,7 +271,11 @@ export class AnthropicCUAClient extends AgentClient {
   }> {
     try {
       // Get response from the model
-      const result = await this.getAction(inputItems, logger);
+      const result = await this.getAction(
+        inputItems,
+        logger,
+        inferenceCtx?.logCall,
+      );
       const content = result.content;
       const usage = {
         input_tokens: result.usage.input_tokens,
@@ -449,6 +455,7 @@ export class AnthropicCUAClient extends AgentClient {
   async getAction(
     inputItems: ResponseInputItem[],
     logger?: (message: LogLine) => void,
+    logCall?: (payload: unknown) => void,
   ): Promise<{
     content: AnthropicContentBlock[];
     id: string;
@@ -609,6 +616,8 @@ export class AnthropicCUAClient extends AgentClient {
         model: this.modelName,
         prompt: extractLlmCuaPromptSummary(messages),
       });
+
+      logCall?.(sanitizeForInferenceLog(requestParams));
 
       const startTime = Date.now();
       // Create the message using the Anthropic Messages API

--- a/packages/core/lib/v3/agent/AnthropicCUAClient.ts
+++ b/packages/core/lib/v3/agent/AnthropicCUAClient.ts
@@ -36,7 +36,6 @@ import {
   getCuaRunStartTools,
   logAgentRunStart,
   runCuaStepWithInferenceLogging,
-  sanitizeForInferenceLog,
   type CuaStepInferenceContext,
 } from "./utils/agentInferenceLogger.js";
 
@@ -620,7 +619,7 @@ export class AnthropicCUAClient extends AgentClient {
         prompt: extractLlmCuaPromptSummary(messages),
       });
 
-      logCall?.(sanitizeForInferenceLog(requestParams));
+      logCall?.(requestParams);
 
       const startTime = Date.now();
       // Create the message using the Anthropic Messages API

--- a/packages/core/lib/v3/agent/AnthropicCUAClient.ts
+++ b/packages/core/lib/v3/agent/AnthropicCUAClient.ts
@@ -32,6 +32,10 @@ import {
 } from "../llm/anthropicOptions.js";
 import { stripModelProvider } from "../../utils.js";
 import { v7 as uuidv7 } from "uuid";
+import {
+  logAgentRunStart,
+  runCuaStepWithInferenceLogging,
+} from "./utils/agentInferenceLogger.js";
 
 export type ResponseInputItem = AnthropicMessage | AnthropicToolResult;
 
@@ -124,9 +128,18 @@ export class AnthropicCUAClient extends AgentClient {
    * @implements AgentClient.execute
    */
   async execute(executionOptions: AgentExecutionOptions): Promise<AgentResult> {
-    const { options, logger } = executionOptions;
+    const { options, logger, logInferenceToFile = false } = executionOptions;
     const { instruction } = options;
     const maxSteps = options.maxSteps || 10;
+
+    if (logInferenceToFile) {
+      logAgentRunStart({
+        instruction,
+        modelId: this.modelName,
+        tools: ["computer_use"],
+        agentType: "cua",
+      });
+    }
 
     let currentStep = 0;
     let completed = false;
@@ -159,7 +172,14 @@ export class AnthropicCUAClient extends AgentClient {
           level: 1,
         });
 
-        const result = await this.executeStep(inputItems, logger);
+        const stepIndex = currentStep + 1;
+        const result = await runCuaStepWithInferenceLogging({
+          logInferenceToFile,
+          stepIndex,
+          modelId: this.modelName,
+          callPayload: { inputItems },
+          executeStep: () => this.executeStep(inputItems, logger),
+        });
         totalInputTokens += result.usage.input_tokens;
         totalOutputTokens += result.usage.output_tokens;
         totalInferenceTime += result.usage.inference_time_ms;

--- a/packages/core/lib/v3/agent/GoogleCUAClient.ts
+++ b/packages/core/lib/v3/agent/GoogleCUAClient.ts
@@ -34,8 +34,11 @@ import {
 } from "./utils/googleCustomToolHandler.js";
 import { ToolSet } from "ai";
 import {
+  getCuaRunStartTools,
   logAgentRunStart,
   runCuaStepWithInferenceLogging,
+  sanitizeForInferenceLog,
+  type CuaStepInferenceContext,
 } from "./utils/agentInferenceLogger.js";
 import {
   FlowLogger,
@@ -237,7 +240,9 @@ export class GoogleCUAClient extends AgentClient {
       logAgentRunStart({
         instruction,
         modelId: this.modelName,
-        tools: ["computer_use"],
+        tools: getCuaRunStartTools(
+          this.tools ? Object.keys(this.tools) : undefined,
+        ),
         agentType: "cua",
       });
     }
@@ -274,8 +279,7 @@ export class GoogleCUAClient extends AgentClient {
           logInferenceToFile,
           stepIndex,
           modelId: this.modelName,
-          callPayload: { history: this.history },
-          executeStep: () => this.executeStep(logger),
+          executeStep: (ctx) => this.executeStep(logger, ctx),
         });
         totalInputTokens += result.usage.input_tokens;
         totalOutputTokens += result.usage.output_tokens;
@@ -370,7 +374,10 @@ export class GoogleCUAClient extends AgentClient {
   /**
    * Execute a single step of the agent
    */
-  async executeStep(logger: (message: LogLine) => void): Promise<{
+  async executeStep(
+    logger: (message: LogLine) => void,
+    inferenceCtx?: CuaStepInferenceContext,
+  ): Promise<{
     actions: AgentAction[];
     message: string;
     completed: boolean;
@@ -391,6 +398,14 @@ export class GoogleCUAClient extends AgentClient {
         2,
       );
       const compressedHistory = compressedResult.items;
+
+      inferenceCtx?.logCall(
+        sanitizeForInferenceLog({
+          model: this.modelName,
+          contents: compressedHistory,
+          config: this.generateContentConfig,
+        }),
+      );
 
       // Use the SDK's generateContent method with retry logic (matching Python's get_model_response)
       const maxRetries = 5;

--- a/packages/core/lib/v3/agent/GoogleCUAClient.ts
+++ b/packages/core/lib/v3/agent/GoogleCUAClient.ts
@@ -34,6 +34,10 @@ import {
 } from "./utils/googleCustomToolHandler.js";
 import { ToolSet } from "ai";
 import {
+  logAgentRunStart,
+  runCuaStepWithInferenceLogging,
+} from "./utils/agentInferenceLogger.js";
+import {
   FlowLogger,
   extractLlmCuaPromptSummary,
   extractLlmCuaResponseSummary,
@@ -225,9 +229,18 @@ export class GoogleCUAClient extends AgentClient {
    * @implements AgentClient.execute
    */
   async execute(executionOptions: AgentExecutionOptions): Promise<AgentResult> {
-    const { options, logger } = executionOptions;
+    const { options, logger, logInferenceToFile = false } = executionOptions;
     const { instruction } = options;
     const maxSteps = options.maxSteps || 10;
+
+    if (logInferenceToFile) {
+      logAgentRunStart({
+        instruction,
+        modelId: this.modelName,
+        tools: ["computer_use"],
+        agentType: "cua",
+      });
+    }
 
     let currentStep = 0;
     let completed = false;
@@ -256,7 +269,14 @@ export class GoogleCUAClient extends AgentClient {
           level: 1,
         });
 
-        const result = await this.executeStep(logger);
+        const stepIndex = currentStep + 1;
+        const result = await runCuaStepWithInferenceLogging({
+          logInferenceToFile,
+          stepIndex,
+          modelId: this.modelName,
+          callPayload: { history: this.history },
+          executeStep: () => this.executeStep(logger),
+        });
         totalInputTokens += result.usage.input_tokens;
         totalOutputTokens += result.usage.output_tokens;
         totalReasoningTokens += result.usage.reasoning_tokens;

--- a/packages/core/lib/v3/agent/GoogleCUAClient.ts
+++ b/packages/core/lib/v3/agent/GoogleCUAClient.ts
@@ -37,7 +37,6 @@ import {
   getCuaRunStartTools,
   logAgentRunStart,
   runCuaStepWithInferenceLogging,
-  sanitizeForInferenceLog,
   type CuaStepInferenceContext,
 } from "./utils/agentInferenceLogger.js";
 import {
@@ -399,13 +398,11 @@ export class GoogleCUAClient extends AgentClient {
       );
       const compressedHistory = compressedResult.items;
 
-      inferenceCtx?.logCall(
-        sanitizeForInferenceLog({
-          model: this.modelName,
-          contents: compressedHistory,
-          config: this.generateContentConfig,
-        }),
-      );
+      inferenceCtx?.logCall({
+        model: this.modelName,
+        contents: compressedHistory,
+        config: this.generateContentConfig,
+      });
 
       // Use the SDK's generateContent method with retry logic (matching Python's get_model_response)
       const maxRetries = 5;

--- a/packages/core/lib/v3/agent/MicrosoftCUAClient.ts
+++ b/packages/core/lib/v3/agent/MicrosoftCUAClient.ts
@@ -18,6 +18,7 @@ import {
 } from "../flowlogger/FlowLogger.js";
 import { v7 as uuidv7 } from "uuid";
 import {
+  getCuaRunStartTools,
   logAgentRunStart,
   runCuaStepWithInferenceLogging,
   sanitizeForInferenceLog,
@@ -894,7 +895,7 @@ For each function call, return a json object with function name and arguments wi
       logAgentRunStart({
         instruction,
         modelId: this.modelName,
-        tools: ["computer_use"],
+        tools: getCuaRunStartTools(),
         agentType: "cua",
       });
     }

--- a/packages/core/lib/v3/agent/MicrosoftCUAClient.ts
+++ b/packages/core/lib/v3/agent/MicrosoftCUAClient.ts
@@ -21,7 +21,6 @@ import {
   getCuaRunStartTools,
   logAgentRunStart,
   runCuaStepWithInferenceLogging,
-  sanitizeForInferenceLog,
   type CuaStepInferenceContext,
 } from "./utils/agentInferenceLogger.js";
 
@@ -722,12 +721,10 @@ For each function call, return a json object with function name and arguments wi
     };
     history = [systemMessage, ...history];
 
-    inferenceCtx?.logCall(
-      sanitizeForInferenceLog({
-        messages: history,
-        temperature: this.temperature,
-      }),
-    );
+    inferenceCtx?.logCall({
+      messages: history,
+      temperature: this.temperature,
+    });
 
     // Make API call
     logger({

--- a/packages/core/lib/v3/agent/MicrosoftCUAClient.ts
+++ b/packages/core/lib/v3/agent/MicrosoftCUAClient.ts
@@ -20,6 +20,8 @@ import { v7 as uuidv7 } from "uuid";
 import {
   logAgentRunStart,
   runCuaStepWithInferenceLogging,
+  sanitizeForInferenceLog,
+  type CuaStepInferenceContext,
 } from "./utils/agentInferenceLogger.js";
 
 /**
@@ -641,8 +643,10 @@ For each function call, return a json object with function name and arguments wi
   private async executeStep(
     logger: (message: LogLine) => void,
     isFirstRound: boolean = false,
+    inferenceCtx?: CuaStepInferenceContext,
   ): Promise<{
     actions: AgentAction[];
+    message: string;
     completed: boolean;
     usage: {
       input_tokens: number;
@@ -716,6 +720,13 @@ For each function call, return a json object with function name and arguments wi
       content: this.generateSystemPrompt(),
     };
     history = [systemMessage, ...history];
+
+    inferenceCtx?.logCall(
+      sanitizeForInferenceLog({
+        messages: history,
+        temperature: this.temperature,
+      }),
+    );
 
     // Make API call
     logger({
@@ -859,6 +870,7 @@ For each function call, return a json object with function name and arguments wi
 
     return {
       actions,
+      message: thoughts,
       completed,
       usage: {
         input_tokens: usage.prompt_tokens,
@@ -923,20 +935,12 @@ For each function call, return a json object with function name and arguments wi
           logInferenceToFile,
           stepIndex,
           modelId: this.modelName,
-          callPayload: {
-            conversationHistory: this.conversationHistory,
-            isFirstRound,
-          },
-          executeStep: () => this.executeStep(logger, isFirstRound),
-          mapResponse: (stepResult) => {
-            const lastAction =
-              stepResult.actions[stepResult.actions.length - 1];
-            return {
-              actions: stepResult.actions,
-              message: (lastAction as { reasoning?: string })?.reasoning ?? "",
-              completed: stepResult.completed,
-            };
-          },
+          executeStep: (ctx) => this.executeStep(logger, isFirstRound, ctx),
+          mapResponse: (stepResult) => ({
+            actions: stepResult.actions,
+            message: stepResult.message ?? "",
+            completed: stepResult.completed,
+          }),
         });
         totalInputTokens += result.usage.input_tokens;
         totalOutputTokens += result.usage.output_tokens;
@@ -951,9 +955,8 @@ For each function call, return a json object with function name and arguments wi
         currentStep++;
 
         // Record message for this step
-        const lastAction = result.actions[result.actions.length - 1];
-        if (lastAction?.reasoning) {
-          messageList.push(lastAction.reasoning);
+        if (result.message) {
+          messageList.push(result.message);
         }
       }
 

--- a/packages/core/lib/v3/agent/MicrosoftCUAClient.ts
+++ b/packages/core/lib/v3/agent/MicrosoftCUAClient.ts
@@ -17,6 +17,10 @@ import {
   extractLlmCuaResponseSummary,
 } from "../flowlogger/FlowLogger.js";
 import { v7 as uuidv7 } from "uuid";
+import {
+  logAgentRunStart,
+  runCuaStepWithInferenceLogging,
+} from "./utils/agentInferenceLogger.js";
 
 /**
  * Message types for FARA agent
@@ -870,9 +874,18 @@ For each function call, return a json object with function name and arguments wi
    * @implements AgentClient.execute
    */
   async execute(executionOptions: AgentExecutionOptions): Promise<AgentResult> {
-    const { options, logger } = executionOptions;
+    const { options, logger, logInferenceToFile = false } = executionOptions;
     const { instruction } = options;
     const maxSteps = options.maxSteps || 10;
+
+    if (logInferenceToFile) {
+      logAgentRunStart({
+        instruction,
+        modelId: this.modelName,
+        tools: ["computer_use"],
+        agentType: "cua",
+      });
+    }
 
     let currentStep = 0;
     let completed = false;
@@ -904,8 +917,27 @@ For each function call, return a json object with function name and arguments wi
           level: 1,
         });
 
+        const stepIndex = currentStep + 1;
         const isFirstRound = currentStep === 0;
-        const result = await this.executeStep(logger, isFirstRound);
+        const result = await runCuaStepWithInferenceLogging({
+          logInferenceToFile,
+          stepIndex,
+          modelId: this.modelName,
+          callPayload: {
+            conversationHistory: this.conversationHistory,
+            isFirstRound,
+          },
+          executeStep: () => this.executeStep(logger, isFirstRound),
+          mapResponse: (stepResult) => {
+            const lastAction =
+              stepResult.actions[stepResult.actions.length - 1];
+            return {
+              actions: stepResult.actions,
+              message: (lastAction as { reasoning?: string })?.reasoning ?? "",
+              completed: stepResult.completed,
+            };
+          },
+        });
         totalInputTokens += result.usage.input_tokens;
         totalOutputTokens += result.usage.output_tokens;
         totalInferenceTime += result.usage.inference_time_ms;

--- a/packages/core/lib/v3/agent/OpenAICUAClient.ts
+++ b/packages/core/lib/v3/agent/OpenAICUAClient.ts
@@ -31,6 +31,7 @@ import {
 } from "../flowlogger/FlowLogger.js";
 import { v7 as uuidv7 } from "uuid";
 import {
+  getCuaRunStartTools,
   logAgentRunStart,
   runCuaStepWithInferenceLogging,
   sanitizeForInferenceLog,
@@ -154,7 +155,9 @@ export class OpenAICUAClient extends AgentClient {
       logAgentRunStart({
         instruction,
         modelId: this.modelName,
-        tools: ["computer_use"],
+        tools: getCuaRunStartTools(
+          this.tools ? Object.keys(this.tools) : undefined,
+        ),
         agentType: "cua",
       });
     }

--- a/packages/core/lib/v3/agent/OpenAICUAClient.ts
+++ b/packages/core/lib/v3/agent/OpenAICUAClient.ts
@@ -33,6 +33,8 @@ import { v7 as uuidv7 } from "uuid";
 import {
   logAgentRunStart,
   runCuaStepWithInferenceLogging,
+  sanitizeForInferenceLog,
+  type CuaStepInferenceContext,
 } from "./utils/agentInferenceLogger.js";
 
 /**
@@ -188,9 +190,8 @@ export class OpenAICUAClient extends AgentClient {
           logInferenceToFile,
           stepIndex,
           modelId: this.modelName,
-          callPayload: { inputItems, previousResponseId },
-          executeStep: () =>
-            this.executeStep(inputItems, previousResponseId, logger),
+          executeStep: (ctx) =>
+            this.executeStep(inputItems, previousResponseId, logger, ctx),
         });
         totalInputTokens += result.usage.input_tokens;
         totalOutputTokens += result.usage.output_tokens;
@@ -273,6 +274,7 @@ export class OpenAICUAClient extends AgentClient {
     inputItems: OpenAIRequestInputItem[],
     previousResponseId: string | undefined,
     logger: (message: LogLine) => void,
+    inferenceCtx?: CuaStepInferenceContext,
   ): Promise<{
     actions: AgentAction[];
     message: string;
@@ -287,7 +289,11 @@ export class OpenAICUAClient extends AgentClient {
   }> {
     try {
       // Get response from the model
-      const result = await this.getAction(inputItems, previousResponseId);
+      const result = await this.getAction(
+        inputItems,
+        previousResponseId,
+        inferenceCtx?.logCall,
+      );
       const output = result.output;
       const responseId = result.responseId;
       const usage = {
@@ -502,6 +508,7 @@ export class OpenAICUAClient extends AgentClient {
   async getAction(
     inputItems: OpenAIRequestInputItem[],
     previousResponseId?: string,
+    logCall?: (payload: unknown) => void,
   ): Promise<{
     output: ResponseItem[];
     responseId: string;
@@ -576,6 +583,8 @@ export class OpenAICUAClient extends AgentClient {
         model: this.modelName,
         prompt: extractLlmCuaPromptSummary(inputItems),
       });
+
+      logCall?.(sanitizeForInferenceLog(requestParams));
 
       const startTime = Date.now();
       // Create the response using the OpenAI Responses API

--- a/packages/core/lib/v3/agent/OpenAICUAClient.ts
+++ b/packages/core/lib/v3/agent/OpenAICUAClient.ts
@@ -34,7 +34,6 @@ import {
   getCuaRunStartTools,
   logAgentRunStart,
   runCuaStepWithInferenceLogging,
-  sanitizeForInferenceLog,
   type CuaStepInferenceContext,
 } from "./utils/agentInferenceLogger.js";
 
@@ -587,7 +586,7 @@ export class OpenAICUAClient extends AgentClient {
         prompt: extractLlmCuaPromptSummary(inputItems),
       });
 
-      logCall?.(sanitizeForInferenceLog(requestParams));
+      logCall?.(requestParams);
 
       const startTime = Date.now();
       // Create the response using the OpenAI Responses API

--- a/packages/core/lib/v3/agent/OpenAICUAClient.ts
+++ b/packages/core/lib/v3/agent/OpenAICUAClient.ts
@@ -30,6 +30,10 @@ import {
   extractLlmCuaResponseSummary,
 } from "../flowlogger/FlowLogger.js";
 import { v7 as uuidv7 } from "uuid";
+import {
+  logAgentRunStart,
+  runCuaStepWithInferenceLogging,
+} from "./utils/agentInferenceLogger.js";
 
 /**
  * Client for OpenAI's Computer Use Assistant API
@@ -140,9 +144,18 @@ export class OpenAICUAClient extends AgentClient {
    * @implements AgentClient.execute
    */
   async execute(executionOptions: AgentExecutionOptions): Promise<AgentResult> {
-    const { options, logger } = executionOptions;
+    const { options, logger, logInferenceToFile = false } = executionOptions;
     const { instruction } = options;
     const maxSteps = options.maxSteps || 10;
+
+    if (logInferenceToFile) {
+      logAgentRunStart({
+        instruction,
+        modelId: this.modelName,
+        tools: ["computer_use"],
+        agentType: "cua",
+      });
+    }
 
     let currentStep = 0;
     let completed = false;
@@ -170,11 +183,15 @@ export class OpenAICUAClient extends AgentClient {
           level: 1,
         });
 
-        const result = await this.executeStep(
-          inputItems,
-          previousResponseId,
-          logger,
-        );
+        const stepIndex = currentStep + 1;
+        const result = await runCuaStepWithInferenceLogging({
+          logInferenceToFile,
+          stepIndex,
+          modelId: this.modelName,
+          callPayload: { inputItems, previousResponseId },
+          executeStep: () =>
+            this.executeStep(inputItems, previousResponseId, logger),
+        });
         totalInputTokens += result.usage.input_tokens;
         totalOutputTokens += result.usage.output_tokens;
         totalInferenceTime += result.usage.inference_time_ms;

--- a/packages/core/lib/v3/agent/utils/agentInferenceLogger.ts
+++ b/packages/core/lib/v3/agent/utils/agentInferenceLogger.ts
@@ -40,8 +40,8 @@ function isImageKey(key: string): boolean {
 }
 
 function isLikelyBase64Image(value: string): boolean {
-  if (value.length < 1024) return false;
   if (value.startsWith("data:image/")) return true;
+  if (value.length < 1024) return false;
   if (!/^[A-Za-z0-9+/=\s]+$/.test(value.slice(0, 512))) return false;
   return value.length >= 4096;
 }
@@ -363,9 +363,13 @@ export function mapCuaStepUsage(usage?: {
     completion_tokens: usage?.output_tokens ?? 0,
     reasoning_tokens: usage?.reasoning_tokens ?? 0,
     cached_input_tokens: usage?.cached_input_tokens ?? 0,
-    inference_time_ms: usage?.inference_time_ms ?? 0,
+    inference_time_ms: usage?.inference_time_ms,
   };
 }
+
+export type CuaStepInferenceContext = {
+  logCall: (payload: unknown) => void;
+};
 
 export interface CuaStepInferenceResult {
   actions: unknown[];
@@ -390,22 +394,31 @@ export async function runCuaStepWithInferenceLogging<
   logInferenceToFile: boolean;
   stepIndex: number;
   modelId: string;
-  callPayload: unknown;
-  executeStep: () => Promise<T>;
+  callPayload?: unknown;
+  executeStep: (ctx?: CuaStepInferenceContext) => Promise<T>;
   mapResponse?: (result: T) => Record<string, unknown>;
 }): Promise<T> {
-  const pendingCall = opts.logInferenceToFile
-    ? logAgentStepCall({
-        stepIndex: opts.stepIndex,
-        payload: {
-          modelId: opts.modelId,
-          request: opts.callPayload,
-        },
-      })
-    : null;
+  let pendingCall: AgentStepCallRecord | null = null;
+
+  const logCall = (payload: unknown) => {
+    if (!opts.logInferenceToFile || pendingCall) return;
+    pendingCall = logAgentStepCall({
+      stepIndex: opts.stepIndex,
+      payload: {
+        modelId: opts.modelId,
+        request: payload,
+      },
+    });
+  };
+
+  if (opts.logInferenceToFile && opts.callPayload !== undefined) {
+    logCall(opts.callPayload);
+  }
+
+  const ctx = opts.logInferenceToFile ? { logCall } : undefined;
 
   try {
-    const result = await opts.executeStep();
+    const result = await opts.executeStep(ctx);
 
     if (pendingCall) {
       const response = opts.mapResponse

--- a/packages/core/lib/v3/agent/utils/agentInferenceLogger.ts
+++ b/packages/core/lib/v3/agent/utils/agentInferenceLogger.ts
@@ -34,11 +34,24 @@ function isImageKey(key: string): boolean {
     normalized.includes("screenshot") ||
     normalized === "base64" ||
     normalized === "inline_data" ||
+    normalized === "inlinedata" ||
     normalized === "imagedata" ||
     normalized === "image_url"
   );
 }
 
+function looksLikeBase64Payload(value: string): boolean {
+  if (value.startsWith("data:image/")) return true;
+  if (value.length < 256) return false;
+  return /^[A-Za-z0-9+/=\s]+$/.test(value.slice(0, 512));
+}
+
+/** Redact base64 image blobs in provider `data` fields (e.g. Gemini inlineData.data). */
+function isLikelyBase64ImageData(value: string): boolean {
+  return looksLikeBase64Payload(value);
+}
+
+/** Redact large base64 blobs in unkeyed / generic string fields. */
 function isLikelyBase64Image(value: string): boolean {
   if (value.startsWith("data:image/")) return true;
   if (value.length < 1024) return false;
@@ -52,7 +65,7 @@ function omitImagePayload(value: string): string {
 
 function shouldOmitString(value: string, key: string): boolean {
   if (isImageKey(key)) return true;
-  if (key.toLowerCase() === "data" && isLikelyBase64Image(value)) return true;
+  if (key.toLowerCase() === "data") return isLikelyBase64ImageData(value);
   return isLikelyBase64Image(value);
 }
 
@@ -316,6 +329,7 @@ export function finalizePendingAgentSteps(
   pendingCalls: Map<number, AgentStepCallRecord>,
   reason: string,
   agentInferenceType = "agent_step",
+  finalizedSteps?: Set<number>,
 ): void {
   for (const [stepIndex, call] of pendingCalls.entries()) {
     failAgentStepInference({
@@ -324,6 +338,7 @@ export function finalizePendingAgentSteps(
       error: reason,
       agentInferenceType,
     });
+    finalizedSteps?.add(stepIndex);
   }
   pendingCalls.clear();
 }
@@ -451,7 +466,7 @@ export async function runCuaStepWithInferenceLogging<
   try {
     const result = await opts.executeStep(ctx);
 
-    if (pendingCall) {
+    if (opts.logInferenceToFile) {
       const response = opts.mapResponse
         ? opts.mapResponse(result)
         : {
@@ -460,17 +475,28 @@ export async function runCuaStepWithInferenceLogging<
             completed: result.completed,
             ...(result.responseId ? { responseId: result.responseId } : {}),
           };
+      const responsePayload = {
+        modelId: opts.modelId,
+        response,
+      };
+      const usage = mapCuaStepUsage(result.usage);
 
-      completeAgentStepInference({
-        stepIndex: opts.stepIndex,
-        call: pendingCall,
-        responsePayload: {
-          modelId: opts.modelId,
-          response,
-        },
-        usage: mapCuaStepUsage(result.usage),
-        agentInferenceType: "agent_cua_step",
-      });
+      if (pendingCall) {
+        completeAgentStepInference({
+          stepIndex: opts.stepIndex,
+          call: pendingCall,
+          responsePayload,
+          usage,
+          agentInferenceType: "agent_cua_step",
+        });
+      } else {
+        completeAgentStepInferenceWithoutCall({
+          stepIndex: opts.stepIndex,
+          responsePayload,
+          usage,
+          agentInferenceType: "agent_cua_step",
+        });
+      }
     }
 
     return result;
@@ -480,6 +506,15 @@ export async function runCuaStepWithInferenceLogging<
         stepIndex: opts.stepIndex,
         call: pendingCall,
         error,
+        agentInferenceType: "agent_cua_step",
+      });
+    } else if (opts.logInferenceToFile) {
+      completeAgentStepInferenceWithoutCall({
+        stepIndex: opts.stepIndex,
+        responsePayload: {
+          status: "failed",
+          error: error instanceof Error ? error.message : String(error),
+        },
         agentInferenceType: "agent_cua_step",
       });
     }

--- a/packages/core/lib/v3/agent/utils/agentInferenceLogger.ts
+++ b/packages/core/lib/v3/agent/utils/agentInferenceLogger.ts
@@ -249,6 +249,8 @@ export function completeAgentStepInferenceWithoutCall(opts: {
   responsePayload: unknown;
   usage?: AgentInferenceUsage;
   agentInferenceType?: string;
+  status?: "completed" | "failed";
+  error?: string;
 }): void {
   const response = logAgentStepResponse({
     stepIndex: opts.stepIndex,
@@ -263,6 +265,8 @@ export function completeAgentStepInferenceWithoutCall(opts: {
     timestamp: response.timestamp,
     usage: opts.usage,
     agentInferenceType: opts.agentInferenceType,
+    status: opts.status,
+    error: opts.error,
   });
 }
 
@@ -509,13 +513,16 @@ export async function runCuaStepWithInferenceLogging<
         agentInferenceType: "agent_cua_step",
       });
     } else if (opts.logInferenceToFile) {
+      const message = error instanceof Error ? error.message : String(error);
       completeAgentStepInferenceWithoutCall({
         stepIndex: opts.stepIndex,
         responsePayload: {
           status: "failed",
-          error: error instanceof Error ? error.message : String(error),
+          error: message,
         },
         agentInferenceType: "agent_cua_step",
+        status: "failed",
+        error: message,
       });
     }
     throw error;

--- a/packages/core/lib/v3/agent/utils/agentInferenceLogger.ts
+++ b/packages/core/lib/v3/agent/utils/agentInferenceLogger.ts
@@ -128,11 +128,12 @@ function tryWriteAgentFile(
   payload: unknown,
 ): { fileName: string; timestamp: string } | null {
   try {
-    return writeTimestampedTxtFile(
+    const written = writeTimestampedTxtFile(
       AGENT_SUMMARY_DIR,
       prefix,
       sanitizeForInferenceLog(payload),
     );
+    return written ?? null;
   } catch {
     return null;
   }
@@ -144,6 +145,10 @@ function tryAppendSummary(entry: Record<string, unknown>): void {
   } catch {
     // Inference logging must never fail the agent run.
   }
+}
+
+export function getCuaRunStartTools(extraToolNames?: string[]): string[] {
+  return ["computer_use", ...(extraToolNames ?? [])];
 }
 
 export function logAgentRunStart(opts: {
@@ -219,6 +224,32 @@ export function logAgentStepSummary(opts: {
     reasoning_tokens: opts.usage?.reasoning_tokens ?? 0,
     cached_input_tokens: opts.usage?.cached_input_tokens ?? 0,
     inference_time_ms: opts.usage?.inference_time_ms ?? 0,
+  });
+}
+
+/**
+ * Records a step response when the call file could not be written.
+ * Keeps per-step summaries aligned with AI SDK step numbers.
+ */
+export function completeAgentStepInferenceWithoutCall(opts: {
+  stepIndex: number;
+  responsePayload: unknown;
+  usage?: AgentInferenceUsage;
+  agentInferenceType?: string;
+}): void {
+  const response = logAgentStepResponse({
+    stepIndex: opts.stepIndex,
+    payload: opts.responsePayload,
+  });
+  if (!response) return;
+
+  logAgentStepSummary({
+    stepIndex: opts.stepIndex,
+    callFile: "(call file unavailable)",
+    responseFile: response.fileName,
+    timestamp: response.timestamp,
+    usage: opts.usage,
+    agentInferenceType: opts.agentInferenceType,
   });
 }
 

--- a/packages/core/lib/v3/agent/utils/agentInferenceLogger.ts
+++ b/packages/core/lib/v3/agent/utils/agentInferenceLogger.ts
@@ -1,0 +1,444 @@
+import {
+  appendSummary,
+  writeTimestampedTxtFile,
+} from "../../../inferenceLogUtils.js";
+
+const AGENT_SUMMARY_DIR = "agent_summary";
+
+export interface AgentInferenceUsage {
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  reasoning_tokens?: number;
+  cached_input_tokens?: number;
+  inference_time_ms?: number;
+}
+
+export interface AgentStepCallRecord {
+  fileName: string;
+  timestamp: string;
+  startedAtMs: number;
+}
+
+function dataToKb(data: string): string {
+  return ((data.length * 0.75) / 1024).toFixed(1);
+}
+
+type SanitizeContext = {
+  parentKey?: string;
+};
+
+function isImageKey(key: string): boolean {
+  const normalized = key.toLowerCase();
+  return (
+    normalized.includes("image") ||
+    normalized.includes("screenshot") ||
+    normalized === "base64" ||
+    normalized === "inline_data" ||
+    normalized === "imagedata" ||
+    normalized === "image_url"
+  );
+}
+
+function isLikelyBase64Image(value: string): boolean {
+  if (value.length < 1024) return false;
+  if (value.startsWith("data:image/")) return true;
+  if (!/^[A-Za-z0-9+/=\s]+$/.test(value.slice(0, 512))) return false;
+  return value.length >= 4096;
+}
+
+function omitImagePayload(value: string): string {
+  return `[image omitted, ${dataToKb(value)}kb]`;
+}
+
+function shouldOmitString(value: string, key: string): boolean {
+  if (isImageKey(key)) return true;
+  if (key.toLowerCase() === "data" && isLikelyBase64Image(value)) return true;
+  return isLikelyBase64Image(value);
+}
+
+function sanitizeUnknownObject(value: object): unknown {
+  if (value instanceof Date) return value.toISOString();
+  if (typeof Buffer !== "undefined" && Buffer.isBuffer(value)) {
+    return `[binary omitted, ${dataToKb(value.toString("base64"))}kb]`;
+  }
+  if (ArrayBuffer.isView(value)) {
+    return `[binary omitted, ${value.byteLength} bytes]`;
+  }
+
+  try {
+    return sanitizeForInferenceLog(JSON.parse(JSON.stringify(value)));
+  } catch {
+    return `[object omitted, ${value.constructor?.name ?? "Object"}]`;
+  }
+}
+
+/**
+ * Deep-clone and redact large binary/image payloads before writing inference logs.
+ *
+ * Complements `redactInlineImagePayloads` in evidenceNormalization.ts, which
+ * targets verifier/evidence output with a fixed key list. This helper is tuned
+ * for inference file dumps: heuristic base64 detection and size markers.
+ */
+export function sanitizeForInferenceLog(
+  data: unknown,
+  context: SanitizeContext = {},
+): unknown {
+  if (data === null || data === undefined) return data;
+
+  if (typeof data === "string") {
+    const key = context.parentKey ?? "";
+    if (shouldOmitString(data, key)) {
+      return omitImagePayload(data);
+    }
+    return data;
+  }
+
+  if (Array.isArray(data)) {
+    return data.map((item) => sanitizeForInferenceLog(item, context));
+  }
+
+  if (typeof data === "object") {
+    const proto = Object.getPrototypeOf(data);
+    if (proto !== Object.prototype && proto !== null) {
+      return sanitizeUnknownObject(data);
+    }
+
+    const out: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(
+      data as Record<string, unknown>,
+    )) {
+      if (
+        key === "type" &&
+        typeof value === "string" &&
+        (value === "image" || value === "input_image" || value === "image_url")
+      ) {
+        out[key] = value;
+        continue;
+      }
+      out[key] = sanitizeForInferenceLog(value, { parentKey: key });
+    }
+    return out;
+  }
+
+  return data;
+}
+
+function tryWriteAgentFile(
+  prefix: string,
+  payload: unknown,
+): { fileName: string; timestamp: string } | null {
+  try {
+    return writeTimestampedTxtFile(
+      AGENT_SUMMARY_DIR,
+      prefix,
+      sanitizeForInferenceLog(payload),
+    );
+  } catch {
+    return null;
+  }
+}
+
+function tryAppendSummary(entry: Record<string, unknown>): void {
+  try {
+    appendSummary("agent", entry);
+  } catch {
+    // Inference logging must never fail the agent run.
+  }
+}
+
+export function logAgentRunStart(opts: {
+  instruction: string;
+  mode?: string;
+  modelId: string;
+  tools: string[];
+  agentType?: "dom" | "cua";
+}): void {
+  tryWriteAgentFile("agent_run_start", {
+    modelCall: "agent",
+    agentType: opts.agentType ?? "dom",
+    instruction: opts.instruction,
+    mode: opts.mode,
+    modelId: opts.modelId,
+    tools: opts.tools,
+  });
+}
+
+export function logAgentStepCall(opts: {
+  stepIndex: number;
+  payload: unknown;
+}): AgentStepCallRecord | null {
+  const written = tryWriteAgentFile(`agent_step_${opts.stepIndex}_call`, {
+    modelCall: "agent",
+    step: opts.stepIndex,
+    ...((typeof opts.payload === "object" && opts.payload !== null
+      ? opts.payload
+      : { payload: opts.payload }) as Record<string, unknown>),
+  });
+  if (!written) return null;
+
+  return {
+    fileName: written.fileName,
+    timestamp: written.timestamp,
+    startedAtMs: Date.now(),
+  };
+}
+
+export function logAgentStepResponse(opts: {
+  stepIndex: number;
+  payload: unknown;
+}): { fileName: string; timestamp: string } | null {
+  return tryWriteAgentFile(`agent_step_${opts.stepIndex}_response`, {
+    modelResponse: "agent",
+    step: opts.stepIndex,
+    ...((typeof opts.payload === "object" && opts.payload !== null
+      ? opts.payload
+      : { payload: opts.payload }) as Record<string, unknown>),
+  });
+}
+
+export function logAgentStepSummary(opts: {
+  stepIndex: number;
+  callFile: string;
+  responseFile: string;
+  timestamp: string;
+  usage?: AgentInferenceUsage;
+  agentInferenceType?: string;
+  status?: "completed" | "failed";
+  error?: string;
+}): void {
+  tryAppendSummary({
+    agent_inference_type: opts.agentInferenceType ?? "agent_step",
+    step: opts.stepIndex,
+    timestamp: opts.timestamp,
+    LLM_input_file: opts.callFile,
+    LLM_output_file: opts.responseFile,
+    status: opts.status ?? "completed",
+    ...(opts.error ? { error: opts.error } : {}),
+    prompt_tokens: opts.usage?.prompt_tokens ?? 0,
+    completion_tokens: opts.usage?.completion_tokens ?? 0,
+    reasoning_tokens: opts.usage?.reasoning_tokens ?? 0,
+    cached_input_tokens: opts.usage?.cached_input_tokens ?? 0,
+    inference_time_ms: opts.usage?.inference_time_ms ?? 0,
+  });
+}
+
+export function completeAgentStepInference(opts: {
+  stepIndex: number;
+  call: AgentStepCallRecord;
+  responsePayload: unknown;
+  usage?: AgentInferenceUsage;
+  agentInferenceType?: string;
+}): void {
+  const response = logAgentStepResponse({
+    stepIndex: opts.stepIndex,
+    payload: opts.responsePayload,
+  });
+  if (!response) return;
+
+  logAgentStepSummary({
+    stepIndex: opts.stepIndex,
+    callFile: opts.call.fileName,
+    responseFile: response.fileName,
+    timestamp: opts.call.timestamp,
+    usage: {
+      ...opts.usage,
+      inference_time_ms:
+        opts.usage?.inference_time_ms ??
+        Math.max(0, Date.now() - opts.call.startedAtMs),
+    },
+    agentInferenceType: opts.agentInferenceType,
+  });
+}
+
+export function failAgentStepInference(opts: {
+  stepIndex: number;
+  call: AgentStepCallRecord;
+  error: unknown;
+  agentInferenceType?: string;
+}): void {
+  const message =
+    opts.error instanceof Error ? opts.error.message : String(opts.error);
+  const response = logAgentStepResponse({
+    stepIndex: opts.stepIndex,
+    payload: {
+      status: "failed",
+      error: message,
+    },
+  });
+  if (!response) return;
+
+  logAgentStepSummary({
+    stepIndex: opts.stepIndex,
+    callFile: opts.call.fileName,
+    responseFile: response.fileName,
+    timestamp: opts.call.timestamp,
+    agentInferenceType: opts.agentInferenceType,
+    status: "failed",
+    error: message,
+    usage: {
+      inference_time_ms: Math.max(0, Date.now() - opts.call.startedAtMs),
+    },
+  });
+}
+
+export function finalizePendingAgentSteps(
+  pendingCalls: Map<number, AgentStepCallRecord>,
+  reason: string,
+  agentInferenceType = "agent_step",
+): void {
+  for (const [stepIndex, call] of pendingCalls.entries()) {
+    failAgentStepInference({
+      stepIndex,
+      call,
+      error: reason,
+      agentInferenceType,
+    });
+  }
+  pendingCalls.clear();
+}
+
+export function logAgentDoneInference(opts: {
+  callPayload: unknown;
+  responsePayload: unknown;
+  usage?: AgentInferenceUsage;
+}): void {
+  const call = tryWriteAgentFile("agent_done_call", {
+    modelCall: "agent_done",
+    ...(typeof opts.callPayload === "object" && opts.callPayload !== null
+      ? opts.callPayload
+      : { payload: opts.callPayload }),
+  });
+  if (!call) return;
+
+  const response = tryWriteAgentFile("agent_done_response", {
+    modelResponse: "agent_done",
+    ...(typeof opts.responsePayload === "object" &&
+    opts.responsePayload !== null
+      ? opts.responsePayload
+      : { payload: opts.responsePayload }),
+  });
+  if (!response) return;
+
+  tryAppendSummary({
+    agent_inference_type: "agent_done",
+    timestamp: call.timestamp,
+    LLM_input_file: call.fileName,
+    LLM_output_file: response.fileName,
+    status: "completed",
+    prompt_tokens: opts.usage?.prompt_tokens ?? 0,
+    completion_tokens: opts.usage?.completion_tokens ?? 0,
+    reasoning_tokens: opts.usage?.reasoning_tokens ?? 0,
+    cached_input_tokens: opts.usage?.cached_input_tokens ?? 0,
+    inference_time_ms: opts.usage?.inference_time_ms ?? 0,
+  });
+}
+
+export function mapAiSdkStepUsage(
+  usage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    reasoningTokens?: number;
+    cachedInputTokens?: number;
+  },
+  inferenceTimeMs?: number,
+): AgentInferenceUsage {
+  return {
+    prompt_tokens: usage?.inputTokens ?? 0,
+    completion_tokens: usage?.outputTokens ?? 0,
+    reasoning_tokens: usage?.reasoningTokens ?? 0,
+    cached_input_tokens: usage?.cachedInputTokens ?? 0,
+    inference_time_ms: inferenceTimeMs,
+  };
+}
+
+export function mapCuaStepUsage(usage?: {
+  input_tokens?: number;
+  output_tokens?: number;
+  reasoning_tokens?: number;
+  cached_input_tokens?: number;
+  inference_time_ms?: number;
+}): AgentInferenceUsage {
+  return {
+    prompt_tokens: usage?.input_tokens ?? 0,
+    completion_tokens: usage?.output_tokens ?? 0,
+    reasoning_tokens: usage?.reasoning_tokens ?? 0,
+    cached_input_tokens: usage?.cached_input_tokens ?? 0,
+    inference_time_ms: usage?.inference_time_ms ?? 0,
+  };
+}
+
+export interface CuaStepInferenceResult {
+  actions: unknown[];
+  message?: string;
+  completed: boolean;
+  responseId?: string;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    reasoning_tokens?: number;
+    cached_input_tokens?: number;
+    inference_time_ms?: number;
+  };
+}
+
+/**
+ * Runs a CUA executeStep with optional per-step inference file logging.
+ */
+export async function runCuaStepWithInferenceLogging<
+  T extends CuaStepInferenceResult,
+>(opts: {
+  logInferenceToFile: boolean;
+  stepIndex: number;
+  modelId: string;
+  callPayload: unknown;
+  executeStep: () => Promise<T>;
+  mapResponse?: (result: T) => Record<string, unknown>;
+}): Promise<T> {
+  const pendingCall = opts.logInferenceToFile
+    ? logAgentStepCall({
+        stepIndex: opts.stepIndex,
+        payload: {
+          modelId: opts.modelId,
+          request: opts.callPayload,
+        },
+      })
+    : null;
+
+  try {
+    const result = await opts.executeStep();
+
+    if (pendingCall) {
+      const response = opts.mapResponse
+        ? opts.mapResponse(result)
+        : {
+            actions: result.actions,
+            message: result.message,
+            completed: result.completed,
+            ...(result.responseId ? { responseId: result.responseId } : {}),
+          };
+
+      completeAgentStepInference({
+        stepIndex: opts.stepIndex,
+        call: pendingCall,
+        responsePayload: {
+          modelId: opts.modelId,
+          response,
+        },
+        usage: mapCuaStepUsage(result.usage),
+        agentInferenceType: "agent_cua_step",
+      });
+    }
+
+    return result;
+  } catch (error) {
+    if (pendingCall) {
+      failAgentStepInference({
+        stepIndex: opts.stepIndex,
+        call: pendingCall,
+        error,
+        agentInferenceType: "agent_cua_step",
+      });
+    }
+    throw error;
+  }
+}

--- a/packages/core/lib/v3/agent/utils/handleDoneToolCall.ts
+++ b/packages/core/lib/v3/agent/utils/handleDoneToolCall.ts
@@ -161,17 +161,14 @@ Call the "done" tool with:
   const modelId = typeof model === "string" ? model : model.modelId;
   const fallbacks = anthropicFallbacksOptions(modelId);
 
-  // Models whose always-on thinking rejects forced tool use go straight to
-  // "auto" — the prompt already instructs calling "done", and the
-  // no-tool-call case below handles a plain-text answer.
-  const callPayload = {
+  const buildCallPayload = () => ({
     system: systemPrompt,
     messages: sanitizeForInferenceLog([
       ...sanitizeMessagesForResubmission(inputMessages),
       userPrompt,
     ]),
     toolChoice: rejectsForcedToolUse(modelId) ? "auto" : "done",
-  };
+  });
 
   const doneStart = Date.now();
   const result = await generateText({
@@ -200,7 +197,7 @@ Call the "done" tool with:
   if (!doneToolCall) {
     if (logInferenceToFile) {
       logAgentDoneInference({
-        callPayload,
+        callPayload: buildCallPayload(),
         responsePayload: {
           text: result.text,
           taskComplete: false,
@@ -231,7 +228,7 @@ Call the "done" tool with:
 
   if (logInferenceToFile) {
     logAgentDoneInference({
-      callPayload,
+      callPayload: buildCallPayload(),
       responsePayload: {
         reasoning: input.reasoning,
         taskComplete: input.taskComplete,

--- a/packages/core/lib/v3/agent/utils/handleDoneToolCall.ts
+++ b/packages/core/lib/v3/agent/utils/handleDoneToolCall.ts
@@ -12,7 +12,6 @@ import type { StagehandZodSchema } from "../../zodCompat.js";
 import {
   logAgentDoneInference,
   mapAiSdkStepUsage,
-  sanitizeForInferenceLog,
 } from "./agentInferenceLogger.js";
 
 interface DoneResult {
@@ -163,10 +162,7 @@ Call the "done" tool with:
 
   const buildCallPayload = () => ({
     system: systemPrompt,
-    messages: sanitizeForInferenceLog([
-      ...sanitizeMessagesForResubmission(inputMessages),
-      userPrompt,
-    ]),
+    messages: [...sanitizeMessagesForResubmission(inputMessages), userPrompt],
     toolChoice: rejectsForcedToolUse(modelId) ? "auto" : "done",
   });
 

--- a/packages/core/lib/v3/agent/utils/handleDoneToolCall.ts
+++ b/packages/core/lib/v3/agent/utils/handleDoneToolCall.ts
@@ -9,6 +9,11 @@ import {
 import { StagehandZodObject } from "../../zodCompat.js";
 import { getZFactory } from "../../../utils.js";
 import type { StagehandZodSchema } from "../../zodCompat.js";
+import {
+  logAgentDoneInference,
+  mapAiSdkStepUsage,
+  sanitizeForInferenceLog,
+} from "./agentInferenceLogger.js";
 
 interface DoneResult {
   reasoning: string;
@@ -79,8 +84,16 @@ export async function handleDoneToolCall(options: {
   instruction: string;
   outputSchema?: StagehandZodObject;
   logger: (message: LogLine) => void;
+  logInferenceToFile?: boolean;
 }): Promise<DoneResult> {
-  const { model, inputMessages, instruction, outputSchema, logger } = options;
+  const {
+    model,
+    inputMessages,
+    instruction,
+    outputSchema,
+    logger,
+    logInferenceToFile = false,
+  } = options;
 
   logger({
     category: "agent",
@@ -151,6 +164,16 @@ Call the "done" tool with:
   // Models whose always-on thinking rejects forced tool use go straight to
   // "auto" — the prompt already instructs calling "done", and the
   // no-tool-call case below handles a plain-text answer.
+  const callPayload = {
+    system: systemPrompt,
+    messages: sanitizeForInferenceLog([
+      ...sanitizeMessagesForResubmission(inputMessages),
+      userPrompt,
+    ]),
+    toolChoice: rejectsForcedToolUse(modelId) ? "auto" : "done",
+  };
+
+  const doneStart = Date.now();
   const result = await generateText({
     model,
     system: systemPrompt,
@@ -166,6 +189,8 @@ Call the "done" tool with:
     },
   });
 
+  const doneInferenceTimeMs = Date.now() - doneStart;
+
   const doneToolCall = result.toolCalls?.find((tc) => tc.toolName === "done");
   const outputMessages: ModelMessage[] = [
     userPrompt,
@@ -173,6 +198,19 @@ Call the "done" tool with:
   ];
 
   if (!doneToolCall) {
+    if (logInferenceToFile) {
+      logAgentDoneInference({
+        callPayload,
+        responsePayload: {
+          text: result.text,
+          taskComplete: false,
+        },
+        usage: {
+          ...mapAiSdkStepUsage(result.usage),
+          inference_time_ms: doneInferenceTimeMs,
+        },
+      });
+    }
     return {
       reasoning: result.text || "Task execution completed",
       taskComplete: false,
@@ -190,6 +228,21 @@ Call the "done" tool with:
     message: `Task completed`,
     level: 1,
   });
+
+  if (logInferenceToFile) {
+    logAgentDoneInference({
+      callPayload,
+      responsePayload: {
+        reasoning: input.reasoning,
+        taskComplete: input.taskComplete,
+        output: input.output,
+      },
+      usage: {
+        ...mapAiSdkStepUsage(result.usage),
+        inference_time_ms: doneInferenceTimeMs,
+      },
+    });
+  }
 
   return {
     reasoning: input.reasoning,

--- a/packages/core/lib/v3/agent/utils/handleDoneToolCall.ts
+++ b/packages/core/lib/v3/agent/utils/handleDoneToolCall.ts
@@ -170,6 +170,9 @@ Call the "done" tool with:
     toolChoice: rejectsForcedToolUse(modelId) ? "auto" : "done",
   });
 
+  // Models whose always-on thinking rejects forced tool use go straight to
+  // "auto" — the prompt already instructs calling "done", and the
+  // no-tool-call case below handles a plain-text answer.
   const doneStart = Date.now();
   const result = await generateText({
     model,

--- a/packages/core/lib/v3/handlers/v3AgentHandler.ts
+++ b/packages/core/lib/v3/handlers/v3AgentHandler.ts
@@ -61,13 +61,14 @@ import {
   logAgentRunStart,
   logAgentStepCall,
   completeAgentStepInference,
+  completeAgentStepInferenceWithoutCall,
   mapAiSdkStepUsage,
   finalizePendingAgentSteps,
   type AgentStepCallRecord,
 } from "../agent/utils/agentInferenceLogger.js";
 
 interface AgentStepInferenceState {
-  stepIndex: number;
+  currentStepIndex: number | null;
   pendingCalls: Map<number, AgentStepCallRecord>;
   systemPrompt: string;
   toolNames: string[];
@@ -323,9 +324,10 @@ export class V3AgentHandler {
           : stepInference?.toolNames;
 
       if (this.logInferenceToFile && stepInference) {
-        stepInference.stepIndex += 1;
+        const stepIndex = stepNumberForLog;
+        stepInference.currentStepIndex = stepIndex;
         const call = logAgentStepCall({
-          stepIndex: stepInference.stepIndex,
+          stepIndex,
           payload: {
             systemPrompt: systemForLog,
             messages: messagesForLog,
@@ -335,7 +337,13 @@ export class V3AgentHandler {
           },
         });
         if (call) {
-          stepInference.pendingCalls.set(stepInference.stepIndex, call);
+          stepInference.pendingCalls.set(stepIndex, call);
+        } else {
+          this.logger({
+            category: "agent",
+            message: `Failed to write agent step inference call file for step ${stepIndex}`,
+            level: 1,
+          });
         }
       }
 
@@ -433,25 +441,37 @@ export class V3AgentHandler {
       }
 
       if (this.logInferenceToFile && stepInference) {
-        const stepIndex = stepInference.stepIndex;
-        const pending = stepInference.pendingCalls.get(stepIndex);
-        if (pending) {
-          completeAgentStepInference({
-            stepIndex,
-            call: pending,
-            responsePayload: {
-              finishReason: event.finishReason,
-              text: event.text,
-              toolCalls: event.toolCalls,
-              toolResults: event.toolResults,
-              usage: event.usage,
-            },
-            usage: mapAiSdkStepUsage(
-              event.usage,
-              Math.max(0, Date.now() - pending.startedAtMs),
-            ),
-          });
-          stepInference.pendingCalls.delete(stepIndex);
+        const stepIndex = stepInference.currentStepIndex;
+        stepInference.currentStepIndex = null;
+        if (stepIndex !== null) {
+          const pending = stepInference.pendingCalls.get(stepIndex);
+          const responsePayload = {
+            finishReason: event.finishReason,
+            text: event.text,
+            toolCalls: event.toolCalls,
+            toolResults: event.toolResults,
+            usage: event.usage,
+          };
+          const usage = mapAiSdkStepUsage(
+            event.usage,
+            pending ? Math.max(0, Date.now() - pending.startedAtMs) : undefined,
+          );
+
+          if (pending) {
+            completeAgentStepInference({
+              stepIndex,
+              call: pending,
+              responsePayload,
+              usage,
+            });
+            stepInference.pendingCalls.delete(stepIndex);
+          } else {
+            completeAgentStepInferenceWithoutCall({
+              stepIndex,
+              responsePayload,
+              usage,
+            });
+          }
         }
       }
 
@@ -535,7 +555,7 @@ export class V3AgentHandler {
       );
 
       const stepInferenceState: AgentStepInferenceState = {
-        stepIndex: 0,
+        currentStepIndex: null,
         pendingCalls: new Map(),
         systemPrompt,
         toolNames: Object.keys(allTools),
@@ -728,7 +748,7 @@ export class V3AgentHandler {
     );
 
     const stepInference: AgentStepInferenceState = {
-      stepIndex: 0,
+      currentStepIndex: null,
       pendingCalls: new Map(),
       systemPrompt,
       toolNames: Object.keys(allTools),

--- a/packages/core/lib/v3/handlers/v3AgentHandler.ts
+++ b/packages/core/lib/v3/handlers/v3AgentHandler.ts
@@ -57,6 +57,22 @@ import {
   CAPTCHA_SOLVED_MSG,
   CAPTCHA_ERRORED_MSG,
 } from "../agent/utils/captchaSolver.js";
+import {
+  logAgentRunStart,
+  logAgentStepCall,
+  completeAgentStepInference,
+  mapAiSdkStepUsage,
+  finalizePendingAgentSteps,
+  type AgentStepCallRecord,
+} from "../agent/utils/agentInferenceLogger.js";
+
+interface AgentStepInferenceState {
+  stepIndex: number;
+  pendingCalls: Map<number, AgentStepCallRecord>;
+  systemPrompt: string;
+  toolNames: string[];
+  providerOptions: Record<string, unknown>;
+}
 
 function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -127,6 +143,7 @@ export class V3AgentHandler {
   private mode: AgentToolMode;
   private captchaAutoSolveEnabled: boolean;
   private thinkingEffort?: string;
+  private readonly logInferenceToFile: boolean;
 
   constructor(
     v3: V3,
@@ -138,6 +155,7 @@ export class V3AgentHandler {
     mode?: AgentToolMode,
     captchaAutoSolveEnabled?: boolean,
     thinkingEffort?: string,
+    logInferenceToFile?: boolean,
   ) {
     this.v3 = v3;
     this.logger = logger;
@@ -148,6 +166,7 @@ export class V3AgentHandler {
     this.mode = mode ?? "dom";
     this.captchaAutoSolveEnabled = captchaAutoSolveEnabled ?? false;
     this.thinkingEffort = thinkingEffort;
+    this.logInferenceToFile = logInferenceToFile ?? false;
   }
 
   private async prepareAgent(
@@ -243,6 +262,7 @@ export class V3AgentHandler {
   private createPrepareStep(
     userCallback?: PrepareStepFunction<ToolSet>,
     captchaSolver?: CaptchaSolver,
+    stepInference?: AgentStepInferenceState,
   ): PrepareStepFunction<ToolSet> {
     return async (options) => {
       processMessages(options.messages);
@@ -282,16 +302,41 @@ export class V3AgentHandler {
           });
         }
       }
-      if (userCallback) {
-        return userCallback(options);
+
+      const resolved = userCallback ? await userCallback(options) : options;
+
+      const messagesForLog =
+        "messages" in resolved && resolved.messages
+          ? resolved.messages
+          : options.messages;
+      const stepNumberForLog =
+        "stepNumber" in resolved ? resolved.stepNumber : options.stepNumber;
+
+      if (this.logInferenceToFile && stepInference) {
+        stepInference.stepIndex += 1;
+        const call = logAgentStepCall({
+          stepIndex: stepInference.stepIndex,
+          payload: {
+            systemPrompt: stepInference.systemPrompt,
+            messages: messagesForLog,
+            stepNumber: stepNumberForLog,
+            tools: stepInference.toolNames,
+            providerOptions: stepInference.providerOptions,
+          },
+        });
+        if (call) {
+          stepInference.pendingCalls.set(stepInference.stepIndex, call);
+        }
       }
-      return options;
+
+      return resolved;
     };
   }
 
   private createStepHandler(
     state: AgentState,
     { userCallback, evidenceCallback, onFinalAnswer }: StepHandlerOptions,
+    stepInference?: AgentStepInferenceState,
   ) {
     return async (event: StepResult<ToolSet>) => {
       this.logger({
@@ -377,6 +422,29 @@ export class V3AgentHandler {
         onFinalAnswer?.(lastFinalAnswer);
       }
 
+      if (this.logInferenceToFile && stepInference) {
+        const stepIndex = stepInference.stepIndex;
+        const pending = stepInference.pendingCalls.get(stepIndex);
+        if (pending) {
+          completeAgentStepInference({
+            stepIndex,
+            call: pending,
+            responsePayload: {
+              finishReason: event.finishReason,
+              text: event.text,
+              toolCalls: event.toolCalls,
+              toolResults: event.toolResults,
+              usage: event.usage,
+            },
+            usage: mapAiSdkStepUsage(
+              event.usage,
+              Math.max(0, Date.now() - pending.startedAtMs),
+            ),
+          });
+          stepInference.pendingCalls.delete(stepIndex);
+        }
+      }
+
       if (userCallback) {
         await userCallback(event);
       }
@@ -406,6 +474,7 @@ export class V3AgentHandler {
 
     let messages: ModelMessage[] = [];
     let captchaSolver: CaptchaSolver | undefined;
+    let stepInference: AgentStepInferenceState | undefined;
 
     try {
       const {
@@ -455,6 +524,28 @@ export class V3AgentHandler {
         this.logger,
       );
 
+      const stepInferenceState: AgentStepInferenceState = {
+        stepIndex: 0,
+        pendingCalls: new Map(),
+        systemPrompt,
+        toolNames: Object.keys(allTools),
+        providerOptions: buildAgentProviderOptions(
+          wrappedModel.modelId,
+          this.thinkingEffort,
+        ),
+      };
+      stepInference = stepInferenceState;
+
+      if (this.logInferenceToFile) {
+        logAgentRunStart({
+          instruction: preparedOptions.instruction,
+          mode: this.mode,
+          modelId: wrappedModel.modelId,
+          tools: Object.keys(allTools),
+          agentType: "dom",
+        });
+      }
+
       const result = await this.llmClient.generateText({
         model: wrappedModel,
         messages: prependSystemMessage(systemPrompt, messages),
@@ -465,14 +556,19 @@ export class V3AgentHandler {
         prepareStep: this.createPrepareStep(
           callbacks?.prepareStep,
           captchaSolver,
+          stepInferenceState,
         ),
-        onStepFinish: this.createStepHandler(state, {
-          userCallback: callbacks?.onStepFinish,
-          evidenceCallback,
-          onFinalAnswer: (answer) => {
-            finalAnswerFromDoneTool = answer;
+        onStepFinish: this.createStepHandler(
+          state,
+          {
+            userCallback: callbacks?.onStepFinish,
+            evidenceCallback,
+            onFinalAnswer: (answer) => {
+              finalAnswerFromDoneTool = answer;
+            },
           },
-        }),
+          stepInferenceState,
+        ),
         abortSignal: preparedOptions.signal,
         providerOptions: buildAgentProviderOptions(
           wrappedModel.modelId,
@@ -508,6 +604,13 @@ export class V3AgentHandler {
         output,
       );
     } catch (error) {
+      if (this.logInferenceToFile && stepInference) {
+        finalizePendingAgentSteps(
+          stepInference.pendingCalls,
+          getErrorMessage(error),
+        );
+      }
+
       // Re-throw validation errors that should propagate to the caller
       if (
         error instanceof StreamingCallbacksInNonStreamingModeError ||
@@ -598,6 +701,9 @@ export class V3AgentHandler {
     const handleError = (error: unknown) => {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
+      if (this.logInferenceToFile) {
+        finalizePendingAgentSteps(stepInference.pendingCalls, errorMessage);
+      }
       this.logger({
         category: "agent",
         message: `Error during streaming: ${errorMessage}`,
@@ -611,6 +717,27 @@ export class V3AgentHandler {
       this.logger,
     );
 
+    const stepInference: AgentStepInferenceState = {
+      stepIndex: 0,
+      pendingCalls: new Map(),
+      systemPrompt,
+      toolNames: Object.keys(allTools),
+      providerOptions: buildAgentProviderOptions(
+        wrappedModel.modelId,
+        this.thinkingEffort,
+      ),
+    };
+
+    if (this.logInferenceToFile) {
+      logAgentRunStart({
+        instruction: options.instruction,
+        mode: this.mode,
+        modelId: wrappedModel.modelId,
+        tools: Object.keys(allTools),
+        agentType: "dom",
+      });
+    }
+
     let streamResult: ReturnType<typeof this.llmClient.streamText>;
     try {
       streamResult = this.llmClient.streamText({
@@ -622,14 +749,19 @@ export class V3AgentHandler {
         prepareStep: this.createPrepareStep(
           callbacks?.prepareStep,
           captchaSolver,
+          stepInference,
         ),
-        onStepFinish: this.createStepHandler(state, {
-          userCallback: callbacks?.onStepFinish,
-          evidenceCallback,
-          onFinalAnswer: (answer) => {
-            finalAnswerFromDoneTool = answer;
+        onStepFinish: this.createStepHandler(
+          state,
+          {
+            userCallback: callbacks?.onStepFinish,
+            evidenceCallback,
+            onFinalAnswer: (answer) => {
+              finalAnswerFromDoneTool = answer;
+            },
           },
-        }),
+          stepInference,
+        ),
         onError: (event) => {
           captchaSolver?.dispose();
           if (callbacks?.onError) {
@@ -684,10 +816,12 @@ export class V3AgentHandler {
           if (callbacks?.onAbort) {
             callbacks.onAbort(event);
           }
-          // Reject the result promise with AgentAbortError when stream is aborted
           const reason = options.signal?.reason
             ? String(options.signal.reason)
             : "Stream was aborted";
+          if (this.logInferenceToFile) {
+            finalizePendingAgentSteps(stepInference.pendingCalls, reason);
+          }
           rejectResult(new AgentAbortError(reason));
         },
         abortSignal: options.signal,
@@ -838,7 +972,8 @@ export class V3AgentHandler {
         inputMessages: messages,
         instruction,
         outputSchema,
-        logger,
+        logger: logger ?? this.logger,
+        logInferenceToFile: this.logInferenceToFile,
       });
     } catch (error) {
       // The forced "done" call only summarizes the run, so its failure must not

--- a/packages/core/lib/v3/handlers/v3AgentHandler.ts
+++ b/packages/core/lib/v3/handlers/v3AgentHandler.ts
@@ -303,7 +303,9 @@ export class V3AgentHandler {
         }
       }
 
-      const resolved = userCallback ? await userCallback(options) : options;
+      const resolved = userCallback
+        ? ((await userCallback(options)) ?? options)
+        : options;
 
       const messagesForLog =
         "messages" in resolved && resolved.messages
@@ -311,16 +313,24 @@ export class V3AgentHandler {
           : options.messages;
       const stepNumberForLog =
         "stepNumber" in resolved ? resolved.stepNumber : options.stepNumber;
+      const systemForLog =
+        "system" in resolved && resolved.system !== undefined
+          ? resolved.system
+          : stepInference?.systemPrompt;
+      const toolsForLog =
+        "activeTools" in resolved && resolved.activeTools
+          ? resolved.activeTools
+          : stepInference?.toolNames;
 
       if (this.logInferenceToFile && stepInference) {
         stepInference.stepIndex += 1;
         const call = logAgentStepCall({
           stepIndex: stepInference.stepIndex,
           payload: {
-            systemPrompt: stepInference.systemPrompt,
+            systemPrompt: systemForLog,
             messages: messagesForLog,
             stepNumber: stepNumberForLog,
-            tools: stepInference.toolNames,
+            tools: toolsForLog,
             providerOptions: stepInference.providerOptions,
           },
         });

--- a/packages/core/lib/v3/handlers/v3AgentHandler.ts
+++ b/packages/core/lib/v3/handlers/v3AgentHandler.ts
@@ -70,9 +70,26 @@ import {
 interface AgentStepInferenceState {
   currentStepIndex: number | null;
   pendingCalls: Map<number, AgentStepCallRecord>;
+  finalizedSteps: Set<number>;
   systemPrompt: string;
   toolNames: string[];
   providerOptions: Record<string, unknown>;
+}
+
+function interruptStepInference(
+  stepInference: AgentStepInferenceState,
+  reason: string,
+): void {
+  finalizePendingAgentSteps(
+    stepInference.pendingCalls,
+    reason,
+    "agent_step",
+    stepInference.finalizedSteps,
+  );
+  if (stepInference.currentStepIndex !== null) {
+    stepInference.finalizedSteps.add(stepInference.currentStepIndex);
+    stepInference.currentStepIndex = null;
+  }
 }
 
 function getErrorMessage(error: unknown): string {
@@ -443,7 +460,10 @@ export class V3AgentHandler {
       if (this.logInferenceToFile && stepInference) {
         const stepIndex = stepInference.currentStepIndex;
         stepInference.currentStepIndex = null;
-        if (stepIndex !== null) {
+        if (
+          stepIndex !== null &&
+          !stepInference.finalizedSteps.has(stepIndex)
+        ) {
           const pending = stepInference.pendingCalls.get(stepIndex);
           const responsePayload = {
             finishReason: event.finishReason,
@@ -472,6 +492,7 @@ export class V3AgentHandler {
               usage,
             });
           }
+          stepInference.finalizedSteps.add(stepIndex);
         }
       }
 
@@ -557,6 +578,7 @@ export class V3AgentHandler {
       const stepInferenceState: AgentStepInferenceState = {
         currentStepIndex: null,
         pendingCalls: new Map(),
+        finalizedSteps: new Set(),
         systemPrompt,
         toolNames: Object.keys(allTools),
         providerOptions: buildAgentProviderOptions(
@@ -635,10 +657,7 @@ export class V3AgentHandler {
       );
     } catch (error) {
       if (this.logInferenceToFile && stepInference) {
-        finalizePendingAgentSteps(
-          stepInference.pendingCalls,
-          getErrorMessage(error),
-        );
+        interruptStepInference(stepInference, getErrorMessage(error));
       }
 
       // Re-throw validation errors that should propagate to the caller
@@ -732,7 +751,7 @@ export class V3AgentHandler {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
       if (this.logInferenceToFile) {
-        finalizePendingAgentSteps(stepInference.pendingCalls, errorMessage);
+        interruptStepInference(stepInference, errorMessage);
       }
       this.logger({
         category: "agent",
@@ -750,6 +769,7 @@ export class V3AgentHandler {
     const stepInference: AgentStepInferenceState = {
       currentStepIndex: null,
       pendingCalls: new Map(),
+      finalizedSteps: new Set(),
       systemPrompt,
       toolNames: Object.keys(allTools),
       providerOptions: buildAgentProviderOptions(
@@ -850,7 +870,7 @@ export class V3AgentHandler {
             ? String(options.signal.reason)
             : "Stream was aborted";
           if (this.logInferenceToFile) {
-            finalizePendingAgentSteps(stepInference.pendingCalls, reason);
+            interruptStepInference(stepInference, reason);
           }
           rejectResult(new AgentAbortError(reason));
         },

--- a/packages/core/lib/v3/handlers/v3CuaAgentHandler.ts
+++ b/packages/core/lib/v3/handlers/v3CuaAgentHandler.ts
@@ -290,7 +290,11 @@ export class V3CuaAgentHandler {
     const start = Date.now();
     let result: AgentResult;
     try {
-      result = await this.agent.execute({ options, logger: this.logger });
+      result = await this.agent.execute({
+        options,
+        logger: this.logger,
+        logInferenceToFile: this.v3.logInferenceToFile,
+      });
       if (this.evidenceCallback) {
         let finalUrl = "";
         try {

--- a/packages/core/lib/v3/types/public/agent.ts
+++ b/packages/core/lib/v3/types/public/agent.ts
@@ -484,6 +484,7 @@ export interface AgentExecutionOptions<
   options: TOptions;
   logger: (message: LogLine) => void;
   retries?: number;
+  logInferenceToFile?: boolean;
 }
 
 export interface AgentHandlerOptions {

--- a/packages/core/lib/v3/v3.ts
+++ b/packages/core/lib/v3/v3.ts
@@ -1875,6 +1875,7 @@ export class V3 {
       resolvedMode,
       this.isCaptchaAutoSolveEnabled,
       agentThinkingEffort,
+      this.logInferenceToFile,
     );
 
     const resolvedOptions: AgentExecuteOptions | AgentStreamExecuteOptions =

--- a/packages/core/tests/unit/agent-inference-logger.test.ts
+++ b/packages/core/tests/unit/agent-inference-logger.test.ts
@@ -85,6 +85,20 @@ describe("agentInferenceLogger", () => {
     expect(sanitized.data).toBe(hash);
   });
 
+  it("sanitizes medium-sized Gemini inlineData.data payloads", () => {
+    const inlineData = {
+      inlineData: {
+        mimeType: "image/png",
+        data: "A".repeat(2000),
+      },
+    };
+    const sanitized = sanitizeForInferenceLog(inlineData) as {
+      inlineData: { mimeType: string; data: string };
+    };
+    expect(sanitized.inlineData.mimeType).toBe("image/png");
+    expect(sanitized.inlineData.data).toContain("[image omitted");
+  });
+
   it("writes run start files under agent_summary", () => {
     logAgentRunStart({
       instruction: "click login",
@@ -255,14 +269,16 @@ describe("agentInferenceLogger", () => {
     });
 
     const pending = new Map();
+    const finalizedSteps = new Set<number>();
     const call1 = logAgentStepCall({ stepIndex: 1, payload: {} });
     const call2 = logAgentStepCall({ stepIndex: 2, payload: {} });
     pending.set(1, call1);
     pending.set(2, call2);
 
-    finalizePendingAgentSteps(pending, "aborted");
+    finalizePendingAgentSteps(pending, "aborted", "agent_step", finalizedSteps);
 
     expect(pending.size).toBe(0);
+    expect(finalizedSteps).toEqual(new Set([1, 2]));
     expect(appendSummary).toHaveBeenCalledTimes(2);
     expect(appendSummary).toHaveBeenCalledWith(
       "agent",
@@ -363,6 +379,45 @@ describe("agentInferenceLogger", () => {
       expect.objectContaining({
         agent_inference_type: "agent_cua_step",
         step: 1,
+      }),
+    );
+  });
+
+  it("records CUA step responses when call file write fails", async () => {
+    (writeTimestampedTxtFile as ReturnType<typeof vi.fn>).mockImplementation(
+      (_directory: string, prefix: string) => {
+        if (prefix.includes("_call")) {
+          return null;
+        }
+        return {
+          fileName: "response.txt",
+          timestamp: "20250705_120009",
+        };
+      },
+    );
+
+    await runCuaStepWithInferenceLogging({
+      logInferenceToFile: true,
+      stepIndex: 7,
+      modelId: "openai/computer-use-preview",
+      executeStep: async (ctx) => {
+        ctx?.logCall({ requestParams: { model: "test" } });
+        return {
+          actions: [{ type: "click" }],
+          message: "clicked",
+          completed: false,
+          usage: { input_tokens: 2, output_tokens: 1, inference_time_ms: 5 },
+        };
+      },
+    });
+
+    expect(appendSummary).toHaveBeenCalledWith(
+      "agent",
+      expect.objectContaining({
+        agent_inference_type: "agent_cua_step",
+        step: 7,
+        LLM_input_file: "(call file unavailable)",
+        LLM_output_file: "response.txt",
       }),
     );
   });

--- a/packages/core/tests/unit/agent-inference-logger.test.ts
+++ b/packages/core/tests/unit/agent-inference-logger.test.ts
@@ -29,8 +29,8 @@ import {
 
 describe("agentInferenceLogger", () => {
   beforeEach(() => {
-    writeTimestampedTxtFile.mockClear();
-    appendSummary.mockClear();
+    writeTimestampedTxtFile.mockReset();
+    appendSummary.mockReset();
     writeTimestampedTxtFile.mockReturnValue({
       fileName: "20250705_120000_agent_step_1_call.txt",
       timestamp: "20250705_120000",
@@ -418,6 +418,43 @@ describe("agentInferenceLogger", () => {
         step: 7,
         LLM_input_file: "(call file unavailable)",
         LLM_output_file: "response.txt",
+      }),
+    );
+  });
+
+  it("records failed CUA steps with failed status when call file write fails", async () => {
+    (writeTimestampedTxtFile as ReturnType<typeof vi.fn>).mockImplementation(
+      (_directory: string, prefix: string) => {
+        if (prefix.includes("_call")) {
+          return null;
+        }
+        return {
+          fileName: "response.txt",
+          timestamp: "20250705_120010",
+        };
+      },
+    );
+
+    await expect(
+      runCuaStepWithInferenceLogging({
+        logInferenceToFile: true,
+        stepIndex: 8,
+        modelId: "openai/computer-use-preview",
+        executeStep: async (ctx) => {
+          ctx?.logCall({ requestParams: { model: "test" } });
+          throw new Error("provider timeout");
+        },
+      }),
+    ).rejects.toThrow("provider timeout");
+
+    expect(appendSummary).toHaveBeenCalledWith(
+      "agent",
+      expect.objectContaining({
+        agent_inference_type: "agent_cua_step",
+        step: 8,
+        status: "failed",
+        error: "provider timeout",
+        LLM_input_file: "(call file unavailable)",
       }),
     );
   });

--- a/packages/core/tests/unit/agent-inference-logger.test.ts
+++ b/packages/core/tests/unit/agent-inference-logger.test.ts
@@ -1,0 +1,328 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { writeTimestampedTxtFile, appendSummary } = vi.hoisted(() => ({
+  writeTimestampedTxtFile: vi.fn(() => ({
+    fileName: "20250705_120000_agent_step_1_call.txt",
+    timestamp: "20250705_120000",
+  })),
+  appendSummary: vi.fn(),
+}));
+
+vi.mock("../../lib/inferenceLogUtils.js", () => ({
+  writeTimestampedTxtFile,
+  appendSummary,
+}));
+
+import {
+  completeAgentStepInference,
+  failAgentStepInference,
+  finalizePendingAgentSteps,
+  logAgentRunStart,
+  logAgentStepCall,
+  logAgentStepSummary,
+  mapCuaStepUsage,
+  runCuaStepWithInferenceLogging,
+  sanitizeForInferenceLog,
+} from "../../lib/v3/agent/utils/agentInferenceLogger.js";
+
+describe("agentInferenceLogger", () => {
+  beforeEach(() => {
+    writeTimestampedTxtFile.mockClear();
+    appendSummary.mockClear();
+    writeTimestampedTxtFile.mockReturnValue({
+      fileName: "20250705_120000_agent_step_1_call.txt",
+      timestamp: "20250705_120000",
+    });
+  });
+
+  it("sanitizes base64 image payloads", () => {
+    const payload = {
+      screenshot: "data:image/png;base64," + "A".repeat(400),
+      note: "hello",
+    };
+
+    const sanitized = sanitizeForInferenceLog(payload) as {
+      screenshot: string;
+      note: string;
+    };
+
+    expect(sanitized.note).toBe("hello");
+    expect(sanitized.screenshot).toContain("[image omitted");
+  });
+
+  it("sanitizes class instances and buffers via JSON round-trip", () => {
+    class MessagePart {
+      constructor(public text: string) {}
+    }
+
+    const sanitized = sanitizeForInferenceLog({
+      part: new MessagePart("hello"),
+      buf:
+        typeof Buffer !== "undefined"
+          ? Buffer.from("abc")
+          : new Uint8Array([1, 2, 3]),
+    }) as { part: { text: string }; buf: string };
+
+    expect(sanitized.part).toEqual({ text: "hello" });
+    expect(sanitized.buf).toContain("omitted");
+  });
+
+  it("does not redact short data fields that are not base64 images", () => {
+    const hash = "a".repeat(64);
+    const sanitized = sanitizeForInferenceLog({ data: hash }) as {
+      data: string;
+    };
+    expect(sanitized.data).toBe(hash);
+  });
+
+  it("writes run start files under agent_summary", () => {
+    logAgentRunStart({
+      instruction: "click login",
+      mode: "dom",
+      modelId: "openai/gpt-4.1-mini",
+      tools: ["act", "extract"],
+      agentType: "dom",
+    });
+
+    expect(writeTimestampedTxtFile).toHaveBeenCalledWith(
+      "agent_summary",
+      "agent_run_start",
+      expect.objectContaining({
+        modelCall: "agent",
+        instruction: "click login",
+      }),
+    );
+  });
+
+  it("appends agent step summaries with token usage", () => {
+    logAgentStepSummary({
+      stepIndex: 2,
+      callFile: "call.txt",
+      responseFile: "response.txt",
+      timestamp: "20250705_120001",
+      usage: {
+        prompt_tokens: 10,
+        completion_tokens: 5,
+        reasoning_tokens: 1,
+        cached_input_tokens: 2,
+        inference_time_ms: 99,
+      },
+    });
+
+    expect(appendSummary).toHaveBeenCalledWith(
+      "agent",
+      expect.objectContaining({
+        agent_inference_type: "agent_step",
+        step: 2,
+        LLM_input_file: "call.txt",
+        LLM_output_file: "response.txt",
+        prompt_tokens: 10,
+        completion_tokens: 5,
+      }),
+    );
+  });
+
+  it("completes CUA step inference with sanitized payloads", () => {
+    writeTimestampedTxtFile
+      .mockReturnValueOnce({
+        fileName: "call.txt",
+        timestamp: "20250705_120002",
+      })
+      .mockReturnValueOnce({
+        fileName: "response.txt",
+        timestamp: "20250705_120002",
+      });
+
+    const call = logAgentStepCall({
+      stepIndex: 1,
+      payload: {
+        modelId: "openai/computer-use-preview",
+        request: {
+          inputItems: [
+            { type: "input_image", image_url: "data:image/png;base64,AAAA" },
+          ],
+        },
+      },
+    });
+
+    completeAgentStepInference({
+      stepIndex: 1,
+      call: call!,
+      responsePayload: {
+        modelId: "openai/computer-use-preview",
+        response: {
+          actions: [{ type: "click" }],
+          completed: false,
+        },
+      },
+      usage: {
+        prompt_tokens: 3,
+        completion_tokens: 1,
+      },
+      agentInferenceType: "agent_cua_step",
+    });
+
+    expect(writeTimestampedTxtFile).toHaveBeenCalledTimes(2);
+    expect(appendSummary).toHaveBeenCalledWith(
+      "agent",
+      expect.objectContaining({
+        agent_inference_type: "agent_cua_step",
+        step: 1,
+      }),
+    );
+  });
+
+  it("records failed steps with error status", () => {
+    writeTimestampedTxtFile
+      .mockReturnValueOnce({
+        fileName: "call.txt",
+        timestamp: "20250705_120003",
+      })
+      .mockReturnValueOnce({
+        fileName: "response.txt",
+        timestamp: "20250705_120003",
+      });
+
+    const call = logAgentStepCall({
+      stepIndex: 3,
+      payload: { messages: [] },
+    });
+    expect(call).not.toBeNull();
+
+    failAgentStepInference({
+      stepIndex: 3,
+      call: call!,
+      error: new Error("provider timeout"),
+      agentInferenceType: "agent_cua_step",
+    });
+
+    expect(appendSummary).toHaveBeenCalledWith(
+      "agent",
+      expect.objectContaining({
+        agent_inference_type: "agent_cua_step",
+        status: "failed",
+        error: "provider timeout",
+      }),
+    );
+  });
+
+  it("finalizes all pending step calls on abort", () => {
+    writeTimestampedTxtFile.mockReturnValue({
+      fileName: "call.txt",
+      timestamp: "20250705_120004",
+    });
+
+    const pending = new Map();
+    const call1 = logAgentStepCall({ stepIndex: 1, payload: {} });
+    const call2 = logAgentStepCall({ stepIndex: 2, payload: {} });
+    pending.set(1, call1);
+    pending.set(2, call2);
+
+    finalizePendingAgentSteps(pending, "aborted");
+
+    expect(pending.size).toBe(0);
+    expect(appendSummary).toHaveBeenCalledTimes(2);
+    expect(appendSummary).toHaveBeenCalledWith(
+      "agent",
+      expect.objectContaining({ status: "failed", error: "aborted" }),
+    );
+  });
+
+  it("maps CUA reasoning and cached tokens", () => {
+    expect(
+      mapCuaStepUsage({
+        input_tokens: 10,
+        output_tokens: 5,
+        reasoning_tokens: 3,
+        cached_input_tokens: 2,
+      }),
+    ).toEqual({
+      prompt_tokens: 10,
+      completion_tokens: 5,
+      reasoning_tokens: 3,
+      cached_input_tokens: 2,
+      inference_time_ms: 0,
+    });
+  });
+
+  it("runs CUA steps with inference logging via shared helper", async () => {
+    writeTimestampedTxtFile
+      .mockReturnValueOnce({
+        fileName: "call.txt",
+        timestamp: "20250705_120006",
+      })
+      .mockReturnValueOnce({
+        fileName: "response.txt",
+        timestamp: "20250705_120006",
+      });
+
+    const result = await runCuaStepWithInferenceLogging({
+      logInferenceToFile: true,
+      stepIndex: 1,
+      modelId: "openai/computer-use-preview",
+      callPayload: { inputItems: [] },
+      executeStep: async () => ({
+        actions: [{ type: "click" }],
+        message: "clicked",
+        completed: false,
+        usage: { input_tokens: 2, output_tokens: 1, inference_time_ms: 5 },
+      }),
+    });
+
+    expect(result.message).toBe("clicked");
+    expect(appendSummary).toHaveBeenCalledWith(
+      "agent",
+      expect.objectContaining({
+        agent_inference_type: "agent_cua_step",
+        step: 1,
+      }),
+    );
+  });
+
+  it("does not append summary when response file write fails", () => {
+    writeTimestampedTxtFile
+      .mockReturnValueOnce({
+        fileName: "call.txt",
+        timestamp: "20250705_120005",
+      })
+      .mockReturnValueOnce(null);
+
+    const call = logAgentStepCall({ stepIndex: 5, payload: {} });
+    completeAgentStepInference({
+      stepIndex: 5,
+      call: call!,
+      responsePayload: { ok: true },
+    });
+
+    expect(writeTimestampedTxtFile).toHaveBeenCalledTimes(2);
+    expect(appendSummary).not.toHaveBeenCalled();
+  });
+
+  it("completes step inference with timing when usage omits inference_time_ms", () => {
+    writeTimestampedTxtFile
+      .mockReturnValueOnce({
+        fileName: "call.txt",
+        timestamp: "20250705_120005",
+      })
+      .mockReturnValueOnce({
+        fileName: "response.txt",
+        timestamp: "20250705_120005",
+      });
+
+    const call = logAgentStepCall({ stepIndex: 4, payload: {} });
+    completeAgentStepInference({
+      stepIndex: 4,
+      call: call!,
+      responsePayload: { ok: true },
+      usage: { prompt_tokens: 1, completion_tokens: 1 },
+      agentInferenceType: "agent_step",
+    });
+
+    expect(appendSummary).toHaveBeenCalledWith(
+      "agent",
+      expect.objectContaining({
+        inference_time_ms: expect.any(Number),
+      }),
+    );
+  });
+});

--- a/packages/core/tests/unit/agent-inference-logger.test.ts
+++ b/packages/core/tests/unit/agent-inference-logger.test.ts
@@ -15,8 +15,10 @@ vi.mock("../../lib/inferenceLogUtils.js", () => ({
 
 import {
   completeAgentStepInference,
+  completeAgentStepInferenceWithoutCall,
   failAgentStepInference,
   finalizePendingAgentSteps,
+  getCuaRunStartTools,
   logAgentRunStart,
   logAgentStepCall,
   logAgentStepSummary,
@@ -102,6 +104,15 @@ describe("agentInferenceLogger", () => {
     );
   });
 
+  it("builds CUA run-start tool lists with custom tools", () => {
+    expect(getCuaRunStartTools()).toEqual(["computer_use"]);
+    expect(getCuaRunStartTools(["search", "extract"])).toEqual([
+      "computer_use",
+      "search",
+      "extract",
+    ]);
+  });
+
   it("appends agent step summaries with token usage", () => {
     logAgentStepSummary({
       stepIndex: 2,
@@ -126,6 +137,29 @@ describe("agentInferenceLogger", () => {
         LLM_output_file: "response.txt",
         prompt_tokens: 10,
         completion_tokens: 5,
+      }),
+    );
+  });
+
+  it("completes step inference without a call file when call write failed", () => {
+    writeTimestampedTxtFile.mockReturnValueOnce({
+      fileName: "response.txt",
+      timestamp: "20250705_120007",
+    });
+
+    completeAgentStepInferenceWithoutCall({
+      stepIndex: 6,
+      responsePayload: { finishReason: "tool-calls" },
+      usage: { prompt_tokens: 1, completion_tokens: 1, inference_time_ms: 10 },
+    });
+
+    expect(appendSummary).toHaveBeenCalledWith(
+      "agent",
+      expect.objectContaining({
+        agent_inference_type: "agent_step",
+        step: 6,
+        LLM_input_file: "(call file unavailable)",
+        LLM_output_file: "response.txt",
       }),
     );
   });

--- a/packages/core/tests/unit/agent-inference-logger.test.ts
+++ b/packages/core/tests/unit/agent-inference-logger.test.ts
@@ -35,6 +35,14 @@ describe("agentInferenceLogger", () => {
     });
   });
 
+  it("sanitizes short data:image URLs", () => {
+    const shortUrl = "data:image/png;base64,AA==";
+    const sanitized = sanitizeForInferenceLog({ image: shortUrl }) as {
+      image: string;
+    };
+    expect(sanitized.image).toContain("[image omitted");
+  });
+
   it("sanitizes base64 image payloads", () => {
     const payload = {
       screenshot: "data:image/png;base64," + "A".repeat(400),
@@ -241,8 +249,54 @@ describe("agentInferenceLogger", () => {
       completion_tokens: 5,
       reasoning_tokens: 3,
       cached_input_tokens: 2,
-      inference_time_ms: 0,
+      inference_time_ms: undefined,
     });
+  });
+
+  it("omits inference_time_ms when CUA usage does not include timing", () => {
+    expect(mapCuaStepUsage({ input_tokens: 1, output_tokens: 2 })).toEqual({
+      prompt_tokens: 1,
+      completion_tokens: 2,
+      reasoning_tokens: 0,
+      cached_input_tokens: 0,
+      inference_time_ms: undefined,
+    });
+  });
+
+  it("defers CUA call logging until executeStep invokes logCall", async () => {
+    writeTimestampedTxtFile
+      .mockReturnValueOnce({
+        fileName: "call.txt",
+        timestamp: "20250705_120006",
+      })
+      .mockReturnValueOnce({
+        fileName: "response.txt",
+        timestamp: "20250705_120006",
+      });
+
+    const result = await runCuaStepWithInferenceLogging({
+      logInferenceToFile: true,
+      stepIndex: 2,
+      modelId: "openai/computer-use-preview",
+      executeStep: async (ctx) => {
+        ctx?.logCall({ requestParams: { model: "test" } });
+        return {
+          actions: [{ type: "click" }],
+          message: "clicked",
+          completed: false,
+          usage: { input_tokens: 2, output_tokens: 1, inference_time_ms: 5 },
+        };
+      },
+    });
+
+    expect(result.message).toBe("clicked");
+    expect(writeTimestampedTxtFile).toHaveBeenCalledWith(
+      "agent_summary",
+      "agent_step_2_call",
+      expect.objectContaining({
+        request: { requestParams: { model: "test" } },
+      }),
+    );
   });
 
   it("runs CUA steps with inference logging via shared helper", async () => {
@@ -279,7 +333,7 @@ describe("agentInferenceLogger", () => {
     );
   });
 
-  it("does not append summary when response file write fails", () => {
+  it("does not append summary when response file write fails", async () => {
     writeTimestampedTxtFile
       .mockReturnValueOnce({
         fileName: "call.txt",

--- a/packages/core/tests/unit/cua-client-inference.test.ts
+++ b/packages/core/tests/unit/cua-client-inference.test.ts
@@ -102,14 +102,11 @@ const clientCases: CuaClientCase[] = [
         { apiKey: "test-key" },
       ),
     mockExecuteStep: (client) => {
-      vi.spyOn(
+      mockCuaExecuteStep(
         client as unknown as {
-          executeStep: (
-            logger: (message: { message: string }) => void,
-          ) => Promise<CuaStepResult>;
+          executeStep: (...args: unknown[]) => Promise<CuaStepResult>;
         },
-        "executeStep",
-      ).mockResolvedValueOnce(completedStep);
+      );
     },
   },
   {
@@ -185,3 +182,85 @@ describe.each(clientCases)(
     });
   },
 );
+
+describe("GoogleCUAClient executeStep inference payload", () => {
+  beforeEach(() => {
+    writeTimestampedTxtFile.mockClear();
+    appendSummary.mockClear();
+    writeTimestampedTxtFile.mockReturnValue({
+      fileName: "call.txt",
+      timestamp: "20250705_120000",
+    });
+  });
+
+  it("logs post-compression API payload via logCall", async () => {
+    const client = new GoogleCUAClient(
+      "google",
+      "gemini-2.5-computer-use-preview-10-2025",
+      undefined,
+      { apiKey: "test-key" },
+    );
+
+    const history = [
+      {
+        role: "user" as const,
+        parts: [
+          {
+            inlineData: { mimeType: "image/png", data: "old-screenshot" },
+          },
+        ],
+      },
+      {
+        role: "user" as const,
+        parts: [
+          {
+            inlineData: { mimeType: "image/png", data: "mid-screenshot" },
+          },
+        ],
+      },
+      {
+        role: "user" as const,
+        parts: [
+          {
+            inlineData: { mimeType: "image/png", data: "new-screenshot" },
+          },
+        ],
+      },
+    ];
+    (client as unknown as { history: typeof history }).history = history;
+
+    const loggedPayloads: unknown[] = [];
+    const logger = vi.fn();
+
+    vi.spyOn(
+      (
+        client as unknown as {
+          client: {
+            models: { generateContent: (...args: unknown[]) => unknown };
+          };
+        }
+      ).client.models,
+      "generateContent",
+    ).mockResolvedValue({
+      candidates: [
+        {
+          content: { parts: [{ text: "done" }] },
+          finishReason: "STOP",
+        },
+      ],
+      usageMetadata: {
+        promptTokenCount: 1,
+        candidatesTokenCount: 1,
+      },
+    } as never);
+
+    await client.executeStep(logger, {
+      logCall: (payload) => {
+        loggedPayloads.push(payload);
+      },
+    });
+
+    expect(loggedPayloads).toHaveLength(1);
+    expect(JSON.stringify(loggedPayloads[0])).toContain("screenshot taken");
+  });
+});

--- a/packages/core/tests/unit/cua-client-inference.test.ts
+++ b/packages/core/tests/unit/cua-client-inference.test.ts
@@ -146,8 +146,8 @@ describe.each(clientCases)(
   "CUA client inference logging ($name)",
   ({ createClient, mockExecuteStep }) => {
     beforeEach(() => {
-      writeTimestampedTxtFile.mockClear();
-      appendSummary.mockClear();
+      writeTimestampedTxtFile.mockReset();
+      appendSummary.mockReset();
       writeTimestampedTxtFile.mockReturnValue({
         fileName: "call.txt",
         timestamp: "20250705_120000",
@@ -185,8 +185,8 @@ describe.each(clientCases)(
 
 describe("GoogleCUAClient executeStep inference payload", () => {
   beforeEach(() => {
-    writeTimestampedTxtFile.mockClear();
-    appendSummary.mockClear();
+    writeTimestampedTxtFile.mockReset();
+    appendSummary.mockReset();
     writeTimestampedTxtFile.mockReturnValue({
       fileName: "call.txt",
       timestamp: "20250705_120000",

--- a/packages/core/tests/unit/cua-client-inference.test.ts
+++ b/packages/core/tests/unit/cua-client-inference.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AnthropicCUAClient } from "../../lib/v3/agent/AnthropicCUAClient.js";
+import { GoogleCUAClient } from "../../lib/v3/agent/GoogleCUAClient.js";
+import { MicrosoftCUAClient } from "../../lib/v3/agent/MicrosoftCUAClient.js";
+import { OpenAICUAClient } from "../../lib/v3/agent/OpenAICUAClient.js";
+
+const { writeTimestampedTxtFile, appendSummary } = vi.hoisted(() => ({
+  writeTimestampedTxtFile: vi.fn(() => ({
+    fileName: "call.txt",
+    timestamp: "20250705_120000",
+  })),
+  appendSummary: vi.fn(),
+}));
+
+vi.mock("../../lib/inferenceLogUtils.js", () => ({
+  writeTimestampedTxtFile,
+  appendSummary,
+}));
+
+type CuaStepResult = {
+  actions: unknown[];
+  message: string;
+  completed: boolean;
+  nextInputItems: unknown[];
+  responseId?: string;
+  usage: {
+    input_tokens: number;
+    output_tokens: number;
+    inference_time_ms: number;
+  };
+};
+
+type CuaClientCase = {
+  name: string;
+  createClient: () =>
+    | AnthropicCUAClient
+    | GoogleCUAClient
+    | MicrosoftCUAClient
+    | OpenAICUAClient;
+  mockExecuteStep: (
+    client:
+      | AnthropicCUAClient
+      | GoogleCUAClient
+      | MicrosoftCUAClient
+      | OpenAICUAClient,
+  ) => void;
+};
+
+const completedStep: CuaStepResult = {
+  actions: [],
+  message: "done",
+  completed: true,
+  nextInputItems: [],
+  responseId: "response-1",
+  usage: { input_tokens: 1, output_tokens: 1, inference_time_ms: 1 },
+};
+
+const clientCases: CuaClientCase[] = [
+  {
+    name: "AnthropicCUAClient",
+    createClient: () =>
+      new AnthropicCUAClient(
+        "anthropic",
+        "claude-sonnet-4-20250514",
+        undefined,
+        { apiKey: "test-key" },
+      ),
+    mockExecuteStep: (client) => {
+      vi.spyOn(
+        client as unknown as {
+          executeStep: (
+            inputItems: unknown[],
+            logger: (message: { message: string }) => void,
+          ) => Promise<CuaStepResult>;
+        },
+        "executeStep",
+      ).mockResolvedValueOnce(completedStep);
+    },
+  },
+  {
+    name: "GoogleCUAClient",
+    createClient: () =>
+      new GoogleCUAClient(
+        "google",
+        "gemini-2.5-computer-use-preview-10-2025",
+        undefined,
+        { apiKey: "test-key" },
+      ),
+    mockExecuteStep: (client) => {
+      vi.spyOn(
+        client as unknown as {
+          executeStep: (
+            logger: (message: { message: string }) => void,
+          ) => Promise<CuaStepResult>;
+        },
+        "executeStep",
+      ).mockResolvedValueOnce(completedStep);
+    },
+  },
+  {
+    name: "MicrosoftCUAClient",
+    createClient: () =>
+      new MicrosoftCUAClient("microsoft", "fara-7b", undefined, {
+        apiKey: "test-key",
+      }),
+    mockExecuteStep: (client) => {
+      vi.spyOn(
+        client as unknown as {
+          executeStep: (
+            logger: (message: { message: string }) => void,
+            isFirstRound: boolean,
+          ) => Promise<CuaStepResult>;
+        },
+        "executeStep",
+      ).mockResolvedValueOnce(completedStep);
+    },
+  },
+  {
+    name: "OpenAICUAClient",
+    createClient: () =>
+      new OpenAICUAClient(
+        "openai",
+        "computer-use-preview-2025-03-11",
+        undefined,
+        { apiKey: "test-key" },
+      ),
+    mockExecuteStep: (client) => {
+      vi.spyOn(
+        client as unknown as {
+          executeStep: (
+            inputItems: unknown[],
+            previousResponseId: string | undefined,
+            logger: (message: { message: string }) => void,
+          ) => Promise<CuaStepResult>;
+        },
+        "executeStep",
+      ).mockResolvedValueOnce(completedStep);
+    },
+  },
+];
+
+describe.each(clientCases)(
+  "CUA client inference logging ($name)",
+  ({ createClient, mockExecuteStep }) => {
+    beforeEach(() => {
+      writeTimestampedTxtFile.mockClear();
+      appendSummary.mockClear();
+      writeTimestampedTxtFile.mockReturnValue({
+        fileName: "call.txt",
+        timestamp: "20250705_120000",
+      });
+    });
+
+    it("logs inference files when logInferenceToFile is enabled", async () => {
+      const client = createClient();
+      mockExecuteStep(client);
+
+      await client.execute({
+        options: { instruction: "Submit the form.", maxSteps: 10 } as never,
+        logger: vi.fn(),
+        logInferenceToFile: true,
+      });
+
+      expect(writeTimestampedTxtFile).toHaveBeenCalledWith(
+        "agent_summary",
+        "agent_run_start",
+        expect.objectContaining({
+          instruction: "Submit the form.",
+          agentType: "cua",
+        }),
+      );
+      expect(appendSummary).toHaveBeenCalledWith(
+        "agent",
+        expect.objectContaining({
+          agent_inference_type: "agent_cua_step",
+          step: 1,
+        }),
+      );
+    });
+  },
+);

--- a/packages/core/tests/unit/cua-client-inference.test.ts
+++ b/packages/core/tests/unit/cua-client-inference.test.ts
@@ -55,6 +55,25 @@ const completedStep: CuaStepResult = {
   usage: { input_tokens: 1, output_tokens: 1, inference_time_ms: 1 },
 };
 
+function mockCuaExecuteStep(client: {
+  executeStep: (...args: unknown[]) => Promise<CuaStepResult>;
+}): void {
+  vi.spyOn(client, "executeStep").mockImplementation(async (...args) => {
+    const maybeCtx = args[args.length - 1];
+    if (
+      maybeCtx &&
+      typeof maybeCtx === "object" &&
+      "logCall" in maybeCtx &&
+      typeof (maybeCtx as { logCall: unknown }).logCall === "function"
+    ) {
+      (maybeCtx as { logCall: (payload: unknown) => void }).logCall({
+        mocked: true,
+      });
+    }
+    return completedStep;
+  });
+}
+
 const clientCases: CuaClientCase[] = [
   {
     name: "AnthropicCUAClient",
@@ -66,15 +85,11 @@ const clientCases: CuaClientCase[] = [
         { apiKey: "test-key" },
       ),
     mockExecuteStep: (client) => {
-      vi.spyOn(
+      mockCuaExecuteStep(
         client as unknown as {
-          executeStep: (
-            inputItems: unknown[],
-            logger: (message: { message: string }) => void,
-          ) => Promise<CuaStepResult>;
+          executeStep: (...args: unknown[]) => Promise<CuaStepResult>;
         },
-        "executeStep",
-      ).mockResolvedValueOnce(completedStep);
+      );
     },
   },
   {
@@ -104,15 +119,11 @@ const clientCases: CuaClientCase[] = [
         apiKey: "test-key",
       }),
     mockExecuteStep: (client) => {
-      vi.spyOn(
+      mockCuaExecuteStep(
         client as unknown as {
-          executeStep: (
-            logger: (message: { message: string }) => void,
-            isFirstRound: boolean,
-          ) => Promise<CuaStepResult>;
+          executeStep: (...args: unknown[]) => Promise<CuaStepResult>;
         },
-        "executeStep",
-      ).mockResolvedValueOnce(completedStep);
+      );
     },
   },
   {
@@ -125,16 +136,11 @@ const clientCases: CuaClientCase[] = [
         { apiKey: "test-key" },
       ),
     mockExecuteStep: (client) => {
-      vi.spyOn(
+      mockCuaExecuteStep(
         client as unknown as {
-          executeStep: (
-            inputItems: unknown[],
-            previousResponseId: string | undefined,
-            logger: (message: { message: string }) => void,
-          ) => Promise<CuaStepResult>;
+          executeStep: (...args: unknown[]) => Promise<CuaStepResult>;
         },
-        "executeStep",
-      ).mockResolvedValueOnce(completedStep);
+      );
     },
   },
 ];

--- a/packages/core/tests/unit/handle-done-tool-call.test.ts
+++ b/packages/core/tests/unit/handle-done-tool-call.test.ts
@@ -41,6 +41,32 @@ describe("handleDoneToolCall inference logging", () => {
       });
   });
 
+  it("does not write inference files when logInferenceToFile is disabled", async () => {
+    generateText.mockResolvedValueOnce({
+      toolCalls: [
+        {
+          toolName: "done",
+          input: {
+            reasoning: "Clicked sign in",
+            taskComplete: true,
+          },
+        },
+      ],
+      response: { messages: [] },
+      usage: { inputTokens: 10, outputTokens: 5 },
+    });
+
+    await handleDoneToolCall({
+      model: { modelId: "openai/gpt-4.1-mini" } as never,
+      inputMessages: [{ role: "user", content: "history" }],
+      instruction: "Sign in",
+      logger: vi.fn(),
+      logInferenceToFile: false,
+    });
+
+    expect(writeTimestampedTxtFile).not.toHaveBeenCalled();
+  });
+
   it("writes agent_done files when logInferenceToFile is enabled", async () => {
     generateText.mockResolvedValueOnce({
       toolCalls: [

--- a/packages/core/tests/unit/handle-done-tool-call.test.ts
+++ b/packages/core/tests/unit/handle-done-tool-call.test.ts
@@ -27,8 +27,8 @@ import { handleDoneToolCall } from "../../lib/v3/agent/utils/handleDoneToolCall.
 
 describe("handleDoneToolCall inference logging", () => {
   beforeEach(() => {
-    writeTimestampedTxtFile.mockClear();
-    appendSummary.mockClear();
+    writeTimestampedTxtFile.mockReset();
+    appendSummary.mockReset();
     generateText.mockReset();
     writeTimestampedTxtFile
       .mockReturnValueOnce({

--- a/packages/core/tests/unit/handle-done-tool-call.test.ts
+++ b/packages/core/tests/unit/handle-done-tool-call.test.ts
@@ -67,6 +67,36 @@ describe("handleDoneToolCall inference logging", () => {
     expect(writeTimestampedTxtFile).not.toHaveBeenCalled();
   });
 
+  it("writes agent_done files when the model returns plain text", async () => {
+    generateText.mockResolvedValueOnce({
+      toolCalls: [],
+      text: "Could not finish with done tool",
+      response: { messages: [] },
+      usage: { inputTokens: 4, outputTokens: 2 },
+    });
+
+    await handleDoneToolCall({
+      model: { modelId: "openai/gpt-4.1-mini" } as never,
+      inputMessages: [{ role: "user", content: "history" }],
+      instruction: "Sign in",
+      logger: vi.fn(),
+      logInferenceToFile: true,
+    });
+
+    expect(writeTimestampedTxtFile).toHaveBeenCalledWith(
+      "agent_summary",
+      "agent_done_call",
+      expect.objectContaining({ modelCall: "agent_done" }),
+    );
+    expect(appendSummary).toHaveBeenCalledWith(
+      "agent",
+      expect.objectContaining({
+        agent_inference_type: "agent_done",
+        status: "completed",
+      }),
+    );
+  });
+
   it("writes agent_done files when logInferenceToFile is enabled", async () => {
     generateText.mockResolvedValueOnce({
       toolCalls: [

--- a/packages/core/tests/unit/handle-done-tool-call.test.ts
+++ b/packages/core/tests/unit/handle-done-tool-call.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { writeTimestampedTxtFile, appendSummary } = vi.hoisted(() => ({
+  writeTimestampedTxtFile: vi.fn(() => ({
+    fileName: "agent_done_call.txt",
+    timestamp: "20250705_120000",
+  })),
+  appendSummary: vi.fn(),
+}));
+
+vi.mock("../../lib/inferenceLogUtils.js", () => ({
+  writeTimestampedTxtFile,
+  appendSummary,
+}));
+
+const generateText = vi.hoisted(() => vi.fn());
+
+vi.mock("ai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ai")>();
+  return {
+    ...actual,
+    generateText,
+  };
+});
+
+import { handleDoneToolCall } from "../../lib/v3/agent/utils/handleDoneToolCall.js";
+
+describe("handleDoneToolCall inference logging", () => {
+  beforeEach(() => {
+    writeTimestampedTxtFile.mockClear();
+    appendSummary.mockClear();
+    generateText.mockReset();
+    writeTimestampedTxtFile
+      .mockReturnValueOnce({
+        fileName: "agent_done_call.txt",
+        timestamp: "20250705_120000",
+      })
+      .mockReturnValueOnce({
+        fileName: "agent_done_response.txt",
+        timestamp: "20250705_120000",
+      });
+  });
+
+  it("writes agent_done files when logInferenceToFile is enabled", async () => {
+    generateText.mockResolvedValueOnce({
+      toolCalls: [
+        {
+          toolName: "done",
+          input: {
+            reasoning: "Clicked sign in",
+            taskComplete: true,
+          },
+        },
+      ],
+      response: { messages: [] },
+      usage: { inputTokens: 10, outputTokens: 5 },
+    });
+
+    await handleDoneToolCall({
+      model: { modelId: "openai/gpt-4.1-mini" } as never,
+      inputMessages: [{ role: "user", content: "history" }],
+      instruction: "Sign in",
+      logger: vi.fn(),
+      logInferenceToFile: true,
+    });
+
+    expect(writeTimestampedTxtFile).toHaveBeenCalledWith(
+      "agent_summary",
+      "agent_done_call",
+      expect.objectContaining({ modelCall: "agent_done" }),
+    );
+    expect(appendSummary).toHaveBeenCalledWith(
+      "agent",
+      expect.objectContaining({
+        agent_inference_type: "agent_done",
+        status: "completed",
+      }),
+    );
+  });
+});

--- a/packages/core/tests/unit/public-api/public-types.test.ts
+++ b/packages/core/tests/unit/public-api/public-types.test.ts
@@ -306,6 +306,7 @@ describe("Stagehand public API types", () => {
       options: T;
       logger: (message: Stagehand.LogLine) => void;
       retries?: number;
+      logInferenceToFile?: boolean;
     };
 
     it("matches expected type shape", () => {

--- a/packages/core/tests/unit/v3-agent-handler-inference.test.ts
+++ b/packages/core/tests/unit/v3-agent-handler-inference.test.ts
@@ -222,8 +222,8 @@ describe("V3AgentHandler inference logging", () => {
 
   beforeEach(() => {
     logger = vi.fn();
-    writeTimestampedTxtFile.mockClear();
-    appendSummary.mockClear();
+    writeTimestampedTxtFile.mockReset();
+    appendSummary.mockReset();
     writeTimestampedTxtFile.mockReturnValue({
       fileName: "call.txt",
       timestamp: "20250705_120000",

--- a/packages/core/tests/unit/v3-agent-handler-inference.test.ts
+++ b/packages/core/tests/unit/v3-agent-handler-inference.test.ts
@@ -332,6 +332,85 @@ describe("V3AgentHandler inference logging", () => {
     );
   });
 
+  it("finalizes pending step inference when a stream errors", async () => {
+    const model = {
+      modelId: "openai/gpt-5-mini",
+      provider: "openai",
+      specificationVersion: "v2",
+    } as unknown as LanguageModelV2;
+
+    const streamText = vi.fn((options: AgentLlmOptions) => {
+      void (async () => {
+        await options.prepareStep?.({
+          messages: [{ role: "user", content: "finish" }],
+          stepNumber: 1,
+        });
+        options.onError?.({ error: new Error("provider timeout") });
+      })();
+
+      return {
+        textStream: (async function* () {})(),
+      };
+    });
+
+    const client = {
+      getLanguageModel: vi.fn(() => model),
+      generateText: vi.fn(),
+      streamText,
+    } as unknown as LLMClient;
+
+    const handler = createInferenceHandler(client, logger);
+
+    const streamResult = await handler.stream({
+      instruction: "finish",
+      maxSteps: 1,
+      excludeTools: ["search"],
+    });
+
+    await expect(streamResult.result).rejects.toThrow("provider timeout");
+    expect(appendSummary).toHaveBeenCalledWith(
+      "agent",
+      expect.objectContaining({
+        agent_inference_type: "agent_step",
+        status: "failed",
+        error: "provider timeout",
+      }),
+    );
+  });
+
+  it("records step responses when call file write fails", async () => {
+    (writeTimestampedTxtFile as ReturnType<typeof vi.fn>).mockImplementation(
+      (_directory: string, prefix: string) => {
+        if (prefix.includes("_call")) {
+          return null;
+        }
+        return {
+          fileName: "response.txt",
+          timestamp: "20250705_120008",
+        };
+      },
+    );
+
+    const { client } = createLlmClient();
+    const handler = createInferenceHandler(client, logger);
+
+    await handler.execute({
+      instruction: "finish",
+      maxSteps: 1,
+      excludeTools: ["search"],
+    });
+
+    expect(appendSummary).toHaveBeenCalledWith(
+      "agent",
+      expect.objectContaining({
+        agent_inference_type: "agent_step",
+        step: 1,
+        LLM_input_file: "(call file unavailable)",
+        LLM_output_file: "response.txt",
+      }),
+    );
+  });
+
   it("finalizes pending step inference when a stream aborts", async () => {
     const model = {
       modelId: "openai/gpt-5-mini",

--- a/packages/core/tests/unit/v3-agent-handler-inference.test.ts
+++ b/packages/core/tests/unit/v3-agent-handler-inference.test.ts
@@ -460,4 +460,128 @@ describe("V3AgentHandler inference logging", () => {
       }),
     );
   });
+
+  it("finalizes pending step inference when execute fails", async () => {
+    const model = {
+      modelId: "openai/gpt-5-mini",
+      provider: "openai",
+      specificationVersion: "v2",
+    } as unknown as LanguageModelV2;
+
+    const generateText = vi.fn(async (options: AgentLlmOptions) => {
+      await options.prepareStep?.({
+        messages: [{ role: "user", content: "finish" }],
+        stepNumber: 1,
+      });
+      throw new Error("provider timeout");
+    });
+
+    const client = {
+      getLanguageModel: vi.fn(() => model),
+      generateText,
+      streamText: vi.fn(),
+    } as unknown as LLMClient;
+
+    const handler = createInferenceHandler(client, logger);
+
+    const result = await handler.execute({
+      instruction: "finish",
+      maxSteps: 1,
+      excludeTools: ["search"],
+    });
+
+    expect(result.success).toBe(false);
+    expect(appendSummary).toHaveBeenCalledWith(
+      "agent",
+      expect.objectContaining({
+        agent_inference_type: "agent_step",
+        status: "failed",
+        error: "provider timeout",
+      }),
+    );
+  });
+
+  it("does not record a completed step after stream abort finalizes it", async () => {
+    const model = {
+      modelId: "openai/gpt-5-mini",
+      provider: "openai",
+      specificationVersion: "v2",
+    } as unknown as LanguageModelV2;
+
+    const streamText = vi.fn((options: AgentLlmOptions) => {
+      void (async () => {
+        await options.prepareStep?.({
+          messages: [{ role: "user", content: "finish" }],
+          stepNumber: 1,
+        });
+        options.onAbort?.({});
+        await options.onStepFinish?.(createDoneStep());
+      })();
+
+      return {
+        textStream: (async function* () {})(),
+      };
+    });
+
+    const client = {
+      getLanguageModel: vi.fn(() => model),
+      generateText: vi.fn(),
+      streamText,
+    } as unknown as LLMClient;
+
+    const handler = createInferenceHandler(client, logger);
+
+    const streamResult = await handler.stream({
+      instruction: "finish",
+      maxSteps: 1,
+      excludeTools: ["search"],
+    });
+
+    await expect(streamResult.result).rejects.toThrow("Stream was aborted");
+    expect(appendSummary).toHaveBeenCalledTimes(1);
+    expect(appendSummary).toHaveBeenCalledWith(
+      "agent",
+      expect.objectContaining({
+        agent_inference_type: "agent_step",
+        status: "failed",
+      }),
+    );
+  });
+
+  it("sanitizes image payloads in prepareStep inference logs", async () => {
+    const { client } = createLlmClient();
+    const handler = createInferenceHandler(client, logger);
+    const imageData = "A".repeat(2000);
+
+    await handler.execute({
+      instruction: "finish",
+      maxSteps: 1,
+      excludeTools: ["search"],
+      callbacks: {
+        prepareStep: async (step) => ({
+          ...step,
+          messages: [
+            {
+              role: "user",
+              content: [
+                { type: "text", text: "see this" },
+                {
+                  type: "image",
+                  image: imageData,
+                },
+              ],
+            },
+          ],
+        }),
+      },
+    });
+
+    const stepCall = (
+      writeTimestampedTxtFile as ReturnType<typeof vi.fn>
+    ).mock.calls.find(
+      (call: [string, string, unknown]) => call[1] === "agent_step_1_call",
+    );
+    expect(stepCall).toBeDefined();
+    expect(JSON.stringify(stepCall?.[2])).toContain("[image omitted");
+  });
 });

--- a/packages/core/tests/unit/v3-agent-handler-inference.test.ts
+++ b/packages/core/tests/unit/v3-agent-handler-inference.test.ts
@@ -283,6 +283,55 @@ describe("V3AgentHandler inference logging", () => {
     );
   });
 
+  it("handles prepareStep returning undefined without crashing", async () => {
+    const { client } = createLlmClient();
+    const handler = createInferenceHandler(client, logger);
+
+    await handler.execute({
+      instruction: "finish",
+      maxSteps: 1,
+      excludeTools: ["search"],
+      callbacks: {
+        prepareStep: async () => undefined as never,
+      },
+    });
+
+    expect(appendSummary).toHaveBeenCalledWith(
+      "agent",
+      expect.objectContaining({
+        agent_inference_type: "agent_step",
+        step: 1,
+      }),
+    );
+  });
+
+  it("logs per-step system and activeTools overrides from prepareStep", async () => {
+    const { client } = createLlmClient();
+    const handler = createInferenceHandler(client, logger);
+
+    await handler.execute({
+      instruction: "finish",
+      maxSteps: 1,
+      excludeTools: ["search"],
+      callbacks: {
+        prepareStep: async (step) => ({
+          ...step,
+          system: "step-specific system",
+          activeTools: ["done"],
+        }),
+      },
+    });
+
+    expect(writeTimestampedTxtFile).toHaveBeenCalledWith(
+      "agent_summary",
+      "agent_step_1_call",
+      expect.objectContaining({
+        systemPrompt: "step-specific system",
+        tools: ["done"],
+      }),
+    );
+  });
+
   it("finalizes pending step inference when a stream aborts", async () => {
     const model = {
       modelId: "openai/gpt-5-mini",

--- a/packages/core/tests/unit/v3-agent-handler-inference.test.ts
+++ b/packages/core/tests/unit/v3-agent-handler-inference.test.ts
@@ -1,0 +1,335 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { LanguageModelV2 } from "@ai-sdk/provider";
+import type { LLMClient } from "../../lib/v3/llm/LLMClient.js";
+import type { LogLine } from "../../lib/v3/types/public/logs.js";
+import type { V3 } from "../../lib/v3/v3.js";
+
+vi.mock("ai", async () => {
+  const actual = await vi.importActual<typeof import("ai")>("ai");
+  return {
+    ...actual,
+    wrapLanguageModel: vi.fn(({ model }) => model),
+  };
+});
+
+const { writeTimestampedTxtFile, appendSummary } = vi.hoisted(() => ({
+  writeTimestampedTxtFile: vi.fn(() => ({
+    fileName: "call.txt",
+    timestamp: "20250705_120000",
+  })),
+  appendSummary: vi.fn(),
+}));
+
+vi.mock("../../lib/inferenceLogUtils.js", () => ({
+  writeTimestampedTxtFile,
+  appendSummary,
+}));
+
+import { V3AgentHandler } from "../../lib/v3/handlers/v3AgentHandler.js";
+
+type AgentLlmOptions = {
+  onStepFinish?: (step: unknown) => Promise<void> | void;
+  prepareStep?: (step: { messages: unknown[]; stepNumber: number }) =>
+    | Promise<{ messages: unknown[]; stepNumber: number }>
+    | {
+        messages: unknown[];
+        stepNumber: number;
+      };
+  onFinish?: (event: unknown) => void;
+  onAbort?: (event: unknown) => void;
+  onError?: (event: { error: unknown }) => void;
+};
+
+const usage = {
+  inputTokens: 1,
+  outputTokens: 1,
+  reasoningTokens: 0,
+  cachedInputTokens: 0,
+  totalTokens: 2,
+};
+
+const emptyList = () => [] as unknown[];
+
+function createDoneStep() {
+  return {
+    content: emptyList(),
+    text: "",
+    reasoning: emptyList(),
+    reasoningText: undefined as string | undefined,
+    files: emptyList(),
+    sources: emptyList(),
+    toolCalls: [
+      {
+        type: "tool-call",
+        toolCallId: "call_done",
+        toolName: "done",
+        input: {
+          reasoning: "Task completed",
+          taskComplete: true,
+        },
+      },
+    ],
+    staticToolCalls: emptyList(),
+    dynamicToolCalls: emptyList(),
+    toolResults: [
+      {
+        type: "tool-result",
+        toolCallId: "call_done",
+        toolName: "done",
+        input: {
+          reasoning: "Task completed",
+          taskComplete: true,
+        },
+        output: {
+          success: true,
+          reasoning: "Task completed",
+          taskComplete: true,
+        },
+      },
+    ],
+    staticToolResults: emptyList(),
+    dynamicToolResults: emptyList(),
+    finishReason: "tool-calls",
+    usage,
+    warnings: undefined as unknown,
+    request: {},
+    response: {
+      id: "response-id",
+      modelId: "openai/gpt-5-mini",
+      timestamp: new Date(0),
+      messages: emptyList(),
+    },
+    providerMetadata: undefined as unknown,
+  };
+}
+
+function createGenerateResult(doneStep: ReturnType<typeof createDoneStep>) {
+  return {
+    content: emptyList(),
+    text: "",
+    reasoning: emptyList(),
+    reasoningText: undefined as string | undefined,
+    files: emptyList(),
+    sources: emptyList(),
+    toolCalls: doneStep.toolCalls,
+    staticToolCalls: emptyList(),
+    dynamicToolCalls: emptyList(),
+    toolResults: doneStep.toolResults,
+    staticToolResults: emptyList(),
+    dynamicToolResults: emptyList(),
+    finishReason: "tool-calls",
+    usage,
+    totalUsage: usage,
+    warnings: undefined as unknown,
+    request: {},
+    response: {
+      id: "response-id",
+      modelId: "openai/gpt-5-mini",
+      timestamp: new Date(0),
+      messages: emptyList(),
+    },
+    providerMetadata: undefined as unknown,
+    steps: [doneStep],
+    experimental_output: undefined as unknown,
+  };
+}
+
+function createV3() {
+  const page = {
+    url: () => "https://example.com",
+    enableCursorOverlay: vi.fn(async () => {}),
+  };
+
+  return {
+    context: {
+      awaitActivePage: vi.fn(async () => page),
+    },
+    isCaptchaAutoSolveEnabled: false,
+    browserbaseApiKey: undefined,
+    logger: vi.fn(),
+    recordAgentReplayStep: vi.fn(),
+    updateMetrics: vi.fn(),
+    act: vi.fn(),
+    extract: vi.fn(),
+    observe: vi.fn(),
+  } as unknown as V3;
+}
+
+function createLlmClient() {
+  const model = {
+    modelId: "openai/gpt-5-mini",
+    provider: "openai",
+    specificationVersion: "v2",
+  } as unknown as LanguageModelV2;
+
+  const generateText = vi.fn(async (options: AgentLlmOptions) => {
+    const doneStep = createDoneStep();
+    await options.prepareStep?.({
+      messages: [{ role: "user", content: "finish" }],
+      stepNumber: 1,
+    });
+    await options.onStepFinish?.(doneStep);
+    return createGenerateResult(doneStep);
+  });
+
+  const streamText = vi.fn((options: AgentLlmOptions) => {
+    void (async () => {
+      const doneStep = createDoneStep();
+      await options.prepareStep?.({
+        messages: [{ role: "user", content: "finish" }],
+        stepNumber: 1,
+      });
+      await options.onStepFinish?.(doneStep);
+      options.onFinish?.(createGenerateResult(doneStep));
+    })();
+
+    return {
+      textStream: (async function* () {})(),
+    };
+  });
+
+  return {
+    client: {
+      getLanguageModel: vi.fn(() => model),
+      generateText,
+      streamText,
+    } as unknown as LLMClient,
+    generateText,
+    streamText,
+  };
+}
+
+function createInferenceHandler(
+  client: LLMClient,
+  logger: (line: LogLine) => void,
+) {
+  return new V3AgentHandler(
+    createV3(),
+    logger,
+    client,
+    undefined,
+    undefined,
+    undefined,
+    "dom",
+    false,
+    undefined,
+    true,
+  );
+}
+
+describe("V3AgentHandler inference logging", () => {
+  let logger: (line: LogLine) => void;
+
+  beforeEach(() => {
+    logger = vi.fn();
+    writeTimestampedTxtFile.mockClear();
+    appendSummary.mockClear();
+    writeTimestampedTxtFile.mockReturnValue({
+      fileName: "call.txt",
+      timestamp: "20250705_120000",
+    });
+  });
+
+  it("writes agent inference files when logInferenceToFile is enabled", async () => {
+    const { client } = createLlmClient();
+    const handler = createInferenceHandler(client, logger);
+
+    await handler.execute({
+      instruction: "finish",
+      maxSteps: 1,
+      excludeTools: ["search"],
+    });
+
+    expect(writeTimestampedTxtFile).toHaveBeenCalledWith(
+      "agent_summary",
+      "agent_run_start",
+      expect.objectContaining({
+        instruction: "finish",
+      }),
+    );
+    expect(appendSummary).toHaveBeenCalledWith(
+      "agent",
+      expect.objectContaining({
+        agent_inference_type: "agent_step",
+        step: 1,
+      }),
+    );
+  });
+
+  it("writes agent inference files when streaming with logInferenceToFile", async () => {
+    const { client } = createLlmClient();
+    const handler = createInferenceHandler(client, logger);
+
+    const streamResult = await handler.stream({
+      instruction: "finish",
+      maxSteps: 1,
+      excludeTools: ["search"],
+    });
+    await streamResult.result;
+
+    expect(writeTimestampedTxtFile).toHaveBeenCalledWith(
+      "agent_summary",
+      "agent_run_start",
+      expect.objectContaining({
+        instruction: "finish",
+      }),
+    );
+    expect(appendSummary).toHaveBeenCalledWith(
+      "agent",
+      expect.objectContaining({
+        agent_inference_type: "agent_step",
+        step: 1,
+      }),
+    );
+  });
+
+  it("finalizes pending step inference when a stream aborts", async () => {
+    const model = {
+      modelId: "openai/gpt-5-mini",
+      provider: "openai",
+      specificationVersion: "v2",
+    } as unknown as LanguageModelV2;
+
+    const streamText = vi.fn((options: AgentLlmOptions) => {
+      void (async () => {
+        await options.prepareStep?.({
+          messages: [{ role: "user", content: "finish" }],
+          stepNumber: 1,
+        });
+        options.onAbort?.({});
+      })();
+
+      return {
+        textStream: (async function* () {})(),
+      };
+    });
+
+    const client = {
+      getLanguageModel: vi.fn(() => model),
+      generateText: vi.fn(),
+      streamText,
+    } as unknown as LLMClient;
+
+    const handler = createInferenceHandler(client, logger);
+
+    const controller = new AbortController();
+    controller.abort("user cancelled");
+
+    const streamResult = await handler.stream({
+      instruction: "finish",
+      maxSteps: 1,
+      excludeTools: ["search"],
+      signal: controller.signal,
+    });
+
+    await expect(streamResult.result).rejects.toThrow("user cancelled");
+    expect(appendSummary).toHaveBeenCalledWith(
+      "agent",
+      expect.objectContaining({
+        agent_inference_type: "agent_step",
+        status: "failed",
+        error: "user cancelled",
+      }),
+    );
+  });
+});

--- a/packages/docs/v3/configuration/logging.mdx
+++ b/packages/docs/v3/configuration/logging.mdx
@@ -427,7 +427,18 @@ Creates timestamped files for each LLM call:
 └── observe_summary/
     ├── observe_summary.json
     └── ...
+├── agent_summary/
+    ├── agent_summary.json
+    ├── 20250127_123600_agent_run_start.txt
+    ├── 20250127_123601_agent_step_1_call.txt
+    ├── 20250127_123601_agent_step_1_response.txt
+    ├── 20250127_123605_agent_done_call.txt
+    └── 20250127_123605_agent_done_response.txt
 ```
+
+`agent()` writes per-step files for DOM/hybrid and CUA agents. Screenshot payloads in agent logs are sanitized (replaced with size markers) to keep files manageable. When agent tools invoke `act()` or `extract()` internally, those calls may also produce files under `act_summary/` or `extract_summary/`.
+
+**Note:** Local file logging applies to in-process agent runs. Remote API agent execution (`env: "BROWSERBASE"` without `experimental: true`) runs inference server-side and does not create local `inference_summary` files.
 
 **File Types:**
 
@@ -490,6 +501,90 @@ Aggregates all calls with metrics:
       "prompt_tokens": 2890,
       "completion_tokens": 38,
       "inference_time_ms": 823
+    }
+  ]
+}
+```
+</Accordion>
+
+<Accordion title="Agent Step Call File (DOM/hybrid)">
+Per-step LLM request after captcha injection and any `prepareStep` callback:
+
+```json
+{
+  "modelCall": "agent",
+  "step": 1,
+  "systemPrompt": "You are a web automation assistant...",
+  "messages": [{ "role": "user", "content": "Click sign in" }],
+  "stepNumber": 1,
+  "tools": ["act", "extract", "done"],
+  "providerOptions": { "openai": { "store": false } }
+}
+```
+</Accordion>
+
+<Accordion title="Agent CUA Step Call File">
+Per-step CUA provider request (screenshots sanitized):
+
+```json
+{
+  "modelCall": "agent",
+  "step": 1,
+  "modelId": "openai/computer-use-preview",
+  "request": {
+    "inputItems": [{ "type": "input_image", "image_url": "[image omitted, 42.0kb]" }]
+  }
+}
+```
+</Accordion>
+
+<Accordion title="Agent Done Call File">
+Forced final `done` tool call when the agent loop ends without calling `done`:
+
+```json
+{
+  "modelCall": "agent_done",
+  "system": "You are a web automation assistant that was tasked with completing a task...",
+  "messages": [{ "role": "user", "content": "Provide your final assessment." }],
+  "toolChoice": "done"
+}
+```
+</Accordion>
+
+<Accordion title="Agent Summary File">
+Aggregates agent steps with metrics. Failed or aborted steps include `status: "failed"` and an `error` field:
+
+```json
+{
+  "agent_summary": [
+    {
+      "agent_inference_type": "agent_step",
+      "step": 1,
+      "timestamp": "20250127_123601",
+      "LLM_input_file": "20250127_123601_agent_step_1_call.txt",
+      "LLM_output_file": "20250127_123601_agent_step_1_response.txt",
+      "status": "completed",
+      "prompt_tokens": 1200,
+      "completion_tokens": 80,
+      "reasoning_tokens": 0,
+      "cached_input_tokens": 0,
+      "inference_time_ms": 2100
+    },
+    {
+      "agent_inference_type": "agent_cua_step",
+      "step": 2,
+      "status": "failed",
+      "error": "Provider rate limit exceeded"
+    },
+    {
+      "agent_inference_type": "agent_done",
+      "timestamp": "20250127_123605",
+      "LLM_input_file": "20250127_123605_agent_done_call.txt",
+      "LLM_output_file": "20250127_123605_agent_done_response.txt",
+      "status": "completed",
+      "prompt_tokens": 800,
+      "completion_tokens": 40,
+      "inference_time_ms": 950
     }
   ]
 }

--- a/packages/docs/v3/configuration/logging.mdx
+++ b/packages/docs/v3/configuration/logging.mdx
@@ -424,10 +424,10 @@ Creates timestamped files for each LLM call:
 │   ├── 20250127_123510_extract_response.txt
 │   ├── 20250127_123511_metadata_call.txt
 │   └── 20250127_123511_metadata_response.txt
-└── observe_summary/
-    ├── observe_summary.json
-    └── ...
-├── agent_summary/
+├── observe_summary/
+│   ├── observe_summary.json
+│   └── ...
+└── agent_summary/
     ├── agent_summary.json
     ├── 20250127_123600_agent_run_start.txt
     ├── 20250127_123601_agent_step_1_call.txt

--- a/packages/docs/v3/configuration/logging.mdx
+++ b/packages/docs/v3/configuration/logging.mdx
@@ -438,7 +438,7 @@ Creates timestamped files for each LLM call:
 
 `agent()` writes per-step files for DOM/hybrid and CUA agents. Screenshot payloads in agent logs are sanitized (replaced with size markers) to keep files manageable. When agent tools invoke `act()` or `extract()` internally, those calls may also produce files under `act_summary/` or `extract_summary/`.
 
-**Note:** Local file logging applies to in-process agent runs. Remote API agent execution (`env: "BROWSERBASE"` without `experimental: true`) runs inference server-side and does not create local `inference_summary` files.
+**Note:** Local file logging applies to in-process runs. On Browserbase, inference files are written when `disableAPI: true` or `experimental: true` (local execution). The default hosted API path (`env: "BROWSERBASE"` with `disableAPI: false` and `experimental: false`) runs inference server-side and does not create local `inference_summary` files.
 
 **File Types:**
 

--- a/packages/docs/v3/references/stagehand.mdx
+++ b/packages/docs/v3/references/stagehand.mdx
@@ -252,7 +252,7 @@ interface V3Options {
 <ParamField path="logInferenceToFile" type="boolean" optional>
   When `true`, writes LLM request/response dumps for `act`, `observe`, `extract`, and `agent` to `./inference_summary/`. Agent logs are stored under `agent_summary/`.
 
-  **Note:** Local file logging applies to in-process runs. Remote API agent execution (`env: "BROWSERBASE"` without `experimental: true`) runs inference server-side and does not create local `inference_summary` files.
+  **Note:** Local file logging applies to in-process runs. On Browserbase, inference files are written when `disableAPI: true` or `experimental: true` (local execution). The default hosted API path (`env: "BROWSERBASE"` with `disableAPI: false` and `experimental: false`) runs inference server-side and does not create local `inference_summary` files.
 
   **Default:** `false`
 </ParamField>

--- a/packages/docs/v3/references/stagehand.mdx
+++ b/packages/docs/v3/references/stagehand.mdx
@@ -252,6 +252,8 @@ interface V3Options {
 <ParamField path="logInferenceToFile" type="boolean" optional>
   When `true`, writes LLM request/response dumps for `act`, `observe`, `extract`, and `agent` to `./inference_summary/`. Agent logs are stored under `agent_summary/`.
 
+  **Note:** Local file logging applies to in-process runs. Remote API agent execution (`env: "BROWSERBASE"` without `experimental: true`) runs inference server-side and does not create local `inference_summary` files.
+
   **Default:** `false`
 </ParamField>
 

--- a/packages/docs/v3/references/stagehand.mdx
+++ b/packages/docs/v3/references/stagehand.mdx
@@ -250,7 +250,7 @@ interface V3Options {
 </ParamField>
 
 <ParamField path="logInferenceToFile" type="boolean" optional>
-  Log AI inference details to files for debugging.
+  When `true`, writes LLM request/response dumps for `act`, `observe`, `extract`, and `agent` to `./inference_summary/`. Agent logs are stored under `agent_summary/`.
 
   **Default:** `false`
 </ParamField>


### PR DESCRIPTION
Closes: https://github.com/browserbase/stagehand/issues/1243

# why

`logInferenceToFile` already works for `act`, `observe`, and `extract`, but not for `agent()`. That made agent runs hard to debug — especially multi-step DOM/hybrid loops and CUA calls with screenshots.

# what changed

- `logInferenceToFile` on `Stagehand` now flows through `stagehand.agent()` into DOM/hybrid and CUA handlers
- new `agentInferenceLogger` writes per-step files under `inference_summary/agent_summary/` (`agent_run_start`, `agent_step_N_call/response`, `agent_done_call/response`) and appends to `agent_summary.json`
- screenshots/base64 blobs are sanitized before writing
- abort/error paths finalize pending steps with `status: "failed"`
- docs updated for the new agent log layout

# test plan

- `packages/core/tests/unit/agent-inference-logger.test.ts` — sanitization, file writes, CUA step helper, failure/abort finalization
- `packages/core/tests/unit/v3-agent-handler-inference.test.ts` — DOM/hybrid logging (execute + stream), prepareStep overrides, abort/error paths
- `packages/core/tests/unit/cua-client-inference.test.ts` — CUA clients log when enabled
- `packages/core/tests/unit/handle-done-tool-call.test.ts` — forced `done` inference logging

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable `logInferenceToFile` for `stagehand.agent()` (DOM/hybrid and CUA) to write per-step call/response logs and a run summary under `inference_summary/agent_summary/`. Improves reliability on abort/error paths and clarifies Browserbase logging behavior.

- New Features
  - `logInferenceToFile` flows through `stagehand.agent()`, logging run start, per-step files (`agent_step_N_call/response`), and final `agent_done_call/response`, and appending to `agent_summary.json`.
  - Shared `agentInferenceLogger` adds usage/timing, fallback when call file creation fails, and sanitizes screenshots/base64 at write time.
  - Supports DOM/hybrid steps (AI SDK) and CUA clients (Anthropic, Google, Microsoft, OpenAI).

- Bug Fixes
  - Prevent duplicate step summaries on abort/error races; pending steps are finalized as `failed`.
  - Defer CUA call logging to API boundaries and mark failed CUA steps as `failed` in summaries.
  - Docs: note that local files are written only for in-process runs; on Browserbase, files are created when `disableAPI: true` or `experimental: true`.

<sup>Written for commit 631d24302c59d9a303843d9d6a3d9137e9e6a232. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

