### PR TITLE
evals: use cross-frame locators for iframe form assertions

### DIFF
--- a/packages/evals/tasks/bench-v4/act/iframe_form_filling.ts
+++ b/packages/evals/tasks/bench-v4/act/iframe_form_filling.ts
@@ -14,51 +14,30 @@ export default defineBenchV4Task(
       await stagehand.act("click 'phone' as the preferred contact method");
       await stagehand.act("type 'yooooooooooooooo' into the message box");
 
-      // v3 used page.frameLocator("iframe") for these assertions; v4 has no
-      // frameLocator, so the same checks are re-expressed in-page via the
-      // same-origin iframe's contentDocument.
-      const {
-        firstNameValue,
-        lastNameValue,
-        emailValue,
-        contactValue,
-        messageValue,
-      } = await page.evaluate(() => {
-        const doc = document.querySelector("iframe")?.contentDocument;
-        if (!doc) throw new Error("could not access iframe contentDocument");
+      // The form lives in a cross-origin iframe, so main-frame evaluation
+      // cannot access its contentDocument. V4 locators resolve `>>` iframe
+      // hops server-side and can inspect the OOPIF directly.
+      const firstNameValue = await page
+        .locator('iframe >> input[placeholder="Jane"]')
+        .inputValue();
 
-        const firstName = doc.querySelector(
-          'input[placeholder="Jane"]',
-        ) as HTMLInputElement | null;
-        const lastName = doc.querySelector(
-          'input[placeholder="Doe"]',
-        ) as HTMLInputElement | null;
-        const email = doc.querySelector(
-          'input[placeholder="jane@example.com"]',
-        ) as HTMLInputElement | null;
-        const contact = doc.evaluate(
-          "/html/body/main/section[1]/form/fieldset/label[2]/input",
-          doc,
-          null,
-          XPathResult.FIRST_ORDERED_NODE_TYPE,
-          null,
-        ).singleNodeValue as HTMLInputElement | null;
-        const message = doc.querySelector(
-          'textarea[placeholder="Say hello…"]',
-        ) as HTMLTextAreaElement | null;
+      const lastNameValue = await page
+        .locator('iframe >> input[placeholder="Doe"]')
+        .inputValue();
 
-        if (!firstName || !lastName || !email || !contact || !message) {
-          throw new Error("could not resolve form fields inside the iframe");
-        }
+      const emailValue = await page
+        .locator('iframe >> input[placeholder="jane@example.com"]')
+        .inputValue();
 
-        return {
-          firstNameValue: firstName.value,
-          lastNameValue: lastName.value,
-          emailValue: email.value,
-          contactValue: contact.checked,
-          messageValue: message.value,
-        };
-      });
+      const contactValue = await page
+        .locator(
+          "iframe >> xpath=/html/body/main/section[1]/form/fieldset/label[2]/input",
+        )
+        .isChecked();
+
+      const messageValue = await page
+        .locator('iframe >> textarea[placeholder="Say hello…"]')
+        .inputValue();
 
       const passed: boolean =
         firstNameValue.toLowerCase().trim() === "nunya" &&


### PR DESCRIPTION
## Why

The V4 `iframe_form_filling` eval validates the completed form through `page.evaluate` and `iframe.contentDocument`.

The fixture contains a cross-origin OOPIF, so the outer page cannot access its `contentDocument`. The validator therefore throws `Uncaught` regardless of the form’s state.

Before:

```ts
document.querySelector("iframe")?.contentDocument?.querySelector('input[placeholder="Jane"]')
```

After:

```ts
page.locator('iframe >> input[placeholder="Jane"]').inputValue()
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the V4 `iframe_form_filling` eval to cross-frame locators for form assertions. Prevents crashes with cross-origin OOPIF iframes and reliably reads field values.

- **Bug Fixes**
  - Replaces `page.evaluate`/`contentDocument` with `page.locator('iframe >> ...')` (uses XPath for the contact radio).
  - Uses `inputValue()` and `isChecked()` to verify text fields, textarea, and radio state.

<sup>Written for commit f2937166feda1cc092c63613d3200576efd45210. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

