### PR TITLE
[STG-2515] feat(evals): vercel_ai_sdk bare-loop harness adapter

### DIFF
--- a/packages/evals/framework/benchHarness.ts
+++ b/packages/evals/framework/benchHarness.ts
@@ -31,6 +31,7 @@ import {
   prepareExternalHarnessAdapter,
   type PreparedExternalHarnessAdapter,
 } from "./externalHarnessToolAdapter.js";
+import { runVercelAiSdkAgent } from "./vercelAiSdkRunner.js";
 import type { DiscoveredTask, TaskResult } from "./types.js";
 import type {
   AdapterBackedHarness,
@@ -439,10 +440,16 @@ export function buildAdapterBackedHarness(
   };
 }
 
+export const vercelAiSdkHarness = buildAdapterBackedHarness(
+  "vercel_ai_sdk",
+  runVercelAiSdkAgent,
+);
+
 const harnessRegistry = new Map<Harness, BenchHarness>([
   ["stagehand", stagehandHarness],
   ["claude_code", claudeCodeHarness],
   ["codex", codexHarness],
+  ["vercel_ai_sdk", vercelAiSdkHarness],
 ]);
 
 export function getBenchHarness(harness: Harness): BenchHarness {

--- a/packages/evals/framework/benchTypes.ts
+++ b/packages/evals/framework/benchTypes.ts
@@ -31,6 +31,7 @@ export const EXECUTABLE_BENCH_HARNESSES = [
   "stagehand",
   "claude_code",
   "codex",
+  "vercel_ai_sdk",
 ] as const satisfies readonly Harness[];
 
 /**

--- a/packages/evals/framework/vercelAiSdkRunner.ts
+++ b/packages/evals/framework/vercelAiSdkRunner.ts
@@ -3,8 +3,8 @@
  *
  * The loop is `generateText` with `stopWhen: stepCountIs(N)` and a single
  * `browse` tool — the AI SDK's own multi-step tool loop IS the harness, with
- * zero additional scaffolding. This mirrors the JS-default bare loop found in
- * the wild (and the Modal sandbox template used in the 2026-07-09 smoke).
+ * zero additional scaffolding, mirroring the default way a JS developer
+ * wires a tool loop with this SDK.
  *
  * Testability: pass `generateTextFn` to drive the loop with a mock. The mock
  * receives the fully-built options (system, prompt, tools, stopWhen) and can

--- a/packages/evals/framework/vercelAiSdkRunner.ts
+++ b/packages/evals/framework/vercelAiSdkRunner.ts
@@ -1,0 +1,155 @@
+/**
+ * vercelAiSdkRunner — bare-loop harness via the Vercel AI SDK (`ai` package).
+ *
+ * The loop is `generateText` with `stopWhen: stepCountIs(N)` and a single
+ * `browse` tool — the AI SDK's own multi-step tool loop IS the harness, with
+ * zero additional scaffolding. This mirrors the JS-default bare loop found in
+ * the wild (and the Modal sandbox template used in the 2026-07-09 smoke).
+ *
+ * Testability: pass `generateTextFn` to drive the loop with a mock. The mock
+ * receives the fully-built options (system, prompt, tools, stopWhen) and can
+ * invoke `options.tools.browse.execute(...)` to exercise tool wiring.
+ */
+import type { AvailableModel } from "@browserbasehq/stagehand";
+import { getAISDKLanguageModel } from "@browserbasehq/stagehand";
+import { EvalsError } from "../errors.js";
+import type { EvalLogger } from "../logger.js";
+import type { TaskResult } from "./types.js";
+import type { ExternalHarnessTaskPlan } from "./externalHarnessPlan.js";
+import type { PreparedExternalHarnessAdapter } from "./externalHarnessToolAdapter.js";
+import { readBareLoopMaxSteps } from "./bareLoopConfig.js";
+import {
+  BROWSE_TOOL_DESCRIPTION,
+  BROWSE_TOOL_NAME,
+  buildBareLoopUserPrompt,
+  createBareLoopToolRecorder,
+  finalizeBareLoopResult,
+  stringifyLoopError,
+} from "./bareLoopRunner.js";
+import type { ExternalHarnessVerifierConfig } from "./verifierAdapter.js";
+
+const HARNESS = "vercel_ai_sdk";
+const MAX_STEPS_ENV = "EVAL_VERCEL_AI_SDK_MAX_STEPS";
+
+export interface VercelAiSdkGenerateTextResult {
+  text: string;
+  steps?: unknown[];
+  totalUsage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    cachedInputTokens?: number;
+    reasoningTokens?: number;
+  };
+  finishReason?: string;
+}
+
+export type VercelAiSdkGenerateTextFn = (
+  options: Record<string, unknown>,
+) => Promise<VercelAiSdkGenerateTextResult>;
+
+export interface VercelAiSdkRunnerInput {
+  plan: ExternalHarnessTaskPlan;
+  model: AvailableModel;
+  logger: EvalLogger;
+  toolAdapter: PreparedExternalHarnessAdapter;
+  signal?: AbortSignal;
+  /** Injectable for unit tests; defaults to the real `ai` generateText. */
+  generateTextFn?: VercelAiSdkGenerateTextFn;
+  verifier?: ExternalHarnessVerifierConfig;
+}
+
+/**
+ * Resolve "provider/model" to an AI SDK LanguageModel via stagehand's own
+ * provider map — the exact resolution the `-m` flag already uses for the
+ * stagehand harness, so model names mean the same thing on every harness.
+ */
+export function resolveVercelAiSdkModel(model: AvailableModel): unknown {
+  if (!model.includes("/")) {
+    throw new EvalsError(
+      `vercel_ai_sdk harness requires a provider-prefixed model (e.g. anthropic/claude-sonnet-4-6); received "${model}".`,
+    );
+  }
+  const slash = model.indexOf("/");
+  return getAISDKLanguageModel(model.slice(0, slash), model.slice(slash + 1));
+}
+
+export async function runVercelAiSdkAgent(
+  input: VercelAiSdkRunnerInput,
+): Promise<TaskResult> {
+  const maxSteps = readBareLoopMaxSteps(MAX_STEPS_ENV);
+  const recorder = createBareLoopToolRecorder(
+    input.toolAdapter,
+    input.logger,
+    HARNESS,
+  );
+
+  let finalText = "";
+  let stepsUsed = 0;
+  let usage: VercelAiSdkGenerateTextResult["totalUsage"];
+  let loopError: unknown;
+
+  try {
+    const ai = await import("ai");
+    const { z } = await import("zod");
+    const generateTextFn =
+      input.generateTextFn ??
+      (ai.generateText as unknown as VercelAiSdkGenerateTextFn);
+
+    const result = await generateTextFn({
+      model:
+        input.generateTextFn === undefined
+          ? resolveVercelAiSdkModel(input.model)
+          : input.model,
+      system: input.toolAdapter.systemPromptAddendum,
+      prompt: buildBareLoopUserPrompt(input.plan),
+      stopWhen: ai.stepCountIs(maxSteps),
+      ...(input.signal && { abortSignal: input.signal }),
+      tools: {
+        [BROWSE_TOOL_NAME]: ai.tool({
+          description: BROWSE_TOOL_DESCRIPTION,
+          inputSchema: z.object({
+            args: z
+              .string()
+              .describe(
+                'Everything after "browse", e.g. "open https://example.com".',
+              ),
+          }),
+          execute: async ({ args }: { args: string }) => recorder.execute(args),
+        }),
+      },
+    });
+
+    finalText = result.text ?? "";
+    stepsUsed = result.steps?.length ?? 0;
+    usage = result.totalUsage;
+  } catch (error) {
+    loopError = error;
+    input.logger.warn({
+      category: HARNESS,
+      message: `vercel_ai_sdk loop stopped before a normal result: ${stringifyLoopError(error)}`,
+      level: 0,
+    });
+  }
+
+  return finalizeBareLoopResult({
+    harness: HARNESS,
+    toolCalls: recorder.calls,
+    finalText,
+    status: loopError ? "error" : "complete",
+    stopReason: loopError ? stringifyLoopError(loopError) : undefined,
+    usage: {
+      input_tokens: usage?.inputTokens ?? 0,
+      output_tokens: usage?.outputTokens ?? 0,
+      ...(usage?.cachedInputTokens !== undefined && {
+        cached_input_tokens: usage.cachedInputTokens,
+      }),
+      ...(usage?.reasoningTokens !== undefined && {
+        reasoning_tokens: usage.reasoningTokens,
+      }),
+    },
+    stepsUsed,
+    maxSteps,
+    logger: input.logger,
+    verifier: input.verifier,
+  });
+}

