### PR TITLE
protocol+sdk: fixes required to run the evals suite on v4-spike

### DIFF
--- a/packages/protocol/schema-registry.ts
+++ b/packages/protocol/schema-registry.ts
@@ -432,7 +432,12 @@ export const StagehandMethodSchema = z
 const stagehandRpcRequestSchemas = Object.values(StagehandMethods).map((method) =>
   JSONRPCRequestSchema.extend({
     method: z.literal(method.name),
-    params: wireSchema(method.params),
+    // paramsWire rides along so request decoding preserves the same opaque
+    // key paths as response encoding — without it, user-controlled keys
+    // (e.g. snake_case extract schema properties) get camelcased on the
+    // way in. Widening `method` to access it would collapse the per-method
+    // literal types, so narrow with `in` instead.
+    params: wireSchema(method.params, "paramsWire" in method ? method.paramsWire : undefined),
   }),
 );
 

--- a/packages/sdk-ts/src/rpcClient.ts
+++ b/packages/sdk-ts/src/rpcClient.ts
@@ -70,6 +70,7 @@ const RPCClientOptionsBaseSchema = z
     serviceWorkerUrlIncludes: z.string().min(1).optional(),
     discoveryTimeoutMs: z.number().int().positive().optional(),
     commandTimeoutMs: z.number().int().positive().optional(),
+    requestTimeoutMs: z.number().int().positive().optional(),
     cdpConnectTimeoutMs: z.number().int().positive().optional(),
     telemetry: TelemetryConfigSchema.default(DEFAULT_TELEMETRY_CONFIG),
     logLevel: RuntimeConfigureParamsSchema.shape.logLevel,
@@ -414,7 +415,9 @@ export async function connectRPCClient(input: RPCClientOptions): Promise<RPCClie
     cdpConnectTimeoutMs: options.cdpConnectTimeoutMs ?? 10_000,
     commandTimeoutMs,
   });
-  const client = new RPCClient(cdpClient, commandTimeoutMs);
+  // Stagehand RPC requests wrap act/extract/observe LLM round trips, which
+  // routinely outlive the CDP command timeout — cap them separately.
+  const client = new RPCClient(cdpClient, options.requestTimeoutMs ?? 180_000);
 
   try {
     await client.send(StagehandMethods.runtimeConfigure, {


### PR DESCRIPTION
Superseded.