### PR TITLE
Add opt-in resident worker lifecycle

### DIFF
--- a/packages/server/controllers/contextController.ts
+++ b/packages/server/controllers/contextController.ts
@@ -18,7 +18,10 @@ import type {
 import type { HandlerContext } from "../rpcRouter.js";
 import type { StagehandRuntime } from "../runtime.js";
 
-export function createContextController(runtime: StagehandRuntime) {
+export function createContextController(
+  runtime: StagehandRuntime,
+  options: { close?: () => Promise<void> } = {},
+) {
   async function pages(_params: EmptyParams, { logger }: HandlerContext) {
     logger.debug("context.pages", {});
     return runtime.contextPages();
@@ -41,7 +44,11 @@ export function createContextController(runtime: StagehandRuntime) {
 
   async function close(_params: EmptyParams, { logger }: HandlerContext) {
     logger.debug("context.close", {});
-    return runtime.contextClose();
+    if (options.close) {
+      await options.close();
+      return { closed: true };
+    }
+    return await runtime.contextClose();
   }
 
   async function addInitScript(params: ContextAddInitScriptParams, { logger }: HandlerContext) {

--- a/packages/server/rpcRouter.ts
+++ b/packages/server/rpcRouter.ts
@@ -34,6 +34,7 @@ export type HandlerContext = {
 export type RPCRouterOptions = {
   initializeStagehand?: (params: StagehandInitParams) => Promise<StagehandInitResult>;
   closeStagehand?: () => Promise<void>;
+  closeContext?: () => Promise<void>;
 };
 
 export class RPCRouter {
@@ -54,7 +55,10 @@ export class RPCRouter {
       ...(options.initializeStagehand ? { initialize: options.initializeStagehand } : {}),
       ...(options.closeStagehand ? { close: options.closeStagehand } : {}),
     });
-    this.contextController = createContextController(runtime);
+    this.contextController = createContextController(
+      runtime,
+      options.closeContext ? { close: options.closeContext } : {},
+    );
     this.pageController = createPageController(runtime);
     this.locatorController = createLocatorController(runtime);
   }

--- a/packages/server/runtime.ts
+++ b/packages/server/runtime.ts
@@ -217,7 +217,14 @@ export type StagehandBrowserSession = {
 export type StagehandBrowserSessionFactory = (
   cdpUrl: string,
   logger: StagehandLogger,
+  lifecycle?: StagehandBrowserSessionLifecycle,
 ) => Promise<StagehandBrowserSession>;
+
+export type StagehandBrowserSessionLifecycle = {
+  bootstrapMode?: "resident";
+  onConnected?(): void;
+  onDisconnected?(): void;
+};
 
 export type StagehandRuntimeAdapters = {
   browserSessionFactory?: StagehandBrowserSessionFactory;
@@ -256,6 +263,10 @@ export class StagehandRuntime {
   );
   browserSession?: StagehandBrowserSession;
   pagesById = new Map<string, UnderstudyRuntimePage>();
+  private browserSessionGeneration = 0;
+  private readonly contextInitScripts: string[] = [];
+  private contextExtraHTTPHeaders?: ContextSetExtraHTTPHeadersParams["headers"];
+  private contextDomainPolicy?: DomainPolicy | null;
 
   constructor(
     readonly adapters: ResolvedStagehandRuntimeAdapters,
@@ -271,18 +282,27 @@ export class StagehandRuntime {
     };
   }
 
-  async configureLoopback(params: { cdpUrl: string }): Promise<void> {
+  async configureLoopback(
+    params: { cdpUrl: string },
+    lifecycle?: StagehandBrowserSessionLifecycle,
+  ): Promise<void> {
     const { cdpUrl } = params;
+    const generation = ++this.browserSessionGeneration;
     const previousSession = this.browserSession;
     this.browserSession = undefined;
     this.pagesById.clear();
     await previousSession?.close();
 
+    let browserSession: StagehandBrowserSession | undefined;
     try {
-      this.browserSession = await this.adapters.browserSessionFactory(cdpUrl, this.logger);
+      browserSession = await this.adapters.browserSessionFactory(cdpUrl, this.logger, lifecycle);
+      if (generation !== this.browserSessionGeneration) {
+        throw new Error("Stagehand browser session bootstrap was superseded");
+      }
+      this.browserSession = browserSession;
     } catch (error) {
-      await this.browserSession?.close();
-      this.browserSession = undefined;
+      await browserSession?.close();
+      if (generation === this.browserSessionGeneration) this.browserSession = undefined;
       throw error;
     }
   }
@@ -293,12 +313,6 @@ export class StagehandRuntime {
     }
 
     this.logger.setLevel(params.logLevel);
-    if (!this.browserSession) {
-      if (!params.browserCdpUrl) {
-        throw new Error("stagehand.init requires browserCdpUrl until resident mode is active");
-      }
-      await this.configureLoopback({ cdpUrl: params.browserCdpUrl });
-    }
     await this.browserSession?.prepareForInitialization?.();
     const pages = await this.contextPages();
     this.tracing.configure(params.telemetry);
@@ -314,6 +328,21 @@ export class StagehandRuntime {
       initialized: true,
       pages,
     };
+  }
+
+  /** Restores initialization-dependent browser instrumentation after replacing a CDP session. */
+  async restoreInitializedBrowserSession(): Promise<void> {
+    if (this.state.getState().status !== "initialized") return;
+    const session = this.requireBrowserSession();
+    await session.prepareForInitialization?.();
+    for (const source of this.contextInitScripts) await session.addInitScript(source);
+    if (this.contextExtraHTTPHeaders) {
+      await session.setExtraHTTPHeaders(this.contextExtraHTTPHeaders);
+    }
+    if (this.contextDomainPolicy !== undefined) {
+      await session.setDomainPolicy(this.contextDomainPolicy);
+    }
+    await this.contextPages();
   }
 
   async browserGetVersion(): Promise<BrowserGetVersionResult> {
@@ -362,6 +391,8 @@ export class StagehandRuntime {
 
   async contextAddInitScript(params: ContextAddInitScriptParams): Promise<ContextVoidResult> {
     await this.requireBrowserSession().addInitScript(params.source);
+    if (!this.contextInitScripts.includes(params.source))
+      this.contextInitScripts.push(params.source);
     return { ok: true };
   }
 
@@ -369,6 +400,7 @@ export class StagehandRuntime {
     params: ContextSetExtraHTTPHeadersParams,
   ): Promise<ContextVoidResult> {
     await this.requireBrowserSession().setExtraHTTPHeaders(params.headers);
+    this.contextExtraHTTPHeaders = { ...params.headers };
     return { ok: true };
   }
 
@@ -378,6 +410,7 @@ export class StagehandRuntime {
 
   async contextSetDomainPolicy(params: ContextSetDomainPolicyParams): Promise<ContextVoidResult> {
     await this.requireBrowserSession().setDomainPolicy(params.policy);
+    this.contextDomainPolicy = params.policy;
     return { ok: true };
   }
 
@@ -687,6 +720,7 @@ export class StagehandRuntime {
   }
 
   async close(): Promise<void> {
+    ++this.browserSessionGeneration;
     const session = this.browserSession;
     this.browserSession = undefined;
     this.pagesById.clear();

--- a/packages/server/service-worker-lifecycle/heartbeat-manager.ts
+++ b/packages/server/service-worker-lifecycle/heartbeat-manager.ts
@@ -47,7 +47,6 @@ export function createServiceWorkerHeartbeatManager(
   let creatingDocument: Promise<void> | null = null;
   let heartbeatPort: RuntimePort | null = null;
   let installed = false;
-
   async function ensure(): Promise<void> {
     const offscreen = chromeApi.offscreen;
     if (offscreen == null) return;

--- a/packages/server/service-worker-lifecycle/resident-runtime.ts
+++ b/packages/server/service-worker-lifecycle/resident-runtime.ts
@@ -1,0 +1,261 @@
+import { STAGEHAND_PROTOCOL_VERSION, STAGEHAND_RUNTIME_VERSION } from "../../protocol/schemas.js";
+import type {
+  RuntimeDescriptor,
+  StagehandInitParams,
+  StagehandInitResult,
+} from "../../protocol/types.js";
+import type { StagehandRuntime } from "../runtime.js";
+
+export type ResidentRuntimeState =
+  | "unconfigured"
+  | "connecting"
+  | "bootstrapping"
+  | "ready"
+  | "reconnecting"
+  | "failed"
+  | "closed";
+
+export type StagehandRuntimeMarker = RuntimeDescriptor & {
+  name: "stagehand";
+  version: string;
+  state: ResidentRuntimeState;
+  connected: boolean;
+  runtimeInstanceId: string;
+  timings: {
+    connectAndBootstrapMs?: number;
+    totalMs?: number;
+  };
+  failure?: {
+    phase: "connecting" | "bootstrapping" | "reconnecting";
+    message: string;
+  };
+};
+
+type ResidentRuntimeFailurePhase = NonNullable<StagehandRuntimeMarker["failure"]>["phase"];
+
+export type ResidentRuntimeLifecycleOptions = {
+  resolveResidentWebSocketUrl?: () => Promise<string>;
+  waitForRpcReceiver?: () => Promise<void>;
+  now?: () => number;
+  startedAt?: number;
+  runtimeInstanceId?: string;
+  reconnectDelaysMs?: readonly number[];
+};
+
+const DEFAULT_RECONNECT_DELAYS_MS = [100, 250, 500] as const;
+
+/** Coordinates one browser VM's resident connection and same-session reconnects. */
+export class ResidentRuntimeLifecycle {
+  readonly marker: StagehandRuntimeMarker;
+  private readonly now: () => number;
+  private readonly startedAt: number;
+  private readonly reconnectDelaysMs: readonly number[];
+  private operationGeneration = 0;
+  private operationTail: Promise<void> = Promise.resolve();
+  private bootstrapPromise?: Promise<void>;
+  private reconnectTimer?: ReturnType<typeof setTimeout>;
+  private reconnectAttempt = 0;
+  private closed = false;
+
+  constructor(
+    private readonly runtime: StagehandRuntime,
+    private readonly options: ResidentRuntimeLifecycleOptions = {},
+  ) {
+    this.now = options.now ?? (() => performance.now());
+    this.startedAt = options.startedAt ?? this.now();
+    this.reconnectDelaysMs = options.reconnectDelaysMs ?? DEFAULT_RECONNECT_DELAYS_MS;
+    this.marker = {
+      name: "stagehand",
+      version: STAGEHAND_RUNTIME_VERSION,
+      protocolVersion: STAGEHAND_PROTOCOL_VERSION,
+      serverInfo: {
+        name: "stagehand",
+        version: STAGEHAND_RUNTIME_VERSION,
+      },
+      state: options.resolveResidentWebSocketUrl ? "connecting" : "unconfigured",
+      connected: false,
+      runtimeInstanceId: options.runtimeInstanceId ?? crypto.randomUUID(),
+      timings: {},
+    };
+  }
+
+  bootstrap(): Promise<void> {
+    if (this.closed) return Promise.resolve();
+    if (!this.options.resolveResidentWebSocketUrl) {
+      return Promise.reject(new Error("Resident browser proxy is not configured"));
+    }
+    if (this.marker.state === "ready" && this.runtime.loopbackStatus().connected) {
+      return Promise.resolve();
+    }
+    if (this.bootstrapPromise) return this.bootstrapPromise;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = undefined;
+      this.operationGeneration += 1;
+    }
+
+    const generation = this.operationGeneration;
+    const operation = this.enqueue(() => this.runResidentBootstrap(generation));
+    const tracked = operation.finally(() => {
+      if (this.bootstrapPromise === tracked) this.bootstrapPromise = undefined;
+    });
+    this.bootstrapPromise = tracked;
+    return tracked;
+  }
+
+  initialize(params: StagehandInitParams): Promise<StagehandInitResult> {
+    if (this.runtime.state.getState().status !== "created") {
+      return Promise.reject(new Error("Stagehand has already been initialized"));
+    }
+
+    const bootstrap = this.bootstrap();
+    const generation = this.operationGeneration;
+    return this.enqueue(async () => {
+      await bootstrap;
+      if (generation !== this.operationGeneration || this.closed) {
+        throw new Error("Resident runtime bootstrap was superseded");
+      }
+      if (this.marker.state !== "ready" || !this.runtime.loopbackStatus().connected) {
+        throw new Error("Resident runtime is not ready for stagehand.init");
+      }
+      return await this.runtime.initialize(params);
+    });
+  }
+
+  close(): Promise<void> {
+    this.cancelReconnects();
+    this.closed = true;
+    this.bootstrapPromise = undefined;
+    ++this.operationGeneration;
+    return this.enqueue(async () => {
+      await this.runtime.close();
+      this.publish("closed", false, {});
+    });
+  }
+
+  private enqueue<Result>(operation: () => Promise<Result>): Promise<Result> {
+    const result = this.operationTail.then(operation, operation);
+    this.operationTail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+
+  private async runResidentBootstrap(generation: number): Promise<void> {
+    if (generation !== this.operationGeneration || this.closed) return;
+
+    const resolveResidentWebSocketUrl = this.options.resolveResidentWebSocketUrl;
+    if (!resolveResidentWebSocketUrl) throw new Error("Resident browser proxy is not configured");
+
+    const connectStartedAt = this.now();
+    const reconnecting = this.reconnectAttempt > 0 || this.marker.state === "reconnecting";
+    this.publish(reconnecting ? "reconnecting" : "connecting", false, {});
+
+    try {
+      const cdpUrl = await resolveResidentWebSocketUrl();
+      if (!this.isCurrent(generation)) return;
+
+      await this.runtime.configureLoopback(
+        { cdpUrl },
+        {
+          bootstrapMode: "resident",
+          onConnected: () => {
+            if (this.isCurrent(generation)) {
+              this.publish("bootstrapping", true, {});
+            }
+          },
+          onDisconnected: () => {
+            if (this.isCurrent(generation)) this.handleResidentDisconnect();
+          },
+        },
+      );
+
+      if (!this.isCurrent(generation)) return;
+      if (!this.runtime.loopbackStatus().connected) {
+        throw new Error("Resident runtime disconnected during bootstrap");
+      }
+
+      await this.runtime.restoreInitializedBrowserSession();
+      this.assertConnected(generation);
+      await this.options.waitForRpcReceiver?.();
+      this.assertConnected(generation);
+
+      this.cancelReconnects();
+      this.publish("ready", true, {
+        connectAndBootstrapMs: this.now() - connectStartedAt,
+        totalMs: this.now() - this.startedAt,
+      });
+    } catch (error) {
+      if (this.isCurrent(generation) && !this.closed) {
+        const phase = this.marker.state === "bootstrapping" ? "bootstrapping" : "connecting";
+        if (this.scheduleReconnect()) {
+          this.publish("reconnecting", false, this.marker.timings);
+        } else {
+          this.publishFailure(phase, `Resident runtime ${phase} failed`);
+        }
+      }
+      throw error;
+    }
+  }
+
+  private assertConnected(generation: number): void {
+    if (!this.isCurrent(generation)) {
+      throw new Error("Stagehand browser session bootstrap was superseded");
+    }
+    if (!this.runtime.loopbackStatus().connected) {
+      throw new Error("Stagehand browser session disconnected during bootstrap");
+    }
+  }
+
+  private handleResidentDisconnect(): void {
+    this.publish("reconnecting", false, this.marker.timings);
+    this.scheduleReconnect();
+  }
+
+  private scheduleReconnect(): boolean {
+    if (this.reconnectTimer || this.closed) return Boolean(this.reconnectTimer);
+    const delay = this.reconnectDelaysMs[this.reconnectAttempt];
+    if (delay === undefined) {
+      this.publishFailure("reconnecting", "Resident runtime reconnect budget exhausted");
+      return false;
+    }
+
+    this.reconnectAttempt += 1;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = undefined;
+      if (this.closed) return;
+      this.bootstrapPromise = undefined;
+      this.operationGeneration += 1;
+      void this.bootstrap().catch(() => {});
+    }, delay);
+    return true;
+  }
+
+  private cancelReconnects(): void {
+    if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
+    this.reconnectTimer = undefined;
+    this.reconnectAttempt = 0;
+  }
+
+  private isCurrent(generation: number): boolean {
+    return generation === this.operationGeneration;
+  }
+
+  private publish(
+    state: ResidentRuntimeState,
+    connected: boolean,
+    timings: StagehandRuntimeMarker["timings"],
+  ): void {
+    this.marker.state = state;
+    this.marker.connected = connected;
+    this.marker.timings = timings;
+    delete this.marker.failure;
+  }
+
+  private publishFailure(phase: ResidentRuntimeFailurePhase, message: string): void {
+    this.marker.state = "failed";
+    this.marker.connected = false;
+    this.marker.failure = { phase, message };
+  }
+}

--- a/packages/server/service-worker.ts
+++ b/packages/server/service-worker.ts
@@ -3,45 +3,74 @@ import {
   StagehandMethods,
   StagehandNotifications,
 } from "../protocol/schema-registry.js";
-import { STAGEHAND_PROTOCOL_VERSION, STAGEHAND_RUNTIME_VERSION } from "../protocol/schemas.js";
-import type { RuntimeDescriptor } from "../protocol/types.js";
 import { ChromeRuntimeClient } from "./clients/chromeRuntimeClient.js";
 import { RPCClient } from "./clients/rpcClient.js";
 import { RPCRouter } from "./rpcRouter.js";
 import { installServiceWorkerHeartbeat } from "./service-worker-lifecycle/heartbeat-manager.js";
+import { resolveResidentBrowserWebSocketUrl } from "./service-worker-lifecycle/resident-browser-proxy.js";
+import {
+  ResidentRuntimeLifecycle,
+  type StagehandRuntimeMarker,
+} from "./service-worker-lifecycle/resident-runtime.js";
 import { createStagehandRuntime, type StagehandRuntime } from "./runtime.js";
 import { browserWebSocketFactory } from "./understudy/browserWebSocketTransport.js";
 import { ChromeTabTargetAdapter } from "./understudy/chromeTabs.js";
 import { V3Context } from "./understudy/context.js";
 
+declare global {
+  interface ImportMeta {
+    readonly env: {
+      readonly VITE_STAGEHAND_BROWSER_PROXY_URL?: string;
+    };
+  }
+}
+
 export type StagehandServiceWorkerScope = {
-  __stagehand_runtime?: RuntimeDescriptor;
+  __stagehand_runtime?: StagehandRuntimeMarker;
   __stagehandReceiveFromHost?: (raw: unknown) => Promise<void>;
+};
+
+export type StartStagehandServiceWorkerOptions = {
+  autoBootstrap?: boolean;
+  browserProxyUrl?: string;
+  resolveResidentWebSocketUrl?: () => Promise<string>;
+  startedAt?: number;
 };
 
 export function startStagehandServiceWorker(
   scope: StagehandServiceWorkerScope = globalThis as typeof globalThis &
     StagehandServiceWorkerScope,
   runtime?: StagehandRuntime,
+  options: StartStagehandServiceWorkerOptions = {},
 ): RPCClient {
   const chromeRuntimeClient = new ChromeRuntimeClient(scope, STAGEHAND_SEND_TO_HOST_BINDING);
+  const receiverReady = deferred();
+  installServiceWorkerHeartbeat();
   let rpcClient: RPCClient | undefined;
   const activeRuntime =
     runtime ??
     createStagehandRuntime({
-      browserSessionFactory: async (cdpUrl, logger) => {
+      browserSessionFactory: async (cdpUrl, logger, lifecycle) => {
         const locatorRuntimeResponse = await fetch(chrome.runtime.getURL("content-script.js"));
         if (!locatorRuntimeResponse.ok) {
           throw new Error(
             `Failed to load Stagehand locator runtime: ${locatorRuntimeResponse.status}`,
           );
         }
+        const fallbackLocatorScriptSource = await locatorRuntimeResponse.text();
+        const residentConnection = lifecycle?.bootstrapMode === "resident";
         return V3Context.create(cdpUrl, {
           websocketFactory: browserWebSocketFactory,
           logger,
           blankPageUrl: chrome.runtime.getURL("blank.html"),
-          fallbackLocatorScriptSource: await locatorRuntimeResponse.text(),
+          fallbackLocatorScriptSource,
           chromeTabs: new ChromeTabTargetAdapter(chrome),
+          ensureInitialPage: !residentConnection,
+          deferPageInstrumentation: residentConnection,
+          ...(lifecycle?.onConnected ? { onConnected: () => lifecycle.onConnected?.() } : {}),
+          ...(lifecycle?.onDisconnected
+            ? { onDisconnected: () => lifecycle.onDisconnected?.() }
+            : {}),
         });
       },
       emitLog: (log) => {
@@ -57,20 +86,57 @@ export function startStagehandServiceWorker(
       },
     });
 
-  rpcClient = new RPCClient(chromeRuntimeClient, new RPCRouter(activeRuntime));
-  scope.__stagehand_runtime = {
-    protocolVersion: STAGEHAND_PROTOCOL_VERSION,
-    serverInfo: {
-      name: "stagehand",
-      version: STAGEHAND_RUNTIME_VERSION,
-    },
-  };
+  const configuredBrowserProxyUrl =
+    options.browserProxyUrl ?? import.meta.env.VITE_STAGEHAND_BROWSER_PROXY_URL?.trim();
+  const resolveResidentWebSocketUrl =
+    options.resolveResidentWebSocketUrl ??
+    (configuredBrowserProxyUrl
+      ? async () => await resolveResidentBrowserWebSocketUrl(configuredBrowserProxyUrl)
+      : undefined);
+  const residentRuntime = new ResidentRuntimeLifecycle(activeRuntime, {
+    ...(resolveResidentWebSocketUrl ? { resolveResidentWebSocketUrl } : {}),
+    waitForRpcReceiver: () => receiverReady.promise,
+    ...(options.startedAt === undefined ? {} : { startedAt: options.startedAt }),
+  });
+  rpcClient = new RPCClient(
+    chromeRuntimeClient,
+    new RPCRouter(activeRuntime, {
+      initializeStagehand: async (params) => {
+        if (!params.browserCdpUrl) return await residentRuntime.initialize(params);
+        if (activeRuntime.state.getState().status !== "created") {
+          return await activeRuntime.initialize(params);
+        }
+        await activeRuntime.configureLoopback({ cdpUrl: params.browserCdpUrl });
+        return await activeRuntime.initialize(params);
+      },
+      closeStagehand: () => residentRuntime.close(),
+      closeContext: () => residentRuntime.close(),
+    }),
+  );
+  scope.__stagehand_runtime = residentRuntime.marker;
   scope.__stagehandReceiveFromHost = (raw) => chromeRuntimeClient.receive(raw);
+  receiverReady.resolve();
+
+  const autoBootstrap = options.autoBootstrap ?? resolveResidentWebSocketUrl !== undefined;
+  if (autoBootstrap) {
+    void residentRuntime.bootstrap().catch(() => {
+      // oxlint-disable-next-line no-console
+      console.error("[stagehand] Resident runtime bootstrap failed");
+    });
+  }
 
   return rpcClient;
 }
 
+function deferred(): { promise: Promise<void>; resolve(): void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 if (typeof chrome !== "undefined") {
-  installServiceWorkerHeartbeat();
-  startStagehandServiceWorker();
+  const startedAt = performance.now();
+  startStagehandServiceWorker(undefined, undefined, { startedAt });
 }

--- a/packages/server/tests/resident-runtime.test.ts
+++ b/packages/server/tests/resident-runtime.test.ts
@@ -1,0 +1,317 @@
+import { describe, expect, it, vi } from "vitest";
+import { StagehandRpcRequestSchema } from "../../protocol/schema-registry.js";
+import type { StagehandBrowserSession, StagehandBrowserSessionFactory } from "../runtime.js";
+import { createStagehandRuntime } from "../runtime.js";
+import { RPCRouter } from "../rpcRouter.js";
+import {
+  ResidentRuntimeLifecycle,
+  type ResidentRuntimeLifecycleOptions,
+} from "../service-worker-lifecycle/resident-runtime.js";
+
+const RESIDENT_TEST_URL = "ws://browser-proxy.test/devtools/browser/session";
+
+const initParams = {
+  protocolVersion: 4 as const,
+  clientInfo: { name: "stagehand-sdk-ts", version: "4.0.0" },
+  logLevel: "info" as const,
+  telemetry: {
+    traces: { endpoint: "http://127.0.0.1:4318/v1/traces", headers: {} },
+  },
+};
+
+function residentOptions(
+  options: ResidentRuntimeLifecycleOptions = {},
+): ResidentRuntimeLifecycleOptions {
+  return {
+    resolveResidentWebSocketUrl: async () => RESIDENT_TEST_URL,
+    reconnectDelaysMs: [],
+    ...options,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function createSession() {
+  let connected = true;
+  const close = vi.fn(async () => {
+    connected = false;
+  });
+  const prepareForInitialization = vi.fn(async () => {});
+  const addInitScript = vi.fn(async () => {});
+  const setExtraHTTPHeaders = vi.fn(async () => {});
+  const setDomainPolicy = vi.fn(async () => {});
+  const session = {
+    get connected() {
+      return connected;
+    },
+    pages: () => [],
+    prepareForInitialization,
+    addInitScript,
+    setExtraHTTPHeaders,
+    setDomainPolicy,
+    close,
+  } as unknown as StagehandBrowserSession;
+  return {
+    session,
+    close,
+    prepareForInitialization,
+    addInitScript,
+    setExtraHTTPHeaders,
+    setDomainPolicy,
+    disconnect: () => {
+      connected = false;
+    },
+  };
+}
+
+function connectedFactory(
+  create: (url: string) => Promise<StagehandBrowserSession>,
+): StagehandBrowserSessionFactory {
+  return async (url, _logger, lifecycle) => {
+    lifecycle?.onConnected?.();
+    return await create(url);
+  };
+}
+
+describe("resident runtime lifecycle", () => {
+  it("does nothing when the resident browser proxy is unconfigured", async () => {
+    const browserSessionFactory = vi.fn();
+    const runtime = createStagehandRuntime({ browserSessionFactory });
+    const lifecycle = new ResidentRuntimeLifecycle(runtime);
+
+    expect(lifecycle.marker).toMatchObject({ state: "unconfigured", connected: false });
+    await expect(lifecycle.bootstrap()).rejects.toThrow("not configured");
+    await expect(lifecycle.initialize(initParams)).rejects.toThrow("not configured");
+    expect(browserSessionFactory).not.toHaveBeenCalled();
+  });
+
+  it("coalesces startup and waits for V3Context bootstrap and the RPC receiver", async () => {
+    const created = deferred<StagehandBrowserSession>();
+    const receiverReady = deferred<void>();
+    const { session } = createSession();
+    const browserSessionFactory = vi.fn(connectedFactory(async () => await created.promise));
+    const runtime = createStagehandRuntime({ browserSessionFactory });
+    const lifecycle = new ResidentRuntimeLifecycle(
+      runtime,
+      residentOptions({
+        waitForRpcReceiver: () => receiverReady.promise,
+        runtimeInstanceId: "worker-a",
+      }),
+    );
+
+    const first = lifecycle.bootstrap();
+    const second = lifecycle.bootstrap();
+    expect(first).toBe(second);
+    await vi.waitFor(() => expect(lifecycle.marker.state).toBe("bootstrapping"));
+    expect(lifecycle.marker.connected).toBe(true);
+
+    created.resolve(session);
+    await Promise.resolve();
+    expect(lifecycle.marker.state).toBe("bootstrapping");
+    receiverReady.resolve();
+    await first;
+
+    expect(browserSessionFactory).toHaveBeenCalledOnce();
+    expect(browserSessionFactory).toHaveBeenCalledWith(
+      RESIDENT_TEST_URL,
+      runtime.logger,
+      expect.objectContaining({ bootstrapMode: "resident" }),
+    );
+    expect(lifecycle.marker).toMatchObject({
+      state: "ready",
+      connected: true,
+      runtimeInstanceId: "worker-a",
+      timings: {
+        connectAndBootstrapMs: expect.any(Number),
+        totalMs: expect.any(Number),
+      },
+    });
+  });
+
+  it("queues the first stagehand.init behind an active resident bootstrap", async () => {
+    const created = deferred<StagehandBrowserSession>();
+    const { session } = createSession();
+    const runtime = createStagehandRuntime({
+      browserSessionFactory: connectedFactory(async () => await created.promise),
+    });
+    const lifecycle = new ResidentRuntimeLifecycle(runtime, residentOptions());
+
+    const bootstrap = lifecycle.bootstrap();
+    await vi.waitFor(() => expect(lifecycle.marker.state).toBe("bootstrapping"));
+    const initialization = lifecycle.initialize(initParams);
+    expect(runtime.state.getState().status).toBe("created");
+
+    created.resolve(session);
+    await bootstrap;
+    await expect(initialization).resolves.toMatchObject({ initialized: true });
+    expect(runtime.state.getState().status).toBe("initialized");
+  });
+
+  it("re-resolves and restores initialized instrumentation after socket loss", async () => {
+    const first = createSession();
+    const second = createSession();
+    const sessions = [first.session, second.session];
+    const hooks: Array<Parameters<StagehandBrowserSessionFactory>[2]> = [];
+    const resolveResidentWebSocketUrl = vi.fn(async () => RESIDENT_TEST_URL);
+    const runtime = createStagehandRuntime({
+      browserSessionFactory: connectedFactory(async () => sessions.shift()!),
+    });
+    const originalFactory = runtime.adapters.browserSessionFactory;
+    runtime.adapters.browserSessionFactory = async (url, logger, lifecycle) => {
+      hooks.push(lifecycle);
+      return await originalFactory(url, logger, lifecycle);
+    };
+    const lifecycle = new ResidentRuntimeLifecycle(
+      runtime,
+      residentOptions({ resolveResidentWebSocketUrl, reconnectDelaysMs: [0] }),
+    );
+
+    await lifecycle.bootstrap();
+    await lifecycle.initialize(initParams);
+    await runtime.contextAddInitScript({ source: "globalThis.__resident = true" });
+    await runtime.contextSetExtraHTTPHeaders({ headers: { "x-stagehand": "resident" } });
+    await runtime.contextSetDomainPolicy({ policy: { allowedDomains: ["example.com"] } });
+
+    const restored = deferred<void>();
+    second.prepareForInitialization.mockImplementation(async () => await restored.promise);
+    first.disconnect();
+    hooks[0]?.onDisconnected?.();
+    expect(lifecycle.marker).toMatchObject({ state: "reconnecting", connected: false });
+    await vi.waitFor(() => expect(hooks).toHaveLength(2));
+    expect(lifecycle.marker).toMatchObject({ state: "bootstrapping", connected: true });
+
+    restored.resolve();
+    await vi.waitFor(() => expect(lifecycle.marker.state).toBe("ready"));
+    expect(resolveResidentWebSocketUrl).toHaveBeenCalledTimes(2);
+    expect(first.close).toHaveBeenCalledOnce();
+    expect(second.addInitScript).toHaveBeenCalledWith("globalThis.__resident = true");
+    expect(second.setExtraHTTPHeaders).toHaveBeenCalledWith({ "x-stagehand": "resident" });
+    expect(second.setDomainPolicy).toHaveBeenCalledWith({ allowedDomains: ["example.com"] });
+    expect(runtime.state.getState().status).toBe("initialized");
+  });
+
+  it("does not publish ready after disconnecting while the receiver is pending", async () => {
+    const receiverReady = deferred<void>();
+    const current = createSession();
+    let hooks: Parameters<StagehandBrowserSessionFactory>[2];
+    const runtime = createStagehandRuntime({
+      browserSessionFactory: connectedFactory(async () => current.session),
+    });
+    const originalFactory = runtime.adapters.browserSessionFactory;
+    runtime.adapters.browserSessionFactory = async (url, logger, lifecycle) => {
+      hooks = lifecycle;
+      return await originalFactory(url, logger, lifecycle);
+    };
+    const lifecycle = new ResidentRuntimeLifecycle(
+      runtime,
+      residentOptions({
+        reconnectDelaysMs: [60_000],
+        waitForRpcReceiver: () => receiverReady.promise,
+      }),
+    );
+
+    const bootstrap = lifecycle.bootstrap();
+    await vi.waitFor(() => expect(lifecycle.marker.state).toBe("bootstrapping"));
+    current.disconnect();
+    hooks?.onDisconnected?.();
+    receiverReady.resolve();
+    await expect(bootstrap).rejects.toThrow("disconnected");
+    expect(lifecycle.marker).toMatchObject({ state: "reconnecting", connected: false });
+    await lifecycle.close();
+  });
+
+  it("publishes a sanitized terminal failure after the reconnect budget is exhausted", async () => {
+    const runtime = createStagehandRuntime({
+      browserSessionFactory: async () => {
+        throw new Error("failed to connect to ws://private.internal/session?secret=value");
+      },
+    });
+    const lifecycle = new ResidentRuntimeLifecycle(runtime, residentOptions());
+
+    await expect(lifecycle.bootstrap()).rejects.toThrow("private.internal");
+    expect(lifecycle.marker).toMatchObject({
+      state: "failed",
+      connected: false,
+      failure: { phase: "connecting", message: "Resident runtime connecting failed" },
+    });
+    expect(JSON.stringify(lifecycle.marker)).not.toContain("private.internal");
+  });
+
+  it("clears connected state and consumes a pending retry when bootstrap is retried", async () => {
+    const replacement = createSession();
+    let attempts = 0;
+    const browserSessionFactory = vi.fn(
+      connectedFactory(async () => {
+        attempts += 1;
+        if (attempts === 1) throw new Error("context bootstrap failed");
+        return replacement.session;
+      }),
+    );
+    const runtime = createStagehandRuntime({ browserSessionFactory });
+    const lifecycle = new ResidentRuntimeLifecycle(
+      runtime,
+      residentOptions({ reconnectDelaysMs: [60_000] }),
+    );
+
+    await expect(lifecycle.bootstrap()).rejects.toThrow("context bootstrap failed");
+    expect(lifecycle.marker).toMatchObject({ state: "reconnecting", connected: false });
+
+    await lifecycle.bootstrap();
+    expect(browserSessionFactory).toHaveBeenCalledTimes(2);
+    expect(lifecycle.marker).toMatchObject({ state: "ready", connected: true });
+    await lifecycle.close();
+  });
+
+  it("does not reconnect after an intentional close", async () => {
+    const current = createSession();
+    let hooks: Parameters<StagehandBrowserSessionFactory>[2];
+    const browserSessionFactory = vi.fn(connectedFactory(async () => current.session));
+    const runtime = createStagehandRuntime({ browserSessionFactory });
+    const originalFactory = runtime.adapters.browserSessionFactory;
+    runtime.adapters.browserSessionFactory = async (url, logger, lifecycle) => {
+      hooks = lifecycle;
+      return await originalFactory(url, logger, lifecycle);
+    };
+    const lifecycle = new ResidentRuntimeLifecycle(
+      runtime,
+      residentOptions({ reconnectDelaysMs: [0] }),
+    );
+
+    await lifecycle.bootstrap();
+    await lifecycle.close();
+    hooks?.onDisconnected?.();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(browserSessionFactory).toHaveBeenCalledOnce();
+    expect(current.close).toHaveBeenCalledOnce();
+    expect(lifecycle.marker).toMatchObject({ state: "closed", connected: false });
+  });
+
+  it("routes context.close through resident lifecycle teardown", async () => {
+    const current = createSession();
+    const runtime = createStagehandRuntime({
+      browserSessionFactory: connectedFactory(async () => current.session),
+    });
+    const lifecycle = new ResidentRuntimeLifecycle(runtime, residentOptions());
+    const router = new RPCRouter(runtime, { closeContext: () => lifecycle.close() });
+
+    await lifecycle.bootstrap();
+    await router.handle(
+      StagehandRpcRequestSchema.parse({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "context.close",
+        params: {},
+      }),
+    );
+
+    expect(current.close).toHaveBeenCalledOnce();
+    expect(lifecycle.marker.state).toBe("closed");
+  });
+});

--- a/packages/server/tests/resident-target-safety.test.ts
+++ b/packages/server/tests/resident-target-safety.test.ts
@@ -1,0 +1,310 @@
+import type { Protocol } from "devtools-protocol";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ChromeTabTargetController } from "../understudy/chromeTabs.js";
+import { V3Context, isSupportedWebTarget } from "../understudy/context.js";
+import { CdpConnection, STAGEHAND_WEB_TARGET_FILTER } from "../understudy/cdp.js";
+import { Page } from "../understudy/page.js";
+
+function target(
+  targetId: string,
+  type: string,
+  url: string,
+  attached = false,
+): Protocol.Target.TargetInfo {
+  return { targetId, type, title: targetId, url, attached, canAccessOpener: false };
+}
+
+const chromeTabs: ChromeTabTargetController = {
+  activeTargetId: async () => undefined,
+  targetIdForTabId: async () => undefined,
+  tabIdForTargetId: async () => undefined,
+  activateTarget: async () => {},
+};
+
+describe("resident target attachment safety", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("allowlists page and injectable iframe targets", () => {
+    expect(isSupportedWebTarget(target("page", "page", "about:blank"))).toBe(true);
+    expect(isSupportedWebTarget(target("internal", "page", "chrome://newtab"))).toBe(false);
+    expect(
+      isSupportedWebTarget(target("other-extension", "page", "chrome-extension://other")),
+    ).toBe(false);
+    expect(isSupportedWebTarget(target("iframe", "iframe", "https://example.com/frame"))).toBe(
+      true,
+    );
+    expect(isSupportedWebTarget(target("extension", "iframe", "chrome-extension://other"))).toBe(
+      false,
+    );
+    for (const type of [
+      "browser",
+      "service_worker",
+      "worker",
+      "shared_worker",
+      "background_page",
+    ]) {
+      expect(isSupportedWebTarget(target(type, type, "https://example.com"))).toBe(false);
+    }
+  });
+
+  it("filters the initial sweep before manually attaching", async () => {
+    const attachToTarget = vi.fn(async () => ({}));
+    const context = new V3Context(
+      {
+        on: vi.fn(),
+        enableAutoAttach: vi.fn(async () => {}),
+        getTargets: vi.fn(async () => [
+          target("page", "page", "about:blank"),
+          target("iframe", "iframe", "https://example.com/frame"),
+          target("worker", "worker", "https://example.com/worker.js"),
+          target("stagehand-worker", "service_worker", "chrome-extension://stagehand/sw.js"),
+          target("background", "background_page", "chrome-extension://other/background.html"),
+        ]),
+        attachToTarget,
+      } as never,
+      {} as never,
+      chromeTabs,
+    );
+    vi.spyOn(context, "waitForInitialTopLevelTargets").mockResolvedValue();
+
+    await context.bootstrap();
+
+    expect(attachToTarget.mock.calls).toStrictEqual([["page"], ["iframe"]]);
+  });
+
+  it("attaches a previously ignored page after it navigates to an injectable URL", async () => {
+    let targetInfoChanged: ((event: Protocol.Target.TargetInfoChangedEvent) => void) | undefined;
+    const attachToTarget = vi.fn(async () => ({}));
+    const context = new V3Context(
+      {
+        on: vi.fn((event: string, handler: (event: never) => void) => {
+          if (event === "Target.targetInfoChanged") targetInfoChanged = handler;
+        }),
+        enableAutoAttach: vi.fn(async () => {}),
+        getTargets: vi.fn(async () => [target("new-tab", "page", "chrome://newtab")]),
+        attachToTarget,
+      } as never,
+      {} as never,
+      chromeTabs,
+    );
+    vi.spyOn(context, "waitForInitialTopLevelTargets").mockResolvedValue();
+
+    await context.bootstrap();
+    expect(attachToTarget).not.toHaveBeenCalled();
+
+    targetInfoChanged?.({ targetInfo: target("new-tab", "page", "https://example.com") });
+    await vi.waitFor(() => expect(attachToTarget).toHaveBeenCalledWith("new-tab"));
+  });
+
+  it("coalesces repeated target-info attachment attempts", async () => {
+    let targetInfoChanged: ((event: Protocol.Target.TargetInfoChangedEvent) => void) | undefined;
+    let resolveAttachment: (() => void) | undefined;
+    const attachToTarget = vi.fn(
+      async () =>
+        await new Promise<void>((resolve) => {
+          resolveAttachment = resolve;
+        }),
+    );
+    const context = new V3Context(
+      {
+        on: vi.fn((event: string, handler: (event: never) => void) => {
+          if (event === "Target.targetInfoChanged") targetInfoChanged = handler;
+        }),
+        enableAutoAttach: vi.fn(async () => {}),
+        getTargets: vi.fn(async () => []),
+        attachToTarget,
+      } as never,
+      {} as never,
+      chromeTabs,
+    );
+    vi.spyOn(context, "waitForInitialTopLevelTargets").mockResolvedValue();
+    await context.bootstrap();
+
+    const event = { targetInfo: target("page", "page", "https://example.com") };
+    targetInfoChanged?.(event);
+    targetInfoChanged?.(event);
+
+    await vi.waitFor(() => expect(attachToTarget).toHaveBeenCalledTimes(1));
+    resolveAttachment?.();
+  });
+
+  it("uses the restricted filter for future root auto-attachment", async () => {
+    const send = vi.fn(async () => ({}));
+    const connection = new CdpConnection(
+      {
+        connected: true,
+        send: vi.fn(),
+        close: vi.fn(async () => {}),
+        onMessage: vi.fn(),
+        onClose: vi.fn(),
+        onError: vi.fn(),
+      },
+      { debug: () => {}, error: () => {} },
+    );
+    vi.spyOn(connection, "send").mockImplementation(send);
+
+    await connection.enableAutoAttach();
+
+    expect(send).toHaveBeenNthCalledWith(1, "Target.setAutoAttach", {
+      autoAttach: true,
+      flatten: true,
+      waitForDebuggerOnStart: true,
+      filter: STAGEHAND_WEB_TARGET_FILTER,
+    });
+  });
+
+  it("resumes and detaches an ignored target that arrives paused", async () => {
+    const send = vi.fn(async () => ({}));
+    const close = vi.fn(async () => {});
+    const context = new V3Context(
+      {
+        getSession: vi.fn(() => ({ send, close })),
+      } as never,
+      {} as never,
+      chromeTabs,
+    );
+
+    await context.onAttachedToTarget(
+      target("worker", "worker", "https://example.com/worker.js"),
+      "session-worker",
+    );
+
+    expect(send).toHaveBeenCalledWith("Runtime.runIfWaitingForDebugger");
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("does not create a blank page during resident V3Context bootstrap", async () => {
+    const connection = {
+      connected: true,
+      onTransportClosed: vi.fn(),
+      close: vi.fn(async () => {}),
+    } as unknown as CdpConnection;
+    vi.spyOn(CdpConnection, "connect").mockResolvedValue(connection);
+    vi.spyOn(V3Context.prototype, "bootstrap").mockResolvedValue();
+    const ensureFirstTopLevelPage = vi
+      .spyOn(V3Context.prototype, "ensureFirstTopLevelPage")
+      .mockResolvedValue();
+
+    await V3Context.create("ws://browser-proxy.test", {
+      websocketFactory: vi.fn(),
+      blankPageUrl: "chrome-extension://stagehand/blank.html",
+      fallbackLocatorScriptSource: "",
+      chromeTabs,
+      logger: {} as never,
+      ensureInitialPage: false,
+    });
+
+    expect(ensureFirstTopLevelPage).not.toHaveBeenCalled();
+  });
+
+  it("defers page and network instrumentation until Stagehand initialization", async () => {
+    const send = vi.fn(async () => ({}));
+    const session = {
+      id: "page-session",
+      send,
+      on: vi.fn(),
+      off: vi.fn(),
+    };
+    const page = new Page(
+      {} as never,
+      session as never,
+      "page-target",
+      "main-frame",
+      {} as never,
+      null,
+      true,
+      true,
+    );
+
+    expect(send).not.toHaveBeenCalled();
+    await page.prepareForInitialization();
+
+    expect(send).toHaveBeenCalledWith("Page.enable");
+    expect(send).toHaveBeenCalledWith("Runtime.enable");
+    expect(send).toHaveBeenCalledWith("Network.enable");
+  });
+
+  it("retries deferred page instrumentation after a transient CDP failure", async () => {
+    let pageEnableAttempts = 0;
+    const send = vi.fn(async (method: string) => {
+      if (method === "Page.enable" && pageEnableAttempts++ === 0) {
+        throw new Error("transient Page.enable failure");
+      }
+      return {};
+    });
+    const page = new Page(
+      {} as never,
+      { id: "page-session", send, on: vi.fn(), off: vi.fn() } as never,
+      "page-target",
+      "main-frame",
+      {} as never,
+      null,
+      true,
+      true,
+    );
+
+    await expect(page.prepareForInitialization()).rejects.toThrow("transient Page.enable failure");
+    expect(page.isInstrumentationReady()).toBe(false);
+
+    await page.prepareForInitialization();
+    expect(page.isInstrumentationReady()).toBe(true);
+    expect(pageEnableAttempts).toBe(2);
+  });
+
+  it("defers Page.enable for OOPIF sessions adopted before initialization", async () => {
+    const mainSession = { id: "main", send: vi.fn(), on: vi.fn(), off: vi.fn() };
+    const childSend = vi.fn(async (method: string) => {
+      if (method === "Page.getFrameTree") {
+        return { frameTree: { frame: { id: "child-frame", url: "https://example.com" } } };
+      }
+      return {};
+    });
+    const childSession = { id: "child", send: childSend, on: vi.fn(), off: vi.fn() };
+    const page = new Page(
+      {} as never,
+      mainSession as never,
+      "page-target",
+      "main-frame",
+      {} as never,
+      null,
+      true,
+      true,
+    );
+
+    page.adoptOopifSession(childSession as never, "child-frame");
+    await vi.waitFor(() => expect(childSend).toHaveBeenCalledWith("Page.getFrameTree"));
+
+    expect(childSend).not.toHaveBeenCalledWith("Page.enable");
+  });
+
+  it("tolerates a page closing during deferred context instrumentation", async () => {
+    let rejectPreparation: ((error: Error) => void) | undefined;
+    const page = {
+      isInstrumentationReady: () => false,
+      prepareForInitialization: () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectPreparation = reject;
+        }),
+    };
+    const context = new V3Context(
+      {} as never,
+      {} as never,
+      chromeTabs,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      true,
+    );
+    context.pagesByTarget.set("closing-page", page as never);
+    context.typeByTarget.set("closing-page", "page");
+
+    const preparation = context.prepareForInitialization();
+    await vi.waitFor(() => expect(rejectPreparation).toBeDefined());
+    context.pagesByTarget.delete("closing-page");
+    rejectPreparation?.(new Error("target closed"));
+
+    await expect(preparation).resolves.toBeUndefined();
+  });
+});

--- a/packages/server/tests/runtime-descriptor.test.ts
+++ b/packages/server/tests/runtime-descriptor.test.ts
@@ -14,12 +14,18 @@ describe("runtime descriptor", () => {
     expect(RuntimeDescriptorSchema.parse(scope.__stagehand_runtime)).toStrictEqual(
       scope.__stagehand_runtime,
     );
-    expect(scope.__stagehand_runtime).toStrictEqual({
+    expect(scope.__stagehand_runtime).toMatchObject({
+      name: "stagehand",
+      version: "4.0.0",
       protocolVersion: 4,
       serverInfo: {
         name: "stagehand",
         version: "4.0.0",
       },
+      state: "unconfigured",
+      connected: false,
+      runtimeInstanceId: expect.any(String),
+      timings: {},
     });
   });
 

--- a/packages/server/tests/stagehand-clients.test.ts
+++ b/packages/server/tests/stagehand-clients.test.ts
@@ -7,7 +7,10 @@ import {
   StagehandRpcNotificationSchema,
   StagehandSendToHostBindingSchema,
 } from "../../protocol/schema-registry.ts";
-import { startStagehandServiceWorker } from "../service-worker.ts";
+import {
+  startStagehandServiceWorker,
+  type StagehandServiceWorkerScope,
+} from "../service-worker.ts";
 import type {
   StagehandBrowserSession,
   UnderstudyRuntimeClipboardOptions,
@@ -604,6 +607,88 @@ describe("Stagehand worker clients", () => {
       },
       __stagehandReceiveFromHost: expect.any(Function),
     });
+  });
+
+  it("does not auto-bootstrap a public build without resident configuration", async () => {
+    const browserSessionFactory = vi.fn(async () => new FakeBrowserSession());
+    const runtime = createStagehandRuntime({ browserSessionFactory }, testTracing);
+    const scope: StagehandServiceWorkerScope & {
+      [STAGEHAND_SEND_TO_HOST_BINDING](payload: string): void;
+    } = {
+      [STAGEHAND_SEND_TO_HOST_BINDING]: () => {},
+    };
+
+    startStagehandServiceWorker(scope, runtime);
+    await Promise.resolve();
+
+    expect(browserSessionFactory).not.toHaveBeenCalled();
+    expect(scope.__stagehand_runtime?.failure).toBeUndefined();
+  });
+
+  it("retries resident bootstrap after a bounded resolver failure", async () => {
+    const session = new FakeBrowserSession();
+    const runtime = createStagehandRuntime(
+      {
+        browserSessionFactory: async (_url, _logger, lifecycle) => {
+          lifecycle?.onConnected?.();
+          return session;
+        },
+      },
+      testTracing,
+    );
+    const resolveResidentWebSocketUrl = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new Error("resident browser proxy is still starting"))
+      .mockResolvedValueOnce("ws://browser-proxy.test/session");
+    const scope: StagehandServiceWorkerScope & {
+      [STAGEHAND_SEND_TO_HOST_BINDING](payload: string): void;
+    } = {
+      [STAGEHAND_SEND_TO_HOST_BINDING]: () => {},
+    };
+
+    startStagehandServiceWorker(scope, runtime, {
+      autoBootstrap: true,
+      resolveResidentWebSocketUrl,
+    });
+
+    await vi.waitFor(() => {
+      expect(scope.__stagehand_runtime).toMatchObject({ state: "ready", connected: true });
+    });
+    expect(resolveResidentWebSocketUrl).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not publish ready while bootstrap is pending even though the receiver is installed", async () => {
+    const session = new FakeBrowserSession();
+    let finishBootstrap: (() => void) | undefined;
+    const runtime = createStagehandRuntime(
+      {
+        browserSessionFactory: async (_url, _logger, lifecycle) => {
+          lifecycle?.onConnected?.();
+          await new Promise<void>((resolve) => {
+            finishBootstrap = resolve;
+          });
+          return session;
+        },
+      },
+      testTracing,
+    );
+    const scope: StagehandServiceWorkerScope & {
+      [STAGEHAND_SEND_TO_HOST_BINDING](payload: string): void;
+    } = {
+      [STAGEHAND_SEND_TO_HOST_BINDING]: () => {},
+    };
+
+    startStagehandServiceWorker(scope, runtime, {
+      autoBootstrap: true,
+      resolveResidentWebSocketUrl: async () => "ws://browser-proxy.test/session",
+    });
+    await vi.waitFor(() => expect(scope.__stagehand_runtime?.state).toBe("bootstrapping"));
+
+    expect(scope.__stagehandReceiveFromHost).toEqual(expect.any(Function));
+    expect(scope.__stagehand_runtime?.state).not.toBe("ready");
+
+    finishBootstrap?.();
+    await vi.waitFor(() => expect(scope.__stagehand_runtime?.state).toBe("ready"));
   });
 
   it("returns responses without streaming debug logs at the default info level", async () => {

--- a/packages/server/tests/understudy-context-lifecycle.test.ts
+++ b/packages/server/tests/understudy-context-lifecycle.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CdpConnection } from "../understudy/cdp.js";
+import { V3Context } from "../understudy/context.js";
+
+function contextOptions(onConnected: () => void, onDisconnected: () => void) {
+  return {
+    websocketFactory: vi.fn(),
+    blankPageUrl: "chrome-extension://stagehand/blank.html",
+    fallbackLocatorScriptSource: "",
+    chromeTabs: {} as never,
+    logger: { debug: vi.fn(), error: vi.fn() } as never,
+    onConnected,
+    onDisconnected,
+  };
+}
+
+describe("V3Context connection lifecycle", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("reports a successful connection and deduplicates disconnect notification", async () => {
+    let transportClosed: (() => void) | undefined;
+    const connection = {
+      onTransportClosed: vi.fn((handler: () => void) => {
+        transportClosed = handler;
+      }),
+      close: vi.fn(async () => {}),
+    };
+    vi.spyOn(CdpConnection, "connect").mockResolvedValue(connection as never);
+    vi.spyOn(V3Context.prototype, "bootstrap").mockResolvedValue();
+    vi.spyOn(V3Context.prototype, "ensureFirstTopLevelPage").mockResolvedValue({} as never);
+    const onConnected = vi.fn();
+    const onDisconnected = vi.fn();
+
+    await V3Context.create("ws://browser.example", contextOptions(onConnected, onDisconnected));
+    transportClosed?.();
+    transportClosed?.();
+
+    expect(onConnected).toHaveBeenCalledOnce();
+    expect(onDisconnected).toHaveBeenCalledOnce();
+  });
+
+  it("closes and reports disconnection when bootstrap fails", async () => {
+    let transportClosed: (() => void) | undefined;
+    const connection = {
+      onTransportClosed: vi.fn((handler: () => void) => {
+        transportClosed = handler;
+      }),
+      close: vi.fn(async () => transportClosed?.()),
+    };
+    vi.spyOn(CdpConnection, "connect").mockResolvedValue(connection as never);
+    vi.spyOn(V3Context.prototype, "bootstrap").mockRejectedValue(new Error("bootstrap failed"));
+    const onConnected = vi.fn();
+    const onDisconnected = vi.fn();
+
+    await expect(
+      V3Context.create("ws://browser.example", contextOptions(onConnected, onDisconnected)),
+    ).rejects.toThrow("bootstrap failed");
+
+    expect(onConnected).toHaveBeenCalledOnce();
+    expect(onDisconnected).toHaveBeenCalledOnce();
+    expect(connection.close).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/server/understudy/browserWebSocketTransport.ts
+++ b/packages/server/understudy/browserWebSocketTransport.ts
@@ -39,8 +39,9 @@ class BrowserWebSocketTransport implements CdpWebSocketTransport {
     });
   }
 
-  onMessage(handler: (data: string) => void): void {
+  onMessage(handler: (data: string) => void): () => void {
     this.messageHandlers.add(handler);
+    return () => this.messageHandlers.delete(handler);
   }
 
   onClose(handler: (event: CdpWebSocketCloseEvent) => void): void {

--- a/packages/server/understudy/cdp.ts
+++ b/packages/server/understudy/cdp.ts
@@ -3,6 +3,13 @@ import type { Protocol } from "devtools-protocol";
 import { z } from "zod/v4";
 import type { StagehandLogger } from "../logger.js";
 
+/** CDP uses the first matching entry, so allowed web types must precede the catch-all exclusion. */
+export const STAGEHAND_WEB_TARGET_FILTER: Protocol.Target.TargetFilter = [
+  { type: "page" },
+  { type: "iframe" },
+  { exclude: true },
+];
+
 /**
  * CDP transport & session multiplexer
  *
@@ -28,7 +35,7 @@ export interface CdpWebSocketTransport {
   readonly connected: boolean;
   send(payload: string): void;
   close(): Promise<void>;
-  onMessage(handler: (data: string) => void): void;
+  onMessage(handler: (data: string) => void): () => void;
   onClose(handler: (event: CdpWebSocketCloseEvent) => void): void;
   onError(handler: (error: Error) => void): void;
 }
@@ -161,6 +168,7 @@ export class CdpConnection implements CDPSessionLike {
       autoAttach: true,
       flatten: true,
       waitForDebuggerOnStart: true,
+      filter: STAGEHAND_WEB_TARGET_FILTER,
     });
     await this.send("Target.setDiscoverTargets", { discover: true });
   }

--- a/packages/server/understudy/context.ts
+++ b/packages/server/understudy/context.ts
@@ -1,7 +1,7 @@
 // lib/v3/understudy/context.ts
 import type { Protocol } from "devtools-protocol";
 import type { StagehandLogger } from "../logger.js";
-import { CdpConnection } from "./cdp.js";
+import { CdpConnection, STAGEHAND_WEB_TARGET_FILTER } from "./cdp.js";
 import type { CDPSessionLike, CdpWebSocketFactory } from "./cdp.js";
 import { Page } from "./page.js";
 import { executionContexts } from "./executionContextRegistry.js";
@@ -60,11 +60,12 @@ function hasInjectableDOM(url: string | undefined): boolean {
 }
 
 function isNonWebTarget(info: Protocol.Target.TargetInfo): boolean {
-  // Top-level pages should always be tracked — the initial URL may be a
-  // non-web scheme (e.g. chrome://newtab/) but the user can navigate to
-  // web content, and the target identity stays the same.
-  if (info.type === "page") return false;
+  if (info.type === "page") return !hasInjectableDOM(info.url);
   return info.type !== "iframe" || !hasInjectableDOM(info.url);
+}
+
+export function isSupportedWebTarget(info: Protocol.Target.TargetInfo): boolean {
+  return !isNonWebTarget(info);
 }
 
 function isTopLevelPage(info: Protocol.Target.TargetInfo): boolean {
@@ -96,6 +97,7 @@ export class V3Context {
     readonly localBrowserLaunchOptions: LocalBrowserLaunchOptions | null = null,
     readonly blankPageUrl: string = "about:blank",
     readonly fallbackLocatorScriptSource: string | null = null,
+    private deferPageInstrumentation = false,
   ) {}
 
   readonly _targetSessionListeners = new Set<SessionId>();
@@ -113,6 +115,8 @@ export class V3Context {
   createdAtByTarget = new Map<TargetId, number>();
   typeByTarget = new Map<TargetId, TargetType>();
   pendingCreatedTargetUrl = new Map<TargetId, string>();
+  private readonly pendingTargetAttachments = new Set<TargetId>();
+  private pageInstrumentationTask?: Promise<void>;
   pageCreationFailures = new Map<TargetId, Error>();
   // Popup close attempts can race targetCreated, targetInfoChanged, and attached.
   // In-flight promises let attach wait for a close result before deciding whether
@@ -165,30 +169,51 @@ export class V3Context {
       fallbackLocatorScriptSource: string;
       chromeTabs: ChromeTabTargetController;
       logger: StagehandLogger;
+      onConnected?(): void;
+      onDisconnected?(): void;
+      ensureInitialPage?: boolean;
+      deferPageInstrumentation?: boolean;
     },
   ): Promise<V3Context> {
     const connectTask = async () => {
       const conn = await CdpConnection.connect(wsUrl, opts.websocketFactory, opts.logger);
-      const ctx = new V3Context(
-        conn,
-        opts.logger,
-        opts.chromeTabs,
-        opts?.env ?? "LOCAL",
-        opts?.apiClient ?? null,
-        opts?.localBrowserLaunchOptions ?? null,
-        opts.blankPageUrl,
-        opts.fallbackLocatorScriptSource,
-      );
-      await ctx.bootstrap();
-      // Allow connectTimeoutMs to also govern how long we wait for the first
-      // top-level page to appear.  On slow machines the browser may need more
-      // time after the CDP socket is open before the initial page registers.
-      const firstPageTimeoutMs = Math.max(
-        opts?.localBrowserLaunchOptions?.connectTimeoutMs ?? 0,
-        DEFAULT_FIRST_TOP_LEVEL_PAGE_TIMEOUT_MS,
-      );
-      await ctx.ensureFirstTopLevelPage(firstPageTimeoutMs);
-      return ctx;
+      if (opts.onDisconnected) {
+        let disconnected = false;
+        conn.onTransportClosed(() => {
+          if (disconnected) return;
+          disconnected = true;
+          opts.onDisconnected?.();
+        });
+      }
+      try {
+        opts.onConnected?.();
+        const ctx = new V3Context(
+          conn,
+          opts.logger,
+          opts.chromeTabs,
+          opts?.env ?? "LOCAL",
+          opts?.apiClient ?? null,
+          opts?.localBrowserLaunchOptions ?? null,
+          opts.blankPageUrl,
+          opts.fallbackLocatorScriptSource,
+          opts.deferPageInstrumentation ?? false,
+        );
+        await ctx.bootstrap();
+        if (opts.ensureInitialPage ?? true) {
+          // Allow connectTimeoutMs to also govern how long we wait for the first
+          // top-level page to appear. On slow machines the browser may need more
+          // time after the CDP socket is open before the initial page registers.
+          const firstPageTimeoutMs = Math.max(
+            opts?.localBrowserLaunchOptions?.connectTimeoutMs ?? 0,
+            DEFAULT_FIRST_TOP_LEVEL_PAGE_TIMEOUT_MS,
+          );
+          await ctx.ensureFirstTopLevelPage(firstPageTimeoutMs);
+        }
+        return ctx;
+      } catch (error) {
+        await conn.close();
+        throw error;
+      }
     };
 
     return await connectTask();
@@ -201,6 +226,35 @@ export class V3Context {
       }
     }
     return false;
+  }
+
+  /** Complete page-domain setup only when the client begins Stagehand initialization. */
+  async prepareForInitialization(): Promise<void> {
+    if (!this.deferPageInstrumentation) return;
+    if (this.pageInstrumentationTask) return await this.pageInstrumentationTask;
+
+    const task = (async () => {
+      while (true) {
+        const pending = this.pages().filter((page) => !page.isInstrumentationReady());
+        if (pending.length === 0) break;
+        await Promise.all(
+          pending.map(async (page) => {
+            try {
+              await page.prepareForInitialization();
+            } catch (error) {
+              if (this.pages().includes(page)) throw error;
+            }
+          }),
+        );
+      }
+      this.deferPageInstrumentation = false;
+    })();
+    this.pageInstrumentationTask = task;
+    try {
+      await task;
+    } finally {
+      if (this.pageInstrumentationTask === task) this.pageInstrumentationTask = undefined;
+    }
   }
 
   async ensureFirstTopLevelPage(timeout: number): Promise<void> {
@@ -585,6 +639,7 @@ export class V3Context {
     this.createdAtByTarget.clear();
     this.typeByTarget.clear();
     this.pendingCreatedTargetUrl.clear();
+    this.pendingTargetAttachments.clear();
     this.pageCreationFailures.clear();
     this.domainPolicyClosingTargets.clear();
     this.domainPolicyClosePromises.clear();
@@ -619,7 +674,7 @@ export class V3Context {
       }
     });
     this.conn.on<Protocol.Target.TargetInfoChangedEvent>("Target.targetInfoChanged", (evt) => {
-      void this.closePopupIfBlockedByDomainPolicy(evt.targetInfo, "targetInfoChanged");
+      void this.onTargetInfoChanged(evt.targetInfo);
     });
 
     // Only enable auto-attach after listeners are ready so replayed targets are captured.
@@ -628,15 +683,33 @@ export class V3Context {
     const targets = await this.conn.getTargets();
     for (const t of targets) {
       if (t.attached) continue; // auto-attach already handled this target
-      try {
-        await this.conn.attachToTarget(t.targetId);
-      } catch {
-        // ignore attach race
-      }
+      if (!isSupportedWebTarget(t)) continue;
+      await this.attachToTarget(t.targetId);
     }
 
-    const topLevelTargetIds = targets.filter((t) => isTopLevelPage(t)).map((t) => t.targetId);
+    const topLevelTargetIds = targets
+      .filter((target) => isTopLevelPage(target) && isSupportedWebTarget(target))
+      .map((target) => target.targetId);
     await this.waitForInitialTopLevelTargets(topLevelTargetIds);
+  }
+
+  private async onTargetInfoChanged(info: Protocol.Target.TargetInfo): Promise<void> {
+    if (await this.closePopupIfBlockedByDomainPolicy(info, "targetInfoChanged")) return;
+    if (info.attached || !isSupportedWebTarget(info) || this.pagesByTarget.has(info.targetId))
+      return;
+    await this.attachToTarget(info.targetId);
+  }
+
+  private async attachToTarget(targetId: TargetId): Promise<void> {
+    if (this.pendingTargetAttachments.has(targetId) || this.pagesByTarget.has(targetId)) return;
+    this.pendingTargetAttachments.add(targetId);
+    try {
+      await this.conn.attachToTarget(targetId);
+    } catch {
+      // Target discovery and auto-attachment can win this race.
+    } finally {
+      this.pendingTargetAttachments.delete(targetId);
+    }
   }
 
   /**
@@ -656,10 +729,14 @@ export class V3Context {
     // They still need to be resumed so we don't leave them paused by
     // waitForDebuggerOnStart. Trying to initialize these targets can throw or
     // corrupt their internal state (e.g. Chrome's PDF viewer).
-    if (isNonWebTarget(info)) {
+    const isStagehandBlankPage =
+      info.type === "page" &&
+      (info.url === this.blankPageUrl || this.pendingCreatedTargetUrl.has(info.targetId));
+    if (isNonWebTarget(info) && !isStagehandBlankPage) {
       const session = this.conn.getSession(sessionId);
       if (session) {
         await session.send("Runtime.runIfWaitingForDebugger").catch(() => {});
+        await session.close().catch(() => {});
       }
       return;
     }
@@ -741,12 +818,14 @@ export class V3Context {
     // - register init scripts.
     // Commands are sent in-order on the same session before resume.
     const corePreResumeOps = [
-      queuePreResume("Page.enable"),
-      queuePreResume("Runtime.enable"),
+      ...(this.deferPageInstrumentation
+        ? []
+        : [queuePreResume("Page.enable"), queuePreResume("Runtime.enable")]),
       queuePreResume("Target.setAutoAttach", {
         autoAttach: true,
         waitForDebuggerOnStart: true,
         flatten: true,
+        filter: STAGEHAND_WEB_TARGET_FILTER,
       }),
     ];
     const headerPreResumeOps: Array<{
@@ -864,7 +943,9 @@ export class V3Context {
     try {
       // Best-effort lifecycle events; do not block top-level page registration
       // on this optional signal stream.
-      void session.send("Page.setLifecycleEventsEnabled", { enabled: true }).catch(() => {});
+      if (!this.deferPageInstrumentation) {
+        void session.send("Page.setLifecycleEventsEnabled", { enabled: true }).catch(() => {});
+      }
 
       // Top-level handling
       if (isTopLevelPage(info)) {
@@ -882,6 +963,7 @@ export class V3Context {
             this.apiClient,
             this.localBrowserLaunchOptions,
             this.env === "BROWSERBASE",
+            this.deferPageInstrumentation,
           );
         } catch (error) {
           createError = error;

--- a/packages/server/understudy/networkManager.ts
+++ b/packages/server/understudy/networkManager.ts
@@ -23,6 +23,8 @@ import {
  * Aggregates network information for all CDP sessions owned by a Page.
  */
 export class NetworkManager {
+  private enabled: boolean;
+  private enableTask?: Promise<void>;
   readonly sessions = new Map<
     string,
     {
@@ -36,6 +38,10 @@ export class NetworkManager {
   readonly requests = new Map<string, NetworkRequestInfo>();
 
   readonly documentRequestsByFrame = new Map<string, string>();
+
+  constructor(enabled = true) {
+    this.enabled = enabled;
+  }
 
   /**
    * Begin tracking network traffic for a CDP session (top-level or OOPIF).
@@ -139,8 +145,9 @@ export class NetworkManager {
     session.on("Network.responseReceived", onResponse);
     session.on("Page.frameStoppedLoading", onFrameStopped);
 
-    void session.send("Network.enable").catch(() => {});
-    void session.send("Page.enable").catch(() => {});
+    if (this.enabled) {
+      void session.send("Network.enable").catch(() => {});
+    }
 
     this.sessions.set(sid, {
       session,
@@ -153,6 +160,40 @@ export class NetworkManager {
         session.off("Page.frameStoppedLoading", onFrameStopped);
       },
     });
+  }
+
+  /** Enable event-producing domains after resident bootstrap has been initialized. */
+  public async enable(): Promise<void> {
+    if (this.enabled) return;
+    if (this.enableTask) return await this.enableTask;
+
+    const task = (async () => {
+      const enabledSessions = new Set<CDPSessionLike>();
+      while (true) {
+        const pending = [...this.sessions.values()]
+          .map(({ session }) => session)
+          .filter((session) => !enabledSessions.has(session));
+        if (pending.length === 0) break;
+        await Promise.all(
+          pending.map(async (session) => {
+            try {
+              await session.send("Network.enable");
+              enabledSessions.add(session);
+            } catch (error) {
+              if (this.sessions.get(this.sessionKey(session))?.session !== session) return;
+              throw error;
+            }
+          }),
+        );
+      }
+      this.enabled = true;
+    })();
+    this.enableTask = task;
+    try {
+      await task;
+    } finally {
+      if (this.enableTask === task) this.enableTask = undefined;
+    }
   }
 
   /**

--- a/packages/server/understudy/page.ts
+++ b/packages/server/understudy/page.ts
@@ -91,6 +91,9 @@ export class Page {
   /** Document-start scripts installed across every session this page owns. */
   readonly initScripts: string[] = [];
   extraHTTPHeaders: Record<string, string> = {};
+  private instrumentationReady: boolean;
+  private instrumentationTask?: Promise<void>;
+  private readonly instrumentedSessions = new WeakSet<CDPSessionLike>();
 
   constructor(
     readonly conn: CdpConnection,
@@ -100,10 +103,12 @@ export class Page {
     public readonly logger: StagehandLogger,
     apiClient?: StagehandAPIClient | null,
     browserIsRemote = false,
+    deferInstrumentation = false,
   ) {
     this.pageId = _targetId;
     this.apiClient = apiClient ?? null;
     this.browserIsRemote = browserIsRemote;
+    this.instrumentationReady = !deferInstrumentation;
 
     // own the main session
     if (mainSession.id) this.sessions.set(mainSession.id, mainSession);
@@ -120,8 +125,48 @@ export class Page {
       this.logger,
     );
 
-    this.networkManager = new NetworkManager();
+    this.networkManager = new NetworkManager(!deferInstrumentation);
     this.networkManager.trackSession(this.mainSession);
+  }
+
+  /** Enable domains intentionally deferred while the resident runtime was only becoming ready. */
+  public async prepareForInitialization(): Promise<void> {
+    if (this.instrumentationReady) return;
+    if (this.instrumentationTask) return await this.instrumentationTask;
+
+    const task = (async () => {
+      await this.networkManager.enable();
+      while (true) {
+        const pending = [...this.sessions.values()].filter(
+          (session) => !this.instrumentedSessions.has(session),
+        );
+        if (pending.length === 0) break;
+        await Promise.all(
+          pending.map(async (session) => {
+            try {
+              await session.send("Page.enable");
+              await session.send("Runtime.enable");
+              await session.send("Page.setLifecycleEventsEnabled", { enabled: true });
+              this.instrumentedSessions.add(session);
+            } catch (error) {
+              if (session.id && !this.sessions.has(session.id)) return;
+              throw error;
+            }
+          }),
+        );
+      }
+      this.instrumentationReady = true;
+    })();
+    this.instrumentationTask = task;
+    try {
+      await task;
+    } finally {
+      if (this.instrumentationTask === task) this.instrumentationTask = undefined;
+    }
+  }
+
+  public isInstrumentationReady(): boolean {
+    return this.instrumentationReady;
   }
 
   // Send a single init script to a specific CDP session.
@@ -200,19 +245,31 @@ export class Page {
     apiClient?: StagehandAPIClient | null,
     localBrowserLaunchOptions?: LocalBrowserLaunchOptions | null,
     browserIsRemote = false,
+    deferInstrumentation = false,
   ): Promise<Page> {
     // Context already issues Page.enable + lifecycle enable before resume.
     // Re-issue here only as best-effort and do not block page registration on
     // their acknowledgements; some remote CDP backends can delay these replies
     // long after the target is otherwise ready.
-    void session.send("Page.enable").catch(() => {});
-    void session.send("Page.setLifecycleEventsEnabled", { enabled: true }).catch(() => {});
+    if (!deferInstrumentation) {
+      void session.send("Page.enable").catch(() => {});
+      void session.send("Page.setLifecycleEventsEnabled", { enabled: true }).catch(() => {});
+    }
     const { frameTree } = await session.send<{
       frameTree: Protocol.Page.FrameTree;
     }>("Page.getFrameTree");
     const mainFrameId = frameTree.frame.id;
 
-    const page = new Page(conn, session, targetId, mainFrameId, logger, apiClient, browserIsRemote);
+    const page = new Page(
+      conn,
+      session,
+      targetId,
+      mainFrameId,
+      logger,
+      apiClient,
+      browserIsRemote,
+      deferInstrumentation,
+    );
     // Seed current URL from initial frame tree
     try {
       page._currentUrl = String(frameTree?.frame?.url ?? page._currentUrl);
@@ -334,7 +391,9 @@ export class Page {
     // One-shot seed the child's subtree ownership from its current tree
     void (async () => {
       try {
-        await childSession.send("Page.enable").catch(() => {});
+        if (this.instrumentationReady) {
+          await childSession.send("Page.enable").catch(() => {});
+        }
         let { frameTree } =
           await childSession.send<Protocol.Page.GetFrameTreeResponse>("Page.getFrameTree");
 


### PR DESCRIPTION
## Summary

- bootstrap the resident browser session when a privately configured MV3 worker starts
- publish ready only after connection, V3Context target bootstrap, and host RPC receiver installation
- coalesce startup and queue the first `stagehand.init` behind active bootstrap
- leave ready immediately on socket loss, re-resolve the browser proxy, and reconnect with a bounded budget
- restore initialized instrumentation before republishing ready
- stop reconnecting after intentional close
- preserve direct local/custom-CDP initialization outside the resident coordinator

## Scope

Stack 6/7, based on `feat/resident-transport`. Each browser VM serves one reservation and is destroyed on release, so there is no arm/disarm, reservation epoch, turnover reset, or successor-reservation behavior.

## Review focus

`service-worker-lifecycle/resident-runtime.ts` now coordinates only resident startup, same-session reconnect, queued initialization, and close. The existing heartbeat behavior is unchanged.

## Validation

- lifecycle coalescing, readiness, first-init-during-bootstrap, reconnect restoration, terminal failure, and intentional-close tests
- local/custom-CDP worker tests
- complete stack validation at PR 7/7
