### PR TITLE
Remove stale Stagehand V4 package references

### DIFF
--- a/packages/docs/v4/first-steps/ai-rules.mdx
+++ b/packages/docs/v4/first-steps/ai-rules.mdx
@@ -90,7 +90,7 @@ try {
 ````markdown
 # Stagehand (Python) rules
 
-You are writing async browser automation with `stagehand-v4`.
+You are writing async browser automation with `stagehand`.
 
 ## Initialization
 

--- a/packages/docs/v4/index.mdx
+++ b/packages/docs/v4/index.mdx
@@ -41,7 +41,7 @@ try {
 **Install**
 
 ```bash
-pip install stagehand-v4
+pip install stagehand
 ```
 
 **Initialize Stagehand**

--- a/packages/sdk-ts/tests/browser-runtime/stagehand-browserbase-smoke.test.ts
+++ b/packages/sdk-ts/tests/browser-runtime/stagehand-browserbase-smoke.test.ts
@@ -17,7 +17,7 @@ describe.runIf(shouldRun)("Stagehand TS SDK Browserbase smoke", () => {
       browser: {
         type: "browserbase",
         userMetadata: {
-          suite: "stagehand-v4-browserbase-smoke",
+          suite: "stagehand-browserbase-smoke",
         },
       },
     });


### PR DESCRIPTION
## Summary

- update the V4 Python landing-page install command from `stagehand-v4` to `stagehand`
- update the Python AI-rules prompt to use the published `stagehand` distribution name
- remove the obsolete `v4` suffix from the Browserbase smoke-test session label

## Why

PR #2400 renamed the V4 Python distribution to `stagehand`, but two restored docs references still used the temporary `stagehand-v4` name after PR #2428 merged. A repository-wide audit found no other hyphenated `stagehand-v4` references after this change. The remaining `stagehand_v4` strings in the Python build helper and its test are intentionally retained so old pre-rename artifacts are cleaned from `dist/`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace remaining `stagehand-v4` references with `stagehand` in V4 docs and Browserbase smoke test metadata. This fixes the Python install command, aligns the AI-rules prompt with the published package name, and removes the obsolete `-v4` suffix from the test label.

<sup>Written for commit d0afe9e08eb95dcbd647f502e679ee889551f49b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

