### PR TITLE
[STG-2249] fix(verifier): configurable canonical-evidence cap + required-field precedence rule

### DIFF
--- a/.changeset/verifier-judgment-quality.md
+++ b/.changeset/verifier-judgment-quality.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Improve verifier judgment quality: the per-blob canonical-evidence cap is env-tunable (VERIFIER_CANONICAL_EVIDENCE_CHARS, lifted by VERIFIER_DISABLE_TRUNCATION) so large aria trees no longer cause false negatives, and required-field grading trusts the visual required marker instead of duplicated aria attributes.

--- a/.changeset/verifier-judgment-quality.md
+++ b/.changeset/verifier-judgment-quality.md
@@ -2,4 +2,4 @@
 "@browserbasehq/stagehand": patch
 ---
 
-Improve verifier judgment quality: the per-blob canonical-evidence cap is env-tunable (VERIFIER_CANONICAL_EVIDENCE_CHARS, lifted by VERIFIER_DISABLE_TRUNCATION) so large aria trees no longer cause false negatives, and required-field grading trusts the visual required marker instead of duplicated aria attributes.
+Improve verifier evidence cap so large aria trees no longer cause false negatives

--- a/packages/core/lib/v3/verifier/evidence.ts
+++ b/packages/core/lib/v3/verifier/evidence.ts
@@ -295,6 +295,14 @@ export async function collectCanonicalEvidence(
     pending.push({ kind: "image", shot });
   }
 
