### PR TITLE
chore(evals): add sonnet-5, gpt-5.6, and grok pricing to braintrust UI publisher

### DIFF
--- a/packages/evals/scripts/publish-braintrust-ui-data.ts
+++ b/packages/evals/scripts/publish-braintrust-ui-data.ts
@@ -169,6 +169,12 @@ type ModelPricing = {
 };
 
 const MODEL_PRICING_USD_PER_1M_TOKENS = new Map<string, ModelPricing>([
+  // Standard (non-introductory) Sonnet 5 pricing. NOTE: introductory pricing
+  // ($2 / $0.20 cached / $10 per 1M) applies through 2026-08-31, so costs
+  // published before then are overstated ~1.5x; standard rates are used
+  // deliberately to keep the dashboard stable across the cutover.
+  ["anthropic/claude-sonnet-5", { input: 3, cachedInput: 0.3, output: 15 }],
+  ["claude-sonnet-5", { input: 3, cachedInput: 0.3, output: 15 }],
   ["anthropic/claude-opus-4-7", { input: 5, cachedInput: 0.5, output: 25 }],
   ["claude-opus-4-7", { input: 5, cachedInput: 0.5, output: 25 }],
   ["anthropic/claude-opus-4-6", { input: 5, cachedInput: 0.5, output: 25 }],

--- a/packages/evals/scripts/publish-braintrust-ui-data.ts
+++ b/packages/evals/scripts/publish-braintrust-ui-data.ts
@@ -182,6 +182,11 @@ const MODEL_PRICING_USD_PER_1M_TOKENS = new Map<string, ModelPricing>([
   ["gpt-5.6-terra", { input: 2.5, cachedInput: 0.25, output: 15 }],
   ["openai/gpt-5.6-luna", { input: 1, cachedInput: 0.1, output: 6 }],
   ["gpt-5.6-luna", { input: 1, cachedInput: 0.1, output: 6 }],
+  // xAI pricing per docs.x.ai/developers/models (2026-07).
+  ["xai/grok-4.5", { input: 2, cachedInput: 0.5, output: 6 }],
+  ["grok-4.5", { input: 2, cachedInput: 0.5, output: 6 }],
+  ["xai/grok-4.3", { input: 1.25, cachedInput: 0.2, output: 2.5 }],
+  ["grok-4.3", { input: 1.25, cachedInput: 0.2, output: 2.5 }],
   ["anthropic/claude-opus-4-7", { input: 5, cachedInput: 0.5, output: 25 }],
   ["claude-opus-4-7", { input: 5, cachedInput: 0.5, output: 25 }],
   ["anthropic/claude-opus-4-6", { input: 5, cachedInput: 0.5, output: 25 }],

--- a/packages/evals/scripts/publish-braintrust-ui-data.ts
+++ b/packages/evals/scripts/publish-braintrust-ui-data.ts
@@ -175,6 +175,13 @@ const MODEL_PRICING_USD_PER_1M_TOKENS = new Map<string, ModelPricing>([
   // deliberately to keep the dashboard stable across the cutover.
   ["anthropic/claude-sonnet-5", { input: 3, cachedInput: 0.3, output: 15 }],
   ["claude-sonnet-5", { input: 3, cachedInput: 0.3, output: 15 }],
+  // GPT-5.6 tiers per OpenAI pricing (2026-07).
+  ["openai/gpt-5.6-sol", { input: 5, cachedInput: 0.5, output: 30 }],
+  ["gpt-5.6-sol", { input: 5, cachedInput: 0.5, output: 30 }],
+  ["openai/gpt-5.6-terra", { input: 2.5, cachedInput: 0.25, output: 15 }],
+  ["gpt-5.6-terra", { input: 2.5, cachedInput: 0.25, output: 15 }],
+  ["openai/gpt-5.6-luna", { input: 1, cachedInput: 0.1, output: 6 }],
+  ["gpt-5.6-luna", { input: 1, cachedInput: 0.1, output: 6 }],
   ["anthropic/claude-opus-4-7", { input: 5, cachedInput: 0.5, output: 25 }],
   ["claude-opus-4-7", { input: 5, cachedInput: 0.5, output: 25 }],
   ["anthropic/claude-opus-4-6", { input: 5, cachedInput: 0.5, output: 25 }],


### PR DESCRIPTION
## Why

Sonnet 5, GPT-5.6, and Grok eval runs published to the Braintrust UI had no pricing entry, so their cost metrics fell through as unknown.

## What changed

Added to the publisher's `MODEL_PRICING_USD_PER_1M_TOKENS` map (prefixed and unprefixed forms per the map's convention):

| Model | Input | Cached input | Output |
|---|---|---|---|
| `claude-sonnet-5` | $3 | $0.30 | $15 |
| `gpt-5.6-sol` | $5 | $0.50 | $30 |
| `gpt-5.6-terra` | $2.50 | $0.25 | $15 |
| `gpt-5.6-luna` | $1 | $0.10 | $6 |
| `grok-4.5` | $2 | $0.50 | $6 |
| `grok-4.3` | $1.25 | $0.20 | $2.50 |

GPT-5.6 keys match the CUA model ids added in #2343 (`openai/gpt-5.6-{sol,terra,luna}`). Grok rates per docs.x.ai/developers/models (2026-07).

Deliberate trade-off (noted in the code comment): Sonnet 5 introductory pricing ($2 / $0.20 / $10) applies through **2026-08-31**, so costs published before then are overstated ~1.5x; standard rates keep the dashboard stable across the cutover instead of requiring a September flip.

## Tests

Internal publish script; no behavior beyond the map entries. Typecheck green.