### PR TITLE
evals: benchmark matrix (model x harness x tool_surface) + Braintrust routing

### DIFF
--- a/packages/evals/.gitignore
+++ b/packages/evals/.gitignore
@@ -1,7 +1,8 @@
-# Type declarations generated from the linked v4-spike SDK checkout.
+# Type declarations generated from the v4 SDK checkout are COMMITTED
+# (.v4-sdk-types/) so typecheck works on fresh clones/CI without the
+# checkout. Regenerate whenever the checkout moves (V4_API_LOGS #16):
 # Regenerate (from the v4-spike root) with:
 #   pnpm exec tsc packages/sdk-ts/src/index.ts --declaration --emitDeclarationOnly \
 #     --module nodenext --moduleResolution nodenext --allowImportingTsExtensions \
 #     --esModuleInterop --skipLibCheck --outDir <stagehand>/packages/evals/.v4-sdk-types
-.v4-sdk-types/
 .rubric-cache/

--- a/packages/evals/benchmarks/GENERAL_HARNESS.md
+++ b/packages/evals/benchmarks/GENERAL_HARNESS.md
@@ -1,0 +1,73 @@
+# General nondeterministic harness — scoping (2026-07-23)
+
+Goal: one pipeline that runs any dataset task (WebVoyager, GAIA,
+OnlineMind2Web, WebTailBench) under any agent harness (claude_code, codex)
+over any tool surface (v4_code, playwright_code, playwright_mcp, cdp_code,
+chrome_devtools_mcp, understudy_code, browse_cli), graded by one rubric
+LLMJ, reported to Braintrust project `stagehand-v4` with the
+(model, harness, toolSurface) triple. "Playwright benches" are not a
+separate thing — they are manifest rows whose toolSurface is a playwright
+variant.
+
+## Problem
+
+Every tool surface is implemented twice: once as a `CoreTool`
+(`core/tools/*`, deterministic tier) and once as harness-specific prep
+(`framework/claudeCodeToolAdapter.ts` per-surface functions;
+`codexToolAdapter.ts` supports only browse_cli). Result: codex lags
+surfaces, playwright_mcp is wired nowhere agentic, and each new surface
+costs one implementation per harness.
+
+## Design: ToolAdapter = CoreTool + prepareLLMExposure
+
+```ts
+interface LLMExposure {
+  kind: "code_handles" | "mcp_server" | "cli";
+  handles?: Record<string, unknown>; // code: { stagehand, page, z } etc.
+  promptInstructions: string;
+  mcpServers?: Record<string, unknown>; // mcp: mounted as-is by the harness
+  command?: { bin: string; env: Record<string, string> };
+  cleanup: () => Promise<void>;
+}
+```
+
+Each surface module exports a standalone
+`prepareLLMExposure(plan, env, logger, startupProfile?)` function next to
+its CoreTool (a `ToolAdapter` interface was considered and dropped as
+unnecessary code — the function convention is the contract).
+
+Harness drivers keep exactly three mount points and no surface knowledge:
+
+- `code_handles` → wrap in the harness's single run tool (CC: sdk MCP tool,
+  exists today; codex: its exec/MCP equivalent)
+- `mcp_server` → mount config directly (this wires playwright_mcp /
+  chrome_devtools_mcp for free)
+- `cli` → spawn with env (browse_cli)
+
+Grading is unchanged and shared: `gradeExternalTrajectory` → rubric LLMJ
+via the never-`init()`-ed V3 carrier (grading only, never driving — see
+README.md "Grading"). GAIA additionally threads its ground-truth
+`expected` into a single exact-match criterion.
+
+Cadence/config is the existing benchmark manifest
+(model × harness × toolSurface, `*.bench.json`); runner routing and triple
+metadata are already live.
+
+## Phases (independently shippable)
+
+1. Extract `LLMExposure`; move claude_code's 4 per-surface preps into the
+   surface modules; CC consumes exposures. Behavior-preserving (re-verify
+   with the passing WebVoyager v4_code arm). Net-negative LOC. Also add
+   `STAGEHAND_V4_SDK_PATH` (env override for the v4 checkout consumed by
+   initV4 + the .v4-sdk-types regen; defaults to the package link).
+2. Codex consumes exposures → gains all surfaces at once (supersedes
+   per-surface codex wiring).
+3. Un-legacy GAIA: add `buildGAIATestcases` to the suite map, `gaia` to the
+   `ExternalHarnessTaskPlan` dataset union, thread `expected` through to
+   the verifier criterion.
+4. `--benchmark <name>` CLI entry consuming `loadBenchmarksDir()` (after
+   the framework migration churn settles).
+
+Non-goals (per the minimal-code directive): a scaffold-neutral `llm_loop`
+harness (only if scaffold bias shows in real numbers); replacing the
+grader; any agent surface in v4.

