### PR TITLE
[STG-2284] fix(evals): default experimental to true on the SDK path

### DIFF
--- a/packages/evals/initV3.ts
+++ b/packages/evals/initV3.ts
@@ -24,6 +24,24 @@ import {
 import { getEnv } from "./env.js";
 import { EvalLogger } from "./logger.js";
 
+/**
+ * Resolve the V3 `experimental` flag for eval runs.
+ *
+ * Experimental features (hybrid agent mode, verifier agent callbacks) require
+ * it on the SDK path, so it defaults ON there. But core forbids `experimental`
+ * together with API mode (`ExperimentalNotConfiguredError`), so it is forced
+ * OFF whenever USE_API=true — even when the caller explicitly asks for it.
+ *
+ * Exported for unit testing.
+ */
+export function resolveExperimental(
+  requested: boolean | undefined,
+  useApi: boolean = process.env.USE_API === "true",
+): boolean {
+  if (useApi) return false;
+  return typeof requested === "boolean" ? requested : true;
+}
+
 type InitV3Args = {
   llmClient?: LLMClient;
   modelClientOptions?: ClientOptions;
@@ -108,10 +126,7 @@ export async function initV3({
         configOverrides?.chromeFlags,
     },
     model: resolvedModelConfig,
-    experimental:
-      typeof configOverrides?.experimental === "boolean"
-        ? configOverrides.experimental && process.env.USE_API !== "true" // experimental only when not using API
-        : false,
+    experimental: resolveExperimental(configOverrides?.experimental),
     verbose: verbose ? 2 : 0,
     browserbaseSessionCreateParams:
       configOverrides?.browserbaseSessionCreateParams,

--- a/packages/evals/tests/initv3-experimental.test.ts
+++ b/packages/evals/tests/initv3-experimental.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { resolveExperimental } from "../initV3.js";
+
+describe("resolveExperimental", () => {
+  it("defaults experimental ON for SDK-path runs", () => {
+    expect(resolveExperimental(undefined, false)).toBe(true);
+  });
+
+  it("forces experimental OFF under API mode, even when requested", () => {
+    // Core rejects `experimental` together with API mode, so the API guard
+    // wins over both the default and an explicit opt-in.
+    expect(resolveExperimental(undefined, true)).toBe(false);
+    expect(resolveExperimental(true, true)).toBe(false);
+    expect(resolveExperimental(false, true)).toBe(false);
+  });
+
+  it("honors an explicit boolean on the SDK path", () => {
+    expect(resolveExperimental(true, false)).toBe(true);
+    expect(resolveExperimental(false, false)).toBe(false);
+  });
+
+  it("reads USE_API from the environment when not passed explicitly", () => {
+    const prev = process.env.USE_API;
+    try {
+      process.env.USE_API = "true";
+      expect(resolveExperimental(undefined)).toBe(false);
+      process.env.USE_API = "false";
+      expect(resolveExperimental(undefined)).toBe(true);
+      delete process.env.USE_API;
+      expect(resolveExperimental(undefined)).toBe(true);
+    } finally {
+      if (prev === undefined) delete process.env.USE_API;
+      else process.env.USE_API = prev;
+    }
+  });
+});


### PR DESCRIPTION
# why

Running any agent eval through the verifier backend failed at V3 construction with `ExperimentalNotConfiguredError` — `Feature "Agent callbacks" is an experimental feature, and cannot be configured when disableAPI: false`.

`initV3` defaulted `experimental: false` whenever a task passed no explicit value, but `verifierAdapter` installs agent callbacks (for trajectory recording) and hybrid agent mode also requires experimental. Core rejects both unless the instance is constructed with `experimental: true`. The verifier-carrier instance in `benchHarness` already sets it; the browser-driving instance did not.

# what changed

One line in `initV3.ts`: when a task passes no explicit `experimental` value, default it to `process.env.USE_API !== "true"` instead of `false`.

**This does not enable experimental in API mode.** The default is gated on `USE_API`, so `USE_API=true` still resolves to `experimental: false` — identical to previous behavior. That gating is deliberate: core forbids the combination outright (*"`experimental` mode cannot be used together with the Stagehand API"*), so experimental is only turned on where `disableAPI: true` already holds, which is the pairing core requires.

**This flag is unrelated to OTEL tracing.** Traces reach LangSmith/Braintrust through the harness-level `tracedSpan` → OTEL exporter path, which never reads V3 config — verified by emitting a full nested `task → agent.execute → verifier.*` tree with no V3 instance at all. What this flag unblocks is whether a verifier-backed run can *start* in SDK mode; the two only looked coupled because a run that fails at construction produces no spans.

**Pre-existing limitation this does not address:** verifier-backed agent evals still cannot run in API mode, because core rejects experimental features whenever `disableAPI: false` regardless of the flag. Supporting that would need either core accepting agent callbacks in API mode, or the harness reconstructing the trajectory from the API response instead of callbacks.

# test plan

- Unit suite green (392), typecheck + lint clean.
- Verified by running a real agent eval (`b:onlineMind2Web`, hybrid, gemini-3-flash) which previously failed at init for every task and now completes and scores.
- No change for `USE_API=true` runs (resolves to `false`, as before). Note: an end-to-end `USE_API=true` run has not been exercised on this branch — the reasoning above is from the code path, so worth a confirmation run before relying on API-mode behavior.

Stack 7/7 · base: #2371