### PR TITLE
feat(cli): add --only-errors to `cloud sessions logs`

### DIFF
--- a/packages/cli/src/commands/cloud/sessions/logs.ts
+++ b/packages/cli/src/commands/cloud/sessions/logs.ts
@@ -1,4 +1,4 @@
-import { Args } from "@oclif/core";
+import { Args, Flags } from "@oclif/core";
 
 import {
   createBrowserbaseClient,
@@ -6,23 +6,53 @@ import {
   withBrowserbaseApi,
 } from "../../../lib/cloud/api.js";
 import { apiCommonFlags, toApiOptions } from "../../../lib/cloud/flags.js";
+import { reduceLogs } from "../../../lib/cloud/reduce-logs.js";
 import { BrowseCommand } from "../../../base.js";
 
 export default class SessionsLogs extends BrowseCommand {
   static override description = "Get Browserbase session logs.";
-  static override examples = ["browse cloud sessions logs <session-id>"];
+  static override examples = [
+    "browse cloud sessions logs <session-id>",
+    "browse cloud sessions logs <session-id> --only-errors",
+    "browse cloud sessions logs <session-id> --only-errors --failed-requests",
+  ];
 
   static override args = {
     id: Args.string({ required: true, description: "Session ID." }),
   };
 
-  static override flags = { ...apiCommonFlags };
+  static override flags = {
+    ...apiCommonFlags,
+    "only-errors": Flags.boolean({
+      description:
+        "Return only the high-signal error records (console errors/exceptions, HTTP 4xx/5xx, network failures) instead of the full CDP firehose.",
+      default: false,
+    }),
+    "failed-requests": Flags.boolean({
+      description:
+        "With --only-errors, narrow to failed / error-status network requests only.",
+      default: false,
+      dependsOn: ["only-errors"],
+    }),
+  };
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse(SessionsLogs);
     await withBrowserbaseApi("sessions", async () => {
       const client = createBrowserbaseClient(toApiOptions(flags));
-      outputJson(await client.sessions.logs.list(args.id));
+      const raw = await client.sessions.logs.list(args.id);
+      if (flags["only-errors"]) {
+        const arr = Array.isArray(raw)
+          ? raw
+          : ((raw as { data?: unknown[] })?.data ?? []);
+        outputJson(
+          reduceLogs(arr as never[], {
+            failedRequests: flags["failed-requests"],
+          }),
+        );
+      } else {
+        outputJson(raw);
+      }
     });
   }
 }

