### PR TITLE
evals: adaptive tool-surface harness (LLMExposure) + v4 code mode

### DIFF
--- a/packages/evals/core/contracts/tool.ts
+++ b/packages/evals/core/contracts/tool.ts
@@ -18,6 +18,7 @@ import type {
 
 export type ToolSurface =
   | "understudy_code"
+  | "v4_code"
   | "playwright_code"
   | "cdp_code"
   | "playwright_mcp"
@@ -167,6 +168,7 @@ export interface CoreTool {
   surface: "code" | "mcp" | "cli";
   family:
     | "understudy"
+    | "stagehand_v4"
     | "playwright"
     | "cdp"
     | "stagehand_cli"
@@ -175,4 +177,81 @@ export interface CoreTool {
   supportedCapabilities: CoreCapability[];
   supportedTargetKinds: TargetKind[];
   start(input: ToolStartInput): Promise<ToolStartResult>;
+}
+
+/**
+ * The MCP server / tool name a `code_handles` exposure is mounted under by an
+ * agent harness. Surfaces reference the tool name in their prompt
+ * instructions; the harness mounts the single "run" tool under the server.
+ */
+export const LLM_RUN_TOOL_SERVER = "stagehand_browser";
+export const LLM_RUN_TOOL_NAME = `mcp__${LLM_RUN_TOOL_SERVER}__run`;
+
+/**
+ * `code_handles` only: the surface-specific pieces of the harness's single
+ * "run" tool. The harness owns the tool mechanics (timeouts, result
+ * stringification, logging); the surface owns the copy the model sees and
+ * the values bound into the snippet scope.
+ */
+export interface LLMRunToolSpec {
+  /** MCP tool description shown to the model. */
+  description: string;
+  /** Description of the tool's `code` parameter. */
+  codeParamDescription: string;
+  /** Denial message when the model requests a tool outside the allowlist. */
+  denyMessage: string;
+  /** Value bound to `task` in the snippet scope. */
+  task: Record<string, unknown>;
+  /**
+   * Value bound to `console` in the snippet scope. Defaults to the
+   * harness's logger-backed console when omitted.
+   */
+  console?: Pick<Console, "log" | "warn" | "error">;
+}
+
+/**
+ * Harness-observed terminal state of a run, captured through the surface
+ * itself after the agent finishes. This is what grounds grading in the task
+ * artifact: the verifier's final-screenshot anchor comes from the harness's
+ * own observation of the page, not from whatever image the agent chose to
+ * return (code surfaces stringify tool results, so agent-returned images
+ * don't exist there at all).
+ */
+export interface TerminalArtifact {
+  screenshot?: Buffer;
+  url?: string;
+}
+
+/**
+ * A harness-agnostic description of how an agent harness (claude_code,
+ * codex, ...) mounts a tool surface. Each surface implements this once;
+ * harness drivers keep exactly three mount points and no surface knowledge:
+ * - `code_handles` -> wrap `handles` in the harness's single run tool
+ * - `mcp_server`   -> mount `mcpServers` config directly
+ * - `cli`          -> spawn `command` with env
+ */
+export interface LLMExposure {
+  kind: "code_handles" | "mcp_server" | "cli";
+  /**
+   * code_handles: named values placed in the run-tool snippet scope. The
+   * harness derives the snippet argument names from these keys (plus
+   * startUrl, task, and console). Names, not order, bind the values.
+   */
+  handles?: Record<string, unknown>;
+  promptInstructions: string;
+  /** mcp_server: mounted as-is by the harness. */
+  mcpServers?: Record<string, unknown>;
+  /** cli: spawned with env by the harness. */
+  command?: { bin: string; env: Record<string, string> };
+  /** code_handles: surface-specific run-tool copy and snippet bindings. */
+  runTool?: LLMRunToolSpec;
+  /** Extra surface facts (session URLs etc.) that flow through to the harness. */
+  metadata?: Record<string, unknown>;
+  /**
+   * Capture the terminal page state (screenshot + URL) for artifact-grounded
+   * grading. Called by the harness after the agent finishes, before cleanup.
+   * Best-effort: implementations should swallow per-field failures.
+   */
+  captureFinalState?: () => Promise<TerminalArtifact>;
+  cleanup: () => Promise<void>;
 }

--- a/packages/evals/core/tools/cdp_code.ts
+++ b/packages/evals/core/tools/cdp_code.ts
@@ -1,12 +1,18 @@
-import type {
-  CoreCapability,
-  CoreLocatorHandle,
-  CorePageHandle,
-  CoreSession,
-  CoreTool,
-  StartupProfile,
-  ToolStartInput,
-  ToolStartResult,
+import { EvalsError } from "../../errors.js";
+import type { EvalLogger } from "../../logger.js";
+import type { ExternalHarnessTaskPlan } from "../../framework/externalHarnessPlan.js";
+import { prepareCoreBrowserTarget } from "../targets/index.js";
+import {
+  LLM_RUN_TOOL_NAME,
+  type LLMExposure,
+  type CoreCapability,
+  type CoreLocatorHandle,
+  type CorePageHandle,
+  type CoreSession,
+  type CoreTool,
+  type StartupProfile,
+  type ToolStartInput,
+  type ToolStartResult,
 } from "../contracts/tool.js";
 import type { Artifact, ConnectionMode } from "../contracts/results.js";
 import type {
@@ -1248,4 +1254,415 @@ export class CdpCodeTool implements CoreTool {
       },
     };
   }
+}
+
+type ActiveCdpPage = {
+  targetId: string;
+  sessionId: string;
+  url: string;
+};
+
+type CdpRuntime = {
+  readonly targetId: string;
+  readonly sessionId: string;
+  send<T = unknown>(
+    method: string,
+    params?: Record<string, unknown>,
+  ): Promise<T>;
+  browser<T = unknown>(
+    method: string,
+    params?: Record<string, unknown>,
+  ): Promise<T>;
+  on(
+    method: string,
+    listener: (event: CdpEventMessage) => unknown | Promise<unknown>,
+  ): () => void;
+  off(
+    method: string,
+    listener: (event: CdpEventMessage) => unknown | Promise<unknown>,
+  ): void;
+  once(
+    method: string,
+    listenerOrTimeout?:
+      | ((event: CdpEventMessage) => unknown | Promise<unknown>)
+      | number,
+    timeoutMs?: number,
+  ): Promise<CdpEventMessage> | (() => void);
+  waitForEvent(method: string, timeoutMs?: number): Promise<CdpEventMessage>;
+  wait(ms: number): Promise<void>;
+};
+
+/**
+ * cdp_code agent exposure: the agent writes code against a raw CDP runtime
+ * (page-scoped send, browser-level send, and event helpers) attached to a
+ * runner-provided CDP endpoint.
+ */
+export async function prepareLLMExposure(
+  plan: ExternalHarnessTaskPlan,
+  env: "LOCAL" | "BROWSERBASE",
+  logger: EvalLogger,
+  startupProfile?: StartupProfile,
+): Promise<LLMExposure> {
+  const resolvedProfile =
+    startupProfile ??
+    (env === "BROWSERBASE"
+      ? "runner_provided_browserbase_cdp"
+      : "runner_provided_local_cdp");
+  if (
+    resolvedProfile !== "runner_provided_local_cdp" &&
+    resolvedProfile !== "runner_provided_browserbase_cdp"
+  ) {
+    throw new EvalsError(
+      `cdp_code startup profile "${resolvedProfile}" is not valid for Claude Code. Use runner_provided_local_cdp or runner_provided_browserbase_cdp.`,
+    );
+  }
+
+  let connection: CdpConnection | undefined;
+  let targetCleanup: () => Promise<void> = async () => {};
+
+  try {
+    const target = await prepareCoreBrowserTarget({
+      environment: env,
+      toolSurface: "cdp_code",
+      startupProfile: resolvedProfile,
+    });
+    targetCleanup = target.cleanup;
+    if (!target.providedEndpoint?.url) {
+      throw new EvalsError(
+        `cdp_code requires a runner-provided CDP endpoint for startup profile "${resolvedProfile}".`,
+      );
+    }
+
+    const openConnection = await CdpConnection.connect(target.providedEndpoint);
+    connection = openConnection;
+    const activePage = await attachActiveCdpPage(openConnection);
+
+    logger.log({
+      category: "claude_code",
+      message: `Initialized cdp_code browser runtime for Claude Code run tool.`,
+      level: 1,
+      auxiliary: {
+        startupProfile: {
+          value: resolvedProfile,
+          type: "string",
+        },
+        environment: {
+          value: env,
+          type: "string",
+        },
+        targetId: {
+          value: activePage.targetId,
+          type: "string",
+        },
+        sessionId: {
+          value: activePage.sessionId,
+          type: "string",
+        },
+        ...(target.metadata && {
+          targetMetadata: {
+            value: JSON.stringify(target.metadata),
+            type: "object",
+          },
+        }),
+      },
+    });
+
+    return {
+      kind: "code_handles",
+      handles: { cdp: buildCdpRuntime(openConnection, activePage, logger) },
+      promptInstructions: buildCdpCodePromptInstructions(),
+      runTool: {
+        description: [
+          "Execute JavaScript against the initialized Chrome DevTools Protocol browser.",
+          "The snippet runs inside an async function with cdp, startUrl, task, and console in scope.",
+          "Use await directly. Return a JSON-serializable value when useful.",
+        ].join(" "),
+        codeParamDescription:
+          "JavaScript function body to execute. cdp/startUrl/task are already in scope.",
+        denyMessage: `Use Bash for inspection and ${LLM_RUN_TOOL_NAME} for CDP browser automation.`,
+        task: {
+          dataset: plan.dataset,
+          id: plan.taskId,
+          startUrl: plan.startUrl,
+          instruction: plan.instruction,
+        },
+      },
+      ...(target.metadata && { metadata: target.metadata }),
+      captureFinalState: async () => {
+        const artifact: { screenshot?: Buffer; url?: string } = {};
+        try {
+          const shot = await openConnection.send<{ data: string }>(
+            "Page.captureScreenshot",
+            {},
+            activePage.sessionId,
+          );
+          artifact.screenshot = Buffer.from(shot.data, "base64");
+        } catch {
+          // best-effort only
+        }
+        try {
+          const evaluated = await openConnection.send<{
+            result?: { value?: unknown };
+          }>(
+            "Runtime.evaluate",
+            { expression: "location.href", returnByValue: true },
+            activePage.sessionId,
+          );
+          const value = evaluated.result?.value;
+          if (typeof value === "string") artifact.url = value;
+        } catch {
+          // best-effort only
+        }
+        return artifact;
+      },
+      cleanup: async () => {
+        try {
+          await openConnection.close();
+        } catch {
+          // best-effort only
+        } finally {
+          await targetCleanup();
+        }
+      },
+    };
+  } catch (error) {
+    try {
+      await connection?.close();
+    } catch {
+      // best-effort only
+    }
+    await targetCleanup();
+    throw error;
+  }
+}
+
+function buildCdpCodePromptInstructions(): string {
+  return [
+    "Browser tool surface: cdp_code.",
+    `Use the ${LLM_RUN_TOOL_NAME} tool for browser automation. It exposes an initialized cdp object, startUrl, and task object.`,
+    "Use cdp.send(method, params) for page-scoped CDP commands and cdp.browser(method, params) for browser-level commands.",
+    "Helpers available: cdp.on(method, listener), cdp.once(method), cdp.waitForEvent(method, timeoutMs), cdp.wait(ms), cdp.targetId, cdp.sessionId.",
+    'The first browser action should usually be: const loaded = cdp.waitForEvent("Page.loadEventFired"); await cdp.send("Page.navigate", { url: startUrl }); await loaded.',
+    "Use Bash for inspection and lightweight scripting. Do not create a separate browser process.",
+    "Do not edit repository files.",
+    "Return useful JSON-serializable values from run snippets so you can inspect progress.",
+  ].join("\n");
+}
+
+function buildCdpRuntime(
+  connection: CdpConnection,
+  activePage: ActiveCdpPage,
+  logger: EvalLogger,
+): CdpRuntime {
+  const listenerUnsubscribes = new Map<
+    (event: CdpEventMessage) => unknown | Promise<unknown>,
+    () => void
+  >();
+  return {
+    targetId: activePage.targetId,
+    sessionId: activePage.sessionId,
+    send: <T = unknown>(
+      method: string,
+      params?: Record<string, unknown>,
+    ): Promise<T> => connection.send<T>(method, params, activePage.sessionId),
+    browser: <T = unknown>(
+      method: string,
+      params?: Record<string, unknown>,
+    ): Promise<T> => connection.send<T>(method, params),
+    on: (
+      method: string,
+      listener: (event: CdpEventMessage) => unknown | Promise<unknown>,
+    ): (() => void) => {
+      const unsubscribe = onCdpEvent(
+        connection,
+        activePage.sessionId,
+        method,
+        listener,
+        logger,
+      );
+      listenerUnsubscribes.set(listener, unsubscribe);
+      return () => {
+        listenerUnsubscribes.delete(listener);
+        unsubscribe();
+      };
+    },
+    off: (
+      _method: string,
+      listener: (event: CdpEventMessage) => unknown | Promise<unknown>,
+    ): void => {
+      const unsubscribe = listenerUnsubscribes.get(listener);
+      listenerUnsubscribes.delete(listener);
+      unsubscribe?.();
+    },
+    once: (
+      method: string,
+      listenerOrTimeout?:
+        | ((event: CdpEventMessage) => unknown | Promise<unknown>)
+        | number,
+      timeoutMs = 15_000,
+    ): Promise<CdpEventMessage> | (() => void) => {
+      if (typeof listenerOrTimeout === "function") {
+        const listener = listenerOrTimeout;
+        const unsubscribe = onCdpEvent(
+          connection,
+          activePage.sessionId,
+          method,
+          (event) => {
+            unsubscribe?.();
+            listenerUnsubscribes.delete(listener);
+            return listener(event);
+          },
+          logger,
+        );
+        listenerUnsubscribes.set(listener, unsubscribe);
+        return () => {
+          listenerUnsubscribes.delete(listener);
+          unsubscribe?.();
+        };
+      }
+      return waitForCdpEvent(
+        connection,
+        activePage.sessionId,
+        method,
+        listenerOrTimeout ?? timeoutMs,
+      );
+    },
+    waitForEvent: (
+      method: string,
+      timeoutMs = 15_000,
+    ): Promise<CdpEventMessage> =>
+      waitForCdpEvent(connection, activePage.sessionId, method, timeoutMs),
+    wait: sleep,
+  };
+}
+
+function onCdpEvent(
+  connection: CdpConnection,
+  sessionId: string,
+  method: string,
+  listener: (event: CdpEventMessage) => unknown | Promise<unknown>,
+  logger: EvalLogger,
+): () => void {
+  return connection.onEvent((event) => {
+    if (
+      event.method !== method ||
+      (event.sessionId && event.sessionId !== sessionId)
+    ) {
+      return;
+    }
+    try {
+      const result = listener(event);
+      if (isPromiseLike(result)) {
+        result.catch((error: unknown) => {
+          logger.warn({
+            category: "claude_code",
+            message: `cdp event listener failed: ${error instanceof Error ? error.message : String(error)}`,
+            level: 1,
+          });
+        });
+      }
+    } catch (error) {
+      logger.warn({
+        category: "claude_code",
+        message: `cdp event listener failed: ${error instanceof Error ? error.message : String(error)}`,
+        level: 1,
+      });
+    }
+  });
+}
+
+async function attachActiveCdpPage(
+  connection: CdpConnection,
+): Promise<ActiveCdpPage> {
+  const targets = await connection.send<{
+    targetInfos: Array<{
+      targetId: string;
+      type: string;
+      url?: string;
+    }>;
+  }>("Target.getTargets");
+
+  const existingPage = targets.targetInfos.find(
+    (target) =>
+      target.type === "page" && !target.url?.startsWith("devtools://"),
+  );
+  const targetId =
+    existingPage?.targetId ??
+    (
+      await connection.send<{ targetId: string }>("Target.createTarget", {
+        url: "about:blank",
+      })
+    ).targetId;
+  const attached = await connection.send<{ sessionId: string }>(
+    "Target.attachToTarget",
+    {
+      targetId,
+      flatten: true,
+    },
+  );
+
+  await connection.send("Page.enable", {}, attached.sessionId);
+  await connection.send("Runtime.enable", {}, attached.sessionId);
+  await connection.send("DOM.enable", {}, attached.sessionId);
+  await connection.send(
+    "Page.setLifecycleEventsEnabled",
+    { enabled: true },
+    attached.sessionId,
+  );
+
+  return {
+    targetId,
+    sessionId: attached.sessionId,
+    url: existingPage?.url ?? "about:blank",
+  };
+}
+
+export function waitForCdpEvent(
+  connection: CdpConnection,
+  sessionId: string,
+  method: string,
+  timeoutMs: number,
+): Promise<CdpEventMessage> {
+  let timeout: NodeJS.Timeout | undefined;
+  let unsubscribe: (() => void) | undefined;
+  const promise = new Promise<CdpEventMessage>((resolve, reject) => {
+    const cleanup = () => {
+      if (timeout) clearTimeout(timeout);
+      unsubscribe?.();
+    };
+    unsubscribe = connection.onEvent((event) => {
+      if (
+        event.method !== method ||
+        (event.sessionId && event.sessionId !== sessionId)
+      ) {
+        return;
+      }
+      cleanup();
+      resolve(event);
+    });
+    timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out waiting for CDP event "${method}"`));
+    }, timeoutMs);
+  });
+
+  // Claude-generated snippets often assign an event wait promise before a CDP
+  // action and may abandon it after another branch finishes. Keep the promise
+  // rejectable for awaited callers, but prevent abandoned waits from crashing
+  // the eval process as unhandled rejections.
+  promise.catch((): undefined => undefined);
+  return promise;
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> & {
+  catch: (handler: (error: unknown) => void) => unknown;
+} {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "then" in value &&
+    typeof (value as { then?: unknown }).then === "function" &&
+    "catch" in value &&
+    typeof (value as { catch?: unknown }).catch === "function"
+  );
 }

--- a/packages/evals/core/tools/playwright_code.ts
+++ b/packages/evals/core/tools/playwright_code.ts
@@ -5,16 +5,22 @@ import {
   type Locator,
   type Page,
 } from "playwright";
+import { EvalsError } from "../../errors.js";
+import type { EvalLogger } from "../../logger.js";
+import type { ExternalHarnessTaskPlan } from "../../framework/externalHarnessPlan.js";
+import { prepareCoreBrowserTarget } from "../targets/index.js";
 import { resolveLocalChromeExecutablePath } from "../targets/localChrome.js";
-import type {
-  CoreCapability,
-  CoreLocatorHandle,
-  CorePageHandle,
-  CoreSession,
-  CoreTool,
-  StartupProfile,
-  ToolStartInput,
-  ToolStartResult,
+import {
+  LLM_RUN_TOOL_NAME,
+  type LLMExposure,
+  type CoreCapability,
+  type CoreLocatorHandle,
+  type CorePageHandle,
+  type CoreSession,
+  type CoreTool,
+  type StartupProfile,
+  type ToolStartInput,
+  type ToolStartResult,
 } from "../contracts/tool.js";
 import type { PageRepresentation } from "../contracts/representation.js";
 import type { Artifact, ConnectionMode } from "../contracts/results.js";
@@ -643,4 +649,143 @@ export class PlaywrightCodeTool implements CoreTool {
       },
     };
   }
+}
+
+/**
+ * playwright_code agent exposure: the agent writes code against an
+ * initialized Playwright page/context/browser connected over a
+ * runner-provided CDP endpoint.
+ */
+export async function prepareLLMExposure(
+  plan: ExternalHarnessTaskPlan,
+  env: "LOCAL" | "BROWSERBASE",
+  logger: EvalLogger,
+  startupProfile?: StartupProfile,
+): Promise<LLMExposure> {
+  const resolvedProfile =
+    startupProfile ??
+    (env === "BROWSERBASE"
+      ? "runner_provided_browserbase_cdp"
+      : "runner_provided_local_cdp");
+  if (
+    resolvedProfile !== "runner_provided_local_cdp" &&
+    resolvedProfile !== "runner_provided_browserbase_cdp"
+  ) {
+    throw new EvalsError(
+      `playwright_code startup profile "${resolvedProfile}" is not valid for Claude Code. Use runner_provided_local_cdp or runner_provided_browserbase_cdp.`,
+    );
+  }
+
+  let browser: Browser | undefined;
+  let targetCleanup: () => Promise<void> = async () => {};
+
+  try {
+    const target = await prepareCoreBrowserTarget({
+      environment: env,
+      toolSurface: "playwright_code",
+      startupProfile: resolvedProfile,
+    });
+    targetCleanup = target.cleanup;
+    if (!target.providedEndpoint?.url) {
+      throw new EvalsError(
+        `playwright_code requires a runner-provided CDP endpoint for startup profile "${resolvedProfile}".`,
+      );
+    }
+
+    const connectedBrowser = await chromium.connectOverCDP(
+      target.providedEndpoint.url,
+      { headers: target.providedEndpoint.headers },
+    );
+    browser = connectedBrowser;
+    const context =
+      connectedBrowser.contexts()[0] ?? (await connectedBrowser.newContext());
+    const page = context.pages()[0] ?? (await context.newPage());
+
+    logger.log({
+      category: "claude_code",
+      message: `Initialized playwright_code browser runtime for Claude Code run tool.`,
+      level: 1,
+      auxiliary: {
+        startupProfile: {
+          value: resolvedProfile,
+          type: "string",
+        },
+        environment: {
+          value: env,
+          type: "string",
+        },
+        ...(target.metadata && {
+          targetMetadata: {
+            value: JSON.stringify(target.metadata),
+            type: "object",
+          },
+        }),
+      },
+    });
+
+    return {
+      kind: "code_handles",
+      handles: { page, context, browser: connectedBrowser },
+      promptInstructions: buildPlaywrightCodePromptInstructions(),
+      runTool: {
+        description: [
+          "Execute JavaScript against the initialized Playwright browser.",
+          "The snippet runs inside an async function with page, context, browser, startUrl, task, and console in scope.",
+          "Use await directly. Return a JSON-serializable value when useful.",
+        ].join(" "),
+        codeParamDescription:
+          "JavaScript function body to execute. page/context/browser/startUrl/task are already in scope.",
+        denyMessage: `Use Bash for inspection and ${LLM_RUN_TOOL_NAME} for browser automation.`,
+        task: {
+          dataset: plan.dataset,
+          id: plan.taskId,
+          startUrl: plan.startUrl,
+          instruction: plan.instruction,
+        },
+      },
+      ...(target.metadata && { metadata: target.metadata }),
+      captureFinalState: async () => {
+        const artifact: { screenshot?: Buffer; url?: string } = {};
+        try {
+          artifact.screenshot = await page.screenshot();
+        } catch {
+          // best-effort only
+        }
+        try {
+          artifact.url = page.url();
+        } catch {
+          // best-effort only
+        }
+        return artifact;
+      },
+      cleanup: async () => {
+        try {
+          await connectedBrowser.close();
+        } catch {
+          // best-effort only
+        } finally {
+          await targetCleanup();
+        }
+      },
+    };
+  } catch (error) {
+    try {
+      await browser?.close();
+    } catch {
+      // best-effort only
+    }
+    await targetCleanup();
+    throw error;
+  }
+}
+
+function buildPlaywrightCodePromptInstructions(): string {
+  return [
+    "Browser tool surface: playwright_code.",
+    `Use the ${LLM_RUN_TOOL_NAME} tool for browser automation. It exposes an initialized Playwright page, context, browser, startUrl, and task object.`,
+    "Use Bash for inspection and lightweight scripting. Do not create a separate browser process.",
+    "The first browser action should usually be: await page.goto(startUrl, { waitUntil: 'domcontentloaded' }).",
+    "Do not edit repository files.",
+    "Return useful JSON-serializable values from run snippets so you can inspect progress.",
+  ].join("\n");
 }

--- a/packages/evals/core/tools/registry.ts
+++ b/packages/evals/core/tools/registry.ts
@@ -5,10 +5,12 @@ import { ChromeDevtoolsMcpTool } from "./chrome_devtools_mcp.js";
 import { PlaywrightCodeTool } from "./playwright_code.js";
 import { PlaywrightMcpTool } from "./playwright_mcp.js";
 import { UnderstudyCodeTool } from "./understudy_code.js";
+import { V4CodeTool } from "./v4_code.js";
 
 export function listCoreTools(): ToolSurface[] {
   return [
     "understudy_code",
+    "v4_code",
     "playwright_code",
     "cdp_code",
     "playwright_mcp",
@@ -21,6 +23,8 @@ export function getCoreTool(toolSurface: ToolSurface): CoreTool {
   switch (toolSurface) {
     case "understudy_code":
       return new UnderstudyCodeTool();
+    case "v4_code":
+      return new V4CodeTool();
     case "playwright_code":
       return new PlaywrightCodeTool();
     case "cdp_code":

--- a/packages/evals/core/tools/v4_code.ts
+++ b/packages/evals/core/tools/v4_code.ts
@@ -1,0 +1,546 @@
+/**
+ * v4_code — the "v4 code mode" tool surface.
+ *
+ * The v4 analogue of understudy_code: a CoreTool whose session is backed by
+ * the Stagehand v4 SDK (initV4), so harnesses can drive the browser by
+ * writing code against v4's Page/Locator/Stagehand surface.
+ *
+ * Capability map vs the contract (all gaps are v4 SDK realities, not
+ * omissions here):
+ * - coords targets: UNSUPPORTED — v4 is DOM-only; no click(x, y) primitive.
+ * - viewport: UNSUPPORTED — no viewport API on the v4 Page.
+ * - url(): the contract is sync but every v4 accessor is an async RPC
+ *   (V4_API_LOGS #9). We track the last URL observed by this handle
+ *   (updated on nav calls and waits); it can lag in-page navigations.
+ * - scroll: page-level wheel scrolling is emulated via evaluate()
+ *   (window.scrollBy) in the main frame.
+ * - type/press on "focused": routed through page.keyPress.
+ */
+import { z } from "zod/v4";
+import type {
+  Page as V4Page,
+  Locator as V4Locator,
+  Stagehand as V4Stagehand,
+} from "@browserbasehq/stagehand-v4-spike-sdk-ts";
+import { EvalsError } from "../../errors.js";
+import { initV4, type V4InitResult } from "../../initV4.js";
+import type { EvalLogger } from "../../logger.js";
+import type { ExternalHarnessTaskPlan } from "../../framework/externalHarnessPlan.js";
+import type {
+  ActionTarget,
+  FocusedTarget,
+  TargetKind,
+  WaitSpec,
+} from "../contracts/targets.js";
+import {
+  LLM_RUN_TOOL_NAME,
+  type LLMExposure,
+  type CoreCapability,
+  type CoreLocatorHandle,
+  type CorePageHandle,
+  type CoreSession,
+  type CoreTool,
+  type NavOpts,
+  type ScreenshotOpts,
+  type StartupProfile,
+  type ToolStartInput,
+  type ToolStartResult,
+} from "../contracts/tool.js";
+import type { Artifact } from "../contracts/results.js";
+
+const SUPPORTED_CAPABILITIES: CoreCapability[] = [
+  "session",
+  "navigation",
+  "evaluation",
+  "screenshot",
+  "wait",
+  "click",
+  "hover",
+  "scroll",
+  "type",
+  "press",
+  "tabs",
+];
+
+/** The tool's internal SDK model (parity with understudy_code's fixed
+ * model); the benchmark's model drives the harness, not this surface. */
+const SURFACE_MODEL = "openai/gpt-4.1-mini";
+
+class V4LocatorHandle implements CoreLocatorHandle {
+  constructor(private readonly locator: V4Locator) {}
+
+  count(): Promise<number> {
+    return this.locator.count();
+  }
+  click(): Promise<void> {
+    return this.locator.click();
+  }
+  hover(): Promise<void> {
+    return this.locator.hover();
+  }
+  fill(value: string): Promise<void> {
+    return this.locator.fill(value);
+  }
+  async type(text: string, opts?: { delay?: number }): Promise<void> {
+    await this.locator.type(
+      text,
+      opts?.delay ? { delay: opts.delay } : undefined,
+    );
+  }
+  isVisible(): Promise<boolean> {
+    return this.locator.isVisible();
+  }
+  textContent(): Promise<string | null> {
+    return this.locator.textContent();
+  }
+  inputValue(): Promise<string> {
+    return this.locator.inputValue();
+  }
+}
+
+function targetSelector(target: string | ActionTarget): string {
+  if (typeof target === "string") return target;
+  if (target.kind === "selector") return target.value;
+  throw new Error(
+    `v4_code supports selector targets only (v4 is DOM-only); got kind "${target.kind}"`,
+  );
+}
+
+class V4PageHandle implements CorePageHandle {
+  readonly id: string;
+  private lastUrl = "about:blank";
+
+  constructor(
+    private readonly page: V4Page,
+    id: string,
+  ) {
+    this.id = id;
+  }
+
+  private async refreshUrl(): Promise<void> {
+    this.lastUrl = await this.page.url();
+  }
+
+  async goto(url: string, opts?: NavOpts): Promise<void> {
+    await this.page.goto(url, {
+      ...(opts?.waitUntil ? { waitUntil: opts.waitUntil } : {}),
+      ...(opts?.timeoutMs ? { timeout: opts.timeoutMs } : {}),
+    });
+    await this.refreshUrl();
+  }
+  async reload(opts?: NavOpts): Promise<void> {
+    await this.page.reload(
+      opts?.waitUntil ? { waitUntil: opts.waitUntil } : undefined,
+    );
+    await this.refreshUrl();
+  }
+  async back(opts?: NavOpts): Promise<boolean> {
+    return this.goBack(opts);
+  }
+  async forward(opts?: NavOpts): Promise<boolean> {
+    return this.goForward(opts);
+  }
+  async goBack(opts?: NavOpts): Promise<boolean> {
+    await this.page.goBack(
+      opts?.waitUntil ? { waitUntil: opts.waitUntil } : undefined,
+    );
+    const before = this.lastUrl;
+    await this.refreshUrl();
+    return this.lastUrl !== before;
+  }
+  async goForward(opts?: NavOpts): Promise<boolean> {
+    await this.page.goForward(
+      opts?.waitUntil ? { waitUntil: opts.waitUntil } : undefined,
+    );
+    const before = this.lastUrl;
+    await this.refreshUrl();
+    return this.lastUrl !== before;
+  }
+
+  url(): string {
+    // Contract is sync; v4's accessor is an async RPC (V4_API_LOGS #9).
+    // Best-effort last-observed value, refreshed by nav calls and wait().
+    return this.lastUrl;
+  }
+  title(): Promise<string> {
+    return this.page.title();
+  }
+  evaluate<R = unknown, Arg = unknown>(
+    pageFunctionOrExpression: string | ((arg: Arg) => R | Promise<R>),
+    arg?: Arg,
+  ): Promise<R> {
+    return this.page.evaluate(pageFunctionOrExpression, arg);
+  }
+  screenshot(opts?: ScreenshotOpts): Promise<Buffer> {
+    return this.page.screenshot(opts);
+  }
+
+  setViewport(): Promise<void> {
+    throw new Error("v4_code: the v4 SDK exposes no viewport API");
+  }
+  setViewportSize(): Promise<void> {
+    throw new Error("v4_code: the v4 SDK exposes no viewport API");
+  }
+
+  async wait(spec: WaitSpec): Promise<void> {
+    if (spec.kind === "timeout") {
+      await this.waitForTimeout(spec.timeoutMs);
+      return;
+    }
+    if (spec.kind === "selector") {
+      await this.waitForSelector(spec.selector, {
+        timeout: spec.timeoutMs,
+        state: spec.state,
+      });
+      return;
+    }
+    // load_state
+    await this.page.waitForLoadState(spec.state ?? "load", spec.timeoutMs);
+    await this.refreshUrl();
+  }
+
+  async waitForSelector(
+    selector: string,
+    opts?: {
+      timeout?: number;
+      state?: "attached" | "detached" | "visible" | "hidden";
+    },
+  ): Promise<boolean> {
+    // No waitForSelector primitive in v4 — poll the locator.
+    const state = opts?.state ?? "visible";
+    const deadline = Date.now() + (opts?.timeout ?? 30_000);
+    const locator = this.page.locator(selector);
+    for (;;) {
+      const [count, visible] = await Promise.all([
+        locator.count(),
+        locator.isVisible().catch(() => false),
+      ]);
+      const satisfied =
+        state === "attached"
+          ? count > 0
+          : state === "detached"
+            ? count === 0
+            : state === "visible"
+              ? visible
+              : !visible;
+      if (satisfied) return true;
+      if (Date.now() >= deadline) return false;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+  }
+  waitForTimeout(ms: number): Promise<void> {
+    return new Promise((r) => setTimeout(r, ms));
+  }
+
+  locator(selector: string): CoreLocatorHandle {
+    return new V4LocatorHandle(this.page.locator(selector));
+  }
+
+  async click(
+    targetOrX: string | ActionTarget | number,
+    maybeY?: number,
+  ): Promise<void> {
+    if (typeof targetOrX === "number" || typeof maybeY === "number") {
+      throw new Error(
+        "v4_code: coordinate clicks are unsupported (v4 is DOM-only)",
+      );
+    }
+    await this.page.locator(targetSelector(targetOrX)).click();
+  }
+
+  async hover(
+    targetOrX: string | ActionTarget | number,
+    maybeY?: number,
+  ): Promise<void> {
+    if (typeof targetOrX === "number" || typeof maybeY === "number") {
+      throw new Error(
+        "v4_code: coordinate hover is unsupported (v4 is DOM-only)",
+      );
+    }
+    await this.page.locator(targetSelector(targetOrX)).hover();
+  }
+
+  async scroll(
+    _x: number,
+    _y: number,
+    deltaX: number,
+    deltaY: number,
+  ): Promise<void> {
+    // No wheel primitive in v4 — emulate in the main frame.
+    await this.page.evaluate(
+      ({ dx, dy }: { dx: number; dy: number }) => window.scrollBy(dx, dy),
+      { dx: deltaX, dy: deltaY },
+    );
+  }
+
+  async type(
+    targetOrText: string | ActionTarget | FocusedTarget,
+    maybeText?: string,
+  ): Promise<void> {
+    if (maybeText === undefined) {
+      // type(text) — focused element; route through keyPress per character.
+      const text = targetOrText as string;
+      for (const char of text) {
+        await this.page.keyPress(char);
+      }
+      return;
+    }
+    const target = targetOrText as string | ActionTarget | FocusedTarget;
+    if (typeof target !== "string" && target.kind === "focused") {
+      for (const char of maybeText) {
+        await this.page.keyPress(char);
+      }
+      return;
+    }
+    await this.page
+      .locator(targetSelector(target as string | ActionTarget))
+      .type(maybeText);
+  }
+
+  async press(
+    targetOrKey: string | ActionTarget | FocusedTarget,
+    maybeKey?: string,
+  ): Promise<void> {
+    if (maybeKey === undefined) {
+      await this.page.keyPress(targetOrKey as string);
+      return;
+    }
+    const target = targetOrKey as string | ActionTarget | FocusedTarget;
+    if (typeof target !== "string" && target.kind === "focused") {
+      await this.page.keyPress(maybeKey);
+      return;
+    }
+    // Selector-targeted press: focus via click, then key.
+    await this.page
+      .locator(targetSelector(target as string | ActionTarget))
+      .click();
+    await this.page.keyPress(maybeKey);
+  }
+}
+
+class V4CodeSession implements CoreSession {
+  private handles = new Map<V4Page, V4PageHandle>();
+  private nextId = 0;
+
+  constructor(private readonly init: V4InitResult) {}
+
+  private handleFor(page: V4Page): V4PageHandle {
+    let handle = this.handles.get(page);
+    if (!handle) {
+      handle = new V4PageHandle(page, `v4-page-${this.nextId++}`);
+      this.handles.set(page, handle);
+    }
+    return handle;
+  }
+
+  private get stagehand(): V4Stagehand {
+    return this.init.stagehand;
+  }
+
+  async listPages(): Promise<CorePageHandle[]> {
+    const pages = await this.stagehand.context.pages();
+    return pages.map((p) => this.handleFor(p));
+  }
+  async activePage(): Promise<CorePageHandle> {
+    const page = await this.stagehand.context.activePage();
+    if (!page) throw new Error("v4_code: no active page");
+    return this.handleFor(page);
+  }
+  async newPage(url?: string): Promise<CorePageHandle> {
+    const page = await this.stagehand.context.newPage(url ? { url } : {});
+    return this.handleFor(page);
+  }
+  async selectPage(pageId: string): Promise<void> {
+    for (const [page, handle] of this.handles) {
+      if (handle.id === pageId) {
+        await this.stagehand.context.setActivePage(page);
+        return;
+      }
+    }
+    throw new Error(`v4_code: unknown page id "${pageId}"`);
+  }
+  async closePage(pageId: string): Promise<void> {
+    for (const [page, handle] of this.handles) {
+      if (handle.id === pageId) {
+        await page.close();
+        this.handles.delete(page);
+        return;
+      }
+    }
+    throw new Error(`v4_code: unknown page id "${pageId}"`);
+  }
+  async close(): Promise<void> {
+    await this.stagehand.close();
+  }
+  async getArtifacts(): Promise<Artifact[]> {
+    return [];
+  }
+  async getRawMetrics(): Promise<Record<string, unknown>> {
+    const sessionId = this.stagehand.browser?.browserbaseSessionId;
+    return {
+      ...(sessionId ? { browserbaseSessionId: sessionId } : {}),
+      metrics: await this.stagehand.metrics().catch((): undefined => undefined),
+    };
+  }
+}
+
+export class V4CodeTool implements CoreTool {
+  readonly id = "v4_code";
+  readonly surface = "code";
+  readonly family = "stagehand_v4";
+  readonly supportedStartupProfiles: StartupProfile[] = [
+    "tool_launch_local",
+    "tool_create_browserbase",
+  ];
+  readonly supportedCapabilities: CoreCapability[] = [
+    ...SUPPORTED_CAPABILITIES,
+  ];
+  readonly supportedTargetKinds: TargetKind[] = ["selector", "focused"];
+
+  async start(input: ToolStartInput): Promise<ToolStartResult> {
+    if (!this.supportedStartupProfiles.includes(input.startupProfile)) {
+      throw new Error(
+        `v4_code does not support startup profile "${input.startupProfile}" yet ` +
+          `(the v4 SDK owns its browser; CDP attach profiles need the SDK's ` +
+          `cdp browser source plumbed through initV4)`,
+      );
+    }
+
+    const init = await initV4({
+      logger: input.logger,
+      modelName: SURFACE_MODEL,
+      configOverrides: {
+        env:
+          input.startupProfile === "tool_create_browserbase"
+            ? "BROWSERBASE"
+            : "LOCAL",
+      },
+    });
+
+    const session = new V4CodeSession(init);
+    return {
+      session,
+      cleanup: async () => {
+        await init.stagehand.close().catch(() => {});
+      },
+      metadata: {
+        environment:
+          input.startupProfile === "tool_create_browserbase"
+            ? "browserbase"
+            : "local",
+        browserOwnership: "tool",
+        connectionMode:
+          input.startupProfile === "tool_create_browserbase"
+            ? "browserbase_native"
+            : "launch",
+      },
+    };
+  }
+}
+
+/**
+ * v4_code agent exposure: the agent writes code against the Stagehand v4
+ * SDK. The v4 SDK owns its browser (launched or created through the
+ * extension stack via initV4), so unlike playwright_code/cdp_code there is
+ * no runner-provided CDP endpoint. This is the arm that makes "v4 vs
+ * Playwright" benchable under the same harness, model, and grader — only
+ * the tool surface varies.
+ */
+export async function prepareLLMExposure(
+  plan: ExternalHarnessTaskPlan,
+  env: "LOCAL" | "BROWSERBASE",
+  logger: EvalLogger,
+  startupProfile?: StartupProfile,
+): Promise<LLMExposure> {
+  const resolvedProfile =
+    startupProfile ??
+    (env === "BROWSERBASE" ? "tool_create_browserbase" : "tool_launch_local");
+  if (
+    resolvedProfile !== "tool_launch_local" &&
+    resolvedProfile !== "tool_create_browserbase"
+  ) {
+    throw new EvalsError(
+      `v4_code startup profile "${resolvedProfile}" is not valid for Claude Code. Use tool_launch_local or tool_create_browserbase (the v4 SDK owns its browser).`,
+    );
+  }
+
+  // The surface's internal SDK model (drives act/extract/observe inside
+  // v4); the benchmark's model drives the agent harness itself. Fixed for
+  // comparability, same convention as the v4_code CoreTool.
+  const v4 = await initV4({
+    logger,
+    modelName: SURFACE_MODEL,
+    configOverrides: {
+      env:
+        resolvedProfile === "tool_create_browserbase" ? "BROWSERBASE" : "LOCAL",
+    },
+  });
+
+  logger.log({
+    category: "claude_code",
+    message: `Initialized v4_code (Stagehand v4 SDK) runtime for Claude Code run tool.`,
+    level: 1,
+    auxiliary: {
+      startupProfile: { value: resolvedProfile, type: "string" },
+      environment: { value: env, type: "string" },
+      ...(v4.sessionUrl && {
+        sessionUrl: { value: v4.sessionUrl, type: "string" },
+      }),
+    },
+  });
+
+  const stagehand = v4.stagehand;
+  return {
+    kind: "code_handles",
+    handles: { stagehand, page: v4.page, z },
+    promptInstructions: buildV4CodePromptInstructions(),
+    runTool: {
+      description: [
+        "Execute JavaScript against the initialized Stagehand v4 SDK.",
+        "The snippet runs inside an async function with stagehand, page, startUrl, task, z (zod), and console in scope.",
+        "Use await directly. Return a JSON-serializable value when useful.",
+      ].join(" "),
+      codeParamDescription:
+        "JavaScript function body to execute. stagehand/page/startUrl/task/z are already in scope.",
+      denyMessage: `Use Bash for inspection and ${LLM_RUN_TOOL_NAME} for browser automation.`,
+      task: { instruction: plan.instruction, startUrl: plan.startUrl },
+      console,
+    },
+    ...(v4.sessionUrl && { metadata: { sessionUrl: v4.sessionUrl } }),
+    captureFinalState: async () => {
+      const artifact: { screenshot?: Buffer; url?: string } = {};
+      try {
+        artifact.screenshot = await v4.page.screenshot();
+      } catch {
+        // best-effort only
+      }
+      try {
+        artifact.url = await v4.page.url();
+      } catch {
+        // best-effort only
+      }
+      return artifact;
+    },
+    cleanup: async () => {
+      try {
+        await stagehand.close();
+      } catch {
+        // best-effort only
+      }
+    },
+  };
+}
+
+function buildV4CodePromptInstructions(): string {
+  return [
+    "Browser tool surface: v4_code (Stagehand v4 SDK).",
+    `Use the ${LLM_RUN_TOOL_NAME} tool for browser automation. It exposes an initialized Stagehand v4 client (stagehand), its active page, startUrl, and task object.`,
+    "AI methods live on the client: await stagehand.act('instruction'), await stagehand.observe('instruction'), await stagehand.extract('instruction', zodSchema) — a zod `z` is in scope for extract schemas (use single-word keys).",
+    "Deterministic methods live on the page: await page.goto(url), page.locator(selector).click()/fill()/type(), await page.url(), await page.title(), await page.screenshot().",
+    "Page accessors are async RPCs — always await them.",
+    "The first browser action should usually be: await page.goto(startUrl, { waitUntil: 'domcontentloaded' }).",
+    "Use Bash for inspection and lightweight scripting. Do not create a separate browser process.",
+    "Do not edit repository files.",
+    "Return useful JSON-serializable values from run snippets so you can inspect progress.",
+  ].join("\n");
+}

--- a/packages/evals/framework/claudeCodeToolAdapter.ts
+++ b/packages/evals/framework/claudeCodeToolAdapter.ts
@@ -3,15 +3,25 @@ import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import matter from "gray-matter";
-import type { Browser, BrowserContext, Page } from "playwright";
 import { z } from "zod/v4";
 import { EvalsError } from "../errors.js";
 import type { EvalLogger } from "../logger.js";
 import { getRepoRootDir } from "../runtimePaths.js";
-import type { StartupProfile, ToolSurface } from "../core/contracts/tool.js";
-import { prepareCoreBrowserTarget } from "../core/targets/index.js";
-import { CdpConnection, type CdpEventMessage } from "../core/tools/cdp_code.js";
+import {
+  LLM_RUN_TOOL_NAME,
+  LLM_RUN_TOOL_SERVER,
+  type LLMExposure,
+  type LLMRunToolSpec,
+  type TerminalArtifact,
+  type StartupProfile,
+  type ToolSurface,
+} from "../core/contracts/tool.js";
+import { prepareLLMExposure as prepareCdpCodeLLMExposure } from "../core/tools/cdp_code.js";
+import { prepareLLMExposure as preparePlaywrightCodeLLMExposure } from "../core/tools/playwright_code.js";
+import { prepareLLMExposure as prepareV4CodeLLMExposure } from "../core/tools/v4_code.js";
 import type { ExternalHarnessTaskPlan } from "./externalHarnessPlan.js";
+
+export { waitForCdpEvent } from "../core/tools/cdp_code.js";
 
 export interface ClaudeCodeToolAdapterInput {
   toolSurface?: ToolSurface;
@@ -34,6 +44,11 @@ export interface PreparedClaudeCodeToolAdapter {
     toolName: string,
     input: Record<string, unknown>,
   ) => Promise<Record<string, unknown>>;
+  /**
+   * Harness-observed terminal state for artifact-grounded grading (bounded;
+   * best-effort). Present when the surface's exposure implements it.
+   */
+  captureFinalState?: () => Promise<TerminalArtifact>;
   cleanup: () => Promise<void>;
 }
 
@@ -113,8 +128,8 @@ the guidance below:
   requested by the harness prompt.
 `;
 const ALLOW_UNSANDBOXED_LOCAL_ENV = "EVAL_CLAUDE_CODE_ALLOW_UNSANDBOXED_LOCAL";
-const RUN_TOOL_SERVER = "stagehand_browser";
-const RUN_TOOL_NAME = `mcp__${RUN_TOOL_SERVER}__run`;
+const RUN_TOOL_SERVER = LLM_RUN_TOOL_SERVER;
+const RUN_TOOL_NAME = LLM_RUN_TOOL_NAME;
 
 type ClaudeToolResult = {
   content: Array<{ type: "text"; text: string }>;
@@ -135,42 +150,6 @@ type SdkMcpServerFactory = (options: {
   tools?: unknown[];
   alwaysLoad?: boolean;
 }) => unknown;
-
-type ActiveCdpPage = {
-  targetId: string;
-  sessionId: string;
-  url: string;
-};
-
-type CdpRuntime = {
-  readonly targetId: string;
-  readonly sessionId: string;
-  send<T = unknown>(
-    method: string,
-    params?: Record<string, unknown>,
-  ): Promise<T>;
-  browser<T = unknown>(
-    method: string,
-    params?: Record<string, unknown>,
-  ): Promise<T>;
-  on(
-    method: string,
-    listener: (event: CdpEventMessage) => unknown | Promise<unknown>,
-  ): () => void;
-  off(
-    method: string,
-    listener: (event: CdpEventMessage) => unknown | Promise<unknown>,
-  ): void;
-  once(
-    method: string,
-    listenerOrTimeout?:
-      | ((event: CdpEventMessage) => unknown | Promise<unknown>)
-      | number,
-    timeoutMs?: number,
-  ): Promise<CdpEventMessage> | (() => void);
-  waitForEvent(method: string, timeoutMs?: number): Promise<CdpEventMessage>;
-  wait(ms: number): Promise<void>;
-};
 
 export interface BrowseCliToolMetadata {
   toolCommand: "browse";
@@ -212,20 +191,29 @@ export async function prepareClaudeCodeToolAdapter(
         startupProfile,
       });
     case "playwright_code":
-      return preparePlaywrightCodeAdapter({
-        ...input,
-        toolSurface,
-        startupProfile,
-      });
     case "cdp_code":
-      return prepareCdpCodeAdapter({
+    case "v4_code": {
+      const prepareSurfaceExposure =
+        toolSurface === "playwright_code"
+          ? preparePlaywrightCodeLLMExposure
+          : toolSurface === "cdp_code"
+            ? prepareCdpCodeLLMExposure
+            : prepareV4CodeLLMExposure;
+      const exposure = await prepareSurfaceExposure(
+        input.plan,
+        input.environment,
+        input.logger,
+        startupProfile,
+      );
+      return prepareCodeExposureAdapter(exposure, {
         ...input,
         toolSurface,
         startupProfile,
       });
+    }
     default:
       throw new EvalsError(
-        `Claude Code harness supports --tool browse_cli, playwright_code, or cdp_code for execution right now; received "${toolSurface}".`,
+        `Claude Code harness supports --tool browse_cli, playwright_code, cdp_code, or v4_code for execution right now; received "${toolSurface}".`,
       );
   }
 }
@@ -237,12 +225,13 @@ export function resolveClaudeCodeToolSurface(
   if (
     requested === "browse_cli" ||
     requested === "playwright_code" ||
-    requested === "cdp_code"
+    requested === "cdp_code" ||
+    requested === "v4_code"
   ) {
     return requested;
   }
   throw new EvalsError(
-    `Claude Code harness supports --tool browse_cli, playwright_code, or cdp_code for execution right now; received "${requested}".`,
+    `Claude Code harness supports --tool browse_cli, playwright_code, cdp_code, or v4_code for execution right now; received "${requested}".`,
   );
 }
 
@@ -253,7 +242,9 @@ export function resolveClaudeCodeStartupProfile(
 ): StartupProfile {
   if (requested) return requested;
 
-  if (toolSurface === "browse_cli") {
+  // browse_cli and v4_code own their browser (the v4 SDK launches or
+  // creates it via the extension stack), so no runner-provided CDP endpoint.
+  if (toolSurface === "browse_cli" || toolSurface === "v4_code") {
     return environment === "BROWSERBASE"
       ? "tool_create_browserbase"
       : "tool_launch_local";
@@ -401,79 +392,61 @@ export async function prepareBrowseCliHarnessAdapter(
   };
 }
 
-async function preparePlaywrightCodeAdapter(
+/**
+ * Per-surface temp working directories keep the same names as the old
+ * per-surface adapters so operators can keep telling run dirs apart.
+ */
+const CODE_EXPOSURE_TMPDIR_SUFFIXES: Partial<Record<ToolSurface, string>> = {
+  v4_code: "v4",
+  playwright_code: "playwright",
+  cdp_code: "cdp",
+};
+
+/**
+ * The single generic mount point for `code_handles` exposures: wraps the
+ * exposure's handles in the harness's MCP "run" tool, whose executor runs
+ * snippet code in an AsyncFunction scope over the handle names plus
+ * startUrl, task, and console. Surface specifics (handles, prompt
+ * instructions, run-tool copy, snippet task/console bindings, cleanup) all
+ * come from the exposure — this function owns only harness mechanics.
+ */
+async function prepareCodeExposureAdapter(
+  exposure: LLMExposure,
   input: ClaudeCodeToolAdapterInput & {
-    toolSurface: "playwright_code";
+    toolSurface: ToolSurface;
     startupProfile: StartupProfile;
   },
 ): Promise<PreparedClaudeCodeToolAdapter> {
-  if (
-    input.startupProfile !== "runner_provided_local_cdp" &&
-    input.startupProfile !== "runner_provided_browserbase_cdp"
-  ) {
-    throw new EvalsError(
-      `playwright_code startup profile "${input.startupProfile}" is not valid for Claude Code. Use runner_provided_local_cdp or runner_provided_browserbase_cdp.`,
-    );
-  }
-
-  const cwd = await fsp.mkdtemp(
-    path.join(os.tmpdir(), "stagehand-evals-claude-playwright-"),
-  );
-  const env = { ...process.env } as Record<string, string>;
-  let browser: Browser | undefined;
-  let targetCleanup: () => Promise<void> = async () => {};
-
+  let cwd: string | undefined;
   try {
-    const target = await prepareCoreBrowserTarget({
-      environment: input.environment,
-      toolSurface: "playwright_code",
-      startupProfile: input.startupProfile,
-    });
-    targetCleanup = target.cleanup;
-    if (!target.providedEndpoint?.url) {
+    if (exposure.kind !== "code_handles" || !exposure.handles) {
       throw new EvalsError(
-        `playwright_code requires a runner-provided CDP endpoint for startup profile "${input.startupProfile}".`,
+        `Claude Code run-tool mounting requires a code_handles exposure with handles; "${input.toolSurface}" returned kind "${exposure.kind}".`,
+      );
+    }
+    const runToolSpec = exposure.runTool;
+    if (!runToolSpec) {
+      throw new EvalsError(
+        `Claude Code run-tool mounting requires the exposure's runTool spec; "${input.toolSurface}" did not provide one.`,
       );
     }
 
