### PR TITLE
[STG-2520] fix(ci): pin release npm to 11.x — npm@12 requires node >= 22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,9 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Update npm for Trusted Publishing
-        run: npm install -g npm@latest
+        # Trusted Publishing (OIDC) needs npm >= 11.5.1; npm 12+ requires
+        # node >= 22 and this job runs node 20, so pin to the 11.x line.
+        run: npm install -g npm@11
 
       - name: Run Lint & Build
         run: pnpm exec turbo run lint && pnpm exec turbo run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,10 @@ jobs:
 
       - name: Update npm for Trusted Publishing
         # Trusted Publishing (OIDC) needs npm >= 11.5.1; npm 12+ requires
-        # node >= 22 and this job runs node 20, so pin to the 11.x line.
-        run: npm install -g npm@11
+        # node >= 22 and this job runs node 20, so pin the last known-good
+        # 11.x exactly. Unpin (back to npm@latest) when the job moves to
+        # node >= 22.
+        run: npm install -g npm@11.18.0
 
       - name: Run Lint & Build
         run: pnpm exec turbo run lint && pnpm exec turbo run build


### PR DESCRIPTION
## Why

Every stagehand release since 2026-07-09 18:52 UTC is broken. The Release workflow's "Update npm for Trusted Publishing" step runs `npm install -g npm@latest`; npm@12.0.0 was published 2026-07-08 21:06 UTC and became `latest`, and it requires node `^22.22.2 || ^24.15.0 || >=26` — the release job runs node 20, so the step dies with `EBADENGINE` before versioning even starts.

- Last green Release: 2026-07-08 17:50 UTC
- First failure: 2026-07-09 18:52 UTC ([run](https://github.com/browserbase/stagehand/actions/runs/29043380120) — `npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"} / Actual: {"npm":"10.8.2","node":"v20.20.2"}`)
- This currently blocks the browse release carrying `browse skills show` (#2335) and the browse-skill guidance fixes (#2336), whose changeset is pending on main.

## What

Pin the step to `npm@11` (currently 11.18.0): supports node >= 20.17 **and** Trusted Publishing/OIDC (needs npm >= 11.5.1) — the reason this step exists, since node 20 bundles npm 10.8.2 which predates it. One line + a comment stating the constraint.

The alternative (bump the job to node 22/24 and keep `@latest`) changes the entire release build environment (SEA binaries, prebuilds) and isn't hotfix material; it can be considered separately.

## Validation

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| Failure-log inspection of both failed Release runs | `EBADENGINE ... npm@12.0.0 ... Required node ^22.22.2 \|\| ^24.15.0 \|\| >=26 / Actual node v20.20.2`, exit 1 at the pinned step | Proves the failure mechanism exactly at this line |
| `curl registry.npmjs.org/npm` → dist-tags + publish times | `latest = 12.0.0`, published 2026-07-08T21:06Z — inside the 07-08 17:50 → 07-09 18:52 breakage window | Proves `@latest` drift is the trigger; nothing repo-side changed |
| npm 11.x engine range vs job node | npm 11.18.0 supports node >= 20.17; job runs 20.20.2 | Proves the pin resolves the engine conflict while keeping Trusted Publishing (>= 11.5.1) |
| Real release exercise | Not possible pre-merge — the Release workflow only runs from main. Merging this PR pushes to main, which itself triggers Release with the pending browse changeset — that run is the live verification | The one path that cannot be tested from a branch |

Linear: STG-2520

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `npm` in the Release workflow to `11.18.0` to avoid `npm@12` requiring Node >=22. Restores releases on Node 20 and keeps Trusted Publishing (Linear: STG-2520).

<sup>Written for commit 90a6d7195bca8d576287f87e285d8e147e2f9cc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