+  // Per-blob ceiling on canonical evidence text captured from a step (aria
+  // tree, tool output, agent text). Full a11y trees are often 30-85k chars and
+  // the datum a criterion needs frequently sits deep in the tree, so a fixed 4k
+  // cut silently drops it downstream -> verifier false-negatives. The
+  // production caller resolves this from VerifierConfig's truncation section
+  // (VERIFIER_CANONICAL_EVIDENCE_CHARS, lifted by the truncation master
+  // switch); direct callers get the historical 4k default.
+  const canonicalEvidenceChars = opts.canonicalEvidenceChars ?? 4000;
   const seenText = new Set<string>();
   const addTextEvidence = (
     stepIdx: number,
@@ -304,11 +312,14 @@ export async function collectCanonicalEvidence(
     // Runtime guard, not just the type: trajectory JSON loaded from disk is
     // unvalidated, so a malformed non-string field must not crash collection.
     if (typeof text !== "string" || text.length === 0) return;
-    const trimmed = text.length > 4000 ? text.slice(0, 4000) : text;
+    const trimmed =
+      text.length > canonicalEvidenceChars
+        ? text.slice(0, canonicalEvidenceChars)
+        : text;
     const normalized = trimmed.replace(/\s+/g, " ").trim();
     if (normalized.length === 0) return;
     // Dedupe on the full normalized text — a length+prefix key would collapse
-    // distinct snippets that share a prefix. The 4k cap bounds key size.
+    // distinct snippets that share a prefix. The per-blob cap bounds key size.
     if (seenText.has(normalized)) return;
     seenText.add(normalized);
     pending.push({

--- a/packages/core/lib/v3/verifier/prompts/fusedJudgment.ts
+++ b/packages/core/lib/v3/verifier/prompts/fusedJudgment.ts
@@ -96,6 +96,8 @@ When task validity is requested, you must populate \`task_validity\` with the bo
    - Critical error → penalize per severity
    - Mix of nitpicks + a critical error → score based on the critical error
 
+9. **Required-field precedence — visual marker over aria on conflict.** When screenshots show a form field, the visual required indicator (asterisk, "required" text) takes precedence over a conflicting "required" attribute in the aria tree — shared form components often duplicate that attribute onto optional fields. When only aria evidence is available for a field, treat its required attribute as a weak signal rather than ignoring it.
+
 **Outcome Judgment:**
 
 \`output_success\` is your independent binary verdict on whether the agent completed the task. It is informed by the per-criterion scores but is not a function of them — a task can have high process score and still fail (right approach, wrong final answer) or have lower process score and still succeed (the answer is right, intermediate steps were inelegant).

--- a/packages/core/lib/v3/verifier/rubricVerifier.ts
+++ b/packages/core/lib/v3/verifier/rubricVerifier.ts
@@ -321,6 +321,14 @@ export function resolveVerifierConfig(
           140,
           truncDisabled,
         ),
+      canonicalEvidenceChars:
+        overrides.truncation?.canonicalEvidenceChars ??
+        readChars(
+          env,
+          "VERIFIER_CANONICAL_EVIDENCE_CHARS",
+          4000,
+          truncDisabled,
+        ),
     },
   };
 }
@@ -534,7 +542,9 @@ export class RubricVerifier implements Verifier {
 
     // Empty-evidence trajectories fall back gracefully — the chosen approach
     // degrades to an action-history-only judgment downstream.
-    const { evidence, loaded } = await collectCanonicalEvidence(trajectory);
+    const { evidence, loaded } = await collectCanonicalEvidence(trajectory, {
+      canonicalEvidenceChars: config.truncation.canonicalEvidenceChars,
+    });
 
     const relevanceScores = await this.scoreRelevanceBatched({
       taskSpec,

--- a/packages/core/lib/v3/verifier/types.ts
+++ b/packages/core/lib/v3/verifier/types.ts
@@ -216,6 +216,12 @@ export interface EvidenceLoadOptions {
   mseThreshold?: number;
   /** Scale factor applied before relevance scoring (default 0.7). */
   imageResize?: number;
+  /**
+   * Per-blob ceiling on canonical evidence text (aria tree, tool output,
+   * agent text) in characters (default 4000). Resolved from VerifierConfig's
+   * truncation section by the production caller.
+   */
+  canonicalEvidenceChars?: number;
 }
 
 /** Score for a single rubric criterion after evidence analysis + rescoring. */
@@ -423,6 +429,8 @@ export interface VerifierConfig {
     buildEvidenceText: number;
     buildEvidenceAria: number;
     actionHistoryReasoning: number;
+    /** Per-blob cap on canonical evidence text collected from a step. */
+    canonicalEvidenceChars: number;
   };
 }
 

--- a/packages/core/tests/unit/verifier-evidence.test.ts
+++ b/packages/core/tests/unit/verifier-evidence.test.ts
@@ -141,4 +141,38 @@ describe("collectCanonicalEvidence", () => {
     expect(texts).toContain(textA);
     expect(texts).toContain(textB);
   });
+
+  it("caps each text blob at 4000 chars by default", async () => {
+    const long = "a".repeat(9000);
+    const trajectory = makeTrajectory([
+      step({ toolOutput: { ok: true, result: long } }),
+    ]);
+
+    const { evidence } = await collectCanonicalEvidence(trajectory);
+    const texts = evidence.filter(isTextEvidence).map((e) => e.content);
+
+    expect(texts).toHaveLength(1);
+    expect(texts[0].length).toBe(4000);
+  });
+
+  it("honors canonicalEvidenceChars, including values below the default", async () => {
+    const long = "b".repeat(9000);
+    const trajectory = makeTrajectory([
+      step({ toolOutput: { ok: true, result: long } }),
+    ]);
+
+    const capped = await collectCanonicalEvidence(trajectory, {
+      canonicalEvidenceChars: 100,
+    });
+    expect(
+      capped.evidence.filter(isTextEvidence).map((e) => e.content)[0].length,
+    ).toBe(100);
+
+    const lifted = await collectCanonicalEvidence(trajectory, {
+      canonicalEvidenceChars: Number.MAX_SAFE_INTEGER,
+    });
+    expect(
+      lifted.evidence.filter(isTextEvidence).map((e) => e.content)[0].length,
+    ).toBe(9000);
+  });
 });

--- a/packages/core/tests/unit/verifier-rubric.test.ts
+++ b/packages/core/tests/unit/verifier-rubric.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { RubricVerifier } from "../../lib/v3/verifier/rubricVerifier.js";
+import {
+  RubricVerifier,
+  resolveVerifierConfig,
+} from "../../lib/v3/verifier/rubricVerifier.js";
 import type { LLMClient } from "../../lib/v3/llm/LLMClient.js";
 import type { TaskSpec, Trajectory } from "../../lib/v3/verifier/types.js";
 
@@ -237,3 +240,26 @@ function makeTrajectory(task: TaskSpec, screenshot: Buffer): Trajectory {
     },
   };
 }
+
+describe("resolveVerifierConfig canonicalEvidenceChars", () => {
+  it("defaults to 4000 and honors any positive env value", () => {
+    expect(resolveVerifierConfig({}).truncation.canonicalEvidenceChars).toBe(
+      4000,
+    );
+    expect(
+      resolveVerifierConfig({ VERIFIER_CANONICAL_EVIDENCE_CHARS: "2000" })
+        .truncation.canonicalEvidenceChars,
+    ).toBe(2000);
+  });
+
+  it("is lifted by the truncation master switch and programmatic override", () => {
+    expect(
+      resolveVerifierConfig({ VERIFIER_DISABLE_TRUNCATION: "1" }).truncation
+        .canonicalEvidenceChars,
+    ).toBe(Number.MAX_SAFE_INTEGER);
+    expect(
+      resolveVerifierConfig({}, { truncation: { disabled: true } } as never)
+        .truncation.canonicalEvidenceChars,
+    ).toBe(Number.MAX_SAFE_INTEGER);
+  });
+});


### PR DESCRIPTION
## Why

Two verifier false-verdict sources found while analyzing eval runs:

1. `collectCanonicalEvidence` cut every text blob at a fixed 4k chars. Full a11y trees are routinely 30–85k chars and the datum a criterion needs often sits deep in the tree — the cut silently dropped it downstream, producing **false negatives** on large-page tasks.
2. The judge inferred field required-ness from the aria tree's `required` attribute, which shared form components duplicate onto optional fields (e.g. "First Name (Legal)" carrying the marker of the truly-required "First Name (Chosen)") — also false negatives on "all required fields filled" criteria.

## What changed

- **`canonicalEvidenceChars` joins `VerifierConfig`'s truncation section** — resolved in `resolveVerifierConfig` via the existing `readChars` helper (`VERIFIER_CANONICAL_EVIDENCE_CHARS`, default 4000, honors any positive value) and lifted by the truncation master switch, env **or** programmatic `truncation.disabled` — matching every other verifier knob. The cap is threaded through `collectCanonicalEvidence`'s options; no inline env reads.
- **Judgment rule 9 (precedence, not a ban):** when screenshots show a form field, the visual required marker takes precedence over a conflicting aria attribute; aria-only evidence remains a (weak) signal rather than being ignored — so forms whose only required indicator is the attribute still grade correctly.

Note: with the master switch on, canonical blobs are unbounded like every other lifted limit — that's the documented contract for high-context judge models; operators opt in.

## Tests

- `collectCanonicalEvidence`: default 4k cap, sub-default override (100), lifted cap (9k survives) — option-based, no env mutation.
- `resolveVerifierConfig`: default, env value below the old floor (2000 honored), master switch via env and via programmatic override.
- typecheck + build green; verifier evidence/rubric suites 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the canonical-evidence text cap configurable and liftable to prevent dropping deep aria data on large pages. Updates required-field judgment to prefer visible markers over conflicting aria attributes. Addresses STG-2249.

- **Bug Fixes**
  - Add `truncation.canonicalEvidenceChars` to `VerifierConfig`; reads `VERIFIER_CANONICAL_EVIDENCE_CHARS` (default 4000) and is lifted by `VERIFIER_DISABLE_TRUNCATION` or `truncation.disabled`. Passed into `collectCanonicalEvidence` so each text blob is capped consistently.
  - When screenshots show a form field, prefer the visual required marker (asterisk, “required” text) over a conflicting aria `required` attribute; aria-only remains a weak signal.

- **Migration**
  - Optional: set `VERIFIER_CANONICAL_EVIDENCE_CHARS` to tune the per-blob cap, or `VERIFIER_DISABLE_TRUNCATION=1` to lift truncation. Defaults remain unchanged.

<sup>Written for commit 9516a15a689eed326623b6da99ff0cc1d18a28c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

