### PR TITLE
[STG-2486] feat(cli): stamp detected agent on session userMetadata

### DIFF
--- a/.changeset/browse-cli-agent-session-metadata.md
+++ b/.changeset/browse-cli-agent-session-metadata.md
@@ -1,0 +1,5 @@
+---
+"browse": patch
+---
+
+Stamp the detected coding agent (e.g. `claude`, `cursor`, `codex`) onto the Browserbase session `userMetadata` (`agent` key) at session create, alongside the existing `browse_cli`/`cli_version`/`install_id` attribution. This lets CLI-created cloud sessions be attributed to the coding agent that drove them. Only set when an agent is detected; caller-supplied `userMetadata` is otherwise preserved.

--- a/packages/cli/src/commands/cloud/sessions/create.ts
+++ b/packages/cli/src/commands/cloud/sessions/create.ts
@@ -9,6 +9,7 @@ import {
 } from "../../../lib/cloud/api.js";
 import { resolveContextRefOrFail } from "../../../lib/cloud/contexts-resolve.js";
 import { apiCommonFlags, toApiOptions } from "../../../lib/cloud/flags.js";
+import { detectAgent } from "../../../lib/agent.js";
 import { fail } from "../../../lib/errors.js";
 import {
   getCliVersion,
@@ -97,12 +98,18 @@ function buildSessionCreateBody(
  * every CLI-created cloud session is attributable to the CLI (matching the
  * driver `open --remote` path). Any user-supplied `userMetadata` (via --body or
  * --stdin) is preserved; our attribution keys (browse_cli/install_id/
- * cli_version) are authoritative and override caller values for those keys.
+ * cli_version/agent) are authoritative and override caller values for those
+ * keys.
  *
- * Resolving the install id is best-effort and never throws; if it can't be
- * resolved we still send browse_cli + cli_version. Values are run through
- * toMetadataValue() so the session-create validator never 400s on a stray
- * character or an over-length value.
+ * When the CLI is running under a detectable coding agent (e.g. claude-code,
+ * cursor, codex), the `agent` key is stamped too so cloud sessions can be
+ * attributed to the agent in Snowflake — mirroring the `agent` property already
+ * sent to PostHog telemetry. It is only set when detectAgent() returns a value.
+ *
+ * Resolving the install id and agent is best-effort and never throws; if they
+ * can't be resolved we still send browse_cli + cli_version. Values are run
+ * through toMetadataValue() so the session-create validator never 400s on a
+ * stray character or an over-length value.
  */
 async function applyCliAttribution(
   body: Record<string, unknown>,
@@ -129,6 +136,14 @@ async function applyCliAttribution(
     const sanitized = toMetadataValue(installId);
     if (sanitized) {
       userMetadata.install_id = sanitized;
+    }
+  }
+
+  const agent = await detectAgent().catch(() => null);
+  if (agent) {
+    const sanitized = toMetadataValue(agent);
+    if (sanitized) {
+      userMetadata.agent = sanitized;
     }
   }
 

--- a/packages/cli/tests/cli-cloud-contract.test.ts
+++ b/packages/cli/tests/cli-cloud-contract.test.ts
@@ -1276,6 +1276,94 @@ describe("cloud API contracts", () => {
     );
   });
 
+  it("sessions create stamps the detected coding agent onto userMetadata", async () => {
+    await withServer(
+      async (_request, response) => {
+        jsonResponse(response, 200, { id: "sess_123" });
+      },
+      async ({ baseUrl, requests }) => {
+        const result = await runCli(
+          [
+            "cloud",
+            "sessions",
+            "create",
+            "--api-key",
+            "test-key",
+            "--base-url",
+            baseUrl,
+          ],
+          // HERMES_SESSION_PLATFORM forces detectAgent() to a deterministic
+          // value regardless of the host env the test runs under.
+          { env: { HERMES_SESSION_PLATFORM: "telegram" } },
+        );
+
+        expect(result.exitCode).toBe(0);
+        expectRequest(requests[0], "POST", "/v1/sessions", "test-key");
+        const body = requests[0]?.jsonBody as {
+          userMetadata?: Record<string, string>;
+        };
+        expect(body.userMetadata?.agent).toBe("hermes");
+      },
+    );
+  });
+
+  it("sessions create omits the agent key when no coding agent is detected", async () => {
+    await withServer(
+      async (_request, response) => {
+        jsonResponse(response, 200, { id: "sess_123" });
+      },
+      async ({ baseUrl, requests }) => {
+        const result = await runCli(
+          [
+            "cloud",
+            "sessions",
+            "create",
+            "--api-key",
+            "test-key",
+            "--base-url",
+            baseUrl,
+          ],
+          // Clear every known agent-detection env var (spawn drops keys set to
+          // undefined) so detectAgent() resolves to null even when the test host
+          // itself runs under an agent.
+          {
+            env: {
+              AI_AGENT: undefined,
+              ANTIGRAVITY_AGENT: undefined,
+              AUGMENT_AGENT: undefined,
+              CLAUDECODE: undefined,
+              CLAUDE_CODE: undefined,
+              CLAUDE_CODE_IS_COWORK: undefined,
+              CODEX_CI: undefined,
+              CODEX_SANDBOX: undefined,
+              CODEX_THREAD_ID: undefined,
+              COPILOT_ALLOW_ALL: undefined,
+              COPILOT_GITHUB_TOKEN: undefined,
+              COPILOT_MODEL: undefined,
+              CURSOR_AGENT: undefined,
+              CURSOR_EXTENSION_HOST_ROLE: undefined,
+              CURSOR_TRACE_ID: undefined,
+              GEMINI_CLI: undefined,
+              HERMES_SESSION_PLATFORM: undefined,
+              OPENCLAW_SHELL: undefined,
+              OPENCODE_CLIENT: undefined,
+              REPL_ID: undefined,
+            },
+          },
+        );
+
+        expect(result.exitCode).toBe(0);
+        expectRequest(requests[0], "POST", "/v1/sessions", "test-key");
+        const body = requests[0]?.jsonBody as {
+          userMetadata?: Record<string, string>;
+        };
+        // Attribution keys still present; agent is only stamped when detected.
+        expect(body.userMetadata?.browse_cli).toBe("true");
+        expect(body.userMetadata?.agent).toBeUndefined();
+      },
+    );
+  });
+
   it("sessions update merges an explicit status flag into the request body", async () => {
     await withServer(
       async (_request, response) => {


### PR DESCRIPTION
**⚠️ DRAFT — overnight autonomous; needs Shrey review**

Linear: [STG-2486](https://linear.app/browserbase/issue/STG-2486/browse-cli-stamp-coding-agent-on-browserbase-session-metadata)

## What

Stamp the detected coding agent onto the Browserbase session `userMetadata` at session create, under a new `agent` key (e.g. `agent: "claude"`, `"cursor"`, `"codex"`, `"hermes"`).

Scope is the `browse` CLI package only (`packages/cli`). The single behavioral change is in `applyCliAttribution()` in `packages/cli/src/commands/cloud/sessions/create.ts`: after the existing `browse_cli` / `cli_version` / `install_id` stamping, it now also calls `detectAgent()` and — only when a value is returned — sanitizes it through `toMetadataValue()` and sets `userMetadata.agent`.

## Why

The CLI already computes the coding agent via `detectAgent()` (`packages/cli/src/lib/agent.ts`), but today that value only flows to PostHog telemetry (`packages/cli/src/lib/telemetry.ts`) — it is **not** stamped on the Browserbase session itself. Without it on the session, we cannot attribute cloud sessions to the coding agent that drove them (Claude Code / Cursor / Codex / etc.) in our internal analytics.

This is the CLI-side prerequisite for that attribution: adding `agent` to the session metadata mirrors the `agent` property already sent to PostHog, so our internal analytics can join sessions back to the agent.

Design notes:
- **Minimal + guarded.** `agent` is only set when `detectAgent()` returns a truthy value (and the sanitized value is non-empty). No agent → no `agent` key, matching how `install_id` is handled.
- **Best-effort, never throws.** `detectAgent()` is wrapped in `.catch(() => null)`, so a detection failure can never break session creation.
- **Consistent style.** Value runs through `toMetadataValue()` (same as the other attribution keys) so the session-create validator never 400s on a stray character or over-length value.
- **Caller metadata preserved.** User-supplied `userMetadata` (via `--body` / `--stdin`) is untouched except for the authoritative attribution keys.

Note: the sibling driver path (`packages/cli/src/lib/driver/remote.ts`, used by `open --remote`) stamps the same `browse_cli`/`cli_version`/`install_id` keys but is **out of scope** for this PR, which targets the `applyCliAttribution` (`sessions create`) path per the task. It can be given the same `agent` key in a follow-up if desired.

## Changeset

Added a PATCH changeset for the `browse` package. `browse` is in the changeset `ignore` list, but release-impacting CLI changes still get a patch changeset (this changes the session metadata the CLI sends).

## E2E Test Matrix

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `pnpm --filter browse run check` (`tsc --noEmit`) after `pnpm turbo run build --filter browse` | exit 0, no diagnostics | Proves the change type-checks against the built workspace. (A fresh worktree first errors on unbuilt `@browserbasehq/stagehand`; those errors are pre-existing/unrelated and clear once the workspace dep is built via turbo.) |
| `pnpm turbo run build --filter browse` | `4 successful, 4 total`; `browse:build` executed `tsc -p tsconfig.json` + oclif manifest | Proves `create.ts` compiles into `dist/` (verified `dist/commands/cloud/sessions/create.js` contains `detectAgent()` + `userMetadata.agent = sanitized`). |
| `vitest run tests/cli-cloud-contract.test.ts tests/agent.test.ts` | `Test Files 2 passed`, `Tests 57 passed` | Full session-create contract suite + agent-detection suite green, including 2 new contract tests below. These run the **compiled** CLI (`bin/run.js`) as a subprocess against a fake Browserbase server and assert the actual POST `/v1/sessions` body. |
| New test: agent detected (`HERMES_SESSION_PLATFORM=telegram`) | Captured request body `userMetadata.agent === "hermes"` | Proves a detected agent is stamped onto the real outgoing session-create request. |
| New test: no agent (all known agent env vars cleared) | Captured body `userMetadata.browse_cli === "true"`, `userMetadata.agent === undefined` | Proves the `agent` key is omitted when nothing is detected, while base attribution still flows. |
| `eslint src/commands/cloud/sessions/create.ts tests/cli-cloud-contract.test.ts` | exit 0, no output | Lint clean (import ordering, style). |

**Not run locally:** no live Browserbase session was created against production (overnight autonomous; nothing irreversible). The contract tests exercise the exact request body via a fake server subprocess, which is the load-bearing behavior here; a real live session would only additionally confirm the Browserbase API accepts the `agent` key (it accepts arbitrary `userMetadata` today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stamp the detected coding agent on session create in the `browse` CLI by setting `userMetadata.agent`. This enables internal analytics attribution of CLI-created cloud sessions to agents and aligns with PostHog telemetry (Linear STG-2486).

- **New Features**
  - Set `userMetadata.agent` from `detectAgent()` in `applyCliAttribution()`; value sanitized via `toMetadataValue()`.
  - Only set when detected; never throws; preserves caller `userMetadata`; `browse_cli`/`cli_version`/`install_id`/`agent` override caller values.
  - Scope: `sessions create` path only; driver `open --remote` unchanged.
  - Added contract tests for detected and no-agent cases; added patch changeset for `browse`.

<sup>Written for commit 985ea63fb52bd506793aecff775ae32a3e5bbc1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


