### PR TITLE
fix: warn when process env shadows dotenv keys in browse doctor

### DIFF
--- a/.changeset/doctor-env-shadow-warning.md
+++ b/.changeset/doctor-env-shadow-warning.md
@@ -1,0 +1,5 @@
+---
+"browse": patch
+---
+
+`browse doctor` now warns when a process-level environment variable differs from `.env` or `.env.local`, so conflicting configuration between projects is easier to spot.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -273,7 +273,10 @@ Set your Browserbase API key to enable remote sessions and cloud commands:
 
 ```bash
 export BROWSERBASE_API_KEY=bb_live_...
+browse doctor                           # run to check that it's configured correctly
 ```
+
+Any `BROWSERBASE_API_KEY` in the current shell environment takes precedence over `.env` (note the `browse` CLI does not auto-load from `.env.local`, only `.env`).
 
 Local driver commands (`--local`) work without an API key.
 

--- a/packages/cli/src/lib/driver/doctor.ts
+++ b/packages/cli/src/lib/driver/doctor.ts
@@ -1,4 +1,7 @@
 import { promises as fs } from "node:fs";
+import { join } from "node:path";
+
+import { parse } from "dotenv";
 
 import { CommandFailure } from "../errors.js";
 import { getDriverStatus } from "./daemon/client.js";
