### PR TITLE
evals: crash-isolate bench tasks in child processes (--isolate)

### DIFF
--- a/packages/evals/framework/benchTaskIsolation.ts
+++ b/packages/evals/framework/benchTaskIsolation.ts
@@ -1,0 +1,194 @@
+/**
+ * Parent side of --isolate: run one bench task in a child process so a hard
+ * crash (OOM, hung SDK, unhandled rejection) fails that task alone instead
+ * of taking down the whole suite.
+ *
+ * The child is `tsx framework/benchTaskWorker.ts` spawned from the repo
+ * root (the SDK ships raw .ts, and repo-root cwd keeps tsx away from the
+ * evals tsconfig paths — see the CLI invocation notes in the README). The
+ * payload travels over stdin; the result comes back as a sentinel-framed
+ * JSON line on stdout. On any non-sentinel outcome the parent synthesizes a
+ * failed TaskResult carrying the exit reason and the tail of stderr.
+ */
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { getRepoRootDir } from "../runtimePaths.js";
+import { hasBraintrustApiKey, loadBraintrust } from "./braintrust.js";
+import type { EvalInput } from "../types/evals.js";
+import type { DiscoveredTask, TaskResult } from "./types.js";
+import type { RunEvalsOptions } from "./runner.js";
+
+export const TASK_RESULT_SENTINEL = "__STAGEHAND_EVAL_TASK_RESULT__:";
+
+/** JSON-serializable subset of RunEvalsOptions a task execution reads. */
+export type IsolatedTaskOptions = Pick<
+  RunEvalsOptions,
+  | "trials"
+  | "environment"
+  | "useApi"
+  | "modelOverride"
+  | "provider"
+  | "categoryFilter"
+  | "datasetFilter"
+  | "agentMode"
+  | "agentModes"
+  | "harness"
+  | "sdk"
+  | "coreToolSurface"
+  | "coreStartupProfile"
+  | "verbose"
+>;
+
+export interface IsolatedTaskPayload {
+  input: EvalInput;
+  task: DiscoveredTask;
+  options: IsolatedTaskOptions;
+  /**
+   * Exported Braintrust span of the parent row, so the child's spans
+   * (verifier.verify etc.) attach to the same trace instead of being lost
+   * at the process boundary. Absent when Braintrust logging is off.
+   */
+  braintrustParent?: string;
+}
+
+/** Hard cap per task process; generous next to in-task timeouts.
+ * Override with EVAL_ISOLATE_TIMEOUT_MS (also how the kill path is
+ * exercised in verification). */
+const TASK_PROCESS_TIMEOUT_MS = (() => {
+  const parsed = Number.parseInt(process.env.EVAL_ISOLATE_TIMEOUT_MS ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 15 * 60 * 1000;
+})();
+const STDERR_TAIL_CHARS = 2000;
+
+function serializableOptions(options: RunEvalsOptions): IsolatedTaskOptions {
+  return {
+    trials: options.trials,
+    environment: options.environment,
+    useApi: options.useApi,
+    modelOverride: options.modelOverride,
+    provider: options.provider,
+    categoryFilter: options.categoryFilter,
+    datasetFilter: options.datasetFilter,
+    agentMode: options.agentMode,
+    agentModes: options.agentModes,
+    harness: options.harness,
+    sdk: options.sdk,
+    // Tool-surface selection must cross the boundary or isolated
+    // external-harness runs silently fall back to browse_cli.
+    coreToolSurface: options.coreToolSurface,
+    coreStartupProfile: options.coreStartupProfile,
+    verbose: options.verbose,
+  };
+}
+
+function resolveWorkerInvocation(repoRoot: string): {
+  command: string;
+  args: string[];
+} {
+  const workerPath = path.join(repoRoot, "packages/evals/framework/benchTaskWorker.ts");
+  const localTsx = path.join(repoRoot, "node_modules/.bin/tsx");
+  if (existsSync(localTsx)) {
+    return { command: localTsx, args: [workerPath] };
+  }
+  return { command: "npx", args: ["tsx", workerPath] };
+}
+
+export async function executeBenchTaskIsolated(
+  input: EvalInput,
+  task: DiscoveredTask,
+  options: RunEvalsOptions,
+): Promise<TaskResult> {
+  const repoRoot = getRepoRootDir();
+  const { command, args } = resolveWorkerInvocation(repoRoot);
+
+  // Distributed tracing across the process boundary (best-effort): export
+  // the current row span so the child can re-enter the trace.
+  let braintrustParent: string | undefined;
+  if (hasBraintrustApiKey()) {
+    try {
+      const bt = await loadBraintrust();
+      braintrustParent = await bt.currentSpan().export();
+    } catch {
+      // tracing is additive - never block execution on it
+    }
+  }
+
+  const payload: IsolatedTaskPayload = {
+    input,
+    task,
+    options: serializableOptions(options),
+    ...(braintrustParent && { braintrustParent }),
+  };
+
+  return new Promise<TaskResult>((resolve) => {
+    const child = spawn(command, args, {
+      cwd: repoRoot,
+      env: process.env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderrTail = "";
+    let settled = false;
+
+    const settle = (result: TaskResult) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      options.signal?.removeEventListener("abort", onAbort);
+      resolve(result);
+    };
+
+    const fail = (reason: string): TaskResult => ({
+      _success: false,
+      error: {
+        message: `Isolated task process ${reason}`,
+        ...(stderrTail.trim() ? { stderr: stderrTail.trim() } : {}),
+      },
+    });
+
+    const timeout = setTimeout(() => {
+      child.kill("SIGKILL");
+      settle(fail(`timed out after ${TASK_PROCESS_TIMEOUT_MS / 1000}s`));
+    }, TASK_PROCESS_TIMEOUT_MS);
+
+    const onAbort = () => {
+      child.kill("SIGKILL");
+      settle(fail("aborted"));
+    };
+    options.signal?.addEventListener("abort", onAbort, { once: true });
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderrTail = (stderrTail + chunk.toString("utf8")).slice(-STDERR_TAIL_CHARS);
+    });
+
+    child.on("error", (error) => {
+      settle(fail(`failed to spawn: ${error.message}`));
+    });
+
+    child.on("close", (code, signal) => {
+      const sentinelIndex = stdout.lastIndexOf(TASK_RESULT_SENTINEL);
+      if (sentinelIndex !== -1) {
+        const line = stdout.slice(sentinelIndex + TASK_RESULT_SENTINEL.length).split("\n", 1)[0];
+        try {
+          settle(JSON.parse(line) as TaskResult);
+          return;
+        } catch {
+          settle(fail("emitted an unparsable result"));
+          return;
+        }
+      }
+      settle(
+        fail(
+          signal ? `was killed by ${signal}` : `exited with code ${code} before reporting a result`,
+        ),
+      );
+    });
+
+    child.stdin.end(JSON.stringify(payload));
+  });
+}