-    const { chromium } = await import("playwright");
-    browser = await chromium.connectOverCDP(target.providedEndpoint.url, {
-      headers: target.providedEndpoint.headers,
-    });
-    const context = browser.contexts()[0] ?? (await browser.newContext());
-    const page = context.pages()[0] ?? (await context.newPage());
-    const mcpServers = await buildPlaywrightRunMcpServers({
-      browser,
-      context,
-      page,
+    const suffix =
+      CODE_EXPOSURE_TMPDIR_SUFFIXES[input.toolSurface] ?? input.toolSurface;
+    cwd = await fsp.mkdtemp(
+      path.join(os.tmpdir(), `stagehand-evals-claude-${suffix}-`),
+    );
+    const cleanupCwd = cwd;
+    const env = { ...process.env } as Record<string, string>;
+    const mcpServers = await buildCodeExposureRunMcpServers({
+      handles: exposure.handles,
+      runToolSpec,
       plan: input.plan,
       logger: input.logger,
     });
 
-    input.logger.log({
-      category: "claude_code",
-      message: `Initialized playwright_code browser runtime for Claude Code run tool.`,
-      level: 1,
-      auxiliary: {
-        startupProfile: {
-          value: input.startupProfile,
-          type: "string",
-        },
-        environment: {
-          value: input.environment,
-          type: "string",
-        },
-        ...(target.metadata && {
-          targetMetadata: {
-            value: JSON.stringify(target.metadata),
-            type: "object",
-          },
-        }),
-      },
-    });
-
     return {
-      toolSurface: "playwright_code",
+      toolSurface: input.toolSurface,
       startupProfile: input.startupProfile,
       cwd,
       env,
@@ -486,152 +459,48 @@ async function preparePlaywrightCodeAdapter(
         }
         return {
           behavior: "deny",
-          message: `Use Bash for inspection and ${RUN_TOOL_NAME} for browser automation.`,
+          message: runToolSpec.denyMessage,
         };
       },
-      promptInstructions: buildPlaywrightCodePromptInstructions(input.plan),
+      promptInstructions: exposure.promptInstructions,
+      ...(exposure.captureFinalState && {
+        captureFinalState: async (): Promise<TerminalArtifact> => {
+          try {
+            return await withTimeout(
+              exposure.captureFinalState!(),
+              readPositiveIntEnv("EVAL_FINAL_STATE_TIMEOUT_MS", 15_000),
+            );
+          } catch {
+            return {};
+          }
+        },
+      }),
       cleanup: async () => {
+        // Bounded (PR b327a4dc parity): a hung surface close must not wedge
+        // the row — the tmpdir removal below always runs.
         try {
-          await browser?.close();
+          await withTimeout(
+            exposure.cleanup(),
+            readPositiveIntEnv("EVAL_EXPOSURE_CLEANUP_TIMEOUT_MS", 30_000),
+          );
         } catch {
           // best-effort only
-        } finally {
-          await targetCleanup();
-          await fsp.rm(cwd, { recursive: true, force: true });
         }
+        await fsp.rm(cleanupCwd, { recursive: true, force: true });
       },
     };
   } catch (error) {
-    try {
-      await browser?.close();
-    } catch {
-      // best-effort only
+    await exposure.cleanup().catch((): undefined => undefined);
+    if (cwd) {
+      await fsp.rm(cwd, { recursive: true, force: true });
     }
-    await targetCleanup();
-    await fsp.rm(cwd, { recursive: true, force: true });
     throw error;
   }
 }
 
