### PR TITLE
[STG-2473] feat(cli): surface navigation httpStatus on browse open

### DIFF
--- a/.changeset/self-documenting-browse-nav-failures.md
+++ b/.changeset/self-documenting-browse-nav-failures.md
@@ -1,0 +1,5 @@
+---
+"browse": patch
+---
+
+feat(cli): surface the navigation httpStatus on `browse open` (and reload/back/forward) so agents can tell a real 200 page apart from a loaded 4xx/5xx error page. Adds an optional `httpStatus` field; a normal 200 page is unchanged.

--- a/packages/cli/skills/browse/SKILL.md
+++ b/packages/cli/skills/browse/SKILL.md
@@ -99,6 +99,10 @@ Prefer `browse snapshot` over screenshots for most browser work. It is structure
 
 Refs are refreshed on every snapshot. After clicks, form submits, navigation, or UI re-renders, take a new snapshot before using another ref.
 
+### Navigation httpStatus
+
+`browse open` (and `reload`/`back`/`forward`) reports the top-level document's `httpStatus` when the navigation returned one. Use it to tell a real `200` page apart from a loaded `4xx`/`5xx` error page — a page that renders but is a dead URL or a blocked response. A normal `200` page is unchanged, and a navigation with no captured response omits the field.
+
 ## Parallel Browser Work
 
 Use a different `--session` value for each independent browser task. Sessions isolate tabs, cookies, refs, and daemon state; parallel tasks that omit `--session` share the `default` session and overwrite each other's active page.

--- a/packages/cli/src/lib/driver/commands/navigation.ts
+++ b/packages/cli/src/lib/driver/commands/navigation.ts
@@ -14,32 +14,47 @@ const OpenSchema = NavigationOptionsSchema.extend({
   url: z.string().min(1),
 });
 
+/**
+ * Understudy's navigation methods return a `Response | null` whose `status()` is
+ * the top-level document's HTTP status. We read it directly (no correlation with
+ * the network layer needed) to surface `httpStatus` on the navigation result.
+ */
+type NavigationResponse = { status: () => number } | null | undefined;
+
+function responseStatus(response: NavigationResponse): number | undefined {
+  const status = response?.status?.();
+  return typeof status === "number" && status > 0 ? status : undefined;
+}
+
 export const navigationHandlers: DriverCommandHandlers = {
   async open(manager, params) {
     const { timeoutMs, url, waitUntil } = OpenSchema.parse(params);
     const page = await manager.pageForOpen();
-    await page.goto(url, { timeoutMs, waitUntil });
-    return manager.openResult(page);
+    const response = (await page.goto(url, {
+      timeoutMs,
+      waitUntil,
+    })) as NavigationResponse;
+    return manager.openResult(page, responseStatus(response));
   },
 
   async reload(manager, params) {
     const options = NavigationOptionsSchema.parse(params);
     const page = await manager.activePage();
-    await page.reload(options);
-    return manager.openResult(page);
+    const response = (await page.reload(options)) as NavigationResponse;
+    return manager.openResult(page, responseStatus(response));
   },
 
   async back(manager, params) {
     const options = NavigationOptionsSchema.parse(params);
     const page = await manager.activePage();
-    await page.goBack(options);
-    return manager.openResult(page);
+    const response = (await page.goBack(options)) as NavigationResponse;
+    return manager.openResult(page, responseStatus(response));
   },
 
   async forward(manager, params) {
     const options = NavigationOptionsSchema.parse(params);
     const page = await manager.activePage();
-    await page.goForward(options);
-    return manager.openResult(page);
+    const response = (await page.goForward(options)) as NavigationResponse;
+    return manager.openResult(page, responseStatus(response));
   },
 };

--- a/packages/cli/src/lib/driver/session-manager.ts
+++ b/packages/cli/src/lib/driver/session-manager.ts
@@ -226,8 +226,15 @@ export class DriverSessionManager {
     this.refMaps = refMaps;
   }
 