--- a/packages/cli/src/lib/cloud/reduce-logs.ts
+++ b/packages/cli/src/lib/cloud/reduce-logs.ts
@@ -1,0 +1,71 @@
+// Deterministic reducer for `browse cloud sessions logs --only-errors`.
+// Turns the raw CDP firehose (~hundreds of events per session) into the high-signal error slice:
+// console errors/warnings/asserts, uncaught exceptions, HTTP 4xx/5xx responses, and net-level load
+// failures. No LLM — pure allowlist + severity/status filter + field projection + dedupe + stack trim.
+
+export interface ReduceLogsOptions {
+  /** Only failed / error-status network requests (4xx/5xx + load failures). */
+  failedRequests?: boolean;
+}
+
+interface RawLog {
+  method?: string;
+  request?: { rawBody?: string; params?: unknown };
+}
+
+function paramsOf(e: RawLog): Record<string, any> {
+  try {
+    return (JSON.parse(e.request?.rawBody ?? "{}").params as Record<string, any>) ?? {};
+  } catch {
+    return {};
+  }
+}
+
+// Keep the message line + the app (`/src/`) stack frames; drop framework/vendor frames and hosts.
+function trimStack(s: string): string {
+  return (s || "")
+    .split("\n")
+    .filter((l, i) => i === 0 || (/\/src\//.test(l) && !/node_modules|\.vite/.test(l)))
+    .slice(0, 4)
+    .map((l) => l.replace(/https?:\/\/[^/)]+/g, "").replace(/\?[^):]*/, "").trim())
+    .join("\n");
+}
+
+export function reduceLogs(raw: RawLog[], opts: ReduceLogsOptions = {}): unknown[] {
+  const out: Record<string, unknown>[] = [];
+  const seen = new Set<string>();
+  const push = (rec: Record<string, unknown>) => {
+    const k = JSON.stringify(rec);
+    if (!seen.has(k)) {
+      seen.add(k);
+      out.push(rec);
+    }
+  };
+
+  for (const e of raw) {
+    const p = paramsOf(e);
+    const m = e.method;
+    let rec: Record<string, unknown> | null = null;
+
+    if (m === "Runtime.consoleAPICalled" && ["error", "warning", "assert"].includes(p.type)) {
+      const text = (p.args ?? []).map((a: any) => a.description || a.value || "").join(" ");
+      if (text && !/^%[os]/.test(text)) rec = { kind: `console.${p.type}`, domain: "Runtime", severity: p.type, text: trimStack(text) };
+    } else if (m === "Runtime.exceptionThrown") {
+      rec = { kind: "exception", domain: "Runtime", severity: "error", text: trimStack(p.exceptionDetails?.exception?.description ?? p.exceptionDetails?.text ?? "") };
+    } else if (m === "Log.entryAdded" && ["error", "warning"].includes(p.entry?.level)) {
+      rec = { kind: `log.${p.entry.level}`, domain: "Log", severity: p.entry.level, text: p.entry.text, url: p.entry.url };
+    } else if (m === "Network.responseReceived" && (p.response?.status ?? 0) >= 400) {
+      rec = { kind: "network", domain: "Network", status: p.response.status, url: p.response.url, type: p.type };
+    } else if (m === "Network.loadingFailed" && p.errorText !== "net::ERR_ABORTED") {
+      rec = { kind: "network.failed", domain: "Network", error: p.errorText, type: p.type };
+    } else {
+      continue; // everything else (byte-chunk / lifecycle events) is noise
+    }
+
+    if (!rec) continue; // e.g. a console.error whose text was empty / formatting noise
+    if (opts.failedRequests && rec.domain !== "Network") continue;
+    push(rec);
+  }
+
+  return out;
+}


### PR DESCRIPTION
## What
Adds `--only-errors` (and `--failed-requests`) to `browse cloud sessions logs`.

By default the command returns the full CDP firehose (~hundreds of events, unchanged). `--only-errors` runs a deterministic reducer that returns just the high-signal error records:
- console errors / warnings / asserts
- uncaught exceptions (with app-frame-trimmed stacks)
- HTTP 4xx/5xx responses
- net-level load failures (CORS / DNS / connection)

deduped, no LLM.

```
browse cloud sessions logs <id> --only-errors
browse cloud sessions logs <id> --only-errors --failed-requests
```

## Why
Agents debugging Browserbase sessions (build/verification agents for AI app builders) want the runtime errors, not the raw firehose. Today they pull ~hundreds of CDP events and grep. `--only-errors` returns the handful that matter in one call — far fewer tokens/tool-calls in the agent loop, and language-agnostic (shell out from any agent).

## Scope / notes
- **Default behavior unchanged** (raw firehose) — opt-in only, so no breaking change.
- Reducer lives in `packages/cli/src/lib/cloud/reduce-logs.ts` (pure, unit-testable).
- Catches console / exception / 4xx-5xx / net-failure classes. Does **not** catch an HTTP 200 response carrying an error *body* (that needs response-body capture at ingest — follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add --only-errors to cloud sessions logs to return only high-signal errors, with an optional --failed-requests to narrow to failed network calls. Default output is unchanged.

- **New Features**
  - `--only-errors`: returns console errors/warnings/asserts, uncaught exceptions (trimmed stacks), HTTP 4xx/5xx, and network load failures; deduped.
  - `--failed-requests`: with `--only-errors`, returns only failed/error-status network requests.
  - Deterministic reducer added in `packages/cli/src/lib/cloud/reduce-logs.ts` (pure and unit-testable).

<sup>Written for commit 88c785f9524e2120ab3d04f2939481a078720bbd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

