### PR TITLE
fix(core): cancel timed-out actions

### DIFF
--- a/.changeset/tidy-cats-cancel.md
+++ b/.changeset/tidy-cats-cancel.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Cancel timed-out browser and model operations and prevent late browser actions from running after a timeout.

--- a/packages/core/lib/inference.ts
+++ b/packages/core/lib/inference.ts
@@ -23,9 +23,12 @@ import { StagehandInvalidArgumentError } from "./v3/types/public/sdkErrors.js";
 // Re-export for backward compatibility
 export type { LLMParsedResponse, LLMUsage } from "./v3/llm/LLMClient.js";
 
-function withLlmTimeout<T>(promise: Promise<T>, operation: string): Promise<T> {
+function withLlmTimeout<T>(
+  inference: () => Promise<T>,
+  operation: string,
+): Promise<T> {
   return withTimeout(
-    promise,
+    inference,
     getEnvTimeoutMs("LLM_MAX_MS"),
     `LLM ${operation}`,
   );
@@ -107,19 +110,20 @@ export async function extract<T extends StagehandZodObject>({
 
   const extractStartTime = Date.now();
   const extractionResponse = await withLlmTimeout(
-    llmClient.createChatCompletion<ExtractionResponse>({
-      options: {
-        messages: extractCallMessages,
-        response_model: {
-          schema,
-          name: "Extraction",
+    () =>
+      llmClient.createChatCompletion<ExtractionResponse>({
+        options: {
+          messages: extractCallMessages,
+          response_model: {
+            schema,
+            name: "Extraction",
+          },
+          top_p: 1,
+          frequency_penalty: 0,
+          presence_penalty: 0,
         },
-        top_p: 1,
-        frequency_penalty: 0,
-        presence_penalty: 0,
-      },
-      logger,
-    }),
+        logger,
+      }),
     "extract",
   );
   const extractEndTime = Date.now();
@@ -173,19 +177,20 @@ export async function extract<T extends StagehandZodObject>({
 
   const metadataStartTime = Date.now();
   const metadataResponse = await withLlmTimeout(
-    llmClient.createChatCompletion<MetadataResponse>({
-      options: {
-        messages: metadataCallMessages,
-        response_model: {
-          name: "Metadata",
-          schema: metadataSchema,
+    () =>
+      llmClient.createChatCompletion<MetadataResponse>({
+        options: {
+          messages: metadataCallMessages,
+          response_model: {
+            name: "Metadata",
+            schema: metadataSchema,
+          },
+          top_p: 1,
+          frequency_penalty: 0,
+          presence_penalty: 0,
         },
-        top_p: 1,
-        frequency_penalty: 0,
-        presence_penalty: 0,
-      },
-      logger,
-    }),
+        logger,
+      }),
     "extract metadata",
   );
   const metadataEndTime = Date.now();

--- a/packages/core/lib/v3/agent/tools/braveSearch.ts
+++ b/packages/core/lib/v3/agent/tools/braveSearch.ts
@@ -1,6 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import type { V3 } from "../../v3.js";
+import { getActiveAbortSignal } from "../../cancellation.js";
 
 export interface BraveSearchResult {
   title: string;
@@ -38,6 +39,7 @@ async function performBraveSearch(query: string): Promise<SearchResponse> {
       `https://api.search.brave.com/res/v1/web/search?q=${encodedQuery}`,
       {
         method: "GET",
+        signal: getActiveAbortSignal(),
         headers: {
           Accept: "application/json",
           "Accept-Encoding": "gzip",

--- a/packages/core/lib/v3/agent/tools/browserbaseSearch.ts
+++ b/packages/core/lib/v3/agent/tools/browserbaseSearch.ts
@@ -1,6 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import type { V3 } from "../../v3.js";
+import { getActiveAbortSignal } from "../../cancellation.js";
 
 export interface SearchResult {
   title: string;
@@ -27,6 +28,7 @@ async function performBrowserbaseSearch(
   try {
     const response = await fetch("https://api.browserbase.com/v1/search", {
       method: "POST",
+      signal: getActiveAbortSignal(),
       headers: {
         "Content-Type": "application/json",
         "x-bb-api-key": apiKey,

--- a/packages/core/lib/v3/agent/tools/index.ts
+++ b/packages/core/lib/v3/agent/tools/index.ts
@@ -122,7 +122,15 @@ function wrapToolWithTimeout<T extends Record<string, any>>(
     ...agentTool,
     execute: async (...args: unknown[]) => {
       try {
-        return await withTimeout(originalExecute(...args), timeoutMs, toolName);
+        const executionOptions = args[1] as
+          | { abortSignal?: AbortSignal }
+          | undefined;
+        return await withTimeout(
+          () => originalExecute(...args),
+          timeoutMs,
+          toolName,
+          { signal: executionOptions?.abortSignal },
+        );
       } catch (error) {
         if (error instanceof TimeoutError) {
           const message = `TimeoutError: ${error.message}${timeoutHint ? ` ${timeoutHint}` : ""}`;
@@ -151,11 +159,10 @@ export function createAgentTools(v3: V3, options?: V3AgentToolOptions) {
   const toolTimeout = options?.toolTimeout;
 
   const timeoutHints: Record<string, string> = {
-    act: "(it may continue executing in the background) — try using a different description for the action",
+    act: "— try using a different description for the action",
     ariaTree: "— the page may be too large",
     extract: "— try using a smaller or simpler schema",
-    fillForm:
-      "(it may continue executing in the background) — try filling fewer fields at once or use a different tool",
+    fillForm: "— try filling fewer fields at once or use a different tool",
   };
 
   const unwrappedTools: ToolSet = {

--- a/packages/core/lib/v3/api.ts
+++ b/packages/core/lib/v3/api.ts
@@ -37,6 +37,7 @@ import type {
 import type { ModelConfiguration } from "./types/public/model.js";
 import { toJsonSchema } from "./zodCompat.js";
 import type { StagehandZodSchema } from "./zodCompat.js";
+import { combineAbortSignals, getActiveAbortSignal } from "./cancellation.js";
 
 // =============================================================================
 // Multi-region API URL mapping
@@ -974,6 +975,7 @@ export class StagehandAPIClient {
 
     const response = await this.fetchWithCookies(`${baseUrl}${path}`, {
       ...options,
+      signal: combineAbortSignals(getActiveAbortSignal(), options.signal),
       headers: {
         ...defaultHeaders,
         ...options.headers,

--- a/packages/core/lib/v3/cache/ActCache.ts
+++ b/packages/core/lib/v3/cache/ActCache.ts
@@ -281,7 +281,7 @@ export class ActCache {
       };
     };
 
-    return await withTimeout(execute(), timeout, "act()");
+    return await withTimeout(() => execute(), timeout, "act()");
   }
 
   private haveActionsChanged(original: Action[], updated: Action[]): boolean {

--- a/packages/core/lib/v3/cancellation.ts
+++ b/packages/core/lib/v3/cancellation.ts
@@ -1,0 +1,55 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+const abortSignalStorage = new AsyncLocalStorage<AbortSignal | undefined>();
+
+export function getActiveAbortSignal(): AbortSignal | undefined {
+  return abortSignalStorage.getStore();
+}
+
+export function runWithAbortSignal<T>(
+  signal: AbortSignal | undefined,
+  operation: () => T,
+): T {
+  return abortSignalStorage.run(signal, operation);
+}
+
+export function runWithoutAbortSignal<T>(operation: () => T): T {
+  return abortSignalStorage.run(undefined, operation);
+}
+
+export function combineAbortSignals(
+  ...signals: Array<AbortSignal | null | undefined>
+): AbortSignal | undefined {
+  const activeSignals = signals.filter(
+    (signal): signal is AbortSignal => signal !== undefined && signal !== null,
+  );
+  if (activeSignals.length === 0) return undefined;
+  if (activeSignals.length === 1) return activeSignals[0];
+  return AbortSignal.any(activeSignals);
+}
+
+export function throwIfAborted(
+  signal: AbortSignal | undefined = getActiveAbortSignal(),
+): void {
+  signal?.throwIfAborted();
+}
+
+export async function raceWithAbort<T>(
+  promise: Promise<T>,
+  signal: AbortSignal | undefined = getActiveAbortSignal(),
+): Promise<T> {
+  if (!signal) return await promise;
+  signal.throwIfAborted();
+
+  let onAbort: (() => void) | undefined;
+  const aborted = new Promise<never>((_, reject) => {
+    onAbort = () => reject(signal.reason);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+
+  try {
+    return await Promise.race([promise, aborted]);
+  } finally {
+    if (onAbort) signal.removeEventListener("abort", onAbort);
+  }
+}

--- a/packages/core/lib/v3/handlers/actHandler.ts
+++ b/packages/core/lib/v3/handlers/actHandler.ts
@@ -26,6 +26,7 @@ import {
 } from "./handlerUtils/actHandlerUtils.js";
 import { createTimeoutGuard } from "./handlerUtils/timeoutGuard.js";
 import { resolveVariableValue } from "../agent/utils/variables.js";
+import { withTimeout } from "../timeoutConfig.js";
 
 type ActInferenceElement = {
   elementId?: string;
@@ -135,6 +136,17 @@ export class ActHandler {
   }
 
   async act(params: ActHandlerParams): Promise<ActResult> {
+    return await withTimeout(
+      () => this.actWithCancellation(params),
+      params.timeout,
+      "act()",
+      { errorFactory: (ms) => new ActTimeoutError(ms) },
+    );
+  }
+
+  private async actWithCancellation(
+    params: ActHandlerParams,
+  ): Promise<ActResult> {
     const { instruction, page, variables, timeout, model } = params;
 
     const llmClient = this.resolveLlmClient(model);

--- a/packages/core/lib/v3/handlers/extractHandler.ts
+++ b/packages/core/lib/v3/handlers/extractHandler.ts
@@ -32,6 +32,7 @@ import type {
   StagehandZodObject,
   StagehandZodSchema,
 } from "../zodCompat.js";
+import { withTimeout } from "../timeoutConfig.js";
 
 /**
  * Scans the provided Zod schema for any `z.string().url()` fields and
@@ -107,6 +108,17 @@ export class ExtractHandler {
   }
 
   async extract<T extends StagehandZodSchema>(
+    params: ExtractHandlerParams<T>,
+  ): Promise<InferStagehandSchema<T> | { pageText: string }> {
+    return await withTimeout(
+      () => this.extractWithCancellation(params),
+      params.timeout,
+      "extract()",
+      { errorFactory: (ms) => new ExtractTimeoutError(ms) },
+    );
+  }
+
+  private async extractWithCancellation<T extends StagehandZodSchema>(
     params: ExtractHandlerParams<T>,
   ): Promise<InferStagehandSchema<T> | { pageText: string }> {
     const {

--- a/packages/core/lib/v3/handlers/handlerUtils/timeoutGuard.ts
+++ b/packages/core/lib/v3/handlers/handlerUtils/timeoutGuard.ts
@@ -1,4 +1,5 @@
 import { TimeoutError } from "../../types/public/sdkErrors.js";
+import { throwIfAborted } from "../../cancellation.js";
 
 export type TimeoutGuard = () => void;
 
@@ -7,11 +8,12 @@ export function createTimeoutGuard(
   errorFactory?: (timeoutMs: number) => Error,
 ): TimeoutGuard {
   if (!timeoutMs || timeoutMs <= 0) {
-    return () => {};
+    return () => throwIfAborted();
   }
 
   const startTime = Date.now();
   return () => {
+    throwIfAborted();
     if (Date.now() - startTime >= timeoutMs) {
       const err =
         errorFactory?.(timeoutMs) ?? new TimeoutError("operation", timeoutMs);

--- a/packages/core/lib/v3/handlers/observeHandler.ts
+++ b/packages/core/lib/v3/handlers/observeHandler.ts
@@ -18,6 +18,7 @@ import {
 } from "../types/public/model.js";
 import { ObserveTimeoutError } from "../types/public/sdkErrors.js";
 import { createTimeoutGuard } from "./handlerUtils/timeoutGuard.js";
+import { withTimeout } from "../timeoutConfig.js";
 
 export class ObserveHandler {
   private readonly llmClient: LLMClient;
@@ -64,6 +65,17 @@ export class ObserveHandler {
   }
 
   async observe(params: ObserveHandlerParams): Promise<Action[]> {
+    return await withTimeout(
+      () => this.observeWithCancellation(params),
+      params.timeout,
+      "observe()",
+      { errorFactory: (ms) => new ObserveTimeoutError(ms) },
+    );
+  }
+
+  private async observeWithCancellation(
+    params: ObserveHandlerParams,
+  ): Promise<Action[]> {
     const {
       instruction,
       page,

--- a/packages/core/lib/v3/llm/AnthropicClient.ts
+++ b/packages/core/lib/v3/llm/AnthropicClient.ts
@@ -17,6 +17,7 @@ import {
 } from "./LLMClient.js";
 import { CreateChatCompletionResponseError } from "../types/public/sdkErrors.js";
 import { toJsonSchema } from "../zodCompat.js";
+import { getActiveAbortSignal } from "../cancellation.js";
 
 export class AnthropicClient extends LLMClient {
   public type = "anthropic" as const;
@@ -165,7 +166,7 @@ export class AnthropicClient extends LLMClient {
       anthropicTools.push(toolDefinition);
     }
 
-    const response = await this.client.messages.create({
+    const request = {
       model: this.modelName,
       max_tokens: options.maxOutputTokens || 8192,
       messages: formattedMessages,
@@ -174,7 +175,11 @@ export class AnthropicClient extends LLMClient {
         ? (systemMessage.content as string | TextBlockParam[]) // we can cast because we already filtered out image content
         : undefined,
       temperature: options.temperature,
-    });
+    };
+    const signal = getActiveAbortSignal();
+    const response = await (signal
+      ? this.client.messages.create(request, { signal })
+      : this.client.messages.create(request));
 
     logger({
       category: "anthropic",

--- a/packages/core/lib/v3/llm/CerebrasClient.ts
+++ b/packages/core/lib/v3/llm/CerebrasClient.ts
@@ -10,6 +10,7 @@ import {
 } from "./LLMClient.js";
 import { CreateChatCompletionResponseError } from "../types/public/sdkErrors.js";
 import { toJsonSchema } from "../zodCompat.js";
+import { getActiveAbortSignal } from "../cancellation.js";
 
 export class CerebrasClient extends LLMClient {
   public type = "cerebras" as const;
@@ -126,7 +127,7 @@ export class CerebrasClient extends LLMClient {
 
     try {
       // Use OpenAI client with Cerebras API
-      const apiResponse = await this.client.chat.completions.create({
+      const request = {
         model: this.modelName.split("cerebras-")[1],
         messages: [
           ...formattedMessages,
@@ -146,7 +147,11 @@ export class CerebrasClient extends LLMClient {
         max_tokens: options.maxOutputTokens,
         tools: tools,
         tool_choice: options.tool_choice || "auto",
-      });
+      };
+      const signal = getActiveAbortSignal();
+      const apiResponse = await (signal
+        ? this.client.chat.completions.create(request, { signal })
+        : this.client.chat.completions.create(request));
 
       // Format the response to match the expected LLMResponse format
       const response: LLMResponse = {

--- a/packages/core/lib/v3/llm/GoogleClient.ts
+++ b/packages/core/lib/v3/llm/GoogleClient.ts
@@ -25,6 +25,7 @@ import {
   LLMResponse,
   AnnotatedScreenshotText,
 } from "./LLMClient.js";
+import { getActiveAbortSignal } from "../cancellation.js";
 import {
   CreateChatCompletionResponseError,
   StagehandError,
@@ -262,6 +263,9 @@ export class GoogleClient extends LLMClient {
       contents: formattedMessages,
       config: {
         ...generationConfig,
+        ...(getActiveAbortSignal()
+          ? { abortSignal: getActiveAbortSignal() }
+          : {}),
         safetySettings: safetySettings,
         tools: formattedTools,
       },
@@ -416,6 +420,7 @@ export class GoogleClient extends LLMClient {
 
       return llmResponse as T;
     } catch (error) {
+      getActiveAbortSignal()?.throwIfAborted();
       logger({
         category: "google",
         message: `Error during Google AI chat completion: ${error.message}`,

--- a/packages/core/lib/v3/llm/GroqClient.ts
+++ b/packages/core/lib/v3/llm/GroqClient.ts
@@ -10,6 +10,7 @@ import {
 } from "./LLMClient.js";
 import { CreateChatCompletionResponseError } from "../types/public/sdkErrors.js";
 import { toJsonSchema } from "../zodCompat.js";
+import { getActiveAbortSignal } from "../cancellation.js";
 
 export class GroqClient extends LLMClient {
   public type = "groq" as const;
@@ -126,7 +127,7 @@ export class GroqClient extends LLMClient {
 
     try {
       // Use OpenAI client with Groq API
-      const apiResponse = await this.client.chat.completions.create({
+      const request = {
         model: this.modelName.split("groq-")[1],
         messages: [
           ...formattedMessages,
@@ -146,7 +147,11 @@ export class GroqClient extends LLMClient {
         max_tokens: options.maxOutputTokens,
         tools: tools,
         tool_choice: options.tool_choice || "auto",
-      });
+      };
+      const signal = getActiveAbortSignal();
+      const apiResponse = await (signal
+        ? this.client.chat.completions.create(request, { signal })
+        : this.client.chat.completions.create(request));
 
       // Format the response to match the expected LLMResponse format
       const response: LLMResponse = {

--- a/packages/core/lib/v3/llm/OpenAIClient.ts
+++ b/packages/core/lib/v3/llm/OpenAIClient.ts
@@ -24,6 +24,7 @@ import {
   ZodSchemaValidationError,
 } from "../types/public/sdkErrors.js";
 import { toJsonSchema } from "../zodCompat.js";
+import { getActiveAbortSignal } from "../cancellation.js";
 
 export class OpenAIClient extends LLMClient {
   public type = "openai" as const;
@@ -292,7 +293,10 @@ export class OpenAIClient extends LLMClient {
       })),
     };
 
-    const response = await this.client.chat.completions.create(body);
+    const signal = getActiveAbortSignal();
+    const response = await (signal
+      ? this.client.chat.completions.create(body, { signal })
+      : this.client.chat.completions.create(body));
 
     // For O1 models, we need to parse the tool call response manually and add it to the response.
     if (isToolsOverridedForO1) {

--- a/packages/core/lib/v3/llm/aisdk.ts
+++ b/packages/core/lib/v3/llm/aisdk.ts
@@ -23,6 +23,7 @@ import {
   extractLlmPromptSummary,
 } from "../flowlogger/FlowLogger.js";
 import { toJsonSchema } from "../zodCompat.js";
+import { getActiveAbortSignal } from "../cancellation.js";
 
 type ProviderOptionValue = JSONValue;
 type ProviderOptionMap = Record<string, ProviderOptionValue>;
@@ -251,6 +252,9 @@ You must respond in JSON format. respond WITH JSON. Do not include any other tex
           model: this.model,
           messages: formattedMessages,
           schema: options.response_model.schema,
+          ...(getActiveAbortSignal()
+            ? { abortSignal: getActiveAbortSignal() }
+            : {}),
           temperature,
           allowSystemInMessages: true,
           ...(Object.keys(providerOptions).length > 0
@@ -374,6 +378,9 @@ You must respond in JSON format. respond WITH JSON. Do not include any other tex
       textResponse = await generateText({
         model: this.model,
         messages: formattedMessages,
+        ...(getActiveAbortSignal()
+          ? { abortSignal: getActiveAbortSignal() }
+          : {}),
         tools: Object.keys(tools).length > 0 ? tools : undefined,
         toolChoice:
           Object.keys(tools).length > 0

--- a/packages/core/lib/v3/timeoutConfig.ts
+++ b/packages/core/lib/v3/timeoutConfig.ts
@@ -1,4 +1,18 @@
 import { TimeoutError } from "./types/public/sdkErrors.js";
+import {
+  combineAbortSignals,
+  getActiveAbortSignal,
+  runWithAbortSignal,
+} from "./cancellation.js";
+
+type TimeoutOperation<T> =
+  | Promise<T>
+  | ((signal: AbortSignal | undefined) => Promise<T>);
+
+export interface WithTimeoutOptions {
+  signal?: AbortSignal;
+  errorFactory?: (timeoutMs: number) => Error;
+}
 
 export function getEnvTimeoutMs(name: string): number | undefined {
   const raw = process.env[name];
@@ -10,27 +24,64 @@ export function getEnvTimeoutMs(name: string): number | undefined {
 }
 
 export async function withTimeout<T>(
-  promise: Promise<T>,
+  operationPromise: TimeoutOperation<T>,
   timeoutMs: number | null | undefined,
   operation: string,
+  options: WithTimeoutOptions = {},
 ): Promise<T> {
+  const parentSignal = combineAbortSignals(
+    getActiveAbortSignal(),
+    options.signal,
+  );
+
   if (
     typeof timeoutMs !== "number" ||
     !Number.isFinite(timeoutMs) ||
     timeoutMs <= 0
   ) {
-    return await promise;
+    parentSignal?.throwIfAborted();
+    return await runWithAbortSignal(parentSignal, () =>
+      typeof operationPromise === "function"
+        ? operationPromise(parentSignal)
+        : operationPromise,
+    );
   }
 
+  const timeoutController = new AbortController();
+  const signal = combineAbortSignals(parentSignal, timeoutController.signal);
   let timeoutId: NodeJS.Timeout | undefined;
   const timeoutPromise = new Promise<never>((_, reject) => {
     timeoutId = setTimeout(() => {
-      reject(new TimeoutError(operation, timeoutMs));
+      const error =
+        options.errorFactory?.(timeoutMs) ??
+        new TimeoutError(operation, timeoutMs);
+      timeoutController.abort(error);
+      reject(error);
     }, timeoutMs);
   });
+
+  let onAbort: (() => void) | undefined;
+  const abortPromise = signal
+    ? new Promise<never>((_, reject) => {
+        onAbort = () => reject(signal.reason);
+        signal.addEventListener("abort", onAbort, { once: true });
+      })
+    : undefined;
+
   try {
-    return await Promise.race([promise, timeoutPromise]);
+    signal?.throwIfAborted();
+    const runningOperation = runWithAbortSignal(signal, () =>
+      typeof operationPromise === "function"
+        ? operationPromise(signal)
+        : operationPromise,
+    );
+    return await Promise.race([
+      runningOperation,
+      timeoutPromise,
+      ...(abortPromise ? [abortPromise] : []),
+    ]);
   } finally {
     if (timeoutId) clearTimeout(timeoutId);
+    if (signal && onAbort) signal.removeEventListener("abort", onAbort);
   }
 }

--- a/packages/core/lib/v3/understudy/cdp.ts
+++ b/packages/core/lib/v3/understudy/cdp.ts
@@ -11,6 +11,7 @@ import {
   CdpConnectionClosedError,
   PageNotFoundError,
 } from "../types/public/sdkErrors.js";
+import { getActiveAbortSignal } from "../cancellation.js";
 
 /**
  * CDP transport & session multiplexer
@@ -142,6 +143,9 @@ export class CdpConnection implements CDPSessionLike {
   }
 
   async send<R = unknown>(method: string, params?: object): Promise<R> {
+    const signal = getActiveAbortSignal();
+    signal?.throwIfAborted();
+
     const id = this.nextId++;
     const payload = { id, method, params };
     const stack = new Error().stack?.split("\n").slice(1, 4).join("\n");
@@ -450,6 +454,9 @@ export class CdpConnection implements CDPSessionLike {
     method: string,
     params?: object,
   ): Promise<R> {
+    const signal = getActiveAbortSignal();
+    signal?.throwIfAborted();
+
     const id = this.nextId++;
     const payload = { id, method, params, sessionId };
     const stack = new Error().stack?.split("\n").slice(1, 4).join("\n");

--- a/packages/core/lib/v3/understudy/page.ts
+++ b/packages/core/lib/v3/understudy/page.ts
@@ -62,6 +62,11 @@ import {
 } from "./screenshotUtils.js";
 import { InitScriptSource } from "../types/private/index.js";
 import { withTimeout } from "../timeoutConfig.js";
+import {
+  getActiveAbortSignal,
+  raceWithAbort,
+  runWithoutAbortSignal,
+} from "../cancellation.js";
 
 /**
  * Page
@@ -1209,6 +1214,9 @@ export class Page {
       timeoutMs: timeout,
       navigationCommandId,
     });
+    const removeAbortHandler = this.stopLoadingWhenAborted(
+      getActiveAbortSignal(),
+    );
 
     try {
       // Route to API if available
@@ -1238,9 +1246,10 @@ export class Page {
         watcher.setExpectedLoaderId(response.loaderId);
         tracker.setExpectedLoaderId(response.loaderId);
       }
-      await watcher.wait();
-      return await tracker.navigationCompleted();
+      await raceWithAbort(watcher.wait());
+      return await raceWithAbort(tracker.navigationCompleted());
     } finally {
+      removeAbortHandler();
       watcher.dispose();
       tracker.dispose();
     }
@@ -1277,6 +1286,9 @@ export class Page {
           navigationCommandId,
         })
       : null;
+    const removeAbortHandler = this.stopLoadingWhenAborted(
+      getActiveAbortSignal(),
+    );
 
     try {
       await this.mainSession.send("Page.reload", {
@@ -1284,10 +1296,11 @@ export class Page {
       });
 
       if (watcher) {
-        await watcher.wait();
+        await raceWithAbort(watcher.wait());
       }
-      return await tracker.navigationCompleted();
+      return await raceWithAbort(tracker.navigationCompleted());
     } finally {
+      removeAbortHandler();
       watcher?.dispose();
       tracker.dispose();
     }
@@ -1329,6 +1342,9 @@ export class Page {
           navigationCommandId,
         })
       : null;
+    const removeAbortHandler = this.stopLoadingWhenAborted(
+      getActiveAbortSignal(),
+    );
 
     try {
       await this.mainSession.send("Page.navigateToHistoryEntry", {
@@ -1337,10 +1353,11 @@ export class Page {
       this._currentUrl = prev.url ?? this._currentUrl;
 
       if (watcher) {
-        await watcher.wait();
+        await raceWithAbort(watcher.wait());
       }
-      return await tracker.navigationCompleted();
+      return await raceWithAbort(tracker.navigationCompleted());
     } finally {
+      removeAbortHandler();
       watcher?.dispose();
       tracker.dispose();
     }
@@ -1384,6 +1401,9 @@ export class Page {
           navigationCommandId,
         })
       : null;
+    const removeAbortHandler = this.stopLoadingWhenAborted(
+      getActiveAbortSignal(),
+    );
 
     try {
       await this.mainSession.send("Page.navigateToHistoryEntry", {
@@ -1392,10 +1412,11 @@ export class Page {
       this._currentUrl = next.url ?? this._currentUrl;
 
       if (watcher) {
-        await watcher.wait();
+        await raceWithAbort(watcher.wait());
       }
-      return await tracker.navigationCompleted();
+      return await raceWithAbort(tracker.navigationCompleted());
     } finally {
+      removeAbortHandler();
       watcher?.dispose();
       tracker.dispose();
     }
@@ -1412,6 +1433,18 @@ export class Page {
     const id = ++this.navigationCommandSeq;
     this.latestNavigationCommandId = id;
     return id;
+  }
+
+  private stopLoadingWhenAborted(signal?: AbortSignal): () => void {
+    if (!signal) return () => {};
+
+    const stopLoading = () => {
+      runWithoutAbortSignal(() => {
+        void this.mainSession.send("Page.stopLoading").catch(() => {});
+      });
+    };
+    signal.addEventListener("abort", stopLoading, { once: true });
+    return () => signal.removeEventListener("abort", stopLoading);
   }
 
   public isCurrentNavigationCommand(id: number): boolean {
@@ -1563,7 +1596,7 @@ export class Page {
       }
     };
 
-    return await withTimeout(exec(), opts.timeout, "screenshot");
+    return await withTimeout(() => exec(), opts.timeout, "screenshot");
   }
 
   /**
@@ -2067,32 +2100,53 @@ export class Page {
       clickCount: 1,
     } as Protocol.Input.DispatchMouseEventRequest);
 
-    // Intermediate moves
-    for (let i = 1; i <= steps; i++) {
-      const t = i / steps;
-      const x = fromX + (toX - fromX) * t;
-      const y = fromY + (toY - fromY) * t;
-      await this.updateCursor(x, y);
+    let releaseNeeded = true;
+    let currentX = fromX;
+    let currentY = fromY;
+    try {
+      // Intermediate moves
+      for (let i = 1; i <= steps; i++) {
+        const t = i / steps;
+        currentX = fromX + (toX - fromX) * t;
+        currentY = fromY + (toY - fromY) * t;
+        await this.updateCursor(currentX, currentY);
+        await this.mainSession.send<never>("Input.dispatchMouseEvent", {
+          type: "mouseMoved",
+          x: currentX,
+          y: currentY,
+          button,
+          buttons: buttonMask(button),
+        } as Protocol.Input.DispatchMouseEventRequest);
+        if (delay) await raceWithAbort(sleep(delay));
+      }
+
+      // Release at end
+      await this.updateCursor(toX, toY);
       await this.mainSession.send<never>("Input.dispatchMouseEvent", {
-        type: "mouseMoved",
-        x,
-        y,
+        type: "mouseReleased",
+        x: toX,
+        y: toY,
         button,
         buttons: buttonMask(button),
+        clickCount: 1,
       } as Protocol.Input.DispatchMouseEventRequest);
-      if (delay) await sleep(delay);
+      releaseNeeded = false;
+    } finally {
+      if (releaseNeeded) {
+        await runWithoutAbortSignal(() =>
+          this.mainSession
+            .send<never>("Input.dispatchMouseEvent", {
+              type: "mouseReleased",
+              x: currentX,
+              y: currentY,
+              button,
+              buttons: buttonMask(button),
+              clickCount: 1,
+            } as Protocol.Input.DispatchMouseEventRequest)
+            .catch(() => {}),
+        );
+      }
     }
-
-    // Release at end
-    await this.updateCursor(toX, toY);
-    await this.mainSession.send<never>("Input.dispatchMouseEvent", {
-      type: "mouseReleased",
-      x: toX,
-      y: toY,
-      button,
-      buttons: buttonMask(button),
-      clickCount: 1,
-    } as Protocol.Input.DispatchMouseEventRequest);
 
     return [fromXpath ?? "", toXpath ?? ""];
   }
@@ -2130,10 +2184,22 @@ export class Page {
           windowsVirtualKeyCode: override.windowsVirtualKeyCode,
         } as Protocol.Input.DispatchKeyEventRequest;
         await this.mainSession.send("Input.dispatchKeyEvent", base);
-        await this.mainSession.send("Input.dispatchKeyEvent", {
-          ...base,
-          type: "keyUp",
-        } as Protocol.Input.DispatchKeyEventRequest);
+        try {
+          await this.mainSession.send("Input.dispatchKeyEvent", {
+            ...base,
+            type: "keyUp",
+          } as Protocol.Input.DispatchKeyEventRequest);
+        } catch (error) {
+          await runWithoutAbortSignal(() =>
+            this.mainSession
+              .send("Input.dispatchKeyEvent", {
+                ...base,
+                type: "keyUp",
+              } as Protocol.Input.DispatchKeyEventRequest)
+              .catch(() => {}),
+          );
+          throw error;
+        }
         return;
       }
 
@@ -2170,12 +2236,20 @@ export class Page {
         windowsVirtualKeyCode,
       };
       await this.mainSession.send("Input.dispatchKeyEvent", down);
-      await this.mainSession.send("Input.dispatchKeyEvent", {
+      const up = {
         type: "keyUp",
         key,
         code: code || undefined,
         windowsVirtualKeyCode,
-      } as Protocol.Input.DispatchKeyEventRequest);
+      } as Protocol.Input.DispatchKeyEventRequest;
+      try {
+        await this.mainSession.send("Input.dispatchKeyEvent", up);
+      } catch (error) {
+        await runWithoutAbortSignal(() =>
+          this.mainSession.send("Input.dispatchKeyEvent", up).catch(() => {}),
+        );
+        throw error;
+      }
     };
 
     const pressBackspace = async () =>
@@ -2214,14 +2288,14 @@ export class Page {
           // Type a wrong character, then backspace to correct
           const wrong = randomPrintable(ch);
           await keyStroke(wrong);
-          if (delay) await sleep(delay);
+          if (delay) await raceWithAbort(sleep(delay));
           await pressBackspace();
-          if (delay) await sleep(delay);
+          if (delay) await raceWithAbort(sleep(delay));
         }
         await keyStroke(ch);
       }
 
-      if (delay) await sleep(delay);
+      if (delay) await raceWithAbort(sleep(delay));
     }
   }
 
@@ -2263,20 +2337,29 @@ export class Page {
     const mainKey = tokens[tokens.length - 1];
     const modifierKeys = tokens.slice(0, -1);
 
+    const pressedKeys: string[] = [];
     try {
       for (const modKey of modifierKeys) {
         await this.keyDown(modKey);
+        pressedKeys.push(modKey);
       }
 
       await this.keyDown(mainKey);
-      if (delay) await sleep(delay);
+      pressedKeys.push(mainKey);
+      if (delay) await raceWithAbort(sleep(delay));
       await this.keyUp(mainKey);
+      pressedKeys.pop();
 
       for (let i = modifierKeys.length - 1; i >= 0; i--) {
         await this.keyUp(modifierKeys[i]);
+        pressedKeys.pop();
       }
     } catch (error) {
-      // Clear stuck modifiers on error to prevent affecting subsequent keyPress calls
+      await runWithoutAbortSignal(async () => {
+        for (let i = pressedKeys.length - 1; i >= 0; i--) {
+          await this.keyUp(pressedKeys[i]).catch(() => {});
+        }
+      });
       this._pressedModifiers.clear();
       throw error;
     }

--- a/packages/core/lib/v3/v3.ts
+++ b/packages/core/lib/v3/v3.ts
@@ -96,7 +96,12 @@ import { FlowLogger, type FlowLoggerContext } from "./flowlogger/FlowLogger.js";
 import { EventEmitterWithWildcardSupport } from "./flowlogger/EventEmitter.js";
 import { EventStore } from "./flowlogger/EventStore.js";
 import { createTimeoutGuard } from "./handlers/handlerUtils/timeoutGuard.js";
-import { ActTimeoutError } from "./types/public/sdkErrors.js";
+import {
+  ActTimeoutError,
+  ExtractTimeoutError,
+  ObserveTimeoutError,
+} from "./types/public/sdkErrors.js";
+import { withTimeout } from "./timeoutConfig.js";
 
 const AUTO_MODEL_API_ONLY_MESSAGE = `model: "${AUTO_MODEL_NAME}" is only supported when running through the Stagehand API (env: "BROWSERBASE" with disableAPI: false and experimental: false). Specify a concrete model (e.g. "openai/gpt-5") instead.`;
 const DEFAULT_MODEL_NAME = "openai/gpt-4.1-mini";
@@ -1275,23 +1280,35 @@ export class V3 {
         // Use selector as provided to support XPath, CSS, and other engines
         const selector = input.selector;
         if (this.apiClient) {
-          actResult = await this.apiClient.act({
-            input,
-            options,
-            frameId: v3Page.mainFrameId(),
-          });
+          actResult = await withTimeout(
+            () =>
+              this.apiClient!.act({
+                input,
+                options,
+                frameId: v3Page.mainFrameId(),
+              }),
+            options?.timeout,
+            "act()",
+            { errorFactory: (ms) => new ActTimeoutError(ms) },
+          );
         } else {
           const ensureTimeRemaining = createTimeoutGuard(
             options?.timeout,
             (ms) => new ActTimeoutError(ms),
           );
-          actResult = await this.actHandler.takeDeterministicAction(
-            { ...input, selector },
-            v3Page,
-            this.domSettleTimeoutMs,
-            this.resolveLlmClient(options?.model),
-            ensureTimeRemaining,
-            options?.variables,
+          actResult = await withTimeout(
+            () =>
+              this.actHandler!.takeDeterministicAction(
+                { ...input, selector },
+                v3Page,
+                this.domSettleTimeoutMs,
+                this.resolveLlmClient(options?.model),
+                ensureTimeRemaining,
+                options?.variables,
+              ),
+            options?.timeout,
+            "act()",
+            { errorFactory: (ms) => new ActTimeoutError(ms) },
           );
         }
 
@@ -1366,7 +1383,12 @@ export class V3 {
       };
       if (this.apiClient) {
         const frameId = page.mainFrameId();
-        actResult = await this.apiClient.act({ input, options, frameId });
+        actResult = await withTimeout(
+          () => this.apiClient!.act({ input, options, frameId }),
+          options?.timeout,
+          "act()",
+          { errorFactory: (ms) => new ActTimeoutError(ms) },
+        );
       } else {
         actResult = await this.actHandler.act(handlerParams);
       }
@@ -1480,12 +1502,18 @@ export class V3 {
       let result: z.infer<typeof effectiveSchema> | { pageText: string };
       if (this.apiClient) {
         const frameId = page.mainFrameId();
-        result = await this.apiClient.extract({
-          instruction: handlerParams.instruction,
-          schema: handlerParams.schema,
-          options,
-          frameId,
-        });
+        result = await withTimeout(
+          () =>
+            this.apiClient!.extract({
+              instruction: handlerParams.instruction,
+              schema: handlerParams.schema,
+              options,
+              frameId,
+            }),
+          options?.timeout,
+          "extract()",
+          { errorFactory: (ms) => new ExtractTimeoutError(ms) },
+        );
       } else {
         result =
           await this.extractHandler.extract<StagehandZodSchema>(handlerParams);
@@ -1556,11 +1584,17 @@ export class V3 {
       let results: Action[];
       if (this.apiClient) {
         const frameId = page.mainFrameId();
-        results = await this.apiClient.observe({
-          instruction,
-          options,
-          frameId,
-        });
+        results = await withTimeout(
+          () =>
+            this.apiClient!.observe({
+              instruction,
+              options,
+              frameId,
+            }),
+          options?.timeout,
+          "observe()",
+          { errorFactory: (ms) => new ObserveTimeoutError(ms) },
+        );
       } else {
         results = await this.observeHandler.observe(handlerParams);
       }

--- a/packages/core/tests/integration/timeouts.spec.ts
+++ b/packages/core/tests/integration/timeouts.spec.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { closeV3 } from "./testUtils.js";
 import type { LLMClient } from "../../lib/v3/llm/LLMClient.js";
 import { generateText } from "ai";
+import { withTimeout } from "../../lib/v3/timeoutConfig.js";
 
 type AgentToolNameWithTimeout =
   | "act"
@@ -241,6 +242,36 @@ test.describe("V3 hard timeouts", () => {
     await expect(v3.act("do nothing", { timeout: 5 })).rejects.toThrow(
       /timed out/i,
     );
+  });
+
+  test("timed-out work cannot dispatch a late browser action", async () => {
+    const page = v3.context.pages()[0];
+    await page.goto(
+      `data:text/html,${encodeURIComponent(`
+        <button
+          style="position:fixed;inset:0;width:200px;height:200px"
+          onclick="window.clickCount += 1"
+        >click</button>
+        <script>window.clickCount = 0</script>
+      `)}`,
+    );
+
+    await expect(
+      withTimeout(
+        async () => {
+          await new Promise((resolve) => setTimeout(resolve, 30));
+          await page.click(50, 50);
+        },
+        5,
+        "delayed click",
+      ),
+    ).rejects.toThrow(/timed out/i);
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const clickCount = await page.evaluate(
+      () => (window as typeof window & { clickCount: number }).clickCount,
+    );
+    expect(clickCount).toBe(0);
   });
 
   test("agent toolTimeout enforces timeout for act tool", async () => {

--- a/packages/core/tests/unit/aisdk-clients.test.ts
+++ b/packages/core/tests/unit/aisdk-clients.test.ts
@@ -3,6 +3,8 @@ import { generateObject, generateText } from "ai";
 import { z } from "zod";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AISdkClient } from "../../lib/v3/llm/aisdk.js";
+import { withTimeout } from "../../lib/v3/timeoutConfig.js";
+import { TimeoutError } from "../../lib/v3/types/public/sdkErrors.js";
 
 vi.mock("ai", async () => {
   const actual = await vi.importActual<typeof import("ai")>("ai");
@@ -171,5 +173,43 @@ describe("AISdkClient allowSystemInMessages", () => {
     expect(mockGenerateText).toHaveBeenCalledWith(
       expect.objectContaining({ allowSystemInMessages: true }),
     );
+  });
+});
+
+describe("AISdkClient cancellation", () => {
+  it("passes the timeout signal to the provider request", async () => {
+    let providerSignal: AbortSignal | undefined;
+    mockGenerateText.mockImplementation(
+      ({ abortSignal }) =>
+        new Promise((_, reject) => {
+          providerSignal = abortSignal;
+          abortSignal?.addEventListener(
+            "abort",
+            () => reject(abortSignal.reason),
+            { once: true },
+          );
+        }),
+    );
+
+    const client = new AISdkClient({
+      model: createModel("openai/gpt-4.1"),
+      logger: vi.fn(),
+    });
+
+    await expect(
+      withTimeout(
+        () =>
+          client.createChatCompletion({
+            options: {
+              messages: [{ role: "user", content: "hello" }],
+            },
+            logger: vi.fn(),
+          }),
+        5,
+        "LLM request",
+      ),
+    ).rejects.toBeInstanceOf(TimeoutError);
+
+    expect(providerSignal?.aborted).toBe(true);
   });
 });

--- a/packages/core/tests/unit/cdp-connection-close.test.ts
+++ b/packages/core/tests/unit/cdp-connection-close.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
 import { WebSocketServer, type WebSocket as ServerWebSocket } from "ws";
 import { CdpConnection } from "../../lib/v3/understudy/cdp.js";
+import { withTimeout } from "../../lib/v3/timeoutConfig.js";
+import { TimeoutError } from "../../lib/v3/types/public/sdkErrors.js";
 
 type ConnectionInternals = {
   eventHandlers: Map<string, Set<unknown>>;
@@ -139,6 +141,33 @@ describe("CdpConnection", () => {
       );
 
       expect(result).toBe("rejected");
+    });
+  });
+
+  describe("cancelled CDP work", () => {
+    it("does not send a command reached after the operation times out", async () => {
+      const pair = await createPair();
+      wss = pair.wss;
+      const receivedCommand = vi.fn();
+      pair.serverSocket.on("message", receivedCommand);
+
+      const operation = withTimeout(
+        async () => {
+          await new Promise((resolve) => setTimeout(resolve, 30));
+          await pair.conn.send("Input.dispatchMouseEvent", {
+            type: "mousePressed",
+            x: 10,
+            y: 10,
+          });
+        },
+        5,
+        "click()",
+      );
+
+      await expect(operation).rejects.toBeInstanceOf(TimeoutError);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(receivedCommand).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/tests/unit/timeout-cancellation.test.ts
+++ b/packages/core/tests/unit/timeout-cancellation.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { withTimeout } from "../../lib/v3/timeoutConfig.js";
+import { TimeoutError } from "../../lib/v3/types/public/sdkErrors.js";
+
+const delay = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+describe("withTimeout cancellation", () => {
+  it("aborts cooperative work and prevents a delayed side effect", async () => {
+    const sideEffect = vi.fn();
+    let operationSignal: AbortSignal | undefined;
+
+    const operation = withTimeout(
+      (signal) =>
+        new Promise<void>((resolve, reject) => {
+          operationSignal = signal;
+          const timer = setTimeout(() => {
+            sideEffect();
+            resolve();
+          }, 50);
+          signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              reject(signal.reason);
+            },
+            { once: true },
+          );
+        }),
+      5,
+      "delayed action",
+    );
+
+    await expect(operation).rejects.toBeInstanceOf(TimeoutError);
+    expect(operationSignal?.aborted).toBe(true);
+
+    await delay(70);
+    expect(sideEffect).not.toHaveBeenCalled();
+  });
+
+  it("does not start an operation when its parent signal is already aborted", async () => {
+    const controller = new AbortController();
+    const reason = new Error("cancelled");
+    controller.abort(reason);
+    const operation = vi.fn(async () => "done");
+
+    await expect(
+      withTimeout(operation, 100, "operation", {
+        signal: controller.signal,
+      }),
+    ).rejects.toBe(reason);
+    expect(operation).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

  Stagehand’s timeout handling previously relied on `Promise.race()`. Although the caller received a `TimeoutError`, the underlying browser
  action, navigation, HTTP request, or model inference continued running.

  This could produce late side effects after an agent had already handled the timeout or started a retry. For example, a timed-out click or form
  submission could complete afterward, causing duplicate or out-of-order actions. Model requests could also continue consuming resources after
  their result was no longer usable.

  This PR changes timeouts from response-only deadlines into cooperative cancellation boundaries.

  ## What changed

  ### Introduce timeout-scoped cancellation

  `withTimeout()` now:

  - creates an `AbortController` for each active timeout;
  - aborts the controller with the appropriate timeout error when the deadline expires;
  - accepts lazy operation factories so the operation starts inside the cancellation context;
  - combines nested timeout signals with caller-provided signals;
  - preserves existing timeout error types and messages;
  - rejects immediately when a parent operation is already aborted.

  Cancellation context is propagated through `AsyncLocalStorage`, avoiding invasive `AbortSignal` parameters across every internal method while
  still allowing lower-level browser and provider integrations to inspect the active signal.

  The existing promise-based `withTimeout()` signature remains supported for compatibility, while cancellation-aware call sites now use the lazy
  factory form.

  ### Cancel agent tools and public handlers

  Timeout signals now cover:

  - agent tool execution;
  - `act()`;
  - `extract()`;
  - `observe()`;
  - deterministic cached actions;
  - screenshots;
  - local handler execution;
  - Stagehand API-backed handler calls.

  The AI SDK’s tool execution `abortSignal` is combined with the configured per-tool timeout, so cancellation from either the overall agent
  execution or the individual tool deadline reaches the underlying operation.

  Handler timeout guards also inspect the active signal at checkpoints, preventing processing from resuming after an aborted call settles.

  ### Cancel model inference

  The active signal is forwarded to supported provider requests:

  - OpenAI;
  - Anthropic;
  - Google;
  - Groq;
  - Cerebras;
  - AI SDK language models.

  This allows in-flight inference requests to terminate instead of continuing after Stagehand has discarded their result.

  The `LLM_MAX_MS` timeout path now starts inference within the cancellation context as well.

  ### Prevent late browser commands

  CDP command dispatch checks the active cancellation signal before sending a command. If a timed-out operation resumes later, it cannot issue
  additional clicks, keyboard input, DOM mutations, or other browser commands.

  Navigation methods additionally:

  - race lifecycle and response waits against cancellation;
  - send a best-effort `Page.stopLoading` when aborted;
  - dispose navigation watchers and abort listeners during cleanup.

  Commands already delivered to Chrome cannot be recalled. This PR therefore stops active navigation where possible and quarantines the
  remainder of an aborted operation so it cannot dispatch subsequent commands.

  ### Clean up partially completed input sequences

  Cancellation can occur between the two halves of a compound input operation. This PR adds best-effort cleanup for:

  - mouse press/release during drag and click-and-hold;
  - key down/up while typing;
  - modifier-key combinations.

  Abort-aware delays release held mouse buttons and keys promptly instead of leaving browser input state stuck.

  ### Cancel HTTP-backed tools

  The active signal is propagated to:

  - Stagehand API requests;
  - Browserbase search;
  - Brave search.

  This prevents timed-out search and API requests from continuing unnecessarily.

  ## Regression coverage

  Added tests verifying that:

  - timeout signals are aborted when the deadline expires;
  - an already-aborted parent prevents a nested operation from starting;
  - a cooperative operation cannot execute its delayed side effect;
  - a CDP command reached after timeout is never sent;
  - AI SDK provider requests receive the timeout signal;
  - a delayed browser click does not mutate the page after the caller receives `TimeoutError`.

  The browser regression waits long enough for the original delayed operation to resume and then verifies that the page click counter is still
  zero. This specifically covers the late-side-effect behavior that the previous tests missed.

  ## Validation

  Passed:

  - Core formatting
  - ESLint
  - TypeScript typecheck
  - ESM build
  - Focused timeout/provider/CDP tests: 45/45
  - Late browser-action regression: 1/1
  - Keyboard and drag-and-drop browser tests: 21/21

  The complete core unit run passes 885/889 tests. The remaining four failures are existing `flowlogger-eventstore` stderr-capture failures that
  reproduce when run independently and are unrelated to this change.

  The test report conversion step also prints an existing Node 24 `glob`/`minimatch` incompatibility after test execution; this does not affect
  the passing focused test results.

  ## Release impact

  Patch release. Existing public method signatures and timeout error behavior remain compatible.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turned timeouts into cooperative cancellation so timed‑out actions, navigations, HTTP calls, and model inferences stop immediately and can’t run late browser commands. This reduces flaky retries and wasted compute while keeping public APIs and timeout errors compatible.

- **New Features**
  - Added cancellation context via `withTimeout()` and `AbortController`; supports lazy factories and combines nested/caller signals.
  - Propagated active signals to agent tools and handlers (`act()`, `extract()`, `observe()`), screenshots, deterministic cached actions, and API/local handlers.
  - Forwarded signals to LLM providers (OpenAI, Anthropic, Google, Groq, Cerebras) and the AI SDK to cancel in‑flight inference.
  - CDP/navigation respect cancellation; aborted navigations race waits, send `Page.stopLoading`, and clean up watchers.
  - Best‑effort cleanup for partial input on abort (mouse press/drag, key down/up).

- **Bug Fixes**
  - Prevent late side effects after timeouts (e.g., delayed clicks or form submits).
  - Do not send CDP commands reached after an operation times out.
  - Cancel HTTP‑backed tools and Stagehand API requests (`browserbaseSearch`, `braveSearch`).
  - Added focused regression tests for signal propagation and late‑effect prevention.

<sup>Written for commit 629deed5317f99b836a7c6b6a4e6fa3eed35af12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

