### PR TITLE
fix: support Anthropic CUA through AI Gateway

### DIFF
--- a/.changeset/quiet-otters-browse.md
+++ b/.changeset/quiet-otters-browse.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Support Anthropic computer-use agents through Vercel AI Gateway.

--- a/packages/core/lib/v3/agent/AnthropicCUAClient.ts
+++ b/packages/core/lib/v3/agent/AnthropicCUAClient.ts
@@ -36,6 +36,18 @@ import { v7 as uuidv7 } from "uuid";
 
 export type ResponseInputItem = AnthropicMessage | AnthropicToolResult;
 
+const VERCEL_AI_GATEWAY_HOSTNAME = "ai-gateway.vercel.sh";
+
+function isVercelAiGatewayBaseUrl(baseURL?: string): boolean {
+  if (!baseURL) return false;
+
+  try {
+    return new URL(baseURL).hostname === VERCEL_AI_GATEWAY_HOSTNAME;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Client for Anthropic's Computer Use API
  * This implementation uses the official Anthropic Messages API for Computer Use
@@ -510,20 +522,32 @@ export class AnthropicCUAClient extends AgentClient {
         ? "computer-use-2025-11-24"
         : "computer-use-2025-01-24";
 
-      // Create the request parameters
-      const requestParams: Record<string, unknown> = {
-        model: this.modelName,
-        max_tokens: 4096,
-        messages: messages,
-        tools: [
-          {
+      // Vercel AI Gateway translates Anthropic Messages requests through its
+      // AI SDK adapter, whose computer-tool schema uses camelCase dimensions.
+      // Anthropic's native Messages endpoint expects the original snake_case
+      // fields, so preserve that shape for every other base URL.
+      const computerTool = isVercelAiGatewayBaseUrl(this.baseURL)
+        ? {
+            type: computerToolType,
+            name: "computer",
+            displayWidthPx: this.currentViewport.width,
+            displayHeightPx: this.currentViewport.height,
+            displayNumber: 1,
+          }
+        : {
             type: computerToolType,
             name: "computer",
             display_width_px: this.currentViewport.width,
             display_height_px: this.currentViewport.height,
             display_number: 1,
-          },
-        ],
+          };
+
+      // Create the request parameters
+      const requestParams: Record<string, unknown> = {
+        model: this.modelName,
+        max_tokens: 4096,
+        messages: messages,
+        tools: [computerTool],
         betas: [betaFlag],
       };
 

--- a/packages/core/tests/unit/anthropic-cua-adaptive-thinking.test.ts
+++ b/packages/core/tests/unit/anthropic-cua-adaptive-thinking.test.ts
@@ -426,4 +426,71 @@ describe("AnthropicCUAClient adaptive thinking", () => {
       expect(callArgs.thinking.type).toBe("adaptive");
     });
   });
+
+  describe("computer tool serialization", () => {
+    it("uses Anthropic's snake_case dimensions for the native endpoint", async () => {
+      const client = new AnthropicCUAClient(
+        "anthropic",
+        "claude-sonnet-4-6",
+        undefined,
+        { apiKey: "test-key" },
+      );
+      client.setViewport(1280, 720);
+
+      await client.getAction([{ role: "user", content: "test" }]);
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tools: [
+            expect.objectContaining({
+              type: "computer_20251124",
+              name: "computer",
+              display_width_px: 1280,
+              display_height_px: 720,
+              display_number: 1,
+            }),
+          ],
+        }),
+      );
+
+      const computerTool = mockCreate.mock.calls[0][0].tools[0];
+      expect(computerTool).not.toHaveProperty("displayWidthPx");
+      expect(computerTool).not.toHaveProperty("displayHeightPx");
+      expect(computerTool).not.toHaveProperty("displayNumber");
+    });
+
+    it("uses camelCase dimensions for Vercel AI Gateway", async () => {
+      const client = new AnthropicCUAClient(
+        "anthropic",
+        "claude-sonnet-4-6",
+        undefined,
+        {
+          apiKey: "test-key",
+          baseURL: "https://ai-gateway.vercel.sh/",
+        },
+      );
+      client.setViewport(1280, 720);
+
+      await client.getAction([{ role: "user", content: "test" }]);
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tools: [
+            expect.objectContaining({
+              type: "computer_20251124",
+              name: "computer",
+              displayWidthPx: 1280,
+              displayHeightPx: 720,
+              displayNumber: 1,
+            }),
+          ],
+        }),
+      );
+
+      const computerTool = mockCreate.mock.calls[0][0].tools[0];
+      expect(computerTool).not.toHaveProperty("display_width_px");
+      expect(computerTool).not.toHaveProperty("display_height_px");
+      expect(computerTool).not.toHaveProperty("display_number");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- serialize Anthropic computer-tool dimensions in the camelCase shape expected by Vercel AI Gateway
- preserve Anthropic's native snake_case request shape for direct provider calls
- cover both endpoint shapes with regression tests and publish the fix as a patch release

## Why

Vercel AI Gateway's Anthropic Messages adapter and Anthropic's native Messages endpoint validate the same computer tool with different field casing. Selecting the request shape from the configured base URL lets the same Anthropic CUA client work through either endpoint.

## E2E Test Matrix

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `pnpm exec turbo run build --filter=@browserbasehq/stagehand` | ESM and CJS builds completed successfully. | Proves the exact local package under review compiles into both published module formats. |
| `<local build>` with `anthropic/claude-sonnet-4-6` through `https://ai-gateway.vercel.sh` | Agent completed successfully, performed 2 browser actions, and navigated from `example.com` to `www.iana.org` with heading `Example Domains`. | Exercises the changed camelCase gateway request end-to-end with a real browser and model response. |
| `<local build>` with `anthropic/claude-sonnet-4-6` through Anthropic directly | Agent completed successfully, performed 2 browser actions, and reached the same `www.iana.org` page and heading. | Confirms the unchanged snake_case provider path still works end-to-end. |
| `pnpm --filter @browserbasehq/stagehand run test:core -- packages/core/dist/esm/tests/unit/anthropic-cua-adaptive-thinking.test.js` | 19 tests passed. | Covers both serialized computer-tool shapes plus the existing adaptive-thinking behavior. |
| `pnpm --filter @browserbasehq/stagehand lint` | Prettier, ESLint, and TypeScript checks passed. | Supporting static validation for formatting, lint rules, and types. |

## Tracking

[STG-2661](https://linear.app/browserbase/issue/STG-2661/support-anthropic-cua-through-model-gateway)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables Anthropic Computer Use Agents to work through Vercel AI Gateway by sending camelCase computer tool dimensions to the gateway and preserving snake_case for direct Anthropic. Adds tests for both paths and publishes a patch to `@browserbasehq/stagehand` (STG-2661).

- **Bug Fixes**
  - Detect `ai-gateway.vercel.sh` via `baseURL` and send `displayWidthPx`, `displayHeightPx`, `displayNumber`.
  - Keep native `display_width_px`, `display_height_px`, `display_number` for Anthropic endpoints.
  - Unit tests cover both shapes; no other API changes.

<sup>Written for commit 250ce646660b941210aacfb9ac0e8714500e3cb9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

