### PR TITLE
Fix malformed snapshot Unicode

### DIFF
--- a/.changeset/fix-malformed-snapshot-unicode.md
+++ b/.changeset/fix-malformed-snapshot-unicode.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Repair malformed UTF-16 snapshot text before it reaches model prompts.

--- a/packages/core/lib/v3/understudy/a11y/snapshot/capture.ts
+++ b/packages/core/lib/v3/understudy/a11y/snapshot/capture.ts
@@ -36,6 +36,7 @@ type Interval = { start: number; end: number };
 type ExclusionIntervalsByFrame = Map<string, Interval[]>;
 type ChildFrameHost = { childFrameId: string; hostBackendNodeId: number };
 type ChildFramesByParent = Map<string, ChildFrameHost[]>;
+type WellFormedString = string & { toWellFormed(): string };
 
 /**
  * Capture a hybrid DOM + Accessibility snapshot for the provided page.
@@ -278,7 +279,7 @@ export async function tryScopedSnapshot(
 
     const scopedUrlMap: Record<string, string> = { ...urlMap };
 
-    const wellFormedOutline = outline.toWellFormed();
+    const wellFormedOutline = (outline as WellFormedString).toWellFormed();
 
     const snapshot: HybridSnapshot = {
       combinedTree: wellFormedOutline,
@@ -848,7 +849,9 @@ export function mergeFramesIntoSnapshot(
     perFrameOutlines.find((o) => o.frameId === context.rootId)?.outline ??
     perFrameOutlines[0]?.outline ??
     "";
-  const combinedTree = injectSubtrees(rootOutline, idToTree).toWellFormed();
+  const combinedTree = (
+    injectSubtrees(rootOutline, idToTree) as WellFormedString
+  ).toWellFormed();
 
   return {
     combinedTree,

--- a/packages/core/lib/v3/understudy/a11y/snapshot/capture.ts
+++ b/packages/core/lib/v3/understudy/a11y/snapshot/capture.ts
@@ -278,14 +278,16 @@ export async function tryScopedSnapshot(
 
     const scopedUrlMap: Record<string, string> = { ...urlMap };
 
+    const wellFormedOutline = outline.toWellFormed();
+
     const snapshot: HybridSnapshot = {
-      combinedTree: outline,
+      combinedTree: wellFormedOutline,
       combinedXpathMap: scopedXpathMap,
       combinedUrlMap: scopedUrlMap,
       perFrame: [
         {
           frameId: targetFrameId,
-          outline,
+          outline: wellFormedOutline,
           xpathMap,
           urlMap,
         },
@@ -846,7 +848,7 @@ export function mergeFramesIntoSnapshot(
     perFrameOutlines.find((o) => o.frameId === context.rootId)?.outline ??
     perFrameOutlines[0]?.outline ??
     "";
-  const combinedTree = injectSubtrees(rootOutline, idToTree);
+  const combinedTree = injectSubtrees(rootOutline, idToTree).toWellFormed();
 
   return {
     combinedTree,

--- a/packages/core/tests/integration/unicode-well-formed.spec.ts
+++ b/packages/core/tests/integration/unicode-well-formed.spec.ts
@@ -18,7 +18,11 @@ test("repairs page text before local SDK model calls", async () => {
     jsonResponses: {
       Observation: (options) => {
         observedPromptText = promptToText(options.prompt);
-        expect(observedPromptText.isWellFormed()).toBe(true);
+        expect(
+          (
+            observedPromptText as string & { isWellFormed(): boolean }
+          ).isWellFormed(),
+        ).toBe(true);
         expect(observedPromptText).toContain("Draw Again. \uFFFD");
         return { elements: [] };
       },

--- a/packages/core/tests/integration/unicode-well-formed.spec.ts
+++ b/packages/core/tests/integration/unicode-well-formed.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "@playwright/test";
+import { V3 } from "../../lib/v3/v3.js";
+import {
+  closeV3,
+  createScriptedAisdkTestLlmClient,
+  promptToText,
+} from "./testUtils.js";
+import { getV3TestConfig } from "./v3.config.js";
+
+function encodeHtml(html: string): string {
+  return `data:text/html,${encodeURIComponent(html)}`;
+}
+
+test("repairs page text before local SDK model calls", async () => {
+  let observedPromptText = "";
+  const llmClient = createScriptedAisdkTestLlmClient({
+    modelId: "mock/unicode-well-formed",
+    jsonResponses: {
+      Observation: (options) => {
+        observedPromptText = promptToText(options.prompt);
+        expect(observedPromptText.isWellFormed()).toBe(true);
+        expect(observedPromptText).toContain("Draw Again. \uFFFD");
+        return { elements: [] };
+      },
+    },
+  });
+
+  const v3 = new V3(getV3TestConfig({ llmClient }));
+  await v3.init();
+
+  try {
+    const page = v3.context.pages()[0];
+    await page.goto(
+      encodeHtml(`<!doctype html>
+<meta charset="utf-8">
+<h1 id="target"></h1>
+<script>
+  document.getElementById("target").textContent =
+    "Draw Again. " + String.fromCharCode(0xd83c);
+</script>`),
+    );
+
+    const observed = await v3.observe("Find the promo banner text");
+
+    expect(observed).toEqual([]);
+    expect(observedPromptText).not.toBe("");
+  } finally {
+    await closeV3(v3);
+  }
+});

--- a/packages/core/tests/unit/snapshot-frame-merge.test.ts
+++ b/packages/core/tests/unit/snapshot-frame-merge.test.ts
@@ -346,6 +346,43 @@ describe("mergeFramesIntoSnapshot", () => {
     expect(snapshot.combinedTree).toBe("[child] frame2");
   });
 
+  it("repairs malformed surrogate pairs in the combined tree", () => {
+    const context: FrameContext = {
+      rootId: "frame-1",
+      frames: ["frame-1"],
+      parentByFrame: new Map([["frame-1", null]]),
+    };
+
+    const perFrameMaps = new Map<string, FrameDomMaps>([
+      [
+        "frame-1",
+        {
+          tagNameMap: {},
+          scrollableMap: {},
+          urlMap: {},
+          xpathMap: {},
+        },
+      ],
+    ]);
+
+    const snapshot = mergeFramesIntoSnapshot(
+      context,
+      perFrameMaps,
+      [
+        {
+          frameId: "frame-1",
+          outline: `Draw Again. ${String.fromCharCode(0xd83c)}`,
+        },
+      ],
+      new Map([["frame-1", ""]]),
+      new Map(),
+      context.frames,
+    );
+
+    expect(snapshot.combinedTree.isWellFormed()).toBe(true);
+    expect(snapshot.combinedTree).toBe("Draw Again. \uFFFD");
+  });
+
   it("overwrites duplicate iframe host entries when multiple children map to the same parent", () => {
     const context: FrameContext = {
       rootId: "frame-1",

--- a/packages/core/tests/unit/snapshot-frame-merge.test.ts
+++ b/packages/core/tests/unit/snapshot-frame-merge.test.ts
@@ -380,7 +380,9 @@ describe("mergeFramesIntoSnapshot", () => {
     );
 
     expect(
-      (snapshot.combinedTree as string & { isWellFormed(): boolean }).isWellFormed(),
+      (
+        snapshot.combinedTree as string & { isWellFormed(): boolean }
+      ).isWellFormed(),
     ).toBe(true);
     expect(snapshot.combinedTree).toBe("Draw Again. \uFFFD");
   });

--- a/packages/core/tests/unit/snapshot-frame-merge.test.ts
+++ b/packages/core/tests/unit/snapshot-frame-merge.test.ts
@@ -379,7 +379,9 @@ describe("mergeFramesIntoSnapshot", () => {
       context.frames,
     );
 
-    expect(snapshot.combinedTree.isWellFormed()).toBe(true);
+    expect(
+      (snapshot.combinedTree as string & { isWellFormed(): boolean }).isWellFormed(),
+    ).toBe(true);
     expect(snapshot.combinedTree).toBe("Draw Again. \uFFFD");
   });
 

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -5,6 +5,7 @@
     "rootDir": ".",
     "outDir": "./dist/esm",
     "allowJs": true,
+    "lib": ["ES2022", "ES2024.String", "DOM", "DOM.Iterable"],
     "paths": {
       "@browserbasehq/stagehand": ["packages/core/lib/v3/index.ts"],
       "@browserbasehq/stagehand/*": ["packages/core/lib/*"],

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -5,7 +5,6 @@
     "rootDir": ".",
     "outDir": "./dist/esm",
     "allowJs": true,
-    "lib": ["ES2022", "ES2024.String", "DOM", "DOM.Iterable"],
     "paths": {
       "@browserbasehq/stagehand": ["packages/core/lib/v3/index.ts"],
       "@browserbasehq/stagehand/*": ["packages/core/lib/*"],


### PR DESCRIPTION
# why

BYOK/direct provider calls reject when page snapshot text we passed in contained malformed UTF-16. I

# what changed

Normalize captured accessibility snapshot strings with `toWellFormed()` at the snapshot boundary and add unit/integration coverage for lone-surrogate page text.

# test plan

Red/greened the new unit and local SDK observe regressions, and the focused `unicode-well-formed` integration test.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes malformed Unicode in accessibility snapshots by normalizing text with `String.prototype.toWellFormed()` at capture and during frame merge, so both local SDK and provider prompts always get well-formed UTF-16. Adds tests that confirm lone surrogates are repaired to U+FFFD in prompts.

- **Bug Fixes**
  - Normalize outline strings during capture and frame merge; per-frame and combined trees are well-formed before prompting.
  - Add integration test asserting U+FFFD appears in the model prompt and a unit test verifying combined tree repair.

- **Dependencies**
  - Add changeset to publish a patch for `@browserbasehq/stagehand`.

<sup>Written for commit 143ac0ecd5317eda7e33e6d84b93ec8e3ad66047. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