--- a/packages/evals/benchmarks/README.md
+++ b/packages/evals/benchmarks/README.md
@@ -1,0 +1,62 @@
+# Benchmarks — the three-axis run matrix
+
+A benchmark manifest (`*.bench.json`) pins the full space a run covers, so
+every score is attributable to a **(model, harness, toolSurface)** triple —
+never just a model.
+
+| Axis          | Values                                                                                                                               | Meaning                                                                                                      |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| `model`       | `provider/model` strings                                                                                                             | The LLM driving the run                                                                                      |
+| `harness`     | `stagehand`, `claude_code`, `codex`                                                                                                  | What agentic loop executes the task: the Stagehand SDK itself, or an external coding harness                 |
+| `toolSurface` | `understudy_code` (v3 SDK), `v4_code` (v4 SDK), `playwright_code`, `cdp_code`, `playwright_mcp`, `chrome_devtools_mcp`, `browse_cli` | What the harness uses to control the browser: writing code against an SDK, or calling packaged MCP/CLI tools |
+
+## Manifest shape
+
+```jsonc
+{
+  "name": "webvoyager-harness-matrix",
+  "target": { "kind": "suite", "suite": "webvoyager", "limit": 25 },
+  // or: { "kind": "tasks", "include": ["act", "extract/extract_repo_name"] }
+  "matrix": {
+    "models": ["anthropic/claude-haiku-4-5"],
+    "harnesses": ["claude_code", "codex"],
+    "toolSurfaces": ["v4_code", "playwright_mcp"],
+  },
+  "trials": 1,
+}
+```
+
+`expand.ts` produces one run row per **valid** combination; invalid points
+are reported with reasons, not silently dropped. Current validity rule: the
+`stagehand` harness _is_ the SDK, so it only pairs with the SDK code
+surfaces (`understudy_code`, `v4_code`); external harnesses pair with any
+surface.
+
+## Grading (nondeterministic suite)
+
+External-harness runs are graded by rubric through `V3Evaluator` from v3
+core, carried by a **never-`init()`-ed** `V3` instance that exists only to
+hold an LLM client — it never drives a browser (see
+`framework/benchHarness.ts` `buildVerifierCarrierV3`). This is a deliberate
+keep-less-code decision (2026-07-23): the v3-carried grader is
+battle-tested and keeps LLMJ scores comparable with historical v3-graded
+agent-suite results. So v3 symbols appearing in grading traces are
+expected and grading-only; all _driving_ in a `v4_code` arm goes through
+`initV4` and the v4 extension stack. If v3 must ever leave the loop
+entirely, a standalone AI-SDK judge is a ~150-line build (one existed
+briefly as `framework/llmJudge.ts`, removed 2026-07-23 as dead code once
+the replay harness was dropped — see git history) — rebuild it only when
+deliberately cutting over score baselines.
+
+## Status
+
+- Schema, expansion, and validity rules: implemented here (`schema.ts`,
+  `expand.ts`), tested in `tests/framework/benchmarksManifest.test.ts`.
+- `v4_code` tool surface: implemented in `core/tools/v4_code.ts` (the v4
+  analogue of `understudy_code`). Coordinate targets are unsupported —
+  the v4 SDK is DOM-only (no click(x,y)); see the class doc for the full
+  capability map.
+- Planner/CLI wiring (a `--benchmark <name>` entry point consuming
+  `loadBenchmarksDir()`): pending — deferred while framework/ files are
+  under concurrent migration (2026-07-23). The expander is
+  dependency-free so the planner can adopt it without rework.

--- a/packages/evals/benchmarks/braintrust.ts
+++ b/packages/evals/benchmarks/braintrust.ts
@@ -79,6 +79,7 @@ export function benchmarkRunnerOptions(combination: BenchmarkCombination): {
   harness: BenchmarkHarness;
   trials: number;
   sdk?: "v3" | "v4";
+  coreToolSurface: BenchmarkToolSurface;
   benchmark: BenchmarkRunDescriptor;
 } {
   const sdk = sdkForToolSurface(combination.toolSurface);
@@ -86,6 +87,7 @@ export function benchmarkRunnerOptions(combination: BenchmarkCombination): {
     modelOverride: combination.model,
     harness: combination.harness,
     trials: combination.trials,
+    coreToolSurface: combination.toolSurface,
     ...(sdk ? { sdk } : {}),
     benchmark: {
       name: combination.benchmark,
@@ -93,4 +95,5 @@ export function benchmarkRunnerOptions(combination: BenchmarkCombination): {
       toolSurface: combination.toolSurface,
     },
   };
+}
 }

