### PR TITLE
Format supported docs files

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,3 +1,3 @@
 {
-  "ignorePatterns": ["packages/docs/**/*.mdx"]
+  "ignorePatterns": ["packages/docs/**/*.md", "packages/docs/**/*.mdx"]
 }

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,3 +1,3 @@
 {
-  "ignorePatterns": ["packages/docs/**"]
+  "ignorePatterns": ["packages/docs/**/*.mdx"]
 }

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -26,9 +26,7 @@
           {
             "dropdown": "TypeScript",
             "icon": "code",
-            "pages": [
-              "v3/first-steps/introduction"
-            ],
+            "pages": ["v3/first-steps/introduction"],
             "groups": [
               {
                 "group": "First Steps",
@@ -138,25 +136,18 @@
               },
               {
                 "group": "Migration Guides",
-                "pages": [
-                  "v3/migrations/v2",
-                  "v3/migrations/python"
-                ]
+                "pages": ["v3/migrations/v2", "v3/migrations/python"]
               }
             ]
           },
           {
             "dropdown": "Python",
             "icon": "code",
-            "pages": [
-              "v3/sdk/python"
-            ],
+            "pages": ["v3/sdk/python"],
             "groups": [
               {
                 "group": "SDK Reference",
-                "pages": [
-                  "v3/sdk/python"
-                ]
+                "pages": ["v3/sdk/python"]
               },
               {
                 "group": "API Reference",
@@ -180,15 +171,11 @@
           {
             "dropdown": "Java",
             "icon": "code",
-            "pages": [
-              "v3/sdk/java"
-            ],
+            "pages": ["v3/sdk/java"],
             "groups": [
               {
                 "group": "SDK Reference",
-                "pages": [
-                  "v3/sdk/java"
-                ]
+                "pages": ["v3/sdk/java"]
               },
               {
                 "group": "API Reference",
@@ -212,15 +199,11 @@
           {
             "dropdown": "Go",
             "icon": "code",
-            "pages": [
-              "v3/sdk/go"
-            ],
+            "pages": ["v3/sdk/go"],
             "groups": [
               {
                 "group": "SDK Reference",
-                "pages": [
-                  "v3/sdk/go"
-                ]
+                "pages": ["v3/sdk/go"]
               },
               {
                 "group": "API Reference",
@@ -244,15 +227,11 @@
           {
             "dropdown": "Ruby",
             "icon": "code",
-            "pages": [
-              "v3/sdk/ruby"
-            ],
+            "pages": ["v3/sdk/ruby"],
             "groups": [
               {
                 "group": "SDK Reference",
-                "pages": [
-                  "v3/sdk/ruby"
-                ]
+                "pages": ["v3/sdk/ruby"]
               },
               {
                 "group": "API Reference",
@@ -289,12 +268,7 @@
           },
           {
             "group": "The Basics",
-            "pages": [
-              "v2/basics/agent",
-              "v2/basics/act",
-              "v2/basics/extract",
-              "v2/basics/observe"
-            ]
+            "pages": ["v2/basics/agent", "v2/basics/act", "v2/basics/extract", "v2/basics/observe"]
           },
           {
             "group": "Configuration",
@@ -424,12 +398,7 @@
     }
   },
   "contextual": {
-    "options": [
-      "copy",
-      "chatgpt",
-      "claude",
-      "view"
-    ]
+    "options": ["copy", "chatgpt", "claude", "view"]
   },
   "redirects": [
     {

--- a/packages/docs/language-selector.js
+++ b/packages/docs/language-selector.js
@@ -1,39 +1,39 @@
 // Language switcher for Stagehand docs
 // Handles: 1) Sidebar language dropdown selection 2) Code block language syncing
 
-(function() {
+(function () {
   // ============================================
   // CONFIGURATION
   // ============================================
 
-  const DROPDOWN_LANGUAGES = ['TypeScript', 'Python', 'Java', 'Go', 'Ruby'];
+  const DROPDOWN_LANGUAGES = ["TypeScript", "Python", "Java", "Go", "Ruby"];
 
   const LANGUAGE_MAP = {
-    'TypeScript': 'Javascript',
-    'Python': 'Python',
-    'Java': 'Java',
-    'Go': 'Go',
-    'Ruby': 'Ruby'
+    TypeScript: "Javascript",
+    Python: "Python",
+    Java: "Java",
+    Go: "Go",
+    Ruby: "Ruby",
   };
 
-  const CODE_BLOCK_LANGUAGES = ['Javascript', 'Python', 'Go', 'Java', 'Ruby', 'cURL', 'PHP'];
+  const CODE_BLOCK_LANGUAGES = ["Javascript", "Python", "Go", "Java", "Ruby", "cURL", "PHP"];
 
   const SDK_PATH_MAP = {
-    'Python': 'python',
-    'Java': 'java',
-    'Go': 'go',
-    'Ruby': 'ruby'
+    Python: "python",
+    Java: "java",
+    Go: "go",
+    Ruby: "ruby",
   };
 
   const NAVIGATION_MAP = {
-    'TypeScript': '/v3/first-steps/introduction',
-    'Python': '/v3/sdk/python',
-    'Java': '/v3/sdk/java',
-    'Go': '/v3/sdk/go',
-    'Ruby': '/v3/sdk/ruby'
+    TypeScript: "/v3/first-steps/introduction",
+    Python: "/v3/sdk/python",
+    Java: "/v3/sdk/java",
+    Go: "/v3/sdk/go",
+    Ruby: "/v3/sdk/ruby",
   };
 
-  let currentSelectedLanguage = 'TypeScript';
+  let currentSelectedLanguage = "TypeScript";
   let isSelecting = false;
 
   // ============================================
@@ -43,8 +43,8 @@
   // Run callback on next frame (immediate visual update)
   const onNextFrame = (fn) => requestAnimationFrame(() => requestAnimationFrame(fn));
 
-  const dropdownStyle = document.createElement('style');
-  dropdownStyle.id = 'stagehand-language-style';
+  const dropdownStyle = document.createElement("style");
+  dropdownStyle.id = "stagehand-language-style";
   dropdownStyle.textContent = `
     /* Hide dropdown during programmatic selection */
     .stagehand-selecting [role="menu"],
@@ -65,32 +65,32 @@
     }
   `;
   document.head.appendChild(dropdownStyle);
-  
+
   // ============================================
   // SDK REFERENCE FILTERING
   // ============================================
-  
+
   function updateSDKReferenceVisibility() {
     // Get the SDK path for the current language
     const currentSDKPath = SDK_PATH_MAP[currentSelectedLanguage];
-    
+
     // Find all SDK reference items in the sidebar
     const sdkItems = document.querySelectorAll('li[id^="/v3/sdk/"]');
-    
-    sdkItems.forEach(item => {
-      const itemId = item.getAttribute('id') || '';
+
+    sdkItems.forEach((item) => {
+      const itemId = item.getAttribute("id") || "";
       // Extract the language from the id (e.g., "/v3/sdk/python" -> "python")
-      const itemLang = itemId.split('/').pop();
-      
-      if (currentSelectedLanguage === 'TypeScript') {
+      const itemLang = itemId.split("/").pop();
+
+      if (currentSelectedLanguage === "TypeScript") {
         // For TypeScript, hide all SDK references (they don't apply)
-        item.classList.add('stagehand-sdk-hidden');
+        item.classList.add("stagehand-sdk-hidden");
       } else if (currentSDKPath && itemLang === currentSDKPath) {
         // Show the SDK that matches the current language
-        item.classList.remove('stagehand-sdk-hidden');
+        item.classList.remove("stagehand-sdk-hidden");
       } else {
         // Hide SDKs that don't match
-        item.classList.add('stagehand-sdk-hidden');
+        item.classList.add("stagehand-sdk-hidden");
       }
     });
   }
@@ -98,77 +98,79 @@
   // ============================================
   // VERSION SWITCHER VISIBILITY
   // ============================================
-  
+
   function getVersionSwitcher() {
     // Find the version switcher button (contains "v3" or "v2" and has chevron-down)
-    const buttons = document.querySelectorAll('button');
+    const buttons = document.querySelectorAll("button");
     for (const btn of buttons) {
-      const text = (btn.textContent || '').trim().toLowerCase();
+      const text = (btn.textContent || "").trim().toLowerCase();
       // Check if it's a version button (v2, v3, etc.) with chevron icon
-      if (/^v\d+$/.test(text) && btn.querySelector('.lucide-chevron-down')) {
+      if (/^v\d+$/.test(text) && btn.querySelector(".lucide-chevron-down")) {
         return btn;
       }
     }
     return null;
   }
-  
+
   function updateVersionSwitcherVisibility() {
     const versionSwitcher = getVersionSwitcher();
-    
+
     if (versionSwitcher) {
       // Mark the version switcher so we can target it with CSS
-      versionSwitcher.classList.add('stagehand-version-switcher');
-      
+      versionSwitcher.classList.add("stagehand-version-switcher");
+
       // Show version switcher only for TypeScript
-      if (currentSelectedLanguage === 'TypeScript') {
-        document.body.classList.remove('stagehand-hide-version-switcher');
+      if (currentSelectedLanguage === "TypeScript") {
+        document.body.classList.remove("stagehand-hide-version-switcher");
       } else {
-        document.body.classList.add('stagehand-hide-version-switcher');
+        document.body.classList.add("stagehand-hide-version-switcher");
       }
     }
   }
-  
+
   // ============================================
   // SIDEBAR DROPDOWN FUNCTIONS
   // ============================================
-  
+
   function getDropdownButton() {
-    const buttons = document.querySelectorAll('button');
+    const buttons = document.querySelectorAll("button");
     for (const btn of buttons) {
-      const text = (btn.textContent || '').trim();
+      const text = (btn.textContent || "").trim();
       if (DROPDOWN_LANGUAGES.includes(text)) {
         return btn;
       }
     }
     return null;
   }
-  
+
   function getDropdownMenu() {
     return document.querySelector('menu[role="menu"], [role="menu"]');
   }
-  
+
   function updateButtonText(newText) {
     const button = getDropdownButton();
     if (!button) return;
-    
-    const paragraph = button.querySelector('p');
+
+    const paragraph = button.querySelector("p");
     if (paragraph) {
       paragraph.textContent = newText;
     }
   }
-  
+
   function updateDropdownCheckIndicator() {
     const menu = getDropdownMenu();
     if (!menu) return;
-    
+
     const menuItems = menu.querySelectorAll('a, [role="menuitem"]');
     const checkIconsMap = new Map();
     let anyCheckIcon = null;
-    
+
     for (const item of menuItems) {
-      const text = (item.textContent || '').trim();
-      const checkIcon = item.querySelector('.lucide-check, [class*="lucide-check"], svg[class*="check"]');
-      
+      const text = (item.textContent || "").trim();
+      const checkIcon = item.querySelector(
+        '.lucide-check, [class*="lucide-check"], svg[class*="check"]',
+      );
+
       for (const lang of DROPDOWN_LANGUAGES) {
         if (text.includes(lang)) {
           checkIconsMap.set(lang, { item, checkIcon });
@@ -179,64 +181,72 @@
         }
       }
     }
-    
+
     for (const [lang, { item, checkIcon }] of checkIconsMap) {
       const shouldBeSelected = lang === currentSelectedLanguage;
-      
+
       if (checkIcon) {
-        checkIcon.style.opacity = shouldBeSelected ? '1' : '0';
-        checkIcon.style.visibility = shouldBeSelected ? 'visible' : 'hidden';
+        checkIcon.style.opacity = shouldBeSelected ? "1" : "0";
+        checkIcon.style.visibility = shouldBeSelected ? "visible" : "hidden";
       } else if (shouldBeSelected && anyCheckIcon) {
         const clonedCheck = anyCheckIcon.cloneNode(true);
-        clonedCheck.style.opacity = '1';
-        clonedCheck.style.visibility = 'visible';
-        
-        const targetSpan = item.querySelector('span:last-child') || item;
+        clonedCheck.style.opacity = "1";
+        clonedCheck.style.visibility = "visible";
+
+        const targetSpan = item.querySelector("span:last-child") || item;
         if (targetSpan.querySelector('.lucide-check, [class*="lucide-check"]') === null) {
           targetSpan.appendChild(clonedCheck);
         }
       }
     }
   }
-  
+
   // ============================================
   // CODE BLOCK LANGUAGE SELECTOR FUNCTIONS
   // ============================================
-  
+
   function simulateClick(element) {
     if (!element) return;
     const rect = element.getBoundingClientRect();
     const x = rect.left + rect.width / 2;
     const y = rect.top + rect.height / 2;
-    
-    ['pointerdown', 'mousedown', 'pointerup', 'mouseup', 'click'].forEach(eventType => {
-      const EventClass = eventType.startsWith('pointer') ? PointerEvent : MouseEvent;
-      element.dispatchEvent(new EventClass(eventType, {
-        view: window, bubbles: true, cancelable: true,
-        clientX: x, clientY: y, button: 0, buttons: 1,
-        isPrimary: true, pointerType: 'mouse'
-      }));
+
+    ["pointerdown", "mousedown", "pointerup", "mouseup", "click"].forEach((eventType) => {
+      const EventClass = eventType.startsWith("pointer") ? PointerEvent : MouseEvent;
+      element.dispatchEvent(
+        new EventClass(eventType, {
+          view: window,
+          bubbles: true,
+          cancelable: true,
+          clientX: x,
+          clientY: y,
+          button: 0,
+          buttons: 1,
+          isPrimary: true,
+          pointerType: "mouse",
+        }),
+      );
     });
   }
-  
+
   function getCodeBlockLanguageDropdown() {
-    const paragraphs = document.querySelectorAll('p');
-    
+    const paragraphs = document.querySelectorAll("p");
+
     for (const p of paragraphs) {
-      const text = (p.textContent || '').trim();
+      const text = (p.textContent || "").trim();
       if (CODE_BLOCK_LANGUAGES.includes(text)) {
-        const parentDiv = p.closest('div');
-        if (parentDiv && parentDiv.querySelector('.lucide-chevrons-up-down')) {
+        const parentDiv = p.closest("div");
+        if (parentDiv && parentDiv.querySelector(".lucide-chevrons-up-down")) {
           return { element: parentDiv, language: text };
         }
       }
     }
     return null;
   }
-  
+
   function waitForCodeBlockMenuAndSelect(targetLanguage, attempts = 0) {
     if (attempts > 30) {
-      document.body.classList.remove('stagehand-selecting');
+      document.body.classList.remove("stagehand-selecting");
       document.body.click();
       isSelecting = false;
       return;
@@ -250,11 +260,11 @@
     }
 
     for (const item of menuItems) {
-      const text = (item.textContent || '').trim();
+      const text = (item.textContent || "").trim();
       if (text === targetLanguage) {
         simulateClick(item);
         onNextFrame(() => {
-          document.body.classList.remove('stagehand-selecting');
+          document.body.classList.remove("stagehand-selecting");
           isSelecting = false;
         });
         return;
@@ -272,7 +282,7 @@
     if (current.language === targetLanguage) return;
 
     isSelecting = true;
-    document.body.classList.add('stagehand-selecting');
+    document.body.classList.add("stagehand-selecting");
     simulateClick(current.element);
     requestAnimationFrame(() => waitForCodeBlockMenuAndSelect(targetLanguage));
   }
@@ -283,11 +293,11 @@
       selectCodeBlockLanguage(codeBlockLang);
     }
   }
-  
+
   // ============================================
   // EVENT HANDLERS & OBSERVERS
   // ============================================
-  
+
   function setupDropdownMenuObserver() {
     const menuObserver = new MutationObserver(() => {
       const menu = getDropdownMenu();
@@ -299,66 +309,70 @@
 
     menuObserver.observe(document.body, {
       subtree: true,
-      childList: true
+      childList: true,
     });
   }
-  
+
   function setupMenuClickHandler() {
-    document.addEventListener('click', (e) => {
-      const target = e.target;
-      
-      // Check if we clicked on a sidebar dropdown menu item
-      const menuItem = target.closest('[role="menu"] a, menu a');
-      if (!menuItem) return;
-      
-      const text = (menuItem.textContent || '').trim();
-      
-      // Check if it's one of our language options
-      for (const lang of DROPDOWN_LANGUAGES) {
-        if (text.includes(lang)) {
-          currentSelectedLanguage = lang;
-          
-          // Update the check indicator immediately
-          updateDropdownCheckIndicator();
-          
-          // Update version switcher visibility
-          updateVersionSwitcherVisibility();
-          
-          // Update SDK reference visibility
-          updateSDKReferenceVisibility();
-          
-          // Store in sessionStorage
-          try {
-            sessionStorage.setItem('stagehand-selected-language', lang);
-          } catch (err) {
-            // Ignore storage errors
+    document.addEventListener(
+      "click",
+      (e) => {
+        const target = e.target;
+
+        // Check if we clicked on a sidebar dropdown menu item
+        const menuItem = target.closest('[role="menu"] a, menu a');
+        if (!menuItem) return;
+
+        const text = (menuItem.textContent || "").trim();
+
+        // Check if it's one of our language options
+        for (const lang of DROPDOWN_LANGUAGES) {
+          if (text.includes(lang)) {
+            currentSelectedLanguage = lang;
+
+            // Update the check indicator immediately
+            updateDropdownCheckIndicator();
+
+            // Update version switcher visibility
+            updateVersionSwitcherVisibility();
+
+            // Update SDK reference visibility
+            updateSDKReferenceVisibility();
+
+            // Store in sessionStorage
+            try {
+              sessionStorage.setItem("stagehand-selected-language", lang);
+            } catch (err) {
+              // Ignore storage errors
+            }
+
+            // Navigate to the corresponding SDK page
+            const targetPath = NAVIGATION_MAP[lang];
+            const normalizedPathname = window.location.pathname.replace(/\/$/, "");
+            if (targetPath && !normalizedPathname.endsWith(targetPath)) {
+              e.preventDefault();
+              e.stopPropagation();
+              window.location.href = targetPath;
+              return;
+            }
+
+            // Update button text after menu closes
+            onNextFrame(() => updateButtonText(lang));
+
+            // Sync the code block language selector
+            onNextFrame(syncCodeBlockLanguage);
+
+            break;
           }
-
-          // Navigate to the corresponding SDK page
-          const targetPath = NAVIGATION_MAP[lang];
-          const normalizedPathname = window.location.pathname.replace(/\/$/, '');
-          if (targetPath && !normalizedPathname.endsWith(targetPath)) {
-            e.preventDefault();
-            e.stopPropagation();
-            window.location.href = targetPath;
-            return;
-          }
-
-          // Update button text after menu closes
-          onNextFrame(() => updateButtonText(lang));
-
-          // Sync the code block language selector
-          onNextFrame(syncCodeBlockLanguage);
-
-          break;
         }
-      }
-    }, true);
+      },
+      true,
+    );
   }
-  
+
   function restoreLanguageSelection() {
     try {
-      const stored = sessionStorage.getItem('stagehand-selected-language');
+      const stored = sessionStorage.getItem("stagehand-selected-language");
       if (stored && DROPDOWN_LANGUAGES.includes(stored)) {
         currentSelectedLanguage = stored;
         updateButtonText(stored);
@@ -376,7 +390,7 @@
       updateSDKReferenceVisibility();
     });
   }
-  
+
   function setupPageChangeObserver() {
     let sdkUpdatePending = false;
 
@@ -384,26 +398,31 @@
       // Check if button needs updating
       const button = getDropdownButton();
       if (button) {
-        const currentText = (button.textContent || '').trim();
-        if (currentText !== currentSelectedLanguage && DROPDOWN_LANGUAGES.includes(currentSelectedLanguage)) {
+        const currentText = (button.textContent || "").trim();
+        if (
+          currentText !== currentSelectedLanguage &&
+          DROPDOWN_LANGUAGES.includes(currentSelectedLanguage)
+        ) {
           updateButtonText(currentSelectedLanguage);
         }
       }
 
       // Re-check version switcher visibility (DOM might have re-rendered)
       const versionSwitcher = getVersionSwitcher();
-      if (versionSwitcher && !versionSwitcher.classList.contains('stagehand-version-switcher')) {
+      if (versionSwitcher && !versionSwitcher.classList.contains("stagehand-version-switcher")) {
         updateVersionSwitcherVisibility();
       }
 
       // Check for SDK reference items that need to be hidden (debounced via rAF)
-      const sdkItems = document.querySelectorAll('li[id^="/v3/sdk/"]:not(.stagehand-sdk-processed)');
+      const sdkItems = document.querySelectorAll(
+        'li[id^="/v3/sdk/"]:not(.stagehand-sdk-processed)',
+      );
       if (sdkItems.length > 0 && !sdkUpdatePending) {
         sdkUpdatePending = true;
         onNextFrame(() => {
           updateSDKReferenceVisibility();
-          document.querySelectorAll('li[id^="/v3/sdk/"]').forEach(item => {
-            item.classList.add('stagehand-sdk-processed');
+          document.querySelectorAll('li[id^="/v3/sdk/"]').forEach((item) => {
+            item.classList.add("stagehand-sdk-processed");
           });
           sdkUpdatePending = false;
         });
@@ -412,10 +431,10 @@
 
     observer.observe(document.body, {
       subtree: true,
-      childList: true
+      childList: true,
     });
   }
-  
+
   // Watch for code block dropdowns appearing and sync them
   function setupCodeBlockObserver() {
     let lastCodeBlockDropdown = null;
@@ -435,10 +454,10 @@
 
     observer.observe(document.body, {
       subtree: true,
-      childList: true
+      childList: true,
     });
   }
-  
+
   // ============================================
   // INITIALIZATION
   // ============================================
@@ -455,8 +474,8 @@
   }
 
   // Initialize on page load
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', init);
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
   } else {
     init();
   }
@@ -467,8 +486,8 @@
     if (location.href !== lastUrl) {
       lastUrl = location.href;
       // Remove processed class so SDK items get re-evaluated
-      document.querySelectorAll('li[id^="/v3/sdk/"].stagehand-sdk-processed').forEach(item => {
-        item.classList.remove('stagehand-sdk-processed');
+      document.querySelectorAll('li[id^="/v3/sdk/"].stagehand-sdk-processed').forEach((item) => {
+        item.classList.remove("stagehand-sdk-processed");
       });
       onNextFrame(() => {
         restoreLanguageSelection();

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -2,6 +2,9 @@
   "name": "@browserbasehq/stagehand-docs",
   "version": "1.0.0",
   "description": "",
+  "keywords": [],
+  "license": "ISC",
+  "author": "",
   "type": "module",
   "main": "index.js",
   "scripts": {
@@ -9,9 +12,6 @@
     "upgrade": "mintlify upgrade",
     "sync-sdk": "node scripts/sync-sdk-docs.js"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
   "dependencies": {
     "mintlify": "^4.2.563",
     "zod": "^4.2.1"

--- a/packages/docs/scripts/runtimePaths.js
+++ b/packages/docs/scripts/runtimePaths.js
@@ -37,8 +37,7 @@ const readCallsites = () => {
 };
 
 const readCallsitePath = (callsite) => {
-  const rawPath =
-    callsite.getFileName?.() ?? callsite.getScriptNameOrSourceURL?.();
+  const rawPath = callsite.getFileName?.() ?? callsite.getScriptNameOrSourceURL?.();
   if (!rawPath) return null;
   if (rawPath.startsWith("node:")) return null;
   if (EVAL_FRAMES.has(rawPath)) return null;

--- a/packages/docs/scripts/sync-sdk-docs.js
+++ b/packages/docs/scripts/sync-sdk-docs.js
@@ -2,9 +2,9 @@
 
 /**
  * Script to sync SDK documentation from GitHub READMEs
- * 
+ *
  * Usage: node scripts/sync-sdk-docs.js
- * 
+ *
  * This script fetches README.md files from each language SDK repo
  * and generates MDX files for the docs.
  */
@@ -19,29 +19,29 @@ const currentDir = getCurrentDirPath();
 // SDK repos configuration
 const SDK_REPOS = {
   java: {
-    repo: 'browserbase/stagehand-java',
-    title: 'Java SDK',
-    description: 'Official Stagehand SDK for Java',
-    outputPath: 'v3/sdk/java.mdx'
+    repo: "browserbase/stagehand-java",
+    title: "Java SDK",
+    description: "Official Stagehand SDK for Java",
+    outputPath: "v3/sdk/java.mdx",
   },
   python: {
-    repo: 'browserbase/stagehand-python',
-    title: 'Python SDK',
-    description: 'Official Stagehand SDK for Python',
-    outputPath: 'v3/sdk/python.mdx'
+    repo: "browserbase/stagehand-python",
+    title: "Python SDK",
+    description: "Official Stagehand SDK for Python",
+    outputPath: "v3/sdk/python.mdx",
   },
   ruby: {
-    repo: 'browserbase/stagehand-ruby',
-    title: 'Ruby SDK',
-    description: 'Official Stagehand SDK for Ruby',
-    outputPath: 'v3/sdk/ruby.mdx'
+    repo: "browserbase/stagehand-ruby",
+    title: "Ruby SDK",
+    description: "Official Stagehand SDK for Ruby",
+    outputPath: "v3/sdk/ruby.mdx",
   },
   go: {
-    repo: 'browserbase/stagehand-go',
-    title: 'Go SDK',
-    description: 'Official Stagehand SDK for Go',
-    outputPath: 'v3/sdk/go.mdx'
-  }
+    repo: "browserbase/stagehand-go",
+    title: "Go SDK",
+    description: "Official Stagehand SDK for Go",
+    outputPath: "v3/sdk/go.mdx",
+  },
 };
 
 /**
@@ -49,27 +49,33 @@ const SDK_REPOS = {
  */
 function fetchUrl(url) {
   return new Promise((resolve, reject) => {
-    https.get(url, {
-      headers: {
-        'User-Agent': 'Stagehand-Docs-Sync'
-      }
-    }, (res) => {
-      // Handle redirects
-      if (res.statusCode === 301 || res.statusCode === 302) {
-        fetchUrl(res.headers.location).then(resolve).catch(reject);
-        return;
-      }
-      
-      if (res.statusCode !== 200) {
-        reject(new Error(`HTTP ${res.statusCode}: ${url}`));
-        return;
-      }
-      
-      let data = '';
-      res.on('data', chunk => data += chunk);
-      res.on('end', () => resolve(data));
-      res.on('error', reject);
-    }).on('error', reject);
+    https
+      .get(
+        url,
+        {
+          headers: {
+            "User-Agent": "Stagehand-Docs-Sync",
+          },
+        },
+        (res) => {
+          // Handle redirects
+          if (res.statusCode === 301 || res.statusCode === 302) {
+            fetchUrl(res.headers.location).then(resolve).catch(reject);
+            return;
+          }
+
+          if (res.statusCode !== 200) {
+            reject(new Error(`HTTP ${res.statusCode}: ${url}`));
+            return;
+          }
+
+          let data = "";
+          res.on("data", (chunk) => (data += chunk));
+          res.on("end", () => resolve(data));
+          res.on("error", reject);
+        },
+      )
+      .on("error", reject);
   });
 }
 
@@ -78,59 +84,62 @@ function fetchUrl(url) {
  */
 function processReadmeContent(content, config) {
   let processed = content;
-  
+
   // Remove HTML comments
-  processed = processed.replace(/<!--[\s\S]*?-->/g, '');
-  
+  processed = processed.replace(/<!--[\s\S]*?-->/g, "");
+
   // Remove entire HTML blocks with picture/source tags (badge sections)
-  processed = processed.replace(/<div[^>]*>[\s\S]*?<\/div>/gi, '');
-  processed = processed.replace(/<p[^>]*align[^>]*>[\s\S]*?<\/p>/gi, '');
-  processed = processed.replace(/<picture>[\s\S]*?<\/picture>/gi, '');
-  
+  processed = processed.replace(/<div[^>]*>[\s\S]*?<\/div>/gi, "");
+  processed = processed.replace(/<p[^>]*align[^>]*>[\s\S]*?<\/p>/gi, "");
+  processed = processed.replace(/<picture>[\s\S]*?<\/picture>/gi, "");
+
   // Remove standalone HTML tags
-  processed = processed.replace(/<a[^>]*>[\s]*<img[^>]*>[\s]*<\/a>/gi, '');
-  processed = processed.replace(/<img[^>]*badge[^>]*>/gi, '');
-  processed = processed.replace(/<img[^>]*shields\.io[^>]*>/gi, '');
-  processed = processed.replace(/<a[^>]*>\s*<picture>[\s\S]*?<\/picture>\s*<\/a>/gi, '');
-  
+  processed = processed.replace(/<a[^>]*>[\s]*<img[^>]*>[\s]*<\/a>/gi, "");
+  processed = processed.replace(/<img[^>]*badge[^>]*>/gi, "");
+  processed = processed.replace(/<img[^>]*shields\.io[^>]*>/gi, "");
+  processed = processed.replace(/<a[^>]*>\s*<picture>[\s\S]*?<\/picture>\s*<\/a>/gi, "");
+
   // Remove badge images in markdown format
-  processed = processed.replace(/^\s*(\[!\[.*?\]\(.*?\)\]\(.*?\)\s*)+/gm, '');
-  processed = processed.replace(/^\s*!\[.*?\]\(https:\/\/.*?badge.*?\)\s*/gm, '');
-  processed = processed.replace(/\[!\[.*?\]\(.*?badge.*?\)\]\(.*?\)/g, '');
-  
+  processed = processed.replace(/^\s*(\[!\[.*?\]\(.*?\)\]\(.*?\)\s*)+/gm, "");
+  processed = processed.replace(/^\s*!\[.*?\]\(https:\/\/.*?badge.*?\)\s*/gm, "");
+  processed = processed.replace(/\[!\[.*?\]\(.*?badge.*?\)\]\(.*?\)/g, "");
+
   // Remove standalone anchor img tags
-  processed = processed.replace(/<a[^>]*href[^>]*><img[^>]*><\/a>/gi, '');
-  
+  processed = processed.replace(/<a[^>]*href[^>]*><img[^>]*><\/a>/gi, "");
+
   // Clean up <code> tags with backticks inside (common in Go docs)
-  processed = processed.replace(/<code>\\`([^`]*?)\\`<\/code>/g, '`$1`');
-  processed = processed.replace(/<code>`([^`]*?)`<\/code>/g, '`$1`');
-  processed = processed.replace(/<code>([^<]*?)<\/code>/g, '`$1`');
-  
+  processed = processed.replace(/<code>\\`([^`]*?)\\`<\/code>/g, "`$1`");
+  processed = processed.replace(/<code>`([^`]*?)`<\/code>/g, "`$1`");
+  processed = processed.replace(/<code>([^<]*?)<\/code>/g, "`$1`");
+
   // Fix malformed links with parentheses in URL (Go docs issue)
-  processed = processed.replace(/\[([^\]]+)\]\(([^)]+)\(([^)]+)\)([^)]*)\)/g, '[$1]($2)');
-  
+  processed = processed.replace(/\[([^\]]+)\]\(([^)]+)\(([^)]+)\)([^)]*)\)/g, "[$1]($2)");
+
   // Convert relative links to absolute GitHub links
   const repoUrl = `https://github.com/${config.repo}`;
-  processed = processed.replace(/\]\((?!http)(?!#)(?!mailto)([^)]+)\)/g, `](${repoUrl}/blob/main/$1)`);
-  
+  processed = processed.replace(
+    /\]\((?!http)(?!#)(?!mailto)([^)]+)\)/g,
+    `](${repoUrl}/blob/main/$1)`,
+  );
+
   // Fix code block language hints for MDX
-  processed = processed.replace(/```kotlin/g, '```java');
-  
+  processed = processed.replace(/```kotlin/g, "```java");
+
   // Remove the first H1 if it exists (we'll add our own title)
-  processed = processed.replace(/^#\s+.*\n+/, '');
-  
+  processed = processed.replace(/^#\s+.*\n+/, "");
+
   // Clean up excessive newlines
-  processed = processed.replace(/\n{4,}/g, '\n\n\n');
-  
+  processed = processed.replace(/\n{4,}/g, "\n\n\n");
+
   // Remove any remaining inline HTML img tags
-  processed = processed.replace(/<img[^>]*>/gi, '');
-  
+  processed = processed.replace(/<img[^>]*>/gi, "");
+
   // Remove any remaining <a> tags that are empty or just whitespace
-  processed = processed.replace(/<a[^>]*>\s*<\/a>/gi, '');
-  
+  processed = processed.replace(/<a[^>]*>\s*<\/a>/gi, "");
+
   // Clean up lines that are just whitespace
-  processed = processed.replace(/^\s+$/gm, '');
-  
+  processed = processed.replace(/^\s+$/gm, "");
+
   return processed.trim();
 }
 
@@ -155,25 +164,25 @@ description: "${config.description}"
  */
 async function syncSdk(language, config) {
   const rawUrl = `https://raw.githubusercontent.com/${config.repo}/main/README.md`;
-  
+
   console.log(`Fetching ${language} SDK docs from ${rawUrl}...`);
-  
+
   try {
     const readme = await fetchUrl(rawUrl);
     const processedContent = processReadmeContent(readme, config);
     const frontmatter = generateFrontmatter(config);
     const mdxContent = frontmatter + processedContent;
-    
+
     // Ensure directory exists
     const outputDir = path.dirname(`${currentDir}/../${config.outputPath}`);
     if (!fs.existsSync(outputDir)) {
       fs.mkdirSync(outputDir, { recursive: true });
     }
-    
+
     // Write MDX file
     const outputFile = `${currentDir}/../${config.outputPath}`;
-    fs.writeFileSync(outputFile, mdxContent, 'utf8');
-    
+    fs.writeFileSync(outputFile, mdxContent, "utf8");
+
     console.log(`✓ ${language} SDK docs written to ${config.outputPath}`);
     return true;
   } catch (error) {
@@ -186,23 +195,23 @@ async function syncSdk(language, config) {
  * Main function
  */
 async function main() {
-  console.log('Syncing SDK documentation from GitHub...\n');
-  
+  console.log("Syncing SDK documentation from GitHub...\n");
+
   const results = await Promise.all(
-    Object.entries(SDK_REPOS).map(([lang, config]) => syncSdk(lang, config))
+    Object.entries(SDK_REPOS).map(([lang, config]) => syncSdk(lang, config)),
   );
-  
+
   const successCount = results.filter(Boolean).length;
   const totalCount = results.length;
-  
+
   console.log(`\nDone! ${successCount}/${totalCount} SDKs synced successfully.`);
-  
+
   if (successCount < totalCount) {
     process.exit(1);
   }
 }
 
-main().catch(error => {
-  console.error('Fatal error:', error);
+main().catch((error) => {
+  console.error("Fatal error:", error);
   process.exit(1);
 });

--- a/packages/docs/sdk-api-reference-labels.js
+++ b/packages/docs/sdk-api-reference-labels.js
@@ -115,9 +115,7 @@
   let lastPath = window.location.pathname;
 
   function currentSdkLanguage() {
-    const match = window.location.pathname.match(
-      /^\/v3\/api-reference\/([^/]+)(?:\/|$)/,
-    );
+    const match = window.location.pathname.match(/^\/v3\/api-reference\/([^/]+)(?:\/|$)/);
     return match ? match[1] : null;
   }
 
@@ -126,10 +124,7 @@
   }
 
   function buildPattern(labels) {
-    return new RegExp(
-      `\\b(${Object.keys(labels).map(escapeRegExp).join("|")})\\b`,
-      "g",
-    );
+    return new RegExp(`\\b(${Object.keys(labels).map(escapeRegExp).join("|")})\\b`, "g");
   }
 
   function shouldRewriteTextNode(node, pattern) {
@@ -149,17 +144,13 @@
     if (!labels) return;
 
     const pattern = buildPattern(labels);
-    const walker = document.createTreeWalker(
-      root || document.body,
-      NodeFilter.SHOW_TEXT,
-      {
-        acceptNode(node) {
-          return shouldRewriteTextNode(node, pattern)
-            ? NodeFilter.FILTER_ACCEPT
-            : NodeFilter.FILTER_REJECT;
-        },
+    const walker = document.createTreeWalker(root || document.body, NodeFilter.SHOW_TEXT, {
+      acceptNode(node) {
+        return shouldRewriteTextNode(node, pattern)
+          ? NodeFilter.FILTER_ACCEPT
+          : NodeFilter.FILTER_REJECT;
       },
-    );
+    });
 
     const nodes = [];
     while (walker.nextNode()) nodes.push(walker.currentNode);


### PR DESCRIPTION
This formats the JavaScript and JSON files that came over with the v3 docs.

The MDX files are intentionally left unchanged. The current Oxfmt MDX formatter changes content inside valid Mintlify code examples, including identifiers and comment delimiters, so formatting those files would not be a safe mechanical change.

The docs MDX path is excluded from Oxfmt until it can format these files without changing their content.