### PR TITLE
fix(server-v3): synchronize in-memory sessions

### DIFF
--- a/packages/server-v3/src/lib/InMemorySessionStore.ts
+++ b/packages/server-v3/src/lib/InMemorySessionStore.ts
@@ -1,4 +1,5 @@
-import { randomUUID } from "crypto";
+import { AsyncLocalStorage } from "node:async_hooks";
+import { randomUUID } from "node:crypto";
 import type { V3Options, LogLine, Api } from "@browserbasehq/stagehand";
 import { V3 } from "@browserbasehq/stagehand";
 import type {
@@ -12,6 +13,11 @@ import type {
 const DEFAULT_MAX_CAPACITY = 100;
 const DEFAULT_TTL_MS = 0; // 0 = infinite (no TTL-based eviction)
 
+interface RequestLoggerScope {
+  logger?: (message: LogLine) => void;
+  active: boolean;
+}
+
 /**
  * Internal node for LRU linked list
  */
@@ -19,7 +25,9 @@ interface LruNode {
   sessionId: string;
   params: CreateSessionParams;
   stagehand: V3 | null;
-  loggerRef: { current?: (message: LogLine) => void };
+  initialization: Promise<V3> | null;
+  closePromise: Promise<void> | null;
+  deleted: boolean;
   expiry: number;
   prev: LruNode | null;
   next: LruNode | null;
@@ -51,7 +59,7 @@ export function withModelApiKeyFallback(
  * - LRU eviction when at capacity
  * - TTL-based expiration
  * - Lazy V3 instance creation
- * - Dynamic logger updates for streaming
+ * - Request-scoped streaming logs
  * - Automatic cleanup of evicted sessions
  *
  * This is the default implementation used when no custom store is provided.
@@ -64,6 +72,8 @@ export class InMemorySessionStore implements SessionStore {
   private maxCapacity: number;
   private ttlMs: number;
   private cleanupInterval: NodeJS.Timeout | null = null;
+  private mutationQueue: Promise<void> = Promise.resolve();
+  private readonly requestLogger = new AsyncLocalStorage<RequestLoggerScope>();
 
   constructor(config?: SessionCacheConfig) {
     this.maxCapacity = config?.maxCapacity ?? DEFAULT_MAX_CAPACITY;
@@ -72,54 +82,62 @@ export class InMemorySessionStore implements SessionStore {
   }
 
   /**
-   * Start periodic cleanup of expired sessions
+   * Serialize mutations to the map and LRU list. Browser shutdown happens
+   * after a node is detached so slow cleanup does not block unrelated sessions.
+   */
+  private async mutate<T>(operation: () => T): Promise<T> {
+    const result = this.mutationQueue.then(operation, operation);
+    this.mutationQueue = result.then(
+      (): void => undefined,
+      (): void => undefined,
+    );
+    return await result;
+  }
+
+  /**
+   * Start periodic cleanup of expired sessions.
    */
   private startCleanupInterval(): void {
-    // Run cleanup every minute
     this.cleanupInterval = setInterval(() => {
-      this.cleanupExpired();
+      void this.cleanupExpired().catch(console.error);
     }, 60_000);
-    // Allow process to exit gracefully even if this timer is still active
     this.cleanupInterval.unref();
   }
 
   /**
-   * Cleanup expired sessions
+   * Cleanup expired sessions.
    */
   private async cleanupExpired(): Promise<void> {
-    const now = Date.now();
-    const expiredIds: string[] = [];
+    const expired = await this.mutate(() => {
+      if (this.ttlMs <= 0) return [];
 
-    for (const [sessionId, node] of this.items.entries()) {
-      if (this.ttlMs > 0 && node.expiry <= now) {
-        expiredIds.push(sessionId);
+      const now = Date.now();
+      const nodes: LruNode[] = [];
+      for (const node of this.items.values()) {
+        if (node.expiry <= now) {
+          this.detachNode(node);
+          nodes.push(node);
+        }
       }
-    }
+      return nodes;
+    });
 
-    for (const sessionId of expiredIds) {
-      await this.deleteSession(sessionId);
-    }
+    await Promise.all(expired.map((node) => this.closeNode(node)));
   }
 
   /**
-   * Bump a node to the end of the LRU list (most recently used)
+   * Bump a node to the end of the LRU list (most recently used).
    */
   private bumpNode(node: LruNode): void {
-    // Update expiry
     node.expiry = this.ttlMs > 0 ? Date.now() + this.ttlMs : Infinity;
 
-    if (this.last === node) {
-      return; // Already most recent
-    }
+    if (this.last === node) return;
 
     const { prev, next } = node;
-
-    // Unlink from current position
     if (prev) prev.next = next;
     if (next) next.prev = prev;
     if (this.first === node) this.first = next;
 
-    // Link to end
     node.prev = this.last;
     node.next = null;
     if (this.last) this.last.next = node;
@@ -129,20 +147,104 @@ export class InMemorySessionStore implements SessionStore {
   }
 
   /**
-   * Evict the least recently used session
+   * Remove a node from cache state synchronously. Cleanup is deliberately
+   * separate because closing a browser may be slow.
    */
-  private async evictLru(): Promise<void> {
-    const lruNode = this.first;
-    if (!lruNode) return;
+  private detachNode(node: LruNode): void {
+    if (node.deleted) return;
 
-    await this.deleteSession(lruNode.sessionId);
+    node.deleted = true;
+    if (this.items.get(node.sessionId) === node) {
+      this.items.delete(node.sessionId);
+    }
+
+    const { prev, next } = node;
+    if (prev) prev.next = next;
+    if (next) next.prev = prev;
+    if (this.first === node) this.first = next;
+    if (this.last === node) this.last = prev;
+    node.prev = null;
+    node.next = null;
+  }
+
+  /**
+   * Close an initialized or initializing node exactly once.
+   */
+  private closeNode(node: LruNode): Promise<void> {
+    if (node.closePromise) return node.closePromise;
+
+    node.closePromise = (async () => {
+      if (node.initialization) {
+        try {
+          await node.initialization;
+        } catch {
+          // Initialization already performs best-effort cleanup on failure.
+        }
+      }
+
+      if (!node.stagehand) return;
+      try {
+        await node.stagehand.close();
+      } catch (error) {
+        console.error(
+          `Error closing stagehand for session ${node.sessionId}:`,
+          error,
+        );
+      } finally {
+        node.stagehand = null;
+      }
+    })();
+
+    return node.closePromise;
+  }
+
+  /**
+   * Initialize a node once. Concurrent callers share this promise.
+   */
+  private initializeNode(node: LruNode, ctx: RequestContext): Promise<V3> {
+    const initialization = this.runWithRequestContext(ctx, async () => {
+      const stagehand = this.createStagehand(
+        this.buildV3Options(node.params, ctx),
+      );
+      try {
+        await stagehand.init();
+      } catch (error) {
+        try {
+          await stagehand.close();
+        } catch {
+          // best-effort cleanup for failed init attempts
+        }
+        throw error;
+      }
+
+      if (node.deleted) {
+        try {
+          await stagehand.close();
+        } catch {
+          // best-effort cleanup for a session deleted during initialization
+        }
+        throw new Error(`Session not found: ${node.sessionId}`);
+      }
+
+      node.stagehand = stagehand;
+      return stagehand;
+    });
+
+    node.initialization = initialization;
+    void initialization.catch(() => {
+      if (!node.deleted && node.initialization === initialization) {
+        node.initialization = null;
+      }
+    });
+    return initialization;
+  }
+
+  protected createStagehand(options: V3Options): V3 {
+    return new V3(options);
   }
 
   async startSession(params: CreateSessionParams): Promise<SessionStartResult> {
-    // Generate session ID or use provided browserbase session ID
     const sessionId = params.browserbaseSessionID ?? randomUUID();
-
-    // Store the session
     await this.createSession(sessionId, params);
 
     return {
@@ -157,71 +259,81 @@ export class InMemorySessionStore implements SessionStore {
   }
 
   async hasSession(sessionId: string): Promise<boolean> {
-    const node = this.items.get(sessionId);
-    if (!node) return false;
+    const expired = await this.mutate(() => {
+      const node = this.items.get(sessionId);
+      if (!node) return null;
+      if (this.ttlMs > 0 && node.expiry <= Date.now()) {
+        this.detachNode(node);
+        return node;
+      }
+      return false;
+    });
 
-    // Check if expired
-    if (this.ttlMs > 0 && node.expiry <= Date.now()) {
-      await this.deleteSession(sessionId);
+    if (expired) {
+      await this.closeNode(expired);
       return false;
     }
-
-    return true;
+    return expired === false;
   }
 
   async getOrCreateStagehand(
     sessionId: string,
     ctx: RequestContext,
   ): Promise<V3> {
-    const node = this.items.get(sessionId);
+    const resolution = await this.mutate(() => {
+      const node = this.items.get(sessionId);
+      if (!node) {
+        throw new Error(`Session not found: ${sessionId}`);
+      }
 
-    if (!node) {
-      throw new Error(`Session not found: ${sessionId}`);
-    }
+      if (this.ttlMs > 0 && node.expiry <= Date.now()) {
+        this.detachNode(node);
+        return { expired: node } as const;
+      }
 
-    // Check if expired
-    if (this.ttlMs > 0 && node.expiry <= Date.now()) {
-      await this.deleteSession(sessionId);
+      this.bumpNode(node);
+      if (node.stagehand) {
+        return { stagehand: node.stagehand } as const;
+      }
+
+      if (!node.initialization) {
+        this.initializeNode(node, ctx);
+      }
+      return { initialization: node.initialization! } as const;
+    });
+
+    if ("expired" in resolution) {
+      await this.closeNode(resolution.expired);
       throw new Error(`Session expired: ${sessionId}`);
     }
+    if ("stagehand" in resolution) return resolution.stagehand;
+    return await resolution.initialization;
+  }
 
-    // Bump to most recently used
-    this.bumpNode(node);
+  async runWithRequestContext<T>(
+    ctx: RequestContext,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    const scope: RequestLoggerScope = {
+      logger: ctx.logger,
+      active: true,
+    };
 
-    // Update logger reference for this request
-    if (ctx.logger) {
-      node.loggerRef.current = ctx.logger;
-    }
-
-    // If V3 instance exists, return it
-    if (node.stagehand) {
-      return node.stagehand;
-    }
-
-    // Create V3 instance (lazy initialization)
-    const options = this.buildV3Options(node.params, ctx, node.loggerRef);
-    const stagehand = new V3(options);
-    try {
-      await stagehand.init();
-    } catch (error) {
+    return await this.requestLogger.run(scope, async () => {
       try {
-        await stagehand.close();
-      } catch {
-        // best-effort cleanup for failed init attempts
+        return await operation();
+      } finally {
+        scope.active = false;
       }
-      throw error;
-    }
-    node.stagehand = stagehand;
-    return stagehand;
+    });
   }
 
   /**
-   * Build V3Options from stored params and request context
+   * Build V3Options from stored params and request context.
    */
   private buildV3Options(
     params: CreateSessionParams,
     ctx: RequestContext,
-    loggerRef: { current?: (message: LogLine) => void },
   ): V3Options {
     const isBrowserbase = params.browserType === "browserbase";
 
@@ -238,11 +350,9 @@ export class InMemorySessionStore implements SessionStore {
       selfHeal: params.selfHeal,
       domSettleTimeout: params.domSettleTimeoutMs,
       experimental: params.experimental,
-      // Wrap logger to use the ref so it can be updated per-request
       logger: (message: LogLine) => {
-        if (loggerRef.current) {
-          loggerRef.current(message);
-        }
+        const scope = this.requestLogger.getStore();
+        if (scope?.active) scope.logger?.(message);
       },
     };
 
@@ -269,94 +379,85 @@ export class InMemorySessionStore implements SessionStore {
     sessionId: string,
     params: CreateSessionParams,
   ): Promise<void> {
-    // Check if already exists
-    if (this.items.has(sessionId)) {
-      throw new Error(`Session already exists: ${sessionId}`);
-    }
+    const evicted = await this.mutate(() => {
+      if (this.items.has(sessionId)) {
+        throw new Error(`Session already exists: ${sessionId}`);
+      }
 
-    // Evict LRU if at capacity
-    if (this.maxCapacity > 0 && this.items.size >= this.maxCapacity) {
-      await this.evictLru();
-    }
+      const nodes: LruNode[] = [];
+      while (this.maxCapacity > 0 && this.items.size >= this.maxCapacity) {
+        if (!this.first) break;
+        const node = this.first;
+        this.detachNode(node);
+        nodes.push(node);
+      }
 
-    // Create new node
-    const node: LruNode = {
-      sessionId,
-      params,
-      stagehand: null, // Lazy initialization
-      loggerRef: {},
-      expiry: this.ttlMs > 0 ? Date.now() + this.ttlMs : Infinity,
-      prev: this.last,
-      next: null,
-    };
+      const node: LruNode = {
+        sessionId,
+        params,
+        stagehand: null,
+        initialization: null,
+        closePromise: null,
+        deleted: false,
+        expiry: this.ttlMs > 0 ? Date.now() + this.ttlMs : Infinity,
+        prev: this.last,
+        next: null,
+      };
 
-    this.items.set(sessionId, node);
+      this.items.set(sessionId, node);
+      if (this.last) this.last.next = node;
+      this.last = node;
+      if (!this.first) this.first = node;
+      return nodes;
+    });
 
-    // Link to end of list
-    if (this.last) this.last.next = node;
-    this.last = node;
-    if (!this.first) this.first = node;
+    await Promise.all(evicted.map((node) => this.closeNode(node)));
   }
 
   async deleteSession(sessionId: string): Promise<void> {
-    const node = this.items.get(sessionId);
-    if (!node) return;
+    const node = await this.mutate(() => {
+      const current = this.items.get(sessionId);
+      if (current) this.detachNode(current);
+      return current;
+    });
 
-    // Close V3 instance if it exists
-    if (node.stagehand) {
-      try {
-        await node.stagehand.close();
-      } catch (error) {
-        console.error(
-          `Error closing stagehand for session ${sessionId}:`,
-          error,
-        );
-      }
-    }
-
-    // Remove from map
-    this.items.delete(sessionId);
-
-    // Unlink from list
-    const { prev, next } = node;
-    if (prev) prev.next = next;
-    if (next) next.prev = prev;
-    if (this.first === node) this.first = next;
-    if (this.last === node) this.last = prev;
+    if (node) await this.closeNode(node);
   }
 
   async getSessionConfig(sessionId: string): Promise<CreateSessionParams> {
-    const node = this.items.get(sessionId);
-
-    if (!node) {
-      throw new Error(`Session not found: ${sessionId}`);
-    }
-
-    // Return the stored params (contains browser metadata needed downstream)
-    return node.params;
+    return await this.mutate(() => {
+      const node = this.items.get(sessionId);
+      if (!node) {
+        throw new Error(`Session not found: ${sessionId}`);
+      }
+      return node.params;
+    });
   }
 
-  updateCacheConfig(config: SessionCacheConfig): void {
-    if (config.maxCapacity !== undefined) {
-      if (config.maxCapacity <= 0) {
-        throw new Error("Max capacity must be greater than 0");
-      }
-      const previousCapacity = this.maxCapacity;
-      this.maxCapacity = config.maxCapacity;
-
-      // Evict excess if new capacity is smaller
-      if (this.maxCapacity < previousCapacity) {
-        const excess = this.items.size - this.maxCapacity;
-        for (let i = 0; i < excess; i++) {
-          // Fire and forget - don't await to match cloud behavior
-          this.evictLru().catch(console.error);
-        }
-      }
+  async updateCacheConfig(config: SessionCacheConfig): Promise<void> {
+    if (config.maxCapacity !== undefined && config.maxCapacity <= 0) {
+      throw new Error("Max capacity must be greater than 0");
     }
 
-    if (config.ttlMs !== undefined) {
-      this.ttlMs = config.ttlMs;
-    }
+    const evicted = await this.mutate(() => {
+      if (config.maxCapacity !== undefined) {
+        this.maxCapacity = config.maxCapacity;
+      }
+      if (config.ttlMs !== undefined) {
+        this.ttlMs = config.ttlMs;
+      }
+
+      const nodes: LruNode[] = [];
+      while (this.maxCapacity > 0 && this.items.size > this.maxCapacity) {
+        if (!this.first) break;
+        const node = this.first;
+        this.detachNode(node);
+        nodes.push(node);
+      }
+      return nodes;
+    });
+
+    await Promise.all(evicted.map((node) => this.closeNode(node)));
   }
 
   getCacheConfig(): SessionCacheConfig {
@@ -367,19 +468,21 @@ export class InMemorySessionStore implements SessionStore {
   }
 
   async destroy(): Promise<void> {
-    // Stop cleanup interval
     if (this.cleanupInterval) {
       clearInterval(this.cleanupInterval);
       this.cleanupInterval = null;
     }
 
-    // Close all V3 instances
-    const sessionIds = Array.from(this.items.keys());
-    await Promise.all(sessionIds.map((id) => this.deleteSession(id)));
+    const nodes = await this.mutate(() => {
+      const current = Array.from(this.items.values());
+      for (const node of current) this.detachNode(node);
+      return current;
+    });
+    await Promise.all(nodes.map((node) => this.closeNode(node)));
   }
 
   /**
-   * Get the number of cached sessions
+   * Get the number of cached sessions.
    */
   get size(): number {
     return this.items.size;

--- a/packages/server-v3/src/lib/SessionStore.ts
+++ b/packages/server-v3/src/lib/SessionStore.ts
@@ -136,7 +136,7 @@ export interface SessionStore {
    * This method handles:
    * - Checking the cache for an existing V3 instance
    * - On cache miss: loading config, creating V3, caching it
-   * - Updating the logger reference for streaming
+   * - Sharing in-flight initialization between concurrent callers
    *
    * @param sessionId - The session identifier
    * @param ctx - Request-time context containing values from headers
@@ -144,6 +144,18 @@ export interface SessionStore {
    * @throws Error if session not found
    */
   getOrCreateStagehand(sessionId: string, ctx: RequestContext): Promise<V3>;
+
+  /**
+   * Run an operation with request-scoped context.
+   *
+   * Stores may use this to route logs and other request-local state while a
+   * shared V3 instance is executing. Implementations that do not need
+   * request-scoped state can omit this method.
+   */
+  runWithRequestContext?<T>(
+    ctx: RequestContext,
+    operation: () => Promise<T>,
+  ): Promise<T>;
 
   /**
    * Create a new session with the given parameters.
@@ -170,7 +182,7 @@ export interface SessionStore {
    * Update cache configuration dynamically.
    * @param config - New cache configuration values
    */
-  updateCacheConfig?(config: SessionCacheConfig): void;
+  updateCacheConfig?(config: SessionCacheConfig): void | Promise<void>;
 
   /**
    * Get current cache configuration.

--- a/packages/server-v3/src/lib/stream.ts
+++ b/packages/server-v3/src/lib/stream.ts
@@ -211,7 +211,10 @@ export async function createStreamingResponse<TV3>({
   let handlerError: Error | null = null;
 
   try {
-    result = await handler({ stagehand, data: parsedData });
+    const executeHandler = () => handler({ stagehand, data: parsedData });
+    result = sessionStore.runWithRequestContext
+      ? await sessionStore.runWithRequestContext(requestContext, executeHandler)
+      : await executeHandler();
   } catch (err) {
     handlerError = err instanceof Error ? err : new Error("Unknown error");
     request.log.error(

--- a/packages/server-v3/tests/unit/inMemorySessionStore.test.ts
+++ b/packages/server-v3/tests/unit/inMemorySessionStore.test.ts
@@ -1,0 +1,218 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { LogLine, V3, V3Options } from "@browserbasehq/stagehand";
+import { InMemorySessionStore } from "../../src/lib/InMemorySessionStore.js";
+import type { CreateSessionParams } from "../../src/lib/SessionStore.js";
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    if (predicate()) return;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+  throw new Error("Timed out waiting for condition");
+}
+
+const sessionParams: CreateSessionParams = {
+  browserType: "local",
+  modelName: "openai/gpt-4.1-mini",
+};
+
+class FakeStagehand {
+  readonly initCalls: number[] = [];
+  readonly closeCalls: number[] = [];
+  initGate: Promise<void> = Promise.resolve();
+  closeGate: Promise<void> = Promise.resolve();
+
+  constructor(readonly options: V3Options) {}
+
+  async init(): Promise<void> {
+    this.initCalls.push(Date.now());
+    await this.initGate;
+  }
+
+  async close(): Promise<void> {
+    this.closeCalls.push(Date.now());
+    await this.closeGate;
+  }
+
+  emit(message: LogLine): void {
+    this.options.logger?.(message);
+  }
+}
+
+class TestSessionStore extends InMemorySessionStore {
+  readonly instances: FakeStagehand[] = [];
+  nextInitGate: Promise<void> = Promise.resolve();
+
+  protected override createStagehand(options: V3Options): V3 {
+    const stagehand = new FakeStagehand(options);
+    stagehand.initGate = this.nextInitGate;
+    this.instances.push(stagehand);
+    return stagehand as unknown as V3;
+  }
+}
+
+function logLine(message: string): LogLine {
+  return {
+    category: "test",
+    message,
+    level: 1,
+  };
+}
+
+describe("InMemorySessionStore concurrency", () => {
+  it("serializes concurrent creation of the same session", async () => {
+    const store = new TestSessionStore();
+
+    const results = await Promise.allSettled([
+      store.createSession("session", sessionParams),
+      store.createSession("session", sessionParams),
+    ]);
+
+    assert.equal(
+      results.filter((result) => result.status === "fulfilled").length,
+      1,
+    );
+    assert.equal(
+      results.filter((result) => result.status === "rejected").length,
+      1,
+    );
+    assert.equal(store.size, 1);
+    await store.destroy();
+  });
+
+  it("shares one initialization across concurrent requests", async () => {
+    const store = new TestSessionStore();
+    const init = deferred();
+    store.nextInitGate = init.promise;
+    await store.createSession("session", sessionParams);
+
+    const first = store.getOrCreateStagehand("session", {});
+    const second = store.getOrCreateStagehand("session", {});
+
+    await waitFor(() => store.instances.length === 1);
+    assert.equal(store.instances[0].initCalls.length, 1);
+
+    init.resolve();
+    const [firstStagehand, secondStagehand] = await Promise.all([
+      first,
+      second,
+    ]);
+
+    assert.strictEqual(firstStagehand, secondStagehand);
+    assert.equal(store.instances.length, 1);
+    await store.destroy();
+  });
+
+  it("closes an initialization deleted while it is in flight", async () => {
+    const store = new TestSessionStore();
+    const init = deferred();
+    store.nextInitGate = init.promise;
+    await store.createSession("session", sessionParams);
+
+    const initialization = store.getOrCreateStagehand("session", {});
+    await waitFor(() => store.instances.length === 1);
+    const deletion = store.deleteSession("session");
+    await waitFor(() => store.size === 0);
+
+    init.resolve();
+    await assert.rejects(initialization, /Session not found/);
+    await deletion;
+
+    assert.equal(store.instances[0].closeCalls.length, 1);
+    await store.destroy();
+  });
+
+  it("isolates overlapping request loggers and suppresses late logs", async () => {
+    const store = new TestSessionStore();
+    await store.createSession("session", sessionParams);
+    await store.getOrCreateStagehand("session", {});
+    const stagehand = store.instances[0];
+    const firstLogs: string[] = [];
+    const secondLogs: string[] = [];
+    const releaseFirst = deferred();
+    const releaseSecond = deferred();
+
+    const first = store.runWithRequestContext(
+      {
+        logger: (line) => firstLogs.push(line.message),
+      },
+      async () => {
+        await releaseFirst.promise;
+        stagehand.emit(logLine("first"));
+      },
+    );
+    const second = store.runWithRequestContext(
+      {
+        logger: (line) => secondLogs.push(line.message),
+      },
+      async () => {
+        await releaseSecond.promise;
+        stagehand.emit(logLine("second"));
+      },
+    );
+
+    releaseSecond.resolve();
+    await second;
+    releaseFirst.resolve();
+    await first;
+
+    assert.deepEqual(firstLogs, ["first"]);
+    assert.deepEqual(secondLogs, ["second"]);
+
+    const releaseLateLog = deferred();
+    let lateTask!: Promise<void>;
+    await store.runWithRequestContext(
+      {
+        logger: (line) => firstLogs.push(line.message),
+      },
+      async () => {
+        lateTask = (async () => {
+          await releaseLateLog.promise;
+          stagehand.emit(logLine("late"));
+        })();
+      },
+    );
+
+    releaseLateLog.resolve();
+    await lateTask;
+    assert.deepEqual(firstLogs, ["first"]);
+    await store.destroy();
+  });
+
+  it("detaches all excess LRU entries before asynchronous shutdown finishes", async () => {
+    const store = new TestSessionStore({ maxCapacity: 3 });
+    for (const sessionId of ["one", "two", "three"]) {
+      await store.createSession(sessionId, sessionParams);
+      await store.getOrCreateStagehand(sessionId, {});
+    }
+
+    const firstClose = deferred();
+    const secondClose = deferred();
+    store.instances[0].closeGate = firstClose.promise;
+    store.instances[1].closeGate = secondClose.promise;
+
+    const update = store.updateCacheConfig({ maxCapacity: 1 });
+    await waitFor(() => store.size === 1);
+
+    assert.equal(store.size, 1);
+    assert.equal(store.instances[0].closeCalls.length, 1);
+    assert.equal(store.instances[1].closeCalls.length, 1);
+    assert.equal(await store.hasSession("three"), true);
+
+    firstClose.resolve();
+    secondClose.resolve();
+    await update;
+    await store.destroy();
+  });
+});


### PR DESCRIPTION
## Summary

  The in-memory session store previously mutated its session map, LRU list, lazy browser initialization state, and streaming logger references
  without synchronization.

  Under concurrent requests, this could:

  - launch multiple V3/browser instances for the same session;
  - overwrite the cached instance and leak the losing browser;
  - route logs from one request to another request’s SSE stream;
  - send logs to a stream after it had completed;
  - start multiple asynchronous evictions for the same LRU entry;
  - temporarily exceed the configured cache capacity while browser shutdown was pending.

  This PR synchronizes the session lifecycle, shares in-flight initialization, and replaces the shared mutable logger reference with request-
  scoped logging.

  ## What changed

  ### Share in-flight V3 initialization

  Each cached session node now tracks its active initialization promise.

  When multiple requests resolve the same uninitialized session:

  1. The first request creates the V3 instance and starts initialization.
  2. The initialization promise is stored on the session node before another mutation can inspect it.
  3. Concurrent requests receive the same promise instead of launching another browser.
  4. Once initialization succeeds, all callers receive the same cached V3 instance.

  Failed initialization remains retryable. The failed V3 instance is closed, and the initialization promise is cleared while the session is
  still active.

  ### Safely handle deletion during initialization

  Session nodes now track whether they have been detached from the cache.

  If a session is deleted or evicted while initialization is still running:

  - the node is removed from the map and LRU list immediately;
  - deletion waits for initialization to settle;
  - an instance that finishes initializing after deletion is closed;
  - waiting callers receive a session-not-found error;
  - cleanup is guarded by a shared close promise so the browser is closed exactly once.

  This prevents a late initialization result from restoring or leaking an evicted browser.

  ### Serialize cache and LRU mutations

  All structural mutations now run through a serialized mutation queue, including:

  - session creation;
  - duplicate-session checks;
  - LRU updates;
  - expiration;
  - deletion;
  - capacity changes;
  - store destruction.

  Browser shutdown is intentionally performed outside the mutation queue. Nodes are first detached synchronously from the cache and LRU list,
  then their browser resources are closed asynchronously.

  This preserves cache invariants without allowing slow browser shutdown to block unrelated session operations.

  ### Make capacity reduction deterministic

  `updateCacheConfig()` is now asynchronous and returns only after evicted browser instances have been closed.

  When capacity is reduced:

  1. The mutation queue updates the capacity.
  2. Every excess LRU node is detached in one serialized mutation.
  3. The store immediately reflects the new capacity.
  4. Detached browsers are closed concurrently outside the critical section.

  This replaces the previous fire-and-forget loop, where every eviction could select the same LRU node because the list was not updated until
  asynchronous shutdown completed.

  The optional `SessionStore.updateCacheConfig()` interface now supports either `void` or `Promise<void>` so custom stores remain compatible.

  ### Add request-scoped logging

  The mutable `loggerRef.current` field has been removed.

  The in-memory store now uses `AsyncLocalStorage` to associate a logger with the request currently executing an operation.
  `createStreamingResponse()` wraps the complete route handler in the store’s optional `runWithRequestContext()` hook.

  This is important because request work happens after `getOrCreateStagehand()` returns and may use nested APIs such as:

  - `stagehand.act()`;
  - `stagehand.observe()`;
  - `stagehand.extract()`;
  - `stagehand.context`;
  - page navigation and other page operations.

  Wrapping only session resolution would not cover those operations.

  Each logger scope is marked inactive when its handler completes. Async work inherited from that request therefore cannot write to an already-
  completed SSE stream.

  Custom `SessionStore` implementations do not need to implement the hook; the server falls back to executing handlers directly.

  ### Preserve cleanup responsiveness

  Slow `stagehand.close()` calls do not hold the structural mutation lock.

  As a result:

  - capacity is accurate while shutdown is pending;
  - another request cannot select an already-evicted node;
  - cleanup for one session does not prevent unrelated sessions from being created or resolved;
  - repeated deletion and eviction share the same cleanup promise.

  ## Tests added

  Added `inMemorySessionStore.test.ts` with concurrency coverage for:

  - concurrent creation of the same session is serialized;
  - concurrent `getOrCreateStagehand()` calls perform one initialization;
  - all callers receive the same V3 instance;
  - deletion during initialization closes the eventual instance exactly once;
  - overlapping request logger scopes remain isolated;
  - logs emitted after a request scope completes are suppressed;
  - capacity reduction detaches all excess LRU entries before asynchronous browser shutdown finishes;
  - the correct most-recently-used session remains cached.

  The tests use a controlled V3 test double with deferred initialization and shutdown promises so the race windows are deterministic.

  ## Validation

  Passed:

  - Prettier
  - ESLint
  - TypeScript typecheck
  - Server distribution build
  - ESM test build
  - All current server-v3 unit tests: 69/69

  The test runner prints an existing Node 24 `glob`/`minimatch` incompatibility while converting JUnit output to CTRF after the tests finish.
  The tests themselves complete successfully.

  ## Compatibility

  - Existing `SessionStore` implementations remain compatible because `runWithRequestContext()` is optional.
  - `updateCacheConfig()` may now return a promise, while synchronous custom implementations remain valid.
  - Session IDs, TTL behavior, LRU ordering, and lazy initialization semantics are preserved.
  - Failed initialization can still be retried.
  - No public API response formats are changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Synchronizes the in-memory session store to eliminate concurrency bugs and log cross-talk. Ensures one browser per session, safe eviction/deletion, and deterministic capacity changes.

- **Bug Fixes**
  - Share in-flight initialization per session so concurrent requests wait on the same promise; failed init cleans up and stays retryable.
  - Serialize map/LRU mutations with a queue; detach nodes first and close browsers outside the lock; TTL cleanup and hasSession detach expired nodes before closing.
  - Handle deletion/eviction during init: detach immediately, wait for init to settle, close the instance exactly once, and return session-not-found to waiters.
  - Replace shared logger refs with request-scoped logging via Node `AsyncLocalStorage`; `createStreamingResponse()` wraps handlers with `runWithRequestContext()` to prevent cross-request logs and late writes.

- **Migration**
  - No changes required. Custom stores may implement optional `runWithRequestContext()`. `updateCacheConfig()` can now return `Promise<void>`; sync implementations remain valid.

<sup>Written for commit f131763204b3b916d4e7544d4d3d0cf7be4c81da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