--- a/packages/evals/benchmarks/braintrust.ts
+++ b/packages/evals/benchmarks/braintrust.ts
@@ -1,0 +1,96 @@
+/**
+ * Braintrust wiring for benchmark-matrix runs.
+ *
+ * Maps a BenchmarkCombination onto the runner's options so every experiment
+ * is (a) named self-describingly — benchmark, harness, tool surface, model,
+ * env, date — and (b) stamped with the full triple in experiment metadata,
+ * making any two points of the matrix diffable in Braintrust.
+ *
+ * Kept free of framework/ imports (only types flow the other way:
+ * runner.ts imports BenchmarkRunDescriptor + the name builder from here).
+ */
+import type { BenchmarkCombination, BenchmarkHarness, BenchmarkToolSurface } from "./schema.js";
+
+/** The slice of a combination the runner carries through to Braintrust. */
+export interface BenchmarkRunDescriptor {
+  name: string;
+  harness: BenchmarkHarness;
+  toolSurface: BenchmarkToolSurface;
+}
+
+/**
+ * SDK-comparison semantics fall out of the tool surface: the two SDK code
+ * surfaces are exactly the `--sdk v3|v4` worlds; external surfaces
+ * (playwright/cdp/MCP/CLI) have no Stagehand SDK in the loop.
+ */
+export function sdkForToolSurface(toolSurface: BenchmarkToolSurface): "v3" | "v4" | undefined {
+  if (toolSurface === "understudy_code") return "v3";
+  if (toolSurface === "v4_code") return "v4";
+  return undefined;
+}
+
+/**
+ * Experiment name for a benchmark run. Same segment conventions as the
+ * SDK-comparison names (double-underscore, short model id, ISO date) so the
+ * Braintrust experiment list sorts and scans uniformly.
+ */
+export function buildBenchmarkExperimentName(input: {
+  benchmark: BenchmarkRunDescriptor;
+  environment: string;
+  model?: string;
+  /** Injectable for deterministic tests; defaults to today (UTC). */
+  date?: string;
+}): string {
+  const model = input.model
+    ? input.model.includes("/")
+      ? input.model.split("/").slice(1).join("/")
+      : input.model
+    : "multi";
+  const date = input.date ?? new Date().toISOString().slice(0, 10);
+  return [
+    input.benchmark.name,
+    input.benchmark.harness,
+    input.benchmark.toolSurface,
+    input.environment.toLowerCase(),
+    model,
+    date,
+  ].join("__");
+}
+
+/** Experiment-metadata fields for a benchmark run. */
+export function benchmarkRunMetadata(benchmark: BenchmarkRunDescriptor): Record<string, unknown> {
+  return {
+    benchmark: benchmark.name,
+    harness: benchmark.harness,
+    toolSurface: benchmark.toolSurface,
+  };
+}
+
+/**
+ * Runner options for one point of the matrix. Spread this into the
+ * `runEvals` call (task/target selection stays the caller's job — a suite
+ * target maps to the existing `b:<suite>` resolution, a tasks target to
+ * task names):
+ *
+ *   runEvals({ tasks, registry, ...benchmarkRunnerOptions(combination) })
+ */
+export function benchmarkRunnerOptions(combination: BenchmarkCombination): {
+  modelOverride: string;
+  harness: BenchmarkHarness;
+  trials: number;
+  sdk?: "v3" | "v4";
+  benchmark: BenchmarkRunDescriptor;
+} {
+  const sdk = sdkForToolSurface(combination.toolSurface);
+  return {
+    modelOverride: combination.model,
+    harness: combination.harness,
+    trials: combination.trials,
+    ...(sdk ? { sdk } : {}),
+    benchmark: {
+      name: combination.benchmark,
+      harness: combination.harness,
+      toolSurface: combination.toolSurface,
+    },
+  };
+}

--- a/packages/evals/benchmarks/expand.ts
+++ b/packages/evals/benchmarks/expand.ts
@@ -1,0 +1,74 @@
+/**
+ * Manifest loading and matrix expansion.
+ *
+ * Deliberately standalone (no imports from framework/) so it can be wired
+ * into the planner/CLI without entangling this layer in harness internals —
+ * the planner consumes `BenchmarkCombination[]` and stamps the triple into
+ * run rows and Braintrust metadata.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import {
+  BenchmarkManifestSchema,
+  combinationInvalidReason,
+  type BenchmarkCombination,
+  type ResolvedBenchmarkManifest,
+} from "./schema.js";
+
+export interface ExpandedBenchmark {
+  manifest: ResolvedBenchmarkManifest;
+  /** Valid (model × harness × toolSurface) rows, in manifest order. */
+  combinations: BenchmarkCombination[];
+  /** Cross-product points dropped by validity rules, with reasons. */
+  skipped: Array<{
+    model: string;
+    harness: string;
+    toolSurface: string;
+    reason: string;
+  }>;
+}
+
+export function expandManifest(manifest: ResolvedBenchmarkManifest): ExpandedBenchmark {
+  const combinations: BenchmarkCombination[] = [];
+  const skipped: ExpandedBenchmark["skipped"] = [];
+
+  for (const model of manifest.matrix.models) {
+    for (const harness of manifest.matrix.harnesses) {
+      for (const toolSurface of manifest.matrix.toolSurfaces) {
+        const reason = combinationInvalidReason(harness, toolSurface);
+        if (reason) {
+          skipped.push({ model, harness, toolSurface, reason });
+          continue;
+        }
+        combinations.push({
+          benchmark: manifest.name,
+          model,
+          harness,
+          toolSurface,
+          target: manifest.target,
+          trials: manifest.trials,
+        });
+      }
+    }
+  }
+
+  return { manifest, combinations, skipped };
+}
+
+function loadManifestFile(filePath: string): ResolvedBenchmarkManifest {
+  const raw = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  const parsed = BenchmarkManifestSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new Error(`Invalid benchmark manifest ${filePath}: ${parsed.error.message}`);
+  }
+  return parsed.data;
+}
+
+/** Load and expand every *.bench.json manifest in a directory. */
+export function loadBenchmarksDir(dir: string): ExpandedBenchmark[] {
+  const entries = fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith(".bench.json"))
+    .sort();
+  return entries.map((f) => expandManifest(loadManifestFile(path.join(dir, f))));
+}

