### PR TITLE
[STG-2497] docs: sync CUA model list with AgentProvider map

### DIFF
--- a/packages/docs/v3/configuration/models.mdx
+++ b/packages/docs/v3/configuration/models.mdx
@@ -692,18 +692,25 @@ const agent = stagehand.agent({
 <Accordion title="All Supported CUA Models">
 | Provider | Model |
 | -------- | ----- |
+| Anthropic | `anthropic/claude-haiku-4-5` |
 | Anthropic | `anthropic/claude-haiku-4-5-20251001` |
-| Anthropic | `anthropic/claude-sonnet-4-6` |
+| Anthropic | `anthropic/claude-sonnet-4-20250514` |
 | Anthropic | `anthropic/claude-sonnet-4-5-20250929` |
+| Anthropic | `anthropic/claude-sonnet-4-6` |
 | Anthropic | `anthropic/claude-opus-4-5-20251101` |
 | Anthropic | `anthropic/claude-opus-4-6` |
 | Anthropic | `anthropic/claude-opus-4-8` |
+| Anthropic | `anthropic/claude-fable-5` |
 | Google   | `google/gemini-2.5-computer-use-preview-10-2025` |
 | Google   | `google/gemini-3-flash-preview` |
+| Google   | `google/gemini-3.5-flash` |
 | Google   | `google/gemini-3-pro-preview` |
 | Microsoft | `microsoft/fara-7b` |
 | OpenAI   | `openai/computer-use-preview` |
 | OpenAI   | `openai/computer-use-preview-2025-03-11` |
+| OpenAI   | `openai/gpt-5.4` |
+| OpenAI   | `openai/gpt-5.4-mini` |
+| OpenAI   | `openai/gpt-5.5` |
 </Accordion>
 
 <Note>


### PR DESCRIPTION
## Summary

The `All Supported CUA Models` table in `packages/docs/v3/configuration/models.mdx` was missing 7 models that are already registered in `packages/core/lib/v3/agent/AgentProvider.ts` (`modelToAgentProviderMap`, lines 17–37). This PR brings the docs table in sync with the code.

Added rows:

- `openai/gpt-5.4`
- `openai/gpt-5.4-mini`
- `openai/gpt-5.5`
- `anthropic/claude-sonnet-4-20250514`
- `anthropic/claude-haiku-4-5` (the short alias — only the dated `claude-haiku-4-5-20251001` was listed)
- `anthropic/claude-fable-5`
- `google/gemini-3.5-flash`

Also lightly reordered the Anthropic and Google rows so variants of the same model family sit next to each other (haiku → sonnet → opus → fable; gemini-2.5 → gemini-3-flash → gemini-3.5-flash → gemini-3-pro).

## Test plan

Docs-only change. No code touched. Rendered table matches the source-of-truth map at `packages/core/lib/v3/agent/AgentProvider.ts`.

Requested by: alexander@browserbase.com
Linear: https://linear.app/browserbase/issue/STG-2497/docs-sync-cua-model-list-with-agentprovider-map
Slack thread: https://browserbase.slack.com/archives/D0AHY8DEQPM/p1783452853684349