### PR TITLE
fix(core): clean up failed initialization

### DIFF
--- a/.changeset/calm-dogs-clean.md
+++ b/.changeset/calm-dogs-clean.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Clean up browsers, profiles, CDP connections, loggers, and registrations when initialization fails.

--- a/packages/core/lib/v3/launch/browserbase.ts
+++ b/packages/core/lib/v3/launch/browserbase.ts
@@ -68,9 +68,19 @@ export async function createBrowserbaseSession(
     bb.sessions.create(createPayload),
     sessionCreateTimeoutMs,
     "Browserbase session create",
-  )) as unknown as { id: string; connectUrl: string };
+  )) as unknown as { id?: string; connectUrl?: string };
 
   if (!created?.connectUrl || !created?.id) {
+    if (created?.id) {
+      try {
+        await bb.sessions.update(created.id, {
+          status: "REQUEST_RELEASE",
+          ...(resolvedProjectId ? { projectId: resolvedProjectId } : {}),
+        });
+      } catch {
+        // best-effort cleanup; preserve the invalid response error
+      }
+    }
     throw new StagehandInitError(
       "Browserbase session creation returned an unexpected shape.",
     );

--- a/packages/core/lib/v3/launch/local.ts
+++ b/packages/core/lib/v3/launch/local.ts
@@ -83,10 +83,18 @@ export async function launchLocalChrome(
     maxConnectionRetries,
   });
 
-  const ws = await waitForWebSocketDebuggerUrl(chrome.port, deadlineMs);
-  await waitForWebSocketReady(ws, deadlineMs);
-
-  return { ws, chrome };
+  try {
+    const ws = await waitForWebSocketDebuggerUrl(chrome.port, deadlineMs);
+    await waitForWebSocketReady(ws, deadlineMs);
+    return { ws, chrome };
+  } catch (error) {
+    try {
+      await chrome.kill();
+    } catch {
+      // best-effort cleanup; preserve the original connection error
+    }
+    throw error;
+  }
 }
 
 async function waitForWebSocketDebuggerUrl(

--- a/packages/core/lib/v3/types/private/internal.ts
+++ b/packages/core/lib/v3/types/private/internal.ts
@@ -11,7 +11,13 @@ export type InitState =
       createdTempProfile?: boolean;
       preserveUserDataDir?: boolean;
     }
-  | { kind: "BROWSERBASE"; bb: Browserbase; sessionId: string; ws: string };
+  | {
+      kind: "BROWSERBASE";
+      bb: Browserbase;
+      sessionId: string;
+      ws: string;
+      ownsSession: boolean;
+    };
 
 export type EncodedId = `${number}-${number}`;
 

--- a/packages/core/lib/v3/understudy/context.ts
+++ b/packages/core/lib/v3/understudy/context.ts
@@ -195,22 +195,32 @@ export class V3Context {
       const conn = await CdpConnection.connect(wsUrl, {
         headers: opts?.cdpHeaders,
       });
-      const ctx = new V3Context(
-        conn,
-        opts?.env ?? "LOCAL",
-        opts?.apiClient ?? null,
-        opts?.localBrowserLaunchOptions ?? null,
-      );
-      await ctx.bootstrap();
-      // Allow connectTimeoutMs to also govern how long we wait for the first
-      // top-level page to appear.  On slow machines the browser may need more
-      // time after the CDP socket is open before the initial page registers.
-      const firstPageTimeoutMs = Math.max(
-        opts?.localBrowserLaunchOptions?.connectTimeoutMs ?? 0,
-        getFirstTopLevelPageTimeoutMs(),
-      );
-      await ctx.ensureFirstTopLevelPage(firstPageTimeoutMs);
-      return ctx;
+      let ctx: V3Context | null = null;
+      try {
+        ctx = new V3Context(
+          conn,
+          opts?.env ?? "LOCAL",
+          opts?.apiClient ?? null,
+          opts?.localBrowserLaunchOptions ?? null,
+        );
+        await ctx.bootstrap();
+        // Allow connectTimeoutMs to also govern how long we wait for the first
+        // top-level page to appear. On slow machines the browser may need more
+        // time after the CDP socket is open before the initial page registers.
+        const firstPageTimeoutMs = Math.max(
+          opts?.localBrowserLaunchOptions?.connectTimeoutMs ?? 0,
+          getFirstTopLevelPageTimeoutMs(),
+        );
+        await ctx.ensureFirstTopLevelPage(firstPageTimeoutMs);
+        return ctx;
+      } catch (error) {
+        try {
+          await (ctx ? ctx.close() : conn.close());
+        } catch {
+          // best-effort cleanup; preserve the original bootstrap error
+        }
+        throw error;
+      }
     };
 
     const cdpTimeoutMs =