-  async openResult(page: DriverPage): Promise<OpenResult> {
-    return {
+  /**
+   * Build the `open`/`reload`/`back`/`forward` result. When a navigation
+   * response was captured, `httpStatus` is the top-level document's HTTP status,
+   * so the driving agent can tell a loaded 4xx/5xx error page apart from a real
+   * 200. The field is optional/additive — a normal 200 page is unchanged, and a
+   * navigation with no captured response omits it entirely.
+   */
+  async openResult(page: DriverPage, httpStatus?: number): Promise<OpenResult> {
+    const result: OpenResult = {
       ...this.browserbaseIdentity(),
       mode: this.target.kind,
       pages: await this.pageSummaries(),
@@ -236,6 +243,12 @@ export class DriverSessionManager {
       title: await this.safeTitle(page),
       url: page.url(),
     };
+
+    if (typeof httpStatus === "number") {
+      result.httpStatus = httpStatus;
+    }
+
+    return result;
   }
 
   async pageSummaries(): Promise<PageSummary[]> {
@@ -272,29 +285,30 @@ export class DriverSessionManager {
           `Target ${target.targetId} was not found in the attached browser.`,
         );
       }
-      this.activateIfNeeded(page);
-      this.selectedTargetId = page.targetId();
-      return page;
+      return this.finalizePage(page);
     }
 
     const existingPage = this.activePageIfPresent() ?? this.context.pages()[0];
     if (existingPage) {
-      this.activateIfNeeded(existingPage);
-      this.selectedTargetId = existingPage.targetId();
-      return existingPage;
+      return this.finalizePage(existingPage);
     }
 
     if (options.createIfMissing) {
       const page = await this.context.newPage();
-      this.activateIfNeeded(page);
-      this.selectedTargetId = page.targetId();
-      return page;
+      return this.finalizePage(page);
     }
 
     throw new DriverError(
       `No active page in session "${this.session}". Run browse open <url> --session ${this.session} or browse tab new <url> --session ${this.session}.`,
       { code: "no_active_page" },
     );
+  }
+
+  /** Activate the resolved page and record its target. */
+  private finalizePage(page: DriverPage): DriverPage {
+    this.activateIfNeeded(page);
+    this.selectedTargetId = page.targetId();
+    return page;
   }
 
   private activePageIfPresent(): DriverPage | undefined {

--- a/packages/cli/src/lib/driver/types.ts
+++ b/packages/cli/src/lib/driver/types.ts
@@ -51,4 +51,9 @@ export interface OpenResult extends BrowserbaseIdentity {
   session: string;
   title: string;
   url: string;
+  /**
+   * HTTP status of the top-level document, when the navigation returned one.
+   * Present for `open`/`reload`/`back`/`forward` when a response was captured.
+   */
+  httpStatus?: number;
 }

--- a/packages/cli/tests/self-documenting.test.ts
+++ b/packages/cli/tests/self-documenting.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { DriverSessionManager } from "../src/lib/driver/session-manager.js";
+
+/**
+ * Build a manager whose `openResult` can run without a live browser: a fake
+ * page plus a minimal context so `pageSummaries()` resolves.
+ */
+function managerWithPage(url: string) {
+  const manager = new DriverSessionManager("http-status", {
+    headless: true,
+    kind: "managed-local",
+  });
+  const page = {
+    targetId: () => "target-1",
+    title: vi.fn(async () => "Example"),
+    url: () => url,
+  };
+  Object.assign(manager, { context: { pages: () => [page] } });
+  return { manager, page };
+}
+
+describe("openResult httpStatus", () => {
+  it("surfaces httpStatus on a 4xx navigation", async () => {
+    const { manager, page } = managerWithPage("https://example.com/missing");
+
+    const result = await manager.openResult(
+      page as unknown as Parameters<DriverSessionManager["openResult"]>[0],
+      404,
+    );
+
+    expect(result.httpStatus).toBe(404);
+  });
+
+  it("surfaces httpStatus on a 200 navigation", async () => {
+    const { manager, page } = managerWithPage("https://example.com/");
+
+    const result = await manager.openResult(
+      page as unknown as Parameters<DriverSessionManager["openResult"]>[0],
+      200,
+    );
+
+    expect(result.httpStatus).toBe(200);
+  });
+
+  it("omits httpStatus entirely when no response status was captured", async () => {
+    const { manager, page } = managerWithPage("https://example.com/");
+
+    const result = await manager.openResult(
+      page as unknown as Parameters<DriverSessionManager["openResult"]>[0],
+    );
+
+    expect(result.httpStatus).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## TL;DR

`browse open` (and `reload`/`back`/`forward`) now includes the **HTTP status of the top-level document** on its result — one optional field, `httpStatus`. That's the whole change. A normal `200` page is unchanged; a navigation with no captured response omits the field.

Why it matters: today, when you `open` a URL that returns a 404/403, the browser still "loads" something (often a rendered error page or `chrome-error://`), and an agent driving the CLI can't tell that apart from a real page — so it happily continues as if the nav succeeded. Surfacing the status gives the driver a fact it can act on.

**Heads up for the reviewer:** I'm opening this as a draft on purpose. I ran a fairly serious A/B (details below) and the honest result is that this is a **correct, harmless primitive that doesn't move the aggregate eval number at Haiku**. I have a specific ask for you at the bottom — mainly *should I keep pursuing this, and should I re-run the eval on Sonnet instead of Haiku?*

Linear: STG-2473

---

## Where this came from (a customer investigation)

An internal customer evaluation showed self-hosted Sonnet 4.5 + browse CLI **underperforming our managed Agents product** on multi-step travel/booking tasks. Digging in, the gap wasn't the model — it was **scaffolding**. Managed agent-runner re-observes and recovers after a bad step; a thin harness driving raw browse CLI didn't even *know* a step was bad, because a loaded 404 looks like success.

So the question this PR set out to answer: **can we make browse "self-documenting" enough that a thin harness recovers like agent-runner does — and does that actually help, measured honestly?**

---

## Approaches considered

I prototyped three layers of "self-documentation" and tried to isolate each one:

| Approach | What it added to the CLI output | Verdict | Why |
| --- | --- | --- | --- |
| **Candidate links** | On a 4xx, scrape the page's own same-domain links and list them so the agent can re-route | ❌ Cut | Overfit to booking/search sites; it's really the job of `browse snapshot`, not nav. No clean signal in evals. |
| **Hint string** | On a 4xx, add a one-line `hint`: *"Navigation returned 404 — the page is unavailable; check the URL…"* | ❌ Not in this PR | Statistically real on the tasks it targets, **but** it over-abandons *recoverable* tasks (see data). Net wash, and it's *guidance baked into output*, which we'd rather keep in SKILL.md. |
| **`httpStatus` fact** | Just the numeric status on the nav result | ✅ **This PR** | It's a plain, correct fact (the actual HTTP status). No regressions, mild positive on the target tasks, and it lets the *downstream harness/model* decide what to do rather than us prescribing it. |

The principle I landed on: **facts belong in tool output, guidance belongs in SKILL.md / the harness prompt.** `httpStatus` is a fact. The hint was guidance-in-output, so it's out.

---

## The eval (this is the part I want your eyes on)

I built a proper A/B instead of eyeballing trajectories. Setup:

- **Harness:** the `claude_code` eval path driving the real browse CLI, on **Browserbase remote**.
- **Scoring:** ground-truth **V3Evaluator rubric** (not the agent's self-report). Judge model = `gemini-2.5-flash`.
- **Model under test:** `claude-haiku-4-5`.
- **`max_turns = 60`** — this matters (see "validity" below).
- **12 tasks × 8 trials × 3 arms = 288 runs.** Tasks are block-/4xx-prone travel + booking (incl. 4 real-world flight-booking tasks from the customer eval) plus a couple of easy controls.
- **3 arms:** `A` = baseline (stock CLI) · `B` = `httpStatus` only · `C` = `httpStatus` + hint.

### Results

| Metric | A: baseline | B: httpStatus | C: httpStatus + hint |
| --- | --- | --- | --- |
| **Overall pass** | 25% (24/96) | **27% (26/96)** | 25% (24/96) |
| **Capped (hit turn limit)** | 46% | 45% | **34%** |
| **Floor tasks pass** (capeair/united/expedia/kayak, n=32) | **0%** | **9%** | **16%** |

Significance (two-proportion z):
- **Overall: no effect.** z(A→B) = +0.33 (p≈0.74); z(A→C) = 0.00. Flat.
- **Floor tasks (the 4xx tasks it's designed for): real.** z(A→B) = +1.77; **z(A→C) = +2.33 (p≈0.02)**. The hint roughly doubles the fact's effect *on those tasks*.

### How to read this honestly

1. **Nothing moves the aggregate.** All three arms are ~25%. If the bar is "improves overall task success at Haiku," neither the fact nor the hint clears it.
2. **The mechanism is real on the target subgroup.** On the dead-URL/4xx tasks, we go 0% → 9% (fact) → 16% (fact+hint). That's the thing working as designed — just diluted to nothing once you average in tasks where HTTP status is irrelevant.
3. **The hint is a double-edged blade — this is the most interesting finding.** It cuts the cap rate 46% → 34% (agent stops flailing on dead-ends) and lifts the floor tasks the most — **but** it also makes Haiku *give up on recoverable tasks*: `santorini_flight` went 3/8 → **0/8** (capped 2 → 0: it bailed instantly), and `ticketmaster_sporting` went 4/8 → **2/8** (the fact-only arm had lifted it to **7/8**). The over-abandonment cancels the floor gains → net wash. The hint text is too blunt for a small model to apply judiciously.
4. **`httpStatus`-only has no regressions** and is a correct primitive, which is why it's the safe thing to land.

### A validity note (why I trust this run and not my earlier ones)

An earlier factorial ran at `max_turns = 30` and showed *no signal anywhere*. That was an artifact: **72% of runs hit the 30-turn cap, and a capped run passes ~2%** — so it was measuring turn-budget, not the change. At `max_turns = 60` the cap rate drops to ~46% and, crucially, becomes **correlated with genuine task difficulty** (easy tasks cap 0%, `kayak` caps 100% in *both* arms because it's just turn-starved) rather than a uniform guillotine. That's why this run's deltas are meaningful and the old one's weren't.

---

## What I actually want advice on

1. **Is this worth pursuing at all?** `httpStatus` is harmless and correct, but the eval doesn't *prove* it lifts task success at Haiku. Is "correct primitive with a real-but-small subgroup effect" a good enough reason to land, or should I hold it?
2. **Haiku vs Sonnet.** The over-abandonment regressions smell like a *small-model* artifact — a stronger model would likely use the status more judiciously. Our real deployment (agent-runner) is Sonnet-class. **I think the haiku result is a floor on the value, not a ceiling.** Should I re-run the A/B (at least the 4 floor tasks) on Sonnet before we decide? Cheap — ~30 min.
3. **The hint.** Given the fact-vs-guidance principle, if we want the hint's floor-task lift, should it live as *guidance in SKILL.md / the harness prompt* (persistence-preserving wording) rather than in tool output? Worth a separate experiment?

---

## Scope of this PR

Deliberately tiny — just the fact:

- `openResult()` sets `httpStatus` when a navigation response was captured (`session-manager.ts`).
- Nav handlers read `response.status()` from `open`/`reload`/`back`/`forward` (`navigation.ts`).
- `OpenResult.httpStatus?: number` type (`types.ts`).
- SKILL.md: one factual line documenting the field (no prescriptive "give up" guidance).
- Unit tests + changeset (`browse` patch).

No candidate links, no hint string — both cut per the data above.

---

## E2E Test Matrix

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `browse open https://httpbin.org/status/404 --remote` (local build) | `"httpStatus": 404`, `url: "chrome-error://chromewebdata/"`, **no `hint` field** | Proves the fact is surfaced on a real 4xx and the hint is gone. This is the exact dead-end an agent would otherwise read as success. |
| `browse open https://example.com --remote` (local build) | `"httpStatus": 200`, no `hint` field | Proves a normal page carries the status and is otherwise unchanged. |
| `vitest run tests/self-documenting.test.ts` | 3/3 pass (404→status, 200→status, no-response→omitted) | Unit-level guarantee of the `openResult` contract. |
| `pnpm build` (packages/cli) | tsc + oclif manifest clean | Typecheck/build green. |
| Powered A/B — 288 runs, Haiku, `max_turns=60`, V3Evaluator-scored, on Browserbase | baseline 25% · httpStatus 27% · +hint 25%; floor tasks 0%→9%→16% | The real evidence. Shows httpStatus is harmless overall and positive-but-small on the 4xx subgroup; motivates the Sonnet question above. Does **not** prove an aggregate win at Haiku. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