--- a/packages/evals/framework/vercelAiSdkRunner.ts
+++ b/packages/evals/framework/vercelAiSdkRunner.ts
@@ -87,6 +87,7 @@ export async function runVercelAiSdkAgent(
   let stepsUsed = 0;
   let usage: VercelAiSdkGenerateTextResult["totalUsage"];
   let loopError: unknown;
+  let cappedOut = false;
 
   try {
     const ai = await import("ai");
@@ -122,6 +123,13 @@ export async function runVercelAiSdkAgent(
     finalText = result.text ?? "";
     stepsUsed = result.steps?.length ?? 0;
     usage = result.totalUsage;
+    // stopWhen: stepCountIs(maxSteps) ends the loop silently -- generateText
+    // returns normally either way, so a clean stop and a cap-truncated one are
+    // otherwise indistinguishable. finishReason on the last step is "stop"
+    // when the model was actually done, or "tool-calls" when it still wanted
+    // to call a tool but the step cap cut it off first. Mirrors anthropic_sdk's
+    // stopReason shape so all bare-loop harnesses report the cap the same way.
+    cappedOut = stepsUsed >= maxSteps && result.finishReason === "tool-calls";
   } catch (error) {
     loopError = error;
     input.logger.warn({
@@ -136,7 +144,11 @@ export async function runVercelAiSdkAgent(
     toolCalls: recorder.calls,
     finalText,
     status: loopError ? "error" : "complete",
-    stopReason: loopError ? stringifyLoopError(loopError) : undefined,
+    stopReason: loopError
+      ? stringifyLoopError(loopError)
+      : cappedOut
+        ? `step cap reached (${maxSteps})`
+        : undefined,
     usage: {
       input_tokens: usage?.inputTokens ?? 0,
       output_tokens: usage?.outputTokens ?? 0,

--- a/packages/evals/framework/vercelAiSdkRunner.ts
+++ b/packages/evals/framework/vercelAiSdkRunner.ts
@@ -37,6 +37,7 @@ export interface VercelAiSdkGenerateTextResult {
   totalUsage?: {
     inputTokens?: number;
     outputTokens?: number;
+    totalTokens?: number;
     cachedInputTokens?: number;
     reasoningTokens?: number;
   };
@@ -115,7 +116,10 @@ export async function runVercelAiSdkAgent(
                 'Everything after "browse", e.g. "open https://example.com".',
               ),
           }),
-          execute: async ({ args }: { args: string }) => recorder.execute(args),
+          execute: async ({ args }: { args: string }) => {
+            const { output } = await recorder.execute(args);
+            return output;
+          },
         }),
       },
     });
@@ -143,7 +147,7 @@ export async function runVercelAiSdkAgent(
     harness: HARNESS,
     toolCalls: recorder.calls,
     finalText,
-    status: loopError ? "error" : "complete",
+    status: loopError ? "error" : cappedOut ? "aborted" : "complete",
     stopReason: loopError
       ? stringifyLoopError(loopError)
       : cappedOut
@@ -159,6 +163,7 @@ export async function runVercelAiSdkAgent(
         reasoning_tokens: usage.reasoningTokens,
       }),
     },
