### PR TITLE
chore: cut stagehand-server-v3 catchup release

### DIFF
--- a/.changeset/stagehand-server-v3-catchup-release.md
+++ b/.changeset/stagehand-server-v3-catchup-release.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand-server-v3": patch
+---
+
+Cut a new stagehand-server-v3 SEA binary release to catch up with recent core changes, including Gemini 3.5 Flash computer-use support.


### PR DESCRIPTION
## Why

The `stagehand-server-v3` SEA binary release workflow (`.github/workflows/stagehand-server-v3-release.yml`) only cuts a new tag/binary build when a changeset added since the last `stagehand-server-v3/v*` tag explicitly lists the `@browserbasehq/stagehand-server-v3` package. It doesn't look at `package.json` versions.

The last such changeset landed on 2026-06-09 (v3.7.2, #2217). Since then, 39 changesets have merged that touch `packages/core`/`packages/server-v3` — including Gemini 3.5 Flash CUA support (#2273) and an AI SDK warning fix affecting act/extract/observe (#2359) — and none of them included the `stagehand-server-v3` package line. So the release-detect job has returned `release=false` on every push for over a month, even though `updateInternalDependencies: patch` cosmetically bumps server-v3's `package.json`/CHANGELOG on every Version Packages PR, making it look like a release happened when it didn't.

This changeset is a one-time catch-up: it doesn't change any code, it just gives the release workflow a qualifying trigger so it cuts a binary build containing everything already merged to `packages/core` since v3.7.2.

Related: a user asked about this gap on Discord, referencing #2333 (Gemini 3.5 Flash support request).

## What changed

- Added `.changeset/stagehand-server-v3-catchup-release.md` bumping `@browserbasehq/stagehand-server-v3` (patch, 3.7.2 → 3.7.3).

## E2E Test Matrix

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| Ran the exact front-matter regex from `stagehand-server-v3-release.yml`'s `detect` job against the new changeset file | `Parsed: @browserbasehq/stagehand-server-v3 patch matches target package: true` | Proves this changeset satisfies the workflow's own detection logic and will set `release=true` on merge to main, advancing the tag from `v3.7.2` to `v3.7.3`. |
| Verified all 13 historical `stagehand-server-v3` tags against their triggering commit's changeset | 13/13 correlate exactly with a changeset explicitly bumping `@browserbasehq/stagehand-server-v3` | Confirms the detection mechanism is real and consistent — this isn't a guess about how the pipeline works. |
| Scanned all 39 changesets added to main since the `v3.7.2` tag commit | 0/39 include a `stagehand-server-v3` line | Confirms the gap is total (not partial) and this PR is the correct/only trigger needed. |

Linear: [STG-2587](https://linear.app/browserbase/issue/STG-2587/cut-a-stagehand-server-v3-release-to-catch-up-on-binary-drift-since)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Triggers a catch-up SEA binary release for `@browserbasehq/stagehand-server-v3` by adding a changeset, so all core changes since v3.7.2 ship (including Gemini 3.5 Flash computer-use support).
Addresses Linear STG-2587 by closing the drift between version bumps and actual binary releases.

<sup>Written for commit efb5f99c6b933f1c2d56c41233eaa4047f8b429f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