--- a/packages/core/lib/v3/v3.ts
+++ b/packages/core/lib/v3/v3.ts
@@ -276,6 +276,7 @@ export class V3 {
   private agentCache: AgentCache;
   private apiClient: StagehandAPIClient | null = null;
   private keepAlive?: boolean;
+  private ownsBrowserbaseSession = false;
   private shutdownSupervisor: ShutdownSupervisorHandle | null = null;
 
   public stagehandMetrics: StagehandMetrics = {
@@ -329,21 +330,6 @@ export class V3 {
     this.stagehandLogger = new StagehandLogger(loggerOptions, opts.logger);
     this.stagehandLogger.setVerbosity(this.verbose);
 
-    // Also bind to AsyncLocalStorage for v3Logger() calls from handlers
-    // This maintains backward compatibility with code that uses v3Logger() directly
-    try {
-      if (this.externalLogger) {
-        // Use external logger directly when provided
-        bindInstanceLogger(this.instanceId, this.externalLogger);
-      } else {
-        // Fall back to stagehandLogger when no external logger
-        bindInstanceLogger(this.instanceId, (line) => {
-          this.stagehandLogger.log(line);
-        });
-      }
-    } catch {
-      // ignore
-    }
     const { modelName, clientOptions, middleware } = resolveModelConfiguration(
       opts.model,
     );
@@ -443,6 +429,19 @@ export class V3 {
     // stays alive until this bus is garbage-collected with the rest of the V3
     // object graph.
     this.bus.on("*", this.eventStore.emit);
+
+    // Bind only after all constructor work that may throw has completed.
+    try {
+      bindInstanceLogger(
+        this.instanceId,
+        this.externalLogger ??
+          ((line) => {
+            this.stagehandLogger.log(line);
+          }),
+      );
+    } catch {
+      // ignore
+    }
 
     // Track instance for global process guard handling
     V3._instances.add(this);
@@ -1012,11 +1011,22 @@ export class V3 {
           }
 
           const keepAlive = this.keepAlive === true;
-          const { ws, chrome } = await launchLocalChrome({
-            ...lbo,
-            userDataDir,
-            handleSIGINT: !keepAlive,
-          });
+          let launched: Awaited<ReturnType<typeof launchLocalChrome>>;
+          try {
+            launched = await launchLocalChrome({
+              ...lbo,
+              userDataDir,
+              handleSIGINT: !keepAlive,
+            });
+          } catch (error) {
+            await cleanupLocalBrowser({
+              userDataDir,
+              createdTempProfile: createdTemp,
+              preserveUserDataDir: !!lbo.preserveUserDataDir,
+            });
+            throw error;
+          }
+          const { ws, chrome } = launched;
           if (keepAlive) {
             try {
               chrome.process?.unref?.();
@@ -1024,12 +1034,8 @@ export class V3 {
               // best-effort: avoid keeping the event loop alive
             }
           }
-          this.ctx = await V3Context.create(ws, {
-            env: "LOCAL",
-            localBrowserLaunchOptions: lbo,
-          });
-          this.ctx.conn.flowLoggerContext = this.flowLoggerContext;
-          this.ctx.conn.onTransportClosed(this._onCdpClosed);
+          // Publish ownership before any subsequent await so init cleanup can
+          // always kill Chrome and remove an SDK-created profile.
           this.state = {
             kind: "LOCAL",
             chrome,
@@ -1038,7 +1044,6 @@ export class V3 {
             createdTempProfile: createdTemp,
             preserveUserDataDir: !!lbo.preserveUserDataDir,
           };
-          this.resetBrowserbaseSessionMetadata();
           const chromePid = chrome.process?.pid ?? chrome.pid;
           if (!keepAlive && chromePid) {
             this.startShutdownSupervisor({
@@ -1049,6 +1054,13 @@ export class V3 {
               preserveUserDataDir: !!lbo.preserveUserDataDir,
             });
           }
+          this.ctx = await V3Context.create(ws, {
+            env: "LOCAL",
+            localBrowserLaunchOptions: lbo,
+          });
+          this.ctx.conn.flowLoggerContext = this.flowLoggerContext;
+          this.ctx.conn.onTransportClosed(this._onCdpClosed);
+          this.resetBrowserbaseSessionMetadata();
 
           // Post-connect settings (downloads and viewport) if provided
           await this._applyPostConnectLocalOptions(lbo);
@@ -1057,6 +1069,9 @@ export class V3 {
 
         if (this.opts.env === "BROWSERBASE") {
           const { apiKey, projectId } = this.requireBrowserbaseCreds();
+          const browserbaseSessionWasSupplied =
+            this.opts.browserbaseSessionID !== undefined;
+          this.ownsBrowserbaseSession = !browserbaseSessionWasSupplied;
           this.logger({
             category: "init",
             message: "Starting browserbase session",
@@ -1136,13 +1151,15 @@ export class V3 {
             effectiveSessionParams,
             this.opts.browserbaseSessionID,
           );
-          this.ctx = await V3Context.create(ws, {
-            env: "BROWSERBASE",
-            apiClient: this.apiClient,
-          });
-          this.ctx.conn.flowLoggerContext = this.flowLoggerContext;
-          this.ctx.conn.onTransportClosed(this._onCdpClosed);
-          this.state = { kind: "BROWSERBASE", sessionId, ws, bb };
+          // Publish ownership before connecting CDP so a failed context
+          // bootstrap can release a newly-created Browserbase session.
+          this.state = {
+            kind: "BROWSERBASE",
+            sessionId,
+            ws,
+            bb,
+            ownsSession: this.ownsBrowserbaseSession,
+          };
           this.browserbaseSessionId = sessionId;
           if (!keepAlive && !this.disableAPI) {
             this.startShutdownSupervisor({
@@ -1152,6 +1169,12 @@ export class V3 {
               projectId,
             });
           }
+          this.ctx = await V3Context.create(ws, {
+            env: "BROWSERBASE",
+            apiClient: this.apiClient,
+          });
+          this.ctx.conn.flowLoggerContext = this.flowLoggerContext;
+          this.ctx.conn.onTransportClosed(this._onCdpClosed);
 
           await this._ensureBrowserbaseDownloadsEnabled();
 
@@ -1196,13 +1219,13 @@ export class V3 {
         throw new StagehandInitError(`Unsupported env: ${neverEnv}`);
       });
     } catch (error) {
-      // Cleanup instanceLoggers map on init failure to prevent memory leak
-      if (this.externalLogger) {
-        try {
-          unbindInstanceLogger(this.instanceId);
-        } catch {
-          // ignore cleanup errors
-        }
+      try {
+        await this.close({
+          force: true,
+          cleanupOwnedResources: true,
+        });
+      } catch {
+        // best-effort cleanup; preserve the original initialization error
       }
       throw error;
     }
@@ -1595,12 +1618,18 @@ export class V3 {
   }
 
   /** Best-effort cleanup of context and launched resources. */
-  async close(opts?: { force?: boolean }): Promise<void> {
+  async close(opts?: {
+    force?: boolean;
+    cleanupOwnedResources?: boolean;
+  }): Promise<void> {
     // If we're already closing and this isn't a forced close, no-op.
     if (this._isClosing && !opts?.force) return;
     this._isClosing = true;
 
-    const keepAlive = this.keepAlive === true;
+    const preserveOwnedResources =
+      this.keepAlive === true && !opts?.cleanupOwnedResources;
+    const browserbaseState =
+      this.state.kind === "BROWSERBASE" ? this.state : null;
 
     // Unhook CDP transport close handler BEFORE ending the API session.
     // apiClient.end() can cause the hosted API to terminate the Browserbase
@@ -1615,10 +1644,31 @@ export class V3 {
       // ignore
     }
 
-    // End Browserbase session via API when keepAlive is not enabled
-    if (!keepAlive && this.apiClient) {
+    // End a managed Browserbase session via the Stagehand API.
+    let endedViaApi = false;
+    if (
+      !preserveOwnedResources &&
+      this.apiClient &&
+      (!opts?.cleanupOwnedResources || this.ownsBrowserbaseSession)
+    ) {
       try {
         await this.apiClient.end();
+        endedViaApi = true;
+      } catch {
+        // best-effort cleanup
+      }
+    }
+
+    if (
+      !preserveOwnedResources &&
+      !endedViaApi &&
+      browserbaseState?.ownsSession
+    ) {
+      try {
+        await browserbaseState.bb.sessions.update(browserbaseState.sessionId, {
+          status: "REQUEST_RELEASE",
+          ...(this.opts.projectId ? { projectId: this.opts.projectId } : {}),
+        });
       } catch {
         // best-effort cleanup
       }
@@ -1639,8 +1689,8 @@ export class V3 {
         // ignore
       }
 
-      // Kill local Chrome and clean up temp profile when keepAlive is not enabled
-      if (!keepAlive && this.state.kind === "LOCAL") {
+      // Kill owned local Chrome and clean up its temporary profile.
+      if (!preserveOwnedResources && this.state.kind === "LOCAL") {
         const localState = this.state;
         await cleanupLocalBrowser({
           killChrome: () => localState.chrome.kill(),
@@ -1657,6 +1707,7 @@ export class V3 {
       this.ctx = null;
       this._isClosing = false;
       this.resetBrowserbaseSessionMetadata();
+      this.ownsBrowserbaseSession = false;
       try {
         unbindInstanceLogger(this.instanceId);
       } catch {

--- a/packages/core/tests/unit/browserbase-launch-cleanup.test.ts
+++ b/packages/core/tests/unit/browserbase-launch-cleanup.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  create: vi.fn(),
+  retrieve: vi.fn(),
+  update: vi.fn(),
+}));
+
+vi.mock("@browserbasehq/sdk", () => ({
+  default: class MockBrowserbase {
+    sessions = mocks;
+  },
+}));
+
+describe("Browserbase launch cleanup", () => {
+  beforeEach(() => {
+    mocks.create.mockReset();
+    mocks.retrieve.mockReset();
+    mocks.update.mockReset();
+  });
+
+  it("releases a created session when its response has no connect URL", async () => {
+    mocks.create.mockResolvedValue({ id: "created-session" });
+    mocks.update.mockResolvedValue(undefined);
+    const { createBrowserbaseSession } = await import(
+      "../../lib/v3/launch/browserbase.js"
+    );
+
+    await expect(
+      createBrowserbaseSession("api-key", "project-id"),
+    ).rejects.toThrow("unexpected shape");
+
+    expect(mocks.update).toHaveBeenCalledWith("created-session", {
+      status: "REQUEST_RELEASE",
+      projectId: "project-id",
+    });
+  });
+});

--- a/packages/core/tests/unit/context-initialization-cleanup.test.ts
+++ b/packages/core/tests/unit/context-initialization-cleanup.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  connect: vi.fn(),
+}));
+
+vi.mock("../../lib/v3/understudy/cdp", () => ({
+  CdpConnection: {
+    connect: mocks.connect,
+  },
+}));
+
+describe("V3Context initialization cleanup", () => {
+  it("closes the CDP connection when bootstrap fails", async () => {
+    const bootstrapError = new Error("auto-attach failed");
+    const connection = {
+      on: vi.fn(),
+      enableAutoAttach: vi.fn().mockRejectedValue(bootstrapError),
+      getTargets: vi.fn(),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    mocks.connect.mockResolvedValue(connection);
+
+    const { V3Context } = await import("../../lib/v3/understudy/context.js");
+
+    await expect(V3Context.create("ws://failed-bootstrap")).rejects.toBe(
+      bootstrapError,
+    );
+    expect(connection.close).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/core/tests/unit/launch-local-ignore-default-args.test.ts
+++ b/packages/core/tests/unit/launch-local-ignore-default-args.test.ts
@@ -80,6 +80,18 @@ async function getLaunchArgs(
 }
 
 describe("launchLocalChrome ignoreDefaultArgs", () => {
+  it("kills Chrome when debugger discovery fails after launch", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("not ready")));
+    const { launchLocalChrome } = await import("../../lib/v3/launch/local.js");
+
+    await expect(launchLocalChrome({ connectTimeoutMs: 1 })).rejects.toThrow(
+      /Timed out waiting/,
+    );
+
+    const chrome = await launchMock.mock.results[0].value;
+    expect(chrome.kill).toHaveBeenCalledOnce();
+  });
+
   it("does not set ignoreDefaultFlags when ignoreDefaultArgs is omitted", async () => {
     const args = await getLaunchArgs({});
     expect(args.ignoreDefaultFlags).toBe(false);

--- a/packages/core/tests/unit/v3-initialization-cleanup.test.ts
+++ b/packages/core/tests/unit/v3-initialization-cleanup.test.ts
@@ -1,0 +1,185 @@
+import fs from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { LogLine } from "../../lib/v3/types/public/logs.js";
+
+const mocks = vi.hoisted(() => ({
+  contextCreate: vi.fn(),
+  launchLocalChrome: vi.fn(),
+  createBrowserbaseSession: vi.fn(),
+  browserbaseUpdate: vi.fn(),
+}));
+
+vi.mock("../../lib/v3/understudy/context", () => ({
+  V3Context: {
+    create: mocks.contextCreate,
+  },
+}));
+
+vi.mock("../../lib/v3/launch/local", () => ({
+  launchLocalChrome: mocks.launchLocalChrome,
+}));
+
+vi.mock("../../lib/v3/launch/browserbase", () => ({
+  createBrowserbaseSession: mocks.createBrowserbaseSession,
+}));
+
+type V3Internals = {
+  instanceId: string;
+  stagehandLogger: { log: (line: LogLine) => void };
+};
+
+function registeredInstances(): Set<unknown> {
+  const { V3 } = requireV3();
+  return (V3 as unknown as { _instances: Set<unknown> })._instances;
+}
+
+let importedV3: typeof import("../../lib/v3/v3.js") | undefined;
+
+function requireV3(): typeof import("../../lib/v3/v3.js") {
+  if (!importedV3) {
+    throw new Error("V3 module has not been imported");
+  }
+  return importedV3;
+}
+
+async function loadV3(): Promise<typeof import("../../lib/v3/v3.js")> {
+  importedV3 ??= await import("../../lib/v3/v3.js");
+  return importedV3;
+}
+
+describe("V3 initialization cleanup", () => {
+  beforeEach(() => {
+    mocks.contextCreate.mockReset();
+    mocks.launchLocalChrome.mockReset();
+    mocks.createBrowserbaseSession.mockReset();
+    mocks.browserbaseUpdate.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("removes a temporary profile when local launch fails", async () => {
+    let profilePath = "";
+    mocks.launchLocalChrome.mockImplementation(
+      async (options: { userDataDir?: string }) => {
+        profilePath = options.userDataDir ?? "";
+        throw new Error("debugger discovery failed");
+      },
+    );
+    const { V3 } = await loadV3();
+    const v3 = new V3({
+      env: "LOCAL",
+      disableAPI: true,
+      keepAlive: true,
+      model: { modelName: "openai/gpt-4.1-mini", apiKey: "test-key" },
+    });
+    const destroyEventStore = vi.spyOn(v3.eventStore, "destroy");
+
+    await expect(v3.init()).rejects.toThrow("debugger discovery failed");
+
+    expect(profilePath).not.toBe("");
+    expect(fs.existsSync(profilePath)).toBe(false);
+    expect(destroyEventStore).toHaveBeenCalledOnce();
+    expect(registeredInstances().has(v3)).toBe(false);
+  });
+
+  it("kills Chrome and removes its profile when context creation fails", async () => {
+    const kill = vi.fn().mockResolvedValue(undefined);
+    let profilePath = "";
+    mocks.launchLocalChrome.mockImplementation(
+      async (options: { userDataDir?: string }) => {
+        profilePath = options.userDataDir ?? "";
+        return {
+          ws: "ws://local-browser",
+          chrome: { kill },
+        };
+      },
+    );
+    mocks.contextCreate.mockRejectedValue(new Error("context failed"));
+    const { V3 } = await loadV3();
+    const v3 = new V3({
+      env: "LOCAL",
+      disableAPI: true,
+      keepAlive: true,
+      model: { modelName: "openai/gpt-4.1-mini", apiKey: "test-key" },
+    });
+    const internals = v3 as unknown as V3Internals;
+    const internalLog = vi.spyOn(internals.stagehandLogger, "log");
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await expect(v3.init()).rejects.toThrow("context failed");
+
+    expect(kill).toHaveBeenCalledOnce();
+    expect(fs.existsSync(profilePath)).toBe(false);
+    expect(registeredInstances().has(v3)).toBe(false);
+
+    const { v3Logger, withInstanceLogContext } = await import(
+      "../../lib/v3/logger.js"
+    );
+    internalLog.mockClear();
+    consoleLog.mockClear();
+    withInstanceLogContext(internals.instanceId, () => {
+      v3Logger({ category: "test", message: "after cleanup", level: 1 });
+    });
+    expect(internalLog).not.toHaveBeenCalled();
+    expect(consoleLog).toHaveBeenCalledOnce();
+  });
+
+  it("releases an owned Browserbase session when context creation fails", async () => {
+    mocks.createBrowserbaseSession.mockResolvedValue({
+      ws: "wss://browserbase",
+      sessionId: "created-session",
+      bb: {
+        sessions: {
+          update: mocks.browserbaseUpdate,
+        },
+      },
+    });
+    mocks.contextCreate.mockRejectedValue(new Error("context failed"));
+    const { V3 } = await loadV3();
+    const v3 = new V3({
+      env: "BROWSERBASE",
+      apiKey: "browserbase-key",
+      projectId: "project-id",
+      disableAPI: true,
+      keepAlive: true,
+      model: { modelName: "openai/gpt-4.1-mini", apiKey: "test-key" },
+    });
+
+    await expect(v3.init()).rejects.toThrow("context failed");
+
+    expect(mocks.browserbaseUpdate).toHaveBeenCalledWith("created-session", {
+      status: "REQUEST_RELEASE",
+      projectId: "project-id",
+    });
+    expect(registeredInstances().has(v3)).toBe(false);
+  });
+
+  it("does not release a caller-owned Browserbase session", async () => {
+    mocks.createBrowserbaseSession.mockResolvedValue({
+      ws: "wss://browserbase",
+      sessionId: "existing-session",
+      bb: {
+        sessions: {
+          update: mocks.browserbaseUpdate,
+        },
+      },
+    });
+    mocks.contextCreate.mockRejectedValue(new Error("context failed"));
+    const { V3 } = await loadV3();
+    const v3 = new V3({
+      env: "BROWSERBASE",
+      apiKey: "browserbase-key",
+      projectId: "project-id",
+      browserbaseSessionID: "existing-session",
+      disableAPI: true,
+      model: { modelName: "openai/gpt-4.1-mini", apiKey: "test-key" },
+    });
+
+    await expect(v3.init()).rejects.toThrow("context failed");
+
+    expect(mocks.browserbaseUpdate).not.toHaveBeenCalled();
+    expect(registeredInstances().has(v3)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

  Initialization previously had several resource-ownership gaps where an error could occur after acquiring a resource but before publishing it
  to `V3.state`.

  In those cases, the outer initialization handler could not find or clean up the resource. Depending on where initialization failed, this could
  leave behind:

  - local Chrome processes;
  - generated browser profiles;
  - open CDP connections;
  - Browserbase sessions;
  - event-store sinks;
  - event-bus listeners;
  - instance logger registrations;
  - entries in the global V3 instance registry.

  This PR gives each acquisition stage structured cleanup and transfers ownership to `V3` before subsequent asynchronous work can fail.

  ## What changed

  ### Kill Chrome when debugger discovery fails

  `launchLocalChrome()` now wraps debugger URL discovery and WebSocket readiness checks in a cleanup boundary.

  If either step fails after `chrome-launcher` has returned:

  1. `chrome.kill()` is called;
  2. kill failures are ignored as best-effort cleanup;
  3. the original connection error is rethrown.

  Previously, failures while polling `/json/version` or probing the CDP WebSocket left the launched Chrome process running.

  ### Remove generated profiles when launch fails

  `V3.init()` creates temporary browser profiles before calling `launchLocalChrome()`.

  The launch call is now wrapped so that when it rejects:

  - SDK-created profiles are removed;
  - caller-provided profiles are preserved;
  - `preserveUserDataDir` remains respected;
  - the original launch error is retained.

  This complements process cleanup inside `launchLocalChrome()`, which does not know whether a profile was generated by Stagehand or supplied by
  the caller.

  ### Publish local browser ownership immediately

  After `launchLocalChrome()` succeeds, the local Chrome handle, WebSocket URL, profile path, and profile ownership metadata are assigned to
  `V3.state` before creating the CDP context.

  The shutdown supervisor is also started immediately after ownership transfer when applicable.

  If `V3Context.create()` or another later initialization step fails, the outer cleanup can now see and clean:

  - the Chrome process;
  - the temporary profile;
  - the supervisor;
  - all other V3-owned resources.

  Previously, state assignment happened after context creation, leaving `close()` with an `UNINITIALIZED` state during that failure window.

  ### Close CDP connections after bootstrap failure

  `V3Context.create()` now owns the connection as soon as `CdpConnection.connect()` succeeds.

  Context construction and bootstrap run inside a `try/catch`. If auto-attach, target discovery, initial-page setup, or another bootstrap stage
  fails, the context or raw connection is closed before the original error is rethrown.

  This prevents a failed context bootstrap from leaving an open WebSocket and its event listeners behind.

  ### Publish Browserbase ownership before CDP setup

  Browserbase session state is now assigned before `V3Context.create()`.

  The state records whether the session was:

  - created by this V3 instance; or
  - explicitly supplied by the caller.

  When later initialization fails:

  - newly created sessions are released with `REQUEST_RELEASE`;
  - caller-supplied sessions are not explicitly released;
  - Stagehand API session termination remains the preferred cleanup path when available;
  - direct Browserbase release acts as a fallback if API termination fails.

  Malformed Browserbase creation responses that contain a session ID but no connect URL are also released before reporting the invalid response.

  ### Fully clean failed V3 instances

  The outer `init()` catch now invokes complete V3 cleanup instead of only conditionally unbinding an external logger.

  Failure cleanup now covers:

  - Stagehand API sessions;
  - owned Browserbase sessions;
  - local Chrome;
  - generated profiles;
  - CDP contexts;
  - shutdown supervisors;
  - FlowLogger resources;
  - EventStore sinks;
  - event-bus listeners;
  - logger bindings;
  - handlers and history;
  - global V3 instance registration.

  The original initialization exception remains the error returned to the caller, even if best-effort cleanup encounters another failure.

  ### Correct logger registration lifetime

  Instance logger registration has been moved to the end of the constructor, after constructor work that may throw.

  Both logger variants are now handled consistently:

  - external logger callbacks;
  - the internal `StagehandLogger` fallback.

  This avoids registering a logger for an object whose constructor never completed and ensures failed initialization always unbinds whichever
  logger was installed.

  ### Preserve successful keep-alive behavior

  Initialization failure cleanup overrides `keepAlive` for resources Stagehand acquired during that failed attempt. A failed initialization
  should not leave an unusable process or session alive.

  Normal `close()` behavior still respects `keepAlive`, and explicitly supplied Browserbase sessions remain caller-owned during failure cleanup.

  ## Tests added

  Added focused fault-injection coverage for the affected acquisition windows.

  ### Local launch cleanup

  Verifies that:

  - Chrome is killed when debugger discovery fails after launch;
  - SDK-created profiles are removed when launch fails;
  - Chrome is killed when CDP context creation fails;
  - generated profiles are removed after context creation failure;
  - failure cleanup still occurs when `keepAlive: true`.

  ### CDP context cleanup

  Verifies that:

  - a successfully opened CDP connection is closed when context bootstrap fails;
  - the original bootstrap error is preserved.

  ### V3 lifecycle cleanup

  Verifies that failed initialization:

  - destroys the event store;
  - removes the instance from the global registry;
  - unbinds the internal logger variant;
  - prevents later logs from routing through the failed instance.

  ### Browserbase cleanup

  Verifies that:

  - newly created Browserbase sessions are released after context failure;
  - release still occurs when `keepAlive: true` during failed initialization;
  - caller-supplied Browserbase sessions are not explicitly released;
  - malformed creation responses with a session ID are released.

  ## Validation

  Passed:

  - Prettier
  - ESLint
  - TypeScript typecheck
  - ESM build
  - Focused initialization cleanup suite: 25/25
  - Real local-Chrome initialization, interaction, and shutdown smoke tests: 2/2

  The full core unit run passes 887/891 tests. The remaining four failures are the existing `flowlogger-eventstore` stderr-capture failures,
  which reproduce independently and are unrelated to this change.

  The test runner also prints the existing Node 24 `glob`/`minimatch` CTRF-conversion error after test execution; it does not affect the passing
  test results.

  ## Release impact

  Patch release.

  No successful initialization or public response behavior changes. The primary behavioral change is that resources acquired during an
  initialization attempt are now released if that attempt fails.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures all resources acquired during initialization are cleaned up on failure, preventing stray Chrome processes, temp profiles, CDP sockets, Browserbase sessions, loggers, and registry entries. Successful runs are unchanged; failures now perform best-effort cleanup and return the original error.

- **Bug Fixes**
  - Local: kill Chrome and delete SDK-created temp profiles when launch or context setup fails; publish ownership to `V3.state` before CDP; start shutdown supervisor earlier.
  - CDP: close the connection if `V3Context.create()` bootstrap fails.
  - Browserbase: assign ownership before CDP; release newly created sessions on failure (including malformed create responses); never release caller-supplied sessions; fall back to direct `REQUEST_RELEASE` if API end fails.
  - Logging/registry: bind instance logger only after constructor completes; unbind and remove global registration on failure.
  - Cleanup path: failed init calls `close({ force: true, cleanupOwnedResources: true })`; ignores secondary cleanup errors; `keepAlive` is ignored for resources acquired during a failed init.

<sup>Written for commit f599b340e2dac7f630772bb5febc6839fa5ada29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

