### PR TITLE
evals: task-declared system prompts, error flattening, provider key aliases

### DIFF
--- a/packages/evals/framework/benchHarness.ts
+++ b/packages/evals/framework/benchHarness.ts
@@ -39,6 +39,8 @@ export interface BenchHarnessStartInput {
   row: BenchMatrixRow;
   logger: EvalLogger;
   verbose?: boolean;
+  /** Task-declared init-time system prompt (from BenchTaskMeta.systemPrompt). */
+  systemPrompt?: string;
 }
 
 export interface BenchHarnessExecuteInput extends BenchHarnessStartInput {
@@ -147,6 +149,7 @@ export const stagehandHarness: BenchHarness = {
     row,
     logger,
     verbose,
+    systemPrompt,
   }: BenchHarnessStartInput): Promise<StartedBenchHarness> {
     let v3Result: V3InitResult | undefined;
     const createAgent = isAgentTask(task);
@@ -175,6 +178,7 @@ export const stagehandHarness: BenchHarness = {
       const v4Result = await initV4({
         logger,
         modelName: input.modelName,
+        systemPrompt,
         configOverrides: { env: config.environment },
       });
       return {
@@ -218,16 +222,22 @@ export const stagehandHarness: BenchHarness = {
         agentMode,
         isCUA,
         verbose,
+        systemPrompt,
         configOverrides: { env: config.environment },
       });
     } else {
       let llmClient: LLMClient | undefined;
       if (input.modelName.includes("/")) {
         const firstSlashIndex = input.modelName.indexOf("/");
+        const subProvider = input.modelName.substring(0, firstSlashIndex);
+        // Resolve the key through the evals alias list (GEMINI_API_KEY etc.)
+        // instead of relying on the AI SDK's single canonical env var.
+        const apiKey = loadApiKeyFromEnv(subProvider, (line) => logger.log(line));
         llmClient = new AISdkClientWrapped({
           model: getAISDKLanguageModel(
-            input.modelName.substring(0, firstSlashIndex),
+            subProvider,
             input.modelName.substring(firstSlashIndex + 1),
+            apiKey ? { apiKey } : undefined,
           ),
         });
       }
@@ -240,6 +250,7 @@ export const stagehandHarness: BenchHarness = {
         agentMode,
         isCUA,
         verbose,
+        systemPrompt,
         configOverrides: { env: config.environment },
       });
     }

--- a/packages/evals/framework/benchRunner.ts
+++ b/packages/evals/framework/benchRunner.ts
@@ -1,5 +1,6 @@
 import { EvalsError } from "../errors.js";
 import { EvalLogger } from "../logger.js";
+import { flattenError } from "./flattenError.js";
 import type { EvalInput } from "../types/evals.js";
 import type { DiscoveredTask, TaskResult } from "./types.js";
 import type { RunEvalsOptions } from "./runner.js";
@@ -13,10 +14,14 @@ function withBenchSessionUrls(
   result: TaskResult,
   ctx: BenchHarnessContext | undefined,
 ): TaskResult {
-  if (!ctx) return result;
+  // Every task result funnels through here — flatten Error instances so the
+  // failure reason survives JSON serialization into Braintrust rows.
+  const flattened =
+    result.error === undefined ? result : { ...result, error: flattenError(result.error) };
+  if (!ctx) return flattened;
 
   return {
-    ...result,
+    ...flattened,
     sessionUrl: result.sessionUrl || ctx.sessionUrl || undefined,
     debugUrl: result.debugUrl || ctx.debugUrl || undefined,
   };
@@ -54,18 +59,25 @@ export async function executeBenchTask(
       });
     }
 
