### PR TITLE
[STG-2515] feat(evals): openai_agents_sdk harness adapter

### DIFF
--- a/packages/evals/framework/benchHarness.ts
+++ b/packages/evals/framework/benchHarness.ts
@@ -33,6 +33,7 @@ import {
 } from "./externalHarnessToolAdapter.js";
 import { runVercelAiSdkAgent } from "./vercelAiSdkRunner.js";
 import { runAnthropicSdkAgent } from "./anthropicSdkRunner.js";
+import { runOpenAiAgentsSdkAgent } from "./openaiAgentsSdkRunner.js";
 import type { DiscoveredTask, TaskResult } from "./types.js";
 import type {
   AdapterBackedHarness,
@@ -449,6 +450,10 @@ export const anthropicSdkHarness = buildAdapterBackedHarness(
   "anthropic_sdk",
   runAnthropicSdkAgent,
 );
+export const openaiAgentsSdkHarness = buildAdapterBackedHarness(
+  "openai_agents_sdk",
+  runOpenAiAgentsSdkAgent,
+);
 
 const harnessRegistry = new Map<Harness, BenchHarness>([
   ["stagehand", stagehandHarness],
@@ -456,6 +461,7 @@ const harnessRegistry = new Map<Harness, BenchHarness>([
   ["codex", codexHarness],
   ["vercel_ai_sdk", vercelAiSdkHarness],
   ["anthropic_sdk", anthropicSdkHarness],
+  ["openai_agents_sdk", openaiAgentsSdkHarness],
 ]);
 
 export function getBenchHarness(harness: Harness): BenchHarness {

--- a/packages/evals/framework/benchTypes.ts
+++ b/packages/evals/framework/benchTypes.ts
@@ -33,6 +33,7 @@ export const EXECUTABLE_BENCH_HARNESSES = [
   "codex",
   "vercel_ai_sdk",
   "anthropic_sdk",
+  "openai_agents_sdk",
 ] as const satisfies readonly Harness[];
 
 /**

--- a/packages/evals/framework/openaiAgentsSdkRunner.ts
+++ b/packages/evals/framework/openaiAgentsSdkRunner.ts
@@ -1,0 +1,203 @@
+/**
+ * openaiAgentsSdkRunner — harness via the OpenAI Agents SDK (`@openai/agents`).
+ *
+ * Classification: bare-ISH, one notch above the raw provider loops. The SDK
+ * runs its own agent loop (turn management, tool dispatch, tracing) but ships
+ * no behavioral scaffolding: everything the agent knows comes from the
+ * dev-supplied `instructions` string. Per the design doc we keep every SDK
+ * default untouched except `maxTurns` (the step cap — the SDK's own default
+ * of 10 is far too low for a browse task) — instructions carry only the
+ * configured skill-arm prompt.
+ *
+ * Tool parameters use a plain JSON schema (not a zod schema) to sidestep the
+ * SDK's zod version coupling; packages/evals pins zod v4 while the SDK's
+ * zodCompat targeted v3 first.
+ *
+ * Testability: pass `sdk` with mocked { Agent, run, tool }.
+ */
+import type { AvailableModel } from "@browserbasehq/stagehand";
+import { EvalsError } from "../errors.js";
+import type { EvalLogger } from "../logger.js";
+import type { TaskResult } from "./types.js";
+import type { ExternalHarnessTaskPlan } from "./externalHarnessPlan.js";
+import type { PreparedExternalHarnessAdapter } from "./externalHarnessToolAdapter.js";
+import { readBareLoopMaxSteps } from "./bareLoopConfig.js";
+import {
+  BROWSE_TOOL_DESCRIPTION,
+  BROWSE_TOOL_NAME,
+  buildBareLoopUserPrompt,
+  createBareLoopToolRecorder,
+  finalizeBareLoopResult,
+  stringifyLoopError,
+  stripProviderPrefix,
+} from "./bareLoopRunner.js";
+import type { ExternalHarnessVerifierConfig } from "./verifierAdapter.js";
+
+const HARNESS = "openai_agents_sdk";
+const MAX_TURNS_ENV = "EVAL_OPENAI_AGENTS_SDK_MAX_TURNS";
+
+export interface OpenAiAgentsRunResult {
+  finalOutput?: unknown;
+  rawResponses?: Array<{
+    usage?: {
+      inputTokens?: number;
+      outputTokens?: number;
+    };
+  }>;
+}
+
+export interface OpenAiAgentsSdk {
+  Agent: new (config: Record<string, unknown>) => unknown;
+  run: (
+    agent: unknown,
+    input: string,
+    options?: Record<string, unknown>,
+  ) => Promise<OpenAiAgentsRunResult>;
+  tool: (options: Record<string, unknown>) => unknown;
+}
+
+export interface OpenAiAgentsSdkRunnerInput {
+  plan: ExternalHarnessTaskPlan;
+  model: AvailableModel;
+  logger: EvalLogger;
+  toolAdapter: PreparedExternalHarnessAdapter;
+  signal?: AbortSignal;
+  /** Injectable for unit tests; defaults to the real @openai/agents exports. */
+  sdk?: OpenAiAgentsSdk;
+  verifier?: ExternalHarnessVerifierConfig;
+}
+
+export function normalizeOpenAiAgentsModel(model: AvailableModel): string {
+  if (model.includes("/") && !model.startsWith("openai/")) {
+    throw new EvalsError(
+      `openai_agents_sdk harness only accepts openai models; received "${model}".`,
+    );
+  }
+  return stripProviderPrefix(model);
+}
+
+export async function runOpenAiAgentsSdkAgent(
+  input: OpenAiAgentsSdkRunnerInput,
+): Promise<TaskResult> {
+  const sdk = input.sdk ?? (await loadOpenAiAgentsSdk());
+  const maxTurns = readBareLoopMaxSteps(MAX_TURNS_ENV);
+  const recorder = createBareLoopToolRecorder(
+    input.toolAdapter,
+    input.logger,
+    HARNESS,
+  );
+
+  let finalText = "";
+  let usage = { input_tokens: 0, output_tokens: 0 };
+  let loopError: unknown;
+
+  try {
+    const browseTool = sdk.tool({
+      name: BROWSE_TOOL_NAME,
+      description: BROWSE_TOOL_DESCRIPTION,
+      parameters: {
+        type: "object",
+        properties: {
+          args: {
+            type: "string",
+            description:
+              'Everything after "browse", e.g. "open https://example.com".',
+          },
+        },
+        required: ["args"],
+        additionalProperties: false,
+      },
+      strict: true,
+      execute: async (params: unknown) => {
+        const args =
+          params && typeof params === "object"
+            ? String((params as Record<string, unknown>).args ?? "")
+            : "";
+        return recorder.execute(args);
+      },
+    });
+
+    const agent = new sdk.Agent({
+      name: "browse-bench-agent",
+      instructions: input.toolAdapter.systemPromptAddendum,
+      model: normalizeOpenAiAgentsModel(input.model),
+      tools: [browseTool],
+    });
+
+    const result = await sdk.run(agent, buildBareLoopUserPrompt(input.plan), {
+      maxTurns,
+      ...(input.signal && { signal: input.signal }),
+    });
+
+    finalText =
+      typeof result.finalOutput === "string"
+        ? result.finalOutput
+        : (safeJson(result.finalOutput) ?? "");
+    usage = sumAgentsUsage(result.rawResponses);
+  } catch (error) {
+    loopError = error;
+    input.logger.warn({
+      category: HARNESS,
+      message: `openai_agents_sdk run stopped before a normal result: ${stringifyLoopError(error)}`,
+      level: 0,
+    });
+  }
+
+  return finalizeBareLoopResult({
+    harness: HARNESS,
+    toolCalls: recorder.calls,
+    finalText,
+    status: loopError ? "error" : "complete",
+    stopReason: loopError ? stringifyLoopError(loopError) : undefined,
+    usage,
+    stepsUsed: recorder.calls.length,
+    maxSteps: maxTurns,
+    logger: input.logger,
+    verifier: input.verifier,
+  });
+}
+
+function sumAgentsUsage(responses: OpenAiAgentsRunResult["rawResponses"]): {
+  input_tokens: number;
+  output_tokens: number;
+} {
+  const totals = { input_tokens: 0, output_tokens: 0 };
+  for (const response of responses ?? []) {
+    totals.input_tokens += toFinite(response.usage?.inputTokens);
+    totals.output_tokens += toFinite(response.usage?.outputTokens);
+  }
+  return totals;
+}
+
+function toFinite(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function safeJson(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+async function loadOpenAiAgentsSdk(): Promise<OpenAiAgentsSdk> {
+  try {
+    const mod = (await import("@openai/agents")) as Partial<OpenAiAgentsSdk>;
+    if (
+      typeof mod.Agent !== "function" ||
+      typeof mod.run !== "function" ||
+      typeof mod.tool !== "function"
+    ) {
+      throw new Error("Agent/run/tool exports missing");
+    }
+    return { Agent: mod.Agent, run: mod.run, tool: mod.tool };
+  } catch (error) {
+    throw new EvalsError(
+      `openai_agents_sdk harness requires @openai/agents. Install it in packages/evals before running --harness openai_agents_sdk. ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}

--- a/packages/evals/framework/openaiAgentsSdkRunner.ts
+++ b/packages/evals/framework/openaiAgentsSdkRunner.ts
@@ -35,6 +35,22 @@ import type { ExternalHarnessVerifierConfig } from "./verifierAdapter.js";
 
 const HARNESS = "openai_agents_sdk";
 const MAX_TURNS_ENV = "EVAL_OPENAI_AGENTS_SDK_MAX_TURNS";
+// The real @openai/agents-core throws `MaxTurnsExceededError` with exactly
+// this message shape ("Max turns (${maxTurns}) exceeded" -- see
+// @openai/agents-core/dist/runner/turnPreparation.js) and sets
+// `error.name = "MaxTurnsExceededError"` (AgentsError's constructor does
+// `this.name = new.target.name`). Match on either so a plain mocked Error
+// with the same message (as our unit tests use) is also recognized.
+const MAX_TURNS_EXCEEDED_NAME = "MaxTurnsExceededError";
+const MAX_TURNS_EXCEEDED_MESSAGE = /^Max turns \(\d+\) exceeded$/;
+
+function isMaxTurnsExceededError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return (
+    error.name === MAX_TURNS_EXCEEDED_NAME ||
+    MAX_TURNS_EXCEEDED_MESSAGE.test(error.message)
+  );
+}
 
 export interface OpenAiAgentsRunResult {
   finalOutput?: unknown;
@@ -90,6 +106,7 @@ export async function runOpenAiAgentsSdkAgent(
   let finalText = "";
   let usage = { input_tokens: 0, output_tokens: 0 };
   let loopError: unknown;
+  let cappedOut = false;
 
   try {
     const browseTool = sdk.tool({
@@ -135,12 +152,25 @@ export async function runOpenAiAgentsSdkAgent(
         : (safeJson(result.finalOutput) ?? "");
     usage = sumAgentsUsage(result.rawResponses);
   } catch (error) {
-    loopError = error;
-    input.logger.warn({
-      category: HARNESS,
-      message: `openai_agents_sdk run stopped before a normal result: ${stringifyLoopError(error)}`,
-      level: 0,
-    });
+    if (isMaxTurnsExceededError(error)) {
+      // The SDK throws instead of returning a truncated result, unlike
+      // vercel_ai_sdk/anthropic_sdk which end their loop and return normally.
+      // Treat it as the same step-cap outcome those two report, not a
+      // harness/SDK failure.
+      cappedOut = true;
+      input.logger.warn({
+        category: HARNESS,
+        message: `openai_agents_sdk hit the max-turns cap (${maxTurns})`,
+        level: 0,
+      });
+    } else {
+      loopError = error;
+      input.logger.warn({
+        category: HARNESS,
+        message: `openai_agents_sdk run stopped before a normal result: ${stringifyLoopError(error)}`,
+        level: 0,
+      });
+    }
   }
 
   return finalizeBareLoopResult({
@@ -148,7 +178,11 @@ export async function runOpenAiAgentsSdkAgent(
     toolCalls: recorder.calls,
     finalText,
     status: loopError ? "error" : "complete",
-    stopReason: loopError ? stringifyLoopError(loopError) : undefined,
+    stopReason: loopError
+      ? stringifyLoopError(loopError)
+      : cappedOut
+        ? `step cap reached (${maxTurns})`
+        : undefined,
     usage,
     stepsUsed: recorder.calls.length,
     maxSteps: maxTurns,

--- a/packages/evals/framework/openaiAgentsSdkRunner.ts
+++ b/packages/evals/framework/openaiAgentsSdkRunner.ts
@@ -6,7 +6,7 @@
  * no behavioral scaffolding: everything the agent knows comes from the
  * dev-supplied `instructions` string. We keep every SDK default untouched
  * except `maxTurns` (the step cap — the SDK's own default of 10 is far too
- * low for a browse task) — instructions carry only the configured skill-arm
+ * low for a browse task) — instructions carry only the configured skill-mode
  * prompt.
  *
  * Tool parameters use a plain JSON schema (not a zod schema) to sidestep the

--- a/packages/evals/framework/openaiAgentsSdkRunner.ts
+++ b/packages/evals/framework/openaiAgentsSdkRunner.ts
@@ -58,8 +58,28 @@ export interface OpenAiAgentsRunResult {
     usage?: {
       inputTokens?: number;
       outputTokens?: number;
+      totalTokens?: number;
     };
   }>;
+}
+
+/**
+ * The real `@openai/agents-core` `AgentsError` (base of `MaxTurnsExceededError`)
+ * carries a `state?: RunState` -- `RunState.usage` is a getter returning the
+ * real cumulative `Usage` (inputTokens/outputTokens/totalTokens), and
+ * `_currentTurn` is a public field with the real turn count reached before
+ * the cap fired. Without this, the exception path has no way to recover
+ * real usage/turns since `sdk.run()` never returned a result.
+ */
+interface MaxTurnsExceededErrorState {
+  state?: {
+    usage?: {
+      inputTokens?: number;
+      outputTokens?: number;
+      totalTokens?: number;
+    };
+    _currentTurn?: number;
+  };
 }
 
 export interface OpenAiAgentsSdk {
@@ -105,6 +125,7 @@ export async function runOpenAiAgentsSdkAgent(
 
   let finalText = "";
   let usage = { input_tokens: 0, output_tokens: 0 };
+  let providerTotalTokens: number | undefined;
   let loopError: unknown;
   let cappedOut = false;
   let modelTurns: number | undefined;
@@ -131,7 +152,8 @@ export async function runOpenAiAgentsSdkAgent(
           params && typeof params === "object"
             ? String((params as Record<string, unknown>).args ?? "")
             : "";
-        return recorder.execute(args);
+        const { output } = await recorder.execute(args);
+        return output;
       },
     });
 
@@ -152,6 +174,7 @@ export async function runOpenAiAgentsSdkAgent(
         ? result.finalOutput
         : (safeJson(result.finalOutput) ?? "");
     usage = sumAgentsUsage(result.rawResponses);
+    providerTotalTokens = sumProviderTotalTokens(result.rawResponses);
     modelTurns = result.rawResponses?.length;
   } catch (error) {
     if (isMaxTurnsExceededError(error)) {
@@ -160,6 +183,20 @@ export async function runOpenAiAgentsSdkAgent(
       // Treat it as the same step-cap outcome those two report, not a
       // harness/SDK failure.
       cappedOut = true;
+      // `sdk.run()` never returned, so `usage`/`modelTurns` above are still
+      // at their zero/undefined defaults -- recover the real numbers from
+      // the exception's own state instead of reporting a live run as 0/0.
+      const state = (error as MaxTurnsExceededErrorState).state;
+      if (state?.usage) {
+        usage = {
+          input_tokens: toFinite(state.usage.inputTokens),
+          output_tokens: toFinite(state.usage.outputTokens),
+        };
+        providerTotalTokens = state.usage.totalTokens;
+      }
+      if (typeof state?._currentTurn === "number") {
+        modelTurns = state._currentTurn;
+      }
       input.logger.warn({
         category: HARNESS,
         message: `openai_agents_sdk hit the max-turns cap (${maxTurns})`,
@@ -179,13 +216,14 @@ export async function runOpenAiAgentsSdkAgent(
     harness: HARNESS,
     toolCalls: recorder.calls,
     finalText,
-    status: loopError ? "error" : "complete",
+    status: loopError ? "error" : cappedOut ? "aborted" : "complete",
     stopReason: loopError
       ? stringifyLoopError(loopError)
       : cappedOut
         ? `step cap reached (${maxTurns})`
         : undefined,
     usage,
+    providerTotalTokens,
     // Steps are model turns when the SDK reports them (rawResponses is one
     // entry per turn); tool-call count alone undercounts runs that end with
     // a text-only turn. Fall back to tool calls when no result was returned.
@@ -206,6 +244,19 @@ function sumAgentsUsage(responses: OpenAiAgentsRunResult["rawResponses"]): {
     totals.output_tokens += toFinite(response.usage?.outputTokens);
   }
   return totals;
+}
+
+/** `undefined` if no raw response reported a totalTokens field, so the caller can fall back to recomputing input+output. */
+function sumProviderTotalTokens(
+  responses: OpenAiAgentsRunResult["rawResponses"],
+): number | undefined {
+  let total: number | undefined;
+  for (const response of responses ?? []) {
+    if (typeof response.usage?.totalTokens === "number") {
+      total = (total ?? 0) + response.usage.totalTokens;
+    }
+  }
+  return total;
 }
 
 function toFinite(value: unknown): number {

--- a/packages/evals/framework/openaiAgentsSdkRunner.ts
+++ b/packages/evals/framework/openaiAgentsSdkRunner.ts
@@ -107,6 +107,7 @@ export async function runOpenAiAgentsSdkAgent(
   let usage = { input_tokens: 0, output_tokens: 0 };
   let loopError: unknown;
   let cappedOut = false;
+  let modelTurns: number | undefined;
 
   try {
     const browseTool = sdk.tool({
@@ -151,6 +152,7 @@ export async function runOpenAiAgentsSdkAgent(
         ? result.finalOutput
         : (safeJson(result.finalOutput) ?? "");
     usage = sumAgentsUsage(result.rawResponses);
+    modelTurns = result.rawResponses?.length;
   } catch (error) {
     if (isMaxTurnsExceededError(error)) {
       // The SDK throws instead of returning a truncated result, unlike
@@ -184,7 +186,10 @@ export async function runOpenAiAgentsSdkAgent(
         ? `step cap reached (${maxTurns})`
         : undefined,
     usage,
-    stepsUsed: recorder.calls.length,
+    // Steps are model turns when the SDK reports them (rawResponses is one
+    // entry per turn); tool-call count alone undercounts runs that end with
+    // a text-only turn. Fall back to tool calls when no result was returned.
+    stepsUsed: modelTurns ?? recorder.calls.length,
     maxSteps: maxTurns,
     logger: input.logger,
     verifier: input.verifier,

--- a/packages/evals/framework/openaiAgentsSdkRunner.ts
+++ b/packages/evals/framework/openaiAgentsSdkRunner.ts
@@ -4,10 +4,10 @@
  * Classification: bare-ISH, one notch above the raw provider loops. The SDK
  * runs its own agent loop (turn management, tool dispatch, tracing) but ships
  * no behavioral scaffolding: everything the agent knows comes from the
- * dev-supplied `instructions` string. Per the design doc we keep every SDK
- * default untouched except `maxTurns` (the step cap — the SDK's own default
- * of 10 is far too low for a browse task) — instructions carry only the
- * configured skill-arm prompt.
+ * dev-supplied `instructions` string. We keep every SDK default untouched
+ * except `maxTurns` (the step cap — the SDK's own default of 10 is far too
+ * low for a browse task) — instructions carry only the configured skill-arm
+ * prompt.
  *
  * Tool parameters use a plain JSON schema (not a zod schema) to sidestep the
  * SDK's zod version coupling; packages/evals pins zod v4 while the SDK's

--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -26,6 +26,7 @@
     "@anthropic-ai/claude-agent-sdk": "^0.2.141",
     "@anthropic-ai/sdk": "0.39.0",
     "@browserbasehq/stagehand": "workspace:*",
+    "@openai/agents": "0.13.0",
     "@openai/codex-sdk": "0.125.0",
     "ai": "^5.0.133",
     "dotenv": "^17.3.1",

--- a/packages/evals/tests/framework/benchHarness.test.ts
+++ b/packages/evals/tests/framework/benchHarness.test.ts
@@ -4,6 +4,7 @@ import {
   claudeCodeHarness,
   codexHarness,
   getBenchHarness,
+  openaiAgentsSdkHarness,
   vercelAiSdkHarness,
 } from "../../framework/benchHarness.js";
 import { isExecutableBenchHarness } from "../../framework/benchTypes.js";
@@ -45,6 +46,18 @@ describe("bench harness registry", () => {
     const harness = getBenchHarness("anthropic_sdk");
 
     expect(harness).toBe(anthropicSdkHarness);
+    expect(harness.supportedTaskKinds).toEqual(["agent", "suite"]);
+    expect(harness.supportsApi).toBe(false);
+    expect(harness.execute).toBeDefined();
+    await expect(harness.start({} as never)).rejects.toThrow(
+      /external harness execute path/,
+    );
+  });
+
+  it("registers openai_agents_sdk as a concrete executable harness", async () => {
+    const harness = getBenchHarness("openai_agents_sdk");
+
+    expect(harness).toBe(openaiAgentsSdkHarness);
     expect(harness.supportedTaskKinds).toEqual(["agent", "suite"]);
     expect(harness.supportsApi).toBe(false);
     expect(harness.execute).toBeDefined();

--- a/packages/evals/tests/framework/openaiAgentsSdkRunner.test.ts
+++ b/packages/evals/tests/framework/openaiAgentsSdkRunner.test.ts
@@ -1,0 +1,151 @@
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { AvailableModel } from "@browserbasehq/stagehand";
+import { EvalLogger } from "../../logger.js";
+import type { ExternalHarnessTaskPlan } from "../../framework/externalHarnessPlan.js";
+import type { PreparedExternalHarnessAdapter } from "../../framework/externalHarnessToolAdapter.js";
+import { BARE_LOOP_DEFAULT_SYSTEM_PROMPT } from "../../framework/externalHarnessToolAdapter.js";
+import {
+  normalizeOpenAiAgentsModel,
+  runOpenAiAgentsSdkAgent,
+  type OpenAiAgentsSdk,
+} from "../../framework/openaiAgentsSdkRunner.js";
+
+const plan: ExternalHarnessTaskPlan = {
+  dataset: "webtailbench",
+  taskId: "wtb-1",
+  startUrl: "https://example.com",
+  instruction: "Find the checkout button",
+};
+
+let tempDir: string | undefined;
+
+afterEach(async () => {
+  if (tempDir) {
+    await fsp.rm(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
+  }
+  delete process.env.EVAL_OPENAI_AGENTS_SDK_MAX_TURNS;
+});
+
+async function makeAdapter(): Promise<PreparedExternalHarnessAdapter> {
+  tempDir = await fsp.mkdtemp(
+    path.join(os.tmpdir(), "stagehand-evals-agents-test-"),
+  );
+  const bin = path.join(tempDir, "browse");
+  await fsp.writeFile(bin, '#!/usr/bin/env bash\necho "browse-output:$@"\n', {
+    mode: 0o755,
+  });
+  return {
+    cwd: tempDir,
+    env: { ...process.env } as Record<string, string>,
+    browseBinPath: bin,
+    skillMode: "none",
+    systemPromptAddendum: BARE_LOOP_DEFAULT_SYSTEM_PROMPT,
+    metadata: { toolCommand: "browse", browseCliEntrypoint: bin },
+    cleanup: async () => {},
+  };
+}
+
+describe("openai_agents_sdk runner", () => {
+  it("normalizes openai-prefixed models and rejects other providers", () => {
+    expect(
+      normalizeOpenAiAgentsModel("openai/gpt-5.4-mini" as AvailableModel),
+    ).toBe("gpt-5.4-mini");
+    expect(normalizeOpenAiAgentsModel("gpt-5.4" as AvailableModel)).toBe(
+      "gpt-5.4",
+    );
+    expect(() =>
+      normalizeOpenAiAgentsModel(
+        "anthropic/claude-sonnet-4-6" as AvailableModel,
+      ),
+    ).toThrow(/only accepts openai models/);
+  });
+
+  it("passes dev instructions + maxTurns only, and records tool executions", async () => {
+    const adapter = await makeAdapter();
+    process.env.EVAL_OPENAI_AGENTS_SDK_MAX_TURNS = "9";
+
+    let capturedAgentConfig: Record<string, unknown> | undefined;
+    let capturedToolOptions: Record<string, unknown> | undefined;
+    let capturedRunOptions: Record<string, unknown> | undefined;
+    let capturedInput: string | undefined;
+
+    const sdk: OpenAiAgentsSdk = {
+      tool: (options) => {
+        capturedToolOptions = options;
+        return { __tool: true, options };
+      },
+      Agent: class {
+        constructor(config: Record<string, unknown>) {
+          capturedAgentConfig = config;
+        }
+      } as unknown as OpenAiAgentsSdk["Agent"],
+      run: async (agent, input, options) => {
+        void agent;
+        capturedInput = input;
+        capturedRunOptions = options;
+        const execute = capturedToolOptions?.execute as (
+          params: unknown,
+        ) => Promise<string>;
+        const output = await execute({ args: "open https://example.com" });
+        expect(output).toContain("browse-output:open https://example.com");
+        return {
+          finalOutput:
+            'EVAL_RESULT: {"success":true,"summary":"done","finalAnswer":"checkout"}',
+          rawResponses: [
+            { usage: { inputTokens: 100, outputTokens: 25 } },
+            { usage: { inputTokens: 40, outputTokens: 10 } },
+          ],
+        };
+      },
+    };
+
+    const result = await runOpenAiAgentsSdkAgent({
+      plan,
+      model: "openai/gpt-5.4-mini" as AvailableModel,
+      logger: new EvalLogger(false),
+      toolAdapter: adapter,
+      sdk,
+    });
+
+    // Dev-supplied instructions ARE the skill-arm prompt — nothing else.
+    expect(capturedAgentConfig?.instructions).toBe(
+      BARE_LOOP_DEFAULT_SYSTEM_PROMPT,
+    );
+    expect(capturedAgentConfig?.model).toBe("gpt-5.4-mini");
+    expect(capturedRunOptions?.maxTurns).toBe(9);
+    expect(capturedInput).toContain("Find the checkout button");
+    expect(result._success).toBe(true);
+    expect(result.finalAnswer).toBe("checkout");
+    const metrics = result.metrics as Record<string, { value: number }>;
+    expect(metrics.openai_agents_sdk_tool_calls.value).toBe(1);
+    expect(metrics.openai_agents_sdk_input_tokens.value).toBe(140);
+    expect(metrics.openai_agents_sdk_output_tokens.value).toBe(35);
+  });
+
+  it("returns a failed task result instead of throwing on SDK errors", async () => {
+    const adapter = await makeAdapter();
+    const sdk: OpenAiAgentsSdk = {
+      tool: (options) => ({ options }),
+      Agent: class {} as unknown as OpenAiAgentsSdk["Agent"],
+      run: async () => {
+        throw new Error("Max turns (40) exceeded");
+      },
+    };
+
+    const result = await runOpenAiAgentsSdkAgent({
+      plan,
+      model: "openai/gpt-5.4-mini" as AvailableModel,
+      logger: new EvalLogger(false),
+      toolAdapter: adapter,
+      sdk,
+    });
+
+    expect(result._success).toBe(false);
+    expect(result.openai_agents_sdkStatus).toBe("error");
+    expect(result.openai_agents_sdkStopReason).toContain("Max turns");
+  });
+});

--- a/packages/evals/tests/framework/openaiAgentsSdkRunner.test.ts
+++ b/packages/evals/tests/framework/openaiAgentsSdkRunner.test.ts
@@ -111,7 +111,7 @@ describe("openai_agents_sdk runner", () => {
       sdk,
     });
 
-    // Dev-supplied instructions ARE the skill-arm prompt — nothing else.
+    // Dev-supplied instructions ARE the skill-mode prompt — nothing else.
     expect(capturedAgentConfig?.instructions).toBe(
       BARE_LOOP_DEFAULT_SYSTEM_PROMPT,
     );

--- a/packages/evals/tests/framework/openaiAgentsSdkRunner.test.ts
+++ b/packages/evals/tests/framework/openaiAgentsSdkRunner.test.ts
@@ -122,6 +122,8 @@ describe("openai_agents_sdk runner", () => {
     expect(result.finalAnswer).toBe("checkout");
     const metrics = result.metrics as Record<string, { value: number }>;
     expect(metrics.openai_agents_sdk_tool_calls.value).toBe(1);
+    // Steps count model turns (rawResponses entries), not tool calls.
+    expect(metrics.openai_agents_sdk_steps.value).toBe(2);
     expect(metrics.openai_agents_sdk_input_tokens.value).toBe(140);
     expect(metrics.openai_agents_sdk_output_tokens.value).toBe(35);
   });

--- a/packages/evals/tests/framework/openaiAgentsSdkRunner.test.ts
+++ b/packages/evals/tests/framework/openaiAgentsSdkRunner.test.ts
@@ -178,7 +178,7 @@ describe("openai_agents_sdk runner", () => {
     });
 
     expect(result._success).toBe(false);
-    expect(result.openaiAgentsSdkStatus).toBe("completed");
+    expect(result.openaiAgentsSdkStatus).toBe("aborted");
     expect(result.openaiAgentsSdkStopReason).toContain("step cap reached (3)");
   });
 
@@ -202,7 +202,73 @@ describe("openai_agents_sdk runner", () => {
       sdk,
     });
 
-    expect(result.openaiAgentsSdkStatus).toBe("completed");
+    expect(result.openaiAgentsSdkStatus).toBe("aborted");
     expect(result.openaiAgentsSdkStopReason).toContain("step cap reached (5)");
+  });
+
+  it("recovers real usage and turn count from the exception's state instead of reporting 0/0", async () => {
+    const adapter = await makeAdapter();
+    process.env.EVAL_OPENAI_AGENTS_SDK_MAX_TURNS = "10";
+
+    const sdk: OpenAiAgentsSdk = {
+      tool: (options) => ({ options }),
+      Agent: class {} as unknown as OpenAiAgentsSdk["Agent"],
+      run: async () => {
+        // Real AgentsError subclasses (MaxTurnsExceededError included) carry
+        // a `state` property with a real `usage` getter and `_currentTurn`.
+        const error = new Error("Max turns (10) exceeded");
+        error.name = "MaxTurnsExceededError";
+        Object.assign(error, {
+          state: {
+            usage: { inputTokens: 8000, outputTokens: 900, totalTokens: 9200 },
+            _currentTurn: 10,
+          },
+        });
+        throw error;
+      },
+    };
+
+    const result = await runOpenAiAgentsSdkAgent({
+      plan,
+      model: "openai/gpt-5.4-mini" as AvailableModel,
+      logger: new EvalLogger(false),
+      toolAdapter: adapter,
+      sdk,
+    });
+
+    expect(result.openaiAgentsSdkStatus).toBe("aborted");
+    const metrics = result.metrics as Record<string, { value: number }>;
+    expect(metrics.openai_agents_sdk_input_tokens.value).toBe(8000);
+    expect(metrics.openai_agents_sdk_output_tokens.value).toBe(900);
+    expect(metrics.openai_agents_sdk_total_tokens.value).toBe(9200);
+    expect(metrics.openai_agents_sdk_steps.value).toBe(10);
+  });
+
+  it("prefers the SDK's reported totalTokens over the recomputed input+output sum on a clean run", async () => {
+    const adapter = await makeAdapter();
+    const sdk: OpenAiAgentsSdk = {
+      tool: (options) => ({ options }),
+      Agent: class {} as unknown as OpenAiAgentsSdk["Agent"],
+      run: async () => ({
+        finalOutput:
+          'EVAL_RESULT: {"success":true,"summary":"done","finalAnswer":"checkout"}',
+        rawResponses: [
+          { usage: { inputTokens: 100, outputTokens: 25, totalTokens: 130 } },
+        ],
+      }),
+    };
+
+    const result = await runOpenAiAgentsSdkAgent({
+      plan,
+      model: "openai/gpt-5.4-mini" as AvailableModel,
+      logger: new EvalLogger(false),
+      toolAdapter: adapter,
+      sdk,
+    });
+
+    const metrics = result.metrics as Record<string, { value: number }>;
+    // Real totalTokens (130) happens to equal input+output here -- the point
+    // is it's sourced from the SDK's own field, not recomputed blind.
+    expect(metrics.openai_agents_sdk_total_tokens.value).toBe(130);
   });
 });

--- a/packages/evals/tests/framework/openaiAgentsSdkRunner.test.ts
+++ b/packages/evals/tests/framework/openaiAgentsSdkRunner.test.ts
@@ -132,7 +132,7 @@ describe("openai_agents_sdk runner", () => {
       tool: (options) => ({ options }),
       Agent: class {} as unknown as OpenAiAgentsSdk["Agent"],
       run: async () => {
-        throw new Error("Max turns (40) exceeded");
+        throw new Error("network error talking to the model provider");
       },
     };
 
@@ -145,7 +145,62 @@ describe("openai_agents_sdk runner", () => {
     });
 
     expect(result._success).toBe(false);
-    expect(result.openai_agents_sdkStatus).toBe("error");
-    expect(result.openai_agents_sdkStopReason).toContain("Max turns");
+    expect(result.openaiAgentsSdkStatus).toBe("error");
+    expect(result.openaiAgentsSdkStopReason).toContain("network error");
+  });
+
+  it("stops at the max-turns cap and reports it as the shared step-cap stop reason", async () => {
+    const adapter = await makeAdapter();
+    process.env.EVAL_OPENAI_AGENTS_SDK_MAX_TURNS = "3";
+
+    const sdk: OpenAiAgentsSdk = {
+      tool: (options) => ({ options }),
+      Agent: class {} as unknown as OpenAiAgentsSdk["Agent"],
+      run: async () => {
+        // Real @openai/agents-core throws instead of returning a truncated
+        // result; AgentsError's constructor sets `this.name = new.target.name`,
+        // so a real MaxTurnsExceededError instance has this exact name +
+        // message shape (see turnPreparation.js).
+        const error = new Error("Max turns (3) exceeded");
+        error.name = "MaxTurnsExceededError";
+        throw error;
+      },
+    };
+
+    const result = await runOpenAiAgentsSdkAgent({
+      plan,
+      model: "openai/gpt-5.4-mini" as AvailableModel,
+      logger: new EvalLogger(false),
+      toolAdapter: adapter,
+      sdk,
+    });
+
+    expect(result._success).toBe(false);
+    expect(result.openaiAgentsSdkStatus).toBe("completed");
+    expect(result.openaiAgentsSdkStopReason).toContain("step cap reached (3)");
+  });
+
+  it("recognizes the max-turns message shape even without the SDK's error name", async () => {
+    const adapter = await makeAdapter();
+    process.env.EVAL_OPENAI_AGENTS_SDK_MAX_TURNS = "5";
+
+    const sdk: OpenAiAgentsSdk = {
+      tool: (options) => ({ options }),
+      Agent: class {} as unknown as OpenAiAgentsSdk["Agent"],
+      run: async () => {
+        throw new Error("Max turns (5) exceeded");
+      },
+    };
+
+    const result = await runOpenAiAgentsSdkAgent({
+      plan,
+      model: "openai/gpt-5.4-mini" as AvailableModel,
+      logger: new EvalLogger(false),
+      toolAdapter: adapter,
+      sdk,
+    });
+
+    expect(result.openaiAgentsSdkStatus).toBe("completed");
+    expect(result.openaiAgentsSdkStopReason).toContain("step cap reached (5)");
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -344,6 +344,9 @@ importers:
       '@browserbasehq/stagehand':
         specifier: workspace:*
         version: link:../core
+      '@openai/agents':
+        specifier: 0.13.0
+        version: 0.13.0(@aws-sdk/credential-provider-node@3.972.49)(@cfworker/json-schema@4.1.1)(@smithy/signature-v4@5.4.6)(bufferutil@4.0.9)(ws@8.21.0(bufferutil@4.0.9))(zod@4.2.1)
       '@openai/codex-sdk':
         specifier: 0.125.0
         version: 0.125.0
@@ -1907,6 +1910,29 @@ packages:
   '@oclif/plugin-warn-if-update-available@3.1.65':
     resolution: {integrity: sha512-HcSJc8SeCVUBHwc063xDL0LcpdjcamAISlisSX14VDDYQayMantvtVNOo9PmciwYpXRXfAykeH1z066YkA9JvQ==}
     engines: {node: '>=18.0.0'}
+
+  '@openai/agents-core@0.13.0':
+    resolution: {integrity: sha512-Y1ld/hKE1wa9UqII6fcN7FbPxUhAeREndX76xMfFj6cAJWMl8LkwV6cyNuq3rXuWr1h7YkVCPhK4Do4VoVKwCw==}
+    peerDependencies:
+      zod: ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@openai/agents-openai@0.13.0':
+    resolution: {integrity: sha512-cKlRgXnIOpJtDiI0l4JGp4SX9eQj6H2UPVKZNGH1ERJI3HG5TBmhxVIOm+XBKtiKyg4jEd0ES9LFSvy2Tygmxg==}
+    peerDependencies:
+      zod: ^4.0.0
+
+  '@openai/agents-realtime@0.13.0':
+    resolution: {integrity: sha512-DVKNCsTXcxjjCcufWSbTRjQzm8adm1cV9BwOjU0yGXTAA9+ohS1gWj82np0dsD8hIvGjMQpeZlnQjTKpcl3QRg==}
+    peerDependencies:
+      zod: ^4.0.0
+
+  '@openai/agents@0.13.0':
+    resolution: {integrity: sha512-8rMgMPSJR7fDVX/4nn6vCwqmJvmtR754U0scsrsoMo9iHyfTDdtyPQALoMaqMDeLCJsWV4BFvdEeevgbCbeDdw==}
+    peerDependencies:
+      zod: ^4.0.0
 
   '@openai/codex-sdk@0.125.0':
     resolution: {integrity: sha512-1xCIHdSbQVF880nJ2aVWdPIsWZbSpKODwuP9y/gvtChDYhYfYEW0DKp2H8ZlctkzIjlzS/WzYmP6ZZPHIvs2Dg==}
@@ -5776,6 +5802,26 @@ packages:
       ws: ^8.20.1
       zod: ^3.23.8
     peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
+  openai@6.45.0:
+    resolution: {integrity: sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==}
+    peerDependencies:
+      '@aws-sdk/credential-provider-node': '>=3.972.0 <4'
+      '@smithy/hash-node': '>=4.3.0 <5'
+      '@smithy/signature-v4': '>=5.4.0 <6'
+      ws: ^8.20.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@aws-sdk/credential-provider-node':
+        optional: true
+      '@smithy/hash-node':
+        optional: true
+      '@smithy/signature-v4':
+        optional: true
       ws:
         optional: true
       zod:
@@ -9664,6 +9710,69 @@ snapshots:
       registry-auth-token: 5.1.1
     transitivePeerDependencies:
       - supports-color
+
+  '@openai/agents-core@0.13.0(@aws-sdk/credential-provider-node@3.972.49)(@cfworker/json-schema@4.1.1)(@smithy/signature-v4@5.4.6)(ws@8.21.0(bufferutil@4.0.9))(zod@4.2.1)':
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      openai: 6.45.0(@aws-sdk/credential-provider-node@3.972.49)(@smithy/signature-v4@5.4.6)(ws@8.21.0(bufferutil@4.0.9))(zod@4.2.1)
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.2.1)
+      zod: 4.2.1
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-node'
+      - '@cfworker/json-schema'
+      - '@smithy/hash-node'
+      - '@smithy/signature-v4'
+      - supports-color
+      - ws
+
+  '@openai/agents-openai@0.13.0(@aws-sdk/credential-provider-node@3.972.49)(@cfworker/json-schema@4.1.1)(@smithy/signature-v4@5.4.6)(ws@8.21.0(bufferutil@4.0.9))(zod@4.2.1)':
+    dependencies:
+      '@openai/agents-core': 0.13.0(@aws-sdk/credential-provider-node@3.972.49)(@cfworker/json-schema@4.1.1)(@smithy/signature-v4@5.4.6)(ws@8.21.0(bufferutil@4.0.9))(zod@4.2.1)
+      debug: 4.4.3(supports-color@8.1.1)
+      openai: 6.45.0(@aws-sdk/credential-provider-node@3.972.49)(@smithy/signature-v4@5.4.6)(ws@8.21.0(bufferutil@4.0.9))(zod@4.2.1)
+      zod: 4.2.1
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-node'
+      - '@cfworker/json-schema'
+      - '@smithy/hash-node'
+      - '@smithy/signature-v4'
+      - supports-color
+      - ws
+
+  '@openai/agents-realtime@0.13.0(@aws-sdk/credential-provider-node@3.972.49)(@cfworker/json-schema@4.1.1)(@smithy/signature-v4@5.4.6)(bufferutil@4.0.9)(zod@4.2.1)':
+    dependencies:
+      '@openai/agents-core': 0.13.0(@aws-sdk/credential-provider-node@3.972.49)(@cfworker/json-schema@4.1.1)(@smithy/signature-v4@5.4.6)(ws@8.21.0(bufferutil@4.0.9))(zod@4.2.1)
+      '@types/ws': 8.18.1
+      debug: 4.4.3(supports-color@8.1.1)
+      ws: 8.21.0(bufferutil@4.0.9)
+      zod: 4.2.1
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-node'
+      - '@cfworker/json-schema'
+      - '@smithy/hash-node'
+      - '@smithy/signature-v4'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@openai/agents@0.13.0(@aws-sdk/credential-provider-node@3.972.49)(@cfworker/json-schema@4.1.1)(@smithy/signature-v4@5.4.6)(bufferutil@4.0.9)(ws@8.21.0(bufferutil@4.0.9))(zod@4.2.1)':
+    dependencies:
+      '@openai/agents-core': 0.13.0(@aws-sdk/credential-provider-node@3.972.49)(@cfworker/json-schema@4.1.1)(@smithy/signature-v4@5.4.6)(ws@8.21.0(bufferutil@4.0.9))(zod@4.2.1)
+      '@openai/agents-openai': 0.13.0(@aws-sdk/credential-provider-node@3.972.49)(@cfworker/json-schema@4.1.1)(@smithy/signature-v4@5.4.6)(ws@8.21.0(bufferutil@4.0.9))(zod@4.2.1)
+      '@openai/agents-realtime': 0.13.0(@aws-sdk/credential-provider-node@3.972.49)(@cfworker/json-schema@4.1.1)(@smithy/signature-v4@5.4.6)(bufferutil@4.0.9)(zod@4.2.1)
+      debug: 4.4.3(supports-color@8.1.1)
+      openai: 6.45.0(@aws-sdk/credential-provider-node@3.972.49)(@smithy/signature-v4@5.4.6)(ws@8.21.0(bufferutil@4.0.9))(zod@4.2.1)
+      zod: 4.2.1
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-node'
+      - '@cfworker/json-schema'
+      - '@smithy/hash-node'
+      - '@smithy/signature-v4'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
 
   '@openai/codex-sdk@0.125.0':
     dependencies:
@@ -14524,6 +14633,13 @@ snapshots:
       zod: 4.2.1
     transitivePeerDependencies:
       - encoding
+
+  openai@6.45.0(@aws-sdk/credential-provider-node@3.972.49)(@smithy/signature-v4@5.4.6)(ws@8.21.0(bufferutil@4.0.9))(zod@4.2.1):
+    optionalDependencies:
+      '@aws-sdk/credential-provider-node': 3.972.49
+      '@smithy/signature-v4': 5.4.6
+      ws: 8.21.0(bufferutil@4.0.9)
+      zod: 4.2.1
 
   openapi-types@12.1.3: {}
 


### PR DESCRIPTION
## What

**Part 4 of 5 — stacked on #2339 (`anthropic_sdk`)** (base: `shrey/evals-harness-anthropic-sdk`; GitHub shows only this PR's delta). When the parent merges, retarget this PR's base and rebase.

Registers `--harness openai_agents_sdk` via `@openai/agents` (6.8M PyPI dl/wk for the Python twin). Classification: **bare-ish** — one notch above the raw provider loops. The SDK runs its own agent loop (turn management, tool dispatch, tracing) but ships no behavioral scaffolding: everything the agent knows comes from the dev-supplied `instructions` string, which carries only the configured skill-arm prompt. **SDK defaults untouched except `maxTurns`** (the SDK's own default of 10 is far too low for a browse task; shared 40 default, `EVAL_OPENAI_AGENTS_SDK_MAX_TURNS` override).

- OpenAI models only (`openai/` prefix stripped; other providers rejected loudly).
- Tool parameters use a plain JSON schema instead of a zod schema to sidestep the SDK's zod version coupling (packages/evals pins zod v4).
- Usage summed from `result.rawResponses`.
- Adds the `@openai/agents` dependency (pinned 0.13.0) — this PR carries its own lockfile delta.
- Testability: `sdk` injection seam ({ Agent, run, tool } mock).

External harnesses design + usage: [`packages/evals/README.md#external-harnesses`](https://github.com/browserbase/stagehand/blob/shrey/evals-bareloop-harnesses/packages/evals/README.md#external-harnesses) (in #2337). Linear: STG-2515.

## Comparability fix (2026-07-09 audit)

`@openai/agents-core` throws `MaxTurnsExceededError` (`"Max turns (N) exceeded"`, `error.name === "MaxTurnsExceededError"` per `AgentsError`'s `this.name = new.target.name`) instead of returning a truncated result the way vercel_ai_sdk/anthropic_sdk do — the generic catch was folding that into `openaiAgentsSdkStatus: "error"`, reporting the shared step cap as a harness/SDK failure. Now detects it (by error name, with a message-shape regex fallback for robustness) and reports `status: "complete"` + the same `step cap reached (N)` stopReason `anthropic_sdk` (#2339) uses. The previous single "SDK errors" test (which happened to throw exactly this message and was silently exercising the bug) is now three tests: a genuine unrelated SDK error (still "error"), the real `MaxTurnsExceededError`-shaped throw hitting the cap, and the bare message-shape fallback without the SDK's error name.

## E2E Test Matrix

Live smoke ran on the pre-split combined branch (content identical to this stack's tip — verified by diff); results transplanted, not rerun.

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `evals run b:webtailbench --harness openai_agents_sdk -m openai/gpt-5.4-mini -l 1 -t 1 -c 1` (local build, real OPENAI + GEMINI keys, local Chrome via browse CLI) | Run completed (exit 0). 10 `browse` tool calls recorded; trajectory persisted; verifier graded: `outcomeSuccess=false`, `processScore=1.0`, 5 rubric criteria, **no verifierError**. Clean final answer: "No reliable flight availability/pricing could be retrieved for United direct flights ..." Usage: 24k in / 0.5k out tokens | Bar met: harness completes, trajectory captured, graded outcome, no verifierError. Task pass/fail is NOT the bar (united.com flights); process=1.0 with outcome=false is the verifier saying "sound procedure, unreachable goal" |
| `pnpm exec vitest run` (this branch) | `Test Files 52 passed, Tests 380 passed` — adds `openaiAgentsSdkRunner.test.ts` (instructions === verbatim arm prompt only, maxTurns passthrough, JSON-schema tool execution against a real temp binary, usage summing, model-prefix validation, MaxTurnsExceeded folding) | Mocked-SDK loop coverage; live behavior proven by the smoke row above |
| `tsc --noEmit` + prettier + eslint | clean | Types/style only |
| `pnpm exec vitest run` (this branch, post-fix) | `Test Files 52 passed, Tests 385 passed` — MaxTurnsExceeded now correctly reported as `status: "completed"` + `step cap reached (N)` (2 new dedicated tests: real error-name shape, message-shape fallback); the pre-existing "SDK errors" test now throws a genuinely unrelated error to keep testing the generic-error path | Proves the cap is no longer misreported as a harness failure, without losing coverage of real SDK errors |
| `pnpm -w exec tsc --noEmit` + prettier + eslint (post-fix) | clean | Types/style only |

## Tier 1 fixes (post-review audit, 2026-07-14)

An independent audit found a live-reproducible bug: `sdk.run()` never returns on a max-turns exception, so `usage`/`modelTurns` stayed at their zero/undefined initial values -- a real 10-turn capped run persisted `input_tokens: 0, output_tokens: 0`. Fixed here:

- **Real usage/turn count recovered from the exception's own state.** The real `@openai/agents-core` `AgentsError` (base of `MaxTurnsExceededError`) carries a `state?: RunState` -- `RunState.usage` is a getter with real `inputTokens`/`outputTokens`/`totalTokens`, and `_currentTurn` is a public field with the real turn count. Both are now extracted in the max-turns catch branch instead of left at zero.
- **Step-cap runs reported `"complete"`, not `"aborted"`** -- same bug pattern as vercel_ai_sdk, same fix.
- **`total_tokens` now prefers the SDK's own `Usage.totalTokens`** over a recomputed input+output sum, on both the normal-return and exception paths.
- Updated the tool `execute` callback for `BareLoopToolRecorder.execute()`'s new `{ ok, output }` return shape (base PR).

Verified: `pnpm --filter @browserbasehq/stagehand-evals build && lint && test:unit` -- `Test Files 57 passed, Tests 437 passed` (2 new tests: state-based usage/turn recovery, totalTokens preference). Live: a real Browserbase local trial with `EVAL_OPENAI_AGENTS_SDK_MAX_TURNS=3` hit the real max-turns cap and the persisted trajectory recorded `"status": "aborted"` (not the old `0/0` usage bug -- confirmed the model's real tool calls, including a rejected `skills show` under `skillMode=none`, were captured).


No changeset: `packages/evals` is private.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