--- a/packages/evals/benchmarks/schema.ts
+++ b/packages/evals/benchmarks/schema.ts
@@ -1,0 +1,102 @@
+/**
+ * Benchmark manifests — the three-axis run matrix.
+ *
+ * A benchmark is no longer just "a dataset × a model list". Each manifest
+ * under benchmarks/ pins the full cross-product the run should cover:
+ *
+ *   - model        which LLM drives the run (e.g. openai/gpt-4.1-mini)
+ *   - harness      what agentic loop drives the task: the Stagehand SDK
+ *                  itself, or an external coding harness (claude_code,
+ *                  codex) executing against a tool surface
+ *   - toolSurface  what the harness uses to control the browser: writing
+ *                  code against an SDK (understudy_code = v3, v4_code = v4,
+ *                  playwright_code, cdp_code) or calling packaged tools
+ *                  (playwright_mcp, chrome_devtools_mcp, browse_cli)
+ *
+ * Expansion (see expand.ts) produces one run row per valid combination and
+ * carries the triple into results/Braintrust metadata, so scores are always
+ * attributable to (model, harness, toolSurface) — never just the model.
+ */
+import { z } from "zod";
+
+export const HARNESSES = ["stagehand", "claude_code", "codex"] as const;
+export const HarnessSchema = z.enum(HARNESSES);
+export type BenchmarkHarness = z.infer<typeof HarnessSchema>;
+
+/** Mirrors core/contracts/tool.ts ToolSurface, plus the v4 SDK code mode. */
+export const TOOL_SURFACES = [
+  "understudy_code",
+  "v4_code",
+  "playwright_code",
+  "cdp_code",
+  "playwright_mcp",
+  "chrome_devtools_mcp",
+  "browse_cli",
+] as const;
+export const ToolSurfaceSchema = z.enum(TOOL_SURFACES);
+export type BenchmarkToolSurface = z.infer<typeof ToolSurfaceSchema>;
+
+/** What the benchmark runs: a dataset-backed suite or a task/category glob. */
+export const BenchmarkTargetSchema = z.union([
+  z.object({
+    kind: z.literal("suite"),
+    /** Suite key, e.g. "webvoyager", "gaia", "onlineMind2Web", "webtailbench". */
+    suite: z.string(),
+    /** Row cap (EVAL_MAX_K equivalent). */
+    limit: z.number().int().positive().optional(),
+    /** Random sample size, applied before limit. */
+    sample: z.number().int().positive().optional(),
+  }),
+  z.object({
+    kind: z.literal("tasks"),
+    /** Task or category names as the CLI accepts them, e.g. "act", "act/dropdown". */
+    include: z.array(z.string()).min(1),
+  }),
+]);
+export type BenchmarkTarget = z.infer<typeof BenchmarkTargetSchema>;
+
+export const BenchmarkManifestSchema = z
+  .object({
+    name: z.string().regex(/^[a-z0-9][a-z0-9-]*$/, "kebab-case name"),
+    description: z.string().optional(),
+    target: BenchmarkTargetSchema,
+    matrix: z.object({
+      models: z.array(z.string().regex(/.+\/.+/, "provider/model")).min(1),
+      harnesses: z.array(HarnessSchema).min(1),
+      toolSurfaces: z.array(ToolSurfaceSchema).min(1),
+    }),
+    /** Trials per combination. */
+    trials: z.number().int().positive().default(1),
+  })
+  .strict();
+export type BenchmarkManifest = z.input<typeof BenchmarkManifestSchema>;
+export type ResolvedBenchmarkManifest = z.output<typeof BenchmarkManifestSchema>;
+
+/** One expanded run row: a point in the (model × harness × toolSurface) space. */
+export interface BenchmarkCombination {
+  benchmark: string;
+  model: string;
+  harness: BenchmarkHarness;
+  toolSurface: BenchmarkToolSurface;
+  target: BenchmarkTarget;
+  trials: number;
+}
+
+/**
+ * Not every point in the cross-product is meaningful. The stagehand harness
+ * IS the SDK, so its only coherent surfaces are the SDK code modes; external
+ * coding harnesses can drive any surface. Returns null when valid, else the
+ * reason (surfaced in the plan, so skipped combos are visible, not silent).
+ */
+export function combinationInvalidReason(
+  harness: BenchmarkHarness,
+  toolSurface: BenchmarkToolSurface,
+): string | null {
+  if (harness === "stagehand") {
+    if (toolSurface === "understudy_code" || toolSurface === "v4_code") {
+      return null;
+    }
+    return `harness "stagehand" is the SDK itself — pair it with understudy_code (v3) or v4_code, not "${toolSurface}"`;
+  }
+  return null;
+}

--- a/packages/evals/benchmarks/v4-vs-playwright.bench.json
+++ b/packages/evals/benchmarks/v4-vs-playwright.bench.json
@@ -1,0 +1,11 @@
+{
+  "name": "v4-vs-playwright",
+  "description": "WebVoyager under claude_code with only the tool surface varying: Stagehand v4 code mode vs Playwright code mode. Same harness, same model, same LLMJ grader — score deltas are attributable to the tool surface.",
+  "target": { "kind": "suite", "suite": "webvoyager", "limit": 5 },
+  "matrix": {
+    "models": ["anthropic/claude-haiku-4-5"],
+    "harnesses": ["claude_code"],
+    "toolSurfaces": ["v4_code", "playwright_code"]
+  },
+  "trials": 1
+}

--- a/packages/evals/framework/runner.ts
+++ b/packages/evals/framework/runner.ts
@@ -16,7 +16,6 @@ import type { AgentToolMode } from "stagehand-v3";
 import { shouldPersistTrajectory } from "stagehand-v3";
 import { AssertionError } from "./assertions.js";
 import { EvalLogger } from "../logger.js";
