### PR TITLE
fix: silence AI SDK "system message in messages" warning in act/extract/observe

### DIFF
--- a/.changeset/aisdk-allow-system-in-messages-act-extract-observe.md
+++ b/.changeset/aisdk-allow-system-in-messages-act-extract-observe.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Remove the noisy AI SDK "system message in messages" warning from `act()`, `extract()`, and `observe()` (including when the agent's own tools call them internally).

--- a/packages/core/lib/v3/external_clients/aisdk.ts
+++ b/packages/core/lib/v3/external_clients/aisdk.ts
@@ -86,6 +86,7 @@ export class AISdkClient extends LLMClient {
         model: this.model,
         messages: formattedMessages,
         schema: options.response_model.schema,
+        allowSystemInMessages: true,
       });
 
       return {
@@ -113,6 +114,7 @@ export class AISdkClient extends LLMClient {
       model: this.model,
       messages: formattedMessages,
       tools,
+      allowSystemInMessages: true,
     });
 
     return {

--- a/packages/core/lib/v3/llm/aisdk.ts
+++ b/packages/core/lib/v3/llm/aisdk.ts
@@ -252,6 +252,7 @@ You must respond in JSON format. respond WITH JSON. Do not include any other tex
           messages: formattedMessages,
           schema: options.response_model.schema,
           temperature,
+          allowSystemInMessages: true,
           ...(Object.keys(providerOptions).length > 0
             ? { providerOptions }
             : {}),
@@ -383,6 +384,7 @@ You must respond in JSON format. respond WITH JSON. Do not include any other tex
                 : "auto"
             : undefined,
         temperature,
+        allowSystemInMessages: true,
       });
     } catch (err) {
       // Log error response to maintain request/response pairing

--- a/packages/core/tests/unit/aisdk-clients.test.ts
+++ b/packages/core/tests/unit/aisdk-clients.test.ts
@@ -1,5 +1,5 @@
 import type { LanguageModelV2 } from "@ai-sdk/provider";
-import { generateObject } from "ai";
+import { generateObject, generateText } from "ai";
 import { z } from "zod";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AISdkClient } from "../../lib/v3/llm/aisdk.js";
@@ -9,10 +9,12 @@ vi.mock("ai", async () => {
   return {
     ...actual,
     generateObject: vi.fn(),
+    generateText: vi.fn(),
   };
 });
 
 const mockGenerateObject = vi.mocked(generateObject);
+const mockGenerateText = vi.mocked(generateText);
 
 function createModel(modelId: string) {
   return {
@@ -96,6 +98,78 @@ describe("AISdkClient structured output provider options", () => {
       expect.objectContaining({
         temperature: undefined,
       }),
+    );
+  });
+});
+
+describe("AISdkClient allowSystemInMessages", () => {
+  beforeEach(() => {
+    mockGenerateObject.mockReset();
+    mockGenerateObject.mockResolvedValue({
+      object: { ok: true },
+      usage: {
+        inputTokens: 1,
+        outputTokens: 2,
+        reasoningTokens: 0,
+        cachedInputTokens: 0,
+        totalTokens: 3,
+      },
+    } as never);
+
+    mockGenerateText.mockReset();
+    mockGenerateText.mockResolvedValue({
+      text: "done",
+      toolCalls: [],
+      finishReason: "stop",
+      usage: {
+        inputTokens: 1,
+        outputTokens: 2,
+        reasoningTokens: 0,
+        cachedInputTokens: 0,
+        totalTokens: 3,
+      },
+    } as never);
+  });
+
+  const systemAndUserMessages = [
+    { role: "system" as const, content: "you are a helpful assistant" },
+    { role: "user" as const, content: "hello" },
+  ];
+
+  it("passes allowSystemInMessages: true on the generateObject (response_model) call", async () => {
+    const client = new AISdkClient({
+      model: createModel("anthropic/claude-haiku-4-5"),
+      logger: vi.fn(),
+    });
+
+    await client.createChatCompletion({
+      options: {
+        messages: systemAndUserMessages,
+        response_model: { name: "test", schema: z.object({ ok: z.boolean() }) },
+      },
+      logger: vi.fn(),
+    });
+
+    expect(mockGenerateObject).toHaveBeenCalledWith(
+      expect.objectContaining({ allowSystemInMessages: true }),
+    );
+  });
+
+  it("passes allowSystemInMessages: true on the generateText (tool-calling) call", async () => {
+    const client = new AISdkClient({
+      model: createModel("anthropic/claude-haiku-4-5"),
+      logger: vi.fn(),
+    });
+
+    await client.createChatCompletion({
+      options: {
+        messages: systemAndUserMessages,
+      },
+      logger: vi.fn(),
+    });
+
+    expect(mockGenerateText).toHaveBeenCalledWith(
+      expect.objectContaining({ allowSystemInMessages: true }),
     );
   });
 });

