### PR TITLE
Complete straightforward cross-SDK v4 parity work

### DIFF
--- a/packages/docs/v4/configuration/logging.mdx
+++ b/packages/docs/v4/configuration/logging.mdx
@@ -39,9 +39,8 @@ to a callback.
 
 ## Forward structured logs
 
-Use `onLog` in TypeScript or `on_log` in Python to send each displayed log to a file or your
-application logger. The callback is additive: Stagehand continues to write its normal terminal
-output.
+Use `onLog` to send each displayed log to a file or your application logger. The callback is
+additive: Stagehand continues to write its normal terminal output.
 
 ```typescript
 import { createWriteStream } from "node:fs";
@@ -88,9 +87,8 @@ to a callback.
 
 ## Forward structured logs
 
-Use `onLog` in TypeScript or `on_log` in Python to send each displayed log to a file or your
-application logger. The callback is additive: Stagehand continues to write its normal terminal
-output.
+Use `on_log` to send each displayed log to a file or your application logger. The callback is
+additive: Stagehand continues to write its normal terminal output.
 
 ```python
 from stagehand import Stagehand, StagehandClientLoggingConfig
@@ -106,6 +104,55 @@ stagehand = Stagehand(
         on_log=lambda log: print(log.model_dump_json(), file=log_file),
     ),
 )
+```
+
+</View>
+
+<View title="Go" icon="go">
+
+```go
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	// ...
+	Logging: &stagehand.StagehandClientLoggingConfig{
+		Level:  stagehand.StagehandClientLogLevelInfo,
+		Format: stagehand.StagehandClientLogFormatPretty,
+	},
+})
+```
+
+| Option   | Default  | Values                                  |
+| -------- | -------- | --------------------------------------- |
+| `Level`  | `info`   | `debug`, `info`, `warn`, `error`, `off` |
+| `Format` | `pretty` | `pretty`, `json`                        |
+
+`Format` only changes the built-in terminal output. It does not change structured logs passed
+to a callback.
+
+## Forward structured logs
+
+Use `OnLog` to send each displayed log to a file or your application logger. The callback is
+additive: Stagehand continues to write its normal terminal output.
+
+```go
+logFile, err := os.OpenFile(
+	"stagehand.jsonl",
+	os.O_APPEND|os.O_CREATE|os.O_WRONLY,
+	0o600,
+)
+if err != nil {
+	return err
+}
+
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	// ...
+	Logging: &stagehand.StagehandClientLoggingConfig{
+		Level:  stagehand.StagehandClientLogLevelInfo,
+		Format: stagehand.StagehandClientLogFormatPretty,
+		OnLog: func(log stagehand.StagehandLog) {
+			_ = json.NewEncoder(logFile).Encode(log)
+		},
+	},
+})
 ```
 
 </View>

--- a/packages/docs/v4/configuration/logging.mdx
+++ b/packages/docs/v4/configuration/logging.mdx
@@ -134,25 +134,44 @@ Use `OnLog` to send each displayed log to a file or your application logger. The
 additive: Stagehand continues to write its normal terminal output.
 
 ```go
-logFile, err := os.OpenFile(
-	"stagehand.jsonl",
-	os.O_APPEND|os.O_CREATE|os.O_WRONLY,
-	0o600,
-)
-if err != nil {
-	return err
-}
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
 