+    providerTotalTokens: usage?.totalTokens,
     stepsUsed,
     maxSteps,
     logger: input.logger,

--- a/packages/evals/tests/framework/benchHarness.test.ts
+++ b/packages/evals/tests/framework/benchHarness.test.ts
@@ -3,6 +3,7 @@ import {
   claudeCodeHarness,
   codexHarness,
   getBenchHarness,
+  vercelAiSdkHarness,
 } from "../../framework/benchHarness.js";
 
 describe("bench harness registry", () => {
@@ -22,5 +23,18 @@ describe("bench harness registry", () => {
     expect(harness.supportedTaskKinds).toEqual(["agent", "suite"]);
     expect(harness.supportsApi).toBe(false);
     expect(harness.execute).toBeDefined();
+  });
+
+  it("registers vercel_ai_sdk as a concrete executable harness", async () => {
+    const harness = getBenchHarness("vercel_ai_sdk");
+
+    expect(harness).toBe(vercelAiSdkHarness);
+    expect(harness.supportedTaskKinds).toEqual(["agent", "suite"]);
+    expect(harness.supportsApi).toBe(false);
+    expect(harness.execute).toBeDefined();
+    // Like claude_code/codex, this harness runs via the execute path only.
+    await expect(harness.start({} as never)).rejects.toThrow(
+      /external harness execute path/,
+    );
   });
 });

