### PR TITLE
evals: single canonical v4 task root + dataset file overrides

### DIFF
--- a/packages/evals/framework/discovery.ts
+++ b/packages/evals/framework/discovery.ts
@@ -123,7 +123,15 @@ function getTierRoots(
   sdk: EvalSdk = "v3",
 ): string[] {
   if (tier === "bench") {
-    return [path.join(tasksRoot, sdk === "v4" ? "bench-v4" : "bench")];
+    if (sdk === "v4") {
+      // tasks/bench-v4 is the single canonical v4 suite (the tasks land in
+      // the stagehand repo — STG-2671). The migration-window copy inside the
+      // v4-spike checkout was verified to be a strict subset and deleted
+      // (2026-07-23), so there is exactly one root and no shadow-copy
+      // semantics to reason about.
+      return [path.join(tasksRoot, "bench-v4")];
+    }
+    return [path.join(tasksRoot, "bench")];
   }
 
   const packageRoot = path.dirname(tasksRoot);
@@ -276,6 +284,11 @@ export async function discoverTasks(
           isLegacy,
           models,
         };
+
+        // A tier can have multiple roots (v4: the v4-spike copy plus
+        // bench-v4) holding the same task under the same name; the first
+        // root wins so the task runs once.
+        if (byName.has(task.name)) continue;
 
         tasks.push(task);
         byName.set(task.name, task);

--- a/packages/evals/suites/webtailbench.ts
+++ b/packages/evals/suites/webtailbench.ts
@@ -12,7 +12,10 @@ import {
 export const buildWebTailBenchTestcases = (
   models: string[] | AgentModelEntry[],
 ): Testcase[] => {
+  // EVAL_WEBTAILBENCH_FILE mirrors EVAL_GAIA_FILE/EVAL_WEBVOYAGER_FILE: the
+  // stock file is category-ordered, so `-l N` alone only ever reaches flights.
   const webtailbenchFilePath =
+    process.env.EVAL_WEBTAILBENCH_FILE ||
     getPackageRootDir() + "/datasets/webtailbench/WebTailBench_data.jsonl";
 
   const lines = readJsonlFile(webtailbenchFilePath);

--- a/packages/evals/suites/webvoyager.ts
+++ b/packages/evals/suites/webvoyager.ts
@@ -13,12 +13,12 @@ import {
 export const buildWebVoyagerTestcases = (
   models: string[] | AgentModelEntry[],
 ): Testcase[] => {
-  const voyagerFilePath = path.join(
-    getPackageRootDir(),
-    "datasets",
-    "webvoyager",
-    "WebVoyager_data.jsonl",
-  );
+  // EVAL_WEBVOYAGER_FILE mirrors EVAL_GAIA_FILE: point runs at a curated
+  // slice (the stock file is site-ordered, so `-l N` alone only ever
+  // reaches Allrecipes).
+  const voyagerFilePath =
+    process.env.EVAL_WEBVOYAGER_FILE ||
+    path.join(getPackageRootDir(), "datasets", "webvoyager", "WebVoyager_data.jsonl");
 
   const lines = readJsonlFile(voyagerFilePath);
 


### PR DESCRIPTION
Part of STG-2671.

## Single canonical v4 task root
`tasks/bench-v4` is the one v4 discovery root — the migration-window copy inside the v4-spike checkout was verified to be a strict subset (60/60 tasks semantically identical) and deleted. The name-collision dedupe guard stays, so multi-root tiers can never double-count (previously `run act --sdk v4` ran 64 cases instead of 40).

## Dataset file overrides
`EVAL_WEBVOYAGER_FILE` / `EVAL_WEBTAILBENCH_FILE` (mirroring `EVAL_GAIA_FILE`) point runs at curated slices — the stock files are site/category-ordered, so `-l N` alone only ever reaches the first site's rows (every WebVoyager smoke so far was Allrecipes-only for exactly this reason).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `tasks/bench-v4` as the single v4 discovery root and added dataset file overrides for WebVoyager and WebTailBench. This aligns v4 evals with STG-2671 and lets short runs target curated slices for better coverage.

- **New Features**
  - Discover v4 bench tasks only from `tasks/bench-v4` (v4-spike copy removed).
  - Support `EVAL_WEBVOYAGER_FILE` and `EVAL_WEBTAILBENCH_FILE` to load curated JSONL slices; defaults unchanged.

- **Bug Fixes**
  - Deduplicate tasks by name across multi-root tiers so each case runs once.

<sup>Written for commit d5dead1fcf87db2cbc93e5b9930a8a90a54f6dfc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