-client := stagehand.New(stagehand.StagehandClientInitParams{
-	// ...
-	Logging: &stagehand.StagehandClientLoggingConfig{
-		Level:  stagehand.StagehandClientLogLevelInfo,
-		Format: stagehand.StagehandClientLogFormatPretty,
-		OnLog: func(log stagehand.StagehandLog) {
-			_ = json.NewEncoder(logFile).Encode(log)
+	stagehand "github.com/browserbase/stagehand/packages/sdk-go"
+)
+
+func run(ctx context.Context) (err error) {
+	logFile, err := os.OpenFile(
+		"stagehand.jsonl",
+		os.O_APPEND|os.O_CREATE|os.O_WRONLY,
+		0o600,
+	)
+	if err != nil {
+		return err
+	}
+	defer func() { err = errors.Join(err, logFile.Close()) }()
+
+	client := stagehand.New(stagehand.StagehandClientInitParams{
+		// ...
+		Logging: &stagehand.StagehandClientLoggingConfig{
+			Level:  stagehand.StagehandClientLogLevelInfo,
+			Format: stagehand.StagehandClientLogFormatPretty,
+			OnLog: func(log stagehand.StagehandLog) {
+				_ = json.NewEncoder(logFile).Encode(log)
+			},
 		},
-	},
-})
+	})
+	if err := client.Init(ctx); err != nil {
+		return err
+	}
+	defer func() { err = errors.Join(err, client.Close(ctx)) }()
+
+	// Use the initialized client here.
+	return nil
+}
 ```
 
 </View>

--- a/packages/sdk-go/behavior_regression_test.go
+++ b/packages/sdk-go/behavior_regression_test.go
@@ -1,0 +1,257 @@
+package stagehand
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestSimpleGettersMapGeneratedResults(t *testing.T) {
+	t.Parallel()
+
+	domainPolicy := &DomainPolicy{
+		AllowedDomains: []string{"example.com"},
+		BlockedDomains: []string{"blocked.example"},
+	}
+	descriptor := LocatorDescriptor{
+		PageID:   "page-1",
+		Selector: "#target",
+		Nth:      testPointer(2),
+	}
+	tests := []struct {
+		name       string
+		method     string
+		response   any
+		want       any
+		wantParams any
+		invoke     func(*recordingProtocolClient) (any, error)
+	}{
+		{
+			name:       "browser context domain policy",
+			method:     "context.get_domain_policy",
+			response:   domainPolicy,
+			want:       domainPolicy,
+			wantParams: EmptyParams{},
+			invoke: func(rpc *recordingProtocolClient) (any, error) {
+				return (&BrowserContext{rpc: rpc}).GetDomainPolicy(context.Background())
+			},
+		},
+		{
+			name:       "page URL",
+			method:     "page.url",
+			response:   PageURLResult("https://example.com/path"),
+			want:       "https://example.com/path",
+			wantParams: PageIDParams{PageID: "page-1"},
+			invoke: func(rpc *recordingProtocolClient) (any, error) {
+				return (&Page{rpc: rpc, ref: PageRef{PageID: "page-1"}}).URL(context.Background())
+			},
+		},
+		{
+			name:       "page title",
+			method:     "page.title",
+			response:   PageTitleResult("Example title"),
+			want:       "Example title",
+			wantParams: PageIDParams{PageID: "page-1"},
+			invoke: func(rpc *recordingProtocolClient) (any, error) {
+				return (&Page{rpc: rpc, ref: PageRef{PageID: "page-1"}}).Title(context.Background())
+			},
+		},
+		{
+			name:       "locator checked state",
+			method:     "locator.is_checked",
+			response:   LocatorIsCheckedResult(true),
+			want:       true,
+			wantParams: descriptor,
+			invoke: func(rpc *recordingProtocolClient) (any, error) {
+				return (&PageLocator{rpc: rpc, descriptor: descriptor}).IsChecked(context.Background())
+			},
+		},
+		{
+			name:       "locator input value",
+			method:     "locator.input_value",
+			response:   LocatorInputValueResult("typed value"),
+			want:       "typed value",
+			wantParams: descriptor,
+			invoke: func(rpc *recordingProtocolClient) (any, error) {
+				return (&PageLocator{rpc: rpc, descriptor: descriptor}).InputValue(context.Background())
+			},
+		},
+		{
+			name:       "locator visibility",
+			method:     "locator.is_visible",
+			response:   LocatorIsVisibleResult(true),
+			want:       true,
+			wantParams: descriptor,
+			invoke: func(rpc *recordingProtocolClient) (any, error) {
+				return (&PageLocator{rpc: rpc, descriptor: descriptor}).IsVisible(context.Background())
+			},
+		},
+		{
+			name:       "locator inner text",
+			method:     "locator.inner_text",
+			response:   LocatorInnerTextResult("rendered text"),
+			want:       "rendered text",
+			wantParams: descriptor,
+			invoke: func(rpc *recordingProtocolClient) (any, error) {
+				return (&PageLocator{rpc: rpc, descriptor: descriptor}).InnerText(context.Background())
+			},
+		},
+		{
+			name:       "locator inner HTML",
+			method:     "locator.inner_html",
+			response:   LocatorInnerHTMLResult("<strong>content</strong>"),
+			want:       "<strong>content</strong>",
+			wantParams: descriptor,
+			invoke: func(rpc *recordingProtocolClient) (any, error) {
+				return (&PageLocator{rpc: rpc, descriptor: descriptor}).InnerHTML(context.Background())
+			},
+		},
+		{
+			name:       "locator text content",
+			method:     "locator.text_content",
+			response:   LocatorTextContentResult("raw text"),
+			want:       "raw text",
+			wantParams: descriptor,
+			invoke: func(rpc *recordingProtocolClient) (any, error) {
+				return (&PageLocator{rpc: rpc, descriptor: descriptor}).TextContent(context.Background())
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			rpc := &recordingProtocolClient{responses: map[string]any{
+				test.method: test.response,
+			}}
+			got, err := test.invoke(rpc)
+			if err != nil {
+				t.Fatalf("getter error = %v", err)
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("getter result = %#v, want %#v", got, test.want)
+			}
+			if len(rpc.calls) != 1 {
+				t.Fatalf("RPC calls = %#v, want one call", rpc.calls)
+			}
+			if rpc.calls[0].method != test.method {
+				t.Fatalf("RPC method = %q, want %q", rpc.calls[0].method, test.method)
+			}
+			if !reflect.DeepEqual(rpc.calls[0].params, test.wantParams) {
+				t.Fatalf("RPC params = %#v, want %#v", rpc.calls[0].params, test.wantParams)
+			}
+		})
+	}
+}
+
+func TestStagehandOperationsPreserveResultEnvelopes(t *testing.T) {
+	t.Parallel()
+
+	page := &Page{ref: PageRef{PageID: "page-1"}}
+	tests := []struct {
+		name     string
+		method   string
+		response any
+		invoke   func(*Stagehand) (any, error)
+	}{
+		{
+			name:   "act",
+			method: "stagehand.act",
+			response: ActResult{
+				Data: ActResultData{
+					Success:           true,
+					Message:           "clicked",
+					ActionDescription: "click submit",
+					Actions:           []Action{},
+				},
+				Metadata: StagehandResultMetadata{
+					ActionID:    testPointer("action-act"),
+					CacheStatus: testPointer(CacheStatusMISS),
+				},
+			},
+			invoke: func(client *Stagehand) (any, error) {
+				return client.Act(
+					context.Background(),
+					"click submit",
+					&StagehandClientActOptions{Page: page},
+				)
+			},
+		},
+		{
+			name:   "observe",
+			method: "stagehand.observe",
+			response: ObserveResult{
+				Data: []Action{{
+					Description: "Submit button",
+					Selector:    "#submit",
+				}},
+				Metadata: StagehandResultMetadata{
+					ActionID:    testPointer("action-observe"),
+					CacheStatus: testPointer(CacheStatusHIT),
+				},
+			},
+			invoke: func(client *Stagehand) (any, error) {
+				instruction := "find submit"
+				return client.Observe(
+					context.Background(),
+					&instruction,
+					&StagehandClientObserveOptions{Page: page},
+				)
+			},
+		},
+		{
+			name:   "extract",
+			method: "stagehand.extract",
+			response: ExtractResult{
+				Data: json.RawMessage(`{"heading":"Example"}`),
+				Metadata: StagehandResultMetadata{
+					ActionID:    testPointer("action-extract"),
+					CacheStatus: testPointer(CacheStatusMISS),
+				},
+			},
+			invoke: func(client *Stagehand) (any, error) {
+				screenshot := true
+				return client.Extract(
+					context.Background(),
+					"extract heading",
+					json.RawMessage(`{"type":"object"}`),
+					&StagehandClientExtractOptions{
+						ExtractOptions: ExtractOptions{Screenshot: &screenshot},
+						Page:           page,
+					},
+				)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			rpc := &recordingProtocolClient{responses: map[string]any{
+				test.method: test.response,
+			}}
+			page.rpc = rpc
+			client := &Stagehand{initialized: true, rpc: rpc}
+			got, err := test.invoke(client)
+			if err != nil {
+				t.Fatalf("%s error = %v", test.name, err)
+			}
+			if !reflect.DeepEqual(got, test.response) {
+				t.Fatalf("%s result = %#v, want full envelope %#v", test.name, got, test.response)
+			}
+			if len(rpc.calls) != 1 || rpc.calls[0].method != test.method {
+				t.Fatalf("%s RPC calls = %#v", test.name, rpc.calls)
+			}
+
+			if test.method != "stagehand.extract" {
+				return
+			}
+			params, ok := rpc.calls[0].params.(StagehandExtractParams)
+			if !ok || params.Options == nil || params.Options.Screenshot == nil ||
+				!*params.Options.Screenshot {
+				t.Fatalf("Extract() screenshot params = %#v", rpc.calls[0].params)
+			}
+		})
+	}
+}

--- a/packages/sdk-go/browser_accessor_test.go
+++ b/packages/sdk-go/browser_accessor_test.go
@@ -1,0 +1,82 @@
+package stagehand
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestBrowserRequiresInitialization(t *testing.T) {
+	t.Parallel()
+
+	client := New(StagehandClientInitParams{})
+	if _, err := client.Browser(); !errors.Is(err, ErrNotInitialized) {
+		t.Fatalf("Browser() error = %v, want ErrNotInitialized", err)
+	}
+}
+
+func TestBrowserReturnsDetachedResolvedSourceSnapshot(t *testing.T) {
+	t.Parallel()
+
+	rpc := &recordingProtocolClient{responses: map[string]any{
+		"runtime.configure": RuntimeConfigureResult{Configured: true},
+		"stagehand.init":    StagehandInitResult{Initialized: true},
+	}}
+	client := newStagehandWithClient(StagehandClientInitParams{}, rpc)
+	client.adapters.resolveBrowserSource = func(
+		context.Context,
+		StagehandClientInitParams,
+	) (resolvedBrowserSource, error) {
+		return resolvedBrowserSource{
+			cdpURL: "wss://connect.example/session",
+			cdpHeaders: http.Header{
+				"Authorization": []string{"Bearer secret"},
+			},
+			browserbaseSessionID: "session-123",
+			extensionDir:         "/private/sdk-extension",
+			preloadedExtension:   true,
+			connectTimeout:       15 * time.Second,
+			keepAlive:            true,
+			close:                func(context.Context) error { return nil },
+			cleanup:              func() error { return nil },
+		}, nil
+	}
+
+	if err := client.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	browser, err := client.Browser()
+	if err != nil {
+		t.Fatalf("Browser() error = %v", err)
+	}
+	if browser.CDPURL != "wss://connect.example/session" ||
+		browser.CDPHeaders["Authorization"] != "Bearer secret" ||
+		browser.BrowserbaseSessionID != "session-123" ||
+		!browser.PreloadedExtension ||
+		browser.ConnectTimeout != 15*time.Second ||
+		!browser.KeepAlive {
+		t.Fatalf("Browser() = %#v", browser)
+	}
+
+	browser.CDPHeaders["Authorization"] = "mutated"
+	next, err := client.Browser()
+	if err != nil {
+		t.Fatalf("second Browser() error = %v", err)
+	}
+	if next.CDPHeaders["Authorization"] != "Bearer secret" {
+		t.Fatalf("Browser() exposed mutable SDK state: %#v", next.CDPHeaders)
+	}
+
+	publicType := reflect.TypeOf(browser)
+	for _, forbiddenField := range []string{"ExtensionDir", "Cleanup", "Close"} {
+		if _, exposed := publicType.FieldByName(forbiddenField); exposed {
+			t.Errorf("ResolvedBrowserSource exposes forbidden field %s", forbiddenField)
+		}
+	}
+	if _, exposed := publicType.MethodByName("Close"); exposed {
+		t.Error("ResolvedBrowserSource exposes lifecycle method Close")
+	}
+}

--- a/packages/sdk-go/browser_source.go
+++ b/packages/sdk-go/browser_source.go
@@ -206,6 +206,7 @@ func connectResolvedBrowser(
 	ctx context.Context,
 	browser resolvedBrowserSource,
 	telemetry TelemetryConfig,
+	logLevel RuntimeConfigureParamsLogLevel,
 ) (protocolClient, error) {
 	return connectRPCClient(ctx, cdpClientOptions{
 		cdpURL:                   browser.cdpURL,
@@ -214,5 +215,5 @@ func connectResolvedBrowser(
 		preloadedExtension:       browser.preloadedExtension,
 		serviceWorkerURLIncludes: "service-worker.js",
 		connectTimeout:           browser.connectTimeout,
-	}, telemetry)
+	}, telemetry, logLevel)
 }

--- a/packages/sdk-go/cdp_client.go
+++ b/packages/sdk-go/cdp_client.go
@@ -195,6 +195,7 @@ func connectRPCClient(
 	ctx context.Context,
 	options cdpClientOptions,
 	telemetry TelemetryConfig,
+	logLevel RuntimeConfigureParamsLogLevel,
 ) (*rpcClient, error) {
 	options = normalizeCDPClientOptions(options)
 	cdp, err := connectCDPClient(ctx, options)
@@ -210,6 +211,7 @@ func connectRPCClient(
 		rpc,
 		resolvedBrowserSource{cdpURL: cdp.webSocketDebuggerURL},
 		telemetry,
+		logLevel,
 	); err != nil {
 		return nil, errors.Join(err, rpc.close())
 	}

--- a/packages/sdk-go/cdp_client_test.go
+++ b/packages/sdk-go/cdp_client_test.go
@@ -746,6 +746,7 @@ func TestCDPClientStagehandExtensionIntegration(t *testing.T) {
 			Endpoint: "https://example.com/v1/traces",
 			Headers:  TelemetryTracesHeaders{},
 		}},
+		RuntimeConfigureParamsLogLevelInfo,
 	)
 	if err != nil {
 		t.Fatalf("connectRPCClient() error = %v", err)

--- a/packages/sdk-go/client.go
+++ b/packages/sdk-go/client.go
@@ -42,6 +42,36 @@ type resolvedBrowserSource struct {
 	cleanup              func() error
 }
 
+// ResolvedBrowserSource is a detached snapshot of the browser connection
+// selected during Init. It intentionally excludes SDK-owned lifecycle and
+// temporary-extension state.
+type ResolvedBrowserSource struct {
+	CDPURL               string
+	CDPHeaders           map[string]string
+	BrowserbaseSessionID string
+	PreloadedExtension   bool
+	ConnectTimeout       time.Duration
+	KeepAlive            bool
+}
+
+func (browser resolvedBrowserSource) snapshot() ResolvedBrowserSource {
+	var headers map[string]string
+	if len(browser.cdpHeaders) > 0 {
+		headers = make(map[string]string, len(browser.cdpHeaders))
+		for name := range browser.cdpHeaders {
+			headers[name] = browser.cdpHeaders.Get(name)
+		}
+	}
+	return ResolvedBrowserSource{
+		CDPURL:               browser.cdpURL,
+		CDPHeaders:           headers,
+		BrowserbaseSessionID: browser.browserbaseSessionID,
+		PreloadedExtension:   browser.preloadedExtension,
+		ConnectTimeout:       browser.connectTimeout,
+		KeepAlive:            browser.keepAlive,
+	}
+}
+
 type clientAdapters struct {
 	resolveBrowserSource func(context.Context, StagehandClientInitParams) (resolvedBrowserSource, error)
 	connectProtocol      func(

--- a/packages/sdk-go/client.go
+++ b/packages/sdk-go/client.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"net/http"
 	"time"
 )
@@ -46,6 +48,7 @@ type clientAdapters struct {
 		context.Context,
 		resolvedBrowserSource,
 		TelemetryConfig,
+		RuntimeConfigureParamsLogLevel,
 	) (protocolClient, error)
 }
 
@@ -63,6 +66,7 @@ func configureProtocol(
 	rpc protocolClient,
 	browser resolvedBrowserSource,
 	telemetry TelemetryConfig,
+	logLevel RuntimeConfigureParamsLogLevel,
 ) error {
 	protocolVersion := stagehandProtocolVersion
 	params := RuntimeConfigureParams{
@@ -72,8 +76,69 @@ func configureProtocol(
 			Version: stagehandSDKVersion,
 		},
 		CDPURL:    browser.cdpURL,
+		LogLevel:  logLevel,
 		Telemetry: telemetry,
 	}
 	var result RuntimeConfigureResult
 	return rpc.call(ctx, "runtime.configure", params, &result)
+}
+
+type resolvedStagehandClientLoggingConfig struct {
+	level  StagehandClientLogLevel
+	format StagehandClientLogFormat
+	onLog  func(StagehandLog)
+	writer io.Writer
+}
+
+func resolveLoggingConfig(
+	config *StagehandClientLoggingConfig,
+	writer io.Writer,
+) (resolvedStagehandClientLoggingConfig, error) {
+	resolved := resolvedStagehandClientLoggingConfig{
+		level:  StagehandClientLogLevelInfo,
+		format: StagehandClientLogFormatPretty,
+		writer: writer,
+	}
+	if config != nil {
+		if config.Level != "" {
+			resolved.level = config.Level
+		}
+		if config.Format != "" {
+			resolved.format = config.Format
+		}
+		resolved.onLog = config.OnLog
+	}
+	if !validClientLogLevel(resolved.level) {
+		return resolvedStagehandClientLoggingConfig{}, fmt.Errorf(
+			"stagehand: invalid logging level %q",
+			resolved.level,
+		)
+	}
+	if resolved.format != StagehandClientLogFormatPretty &&
+		resolved.format != StagehandClientLogFormatJSON {
+		return resolvedStagehandClientLoggingConfig{}, fmt.Errorf(
+			"stagehand: invalid logging format %q",
+			resolved.format,
+		)
+	}
+	return resolved, nil
+}
+
+func validClientLogLevel(level StagehandClientLogLevel) bool {
+	switch level {
+	case StagehandClientLogLevelOff,
+		StagehandClientLogLevelError,
+		StagehandClientLogLevelWarn,
+		StagehandClientLogLevelInfo,
+		StagehandClientLogLevelDebug:
+		return true
+	default:
+		return false
+	}
+}
+
+func runtimeLogLevel(
+	level StagehandClientLogLevel,
+) RuntimeConfigureParamsLogLevel {
+	return RuntimeConfigureParamsLogLevel(level)
 }

--- a/packages/sdk-go/client_options.go
+++ b/packages/sdk-go/client_options.go
@@ -84,8 +84,29 @@ type LLMGenerateFunc func(context.Context, LLMGenerateParams) (LLMGenerateResult
 
 // StagehandClientLoggingConfig controls client-side handling of runtime log notifications.
 type StagehandClientLoggingConfig struct {
-	OnLog func(StagehandLog)
+	Level  StagehandClientLogLevel
+	Format StagehandClientLogFormat
+	OnLog  func(StagehandLog)
 }
+
+// StagehandClientLogLevel controls which runtime log notifications the SDK emits.
+type StagehandClientLogLevel string
+
+const (
+	StagehandClientLogLevelOff   StagehandClientLogLevel = "off"
+	StagehandClientLogLevelError StagehandClientLogLevel = "error"
+	StagehandClientLogLevelWarn  StagehandClientLogLevel = "warn"
+	StagehandClientLogLevelInfo  StagehandClientLogLevel = "info"
+	StagehandClientLogLevelDebug StagehandClientLogLevel = "debug"
+)
+
+// StagehandClientLogFormat controls terminal rendering of runtime logs.
+type StagehandClientLogFormat string
+
+const (
+	StagehandClientLogFormatPretty StagehandClientLogFormat = "pretty"
+	StagehandClientLogFormatJSON   StagehandClientLogFormat = "json"
+)
 
 // StagehandClientInitParams extends the generated worker init shape with the
 // two client-only unions: browser setup and an optional local LLM callback.

--- a/packages/sdk-go/examples/custom-logging.go
+++ b/packages/sdk-go/examples/custom-logging.go
@@ -36,6 +36,8 @@ func run(ctx context.Context) (err error) {
 		Browser: stagehand.LocalBrowserSource{Headless: true},
 		Model:   &model,
 		Logging: &stagehand.StagehandClientLoggingConfig{
+			Level:  stagehand.StagehandClientLogLevelInfo,
+			Format: stagehand.StagehandClientLogFormatPretty,
 			OnLog: func(entry stagehand.StagehandLog) {
 				_ = json.NewEncoder(logFile).Encode(entry)
 			},

--- a/packages/sdk-go/flexible_objects.go
+++ b/packages/sdk-go/flexible_objects.go
@@ -1,25 +1,21 @@
 package stagehand
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 )
 
-// LLMMessageGenerateResult is a text-format result. Unknown provider-specific
-// fields are preserved in AdditionalProperties.
+// LLMMessageGenerateResult is a strict text-format result.
 type LLMMessageGenerateResult struct {
-	Role                 LLMRole                    `json:"role"`
-	Content              LLMMessageContent          `json:"content"`
-	StopReason           *string                    `json:"stop_reason,omitempty"`
-	Usage                *LLMUsage                  `json:"usage,omitempty"`
-	OutputFormat         string                     `json:"output_format"`
-	AdditionalProperties map[string]json.RawMessage `json:"-"`
+	Role         LLMRole           `json:"role"`
+	Content      LLMMessageContent `json:"content"`
+	StopReason   *string           `json:"stop_reason,omitempty"`
+	Usage        *LLMUsage         `json:"usage,omitempty"`
+	OutputFormat string            `json:"output_format"`
 }
-
-var llmMessageResultPropertyNames = propertySet(
-	"role", "content", "stop_reason", "usage", "output_format",
-)
 
 func (value LLMMessageGenerateResult) MarshalJSON() ([]byte, error) {
 	if value.OutputFormat != outputFormatText {
@@ -29,11 +25,7 @@ func (value LLMMessageGenerateResult) MarshalJSON() ([]byte, error) {
 		)
 	}
 	type plain LLMMessageGenerateResult
-	return marshalObjectWithAdditionalProperties(
-		plain(value),
-		value.AdditionalProperties,
-		llmMessageResultPropertyNames,
-	)
+	return json.Marshal(plain(value))
 }
 
 func (value *LLMMessageGenerateResult) UnmarshalJSON(data []byte) error {
@@ -42,33 +34,25 @@ func (value *LLMMessageGenerateResult) UnmarshalJSON(data []byte) error {
 	}
 	type plain LLMMessageGenerateResult
 	var decoded plain
-	extras, err := unmarshalObjectWithAdditionalProperties(data, &decoded, llmMessageResultPropertyNames)
-	if err != nil {
+	if err := decodeStrictLLMResultJSON(data, &decoded); err != nil {
 		return fmt.Errorf("decode message LLM result: %w", err)
 	}
 	if decoded.OutputFormat != outputFormatText {
 		return fmt.Errorf("decode message LLM result: output_format must be %q", outputFormatText)
 	}
 	*value = LLMMessageGenerateResult(decoded)
-	value.AdditionalProperties = extras
 	return nil
 }
 
-// LLMStructuredGenerateResult is a JSON-schema-format result. Unknown
-// provider-specific fields are preserved in AdditionalProperties.
+// LLMStructuredGenerateResult is a strict JSON-schema-format result.
 type LLMStructuredGenerateResult struct {
-	Role                 LLMRole                    `json:"role"`
-	Content              LLMMessageContent          `json:"content"`
-	StopReason           *string                    `json:"stop_reason,omitempty"`
-	Usage                *LLMUsage                  `json:"usage,omitempty"`
-	OutputFormat         string                     `json:"output_format"`
-	StructuredContent    json.RawMessage            `json:"structured_content"`
-	AdditionalProperties map[string]json.RawMessage `json:"-"`
+	Role              LLMRole           `json:"role"`
+	Content           LLMMessageContent `json:"content"`
+	StopReason        *string           `json:"stop_reason,omitempty"`
+	Usage             *LLMUsage         `json:"usage,omitempty"`
+	OutputFormat      string            `json:"output_format"`
+	StructuredContent json.RawMessage   `json:"structured_content"`
 }
-
-var llmStructuredResultPropertyNames = propertySet(
-	"role", "content", "stop_reason", "usage", "output_format", "structured_content",
-)
 
 func (value LLMStructuredGenerateResult) MarshalJSON() ([]byte, error) {
 	if value.OutputFormat != outputFormatJSONSchema {
@@ -78,11 +62,7 @@ func (value LLMStructuredGenerateResult) MarshalJSON() ([]byte, error) {
 		)
 	}
 	type plain LLMStructuredGenerateResult
-	return marshalObjectWithAdditionalProperties(
-		plain(value),
-		value.AdditionalProperties,
-		llmStructuredResultPropertyNames,
-	)
+	return json.Marshal(plain(value))
 }
 
 func (value *LLMStructuredGenerateResult) UnmarshalJSON(data []byte) error {
@@ -91,8 +71,7 @@ func (value *LLMStructuredGenerateResult) UnmarshalJSON(data []byte) error {
 	}
 	type plain LLMStructuredGenerateResult
 	var decoded plain
-	extras, err := unmarshalObjectWithAdditionalProperties(data, &decoded, llmStructuredResultPropertyNames)
-	if err != nil {
+	if err := decodeStrictLLMResultJSON(data, &decoded); err != nil {
 		return fmt.Errorf("decode structured LLM result: %w", err)
 	}
 	if decoded.OutputFormat != outputFormatJSONSchema {
@@ -102,64 +81,20 @@ func (value *LLMStructuredGenerateResult) UnmarshalJSON(data []byte) error {
 		)
 	}
 	*value = LLMStructuredGenerateResult(decoded)
-	value.AdditionalProperties = extras
 	return nil
 }
 
-func marshalObjectWithAdditionalProperties(
-	known any,
-	extras map[string]json.RawMessage,
-	reserved map[string]struct{},
-) ([]byte, error) {
-	data, err := json.Marshal(known)
-	if err != nil {
-		return nil, err
+func decodeStrictLLMResultJSON(data []byte, target any) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
 	}
-	var object map[string]json.RawMessage
-	if err := json.Unmarshal(data, &object); err != nil {
-		return nil, err
-	}
-	for key, raw := range extras {
-		if _, knownName := reserved[key]; knownName {
-			continue
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("multiple JSON values")
 		}
-		object[key] = append(json.RawMessage(nil), raw...)
+		return err
 	}
-	return json.Marshal(object)
-}
-
-func unmarshalObjectWithAdditionalProperties(
-	data []byte,
-	target any,
-	known map[string]struct{},
-) (map[string]json.RawMessage, error) {
-	var object map[string]json.RawMessage
-	if err := json.Unmarshal(data, &object); err != nil {
-		return nil, err
-	}
-	if object == nil {
-		return nil, errors.New("expected JSON object")
-	}
-	if err := json.Unmarshal(data, target); err != nil {
-		return nil, err
-	}
-	extras := make(map[string]json.RawMessage)
-	for key, raw := range object {
-		if _, isKnown := known[key]; isKnown {
-			continue
-		}
-		extras[key] = append(json.RawMessage(nil), raw...)
-	}
-	if len(extras) == 0 {
-		return nil, nil
-	}
-	return extras, nil
-}
-
-func propertySet(names ...string) map[string]struct{} {
-	result := make(map[string]struct{}, len(names))
-	for _, name := range names {
-		result[name] = struct{}{}
-	}
-	return result
+	return nil
 }

--- a/packages/sdk-go/flexible_objects.go
+++ b/packages/sdk-go/flexible_objects.go
@@ -1,11 +1,9 @@
 package stagehand
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 )
 
 // LLMMessageGenerateResult is a strict text-format result.
@@ -34,7 +32,7 @@ func (value *LLMMessageGenerateResult) UnmarshalJSON(data []byte) error {
 	}
 	type plain LLMMessageGenerateResult
 	var decoded plain
-	if err := decodeStrictLLMResultJSON(data, &decoded); err != nil {
+	if err := decodeStrictVariantJSON(data, &decoded); err != nil {
 		return fmt.Errorf("decode message LLM result: %w", err)
 	}
 	if decoded.OutputFormat != outputFormatText {
@@ -71,7 +69,7 @@ func (value *LLMStructuredGenerateResult) UnmarshalJSON(data []byte) error {
 	}
 	type plain LLMStructuredGenerateResult
 	var decoded plain
-	if err := decodeStrictLLMResultJSON(data, &decoded); err != nil {
+	if err := decodeStrictVariantJSON(data, &decoded); err != nil {
 		return fmt.Errorf("decode structured LLM result: %w", err)
 	}
 	if decoded.OutputFormat != outputFormatJSONSchema {
@@ -81,20 +79,5 @@ func (value *LLMStructuredGenerateResult) UnmarshalJSON(data []byte) error {
 		)
 	}
 	*value = LLMStructuredGenerateResult(decoded)
-	return nil
-}
-
-func decodeStrictLLMResultJSON(data []byte, target any) error {
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(target); err != nil {
-		return err
-	}
-	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
-		if err == nil {
-			return errors.New("multiple JSON values")
-		}
-		return err
-	}
 	return nil
 }

--- a/packages/sdk-go/idiomatic_go.md
+++ b/packages/sdk-go/idiomatic_go.md
@@ -250,9 +250,9 @@ The `add-go` model PR adopts the narrow hybrid, without modifying the canonical 
 - Ordinary objects, maps, aliases, and string enums are emitted by pinned `go-jsonschema` `v0.23.1` in model-only mode. The checked-in result has no SDK runtime dependency. `LoadState` is the one handwritten enum because its concatenated wire values otherwise produce non-idiomatic exported constant names.
 - The projection converts only the schema's `T | null` pairs to Go pointers. It routes real unions through the generator's custom-type extension and fails generation if any unhandled `anyOf` or `oneOf` remains. This prevents a future schema change from silently becoming `interface{}`.
 - Handwritten wrappers cover the irreducible Go cases: model, proxy, variable, cookie, LLM, boolean-or-list, string-or-list, and string-or-number unions. Constructors set known discriminators, JSON decoding rejects unknown discriminators, and zero-value unions fail to marshal.
-- `json.RawMessage` is used for intentionally arbitrary JSON. LLM callback results preserve allowed unknown properties in an explicit `AdditionalProperties` map.
+- `json.RawMessage` is used for intentionally arbitrary JSON. LLM callback results are closed protocol objects and reject unknown provider-specific properties.
 - The generator lives in a nested module to keep its dependencies out of the SDK runtime. Both modules target Go 1.26, and the generated SDK does not import Omissis.
-- Tests compare the generated catalog with the complete reachable protocol definition graph, forbid `interface{}` fallbacks, and round-trip representative union and open-object values. CI also checks generator staleness, formatting, vet, tests, and build.
+- Tests compare the generated catalog with the complete reachable protocol definition graph, forbid `interface{}` fallbacks, and round-trip representative union and closed-object values. CI also checks generator staleness, formatting, vet, tests, and build.
 
 This is deliberately schema projection, not output patching: Omissis output is accepted as generated or generation fails. The only custom logic is the part Go cannot express as native tagged unions.
 

--- a/packages/sdk-go/llm_unions.go
+++ b/packages/sdk-go/llm_unions.go
@@ -86,25 +86,25 @@ func (value *LLMMessageContentBlock) UnmarshalJSON(data []byte) error {
 	switch discriminator {
 	case contentTypeText:
 		var decoded LLMTextContent
-		if err := json.Unmarshal(data, &decoded); err != nil {
+		if err := decodeStrictVariantJSON(data, &decoded); err != nil {
 			return fmt.Errorf("decode LLM text block: %w", err)
 		}
 		*value = TextContentBlock(decoded)
 	case contentTypeImage:
 		var decoded LLMImageContent
-		if err := json.Unmarshal(data, &decoded); err != nil {
+		if err := decodeStrictVariantJSON(data, &decoded); err != nil {
 			return fmt.Errorf("decode LLM image block: %w", err)
 		}
 		*value = ImageContentBlock(decoded)
 	case contentTypeToolUse:
 		var decoded LLMToolUseContent
-		if err := json.Unmarshal(data, &decoded); err != nil {
+		if err := decodeStrictVariantJSON(data, &decoded); err != nil {
 			return fmt.Errorf("decode LLM tool-use block: %w", err)
 		}
 		*value = ToolUseContentBlock(decoded)
 	case contentTypeToolResult:
 		var decoded LLMToolResultContent
-		if err := json.Unmarshal(data, &decoded); err != nil {
+		if err := decodeStrictVariantJSON(data, &decoded); err != nil {
 			return fmt.Errorf("decode LLM tool-result block: %w", err)
 		}
 		*value = ToolResultContentBlock(decoded)
@@ -138,7 +138,7 @@ func (content *LLMMessageContent) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	var decoded LLMMessageContentBlock
-	if err := json.Unmarshal(data, &decoded); err != nil {
+	if err := decodeStrictVariantJSON(data, &decoded); err != nil {
 		return fmt.Errorf("decode LLM message content: %w", err)
 	}
 	*content = LLMMessageContent{decoded}
@@ -199,13 +199,13 @@ func (value *LLMToolResultContentBlock) UnmarshalJSON(data []byte) error {
 	switch discriminator {
 	case contentTypeText:
 		var decoded LLMTextContent
-		if err := json.Unmarshal(data, &decoded); err != nil {
+		if err := decodeStrictVariantJSON(data, &decoded); err != nil {
 			return fmt.Errorf("decode LLM tool-result text block: %w", err)
 		}
 		*value = ToolResultTextBlock(decoded)
 	case contentTypeImage:
 		var decoded LLMImageContent
-		if err := json.Unmarshal(data, &decoded); err != nil {
+		if err := decodeStrictVariantJSON(data, &decoded); err != nil {
 			return fmt.Errorf("decode LLM tool-result image block: %w", err)
 		}
 		*value = ToolResultImageBlock(decoded)
@@ -275,7 +275,7 @@ func (value *LLMGenerateParams) UnmarshalJSON(data []byte) error {
 	}
 	if present && format == outputFormatJSONSchema {
 		var decoded LLMStructuredGenerateParams
-		if err := json.Unmarshal(data, &decoded); err != nil {
+		if err := decodeStrictVariantJSON(data, &decoded); err != nil {
 			return fmt.Errorf("decode structured LLM generate params: %w", err)
 		}
 		*value = StructuredGenerateParams(decoded)
@@ -285,7 +285,7 @@ func (value *LLMGenerateParams) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("decode LLM generate params: unknown response format %q", format)
 	}
 	var decoded LLMMessageGenerateParams
-	if err := json.Unmarshal(data, &decoded); err != nil {
+	if err := decodeStrictVariantJSON(data, &decoded); err != nil {
 		return fmt.Errorf("decode message LLM generate params: %w", err)
 	}
 	*value = MessageGenerateParams(decoded)
@@ -345,17 +345,17 @@ func (value *LLMGenerateResult) UnmarshalJSON(data []byte) error {
 	}
 	switch format {
 	case outputFormatText:
-		var decoded LLMMessageGenerateResult
-		if err := json.Unmarshal(data, &decoded); err != nil {
+		var messageResult LLMMessageGenerateResult
+		if err := decodeStrictVariantJSON(data, &messageResult); err != nil {
 			return fmt.Errorf("decode message LLM generate result: %w", err)
 		}
-		*value = MessageGenerateResult(decoded)
+		*value = MessageGenerateResult(messageResult)
 	case outputFormatJSONSchema:
-		var decoded LLMStructuredGenerateResult
-		if err := json.Unmarshal(data, &decoded); err != nil {
+		var structuredResult LLMStructuredGenerateResult
+		if err := decodeStrictVariantJSON(data, &structuredResult); err != nil {
 			return fmt.Errorf("decode structured LLM generate result: %w", err)
 		}
-		*value = StructuredGenerateResult(decoded)
+		*value = StructuredGenerateResult(structuredResult)
 	default:
 		return fmt.Errorf("decode LLM generate result: unknown output format %q", format)
 	}

--- a/packages/sdk-go/llm_unions_test.go
+++ b/packages/sdk-go/llm_unions_test.go
@@ -56,25 +56,20 @@ func TestLLMToolResultContentBlockVariants(t *testing.T) {
 	}
 }
 
-func TestLLMMessageGenerateResultTextAndOpenProperties(t *testing.T) {
+func TestLLMMessageGenerateResultIsStrict(t *testing.T) {
 	t.Parallel()
 
-	input := []byte(`{
+	valid := []byte(`{
 		"role":"assistant",
 		"content":{"type":"text","text":"done"},
-		"output_format":"text",
-		"provider_request_id":"req_123"
+		"output_format":"text"
 	}`)
 	var result LLMGenerateResult
-	if err := json.Unmarshal(input, &result); err != nil {
+	if err := json.Unmarshal(valid, &result); err != nil {
 		t.Fatal(err)
 	}
-	message, ok := result.AsMessage()
-	if !ok {
+	if _, ok := result.AsMessage(); !ok {
 		t.Fatal("decoded the wrong LLM result variant")
-	}
-	if string(message.AdditionalProperties["provider_request_id"]) != `"req_123"` {
-		t.Fatal("did not retain message result additional property")
 	}
 	data, err := json.Marshal(result)
 	if err != nil {
@@ -83,11 +78,20 @@ func TestLLMMessageGenerateResultTextAndOpenProperties(t *testing.T) {
 	want := []byte(`{
 		"role":"assistant",
 		"content":[{"type":"text","text":"done"}],
-		"output_format":"text",
-		"provider_request_id":"req_123"
+		"output_format":"text"
 	}`)
 	if !jsonEqual(want, data) {
 		t.Fatalf("message result round trip mismatch:\nwant %s\n got %s", want, data)
+	}
+
+	unknownProviderField := []byte(`{
+		"role":"assistant",
+		"content":{"type":"text","text":"done"},
+		"output_format":"text",
+		"provider_request_id":"req_123"
+	}`)
+	if err := json.Unmarshal(unknownProviderField, &result); err == nil {
+		t.Fatal("expected unknown provider field to fail")
 	}
 
 	if err := json.Unmarshal([]byte(`{"output_format":"audio"}`), &result); err == nil {

--- a/packages/sdk-go/logging_test.go
+++ b/packages/sdk-go/logging_test.go
@@ -97,6 +97,78 @@ func TestGoLoggingDefaultsToInfoPrettyAndRemovesListener(t *testing.T) {
 	}
 }
 
+func TestGoLoggingRejectsQueuedNotificationsAfterRelease(t *testing.T) {
+	t.Parallel()
+
+	var firstSessionLogs []StagehandLog
+	rpc := &loggingProtocolClient{}
+	client := newStagehandWithClient(StagehandClientInitParams{
+		Logging: &StagehandClientLoggingConfig{
+			OnLog: func(log StagehandLog) {
+				firstSessionLogs = append(firstSessionLogs, log)
+			},
+		},
+	}, rpc)
+	var firstSessionOutput bytes.Buffer
+	client.logWriter = &firstSessionOutput
+
+	if err := client.Init(context.Background()); err != nil {
+		t.Fatalf("first Init() error = %v", err)
+	}
+	queuedHandler := rpc.notificationHandler
+	if queuedHandler == nil {
+		t.Fatal("first Init() did not register a logging notification listener")
+	}
+	if err := client.Close(context.Background()); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	var secondSessionLogs []StagehandLog
+	client.initParams.Logging = &StagehandClientLoggingConfig{
+		OnLog: func(log StagehandLog) {
+			secondSessionLogs = append(secondSessionLogs, log)
+		},
+	}
+	var secondSessionOutput bytes.Buffer
+	client.logWriter = &secondSessionOutput
+	if err := client.Init(context.Background()); err != nil {
+		t.Fatalf("second Init() error = %v", err)
+	}
+
+	log := testStagehandLogs()[1]
+	queuedHandler(log)
+	if firstSessionOutput.Len() != 0 || len(firstSessionLogs) != 0 {
+		t.Fatalf(
+			"released session handled queued log: output = %q, callback logs = %#v",
+			firstSessionOutput.String(),
+			firstSessionLogs,
+		)
+	}
+	if secondSessionOutput.Len() != 0 || len(secondSessionLogs) != 0 {
+		t.Fatalf(
+			"queued log leaked into new session: output = %q, callback logs = %#v",
+			secondSessionOutput.String(),
+			secondSessionLogs,
+		)
+	}
+
+	rpc.emit(log)
+	if !strings.Contains(secondSessionOutput.String(), log.Message) {
+		t.Fatalf(
+			"active session output = %q, want message %q",
+			secondSessionOutput.String(),
+			log.Message,
+		)
+	}
+	if !reflect.DeepEqual(secondSessionLogs, []StagehandLog{log}) {
+		t.Fatalf(
+			"active session callback logs = %#v, want %#v",
+			secondSessionLogs,
+			[]StagehandLog{log},
+		)
+	}
+}
+
 func TestGoLoggingHonorsEveryThreshold(t *testing.T) {
 	t.Parallel()
 

--- a/packages/sdk-go/logging_test.go
+++ b/packages/sdk-go/logging_test.go
@@ -1,0 +1,270 @@
+package stagehand
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type loggingCall struct {
+	method string
+	params any
+}
+
+type loggingProtocolClient struct {
+	calls               []loggingCall
+	notificationHandler func(StagehandLog)
+	removed             bool
+	closed              bool
+}
+
+func (client *loggingProtocolClient) call(
+	_ context.Context,
+	method string,
+	params any,
+	_ any,
+) error {
+	client.calls = append(client.calls, loggingCall{method: method, params: params})
+	return nil
+}
+
+func (*loggingProtocolClient) onRequest(string, requestHandler) func() {
+	return func() {}
+}
+
+func (client *loggingProtocolClient) onNotification(
+	_ string,
+	handler func(StagehandLog),
+) func() {
+	client.notificationHandler = handler
+	return func() {
+		client.notificationHandler = nil
+		client.removed = true
+	}
+}
+
+func (client *loggingProtocolClient) close() error {
+	client.closed = true
+	return nil
+}
+
+func (client *loggingProtocolClient) emit(log StagehandLog) {
+	if client.notificationHandler != nil {
+		client.notificationHandler(log)
+	}
+}
+
+func TestGoLoggingDefaultsToInfoPrettyAndRemovesListener(t *testing.T) {
+	t.Parallel()
+
+	rpc := &loggingProtocolClient{}
+	client := newStagehandWithClient(StagehandClientInitParams{}, rpc)
+	var output bytes.Buffer
+	client.logWriter = &output
+
+	if err := client.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	configure, ok := rpc.calls[0].params.(RuntimeConfigureParams)
+	if !ok {
+		t.Fatalf("runtime.configure params = %T", rpc.calls[0].params)
+	}
+	if configure.LogLevel != RuntimeConfigureParamsLogLevelInfo {
+		t.Fatalf("log level = %q, want info", configure.LogLevel)
+	}
+
+	for _, log := range testStagehandLogs() {
+		rpc.emit(log)
+	}
+	want := strings.Join([]string{
+		`[stagehand] INFO Page opened {"pageId":"page-1"}`,
+		"[stagehand] WARN Selector fallback",
+		`[stagehand] ERROR Action failed {"retryable":false}`,
+		"",
+	}, "\n")
+	if output.String() != want {
+		t.Fatalf("terminal output = %q, want %q", output.String(), want)
+	}
+
+	if err := client.Close(context.Background()); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if !rpc.removed || rpc.notificationHandler != nil {
+		t.Fatal("Close() did not remove the logging notification listener")
+	}
+}
+
+func TestGoLoggingHonorsEveryThreshold(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		level StagehandClientLogLevel
+		want  []string
+	}{
+		{
+			level: StagehandClientLogLevelDebug,
+			want:  []string{"CDP call", "Page opened", "Selector fallback", "Action failed"},
+		},
+		{
+			level: StagehandClientLogLevelInfo,
+			want:  []string{"Page opened", "Selector fallback", "Action failed"},
+		},
+		{
+			level: StagehandClientLogLevelWarn,
+			want:  []string{"Selector fallback", "Action failed"},
+		},
+		{
+			level: StagehandClientLogLevelError,
+			want:  []string{"Action failed"},
+		},
+		{level: StagehandClientLogLevelOff, want: nil},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(string(test.level), func(t *testing.T) {
+			t.Parallel()
+
+			rpc := &loggingProtocolClient{}
+			client := newStagehandWithClient(StagehandClientInitParams{
+				Logging: &StagehandClientLoggingConfig{Level: test.level},
+			}, rpc)
+			var output bytes.Buffer
+			client.logWriter = &output
+			if err := client.Init(context.Background()); err != nil {
+				t.Fatalf("Init() error = %v", err)
+			}
+			for _, log := range testStagehandLogs() {
+				rpc.emit(log)
+			}
+			for _, log := range testStagehandLogs() {
+				got := strings.Contains(output.String(), log.Message)
+				want := containsString(test.want, log.Message)
+				if got != want {
+					t.Errorf(
+						"output contains %q = %t, want %t; output: %q",
+						log.Message,
+						got,
+						want,
+						output.String(),
+					)
+				}
+			}
+		})
+	}
+}
+
+func TestGoLoggingWritesJSONAndCallsCallback(t *testing.T) {
+	t.Parallel()
+
+	var received []StagehandLog
+	rpc := &loggingProtocolClient{}
+	client := newStagehandWithClient(StagehandClientInitParams{
+		Logging: &StagehandClientLoggingConfig{
+			Level:  StagehandClientLogLevelDebug,
+			Format: StagehandClientLogFormatJSON,
+			OnLog: func(log StagehandLog) {
+				received = append(received, log)
+			},
+		},
+	}, rpc)
+	var output bytes.Buffer
+	client.logWriter = &output
+	if err := client.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	log := testStagehandLogs()[0]
+	rpc.emit(log)
+
+	want := "{\"level\":\"debug\",\"message\":\"CDP call\",\"data\":{\"method\":\"Page.navigate\"}}\n"
+	if output.String() != want {
+		t.Fatalf("JSON output = %q, want %q", output.String(), want)
+	}
+	if !reflect.DeepEqual(received, []StagehandLog{log}) {
+		t.Fatalf("callback logs = %#v, want %#v", received, []StagehandLog{log})
+	}
+}
+
+func TestGoLoggingRecoversCallbackPanic(t *testing.T) {
+	t.Parallel()
+
+	rpc := &loggingProtocolClient{}
+	client := newStagehandWithClient(StagehandClientInitParams{
+		Logging: &StagehandClientLoggingConfig{
+			OnLog: func(StagehandLog) { panic("callback exploded") },
+		},
+	}, rpc)
+	var output bytes.Buffer
+	client.logWriter = &output
+	if err := client.Init(context.Background()); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	rpc.emit(testStagehandLogs()[1])
+	if !strings.Contains(
+		output.String(),
+		"[stagehand] ERROR onLog callback failed: callback exploded\n",
+	) {
+		t.Fatalf("callback panic output = %q", output.String())
+	}
+}
+
+func TestGoLoggingRejectsInvalidConfiguration(t *testing.T) {
+	t.Parallel()
+
+	tests := []StagehandClientLoggingConfig{
+		{Level: "trace"},
+		{Format: "xml"},
+	}
+	for _, logging := range tests {
+		client := newStagehandWithClient(
+			StagehandClientInitParams{Logging: &logging},
+			&loggingProtocolClient{},
+		)
+		err := client.Init(context.Background())
+		if err == nil || !strings.Contains(err.Error(), "invalid logging") {
+			t.Fatalf("Init() error = %v, want invalid logging error", err)
+		}
+	}
+}
+
+func testStagehandLogs() []StagehandLog {
+	return []StagehandLog{
+		{
+			Level:   StagehandLogLevelDebug,
+			Message: "CDP call",
+			Data: StagehandLogData{
+				"method": json.RawMessage(`"Page.navigate"`),
+			},
+		},
+		{
+			Level:   StagehandLogLevelInfo,
+			Message: "Page opened",
+			Data: StagehandLogData{
+				"pageId": json.RawMessage(`"page-1"`),
+			},
+		},
+		{
+			Level:   StagehandLogLevelWarn,
+			Message: "Selector fallback",
+			Data:    StagehandLogData{},
+		},
+		{
+			Level:   StagehandLogLevelError,
+			Message: "Action failed",
+			Data: StagehandLogData{
+				"retryable": json.RawMessage("false"),
+			},
+		},
+	}
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}

--- a/packages/sdk-go/models_test.go
+++ b/packages/sdk-go/models_test.go
@@ -321,8 +321,7 @@ func TestLLMContentAndGenerateUnions(t *testing.T) {
 		"role":"assistant",
 		"content":{"type":"text","text":"done"},
 		"output_format":"json_schema",
-		"structured_content":{"ok":true},
-		"provider_request_id":"req_123"
+		"structured_content":{"ok":true}
 	}`)
 	var result LLMGenerateResult
 	if err := json.Unmarshal(resultJSON, &result); err != nil {
@@ -332,8 +331,8 @@ func TestLLMContentAndGenerateUnions(t *testing.T) {
 	if !ok {
 		t.Fatal("decoded the wrong LLM result variant")
 	}
-	if string(structured.AdditionalProperties["provider_request_id"]) != `"req_123"` {
-		t.Fatal("did not retain LLM result additional property")
+	if string(structured.StructuredContent) != `{"ok":true}` {
+		t.Fatal("did not retain structured content")
 	}
 	roundTrip, err := json.Marshal(result)
 	if err != nil {
@@ -343,11 +342,21 @@ func TestLLMContentAndGenerateUnions(t *testing.T) {
 		"role":"assistant",
 		"content":[{"type":"text","text":"done"}],
 		"output_format":"json_schema",
-		"structured_content":{"ok":true},
-		"provider_request_id":"req_123"
+		"structured_content":{"ok":true}
 	}`)
 	if !jsonEqual(canonicalResult, roundTrip) {
 		t.Fatalf("LLM result round trip mismatch:\nwant %s\n got %s", canonicalResult, roundTrip)
+	}
+
+	unknownProviderField := []byte(`{
+		"role":"assistant",
+		"content":{"type":"text","text":"done"},
+		"output_format":"json_schema",
+		"structured_content":{"ok":true},
+		"provider_request_id":"req_123"
+	}`)
+	if err := json.Unmarshal(unknownProviderField, &result); err == nil {
+		t.Fatal("expected unknown provider field to fail")
 	}
 }
 

--- a/packages/sdk-go/models_test.go
+++ b/packages/sdk-go/models_test.go
@@ -244,6 +244,131 @@ func TestObjectUnionsRoundTrip(t *testing.T) {
 	}
 }
 
+func TestClosedObjectUnionVariantsRejectUnknownFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		new   func() any
+	}{
+		{
+			name:  "action",
+			input: `{"selector":"button","description":"Submit","unexpected":true}`,
+			new:   func() any { return new(ActInput) },
+		},
+		{
+			name:  "known model",
+			input: `{"model_name":"openai/gpt-5.6","unexpected":true}`,
+			new:   func() any { return new(ModelConfig) },
+		},
+		{
+			name:  "custom model",
+			input: `{"model_name":"private/model","base_url":"https://models.test/v1","unexpected":true}`,
+			new:   func() any { return new(ModelConfig) },
+		},
+		{
+			name:  "client init model",
+			input: `{"source":"client","unexpected":true}`,
+			new:   func() any { return new(StagehandInitModel) },
+		},
+		{
+			name:  "browserbase proxy",
+			input: `{"type":"browserbase","unexpected":true}`,
+			new:   func() any { return new(ProxyConfig) },
+		},
+		{
+			name:  "external proxy",
+			input: `{"type":"external","server":"http://proxy.test","unexpected":true}`,
+			new:   func() any { return new(ProxyConfig) },
+		},
+		{
+			name:  "described variable",
+			input: `{"value":true,"unexpected":true}`,
+			new:   func() any { return new(VariableValue) },
+		},
+		{
+			name:  "cookie regex",
+			input: `{"source":"^session","unexpected":true}`,
+			new:   func() any { return new(CookieFilter) },
+		},
+		{
+			name:  "caching options",
+			input: `{"threshold":1,"unexpected":true}`,
+			new:   func() any { return new(Caching) },
+		},
+		{
+			name:  "LLM text content",
+			input: `{"type":"text","text":"done","unexpected":true}`,
+			new:   func() any { return new(LLMMessageContentBlock) },
+		},
+		{
+			name:  "LLM image content",
+			input: `{"type":"image","data":"aW1hZ2U=","mime_type":"image/png","unexpected":true}`,
+			new:   func() any { return new(LLMMessageContentBlock) },
+		},
+		{
+			name:  "LLM tool use content",
+			input: `{"type":"tool_use","id":"tool-1","name":"search","input":{},"unexpected":true}`,
+			new:   func() any { return new(LLMMessageContentBlock) },
+		},
+		{
+			name:  "LLM tool result content",
+			input: `{"type":"tool_result","tool_use_id":"tool-1","content":[],"unexpected":true}`,
+			new:   func() any { return new(LLMMessageContentBlock) },
+		},
+		{
+			name:  "LLM tool result text block",
+			input: `{"type":"text","text":"done","unexpected":true}`,
+			new:   func() any { return new(LLMToolResultContentBlock) },
+		},
+		{
+			name:  "LLM message generate params",
+			input: `{"messages":[],"unexpected":true}`,
+			new:   func() any { return new(LLMGenerateParams) },
+		},
+		{
+			name: "LLM structured generate params",
+			input: `{
+				"messages":[],
+				"response_format":{"type":"json_schema","name":"answer","schema":{"type":"object"}},
+				"unexpected":true
+			}`,
+			new: func() any { return new(LLMGenerateParams) },
+		},
+		{
+			name: "LLM message generate result",
+			input: `{
+				"role":"assistant",
+				"content":{"type":"text","text":"done"},
+				"output_format":"text",
+				"unexpected":true
+			}`,
+			new: func() any { return new(LLMGenerateResult) },
+		},
+		{
+			name: "LLM structured generate result",
+			input: `{
+				"role":"assistant",
+				"content":{"type":"text","text":"done"},
+				"output_format":"json_schema",
+				"structured_content":{"ok":true},
+				"unexpected":true
+			}`,
+			new: func() any { return new(LLMGenerateResult) },
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := json.Unmarshal([]byte(test.input), test.new())
+			if err == nil || !strings.Contains(err.Error(), `unknown field "unexpected"`) {
+				t.Fatalf("Unmarshal() error = %v, want unknown-field error", err)
+			}
+		})
+	}
+}
+
 func TestBrowserbaseProxiesSupportsBooleanAndList(t *testing.T) {
 	t.Parallel()
 

--- a/packages/sdk-go/object_unions.go
+++ b/packages/sdk-go/object_unions.go
@@ -71,7 +71,7 @@ func (value *ActInput) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	var action Action
-	if err := json.Unmarshal(data, &action); err != nil {
+	if err := decodeStrictVariantJSON(data, &action); err != nil {
 		return fmt.Errorf("decode act input: %w", err)
 	}
 	*value = ObservedAction(action)
@@ -135,7 +135,7 @@ func (value *ModelConfig) UnmarshalJSON(data []byte) error {
 			return errors.New("decode custom model config: base_url and model_name are required")
 		}
 		var decoded CustomModelConfig
-		if err := json.Unmarshal(data, &decoded); err != nil {
+		if err := decodeStrictVariantJSON(data, &decoded); err != nil {
 			return fmt.Errorf("decode custom model config: %w", err)
 		}
 		*value = CustomModel(decoded)
@@ -146,7 +146,7 @@ func (value *ModelConfig) UnmarshalJSON(data []byte) error {
 		return errors.New("decode known model config: model_name is required")
 	}
 	var decoded KnownModelConfig
-	if err := json.Unmarshal(data, &decoded); err != nil {
+	if err := decodeStrictVariantJSON(data, &decoded); err != nil {
 		return fmt.Errorf("decode known model config: %w", err)
 	}
 	*value = KnownModel(decoded)
@@ -201,14 +201,18 @@ func (value *StagehandInitModel) UnmarshalJSON(data []byte) error {
 	}
 	source, _ := stringProperty(data, "source")
 	if source == modelSourceClient {
+		var clientReference ClientModelReference
+		if err := decodeStrictVariantJSON(data, &clientReference); err != nil {
+			return fmt.Errorf("decode client init model: %w", err)
+		}
 		*value = ClientModel()
 		return nil
 	}
-	var decoded ModelConfig
-	if err := json.Unmarshal(data, &decoded); err != nil {
+	var serverModel ModelConfig
+	if err := decodeStrictVariantJSON(data, &serverModel); err != nil {
 		return fmt.Errorf("decode init model: %w", err)
 	}
-	*value = ServerModel(decoded)
+	*value = ServerModel(serverModel)
 	return nil
 }
 
@@ -266,13 +270,13 @@ func (value *ProxyConfig) UnmarshalJSON(data []byte) error {
 	switch discriminator {
 	case proxyTypeBrowserbase:
 		var decoded BrowserbaseProxyConfig
-		if err := json.Unmarshal(data, &decoded); err != nil {
+		if err := decodeStrictVariantJSON(data, &decoded); err != nil {
 			return fmt.Errorf("decode Browserbase proxy: %w", err)
 		}
 		*value = BrowserbaseProxy(decoded)
 	case proxyTypeExternal:
 		var decoded ExternalProxyConfig
-		if err := json.Unmarshal(data, &decoded); err != nil {
+		if err := decodeStrictVariantJSON(data, &decoded); err != nil {
 			return fmt.Errorf("decode external proxy: %w", err)
 		}
 		*value = ExternalProxy(decoded)
@@ -405,18 +409,18 @@ func (value *VariableValue) UnmarshalJSON(data []byte) error {
 		return errors.New("stagehand.VariableValue: UnmarshalJSON on nil pointer")
 	}
 	if firstJSONByte(data) == '{' {
-		var decoded DescribedVariableValue
-		if err := json.Unmarshal(data, &decoded); err != nil {
+		var described DescribedVariableValue
+		if err := decodeStrictVariantJSON(data, &described); err != nil {
 			return fmt.Errorf("decode described variable: %w", err)
 		}
-		*value = DescribedVariable(decoded)
+		*value = DescribedVariable(described)
 		return nil
 	}
-	var decoded VariablePrimitive
-	if err := json.Unmarshal(data, &decoded); err != nil {
+	var primitive VariablePrimitive
+	if err := json.Unmarshal(data, &primitive); err != nil {
 		return fmt.Errorf("decode primitive variable: %w", err)
 	}
-	*value = PrimitiveVariable(decoded)
+	*value = PrimitiveVariable(primitive)
 	return nil
 }
 
@@ -480,7 +484,7 @@ func (value *CookieFilter) UnmarshalJSON(data []byte) error {
 		return errors.New("decode cookie filter: expected string or object")
 	}
 	var decoded CookieRegex
-	if err := json.Unmarshal(data, &decoded); err != nil {
+	if err := decodeStrictVariantJSON(data, &decoded); err != nil {
 		return fmt.Errorf("decode regex cookie filter: %w", err)
 	}
 	*value = RegexCookie(decoded)

--- a/packages/sdk-go/scalar_unions.go
+++ b/packages/sdk-go/scalar_unions.go
@@ -84,7 +84,7 @@ func (value *Caching) UnmarshalJSON(data []byte) error {
 		return nil
 	case '{':
 		var options CacheOptions
-		if err := json.Unmarshal(data, &options); err != nil {
+		if err := decodeStrictVariantJSON(data, &options); err != nil {
 			return fmt.Errorf("decode caching options: %w", err)
 		}
 		if threshold := options.Threshold; threshold != nil &&

--- a/packages/sdk-go/stagehand.go
+++ b/packages/sdk-go/stagehand.go
@@ -5,6 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"os"
+	"strings"
 	"sync"
 )
 
@@ -16,6 +19,8 @@ type Stagehand struct {
 	rpc                       protocolClient
 	browser                   *resolvedBrowserSource
 	context                   *BrowserContext
+	logging                   resolvedStagehandClientLoggingConfig
+	logWriter                 io.Writer
 	initialized               bool
 	removeLLMHandler          func()
 	removeNotificationHandler func()
@@ -23,7 +28,11 @@ type Stagehand struct {
 
 // New creates a Stagehand client. Init performs browser and transport setup.
 func New(initParams StagehandClientInitParams) *Stagehand {
-	return &Stagehand{initParams: initParams, adapters: defaultClientAdapters()}
+	return &Stagehand{
+		initParams: initParams,
+		adapters:   defaultClientAdapters(),
+		logWriter:  os.Stderr,
+	}
 }
 
 // Context returns the initialized browser context.
@@ -206,6 +215,11 @@ func (s *Stagehand) Init(ctx context.Context) error {
 	if s.initParams.Model != nil && s.initParams.Generate != nil {
 		return errors.New("stagehand: Model and Generate are mutually exclusive")
 	}
+	logging, err := resolveLoggingConfig(s.initParams.Logging, s.logWriter)
+	if err != nil {
+		return err
+	}
+	s.logging = logging
 
 	browser, err := s.adapters.resolveBrowserSource(ctx, s.initParams)
 	if err != nil {
@@ -213,7 +227,12 @@ func (s *Stagehand) Init(ctx context.Context) error {
 	}
 	s.browser = &browser
 
-	rpc, err := s.adapters.connectProtocol(ctx, browser, s.initParams.Telemetry)
+	rpc, err := s.adapters.connectProtocol(
+		ctx,
+		browser,
+		s.initParams.Telemetry,
+		runtimeLogLevel(logging.level),
+	)
 	if err != nil {
 		return errors.Join(
 			fmt.Errorf("connect protocol: %w", err),
@@ -221,11 +240,10 @@ func (s *Stagehand) Init(ctx context.Context) error {
 		)
 	}
 	s.rpc = rpc
-	onLog := func(StagehandLog) {}
-	if s.initParams.Logging != nil && s.initParams.Logging.OnLog != nil {
-		onLog = s.initParams.Logging.OnLog
-	}
-	s.removeNotificationHandler = rpc.onNotification("stagehand.log", onLog)
+	s.removeNotificationHandler = rpc.onNotification(
+		"stagehand.log",
+		s.handleStagehandLog,
+	)
 	if generate := s.initParams.Generate; generate != nil {
 		s.removeLLMHandler = rpc.onRequest("llm.generate", newRequestHandler(generate))
 	}
@@ -396,6 +414,82 @@ func (s *Stagehand) releaseBrowser(ctx context.Context, preserveKeepAlive bool) 
 	return errors.Join(browserErr, cleanupErr)
 }
 
+func (s *Stagehand) handleStagehandLog(log StagehandLog) {
+	s.mu.RLock()
+	logging := s.logging
+	s.mu.RUnlock()
+
+	if !isClientLogLevelEnabled(log.Level, logging.level) {
+		return
+	}
+	rendered, err := renderStagehandLog(log, logging.format)
+	if err != nil {
+		fmt.Fprintf(logging.writer, "[stagehand] ERROR render log failed: %v\n", err)
+		return
+	}
+	fmt.Fprintln(logging.writer, rendered)
+	if logging.onLog == nil {
+		return
+	}
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			fmt.Fprintf(
+				logging.writer,
+				"[stagehand] ERROR onLog callback failed: %v\n",
+				recovered,
+			)
+		}
+	}()
+	logging.onLog(log)
+}
+
+func isClientLogLevelEnabled(
+	level StagehandLogLevel,
+	threshold StagehandClientLogLevel,
+) bool {
+	priority := map[string]int{
+		"debug": 10,
+		"info":  20,
+		"warn":  30,
+		"error": 40,
+		"off":   int(^uint(0) >> 1),
+	}
+	logPriority, ok := priority[string(level)]
+	if !ok {
+		return false
+	}
+	return logPriority >= priority[string(threshold)]
+}
+
+func renderStagehandLog(
+	log StagehandLog,
+	format StagehandClientLogFormat,
+) (string, error) {
+	data, err := json.Marshal(log.Data)
+	if err != nil {
+		return "", err
+	}
+	if format == StagehandClientLogFormatJSON {
+		record := struct {
+			Level   StagehandLogLevel `json:"level"`
+			Message string            `json:"message"`
+			Data    StagehandLogData  `json:"data"`
+		}{Level: log.Level, Message: log.Message, Data: log.Data}
+		encoded, err := json.Marshal(record)
+		return string(encoded), err
+	}
+	suffix := ""
+	if len(log.Data) != 0 {
+		suffix = " " + string(data)
+	}
+	return fmt.Sprintf(
+		"[stagehand] %s %s%s",
+		strings.ToUpper(string(log.Level)),
+		log.Message,
+		suffix,
+	), nil
+}
+
 func newStagehandWithClient(initParams StagehandClientInitParams, rpc protocolClient) *Stagehand {
 	client := New(initParams)
 	client.adapters = clientAdapters{
@@ -406,8 +500,15 @@ func newStagehandWithClient(initParams StagehandClientInitParams, rpc protocolCl
 			ctx context.Context,
 			browser resolvedBrowserSource,
 			telemetry TelemetryConfig,
+			logLevel RuntimeConfigureParamsLogLevel,
 		) (protocolClient, error) {
-			if err := configureProtocol(ctx, rpc, browser, telemetry); err != nil {
+			if err := configureProtocol(
+				ctx,
+				rpc,
+				browser,
+				telemetry,
+				logLevel,
+			); err != nil {
 				return nil, err
 			}
 			return rpc, nil

--- a/packages/sdk-go/stagehand.go
+++ b/packages/sdk-go/stagehand.go
@@ -461,28 +461,38 @@ func isClientLogLevelEnabled(
 	level StagehandLogLevel,
 	threshold StagehandClientLogLevel,
 ) bool {
-	priority := map[string]int{
-		"debug": 10,
-		"info":  20,
-		"warn":  30,
-		"error": 40,
-		"off":   int(^uint(0) >> 1),
-	}
-	logPriority, ok := priority[string(level)]
+	logPriority, ok := clientLogLevelPriority(string(level))
 	if !ok {
 		return false
 	}
-	return logPriority >= priority[string(threshold)]
+	thresholdPriority, ok := clientLogLevelPriority(string(threshold))
+	if !ok {
+		return false
+	}
+	return logPriority >= thresholdPriority
+}
+
+func clientLogLevelPriority(level string) (int, bool) {
+	switch level {
+	case string(StagehandClientLogLevelDebug):
+		return 10, true
+	case string(StagehandClientLogLevelInfo):
+		return 20, true
+	case string(StagehandClientLogLevelWarn):
+		return 30, true
+	case string(StagehandClientLogLevelError):
+		return 40, true
+	case string(StagehandClientLogLevelOff):
+		return int(^uint(0) >> 1), true
+	default:
+		return 0, false
+	}
 }
 
 func renderStagehandLog(
 	log StagehandLog,
 	format StagehandClientLogFormat,
 ) (string, error) {
-	data, err := json.Marshal(log.Data)
-	if err != nil {
-		return "", err
-	}
 	if format == StagehandClientLogFormatJSON {
 		record := struct {
 			Level   StagehandLogLevel `json:"level"`
@@ -491,6 +501,10 @@ func renderStagehandLog(
 		}{Level: log.Level, Message: log.Message, Data: log.Data}
 		encoded, err := json.Marshal(record)
 		return string(encoded), err
+	}
+	data, err := json.Marshal(log.Data)
+	if err != nil {
+		return "", err
 	}
 	suffix := ""
 	if len(log.Data) != 0 {

--- a/packages/sdk-go/stagehand.go
+++ b/packages/sdk-go/stagehand.go
@@ -19,7 +19,6 @@ type Stagehand struct {
 	rpc                       protocolClient
 	browser                   *resolvedBrowserSource
 	context                   *BrowserContext
-	logging                   resolvedStagehandClientLoggingConfig
 	logWriter                 io.Writer
 	initialized               bool
 	removeLLMHandler          func()
@@ -229,7 +228,6 @@ func (s *Stagehand) Init(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	s.logging = logging
 
 	browser, err := s.adapters.resolveBrowserSource(ctx, s.initParams)
 	if err != nil {
@@ -250,10 +248,20 @@ func (s *Stagehand) Init(ctx context.Context) error {
 		)
 	}
 	s.rpc = rpc
-	s.removeNotificationHandler = rpc.onNotification(
+	notificationContext, cancelNotificationHandler := context.WithCancel(context.Background())
+	removeNotificationHandler := rpc.onNotification(
 		"stagehand.log",
-		s.handleStagehandLog,
+		func(log StagehandLog) {
+			if notificationContext.Err() != nil {
+				return
+			}
+			handleStagehandLog(log, logging)
+		},
 	)
+	s.removeNotificationHandler = func() {
+		cancelNotificationHandler()
+		removeNotificationHandler()
+	}
 	if generate := s.initParams.Generate; generate != nil {
 		s.removeLLMHandler = rpc.onRequest("llm.generate", newRequestHandler(generate))
 	}
@@ -424,11 +432,7 @@ func (s *Stagehand) releaseBrowser(ctx context.Context, preserveKeepAlive bool) 
 	return errors.Join(browserErr, cleanupErr)
 }
 
-func (s *Stagehand) handleStagehandLog(log StagehandLog) {
-	s.mu.RLock()
-	logging := s.logging
-	s.mu.RUnlock()
-
+func handleStagehandLog(log StagehandLog, logging resolvedStagehandClientLoggingConfig) {
 	if !isClientLogLevelEnabled(log.Level, logging.level) {
 		return
 	}

--- a/packages/sdk-go/stagehand.go
+++ b/packages/sdk-go/stagehand.go
@@ -45,6 +45,16 @@ func (s *Stagehand) Context() (*BrowserContext, error) {
 	return s.context, nil
 }
 
+// Browser returns a detached snapshot of the resolved browser connection.
+func (s *Stagehand) Browser() (ResolvedBrowserSource, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.browser == nil {
+		return ResolvedBrowserSource{}, ErrNotInitialized
+	}
+	return s.browser.snapshot(), nil
+}
+
 // Initialized reports whether Init completed successfully.
 func (s *Stagehand) Initialized() bool {
 	s.mu.RLock()

--- a/packages/sdk-go/stagehand_live_test.go
+++ b/packages/sdk-go/stagehand_live_test.go
@@ -1,10 +1,13 @@
 package stagehand
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
@@ -103,6 +106,135 @@ func TestStagehandExistingCDPBrowserIntegration(t *testing.T) {
 			t.Errorf("remove kept-alive extension directory: %v", err)
 		}
 	})
+}
+
+func TestStagehandExtractSendsScreenshotToClientLLM(t *testing.T) {
+	chromePath, err := findChromePath("")
+	if err != nil {
+		t.Skipf("Chrome is not installed: %v", err)
+	}
+
+	fixture := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = writer.Write([]byte(
+			`<!doctype html><html><head><title>Stagehand Go Screenshot</title></head>` +
+				`<body><h1>Stagehand Go Screenshot</h1></body></html>`,
+		))
+	}))
+	defer fixture.Close()
+
+	screenshots := make(chan LLMImageContent, 1)
+	generate := func(
+		_ context.Context,
+		params LLMGenerateParams,
+	) (LLMGenerateResult, error) {
+		structured, ok := params.AsStructured()
+		if !ok {
+			return LLMGenerateResult{}, errors.New("smoke LLM only supports structured generation")
+		}
+		for _, message := range structured.Messages {
+			for _, block := range message.Content {
+				if image, ok := block.AsImage(); ok {
+					select {
+					case screenshots <- image:
+					default:
+					}
+				}
+			}
+		}
+
+		content := json.RawMessage(`{"heading":"Stagehand Go Screenshot"}`)
+		if structured.ResponseFormat.Name == "Metadata" {
+			content = json.RawMessage(
+				`{"progress":"The requested heading was extracted","completed":true}`,
+			)
+		}
+		return StructuredGenerateResult(LLMStructuredGenerateResult{
+			Role: LLMRoleAssistant,
+			Content: LLMMessageContent{
+				TextContentBlock(LLMTextContent{Text: string(content)}),
+			},
+			StructuredContent: content,
+		}), nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	client := New(StagehandClientInitParams{
+		Browser: LocalBrowserSource{
+			ExecutablePath:   chromePath,
+			Headless:         true,
+			ConnectTimeoutMs: 15_000,
+		},
+		Generate: generate,
+	})
+	closeStagehandAfterTest(t, client)
+	if err := client.Init(ctx); err != nil {
+		t.Fatalf("Stagehand.Init() with screenshot LLM error = %v", err)
+	}
+	browserContext, err := client.Context()
+	if err != nil {
+		t.Fatalf("Stagehand.Context() error = %v", err)
+	}
+	page, err := browserContext.ActivePage(ctx)
+	if err != nil {
+		t.Fatalf("BrowserContext.ActivePage() error = %v", err)
+	}
+	if page == nil {
+		page, err = browserContext.NewPage(ctx, ContextNewPageParams{})
+		if err != nil {
+			t.Fatalf("BrowserContext.NewPage() error = %v", err)
+		}
+	}
+	if err := page.Goto(ctx, fixture.URL, nil); err != nil {
+		t.Fatalf("Page.Goto() error = %v", err)
+	}
+
+	screenshot := true
+	result, err := client.Extract(
+		ctx,
+		"Extract the page heading",
+		json.RawMessage(
+			`{"type":"object","properties":{"heading":{"type":"string"}},"required":["heading"]}`,
+		),
+		&StagehandClientExtractOptions{
+			ExtractOptions: ExtractOptions{Screenshot: &screenshot},
+			Page:           page,
+		},
+	)
+	if err != nil {
+		t.Fatalf("Stagehand.Extract() with screenshot error = %v", err)
+	}
+	var extracted struct {
+		Heading string `json:"heading"`
+	}
+	if err := json.Unmarshal(result.Data, &extracted); err != nil {
+		t.Fatalf("decode Extract() data: %v", err)
+	}
+	if extracted.Heading != "Stagehand Go Screenshot" {
+		t.Fatalf("Extract() heading = %q", extracted.Heading)
+	}
+
+	var image LLMImageContent
+	select {
+	case image = <-screenshots:
+	default:
+		t.Fatal("client LLM did not receive the requested extraction screenshot")
+	}
+	if image.Type != "image" || image.MIMEType != "image/png" {
+		t.Fatalf("screenshot content = %#v", image)
+	}
+	png, err := base64.StdEncoding.DecodeString(image.Data)
+	if err != nil {
+		t.Fatalf("decode LLM screenshot: %v", err)
+	}
+	if signature := []byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n'}; !bytes.HasPrefix(png, signature) {
+		t.Fatalf("LLM screenshot is not PNG data: %v", png[:min(len(png), len(signature))])
+	}
+
+	if err := client.Close(ctx); err != nil {
+		t.Fatalf("Stagehand.Close() with screenshot LLM error = %v", err)
+	}
 }
 
 func TestStagehandBrowserbaseIntegration(t *testing.T) {

--- a/packages/sdk-go/stagehand_live_test.go
+++ b/packages/sdk-go/stagehand_live_test.go
@@ -122,7 +122,7 @@ func TestStagehandBrowserbaseIntegration(t *testing.T) {
 			KeepAlive: testPointer(false),
 			Timeout:   testPointer(300.0),
 			UserMetadata: map[string]json.RawMessage{
-				"suite": json.RawMessage(`"stagehand-v4-go-public-smoke"`),
+				"suite": json.RawMessage(`"stagehand-go-public-smoke"`),
 			},
 		},
 	})

--- a/packages/sdk-go/strict_unions.go
+++ b/packages/sdk-go/strict_unions.go
@@ -1,0 +1,30 @@
+package stagehand
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// decodeStrictVariantJSON decodes one closed object variant. Semantic JSON
+// Schema constraints remain the responsibility of the generated model layer
+// or the authoritative protocol boundary.
+func decodeStrictVariantJSON(data []byte, target any) error {
+	if firstJSONByte(data) != '{' {
+		return errors.New("expected JSON object")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("multiple JSON values")
+		}
+		return fmt.Errorf("decode trailing JSON: %w", err)
+	}
+	return nil
+}

--- a/rules/ast-grep/go-union-strictness.test.ts
+++ b/rules/ast-grep/go-union-strictness.test.ts
@@ -1,0 +1,102 @@
+import { readdir, readFile } from "node:fs/promises";
+import go from "@ast-grep/lang-go";
+import { parse, registerDynamicLanguage, type SgNode } from "@ast-grep/napi";
+import { describe, expect, it } from "vitest";
+
+registerDynamicLanguage({ go });
+
+const goSource = new URL("../../packages/sdk-go/", import.meta.url);
+const protocolUrl = new URL("../../packages/protocol/stagehand.v4.json", import.meta.url);
+const handwrittenUnionFiles = [
+  "flexible_objects.go",
+  "llm_unions.go",
+  "object_unions.go",
+  "scalar_unions.go",
+] as const;
+
+type ProtocolDocument = {
+  $defs: Record<string, { additionalProperties?: boolean }>;
+};
+
+describe("Go handwritten union strictness", () => {
+  it("decodes closed object variants through the strict helper", async () => {
+    const closedTypes = await closedProtocolObjectTypes();
+    closedTypes.add("CacheOptions");
+    const violations: string[] = [];
+    let strictHelperCalls = 0;
+
+    for (const file of handwrittenUnionFiles) {
+      const root = parse("go", await readFile(new URL(file, goSource), "utf8")).root();
+      strictHelperCalls += root.findAll({
+        rule: { pattern: "decodeStrictVariantJSON($DATA, &$TARGET)" },
+      }).length;
+      for (const call of root.findAll({
+        rule: { pattern: "json.Unmarshal($DATA, &$TARGET)" },
+      })) {
+        const target = call.getMatch("TARGET");
+        const scope = call
+          .ancestors()
+          .find(
+            (ancestor) =>
+              ancestor.kind() === "method_declaration" ||
+              ancestor.kind() === "function_declaration",
+          );
+        if (!target || !scope) continue;
+        const declaration = scope.find({
+          rule: { pattern: `var ${target.text()} $TYPE` },
+        });
+        const decodedType = declaration?.getMatch("TYPE")?.text();
+        if (decodedType && closedTypes.has(decodedType)) {
+          violations.push(`${file}: json.Unmarshal into ${decodedType}`);
+        }
+      }
+    }
+
+    expect(strictHelperCalls, "Handwritten unions must use the strict decoder").toBeGreaterThan(0);
+    expect(violations, "Closed Go union variants must use decodeStrictVariantJSON").toStrictEqual(
+      [],
+    );
+  });
+
+  it("does not add AdditionalProperties to closed protocol models", async () => {
+    const closedTypes = await closedProtocolObjectTypes();
+    const files = (await readdir(goSource))
+      .filter((file) => file.endsWith(".go") && !file.endsWith("_test.go"))
+      .sort();
+    const violations: string[] = [];
+    let inspectedClosedTypes = 0;
+
+    for (const file of files) {
+      const root = parse("go", await readFile(new URL(file, goSource), "utf8")).root();
+      for (const type of root.findAll({ rule: { kind: "type_spec" } })) {
+        const name = namedChildren(type).find((child) => child.kind() === "type_identifier");
+        if (!name || !closedTypes.has(name.text())) continue;
+        inspectedClosedTypes++;
+        if (/\bAdditionalProperties\b/u.test(type.text())) {
+          violations.push(`${file}: ${name.text()}`);
+        }
+      }
+    }
+
+    expect(inspectedClosedTypes, "The rule must inspect generated closed models").toBeGreaterThan(
+      0,
+    );
+    expect(
+      violations,
+      "additionalProperties: false models must not expose AdditionalProperties",
+    ).toStrictEqual([]);
+  });
+});
+
+async function closedProtocolObjectTypes(): Promise<Set<string>> {
+  const protocol = JSON.parse(await readFile(protocolUrl, "utf8")) as ProtocolDocument;
+  return new Set(
+    Object.entries(protocol.$defs)
+      .filter(([, schema]) => schema.additionalProperties === false)
+      .map(([name]) => name),
+  );
+}
+
+function namedChildren(node: SgNode): SgNode[] {
+  return node.children().filter((child) => child.isNamed());
+}

--- a/rules/ast-grep/sdk-parity.test.ts
+++ b/rules/ast-grep/sdk-parity.test.ts
@@ -385,6 +385,37 @@ describe("All language SDK operations remain in sync", () => {
 
     expect(staticallyVisibleParams).toBeGreaterThan(0);
   });
+
+  it("returns full Go Stagehand result envelopes", async () => {
+    const root = parse("go", await readFile(new URL("stagehand.go", goSource), "utf8")).root();
+    const stagehand = findClass(root, "go", "Stagehand");
+
+    expect(stagehand, "Go Stagehand must exist").toBeDefined();
+    if (!stagehand) return;
+
+    for (const [methodNameText, resultType] of [
+      ["Act", "ActResult"],
+      ["Observe", "ObserveResult"],
+      ["Extract", "ExtractResult"],
+    ] as const) {
+      const method = directClassMethods(stagehand, "go", "Stagehand").find(
+        (candidate) => methodName(candidate.node, "go")?.text() === methodNameText,
+      )?.node;
+      expect(method, `Go Stagehand.${methodNameText} must exist`).toBeDefined();
+      if (!method) continue;
+
+      expect(method.field("result")?.text(), `Go Stagehand.${methodNameText} result type`).toBe(
+        `(${resultType}, error)`,
+      );
+      const dataOnlyReturns = method
+        .findAll({ rule: { kind: "return_statement" } })
+        .filter((statement) => /\bresult\.Data\b/u.test(statement.text()));
+      expect(
+        dataOnlyReturns,
+        `Go Stagehand.${methodNameText} must preserve result metadata`,
+      ).toEqual([]);
+    }
+  });
 });
 
 async function publicOperations(

--- a/rules/ast-grep/sdk-parity.test.ts
+++ b/rules/ast-grep/sdk-parity.test.ts
@@ -85,7 +85,7 @@ type PythonRpcCall = {
 type GoRpcCall = PythonRpcCall;
 
 const goAccessors: Readonly<Record<string, ReadonlySet<string>>> = {
-  Stagehand: new Set(["Context", "Initialized"]),
+  Stagehand: new Set(["Browser", "Context", "Initialized"]),
   BrowserContext: new Set(["Clipboard"]),
   BrowserClipboard: new Set(),
   Page: new Set(["PageID", "Ref"]),
@@ -200,6 +200,38 @@ describe("All language SDK operations remain in sync", () => {
         typescript,
       );
       expect(typescript.length, `${className} must expose public methods`).toBeGreaterThan(0);
+    }
+  });
+
+  it("keeps Stagehand accessors aligned and every declared Go accessor present", async () => {
+    const [className, typescriptFile, pythonFile, goFile, goType] = sdkObjects[0];
+    const typescript = await publicAccessors(
+      "typescript",
+      new URL(typescriptFile, typescriptSource),
+      className,
+    );
+    const python = await publicAccessors("python", new URL(pythonFile, pythonSource), className);
+    const goClient = await publicAccessors("go", new URL(goFile, goSource), goType);
+
+    expect(python, "Stagehand Python accessors must remain in sync").toStrictEqual(typescript);
+    expect(goClient, "Stagehand Go accessors must remain in sync").toStrictEqual(typescript);
+    expect(typescript.length, "Stagehand must expose public accessors").toBeGreaterThan(0);
+
+    for (const [, , , goFile, goType] of sdkObjects) {
+      const root = parse("go", await readFile(new URL(goFile, goSource), "utf8")).root();
+      const classNode = findClass(root, "go", goType);
+
+      expect(classNode, `${goType} must exist`).toBeDefined();
+      if (!classNode) continue;
+      const methods = new Set(
+        directClassMethods(classNode, "go", goType).flatMap((method) => {
+          const name = methodName(method.node, "go");
+          return name ? [name.text()] : [];
+        }),
+      );
+      for (const accessor of goAccessors[goType] ?? []) {
+        expect(methods.has(accessor), `${goType}.${accessor} accessor must exist`).toBe(true);
+      }
     }
   });
 
@@ -476,6 +508,43 @@ async function publicCallableMethods(
         }),
     ),
   ].sort();
+}
+
+async function publicAccessors(
+  language: SdkLanguage,
+  file: URL,
+  className: string,
+): Promise<string[]> {
+  const root = parse(language, await readFile(file, "utf8")).root();
+  const classNode = findClass(root, language, className);
+
+  expect(classNode, `${className} must exist in ${file.pathname}`).toBeDefined();
+  if (!classNode) return [];
+
+  return directClassMethods(classNode, language, className)
+    .filter((method) => {
+      const name = methodName(method.node, language);
+      if (!name) return false;
+      if (language === "go") return goAccessors[className]?.has(name.text()) === true;
+      if (language === "python") {
+        return (
+          !name.text().startsWith("_") &&
+          method.decoratedDefinition?.text().startsWith("@property") === true
+        );
+      }
+      const declarationPrefix = method.node
+        .text()
+        .slice(0, method.node.text().indexOf(name.text()));
+      return (
+        !/\b(?:private|protected)\b/u.test(declarationPrefix) &&
+        /\bget\s*$/u.test(declarationPrefix)
+      );
+    })
+    .flatMap((method) => {
+      const name = methodName(method.node, language);
+      return name ? [snakeCase(name.text())] : [];
+    })
+    .sort();
 }
 
 async function clientProtocolOperations(

--- a/rules/ast-grep/stale-identity.test.ts
+++ b/rules/ast-grep/stale-identity.test.ts
@@ -1,0 +1,46 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+
+// The Python build removes artifacts produced before the distribution was
+// renamed. These exact legacy cleanup patterns are data, not public identities.
+const legacyDistributionName = ["stagehand", "v4"].join("_");
+const allowedLegacyCleanupMatches = new Set([
+  `packages/sdk-python/scripts/build.py:"${legacyDistributionName}-*.whl",`,
+  `packages/sdk-python/scripts/build.py:"${legacyDistributionName}-*.tar.gz",`,
+  `packages/sdk-python/tests/test_build.py:"${legacyDistributionName}-0.1.0-py3-none-any.whl",`,
+  `packages/sdk-python/tests/test_build.py:"${legacyDistributionName}-0.1.0.tar.gz",`,
+]);
+
+describe("Retired package identities", () => {
+  it("does not reintroduce a Stagehand v4 package or test identity", async () => {
+    const pattern = ["stagehand", "[-_]v4"].join("");
+    let stdout = "";
+    try {
+      ({ stdout } = await execFileAsync("git", ["grep", "-n", "-I", "-E", pattern, "--", "."], {
+        encoding: "utf8",
+      }));
+    } catch (error) {
+      const grepError = error as Error & { code?: number; stdout?: string };
+      if (grepError.code !== 1) throw error;
+      stdout = grepError.stdout ?? "";
+    }
+    const unexpected = stdout
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .flatMap((match) => {
+        const parsed = /^(?<file>[^:]+):\d+:(?<contents>.*)$/u.exec(match)?.groups;
+        if (!parsed?.file || parsed.contents === undefined) return [match];
+        const identity = `${parsed.file}:${parsed.contents.trim()}`;
+        return allowedLegacyCleanupMatches.has(identity) ? [] : [match];
+      });
+
+    expect(
+      unexpected,
+      "Use the stable Stagehand package identity; only exact Python legacy-artifact cleanup patterns are allowed",
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What changed

This PR handles a lot of the simple SDK parity work needed to catch the Go stack up with changes merged since [`a18e4d825`](https://github.com/browserbase/stagehand/commit/a18e4d825d453ff4ed0d77c59db7912f8864104a).

- **Commit 1 — Implement full Go logging parity**
  - Adds `off | error | warn | info | debug`, `pretty | json`, default stderr output, additive `OnLog`, callback recovery, and `runtime.configure.log_level`.
  - `StagehandClientLoggingConfig{Level: StagehandClientLogLevelInfo, Format: StagehandClientLogFormatPretty}`

- **Commit 2 — Make Go's LLM result objects strict**
  - Removes `AdditionalProperties` and rejects undeclared result fields such as `provider_request_id`.

- **Commit 3 — Make handwritten Go union decoders strict**
  - Adds `decodeStrictVariantJSON` for action, model, proxy, cookie, caching, and LLM variants.
  - AST rules added:
    - `Go handwritten union strictness > decodes closed object variants through the strict helper`
    - `Go handwritten union strictness > does not add AdditionalProperties to closed protocol models`

- **Commit 4 — Remove the stale v4 smoke-test name**
  - Removes `stagehand-v4-go-public-smoke` and blocks stale `stagehand-v4` / `stagehand_v4` identities.
  - AST rule added:
    - `Retired package identities > does not reintroduce a Stagehand v4 package or test identity`

- **Commit 5 — Complete Go regression coverage for behavior that already works**
  - Covers direct getters, `{data, metadata}` envelopes, `action_id`, `cache_status`, screenshot forwarding, and PNG image input.
  - AST rule added:
    - `All language SDK operations remain in sync > returns full Go Stagehand result envelopes`

- **Commit 6 — Add the missing Go browser accessor**
  - Adds `Browser() (ResolvedBrowserSource, error)` with a detached connection snapshot and `ErrNotInitialized` behavior.
  - AST rule added:
    - `All language SDK operations remain in sync > keeps Stagehand accessors aligned and every declared Go accessor present`