--- a/packages/evals/framework/benchTaskWorker.ts
+++ b/packages/evals/framework/benchTaskWorker.ts
@@ -1,0 +1,64 @@
+/**
+ * Child-process entrypoint for isolated bench task execution (--isolate).
+ *
+ * Reads a JSON payload from stdin ({ input, task, options }), runs the task
+ * through the normal executeBenchTask path, and emits the TaskResult as a
+ * single sentinel-framed line on stdout. Everything else the task prints
+ * (SDK notifications, console noise) passes through untouched — the parent
+ * only trusts the sentinel line.
+ *
+ * A hard crash here (OOM, unhandled rejection, hung SDK) kills only this
+ * process; the parent synthesizes a failed TaskResult from the exit.
+ */
+import { executeBenchTask } from "./benchRunner.js";
+import { hasBraintrustApiKey, loadBraintrust } from "./braintrust.js";
+import type { IsolatedTaskPayload } from "./benchTaskIsolation.js";
+import { TASK_RESULT_SENTINEL } from "./benchTaskIsolation.js";
+import type { RunEvalsOptions } from "./runner.js";
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+const payload = JSON.parse(await readStdin()) as IsolatedTaskPayload;
+
+// The serializable option subset is all executeBenchTask reads; the
+// coordination-only fields (tasks/registry/signal/onProgress) never cross
+// the process boundary.
+const run = () => executeBenchTask(payload.input, payload.task, payload.options as RunEvalsOptions);
+
+// Re-enter the parent row's Braintrust trace so spans created in this
+// process (verifier.verify etc.) attach to it; wrap execution in an
+// `isolated:` span so the process boundary is visible in the trace.
+// Best-effort: tracing must never change execution behavior.
+let result;
+if (payload.braintrustParent && hasBraintrustApiKey()) {
+  const bt = await loadBraintrust();
+  // No Eval() context exists in this process - log in explicitly, then
+  // attach directly to the exported parent span (the documented
+  // distributed-tracing pattern). Nested tracedSpan calls inside
+  // executeBenchTask chain off this span via the current-span context.
+  await bt.login({});
+  result = await bt.traced(() => run(), {
+    name: `isolated:${payload.task.name}`,
+    parent: payload.braintrustParent,
+  });
+  await bt.flush();
+} else {
+  result = await run();
+}
+
+// Error instances JSON-serialize to {} — flatten them at the boundary so
+// task results that still carry raw errors stay diagnosable in the parent
+// (the same masking class the task-level flattenError work addressed).
+const replacer = (_key: string, value: unknown): unknown =>
+  value instanceof Error
+    ? { message: value.message, ...(value.stack ? { stack: value.stack } : {}) }
+    : value;
+
+process.stdout.write(`\n${TASK_RESULT_SENTINEL}${JSON.stringify(result, replacer)}\n`);
+process.exit(0);

