### PR TITLE
evals: codex harness across all code tool surfaces

### DIFF
--- a/packages/evals/framework/codexCodeBridge.ts
+++ b/packages/evals/framework/codexCodeBridge.ts
@@ -1,0 +1,190 @@
+/**
+ * Code-execution bridge for the codex harness.
+ *
+ * codex-sdk has no in-process MCP server mounting (unlike claude-agent-sdk),
+ * and an external MCP process could not share this process's live surface
+ * handles (the v4 Stagehand client, playwright browser objects). So the
+ * codex mount for a `code_handles` LLMExposure is a loopback HTTP bridge:
+ * this process executes snippets against the in-memory handles; the codex
+ * workspace gets a tiny client script (`browser_run.mjs`) that posts a
+ * snippet file's contents to the bridge and prints the result.
+ *
+ * Scope semantics are identical to the claude_code run tool: the snippet
+ * runs inside an async function whose arguments are the exposure's handle
+ * names plus startUrl, task, and console — names, not order, bind values.
+ */
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import type { LLMExposure } from "../core/contracts/tool.js";
+import type { ExternalHarnessTaskPlan } from "./externalHarnessPlan.js";
+import type { EvalLogger } from "../logger.js";
+
+const DEFAULT_RUN_TIMEOUT_MS = 60_000;
+
+function readPositiveIntEnv(name: string, fallback: number): number {
+  const parsed = Number.parseInt(process.env[name] ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`run timed out after ${timeoutMs}ms`)),
+      timeoutMs,
+    );
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
+function stringifyResult(value: unknown): string {
+  if (typeof value === "undefined") return "undefined";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value, null, 2) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+export interface CodeBridge {
+  port: number;
+  close: () => Promise<void>;
+}
+
+export async function startCodeBridge(input: {
+  exposure: LLMExposure;
+  plan: ExternalHarnessTaskPlan;
+  logger: EvalLogger;
+}): Promise<CodeBridge> {
+  const { exposure, plan, logger } = input;
+  const handles = exposure.handles ?? {};
+  const runTool = exposure.runTool;
+  const bridgeConsole = runTool?.console ?? {
+    log: (...args: unknown[]) =>
+      logger.log({ category: "codex", level: 1, message: args.join(" ") }),
+    warn: (...args: unknown[]) =>
+      logger.warn({ category: "codex", level: 1, message: args.join(" ") }),
+    error: (...args: unknown[]) =>
+      logger.error({ category: "codex", level: 0, message: args.join(" ") }),
+  };
+
+  async function executeSnippet(code: string): Promise<unknown> {
+    const AsyncFunction = Object.getPrototypeOf(async function () {})
+      .constructor as new (
+      ...args: string[]
+    ) => (...values: unknown[]) => Promise<unknown>;
+    const fn = new AsyncFunction(
+      ...Object.keys(handles),
+      "startUrl",
+      "task",
+      "console",
+      code,
+    );
+    return fn(
+      ...Object.values(handles),
+      plan.startUrl,
+      runTool?.task ?? {
+        instruction: plan.instruction,
+        startUrl: plan.startUrl,
+      },
+      bridgeConsole,
+    );
+  }
+
+  const server = http.createServer((req, res) => {
+    if (req.method !== "POST" || req.url !== "/run") {
+      res.writeHead(404).end();
+      return;
+    }
+    let body = "";
+    req.on("data", (chunk) => (body += chunk));
+    req.on("end", async () => {
+      let code: string;
+      try {
+        code = String((JSON.parse(body) as { code?: unknown }).code ?? "");
+      } catch {
+        res
+          .writeHead(400)
+          .end(JSON.stringify({ ok: false, error: "invalid JSON body" }));
+        return;
+      }
+      try {
+        const result = await withTimeout(
+          executeSnippet(code),
+          readPositiveIntEnv(
+            "EVAL_CODEX_RUN_TOOL_TIMEOUT_MS",
+            DEFAULT_RUN_TIMEOUT_MS,
+          ),
+        );
+        const text = stringifyResult(result);
+        logger.log({
+          category: "codex",
+          level: 1,
+          message: `bridge run completed: ${text.slice(0, 500)}`,
+        });
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: true, result: text }));
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.warn({
+          category: "codex",
+          level: 1,
+          message: `bridge run failed: ${message}`,
+        });
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: false, error: message }));
+      }
+    });
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const port = (server.address() as AddressInfo).port;
+
+  return {
+    port,
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve());
+        server.closeAllConnections?.();
+      }),
+  };
+}
+
+/**
+ * The workspace client codex invokes via shell. Kept dependency-free and
+ * tiny: read a snippet file (or stdin), post to the bridge, print the
+ * result text; non-zero exit on execution error so the agent notices.
+ */
+export function buildBridgeClientScript(port: number): string {
+  return `#!/usr/bin/env node
+// browser_run.mjs — execute a browser-automation snippet via the eval bridge.
+// Usage: node browser_run.mjs <snippet-file>   (or pipe the snippet on stdin)
+import { readFileSync } from "node:fs";
+
+const file = process.argv[2];
+const code = file ? readFileSync(file, "utf8") : readFileSync(0, "utf8");
+const res = await fetch("http://127.0.0.1:${port}/run", {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({ code }),
+});
+const payload = await res.json();
+if (payload.ok) {
+  console.log(payload.result);
+} else {
+  console.error("run failed: " + payload.error);
+  process.exit(1);
+}
+`;
+}

