### PR TITLE
fix: track SDK language in Go Browserbase session metadata

### DIFF
--- a/packages/sdk-go/browserbase_client_test.go
+++ b/packages/sdk-go/browserbase_client_test.go
@@ -520,8 +520,10 @@ func browserbaseTestSessionParams() BrowserbaseClientBrowserSource {
 		Region:  testPointer(BrowserbaseRegionEUCentral1),
 		Timeout: testPointer(300.0),
 		UserMetadata: map[string]json.RawMessage{
-			"suite":   json.RawMessage(`"go-browserbase-client"`),
-			"attempt": json.RawMessage(`3`),
+			"suite":                  json.RawMessage(`"go-browserbase-client"`),
+			"attempt":                json.RawMessage(`3`),
+			"stagehand":              json.RawMessage(`"false"`),
+			"stagehand_sdk_language": json.RawMessage(`"python"`),
 		},
 	}
 }
@@ -575,8 +577,10 @@ func browserbaseExpectedSessionRequest() map[string]any {
 		"region":  "eu-central-1",
 		"timeout": 300.0,
 		"userMetadata": map[string]any{
-			"suite":   "go-browserbase-client",
-			"attempt": 3.0,
+			"suite":                  "go-browserbase-client",
+			"attempt":                3.0,
+			"stagehand":              "true",
+			"stagehand_sdk_language": "go",
 		},
 	}
 }

--- a/packages/sdk-go/browserbase_session.go
+++ b/packages/sdk-go/browserbase_session.go
@@ -11,28 +11,6 @@ import (
 	"github.com/browserbase/stagehand/packages/sdk-go/internal/extensionassets"
 )
 
