### PR TITLE
feat(core): add setInputFiles to act() and observe()

### DIFF
--- a/.changeset/fuzzy-files-upload.md
+++ b/.changeset/fuzzy-files-upload.md
@@ -1,0 +1,8 @@
+---
+"@browserbasehq/stagehand": minor
+"@browserbasehq/stagehand-evals": patch
+---
+
+Add `setInputFiles` as an AI-supported action for `act()` and `observe()`,
+including file-path variable substitution and local file transfer when using the
+hosted Browserbase API.

--- a/packages/core/lib/inference.ts
+++ b/packages/core/lib/inference.ts
@@ -304,7 +304,7 @@ export async function observe({
             z
               .string()
               .describe(
-                "the arguments to pass to the method. For example, for a click, the arguments are empty, but for a fill, the arguments are the value to fill in.",
+                "the arguments to pass to the method. For example, click takes no arguments, fill takes the value to fill, and setInputFiles takes one or more file paths or variable placeholders.",
               ),
           ),
         }),
@@ -449,7 +449,7 @@ export async function act({
           z
             .string()
             .describe(
-              "the arguments to pass to the method. For example, for a click, the arguments are empty, but for a fill, the arguments are the value to fill in.",
+              "the arguments to pass to the method. For example, click takes no arguments, fill takes the value to fill, and setInputFiles takes one or more file paths or variable placeholders.",
             ),
         ),
       })

