### PR TITLE
Repair imported docs

### DIFF
--- a/packages/docs/v2/best-practices/deployments.mdx
+++ b/packages/docs/v2/best-practices/deployments.mdx
@@ -172,7 +172,7 @@ vercel env add BROWSERBASE_PROJECT_ID
 vercel env add GOOGLE_API_KEY
 ```
 
-See also: [Browser Environment](/configuration/environment) for details on required variables.
+See also: [Browser Configuration](/v2/configuration/browser) for details on required variables.
 
 ### 9. Test locally
 
@@ -235,4 +235,3 @@ Hit the same endpoint on a schedule by extending `vercel.json`:
 - **No local browsers needed** with `env: "BROWSERBASE"`. [Browserbase](https://www.browserbase.com/) provides the browsers.
 - **Fast functionality**: Offload browser work to Browserbase and return JSON promptly.
 - **Long-running tasks**: Raise `maxDuration` and/or consider Edge runtime limits depending on plan.
-

--- a/packages/docs/v2/integrations/vercel/introduction.mdx
+++ b/packages/docs/v2/integrations/vercel/introduction.mdx
@@ -52,11 +52,10 @@ Local Playwright browsers are not available on Vercel. Set Stagehand to Browserb
 ## Links
 
 <CardGroup cols={2}>
-  <Card title="Quickstart" icon="rocket" href="/integrations/vercel/quickstart">
+  <Card title="Configuration" icon="rocket" href="/v2/integrations/vercel/configuration">
     Run locally and deploy to Vercel in minutes
   </Card>
   <Card title="TypeScript Quickstart" icon="code" href="/first-steps/quickstart">
     More templates, including Vercel deployment examples
   </Card>
 </CardGroup>
-

--- a/packages/docs/v3/basics/act.mdx
+++ b/packages/docs/v3/basics/act.mdx
@@ -327,7 +327,7 @@ for (let attempt = 0; attempt <= maxRetries; attempt++) {
 
 **Solutions**:
 - Ensure page has fully loaded
-- Check if content is in iframes: [Learn more about working with iframes](/best-practices/working-with-iframes)
+- Check if content is in iframes: [Learn more about deep locators](/v3/references/deeplocator)
 - Increase action timeout
 - Use `observe()` first to verify element exists
 

--- a/packages/docs/v3/best-practices/deployments.mdx
+++ b/packages/docs/v3/best-practices/deployments.mdx
@@ -168,7 +168,7 @@ vercel env add BROWSERBASE_API_KEY
 vercel env add GOOGLE_API_KEY
 ```
 
-See also: [Browser Environment](/configuration/environment) for details on required variables.
+See also: [Browser Configuration](/v3/configuration/browser) for details on required variables.
 
 ### 9. Test locally
 
@@ -231,4 +231,3 @@ Hit the same endpoint on a schedule by extending `vercel.json`:
 - **No local browsers needed** with `env: "BROWSERBASE"`. [Browserbase](https://www.browserbase.com/) provides the browsers.
 - **Fast functionality**: Offload browser work to Browserbase and return JSON promptly.
 - **Long-running tasks**: Raise `maxDuration` and/or consider Edge runtime limits depending on plan.
-

--- a/packages/docs/v3/best-practices/using-multiple-tabs.mdx
+++ b/packages/docs/v3/best-practices/using-multiple-tabs.mdx
@@ -60,7 +60,7 @@ console.log(`Stagehand-Python stars: ${stagehandPythonStars}`);
     Use `Agent` to autonomously execute multi-step tasks and complex workflows.
   </Card>
 
-  <Card title="Working with iframes" icon="frame" iconType="sharp-solid" href="/v3/best-practices/working-with-iframes">
+  <Card title="Deep locators" icon="frame" iconType="sharp-solid" href="/v3/references/deeplocator">
     Learn best practices for interacting with elements inside iframes.
   </Card>
 


### PR DESCRIPTION
This fixes five links that were already broken in the v3 docs:

- `/configuration/environment` → `/v2/configuration/browser`
- `/integrations/vercel/quickstart` → `/v2/integrations/vercel/configuration`
- `/best-practices/working-with-iframes` → `/v3/references/deeplocator`
- `/configuration/environment` → `/v3/configuration/browser`
- `/v3/best-practices/working-with-iframes` → `/v3/references/deeplocator`

The replacements point to existing, version-specific pages. No other documentation or styling is changed.