### PR TITLE
fix: wait for the locator world when a deep XPath crosses an iframe

### DIFF
--- a/.changeset/iframe-locator-world-readiness.md
+++ b/.changeset/iframe-locator-world-readiness.md
@@ -1,0 +1,8 @@
+---
+"@browserbasehq/stagehand-extension": patch
+"@browserbasehq/stagehand": patch
+"@browserbasehq/stagehand-python": patch
+"@browserbasehq/stagehand-go": patch
+---
+
+Wait for delayed iframe locator worlds on genuine frame hops, and keep trailing iframe XPaths in the parent frame.

--- a/packages/extension/tests/deep-locator.test.ts
+++ b/packages/extension/tests/deep-locator.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { planDeepXPathTarget } from "../understudy/deepLocator.js";
+
+describe("planDeepXPathTarget", () => {
+  it("keeps a trailing iframe as the parent-frame selector (no hop)", () => {
+    expect(planDeepXPathTarget("xpath=/html/body/iframe[1]")).toEqual({
+      frameHopSelectors: [],
+      finalSelector: "xpath=/html/body/iframe[1]",
+    });
+  });
+
+  it("hops into an iframe when further steps follow", () => {
+    expect(planDeepXPathTarget("xpath=/html/iframe[1]/html/body/button")).toEqual({
+      frameHopSelectors: ["xpath=/html/iframe[1]"],
+      finalSelector: "xpath=/html/body/button",
+    });
+  });
+
+  it("hops once then keeps a nested trailing iframe as the in-frame target", () => {
+    expect(planDeepXPathTarget("xpath=/html/iframe[1]/html/iframe[2]")).toEqual({
+      frameHopSelectors: ["xpath=/html/iframe[1]"],
+      finalSelector: "xpath=/html/iframe[2]",
+    });
+  });
+
+  it("supports nested crossing iframes", () => {
+    expect(planDeepXPathTarget("xpath=/html/iframe[1]/html/iframe[2]/html/body/button")).toEqual({
+      frameHopSelectors: ["xpath=/html/iframe[1]", "xpath=/html/iframe[2]"],
+      finalSelector: "xpath=/html/body/button",
+    });
+  });
+
+  it("treats frame the same as iframe for hop detection", () => {
+    expect(planDeepXPathTarget("/html/body/frame[1]/html/body/div")).toEqual({
+      frameHopSelectors: ["xpath=/html/body/frame[1]"],
+      finalSelector: "xpath=/html/body/div",
+    });
+  });
+});

--- a/packages/extension/tests/frame-locator.test.ts
+++ b/packages/extension/tests/frame-locator.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { CDPSessionLike } from "../understudy/cdp.js";
+import { executionContexts } from "../understudy/executionContextRegistry.js";
+import type { Frame } from "../understudy/frame.js";
+import { FrameLocator } from "../understudy/frameLocator.js";
+import type { Page } from "../understudy/page.js";
+
+function createSession(id: string): CDPSessionLike {
+  const send = vi.fn(async (method: string): Promise<unknown> => {
+    if (method === "DOM.describeNode") return { node: { backendNodeId: 1 } };
+    if (method === "DOM.getFrameOwner") return { backendNodeId: 1 };
+    return {};
+  });
+  return {
+    id,
+    send: send as CDPSessionLike["send"],
+    on: vi.fn(),
+    off: vi.fn(),
+    close: vi.fn(),
+  };
+}
+
+function createFrameLocator(
+  initialSession: CDPSessionLike,
+  getSessionForFrame: () => CDPSessionLike,
+): { locator: FrameLocator; childFrame: Frame } {
+  const childFrame = { frameId: "child" } as Frame;
+  const root = {
+    frameId: "parent",
+    session: initialSession,
+    locator: () => ({
+      resolveNode: async () => ({ objectId: "iframe-object" }),
+    }),
+  } as unknown as Frame;
+  const page = {
+    getFullFrameTree: () => ({
+      frame: { id: "parent" },
+      childFrames: [{ frame: { id: "child" } }],
+    }),
+    getSessionForFrame,
+    frameForId: () => childFrame,
+  } as unknown as Page;
+
+  return {
+    locator: new FrameLocator(page, "xpath=/html/body/iframe[1]", undefined, root),
+    childFrame,
+  };
+}
+
+describe("FrameLocator readiness", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("propagates readiness failures after finding the matching child frame", async () => {
+    const session = createSession("session-a");
+    const readinessError = new Error("Stagehand extension world not ready for frame child");
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    vi.spyOn(executionContexts, "waitForLocatorWorld").mockImplementation(async () => {
+      vi.setSystemTime(15_000);
+      throw readinessError;
+    });
+    const { locator } = createFrameLocator(session, () => session);
+
+    await expect(locator.resolveFrame()).rejects.toBe(readinessError);
+  });
+
+  it("retries readiness when OOPIF ownership changes during an attempt", async () => {
+    const oldSession = createSession("session-a");
+    const adoptedSession = createSession("session-b");
+    const getSessionForFrame = vi
+      .fn<() => CDPSessionLike>()
+      .mockReturnValueOnce(oldSession)
+      .mockReturnValue(adoptedSession);
+    const waitForLocatorWorld = vi
+      .spyOn(executionContexts, "waitForLocatorWorld")
+      .mockResolvedValue({
+        kind: "extension",
+        contextId: 1,
+        capabilities: { closedShadowRoots: true },
+      });
+    const { locator, childFrame } = createFrameLocator(oldSession, getSessionForFrame);
+
+    await expect(locator.resolveFrame()).resolves.toBe(childFrame);
+    expect(waitForLocatorWorld).toHaveBeenNthCalledWith(1, oldSession, "child", 200);
+    expect(waitForLocatorWorld).toHaveBeenNthCalledWith(2, adoptedSession, "child", 200);
+  });
+});

