### PR TITLE
[STG-2284] feat(evals): richer OTEL traces — task root, thread grouping, trajectory

### DIFF
--- a/packages/evals/framework/runner.ts
+++ b/packages/evals/framework/runner.ts
@@ -36,6 +36,7 @@ import { onceAsync, registerActiveRunCleanup } from "./activeRunCleanup.js";
 import { loadTaskModuleFromPath } from "./taskLoader.js";
 import { resolveTraceTransport } from "./langsmith.js";
 import { buildTracerProvider, shutdownTracing } from "./otel.js";
+import { randomUUID } from "node:crypto";
 
 export { discoverTasks, resolveTarget } from "./discovery.js";
 export {
@@ -279,6 +280,87 @@ export interface RunEvalsResult {
   }>;
 }
 
+/**
+ * Upper bound on the JSON size of a span payload. Measured against the live
+ * LangSmith OTLP endpoint: 300KB/700KB/1MB/3MB payloads all round-trip intact
+ * (it offloads large values to S3), and real agent runs land around 600KB. 2MB
+ * keeps ~3x headroom over observed runs while staying under the proven ceiling
+ * — a single oversized span can fail its whole OTLP export batch and silently
+ * take every other span in that batch with it.
+ */
+const MAX_SPAN_PAYLOAD_BYTES = 2_000_000;
+
+/** UTF-8 byte length of a value's JSON, or undefined if it can't serialize. */
+function jsonByteSize(value: unknown): number | undefined {
+  try {
+    const json = JSON.stringify(value);
+    return json === undefined ? undefined : Buffer.byteLength(json, "utf8");
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Keep `value` whole when it serializes small enough. Otherwise progressively
+ * drop the oldest `logs` entries (the only unbounded field) until it fits, so a
+ * huge run still yields a useful tail rather than nothing, and record what was
+ * dropped. If the non-`logs` fields alone already exceed the cap, `logs` is
+ * dropped entirely — the return value is always within the cap, never a payload
+ * that would fail its OTLP batch. `.trajectories` remains the complete record
+ * either way.
+ *
+ * Exported for unit testing; not part of the module's public surface.
+ */
+export function capForSpan(
+  value: Record<string, unknown>,
+): Record<string, unknown> {
+  const size = jsonByteSize(value);
+  if (size === undefined) return { _truncated: "payload not serializable" };
+  if (size <= MAX_SPAN_PAYLOAD_BYTES) return value;
+
+  const logs = value.logs;
+  const rest = { ...value };
+  delete rest.logs;
+  const baseSize = jsonByteSize(rest);
+
+  // Non-`logs` fields already over the cap (or `logs` isn't a trimmable array,
+  // or `rest` won't serialize): trimming logs can't bring us under. Keep only
+  // the fields that are individually small so the return is guaranteed within
+  // the cap rather than shipping an oversized payload that fails its batch.
+  if (
+    !Array.isArray(logs) ||
+    baseSize === undefined ||
+    baseSize > MAX_SPAN_PAYLOAD_BYTES
+  ) {
+    const PER_FIELD_LIMIT = 64_000;
+    const compact: Record<string, unknown> = {};
+    for (const [key, fieldValue] of Object.entries(rest)) {
+      const fieldSize = jsonByteSize(fieldValue);
+      if (fieldSize !== undefined && fieldSize <= PER_FIELD_LIMIT) {
+        compact[key] = fieldValue;
+      }
+    }
+    return {
+      ...compact,
+      _truncated: `payload ${size}B exceeded cap ${MAX_SPAN_PAYLOAD_BYTES}B; oversized fields omitted — see .trajectories for the complete record`,
+    };
+  }
+
+  // Halve the retained tail (dropping the oldest entries) until it fits. The
+  // baseSize check above guarantees this terminates within the cap.
+  let kept = logs;
+  while (kept.length > 0) {
+    kept = kept.slice(Math.ceil(kept.length / 2));
+    const probe = jsonByteSize({ ...rest, logs: kept });
+    if (probe !== undefined && probe <= MAX_SPAN_PAYLOAD_BYTES) break;
+  }
+  return {
+    ...rest,
+    logs: kept,
+    _truncated: `kept the last ${kept.length} of ${logs.length} log entries: full payload was ${size}B (cap ${MAX_SPAN_PAYLOAD_BYTES}B) — see .trajectories for the complete record`,
+  };
+}
+
 function formatProgressError(error: unknown): string | undefined {
   if (error === undefined || error === null) return undefined;
   if (typeof error === "string") return error;
@@ -337,6 +419,19 @@ export async function runEvals(
   const runModel = resolveUnambiguousModel(
     testcases.map((testcase) => testcase.input?.modelName),
   );
+
+  // LangSmith addresses threads by URL path segment (/v2/threads/<id>/...),
+  // and its gateway rejects percent-encoded slashes with a 403 HTML page —
+  // which the browser reports as a CORS preflight failure, breaking the whole
+  // thread/peek view. Experiment names contain "/" (e.g. "agent/onlineMind2Web"),
+  // so the id must be sanitized to a path-safe form. The timestamp + random
+  // suffix scopes the thread to this invocation (so one eval run groups as one
+  // thread) while the random component avoids collisions between runs that
+  // start within the same millisecond.
+  const traceThreadId = `${experimentName.replace(
+    /[^A-Za-z0-9._-]+/g,
+    "__",
+  )}-${Date.now().toString(36)}-${randomUUID().slice(0, 8)}`;
 
   // Stamp the run-scoped trajectory group; the token is generated once here and
   // reused for the completion-time experiment link. Local persistence only.
@@ -443,7 +538,59 @@ export async function runEvals(
           modelName: input.modelName,
         });
 
-        const result = await executeTask(input, resolvedTask, options);
+        // Task-root span for the OTEL transport only: it gives LangSmith a
+        // per-task trace root (agent/verifier spans nest beneath) and carries
+        // the thread_id that groups one eval run in the Threads view. Gated
+        // off in native mode so the Braintrust span tree stays byte-identical.
+        const result =
+          traceTransport === "otel"
+            ? await tracedSpan(
+                async (span) => {
+                  const taskResult = await executeTask(
+                    input,
+                    resolvedTask,
+                    options,
+                  );
+                  // Mirror the whole TaskResult onto the root span so the
+                  // trace carries the agent's trajectory. Braintrust gets this
+                  // for free: its Eval() framework hands the TaskResult to the
+                  // scorers, so the logs show up in the scorer spans (~400KB).
+                  // OTEL has no equivalent, so we attach it explicitly here.
+                  // `logs` is the Stagehand logger output — i.e. what the
+                  // agent actually did — and is already screenshot-redacted by
+                  // EvalLogger. Capped so a pathological run can't blow up the
+                  // OTLP payload.
+                  span?.log({
+                    output: capForSpan({
+                      _success: taskResult._success,
+                      ...(taskResult.error !== undefined && {
+                        error: taskResult.error,
+                      }),
+                      ...(taskResult.metrics !== undefined && {
+                        metrics: taskResult.metrics,
+                      }),
+                      ...(taskResult.logs !== undefined && {
+                        logs: taskResult.logs,
+                      }),
+                    }),
+                    metadata: {
+                      experiment_name: experimentName,
+                      thread_id: traceThreadId,
+                      model: input.modelName,
+                      task: input.name,
+                    },
+                  });
+                  return taskResult;
+                },
+                {
+                  name: input.name,
+                  type: "task",
+                  event: {
+                    input: { task: input.name, model: input.modelName },
+                  },
+                },
+              )
+            : await executeTask(input, resolvedTask, options);
 
         options.onProgress?.({
           type: result._success ? "passed" : "failed",

--- a/packages/evals/tests/framework/capforspan.test.ts
+++ b/packages/evals/tests/framework/capforspan.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { capForSpan } from "../../framework/runner.js";
+
+const MAX_SPAN_PAYLOAD_BYTES = 2_000_000;
+
+function jsonBytes(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value), "utf8");
+}
+
+describe("capForSpan", () => {
+  it("returns small payloads unchanged", () => {
+    const value = { _success: true, metrics: { steps: 3 }, logs: ["a", "b"] };
+    expect(capForSpan(value)).toBe(value);
+  });
+
+  it("flags payloads that cannot be serialized", () => {
+    const circular: Record<string, unknown> = { _success: true };
+    circular.self = circular;
+    expect(capForSpan(circular)).toEqual({
+      _truncated: "payload not serializable",
+    });
+  });
+
+  it("keeps a tail of logs when the payload exceeds the cap", () => {
+    // ~4MB of logs: 400 entries × ~10KB each. Entries are distinguishable so
+    // we can assert the *tail* (newest) is what survives.
+    const logs = Array.from(
+      { length: 400 },
+      (_, i) => `entry-${i}-${"x".repeat(10_000)}`,
+    );
+    const value = { _success: false, logs };
+
+    const capped = capForSpan(value);
+
+    expect(jsonBytes(capped)).toBeLessThanOrEqual(MAX_SPAN_PAYLOAD_BYTES);
+    const keptLogs = capped.logs as string[];
+    expect(keptLogs.length).toBeGreaterThan(0);
+    expect(keptLogs.length).toBeLessThan(logs.length);
+    // Tail-preserving: the kept entries are a contiguous suffix of the input.
+    expect(keptLogs).toEqual(logs.slice(logs.length - keptLogs.length));
+    expect(keptLogs[keptLogs.length - 1]).toBe(logs[logs.length - 1]);
+    expect(capped._truncated).toMatch(/kept the last \d+ of 400 log entries/);
+  });
+
+  it("drops oversized non-log fields so the result is always within the cap (P1)", () => {
+    // A single non-`logs` field alone blows the cap; trimming logs can't help.
+    const value = {
+      _success: false,
+      error: "e".repeat(2_500_000),
+      metrics: { steps: 2 },
+      logs: ["a", "b"],
+    };
+
+    const capped = capForSpan(value);
+
+    expect(jsonBytes(capped)).toBeLessThanOrEqual(MAX_SPAN_PAYLOAD_BYTES);
+    expect(capped.error).toBeUndefined();
+    expect(capped._success).toBe(false); // small scalar survives
+    expect(capped.metrics).toEqual({ steps: 2 }); // small object survives
+    expect(capped._truncated).toMatch(/oversized fields omitted/);
+  });
+
+  it("measures bytes, not UTF-16 code units (P2)", () => {
+    // "€" is 1 UTF-16 unit but 3 UTF-8 bytes. This string's JSON char length
+    // is under the cap, but its byte length is over — a char-counting cap
+    // would wrongly pass it through whole.
+    const value = { note: "€".repeat(700_000) };
+    expect(JSON.stringify(value).length).toBeLessThan(MAX_SPAN_PAYLOAD_BYTES);
+    expect(jsonBytes(value)).toBeGreaterThan(MAX_SPAN_PAYLOAD_BYTES);
+
+    const capped = capForSpan(value);
+
+    expect(jsonBytes(capped)).toBeLessThanOrEqual(MAX_SPAN_PAYLOAD_BYTES);
+    expect(capped.note).toBeUndefined();
+    expect(capped._truncated).toBeDefined();
+  });
+});


### PR DESCRIPTION
# why

With the transport wired (#2353), a whole eval run rendered in LangSmith as a handful of opaque spans: `agent.execute` and the verifier spans arrived as separate flat traces with no per-task parent, nothing tied the tasks of one run together, and none of them carried what the agent actually did — so a trace told you almost nothing.

Braintrust looks richer only because its `Eval()` framework hands the whole `TaskResult` to its scorers, so the Stagehand logs ride along in the scorer spans (~400KB). OTEL has no equivalent hook, so the same data has to be attached explicitly.

# what changed

All three additions are gated on `EVAL_TRACE_TRANSPORT=otel`; the native Braintrust span tree is untouched.

- **Per-task root span** — `agent.execute` / `verifier.*` now nest under their task instead of arriving as sibling traces.
- **Path-safe `thread_id`** — groups every task of one invocation into one LangSmith thread. LangSmith addresses threads as a URL *path* segment and its gateway answers percent-encoded slashes with a 403 HTML page (which the browser surfaces as a CORS preflight failure, breaking the thread/peek view), so experiment names like `agent/onlineMind2Web` are sanitized and suffixed per run.
- **Trajectory on the root span** — the `TaskResult` (`_success`, `error`, `metrics`, `logs`). Capped at 2MB with a log-tail trim: LangSmith accepts 3MB payloads and real runs land ~270–640KB, but one oversized span can fail its entire OTLP export batch and silently take every other span in it down.

# test plan

- Unit suite green (392); native-path invariants unchanged (`braintrust-optional`, `braintrust-runner-nolog`, `core-runner`).
- Verified end-to-end against live LangSmith on a real local agent run: root + 3 nested children, 59-entry trajectory on the root, all three thread endpoints (`stats`/`traces`/`messages`) returning 200 where the unsanitized id returned 403.
- `.trajectories/` remains the complete record and is byte-unchanged.

Stack 6/7 · base: #2355

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves OTEL traces for eval runs: per-task root spans, run-level thread grouping with a collision‑resistant, path‑safe `thread_id`, and the full task trajectory on each task root. Addresses STG-2284. LangSmith traces are now readable and grouped per run; Braintrust spans are unchanged.

- **New Features**
  - Per-task root span (otel only): `agent.execute` and `verifier.*` now nest under each task.
  - Path-safe, collision‑resistant `thread_id`: sanitizes experiment name and adds timestamp + random suffix to group a run and avoid 403s in LangSmith.
  - Trajectory on the task root: attaches `_success`, `error`, `metrics`, and `logs`; capped at 2MB (UTF‑8 bytes) with tail-trim; guaranteed within cap even when non‑log fields are oversized; `.trajectories/` remains the full record.
  - Tests: unit tests for `capForSpan` (identity, tail-trim, oversized non-log fields, byte-size enforcement).

<sup>Written for commit 0dd9b6fbad9c56de65e647a896228b2fd10dfdd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

