### PR TITLE
feat(core): support OpenAI Chat Completions via openaiEndpointFormat

### DIFF
--- a/.changeset/openai-chat-api-mode.md
+++ b/.changeset/openai-chat-api-mode.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Allow OpenAI-compatible models to select the Chat Completions API with `apiMode: "chat"` in model configuration.

--- a/.changeset/openai-chat-api-mode.md
+++ b/.changeset/openai-chat-api-mode.md
@@ -2,4 +2,4 @@
 "@browserbasehq/stagehand": patch
 ---
 
-Allow OpenAI-compatible models to select the Chat Completions API with `apiMode: "chat"` in model configuration.
+Allow OpenAI-compatible models to select the Chat Completions API with `apiMode: "chat"` in model configuration without sending Responses-only options.

--- a/.changeset/openai-chat-api-mode.md
+++ b/.changeset/openai-chat-api-mode.md
@@ -2,4 +2,4 @@
 "@browserbasehq/stagehand": patch
 ---
 
-Allow OpenAI-compatible models to select the Chat Completions API with `apiMode: "chat"` in model configuration without sending Responses-only options.
+Allow OpenAI-compatible models to select the Chat Completions API with `openaiEndpointFormat: "chat"` in model configuration without sending Responses-only options.

--- a/packages/core/lib/v3/agent/utils/handleDoneToolCall.ts
+++ b/packages/core/lib/v3/agent/utils/handleDoneToolCall.ts
@@ -9,6 +9,7 @@ import {
 import { StagehandZodObject } from "../../zodCompat.js";
 import { getZFactory } from "../../../utils.js";
 import type { StagehandZodSchema } from "../../zodCompat.js";
+import { openAIStoreProviderOptions } from "../../llm/providerOptions.js";
 
 interface DoneResult {
   reasoning: string;
@@ -146,6 +147,7 @@ Call the "done" tool with:
   };
 
   const modelId = typeof model === "string" ? model : model.modelId;
+  const modelProvider = typeof model === "string" ? undefined : model.provider;
   const fallbacks = anthropicFallbacksOptions(modelId);
 
   // Models whose always-on thinking rejects forced tool use go straight to
@@ -161,7 +163,7 @@ Call the "done" tool with:
       : { type: "tool", toolName: "done" },
     providerOptions: {
       google: { mediaResolution: "MEDIA_RESOLUTION_HIGH" },
-      openai: { store: false },
+      ...openAIStoreProviderOptions(modelProvider),
       ...(fallbacks ? { anthropic: fallbacks } : {}),
     },
   });

--- a/packages/core/lib/v3/handlers/v3AgentHandler.ts
+++ b/packages/core/lib/v3/handlers/v3AgentHandler.ts
@@ -22,6 +22,7 @@ import {
   anthropicAdaptiveThinkingOptions,
   anthropicFallbacksOptions,
 } from "../llm/anthropicOptions.js";
