### PR TITLE
refactor(evals): extract EvalRunner interface (Braintrust Eval() default; no behavior change)

### DIFF
--- a/packages/evals/framework/evalRunner.ts
+++ b/packages/evals/framework/evalRunner.ts
@@ -1,0 +1,81 @@
+import type { TaskResult } from "./types.js";
+import type { EvalInput, Testcase } from "../types/evals.js";
+import { loadBraintrust } from "./braintrust.js";
+
+export interface EvalRunnerConfig {
+  projectName: string;
+  experimentName: string;
+  metadata: Record<string, unknown>;
+  data: () => Testcase[];
+  task: (input: EvalInput) => Promise<TaskResult>;
+  scores: unknown[];
+  maxConcurrency: number;
+  trialCount: number;
+  sendLogs: boolean;
+}
+
+export interface EvalRunnerResult {
+  results: Array<{
+    input: EvalInput;
+    output: TaskResult | boolean;
+    metadata?: Record<string, unknown>;
+    [key: string]: unknown;
+  }>;
+  summary: {
+    experimentName: string;
+    experimentId?: string;
+    experimentUrl?: string;
+    projectName: string;
+    projectUrl?: string;
+    scores: Record<string, unknown>;
+  };
+}
+
+export interface EvalRunner {
+  run(config: EvalRunnerConfig): Promise<EvalRunnerResult>;
+}
+
+const silentBraintrustProgress = {
+  start: (): void => {},
+  increment: (): void => {},
+  stop: (): void => {},
+};
+
+const silentBraintrustReporter = {
+  name: "stagehand-evals-silent-reporter",
+  async reportEval(): Promise<boolean> {
+    return true;
+  },
+  async reportRun(): Promise<boolean> {
+    return true;
+  },
+};
+
+export class BraintrustEvalRunner implements EvalRunner {
+  async run(config: EvalRunnerConfig): Promise<EvalRunnerResult> {
+    const { Eval, flush } = await loadBraintrust();
+    const evalResult = await Eval(
+      config.projectName,
+      {
+        experimentName: config.experimentName,
+        metadata: config.metadata,
+        data: config.data,
+        task: config.task,
+        scores: config.scores as unknown as never,
+        maxConcurrency: config.maxConcurrency,
+        trialCount: config.trialCount,
+      },
+      {
+        progress: silentBraintrustProgress,
+        reporter: silentBraintrustReporter,
+        ...(config.sendLogs ? {} : { noSendLogs: true }),
+      },
+    );
+
+    if (config.sendLogs) {
+      await flush();
+    }
+
+    return evalResult;
+  }
+}

--- a/packages/evals/framework/runner.ts
+++ b/packages/evals/framework/runner.ts
@@ -30,11 +30,8 @@ import type { Testcase, EvalInput } from "../types/evals.js";
 import { generateBenchTestcases } from "./benchPlanner.js";
 import { DEFAULT_BENCH_HARNESS, type Harness } from "./benchTypes.js";
 import { executeBenchTask } from "./benchRunner.js";
-import {
-  hasBraintrustApiKey,
-  loadBraintrust,
-  tracedSpan,
-} from "./braintrust.js";
+import { hasBraintrustApiKey, tracedSpan } from "./braintrust.js";
+import { BraintrustEvalRunner, type EvalRunner } from "./evalRunner.js";
 import { onceAsync, registerActiveRunCleanup } from "./activeRunCleanup.js";
 import { loadTaskModuleFromPath } from "./taskLoader.js";
 import { resolveTraceTransport } from "./langsmith.js";
@@ -95,22 +92,6 @@ function readAbortMode(signal?: AbortSignal): AbortMode {
   const reason = signal.reason;
   return reason === "aggressive" ? "aggressive" : "cooperative";
 }
