### PR TITLE
protocol+sdk: fixes required to run the evals suite on v4-spike

### DIFF
--- a/packages/protocol/schema-registry.ts
+++ b/packages/protocol/schema-registry.ts
@@ -432,7 +432,12 @@ export const StagehandMethodSchema = z
 const stagehandRpcRequestSchemas = Object.values(StagehandMethods).map((method) =>
   JSONRPCRequestSchema.extend({
     method: z.literal(method.name),
-    params: wireSchema(method.params),
+    // paramsWire rides along so request decoding preserves the same opaque
+    // key paths as response encoding — without it, user-controlled keys
+    // (e.g. snake_case extract schema properties) get camelcased on the
+    // way in. Widening `method` to access it would collapse the per-method
+    // literal types, so narrow with `in` instead.
+    params: wireSchema(method.params, "paramsWire" in method ? method.paramsWire : undefined),
   }),
 );
 

--- a/packages/protocol/tests/protocol/wire-casing.test.ts
+++ b/packages/protocol/tests/protocol/wire-casing.test.ts
@@ -2,7 +2,11 @@ import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 import { z } from "zod/v4";
 import { encodeWireValue, toWireJsonSchema, wireSchema } from "../../json-rpc/wire-casing.js";
-import { StagehandNotifications, StagehandMethods } from "../../schema-registry.js";
+import {
+  StagehandNotifications,
+  StagehandMethods,
+  StagehandRpcRequestSchema,
+} from "../../schema-registry.js";
 
 const snakeCaseKey = /^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$/;
 const snakeCaseMethodSegment = /^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$/;
@@ -567,3 +571,38 @@ function isWirePropertyName(key: string): boolean {
 function asRecord(value: unknown): Record<string, unknown> {
   return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
 }
+
+describe("StagehandRpcRequestSchema paramsWire handling", () => {
+  it("preserves user extract-schema keys as opaque through request parsing", () => {
+    // The extract method declares paramsWire opaqueKeys: ["schema"] — user
+    // schema property names are data, not protocol fields, and must survive
+    // wire decoding verbatim (snake_case keys were previously camelCased in
+    // `properties` but not `required`, producing an inconsistent JSON schema
+    // that structured-output providers reject).
+    const parsed = StagehandRpcRequestSchema.parse({
+      jsonrpc: "2.0",
+      id: 7,
+      method: "stagehand.extract",
+      params: {
+        page_id: "page-1",
+        instruction: "extract the company",
+        schema: {
+          type: "object",
+          properties: { company_name: { type: "string" } },
+          required: ["company_name"],
+          additionalProperties: false,
+        },
+      },
+    });
+
+    expect(parsed.method).toBe("stagehand.extract");
+    expect(parsed.params).toMatchObject({
+      pageId: "page-1",
+      schema: {
+        type: "object",
+        properties: { company_name: { type: "string" } },
+        required: ["company_name"],
+      },
+    });
+  });
+});

--- a/packages/protocol/tests/rpc-client/options.test.ts
+++ b/packages/protocol/tests/rpc-client/options.test.ts
@@ -119,6 +119,19 @@ describe("RPCClientOptionsSchema", () => {
     ).toThrow();
   });
 
