### PR TITLE
feat: warn and add opt-out flag for browse CLI .env auto-loading

### DIFF
--- a/.changeset/wobbly-otters-deprecate.md
+++ b/.changeset/wobbly-otters-deprecate.md
@@ -1,0 +1,5 @@
+---
+"browse": minor
+---
+
+`browse` now warns when it auto-loads environment variables from `.env` and adds a `BROWSE_LOAD_DOTENV` toggle to opt out ahead of a future release where auto-loading will be off by default.

--- a/.changeset/wobbly-otters-deprecate.md
+++ b/.changeset/wobbly-otters-deprecate.md
@@ -1,5 +1,5 @@
 ---
-"browse": minor
+"browse": patch
 ---
 
-`browse` now warns when it auto-loads environment variables from `.env` and adds a `BROWSE_LOAD_DOTENV` toggle to opt out ahead of a future release where auto-loading will be off by default.
+Warn when auto-loading variables from `.env` and add `BROWSE_LOAD_DOTENV` to opt out ahead of a future release where this will be off by default.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -277,10 +277,19 @@ export BROWSERBASE_API_KEY=bb_live_...
 
 Local driver commands (`--local`) work without an API key.
 
+`browse` also auto-loads a `.env` file from the current directory on startup, and prints a
+one-time deprecation warning to stderr when it actually pulls a variable from `.env` this way.
+This is deprecated because a CLI used across many unrelated projects can silently pick up a
+stale key from the wrong project's `.env`; a future release will disable auto-loading by
+default so `browse` only reads `process.env`. Set `BROWSE_LOAD_DOTENV=0` (or `false`/`no`) to
+opt out of `.env` auto-loading now, ahead of that change, or `BROWSE_LOAD_DOTENV=1` to keep
+auto-loading with no warning.
+
 | Variable | Description |
 |----------|-------------|
 | `BROWSERBASE_API_KEY` | Enables `--remote` sessions and all `browse cloud` / `functions` commands |
 | `BROWSE_SESSION` | Default session name (alternative to `-s, --session`) |
+| `BROWSE_LOAD_DOTENV` | Controls `.env` auto-loading: unset = load + warn once (default, deprecated), `0`/`false`/`no` = skip loading, anything else = load silently |
 
 ## Links
 

--- a/packages/cli/bin/run.js
+++ b/packages/cli/bin/run.js
@@ -1,5 +1,31 @@
 #!/usr/bin/env node
-import "dotenv/config";
+import { config as loadDotenvConfig } from "dotenv";
+
+// `BROWSE_LOAD_DOTENV` controls whether `browse` auto-loads a `.env` file
+// from the current working directory. This is deprecated: a future release
+// will flip the default to "off" so `browse` only reads `process.env`,
+// matching how most CLIs used across many unrelated projects behave. Until
+// then we keep loading `.env` by default (unset behaves exactly as before)
+// but warn once when we actually pull a value from it, so users relying on
+// the implicit default get a heads-up before the default changes.
+const dotenvToggle = process.env.BROWSE_LOAD_DOTENV;
+const dotenvOptedOut =
+  dotenvToggle !== undefined &&
+  ["0", "false", "no"].includes(dotenvToggle.toLowerCase());
+
+if (!dotenvOptedOut) {
+  const keysBeforeLoad = new Set(Object.keys(process.env));
+  const { parsed } = loadDotenvConfig();
+  const appliedFromDotenv = Object.keys(parsed ?? {}).filter(
+    (key) => !keysBeforeLoad.has(key),
+  );
+
+  if (appliedFromDotenv.length > 0 && dotenvToggle === undefined) {
+    console.error(
+      `[browse] Loaded ${appliedFromDotenv.join(", ")} from .env. Auto-loading .env is deprecated and will be disabled by default in a future release -- export these variables in your shell instead, or set BROWSE_LOAD_DOTENV=1 to keep this behavior explicitly once that happens. Set BROWSE_LOAD_DOTENV=0 to opt out today. Run \`browse doctor\` to check for conflicts with your shell environment.`,
+    );
+  }
+}
 
 globalThis.oclif = {
   ...globalThis.oclif,

--- a/packages/cli/tests/cli-cloud-contract.test.ts
+++ b/packages/cli/tests/cli-cloud-contract.test.ts
@@ -734,24 +734,27 @@ describe("cloud API contracts", () => {
     );
   });
 
