### PR TITLE
[chore]: rm unnecessary comment

### DIFF
--- a/packages/core/tests/unit/agent-finalization-resilience.test.ts
+++ b/packages/core/tests/unit/agent-finalization-resilience.test.ts
@@ -24,10 +24,6 @@ const mockModel = {
   },
 } as unknown as LanguageModelV2;
 
-// Mirrors PermitFlow's custom tool: an optional field (`matchedExpected`) is
-// left `undefined` in the tool result, so the re-submitted tool-result carries
-// an `undefined` inside output.value. Also includes a valid reasoning part
-// (text: "") to confirm sanitization leaves real content intact.
 const malformedHistory = [
   { role: "user", content: "do the task" },
   {


### PR DESCRIPTION
# why

# what changed

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed an unnecessary comment from `packages/core/tests/unit/agent-finalization-resilience.test.ts` to reduce noise; no code or test behavior changes.

<sup>Written for commit 319fc334fbc6d6c9d17a5c3bb2f4a8fe2dcbcf33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

