### PR TITLE
Set up Cloud dev environment + AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Stagehand is a pnpm + Turborepo monorepo (the AI browser-automation framework). Standard commands live in the root `package.json` scripts, `turbo.json`, and per-package `package.json` files; prefer those over duplicating here.
+
+### Services / packages
+
+- `packages/core` (`@browserbasehq/stagehand`) — the primary library/SDK.
+- `packages/server-v3` — Fastify REST API wrapping Stagehand. Dev: `pnpm --filter @browserbasehq/stagehand-server-v3 dev` (listens on `PORT`, default `3000`; health at `/healthz`, `/readyz`). Auth is currently disabled server-side, so requests need no auth token.
+- `packages/cli` (`browse`) — oclif CLI.
+- `packages/evals`, `packages/docs` — evals suite and Mintlify docs.
+- Note: `pnpm-workspace.yaml` references `packages/server-v4`, which does not exist on disk; the resulting pnpm warning is harmless.
+
+### Browser (local automation)
+
+- LOCAL mode launches the system Chrome via `chrome-launcher` (`google-chrome` is preinstalled); no Playwright browser download is needed.
+- In this container Chrome needs `--no-sandbox`. Pass it through `localBrowserLaunchOptions.args` (core) or `browser.launchOptions.args` (server API). Use `headless: true` for non-GUI runs (default is headed).
+
+### API keys (required for AI features + most tests)
+
+- No LLM keys are set by default. The AI methods (`act`/`extract`/`observe`/`agent`) and the test suites `test:core`, `test:e2e`, `test:evals`, and server `test:integration` require at least one provider key (e.g. `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`) set in the environment or `.env`.
+- Pure browser control works without a key: `page.goto`, `title()`, `screenshot()`, and the server `navigate` endpoint. A local session can start without a key (server treats the model API key as optional).
+- Browserbase-targeted variants (`test:*:bb`, `STAGEHAND_SERVER_TARGET=remote`) need `BROWSERBASE_API_KEY`.
+
+### Lint / test caveats
+
+- `pnpm lint` currently fails only on a pre-existing Prettier formatting issue in `packages/cli/src/lib/cloud/reduce-logs.ts` (unrelated to any change). The lint tooling itself works.
+- Key-free automated tests: `pnpm --filter browse run test:cli` (vitest) and `pnpm --filter @browserbasehq/stagehand-server-v3 run test:unit`. The server unit run passes all tests but the optional CTRF report step (`junit-to-ctrf`) errors on a `minimatch`/`glob` ESM mismatch — this is post-test reporting only and does not affect results.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the Stagehand monorepo (pnpm + Turborepo) so future Cloud Agents can install, lint, test, build, and run the products.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering the services, local-browser (`--no-sandbox`) caveat, required LLM keys, and lint/test gotchas.
- Update script set to `pnpm install` (also runs the repo's `prepare` build hook).

No application code was modified.

## Verified in this environment

| Step | Command | Result |
|---|---|---|
| Install | `pnpm install` | OK (prepare build ran) |
| Build | `pnpm build` | 6/6 tasks OK |
| Lint | `pnpm lint` | Tooling OK; 1 pre-existing Prettier warning in `packages/cli/src/lib/cloud/reduce-logs.ts` |
| Tests (CLI) | `pnpm --filter browse run test:cli` | 357 passed |
| Tests (server unit) | `pnpm --filter @browserbasehq/stagehand-server-v3 run test:unit` | 64 passed |
| Run API | `pnpm --filter @browserbasehq/stagehand-server-v3 dev` | `/healthz` 200; start → navigate → end all `success:true` |
| Run core | Stagehand LOCAL browser: goto + title + screenshot | title `Example Domain`, screenshot captured |

Hello-world screenshot captured by Stagehand's own core library:

[Stagehand core hello world screenshot of example.com](https://cursor.com/agents/bc-2ca186b4-e93b-4c26-bd64-2477c0252744/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstagehand_core_hello_world.png)

## Note

AI methods (`act`/`extract`/`observe`/`agent`) and the `test:core`/`test:e2e`/`test:evals`/server integration suites require an LLM provider API key, which is not set in this environment.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ca186b4-e93b-4c26-bd64-2477c0252744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ca186b4-e93b-4c26-bd64-2477c0252744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `AGENTS.md` with Cursor Cloud dev setup for the Stagehand `pnpm` + `Turborepo` monorepo so you can install, build, lint, test, and run locally. Covers local Chrome `--no-sandbox`/headless flags, required model keys and which tests work without keys, plus basic core/server/CLI commands; docs only, no application code changes.

<sup>Written for commit 0d4c485599c4cf53815336e21ab54351c19c30ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

