### PR TITLE
[STG-2511] feat: add browse skills show and agent-facing --help header

### DIFF
--- a/.changeset/cli-skills-show.md
+++ b/.changeset/cli-skills-show.md
@@ -1,0 +1,5 @@
+---
+"browse": patch
+---
+
+Add `browse skills show` to print the bundled skill and point agents to it from `--help`.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,6 +24,7 @@
     "bin": "browse",
     "dirname": "browse",
     "commands": "./dist/commands",
+    "helpClass": "./dist/help.js",
     "hooks": {
       "init": "./dist/hooks/init.js",
       "prerun": "./dist/hooks/prerun.js",

--- a/packages/cli/src/commands/skills/show.ts
+++ b/packages/cli/src/commands/skills/show.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { BrowseCommand } from "../../base.js";
@@ -16,7 +16,7 @@ export default class SkillsShow extends BrowseCommand {
 
     let contents: string;
     try {
-      contents = readFileSync(skillMdPath, "utf8");
+      contents = await readFile(skillMdPath, "utf8");
     } catch (error) {
       fail(
         `Could not read the bundled browse skill (SKILL.md): ${(error as Error).message}`,

--- a/packages/cli/src/commands/skills/show.ts
+++ b/packages/cli/src/commands/skills/show.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { BrowseCommand } from "../../base.js";
+import { fail } from "../../lib/errors.js";
 import { bundledCliSkillPath } from "../../lib/skills/install.js";
 
 export default class SkillsShow extends BrowseCommand {
@@ -17,8 +18,10 @@ export default class SkillsShow extends BrowseCommand {
     try {
       contents = readFileSync(skillMdPath, "utf8");
     } catch (error) {
-      this.error(
+      fail(
         `Could not read the bundled browse skill (SKILL.md): ${(error as Error).message}`,
+        1,
+        { resultCode: "skill_show_missing" },
       );
     }
 

--- a/packages/cli/src/commands/skills/show.ts
+++ b/packages/cli/src/commands/skills/show.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { BrowseCommand } from "../../base.js";
+import { bundledCliSkillPath } from "../../lib/skills/install.js";
+
+export default class SkillsShow extends BrowseCommand {
+  static override description =
+    "Print the bundled browse skill (usage patterns, workflows, gotchas) to stdout. Run before using browse in an agent.";
+
+  static override examples = ["browse skills show"];
+
+  async run(): Promise<void> {
+    const skillMdPath = join(bundledCliSkillPath(), "SKILL.md");
+
+    let contents: string;
+    try {
+      contents = readFileSync(skillMdPath, "utf8");
+    } catch (error) {
+      this.error(
+        `Could not read the bundled browse skill (SKILL.md): ${(error as Error).message}`,
+      );
+    }
+
+    this.log(contents);
+  }
+}

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -1,0 +1,21 @@
+import { Help } from "@oclif/core";
+
+// Custom root-help formatter so `browse --help` (and bare `browse`) lead with
+// a short block pointing agents at the bundled skill, ahead of oclif's
+// auto-generated VERSION/USAGE/DESCRIPTION/COMMANDS sections. Only the root
+// help view is customized -- individual `browse <command> --help` views are
+// unaffected.
+const AGENT_HEADER = `Start here (for AI agents):
+  browse skills show
+
+  The bundled skill ships with the CLI (always version-matched) and covers
+  workflows, session management, and common failure recovery. Prefer it over
+  guessing commands from flag docs alone.
+`;
+
+export default class BrowseHelp extends Help {
+  override async showRootHelp(): Promise<void> {
+    this.log(AGENT_HEADER);
+    await super.showRootHelp();
+  }
+}

--- a/packages/cli/src/lib/skills/install.ts
+++ b/packages/cli/src/lib/skills/install.ts
@@ -281,7 +281,7 @@ function localSkillPath(skillId: ParsedSkillId): string {
   );
 }
 
-function bundledCliSkillPath(): string {
+export function bundledCliSkillPath(): string {
   return join(packageRoot(), "skills", "browse");
 }
 

--- a/packages/cli/tests/cli-surface.test.ts
+++ b/packages/cli/tests/cli-surface.test.ts
@@ -45,6 +45,7 @@ const skillsCommandsWithExamples = [
   ["skills", "find"],
   ["skills", "install"],
   ["skills", "list"],
+  ["skills", "show"],
 ];
 
 describe("CLI surface", () => {
@@ -57,6 +58,27 @@ describe("CLI surface", () => {
     expect(result.stdout).toContain("functions");
     expect(result.stdout).toContain("templates");
     expect(result.stdout).toContain("skills");
+  });
+
+  it("leads root help with the agent-facing header", async () => {
+    const helpResult = await runCli(["--help"]);
+    const bareResult = await runCli([]);
+
+    for (const result of [helpResult, bareResult]) {
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("Start here (for AI agents):");
+      expect(result.stdout).toContain("browse skills show");
+      // The header must appear before the auto-generated sections.
+      expect(result.stdout.indexOf("Start here (for AI agents):")).toBeLessThan(
+        result.stdout.indexOf("USAGE"),
+      );
+    }
+  });
+
+  it("does not show the agent-facing header on command help", async () => {
+    const result = await runCli(["open", "--help"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toContain("Start here (for AI agents):");
   });
 
   it("prints cloud topic help", async () => {
@@ -141,6 +163,7 @@ describe("CLI surface", () => {
     expect(result.stdout).toContain("skills find");
     expect(result.stdout).toContain("skills install");
     expect(result.stdout).toContain("skills list");
+    expect(result.stdout).toContain("skills show");
   });
 
   it.each(skillsCommandsWithExamples)(

--- a/packages/cli/tests/skills-show.test.ts
+++ b/packages/cli/tests/skills-show.test.ts
@@ -1,6 +1,14 @@
+import { rename } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { describe, expect, it } from "vitest";
 
 import { runCli } from "./helpers/run-cli.js";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const skillMdPath = join(repoRoot, "skills", "browse", "SKILL.md");
 
 describe("skills show", () => {
   it("prints the bundled browse skill to stdout", async () => {
@@ -15,9 +23,31 @@ describe("skills show", () => {
     // The command resolves SKILL.md relative to its own module location, not
     // the process cwd, so it must work regardless of where `browse` is run
     // from (e.g. an agent invoking it from an arbitrary project directory).
-    const result = await runCli(["skills", "show"], { cwd: "/tmp" });
+    // Use the OS temp dir rather than a hardcoded POSIX path so this also
+    // runs on Windows CI.
+    const result = await runCli(["skills", "show"], { cwd: tmpdir() });
 
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain("name: browse");
+  });
+
+  it("fails cleanly with a non-zero exit when the bundled SKILL.md is missing", async () => {
+    // Temporarily move the real bundled SKILL.md aside to exercise the
+    // missing-file error path against the actual resolved path, then always
+    // restore it so other tests (and the package itself) are unaffected.
+    // Safe because vitest.config.ts sets fileParallelism: false -- no other
+    // test file can be mid-run against this file concurrently.
+    const movedPath = `${skillMdPath}.moved-for-test`;
+    await rename(skillMdPath, movedPath);
+    try {
+      const result = await runCli(["skills", "show"]);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain(
+        "Could not read the bundled browse skill (SKILL.md)",
+      );
+    } finally {
+      await rename(movedPath, skillMdPath);
+    }
   });
 });

--- a/packages/cli/tests/skills-show.test.ts
+++ b/packages/cli/tests/skills-show.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { runCli } from "./helpers/run-cli.js";
+
+describe("skills show", () => {
+  it("prints the bundled browse skill to stdout", async () => {
+    const result = await runCli(["skills", "show"]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("name: browse");
+    expect(result.stdout).toContain("# Browse CLI");
+  });
+
+  it("resolves the bundled skill from a different working directory", async () => {
+    // The command resolves SKILL.md relative to its own module location, not
+    // the process cwd, so it must work regardless of where `browse` is run
+    // from (e.g. an agent invoking it from an arbitrary project directory).
+    const result = await runCli(["skills", "show"], { cwd: "/tmp" });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("name: browse");
+  });
+});


### PR DESCRIPTION
## Why

Agents run `browse` inside sandboxes/harnesses we don't control, so they can't rely on a copied SKILL.md or a docs URL staying in sync with the installed CLI version. Serving the skill straight from the binary means the guidance is always version-matched to whatever `browse` the agent actually has.

This converges with the shape competitors have already landed on:
- agent-browser: `agent-browser skills get core --full` + a top-of-`--help` "Start here (for AI agents)" header
- Modal: `modal skills show`
- browser-use: `skill show`

## What changed

- Added `browse skills show` (`packages/cli/src/commands/skills/show.ts`), following the existing `skills` topic command style (`BrowseCommand` base, single-line description, `examples`). It resolves and prints the bundled `SKILL.md` via the same `bundledCliSkillPath()` helper `skills install` already uses (exported from `packages/cli/src/lib/skills/install.ts`), so path resolution is shared and works in both `src` and `dist` layouts. Reads the file synchronously and calls `this.error(...)` with a clear message + non-zero exit if it's missing/unreadable.
- Added a custom oclif `Help` class (`packages/cli/src/help.ts`) that prepends a short agent-facing block before oclif's auto-generated VERSION/USAGE/DESCRIPTION/TOPICS/COMMANDS sections on **root help only** (`browse --help` and bare `browse`). Wired via `"helpClass": "./dist/help.js"` in `packages/cli/package.json`'s oclif config. Per-command `--help` views (e.g. `browse open --help`) are unaffected.
- Added a patch changeset — `browse` is in the changesets `ignore` list by default, but per team convention it still gets patch changesets for release-impacting CLI changes.
- Tests: new `packages/cli/tests/skills-show.test.ts` (happy path + resolution from a different cwd), plus updates to `packages/cli/tests/cli-surface.test.ts` for the new `skills show` command help, the agent header appearing before `USAGE` on root help, and its absence on command help.

## E2E Test Matrix

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `node packages/cli/bin/run.js skills show \| head -20` | Prints bundled `SKILL.md` frontmatter: `name: browse`, `description: Use the browse CLI for...`, `# Browse CLI` heading | Proves the command reads and prints the real bundled skill from the local build, not a mock |
| `node packages/cli/bin/run.js skills show \| wc -lc` | `369 17221` (369 lines, 17221 bytes) | Confirms full file is printed, not truncated |
| `node packages/cli/bin/run.js --help \| head -25` | Output opens with `Start here (for AI agents):` / `browse skills show` / rationale block, then `Unified Browserbase CLI...`, `VERSION`, `USAGE`, `TOPICS` (incl. `skills`) | Confirms header renders before the auto-generated sections on `--help` |
| `node packages/cli/bin/run.js \| head -25` | Same header block, same ordering, for bare `browse` with no args | Confirms bare invocation (not just `--help`) also gets the header |
| `node packages/cli/bin/run.js open --help \| head -15` | Standard command help (`Open a URL in a browse driver session.`, `USAGE`, `ARGUMENTS`, `FLAGS`) with **no** agent header | Confirms per-command help is unaffected |
| `cd /tmp && node <worktree>/packages/cli/bin/run.js skills show \| head -3` | Same `SKILL.md` frontmatter, run from an unrelated cwd | Confirms path resolution is relative to the module file, not `process.cwd()` — required for the dist-layout published package |
| `pnpm test:cli` (vitest) | `Test Files 24 passed (24)`, `Tests 349 passed (349)` | Full existing CLI suite plus new/updated tests all green — no regressions |
| `pnpm lint` (prettier + eslint + tsc) | All three steps pass with no output/errors | Static checks clean |

## Linear

https://linear.app/browserbase/issue/STG-2511/add-browse-skills-show-agent-facing-help-header

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `browse skills show` to print the bundled `SKILL.md` for version-matched guidance, and adds an agent-facing header on root help pointing to it. Addresses STG-2511.

- New Features
  - `browse skills show` prints the bundled skill via `bundledCliSkillPath()` and, on error, uses `fail()` (exit 1 with `resultCode: "skill_show_missing"`).
  - Root help (`browse --help` and bare `browse`) prepends a short “Start here” header; per-command help is unchanged. Wired via `helpClass` in `packages/cli/package.json`.
  - Exported `bundledCliSkillPath()` so path resolution works in both `src` and `dist`.

- Refactors
  - Use `fs/promises.readFile` for async skill file reads.

<sup>Written for commit 2a74053400195d5742dae45d970720d95f718929. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

