### PR TITLE
Expose extract metadata in SDK results

### DIFF
--- a/packages/docs/v4/basics/extract.mdx
+++ b/packages/docs/v4/basics/extract.mdx
@@ -15,7 +15,7 @@ Define the schema as a [Zod](https://zod.dev) object:
 ```typescript
 import { z } from "zod";
 
-const product = await stagehand.extract(
+const { data: product } = await stagehand.extract(
   "Extract the product name and price",
   z.object({
     name: z.string(),
@@ -50,7 +50,7 @@ values, and use field descriptions to guide the model.
 ```typescript
 import { z } from "zod";
 
-const results = await stagehand.extract(
+const { data: results } = await stagehand.extract(
   "Extract each search result",
   z.object({
     results: z.array(
@@ -66,25 +66,26 @@ const results = await stagehand.extract(
 
 ### Return value
 
-`extract()` resolves to data that matches your schema, with no wrapper object. In
-TypeScript the type is inferred from the Zod schema; in Python it's an instance of your
-Pydantic model. When the schema is an array or list, you get an array or list back.
+`extract()` resolves to an object with `data` and `metadata`. `data` matches your schema:
+in TypeScript its type is inferred from Zod, and in Python it is an instance of your
+Pydantic model. `metadata` contains Stagehand-owned information such as cache status and
+an optional action ID.
 
 ```typescript
-const product = await stagehand.extract(
+const extraction = await stagehand.extract(
   "Extract the product details",
   z.object({ name: z.string(), price: z.number(), inStock: z.boolean() }),
 );
-// product is typed as { name: string; price: number; inStock: boolean }
-// e.g. { name: "Wireless Mouse", price: 29.99, inStock: true }
+// extraction.data is typed as { name: string; price: number; inStock: boolean }
 
-console.log(product.name, product.price);
+console.log(extraction.data.name, extraction.data.price);
+console.log(extraction.metadata.cacheStatus);
 ```
 
 ## Advanced configuration
 
 ```typescript
-const data = await stagehand.extract("Extract the article body", schema, {
+const extraction = await stagehand.extract("Extract the article body", schema, {
   selector: "#main-content",
   ignoreSelectors: ["nav", ".cookie-banner"],
   screenshot: true,
@@ -108,7 +109,9 @@ with `ignoreSelectors`) is faster, cheaper, and more accurate than extracting fr
 whole document.
 
 ```typescript
-const { price } = await stagehand.extract(
+const {
+  data: { price },
+} = await stagehand.extract(
   "Extract the sale price",
   z.object({ price: z.number() }),
   { selector: "#product-summary", ignoreSelectors: [".related-products"] },
@@ -126,11 +129,12 @@ On Browserbase, turn on caching
 so repeated, identical extractions are served from a cache instead of calling the model again.
 
 ```typescript
-const product = await stagehand.extract(
+const extraction = await stagehand.extract(
   "Extract the product name and price",
   z.object({ name: z.string(), price: z.number() }),
   { cache: true },
 );
+console.log(extraction.data, extraction.metadata.cacheStatus);
 ```
 
 ## Best practices
@@ -155,7 +159,9 @@ Narrow with `selector`, exclude distractors with `ignoreSelectors`, or enable `s
 when the correct value is clear visually but ambiguous in the DOM.
 
 ```typescript
-const { price } = await stagehand.extract(
+const {
+  data: { price },
+} = await stagehand.extract(
   "Extract the sale price, not the original price",
   z.object({ price: z.number() }),
   { selector: "#product-summary", ignoreSelectors: [".related-products"] },
@@ -180,11 +186,11 @@ class Product(BaseModel):
     price: float
 
 
-product = await stagehand.extract(
+extraction = await stagehand.extract(
     instruction="Extract the product name and price",
     schema=Product,
 )
-# product.name -> str, product.price -> float
+# extraction.data.name -> str, extraction.data.price -> float
 ```
 
 ## Why use `extract()`?
@@ -223,7 +229,7 @@ class SearchResults(BaseModel):
     results: list[Result]
 
 
-results = await stagehand.extract(
+extraction = await stagehand.extract(
     instruction="Extract each search result",
     schema=SearchResults,
 )
@@ -231,9 +237,9 @@ results = await stagehand.extract(
 
 ### Return value
 
-`extract()` resolves to data that matches your schema, with no wrapper object. In
-TypeScript the type is inferred from the Zod schema; in Python it's an instance of your
-Pydantic model. When the schema is an array or list, you get an array or list back.
+`extract()` resolves to an object with `data` and `metadata`. `data` is an instance of
+your Pydantic model, while `metadata` contains Stagehand-owned information such as cache
+status and an optional action ID.
 
 ```python
 class Product(BaseModel):
@@ -242,13 +248,14 @@ class Product(BaseModel):
     in_stock: bool
 
 
-product = await stagehand.extract(
+extraction = await stagehand.extract(
     instruction="Extract the product details",
     schema=Product,
 )
-# product is a Product instance, e.g. Product(name="Wireless Mouse", price=29.99, in_stock=True)
+# extraction.data is a Product instance
 
-print(product.name, product.price)
+print(extraction.data.name, extraction.data.price)
+print(extraction.metadata.cache_status)
 ```
 
 ## Advanced configuration
@@ -257,7 +264,7 @@ print(product.name, product.price)
 from stagehand import ModelConfig
 
 
-data = await stagehand.extract(
+extraction = await stagehand.extract(
     instruction="Extract the article body",
     schema=schema,
     selector="#main-content",
@@ -302,11 +309,12 @@ On Browserbase, turn on caching
 so repeated, identical extractions are served from a cache instead of calling the model again.
 
 ```python
-product = await stagehand.extract(
+extraction = await stagehand.extract(
     instruction="Extract the product name and price",
     schema=Product,
     cache=True,
 )
+print(extraction.data, extraction.metadata.cache_status)
 ```
 
 ## Best practices

--- a/packages/docs/v4/basics/observe.mdx
+++ b/packages/docs/v4/basics/observe.mdx
@@ -177,6 +177,7 @@ if (table) {
   const pricing = await stagehand.extract("Extract each pricing tier", pricingSchema, {
     selector: table.selector,
   });
+  console.log(pricing.data);
 }
 ```
 
@@ -401,6 +402,7 @@ if tables:
         schema=Pricing,
         selector=tables[0].selector,
     )
+    print(pricing.data)
 ```
 
 ### Validate before acting

--- a/packages/docs/v4/first-steps/ai-rules.mdx
+++ b/packages/docs/v4/first-steps/ai-rules.mdx
@@ -64,7 +64,8 @@ try {
 
 ## Extract: typed data with Zod
 
-- `await stagehand.extract("instruction", zodSchema)` returns data validated against the schema.
+- `await stagehand.extract("instruction", zodSchema)` returns `{ data, metadata }`; `data` is
+  validated against the schema.
 - Define the schema with `zod`: `z.object({ price: z.number() })`.
 - Scope large pages with `{ selector }` or `{ ignoreSelectors }`.
 
@@ -140,6 +141,7 @@ asyncio.run(main())
 
 - Define a `pydantic.BaseModel` and pass it as `schema`:
   `await stagehand.extract(instruction="...", schema=MyModel)`.
+- Read the validated model from `.data` and Stagehand-owned information from `.metadata`.
 
 ## Observe
 

--- a/packages/docs/v4/first-steps/introduction.mdx
+++ b/packages/docs/v4/first-steps/introduction.mdx
@@ -50,7 +50,9 @@ try {
   await stagehand.act("Click the primary call-to-action");
 
   // Extract: pull structured data
-  const { heading } = await stagehand.extract(
+  const {
+    data: { heading },
+  } = await stagehand.extract(
     "Extract the page heading",
     z.object({ heading: z.string() }),
   );
@@ -92,6 +94,7 @@ async def main() -> None:
             instruction="Extract the page heading",
             schema=PageInfo,
         )
+        print(page_info.data.heading)
     finally:
         await stagehand.close()
 

--- a/packages/docs/v4/first-steps/quickstart.mdx
+++ b/packages/docs/v4/first-steps/quickstart.mdx
@@ -63,7 +63,7 @@ try {
     "Extract the page heading and description",
     z.object({ heading: z.string(), description: z.string() }),
   );
-  console.log(info);
+  console.log(info.data);
 } finally {
   await stagehand.close();
 }
@@ -139,7 +139,7 @@ async def main() -> None:
             instruction="Extract the page heading and description",
             schema=PageInfo,
         )
-        print(info)
+        print(info.data)
     finally:
         await stagehand.close()
 

--- a/packages/docs/v4/reference/stagehand.mdx
+++ b/packages/docs/v4/reference/stagehand.mdx
@@ -410,6 +410,7 @@ Extract structured data from the page.
 
 ```typescript
 const product = await stagehand.extract("Extract the product", ProductSchema);
+console.log(product.data, product.metadata.cacheStatus);
 ```
 
 <ParamField path="instruction" type="string">
@@ -483,8 +484,20 @@ const product = await stagehand.extract("Extract the product", ProductSchema);
   </ParamField>
 </ParamField>
 
-<ResponseField name="result" type="Promise<z.output<Schema>>">
-  The operation result.
+<ResponseField name="result" type="Promise<ExtractResult<Schema>>">
+  The extraction result.
+
+  <ResponseField name="result.data" type="z.output<Schema>">
+    Data validated against the caller's schema.
+  </ResponseField>
+
+  <ResponseField name="result.metadata.cacheStatus" type='"HIT" | "MISS"' optional>
+    Whether server-side caching served or computed the result.
+  </ResponseField>
+
+  <ResponseField name="result.metadata.actionId" type="string" optional>
+    The action ID associated with the extraction.
+  </ResponseField>
 </ResponseField>
 
 </View>
@@ -887,6 +900,7 @@ Extract structured data from the page.
 
 ```python
 product = await stagehand.extract(instruction="Extract the product", schema=Product)
+print(product.data, product.metadata.cache_status)
 ```
 
 <ParamField path="instruction" type="str">
@@ -957,8 +971,20 @@ product = await stagehand.extract(instruction="Extract the product", schema=Prod
   </ParamField>
 </ParamField>
 
-<ResponseField name="result" type="ResultModel">
-  The operation result.
+<ResponseField name="result" type="ExtractResult[ResultModel]">
+  The extraction result.
+
+  <ResponseField name="result.data" type="ResultModel">
+    Data validated against the caller's Pydantic model.
+  </ResponseField>
+
+  <ResponseField name="result.metadata.cache_status" type='"HIT" | "MISS"' optional>
+    Whether server-side caching served or computed the result.
+  </ResponseField>
+
+  <ResponseField name="result.metadata.action_id" type="str" optional>
+    The action ID associated with the extraction.
+  </ResponseField>
 </ResponseField>
 
 </View>

--- a/packages/protocol/schema-registry.ts
+++ b/packages/protocol/schema-registry.ts
@@ -151,7 +151,7 @@ export const StagehandMethods = {
     params: StagehandExtractParamsSchema,
     result: ExtractResultSchema,
     paramsWire: { opaqueKeys: ["schema"] },
-    resultWire: { opaqueKeys: ["result"] },
+    resultWire: { opaqueKeys: ["data"] },
   },
   stagehandMetrics: {
     name: "stagehand.metrics",

--- a/packages/protocol/schemas.ts
+++ b/packages/protocol/schemas.ts
@@ -1200,20 +1200,23 @@ export const ExtractOptionsSchema = z
   .optional()
   .meta({ id: "ExtractOptions" });
 
-export const ExtractResultSchema = z
-  .object({
-    result: z.unknown().meta({
-      description: "Extracted data matching the requested schema",
-      override: ({ jsonSchema }: { jsonSchema: Record<string, unknown> }) => {
-        jsonSchema["x-stainless-any"] = true;
-      },
-    }),
+export const ExtractMetadataSchema = z
+  .strictObject({
     actionId: z.string().optional().meta({
       description: "Action ID for tracking",
     }),
     cacheStatus: CacheStatusSchema.optional().meta({
       description: "Server-side cache status for this result",
     }),
+  })
+  .meta({ id: "ExtractMetadata" });
+
+export const ExtractResultSchema = z
+  .strictObject({
+    data: z.json().meta({
+      description: "Extracted data matching the requested schema",
+    }),
+    metadata: ExtractMetadataSchema,
   })
   .meta({ id: "ExtractResult" });
 

--- a/packages/protocol/stagehand.v4.json
+++ b/packages/protocol/stagehand.v4.json
@@ -1976,9 +1976,51 @@
     "ExtractResult": {
       "type": "object",
       "properties": {
-        "result": {
-          "description": "Extracted data matching the requested schema"
+        "data": {
+          "description": "Extracted data matching the requested schema",
+          "$ref": "#/$defs/__schema1"
         },
+        "metadata": {
+          "$ref": "#/$defs/ExtractMetadata"
+        }
+      },
+      "required": ["data", "metadata"],
+      "additionalProperties": false
+    },
+    "__schema1": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/__schema1"
+          }
+        },
+        {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema1"
+          }
+        }
+      ]
+    },
+    "ExtractMetadata": {
+      "type": "object",
+      "properties": {
         "action_id": {
           "description": "Action ID for tracking",
           "type": "string"
@@ -1988,7 +2030,7 @@
           "$ref": "#/$defs/CacheStatus"
         }
       },
-      "required": ["result"]
+      "additionalProperties": false
     },
     "StagehandMetrics": {
       "type": "object",
@@ -2238,85 +2280,12 @@
             "type": "string"
           },
           "additionalProperties": {
-            "$ref": "#/$defs/__schema1"
+            "$ref": "#/$defs/__schema2"
           }
         }
       },
       "required": ["type", "id", "name", "input"],
       "additionalProperties": false
-    },
-    "__schema1": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "number"
-        },
-        {
-          "type": "boolean"
-        },
-        {
-          "type": "null"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/__schema1"
-          }
-        },
-        {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          },
-          "additionalProperties": {
-            "$ref": "#/$defs/__schema1"
-          }
-        }
-      ]
-    },
-    "LLMToolResultContent": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "const": "tool_result"
-        },
-        "tool_use_id": {
-          "type": "string"
-        },
-        "content": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/LLMToolResultContentBlock"
-          }
-        },
-        "structured_content": {
-          "type": "object",
-          "propertyNames": {
-            "type": "string"
-          },
-          "additionalProperties": {
-            "$ref": "#/$defs/__schema2"
-          }
-        },
-        "is_error": {
-          "type": "boolean"
-        }
-      },
-      "required": ["type", "tool_use_id", "content"],
-      "additionalProperties": false
-    },
-    "LLMToolResultContentBlock": {
-      "oneOf": [
-        {
-          "$ref": "#/$defs/LLMTextContent"
-        },
-        {
-          "$ref": "#/$defs/LLMImageContent"
-        }
-      ]
     },
     "__schema2": {
       "anyOf": [
@@ -2349,25 +2318,47 @@
         }
       ]
     },
-    "LLMJsonSchemaResponseFormat": {
+    "LLMToolResultContent": {
       "type": "object",
       "properties": {
         "type": {
           "type": "string",
-          "const": "json_schema"
+          "const": "tool_result"
         },
-        "name": {
+        "tool_use_id": {
           "type": "string"
         },
-        "description": {
-          "type": "string"
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/LLMToolResultContentBlock"
+          }
         },
-        "schema": {
-          "$ref": "#/$defs/__schema3"
+        "structured_content": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema3"
+          }
+        },
+        "is_error": {
+          "type": "boolean"
         }
       },
-      "required": ["type", "name", "schema"],
+      "required": ["type", "tool_use_id", "content"],
       "additionalProperties": false
+    },
+    "LLMToolResultContentBlock": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/LLMTextContent"
+        },
+        {
+          "$ref": "#/$defs/LLMImageContent"
+        }
+      ]
     },
     "__schema3": {
       "anyOf": [
@@ -2396,6 +2387,57 @@
           },
           "additionalProperties": {
             "$ref": "#/$defs/__schema3"
+          }
+        }
+      ]
+    },
+    "LLMJsonSchemaResponseFormat": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "json_schema"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "schema": {
+          "$ref": "#/$defs/__schema4"
+        }
+      },
+      "required": ["type", "name", "schema"],
+      "additionalProperties": false
+    },
+    "__schema4": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/__schema4"
+          }
+        },
+        {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema4"
           }
         }
       ]
@@ -2516,7 +2558,7 @@
               "type": "string"
             },
             "additionalProperties": {
-              "$ref": "#/$defs/__schema4"
+              "$ref": "#/$defs/__schema5"
             }
           }
         },
@@ -2530,7 +2572,7 @@
       "required": ["type"],
       "additionalProperties": false
     },
-    "__schema4": {
+    "__schema5": {
       "anyOf": [
         {
           "type": "string"
@@ -2547,7 +2589,7 @@
         {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/__schema4"
+            "$ref": "#/$defs/__schema5"
           }
         },
         {
@@ -2556,7 +2598,7 @@
             "type": "string"
           },
           "additionalProperties": {
-            "$ref": "#/$defs/__schema4"
+            "$ref": "#/$defs/__schema5"
           }
         }
       ]
@@ -2655,7 +2697,7 @@
       },
       "required": ["role", "content", "output_format"],
       "additionalProperties": {
-        "$ref": "#/$defs/__schema5"
+        "$ref": "#/$defs/__schema6"
       }
     },
     "LLMUsage": {
@@ -2690,7 +2732,7 @@
       "required": ["input_tokens", "output_tokens", "total_tokens"],
       "additionalProperties": false
     },
-    "__schema5": {
+    "__schema6": {
       "anyOf": [
         {
           "type": "string"
@@ -2707,7 +2749,7 @@
         {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/__schema5"
+            "$ref": "#/$defs/__schema6"
           }
         },
         {
@@ -2716,7 +2758,7 @@
             "type": "string"
           },
           "additionalProperties": {
-            "$ref": "#/$defs/__schema5"
+            "$ref": "#/$defs/__schema6"
           }
         }
       ]
@@ -2751,15 +2793,15 @@
           "const": "json_schema"
         },
         "structured_content": {
-          "$ref": "#/$defs/__schema6"
+          "$ref": "#/$defs/__schema7"
         }
       },
       "required": ["role", "content", "output_format", "structured_content"],
       "additionalProperties": {
-        "$ref": "#/$defs/__schema5"
+        "$ref": "#/$defs/__schema6"
       }
     },
-    "__schema6": {
+    "__schema7": {
       "anyOf": [
         {
           "type": "string"
@@ -2776,7 +2818,7 @@
         {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/__schema6"
+            "$ref": "#/$defs/__schema7"
           }
         },
         {
@@ -2785,7 +2827,7 @@
             "type": "string"
           },
           "additionalProperties": {
-            "$ref": "#/$defs/__schema6"
+            "$ref": "#/$defs/__schema7"
           }
         }
       ]
@@ -3526,13 +3568,13 @@
       "type": "object",
       "properties": {
         "value": {
-          "$ref": "#/$defs/__schema7"
+          "$ref": "#/$defs/__schema8"
         }
       },
       "required": ["value"],
       "additionalProperties": false
     },
-    "__schema7": {
+    "__schema8": {
       "anyOf": [
         {
           "type": "string"
@@ -3549,7 +3591,7 @@
         {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/__schema7"
+            "$ref": "#/$defs/__schema8"
           }
         },
         {
@@ -3558,7 +3600,7 @@
             "type": "string"
           },
           "additionalProperties": {
-            "$ref": "#/$defs/__schema7"
+            "$ref": "#/$defs/__schema8"
           }
         }
       ]
@@ -4332,10 +4374,10 @@
         "type": "string"
       },
       "additionalProperties": {
-        "$ref": "#/$defs/__schema8"
+        "$ref": "#/$defs/__schema9"
       }
     },
-    "__schema8": {
+    "__schema9": {
       "anyOf": [
         {
           "type": "string"
@@ -4352,7 +4394,7 @@
         {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/__schema8"
+            "$ref": "#/$defs/__schema9"
           }
         },
         {
@@ -4361,7 +4403,7 @@
             "type": "string"
           },
           "additionalProperties": {
-            "$ref": "#/$defs/__schema8"
+            "$ref": "#/$defs/__schema9"
           }
         }
       ]
@@ -6210,7 +6252,7 @@
           "const": "2.0"
         },
         "result": {
-          "$ref": "#/$defs/__schema9"
+          "$ref": "#/$defs/__schema10"
         },
         "id": {
           "$ref": "#/$defs/JSONRPCRequestId"
@@ -6219,7 +6261,7 @@
       "required": ["jsonrpc", "result", "id"],
       "additionalProperties": false
     },
-    "__schema9": {
+    "__schema10": {
       "anyOf": [
         {
           "type": "string"
@@ -6236,7 +6278,7 @@
         {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/__schema9"
+            "$ref": "#/$defs/__schema10"
           }
         },
         {
@@ -6245,7 +6287,7 @@
             "type": "string"
           },
           "additionalProperties": {
-            "$ref": "#/$defs/__schema9"
+            "$ref": "#/$defs/__schema10"
           }
         }
       ]
@@ -6279,13 +6321,13 @@
           "type": "string"
         },
         "data": {
-          "$ref": "#/$defs/__schema10"
+          "$ref": "#/$defs/__schema11"
         }
       },
       "required": ["code", "message"],
       "additionalProperties": false
     },
-    "__schema10": {
+    "__schema11": {
       "anyOf": [
         {
           "type": "string"
@@ -6302,7 +6344,7 @@
         {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/__schema10"
+            "$ref": "#/$defs/__schema11"
           }
         },
         {
@@ -6311,7 +6353,7 @@
             "type": "string"
           },
           "additionalProperties": {
-            "$ref": "#/$defs/__schema10"
+            "$ref": "#/$defs/__schema11"
           }
         }
       ]

--- a/packages/protocol/tests/protocol/wire-casing.test.ts
+++ b/packages/protocol/tests/protocol/wire-casing.test.ts
@@ -398,12 +398,12 @@ describe("JSON-RPC wire casing", () => {
   it("preserves arbitrary extraction result keys", () => {
     const definition = StagehandMethods.stagehandExtract;
     const apiValue = {
-      result: { userName: "Sam" },
-      actionId: "action_1",
+      data: { userName: "Sam" },
+      metadata: { actionId: "action_1", cacheStatus: "HIT" as const },
     };
     const wireValue = {
-      result: { userName: "Sam" },
-      action_id: "action_1",
+      data: { userName: "Sam" },
+      metadata: { action_id: "action_1", cache_status: "HIT" },
     };
 
     expect(encodeWireValue(apiValue, definition.resultWire)).toStrictEqual(wireValue);

--- a/packages/protocol/types.ts
+++ b/packages/protocol/types.ts
@@ -64,6 +64,7 @@ import type {
   EmptyParamsSchema,
   ExternalProxyConfigSchema,
   ExtractOptionsSchema,
+  ExtractMetadataSchema,
   ExtractResultSchema,
   CustomModelConfigSchema,
   GoogleModelIdSchema,
@@ -255,6 +256,7 @@ export type ActOptions = z.infer<typeof ActOptionsSchema>;
 export type ActResultData = z.infer<typeof ActResultDataSchema>;
 export type ActResult = z.infer<typeof ActResultSchema>;
 export type ExtractOptions = z.infer<typeof ExtractOptionsSchema>;
+export type ExtractMetadata = z.infer<typeof ExtractMetadataSchema>;
 export type ExtractResult = z.infer<typeof ExtractResultSchema>;
 export type ObserveOptions = z.infer<typeof ObserveOptionsSchema>;
 export type ObserveResult = z.infer<typeof ObserveResultSchema>;

--- a/packages/sdk-python/examples/caching.py
+++ b/packages/sdk-python/examples/caching.py
@@ -5,7 +5,7 @@ from time import perf_counter
 
 from pydantic import BaseModel
 
-from stagehand import Stagehand
+from stagehand import ExtractResult, Stagehand
 
 BROWSERBASE_API_KEY = os.environ["BROWSERBASE_API_KEY"]
 OPENAI_API_KEY = os.environ["OPENAI_API_KEY"]
@@ -41,7 +41,7 @@ async def main() -> None:
             raise RuntimeError("Stagehand initialized without an active page")
         await page.goto("https://aigrant.com")
 
-        async def extract_companies() -> tuple[Companies, int]:
+        async def extract_companies() -> tuple[ExtractResult[Companies], int]:
             start = perf_counter()
             result = await stagehand.extract(
                 instruction=(
@@ -56,11 +56,13 @@ async def main() -> None:
 
         first, first_duration_ms = await extract_companies()
         print(f"First extraction ({first_duration_ms}ms):")
-        print(json.dumps(first.model_dump(mode="json"), indent=2))
+        print(json.dumps(first.data.model_dump(mode="json"), indent=2))
+        print(f"Cache status: {first.metadata.cache_status or 'disabled'}")
 
         second, second_duration_ms = await extract_companies()
         print(f"Second extraction ({second_duration_ms}ms):")
-        print(json.dumps(second.model_dump(mode="json"), indent=2))
+        print(json.dumps(second.data.model_dump(mode="json"), indent=2))
+        print(f"Cache status: {second.metadata.cache_status or 'disabled'}")
     finally:
         await stagehand.close()
 

--- a/packages/sdk-python/src/stagehand/__init__.py
+++ b/packages/sdk-python/src/stagehand/__init__.py
@@ -43,6 +43,7 @@ from .browser_clipboard import BrowserClipboard
 from .browser_context import BrowserContext
 from .client_models import (
     CacheOptions,
+    ExtractResult,
     LLMGenerateCallback,
     LLMGenerateInput,
     LLMGenerateOutput,
@@ -68,6 +69,7 @@ __all__ = [
     "CookieParam",
     "DomainPolicy",
     "ExternalProxyConfig",
+    "ExtractResult",
     "LLMGenerateCallback",
     "LLMGenerateInput",
     "LLMGenerateOutput",

--- a/packages/sdk-python/src/stagehand/_generated/models.py
+++ b/packages/sdk-python/src/stagehand/_generated/models.py
@@ -552,6 +552,17 @@ class ExternalProxyConfig(WireModel):
     password: Optional[StrictStr] = None
 
 
+class ExtractMetadata(WireModel):
+    model_config = ConfigDict(
+        extra="forbid",
+        validate_by_name=True,
+    )
+    action_id: Optional[StrictStr] = None
+    """Action ID for tracking"""
+    cache_status: Optional[CacheStatus] = None
+    """Server-side cache status for this result"""
+
+
 class ExtractOptions(WireModel):
     model_config = ConfigDict(
         validate_by_name=True,
@@ -593,14 +604,12 @@ class ExtractOptions(WireModel):
 
 class ExtractResult(WireModel):
     model_config = ConfigDict(
+        extra="forbid",
         validate_by_name=True,
     )
-    result: Any
+    data: Optional[FieldSchema1]
     """Extracted data matching the requested schema"""
-    action_id: Optional[StrictStr] = None
-    """Action ID for tracking"""
-    cache_status: Optional[CacheStatus] = None
-    """Server-side cache status for this result"""
+    metadata: ExtractMetadata
 
 
 class FieldSchema0(
@@ -619,6 +628,12 @@ class FieldSchema10(
     RootModel[Optional[Union[StrictStr, StrictFloat, StrictBool, list[Optional["FieldSchema10"]], dict[StrictStr, Optional["FieldSchema10"]]]]]
 ):
     root: Optional[Union[StrictStr, StrictFloat, StrictBool, list[Optional["FieldSchema10"]], dict[StrictStr, Optional["FieldSchema10"]]]]
+
+
+class FieldSchema11(
+    RootModel[Optional[Union[StrictStr, StrictFloat, StrictBool, list[Optional["FieldSchema11"]], dict[StrictStr, Optional["FieldSchema11"]]]]]
+):
+    root: Optional[Union[StrictStr, StrictFloat, StrictBool, list[Optional["FieldSchema11"]], dict[StrictStr, Optional["FieldSchema11"]]]]
 
 
 class FieldSchema2(
@@ -708,7 +723,7 @@ class JSONRPCErrorObject(WireModel):
     )
     code: Annotated[StrictInt, Field(ge=-9007199254740991, le=9007199254740991)]
     message: StrictStr
-    data: Optional[FieldSchema10] = None
+    data: Optional[FieldSchema11] = None
 
 
 class JSONRPCRequestId(RootModel[StrictInt]):
@@ -788,7 +803,7 @@ class LLMJsonSchemaResponseFormat(WireModel):
     type: Literal["json_schema"]
     name: StrictStr
     description: Optional[StrictStr] = None
-    schema_: Annotated[Optional[FieldSchema3], Field(alias="schema")]
+    schema_: Annotated[Optional[FieldSchema4], Field(alias="schema")]
 
 
 class LLMMessage(WireModel):
@@ -820,7 +835,7 @@ class LLMMessageGenerateResult(WireModel):
         validate_by_name=True,
     )
     __annotations__ = {
-        "__pydantic_extra__": Dict[str, Optional[FieldSchema5]],
+        "__pydantic_extra__": Dict[str, Optional[FieldSchema6]],
     }
     role: LLMRole
     content: Union[LLMMessageContentBlock, list[LLMMessageContentBlock]]
@@ -858,14 +873,14 @@ class LLMStructuredGenerateResult(WireModel):
         validate_by_name=True,
     )
     __annotations__ = {
-        "__pydantic_extra__": Dict[str, Optional[FieldSchema5]],
+        "__pydantic_extra__": Dict[str, Optional[FieldSchema6]],
     }
     role: LLMRole
     content: Union[LLMMessageContentBlock, list[LLMMessageContentBlock]]
     stop_reason: Optional[StrictStr] = None
     usage: Optional[LLMUsage] = None
     output_format: Literal["json_schema"]
-    structured_content: Optional[FieldSchema6]
+    structured_content: Optional[FieldSchema7]
 
 
 class LLMGenerateResult(
@@ -939,7 +954,7 @@ class LLMToolJson(WireModel):
     )
     field_schema: Annotated[Optional[StrictStr], Field(alias="$schema")] = None
     type: Literal["object"]
-    properties: Optional[dict[StrictStr, dict[StrictStr, Optional[FieldSchema4]]]] = (
+    properties: Optional[dict[StrictStr, dict[StrictStr, Optional[FieldSchema5]]]] = (
         None
     )
     required: Optional[list[StrictStr]] = None
@@ -953,7 +968,7 @@ class LLMToolResultContent(WireModel):
     type: Literal["tool_result"]
     tool_use_id: StrictStr
     content: list[LLMToolResultContentBlock]
-    structured_content: Optional[dict[StrictStr, Optional[FieldSchema2]]] = None
+    structured_content: Optional[dict[StrictStr, Optional[FieldSchema3]]] = None
     is_error: Optional[StrictBool] = None
 
 
@@ -969,7 +984,7 @@ class LLMToolUseContent(WireModel):
     type: Literal["tool_use"]
     id: StrictStr
     name: StrictStr
-    input: dict[StrictStr, Optional[FieldSchema1]]
+    input: dict[StrictStr, Optional[FieldSchema2]]
 
 
 class LLMMessageContentBlock(
@@ -1468,7 +1483,7 @@ class PageEvaluateResult(WireModel):
         extra="forbid",
         validate_by_name=True,
     )
-    value: Optional[FieldSchema7]
+    value: Optional[FieldSchema8]
 
 
 class PageGoBackParams(WireModel):
@@ -1943,8 +1958,8 @@ class StagehandLog(WireModel):
     data: StagehandLogData
 
 
-class StagehandLogData(RootModel[dict[StrictStr, Optional[FieldSchema8]]]):
-    root: dict[StrictStr, Optional[FieldSchema8]]
+class StagehandLogData(RootModel[dict[StrictStr, Optional[FieldSchema9]]]):
+    root: dict[StrictStr, Optional[FieldSchema9]]
 
 
 class StagehandLogLevel(StrEnum):
@@ -2056,6 +2071,7 @@ class Variables(RootModel[dict[StrictStr, VariableValue]]):
 FieldSchema0.model_rebuild()
 FieldSchema1.model_rebuild()
 FieldSchema10.model_rebuild()
+FieldSchema11.model_rebuild()
 FieldSchema2.model_rebuild()
 FieldSchema3.model_rebuild()
 FieldSchema4.model_rebuild()

--- a/packages/sdk-python/src/stagehand/client_models.py
+++ b/packages/sdk-python/src/stagehand/client_models.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from typing import Annotated, Literal
+from typing import Annotated, Generic, Literal, TypeVar
 
-from pydantic import ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from ._generated import models as _models
 from ._generated.models import (
     BrowserbaseBrowserSettings,
     BrowserbaseRegion,
     CustomModelConfig,
+    ExtractMetadata,
     KnownModelConfig,
     LLMMessageGenerateParams,
     LLMMessageGenerateResult,
@@ -21,6 +22,15 @@ from ._generated.models import (
     StagehandLog,
 )
 from ._validation import WireModel
+
+ExtractData = TypeVar("ExtractData", bound=BaseModel)
+
+
+class ExtractResult(WireModel, Generic[ExtractData]):
+    model_config = ConfigDict(extra="forbid")
+
+    data: ExtractData
+    metadata: ExtractMetadata
 
 
 class LocalProxyConfig(WireModel):

--- a/packages/sdk-python/src/stagehand/stagehand.py
+++ b/packages/sdk-python/src/stagehand/stagehand.py
@@ -25,7 +25,6 @@ from ._generated.models import (
     EmptyParams,
     ExternalProxyConfig,
     ExtractOptions,
-    ExtractResult,
     LLMGenerateParams,
     LLMGenerateResult,
     ModelConfig,
@@ -46,6 +45,9 @@ from ._generated.models import (
     Variables,
 )
 from ._generated.models import (
+    ExtractResult as WireExtractResult,
+)
+from ._generated.models import (
     Locator as ProtocolLocator,
 )
 from .browser_context import BrowserContext
@@ -56,6 +58,7 @@ from .client_models import (
     Cache,
     CdpBrowserSource,
     ClientLLM,
+    ExtractResult,
     LLMGenerateCallback,
     LocalBrowserSource,
     LocalProxyConfig,
@@ -541,7 +544,7 @@ class Stagehand:
         screenshot: bool | None = None,
         locator: ProtocolLocator | None = None,
         cache: Cache | None = None,
-    ) -> ResultModel:
+    ) -> ExtractResult[ResultModel]:
         options = ExtractOptions.model_validate({
             name: value
             for name, value in (
@@ -565,11 +568,14 @@ class Stagehand:
         )
         if options.model_fields_set:
             params.options = options
-        result = await self._connected_rpc_client.send("stagehand.extract", params, ExtractResult)
-        value = (
-            result.result.model_dump() if isinstance(result.result, BaseModel) else result.result
+        result = await self._connected_rpc_client.send(
+            "stagehand.extract", params, WireExtractResult
         )
-        return schema.model_validate(value)
+        value = result.data.model_dump() if isinstance(result.data, BaseModel) else result.data
+        return ExtractResult(
+            data=schema.model_validate(value),
+            metadata=result.metadata,
+        )
 
     async def close(self) -> None:
         async with self._lifecycle_lock:

--- a/packages/sdk-python/tests/test_stagehand.py
+++ b/packages/sdk-python/tests/test_stagehand.py
@@ -255,7 +255,10 @@ async def test_stagehand_ai_methods_resolve_pages_and_validate_results(
         "context.active_page": PageRef(page_id="active-page"),
         "stagehand.act": ActResult(result=act_result),
         "stagehand.observe": ObserveResult(result=[action]),
-        "stagehand.extract": ExtractResult(result={"heading": "Example Domain"}),
+        "stagehand.extract": ExtractResult(
+            data={"heading": "Example Domain"},
+            metadata={"cache_status": "HIT"},
+        ),
     })
     model = ModelConfig.model_validate({"model_name": "openai/gpt-4.1-mini"})
     locator = ProtocolLocator(selector="main")
@@ -291,7 +294,8 @@ async def test_stagehand_ai_methods_resolve_pages_and_validate_results(
 
     assert action_result == act_result
     assert actions == [action]
-    assert page_info == PageInfo(heading="Example Domain")
+    assert page_info.data == PageInfo(heading="Example Domain")
+    assert page_info.metadata.cache_status == "HIT"
     assert [call[0] for call in recording.calls] == [
         "stagehand.init",
         "stagehand.act",

--- a/packages/sdk-ts/examples/caching.ts
+++ b/packages/sdk-ts/examples/caching.ts
@@ -49,11 +49,13 @@ try {
 
   const first = await extractCompanies();
   console.log(`First extraction (expected cache miss, ${first.durationMs}ms):`);
-  console.log(JSON.stringify(first.result, null, 2));
+  console.log(JSON.stringify(first.result.data, null, 2));
+  console.log(`Cache status: ${first.result.metadata.cacheStatus ?? "disabled"}`);
 
   const second = await extractCompanies();
   console.log(`Second extraction (expected cache hit, ${second.durationMs}ms):`);
-  console.log(JSON.stringify(second.result, null, 2));
+  console.log(JSON.stringify(second.result.data, null, 2));
+  console.log(`Cache status: ${second.result.metadata.cacheStatus ?? "disabled"}`);
 } finally {
   await stagehand.close();
 }

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -13,7 +13,7 @@ export {
 export { Locator } from "./locator.js";
 export { Page, type ScreenshotOptions } from "./page.js";
 export type { InitScriptSource } from "./pageScripts.js";
-export { Stagehand } from "./stagehand.js";
+export { Stagehand, type ExtractResult } from "./stagehand.js";
 export type {
   BrowserGetVersionResult,
   RuntimeLoopbackStatusResult,

--- a/packages/sdk-ts/src/stagehand.ts
+++ b/packages/sdk-ts/src/stagehand.ts
@@ -35,6 +35,12 @@ type StagehandAdapters = {
 
 const stagehandAdapters = new WeakMap<Stagehand, StagehandAdapters>();
 
+type ProtocolExtractResult = import("../../protocol/types.js").ExtractResult;
+
+export type ExtractResult<Schema extends z.ZodType> = Omit<ProtocolExtractResult, "data"> & {
+  data: z.output<Schema>;
+};
+
 export class Stagehand {
   browserContext: BrowserContext | undefined;
   isInitialized = false;
@@ -170,7 +176,7 @@ export class Stagehand {
     instruction: string,
     schema: Schema,
     options?: StagehandClientExtractOptions,
-  ): Promise<z.output<Schema>> {
+  ): Promise<ExtractResult<Schema>> {
     const { page, ...protocolOptions } = StagehandClientExtractOptionsSchema.parse(options ?? {});
     const targetPage = page ?? (await this.context.activePage());
     if (!targetPage) throw new Error("Stagehand has no active page.");
@@ -182,7 +188,10 @@ export class Stagehand {
       ...(options === undefined ? {} : { options: protocolOptions }),
     });
 
-    return schema.parse(response.result);
+    return {
+      ...response,
+      data: schema.parse(response.data),
+    };
   }
 
   close(): Promise<void> {

--- a/packages/sdk-ts/tests/object-wrapper.test.ts
+++ b/packages/sdk-ts/tests/object-wrapper.test.ts
@@ -838,7 +838,8 @@ describe("Stagehand TS object wrapper", () => {
   it("sends the caller's Zod schema through stagehand.extract", async () => {
     const client = new FakeProtocolClient();
     client.queueResponse(StagehandMethods.stagehandExtract, {
-      result: { heading: "Example Domain" },
+      data: { heading: "Example Domain" },
+      metadata: { cacheStatus: "HIT" },
     });
     const stagehand = createStagehandWithClientForTest(client);
     await stagehand.init();
@@ -847,7 +848,10 @@ describe("Stagehand TS object wrapper", () => {
 
     await expect(
       stagehand.extract("Extract the page heading", schema, { page, selector: "main" }),
-    ).resolves.toStrictEqual({ heading: "Example Domain" });
+    ).resolves.toStrictEqual({
+      data: { heading: "Example Domain" },
+      metadata: { cacheStatus: "HIT" },
+    });
     expect(client.calls).toStrictEqual([
       stagehandInitCall,
       requestCall(StagehandMethods.stagehandExtract, {
@@ -862,7 +866,8 @@ describe("Stagehand TS object wrapper", () => {
   it("validates stagehand.extract data with the caller's original Zod schema", async () => {
     const client = new FakeProtocolClient();
     client.queueResponse(StagehandMethods.stagehandExtract, {
-      result: { heading: 42 },
+      data: { heading: 42 },
+      metadata: {},
     });
     const stagehand = createStagehandWithClientForTest(client);
     await stagehand.init();

--- a/packages/server/services/actService.ts
+++ b/packages/server/services/actService.ts
@@ -88,6 +88,9 @@ export async function act({
     context: cache,
     logger,
     onHit: (value) => replayCachedActions(value, input, variables, context),
+    setCacheStatus: (result, cacheStatus) => {
+      result.cacheStatus = cacheStatus;
+    },
     execute: async () => {
       const result = await runActPipeline();
       return {

--- a/packages/server/services/cacheService.ts
+++ b/packages/server/services/cacheService.ts
@@ -155,7 +155,7 @@ export interface CacheExecuteOutcome<Result> {
  * or whenever any cache step fails, including `onHit` itself — falls back to
  * `execute` and then persists the outcome's `cacheValue`.
  */
-export async function withCache<Result extends { cacheStatus?: CacheStatus }>({
+export async function withCache<Result>({
   method,
   page,
   data,
@@ -165,6 +165,7 @@ export async function withCache<Result extends { cacheStatus?: CacheStatus }>({
   logger,
   onHit,
   execute,
+  setCacheStatus,
 }: {
   method: CacheMethod;
   page: unknown;
@@ -178,6 +179,7 @@ export async function withCache<Result extends { cacheStatus?: CacheStatus }>({
   logger: StagehandLogger;
   onHit: (value: unknown) => Promise<Result> | Result;
   execute: () => Promise<CacheExecuteOutcome<Result>>;
+  setCacheStatus: (result: Result, status: CacheStatus) => void;
 }): Promise<Result> {
   const resolvedCaching = caching ?? context?.defaultCaching ?? false;
   const cachePage = resolvedCaching !== false ? asCachePage(page) : null;
@@ -212,7 +214,7 @@ export async function withCache<Result extends { cacheStatus?: CacheStatus }>({
   if (getResponse?.hit && getResponse.value !== undefined && getResponse.value !== null) {
     try {
       const result = await onHit(getResponse.value);
-      result.cacheStatus = "HIT";
+      setCacheStatus(result, "HIT");
       logger.debug("Cache hit", {
         category: "cache",
         method,
@@ -239,7 +241,7 @@ export async function withCache<Result extends { cacheStatus?: CacheStatus }>({
   }
 
   const outcome = await execute();
-  outcome.result.cacheStatus = "MISS";
+  setCacheStatus(outcome.result, "MISS");
 
   if (outcome.cacheValue !== undefined && outcome.cacheValue !== null) {
     try {

--- a/packages/server/services/extractService.ts
+++ b/packages/server/services/extractService.ts
@@ -73,8 +73,11 @@ export async function extract({
     caching: options?.cache,
     context: cache,
     logger,
-    onHit: (value) => ({ result: value }),
+    onHit: (value) => ({ data: z.json().parse(value), metadata: {} }),
     execute: () => runExtraction(),
+    setCacheStatus: (result, cacheStatus) => {
+      result.metadata.cacheStatus = cacheStatus;
+    },
   });
 
   async function runExtraction(): Promise<cacheService.CacheExecuteOutcome<ExtractResult>> {
@@ -147,7 +150,7 @@ export async function extract({
     );
 
     return {
-      result: { result: output },
+      result: { data: z.json().parse(output), metadata: {} },
       cacheValue: output,
       llmUsage: {
         inputTokens: prompt_tokens,

--- a/packages/server/services/observeService.ts
+++ b/packages/server/services/observeService.ts
@@ -65,6 +65,9 @@ export async function observe({
       }
       return { result: actions };
     },
+    setCacheStatus: (result, cacheStatus) => {
+      result.cacheStatus = cacheStatus;
+    },
     execute: () => runObservation(),
   });
 


### PR DESCRIPTION
## Summary

- replace the extract protocol's nested `result` field with `data`
- group `cacheStatus` and `actionId` under an extensible `metadata` object
- return the complete typed extraction result from the TypeScript and Python SDKs instead of unwrapping and discarding metadata
- remove the `x-stainless-any` schema override
- regenerate protocol/Python models and update V4 documentation and examples

## Why

The server already populated cache hit/miss status, but both SDKs returned only the extracted payload. This discarded the metadata and left the raw wire response with an ambiguous `result.result` shape.

The new public shape is:

```ts
{
  data: T,
  metadata: {
    cacheStatus?: "HIT" | "MISS";
    actionId?: string;
  }
}
```

The caller's Zod or Pydantic schema continues to validate and type `data` specifically.

## Validation

- protocol: 322 tests passed
- server: 151 tests passed, 13 existing todos
- TypeScript focused SDK: 39 tests passed; build and package validation passed
- Python: 149 tests passed; type and lint checks passed
- full workspace formatting, lint, TypeScript, docs, broken-link, and accessibility checks passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose extraction metadata and return a typed `{ data, metadata }` object from `stagehand.extract()` in both TypeScript and Python, replacing the old `result` shape. This surfaces cache hits/misses and action IDs and aligns protocol, SDKs, and docs.

- **New Features**
  - Protocol: `result` replaced with `data`; added `metadata` with `cacheStatus` and `actionId`.
  - TypeScript SDK: `stagehand.extract()` returns `ExtractResult<Schema>`; `data` is Zod-typed, `metadata.cacheStatus` exposed; `ExtractResult` is exported.
  - Python SDK: `stagehand.extract()` returns `ExtractResult[Model]`; `.data` is your Pydantic model; `.metadata.cache_status` exposed.
  - Server: cache service now sets cache status; hits/misses reported in results.
  - Docs and examples updated to use `.data` and show metadata.

- **Migration**
  - TypeScript: change `await stagehand.extract(...)` usages to read `result.data` (or destructure `{ data }`); read `result.metadata.cacheStatus` if needed.
  - Python: read `result.data` for the validated model and `result.metadata.cache_status` for cache info; annotate as `ExtractResult[MyModel]` if you type results.
  - Direct protocol consumers: update to `{"data": ..., "metadata": { "cache_status": "HIT" | "MISS", "action_id": string? }}`; `resultWire` opaque key is now `"data"`.

<sup>Written for commit a4aced0a3270cceb3d4b296207a2828ec150698f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