+import { openAIStoreProviderOptions } from "../llm/providerOptions.js";
 import {
   AgentExecuteOptions,
   AgentStreamExecuteOptions,
@@ -105,14 +106,18 @@ function prependSystemMessage(
  * Anthropic at all. Fable 5 additionally opts into the API's server-side
  * refusal fallback.
  */
-function buildAgentProviderOptions(modelId: string, thinkingEffort?: string) {
+function buildAgentProviderOptions(
+  modelId: string,
+  provider: string | undefined,
+  thinkingEffort?: string,
+) {
   const anthropic = {
     ...(anthropicAdaptiveThinkingOptions(modelId, thinkingEffort) ?? {}),
     ...(anthropicFallbacksOptions(modelId) ?? {}),
   };
   return {
     google: { mediaResolution: "MEDIA_RESOLUTION_HIGH" },
-    openai: { store: false },
+    ...openAIStoreProviderOptions(provider),
     ...(Object.keys(anthropic).length > 0 ? { anthropic } : {}),
   };
 }
@@ -477,6 +482,7 @@ export class V3AgentHandler {
         abortSignal: preparedOptions.signal,
         providerOptions: buildAgentProviderOptions(
           wrappedModel.modelId,
+          wrappedModel.provider,
           this.thinkingEffort,
         ),
       });
@@ -695,6 +701,7 @@ export class V3AgentHandler {
         abortSignal: options.signal,
         providerOptions: buildAgentProviderOptions(
           wrappedModel.modelId,
+          wrappedModel.provider,
           this.thinkingEffort,
         ),
       });

--- a/packages/core/lib/v3/llm/LLMProvider.ts
+++ b/packages/core/lib/v3/llm/LLMProvider.ts
@@ -160,15 +160,24 @@ export function getAISDKLanguageModel(
   clientOptions?: ClientOptions,
   middleware?: LanguageModelV2Middleware,
 ): LanguageModelV2 {
-  const aiSdkClientOptions = toAISDKClientOptions(subProvider, clientOptions);
+  const { apiMode, ...providerClientOptions } = clientOptions ?? {};
+  const aiSdkClientOptions = toAISDKClientOptions(
+    subProvider,
+    providerClientOptions,
+  );
   const hasValidOptions =
     aiSdkClientOptions &&
     Object.values(aiSdkClientOptions).some(
       (v) => v !== undefined && v !== null,
     );
 
-  let model;
-  if (hasValidOptions) {
+  let model: LanguageModelV2;
+  if (subProvider === "openai" && apiMode === "chat") {
+    const provider = hasValidOptions
+      ? createOpenAI(aiSdkClientOptions)
+      : openai;
+    model = provider.chat(subModelName);
+  } else if (hasValidOptions) {
     const creator = AISDKProvidersWithAPIKey[subProvider];
     if (!creator) {
       throw new UnsupportedAISDKModelProviderError(

--- a/packages/core/lib/v3/llm/LLMProvider.ts
+++ b/packages/core/lib/v3/llm/LLMProvider.ts
@@ -160,7 +160,8 @@ export function getAISDKLanguageModel(
   clientOptions?: ClientOptions,
   middleware?: LanguageModelV2Middleware,
 ): LanguageModelV2 {
-  const { apiMode, ...providerClientOptions } = clientOptions ?? {};
+  const { openaiEndpointFormat, ...providerClientOptions } =
+    clientOptions ?? {};
   const aiSdkClientOptions = toAISDKClientOptions(
     subProvider,
     providerClientOptions,
@@ -172,7 +173,7 @@ export function getAISDKLanguageModel(
     );
 
   let model: LanguageModelV2;
-  if (subProvider === "openai" && apiMode === "chat") {
+  if (subProvider === "openai" && openaiEndpointFormat === "chat") {
     const provider = hasValidOptions
       ? createOpenAI(aiSdkClientOptions)
       : openai;

--- a/packages/core/lib/v3/llm/providerOptions.ts
+++ b/packages/core/lib/v3/llm/providerOptions.ts
@@ -1,0 +1,5 @@
+export function openAIStoreProviderOptions(provider: string | undefined) {
+  return provider === "openai.responses"
+    ? { openai: { store: false as const } }
+    : {};
+}

--- a/packages/core/lib/v3/types/public/model.ts
+++ b/packages/core/lib/v3/types/public/model.ts
@@ -139,6 +139,8 @@ export type ThinkingEffort =
   | "xhigh"
   | "max";
 
+export type OpenAIApiMode = "responses" | "chat";
+
 export type ClientOptions = (OpenAIClientOptions | AnthropicClientOptions) & {
   apiKey?: string;
   provider?: AgentProviderType;
@@ -172,6 +174,11 @@ export type ClientOptions = (OpenAIClientOptions | AnthropicClientOptions) & {
   headers?: Record<string, string>;
   /** Reasoning effort for reasoning-capable models (e.g., "none", "low", "medium", "high") */
   reasoningEffort?: string;
+  /**
+   * OpenAI API used for text generation. Defaults to the Responses API.
+   * Use `chat` for providers that expose only an OpenAI-compatible Chat Completions endpoint.
+   */
+  apiMode?: OpenAIApiMode;
 };
 
 export type ModelConfiguration =

--- a/packages/core/lib/v3/types/public/model.ts
+++ b/packages/core/lib/v3/types/public/model.ts
@@ -139,7 +139,7 @@ export type ThinkingEffort =
   | "xhigh"
   | "max";
 
-export type OpenAIApiMode = "responses" | "chat";
+export type OpenAIEndpointFormat = "responses" | "chat";
 
 export type ClientOptions = (OpenAIClientOptions | AnthropicClientOptions) & {
   apiKey?: string;
@@ -175,10 +175,11 @@ export type ClientOptions = (OpenAIClientOptions | AnthropicClientOptions) & {
   /** Reasoning effort for reasoning-capable models (e.g., "none", "low", "medium", "high") */
   reasoningEffort?: string;
   /**
-   * OpenAI API used for text generation. Defaults to the Responses API.
-   * Use `chat` for providers that expose only an OpenAI-compatible Chat Completions endpoint.
+   * Wire format used against the OpenAI-compatible endpoint at `baseURL`.
+   * Defaults to the Responses API. Use `chat` for providers that expose only
+   * an OpenAI-compatible Chat Completions endpoint (e.g. Databricks).
    */
-  apiMode?: OpenAIApiMode;
+  openaiEndpointFormat?: OpenAIEndpointFormat;
 };
 
 export type ModelConfiguration =

--- a/packages/core/tests/unit/agent-temperature.test.ts
+++ b/packages/core/tests/unit/agent-temperature.test.ts
@@ -136,10 +136,10 @@ function createV3() {
   } as unknown as V3;
 }
 
-function createLlmClient() {
+function createLlmClient(provider = "openai.responses") {
   const model = {
     modelId: "openai/gpt-5-mini",
-    provider: "openai",
+    provider,
     specificationVersion: "v2",
   } as unknown as LanguageModelV2;
 
@@ -215,6 +215,22 @@ describe("v3 agent temperature options", () => {
     expect(options.providerOptions).toEqual({
       google: { mediaResolution: "MEDIA_RESOLUTION_HIGH" },
       openai: { store: false },
+    });
+  });
+
+  it("does not send Responses-only options to OpenAI chat providers", async () => {
+    const { client, generateText } = createLlmClient("openai.chat");
+    const handler = new V3AgentHandler(createV3(), logger, client);
+
+    await handler.execute({
+      instruction: "finish",
+      maxSteps: 1,
+      excludeTools: ["search"],
+    });
+
+    const options = generateText.mock.calls[0][0] as AgentLlmOptions;
+    expect(options.providerOptions).toEqual({
+      google: { mediaResolution: "MEDIA_RESOLUTION_HIGH" },
     });
   });
 });

--- a/packages/core/tests/unit/llm-provider.test.ts
+++ b/packages/core/tests/unit/llm-provider.test.ts
@@ -59,6 +59,29 @@ describe("getAISDKLanguageModel", () => {
       });
       expect(customModel).toBeDefined();
     });
+
+    it("uses the OpenAI Responses API by default", () => {
+      const model = getAISDKLanguageModel("openai", "gpt-4o", {
+        apiKey: "test-key",
+      });
+
+      expect(model.provider).toBe("openai.responses");
+    });
+
+    it("can select OpenAI-compatible Chat Completions", () => {
+      const model = getAISDKLanguageModel(
+        "openai",
+        "databricks-claude-opus-4-6",
+        {
+          apiKey: "test-key",
+          baseURL:
+            "https://example.databricks.com/serving-endpoints/model/invocations",
+          apiMode: "chat",
+        },
+      );
+
+      expect(model.provider).toBe("openai.chat");
+    });
   });
 
   describe("hasValidOptions logic", () => {
@@ -74,6 +97,21 @@ describe("getAISDKLanguageModel", () => {
 });
 
 describe("LLMProvider", () => {
+  it("passes Chat Completions mode through model client options", () => {
+    const provider = new LLMProvider(() => {});
+    const client = provider.getClient(
+      "openai/databricks-claude-opus-4-6",
+      {
+        apiKey: "test-key",
+        baseURL: "https://example.databricks.com/serving-endpoints",
+        apiMode: "chat",
+      },
+      { disableAPI: true },
+    );
+
+    expect(client.getLanguageModel?.().provider).toBe("openai.chat");
+  });
+
   it("allows Vertex models without experimental mode", () => {
     const provider = new LLMProvider(() => {});
 

--- a/packages/core/tests/unit/llm-provider.test.ts
+++ b/packages/core/tests/unit/llm-provider.test.ts
@@ -76,7 +76,7 @@ describe("getAISDKLanguageModel", () => {
           apiKey: "test-key",
           baseURL:
             "https://example.databricks.com/serving-endpoints/model/invocations",
-          apiMode: "chat",
+          openaiEndpointFormat: "chat",
         },
       );
 
@@ -104,7 +104,7 @@ describe("LLMProvider", () => {
       {
         apiKey: "test-key",
         baseURL: "https://example.databricks.com/serving-endpoints",
-        apiMode: "chat",
+        openaiEndpointFormat: "chat",
       },
       { disableAPI: true },
     );


### PR DESCRIPTION
## Summary
- add `openaiEndpointFormat` to public model configuration
- select OpenAI Chat Completions when `openaiEndpointFormat` is `chat`
- preserve Responses API as the default
- omit the Responses-only `store` option for Chat providers, including finalization calls
- add a patch changeset

## Usage

```ts
const stagehand = new Stagehand({
  model: {
    modelName: "openai/databricks-claude-opus-4-6",
    apiKey: process.env.DATABRICKS_TOKEN,
    baseURL: "https://example.databricks.com/serving-endpoints",
    openaiEndpointFormat: "chat",
  },
});
```

The option names the *wire format* used against the OpenAI-compatible endpoint at `baseURL` — deliberately not `apiMode` (too generic) or `openaiEndpoint` (reads like it holds a URL, and sits right next to `baseURL`).

## Databricks verification
- basic Chat Completions request: 200
- request with `store: false` reproduced the 400: extra inputs are not permitted
- two-turn tool call and tool-result replay without `store`: 200 on both turns

## Testing
- focused llm-provider and agent suites: 19 passed
- TypeScript typecheck
- ESLint on touched TypeScript files
- Prettier check on touched files