### PR TITLE
fix: track SDK language in v4 metadata

### DIFF
--- a/.changeset/swift-taxis-listen.md
+++ b/.changeset/swift-taxis-listen.md
@@ -1,0 +1,6 @@
+---
+"@browserbasehq/stagehand": patch
+"@browserbasehq/stagehand-python": patch
+---
+
+Track the Stagehand SDK language in Browserbase session and runtime metadata.

--- a/packages/sdk-python/src/stagehand/rpc_client.py
+++ b/packages/sdk-python/src/stagehand/rpc_client.py
@@ -5,6 +5,7 @@ import inspect
 import json
 from collections.abc import Awaitable, Callable, Coroutine
 from contextlib import suppress
+from importlib.metadata import version
 from typing import Annotated, Literal, Protocol, TypeVar, cast
 
 from pydantic import BaseModel, ConfigDict, Field, JsonValue, TypeAdapter, ValidationError
@@ -13,6 +14,10 @@ from ._generated import models
 
 _MAX_REQUEST_ID = 9_007_199_254_740_991
 _MAX_PENDING_NOTIFICATIONS = 100
+_STAGEHAND_SDK_CLIENT_INFO = models.ImplementationInfo(
+    name="stagehand-sdk-python",
+    version=version("stagehand"),
+)
 
 ParamsT = TypeVar("ParamsT", bound=BaseModel)
 ResultT = TypeVar("ResultT", bound=BaseModel)
