### PR TITLE
docs(models): add DaoXE multi-protocol gateway custom endpoint example

### DIFF
--- a/packages/docs/v3/configuration/models.mdx
+++ b/packages/docs/v3/configuration/models.mdx
@@ -720,7 +720,7 @@ const agent = stagehand.agent({
 
 ### Custom Endpoints
 
-If you need Azure OpenAI deployments or enterprise deployments.
+If you need Azure OpenAI deployments, multi-protocol gateways, or other enterprise endpoints.
 
 <Tabs>
 <Tab title="OpenAI">
@@ -756,6 +756,27 @@ const stagehand = new Stagehand({
 ```
 
   </Tab>
+<Tab title="DaoXE">
+
+[DaoXE](https://daoxe.com) is a multi-model multi-protocol API gateway (OpenAI Chat Completions / Responses and Anthropic Messages). Stagehand's model object can point at DaoXE's OpenAI-compatible base URL; use an exact account-scoped model ID from your DaoXE dashboard (no hardcoded public model list). Service is not available in mainland China.
+
+```typescript
+const stagehand = new Stagehand({
+  env: "BROWSERBASE",
+  model: {
+    // Use an exact model ID from your DaoXE account
+    modelName: "openai/<your-daoxe-model-id>",
+    apiKey: process.env.DAOXE_API_KEY,
+    baseURL: "https://daoxe.com/v1",
+  },
+});
+
+await stagehand.init();
+```
+
+Set `DAOXE_API_KEY` in `.env`. Prefer models that support structured outputs for `act` / `extract` / `observe`. DaoXE also exposes Anthropic Messages and other OpenAI-compatible paths for non-Stagehand clients; Stagehand uses the OpenAI-compatible route above.
+
+</Tab>
 <Tab title="All Other Providers">
 For all other providers, use `llmClient`. Here's an example with Hugging Face:
 
@@ -965,6 +986,7 @@ The following models work without the `provider/` prefix in the model parameter 
 | Vertex | Service account credentials (see [setup](#first-class-models)) |
 | Anthropic  | `ANTHROPIC_API_KEY`            |
 | OpenAI     | `OPENAI_API_KEY`               |
+| DaoXE (custom endpoint) | `DAOXE_API_KEY` (pass via `model.apiKey`) |
 | Azure      | `AZURE_API_KEY`                |
 | Cerebras   | `CEREBRAS_API_KEY`             |
 | DeepSeek   | `DEEPSEEK_API_KEY`             |


### PR DESCRIPTION
# why

Document how to use [DaoXE](https://daoxe.com) with Stagehand through the existing **Custom Endpoints** pattern (`model.baseURL` + account API key).

# what changed

- Add a **DaoXE** tab under Custom Endpoints in `packages/docs/v3/configuration/models.mdx`
- Base URL: `https://daoxe.com/v1`
- Model form: `openai/<your-daoxe-model-id>` (exact account-scoped ID from the DaoXE dashboard; no hardcoded public model list)
- Note multi-protocol surface (OpenAI Chat Completions / Responses and Anthropic Messages); Stagehand uses the OpenAI-compatible path
- Note service is not available in mainland China
- Add `DAOXE_API_KEY` to the troubleshooting env table

DaoXE is a multi-model multi-protocol API gateway. I am a DaoXE maintainer. Examples: https://github.com/seven7763/DaoXE-AI

# test plan

- [ ] Docs page renders with the new Custom Endpoints → DaoXE tab
- [ ] Example matches Stagehand `model: { modelName, apiKey, baseURL }` pattern used for OpenAI custom endpoints
- [ ] Optional: smoke chat against `https://daoxe.com/v1` with a real key + account model ID

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a DaoXE custom endpoint example in the models docs so users can connect via an OpenAI‑compatible base URL. Also document `DAOXE_API_KEY` and note support for multi‑protocol gateways.

- **New Features**
  - Added a DaoXE tab under Custom Endpoints with a working example using `model.baseURL` (`https://daoxe.com/v1`), `modelName` `openai/<your-daoxe-model-id>`, and `DAOXE_API_KEY`.
  - Clarified that `Stagehand` uses the OpenAI-compatible route; DaoXE also supports Anthropic Messages.
  - Updated the Custom Endpoints intro to include multi-protocol gateways, added `DAOXE_API_KEY` to the env table, and noted DaoXE is unavailable in mainland China.

<sup>Written for commit e9810a64e6fcacd06bdad31cd3655ab2b98ce524. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

