### PR TITLE
Add Go code snippets and support parity to docs

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -38,7 +38,7 @@
           },
           {
             "group": "The Basics",
-            "pages": ["v4/basics/act", "v4/basics/extract", "v4/basics/observe"]
+            "pages": ["v4/basics/act", "v4/basics/extract", "v4/basics/observe", "v4/basics/webmcp"]
           },
           {
             "group": "Configuration",

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -28,7 +28,7 @@
             "pages": ["v4/index"]
           },
           {
-            "group": "First steps",
+            "group": "First Steps",
             "pages": [
               "v4/first-steps/introduction",
               "v4/first-steps/quickstart",
@@ -37,7 +37,7 @@
             ]
           },
           {
-            "group": "The basics",
+            "group": "The Basics",
             "pages": ["v4/basics/act", "v4/basics/extract", "v4/basics/observe"]
           },
           {

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -28,7 +28,7 @@
             "pages": ["v4/index"]
           },
           {
-            "group": "First Steps",
+            "group": "First steps",
             "pages": [
               "v4/first-steps/introduction",
               "v4/first-steps/quickstart",
@@ -37,7 +37,7 @@
             ]
           },
           {
-            "group": "The Basics",
+            "group": "The basics",
             "pages": ["v4/basics/act", "v4/basics/extract", "v4/basics/observe", "v4/basics/webmcp"]
           },
           {

--- a/packages/docs/tests/sdk-reference.test.ts
+++ b/packages/docs/tests/sdk-reference.test.ts
@@ -780,29 +780,76 @@ describe("Mintlify customization boundary", () => {
     );
   });
 
