### PR TITLE
[STG-2515] feat(evals): anthropic_sdk bare-loop harness adapter

### DIFF
--- a/packages/evals/framework/anthropicSdkRunner.ts
+++ b/packages/evals/framework/anthropicSdkRunner.ts
@@ -2,9 +2,8 @@
  * anthropicSdkRunner — bare-loop harness via the raw Anthropic SDK
  * (`@anthropic-ai/sdk`), a hand-rolled `tool_use` loop.
  *
- * This is the TS twin of the Python `while stop_reason == "tool_use"` loop
- * that dominates real-world Anthropic usage (and of the Modal sandbox
- * template's agent.mjs): call messages.create, execute every tool_use block,
+ * This is the TS twin of the canonical Python `while stop_reason ==
+ * "tool_use"` loop: call messages.create, execute every tool_use block,
  * append tool_results, repeat until the model stops or the step cap binds.
  * No retries, no planning, no memory — deliberately.
  *
@@ -130,9 +129,10 @@ export async function runAnthropicSdkAgent(
           messages,
           tools: [BROWSE_TOOL_DEFINITION],
         },
-        // Native abort wiring: the SDK cancels the in-flight HTTP request
-        // instead of us only checking `aborted` between requests, which left
-        // an already-sent request to run to completion after abort.
+        // Native abort wiring: with the signal passed through, the SDK
+        // cancels the in-flight HTTP request; checking `aborted` only
+        // between iterations would let an already-sent request run to
+        // completion.
         input.signal ? { signal: input.signal } : undefined,
       );
 

--- a/packages/evals/framework/anthropicSdkRunner.ts
+++ b/packages/evals/framework/anthropicSdkRunner.ts
@@ -52,7 +52,10 @@ export interface AnthropicMessageResponse {
 
 export interface AnthropicMessagesClient {
   messages: {
-    create(params: Record<string, unknown>): Promise<AnthropicMessageResponse>;
+    create(
+      params: Record<string, unknown>,
+      options?: { signal?: AbortSignal },
+    ): Promise<AnthropicMessageResponse>;
   };
 }
 
@@ -119,13 +122,19 @@ export async function runAnthropicSdkAgent(
         throw new EvalsError("anthropic_sdk run aborted");
       }
       stepsUsed = step + 1;
-      const response = await client.messages.create({
-        model: normalizeAnthropicModel(input.model),
-        max_tokens: DEFAULT_MAX_OUTPUT_TOKENS,
-        system: input.toolAdapter.systemPromptAddendum,
-        messages,
-        tools: [BROWSE_TOOL_DEFINITION],
-      });
+      const response = await client.messages.create(
+        {
+          model: normalizeAnthropicModel(input.model),
+          max_tokens: DEFAULT_MAX_OUTPUT_TOKENS,
+          system: input.toolAdapter.systemPromptAddendum,
+          messages,
+          tools: [BROWSE_TOOL_DEFINITION],
+        },
+        // Native abort wiring: the SDK cancels the in-flight HTTP request
+        // instead of us only checking `aborted` between requests, which left
+        // an already-sent request to run to completion after abort.
+        input.signal ? { signal: input.signal } : undefined,
+      );
 
       usageTotals.input_tokens += response.usage?.input_tokens ?? 0;
       usageTotals.output_tokens += response.usage?.output_tokens ?? 0;

--- a/packages/evals/framework/anthropicSdkRunner.ts
+++ b/packages/evals/framework/anthropicSdkRunner.ts
@@ -46,6 +46,7 @@ export interface AnthropicMessageResponse {
     input_tokens?: number;
     output_tokens?: number;
     cache_read_input_tokens?: number | null;
+    cache_creation_input_tokens?: number | null;
   };
 }
 