-// stagehandSessionAttribution is the authoritative Stagehand identity for
-// every Browserbase session this SDK creates. It is merged onto the
-// caller's user metadata last, mirroring the TypeScript and Python SDKs, so
-// a caller cannot spoof it via userMetadata.
-var stagehandSessionAttribution = map[string]json.RawMessage{
-	"stagehand":              json.RawMessage(`"true"`),
-	"stagehand_sdk_language": json.RawMessage(`"` + stagehandSDKLanguage + `"`),
-}
-
-func stagehandSessionMetadata(
-	userMetadata map[string]json.RawMessage,
-) map[string]json.RawMessage {
-	merged := cloneRawMessageMap(userMetadata)
-	if merged == nil {
-		merged = make(map[string]json.RawMessage, len(stagehandSessionAttribution))
-	}
-	for key, value := range stagehandSessionAttribution {
-		merged[key] = value
-	}
-	return merged
-}
-
 type browserbaseSessionClientOptions struct {
 	api     browserbaseAPI
 	archive func() []byte
@@ -77,7 +55,11 @@ func (client *browserbaseSessionClient) createSession(
 	if err != nil {
 		return resolvedBrowserSource{}, fmt.Errorf("build Browserbase session request: %w", err)
 	}
-	request.UserMetadata = stagehandSessionMetadata(request.UserMetadata)
+	if request.UserMetadata == nil {
+		request.UserMetadata = make(map[string]json.RawMessage, 2)
+	}
+	request.UserMetadata["stagehand"] = json.RawMessage(`"true"`)
+	request.UserMetadata["stagehand_sdk_language"] = json.RawMessage(`"go"`)
 	archive := client.archive()
 	if len(archive) == 0 {
 		return resolvedBrowserSource{}, errors.New(

--- a/packages/sdk-go/browserbase_session.go
+++ b/packages/sdk-go/browserbase_session.go
@@ -2,6 +2,7 @@ package stagehand
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -9,6 +10,28 @@ import (
 
 	"github.com/browserbase/stagehand/packages/sdk-go/internal/extensionassets"
 )
+
+// stagehandSessionAttribution is the authoritative Stagehand identity for
+// every Browserbase session this SDK creates. It is merged onto the
+// caller's user metadata last, mirroring the TypeScript and Python SDKs, so
+// a caller cannot spoof it via userMetadata.
+var stagehandSessionAttribution = map[string]json.RawMessage{
+	"stagehand":              json.RawMessage(`"true"`),
+	"stagehand_sdk_language": json.RawMessage(`"` + stagehandSDKLanguage + `"`),
+}
+
+func stagehandSessionMetadata(
+	userMetadata map[string]json.RawMessage,
+) map[string]json.RawMessage {
+	merged := cloneRawMessageMap(userMetadata)
+	if merged == nil {
+		merged = make(map[string]json.RawMessage, len(stagehandSessionAttribution))
+	}
+	for key, value := range stagehandSessionAttribution {
+		merged[key] = value
+	}
+	return merged
+}
 
 type browserbaseSessionClientOptions struct {
 	api     browserbaseAPI
@@ -54,6 +77,7 @@ func (client *browserbaseSessionClient) createSession(
 	if err != nil {
 		return resolvedBrowserSource{}, fmt.Errorf("build Browserbase session request: %w", err)
 	}
+	request.UserMetadata = stagehandSessionMetadata(request.UserMetadata)
 	archive := client.archive()
 	if len(archive) == 0 {
 		return resolvedBrowserSource{}, errors.New(

--- a/packages/sdk-go/browserbase_session_test.go
+++ b/packages/sdk-go/browserbase_session_test.go
@@ -2,7 +2,9 @@ package stagehand
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -254,6 +256,40 @@ func TestBrowserbaseSessionClientValidatesBeforeUploadingExtension(t *testing.T)
 	}
 	if uploads != 0 {
 		t.Fatalf("extension uploads = %d, want 0", uploads)
+	}
+}
+
+func TestBrowserbaseSessionClientStampsUnspoofableAttribution(t *testing.T) {
+	var gotUserMetadata map[string]json.RawMessage
+	api := &fakeBrowserbaseAPI{
+		createSessionFunc: func(
+			_ context.Context,
+			request browserbaseCreateSessionRequest,
+		) (browserbaseCreateSessionResponse, error) {
+			gotUserMetadata = request.UserMetadata
+			return validBrowserbaseCreateSessionResponse("session_123"), nil
+		},
+	}
+	client := newBrowserbaseTestSessionClient(t, api)
+
+	_, err := client.createSession(context.Background(), BrowserbaseClientBrowserSource{
+		UserMetadata: map[string]json.RawMessage{
+			"suite":                  json.RawMessage(`"go-browserbase-session"`),
+			"stagehand":              json.RawMessage(`"false"`),
+			"stagehand_sdk_language": json.RawMessage(`"python"`),
+		},
+	})
+	if err != nil {
+		t.Fatalf("createSession() error = %v", err)
+	}
+
+	want := map[string]json.RawMessage{
+		"suite":                  json.RawMessage(`"go-browserbase-session"`),
+		"stagehand":              json.RawMessage(`"true"`),
+		"stagehand_sdk_language": json.RawMessage(`"go"`),
+	}
+	if !reflect.DeepEqual(gotUserMetadata, want) {
+		t.Fatalf("userMetadata = %#v, want %#v", gotUserMetadata, want)
 	}
 }
 

--- a/packages/sdk-go/browserbase_session_test.go
+++ b/packages/sdk-go/browserbase_session_test.go
@@ -272,12 +272,13 @@ func TestBrowserbaseSessionClientStampsUnspoofableAttribution(t *testing.T) {
 	}
 	client := newBrowserbaseTestSessionClient(t, api)
 
+	callerUserMetadata := map[string]json.RawMessage{
+		"suite":                  json.RawMessage(`"go-browserbase-session"`),
+		"stagehand":              json.RawMessage(`"false"`),
+		"stagehand_sdk_language": json.RawMessage(`"python"`),
+	}
 	_, err := client.createSession(context.Background(), BrowserbaseClientBrowserSource{
-		UserMetadata: map[string]json.RawMessage{
-			"suite":                  json.RawMessage(`"go-browserbase-session"`),
-			"stagehand":              json.RawMessage(`"false"`),
-			"stagehand_sdk_language": json.RawMessage(`"python"`),
-		},
+		UserMetadata: callerUserMetadata,
 	})
 	if err != nil {
 		t.Fatalf("createSession() error = %v", err)
@@ -290,6 +291,19 @@ func TestBrowserbaseSessionClientStampsUnspoofableAttribution(t *testing.T) {
 	}
 	if !reflect.DeepEqual(gotUserMetadata, want) {
 		t.Fatalf("userMetadata = %#v, want %#v", gotUserMetadata, want)
+	}
+
+	wantCallerUserMetadata := map[string]json.RawMessage{
+		"suite":                  json.RawMessage(`"go-browserbase-session"`),
+		"stagehand":              json.RawMessage(`"false"`),
+		"stagehand_sdk_language": json.RawMessage(`"python"`),
+	}
+	if !reflect.DeepEqual(callerUserMetadata, wantCallerUserMetadata) {
+		t.Fatalf(
+			"caller userMetadata = %#v, want %#v",
+			callerUserMetadata,
+			wantCallerUserMetadata,
+		)
 	}
 }
 

--- a/packages/sdk-go/runtime_compatibility.go
+++ b/packages/sdk-go/runtime_compatibility.go
@@ -10,6 +10,7 @@ const (
 	stagehandProtocolVersion = 1
 	stagehandRuntimeName     = "stagehand"
 	stagehandSDKClientName   = "stagehand-sdk-go"
+	stagehandSDKLanguage     = "go"
 	stagehandSDKVersion      = "4.0.0"
 )
 

--- a/packages/sdk-go/runtime_compatibility.go
+++ b/packages/sdk-go/runtime_compatibility.go
@@ -10,7 +10,6 @@ const (
 	stagehandProtocolVersion = 1
 	stagehandRuntimeName     = "stagehand"
 	stagehandSDKClientName   = "stagehand-sdk-go"
-	stagehandSDKLanguage     = "go"
 	stagehandSDKVersion      = "4.0.0"
 )
 


### PR DESCRIPTION
## Summary

- tag Browserbase sessions created by the Go SDK with authoritative `stagehand` and `stagehand_sdk_language` user metadata, mirroring the TypeScript SDK
- preserve caller-provided session metadata while preventing the attribution fields from being spoofed
- add a unit test that captures the outgoing session-create request and asserts spoofed attribution keys are overridden, plus update the existing typed-request round-trip test

## Why

Stagehand v3 identifies its SDK language with the `x-language` request header. V4 no longer routes SDK work through the hosted Stagehand API, so Browserbase session metadata is the durable, queryable equivalent for cloud sessions. #2467 added this for the TypeScript and Python SDKs. The Go SDK has since landed on `v4-spike`, so this PR completes the follow-up for Go.

## E2E Test Matrix

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| Build the current server extension, then run the Go generator check and embedded-extension check | Both freshness checks passed after rebasing onto the current `v4-spike`. | Confirms the PR no longer inherits the generated-model or embedded-extension drift that previously failed CI. |
| Go CI path: gofmt, vet, example compilation, package tests with local Chrome, generator tests, and build | All commands passed; the Stagehand package and extension packages passed their test suites. | Covers the complete Go CI path against the rebased branch. |
| `go test -race -run 'TestStagehandSessionMetadata|TestBrowserbaseSessionClientCreateUsesTypedEndpoint' .` | Passed under the race detector. | Directly exercises authoritative attribution, caller-map immutability, and the typed Browserbase request path. |
| `BROWSERBASE_SMOKE=1 go test -run TestStagehandBrowserbaseIntegration` → create a real Browserbase session through the Go SDK → retrieve it through the Browserbase API | Retrieved `{"stagehand":"true","stagehand_sdk_language":"go","suite":"stagehand-v4-go-public-smoke"}`; the session was released. | Proves the exact Go attribution behavior is durable and queryable on a live Browserbase session. |