-
-const silentBraintrustProgress = {
-  start: (): void => {},
-  increment: (): void => {},
-  stop: (): void => {},
-};
-
-const silentBraintrustReporter = {
-  name: "stagehand-evals-silent-reporter",
-  async reportEval(): Promise<boolean> {
-    return true;
-  },
-  async reportRun(): Promise<boolean> {
-    return true;
-  },
-};
 
 function generateTestcases(
   tasks: DiscoveredTask[],
@@ -391,7 +372,6 @@ export async function runEvals(
       ? [passRate, errorMatch]
       : [exactMatch, errorMatch];
 
-    const { Eval, flush } = await loadBraintrust();
     const sendLogs = hasBraintrustApiKey();
 
     // Aggressive abort: when the caller flips signal.reason to "aggressive",
@@ -409,87 +389,78 @@ export async function runEvals(
       void onAggressiveAbort();
     });
 
-    const evalResult = await Eval(
-      braintrustProjectName,
-      {
-        experimentName,
-        metadata: {
-          environment,
-          tier: hasCoreOnly ? "core" : "bench",
-          ...(effectiveCoreToolSurface && {
-            toolSurface: effectiveCoreToolSurface,
-          }),
-          ...(effectiveCoreStartupProfile && {
-            startupProfile: effectiveCoreStartupProfile,
-          }),
-          ...(effectiveBenchHarness && { harness: effectiveBenchHarness }),
-          ...(options.provider && { provider: options.provider }),
-          ...(options.modelOverride && { model: options.modelOverride }),
-          ...(options.useApi && { api: true }),
-        },
-        data: () => testcases,
-        task: async (input: EvalInput): Promise<TaskResult> => {
-          // Cooperative abort: skip any testcase that hasn't started yet
-          // when the signal has flipped. The in-flight task at the moment of
-          // abort still finishes its current step; this stops the next one
-          // from spinning up.
-          if (options.signal?.aborted) {
-            options.onProgress?.({
-              type: "failed",
-              taskName: input.name,
-              modelName: input.modelName,
-              error: "aborted",
-            });
-            return {
-              _success: false,
-              error: "aborted by user",
-              logs: [],
-            };
-          }
-
-          const resolvedTask =
-            options.registry.byName.get(input.name) ??
-            (input.name.includes("/")
-              ? undefined
-              : options.registry.byName.get(`agent/${input.name}`));
-
-          if (!resolvedTask) {
-            throw new EvalsError(`Task "${input.name}" not found in registry.`);
-          }
-
+    const evalRunner: EvalRunner = new BraintrustEvalRunner();
+    const evalResult = await evalRunner.run({
+      projectName: braintrustProjectName,
+      experimentName,
+      metadata: {
+        environment,
+        tier: hasCoreOnly ? "core" : "bench",
+        ...(effectiveCoreToolSurface && {
+          toolSurface: effectiveCoreToolSurface,
+        }),
+        ...(effectiveCoreStartupProfile && {
+          startupProfile: effectiveCoreStartupProfile,
+        }),
+        ...(effectiveBenchHarness && { harness: effectiveBenchHarness }),
+        ...(options.provider && { provider: options.provider }),
+        ...(options.modelOverride && { model: options.modelOverride }),
+        ...(options.useApi && { api: true }),
+      },
+      data: () => testcases,
+      task: async (input: EvalInput): Promise<TaskResult> => {
+        // Cooperative abort: skip any testcase that hasn't started yet
+        // when the signal has flipped. The in-flight task at the moment of
+        // abort still finishes its current step; this stops the next one
+        // from spinning up.
+        if (options.signal?.aborted) {
           options.onProgress?.({
-            type: "started",
+            type: "failed",
             taskName: input.name,
             modelName: input.modelName,
+            error: "aborted",
           });
+          return {
+            _success: false,
+            error: "aborted by user",
+            logs: [],
+          };
+        }
 
-          const result = await executeTask(input, resolvedTask, options);
+        const resolvedTask =
+          options.registry.byName.get(input.name) ??
+          (input.name.includes("/")
+            ? undefined
+            : options.registry.byName.get(`agent/${input.name}`));
 
-          options.onProgress?.({
-            type: result._success ? "passed" : "failed",
-            taskName: input.name,
-            modelName: input.modelName,
-            error: result._success
-              ? undefined
-              : formatProgressError(result.error),
-          });
+        if (!resolvedTask) {
+          throw new EvalsError(`Task "${input.name}" not found in registry.`);
+        }
 
-          return result;
-        },
-        scores: scores as unknown as never,
-        maxConcurrency: concurrency,
-        trialCount: trials,
+        options.onProgress?.({
+          type: "started",
+          taskName: input.name,
+          modelName: input.modelName,
+        });
+
+        const result = await executeTask(input, resolvedTask, options);
+
+        options.onProgress?.({
+          type: result._success ? "passed" : "failed",
+          taskName: input.name,
+          modelName: input.modelName,
+          error: result._success
+            ? undefined
+            : formatProgressError(result.error),
+        });
+
+        return result;
       },
-      {
-        progress: silentBraintrustProgress,
-        reporter: silentBraintrustReporter,
-        ...(sendLogs ? {} : { noSendLogs: true }),
-      },
-    );
-
-    if (sendLogs) {
-      await flush();
-    }
+      scores,
+      maxConcurrency: concurrency,
+      trialCount: trials,
+      sendLogs,
+    });
 
     const summaryResults = evalResult.results.map((result) => {
       const output =


### PR DESCRIPTION
# why

Isolates the Braintrust `Eval()` coupling behind a thin seam so a future backend swap is mechanical instead of a rewrite. Pure structural refactor.

# what changed

- `framework/evalRunner.ts` (new): `EvalRunner` interface + `BraintrustEvalRunner` wrapping the existing `Eval()` call verbatim (same progress/reporter/`noSendLogs`/`flush` semantics)
- `framework/runner.ts`: `runEvals` builds a config and delegates; everything else (trajectories, summary mapping, otel init/shutdown, offline mode, abort handling) unchanged

# test plan

- Unit suite 362/362; concurrency/trialCount/results/summary shapes verified unchanged in review
- Offline (`noSendLogs`) behavior identical

Stack 4/5 · base: #2353

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted an `EvalRunner` interface with a default `BraintrustEvalRunner` to decouple eval execution from Braintrust. No behavior change; `runEvals` now builds a config and delegates to the runner.

- **Refactors**
  - Added `framework/evalRunner.ts` with `EvalRunner`, `EvalRunnerConfig`, `EvalRunnerResult`, and `BraintrustEvalRunner` that wrap Braintrust `Eval()`/`flush`, use silent progress/reporter, and honor `sendLogs` via `noSendLogs`.
  - Updated `framework/runner.ts` to remove inline Braintrust wiring, derive `sendLogs` from `hasBraintrustApiKey()`, and call the runner; abort handling, offline mode, concurrency/trials, and summary mapping unchanged.

<sup>Written for commit 044620c1c2f69cda91eab5c1be06a6a56a040d85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