--- a/packages/extension/understudy/deepLocator.ts
+++ b/packages/extension/understudy/deepLocator.ts
@@ -212,34 +212,49 @@ export function deepLocatorFromPage(
   return new DeepLocatorDelegate(page, root, selector);
 }
 
-async function resolveDeepXPathTarget(
-  page: Page,
-  root: Frame,
-  xpathOrSelector: string,
-): Promise<ResolvedLocatorTarget> {
+/**
+ * Plan deep-XPath frame hops without resolving frames.
+ * An iframe/frame step becomes a hop only when further selector steps follow it,
+ * so a trailing iframe remains a parent-frame element target.
+ */
+export function planDeepXPathTarget(xpathOrSelector: string): {
+  frameHopSelectors: string[];
+  finalSelector: string;
+} {
   let path = xpathOrSelector.trim();
   if (path.startsWith("xpath=")) path = path.slice("xpath=".length).trim();
   if (!path.startsWith("/")) path = "/" + path;
 
   const steps = parseXPath(path);
-  let fl: FrameLocator | undefined;
+  const frameHopSelectors: string[] = [];
   let buf: Step[] = [];
 
-  const flushIntoFrameLocator = () => {
-    if (!buf.length) return;
-    const selectorForIframe = "xpath=" + buildXPathFromSteps(buf);
-    fl = fl
-      ? fl.frameLocator(selectorForIframe)
-      : frameLocatorFromFrame(page, root, selectorForIframe);
-    buf = [];
-  };
-
-  for (const st of steps) {
+  for (let i = 0; i < steps.length; i++) {
+    const st = steps[i]!;
     buf.push(st);
-    if (IFRAME_STEP_RE.test(st.name)) flushIntoFrameLocator();
+    const hasStepsAfter = i < steps.length - 1;
+    if (IFRAME_STEP_RE.test(st.name) && hasStepsAfter) {
+      frameHopSelectors.push("xpath=" + buildXPathFromSteps(buf));
+      buf = [];
+    }
   }
 
-  const finalSelector = "xpath=" + buildXPathFromSteps(buf);
+  return {
+    frameHopSelectors,
+    finalSelector: "xpath=" + buildXPathFromSteps(buf),
+  };
+}
+
+async function resolveDeepXPathTarget(
+  page: Page,
+  root: Frame,
+  xpathOrSelector: string,
+): Promise<ResolvedLocatorTarget> {
+  const plan = planDeepXPathTarget(xpathOrSelector);
+  let fl: FrameLocator | undefined;
+  for (const hop of plan.frameHopSelectors) {
+    fl = fl ? fl.frameLocator(hop) : frameLocatorFromFrame(page, root, hop);
+  }
   const targetFrame = fl ? await fl.resolveFrame() : root;
-  return { frame: targetFrame, selector: finalSelector };
+  return { frame: targetFrame, selector: plan.finalSelector };
 }

--- a/packages/extension/understudy/frameLocator.ts
+++ b/packages/extension/understudy/frameLocator.ts
@@ -4,6 +4,11 @@ import type { Page } from "./page.js";
 import { Frame } from "./frame.js";
 import { executionContexts } from "./executionContextRegistry.js";
 
+/** Bounded wait only for genuine frame transitions (not same-frame locator ops). */
+const FRAME_LOCATOR_READY_TIMEOUT_MS = 15_000;
+/** Cap each locator-world wait so OOPIF session ownership can be re-resolved. */
+const SESSION_RECHECK_MS = 200;
+
 /**
  * FrameLocator: resolves iframe elements to their child Frames and allows
  * creating locators scoped to that frame. Supports chaining.
@@ -59,7 +64,7 @@ export class FrameLocator {
           }>("DOM.getFrameOwner", { frameId: fid as Protocol.Page.FrameId });
           if (owner.backendNodeId === iframeBackendNodeId) {
             // Ensure child frame is ready (handles OOPIF adoption or same-process)
-            await ensureChildFrameReady(this.page, parentFrame, fid, 1200);
+            await ensureChildFrameReady(this.page, fid, FRAME_LOCATOR_READY_TIMEOUT_MS);
             return this.page.frameForId(fid);
           }
         } catch {
@@ -186,90 +191,34 @@ function findFrameNode(
 }
 
 /**
- * Ensure we can evaluate in the child frame with minimal delay.
- * - If the child is same-process: parent session owns it and main world appears quickly.
- * - If OOPIF and adoption not finished: wait briefly for ownership change, then main world.
+ * Block until the Stagehand locator/extension world is usable in the child frame.
+ * Re-resolves CDP session ownership on each attempt so OOPIF adoption cannot pin
+ * the wait to a stale session for the full budget.
  */
 async function ensureChildFrameReady(
   page: Page,
-  parentFrame: Frame,
   childFrameId: string,
   budgetMs: number,
 ): Promise<void> {
-  const parentSession = parentFrame.session;
   const deadline = Date.now() + Math.max(0, budgetMs);
+  let lastError: unknown;
 
-  // If already owned by a different session (OOPIF adopted), wait briefly there.
-  const owner = page.getSessionForFrame(childFrameId);
-  if (owner && owner !== parentSession) {
+  while (Date.now() < deadline) {
+    const session = page.getSessionForFrame(childFrameId);
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
     try {
-      await executionContexts.waitForMainWorld(owner, childFrameId, 600);
-    } catch {
-      // best effort
+      await executionContexts.waitForLocatorWorld(
+        session,
+        childFrameId,
+        Math.min(remaining, SESSION_RECHECK_MS),
+      );
+      return;
+    } catch (error) {
+      lastError = error;
     }
-    return;
   }
 
-  const hasMainWorldOnParent = (): boolean => {
-    try {
-      return executionContexts.getMainWorld(parentSession, childFrameId) !== null;
-    } catch {
-      return false;
-    }
-  };
-
-  if (hasMainWorldOnParent()) return;
-
-  await parentSession.send("Page.setLifecycleEventsEnabled", { enabled: true }).catch(() => {});
-  await parentSession.send("Runtime.enable").catch(() => {});
-
-  await new Promise<void>((resolve) => {
-    let done = false;
-    const finish = () => {
-      if (done) return;
-      done = true;
-      parentSession.off("Page.lifecycleEvent", onLifecycle);
-      resolve();
-    };
-    const onLifecycle = (evt: Protocol.Page.LifecycleEventEvent) => {
-      if (
-        evt.frameId !== childFrameId ||
-        (evt.name !== "DOMContentLoaded" &&
-          evt.name !== "load" &&
-          evt.name !== "networkIdle" &&
-          evt.name !== "networkidle")
-      ) {
-        return;
-      }
-      if (hasMainWorldOnParent()) return finish();
-      try {
-        const nowOwner = page.getSessionForFrame(childFrameId);
-        if (nowOwner && nowOwner !== parentSession) {
-          const left = Math.max(150, deadline - Date.now());
-          void executionContexts.waitForMainWorld(nowOwner, childFrameId, left).finally(finish);
-        }
-      } catch {
-        // ignore
-      }
-    };
-    parentSession.on("Page.lifecycleEvent", onLifecycle);
-
-    const tick = () => {
-      if (done) return;
-      if (hasMainWorldOnParent()) return finish();
-      try {
-        const nowOwner = page.getSessionForFrame(childFrameId);
-        if (nowOwner && nowOwner !== parentSession) {
-          const left = Math.max(150, deadline - Date.now());
-          void executionContexts.waitForMainWorld(nowOwner, childFrameId, left).finally(finish);
-          return;
-        }
-      } catch {
-        // ignore
-      }
-      if (Date.now() >= deadline) return finish();
-      setTimeout(tick, 50);
-    };
-    tick();
-  });
+  if (lastError instanceof Error) throw lastError;
+  throw new Error(`Locator world not ready for frame ${childFrameId}`);
 }

--- a/packages/extension/understudy/frameLocator.ts
+++ b/packages/extension/understudy/frameLocator.ts
@@ -6,8 +6,11 @@ import { executionContexts } from "./executionContextRegistry.js";
 
 /** Bounded wait only for genuine frame transitions (not same-frame locator ops). */
 const FRAME_LOCATOR_READY_TIMEOUT_MS = 15_000;
-/** Cap each locator-world wait so OOPIF session ownership can be re-resolved. */
-const SESSION_RECHECK_MS = 200;
+/**
+ * Best-effort timeout for each locator-world attempt. Fallback eligibility can
+ * extend an attempt while it waits for the main world.
+ */
+const LOCATOR_WORLD_ATTEMPT_TIMEOUT_MS = 200;
 
 /**
  * FrameLocator: resolves iframe elements to their child Frames and allows
@@ -57,18 +60,23 @@ export class FrameLocator {
       );
 
       for (const fid of childIds) {
+        let owner: {
+          backendNodeId: Protocol.DOM.BackendNodeId;
+          nodeId?: Protocol.DOM.NodeId;
+        };
         try {
-          const owner = await parentSession.send<{
+          owner = await parentSession.send<{
             backendNodeId: Protocol.DOM.BackendNodeId;
             nodeId?: Protocol.DOM.NodeId;
           }>("DOM.getFrameOwner", { frameId: fid as Protocol.Page.FrameId });
-          if (owner.backendNodeId === iframeBackendNodeId) {
-            // Ensure child frame is ready (handles OOPIF adoption or same-process)
-            await ensureChildFrameReady(this.page, fid, FRAME_LOCATOR_READY_TIMEOUT_MS);
-            return this.page.frameForId(fid);
-          }
         } catch {
           // ignore and try next
+          continue;
+        }
+        if (owner.backendNodeId === iframeBackendNodeId) {
+          // Readiness failures must propagate after the matching child is identified.
+          await ensureChildFrameReady(this.page, fid, FRAME_LOCATOR_READY_TIMEOUT_MS);
+          return this.page.frameForId(fid);
         }
       }
       throw new Error(`Unable to obtain a content frame for selector: ${this.selector}`);
@@ -211,9 +219,9 @@ async function ensureChildFrameReady(
       await executionContexts.waitForLocatorWorld(
         session,
         childFrameId,
-        Math.min(remaining, SESSION_RECHECK_MS),
+        Math.min(remaining, LOCATOR_WORLD_ATTEMPT_TIMEOUT_MS),
       );
-      return;
+      if (page.getSessionForFrame(childFrameId) === session) return;
     } catch (error) {
       lastError = error;
     }

--- a/packages/sdk-ts/tests/integration/iframeLocatorReadiness.test.ts
+++ b/packages/sdk-ts/tests/integration/iframeLocatorReadiness.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { Stagehand } from "../../src/index.js";
+import {
+  closeStagehand,
+  createStagehand,
+  firstPage,
+  startFixtureServer,
+  type FixtureServer,
+} from "./_support.js";
+
+const CHILD_DELAY_MS = 4_000;
+const FAST_CLICK_BUDGET_MS = 1_500;
+const XPATH_IFRAME = "xpath=/html[1]/body[1]/div[1]/iframe[1]";
+const XPATH_INNER = "xpath=/html[1]/body[1]/div[1]/iframe[1]/html[1]/body[1]/div[1]/button[1]";
+
+type IframeFixture = {
+  parent: FixtureServer;
+  child: FixtureServer;
+  parentGotoUrl: string;
+  clickCount: () => number;
+  childServed: () => number;
+};
+
+async function createDelayedIframeFixture(options: {
+  /** Absolute iframe src written into the parent HTML. */
+  childSrc: (child: FixtureServer) => string;
+  /** URL passed to page.goto (may use a mapped hostname). */
+  parentGotoUrl: (parent: FixtureServer) => string;
+}): Promise<IframeFixture> {
+  let clickCount = 0;
+  let childServed = 0;
+
+  const child = await startFixtureServer({
+    "/child": async () => {
+      await new Promise((resolve) => setTimeout(resolve, CHILD_DELAY_MS));
+      childServed += 1;
+      return {
+        body: `<!doctype html><html><body style="margin:0">
+<div style="padding:20px">
+  <button id="b" style="width:300px;height:120px"
+    onclick="fetch('/clicked').catch(()=>{})">click me</button>
+</div>
+</body></html>`,
+      };
+    },
+    "/clicked": () => {
+      clickCount += 1;
+      return { headers: { "content-type": "text/plain" }, body: "ok" };
+    },
+  });
+
+  const parent = await startFixtureServer({
+    "/": `<!doctype html><html><body style="margin:0">
+<div style="padding:40px">
+  <iframe src="${options.childSrc(child)}" width="600" height="360"></iframe>
+</div>
+</body></html>`,
+  });
+
+  return {
+    parent,
+    child,
+    parentGotoUrl: options.parentGotoUrl(parent),
+    clickCount: () => clickCount,
+    childServed: () => childServed,
+  };
+}
+
+async function waitForIframeElement(page: Awaited<ReturnType<typeof firstPage>>): Promise<void> {
+  await expect.poll(async () => page.locator("iframe").count(), { timeout: 10_000 }).toBe(1);
+}
+
+describe("iframe locator readiness", () => {
+  const stagehands: Stagehand[] = [];
+  const fixtures: IframeFixture[] = [];
+
+  afterEach(async () => {
+    await Promise.all(stagehands.splice(0).map((stagehand) => closeStagehand(stagehand)));
+    await Promise.all(
+      fixtures.splice(0).map(async (fixture) => {
+        await Promise.all([fixture.parent.close(), fixture.child.close()]);
+      }),
+    );
+  });
+
+  it("same-process trailing iframe XPath clicks without waiting for the child document", async () => {
+    const fixture = await createDelayedIframeFixture({
+      childSrc: (child) => new URL("/child", child.url).href,
+      parentGotoUrl: (parent) => parent.url,
+    });
+    fixtures.push(fixture);
+
+    const stagehand = await createStagehand();
+    stagehands.push(stagehand);
+    const page = await firstPage(stagehand);
+    await page.goto(fixture.parentGotoUrl, { waitUntil: "domcontentloaded" });
+    await waitForIframeElement(page);
+
+    expect(fixture.childServed()).toBe(0);
+    const started = Date.now();
+    await page.locator(XPATH_IFRAME).click();
+    const elapsed = Date.now() - started;
+
+    expect(elapsed).toBeLessThan(FAST_CLICK_BUDGET_MS);
+    expect(fixture.childServed()).toBe(0);
+  });
+
+  it("same-process deep XPath waits for the child and performs a verifiable button action", async () => {
+    const fixture = await createDelayedIframeFixture({
+      childSrc: (child) => new URL("/child", child.url).href,
+      parentGotoUrl: (parent) => parent.url,
+    });
+    fixtures.push(fixture);
+
+    const stagehand = await createStagehand();
+    stagehands.push(stagehand);
+    const page = await firstPage(stagehand);
+    await page.goto(fixture.parentGotoUrl, { waitUntil: "domcontentloaded" });
+    await waitForIframeElement(page);
+
+    expect(fixture.childServed()).toBe(0);
+    const started = Date.now();
+    await page.locator(XPATH_INNER).click();
+    const elapsed = Date.now() - started;
+
+    expect(elapsed).toBeGreaterThanOrEqual(CHILD_DELAY_MS - 500);
+    await expect.poll(() => fixture.clickCount(), { timeout: 5_000 }).toBe(1);
+  });
+
+  it("OOPIF trailing iframe XPath clicks without waiting for the child document", async () => {
+    let childServed = 0;
+    const child = await startFixtureServer({
+      "/child": async () => {
+        await new Promise((resolve) => setTimeout(resolve, CHILD_DELAY_MS));
+        childServed += 1;
+        return {
+          body: `<!doctype html><html><body style="margin:0">
+<div style="padding:20px">
+  <button id="b" style="width:300px;height:120px"
+    onclick="fetch('/clicked').catch(()=>{})">click me</button>
+</div>
+</body></html>`,
+        };
+      },
+    });
+    const childPort = new URL(child.url).port;
+
+    const parent = await startFixtureServer({
+      "/": `<!doctype html><html><body style="margin:0">
+<div style="padding:40px">
+  <iframe src="http://child.test:${childPort}/child" width="600" height="360"></iframe>
+</div>
+</body></html>`,
+    });
+    const parentPort = new URL(parent.url).port;
+    fixtures.push({
+      parent,
+      child,
+      parentGotoUrl: `http://parent.test:${parentPort}/`,
+      clickCount: () => 0,
+      childServed: () => childServed,
+    });
+
+    const stagehand = await createStagehand({
+      browser: {
+        args: [
+          `--host-resolver-rules=MAP parent.test 127.0.0.1:${parentPort},MAP child.test 127.0.0.1:${childPort}`,
+          "--site-per-process",
+        ],
+      },
+    });
+    stagehands.push(stagehand);
+    const page = await firstPage(stagehand);
+    await page.goto(`http://parent.test:${parentPort}/`, { waitUntil: "domcontentloaded" });
+    await waitForIframeElement(page);
+
+    expect(childServed).toBe(0);
+    const started = Date.now();
+    await page.locator(XPATH_IFRAME).click();
+    const elapsed = Date.now() - started;
+
+    expect(elapsed).toBeLessThan(FAST_CLICK_BUDGET_MS);
+    expect(childServed).toBe(0);
+  });
+
+  it("OOPIF deep XPath waits across session adoption and performs a verifiable button action", async () => {
+    let clickCount = 0;
+    let childServed = 0;
+    const child = await startFixtureServer({
+      "/child": async () => {
+        await new Promise((resolve) => setTimeout(resolve, CHILD_DELAY_MS));
+        childServed += 1;
+        return {
+          body: `<!doctype html><html><body style="margin:0">
+<div style="padding:20px">
+  <button id="b" style="width:300px;height:120px"
+    onclick="fetch('/clicked').catch(()=>{})">click me</button>
+</div>
+</body></html>`,
+        };
+      },
+      "/clicked": () => {
+        clickCount += 1;
+        return { headers: { "content-type": "text/plain" }, body: "ok" };
+      },
+    });
+    const childPort = new URL(child.url).port;
+    const parent = await startFixtureServer({
+      "/": `<!doctype html><html><body style="margin:0">
+<div style="padding:40px">
+  <iframe src="http://child.test:${childPort}/child" width="600" height="360"></iframe>
+</div>
+</body></html>`,
+    });
+    const parentPort = new URL(parent.url).port;
+    fixtures.push({
+      parent,
+      child,
+      parentGotoUrl: `http://parent.test:${parentPort}/`,
+      clickCount: () => clickCount,
+      childServed: () => childServed,
+    });
+
+    const stagehand = await createStagehand({
+      browser: {
+        args: [
+          `--host-resolver-rules=MAP parent.test 127.0.0.1:${parentPort},MAP child.test 127.0.0.1:${childPort}`,
+          "--site-per-process",
+        ],
+      },
+    });
+    stagehands.push(stagehand);
+    const page = await firstPage(stagehand);
+    await page.goto(`http://parent.test:${parentPort}/`, { waitUntil: "domcontentloaded" });
+    await waitForIframeElement(page);
+
+    expect(childServed).toBe(0);
+    const started = Date.now();
+    await page.locator(XPATH_INNER).click();
+    const elapsed = Date.now() - started;
+
+    expect(elapsed).toBeGreaterThanOrEqual(CHILD_DELAY_MS - 500);
+    await expect.poll(() => clickCount, { timeout: 5_000 }).toBe(1);
+    expect(childServed).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/scripts/test-integration.ts
+++ b/scripts/test-integration.ts
@@ -37,7 +37,7 @@ export const integrationTestGroups = {
     "contextDomainPolicy",
     "contextExtraHttpHeaders",
   ],
-  "local/frames-shadow": ["coordinateClick", "nestedDiv"],
+  "local/frames-shadow": ["coordinateClick", "iframeLocatorReadiness", "nestedDiv"],
   "local/input": ["clipboard", "keyboard"],
   "local/locators-read": [
     "locatorContentMethods",


### PR DESCRIPTION
Fixes #2324.

> Rebuilt against current v4 `main`. The original implementation in this PR targeted `packages/core/lib/v3/understudy/`, which no longer exists, and waited on the **main world**. v4 fails on the **Stagehand extension/locator world** instead, so this branch was rewritten rather than rebased.

## Why

Clicking through a still-loading iframe fails deterministically on v4:

```
Stagehand extension world not ready for frame <id>; checked contexts: none
```

The same click succeeds immediately once the child document commits. The reproduction in #2324 sharpens the original report in two ways: the trigger is **frame descent** rather than the target element, and it is **not cross-origin specific** — a same-site, in-process delayed iframe fails identically.

That surfaces two distinct defects:

| Case | Selector | Expected | Before |
| --- | --- | --- | --- |
| A. Selector ends at the iframe | `/html/body/iframe[1]` | Stay in the parent document and target the `<iframe>` element | `resolveDeepXPathTarget` flushed the trailing iframe into a `FrameLocator`, entered the child with `xpath=/`, and needed a child execution context it never required |
| B. Selector crosses the iframe | `/html/body/iframe[1]/html/body/button` | Descend, then wait for the child's locator world | `ensureChildFrameReady` waited ~1200ms best-effort for the **main** world and swallowed failures, so evaluation reached the child before the extension world existed |

A plain CSS `iframe` click already worked while loading, which is the semantic target for case A.

## What changed

**`packages/extension/understudy/deepLocator.ts`** — an iframe step becomes a frame hop only when further selector steps follow it. A trailing `iframe[n]` stays an element target in the parent frame. Hop planning moved into `planDeepXPathTarget()` so the semantics are unit-testable without CDP.

**`packages/extension/understudy/frameLocator.ts`** — `ensureChildFrameReady()` now blocks on `executionContexts.waitForLocatorWorld()` instead of the main world:

- one bounded `15s` deadline, applied only when crossing a frame;
- session ownership is re-resolved per attempt so OOPIF adoption cannot pin the wait to a stale session, and re-verified after a successful wait;
- readiness failure throws instead of returning best-effort;
- the per-child `try/catch` in `resolveFrame()` was narrowed to the `DOM.getFrameOwner` lookup, so a readiness failure surfaces its real message rather than the generic `Unable to obtain a content frame for selector: ...`.

`executionContextRegistry.ts` is untouched, and the generic `1s` `waitForLocatorWorld` call sites are unchanged — after a gated transition that budget is only a short recovery window for context churn, not the loading timeout.

## Test plan

New unit coverage:

- `packages/extension/tests/deep-locator.test.ts` — trailing, crossing, nested-trailing, and nested-crossing XPath semantics, plus `frame` parity with `iframe`.
- `packages/extension/tests/frame-locator.test.ts` — readiness errors propagate out of `resolveFrame()`, and readiness retries against the new session when OOPIF ownership changes mid-attempt.

New browser regression, `packages/sdk-ts/tests/integration/iframeLocatorReadiness.test.ts`, registered in the `local/frames-shadow` group. The child document response is delayed while the `<iframe>` element is in the parent DOM immediately:

| Case | Same-process | OOPIF (`--site-per-process` + host-resolver rules) |
| --- | --- | --- |
| Trailing iframe XPath | clicks without waiting for the child document | same |
| Deep XPath into the child button | waits for readiness, then the button's server-side counter increments | waits across session adoption, then increments |

Case B asserts a real side effect (the child button issues an HTTP request the fixture counts) rather than only elapsed time, so it works for OOPIF without cross-origin DOM inspection.

Results locally: extension unit suite passes, all 4 integration cases pass, `oxfmt` and `oxlint` clean, and typecheck reports no errors in the touched files.

## Changeset

Extension patch plus the SDKs that embed it; no protocol bump, since there is no wire or API change.
