### PR TITLE
fix active page handling

### DIFF
--- a/packages/sdk-ts/tests/browser-runtime/stagehand-launch-connect-smoke.test.ts
+++ b/packages/sdk-ts/tests/browser-runtime/stagehand-launch-connect-smoke.test.ts
@@ -338,7 +338,7 @@ describe("Stagehand TS SDK launch/connect smoke", () => {
     }
   }, 20_000);
 
-  it("tracks a user-gesture popup as it opens, activates, and closes", async () => {
+  it("waits for an active popup to be registered before returning it", async () => {
     const activeStagehand = requireStagehand(stagehand);
     const activeFixtureServer = requireFixtureServer(fixtureServer);
     const createdPages: Page[] = [];
@@ -354,14 +354,17 @@ describe("Stagehand TS SDK launch/connect smoke", () => {
       );
       await opener.locator("#popup-button").click();
 
-      const popup = await waitForNewPage(activeStagehand.context, pageIdsBeforePopup);
+      const popup = await activeStagehand.context.activePage();
+      if (!popup) {
+        throw new Error("Stagehand did not resolve the active popup");
+      }
       createdPages.push(popup);
       await popup.waitForLoadState("load");
 
       expect(popup.pageId).not.toBe(opener.pageId);
+      expect(pageIdsBeforePopup.has(popup.pageId)).toBe(false);
       await expect(popup.url()).resolves.toBe(activeFixtureServer.url);
       await expect(popup.title()).resolves.toBe("Stagehand SDK Smoke");
-      await waitForActivePageId(activeStagehand.context, popup.pageId);
 
       await popup.close();
       await waitForPageRemoval(activeStagehand.context, popup.pageId);
@@ -611,19 +614,6 @@ async function waitForActivePageOtherThan(
     () => context.activePage(),
     (page): page is Page => page !== undefined && page.pageId !== excludedPageId,
     `an active page other than ${excludedPageId}`,
-    timeoutMs,
-  );
-}
-
-async function waitForNewPage(
-  context: BrowserContext,
-  existingPageIds: ReadonlySet<string>,
-  timeoutMs = 10_000,
-): Promise<Page> {
-  return await pollUntil(
-    async () => (await context.pages()).find((page) => !existingPageIds.has(page.pageId)),
-    (page): page is Page => page !== undefined,
-    "a newly opened popup page",
     timeoutMs,
   );
 }

--- a/packages/server/tests/understudy-context-active-page.test.ts
+++ b/packages/server/tests/understudy-context-active-page.test.ts
@@ -49,7 +49,7 @@ describe("V3Context active page", () => {
     try {
       const { context } = createContext("unregistered-target");
       const activePage = expect(context.activePage()).rejects.toThrow(
-        "activePage: active target not registered (unregistered-target) timed out after 5000ms",
+        "activePage: active target not registered (unregistered-target) timed out after 3000ms",
       );
 
       await vi.advanceTimersByTimeAsync(5000);

--- a/packages/server/tests/understudy-context-active-page.test.ts
+++ b/packages/server/tests/understudy-context-active-page.test.ts
@@ -28,10 +28,36 @@ describe("V3Context active page", () => {
     expect(chromeTabs.activeTargetId).toHaveBeenCalledOnce();
   });
 
-  it("returns undefined when Chrome's active target is not registered", async () => {
-    const { context } = createContext("unregistered-target");
+  it("waits for Chrome's active target to be registered", async () => {
+    const { context } = createContext("popup-target");
+    const page = createPage("popup-target");
+
+    const activePage = context.activePage();
+    setTimeout(() => context.pagesByTarget.set("popup-target", page), 10);
+
+    await expect(activePage).resolves.toBe(page);
+  });
+
+  it("returns undefined when Chrome has no active page target", async () => {
+    const { context } = createContext();
 
     await expect(context.activePage()).resolves.toBeUndefined();
+  });
+
+  it("times out when Chrome's active target is never registered", async () => {
+    vi.useFakeTimers();
+    try {
+      const { context } = createContext("unregistered-target");
+      const activePage = expect(context.activePage()).rejects.toThrow(
+        "activePage: active target not registered (unregistered-target) timed out after 5000ms",
+      );
+
+      await vi.advanceTimersByTimeAsync(5000);
+
+      await activePage;
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("uses the Chrome-backed active page for implicit clipboard operations", async () => {

--- a/packages/server/understudy/context.ts
+++ b/packages/server/understudy/context.ts
@@ -73,6 +73,7 @@ function isTopLevelPage(info: Protocol.Target.TargetInfo): boolean {
 }
 
 const DEFAULT_FIRST_TOP_LEVEL_PAGE_TIMEOUT_MS = 5000;
+const DEFAULT_ACTIVE_PAGE_TIMEOUT_MS = 3000;
 const WAIT_FOR_FIRST_TOP_LEVEL_PAGE_OPERATION = "waitForFirstTopLevelPage (no top-level Page)";
 
 /**
@@ -267,8 +268,25 @@ export class V3Context {
 
   /** Return the understudy Page for Chrome's active tab in its last-focused window. */
   public async activePage(): Promise<Page | undefined> {
-    const targetId = await this.chromeTabs.activeTargetId();
-    return targetId === undefined ? undefined : this.pagesByTarget.get(targetId);
+    const deadline = Date.now() + DEFAULT_ACTIVE_PAGE_TIMEOUT_MS;
+    let targetId: string | undefined;
+
+    while (Date.now() < deadline) {
+      targetId = await this.chromeTabs.activeTargetId();
+      if (targetId === undefined) return undefined;
+
+      const page = this.pagesByTarget.get(targetId);
+      if (page) return page;
+
+      // Chrome can activate a popup before its auto-attached target has
+      // completed Page creation and registration in pagesByTarget.
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+
+    throw new TimeoutError(
+      `activePage: active target not registered (${targetId ?? "unknown"})`,
+      DEFAULT_ACTIVE_PAGE_TIMEOUT_MS,
+    );
   }
 
   /** Select the Chrome tab that owns a known understudy Page. */


### PR DESCRIPTION
# why
- when new tabs were opened via a popup, `chromeTabs.activeTargetId()` was pointing to the correct target ID, but stagehand didn't have time to register that target in its registry
- this caused lookup to fail, and `activePage()` to return undefined
# what changed
- added polling with a max of 3 seconds inside `activePage()`
# test plan
- added tests for delayed page registration

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race where popups activated by user gesture were not returned by activePage(). The method now polls for up to 3s for Chrome’s active target to be registered and throws a clear timeout if it never is.

- **Bug Fixes**
  - V3Context.activePage() polls until the active target’s Page is registered; returns undefined when Chrome has no active target; throws a TimeoutError after 3s if never registered.
  - Added tests for delayed registration, no-active-target, and timeout; updated the SDK smoke test to use context.activePage() and removed the custom waitForNewPage helper.

<sup>Written for commit 736109191824ecd31514cf0cec1fb5f3489d7f24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

