### PR TITLE
[docs]: add Model Router section to v3 models page

### DIFF
--- a/packages/docs/v3/configuration/models.mdx
+++ b/packages/docs/v3/configuration/models.mdx
@@ -103,7 +103,7 @@ await stagehand.observe("find the login button", {
 </Note>
 
 <Tip>
-  Auto Model Router works with [caching](/v3/best-practices/caching), but replay is handled by the API's server-side cache rather than the local cache — there's no local client available to self-heal a stale cached action. Pin a concrete model if you need local cache replay.
+  Auto Model Router works with [caching](/v3/best-practices/caching), but replay is handled by the API's server-side cache rather than the local cache. There's no local client available to self-heal a stale cached action. Pin a concrete model if you need local cache replay.
 </Tip>
 
 ### Switching models

--- a/packages/docs/v3/configuration/models.mdx
+++ b/packages/docs/v3/configuration/models.mdx
@@ -9,7 +9,11 @@ import { V3Banner } from '/snippets/v3-banner.mdx';
 
 
 <Callout icon="sparkles" color="#FFC107" iconType="regular">
-  **(NEW) Model Gateway** — Use your Browserbase API key to access top models from OpenAI, Anthropic, and Google. One key, one bill, no provider accounts needed. [Read the blog](https://www.browserbase.com/blog/model-gateway)
+  **(NEW) Model Router** — Stop picking models. Set `model: "auto"` and Browserbase selects the right one for every call, cutting inference cost 30–40% with no code changes. [Jump to setup](#model-router)
+</Callout>
+
+<Callout icon="sparkles" color="#FFC107" iconType="regular">
+  **Model Gateway** — Use your Browserbase API key to access top models from OpenAI, Anthropic, and Google. One key, one bill, no provider accounts needed. [Read the blog](https://www.browserbase.com/blog/model-gateway)
 </Callout>
 
 ## Model Gateway
@@ -35,7 +39,7 @@ When only a Browserbase API key is provided (without a provider-specific API key
   Model Gateway requires Browserbase-hosted browsers. It does not work with `env: "LOCAL"`.
 </Note>
 
-### Auto Model Router
+### Model Router
 
 Don't want to pick a model at all? Set `model: "auto"` and Browserbase chooses one for you on every call.
 
@@ -56,7 +60,7 @@ With `model: "auto"`, the Stagehand API selects the model for each `act`, `extra
 Because the router matches each call to the cheapest model that can handle it (instead of sending every request to one frontier model), teams typically see **30–40% lower inference cost** with no change to their automation code.
 
 <Note>
-  Auto Model Router runs on Model Gateway, so inference is billed to your Browserbase API key at market-price tokens. You don't need any provider accounts or keys.
+  Model Router runs on Model Gateway, so inference is billed to your Browserbase API key at market-price tokens. You don't need any provider accounts or keys.
 </Note>
 
 #### Requirements
@@ -103,7 +107,7 @@ await stagehand.observe("find the login button", {
 </Note>
 
 <Tip>
-  Auto Model Router works with [caching](/v3/best-practices/caching), but replay is handled by the API's server-side cache rather than the local cache. There's no local client available to self-heal a stale cached action. Pin a concrete model if you need local cache replay.
+  Model Router works with [caching](/v3/best-practices/caching), but replay is handled by the API's server-side cache rather than the local cache. There's no local client available to self-heal a stale cached action. Pin a concrete model if you need local cache replay.
 </Tip>
 
 ### Switching models
@@ -1032,7 +1036,7 @@ The following models work without the `provider/` prefix in the model parameter 
 | Provider   | Environment Variable           |
 | ---------- | ------------------------------ |
 | Model Gateway | `BROWSERBASE_API_KEY` (no provider key needed) |
-| Auto Model Router (`model: "auto"`) | `BROWSERBASE_API_KEY` (no provider key needed) |
+| Model Router (`model: "auto"`) | `BROWSERBASE_API_KEY` (no provider key needed) |
 | Google     | `GOOGLE_GENERATIVE_AI_API_KEY` or `GEMINI_API_KEY` |
 | Vertex | Service account credentials (see [setup](#first-class-models)) |
 | Anthropic  | `ANTHROPIC_API_KEY`            |
@@ -1064,7 +1068,7 @@ The following models work without the `provider/` prefix in the model parameter 
 <Accordion title="Error: model 'auto' is only supported through the Stagehand API">
 **Error:** `model: "auto" is only supported when running through the Stagehand API`
 
-[Auto Model Router](#auto-model-router) resolves the model server-side, so the session has to run through the Stagehand API.
+[Model Router](#model-router) resolves the model server-side, so the session has to run through the Stagehand API.
 
 **Solutions:**
 

--- a/packages/docs/v3/configuration/models.mdx
+++ b/packages/docs/v3/configuration/models.mdx
@@ -35,6 +35,77 @@ When only a Browserbase API key is provided (without a provider-specific API key
   Model Gateway requires Browserbase-hosted browsers. It does not work with `env: "LOCAL"`.
 </Note>
 
+### Auto Model Router
+
+Don't want to pick a model at all? Set `model: "auto"` and Browserbase chooses one for you on every call.
+
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const stagehand = new Stagehand({
+  env: "BROWSERBASE",
+  model: "auto",
+  // Only BROWSERBASE_API_KEY is needed — no provider key
+});
+
+await stagehand.init();
+```
+
+With `model: "auto"`, the Stagehand API selects the model for each `act`, `extract`, and `observe` call on your behalf, balancing accuracy, speed, and cost for that specific task. Selection happens server-side, so your code never pins a model name and automatically picks up new models as they're added.
+
+Because the router matches each call to the cheapest model that can handle it — instead of sending every request to one frontier model — teams typically see **30–40% lower inference cost** with no change to their automation code.
+
+<Note>
+  Auto Model Router runs on Model Gateway, so inference is billed to your Browserbase API key at market-price tokens. You don't need any provider accounts or keys.
+</Note>
+
+#### Requirements
+
+`"auto"` delegates model selection to the Stagehand API, so it only works when your session actually runs through that API. Stagehand throws at construction time if any of the following bypass it:
+
+| Requirement | Why |
+| ----------- | --- |
+| `env: "BROWSERBASE"` | Model selection happens server-side; `env: "LOCAL"` has no API to route through |
+| `disableAPI: false` (default) | `disableAPI: true` forces local inference, which has no model to resolve |
+| `experimental: false` (default) | Experimental mode bypasses the API |
+| No `llmClient` | A custom client replaces API-side inference entirely |
+
+<Warning>
+  Unlike a concrete model, `"auto"` has no local fallback. If the Stagehand API is unavailable for a session, `init()` throws instead of silently falling back to local inference.
+</Warning>
+
+#### Per-call routing
+
+You can also opt into the router for individual calls while keeping a concrete default model — useful for letting cheap steps route themselves while pinning a known-good model everywhere else:
+
+```typescript
+const stagehand = new Stagehand({
+  env: "BROWSERBASE",
+  model: "openai/gpt-5", // default for every call
+});
+
+// This one call is routed automatically
+const { extraction } = await stagehand.extract("get the page headline", {
+  model: "auto",
+});
+```
+
+Per-call overrides never inherit the session model's provider or API key — the server picks the provider. Explicit options are still passed through:
+
+```typescript
+await stagehand.observe("find the login button", {
+  model: { modelName: "auto", temperature: 0.5 },
+});
+```
+
+<Note>
+  `stagehand.agent()` supports `"auto"` in the default `dom` and `hybrid` modes. It is **not** supported with `mode: "cua"`, which requires an explicit [CUA model](/v3/configuration/models#agent-models-with-cua-support).
+</Note>
+
+<Tip>
+  Auto Model Router works with [caching](/v3/best-practices/caching), but replay is handled by the API's server-side cache rather than the local cache — there's no local client available to self-heal a stale cached action. Pin a concrete model if you need local cache replay.
+</Tip>
+
 ### Switching models
 
 With Model Gateway, switching between providers is just a config change — no new accounts, API keys, or code rewiring required:
@@ -961,6 +1032,7 @@ The following models work without the `provider/` prefix in the model parameter 
 | Provider   | Environment Variable           |
 | ---------- | ------------------------------ |
 | Model Gateway | `BROWSERBASE_API_KEY` (no provider key needed) |
+| Auto Model Router (`model: "auto"`) | `BROWSERBASE_API_KEY` (no provider key needed) |
 | Google     | `GOOGLE_GENERATIVE_AI_API_KEY` or `GEMINI_API_KEY` |
 | Vertex | Service account credentials (see [setup](#first-class-models)) |
 | Anthropic  | `ANTHROPIC_API_KEY`            |
@@ -987,6 +1059,22 @@ The following models work without the `provider/` prefix in the model parameter 
 - Verify the model name exists in the provider's documentation
 - Check model name is spelled correctly
 - Ensure your Model API key can access the model
+</Accordion>
+
+<Accordion title="Error: model 'auto' is only supported through the Stagehand API">
+**Error:** `model: "auto" is only supported when running through the Stagehand API`
+
+[Auto Model Router](#auto-model-router) resolves the model server-side, so the session has to run through the Stagehand API.
+
+**Solutions:**
+
+- Use `env: "BROWSERBASE"` — `"auto"` does not work with `env: "LOCAL"`
+- Remove `disableAPI: true`
+- Remove `experimental: true`
+- Remove any custom `llmClient` — it replaces API-side inference
+- Or specify a concrete model instead, e.g. `model: "openai/gpt-5"`
+
+A related error at init — `model: "auto" requires the Stagehand API, but it is unavailable for this session` — means the API declined the session. Unlike a concrete model, `"auto"` has no local fallback, so pin a model to proceed.
 </Accordion>
 
 <Accordion title="Model doesn't support structured outputs">

--- a/packages/docs/v3/configuration/models.mdx
+++ b/packages/docs/v3/configuration/models.mdx
@@ -9,11 +9,11 @@ import { V3Banner } from '/snippets/v3-banner.mdx';
 
 
 <Callout icon="sparkles" color="#FFC107" iconType="regular">
-  **(NEW) Model Router** — Stop picking models. Set `model: "auto"` and Browserbase selects the right one for every call, cutting inference cost 30–40% with no code changes. [Jump to setup](#model-router)
+  **(NEW) Model Router:** Stop picking models. Set `model: "auto"` and Browserbase selects the right one for every call, cutting inference cost 30–40% with no code changes. [Jump to setup](#model-router)
 </Callout>
 
 <Callout icon="sparkles" color="#FFC107" iconType="regular">
-  **Model Gateway** — Use your Browserbase API key to access top models from OpenAI, Anthropic, and Google. One key, one bill, no provider accounts needed. [Read the blog](https://www.browserbase.com/blog/model-gateway)
+  **Model Gateway:** Use your Browserbase API key to access top models from OpenAI, Anthropic, and Google. One key, one bill, no provider accounts needed. [Read the blog](https://www.browserbase.com/blog/model-gateway)
 </Callout>
 
 ## Model Gateway
@@ -49,7 +49,7 @@ import { Stagehand } from "@browserbasehq/stagehand";
 const stagehand = new Stagehand({
   env: "BROWSERBASE",
   model: "auto",
-  // Only BROWSERBASE_API_KEY is needed — no provider key
+  // Only BROWSERBASE_API_KEY is needed (no provider key)
 });
 
 await stagehand.init();
@@ -1072,13 +1072,13 @@ The following models work without the `provider/` prefix in the model parameter 
 
 **Solutions:**
 
-- Use `env: "BROWSERBASE"` — `"auto"` does not work with `env: "LOCAL"`
+- Use `env: "BROWSERBASE"`. `"auto"` does not work with `env: "LOCAL"`
 - Remove `disableAPI: true`
 - Remove `experimental: true`
-- Remove any custom `llmClient` — it replaces API-side inference
+- Remove any custom `llmClient`. It replaces API-side inference
 - Or specify a concrete model instead, e.g. `model: "openai/gpt-5"`
 
-A related error at init — `model: "auto" requires the Stagehand API, but it is unavailable for this session` — means the API declined the session. Unlike a concrete model, `"auto"` has no local fallback, so pin a model to proceed.
+A related error at init, `model: "auto" requires the Stagehand API, but it is unavailable for this session`, means the API declined the session. Unlike a concrete model, `"auto"` has no local fallback, so pin a model to proceed.
 </Accordion>
 
 <Accordion title="Model doesn't support structured outputs">

--- a/packages/docs/v3/configuration/models.mdx
+++ b/packages/docs/v3/configuration/models.mdx
@@ -53,7 +53,7 @@ await stagehand.init();
 
 With `model: "auto"`, the Stagehand API selects the model for each `act`, `extract`, and `observe` call on your behalf, balancing accuracy, speed, and cost for that specific task. Selection happens server-side, so your code never pins a model name and automatically picks up new models as they're added.
 
-Because the router matches each call to the cheapest model that can handle it — instead of sending every request to one frontier model — teams typically see **30–40% lower inference cost** with no change to their automation code.
+Because the router matches each call to the cheapest model that can handle it (instead of sending every request to one frontier model), teams typically see **30–40% lower inference cost** with no change to their automation code.
 
 <Note>
   Auto Model Router runs on Model Gateway, so inference is billed to your Browserbase API key at market-price tokens. You don't need any provider accounts or keys.
@@ -76,7 +76,7 @@ Because the router matches each call to the cheapest model that can handle it �
 
 #### Per-call routing
 
-You can also opt into the router for individual calls while keeping a concrete default model — useful for letting cheap steps route themselves while pinning a known-good model everywhere else:
+You can also opt into the router for individual calls while keeping a concrete default model. This is useful for letting cheap steps route themselves while pinning a known-good model everywhere else:
 
 ```typescript
 const stagehand = new Stagehand({
@@ -90,7 +90,7 @@ const { extraction } = await stagehand.extract("get the page headline", {
 });
 ```
 
-Per-call overrides never inherit the session model's provider or API key — the server picks the provider. Explicit options are still passed through:
+Per-call overrides never inherit the session model's provider or API key. The server picks the provider. Explicit options are still passed through:
 
 ```typescript
 await stagehand.observe("find the login button", {


### PR DESCRIPTION
# why

`model: "auto"` shipped in #2328 but is undocumented. This adds a **Model Router** section to `/v3/configuration/models`, nested under **Model Gateway** right after **Setup**, plus a launch callout at the top of the page.

# what changed

`packages/docs/v3/configuration/models.mdx` only — no code, so no changeset.

- **`(NEW) Model Router` callout** at the top of the page, above the Model Gateway one, linking to `#model-router`. Dropped `(NEW)` from the Model Gateway callout so only one feature is flagged as new.
- **`### Model Router`** subsection: what it does, basic usage, Model Gateway billing (market-price tokens on your Browserbase key), and the 30–40% cost reduction vs. pinning one frontier model.
- **`#### Requirements`** table covering the four API-only constraints the constructor enforces (`env: "BROWSERBASE"`, `disableAPI: false`, `experimental: false`, no `llmClient`), plus a warning that `"auto"` has no local fallback if the API is unavailable at init.
- **`#### Per-call routing`**: `{ model: "auto" }` as a per-primitive override on top of a concrete default, including the object form (`{ modelName: "auto", temperature: 0.5 }`) and the note that overrides don't inherit the session provider/API key.
- Agent support: works in default `dom`/`hybrid`, **not** with `mode: "cua"` (`"auto"` isn't in `AVAILABLE_CUA_MODELS`, so it throws `CuaModelRequiredError`).
- Caching: local replay is skipped for `"auto"` sessions; the API's server-side cache handles it.
- Troubleshooting accordion for both auto-specific errors, and an env-var table row.

Behavior claims were taken from `modelUtils.ts`, `v3.ts`, `api.ts`, `AgentCache.ts`, and `tests/unit/auto-model.test.ts`. The routing heuristic itself is server-side and not in this repo, so the copy deliberately stays general about how a model gets picked — nothing here goes stale when the router changes.

# open question

Should omitting `model` entirely also route through Model Router?

Today it doesn't — `resolveModelConfiguration()` falls back to `DEFAULT_MODEL_NAME = "openai/gpt-4.1-mini"` (`packages/core/lib/v3/v3.ts:101,115`), so an omitted `model` pins gpt-4.1-mini (run through Model Gateway if only a Browserbase key is set). That's a fixed model, not per-call routing. I left the omit path out of the docs for now. If the default should become `"auto"`, that's a core change and the docs can follow alongside it.

# test plan

- `mintlify broken-links` — no new broken links (the 5 reported are pre-existing and in other files)
- JSX components balanced, code fences even, heading nesting verified, `#model-router` anchor resolves