@@ -108,7 +109,12 @@ export async function runAnthropicSdkAgent(
   const messages: Array<Record<string, unknown>> = [
     { role: "user", content: buildBareLoopUserPrompt(input.plan) },
   ];
-  const usageTotals = { input_tokens: 0, output_tokens: 0, cached: 0 };
+  const usageTotals = {
+    input_tokens: 0,
+    output_tokens: 0,
+    cached: 0,
+    cacheCreation: 0,
+  };
 
   let finalText = "";
   let stepsUsed = 0;
@@ -139,6 +145,8 @@ export async function runAnthropicSdkAgent(
       usageTotals.input_tokens += response.usage?.input_tokens ?? 0;
       usageTotals.output_tokens += response.usage?.output_tokens ?? 0;
       usageTotals.cached += response.usage?.cache_read_input_tokens ?? 0;
+      usageTotals.cacheCreation +=
+        response.usage?.cache_creation_input_tokens ?? 0;
 
       const textParts = response.content
         .filter((block) => block.type === "text" && block.text)
@@ -147,8 +155,19 @@ export async function runAnthropicSdkAgent(
         finalText = textParts.join("\n");
       }
 
-      if (response.stop_reason !== "tool_use") {
+      // Only "end_turn" is a genuine, natural completion. Every other
+      // non-tool_use stop reason (max_tokens, refusal, pause_turn, ...) means
+      // the model was cut off or stopped abnormally -- reporting those as
+      // "complete" would make a truncated response indistinguishable from a
+      // real success.
+      if (response.stop_reason === "end_turn") {
         return finish("complete");
+      }
+      if (response.stop_reason !== "tool_use") {
+        return finish(
+          "aborted",
+          `stop_reason: ${response.stop_reason ?? "unknown"}`,
+        );
       }
 
       const toolUses = response.content.filter(
@@ -160,7 +179,7 @@ export async function runAnthropicSdkAgent(
           use.input && typeof use.input === "object"
             ? String((use.input as Record<string, unknown>).args ?? "")
             : "";
-        const output = await recorder.execute(
+        const { ok, output } = await recorder.execute(
           args,
           textParts.join("\n") || undefined,
         );
@@ -168,6 +187,7 @@ export async function runAnthropicSdkAgent(
           type: "tool_result",
           tool_use_id: use.id ?? "",
           content: output,
+          is_error: !ok,
         });
       }
 
@@ -184,9 +204,12 @@ export async function runAnthropicSdkAgent(
     });
   }
 
-  return finish(loopError ? "error" : "complete");
+  return finish(loopError ? "error" : cappedOut ? "aborted" : "complete");
 
-  function finish(status: "complete" | "error"): Promise<TaskResult> {
+  function finish(
+    status: "complete" | "aborted" | "error",
+    abnormalStopReason?: string,
+  ): Promise<TaskResult> {
     return finalizeBareLoopResult({
       harness: HARNESS,
       toolCalls: recorder.calls,
@@ -194,9 +217,11 @@ export async function runAnthropicSdkAgent(
       status,
       stopReason: loopError
         ? stringifyLoopError(loopError)
-        : cappedOut
-          ? `step cap reached (${maxSteps})`
-          : undefined,
+        : abnormalStopReason
+          ? abnormalStopReason
+          : cappedOut
+            ? `step cap reached (${maxSteps})`
+            : undefined,
       usage: {
         input_tokens: usageTotals.input_tokens,
         output_tokens: usageTotals.output_tokens,
@@ -204,6 +229,16 @@ export async function runAnthropicSdkAgent(
           cached_input_tokens: usageTotals.cached,
         }),
       },
+      // Anthropic's real total input = input + cache_creation + cache_read;
+      // the `usage` field above only carries cache_read (cached_input_tokens
+      // is a display convention shared with the other bare-loop runners), so
+      // report the true total separately rather than fold cache_creation in
+      // there and double-count it.
+      providerTotalTokens:
+        usageTotals.input_tokens +
+        usageTotals.output_tokens +
+        usageTotals.cacheCreation +
+        usageTotals.cached,
       stepsUsed,
       maxSteps,
       logger: input.logger,

--- a/packages/evals/framework/anthropicSdkRunner.ts
+++ b/packages/evals/framework/anthropicSdkRunner.ts
@@ -1,0 +1,228 @@
+/**
+ * anthropicSdkRunner — bare-loop harness via the raw Anthropic SDK
+ * (`@anthropic-ai/sdk`), a hand-rolled `tool_use` loop.
+ *
+ * This is the TS twin of the Python `while stop_reason == "tool_use"` loop
+ * that dominates real-world Anthropic usage (and of the Modal sandbox
+ * template's agent.mjs): call messages.create, execute every tool_use block,
+ * append tool_results, repeat until the model stops or the step cap binds.
+ * No retries, no planning, no memory — deliberately.
+ *
+ * Testability: pass `client` with a mocked `messages.create`.
+ */
+import type { AvailableModel } from "@browserbasehq/stagehand";
+import { EvalsError } from "../errors.js";
+import type { EvalLogger } from "../logger.js";
+import type { TaskResult } from "./types.js";
+import type { ExternalHarnessTaskPlan } from "./externalHarnessPlan.js";
+import type { PreparedExternalHarnessAdapter } from "./externalHarnessToolAdapter.js";
+import { readBareLoopMaxSteps } from "./bareLoopConfig.js";
+import {
+  BROWSE_TOOL_DESCRIPTION,
+  BROWSE_TOOL_NAME,
+  buildBareLoopUserPrompt,
+  createBareLoopToolRecorder,
+  finalizeBareLoopResult,
+  stringifyLoopError,
+  stripProviderPrefix,
+} from "./bareLoopRunner.js";
+import type { ExternalHarnessVerifierConfig } from "./verifierAdapter.js";
+
+const HARNESS = "anthropic_sdk";
+const MAX_STEPS_ENV = "EVAL_ANTHROPIC_SDK_MAX_STEPS";
+const DEFAULT_MAX_OUTPUT_TOKENS = 4096;
+
+interface AnthropicContentBlock {
+  type: string;
+  text?: string;
+  id?: string;
+  name?: string;
+  input?: unknown;
+}
+
+export interface AnthropicMessageResponse {
+  content: AnthropicContentBlock[];
+  stop_reason?: string | null;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    cache_read_input_tokens?: number | null;
+  };
+}
+
+export interface AnthropicMessagesClient {
+  messages: {
+    create(params: Record<string, unknown>): Promise<AnthropicMessageResponse>;
+  };
+}
+
+export interface AnthropicSdkRunnerInput {
+  plan: ExternalHarnessTaskPlan;
+  model: AvailableModel;
+  logger: EvalLogger;
+  toolAdapter: PreparedExternalHarnessAdapter;
+  signal?: AbortSignal;
+  /** Injectable for unit tests; defaults to a real Anthropic client. */
+  client?: AnthropicMessagesClient;
+  verifier?: ExternalHarnessVerifierConfig;
+}
+
+export function normalizeAnthropicModel(model: AvailableModel): string {
+  if (model.includes("/") && !model.startsWith("anthropic/")) {
+    throw new EvalsError(
+      `anthropic_sdk harness only accepts anthropic models; received "${model}".`,
+    );
+  }
+  return stripProviderPrefix(model);
+}
+
+const BROWSE_TOOL_DEFINITION = {
+  name: BROWSE_TOOL_NAME,
+  description: BROWSE_TOOL_DESCRIPTION,
+  input_schema: {
+    type: "object",
+    properties: {
+      args: {
+        type: "string",
+        description:
+          'Everything after "browse", e.g. "open https://example.com".',
+      },
+    },
+    required: ["args"],
+  },
+} as const;
+
+export async function runAnthropicSdkAgent(
+  input: AnthropicSdkRunnerInput,
+): Promise<TaskResult> {
+  const client = input.client ?? (await loadAnthropicClient());
+  const maxSteps = readBareLoopMaxSteps(MAX_STEPS_ENV);
+  const recorder = createBareLoopToolRecorder(
+    input.toolAdapter,
+    input.logger,
+    HARNESS,
+  );
+
+  const messages: Array<Record<string, unknown>> = [
+    { role: "user", content: buildBareLoopUserPrompt(input.plan) },
+  ];
+  const usageTotals = { input_tokens: 0, output_tokens: 0, cached: 0 };
+
+  let finalText = "";
+  let stepsUsed = 0;
+  let loopError: unknown;
+  let cappedOut = false;
+
+  try {
+    for (let step = 0; step < maxSteps; step++) {
+      if (input.signal?.aborted) {
+        throw new EvalsError("anthropic_sdk run aborted");
+      }
+      stepsUsed = step + 1;
+      const response = await client.messages.create({
+        model: normalizeAnthropicModel(input.model),
+        max_tokens: DEFAULT_MAX_OUTPUT_TOKENS,
+        system: input.toolAdapter.systemPromptAddendum,
+        messages,
+        tools: [BROWSE_TOOL_DEFINITION],
+      });
+
+      usageTotals.input_tokens += response.usage?.input_tokens ?? 0;
+      usageTotals.output_tokens += response.usage?.output_tokens ?? 0;
+      usageTotals.cached += response.usage?.cache_read_input_tokens ?? 0;
+
+      const textParts = response.content
+        .filter((block) => block.type === "text" && block.text)
+        .map((block) => block.text as string);
+      if (textParts.length > 0) {
+        finalText = textParts.join("\n");
+      }
+
+      if (response.stop_reason !== "tool_use") {
+        return finish("complete");
+      }
+
+      const toolUses = response.content.filter(
+        (block) => block.type === "tool_use",
+      );
+      const toolResults: Array<Record<string, unknown>> = [];
+      for (const use of toolUses) {
+        const args =
+          use.input && typeof use.input === "object"
+            ? String((use.input as Record<string, unknown>).args ?? "")
+            : "";
+        const output = await recorder.execute(
+          args,
+          textParts.join("\n") || undefined,
+        );
+        toolResults.push({
+          type: "tool_result",
+          tool_use_id: use.id ?? "",
+          content: output,
+        });
+      }
+
+      messages.push({ role: "assistant", content: response.content });
+      messages.push({ role: "user", content: toolResults });
+    }
+    cappedOut = true;
+  } catch (error) {
+    loopError = error;
+    input.logger.warn({
+      category: HARNESS,
+      message: `anthropic_sdk loop stopped before a normal result: ${stringifyLoopError(error)}`,
+      level: 0,
+    });
+  }
+
+  return finish(loopError ? "error" : "complete");
+
+  function finish(status: "complete" | "error"): Promise<TaskResult> {
+    return finalizeBareLoopResult({
+      harness: HARNESS,
+      toolCalls: recorder.calls,
+      finalText,
+      status,
+      stopReason: loopError
+        ? stringifyLoopError(loopError)
+        : cappedOut
+          ? `step cap reached (${maxSteps})`
+          : undefined,
+      usage: {
+        input_tokens: usageTotals.input_tokens,
+        output_tokens: usageTotals.output_tokens,
+        ...(usageTotals.cached > 0 && {
+          cached_input_tokens: usageTotals.cached,
+        }),
+      },
+      stepsUsed,
+      maxSteps,
+      logger: input.logger,
+      verifier: input.verifier,
+    });
+  }
+}
+
+async function loadAnthropicClient(): Promise<AnthropicMessagesClient> {
+  try {
+    const mod = (await import("@anthropic-ai/sdk")) as unknown as {
+      default?: new (
+        options?: Record<string, unknown>,
+      ) => AnthropicMessagesClient;
+      Anthropic?: new (
+        options?: Record<string, unknown>,
+      ) => AnthropicMessagesClient;
+    };
+    const Ctor = mod.default ?? mod.Anthropic;
+    if (typeof Ctor !== "function") {
+      throw new Error("Anthropic export missing");
+    }
+    return new Ctor();
+  } catch (error) {
+    throw new EvalsError(
+      `anthropic_sdk harness requires @anthropic-ai/sdk. Install it in packages/evals before running --harness anthropic_sdk. ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}

--- a/packages/evals/framework/benchHarness.ts
+++ b/packages/evals/framework/benchHarness.ts
@@ -32,6 +32,7 @@ import {
   type PreparedExternalHarnessAdapter,
 } from "./externalHarnessToolAdapter.js";
 import { runVercelAiSdkAgent } from "./vercelAiSdkRunner.js";
+import { runAnthropicSdkAgent } from "./anthropicSdkRunner.js";
 import type { DiscoveredTask, TaskResult } from "./types.js";
 import type {
   AdapterBackedHarness,
@@ -444,12 +445,17 @@ export const vercelAiSdkHarness = buildAdapterBackedHarness(
   "vercel_ai_sdk",
   runVercelAiSdkAgent,
 );
+export const anthropicSdkHarness = buildAdapterBackedHarness(
+  "anthropic_sdk",
+  runAnthropicSdkAgent,
+);
 
 const harnessRegistry = new Map<Harness, BenchHarness>([
   ["stagehand", stagehandHarness],
   ["claude_code", claudeCodeHarness],
   ["codex", codexHarness],
   ["vercel_ai_sdk", vercelAiSdkHarness],
+  ["anthropic_sdk", anthropicSdkHarness],
 ]);
 
 export function getBenchHarness(harness: Harness): BenchHarness {

--- a/packages/evals/framework/benchTypes.ts
+++ b/packages/evals/framework/benchTypes.ts
@@ -32,6 +32,7 @@ export const EXECUTABLE_BENCH_HARNESSES = [
   "claude_code",
   "codex",
   "vercel_ai_sdk",
+  "anthropic_sdk",
 ] as const satisfies readonly Harness[];
 
 /**

--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@ai-sdk/provider": "^2.0.0",
     "@anthropic-ai/claude-agent-sdk": "^0.2.141",
+    "@anthropic-ai/sdk": "0.39.0",
     "@browserbasehq/stagehand": "workspace:*",
     "@openai/codex-sdk": "0.125.0",
     "ai": "^5.0.133",

--- a/packages/evals/tests/framework/anthropicSdkRunner.test.ts
+++ b/packages/evals/tests/framework/anthropicSdkRunner.test.ts
@@ -1,0 +1,188 @@
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { AvailableModel } from "@browserbasehq/stagehand";
+import { EvalLogger } from "../../logger.js";
+import type { ExternalHarnessTaskPlan } from "../../framework/externalHarnessPlan.js";
+import type { PreparedExternalHarnessAdapter } from "../../framework/externalHarnessToolAdapter.js";
+import { BARE_LOOP_DEFAULT_SYSTEM_PROMPT } from "../../framework/externalHarnessToolAdapter.js";
+import {
+  normalizeAnthropicModel,
+  runAnthropicSdkAgent,
+  type AnthropicMessageResponse,
+} from "../../framework/anthropicSdkRunner.js";
+
+const plan: ExternalHarnessTaskPlan = {
+  dataset: "webtailbench",
+  taskId: "wtb-1",
+  startUrl: "https://example.com",
+  instruction: "Find the checkout button",
+};
+
+let tempDir: string | undefined;
+
+afterEach(async () => {
+  if (tempDir) {
+    await fsp.rm(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
+  }
+  delete process.env.EVAL_ANTHROPIC_SDK_MAX_STEPS;
+});
+
+async function makeAdapter(): Promise<PreparedExternalHarnessAdapter> {
+  tempDir = await fsp.mkdtemp(
+    path.join(os.tmpdir(), "stagehand-evals-anthropic-test-"),
+  );
+  const bin = path.join(tempDir, "browse");
+  await fsp.writeFile(bin, '#!/usr/bin/env bash\necho "browse-output:$@"\n', {
+    mode: 0o755,
+  });
+  return {
+    cwd: tempDir,
+    env: { ...process.env } as Record<string, string>,
+    browseBinPath: bin,
+    skillMode: "none",
+    systemPromptAddendum: BARE_LOOP_DEFAULT_SYSTEM_PROMPT,
+    metadata: { toolCommand: "browse", browseCliEntrypoint: bin },
+    cleanup: async () => {},
+  };
+}
+
+describe("anthropic_sdk runner", () => {
+  it("normalizes anthropic-prefixed models and rejects other providers", () => {
+    expect(
+      normalizeAnthropicModel("anthropic/claude-sonnet-4-6" as AvailableModel),
+    ).toBe("claude-sonnet-4-6");
+    expect(normalizeAnthropicModel("claude-haiku-4-5" as AvailableModel)).toBe(
+      "claude-haiku-4-5",
+    );
+    expect(() =>
+      normalizeAnthropicModel("openai/gpt-5.4" as AvailableModel),
+    ).toThrow(/only accepts anthropic models/);
+  });
+
+  it("hand-rolls the tool_use loop: executes tools, threads tool_results, stops on end_turn", async () => {
+    const adapter = await makeAdapter();
+    const requests: Array<Record<string, unknown>> = [];
+    const responses: AnthropicMessageResponse[] = [
+      {
+        content: [
+          { type: "text", text: "Let me check the help." },
+          {
+            type: "tool_use",
+            id: "tu-1",
+            name: "browse",
+            input: { args: "--help" },
+          },
+        ],
+        stop_reason: "tool_use",
+        usage: { input_tokens: 50, output_tokens: 10 },
+      },
+      {
+        content: [
+          {
+            type: "text",
+            text: 'EVAL_RESULT: {"success":true,"summary":"done","finalAnswer":"checkout"}',
+          },
+        ],
+        stop_reason: "end_turn",
+        usage: { input_tokens: 80, output_tokens: 20 },
+      },
+    ];
+
+    const result = await runAnthropicSdkAgent({
+      plan,
+      model: "anthropic/claude-sonnet-4-6" as AvailableModel,
+      logger: new EvalLogger(false),
+      toolAdapter: adapter,
+      client: {
+        messages: {
+          create: async (params) => {
+            requests.push(params);
+            return responses[requests.length - 1];
+          },
+        },
+      },
+    });
+
+    expect(requests).toHaveLength(2);
+    expect(requests[0].system).toBe(BARE_LOOP_DEFAULT_SYSTEM_PROMPT);
+    expect(requests[0].model).toBe("claude-sonnet-4-6");
+    // Second request must carry assistant tool_use + user tool_result turns.
+    const secondMessages = requests[1].messages as Array<
+      Record<string, unknown>
+    >;
+    expect(secondMessages).toHaveLength(3);
+    expect(secondMessages[1].role).toBe("assistant");
+    const toolResults = secondMessages[2].content as Array<
+      Record<string, unknown>
+    >;
+    expect(toolResults[0].type).toBe("tool_result");
+    expect(toolResults[0].tool_use_id).toBe("tu-1");
+    expect(String(toolResults[0].content)).toContain("browse-output:--help");
+
+    expect(result._success).toBe(true);
+    expect(result.finalAnswer).toBe("checkout");
+    expect(result.anthropic_sdkStatus).toBe("completed");
+    const metrics = result.metrics as Record<string, { value: number }>;
+    expect(metrics.anthropic_sdk_tool_calls.value).toBe(1);
+    expect(metrics.anthropic_sdk_input_tokens.value).toBe(130);
+    expect(metrics.anthropic_sdk_output_tokens.value).toBe(30);
+  });
+
+  it("stops at the step cap and reports it as the stop reason", async () => {
+    const adapter = await makeAdapter();
+    process.env.EVAL_ANTHROPIC_SDK_MAX_STEPS = "2";
+
+    const result = await runAnthropicSdkAgent({
+      plan,
+      model: "anthropic/claude-sonnet-4-6" as AvailableModel,
+      logger: new EvalLogger(false),
+      toolAdapter: adapter,
+      client: {
+        messages: {
+          create: async () => ({
+            content: [
+              {
+                type: "tool_use",
+                id: "tu-x",
+                name: "browse",
+                input: { args: "snapshot" },
+              },
+            ],
+            stop_reason: "tool_use",
+            usage: { input_tokens: 10, output_tokens: 5 },
+          }),
+        },
+      },
+    });
+
+    expect(result._success).toBe(false);
+    expect(result.anthropic_sdkStopReason).toContain("step cap reached (2)");
+    const metrics = result.metrics as Record<string, { value: number }>;
+    expect(metrics.anthropic_sdk_tool_calls.value).toBe(2);
+    expect(metrics.anthropic_sdk_max_steps.value).toBe(2);
+  });
+
+  it("returns a failed task result instead of throwing on SDK errors", async () => {
+    const adapter = await makeAdapter();
+    const result = await runAnthropicSdkAgent({
+      plan,
+      model: "anthropic/claude-sonnet-4-6" as AvailableModel,
+      logger: new EvalLogger(false),
+      toolAdapter: adapter,
+      client: {
+        messages: {
+          create: async () => {
+            throw new Error("anthropic exploded");
+          },
+        },
+      },
+    });
+
+    expect(result._success).toBe(false);
+    expect(result.anthropic_sdkStatus).toBe("error");
+    expect(result.anthropic_sdkStopReason).toContain("anthropic exploded");
+  });
+});

--- a/packages/evals/tests/framework/anthropicSdkRunner.test.ts
+++ b/packages/evals/tests/framework/anthropicSdkRunner.test.ts
@@ -124,7 +124,7 @@ describe("anthropic_sdk runner", () => {
 
     expect(result._success).toBe(true);
     expect(result.finalAnswer).toBe("checkout");
-    expect(result.anthropic_sdkStatus).toBe("completed");
+    expect(result.anthropicSdkStatus).toBe("completed");
     const metrics = result.metrics as Record<string, { value: number }>;
     expect(metrics.anthropic_sdk_tool_calls.value).toBe(1);
     expect(metrics.anthropic_sdk_input_tokens.value).toBe(130);
@@ -159,10 +159,45 @@ describe("anthropic_sdk runner", () => {
     });
 
     expect(result._success).toBe(false);
-    expect(result.anthropic_sdkStopReason).toContain("step cap reached (2)");
+    expect(result.anthropicSdkStopReason).toContain("step cap reached (2)");
     const metrics = result.metrics as Record<string, { value: number }>;
     expect(metrics.anthropic_sdk_tool_calls.value).toBe(2);
     expect(metrics.anthropic_sdk_max_steps.value).toBe(2);
+  });
+
+  it("wires the caller's AbortSignal through to the SDK's native abort option", async () => {
+    const adapter = await makeAdapter();
+    const controller = new AbortController();
+    const capturedOptions: Array<{ signal?: AbortSignal } | undefined> = [];
+
+    await runAnthropicSdkAgent({
+      plan,
+      model: "anthropic/claude-sonnet-4-6" as AvailableModel,
+      logger: new EvalLogger(false),
+      toolAdapter: adapter,
+      signal: controller.signal,
+      client: {
+        messages: {
+          create: async (_params, options) => {
+            capturedOptions.push(options);
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: 'EVAL_RESULT: {"success":true,"summary":"done","finalAnswer":"checkout"}',
+                },
+              ],
+              stop_reason: "end_turn",
+            };
+          },
+        },
+      },
+    });
+
+    expect(capturedOptions).toHaveLength(1);
+    // The SDK cancels the in-flight HTTP request via this signal instead of
+    // us only polling `aborted` between requests.
+    expect(capturedOptions[0]?.signal).toBe(controller.signal);
   });
 
   it("returns a failed task result instead of throwing on SDK errors", async () => {
@@ -182,7 +217,7 @@ describe("anthropic_sdk runner", () => {
     });
 
     expect(result._success).toBe(false);
-    expect(result.anthropic_sdkStatus).toBe("error");
-    expect(result.anthropic_sdkStopReason).toContain("anthropic exploded");
+    expect(result.anthropicSdkStatus).toBe("error");
+    expect(result.anthropicSdkStopReason).toContain("anthropic exploded");
   });
 });

--- a/packages/evals/tests/framework/anthropicSdkRunner.test.ts
+++ b/packages/evals/tests/framework/anthropicSdkRunner.test.ts
@@ -121,6 +121,7 @@ describe("anthropic_sdk runner", () => {
     expect(toolResults[0].type).toBe("tool_result");
     expect(toolResults[0].tool_use_id).toBe("tu-1");
     expect(String(toolResults[0].content)).toContain("browse-output:--help");
+    expect(toolResults[0].is_error).toBe(false);
 
     expect(result._success).toBe(true);
     expect(result.finalAnswer).toBe("checkout");
@@ -159,10 +160,119 @@ describe("anthropic_sdk runner", () => {
     });
 
     expect(result._success).toBe(false);
+    expect(result.anthropicSdkStatus).toBe("aborted");
     expect(result.anthropicSdkStopReason).toContain("step cap reached (2)");
     const metrics = result.metrics as Record<string, { value: number }>;
     expect(metrics.anthropic_sdk_tool_calls.value).toBe(2);
     expect(metrics.anthropic_sdk_max_steps.value).toBe(2);
+  });
+
+  it("reports aborted (not completed) when the model is truncated by max_tokens", async () => {
+    const adapter = await makeAdapter();
+    const result = await runAnthropicSdkAgent({
+      plan,
+      model: "anthropic/claude-sonnet-4-6" as AvailableModel,
+      logger: new EvalLogger(false),
+      toolAdapter: adapter,
+      client: {
+        messages: {
+          create: async () => ({
+            content: [{ type: "text", text: "partial output cut off mid" }],
+            stop_reason: "max_tokens",
+            usage: { input_tokens: 40, output_tokens: 4096 },
+          }),
+        },
+      },
+    });
+
+    expect(result._success).toBe(false);
+    expect(result.anthropicSdkStatus).toBe("aborted");
+    expect(result.anthropicSdkStopReason).toContain("stop_reason: max_tokens");
+  });
+
+  it("propagates a rejected tool call as a native is_error tool_result", async () => {
+    const adapter = await makeAdapter();
+    process.env.EVAL_ANTHROPIC_SDK_MAX_STEPS = "2";
+    const requests: Array<Record<string, unknown>> = [];
+
+    await runAnthropicSdkAgent({
+      plan,
+      model: "anthropic/claude-sonnet-4-6" as AvailableModel,
+      logger: new EvalLogger(false),
+      toolAdapter: adapter,
+      client: {
+        messages: {
+          create: async (params) => {
+            requests.push(params);
+            if (requests.length === 1) {
+              return {
+                content: [
+                  {
+                    type: "tool_use",
+                    id: "tu-fail",
+                    name: "browse",
+                    input: { args: "&& rm -rf /" },
+                  },
+                ],
+                stop_reason: "tool_use",
+                usage: { input_tokens: 10, output_tokens: 5 },
+              };
+            }
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: 'EVAL_RESULT: {"success":false,"summary":"gave up"}',
+                },
+              ],
+              stop_reason: "end_turn",
+              usage: { input_tokens: 10, output_tokens: 5 },
+            };
+          },
+        },
+      },
+    });
+
+    const secondMessages = requests[1].messages as Array<
+      Record<string, unknown>
+    >;
+    const toolResults = secondMessages[2].content as Array<
+      Record<string, unknown>
+    >;
+    expect(toolResults[0].is_error).toBe(true);
+  });
+
+  it("prefers input + cache_creation + cache_read over the recomputed input+output sum", async () => {
+    const adapter = await makeAdapter();
+    const result = await runAnthropicSdkAgent({
+      plan,
+      model: "anthropic/claude-sonnet-4-6" as AvailableModel,
+      logger: new EvalLogger(false),
+      toolAdapter: adapter,
+      client: {
+        messages: {
+          create: async () => ({
+            content: [
+              {
+                type: "text",
+                text: 'EVAL_RESULT: {"success":true,"summary":"done","finalAnswer":"checkout"}',
+              },
+            ],
+            stop_reason: "end_turn",
+            usage: {
+              input_tokens: 50,
+              output_tokens: 20,
+              cache_creation_input_tokens: 200,
+              cache_read_input_tokens: 30,
+            },
+          }),
+        },
+      },
+    });
+
+    const metrics = result.metrics as Record<string, { value: number }>;
+    // 50 + 20 + 200 + 30 = 300, not the naive 50 + 20 = 70.
+    expect(metrics.anthropic_sdk_total_tokens.value).toBe(300);
   });
 
   it("wires the caller's AbortSignal through to the SDK's native abort option", async () => {

--- a/packages/evals/tests/framework/benchHarness.test.ts
+++ b/packages/evals/tests/framework/benchHarness.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  anthropicSdkHarness,
   claudeCodeHarness,
   codexHarness,
   getBenchHarness,
@@ -35,6 +36,18 @@ describe("bench harness registry", () => {
     expect(harness.supportsApi).toBe(false);
     expect(harness.execute).toBeDefined();
     // Like claude_code/codex, this harness runs via the execute path only.
+    await expect(harness.start({} as never)).rejects.toThrow(
+      /external harness execute path/,
+    );
+  });
+
+  it("registers anthropic_sdk as a concrete executable harness", async () => {
+    const harness = getBenchHarness("anthropic_sdk");
+
+    expect(harness).toBe(anthropicSdkHarness);
+    expect(harness.supportedTaskKinds).toEqual(["agent", "suite"]);
+    expect(harness.supportsApi).toBe(false);
+    expect(harness.execute).toBeDefined();
     await expect(harness.start({} as never)).rejects.toThrow(
       /external harness execute path/,
     );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,6 +338,9 @@ importers:
       '@anthropic-ai/claude-agent-sdk':
         specifier: ^0.2.141
         version: 0.2.141(@cfworker/json-schema@4.1.1)(zod@4.2.1)
+      '@anthropic-ai/sdk':
+        specifier: 0.39.0
+        version: 0.39.0
       '@browserbasehq/stagehand':
         specifier: workspace:*
         version: link:../core


### PR DESCRIPTION
## What

**Part 3 of 5 — stacked on #2338 (`vercel_ai_sdk`)** (base: `shrey/evals-harness-vercel-ai-sdk`; GitHub shows only this PR's delta). When the parent merges, retarget this PR's base and rebase.

Registers `--harness anthropic_sdk`: a hand-rolled `tool_use` loop via `@anthropic-ai/sdk` — the TS twin of the Python `while stop_reason == "tool_use"` loop that dominates real-world Anthropic usage (37.5M PyPI dl/wk) and of the Modal sandbox template's `agent.mjs`. No retries, no planning, no memory — deliberately: **the bareness is the instrument**.

- Anthropic models only (`anthropic/` prefix stripped; other providers rejected loudly).
- Step cap: shared 40 default, `EVAL_ANTHROPIC_SDK_MAX_STEPS` override; when the cap binds it's surfaced as the stop reason.
- Assistant text buffered per turn folds into the next tool call's `reasoning`; usage summed across turns.
- Adds the `@anthropic-ai/sdk` dependency (pinned 0.39.0, matching packages/core) — this PR carries its own lockfile delta.
- Testability: `client` injection seam (`messages.create` mock).

External harnesses design + usage: [`packages/evals/README.md#external-harnesses`](https://github.com/browserbase/stagehand/blob/shrey/evals-bareloop-harnesses/packages/evals/README.md#external-harnesses) (in #2337). Linear: STG-2515.

## Comparability fix (2026-07-09 audit)

Wired the caller's `AbortSignal` into `@anthropic-ai/sdk`'s native abort option (`messages.create(body, { signal })`) instead of only polling `signal?.aborted` between loop iterations — previously an abort mid-loop left an already-in-flight `messages.create()` call running to completion instead of cancelling the HTTP request. One new test asserts the signal is forwarded as-is to the client.

(anthropic_sdk's `step cap reached (N)` stop-reason shape was already correct here — it's the reference shape vercel_ai_sdk (#2338) and openai_agents_sdk (#2340) were fixed to match, per the same audit.)

## E2E Test Matrix

Live smoke ran on the pre-split combined branch (content identical to this stack's tip — verified by diff); results transplanted, not rerun.

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `evals run b:webtailbench --harness anthropic_sdk -m anthropic/claude-haiku-4-5-20251001 -l 1 -t 1 -c 1` (local build, real ANTHROPIC + GEMINI keys, local Chrome via browse CLI) | Run completed (exit 0) **at the 40-step cap** (stop reason `step cap reached (40)`). 40 `browse` tool calls recorded; trajectory persisted; verifier graded: `outcomeSuccess=false`, `processScore=0.29`, 5 rubric criteria, **no verifierError**. Usage: 172k in / 2.6k out tokens | Bar met: harness completes, trajectory captured, graded outcome, no verifierError. Task pass/fail is NOT the bar (united.com flights). Cap-binding at 40 with haiku on a hard task is exactly the instrument behavior the design doc predicts |
| `pnpm exec vitest run` (this branch) | `Test Files 51 passed, Tests 376 passed` — adds `anthropicSdkRunner.test.ts` (multi-turn loop threading assistant/tool_result messages, tool_use → browse execution, step-cap stop reason, usage summing, model-prefix validation, SDK-error folding) | Mocked-model loop coverage; live behavior proven by the smoke row above |
| `tsc --noEmit` + prettier + eslint | clean | Types/style only |
| `pnpm exec vitest run` (this branch, post-fix) | `Test Files 51 passed, Tests 379 passed` — adds the AbortSignal-forwarding test | Proves the signal reaches `messages.create`'s options arg unchanged |
| `pnpm -w exec tsc --noEmit` + prettier + eslint (post-fix) | clean | Types/style only |

## Tier 1 fixes (post-review audit, 2026-07-14)

An independent audit found every non-`tool_use` stop reason -- including `max_tokens` (truncated output) -- was reported as a successful `"complete"`, tool-call failures had no native `is_error` signal, and `cache_creation_input_tokens` was never counted toward the total. Fixed here:

- **`max_tokens` truncation was indistinguishable from a real success.** Only `stop_reason === "end_turn"` now maps to `"complete"`; every other non-`tool_use` reason (`max_tokens`, `refusal`, `pause_turn`, ...) maps to `"aborted"` with the real `stop_reason` recorded as the stopReason.
- **Tool failures had no native `is_error`.** `tool_result` blocks now carry `is_error: !ok`, derived from `BareLoopToolRecorder.execute()`'s `{ ok, output }` (base PR) instead of silently dropping the failure signal.
- **Cache-creation tokens were never counted.** `AnthropicMessageResponse.usage` now tracks `cache_creation_input_tokens`; `providerTotalTokens` reports Anthropic's real total (input + output + cache_creation + cache_read) instead of undercounting via a recomputed input+output sum.

Verified: `pnpm --filter @browserbasehq/stagehand-evals build && lint && test:unit` -- `Test Files 56 passed, Tests 429 passed` (4 new tests: max_tokens-as-aborted, is_error propagation, cache-creation total, existing step-cap test updated to `"aborted"`).


No changeset: `packages/evals` is private.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



