### PR TITLE
[STG-2672] fix(core): fail fast when the CDP transport dies instead of timing out

### DIFF
--- a/.changeset/cdp-transport-death-fails-fast.md
+++ b/.changeset/cdp-transport-death-fails-fast.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Report a dead CDP connection instead of a misleading timeout. When the browser's websocket closed mid-operation, `waitForMainLoadState` kept polling a dead session — every poll error was swallowed as "not ready yet" — and eventually failed with `waitForMainLoadState(domcontentloaded) timed out after 15000ms`, which reads like a slow page rather than a lost browser. Lifecycle waits now abort immediately with `CdpConnectionClosedError` carrying the socket close reason.

--- a/packages/core/lib/v3/understudy/cdp.ts
+++ b/packages/core/lib/v3/understudy/cdp.ts
@@ -77,8 +77,25 @@ export class CdpConnection implements CDPSessionLike {
   private sessionDispatchWaiters = new Set<SessionDispatchWaiter>();
   public readonly id: string | null = null; // root
   private transportCloseHandlers = new Set<(why: string) => void>();
+  private _transportClosedReason: string | null = null;
 
   public flowLoggerContext?: FlowLoggerContext; // Instance-owned fallback flow context; V3 sets this once and later sends/callbacks re-enter it when ALS is absent.
+
+  /**
+   * Why the transport closed, or null while it is still open.
+   *
+   * Waiters that subscribe *after* the socket has already gone need this: no
+   * further close event will ever be emitted for them, so without a way to ask
+   * they would block until their own timeout and report a misleading error.
+   */
+  public get transportClosedReason(): string | null {
+    if (this._transportClosedReason) return this._transportClosedReason;
+    const state = this.ws.readyState;
+    if (state === WebSocket.CLOSED || state === WebSocket.CLOSING) {
+      return `socket-${state === WebSocket.CLOSED ? "closed" : "closing"}`;
+    }
+    return null;
+  }
 
   public onTransportClosed(handler: (why: string) => void): void {
     this.transportCloseHandlers.add(handler);
@@ -88,6 +105,7 @@ export class CdpConnection implements CDPSessionLike {
   }
 
   private emitTransportClosed(why: string) {
+    this._transportClosedReason ??= why;
     for (const h of this.transportCloseHandlers) {
       try {
         h(why);

--- a/packages/core/lib/v3/understudy/page.ts
+++ b/packages/core/lib/v3/understudy/page.ts
@@ -39,6 +39,7 @@ import {
   StagehandInvalidArgumentError,
   StagehandEvalError,
   StagehandUnsupportedBrowserFeatureError,
+  CdpConnectionClosedError,
 } from "../types/public/sdkErrors.js";
 import { normalizeInitScriptSource } from "./initScripts.js";
 import { buildLocatorInvocation } from "./locatorInvocation.js";
@@ -2667,6 +2668,14 @@ export class Page {
     state: LoadState,
     timeoutMs = 15000,
   ): Promise<void> {
+    // A dead transport can never deliver the lifecycle event we are about to
+    // wait for. Without this check the wait burns its whole timeout and then
+    // blames the page for loading slowly, which hides the real failure.
+    const alreadyClosed = this.conn.transportClosedReason;
+    if (alreadyClosed) {
+      throw new CdpConnectionClosedError(alreadyClosed);
+    }
+
     await this.mainSession
       .send("Page.setLifecycleEventsEnabled", { enabled: true })
       .catch(() => {});
@@ -2690,6 +2699,7 @@ export class Page {
         this.mainSession.off("Page.lifecycleEvent", onLifecycle);
         this.mainSession.off("Page.domContentEventFired", onDomContent);
         this.mainSession.off("Page.loadEventFired", onLoad);
+        this.conn.offTransportClosed(onTransportClosed);
       };
       const clearPollTimer = () => {
         if (pollTimer) {
@@ -2724,6 +2734,31 @@ export class Page {
         if (state === "load") finish();
       };
 
+      // If the browser goes away mid-wait the lifecycle listeners fall silent
+      // and every readyState poll fails, which isMainLoadStateReady reports as
+      // "not ready". Fail fast with the real reason instead of timing out.
+      const onTransportClosed = (why: string) => {
+        if (done) return;
+        done = true;
+        if (timer) {
+          clearTimeout(timer);
+          timer = null;
+        }
+        clearPollTimer();
+        off();
+        reject(new CdpConnectionClosedError(why));
+      };
+      this.conn.onTransportClosed(onTransportClosed);
+      // The transport can die between the pre-flight check above and this
+      // subscription (an await sits in between). In that window the close event
+      // has already been emitted and will never fire again, so re-check now
+      // rather than waiting out the full timeout.
+      const closedDuringSetup = this.conn.transportClosedReason;
+      if (closedDuringSetup) {
+        onTransportClosed(closedDuringSetup);
+        return;
+      }
+
       this.mainSession.on("Page.lifecycleEvent", onLifecycle);
       // Backups for sites that don't emit lifecycle consistently
       this.mainSession.on("Page.domContentEventFired", onDomContent);
@@ -2733,6 +2768,14 @@ export class Page {
       // where readyState has advanced but the corresponding event was missed.
       const pollReadyState = async () => {
         if (done || pollInFlight) return;
+        // The poll is what masks a dead browser: isMainLoadStateReady catches
+        // the failed CDP send and reports "not ready". Check the transport
+        // explicitly so the death cannot hide behind a falsy readyState.
+        const closedNow = this.conn.transportClosedReason;
+        if (closedNow) {
+          onTransportClosed(closedNow);
+          return;
+        }
         pollInFlight = true;
         try {
           if (done) return;


### PR DESCRIPTION
## Summary

When the browser's CDP websocket dies mid-operation, `waitForMainLoadState` cannot tell **"page not loaded yet"** from **"connection is dead"** — so it burns its full 15s timeout and reports a load-state failure. This makes it report the truth instead.

Stacked on #2369 (base branch), which fixes the flaky test that surfaced this. Review that one first.

## Why it matters

This is not hypothetical. A CI failure where Chrome segfaulted mid-test produced this dump — note the navigation **succeeded**:

```
error            : waitForMainLoadState(domcontentloaded) timed out after 15000ms
mainSession before: 2B6F662B…   after: 2B6F662B…  (same=true)
page url         : data:text/html,…<h1 id="marker">newtab target</h1>
pages tracked    : 0
```

`DOMContentLoaded` arrived at +247ms and `networkIdle` at +254ms, on the original session — then the wait sat for 15 more seconds and blamed the page. The misleading message sent two engineers through four wrong diagnoses (external network latency, a CDP session swap, an NTP redirect race) before the actual cause — a Chrome `SIGSEGV` — surfaced.

The mechanism, in `page.ts`:

```ts
// isMainLoadStateReady
} catch {
  return false;   // "not ready yet" — indistinguishable from "connection is dead"
}
```

The lifecycle listeners fall silent and every poll's CDP send throws into that bare catch, so a dead browser looks exactly like a slow page.

## What changed

- **`CdpConnection.transportClosedReason`** — lets a waiter that subscribes *after* the socket has gone still discover it. No further close event will ever be emitted for it.
- **`waitForMainLoadState`** rejects immediately on transport close; refuses to start on an already-dead transport; re-checks after subscribing (the socket can die in the `await` between the pre-flight check and the subscription — this race is why my first attempt didn't engage); and re-checks in the readyState poll.
- **`send()` / `_sendViaSession()`** reject on a closed transport instead of parking a request in `inflight` that nothing will ever settle.

## Verification

| Scenario | Before | After |
|---|---|---|
| Socket killed mid-wait | 15000ms, "load state timed out" | **~405ms**, `CdpConnectionClosedError: socket-close code=1006` |
| Already-dead transport | hung indefinitely | **0ms**, rejects naming the attempted method |

Confirmed in CI too: the same failure that previously hung for 15-90s now reports `CdpConnectionClosedError` in 1.9-4.3s.

No regressions across the e2e suite. Includes a changeset.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail fast when the CDP websocket dies to avoid misleading load-state timeouts. Lifecycle waits now abort with `CdpConnectionClosedError` that includes the socket close reason.

- **Bug Fixes**
  - Exposed `CdpConnection.transportClosedReason` so late subscribers can detect a dead socket (including "closing/closed") and why.
  - Updated `waitForMainLoadState` to refuse starting on a dead transport, subscribe to socket-close, and re-check during setup and readyState polls to fail fast.

<sup>Written for commit 2a39718803e371daa8b0bc2edde98f5a1539a754. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

