### PR TITLE
[STG-2501] docs(cli): make unique named sessions the default in bundled browse skill

### DIFF
--- a/packages/cli/skills/browse/SKILL.md
+++ b/packages/cli/skills/browse/SKILL.md
@@ -104,16 +104,16 @@ Refs are refreshed on every snapshot. After clicks, form submits, navigation, or
 Give each independent browser task a unique `--session` value. Sessions isolate tabs, cookies, refs, and daemon state; parallel tasks that omit `--session` share the `default` session and overwrite each other's active page — and parallel tasks that happen to pick the same name collide the same way, so uniqueness matters as much as naming. When spawning subagents that browse, assign each one its own session name (or set `BROWSE_SESSION` per subagent) instead of letting them choose.
 
 ```bash
-browse open https://example.com/search-a --session search-a --local
-browse open https://example.com/search-b --session search-b --local
-browse snapshot --session search-a
-browse snapshot --session search-b
+browse open https://example.com/search-a --session search-a-9fk --local
+browse open https://example.com/search-b --session search-b-2qh --local
+browse snapshot --session search-a-9fk
+browse snapshot --session search-b-2qh
 ```
 
 When a task is complete, stop only that task's session:
 
 ```bash
-browse stop --session search-a
+browse stop --session search-a-9fk
 ```
 
 ## Core Browser Commands

--- a/packages/cli/skills/browse/SKILL.md
+++ b/packages/cli/skills/browse/SKILL.md
@@ -51,16 +51,16 @@ Use `browse <topic> --help` for exact flags before running unfamiliar commands.
 
 ## Browser Target Selection
 
-Browser driver commands auto-start the browse daemon when needed. Choose the browser target per command with flags:
+Browser driver commands auto-start the browse daemon when needed. Choose the browser target per command with flags, and give every task its own named session:
 
 ```bash
-browse open https://example.com --local
-browse open https://example.com --local --headed
-browse open https://example.com --remote
-browse open https://example.com --remote --verified --proxies
-browse open https://example.com --auto-connect
-browse open https://example.com --cdp 9222
-browse open https://example.com --cdp ws://127.0.0.1:9222/devtools/browser/<id>
+browse open https://example.com --session research-a7f --local
+browse open https://example.com --session research-a7f --local --headed
+browse open https://example.com --session research-a7f --remote
+browse open https://example.com --session research-a7f --remote --verified --proxies
+browse open https://example.com --session research-a7f --auto-connect
+browse open https://example.com --session research-a7f --cdp 9222
+browse open https://example.com --session research-a7f --cdp ws://127.0.0.1:9222/devtools/browser/<id>
 ```
 
 Use local mode for development, localhost, trusted sites, and fast iteration. Use `--auto-connect` only when the user explicitly wants to attach to an already-running debuggable Chrome session with existing cookies or login state; use `--local` when no debuggable Chrome is available. Use remote mode when Browserbase credentials are available and the site needs hosted browser infrastructure, Verified browser mode, CAPTCHA solving, proxies, or session persistence.
@@ -69,11 +69,11 @@ For a Verified and/or proxied remote session, add `--verified` and/or `--proxies
 
 Choose headed/headless and local/remote mode when starting a session. A running session keeps its mode: passing a conflicting flag such as `--headed` to an already-running headless session fails until you run `browse stop --session <name>` or target a different session.
 
-Use named sessions for any non-trivial work, especially when multiple agents or parallel tasks may run at once. Every browser command accepts `--session <name>` (or `-s <name>`); the `BROWSE_SESSION` env var sets the default, and commands without either share the `default` session.
+Always give each task its own named session. Pass `--session <name>` (or `-s <name>`) on every browser command, using a short task-derived name plus a unique suffix (`research-a7f`), or set the `BROWSE_SESSION` env var once for the whole task. Commands without either share the machine-wide `default` session, and two tasks that pick the same name share one browser: another agent's navigation replaces your active page and invalidates your refs, and its `browse stop` kills your browser mid-task. Other agents' sessions are invisible to you, so never assume you are alone — do not use the shared `default` session unless the user explicitly asks you to attach to it.
 
 ```bash