--- a/packages/core/tests/unit/external-aisdk-client.test.ts
+++ b/packages/core/tests/unit/external-aisdk-client.test.ts
@@ -1,0 +1,92 @@
+import type { LanguageModelV2 } from "@ai-sdk/provider";
+import { generateObject, generateText } from "ai";
+import { z } from "zod";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AISdkClient } from "../../lib/v3/external_clients/aisdk.js";
+
+vi.mock("ai", async () => {
+  const actual = await vi.importActual<typeof import("ai")>("ai");
+  return {
+    ...actual,
+    generateObject: vi.fn(),
+    generateText: vi.fn(),
+  };
+});
+
+const mockGenerateObject = vi.mocked(generateObject);
+const mockGenerateText = vi.mocked(generateText);
+
+function createModel(modelId: string) {
+  return {
+    modelId,
+    specificationVersion: "v2",
+  } as unknown as LanguageModelV2;
+}
+
+describe("BYOC AISdkClient allowSystemInMessages", () => {
+  beforeEach(() => {
+    mockGenerateObject.mockReset();
+    mockGenerateObject.mockResolvedValue({
+      object: { ok: true },
+      usage: {
+        inputTokens: 1,
+        outputTokens: 2,
+        reasoningTokens: 0,
+        cachedInputTokens: 0,
+        totalTokens: 3,
+      },
+    } as never);
+
+    mockGenerateText.mockReset();
+    mockGenerateText.mockResolvedValue({
+      text: "done",
+      toolCalls: [],
+      finishReason: "stop",
+      usage: {
+        inputTokens: 1,
+        outputTokens: 2,
+        reasoningTokens: 0,
+        cachedInputTokens: 0,
+        totalTokens: 3,
+      },
+    } as never);
+  });
+
+  const systemAndUserMessages = [
+    { role: "system" as const, content: "you are a helpful assistant" },
+    { role: "user" as const, content: "hello" },
+  ];
+
+  it("passes allowSystemInMessages: true on the generateObject (response_model) call", async () => {
+    const client = new AISdkClient({ model: createModel("openai/gpt-4.1") });
+
+    await client.createChatCompletion({
+      options: {
+        messages: systemAndUserMessages,
+        response_model: { name: "test", schema: z.object({ ok: z.boolean() }) },
+        tools: [],
+      },
+      logger: vi.fn(),
+    });
+
+    expect(mockGenerateObject).toHaveBeenCalledWith(
+      expect.objectContaining({ allowSystemInMessages: true }),
+    );
+  });
+
+  it("passes allowSystemInMessages: true on the generateText (tool-calling) call", async () => {
+    const client = new AISdkClient({ model: createModel("openai/gpt-4.1") });
+
+    await client.createChatCompletion({
+      options: {
+        messages: systemAndUserMessages,
+        tools: [],
+      },
+      logger: vi.fn(),
+    });
+
+    expect(mockGenerateText).toHaveBeenCalledWith(
+      expect.objectContaining({ allowSystemInMessages: true }),
+    );
+  });
+});


### PR DESCRIPTION
## What & why

[#2305](https://github.com/browserbase/stagehand/pull/2305) silenced the AI SDK v5 "system message in messages" warning, but only for `agent.execute()`'s outer loop (`v3AgentHandler.ts`). `act()`, `extract()`, and `observe()` build their system prompt the same way — a `{ role: "system", ... }` message inside the `messages` array — and route through a separate call path that was never patched: `AISdkClient.createChatCompletion()` in `packages/core/lib/v3/llm/aisdk.ts` (the default client for any `"provider/model"` string), plus the identical pattern in the public BYOC client `packages/core/lib/v3/external_clients/aisdk.ts`.

Since the hybrid/DOM agent's own `act`/`extract`/`observe` tools call these primitives internally on every step, an `agent.execute()` run that clicks/types repeatedly still spammed the warning even after upgrading past the first fix — a customer reported exactly this.

### Fix
Add `allowSystemInMessages: true` to the 4 remaining `generateObject`/`generateText` call sites (2 in `llm/aisdk.ts`, 2 in `external_clients/aisdk.ts`), same pattern as the original fix.

## E2E Test Matrix

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| **BEFORE** — published `@browserbasehq/stagehand@alpha` (already includes #2305's fix), `act()` → `extract()` → `observe()` chain on a real Browserbase session | `AI SDK system-in-messages warnings emitted: YES (4)` | Reproduces the customer's exact symptom on the current alpha — confirms #2305 left this path unpatched. |
| **AFTER** — local patched build (this branch), identical `act()` → `extract()` → `observe()` chain, same model, real Browserbase session | `AI SDK system-in-messages warnings emitted: NO (0)` | Proves the fix removes the warning from all three primitives. |
| **AFTER** — local patched build, full chain: `act()` + `extract()` + `observe()` + hybrid `agent.execute()` (multi-step form fill, real Browserbase session) | `AI SDK system-in-messages warnings emitted: NO (0 total)` | Confirms no regression on the already-fixed `agent.execute()` outer loop, and that the agent's internal act/extract/observe tool calls are also silenced end-to-end. |
| `pnpm turbo run build --filter @browserbasehq/stagehand` | `Tasks: 3 successful, 3 total` | Typecheck + emit green. |
| `eslint` + `prettier --check` on changed files | Both clean | Style/lint gates pass. |

A/B model: `anthropic/claude-haiku-4-5-20251001`, `experimental: true`, hybrid agent mode — same harness shape as #2305's own E2E matrix.

Closes STG-2573.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Silences the noisy "system message in messages" warning in `act()`, `extract()`, and `observe()`, including internal tool calls. Sets `allowSystemInMessages: true` at 4 `generateObject`/`generateText` sites and adds unit tests for both AISDK clients; closes STG-2573.

<sup>Written for commit d001bd5b890c28827159ba42bb375b3116a4f833. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