+    // Load the task module before starting the harness: init-time meta
+    // (e.g. a custom systemPrompt) must reach the Stagehand constructor.
+    const taskModule = await loadTaskModuleFromPath(task.filePath, task.name);
+    const taskMeta = taskModule.definition?.meta;
+    const systemPrompt =
+      taskMeta && "systemPrompt" in taskMeta ? taskMeta.systemPrompt : undefined;
+
     const startedHarness = await harness.start({
       task,
       input,
       row,
       logger,
       verbose: options.verbose,
+      systemPrompt,
     });
     cleanup = onceAsync(startedHarness.cleanup);
     unregisterCleanup = registerActiveRunCleanup(cleanup);
 
     harnessCtx = startedHarness.ctx;
-    const taskModule = await loadTaskModuleFromPath(task.filePath, task.name);
     if (taskModule.definition) {
       const ctx = {
         v3: harnessCtx.v3,
@@ -119,10 +131,7 @@ export async function executeBenchTask(
     return withBenchSessionUrls(
       {
         _success: false,
-        error:
-          error instanceof Error
-            ? JSON.parse(JSON.stringify(error, null, 2))
-            : String(error),
+        error: flattenError(error),
         logs: logger.getLogs(),
       },
       harnessCtx,

--- a/packages/evals/framework/flattenError.ts
+++ b/packages/evals/framework/flattenError.ts
@@ -1,0 +1,13 @@
+/**
+ * Flatten a caught error for inclusion in a task result row.
+ *
+ * Error instances JSON-serialize to `{}` (message/stack are non-enumerable),
+ * so returning a raw `error` — or `JSON.parse(JSON.stringify(error))` — hides
+ * the real failure from the TUI and Braintrust rows. Flatten to a plain
+ * `{ message, stack }` object so the failure reason survives serialization.
+ */
+export function flattenError(error: unknown): unknown {
+  return error instanceof Error
+    ? { message: error.message, stack: error.stack }
+    : error;
+}

--- a/packages/evals/framework/index.ts
+++ b/packages/evals/framework/index.ts
@@ -10,3 +10,4 @@ export { runEvals } from "./runner.js";
 export { createAssertHelpers, AssertionError } from "./assertions.js";
 export { createMetricsCollector } from "./metrics.js";
 export { buildCoreContext, buildBenchContext } from "./context.js";
+export { flattenError } from "./flattenError.js";

--- a/packages/evals/framework/taskLoader.ts
+++ b/packages/evals/framework/taskLoader.ts
@@ -1,11 +1,11 @@
 import fs from "node:fs";
 import { pathToFileURL } from "node:url";
 import { EvalsError } from "../errors.js";
-import type { TaskResult } from "./types.js";
+import type { BenchTaskMeta, TaskMeta, TaskResult } from "./types.js";
 
 export interface LoadedTaskDefinition {
   __taskDefinition: true;
-  meta: unknown;
+  meta: TaskMeta | BenchTaskMeta;
   fn: (ctx: unknown) => Promise<unknown>;
 }
 

--- a/packages/evals/framework/types.ts
+++ b/packages/evals/framework/types.ts
@@ -42,6 +42,12 @@ export interface TaskMeta {
 export interface BenchTaskMeta extends TaskMeta {
   /** Override the default model list for this specific task. */
   models?: string[];
+  /**
+   * Custom system prompt passed to the Stagehand instance at init time
+   * (v3 `V3Options.systemPrompt` / v4 `StagehandInitParams.systemPrompt`).
+   * Used by tasks that test instruction-following (e.g. combination/instructions).
+   */
+  systemPrompt?: string;
 }
 
 /** Context provided to core (tier 1) tasks. */

--- a/packages/evals/initV3.ts
+++ b/packages/evals/initV3.ts
@@ -44,6 +44,8 @@ type InitV3Args = {
   actTimeoutMs?: number; // retained for parity (v3 agent tools don't use this globally)
   modelName: AvailableModel;
   verbose?: boolean;
+  /** Task-declared custom system prompt, forwarded to V3Options.systemPrompt. */
+  systemPrompt?: string;
 };
 
 export type V3InitResult = {
@@ -65,6 +67,7 @@ export async function initV3({
   agentMode,
   isCUA,
   verbose = false,
+  systemPrompt,
 }: InitV3Args): Promise<V3InitResult> {
   // If CUA, choose a safe internal AISDK model for V3 handlers based on available API keys
   let internalModel: AvailableModel = modelName;
@@ -116,6 +119,7 @@ export async function initV3({
     browserbaseSessionCreateParams:
       configOverrides?.browserbaseSessionCreateParams,
     browserbaseSessionID: configOverrides?.browserbaseSessionID,
+    systemPrompt,
     selfHeal: true,
     disablePino: true,
     disableAPI: process.env.USE_API !== "true", // Negate: USE_API=true → disableAPI=false

--- a/packages/evals/tasks/bench/combination/instructions.ts
+++ b/packages/evals/tasks/bench/combination/instructions.ts
@@ -1,7 +1,13 @@
 import { defineBenchTask } from "../../../framework/defineTask.js";
 
 export default defineBenchTask(
-  { name: "instructions" },
+  {
+    name: "instructions",
+    // The task exercises init-time custom instructions: without this prompt
+    // "secret12345" is meaningless and the act() cannot succeed.
+    systemPrompt:
+      "if the users says `secret12345`, click on the 'Overview' link in the sidebar navigation. additionally, if the user says to type something, translate their input into french and type it.",
+  },
   async ({ debugUrl, sessionUrl, v3, logger }) => {
     try {
       const page = v3.context.pages()[0];
@@ -12,11 +18,16 @@ export default defineBenchTask(
 
       await page.waitForLoadState("domcontentloaded");
 
-      const url = page.url();
+      // The docs site navigates client-side; poll for the route change.
+      const expectedUrl =
+        "https://docs.browserbase.com/welcome/getting-started";
+      let url = page.url();
+      for (let i = 0; i < 20 && url !== expectedUrl; i++) {
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        url = page.url();
+      }
 
-      const isCorrectUrl =
-        (await url) ===
-        "https://docs.browserbase.com/introduction/what-is-browserbase";
+      const isCorrectUrl = url === expectedUrl;
 
       return {
         _success: isCorrectUrl,


### PR DESCRIPTION
Part of STG-2671.

Three harness reliability fixes that share files (hence one PR):

## Task-declared system prompts
`BenchTaskMeta.systemPrompt` threads through the harness into `V3Options.systemPrompt` / `StagehandInitParams.systemPrompt` on **both** SDK paths. Restores `combination/instructions` — its custom prompt was lost in the evals-v2 rewrite, making the eval unpassable on either SDK (`act("secret12345")` was meaningless without it). The task also now polls for the docs site's client-side route change instead of reading the URL once.

## Error flattening at the result funnel
`framework/flattenError.ts` + one application point in `benchRunner` — `Error` instances survive JSON serialization into Braintrust rows instead of collapsing to `{}`. This masking class hid two distinct root causes during the compatibility sweeps.

## Provider key aliases (non-API v3 bench path)
Model API keys resolve through the evals alias list (`GEMINI_API_KEY` etc.) instead of the AI SDK's single canonical env var — fixes v3-side google runs with only the alias set.

Stacked on `stg-2671-benchmark-matrix-braintrust` (uses its `initV4` systemPrompt param).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the `combination/instructions` eval and improves harness reliability by threading task-declared system prompts, flattening errors in results, and resolving provider keys via aliases. Part of STG-2671; fixes v3 Google runs with `GEMINI_API_KEY` only and surfaces real failure reasons in Braintrust.

- **Bug Fixes**
  - Thread `BenchTaskMeta.systemPrompt` into `V3Options.systemPrompt` and `StagehandInitParams.systemPrompt`; the task now polls for the docs app’s client-side route change.
  - Flatten errors via `flattenError` so results include `message` and `stack` instead of `{}`.
  - Resolve model API keys via eval alias env vars (e.g., `GEMINI_API_KEY`) on the non-API v3 path.

<sup>Written for commit 0b59703f5421818b364341d8da996950808ad4b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