--- a/packages/evals/framework/runner.ts
+++ b/packages/evals/framework/runner.ts
@@ -173,6 +173,11 @@ export interface RunEvalsOptions {
   agentModes?: AgentToolMode[];
   harness?: Harness;
   /**
+   * Run each bench task in its own child process so a hard crash (OOM,
+   * hung SDK, unhandled rejection) fails only that task. Set by --isolate.
+   */
+  isolateTasks?: boolean;
+  /**
    * Which Stagehand SDK drives bench tasks. When set explicitly (v3 or v4),
    * the run is treated as part of an SDK comparison: the Braintrust
    * experiment name gains sdk/env/model/date segments and metadata carries
@@ -273,6 +278,10 @@ async function executeTask(
 ): Promise<TaskResult> {
   if (task.tier === "core") {
     return executeCoreTask(input, task, options);
+  }
+  if (options.isolateTasks) {
+    const { executeBenchTaskIsolated } = await import("./benchTaskIsolation.js");
+    return executeBenchTaskIsolated(input, task, options);
   }
   return executeBenchTask(input, task, options);
 }

--- a/packages/evals/tui/commands/help.ts
+++ b/packages/evals/tui/commands/help.ts
@@ -100,6 +100,10 @@ export function printRunHelp(): void {
       `${cyan("-f, --filter")} ${dim("key=value")}`,
       `Benchmark-specific filter ${gray("(repeatable)")}`,
     ),
+    row(
+      cyan("--isolate"),
+      `Run each bench task in its own child process ${gray("(crash isolation)")}`,
+    ),
     "",
     `  ${bold("Inspect:")}`,
     "",

--- a/packages/evals/tui/commands/parse.ts
+++ b/packages/evals/tui/commands/parse.ts
@@ -48,6 +48,8 @@ export interface RunFlags {
   success?: SuccessMode;
   /** Spawn the pre-refactor index.eval.ts runner instead of the unified path. */
   legacy?: boolean;
+  /** Run each bench task in its own child process (crash isolation). */
+  isolate?: boolean;
   /** Which Stagehand SDK drives bench tasks: v3 (default) or v4. */
   sdk?: "v3" | "v4";
 }
@@ -98,6 +100,8 @@ export interface ResolvedRunOptions {
   dryRun: boolean;
   preview: boolean;
   verbose: boolean;
+  /** Run each bench task in its own child process (crash isolation). */
+  isolate?: boolean;
 }
 
 /**
@@ -113,7 +117,7 @@ const SUPPORTED_BENCHMARKS = new Set([
 
 const LEGACY_ONLY_BENCHMARKS = new Set(["gaia", "osworld"]);
 
-const BOOLEAN_FLAGS = new Set(["api", "dry-run", "preview", "legacy"]);
+const BOOLEAN_FLAGS = new Set(["api", "dry-run", "preview", "legacy", "isolate"]);
 const VALUE_FLAGS = new Set([
   "trials",
   "concurrency",
@@ -230,6 +234,7 @@ export function parseRunArgs(tokens: string[]): RunFlags {
         else if (name === "dry-run") flags.dryRun = true;
         else if (name === "preview") flags.preview = true;
         else if (name === "legacy") flags.legacy = true;
+        else if (name === "isolate") flags.isolate = true;
         i++;
         continue;
       }
@@ -491,6 +496,7 @@ export function resolveRunOptions(
     dryRun: flags.dryRun ?? false,
     preview: flags.preview ?? false,
     verbose: defaults.verbose ?? false,
+    isolate: flags.isolate ?? false,
   };
 }
 

--- a/packages/evals/tui/commands/run.ts
+++ b/packages/evals/tui/commands/run.ts
@@ -291,6 +291,7 @@ export async function runCommand(
           agentModes: options.agentModes,
           harness: options.harness,
           sdk: options.sdk,
+          isolateTasks: options.isolate,
           categoryFilter,
           datasetFilter: options.datasetFilter,
           coreToolSurface: options.coreToolSurface as ToolSurface | undefined,


### PR DESCRIPTION
Nondeterministic-suite stack 4/4. Supersedes #2403.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new --isolate mode that runs each bench task in its own child process, so a hard crash (OOM, hung SDK, unhandled rejection) only fails that task and still records a Braintrust row. This improves run reliability for STG-2671 by preventing suite-wide aborts and preserving traceability across the process boundary.

- New Features
  - Added --isolate flag to run bench tasks in child processes; core tasks are unchanged.
  - Child executes the same bench path and returns a sentinel-framed JSON result; all other stdout/stderr passes through.
  - Parent synthesizes a failure on crash/timeout/abort and includes the stderr tail; default timeout 15m (override with EVAL_ISOLATE_TIMEOUT_MS).
  - Propagates Braintrust tracing: parent exports the row span; child re-enters it and emits an isolated:<task> span before flushing.
  - Sends only the serializable option subset across the boundary, including coreToolSurface/coreStartupProfile, so tool-surface selection remains correct.

<sup>Written for commit 8684a18cf82945a161a2c6f048c51051d737de58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

