### PR TITLE
feat(core): support modelName "auto" when using the Stagehand API

### DIFF
--- a/.changeset/auto-model-api-mode.md
+++ b/.changeset/auto-model-api-mode.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Allow modelName "auto" in the constructor and per-primitive model overrides when running through the Stagehand API

--- a/packages/core/lib/modelUtils.ts
+++ b/packages/core/lib/modelUtils.ts
@@ -4,6 +4,19 @@ import {
   AvailableCuaModel,
 } from "./v3/types/public/agent.js";
 
+/**
+ * Sentinel model name that delegates model selection to the Stagehand API.
+ * Only valid when running through the API (env: "BROWSERBASE" with
+ * disableAPI: false); no local LLM client or provider API key is involved.
+ */
+export const AUTO_MODEL_NAME = "auto";
+
+export function isAutoModel(
+  model?: string | { modelName: string; [key: string]: unknown },
+): boolean {
+  return extractModelName(model) === AUTO_MODEL_NAME;
+}
+
 //useful when resolving a model from string or object formats we accept
 export function extractModelName(
   model?: string | { modelName: string; [key: string]: unknown },

--- a/packages/core/lib/v3/api.ts
+++ b/packages/core/lib/v3/api.ts
@@ -4,6 +4,7 @@ import {
   hasModelProviderAuth,
   loadApiKeyFromEnv,
 } from "../utils.js";
+import { isAutoModel } from "../modelUtils.js";
 import { STAGEHAND_VERSION } from "../version.js";
 import {
   StagehandAPIError,
@@ -655,6 +656,15 @@ export class StagehandAPIClient {
    * model provider differs from the one used to init the session.
    */
   private prepareModelConfig(model: ModelConfiguration): PreparedModelConfig {
+    // "auto" delegates model selection to the API, so never inherit the
+    // default model's provider config or API key — the server picks the
+    // provider. Explicit per-call options are still passed through.
+    if (isAutoModel(model)) {
+      return typeof model === "string"
+        ? { modelName: model }
+        : ({ ...model } as PreparedModelConfig);
+    }
+
     if (typeof model === "string") {
       // Extract provider from model string (e.g., "openai/gpt-5-nano" -> "openai")
       const provider = this.getModelProvider(model);

--- a/packages/core/lib/v3/cache/AgentCache.ts
+++ b/packages/core/lib/v3/cache/AgentCache.ts
@@ -35,6 +35,7 @@ import {
   waitForCachedSelector,
 } from "./utils.js";
 import { substituteVariables } from "../agent/utils/variables.js";
+import { isAutoModel } from "../../modelUtils.js";
 
 const SENSITIVE_CONFIG_KEYS = new Set(["apikey", "api_key", "api-key"]);
 
@@ -82,7 +83,13 @@ export class AgentCache {
   }
 
   shouldAttemptCache(instruction: string): boolean {
-    return this.enabled && instruction.trim().length > 0;
+    return (
+      this.enabled &&
+      instruction.trim().length > 0 &&
+      // "auto" sessions have no local LLM client for replay self-heal;
+      // rely on the API (and its server-side cache) instead.
+      !isAutoModel(this.getBaseModelName())
+    );
   }
 
   sanitizeExecuteOptions(

--- a/packages/core/lib/v3/v3.ts
+++ b/packages/core/lib/v3/v3.ts
@@ -357,17 +357,22 @@ export class V3 {
     const baseClientOptions: ClientOptions = clientOptions
       ? ({ ...clientOptions } as ClientOptions)
       : ({} as ClientOptions);
-    if (opts.llmClient) {
-      this.llmClient = opts.llmClient;
-      this.modelClientOptions = baseClientOptions;
-      this.disableAPI = true;
-    } else if (isAutoModel(this.modelName)) {
-      if (opts.env !== "BROWSERBASE" || this.disableAPI || this.experimental) {
+    if (isAutoModel(this.modelName)) {
+      if (
+        opts.llmClient ||
+        opts.env !== "BROWSERBASE" ||
+        this.disableAPI ||
+        this.experimental
+      ) {
         throw new StagehandInvalidArgumentError(AUTO_MODEL_API_ONLY_MESSAGE);
       }
       // "auto" delegates model selection to the Stagehand API, so no local
       // LLM client is created and no provider API key is required.
       this.modelClientOptions = baseClientOptions;
+    } else if (opts.llmClient) {
+      this.llmClient = opts.llmClient;
+      this.modelClientOptions = baseClientOptions;
+      this.disableAPI = true;
     } else {
       // Ensure API key is set unless provider-native auth was configured.
       let apiKey = (baseClientOptions as { apiKey?: string }).apiKey;

--- a/packages/core/lib/v3/v3.ts
+++ b/packages/core/lib/v3/v3.ts
@@ -88,7 +88,7 @@ import {
 } from "./types/public/index.js";
 import { V3Context } from "./understudy/context.js";
 import { Page } from "./understudy/page.js";
-import { resolveModel } from "../modelUtils.js";
+import { AUTO_MODEL_NAME, isAutoModel, resolveModel } from "../modelUtils.js";
 import { StagehandAPIClient } from "./api.js";
 import { validateExperimentalFeatures } from "./agent/utils/validateExperimentalFeatures.js";
 import { flattenVariables } from "./agent/utils/variables.js";
@@ -98,6 +98,7 @@ import { EventStore } from "./flowlogger/EventStore.js";
 import { createTimeoutGuard } from "./handlers/handlerUtils/timeoutGuard.js";
 import { ActTimeoutError } from "./types/public/sdkErrors.js";
 
+const AUTO_MODEL_API_ONLY_MESSAGE = `model: "${AUTO_MODEL_NAME}" is only supported when running through the Stagehand API (env: "BROWSERBASE" with disableAPI: false and experimental: false). Specify a concrete model (e.g. "openai/gpt-5") instead.`;
 const DEFAULT_MODEL_NAME = "openai/gpt-4.1-mini";
 const DEFAULT_VIEWPORT = { width: 1288, height: 711 };
 const DEFAULT_AGENT_TOOL_TIMEOUT_MS = 45000;
@@ -360,6 +361,13 @@ export class V3 {
       this.llmClient = opts.llmClient;
       this.modelClientOptions = baseClientOptions;
       this.disableAPI = true;
+    } else if (isAutoModel(this.modelName)) {
+      if (opts.env !== "BROWSERBASE" || this.disableAPI || this.experimental) {
+        throw new StagehandInvalidArgumentError(AUTO_MODEL_API_ONLY_MESSAGE);
+      }
+      // "auto" delegates model selection to the Stagehand API, so no local
+      // LLM client is created and no provider API key is required.
+      this.modelClientOptions = baseClientOptions;
     } else {
       // Ensure API key is set unless provider-native auth was configured.
       let apiKey = (baseClientOptions as { apiKey?: string }).apiKey;
@@ -579,6 +587,16 @@ export class V3 {
       modelName = overrideModelName;
       clientOptions = rest as ClientOptions;
       perCallMiddleware = middleware;
+    }
+
+    if (isAutoModel(modelName)) {
+      if (!this.apiClient) {
+        throw new StagehandInvalidArgumentError(AUTO_MODEL_API_ONLY_MESSAGE);
+      }
+      // The Stagehand API resolves "auto" server-side and intercepts every
+      // act/extract/observe, so the local client is never dereferenced here.
+      // Note it is undefined when the session's base model is also "auto".
+      return this.llmClient;
     }
 
     if (
@@ -1091,6 +1109,14 @@ export class V3 {
               browserbaseSessionID: this.opts.browserbaseSessionID,
             });
             if (!available) {
+              if (isAutoModel(this.modelName)) {
+                // "auto" has no local fallback; end the just-created session
+                // best-effort before surfacing the error.
+                await this.apiClient.end().catch(() => {});
+                throw new StagehandInitError(
+                  `model: "${AUTO_MODEL_NAME}" requires the Stagehand API, but it is unavailable for this session (sessionId: ${sessionId}). Specify a concrete model (e.g. "openai/gpt-5") instead.`,
+                );
+              }
               this.apiClient = null;
             }
             this.opts.browserbaseSessionID = sessionId;
@@ -1289,7 +1315,10 @@ export class V3 {
       const canUseCache =
         typeof input === "string" &&
         !this.isAgentReplayRecording() &&
-        this.actCache.enabled;
+        this.actCache.enabled &&
+        // "auto" sessions have no local LLM client for replay self-heal;
+        // rely on the API (and its server-side cache) instead.
+        !isAutoModel(this.modelName);
       if (canUseCache) {
         actCacheContext = await this.actCache.prepareContext(
           input,
@@ -1982,7 +2011,10 @@ export class V3 {
         cua: { value: isCuaMode ? "true" : "false", type: "boolean" },
         mode: { value: loggedMode, type: "string" },
         model: {
-          value: extractModelName(options?.model) ?? this.llmClient.modelName,
+          value:
+            extractModelName(options?.model) ??
+            this.llmClient?.modelName ??
+            this.modelName,
           type: "string",
         },
         systemPrompt: { value: options?.systemPrompt ?? "", type: "string" },

--- a/packages/core/lib/v3/v3.ts
+++ b/packages/core/lib/v3/v3.ts
@@ -1116,8 +1116,11 @@ export class V3 {
             if (!available) {
               if (isAutoModel(this.modelName)) {
                 // "auto" has no local fallback; end the just-created session
-                // best-effort before surfacing the error.
-                await this.apiClient.end().catch(() => {});
+                // best-effort before surfacing the error. Never end a
+                // caller-supplied (resumed) session we didn't create.
+                if (!this.opts.browserbaseSessionID) {
+                  await this.apiClient.end().catch(() => {});
+                }
                 this.apiClient = null;
                 throw new StagehandInitError(
                   `model: "${AUTO_MODEL_NAME}" requires the Stagehand API, but it is unavailable for this session (sessionId: ${sessionId}). Specify a concrete model (e.g. "openai/gpt-5") instead.`,

--- a/packages/core/lib/v3/v3.ts
+++ b/packages/core/lib/v3/v3.ts
@@ -1118,6 +1118,7 @@ export class V3 {
                 // "auto" has no local fallback; end the just-created session
                 // best-effort before surfacing the error.
                 await this.apiClient.end().catch(() => {});
+                this.apiClient = null;
                 throw new StagehandInitError(
                   `model: "${AUTO_MODEL_NAME}" requires the Stagehand API, but it is unavailable for this session (sessionId: ${sessionId}). Specify a concrete model (e.g. "openai/gpt-5") instead.`,
                 );

--- a/packages/core/tests/unit/auto-model.test.ts
+++ b/packages/core/tests/unit/auto-model.test.ts
@@ -89,6 +89,17 @@ describe("Stagehand constructor with model 'auto'", () => {
         }),
     ).toThrow(StagehandInvalidArgumentError);
   });
+
+  it("throws when a custom llmClient bypasses the API", () => {
+    expect(
+      () =>
+        new Stagehand({
+          env: "BROWSERBASE",
+          model: "auto",
+          llmClient: {} as never,
+        }),
+    ).toThrow(StagehandInvalidArgumentError);
+  });
 });
 
 describe("per-call model 'auto' local resolution", () => {

--- a/packages/core/tests/unit/auto-model.test.ts
+++ b/packages/core/tests/unit/auto-model.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { StagehandAPIClient } from "../../lib/v3/api.js";
 import { V3 as Stagehand } from "../../lib/v3/v3.js";
+import { AgentCache } from "../../lib/v3/cache/AgentCache.js";
+import type { CacheStorage } from "../../lib/v3/cache/CacheStorage.js";
 import { StagehandInvalidArgumentError } from "../../lib/v3/types/public/sdkErrors.js";
 import type { ModelConfiguration } from "../../lib/v3/types/public/model.js";
 
@@ -133,6 +135,36 @@ describe("per-call model 'auto' local resolution", () => {
     expect(privateStagehand.resolveLlmClient("auto")).toBe(
       privateStagehand.llmClient,
     );
+  });
+});
+
+describe("agent cache with model 'auto'", () => {
+  function createAgentCache(baseModelName: string) {
+    return new AgentCache({
+      storage: { enabled: true } as unknown as CacheStorage,
+      logger: vi.fn(),
+      getActHandler: () => null,
+      getContext: () => null,
+      getDefaultLlmClient: () => undefined as never,
+      getBaseModelName: () => baseModelName,
+      getSystemPrompt: () => undefined,
+      domSettleTimeoutMs: undefined,
+      act: vi.fn(),
+    });
+  }
+
+  it("skips local replay for 'auto' sessions (no local client for self-heal)", () => {
+    expect(createAgentCache("auto").shouldAttemptCache("do the thing")).toBe(
+      false,
+    );
+  });
+
+  it("still replays for concrete-model sessions", () => {
+    expect(
+      createAgentCache("openai/gpt-4.1-mini").shouldAttemptCache(
+        "do the thing",
+      ),
+    ).toBe(true);
   });
 });
 

--- a/packages/core/tests/unit/auto-model.test.ts
+++ b/packages/core/tests/unit/auto-model.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { StagehandAPIClient } from "../../lib/v3/api.js";
+import { V3 as Stagehand } from "../../lib/v3/v3.js";
+import { StagehandInvalidArgumentError } from "../../lib/v3/types/public/sdkErrors.js";
+import type { ModelConfiguration } from "../../lib/v3/types/public/model.js";
+
+/**
+ * Tests for modelName "auto", which delegates model selection to the
+ * Stagehand API. "auto" is only valid when running through the API
+ * (env: "BROWSERBASE" with disableAPI: false and experimental: false):
+ * no local LLM client is created and no provider API key is loaded.
+ */
+
+function createClientWithExecuteMock() {
+  const client = new StagehandAPIClient({
+    apiKey: "bb-test",
+    logger: vi.fn(),
+  });
+  const executeMock = vi.fn().mockResolvedValue({});
+
+  (
+    client as unknown as {
+      execute: typeof executeMock;
+    }
+  ).execute = executeMock;
+
+  return { client, executeMock };
+}
+
+describe("Stagehand constructor with model 'auto'", () => {
+  it("does not throw and does not look up a provider API key in API mode", () => {
+    const logger = vi.fn();
+
+    expect(
+      () =>
+        new Stagehand({
+          env: "BROWSERBASE",
+          model: "auto",
+          logger,
+        }),
+    ).not.toThrow();
+
+    expect(logger).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("No known environment variable"),
+      }),
+    );
+  });
+
+  it("accepts the object form { modelName: 'auto' } in API mode", () => {
+    expect(
+      () =>
+        new Stagehand({
+          env: "BROWSERBASE",
+          model: { modelName: "auto" },
+        }),
+    ).not.toThrow();
+  });
+
+  it("throws when env is LOCAL", () => {
+    expect(
+      () =>
+        new Stagehand({
+          env: "LOCAL",
+          model: "auto",
+        }),
+    ).toThrow(StagehandInvalidArgumentError);
+  });
+
+  it("throws when the API is disabled", () => {
+    expect(
+      () =>
+        new Stagehand({
+          env: "BROWSERBASE",
+          model: "auto",
+          disableAPI: true,
+        }),
+    ).toThrow(StagehandInvalidArgumentError);
+  });
+
+  it("throws when experimental mode bypasses the API", () => {
+    expect(
+      () =>
+        new Stagehand({
+          env: "BROWSERBASE",
+          model: "auto",
+          experimental: true,
+        }),
+    ).toThrow(StagehandInvalidArgumentError);
+  });
+});
+
+describe("per-call model 'auto' local resolution", () => {
+  it("throws when resolving 'auto' without an API client", () => {
+    const stagehand = new Stagehand({
+      env: "BROWSERBASE",
+      model: "openai/gpt-4.1-mini",
+      disableAPI: true,
+    });
+    const privateStagehand = stagehand as unknown as {
+      resolveLlmClient(model: ModelConfiguration): unknown;
+    };
+
+    expect(() => privateStagehand.resolveLlmClient("auto")).toThrow(
+      StagehandInvalidArgumentError,
+    );
+  });
+
+  it("reuses the default client when resolving 'auto' with an API client", () => {
+    const stagehand = new Stagehand({
+      env: "BROWSERBASE",
+      model: "openai/gpt-4.1-mini",
+    });
+    const privateStagehand = stagehand as unknown as {
+      apiClient: unknown;
+      llmClient: unknown;
+      resolveLlmClient(model: ModelConfiguration): unknown;
+    };
+    privateStagehand.apiClient = {};
+
+    expect(privateStagehand.resolveLlmClient("auto")).toBe(
+      privateStagehand.llmClient,
+    );
+  });
+});
+
+describe("StagehandAPIClient with model 'auto'", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          success: true,
+          data: { sessionId: "sess-auto-model", available: true },
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("sends per-call model 'auto' without inheriting the session model API key", async () => {
+    const { client, executeMock } = createClientWithExecuteMock();
+
+    await client.init({
+      modelName: "openai/gpt-4.1-mini",
+      modelApiKey: "sk-default",
+    });
+
+    await client.act({
+      input: "click the login button",
+      options: { model: "auto" },
+    });
+
+    expect(executeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "act",
+        args: expect.objectContaining({
+          options: expect.objectContaining({
+            model: { modelName: "auto" },
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("passes explicit per-call options through for the object form of 'auto'", async () => {
+    const { client, executeMock } = createClientWithExecuteMock();
+
+    await client.init({
+      modelName: "openai/gpt-4.1-mini",
+      modelApiKey: "sk-default",
+    });
+
+    await client.observe({
+      instruction: "find the login button",
+      options: {
+        model: { modelName: "auto", temperature: 0.5 } as ModelConfiguration,
+      },
+    });
+
+    const model = executeMock.mock.calls[0][0].args.options.model as Record<
+      string,
+      unknown
+    >;
+    expect(model).toEqual({ modelName: "auto", temperature: 0.5 });
+    expect(model).not.toHaveProperty("apiKey");
+  });
+
+  it("initializes a session with modelName 'auto' and no model API key", async () => {
+    const { client, executeMock } = createClientWithExecuteMock();
+
+    await client.init({
+      modelName: "auto",
+    });
+
+    await client.extract({ instruction: "extract the headline" });
+
+    expect(executeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "extract",
+        args: expect.objectContaining({
+          options: undefined,
+        }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Why

Passing `model: "auto"` failed at the constructor with:

```
ERROR: No known environment variable for provider 'auto'
```

followed by an `UnsupportedModelError`, because Stagehand always resolved a provider API key and built a local LLM client — even when all inference runs server-side through the Stagehand API.

## What changed

`model: "auto"` is now accepted in the constructor and in per-primitive (`act`/`extract`/`observe`) model overrides **when running through the Stagehand API** (`env: "BROWSERBASE"`, `disableAPI: false`, `experimental: false`). The API resolves `"auto"` server-side.

- `modelUtils.ts`: new `AUTO_MODEL_NAME` constant + `isAutoModel()` helper.
- `v3.ts` constructor: for `"auto"`, skip provider API-key lookup and local client creation; throw a clear `StagehandInvalidArgumentError` when the API won't be used (LOCAL env, `disableAPI: true`, or `experimental: true`).
- `v3.ts` `resolveLlmClient`: per-call `"auto"` overrides no-op onto the default client in API mode and throw the same clear error otherwise.
- `v3.ts` `act()`: local act-cache replay is skipped for `"auto"` sessions — there is no local client for self-heal; the server-side cache still applies.
- `v3.ts` `init()`: if the API reports `available: false`, `"auto"` has no local fallback — the just-created session is ended best-effort and a clear `StagehandInitError` (with sessionId) is thrown instead of failing later with an undefined-client TypeError.
- `api.ts` `prepareModelConfig`: `"auto"` never inherits the default model's provider config or API key (the server picks the provider); explicit per-call options still pass through.

Agent/CUA mode is intentionally out of scope.

## Known limits (intentional, kept surgical)

- `middleware` on a per-call `{ modelName: "auto" }` override is inert — consistent with middleware being documented local-only and already inert in API mode for concrete models.
- The public `llmClient!: LLMClient` field is `undefined` for `"auto"` sessions; tightening that type ripples across the public surface and is left for a follow-up.

## Tests

- New `tests/unit/auto-model.test.ts` (10 tests): constructor accept/reject matrix (string + object form), per-call resolution guard, and wire-level assertions that `"auto"` payloads carry no inherited API key.
- Full core unit suite: 869 passed; the 4 `flowlogger-eventstore` failures reproduce on clean `main` (pre-existing, unrelated).
- Typecheck, eslint, and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables `model: "auto"` in `@browserbasehq/stagehand` when using the Stagehand API, delegating model selection to the server and avoiding local provider keys. Outside API mode, `"auto"` now fails fast with clear errors.

- **New Features**
  - Accept `"auto"` in the constructor and per-call overrides only in API mode (env: "BROWSERBASE", `disableAPI: false`, `experimental: false`).
  - No local LLM client or provider API key; the API selects the provider and payloads don’t inherit API keys.
  - Clear errors: `StagehandInvalidArgumentError` when not in API mode or when a custom `llmClient` is supplied; `StagehandInitError` if the API is unavailable. On `"auto"` init failure, only end sessions created by this init and leave caller-supplied `browserbaseSessionID` sessions untouched.
  - Per-call `"auto"` reuses the default client in API mode; explicit options pass through. Local act-cache and agent-cache replay are disabled for `"auto"` sessions.

<sup>Written for commit 1f9b6aaa492c1a4d93ba50234a66cedefb0efc68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

