### PR TITLE
fix chrome-newtab page tracking flaky test via local server

### DIFF
--- a/packages/core/tests/integration/chrome-newtab-page-tracking.spec.ts
+++ b/packages/core/tests/integration/chrome-newtab-page-tracking.spec.ts
@@ -3,6 +3,17 @@ import { V3 } from "../../lib/v3/v3.js";
 import { v3DynamicTestConfig } from "./v3.dynamic.config.js";
 import { closeV3 } from "./testUtils.js";
 
+// #1924: page targets with a non-web scheme were dropped, so tabs opened with
+// Ctrl+T (chrome://newtab/) never attached. Any chrome:// target covers that.
+// Not the New Tab Page itself though — chrome://newtab/ and chrome://new-tab-page/
+// both segfault Chrome 151 headless on CI runners seconds after the tab opens.
+const WEBUI_URL = "chrome://version/";
+
+// data: needs no network, so this behaves the same when the browser is remote
+// (e2e-bb). Leaving the WebUI still forces the renderer process swap under test.
+const TARGET_MARKER = "newtab target";
+const TARGET_URL = `data:text/html,<html><body><h1 id="marker">${TARGET_MARKER}</h1></body></html>`;
+
 test.describe("V3 chrome:// new-tab page tracking", () => {
   let v3: V3;
 
@@ -15,16 +26,15 @@ test.describe("V3 chrome:// new-tab page tracking", () => {
     await closeV3(v3);
   });
 
-  test("pages() includes a tab opened via chrome://newtab/", async () => {
+  test("pages() includes a tab opened at a chrome:// URL", async () => {
     const ctx = v3.context;
     const initialPages = ctx.pages();
     expect(initialPages.length).toBe(1);
 
-    // Simulate a manually-opened tab by creating a target at chrome://newtab/.
-    // This is the same CDP path the browser takes when the user presses Ctrl+T.
+    // Same CDP path the browser takes when the user presses Ctrl+T.
     const { targetId } = await ctx.conn.send<{ targetId: string }>(
       "Target.createTarget",
-      { url: "chrome://newtab/" },
+      { url: WEBUI_URL },
     );
 
     // Wait for the page to be registered (onAttachedToTarget is async).
@@ -42,13 +52,12 @@ test.describe("V3 chrome:// new-tab page tracking", () => {
     expect(newPage).toBeTruthy();
   });
 
-  test("chrome://newtab/ tab becomes usable after navigating to a web URL", async () => {
+  test("a chrome:// tab becomes usable after navigating to a web URL", async () => {
     const ctx = v3.context;
 
-    // Create a tab at chrome://newtab/ (same as user pressing Ctrl+T).
     const { targetId } = await ctx.conn.send<{ targetId: string }>(
       "Target.createTarget",
-      { url: "chrome://newtab/" },
+      { url: WEBUI_URL },
     );
 
     // Wait for registration.
@@ -61,11 +70,15 @@ test.describe("V3 chrome:// new-tab page tracking", () => {
     const newPage = ctx.pages().find((p) => p.targetId() === targetId);
     expect(newPage).toBeTruthy();
 
-    // Navigate the new tab to a real web page.
-    await newPage!.goto("https://example.com/", {
-      waitUntil: "domcontentloaded",
-    });
+    // Navigate the new tab out of the privileged WebUI into web content.
+    await newPage!.goto(TARGET_URL, { waitUntil: "domcontentloaded" });
 
-    expect(newPage!.url()).toContain("example.com");
+    expect(newPage!.url()).toContain("data:text/html");
+
+    // The swap must not orphan the caller's Page object.
+    expect(ctx.pages().find((p) => p.targetId() === targetId)).toBe(newPage);
+
+    // "Usable" means drivable, not just a correct url().
+    expect(await newPage!.locator("#marker").textContent()).toBe(TARGET_MARKER);
   });
 });


### PR DESCRIPTION
## Why

`e2e/local/chrome-newtab-page-tracking` fails intermittently on unrelated PRs (e.g. [this run on #2347](https://github.com/browserbase/stagehand/actions/runs/29538363318/job/87758303923?pr=2347)). This removes the cause.

## What changed

Updated `chrome://new-tab` to go to `chrome://version` from a static injected site

## Test plan
- [x] get CI fully green again
