### PR TITLE
add serverCacheThreshold option to act/observe/extract

### DIFF
--- a/packages/core/lib/v3/api.ts
+++ b/packages/core/lib/v3/api.ts
@@ -302,16 +302,28 @@ export class StagehandAPIClient {
     let wireOptions: Api.ActRequest["options"];
     let serverCache: boolean | undefined;
     if (options) {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { page: _, serverCache: enableCache, ...restOptions } = options;
+      const {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        page: _,
+        serverCache: enableCache,
+        serverCacheThreshold,
+        ...restOptions
+      } = options;
       serverCache = enableCache;
       if (restOptions.model) {
         restOptions.model = this.prepareModelConfig(restOptions.model);
       } else if (this.defaultModelConfig) {
         restOptions.model = this.getDefaultModelConfig();
       }
-      if (Object.keys(restOptions).length > 0) {
-        wireOptions = restOptions as unknown as Api.ActRequest["options"];
+      // serverCacheThreshold is SDK-named; the API expects options.cacheThreshold
+      const mappedOptions = {
+        ...restOptions,
+        ...(serverCacheThreshold !== undefined && {
+          cacheThreshold: serverCacheThreshold,
+        }),
+      };
+      if (Object.keys(mappedOptions).length > 0) {
+        wireOptions = mappedOptions as unknown as Api.ActRequest["options"];
       }
     } else if (this.defaultModelConfig) {
       wireOptions = {
@@ -346,16 +358,28 @@ export class StagehandAPIClient {
     let wireOptions: Api.ExtractRequest["options"];
     let serverCache: boolean | undefined;
     if (options) {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { page: _, serverCache: enableCache, ...restOptions } = options;
+      const {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        page: _,
+        serverCache: enableCache,
+        serverCacheThreshold,
+        ...restOptions
+      } = options;
       serverCache = enableCache;
       if (restOptions.model) {
         restOptions.model = this.prepareModelConfig(restOptions.model);
       } else if (this.defaultModelConfig) {
         restOptions.model = this.getDefaultModelConfig();
       }
-      if (Object.keys(restOptions).length > 0) {
-        wireOptions = restOptions as unknown as Api.ExtractRequest["options"];
+      // serverCacheThreshold is SDK-named; the API expects options.cacheThreshold
+      const mappedOptions = {
+        ...restOptions,
+        ...(serverCacheThreshold !== undefined && {
+          cacheThreshold: serverCacheThreshold,
+        }),
+      };
+      if (Object.keys(mappedOptions).length > 0) {
+        wireOptions = mappedOptions as unknown as Api.ExtractRequest["options"];
       }
     } else if (this.defaultModelConfig) {
       wireOptions = {
@@ -387,16 +411,28 @@ export class StagehandAPIClient {
     let wireOptions: Api.ObserveRequest["options"];
     let serverCache: boolean | undefined;
     if (options) {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { page: _, serverCache: enableCache, ...restOptions } = options;
+      const {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        page: _,
+        serverCache: enableCache,
+        serverCacheThreshold,
+        ...restOptions
+      } = options;
       serverCache = enableCache;
       if (restOptions.model) {
         restOptions.model = this.prepareModelConfig(restOptions.model);
       } else if (this.defaultModelConfig) {
         restOptions.model = this.getDefaultModelConfig();
       }
-      if (Object.keys(restOptions).length > 0) {
-        wireOptions = restOptions as unknown as Api.ObserveRequest["options"];
+      // serverCacheThreshold is SDK-named; the API expects options.cacheThreshold
+      const mappedOptions = {
+        ...restOptions,
+        ...(serverCacheThreshold !== undefined && {
+          cacheThreshold: serverCacheThreshold,
+        }),
+      };
+      if (Object.keys(mappedOptions).length > 0) {
+        wireOptions = mappedOptions as unknown as Api.ObserveRequest["options"];
       }
     } else if (this.defaultModelConfig) {
       wireOptions = {

--- a/packages/core/lib/v3/api.ts
+++ b/packages/core/lib/v3/api.ts
@@ -872,11 +872,12 @@ export class StagehandAPIClient {
               eventData.type === "system" &&
               eventData.data.status === "finished"
             ) {
+              const cacheEnabled = this.shouldUseCache(serverCache);
               return this.attachCacheStatus(
                 eventData.data.result as T,
                 method,
-                cacheStatus,
-                eventData,
+                cacheEnabled ? cacheStatus : null,
+                cacheEnabled ? eventData : { data: {} },
               );
             }
           } catch {

--- a/packages/core/lib/v3/api.ts
+++ b/packages/core/lib/v3/api.ts
@@ -151,6 +151,11 @@ interface ExecuteActionParams {
    * When false, disables server-side caching.
    */
   serverCache?: boolean;
+  /**
+   * When true, attaches detailed cache metadata to the result.
+   * `cacheStatus` is always attached when caching is used.
+   */
+  includeCacheMetadata?: boolean;
 }
 
 /**
@@ -302,15 +307,18 @@ export class StagehandAPIClient {
     // Strip non-serializable `page` and SDK-only fields from options before wire serialization
     let wireOptions: Api.ActRequest["options"];
     let serverCache: boolean | undefined;
+    let includeCacheMetadata: boolean | undefined;
     if (options) {
       const {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         page: _,
         serverCache: enableCache,
         serverCacheThreshold,
+        includeCacheMetadata: includeMetadata,
         ...restOptions
       } = options;
       serverCache = enableCache;
+      includeCacheMetadata = includeMetadata;
       if (restOptions.model) {
         restOptions.model = this.prepareModelConfig(restOptions.model);
       } else if (this.defaultModelConfig) {
@@ -340,6 +348,7 @@ export class StagehandAPIClient {
       method: "act",
       args: requestBody,
       serverCache,
+      includeCacheMetadata,
     });
   }
 
@@ -355,15 +364,18 @@ export class StagehandAPIClient {
     // Strip non-serializable `page` and SDK-only fields from options before wire serialization
     let wireOptions: Api.ExtractRequest["options"];
     let serverCache: boolean | undefined;
+    let includeCacheMetadata: boolean | undefined;
     if (options) {
       const {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         page: _,
         serverCache: enableCache,
         serverCacheThreshold,
+        includeCacheMetadata: includeMetadata,
         ...restOptions
       } = options;
       serverCache = enableCache;
+      includeCacheMetadata = includeMetadata;
       if (restOptions.model) {
         restOptions.model = this.prepareModelConfig(restOptions.model);
       } else if (this.defaultModelConfig) {
@@ -394,6 +406,7 @@ export class StagehandAPIClient {
       method: "extract",
       args: requestBody,
       serverCache,
+      includeCacheMetadata,
     });
   }
 
@@ -405,15 +418,18 @@ export class StagehandAPIClient {
     // Strip non-serializable `page` and SDK-only fields from options before wire serialization
     let wireOptions: Api.ObserveRequest["options"];
     let serverCache: boolean | undefined;
+    let includeCacheMetadata: boolean | undefined;
     if (options) {
       const {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         page: _,
         serverCache: enableCache,
         serverCacheThreshold,
+        includeCacheMetadata: includeMetadata,
         ...restOptions
       } = options;
       serverCache = enableCache;
+      includeCacheMetadata = includeMetadata;
       if (restOptions.model) {
         restOptions.model = this.prepareModelConfig(restOptions.model);
       } else if (this.defaultModelConfig) {
@@ -443,6 +459,7 @@ export class StagehandAPIClient {
       method: "observe",
       args: requestBody,
       serverCache,
+      includeCacheMetadata,
     });
   }
 
@@ -763,6 +780,7 @@ export class StagehandAPIClient {
     args,
     params,
     serverCache,
+    includeCacheMetadata,
   }: ExecuteActionParams): Promise<T> {
     this.lastFinishedEventData = null;
     const urlParams = new URLSearchParams(params as Record<string, string>);
@@ -835,6 +853,7 @@ export class StagehandAPIClient {
                 method,
                 cacheEnabled ? cacheStatus : null,
                 cacheEnabled ? eventData : { data: {} },
+                includeCacheMetadata === true,
               );
             }
           } else if (eventData.type === "log") {
@@ -879,6 +898,7 @@ export class StagehandAPIClient {
                 method,
                 cacheEnabled ? cacheStatus : null,
                 cacheEnabled ? eventData : { data: {} },
+                includeCacheMetadata === true,
               );
             }
           } catch {
@@ -899,6 +919,7 @@ export class StagehandAPIClient {
   /**
    * Resolves the final cache status from the response header or SSE event data,
    * logs it, and attaches it to act/extract results before returning.
+   * Detailed metadata is only attached when `includeCacheMetadata` is true.
    */
   private attachCacheStatus<T>(
     result: T,
@@ -912,6 +933,7 @@ export class StagehandAPIClient {
         tokensSaved?: TokenSavings;
       };
     },
+    includeCacheMetadata: boolean,
   ): T {
     const finalCacheStatus =
       cacheStatus ||
@@ -942,23 +964,25 @@ export class StagehandAPIClient {
         | ExtractResult<any>
         | ObserveResult;
       cacheAwareResult.cacheStatus = finalCacheStatus;
-      if (typeof eventData.data.cacheCount === "number") {
-        cacheAwareResult.cacheHitCount = eventData.data.cacheCount;
-      }
-      const tokensSaved = eventData.data.tokensSaved;
-      if (
-        tokensSaved &&
-        typeof tokensSaved.input === "number" &&
-        typeof tokensSaved.output === "number" &&
-        typeof tokensSaved.total === "number"
-      ) {
-        cacheAwareResult.tokensSaved = tokensSaved;
-      }
-      if (
-        finalCacheStatus === "MISS" &&
-        typeof eventData.data.cacheMissReason === "string"
-      ) {
-        cacheAwareResult.cacheMissReason = eventData.data.cacheMissReason;
+      if (includeCacheMetadata) {
+        if (typeof eventData.data.cacheCount === "number") {
+          cacheAwareResult.cacheHitCount = eventData.data.cacheCount;
+        }
+        const tokensSaved = eventData.data.tokensSaved;
+        if (
+          tokensSaved &&
+          typeof tokensSaved.input === "number" &&
+          typeof tokensSaved.output === "number" &&
+          typeof tokensSaved.total === "number"
+        ) {
+          cacheAwareResult.tokensSaved = tokensSaved;
+        }
+        if (
+          finalCacheStatus === "MISS" &&
+          typeof eventData.data.cacheMissReason === "string"
+        ) {
+          cacheAwareResult.cacheMissReason = eventData.data.cacheMissReason;
+        }
       }
     }
     return result;

--- a/packages/core/lib/v3/api.ts
+++ b/packages/core/lib/v3/api.ts
@@ -943,7 +943,7 @@ export class StagehandAPIClient {
         | ObserveResult;
       cacheAwareResult.cacheStatus = finalCacheStatus;
       if (typeof eventData.data.cacheCount === "number") {
-        cacheAwareResult.cacheCount = eventData.data.cacheCount;
+        cacheAwareResult.cacheHitCount = eventData.data.cacheCount;
       }
       const tokensSaved = eventData.data.tokensSaved;
       if (

--- a/packages/core/lib/v3/api.ts
+++ b/packages/core/lib/v3/api.ts
@@ -911,7 +911,7 @@ export class StagehandAPIClient {
     result: T,
     method: string,
     cacheStatus: "HIT" | "MISS" | null,
-    eventData: { data: { cacheHit?: boolean } },
+    eventData: { data: { cacheHit?: boolean; cacheMissReason?: string } },
   ): T {
     const finalCacheStatus =
       cacheStatus ||
@@ -936,9 +936,18 @@ export class StagehandAPIClient {
       typeof result === "object" &&
       (method === "act" || method === "extract" || method === "observe")
     ) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (result as ActResult | ExtractResult<any> | ObserveResult).cacheStatus =
-        finalCacheStatus;
+      const cacheAwareResult = result as
+        | ActResult
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        | ExtractResult<any>
+        | ObserveResult;
+      cacheAwareResult.cacheStatus = finalCacheStatus;
+      if (
+        finalCacheStatus === "MISS" &&
+        typeof eventData.data.cacheMissReason === "string"
+      ) {
+        cacheAwareResult.cacheMissReason = eventData.data.cacheMissReason;
+      }
     }
     return result;
   }

--- a/packages/core/lib/v3/api.ts
+++ b/packages/core/lib/v3/api.ts
@@ -315,12 +315,9 @@ export class StagehandAPIClient {
       } else if (this.defaultModelConfig) {
         restOptions.model = this.getDefaultModelConfig();
       }
-      // serverCacheThreshold is SDK-named; the API expects options.cacheThreshold
       const mappedOptions = {
         ...restOptions,
-        ...(serverCacheThreshold !== undefined && {
-          cacheThreshold: serverCacheThreshold,
-        }),
+        ...(serverCacheThreshold !== undefined && { serverCacheThreshold }),
       };
       if (Object.keys(mappedOptions).length > 0) {
         wireOptions = mappedOptions as unknown as Api.ActRequest["options"];
@@ -371,12 +368,9 @@ export class StagehandAPIClient {
       } else if (this.defaultModelConfig) {
         restOptions.model = this.getDefaultModelConfig();
       }
-      // serverCacheThreshold is SDK-named; the API expects options.cacheThreshold
       const mappedOptions = {
         ...restOptions,
-        ...(serverCacheThreshold !== undefined && {
-          cacheThreshold: serverCacheThreshold,
-        }),
+        ...(serverCacheThreshold !== undefined && { serverCacheThreshold }),
       };
       if (Object.keys(mappedOptions).length > 0) {
         wireOptions = mappedOptions as unknown as Api.ExtractRequest["options"];
@@ -424,12 +418,9 @@ export class StagehandAPIClient {
       } else if (this.defaultModelConfig) {
         restOptions.model = this.getDefaultModelConfig();
       }
-      // serverCacheThreshold is SDK-named; the API expects options.cacheThreshold
       const mappedOptions = {
         ...restOptions,
-        ...(serverCacheThreshold !== undefined && {
-          cacheThreshold: serverCacheThreshold,
-        }),
+        ...(serverCacheThreshold !== undefined && { serverCacheThreshold }),
       };
       if (Object.keys(mappedOptions).length > 0) {
         wireOptions = mappedOptions as unknown as Api.ObserveRequest["options"];

--- a/packages/core/lib/v3/api.ts
+++ b/packages/core/lib/v3/api.ts
@@ -22,6 +22,7 @@ import type {
   AgentResult,
   ExtractResult,
   ObserveResult,
+  TokenSavings,
   LogLine,
   StagehandMetrics,
   BrowserbaseRegion,
@@ -903,7 +904,14 @@ export class StagehandAPIClient {
     result: T,
     method: string,
     cacheStatus: "HIT" | "MISS" | null,
-    eventData: { data: { cacheHit?: boolean; cacheMissReason?: string } },
+    eventData: {
+      data: {
+        cacheHit?: boolean;
+        cacheMissReason?: string;
+        cacheCount?: number;
+        tokensSaved?: TokenSavings;
+      };
+    },
   ): T {
     const finalCacheStatus =
       cacheStatus ||
@@ -934,6 +942,18 @@ export class StagehandAPIClient {
         | ExtractResult<any>
         | ObserveResult;
       cacheAwareResult.cacheStatus = finalCacheStatus;
+      if (typeof eventData.data.cacheCount === "number") {
+        cacheAwareResult.cacheCount = eventData.data.cacheCount;
+      }
+      const tokensSaved = eventData.data.tokensSaved;
+      if (
+        tokensSaved &&
+        typeof tokensSaved.input === "number" &&
+        typeof tokensSaved.output === "number" &&
+        typeof tokensSaved.total === "number"
+      ) {
+        cacheAwareResult.tokensSaved = tokensSaved;
+      }
       if (
         finalCacheStatus === "MISS" &&
         typeof eventData.data.cacheMissReason === "string"

--- a/packages/core/lib/v3/types/public/api.ts
+++ b/packages/core/lib/v3/types/public/api.ts
@@ -624,6 +624,11 @@ export const ActOptionsSchema = z
       description: "Timeout in ms for the action",
       example: 30000,
     }),
+    cacheThreshold: z.number().int().nonnegative().optional().meta({
+      description:
+        "Per-action override of the server cache validation threshold — how many times this action must be seen before the cached result is served. Persists on the cache entry for later requests that omit it.",
+      example: 5,
+    }),
   })
   .optional()
   .meta({ id: "ActOptions" });
@@ -708,6 +713,11 @@ export const ExtractOptionsSchema = z
         "When true, include a screenshot of the current viewport in the extraction LLM call. Defaults to false.",
       example: false,
     }),
+    cacheThreshold: z.number().int().nonnegative().optional().meta({
+      description:
+        "Per-action override of the server cache validation threshold — how many times this action must be seen before the cached result is served. Persists on the cache entry for later requests that omit it.",
+      example: 5,
+    }),
   })
   .optional()
   .meta({ id: "ExtractOptions" });
@@ -788,6 +798,11 @@ export const ObserveOptionsSchema = z
           "Selectors for elements and subtrees that should be excluded from observation",
         example: ["nav", ".cookie-banner", "#sidebar-ads"],
       }),
+    cacheThreshold: z.number().int().nonnegative().optional().meta({
+      description:
+        "Per-action override of the server cache validation threshold — how many times this action must be seen before the cached result is served. Persists on the cache entry for later requests that omit it.",
+      example: 5,
+    }),
   })
   .optional()
   .meta({ id: "ObserveOptions" });

--- a/packages/core/lib/v3/types/public/api.ts
+++ b/packages/core/lib/v3/types/public/api.ts
@@ -624,7 +624,7 @@ export const ActOptionsSchema = z
       description: "Timeout in ms for the action",
       example: 30000,
     }),
-    cacheThreshold: z.number().int().nonnegative().optional().meta({
+    serverCacheThreshold: z.number().int().nonnegative().optional().meta({
       description:
         "Per-action override of the server cache validation threshold — how many times this action must be seen before the cached result is served. Persists on the cache entry for later requests that omit it.",
       example: 5,
@@ -713,7 +713,7 @@ export const ExtractOptionsSchema = z
         "When true, include a screenshot of the current viewport in the extraction LLM call. Defaults to false.",
       example: false,
     }),
-    cacheThreshold: z.number().int().nonnegative().optional().meta({
+    serverCacheThreshold: z.number().int().nonnegative().optional().meta({
       description:
         "Per-action override of the server cache validation threshold — how many times this action must be seen before the cached result is served. Persists on the cache entry for later requests that omit it.",
       example: 5,
@@ -798,7 +798,7 @@ export const ObserveOptionsSchema = z
           "Selectors for elements and subtrees that should be excluded from observation",
         example: ["nav", ".cookie-banner", "#sidebar-ads"],
       }),
-    cacheThreshold: z.number().int().nonnegative().optional().meta({
+    serverCacheThreshold: z.number().int().nonnegative().optional().meta({
       description:
         "Per-action override of the server cache validation threshold — how many times this action must be seen before the cached result is served. Persists on the cache entry for later requests that omit it.",
       example: 5,

--- a/packages/core/lib/v3/types/public/methods.ts
+++ b/packages/core/lib/v3/types/public/methods.ts
@@ -21,6 +21,13 @@ export interface ActOptions {
    * When false, disables server-side caching.
    */
   serverCache?: boolean;
+  /**
+   * Per-action override of the server cache validation threshold: how many
+   * times this action must be seen before the cached result is served.
+   * The value persists on the cache entry, so later requests that omit it
+   * keep honoring it; passing a new value updates it. Non-negative integer.
+   */
+  serverCacheThreshold?: number;
 }
 
 export interface ActResult {
@@ -63,6 +70,13 @@ export interface ExtractOptions {
    * When false, disables server-side caching.
    */
   serverCache?: boolean;
+  /**
+   * Per-action override of the server cache validation threshold: how many
+   * times this action must be seen before the cached result is served.
+   * The value persists on the cache entry, so later requests that omit it
+   * keep honoring it; passing a new value updates it. Non-negative integer.
+   */
+  serverCacheThreshold?: number;
 }
 
 export const defaultExtractSchema = z.object({
@@ -86,6 +100,13 @@ export interface ObserveOptions {
    * When false, disables server-side caching.
    */
   serverCache?: boolean;
+  /**
+   * Per-action override of the server cache validation threshold: how many
+   * times this action must be seen before the cached result is served.
+   * The value persists on the cache entry, so later requests that omit it
+   * keep honoring it; passing a new value updates it. Non-negative integer.
+   */
+  serverCacheThreshold?: number;
 }
 
 /**

--- a/packages/core/lib/v3/types/public/methods.ts
+++ b/packages/core/lib/v3/types/public/methods.ts
@@ -28,6 +28,12 @@ export interface ActOptions {
    * keep honoring it; passing a new value updates it. Non-negative integer.
    */
   serverCacheThreshold?: number;
+  /**
+   * When true, attaches detailed cache metadata (`cacheHitCount`,
+   * `tokensSaved`, `cacheMissReason`) to the result. `cacheStatus` is always
+   * attached when server caching is used, regardless of this flag.
+   */
+  includeCacheMetadata?: boolean;
 }
 
 export interface TokenSavings {
@@ -42,14 +48,21 @@ export interface ActResult {
   actionDescription: string;
   actions: Action[];
   cacheStatus?: "HIT" | "MISS";
-  /** Cache entry count after this request, when server caching was used. */
+  /**
+   * Cache entry count after this request. Only attached when
+   * `includeCacheMetadata: true` is set on the request options.
+   */
   cacheHitCount?: number;
-  /** Input, output, and total LLM tokens avoided by a server cache hit. */
+  /**
+   * Input, output, and total LLM tokens avoided by a server cache hit.
+   * Only attached when `includeCacheMetadata: true` is set on the request
+   * options.
+   */
   tokensSaved?: TokenSavings;
   /**
    * Why the server cache missed, when it reports a reason (e.g. "threshold",
-   * "empty_array", "timeout", "error"). Absent on hits and on first-time
-   * misses with no prior cache entry.
+   * "empty_array", "timeout", "error"). Only attached when
+   * `includeCacheMetadata: true` is set on the request options.
    */
   cacheMissReason?: string;
 }
@@ -96,6 +109,12 @@ export interface ExtractOptions {
    * keep honoring it; passing a new value updates it. Non-negative integer.
    */
   serverCacheThreshold?: number;
+  /**
+   * When true, attaches detailed cache metadata (`cacheHitCount`,
+   * `tokensSaved`, `cacheMissReason`) to the result. `cacheStatus` is always
+   * attached when server caching is used, regardless of this flag.
+   */
+  includeCacheMetadata?: boolean;
 }
 
 export const defaultExtractSchema = z.object({
@@ -126,15 +145,21 @@ export interface ObserveOptions {
    * keep honoring it; passing a new value updates it. Non-negative integer.
    */
   serverCacheThreshold?: number;
+  /**
+   * When true, attaches detailed cache metadata (`cacheHitCount`,
+   * `tokensSaved`, `cacheMissReason`) to the result. `cacheStatus` is always
+   * attached when server caching is used, regardless of this flag.
+   */
+  includeCacheMetadata?: boolean;
 }
 
 /**
  * Observe returns an array of candidate actions. The optional `cacheStatus`
  * property is attached when the server responds with a
  * `browserbase-cache-status` header so callers can tell whether the result
- * was served from the server-side cache. `cacheHitCount` reports the entry
- * count after the request, `tokensSaved` reports avoided LLM usage, and
- * `cacheMissReason` explains a miss when available.
+ * was served from the server-side cache. Detailed fields (`cacheHitCount`,
+ * `tokensSaved`, `cacheMissReason`) are only attached when
+ * `includeCacheMetadata: true` is set on the request options.
  */
 export type ObserveResult = Action[] & {
   cacheStatus?: "HIT" | "MISS";

--- a/packages/core/lib/v3/types/public/methods.ts
+++ b/packages/core/lib/v3/types/public/methods.ts
@@ -30,12 +30,22 @@ export interface ActOptions {
   serverCacheThreshold?: number;
 }
 
+export interface TokenSavings {
+  input: number;
+  output: number;
+  total: number;
+}
+
 export interface ActResult {
   success: boolean;
   message: string;
   actionDescription: string;
   actions: Action[];
   cacheStatus?: "HIT" | "MISS";
+  /** Cache entry count after this request, when server caching was used. */
+  cacheCount?: number;
+  /** Input, output, and total LLM tokens avoided by a server cache hit. */
+  tokensSaved?: TokenSavings;
   /**
    * Why the server cache missed, when it reports a reason (e.g. "threshold",
    * "empty_array", "timeout", "error"). Absent on hits and on first-time
@@ -47,6 +57,8 @@ export interface ActResult {
 export type ExtractResult<T extends StagehandZodSchema> =
   InferStagehandSchema<T> & {
     cacheStatus?: "HIT" | "MISS";
+    cacheCount?: number;
+    tokensSaved?: TokenSavings;
     cacheMissReason?: string;
   };
 
@@ -120,11 +132,14 @@ export interface ObserveOptions {
  * Observe returns an array of candidate actions. The optional `cacheStatus`
  * property is attached when the server responds with a
  * `browserbase-cache-status` header so callers can tell whether the result
- * was served from the server-side cache. `cacheMissReason` is attached when
- * the server reports why a result missed the cache.
+ * was served from the server-side cache. `cacheCount` reports the entry count
+ * after the request, `tokensSaved` reports avoided LLM usage, and
+ * `cacheMissReason` explains a miss when available.
  */
 export type ObserveResult = Action[] & {
   cacheStatus?: "HIT" | "MISS";
+  cacheCount?: number;
+  tokensSaved?: TokenSavings;
   cacheMissReason?: string;
 };
 

--- a/packages/core/lib/v3/types/public/methods.ts
+++ b/packages/core/lib/v3/types/public/methods.ts
@@ -43,7 +43,7 @@ export interface ActResult {
   actions: Action[];
   cacheStatus?: "HIT" | "MISS";
   /** Cache entry count after this request, when server caching was used. */
-  cacheCount?: number;
+  cacheHitCount?: number;
   /** Input, output, and total LLM tokens avoided by a server cache hit. */
   tokensSaved?: TokenSavings;
   /**
@@ -57,7 +57,7 @@ export interface ActResult {
 export type ExtractResult<T extends StagehandZodSchema> =
   InferStagehandSchema<T> & {
     cacheStatus?: "HIT" | "MISS";
-    cacheCount?: number;
+    cacheHitCount?: number;
     tokensSaved?: TokenSavings;
     cacheMissReason?: string;
   };
@@ -132,13 +132,13 @@ export interface ObserveOptions {
  * Observe returns an array of candidate actions. The optional `cacheStatus`
  * property is attached when the server responds with a
  * `browserbase-cache-status` header so callers can tell whether the result
- * was served from the server-side cache. `cacheCount` reports the entry count
- * after the request, `tokensSaved` reports avoided LLM usage, and
+ * was served from the server-side cache. `cacheHitCount` reports the entry
+ * count after the request, `tokensSaved` reports avoided LLM usage, and
  * `cacheMissReason` explains a miss when available.
  */
 export type ObserveResult = Action[] & {
   cacheStatus?: "HIT" | "MISS";
-  cacheCount?: number;
+  cacheHitCount?: number;
   tokensSaved?: TokenSavings;
   cacheMissReason?: string;
 };

--- a/packages/core/lib/v3/types/public/methods.ts
+++ b/packages/core/lib/v3/types/public/methods.ts
@@ -36,11 +36,18 @@ export interface ActResult {
   actionDescription: string;
   actions: Action[];
   cacheStatus?: "HIT" | "MISS";
+  /**
+   * Why the server cache missed, when it reports a reason (e.g. "threshold",
+   * "empty_array", "timeout", "error"). Absent on hits and on first-time
+   * misses with no prior cache entry.
+   */
+  cacheMissReason?: string;
 }
 
 export type ExtractResult<T extends StagehandZodSchema> =
   InferStagehandSchema<T> & {
     cacheStatus?: "HIT" | "MISS";
+    cacheMissReason?: string;
   };
 
 export interface Action {
@@ -113,9 +120,13 @@ export interface ObserveOptions {
  * Observe returns an array of candidate actions. The optional `cacheStatus`
  * property is attached when the server responds with a
  * `browserbase-cache-status` header so callers can tell whether the result
- * was served from the server-side cache.
+ * was served from the server-side cache. `cacheMissReason` is attached when
+ * the server reports why a result missed the cache.
  */
-export type ObserveResult = Action[] & { cacheStatus?: "HIT" | "MISS" };
+export type ObserveResult = Action[] & {
+  cacheStatus?: "HIT" | "MISS";
+  cacheMissReason?: string;
+};
 
 export enum V3FunctionName {
   ACT = "ACT",

--- a/packages/core/tests/unit/api-client-serialization.test.ts
+++ b/packages/core/tests/unit/api-client-serialization.test.ts
@@ -133,6 +133,92 @@ describe("StagehandAPIClient variable serialization", () => {
     });
   });
 
+  it("maps serverCacheThreshold to wire options.cacheThreshold", async () => {
+    const client = new StagehandAPIClient({
+      apiKey: "bb-test",
+      logger: vi.fn(),
+    });
+    const executeMock = vi.fn().mockResolvedValue({
+      success: true,
+      message: "ok",
+      actionDescription: "clicked",
+      actions: [],
+    });
+
+    (
+      client as unknown as {
+        execute: typeof executeMock;
+      }
+    ).execute = executeMock;
+
+    await client.act({
+      input: "click the submit button",
+      options: {
+        serverCacheThreshold: 5,
+        timeout: 30000,
+      },
+    });
+
+    expect(executeMock).toHaveBeenCalledWith({
+      method: "act",
+      args: {
+        input: "click the submit button",
+        options: {
+          timeout: 30000,
+          cacheThreshold: 5,
+        },
+        frameId: undefined,
+      },
+      serverCache: undefined,
+    });
+  });
+
+  it("maps serverCacheThreshold for observe and extract requests", async () => {
+    const client = new StagehandAPIClient({
+      apiKey: "bb-test",
+      logger: vi.fn(),
+    });
+    const executeMock = vi.fn().mockResolvedValue([]);
+
+    (
+      client as unknown as {
+        execute: typeof executeMock;
+      }
+    ).execute = executeMock;
+
+    await client.observe({
+      instruction: "find the submit button",
+      options: { serverCacheThreshold: 0 },
+    });
+
+    expect(executeMock).toHaveBeenLastCalledWith({
+      method: "observe",
+      args: {
+        instruction: "find the submit button",
+        options: { cacheThreshold: 0 },
+        frameId: undefined,
+      },
+      serverCache: undefined,
+    });
+
+    executeMock.mockResolvedValue({ title: "ok" });
+    await client.extract({
+      instruction: "extract the title",
+      options: { serverCacheThreshold: 10, serverCache: true },
+    });
+
+    expect(executeMock).toHaveBeenLastCalledWith({
+      method: "extract",
+      args: {
+        instruction: "extract the title",
+        schema: undefined,
+        options: { cacheThreshold: 10 },
+        frameId: undefined,
+      },
+      serverCache: true,
+    });
+  });
+
   it("preserves rich variables when sending the agentExecute request", async () => {
     const client = new StagehandAPIClient({
       apiKey: "bb-test",

--- a/packages/core/tests/unit/api-client-serialization.test.ts
+++ b/packages/core/tests/unit/api-client-serialization.test.ts
@@ -344,7 +344,7 @@ describe("StagehandAPIClient cache metadata", () => {
 
     expect(result.cacheStatus).toBe("MISS");
     expect(result.cacheMissReason).toBe("threshold");
-    expect(result.cacheCount).toBe(3);
+    expect(result.cacheHitCount).toBe(3);
     expect(result.tokensSaved).toEqual({ input: 0, output: 0, total: 0 });
   });
 
@@ -358,7 +358,7 @@ describe("StagehandAPIClient cache metadata", () => {
 
     expect(result.cacheStatus).toBe("HIT");
     expect(result.cacheMissReason).toBeUndefined();
-    expect(result.cacheCount).toBe(8);
+    expect(result.cacheHitCount).toBe(8);
     expect(result.tokensSaved).toEqual({
       input: 120,
       output: 30,
@@ -385,7 +385,7 @@ describe("StagehandAPIClient cache metadata", () => {
 
     expect(result.cacheStatus).toBeUndefined();
     expect(result.cacheMissReason).toBeUndefined();
-    expect(result.cacheCount).toBeUndefined();
+    expect(result.cacheHitCount).toBeUndefined();
     expect(result.tokensSaved).toBeUndefined();
   });
 });

--- a/packages/core/tests/unit/api-client-serialization.test.ts
+++ b/packages/core/tests/unit/api-client-serialization.test.ts
@@ -283,11 +283,15 @@ describe("StagehandAPIClient cache metadata", () => {
   const runAct = async ({
     cacheHit,
     cacheMissReason,
+    cacheCount,
+    tokensSaved,
     serverCache = true,
     finalEventBuffered = false,
   }: {
     cacheHit: boolean;
     cacheMissReason?: string;
+    cacheCount?: number;
+    tokensSaved?: { input: number; output: number; total: number };
     serverCache?: boolean;
     finalEventBuffered?: boolean;
   }) => {
@@ -307,6 +311,8 @@ describe("StagehandAPIClient cache metadata", () => {
         },
         cacheHit,
         ...(cacheMissReason !== undefined && { cacheMissReason }),
+        ...(cacheCount !== undefined && { cacheCount }),
+        ...(tokensSaved !== undefined && { tokensSaved }),
       },
     };
     const cacheStatus = cacheHit ? "HIT" : "MISS";
@@ -332,20 +338,32 @@ describe("StagehandAPIClient cache metadata", () => {
     const result = await runAct({
       cacheHit: false,
       cacheMissReason: "threshold",
+      cacheCount: 3,
+      tokensSaved: { input: 0, output: 0, total: 0 },
     });
 
     expect(result.cacheStatus).toBe("MISS");
     expect(result.cacheMissReason).toBe("threshold");
+    expect(result.cacheCount).toBe(3);
+    expect(result.tokensSaved).toEqual({ input: 0, output: 0, total: 0 });
   });
 
   it("does not attach a miss reason to a cache hit", async () => {
     const result = await runAct({
       cacheHit: true,
       cacheMissReason: "threshold",
+      cacheCount: 8,
+      tokensSaved: { input: 120, output: 30, total: 150 },
     });
 
     expect(result.cacheStatus).toBe("HIT");
     expect(result.cacheMissReason).toBeUndefined();
+    expect(result.cacheCount).toBe(8);
+    expect(result.tokensSaved).toEqual({
+      input: 120,
+      output: 30,
+      total: 150,
+    });
   });
 
   it("does not attach a miss reason when none is provided", async () => {
@@ -359,11 +377,15 @@ describe("StagehandAPIClient cache metadata", () => {
     const result = await runAct({
       cacheHit: false,
       cacheMissReason: "threshold",
+      cacheCount: 3,
+      tokensSaved: { input: 0, output: 0, total: 0 },
       serverCache: false,
       finalEventBuffered: true,
     });
 
     expect(result.cacheStatus).toBeUndefined();
     expect(result.cacheMissReason).toBeUndefined();
+    expect(result.cacheCount).toBeUndefined();
+    expect(result.tokensSaved).toBeUndefined();
   });
 });

--- a/packages/core/tests/unit/api-client-serialization.test.ts
+++ b/packages/core/tests/unit/api-client-serialization.test.ts
@@ -50,6 +50,7 @@ describe("StagehandAPIClient variable serialization", () => {
         frameId: undefined,
       },
       serverCache: undefined,
+      includeCacheMetadata: undefined,
     });
   });
 
@@ -84,6 +85,7 @@ describe("StagehandAPIClient variable serialization", () => {
         frameId: undefined,
       },
       serverCache: undefined,
+      includeCacheMetadata: undefined,
     });
   });
 
@@ -131,6 +133,7 @@ describe("StagehandAPIClient variable serialization", () => {
         frameId: undefined,
       },
       serverCache: undefined,
+      includeCacheMetadata: undefined,
     });
   });
 
@@ -171,6 +174,7 @@ describe("StagehandAPIClient variable serialization", () => {
         frameId: undefined,
       },
       serverCache: undefined,
+      includeCacheMetadata: undefined,
     });
   });
 
@@ -200,6 +204,7 @@ describe("StagehandAPIClient variable serialization", () => {
         frameId: undefined,
       },
       serverCache: undefined,
+      includeCacheMetadata: undefined,
     });
 
     executeMock.mockResolvedValue({ title: "ok" });
@@ -217,6 +222,7 @@ describe("StagehandAPIClient variable serialization", () => {
         frameId: undefined,
       },
       serverCache: true,
+      includeCacheMetadata: undefined,
     });
   });
 
@@ -286,6 +292,7 @@ describe("StagehandAPIClient cache metadata", () => {
     cacheCount,
     tokensSaved,
     serverCache = true,
+    includeCacheMetadata,
     finalEventBuffered = false,
   }: {
     cacheHit: boolean;
@@ -293,6 +300,7 @@ describe("StagehandAPIClient cache metadata", () => {
     cacheCount?: number;
     tokensSaved?: { input: number; output: number; total: number };
     serverCache?: boolean;
+    includeCacheMetadata?: boolean;
     finalEventBuffered?: boolean;
   }) => {
     const client = new StagehandAPIClient({
@@ -330,16 +338,31 @@ describe("StagehandAPIClient cache metadata", () => {
 
     return client.act({
       input: "click the submit button",
-      options: { serverCache },
+      options: { serverCache, includeCacheMetadata },
     });
   };
 
-  it("attaches the reason when a cache miss provides one", async () => {
+  it("always attaches cacheStatus when caching is enabled", async () => {
     const result = await runAct({
       cacheHit: false,
       cacheMissReason: "threshold",
       cacheCount: 3,
       tokensSaved: { input: 0, output: 0, total: 0 },
+    });
+
+    expect(result.cacheStatus).toBe("MISS");
+    expect(result.cacheMissReason).toBeUndefined();
+    expect(result.cacheHitCount).toBeUndefined();
+    expect(result.tokensSaved).toBeUndefined();
+  });
+
+  it("attaches detailed metadata only when includeCacheMetadata is true", async () => {
+    const result = await runAct({
+      cacheHit: false,
+      cacheMissReason: "threshold",
+      cacheCount: 3,
+      tokensSaved: { input: 0, output: 0, total: 0 },
+      includeCacheMetadata: true,
     });
 
     expect(result.cacheStatus).toBe("MISS");
@@ -354,6 +377,7 @@ describe("StagehandAPIClient cache metadata", () => {
       cacheMissReason: "threshold",
       cacheCount: 8,
       tokensSaved: { input: 120, output: 30, total: 150 },
+      includeCacheMetadata: true,
     });
 
     expect(result.cacheStatus).toBe("HIT");
@@ -367,7 +391,10 @@ describe("StagehandAPIClient cache metadata", () => {
   });
 
   it("does not attach a miss reason when none is provided", async () => {
-    const result = await runAct({ cacheHit: false });
+    const result = await runAct({
+      cacheHit: false,
+      includeCacheMetadata: true,
+    });
 
     expect(result.cacheStatus).toBe("MISS");
     expect(result.cacheMissReason).toBeUndefined();
@@ -380,6 +407,7 @@ describe("StagehandAPIClient cache metadata", () => {
       cacheCount: 3,
       tokensSaved: { input: 0, output: 0, total: 0 },
       serverCache: false,
+      includeCacheMetadata: true,
       finalEventBuffered: true,
     });
 
@@ -387,5 +415,45 @@ describe("StagehandAPIClient cache metadata", () => {
     expect(result.cacheMissReason).toBeUndefined();
     expect(result.cacheHitCount).toBeUndefined();
     expect(result.tokensSaved).toBeUndefined();
+  });
+
+  it("strips includeCacheMetadata from the wire options", async () => {
+    const client = new StagehandAPIClient({
+      apiKey: "bb-test",
+      logger: vi.fn(),
+    });
+    const executeMock = vi.fn().mockResolvedValue({
+      success: true,
+      message: "ok",
+      actionDescription: "clicked",
+      actions: [],
+    });
+
+    (
+      client as unknown as {
+        execute: typeof executeMock;
+      }
+    ).execute = executeMock;
+
+    await client.act({
+      input: "click the submit button",
+      options: {
+        includeCacheMetadata: true,
+        serverCacheThreshold: 5,
+      },
+    });
+
+    expect(executeMock).toHaveBeenCalledWith({
+      method: "act",
+      args: {
+        input: "click the submit button",
+        options: {
+          serverCacheThreshold: 5,
+        },
+        frameId: undefined,
+      },
+      serverCache: undefined,
+      includeCacheMetadata: true,
+    });
   });
 });

--- a/packages/core/tests/unit/api-client-serialization.test.ts
+++ b/packages/core/tests/unit/api-client-serialization.test.ts
@@ -133,7 +133,7 @@ describe("StagehandAPIClient variable serialization", () => {
     });
   });
 
-  it("maps serverCacheThreshold to wire options.cacheThreshold", async () => {
+  it("sends serverCacheThreshold in the wire options for act", async () => {
     const client = new StagehandAPIClient({
       apiKey: "bb-test",
       logger: vi.fn(),
@@ -165,7 +165,7 @@ describe("StagehandAPIClient variable serialization", () => {
         input: "click the submit button",
         options: {
           timeout: 30000,
-          cacheThreshold: 5,
+          serverCacheThreshold: 5,
         },
         frameId: undefined,
       },
@@ -173,7 +173,7 @@ describe("StagehandAPIClient variable serialization", () => {
     });
   });
 
-  it("maps serverCacheThreshold for observe and extract requests", async () => {
+  it("sends serverCacheThreshold in the wire options for observe and extract", async () => {
     const client = new StagehandAPIClient({
       apiKey: "bb-test",
       logger: vi.fn(),
@@ -195,7 +195,7 @@ describe("StagehandAPIClient variable serialization", () => {
       method: "observe",
       args: {
         instruction: "find the submit button",
-        options: { cacheThreshold: 0 },
+        options: { serverCacheThreshold: 0 },
         frameId: undefined,
       },
       serverCache: undefined,
@@ -212,7 +212,7 @@ describe("StagehandAPIClient variable serialization", () => {
       args: {
         instruction: "extract the title",
         schema: undefined,
-        options: { cacheThreshold: 10 },
+        options: { serverCacheThreshold: 10 },
         frameId: undefined,
       },
       serverCache: true,

--- a/packages/core/tests/unit/api-client-serialization.test.ts
+++ b/packages/core/tests/unit/api-client-serialization.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { StagehandAPIClient } from "../../lib/v3/api.js";
+import type { ActResult } from "../../lib/v3/types/public/index.js";
 
 describe("StagehandAPIClient variable serialization", () => {
   it("preserves rich variables when sending the act request", async () => {
@@ -275,5 +276,94 @@ describe("StagehandAPIClient variable serialization", () => {
         shouldCache: undefined,
       },
     });
+  });
+});
+
+describe("StagehandAPIClient cache metadata", () => {
+  const runAct = async ({
+    cacheHit,
+    cacheMissReason,
+    serverCache = true,
+    finalEventBuffered = false,
+  }: {
+    cacheHit: boolean;
+    cacheMissReason?: string;
+    serverCache?: boolean;
+    finalEventBuffered?: boolean;
+  }) => {
+    const client = new StagehandAPIClient({
+      apiKey: "bb-test",
+      logger: vi.fn(),
+    });
+    const event = {
+      type: "system",
+      data: {
+        status: "finished",
+        result: {
+          success: true,
+          message: "ok",
+          actionDescription: "clicked",
+          actions: [] as ActResult["actions"],
+        },
+        cacheHit,
+        ...(cacheMissReason !== undefined && { cacheMissReason }),
+      },
+    };
+    const cacheStatus = cacheHit ? "HIT" : "MISS";
+    const eventTerminator = finalEventBuffered ? "" : "\n\n";
+
+    (
+      client as unknown as {
+        request: () => Promise<Response>;
+      }
+    ).request = vi.fn().mockResolvedValue(
+      new Response(`data: ${JSON.stringify(event)}${eventTerminator}`, {
+        headers: { "browserbase-cache-status": cacheStatus },
+      }),
+    );
+
+    return client.act({
+      input: "click the submit button",
+      options: { serverCache },
+    });
+  };
+
+  it("attaches the reason when a cache miss provides one", async () => {
+    const result = await runAct({
+      cacheHit: false,
+      cacheMissReason: "threshold",
+    });
+
+    expect(result.cacheStatus).toBe("MISS");
+    expect(result.cacheMissReason).toBe("threshold");
+  });
+
+  it("does not attach a miss reason to a cache hit", async () => {
+    const result = await runAct({
+      cacheHit: true,
+      cacheMissReason: "threshold",
+    });
+
+    expect(result.cacheStatus).toBe("HIT");
+    expect(result.cacheMissReason).toBeUndefined();
+  });
+
+  it("does not attach a miss reason when none is provided", async () => {
+    const result = await runAct({ cacheHit: false });
+
+    expect(result.cacheStatus).toBe("MISS");
+    expect(result.cacheMissReason).toBeUndefined();
+  });
+
+  it("suppresses cache metadata from a final buffered event when caching is disabled", async () => {
+    const result = await runAct({
+      cacheHit: false,
+      cacheMissReason: "threshold",
+      serverCache: false,
+      finalEventBuffered: true,
+    });
+
+    expect(result.cacheStatus).toBeUndefined();
+    expect(result.cacheMissReason).toBeUndefined();
   });
 });

--- a/packages/core/tests/unit/public-api/public-types.test.ts
+++ b/packages/core/tests/unit/public-api/public-types.test.ts
@@ -136,6 +136,7 @@ describe("Stagehand public API types", () => {
       timeout?: number;
       page?: Stagehand.AnyPage;
       serverCache?: boolean;
+      serverCacheThreshold?: number;
     };
 
     it("matches expected type shape", () => {
@@ -166,6 +167,7 @@ describe("Stagehand public API types", () => {
       screenshot?: boolean;
       page?: Stagehand.AnyPage;
       serverCache?: boolean;
+      serverCacheThreshold?: number;
     };
 
     it("matches expected type shape", () => {
@@ -182,6 +184,7 @@ describe("Stagehand public API types", () => {
       ignoreSelectors?: string[];
       page?: Stagehand.AnyPage;
       serverCache?: boolean;
+      serverCacheThreshold?: number;
     };
 
     it("matches expected type shape", () => {

--- a/packages/core/tests/unit/public-api/public-types.test.ts
+++ b/packages/core/tests/unit/public-api/public-types.test.ts
@@ -20,6 +20,7 @@ type ExpectedExportedTypes = {
   // Types from methods.ts
   ActOptions: Stagehand.ActOptions;
   ActResult: Stagehand.ActResult;
+  TokenSavings: Stagehand.TokenSavings;
   ExtractResult: Stagehand.ExtractResult<Stagehand.StagehandZodSchema>;
   Action: Stagehand.Action;
   HistoryEntry: Stagehand.HistoryEntry;
@@ -151,6 +152,8 @@ describe("Stagehand public API types", () => {
       actionDescription: string;
       actions: Stagehand.Action[];
       cacheStatus?: "HIT" | "MISS";
+      cacheCount?: number;
+      tokensSaved?: Stagehand.TokenSavings;
       cacheMissReason?: string;
     };
 
@@ -198,6 +201,12 @@ describe("Stagehand public API types", () => {
       expectTypeOf<Stagehand.ObserveResult>().toExtend<Stagehand.Action[]>();
       expectTypeOf<Stagehand.ObserveResult["cacheStatus"]>().toEqualTypeOf<
         "HIT" | "MISS" | undefined
+      >();
+      expectTypeOf<Stagehand.ObserveResult["cacheCount"]>().toEqualTypeOf<
+        number | undefined
+      >();
+      expectTypeOf<Stagehand.ObserveResult["tokensSaved"]>().toEqualTypeOf<
+        Stagehand.TokenSavings | undefined
       >();
       expectTypeOf<Stagehand.ObserveResult["cacheMissReason"]>().toEqualTypeOf<
         string | undefined

--- a/packages/core/tests/unit/public-api/public-types.test.ts
+++ b/packages/core/tests/unit/public-api/public-types.test.ts
@@ -152,7 +152,7 @@ describe("Stagehand public API types", () => {
       actionDescription: string;
       actions: Stagehand.Action[];
       cacheStatus?: "HIT" | "MISS";
-      cacheCount?: number;
+      cacheHitCount?: number;
       tokensSaved?: Stagehand.TokenSavings;
       cacheMissReason?: string;
     };
@@ -202,7 +202,7 @@ describe("Stagehand public API types", () => {
       expectTypeOf<Stagehand.ObserveResult["cacheStatus"]>().toEqualTypeOf<
         "HIT" | "MISS" | undefined
       >();
-      expectTypeOf<Stagehand.ObserveResult["cacheCount"]>().toEqualTypeOf<
+      expectTypeOf<Stagehand.ObserveResult["cacheHitCount"]>().toEqualTypeOf<
         number | undefined
       >();
       expectTypeOf<Stagehand.ObserveResult["tokensSaved"]>().toEqualTypeOf<

--- a/packages/core/tests/unit/public-api/public-types.test.ts
+++ b/packages/core/tests/unit/public-api/public-types.test.ts
@@ -151,6 +151,7 @@ describe("Stagehand public API types", () => {
       actionDescription: string;
       actions: Stagehand.Action[];
       cacheStatus?: "HIT" | "MISS";
+      cacheMissReason?: string;
     };
 
     it("matches expected type shape", () => {
@@ -197,6 +198,9 @@ describe("Stagehand public API types", () => {
       expectTypeOf<Stagehand.ObserveResult>().toExtend<Stagehand.Action[]>();
       expectTypeOf<Stagehand.ObserveResult["cacheStatus"]>().toEqualTypeOf<
         "HIT" | "MISS" | undefined
+      >();
+      expectTypeOf<Stagehand.ObserveResult["cacheMissReason"]>().toEqualTypeOf<
+        string | undefined
       >();
     });
   });

--- a/packages/core/tests/unit/public-api/public-types.test.ts
+++ b/packages/core/tests/unit/public-api/public-types.test.ts
@@ -138,6 +138,7 @@ describe("Stagehand public API types", () => {
       page?: Stagehand.AnyPage;
       serverCache?: boolean;
       serverCacheThreshold?: number;
+      includeCacheMetadata?: boolean;
     };
 
     it("matches expected type shape", () => {
@@ -172,6 +173,7 @@ describe("Stagehand public API types", () => {
       page?: Stagehand.AnyPage;
       serverCache?: boolean;
       serverCacheThreshold?: number;
+      includeCacheMetadata?: boolean;
     };
 
     it("matches expected type shape", () => {
@@ -189,6 +191,7 @@ describe("Stagehand public API types", () => {
       page?: Stagehand.AnyPage;
       serverCache?: boolean;
       serverCacheThreshold?: number;
+      includeCacheMetadata?: boolean;
     };
 
     it("matches expected type shape", () => {


### PR DESCRIPTION
## Summary

Adds the SDK side of caching configurability: a per-action override of the server cache validation threshold.

```typescript
await stagehand.act("click submit", {
  serverCacheThreshold: 5,
});
```

- `serverCacheThreshold?: number` (non-negative integer) added to `ActOptions`, `ObserveOptions`, and `ExtractOptions`
- The API client maps it to `options.cacheThreshold` on the wire and strips the SDK-named field, following the existing `serverCache` pattern
- Wire schemas (`ActOptionsSchema` / `ObserveOptionsSchema` / `ExtractOptionsSchema`) gain the `cacheThreshold` field
- Ignored in local (non-API) mode, same as `serverCache`

## Tests

- Serialization tests: `serverCacheThreshold` maps to `options.cacheThreshold` for act/observe/extract and is never sent under its SDK name
- Public type-shape tests updated for the new option


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-action server cache threshold and an opt-in flag for detailed cache metadata on `act`, `observe`, and `extract`. `cacheStatus` is still attached by default when caching is used, and all cache fields remain suppressed when caching is disabled.

- **New Features**
  - Added `serverCacheThreshold?: number` to `ActOptions`, `ObserveOptions`, and `ExtractOptions`; sent as `serverCacheThreshold` and included in the wire schemas.
  - Added `includeCacheMetadata?: boolean`; when true, results include `cacheHitCount`, `tokensSaved` (input/output/total), and `cacheMissReason` on misses. `cacheStatus` is always present when caching is used.
  - Introduced `TokenSavings` type. Ignored in local (non-API) mode. Meets STG-2564, STG-2602, STG-2614.

- **Bug Fixes**
  - Suppress all cache metadata (`cacheStatus`, `cacheMissReason`, `cacheHitCount`, `tokensSaved`) when `serverCache: false`, including for final buffered SSE events (STG-2602).
  - Expose server `cacheCount` as `cacheHitCount` on results when metadata is included (STG-2602).

<sup>Written for commit d91acabf511998039cb0ab01e887266593a50003. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



