### PR TITLE
[chore]: clean up changeset

### DIFF
--- a/.changeset/curvy-pillows-attack.md
+++ b/.changeset/curvy-pillows-attack.md
@@ -1,5 +1,0 @@
----
-"@browserbasehq/stagehand": patch
----
-
-Fix `agent.execute()` occasionally reporting a completed run as failed (most often with reasoning models such as `openai/gpt-5.x`).


### PR DESCRIPTION
# why

# what changed

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed a stale changeset entry to prevent an unintended duplicate patch release of `@browserbasehq/stagehand`. No code or behavior changes; only release metadata cleanup.

<sup>Written for commit e7bd6dc69f6598dc2a82794164018a9148466765. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