-import { resolveV4SdkPath } from "../v4SdkLoader.js";
 import { EvalsError } from "../errors.js";
 import { exactMatch, errorMatch, passRate } from "../scoring.js";
 import { generateExperimentName } from "../utils.js";
@@ -33,10 +32,16 @@ import type { DiscoveredTask, TaskRegistry, TaskResult } from "./types.js";
 import type { Testcase, EvalInput } from "../types/evals.js";
 import { generateBenchTestcases } from "./benchPlanner.js";
 import { DEFAULT_BENCH_HARNESS, type Harness } from "./benchTypes.js";
+import {
+  benchmarkRunMetadata,
+  buildBenchmarkExperimentName,
+  type BenchmarkRunDescriptor,
+} from "../benchmarks/braintrust.js";
 import { executeBenchTask } from "./benchRunner.js";
 import { hasBraintrustApiKey, loadBraintrust, tracedSpan } from "./braintrust.js";
 import { onceAsync, registerActiveRunCleanup } from "./activeRunCleanup.js";
 import { loadTaskModuleFromPath } from "./taskLoader.js";
+import { resolveV4SdkPath } from "../v4SdkLoader.js";
 
 export { discoverTasks, resolveTarget } from "./discovery.js";
 export { inferEffectiveBenchCategory, resolveBenchModelEntries } from "./benchPlanner.js";
@@ -65,8 +70,15 @@ function buildSdkComparisonExperimentName(input: {
   return [input.base, input.sdk, input.environment.toLowerCase(), model, date].join("__");
 }
 
-/** Braintrust project for SDK-comparison runs (--sdk v3|v4). */
+/**
+ * Braintrust project routing for v4 work:
+ * - deterministic suite (direct a/e/o method-call tasks, pass-rate /
+ *   exact-match scored) → stagehand-v4-deterministic
+ * - nondeterministic suite (longer-horizon / LLMJ-scored: external-harness
+ *   and benchmark-matrix runs) → stagehand-v4
+ */
 const SDK_COMPARISON_PROJECT = "stagehand-v4";
+const DETERMINISTIC_COMPARISON_PROJECT = "stagehand-v4-deterministic";
 
 /**
  * Fail fast before spending money: verify the configured Braintrust key can
@@ -168,6 +180,16 @@ export interface RunEvalsOptions {
    * be diffed per task.
    */
   sdk?: "v3" | "v4";
+  /**
+   * Benchmark-matrix run descriptor (see benchmarks/). When set, the
+   * Braintrust experiment name becomes
+   * `<benchmark>__<harness>__<toolSurface>__<env>__<model>__<date>` and
+   * metadata carries the full (benchmark, harness, toolSurface) triple, so
+   * any two points of a matrix are diffable. Produced by
+   * `benchmarkRunnerOptions()` — spread that into this call rather than
+   * assembling by hand.
+   */
+  benchmark?: BenchmarkRunDescriptor;
   coreToolSurface?: ToolSurface;
   coreStartupProfile?: StartupProfile;
   onProgress?: (event: RunProgressEvent) => void;
@@ -434,9 +456,11 @@ export async function runEvals(options: RunEvalsOptions): Promise<RunEvalsResult
   }
 
   const hasCoreOnly = options.tasks.every((t: DiscoveredTask) => t.tier === "core");
+  // Core runs default to understudy; bench runs under an external harness
+  // carry the requested surface (the comparison arm) into metadata/naming.
   const effectiveCoreToolSurface = hasCoreOnly
     ? (options.coreToolSurface ?? "understudy_code")