--- a/packages/evals/framework/codexRunner.ts
+++ b/packages/evals/framework/codexRunner.ts
@@ -223,6 +223,16 @@ export async function runCodexAgent({
     return baseResult;
   }
 
+  // Artifact-grounded grading: capture the terminal page state through the
+  // tool surface (harness-observed, independent of the agent's self-report)
+  // before cleanup, mirroring the claude_code runner.
+  const terminalArtifact =
+    toolAdapter && "captureFinalState" in toolAdapter
+      ? await toolAdapter
+          .captureFinalState?.()
+          .catch((): undefined => undefined)
+      : undefined;
+
   // Build a Trajectory from the codex event stream and grade it with the
   // rubric verifier; any failure in that path folds into `verifierError`.
   return gradeExternalTrajectory({
@@ -230,6 +240,7 @@ export async function runCodexAgent({
       codexAdapter.fromHarnessResult(
         {
           events,
+          ...(terminalArtifact && { terminalArtifact }),
           finalAnswer: parsed.finalAnswer ?? finalResponse,
           status: status === "completed" ? "complete" : "error",
           usage: {

--- a/packages/evals/framework/codexToolAdapter.ts
+++ b/packages/evals/framework/codexToolAdapter.ts
@@ -1,7 +1,19 @@
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { EvalsError } from "../errors.js";
 import type { EvalLogger } from "../logger.js";
-import type { StartupProfile, ToolSurface } from "../core/contracts/tool.js";
+import {
+  LLM_RUN_TOOL_NAME,
+  type StartupProfile,
+  type TerminalArtifact,
+  type ToolSurface,
+} from "../core/contracts/tool.js";
+import { prepareLLMExposure as prepareCdpCodeLLMExposure } from "../core/tools/cdp_code.js";
+import { prepareLLMExposure as preparePlaywrightCodeLLMExposure } from "../core/tools/playwright_code.js";
+import { prepareLLMExposure as prepareV4CodeLLMExposure } from "../core/tools/v4_code.js";
 import type { ExternalHarnessTaskPlan } from "./externalHarnessPlan.js";
+import { buildBridgeClientScript, startCodeBridge } from "./codexCodeBridge.js";
 import {
   prepareBrowseCliHarnessAdapter,
   type PreparedBrowseCliHarnessAdapter,
@@ -15,7 +27,27 @@ export interface CodexToolAdapterInput {
   logger: EvalLogger;
 }
 
-export type PreparedCodexToolAdapter = PreparedBrowseCliHarnessAdapter;
+/** Code-surface variant: same runner-facing fields as the browse_cli shape. */
+export interface PreparedCodexCodeAdapter {
+  toolSurface: ToolSurface;
+  startupProfile: StartupProfile;
+  cwd: string;
+  env: Record<string, string>;
+  promptInstructions: string;
+  /** Harness-observed terminal state for artifact-grounded grading. */
+  captureFinalState?: () => Promise<TerminalArtifact>;
+  cleanup: () => Promise<void>;
+}
+
+export type PreparedCodexToolAdapter =
+  | PreparedBrowseCliHarnessAdapter
+  | PreparedCodexCodeAdapter;
+
+const CODE_SURFACES = new Set<ToolSurface>([
+  "v4_code",
+  "playwright_code",
+  "cdp_code",
+]);
 
 export async function prepareCodexToolAdapter(
   input: CodexToolAdapterInput,
@@ -27,20 +59,135 @@ export async function prepareCodexToolAdapter(
     input.startupProfile,
   );
 
-  return prepareBrowseCliHarnessAdapter({
+  if (toolSurface === "browse_cli") {
+    return prepareBrowseCliHarnessAdapter({
+      startupProfile,
+      environment: input.environment,
+      plan: input.plan,
+      logger: input.logger,
+      logCategory: "codex",
+    });
+  }
+
+  const prepareSurfaceExposure =
+    toolSurface === "playwright_code"
+      ? preparePlaywrightCodeLLMExposure
+      : toolSurface === "cdp_code"
+        ? prepareCdpCodeLLMExposure
+        : prepareV4CodeLLMExposure;
+  const exposure = await prepareSurfaceExposure(
+    input.plan,
+    input.environment,
+    input.logger,
     startupProfile,
-    environment: input.environment,
-    plan: input.plan,
-    logger: input.logger,
-    logCategory: "codex",
-  });
+  );
+
+  let cwd: string | undefined;
+  let bridge: Awaited<ReturnType<typeof startCodeBridge>> | undefined;
+  try {
+    if (exposure.kind !== "code_handles" || !exposure.handles) {
+      throw new EvalsError(
+        `Codex code mounting requires a code_handles exposure with handles; "${toolSurface}" returned kind "${exposure.kind}".`,
+      );
+    }
+    bridge = await startCodeBridge({
+      exposure,
+      plan: input.plan,
+      logger: input.logger,
+    });
+    cwd = await fsp.mkdtemp(
+      path.join(
+        os.tmpdir(),
+        `stagehand-evals-codex-${toolSurface.replace(/_/g, "-")}-`,
+      ),
+    );
+    await fsp.writeFile(
+      path.join(cwd, "browser_run.mjs"),
+      buildBridgeClientScript(bridge.port),
+    );
+
+    input.logger.log({
+      category: "codex",
+      message: `Initialized ${toolSurface} bridge runtime for Codex (port ${bridge.port}).`,
+      level: 1,
+      auxiliary: {
+        startupProfile: { value: startupProfile, type: "string" },
+        environment: { value: input.environment, type: "string" },
+      },
+    });
+
+    const capturedBridge = bridge;
+    const capturedCwd = cwd;
+    return {
+      toolSurface,
+      startupProfile,
+      cwd,
+      env: { ...process.env } as Record<string, string>,
+      promptInstructions: buildCodexCodePromptInstructions(
+        exposure,
+        toolSurface,
+      ),
+      ...(exposure.captureFinalState && {
+        captureFinalState: exposure.captureFinalState,
+      }),
+      cleanup: async () => {
+        try {
+          await capturedBridge.close();
+        } catch {
+          // best-effort only
+        }
+        try {
+          await exposure.cleanup();
+        } catch {
+          // best-effort only
+        }
+        await fsp.rm(capturedCwd, { recursive: true, force: true });
+      },
+    };
+  } catch (error) {
+    await bridge?.close().catch((): undefined => undefined);
+    await exposure.cleanup().catch((): undefined => undefined);
+    if (cwd) await fsp.rm(cwd, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+/**
+ * Codex has no MCP run tool — snippets go through the workspace bridge
+ * client. Reuse the surface's own API guidance, rewriting the claude-style
+ * run-tool reference to the codex invocation.
+ */
+function buildCodexCodePromptInstructions(
+  exposure: { promptInstructions: string; handles?: Record<string, unknown> },
+  toolSurface: ToolSurface,
+): string {
+  const scopeNames = [
+    ...Object.keys(exposure.handles ?? {}),
+    "startUrl",
+    "task",
+    "console",
+  ].join(", ");
+  const surfaceGuidance = exposure.promptInstructions.replaceAll(
+    LLM_RUN_TOOL_NAME,
+    "browser_run.mjs",
+  );
+  return [
+    `Browser automation for this task runs through a snippet bridge, not a browser you launch.`,
+    `Write a JavaScript snippet to a file (e.g. snippet.js), then execute it with: node browser_run.mjs snippet.js`,
+    `The snippet runs inside an async function with ${scopeNames} in scope. Use await directly; return a JSON-serializable value to inspect it.`,
+    `Never launch your own browser process; browser_run.mjs is the only browser access.`,
+    surfaceGuidance,
+    `Surface: ${toolSurface}.`,
+  ].join("\n");
 }
 
 export function resolveCodexToolSurface(requested?: ToolSurface): ToolSurface {
   if (!requested) return "browse_cli";
-  if (requested === "browse_cli") return requested;
+  if (requested === "browse_cli" || CODE_SURFACES.has(requested)) {
+    return requested;
+  }
   throw new EvalsError(
-    `Codex harness supports --tool browse_cli for execution right now; received "${requested}".`,
+    `Codex harness supports --tool browse_cli, playwright_code, cdp_code, or v4_code for execution right now; received "${requested}".`,
   );
 }
 
@@ -51,10 +198,17 @@ export function resolveCodexStartupProfile(
 ): StartupProfile {
   if (requested) return requested;
 
-  if (toolSurface === "browse_cli") {
+  // browse_cli and v4_code own their browser; playwright/cdp attach to a
+  // runner-provided CDP endpoint (same defaults as the claude_code harness).
+  if (toolSurface === "browse_cli" || toolSurface === "v4_code") {
     return environment === "BROWSERBASE"
       ? "tool_create_browserbase"
       : "tool_launch_local";
+  }
+  if (toolSurface === "playwright_code" || toolSurface === "cdp_code") {
+    return environment === "BROWSERBASE"
+      ? "runner_provided_browserbase_cdp"
+      : "runner_provided_local_cdp";
   }
 
   throw new EvalsError(

--- a/packages/evals/framework/harnesses/codexAdapter.ts
+++ b/packages/evals/framework/harnesses/codexAdapter.ts
@@ -42,6 +42,11 @@ export interface CodexRunResult {
   status?: Trajectory["status"];
   /** Optional usage to fold into Trajectory.usage. */
   usage?: Partial<Trajectory["usage"]>;
+  /**
+   * Harness-observed terminal page state (captured through the tool surface
+   * after the agent finished) — anchors the verifier's final observation.
+   */
+  terminalArtifact?: { screenshot?: Buffer; url?: string };
 }
 
 export class CodexTrajectoryAdapter
@@ -88,6 +93,14 @@ export class CodexTrajectoryAdapter
       finalAnswer,
       status: result.status ?? "complete",
       usage: result.usage,
+      ...(result.terminalArtifact?.screenshot && {
+        finalObservation: {
+          screenshot: result.terminalArtifact.screenshot,
+          ...(result.terminalArtifact.url && {
+            url: result.terminalArtifact.url,
+          }),
+        },
+      }),
     });
   }
 }

--- a/packages/evals/tests/framework/claudeCodeToolAdapter.test.ts
+++ b/packages/evals/tests/framework/claudeCodeToolAdapter.test.ts
@@ -72,17 +72,26 @@ describe("claude code tool adapter resolution", () => {
     );
   });
 
-  it("supports browse_cli as the first Codex tool surface", () => {
+  it("supports browse_cli and the code surfaces on Codex", () => {
     expect(resolveCodexToolSurface()).toBe("browse_cli");
     expect(resolveCodexToolSurface("browse_cli")).toBe("browse_cli");
+    expect(resolveCodexToolSurface("v4_code")).toBe("v4_code");
+    expect(resolveCodexToolSurface("playwright_code")).toBe("playwright_code");
+    expect(resolveCodexToolSurface("cdp_code")).toBe("cdp_code");
+    expect(resolveCodexStartupProfile("v4_code", "BROWSERBASE")).toBe(
+      "tool_create_browserbase",
+    );
+    expect(resolveCodexStartupProfile("playwright_code", "BROWSERBASE")).toBe(
+      "runner_provided_browserbase_cdp",
+    );
+    expect(() => resolveCodexToolSurface("playwright_mcp")).toThrow(
+      /browse_cli, playwright_code, cdp_code, or v4_code/,
+    );
     expect(resolveCodexStartupProfile("browse_cli", "LOCAL")).toBe(
       "tool_launch_local",
     );
     expect(resolveCodexStartupProfile("browse_cli", "BROWSERBASE")).toBe(
       "tool_create_browserbase",
-    );
-    expect(() => resolveCodexToolSurface("playwright_code")).toThrow(
-      /Codex harness supports --tool browse_cli/,
     );
   });
 

--- a/packages/evals/tests/framework/codexCodeBridge.test.ts
+++ b/packages/evals/tests/framework/codexCodeBridge.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, afterEach } from "vitest";
+import {
+  buildBridgeClientScript,
+  startCodeBridge,
+  type CodeBridge,
+} from "../../framework/codexCodeBridge.js";
+import { EvalLogger } from "../../logger.js";
+import type { LLMExposure } from "../../core/contracts/tool.js";
+import type { ExternalHarnessTaskPlan } from "../../framework/externalHarnessPlan.js";
+
+const plan: ExternalHarnessTaskPlan = {
+  dataset: "webvoyager",
+  taskId: "test-1",
+  startUrl: "https://example.com",
+  instruction: "do the thing",
+};
+
+function exposureWith(handles: Record<string, unknown>): LLMExposure {
+  return {
+    kind: "code_handles",
+    handles,
+    promptInstructions: "test",
+    runTool: {
+      description: "test run tool",
+      codeParamDescription: "code",
+      denyMessage: "deny",
+      task: { instruction: plan.instruction, startUrl: plan.startUrl },
+    },
+    cleanup: async () => {},
+  };
+}
+
+async function post(bridge: CodeBridge, code: string) {
+  const res = await fetch(`http://127.0.0.1:${bridge.port}/run`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ code }),
+  });
+  return (await res.json()) as { ok: boolean; result?: string; error?: string };
+}
+
+let bridge: CodeBridge | undefined;
+afterEach(async () => {
+  await bridge?.close();
+  bridge = undefined;
+});
+
+describe("codex code bridge", () => {
+  it("executes snippets with handles, startUrl, and task in scope", async () => {
+    const page = { url: async () => "https://example.com/live" };
+    bridge = await startCodeBridge({
+      exposure: exposureWith({ page, marker: 42 }),
+      plan,
+      logger: new EvalLogger(),
+    });
+    const out = await post(
+      bridge,
+      "return { url: await page.url(), marker, startUrl, instruction: task.instruction };",
+    );
+    expect(out.ok).toBe(true);
+    expect(JSON.parse(out.result!)).toEqual({
+      url: "https://example.com/live",
+      marker: 42,
+      startUrl: "https://example.com",
+      instruction: "do the thing",
+    });
+  });
+
+  it("reports snippet errors without killing the bridge", async () => {
+    bridge = await startCodeBridge({
+      exposure: exposureWith({}),
+      plan,
+      logger: new EvalLogger(),
+    });
+    const bad = await post(bridge, "throw new Error('boom');");
+    expect(bad).toEqual({ ok: false, error: "boom" });
+    const good = await post(bridge, "return 'still alive';");
+    expect(good).toEqual({ ok: true, result: "still alive" });
+  });
+
+  it("times out runaway snippets", async () => {
+    process.env.EVAL_CODEX_RUN_TOOL_TIMEOUT_MS = "150";
+    try {
+      bridge = await startCodeBridge({
+        exposure: exposureWith({}),
+        plan,
+        logger: new EvalLogger(),
+      });
+      const out = await post(bridge, "await new Promise(() => {});");
+      expect(out.ok).toBe(false);
+      expect(out.error).toMatch(/timed out after 150ms/);
+    } finally {
+      delete process.env.EVAL_CODEX_RUN_TOOL_TIMEOUT_MS;
+    }
+  });
+
+  it("client script embeds the bridge port and pipes code", () => {
+    const script = buildBridgeClientScript(45678);
+    expect(script).toContain("http://127.0.0.1:45678/run");
+    expect(script).toContain("process.argv[2]");
+  });
+});


### PR DESCRIPTION
Part of STG-2671 (cadence: harness axis — CC, **Codex**).

Codex now drives every code tool surface (`v4_code`, `playwright_code`, `cdp_code`) through the same `LLMExposure` contract as claude_code.

## How
codex-sdk has no in-process MCP mounting, and an external MCP process couldn't share the eval process's live handles — so `code_handles` exposures mount via a **loopback HTTP bridge**: the eval process executes snippets against its in-memory handles; the codex workspace gets a dependency-free `browser_run.mjs` client. Snippet scope is byte-compatible with the claude_code run tool (handle names + `startUrl`, `task`, `console`).

## What's inside
- `codexCodeBridge.ts` — the bridge (bounded per-run timeout) + generated workspace client, 4 unit tests
- `codexToolAdapter.ts` — browse_cli-only → all four surfaces; startup-profile parity with claude_code; bounded cleanup (bridge → exposure → tmpdir)
- `codexRunner` / `codexAdapter` — artifact-grounded grading parity: harness-observed terminal screenshot + URL anchor the verifier

## Verified live
codex × `v4_code` passed a WebVoyager row end-to-end on Browserbase — 71 trajectory steps, 32 bridge invocations, rubric-graded, terminal artifact captured. (Machine note: `EVAL_CODEX_PATH` needed where pnpm's vendored codex binary is absent — pre-existing issue.)

Stacked on `stg-2671-v4-harness`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Codex now runs code on `v4_code`, `playwright_code`, and `cdp_code` through the same `LLMExposure` flow as `claude_code`, via a loopback bridge and unified adapter. This delivers feature and grading parity across tool surfaces. (STG-2671)

- **New Features**
  - Added `codexCodeBridge.ts`: a loopback HTTP server with per-run timeout and a generated `browser_run.mjs` client; snippets run with handles, `startUrl`, `task`, and `console` in scope.
  - Extended `codexToolAdapter` to all code surfaces: mounts per-surface exposures, writes `browser_run.mjs`, rewrites prompt guidance (replaces `LLM_RUN_TOOL_NAME`), and cleans up bridge/exposure/tmpdir.
  - Startup defaults: `browse_cli`/`v4_code` create a browser; `playwright_code`/`cdp_code` attach to runner-provided CDP (local or Browserbase), matching `claude_code`.
  - Artifact-grounded grading parity: `codexRunner` captures final screenshot/URL; `codexAdapter` feeds it to the verifier. Tests added for the bridge and tool resolution.

- **Migration**
  - No changes for `browse_cli`.
  - For code surfaces, ensure the Codex binary is available; set `EVAL_CODEX_PATH` if not vendored. Optional: adjust `EVAL_CODEX_RUN_TOOL_TIMEOUT_MS` (default 60s).

<sup>Written for commit 80916aa743aefb8ef5a9e6df08874f40214a6e8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

