### PR TITLE
[STG-2560] docs: replace deprecated advancedStealth with verified

### DIFF
--- a/packages/docs/v2/configuration/browser.mdx
+++ b/packages/docs/v2/configuration/browser.mdx
@@ -120,7 +120,7 @@ stagehand = Stagehand(
         timeout: 3600, // 1 hour session timeout
         keepAlive: true, // Available on Startup plan
         browserSettings: {
-          advancedStealth: false, // this is a Scale Plan feature - reach out to support@browserbase.com to enable
+          verified: false, // this is a Scale Plan feature - reach out to support@browserbase.com to enable
           blockAds: true,
           solveCaptchas: true,
           recordSession: false,

--- a/packages/docs/v2/integrations/mcp/configuration.mdx
+++ b/packages/docs/v2/integrations/mcp/configuration.mdx
@@ -34,7 +34,7 @@ Your Browserbase project ID
 | Flag | Description |
 |------|-------------|
 | `--proxies` | Enable Browserbase proxies for the session |
-| `--advancedStealth` | Enable Browserbase Advanced Stealth (Scale Plan only) |
+| `--verified` | Enable Browserbase Verified Identity (Scale Plan only) |
 | `--keepAlive` | Enable Browserbase Keep Alive Session |
 | `--contextId <contextId>` | Specify a Browserbase Context ID to use |
 | `--persist [boolean]` | Whether to persist the Browserbase context (default: true) |
@@ -157,13 +157,13 @@ Enable Browserbase proxies for IP rotation and geo-location testing.
 ```
 </Tab>
 
-<Tab title="Advanced Stealth">
-Enable advanced anti-detection features for enhanced stealth browsing.
+<Tab title="Verified">
+Enable Browserbase Verified Identity for enhanced anti-detection during browsing.
 
 <Panel>
-[Learn more about Advanced Stealth](https://docs.browserbase.com/features/stealth-mode#advanced-stealth-mode)
+[Learn more about Verified Identity](https://docs.browserbase.com/features/stealth-mode#advanced-stealth-mode)
 
-**Note:** Advanced Stealth is only available for Scale Plan users.
+**Note:** Verified Identity is only available for Scale Plan users. The previous `--advancedStealth` flag is still accepted as a deprecated alias.
 </Panel>
 
 ```json
@@ -171,7 +171,7 @@ Enable advanced anti-detection features for enhanced stealth browsing.
   "mcpServers": {
     "browserbase": {
       "command": "npx",
-      "args": ["@browserbasehq/mcp", "--advancedStealth"],
+      "args": ["@browserbasehq/mcp", "--verified"],
       "env": {
         "BROWSERBASE_API_KEY": "your_api_key",
         "BROWSERBASE_PROJECT_ID": "your_project_id",
@@ -400,7 +400,7 @@ Configure custom host and port for SHTTP transport.
 
 <Accordion title="Security - What security measures should I implement?">
 - Store API keys securely in environment variables
-- Use Advanced Stealth for sensitive operations
+- Use Verified Identity for sensitive operations
 - Implement proper session management
 - Rotate cookies and contexts regularly
 </Accordion>

--- a/packages/docs/v2/integrations/mcp/setup.mdx
+++ b/packages/docs/v2/integrations/mcp/setup.mdx
@@ -64,7 +64,7 @@ Pass your Browserbase API key as an HTTP authorization header: `Authorization: B
 | `modelApiKey`     | string         | Required when `modelName` is non-default   |
 | `keepAlive`       | boolean string | `"true"` or `"false"`                      |
 | `proxies`         | boolean string | `"true"` or `"false"`                      |
-| `advancedStealth` | boolean string | `"true"` or `"false"`                      |
+| `verified`        | boolean string | `"true"` or `"false"`                      |
 
 <Warning>
   Boolean query values must be exact strings: `"true"` or `"false"`.
@@ -129,7 +129,7 @@ Command-line flags are only available when running the server locally (`npx @bro
 | Flag | Description |
 |------|-------------|
 | `--proxies` | Enable Browserbase proxies for the session |
-| `--advancedStealth` | Enable Browserbase Advanced Stealth (Scale Plan only) |
+| `--verified` | Enable Browserbase Verified Identity (Scale Plan only) |
 | `--keepAlive` | Enable Browserbase Keep Alive Session |
 | `--contextId <contextId>` | Specify a Browserbase Context ID to use |
 | `--persist [boolean]` | Whether to persist the Browserbase context (default: true) |

--- a/packages/docs/v3/configuration/browser.mdx
+++ b/packages/docs/v3/configuration/browser.mdx
@@ -136,7 +136,7 @@ const stagehand = new Stagehand({
         timeout: 3600, // 1 hour session timeout
         keepAlive: true, // Available on Startup plan
         browserSettings: {
-          advancedStealth: false, // this is a Scale Plan feature - reach out to support@browserbase.com to enable
+          verified: false, // this is a Scale Plan feature - reach out to support@browserbase.com to enable
           blockAds: true,
           solveCaptchas: true,
           recordSession: false,

--- a/packages/docs/v3/integrations/mcp/configuration.mdx
+++ b/packages/docs/v3/integrations/mcp/configuration.mdx
@@ -31,7 +31,7 @@ Your Browserbase API key for authentication
 | Flag | Description |
 |------|-------------|
 | `--proxies` | Enable Browserbase proxies for the session |
-| `--advancedStealth` | Enable Browserbase Advanced Stealth (Scale Plan only) |
+| `--verified` | Enable Browserbase Verified Identity (Scale Plan only) |
 | `--keepAlive` | Enable Browserbase Keep Alive Session |
 | `--contextId <contextId>` | Specify a Browserbase Context ID to use |
 | `--persist [boolean]` | Whether to persist the Browserbase context (default: true) |
@@ -149,13 +149,13 @@ Enable Browserbase proxies for IP rotation and geo-location testing.
 ```
 </Tab>
 
-<Tab title="Advanced Stealth">
-Enable advanced anti-detection features for enhanced stealth browsing.
+<Tab title="Verified">
+Enable Browserbase Verified Identity for enhanced anti-detection during browsing.
 
 <Panel>
-[Learn more about Advanced Stealth](https://docs.browserbase.com/features/stealth-mode#advanced-stealth-mode)
+[Learn more about Verified Identity](https://docs.browserbase.com/features/stealth-mode#advanced-stealth-mode)
 
-**Note:** Advanced Stealth is only available for Scale Plan users.
+**Note:** Verified Identity is only available for Scale Plan users. The previous `--advancedStealth` flag is still accepted as a deprecated alias.
 </Panel>
 
 ```json
@@ -163,7 +163,7 @@ Enable advanced anti-detection features for enhanced stealth browsing.
   "mcpServers": {
     "browserbase": {
       "command": "npx",
-      "args": ["@browserbasehq/mcp", "--advancedStealth"],
+      "args": ["@browserbasehq/mcp", "--verified"],
       "env": {
         "BROWSERBASE_API_KEY": "your_api_key",
         "GEMINI_API_KEY": "your_gemini_api_key"
@@ -337,7 +337,7 @@ Configure custom host and port for SHTTP transport.
 
 <Accordion title="Security - What security measures should I implement?">
 - Store API keys securely in environment variables
-- Use Advanced Stealth for sensitive operations
+- Use Verified Identity for sensitive operations
 - Implement proper session management
 - Rotate cookies and contexts regularly
 </Accordion>

--- a/packages/docs/v3/integrations/mcp/setup.mdx
+++ b/packages/docs/v3/integrations/mcp/setup.mdx
@@ -67,7 +67,7 @@ Pass your Browserbase API key as an HTTP authorization header: `Authorization: B
 | `modelApiKey`     | string         | Required when `modelName` is non-default   |
 | `keepAlive`       | boolean string | `"true"` or `"false"`                      |
 | `proxies`         | boolean string | `"true"` or `"false"`                      |
-| `advancedStealth` | boolean string | `"true"` or `"false"`                      |
+| `verified`        | boolean string | `"true"` or `"false"`                      |
 
 <Warning>
   Boolean query values must be exact strings: `"true"` or `"false"`.
@@ -134,7 +134,7 @@ Command-line flags are only available when running the server locally (`npx @bro
 | Flag | Description |
 |------|-------------|
 | `--proxies` | Enable Browserbase proxies for the session |
-| `--advancedStealth` | Enable Browserbase Advanced Stealth (Scale Plan only) |
+| `--verified` | Enable Browserbase Verified Identity (Scale Plan only) |
 | `--keepAlive` | Enable Browserbase Keep Alive Session |
 | `--contextId <contextId>` | Specify a Browserbase Context ID to use |
 | `--persist [boolean]` | Whether to persist the Browserbase context (default: true) |


### PR DESCRIPTION
## Summary

Docs pass to replace the deprecated `advancedStealth` browser setting with `verified` across the Stagehand docs. The old name is still accepted (Stagehand core keeps it as a backwards-compat alias, and the standalone MCP server documents `--advancedStealth` as a deprecated alias in its own CLI `--help`), but user-facing examples and tables should show the current canonical name.

Reported by Alex on Slack, pointing at [`v3/configuration/browser` → "Advanced Browserbase Configuration Example"](https://docs.stagehand.dev/v3/configuration/browser#advanced-browserbase-configuration-example).

## Changes

**v3 docs**
- `packages/docs/v3/configuration/browser.mdx` — code sample now uses `verified: false` instead of `advancedStealth: false`
- `packages/docs/v3/integrations/mcp/setup.mdx` — Optional query params table + Local CLI flags table swapped to `verified` / `--verified`
- `packages/docs/v3/integrations/mcp/configuration.mdx` — CLI flags table swapped, "Advanced Stealth" tab retitled to "Verified" with a deprecated-alias note, security best-practices bullet updated

**v2 docs** — same fixes for the v2 mirror

## Not touched

- `packages/docs/sdk-api-reference-labels.js` — this is a snake_case rewriter driven by the live OpenAPI wire field; `advancedStealth` is still part of the API spec, so the mapping is intentional.
- Generated SDK code across `stagehand-{java,go,python,ruby}` and `sdk-node` — regenerated from OpenAPI, not human-authored docs.
- `packages/core/lib/v3/v3.ts` and `packages/core/lib/v3/types/public/api.ts` — deliberately keep `advancedStealth` as a backwards-compat alias (see the `@deprecated` comment on `isAdvancedStealth` in `v3.ts`).

## Test plan

Docs-only diff — no code paths touched. Verified with `git diff` that only the six intended MDX files change and every remaining `advancedStealth` mention is either an intentional deprecated-alias note or unchanged code that reflects the API's continued support of both names.

Requested by: alexander@browserbase.com
Linear: https://linear.app/browserbase/issue/STG-2560/docs-replace-deprecated-advancedstealth-with-verified-across-stagehand
Slack thread: https://browserbase.slack.com/archives/D0AHY8DEQPM/p1783960618071569

> [!NOTE]
> Alex asked for a draft PR. The internal `createOrUpdatePR` tool doesn't currently support the `draft` flag — opening as a regular PR. Please mark it as draft in the GitHub UI if that's still desired.