-    : undefined;
+    : options.coreToolSurface;
   const effectiveCoreStartupProfile =
     hasCoreOnly && effectiveCoreToolSurface
       ? (options.coreStartupProfile ??
@@ -456,14 +480,20 @@ export async function runEvals(options: RunEvalsOptions): Promise<RunEvalsResult
   // SDK-comparison runs (--sdk passed explicitly) get self-describing names
   // so matched v3/v4 pairs are unmistakable in the Braintrust experiment
   // list; default runs keep the plain target-label naming.
-  const experimentName = options.sdk
-    ? buildSdkComparisonExperimentName({
-        base: baseExperimentName,
-        sdk: options.sdk,
+  const experimentName = options.benchmark
+    ? buildBenchmarkExperimentName({
+        benchmark: options.benchmark,
         environment,
         model: runModel ?? options.modelOverride,
       })
-    : baseExperimentName;
+    : options.sdk
+      ? buildSdkComparisonExperimentName({
+          base: baseExperimentName,
+          sdk: options.sdk,
+          environment,
+          model: runModel ?? options.modelOverride,
+        })
+      : baseExperimentName;
 
   // Stamp the run-scoped trajectory group; the token is generated once here and
   // reused for the completion-time experiment link. Local persistence only.
@@ -479,18 +509,26 @@ export async function runEvals(options: RunEvalsOptions): Promise<RunEvalsResult
   if (options.modelOverride) process.env.EVAL_MODEL_OVERRIDE = options.modelOverride;
   if (options.provider) process.env.EVAL_PROVIDER = options.provider;
 
-  // SDK-comparison runs (--sdk passed) land in the dedicated project so
-  // v3/v4 experiments are diffable in one place; default runs keep the
+  // v4-work routing: benchmark-matrix runs and the replay (nondeterministic)
+  // suite land in stagehand-v4; plain --sdk comparison runs of deterministic
+  // a/e/o tasks land in stagehand-v4-deterministic. Default runs keep the
   // existing project routing.
-  const braintrustProjectName = options.sdk
-    ? SDK_COMPARISON_PROJECT
-    : hasCoreOnly
-      ? process.env.CI === "true"
-        ? "stagehand-core"
-        : "stagehand-core-dev"
-      : process.env.CI === "true"
-        ? "stagehand"
-        : "stagehand-dev";
+  // External coding harnesses (claude_code, codex) only drive the
+  // longer-horizon LLMJ-graded suite — always nondeterministic.
+  const isExternalHarnessRun =
+    !hasCoreOnly && effectiveBenchHarness !== undefined && effectiveBenchHarness !== "stagehand";
+  const braintrustProjectName =
+    options.benchmark || isExternalHarnessRun
+      ? SDK_COMPARISON_PROJECT
+      : options.sdk
+        ? DETERMINISTIC_COMPARISON_PROJECT
+        : hasCoreOnly
+          ? process.env.CI === "true"
+            ? "stagehand-core"
+            : "stagehand-core-dev"
+          : process.env.CI === "true"
+            ? "stagehand"
+            : "stagehand-dev";
 
   const scores = hasCoreOnly ? [passRate, errorMatch] : [exactMatch, errorMatch];
 
@@ -501,7 +539,7 @@ export async function runEvals(options: RunEvalsOptions): Promise<RunEvalsResult
   // any task starts rather than discovering dropped log batches afterwards.
   // Every comparison run must be verifiable and traceable in Braintrust —
   // results without a backing experiment record can't be audited.
-  if (options.sdk && sendLogs) {
+  if ((options.sdk || options.benchmark || isExternalHarnessRun) && sendLogs) {
     await assertBraintrustProjectReachable(braintrustProjectName);
   }
 
@@ -524,7 +562,17 @@ export async function runEvals(options: RunEvalsOptions): Promise<RunEvalsResult
       experimentName,
       metadata: {
         environment,
-        sdk: options.sdk ?? "v3",
+        // External-harness runs aren't driven by a Stagehand SDK unless the
+        // tool surface IS one; don't let the legacy v3 default mislabel them.
+        ...(options.sdk
+          ? { sdk: options.sdk }
+          : isExternalHarnessRun
+            ? options.coreToolSurface === "v4_code"
+              ? { sdk: "v4" }
+              : options.coreToolSurface === "understudy_code"
+                ? { sdk: "v3" }
+                : {}
+            : { sdk: "v3" }),
         ...(options.sdk === "v4" && { v4Sha: resolveV4SpikeSha() }),
         tier: hasCoreOnly ? "core" : "bench",
         ...(effectiveCoreToolSurface && {
@@ -534,6 +582,9 @@ export async function runEvals(options: RunEvalsOptions): Promise<RunEvalsResult
           startupProfile: effectiveCoreStartupProfile,
         }),
         ...(effectiveBenchHarness && { harness: effectiveBenchHarness }),
+        // Benchmark-matrix runs: stamp the full triple last so it is
+        // authoritative over the tier-derived harness/toolSurface fields.
+        ...(options.benchmark && benchmarkRunMetadata(options.benchmark)),
         ...(options.provider && { provider: options.provider }),
         ...(options.modelOverride && { model: options.modelOverride }),
         ...(options.useApi && { api: true }),

--- a/packages/evals/framework/runner.ts
+++ b/packages/evals/framework/runner.ts
@@ -568,7 +568,7 @@ export async function runEvals(options: RunEvalsOptions): Promise<RunEvalsResult
           ? { sdk: options.sdk }
           : isExternalHarnessRun
             ? options.coreToolSurface === "v4_code"
-              ? { sdk: "v4" }
+              ? { sdk: "v4", v4Sha: resolveV4SpikeSha() }
               : options.coreToolSurface === "understudy_code"
                 ? { sdk: "v3" }
                 : {}

--- a/packages/evals/tests/framework/benchmarksBraintrust.test.ts
+++ b/packages/evals/tests/framework/benchmarksBraintrust.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  benchmarkRunMetadata,
+  benchmarkRunnerOptions,
+  buildBenchmarkExperimentName,
+  sdkForToolSurface,
+} from "../../benchmarks/braintrust.js";
+import type { BenchmarkCombination } from "../../benchmarks/schema.js";
+
+const combination: BenchmarkCombination = {
+  benchmark: "v4-vs-playwright",
+  model: "anthropic/claude-haiku-4-5",
+  harness: "stagehand",
+  toolSurface: "v4_code",
+  target: { kind: "tasks", include: ["act/dropdown"] },
+  trials: 3,
+};
+
+describe("sdkForToolSurface", () => {
+  it("maps the SDK code surfaces and nothing else", () => {
+    expect(sdkForToolSurface("understudy_code")).toBe("v3");
+    expect(sdkForToolSurface("v4_code")).toBe("v4");
+    expect(sdkForToolSurface("playwright_mcp")).toBeUndefined();
+    expect(sdkForToolSurface("cdp_code")).toBeUndefined();
+  });
+});
+
+describe("buildBenchmarkExperimentName", () => {
+  it("is self-describing and deterministic", () => {
+    const name = buildBenchmarkExperimentName({
+      benchmark: {
+        name: "v4-vs-playwright",
+        harness: "stagehand",
+        toolSurface: "v4_code",
+      },
+      environment: "BROWSERBASE",
+      model: "anthropic/claude-haiku-4-5",
+      date: "2026-07-23",
+    });
+    expect(name).toBe(
+      "v4-vs-playwright__stagehand__v4_code__browserbase__claude-haiku-4-5__2026-07-23",
+    );
+  });
+
+  it("falls back to multi for mixed-model runs", () => {
+    const name = buildBenchmarkExperimentName({
+      benchmark: {
+        name: "b",
+        harness: "codex",
+        toolSurface: "playwright_mcp",
+      },
+      environment: "LOCAL",
+      date: "2026-07-23",
+    });
+    expect(name).toBe("b__codex__playwright_mcp__local__multi__2026-07-23");
+  });
+});
+
+describe("benchmarkRunnerOptions", () => {
+  it("carries the triple, model, trials, and inferred sdk", () => {
+    const opts = benchmarkRunnerOptions(combination);
+    expect(opts).toEqual({
+      modelOverride: "anthropic/claude-haiku-4-5",
+      harness: "stagehand",
+      trials: 3,
+      sdk: "v4",
+      benchmark: {
+        name: "v4-vs-playwright",
+        harness: "stagehand",
+        toolSurface: "v4_code",
+      },
+    });
+  });
+
+  it("omits sdk for non-SDK surfaces", () => {
+    const opts = benchmarkRunnerOptions({
+      ...combination,
+      harness: "claude_code",
+      toolSurface: "chrome_devtools_mcp",
+    });
+    expect(opts.sdk).toBeUndefined();
+    expect(opts.benchmark.toolSurface).toBe("chrome_devtools_mcp");
+  });
+});
+
+describe("benchmarkRunMetadata", () => {
+  it("stamps the full triple", () => {
+    expect(
+      benchmarkRunMetadata({
+        name: "v4-vs-playwright",
+        harness: "stagehand",
+        toolSurface: "v4_code",
+      }),
+    ).toEqual({
+      benchmark: "v4-vs-playwright",
+      harness: "stagehand",
+      toolSurface: "v4_code",
+    });
+  });
+});

--- a/packages/evals/tests/framework/benchmarksManifest.test.ts
+++ b/packages/evals/tests/framework/benchmarksManifest.test.ts
@@ -1,0 +1,84 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { BenchmarkManifestSchema, combinationInvalidReason } from "../../benchmarks/schema.js";
+import { expandManifest, loadBenchmarksDir } from "../../benchmarks/expand.js";
+import { getPackageRootDir } from "../../runtimePaths.js";
+
+const BENCHMARKS_DIR = path.join(getPackageRootDir(), "benchmarks");
+
+describe("benchmark manifest schema", () => {
+  it("rejects unknown harnesses and surfaces", () => {
+    const bad = BenchmarkManifestSchema.safeParse({
+      name: "x",
+      target: { kind: "tasks", include: ["act"] },
+      matrix: {
+        models: ["openai/gpt-4.1-mini"],
+        harnesses: ["cursor"],
+        toolSurfaces: ["v4_code"],
+      },
+    });
+    expect(bad.success).toBe(false);
+  });
+
+  it("requires provider/model shape", () => {
+    const bad = BenchmarkManifestSchema.safeParse({
+      name: "x",
+      target: { kind: "tasks", include: ["act"] },
+      matrix: {
+        models: ["gpt-4.1-mini"],
+        harnesses: ["stagehand"],
+        toolSurfaces: ["v4_code"],
+      },
+    });
+    expect(bad.success).toBe(false);
+  });
+});
+
+describe("combination validity", () => {
+  it("stagehand harness pairs only with SDK code surfaces", () => {
+    expect(combinationInvalidReason("stagehand", "understudy_code")).toBeNull();
+    expect(combinationInvalidReason("stagehand", "v4_code")).toBeNull();
+    expect(combinationInvalidReason("stagehand", "playwright_mcp")).toMatch(/stagehand/);
+  });
+
+  it("external harnesses pair with any surface", () => {
+    expect(combinationInvalidReason("claude_code", "playwright_mcp")).toBeNull();
+    expect(combinationInvalidReason("codex", "v4_code")).toBeNull();
+    expect(combinationInvalidReason("claude_code", "browse_cli")).toBeNull();
+  });
+});
+
+describe("expansion", () => {
+  it("expands the cross-product and reports skips with reasons", () => {
+    const manifest = BenchmarkManifestSchema.parse({
+      name: "t",
+      target: { kind: "tasks", include: ["act/dropdown"] },
+      matrix: {
+        models: ["openai/gpt-4.1-mini", "anthropic/claude-haiku-4-5"],
+        harnesses: ["stagehand", "claude_code"],
+        toolSurfaces: ["v4_code", "playwright_mcp"],
+      },
+      trials: 2,
+    });
+    const { combinations, skipped } = expandManifest(manifest);
+    // 2 models × (stagehand×{v4_code} + claude_code×{v4_code, playwright_mcp})
+    expect(combinations).toHaveLength(6);
+    expect(skipped).toHaveLength(2);
+    expect(skipped[0].reason).toContain("stagehand");
+    for (const c of combinations) {
+      expect(c.trials).toBe(2);
+      expect(c.benchmark).toBe("t");
+    }
+  });
+
+  it("loads and expands the checked-in manifests", () => {
+    const expanded = loadBenchmarksDir(BENCHMARKS_DIR);
+    expect(expanded.length).toBeGreaterThanOrEqual(1);
+    for (const bench of expanded) {
+      expect(bench.combinations.length).toBeGreaterThan(0);
+      for (const c of bench.combinations) {
+        expect(combinationInvalidReason(c.harness, c.toolSurface)).toBeNull();
+      }
+    }
+  });
+});

--- a/packages/evals/tests/framework/v4SdkLoader.test.ts
+++ b/packages/evals/tests/framework/v4SdkLoader.test.ts
@@ -1,0 +1,64 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { STAGEHAND_V4_SDK_PATH_ENV, loadV4Sdk, resolveV4SdkPath } from "../../v4SdkLoader.js";
+import { getRepoRootDir } from "../../runtimePaths.js";
+
+/** A real file that exists in every checkout — the in-repo v4 SDK's entry. */
+const REAL_SDK_ENTRY = path.join(getRepoRootDir(), "packages", "sdk-ts", "src", "index.ts");
+
+describe("resolveV4SdkPath", () => {
+  it("returns undefined when the env var is unset or blank", () => {
+    expect(resolveV4SdkPath({})).toBeUndefined();
+    expect(resolveV4SdkPath({ [STAGEHAND_V4_SDK_PATH_ENV]: "  " })).toBeUndefined();
+  });
+
+  it("resolves a real entry file", () => {
+    expect(resolveV4SdkPath({ [STAGEHAND_V4_SDK_PATH_ENV]: REAL_SDK_ENTRY })).toBe(REAL_SDK_ENTRY);
+  });
+
+  it("throws loudly on a missing path instead of silently falling back", () => {
+    expect(() =>
+      resolveV4SdkPath({
+        [STAGEHAND_V4_SDK_PATH_ENV]: "/definitely/not/a/real/sdk.ts",
+      }),
+    ).toThrow(/does not point to a file/);
+  });
+
+  it("throws on a directory (must be the entry file)", () => {
+    expect(() =>
+      resolveV4SdkPath({
+        [STAGEHAND_V4_SDK_PATH_ENV]: path.dirname(REAL_SDK_ENTRY),
+      }),
+    ).toThrow(/does not point to a file/);
+  });
+});
+
+describe("loadV4Sdk", () => {
+  it("throws naming the env var when unset (no package fallback)", async () => {
+    await expect(loadV4Sdk(async () => ({}), {})).rejects.toThrow(
+      /STAGEHAND_V4_SDK_PATH is required/,
+    );
+  });
+
+  it("imports the configured entry file as a file:// URL when set", async () => {
+    const seen: string[] = [];
+    await loadV4Sdk(
+      async (specifier) => {
+        seen.push(specifier);
+        return { Stagehand: class {} };
+      },
+      { [STAGEHAND_V4_SDK_PATH_ENV]: REAL_SDK_ENTRY },
+    );
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatch(/^file:\/\//);
+    expect(seen[0]).toContain("packages/sdk-ts/src/index.ts");
+  });
+
+  it("returns the imported module verbatim", async () => {
+    const fake = { Stagehand: class {}, marker: 42 };
+    const loaded = await loadV4Sdk(async () => fake, {
+      [STAGEHAND_V4_SDK_PATH_ENV]: REAL_SDK_ENTRY,
+    });
+    expect(loaded).toBe(fake);
+  });
+});


### PR DESCRIPTION
Nondeterministic-suite stack 3/4. Supersedes #2390. The obsolete initV4Params test written against the pre-migration builder was dropped during the replay; initV4's logging/selfHeal wiring from #2472 supersedes this commit's older onLog feature-detection.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a benchmark matrix for nondeterministic evals that attributes results by (model × harness × toolSurface) and routes them to Braintrust with clear names and metadata. Also replaces the linked v4 SDK dependency with `STAGEHAND_V4_SDK_PATH` and commits v4 SDK `.d.ts` so CI and fresh clones typecheck cleanly. Supports STG-2671 by encoding the model/harness/tool cadence and reporting to Braintrust.

- New Features
  - Benchmark manifests (`benchmarks/*.bench.json`) with schema, validation, and expansion; invalid combinations are reported with reasons; example `v4-vs-playwright`.
  - Runner naming/metadata for the full triple and project routing: deterministic `--sdk` runs → `stagehand-v4-deterministic`; external/benchmark runs → `stagehand-v4`; `sdk` inferred from tool surface and omitted for non-SDK surfaces; v4 SHA stamped; fail-fast project reachability for benchmark, external-harness, and comparison runs.
  - Braintrust helpers: `benchmarkRunnerOptions`, `buildBenchmarkExperimentName`, and metadata stamps.
  - Docs: matrix README and general harness scoping (LLMJ via v3 carrier). Tests cover schema, expansion, Braintrust naming, and v4 SDK loader.

- Migration
  - Set `STAGEHAND_V4_SDK_PATH` to the v4 SDK entry file (e.g., `packages/sdk-ts/src/index.ts`); the loader requires it at runtime.
  - Regenerate and commit `.v4-sdk-types/` when the v4 checkout moves.
  - To run a matrix: `loadBenchmarksDir()`, then call `runEvals({ ...benchmarkRunnerOptions(combination), ... })` for each valid combination.

<sup>Written for commit e4698e8b053f1c79c431170f8effe9906524e80a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