--- a/packages/core/lib/prompt.ts
+++ b/packages/core/lib/prompt.ts
@@ -235,7 +235,7 @@ export function buildActPrompt(
     If the user is asking to scroll to a position on the page, e.g., 'halfway' or 0.75, etc, you must return the argument formatted as the correct percentage, e.g., '50%' or '75%', etc.
     If the user is asking to scroll to the next chunk/previous chunk, choose the nextChunk/prevChunk method. No arguments are required here.
     If the action implies a key press, e.g., 'press enter', 'press a', 'press space', etc., always choose the press method with the appropriate key as argument — e.g. 'a', 'Enter', 'Space'. Do not choose a click action on an on-screen keyboard. Capitalize the first character like 'Enter', 'Tab', 'Escape' only for special keys. 
-    If the action asks to find, locate, upload, or attach files on an "input, file" element, choose setInputFiles and put each file path or matching variable placeholder in the arguments array. Do not choose click for a file input when the goal is to upload a file.
+    If the action asks to upload or attach files on an "input, file" element, choose setInputFiles and put each file path or matching variable placeholder in the arguments array. Do not choose click for a file input when the goal is to upload a file. Do not choose setInputFiles for find/locate-only instructions.
   
   Dropdown Specific Instructions:
     For interacting with dropdowns, there are two specific cases that you need to handle. 
@@ -276,7 +276,7 @@ export function buildStepTwoPrompt(
   If the user is asking to scroll to a position on the page, e.g., 'halfway' or 0.75, etc, you must return the argument formatted as the correct percentage, e.g., '50%' or '75%', etc.
   If the user is asking to scroll to the next chunk/previous chunk, choose the nextChunk/prevChunk method. No arguments are required here.
   If the action implies a key press, e.g., 'press enter', 'press a', 'press space', etc., always choose the press method with the appropriate key as argument — e.g. 'a', 'Enter', 'Space'. Do not choose a click action on an on-screen keyboard. Capitalize the first character like 'Enter', 'Tab', 'Escape' only for special keys. 
-  If the action asks to find, locate, upload, or attach files on an "input, file" element, choose setInputFiles and put each file path or matching variable placeholder in the arguments array. Do not choose click for a file input when the goal is to upload a file.
+  If the action asks to upload or attach files on an "input, file" element, choose setInputFiles and put each file path or matching variable placeholder in the arguments array. Do not choose click for a file input when the goal is to upload a file. Do not choose setInputFiles for find/locate-only instructions.
   `;
 
   instruction += buildActVariablesPrompt(variables);

--- a/packages/core/lib/prompt.ts
+++ b/packages/core/lib/prompt.ts
@@ -155,7 +155,11 @@ You will be given:
 2. a hierarchical accessibility tree showing the semantic structure of the page. The tree is a hybrid of the DOM and the accessibility tree.
 
 Return an array of elements that match the instruction if they exist, otherwise return an empty array.
-When returning elements, include the appropriate method from the supported actions list.${actionsString}${variablesString}. When choosing non-left click actions, provide right or middle as the argument.
+When returning elements, include the appropriate method from the supported actions list.${actionsString}${variablesString}.
+When the instruction asks to find, locate, upload, or attach files on an "input, file" element, choose setInputFiles (not click) so the element can be targeted for programmatic upload.
+Put each file path or matching %variableName% placeholder in the arguments array when the instruction supplies them or when matching variables are available; otherwise return an empty arguments array.
+Do not choose click for a file input when the goal is to upload a file.
+When choosing non-left click actions, provide right or middle as the argument.
 
 Each element in the accessibility tree has an ID in square brackets, like [0-18372]. The ID has two parts: frame ordinal and backend node ID. Always copy the complete ID exactly as shown inside the brackets into elementId, including the frame ordinal and hyphen. For example, if the tree shows [0-18372], return elementId "0-18372"; never return only "18372".`;
   const content = observeSystemPrompt.replace(/\s+/g, " ");
@@ -231,6 +235,7 @@ export function buildActPrompt(
     If the user is asking to scroll to a position on the page, e.g., 'halfway' or 0.75, etc, you must return the argument formatted as the correct percentage, e.g., '50%' or '75%', etc.
     If the user is asking to scroll to the next chunk/previous chunk, choose the nextChunk/prevChunk method. No arguments are required here.
     If the action implies a key press, e.g., 'press enter', 'press a', 'press space', etc., always choose the press method with the appropriate key as argument — e.g. 'a', 'Enter', 'Space'. Do not choose a click action on an on-screen keyboard. Capitalize the first character like 'Enter', 'Tab', 'Escape' only for special keys. 
+    If the action asks to find, locate, upload, or attach files on an "input, file" element, choose setInputFiles and put each file path or matching variable placeholder in the arguments array. Do not choose click for a file input when the goal is to upload a file.
   
   Dropdown Specific Instructions:
     For interacting with dropdowns, there are two specific cases that you need to handle. 
@@ -271,6 +276,7 @@ export function buildStepTwoPrompt(
   If the user is asking to scroll to a position on the page, e.g., 'halfway' or 0.75, etc, you must return the argument formatted as the correct percentage, e.g., '50%' or '75%', etc.
   If the user is asking to scroll to the next chunk/previous chunk, choose the nextChunk/prevChunk method. No arguments are required here.
   If the action implies a key press, e.g., 'press enter', 'press a', 'press space', etc., always choose the press method with the appropriate key as argument — e.g. 'a', 'Enter', 'Space'. Do not choose a click action on an on-screen keyboard. Capitalize the first character like 'Enter', 'Tab', 'Escape' only for special keys. 
+  If the action asks to find, locate, upload, or attach files on an "input, file" element, choose setInputFiles and put each file path or matching variable placeholder in the arguments array. Do not choose click for a file input when the goal is to upload a file.
   `;
 
   instruction += buildActVariablesPrompt(variables);

--- a/packages/core/lib/v3/handlers/actHandler.ts
+++ b/packages/core/lib/v3/handlers/actHandler.ts
@@ -26,7 +26,7 @@ import {
 } from "./handlerUtils/actHandlerUtils.js";
 import { createTimeoutGuard } from "./handlerUtils/timeoutGuard.js";
 import { resolveVariableValue } from "../agent/utils/variables.js";
-import { resolveSetInputFilesArguments } from "./handlerUtils/fileUploadActUtils.js";
+import { resolveSetInputFilesArguments } from "./handlerUtils/actFileUploadRouting.js";
 
 type ActInferenceElement = {
   elementId?: string;

--- a/packages/core/lib/v3/handlers/actHandler.ts
+++ b/packages/core/lib/v3/handlers/actHandler.ts
@@ -26,6 +26,7 @@ import {
 } from "./handlerUtils/actHandlerUtils.js";
 import { createTimeoutGuard } from "./handlerUtils/timeoutGuard.js";
 import { resolveVariableValue } from "../agent/utils/variables.js";
+import { resolveSetInputFilesArguments } from "./handlerUtils/fileUploadActUtils.js";
 
 type ActInferenceElement = {
   elementId?: string;
@@ -192,6 +193,7 @@ export class ActHandler {
       llmClient,
       ensureTimeRemaining,
       variables,
+      instruction,
     );
 
     // If not two-step, return the first action result
@@ -249,6 +251,7 @@ export class ActHandler {
       llmClient,
       ensureTimeRemaining,
       variables,
+      instruction,
     );
 
     // Combine results
@@ -272,6 +275,7 @@ export class ActHandler {
     llmClientOverride?: LLMClient,
     ensureTimeRemaining?: () => void,
     variables?: Variables,
+    instruction?: string,
   ): Promise<ActResult> {
     ensureTimeRemaining?.();
     const settleTimeout = domSettleTimeoutMs ?? this.defaultDomSettleTimeoutMs;
@@ -299,7 +303,9 @@ export class ActHandler {
       ? [...action.arguments]
       : [];
     const resolvedArgs =
-      substituteVariablesInArguments(action.arguments, variables) ?? [];
+      method === "setInputFiles"
+        ? resolveSetInputFilesArguments(action, variables, instruction)
+        : (substituteVariablesInArguments(action.arguments, variables) ?? []);
 
     try {
       ensureTimeRemaining?.();
@@ -364,7 +370,7 @@ export class ActHandler {
           const instruction = buildActPrompt(
             actCommand,
             Object.values(SupportedUnderstudyAction),
-            {},
+            variables,
           );
 
           ensureTimeRemaining?.();

--- a/packages/core/lib/v3/handlers/handlerUtils/actFileUploadRouting.ts
+++ b/packages/core/lib/v3/handlers/handlerUtils/actFileUploadRouting.ts
@@ -13,8 +13,8 @@ const FILE_INPUT_TARGET_RE = /\b(?:field|input|picker|dropzone|drop zone)\b/i;
 const VARIABLE_TOKEN_RE = /%([\w.]+)%/g;
 const UNRESOLVED_VARIABLE_RE = /%[^%]+%/;
 const RELATIVE_PATH_WITH_EXTENSION_RE =
-  /(?:^|[/\\])[^/\\@]+\.[a-z][a-z0-9]{1,9}$/i;
-const BARE_FILENAME_WITH_EXTENSION_RE = /^[^/\\@]+\.[a-z][a-z0-9]{1,9}$/i;
+  /(?:^|[/\\])[^/\\]+\.[a-z][a-z0-9]{1,9}$/i;
+const BARE_FILENAME_WITH_EXTENSION_RE = /^[^/\\]+\.[a-z][a-z0-9]{1,9}$/i;
 const COMMON_FILE_EXTENSION_RE =
   /\.(?:pdf|docx?|xlsx?|pptx?|txt|csv|json|xml|html?|png|jpe?g|gif|webp|svg|zip|tar|gz|mp[34]|wav|mov|avi|heic|pages|key|numbers)$/i;
 
@@ -89,7 +89,7 @@ export function looksLikeFilePath(
   const trimmed = value.trim();
   if (!trimmed) return false;
   if (/^[a-z][a-z\d+.-]*:\/\//i.test(trimmed)) return false;
-  if (trimmed.includes("@")) return false;
+  if (looksLikeEmail(trimmed)) return false;
   if (path.isAbsolute(trimmed)) return true;
   if (isExistingLocalFile(trimmed, opts.baseDir)) return true;
   if (/[/\\]/.test(trimmed) && RELATIVE_PATH_WITH_EXTENSION_RE.test(trimmed)) {
@@ -102,6 +102,13 @@ export function looksLikeFilePath(
     return true;
   }
   return false;
+}
+
+/** Reject email-shaped values without treating filenames like resume@2024.pdf as emails. */
+function looksLikeEmail(value: string): boolean {
+  if (!/^[^\s@/\\]+@[^\s@/\\]+\.[^\s@/\\]+$/i.test(value)) return false;
+  if (COMMON_FILE_EXTENSION_RE.test(value)) return false;
+  return true;
 }
 
 function isExistingLocalFile(value: string, baseDir = process.cwd()): boolean {

--- a/packages/core/lib/v3/handlers/handlerUtils/actHandlerUtils.ts
+++ b/packages/core/lib/v3/handlers/handlerUtils/actHandlerUtils.ts
@@ -136,12 +136,40 @@ const METHOD_HANDLER_MAP: Record<
   click: clickElement,
   doubleClick,
   dragAndDrop,
+  setInputFiles,
   nextChunk: scrollToNextChunk,
   prevChunk: scrollToPreviousChunk,
   selectOptionFromDropdown: selectOption,
   selectOption: selectOption,
   hover: hover,
 };
+
+async function setInputFiles(
+  ctx: UnderstudyMethodHandlerContext,
+): Promise<void> {
+  const { locator, xpath, args } = ctx;
+  if (args.length === 0 || args.some((file) => file.trim().length === 0)) {
+    throw new UnderstudyCommandException(
+      "setInputFiles(): requires at least one non-empty file path",
+    );
+  }
+
+  try {
+    await locator.setInputFiles(args.length === 1 ? args[0] : [...args]);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    v3Logger({
+      category: "action",
+      message: "error setting input files",
+      level: 0,
+      auxiliary: {
+        error: { value: msg, type: "string" },
+        xpath: { value: xpath, type: "string" },
+      },
+    });
+    throw new UnderstudyCommandException(msg, e);
+  }
+}
 
 export async function selectOption(ctx: UnderstudyMethodHandlerContext) {
   const { locator, xpath, args } = ctx;

--- a/packages/core/lib/v3/handlers/handlerUtils/fileUploadActUtils.ts
+++ b/packages/core/lib/v3/handlers/handlerUtils/fileUploadActUtils.ts
@@ -1,0 +1,269 @@
+import { existsSync, statSync } from "fs";
+import path from "path";
+import type { Variables } from "../../types/public/agent.js";
+import type { Action } from "../../types/public/methods.js";
+import { StagehandInvalidArgumentError } from "../../types/public/sdkErrors.js";
+import {
+  flattenVariables,
+  substituteVariables,
+} from "../../agent/utils/variables.js";
+
+const FILE_UPLOAD_VERB_RE = /\b(?:upload|attach)\b/i;
+const FILE_INPUT_TARGET_RE = /\b(?:field|input|picker|dropzone|drop zone)\b/i;
+const VARIABLE_TOKEN_RE = /%([\w.]+)%/g;
+const UNRESOLVED_VARIABLE_RE = /%[^%]+%/;
+const RELATIVE_PATH_WITH_EXTENSION_RE =
+  /(?:^|[/\\])[^/\\]+\.[a-zA-Z0-9]{1,10}$/;
+
+function fileUploadActDisambiguationError(
+  candidateCount: number,
+  tiedCount?: number,
+): string {
+  if (tiedCount && tiedCount > 1) {
+    return `act(): observe() returned ${candidateCount} "setInputFiles" actions and ${tiedCount} tied as the best match. Name the target field more specifically in the instruction.`;
+  }
+  return `act(): observe() returned ${candidateCount} "setInputFiles" actions and the instruction could not disambiguate which file input to use. Name the target field more specifically in the instruction.`;
+}
+
+/**
+ * Returns true when act() must resolve and execute a file upload locally
+ * (Browserbase remote act cannot read the developer machine's filesystem).
+ */
+export function shouldResolveFileUploadLocally(
+  instruction: string,
+  variables?: Variables,
+): boolean {
+  const flat = flattenVariables(variables);
+  if (!flat) return false;
+
+  if (!FILE_UPLOAD_VERB_RE.test(instruction)) return false;
+
+  const fileVarEntries = Object.entries(flat).filter(([, value]) =>
+    looksLikeFilePath(value),
+  );
+  if (fileVarEntries.length === 0) return false;
+
+  const tokens = extractVariableTokens(instruction);
+  if (
+    tokens.some((name) => name in flat && looksLikeFilePath(flat[name] ?? ""))
+  ) {
+    return true;
+  }
+
+  if (!FILE_INPUT_TARGET_RE.test(instruction)) return false;
+
+  return fileVarEntries.some(([key]) =>
+    instructionMentionsVariableKey(instruction, key),
+  );
+}
+
+/** Match %key% tokens or whole-word variable names (not substrings like cv in archive). */
+export function instructionMentionsVariableKey(
+  text: string,
+  key: string,
+): boolean {
+  if (extractVariableTokens(text).includes(key)) return true;
+  const pattern = new RegExp(
+    `(?:^|[^\\w.])${escapeRegExp(key)}(?:[^\\w.]|$)`,
+    "i",
+  );
+  return pattern.test(text.replace(VARIABLE_TOKEN_RE, " "));
+}
+
+export function extractVariableTokens(instruction: string): string[] {
+  const tokens: string[] = [];
+  for (const match of instruction.matchAll(VARIABLE_TOKEN_RE)) {
+    const name = match[1];
+    if (name) tokens.push(name);
+  }
+  return tokens;
+}
+
+export function looksLikeFilePath(
+  value: string,
+  opts: { baseDir?: string } = {},
+): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  if (/^[a-z][a-z\d+.-]*:\/\//i.test(trimmed)) return false;
+  if (path.isAbsolute(trimmed)) return true;
+  if (RELATIVE_PATH_WITH_EXTENSION_RE.test(trimmed)) return true;
+  return isExistingLocalFile(trimmed, opts.baseDir);
+}
+
+function isExistingLocalFile(value: string, baseDir = process.cwd()): boolean {
+  try {
+    const absolute = path.isAbsolute(value)
+      ? value
+      : path.resolve(baseDir, value);
+    if (!existsSync(absolute)) return false;
+    return statSync(absolute).isFile();
+  } catch {
+    return false;
+  }
+}
+
+export function selectFileUploadAction(
+  actions: Action[],
+  instruction: string,
+  variables?: Variables,
+): Action | undefined {
+  const candidates = actions.filter(
+    (action) => action.method === "setInputFiles",
+  );
+  if (candidates.length === 0) return undefined;
+  if (candidates.length === 1) return candidates[0];
+
+  const instructionWords = tokenizeForMatch(instruction);
+  let best: { action: Action; score: number } | undefined;
+
+  for (const action of candidates) {
+    const score = scoreFileUploadAction(action, instructionWords, variables);
+    if (!best || score > best.score) {
+      best = { action, score };
+    }
+  }
+
+  if (best && best.score > 0) {
+    const tied = candidates.filter(
+      (action) =>
+        scoreFileUploadAction(action, instructionWords, variables) ===
+        best!.score,
+    );
+    if (tied.length > 1) {
+      throw new StagehandInvalidArgumentError(
+        fileUploadActDisambiguationError(candidates.length, tied.length),
+      );
+    }
+    return best.action;
+  }
+
+  throw new StagehandInvalidArgumentError(
+    fileUploadActDisambiguationError(candidates.length),
+  );
+}
+
+export function resolveSetInputFilesArguments(
+  action: Action,
+  variables?: Variables,
+  instruction?: string,
+): string[] {
+  let args =
+    variables && Array.isArray(action.arguments)
+      ? action.arguments.map((arg) => substituteVariables(arg, variables))
+      : [...(action.arguments ?? [])];
+
+  if (args.length === 0 || args.every((arg) => arg.trim().length === 0)) {
+    args = inferFilePathsFromVariables(action, variables, instruction);
+  }
+
+  assertResolvedFileArguments(args);
+  return args;
+}
+
+function inferFilePathsFromVariables(
+  action: Action,
+  variables?: Variables,
+  instruction?: string,
+): string[] {
+  const flat = flattenVariables(variables);
+  if (!flat) return [];
+
+  const fileEntries = Object.entries(flat).filter(([, value]) =>
+    looksLikeFilePath(value),
+  );
+  if (fileEntries.length === 0) return [];
+
+  const instructionMentions = instruction
+    ? fileEntries.filter(([key]) =>
+        instructionMentionsVariableKey(instruction, key),
+      )
+    : [];
+  const description = action.description ?? "";
+
+  if (instructionMentions.length === 1) {
+    return [instructionMentions[0]![1]];
+  }
+  if (instructionMentions.length > 1) {
+    const descriptionScoped = instructionMentions.filter(([key]) =>
+      instructionMentionsVariableKey(description, key),
+    );
+    if (descriptionScoped.length > 0) {
+      return descriptionScoped.map(([, value]) => value);
+    }
+    return instructionMentions.map(([, value]) => value);
+  }
+
+  const descriptionMentions = fileEntries.filter(([key]) =>
+    instructionMentionsVariableKey(description, key),
+  );
+  if (descriptionMentions.length === 1) {
+    return [descriptionMentions[0]![1]];
+  }
+  if (descriptionMentions.length > 1) {
+    return descriptionMentions.map(([, value]) => value);
+  }
+
+  if (fileEntries.length === 1) {
+    return [fileEntries[0]![1]];
+  }
+
+  return [];
+}
+
+function assertResolvedFileArguments(args: string[]): void {
+  const unresolved = args.filter((arg) => UNRESOLVED_VARIABLE_RE.test(arg));
+  if (unresolved.length > 0) {
+    throw new StagehandInvalidArgumentError(
+      `setInputFiles(): variable placeholder(s) ${unresolved.join(", ")} were not provided in act() options.variables`,
+    );
+  }
+
+  if (args.length === 0 || args.some((arg) => arg.trim().length === 0)) {
+    throw new StagehandInvalidArgumentError(
+      "setInputFiles(): requires at least one non-empty file path. Provide paths through act() options.variables or include %variableName% placeholders in the instruction.",
+    );
+  }
+}
+
+function scoreFileUploadAction(
+  action: Action,
+  instructionWords: string[],
+  variables?: Variables,
+): number {
+  const haystack = [
+    action.description ?? "",
+    ...(action.arguments ?? []),
+    ...extractVariableTokens(action.description ?? ""),
+  ]
+    .join(" ")
+    .toLowerCase();
+
+  let score = 0;
+  for (const word of instructionWords) {
+    if (haystack.includes(word)) score += 1;
+  }
+
+  const flat = flattenVariables(variables);
+  if (flat) {
+    for (const [key, value] of Object.entries(flat)) {
+      if (!looksLikeFilePath(value)) continue;
+      if (instructionMentionsVariableKey(haystack, key)) score += 2;
+      if ((action.arguments ?? []).includes(`%${key}%`)) score += 3;
+    }
+  }
+
+  return score;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function tokenizeForMatch(instruction: string): string[] {
+  return instruction
+    .toLowerCase()
+    .replace(/%[\w.]+%/g, " ")
+    .split(/[^a-z0-9]+/)
+    .filter((word) => word.length > 2);
+}

--- a/packages/core/lib/v3/handlers/handlerUtils/fileUploadActUtils.ts
+++ b/packages/core/lib/v3/handlers/handlerUtils/fileUploadActUtils.ts
@@ -8,12 +8,15 @@ import {
   substituteVariables,
 } from "../../agent/utils/variables.js";
 
-const FILE_UPLOAD_VERB_RE = /\b(?:upload|attach)\b/i;
+const FILE_UPLOAD_VERB_RE = /\b(?:upload|attach|select|choose|pick)\b/i;
 const FILE_INPUT_TARGET_RE = /\b(?:field|input|picker|dropzone|drop zone)\b/i;
 const VARIABLE_TOKEN_RE = /%([\w.]+)%/g;
 const UNRESOLVED_VARIABLE_RE = /%[^%]+%/;
 const RELATIVE_PATH_WITH_EXTENSION_RE =
-  /(?:^|[/\\])[^/\\]+\.[a-zA-Z0-9]{1,10}$/;
+  /(?:^|[/\\])[^/\\@]+\.[a-z][a-z0-9]{1,9}$/i;
+const BARE_FILENAME_WITH_EXTENSION_RE = /^[^/\\@]+\.[a-z][a-z0-9]{1,9}$/i;
+const COMMON_FILE_EXTENSION_RE =
+  /\.(?:pdf|docx?|xlsx?|pptx?|txt|csv|json|xml|html?|png|jpe?g|gif|webp|svg|zip|tar|gz|mp[34]|wav|mov|avi|heic|pages|key|numbers)$/i;
 
 function fileUploadActDisambiguationError(
   candidateCount: number,
@@ -86,9 +89,19 @@ export function looksLikeFilePath(
   const trimmed = value.trim();
   if (!trimmed) return false;
   if (/^[a-z][a-z\d+.-]*:\/\//i.test(trimmed)) return false;
+  if (trimmed.includes("@")) return false;
   if (path.isAbsolute(trimmed)) return true;
-  if (RELATIVE_PATH_WITH_EXTENSION_RE.test(trimmed)) return true;
-  return isExistingLocalFile(trimmed, opts.baseDir);
+  if (isExistingLocalFile(trimmed, opts.baseDir)) return true;
+  if (/[/\\]/.test(trimmed) && RELATIVE_PATH_WITH_EXTENSION_RE.test(trimmed)) {
+    return true;
+  }
+  if (
+    BARE_FILENAME_WITH_EXTENSION_RE.test(trimmed) &&
+    COMMON_FILE_EXTENSION_RE.test(trimmed)
+  ) {
+    return true;
+  }
+  return false;
 }
 
 function isExistingLocalFile(value: string, baseDir = process.cwd()): boolean {

--- a/packages/core/lib/v3/types/private/handlers.ts
+++ b/packages/core/lib/v3/types/private/handlers.ts
@@ -45,4 +45,5 @@ export enum SupportedUnderstudyAction {
   HOVER = "hover",
   DOUBLE_CLICK = "doubleClick",
   DRAG_AND_DROP = "dragAndDrop",
+  SET_INPUT_FILES = "setInputFiles",
 }

--- a/packages/core/lib/v3/types/private/snapshot.ts
+++ b/packages/core/lib/v3/types/private/snapshot.ts
@@ -56,6 +56,8 @@ export type SessionDomIndex = {
   rootBackend: number;
   absByBe: Map<number, string>;
   tagByBe: Map<number, string>;
+  /** backendNodeId -> lowercased input type value for <input> nodes. */
+  inputTypeByBe?: Map<number, string>;
   scrollByBe: Map<number, boolean>;
   docRootOf: Map<number, number>;
   contentDocRootByIframe: Map<number, number>;
@@ -65,6 +67,8 @@ export type SessionDomIndex = {
 
 export type FrameDomMaps = {
   tagNameMap: Record<string, string>;
+  /** EncodedId -> lowercased input type value for <input> nodes. */
+  inputTypeMap?: Record<string, string>;
   xpathMap: Record<string, string>;
   scrollableMap: Record<string, boolean>;
   urlMap: Record<string, string>;
@@ -116,8 +120,11 @@ export type A11yOptions = {
   isIgnoredBackendNode?: (backendNodeId: number) => boolean;
   experimental: boolean;
   tagNameMap: Record<string, string>;
+  inputTypeMap?: Record<string, string>;
+  xpathMap?: Record<string, string>;
   scrollableMap: Record<string, boolean>;
   encode: (backendNodeId: number) => string;
+  decode?: (encodedId: string) => number | undefined;
 };
 
 export type AccessibilityTreeResult = {

--- a/packages/core/lib/v3/understudy/a11y/snapshot/a11yTree.ts
+++ b/packages/core/lib/v3/understudy/a11y/snapshot/a11yTree.ts
@@ -43,6 +43,7 @@ export async function a11yForFrame(
   }
 
   let scopeApplied = false;
+  let scopedRootBackendNodeId: number | undefined;
   const nodesForOutline = await (async () => {
     const sel = opts.focusSelector?.trim();
     if (!sel) return nodes;
@@ -61,6 +62,7 @@ export async function a11yForFrame(
       const target = nodes.find((n) => n.backendDOMNodeId === be);
       if (!target) return nodes;
       scopeApplied = true;
+      scopedRootBackendNodeId = be;
       const keep = new Set<string>([target.nodeId]);
       const queue: Protocol.Accessibility.AXNode[] = [target];
       while (queue.length) {
@@ -99,8 +101,16 @@ export async function a11yForFrame(
 
   const decorated = decorateRoles(filteredNodes, opts);
   const { tree } = await buildHierarchicalTree(decorated, opts);
+  const treeWithFileInputs = appendMissingFileInputNodes(
+    tree,
+    decorated,
+    opts,
+    scopedRootBackendNodeId,
+  );
 
-  const simplified = tree.map((n) => formatTreeLine(n)).join("\n");
+  const simplified = treeWithFileInputs
+    .map((n) => formatTreeLine(n))
+    .join("\n");
   return { outline: simplified.trimEnd(), urlMap, scopeApplied };
 }
 
@@ -167,7 +177,8 @@ export async function buildHierarchicalTree(
     const keep =
       !!(n.name && n.name.trim()) ||
       !!(n.childIds && n.childIds.length) ||
-      !isStructural(n.role);
+      !isStructural(n.role) ||
+      isFileInputNode(n, opts);
     if (!keep) continue;
     nodeMap.set(n.nodeId, { ...n });
   }
@@ -194,6 +205,9 @@ export async function buildHierarchicalTree(
 
     const children = node.children ?? [];
     if (!children.length) {
+      if (isFileInputNode(node, opts)) {
+        return { ...node, role: "input, file" };
+      }
       return isStructural(node.role) ? null : node;
     }
 
@@ -203,12 +217,15 @@ export async function buildHierarchicalTree(
 
     const prunedStatic = removeRedundantStaticTextChildren(node, cleanedKids);
 
-    if (isStructural(node.role)) {
+    if (isStructural(node.role) && !isFileInputNode(node, opts)) {
       if (prunedStatic.length === 1) return prunedStatic[0]!;
       if (prunedStatic.length === 0) return null;
     }
 
     let newRole = node.role;
+    if (isFileInputNode(node, opts)) {
+      newRole = "input, file";
+    }
     if ((newRole === "generic" || newRole === "none") && node.encodedId) {
       const tagName = opts.tagNameMap[node.encodedId];
       if (tagName) newRole = tagName;
@@ -221,6 +238,106 @@ export async function buildHierarchicalTree(
 
     return { ...node, role: newRole, children: prunedStatic };
   }
+}
+
+function isEncodedFileInput(encodedId: string, opts: A11yOptions): boolean {
+  const tag = String(opts.tagNameMap[encodedId] ?? "").toLowerCase();
+  if (tag === "input, file") return true;
+  const inputType = opts.inputTypeMap?.[encodedId];
+  return tag === "input" && String(inputType ?? "").toLowerCase() === "file";
+}
+
+function isFileInputNode(node: A11yNode, opts: A11yOptions): boolean {
+  if (!node.encodedId) return false;
+  return isEncodedFileInput(node.encodedId, opts);
+}
+
+function collectEncodedIds(
+  nodes: A11yNode[],
+  out = new Set<string>(),
+): Set<string> {
+  for (const node of nodes) {
+    if (node.encodedId) out.add(node.encodedId);
+    if (node.children?.length) collectEncodedIds(node.children, out);
+  }
+  return out;
+}
+
+export function appendMissingFileInputNodes(
+  tree: A11yNode[],
+  decorated: A11yNode[],
+  opts: A11yOptions,
+  scopedRootBackendNodeId?: number,
+): A11yNode[] {
+  const presentEncodedIds = collectEncodedIds(tree);
+  const decoratedByEncoded = new Map<string, A11yNode>();
+  for (const node of decorated) {
+    if (node.encodedId && !decoratedByEncoded.has(node.encodedId)) {
+      decoratedByEncoded.set(node.encodedId, node);
+    }
+  }
+
+  const fileInputEncodedIds = new Set<string>();
+  for (const [encodedId, tag] of Object.entries(opts.tagNameMap)) {
+    if (String(tag).toLowerCase() === "input, file") {
+      fileInputEncodedIds.add(encodedId);
+    }
+  }
+  for (const [encodedId, inputType] of Object.entries(
+    opts.inputTypeMap ?? {},
+  )) {
+    if (String(inputType).toLowerCase() === "file") {
+      fileInputEncodedIds.add(encodedId);
+    }
+  }
+
+  const extras: A11yNode[] = [];
+  const hasScopedRoot = scopedRootBackendNodeId !== undefined;
+  const scopedRootXpath = hasScopedRoot
+    ? opts.xpathMap?.[opts.encode(scopedRootBackendNodeId)]
+    : undefined;
+  for (const encodedId of fileInputEncodedIds) {
+    if (!isEncodedFileInput(encodedId, opts)) continue;
+    if (presentEncodedIds.has(encodedId)) continue;
+    const backendNodeId = opts.decode?.(encodedId);
+    if (
+      backendNodeId !== undefined &&
+      opts.isIgnoredBackendNode?.(backendNodeId)
+    ) {
+      continue;
+    }
+    if (hasScopedRoot && scopedRootXpath === undefined) {
+      continue;
+    }
+    if (scopedRootXpath !== undefined && scopedRootXpath !== "/") {
+      const candidateXpath = opts.xpathMap?.[encodedId];
+      if (
+        candidateXpath !== scopedRootXpath &&
+        !candidateXpath?.startsWith(`${scopedRootXpath}/`)
+      ) {
+        continue;
+      }
+    }
+
+    const existing = decoratedByEncoded.get(encodedId);
+    if (existing) {
+      extras.push({
+        ...existing,
+        role: "input, file",
+        children: undefined,
+      });
+      continue;
+    }
+
+    extras.push({
+      role: "input, file",
+      nodeId: `synthetic-file-${encodedId}`,
+      encodedId,
+    });
+  }
+
+  if (!extras.length) return tree;
+  return [...tree, ...extras];
 }
 
 export function isStructural(role: string): boolean {

--- a/packages/core/lib/v3/understudy/a11y/snapshot/a11yTree.ts
+++ b/packages/core/lib/v3/understudy/a11y/snapshot/a11yTree.ts
@@ -121,6 +121,13 @@ export async function a11yForFrame(
   return { outline: simplified.trimEnd(), urlMap, scopeApplied };
 }
 
+function isEncodedFileInput(encodedId: string, opts: A11yOptions): boolean {
+  const tag = String(opts.tagNameMap[encodedId] ?? "").toLowerCase();
+  if (tag === "input, file") return true;
+  const inputType = opts.inputTypeMap?.[encodedId];
+  return tag === "input" && String(inputType ?? "").toLowerCase() === "file";
+}
+
 export function decorateRoles(
   nodes: Protocol.Accessibility.AXNode[],
   opts: A11yOptions,
@@ -154,8 +161,8 @@ export function decorateRoles(
 
     // File inputs typically get role "button" from Chrome's AX tree;
     // override so they appear as "input, file" in the outline.
-    if (tag === "input, file") {
-      role = tag;
+    if (encodedId && isEncodedFileInput(encodedId, opts)) {
+      role = "input, file";
     }
 
     return {
@@ -245,13 +252,6 @@ export async function buildHierarchicalTree(
 
     return { ...node, role: newRole, children: prunedStatic };
   }
-}
-
-function isEncodedFileInput(encodedId: string, opts: A11yOptions): boolean {
-  const tag = String(opts.tagNameMap[encodedId] ?? "").toLowerCase();
-  if (tag === "input, file") return true;
-  const inputType = opts.inputTypeMap?.[encodedId];
-  return tag === "input" && String(inputType ?? "").toLowerCase() === "file";
 }
 
 function isFileInputNode(node: A11yNode, opts: A11yOptions): boolean {

--- a/packages/core/lib/v3/understudy/a11y/snapshot/a11yTree.ts
+++ b/packages/core/lib/v3/understudy/a11y/snapshot/a11yTree.ts
@@ -60,7 +60,14 @@ export async function a11yForFrame(
       const be = desc.node?.backendNodeId;
       if (typeof be !== "number") return nodes;
       const target = nodes.find((n) => n.backendDOMNodeId === be);
-      if (!target) return nodes;
+      if (!target) {
+        scopeApplied = true;
+        scopedRootBackendNodeId = be;
+        if (isEncodedFileInput(opts.encode(be), opts)) {
+          return [];
+        }
+        return nodes;
+      }
       scopeApplied = true;
       scopedRootBackendNodeId = be;
       const keep = new Set<string>([target.nodeId]);

--- a/packages/core/lib/v3/understudy/a11y/snapshot/capture.ts
+++ b/packages/core/lib/v3/understudy/a11y/snapshot/capture.ts
@@ -217,13 +217,14 @@ export async function tryScopedSnapshot(
     const sameSessionAsParent =
       !!parentId &&
       ownerSession(page, parentId) === ownerSession(page, targetFrameId);
-    const { tagNameMap, xpathMap, scrollableMap } = await domMapsForSession(
-      owningSess,
-      targetFrameId,
-      pierce,
-      (fid, be) => `${page.getOrdinal(fid)}-${be}`,
-      sameSessionAsParent,
-    );
+    const { tagNameMap, inputTypeMap, xpathMap, scrollableMap } =
+      await domMapsForSession(
+        owningSess,
+        targetFrameId,
+        pierce,
+        (fid, be) => `${page.getOrdinal(fid)}-${be}`,
+        sameSessionAsParent,
+      );
 
     const { outline, urlMap, scopeApplied } = await a11yForFrame(
       owningSess,
@@ -236,10 +237,13 @@ export async function tryScopedSnapshot(
           exclusionIntervalsByFrame,
         ),
         tagNameMap,
+        inputTypeMap,
+        xpathMap,
         experimental: options?.experimental ?? false,
         scrollableMap,
         encode: (backendNodeId) =>
           `${page.getOrdinal(targetFrameId)}-${backendNodeId}`,
+        decode: parseEncodedBackendNodeId,
       },
     );
 
@@ -371,6 +375,7 @@ export async function collectPerFrameMaps(
     );
 
     const tagNameMap: Record<string, string> = {};
+    const inputTypeMap: Record<string, string> = {};
     const xpathMap: Record<string, string> = {};
     const scrollableMap: Record<string, boolean> = {};
     const isIgnoredBackendNode = makeIsIgnoredBackendNode(
@@ -392,6 +397,8 @@ export async function collectPerFrameMaps(
       xpathMap[key] = rel;
       const tag = idx.tagByBe.get(be);
       if (tag) tagNameMap[key] = tag;
+      const inputType = idx.inputTypeByBe?.get(be);
+      if (inputType) inputTypeMap[key] = inputType;
       if (idx.scrollByBe.get(be)) scrollableMap[key] = true;
     }
 
@@ -399,12 +406,21 @@ export async function collectPerFrameMaps(
       isIgnoredBackendNode,
       experimental: options?.experimental ?? false,
       tagNameMap,
+      inputTypeMap,
+      xpathMap,
       scrollableMap,
       encode: (backendNodeId) => `${page.getOrdinal(frameId)}-${backendNodeId}`,
+      decode: parseEncodedBackendNodeId,
     });
 
     perFrameOutlines.push({ frameId, outline });
-    perFrameMaps.set(frameId, { tagNameMap, xpathMap, scrollableMap, urlMap });
+    perFrameMaps.set(frameId, {
+      tagNameMap,
+      inputTypeMap,
+      xpathMap,
+      scrollableMap,
+      urlMap,
+    });
   }
 
   return { perFrameMaps, perFrameOutlines };

--- a/packages/core/lib/v3/understudy/a11y/snapshot/domTree.ts
+++ b/packages/core/lib/v3/understudy/a11y/snapshot/domTree.ts
@@ -17,6 +17,13 @@ function isCborStackError(message: string): boolean {
   return message.includes("CBOR: stack limit exceeded");
 }
 
+function extractInputType(node: Protocol.DOM.Node): string | undefined {
+  const tag = String(node.nodeName ?? "").toLowerCase();
+  if (tag !== "input") return undefined;
+  const type = getAttr(node.attributes, "type");
+  return (type || "text").toLowerCase();
+}
+
 /**
  * Determine if CDP truncated a node's children when streaming the DOM tree.
  * childNodeCount stays accurate even when `children` are omitted; we use this to
@@ -182,6 +189,7 @@ export async function domMapsForSession(
   attemptOwnerLookup = true,
 ): Promise<{
   tagNameMap: Record<string, string>;
+  inputTypeMap: Record<string, string>;
   xpathMap: Record<string, string>;
   scrollableMap: Record<string, boolean>;
 }> {
@@ -208,6 +216,7 @@ export async function domMapsForSession(
   }
 
   const tagNameMap: Record<string, string> = {};
+  const inputTypeMap: Record<string, string> = {};
   const xpathMap: Record<string, string> = {};
   const scrollableMap: Record<string, boolean> = {};
 
@@ -220,6 +229,8 @@ export async function domMapsForSession(
     if (node.backendNodeId) {
       const encId = encode(frameId, node.backendNodeId);
       tagNameMap[encId] = enrichedTagName(node);
+      const inputType = extractInputType(node);
+      if (inputType) inputTypeMap[encId] = inputType;
       xpathMap[encId] = xpath || "/";
       const isScrollable = node?.isScrollable === true;
       if (isScrollable) scrollableMap[encId] = true;
@@ -246,7 +257,7 @@ export async function domMapsForSession(
     }
   }
 
-  return { tagNameMap, xpathMap, scrollableMap };
+  return { tagNameMap, inputTypeMap, xpathMap, scrollableMap };
 }
 
 /**
@@ -263,6 +274,7 @@ export async function buildSessionDomIndex(
 
   const absByBe = new Map<number, string>();
   const tagByBe = new Map<number, string>();
+  const inputTypeByBe = new Map<number, string>();
   const scrollByBe = new Map<number, boolean>();
   const docRootOf = new Map<number, number>();
   const contentDocRootByIframe = new Map<number, number>();
@@ -294,6 +306,8 @@ export async function buildSessionDomIndex(
       enterByBe.set(node.backendNodeId, dfsIndex++);
       absByBe.set(node.backendNodeId, xp || "/");
       tagByBe.set(node.backendNodeId, enrichedTagName(node));
+      const inputType = extractInputType(node);
+      if (inputType) inputTypeByBe.set(node.backendNodeId, inputType);
       if (node?.isScrollable === true) scrollByBe.set(node.backendNodeId, true);
       docRootOf.set(node.backendNodeId, docRootBe);
     }
@@ -340,6 +354,7 @@ export async function buildSessionDomIndex(
     rootBackend: rootBe,
     absByBe,
     tagByBe,
+    inputTypeByBe,
     scrollByBe,
     docRootOf,
     contentDocRootByIframe,

--- a/packages/core/lib/v3/v3.ts
+++ b/packages/core/lib/v3/v3.ts
@@ -96,6 +96,10 @@ import { FlowLogger, type FlowLoggerContext } from "./flowlogger/FlowLogger.js";
 import { EventEmitterWithWildcardSupport } from "./flowlogger/EventEmitter.js";
 import { EventStore } from "./flowlogger/EventStore.js";
 import { createTimeoutGuard } from "./handlers/handlerUtils/timeoutGuard.js";
+import {
+  selectFileUploadAction,
+  shouldResolveFileUploadLocally,
+} from "./handlers/handlerUtils/fileUploadActUtils.js";
 import { ActTimeoutError } from "./types/public/sdkErrors.js";
 
 const DEFAULT_MODEL_NAME = "openai/gpt-4.1-mini";
@@ -1239,7 +1243,7 @@ export class V3 {
 
         // Use selector as provided to support XPath, CSS, and other engines
         const selector = input.selector;
-        if (this.apiClient) {
+        if (this.apiClient && input.method !== "setInputFiles") {
           actResult = await this.apiClient.act({
             input,
             options,
@@ -1286,10 +1290,15 @@ export class V3 {
       let actCacheContext: Awaited<
         ReturnType<typeof this.actCache.prepareContext>
       > | null = null;
+      const isFileUploadAct = shouldResolveFileUploadLocally(
+        input,
+        options?.variables,
+      );
       const canUseCache =
         typeof input === "string" &&
         !this.isAgentReplayRecording() &&
-        this.actCache.enabled;
+        this.actCache.enabled &&
+        !isFileUploadAct;
       if (canUseCache) {
         actCacheContext = await this.actCache.prepareContext(
           input,
@@ -1326,7 +1335,41 @@ export class V3 {
         timeout: options?.timeout,
         model: options?.model,
       };
-      if (this.apiClient) {
+      if (this.apiClient && isFileUploadAct) {
+        const ensureTimeRemaining = createTimeoutGuard(
+          options?.timeout,
+          (ms) => new ActTimeoutError(ms),
+        );
+        ensureTimeRemaining();
+        const frameId = page.mainFrameId();
+        const actions = await this.apiClient.observe({
+          instruction: input,
+          options,
+          frameId,
+        });
+        ensureTimeRemaining();
+        const uploadAction = selectFileUploadAction(
+          actions,
+          input,
+          options?.variables,
+        );
+
+        if (!uploadAction) {
+          throw new StagehandInvalidArgumentError(
+            'act(): the instruction requests a file upload, but observe() did not return a "setInputFiles" action. Ensure the instruction names the file input and supplies each local path through variables.',
+          );
+        } else {
+          actResult = await this.actHandler.takeDeterministicAction(
+            uploadAction,
+            page,
+            this.domSettleTimeoutMs,
+            this.resolveLlmClient(options?.model),
+            ensureTimeRemaining,
+            options?.variables,
+            input,
+          );
+        }
+      } else if (this.apiClient) {
         const frameId = page.mainFrameId();
         actResult = await this.apiClient.act({ input, options, frameId });
       } else {

--- a/packages/core/lib/v3/v3.ts
+++ b/packages/core/lib/v3/v3.ts
@@ -99,7 +99,7 @@ import { createTimeoutGuard } from "./handlers/handlerUtils/timeoutGuard.js";
 import {
   selectFileUploadAction,
   shouldResolveFileUploadLocally,
-} from "./handlers/handlerUtils/fileUploadActUtils.js";
+} from "./handlers/handlerUtils/actFileUploadRouting.js";
 import { ActTimeoutError } from "./types/public/sdkErrors.js";
 
 const DEFAULT_MODEL_NAME = "openai/gpt-4.1-mini";
@@ -1358,17 +1358,16 @@ export class V3 {
           throw new StagehandInvalidArgumentError(
             'act(): the instruction requests a file upload, but observe() did not return a "setInputFiles" action. Ensure the instruction names the file input and supplies each local path through variables.',
           );
-        } else {
-          actResult = await this.actHandler.takeDeterministicAction(
-            uploadAction,
-            page,
-            this.domSettleTimeoutMs,
-            this.resolveLlmClient(options?.model),
-            ensureTimeRemaining,
-            options?.variables,
-            input,
-          );
         }
+        actResult = await this.actHandler.takeDeterministicAction(
+          uploadAction,
+          page,
+          this.domSettleTimeoutMs,
+          this.resolveLlmClient(options?.model),
+          ensureTimeRemaining,
+          options?.variables,
+          input,
+        );
       } else if (this.apiClient) {
         const frameId = page.mainFrameId();
         actResult = await this.apiClient.act({ input, options, frameId });

--- a/packages/core/tests/integration/setinputfiles.spec.ts
+++ b/packages/core/tests/integration/setinputfiles.spec.ts
@@ -6,6 +6,7 @@ import crypto from "crypto";
 import type { Page as V3Page } from "../../lib/v3/understudy/page.js";
 import { V3 } from "../../lib/v3/v3.js";
 import { v3TestConfig } from "./v3.config.js";
+import { performUnderstudyMethod } from "../../lib/v3/handlers/handlerUtils/actHandlerUtils.js";
 
 const FILE_UPLOAD_IFRAME_URL =
   "https://browserbase.github.io/stagehand-eval-sites/sites/file-uploads-iframe/";
@@ -130,6 +131,40 @@ test.describe("tests setInputFiles()", () => {
     await page.locator(IMAGES_INPUT).setInputFiles([first, second]);
     await expectUploadSuccess(page, IMAGES_SUCCESS, "Images uploaded!");
     await expectFileCount(page, IMAGES_INPUT, 2);
+  });
+
+  test("understudy action executor uploads multiple files", async () => {
+    const page = v3.context.pages()[0];
+    await page.goto(FILE_UPLOAD_V2_URL);
+    const first = await createFixture("action-image-a", "A", ".png");
+    const second = await createFixture("action-image-b", "B", ".jpeg");
+
+    await performUnderstudyMethod(
+      page,
+      page.mainFrame(),
+      "setInputFiles",
+      `xpath=//*[@id="imagesUpload"]`,
+      [first, second],
+      30_000,
+    );
+
+    await expectUploadSuccess(page, IMAGES_SUCCESS, "Images uploaded!");
+    await expectFileCount(page, IMAGES_INPUT, 2);
+  });
+
+  test("act uploads a file supplied through variables", async () => {
+    const page = v3.context.pages()[0];
+    await page.goto(FILE_UPLOAD_V2_URL);
+    const resume = await createFixture("act-resume", "resume", ".pdf");
+
+    const result = await v3.act("upload %resume% to the resume field", {
+      variables: { resume },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.actions[0]?.method).toBe("setInputFiles");
+    await expectUploadSuccess(page, RESUME_SUCCESS, "Resume uploaded!");
+    await expectFileCount(page, RESUME_INPUT, 1);
   });
 
   test("locator uploads audio via payload object", async () => {

--- a/packages/core/tests/unit/act-file-upload-routing.test.ts
+++ b/packages/core/tests/unit/act-file-upload-routing.test.ts
@@ -11,7 +11,7 @@ import {
   resolveSetInputFilesArguments,
   selectFileUploadAction,
   shouldResolveFileUploadLocally,
-} from "../../lib/v3/handlers/handlerUtils/fileUploadActUtils.js";
+} from "../../lib/v3/handlers/handlerUtils/actFileUploadRouting.js";
 
 describe("shouldResolveFileUploadLocally", () => {
   it("detects attach instructions with file variables", () => {
@@ -59,6 +59,14 @@ describe("shouldResolveFileUploadLocally", () => {
     expect(
       shouldResolveFileUploadLocally("upload %resume% to the resume field", {
         resume: filePath,
+      }),
+    ).toBe(true);
+  });
+
+  it("detects upload instructions with @ in the file path", () => {
+    expect(
+      shouldResolveFileUploadLocally("upload %resume% to the resume field", {
+        resume: "/tmp/resume@2024.pdf",
       }),
     ).toBe(true);
   });
@@ -318,6 +326,9 @@ describe("file upload helpers", () => {
     expect(looksLikeFilePath("2024/01/15")).toBe(false);
     expect(looksLikeFilePath("secret123")).toBe(false);
     expect(looksLikeFilePath("user@example.com")).toBe(false);
+    expect(looksLikeFilePath("/tmp/resume@2024.pdf")).toBe(true);
+    expect(looksLikeFilePath("resume@2024.pdf")).toBe(true);
+    expect(looksLikeFilePath("fixtures/resume@2024.pdf")).toBe(true);
     expect(looksLikeFilePath("example.com")).toBe(false);
     expect(looksLikeFilePath("v1.2.3")).toBe(false);
   });

--- a/packages/core/tests/unit/file-upload-act-utils.test.ts
+++ b/packages/core/tests/unit/file-upload-act-utils.test.ts
@@ -30,6 +30,19 @@ describe("shouldResolveFileUploadLocally", () => {
     ).toBe(true);
   });
 
+  it("detects select/choose phrasing with file variables", () => {
+    expect(
+      shouldResolveFileUploadLocally("select %resume% in the resume field", {
+        resume: "/tmp/resume.pdf",
+      }),
+    ).toBe(true);
+    expect(
+      shouldResolveFileUploadLocally("choose %resume% for the resume field", {
+        resume: "/tmp/resume.pdf",
+      }),
+    ).toBe(true);
+  });
+
   it("detects upload instructions when variables are named in the instruction", () => {
     expect(
       shouldResolveFileUploadLocally("upload resume to the resume field", {
@@ -304,6 +317,9 @@ describe("file upload helpers", () => {
     expect(looksLikeFilePath("https://example.com/resume.pdf")).toBe(false);
     expect(looksLikeFilePath("2024/01/15")).toBe(false);
     expect(looksLikeFilePath("secret123")).toBe(false);
+    expect(looksLikeFilePath("user@example.com")).toBe(false);
+    expect(looksLikeFilePath("example.com")).toBe(false);
+    expect(looksLikeFilePath("v1.2.3")).toBe(false);
   });
 
   it("recognizes extensionless relative paths that exist on disk", () => {

--- a/packages/core/tests/unit/file-upload-act-utils.test.ts
+++ b/packages/core/tests/unit/file-upload-act-utils.test.ts
@@ -1,0 +1,322 @@
+import { mkdtempSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { describe, expect, it } from "vitest";
+import type { Action } from "../../lib/v3/types/public/methods.js";
+import { StagehandInvalidArgumentError } from "../../lib/v3/types/public/sdkErrors.js";
+import {
+  extractVariableTokens,
+  instructionMentionsVariableKey,
+  looksLikeFilePath,
+  resolveSetInputFilesArguments,
+  selectFileUploadAction,
+  shouldResolveFileUploadLocally,
+} from "../../lib/v3/handlers/handlerUtils/fileUploadActUtils.js";
+
+describe("shouldResolveFileUploadLocally", () => {
+  it("detects attach instructions with file variables", () => {
+    expect(
+      shouldResolveFileUploadLocally("attach %resume% to the resume field", {
+        resume: "/tmp/resume.pdf",
+      }),
+    ).toBe(true);
+  });
+
+  it("detects upload instructions that name files", () => {
+    expect(
+      shouldResolveFileUploadLocally("upload %resume% to the resume field", {
+        resume: "/tmp/resume.pdf",
+      }),
+    ).toBe(true);
+  });
+
+  it("detects upload instructions when variables are named in the instruction", () => {
+    expect(
+      shouldResolveFileUploadLocally("upload resume to the resume field", {
+        resume: "/tmp/resume.pdf",
+      }),
+    ).toBe(true);
+  });
+
+  it("detects extensionless relative paths referenced by variable tokens", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "stagehand-upload-"));
+    const filePath = path.join(dir, "resume");
+    writeFileSync(filePath, "resume");
+
+    expect(
+      shouldResolveFileUploadLocally("upload %resume% to the resume field", {
+        resume: filePath,
+      }),
+    ).toBe(true);
+  });
+
+  it("ignores unrelated upload wording", () => {
+    expect(
+      shouldResolveFileUploadLocally("scroll the upload section into view"),
+    ).toBe(false);
+    expect(shouldResolveFileUploadLocally("attach debugger to the page")).toBe(
+      false,
+    );
+    expect(shouldResolveFileUploadLocally("upload progress to 100%")).toBe(
+      false,
+    );
+  });
+
+  it("does not route file-variable instructions without upload intent", () => {
+    expect(
+      shouldResolveFileUploadLocally("fill in the pdf form", {
+        pdf: "/tmp/form.pdf",
+      }),
+    ).toBe(false);
+    expect(
+      shouldResolveFileUploadLocally("open the resume preview", {
+        resume: "/tmp/resume.pdf",
+      }),
+    ).toBe(false);
+  });
+
+  it("requires a referenced file variable even with upload wording", () => {
+    expect(
+      shouldResolveFileUploadLocally("upload the photo gallery", {
+        photo: "/tmp/photo.png",
+      }),
+    ).toBe(false);
+    expect(
+      shouldResolveFileUploadLocally("upload the photo gallery", {
+        resume: "/tmp/resume.pdf",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not treat URL variables as local file uploads", () => {
+    expect(
+      shouldResolveFileUploadLocally("go to %url%", {
+        url: "https://example.com/path",
+      }),
+    ).toBe(false);
+    expect(
+      shouldResolveFileUploadLocally("upload %url% to the form", {
+        url: "https://example.com/file.pdf",
+      }),
+    ).toBe(false);
+  });
+
+  it("requires a resolvable file path before using the local upload path", () => {
+    expect(shouldResolveFileUploadLocally("upload the document")).toBe(false);
+    expect(
+      shouldResolveFileUploadLocally("upload %document%", {
+        document: "not-a-path",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not match variable names as substrings of unrelated words", () => {
+    expect(
+      shouldResolveFileUploadLocally("upload to the archive section", {
+        cv: "/tmp/resume.pdf",
+      }),
+    ).toBe(false);
+    expect(
+      shouldResolveFileUploadLocally("upload the candidate resume", {
+        id: "/tmp/resume.pdf",
+      }),
+    ).toBe(false);
+  });
+
+  it("still matches whole-word variable names without %tokens%", () => {
+    expect(
+      shouldResolveFileUploadLocally("upload resume to the resume field", {
+        resume: "/tmp/resume.pdf",
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("selectFileUploadAction", () => {
+  const resumeAction: Action = {
+    selector: "xpath=/html/body/input#resume",
+    description: "resume file input",
+    method: "setInputFiles",
+    arguments: ["%resume%"],
+  };
+  const imagesAction: Action = {
+    selector: "xpath=/html/body/input#images",
+    description: "images file input",
+    method: "setInputFiles",
+    arguments: ["%images%"],
+  };
+
+  it("returns the only setInputFiles candidate", () => {
+    expect(
+      selectFileUploadAction([resumeAction], "upload %resume%", {
+        resume: "/tmp/resume.pdf",
+      }),
+    ).toEqual(resumeAction);
+  });
+
+  it("prefers the candidate that matches the instruction", () => {
+    expect(
+      selectFileUploadAction(
+        [imagesAction, resumeAction],
+        "upload %resume% to the resume field",
+        { resume: "/tmp/resume.pdf", images: "/tmp/a.png" },
+      ),
+    ).toEqual(resumeAction);
+  });
+
+  it("throws when multiple file inputs cannot be disambiguated", () => {
+    expect(() =>
+      selectFileUploadAction([imagesAction, resumeAction], "upload files", {
+        resume: "/tmp/resume.pdf",
+        images: "/tmp/a.png",
+      }),
+    ).toThrow(StagehandInvalidArgumentError);
+  });
+});
+
+describe("resolveSetInputFilesArguments", () => {
+  it("substitutes variable placeholders", () => {
+    expect(
+      resolveSetInputFilesArguments(
+        {
+          selector: "xpath=/html/body/input",
+          description: "resume file input",
+          method: "setInputFiles",
+          arguments: ["%resume%"],
+        },
+        { resume: "/tmp/resume.pdf" },
+      ),
+    ).toEqual(["/tmp/resume.pdf"]);
+  });
+
+  it("infers a single file variable from the action description", () => {
+    expect(
+      resolveSetInputFilesArguments(
+        {
+          selector: "xpath=/html/body/input",
+          description: "resume file input",
+          method: "setInputFiles",
+          arguments: [],
+        },
+        { resume: "/tmp/resume.pdf" },
+      ),
+    ).toEqual(["/tmp/resume.pdf"]);
+  });
+
+  it("infers a file variable from the original instruction before the generic description", () => {
+    expect(
+      resolveSetInputFilesArguments(
+        {
+          selector: "xpath=/html/body/input",
+          description: "file upload input",
+          method: "setInputFiles",
+          arguments: [],
+        },
+        { resume: "/tmp/resume.pdf", avatar: "/tmp/avatar.png" },
+        "upload %resume% to the resume field",
+      ),
+    ).toEqual(["/tmp/resume.pdf"]);
+  });
+
+  it("infers the only file variable when observe returns empty arguments", () => {
+    expect(
+      resolveSetInputFilesArguments(
+        {
+          selector: "xpath=/html/body/input",
+          description: "file upload input",
+          method: "setInputFiles",
+          arguments: [],
+        },
+        { resume: "/tmp/resume.pdf" },
+      ),
+    ).toEqual(["/tmp/resume.pdf"]);
+  });
+
+  it("scopes multi-variable instructions to the action description", () => {
+    expect(
+      resolveSetInputFilesArguments(
+        {
+          selector: "xpath=/html/body/input#resume",
+          description: "resume file input",
+          method: "setInputFiles",
+          arguments: [],
+        },
+        { resume: "/tmp/resume.pdf", cover: "/tmp/cover.pdf" },
+        "upload %resume% and %cover%",
+      ),
+    ).toEqual(["/tmp/resume.pdf"]);
+  });
+
+  it("does not infer when multiple file variables are present but none are mentioned", () => {
+    expect(() =>
+      resolveSetInputFilesArguments(
+        {
+          selector: "xpath=/html/body/input",
+          description: "file input",
+          method: "setInputFiles",
+          arguments: [],
+        },
+        { resume: "/tmp/resume.pdf", avatar: "/tmp/avatar.png" },
+      ),
+    ).toThrow(/at least one non-empty file path/i);
+  });
+
+  it("rejects unresolved variable placeholders", () => {
+    expect(() =>
+      resolveSetInputFilesArguments({
+        selector: "xpath=/html/body/input",
+        description: "resume file input",
+        method: "setInputFiles",
+        arguments: ["%resume%"],
+      }),
+    ).toThrow(/variable placeholder/i);
+  });
+});
+
+describe("file upload helpers", () => {
+  it("extracts variable tokens", () => {
+    expect(extractVariableTokens("upload %resume% and %cover%")).toEqual([
+      "resume",
+      "cover",
+    ]);
+  });
+
+  it("matches variable keys by token or whole word only", () => {
+    expect(instructionMentionsVariableKey("upload %resume%", "resume")).toBe(
+      true,
+    );
+    expect(
+      instructionMentionsVariableKey("upload resume to the field", "resume"),
+    ).toBe(true);
+    expect(instructionMentionsVariableKey("upload to the archive", "cv")).toBe(
+      false,
+    );
+    expect(
+      instructionMentionsVariableKey("upload candidate resume", "id"),
+    ).toBe(false);
+  });
+
+  it("recognizes likely file paths", () => {
+    expect(looksLikeFilePath("/tmp/resume.pdf")).toBe(true);
+    expect(looksLikeFilePath("/tmp/resume")).toBe(true);
+    expect(looksLikeFilePath("resume.pdf")).toBe(true);
+    expect(looksLikeFilePath("fixtures/resume.pdf")).toBe(true);
+    expect(looksLikeFilePath("https://example.com/resume.pdf")).toBe(false);
+    expect(looksLikeFilePath("2024/01/15")).toBe(false);
+    expect(looksLikeFilePath("secret123")).toBe(false);
+  });
+
+  it("recognizes extensionless relative paths that exist on disk", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "stagehand-upload-"));
+    const relativeDir = path.basename(dir);
+    const fileName = "resume";
+    writeFileSync(path.join(dir, fileName), "resume");
+
+    expect(
+      looksLikeFilePath(path.join(relativeDir, fileName), {
+        baseDir: path.dirname(dir),
+      }),
+    ).toBe(true);
+    expect(looksLikeFilePath("missing/fixtures/resume")).toBe(false);
+  });
+});

--- a/packages/core/tests/unit/prompt-observe-variables.test.ts
+++ b/packages/core/tests/unit/prompt-observe-variables.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildObserveSystemPrompt } from "../../lib/prompt.js";
+import { buildActPrompt, buildObserveSystemPrompt } from "../../lib/prompt.js";
 
 describe("buildObserveSystemPrompt", () => {
   it("includes variable descriptions when present", () => {
@@ -28,5 +28,34 @@ describe("buildObserveSystemPrompt", () => {
     );
     expect(prompt.content).toContain('return elementId "0-18372"');
     expect(prompt.content).toContain('never return only "18372"');
+  });
+
+  it("instructs observe to upload files without clicking the file input", () => {
+    const prompt = buildObserveSystemPrompt(undefined, [
+      "click",
+      "setInputFiles",
+    ]);
+
+    expect(prompt.content).toContain(
+      'find, locate, upload, or attach files on an "input, file" element',
+    );
+    expect(prompt.content).toContain("choose setInputFiles");
+    expect(prompt.content).toContain(
+      "Do not choose click for a file input when the goal is to upload a file",
+    );
+  });
+
+  it("instructs act to pass file variables to setInputFiles", () => {
+    const prompt = buildActPrompt(
+      "upload my resume",
+      ["click", "setInputFiles"],
+      { resume: "/tmp/resume.pdf" },
+    );
+
+    expect(prompt).toContain("choose setInputFiles");
+    expect(prompt).toContain(
+      "put each file path or matching variable placeholder in the arguments array",
+    );
+    expect(prompt).toContain("%resume%");
   });
 });

--- a/packages/core/tests/unit/snapshot-a11y-resolvers.test.ts
+++ b/packages/core/tests/unit/snapshot-a11y-resolvers.test.ts
@@ -363,6 +363,7 @@ describe("tryScopedSnapshot", () => {
       .spyOn(domTree, "domMapsForSession")
       .mockResolvedValue({
         tagNameMap: { "1-10": "div" },
+        inputTypeMap: {},
         xpathMap: { "1-10": "/div[1]" },
         scrollableMap: {},
       });
@@ -398,6 +399,7 @@ describe("tryScopedSnapshot", () => {
     const session = new MockCDPSession({});
     vi.spyOn(domTree, "domMapsForSession").mockResolvedValue({
       tagNameMap: { "1-10": "div" },
+      inputTypeMap: {},
       xpathMap: { "1-10": "/div[1]" },
       scrollableMap: {},
     });
@@ -437,6 +439,7 @@ describe("tryScopedSnapshot", () => {
     const session = new MockCDPSession({});
     vi.spyOn(domTree, "domMapsForSession").mockResolvedValue({
       tagNameMap: { "1-10": "div" },
+      inputTypeMap: {},
       xpathMap: { "1-10": "/div[1]" },
       scrollableMap: {},
     });
@@ -488,6 +491,7 @@ describe("tryScopedSnapshot", () => {
     const session = new MockCDPSession({});
     vi.spyOn(domTree, "domMapsForSession").mockResolvedValue({
       tagNameMap: { "1-10": "div", "1-11": "div" },
+      inputTypeMap: {},
       xpathMap: { "1-10": "/div[1]", "1-11": "/div[2]" },
       scrollableMap: {},
     });

--- a/packages/core/tests/unit/snapshot-a11y-resolvers.test.ts
+++ b/packages/core/tests/unit/snapshot-a11y-resolvers.test.ts
@@ -128,6 +128,39 @@ describe("a11yForFrame", () => {
     resolveSpy.mockRestore();
   });
 
+  it("scopes omitted file inputs to the resolved focus selector target", async () => {
+    const session = new MockCDPSession({
+      ...baseHandlers,
+      "Accessibility.getFullAXTree": async () => ({ nodes: baseAxNodes() }),
+      "DOM.describeNode": async () => ({
+        node: { backendNodeId: 42 },
+      }),
+    });
+
+    const resolveSpy = vi
+      .spyOn(focusSelectors, "resolveObjectIdForCss")
+      .mockResolvedValue("object-42");
+
+    const opts: A11yOptions = {
+      focusSelector: "#resumeUpload",
+      experimental: false,
+      tagNameMap: { "enc-42": "input, file", "enc-101": "a" },
+      xpathMap: {
+        "enc-42": "/html[1]/body[1]/input[1]",
+        "enc-101": "/html[1]/body[1]/a[1]",
+      },
+      scrollableMap: {},
+      encode: (backend) => `enc-${backend}`,
+    };
+
+    const result = await a11yForFrame(session, "frame-1", opts);
+
+    expect(result.scopeApplied).toBe(true);
+    expect(result.outline).toContain("input, file");
+    expect(result.outline).not.toContain("Docs");
+    resolveSpy.mockRestore();
+  });
+
   it("falls back to full tree when resolveObjectId throws", async () => {
     const session = new MockCDPSession({
       ...baseHandlers,

--- a/packages/core/tests/unit/snapshot-a11y-tree-utils.test.ts
+++ b/packages/core/tests/unit/snapshot-a11y-tree-utils.test.ts
@@ -5,6 +5,7 @@ import type {
   A11yOptions,
 } from "../../lib/v3/types/private/snapshot.js";
 import {
+  appendMissingFileInputNodes,
   buildHierarchicalTree,
   decorateRoles,
   extractUrlFromAXNode,
@@ -182,6 +183,49 @@ describe("buildHierarchicalTree", () => {
     expect(tree).toEqual([]);
   });
 
+  it("keeps structural file inputs so observe context retains upload targets", async () => {
+    const nodes: A11yNode[] = [
+      {
+        role: "generic",
+        name: "",
+        nodeId: "upload",
+        encodedId: "upload",
+        parentId: undefined,
+        childIds: [],
+      },
+    ];
+
+    const { tree } = await buildHierarchicalTree(nodes, {
+      ...opts,
+      tagNameMap: { upload: "input, file" },
+    });
+    expect(tree).toHaveLength(1);
+    expect(tree[0]?.encodedId).toBe("upload");
+    expect(tree[0]?.role).toBe("input, file");
+  });
+
+  it("keeps structural file inputs when input type metadata is present", async () => {
+    const nodes: A11yNode[] = [
+      {
+        role: "generic",
+        name: "",
+        nodeId: "upload",
+        encodedId: "upload",
+        parentId: undefined,
+        childIds: [],
+      },
+    ];
+
+    const { tree } = await buildHierarchicalTree(nodes, {
+      ...opts,
+      tagNameMap: { upload: "input" },
+      inputTypeMap: { upload: "file" },
+    });
+    expect(tree).toHaveLength(1);
+    expect(tree[0]?.encodedId).toBe("upload");
+    expect(tree[0]?.role).toBe("input, file");
+  });
+
   it("promotes select/combobox tag names for structural nodes", async () => {
     const nodes: A11yNode[] = [
       {
@@ -306,6 +350,60 @@ describe("buildHierarchicalTree", () => {
 
     const { tree } = await buildHierarchicalTree(nodes, opts);
     expect(tree).toEqual([]);
+  });
+});
+
+describe("appendMissingFileInputNodes", () => {
+  it("synthesizes a file input omitted from the accessibility tree", () => {
+    const tree = appendMissingFileInputNodes([], [], {
+      ...defaultOpts,
+      tagNameMap: { "enc-42": "input, file" },
+    });
+
+    expect(tree).toEqual([
+      {
+        role: "input, file",
+        nodeId: "synthetic-file-enc-42",
+        encodedId: "enc-42",
+      },
+    ]);
+  });
+
+  it("does not synthesize ignored file inputs", () => {
+    const tree = appendMissingFileInputNodes([], [], {
+      ...defaultOpts,
+      tagNameMap: { "enc-42": "input, file" },
+      decode: () => 42,
+      isIgnoredBackendNode: (backendNodeId) => backendNodeId === 42,
+    });
+
+    expect(tree).toEqual([]);
+  });
+
+  it("only synthesizes file inputs inside the scoped subtree", () => {
+    const opts: A11yOptions = {
+      ...defaultOpts,
+      tagNameMap: {
+        "enc-10": "section",
+        "enc-11": "input, file",
+        "enc-12": "input, file",
+      },
+      xpathMap: {
+        "enc-10": "/html[1]/body[1]/section[1]",
+        "enc-11": "/html[1]/body[1]/section[1]/input[1]",
+        "enc-12": "/html[1]/body[1]/input[1]",
+      },
+    };
+
+    const tree = appendMissingFileInputNodes([], [], opts, 10);
+
+    expect(tree).toEqual([
+      {
+        role: "input, file",
+        nodeId: "synthetic-file-enc-11",
+        encodedId: "enc-11",
+      },
+    ]);
   });
 });
 

--- a/packages/core/tests/unit/snapshot-a11y-tree-utils.test.ts
+++ b/packages/core/tests/unit/snapshot-a11y-tree-utils.test.ts
@@ -109,6 +109,29 @@ describe("decorateRoles", () => {
     });
   });
 
+  it("overrides role to 'input, file' when input type metadata is present", () => {
+    const opts: A11yOptions = {
+      ...defaultOpts,
+      tagNameMap: { "enc-10": "input" },
+      inputTypeMap: { "enc-10": "file" },
+      scrollableMap: {},
+    };
+    const nodes = [
+      makeAxNode({
+        backendDOMNodeId: 10,
+        role: axString("button"),
+        name: axString("Choose File"),
+      }),
+    ];
+
+    const decorated = decorateRoles(nodes, opts);
+    expect(decorated[0]).toMatchObject({
+      encodedId: "enc-10",
+      role: "input, file",
+      name: "Choose File",
+    });
+  });
+
   it("falls back when encoding fails", () => {
     const opts: A11yOptions = {
       ...defaultOpts,

--- a/packages/core/tests/unit/snapshot-capture-orchestration.test.ts
+++ b/packages/core/tests/unit/snapshot-capture-orchestration.test.ts
@@ -347,6 +347,7 @@ describe("captureHybridSnapshot", () => {
       .spyOn(domTree, "domMapsForSession")
       .mockResolvedValue({
         tagNameMap: { "0-100": "#document" },
+        inputTypeMap: {},
         xpathMap: { "0-100": "/" },
         scrollableMap: {},
       });
@@ -384,6 +385,7 @@ describe("captureHybridSnapshot", () => {
       .spyOn(domTree, "domMapsForSession")
       .mockResolvedValue({
         tagNameMap: { "0-100": "#document" },
+        inputTypeMap: {},
         xpathMap: { "0-100": "/" },
         scrollableMap: {},
       });

--- a/packages/core/tests/unit/snapshot-dom-session-builders.test.ts
+++ b/packages/core/tests/unit/snapshot-dom-session-builders.test.ts
@@ -27,6 +27,7 @@ const makeDomNode = (
     nodeValue: overrides.nodeValue ?? "",
     childNodeCount: overrides.childNodeCount ?? children.length,
     children,
+    attributes: overrides.attributes,
     shadowRoots: overrides.shadowRoots,
     contentDocument: overrides.contentDocument,
     isScrollable: overrides.isScrollable,
@@ -35,9 +36,13 @@ const makeDomNode = (
 
 const buildSampleDomTree = () => {
   const iframeChild = makeDomNode({ nodeName: "P" });
+  const iframeFileInput = makeDomNode({
+    nodeName: "INPUT",
+    attributes: ["type", "file", "id", "resumeUpload"],
+  });
   const iframeBody = makeDomNode({
     nodeName: "BODY",
-    children: [iframeChild],
+    children: [iframeChild, iframeFileInput],
     isScrollable: true,
   });
   const iframeHtml = makeDomNode({ nodeName: "HTML", children: [iframeBody] });
@@ -74,6 +79,7 @@ const buildSampleDomTree = () => {
     iframeHtml,
     iframeBody,
     iframeChild,
+    iframeFileInput,
   };
 };
 
@@ -209,6 +215,9 @@ describe("buildSessionDomIndex", () => {
     expect(
       index.contentDocRootByIframe.get(tree.iframeElement.backendNodeId),
     ).toBe(tree.iframeDoc.backendNodeId);
+    expect(index.inputTypeByBe?.get(tree.iframeFileInput.backendNodeId)).toBe(
+      "file",
+    );
   });
 });
 
@@ -237,11 +246,15 @@ describe("domMapsForSession", () => {
     const iframeDocKey = `frame-A-${tree.iframeDoc.backendNodeId}`;
     const iframeBodyKey = `frame-A-${tree.iframeBody.backendNodeId}`;
     const iframeChildKey = `frame-A-${tree.iframeChild.backendNodeId}`;
+    const iframeFileInputKey = `frame-A-${tree.iframeFileInput.backendNodeId}`;
 
     expect(maps.tagNameMap[iframeDocKey]).toBe("#document");
     expect(maps.xpathMap[iframeDocKey]).toBe("/");
     expect(maps.xpathMap[iframeBodyKey]).toBe("/html[1]/body[1]");
     expect(maps.xpathMap[iframeChildKey]).toBe("/html[1]/body[1]/p[1]");
+    expect(maps.xpathMap[iframeFileInputKey]).toBe("/html[1]/body[1]/input[1]");
+    expect(maps.tagNameMap[iframeFileInputKey]).toBe("input, file");
+    expect(maps.inputTypeMap[iframeFileInputKey]).toBe("file");
     expect(maps.scrollableMap[iframeBodyKey]).toBe(true);
     expect(Object.keys(maps.tagNameMap)).not.toContain(
       `frame-A-${tree.html.backendNodeId}`,

--- a/packages/core/tests/unit/timeout-handlers.test.ts
+++ b/packages/core/tests/unit/timeout-handlers.test.ts
@@ -1272,6 +1272,7 @@ describe("No-timeout success paths", () => {
       ["/tmp/resume.pdf"],
       5_000,
     );
+    expect(result.success).toBe(true);
     expect(result.actions[0]?.arguments).toEqual(["%resume%"]);
   });
 
@@ -1287,7 +1288,7 @@ describe("No-timeout success paths", () => {
       mainFrame: vi.fn().mockReturnValue({}),
     } as unknown as Page;
 
-    await handler.takeDeterministicAction(
+    const result = await handler.takeDeterministicAction(
       {
         selector: "xpath=/html/body/input",
         description: "resume file input",
@@ -1301,6 +1302,7 @@ describe("No-timeout success paths", () => {
       { resume: "/tmp/resume.pdf" },
     );
 
+    expect(result.success).toBe(true);
     expect(performUnderstudyMethodMock).toHaveBeenCalledWith(
       fakePage,
       expect.anything(),
@@ -1323,7 +1325,7 @@ describe("No-timeout success paths", () => {
       mainFrame: vi.fn().mockReturnValue({}),
     } as unknown as Page;
 
-    await handler.takeDeterministicAction(
+    const result = await handler.takeDeterministicAction(
       {
         selector: "xpath=/html/body/input",
         description: "file upload input",
@@ -1337,6 +1339,7 @@ describe("No-timeout success paths", () => {
       { resume: "/tmp/resume.pdf" },
     );
 
+    expect(result.success).toBe(true);
     expect(performUnderstudyMethodMock).toHaveBeenCalledWith(
       fakePage,
       expect.anything(),

--- a/packages/core/tests/unit/timeout-handlers.test.ts
+++ b/packages/core/tests/unit/timeout-handlers.test.ts
@@ -1237,6 +1237,115 @@ describe("No-timeout success paths", () => {
 
     expect(result.success).toBe(true);
   });
+
+  it("substitutes file variables before executing setInputFiles", async () => {
+    const { performUnderstudyMethod } = await import(
+      "../../lib/v3/handlers/handlerUtils/actHandlerUtils.js"
+    );
+    const performUnderstudyMethodMock = vi.mocked(performUnderstudyMethod);
+    performUnderstudyMethodMock.mockResolvedValue(undefined);
+
+    const handler = buildActHandler();
+    const fakePage = {
+      mainFrame: vi.fn().mockReturnValue({}),
+    } as unknown as Page;
+
+    const result = await handler.takeDeterministicAction(
+      {
+        selector: "xpath=/html/body/input",
+        description: "resume file input",
+        method: "setInputFiles",
+        arguments: ["%resume%"],
+      },
+      fakePage,
+      5_000,
+      undefined,
+      undefined,
+      { resume: "/tmp/resume.pdf" },
+    );
+
+    expect(performUnderstudyMethodMock).toHaveBeenCalledWith(
+      fakePage,
+      expect.anything(),
+      "setInputFiles",
+      "xpath=/html/body/input",
+      ["/tmp/resume.pdf"],
+      5_000,
+    );
+    expect(result.actions[0]?.arguments).toEqual(["%resume%"]);
+  });
+
+  it("infers file variables for setInputFiles when observe returns empty arguments", async () => {
+    const { performUnderstudyMethod } = await import(
+      "../../lib/v3/handlers/handlerUtils/actHandlerUtils.js"
+    );
+    const performUnderstudyMethodMock = vi.mocked(performUnderstudyMethod);
+    performUnderstudyMethodMock.mockResolvedValue(undefined);
+
+    const handler = buildActHandler();
+    const fakePage = {
+      mainFrame: vi.fn().mockReturnValue({}),
+    } as unknown as Page;
+
+    await handler.takeDeterministicAction(
+      {
+        selector: "xpath=/html/body/input",
+        description: "resume file input",
+        method: "setInputFiles",
+        arguments: [],
+      },
+      fakePage,
+      5_000,
+      undefined,
+      undefined,
+      { resume: "/tmp/resume.pdf" },
+    );
+
+    expect(performUnderstudyMethodMock).toHaveBeenCalledWith(
+      fakePage,
+      expect.anything(),
+      "setInputFiles",
+      "xpath=/html/body/input",
+      ["/tmp/resume.pdf"],
+      5_000,
+    );
+  });
+
+  it("infers the only file variable for observe-to-act uploads with generic descriptions", async () => {
+    const { performUnderstudyMethod } = await import(
+      "../../lib/v3/handlers/handlerUtils/actHandlerUtils.js"
+    );
+    const performUnderstudyMethodMock = vi.mocked(performUnderstudyMethod);
+    performUnderstudyMethodMock.mockResolvedValue(undefined);
+
+    const handler = buildActHandler();
+    const fakePage = {
+      mainFrame: vi.fn().mockReturnValue({}),
+    } as unknown as Page;
+
+    await handler.takeDeterministicAction(
+      {
+        selector: "xpath=/html/body/input",
+        description: "file upload input",
+        method: "setInputFiles",
+        arguments: [],
+      },
+      fakePage,
+      5_000,
+      undefined,
+      undefined,
+      { resume: "/tmp/resume.pdf" },
+    );
+
+    expect(performUnderstudyMethodMock).toHaveBeenCalledWith(
+      fakePage,
+      expect.anything(),
+      "setInputFiles",
+      "xpath=/html/body/input",
+      ["/tmp/resume.pdf"],
+      5_000,
+    );
+  });
 });
 
 interface BuildActHandlerOptions {

--- a/packages/core/tests/unit/v3-file-upload-act.test.ts
+++ b/packages/core/tests/unit/v3-file-upload-act.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from "vitest";
+import { V3 } from "../../lib/v3/v3.js";
+import type { Action } from "../../lib/v3/types/public/methods.js";
+
+type TestV3 = V3 & Record<string, unknown>;
+
+describe("V3 act file upload routing", () => {
+  it("uses remote observe and local setInputFiles for hosted file uploads", async () => {
+    const stagehand = Object.create(V3.prototype) as TestV3;
+    const mutableStagehand = stagehand as Record<string, unknown>;
+    const mockPage = { mainFrameId: () => "frame-1" };
+    const uploadAction: Action = {
+      selector: "xpath=/html/body/input",
+      description: "resume file input",
+      method: "setInputFiles",
+      arguments: ["%resume%"],
+    };
+
+    const observe = vi.fn().mockResolvedValue([uploadAction]);
+    const act = vi.fn();
+    const takeDeterministicAction = vi.fn().mockResolvedValue({
+      success: true,
+      message: "ok",
+      actions: [uploadAction],
+    });
+
+    mutableStagehand["instanceId"] = "test-instance";
+    mutableStagehand["actHandler"] = { takeDeterministicAction };
+    mutableStagehand["apiClient"] = { observe, act };
+    mutableStagehand["domSettleTimeoutMs"] = 1_000;
+    mutableStagehand["actCache"] = { enabled: false };
+    mutableStagehand["resolvePage"] = vi.fn().mockResolvedValue(mockPage);
+    mutableStagehand["resolveLlmClient"] = vi.fn().mockReturnValue({});
+    mutableStagehand["addToHistory"] = vi.fn();
+    mutableStagehand["isAgentReplayRecording"] = () => false;
+
+    await stagehand.act("upload %resume% to the resume field", {
+      variables: { resume: "/tmp/resume.pdf" },
+    });
+
+    expect(observe).toHaveBeenCalledOnce();
+    expect(act).not.toHaveBeenCalled();
+    expect(takeDeterministicAction).toHaveBeenCalledWith(
+      uploadAction,
+      mockPage,
+      1_000,
+      expect.anything(),
+      expect.any(Function),
+      { resume: "/tmp/resume.pdf" },
+      "upload %resume% to the resume field",
+    );
+  });
+
+  it("executes setInputFiles actions locally when passed an Action", async () => {
+    const stagehand = Object.create(V3.prototype) as TestV3;
+    const mutableStagehand = stagehand as Record<string, unknown>;
+    const mockPage = { mainFrameId: () => "frame-1" };
+    const uploadAction: Action = {
+      selector: "xpath=/html/body/input",
+      description: "resume file input",
+      method: "setInputFiles",
+      arguments: ["/tmp/resume.pdf"],
+    };
+
+    const act = vi.fn();
+    const takeDeterministicAction = vi.fn().mockResolvedValue({
+      success: true,
+      message: "ok",
+      actions: [uploadAction],
+    });
+
+    mutableStagehand["instanceId"] = "test-instance";
+    mutableStagehand["actHandler"] = { takeDeterministicAction };
+    mutableStagehand["apiClient"] = { act };
+    mutableStagehand["domSettleTimeoutMs"] = 1_000;
+    mutableStagehand["resolvePage"] = vi.fn().mockResolvedValue(mockPage);
+    mutableStagehand["resolveLlmClient"] = vi.fn().mockReturnValue({});
+    mutableStagehand["addToHistory"] = vi.fn();
+
+    await stagehand.act(uploadAction, {
+      variables: { resume: "/tmp/resume.pdf" },
+    });
+
+    expect(act).not.toHaveBeenCalled();
+    expect(takeDeterministicAction).toHaveBeenCalledWith(
+      uploadAction,
+      mockPage,
+      1_000,
+      expect.anything(),
+      expect.any(Function),
+      { resume: "/tmp/resume.pdf" },
+    );
+  });
+
+  it("resolves file variables for observed setInputFiles actions with empty arguments", async () => {
+    const stagehand = Object.create(V3.prototype) as TestV3;
+    const mutableStagehand = stagehand as Record<string, unknown>;
+    const mockPage = { mainFrameId: () => "frame-1" };
+    const uploadAction: Action = {
+      selector: "xpath=/html/body/input",
+      description: "file upload input",
+      method: "setInputFiles",
+      arguments: [],
+    };
+
+    const act = vi.fn();
+    const takeDeterministicAction = vi.fn().mockResolvedValue({
+      success: true,
+      message: "ok",
+      actions: [uploadAction],
+    });
+
+    mutableStagehand["instanceId"] = "test-instance";
+    mutableStagehand["actHandler"] = { takeDeterministicAction };
+    mutableStagehand["apiClient"] = { act };
+    mutableStagehand["domSettleTimeoutMs"] = 1_000;
+    mutableStagehand["resolvePage"] = vi.fn().mockResolvedValue(mockPage);
+    mutableStagehand["resolveLlmClient"] = vi.fn().mockReturnValue({});
+    mutableStagehand["addToHistory"] = vi.fn();
+
+    await stagehand.act(uploadAction, {
+      variables: { resume: "/tmp/resume.pdf" },
+    });
+
+    expect(act).not.toHaveBeenCalled();
+    expect(takeDeterministicAction).toHaveBeenCalledWith(
+      uploadAction,
+      mockPage,
+      1_000,
+      expect.anything(),
+      expect.any(Function),
+      { resume: "/tmp/resume.pdf" },
+    );
+  });
+});

--- a/packages/core/tests/unit/zod-enum-compatibility.test.ts
+++ b/packages/core/tests/unit/zod-enum-compatibility.test.ts
@@ -45,7 +45,8 @@ describe("SupportedUnderstudyAction enum Zod compatibility", () => {
     expect(enumValues).toContain("hover");
     expect(enumValues).toContain("doubleClick");
     expect(enumValues).toContain("dragAndDrop");
-    expect(enumValues.length).toBe(11);
+    expect(enumValues).toContain("setInputFiles");
+    expect(enumValues.length).toBe(12);
   });
 
   it("Zod v3 z.enum() with Object.values(SupportedUnderstudyAction) works correctly", () => {

--- a/packages/docs/v3/basics/act.mdx
+++ b/packages/docs/v3/basics/act.mdx
@@ -56,6 +56,7 @@ With `act`, breaking complex actions into small, single-step actions works best.
 | Press | `press <key> in the search field` |
 | Scroll | `scroll to <position>` |
 | Select from dropdown | `select <value> from the dropdown` |
+| Upload files | `upload %resume% to the resume field` |
 </Accordion>
 
 ### Return value of `act()`?
@@ -116,6 +117,27 @@ await stagehand.act("choose 'Peach' from the favorite color dropdown", {
   timeout: 10000
 });
 ```
+
+### Upload files
+
+Pass local file paths through variables when uploading files. Stagehand targets the
+file input directly, without opening the operating system file picker.
+
+```typescript
+await stagehand.act("upload %resume% to the resume field", {
+  variables: { resume: "/path/to/resume.pdf" },
+});
+```
+
+Relative paths work too, including extensionless files such as `fixtures/resume`,
+as long as the path resolves to a real file on the machine running Stagehand.
+On Browserbase, file uploads always execute locally on your machine, so include
+the variable in the instruction (for example `%resume%`) or name the variable in
+the instruction text (for example `upload resume to the resume field`).
+
+The AI action accepts file paths only. To upload in-memory payloads containing a
+buffer, filename, and MIME type, use
+[`locator.setInputFiles()`](/v3/references/locator#setinputfiles) directly.
 
 ### Server-side Caching
 

--- a/packages/evals/tasks/bench/act/act_file_upload_variables.ts
+++ b/packages/evals/tasks/bench/act/act_file_upload_variables.ts
@@ -91,8 +91,11 @@ export default defineBenchTask(
         logs: logger.getLogs(),
       };
     } finally {
-      await v3.close();
-      await fs.unlink(fixturePath).catch(() => {});
+      try {
+        await v3.close();
+      } finally {
+        await fs.unlink(fixturePath).catch(() => {});
+      }
     }
   },
 );

--- a/packages/evals/tasks/bench/act/act_file_upload_variables.ts
+++ b/packages/evals/tasks/bench/act/act_file_upload_variables.ts
@@ -1,0 +1,98 @@
+import crypto from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { defineBenchTask } from "../../../framework/defineTask.js";
+
+const FILE_UPLOAD_V2_URL =
+  "https://browserbase.github.io/stagehand-eval-sites/sites/file-uploads-2/";
+const RESUME_INPUT = "#resumeUpload";
+const RESUME_SUCCESS = "#resumeSuccess";
+
+export default defineBenchTask(
+  { name: "act_file_upload_variables" },
+  async ({ debugUrl, sessionUrl, v3, logger }) => {
+    const fixturePath = path.resolve(
+      process.cwd(),
+      `eval-resume-${crypto.randomBytes(4).toString("hex")}.pdf`,
+    );
+
+    try {
+      await fs.writeFile(fixturePath, "resume", "utf-8");
+
+      const page = v3.context.pages()[0];
+      await page.goto(FILE_UPLOAD_V2_URL);
+
+      const result = await v3.act("upload %resume% to the resume field", {
+        variables: { resume: fixturePath },
+      });
+
+      if (!result.success) {
+        return {
+          _success: false,
+          message: result.message || "act() did not report success",
+          result,
+          debugUrl,
+          sessionUrl,
+          logs: logger.getLogs(),
+        };
+      }
+
+      const usedSetInputFiles = result.actions.some(
+        (action) => action.method === "setInputFiles",
+      );
+      if (!usedSetInputFiles) {
+        return {
+          _success: false,
+          message: 'act() succeeded but did not use the "setInputFiles" method',
+          result,
+          debugUrl,
+          sessionUrl,
+          logs: logger.getLogs(),
+        };
+      }
+
+      const successText = await page.evaluate((selector) => {
+        const el = document.querySelector(selector);
+        if (!el) return "";
+        const display = window.getComputedStyle(el).display;
+        if (display === "none") return "";
+        return el.textContent ?? "";
+      }, RESUME_SUCCESS);
+
+      const fileCount = await page.evaluate((selector) => {
+        const el = document.querySelector(selector);
+        if (!(el instanceof HTMLInputElement)) return 0;
+        return el.files?.length ?? 0;
+      }, RESUME_INPUT);
+
+      const uploaded =
+        successText.includes("Resume uploaded!") && fileCount === 1;
+
+      return {
+        _success: uploaded,
+        message: uploaded
+          ? undefined
+          : `expected resume upload confirmation and one file on input (success="${successText}", fileCount=${fileCount})`,
+        result,
+        debugUrl,
+        sessionUrl,
+        logs: logger.getLogs(),
+      };
+    } catch (error) {
+      return {
+        _success: false,
+        error,
+        message:
+          error instanceof Error
+            ? error.message
+            : "act() file upload via variables failed",
+        debugUrl,
+        sessionUrl,
+        logs: logger.getLogs(),
+      };
+    } finally {
+      await v3.close();
+      await fs.unlink(fixturePath).catch(() => {});
+    }
+  },
+);

--- a/packages/evals/tasks/bench/observe/observe_file_uploads.ts
+++ b/packages/evals/tasks/bench/observe/observe_file_uploads.ts
@@ -31,7 +31,9 @@ export default defineBenchTask(
       const actualBackendNodeId = await page
         .locator(observations[0].selector)
         .backendNodeId();
-      const foundMatch = expectedBackendNodeId === actualBackendNodeId;
+      const foundMatch =
+        expectedBackendNodeId === actualBackendNodeId &&
+        observations[0].method === "setInputFiles";
 
       return {
         _success: foundMatch,


### PR DESCRIPTION
Fixes #972

Thanks @shrey150 for the base #1718 for the snapshot/a11y groundwork there. 

It's worked in a real job application flow - https://www.browserbase.com/sessions/a18ed533-de39-4684-b2bf-eaf8faeb04d3

This PR takes the next step `setInputFiles` as a first-class AI action so you can upload files through `act()` without manually unpacking an observe result and calling `page.locator().setInputFiles()`.

## why

`observe()` on file inputs was returning `click` on a wrapper div instead of the actual `<input type="file">` (see #972). Even after the observe context fix in #1718, there was still no way to say "upload this file" in one `act()` call — you had to wire up the selector yourself.

On Browserbase, remote `act()` also can't read files off your laptop, so uploads need a local execution path even when observe runs server-side.

## what changed

- add `setInputFiles` to the supported action methods in inference + prompts (act + observe)
- thread `input[type]` metadata through the snapshot pipeline; keep file inputs during a11y pruning and synthesize them when AX drops them (carried over from #1718)
- new `fileUploadActUtils.ts`: detect upload instructions with file-path variables, resolve `%key%` placeholders, disambiguate when multiple file inputs match
- on Browserbase: remote `observe()` to find the input, local `setInputFiles` to push the file from the developer machine
- update `observe_file_uploads` bench eval to assert `method === "setInputFiles"`
- add `act_file_upload_variables` bench eval — ran it on Browserbase, session `360fc05f-30b1-4a2c-a1f5-e0597bbfd1cb`
- docs: file upload section in `act.mdx`
- changeset: minor bump for `@browserbasehq/stagehand`

Usage:

```ts
await stagehand.act("upload %resume% to the resume field", {
  variables: { resume: "/path/to/resume.pdf" },
});
```

## test plan

- [x] unit: `file-upload-act-utils.test.ts`, `v3-file-upload-act.test.ts`, snapshot/a11y tests, prompt tests
- [x] integration: `setinputfiles.spec.ts` (locator, deepLocator iframe, act with variables, payload objects)
- [x] bench eval `act_file_upload_variables` — green on Browserbase ([session](https://www.browserbase.com/sessions/360fc05f-30b1-4a2c-a1f5-e0597bbfd1cb))
- [ ] `pnpm --filter @browserbasehq/stagehand test` (unit)
- [ ] `pnpm --filter @browserbasehq/stagehand test:integration` (if you want the browser suite)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds file upload support to `act()` and `observe()` via the new `setInputFiles` action with smarter variable resolution, input disambiguation, and local execution when using the hosted API. This improves reliability and makes uploads a first-class action in `@browserbasehq/stagehand`.

- **New Features**
  - Support `setInputFiles` in `act()`/`observe()`; accepts one or more file paths or `%var%` placeholders.
  - Resolves variables and infers file paths when arguments are empty; understands `%tokens%` and whole-word variable names; supports existing extensionless paths; clear errors when multiple inputs tie.
  - Hosted flow: detects upload intent, bypasses act-cache, runs `observe()` remotely and performs `setInputFiles` locally; also executes locally when an `Action` with `method: "setInputFiles"` is passed.
  - Prompts updated to choose `setInputFiles` for “input, file” (never `click`) and pass file paths/placeholders; schema descriptions updated; docs updated with an uploads section; new bench eval `act_file_upload_variables`.

- **Bug Fixes**
  - Snapshot/a11y now keeps and synthesizes `<input type="file">` (including within scoped trees) so `observe()` targets the real input instead of wrappers.
  - DOM snapshot threads `input[type]` and XPath metadata and respects scoping/ignored nodes, improving file input detection and upload targeting.

<sup>Written for commit ef2bc4d921680ad0e44ea0b707eb1163ab70ad3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