@@ -479,6 +484,7 @@ async def connect_rpc_client(
     )
     client = RPCClient(cdp, request_timeout_ms=command_timeout_ms)
     configure = models.RuntimeConfigureParams(
+        client_info=_STAGEHAND_SDK_CLIENT_INFO,
         cdp_url=cdp.web_socket_debugger_url,
         **({"telemetry": telemetry} if telemetry is not None else {}),
         log_level=models.LogLevel(log_level),

--- a/packages/sdk-python/tests/test_rpc_client.py
+++ b/packages/sdk-python/tests/test_rpc_client.py
@@ -1,4 +1,5 @@
 import asyncio
+from importlib.metadata import version
 from typing import ClassVar, cast
 
 import pytest
@@ -487,6 +488,10 @@ async def test_connect_rpc_client_passes_cdp_options_and_configures_the_runtime(
             "id": 1,
             "method": "runtime.configure",
             "params": {
+                "client_info": {
+                    "name": "stagehand-sdk-python",
+                    "version": version("stagehand"),
+                },
                 "cdp_url": "ws://resolved.example/devtools/browser/1",
                 "log_level": "info",
                 "telemetry": {

--- a/packages/sdk-ts/src/browserbaseSession.ts
+++ b/packages/sdk-ts/src/browserbaseSession.ts
@@ -7,6 +7,7 @@ import {
   type BrowserbaseExtensionSdk,
   type ProvisionedBrowserbaseExtension,
 } from "./browserbaseExtension.js";
+import { STAGEHAND_SESSION_METADATA } from "./sdkIdentity.js";
 
 export type BrowserbaseSessionClient = {
   createSession(
@@ -38,11 +39,6 @@ type BrowserbaseSdk = BrowserbaseExtensionSdk & {
 };
 
 type BrowserbaseSdkFactory = (apiKey: string) => BrowserbaseSdk;
-
-const STAGEHAND_SESSION_METADATA = {
-  stagehand: "true",
-  stagehand_sdk_language: "typescript",
-} as const;
 
 export function createBrowserbaseSessionClient(
   apiKey: string,

--- a/packages/sdk-ts/src/browserbaseSession.ts
+++ b/packages/sdk-ts/src/browserbaseSession.ts
@@ -39,6 +39,11 @@ type BrowserbaseSdk = BrowserbaseExtensionSdk & {
 
 type BrowserbaseSdkFactory = (apiKey: string) => BrowserbaseSdk;
 
+const STAGEHAND_SESSION_METADATA = {
+  stagehand: "true",
+  stagehand_sdk_language: "typescript",
+} as const;
+
 export function createBrowserbaseSessionClient(
   apiKey: string,
   dependencies: BrowserbaseSessionClientDependencies = {},
@@ -55,6 +60,10 @@ export function createBrowserbaseSessionClient(
         session = await browserbase.createSession({
           ...params,
           extensionId: extension.extensionId,
+          userMetadata: {
+            ...params.userMetadata,
+            ...STAGEHAND_SESSION_METADATA,
+          },
         });
       } catch (error) {
         await extension.cleanup().catch(() => undefined);

--- a/packages/sdk-ts/src/rpcClient.ts
+++ b/packages/sdk-ts/src/rpcClient.ts
@@ -42,7 +42,7 @@ import {
 import type { StagehandRpcNotification } from "../../protocol/types.js";
 import { z } from "zod/v4";
 import { CDPClient, type ServiceWorkerInfo } from "./cdpClient.js";
-import { STAGEHAND_SDK_VERSION } from "./version.js";
+import { STAGEHAND_SDK_CLIENT_INFO } from "./sdkIdentity.js";
 
 type PendingRequest = {
   method: RPCMethod;
@@ -59,10 +59,6 @@ type RegisteredRequestHandler = {
 const TRACER = trace.getTracer("@browserbasehq/stagehand");
 const W3C_TRACE_CONTEXT_PROPAGATOR = new W3CTraceContextPropagator();
 const MAX_PENDING_NOTIFICATIONS = 100;
-const STAGEHAND_SDK_CLIENT_INFO = {
-  name: "stagehand-sdk-ts",
-  version: STAGEHAND_SDK_VERSION,
-} as const;
 
 const RPCClientOptionsBaseSchema = z
   .object({

--- a/packages/sdk-ts/src/sdkIdentity.ts
+++ b/packages/sdk-ts/src/sdkIdentity.ts
@@ -1,0 +1,17 @@
+import { STAGEHAND_SDK_VERSION } from "./version.js";
+
+const STAGEHAND_SDK_IDENTITY = {
+  name: "stagehand-sdk-ts",
+  language: "typescript",
+  version: STAGEHAND_SDK_VERSION,
+} as const;
+
+export const STAGEHAND_SDK_CLIENT_INFO = {
+  name: STAGEHAND_SDK_IDENTITY.name,
+  version: STAGEHAND_SDK_IDENTITY.version,
+} as const;
+
+export const STAGEHAND_SESSION_METADATA = {
+  stagehand: "true",
+  stagehand_sdk_language: STAGEHAND_SDK_IDENTITY.language,
+} as const;

--- a/packages/sdk-ts/tests/browserbaseSession.test.ts
+++ b/packages/sdk-ts/tests/browserbaseSession.test.ts
@@ -52,7 +52,11 @@ describe("Browserbase session creation", () => {
     const session = await client.createSession({
       keepAlive: false,
       region: "eu-central-1",
-      userMetadata: { suite: "unit" },
+      userMetadata: {
+        stagehand: "false",
+        stagehand_sdk_language: "python",
+        suite: "unit",
+      },
     });
 
     expect(provisionExtension).toHaveBeenCalledWith(browserbase);
@@ -60,7 +64,11 @@ describe("Browserbase session creation", () => {
       extensionId: "ext_stagehand",
       keepAlive: false,
       region: "eu-central-1",
-      userMetadata: { suite: "unit" },
+      userMetadata: {
+        stagehand: "true",
+        stagehand_sdk_language: "typescript",
+        suite: "unit",
+      },
     });
     expect(session.cdpUrl).toBe("wss://connect.browserbase.com/devtools/browser/session_123");
     expect(session.sessionId).toBe("session_123");


### PR DESCRIPTION
## Summary

- tag Browserbase sessions created by the TypeScript SDK with authoritative `stagehand` and `stagehand_sdk_language` user metadata
- preserve caller-provided session metadata while preventing attribution fields from being spoofed
- send the Python SDK name and installed package version through the existing `runtime.configure.clientInfo` metadata field
- add patch changesets for the TypeScript and Python SDKs

## Why

Stagehand v3 identifies its SDK language with the `x-language` request header. V4 no longer routes SDK work through the hosted Stagehand API, so Browserbase session metadata is the durable, queryable equivalent for cloud sessions. The existing cross-language `clientInfo` handshake remains the right metadata path for runtime connections.

`v4-spike` currently creates Browserbase sessions from the TypeScript SDK. Python session creation is not implemented on this branch yet, while the in-flight Go SDK already sends its language and version through `clientInfo`. Future Python and Go Browserbase session creators should stamp `stagehand_sdk_language` with their respective language values.

## E2E Test Matrix

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| Local TypeScript build → create a real Browserbase session with spoofed attribution → retrieve the session through the Browserbase API | Retrieved `stagehand: "true"`, `stagehand_sdk_language: "typescript"`, and preserved the custom `suite` field | Proves the exact code under review writes durable Browserbase session metadata and keeps Stagehand attribution authoritative |
| `vitest run --root . packages/sdk-ts/tests` | 134 passed, 1 skipped | Covers the TypeScript SDK, including session creation, packaging, and metadata merge behavior |
| `uv run --locked pytest` | 196 passed | Covers the full Python SDK, including the serialized `runtime.configure.client_info` payload |
| Build the local Python wheel → `uv run --isolated --no-project --with dist/*.whl python scripts/smoke.py` | Installed wheel completed `stagehand.init` and `stagehand.close` against the built extension | Proves the published Python artifact can complete the real runtime handshake with the new metadata |
| Workspace formatting, linting, protocol/evals type checking, Python formatting/linting/type checking, and changeset checks | All commands exited successfully; workspace lint reported pre-existing warnings only | Supporting static validation across every changed package |

## Linear

[STG-2714](https://linear.app/browserbase/issue/STG-2714/track-sdk-language-in-v4-metadata)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Track SDK language in v4 metadata to meet Linear STG-2714. TypeScript sessions now set authoritative Browserbase user metadata, and Python sends SDK name and version via client_info during runtime configuration.

- New Features
  - TypeScript SDK: stamp Browserbase sessions with `stagehand: "true"` and `stagehand_sdk_language: "typescript"`, merging other `userMetadata` and preventing spoofing using centralized SDK identity.
  - Python SDK: send `client_info` with `name: "stagehand-sdk-python"` and installed package `version` in `runtime.configure`.

<sup>Written for commit f9ff170ca8e1ee34b1cc090f6d9f20ab0e259336. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