@@ -49,6 +52,7 @@ export interface BuildDoctorReportOptions {
 }
 
 export interface DoctorDeps {
+  cwd?: string;
   discoverLocalCdp?: typeof discoverLocalCdp;
   env?: NodeJS.ProcessEnv;
   getDriverStatus?: typeof getDriverStatus;
@@ -194,6 +198,12 @@ export async function buildDoctorReport(
     if (modeCheck) checks.push(modeCheck);
   }
 
+  const environmentWarning = await dotenvShadowingWarning(
+    env,
+    deps.cwd ?? process.cwd(),
+  );
+  if (environmentWarning) checks.push(environmentWarning);
+
   const verdict = reportVerdict(checks);
   return {
     checks,
@@ -232,6 +242,48 @@ export function renderDoctorReport(report: DoctorReport): string {
     lines.push(`Next: ${report.next}`);
   }
   return lines.join("\n");
+}
+
+async function dotenvShadowingWarning(
+  env: NodeJS.ProcessEnv,
+  cwd: string,
+): Promise<DoctorCheck | null> {
+  const envKeys = (await getRemote()).forwardedEnvKeys();
+  const dotenvFiles = [".env", ".env.local"];
+  const conflicts: Array<{ file: string; variable: string }> = [];
+
+  for (const file of dotenvFiles) {
+    let parsed: Record<string, string>;
+    try {
+      parsed = parse(await fs.readFile(join(cwd, file)));
+    } catch {
+      continue;
+    }
+
+    for (const variable of envKeys) {
+      const processValue = env[variable];
+      const fileValue = parsed[variable];
+      if (
+        typeof processValue === "string" &&
+        typeof fileValue === "string" &&
+        fileValue !== processValue
+      ) {
+        conflicts.push({ file, variable });
+      }
+    }
+  }
+
+  if (conflicts.length === 0) return null;
+
+  const files = [...new Set(conflicts.map(({ file }) => file))];
+  const variables = [...new Set(conflicts.map(({ variable }) => variable))];
+  return {
+    details: { files, variables },
+    fix: `set ${variables.join(" and ")} explicitly for each process instead of relying on conflicting dotenv files`,
+    message: `${variables.join(" and ")} in the process environment ${variables.length === 1 ? "overrides" : "override"} different ${files.join(" and ")} ${files.length === 1 ? "value" : "values"}`,
+    name: "environment",
+    status: "warn",
+  };
 }
 
 async function daemonCheck(

--- a/packages/cli/src/lib/driver/doctor.ts
+++ b/packages/cli/src/lib/driver/doctor.ts
@@ -249,13 +249,22 @@ async function dotenvShadowingWarning(
   cwd: string,
 ): Promise<DoctorCheck | null> {
   const envKeys = (await getRemote()).forwardedEnvKeys();
-  const dotenvFiles = [".env", ".env.local"];
-  const conflicts: Array<{ file: string; variable: string }> = [];
+  // `.env` is auto-loaded by `browse`, so a differing process value genuinely
+  // overrides it. `.env.local` is never loaded at all, so a differing value
+  // there was never going to apply -- flag it as ignored, not overridden, or
+  // the fix advice ("set it explicitly instead of relying on dotenv") reads
+  // as if unsetting the process var would let `.env.local` take effect.
+  const dotenvFiles = [
+    { loaded: true, name: ".env" },
+    { loaded: false, name: ".env.local" },
+  ];
+  const overrides: Array<{ file: string; variable: string }> = [];
+  const ignored: Array<{ file: string; variable: string }> = [];
 
-  for (const file of dotenvFiles) {
+  for (const { loaded, name } of dotenvFiles) {
     let parsed: Record<string, string>;
     try {
-      parsed = parse(await fs.readFile(join(cwd, file)));
+      parsed = parse(await fs.readFile(join(cwd, name)));
     } catch {
       continue;
     }
@@ -268,19 +277,49 @@ async function dotenvShadowingWarning(
         typeof fileValue === "string" &&
         fileValue !== processValue
       ) {
-        conflicts.push({ file, variable });
+        (loaded ? overrides : ignored).push({ file: name, variable });
       }
     }
   }
 
-  if (conflicts.length === 0) return null;
+  if (overrides.length === 0 && ignored.length === 0) return null;
 
-  const files = [...new Set(conflicts.map(({ file }) => file))];
-  const variables = [...new Set(conflicts.map(({ variable }) => variable))];
+  const messages: string[] = [];
+  const fixes: string[] = [];
+
+  if (overrides.length > 0) {
+    const variables = [...new Set(overrides.map(({ variable }) => variable))];
+    const plural = variables.length > 1;
+    messages.push(
+      `${variables.join(" and ")} in the process environment ${plural ? "override" : "overrides"} a different .env value`,
+    );
+    fixes.push(
+      `set ${variables.join(" and ")} explicitly for each process instead of relying on .env`,
+    );
+  }
+
+  if (ignored.length > 0) {
+    const variables = [...new Set(ignored.map(({ variable }) => variable))];
+    const plural = variables.length > 1;
+    messages.push(
+      `${variables.join(" and ")} in .env.local ${plural ? "differ" : "differs"} from the process environment -- browse never loads .env.local, so ${plural ? "these values are" : "this value is"} ignored, not applied`,
+    );
+    fixes.push(
+      `move ${variables.join(" and ")} from .env.local to .env, or export ${plural ? "them" : "it"} directly, if you want browse to pick ${plural ? "them" : "it"} up`,
+    );
+  }
+
+  const files = [
+    ...new Set([...overrides, ...ignored].map(({ file }) => file)),
+  ];
+  const variables = [
+    ...new Set([...overrides, ...ignored].map(({ variable }) => variable)),
+  ];
+
   return {
     details: { files, variables },
-    fix: `set ${variables.join(" and ")} explicitly for each process instead of relying on conflicting dotenv files`,
-    message: `${variables.join(" and ")} in the process environment ${variables.length === 1 ? "overrides" : "override"} different ${files.join(" and ")} ${files.length === 1 ? "value" : "values"}`,
+    fix: fixes.join("; "),
+    message: messages.join("; "),
     name: "environment",
     status: "warn",
   };

--- a/packages/cli/tests/doctor.test.ts
+++ b/packages/cli/tests/doctor.test.ts
@@ -98,6 +98,69 @@ describe("doctor command", () => {
     });
   });
 
+  it("warns when the process API key shadows dotenv files in local mode", async () => {
+    const cwd = await tempProjectDir();
+    const daemonDir = await tempDaemonDir();
+    await writeFile(join(cwd, ".env"), "BROWSERBASE_API_KEY=dotenv-key\n");
+    await writeFile(
+      join(cwd, ".env.local"),
+      "BROWSERBASE_API_KEY=dotenv-local-key\n",
+    );
+
+    const result = await runCli(["doctor", "--local", "--json"], {
+      cwd,
+      env: {
+        BROWSERBASE_API_KEY: "process-key",
+        BROWSE_DAEMON_DIR: daemonDir,
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      verdict: "warn",
+      checks: expect.arrayContaining([
+        expect.objectContaining({
+          details: {
+            files: [".env", ".env.local"],
+            variables: ["BROWSERBASE_API_KEY"],
+          },
+          name: "environment",
+          status: "warn",
+        }),
+      ]),
+    });
+    expect(result.stdout).not.toContain("process-key");
+    expect(result.stdout).not.toContain("dotenv-key");
+    expect(result.stdout).not.toContain("dotenv-local-key");
+  });
+
+  it("does not warn when process and dotenv API keys match", async () => {
+    const cwd = await tempProjectDir();
+    const daemonDir = await tempDaemonDir();
+    await writeFile(join(cwd, ".env"), "BROWSERBASE_API_KEY=same-key\n");
+    await writeFile(join(cwd, ".env.local"), "BROWSERBASE_API_KEY=same-key\n");
+
+    const result = await runCli(["doctor", "--local", "--json"], {
+      cwd,
+      env: {
+        BROWSERBASE_API_KEY: "same-key",
+        BROWSE_DAEMON_DIR: daemonDir,
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    const report = JSON.parse(result.stdout) as {
+      checks: Array<{ name: string }>;
+      verdict: string;
+    };
+    expect(report.verdict).toBe("ok");
+    expect(report.checks).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "environment" }),
+      ]),
+    );
+  });
+
   it("reports conflicting mode flags as a failed target check", async () => {
     const daemonDir = await tempDaemonDir();
     const result = await runCli(["doctor", "--local", "--remote", "--json"], {
@@ -267,6 +330,7 @@ describe("doctor report builder", () => {
         session: "default",
       },
       {
+        cwd: await tempProjectDir(),
         env: { BROWSERBASE_API_KEY: "" },
         getDriverStatus: async () => ({
           browserConnected: true,
@@ -296,6 +360,7 @@ describe("doctor report builder", () => {
           session: "default",
         },
         {
+          cwd: await tempProjectDir(),
           discoverLocalCdp: async () => ({
             source: "DevToolsActivePort:/tmp/profile",
             wsUrl: "ws://127.0.0.1:9222/devtools/browser/test",
@@ -321,6 +386,7 @@ describe("doctor report builder", () => {
     const report = await buildDoctorReport(
       { flags: {}, session: "default" },
       {
+        cwd: await tempProjectDir(),
         env: { BROWSERBASE_API_KEY: "test-key" },
         getDriverStatus: async () => ({
           browserbaseDebugUrl: "https://www.browserbase.com/live/sess-123",
@@ -366,6 +432,7 @@ describe("doctor report builder", () => {
         session: "default",
       },
       {
+        cwd: await tempProjectDir(),
         env: { BROWSERBASE_API_KEY: "test-key" },
         getDriverStatus: async () => null,
         readPackageVersion: async () => "0.0.0-test",
@@ -389,6 +456,12 @@ describe("doctor report builder", () => {
 
 async function tempDaemonDir(): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), "browse-doctor-test-"));
+  cleanupPaths.push(dir);
+  return dir;
+}
+
+async function tempProjectDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "browse-doctor-project-test-"));
   cleanupPaths.push(dir);
   return dir;
 }

--- a/packages/cli/tests/doctor.test.ts
+++ b/packages/cli/tests/doctor.test.ts
@@ -134,6 +134,41 @@ describe("doctor command", () => {
     expect(result.stdout).not.toContain("dotenv-local-key");
   });
 
+  it("flags a .env.local-only mismatch as ignored, not overridden", async () => {
+    const cwd = await tempProjectDir();
+    const daemonDir = await tempDaemonDir();
+    await writeFile(
+      join(cwd, ".env.local"),
+      "BROWSERBASE_API_KEY=dotenv-local-key\n",
+    );
+
+    const result = await runCli(["doctor", "--local", "--json"], {
+      cwd,
+      env: {
+        BROWSERBASE_API_KEY: "process-key",
+        BROWSE_DAEMON_DIR: daemonDir,
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    const report = JSON.parse(result.stdout) as {
+      checks: Array<{
+        details?: { files: string[]; variables: string[] };
+        message: string;
+        name: string;
+      }>;
+      verdict: string;
+    };
+    expect(report.verdict).toBe("warn");
+    const check = report.checks.find((c) => c.name === "environment");
+    expect(check?.details).toEqual({
+      files: [".env.local"],
+      variables: ["BROWSERBASE_API_KEY"],
+    });
+    expect(check?.message).toContain("browse never loads .env.local");
+    expect(check?.message).not.toContain("overrides");
+  });
+
   it("does not warn when process and dotenv API keys match", async () => {
     const cwd = await tempProjectDir();
     const daemonDir = await tempDaemonDir();


### PR DESCRIPTION
## Summary

- warn in `browse doctor` when a process-level Browserbase API key differs from `.env` or `.env.local`
- parse dotenv files for diagnostics without loading them or exposing credential values
- document process-environment precedence in the CLI setup README

## Why

An inherited API key takes precedence over dotenv values and can silently route Browserbase sessions to a different account. The doctor warning makes that conflict visible while preserving the CLI's existing `.env` behavior and continuing not to load `.env.local`.

## Validation

- `pnpm exec prettier --check packages/cli/src/lib/driver/doctor.ts packages/cli/tests/doctor.test.ts`
- `pnpm exec eslint packages/cli/src/lib/driver/doctor.ts packages/cli/tests/doctor.test.ts`
- TypeScript syntax transpilation for the modified source and test
- `git diff --check`
- confirmed the generic doctor source remains free of a hard-coded API-key variable name

The focused Vitest suite could not run locally because the checkout's CLI dependencies were incomplete and the configured package proxy failed DNS resolution with `ENOTFOUND socket-firewall.tail929132.ts.net`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Warns when a process-level `BROWSERBASE_API_KEY` overrides `.env` and flags `.env.local` differences as ignored, making config conflicts visible without exposing secrets. Updates the CLI README to clarify environment precedence and recommend running `browse doctor`.

- **New Features**
  - `browse doctor` compares process env with `.env` and `.env.local`; warns when `.env` is overridden and notes `.env.local` mismatches are ignored since it isn’t auto-loaded, parsing with `dotenv` without loading files or printing values.
  - README clarifies that the process environment takes precedence, `browse` auto-loads only `.env` (not `.env.local`), and adds a quick `browse doctor` check.

<sup>Written for commit d826810bf242183d92f744eed28cf2d66317bd6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

