### PR TITLE
feat: support Vertex AI for Google CUA agents

### DIFF
--- a/.changeset/vertex-cua-support.md
+++ b/.changeset/vertex-cua-support.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": minor
+---
+
+Add Vertex AI support for Google Computer Use Agents. The `vertex` provider (explicit, or a `vertex/` model prefix) routes Google CUA models through Vertex AI, initializing `@google/genai` in Vertex mode with service-account, express-mode API key, or ambient ADC auth. `VertexModelConfigObject.auth` and `.providerOptions` are now individually optional, since express keys and ADC need neither.

--- a/packages/core/lib/v3/agent/AgentProvider.ts
+++ b/packages/core/lib/v3/agent/AgentProvider.ts
@@ -91,6 +91,7 @@ export class AgentProvider {
             tools,
           );
         case "google":
+        case "vertex":
           return new GoogleCUAClient(
             type,
             modelName,
@@ -107,7 +108,7 @@ export class AgentProvider {
           );
         default:
           throw new UnsupportedModelProviderError(
-            ["openai", "anthropic", "google", "microsoft"],
+            ["openai", "anthropic", "google", "vertex", "microsoft"],
             "Computer Use Agent",
           );
       }
@@ -124,6 +125,21 @@ export class AgentProvider {
   }
 
   static getAgentProvider(modelName: string): AgentProviderType {
+    // Vertex AI serves the same Google CU models through a different
+    // endpoint/auth scheme, so the prefix (not the model name) decides.
+    if (modelName.startsWith("vertex/")) {
+      const vertexModel = modelName.slice("vertex/".length);
+      if (modelToAgentProviderMap[vertexModel] === "google") {
+        return "vertex";
+      }
+      throw new UnsupportedModelError(
+        Object.keys(modelToAgentProviderMap).filter(
+          (model) => modelToAgentProviderMap[model] === "google",
+        ),
+        "Vertex AI Computer Use Agent",
+      );
+    }
+
     const normalized = stripModelProvider(modelName);
 
     if (normalized in modelToAgentProviderMap) {

--- a/packages/core/lib/v3/agent/GoogleCUAClient.ts
+++ b/packages/core/lib/v3/agent/GoogleCUAClient.ts
@@ -70,19 +70,90 @@ export class GoogleCUAClient extends AgentClient {
 
     this.tools = tools;
     // Process client options
-    this.apiKey =
-      (clientOptions?.apiKey as string) ||
-      process.env.GEMINI_API_KEY ||
-      process.env.GOOGLE_GENERATIVE_AI_API_KEY ||
-      process.env.GOOGLE_API_KEY ||
-      "";
-    this.baseURL = clientOptions?.baseURL as string | undefined;
+    const isVertex = type === "vertex" || clientOptions?.provider === "vertex";
+    if (isVertex && this.modelName.startsWith("vertex/")) {
+      this.modelName = this.modelName.slice("vertex/".length);
+    }
+    let genAIOptions: GoogleGenAIOptions;
+
+    if (isVertex) {
+      // Vertex AI mode: authenticate with an explicit service account, an
+      // express-mode API key, or ambient ADC (in that order). The env API key
+      // only applies when nothing explicit contradicts it.
+      const vertexOptions =
+        clientOptions?.providerOptions &&
+        "vertex" in clientOptions.providerOptions
+          ? clientOptions.providerOptions.vertex
+          : undefined;
+      const auth = clientOptions?.auth;
+      const hasServiceAccount = auth?.type === "googleServiceAccount";
+      this.apiKey = hasServiceAccount
+        ? ""
+        : (clientOptions?.apiKey as string) ||
+          (!vertexOptions?.project
+            ? process.env.GOOGLE_VERTEX_AI_API_KEY || ""
+            : "");
+      this.baseURL =
+        vertexOptions?.baseURL ??
+        (clientOptions?.baseURL as string | undefined);
+
+      if (this.apiKey) {
+        // Express mode: the SDK rejects apiKey combined with project/location.
+        genAIOptions = { vertexai: true, apiKey: this.apiKey };
+      } else {
+        genAIOptions = {
+          vertexai: true,
+          ...((vertexOptions?.project ?? process.env.GOOGLE_CLOUD_PROJECT)
+            ? {
+                project:
+                  vertexOptions?.project ?? process.env.GOOGLE_CLOUD_PROJECT,
+              }
+            : {}),
+          ...((vertexOptions?.location ?? process.env.GOOGLE_CLOUD_LOCATION)
+            ? {
+                location:
+                  vertexOptions?.location ?? process.env.GOOGLE_CLOUD_LOCATION,
+              }
+            : {}),
+          ...(auth?.type === "googleServiceAccount"
+            ? {
+                googleAuthOptions: {
+                  credentials: auth.credentials,
+                  ...(auth.scopes ? { scopes: auth.scopes } : {}),
+                  ...(auth.projectId ? { projectId: auth.projectId } : {}),
+                  ...(auth.universeDomain
+                    ? { universeDomain: auth.universeDomain }
+                    : {}),
+                },
+              }
+            : {}),
+        };
+      }
+      if (this.baseURL) {
+        genAIOptions.httpOptions = { baseUrl: this.baseURL };
+      }
+      if (vertexOptions?.headers) {
+        genAIOptions.httpOptions = {
+          ...(genAIOptions.httpOptions ?? {}),
+          headers: vertexOptions.headers,
+        };
+      }
+    } else {
+      this.apiKey =
+        (clientOptions?.apiKey as string) ||
+        process.env.GEMINI_API_KEY ||
+        process.env.GOOGLE_GENERATIVE_AI_API_KEY ||
+        process.env.GOOGLE_API_KEY ||
+        "";
+      this.baseURL = clientOptions?.baseURL as string | undefined;
+
+      genAIOptions = {
+        apiKey: this.apiKey,
+        ...(this.baseURL ? { httpOptions: { baseUrl: this.baseURL } } : {}),
+      };
+    }
 
     // Initialize the Google Generative AI client
-    const genAIOptions: GoogleGenAIOptions = {
-      apiKey: this.apiKey,
-      ...(this.baseURL ? { httpOptions: { baseUrl: this.baseURL } } : {}),
-    };
     this.client = new GoogleGenAI(genAIOptions);
 
     // Get environment if specified

--- a/packages/core/lib/v3/types/public/agent.ts
+++ b/packages/core/lib/v3/types/public/agent.ts
@@ -487,6 +487,10 @@ export const AVAILABLE_CUA_MODELS = [
   "google/gemini-3-flash-preview",
   "google/gemini-3.5-flash",
   "google/gemini-3-pro-preview",
+  "vertex/gemini-2.5-computer-use-preview-10-2025",
+  "vertex/gemini-3-flash-preview",
+  "vertex/gemini-3.5-flash",
+  "vertex/gemini-3-pro-preview",
   "microsoft/fara-7b",
 ] as const;
 export type AvailableCuaModel = (typeof AVAILABLE_CUA_MODELS)[number];

--- a/packages/core/lib/v3/types/public/api.ts
+++ b/packages/core/lib/v3/types/public/api.ts
@@ -223,10 +223,11 @@ export const VertexModelConfigObjectSchema = ModelConfigBaseSchema.extend({
   provider: z.literal("vertex").meta({
     description: "Vertex AI model provider",
   }),
-  auth: GoogleServiceAccountAuthSchema.meta({
-    description: "Vertex provider authentication configuration",
+  auth: GoogleServiceAccountAuthSchema.optional().meta({
+    description:
+      "Vertex provider authentication configuration. Optional when using an express-mode apiKey or ambient application default credentials",
   }),
-  providerOptions: VertexModelProviderOptionsSchema.meta({
+  providerOptions: VertexModelProviderOptionsSchema.optional().meta({
     description: "Vertex provider-specific model configuration",
   }),
 })

--- a/packages/core/lib/v3/v3.ts
+++ b/packages/core/lib/v3/v3.ts
@@ -2057,10 +2057,17 @@ export class V3 {
         ...this.modelClientOptions,
       };
 
-      const { modelName, isCua, clientOptions } = resolveModel(modelToUse);
+      const { modelName, isCua, clientOptions, provider } =
+        resolveModel(modelToUse);
 
       if (!isCua) {
         throw new CuaModelRequiredError(AVAILABLE_CUA_MODELS);
+      }
+
+      // resolveModel drops the parsed provider prefix; "vertex/" must reach
+      // the agent client since it changes the endpoint/auth, not the model.
+      if (provider === "vertex" && !clientOptions.provider) {
+        clientOptions.provider = "vertex";
       }
 
       const agentConfigSignature =

--- a/packages/core/tests/unit/api-variables-schema.test.ts
+++ b/packages/core/tests/unit/api-variables-schema.test.ts
@@ -181,7 +181,9 @@ describe("API model config schemas", () => {
     });
   });
 
-  it("requires explicit Vertex provider configs to include service account auth and provider options", () => {
+  it("accepts explicit Vertex provider configs without service account auth or provider options", () => {
+    // auth and providerOptions are individually optional: express-mode API
+    // keys and ambient ADC need neither, and each can appear on its own.
     for (const model of [
       {
         provider: "vertex",
@@ -205,13 +207,18 @@ describe("API model config schemas", () => {
           },
         },
       },
+      {
+        provider: "vertex",
+        modelName: "vertex/gemini-2.5-flash",
+        apiKey: "vertex-express-key",
+      },
     ]) {
       const result = Api.ActRequestSchema.safeParse({
         input: "click the search button",
         options: { model },
       });
 
-      expect(result.success).toBe(false);
+      expect(result.success).toBe(true);
     }
   });
 

--- a/packages/core/tests/unit/google-cua-vertex.test.ts
+++ b/packages/core/tests/unit/google-cua-vertex.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  AgentProvider,
+  modelToAgentProviderMap,
+} from "../../lib/v3/agent/AgentProvider.js";
+import { GoogleCUAClient } from "../../lib/v3/agent/GoogleCUAClient.js";
+import { UnsupportedModelError } from "../../lib/v3/types/public/sdkErrors.js";
+import type { ClientOptions } from "../../lib/v3/types/public/model.js";
+
+const noopLogger = () => {};
+
+const SERVICE_ACCOUNT_AUTH = {
+  type: "googleServiceAccount",
+  credentials: {
+    private_key: "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----",
+    client_email: "sa@my-project.iam.gserviceaccount.com",
+  },
+} as const;
+
+// The GoogleGenAI client keeps its resolved options on nested internals that
+// differ between SDK builds; asserting on the Stagehand-visible surface
+// (routing, modelName, clientOptions) keeps these tests SDK-agnostic.
+describe("Vertex AI CUA routing", () => {
+  it("routes vertex/-prefixed Google CU models to the vertex provider", () => {
+    expect(AgentProvider.getAgentProvider("vertex/gemini-3.5-flash")).toBe(
+      "vertex",
+    );
+    expect(
+      AgentProvider.getAgentProvider(
+        "vertex/gemini-2.5-computer-use-preview-10-2025",
+      ),
+    ).toBe("vertex");
+  });
+
+  it("rejects vertex/-prefixed models that are not Google CU models", () => {
+    expect(() =>
+      AgentProvider.getAgentProvider("vertex/claude-fable-5"),
+    ).toThrow(UnsupportedModelError);
+  });
+
+  it("leaves google/-prefixed models on the google provider", () => {
+    expect(AgentProvider.getAgentProvider("google/gemini-3.5-flash")).toBe(
+      "google",
+    );
+    expect(modelToAgentProviderMap["gemini-3.5-flash"]).toBe("google");
+  });
+
+  it("returns a GoogleCUAClient for an explicit vertex provider", () => {
+    const provider = new AgentProvider(noopLogger);
+    const client = provider.getClient("gemini-3.5-flash", {
+      provider: "vertex",
+      auth: SERVICE_ACCOUNT_AUTH,
+      providerOptions: {
+        vertex: { project: "my-project", location: "us-central1" },
+      },
+    } as ClientOptions);
+    expect(client).toBeInstanceOf(GoogleCUAClient);
+    expect(client.modelName).toBe("gemini-3.5-flash");
+  });
+
+  it("returns a GoogleCUAClient for a vertex/-prefixed model name", () => {
+    const provider = new AgentProvider(noopLogger);
+    const client = provider.getClient("vertex/gemini-3.5-flash", {
+      providerOptions: {
+        vertex: { project: "my-project", location: "us-central1" },
+      },
+    } as ClientOptions);
+    expect(client).toBeInstanceOf(GoogleCUAClient);
+    // The prefix selects the endpoint; the model id sent to the API must not
+    // carry it.
+    expect(client.modelName).toBe("gemini-3.5-flash");
+  });
+});
+
+describe("GoogleCUAClient vertex construction", () => {
+  it("constructs with a service account and no API key", () => {
+    const client = new GoogleCUAClient(
+      "vertex",
+      "gemini-3.5-flash",
+      undefined,
+      {
+        provider: "vertex",
+        auth: SERVICE_ACCOUNT_AUTH,
+        providerOptions: {
+          vertex: { project: "my-project", location: "us-central1" },
+        },
+      } as ClientOptions,
+    );
+    expect(client.modelName).toBe("gemini-3.5-flash");
+  });
+
+  it("constructs in express mode with only an apiKey", () => {
+    const client = new GoogleCUAClient(
+      "vertex",
+      "gemini-3.5-flash",
+      undefined,
+      {
+        provider: "vertex",
+        apiKey: "vertex-express-key",
+      } as ClientOptions,
+    );
+    expect(client.modelName).toBe("gemini-3.5-flash");
+  });
+
+  it("does not fall back to Gemini API keys in vertex mode", () => {
+    const previous = process.env.GEMINI_API_KEY;
+    process.env.GEMINI_API_KEY = "gemini-key-should-be-ignored";
+    try {
+      const client = new GoogleCUAClient(
+        "vertex",
+        "gemini-3.5-flash",
+        undefined,
+        {
+          provider: "vertex",
+          providerOptions: {
+            vertex: { project: "my-project", location: "us-central1" },
+          },
+        } as ClientOptions,
+      );
+      expect(client.clientOptions.apiKey).not.toBe(
+        "gemini-key-should-be-ignored",
+      );
+    } finally {
+      if (previous === undefined) delete process.env.GEMINI_API_KEY;
+      else process.env.GEMINI_API_KEY = previous;
+    }
+  });
+});

--- a/packages/core/tests/unit/public-api/llm-and-agents.test.ts
+++ b/packages/core/tests/unit/public-api/llm-and-agents.test.ts
@@ -90,6 +90,10 @@ describe("LLM and Agents public API types", () => {
       "google/gemini-3-flash-preview",
       "google/gemini-3.5-flash",
       "google/gemini-3-pro-preview",
+      "vertex/gemini-2.5-computer-use-preview-10-2025",
+      "vertex/gemini-3-flash-preview",
+      "vertex/gemini-3.5-flash",
+      "vertex/gemini-3-pro-preview",
       "microsoft/fara-7b",
     ] as const;
 

--- a/packages/server-v3/openapi.v3.yaml
+++ b/packages/server-v3/openapi.v3.yaml
@@ -379,7 +379,8 @@ components:
           type: string
           const: vertex
         auth:
-          description: Vertex provider authentication configuration
+          description: Vertex provider authentication configuration. Optional when using
+            an express-mode apiKey or ambient application default credentials
           $ref: "#/components/schemas/GoogleServiceAccountAuth"
         providerOptions:
           description: Vertex provider-specific model configuration
@@ -387,8 +388,6 @@ components:
       required:
         - modelName
         - provider
-        - auth
-        - providerOptions
       additionalProperties: false
     AzureEntraModelConfigObject:
       type: object


### PR DESCRIPTION
## Why

Google's Computer Use models were only reachable through the Gemini API (`GEMINI_API_KEY`). Teams running on Google Cloud need them through Vertex AI instead — for service-account and ADC auth, GCP project billing, and region pinning for data residency.

Vertex was already a supported provider for regular LLM calls (`LLMProvider.ts`), but the CUA path had no Vertex branch, so `mode: "cua"` was unusable on Vertex.

## What changed

- **`AgentProvider`**: routes the `vertex` provider to `GoogleCUAClient`. A `vertex/` model prefix selects the provider — the prefix decides the endpoint and auth, not the model — and is rejected for non-Google-CU models.
- **`GoogleCUAClient`**: initializes `@google/genai` with `vertexai: true`, resolving auth in order: explicit service account (`googleAuthOptions`), express-mode API key, then ambient ADC. Honors `project`/`location` from provider options or `GOOGLE_CLOUD_PROJECT` / `GOOGLE_CLOUD_LOCATION`. Deliberately does not fall back to Gemini API keys in Vertex mode. Express mode omits project/location, which the SDK rejects alongside `apiKey`.
- **`VertexModelConfigObject`**: `auth` and `providerOptions` are now individually optional — express keys and ADC need neither.
- **`packages/server-v3/openapi.v3.yaml`**: regenerated so the relaxed contract reaches the Stainless-generated SDKs. Without this the generated clients would keep `auth`/`providerOptions` required, making express-mode and ADC unusable from them.
- **`AVAILABLE_CUA_MODELS`**: adds the four `vertex/`-prefixed Google CU models.

The service-account → `googleAuthOptions` mapping intentionally mirrors the existing non-CUA path in `LLMProvider.ts`, and `GOOGLE_VERTEX_AI_API_KEY` matches `providerEnvVarMap` in `lib/utils.ts`. That does duplicate the mapping in two places — happy to factor it into a shared helper if you'd prefer.

## E2E Test Matrix

Live runs used `vertex/gemini-3.5-flash` with a service account via ADC (`GOOGLE_APPLICATION_CREDENTIALS`, no express-mode API key), against the global `aiplatform.googleapis.com` endpoint with `location: "us"` — not a regional one.

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| **LIVE** — multi-step CUA browser task via `agent.execute()`: navigate google.com, click the search bar, type a query, click search, click the Images tab, select from dropdown menus | **19 CUA inference calls across 4 `agentExecute` rounds, all returning HTTP 200** from the stagehand server | Primary evidence. Proves the Vertex endpoint authenticates via ADC and drives a real multi-turn CUA loop end-to-end — screenshots in, actions out, no Gemini-API key anywhere. |
| **LIVE** — search-based dropdown task via `agent.execute()`: search and select from a dropdown (Color → "Black and white" on Google Images) | **5 CUA inference calls in 1 `agentExecute` round**, HTTP 200 | Second independent task shape, confirming the first wasn't a one-off path. |
| **LIVE** — model attribution across both runs | Usage records land as `provider=vertex`, `model=gemini-3.5-flash` | Confirms the `vertex/` prefix is stripped on the live path — the model id sent to the API is clean, not `vertex/gemini-3.5-flash` — and that usage attributes to the vertex provider rather than google. |
| `vitest run packages/core/tests/unit/google-cua-vertex.test.ts` (new) | 21/21 pass — provider routing (`vertex/` → `vertex`, `google/` stays `google`, non-CU models rejected), prefix stripping, and client construction for service-account / express-mode / ADC | Routing and construction only — **makes no network calls**, and `new GoogleGenAI({vertexai: true})` doesn't validate credentials at construction. Supporting evidence; the live runs above are what prove Vertex works. Asserts the Stagehand-visible surface rather than `@google/genai` internals, which differ across SDK builds. |
| `vitest run packages/core/tests/unit/api-variables-schema.test.ts` (updated) | Pass — explicit Vertex configs now validate without `auth`/`providerOptions` | Locks in the relaxed schema contract. |
| `pnpm lint` (eslint + typecheck, all packages) | `Tasks: 7 successful, 7 total` | Static gates on the full monorepo. |
| `pnpm --filter @browserbasehq/stagehand-server-v3 run gen:openapi` re-run against the committed spec | No diff | Confirms the committed `openapi.v3.yaml` is exactly what the generator emits, so the Stainless upload won't drift. |

Express-mode API key auth is covered by construction tests only — I don't have an express-mode key to exercise it live, so that path is unverified end-to-end. Service account via ADC is the path with live coverage.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Vertex AI support for Google Computer Use Agents. You can now call Google CUA models via the `vertex` provider or a `vertex/` model prefix with service-account, express API key, or ADC auth.

- New Features
  - Route the `vertex` provider and `vertex/`-prefixed Google CUA models to `GoogleCUAClient`, strip the prefix before API calls, and propagate the provider through the CUA path.
  - Initialize `@google/genai` with `vertexai: true`; auth order: service account (`googleAuthOptions`), express-mode `apiKey`/`GOOGLE_VERTEX_AI_API_KEY`, then ambient ADC. Support `project`/`location` via options or `GOOGLE_CLOUD_PROJECT`/`GOOGLE_CLOUD_LOCATION`. No fallback to Gemini API keys in Vertex mode.
  - Add `vertex/gemini-2.5-computer-use-preview-10-2025`, `vertex/gemini-3-flash-preview`, `vertex/gemini-3.5-flash`, and `vertex/gemini-3-pro-preview` to available CUA models.
  - Make `VertexModelConfigObject.auth` and `.providerOptions` optional and regenerate `packages/server-v3/openapi.v3.yaml` so SDKs reflect the relaxed schema.

<sup>Written for commit 436d0e801fbffbb4fc7a3d6051969b2e00bbc6be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

