### PR TITLE
[STG-2477] test(cli): fix flaky Windows EBUSY temp-dir cleanup in functions dev test

### DIFF
--- a/packages/cli/tests/cli-functions-contract.test.ts
+++ b/packages/cli/tests/cli-functions-contract.test.ts
@@ -39,7 +39,12 @@ afterEach(async () => {
   while (cleanupPaths.length > 0) {
     const path = cleanupPaths.pop();
     if (path) {
-      await rm(path, { recursive: true, force: true });
+      await rm(path, {
+        recursive: true,
+        force: true,
+        maxRetries: 5,
+        retryDelay: 100,
+      });
     }
   }
 });


### PR DESCRIPTION
## Summary

Fixes an intermittent **Windows-only** CI failure in `packages/cli/tests/cli-functions-contract.test.ts`.

Failing test: `functions scaffolding and local dev > runs a local dev server and invokes a function`

Observed error (Windows CI only):

```
Error: EBUSY: resource busy or locked, rmdir 'C:\...\Temp\functions-dev-XXXX'
```

## Root cause

The test spawns `browse functions dev`, which in turn spawns a **runtime subprocess** (a grandchild of the test). The `afterEach` cleanup does `child.kill("SIGTERM")` + `waitForExit(child)` — but on Windows `kill` only terminates the **direct child**, not the grandchild runtime. That grandchild can still hold open file handles inside the per-test temp dir when cleanup runs.

The subsequent `rm(path, { recursive: true, force: true })` then hits a directory with live handles, and Windows refuses to remove it → `EBUSY`. Critically, `force: true` only **ignores missing paths**; it does **not** retry on `EBUSY`. Node's `fs.rm` exposes `maxRetries`/`retryDelay` precisely to retry transient Windows `EBUSY`/`EPERM`/`ENOTEMPTY` errors during recursive removal.

## Fix

Add retry options to the temp-dir cleanup `rm(...)` call in `afterEach`:

```js
await rm(path, {
  recursive: true,
  force: true,
  maxRetries: 5,
  retryDelay: 100,
});
```

This is the only `rm`/`rmdir` call in the file that removes temp dirs.

## Scope / impact

- **Test-only change.** No production/source code touched.
- **No changeset** (non-release, no runtime behavior change).

## E2E Test Matrix

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `pnpm vitest run tests/cli-functions-contract.test.ts` (in `<worktree>/packages/cli`, after `pnpm install --frozen-lockfile` + `pnpm turbo run build --filter=browse...`) | `Test Files 1 passed (1)` / `Tests 13 passed (13)`; verbose shows `✓ ... runs a local dev server and invokes a function 626ms` | Proves **no regression on POSIX (macOS)** — all 13 tests including the previously-flaky one still pass with the retry options. The Windows `EBUSY` path can't be reproduced on macOS (POSIX unlinks directories with open handles), so this run cannot exercise the retry itself; the `maxRetries`/`retryDelay` options are the canonical, documented Node remedy for Windows `EBUSY`/`EPERM`/`ENOTEMPTY` on recursive `rm`. |
| `npx prettier --check tests/cli-functions-contract.test.ts` | `All matched files use Prettier code style!` | Formatting passes — no CI format failure. |
| `npx eslint tests/cli-functions-contract.test.ts` | exit 0, no output | Lint passes. |

## Linear

[STG-2477](https://linear.app/browserbase/issue/STG-2477/testcli-retry-temp-dir-cleanup-to-fix-windows-ebusy-flake-in-functions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a Windows-only flaky test by retrying temp-dir cleanup in `packages/cli/tests/cli-functions-contract.test.ts` to avoid `EBUSY` during the `functions dev` test. Addresses STG-2477 and stabilizes CI without touching production code.

- **Bug Fixes**
  - Add `maxRetries: 5` and `retryDelay: 100` to `fs.rm` in the test `afterEach` cleanup.
  - Prevents transient `EBUSY`/`EPERM`/`ENOTEMPTY` errors when a grandchild process holds open handles on Windows.

<sup>Written for commit c17987aa141e07b1674775dbc4b5dd07196cfb0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

