### PR TITLE
Emit deterministic resident extension artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "check": "oxfmt --check . && oxlint . && tsc --noEmit -p packages/protocol/tsconfig.json",
     "docs": "pnpm --filter ./packages/docs dev",
     "fmt": "oxfmt --write .",
-    "test": "pnpm --filter ./packages/server build && pnpm --filter ./packages/sdk-ts build && pnpm --recursive --if-present test && vitest run rules/ast-grep",
+    "test": "pnpm --filter ./packages/server test && pnpm --filter ./packages/sdk-ts build && pnpm --filter ./packages/sdk-ts test && pnpm --filter ./packages/protocol test && vitest run rules/ast-grep",
     "build": "pnpm --filter ./packages/protocol build && pnpm --filter ./packages/server build && pnpm --filter ./packages/sdk-ts build"
   },
   "devDependencies": {

--- a/packages/protocol/tests/browser-runtime/resident-browser-proxy-smoke.test.ts
+++ b/packages/protocol/tests/browser-runtime/resident-browser-proxy-smoke.test.ts
@@ -1,0 +1,226 @@
+import { connect, type Socket } from "node:net";
+import { createServer, type Server } from "node:http";
+import { cp, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { getChromePath, launch, Launcher, type LaunchedChrome } from "chrome-launcher";
+import { build } from "vite";
+import { describe, expect, it } from "vitest";
+import { instrumentedDecoratorBuild } from "../../../server/instrumentedDecoratorBuild.js";
+import { CDPClient } from "../../../sdk-ts/src/cdpClient.js";
+import { connectRPCClient, type RPCClient } from "../../../sdk-ts/src/rpcClient.js";
+import { StagehandMethods } from "../../schema-registry.js";
+
+const COMMAND_TIMEOUT_MS = 15_000;
+const serverDistDir = path.resolve(fileURLToPath(new URL("../../../server/dist", import.meta.url)));
+const serviceWorkerEntry = path.resolve(
+  fileURLToPath(new URL("../../../server/service-worker.ts", import.meta.url)),
+);
+
+type BrowserProxy = {
+  url: string;
+  close(): Promise<void>;
+};
+
+describe("resident browser proxy", () => {
+  it("bootstraps a real extension and serves the first RPC without a client CDP URL", async () => {
+    let chrome: LaunchedChrome | undefined;
+    let proxy: BrowserProxy | undefined;
+    let extensionDir: string | undefined;
+    let rpcClient: RPCClient | undefined;
+
+    try {
+      chrome = await launchChrome();
+      proxy = await startBrowserProxy(chrome.port);
+      extensionDir = await buildResidentExtension(proxy.url);
+      rpcClient = await connectRPCClient({
+        cdpUrl: `http://127.0.0.1:${chrome.port}`,
+        extensionDir,
+        serviceWorkerUrlIncludes: "service-worker.js",
+        discoveryTimeoutMs: COMMAND_TIMEOUT_MS,
+        commandTimeoutMs: COMMAND_TIMEOUT_MS,
+      });
+
+      const marker = await waitForResidentReady(rpcClient);
+      expect(marker).toMatchObject({
+        state: "ready",
+        connected: true,
+        runtimeInstanceId: expect.any(String),
+        timings: {
+          connectAndBootstrapMs: expect.any(Number),
+          totalMs: expect.any(Number),
+        },
+      });
+
+      await expect(
+        rpcClient.send(StagehandMethods.stagehandInit, {
+          protocolVersion: 4,
+          clientInfo: { name: "stagehand-sdk-ts", version: "4.0.0" },
+          logLevel: "off",
+          telemetry: { traces: { endpoint: "http://127.0.0.1:4318/v1/traces", headers: {} } },
+        }),
+      ).resolves.toMatchObject({ initialized: true });
+      await expect(rpcClient.send(StagehandMethods.browserGetVersion, {})).resolves.toMatchObject({
+        protocolVersion: "1.3",
+        product: expect.stringContaining("Chrome/"),
+      });
+
+      const existingPages = await rpcClient.send(StagehandMethods.contextPages, {});
+      expect(existingPages).toHaveLength(1);
+      const page = await rpcClient.send(StagehandMethods.contextNewPage, {
+        url: "data:text/html,<title>Resident proxy smoke</title>",
+      });
+      await expect(
+        rpcClient.send(StagehandMethods.pageEvaluate, {
+          pageId: page.pageId,
+          expression: "document.title",
+        }),
+      ).resolves.toStrictEqual({ value: "Resident proxy smoke" });
+    } finally {
+      rpcClient?.close();
+      chrome?.kill();
+      await proxy?.close();
+      if (extensionDir) await rm(extensionDir, { force: true, recursive: true });
+    }
+  }, 60_000);
+});
+
+async function buildResidentExtension(browserProxyUrl: string): Promise<string> {
+  const extensionDir = await mkdtemp(path.join(tmpdir(), "stagehand-resident-proxy-"));
+  await cp(serverDistDir, extensionDir, { recursive: true });
+  await build({
+    configFile: false,
+    logLevel: "silent",
+    define: {
+      "import.meta.env.VITE_STAGEHAND_BROWSER_PROXY_URL": JSON.stringify(browserProxyUrl),
+    },
+    plugins: [instrumentedDecoratorBuild()],
+    build: {
+      emptyOutDir: false,
+      minify: "oxc",
+      outDir: extensionDir,
+      target: "es2022",
+      rolldownOptions: {
+        input: serviceWorkerEntry,
+        output: {
+          entryFileNames: "service-worker.js",
+          minify: {
+            compress: { keepNames: { function: true, class: true } },
+            mangle: { keepNames: { function: true, class: true } },
+          },
+        },
+      },
+    },
+  });
+  return extensionDir;
+}
+
+async function launchChrome(): Promise<LaunchedChrome> {
+  const chromePath = getChromePath();
+  if (!chromePath) throw new Error("No local Chrome or Chromium installation was found");
+
+  return await launch({
+    chromePath,
+    startingUrl: "about:blank",
+    ignoreDefaultFlags: true,
+    chromeFlags: [
+      ...Launcher.defaultFlags().filter((flag) => flag !== "--disable-extensions"),
+      "--enable-unsafe-extension-debugging",
+      "--remote-allow-origins=*",
+      "--window-size=1280,800",
+      "--headless",
+      ...(process.env.CI ? ["--no-sandbox"] : []),
+    ],
+  });
+}
+
+async function startBrowserProxy(chromePort: number): Promise<BrowserProxy> {
+  const sockets = new Set<Socket>();
+  const server = createServer(async (request, response) => {
+    try {
+      if (request.url !== "/json/version") {
+        response.writeHead(404).end("not found");
+        return;
+      }
+      const upstream = await fetch(`http://127.0.0.1:${chromePort}/json/version`);
+      response.writeHead(upstream.status, {
+        "content-type": upstream.headers.get("content-type") ?? "application/json",
+      });
+      response.end(Buffer.from(await upstream.arrayBuffer()));
+    } catch (error) {
+      response.writeHead(502).end(error instanceof Error ? error.message : String(error));
+    }
+  });
+
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
+  });
+  server.on("upgrade", (request, clientSocket, head) => {
+    const upstreamSocket = connect(chromePort, "127.0.0.1");
+    sockets.add(upstreamSocket);
+    upstreamSocket.once("close", () => sockets.delete(upstreamSocket));
+    upstreamSocket.once("error", () => clientSocket.destroy());
+    clientSocket.once("error", () => upstreamSocket.destroy());
+    upstreamSocket.once("connect", () => {
+      const headers: string[] = [];
+      for (let index = 0; index < request.rawHeaders.length; index += 2) {
+        headers.push(`${request.rawHeaders[index]}: ${request.rawHeaders[index + 1]}`);
+      }
+      upstreamSocket.write(
+        `${request.method} ${request.url} HTTP/${request.httpVersion}\r\n${headers.join("\r\n")}\r\n\r\n`,
+      );
+      if (head.length > 0) upstreamSocket.write(head);
+      clientSocket.pipe(upstreamSocket).pipe(clientSocket);
+    });
+  });
+
+  await listen(server);
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("Browser proxy did not bind");
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    close: async () => {
+      for (const socket of sockets) socket.destroy();
+      await closeServer(server);
+    },
+  };
+}
+
+async function waitForResidentReady(rpcClient: RPCClient): Promise<unknown> {
+  const cdp = rpcClient.cdp as CDPClient;
+  const sessionId = cdp.sessionId;
+  if (!sessionId) throw new Error("Stagehand service worker is not attached");
+  const deadline = Date.now() + COMMAND_TIMEOUT_MS;
+  let marker: unknown;
+  while (Date.now() < deadline) {
+    const evaluated = await cdp.sendCommand<{ result?: { value?: unknown } }>(
+      "Runtime.evaluate",
+      { expression: "globalThis.__stagehand_runtime", returnByValue: true },
+      sessionId,
+    );
+    marker = evaluated.result?.value;
+    if (typeof marker === "object" && marker !== null && Reflect.get(marker, "state") === "ready") {
+      return marker;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`Timed out waiting for resident readiness: ${JSON.stringify(marker)}`);
+}
+
+async function listen(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}

--- a/packages/sdk-ts/extensionArtifactPackaging.ts
+++ b/packages/sdk-ts/extensionArtifactPackaging.ts
@@ -1,0 +1,9 @@
+export function assertPublicExtensionArtifact(metadata: unknown): void {
+  const configured =
+    typeof metadata === "object" && metadata !== null && "residentTransportConfigured" in metadata
+      ? metadata.residentTransportConfigured
+      : undefined;
+  if (configured !== false) {
+    throw new Error("Refusing to package a privately configured resident extension in the SDK");
+  }
+}

--- a/packages/sdk-ts/src/extensionAssets.ts
+++ b/packages/sdk-ts/src/extensionAssets.ts
@@ -2,10 +2,6 @@ import { fileURLToPath } from "node:url";
 
 const packageRoot = new URL("../", import.meta.url);
 
-export const STAGEHAND_EXTENSION_ARCHIVE_PATH = fileURLToPath(
-  new URL("dist/assets/stagehand-extension.zip", packageRoot),
-);
-
 export const STAGEHAND_EXTENSION_DIRECTORY_PATH = fileURLToPath(
   new URL("dist/extension/", packageRoot),
 );

--- a/packages/sdk-ts/tests/extension-artifact-packaging.test.ts
+++ b/packages/sdk-ts/tests/extension-artifact-packaging.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { assertPublicExtensionArtifact } from "../extensionArtifactPackaging.js";
+
+describe("extension artifact packaging", () => {
+  it("accepts an explicitly public extension artifact", () => {
+    expect(() =>
+      assertPublicExtensionArtifact({ residentTransportConfigured: false }),
+    ).not.toThrow();
+  });
+
+  it.each([{ residentTransportConfigured: true }, {}, null])(
+    "rejects private or ambiguous extension metadata %#",
+    (metadata) => {
+      expect(() => assertPublicExtensionArtifact(metadata)).toThrow(
+        "Refusing to package a privately configured resident extension",
+      );
+    },
+  );
+});

--- a/packages/sdk-ts/tests/package-contract.test.ts
+++ b/packages/sdk-ts/tests/package-contract.test.ts
@@ -9,7 +9,7 @@ const execFileAsync = promisify(execFile);
 const sdkRoot = new URL("..", import.meta.url);
 
 describe("published TypeScript SDK", () => {
-  it("installs the tarball and resolves both packaged extension artifacts", async () => {
+  it("installs the tarball and resolves the unpacked extension", async () => {
     const temporaryRoot = await mkdtemp(
       path.join(tmpdir(), "stagehand package contract with spaces "),
     );
@@ -48,9 +48,8 @@ describe("published TypeScript SDK", () => {
 
             if (typeof Stagehand !== "function") throw new Error("Stagehand export is unavailable");
             const entryUrl = import.meta.resolve("@browserbasehq/stagehand-v4-spike-sdk-ts");
-            const archiveUrl = new URL("./assets/stagehand-extension.zip", entryUrl);
             const manifestUrl = new URL("./extension/manifest.json", entryUrl);
-            await access(fileURLToPath(archiveUrl));
+            await access(fileURLToPath(manifestUrl));
             const manifest = JSON.parse(await readFile(fileURLToPath(manifestUrl), "utf8"));
             if (manifest.manifest_version !== 3) throw new Error("Invalid packaged manifest");
           `,

--- a/packages/sdk-ts/tsdown.config.ts
+++ b/packages/sdk-ts/tsdown.config.ts
@@ -1,4 +1,14 @@
+import { readFileSync } from "node:fs";
 import { defineConfig } from "tsdown";
+import { assertPublicExtensionArtifact } from "./extensionArtifactPackaging.ts";
+
+const extensionMetadata: unknown = JSON.parse(
+  readFileSync(
+    new URL("../server/artifacts/stagehand-extension.metadata.json", import.meta.url),
+    "utf8",
+  ),
+);
+assertPublicExtensionArtifact(extensionMetadata);
 
 export default defineConfig({
   entry: "src/index.ts",
@@ -21,10 +31,6 @@ export default defineConfig({
     ],
   },
   copy: [
-    {
-      from: "../server/artifacts/stagehand-extension.zip",
-      to: "dist/assets",
-    },
     {
       from: "../server/dist",
       to: "dist",

--- a/packages/server/manifest.json
+++ b/packages/server/manifest.json
@@ -1,6 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Stagehand Runtime",
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4T0m6kKxyC5WzHGSJabgBmm+YlruD5QfYipxafleAaumezh6fQ5pjEEQtXTNg9w835UIXDNS7UZOEjbhJEpv5Nx8K377mCSCOFPGZ9fwiirG8KoBw+yOqDwuSaXu+hJnc9n6nxSwbPfF9m1fpOtAprVMKNpr0Tdjt718RRkEJlDxIcw9PeF12d72yjk/P4bbBN+Mv5lLYXNTzCdY1kCJ4ZUqBoYl7ivAior/Y7OSHYKv/n853AmicKfFZy/z3ad3ocMd28gbgjij5ad/FlFqd0hfTEqlCE+CIxn1VpwuAkPyyRkybCWjeIbcmqRUDnCMFMXr89uCbbOWWEviUPe9eQIDAQAB",
   "version": "0.0.0",
   "minimum_chrome_version": "116",
   "permissions": ["debugger", "offscreen", "scripting", "tabs"],

--- a/packages/server/tests/extension-build.test.ts
+++ b/packages/server/tests/extension-build.test.ts
@@ -4,18 +4,24 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { unzipSync, zipSync, type Zippable } from "fflate";
 import { describe, expect, it } from "vitest";
+import { loadEnv } from "vite";
 import { z } from "zod/v4";
 import serverPackageJson from "../package.json" with { type: "json" };
 
 const stagehandExtensionDistDir = fileURLToPath(new URL("../dist", import.meta.url));
+const serverRoot = fileURLToPath(new URL("..", import.meta.url));
 const stagehandExtensionArchive = fileURLToPath(
   new URL("../artifacts/stagehand-extension.zip", import.meta.url),
+);
+const stagehandExtensionMetadata = fileURLToPath(
+  new URL("../artifacts/stagehand-extension.metadata.json", import.meta.url),
 );
 const expectedManifestVersion = serverPackageJson.version.replace(/[+-].*$/u, "");
 
 const ManifestSchema = z.looseObject({
   manifest_version: z.literal(3),
   name: z.string(),
+  key: z.string().min(1),
   version: z.string(),
   minimum_chrome_version: z.literal("116"),
   permissions: z.array(z.string()),
@@ -110,7 +116,7 @@ describe("extension build", () => {
     expect(offscreenScript).toContain("StagehandExtensionServiceWorkerHeartbeat");
     expect(serviceWorker).not.toContain("src/shims");
     expect(serviceWorker).toContain("new WebSocket");
-    expect(serviceWorker).toContain('binaryType = "arraybuffer"');
+    expect(serviceWorker).toMatch(/binaryType\s*=\s*[`"']arraybuffer[`"']/u);
     expect(serviceWorker).not.toContain("__vite-browser-external");
     expect(serviceWorker).not.toContain("__vite_browser_external");
     expect(serviceWorker).not.toContain("Node WebSocket transport is unavailable");
@@ -139,11 +145,46 @@ describe("extension build", () => {
       ];
     }
     expect(sha256(archiveBytes)).toBe(sha256(zipSync(deterministicEntries, { level: 9 })));
+
+    const metadata = z
+      .object({
+        chromeExtensionId: z.string().regex(/^[a-p]{32}$/u),
+        extensionVersion: z.literal(expectedManifestVersion),
+        stagehandProtocolVersion: z.literal(4),
+        residentTransportConfigured: z.boolean(),
+        sha256: z.string().regex(/^[0-9a-f]{64}$/u),
+        serviceWorkerPath: z.literal("service-worker.js"),
+        sourceCommit: z.string().regex(/^[0-9a-f]{40}$/u),
+      })
+      .parse(JSON.parse(await readFile(stagehandExtensionMetadata, "utf8")));
+    const archivedManifest = ManifestSchema.parse(
+      JSON.parse(new TextDecoder().decode(archive["manifest.json"])),
+    );
+    expect(metadata.chromeExtensionId).toBe(chromeExtensionId(archivedManifest.key));
+    const env = loadEnv("production", serverRoot, "VITE_STAGEHAND_");
+    expect(metadata.residentTransportConfigured).toBe(
+      Boolean(
+        (
+          process.env.VITE_STAGEHAND_BROWSER_PROXY_URL ?? env.VITE_STAGEHAND_BROWSER_PROXY_URL
+        )?.trim(),
+      ),
+    );
+    expect(metadata.sha256).toBe(sha256(archiveBytes));
   }, 30_000);
 });
 
 function sha256(value: Uint8Array): string {
   return createHash("sha256").update(value).digest("hex");
+}
+
+function chromeExtensionId(publicKey: string): string {
+  return createHash("sha256")
+    .update(Buffer.from(publicKey, "base64"))
+    .digest("hex")
+    .slice(0, 32)
+    .replace(/[0-9a-f]/gu, (character) =>
+      String.fromCharCode("a".charCodeAt(0) + Number.parseInt(character, 16)),
+    );
 }
 
 async function readBuiltExtensionFiles(

--- a/packages/server/vite.config.ts
+++ b/packages/server/vite.config.ts
@@ -1,7 +1,10 @@
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
 import { cp, mkdir, readFile, readdir, rename, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { zipSync, type Zippable } from "fflate";
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
+import { STAGEHAND_PROTOCOL_VERSION } from "../protocol/schemas.ts";
 import { instrumentedDecoratorBuild } from "./instrumentedDecoratorBuild.ts";
 import packageJson from "./package.json" with { type: "json" };
 
@@ -9,9 +12,10 @@ const root = import.meta.dirname;
 const outDir = path.join(root, "dist");
 const artifactsDir = path.join(root, "artifacts");
 const extensionArchivePath = path.join(artifactsDir, "stagehand-extension.zip");
+const extensionMetadataPath = path.join(artifactsDir, "stagehand-extension.metadata.json");
 const zipModifiedAt = new Date(1980, 0, 1);
 
-function buildExtensionArtifacts() {
+function buildExtensionArtifacts(residentTransportConfigured: boolean) {
   return {
     name: "stagehand-extension-artifacts",
     async closeBundle() {
@@ -44,8 +48,51 @@ function buildExtensionArtifacts() {
       } finally {
         await rm(temporaryArchivePath, { force: true });
       }
+      const manifestKey = manifest.key;
+      if (typeof manifestKey !== "string" || manifestKey.length === 0) {
+        throw new Error("Stagehand extension manifest must contain a stable public key");
+      }
+      await writeFile(
+        extensionMetadataPath,
+        `${JSON.stringify(
+          {
+            chromeExtensionId: chromeExtensionId(manifestKey),
+            extensionVersion: chromeManifestVersion(packageJson.version),
+            stagehandProtocolVersion: STAGEHAND_PROTOCOL_VERSION,
+            residentTransportConfigured,
+            sha256: sha256(archive),
+            serviceWorkerPath: "service-worker.js",
+            sourceCommit: sourceCommit(),
+          },
+          null,
+          2,
+        )}\n`,
+      );
     },
   };
+}
+
+function sha256(value: Uint8Array): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function chromeExtensionId(publicKey: string): string {
+  return createHash("sha256")
+    .update(Buffer.from(publicKey, "base64"))
+    .digest("hex")
+    .slice(0, 32)
+    .replace(/[0-9a-f]/gu, (character) =>
+      String.fromCharCode("a".charCodeAt(0) + Number.parseInt(character, 16)),
+    );
+}
+
+function sourceCommit(): string {
+  const suppliedCommit = process.env.GITHUB_SHA?.trim();
+  if (suppliedCommit) return suppliedCommit;
+  return execFileSync("git", ["rev-parse", "HEAD"], {
+    cwd: path.resolve(root, "../.."),
+    encoding: "utf8",
+  }).trim();
 }
 
 function chromeManifestVersion(version: string): string {
@@ -106,27 +153,38 @@ async function readExtensionFiles(directory: string, relativeDirectory = ""): Pr
   return files;
 }
 
-export default defineConfig({
-  build: {
-    emptyOutDir: true,
-    minify: false,
-    modulePreload: false,
-    outDir,
-    target: "es2022",
-    rolldownOptions: {
-      input: {
-        "service-worker": path.join(root, "service-worker.ts"),
-        "content-script": path.join(root, "content-script.ts"),
-        "offscreen/service-worker-heartbeat": path.join(
-          root,
-          "service-worker-lifecycle/heartbeat.ts",
-        ),
-        "wake-service-worker": path.join(root, "service-worker-lifecycle/wake.ts"),
-      },
-      output: {
-        entryFileNames: "[name].js",
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, root, "VITE_STAGEHAND_");
+  const residentTransportConfigured = Boolean(
+    (process.env.VITE_STAGEHAND_BROWSER_PROXY_URL ?? env.VITE_STAGEHAND_BROWSER_PROXY_URL)?.trim(),
+  );
+  return {
+    build: {
+      emptyOutDir: true,
+      minify: "oxc",
+      modulePreload: false,
+      outDir,
+      target: "es2022",
+      rolldownOptions: {
+        input: {
+          "service-worker": path.join(root, "service-worker.ts"),
+          "content-script": path.join(root, "content-script.ts"),
+          "offscreen/service-worker-heartbeat": path.join(
+            root,
+            "service-worker-lifecycle/heartbeat.ts",
+          ),
+          "wake-service-worker": path.join(root, "service-worker-lifecycle/wake.ts"),
+        },
+        output: {
+          entryFileNames: "[name].js",
+          // Decorated handlers and the RPC router rely on stable runtime names.
+          minify: {
+            compress: { keepNames: { function: true, class: true } },
+            mangle: { keepNames: { function: true, class: true } },
+          },
+        },
       },
     },
-  },
-  plugins: [instrumentedDecoratorBuild(), buildExtensionArtifacts()],
+    plugins: [instrumentedDecoratorBuild(), buildExtensionArtifacts(residentTransportConfigured)],
+  };
 });


### PR DESCRIPTION
## Summary

- pin the unpacked MV3 extension identity with a manifest key
- retain OXC minification and decorated-symbol name preservation
- emit a deterministic extension ZIP and metadata file
- record Stagehand protocol version and whether resident transport was configured
- keep public builds unconfigured and fail SDK packaging closed for private or ambiguous artifacts
- stop duplicating the ZIP in npm while retaining the unpacked local extension
- add a transparent real-Chrome browser-proxy smoke test

## Scope

Stack 7/7, based on PR #2446. The private build injects its loopback browser-proxy origin; no infrastructure address is committed in source or artifact metadata.

## Validation

- `pnpm check`
- `pnpm test`: 647 package tests and 12 rule tests passed
- `uv run --project packages/sdk-python pytest`: 195 passed
- real-Chrome resident proxy smoke passed
- public ZIP reproduced twice: `b5c885b2433595aebae8ec5f57a069f396ea257d384fe36a8aa1a5f5a583c797`
- private ZIP reproduced twice: `aa43f7fdef3190e9037c3da89246a041b02aef707ecf86184b10bf725e336336`
- private artifact was rejected by SDK packaging as intended