-browse open https://example.com --session research --local
-browse snapshot --session research
+browse open https://example.com --session research-a7f --local
+browse snapshot --session research-a7f
 ```
 
 Remote browser and cloud API commands require:
@@ -101,7 +101,7 @@ Refs are refreshed on every snapshot. After clicks, form submits, navigation, or
 
 ## Parallel Browser Work
 
-Use a different `--session` value for each independent browser task. Sessions isolate tabs, cookies, refs, and daemon state; parallel tasks that omit `--session` share the `default` session and overwrite each other's active page.
+Give each independent browser task a unique `--session` value. Sessions isolate tabs, cookies, refs, and daemon state; parallel tasks that omit `--session` share the `default` session and overwrite each other's active page — and parallel tasks that happen to pick the same name collide the same way, so uniqueness matters as much as naming. When spawning subagents that browse, assign each one its own session name (or set `BROWSE_SESSION` per subagent) instead of letting them choose.
 
 ```bash
 browse open https://example.com/search-a --session search-a --local
@@ -346,7 +346,7 @@ JSON output includes every match with full descriptions and ignores `--limit`; `
 3. Re-run `browse snapshot` after navigation or DOM-changing actions because refs can change.
 4. Prefer refs from snapshots for clicks and uploads; use selectors or XPath when refs are unavailable.
 5. Use `--local` for localhost and repeatable development; use `--remote` for protected sites or Browserbase-specific behavior.
-6. Use a distinct `--session <name>` for each parallel or long-running task; commands without the flag share the `default` session.
+6. Always pass a unique `--session <name>` per task (task-derived name + unique suffix); the unnamed `default` session is shared by every agent on the machine, and duplicate names collide the same way.
 7. Use `--auto-connect` only when attaching to an existing debuggable local Chrome session is intended.
 8. Use `browse doctor` when session startup, browser discovery, CDP attach, or Browserbase auth looks wrong.
 9. Never retry a failing command unchanged. If the same command fails twice with the same error, stop — run `browse doctor --json`, then change approach (fix the key, switch `--local`/`--remote`, or `browse stop --force` and start fresh). Repeating an identical failing command will keep failing.
@@ -356,6 +356,7 @@ JSON output includes every match with full descriptions and ignores `--limit`; `
 ## Troubleshooting
 
 - "No active page": run `browse status --session <name>`, then `browse open <url> --session <name>` or `browse tab new <url> --session <name>`; use `browse stop --force` if the daemon is stale.
+- Page changed to a URL you never navigated to, refs stopped matching, or your session died mid-task: another agent is sharing your session name (or `default`). Switch to a fresh unique `--session <name>` and re-open your URL instead of fighting for the shared one.
 - Chrome not found: use `--remote` with Browserbase credentials, install Chrome, or attach with `--cdp`.
 - Action fails: run `browse snapshot` and use a visible ref from the current page state.
 - 401 Unauthorized on `open`, `get`, or other driver commands: a set `BROWSERBASE_API_KEY` makes `browse` default to remote mode. Fix the key at https://browserbase.com/settings, unset it, or pass `--local` to run a managed local browser (no key needed).


### PR DESCRIPTION
## Summary

Two agents running the browse CLI in parallel clobber each other when they share a browser session — reported on browse 0.9.4: two Claude Code sessions mixed up each other's pages until one agent noticed the shared `default` session "got hijacked" and recovered by improvising a named session.

Reproduced with parallel Claude subagents against the shipped skill text. Two distinct failure modes, one root cause — **session identity is not unique per agent**:

1. **Bare `default` sharing.** Quick one-off tasks run session-less commands (`browse open <url> --local`) because the skill's guidance is conditional ("named sessions for any non-trivial work… when multiple agents or parallel tasks **may** run at once" — a condition an agent cannot evaluate, since sibling sessions are invisible to it) and the first seven example commands in the file carry no `--session`. Repro: two parallel subagents given trivial tasks both landed on `"session": "default"` and both ran bare `browse stop` at the end — each stop tears down the other's browser.
2. **Colliding names.** Even when agents follow the "use a named session" guidance, nothing says the name must be **unique**. Repro: two parallel subagents with similar prompts independently chose `--session example-task`; one agent's click showed up in the other's snapshots (the victim interpreted it as "the site silently redirected"), and the first finisher's `browse stop --session example-task` killed the sibling's browser mid-task, forcing a doctor → stop → re-open recovery cycle.