+  it("bounds requestTimeoutMs to the maximum timer duration", () => {
+    const base = {
+      cdpUrl: "http://127.0.0.1:9222",
+      extensionDir: "/tmp/stagehand-extension",
+    };
+    // setTimeout clamps delays above 2^31 - 1 ms to ~1 ms, so larger values
+    // would make every request time out almost immediately.
+    expect(RPCClientOptionsSchema.parse({ ...base, requestTimeoutMs: 2 ** 31 - 1 })).toMatchObject({
+      requestTimeoutMs: 2_147_483_647,
+    });
+    expect(() => RPCClientOptionsSchema.parse({ ...base, requestTimeoutMs: 2 ** 31 })).toThrow();
+  });
+
   it("validates options at the RPC client boundary before opening CDP", async () => {
     await expect(
       connectRPCClient({

--- a/packages/sdk-ts/src/rpcClient.ts
+++ b/packages/sdk-ts/src/rpcClient.ts
@@ -70,6 +70,7 @@ const RPCClientOptionsBaseSchema = z
     serviceWorkerUrlIncludes: z.string().min(1).optional(),
     discoveryTimeoutMs: z.number().int().positive().optional(),
     commandTimeoutMs: z.number().int().positive().optional(),
+    requestTimeoutMs: z.number().int().positive().optional(),
     cdpConnectTimeoutMs: z.number().int().positive().optional(),
     telemetry: TelemetryConfigSchema.default(DEFAULT_TELEMETRY_CONFIG),
     logLevel: RuntimeConfigureParamsSchema.shape.logLevel,
@@ -414,7 +415,9 @@ export async function connectRPCClient(input: RPCClientOptions): Promise<RPCClie
     cdpConnectTimeoutMs: options.cdpConnectTimeoutMs ?? 10_000,
     commandTimeoutMs,
   });
-  const client = new RPCClient(cdpClient, commandTimeoutMs);
+  // Stagehand RPC requests wrap act/extract/observe LLM round trips, which
+  // routinely outlive the CDP command timeout — cap them separately.
+  const client = new RPCClient(cdpClient, options.requestTimeoutMs ?? 180_000);
 
   try {
     await client.send(StagehandMethods.runtimeConfigure, {

--- a/packages/sdk-ts/src/rpcClient.ts
+++ b/packages/sdk-ts/src/rpcClient.ts
@@ -64,13 +64,17 @@ const STAGEHAND_SDK_CLIENT_INFO = {
   version: STAGEHAND_SDK_VERSION,
 } as const;
 
+// setTimeout clamps delays above 2^31 - 1 ms to ~1 ms (Node and browsers
+// alike), so a longer configured cap would time out almost immediately.
+const MAX_TIMEOUT_MS = 2 ** 31 - 1;
+
 const RPCClientOptionsBaseSchema = z
   .object({
     cdpUrl: z.string().min(1),
     serviceWorkerUrlIncludes: z.string().min(1).optional(),
     discoveryTimeoutMs: z.number().int().positive().optional(),
     commandTimeoutMs: z.number().int().positive().optional(),
-    requestTimeoutMs: z.number().int().positive().optional(),
+    requestTimeoutMs: z.number().int().positive().max(MAX_TIMEOUT_MS).optional(),
     cdpConnectTimeoutMs: z.number().int().positive().optional(),
     telemetry: TelemetryConfigSchema.default(DEFAULT_TELEMETRY_CONFIG),
     logLevel: RuntimeConfigureParamsSchema.shape.logLevel,

--- a/packages/sdk-ts/tests/rpcClient.test.ts
+++ b/packages/sdk-ts/tests/rpcClient.test.ts
@@ -372,3 +372,67 @@ describe("RPCClient", () => {
     expect(cdp.sent).toStrictEqual([]);
   });
 });
+
+describe("RPC request timeout", () => {
+  it("defaults RPC requests to a 180s cap, independent of commandTimeoutMs", async () => {
+    const cdp = new FakeCDPTransport({ configured: true });
+    const connect = vi.spyOn(CDPClient, "connect").mockResolvedValue(cdp as unknown as CDPClient);
+
+    try {
+      const client = await connectRPCClient({
+        cdpUrl: "ws://127.0.0.1:9222/devtools/browser/test",
+        extensionId: "stagehand",
+        commandTimeoutMs: 10_000,
+      });
+      try {
+        expect(client.requestTimeoutMs).toBe(180_000);
+        expect(connect).toHaveBeenCalledWith(
+          expect.objectContaining({ commandTimeoutMs: 10_000 }),
+        );
+      } finally {
+        client.close();
+      }
+    } finally {
+      connect.mockRestore();
+    }
+  });
+
+  it("passes a requestTimeoutMs override through to the RPC client", async () => {
+    const cdp = new FakeCDPTransport({ configured: true });
+    const connect = vi.spyOn(CDPClient, "connect").mockResolvedValue(cdp as unknown as CDPClient);
+
+    try {
+      const client = await connectRPCClient({
+        cdpUrl: "ws://127.0.0.1:9222/devtools/browser/test",
+        extensionId: "stagehand",
+        requestTimeoutMs: 30_000,
+      });
+      try {
+        expect(client.requestTimeoutMs).toBe(30_000);
+      } finally {
+        client.close();
+      }
+    } finally {
+      connect.mockRestore();
+    }
+  });
+
+  it("rejects a pending request once requestTimeoutMs elapses", async () => {
+    vi.useFakeTimers();
+    try {
+      const cdp = new ManualCDPTransport();
+      const client = new RPCClient(cdp, 5_000);
+
+      const outcome = client.send(UppercaseMethod, { value: "never answered" }).then(
+        () => "resolved",
+        (error: Error) => error.message,
+      );
+
+      await vi.advanceTimersByTimeAsync(4_999);
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(outcome).resolves.toBe("RPC request timed out: test.uppercase");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
Two small runtime fixes the restored evals suite needs to run against v4-spike. Both verified together on a live bench-v4 sweep: **47/77 → 62/77** (gpt-4.1-mini, LOCAL, single trial) on the evals migration branch.

## 1. protocol: thread `paramsWire` through `StagehandRpcRequestSchema` (V4_API_LOGS #14)

The method registry already declares `paramsWire` opaque-key paths (e.g. extract's `schema`), and `rpcRouter.parseParams` honors them — but the request-schema construction in `schema-registry.ts` dropped the second `wireSchema` argument, so incoming requests were re-cased before the router's parse ran. User extract schemas with snake_case keys arrived internally inconsistent (`properties` camelCased, `required` not) and OpenAI structured-outputs rejected them.

**Measured impact: 13 snake_case extract tasks flip red → green.**

## 2. sdk: cap RPC requests separately from CDP commands

`connectRPCClient` reused `commandTimeoutMs` (default 10s) as the RPC request timeout, but `stagehand.act/extract/observe` requests wrap full LLM round trips that routinely exceed 10s. Requests now default to a 180s cap, configurable via `requestTimeoutMs`.

---
Both changes are pre-existing local fixes from the eval-validation checkouts, now upstreamed; the evals migration PR that depends on them follows separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes request decoding and RPC timeouts so the v4 evals suite runs reliably on `v4-spike`. Preserves user schema key casing and sets a safe, bounded RPC request timeout.

- **Bug Fixes**
  - Protocol: thread `paramsWire` into `StagehandRpcRequestSchema` to keep `snake_case` extract schema keys intact and avoid mixed-case schemas being rejected (V4_API_LOGS #14).
  - SDK: add `requestTimeoutMs` for RPC requests (default 180s) separate from `commandTimeoutMs` (10s), and bound it to the max timer duration (`2_147_483_647` ms) to prevent overflow and instant timeouts.

<sup>Written for commit a8a3b518dc6627d5de9c0f1a46a85f848db1f77a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