-  it("does not auto-load .env when BROWSE_LOAD_DOTENV=0", async () => {
-    const cwd = await createTempDir("browse-dotenv-optout-");
+  it.each(["0", "false", "no", "FALSE", "NO"])(
+    "does not auto-load .env when BROWSE_LOAD_DOTENV=%s",
+    async (optOutValue) => {
+      const cwd = await createTempDir("browse-dotenv-optout-");
 
-    await writeFile(join(cwd, ".env"), "BROWSERBASE_API_KEY=test-key\n");
+      await writeFile(join(cwd, ".env"), "BROWSERBASE_API_KEY=test-key\n");
 
-    const result = await runCli(["cloud", "projects", "list"], {
-      cwd,
-      env: {
-        BROWSERBASE_API_KEY: undefined,
-        BROWSERBASE_BASE_URL: undefined,
-        BROWSE_LOAD_DOTENV: "0",
-      },
-    });
+      const result = await runCli(["cloud", "projects", "list"], {
+        cwd,
+        env: {
+          BROWSERBASE_API_KEY: undefined,
+          BROWSERBASE_BASE_URL: undefined,
+          BROWSE_LOAD_DOTENV: optOutValue,
+        },
+      });
 
-    expect(result.exitCode).toBe(1);
-    expect(result.stderr).toContain("Missing Browserbase API key");
-    expect(result.stderr).not.toContain("deprecated");
-  });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("Missing Browserbase API key");
+      expect(result.stderr).not.toContain("deprecated");
+    },
+  );
 
   it.each([
     {

--- a/packages/cli/tests/cli-cloud-contract.test.ts
+++ b/packages/cli/tests/cli-cloud-contract.test.ts
@@ -669,6 +669,90 @@ describe("cloud API contracts", () => {
     );
   });
 
+  it("warns on stderr when auto-loading .env variables with BROWSE_LOAD_DOTENV unset", async () => {
+    const cwd = await createTempDir("browse-dotenv-warn-");
+
+    await withServer(
+      async (_request, response) => {
+        jsonResponse(response, 200, [{ id: "proj_123", name: "Demo" }]);
+      },
+      async ({ baseUrl, requests }) => {
+        await writeFile(
+          join(cwd, ".env"),
+          [
+            "BROWSERBASE_API_KEY=test-key",
+            `BROWSERBASE_BASE_URL=${baseUrl}`,
+          ].join("\n"),
+        );
+
+        const result = await runCli(["cloud", "projects", "list"], {
+          cwd,
+          env: {
+            BROWSERBASE_API_KEY: undefined,
+            BROWSERBASE_BASE_URL: undefined,
+            BROWSE_LOAD_DOTENV: undefined,
+          },
+        });
+
+        expect(result.exitCode).toBe(0);
+        expectRequest(requests[0], "GET", "/v1/projects", "test-key");
+        expect(result.stderr).toContain("deprecated");
+        expect(result.stderr).toContain("BROWSERBASE_API_KEY");
+      },
+    );
+  });
+
+  it("does not warn when BROWSE_LOAD_DOTENV=1 is explicitly set", async () => {
+    const cwd = await createTempDir("browse-dotenv-optin-");
+
+    await withServer(
+      async (_request, response) => {
+        jsonResponse(response, 200, [{ id: "proj_123", name: "Demo" }]);
+      },
+      async ({ baseUrl, requests }) => {
+        await writeFile(
+          join(cwd, ".env"),
+          [
+            "BROWSERBASE_API_KEY=test-key",
+            `BROWSERBASE_BASE_URL=${baseUrl}`,
+          ].join("\n"),
+        );
+
+        const result = await runCli(["cloud", "projects", "list"], {
+          cwd,
+          env: {
+            BROWSERBASE_API_KEY: undefined,
+            BROWSERBASE_BASE_URL: undefined,
+            BROWSE_LOAD_DOTENV: "1",
+          },
+        });
+
+        expect(result.exitCode).toBe(0);
+        expectRequest(requests[0], "GET", "/v1/projects", "test-key");
+        expect(result.stderr).not.toContain("deprecated");
+      },
+    );
+  });
+
+  it("does not auto-load .env when BROWSE_LOAD_DOTENV=0", async () => {
+    const cwd = await createTempDir("browse-dotenv-optout-");
+
+    await writeFile(join(cwd, ".env"), "BROWSERBASE_API_KEY=test-key\n");
+
+    const result = await runCli(["cloud", "projects", "list"], {
+      cwd,
+      env: {
+        BROWSERBASE_API_KEY: undefined,
+        BROWSERBASE_BASE_URL: undefined,
+        BROWSE_LOAD_DOTENV: "0",
+      },
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Missing Browserbase API key");
+    expect(result.stderr).not.toContain("deprecated");
+  });
+
   it.each([
     {
       args: ["cloud", "contexts", "create", "--body", '{"region":"us-west-2"}'],


### PR DESCRIPTION
## Summary

`browse` has auto-loaded a `.env` file from the current directory on startup since it moved into this monorepo, with no way to turn it off. A user reported `.env` values in one project being silently overridden by a stale shell-level key from another project -- the shell-level `BROWSERBASE_API_KEY` from an earlier project took precedence over the correct key in a different project's `.env`, so session replays went to the wrong Browserbase account.

The agreed direction (per internal eng review) is that CLI tools used across many unrelated projects/directories shouldn't auto-load `.env` at all -- only `process.env` should matter, and it's on the user to `export` vars or source `.env` themselves. Ripping that out in one PR would break the existing install base that relies on the implicit behavior, so this PR is the non-breaking first step:

- Default behavior is unchanged: `browse` still loads `.env` by default.
- New `BROWSE_LOAD_DOTENV` env var makes that behavior explicitly toggleable: `0`/`false`/`no` (case-insensitive) skips `.env` loading entirely today; any other explicit value (e.g. `1`) keeps loading with no nagging.
- When the toggle is left unset (the implicit default) and loading a `.env` file actually applies a variable not already in `process.env`, we print a one-time deprecation warning to stderr naming the variable(s), so people relying on the implicit default get advance notice.

A future PR (not this one) will flip the default of `BROWSE_LOAD_DOTENV` to off, once the warning has had time to reach users.

This complements #2360, which adds a `browse doctor` warning when `process.env` and `.env`/`.env.local` values *disagree* -- a useful on-demand diagnostic, but it doesn't touch the auto-load behavior itself. This PR does not depend on #2360.

## E2E Test Matrix

Built the CLI locally (`pnpm turbo run build --filter=browse`) and ran the built `bin/run.js` directly in a scratch temp dir containing a `.env` with a fake `BROWSERBASE_API_KEY`.

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `node bin/run.js doctor --json` in scratch dir with `.env` containing `BROWSERBASE_API_KEY=<fake>`, `BROWSE_LOAD_DOTENV` unset | stderr: `[browse] Loaded BROWSERBASE_API_KEY from .env. Auto-loading .env is deprecated and will be disabled by default in a future release -- export these variables in your shell instead, or set BROWSE_LOAD_DOTENV=1 to keep this behavior explicitly once that happens. Set BROWSE_LOAD_DOTENV=0 to opt out today. Run \`browse doctor\` to check for conflicts with your shell environment.` / stdout `verdict: "ok"` / exit 0 | Proves default (implicit) path still loads `.env` and now warns exactly once, naming the applied var. |
| `node bin/run.js doctor --remote` in same dir with `BROWSE_LOAD_DOTENV=0` | stdout: `[fail] browserbase BROWSERBASE_API_KEY is not set` / no stderr / exit 1 | Proves opting out today skips `.env` entirely -- the key never reaches `process.env`, no warning printed (explicit choice). |
| `node bin/run.js doctor --remote` in same dir with `BROWSE_LOAD_DOTENV=1` | stdout: `[ok] browserbase BROWSERBASE_API_KEY is set` / no stderr / exit 0 | Proves explicit opt-in keeps loading `.env` with zero nagging. |
| `pnpm exec vitest run tests/cli-cloud-contract.test.ts tests/doctor.test.ts` | `Test Files 2 passed (2)` / `Tests 69 passed (69)` | Covers the existing `.env`-loads-config contract (unchanged default) plus: warns when unset+applied, silent when `BROWSE_LOAD_DOTENV=1`, and fails auth (key never loaded, no warning) for each of `0`/`false`/`no`/`FALSE`/`NO` as `BROWSE_LOAD_DOTENV` -- added the extra opt-out aliases per cubic review feedback below. |
| `pnpm exec eslint bin/run.js tests/cli-cloud-contract.test.ts` + `pnpm exec prettier --check bin/run.js README.md tests/cli-cloud-contract.test.ts` + `pnpm exec tsc --noEmit -p tsconfig.json` | All clean, no output/errors | Static checks on touched files; supporting evidence, not a substitute for the live runs above. |

## Linear

STG-2579 (linked via branch name).