Amplifier: after a sibling's `stop` tears down the shared daemon, the victim's next command auto-starts a fresh daemon — which defaults to **remote** mode when `BROWSERBASE_API_KEY` is set (existing documented behavior), silently spinning up a paid cloud session for what the agent thinks is local work.

## Fix (docs-only, bundled skill text)

Make unique task-derived session names the modeled default in `packages/cli/skills/browse/SKILL.md`:

- `--session research-a7f` added to the anchor examples in Browser Target Selection (the block agents copy verbatim)
- the conditional named-session paragraph is now unconditional, requires a task-derived name **plus a unique suffix**, and explains what sharing actually does (active page replaced, refs invalidated, sibling `stop` kills your browser)
- Parallel Browser Work: uniqueness matters as much as naming; when spawning subagents, assign each one its session name (or set `BROWSE_SESSION` per subagent) instead of letting them choose
- Best Practices rule 6 strengthened to match
- new Troubleshooting bullet: how to recognize a hijacked session (page you never navigated to, refs stop matching, session dies mid-task) and recover by moving to a fresh unique name

No changeset: skill-text-only change, no runtime/package behavior change (same treatment as #2235, #2245).

## E2E Test Matrix

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| Baseline: 2 parallel Claude subagents, trivial one-off task framing, shipped skill text (browse 0.9.1 local install; identical skill text to 0.9.4/main) | Both ran bare `browse open <url> --local` → `"session": "default"` in JSON output; both ran bare `browse stop` on the shared session | Reproduces failure mode 1: agents default to the shared `default` session on quick tasks |
| Baseline: 2 parallel Claude subagents, multi-step tasks with similar prompts | Both independently picked `--session example-task`; arm B's snapshot showed the IANA page arm A had clicked into (`urlMap` → `https://www.iana.org/help/example-domains` on a task that never navigated there); arm A's `browse stop --session example-task` killed arm B mid-task (`about:blank`, then "already running in remote mode" on re-open) | Reproduces failure mode 2: named-but-colliding sessions clobber exactly like `default` sharing |
| Post-fix: same 2 trivial prompts, agents pointed at the updated SKILL.md | `--session check-ex1a` and `--session httpbin-a1b` — unique task-derived names, correct title/heading/URL output, each stopped only its own session | Fixes mode 1: trivial tasks now start unique named sessions |
| Post-fix: same 2 multi-step prompts, agents pointed at the updated SKILL.md | `--session iana-check-x7q` and `--session research-ex01` — distinct names, no literal copy of the `research-a7f` example suffix, no foreign pages in any snapshot, clean isolated stops | Fixes mode 2: derived names no longer collide; the concrete example suffix is not copied verbatim |
| `pnpm turbo run build --filter=browse` then `pnpm vitest run tests/skills.test.ts tests/skills-install.test.ts` in `packages/cli` (<local build>) | `Test Files  2 passed (2)` / `Tests  33 passed (33)` | Skill install/catalog tests unaffected by the text change |
| `npx prettier skills/browse/SKILL.md --check` | `All matched files use Prettier code style!` | Formatting gate clean |

Post-fix rows point agents at the updated file explicitly (installed copies keep the old text until the next release picks this up); baseline multi-step agents read the shipped text. n=2 per arm — behavioral evidence, not a statistical guarantee.

Linear: [STG-2501](https://linear.app/browserbase/issue/STG-2501/make-unique-named-sessions-the-default-in-bundled-browse-skill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make unique named sessions the default in the bundled browse skill so parallel agents don’t share the `default` session or collide on the same name. Updates `packages/cli/skills/browse/SKILL.md` to add `--session` to anchor examples, require task‑derived names with a unique suffix (and use them in the parallel‑work example), add guidance for subagents and a troubleshooting tip, and clarify `BROWSE_SESSION`; no runtime changes (Linear STG‑2501).

<sup>Written for commit 3f1e607ab849debe4ced8f79ff859d6a78c1e9ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