-  it("uses every View title only once per page", async () => {
+  it("gives every View group the same complete language set", async () => {
     const contentPages = (await listFiles(V4_DOCS_ROOT, shouldInspectDocsDirectory)).filter(
       (filePath) => extname(filePath) === ".mdx",
     );
-    const duplicateTitles = (
+    const problems = (
       await Promise.all(
         contentPages.map(async (filePath) => {
           const tree = createProcessor({ format: "mdx" }).parse(
             await readFile(filePath, "utf8"),
           ) as MdxNode;
-          const titles = findElements(tree, "View")
-            .map((view) => stringAttribute(view, "title"))
-            .filter((title): title is string => title !== undefined);
-          const duplicates = titles.filter((title, index) => titles.indexOf(title) !== index);
+          const views = findElements(tree, "View").map((view) => ({
+            title: stringAttribute(view, "title"),
+            icon: stringAttribute(view, "icon"),
+          }));
           const pagePath = relative(DOCS_ROOT, filePath).split(sep).join("/");
-          return [...new Set(duplicates)].map((title) => `${pagePath}: ${title}`);
+          const found: string[] = [];
+
+          const titled = views.filter(
+            (view): view is { title: string; icon: string | undefined } => view.title !== undefined,
+          );
+          if (titled.length !== views.length) {
+            found.push(`${pagePath}: a View is missing a title`);
+          }
+          if (titled.length === 0) return found;
+
+          // Every language present on the page must appear the same number of times
+          const counts = new Map<string, number>();
+          for (const { title } of titled) {
+            counts.set(title, (counts.get(title) ?? 0) + 1);
+          }
+          const tallies = [...counts.entries()].sort(([a], [b]) => a.localeCompare(b));
+          const expected = Math.max(...counts.values());
+          const short = tallies.filter(([, count]) => count !== expected);
+          if (short.length > 0) {
+            found.push(
+              `${pagePath}: uneven View groups (${tallies
+                .map(([title, count]) => `${title} x${count}`)
+                .join(", ")})`,
+            );
+          }
+
+          // One icon per title, so the selector labels stay stable.
+          const icons = new Map<string, Set<string>>();
+          for (const { title, icon } of titled) {
+            if (icon === undefined) continue;
+            if (!icons.has(title)) icons.set(title, new Set());
+            icons.get(title)?.add(icon);
+          }
+          for (const [title, set] of icons) {
+            if (set.size > 1) {
+              found.push(`${pagePath}: ${title} uses more than one icon (${[...set].join(", ")})`);
+            }
+          }
+
+          // Two adjacent Views sharing a title means a malformed group.
+          for (let index = 1; index < titled.length; index += 1) {
+            if (titled[index].title === titled[index - 1].title) {
+              found.push(`${pagePath}: two adjacent Views both titled ${titled[index].title}`);
+              break;
+            }
+          }
+
+          return found;
         }),
       )
     ).flat();
 
     expect(
-      duplicateTitles,
-      "Mintlify accepts only one View with a given title on each page",
+      problems,
+      "Every View group must offer the same languages, so switching never hides a snippet",
     ).toEqual([]);
   });
 

--- a/packages/docs/v4/basics/act.mdx
+++ b/packages/docs/v4/basics/act.mdx
@@ -389,7 +389,7 @@ if result.Metadata.CacheStatus != nil {
 ```
 </View>
 
-<Card title="Complete caching guide" icon="database" iconType="sharp-solid" href="/v4/best-practices/caching">
+<Card title="Complete caching guide" icon="database" iconType="sharp-solid" href="/v3/best-practices/caching">
   Learn how the cache key is built, what the threshold does, and when results are invalidated.
 </Card>
 
@@ -471,7 +471,7 @@ This works with:
 - **New pages:** create one with `context.newPage()`
 - **Existing browsers:** attach to a browser you already run with the `cdp` browser source
 
-<Card title="Complete API Reference" icon="book" href="/v4/references/stagehand">
+<Card title="Complete API Reference" icon="book" href="/v3/references/stagehand">
   See the full `Stagehand` reference for detailed parameter documentation, return values, and advanced examples.
 </Card>
 
@@ -606,7 +606,7 @@ if _, err := client.Act(ctx, "click the login button", nil); err != nil {
 The cache lives on Browserbase, keyed on the instruction, page content, and call options, so it persists across script executions and across machines. The model configuration is deliberately excluded from the key, so switching models does not invalidate your cache.
 </Note>
 
-<Card title="Complete caching guide" icon="database" iconType="sharp-solid" href="/v4/best-practices/caching">
+<Card title="Complete caching guide" icon="database" iconType="sharp-solid" href="/v3/best-practices/caching">
   Learn advanced caching techniques and patterns for optimal performance.
 </Card>
 
@@ -678,7 +678,7 @@ _, err = client.Act(ctx, "click the login button", nil)
 When handling sensitive data, turn logging off in your Stagehand configuration to prevent secrets from appearing in logs. See the [logging guide](/v4/configuration/logging) for more details.
 </Warning>
 
-<Card title="User Data Best Practices" icon="shield-check" iconType="sharp-solid" href="/v4/best-practices/user-data">
+<Card title="User Data Best Practices" icon="shield-check" iconType="sharp-solid" href="/v3/best-practices/user-data">
   Complete guide to persisting and securing browser state across sessions.
 </Card>
 
@@ -1024,7 +1024,7 @@ if len(observed.Data) > 0 && strings.Contains(observed.Data[0].Description, "che
     Use `observe()` to plan actions before executing them.
   </Card>
 
-   <Card title="Caching actions" icon="bolt" iconType="sharp-solid" href="/v4/best-practices/caching">
+   <Card title="Caching actions" icon="bolt" iconType="sharp-solid" href="/v3/best-practices/caching">
     Speed up repeated automations by caching actions.
   </Card>
 
@@ -1032,7 +1032,7 @@ if len(observed.Data) > 0 && strings.Contains(observed.Data[0].Description, "che
     Use `extract` with a data schema to pull clean, typed data from any page.
   </Card>
 
-  <Card title="Work across multiple tabs" icon="clone" iconType="sharp-solid" href="/v4/best-practices/using-multiple-tabs">
+  <Card title="Work across multiple tabs" icon="clone" iconType="sharp-solid" href="/v3/best-practices/using-multiple-tabs">
     Target a specific page with the `page` option.
   </Card>
 </CardGroup>

--- a/packages/docs/v4/basics/act.mdx
+++ b/packages/docs/v4/basics/act.mdx
@@ -30,13 +30,13 @@ result, err := client.Act(ctx, "click on add to cart", nil)
 ## Why use `act()`?
 
 <CardGroup cols={2}>
-  <Card title="Natural Language Instructions" icon="wand-magic-sparkles" href="#using-act">
+  <Card title="Natural language instructions" icon="wand-magic-sparkles" href="#using-act">
     Write automation in plain English. No selectors or complex syntax.
   </Card>
-  <Card title="Precise Control" icon="crosshairs" href="#best-practices">
+  <Card title="Precise control" icon="crosshairs" href="#best-practices">
     Build automations step by step. Define exactly what happens at every moment.
   </Card>
-  <Card title="Self-Healing" icon="bandage" href="#ensure-reliable-actions">
+  <Card title="Self-healing" icon="bandage" href="#ensure-reliable-actions">
     Actions automatically adapt when websites change.
   </Card>
   <Card title="Caching" icon="repeat" href="#reduce-model-costs">
@@ -73,7 +73,7 @@ result, err := client.Act(ctx, "click the add to cart button", nil)
 </View>
 
 <Note>
-**iFrame and Shadow DOM Support** Stagehand automatically handles iFrame traversal and shadow DOM elements without requiring additional configuration. Page snapshots merge every frame's accessibility tree by default.
+**iFrame and Shadow DOM support** Stagehand automatically handles iFrame traversal and shadow DOM elements without requiring additional configuration. Page snapshots merge every frame's accessibility tree by default.
 </Note>
 
 With `act`, breaking complex actions into small, single-step actions works best. If you need to orchestrate multi-step flows, use multiple `act` commands.
@@ -161,7 +161,11 @@ ActResult(
 
 <View title="Go" icon="golang">
 ```go
-stagehand.ActResult{
+clickMethod := "click"
+actionID := "act_01HZY..."
+cacheStatus := stagehand.CacheStatusMISS
+
+result := stagehand.ActResult{
 	Data: stagehand.ActResultData{
 		Success:           true,
 		Message:           "Action [click] performed successfully on selector: xpath=/html[1]/body[1]/div[1]/span[1]",
@@ -254,7 +258,7 @@ result, err := client.Act(ctx, "open the filters panel, choose 4-star rating, an
 </Tab>
 </Tabs>
 
-## Advanced Configuration
+## Advanced configuration
 
 You can pass additional options to configure the model, timeout, variables, and target page:
 
@@ -306,7 +310,7 @@ result, err := client.Act(ctx, "choose 'Peach' from the favorite color dropdown"
 ```
 </View>
 
-### Server-side Caching
+### Server-side caching
 
 <Note>
 `cache` requires the Browserbase browser source and a Browserbase API key. It has no effect on local or CDP browsers.
@@ -393,7 +397,7 @@ if result.Metadata.CacheStatus != nil {
   Learn how the cache key is built, what the threshold does, and when results are invalidated.
 </Card>
 
-### Using with Custom Pages
+### Using with custom pages
 
 Stagehand v4 drives the browser directly over the Chrome DevTools Protocol, so there is no Puppeteer, Playwright, or Patchright page interop. Instead, target any page Stagehand manages by passing the `page` option:
 
@@ -467,11 +471,11 @@ _, err = client.Act(ctx, "click the next page button", &stagehand.StagehandClien
 
 This works with:
 - **Active page:** omit `page` and Stagehand uses `context.activePage()` (default)
-- **Existing pages:** index into `context.pages()`
+- **Existing pages:** receive the list from `context.pages()` first (await it in TypeScript and Python), then index into it
 - **New pages:** create one with `context.newPage()`
 - **Existing browsers:** attach to a browser you already run with the `cdp` browser source
 
-<Card title="Complete API Reference" icon="book" href="/v3/references/stagehand">
+<Card title="Complete API reference" icon="book" href="/v3/references/stagehand">
   See the full `Stagehand` reference for detailed parameter documentation, return values, and advanced examples.
 </Card>
 
@@ -678,7 +682,7 @@ _, err = client.Act(ctx, "click the login button", nil)
 When handling sensitive data, turn logging off in your Stagehand configuration to prevent secrets from appearing in logs. See the [logging guide](/v4/configuration/logging) for more details.
 </Warning>
 
-<Card title="User Data Best Practices" icon="shield-check" iconType="sharp-solid" href="/v3/best-practices/user-data">
+<Card title="User data best practices" icon="shield-check" iconType="sharp-solid" href="/v3/best-practices/user-data">
   Complete guide to persisting and securing browser state across sessions.
 </Card>
 
@@ -692,7 +696,7 @@ When handling sensitive data, turn logging off in your Stagehand configuration t
 
 **Solutions**:
 - Use clear and detailed instructions for what you want to accomplish
-- Review our [evals](https://stagehand.dev/evals) to find the best models for your use case
+- Review the [Stagehand evals](https://stagehand.dev/evals) to find the best models for your use case
 - Use [`observe()`](/v4/basics/observe) and verify the resulting action is within a list of expected actions
 
 **Solution 1: Validate with observe**
@@ -705,7 +709,9 @@ const expectedMethod = "click";
 try {
   await stagehand.act(prompt);
 } catch (error) {
-  if (error.message.includes("method not supported")) {
+  const message = error instanceof Error ? error.message : String(error);
+
+  if (message.includes("method not supported")) {
     // Observe the same prompt to get the planned action
     const { data: actions } = await stagehand.observe(prompt);
     const [action] = actions;
@@ -788,7 +794,9 @@ for (let attempt = 0; attempt <= maxRetries; attempt++) {
     await stagehand.act(prompt, { timeout: 10000 + (attempt * 5000) });
     break; // Success, exit retry loop
   } catch (error) {
-    if (error.message.includes("method not supported") && attempt < maxRetries) {
+    const message = error instanceof Error ? error.message : String(error);
+
+    if (message.includes("method not supported") && attempt < maxRetries) {
       // Exponential backoff: wait 2^attempt seconds
       const delay = Math.pow(2, attempt) * 1000;
       console.log(`Retry ${attempt + 1}/${maxRetries} after ${delay}ms`);
@@ -964,7 +972,7 @@ await stagehand.act("click the red 'Delete' button next to the user John Smith")
 // Or preview with observe first:
 const { data: actions } = await stagehand.observe("click the submit button in the checkout form");
 const [action] = actions;
-if (action.description.includes("checkout")) {
+if (action?.description.includes("checkout")) {
   await stagehand.act(action);
 }
 ```
@@ -983,7 +991,7 @@ await stagehand.act("click the red 'Delete' button next to the user John Smith")
 observed = await stagehand.observe(
     instruction="click the submit button in the checkout form"
 )
-if "checkout" in observed.data[0].description:
+if observed.data and "checkout" in observed.data[0].description:
     await stagehand.act(observed.data[0])
 ```
 </View>

--- a/packages/docs/v4/basics/act.mdx
+++ b/packages/docs/v4/basics/act.mdx
@@ -19,7 +19,9 @@ await stagehand.act("click on add to cart")
 
 <View title="Go" icon="golang">
 ```go
-result, err := client.Act(ctx, "click on add to cart", nil)
+if _, err := client.Act(ctx, "click on add to cart", nil); err != nil {
+	return err
+}
 ```
 </View>
 
@@ -68,7 +70,9 @@ await stagehand.act("click the add to cart button")
 if err := page.Goto(ctx, "https://example-store.com", nil); err != nil {
 	return err
 }
-result, err := client.Act(ctx, "click the add to cart button", nil)
+if _, err := client.Act(ctx, "click the add to cart button", nil); err != nil {
+	return err
+}
 ```
 </View>
 
@@ -190,6 +194,9 @@ result := stagehand.ActResult{
 		CacheStatus: &cacheStatus,
 	},
 }
+
+// Read the fields you care about off the result
+fmt.Println(result.Data.Message, *result.Metadata.CacheStatus)
 ```
 </View>
 
@@ -252,7 +259,9 @@ await stagehand.act("open the filters panel, choose 4-star rating, and click app
 <View title="Go" icon="golang">
 ```go
 // Too complex - trying to do multiple things at once
-result, err := client.Act(ctx, "open the filters panel, choose 4-star rating, and click apply", nil)
+if _, err := client.Act(ctx, "open the filters panel, choose 4-star rating, and click apply", nil); err != nil {
+	return err
+}
 ```
 </View>
 </Tab>
@@ -301,12 +310,14 @@ model := stagehand.KnownModel(stagehand.KnownModelConfig{
 })
 timeout := 10000.0
 
-result, err := client.Act(ctx, "choose 'Peach' from the favorite color dropdown", &stagehand.StagehandClientActOptions{
+if _, err := client.Act(ctx, "choose 'Peach' from the favorite color dropdown", &stagehand.StagehandClientActOptions{
 	ActOptions: stagehand.ActOptions{
 		Model:   &model,
 		Timeout: &timeout,
 	},
-})
+}); err != nil {
+	return err
+}
 ```
 </View>
 
@@ -375,18 +386,25 @@ client := stagehand.New(stagehand.StagehandClientInitParams{
 
 // Or disable it for a single call
 off := stagehand.CacheEnabled(false)
-_, err := client.Act(ctx, "click the login button", &stagehand.StagehandClientActOptions{
+if _, err := client.Act(ctx, "click the login button", &stagehand.StagehandClientActOptions{
 	ActOptions: stagehand.ActOptions{Cache: &off},
-})
+}); err != nil {
+	return err
+}
 
 // Or lower the hit-count threshold for a single call
 eager := stagehand.CacheWithThreshold(1)
-_, err = client.Act(ctx, "click the login button", &stagehand.StagehandClientActOptions{
+if _, err := client.Act(ctx, "click the login button", &stagehand.StagehandClientActOptions{
 	ActOptions: stagehand.ActOptions{Cache: &eager},
-})
+}); err != nil {
+	return err
+}
 
 // Check whether a result was served from cache
 result, err := client.Act(ctx, "click the login button", nil)
+if err != nil {
+	return err
+}
 if result.Metadata.CacheStatus != nil {
 	fmt.Println(*result.Metadata.CacheStatus) // "HIT" or "MISS"
 }
@@ -657,24 +675,30 @@ await stagehand.act("click the login button")
 <View title="Go" icon="golang">
 ```go
 // Variables use %variableName% syntax in the instruction
-_, err := client.Act(ctx, "type %username% into the email field", &stagehand.StagehandClientActOptions{
+if _, err := client.Act(ctx, "type %username% into the email field", &stagehand.StagehandClientActOptions{
 	ActOptions: stagehand.ActOptions{
 		Variables: stagehand.Variables{
 			"username": stagehand.PrimitiveVariable(stagehand.StringVariable("user@example.com")),
 		},
 	},
-})
+}); err != nil {
+	return err
+}
 
-password := os.Getenv("USER_PASSWORD")
-_, err = client.Act(ctx, "type %password% into the password field", &stagehand.StagehandClientActOptions{
+userPassword := os.Getenv("USER_PASSWORD")
+if _, err := client.Act(ctx, "type %password% into the password field", &stagehand.StagehandClientActOptions{
 	ActOptions: stagehand.ActOptions{
 		Variables: stagehand.Variables{
-			"password": stagehand.PrimitiveVariable(stagehand.StringVariable(password)),
+			"password": stagehand.PrimitiveVariable(stagehand.StringVariable(userPassword)),
 		},
 	},
-})
+}); err != nil {
+	return err
+}
 
-_, err = client.Act(ctx, "click the login button", nil)
+if _, err := client.Act(ctx, "click the login button", nil); err != nil {
+	return err
+}
 ```
 </View>
 

--- a/packages/docs/v4/basics/act.mdx
+++ b/packages/docs/v4/basics/act.mdx
@@ -6,466 +6,1033 @@ description: "Interact with a web page."
 ## What is `act()`?
 
 <View title="TypeScript" icon="js">
-
 ```typescript
-await stagehand.act("Click the add to cart button");
+await stagehand.act("click on add to cart");
 ```
-
-`act()` enables Stagehand to perform **individual** actions on a web page. Use it to build self-healing and deterministic automations that adapt to website changes.
-
-## Why use `act()`?
-
-<CardGroup cols="2">
-  <Card title="Natural language" icon="wand-magic-sparkles">
-    Describe the action in plain English, with no selectors or brittle syntax.
-  </Card>
-  <Card title="Precise control" icon="crosshairs">
-    Drive your automation one deliberate step at a time.
-  </Card>
-  <Card title="Adapts to change" icon="bandage">
-    Instructions keep working when a site's markup shifts.
-  </Card>
-  <Card title="Composable" icon="layer-group">
-    Pair with [`observe()`](/v4/basics/observe) to plan before acting.
-  </Card>
-</CardGroup>
-
-## Using `act()`
-
-Call `act()` on your [`stagehand`](/v4/reference/stagehand) instance. By default it runs on
-the browser's active page; pass a `page` option to target a specific one. Keep each call to
-a single step, and break multi-step flows into multiple `act()` calls.
-
-<Tabs>
-  <Tab title="Do this" icon="check">
-
-Break the task into single-step actions.
-
-```typescript
-await page.goto("https://example-store.com");
-await stagehand.act("Open the filters panel");
-await stagehand.act("Choose the 4-star rating");
-await stagehand.act("Click the apply button");
-```
-
-</Tab>
-  <Tab title="Avoid this" icon="xmark">
-
-Cramming several steps into one instruction is less reliable.
-
-```typescript
-await stagehand.act("Open filters, choose 4-star rating, and click apply");
-```
-
-</Tab>
-</Tabs>
-
-<Note>
-  Stagehand resolves elements inside iframes and shadow DOM for you, so you rarely need to target
-  nested documents manually. This relies on privileged browser APIs that aren't available on
-  `about:blank` or `data:` URLs, so navigate to a real page first when a target sits inside a closed
-  shadow root (see [locator limitations](/v4/reference/locator)).
-</Note>
-
-<Accordion title="Suggested actions">
-
-| Action           | Example instruction                              |
-| ---------------- | ------------------------------------------------ |
-| Click            | `Click the sign in button`                       |
-| Fill a field     | `Fill the email field with user@example.com`     |
-| Type text        | `Type "wireless headphones" into the search box` |
-| Press a key      | `Press Enter in the search field`                |
-| Scroll           | `Scroll to the footer`                           |
-| Select an option | `Select "Large" from the size dropdown`          |
-
-</Accordion>
-
-### Return value
-
-`act()` resolves to an `ActResult` with typed `data` and shared `metadata`.
-
-```typescript
-const result = await stagehand.act("Click the sign in button");
-// {
-//   data: {
-//     success: true,
-//     message: "Successfully clicked the sign in button",
-//     actionDescription: "Clicked button with text 'Sign in'",
-//     actions: [...]
-//   },
-//   metadata: { cacheStatus: "MISS" }
-// }
-
-if (!result.data.success) {
-  throw new Error(`act() failed: ${result.data.message}`);
-}
-```
-
-Always check `data.success` before assuming the action ran. See the full field list in the
-[`stagehand` reference](/v4/reference/stagehand).
-
-<Card title="Complete act() reference" icon="book" href="/v4/reference/stagehand">
-  Full parameters, per-call options, and the `ActResult` shape.
-</Card>
-
-## Advanced configuration
-
-You can pass additional options to configure `act()` for your exact use case:
-
-```typescript
-await stagehand.act("Choose 'Peach' from the favorite color dropdown", {
-  model: { modelName: "google/gemini-2.5-flash", apiKey: process.env.GOOGLE_API_KEY },
-  timeout: 10_000,
-});
-```
-
-- `page`: the page to act on. Defaults to the active page.
-- `model`: override the model for this call.
-- `timeout`: maximum time in milliseconds.
-- `variables`: values substituted into the instruction (see below).
-- `locator`: a serialized element target to scope the action.
-- `cache`: reuse a prior result for this call.
-
-### Variables
-
-Variables keep sensitive or dynamic values **out of the model prompt**. Reference them in
-the instruction with `%name%`. A variable can be a plain value, or a
-`{ value, description }` object to give the model a hint about a secret without revealing
-it.
-
-```typescript
-await stagehand.act("Type %username% into the email field", {
-  variables: { username: "user@example.com" },
-});
-
-await stagehand.act("Type %password% into the password field", {
-  variables: {
-    password: { value: process.env.USER_PASSWORD, description: "the login password" },
-  },
-});
-
-await stagehand.act("Click the login button");
-```
-
-<Warning>
-  Load secrets from environment variables, and never hardcode them. Variables are substituted
-  locally, so their values are not sent to the model provider as part of the instruction.
-</Warning>
-
-## Best practices
-
-### Plan reliably with `observe()`
-
-`observe()` returns candidate actions on the current page. Use it to verify an element
-exists or to preview what `act()` will do.
-
-```typescript
-const {
-  data: [candidate],
-} = await stagehand.observe("Find the login button");
-if (candidate) {
-  await stagehand.act("Click the login button");
-}
-```
-
-<Card title="Plan with observe()" icon="eye" href="/v4/basics/observe">
-  Discover and verify actions before you run them.
-</Card>
-
-### Be specific
-
-Ambiguous instructions can target the wrong element. Add context like position, nearby
-text, or a visual cue: `"Click the red 'Delete' button next to the user John Smith"`.
-
-### Cache repeated actions
-
-On Browserbase, turn on caching
-so repeated, identical actions are served from a cache instead of calling the model again.
-
-```typescript
-const result = await stagehand.act("Click the sign in button", { cache: true });
-console.log(result.metadata.cacheStatus);
-```
-
-## Troubleshooting
-
-<AccordionGroup>
-  <Accordion title="Action failed or timed out">
-
-Make sure the page has finished loading, increase `timeout`, and use `observe()` to confirm
-the target element exists before acting.
-
-```typescript
-await page.waitForLoadState("domcontentloaded");
-
-const {
-  data: [candidate],
-} = await stagehand.observe("Find the submit button");
-if (candidate) {
-  await stagehand.act("Click the submit button", { timeout: 30_000 });
-}
-```
-
-</Accordion>
-  <Accordion title="Wrong element selected">
-
-Be more specific in the instruction, or preview the target with `observe()` and inspect its
-`description` before calling `act()`.
-
-```typescript
-// Instead of a vague instruction:
-await stagehand.act("Click the button");
-
-// Add context so the target is unambiguous:
-await stagehand.act("Click the red 'Delete' button next to the user John Smith");
-
-// Or preview with observe() and confirm the description before acting:
-const {
-  data: [candidate],
-} = await stagehand.observe("Find the submit button in the checkout form");
-if (candidate?.description.toLowerCase().includes("checkout")) {
-  await stagehand.act("Click the submit button in the checkout form");
-}
-```
-
-  </Accordion>
-</AccordionGroup>
-
 </View>
 
 <View title="Python" icon="python">
-
 ```python
-await stagehand.act("Click the add to cart button")
+await stagehand.act("click on add to cart")
 ```
+</View>
 
-`act()` enables Stagehand to perform **individual** actions on a web page. Use it to build self-healing and deterministic automations that adapt to website changes.
+<View title="Go" icon="golang">
+```go
+result, err := client.Act(ctx, "click on add to cart", nil)
+```
+</View>
+
+`act` enables Stagehand to perform **individual** actions on a web page. Use it to build self-healing and deterministic automations that adapt to website changes.
+
+`act` accepts either a natural language instruction or an `Action` returned by [`observe()`](/v4/basics/observe). Passing an instruction runs model inference to find the target; passing an `Action` replays it deterministically with no inference at all.
 
 ## Why use `act()`?
 
-<CardGroup cols="2">
-  <Card title="Natural language" icon="wand-magic-sparkles">
-    Describe the action in plain English, with no selectors or brittle syntax.
+<CardGroup cols={2}>
+  <Card title="Natural Language Instructions" icon="wand-magic-sparkles" href="#using-act">
+    Write automation in plain English. No selectors or complex syntax.
   </Card>
-  <Card title="Precise control" icon="crosshairs">
-    Drive your automation one deliberate step at a time.
+  <Card title="Precise Control" icon="crosshairs" href="#best-practices">
+    Build automations step by step. Define exactly what happens at every moment.
   </Card>
-  <Card title="Adapts to change" icon="bandage">
-    Instructions keep working when a site's markup shifts.
+  <Card title="Self-Healing" icon="bandage" href="#ensure-reliable-actions">
+    Actions automatically adapt when websites change.
   </Card>
-  <Card title="Composable" icon="layer-group">
-    Pair with [`observe()`](/v4/basics/observe) to plan before acting.
+  <Card title="Caching" icon="repeat" href="#reduce-model-costs">
+    Cache actions to avoid LLM calls and ensure consistent execution across runs.
   </Card>
 </CardGroup>
 
+
 ## Using `act()`
 
-Call `act()` on your [`stagehand`](/v4/reference/stagehand) instance. By default it runs on
-the browser's active page; pass a `page` option to target a specific one. Keep each call to
-a single step, and break multi-step flows into multiple `act()` calls.
+Use `act` to perform single actions in your automation. Here's how to click a button:
 
-<Tabs>
-  <Tab title="Do this" icon="check">
+<View title="TypeScript" icon="js">
+```typescript
+await page.goto("https://example-store.com");
+await stagehand.act("click the add to cart button");
+```
+</View>
 
-Break the task into single-step actions.
-
+<View title="Python" icon="python">
 ```python
 await page.goto("https://example-store.com")
-await stagehand.act("Open the filters panel")
-await stagehand.act("Choose the 4-star rating")
-await stagehand.act("Click the apply button")
+await stagehand.act("click the add to cart button")
 ```
+</View>
 
-</Tab>
-  <Tab title="Avoid this" icon="xmark">
-
-Cramming several steps into one instruction is less reliable.
-
-```python
-await stagehand.act("Open filters, choose 4-star rating, and click apply")
+<View title="Go" icon="golang">
+```go
+if err := page.Goto(ctx, "https://example-store.com", nil); err != nil {
+	return err
+}
+result, err := client.Act(ctx, "click the add to cart button", nil)
 ```
-
-</Tab>
-</Tabs>
+</View>
 
 <Note>
-  Stagehand resolves elements inside iframes and shadow DOM for you, so you rarely need to target
-  nested documents manually. This relies on privileged browser APIs that aren't available on
-  `about:blank` or `data:` URLs, so navigate to a real page first when a target sits inside a closed
-  shadow root (see [locator limitations](/v4/reference/locator)).
+**iFrame and Shadow DOM Support** Stagehand automatically handles iFrame traversal and shadow DOM elements without requiring additional configuration. Page snapshots merge every frame's accessibility tree by default.
 </Note>
+
+With `act`, breaking complex actions into small, single-step actions works best. If you need to orchestrate multi-step flows, use multiple `act` commands.
 
 <Accordion title="Suggested actions">
 
-| Action           | Example instruction                              |
-| ---------------- | ------------------------------------------------ |
-| Click            | `Click the sign in button`                       |
-| Fill a field     | `Fill the email field with user@example.com`     |
-| Type text        | `Type "wireless headphones" into the search box` |
-| Press a key      | `Press Enter in the search field`                |
-| Scroll           | `Scroll to the footer`                           |
-| Select an option | `Select "Large" from the size dropdown`          |
+| Action | `method` | Example instruction |
+|--------|----------|---------------------|
+| Click | `click` | `click the button` |
+| Double click | `doubleClick` | `double click the file name` |
+| Fill | `fill` | `fill the field with <value>` |
+| Type | `type` | `type <text> into the search box` |
+| Press | `press` | `press <key> in the search field` |
+| Hover | `hover` | `hover over the account menu` |
+| Scroll | `scrollTo` | `scroll to <position>` |
+| Scroll one screen | `nextChunk` / `prevChunk` | `scroll down one page` |
+| Select from dropdown | `selectOptionFromDropdown` | `select <value> from the dropdown` |
+| Drag and drop | `dragAndDrop` | `drag the card onto the Done column` |
 
+The `method` column is the value you will see on an `Action` returned by [`observe()`](/v4/basics/observe).
 </Accordion>
 
-### Return value
+### Return value of `act()`?
+When you use `act()`, Stagehand returns a result with two fields: `data` holds the action payload, and `metadata` carries the action ID and server-side cache status.
 
-`act()` resolves to an `ActResult` with typed `data` and shared `metadata`.
-
-```python
-result = await stagehand.act("Click the sign in button")
-# result.data.success            -> bool
-# result.data.message            -> str
-# result.data.action_description -> str
-# result.data.actions            -> list of executed actions
-# result.metadata.cache_status   -> "HIT", "MISS", or None
-
-if not result.data.success:
-    raise RuntimeError(f"act() failed: {result.data.message}")
+<View title="TypeScript" icon="js">
+```typescript
+{
+  data: {
+    success: true,
+    message: 'Action [click] performed successfully on selector: xpath=/html[1]/body[1]/div[1]/span[1]',
+    actionDescription: 'Favorite Colour',
+    actions: [
+      {
+        selector: 'xpath=/html[1]/body[1]/div[1]/span[1]',
+        description: 'Favorite Colour',
+        method: 'click',
+        arguments: []
+      },
+      {
+        selector: 'xpath=/html[1]/body[1]/div[2]/div[1]/section[1]/div[1]/div[1]/div[25]',
+        description: 'Peach',
+        method: 'click',
+        arguments: []
+      }
+    ]
+  },
+  metadata: {
+    actionId: 'act_01HZY...',
+    cacheStatus: 'MISS'
+  }
+}
 ```
+</View>
 
-Always check `data.success` before assuming the action ran. See the full field list in the
-[`stagehand` reference](/v4/reference/stagehand).
-
-<Card title="Complete act() reference" icon="book" href="/v4/reference/stagehand">
-  Full parameters, per-call options, and the `ActResult` shape.
-</Card>
-
-## Advanced configuration
-
-You can pass additional options to configure `act()` for your exact use case:
-
+<View title="Python" icon="python">
 ```python
-import os
-
-from stagehand import ModelConfig
-
-
-await stagehand.act(
-    "Choose 'Peach' from the favorite color dropdown",
-    model=ModelConfig.model_validate(
-        {
-            "model_name": "google/gemini-2.5-flash",
-            "api_key": os.environ["GOOGLE_API_KEY"],
-        }
+ActResult(
+    data=ActResultData(
+        success=True,
+        message="Action [click] performed successfully on selector: xpath=/html[1]/body[1]/div[1]/span[1]",
+        action_description="Favorite Colour",
+        actions=[
+            Action(
+                selector="xpath=/html[1]/body[1]/div[1]/span[1]",
+                description="Favorite Colour",
+                method="click",
+                arguments=[],
+            ),
+            Action(
+                selector="xpath=/html[1]/body[1]/div[2]/div[1]/section[1]/div[1]/div[1]/div[25]",
+                description="Peach",
+                method="click",
+                arguments=[],
+            ),
+        ],
     ),
-    timeout=10_000,
+    metadata=StagehandResultMetadata(
+        action_id="act_01HZY...",
+        cache_status="MISS",
+    ),
 )
 ```
+</View>
 
-- `page`: the page to act on. Defaults to the active page.
-- `model`: override the complete model configuration for this call.
-- `timeout`: maximum time in milliseconds.
-- `variables`: values substituted into the instruction (see below).
-- `cache`: reuse a prior result for this call.
+<View title="Go" icon="golang">
+```go
+stagehand.ActResult{
+	Data: stagehand.ActResultData{
+		Success:           true,
+		Message:           "Action [click] performed successfully on selector: xpath=/html[1]/body[1]/div[1]/span[1]",
+		ActionDescription: "Favorite Colour",
+		Actions: []stagehand.Action{
+			{
+				Selector:    "xpath=/html[1]/body[1]/div[1]/span[1]",
+				Description: "Favorite Colour",
+				Method:      &clickMethod,
+				Arguments:   []string{},
+			},
+			{
+				Selector:    "xpath=/html[1]/body[1]/div[2]/div[1]/section[1]/div[1]/div[1]/div[25]",
+				Description: "Peach",
+				Method:      &clickMethod,
+				Arguments:   []string{},
+			},
+		},
+	},
+	Metadata: stagehand.StagehandResultMetadata{
+		ActionID:    &actionID,
+		CacheStatus: &cacheStatus,
+	},
+}
+```
+</View>
 
-### Variables
 
-Variables keep sensitive or dynamic values **out of the model prompt**. Reference them in
-the instruction with `%name%`. A variable can be a plain value, or a
-`{ value, description }` object to give the model a hint about a secret without revealing
-it.
+<Tabs>
+<Tab title="Do this" icon="check">
+Break your task into single-step actions.
 
+<View title="TypeScript" icon="js">
+```typescript
+// Break it into single-step actions
+await stagehand.act("open the filters panel");
+await stagehand.act("choose 4-star rating");
+await stagehand.act("click the apply button");
+```
+</View>
+
+<View title="Python" icon="python">
 ```python
+# Break it into single-step actions
+await stagehand.act("open the filters panel")
+await stagehand.act("choose 4-star rating")
+await stagehand.act("click the apply button")
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+// Break it into single-step actions
+if _, err := client.Act(ctx, "open the filters panel", nil); err != nil {
+	return err
+}
+if _, err := client.Act(ctx, "choose 4-star rating", nil); err != nil {
+	return err
+}
+if _, err := client.Act(ctx, "click the apply button", nil); err != nil {
+	return err
+}
+```
+</View>
+</Tab>
+
+<Tab title="Don't do this" icon="xmark">
+Multi-step instructions are unreliable. Sequence them yourself instead.
+
+<View title="TypeScript" icon="js">
+```typescript
+// Too complex - trying to do multiple things at once
+await stagehand.act("open the filters panel, choose 4-star rating, and click apply");
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+# Too complex - trying to do multiple things at once
+await stagehand.act("open the filters panel, choose 4-star rating, and click apply")
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+// Too complex - trying to do multiple things at once
+result, err := client.Act(ctx, "open the filters panel, choose 4-star rating, and click apply", nil)
+```
+</View>
+</Tab>
+</Tabs>
+
+## Advanced Configuration
+
+You can pass additional options to configure the model, timeout, variables, and target page:
+
+<View title="TypeScript" icon="js">
+```typescript
+// Custom model configuration
+await stagehand.act("choose 'Peach' from the favorite color dropdown", {
+  model: {
+    modelName: "google/gemini-2.5-flash",
+    apiKey: process.env.GOOGLE_API_KEY,
+  },
+  timeout: 10000,
+});
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+# Custom model configuration
+from stagehand import ModelConfig
+
 await stagehand.act(
-    "Type %username% into the email field",
+    "choose 'Peach' from the favorite color dropdown",
+    model=ModelConfig.model_validate({
+        "model_name": "google/gemini-2.5-flash",
+        "api_key": os.environ["GOOGLE_API_KEY"],
+    }),
+    timeout=10000,
+)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+// Custom model configuration
+modelAPIKey := os.Getenv("GOOGLE_API_KEY")
+model := stagehand.KnownModel(stagehand.KnownModelConfig{
+	ModelName: "google/gemini-2.5-flash",
+	APIKey:    &modelAPIKey,
+})
+timeout := 10000.0
+
+result, err := client.Act(ctx, "choose 'Peach' from the favorite color dropdown", &stagehand.StagehandClientActOptions{
+	ActOptions: stagehand.ActOptions{
+		Model:   &model,
+		Timeout: &timeout,
+	},
+})
+```
+</View>
+
+### Server-side Caching
+
+<Note>
+`cache` requires the Browserbase browser source and a Browserbase API key. It has no effect on local or CDP browsers.
+</Note>
+
+When running on Browserbase, Stagehand can cache `act()` results server-side. Repeated calls with the same inputs return instantly without consuming LLM tokens. Enable caching on the constructor and override it per call:
+
+<View title="TypeScript" icon="js">
+```typescript
+// Enable server-side caching for the entire instance
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  browser: { type: "browserbase" },
+  cache: true,
+});
+
+// Or disable it for a single call
+await stagehand.act("click the login button", { cache: false });
+
+// Or lower the hit-count threshold for a single call
+await stagehand.act("click the login button", { cache: { threshold: 1 } });
+
+// Check whether a result was served from cache
+const result = await stagehand.act("click the login button");
+console.log(result.metadata.cacheStatus); // "HIT", "MISS", or undefined
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+from stagehand import CacheOptions, Stagehand
+
+# Enable server-side caching for the entire instance
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    browser="browserbase",
+    cache=True,
+)
+
+# Or disable it for a single call
+await stagehand.act("click the login button", cache=False)
+
+# Or lower the hit-count threshold for a single call
+await stagehand.act("click the login button", cache=CacheOptions(threshold=1))
+
+# Check whether a result was served from cache
+result = await stagehand.act("click the login button")
+print(result.metadata.cache_status)  # "HIT", "MISS", or None
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+// Enable server-side caching for the entire instance
+apiKey := os.Getenv("BROWSERBASE_API_KEY")
+instanceCache := stagehand.CacheEnabled(true)
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey:  &apiKey,
+	Browser: stagehand.BrowserbaseClientBrowserSource{},
+	Cache:   &instanceCache,
+})
+
+// Or disable it for a single call
+off := stagehand.CacheEnabled(false)
+_, err := client.Act(ctx, "click the login button", &stagehand.StagehandClientActOptions{
+	ActOptions: stagehand.ActOptions{Cache: &off},
+})
+
+// Or lower the hit-count threshold for a single call
+eager := stagehand.CacheWithThreshold(1)
+_, err = client.Act(ctx, "click the login button", &stagehand.StagehandClientActOptions{
+	ActOptions: stagehand.ActOptions{Cache: &eager},
+})
+
+// Check whether a result was served from cache
+result, err := client.Act(ctx, "click the login button", nil)
+if result.Metadata.CacheStatus != nil {
+	fmt.Println(*result.Metadata.CacheStatus) // "HIT" or "MISS"
+}
+```
+</View>
+
+<Card title="Complete caching guide" icon="database" iconType="sharp-solid" href="/v4/best-practices/caching">
+  Learn how the cache key is built, what the threshold does, and when results are invalidated.
+</Card>
+
+### Using with Custom Pages
+
+Stagehand v4 drives the browser directly over the Chrome DevTools Protocol, so there is no Puppeteer, Playwright, or Patchright page interop. Instead, target any page Stagehand manages by passing the `page` option:
+
+<View title="TypeScript" icon="js">
+```typescript
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  browser: { type: "browserbase" },
+});
+await stagehand.init();
+
+// Open a second page in the same browser context
+const blogPage = await stagehand.context.newPage();
+await blogPage.goto("https://www.example.com/blog");
+
+// Use act with that specific page
+await stagehand.act("click the next page button", {
+  page: blogPage,
+});
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    browser="browserbase",
+)
+await stagehand.init()
+
+# Open a second page in the same browser context
+blog_page = await stagehand.context.new_page()
+await blog_page.goto("https://www.example.com/blog")
+
+# Use act with that specific page
+await stagehand.act("click the next page button", page=blog_page)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+apiKey := os.Getenv("BROWSERBASE_API_KEY")
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey:  &apiKey,
+	Browser: stagehand.BrowserbaseClientBrowserSource{},
+})
+if err := client.Init(ctx); err != nil {
+	return err
+}
+
+browserContext, err := client.Context()
+if err != nil {
+	return err
+}
+
+// Open a second page in the same browser context
+blogPage, err := browserContext.NewPage(ctx, stagehand.ContextNewPageParams{})
+if err != nil {
+	return err
+}
+if err := blogPage.Goto(ctx, "https://www.example.com/blog", nil); err != nil {
+	return err
+}
+
+// Use Act with that specific page
+_, err = client.Act(ctx, "click the next page button", &stagehand.StagehandClientActOptions{
+	Page: blogPage,
+})
+```
+</View>
+
+This works with:
+- **Active page:** omit `page` and Stagehand uses `context.activePage()` (default)
+- **Existing pages:** index into `context.pages()`
+- **New pages:** create one with `context.newPage()`
+- **Existing browsers:** attach to a browser you already run with the `cdp` browser source
+
+<Card title="Complete API Reference" icon="book" href="/v4/references/stagehand">
+  See the full `Stagehand` reference for detailed parameter documentation, return values, and advanced examples.
+</Card>
+
+
+
+
+## Best practices
+
+### Ensure reliable actions
+
+Use `observe()` to discover candidate actions on the current page and plan reliably. It returns a list of suggested actions (with selector, description, method, and arguments). Inspect the action before you commit to it, then hand it straight back to `act`:
+
+<View title="TypeScript" icon="js">
+```typescript
+const { data: actions } = await stagehand.observe("click the login button");
+const [action] = actions;
+
+if (action?.method === "click") {
+  // No inference: Stagehand replays the observed action
+  await stagehand.act(action);
+}
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+result = await stagehand.observe(instruction="click the login button")
+
+if result.data and result.data[0].method == "click":
+    # No inference: Stagehand replays the observed action
+    await stagehand.act(result.data[0])
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+instruction := "click the login button"
+observed, err := client.Observe(ctx, &instruction, nil)
+if err != nil {
+	return err
+}
+
+if len(observed.Data) > 0 && observed.Data[0].Method != nil && *observed.Data[0].Method == "click" {
+	// No inference: Stagehand replays the observed action
+	if _, err := client.Act(ctx, observed.Data[0], nil); err != nil {
+		return err
+	}
+}
+```
+</View>
+
+<Note>
+Replaying an `Action` skips model inference, the page snapshot, and the DOM-settle wait, and it does not consult the server-side cache. If the recorded selector no longer resolves and `selfHeal` is on, Stagehand re-infers the action and retries once.
+</Note>
+
+<Card title="Analyze pages with observe()" icon="magnifying-glass" iconType="sharp-solid" href="/v4/basics/observe">
+  Plan actions with `observe()` before executing with `act`.
+</Card>
+
+### Reduce model costs
+
+Enable server-side caching with `cache` when running on Browserbase. The first time an action runs it is cached; once the hit-count threshold is met, subsequent identical calls are served from the cache without an LLM call.
+
+<View title="TypeScript" icon="js">
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  browser: { type: "browserbase" },
+  cache: { threshold: 1 }, // Actions are cached after one identical result
+});
+
+await stagehand.init();
+
+// First run makes an LLM call and records the action
+await stagehand.act("click the login button");
+
+// Second run is served from the cache
+await stagehand.act("click the login button");
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+from stagehand import CacheOptions, Stagehand
+
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    browser="browserbase",
+    cache=CacheOptions(threshold=1),  # Actions are cached after one identical result
+)
+
+await stagehand.init()
+
+# First run makes an LLM call and records the action
+await stagehand.act("click the login button")
+
+# Second run is served from the cache
+await stagehand.act("click the login button")
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+apiKey := os.Getenv("BROWSERBASE_API_KEY")
+cache := stagehand.CacheWithThreshold(1) // Actions are cached after one identical result
+
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey:  &apiKey,
+	Browser: stagehand.BrowserbaseClientBrowserSource{},
+	Cache:   &cache,
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+
+// First run makes an LLM call and records the action
+if _, err := client.Act(ctx, "click the login button", nil); err != nil {
+	return err
+}
+
+// Second run is served from the cache
+if _, err := client.Act(ctx, "click the login button", nil); err != nil {
+	return err
+}
+```
+</View>
+
+<Note>
+The cache lives on Browserbase, keyed on the instruction, page content, and call options, so it persists across script executions and across machines. The model configuration is deliberately excluded from the key, so switching models does not invalidate your cache.
+</Note>
+
+<Card title="Complete caching guide" icon="database" iconType="sharp-solid" href="/v4/best-practices/caching">
+  Learn advanced caching techniques and patterns for optimal performance.
+</Card>
+
+### Secure your automations
+
+Variables are **not shared with LLM providers**. Use them for passwords, API keys, and other sensitive data. Stagehand exposes only the variable names to the model and substitutes the real values locally, so the results and the cache record the placeholder rather than the secret.
+
+<Note>
+Load sensitive data from environment variables. Never hardcode API keys, passwords, or other secrets directly in your code.
+</Note>
+
+<View title="TypeScript" icon="js">
+```typescript
+// Variables use %variableName% syntax in the instruction
+await stagehand.act("type %username% into the email field", {
+  variables: { username: "user@example.com" },
+});
+
+await stagehand.act("type %password% into the password field", {
+  variables: { password: process.env.USER_PASSWORD },
+});
+
+await stagehand.act("click the login button");
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+# Variables use %variable_name% syntax in the instruction
+await stagehand.act(
+    "type %username% into the email field",
     variables={"username": "user@example.com"},
 )
 
 await stagehand.act(
-    "Type %password% into the password field",
-    variables={
-        "password": {"value": os.environ["USER_PASSWORD"], "description": "the login password"}
-    },
+    "type %password% into the password field",
+    variables={"password": os.environ["USER_PASSWORD"]},
 )
 
-await stagehand.act("Click the login button")
+await stagehand.act("click the login button")
 ```
+</View>
+
+<View title="Go" icon="golang">
+```go
+// Variables use %variableName% syntax in the instruction
+_, err := client.Act(ctx, "type %username% into the email field", &stagehand.StagehandClientActOptions{
+	ActOptions: stagehand.ActOptions{
+		Variables: stagehand.Variables{
+			"username": stagehand.PrimitiveVariable(stagehand.StringVariable("user@example.com")),
+		},
+	},
+})
+
+password := os.Getenv("USER_PASSWORD")
+_, err = client.Act(ctx, "type %password% into the password field", &stagehand.StagehandClientActOptions{
+	ActOptions: stagehand.ActOptions{
+		Variables: stagehand.Variables{
+			"password": stagehand.PrimitiveVariable(stagehand.StringVariable(password)),
+		},
+	},
+})
+
+_, err = client.Act(ctx, "click the login button", nil)
+```
+</View>
 
 <Warning>
-  Load secrets from environment variables, and never hardcode them. Variables are substituted
-  locally, so their values are not sent to the model provider as part of the instruction.
+When handling sensitive data, turn logging off in your Stagehand configuration to prevent secrets from appearing in logs. See the [logging guide](/v4/configuration/logging) for more details.
 </Warning>
 
-## Best practices
-
-### Plan reliably with `observe()`
-
-`observe()` returns candidate actions on the current page. Use it to verify an element
-exists or to preview what `act()` will do.
-
-```python
-candidates = await stagehand.observe(instruction="Find the login button")
-if candidates.data:
-    await stagehand.act("Click the login button")
-```
-
-<Card title="Plan with observe()" icon="eye" href="/v4/basics/observe">
-  Discover and verify actions before you run them.
+<Card title="User Data Best Practices" icon="shield-check" iconType="sharp-solid" href="/v4/best-practices/user-data">
+  Complete guide to persisting and securing browser state across sessions.
 </Card>
-
-### Be specific
-
-Ambiguous instructions can target the wrong element. Add context like position, nearby
-text, or a visual cue: `"Click the red 'Delete' button next to the user John Smith"`.
-
-### Cache repeated actions
-
-On Browserbase, turn on caching
-so repeated, identical actions are served from a cache instead of calling the model again.
-
-```python
-result = await stagehand.act("Click the sign in button", cache=True)
-print(result.metadata.cache_status)
-```
 
 ## Troubleshooting
 
 <AccordionGroup>
-  <Accordion title="Action failed or timed out">
 
-Make sure the page has finished loading, increase `timeout`, and use `observe()` to confirm
-the target element exists before acting.
 
-```python
-await page.wait_for_load_state("domcontentloaded")
+<Accordion title="Method not supported">
+**Problem**: `act` fails with "method not supported" error
 
-candidates = await stagehand.observe(instruction="Find the submit button")
-if candidates.data:
-    await stagehand.act("Click the submit button", timeout=30_000)
+**Solutions**:
+- Use clear and detailed instructions for what you want to accomplish
+- Review our [evals](https://stagehand.dev/evals) to find the best models for your use case
+- Use [`observe()`](/v4/basics/observe) and verify the resulting action is within a list of expected actions
+
+**Solution 1: Validate with observe**
+
+<View title="TypeScript" icon="js">
+```typescript
+const prompt = "click the submit button";
+const expectedMethod = "click";
+
+try {
+  await stagehand.act(prompt);
+} catch (error) {
+  if (error.message.includes("method not supported")) {
+    // Observe the same prompt to get the planned action
+    const { data: actions } = await stagehand.observe(prompt);
+    const [action] = actions;
+
+    if (action && action.method === expectedMethod) {
+      await stagehand.act(action);
+    } else {
+      throw new Error(`Unsupported method: expected "${expectedMethod}", got "${action?.method}"`);
+    }
+  } else {
+    throw error;
+  }
+}
 ```
+</View>
+
+<View title="Python" icon="python">
+```python
+prompt = "click the submit button"
+expected_method = "click"
+
+try:
+    await stagehand.act(prompt)
+except Exception as error:
+    if "method not supported" not in str(error):
+        raise
+
+    # Observe the same prompt to get the planned action
+    observed = await stagehand.observe(instruction=prompt)
+    action = observed.data[0] if observed.data else None
+
+    if action is not None and action.method == expected_method:
+        await stagehand.act(action)
+    else:
+        method = action.method if action else None
+        raise RuntimeError(f'Unsupported method: expected "{expected_method}", got "{method}"')
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+prompt := "click the submit button"
+expectedMethod := "click"
+
+if _, err := client.Act(ctx, prompt, nil); err != nil {
+	if !strings.Contains(err.Error(), "method not supported") {
+		return err
+	}
+
+	// Observe the same prompt to get the planned action
+	observed, observeErr := client.Observe(ctx, &prompt, nil)
+	if observeErr != nil {
+		return observeErr
+	}
+	if len(observed.Data) == 0 {
+		return fmt.Errorf("no action found for %q", prompt)
+	}
+
+	action := observed.Data[0]
+	if action.Method == nil || *action.Method != expectedMethod {
+		return fmt.Errorf("unsupported method: expected %q, got %v", expectedMethod, action.Method)
+	}
+	if _, err := client.Act(ctx, action, nil); err != nil {
+		return err
+	}
+}
+```
+</View>
+
+**Solution 2: Retry with exponential backoff**
+
+<View title="TypeScript" icon="js">
+```typescript
+// Retry with exponential backoff for intermittent issues
+const prompt = "click the submit button";
+const maxRetries = 3;
+
+for (let attempt = 0; attempt <= maxRetries; attempt++) {
+  try {
+    await stagehand.act(prompt, { timeout: 10000 + (attempt * 5000) });
+    break; // Success, exit retry loop
+  } catch (error) {
+    if (error.message.includes("method not supported") && attempt < maxRetries) {
+      // Exponential backoff: wait 2^attempt seconds
+      const delay = Math.pow(2, attempt) * 1000;
+      console.log(`Retry ${attempt + 1}/${maxRetries} after ${delay}ms`);
+      await new Promise(resolve => setTimeout(resolve, delay));
+    } else {
+      throw error;
+    }
+  }
+}
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+# Retry with exponential backoff for intermittent issues
+import asyncio
+
+prompt = "click the submit button"
+max_retries = 3
+
+for attempt in range(max_retries + 1):
+    try:
+        await stagehand.act(prompt, timeout=10000 + (attempt * 5000))
+        break  # Success, exit retry loop
+    except Exception as error:
+        if "method not supported" in str(error) and attempt < max_retries:
+            # Exponential backoff: wait 2^attempt seconds
+            delay = 2**attempt
+            print(f"Retry {attempt + 1}/{max_retries} after {delay * 1000}ms")
+            await asyncio.sleep(delay)
+        else:
+            raise
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+// Retry with exponential backoff for intermittent issues
+prompt := "click the submit button"
+const maxRetries = 3
+
+for attempt := 0; attempt <= maxRetries; attempt++ {
+	timeout := float64(10000 + attempt*5000)
+	_, err := client.Act(ctx, prompt, &stagehand.StagehandClientActOptions{
+		ActOptions: stagehand.ActOptions{Timeout: &timeout},
+	})
+	if err == nil {
+		break // Success, exit retry loop
+	}
+	if !strings.Contains(err.Error(), "method not supported") || attempt == maxRetries {
+		return err
+	}
+	// Exponential backoff: wait 2^attempt seconds
+	delay := time.Duration(1<<attempt) * time.Second
+	fmt.Printf("Retry %d/%d after %v\n", attempt+1, maxRetries, delay)
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(delay):
+	}
+}
+```
+</View>
 
 </Accordion>
-  <Accordion title="Wrong element selected">
 
-Be more specific in the instruction, or preview the target with `observe()` and inspect its
-`description` before calling `act()`.
+<Accordion title="Action failed or timed out">
+**Problem**: `act` times out or fails to complete action (often due to element not found)
 
-```python
-# Instead of a vague instruction:
-await stagehand.act("Click the button")
+**Solutions**:
+- Ensure page has fully loaded
+- Check if content is in iframes: Stagehand traverses them automatically, but a scoped `selector` can help
+- Increase action timeout
+- Use `observe()` first to verify element exists
+- Raise `domSettleTimeoutMs` on the constructor if the page keeps mutating after load
 
-# Add context so the target is unambiguous:
-await stagehand.act("Click the red 'Delete' button next to the user John Smith")
+<View title="TypeScript" icon="js">
+```typescript
+// Handle timeout and element not found issues
+try {
+  await stagehand.act("click the submit button", { timeout: 30000 });
+} catch (error) {
+  // Check if page is fully loaded
+  await page.waitForLoadState("domcontentloaded");
 
-# Or preview with observe() and confirm the description before acting:
-candidates = await stagehand.observe(instruction="Find the submit button in the checkout form")
-if candidates.data and "checkout" in candidates.data[0].description.lower():
-    await stagehand.act("Click the submit button in the checkout form")
+  // Use observe to check element state
+  const { data: elements } = await stagehand.observe("find the submit button");
+
+  if (elements.length > 0) {
+    console.log("Element found, trying more specific instruction");
+    await stagehand.act("click the submit button at the bottom of the form");
+  } else {
+    console.log("Element not found, trying alternative selector");
+    await stagehand.act("click the button with text 'Submit'");
+  }
+}
 ```
-
-  </Accordion>
-</AccordionGroup>
-
 </View>
+
+<View title="Python" icon="python">
+```python
+# Handle timeout and element not found issues
+try:
+    await stagehand.act("click the submit button", timeout=30000)
+except Exception:
+    # Check if page is fully loaded
+    await page.wait_for_load_state("domcontentloaded")
+
+    # Use observe to check element state
+    observed = await stagehand.observe(instruction="find the submit button")
+
+    if observed.data:
+        print("Element found, trying more specific instruction")
+        await stagehand.act("click the submit button at the bottom of the form")
+    else:
+        print("Element not found, trying alternative selector")
+        await stagehand.act("click the button with text 'Submit'")
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+// Handle timeout and element not found issues
+timeout := 30000.0
+if _, err := client.Act(ctx, "click the submit button", &stagehand.StagehandClientActOptions{
+	ActOptions: stagehand.ActOptions{Timeout: &timeout},
+}); err != nil {
+	// Check if page is fully loaded
+	if err := page.WaitForLoadState(ctx, stagehand.LoadStateDOMContentLoaded, nil); err != nil {
+		return err
+	}
+
+	// Use Observe to check element state
+	instruction := "find the submit button"
+	observed, observeErr := client.Observe(ctx, &instruction, nil)
+	if observeErr != nil {
+		return observeErr
+	}
+
+	if len(observed.Data) > 0 {
+		fmt.Println("Element found, trying more specific instruction")
+		_, err = client.Act(ctx, "click the submit button at the bottom of the form", nil)
+	} else {
+		fmt.Println("Element not found, trying alternative selector")
+		_, err = client.Act(ctx, "click the button with text 'Submit'", nil)
+	}
+	if err != nil {
+		return err
+	}
+}
+```
+</View>
+</Accordion>
+
+<Accordion title="Incorrect element selected">
+**Problem**: `act` performs action on wrong element
+
+**Solutions**:
+- Be more specific in instructions: include visual cues, position, or context
+- Use `observe()` to preview which element will be selected
+- Add contextual information: "the search button in the header"
+- Use unique identifiers when available
+
+<View title="TypeScript" icon="js">
+```typescript
+// More precise element targeting
+// Instead of:
+await stagehand.act("click the button");
+
+// Use specific context:
+await stagehand.act("click the red 'Delete' button next to the user John Smith");
+
+// Or preview with observe first:
+const { data: actions } = await stagehand.observe("click the submit button in the checkout form");
+const [action] = actions;
+if (action.description.includes("checkout")) {
+  await stagehand.act(action);
+}
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+# More precise element targeting
+# Instead of:
+await stagehand.act("click the button")
+
+# Use specific context:
+await stagehand.act("click the red 'Delete' button next to the user John Smith")
+
+# Or preview with observe first:
+observed = await stagehand.observe(
+    instruction="click the submit button in the checkout form"
+)
+if "checkout" in observed.data[0].description:
+    await stagehand.act(observed.data[0])
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+// More precise element targeting
+// Instead of:
+_, err := client.Act(ctx, "click the button", nil)
+
+// Use specific context:
+_, err = client.Act(ctx, "click the red 'Delete' button next to the user John Smith", nil)
+
+// Or preview with Observe first:
+instruction := "click the submit button in the checkout form"
+observed, err := client.Observe(ctx, &instruction, nil)
+if err != nil {
+	return err
+}
+if len(observed.Data) > 0 && strings.Contains(observed.Data[0].Description, "checkout") {
+	if _, err := client.Act(ctx, observed.Data[0], nil); err != nil {
+		return err
+	}
+}
+```
+</View>
+</Accordion>
+
+
+
+</AccordionGroup>
 
 ## Next steps
 
-<CardGroup cols="2">
-  <Card title="Observe" icon="eye" href="/v4/basics/observe">
-    Preview actions before executing them.
+<CardGroup cols={2}>
+
+  <Card title="Discover actions with observe()" icon="magnifying-glass" iconType="sharp-solid" href="/v4/basics/observe">
+    Use `observe()` to plan actions before executing them.
   </Card>
-  <Card title="Extract" icon="download" href="/v4/basics/extract">
-    Pull typed data from a page.
+
+   <Card title="Caching actions" icon="bolt" iconType="sharp-solid" href="/v4/best-practices/caching">
+    Speed up repeated automations by caching actions.
+  </Card>
+
+  <Card title="Extract data with extract()" icon="table" iconType="sharp-solid" href="/v4/basics/extract">
+    Use `extract` with a data schema to pull clean, typed data from any page.
+  </Card>
+
+  <Card title="Work across multiple tabs" icon="clone" iconType="sharp-solid" href="/v4/best-practices/using-multiple-tabs">
+    Target a specific page with the `page` option.
   </Card>
 </CardGroup>

--- a/packages/docs/v4/basics/extract.mdx
+++ b/packages/docs/v4/basics/extract.mdx
@@ -148,7 +148,8 @@ Product(name="Wireless Mouse", price=29.99, in_stock=True)
 
 <View title="Go" icon="golang">
 ```go
-product{Name: "Wireless Mouse", Price: 29.99, InStock: true}
+result := product{Name: "Wireless Mouse", Price: 29.99, InStock: true}
+fmt.Println(result.Name, result.Price, result.InStock)
 ```
 </View>
 
@@ -268,10 +269,11 @@ Apartments(apartments=[
 
 <View title="Go" icon="golang">
 ```go
-apartments{Apartments: []apartment{
+result := apartments{Apartments: []apartment{
 	{Address: "123 Main St", Price: "$1,200/mo", Sqft: 750},
 	{Address: "456 Oak Ave", Price: "$1,500/mo", Sqft: 900},
 }}
+fmt.Println(result.Apartments[0].Address, result.Apartments[0].Sqft)
 ```
 </View>
 
@@ -343,7 +345,8 @@ Price(price=19.99)
 
 <View title="Go" icon="golang">
 ```go
-price{Price: 19.99}
+result := price{Price: 19.99}
+fmt.Println(result.Price)
 ```
 </View>
 
@@ -462,6 +465,12 @@ result, err := client.Extract(ctx, "extract the repository name", repositorySche
 		Selector: &selector,
 	},
 })
+if err != nil {
+	return err
+}
+
+// Extract hands back the raw JSON; use stagehand.ExtractAs to decode into a type
+fmt.Println(string(result.Data))
 ```
 </View>
 
@@ -540,6 +549,9 @@ off := stagehand.CacheEnabled(false)
 result, err := client.Extract(ctx, "extract the repository name", repositorySchema, &stagehand.StagehandClientExtractOptions{
 	ExtractOptions: stagehand.ExtractOptions{Cache: &off},
 })
+if err != nil {
+	return err
+}
 
 // Cache status travels on the result metadata
 if result.Metadata.CacheStatus != nil {
@@ -1015,6 +1027,11 @@ extracted, err := stagehand.ExtractAs[products](
 	productsSchema,
 	nil,
 )
+if err != nil {
+	return err
+}
+
+fmt.Println("extracted", len(extracted.Products), "products")
 ```
 </View>
 </Accordion>
@@ -1173,6 +1190,13 @@ extracted, err := stagehand.ExtractAs[products](
 	productsSchema,
 	nil,
 )
+if err != nil {
+	return err
+}
+
+for _, item := range extracted.Products {
+	fmt.Println(item.Name, item.Price)
+}
 ```
 </View>
 </Accordion>

--- a/packages/docs/v4/basics/extract.mdx
+++ b/packages/docs/v4/basics/extract.mdx
@@ -5,242 +5,86 @@ description: "Extract structured data from a webpage."
 
 ## What is `extract()`?
 
-`extract()` reads a page and returns data that matches a schema you define. The result is
-validated against that schema, so you get fully typed data back.
-
 <View title="TypeScript" icon="js">
-
-Define the schema as a [Zod](https://zod.dev) object:
-
 ```typescript
-import { z } from "zod";
-
-const { data: product } = await stagehand.extract(
-  "Extract the product name and price",
-  z.object({
-    name: z.string(),
-    price: z.number(),
-  }),
-);
-// product: { name: string; price: number }
-```
-
-## Why use `extract()`?
-
-<CardGroup cols="2">
-  <Card title="Typed output" icon="brackets-curly">
-    Results are validated and typed against your schema.
-  </Card>
-  <Card title="Resilient" icon="shield-check">
-    Reads meaning, not markup, so there are no brittle scraping selectors.
-  </Card>
-  <Card title="Scoped" icon="crop">
-    Narrow extraction to part of the page for speed and accuracy.
-  </Card>
-  <Card title="Visual" icon="image">
-    Optionally include a screenshot for layout-dependent data.
-  </Card>
-</CardGroup>
-
-## Using `extract()`
-
-Describe exactly the shape you want. Add fields for lists, nested objects, and optional
-values, and use field descriptions to guide the model.
-
-```typescript
-import { z } from "zod";
-
-const { data: results } = await stagehand.extract(
-  "Extract each search result",
-  z.object({
-    results: z.array(
-      z.object({
-        title: z.string(),
-        url: z.string().describe("The absolute link to the result"),
-        rating: z.number().optional(),
-      }),
-    ),
-  }),
+await stagehand.extract(
+  "extract the name of the repository",
+  z.object({ name: z.string() }),
 );
 ```
-
-### Return value
-
-`extract()` resolves to an object with `data` and `metadata`. `data` matches your schema:
-in TypeScript its type is inferred from Zod, and in Python it is an instance of your
-Pydantic model. `metadata` contains Stagehand-owned information such as cache status and
-an optional action ID.
-
-```typescript
-const extraction = await stagehand.extract(
-  "Extract the product details",
-  z.object({ name: z.string(), price: z.number(), inStock: z.boolean() }),
-);
-// extraction.data is typed as { name: string; price: number; inStock: boolean }
-
-console.log(extraction.data.name, extraction.data.price);
-console.log(extraction.metadata.cacheStatus);
-```
-
-## Advanced configuration
-
-```typescript
-const extraction = await stagehand.extract("Extract the article body", schema, {
-  selector: "#main-content",
-  ignoreSelectors: ["nav", ".cookie-banner"],
-  screenshot: true,
-  timeout: 30_000,
-  model: { modelName: "openai/gpt-5.4-mini", apiKey: process.env.OPENAI_API_KEY },
-});
-```
-
-- `page`: the page to extract from. Defaults to the active page.
-- `selector`: a CSS selector that scopes extraction to one element and its subtree.
-- `ignoreSelectors`: elements to exclude, such as ads, chrome, and boilerplate.
-- `screenshot`: include a screenshot of the viewport for layout-dependent extraction.
-- `timeout`: maximum time in milliseconds.
-- `model`: override the model for this call.
-- `cache`: reuse a prior result for this call.
-
-### Scoped extraction
-
-When a page is large, scoping to the relevant region with `selector` (and excluding noise
-with `ignoreSelectors`) is faster, cheaper, and more accurate than extracting from the
-whole document.
-
-```typescript
-const {
-  data: { price },
-} = await stagehand.extract(
-  "Extract the sale price",
-  z.object({ price: z.number() }),
-  { selector: "#product-summary", ignoreSelectors: [".related-products"] },
-);
-```
-
-### Visual extraction
-
-Set `screenshot` to include an image of the current viewport in the model call. This helps
-when the data depends on layout or styling that isn't obvious from the DOM alone.
-
-### Cache repeated extractions
-
-On Browserbase, turn on caching
-so repeated, identical extractions are served from a cache instead of calling the model again.
-
-```typescript
-const extraction = await stagehand.extract(
-  "Extract the product name and price",
-  z.object({ name: z.string(), price: z.number() }),
-  { cache: true },
-);
-console.log(extraction.data, extraction.metadata.cacheStatus);
-```
-
-## Best practices
-
-- **Ask for exactly what you need:** Smaller schemas are faster and more reliable than
-  "extract everything."
-- **Use descriptions:** Field descriptions disambiguate similar values (for example, which
-  price is the sale price).
-- **Scope first:** Reach for `selector`/`ignoreSelectors` before extracting from a busy
-  page.
-
-## Troubleshooting
-
-<AccordionGroup>
-  <Accordion title="Missing or empty fields">
-    Make the instruction and field descriptions more specific, mark truly optional fields
-    as optional, and confirm the data is actually present in the scoped region.
-  </Accordion>
-  <Accordion title="Wrong value picked">
-
-Narrow with `selector`, exclude distractors with `ignoreSelectors`, or enable `screenshot`
-when the correct value is clear visually but ambiguous in the DOM.
-
-```typescript
-const {
-  data: { price },
-} = await stagehand.extract(
-  "Extract the sale price, not the original price",
-  z.object({ price: z.number() }),
-  { selector: "#product-summary", ignoreSelectors: [".related-products"] },
-);
-```
-
-  </Accordion>
-</AccordionGroup>
-
 </View>
 
 <View title="Python" icon="python">
-
-Define the schema as a [Pydantic](https://docs.pydantic.dev/) model:
-
 ```python
-from pydantic import BaseModel
-
-
-class Product(BaseModel):
+class Repository(BaseModel):
     name: str
-    price: float
 
 
-extraction = await stagehand.extract(
-    instruction="Extract the product name and price",
-    schema=Product,
+await stagehand.extract(
+    instruction="extract the name of the repository",
+    schema=Repository,
 )
-# extraction.data.name -> str, extraction.data.price -> float
 ```
+</View>
+
+<View title="Go" icon="golang">
+```go
+type repository struct {
+	Name string `json:"name"`
+}
+
+var repositorySchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {"name": {"type": "string"}},
+  "required": ["name"],
+  "additionalProperties": false
+}`)
+
+extracted, err := stagehand.ExtractAs[repository](
+	ctx,
+	client,
+	"extract the name of the repository",
+	repositorySchema,
+	nil,
+)
+```
+</View>
+
+`extract()` grabs structured data from a webpage. Every call takes an instruction and a schema: [Zod](https://github.com/colinhacks/zod) in TypeScript, [Pydantic](https://docs.pydantic.dev) in Python. The result is validated against your schema before it is returned, so what you get back is already typed.
 
 ## Why use `extract()`?
 
-<CardGroup cols="2">
-  <Card title="Typed output" icon="brackets-curly">
-    Results are validated and typed against your schema.
+<CardGroup cols={2}>
+  <Card title="Structured" icon="brackets-curly" href="#basic-schema">
+    Turn messy webpage data into clean objects that follow a schema.
   </Card>
-  <Card title="Resilient" icon="shield-check">
-    Reads meaning, not markup, so there are no brittle scraping selectors.
-  </Card>
-  <Card title="Scoped" icon="crop">
-    Narrow extraction to part of the page for speed and accuracy.
-  </Card>
-  <Card title="Visual" icon="image">
-    Optionally include a screenshot for layout-dependent data.
+  <Card title="Resilient" icon="dumbbell" href="#extract-with-context">
+    Build resilient extractions that don't break when the website changes
   </Card>
 </CardGroup>
 
-## Using `extract()`
+## Return value
 
-Describe exactly the shape you want. Add fields for lists, nested objects, and optional
-values, and use field descriptions to guide the model.
+`extract()` returns a result with two fields: `data` holds the value matching the schema you passed, and `metadata` carries the action ID and server-side cache status. The shape of `data` depends on the schema:
+<Tabs>
+<Tab title="Basic Schema">
 
-```python
-from pydantic import BaseModel, Field
+When extracting with an object schema, the return type is inferred from that schema:
 
-
-class Result(BaseModel):
-    title: str
-    url: str = Field(description="The absolute link to the result")
-    rating: float | None = None
-
-
-class SearchResults(BaseModel):
-    results: list[Result]
-
-
-extraction = await stagehand.extract(
-    instruction="Extract each search result",
-    schema=SearchResults,
-)
+<View title="TypeScript" icon="js">
+```typescript
+const { data } = await stagehand.extract(
+  "extract product details",
+  z.object({
+    name: z.string(),
+    price: z.number(),
+    inStock: z.boolean(),
+  }),
+);
 ```
+</View>
 
-### Return value
-
-`extract()` resolves to an object with `data` and `metadata`. `data` is an instance of
-your Pydantic model, while `metadata` contains Stagehand-owned information such as cache
-status and an optional action ID.
-
+<View title="Python" icon="python">
 ```python
 class Product(BaseModel):
     name: str
@@ -248,117 +92,1055 @@ class Product(BaseModel):
     in_stock: bool
 
 
-extraction = await stagehand.extract(
-    instruction="Extract the product details",
+result = await stagehand.extract(
+    instruction="extract product details",
     schema=Product,
 )
-# extraction.data is a Product instance
-
-print(extraction.data.name, extraction.data.price)
-print(extraction.metadata.cache_status)
 ```
+</View>
 
-## Advanced configuration
+<View title="Go" icon="golang">
+```go
+type product struct {
+	Name    string  `json:"name"`
+	Price   float64 `json:"price"`
+	InStock bool    `json:"in_stock"`
+}
 
+var productSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "name": {"type": "string"},
+    "price": {"type": "number"},
+    "in_stock": {"type": "boolean"}
+  },
+  "required": ["name", "price", "in_stock"],
+  "additionalProperties": false
+}`)
+
+extracted, err := stagehand.ExtractAs[product](
+	ctx,
+	client,
+	"extract product details",
+	productSchema,
+	nil,
+)
+```
+</View>
+
+**Example result:**
+
+<View title="TypeScript" icon="js">
+```typescript
+{
+  name: "Wireless Mouse",
+  price: 29.99,
+  inStock: true
+}
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+Product(name="Wireless Mouse", price=29.99, in_stock=True)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+product{Name: "Wireless Mouse", Price: 29.99, InStock: true}
+```
+</View>
+
+</Tab>
+<Tab title="Array">
+
+To extract a list, wrap it in a field on your schema:
+
+<View title="TypeScript" icon="js">
+```typescript
+const { data } = await stagehand.extract(
+  "extract all apartment listings",
+  z.object({
+    apartments: z.array(
+      z.object({
+        address: z.string(),
+        price: z.string(),
+        sqft: z.number(),
+      }),
+    ),
+  }),
+);
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+class Apartment(BaseModel):
+    address: str
+    price: str
+    sqft: int
+
+
+class Apartments(BaseModel):
+    apartments: list[Apartment]
+
+
+result = await stagehand.extract(
+    instruction="extract all apartment listings",
+    schema=Apartments,
+)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+type apartment struct {
+	Address string `json:"address"`
+	Price   string `json:"price"`
+	Sqft    int    `json:"sqft"`
+}
+
+type apartments struct {
+	Apartments []apartment `json:"apartments"`
+}
+
+extracted, err := stagehand.ExtractAs[apartments](
+	ctx,
+	client,
+	"extract all apartment listings",
+	apartmentsSchema,
+	nil,
+)
+```
+</View>
+
+**Example result:**
+
+<View title="TypeScript" icon="js">
+```typescript
+[
+  {
+    address: "123 Main St",
+    price: "$1,200/mo",
+    sqft: 750
+  },
+  {
+    address: "456 Oak Ave",
+    price: "$1,500/mo",
+    sqft: 900
+  }
+]
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+[
+    Apartment(address="123 Main St", price="$1,200/mo", sqft=750),
+    Apartment(address="456 Oak Ave", price="$1,500/mo", sqft=900),
+]
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+[]apartment{
+	{Address: "123 Main St", Price: "$1,200/mo", Sqft: 750},
+	{Address: "456 Oak Ave", Price: "$1,500/mo", Sqft: 900},
+}
+```
+</View>
+
+</Tab>
+<Tab title="Primitive">
+
+To extract a single value, give it a named field:
+
+<View title="TypeScript" icon="js">
+```typescript
+const { data } = await stagehand.extract(
+  "extract the price",
+  z.object({ price: z.number() }),
+);
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+class Price(BaseModel):
+    price: float
+
+
+result = await stagehand.extract(
+    instruction="extract the price",
+    schema=Price,
+)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+type price struct {
+	Price float64 `json:"price"`
+}
+
+extracted, err := stagehand.ExtractAs[price](
+	ctx,
+	client,
+	"extract the price",
+	priceSchema,
+	nil,
+)
+```
+</View>
+
+**Example result:**
+
+<View title="TypeScript" icon="js">
+```typescript
+19.99
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+19.99
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+19.99
+```
+</View>
+
+You can also extract strings, booleans, and URLs:
+
+<View title="TypeScript" icon="js">
+```typescript
+const { data } = await stagehand.extract(
+  "extract the contact page link",
+  z.object({ url: z.url() }),
+);
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+from pydantic import AnyUrl
+
+
+class ContactLink(BaseModel):
+    url: AnyUrl
+
+
+result = await stagehand.extract(
+    instruction="extract the contact page link",
+    schema=ContactLink,
+)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+type contactLink struct {
+	URL string `json:"url"`
+}
+
+var contactLinkSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {"url": {"type": "string", "format": "uri"}},
+  "required": ["url"],
+  "additionalProperties": false
+}`)
+
+extracted, err := stagehand.ExtractAs[contactLink](
+	ctx,
+	client,
+	"extract the contact page link",
+	contactLinkSchema,
+	nil,
+)
+```
+</View>
+
+</Tab>
+</Tabs>
+
+## Advanced Configuration
+
+You can pass additional options to configure the model, timeout, selector scope, and whether to include a screenshot:
+
+<View title="TypeScript" icon="js">
+```typescript
+const result = await stagehand.extract(
+  "extract the repository name",
+  z.object({ name: z.string() }),
+  {
+    model: {
+      modelName: "anthropic/claude-sonnet-4-5",
+      apiKey: process.env.ANTHROPIC_API_KEY,
+    },
+    timeout: 30000,
+    selector: "//header", // Focus on specific area
+  },
+);
+```
+</View>
+
+<View title="Python" icon="python">
 ```python
 from stagehand import ModelConfig
 
-
-extraction = await stagehand.extract(
-    instruction="Extract the article body",
-    schema=schema,
-    selector="#main-content",
-    ignore_selectors=["nav", ".cookie-banner"],
-    screenshot=True,
-    timeout=30_000,
-    model=ModelConfig.model_validate({"model_name": "openai/gpt-5.4-mini"}),
-)
-```
-
-- `page`: the page to extract from. Defaults to the active page.
-- `selector`: a CSS selector that scopes extraction to one element and its subtree.
-- `ignore_selectors`: elements to exclude, such as ads, chrome, and boilerplate.
-- `screenshot`: include a screenshot of the viewport for layout-dependent extraction.
-- `timeout`: maximum time in milliseconds.
-- `model`: override the complete model configuration for this call.
-- `cache`: reuse a prior result for this call.
-
-### Scoped extraction
-
-When a page is large, scoping to the relevant region with `selector` (and excluding noise
-with `ignore_selectors`) is faster, cheaper, and more accurate than extracting from the
-whole document.
-
-```python
 result = await stagehand.extract(
-    instruction="Extract the sale price",
-    schema=Product,
-    selector="#product-summary",
-    ignore_selectors=[".related-products"],
+    instruction="extract the repository name",
+    schema=Repository,
+    model=ModelConfig.model_validate({
+        "model_name": "anthropic/claude-sonnet-4-5",
+        "api_key": os.environ["ANTHROPIC_API_KEY"],
+    }),
+    timeout=30000,
+    selector="//header",  # Focus on specific area
 )
 ```
+</View>
 
-### Visual extraction
+<View title="Go" icon="golang">
+```go
+modelAPIKey := os.Getenv("ANTHROPIC_API_KEY")
+model := stagehand.KnownModel(stagehand.KnownModelConfig{
+	ModelName: "anthropic/claude-sonnet-4-5",
+	APIKey:    &modelAPIKey,
+})
+timeout := 30000.0
+selector := "//header" // Focus on specific area
 
-Set `screenshot` to include an image of the current viewport in the model call. This helps
-when the data depends on layout or styling that isn't obvious from the DOM alone.
+result, err := client.Extract(ctx, "extract the repository name", repositorySchema, &stagehand.StagehandClientExtractOptions{
+	ExtractOptions: stagehand.ExtractOptions{
+		Model:    &model,
+		Timeout:  &timeout,
+		Selector: &selector,
+	},
+})
+```
+</View>
 
-### Cache repeated extractions
+### Server-side Caching
 
-On Browserbase, turn on caching
-so repeated, identical extractions are served from a cache instead of calling the model again.
+<Note>
+`cache` requires the Browserbase browser source and a Browserbase API key. It has no effect on local or CDP browsers.
+</Note>
 
+When running on Browserbase, Stagehand can cache `extract()` results server-side. Repeated calls with the same inputs return instantly without consuming LLM tokens. Enable caching on the constructor and override it per call:
+
+<View title="TypeScript" icon="js">
+```typescript
+// Enable server-side caching for the entire instance
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  browser: { type: "browserbase" },
+  cache: true,
+});
+
+// Or disable it for a single call
+const result = await stagehand.extract(
+  "extract the repository name",
+  z.object({ name: z.string() }),
+  { cache: false },
+);
+
+// Cache status travels on the result metadata
+console.log(result.metadata.cacheStatus); // "HIT", "MISS", or undefined
+```
+</View>
+
+<View title="Python" icon="python">
 ```python
-extraction = await stagehand.extract(
-    instruction="Extract the product name and price",
-    schema=Product,
+from stagehand import Stagehand
+
+# Enable server-side caching for the entire instance
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    browser="browserbase",
     cache=True,
 )
-print(extraction.data, extraction.metadata.cache_status)
+
+# Or disable it for a single call
+result = await stagehand.extract(
+    instruction="extract the repository name",
+    schema=Repository,
+    cache=False,
+)
+
+# Cache status travels on the result metadata
+print(result.metadata.cache_status)  # "HIT", "MISS", or None
 ```
+</View>
+
+<View title="Go" icon="golang">
+```go
+// Enable server-side caching for the entire instance
+apiKey := os.Getenv("BROWSERBASE_API_KEY")
+instanceCache := stagehand.CacheEnabled(true)
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey:  &apiKey,
+	Browser: stagehand.BrowserbaseClientBrowserSource{},
+	Cache:   &instanceCache,
+})
+
+// Or disable it for a single call
+off := stagehand.CacheEnabled(false)
+result, err := client.Extract(ctx, "extract the repository name", repositorySchema, &stagehand.StagehandClientExtractOptions{
+	ExtractOptions: stagehand.ExtractOptions{Cache: &off},
+})
+
+// Cache status travels on the result metadata
+if result.Metadata.CacheStatus != nil {
+	fmt.Println(*result.Metadata.CacheStatus) // "HIT" or "MISS"
+}
+```
+</View>
+
+### Targeted Extract
+
+Pass a selector to `extract` to target a specific element on the page.
+<Tip>
+This helps reduce the context passed to the LLM, optimizing token usage/speed and improving accuracy.
+</Tip>
+
+<View title="TypeScript" icon="js">
+```typescript
+const { data: tableData } = await stagehand.extract(
+  "Extract the values of the third row",
+  z.object({
+    values: z.array(z.string()),
+  }),
+  {
+    // xPath or CSS selector
+    selector: "xpath=/html/body/div/table/",
+  },
+);
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+class TableRow(BaseModel):
+    values: list[str]
+
+
+table_data = (await stagehand.extract(
+    instruction="Extract the values of the third row",
+    schema=TableRow,
+    # xPath or CSS selector
+    selector="xpath=/html/body/div/table/",
+)).data
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+type tableRow struct {
+	Values []string `json:"values"`
+}
+
+// xPath or CSS selector
+selector := "xpath=/html/body/div/table/"
+
+tableData, err := stagehand.ExtractAs[tableRow](
+	ctx,
+	client,
+	"Extract the values of the third row",
+	tableRowSchema,
+	&stagehand.StagehandClientExtractOptions{
+		ExtractOptions: stagehand.ExtractOptions{Selector: &selector},
+	},
+)
+```
+</View>
+
+You can also exclude specific nodes (including their descendant nodes) with the ignore-selectors option.
+
+<View title="TypeScript" icon="js">
+```typescript
+const { data: article } = await stagehand.extract(
+  "extract the article title and body",
+  z.object({
+    title: z.string(),
+    body: z.string(),
+  }),
+  {
+    ignoreSelectors: [".ad", ".newsletter-modal", "nav.related-posts"],
+  },
+);
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+class Article(BaseModel):
+    title: str
+    body: str
+
+
+article = (await stagehand.extract(
+    instruction="extract the article title and body",
+    schema=Article,
+    ignore_selectors=[".ad", ".newsletter-modal", "nav.related-posts"],
+)).data
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+type article struct {
+	Title string `json:"title"`
+	Body  string `json:"body"`
+}
+
+extracted, err := stagehand.ExtractAs[article](
+	ctx,
+	client,
+	"extract the article title and body",
+	articleSchema,
+	&stagehand.StagehandClientExtractOptions{
+		ExtractOptions: stagehand.ExtractOptions{
+			IgnoreSelectors: []string{".ad", ".newsletter-modal", "nav.related-posts"},
+		},
+	},
+)
+```
+</View>
+
+<Note>
+  The ignore-selectors option removes all matches for each selector, along with each matched node's descendants. The selector option still scopes extraction to a single resolved subtree.
+</Note>
+
+### Visual Extract
+
+Turn the screenshot option on when the extraction needs visual information from the current viewport in addition to the page accessibility tree.
+
+<View title="TypeScript" icon="js">
+```typescript
+const { data: saleBadge } = await stagehand.extract(
+  "extract the text shown in the visible sale badge",
+  z.object({
+    text: z.string(),
+  }),
+  {
+    screenshot: true,
+  },
+);
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+class SaleBadge(BaseModel):
+    text: str
+
+
+sale_badge = (await stagehand.extract(
+    instruction="extract the text shown in the visible sale badge",
+    schema=SaleBadge,
+    screenshot=True,
+)).data
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+type saleBadge struct {
+	Text string `json:"text"`
+}
+
+screenshot := true
+
+saleBadgeData, err := stagehand.ExtractAs[saleBadge](
+	ctx,
+	client,
+	"extract the text shown in the visible sale badge",
+	saleBadgeSchema,
+	&stagehand.StagehandClientExtractOptions{
+		ExtractOptions: stagehand.ExtractOptions{Screenshot: &screenshot},
+	},
+)
+```
+</View>
+
+<Note>
+  The screenshot option captures the current viewport, not the full page. Visual extractions always bypass the server-side cache, because a cache key is built from DOM state and cannot represent the pixels the model saw.
+</Note>
+
 
 ## Best practices
 
-- **Ask for exactly what you need:** Smaller schemas are faster and more reliable than
-  "extract everything."
-- **Use descriptions:** Field descriptions disambiguate similar values (for example, which
-  price is the sale price).
-- **Scope first:** Reach for `selector`/`ignore_selectors` before extracting from a busy
-  page.
+
+### Extract with Context
+
+You can provide additional context to your schema to help the model extract the data more accurately.
+
+<View title="TypeScript" icon="js">
+```typescript
+const { data } = await stagehand.extract(
+  "Extract ALL the apartment listings and their details, including address, price, and square feet.",
+  z.object({
+    apartments: z.array(
+      z.object({
+        address: z.string().describe("the address of the apartment"),
+        price: z.string().describe("the price of the apartment"),
+        squareFeet: z.string().describe("the square footage of the apartment"),
+      }),
+    ),
+  }),
+);
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+from pydantic import BaseModel, Field
+
+
+class Apartment(BaseModel):
+    address: str = Field(description="the address of the apartment")
+    price: str = Field(description="the price of the apartment")
+    square_feet: str = Field(description="the square footage of the apartment")
+
+
+class Apartments(BaseModel):
+    apartments: list[Apartment]
+
+
+result = await stagehand.extract(
+    instruction=(
+        "Extract ALL the apartment listings and their details, "
+        "including address, price, and square feet."
+    ),
+    schema=Apartments,
+)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+type apartment struct {
+	Address     string `json:"address"`
+	Price       string `json:"price"`
+	SquareFeet  string `json:"square_feet"`
+}
+
+type apartments struct {
+	Apartments []apartment `json:"apartments"`
+}
+
+// Field descriptions live in the JSON Schema you pass to Extract
+var apartmentsSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "apartments": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "address": {"type": "string", "description": "the address of the apartment"},
+          "price": {"type": "string", "description": "the price of the apartment"},
+          "square_feet": {"type": "string", "description": "the square footage of the apartment"}
+        },
+        "required": ["address", "price", "square_feet"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["apartments"],
+  "additionalProperties": false
+}`)
+
+extracted, err := stagehand.ExtractAs[apartments](
+	ctx,
+	client,
+	"Extract ALL the apartment listings and their details, including address, price, and square feet.",
+	apartmentsSchema,
+	nil,
+)
+```
+</View>
+
+### Link Extraction
+<Note>
+To extract links or URLs, define the relevant field as a URL type.
+</Note>
+
+Here is how an `extract` call might look for extracting a link or URL. This also works for image links.
+
+<View title="TypeScript" icon="js">
+```typescript
+const { data } = await stagehand.extract(
+  "extract the link to the 'contact us' page",
+  // note the usage of z.url() for URL validation
+  z.object({ contactLink: z.url() }),
+);
+
+console.log("the link to the contact us page is: ", data.contactLink);
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+from pydantic import AnyUrl, BaseModel
+
+
+class ContactLink(BaseModel):
+    # note the usage of AnyUrl for URL validation
+    contact_link: AnyUrl
+
+
+result = await stagehand.extract(
+    instruction="extract the link to the 'contact us' page",
+    schema=ContactLink,
+)
+
+print("the link to the contact us page is: ", result.data.contact_link)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+type contactLink struct {
+	ContactLink string `json:"contact_link"`
+}
+
+// note the "format": "uri" annotation for URL extraction
+var contactLinkSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {"contact_link": {"type": "string", "format": "uri"}},
+  "required": ["contact_link"],
+  "additionalProperties": false
+}`)
+
+extracted, err := stagehand.ExtractAs[contactLink](
+	ctx,
+	client,
+	"extract the link to the 'contact us' page",
+	contactLinkSchema,
+	nil,
+)
+if err != nil {
+	return err
+}
+
+fmt.Println("the link to the contact us page is: ", extracted.ContactLink)
+```
+</View>
+
+<Tip>
+Inside Stagehand, extracting links works by asking the LLM to select an ID. Stagehand looks up that ID in a mapping of IDs to URLs. When logging the LLM trace, you should expect to see IDs. The actual URLs will be included in the final result.
+</Tip>
 
 ## Troubleshooting
 
 <AccordionGroup>
-  <Accordion title="Missing or empty fields">
-    Make the instruction and field descriptions more specific, mark truly optional fields
-    as optional, and confirm the data is actually present in the scoped region.
-  </Accordion>
-  <Accordion title="Wrong value picked">
+<Accordion title="Empty or partial results">
+**Problem**: `extract()` returns empty or incomplete data
 
-Narrow with `selector`, exclude distractors with `ignore_selectors`, or enable `screenshot`
-when the correct value is clear visually but ambiguous in the DOM.
+**Solutions**:
+- **Check your instruction clarity:** Make sure your instruction is specific and describes exactly what data you want to extract
+- **Verify the data exists:** Use `observe()` first to confirm the data is present on the page
+- **Wait for dynamic content:** If the page loads content dynamically, wait for it before extracting
 
+**Solution: Wait for content before extracting**
+
+<View title="TypeScript" icon="js">
+```typescript
+// Wait for content before extracting
+await page.waitForSelector(".product-listing");
+
+const { data } = await stagehand.extract(
+  "extract all product names and prices",
+  z.object({
+    products: z.array(z.object({
+      name: z.string(),
+      price: z.string(),
+    })),
+  }),
+);
+```
+</View>
+
+<View title="Python" icon="python">
 ```python
+# Wait for content before extracting
+await page.wait_for_selector(".product-listing")
+
+
+class Product(BaseModel):
+    name: str
+    price: str
+
+
+class Products(BaseModel):
+    products: list[Product]
+
+
 result = await stagehand.extract(
-    instruction="Extract the sale price, not the original price",
-    schema=Product,
-    selector="#product-summary",
-    ignore_selectors=[".related-products"],
+    instruction="extract all product names and prices",
+    schema=Products,
 )
 ```
-
-  </Accordion>
-</AccordionGroup>
-
 </View>
+
+<View title="Go" icon="golang">
+```go
+// Wait for content before extracting
+if _, err := page.WaitForSelector(ctx, ".product-listing", nil); err != nil {
+	return err
+}
+
+type product struct {
+	Name  string `json:"name"`
+	Price string `json:"price"`
+}
+
+type products struct {
+	Products []product `json:"products"`
+}
+
+extracted, err := stagehand.ExtractAs[products](
+	ctx,
+	client,
+	"extract all product names and prices",
+	productsSchema,
+	nil,
+)
+```
+</View>
+</Accordion>
+
+<Accordion title="Schema validation errors">
+**Problem**: Getting schema validation errors or type mismatches
+
+**Solutions**:
+- **Use optional fields:** Make fields optional if the data might not always be present
+- **Use flexible types:** Consider using a string instead of a number for prices that might include currency symbols
+- **Add descriptions:** Describe each field to help the model understand its requirements
+
+**Solution: More flexible schema**
+
+<View title="TypeScript" icon="js">
+```typescript
+const schema = z.object({
+  price: z.string().describe("price including currency symbol, e.g., '$19.99'"),
+  availability: z.string().optional().describe("stock status if available"),
+  rating: z.number().optional(),
+});
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+class ProductDetails(BaseModel):
+    price: str = Field(description="price including currency symbol, e.g., '$19.99'")
+    availability: str | None = Field(default=None, description="stock status if available")
+    rating: float | None = None
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+// Optional fields are pointers, and descriptions live in the JSON Schema
+type productDetails struct {
+	Price        string   `json:"price"`
+	Availability *string  `json:"availability,omitempty"`
+	Rating       *float64 `json:"rating,omitempty"`
+}
+
+var productDetailsSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "price": {"type": "string", "description": "price including currency symbol, e.g., '$19.99'"},
+    "availability": {"type": "string", "description": "stock status if available"},
+    "rating": {"type": "number"}
+  },
+  "required": ["price"],
+  "additionalProperties": false
+}`)
+```
+</View>
+</Accordion>
+
+<Accordion title="Inconsistent results">
+**Problem**: Extraction results vary between runs
+
+**Solutions**:
+- **Be more specific in instructions:** Instead of "extract prices", use "extract the numerical price value for each item"
+- **Use context in schema descriptions:** Add field descriptions to guide the model
+- **Combine with observe:** Use `observe()` to understand the page structure first
+
+**Solution: Validate with observe first**
+
+<View title="TypeScript" icon="js">
+```typescript
+// First observe to understand the page structure
+const { data: elements } = await stagehand.observe("find all product listings");
+console.log("Found elements:", elements.map(e => e.description));
+
+// Then extract with specific targeting
+const { data } = await stagehand.extract(
+  "extract name and price from each product listing shown on the page",
+  z.object({
+    products: z.array(z.object({
+      name: z.string().describe("the product title or name"),
+      price: z.string().describe("the price as displayed, including currency"),
+    })),
+  }),
+);
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+# First observe to understand the page structure
+observed = await stagehand.observe(instruction="find all product listings")
+print("Found elements:", [element.description for element in observed.data])
+
+
+# Then extract with specific targeting
+class Product(BaseModel):
+    name: str = Field(description="the product title or name")
+    price: str = Field(description="the price as displayed, including currency")
+
+
+class Products(BaseModel):
+    products: list[Product]
+
+
+result = await stagehand.extract(
+    instruction="extract name and price from each product listing shown on the page",
+    schema=Products,
+)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+// First observe to understand the page structure
+instruction := "find all product listings"
+observed, err := client.Observe(ctx, &instruction, nil)
+if err != nil {
+	return err
+}
+for _, element := range observed.Data {
+	fmt.Println("Found element:", element.Description)
+}
+
+// Then extract with specific targeting
+extracted, err := stagehand.ExtractAs[products](
+	ctx,
+	client,
+	"extract name and price from each product listing shown on the page",
+	productsSchema,
+	nil,
+)
+```
+</View>
+</Accordion>
+
+<Accordion title="Performance issues">
+**Problem**: Extraction is slow or timing out
+
+**Solutions**:
+- **Reduce scope:** Extract smaller chunks of data in multiple calls rather than everything at once
+- **Use targeted instructions:** Be specific about which part of the page to focus on
+- **Consider pagination:** For large datasets, extract one page at a time
+- **Increase timeout:** Use the timeout option for complex extractions
+
+**Solution: Break down large extractions**
+
+<View title="TypeScript" icon="js">
+```typescript
+// Instead of extracting everything at once
+const allData = [];
+const pageNumbers = [1, 2, 3, 4, 5];
+
+for (const pageNum of pageNumbers) {
+  await stagehand.act(`navigate to page ${pageNum}`);
+
+  const { data } = await stagehand.extract(
+    "extract product data from the current page only",
+    z.object({
+      products: z.array(z.object({
+        name: z.string(),
+        price: z.number(),
+      })),
+    }),
+    { timeout: 60000 }, // 60 second timeout
+  );
+
+  allData.push(...data.products);
+}
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+# Instead of extracting everything at once
+all_data = []
+page_numbers = [1, 2, 3, 4, 5]
+
+for page_num in page_numbers:
+    await stagehand.act(f"navigate to page {page_num}")
+
+    result = await stagehand.extract(
+        instruction="extract product data from the current page only",
+        schema=Products,
+        timeout=60000,  # 60 second timeout
+    )
+
+    all_data.extend(result.data.products)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+// Instead of extracting everything at once
+var allData []product
+timeout := 60000.0 // 60 second timeout
+
+for pageNum := 1; pageNum <= 5; pageNum++ {
+	if _, err := client.Act(ctx, fmt.Sprintf("navigate to page %d", pageNum), nil); err != nil {
+		return err
+	}
+
+	extracted, err := stagehand.ExtractAs[products](
+		ctx,
+		client,
+		"extract product data from the current page only",
+		productsSchema,
+		&stagehand.StagehandClientExtractOptions{
+			ExtractOptions: stagehand.ExtractOptions{Timeout: &timeout},
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	allData = append(allData, extracted.Products...)
+}
+```
+</View>
+</Accordion>
+</AccordionGroup>
 
 ## Next steps
 
-<CardGroup cols="2">
-  <Card title="Act" icon="arrow-pointer" href="/v4/basics/act">
-    Perform actions with natural language.
+<CardGroup cols={2}>
+
+  <Card title="Act" icon="play" href="/v4/basics/act">
+    Execute actions efficiently
   </Card>
-  <Card title="Observe" icon="eye" href="/v4/basics/observe">
-    Discover available actions on a page.
+
+  <Card title="Observe" icon="magnifying-glass" href="/v4/basics/observe">
+    Analyze pages and preview actions
   </Card>
 </CardGroup>

--- a/packages/docs/v4/basics/extract.mdx
+++ b/packages/docs/v4/basics/extract.mdx
@@ -50,7 +50,7 @@ extracted, err := stagehand.ExtractAs[repository](
 ```
 </View>
 
-`extract()` grabs structured data from a webpage. Every call takes an instruction and a schema: [Zod](https://github.com/colinhacks/zod) in TypeScript, [Pydantic](https://docs.pydantic.dev) in Python. The result is validated against your schema before it is returned, so what you get back is already typed.
+`extract()` grabs structured data from a webpage. Every call takes an instruction and a schema: [Zod](https://github.com/colinhacks/zod) in TypeScript, [Pydantic](https://docs.pydantic.dev) in Python, and a [JSON Schema](https://json-schema.org) as `json.RawMessage` in Go. The result is validated against your schema before it is returned, so what you get back is already typed.
 
 ## Why use `extract()`?
 
@@ -67,7 +67,7 @@ extracted, err := stagehand.ExtractAs[repository](
 
 `extract()` returns a result with two fields: `data` holds the value matching the schema you passed, and `metadata` carries the action ID and server-side cache status. The shape of `data` depends on the schema:
 <Tabs>
-<Tab title="Basic Schema">
+<Tab title="Basic schema">
 
 When extracting with an object schema, the return type is inferred from that schema:
 
@@ -205,6 +205,27 @@ type apartments struct {
 	Apartments []apartment `json:"apartments"`
 }
 
+var apartmentsSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "apartments": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "address": {"type": "string"},
+          "price": {"type": "string"},
+          "sqft": {"type": "integer"}
+        },
+        "required": ["address", "price", "sqft"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["apartments"],
+  "additionalProperties": false
+}`)
+
 extracted, err := stagehand.ExtractAs[apartments](
 	ctx,
 	client,
@@ -219,36 +240,38 @@ extracted, err := stagehand.ExtractAs[apartments](
 
 <View title="TypeScript" icon="js">
 ```typescript
-[
-  {
-    address: "123 Main St",
-    price: "$1,200/mo",
-    sqft: 750
-  },
-  {
-    address: "456 Oak Ave",
-    price: "$1,500/mo",
-    sqft: 900
-  }
-]
+{
+  apartments: [
+    {
+      address: "123 Main St",
+      price: "$1,200/mo",
+      sqft: 750
+    },
+    {
+      address: "456 Oak Ave",
+      price: "$1,500/mo",
+      sqft: 900
+    }
+  ]
+}
 ```
 </View>
 
 <View title="Python" icon="python">
 ```python
-[
+Apartments(apartments=[
     Apartment(address="123 Main St", price="$1,200/mo", sqft=750),
     Apartment(address="456 Oak Ave", price="$1,500/mo", sqft=900),
-]
+])
 ```
 </View>
 
 <View title="Go" icon="golang">
 ```go
-[]apartment{
+apartments{Apartments: []apartment{
 	{Address: "123 Main St", Price: "$1,200/mo", Sqft: 750},
 	{Address: "456 Oak Ave", Price: "$1,500/mo", Sqft: 900},
-}
+}}
 ```
 </View>
 
@@ -285,6 +308,13 @@ type price struct {
 	Price float64 `json:"price"`
 }
 
+var priceSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {"price": {"type": "number"}},
+  "required": ["price"],
+  "additionalProperties": false
+}`)
+
 extracted, err := stagehand.ExtractAs[price](
 	ctx,
 	client,
@@ -299,19 +329,21 @@ extracted, err := stagehand.ExtractAs[price](
 
 <View title="TypeScript" icon="js">
 ```typescript
-19.99
+{
+  price: 19.99
+}
 ```
 </View>
 
 <View title="Python" icon="python">
 ```python
-19.99
+Price(price=19.99)
 ```
 </View>
 
 <View title="Go" icon="golang">
 ```go
-19.99
+price{Price: 19.99}
 ```
 </View>
 
@@ -368,7 +400,7 @@ extracted, err := stagehand.ExtractAs[contactLink](
 </Tab>
 </Tabs>
 
-## Advanced Configuration
+## Advanced configuration
 
 You can pass additional options to configure the model, timeout, selector scope, and whether to include a screenshot:
 
@@ -379,7 +411,7 @@ const result = await stagehand.extract(
   z.object({ name: z.string() }),
   {
     model: {
-      modelName: "anthropic/claude-sonnet-4-5",
+      modelName: "anthropic/claude-sonnet-4-6",
       apiKey: process.env.ANTHROPIC_API_KEY,
     },
     timeout: 30000,
@@ -397,7 +429,7 @@ result = await stagehand.extract(
     instruction="extract the repository name",
     schema=Repository,
     model=ModelConfig.model_validate({
-        "model_name": "anthropic/claude-sonnet-4-5",
+        "model_name": "anthropic/claude-sonnet-4-6",
         "api_key": os.environ["ANTHROPIC_API_KEY"],
     }),
     timeout=30000,
@@ -408,9 +440,16 @@ result = await stagehand.extract(
 
 <View title="Go" icon="golang">
 ```go
+var repositorySchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {"name": {"type": "string"}},
+  "required": ["name"],
+  "additionalProperties": false
+}`)
+
 modelAPIKey := os.Getenv("ANTHROPIC_API_KEY")
 model := stagehand.KnownModel(stagehand.KnownModelConfig{
-	ModelName: "anthropic/claude-sonnet-4-5",
+	ModelName: "anthropic/claude-sonnet-4-6",
 	APIKey:    &modelAPIKey,
 })
 timeout := 30000.0
@@ -426,7 +465,7 @@ result, err := client.Extract(ctx, "extract the repository name", repositorySche
 ```
 </View>
 
-### Server-side Caching
+### Server-side caching
 
 <Note>
 `cache` requires the Browserbase browser source and a Browserbase API key. It has no effect on local or CDP browsers.
@@ -480,6 +519,13 @@ print(result.metadata.cache_status)  # "HIT", "MISS", or None
 
 <View title="Go" icon="golang">
 ```go
+var repositorySchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {"name": {"type": "string"}},
+  "required": ["name"],
+  "additionalProperties": false
+}`)
+
 // Enable server-side caching for the entire instance
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 instanceCache := stagehand.CacheEnabled(true)
@@ -502,7 +548,7 @@ if result.Metadata.CacheStatus != nil {
 ```
 </View>
 
-### Targeted Extract
+### Targeted extract
 
 Pass a selector to `extract` to target a specific element on the page.
 <Tip>
@@ -544,6 +590,13 @@ table_data = (await stagehand.extract(
 type tableRow struct {
 	Values []string `json:"values"`
 }
+
+var tableRowSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {"values": {"type": "array", "items": {"type": "string"}}},
+  "required": ["values"],
+  "additionalProperties": false
+}`)
 
 // xPath or CSS selector
 selector := "xpath=/html/body/div/table/"
@@ -599,6 +652,16 @@ type article struct {
 	Body  string `json:"body"`
 }
 
+var articleSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "title": {"type": "string"},
+    "body": {"type": "string"}
+  },
+  "required": ["title", "body"],
+  "additionalProperties": false
+}`)
+
 extracted, err := stagehand.ExtractAs[article](
 	ctx,
 	client,
@@ -617,7 +680,7 @@ extracted, err := stagehand.ExtractAs[article](
   The ignore-selectors option removes all matches for each selector, along with each matched node's descendants. The selector option still scopes extraction to a single resolved subtree.
 </Note>
 
-### Visual Extract
+### Visual extract
 
 Turn the screenshot option on when the extraction needs visual information from the current viewport in addition to the page accessibility tree.
 
@@ -655,6 +718,13 @@ type saleBadge struct {
 	Text string `json:"text"`
 }
 
+var saleBadgeSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {"text": {"type": "string"}},
+  "required": ["text"],
+  "additionalProperties": false
+}`)
+
 screenshot := true
 
 saleBadgeData, err := stagehand.ExtractAs[saleBadge](
@@ -677,7 +747,7 @@ saleBadgeData, err := stagehand.ExtractAs[saleBadge](
 ## Best practices
 
 
-### Extract with Context
+### Extract with context
 
 You can provide additional context to your schema to help the model extract the data more accurately.
 
@@ -767,7 +837,7 @@ extracted, err := stagehand.ExtractAs[apartments](
 ```
 </View>
 
-### Link Extraction
+### Link extraction
 <Note>
 To extract links or URLs, define the relevant field as a URL type.
 </Note>
@@ -853,8 +923,12 @@ Inside Stagehand, extracting links works by asking the LLM to select an ID. Stag
 
 <View title="TypeScript" icon="js">
 ```typescript
-// Wait for content before extracting
-await page.waitForSelector(".product-listing");
+// waitForSelector reports whether the selector matched, so check it
+// before extracting: a timeout resolves to false without throwing.
+const listingReady = await page.waitForSelector(".product-listing");
+if (!listingReady) {
+  throw new Error("timed out waiting for .product-listing");
+}
 
 const { data } = await stagehand.extract(
   "extract all product names and prices",
@@ -870,8 +944,11 @@ const { data } = await stagehand.extract(
 
 <View title="Python" icon="python">
 ```python
-# Wait for content before extracting
-await page.wait_for_selector(".product-listing")
+# wait_for_selector reports whether the selector matched, so check it
+# before extracting: a timeout returns False without raising.
+listing_ready = await page.wait_for_selector(".product-listing")
+if not listing_ready:
+    raise TimeoutError("timed out waiting for .product-listing")
 
 
 class Product(BaseModel):
@@ -892,9 +969,14 @@ result = await stagehand.extract(
 
 <View title="Go" icon="golang">
 ```go
-// Wait for content before extracting
-if _, err := page.WaitForSelector(ctx, ".product-listing", nil); err != nil {
+// WaitForSelector returns (matched, error), so check matched before
+// extracting: a timeout reports false without returning an error.
+matched, err := page.WaitForSelector(ctx, ".product-listing", nil)
+if err != nil {
 	return err
+}
+if !matched {
+	return fmt.Errorf("timed out waiting for .product-listing")
 }
 
 type product struct {
@@ -905,6 +987,26 @@ type product struct {
 type products struct {
 	Products []product `json:"products"`
 }
+
+var productsSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "products": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {"type": "string"},
+          "price": {"type": "string"}
+        },
+        "required": ["name", "price"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["products"],
+  "additionalProperties": false
+}`)
 
 extracted, err := stagehand.ExtractAs[products](
 	ctx,
@@ -1035,6 +1137,35 @@ for _, element := range observed.Data {
 }
 
 // Then extract with specific targeting
+type product struct {
+	Name  string `json:"name"`
+	Price string `json:"price"`
+}
+
+type products struct {
+	Products []product `json:"products"`
+}
+
+var productsSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "products": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {"type": "string", "description": "the product title or name"},
+          "price": {"type": "string", "description": "the price as displayed, including currency"}
+        },
+        "required": ["name", "price"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["products"],
+  "additionalProperties": false
+}`)
+
 extracted, err := stagehand.ExtractAs[products](
 	ctx,
 	client,
@@ -1103,6 +1234,35 @@ for page_num in page_numbers:
 
 <View title="Go" icon="golang">
 ```go
+type product struct {
+	Name  string  `json:"name"`
+	Price float64 `json:"price"`
+}
+
+type products struct {
+	Products []product `json:"products"`
+}
+
+var productsSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "products": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {"type": "string"},
+          "price": {"type": "number"}
+        },
+        "required": ["name", "price"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["products"],
+  "additionalProperties": false
+}`)
+
 // Instead of extracting everything at once
 var allData []product
 timeout := 60000.0 // 60 second timeout

--- a/packages/docs/v4/basics/observe.mdx
+++ b/packages/docs/v4/basics/observe.mdx
@@ -896,13 +896,6 @@ cachedObserve := func(ctx context.Context, instruction string) ([]stagehand.Acti
 	actionCache[instruction] = observed.Data
 	return observed.Data, nil
 }
-
-// The second call for the same instruction is served from actionCache
-actions, err := cachedObserve(ctx, "find all form input fields")
-if err != nil {
-	return err
-}
-fmt.Println("cached", len(actions), "actions")
 ```
 </View>
 

--- a/packages/docs/v4/basics/observe.mdx
+++ b/packages/docs/v4/basics/observe.mdx
@@ -35,7 +35,7 @@ result, err := client.Observe(ctx, &instruction, nil)
   <Card title="Plan" icon="map" href="#plan-then-execute">
     Map out multi-step workflows by discovering all required actions upfront
   </Card>
-  <Card title="Cache" icon="database" href="/v4/best-practices/caching">
+  <Card title="Cache" icon="database" href="/v3/best-practices/caching">
     Store discovered actions to skip LLM calls and speed up repeated workflows
   </Card>
   <Card title="Validate" icon="check" href="#validate-before-acting">
@@ -576,7 +576,7 @@ This works with:
 - **New pages:** create one on the context
 - **Existing browsers:** attach to a browser you already run with the `cdp` browser source
 
-<Card title="Complete API Reference" icon="book" href="/v4/references/stagehand">
+<Card title="Complete API Reference" icon="book" href="/v3/references/stagehand">
   See the full `Stagehand` reference for detailed parameter documentation, return values, and advanced examples.
 </Card>
 
@@ -624,7 +624,7 @@ for _, field := range observed.Data {
 ```
 </View>
 
-<Card title="Analyze pages with observe()" icon="magnifying-glass" href="/v4/references/stagehand">
+<Card title="Analyze pages with observe()" icon="magnifying-glass" href="/v3/references/stagehand">
   Complete guide to planning actions with `observe()`.
 </Card>
 
@@ -784,7 +784,7 @@ cachedObserve := func(ctx context.Context, instruction string) ([]stagehand.Acti
 ```
 </View>
 
-<Card title="Complete caching guide" icon="database" href="/v4/best-practices/caching">
+<Card title="Complete caching guide" icon="database" href="/v3/best-practices/caching">
   Learn advanced caching techniques and patterns for optimal performance.
 </Card>
 
@@ -912,7 +912,7 @@ _, err = client.Observe(ctx, &specific, nil)
 **Solutions**:
 - Validate the method before using it
 - Check [supported actions](/v4/basics/act) for valid method names
-- Reach for a [locator](/v4/references/stagehand) when you want to call a specific method instead of trusting the suggestion
+- Reach for a [locator](/v3/references/stagehand) when you want to call a specific method instead of trusting the suggestion
 
 <View title="TypeScript" icon="js">
 ```typescript
@@ -978,11 +978,11 @@ if len(observed.Data) > 0 && observed.Data[0].Method != nil &&
     Combine `observe()` with `extract()` for precise data extraction.
   </Card>
 
-  <Card title="Caching actions" icon="bolt" href="/v4/best-practices/caching">
+  <Card title="Caching actions" icon="bolt" href="/v3/best-practices/caching">
     Build action caches to eliminate redundant LLM calls.
   </Card>
 
-  <Card title="Complete API Reference" icon="book" href="/v4/references/stagehand">
+  <Card title="Complete API Reference" icon="book" href="/v3/references/stagehand">
     Full `Stagehand` reference with detailed parameter documentation.
   </Card>
 </CardGroup>

--- a/packages/docs/v4/basics/observe.mdx
+++ b/packages/docs/v4/basics/observe.mdx
@@ -50,6 +50,9 @@ Use `observe()` to discover actionable elements on a page. Here's how to find a 
 <View title="TypeScript" icon="js">
 ```typescript
 const page = await stagehand.context.activePage();
+if (!page) {
+  throw new Error("Stagehand initialized without an active page");
+}
 await page.goto("https://example.com");
 const { data: actions } = await stagehand.observe("find the learn more button");
 ```
@@ -58,6 +61,8 @@ const { data: actions } = await stagehand.observe("find the learn more button");
 <View title="Python" icon="python">
 ```python
 page = await stagehand.context.active_page()
+if page is None:
+    raise RuntimeError("Stagehand initialized without an active page")
 await page.goto("https://example.com")
 result = await stagehand.observe(instruction="find the learn more button")
 ```
@@ -69,6 +74,9 @@ page, err := browserContext.ActivePage(ctx)
 if err != nil {
 	return err
 }
+if page == nil {
+	return errors.New("Stagehand initialized without an active page")
+}
 if err := page.Goto(ctx, "https://example.com", nil); err != nil {
 	return err
 }
@@ -79,7 +87,7 @@ result, err := client.Observe(ctx, &instruction, nil)
 </View>
 
 <Note>
-**iFrame and Shadow DOM Support** Stagehand automatically handles iFrame traversal and shadow DOM elements without requiring additional configuration.
+**iFrame and Shadow DOM support** Stagehand automatically handles iFrame traversal and shadow DOM elements without requiring additional configuration.
 </Note>
 
 <Accordion title="Common use cases">
@@ -127,7 +135,9 @@ When you use `observe()`, Stagehand returns a result whose `data` field is a lis
 
 <View title="Go" icon="golang">
 ```go
-[]stagehand.Action{
+clickMethod := "click"
+
+actions := []stagehand.Action{
 	{
 		Description: "Learn more button",
 		Method:      &clickMethod,
@@ -220,7 +230,7 @@ _, err = client.Observe(ctx, &title, nil)
 </Tab>
 </Tabs>
 
-## Advanced Configuration
+## Advanced configuration
 
 You can pass additional options to configure the model, timeout, selector scope, ignored page regions, and placeholder variables:
 
@@ -323,7 +333,7 @@ result, err := client.Observe(ctx, &instruction, &stagehand.StagehandClientObser
   The ignore-selectors option removes all matches for each selector, along with each matched node's descendants. The selector option still scopes observation to a single resolved subtree.
 </Note>
 
-### Validate Then Act with Variables
+### Validate then act with variables
 
 For login and other safety-sensitive flows, use `observe()` to discover candidate actions, validate them, and then execute them. When you pass variables, `observe()` returns `%variableName%` placeholders in the suggested action arguments instead of raw secret values, so no secret ever reaches the model.
 
@@ -360,12 +370,19 @@ observed = await stagehand.observe(
     },
 )
 
-email_field = next(a for a in observed.data if "%username%" in (a.arguments or []))
-password_field = next(a for a in observed.data if "%password%" in (a.arguments or []))
+email_field = next(
+    (a for a in observed.data if "%username%" in (a.arguments or [])), None
+)
+password_field = next(
+    (a for a in observed.data if "%password%" in (a.arguments or [])), None
+)
 
+if email_field is not None and password_field is not None:
 # Replay the observed actions, resolving placeholders locally
 await stagehand.act(email_field, variables={"username": "user@example.com"})
-await stagehand.act(password_field, variables={"password": os.environ["USER_PASSWORD"]})
+    await stagehand.act(
+        password_field, variables={"password": os.environ["USER_PASSWORD"]}
+    )
 ```
 </View>
 
@@ -404,8 +421,8 @@ for i, action := range result.Data {
 	}
 }
 
-// Replay the observed actions, resolving placeholders locally
 if emailField != nil && passwordField != nil {
+	// Replay the observed actions, resolving placeholders locally
 	if _, err := client.Act(ctx, *emailField, &stagehand.StagehandClientActOptions{
 		ActOptions: stagehand.ActOptions{
 			Variables: stagehand.Variables{
@@ -432,7 +449,7 @@ if emailField != nil && passwordField != nil {
 `act()` supports the same variables option with either input form. Pass an instruction when you want Stagehand to locate the field for you, or pass the observed `Action` to replay a known target, in both cases keeping the value out of the prompt.
 </Tip>
 
-### Server-side Caching
+### Server-side caching
 
 <Note>
 `cache` requires the Browserbase browser source and a Browserbase API key. It has no effect on local or CDP browsers.
@@ -494,7 +511,7 @@ result, err := client.Observe(ctx, &instruction, &stagehand.StagehandClientObser
   Cache status is reported on the result metadata, alongside the observed actions. You can also see it in the [Browserbase session replay dashboard](https://docs.browserbase.com/features/observability#stagehand) or in the session logs at debug level.
 </Note>
 
-### Using with Custom Pages
+### Using with custom pages
 
 Stagehand v4 drives the browser directly over the Chrome DevTools Protocol, so there is no Puppeteer, Playwright, or Patchright page interop. Instead, target any page Stagehand manages by passing the `page` option:
 
@@ -576,7 +593,7 @@ This works with:
 - **New pages:** create one on the context
 - **Existing browsers:** attach to a browser you already run with the `cdp` browser source
 
-<Card title="Complete API Reference" icon="book" href="/v3/references/stagehand">
+<Card title="Complete API reference" icon="book" href="/v3/references/stagehand">
   See the full `Stagehand` reference for detailed parameter documentation, return values, and advanced examples.
 </Card>
 
@@ -584,7 +601,7 @@ This works with:
 
 ### Plan then execute
 
-Discover all actions once, then feed each one back to `act()` without additional LLM calls. This approach is 2-3x faster than separate instruction-driven `act()` calls.
+Discover all actions once, then feed each one back to `act()`. Passing an action rather than a string skips inference, so the loop below makes one model call for the whole form instead of one per field.
 
 <View title="TypeScript" icon="js">
 ```typescript
@@ -630,7 +647,7 @@ for _, field := range observed.Data {
 
 ### Scope extractions
 
-Use `observe()` to narrow extraction scope and reduce token usage by up to 10x.
+Use `observe()` to find a container, then pass its selector to `extract()`. Extraction then sees only that subtree instead of the whole page, so token usage falls in proportion to how much of the page you exclude.
 
 <View title="TypeScript" icon="js">
 ```typescript
@@ -805,6 +822,9 @@ cachedObserve := func(ctx context.Context, instruction string) ([]stagehand.Acti
 ```typescript
 // Check page state before observing
 const page = await stagehand.context.activePage();
+if (!page) {
+  throw new Error("Stagehand initialized without an active page");
+}
 await page.waitForLoadState("domcontentloaded");
 
 const { data: actions } = await stagehand.observe("find the submit button");
@@ -820,6 +840,8 @@ if (actions.length === 0) {
 ```python
 # Check page state before observing
 page = await stagehand.context.active_page()
+if page is None:
+    raise RuntimeError("Stagehand initialized without an active page")
 await page.wait_for_load_state("domcontentloaded")
 
 observed = await stagehand.observe(instruction="find the submit button")
@@ -838,6 +860,9 @@ if not observed.data:
 page, err := browserContext.ActivePage(ctx)
 if err != nil {
 	return err
+}
+if page == nil {
+	return errors.New("Stagehand initialized without an active page")
 }
 if err := page.WaitForLoadState(ctx, stagehand.LoadStateDOMContentLoaded, nil); err != nil {
 	return err
@@ -951,15 +976,24 @@ if err != nil {
 	return err
 }
 
+var action *stagehand.Action
+if len(observed.Data) > 0 {
+	action = &observed.Data[0]
+}
+
+method := "<none>"
+if action != nil && action.Method != nil {
+	method = *action.Method
+}
+
 // Validate method before acting
 validMethods := []string{"click", "fill", "type", "press"}
-if len(observed.Data) > 0 && observed.Data[0].Method != nil &&
-	slices.Contains(validMethods, *observed.Data[0].Method) {
-	if _, err := client.Act(ctx, observed.Data[0], nil); err != nil {
+if action != nil && slices.Contains(validMethods, method) {
+	if _, err := client.Act(ctx, *action, nil); err != nil {
 		return err
 	}
 } else {
-	fmt.Println("Unexpected method:", observed.Data[0].Method)
+	fmt.Println("Unexpected method:", method)
 }
 ```
 </View>
@@ -982,7 +1016,7 @@ if len(observed.Data) > 0 && observed.Data[0].Method != nil &&
     Build action caches to eliminate redundant LLM calls.
   </Card>
 
-  <Card title="Complete API Reference" icon="book" href="/v3/references/stagehand">
+  <Card title="Complete API reference" icon="book" href="/v3/references/stagehand">
     Full `Stagehand` reference with detailed parameter documentation.
   </Card>
 </CardGroup>

--- a/packages/docs/v4/basics/observe.mdx
+++ b/packages/docs/v4/basics/observe.mdx
@@ -5,469 +5,984 @@ description: "Discover and plan executable actions on any web page."
 
 ## What is `observe()`?
 
-`observe()` discovers actionable elements on a page and returns structured actions you can execute or validate before acting. Use it to explore pages, plan multi-step workflows, cache actions, and validate elements before acting.
-
 <View title="TypeScript" icon="js">
-
 ```typescript
-const actions = await stagehand.observe("Find the sign in button");
-// actions.data -> [
-//   { selector: "xpath=/html/body/...", description: "Sign in", method: "click", arguments: [] }
-// ]
-// actions.metadata.cacheStatus -> "HIT", "MISS", or undefined
+await stagehand.observe("find the login button");
 ```
+</View>
 
-The `instruction` is optional: call `observe()` with no argument to survey the page broadly.
+<View title="Python" icon="python">
+```python
+await stagehand.observe(instruction="find the login button")
+```
+</View>
 
-<Accordion title="Common things to observe">
+<View title="Go" icon="golang">
+```go
+instruction := "find the login button"
+result, err := client.Observe(ctx, &instruction, nil)
+```
+</View>
 
-| Goal                | Example instruction                          |
-| ------------------- | -------------------------------------------- |
-| Find a button       | `Find the submit button`                     |
-| Locate form fields  | `Find all input fields in the checkout form` |
-| Discover links      | `Find the navigation links`                  |
-| Identify a region   | `Find the pricing table`                     |
-| Map a workflow      | `Find each step in the checkout flow`        |
-| Validate an element | `Find the delete account button`             |
-
-</Accordion>
+`observe()` discovers actionable elements on a page and returns structured actions you can execute or validate before acting. Use it to explore pages, plan multi-step workflows, cache actions, and validate elements before acting.
 
 ## Why use `observe()`?
 
-<CardGroup cols="2">
-  <Card title="Plan before acting" icon="list-check">
-    Preview what an action will target before running it.
+<CardGroup cols={2}>
+  <Card title="Explore" icon="compass" href="#using-observe">
+    Discover what's possible on a page: find buttons, forms, links, and interactive elements
   </Card>
-  <Card title="Verify elements" icon="circle-check">
-    Confirm an element is present before interacting with it.
+  <Card title="Plan" icon="map" href="#plan-then-execute">
+    Map out multi-step workflows by discovering all required actions upfront
   </Card>
-  <Card title="Scope the search" icon="crop">
-    Limit consideration to part of the page.
+  <Card title="Cache" icon="database" href="/v4/best-practices/caching">
+    Store discovered actions to skip LLM calls and speed up repeated workflows
   </Card>
-  <Card title="Cheaper than acting blind" icon="gauge-high">
-    One planning call can prevent repeated failed actions.
+  <Card title="Validate" icon="check" href="#validate-before-acting">
+    Verify elements exist and check their properties before performing critical actions
   </Card>
 </CardGroup>
 
 ## Using `observe()`
 
-The most common pattern is to observe first, decide, then act.
+Use `observe()` to discover actionable elements on a page. Here's how to find a button:
 
+<View title="TypeScript" icon="js">
 ```typescript
-const {
-  data: [candidate],
-} = await stagehand.observe("Find the primary call-to-action");
+const page = await stagehand.context.activePage();
+await page.goto("https://example.com");
+const { data: actions } = await stagehand.observe("find the learn more button");
+```
+</View>
 
-if (candidate) {
-  console.log(candidate.description); // inspect before acting
-  await stagehand.act("Click the primary call-to-action");
+<View title="Python" icon="python">
+```python
+page = await stagehand.context.active_page()
+await page.goto("https://example.com")
+result = await stagehand.observe(instruction="find the learn more button")
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+page, err := browserContext.ActivePage(ctx)
+if err != nil {
+	return err
+}
+if err := page.Goto(ctx, "https://example.com", nil); err != nil {
+	return err
+}
+
+instruction := "find the learn more button"
+result, err := client.Observe(ctx, &instruction, nil)
+```
+</View>
+
+<Note>
+**iFrame and Shadow DOM Support** Stagehand automatically handles iFrame traversal and shadow DOM elements without requiring additional configuration.
+</Note>
+
+<Accordion title="Common use cases">
+
+| Use Case | Example instruction |
+|----------|---------------------|
+| Find buttons | `find the submit button` |
+| Locate forms | `find all input fields in the form` |
+| Discover links | `find navigation links` |
+| Identify tables | `find the pricing table` |
+| Map workflows | `find all checkout steps` |
+| Validate elements | `find the delete account button` |
+
+</Accordion>
+
+
+### Return value of `observe()`?
+When you use `observe()`, Stagehand returns a result whose `data` field is a list of `Action` objects, alongside `metadata` carrying the action ID and server-side cache status. Each `Action` can be passed straight to [`act()`](/v4/basics/act) for deterministic replay:
+
+<View title="TypeScript" icon="js">
+```typescript
+[
+  {
+    description: 'Learn more button',
+    method: 'click',
+    arguments: [],
+    selector: 'xpath=/html[1]/body[1]/shadow-demo[1]//div[1]/button[1]'
+  }
+]
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+[
+    Action(
+        description="Learn more button",
+        method="click",
+        arguments=[],
+        selector="xpath=/html[1]/body[1]/shadow-demo[1]//div[1]/button[1]",
+    )
+]
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+[]stagehand.Action{
+	{
+		Description: "Learn more button",
+		Method:      &clickMethod,
+		Arguments:   []string{},
+		Selector:    "xpath=/html[1]/body[1]/shadow-demo[1]//div[1]/button[1]",
+	},
 }
 ```
+</View>
 
 <Tabs>
-  <Tab title="Do this" icon="check">
-
+<Tab title="Do this">
 Use specific, descriptive instructions.
 
+<View title="TypeScript" icon="js">
 ```typescript
-await stagehand.observe("Find the primary call-to-action in the hero section");
-await stagehand.observe("Find all input fields in the checkout form");
+// Clear and specific
+await stagehand.observe("find the primary call-to-action button in the hero section");
+await stagehand.observe("find all input fields in the checkout form");
+await stagehand.observe("find the delete account button in settings");
 ```
+</View>
 
+<View title="Python" icon="python">
+```python
+# Clear and specific
+await stagehand.observe(
+    instruction="find the primary call-to-action button in the hero section"
+)
+await stagehand.observe(instruction="find all input fields in the checkout form")
+await stagehand.observe(instruction="find the delete account button in settings")
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+// Clear and specific
+hero := "find the primary call-to-action button in the hero section"
+if _, err := client.Observe(ctx, &hero, nil); err != nil {
+	return err
+}
+
+fields := "find all input fields in the checkout form"
+if _, err := client.Observe(ctx, &fields, nil); err != nil {
+	return err
+}
+
+deleteButton := "find the delete account button in settings"
+if _, err := client.Observe(ctx, &deleteButton, nil); err != nil {
+	return err
+}
+```
+</View>
 </Tab>
-  <Tab title="Avoid this" icon="xmark">
 
-Avoid vague instructions, and reach for [`extract()`](/v4/basics/extract) to read data instead of observing it.
+<Tab title="Don't do this">
+Avoid vague or data-oriented queries.
 
+<View title="TypeScript" icon="js">
 ```typescript
-// Too vague to target reliably
-await stagehand.observe("Find buttons");
+// Too vague
+await stagehand.observe("find buttons");
 
-// Reading data: use extract() instead
-await stagehand.observe("What is the page title?");
+// Use extract() for data instead
+await stagehand.observe("what is the page title?");
 ```
+</View>
 
+<View title="Python" icon="python">
+```python
+# Too vague
+await stagehand.observe(instruction="find buttons")
+
+# Use extract() for data instead
+await stagehand.observe(instruction="what is the page title?")
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+// Too vague
+vague := "find buttons"
+_, err := client.Observe(ctx, &vague, nil)
+
+// Use Extract() for data instead
+title := "what is the page title?"
+_, err = client.Observe(ctx, &title, nil)
+```
+</View>
 </Tab>
 </Tabs>
 
-<Card title="Act on what you found" icon="arrow-pointer" href="/v4/basics/act">
-  Run the action once observe confirms the right target.
-</Card>
+## Advanced Configuration
 
-### Return value
+You can pass additional options to configure the model, timeout, selector scope, ignored page regions, and placeholder variables:
 
-`observe()` resolves to an `ObserveResult`. Its `data` is an array of `Action` objects,
-and its `metadata` contains shared operation information such as cache status.
-
+<View title="TypeScript" icon="js">
 ```typescript
-const actions = await stagehand.observe("Find the learn more button");
-// actions.data -> [
-//   {
-//     selector: "xpath=/html/body/shadow-demo/div[1]/button[1]",
-//     description: "Learn more button",
-//     method: "click",
-//     arguments: [],
-//   },
-// ]
-```
-
-## Advanced configuration
-
-```typescript
-const actions = await stagehand.observe("Find form fields", {
-  selector: "form#signup",
-  ignoreSelectors: [".advertisement"],
-  timeout: 15_000,
-  model: { modelName: "openai/gpt-5.4-mini", apiKey: process.env.OPENAI_API_KEY },
+// Custom model configuration
+const { data: actions } = await stagehand.observe("find navigation links", {
+  model: {
+    modelName: "openai/gpt-5.4-mini",
+    apiKey: process.env.OPENAI_API_KEY,
+  },
+  timeout: 30000,
+  selector: "//header", // Focus on specific area
 });
 ```
+</View>
 
-- `page`: the page to observe. Defaults to the active page.
-- `selector`: a CSS selector that scopes observation to one element.
-- `ignoreSelectors`: elements to exclude.
-- `timeout`: maximum time in milliseconds.
-- `model`: override the model for this call.
-- `variables`: variable names surface as `%name%` placeholders in suggested arguments (see
-  below).
-- `cache`: reuse a prior result for this call.
+<View title="Python" icon="python">
+```python
+from stagehand import ModelConfig
+
+# Custom model configuration
+result = await stagehand.observe(
+    instruction="find navigation links",
+    model=ModelConfig.model_validate({
+        "model_name": "openai/gpt-5.4-mini",
+        "api_key": os.environ["OPENAI_API_KEY"],
+    }),
+    timeout=30000,
+    selector="//header",  # Focus on specific area
+)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+// Custom model configuration
+modelAPIKey := os.Getenv("OPENAI_API_KEY")
+model := stagehand.KnownModel(stagehand.KnownModelConfig{
+	ModelName: "openai/gpt-5.4-mini",
+	APIKey:    &modelAPIKey,
+})
+timeout := 30000.0
+selector := "//header" // Focus on specific area
+
+instruction := "find navigation links"
+result, err := client.Observe(ctx, &instruction, &stagehand.StagehandClientObserveOptions{
+	ObserveOptions: stagehand.ObserveOptions{
+		Model:    &model,
+		Timeout:  &timeout,
+		Selector: &selector,
+	},
+})
+```
+</View>
+
+You can also exclude specific nodes, including their descendant nodes, with the ignore-selectors option.
+
+<View title="TypeScript" icon="js">
+```typescript
+const { data: actions } = await stagehand.observe("find the main call-to-action buttons", {
+  ignoreSelectors: [
+    "//aside[contains(@class, 'promo-rail')]",
+    "//div[@id='floating-chat-launcher']",
+    "//section[@aria-label='recommended articles']",
+  ],
+});
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+result = await stagehand.observe(
+    instruction="find the main call-to-action buttons",
+    ignore_selectors=[
+        "//aside[contains(@class, 'promo-rail')]",
+        "//div[@id='floating-chat-launcher']",
+        "//section[@aria-label='recommended articles']",
+    ],
+)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+instruction := "find the main call-to-action buttons"
+result, err := client.Observe(ctx, &instruction, &stagehand.StagehandClientObserveOptions{
+	ObserveOptions: stagehand.ObserveOptions{
+		IgnoreSelectors: []string{
+			"//aside[contains(@class, 'promo-rail')]",
+			"//div[@id='floating-chat-launcher']",
+			"//section[@aria-label='recommended articles']",
+		},
+	},
+})
+```
+</View>
 
 <Note>
-  `ignoreSelectors` removes every match and its descendants from consideration, while `selector`
-  scopes observation to a single resolved subtree.
+  The ignore-selectors option removes all matches for each selector, along with each matched node's descendants. The selector option still scopes observation to a single resolved subtree.
 </Note>
 
-### Variables and placeholders
+### Validate Then Act with Variables
 
-When you pass `variables`, `observe()` exposes their **names** to the model and returns
-`%name%` placeholders in suggested action arguments instead of literal values, so secrets
-stay out of the returned plan.
+For login and other safety-sensitive flows, use `observe()` to discover candidate actions, validate them, and then execute them. When you pass variables, `observe()` returns `%variableName%` placeholders in the suggested action arguments instead of raw secret values, so no secret ever reaches the model.
 
+<View title="TypeScript" icon="js">
 ```typescript
-const actions = await stagehand.observe("Fill the login form", {
+const { data: actions } = await stagehand.observe("find the login form fields", {
   variables: {
-    username: { value: "user@example.com", description: "the login email" },
-    rememberMe: true,
+    username: { value: "user@example.com", description: "The login email" },
+    password: { value: process.env.USER_PASSWORD, description: "The login password" },
   },
 });
-// suggested arguments reference %username% rather than the literal email
+
+const emailField = actions.find((action) => action.arguments?.includes("%username%"));
+const passwordField = actions.find((action) => action.arguments?.includes("%password%"));
+
+if (emailField && passwordField) {
+  // Replay the observed actions, resolving placeholders locally
+  await stagehand.act(emailField, { variables: { username: "user@example.com" } });
+  await stagehand.act(passwordField, { variables: { password: process.env.USER_PASSWORD } });
+}
 ```
+</View>
 
-### Cache repeated observations
+<View title="Python" icon="python">
+```python
+observed = await stagehand.observe(
+    instruction="find the login form fields",
+    variables={
+        "username": {"value": "user@example.com", "description": "The login email"},
+        "password": {
+            "value": os.environ["USER_PASSWORD"],
+            "description": "The login password",
+        },
+    },
+)
 
-On Browserbase, turn on caching
-so repeated, identical observations are served from a cache instead of calling the model again.
+email_field = next(a for a in observed.data if "%username%" in (a.arguments or []))
+password_field = next(a for a in observed.data if "%password%" in (a.arguments or []))
 
+# Replay the observed actions, resolving placeholders locally
+await stagehand.act(email_field, variables={"username": "user@example.com"})
+await stagehand.act(password_field, variables={"password": os.environ["USER_PASSWORD"]})
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+usernameDescription := "The login email"
+passwordDescription := "The login password"
+password := os.Getenv("USER_PASSWORD")
+
+instruction := "find the login form fields"
+result, err := client.Observe(ctx, &instruction, &stagehand.StagehandClientObserveOptions{
+	ObserveOptions: stagehand.ObserveOptions{
+		Variables: stagehand.Variables{
+			"username": stagehand.DescribedVariable(stagehand.DescribedVariableValue{
+				Value:       stagehand.StringVariable("user@example.com"),
+				Description: &usernameDescription,
+			}),
+			"password": stagehand.DescribedVariable(stagehand.DescribedVariableValue{
+				Value:       stagehand.StringVariable(password),
+				Description: &passwordDescription,
+			}),
+		},
+	},
+})
+if err != nil {
+	return err
+}
+
+var emailField, passwordField *stagehand.Action
+for i, action := range result.Data {
+	if slices.Contains(action.Arguments, "%username%") {
+		emailField = &result.Data[i]
+	}
+	if slices.Contains(action.Arguments, "%password%") {
+		passwordField = &result.Data[i]
+	}
+}
+
+// Replay the observed actions, resolving placeholders locally
+if emailField != nil && passwordField != nil {
+	if _, err := client.Act(ctx, *emailField, &stagehand.StagehandClientActOptions{
+		ActOptions: stagehand.ActOptions{
+			Variables: stagehand.Variables{
+				"username": stagehand.PrimitiveVariable(stagehand.StringVariable("user@example.com")),
+			},
+		},
+	}); err != nil {
+		return err
+	}
+	if _, err := client.Act(ctx, *passwordField, &stagehand.StagehandClientActOptions{
+		ActOptions: stagehand.ActOptions{
+			Variables: stagehand.Variables{
+				"password": stagehand.PrimitiveVariable(stagehand.StringVariable(password)),
+			},
+		},
+	}); err != nil {
+		return err
+	}
+}
+```
+</View>
+
+<Tip>
+`act()` supports the same variables option with either input form. Pass an instruction when you want Stagehand to locate the field for you, or pass the observed `Action` to replay a known target, in both cases keeping the value out of the prompt.
+</Tip>
+
+### Server-side Caching
+
+<Note>
+`cache` requires the Browserbase browser source and a Browserbase API key. It has no effect on local or CDP browsers.
+</Note>
+
+When running on Browserbase, Stagehand can cache `observe()` results server-side. Repeated calls with the same inputs return instantly without consuming LLM tokens. Enable caching on the constructor and override it per call:
+
+<View title="TypeScript" icon="js">
 ```typescript
-const actions = await stagehand.observe("Find the sign in button", { cache: true });
-console.log(actions.metadata.cacheStatus);
+// Enable server-side caching for the entire instance
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  browser: { type: "browserbase" },
+  cache: true,
+});
+
+// Or disable it for a single call
+const { data: actions } = await stagehand.observe("find the login button", { cache: false });
 ```
+</View>
+
+<View title="Python" icon="python">
+```python
+from stagehand import Stagehand
+
+# Enable server-side caching for the entire instance
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    browser="browserbase",
+    cache=True,
+)
+
+# Or disable it for a single call
+result = await stagehand.observe(instruction="find the login button", cache=False)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+// Enable server-side caching for the entire instance
+apiKey := os.Getenv("BROWSERBASE_API_KEY")
+instanceCache := stagehand.CacheEnabled(true)
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey:  &apiKey,
+	Browser: stagehand.BrowserbaseClientBrowserSource{},
+	Cache:   &instanceCache,
+})
+
+// Or disable it for a single call
+off := stagehand.CacheEnabled(false)
+instruction := "find the login button"
+result, err := client.Observe(ctx, &instruction, &stagehand.StagehandClientObserveOptions{
+	ObserveOptions: stagehand.ObserveOptions{Cache: &off},
+})
+```
+</View>
+
+<Note>
+  Cache status is reported on the result metadata, alongside the observed actions. You can also see it in the [Browserbase session replay dashboard](https://docs.browserbase.com/features/observability#stagehand) or in the session logs at debug level.
+</Note>
+
+### Using with Custom Pages
+
+Stagehand v4 drives the browser directly over the Chrome DevTools Protocol, so there is no Puppeteer, Playwright, or Patchright page interop. Instead, target any page Stagehand manages by passing the `page` option:
+
+<View title="TypeScript" icon="js">
+```typescript
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  browser: { type: "browserbase" },
+});
+await stagehand.init();
+
+// Open a second page in the same browser context
+const productsPage = await stagehand.context.newPage();
+await productsPage.goto("https://www.example.com/products");
+
+// Use observe with that specific page
+const { data: actions } = await stagehand.observe("find all product cards", {
+  page: productsPage,
+});
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    browser="browserbase",
+)
+await stagehand.init()
+
+# Open a second page in the same browser context
+products_page = await stagehand.context.new_page()
+await products_page.goto("https://www.example.com/products")
+
+# Use observe with that specific page
+result = await stagehand.observe(
+    instruction="find all product cards",
+    page=products_page,
+)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+apiKey := os.Getenv("BROWSERBASE_API_KEY")
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey:  &apiKey,
+	Browser: stagehand.BrowserbaseClientBrowserSource{},
+})
+if err := client.Init(ctx); err != nil {
+	return err
+}
+
+browserContext, err := client.Context()
+if err != nil {
+	return err
+}
+
+// Open a second page in the same browser context
+productsPage, err := browserContext.NewPage(ctx, stagehand.ContextNewPageParams{})
+if err != nil {
+	return err
+}
+if err := productsPage.Goto(ctx, "https://www.example.com/products", nil); err != nil {
+	return err
+}
+
+// Use Observe with that specific page
+instruction := "find all product cards"
+result, err := client.Observe(ctx, &instruction, &stagehand.StagehandClientObserveOptions{
+	Page: productsPage,
+})
+```
+</View>
+
+This works with:
+- **Active page:** omit `page` and Stagehand uses the active page (default)
+- **Existing pages:** index into the list of context pages
+- **New pages:** create one on the context
+- **Existing browsers:** attach to a browser you already run with the `cdp` browser source
+
+<Card title="Complete API Reference" icon="book" href="/v4/references/stagehand">
+  See the full `Stagehand` reference for detailed parameter documentation, return values, and advanced examples.
+</Card>
 
 ## Best practices
 
-- **Observe to verify, act to do:** Use `observe()` to confirm the right element exists,
-  then run `act()` with the same intent.
-- **Scope busy pages:** `selector` and `ignoreSelectors` cut noise and speed up planning.
-- **Handle empty results:** An empty `data` array means nothing matched, so surface that instead
-  of acting anyway.
+### Plan then execute
 
-### Scope downstream work
+Discover all actions once, then feed each one back to `act()` without additional LLM calls. This approach is 2-3x faster than separate instruction-driven `act()` calls.
 
-An observed action's `selector` can scope a follow-up `extract()`, narrowing the model to
-just the relevant region.
-
+<View title="TypeScript" icon="js">
 ```typescript
-const {
-  data: [table],
-} = await stagehand.observe("Find the pricing table");
-if (table) {
-  const pricing = await stagehand.extract("Extract each pricing tier", pricingSchema, {
-    selector: table.selector,
-  });
-  console.log(pricing.data);
+const { data: formFields } = await stagehand.observe("find all form input fields");
+
+for (const field of formFields) {
+  // No LLM call: Stagehand replays the observed action
+  await stagehand.act(field);
 }
 ```
+</View>
+
+<View title="Python" icon="python">
+```python
+observed = await stagehand.observe(instruction="find all form input fields")
+
+for field in observed.data:
+    # No LLM call: Stagehand replays the observed action
+    await stagehand.act(field)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+instruction := "find all form input fields"
+observed, err := client.Observe(ctx, &instruction, nil)
+if err != nil {
+	return err
+}
+
+for _, field := range observed.Data {
+	// No LLM call: Stagehand replays the observed action
+	if _, err := client.Act(ctx, field, nil); err != nil {
+		return err
+	}
+}
+```
+</View>
+
+<Card title="Analyze pages with observe()" icon="magnifying-glass" href="/v4/references/stagehand">
+  Complete guide to planning actions with `observe()`.
+</Card>
+
+### Scope extractions
+
+Use `observe()` to narrow extraction scope and reduce token usage by up to 10x.
+
+<View title="TypeScript" icon="js">
+```typescript
+const { data: tables } = await stagehand.observe("find the pricing table");
+const [table] = tables;
+
+const { data: pricing } = await stagehand.extract(
+  "extract all pricing tiers",
+  PricingSchema,
+  { selector: table.selector },
+);
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+observed = await stagehand.observe(instruction="find the pricing table")
+
+pricing = (await stagehand.extract(
+    instruction="extract all pricing tiers",
+    schema=Pricing,
+    selector=observed.data[0].selector,
+)).data
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+instruction := "find the pricing table"
+observed, err := client.Observe(ctx, &instruction, nil)
+if err != nil {
+	return err
+}
+if len(observed.Data) == 0 {
+	return errors.New("pricing table not found")
+}
+
+selector := observed.Data[0].Selector
+pricing, err := client.Extract(ctx, "extract all pricing tiers", pricingSchema, &stagehand.StagehandClientExtractOptions{
+	ExtractOptions: stagehand.ExtractOptions{Selector: &selector},
+})
+```
+</View>
+
+<Card title="Extract structured data" icon="table" href="/v4/basics/extract">
+  Learn how to use `observe()` with `extract()` for precise data extraction.
+</Card>
 
 ### Validate before acting
 
-Check that an observed action matches what you expect before running a critical step.
+Check elements exist and verify their properties before performing critical operations.
 
+<View title="TypeScript" icon="js">
 ```typescript
-const {
-  data: [deleteButton],
-} = await stagehand.observe("Find the delete account button");
+const { data: buttons } = await stagehand.observe("find the delete account button");
+const [deleteButton] = buttons;
+
 if (deleteButton?.method === "click") {
-  await stagehand.act("Click the delete account button");
+  await stagehand.act(deleteButton);
 } else {
   throw new Error("Delete button not found");
 }
 ```
-
-## Troubleshooting
-
-<AccordionGroup>
-  <Accordion title="No actions returned">
-
-An empty `data` array means nothing matched. Loosen an over-specific instruction, make sure the
-page has loaded, and confirm you're scoped to the right region.
-
-```typescript
-let actions = await stagehand.observe("Find the checkout button");
-if (actions.data.length === 0) {
-  await page.waitForLoadState("domcontentloaded");
-  actions = await stagehand.observe("Find the checkout button");
-}
-```
-
-</Accordion>
-  <Accordion title="Too many or irrelevant actions">
-
-Scope observation to the relevant region with `selector`, and exclude noise with
-`ignoreSelectors`.
-
-```typescript
-const actions = await stagehand.observe("Find the form fields", {
-  selector: "form#signup",
-  ignoreSelectors: [".advertisement"],
-});
-```
-
-  </Accordion>
-</AccordionGroup>
-
 </View>
 
 <View title="Python" icon="python">
-
 ```python
-actions = await stagehand.observe(instruction="Find the sign in button")
-# actions.data -> [Action(selector="xpath=...", description="Sign in", method="click", arguments=[])]
-# actions.metadata.cache_status -> "HIT", "MISS", or None
-```
+observed = await stagehand.observe(instruction="find the delete account button")
+delete_button = observed.data[0] if observed.data else None
 
-The `instruction` is optional: call `observe()` with no argument to survey the page broadly.
-
-<Accordion title="Common things to observe">
-
-| Goal                | Example instruction                          |
-| ------------------- | -------------------------------------------- |
-| Find a button       | `Find the submit button`                     |
-| Locate form fields  | `Find all input fields in the checkout form` |
-| Discover links      | `Find the navigation links`                  |
-| Identify a region   | `Find the pricing table`                     |
-| Map a workflow      | `Find each step in the checkout flow`        |
-| Validate an element | `Find the delete account button`             |
-
-</Accordion>
-
-## Why use `observe()`?
-
-<CardGroup cols="2">
-  <Card title="Plan before acting" icon="list-check">
-    Preview what an action will target before running it.
-  </Card>
-  <Card title="Verify elements" icon="circle-check">
-    Confirm an element is present before interacting with it.
-  </Card>
-  <Card title="Scope the search" icon="crop">
-    Limit consideration to part of the page.
-  </Card>
-  <Card title="Cheaper than acting blind" icon="gauge-high">
-    One planning call can prevent repeated failed actions.
-  </Card>
-</CardGroup>
-
-## Using `observe()`
-
-The most common pattern is to observe first, decide, then act.
-
-```python
-candidates = await stagehand.observe(instruction="Find the primary call-to-action")
-
-if candidates.data:
-    print(candidates.data[0].description)  # inspect before acting
-    await stagehand.act("Click the primary call-to-action")
-```
-
-<Tabs>
-  <Tab title="Do this" icon="check">
-
-Use specific, descriptive instructions.
-
-```python
-await stagehand.observe(instruction="Find the primary call-to-action in the hero section")
-await stagehand.observe(instruction="Find all input fields in the checkout form")
-```
-
-</Tab>
-  <Tab title="Avoid this" icon="xmark">
-
-Avoid vague instructions, and reach for [`extract()`](/v4/basics/extract) to read data instead of observing it.
-
-```python
-# Too vague to target reliably
-await stagehand.observe(instruction="Find buttons")
-
-# Reading data: use extract() instead
-await stagehand.observe(instruction="What is the page title?")
-```
-
-</Tab>
-</Tabs>
-
-<Card title="Act on what you found" icon="arrow-pointer" href="/v4/basics/act">
-  Run the action once observe confirms the right target.
-</Card>
-
-### Return value
-
-`observe()` resolves to an `ObserveResult`. Its `data` is a list of `Action` objects,
-and its `metadata` contains shared operation information such as cache status.
-
-```python
-actions = await stagehand.observe(instruction="Find the learn more button")
-# actions.data -> [
-#     Action(
-#         selector="xpath=/html/body/shadow-demo/div[1]/button[1]",
-#         description="Learn more button",
-#         method="click",
-#         arguments=[],
-#     ),
-# ]
-```
-
-## Advanced configuration
-
-```python
-from stagehand import ModelConfig
-
-
-actions = await stagehand.observe(
-    instruction="Find form fields",
-    selector="form#signup",
-    ignore_selectors=[".advertisement"],
-    timeout=15_000,
-    model=ModelConfig.model_validate({"model_name": "openai/gpt-5.4-mini"}),
-)
-```
-
-- `page`: the page to observe. Defaults to the active page.
-- `selector`: a CSS selector that scopes observation to one element.
-- `ignore_selectors`: elements to exclude.
-- `timeout`: maximum time in milliseconds.
-- `model`: override the complete model configuration for this call.
-- `variables`: variable names surface as `%name%` placeholders in suggested arguments (see
-  below).
-- `cache`: reuse a prior result for this call.
-
-<Note>
-  `ignore_selectors` removes every match and its descendants from consideration, while `selector`
-  scopes observation to a single resolved subtree.
-</Note>
-
-### Variables and placeholders
-
-When you pass `variables`, `observe()` exposes their **names** to the model and returns
-`%name%` placeholders in suggested action arguments instead of literal values, so secrets
-stay out of the returned plan.
-
-```python
-actions = await stagehand.observe(
-    instruction="Fill the login form",
-    variables={
-        "username": {"value": "user@example.com", "description": "the login email"},
-        "remember_me": True,
-    },
-)
-# suggested arguments reference %username% rather than the literal email
-```
-
-### Cache repeated observations
-
-On Browserbase, turn on caching
-so repeated, identical observations are served from a cache instead of calling the model again.
-
-```python
-actions = await stagehand.observe(instruction="Find the sign in button", cache=True)
-print(actions.metadata.cache_status)
-```
-
-## Best practices
-
-- **Observe to verify, act to do:** Use `observe()` to confirm the right element exists,
-  then run `act()` with the same intent.
-- **Scope busy pages:** `selector` and `ignore_selectors` cut noise and speed up planning.
-- **Handle empty results:** An empty `data` list means nothing matched, so surface that instead
-  of acting anyway.
-
-### Scope downstream work
-
-An observed action's `selector` can scope a follow-up `extract()`, narrowing the model to
-just the relevant region.
-
-```python
-tables = await stagehand.observe(instruction="Find the pricing table")
-if tables.data:
-    pricing = await stagehand.extract(
-        instruction="Extract each pricing tier",
-        schema=Pricing,
-        selector=tables.data[0].selector,
-    )
-    print(pricing.data)
-```
-
-### Validate before acting
-
-Check that an observed action matches what you expect before running a critical step.
-
-```python
-candidates = await stagehand.observe(instruction="Find the delete account button")
-if candidates.data and candidates.data[0].method == "click":
-    await stagehand.act("Click the delete account button")
+if delete_button is not None and delete_button.method == "click":
+    await stagehand.act(delete_button)
 else:
     raise RuntimeError("Delete button not found")
 ```
+</View>
+
+<View title="Go" icon="golang">
+```go
+instruction := "find the delete account button"
+observed, err := client.Observe(ctx, &instruction, nil)
+if err != nil {
+	return err
+}
+
+if len(observed.Data) == 0 || observed.Data[0].Method == nil || *observed.Data[0].Method != "click" {
+	return errors.New("Delete button not found")
+}
+
+if _, err := client.Act(ctx, observed.Data[0], nil); err != nil {
+	return err
+}
+```
+</View>
+
+<Card title="Execute actions with act()" icon="play" href="/v4/basics/act">
+  Learn how to execute observed actions reliably.
+</Card>
+
+### Cache observed actions
+
+Store and reuse observed actions to eliminate redundant LLM calls. Build a simple in-process cache:
+
+<View title="TypeScript" icon="js">
+```typescript
+const actionCache = new Map<string, Action[]>();
+
+async function cachedObserve(instruction: string) {
+  if (actionCache.has(instruction)) {
+    return actionCache.get(instruction)!;
+  }
+
+  const { data: actions } = await stagehand.observe(instruction);
+  actionCache.set(instruction, actions);
+  return actions;
+}
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+action_cache: dict[str, list[Action]] = {}
+
+
+async def cached_observe(instruction: str) -> list[Action]:
+    if instruction in action_cache:
+        return action_cache[instruction]
+
+    observed = await stagehand.observe(instruction=instruction)
+    action_cache[instruction] = observed.data
+    return observed.data
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+actionCache := map[string][]stagehand.Action{}
+
+cachedObserve := func(ctx context.Context, instruction string) ([]stagehand.Action, error) {
+	if cached, ok := actionCache[instruction]; ok {
+		return cached, nil
+	}
+
+	observed, err := client.Observe(ctx, &instruction, nil)
+	if err != nil {
+		return nil, err
+	}
+	actionCache[instruction] = observed.Data
+	return observed.Data, nil
+}
+```
+</View>
+
+<Card title="Complete caching guide" icon="database" href="/v4/best-practices/caching">
+  Learn advanced caching techniques and patterns for optimal performance.
+</Card>
 
 ## Troubleshooting
 
 <AccordionGroup>
-  <Accordion title="No actions returned">
 
-An empty `data` list means nothing matched. Loosen an over-specific instruction, make sure the
-page has loaded, and confirm you're scoped to the right region.
+<Accordion title="No elements found">
+**Problem**: `observe()` returns an empty list
 
-```python
-actions = await stagehand.observe(instruction="Find the checkout button")
-if not actions.data:
-    await page.wait_for_load_state("domcontentloaded")
-    actions = await stagehand.observe(instruction="Find the checkout button")
+**Solutions**:
+- Verify the element exists on the page
+- Use more specific instructions (e.g., "find the blue submit button" instead of "find button")
+- Ensure page has fully loaded before calling `observe()`
+- Set the log level to `debug` in your Stagehand configuration to inspect detection behavior
+
+<View title="TypeScript" icon="js">
+```typescript
+// Check page state before observing
+const page = await stagehand.context.activePage();
+await page.waitForLoadState("domcontentloaded");
+
+const { data: actions } = await stagehand.observe("find the submit button");
+
+if (actions.length === 0) {
+  console.log("No elements found, trying alternative instruction");
+  const { data: altActions } = await stagehand.observe("find the button at the bottom of the form");
+}
 ```
+</View>
 
-</Accordion>
-  <Accordion title="Too many or irrelevant actions">
-
-Scope observation to the relevant region with `selector`, and exclude noise with
-`ignore_selectors`.
-
+<View title="Python" icon="python">
 ```python
-actions = await stagehand.observe(
-    instruction="Find the form fields",
-    selector="form#signup",
-    ignore_selectors=[".advertisement"],
+# Check page state before observing
+page = await stagehand.context.active_page()
+await page.wait_for_load_state("domcontentloaded")
+
+observed = await stagehand.observe(instruction="find the submit button")
+
+if not observed.data:
+    print("No elements found, trying alternative instruction")
+    alt = await stagehand.observe(
+        instruction="find the button at the bottom of the form"
+    )
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+// Check page state before observing
+page, err := browserContext.ActivePage(ctx)
+if err != nil {
+	return err
+}
+if err := page.WaitForLoadState(ctx, stagehand.LoadStateDOMContentLoaded, nil); err != nil {
+	return err
+}
+
+instruction := "find the submit button"
+observed, err := client.Observe(ctx, &instruction, nil)
+if err != nil {
+	return err
+}
+
+if len(observed.Data) == 0 {
+	fmt.Println("No elements found, trying alternative instruction")
+	alt := "find the button at the bottom of the form"
+	if _, err := client.Observe(ctx, &alt, nil); err != nil {
+		return err
+	}
+}
+```
+</View>
+</Accordion>
+
+<Accordion title="Inaccurate results">
+**Problem**: Descriptions or selectors don't match actual elements
+
+**Solutions**:
+- Use more capable models, and check [model evals](https://stagehand.dev/evals) for recommendations
+- Provide more context in your instruction (e.g., "find the submit button in the checkout form")
+- Set the log level to `debug` in your Stagehand configuration to inspect LLM reasoning
+
+<View title="TypeScript" icon="js">
+```typescript
+// More specific instructions improve accuracy
+// Instead of:
+await stagehand.observe("find the button");
+
+// Use context:
+await stagehand.observe("find the red 'Delete' button in the user settings panel");
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+# More specific instructions improve accuracy
+# Instead of:
+await stagehand.observe(instruction="find the button")
+
+# Use context:
+await stagehand.observe(
+    instruction="find the red 'Delete' button in the user settings panel"
 )
 ```
-
-  </Accordion>
-</AccordionGroup>
-
 </View>
+
+<View title="Go" icon="golang">
+```go
+// More specific instructions improve accuracy
+// Instead of:
+vague := "find the button"
+_, err := client.Observe(ctx, &vague, nil)
+
+// Use context:
+specific := "find the red 'Delete' button in the user settings panel"
+_, err = client.Observe(ctx, &specific, nil)
+```
+</View>
+</Accordion>
+
+<Accordion title="Wrong method suggested">
+**Problem**: The `method` field has an unexpected value
+
+**Solutions**:
+- Validate the method before using it
+- Check [supported actions](/v4/basics/act) for valid method names
+- Reach for a [locator](/v4/references/stagehand) when you want to call a specific method instead of trusting the suggestion
+
+<View title="TypeScript" icon="js">
+```typescript
+const { data: actions } = await stagehand.observe("find the submit button");
+const [action] = actions;
+
+// Validate method before acting
+const validMethods = ["click", "fill", "type", "press"];
+if (action && validMethods.includes(action.method || "")) {
+  await stagehand.act(action);
+} else {
+  console.warn(`Unexpected method: ${action?.method}`);
+}
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+observed = await stagehand.observe(instruction="find the submit button")
+action = observed.data[0] if observed.data else None
+
+# Validate method before acting
+valid_methods = {"click", "fill", "type", "press"}
+if action is not None and action.method in valid_methods:
+    await stagehand.act(action)
+else:
+    print(f"Unexpected method: {action.method if action else None}")
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+instruction := "find the submit button"
+observed, err := client.Observe(ctx, &instruction, nil)
+if err != nil {
+	return err
+}
+
+// Validate method before acting
+validMethods := []string{"click", "fill", "type", "press"}
+if len(observed.Data) > 0 && observed.Data[0].Method != nil &&
+	slices.Contains(validMethods, *observed.Data[0].Method) {
+	if _, err := client.Act(ctx, observed.Data[0], nil); err != nil {
+		return err
+	}
+} else {
+	fmt.Println("Unexpected method:", observed.Data[0].Method)
+}
+```
+</View>
+</Accordion>
+
+</AccordionGroup>
 
 ## Next steps
 
-<CardGroup cols="2">
-  <Card title="Act" icon="arrow-pointer" href="/v4/basics/act">
-    Execute the action you planned.
+<CardGroup cols={2}>
+  <Card title="Execute actions with act()" icon="play" href="/v4/basics/act">
+    Use `act()` to execute discovered actions reliably.
   </Card>
-  <Card title="Extract" icon="download" href="/v4/basics/extract">
-    Pull typed data from a page.
+
+  <Card title="Extract structured data" icon="table" href="/v4/basics/extract">
+    Combine `observe()` with `extract()` for precise data extraction.
+  </Card>
+
+  <Card title="Caching actions" icon="bolt" href="/v4/best-practices/caching">
+    Build action caches to eliminate redundant LLM calls.
+  </Card>
+
+  <Card title="Complete API Reference" icon="book" href="/v4/references/stagehand">
+    Full `Stagehand` reference with detailed parameter documentation.
   </Card>
 </CardGroup>

--- a/packages/docs/v4/basics/observe.mdx
+++ b/packages/docs/v4/basics/observe.mdx
@@ -20,7 +20,9 @@ await stagehand.observe(instruction="find the login button")
 <View title="Go" icon="golang">
 ```go
 instruction := "find the login button"
-result, err := client.Observe(ctx, &instruction, nil)
+if _, err := client.Observe(ctx, &instruction, nil); err != nil {
+	return err
+}
 ```
 </View>
 
@@ -83,6 +85,10 @@ if err := page.Goto(ctx, "https://example.com", nil); err != nil {
 
 instruction := "find the learn more button"
 result, err := client.Observe(ctx, &instruction, nil)
+if err != nil {
+	return err
+}
+fmt.Println("found", len(result.Data), "actions")
 ```
 </View>
 
@@ -145,6 +151,8 @@ actions := []stagehand.Action{
 		Selector:    "xpath=/html[1]/body[1]/shadow-demo[1]//div[1]/button[1]",
 	},
 }
+
+fmt.Println(actions[0].Description, *actions[0].Method, actions[0].Selector)
 ```
 </View>
 
@@ -220,11 +228,15 @@ await stagehand.observe(instruction="what is the page title?")
 ```go
 // Too vague
 vague := "find buttons"
-_, err := client.Observe(ctx, &vague, nil)
+if _, err := client.Observe(ctx, &vague, nil); err != nil {
+	return err
+}
 
 // Use Extract() for data instead
 title := "what is the page title?"
-_, err = client.Observe(ctx, &title, nil)
+if _, err := client.Observe(ctx, &title, nil); err != nil {
+	return err
+}
 ```
 </View>
 </Tab>
@@ -284,6 +296,10 @@ result, err := client.Observe(ctx, &instruction, &stagehand.StagehandClientObser
 		Selector: &selector,
 	},
 })
+if err != nil {
+	return err
+}
+fmt.Println("found", len(result.Data), "navigation links")
 ```
 </View>
 
@@ -326,6 +342,10 @@ result, err := client.Observe(ctx, &instruction, &stagehand.StagehandClientObser
 		},
 	},
 })
+if err != nil {
+	return err
+}
+fmt.Println("found", len(result.Data), "call-to-action buttons")
 ```
 </View>
 
@@ -504,6 +524,13 @@ instruction := "find the login button"
 result, err := client.Observe(ctx, &instruction, &stagehand.StagehandClientObserveOptions{
 	ObserveOptions: stagehand.ObserveOptions{Cache: &off},
 })
+if err != nil {
+	return err
+}
+
+if result.Metadata.CacheStatus != nil {
+	fmt.Println(*result.Metadata.CacheStatus) // "HIT" or "MISS"
+}
 ```
 </View>
 
@@ -584,6 +611,10 @@ instruction := "find all product cards"
 result, err := client.Observe(ctx, &instruction, &stagehand.StagehandClientObserveOptions{
 	Page: productsPage,
 })
+if err != nil {
+	return err
+}
+fmt.Println("found", len(result.Data), "product cards")
 ```
 </View>
 
@@ -651,6 +682,15 @@ Use `observe()` to find a container, then pass its selector to `extract()`. Extr
 
 <View title="TypeScript" icon="js">
 ```typescript
+const PricingSchema = z.object({
+  tiers: z.array(
+    z.object({
+      name: z.string(),
+      price: z.string(),
+    }),
+  ),
+});
+
 const { data: tables } = await stagehand.observe("find the pricing table");
 const [table] = tables;
 
@@ -659,11 +699,24 @@ const { data: pricing } = await stagehand.extract(
   PricingSchema,
   { selector: table.selector },
 );
+
+for (const tier of pricing.tiers) {
+  console.log(tier.name, tier.price);
+}
 ```
 </View>
 
 <View title="Python" icon="python">
 ```python
+class PricingTier(BaseModel):
+    name: str
+    price: str
+
+
+class Pricing(BaseModel):
+    tiers: list[PricingTier]
+
+
 observed = await stagehand.observe(instruction="find the pricing table")
 
 pricing = (await stagehand.extract(
@@ -671,11 +724,43 @@ pricing = (await stagehand.extract(
     schema=Pricing,
     selector=observed.data[0].selector,
 )).data
+
+for tier in pricing.tiers:
+    print(tier.name, tier.price)
 ```
 </View>
 
 <View title="Go" icon="golang">
 ```go
+type pricingTier struct {
+	Name  string `json:"name"`
+	Price string `json:"price"`
+}
+
+type pricingTiers struct {
+	Tiers []pricingTier `json:"tiers"`
+}
+
+var pricingSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "tiers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {"type": "string"},
+          "price": {"type": "string"}
+        },
+        "required": ["name", "price"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["tiers"],
+  "additionalProperties": false
+}`)
+
 instruction := "find the pricing table"
 observed, err := client.Observe(ctx, &instruction, nil)
 if err != nil {
@@ -686,9 +771,22 @@ if len(observed.Data) == 0 {
 }
 
 selector := observed.Data[0].Selector
-pricing, err := client.Extract(ctx, "extract all pricing tiers", pricingSchema, &stagehand.StagehandClientExtractOptions{
+pricing, err := stagehand.ExtractAs[pricingTiers](
+	ctx,
+	client,
+	"extract all pricing tiers",
+	pricingSchema,
+	&stagehand.StagehandClientExtractOptions{
 	ExtractOptions: stagehand.ExtractOptions{Selector: &selector},
-})
+	},
+)
+if err != nil {
+	return err
+}
+
+for _, tier := range pricing.Tiers {
+	fmt.Println(tier.Name, tier.Price)
+}
 ```
 </View>
 
@@ -798,6 +896,13 @@ cachedObserve := func(ctx context.Context, instruction string) ([]stagehand.Acti
 	actionCache[instruction] = observed.Data
 	return observed.Data, nil
 }
+
+// The second call for the same instruction is served from actionCache
+actions, err := cachedObserve(ctx, "find all form input fields")
+if err != nil {
+	return err
+}
+fmt.Println("cached", len(actions), "actions")
 ```
 </View>
 
@@ -922,11 +1027,15 @@ await stagehand.observe(
 // More specific instructions improve accuracy
 // Instead of:
 vague := "find the button"
-_, err := client.Observe(ctx, &vague, nil)
+if _, err := client.Observe(ctx, &vague, nil); err != nil {
+	return err
+}
 
 // Use context:
 specific := "find the red 'Delete' button in the user settings panel"
-_, err = client.Observe(ctx, &specific, nil)
+if _, err := client.Observe(ctx, &specific, nil); err != nil {
+	return err
+}
 ```
 </View>
 </Accordion>

--- a/packages/docs/v4/basics/webmcp.mdx
+++ b/packages/docs/v4/basics/webmcp.mdx
@@ -1,0 +1,421 @@
+---
+title: "WebMCP"
+sidebarTitle: "WebMCP"
+description: "List and invoke tools registered by the current web page."
+---
+
+## What is WebMCP?
+
+Some pages expose their own capabilities as callable tools rather than making you drive their UI. WebMCP is the browser API for discovering those tools and invoking them directly, so a checkout flow that would otherwise take six clicks becomes one call with typed input.
+
+`page.tools()` returns the tools the current page has registered. Each tool carries a name, a description, and a JSON Schema for its input, and each one can be invoked and awaited.
+
+{/* TODO(go): confirm the Go samples once a Go toolchain is available; they are symbol-checked but not compiled. */}
+
+<View title="TypeScript" icon="js">
+```typescript
+const tools = await page.tools();
+const [checkout] = tools;
+
+const invocation = await checkout.invoke({ input: { quantity: 2 } });
+const response = await invocation.result();
+
+console.log(response.status, response.output);
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+tools = await page.tools()
+checkout = tools[0]
+
+invocation = await checkout.invoke(input={"quantity": 2})
+response = await invocation.result()
+
+print(response.status, response.output)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+tools, err := page.Tools(ctx, nil)
+if err != nil {
+	return err
+}
+checkout := tools[0]
+
+invocation, err := checkout.Invoke(ctx, stagehand.WebMCPInput{"quantity": 2})
+if err != nil {
+	return err
+}
+
+response, err := invocation.Result(ctx, nil)
+if err != nil {
+	return err
+}
+
+fmt.Println(response.Status, response.Output)
+```
+</View>
+
+<Note>
+WebMCP tools are registered *by the page*. That makes them distinct from tools you wire into a model yourself: you do not define them, you discover whatever the site chose to publish.
+</Note>
+
+## Browser Support
+
+WebMCP requires a Chromium build with the WebMCP features enabled. Stagehand adds the required flag for you on every local browser it launches:
+
+```
+--enable-features=WebMCPTesting,DevToolsWebMCPSupport
+```
+
+<Warning>
+If you attach to a browser you started yourself with the `cdp` browser source, Stagehand cannot add the flag. Launch that browser with `--enable-features=WebMCPTesting,DevToolsWebMCPSupport` or `page.tools()` will return an empty list.
+</Warning>
+
+## Listing Tools
+
+`page.tools()` takes a snapshot of what the page currently exposes. Call it again after navigating or after the page mounts new UI; the result is not live.
+
+<View title="TypeScript" icon="js">
+```typescript
+// Wait up to 3 seconds for the page to register its tools
+const tools = await page.tools({ timeout: 3000 });
+
+for (const tool of tools) {
+  console.log(tool.name, tool.description);
+  console.log(tool.inputSchema);   // JSON Schema for invoke() input
+  console.log(tool.annotations);   // { readOnly?, untrustedContent?, autosubmit? }
+  console.log(tool.frameId);       // the frame that registered the tool
+}
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+# Wait up to 3 seconds for the page to register its tools
+tools = await page.tools(timeout=3000)
+
+for tool in tools:
+    print(tool.name, tool.description)
+    print(tool.input_schema)  # JSON Schema for invoke() input
+    print(tool.annotations)   # read_only / untrusted_content / autosubmit
+    print(tool.frame_id)      # the frame that registered the tool
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+// Wait up to 3 seconds for the page to register its tools
+timeout := 3000.0
+tools, err := page.Tools(ctx, &stagehand.WebMCPToolsOptions{Timeout: timeout})
+if err != nil {
+	return err
+}
+
+for _, tool := range tools {
+	descriptor := tool.Descriptor()
+	fmt.Println(descriptor.Name, descriptor.Description)
+	fmt.Println(descriptor.InputSchema)  // JSON Schema for Invoke input
+	fmt.Println(descriptor.Annotations)  // ReadOnly / UntrustedContent / Autosubmit
+	fmt.Println(descriptor.FrameID)      // the frame that registered the tool
+}
+```
+</View>
+
+The listing timeout defaults to 1000 ms. Tools declared in iframes are included, each tagged with the `frameId` that registered it.
+
+<Accordion title="Tool annotations">
+
+| Annotation | Meaning |
+|---|---|
+| `readOnly` | The tool does not mutate state, so it is safe to call speculatively |
+| `untrustedContent` | The output contains page-controlled text; do not feed it to a model as if it were trusted |
+| `autosubmit` | Invoking the tool submits something on the user's behalf |
+
+Annotations are hints from the page, not guarantees enforced by the browser. Treat `untrustedContent` output as data, never as instructions.
+</Accordion>
+
+## Invoking Tools
+
+Invoking is two steps: `invoke()` hands the call to the browser and returns immediately with a handle, then `result()` waits for the terminal response. Splitting them means a long-running tool does not block you, and you can cancel while it is in flight.
+
+<View title="TypeScript" icon="js">
+```typescript
+const [search] = await page.tools();
+
+// Returns as soon as Chrome accepts the invocation
+const invocation = await search.invoke({ input: { query: "wireless mouse" } });
+
+console.log(invocation.invocationId, invocation.toolName, invocation.input);
+
+// Blocks until the tool reaches a terminal state
+const response = await invocation.result({ timeout: 30000 });
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+tools = await page.tools()
+search = tools[0]
+
+# Returns as soon as Chrome accepts the invocation
+invocation = await search.invoke(input={"query": "wireless mouse"})
+
+print(invocation.invocation_id, invocation.tool_name, invocation.input)
+
+# Blocks until the tool reaches a terminal state
+response = await invocation.result(timeout=30000)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+tools, err := page.Tools(ctx, nil)
+if err != nil {
+	return err
+}
+search := tools[0]
+
+// Returns as soon as Chrome accepts the invocation
+invocation, err := search.Invoke(ctx, stagehand.WebMCPInput{"query": "wireless mouse"})
+if err != nil {
+	return err
+}
+
+descriptor := invocation.Descriptor()
+fmt.Println(descriptor.InvocationID, descriptor.ToolName, descriptor.Input)
+
+// Blocks until the tool reaches a terminal state
+resultTimeout := 30000.0
+response, err := invocation.Result(ctx, &stagehand.WebMCPResultOptions{Timeout: &resultTimeout})
+```
+</View>
+
+<Note>
+Omitting the input sends an empty object. Validate your input against the tool's `inputSchema` before invoking if you want a clear failure locally rather than an `Error` response from the page.
+</Note>
+
+## Handling Results
+
+A terminal response reports one of three statuses:
+
+| `status` | Meaning | Where to look |
+|---|---|---|
+| `Completed` | The tool finished | `output` |
+| `Canceled` | Cancellation was honored | neither |
+| `Error` | The tool failed | `errorText`, and `exception` when the page threw |
+
+<View title="TypeScript" icon="js">
+```typescript
+const response = await invocation.result();
+
+switch (response.status) {
+  case "Completed":
+    console.log("output:", response.output);
+    break;
+  case "Canceled":
+    console.log("canceled before it finished");
+    break;
+  case "Error":
+    console.error(response.errorText, response.exception);
+    break;
+}
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+response = await invocation.result()
+
+if response.status == "Completed":
+    print("output:", response.output)
+elif response.status == "Canceled":
+    print("canceled before it finished")
+else:
+    print(response.error_text, response.exception)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+response, err := invocation.Result(ctx, nil)
+if err != nil {
+	return err
+}
+
+switch response.Status {
+case stagehand.WebMCPInvocationStatusCompleted:
+	// Decode the JSON output into a type you choose
+	type searchOutput struct {
+		Results []string `json:"results"`
+	}
+	output, err := stagehand.WebMCPOutputAs[searchOutput](response)
+	if err != nil {
+		return err
+	}
+	fmt.Println("output:", output.Results)
+case stagehand.WebMCPInvocationStatusCanceled:
+	fmt.Println("canceled before it finished")
+case stagehand.WebMCPInvocationStatusError:
+	fmt.Println(response.ErrorText, response.Exception)
+}
+```
+</View>
+
+`result()` caches the terminal response, so calling it twice is cheap and returns the same value. A timeout or transport failure is not cached and can be retried.
+
+### Canceling an Invocation
+
+<View title="TypeScript" icon="js">
+```typescript
+const invocation = await slowTool.invoke({ input: {} });
+
+// Ask the page to stop. The terminal status is still whatever Chrome reports.
+await invocation.cancel();
+
+const response = await invocation.result();
+console.log(response.status); // often "Canceled", but the tool may have finished first
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+invocation = await slow_tool.invoke(input={})
+
+# Ask the page to stop. The terminal status is still whatever Chrome reports.
+await invocation.cancel()
+
+response = await invocation.result()
+print(response.status)  # often "Canceled", but the tool may have finished first
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+invocation, err := slowTool.Invoke(ctx, nil)
+if err != nil {
+	return err
+}
+
+// Ask the page to stop. The terminal status is still whatever Chrome reports.
+if err := invocation.Cancel(ctx); err != nil {
+	return err
+}
+
+response, err := invocation.Result(ctx, nil)
+if err != nil {
+	return err
+}
+fmt.Println(response.Status) // often "Canceled", but the tool may have finished first
+```
+</View>
+
+<Warning>
+Cancellation is a request, not a guarantee. Chrome decides the terminal status, so always read it from `result()` rather than assuming the invocation stopped.
+</Warning>
+
+## Timeouts
+
+| Call | Default | Purpose |
+|---|---|---|
+| listing tools | 1000 ms | How long to wait for the page to register its tools |
+| awaiting a result | none | How long to wait for a terminal response; waits indefinitely when unset |
+
+Raise the listing timeout on pages that register tools after an async bootstrap. Set a result timeout whenever a tool could hang, so your automation fails loudly instead of stalling.
+
+## Combining With the Primitives
+
+WebMCP and the primitives solve different problems, and mixing them is normal: use a tool where the page gives you one, and fall back to [`observe()`](/v4/basics/observe) and [`act()`](/v4/basics/act) where it does not.
+
+<View title="TypeScript" icon="js">
+```typescript
+const tools = await page.tools();
+const addToCart = tools.find((tool) => tool.name === "addToCart");
+
+if (addToCart) {
+  // Deterministic, typed, no model call
+  const invocation = await addToCart.invoke({ input: { sku: "ABC-123", quantity: 1 } });
+  await invocation.result();
+} else {
+  // The page publishes no tool for this, so drive the UI
+  await stagehand.act("add the item to the cart");
+}
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+tools = await page.tools()
+add_to_cart = next((tool for tool in tools if tool.name == "addToCart"), None)
+
+if add_to_cart is not None:
+    # Deterministic, typed, no model call
+    invocation = await add_to_cart.invoke(input={"sku": "ABC-123", "quantity": 1})
+    await invocation.result()
+else:
+    # The page publishes no tool for this, so drive the UI
+    await stagehand.act("add the item to the cart")
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+tools, err := page.Tools(ctx, nil)
+if err != nil {
+	return err
+}
+
+var addToCart *stagehand.WebMCPTool
+for _, tool := range tools {
+	if tool.Descriptor().Name == "addToCart" {
+		addToCart = tool
+		break
+	}
+}
+
+if addToCart != nil {
+	// Deterministic, typed, no model call
+	invocation, err := addToCart.Invoke(ctx, stagehand.WebMCPInput{"sku": "ABC-123", "quantity": 1})
+	if err != nil {
+		return err
+	}
+	if _, err := invocation.Result(ctx, nil); err != nil {
+		return err
+	}
+} else {
+	// The page publishes no tool for this, so drive the UI
+	if _, err := client.Act(ctx, "add the item to the cart", nil); err != nil {
+		return err
+	}
+}
+```
+</View>
+
+<Tip>
+A tool invocation costs no LLM tokens and cannot pick the wrong element, so prefer one over an `act()` call whenever the page offers it.
+</Tip>
+
+## API Reference
+
+<Card title="Complete API Reference" icon="book" href="/v3/references/stagehand">
+  Full `Page`, `WebMCPTool`, and `WebMCPInvocation` reference with every option and field.
+</Card>
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Observe" icon="magnifying-glass" href="/v4/basics/observe">
+    Discover what a page can do when it publishes no tools
+  </Card>
+  <Card title="Act" icon="play" href="/v4/basics/act">
+    Execute a single action with natural language
+  </Card>
+  <Card title="Extract" icon="table" href="/v4/basics/extract">
+    Pull typed, structured data off any page
+  </Card>
+  <Card title="Browser Configuration" icon="browser" href="/v3/configuration/browser">
+    Launch flags, browser sources, and attaching over CDP
+  </Card>
+</CardGroup>

--- a/packages/docs/v4/basics/webmcp.mdx
+++ b/packages/docs/v4/basics/webmcp.mdx
@@ -62,19 +62,19 @@ fmt.Println(response.Status, response.Output)
 WebMCP tools are registered *by the page*. That makes them distinct from tools you wire into a model yourself: you do not define them, you discover whatever the site chose to publish.
 </Note>
 
-## Browser Support
+## Browser support
 
-WebMCP requires a Chromium build with the WebMCP features enabled. Stagehand adds the required flag for you on every local browser it launches:
+WebMCP requires a Chromium build with the WebMCP features enabled. Stagehand ships this flag as one of the default launch flags for every local browser it starts:
 
 ```
 --enable-features=WebMCPTesting,DevToolsWebMCPSupport
 ```
 
 <Warning>
-If you attach to a browser you started yourself with the `cdp` browser source, Stagehand cannot add the flag. Launch that browser with `--enable-features=WebMCPTesting,DevToolsWebMCPSupport` or `page.tools()` will return an empty list.
+Stagehand can only set launch flags on browsers it launches. If you attach to a browser you started yourself with the `cdp` browser source, or you strip Stagehand's default flags on a local launch, start Chrome with `--enable-features=WebMCPTesting,DevToolsWebMCPSupport` or `page.tools()` will return an empty list.
 </Warning>
 
-## Listing Tools
+## Listing tools
 
 `page.tools()` takes a snapshot of what the page currently exposes. Call it again after navigating or after the page mounts new UI; the result is not live.
 
@@ -137,7 +137,7 @@ The listing timeout defaults to 1000 ms. Tools declared in iframes are included,
 Annotations are hints from the page, not guarantees enforced by the browser. Treat `untrustedContent` output as data, never as instructions.
 </Accordion>
 
-## Invoking Tools
+## Invoking tools
 
 Invoking is two steps: `invoke()` hands the call to the browser and returns immediately with a handle, then `result()` waits for the terminal response. Splitting them means a long-running tool does not block you, and you can cancel while it is in flight.
 
@@ -190,6 +190,11 @@ fmt.Println(descriptor.InvocationID, descriptor.ToolName, descriptor.Input)
 // Blocks until the tool reaches a terminal state
 resultTimeout := 30000.0
 response, err := invocation.Result(ctx, &stagehand.WebMCPResultOptions{Timeout: &resultTimeout})
+if err != nil {
+	return err
+}
+
+fmt.Println(response.Status, response.Output)
 ```
 </View>
 
@@ -197,7 +202,7 @@ response, err := invocation.Result(ctx, &stagehand.WebMCPResultOptions{Timeout: 
 Omitting the input sends an empty object. Validate your input against the tool's `inputSchema` before invoking if you want a clear failure locally rather than an `Error` response from the page.
 </Note>
 
-## Handling Results
+## Handling results
 
 A terminal response reports one of three statuses:
 
@@ -266,7 +271,7 @@ case stagehand.WebMCPInvocationStatusError:
 
 `result()` caches the terminal response, so calling it twice is cheap and returns the same value. A timeout or transport failure is not cached and can be retried.
 
-### Canceling an Invocation
+### Canceling an invocation
 
 <View title="TypeScript" icon="js">
 ```typescript
@@ -325,7 +330,7 @@ Cancellation is a request, not a guarantee. Chrome decides the terminal status, 
 
 Raise the listing timeout on pages that register tools after an async bootstrap. Set a result timeout whenever a tool could hang, so your automation fails loudly instead of stalling.
 
-## Combining With the Primitives
+## Combining with the primitives
 
 WebMCP and the primitives solve different problems, and mixing them is normal: use a tool where the page gives you one, and fall back to [`observe()`](/v4/basics/observe) and [`act()`](/v4/basics/act) where it does not.
 
@@ -397,9 +402,9 @@ if addToCart != nil {
 A tool invocation costs no LLM tokens and cannot pick the wrong element, so prefer one over an `act()` call whenever the page offers it.
 </Tip>
 
-## API Reference
+## API reference
 
-<Card title="Complete API Reference" icon="book" href="/v3/references/stagehand">
+<Card title="Complete API reference" icon="book" href="/v3/references/stagehand">
   Full `Page`, `WebMCPTool`, and `WebMCPInvocation` reference with every option and field.
 </Card>
 
@@ -415,7 +420,7 @@ A tool invocation costs no LLM tokens and cannot pick the wrong element, so pref
   <Card title="Extract" icon="table" href="/v4/basics/extract">
     Pull typed, structured data off any page
   </Card>
-  <Card title="Browser Configuration" icon="browser" href="/v3/configuration/browser">
+  <Card title="Browser configuration" icon="browser" href="/v3/configuration/browser">
     Launch flags, browser sources, and attaching over CDP
   </Card>
 </CardGroup>

--- a/packages/docs/v4/first-steps/ai-rules.mdx
+++ b/packages/docs/v4/first-steps/ai-rules.mdx
@@ -1,5 +1,5 @@
 ---
-title: "AI Rules"
+title: "AI rules"
 description: "Give your AI coding assistant the rules it needs to write correct Stagehand v4 code."
 ---
 
@@ -16,7 +16,7 @@ You're likely using AI to write code, and there's a **right and wrong way to do 
   </Card>
 </CardGroup>
 
-## Using MCP Servers
+## Using MCP servers
 
 MCP (Model Context Protocol) servers act as intermediaries that connect AI systems to external data sources and tools. These servers enable your coding assistant to access real-time information, execute tasks, and retrieve structured data to enhance code generation accuracy.
 
@@ -53,7 +53,7 @@ Offers deep indexing of GitHub repositories and documentation. DeepWiki allows A
 ```
 </Accordion>
 
-<Accordion title="Stagehand Docs by Mintlify" icon="mintbit">
+<Accordion title="Stagehand docs by Mintlify" icon="mintbit">
 Direct access to official Stagehand documentation. This MCP server provides AI assistants with up-to-date API references, configuration options, and usage examples for accurate code generation. Mintlify auto-generates this server from the official docs, ensuring your AI assistant always has the latest information.
 
 **Usage:**
@@ -68,7 +68,7 @@ Direct access to official Stagehand documentation. This MCP server provides AI a
 ```
 </Accordion>
 
-**How MCP Servers Enhance Your Development:**
+**How MCP servers enhance your development:**
 - **Real-time Documentation Access:** AI assistants can query the latest Stagehand docs, examples, and best practices
 - **Context-Aware Code Generation:** Servers provide relevant code patterns and configurations based on your specific use case
 - **Reduced Integration Overhead:** Standardized protocol eliminates the need for custom integrations with each documentation source
@@ -184,7 +184,11 @@ To target a specific page:
 const { data: actions } = await stagehand.observe("select blue as the favorite color", {
   page: page2,
 });
-await stagehand.act(actions[0], { page: page2 });
+const [action] = actions;
+
+if (action) {
+  await stagehand.act(action, { page: page2 });
+}
 ```
 
 ## Extract
@@ -270,6 +274,7 @@ const { data } = await stagehand.extract(
 const result = await stagehand.extract("extract the page title", TitleSchema);
 
 console.log(result.data.title);
+console.log(result.metadata.actionId); // Action ID for tracing this call
 console.log(result.metadata.cacheStatus); // "HIT", "MISS", or undefined
 ```
 
@@ -282,7 +287,9 @@ Plan actions before executing them. Candidate actions are returned on `data`:
 const { data: actions } = await stagehand.observe("Click the sign in button");
 const [action] = actions;
 
-console.log(action.selector, action.method, action.arguments);
+if (action) {
+  console.log(action.selector, action.method, action.arguments);
+}
 ```
 
 Observing on a specific page:
@@ -345,6 +352,30 @@ try {
   await stagehand.close();
 }
 ```
+
+## Project Structure Best Practices
+
+- Read configuration from environment variables and pass it explicitly to the `Stagehand` constructor
+- Construct and initialize `Stagehand` in one place, then pass the instance into your automation functions
+- Use `async`/`await` consistently; `init`, `act`, `extract`, `observe`, and `close` all return promises
+- Keep Zod schemas next to the code that consumes them and reuse `z.infer` for the decoded type
+- Wrap every workflow in `try`/`finally` so `close` runs even when a step throws
+- Prefer narrow, atomic instructions over one instruction that describes a whole workflow
+
+## Security Notes
+
+- Never hard-code API keys. Read them from `process.env` and pass them explicitly; Stagehand reads no environment variables for you
+- Pass secrets through `variables` so they are substituted locally and never sent to the model provider
+- Set `logging: { level: "off" }` when handling sensitive data so nothing sensitive reaches your logs
+- Avoid broad instructions that may trigger unintended navigation; call `observe` first, then replay the returned `Action`
+
+## Resources/References
+
+- TypeScript SDK: `@browserbasehq/stagehand` on npm
+- Stagehand documentation: https://docs.stagehand.dev
+- Stagehand Docs MCP (Mintlify): https://docs.stagehand.dev/mcp
+- Context7 MCP (Upstash): https://github.com/upstash/context7
+- DeepWiki MCP: https://mcp.deepwiki.com/
 ``````
 
 </View>
@@ -439,9 +470,9 @@ await stagehand.act(
 
 ```python
 result = await stagehand.observe(instruction="Click the sign in button")
-action = result.data[0]
+action = result.data[0] if result.data else None
 
-if action.method == "click":
+if action is not None and action.method == "click":
     await stagehand.act(action)
 ```
 
@@ -461,7 +492,7 @@ Extract data from pages using natural language instructions. The `extract` metho
 
 Every primitive returns a result with `data` and `metadata`. Your extracted model instance is on `data`; `metadata` carries the action ID and server-side cache status.
 
-### Structured Extraction with Schema (Recommended)
+### Basic Extraction (with schema)
 
 ```python
 from pydantic import BaseModel
@@ -550,15 +581,29 @@ result = await stagehand.extract(
 )
 ```
 
+### Inspecting Metadata
+
+```python
+result = await stagehand.extract(
+    instruction="extract the page title",
+    schema=Title,
+)
+
+print(result.data.title)
+print(result.metadata.action_id)  # Action ID for tracing this call
+print(result.metadata.cache_status)  # "HIT", "MISS", or None
+```
+
 ## Observe
 
 Plan actions before executing them. Candidate actions are returned on `data`:
 
 ```python
 result = await stagehand.observe(instruction="Click the sign in button")
-action = result.data[0]
+action = result.data[0] if result.data else None
 
-print(action.selector, action.method, action.arguments)
+if action is not None:
+    print(action.selector, action.method, action.arguments)
 ```
 
 Observing on a specific page:
@@ -627,6 +672,21 @@ async with Stagehand(browser="local", headless=True) as stagehand:
 - Use async context managers for resource management
 - Use type hints and Pydantic models for data validation
 - Handle exceptions appropriately with try/except blocks
+
+## Security Notes
+
+- Never hard-code API keys. Read them from `os.environ` and pass them explicitly; Stagehand reads no environment variables for you
+- Pass secrets through `variables` so they are substituted locally and never sent to the model provider
+- Set `logging=StagehandClientLoggingConfig(level="off")` when handling sensitive data so nothing sensitive reaches your logs
+- Avoid broad instructions that may trigger unintended navigation; call `observe` first, then replay the returned `Action`
+
+## Resources/References
+
+- Python SDK: `stagehand` on PyPI
+- Stagehand documentation: https://docs.stagehand.dev
+- Stagehand Docs MCP (Mintlify): https://docs.stagehand.dev/mcp
+- Context7 MCP (Upstash): https://github.com/upstash/context7
+- DeepWiki MCP: https://mcp.deepwiki.com/
 ``````
 
 </View>
@@ -807,7 +867,7 @@ fmt.Println(data.Listings)
 
 ### Working With the Raw Result
 
-Call `client.Extract` directly when you want the metadata alongside the payload:
+`ExtractAs` decodes for you but discards the metadata. Call `client.Extract` directly when you want the raw `json.RawMessage` payload and the metadata alongside it:
 
 ```go
 result, err := client.Extract(ctx, "extract the sign in button text", buttonTextSchema, nil)
@@ -815,14 +875,13 @@ if err != nil {
 	return err
 }
 
+// result.Data is json.RawMessage, so decode it into your own type
 var decoded buttonText
 if err := json.Unmarshal(result.Data, &decoded); err != nil {
 	return err
 }
 
-if result.Metadata.CacheStatus != nil {
-	fmt.Println("cache:", *result.Metadata.CacheStatus)
-}
+fmt.Println(decoded.ButtonText)
 ```
 
 ### Targeted Extraction
@@ -862,6 +921,24 @@ result, err := client.Extract(ctx, "extract the placeholder text on the name fie
 })
 ```
 
+### Inspecting Metadata
+
+Both `ActionID` and `CacheStatus` are pointers, so check for nil before dereferencing:
+
+```go
+result, err := client.Extract(ctx, "extract the page title", titleSchema, nil)
+if err != nil {
+	return err
+}
+
+if result.Metadata.ActionID != nil {
+	fmt.Println("action:", *result.Metadata.ActionID) // Action ID for tracing this call
+}
+if result.Metadata.CacheStatus != nil {
+	fmt.Println("cache:", *result.Metadata.CacheStatus) // stagehand.CacheStatusHIT or stagehand.CacheStatusMISS
+}
+```
+
 ## Observe
 
 Plan actions before executing them. `Observe` takes an optional instruction pointer and returns candidate actions on `result.Data`:
@@ -887,8 +964,10 @@ observed, err := client.Observe(ctx, &instruction, &stagehand.StagehandClientObs
 if err != nil {
 	return err
 }
-if _, err := client.Act(ctx, observed.Data[0], &stagehand.StagehandClientActOptions{Page: page2}); err != nil {
-	return err
+if len(observed.Data) > 0 {
+	if _, err := client.Act(ctx, observed.Data[0], &stagehand.StagehandClientActOptions{Page: page2}); err != nil {
+		return err
+	}
 }
 ```
 
@@ -969,6 +1048,21 @@ func run(ctx context.Context) (err error) {
 - Check every returned `error`; do not discard them
 - Keep JSON Schemas next to the Go structs they decode into
 - Prefer `stagehand.ExtractAs` over manual `json.Unmarshal` when you do not need metadata
+
+## Security Notes
+
+- Never hard-code API keys. Read them with `os.Getenv` and pass their addresses explicitly; Stagehand reads no environment variables for you
+- Pass secrets through `ActOptions.Variables` so they are substituted locally and never sent to the model provider
+- The Go client has no log level filter. Leave `Logging.OnLog` unset, or redact inside the handler, when handling sensitive data
+- Avoid broad instructions that may trigger unintended navigation; call `Observe` first, then replay the returned `Action`
+
+## Resources/References
+
+- Go SDK: `github.com/browserbase/stagehand/packages/sdk-go`
+- Stagehand documentation: https://docs.stagehand.dev
+- Stagehand Docs MCP (Mintlify): https://docs.stagehand.dev/mcp
+- Context7 MCP (Upstash): https://github.com/upstash/context7
+- DeepWiki MCP: https://mcp.deepwiki.com/
 ``````
 
 </View>

--- a/packages/docs/v4/first-steps/ai-rules.mdx
+++ b/packages/docs/v4/first-steps/ai-rules.mdx
@@ -271,6 +271,8 @@ const { data } = await stagehand.extract(
 ### Inspecting Metadata
 
 ```typescript
+const TitleSchema = z.object({ title: z.string() });
+
 const result = await stagehand.extract("extract the page title", TitleSchema);
 
 console.log(result.data.title);
@@ -584,6 +586,10 @@ result = await stagehand.extract(
 ### Inspecting Metadata
 
 ```python
+class Title(BaseModel):
+    title: str
+
+
 result = await stagehand.extract(
     instruction="extract the page title",
     schema=Title,
@@ -739,9 +745,18 @@ page, err := browserContext.ActivePage(ctx)
 if err != nil {
 	return err
 }
+if page == nil {
+	return errors.New("Stagehand initialized without an active page")
+}
 
 // Create new pages if needed
 page2, err := browserContext.NewPage(ctx, stagehand.ContextNewPageParams{})
+if err != nil {
+	return err
+}
+if err := page2.Goto(ctx, "https://example.com", nil); err != nil {
+	return err
+}
 ```
 
 For Browserbase cloud browsers, pass a Browserbase API key at the top level:
@@ -753,6 +768,9 @@ client := stagehand.New(stagehand.StagehandClientInitParams{
 	Browser: stagehand.BrowserbaseClientBrowserSource{},
 	Model:   &model,
 })
+if err := client.Init(ctx); err != nil {
+	return err
+}
 ```
 
 Stagehand never reads environment variables for you. Always pass keys explicitly.
@@ -763,17 +781,26 @@ Actions are called on the client (not the page). Use atomic, specific instructio
 
 ```go
 // Act on the current active page
-result, err := client.Act(ctx, "click the sign in button", nil)
+if _, err := client.Act(ctx, "click the sign in button", nil); err != nil {
+	return err
+}
 
 // Act on a specific page (when you need to target a page that isn't currently active)
-result, err := client.Act(ctx, "click the sign in button", &stagehand.StagehandClientActOptions{
+if _, err := client.Act(ctx, "click the sign in button", &stagehand.StagehandClientActOptions{
 	Page: page2,
-})
+}); err != nil {
+	return err
+}
 ```
 
 `Act` takes either a `string` instruction or a `stagehand.Action`. It returns an `ActResult`: the action payload is on `result.Data`, and cache status is on `result.Metadata`:
 
 ```go
+result, err := client.Act(ctx, "click the sign in button", nil)
+if err != nil {
+	return err
+}
+
 if !result.Data.Success {
 	return fmt.Errorf("act failed: %s", result.Data.Message)
 }
@@ -788,13 +815,15 @@ Use variables for secrets. Values are substituted locally and never sent to the 
 
 ```go
 password := os.Getenv("USER_PASSWORD")
-_, err := client.Act(ctx, "type %password% into the password field", &stagehand.StagehandClientActOptions{
+if _, err := client.Act(ctx, "type %password% into the password field", &stagehand.StagehandClientActOptions{
 	ActOptions: stagehand.ActOptions{
 		Variables: stagehand.Variables{
 			"password": stagehand.PrimitiveVariable(stagehand.StringVariable(password)),
 		},
 	},
-})
+}); err != nil {
+	return err
+}
 ```
 
 ### Observe Then Act Pattern (Recommended)
@@ -870,6 +899,19 @@ fmt.Println(data.Listings)
 `ExtractAs` decodes for you but discards the metadata. Call `client.Extract` directly when you want the raw `json.RawMessage` payload and the metadata alongside it:
 
 ```go
+type buttonText struct {
+	ButtonText string `json:"buttonText"`
+}
+
+var buttonTextSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "buttonText": {"type": "string"}
+  },
+  "required": ["buttonText"],
+  "additionalProperties": false
+}`)
+
 result, err := client.Extract(ctx, "extract the sign in button text", buttonTextSchema, nil)
 if err != nil {
 	return err
@@ -889,6 +931,15 @@ fmt.Println(decoded.ButtonText)
 Scope extraction to a specific element with `Selector`, and prune noise with `IgnoreSelectors`:
 
 ```go
+var articleSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "body": {"type": "string"}
+  },
+  "required": ["body"],
+  "additionalProperties": false
+}`)
+
 selector := "#main-content"
 result, err := client.Extract(ctx, "extract the article body", articleSchema, &stagehand.StagehandClientExtractOptions{
 	ExtractOptions: stagehand.ExtractOptions{
@@ -896,6 +947,11 @@ result, err := client.Extract(ctx, "extract the article body", articleSchema, &s
 		IgnoreSelectors: []string{"nav", ".cookie-banner"},
 	},
 })
+if err != nil {
+	return err
+}
+
+fmt.Println(string(result.Data))
 ```
 
 ### URL Extraction
@@ -916,9 +972,23 @@ var linksSchema = json.RawMessage(`{
 ### Extracting from a Specific Page
 
 ```go
+var placeholderSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "placeholder": {"type": "string"}
+  },
+  "required": ["placeholder"],
+  "additionalProperties": false
+}`)
+
 result, err := client.Extract(ctx, "extract the placeholder text on the name field", placeholderSchema, &stagehand.StagehandClientExtractOptions{
 	Page: page2,
 })
+if err != nil {
+	return err
+}
+
+fmt.Println(string(result.Data))
 ```
 
 ### Inspecting Metadata
@@ -926,6 +996,15 @@ result, err := client.Extract(ctx, "extract the placeholder text on the name fie
 Both `ActionID` and `CacheStatus` are pointers, so check for nil before dereferencing:
 
 ```go
+var titleSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "title": {"type": "string"}
+  },
+  "required": ["title"],
+  "additionalProperties": false
+}`)
+
 result, err := client.Extract(ctx, "extract the page title", titleSchema, nil)
 if err != nil {
 	return err
@@ -958,6 +1037,7 @@ for _, action := range observed.Data {
 Observing on a specific page:
 
 ```go
+instruction := "find the next page button"
 observed, err := client.Observe(ctx, &instruction, &stagehand.StagehandClientObserveOptions{
 	Page: page2,
 })
@@ -985,6 +1065,10 @@ if err := page.Locator("#email").Fill(ctx, "user@example.com"); err != nil {
 	return err
 }
 count, err := page.Locator("li.result").Count(ctx)
+if err != nil {
+	return err
+}
+fmt.Println("results:", count)
 ```
 
 ### Multi-Page Workflows
@@ -1008,7 +1092,9 @@ if err := page2.Goto(ctx, "https://example2.com", nil); err != nil {
 
 // Act/Extract/Observe operate on the current active page by default
 // Pass Page in the options struct to target a specific page
-_, err = client.Act(ctx, "click button", &stagehand.StagehandClientActOptions{Page: page1})
+if _, err := client.Act(ctx, "click button", &stagehand.StagehandClientActOptions{Page: page1}); err != nil {
+	return err
+}
 ```
 
 ### Caching
@@ -1022,6 +1108,9 @@ client := stagehand.New(stagehand.StagehandClientInitParams{
 	Browser: stagehand.BrowserbaseClientBrowserSource{},
 	Cache:   &cache,
 })
+if err := client.Init(ctx); err != nil {
+	return err
+}
 ```
 
 ## Cleanup
@@ -1030,7 +1119,9 @@ Always close the client. The idiomatic pattern is a named error return plus a de
 
 ```go
 func run(ctx context.Context) (err error) {
-	client := stagehand.New(params)
+	client := stagehand.New(stagehand.StagehandClientInitParams{
+		Browser: stagehand.LocalBrowserSource{Headless: true},
+	})
 	if err := client.Init(ctx); err != nil {
 		return err
 	}

--- a/packages/docs/v4/first-steps/ai-rules.mdx
+++ b/packages/docs/v4/first-steps/ai-rules.mdx
@@ -3,162 +3,988 @@ title: "AI Rules"
 description: "Give your AI coding assistant the rules it needs to write correct Stagehand v4 code."
 ---
 
-AI coding assistants often write Stagehand code from older APIs: putting `act`/`extract`/
-`observe` on `page`, using an `env` string, or calling methods that no longer exist. Drop
-the rules below into your editor's rules file (for example
-`.cursor/rules/stagehand.md`, `CLAUDE.md`, or `AGENTS.md`) so your assistant writes code
-that matches this SDK.
+You're likely using AI to write code, and there's a **right and wrong way to do it.** This page is a collection of rules, configs, and copy-paste snippets to allow your AI agents/assistants to write performant, Stagehand code as fast as possible.
 
-<Note>
-  These rules cover the primitives available today: initialization, `act`, `extract`, and `observe`.
-  They intentionally omit APIs that don't exist in v4.
-</Note>
+## Quickstart
+
+<CardGroup cols={2}>
+  <Card title="Add MCP servers" icon="screwdriver-wrench">
+    Configure Context7, DeepWiki, and Stagehand Docs in your MCP client.
+  </Card>
+  <Card title="Pin editor rules" icon="memo">
+    Drop in `cursorrules` and `claude.md` so AI agents/assistants always emit Stagehand patterns.
+  </Card>
+</CardGroup>
+
+## Using MCP Servers
+
+MCP (Model Context Protocol) servers act as intermediaries that connect AI systems to external data sources and tools. These servers enable your coding assistant to access real-time information, execute tasks, and retrieve structured data to enhance code generation accuracy.
+
+The following **MCP servers** provide specialized access to Stagehand documentation and related resources:
+
+<Accordion title="Context7 by Upstash" icon="database">
+Provides semantic search across documentation and codebase context. Context7 enables AI assistants to find relevant code patterns, examples, and implementation details from your project history. It maintains contextual understanding of your development workflow and can surface related solutions from previous work.
+
+**Installation:**
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp"]
+    }
+  }
+}
+```
+</Accordion>
+
+<Accordion title="DeepWiki by Cognition" icon="book-open">
+Offers deep indexing of GitHub repositories and documentation. DeepWiki allows AI agents to understand project architecture, API references, and best practices from the entire Stagehand ecosystem. It provides comprehensive knowledge about repository structure, code relationships, and development patterns.
+
+**Installation:**
+```json
+{
+  "mcpServers": {
+    "deepwiki": {
+      "url": "https://mcp.deepwiki.com/mcp"
+    }
+  }
+}
+```
+</Accordion>
+
+<Accordion title="Stagehand Docs by Mintlify" icon="mintbit">
+Direct access to official Stagehand documentation. This MCP server provides AI assistants with up-to-date API references, configuration options, and usage examples for accurate code generation. Mintlify auto-generates this server from the official docs, ensuring your AI assistant always has the latest information.
+
+**Usage:**
+```json
+{
+  "mcpServers": {
+    "stagehand-docs": {
+      "url": "https://docs.stagehand.dev/mcp"
+    }
+  }
+}
+```
+</Accordion>
+
+**How MCP Servers Enhance Your Development:**
+- **Real-time Documentation Access:** AI assistants can query the latest Stagehand docs, examples, and best practices
+- **Context-Aware Code Generation:** Servers provide relevant code patterns and configurations based on your specific use case
+- **Reduced Integration Overhead:** Standardized protocol eliminates the need for custom integrations with each documentation source
+- **Enhanced Accuracy:** AI agents receive structured, up-to-date information rather than relying on potentially outdated training data
+
+<Tip>
+**Prompting tip:**
+Explicitly ask your coding agent/assistant to use these MCP servers to fetch relevant information from the docs so they have better context and know how to write proper Stagehand code.
+
+ie. **"Use the stagehand-docs MCP to fetch the act/observe guidelines, then generate code that follows them. Prefer cached observe results."**
+</Tip>
+
+## Editor rule files (copy-paste)
+
+Drop these in `.cursorrules`, `windsurfrules`, `claude.md`, or any agent rule framework:
+
 
 <View title="TypeScript" icon="js">
 
-## TypeScript rules
+``````md
+# Stagehand Project
 
-````markdown
-# Stagehand (TypeScript) rules
+This is a project that uses Stagehand v4, a browser automation framework with AI-powered `act`, `extract`, and `observe` methods.
 
-You are writing browser automation with `@browserbasehq/stagehand` (v4).
+The main class can be imported as `Stagehand` from `@browserbasehq/stagehand`.
 
-## Initialization
+**Key Classes:**
 
-- Import from the package: `import { Stagehand } from "@browserbasehq/stagehand";`
-- Construct with a `browser` source and a `model`, then `await stagehand.init()`.
-- `browser` is a discriminated union: `{ type: "local" }`, `{ type: "browserbase" }`
-  (default; requires `apiKey`), or `{ type: "cdp", cdpUrl }`.
-- Always `await stagehand.close()` in a `finally` block.
+- `Stagehand`: Main orchestrator class providing `act`, `extract`, and `observe` methods
+- `stagehand.context`: A `BrowserContext` object that manages pages, cookies, and the clipboard
+- `page`: Individual page objects accessed via `stagehand.context.activePage()`, `stagehand.context.pages()`, or created with `stagehand.context.newPage()`
+
+There is no `agent` API in v4. Compose `observe`, `act`, and `extract` in your own control flow instead.
+
+## Initialize
 
 ```typescript
 import { Stagehand } from "@browserbasehq/stagehand";
 
 const stagehand = new Stagehand({
+  // Browser source: "browserbase" (default), "local", or "cdp"
   browser: { type: "local", headless: true },
+  model: {
+    modelName: "openai/gpt-5.4-mini",
+    apiKey: process.env.OPENAI_API_KEY,
+  },
+  logging: { level: "info", format: "pretty" },
+});
+
+await stagehand.init();
+
+// Access the browser context and pages
+const page = await stagehand.context.activePage();
+const context = stagehand.context;
+
+// Create new pages if needed
+const page2 = await stagehand.context.newPage();
+```
+
+For Browserbase cloud browsers, pass a Browserbase API key at the top level:
+
+```typescript
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  browser: { type: "browserbase" },
   model: { modelName: "openai/gpt-5.4-mini", apiKey: process.env.OPENAI_API_KEY },
 });
+```
+
+Stagehand never reads environment variables for you. Always pass keys explicitly.
+
+## Act
+
+Actions are called on the `stagehand` instance (not the page). `act` takes either a string instruction or an `Action` from `observe`. Use atomic, specific instructions:
+
+```typescript
+// Act on the current active page
+await stagehand.act("click the sign in button");
+
+// Act on a specific page (when you need to target a page that isn't currently active)
+await stagehand.act("click the sign in button", { page: page2 });
+```
+
+**Important:** Act instructions should be atomic and specific:
+
+- Good: "Click the sign in button" or "Type 'hello' into the search input"
+- Bad: "Order me pizza" or "Type in the search bar and hit enter" (multi-step)
+
+Use `variables` for secrets. Values are substituted locally and never sent to the model:
+
+```typescript
+await stagehand.act("type %password% into the password field", {
+  variables: { password: process.env.USER_PASSWORD },
+});
+```
+
+### Observe Then Act Pattern (Recommended)
+
+`act` accepts either a string instruction or an `Action` returned by `observe`. Use `observe` to inspect the candidate action, then pass it back to `act` for deterministic replay with no inference:
+
+```typescript
+const { data: actions } = await stagehand.observe("Click the sign in button");
+const [action] = actions;
+
+if (action?.method === "click") {
+  await stagehand.act(action);
+}
+```
+
+To target a specific page:
+
+```typescript
+const { data: actions } = await stagehand.observe("select blue as the favorite color", {
+  page: page2,
+});
+await stagehand.act(actions[0], { page: page2 });
+```
+
+## Extract
+
+Extract data from pages using natural language instructions. The `extract` method is called on the `stagehand` instance and always takes both an instruction and a schema.
+
+Every primitive returns `{ data, metadata }`. Your extracted value is on `data`; `metadata` carries the action ID and server-side cache status.
+
+### Basic Extraction (with schema)
+
+```typescript
+import { z } from "zod/v4";
+
+const { data } = await stagehand.extract(
+  "extract all apartment listings with prices and addresses",
+  z.object({
+    listings: z.array(
+      z.object({
+        price: z.string(),
+        address: z.string(),
+      }),
+    ),
+  }),
+);
+
+console.log(data.listings);
+```
+
+### Simple Extraction
+
+A schema is always required, so wrap single values in an object:
+
+```typescript
+const { data } = await stagehand.extract(
+  "extract the sign in button text",
+  z.object({ buttonText: z.string() }),
+);
+
+console.log(data.buttonText); // "Sign in"
+```
+
+### Targeted Extraction
+
+Scope extraction to a specific element with `selector`, and prune noise with `ignoreSelectors`:
+
+```typescript
+const { data } = await stagehand.extract(
+  "extract the reason why script injection fails",
+  z.object({ reason: z.string() }),
+  {
+    selector: "#main-content",
+    ignoreSelectors: ["nav", ".cookie-banner"],
+  },
+);
+```
+
+### URL Extraction
+
+When extracting links or URLs, use `z.url()`:
+
+```typescript
+const { data } = await stagehand.extract(
+  "extract all navigation links",
+  z.object({
+    links: z.array(z.url()),
+  }),
+);
+```
+
+### Extracting from a Specific Page
+
+```typescript
+const { data } = await stagehand.extract(
+  "extract the placeholder text on the name field",
+  z.object({ placeholder: z.string() }),
+  { page: page2 },
+);
+```
+
+### Inspecting Metadata
+
+```typescript
+const result = await stagehand.extract("extract the page title", TitleSchema);
+
+console.log(result.data.title);
+console.log(result.metadata.cacheStatus); // "HIT", "MISS", or undefined
+```
+
+## Observe
+
+Plan actions before executing them. Candidate actions are returned on `data`:
+
+```typescript
+// Get candidate actions on the current active page
+const { data: actions } = await stagehand.observe("Click the sign in button");
+const [action] = actions;
+
+console.log(action.selector, action.method, action.arguments);
+```
+
+Observing on a specific page:
+
+```typescript
+const { data: actions } = await stagehand.observe("find the next page button", {
+  page: page2,
+});
+await stagehand.act(actions[0], { page: page2 });
+```
+
+## Advanced Features
+
+### Locators
+
+Use `page.locator(selector)` for deterministic, non-AI interactions. Selectors returned by `observe` are XPath strings prefixed with `xpath=`:
+
+```typescript
+await page.locator("xpath=/html/body/div[2]/button").click();
+await page.locator("#email").fill("user@example.com");
+const count = await page.locator("li.result").count();
+```
+
+### Multi-Page Workflows
+
+```typescript
+const page1 = await stagehand.context.newPage();
+await page1.goto("https://example.com");
+
+const page2 = await stagehand.context.newPage();
+await page2.goto("https://example2.com");
+
+// Act/extract/observe operate on the current active page by default
+// Pass { page } option to target a specific page
+await stagehand.act("click button", { page: page1 });
+await stagehand.extract("get title", z.object({ title: z.string() }), { page: page2 });
+```
+
+### Caching
+
+Server-side caching requires a Browserbase browser source and a Browserbase API key:
+
+```typescript
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  browser: { type: "browserbase" },
+  cache: true, // or { threshold: 1 }
+});
+```
+
+## Cleanup
+
+Always close Stagehand in a `finally` block:
+
+```typescript
 try {
   await stagehand.init();
-  const page = await stagehand.context.newPage();
-  await page.goto("https://example.com");
+  // ...
 } finally {
   await stagehand.close();
 }
 ```
-
-## Pages
-
-- `act`, `extract`, and `observe` are methods on `stagehand`, NOT on `page`.
-- They run on the browser's active page by default. Pass `{ page }` to target a specific one.
-- Get a page from `stagehand.context.newPage()` or `stagehand.context.activePage()`, and use
-  it for deterministic controls like `page.goto(...)`.
-
-## Act: one action per call
-
-- `await stagehand.act("click the sign in button")` returns
-  `{ data, metadata }`; `data` contains `{ success, message, actionDescription, actions }`.
-  Always check `result.data.success`.
-- Keep instructions to a single step. Chain multiple `act` calls for multi-step flows.
-- Pass secrets through `variables`, referenced as `%name%` in the instruction:
-  `await stagehand.act("type %password% into the password field", { variables: { password } })`.
-
-## Extract: typed data with Zod
-
-- `await stagehand.extract("instruction", zodSchema)` returns `{ data, metadata }`; `data` is
-  validated against the schema.
-- Define the schema with `zod`: `z.object({ price: z.number() })`.
-- Scope large pages with `{ selector }` or `{ ignoreSelectors }`.
-
-## Observe: plan before acting
-
-- `await stagehand.observe("find the submit button")` returns `{ data, metadata }`; `data` is
-  an array of `{ selector, description, method?, arguments? }`.
-- Use it to check an element exists or to preview what `act` will do.
-
-## Don't
-
-- Don't call `page.act` / `page.extract` / `page.observe` (they moved to `stagehand`).
-- Don't use an `env: "LOCAL" | "BROWSERBASE"` option. Use the `browser` source object instead.
-- Don't hardcode secrets; read them from environment variables and pass via `variables`.
-````
+``````
 
 </View>
 
 <View title="Python" icon="python">
 
-## Python rules
+``````md
+# Stagehand Python Project
 
-````markdown
-# Stagehand (Python) rules
+This is a project that uses Stagehand v4 for Python, which provides AI-powered browser automation with `act`, `extract`, and `observe` methods.
 
-You are writing async browser automation with `stagehand`.
+The main class can be imported as `Stagehand` from `stagehand`.
 
-## Initialization
+**Key Classes:**
 
-- Import: `from stagehand import Stagehand`
-- The SDK is async: everything is awaited inside `async def` and run with `asyncio.run`.
-- Construct with keyword args, then `await stagehand.init()`:
+- `Stagehand`: Main orchestrator class providing `act`, `extract`, and `observe` methods
+- `stagehand.context`: A `BrowserContext` object that manages pages, cookies, and the clipboard
+- `page`: Individual page objects accessed via `stagehand.context.active_page()`, `stagehand.context.pages()`, or created with `stagehand.context.new_page()`
+
+There is no `agent` API in v4. Compose `observe`, `act`, and `extract` in your own control flow instead.
+
+All Stagehand methods are async. `observe` and `extract` take keyword-only arguments.
+
+## Initialize
 
 ```python
-import asyncio
 import os
 
-from stagehand import Stagehand
+from stagehand import Stagehand, StagehandClientLoggingConfig
 
+stagehand = Stagehand(
+    # Browser source: "browserbase" (default), "local", or "cdp"
+    browser="local",
+    headless=True,
+    model="openai/gpt-5.4-mini",
+    model_api_key=os.environ["OPENAI_API_KEY"],
+    logging=StagehandClientLoggingConfig(level="info", format="pretty"),
+)
 
-async def main() -> None:
-    stagehand = Stagehand(
-        browser="local",  # or "browserbase" (default; needs an API key)
-        headless=True,
-        model="openai/gpt-5.4-mini",
-        model_api_key=os.environ["OPENAI_API_KEY"],
-    )
-    try:
-        await stagehand.init()
-        page = await stagehand.context.new_page()
-        await page.goto("https://example.com")
-    finally:
-        await stagehand.close()
+await stagehand.init()
 
+# Access the browser context and pages
+page = await stagehand.context.active_page()
+context = stagehand.context
 
-asyncio.run(main())
+# Create new pages if needed
+page2 = await stagehand.context.new_page()
 ```
 
-- Always `await stagehand.close()` in a `finally` block.
+For Browserbase cloud browsers, pass a Browserbase API key:
 
-## Pages
+```python
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    browser="browserbase",
+    model="openai/gpt-5.4-mini",
+    model_api_key=os.environ["OPENAI_API_KEY"],
+)
+```
 
-- `act`, `extract`, and `observe` are methods on `stagehand`, NOT on `page`.
-- They run on the active page by default; pass `page=` to target a specific one.
-- Use `page` objects for deterministic controls like `page.goto(...)`.
+Stagehand never reads environment variables for you. Always pass keys explicitly.
 
 ## Act
 
-- `result = await stagehand.act("click the sign in button")`; check `result.data.success`.
-- One action per call. Pass secrets via `variables` with `%name%` placeholders.
+Actions are called on the `stagehand` instance (not the page). `act` takes either a string instruction or an `Action` from `observe`. Use atomic, specific instructions:
 
-## Extract: typed data with Pydantic
+```python
+# Act on the current active page
+await stagehand.act("click the sign in button")
 
-- Define a `pydantic.BaseModel` and pass it as `schema`:
-  `await stagehand.extract(instruction="...", schema=MyModel)`.
-- Read the validated model from `.data` and Stagehand-owned information from `.metadata`.
+# Act on a specific page (when you need to target a page that isn't currently active)
+await stagehand.act("click the sign in button", page=page2)
+```
+
+**Important:** Act instructions should be atomic and specific:
+
+- Good: "Click the sign in button" or "Type 'hello' into the search input"
+- Bad: "Order me pizza" or "Type in the search bar and hit enter" (multi-step)
+
+Use `variables` for secrets. Values are substituted locally and never sent to the model:
+
+```python
+await stagehand.act(
+    "type %password% into the password field",
+    variables={"password": os.environ["USER_PASSWORD"]},
+)
+```
+
+### Observe Then Act Pattern (Recommended)
+
+`act` accepts either a string instruction or an `Action` returned by `observe`. Use `observe` to inspect the candidate action, then pass it back to `act` for deterministic replay with no inference:
+
+```python
+result = await stagehand.observe(instruction="Click the sign in button")
+action = result.data[0]
+
+if action.method == "click":
+    await stagehand.act(action)
+```
+
+To target a specific page:
+
+```python
+result = await stagehand.observe(
+    instruction="select blue as the favorite color",
+    page=page2,
+)
+await stagehand.act(result.data[0], page=page2)
+```
+
+## Extract
+
+Extract data from pages using natural language instructions. The `extract` method is called on the `stagehand` instance and always takes both an instruction and a Pydantic model.
+
+Every primitive returns a result with `data` and `metadata`. Your extracted model instance is on `data`; `metadata` carries the action ID and server-side cache status.
+
+### Structured Extraction with Schema (Recommended)
+
+```python
+from pydantic import BaseModel
+
+
+class Listing(BaseModel):
+    price: str
+    address: str
+
+
+class Listings(BaseModel):
+    listings: list[Listing]
+
+
+result = await stagehand.extract(
+    instruction="extract all apartment listings with prices and addresses",
+    schema=Listings,
+)
+
+print(result.data.listings)
+```
+
+### Simple Extraction
+
+A schema is always required, so wrap single values in a model:
+
+```python
+class ButtonText(BaseModel):
+    button_text: str
+
+
+result = await stagehand.extract(
+    instruction="extract the sign in button text",
+    schema=ButtonText,
+)
+
+print(result.data.button_text)  # "Sign in"
+```
+
+### Targeted Extraction
+
+Scope extraction to a specific element with `selector`, and prune noise with `ignore_selectors`:
+
+```python
+class Reason(BaseModel):
+    reason: str
+
+
+result = await stagehand.extract(
+    instruction="extract the reason why script injection fails",
+    schema=Reason,
+    selector="#main-content",
+    ignore_selectors=["nav", ".cookie-banner"],
+)
+```
+
+### URL Extraction
+
+When extracting links or URLs, type the field as a URL:
+
+```python
+from pydantic import AnyUrl, BaseModel
+
+
+class Links(BaseModel):
+    links: list[AnyUrl]
+
+
+result = await stagehand.extract(
+    instruction="extract all navigation links",
+    schema=Links,
+)
+```
+
+### Extracting from a Specific Page
+
+```python
+class Placeholder(BaseModel):
+    placeholder: str
+
+
+result = await stagehand.extract(
+    instruction="extract the placeholder text on the name field",
+    schema=Placeholder,
+    page=page2,
+)
+```
 
 ## Observe
 
-- `result = await stagehand.observe(instruction="find the submit button")` returns
-  `{ data, metadata }`; iterate over `result.data` to use the action objects.
+Plan actions before executing them. Candidate actions are returned on `data`:
 
-## Don't
+```python
+result = await stagehand.observe(instruction="Click the sign in button")
+action = result.data[0]
 
-- Don't put `act`/`extract`/`observe` on `page` (they moved to `stagehand`).
-- Don't hardcode secrets; use environment variables and `variables`.
-````
+print(action.selector, action.method, action.arguments)
+```
+
+Observing on a specific page:
+
+```python
+result = await stagehand.observe(
+    instruction="find the next page button",
+    page=page2,
+)
+await stagehand.act(result.data[0], page=page2)
+```
+
+## Advanced Features
+
+### Locators
+
+Use `page.locator(selector)` for deterministic, non-AI interactions. Selectors returned by `observe` are XPath strings prefixed with `xpath=`:
+
+```python
+await page.locator("xpath=/html/body/div[2]/button").click()
+await page.locator("#email").fill("user@example.com")
+count = await page.locator("li.result").count()
+```
+
+### Multi-Page Workflows
+
+```python
+page1 = await stagehand.context.new_page()
+await page1.goto("https://example.com")
+
+page2 = await stagehand.context.new_page()
+await page2.goto("https://example2.com")
+
+# Act/extract/observe operate on the current active page by default
+# Pass page= to target a specific page
+await stagehand.act("click button", page=page1)
+await stagehand.extract(instruction="get title", schema=Title, page=page2)
+```
+
+### Caching
+
+Server-side caching requires a Browserbase browser source and a Browserbase API key:
+
+```python
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    browser="browserbase",
+    cache=True,  # or CacheOptions(threshold=1)
+)
+```
+
+## Cleanup
+
+Use the async context manager, or always close in a `finally` block:
+
+```python
+async with Stagehand(browser="local", headless=True) as stagehand:
+    ...
+```
+
+## Project Structure Best Practices
+
+- Store configurations in environment variables or config files
+- Use async/await patterns consistently
+- Implement main automation logic in async functions
+- Use async context managers for resource management
+- Use type hints and Pydantic models for data validation
+- Handle exceptions appropriately with try/except blocks
+``````
 
 </View>
 
-## Next steps
+<View title="Go" icon="golang">
 
-<Card title="SDK reference" icon="book" href="/v4/reference/stagehand">
-  The full list of Stagehand methods and options.
-</Card>
+``````md
+# Stagehand Go Project
+
+This is a project that uses Stagehand v4 for Go, which provides AI-powered browser automation with `Act`, `Extract`, and `Observe` methods.
+
+Import the package as `stagehand "github.com/browserbase/stagehand/packages/sdk-go"`.
+
+**Key Types:**
+
+- `*stagehand.Stagehand`: Main client, constructed with `stagehand.New`, providing `Act`, `Extract`, and `Observe`
+- `*stagehand.BrowserContext`: Returned by `client.Context()`, manages pages, cookies, and the clipboard
+- `*stagehand.Page`: Individual pages from `browserContext.ActivePage(ctx)`, `browserContext.Pages(ctx)`, or `browserContext.NewPage(ctx, params)`
+
+There is no agent API in v4. Compose `Observe`, `Act`, and `Extract` in your own control flow instead.
+
+Every method takes a `context.Context` as its first argument and returns an `error` as its last. Optional struct fields are pointers, so read values into variables and take their address.
+
+## Initialize
+
+```go
+apiKey := os.Getenv("OPENAI_API_KEY")
+model := stagehand.KnownModel(stagehand.KnownModelConfig{
+	ModelName: "openai/gpt-5.4-mini",
+	APIKey:    &apiKey,
+})
+
+// Browser source: BrowserbaseClientBrowserSource (default), LocalBrowserSource, or CDPBrowserSource
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	Browser: stagehand.LocalBrowserSource{Headless: true},
+	Model:   &model,
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+defer func() { err = errors.Join(err, client.Close(ctx)) }()
+
+// Access the browser context and pages
+browserContext, err := client.Context()
+if err != nil {
+	return err
+}
+page, err := browserContext.ActivePage(ctx)
+if err != nil {
+	return err
+}
+
+// Create new pages if needed
+page2, err := browserContext.NewPage(ctx, stagehand.ContextNewPageParams{})
+```
+
+For Browserbase cloud browsers, pass a Browserbase API key at the top level:
+
+```go
+browserbaseAPIKey := os.Getenv("BROWSERBASE_API_KEY")
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey:  &browserbaseAPIKey,
+	Browser: stagehand.BrowserbaseClientBrowserSource{},
+	Model:   &model,
+})
+```
+
+Stagehand never reads environment variables for you. Always pass keys explicitly.
+
+## Act
+
+Actions are called on the client (not the page). Use atomic, specific instructions:
+
+```go
+// Act on the current active page
+result, err := client.Act(ctx, "click the sign in button", nil)
+
+// Act on a specific page (when you need to target a page that isn't currently active)
+result, err := client.Act(ctx, "click the sign in button", &stagehand.StagehandClientActOptions{
+	Page: page2,
+})
+```
+
+`Act` takes either a `string` instruction or a `stagehand.Action`. It returns an `ActResult`: the action payload is on `result.Data`, and cache status is on `result.Metadata`:
+
+```go
+if !result.Data.Success {
+	return fmt.Errorf("act failed: %s", result.Data.Message)
+}
+```
+
+**Important:** Act instructions should be atomic and specific:
+
+- Good: "Click the sign in button" or "Type 'hello' into the search input"
+- Bad: "Order me pizza" or "Type in the search bar and hit enter" (multi-step)
+
+Use variables for secrets. Values are substituted locally and never sent to the model:
+
+```go
+password := os.Getenv("USER_PASSWORD")
+_, err := client.Act(ctx, "type %password% into the password field", &stagehand.StagehandClientActOptions{
+	ActOptions: stagehand.ActOptions{
+		Variables: stagehand.Variables{
+			"password": stagehand.PrimitiveVariable(stagehand.StringVariable(password)),
+		},
+	},
+})
+```
+
+### Observe Then Act Pattern (Recommended)
+
+`Act` accepts either a string instruction or an `Action` returned by `Observe`. Use `Observe` to inspect the candidate action, then pass it back to `Act` for deterministic replay with no inference:
+
+```go
+instruction := "Click the sign in button"
+observed, err := client.Observe(ctx, &instruction, nil)
+if err != nil {
+	return err
+}
+
+if len(observed.Data) > 0 && observed.Data[0].Method != nil && *observed.Data[0].Method == "click" {
+	if _, err := client.Act(ctx, observed.Data[0], nil); err != nil {
+		return err
+	}
+}
+```
+
+## Extract
+
+Extract data from pages using natural language instructions. `Extract` takes an instruction and a JSON Schema, and returns the raw JSON payload. Use the generic `stagehand.ExtractAs` helper to decode straight into a Go type.
+
+### Basic Extraction (with schema)
+
+```go
+type listing struct {
+	Price   string `json:"price"`
+	Address string `json:"address"`
+}
+
+type listings struct {
+	Listings []listing `json:"listings"`
+}
+
+var listingsSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "listings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "price": {"type": "string"},
+          "address": {"type": "string"}
+        },
+        "required": ["price", "address"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["listings"],
+  "additionalProperties": false
+}`)
+
+data, err := stagehand.ExtractAs[listings](
+	ctx,
+	client,
+	"extract all apartment listings with prices and addresses",
+	listingsSchema,
+	nil,
+)
+if err != nil {
+	return err
+}
+
+fmt.Println(data.Listings)
+```
+
+### Working With the Raw Result
+
+Call `client.Extract` directly when you want the metadata alongside the payload:
+
+```go
+result, err := client.Extract(ctx, "extract the sign in button text", buttonTextSchema, nil)
+if err != nil {
+	return err
+}
+
+var decoded buttonText
+if err := json.Unmarshal(result.Data, &decoded); err != nil {
+	return err
+}
+
+if result.Metadata.CacheStatus != nil {
+	fmt.Println("cache:", *result.Metadata.CacheStatus)
+}
+```
+
+### Targeted Extraction
+
+Scope extraction to a specific element with `Selector`, and prune noise with `IgnoreSelectors`:
+
+```go
+selector := "#main-content"
+result, err := client.Extract(ctx, "extract the article body", articleSchema, &stagehand.StagehandClientExtractOptions{
+	ExtractOptions: stagehand.ExtractOptions{
+		Selector:        &selector,
+		IgnoreSelectors: []string{"nav", ".cookie-banner"},
+	},
+})
+```
+
+### URL Extraction
+
+When extracting links or URLs, declare the field as a URI-formatted string in your schema:
+
+```go
+var linksSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "links": {"type": "array", "items": {"type": "string", "format": "uri"}}
+  },
+  "required": ["links"],
+  "additionalProperties": false
+}`)
+```
+
+### Extracting from a Specific Page
+
+```go
+result, err := client.Extract(ctx, "extract the placeholder text on the name field", placeholderSchema, &stagehand.StagehandClientExtractOptions{
+	Page: page2,
+})
+```
+
+## Observe
+
+Plan actions before executing them. `Observe` takes an optional instruction pointer and returns candidate actions on `result.Data`:
+
+```go
+instruction := "Click the sign in button"
+observed, err := client.Observe(ctx, &instruction, nil)
+if err != nil {
+	return err
+}
+
+for _, action := range observed.Data {
+	fmt.Println(action.Selector, action.Description)
+}
+```
+
+Observing on a specific page:
+
+```go
+observed, err := client.Observe(ctx, &instruction, &stagehand.StagehandClientObserveOptions{
+	Page: page2,
+})
+if err != nil {
+	return err
+}
+if _, err := client.Act(ctx, observed.Data[0], &stagehand.StagehandClientActOptions{Page: page2}); err != nil {
+	return err
+}
+```
+
+## Advanced Features
+
+### Locators
+
+Use `page.Locator(selector)` for deterministic, non-AI interactions. Selectors returned by `Observe` are XPath strings prefixed with `xpath=`:
+
+```go
+if err := page.Locator("xpath=/html/body/div[2]/button").Click(ctx, nil); err != nil {
+	return err
+}
+if err := page.Locator("#email").Fill(ctx, "user@example.com"); err != nil {
+	return err
+}
+count, err := page.Locator("li.result").Count(ctx)
+```
+
+### Multi-Page Workflows
+
+```go
+page1, err := browserContext.NewPage(ctx, stagehand.ContextNewPageParams{})
+if err != nil {
+	return err
+}
+if err := page1.Goto(ctx, "https://example.com", nil); err != nil {
+	return err
+}
+
+page2, err := browserContext.NewPage(ctx, stagehand.ContextNewPageParams{})
+if err != nil {
+	return err
+}
+if err := page2.Goto(ctx, "https://example2.com", nil); err != nil {
+	return err
+}
+
+// Act/Extract/Observe operate on the current active page by default
+// Pass Page in the options struct to target a specific page
+_, err = client.Act(ctx, "click button", &stagehand.StagehandClientActOptions{Page: page1})
+```
+
+### Caching
+
+Server-side caching requires a Browserbase browser source and a Browserbase API key:
+
+```go
+cache := stagehand.CacheEnabled(true) // or stagehand.CacheWithThreshold(1)
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey:  &browserbaseAPIKey,
+	Browser: stagehand.BrowserbaseClientBrowserSource{},
+	Cache:   &cache,
+})
+```
+
+## Cleanup
+
+Always close the client. The idiomatic pattern is a named error return plus a deferred `errors.Join`:
+
+```go
+func run(ctx context.Context) (err error) {
+	client := stagehand.New(params)
+	if err := client.Init(ctx); err != nil {
+		return err
+	}
+	defer func() { err = errors.Join(err, client.Close(ctx)) }()
+
+	// ...
+	return nil
+}
+```
+
+## Project Structure Best Practices
+
+- Read configuration from environment variables and pass it explicitly
+- Thread `context.Context` through every call so cancellation works
+- Check every returned `error`; do not discard them
+- Keep JSON Schemas next to the Go structs they decode into
+- Prefer `stagehand.ExtractAs` over manual `json.Unmarshal` when you do not need metadata
+``````
+
+</View>
+
+## Security notes
+
+- Do not embed secrets in docs or rule files; use environment variables in MCP configs.
+- Pass secrets through `variables` so they are substituted locally and never sent to the model provider.
+- Set `logging.level` to `"off"` when handling sensitive data so nothing sensitive reaches your logs.
+- Avoid broad actions that may trigger unintended navigation; prefer `observe` first.
+
+## Resources/references
+
+- Context7 MCP (Upstash)
+  - https://github.com/upstash/context7
+- DeepWiki MCP
+  - https://mcp.deepwiki.com/
+- Stagehand Docs MCP (Mintlify)
+  - https://docs.stagehand.dev/mcp

--- a/packages/docs/v4/first-steps/installation.mdx
+++ b/packages/docs/v4/first-steps/installation.mdx
@@ -6,7 +6,7 @@ description: "Add Stagehand to an existing project."
 Install Stagehand in your current app.
 
 <Tip>
-We recommend using the Node.js runtime environment to run Stagehand scripts. Stagehand requires Node.js 22.18 or later, Python 3.11 or later, or Go 1.26 or later.
+Node.js is the recommended runtime environment for Stagehand scripts. Stagehand requires Node.js 22.18 or later, Python 3.11 or later, or Go 1.26 or later.
 
 **Bun is supported.** Stagehand drives the browser over the Chrome DevTools Protocol and has no Playwright dependency, so there is no runtime caveat.
 </Tip>
@@ -72,7 +72,7 @@ Read the values in your own app code and pass them explicitly to the constructor
 
 <View title="TypeScript" icon="js">
 ```typescript
-// Optional: load an env file yourself before constructing Stagehand
+// Optional: install dotenv first (pnpm add dotenv), then load an env file yourself
 import "dotenv/config";
 
 const stagehand = new Stagehand({
@@ -136,22 +136,27 @@ async function main() {
   });
 
   await stagehand.init();
-  const page = await stagehand.context.activePage();
-  if (!page) throw new Error("Stagehand initialized without an active page");
 
-  await page.goto("https://example.com");
+  // Close in a finally block so the session is released even if a step throws
+  try {
+    const page = await stagehand.context.activePage();
+    if (!page) throw new Error("Stagehand initialized without an active page");
 
-  // Act on the page
-  await stagehand.act("Click the learn more button");
+    await page.goto("https://example.com");
 
-  // Extract structured data
-  const { data } = await stagehand.extract(
-    "extract the description",
-    z.object({ description: z.string() }),
-  );
+    // Act on the page
+    await stagehand.act("Click the learn more button");
 
-  console.log(data.description);
-  await stagehand.close();
+    // Extract structured data
+    const { data } = await stagehand.extract(
+      "extract the description",
+      z.object({ description: z.string() }),
+    );
+
+    console.log(data.description);
+  } finally {
+    await stagehand.close();
+  }
 }
 
 main().catch((err) => {
@@ -183,23 +188,27 @@ async def main() -> None:
     )
 
     await stagehand.init()
-    page = await stagehand.context.active_page()
-    if page is None:
-        raise RuntimeError("Stagehand initialized without an active page")
 
-    await page.goto("https://example.com")
+    # Close in a finally block so the session is released even if a step raises
+    try:
+        page = await stagehand.context.active_page()
+        if page is None:
+            raise RuntimeError("Stagehand initialized without an active page")
 
-    # Act on the page
-    await stagehand.act("Click the learn more button")
+        await page.goto("https://example.com")
 
-    # Extract structured data
-    result = await stagehand.extract(
-        instruction="extract the description",
-        schema=Description,
-    )
+        # Act on the page
+        await stagehand.act("Click the learn more button")
 
-    print(result.data.description)
-    await stagehand.close()
+        # Extract structured data
+        result = await stagehand.extract(
+            instruction="extract the description",
+            schema=Description,
+        )
+
+        print(result.data.description)
+    finally:
+        await stagehand.close()
 
 
 asyncio.run(main())

--- a/packages/docs/v4/first-steps/installation.mdx
+++ b/packages/docs/v4/first-steps/installation.mdx
@@ -302,7 +302,7 @@ func run(ctx context.Context) (err error) {
   <Card
     title="Configuration"
     icon="gear"
-    href="/v4/configuration/browser"
+    href="/v3/configuration/browser"
   >
     Browser sources, Browserbase vs local, logging, timeouts, LLM customization
   </Card>

--- a/packages/docs/v4/first-steps/installation.mdx
+++ b/packages/docs/v4/first-steps/installation.mdx
@@ -3,142 +3,328 @@ title: "Installation"
 description: "Add Stagehand to an existing project."
 ---
 
-Add Stagehand to a project you already have. If you're starting from scratch, the
-[Quickstart](/v4/first-steps/quickstart) has a complete runnable script.
+Install Stagehand in your current app.
 
-## Install the SDK
+<Tip>
+We recommend using the Node.js runtime environment to run Stagehand scripts. Stagehand requires Node.js 22.18 or later, Python 3.11 or later, or Go 1.26 or later.
+
+**Bun is supported.** Stagehand drives the browser over the Chrome DevTools Protocol and has no Playwright dependency, so there is no runtime caveat.
+</Tip>
+
+### Install dependencies
 
 <View title="TypeScript" icon="js">
-
 ```bash
-pnpm add @browserbasehq/stagehand zod
+pnpm install @browserbasehq/stagehand zod
+# npm add @browserbasehq/stagehand zod
+# yarn add @browserbasehq/stagehand zod
+# bun add @browserbasehq/stagehand zod
 ```
+</View>
 
-`zod` is a peer of `extract()`, which uses Zod schemas to type and validate results. Any
-recent package manager works, so swap `pnpm` for `npm` or `yarn` if you prefer.
-
-## Configure credentials
-
-Stagehand needs an API key for the model provider it calls. If you run on Browserbase, it
-also needs a Browserbase API key. Store both in environment variables rather than in code.
-
+<View title="Python" icon="python">
 ```bash
-# Model provider (example: OpenAI)
-export OPENAI_API_KEY="sk-..."
-
-# Only required for the Browserbase browser source
-export BROWSERBASE_API_KEY="bb_..."
+pip install stagehand
+# uv add stagehand
+# poetry add stagehand
 ```
+</View>
 
-<Warning>
-  Never hardcode API keys, passwords, or other secrets in your source. Load them from environment
-  variables or a secrets manager, and pass user credentials to `act()` through
-  [variables](/v4/basics/act#variables) so they're kept out of the model prompt.
-</Warning>
+<View title="Go" icon="golang">
+```bash
+go get github.com/browserbase/stagehand/packages/sdk-go
+```
+</View>
 
-## Initialize Stagehand
+<Tip>
+If you plan to run locally, you need to have [Chrome](https://www.google.com/chrome/) installed on your machine. For cloud browser sessions, skip this.
+</Tip>
 
-Construct a `Stagehand`, choose a browser source and a model, then call `init()`.
+### Configure environment
 
+Set environment variables for your Browserbase API key and your model provider key:
+
+<View title="TypeScript" icon="js">
+```bash
+export OPENAI_API_KEY=your_api_key
+export BROWSERBASE_API_KEY=your_api_key
+```
+</View>
+
+<View title="Python" icon="python">
+```bash
+export OPENAI_API_KEY=your_api_key
+export BROWSERBASE_API_KEY=your_api_key
+```
+</View>
+
+<View title="Go" icon="golang">
+```bash
+export OPENAI_API_KEY=your_api_key
+export BROWSERBASE_API_KEY=your_api_key
+```
+</View>
+
+<Note>
+Stagehand does not read environment variables on your behalf, and it does not auto-load env files.
+
+Read the values in your own app code and pass them explicitly to the constructor:
+
+<View title="TypeScript" icon="js">
 ```typescript
-import { Stagehand } from "@browserbasehq/stagehand";
+// Optional: load an env file yourself before constructing Stagehand
+import "dotenv/config";
 
 const stagehand = new Stagehand({
-  browser: { type: "local", headless: true },
+  apiKey: process.env.BROWSERBASE_API_KEY,
   model: {
     modelName: "openai/gpt-5.4-mini",
     apiKey: process.env.OPENAI_API_KEY,
   },
 });
-
-try {
-  await stagehand.init();
-  const page = await stagehand.context.newPage();
-  await page.goto("https://example.com");
-
-  // ... use stagehand.act / stagehand.extract / stagehand.observe ...
-} finally {
-  await stagehand.close();
-}
 ```
-
 </View>
 
 <View title="Python" icon="python">
+```python
+import os
 
-```bash
-uv pip install stagehand
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    model="openai/gpt-5.4-mini",
+    model_api_key=os.environ["OPENAI_API_KEY"],
+)
 ```
+</View>
 
-The Python SDK is async and uses [Pydantic](https://docs.pydantic.dev/) models for
-`extract()` schemas (Pydantic is installed as a dependency).
+<View title="Go" icon="golang">
+```go
+// Every optional field is a pointer, so read your keys into variables first
+apiKey := os.Getenv("BROWSERBASE_API_KEY")
+modelAPIKey := os.Getenv("OPENAI_API_KEY")
 
-## Configure credentials
+model := stagehand.KnownModel(stagehand.KnownModelConfig{
+	ModelName: "openai/gpt-5.4-mini",
+	APIKey:    &modelAPIKey,
+})
 
-Stagehand needs an API key for the model provider it calls. If you run on Browserbase, it
-also needs a Browserbase API key. Store both in environment variables rather than in code.
-
-```bash
-# Model provider (example: OpenAI)
-export OPENAI_API_KEY="sk-..."
-
-# Only required for the Browserbase browser source
-export BROWSERBASE_API_KEY="bb_..."
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey: &apiKey,
+	Model:  &model,
+})
 ```
+</View>
+</Note>
 
-<Warning>
-  Never hardcode API keys, passwords, or other secrets in your source. Load them from environment
-  variables or a secrets manager, and pass user credentials to `act()` through
-  [variables](/v4/basics/act#variables) so they're kept out of the model prompt.
-</Warning>
+### Use in your codebase
 
-## Initialize Stagehand
+Add Stagehand where you need browser automation.
 
-Construct a `Stagehand`, choose a browser source and a model, then call `init()`.
+<View title="TypeScript" icon="js">
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+import { z } from "zod/v4";
 
+async function main() {
+  const stagehand = new Stagehand({
+    apiKey: process.env.BROWSERBASE_API_KEY,
+    browser: { type: "browserbase" },
+    model: {
+      modelName: "openai/gpt-5.4-mini",
+      apiKey: process.env.OPENAI_API_KEY,
+    },
+  });
+
+  await stagehand.init();
+  const page = await stagehand.context.activePage();
+  if (!page) throw new Error("Stagehand initialized without an active page");
+
+  await page.goto("https://example.com");
+
+  // Act on the page
+  await stagehand.act("Click the learn more button");
+
+  // Extract structured data
+  const { data } = await stagehand.extract(
+    "extract the description",
+    z.object({ description: z.string() }),
+  );
+
+  console.log(data.description);
+  await stagehand.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+```
+</View>
+
+<View title="Python" icon="python">
 ```python
 import asyncio
 import os
 
+from pydantic import BaseModel
 from stagehand import Stagehand
+
+
+class Description(BaseModel):
+    description: str
 
 
 async def main() -> None:
     stagehand = Stagehand(
-        browser="local",
-        headless=True,
+        api_key=os.environ["BROWSERBASE_API_KEY"],
+        browser="browserbase",
         model="openai/gpt-5.4-mini",
         model_api_key=os.environ["OPENAI_API_KEY"],
     )
 
-    try:
-        await stagehand.init()
-        page = await stagehand.context.new_page()
-        await page.goto("https://example.com")
+    await stagehand.init()
+    page = await stagehand.context.active_page()
+    if page is None:
+        raise RuntimeError("Stagehand initialized without an active page")
 
-        # ... use stagehand.act / stagehand.extract / stagehand.observe ...
-    finally:
-        await stagehand.close()
+    await page.goto("https://example.com")
+
+    # Act on the page
+    await stagehand.act("Click the learn more button")
+
+    # Extract structured data
+    result = await stagehand.extract(
+        instruction="extract the description",
+        schema=Description,
+    )
+
+    print(result.data.description)
+    await stagehand.close()
 
 
 asyncio.run(main())
 ```
-
 </View>
 
-<Note>
-  The `browser` source defaults to `browserbase`, which requires a Browserbase API key. The examples
-  above use `local` so you can run without one. Always `await stagehand.init()` before using a page,
-  and `await stagehand.close()` when you're done.
-</Note>
+<View title="Go" icon="golang">
+```go
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+
+	stagehand "github.com/browserbase/stagehand/packages/sdk-go"
+)
+
+type description struct {
+	Description string `json:"description"`
+}
+
+var descriptionSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {"description": {"type": "string"}},
+  "required": ["description"],
+  "additionalProperties": false
+}`)
+
+func main() {
+	if err := run(context.Background()); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run(ctx context.Context) (err error) {
+	apiKey := os.Getenv("BROWSERBASE_API_KEY")
+	modelAPIKey := os.Getenv("OPENAI_API_KEY")
+	model := stagehand.KnownModel(stagehand.KnownModelConfig{
+		ModelName: "openai/gpt-5.4-mini",
+		APIKey:    &modelAPIKey,
+	})
+
+	client := stagehand.New(stagehand.StagehandClientInitParams{
+		APIKey:  &apiKey,
+		Browser: stagehand.BrowserbaseClientBrowserSource{},
+		Model:   &model,
+	})
+
+	if err := client.Init(ctx); err != nil {
+		return err
+	}
+	defer func() { err = errors.Join(err, client.Close(ctx)) }()
+
+	browserContext, err := client.Context()
+	if err != nil {
+		return err
+	}
+	page, err := browserContext.ActivePage(ctx)
+	if err != nil {
+		return err
+	}
+	if page == nil {
+		return errors.New("Stagehand initialized without an active page")
+	}
+
+	if err := page.Goto(ctx, "https://example.com", nil); err != nil {
+		return err
+	}
+
+	// Act on the page
+	if _, err := client.Act(ctx, "Click the learn more button", nil); err != nil {
+		return err
+	}
+
+	// Extract structured data
+	extracted, err := stagehand.ExtractAs[description](
+		ctx,
+		client,
+		"extract the description",
+		descriptionSchema,
+		nil,
+	)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(extracted.Description)
+	return nil
+}
+```
+</View>
 
 ## Next steps
 
-<CardGroup cols="2">
-  <Card title="Quickstart" icon="rocket" href="/v4/first-steps/quickstart">
-    Run a full example end to end.
+<CardGroup cols={2}>
+  <Card
+    title="Configuration"
+    icon="gear"
+    href="/v4/configuration/browser"
+  >
+    Browser sources, Browserbase vs local, logging, timeouts, LLM customization
   </Card>
-  <Card title="AI rules" icon="robot" href="/v4/first-steps/ai-rules">
-    Give your AI coding assistant the rules to write correct Stagehand code.
+  <Card
+    title="Act"
+    icon="arrow-pointer"
+    href="/v4/basics/act"
+  >
+    Perform precise actions with natural language
+  </Card>
+  <Card
+    title="Extract"
+    icon="download"
+    href="/v4/basics/extract"
+  >
+    Typed data extraction with schemas
+  </Card>
+  <Card
+    title="Observe"
+    icon="eye"
+    href="/v4/basics/observe"
+  >
+    Discover elements and suggested actions
   </Card>
 </CardGroup>

--- a/packages/docs/v4/first-steps/introduction.mdx
+++ b/packages/docs/v4/first-steps/introduction.mdx
@@ -6,7 +6,7 @@ description: "Developers use Stagehand to reliably automate the web."
 
 Stagehand is a browser automation framework used to control web browsers with natural language and code. By combining the power of AI with the precision of code, Stagehand makes web automation flexible, maintainable, and actually reliable.
 
-## The Problem with Browser Automation
+## The problem with browser automation
 
 Traditional frameworks like Playwright and Puppeteer force you to write brittle scripts that break with every UI change. Web agents promise to solve this with AI, but leave you at the mercy of unpredictable behavior.
 
@@ -68,8 +68,14 @@ actions = (await stagehand.observe(instruction="find submit buttons")).data
 
 <View title="Go" icon="golang">
 ```go
+// ctx, client, and the encoding/json import come from the quickstart
+
 // Act: execute natural language actions
 actResult, err := client.Act(ctx, "click the login button", nil)
+if err != nil {
+	return err
+}
+fmt.Println(actResult.Data.Success)
 
 // Extract: pull structured data
 type price struct {
@@ -82,14 +88,22 @@ priceSchema := json.RawMessage(`{
   "additionalProperties": false
 }`)
 extracted, err := stagehand.ExtractAs[price](ctx, client, "extract the price", priceSchema, nil)
+if err != nil {
+	return err
+}
+fmt.Println(extracted.Price)
 
 // Observe: discover available actions
 instruction := "find submit buttons"
-observeResult, err := client.Observe(ctx, &instruction, nil)
+observed, err := client.Observe(ctx, &instruction, nil)
+if err != nil {
+	return err
+}
+fmt.Println(len(observed.Data), "candidate actions")
 ```
 </View>
 
-## Why Developers Choose Stagehand
+## Why developers choose Stagehand
 
 - **Precise Control:** Mix AI-powered actions with deterministic code. You decide exactly how much AI to use.
 - **The engine runs inside the browser:** Act, extract, and observe execute in an in-browser runtime instead of a Node process wrapping Playwright, and clients talk to it over a typed, bidirectional JSON-RPC protocol.
@@ -99,11 +113,11 @@ observeResult, err := client.Observe(ctx, &instruction, nil)
 - **Models are flexible:** Use a hosted provider by name, a custom OpenAI-compatible endpoint, or your own client-side LLM callback.
 - **Metrics are built in:** Read per-method token usage and inference timing with [`metrics()`](/v4/reference/stagehand).
 
-## Built for Modern Development
+## Built for modern development
 Stagehand is designed for developers building production browser automations and AI agents that need reliable web access.
 
 <AccordionGroup>
-  <Accordion title="Works Everywhere">
+  <Accordion title="Works everywhere">
     Compatible with all Chromium-based browsers: Chrome, Edge, Arc, Brave, and more. Stagehand drives the browser over the Chrome DevTools Protocol, so there is no Playwright or Puppeteer dependency.
   </Accordion>
   <Accordion title="Built by Browserbase">
@@ -111,9 +125,9 @@ Stagehand is designed for developers building production browser automations and
   </Accordion>
 </AccordionGroup>
 
-## Get Started in 60 Seconds
+## Get started in 60 seconds
 <Info>
-  **Pro tip**: For best results, we recommend using Stagehand with [Browserbase](https://www.browserbase.com) for reliable cloud browser infrastructure. It is the default browser source, and it unlocks [server-side caching](/v3/best-practices/caching) and the [Model Gateway](/v3/configuration/models#model-gateway).
+  **Pro tip**: For best results, Browserbase recommends using Stagehand with [Browserbase](https://www.browserbase.com) for reliable cloud browser infrastructure. It is the default browser source, and it unlocks [server-side caching](/v3/best-practices/caching) and the [Model Gateway](/v3/configuration/models#model-gateway).
 </Info>
 <CardGroup cols={2}>
   <Card
@@ -124,7 +138,7 @@ Stagehand is designed for developers building production browser automations and
     Build your first automation in under a minute
   </Card>
   <Card
-    title="View Templates"
+    title="View templates"
     icon="code"
     href="https://www.browserbase.com/templates"
   >

--- a/packages/docs/v4/first-steps/introduction.mdx
+++ b/packages/docs/v4/first-steps/introduction.mdx
@@ -4,110 +4,94 @@ sidebarTitle: "Introduction"
 description: "Developers use Stagehand to reliably automate the web."
 ---
 
-Stagehand is a browser automation framework used to control web browsers with natural language and code. By combining the power of AI with the precision of code, Stagehand makes web automation flexible, maintainable, and reliable.
+Stagehand is a browser automation framework used to control web browsers with natural language and code. By combining the power of AI with the precision of code, Stagehand makes web automation flexible, maintainable, and actually reliable.
 
-## The problem with browser automation
+## The Problem with Browser Automation
 
 Traditional frameworks like Playwright and Puppeteer force you to write brittle scripts that break with every UI change. Web agents promise to solve this with AI, but leave you at the mercy of unpredictable behavior.
 
 **You're stuck between two bad options:**
-
 - **Too brittle:** Traditional selectors break when websites change
 - **Too agentic:** AI agents are unpredictable and impossible to debug
 
 ## Enter Stagehand
 
-Stagehand gives you three composable primitives, so you decide exactly how much AI to use on any given step and drop down to deterministic browser controls whenever you want.
+Stagehand gives you the best of both worlds through three powerful primitives that let you choose exactly how much AI to use:
 
-<CardGroup cols="3">
-  <Card title="Act" icon="arrow-pointer" href="/v4/basics/act">
-    Perform a single action described in natural language.
+<CardGroup cols={3}>
+  <Card title="Act" icon="play" href="/v4/basics/act">
+    Execute actions using natural language
   </Card>
-  <Card title="Extract" icon="download" href="/v4/basics/extract">
-    Pull structured, schema-typed data from a page.
+  <Card title="Extract" icon="database" href="/v4/basics/extract">
+    Pull structured data with schemas
   </Card>
   <Card title="Observe" icon="eye" href="/v4/basics/observe">
-    Discover the actions available on a page before acting.
+    Discover available actions on any page
   </Card>
 </CardGroup>
 
 <View title="TypeScript" icon="js">
-
 ```typescript
-import { Stagehand } from "@browserbasehq/stagehand";
-import { z } from "zod";
+// Act: execute natural language actions
+await stagehand.act("click the login button");
 
-const stagehand = new Stagehand({ browser: { type: "local" } });
-try {
-  await stagehand.init();
-  const page = await stagehand.context.newPage();
-  await page.goto("https://example.com");
+// Extract: pull structured data
+const { data } = await stagehand.extract(
+  "extract the price",
+  z.object({ price: z.number() }),
+);
 
-  // Observe: discover the available actions
-  const actions = await stagehand.observe("Find the primary call-to-action");
-  console.log(actions.data);
-
-  // Act: perform a natural-language action
-  await stagehand.act("Click the primary call-to-action");
-
-  // Extract: pull structured data
-  const {
-    data: { heading },
-  } = await stagehand.extract(
-    "Extract the page heading",
-    z.object({ heading: z.string() }),
-  );
-} finally {
-  await stagehand.close();
-}
+// Observe: discover available actions
+const { data: actions } = await stagehand.observe("find submit buttons");
 ```
-
 </View>
 
 <View title="Python" icon="python">
-
 ```python
-import asyncio
+# Act: execute natural language actions
+await stagehand.act("click the login button")
 
-from pydantic import BaseModel
-from stagehand import Stagehand
+# Extract: pull structured data
+class Price(BaseModel):
+    price: float
 
+result = await stagehand.extract(
+    instruction="extract the price",
+    schema=Price,
+)
+price = result.data.price
 
-class PageInfo(BaseModel):
-    heading: str
-
-
-async def main() -> None:
-    stagehand = Stagehand(browser="local")
-    try:
-        await stagehand.init()
-        page = await stagehand.context.new_page()
-        await page.goto("https://example.com")
-
-        # Observe: discover the available actions
-        actions = await stagehand.observe(instruction="Find the primary call-to-action")
-        print(actions.data)
-
-        # Act: perform a natural-language action
-        await stagehand.act("Click the primary call-to-action")
-
-        # Extract: pull structured data
-        page_info = await stagehand.extract(
-            instruction="Extract the page heading",
-            schema=PageInfo,
-        )
-        print(page_info.data.heading)
-    finally:
-        await stagehand.close()
-
-
-asyncio.run(main())
+# Observe: discover available actions
+actions = (await stagehand.observe(instruction="find submit buttons")).data
 ```
-
 </View>
 
-## What's new in V4
+<View title="Go" icon="golang">
+```go
+// Act: execute natural language actions
+actResult, err := client.Act(ctx, "click the login button", nil)
 
+// Extract: pull structured data
+type price struct {
+	Price float64 `json:"price"`
+}
+priceSchema := json.RawMessage(`{
+  "type": "object",
+  "properties": {"price": {"type": "number"}},
+  "required": ["price"],
+  "additionalProperties": false
+}`)
+extracted, err := stagehand.ExtractAs[price](ctx, client, "extract the price", priceSchema, nil)
+
+// Observe: discover available actions
+instruction := "find submit buttons"
+observeResult, err := client.Observe(ctx, &instruction, nil)
+```
+</View>
+
+## Why Developers Choose Stagehand
+
+- **Precise Control:** Mix AI-powered actions with deterministic code. You decide exactly how much AI to use.
 - **The engine runs inside the browser:** Act, extract, and observe execute in an in-browser runtime instead of a Node process wrapping Playwright, and clients talk to it over a typed, bidirectional JSON-RPC protocol.
 - **First-class TypeScript and Python SDKs:** Each client is generated from the same protocol, so every method and option matches across supported languages.
 - **The AI primitives live on Stagehand:** `act`, `extract`, and `observe` are methods on [`stagehand`](/v4/reference/stagehand). They run on the browser's active page by default, or on a page you pass. Deterministic controls like `goto`, `click`, and `type` stay on [`page`](/v4/reference/page).
@@ -115,39 +99,49 @@ asyncio.run(main())
 - **Models are flexible:** Use a hosted provider by name, a custom OpenAI-compatible endpoint, or your own client-side LLM callback.
 - **Metrics are built in:** Read per-method token usage and inference timing with [`metrics()`](/v4/reference/stagehand).
 
-## Why developers choose Stagehand
-
-- **Precise Control:** Mix AI-powered actions with deterministic code. You decide exactly how much AI to use.
-- **Actually Repeatable:** Save and replay actions exactly. No more “it worked on my machine” with browser automations.
-- **Maintainable at Scale:** One script can automate multiple websites. When sites change, your automations adapt.
-- **Composable Tools:** Plan with `observe`, act with `act`, and read data with `extract`.
-
-## Built for modern development
-
-Stagehand works whether you run locally or on [Browserbase](https://www.browserbase.com).
+## Built for Modern Development
+Stagehand is designed for developers building production browser automations and AI agents that need reliable web access.
 
 <AccordionGroup>
   <Accordion title="Works Everywhere">
-    Compatible with all Chromium-based browsers: Chrome, Edge, Arc, Brave, and more.
+    Compatible with all Chromium-based browsers: Chrome, Edge, Arc, Brave, and more. Stagehand drives the browser over the Chrome DevTools Protocol, so there is no Playwright or Puppeteer dependency.
   </Accordion>
   <Accordion title="Built by Browserbase">
     Created and maintained by the team behind enterprise browser infrastructure.
   </Accordion>
 </AccordionGroup>
 
-## Get started
-
-<CardGroup cols="2">
-  <Card title="Quickstart" icon="rocket" href="/v4/first-steps/quickstart">
-    Build your first automation end to end.
+## Get Started in 60 Seconds
+<Info>
+  **Pro tip**: For best results, we recommend using Stagehand with [Browserbase](https://www.browserbase.com) for reliable cloud browser infrastructure. It is the default browser source, and it unlocks [server-side caching](/v4/best-practices/caching) and the [Model Gateway](/v4/configuration/models#model-gateway).
+</Info>
+<CardGroup cols={2}>
+  <Card
+    title="Quickstart"
+    icon="rocket"
+    href="/v4/first-steps/quickstart"
+  >
+    Build your first automation in under a minute
   </Card>
-  <Card title="Installation" icon="download" href="/v4/first-steps/installation">
-    Add Stagehand to an existing project.
+  <Card
+    title="View Templates"
+    icon="code"
+    href="https://www.browserbase.com/templates"
+  >
+    See real-world automation examples
   </Card>
-  <Card title="SDK reference" icon="book" href="/v4/reference/stagehand">
-    Explore the full API surface.
+  <Card
+    title="Join Discord"
+    icon="discord"
+    href="https://stagehand.dev/discord"
+  >
+    Get help from the community
   </Card>
-  <Card title="Join Discord" icon="discord" href="https://stagehand.dev/discord">
-    Get help from the community.
+  <Card
+    title="Installation"
+    icon="download"
+    href="/v4/first-steps/installation"
+  >
+    Add Stagehand to your project
   </Card>
 </CardGroup>

--- a/packages/docs/v4/first-steps/introduction.mdx
+++ b/packages/docs/v4/first-steps/introduction.mdx
@@ -113,7 +113,7 @@ Stagehand is designed for developers building production browser automations and
 
 ## Get Started in 60 Seconds
 <Info>
-  **Pro tip**: For best results, we recommend using Stagehand with [Browserbase](https://www.browserbase.com) for reliable cloud browser infrastructure. It is the default browser source, and it unlocks [server-side caching](/v4/best-practices/caching) and the [Model Gateway](/v4/configuration/models#model-gateway).
+  **Pro tip**: For best results, we recommend using Stagehand with [Browserbase](https://www.browserbase.com) for reliable cloud browser infrastructure. It is the default browser source, and it unlocks [server-side caching](/v3/best-practices/caching) and the [Model Gateway](/v3/configuration/models#model-gateway).
 </Info>
 <CardGroup cols={2}>
   <Card

--- a/packages/docs/v4/first-steps/quickstart.mdx
+++ b/packages/docs/v4/first-steps/quickstart.mdx
@@ -263,7 +263,7 @@ func run(ctx context.Context) (err error) {
 </View>
 
 <Tip>
-Prefer to run against a browser on your own machine while you develop? Swap the browser source for a local one and drop the Browserbase key. See [Browser configuration](/v4/configuration/browser).
+Prefer to run against a browser on your own machine while you develop? Swap the browser source for a local one and drop the Browserbase key. See [Browser configuration](/v3/configuration/browser).
 </Tip>
 
 ## Next steps

--- a/packages/docs/v4/first-steps/quickstart.mdx
+++ b/packages/docs/v4/first-steps/quickstart.mdx
@@ -3,97 +3,120 @@ title: "Quickstart"
 description: "Build your first Stagehand automation with act, extract, and observe."
 ---
 
-This quickstart walks through a complete Stagehand script that launches a local browser,
-navigates to a page, and uses all three AI primitives. Pick your language using the selector.
+The quickest way to start with Stagehand is to install the SDK, point it at a browser, and write a script. This page gets you from an empty directory to a working automation in three steps.
 
-## 1. Install Stagehand
+<Note>
+Use the language selector on this page to switch every code sample between TypeScript, Python, and Go.
+</Note>
+
+## 1) Create a sample project
 
 <View title="TypeScript" icon="js">
-
 ```bash
-pnpm add @browserbasehq/stagehand zod
+mkdir my-stagehand-app && cd my-stagehand-app
+pnpm init -y
+pnpm install @browserbasehq/stagehand zod
 ```
-
-## 2. Set your model API key
-
-Stagehand needs an API key for the LLM provider it calls. Export it in your shell (or put
-it in a `.env` file).
-
-```bash
-export OPENAI_API_KEY="sk-..."
-```
-
-## 3. Write the script
-
-```typescript
-import "dotenv/config";
-import { Stagehand } from "@browserbasehq/stagehand";
-import { z } from "zod";
-
-const stagehand = new Stagehand({
-  browser: { type: "local", headless: true },
-  model: {
-    modelName: "openai/gpt-5.4-mini",
-    apiKey: process.env.OPENAI_API_KEY,
-  },
-});
-
-try {
-  await stagehand.init();
-
-  const page = await stagehand.context.newPage();
-  await page.goto("https://example.com");
-
-  // Observe: discover candidate actions before acting.
-  const actions = await stagehand.observe(
-    "Find the link that provides more information about Example Domain",
-  );
-  console.log(actions.data);
-
-  // Act: perform a natural-language action.
-  const result = await stagehand.act(
-    "Click the link that provides more information about Example Domain",
-  );
-  if (!result.data.success) {
-    throw new Error(`act() failed: ${result.data.message}`);
-  }
-
-  // Extract: pull structured, typed data.
-  const info = await stagehand.extract(
-    "Extract the page heading and description",
-    z.object({ heading: z.string(), description: z.string() }),
-  );
-  console.log(info.data);
-} finally {
-  await stagehand.close();
-}
-```
-
-## 4. Run it
-
-```bash
-pnpm dlx tsx quickstart.ts
-```
-
 </View>
 
 <View title="Python" icon="python">
-
 ```bash
-uv pip install stagehand
+mkdir my-stagehand-app && cd my-stagehand-app
+python -m venv .venv && source .venv/bin/activate
+pip install stagehand
 ```
+</View>
 
-## 2. Set your model API key
-
-Stagehand needs an API key for the LLM provider it calls. Export it in your shell (or put
-it in a `.env` file).
-
+<View title="Go" icon="golang">
 ```bash
-export OPENAI_API_KEY="sk-..."
+mkdir my-stagehand-app && cd my-stagehand-app
+go mod init example.com/my-stagehand-app
+go get github.com/browserbase/stagehand/packages/sdk-go
 ```
+</View>
 
-## 3. Write the script
+## 2) Run it
 
+Set your API keys as environment variables, then run the example script. Stagehand runs on Browserbase cloud browsers by default, so you need a `BROWSERBASE_API_KEY` plus a key for your model provider.
+
+<View title="TypeScript" icon="js">
+```bash
+export BROWSERBASE_API_KEY="bb_live_..." # Your Browserbase API key
+export OPENAI_API_KEY="sk-..."           # Your model provider key
+npx tsx index.ts                         # Run the example script
+```
+</View>
+
+<View title="Python" icon="python">
+```bash
+export BROWSERBASE_API_KEY="bb_live_..." # Your Browserbase API key
+export OPENAI_API_KEY="sk-..."           # Your model provider key
+python main.py                           # Run the example script
+```
+</View>
+
+<View title="Go" icon="golang">
+```bash
+export BROWSERBASE_API_KEY="bb_live_..." # Your Browserbase API key
+export OPENAI_API_KEY="sk-..."           # Your model provider key
+go run .                                 # Run the example script
+```
+</View>
+
+<Note>
+Stagehand never reads environment variables on your behalf. Read them in your own code and pass the values to the constructor, as shown below.
+</Note>
+
+## 3) Use Stagehand (act, extract, observe)
+
+Here is the full example script, exercising all three primitives:
+
+<View title="TypeScript" icon="js">
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+import { z } from "zod/v4";
+
+async function main() {
+  const stagehand = new Stagehand({
+    apiKey: process.env.BROWSERBASE_API_KEY,
+    browser: { type: "browserbase" },
+    model: {
+      modelName: "openai/gpt-5.4-mini",
+      apiKey: process.env.OPENAI_API_KEY,
+    },
+  });
+
+  await stagehand.init();
+
+  console.log("Stagehand session started");
+
+  const page = await stagehand.context.activePage();
+  if (!page) throw new Error("Stagehand initialized without an active page");
+
+  await page.goto("https://stagehand.dev");
+
+  const extractResult = await stagehand.extract(
+    "Extract the value proposition from the page.",
+    z.object({ valueProposition: z.string() }),
+  );
+  console.log("Extract result:\n", extractResult.data);
+
+  await stagehand.act("Click the 'Evals' button.");
+
+  const observeResult = await stagehand.observe("What can I click on this page?");
+  console.log("Observe result:\n", observeResult.data);
+
+  await stagehand.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+```
+</View>
+
+<View title="Python" icon="python">
 ```python
 import asyncio
 import os
@@ -102,74 +125,181 @@ from pydantic import BaseModel
 from stagehand import Stagehand
 
 
-class PageInfo(BaseModel):
-    heading: str
-    description: str
+class ValueProposition(BaseModel):
+    value_proposition: str
 
 
 async def main() -> None:
     stagehand = Stagehand(
-        browser="local",
-        headless=True,
+        api_key=os.environ["BROWSERBASE_API_KEY"],
+        browser="browserbase",
         model="openai/gpt-5.4-mini",
         model_api_key=os.environ["OPENAI_API_KEY"],
     )
 
-    try:
-        await stagehand.init()
+    await stagehand.init()
 
-        page = await stagehand.context.new_page()
-        await page.goto("https://example.com")
+    print("Stagehand session started")
 
-        # Observe: discover candidate actions before acting.
-        actions = await stagehand.observe(
-            instruction="Find the link that provides more information about Example Domain",
-        )
-        print(actions.data)
+    page = await stagehand.context.active_page()
+    if page is None:
+        raise RuntimeError("Stagehand initialized without an active page")
 
-        # Act: perform a natural-language action.
-        result = await stagehand.act(
-            "Click the link that provides more information about Example Domain"
-        )
-        if not result.data.success:
-            raise RuntimeError(f"act() failed: {result.data.message}")
+    await page.goto("https://stagehand.dev")
 
-        # Extract: pull structured, typed data.
-        info = await stagehand.extract(
-            instruction="Extract the page heading and description",
-            schema=PageInfo,
-        )
-        print(info.data)
-    finally:
-        await stagehand.close()
+    extract_result = await stagehand.extract(
+        instruction="Extract the value proposition from the page.",
+        schema=ValueProposition,
+    )
+    print("Extract result:\n", extract_result.data)
+
+    await stagehand.act("Click the 'Evals' button.")
+
+    observe_result = await stagehand.observe(instruction="What can I click on this page?")
+    print("Observe result:\n", observe_result.data)
+
+    await stagehand.close()
 
 
 asyncio.run(main())
 ```
-
-## 4. Run it
-
-```bash
-python quickstart.py
-```
-
 </View>
 
-You should see the observed actions, a successful `act()` result, and the extracted
-heading and description printed to your console.
+<View title="Go" icon="golang">
+```go
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+
+	stagehand "github.com/browserbase/stagehand/packages/sdk-go"
+)
+
+type valueProposition struct {
+	ValueProposition string `json:"value_proposition"`
+}
+
+var valuePropositionSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {"value_proposition": {"type": "string"}},
+  "required": ["value_proposition"],
+  "additionalProperties": false
+}`)
+
+func main() {
+	if err := run(context.Background()); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run(ctx context.Context) (err error) {
+	apiKey := os.Getenv("BROWSERBASE_API_KEY")
+	modelAPIKey := os.Getenv("OPENAI_API_KEY")
+	model := stagehand.KnownModel(stagehand.KnownModelConfig{
+		ModelName: "openai/gpt-5.4-mini",
+		APIKey:    &modelAPIKey,
+	})
+
+	client := stagehand.New(stagehand.StagehandClientInitParams{
+		APIKey:  &apiKey,
+		Browser: stagehand.BrowserbaseClientBrowserSource{},
+		Model:   &model,
+	})
+
+	if err := client.Init(ctx); err != nil {
+		return err
+	}
+	defer func() { err = errors.Join(err, client.Close(ctx)) }()
+
+	fmt.Println("Stagehand session started")
+
+	browserContext, err := client.Context()
+	if err != nil {
+		return err
+	}
+	page, err := browserContext.ActivePage(ctx)
+	if err != nil {
+		return err
+	}
+	if page == nil {
+		return errors.New("Stagehand initialized without an active page")
+	}
+
+	if err := page.Goto(ctx, "https://stagehand.dev", nil); err != nil {
+		return err
+	}
+
+	extracted, err := stagehand.ExtractAs[valueProposition](
+		ctx,
+		client,
+		"Extract the value proposition from the page.",
+		valuePropositionSchema,
+		nil,
+	)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Extract result:\n%+v\n", extracted)
+
+	if _, err := client.Act(ctx, "Click the 'Evals' button.", nil); err != nil {
+		return err
+	}
+
+	instruction := "What can I click on this page?"
+	observeResult, err := client.Observe(ctx, &instruction, nil)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Observe result:\n%+v\n", observeResult.Data)
+
+	return nil
+}
+```
+</View>
+
+<Tip>
+Prefer to run against a browser on your own machine while you develop? Swap the browser source for a local one and drop the Browserbase key. See [Browser configuration](/v4/configuration/browser).
+</Tip>
 
 ## Next steps
 
 Learn about the Stagehand primitives: act, extract, and observe.
 
-<CardGroup cols="2">
-  <Card title="Act" icon="arrow-pointer" href="/v4/basics/act">
-    Perform actions on pages with natural language.
+<CardGroup cols={2}>
+  <Card
+    title="Act"
+    icon="arrow-pointer"
+    href="/v4/basics/act"
+  >
+    Perform actions on web pages with natural language
   </Card>
-  <Card title="Extract" icon="download" href="/v4/basics/extract">
-    Pull typed data with schemas.
+
+  <Card
+    title="Extract"
+    icon="download"
+    href="/v4/basics/extract"
+  >
+    Get structured data with typed schemas
   </Card>
-  <Card title="Observe" icon="eye" href="/v4/basics/observe">
-    Plan actions before executing them.
+
+  <Card
+    title="Observe"
+    icon="eye"
+    href="/v4/basics/observe"
+  >
+    Discover available elements and actions
+  </Card>
+
+  <Card
+    title="Installation"
+    icon="download"
+    href="/v4/first-steps/installation"
+  >
+    Add Stagehand to an existing project
   </Card>
 </CardGroup>

--- a/packages/docs/v4/first-steps/quickstart.mdx
+++ b/packages/docs/v4/first-steps/quickstart.mdx
@@ -35,41 +35,9 @@ go get github.com/browserbase/stagehand/packages/sdk-go
 ```
 </View>
 
-## 2) Run it
+## 2) Write the script
 
-Set your API keys as environment variables, then run the example script. Stagehand runs on Browserbase cloud browsers by default, so you need a `BROWSERBASE_API_KEY` plus a key for your model provider.
-
-<View title="TypeScript" icon="js">
-```bash
-export BROWSERBASE_API_KEY="bb_live_..." # Your Browserbase API key
-export OPENAI_API_KEY="sk-..."           # Your model provider key
-npx tsx index.ts                         # Run the example script
-```
-</View>
-
-<View title="Python" icon="python">
-```bash
-export BROWSERBASE_API_KEY="bb_live_..." # Your Browserbase API key
-export OPENAI_API_KEY="sk-..."           # Your model provider key
-python main.py                           # Run the example script
-```
-</View>
-
-<View title="Go" icon="golang">
-```bash
-export BROWSERBASE_API_KEY="bb_live_..." # Your Browserbase API key
-export OPENAI_API_KEY="sk-..."           # Your model provider key
-go run .                                 # Run the example script
-```
-</View>
-
-<Note>
-Stagehand never reads environment variables on your behalf. Read them in your own code and pass the values to the constructor, as shown below.
-</Note>
-
-## 3) Use Stagehand (act, extract, observe)
-
-Here is the full example script, exercising all three primitives:
+Create the example script (`index.ts`, `main.py`, or `main.go`). It exercises all three primitives: act, extract, and observe.
 
 <View title="TypeScript" icon="js">
 ```typescript
@@ -90,23 +58,26 @@ async function main() {
 
   console.log("Stagehand session started");
 
-  const page = await stagehand.context.activePage();
-  if (!page) throw new Error("Stagehand initialized without an active page");
+  try {
+    const page = await stagehand.context.activePage();
+    if (!page) throw new Error("Stagehand initialized without an active page");
 
-  await page.goto("https://stagehand.dev");
+    await page.goto("https://stagehand.dev");
 
-  const extractResult = await stagehand.extract(
-    "Extract the value proposition from the page.",
-    z.object({ valueProposition: z.string() }),
-  );
-  console.log("Extract result:\n", extractResult.data);
+    const extractResult = await stagehand.extract(
+      "Extract the value proposition from the page.",
+      z.object({ valueProposition: z.string() }),
+    );
+    console.log("Extract result:\n", extractResult.data);
 
-  await stagehand.act("Click the 'Evals' button.");
+    await stagehand.act("Click the 'Evals' button.");
 
-  const observeResult = await stagehand.observe("What can I click on this page?");
-  console.log("Observe result:\n", observeResult.data);
-
-  await stagehand.close();
+    const observeResult = await stagehand.observe("What can I click on this page?");
+    console.log("Observe result:\n", observeResult.data);
+  } finally {
+    // Always release the session, even when a step above throws
+    await stagehand.close();
+  }
 }
 
 main().catch((err) => {
@@ -141,24 +112,26 @@ async def main() -> None:
 
     print("Stagehand session started")
 
-    page = await stagehand.context.active_page()
-    if page is None:
-        raise RuntimeError("Stagehand initialized without an active page")
+    try:
+        page = await stagehand.context.active_page()
+        if page is None:
+            raise RuntimeError("Stagehand initialized without an active page")
 
-    await page.goto("https://stagehand.dev")
+        await page.goto("https://stagehand.dev")
 
-    extract_result = await stagehand.extract(
-        instruction="Extract the value proposition from the page.",
-        schema=ValueProposition,
-    )
-    print("Extract result:\n", extract_result.data)
+        extract_result = await stagehand.extract(
+            instruction="Extract the value proposition from the page.",
+            schema=ValueProposition,
+        )
+        print("Extract result:\n", extract_result.data)
 
-    await stagehand.act("Click the 'Evals' button.")
+        await stagehand.act("Click the 'Evals' button.")
 
-    observe_result = await stagehand.observe(instruction="What can I click on this page?")
-    print("Observe result:\n", observe_result.data)
-
-    await stagehand.close()
+        observe_result = await stagehand.observe(instruction="What can I click on this page?")
+        print("Observe result:\n", observe_result.data)
+    finally:
+        # Always release the session, even when a step above raises
+        await stagehand.close()
 
 
 asyncio.run(main())
@@ -259,6 +232,38 @@ func run(ctx context.Context) (err error) {
 
 	return nil
 }
+```
+</View>
+
+<Note>
+Stagehand never reads environment variables on your behalf. Read them in your own code and pass the values to the constructor, as the script above does.
+</Note>
+
+## 3) Run it
+
+Set your API keys as environment variables, then run the script. Stagehand runs on Browserbase cloud browsers by default, so you need a `BROWSERBASE_API_KEY` plus a key for your model provider.
+
+<View title="TypeScript" icon="js">
+```bash
+export BROWSERBASE_API_KEY="bb_live_..." # Your Browserbase API key
+export OPENAI_API_KEY="sk-..."           # Your model provider key
+npx tsx index.ts                         # Run the example script
+```
+</View>
+
+<View title="Python" icon="python">
+```bash
+export BROWSERBASE_API_KEY="bb_live_..." # Your Browserbase API key
+export OPENAI_API_KEY="sk-..."           # Your model provider key
+python main.py                           # Run the example script
+```
+</View>
+
+<View title="Go" icon="golang">
+```bash
+export BROWSERBASE_API_KEY="bb_live_..." # Your Browserbase API key
+export OPENAI_API_KEY="sk-..."           # Your model provider key
+go run .                                 # Run the example script
 ```
 </View>
 


### PR DESCRIPTION
# why

* We're getting to parity on the docs! So much more to cover

# what changed

* Adds WebMCP page
* Adds Go snippets to existing set of docs
* Adds back dropped content to match current state of v4
* Temporarily using a few v3 hrefs until v4 content is available to link to

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Go code samples and full TypeScript/Python/Go parity across v4 docs, plus a new WebMCP page and expanded First Steps aligned with the `@browserbasehq/stagehand` v4 API and runtime. Hardened Go snippets and new parity tests ensure examples match across languages; temporary v3 hrefs remain while v4 routing finalizes, advancing STG-2666.

- **New Features**
  - Go parity for `act`, `extract`, `observe`, Installation, Quickstart, and AI rules; examples use JSON Schema (Go), `zod` (TS), and Pydantic (Python).
  - New WebMCP page with `page.tools()` discovery and typed invocation; TypeScript, Python, and Go samples.
  - `act` accepts natural language or an `Action` from `observe`; expanded examples and supported functionality across pages.
  - Installation: Node 22.18+, Python 3.11+, Go 1.26+; Bun supported; no Playwright dependency.

- **Refactors**
  - Sidebar groups updated to “First Steps” and “The basics”; added WebMCP in `docs.json`; temporary v3 hrefs for missing v4 routes.
  - Tests now require each View group to have the same complete language set.
  - Hardened Go snippets; removed an out-of-scope second call; addressed review feedback.

<sup>Written for commit fadda675271e3e7f1bfc660ba2f5f6e9258c6ae7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



