### PR TITLE
chore(docs): Replace “LLM model” wording in Stagehand docs

### DIFF
--- a/packages/docs/v3/configuration/models.mdx
+++ b/packages/docs/v3/configuration/models.mdx
@@ -1,7 +1,7 @@
 ---
 title: Models
 sidebarTitle: Models
-description: Use any LLM model with Stagehand
+description: Use any LLM with Stagehand
 ---
 import { V3Banner } from '/snippets/v3-banner.mdx';
 


### PR DESCRIPTION
## Summary

- replace the redundant “LLM model” wording in the Models page description
- keep the existing “Models” page title unchanged

## Why

“LLM model” repeats “model,” since LLM already stands for large language model. The updated description reads “Use any LLM with Stagehand.”

## Impact

This improves the wording shown in the Models page header and search previews. There is no runtime or API impact.

## Validation

- `git diff --check`
- confirmed the Models page no longer contains “LLM model”

Linear: [GRO-1928](https://linear.app/browserbase/issue/GRO-1928/replace-llm-model-wording-in-stagehand-docs)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace “LLM model” with “LLM” in the Models page description to remove redundancy and improve clarity. Title remains “Models”; docs-only change with no runtime or API impact. Addresses Linear GRO-1928.

<sup>Written for commit 63ba4a79b529b7b5378cc71fbc14a944a1c7abc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