--- a/packages/evals/tests/framework/benchHarness.test.ts
+++ b/packages/evals/tests/framework/benchHarness.test.ts
@@ -5,6 +5,7 @@ import {
   getBenchHarness,
   vercelAiSdkHarness,
 } from "../../framework/benchHarness.js";
+import { isExecutableBenchHarness } from "../../framework/benchTypes.js";
 
 describe("bench harness registry", () => {
   it("registers claude_code as a concrete executable harness", () => {
@@ -28,6 +29,7 @@ describe("bench harness registry", () => {
   it("registers vercel_ai_sdk as a concrete executable harness", async () => {
     const harness = getBenchHarness("vercel_ai_sdk");
 
+    expect(isExecutableBenchHarness("vercel_ai_sdk")).toBe(true);
     expect(harness).toBe(vercelAiSdkHarness);
     expect(harness.supportedTaskKinds).toEqual(["agent", "suite"]);
     expect(harness.supportsApi).toBe(false);

--- a/packages/evals/tests/framework/vercelAiSdkRunner.test.ts
+++ b/packages/evals/tests/framework/vercelAiSdkRunner.test.ts
@@ -1,0 +1,117 @@
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { AvailableModel } from "@browserbasehq/stagehand";
+import { EvalLogger } from "../../logger.js";
+import type { ExternalHarnessTaskPlan } from "../../framework/externalHarnessPlan.js";
+import type { PreparedExternalHarnessAdapter } from "../../framework/externalHarnessToolAdapter.js";
+import { BARE_LOOP_DEFAULT_SYSTEM_PROMPT } from "../../framework/externalHarnessToolAdapter.js";
+import {
+  resolveVercelAiSdkModel,
+  runVercelAiSdkAgent,
+} from "../../framework/vercelAiSdkRunner.js";
+
+const plan: ExternalHarnessTaskPlan = {
+  dataset: "webtailbench",
+  taskId: "wtb-1",
+  startUrl: "https://example.com",
+  instruction: "Find the checkout button",
+};
+
+let tempDir: string | undefined;
+
+afterEach(async () => {
+  if (tempDir) {
+    await fsp.rm(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
+  }
+  delete process.env.EVAL_VERCEL_AI_SDK_MAX_STEPS;
+});
+
+async function makeAdapter(): Promise<PreparedExternalHarnessAdapter> {
+  tempDir = await fsp.mkdtemp(
+    path.join(os.tmpdir(), "stagehand-evals-vercel-test-"),
+  );
+  const bin = path.join(tempDir, "browse");
+  await fsp.writeFile(bin, '#!/usr/bin/env bash\necho "browse-output:$@"\n', {
+    mode: 0o755,
+  });
+  return {
+    cwd: tempDir,
+    env: { ...process.env } as Record<string, string>,
+    browseBinPath: bin,
+    skillMode: "none",
+    systemPromptAddendum: BARE_LOOP_DEFAULT_SYSTEM_PROMPT,
+    metadata: { toolCommand: "browse", browseCliEntrypoint: bin },
+    cleanup: async () => {},
+  };
+}
+
+describe("vercel_ai_sdk runner", () => {
+  it("requires a provider-prefixed model", () => {
+    expect(() =>
+      resolveVercelAiSdkModel("claude-sonnet-4-6" as AvailableModel),
+    ).toThrow(/provider-prefixed/);
+  });
+
+  it("drives the loop through generateText with the bare system prompt and records tool calls", async () => {
+    const adapter = await makeAdapter();
+    process.env.EVAL_VERCEL_AI_SDK_MAX_STEPS = "7";
+    let captured: Record<string, unknown> | undefined;
+
+    const result = await runVercelAiSdkAgent({
+      plan,
+      model: "anthropic/claude-sonnet-4-6" as AvailableModel,
+      logger: new EvalLogger(false),
+      toolAdapter: adapter,
+      generateTextFn: async (options) => {
+        captured = options;
+        const tools = options.tools as Record<
+          string,
+          { execute: (input: { args: string }) => Promise<string> }
+        >;
+        const first = await tools.browse.execute({ args: "--help" });
+        expect(first).toContain("browse-output:--help");
+        await tools.browse.execute({ args: "open https://example.com" });
+        return {
+          text: 'done\nEVAL_RESULT: {"success":true,"summary":"found it","finalAnswer":"checkout"}',
+          steps: [{}, {}, {}],
+          totalUsage: { inputTokens: 120, outputTokens: 30 },
+        };
+      },
+    });
+
+    expect(captured?.system).toBe(BARE_LOOP_DEFAULT_SYSTEM_PROMPT);
+    expect(String(captured?.prompt)).toContain("Find the checkout button");
+    expect(String(captured?.prompt)).toContain(
+      "Start URL: https://example.com",
+    );
+    expect(result._success).toBe(true);
+    expect(result.finalAnswer).toBe("checkout");
+    expect(result.vercel_ai_sdkStatus).toBe("completed");
+    const metrics = result.metrics as Record<string, { value: number }>;
+    expect(metrics.vercel_ai_sdk_tool_calls.value).toBe(2);
+    expect(metrics.vercel_ai_sdk_steps.value).toBe(3);
+    expect(metrics.vercel_ai_sdk_max_steps.value).toBe(7);
+    expect(metrics.vercel_ai_sdk_input_tokens.value).toBe(120);
+    expect(metrics.vercel_ai_sdk_output_tokens.value).toBe(30);
+  });
+
+  it("returns a failed task result instead of throwing on loop errors", async () => {
+    const adapter = await makeAdapter();
+    const result = await runVercelAiSdkAgent({
+      plan,
+      model: "anthropic/claude-sonnet-4-6" as AvailableModel,
+      logger: new EvalLogger(false),
+      toolAdapter: adapter,
+      generateTextFn: async () => {
+        throw new Error("provider exploded");
+      },
+    });
+
+    expect(result._success).toBe(false);
+    expect(result.vercel_ai_sdkStatus).toBe("error");
+    expect(result.vercel_ai_sdkStopReason).toContain("provider exploded");
+  });
+});

--- a/packages/evals/tests/framework/vercelAiSdkRunner.test.ts
+++ b/packages/evals/tests/framework/vercelAiSdkRunner.test.ts
@@ -89,13 +89,62 @@ describe("vercel_ai_sdk runner", () => {
     );
     expect(result._success).toBe(true);
     expect(result.finalAnswer).toBe("checkout");
-    expect(result.vercel_ai_sdkStatus).toBe("completed");
+    expect(result.vercelAiSdkStatus).toBe("completed");
     const metrics = result.metrics as Record<string, { value: number }>;
     expect(metrics.vercel_ai_sdk_tool_calls.value).toBe(2);
     expect(metrics.vercel_ai_sdk_steps.value).toBe(3);
     expect(metrics.vercel_ai_sdk_max_steps.value).toBe(7);
     expect(metrics.vercel_ai_sdk_input_tokens.value).toBe(120);
     expect(metrics.vercel_ai_sdk_output_tokens.value).toBe(30);
+  });
+
+  it("stops at the step cap and reports it as the stop reason", async () => {
+    const adapter = await makeAdapter();
+    process.env.EVAL_VERCEL_AI_SDK_MAX_STEPS = "2";
+
+    const result = await runVercelAiSdkAgent({
+      plan,
+      model: "anthropic/claude-sonnet-4-6" as AvailableModel,
+      logger: new EvalLogger(false),
+      toolAdapter: adapter,
+      generateTextFn: async () => ({
+        // The model was still mid tool-call when stepCountIs(2) cut the loop
+        // off -- generateText returns normally either way, so finishReason is
+        // the only signal that distinguishes this from a clean stop.
+        text: "",
+        steps: [{}, {}],
+        finishReason: "tool-calls",
+        totalUsage: { inputTokens: 10, outputTokens: 5 },
+      }),
+    });
+
+    expect(result._success).toBe(false);
+    expect(result.vercelAiSdkStatus).toBe("completed");
+    expect(result.vercelAiSdkStopReason).toContain("step cap reached (2)");
+    const metrics = result.metrics as Record<string, { value: number }>;
+    expect(metrics.vercel_ai_sdk_steps.value).toBe(2);
+    expect(metrics.vercel_ai_sdk_max_steps.value).toBe(2);
+  });
+
+  it("does not report a step cap on a clean stop even at the max step count", async () => {
+    const adapter = await makeAdapter();
+    process.env.EVAL_VERCEL_AI_SDK_MAX_STEPS = "2";
+
+    const result = await runVercelAiSdkAgent({
+      plan,
+      model: "anthropic/claude-sonnet-4-6" as AvailableModel,
+      logger: new EvalLogger(false),
+      toolAdapter: adapter,
+      generateTextFn: async () => ({
+        text: 'EVAL_RESULT: {"success":true,"summary":"done","finalAnswer":"checkout"}',
+        steps: [{}, {}],
+        finishReason: "stop",
+        totalUsage: { inputTokens: 10, outputTokens: 5 },
+      }),
+    });
+
+    expect(result._success).toBe(true);
+    expect(result.vercelAiSdkStopReason).toBeUndefined();
   });
 
   it("returns a failed task result instead of throwing on loop errors", async () => {
@@ -111,7 +160,7 @@ describe("vercel_ai_sdk runner", () => {
     });
 
     expect(result._success).toBe(false);
-    expect(result.vercel_ai_sdkStatus).toBe("error");
-    expect(result.vercel_ai_sdkStopReason).toContain("provider exploded");
+    expect(result.vercelAiSdkStatus).toBe("error");
+    expect(result.vercelAiSdkStopReason).toContain("provider exploded");
   });
 });

--- a/packages/evals/tests/framework/vercelAiSdkRunner.test.ts
+++ b/packages/evals/tests/framework/vercelAiSdkRunner.test.ts
@@ -119,11 +119,51 @@ describe("vercel_ai_sdk runner", () => {
     });
 
     expect(result._success).toBe(false);
-    expect(result.vercelAiSdkStatus).toBe("completed");
+    expect(result.vercelAiSdkStatus).toBe("aborted");
     expect(result.vercelAiSdkStopReason).toContain("step cap reached (2)");
     const metrics = result.metrics as Record<string, { value: number }>;
     expect(metrics.vercel_ai_sdk_steps.value).toBe(2);
     expect(metrics.vercel_ai_sdk_max_steps.value).toBe(2);
+  });
+
+  it("prefers the AI SDK's reported totalTokens over the recomputed input+output sum", async () => {
+    const adapter = await makeAdapter();
+    const result = await runVercelAiSdkAgent({
+      plan,
+      model: "anthropic/claude-sonnet-4-6" as AvailableModel,
+      logger: new EvalLogger(false),
+      toolAdapter: adapter,
+      generateTextFn: async () => ({
+        text: 'EVAL_RESULT: {"success":true,"summary":"done","finalAnswer":"checkout"}',
+        steps: [{}],
+        finishReason: "stop",
+        // Deliberately not input+output (130) -- e.g. reasoning tokens the
+        // SDK bills but this harness doesn't otherwise track.
+        totalUsage: { inputTokens: 100, outputTokens: 30, totalTokens: 180 },
+      }),
+    });
+
+    const metrics = result.metrics as Record<string, { value: number }>;
+    expect(metrics.vercel_ai_sdk_total_tokens.value).toBe(180);
+  });
+
+  it("falls back to input+output when the AI SDK doesn't report totalTokens", async () => {
+    const adapter = await makeAdapter();
+    const result = await runVercelAiSdkAgent({
+      plan,
+      model: "anthropic/claude-sonnet-4-6" as AvailableModel,
+      logger: new EvalLogger(false),
+      toolAdapter: adapter,
+      generateTextFn: async () => ({
+        text: 'EVAL_RESULT: {"success":true,"summary":"done","finalAnswer":"checkout"}',
+        steps: [{}],
+        finishReason: "stop",
+        totalUsage: { inputTokens: 100, outputTokens: 30 },
+      }),
+    });
+
+    const metrics = result.metrics as Record<string, { value: number }>;
+    expect(metrics.vercel_ai_sdk_total_tokens.value).toBe(130);
   });
 
   it("does not report a step cap on a clean stop even at the max step count", async () => {


### PR DESCRIPTION
## What

**Part 2 of 5 — stacked on #2337** (base: `shrey/evals-bareloop-harnesses`; GitHub shows only this PR's delta). When #2337 merges, retarget this PR's base to `main` and rebase.

Registers `--harness vercel_ai_sdk`: a **bare loop** via the `ai` package — `generateText` + `stopWhen: stepCountIs(N)` with a single gated `browse` tool. The AI SDK's own multi-step loop IS the harness; zero additional scaffolding. This mirrors the JS-default bare loop found in the wild (15.1M npm dl/wk) and the Modal sandbox template used in the 2026-07-09 smoke that surfaced 5 SKILL.md issues.

- Model resolution goes through stagehand's own `getAISDKLanguageModel` provider map, so `-m provider/model` means the same thing as on the stagehand harness.
- Step cap: shared 40 default, `EVAL_VERCEL_AI_SDK_MAX_STEPS` override.
- Tool calls recorded at execution time as `NormalizedToolCall`s → `gradeExternalTrajectory` unchanged.
- Testability: `generateTextFn` injection seam — unit tests drive the loop and invoke the real tool wiring against a temp `browse` binary.

External harnesses design + usage: [`packages/evals/README.md#external-harnesses`](https://github.com/browserbase/stagehand/blob/shrey/evals-bareloop-harnesses/packages/evals/README.md#external-harnesses) (in #2337). Linear: STG-2515.

## Comparability fix (2026-07-09 audit)

`generateText` returns normally whether `stopWhen: stepCountIs(maxSteps)` cut the loop off mid tool-call or the model actually finished — `finishReason` was declared on the result type but never read, so a cap-truncated run and a clean stop were indistinguishable in `vercelAiSdkStatus`/`vercelAiSdkStopReason`. Now reads `finishReason === "tool-calls"` at `stepsUsed >= maxSteps` as the step-cap signal and reports the same `step cap reached (N)` stopReason shape `anthropic_sdk` (#2339) already uses, so every bare-loop harness surfaces the cap identically. Two new tests cover both the capped case and a clean stop that happens to land exactly at the max step count (to prove the fix keys off `finishReason`, not just the step count).

## E2E Test Matrix

Live smoke ran on the pre-split combined branch (content identical to this stack's tip — verified by diff); results transplanted, not rerun.

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `evals run b:webtailbench --harness vercel_ai_sdk -m anthropic/claude-haiku-4-5-20251001 -l 1 -t 1 -c 1` (local build, real ANTHROPIC + GEMINI keys, local Chrome via browse CLI) | Run completed (exit 0). 13 `browse` tool calls recorded (first action: `open https://www.google.com`); trajectory persisted; verifier graded: `outcomeSuccess=false`, `processScore=0.79`, 5 rubric criteria, **no verifierError**. Usage: 440k in / 1.3k out tokens | The bar for this smoke: harness completes, trajectory captured, verifier returns a graded outcome — all met. Task pass/fail is NOT the bar (united.com flights, hard target; haiku hit a browser hiccup mid-run and reported honestly) |
| `pnpm exec vitest run` (this branch) | `Test Files 50 passed, Tests 371 passed` — adds `vercelAiSdkRunner.test.ts` (system prompt = verbatim bare one-liner, tool wiring against a real temp binary, step/token metrics, error-to-TaskResult folding) + the registry test | Mocked-model loop coverage; live behavior proven by the smoke row above |
| `tsc --noEmit` + prettier + eslint | clean | Types/style only |
| `pnpm exec vitest run` (this branch, post-fix) | `Test Files 50 passed, Tests 373 passed` — adds the two step-cap tests (capped-with-tool-calls-finishReason vs. clean-stop-at-max-steps) | Proves the finishReason-based cap detection fires only on genuine truncation, not just on reaching the step count |
| `pnpm -w exec tsc --noEmit` + prettier + eslint (post-fix) | clean | Types/style only |

The 440k cumulative input tokens in the smoke is what motivated the 20k-char tool-output clip that ships in the base PR (`EVAL_BARE_LOOP_TOOL_OUTPUT_LIMIT`) — the smoke ran pre-clip and still completed, but larger `snapshot` outputs would have overflowed context.

## Tier 1 fixes (post-review audit, 2026-07-14)

An independent audit (on top of the 07-09 review round) found the step-cap status still reported `"complete"` and the token total still ignored the AI SDK's own `totalUsage.totalTokens`. Fixed here:

- **Step-cap runs reported `"complete"`, not `"aborted"`.** `cappedOut` was already detected correctly but never fed into `status` -- now `cappedOut ? "aborted" : "complete"`.
- **`total_tokens` recomputed input+output, ignoring the SDK's own total.** `VercelAiSdkGenerateTextResult.totalUsage` now declares `totalTokens`, passed through via the base PR's new `providerTotalTokens` override instead of being silently recomputed.
- Updated the tool `execute` callback for `BareLoopToolRecorder.execute()`'s new `{ ok, output }` return shape (base PR).

Verified: `pnpm --filter @browserbasehq/stagehand-evals build && lint && test:unit` -- `Test Files 55 passed, Tests 420 passed` (2 new tests for the totalTokens preference/fallback). Live: a real Browserbase local trial with `EVAL_VERCEL_AI_SDK_MAX_STEPS=2` hit the step cap and the persisted trajectory (`task_data.json`) recorded `"status": "aborted"`, not `"complete"`.


No changeset: `packages/evals` is private.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `vercel_ai_sdk` bare-loop harness that runs `ai.generateText` with `stopWhen: stepCountIs(N)` and a single gated `browse` tool. Registers it as an executable bench harness; aligns model mapping with `@browserbasehq/stagehand` and reports step-cap truncation consistently with an `aborted` status and provider `totalTokens` passthrough (STG-2515).

- **New Features**
  - Registers `--harness vercel_ai_sdk` as executable (agent/suite).
  - Runs `generateText` with `stopWhen: stepCountIs(N)`; default max steps 40 via `EVAL_VERCEL_AI_SDK_MAX_STEPS`.
  - Resolves models via `@browserbasehq/stagehand` `getAISDKLanguageModel`; requires `provider/model`.
  - Exposes a single `browse` tool; records tool calls; returns usage metrics (input/output, optional `cached_input`/`reasoning`, and provider `totalTokens`).
  - Supports an injectable `generateTextFn` for tests.

- **Bug Fixes**
  - Detects step-cap truncation using `finishReason === "tool-calls"` at the cap; sets status to `aborted` and stopReason `step cap reached (N)`, matching other bare-loop harnesses.

<sup>Written for commit aaed51e8f5ded15abdc590fbce961f5407f344c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


