### PR TITLE
evals: ground rubric grading in harness-observed task artifacts

### DIFF
--- a/packages/evals/.gitignore
+++ b/packages/evals/.gitignore
@@ -4,3 +4,4 @@
 #     --module nodenext --moduleResolution nodenext --allowImportingTsExtensions \
 #     --esModuleInterop --skipLibCheck --outDir <stagehand>/packages/evals/.v4-sdk-types
 .v4-sdk-types/
+.rubric-cache/

--- a/packages/evals/framework/claudeCodeRunner.ts
+++ b/packages/evals/framework/claudeCodeRunner.ts
@@ -256,6 +256,13 @@ export async function runClaudeCodeAgent({
 
   // Build a Trajectory from the SDK message stream and grade it with the
   // rubric verifier; any failure in that path folds into `verifierError`.
+  // Artifact-grounded grading: the harness observes the terminal page state
+  // itself (screenshot + URL through the tool surface) so the verifier's
+  // final-observation anchor never depends on what the agent chose to
+  // return. Code surfaces stringify tool results, so without this the
+  // verifier had no terminal screenshot at all.
+  const terminalArtifact = await toolAdapter?.captureFinalState?.();
+
   return gradeExternalTrajectory({
     buildTrajectory: () =>
       claudeCodeAdapter.fromHarnessResult(
@@ -268,6 +275,7 @@ export async function runClaudeCodeAgent({
             output_tokens: tokenUsage.outputTokens,
             cached_input_tokens: tokenUsage.cacheReadInputTokens,
           },
+          ...(terminalArtifact && { terminalArtifact }),
         },
         verifier.taskSpec,
       ),

--- a/packages/evals/framework/harnesses/claudeCodeAdapter.ts
+++ b/packages/evals/framework/harnesses/claudeCodeAdapter.ts
@@ -44,6 +44,12 @@ export interface ClaudeCodeRunResult {
   status?: Trajectory["status"];
   /** Optional usage to fold into Trajectory.usage. */
   usage?: Partial<Trajectory["usage"]>;
+  /**
+   * Harness-observed terminal page state (screenshot + URL captured through
+   * the tool surface after the agent finished). Preferred over any
+   * agent-returned image as the verifier's final-observation anchor.
+   */
+  terminalArtifact?: { screenshot?: Buffer; url?: string };
 }
 
 interface ToolUseBlock {
@@ -175,17 +181,31 @@ export class ClaudeCodeTrajectoryAdapter
       resultMessageText ??
       (trailing.length > 0 ? trailing : undefined);
 
-    // Anchor the closing frame with the most recent screenshot the agent
-    // captured. Claude Code doesn't run a post-task probe, so the last
-    // tool_result image is the best proxy for "terminal observation" — without
-    // it the verifier's final-screenshot anchor (evidence.ts:136-143) is empty.
+    // Anchor the closing frame for the verifier. Preference order:
+    // 1. The harness-observed terminal artifact (screenshot + URL captured
+    //    through the tool surface after the agent finished) — grading is
+    //    grounded in what actually happened on the page, independent of the
+    //    agent's self-report. Code surfaces stringify tool results, so this
+    //    is the ONLY screenshot source for v4_code/playwright_code/cdp_code.
+    // 2. Fallback: the most recent image the agent returned from a tool call
+    //    (browse_cli), the pre-existing best proxy — without any anchor the
+    //    verifier's final-screenshot slot (evidence.ts:136-143) is empty.
     let finalObservation: ProbeEvidence | undefined;
-    for (let i = toolUses.length - 1; i >= 0; i--) {
-      const matched = toolResults.get(toolUses[i].id);
-      const lastImage = matched?.images[matched.images.length - 1];
-      if (lastImage) {
-        finalObservation = { screenshot: lastImage.bytes };
-        break;
+    if (result.terminalArtifact?.screenshot) {
+      finalObservation = {
+        screenshot: result.terminalArtifact.screenshot,
+        ...(result.terminalArtifact.url && {
+          url: result.terminalArtifact.url,
+        }),
+      };
+    } else {
+      for (let i = toolUses.length - 1; i >= 0; i--) {
+        const matched = toolResults.get(toolUses[i].id);
+        const lastImage = matched?.images[matched.images.length - 1];
+        if (lastImage) {
+          finalObservation = { screenshot: lastImage.bytes };
+          break;
+        }
       }
     }
 

--- a/packages/evals/framework/rubricCache.ts
+++ b/packages/evals/framework/rubricCache.ts
@@ -86,10 +86,28 @@ export class RubricCache {
       );
       return undefined;
     }
+    if (!parsed.rubric?.items?.length) {
+      // An empty rubric grades nothing: every trial gets processScore 0 and
+      // no per-criterion rows, silently, in every arm that hits the cache
+      // (observed on webvoyager Allrecipes--2, 2026-07-23). Treat it as a
+      // miss so generation is retried instead of poisoning whole matrices.
+      console.warn(
+        `[rubric-cache] cached rubric for ${taskSpec.id} has no items; regenerating`,
+      );
+      return undefined;
+    }
     return parsed.rubric;
   }
 
   async write(taskSpec: TaskSpec, rubric: Rubric): Promise<void> {
+    if (!rubric?.items?.length) {
+      // Never persist an empty rubric — a cached zero-item rubric silently
+      // disables grading for every future trial of this task.
+      console.warn(
+        `[rubric-cache] refusing to cache empty rubric for ${taskSpec.id}`,
+      );
+      return;
+    }
     await fs.mkdir(this.cacheDir, { recursive: true });
     const entry: CacheEntry = {
       taskId: taskSpec.id,

--- a/packages/evals/tests/framework/claudeCodeTerminalArtifact.test.ts
+++ b/packages/evals/tests/framework/claudeCodeTerminalArtifact.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { claudeCodeAdapter } from "../../framework/harnesses/claudeCodeAdapter.js";
+import type { TaskSpec } from "@browserbasehq/stagehand";
+
+const taskSpec: TaskSpec = {
+  id: "test/terminal-artifact",
+  instruction: "Do the task",
+  initUrl: "https://example.com",
+};
+
+const HARNESS_SHOT = Buffer.from("harness-observed-screenshot");
+const AGENT_SHOT = Buffer.from("agent-returned-screenshot");
+
+function messagesWithAgentImage() {
+  return [
+    {
+      type: "assistant",
+      message: {
+        content: [
+          {
+            type: "tool_use",
+            id: "tu_1",
+            name: "run",
+            input: { code: "await page.screenshot()" },
+          },
+        ],
+      },
+    },
+    {
+      type: "user",
+      message: {
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "tu_1",
+            content: [
+              {
+                type: "image",
+                source: {
+                  type: "base64",
+                  media_type: "image/png",
+                  data: AGENT_SHOT.toString("base64"),
+                },
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ];
+}
+
+describe("artifact-grounded final observation", () => {
+  it("prefers the harness-observed terminal artifact over agent-returned images", () => {
+    const trajectory = claudeCodeAdapter.fromHarnessResult(
+      {
+        messages: messagesWithAgentImage(),
+        finalAnswer: "done",
+        terminalArtifact: {
+          screenshot: HARNESS_SHOT,
+          url: "https://example.com/final",
+        },
+      },
+      taskSpec,
+    );
+    expect(trajectory.finalObservation?.screenshot).toBe(HARNESS_SHOT);
+    expect(trajectory.finalObservation?.url).toBe("https://example.com/final");
+  });
+
+  it("falls back to the last agent-returned image when no artifact was captured", () => {
+    const trajectory = claudeCodeAdapter.fromHarnessResult(
+      { messages: messagesWithAgentImage(), finalAnswer: "done" },
+      taskSpec,
+    );
+    expect(trajectory.finalObservation?.screenshot?.equals(AGENT_SHOT)).toBe(
+      true,
+    );
+  });
+
+  it("omits the anchor entirely when neither source exists", () => {
+    const trajectory = claudeCodeAdapter.fromHarnessResult(
+      { messages: [], finalAnswer: "done" },
+      taskSpec,
+    );
+    expect(trajectory.finalObservation).toBeUndefined();
+  });
+
+  it("ignores an empty artifact (no screenshot) and still falls back", () => {
+    const trajectory = claudeCodeAdapter.fromHarnessResult(
+      {
+        messages: messagesWithAgentImage(),
+        finalAnswer: "done",
+        terminalArtifact: {},
+      },
+      taskSpec,
+    );
+    expect(trajectory.finalObservation?.screenshot?.equals(AGENT_SHOT)).toBe(
+      true,
+    );
+  });
+});

--- a/packages/evals/tests/framework/rubricCacheEmptyGuard.test.ts
+++ b/packages/evals/tests/framework/rubricCacheEmptyGuard.test.ts
@@ -1,0 +1,66 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { RubricCache } from "../../framework/rubricCache.js";
+import type { TaskSpec } from "@browserbasehq/stagehand";
+
+const taskSpec: TaskSpec = {
+  id: "row-1",
+  instruction: "find the thing",
+};
+
+let root: string;
+let cache: RubricCache;
+
+beforeEach(async () => {
+  root = await fs.mkdtemp(path.join(os.tmpdir(), "rubric-cache-test-"));
+  cache = new RubricCache({ dataset: "testset", cacheRoot: root });
+});
+
+afterEach(async () => {
+  await fs.rm(root, { recursive: true, force: true });
+});
+
+describe("rubric cache empty-rubric guards", () => {
+  it("refuses to persist an empty rubric", async () => {
+    await cache.write(taskSpec, { items: [] });
+    expect(await cache.read(taskSpec)).toBeUndefined();
+  });
+
+  it("treats a pre-existing empty cached rubric as a miss", async () => {
+    // Simulate the poisoned-cache state observed on Allrecipes--2: an empty
+    // rubric written by an older version of the cache.
+    const dir = path.join(root, "testset");
+    await fs.mkdir(dir, { recursive: true });
+    const { createHash } = await import("node:crypto");
+    const hash = createHash("sha256")
+      .update(taskSpec.instruction)
+      .digest("hex")
+      .slice(0, 16);
+    await fs.writeFile(
+      path.join(dir, "row-1.json"),
+      JSON.stringify({
+        taskId: "row-1",
+        instructionHash: hash,
+        generatedAt: new Date().toISOString(),
+        rubric: { items: [] },
+      }),
+    );
+    expect(await cache.read(taskSpec)).toBeUndefined();
+  });
+
+  it("round-trips a real rubric untouched", async () => {
+    const rubric = {
+      items: [
+        {
+          criterion: "did the thing",
+          description: "full credit if the thing was done",
+          maxPoints: 3,
+        },
+      ],
+    };
+    await cache.write(taskSpec, rubric);
+    expect(await cache.read(taskSpec)).toEqual(rubric);
+  });
+});


### PR DESCRIPTION
Part of STG-2671 (LLMJ grading — LLM grades only, never drives).

Grounds rubric grading in **harness-observed task artifacts**. Code tool surfaces stringify run-tool results, so the verifier's final-screenshot anchor was empty on every `v4_code`/`playwright_code`/`cdp_code` run — grading rested on the agent's textual self-report (the verifier itself emitted a `blocking` trajectory_capture finding asking for exactly this).

## What's inside
- `claudeCodeRunner` — after the agent finishes, before cleanup: capture terminal page state through the tool surface (bounded, best-effort), thread into the trajectory
- `claudeCodeAdapter` — final-observation anchor prefers the harness-observed artifact (screenshot + URL) over agent-returned images; browse_cli fallback preserved
- `rubricCache` — never cache or serve a zero-item rubric: an empty cached rubric silently disabled grading for every trial of a task in both comparison arms (observed live on `Allrecipes--2`)
- `.gitignore` — exclude runtime `.rubric-cache/`

## Verification
- Unit tests pin the anchor preference order and both rubric guards
- Poisoned cache entry purged; framework suite green

Stacked on `stg-2671-v4-harness`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ground rubric grading in harness-observed artifacts so the verifier uses a real final screenshot and URL for `v4_code`/`playwright_code`/`cdp_code`. Also guard the rubric cache against empty rubrics that disabled grading; part of STG-2671.

- New Features
  - `claudeCodeRunner`: capture terminal page state (screenshot + URL) via the tool surface after the agent finishes, and pass it into the trajectory.
  - `claudeCodeAdapter`: prefer the harness terminal artifact for the final observation; fall back to the latest agent-returned image (e.g., `browse_cli`).

- Bug Fixes
  - `rubricCache`: never read or persist empty rubrics; treat as a cache miss and regenerate.
  - Tests: add coverage for anchor preference and empty-rubric guards; ignore `.rubric-cache/`.

<sup>Written for commit 98bdf3ccdd3c085d2e38c111f076825e1127a57a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