-async function prepareCdpCodeAdapter(
-  input: ClaudeCodeToolAdapterInput & {
-    toolSurface: "cdp_code";
-    startupProfile: StartupProfile;
-  },
-): Promise<PreparedClaudeCodeToolAdapter> {
-  if (
-    input.startupProfile !== "runner_provided_local_cdp" &&
-    input.startupProfile !== "runner_provided_browserbase_cdp"
-  ) {
-    throw new EvalsError(
-      `cdp_code startup profile "${input.startupProfile}" is not valid for Claude Code. Use runner_provided_local_cdp or runner_provided_browserbase_cdp.`,
-    );
-  }
-
-  const cwd = await fsp.mkdtemp(
-    path.join(os.tmpdir(), "stagehand-evals-claude-cdp-"),
-  );
-  const env = { ...process.env } as Record<string, string>;
-  let connection: CdpConnection | undefined;
-  let targetCleanup: () => Promise<void> = async () => {};
-
-  try {
-    const target = await prepareCoreBrowserTarget({
-      environment: input.environment,
-      toolSurface: "cdp_code",
-      startupProfile: input.startupProfile,
-    });
-    targetCleanup = target.cleanup;
-    if (!target.providedEndpoint?.url) {
-      throw new EvalsError(
-        `cdp_code requires a runner-provided CDP endpoint for startup profile "${input.startupProfile}".`,
-      );
-    }
-
-    connection = await CdpConnection.connect(target.providedEndpoint);
-    const activePage = await attachActiveCdpPage(connection);
-    const mcpServers = await buildCdpRunMcpServers({
-      connection,
-      activePage,
-      plan: input.plan,
-      logger: input.logger,
-    });
-
-    input.logger.log({
-      category: "claude_code",
-      message: `Initialized cdp_code browser runtime for Claude Code run tool.`,
-      level: 1,
-      auxiliary: {
-        startupProfile: {
-          value: input.startupProfile,
-          type: "string",
-        },
-        environment: {
-          value: input.environment,
-          type: "string",
-        },
-        targetId: {
-          value: activePage.targetId,
-          type: "string",
-        },
-        sessionId: {
-          value: activePage.sessionId,
-          type: "string",
-        },
-        ...(target.metadata && {
-          targetMetadata: {
-            value: JSON.stringify(target.metadata),
-            type: "object",
-          },
-        }),
-      },
-    });
-
-    return {
-      toolSurface: "cdp_code",
-      startupProfile: input.startupProfile,
-      cwd,
-      env,
-      allowedTools: ["Bash", RUN_TOOL_NAME],
-      settingSources: [],
-      mcpServers,
-      canUseTool: async (toolName, commandInput) => {
-        if (toolName === RUN_TOOL_NAME || toolName === "Bash") {
-          return { behavior: "allow", updatedInput: commandInput };
-        }
-        return {
-          behavior: "deny",
-          message: `Use Bash for inspection and ${RUN_TOOL_NAME} for CDP browser automation.`,
-        };
-      },
-      promptInstructions: buildCdpCodePromptInstructions(input.plan),
-      cleanup: async () => {
-        try {
-          await connection?.close();
-        } catch {
-          // best-effort only
-        } finally {
-          await targetCleanup();
-          await fsp.rm(cwd, { recursive: true, force: true });
-        }
-      },
-    };
-  } catch (error) {
-    try {
-      await connection?.close();
-    } catch {
-      // best-effort only
-    }
-    await targetCleanup();
-    await fsp.rm(cwd, { recursive: true, force: true });
-    throw error;
-  }
-}
-
-async function buildPlaywrightRunMcpServers(input: {
-  browser: Browser;
-  context: BrowserContext;
-  page: Page;
+async function buildCodeExposureRunMcpServers(input: {
+  handles: Record<string, unknown>;
+  runToolSpec: LLMRunToolSpec;
   plan: ExternalHarnessTaskPlan;
   logger: EvalLogger;
 }): Promise<Record<string, unknown>> {
@@ -642,24 +511,15 @@ async function buildPlaywrightRunMcpServers(input: {
 
   const runTool = sdk.tool(
     "run",
-    [
-      "Execute JavaScript against the initialized Playwright browser.",
-      "The snippet runs inside an async function with page, context, browser, startUrl, task, and console in scope.",
-      "Use await directly. Return a JSON-serializable value when useful.",
-    ].join(" "),
+    input.runToolSpec.description,
     {
-      code: z
-        .string()
-        .describe(
-          "JavaScript function body to execute. page/context/browser/startUrl/task are already in scope.",
-        ),
+      code: z.string().describe(input.runToolSpec.codeParamDescription),
     },
     async ({ code }) => {
-      return executePlaywrightRunTool({
+      return executeCodeExposureRunTool({
         code,
-        browser: input.browser,
-        context: input.context,
-        page: input.page,
+        handles: input.handles,
+        runToolSpec: input.runToolSpec,
         plan: input.plan,
         logger: input.logger,
       });
@@ -677,17 +537,16 @@ async function buildPlaywrightRunMcpServers(input: {
   };
 }
 
-async function executePlaywrightRunTool(input: {
+async function executeCodeExposureRunTool(input: {
   code: string;
-  browser: Browser;
-  context: BrowserContext;
-  page: Page;
+  handles: Record<string, unknown>;
+  runToolSpec: LLMRunToolSpec;
   plan: ExternalHarnessTaskPlan;
   logger: EvalLogger;
 }): Promise<ClaudeToolResult> {
   try {
     const result = await withTimeout(
-      executePlaywrightSnippet(input),
+      executeCodeExposureSnippet(input),
       readPositiveIntEnv("EVAL_CLAUDE_CODE_RUN_TOOL_TIMEOUT_MS", 60_000),
     );
     const text = stringifyToolResult(result);
@@ -713,11 +572,10 @@ async function executePlaywrightRunTool(input: {
   }
 }
 
-async function executePlaywrightSnippet(input: {
+async function executeCodeExposureSnippet(input: {
   code: string;
-  browser: Browser;
-  context: BrowserContext;
-  page: Page;
+  handles: Record<string, unknown>;
+  runToolSpec: LLMRunToolSpec;
   plan: ExternalHarnessTaskPlan;
   logger: EvalLogger;
 }): Promise<unknown> {
@@ -725,346 +583,22 @@ async function executePlaywrightSnippet(input: {
     .constructor as new (
     ...args: string[]
   ) => (...values: unknown[]) => Promise<unknown>;
+  // Snippet scope = the exposure's handle names plus startUrl/task/console.
+  // Object.keys/Object.values over the same object are guaranteed to align,
+  // so names — not positions — bind the values.
   const fn = new AsyncFunction(
-    "page",
-    "context",
-    "browser",
+    ...Object.keys(input.handles),
     "startUrl",
     "task",
     "console",
     input.code,
   );
   return fn(
-    input.page,
-    input.context,
-    input.browser,
+    ...Object.values(input.handles),
     input.plan.startUrl,
-    {
-      dataset: input.plan.dataset,
-      id: input.plan.taskId,
-      startUrl: input.plan.startUrl,
-      instruction: input.plan.instruction,
-    },
-    buildRunToolConsole(input.logger),
+    input.runToolSpec.task,
+    input.runToolSpec.console ?? buildRunToolConsole(input.logger),
   );
-}
-
-async function buildCdpRunMcpServers(input: {
-  connection: CdpConnection;
-  activePage: ActiveCdpPage;
-  plan: ExternalHarnessTaskPlan;
-  logger: EvalLogger;
-}): Promise<Record<string, unknown>> {
-  const sdk = (await import("@anthropic-ai/claude-agent-sdk")) as unknown as {
-    createSdkMcpServer: SdkMcpServerFactory;
-    tool: SdkToolFactory;
-  };
-
-  const runTool = sdk.tool(
-    "run",
-    [
-      "Execute JavaScript against the initialized Chrome DevTools Protocol browser.",
-      "The snippet runs inside an async function with cdp, startUrl, task, and console in scope.",
-      "Use await directly. Return a JSON-serializable value when useful.",
-    ].join(" "),
-    {
-      code: z
-        .string()
-        .describe(
-          "JavaScript function body to execute. cdp/startUrl/task are already in scope.",
-        ),
-    },
-    async ({ code }) => {
-      return executeCdpRunTool({
-        code,
-        connection: input.connection,
-        activePage: input.activePage,
-        plan: input.plan,
-        logger: input.logger,
-      });
-    },
-    { alwaysLoad: true },
-  );
-
-  return {
-    [RUN_TOOL_SERVER]: sdk.createSdkMcpServer({
-      name: RUN_TOOL_SERVER,
-      version: "1.0.0",
-      tools: [runTool],
-      alwaysLoad: true,
-    }),
-  };
-}
-
-async function executeCdpRunTool(input: {
-  code: string;
-  connection: CdpConnection;
-  activePage: ActiveCdpPage;
-  plan: ExternalHarnessTaskPlan;
-  logger: EvalLogger;
-}): Promise<ClaudeToolResult> {
-  try {
-    const result = await withTimeout(
-      executeCdpSnippet(input),
-      readPositiveIntEnv("EVAL_CLAUDE_CODE_RUN_TOOL_TIMEOUT_MS", 60_000),
-    );
-    const text = stringifyToolResult(result);
-    input.logger.log({
-      category: "claude_code",
-      message: `run tool completed: ${clip(text, 500)}`,
-      level: 1,
-    });
-    return {
-      content: [{ type: "text", text }],
-    };
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    input.logger.warn({
-      category: "claude_code",
-      message: `run tool failed: ${message}`,
-      level: 1,
-    });
-    return {
-      isError: true,
-      content: [{ type: "text", text: message }],
-    };
-  }
-}
-
-async function executeCdpSnippet(input: {
-  code: string;
-  connection: CdpConnection;
-  activePage: ActiveCdpPage;
-  plan: ExternalHarnessTaskPlan;
-  logger: EvalLogger;
-}): Promise<unknown> {
-  const AsyncFunction = Object.getPrototypeOf(async function () {})
-    .constructor as new (
-    ...args: string[]
-  ) => (...values: unknown[]) => Promise<unknown>;
-  const fn = new AsyncFunction(
-    "cdp",
-    "startUrl",
-    "task",
-    "console",
-    input.code,
-  );
-  return fn(
-    buildCdpRuntime(input.connection, input.activePage, input.logger),
-    input.plan.startUrl,
-    {
-      dataset: input.plan.dataset,
-      id: input.plan.taskId,
-      startUrl: input.plan.startUrl,
-      instruction: input.plan.instruction,
-    },
-    buildRunToolConsole(input.logger),
-  );
-}
-
-function buildCdpRuntime(
-  connection: CdpConnection,
-  activePage: ActiveCdpPage,
-  logger: EvalLogger,
-): CdpRuntime {
-  const listenerUnsubscribes = new Map<
-    (event: CdpEventMessage) => unknown | Promise<unknown>,
-    () => void
-  >();
-  return {
-    targetId: activePage.targetId,
-    sessionId: activePage.sessionId,
-    send: <T = unknown>(
-      method: string,
-      params?: Record<string, unknown>,
-    ): Promise<T> => connection.send<T>(method, params, activePage.sessionId),
-    browser: <T = unknown>(
-      method: string,
-      params?: Record<string, unknown>,
-    ): Promise<T> => connection.send<T>(method, params),
-    on: (
-      method: string,
-      listener: (event: CdpEventMessage) => unknown | Promise<unknown>,
-    ): (() => void) => {
-      const unsubscribe = onCdpEvent(
-        connection,
-        activePage.sessionId,
-        method,
-        listener,
-        logger,
-      );
-      listenerUnsubscribes.set(listener, unsubscribe);
-      return () => {
-        listenerUnsubscribes.delete(listener);
-        unsubscribe();
-      };
-    },
-    off: (
-      _method: string,
-      listener: (event: CdpEventMessage) => unknown | Promise<unknown>,
-    ): void => {
-      const unsubscribe = listenerUnsubscribes.get(listener);
-      listenerUnsubscribes.delete(listener);
-      unsubscribe?.();
-    },
-    once: (
-      method: string,
-      listenerOrTimeout?:
-        | ((event: CdpEventMessage) => unknown | Promise<unknown>)
-        | number,
-      timeoutMs = 15_000,
-    ): Promise<CdpEventMessage> | (() => void) => {
-      if (typeof listenerOrTimeout === "function") {
-        const listener = listenerOrTimeout;
-        const unsubscribe = onCdpEvent(
-          connection,
-          activePage.sessionId,
-          method,
-          (event) => {
-            unsubscribe?.();
-            listenerUnsubscribes.delete(listener);
-            return listener(event);
-          },
-          logger,
-        );
-        listenerUnsubscribes.set(listener, unsubscribe);
-        return () => {
-          listenerUnsubscribes.delete(listener);
-          unsubscribe?.();
-        };
-      }
-      return waitForCdpEvent(
-        connection,
-        activePage.sessionId,
-        method,
-        listenerOrTimeout ?? timeoutMs,
-      );
-    },
-    waitForEvent: (
-      method: string,
-      timeoutMs = 15_000,
-    ): Promise<CdpEventMessage> =>
-      waitForCdpEvent(connection, activePage.sessionId, method, timeoutMs),
-    wait: sleep,
-  };
-}
-
-function onCdpEvent(
-  connection: CdpConnection,
-  sessionId: string,
-  method: string,
-  listener: (event: CdpEventMessage) => unknown | Promise<unknown>,
-  logger: EvalLogger,
-): () => void {
-  return connection.onEvent((event) => {
-    if (
-      event.method !== method ||
-      (event.sessionId && event.sessionId !== sessionId)
-    ) {
-      return;
-    }
-    try {
-      const result = listener(event);
-      if (isPromiseLike(result)) {
-        result.catch((error: unknown) => {
-          logger.warn({
-            category: "claude_code",
-            message: `cdp event listener failed: ${error instanceof Error ? error.message : String(error)}`,
-            level: 1,
-          });
-        });
-      }
-    } catch (error) {
-      logger.warn({
-        category: "claude_code",
-        message: `cdp event listener failed: ${error instanceof Error ? error.message : String(error)}`,
-        level: 1,
-      });
-    }
-  });
-}
-
-async function attachActiveCdpPage(
-  connection: CdpConnection,
-): Promise<ActiveCdpPage> {
-  const targets = await connection.send<{
-    targetInfos: Array<{
-      targetId: string;
-      type: string;
-      url?: string;
-    }>;
-  }>("Target.getTargets");
-
-  const existingPage = targets.targetInfos.find(
-    (target) =>
-      target.type === "page" && !target.url?.startsWith("devtools://"),
-  );
-  const targetId =
-    existingPage?.targetId ??
-    (
-      await connection.send<{ targetId: string }>("Target.createTarget", {
-        url: "about:blank",
-      })
-    ).targetId;
-  const attached = await connection.send<{ sessionId: string }>(
-    "Target.attachToTarget",
-    {
-      targetId,
-      flatten: true,
-    },
-  );
-
-  await connection.send("Page.enable", {}, attached.sessionId);
-  await connection.send("Runtime.enable", {}, attached.sessionId);
-  await connection.send("DOM.enable", {}, attached.sessionId);
-  await connection.send(
-    "Page.setLifecycleEventsEnabled",
-    { enabled: true },
-    attached.sessionId,
-  );
-
-  return {
-    targetId,
-    sessionId: attached.sessionId,
-    url: existingPage?.url ?? "about:blank",
-  };
-}
-
-export function waitForCdpEvent(
-  connection: CdpConnection,
-  sessionId: string,
-  method: string,
-  timeoutMs: number,
-): Promise<CdpEventMessage> {
-  let timeout: NodeJS.Timeout | undefined;
-  let unsubscribe: (() => void) | undefined;
-  const promise = new Promise<CdpEventMessage>((resolve, reject) => {
-    const cleanup = () => {
-      if (timeout) clearTimeout(timeout);
-      unsubscribe?.();
-    };
-    unsubscribe = connection.onEvent((event) => {
-      if (
-        event.method !== method ||
-        (event.sessionId && event.sessionId !== sessionId)
-      ) {
-        return;
-      }
-      cleanup();
-      resolve(event);
-    });
-    timeout = setTimeout(() => {
-      cleanup();
-      reject(new Error(`Timed out waiting for CDP event "${method}"`));
-    }, timeoutMs);
-  });
-
-  // Claude-generated snippets often assign an event wait promise before a CDP
-  // action and may abandon it after another branch finishes. Keep the promise
-  // rejectable for awaited callers, but prevent abandoned waits from crashing
-  // the eval process as unhandled rejections.
-  promise.catch((): undefined => undefined);
-  return promise;
 }
 
 function buildRunToolConsole(
@@ -1082,34 +616,6 @@ function buildRunToolConsole(
     warn: (...values: unknown[]) => write("warn", values),
     error: (...values: unknown[]) => write("error", values),
   };
-}
-
-function buildPlaywrightCodePromptInstructions(
-  plan: ExternalHarnessTaskPlan,
-): string {
-  void plan;
-  return [
-    "Browser tool surface: playwright_code.",
-    `Use the ${RUN_TOOL_NAME} tool for browser automation. It exposes an initialized Playwright page, context, browser, startUrl, and task object.`,
-    "Use Bash for inspection and lightweight scripting. Do not create a separate browser process.",
-    "The first browser action should usually be: await page.goto(startUrl, { waitUntil: 'domcontentloaded' }).",
-    "Do not edit repository files.",
-    "Return useful JSON-serializable values from run snippets so you can inspect progress.",
-  ].join("\n");
-}
-
-function buildCdpCodePromptInstructions(plan: ExternalHarnessTaskPlan): string {
-  void plan;
-  return [
-    "Browser tool surface: cdp_code.",
-    `Use the ${RUN_TOOL_NAME} tool for browser automation. It exposes an initialized cdp object, startUrl, and task object.`,
-    "Use cdp.send(method, params) for page-scoped CDP commands and cdp.browser(method, params) for browser-level commands.",
-    "Helpers available: cdp.on(method, listener), cdp.once(method), cdp.waitForEvent(method, timeoutMs), cdp.wait(ms), cdp.targetId, cdp.sessionId.",
-    'The first browser action should usually be: const loaded = cdp.waitForEvent("Page.loadEventFired"); await cdp.send("Page.navigate", { url: startUrl }); await loaded.',
-    "Use Bash for inspection and lightweight scripting. Do not create a separate browser process.",
-    "Do not edit repository files.",
-    "Return useful JSON-serializable values from run snippets so you can inspect progress.",
-  ].join("\n");
 }
 
 function buildBrowseCliPromptInstructions(
@@ -1203,10 +709,6 @@ function readPositiveIntEnv(key: string, fallback: number): number {
   return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 async function withTimeout<T>(
   promise: Promise<T>,
   timeoutMs: number,
@@ -1241,19 +743,6 @@ function clip(value: string, maxLength: number): string {
   return value.length <= maxLength
     ? value
     : `${value.slice(0, maxLength - 1)}…`;
-}
-
-function isPromiseLike(value: unknown): value is PromiseLike<unknown> & {
-  catch: (handler: (error: unknown) => void) => unknown;
-} {
-  return (
-    value !== null &&
-    typeof value === "object" &&
-    "then" in value &&
-    typeof (value as { then?: unknown }).then === "function" &&
-    "catch" in value &&
-    typeof (value as { catch?: unknown }).catch === "function"
-  );
 }
 
 function createBrowseSessionName(): string {

--- a/packages/evals/tests/framework/claudeCodeToolAdapter.test.ts
+++ b/packages/evals/tests/framework/claudeCodeToolAdapter.test.ts
@@ -58,7 +58,17 @@ describe("claude code tool adapter resolution", () => {
 
   it("rejects unsupported Claude Code tool surfaces for now", () => {
     expect(() => resolveClaudeCodeToolSurface("understudy_code")).toThrow(
-      /supports --tool browse_cli, playwright_code, or cdp_code/,
+      /supports --tool browse_cli, playwright_code, cdp_code, or v4_code/,
+    );
+  });
+
+  it("accepts v4_code with SDK-owned startup profiles", () => {
+    expect(resolveClaudeCodeToolSurface("v4_code")).toBe("v4_code");
+    expect(resolveClaudeCodeStartupProfile("v4_code", "BROWSERBASE")).toBe(
+      "tool_create_browserbase",
+    );
+    expect(resolveClaudeCodeStartupProfile("v4_code", "LOCAL")).toBe(
+      "tool_launch_local",
     );
   });
 


### PR DESCRIPTION
Part of STG-2671 (non-deterministic suite: harness + tool_surface cadence).

Introduces a harness-agnostic **`LLMExposure`** contract so LLM coding harnesses (claude_code today, codex next) drive *any* browser tool surface through one seam. Each surface implements a single `prepareLLMExposure()`; the harness keeps three generic mount points (code handles / MCP server / CLI) and zero per-surface knowledge.

## What's inside
- `core/contracts/tool.ts` — `LLMExposure`, `LLMRunToolSpec`, `TerminalArtifact`, shared run-tool naming
- `core/tools/v4_code.ts` — **v4 code mode**: the agent writes real Stagehand v4 SDK code (`stagehand.act/extract/observe`, locators) against the extension stack; CoreTool for the deterministic tier + its exposure
- `playwright_code` / `cdp_code` — exposures moved in from the claude_code adapter; each also captures harness-observed terminal state for artifact-grounded grading
- `framework/claudeCodeToolAdapter.ts` — one generic exposure consumer replaces all per-surface setup (**−638 lines here**); bounded exposure cleanup

## Why
Makes v4 vs Playwright vs CDP benchable under the same harness, model, and grader — score deltas attribute to the tool surface alone. Adding a competitor framework is one function, not a fork.

## Verification
- Live WebVoyager runs on both `v4_code` and `playwright_code` arms (5 rows × 3 trials each, published to Braintrust `stagehand-v4` with per-surface attribution)
- Model-visible prompt strings byte-identical through the refactor
- Typecheck / eslint / prettier clean; framework suite green


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a harness‑agnostic `LLMExposure` contract and introduces `v4_code` so the Claude Code harness can drive v4, Playwright, and CDP through one seam for apples‑to‑apples benchmarking. Part of STG‑2671; reduces per‑surface setup and grounds grading with harness‑captured artifacts.

- **New Features**
  - Added `LLMExposure`, `LLMRunToolSpec`, and `TerminalArtifact` with shared run‑tool names.
  - Implemented `v4_code` CoreTool and exposure; agents write real Stagehand v4 SDK code (`stagehand.act/extract/observe`, locators).
  - Moved `playwright_code` and `cdp_code` exposures into core with final‑state capture (screenshot + URL).

- **Refactors**
  - Replaced per‑surface wiring in `claudeCodeToolAdapter` with a single exposure consumer; bounded cleanup; net −638 LOC.
  - Registered `v4_code`; updated startup profile resolution and tests.
  - Kept model‑visible prompt strings byte‑identical to pre‑refactor.

<sup>Written for commit db091953e34615cc855f02c3aadf880ed6743e9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

