### PR TITLE
feat(server-v3): expose OpenAI endpoint format

### DIFF
--- a/.changeset/openai-chat-api-mode.md
+++ b/.changeset/openai-chat-api-mode.md
@@ -3,4 +3,4 @@
 "@browserbasehq/stagehand-server-v3": patch
 ---
 
-Allow OpenAI-compatible models to select the Chat Completions API with `openaiEndpointFormat: "chat"` in model configuration without sending Responses-only options.
+Allow OpenAI-compatible models to select the Chat Completions API with `openaiEndpointFormat: "chat"`

--- a/.changeset/openai-chat-api-mode.md
+++ b/.changeset/openai-chat-api-mode.md
@@ -1,5 +1,6 @@
 ---
 "@browserbasehq/stagehand": patch
+"@browserbasehq/stagehand-server-v3": patch
 ---
 
 Allow OpenAI-compatible models to select the Chat Completions API with `openaiEndpointFormat: "chat"` in model configuration without sending Responses-only options.

--- a/packages/core/lib/v3/types/public/api.ts
+++ b/packages/core/lib/v3/types/public/api.ts
@@ -207,6 +207,11 @@ const ModelConfigBaseSchema = z
   .strict();
 
 export const GenericModelConfigObjectSchema = ModelConfigBaseSchema.extend({
+  openaiEndpointFormat: z.enum(["responses", "chat"]).optional().meta({
+    description:
+      "Wire format used by an OpenAI-compatible endpoint. Defaults to the Responses API; use chat for Chat Completions-only endpoints.",
+    example: "chat",
+  }),
   provider: z
     .enum(["openai", "anthropic", "google", "microsoft", "bedrock"])
     .optional()

--- a/packages/server-v3/openapi.v3.yaml
+++ b/packages/server-v3/openapi.v3.yaml
@@ -338,6 +338,14 @@ components:
             type: string
           additionalProperties:
             type: string
+        openaiEndpointFormat:
+          description: Wire format used by an OpenAI-compatible endpoint. Defaults to the
+            Responses API; use chat for Chat Completions-only endpoints.
+          example: chat
+          type: string
+          enum:
+            - responses
+            - chat
         provider:
           description: AI provider for the model (or provide a baseURL endpoint instead)
           example: openai

--- a/packages/server-v3/tests/unit/requestModelConfig.test.ts
+++ b/packages/server-v3/tests/unit/requestModelConfig.test.ts
@@ -34,6 +34,25 @@ function assertSuccess(
 }
 
 describe("getRequestModelConfig", () => {
+  it("preserves the OpenAI endpoint format through session initialization", () => {
+    const model = {
+      modelName: "openai/gpt-4.1-mini",
+      baseURL: "https://example.com/v1",
+      openaiEndpointFormat: "chat",
+    } as const;
+    const request = createRequest({
+      body: {
+        options: { model },
+      },
+    });
+
+    assert.deepEqual(assertSuccess(getRequestModelConfig(request)).model, model);
+    assert.deepEqual(
+      assertSuccess(getStagehandInitModelConfig(request)).model,
+      model,
+    );
+  });
+
   it("preserves a Vertex model config from an action request so auth fields reach session initialization", () => {
     const model = {
       provider: "vertex",

--- a/packages/server-v3/tests/unit/requestModelConfig.test.ts
+++ b/packages/server-v3/tests/unit/requestModelConfig.test.ts
@@ -46,7 +46,10 @@ describe("getRequestModelConfig", () => {
       },
     });
 
-    assert.deepEqual(assertSuccess(getRequestModelConfig(request)).model, model);
+    assert.deepEqual(
+      assertSuccess(getRequestModelConfig(request)).model,
+      model,
+    );
     assert.deepEqual(
       assertSuccess(getStagehandInitModelConfig(request)).model,
       model,


### PR DESCRIPTION
Propagates openaiEndpointFormat through the server-v3 request schema and generated OpenAPI spec so Stainless can expose it in the Python SDK. Adds a regression test covering request and session initialization parsing

Validation:
- core build
- server-v3 OpenAPI generation
- server-v3 typecheck
- requestModelConfig unit tests (9 passing)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose the OpenAI endpoint wire format in v3 via `openaiEndpointFormat` on model config and OpenAPI, so SDKs can target `responses` or `chat` (defaults to Responses). Adds a unit test to ensure the format is preserved through request parsing and session initialization, and a changeset to release in `@browserbasehq/stagehand` and `@browserbasehq/stagehand-server-v3`.

<sup>Written for commit 6f8dedbbadf7b2c9f66dee802ffbd49347c39565. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



