### PR TITLE
[STG-2720] docs: add Auto Mode section to Model Gateway configuration page

### DIFF
--- a/packages/docs/v3/configuration/models.mdx
+++ b/packages/docs/v3/configuration/models.mdx
@@ -86,6 +86,39 @@ const stagehand = new Stagehand({
   Need a provider that isn't listed? [Reach out](https://www.browserbase.com/contact) — we're happy to work with teams on additional model support.
 </Tip>
 
+### Auto mode
+
+Auto mode delegates model selection to Model Gateway instead of pinning a single model yourself. Set `model: "auto"` (or simply omit `model`), and Browserbase picks the most accuracy-per-cost model for each Stagehand primitive — `act`, `extract`, `observe`, and `agent` are each routed independently based on our evals, rather than all sharing one model.
+
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const stagehand = new Stagehand({
+  env: "BROWSERBASE",
+  model: "auto",
+});
+
+await stagehand.init();
+
+// act, extract, and observe are each routed to the best model for that primitive
+await stagehand.act("click the sign in button");
+await stagehand.extract("get the page title");
+```
+
+You can also opt a single call into auto mode while pinning a concrete model everywhere else:
+
+```typescript
+await stagehand.act("click the sign in button", { model: "auto" });
+```
+
+<Note>
+  Auto mode is a Model Gateway feature: it requires `env: "BROWSERBASE"` and only applies when Stagehand is routing model requests for you (no custom `llmClient`, no per-call API key or provider `auth`, and not `experimental: true`). Passing a concrete model (e.g. `"openai/gpt-5"`) always opts that call out of auto mode.
+</Note>
+
+<Tip>
+  Auto mode works with Stagehand's [managed action caching](/v3/best-practices/caching) — once a routed action is cached, replays skip inference entirely regardless of which model handled the original call.
+</Tip>
+
 ---
 
 ## Configuration Setup

--- a/packages/docs/v3/configuration/models.mdx
+++ b/packages/docs/v3/configuration/models.mdx
@@ -88,7 +88,7 @@ const stagehand = new Stagehand({
 
 ### Auto mode
 
-Auto mode delegates model selection to Model Gateway instead of pinning a single model yourself. Set `model: "auto"` (or simply omit `model`), and Browserbase picks the most accuracy-per-cost model for each Stagehand primitive — `act`, `extract`, `observe`, and `agent` are each routed independently based on our evals, rather than all sharing one model.
+Auto mode delegates model selection to Model Gateway instead of pinning a single model yourself. Set `model: "auto"` (or simply omit `model`), and Browserbase picks the most accuracy-per-cost model for each Stagehand primitive — `act`, `extract`, `observe`, and `agent` are each routed independently based on Browserbase's evals, rather than all sharing one model.
 
 ```typescript
 import { Stagehand } from "@browserbasehq/stagehand";


### PR DESCRIPTION
## Summary

- Adds an "Auto mode" section to the Model Gateway configuration docs (`packages/docs/v3/configuration/models.mdx`)
- Documents `model: "auto"` (or omitting `model`), which delegates per-primitive (act/extract/observe/agent) model selection to Model Gateway's intelligent routing
- Notes the gating: requires `env: "BROWSERBASE"`, no custom `llmClient`, no per-call credentials, not `experimental: true` — matches the constructor/per-call validation in `packages/core/lib/v3/v3.ts` and the gateway-only gating in `core/apps/stagehand-api-v3/lib/auto-mode/auto-model-router.ts`
- Notes it composes with managed action caching

## Context

Prompted by the Stagehand/Browserbase Twitter announcement ("Introducing intelligent routing for Model Gateway... automatically chooses the best accuracy-to-cost model for every action... save up to 30% on inference costs"). Docs previously had no mention of `model: "auto"`.

## Test plan

- Docs-only MDX change, no build changes
- Verified auto-mode behavior against source: `packages/core/lib/modelUtils.ts`, `packages/core/lib/v3/v3.ts`, `packages/core/tests/unit/auto-model.test.ts`, `core/apps/stagehand-api-v3/lib/auto-mode/{rules,flags,auto-model-router}.ts`

Linear: https://linear.app/browserbase/issue/STG-2720/docs-add-auto-mode-section-to-model-gateway-configuration-page
Requested by: shrey@browserbase.com
Slack thread: https://browserbase.slack.com/archives/D0AJGAL04P2/p1785227380175219