### PR TITLE
Add resident runtime connection foundations

### DIFF
--- a/packages/server/runtime.ts
+++ b/packages/server/runtime.ts
@@ -218,7 +218,14 @@ export type StagehandBrowserSession = {
 export type StagehandBrowserSessionFactory = (
   cdpUrl: string,
   logger: StagehandLogger,
+  lifecycle?: StagehandBrowserSessionLifecycle,
 ) => Promise<StagehandBrowserSession>;
+
+export type StagehandBrowserSessionLifecycle = {
+  onConnecting?(): void;
+  onConnected?(): void;
+  onDisconnected?(): void;
+};
 
 export type StagehandRuntimeAdapters = {
   browserSessionFactory?: StagehandBrowserSessionFactory;
@@ -257,6 +264,7 @@ export class StagehandRuntime {
   );
   browserSession?: StagehandBrowserSession;
   pagesById = new Map<string, UnderstudyRuntimePage>();
+  private browserSessionGeneration = 0;
 
   constructor(
     readonly adapters: ResolvedStagehandRuntimeAdapters,
@@ -272,23 +280,43 @@ export class StagehandRuntime {
     };
   }
 
-  async configureLoopback(params: RuntimeConfigureParams): Promise<RuntimeConfigureResult> {
-    this.logger.setLevel(params.logLevel);
+  async configureLoopback(
+    params: Pick<RuntimeConfigureParams, "cdpUrl"> &
+      Partial<Omit<RuntimeConfigureParams, "cdpUrl">>,
+    lifecycle?: StagehandBrowserSessionLifecycle,
+  ): Promise<RuntimeConfigureResult> {
+    if (params.logLevel) this.logger.setLevel(params.logLevel);
     const { cdpUrl } = params;
+    const generation = ++this.browserSessionGeneration;
     const previousSession = this.browserSession;
     this.browserSession = undefined;
     this.pagesById.clear();
     await previousSession?.close();
 
+    let browserSession: StagehandBrowserSession | undefined;
     try {
-      this.browserSession = await this.adapters.browserSessionFactory(cdpUrl, this.logger);
+      browserSession = await this.adapters.browserSessionFactory(cdpUrl, this.logger, lifecycle);
+      if (generation !== this.browserSessionGeneration) {
+        throw new Error("Stagehand browser session bootstrap was superseded");
+      }
+      this.browserSession = browserSession;
     } catch (error) {
-      await this.browserSession?.close();
-      this.browserSession = undefined;
+      await browserSession?.close();
+      if (generation === this.browserSessionGeneration) this.browserSession = undefined;
       throw error;
     }
 
     return { configured: true };
+  }
+
+  /** Returns this runtime to a fresh reservation while keeping the worker alive. */
+  async resetForReservation(): Promise<void> {
+    ++this.browserSessionGeneration;
+    const previousSession = this.browserSession;
+    this.browserSession = undefined;
+    this.pagesById.clear();
+    this.state.setState(StagehandRuntimeStateSchema.parse({ status: "created" }), true);
+    await previousSession?.close();
   }
 
   async initialize(params: StagehandInitParams): Promise<StagehandInitResult> {
@@ -682,6 +710,7 @@ export class StagehandRuntime {
   }
 
   async close(): Promise<void> {
+    ++this.browserSessionGeneration;
     const session = this.browserSession;
     this.browserSession = undefined;
     this.pagesById.clear();

--- a/packages/server/runtime.ts
+++ b/packages/server/runtime.ts
@@ -222,7 +222,6 @@ export type StagehandBrowserSessionFactory = (
 ) => Promise<StagehandBrowserSession>;
 
 export type StagehandBrowserSessionLifecycle = {
-  onConnecting?(): void;
   onConnected?(): void;
   onDisconnected?(): void;
 };
@@ -700,16 +699,14 @@ export class StagehandRuntime {
   }
 
   async close(): Promise<void> {
-    const generation = ++this.browserSessionGeneration;
+    ++this.browserSessionGeneration;
     const session = this.browserSession;
     this.browserSession = undefined;
     this.pagesById.clear();
     try {
       await session?.close();
     } finally {
-      if (generation === this.browserSessionGeneration) {
-        this.state.setState(StagehandRuntimeStateSchema.parse({ status: "closed" }), true);
-      }
+      this.state.setState(StagehandRuntimeStateSchema.parse({ status: "closed" }), true);
     }
   }
 

--- a/packages/server/runtime.ts
+++ b/packages/server/runtime.ts
@@ -309,16 +309,6 @@ export class StagehandRuntime {
     return { configured: true };
   }
 
-  /** Returns this runtime to a fresh reservation while keeping the worker alive. */
-  async resetForReservation(): Promise<void> {
-    ++this.browserSessionGeneration;
-    const previousSession = this.browserSession;
-    this.browserSession = undefined;
-    this.pagesById.clear();
-    this.state.setState(StagehandRuntimeStateSchema.parse({ status: "created" }), true);
-    await previousSession?.close();
-  }
-
   async initialize(params: StagehandInitParams): Promise<StagehandInitResult> {
     if (this.state.getState().status !== "created") {
       throw new Error("Stagehand has already been initialized");

--- a/packages/server/runtime.ts
+++ b/packages/server/runtime.ts
@@ -710,14 +710,16 @@ export class StagehandRuntime {
   }
 
   async close(): Promise<void> {
-    ++this.browserSessionGeneration;
+    const generation = ++this.browserSessionGeneration;
     const session = this.browserSession;
     this.browserSession = undefined;
     this.pagesById.clear();
     try {
       await session?.close();
     } finally {
-      this.state.setState(StagehandRuntimeStateSchema.parse({ status: "closed" }), true);
+      if (generation === this.browserSessionGeneration) {
+        this.state.setState(StagehandRuntimeStateSchema.parse({ status: "closed" }), true);
+      }
     }
   }
 

--- a/packages/server/tests/runtime-state.test.ts
+++ b/packages/server/tests/runtime-state.test.ts
@@ -149,4 +149,25 @@ describe("Stagehand runtime state", () => {
     expect(runtime.state.getState()).toStrictEqual({ status: "created" });
     expect(runtime.loopbackStatus()).toStrictEqual({ configured: false, connected: false });
   });
+
+  it("does not let an older close overwrite a reservation reset", async () => {
+    let finishClose: (() => void) | undefined;
+    const closeStarted = new Promise<void>((resolve) => {
+      finishClose = resolve;
+    });
+    const close = vi.fn(async () => await closeStarted);
+    const runtime = createStagehandRuntime({
+      browserSessionFactory: async () => createBrowserSession({ close }),
+    });
+
+    await runtime.configureLoopback({ cdpUrl: "ws://browser.example" });
+    const closing = runtime.close();
+    await vi.waitFor(() => expect(close).toHaveBeenCalledOnce());
+
+    await runtime.resetForReservation();
+    finishClose?.();
+    await closing;
+
+    expect(runtime.state.getState()).toStrictEqual({ status: "created" });
+  });
 });

--- a/packages/server/tests/runtime-state.test.ts
+++ b/packages/server/tests/runtime-state.test.ts
@@ -126,35 +126,4 @@ describe("Stagehand runtime state", () => {
     expect(runtime.state.getState()).toStrictEqual({ status: "closed" });
     expect(close).toHaveBeenCalledOnce();
   });
-
-  it("does not let an older close overwrite a replacement browser session", async () => {
-    let finishClose: (() => void) | undefined;
-    const closeStarted = new Promise<void>((resolve) => {
-      finishClose = resolve;
-    });
-    const oldClose = vi.fn(async () => await closeStarted);
-    const replacementSession = createBrowserSession();
-    const runtime = createStagehandRuntime({
-      browserSessionFactory: async (cdpUrl) =>
-        cdpUrl.endsWith("replacement")
-          ? replacementSession
-          : createBrowserSession({ close: oldClose }),
-    });
-
-    await runtime.configureLoopback({ cdpUrl: "ws://browser.example" });
-    await runtime.initialize({
-      telemetry: {
-        traces: { endpoint: "https://collector.example.com/v1/traces", headers: {} },
-      },
-    });
-    const closing = runtime.close();
-    await vi.waitFor(() => expect(oldClose).toHaveBeenCalledOnce());
-
-    await runtime.configureLoopback({ cdpUrl: "ws://browser.replacement" });
-    finishClose?.();
-    await closing;
-
-    expect(runtime.browserSession).toBe(replacementSession);
-    expect(runtime.state.getState().status).toBe("initialized");
-  });
 });

--- a/packages/server/tests/runtime-state.test.ts
+++ b/packages/server/tests/runtime-state.test.ts
@@ -126,4 +126,27 @@ describe("Stagehand runtime state", () => {
     expect(runtime.state.getState()).toStrictEqual({ status: "closed" });
     expect(close).toHaveBeenCalledOnce();
   });
+
+  it("returns the runtime to created state for a new reservation", async () => {
+    const close = vi.fn(async () => {});
+    const runtime = createStagehandRuntime({
+      browserSessionFactory: async () => createBrowserSession({ close }),
+    });
+
+    await runtime.configureLoopback({ cdpUrl: "ws://browser.example" });
+    await runtime.initialize({
+      model: { modelName: "openai/gpt-5" },
+      telemetry: {
+        traces: { endpoint: "https://collector.example.com/v1/traces", headers: {} },
+      },
+    });
+    runtime.pagesById.set("previous-page", {} as never);
+
+    await runtime.resetForReservation();
+
+    expect(close).toHaveBeenCalledOnce();
+    expect(runtime.pagesById.size).toBe(0);
+    expect(runtime.state.getState()).toStrictEqual({ status: "created" });
+    expect(runtime.loopbackStatus()).toStrictEqual({ configured: false, connected: false });
+  });
 });

--- a/packages/server/tests/runtime-state.test.ts
+++ b/packages/server/tests/runtime-state.test.ts
@@ -127,47 +127,34 @@ describe("Stagehand runtime state", () => {
     expect(close).toHaveBeenCalledOnce();
   });
 
-  it("returns the runtime to created state for a new reservation", async () => {
-    const close = vi.fn(async () => {});
-    const runtime = createStagehandRuntime({
-      browserSessionFactory: async () => createBrowserSession({ close }),
-    });
-
-    await runtime.configureLoopback({ cdpUrl: "ws://browser.example" });
-    await runtime.initialize({
-      model: { modelName: "openai/gpt-5" },
-      telemetry: {
-        traces: { endpoint: "https://collector.example.com/v1/traces", headers: {} },
-      },
-    });
-    runtime.pagesById.set("previous-page", {} as never);
-
-    await runtime.resetForReservation();
-
-    expect(close).toHaveBeenCalledOnce();
-    expect(runtime.pagesById.size).toBe(0);
-    expect(runtime.state.getState()).toStrictEqual({ status: "created" });
-    expect(runtime.loopbackStatus()).toStrictEqual({ configured: false, connected: false });
-  });
-
-  it("does not let an older close overwrite a reservation reset", async () => {
+  it("does not let an older close overwrite a replacement browser session", async () => {
     let finishClose: (() => void) | undefined;
     const closeStarted = new Promise<void>((resolve) => {
       finishClose = resolve;
     });
-    const close = vi.fn(async () => await closeStarted);
+    const oldClose = vi.fn(async () => await closeStarted);
+    const replacementSession = createBrowserSession();
     const runtime = createStagehandRuntime({
-      browserSessionFactory: async () => createBrowserSession({ close }),
+      browserSessionFactory: async (cdpUrl) =>
+        cdpUrl.endsWith("replacement")
+          ? replacementSession
+          : createBrowserSession({ close: oldClose }),
     });
 
     await runtime.configureLoopback({ cdpUrl: "ws://browser.example" });
+    await runtime.initialize({
+      telemetry: {
+        traces: { endpoint: "https://collector.example.com/v1/traces", headers: {} },
+      },
+    });
     const closing = runtime.close();
-    await vi.waitFor(() => expect(close).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(oldClose).toHaveBeenCalledOnce());
 
-    await runtime.resetForReservation();
+    await runtime.configureLoopback({ cdpUrl: "ws://browser.replacement" });
     finishClose?.();
     await closing;
 
-    expect(runtime.state.getState()).toStrictEqual({ status: "created" });
+    expect(runtime.browserSession).toBe(replacementSession);
+    expect(runtime.state.getState().status).toBe("initialized");
   });
 });

--- a/packages/server/tests/understudy-context-lifecycle.test.ts
+++ b/packages/server/tests/understudy-context-lifecycle.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CdpConnection } from "../understudy/cdp.js";
+import { V3Context } from "../understudy/context.js";
+
+function contextOptions(onConnected: () => void, onDisconnected: () => void) {
+  return {
+    websocketFactory: vi.fn(),
+    blankPageUrl: "chrome-extension://stagehand/blank.html",
+    fallbackLocatorScriptSource: "",
+    chromeTabs: {} as never,
+    logger: { debug: vi.fn(), error: vi.fn() } as never,
+    onConnected,
+    onDisconnected,
+  };
+}
+
+describe("V3Context connection lifecycle", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("reports a successful connection and deduplicates disconnect notification", async () => {
+    let transportClosed: (() => void) | undefined;
+    const connection = {
+      onTransportClosed: vi.fn((handler: () => void) => {
+        transportClosed = handler;
+      }),
+      close: vi.fn(async () => {}),
+    };
+    vi.spyOn(CdpConnection, "connect").mockResolvedValue(connection as never);
+    vi.spyOn(V3Context.prototype, "bootstrap").mockResolvedValue();
+    vi.spyOn(V3Context.prototype, "ensureFirstTopLevelPage").mockResolvedValue({} as never);
+    const onConnected = vi.fn();
+    const onDisconnected = vi.fn();
+
+    await V3Context.create("ws://browser.example", contextOptions(onConnected, onDisconnected));
+    transportClosed?.();
+    transportClosed?.();
+
+    expect(onConnected).toHaveBeenCalledOnce();
+    expect(onDisconnected).toHaveBeenCalledOnce();
+  });
+
+  it("closes and reports disconnection when bootstrap fails", async () => {
+    let transportClosed: (() => void) | undefined;
+    const connection = {
+      onTransportClosed: vi.fn((handler: () => void) => {
+        transportClosed = handler;
+      }),
+      close: vi.fn(async () => transportClosed?.()),
+    };
+    vi.spyOn(CdpConnection, "connect").mockResolvedValue(connection as never);
+    vi.spyOn(V3Context.prototype, "bootstrap").mockRejectedValue(new Error("bootstrap failed"));
+    const onConnected = vi.fn();
+    const onDisconnected = vi.fn();
+
+    await expect(
+      V3Context.create("ws://browser.example", contextOptions(onConnected, onDisconnected)),
+    ).rejects.toThrow("bootstrap failed");
+
+    expect(onConnected).toHaveBeenCalledOnce();
+    expect(onDisconnected).toHaveBeenCalledOnce();
+    expect(connection.close).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/server/understudy/context.ts
+++ b/packages/server/understudy/context.ts
@@ -172,7 +172,12 @@ export class V3Context {
     const connectTask = async () => {
       const conn = await CdpConnection.connect(wsUrl, opts.websocketFactory, opts.logger);
       if (opts.onDisconnected) {
-        conn.onTransportClosed(() => opts.onDisconnected?.());
+        let disconnected = false;
+        conn.onTransportClosed(() => {
+          if (disconnected) return;
+          disconnected = true;
+          opts.onDisconnected?.();
+        });
       }
       try {
         opts.onConnected?.();

--- a/packages/server/understudy/context.ts
+++ b/packages/server/understudy/context.ts
@@ -165,30 +165,41 @@ export class V3Context {
       fallbackLocatorScriptSource: string;
       chromeTabs: ChromeTabTargetController;
       logger: StagehandLogger;
+      onConnected?(): void;
+      onDisconnected?(): void;
     },
   ): Promise<V3Context> {
     const connectTask = async () => {
       const conn = await CdpConnection.connect(wsUrl, opts.websocketFactory, opts.logger);
-      const ctx = new V3Context(
-        conn,
-        opts.logger,
-        opts.chromeTabs,
-        opts?.env ?? "LOCAL",
-        opts?.apiClient ?? null,
-        opts?.localBrowserLaunchOptions ?? null,
-        opts.blankPageUrl,
-        opts.fallbackLocatorScriptSource,
-      );
-      await ctx.bootstrap();
-      // Allow connectTimeoutMs to also govern how long we wait for the first
-      // top-level page to appear.  On slow machines the browser may need more
-      // time after the CDP socket is open before the initial page registers.
-      const firstPageTimeoutMs = Math.max(
-        opts?.localBrowserLaunchOptions?.connectTimeoutMs ?? 0,
-        DEFAULT_FIRST_TOP_LEVEL_PAGE_TIMEOUT_MS,
-      );
-      await ctx.ensureFirstTopLevelPage(firstPageTimeoutMs);
-      return ctx;
+      if (opts.onDisconnected) {
+        conn.onTransportClosed(() => opts.onDisconnected?.());
+      }
+      try {
+        opts.onConnected?.();
+        const ctx = new V3Context(
+          conn,
+          opts.logger,
+          opts.chromeTabs,
+          opts?.env ?? "LOCAL",
+          opts?.apiClient ?? null,
+          opts?.localBrowserLaunchOptions ?? null,
+          opts.blankPageUrl,
+          opts.fallbackLocatorScriptSource,
+        );
+        await ctx.bootstrap();
+        // Allow connectTimeoutMs to also govern how long we wait for the first
+        // top-level page to appear.  On slow machines the browser may need more
+        // time after the CDP socket is open before the initial page registers.
+        const firstPageTimeoutMs = Math.max(
+          opts?.localBrowserLaunchOptions?.connectTimeoutMs ?? 0,
+          DEFAULT_FIRST_TOP_LEVEL_PAGE_TIMEOUT_MS,
+        );
+        await ctx.ensureFirstTopLevelPage(firstPageTimeoutMs);
+        return ctx;
+      } catch (error) {
+        await conn.close();
+        throw error;
+      }
     };
 
     return await connectTask();


### PR DESCRIPTION
## Summary

- make browser-session replacement close the previous CDP session and clear target/page mappings
- ensure only the newest asynchronous browser-session creation attempt can install itself
- make close invalidate any in-flight session creation without supporting replacement-after-close
- keep initial V3Context target bootstrap reusable without forcing a new page

## Scope

Stack 1/7.

This PR retains within-session connection replacement only. It does not model reservation turnover, successor reservations, or a new session replacing one that is already closing.

## Validation

- focused runtime-state and context-lifecycle tests
- `pnpm check`
