### PR TITLE
Add configuration docs and update links

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -42,7 +42,12 @@
           },
           {
             "group": "Configuration",
-            "pages": ["v4/configuration/logging"]
+            "pages": [
+              "v4/configuration/browser",
+              "v4/configuration/models",
+              "v4/configuration/logging",
+              "v4/configuration/observability"
+            ]
           },
           {
             "group": "SDK reference",

--- a/packages/docs/v4/basics/webmcp.mdx
+++ b/packages/docs/v4/basics/webmcp.mdx
@@ -420,7 +420,7 @@ A tool invocation costs no LLM tokens and cannot pick the wrong element, so pref
   <Card title="Extract" icon="table" href="/v4/basics/extract">
     Pull typed, structured data off any page
   </Card>
-  <Card title="Browser configuration" icon="browser" href="/v3/configuration/browser">
+  <Card title="Browser configuration" icon="browser" href="/v4/configuration/browser">
     Launch flags, browser sources, and attaching over CDP
   </Card>
 </CardGroup>

--- a/packages/docs/v4/configuration/browser.mdx
+++ b/packages/docs/v4/configuration/browser.mdx
@@ -47,22 +47,13 @@ stagehand.New(stagehand.StagehandClientInitParams{
 
 Browserbase provides managed cloud browser infrastructure optimized for web automation at scale. It offers advanced features like stealth mode, proxy support, and persistent contexts. It is also the only browser source that supports [server-side caching](/v3/best-practices/caching) and the [Model Gateway](/v4/configuration/models#model-gateway).
 
-<Card icon="cloud" title="Browserbase" href="https://docs.browserbase.com" description="Explore the features and benefits of using Browserbase for scalable web automation.">
-  Discover the power of cloud-managed browser infrastructure with Browserbase.
+<Card icon="cloud" title="Browserbase" href="https://docs.browserbase.com" description="Session settings, proxies, stealth mode, and session recordings.">
+  Read the Browserbase documentation for the full set of session settings Stagehand passes through.
 </Card>
 
 ### Multi-region support
 
-Stagehand API is available in multiple regions to optimize latency and support data residency requirements. The SDK automatically routes requests to the correct regional API endpoint based on your browser session's region.
-
-| Region | API Endpoint |
-| --- | --- |
-| **us-west-2** (Default) | https://api.stagehand.browserbase.com |
-| **us-east-1** | https://api.use1.stagehand.browserbase.com |
-| **eu-central-1** | https://api.euc1.stagehand.browserbase.com |
-| **ap-southeast-1** | https://api.apse1.stagehand.browserbase.com |
-
-Configure your browser session region on the browser source:
+Browserbase runs browsers in four regions, so you can cut latency by starting the browser near your users or your target site, and keep session data in a required jurisdiction. Set the region on the browser source; `us-west-2` is the default.
 
 <View title="TypeScript" icon="js">
 ```typescript
@@ -112,10 +103,11 @@ if err := client.Init(ctx); err != nil {
 ```
 </View>
 
-<Warning>
-The API endpoint must match your browser session region. If there's a mismatch, you'll receive an error:
-`Session is in region 'X' but this API instance serves 'Y'. Please route your request to the X Stagehand API endpoint.`
-</Warning>
+Supported regions: `us-west-2` (default), `us-east-1`, `eu-central-1`, `ap-southeast-1`.
+
+<Note>
+  There is no regional endpoint to configure. Stagehand picks the API deployment that matches your session's region on its own, including for [server-side caching](/v3/best-practices/caching).
+</Note>
 
 ### Environment variables
 
@@ -187,7 +179,7 @@ if err := client.Init(ctx); err != nil {
 ```
 </View>
 
-{/* TODO: the Python SDK currently raises NotImplementedError for the Browserbase browser source. Verify before publishing. */}
+{/* TODO: every Browserbase Python View on this page fails at init(): sdk-python/src/stagehand/browser_source.py:70 raises NotImplementedError("Browserbase session creation is not implemented yet") for browser="browserbase", which is also the Python default. Affects the multi-region, basic setup, advanced configuration, accordion, and keep-alive Views. TypeScript (sdk-ts/src/browserSource.ts:52) and Go (sdk-go/browser_source.go:86) create sessions normally. Verify before publishing. */}
 
 #### Advanced configuration
 
@@ -483,7 +475,7 @@ if err := client.Init(ctx); err != nil {
 Stagehand never closes a browser it did not launch. With the `cdp` source, `close()` tears down the Stagehand connection and leaves the browser running.
 </Note>
 
-{/* TODO: custom CDP headers work in Go but are not yet threaded through the connection handshake in TypeScript or Python (Python raises NotImplementedError). Verify before publishing. */}
+{/* TODO: custom CDP headers only work in Go (sdk-go/browser_source.go:163 forwards them to the handshake). TypeScript accepts and resolves them (sdk-ts/src/browserSource.ts:83) then drops them: sdk-ts/src/stagehand.ts:88 is an explicit TODO and CDPClientOptions (sdk-ts/src/cdpClient.ts:30) has no headers field, so the header is silently ignored rather than failing. Python is worse: sdk-python/src/stagehand/browser_source.py:76 raises NotImplementedError("CDP headers are not implemented yet"), so the Python View fails at init() whenever headers is set. The cdp source itself works in all three languages without headers. Verify before publishing. */}
 
 ## Local environment
 
@@ -666,7 +658,11 @@ if err := client.Init(ctx); err != nil {
 ```
 </View>
 
-{/* TODO: the TypeScript launcher currently forwards only headless, devtools, userDataDir, and port to Chrome. The remaining launch options validate but are not yet applied. Verify before publishing. */}
+{/* TODO: the three languages diverge on this example.
+TypeScript: launches, but silently ignores most of these options. sdk-ts/src/browserSource.ts:88-106 forwards only userDataDir and port to chrome-launcher, and localBrowserChromeFlags (browserSource.ts:108-131) only translates ignoreDefaultArgs, headless, devtools, and args. Dropped: viewport (--window-size is hardcoded to 1280,800 at browserSource.ts:22), executablePath (getChromePath() is called instead at browserSource.ts:93), chromiumSandbox (--no-sandbox only when CI is set, browserSource.ts:128), ignoreHTTPSErrors, locale, deviceScaleFactor, hasTouch, proxy, downloadsPath, acceptDownloads, preserveUserDataDir, and connectTimeoutMs. All validate against LocalBrowserLaunchOptionsSchema (protocol/schemas.ts:972), so there is no error, just no effect.
+Python: fails at init(). sdk-python/src/stagehand/browser_source.py:84 raises NotImplementedError for proxy_username / proxy_password, and :86 raises for downloads_path / accept_downloads. Everything else in this View is honored.
+Go: fails at Init(). sdk-go/chrome_launcher.go:200 rejects authenticated proxies and :204 rejects DownloadsPath / AcceptDownloads in validateLocalBrowserOptions, before Chrome launches. Everything else in this View is honored by buildChromeArgs (chrome_launcher.go:209).
+Verify before publishing. */}
 
 #### Default local launch arguments
 
@@ -705,6 +701,8 @@ When Stagehand launches a local browser, it adds the following Chrome arguments 
 <Note>
 `--enable-unsafe-extension-debugging` is required: Stagehand runs as a browser extension and needs the debugger to reach its service worker.
 </Note>
+
+{/* TODO: all three lists omit a fourth flag that every SDK also prepends unconditionally: --enable-features=WebMCPTesting,DevToolsWebMCPSupport (sdk-ts/src/browserSource.ts:17-24, sdk-python/src/stagehand/browser_source.py:16 and :156, sdk-go/chrome_launcher.go:219). Also note --window-size is only 1280,800 when no viewport is set in Python and Go; in TypeScript it is hardcoded. Decide whether to surface the WebMCP flag here or cross-reference the WebMCP page. Verify before publishing. */}
 
 A larger set of standard Chrome automation flags (disabling background networking, component updates, sync, translation, and similar) is prepended as well. To remove some of them, list the exact flags in the ignore-default-args option:
 

--- a/packages/docs/v4/configuration/browser.mdx
+++ b/packages/docs/v4/configuration/browser.mdx
@@ -1,0 +1,1142 @@
+---
+title: Browser
+sidebarTitle: Browser
+description: Configure Stagehand on Browserbase or locally
+---
+
+Stagehand connects to a browser through a browser source. There are three:
+
+- **Browserbase (default):** Cloud-managed browser infrastructure optimized for production web automation at scale
+- **Local:** Run browsers directly on your machine for development and debugging
+- **CDP:** Attach to any Chromium browser you are already running, by URL
+
+<View title="TypeScript" icon="js">
+```typescript
+new Stagehand({ apiKey: process.env.BROWSERBASE_API_KEY, browser: { type: "browserbase" } }); // default
+new Stagehand({ browser: { type: "local", headless: true } });
+new Stagehand({ browser: { type: "cdp", cdpUrl: "http://127.0.0.1:9222" } });
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+Stagehand(api_key=os.environ["BROWSERBASE_API_KEY"], browser="browserbase")  # default
+Stagehand(browser="local", headless=True)
+Stagehand(browser="cdp", cdp_url="http://127.0.0.1:9222")
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+apiKey := os.Getenv("BROWSERBASE_API_KEY")
+
+stagehand.New(stagehand.StagehandClientInitParams{ // default
+	APIKey:  &apiKey,
+	Browser: stagehand.BrowserbaseClientBrowserSource{},
+})
+stagehand.New(stagehand.StagehandClientInitParams{
+	Browser: stagehand.LocalBrowserSource{Headless: true},
+})
+stagehand.New(stagehand.StagehandClientInitParams{
+	Browser: stagehand.CDPBrowserSource{CDPURL: "http://127.0.0.1:9222"},
+})
+```
+</View>
+
+## Browserbase environment
+
+Browserbase provides managed cloud browser infrastructure optimized for web automation at scale. It offers advanced features like stealth mode, proxy support, and persistent contexts. It is also the only browser source that supports [server-side caching](/v3/best-practices/caching) and the [Model Gateway](/v4/configuration/models#model-gateway).
+
+<Card icon="cloud" title="Browserbase" href="https://docs.browserbase.com" description="Explore the features and benefits of using Browserbase for scalable web automation.">
+  Discover the power of cloud-managed browser infrastructure with Browserbase.
+</Card>
+
+### Multi-region support
+
+Stagehand API is available in multiple regions to optimize latency and support data residency requirements. The SDK automatically routes requests to the correct regional API endpoint based on your browser session's region.
+
+| Region | API Endpoint |
+| --- | --- |
+| **us-west-2** (Default) | https://api.stagehand.browserbase.com |
+| **us-east-1** | https://api.use1.stagehand.browserbase.com |
+| **eu-central-1** | https://api.euc1.stagehand.browserbase.com |
+| **ap-southeast-1** | https://api.apse1.stagehand.browserbase.com |
+
+Configure your browser session region on the browser source:
+
+<View title="TypeScript" icon="js">
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  browser: {
+    type: "browserbase",
+    region: "eu-central-1", // Browser runs in Frankfurt
+  },
+});
+
+await stagehand.init();
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+from stagehand import Stagehand
+
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    browser="browserbase",
+    region="eu-central-1",  # Browser runs in Frankfurt
+)
+
+await stagehand.init()
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+apiKey := os.Getenv("BROWSERBASE_API_KEY")
+region := stagehand.BrowserbaseRegionEUCentral1 // Browser runs in Frankfurt
+
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey: &apiKey,
+	Browser: stagehand.BrowserbaseClientBrowserSource{
+		Region: &region,
+	},
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+```
+</View>
+
+<Warning>
+The API endpoint must match your browser session region. If there's a mismatch, you'll receive an error:
+`Session is in region 'X' but this API instance serves 'Y'. Please route your request to the X Stagehand API endpoint.`
+</Warning>
+
+### Environment variables
+
+Before getting started, set up the required environment variables:
+
+<View title="TypeScript" icon="js">
+```bash
+export BROWSERBASE_API_KEY=your_api_key_here
+```
+</View>
+
+<View title="Python" icon="python">
+```bash
+export BROWSERBASE_API_KEY=your_api_key_here
+```
+</View>
+
+<View title="Go" icon="golang">
+```bash
+export BROWSERBASE_API_KEY=your_api_key_here
+```
+</View>
+
+<Tip>
+Get your API key from the [Browserbase Dashboard](https://browserbase.com/overview). Stagehand does not read this variable for you: read it in your own code and pass it as the top-level `apiKey`.
+</Tip>
+
+### Using Stagehand with Browserbase
+
+#### Basic setup
+
+The simplest way to get started is with default settings. Browserbase is the default browser source, so a top-level Browserbase API key is all you need:
+
+<View title="TypeScript" icon="js">
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+});
+
+await stagehand.init();
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+from stagehand import Stagehand
+
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+)
+
+await stagehand.init()
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+apiKey := os.Getenv("BROWSERBASE_API_KEY")
+
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey: &apiKey,
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+```
+</View>
+
+{/* TODO: the Python SDK currently raises NotImplementedError for the Browserbase browser source. Verify before publishing. */}
+
+#### Advanced configuration
+
+Configure browser settings, proxy support, and other session parameters directly on the browser source:
+
+<View title="TypeScript" icon="js">
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  browser: {
+    type: "browserbase",
+    proxies: true,
+    region: "us-west-2",
+    browserSettings: {
+      viewport: { width: 1920, height: 1080 },
+      blockAds: true,
+    },
+  },
+});
+
+await stagehand.init();
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+from stagehand import BrowserbaseBrowserSettings, Stagehand
+
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    browser="browserbase",
+    proxies=True,
+    region="us-west-2",
+    browser_settings=BrowserbaseBrowserSettings.model_validate({
+        "viewport": {"width": 1920, "height": 1080},
+        "block_ads": True,
+    }),
+)
+
+await stagehand.init()
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+apiKey := os.Getenv("BROWSERBASE_API_KEY")
+region := stagehand.BrowserbaseRegionUSWest2
+proxies := stagehand.BrowserbaseProxyEnabled(true)
+blockAds := true
+width, height := 1920.0, 1080.0
+
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey: &apiKey,
+	Browser: stagehand.BrowserbaseClientBrowserSource{
+		Proxies: &proxies,
+		Region:  &region,
+		BrowserSettings: &stagehand.BrowserbaseBrowserSettings{
+			Viewport: &stagehand.BrowserbaseViewport{Width: &width, Height: &height},
+			BlockAds: &blockAds,
+		},
+	},
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+```
+</View>
+
+<Accordion title="Advanced Browserbase configuration example">
+
+<View title="TypeScript" icon="js">
+```typescript
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  browser: {
+    type: "browserbase",
+    proxies: true,
+    region: "us-west-2",
+    timeout: 3600, // 1 hour session timeout
+    keepAlive: true, // Available on Startup plan
+    browserSettings: {
+      verified: false, // this is a Scale Plan feature - reach out to support@browserbase.com to enable
+      blockAds: true,
+      solveCaptchas: true,
+      recordSession: false,
+      viewport: {
+        width: 1920,
+        height: 1080,
+      },
+    },
+    userMetadata: {
+      userId: "automation-user-123",
+      environment: "production",
+    },
+  },
+});
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    browser="browserbase",
+    proxies=True,
+    region="us-west-2",
+    timeout=3600,  # 1 hour session timeout
+    keep_alive=True,  # Available on Startup plan
+    browser_settings=BrowserbaseBrowserSettings.model_validate({
+        # verified is a Scale Plan feature: contact support@browserbase.com to enable
+        "verified": False,
+        "block_ads": True,
+        "solve_captchas": True,
+        "record_session": False,
+        "viewport": {"width": 1920, "height": 1080},
+    }),
+    user_metadata={
+        "user_id": "automation-user-123",
+        "environment": "production",
+    },
+)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+apiKey := os.Getenv("BROWSERBASE_API_KEY")
+region := stagehand.BrowserbaseRegionUSWest2
+proxies := stagehand.BrowserbaseProxyEnabled(true)
+timeout := 3600.0 // 1 hour session timeout
+keepAlive := true // Available on Startup plan
+
+// verified is a Scale Plan feature: contact support@browserbase.com to enable
+verified := false
+blockAds := true
+solveCaptchas := true
+recordSession := false
+width, height := 1920.0, 1080.0
+
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey: &apiKey,
+	Browser: stagehand.BrowserbaseClientBrowserSource{
+		Proxies:   &proxies,
+		Region:    &region,
+		Timeout:   &timeout,
+		KeepAlive: &keepAlive,
+		BrowserSettings: &stagehand.BrowserbaseBrowserSettings{
+			Verified:      &verified,
+			BlockAds:      &blockAds,
+			SolveCaptchas: &solveCaptchas,
+			RecordSession: &recordSession,
+			Viewport:      &stagehand.BrowserbaseViewport{Width: &width, Height: &height},
+		},
+		UserMetadata: map[string]json.RawMessage{
+			"userId":      json.RawMessage(`"automation-user-123"`),
+			"environment": json.RawMessage(`"production"`),
+		},
+	},
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+defer func() { err = errors.Join(err, client.Close(ctx)) }()
+```
+</View>
+</Accordion>
+
+<Note>
+Stagehand provisions its own browser extension on every Browserbase session, so the `extensionId` session setting is not available on the Browserbase browser source.
+</Note>
+
+### Alternative: Browserbase SDK
+
+If you prefer to manage sessions directly, create the session with the Browserbase SDK and hand Stagehand the resulting connect URL through the `cdp` browser source:
+
+<View title="TypeScript" icon="js">
+```typescript
+import { Browserbase } from "@browserbasehq/sdk";
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const bb = new Browserbase({
+  apiKey: process.env.BROWSERBASE_API_KEY!,
+});
+
+const session = await bb.sessions.create({
+  projectId: process.env.BROWSERBASE_PROJECT_ID!,
+  // Add configuration options here
+});
+
+const stagehand = new Stagehand({
+  browser: { type: "cdp", cdpUrl: session.connectUrl },
+});
+
+await stagehand.init();
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+from browserbase import Browserbase
+
+from stagehand import Stagehand
+
+bb = Browserbase(api_key=os.environ["BROWSERBASE_API_KEY"])
+
+session = bb.sessions.create(
+    project_id=os.environ["BROWSERBASE_PROJECT_ID"],
+    # Add configuration options here
+)
+
+stagehand = Stagehand(
+    browser="cdp",
+    cdp_url=session.connect_url,
+)
+
+await stagehand.init()
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+// Create the session with your Browserbase client of choice, then hand
+// Stagehand the resulting connect URL.
+connectURL, err := createBrowserbaseSession(ctx)
+if err != nil {
+	return err
+}
+
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	Browser: stagehand.CDPBrowserSource{CDPURL: connectURL},
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+```
+</View>
+
+#### Connecting to an existing session
+
+The `cdp` browser source attaches to any Chromium browser that is already running and exposing a DevTools endpoint, whether that is a Browserbase session you created earlier or a browser on your own machine:
+
+<View title="TypeScript" icon="js">
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const stagehand = new Stagehand({
+  browser: {
+    type: "cdp",
+    cdpUrl: "wss://connect.browserbase.com/?apiKey=...&sessionId=...",
+    headers: { "x-my-header": "value" },
+  },
+});
+
+await stagehand.init();
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+from stagehand import Stagehand
+
+stagehand = Stagehand(
+    browser="cdp",
+    cdp_url=connect_url,  # from your Browserbase session
+    headers={"x-my-header": "value"},
+)
+
+await stagehand.init()
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	Browser: stagehand.CDPBrowserSource{
+		CDPURL:  "wss://connect.browserbase.com/?apiKey=...&sessionId=...",
+		Headers: map[string]string{"x-my-header": "value"},
+	},
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+```
+</View>
+
+<Note>
+Stagehand never closes a browser it did not launch. With the `cdp` source, `close()` tears down the Stagehand connection and leaves the browser running.
+</Note>
+
+{/* TODO: custom CDP headers work in Go but are not yet threaded through the connection handshake in TypeScript or Python (Python raises NotImplementedError). Verify before publishing. */}
+
+## Local environment
+
+The local environment runs browsers directly on your machine, providing full control over browser instances and configurations. Ideal for development, debugging, and scenarios requiring custom browser setups.
+
+### Environment comparison
+
+| Feature | Browserbase | Local |
+| --- | --- | --- |
+| **Scalability** | High (cloud-managed) | Limited (local resources) |
+| **Stealth Features** | Advanced fingerprinting | Basic stealth |
+| **Proxy Support** | Built-in residential proxies | Manual configuration |
+| **Session Persistence** | Cloud context storage | File-based user data |
+| **Geographic Distribution** | Multi-region deployment | Single machine |
+| **Debugging** | Session recordings & logs | Direct DevTools access |
+| **Setup Complexity** | API key only | Browser installation required |
+| **Server-side caching** | Supported | Not available |
+| **Model Gateway** | Supported | Not available |
+| **Cost** | Usage-based pricing | Infrastructure & maintenance |
+| **Best For** | Production, scale, compliance | Development, debugging |
+
+### Basic local setup
+
+<View title="TypeScript" icon="js">
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const stagehand = new Stagehand({
+  browser: { type: "local" },
+});
+
+await stagehand.init();
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+from stagehand import Stagehand
+
+stagehand = Stagehand(browser="local")
+
+await stagehand.init()
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	Browser: stagehand.LocalBrowserSource{},
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+```
+</View>
+
+### Advanced local configuration
+
+Customize browser launch options for local development:
+
+<View title="TypeScript" icon="js">
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const stagehand = new Stagehand({
+  browser: {
+    type: "local",
+    headless: false, // Show browser window
+    devtools: true, // Open developer tools
+    viewport: { width: 1280, height: 720 },
+    executablePath: "/opt/google/chrome/chrome", // Custom Chrome path
+    port: 9222, // Fixed CDP debugging port
+    ignoreDefaultArgs: [
+      "--disable-sync",
+    ], // Remove specific default launch args
+    args: [
+      "--disable-web-security",
+      "--allow-running-insecure-content",
+    ],
+    userDataDir: "./chrome-user-data", // Persist browser data
+    preserveUserDataDir: true, // Keep data after closing
+    chromiumSandbox: false, // Disable sandbox (adds --no-sandbox)
+    ignoreHTTPSErrors: true, // Ignore certificate errors
+    locale: "en-US", // Set browser language
+    deviceScaleFactor: 1.0, // Display scaling
+    hasTouch: false, // Emulate touch input
+    proxy: {
+      server: "http://proxy.example.com:8080",
+      username: "user",
+      password: "pass",
+    },
+    downloadsPath: "./downloads", // Download directory
+    acceptDownloads: true, // Allow downloads
+    connectTimeoutMs: 30000, // Connection timeout
+  },
+});
+
+await stagehand.init();
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+from stagehand import Stagehand
+
+stagehand = Stagehand(
+    browser="local",
+    headless=False,  # Show browser window
+    devtools=True,  # Open developer tools
+    viewport_width=1280,
+    viewport_height=720,
+    executable_path="/opt/google/chrome/chrome",  # Custom Chrome path
+    port=9222,  # Fixed CDP debugging port
+    ignore_default_args=["--disable-sync"],  # Remove specific default launch args
+    args=[
+        "--disable-web-security",
+        "--allow-running-insecure-content",
+    ],
+    user_data_dir="./chrome-user-data",  # Persist browser data
+    preserve_user_data_dir=True,  # Keep data after closing
+    chromium_sandbox=False,  # Disable sandbox (adds --no-sandbox)
+    ignore_https_errors=True,  # Ignore certificate errors
+    locale="en-US",  # Set browser language
+    device_scale_factor=1.0,  # Display scaling
+    has_touch=False,  # Emulate touch input
+    proxy_server="http://proxy.example.com:8080",
+    proxy_username="user",
+    proxy_password="pass",
+    downloads_path="./downloads",  # Download directory
+    accept_downloads=True,  # Allow downloads
+    connect_timeout_ms=30000,  # Connection timeout
+)
+
+await stagehand.init()
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+chromiumSandbox := false // Disable sandbox (adds --no-sandbox)
+acceptDownloads := true  // Allow downloads
+deviceScaleFactor := 1.0 // Display scaling
+
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	Browser: stagehand.LocalBrowserSource{
+		Headless:       false,                            // Show browser window
+		Devtools:       true,                             // Open developer tools
+		Viewport:       &stagehand.LocalViewport{Width: 1280, Height: 720},
+		ExecutablePath: "/opt/google/chrome/chrome",      // Custom Chrome path
+		Port:           9222,                             // Fixed CDP debugging port
+		IgnoreDefaultArgs: &stagehand.IgnoreDefaultArgs{ // Remove specific default launch args
+			Args: []string{"--disable-sync"},
+		},
+		Args: []string{
+			"--disable-web-security",
+			"--allow-running-insecure-content",
+		},
+		UserDataDir:         "./chrome-user-data", // Persist browser data
+		PreserveUserDataDir: true,                 // Keep data after closing
+		ChromiumSandbox:     &chromiumSandbox,
+		IgnoreHTTPSErrors:   true,     // Ignore certificate errors
+		Locale:              "en-US",  // Set browser language
+		DeviceScaleFactor:   &deviceScaleFactor,
+		HasTouch:            false,    // Emulate touch input
+		Proxy: &stagehand.LocalProxyConfig{
+			Server:   "http://proxy.example.com:8080",
+			Username: "user",
+			Password: "pass",
+		},
+		DownloadsPath:    "./downloads", // Download directory
+		AcceptDownloads:  &acceptDownloads,
+		ConnectTimeoutMs: 30000, // Connection timeout
+	},
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+```
+</View>
+
+{/* TODO: the TypeScript launcher currently forwards only headless, devtools, userDataDir, and port to Chrome. The remaining launch options validate but are not yet applied. Verify before publishing. */}
+
+#### Default local launch arguments
+
+When Stagehand launches a local browser, it adds the following Chrome arguments before any values you pass in the launch `args`:
+
+<View title="TypeScript" icon="js">
+```typescript
+[
+  "--enable-unsafe-extension-debugging",
+  "--remote-allow-origins=*",
+  "--window-size=1280,800",
+]
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+[
+    "--enable-unsafe-extension-debugging",
+    "--remote-allow-origins=*",
+    "--window-size=1280,800",
+]
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+[]string{
+	"--enable-unsafe-extension-debugging",
+	"--remote-allow-origins=*",
+	"--window-size=1280,800",
+}
+```
+</View>
+
+<Note>
+`--enable-unsafe-extension-debugging` is required: Stagehand runs as a browser extension and needs the debugger to reach its service worker.
+</Note>
+
+A larger set of standard Chrome automation flags (disabling background networking, component updates, sync, translation, and similar) is prepended as well. To remove some of them, list the exact flags in the ignore-default-args option:
+
+<View title="TypeScript" icon="js">
+```typescript
+const stagehand = new Stagehand({
+  browser: {
+    type: "local",
+    ignoreDefaultArgs: ["--disable-sync"],
+    args: [
+      "--disable-features=site-per-process,IsolateOrigins",
+      "--renderer-process-limit=6",
+    ],
+  },
+});
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+stagehand = Stagehand(
+    browser="local",
+    ignore_default_args=["--disable-sync"],
+    args=[
+        "--disable-features=site-per-process,IsolateOrigins",
+        "--renderer-process-limit=6",
+    ],
+)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	Browser: stagehand.LocalBrowserSource{
+		IgnoreDefaultArgs: &stagehand.IgnoreDefaultArgs{
+			Args: []string{"--disable-sync"},
+		},
+		Args: []string{
+			"--disable-features=site-per-process,IsolateOrigins",
+			"--renderer-process-limit=6",
+		},
+	},
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+defer func() { err = errors.Join(err, client.Close(ctx)) }()
+```
+</View>
+
+Set the ignore-default-args option to `true` to remove all default arguments. Use a list to remove only exact matches while preserving the rest.
+
+## Advanced configuration
+
+### Keep alive
+
+The keep-alive option controls whether the browser remains running after `close()` is called.
+
+By default, Stagehand terminates the browser it launched and cleans up all resources when it shuts down. Turning keep-alive on keeps the browser running independently so you can reconnect to it later.
+
+<View title="TypeScript" icon="js">
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  browser: { type: "browserbase", keepAlive: true },
+});
+
+await stagehand.init();
+
+// The browser session continues running after close()
+await stagehand.close();
+
+// Later, reconnect to the same session over CDP
+const stagehand2 = new Stagehand({
+  browser: { type: "cdp", cdpUrl: existingConnectUrl },
+});
+await stagehand2.init();
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+from stagehand import Stagehand
+
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    browser="browserbase",
+    keep_alive=True,
+)
+
+await stagehand.init()
+
+# The browser session continues running after close()
+await stagehand.close()
+
+# Later, reconnect to the same session over CDP
+stagehand2 = Stagehand(browser="cdp", cdp_url=existing_connect_url)
+await stagehand2.init()
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+apiKey := os.Getenv("BROWSERBASE_API_KEY")
+keepAlive := true
+
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey: &apiKey,
+	Browser: stagehand.BrowserbaseClientBrowserSource{
+		KeepAlive: &keepAlive,
+	},
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+
+// The browser session continues running after Close()
+if err := client.Close(ctx); err != nil {
+	return err
+}
+
+// Later, reconnect to the same session over CDP
+client2 := stagehand.New(stagehand.StagehandClientInitParams{
+	Browser: stagehand.CDPBrowserSource{CDPURL: existingConnectURL},
+})
+if err := client2.Init(ctx); err != nil {
+	return err
+}
+```
+</View>
+
+#### Behavior by environment
+
+| Behavior | keep-alive on | keep-alive off (default) |
+| --- | --- | --- |
+| **Browserbase** | Session stays active after `close()` | Session is terminated via API |
+| **Local** | Chrome process continues running | Chrome process is killed and temp profile is removed |
+| **CDP** | Always left running | Always left running (Stagehand never owns the browser) |
+
+#### Local environment
+
+When running locally with keep-alive on, Stagehand leaves the Chrome process running when your script exits. This is useful for debugging or for handing off a browser session to another process. Combine it with a fixed `port` so you can reattach with the `cdp` source.
+
+<View title="TypeScript" icon="js">
+```typescript
+const stagehand = new Stagehand({
+  browser: {
+    type: "local",
+    keepAlive: true,
+    headless: false,
+    port: 9222,
+  },
+});
+
+await stagehand.init();
+const page = await stagehand.context.activePage();
+if (!page) {
+  throw new Error("Stagehand initialized without an active page");
+}
+await page.goto("https://example.com");
+
+// Browser window stays open after the script exits
+await stagehand.close();
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+stagehand = Stagehand(
+    browser="local",
+    keep_alive=True,
+    headless=False,
+    port=9222,
+)
+
+await stagehand.init()
+page = await stagehand.context.active_page()
+if page is None:
+    raise RuntimeError("Stagehand initialized without an active page")
+await page.goto("https://example.com")
+
+# Browser window stays open after the script exits
+await stagehand.close()
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	Browser: stagehand.LocalBrowserSource{
+		KeepAlive: true,
+		Headless:  false,
+		Port:      9222,
+	},
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+
+browserContext, err := client.Context()
+if err != nil {
+	return err
+}
+page, err := browserContext.ActivePage(ctx)
+if err != nil {
+	return err
+}
+if page == nil {
+	return errors.New("Stagehand initialized without an active page")
+}
+if err := page.Goto(ctx, "https://example.com", nil); err != nil {
+	return err
+}
+
+// Browser window stays open after the program exits
+return client.Close(ctx)
+```
+</View>
+
+<Note>
+A temporary user data directory is deleted when a local browser shuts down. Set `userDataDir` (or turn on the preserve option) if you want the profile to survive.
+</Note>
+
+#### Browserbase environment
+
+On Browserbase, keep-alive keeps the cloud session active so you can reconnect later with the `cdp` browser source. This is useful for long-running workflows that span multiple script executions.
+
+<Note>
+Keeping sessions alive is available on the Browserbase Startup plan and above.
+</Note>
+
+### Fixed CDP debugging port
+
+Specify a fixed Chrome DevTools Protocol (CDP) debugging port instead of using a randomly assigned one.
+
+<View title="TypeScript" icon="js">
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const stagehand = new Stagehand({
+  browser: {
+    type: "local",
+    port: 9222,
+  },
+});
+
+await stagehand.init();
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+from stagehand import Stagehand
+
+stagehand = Stagehand(
+    browser="local",
+    port=9222,
+)
+
+await stagehand.init()
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	Browser: stagehand.LocalBrowserSource{
+		Port: 9222,
+	},
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+```
+</View>
+
+<Tip>
+If no port is specified, a random free port will be assigned.
+</Tip>
+
+### DOM settle timeout
+
+Configure how long Stagehand waits for the DOM to stabilize before taking actions. The default is 5000 ms.
+
+<View title="TypeScript" icon="js">
+```typescript
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  domSettleTimeoutMs: 3000, // Wait up to 3 seconds for DOM to settle
+});
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    dom_settle_timeout_ms=3000,  # Wait up to 3 seconds for DOM to settle
+)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+apiKey := os.Getenv("BROWSERBASE_API_KEY")
+domSettleTimeoutMs := 3000 // Wait up to 3 seconds for DOM to settle
+
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey:             &apiKey,
+	DOMSettleTimeoutMs: &domSettleTimeoutMs,
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+defer func() { err = errors.Join(err, client.Close(ctx)) }()
+```
+</View>
+
+<Note>
+DOM settling applies to `act()`. `observe()` and `extract()` read a snapshot of the page as they find it.
+</Note>
+
+#### What is DOM settling?
+
+DOM settling ensures that:
+- **Animations complete** before interacting with elements
+- **Lazy-loaded content** has time to appear
+- **JavaScript updates** finish before actions are taken
+- **Dynamic content** is fully rendered
+
+#### When to adjust
+
+Increase the DOM settle timeout for pages with:
+- Heavy animations or transitions
+- Lazy-loading or infinite scroll
+- Dynamic JavaScript frameworks (React, Vue, Angular)
+- Complex single-page applications
+
+<View title="TypeScript" icon="js">
+```typescript
+// For fast, static pages
+const fast = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  domSettleTimeoutMs: 500, // Minimal wait
+});
+
+// For dynamic, animated pages
+const dynamic = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  domSettleTimeoutMs: 5000, // Longer wait for stability
+});
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+# For fast, static pages
+fast = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    dom_settle_timeout_ms=500,  # Minimal wait
+)
+
+# For dynamic, animated pages
+dynamic = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    dom_settle_timeout_ms=5000,  # Longer wait for stability
+)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+apiKey := os.Getenv("BROWSERBASE_API_KEY")
+
+// For fast, static pages
+fastSettle := 500 // Minimal wait
+fast := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey:             &apiKey,
+	DOMSettleTimeoutMs: &fastSettle,
+})
+
+// For dynamic, animated pages
+slowSettle := 5000 // Longer wait for stability
+dynamic := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey:             &apiKey,
+	DOMSettleTimeoutMs: &slowSettle,
+})
+
+// Pick the client that matches the pages you are about to automate
+client := fast
+if os.Getenv("PAGE_PROFILE") == "dynamic" {
+	client = dynamic
+}
+if err := client.Init(ctx); err != nil {
+	return err
+}
+defer func() { err = errors.Join(err, client.Close(ctx)) }()
+```
+</View>
+
+<Warning>
+Setting the DOM settle timeout too low may cause actions to fail on elements that aren't ready. Setting it too high increases execution time unnecessarily.
+</Warning>
+
+## Troubleshooting
+
+<AccordionGroup>
+<Accordion title="Browserbase authentication errors">
+- Verify your `BROWSERBASE_API_KEY` is read and passed as the top-level `apiKey`
+- Check that your API key has the necessary permissions
+- Ensure your Browserbase account has sufficient credits
+- Remember that the Browserbase browser source requires an API key: initialization fails without one
+</Accordion>
+
+<Accordion title="Local browser launch failures">
+- Install Chrome or Chromium on your system
+- Set the correct executable path for your Chrome installation, or set `CHROME_PATH`
+- Check that required dependencies are installed (Linux: `libnss3-dev libatk-bridge2.0-dev libgtk-3-dev libxss1 libasound2`)
+- If the extension fails to load, confirm nothing is stripping `--enable-unsafe-extension-debugging` from the launch arguments
+</Accordion>
+
+<Accordion title="Session timeout issues">
+- Increase the session timeout on the Browserbase browser source
+- Turn on keep-alive for long-running sessions
+- Monitor session usage to avoid unexpected terminations
+</Accordion>
+</AccordionGroup>

--- a/packages/docs/v4/configuration/logging.mdx
+++ b/packages/docs/v4/configuration/logging.mdx
@@ -3,73 +3,827 @@ title: "Logging"
 description: "Control terminal output and forward structured Stagehand logs."
 ---
 
-Stagehand writes `info`, `warn`, and `error` logs to stderr by default. In `pretty` format,
-each event is rendered as a single line:
+Stagehand provides comprehensive logging capabilities to help you debug automation workflows, track execution, and diagnose issues. Configure logging levels, structured output, and debugging tools for both development and production environments.
 
-```text
-[stagehand] INFO Starting observation {"category":"observation","instruction":"Find the Learn more link"}
-```
+All logging is configured through a single `logging` option on the constructor. Use the language selector to see the exact shape your SDK accepts: some expose a level and an output format alongside the record callback, others hand you the record stream and let you filter and format it yourself.
 
-## Configure terminal output
+## Quick start
 
-Set `level` to control which logs Stagehand sends from the runtime. Set `format` to choose
-human-readable or newline-delimited JSON terminal output.
+Choose your logging setup based on your environment:
 
 <View title="TypeScript" icon="js">
-
 ```typescript
 import { Stagehand } from "@browserbasehq/stagehand";
 
-const stagehand = new Stagehand({
-  // ...
+// Development: full debug output, human-readable
+const development = new Stagehand({
+  browser: { type: "local" },
+  logging: { level: "debug", format: "pretty" },
+  // restOfYourConfiguration...
+});
+
+// Production: standard logging, machine-readable, forwarded to your platform
+const production = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
   logging: {
     level: "info",
-    format: "pretty",
+    format: "json",
+    onLog: yourProductionLogger, // Send to Sentry, DataDog, or similar
   },
+  // restOfYourConfiguration...
+});
+
+// Testing: warnings and errors only, no console noise
+const testing = new Stagehand({
+  browser: { type: "local" },
+  logging: { level: "warn", onLog: yourTestLogger },
+  // restOfYourConfiguration...
 });
 ```
+</View>
 
-| Option   | Default  | Values                                  |
-| -------- | -------- | --------------------------------------- |
-| `level`  | `info`   | `debug`, `info`, `warn`, `error`, `off` |
-| `format` | `pretty` | `pretty`, `json`                        |
+<View title="Python" icon="python">
+```python
+from stagehand import Stagehand, StagehandClientLoggingConfig
 
-`format` only changes the built-in terminal output. It does not change structured logs passed
-to a callback.
+# Development: full debug output, human-readable
+development = Stagehand(
+    browser="local",
+    logging=StagehandClientLoggingConfig(level="debug", format="pretty"),
+    # rest_of_your_configuration...
+)
 
-## Forward structured logs
+# Production: standard logging, machine-readable, forwarded to your platform
+production = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    logging=StagehandClientLoggingConfig(
+        level="info",
+        format="json",
+        on_log=your_production_logger,  # Send to Sentry, DataDog, or similar
+    ),
+    # rest_of_your_configuration...
+)
 
-Use `onLog` to send each displayed log to a file or your application logger. The callback is
-additive: Stagehand continues to write its normal terminal output.
+# Testing: warnings and errors only, no console noise
+testing = Stagehand(
+    browser="local",
+    logging=StagehandClientLoggingConfig(level="warn", on_log=your_test_logger),
+    # rest_of_your_configuration...
+)
+```
+</View>
 
+<View title="Go" icon="golang">
+```go
+// The Go SDK exposes a single OnLog callback: you own filtering and formatting.
+// Development: print everything, human-readable
+development := stagehand.New(stagehand.StagehandClientInitParams{
+	Browser: stagehand.LocalBrowserSource{},
+	Logging: &stagehand.StagehandClientLoggingConfig{
+		OnLog: func(entry stagehand.StagehandLog) {
+			fmt.Fprintf(os.Stderr, "[stagehand] %s %s %v\n", entry.Level, entry.Message, entry.Data)
+		},
+	},
+	// restOfYourConfiguration...
+})
+
+// Production: machine-readable, forwarded to your platform
+production := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey: &apiKey,
+	Logging: &stagehand.StagehandClientLoggingConfig{
+		OnLog: yourProductionLogger, // Send to Sentry, DataDog, or similar
+	},
+	// restOfYourConfiguration...
+})
+
+// Testing: warnings and errors only, no console noise
+testing := stagehand.New(stagehand.StagehandClientInitParams{
+	Browser: stagehand.LocalBrowserSource{},
+	Logging: &stagehand.StagehandClientLoggingConfig{
+		OnLog: func(entry stagehand.StagehandLog) {
+			if entry.Level == stagehand.StagehandLogLevelWarn || entry.Level == stagehand.StagehandLogLevelError {
+				yourTestLogger(entry)
+			}
+		},
+	},
+	// restOfYourConfiguration...
+})
+
+// Pick the client that matches the environment you are running in
+client := development
+switch os.Getenv("APP_ENV") {
+case "production":
+	client = production
+case "test":
+	client = testing
+}
+if err := client.Init(ctx); err != nil {
+	return err
+}
+defer func() { err = errors.Join(err, client.Close(ctx)) }()
+```
+</View>
+
+---
+
+## Operational logging
+
+Real-time event logging during automation execution.
+
+### Verbosity level
+
+Control how much detail you see in logs. The level is always applied at the source, so the Stagehand runtime never generates or sends a record below your threshold.
+
+<Tabs>
+<Tab title="Level: debug">
+**Use for:** Development, debugging specific issues
+
+<View title="TypeScript" icon="js">
 ```typescript
-import { createWriteStream } from "node:fs";
-import { Stagehand } from "@browserbasehq/stagehand";
-
-const logFile = createWriteStream("stagehand.jsonl", { flags: "a" });
-
 const stagehand = new Stagehand({
-  // ...
+  logging: { level: "debug" }, // Maximum detail
+  // restOfYourConfiguration...
+});
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+stagehand = Stagehand(
+    logging=StagehandClientLoggingConfig(level="debug"),  # Maximum detail
+    # rest_of_your_configuration...
+)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+// Go delivers every record to OnLog; keep them all for maximum detail
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	Logging: &stagehand.StagehandClientLoggingConfig{
+		OnLog: func(entry stagehand.StagehandLog) {
+			fmt.Fprintf(os.Stderr, "[stagehand] %s %s %v\n", entry.Level, entry.Message, entry.Data)
+		},
+	},
+	// restOfYourConfiguration...
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+defer func() { err = errors.Join(err, client.Close(ctx)) }()
+```
+</View>
+
+<Accordion title="Example output">
+
+```
+[stagehand] DEBUG Capturing DOM snapshot {"pageId":"page-1"}
+[stagehand] DEBUG DOM contains 847 elements {"count":847}
+[stagehand] DEBUG LLM inference started {"category":"llm"}
+[stagehand] DEBUG LLM response {"selector":"#btn-submit","method":"click"}
+[stagehand] INFO act completed successfully {"category":"action"}
+```
+
+</Accordion>
+</Tab>
+
+<Tab title="Level: info (default)">
+**Use for:** Standard operations, staging, production
+
+<View title="TypeScript" icon="js">
+```typescript
+const stagehand = new Stagehand({
+  logging: { level: "info" }, // Default level
+  // restOfYourConfiguration...
+});
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+stagehand = Stagehand(
+    logging=StagehandClientLoggingConfig(level="info"),  # Default level
+    # rest_of_your_configuration...
+)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+// Drop debug records to match the default level of the other SDKs
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	Logging: &stagehand.StagehandClientLoggingConfig{
+		OnLog: func(entry stagehand.StagehandLog) {
+			if entry.Level == stagehand.StagehandLogLevelDebug {
+				return
+			}
+			fmt.Fprintf(os.Stderr, "[stagehand] %s %s\n", entry.Level, entry.Message)
+		},
+	},
+	// restOfYourConfiguration...
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+defer func() { err = errors.Join(err, client.Close(ctx)) }()
+```
+</View>
+
+
+<Accordion title="Example output">
+
+```
+[stagehand] INFO act started {"category":"action"}
+[stagehand] INFO act completed successfully {"category":"action"}
+[stagehand] INFO extract started {"category":"extraction"}
+[stagehand] INFO extract completed {"category":"extraction"}
+```
+
+</Accordion>
+</Tab>
+
+<Tab title="Level: error or off">
+**Use for:** Production with external monitoring, minimal noise, or handling secrets
+
+<View title="TypeScript" icon="js">
+```typescript
+const stagehand = new Stagehand({
+  logging: { level: "error" }, // Errors only
+  // restOfYourConfiguration...
+});
+
+const silent = new Stagehand({
+  logging: { level: "off" }, // Nothing at all
+  // restOfYourConfiguration...
+});
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+stagehand = Stagehand(
+    logging=StagehandClientLoggingConfig(level="error"),  # Errors only
+    # rest_of_your_configuration...
+)
+
+silent = Stagehand(
+    logging=StagehandClientLoggingConfig(level="off"),  # Nothing at all
+    # rest_of_your_configuration...
+)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+// Errors only
+errorsOnly := stagehand.New(stagehand.StagehandClientInitParams{
+	Logging: &stagehand.StagehandClientLoggingConfig{
+		OnLog: func(entry stagehand.StagehandLog) {
+			if entry.Level != stagehand.StagehandLogLevelError {
+				return
+			}
+			fmt.Fprintf(os.Stderr, "[stagehand] ERROR %s\n", entry.Message)
+		},
+	},
+	// restOfYourConfiguration...
+})
+
+// Nothing at all: omit Logging entirely, and Go writes no output
+silent := stagehand.New(stagehand.StagehandClientInitParams{
+	// restOfYourConfiguration...
+})
+
+// Pick the client that matches how much output you want
+client := errorsOnly
+if os.Getenv("STAGEHAND_SILENT") == "1" {
+	client = silent
+}
+if err := client.Init(ctx); err != nil {
+	return err
+}
+defer func() { err = errors.Join(err, client.Close(ctx)) }()
+```
+</View>
+
+<Accordion title="Example output">
+
+```
+[stagehand] ERROR act failed: element not found {"category":"action"}
+[stagehand] ERROR navigation timeout exceeded {"category":"navigation"}
+```
+
+</Accordion>
+</Tab>
+</Tabs>
+
+<Warning>
+Turning logging off suppresses the record callback as well as console output. Do this when handling passwords or other secrets.
+</Warning>
+
+---
+
+### Log destinations
+
+Logs can be sent to different destinations, including your console and external observability platforms. Every destination is driven by the record callback, so anything you can write to from your own code is a valid sink:
+
+<Tabs>
+<Tab title="Pretty (default)">
+Human-readable, single-line console output written to standard error.
+
+**When to use:** Development and interactive debugging
+
+<View title="TypeScript" icon="js">
+```typescript
+// Enabled by default: level "info", format "pretty"
+const stagehand = new Stagehand({
+  logging: { level: "info", format: "pretty" },
+  // restOfYourConfiguration...
+});
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+# Enabled by default: level "info", format "pretty"
+stagehand = Stagehand(
+    logging=StagehandClientLoggingConfig(level="info", format="pretty"),
+    # rest_of_your_configuration...
+)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+// Go prints nothing unless you ask it to. This reproduces the pretty format.
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	Logging: &stagehand.StagehandClientLoggingConfig{
+		OnLog: func(entry stagehand.StagehandLog) {
+			suffix := ""
+			if len(entry.Data) > 0 {
+				if encoded, err := json.Marshal(entry.Data); err == nil {
+					suffix = " " + string(encoded)
+				}
+			}
+			fmt.Fprintf(os.Stderr, "[stagehand] %s %s%s\n", strings.ToUpper(string(entry.Level)), entry.Message, suffix)
+		},
+	},
+	// restOfYourConfiguration...
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+defer func() { err = errors.Join(err, client.Close(ctx)) }()
+```
+</View>
+
+<Accordion title="Output shape">
+Each line is `[stagehand] LEVEL message {json data}`, with the data object omitted when empty. Output goes to standard error so it never mixes with your program's own standard output.
+</Accordion>
+</Tab>
+
+<Tab title="JSON">
+One JSON object per line, ready for log shippers and structured search.
+
+**When to use:** Containers, CI, or anywhere a collector tails standard error
+
+<View title="TypeScript" icon="js">
+```typescript
+const stagehand = new Stagehand({
+  logging: { level: "info", format: "json" },
+  // restOfYourConfiguration...
+});
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+stagehand = Stagehand(
+    logging=StagehandClientLoggingConfig(level="info", format="json"),
+    # rest_of_your_configuration...
+)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	Logging: &stagehand.StagehandClientLoggingConfig{
+		OnLog: func(entry stagehand.StagehandLog) {
+			_ = json.NewEncoder(os.Stderr).Encode(entry)
+		},
+	},
+	// restOfYourConfiguration...
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+defer func() { err = errors.Join(err, client.Close(ctx)) }()
+```
+</View>
+
+<Accordion title="Output shape">
+```json
+{"level":"info","message":"act completed successfully","data":{"category":"action"}}
+```
+</Accordion>
+</Tab>
+<Tab title="Custom logger">
+Your own callback receives every log record that passes the level filter, in addition to the console output.
+
+**When to use:** Development, debugging, or when you don't need querying
+capabilities.
+
+<Steps>
+
+<Step title="Create a simple logger">
+
+<View title="TypeScript" icon="js">
+```typescript
+
+// Simple logger without parsing (for basic console output)
+// The callback receives a `StagehandLog`; see the reference below for the shape.
+const simpleLogger = (log: {
+  level: "debug" | "info" | "warn" | "error";
+  message: string;
+  data: Record<string, unknown>;
+}) => {
+  console.log(`[${log.level}] ${log.message}`);
+
+  // Optional: log raw structured data
+  if (Object.keys(log.data).length > 0) {
+    console.log("  Context:", log.data);
+  }
+};
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+
+
+# Simple logger without parsing (for basic console output)
+def simple_logger(log) -> None:
+    print(f"[{log.level.value}] {log.message}")
+
+    # Optional: log raw structured data
+    data = log.data.model_dump(mode="json")
+    if data:
+        print("  Context:", data)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+// Simple logger without parsing (for basic console output)
+func simpleLogger(entry stagehand.StagehandLog) {
+	fmt.Printf("[%s] %s\n", entry.Level, entry.Message)
+
+	// Optional: log raw structured data
+	if len(entry.Data) > 0 {
+		fmt.Println("  Context:", entry.Data)
+	}
+}
+```
+</View>
+</Step>
+
+<Step title="Pass the logger in your Stagehand instance">
+Then pass the logger in your Stagehand instance:
+
+<View title="TypeScript" icon="js">
+```typescript
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
   logging: {
     level: "info",
+    onLog: simpleLogger,
+  },
+  // restOfYourConfiguration...
+});
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    logging=StagehandClientLoggingConfig(
+        level="info",
+        on_log=simple_logger,
+    ),
+    # rest_of_your_configuration...
+)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey: &apiKey,
+	Logging: &stagehand.StagehandClientLoggingConfig{
+		OnLog: simpleLogger,
+	},
+	// restOfYourConfiguration...
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+defer func() { err = errors.Join(err, client.Close(ctx)) }()
+```
+</View>
+
+</Step>
+</Steps>
+
+<Note>
+The log callback runs in addition to console output, not instead of it. Set the level to `off` if you want no console output, and do your own filtering inside the callback if you need finer control.
+</Note>
+</Tab>
+
+<Tab title="External logger (production)">
+The same callback, pointed at an observability platform.
+
+**When to use:** Production with DataDog, Sentry, CloudWatch, or custom observability platforms for centralized monitoring and error alerting. Here are examples using Sentry and DataDog:
+
+<Steps>
+
+<Step title="Create a production logger">
+
+<Tabs>
+
+<Tab title="Sentry">
+
+<View title="TypeScript" icon="js">
+```typescript
+import * as Sentry from "@sentry/node";
+
+const productionLogger = (log: {
+  level: "debug" | "info" | "warn" | "error";
+  message: string;
+  data: Record<string, unknown>;
+}) => {
+  // Send errors to Sentry
+  if (log.level === "error") {
+    Sentry.captureMessage(log.message, {
+      level: "error",
+      extra: log.data,
+    });
+  }
+};
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+import sentry_sdk
+
+
+
+def production_logger(log) -> None:
+    # Send errors to Sentry
+    if log.level.value == "error":
+        sentry_sdk.capture_message(
+            log.message,
+            level="error",
+            extras=log.data.model_dump(mode="json"),
+        )
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+func productionLogger(entry stagehand.StagehandLog) {
+	// Send errors to Sentry
+	if entry.Level != stagehand.StagehandLogLevelError {
+		return
+	}
+	sentry.WithScope(func(scope *sentry.Scope) {
+		for key, value := range entry.Data {
+			scope.SetExtra(key, string(value))
+		}
+		scope.SetLevel(sentry.LevelError)
+		sentry.CaptureMessage(entry.Message)
+	})
+}
+```
+</View>
+
+</Tab>
+<Tab title="DataDog">
+
+<View title="TypeScript" icon="js">
+```typescript
+import { datadogLogs } from "@datadog/browser-logs";
+
+const productionLogger = (log: {
+  level: "debug" | "info" | "warn" | "error";
+  message: string;
+  data: Record<string, unknown>;
+}) => {
+  // Send all logs to DataDog
+  datadogLogs.logger.log(log.message, {
+    status: log.level === "error" ? "error" : "info",
+    service: "stagehand-automation",
+    ...log.data,
+  });
+};
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+from datadog_api_client import ApiClient, Configuration
+from datadog_api_client.v2.api.logs_api import LogsApi
+
+logs_api = LogsApi(ApiClient(Configuration()))
+
+
+def production_logger(log) -> None:
+    # Send all logs to DataDog
+    logs_api.submit_log(body=[{
+        "message": log.message,
+        "status": "error" if log.level.value == "error" else "info",
+        "service": "stagehand-automation",
+        **log.data.model_dump(mode="json"),
+    }])
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+func productionLogger(entry stagehand.StagehandLog) {
+	// Send all logs to DataDog
+	status := "info"
+	if entry.Level == stagehand.StagehandLogLevelError {
+		status = "error"
+	}
+	payload := map[string]any{
+		"message": entry.Message,
+		"status":  status,
+		"service": "stagehand-automation",
+	}
+	for key, value := range entry.Data {
+		payload[key] = string(value)
+	}
+	_ = submitDataDogLog(payload)
+}
+```
+</View>
+</Tab>
+</Tabs>
+
+</Step>
+
+<Step title="Pass the logger in your Stagehand instance">
+
+<View title="TypeScript" icon="js">
+```typescript
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  logging: {
+    level: "info",
+    format: "json",
+    onLog: productionLogger,
+  },
+  // restOfYourConfiguration...
+});
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    logging=StagehandClientLoggingConfig(
+        level="info",
+        format="json",
+        on_log=production_logger,
+    ),
+    # rest_of_your_configuration...
+)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey: &apiKey,
+	Logging: &stagehand.StagehandClientLoggingConfig{
+		OnLog: productionLogger,
+	},
+	// restOfYourConfiguration...
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+defer func() { err = errors.Join(err, client.Close(ctx)) }()
+```
+</View>
+
+</Step>
+</Steps>
+
+<Note>
+Exceptions thrown by your callback, including rejected promises, are caught and reported on standard error. A failing logger will not take down your automation.
+</Note>
+
+</Tab>
+</Tabs>
+
+---
+
+## File-based session logging
+
+Route the log callback to a file to get a durable, per-session record of every Stagehand operation: `act`, `observe`, `extract`, LLM inference, and browser events.
+
+### Setup
+
+Pick a directory for your session logs and open a file per run:
+
+<View title="TypeScript" icon="js">
+```typescript
+import { createWriteStream } from "node:fs";
+import { mkdirSync } from "node:fs";
+
+mkdirSync("./stagehand-logs", { recursive: true });
+const sessionId = new Date().toISOString().replace(/[:.]/g, "-");
+const logFile = createWriteStream(`./stagehand-logs/${sessionId}.jsonl`, { flags: "a" });
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+from datetime import datetime, timezone
+from pathlib import Path
+
+Path("./stagehand-logs").mkdir(parents=True, exist_ok=True)
+session_id = datetime.now(timezone.utc).isoformat().replace(":", "-").replace(".", "-")
+log_file = open(f"./stagehand-logs/{session_id}.jsonl", "a", encoding="utf-8")
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+if err := os.MkdirAll("./stagehand-logs", 0o755); err != nil {
+	return err
+}
+startedAt := time.Now().UTC()
+sessionID := strings.NewReplacer(":", "-", ".", "-").Replace(startedAt.Format(time.RFC3339Nano))
+logFile, err := os.OpenFile(
+	fmt.Sprintf("./stagehand-logs/%s.jsonl", sessionID),
+	os.O_APPEND|os.O_CREATE|os.O_WRONLY,
+	0o600,
+)
+if err != nil {
+	return err
+}
+fmt.Fprintf(os.Stderr, "writing Stagehand logs to %s\n", logFile.Name())
+```
+</View>
+
+### Usage
+
+Write each record as one JSON line, then run your Stagehand script as normal:
+
+<View title="TypeScript" icon="js">
+```typescript
+import { finished } from "node:stream/promises";
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const stagehand = new Stagehand({
+  browser: { type: "local" },
+  logging: {
+    level: "debug",
     format: "pretty",
     onLog(log) {
       logFile.write(`${JSON.stringify(log)}\n`);
     },
   },
 });
-```
 
+try {
+  await stagehand.init();
+  // ... your automation
+} finally {
+  await stagehand.close();
+  logFile.end();
+  await finished(logFile);
+}
+```
 </View>
 
 <View title="Python" icon="python">
-
 ```python
 from stagehand import Stagehand, StagehandClientLoggingConfig
 
-
 stagehand = Stagehand(
-    # ...
+    browser="local",
     logging=StagehandClientLoggingConfig(
         level="info",
         format="pretty",
@@ -104,8 +858,14 @@ stagehand = Stagehand(
         on_log=lambda log: print(log.model_dump_json(), file=log_file),
     ),
 )
-```
 
+try:
+    await stagehand.init()
+    # ... your automation
+finally:
+    await stagehand.close()
+    log_file.close()
+```
 </View>
 
 <View title="Go" icon="go">
@@ -177,22 +937,382 @@ func run(ctx context.Context) (err error) {
 </View>
 
 Each callback receives the event as a structured log:
+<View title="Go" icon="golang">
+```go
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	Browser: stagehand.LocalBrowserSource{},
+	Logging: &stagehand.StagehandClientLoggingConfig{
+		OnLog: func(entry stagehand.StagehandLog) {
+			_ = json.NewEncoder(logFile).Encode(entry)
+		},
+	},
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+defer func() {
+	err = errors.Join(err, client.Close(ctx), logFile.Close())
+}()
+
+// ... your automation
+```
+</View>
+
+### Viewing logs
+
+<Tabs>
+<Tab title="Real-time monitoring">
+Follow all logs as they happen:
+
+```bash
+tail -f ./stagehand-logs/*.jsonl
+```
+
+Or filter by category as they stream:
+
+```bash
+# LLM requests and responses only
+tail -f ./stagehand-logs/*.jsonl | jq 'select(.data.category == "llm")'
+
+# Action events only
+tail -f ./stagehand-logs/*.jsonl | jq 'select(.data.category == "action")'
+```
+</Tab>
+
+<Tab title="Chronological review">
+View unified output across every session file:
+
+```bash
+cat ./stagehand-logs/*.jsonl | jq -r '"\(.level)\t\(.message)"'
+```
+</Tab>
+
+<Tab title="Historical sessions">
+Browse previous session logs:
+
+```bash
+ls ./stagehand-logs/
+# Output: 2026-01-06T14-30-45-000Z.jsonl  2026-01-06T15-45-12-000Z.jsonl
+
+jq -r 'select(.level == "error")' ./stagehand-logs/2026-01-06T14-30-45-000Z.jsonl
+```
+</Tab>
+</Tabs>
+
+### Log files
+
+Because you own the sink, you decide how records are split. A common layout is one file per concern, keyed off the log category:
+
+| File | Contents |
+|------|----------|
+| `llm_events.jsonl` | LLM requests and responses for act, extract, and observe operations |
+| `browser_events.jsonl` | Navigation, snapshot, and page lifecycle events |
+| `stagehand.jsonl` | Every record, unfiltered |
+
+<Note>
+This is especially useful for debugging long workflows where you need to trace the full sequence of LLM decisions and browser actions after the fact.
+</Note>
+
+---
+
+## LLM inference debugging
+
+<Warning>
+**Development only** - Produces large volumes of output and contains page content. Do not use in production.
+</Warning>
+
+Run at the `debug` level to see the complete inference path: the snapshot that was captured, the prompt category, the model's chosen element, and the token counts for each call.
+
+<View title="TypeScript" icon="js">
+```typescript
+const stagehand = new Stagehand({
+  browser: { type: "local" },
+  logging: {
+    level: "debug",
+    format: "json",
+    onLog(log) {
+      // Persist only the LLM records for offline analysis
+      if (log.data.category === "llm") {
+        inferenceFile.write(`${JSON.stringify(log)}\n`);
+      }
+    },
+  },
+});
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+def capture_inference(log) -> None:
+    # Persist only the LLM records for offline analysis
+    data = log.data.model_dump(mode="json")
+    if data.get("category") == "llm":
+        print(log.model_dump_json(), file=inference_file)
+
+
+stagehand = Stagehand(
+    browser="local",
+    logging=StagehandClientLoggingConfig(
+        level="debug",
+        format="json",
+        on_log=capture_inference,
+    ),
+)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+func captureInference(inferenceFile *os.File) func(stagehand.StagehandLog) {
+	return func(entry stagehand.StagehandLog) {
+		// Persist only the LLM records for offline analysis
+		if category, ok := entry.Data["category"]; ok && string(category) == `"llm"` {
+			_ = json.NewEncoder(inferenceFile).Encode(entry)
+		}
+	}
+}
+
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	Browser: stagehand.LocalBrowserSource{},
+	Logging: &stagehand.StagehandClientLoggingConfig{
+		OnLog: captureInference(inferenceFile),
+	},
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+defer func() { err = errors.Join(err, client.Close(ctx)) }()
+```
+</View>
+
+Debug-level records include:
+
+<AccordionGroup>
+<Accordion title="Inference request">
+Emitted before each LLM call, carrying the operation and prompt metadata:
 
 ```json
 {
-  "level": "info",
-  "message": "Starting observation",
+  "level": "debug",
+  "message": "inference started",
   "data": {
-    "category": "observation",
-    "instruction": "Find the Learn more link"
+    "category": "llm",
+    "operation": "act",
+    "model": "openai/gpt-5.4-mini"
   }
 }
 ```
+</Accordion>
 
-Close or flush your destination when your application exits.
+<Accordion title="Inference response">
+Emitted when the model returns, carrying the selected element:
+
+```json
+{
+  "level": "debug",
+  "message": "inference completed",
+  "data": {
+    "category": "llm",
+    "operation": "act",
+    "elementId": "0-1183",
+    "method": "click"
+  }
+}
+```
+</Accordion>
+
+<Accordion title="Usage summary">
+Emitted once per operation with the token and latency accounting:
+
+```json
+{
+  "level": "debug",
+  "message": "act inference usage",
+  "data": {
+    "category": "llm",
+    "promptTokens": 3451,
+    "completionTokens": 45,
+    "inferenceTimeMs": 951
+  }
+}
+```
+</Accordion>
+</AccordionGroup>
+
+<Tip>
+Token counters are also aggregated across the whole session. See [Observability](/v4/configuration/observability#real-time-metrics-%26-monitoring) for the cumulative view.
+</Tip>
+
+---
+
+## Reference
+
+### Logging configuration
+
+All logging options are passed as a single object to the Stagehand constructor:
+
+<View title="TypeScript" icon="js">
+```typescript
+// The shape of the `logging` value on the Stagehand constructor options.
+type StagehandClientLoggingConfig = {
+  level?: "off" | "error" | "warn" | "info" | "debug"; // default: "info"
+  format?: "pretty" | "json"; // default: "pretty"
+  onLog?: (log: StagehandLog) => void | Promise<void>; // default: undefined
+};
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+stagehand = Stagehand(
+    # ... your other configurations (browser, model, etc.)
+    logging=StagehandClientLoggingConfig(
+        level="info",   # "off" | "error" | "warn" | "info" | "debug"
+        format="pretty",  # "pretty" | "json"
+        on_log=None,      # Callable[[StagehandLog], None | Awaitable[None]]
+    ),
+)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	// ... your other configurations (Browser, Model, etc.)
+
+	// Go exposes only the callback. Filtering and formatting are yours.
+	Logging: &stagehand.StagehandClientLoggingConfig{
+		OnLog: func(entry stagehand.StagehandLog) {},
+	},
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+defer func() { err = errors.Join(err, client.Close(ctx)) }()
+```
+</View>
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| level | `info` | Minimum level to emit: `off`, `error`, `warn`, `info`, or `debug` |
+| format | `pretty` | Console rendering: human-readable lines or one JSON object per line |
+| log callback | none | Receives every record that passes the level filter, in addition to console output |
 
 <Note>
-  Logging and OpenTelemetry serve different purposes. Logging controls runtime events sent to your
-  terminal and callback. Telemetry exports Stagehand spans through your configured OpenTelemetry
-  endpoint.
+The level is also forwarded to the Stagehand runtime, so suppressed records are never generated or sent over the wire. Raising it to `debug` increases both log volume and message traffic.
 </Note>
+
+### Log structure
+
+{/* TODO: neither SDK currently re-exports the StagehandLog type from its public entrypoint, so callbacks rely on inference. Export it and add an import line to these samples. */}
+
+Each log entry follows a structured format:
+
+<View title="TypeScript" icon="js">
+```typescript
+interface StagehandLog {
+  level: "debug" | "info" | "warn" | "error"; // Severity
+  message: string;                            // "act completed successfully"
+  data: Record<string, unknown>;              // Structured metadata, JSON-serializable
+}
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+class StagehandLog(BaseModel):
+    level: StagehandLogLevel  # "debug" | "info" | "warn" | "error"
+    message: str              # "act completed successfully"
+    data: StagehandLogData    # Structured metadata, JSON-serializable
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+type StagehandLog struct {
+	Level   StagehandLogLevel // "debug" | "info" | "warn" | "error"
+	Message string            // "act completed successfully"
+	Data    StagehandLogData  // map[string]json.RawMessage
+}
+```
+</View>
+
+<Note>
+Unlike v3's `LogLine`, `data` is a flat JSON object: values are already typed, so there is no `{ value, type }` wrapper to parse. Fields such as `category` and `timestamp` appear inside `data` when the emitting operation provides them.
+</Note>
+
+<Accordion title="Log examples">
+
+<Tabs>
+<Tab title="Successful action">
+```json
+{
+  "level": "info",
+  "message": "act completed successfully",
+  "data": {
+    "category": "action",
+    "selector": "xpath=/html[1]/body[1]/button[1]",
+    "executionTimeMs": 1250
+  }
+}
+```
+</Tab>
+
+<Tab title="LLM inference">
+```json
+{
+  "level": "debug",
+  "message": "inference completed",
+  "data": {
+    "category": "llm",
+    "model": "openai/gpt-5.4-mini",
+    "promptTokens": 3451,
+    "completionTokens": 45
+  }
+}
+```
+</Tab>
+
+<Tab title="Error">
+```json
+{
+  "level": "error",
+  "message": "action failed: element not found",
+  "data": {
+    "category": "action",
+    "selector": "#missing-btn",
+    "url": "https://example.com/form"
+  }
+}
+```
+</Tab>
+</Tabs>
+
+</Accordion>
+
+---
+
+## Next steps
+
+Now that you have logging configured, explore additional debugging and monitoring tools in [the Observability guide](/v4/configuration/observability):
+
+<CardGroup cols={2}>
+<Card title="Tracing" icon="diagram-project" href="/v4/configuration/observability#tracing">
+Export OpenTelemetry spans for every Stagehand operation to your own collector, with trace context propagated across the SDK and runtime boundary.
+</Card>
+
+<Card title="Metrics API" icon="chart-line" href="/v4/configuration/observability#real-time-metrics-%26-monitoring">
+Monitor token usage and performance in real-time. Track costs per operation, identify expensive calls, and optimize resource usage.
+</Card>
+
+<Card title="LLM inference debugging" icon="microscope" href="/v4/configuration/logging#llm-inference-debugging">
+Run at debug level to see exactly what was sent to the model and why it made specific decisions.
+</Card>
+
+<Card title="Browserbase session monitoring" icon="video" href="/v4/configuration/observability#browserbase-session-monitoring">
+Watch your automation visually with session recordings, network monitoring, and real-time browser inspection (Browserbase only).
+</Card>
+</CardGroup>

--- a/packages/docs/v4/configuration/logging.mdx
+++ b/packages/docs/v4/configuration/logging.mdx
@@ -135,7 +135,7 @@ Real-time event logging during automation execution.
 
 ### Verbosity level
 
-Control how much detail you see in logs. The level is always applied at the source, so the Stagehand runtime never generates or sends a record below your threshold.
+Control how much detail you see in logs. The level is always applied at the source, so the Stagehand runtime never generates or sends a record below your threshold. TypeScript and Python set that threshold; Go does not expose one and receives the default of `info` and above.
 
 <Tabs>
 <Tab title="Level: debug">
@@ -161,7 +161,7 @@ stagehand = Stagehand(
 
 <View title="Go" icon="golang">
 ```go
-// Go delivers every record to OnLog; keep them all for maximum detail
+// Go has no level to raise: OnLog receives every record the runtime emits
 client := stagehand.New(stagehand.StagehandClientInitParams{
 	Logging: &stagehand.StagehandClientLoggingConfig{
 		OnLog: func(entry stagehand.StagehandLog) {
@@ -214,7 +214,7 @@ stagehand = Stagehand(
 
 <View title="Go" icon="golang">
 ```go
-// Drop debug records to match the default level of the other SDKs
+// Go filters in OnLog: this keeps info and above, the default of the other SDKs
 client := stagehand.New(stagehand.StagehandClientInitParams{
 	Logging: &stagehand.StagehandClientLoggingConfig{
 		OnLog: func(entry stagehand.StagehandLog) {
@@ -322,7 +322,7 @@ defer func() { err = errors.Join(err, client.Close(ctx)) }()
 </Tabs>
 
 <Warning>
-Turning logging off suppresses the record callback as well as console output. Do this when handling passwords or other secrets.
+In TypeScript and Python, turning logging off suppresses the record callback as well as console output. Do this when handling passwords or other secrets. Go has no level, so the runtime keeps generating records: leave `OnLog` unset to keep them out of your own sinks.
 </Warning>
 
 ---
@@ -333,7 +333,7 @@ Logs can be sent to different destinations, including your console and external 
 
 <Tabs>
 <Tab title="Pretty (default)">
-Human-readable, single-line console output written to standard error.
+Human-readable, single-line console output written to standard error. TypeScript and Python render this format for you; in Go you produce it in the callback.
 
 **When to use:** Development and interactive debugging
 
@@ -383,7 +383,7 @@ defer func() { err = errors.Join(err, client.Close(ctx)) }()
 </View>
 
 <Accordion title="Output shape">
-Each line is `[stagehand] LEVEL message {json data}`, with the data object omitted when empty. Output goes to standard error so it never mixes with your program's own standard output.
+Each line is `[stagehand] LEVEL message {json data}`, with the data object omitted when empty. TypeScript and Python write it to standard error so it never mixes with your program's own standard output.
 </Accordion>
 </Tab>
 
@@ -435,7 +435,7 @@ defer func() { err = errors.Join(err, client.Close(ctx)) }()
 </Accordion>
 </Tab>
 <Tab title="Custom logger">
-Your own callback receives every log record that passes the level filter, in addition to the console output.
+Your own callback receives every log record that passes the level filter, alongside the console output in TypeScript and Python.
 
 **When to use:** Development, debugging, or when you don't need querying
 capabilities.
@@ -544,7 +544,7 @@ defer func() { err = errors.Join(err, client.Close(ctx)) }()
 </Steps>
 
 <Note>
-The log callback runs in addition to console output, not instead of it, and the level gates both. Setting the level to `off` suppresses the callback as well as the console, so keep the level at the lowest severity you want to receive and do your own filtering inside the callback. Redirect standard error if you need the console itself to stay clean.
+The callback receives every record that passes the level gate, so do any finer filtering inside it. In TypeScript and Python the callback runs in addition to the console output rather than instead of it: the level gates both and `off` silences both, so keep the level at the lowest severity you want to receive and redirect standard error if the console itself needs to stay quiet. Go exposes no level and writes nothing to the console, so the callback is the only sink and always receives the runtime default of `info` and above.
 </Note>
 </Tab>
 
@@ -737,7 +737,7 @@ defer func() { err = errors.Join(err, client.Close(ctx)) }()
 </Steps>
 
 <Note>
-Exceptions thrown by your callback, including rejected promises, are caught and reported on standard error. A failing logger will not take down your automation.
+In TypeScript and Python, exceptions thrown by your callback, including rejected promises, are caught and reported on standard error, so a failing logger will not take down your automation. Go does not recover from a panic in `OnLog`, so handle failures inside the callback.
 </Note>
 
 </Tab>
@@ -1029,7 +1029,7 @@ This is especially useful for debugging long workflows where you need to trace t
 **Development only** - Produces large volumes of output and contains page content. Do not use in production.
 </Warning>
 
-Run at the `debug` level to see the complete inference path: the snapshot that was captured, the prompt category, the model's chosen element, and the token counts for each call.
+Run at the `debug` level to see the complete inference path: the snapshot that was captured, the prompt category, the model's chosen element, and the token counts for each call. TypeScript and Python can raise the level to `debug`; Go cannot, so debug records never reach a Go callback.
 
 <View title="TypeScript" icon="js">
 ```typescript
@@ -1206,10 +1206,10 @@ defer func() { err = errors.Join(err, client.Close(ctx)) }()
 |--------|---------|-------------|
 | level | `info` | Minimum level to emit: `off`, `error`, `warn`, `info`, or `debug` |
 | format | `pretty` | Console rendering: human-readable lines or one JSON object per line |
-| log callback | none | Receives every record that passes the level filter, in addition to console output |
+| log callback | none | Receives every record that passes the level filter, alongside the console output in TypeScript and Python |
 
 <Note>
-The level is also forwarded to the Stagehand runtime, so suppressed records are never generated or sent over the wire. Raising it to `debug` increases both log volume and message traffic.
+The level is also forwarded to the Stagehand runtime, so suppressed records are never generated or sent over the wire. Raising it to `debug` increases both log volume and message traffic. Go sends no level, so its runtime stays at `info`.
 </Note>
 
 ### Log structure

--- a/packages/docs/v4/configuration/logging.mdx
+++ b/packages/docs/v4/configuration/logging.mdx
@@ -44,6 +44,8 @@ const testing = new Stagehand({
 
 <View title="Python" icon="python">
 ```python
+import os
+
 from stagehand import Stagehand, StagehandClientLoggingConfig
 
 # Development: full debug output, human-readable
@@ -117,6 +119,7 @@ case "production":
 case "test":
 	client = testing
 }
+
 if err := client.Init(ctx); err != nil {
 	return err
 }
@@ -541,7 +544,7 @@ defer func() { err = errors.Join(err, client.Close(ctx)) }()
 </Steps>
 
 <Note>
-The log callback runs in addition to console output, not instead of it. Set the level to `off` if you want no console output, and do your own filtering inside the callback if you need finer control.
+The log callback runs in addition to console output, not instead of it, and the level gates both. Setting the level to `off` suppresses the callback as well as the console, so keep the level at the lowest severity you want to receive and do your own filtering inside the callback. Redirect standard error if you need the console itself to stay clean.
 </Note>
 </Tab>
 
@@ -603,8 +606,10 @@ func productionLogger(entry stagehand.StagehandLog) {
 		return
 	}
 	sentry.WithScope(func(scope *sentry.Scope) {
+		// Data values are json.RawMessage. Pass them through so Sentry keeps each
+		// field's JSON type instead of recording it as quoted text.
 		for key, value := range entry.Data {
-			scope.SetExtra(key, string(value))
+			scope.SetExtra(key, value)
 		}
 		scope.SetLevel(sentry.LevelError)
 		sentry.CaptureMessage(entry.Message)
@@ -667,8 +672,10 @@ func productionLogger(entry stagehand.StagehandLog) {
 		"status":  status,
 		"service": "stagehand-automation",
 	}
+	// Data values are json.RawMessage. Keep them raw so DataDog indexes numbers
+	// as numbers and strings as strings.
 	for key, value := range entry.Data {
-		payload[key] = string(value)
+		payload[key] = value
 	}
 	_ = submitDataDogLog(payload)
 }

--- a/packages/docs/v4/configuration/models.mdx
+++ b/packages/docs/v4/configuration/models.mdx
@@ -649,11 +649,21 @@ type LLMGenerateParams = {
     | { type: "json_schema"; name: string; schema: unknown };
 };
 
-// A message's content is one block or an array of them. Bedrock's `text` field
-// wants a string, so join the text blocks and skip the image blocks.
-function messageText(content: LLMContentBlock | LLMContentBlock[]): string {
+// A message's content is one block or an array of them. Converse takes a list
+// of content blocks, so map text to a text block and images (which
+// `extract({ screenshot: true })` sends) to Converse's image block.
+function messageContent(content: LLMContentBlock | LLMContentBlock[]) {
   const blocks = Array.isArray(content) ? content : [content];
-  return blocks.map((block) => (block.type === "text" ? block.text : "")).join("");
+  return blocks.map((block) =>
+    block.type === "text"
+      ? { text: block.text }
+      : {
+          image: {
+            format: block.mimeType.replace("image/", ""),
+            source: { bytes: Buffer.from(block.data, "base64") },
+          },
+        },
+  );
 }
 
 async function generateWithBedrock(params: LLMGenerateParams) {
@@ -666,7 +676,7 @@ async function generateWithBedrock(params: LLMGenerateParams) {
     system: params.systemPrompt ? [{ text: params.systemPrompt }] : undefined,
     messages: params.messages.map((message) => ({
       role: message.role,
-      content: [{ text: messageText(message.content) }],
+      content: messageContent(message.content),
     })),
   }));
 
@@ -683,6 +693,7 @@ async function generateWithBedrock(params: LLMGenerateParams) {
 
 <View title="Python" icon="python">
 ```python
+import base64
 import json
 
 import boto3
@@ -690,13 +701,25 @@ import boto3
 bedrock = boto3.client("bedrock-runtime", region_name="us-east-1")
 
 
-def message_text(message):
-    # A message's content is one block or a list of them, each block a
-    # LLMTextContent or LLMImageContent under `.root`. Bedrock's `text` field
-    # wants a string, so join the text blocks and skip the image blocks.
+def content_block(block):
+    # Each block is a LLMTextContent or LLMImageContent under `.root`. Converse
+    # takes its own content blocks, so map text to a text block and images
+    # (which `extract(screenshot=True)` sends) to Converse's image block.
+    if block.root.type == "text":
+        return {"text": block.root.text}
+    return {
+        "image": {
+            "format": block.root.mime_type.removeprefix("image/"),
+            "source": {"bytes": base64.b64decode(block.root.data)},
+        }
+    }
+
+
+def message_content(message):
+    # A message's content is one block or a list of them.
     content = message.content
     blocks = content if isinstance(content, list) else [content]
-    return "".join(block.root.text for block in blocks if block.root.type == "text")
+    return [content_block(block) for block in blocks]
 
 
 async def generate_with_bedrock(params):
@@ -704,7 +727,7 @@ async def generate_with_bedrock(params):
         modelId="amazon.nova-pro-v1:0",
         system=[{"text": params.system_prompt}] if params.system_prompt else [],
         messages=[
-            {"role": message.role.value, "content": [{"text": message_text(message)}]}
+            {"role": message.role.value, "content": message_content(message)}
             for message in params.messages
         ],
     )
@@ -722,16 +745,27 @@ async def generate_with_bedrock(params):
 <View title="Go" icon="golang">
 ```go
 // A message's content is a slice of blocks, each one text, image, tool-use, or
-// tool-result. Bedrock's text block wants a string, so join the text blocks and
-// skip the rest.
-func messageText(message stagehand.LLMMessage) string {
-	var text strings.Builder
+// tool-result. Converse takes its own content blocks, so map text to a text
+// block and images (which extract sends when Screenshot is true) to an image
+// block.
+func messageContent(message stagehand.LLMMessage) ([]types.ContentBlock, error) {
+	blocks := make([]types.ContentBlock, 0, len(message.Content))
 	for _, block := range message.Content {
 		if content, ok := block.AsText(); ok {
-			text.WriteString(content.Text)
+			blocks = append(blocks, &types.ContentBlockMemberText{Value: content.Text})
+		}
+		if content, ok := block.AsImage(); ok {
+			data, err := base64.StdEncoding.DecodeString(content.Data)
+			if err != nil {
+				return nil, err
+			}
+			blocks = append(blocks, &types.ContentBlockMemberImage{Value: types.ImageBlock{
+				Format: types.ImageFormat(strings.TrimPrefix(content.MIMEType, "image/")),
+				Source: &types.ImageSourceMemberBytes{Value: data},
+			}})
 		}
 	}
-	return text.String()
+	return blocks, nil
 }
 
 func generateWithBedrock(
@@ -745,9 +779,13 @@ func generateWithBedrock(
 
 	messages := make([]types.Message, 0, len(request.Messages))
 	for _, message := range request.Messages {
+		content, err := messageContent(message)
+		if err != nil {
+			return stagehand.LLMGenerateResult{}, err
+		}
 		messages = append(messages, types.Message{
 			Role:    types.ConversationRole(message.Role),
-			Content: []types.ContentBlock{&types.ContentBlockMemberText{Value: messageText(message)}},
+			Content: content,
 		})
 	}
 
@@ -867,11 +905,20 @@ type LLMGenerateParams = {
     | { type: "json_schema"; name: string; schema: unknown };
 };
 
-// A message's content is one block or an array of them. Join the text blocks
-// and skip the image blocks to get the string the Responses API expects.
-function messageText(content: LLMContentBlock | LLMContentBlock[]): string {
+// A message's content is one block or an array of them. The Responses API takes
+// input parts, so map text to an input text part and images (which
+// `extract({ screenshot: true })` sends) to an input image data URL.
+function messageContent(content: LLMContentBlock | LLMContentBlock[]) {
   const blocks = Array.isArray(content) ? content : [content];
-  return blocks.map((block) => (block.type === "text" ? block.text : "")).join("");
+  return blocks.map((block) =>
+    block.type === "text"
+      ? { type: "input_text", text: block.text }
+      : {
+          type: "input_image",
+          image_url: `data:${block.mimeType};base64,${block.data}`,
+          detail: "auto",
+        },
+  );
 }
 
 async function generateWithOpenAI(params: LLMGenerateParams) {
@@ -884,7 +931,7 @@ async function generateWithOpenAI(params: LLMGenerateParams) {
     instructions: params.systemPrompt,
     input: params.messages.map((message) => ({
       role: message.role,
-      content: messageText(message.content),
+      content: messageContent(message.content),
     })),
     temperature: params.temperature,
     text: {
@@ -902,17 +949,6 @@ async function generateWithOpenAI(params: LLMGenerateParams) {
     content: { type: "text", text: response.output_text },
     outputFormat: "json_schema",
     structuredContent: JSON.parse(response.output_text),
-    // usage is optional; map your provider's field names onto Stagehand's
-    // (`reasoningTokens` and `cachedInputTokens` are optional too)
-    ...(response.usage
-      ? {
-          usage: {
-            inputTokens: response.usage.input_tokens,
-            outputTokens: response.usage.output_tokens,
-            totalTokens: response.usage.total_tokens,
-          },
-        }
-      : {}),
   };
 }
 ```
@@ -929,13 +965,24 @@ from stagehand import LLMStructuredGenerateResult
 openai = AsyncOpenAI(api_key=os.environ["OPENAI_API_KEY"])
 
 
-def message_text(message):
-    # A message's content is one block or a list of them, each block a
-    # LLMTextContent or LLMImageContent under `.root`. Join the text blocks and
-    # skip the image blocks to get the string the Responses API expects.
+def content_part(block):
+    # Each block is a LLMTextContent or LLMImageContent under `.root`. The
+    # Responses API takes input parts, so map text to an input text part and
+    # images (which `extract(screenshot=True)` sends) to an input image data URL.
+    if block.root.type == "text":
+        return {"type": "input_text", "text": block.root.text}
+    return {
+        "type": "input_image",
+        "image_url": f"data:{block.root.mime_type};base64,{block.root.data}",
+        "detail": "auto",
+    }
+
+
+def message_content(message):
+    # A message's content is one block or a list of them.
     content = message.content
     blocks = content if isinstance(content, list) else [content]
-    return "".join(block.root.text for block in blocks if block.root.type == "text")
+    return [content_part(block) for block in blocks]
 
 
 async def generate_with_openai(params):
@@ -944,7 +991,7 @@ async def generate_with_openai(params):
         model="gpt-5.4-mini",
         instructions=params.system_prompt,
         input=[
-            {"role": message.role.value, "content": message_text(message)}
+            {"role": message.role.value, "content": message_content(message)}
             for message in params.messages
         ],
         temperature=params.temperature,
@@ -998,6 +1045,10 @@ func generateWithOpenAI(
 }
 ```
 </View>
+
+<Note>
+Reporting token usage is optional. To report it, add a `usage` field to the result and map your provider's own usage field names onto Stagehand's: input tokens, output tokens, and total tokens are required, while reasoning tokens and cached input tokens are optional. Providers spell these differently, so read the names off your provider's response type rather than assuming they match Stagehand's.
+</Note>
 </Step>
 
 <Step title="Pass the callback to Stagehand">
@@ -1131,6 +1182,10 @@ func generateWithYourProvider(
 }
 ```
 </View>
+
+<Note>
+A message's content is one content block or an array of them. Text blocks carry a string, and image blocks carry base64 data plus a MIME type. [`extract()` with the screenshot option](/v4/basics/extract) sends a viewport screenshot as an image block, so map image blocks onto your provider's own image format. A callback that reads only the text blocks answers a visual extraction from the accessibility tree alone.
+</Note>
 </Step>
 <Step title="Pass the callback to Stagehand">
 

--- a/packages/docs/v4/configuration/models.mdx
+++ b/packages/docs/v4/configuration/models.mdx
@@ -633,14 +633,28 @@ const bedrock = new BedrockRuntimeClient({ region: "us-east-1" });
 
 // The shape Stagehand passes to your callback. The TypeScript SDK does not
 // re-export `LLMGenerateParams` yet, so spell out the fields you read.
+type LLMContentBlock =
+  | { type: "text"; text: string }
+  | { type: "image"; data: string; mimeType: string };
+
 type LLMGenerateParams = {
-  messages: Array<{ role: "user" | "assistant"; content: unknown }>;
+  messages: Array<{
+    role: "user" | "assistant";
+    content: LLMContentBlock | LLMContentBlock[];
+  }>;
   systemPrompt?: string;
   temperature?: number;
   responseFormat?:
     | { type: "text" }
     | { type: "json_schema"; name: string; schema: unknown };
 };
+
+// A message's content is one block or an array of them. Bedrock's `text` field
+// wants a string, so join the text blocks and skip the image blocks.
+function messageText(content: LLMContentBlock | LLMContentBlock[]): string {
+  const blocks = Array.isArray(content) ? content : [content];
+  return blocks.map((block) => (block.type === "text" ? block.text : "")).join("");
+}
 
 async function generateWithBedrock(params: LLMGenerateParams) {
   if (params.responseFormat?.type !== "json_schema") {
@@ -676,6 +690,15 @@ import boto3
 bedrock = boto3.client("bedrock-runtime", region_name="us-east-1")
 
 
+def message_text(message):
+    # A message's content is one block or a list of them, each block a
+    # LLMTextContent or LLMImageContent under `.root`. Bedrock's `text` field
+    # wants a string, so join the text blocks and skip the image blocks.
+    content = message.content
+    blocks = content if isinstance(content, list) else [content]
+    return "".join(block.root.text for block in blocks if block.root.type == "text")
+
+
 async def generate_with_bedrock(params):
     response = bedrock.converse(
         modelId="amazon.nova-pro-v1:0",
@@ -698,6 +721,19 @@ async def generate_with_bedrock(params):
 
 <View title="Go" icon="golang">
 ```go
+// A message's content is a slice of blocks, each one text, image, tool-use, or
+// tool-result. Bedrock's text block wants a string, so join the text blocks and
+// skip the rest.
+func messageText(message stagehand.LLMMessage) string {
+	var text strings.Builder
+	for _, block := range message.Content {
+		if content, ok := block.AsText(); ok {
+			text.WriteString(content.Text)
+		}
+	}
+	return text.String()
+}
+
 func generateWithBedrock(
 	ctx context.Context,
 	params stagehand.LLMGenerateParams,
@@ -815,14 +851,28 @@ const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
 // The shape Stagehand passes to your callback. The TypeScript SDK does not
 // re-export `LLMGenerateParams` yet, so spell out the fields you read.
+type LLMContentBlock =
+  | { type: "text"; text: string }
+  | { type: "image"; data: string; mimeType: string };
+
 type LLMGenerateParams = {
-  messages: Array<{ role: "user" | "assistant"; content: unknown }>;
+  messages: Array<{
+    role: "user" | "assistant";
+    content: LLMContentBlock | LLMContentBlock[];
+  }>;
   systemPrompt?: string;
   temperature?: number;
   responseFormat?:
     | { type: "text" }
     | { type: "json_schema"; name: string; schema: unknown };
 };
+
+// A message's content is one block or an array of them. Join the text blocks
+// and skip the image blocks to get the string the Responses API expects.
+function messageText(content: LLMContentBlock | LLMContentBlock[]): string {
+  const blocks = Array.isArray(content) ? content : [content];
+  return blocks.map((block) => (block.type === "text" ? block.text : "")).join("");
+}
 
 async function generateWithOpenAI(params: LLMGenerateParams) {
   if (params.responseFormat?.type !== "json_schema") {
@@ -852,8 +902,17 @@ async function generateWithOpenAI(params: LLMGenerateParams) {
     content: { type: "text", text: response.output_text },
     outputFormat: "json_schema",
     structuredContent: JSON.parse(response.output_text),
-    // usage is optional; map your provider's own field names onto Stagehand's
-    ...(response.usage ? { usage: toStagehandUsage(response.usage) } : {}),
+    // usage is optional; map your provider's field names onto Stagehand's
+    // (`reasoningTokens` and `cachedInputTokens` are optional too)
+    ...(response.usage
+      ? {
+          usage: {
+            inputTokens: response.usage.input_tokens,
+            outputTokens: response.usage.output_tokens,
+            totalTokens: response.usage.total_tokens,
+          },
+        }
+      : {}),
   };
 }
 ```
@@ -868,6 +927,15 @@ from openai import AsyncOpenAI
 from stagehand import LLMStructuredGenerateResult
 
 openai = AsyncOpenAI(api_key=os.environ["OPENAI_API_KEY"])
+
+
+def message_text(message):
+    # A message's content is one block or a list of them, each block a
+    # LLMTextContent or LLMImageContent under `.root`. Join the text blocks and
+    # skip the image blocks to get the string the Responses API expects.
+    content = message.content
+    blocks = content if isinstance(content, list) else [content]
+    return "".join(block.root.text for block in blocks if block.root.type == "text")
 
 
 async def generate_with_openai(params):

--- a/packages/docs/v4/configuration/models.mdx
+++ b/packages/docs/v4/configuration/models.mdx
@@ -1,0 +1,1618 @@
+---
+title: Models
+sidebarTitle: Models
+description: Use any LLM with Stagehand
+---
+
+<Callout icon="sparkles" color="#FFC107" iconType="regular">
+  **(NEW) Model Gateway**: Use your Browserbase API key to access top models from OpenAI, Anthropic, and Google. One key, one bill, no provider accounts needed. [Read the blog](https://www.browserbase.com/blog/model-gateway)
+</Callout>
+
+## Model Gateway
+
+Model Gateway lets you use Stagehand without wiring up model providers yourself. Instead of managing separate API keys for each provider, pass your Browserbase API key and pick a model. Browserbase routes the request to the upstream provider for you.
+
+### Setup
+
+<View title="TypeScript" icon="js">
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  browser: { type: "browserbase" },
+  model: { modelName: "openai/gpt-5" },
+});
+
+await stagehand.init();
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+from stagehand import Stagehand
+
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    browser="browserbase",
+    model="openai/gpt-5",
+)
+
+await stagehand.init()
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+apiKey := os.Getenv("BROWSERBASE_API_KEY")
+// No model API key: requests route through Model Gateway
+model := stagehand.KnownModel(stagehand.KnownModelConfig{ModelName: "openai/gpt-5"})
+
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey:  &apiKey,
+	Browser: stagehand.BrowserbaseClientBrowserSource{},
+	Model:   &model,
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+```
+</View>
+
+When only a Browserbase API key is provided (without a provider-specific API key), Stagehand automatically routes model requests through Model Gateway. No additional configuration is needed: omit the model API key and the gateway takes over.
+
+<Note>
+  Model Gateway requires Browserbase-hosted browsers. It does not work with the local or CDP browser sources, because those have no Browserbase session to bill and authorize against.
+</Note>
+
+{/* TODO: Model Gateway routing is not yet wired up in the v4 runtime, which currently raises "Direct model inference requires an API key" when no provider key is present. Verify before publishing. */}
+
+### Switching models
+
+With Model Gateway, switching between providers is a config change: no new accounts, API keys, or code rewiring required.
+
+<Tabs>
+<Tab title="OpenAI">
+
+<View title="TypeScript" icon="js">
+```typescript
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  model: { modelName: "openai/gpt-5" },
+});
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    model="openai/gpt-5",
+)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+apiKey := os.Getenv("BROWSERBASE_API_KEY")
+// No model API key: requests route through Model Gateway
+model := stagehand.KnownModel(stagehand.KnownModelConfig{ModelName: "openai/gpt-5"})
+
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey:  &apiKey,
+	Browser: stagehand.BrowserbaseClientBrowserSource{},
+	Model:   &model,
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+defer func() { err = errors.Join(err, client.Close(ctx)) }()
+```
+</View>
+</Tab>
+<Tab title="Anthropic">
+
+<View title="TypeScript" icon="js">
+```typescript
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  model: { modelName: "anthropic/claude-sonnet-4-6" },
+});
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    model="anthropic/claude-sonnet-4-6",
+)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+apiKey := os.Getenv("BROWSERBASE_API_KEY")
+// No model API key: requests route through Model Gateway
+model := stagehand.KnownModel(stagehand.KnownModelConfig{ModelName: "anthropic/claude-sonnet-4-6"})
+
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey:  &apiKey,
+	Browser: stagehand.BrowserbaseClientBrowserSource{},
+	Model:   &model,
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+defer func() { err = errors.Join(err, client.Close(ctx)) }()
+```
+</View>
+</Tab>
+<Tab title="Google">
+
+<View title="TypeScript" icon="js">
+```typescript
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  model: { modelName: "google/gemini-3-flash-preview" },
+});
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    model="google/gemini-3-flash-preview",
+)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+apiKey := os.Getenv("BROWSERBASE_API_KEY")
+// No model API key: requests route through Model Gateway
+model := stagehand.KnownModel(stagehand.KnownModelConfig{ModelName: "google/gemini-3-flash-preview"})
+
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey:  &apiKey,
+	Browser: stagehand.BrowserbaseClientBrowserSource{},
+	Model:   &model,
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+defer func() { err = errors.Join(err, client.Close(ctx)) }()
+```
+</View>
+</Tab>
+</Tabs>
+
+### Key benefits
+
+- **One key, one bill:** LLM inference, browser infrastructure, and caching all run through your Browserbase API key.
+- **Market-price tokens:** Browserbase charges the same price as going direct to the provider. No markup.
+- **Built-in reliability:** Retries, backoff, and rate limit handling are managed for you.
+- **No tier-gating:** Access new models immediately without hitting provider spend thresholds.
+- **Action caching:** Model Gateway works with Stagehand's [managed action caching](/v3/best-practices/caching), so repeated steps are reused instead of re-run. Both features run off the same Browserbase session, so turning on `cache` costs you nothing extra to set up.
+
+### Supported providers
+
+| Provider   | Example Model                  |
+| ---------- | ------------------------------ |
+| OpenAI     | `openai/gpt-5`                |
+| Anthropic  | `anthropic/claude-sonnet-4-6` |
+| Google     | `google/gemini-2.5-flash`     |
+
+<Tip>
+  Need a provider that isn't listed? [Reach out](https://www.browserbase.com/contact): Browserbase is happy to work with teams on additional model support.
+</Tip>
+
+---
+
+## Configuration setup
+
+### Quick start
+
+<Tip>
+  Read your provider key from the environment and pass it on the model configuration. Stagehand does not read environment variables for you.
+</Tip>
+
+Get started with Google Gemini (recommended for speed and cost):
+
+<View title="TypeScript" icon="js">
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  model: {
+    modelName: "google/gemini-2.5-flash",
+    apiKey: process.env.GOOGLE_GENERATIVE_AI_API_KEY,
+  },
+});
+
+await stagehand.init();
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+from stagehand import Stagehand
+
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    model="google/gemini-2.5-flash",
+    model_api_key=os.environ["GOOGLE_GENERATIVE_AI_API_KEY"],
+)
+
+await stagehand.init()
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+apiKey := os.Getenv("BROWSERBASE_API_KEY")
+modelAPIKey := os.Getenv("GOOGLE_GENERATIVE_AI_API_KEY")
+model := stagehand.KnownModel(stagehand.KnownModelConfig{
+	ModelName: "google/gemini-2.5-flash",
+	APIKey:    &modelAPIKey,
+})
+
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey:  &apiKey,
+	Browser: stagehand.BrowserbaseClientBrowserSource{},
+	Model:   &model,
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+```
+</View>
+
+<Note>
+Model names for the providers below carry a `provider/` prefix, and the provider must be one of the five. Stagehand does not keep a list of valid model IDs: whatever follows the prefix is passed through to the provider untouched, so new model releases and early-access models work without a Stagehand upgrade. A model ID that the provider does not recognize, or that your key cannot reach, fails at request time with the provider's own error. The prefix is dropped when you point at a [custom endpoint](#custom-endpoints), where the name can be a deployment name instead.
+</Note>
+
+
+---
+
+### First class models
+
+Use any model from the following supported providers.
+
+<Tabs>
+<Tab title="Google">
+
+<View title="TypeScript" icon="js">
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  model: {
+    modelName: "google/gemini-2.5-flash",
+    apiKey: process.env.GOOGLE_GENERATIVE_AI_API_KEY,
+  },
+});
+
+await stagehand.init();
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+from stagehand import Stagehand
+
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    model="google/gemini-2.5-flash",
+    model_api_key=os.environ["GOOGLE_GENERATIVE_AI_API_KEY"],
+)
+
+await stagehand.init()
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+apiKey := os.Getenv("BROWSERBASE_API_KEY")
+modelAPIKey := os.Getenv("GOOGLE_GENERATIVE_AI_API_KEY")
+model := stagehand.KnownModel(stagehand.KnownModelConfig{
+	ModelName: "google/gemini-2.5-flash",
+	APIKey:    &modelAPIKey,
+})
+
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey:  &apiKey,
+	Browser: stagehand.BrowserbaseClientBrowserSource{},
+	Model:   &model,
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+```
+</View>
+
+Commonly used: `google/gemini-3.1-pro-preview`, `google/gemini-3-flash-preview`, `google/gemini-3.5-flash`, `google/gemini-2.5-flash`, `google/gemini-flash-latest`.
+
+[View all supported Google models →](https://ai.google.dev/gemini-api/docs/models)
+</Tab>
+
+<Tab title="Anthropic">
+
+<View title="TypeScript" icon="js">
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  model: {
+    modelName: "anthropic/claude-haiku-4-5",
+    apiKey: process.env.ANTHROPIC_API_KEY,
+  },
+});
+
+await stagehand.init();
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+from stagehand import Stagehand
+
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    model="anthropic/claude-haiku-4-5",
+    model_api_key=os.environ["ANTHROPIC_API_KEY"],
+)
+
+await stagehand.init()
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+apiKey := os.Getenv("BROWSERBASE_API_KEY")
+modelAPIKey := os.Getenv("ANTHROPIC_API_KEY")
+model := stagehand.KnownModel(stagehand.KnownModelConfig{
+	ModelName: "anthropic/claude-haiku-4-5",
+	APIKey:    &modelAPIKey,
+})
+
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey:  &apiKey,
+	Browser: stagehand.BrowserbaseClientBrowserSource{},
+	Model:   &model,
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+```
+</View>
+
+Commonly used: `anthropic/claude-sonnet-5`, `anthropic/claude-fable-5`, `anthropic/claude-opus-4-8`, `anthropic/claude-sonnet-4-6`, `anthropic/claude-haiku-4-5`.
+
+[View all supported Anthropic models →](https://docs.anthropic.com/en/docs/models-overview)
+</Tab>
+
+<Tab title="OpenAI">
+
+<View title="TypeScript" icon="js">
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  model: {
+    modelName: "openai/gpt-5",
+    apiKey: process.env.OPENAI_API_KEY,
+  },
+});
+
+await stagehand.init();
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+from stagehand import Stagehand
+
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    model="openai/gpt-5",
+    model_api_key=os.environ["OPENAI_API_KEY"],
+)
+
+await stagehand.init()
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+apiKey := os.Getenv("BROWSERBASE_API_KEY")
+modelAPIKey := os.Getenv("OPENAI_API_KEY")
+model := stagehand.KnownModel(stagehand.KnownModelConfig{
+	ModelName: "openai/gpt-5",
+	APIKey:    &modelAPIKey,
+})
+
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey:  &apiKey,
+	Browser: stagehand.BrowserbaseClientBrowserSource{},
+	Model:   &model,
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+```
+</View>
+
+Commonly used: `openai/gpt-5.6`, `openai/gpt-5.5`, `openai/gpt-5.4`, `openai/gpt-5.4-mini`, `openai/gpt-5.4-nano`, `openai/o4-mini`.
+
+<Note>
+OpenAI models are called through the Responses API.
+</Note>
+
+[View all supported OpenAI models →](https://platform.openai.com/docs/models)
+</Tab>
+
+<Tab title="Groq">
+
+<View title="TypeScript" icon="js">
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  model: {
+    modelName: "groq/llama-3.3-70b-versatile",
+    apiKey: process.env.GROQ_API_KEY,
+  },
+});
+
+await stagehand.init();
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+from stagehand import Stagehand
+
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    model="groq/llama-3.3-70b-versatile",
+    model_api_key=os.environ["GROQ_API_KEY"],
+)
+
+await stagehand.init()
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+apiKey := os.Getenv("BROWSERBASE_API_KEY")
+modelAPIKey := os.Getenv("GROQ_API_KEY")
+model := stagehand.KnownModel(stagehand.KnownModelConfig{
+	ModelName: "groq/llama-3.3-70b-versatile",
+	APIKey:    &modelAPIKey,
+})
+
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey:  &apiKey,
+	Browser: stagehand.BrowserbaseClientBrowserSource{},
+	Model:   &model,
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+```
+</View>
+
+Commonly used: `groq/llama-3.3-70b-versatile`, `groq/openai/gpt-oss-120b`, `groq/moonshotai/kimi-k2-instruct-0905`, `groq/qwen/qwen3-32b`.
+
+[View all supported Groq models →](https://console.groq.com/docs/models)
+</Tab>
+
+<Tab title="Cerebras">
+
+<View title="TypeScript" icon="js">
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  model: {
+    modelName: "cerebras/gpt-oss-120b",
+    apiKey: process.env.CEREBRAS_API_KEY,
+  },
+});
+
+await stagehand.init();
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+from stagehand import Stagehand
+
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    model="cerebras/gpt-oss-120b",
+    model_api_key=os.environ["CEREBRAS_API_KEY"],
+)
+
+await stagehand.init()
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+apiKey := os.Getenv("BROWSERBASE_API_KEY")
+modelAPIKey := os.Getenv("CEREBRAS_API_KEY")
+model := stagehand.KnownModel(stagehand.KnownModelConfig{
+	ModelName: "cerebras/gpt-oss-120b",
+	APIKey:    &modelAPIKey,
+})
+
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey:  &apiKey,
+	Browser: stagehand.BrowserbaseClientBrowserSource{},
+	Model:   &model,
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+```
+</View>
+
+Commonly used: `cerebras/gpt-oss-120b`, `cerebras/qwen-3-235b-a22b-instruct-2507`, `cerebras/zai-glm-4.7`, `cerebras/llama3.1-8b`.
+
+[View all supported Cerebras models →](https://inference-docs.cerebras.ai/models/overview)
+</Tab>
+
+</Tabs>
+
+---
+
+### Custom models
+
+Any provider Stagehand does not call natively is supported by bringing your own LLM. Instead of a model name, pass a function that Stagehand calls whenever it needs an inference. Your function runs in your process, on your machine, with your own SDKs and credentials: Amazon Bedrock, Cohere, Azure OpenAI, a self-hosted model, anything you can reach from code.
+
+Stagehand sends a provider-neutral request (messages, system prompt, temperature, and a response format) and expects a matching result back. When the response format is a JSON schema, return the parsed object in the structured content field.
+
+<AccordionGroup>
+<Accordion title="Amazon Bedrock">
+
+<Steps>
+<Step title="Install dependencies">
+Install your provider's SDK.
+
+<View title="TypeScript" icon="js">
+```bash
+npm install @aws-sdk/client-bedrock-runtime
+# pnpm add @aws-sdk/client-bedrock-runtime
+# yarn add @aws-sdk/client-bedrock-runtime
+# bun add @aws-sdk/client-bedrock-runtime
+```
+</View>
+
+<View title="Python" icon="python">
+```bash
+pip install boto3
+```
+</View>
+
+<View title="Go" icon="golang">
+```bash
+go get github.com/aws/aws-sdk-go-v2/service/bedrockruntime
+```
+</View>
+</Step>
+
+<Step title="Write the generate callback">
+
+<View title="TypeScript" icon="js">
+```typescript
+import {
+  BedrockRuntimeClient,
+  ConverseCommand,
+} from "@aws-sdk/client-bedrock-runtime";
+
+const bedrock = new BedrockRuntimeClient({ region: "us-east-1" });
+
+// The shape Stagehand passes to your callback. The TypeScript SDK does not
+// re-export `LLMGenerateParams` yet, so spell out the fields you read.
+type LLMGenerateParams = {
+  messages: Array<{ role: "user" | "assistant"; content: unknown }>;
+  systemPrompt?: string;
+  temperature?: number;
+  responseFormat?:
+    | { type: "text" }
+    | { type: "json_schema"; name: string; schema: unknown };
+};
+
+async function generateWithBedrock(params: LLMGenerateParams) {
+  if (params.responseFormat?.type !== "json_schema") {
+    throw new TypeError("Stagehand only issues structured generations");
+  }
+
+  const response = await bedrock.send(new ConverseCommand({
+    modelId: "amazon.nova-pro-v1:0",
+    system: params.systemPrompt ? [{ text: params.systemPrompt }] : undefined,
+    messages: params.messages.map((message) => ({
+      role: message.role,
+      content: [{ text: messageText(message.content) }],
+    })),
+  }));
+
+  const text = response.output?.message?.content?.[0]?.text ?? "";
+  return {
+    role: "assistant",
+    content: { type: "text", text },
+    outputFormat: "json_schema",
+    structuredContent: JSON.parse(text),
+  };
+}
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+import json
+
+import boto3
+
+bedrock = boto3.client("bedrock-runtime", region_name="us-east-1")
+
+
+async def generate_with_bedrock(params):
+    response = bedrock.converse(
+        modelId="amazon.nova-pro-v1:0",
+        system=[{"text": params.system_prompt}] if params.system_prompt else [],
+        messages=[
+            {"role": message.role.value, "content": [{"text": message_text(message)}]}
+            for message in params.messages
+        ],
+    )
+
+    text = response["output"]["message"]["content"][0]["text"]
+    return LLMStructuredGenerateResult.model_validate({
+        "role": "assistant",
+        "content": {"type": "text", "text": text},
+        "output_format": "json_schema",
+        "structured_content": json.loads(text),
+    })
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+func generateWithBedrock(
+	ctx context.Context,
+	params stagehand.LLMGenerateParams,
+) (stagehand.LLMGenerateResult, error) {
+	request, ok := params.AsStructured()
+	if !ok {
+		return stagehand.LLMGenerateResult{}, errors.New("Stagehand only issues structured generations")
+	}
+
+	messages := make([]types.Message, 0, len(request.Messages))
+	for _, message := range request.Messages {
+		messages = append(messages, types.Message{
+			Role:    types.ConversationRole(message.Role),
+			Content: []types.ContentBlock{&types.ContentBlockMemberText{Value: messageText(message)}},
+		})
+	}
+
+	response, err := bedrock.Converse(ctx, &bedrockruntime.ConverseInput{
+		ModelId:  aws.String("amazon.nova-pro-v1:0"),
+		Messages: messages,
+		System:   systemBlocks(request.SystemPrompt),
+	})
+	if err != nil {
+		return stagehand.LLMGenerateResult{}, err
+	}
+
+	text := responseText(response)
+	return stagehand.StructuredGenerateResult(stagehand.LLMStructuredGenerateResult{
+		Role:              stagehand.LLMRoleAssistant,
+		Content:           stagehand.LLMMessageContent{stagehand.TextContentBlock(stagehand.LLMTextContent{Text: text})},
+		StructuredContent: json.RawMessage(text),
+	}), nil
+}
+```
+</View>
+</Step>
+
+<Step title="Pass the callback to Stagehand">
+
+<View title="TypeScript" icon="js">
+```typescript
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  model: { generate: generateWithBedrock },
+});
+
+await stagehand.init();
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    model=generate_with_bedrock,
+)
+
+await stagehand.init()
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+apiKey := os.Getenv("BROWSERBASE_API_KEY")
+
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey:   &apiKey,
+	Generate: generateWithBedrock,
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+```
+</View>
+
+</Step>
+</Steps>
+</Accordion>
+<Accordion title="OpenAI-compatible SDKs">
+
+<Steps>
+<Step title="Install dependencies">
+Install your provider's SDK.
+
+<View title="TypeScript" icon="js">
+```bash
+npm install openai
+# pnpm add openai
+# yarn add openai
+# bun add openai
+```
+</View>
+
+<View title="Python" icon="python">
+```bash
+pip install openai
+```
+</View>
+
+<View title="Go" icon="golang">
+```bash
+go get github.com/openai/openai-go
+```
+</View>
+</Step>
+
+<Step title="Write the generate callback">
+
+<View title="TypeScript" icon="js">
+```typescript
+import OpenAI from "openai";
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+// The shape Stagehand passes to your callback. The TypeScript SDK does not
+// re-export `LLMGenerateParams` yet, so spell out the fields you read.
+type LLMGenerateParams = {
+  messages: Array<{ role: "user" | "assistant"; content: unknown }>;
+  systemPrompt?: string;
+  temperature?: number;
+  responseFormat?:
+    | { type: "text" }
+    | { type: "json_schema"; name: string; schema: unknown };
+};
+
+async function generateWithOpenAI(params: LLMGenerateParams) {
+  if (params.responseFormat?.type !== "json_schema") {
+    throw new TypeError("Stagehand only issues structured generations");
+  }
+
+  const response = await openai.responses.create({
+    model: "gpt-5.4-mini",
+    instructions: params.systemPrompt,
+    input: params.messages.map((message) => ({
+      role: message.role,
+      content: messageText(message.content),
+    })),
+    temperature: params.temperature,
+    text: {
+      format: {
+        type: "json_schema",
+        name: params.responseFormat.name,
+        schema: params.responseFormat.schema,
+        strict: true,
+      },
+    },
+  });
+
+  return {
+    role: "assistant",
+    content: { type: "text", text: response.output_text },
+    outputFormat: "json_schema",
+    structuredContent: JSON.parse(response.output_text),
+    // usage is optional; map your provider's own field names onto Stagehand's
+    ...(response.usage ? { usage: toStagehandUsage(response.usage) } : {}),
+  };
+}
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+import json
+
+from openai import AsyncOpenAI
+
+from stagehand import LLMStructuredGenerateResult
+
+openai = AsyncOpenAI(api_key=os.environ["OPENAI_API_KEY"])
+
+
+async def generate_with_openai(params):
+    response_format = params.response_format
+    response = await openai.responses.create(
+        model="gpt-5.4-mini",
+        instructions=params.system_prompt,
+        input=[
+            {"role": message.role.value, "content": message_text(message)}
+            for message in params.messages
+        ],
+        temperature=params.temperature,
+        text={
+            "format": {
+                "type": "json_schema",
+                "name": response_format.name,
+                "schema": response_format.schema_.model_dump(),
+                "strict": True,
+            }
+        },
+    )
+
+    return LLMStructuredGenerateResult.model_validate({
+        "role": "assistant",
+        "content": {"type": "text", "text": response.output_text},
+        "output_format": "json_schema",
+        "structured_content": json.loads(response.output_text),
+    })
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+func generateWithOpenAI(
+	ctx context.Context,
+	params stagehand.LLMGenerateParams,
+) (stagehand.LLMGenerateResult, error) {
+	request, ok := params.AsStructured()
+	if !ok {
+		return stagehand.LLMGenerateResult{}, errors.New("Stagehand only issues structured generations")
+	}
+
+	text, err := callOpenAI(ctx, callOpenAIInput{
+		Model:          "gpt-5.4-mini",
+		Instructions:   request.SystemPrompt,
+		Messages:       request.Messages,
+		Temperature:    request.Temperature,
+		SchemaName:     request.ResponseFormat.Name,
+		Schema:         request.ResponseFormat.Schema,
+	})
+	if err != nil {
+		return stagehand.LLMGenerateResult{}, err
+	}
+
+	return stagehand.StructuredGenerateResult(stagehand.LLMStructuredGenerateResult{
+		Role:              stagehand.LLMRoleAssistant,
+		Content:           stagehand.LLMMessageContent{stagehand.TextContentBlock(stagehand.LLMTextContent{Text: text})},
+		StructuredContent: json.RawMessage(text),
+	}), nil
+}
+```
+</View>
+</Step>
+
+<Step title="Pass the callback to Stagehand">
+
+<View title="TypeScript" icon="js">
+```typescript
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  model: { generate: generateWithOpenAI },
+});
+
+await stagehand.init();
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    model=generate_with_openai,
+)
+
+await stagehand.init()
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+apiKey := os.Getenv("BROWSERBASE_API_KEY")
+
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey:   &apiKey,
+	Generate: generateWithOpenAI,
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+```
+</View>
+
+</Step>
+</Steps>
+</Accordion>
+<Accordion title="All providers">
+
+The pattern is the same for every provider: implement one function, wire it in, done. Your callback never crosses the wire; Stagehand records only that the model lives on the client and calls back to you over the same connection.
+
+<Steps>
+<Step title="Install dependencies">
+Install your provider's SDK.
+</Step>
+<Step title="Write the generate callback">
+
+<View title="TypeScript" icon="js">
+```typescript
+// The shape Stagehand passes to your callback. The TypeScript SDK does not
+// re-export `LLMGenerateParams` yet, so spell out the fields you read.
+type LLMGenerateParams = {
+  messages: Array<{ role: "user" | "assistant"; content: unknown }>;
+  systemPrompt?: string;
+  temperature?: number;
+  responseFormat?:
+    | { type: "text" }
+    | { type: "json_schema"; name: string; schema: unknown };
+};
+
+async function generateWithYourProvider(params: LLMGenerateParams) {
+  // params.messages       Conversation so far
+  // params.systemPrompt   System instructions
+  // params.temperature    Sampling temperature, when set
+  // params.responseFormat { type: "json_schema", name, schema } for act/observe/extract
+
+  const text = await callYourProvider(params);
+
+  return {
+    role: "assistant",
+    content: { type: "text", text },
+    outputFormat: "json_schema",
+    structuredContent: JSON.parse(text),
+  };
+}
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+async def generate_with_your_provider(params):
+    # params.messages         Conversation so far
+    # params.system_prompt    System instructions
+    # params.temperature      Sampling temperature, when set
+    # params.response_format  JSON schema request for act/observe/extract
+
+    text = await call_your_provider(params)
+
+    return LLMStructuredGenerateResult.model_validate({
+        "role": "assistant",
+        "content": {"type": "text", "text": text},
+        "output_format": "json_schema",
+        "structured_content": json.loads(text),
+    })
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+func generateWithYourProvider(
+	ctx context.Context,
+	params stagehand.LLMGenerateParams,
+) (stagehand.LLMGenerateResult, error) {
+	// params.AsStructured() yields the JSON schema request act/observe/extract send
+	//   request.Messages        Conversation so far
+	//   request.SystemPrompt    System instructions
+	//   request.Temperature     Sampling temperature, when set
+	//   request.ResponseFormat  Name plus the JSON Schema to satisfy
+	request, ok := params.AsStructured()
+	if !ok {
+		return stagehand.LLMGenerateResult{}, errors.New("expected a structured generation")
+	}
+
+	text, err := callYourProvider(ctx, request)
+	if err != nil {
+		return stagehand.LLMGenerateResult{}, err
+	}
+
+	return stagehand.StructuredGenerateResult(stagehand.LLMStructuredGenerateResult{
+		Role:              stagehand.LLMRoleAssistant,
+		Content:           stagehand.LLMMessageContent{stagehand.TextContentBlock(stagehand.LLMTextContent{Text: text})},
+		StructuredContent: json.RawMessage(text),
+	}), nil
+}
+```
+</View>
+</Step>
+<Step title="Pass the callback to Stagehand">
+
+<View title="TypeScript" icon="js">
+```typescript
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  model: { generate: generateWithYourProvider },
+});
+
+await stagehand.init();
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    model=generate_with_your_provider,
+)
+
+await stagehand.init()
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+apiKey := os.Getenv("BROWSERBASE_API_KEY")
+
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey:   &apiKey,
+	Generate: generateWithYourProvider,
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+```
+</View>
+
+</Step>
+</Steps>
+</Accordion>
+</AccordionGroup>
+
+<Note>
+The result is validated against the response format Stagehand asked for. If you return text when a JSON schema was requested, or structured content that does not match the schema, the call fails loudly rather than silently degrading.
+</Note>
+
+
+---
+
+## Choose a model
+
+Different models excel at different tasks. Consider speed, accuracy, and cost for your use case.
+
+<Card title="Model selection guide" href="https://www.stagehand.dev/evals" icon="scale-balanced">
+  Find detailed model comparisons and recommendations on the Stagehand model evaluation page.
+</Card>
+
+**Quick recommendations**
+
+| Use Case                  | Recommended Model                    | Why                            |
+| ------------------------- | ------------------------------------ | ------------------------------ |
+| **Production** | `google/gemini-2.5-flash`            | Fast, accurate, cost-effective |
+| **Intelligence**     | `google/gemini-3.1-pro-preview` | Best accuracy on hard tasks    |
+| **Speed**        | `google/gemini-2.5-flash`                 | Fastest response times         |
+| **Cost**     | `google/gemini-2.5-flash`            | Best value per token           |
+| **Local/offline**         | Bring your own LLM callback                    | No API costs, full control     |
+
+
+---
+
+## Advanced options
+
+### Per-call model overrides
+
+Every primitive accepts a model configuration for a single call, so you can run cheap inference by default and reach for a stronger model only where it matters:
+
+<View title="TypeScript" icon="js">
+```typescript
+const PricingSchema = z.object({ summary: z.string() });
+
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  model: {
+    modelName: "google/gemini-2.5-flash",
+    apiKey: process.env.GOOGLE_GENERATIVE_AI_API_KEY,
+  },
+});
+
+// Uses the instance model
+await stagehand.act("click the login button");
+
+// Uses a stronger model for one hard extraction
+const { data } = await stagehand.extract("summarize the pricing table", PricingSchema, {
+  model: {
+    modelName: "anthropic/claude-sonnet-4-6",
+    apiKey: process.env.ANTHROPIC_API_KEY,
+  },
+});
+
+console.log(data.summary);
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+from stagehand import ModelConfig, Stagehand
+
+
+class Pricing(BaseModel):
+    summary: str
+
+
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    model="google/gemini-2.5-flash",
+    model_api_key=os.environ["GOOGLE_GENERATIVE_AI_API_KEY"],
+)
+
+# Uses the instance model
+await stagehand.act("click the login button")
+
+# Uses a stronger model for one hard extraction
+data = (await stagehand.extract(
+    instruction="summarize the pricing table",
+    schema=Pricing,
+    model=ModelConfig.model_validate({
+        "model_name": "anthropic/claude-sonnet-4-6",
+        "api_key": os.environ["ANTHROPIC_API_KEY"],
+    }),
+)).data
+
+print(data.summary)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+type pricing struct {
+	Summary string `json:"summary"`
+}
+
+var pricingSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {"summary": {"type": "string"}},
+  "required": ["summary"],
+  "additionalProperties": false
+}`)
+
+apiKey := os.Getenv("BROWSERBASE_API_KEY")
+googleKey := os.Getenv("GOOGLE_GENERATIVE_AI_API_KEY")
+instanceModel := stagehand.KnownModel(stagehand.KnownModelConfig{
+	ModelName: "google/gemini-2.5-flash",
+	APIKey:    &googleKey,
+})
+
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey: &apiKey,
+	Model:  &instanceModel,
+})
+
+// Uses the instance model
+if _, err := client.Act(ctx, "click the login button", nil); err != nil {
+	return err
+}
+
+// Uses a stronger model for one hard extraction
+anthropicKey := os.Getenv("ANTHROPIC_API_KEY")
+strongModel := stagehand.KnownModel(stagehand.KnownModelConfig{
+	ModelName: "anthropic/claude-sonnet-4-6",
+	APIKey:    &anthropicKey,
+})
+
+extracted, err := stagehand.ExtractAs[pricing](
+	ctx,
+	client,
+	"summarize the pricing table",
+	pricingSchema,
+	&stagehand.StagehandClientExtractOptions{
+		ExtractOptions: stagehand.ExtractOptions{Model: &strongModel},
+	},
+)
+if err != nil {
+	return err
+}
+
+fmt.Println(extracted.Summary)
+```
+</View>
+
+<Note>
+Model configuration is deliberately excluded from the [cache key](/v3/best-practices/caching), so switching models per call does not invalidate cached results.
+</Note>
+
+---
+
+### Custom endpoints
+
+If you need Azure OpenAI deployments or enterprise deployments, point Stagehand at an OpenAI-compatible base URL. The model name is passed through untouched, so it can be a deployment name rather than a public model ID.
+
+<Tabs>
+<Tab title="OpenAI-compatible endpoint">
+
+<View title="TypeScript" icon="js">
+```typescript
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  model: {
+    modelName: "gpt-5",
+    apiKey: process.env.OPENAI_API_KEY,
+    baseURL: "https://custom-openai-endpoint.com/v1",
+  },
+});
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    model="gpt-5",
+    model_api_key=os.environ["OPENAI_API_KEY"],
+    model_base_url="https://custom-openai-endpoint.com/v1",
+)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+apiKey := os.Getenv("BROWSERBASE_API_KEY")
+modelAPIKey := os.Getenv("OPENAI_API_KEY")
+model := stagehand.CustomModel(stagehand.CustomModelConfig{
+	ModelName: "gpt-5",
+	APIKey:    &modelAPIKey,
+	BaseURL:   "https://custom-openai-endpoint.com/v1",
+})
+
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey: &apiKey,
+	Model:  &model,
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+defer func() { err = errors.Join(err, client.Close(ctx)) }()
+```
+</View>
+
+</Tab>
+
+<Tab title="Custom headers">
+
+Some enterprise gateways require extra headers on every request. Attach them to the model configuration:
+
+<View title="TypeScript" icon="js">
+```typescript
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  model: {
+    modelName: "my-deployment",
+    apiKey: process.env.GATEWAY_TOKEN,
+    baseURL: "https://models.example.com/v1",
+    headers: { "x-tenant-id": "acme" },
+  },
+});
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    model="my-deployment",
+    model_api_key=os.environ["GATEWAY_TOKEN"],
+    model_base_url="https://models.example.com/v1",
+    model_headers={"x-tenant-id": "acme"},
+)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+apiKey := os.Getenv("BROWSERBASE_API_KEY")
+gatewayToken := os.Getenv("GATEWAY_TOKEN")
+model := stagehand.CustomModel(stagehand.CustomModelConfig{
+	ModelName: "my-deployment",
+	APIKey:    &gatewayToken,
+	BaseURL:   "https://models.example.com/v1",
+	Headers:   stagehand.CustomModelConfigHeaders{"x-tenant-id": "acme"},
+})
+
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey: &apiKey,
+	Model:  &model,
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+defer func() { err = errors.Join(err, client.Close(ctx)) }()
+```
+</View>
+
+</Tab>
+<Tab title="Providers without an OpenAI-compatible API">
+
+For anything that is not OpenAI-compatible, use the [bring-your-own-LLM callback](#custom-models). You keep full control of the client, the transport, and the credentials.
+
+<View title="TypeScript" icon="js">
+```typescript
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  model: { generate: generateWithYourProvider },
+});
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    model=generate_with_your_provider,
+)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+apiKey := os.Getenv("BROWSERBASE_API_KEY")
+
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey:   &apiKey,
+	Generate: generateWithYourProvider,
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+defer func() { err = errors.Join(err, client.Close(ctx)) }()
+```
+</View>
+
+</Tab>
+</Tabs>
+
+{/* TODO: baseURL / model_base_url validates but the v4 runtime currently raises "Custom OpenAI-compatible inference is not implemented yet." Verify before publishing. */}
+
+---
+
+### Extending your LLM client
+
+For advanced use cases like custom retries or caching logic, wrap your generate callback. Because the callback is ordinary code in your process, you can layer whatever behavior you need around it:
+
+<View title="TypeScript" icon="js">
+```typescript
+// Generic in the callback's own params and result, so the wrapper stays
+// interchangeable with the callback it wraps.
+function withRetries<Params, Result>(
+  generate: (params: Params) => Promise<Result>,
+  attempts = 3,
+) {
+  return async (params: Params) => {
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+      try {
+        return await generate(params);
+      } catch (error) {
+        if (attempt === attempts) throw error;
+        await new Promise((resolve) => setTimeout(resolve, 1000 * attempt));
+      }
+    }
+    throw new Error("withRetries needs at least one attempt");
+  };
+}
+
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  model: { generate: withRetries(generateWithOpenAI) },
+});
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+import asyncio
+
+
+def with_retries(generate, attempts: int = 3):
+    async def wrapped(params):
+        for attempt in range(1, attempts + 1):
+            try:
+                return await generate(params)
+            except Exception:
+                if attempt == attempts:
+                    raise
+                await asyncio.sleep(attempt)
+
+    return wrapped
+
+
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    model=with_retries(generate_with_openai),
+)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+func withRetries(generate stagehand.LLMGenerateFunc, attempts int) stagehand.LLMGenerateFunc {
+	return func(ctx context.Context, params stagehand.LLMGenerateParams) (stagehand.LLMGenerateResult, error) {
+		var lastErr error
+		for attempt := 1; attempt <= attempts; attempt++ {
+			result, err := generate(ctx, params)
+			if err == nil {
+				return result, nil
+			}
+			lastErr = err
+			if attempt == attempts {
+				break
+			}
+			select {
+			case <-ctx.Done():
+				return stagehand.LLMGenerateResult{}, ctx.Err()
+			case <-time.After(time.Duration(attempt) * time.Second):
+			}
+		}
+		return stagehand.LLMGenerateResult{}, lastErr
+	}
+}
+
+apiKey := os.Getenv("BROWSERBASE_API_KEY")
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey:   &apiKey,
+	Generate: withRetries(generateWithOpenAI, 3),
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+defer func() { err = errors.Join(err, client.Close(ctx)) }()
+```
+</View>
+
+<Tip>
+  Need result caching rather than request retries? Use the built-in [caching
+  feature](/v3/best-practices/caching), which skips the inference call entirely.
+</Tip>
+
+---
+
+## Troubleshooting
+
+<AccordionGroup>
+<Accordion title="Error: API key not found">
+**Error:** `API key not found`
+
+**Solutions:**
+
+- Read the provider key from the environment and pass it on the model configuration; Stagehand never reads it for you
+- Confirm you are reading the variable name your provider expects
+- If you intended to use Model Gateway, omit the model API key entirely and pass only your Browserbase key
+
+| Provider   | Conventional Environment Variable |
+| ---------- | ------------------------------ |
+| Model Gateway | `BROWSERBASE_API_KEY` (no provider key needed) |
+| Google     | `GOOGLE_GENERATIVE_AI_API_KEY` or `GEMINI_API_KEY` |
+| Anthropic  | `ANTHROPIC_API_KEY`            |
+| OpenAI     | `OPENAI_API_KEY`               |
+| Groq       | `GROQ_API_KEY`                 |
+| Cerebras   | `CEREBRAS_API_KEY`             |
+| Custom endpoint | Whatever your gateway issues, passed as the model API key |
+| Bring your own LLM | None; your callback owns its credentials |
+
+</Accordion>
+
+<Accordion title="Error: model not supported">
+**Error:** `Unsupported model`
+
+**Solutions:**
+
+- Use the `provider/model` format: `openai/gpt-5`. The prefix is required; bare model names are rejected
+- Use one of the five supported providers: `openai`, `anthropic`, `google`, `groq`, `cerebras`
+- For a provider outside that list, use a [custom endpoint](#custom-endpoints) or a [bring-your-own-LLM callback](#custom-models)
+
+Only the provider prefix is checked. The model ID itself is not validated, so a typo or a model your key cannot reach surfaces as the provider's own error (usually a `400`) on the first inference, not as an `Unsupported model` error. Verify the model name against the provider's documentation and confirm your model API key has access to it.
+</Accordion>
+
+<Accordion title="Model doesn't support structured outputs">
+**Error:** `Model does not support structured outputs`
+
+**Solutions:**
+
+- Every Stagehand primitive requests a JSON schema response, so the model must support structured outputs
+- Check the [Stagehand model evaluation page](https://www.stagehand.dev/evals) for recommended models
+</Accordion>
+
+<Accordion title="High costs or slow performance">
+**Symptoms:** Automation is expensive or slow
+
+**Solutions:**
+
+- Switch to cost-effective models (check [evals](https://www.stagehand.dev/evals) for comparisons)
+- Use faster models for simple tasks and reach for powerful ones per call with a [model override](#per-call-model-overrides)
+- Implement [caching](/v3/best-practices/caching) for repeated patterns
+</Accordion>
+<Accordion title="Python SDK or custom models">
+Python is a first-class SDK in Stagehand v4 with the same surface as TypeScript.
+
+**Solutions:**
+
+- Use the language selector on this page to see every sample in Python
+- Pass an async callable as the model to bring your own LLM
+</Accordion>
+</AccordionGroup>
+
+### Need help? Contact support
+
+Can't find a solution? Have a question? Reach out to the Browserbase support team:
+
+<Card
+  title="Contact support"
+  icon="envelope"
+  href="mailto:support@browserbase.com"
+>
+  Email Browserbase at support@browserbase.com
+</Card>
+
+---
+
+## Next steps
+
+<CardGroup cols={2}>
+<Card title="Prompting guide" href="/v3/best-practices/prompting-best-practices" icon="brain">
+  Learn how to prompt LLMs for optimal results
+</Card>
+<Card title="Observability" href="/v4/configuration/observability" icon="chart-line">
+  Track token usage and inference latency per operation
+</Card>
+
+<Card title="Caching guide" href="/v3/best-practices/caching" icon="database">
+  Cache responses to reduce costs and improve speed
+</Card>
+<Card
+  title="Optimize costs"
+  href="/v3/best-practices/cost-optimization"
+  icon="dollar-sign"
+>
+  Reduce LLM spending with caching and smart model selection
+</Card>
+</CardGroup>

--- a/packages/docs/v4/configuration/observability.mdx
+++ b/packages/docs/v4/configuration/observability.mdx
@@ -57,6 +57,8 @@ console.log("Proxy bytes:", sessionInfo.proxyBytes);
 
 <View title="Python" icon="python">
 ```python
+import os
+
 from browserbase import Browserbase
 
 from stagehand import Stagehand
@@ -276,6 +278,8 @@ For local development, Stagehand provides performance monitoring and resource tr
 
 ### Performance tracking
 
+{/* TODO: these samples call stagehand.metrics(), which is typed end to end but currently throws "Method not implemented" in the runtime. Same caveat as the "Real-time metrics & monitoring" section below; verify both before publishing. */}
+
 <View title="TypeScript" icon="js">
 ```typescript
 import { Stagehand } from "@browserbasehq/stagehand";
@@ -323,6 +327,8 @@ console.log("Local Performance Summary:", {
 <View title="Python" icon="python">
 ```python
 from time import perf_counter
+
+from pydantic import BaseModel
 
 from stagehand import Stagehand, StagehandClientLoggingConfig
 

--- a/packages/docs/v4/configuration/observability.mdx
+++ b/packages/docs/v4/configuration/observability.mdx
@@ -1,0 +1,1118 @@
+---
+title: Observability
+sidebarTitle: Observability
+description: Track Stagehand automation with session visibility and analytics
+---
+
+Stagehand provides powerful observability features to help you monitor, track performance, and analyze your browser automation workflows. Focus on session monitoring, resource usage, and operational insights for both Browserbase and local environments.
+
+## Browserbase session monitoring
+
+When running on Browserbase, you gain access to comprehensive cloud-based monitoring and session management through the Browserbase API and dashboard.
+
+<div style={{ textAlign: "center" }}>
+  <img src="/media/observability.gif" alt="Browserbase Session Observability" width="400" />
+</div>
+
+### Live session visibility
+
+Browserbase provides real-time visibility into your automation sessions:
+
+**Session dashboard features**
+- Real-time browser screen recording and replay
+- Network request monitoring with detailed timing
+- JavaScript console logs and error tracking
+- CPU and memory usage metrics
+- Session status and duration tracking
+
+**Session management & API access**
+
+<View title="TypeScript" icon="js">
+```typescript
+import { Browserbase } from "@browserbasehq/sdk";
+import { Stagehand } from "@browserbasehq/stagehand";
+
+const browserbase = new Browserbase({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+});
+
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  browser: { type: "browserbase" },
+});
+
+await stagehand.init();
+
+// The resolved browser source carries the Browserbase session ID
+const sessionId = stagehand.browser.browserbaseSessionId;
+const sessionInfo = await browserbase.sessions.retrieve(sessionId);
+
+console.log("Session status:", sessionInfo.status);
+console.log("Session region:", sessionInfo.region);
+console.log("CPU usage:", sessionInfo.avgCpuUsage);
+console.log("Memory usage:", sessionInfo.memoryUsage);
+console.log("Proxy bytes:", sessionInfo.proxyBytes);
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+from browserbase import Browserbase
+
+from stagehand import Stagehand
+
+browserbase = Browserbase(api_key=os.environ["BROWSERBASE_API_KEY"])
+
+# Create the session yourself so you hold the session ID
+session = browserbase.sessions.create(
+    project_id=os.environ["BROWSERBASE_PROJECT_ID"],
+)
+
+stagehand = Stagehand(browser="cdp", cdp_url=session.connect_url)
+
+await stagehand.init()
+
+session_info = browserbase.sessions.retrieve(session.id)
+
+print("Session status:", session_info.status)
+print("Session region:", session_info.region)
+print("CPU usage:", session_info.avg_cpu_usage)
+print("Memory usage:", session_info.memory_usage)
+print("Proxy bytes:", session_info.proxy_bytes)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+// Create the session with your Browserbase client of choice so you hold the
+// session ID, then attach Stagehand over CDP.
+session, err := createBrowserbaseSession(ctx)
+if err != nil {
+	return err
+}
+
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	Browser: stagehand.CDPBrowserSource{CDPURL: session.ConnectURL},
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+
+info, err := retrieveBrowserbaseSession(ctx, session.ID)
+if err != nil {
+	return err
+}
+
+fmt.Println("Session status:", info.Status)
+fmt.Println("Session region:", info.Region)
+fmt.Println("CPU usage:", info.AvgCPUUsage)
+fmt.Println("Memory usage:", info.MemoryUsage)
+fmt.Println("Proxy bytes:", info.ProxyBytes)
+```
+</View>
+
+### Session analytics & insights
+
+<CardGroup>
+  <Card title="Real-time monitoring" icon="chart-line">
+    Monitor live session status, resource usage, and geographic distribution. Scale and manage concurrent sessions with real-time insights.
+  </Card>
+
+  <Card title="Session recordings" icon="video">
+    Review complete session recordings with frame-by-frame playback. Analyze network requests and debug browser interactions visually.
+  </Card>
+
+  <Card title="API management" icon="code">
+    Programmatically access session data, automate lifecycle management, and integrate with monitoring systems through the Browserbase API.
+  </Card>
+
+  <Card title="Usage monitoring" icon="chart-bar">
+    Track resource consumption, session duration, and API usage. Get detailed breakdowns of costs and utilization across your automation.
+  </Card>
+</CardGroup>
+
+### Session monitoring & filtering
+
+Query and monitor sessions by status and metadata:
+
+<View title="TypeScript" icon="js">
+```typescript
+import { Browserbase } from "@browserbasehq/sdk";
+
+const browserbase = new Browserbase({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+});
+
+// The fields this example reads off a Browserbase session. Resource counters
+// are optional because older API versions omit them.
+type BrowserbaseSession = {
+  id: string;
+  status: string;
+  startedAt: string;
+  endedAt?: string;
+  region: string;
+  proxyBytes: number;
+  avgCpuUsage?: number;
+  memoryUsage?: number;
+  userMetadata?: Record<string, unknown>;
+};
+
+// List sessions with filtering
+async function getFilteredSessions() {
+  const sessions = await browserbase.sessions.list({
+    status: "RUNNING",
+  });
+
+  return sessions.map((session: BrowserbaseSession) => ({
+    id: session.id,
+    status: session.status, // RUNNING, COMPLETED, ERROR, TIMED_OUT
+    startedAt: session.startedAt,
+    endedAt: session.endedAt,
+    region: session.region,
+    avgCpuUsage: session.avgCpuUsage,
+    memoryUsage: session.memoryUsage,
+    proxyBytes: session.proxyBytes,
+    userMetadata: session.userMetadata,
+  }));
+}
+
+// Query sessions by metadata
+async function querySessionsByMetadata(query: string) {
+  const sessions = await browserbase.sessions.list({
+    q: query,
+  });
+
+  return sessions;
+}
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+from browserbase import Browserbase
+
+browserbase = Browserbase(api_key=os.environ["BROWSERBASE_API_KEY"])
+
+
+# List sessions with filtering
+def get_filtered_sessions():
+    sessions = browserbase.sessions.list(status="RUNNING")
+
+    return [
+        {
+            "id": session.id,
+            "status": session.status,  # RUNNING, COMPLETED, ERROR, TIMED_OUT
+            "started_at": session.started_at,
+            "ended_at": session.ended_at,
+            "region": session.region,
+            "avg_cpu_usage": session.avg_cpu_usage,
+            "memory_usage": session.memory_usage,
+            "proxy_bytes": session.proxy_bytes,
+            "user_metadata": session.user_metadata,
+        }
+        for session in sessions
+    ]
+
+
+# Query sessions by metadata
+def query_sessions_by_metadata(query: str):
+    return browserbase.sessions.list(q=query)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+type sessionSummary struct {
+	ID           string
+	Status       string // RUNNING, COMPLETED, ERROR, TIMED_OUT
+	StartedAt    time.Time
+	EndedAt      time.Time
+	Region       string
+	AvgCPUUsage  float64
+	MemoryUsage  float64
+	ProxyBytes   int64
+	UserMetadata map[string]any
+}
+
+// List sessions with filtering
+func getFilteredSessions(ctx context.Context) ([]sessionSummary, error) {
+	sessions, err := listBrowserbaseSessions(ctx, listOptions{Status: "RUNNING"})
+	if err != nil {
+		return nil, err
+	}
+
+	summaries := make([]sessionSummary, 0, len(sessions))
+	for _, session := range sessions {
+		summaries = append(summaries, sessionSummary{
+			ID:           session.ID,
+			Status:       session.Status,
+			StartedAt:    session.StartedAt,
+			EndedAt:      session.EndedAt,
+			Region:       session.Region,
+			AvgCPUUsage:  session.AvgCPUUsage,
+			MemoryUsage:  session.MemoryUsage,
+			ProxyBytes:   session.ProxyBytes,
+			UserMetadata: session.UserMetadata,
+		})
+	}
+	return summaries, nil
+}
+
+// Query sessions by metadata
+func querySessionsByMetadata(ctx context.Context, query string) ([]browserbaseSession, error) {
+	return listBrowserbaseSessions(ctx, listOptions{Query: query})
+}
+```
+</View>
+
+<Tip>
+Tag every session with `userMetadata` on the Browserbase browser source so you can slice these queries by workflow, customer, or deployment.
+</Tip>
+
+## Local environment monitoring
+
+For local development, Stagehand provides performance monitoring and resource tracking capabilities directly on your machine.
+
+### Performance tracking
+
+<View title="TypeScript" icon="js">
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+import { z } from "zod/v4";
+
+const DataSchema = z.object({ title: z.string() });
+
+const stagehand = new Stagehand({
+  browser: { type: "local" },
+  logging: { level: "info" }, // Monitor performance without debug noise
+});
+
+await stagehand.init();
+
+// Track local automation metrics
+const startTime = Date.now();
+const initialMetrics = await stagehand.metrics();
+
+// ... perform automation tasks
+const page = await stagehand.context.activePage();
+if (!page) {
+  throw new Error("Stagehand initialized without an active page");
+}
+await page.goto("https://example.com");
+await stagehand.act("click button");
+await stagehand.extract("get data", DataSchema);
+
+const finalMetrics = await stagehand.metrics();
+const executionTime = Date.now() - startTime;
+
+// Metrics are cumulative for the session, so subtract the baseline
+const tokensUsed =
+  finalMetrics.totalPromptTokens + finalMetrics.totalCompletionTokens -
+  (initialMetrics.totalPromptTokens + initialMetrics.totalCompletionTokens);
+
+console.log("Local Performance Summary:", {
+  executionTime: `${executionTime}ms`,
+  tokensUsed,
+  totalInferenceTime: `${finalMetrics.totalInferenceTimeMs}ms`,
+  tokensPerSecond: (tokensUsed / (executionTime / 1000)).toFixed(2),
+});
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+from time import perf_counter
+
+from stagehand import Stagehand, StagehandClientLoggingConfig
+
+
+class Data(BaseModel):
+    title: str
+
+
+stagehand = Stagehand(
+    browser="local",
+    logging=StagehandClientLoggingConfig(level="info"),  # Monitor without debug noise
+)
+
+await stagehand.init()
+
+# Track local automation metrics
+start_time = perf_counter()
+initial_metrics = await stagehand.metrics()
+
+# ... perform automation tasks
+page = await stagehand.context.active_page()
+if page is None:
+    raise RuntimeError("Stagehand initialized without an active page")
+await page.goto("https://example.com")
+await stagehand.act("click button")
+await stagehand.extract(instruction="get data", schema=Data)
+
+final_metrics = await stagehand.metrics()
+execution_time = (perf_counter() - start_time) * 1000
+
+# Metrics are cumulative for the session, so subtract the baseline
+tokens_used = (
+    final_metrics.total_prompt_tokens
+    + final_metrics.total_completion_tokens
+    - initial_metrics.total_prompt_tokens
+    - initial_metrics.total_completion_tokens
+)
+print("Local Performance Summary:", {
+    "execution_time": f"{execution_time:.0f}ms",
+    "tokens_used": tokens_used,
+    "total_inference_time": f"{final_metrics.total_inference_time_ms}ms",
+    "tokens_per_second": f"{tokens_used / (execution_time / 1000):.2f}",
+})
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+type data struct {
+	Title string `json:"title"`
+}
+
+var dataSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {"title": {"type": "string"}},
+  "required": ["title"],
+  "additionalProperties": false
+}`)
+
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	Browser: stagehand.LocalBrowserSource{},
+	Logging: &stagehand.StagehandClientLoggingConfig{
+		OnLog: func(entry stagehand.StagehandLog) {
+			if entry.Level == stagehand.StagehandLogLevelDebug {
+				return // Monitor performance without debug noise
+			}
+			fmt.Fprintf(os.Stderr, "[stagehand] %s %s\n", entry.Level, entry.Message)
+		},
+	},
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+
+// Track local automation metrics
+startTime := time.Now()
+initialMetrics, err := client.Metrics(ctx)
+if err != nil {
+	return err
+}
+
+// ... perform automation tasks
+browserContext, err := client.Context()
+if err != nil {
+	return err
+}
+page, err := browserContext.ActivePage(ctx)
+if err != nil {
+	return err
+}
+if page == nil {
+	return errors.New("Stagehand initialized without an active page")
+}
+if err := page.Goto(ctx, "https://example.com", nil); err != nil {
+	return err
+}
+if _, err := client.Act(ctx, "click button", nil); err != nil {
+	return err
+}
+if _, err := stagehand.ExtractAs[data](ctx, client, "get data", dataSchema, nil); err != nil {
+	return err
+}
+
+finalMetrics, err := client.Metrics(ctx)
+if err != nil {
+	return err
+}
+executionTime := time.Since(startTime)
+
+// Metrics are cumulative for the session, so subtract the baseline
+tokensUsed := (finalMetrics.TotalPromptTokens + finalMetrics.TotalCompletionTokens) -
+	(initialMetrics.TotalPromptTokens + initialMetrics.TotalCompletionTokens)
+
+fmt.Printf(
+	"Local Performance Summary: executionTime=%dms tokensUsed=%.0f totalInferenceTime=%.0fms tokensPerSecond=%.2f\n",
+	executionTime.Milliseconds(),
+	tokensUsed,
+	finalMetrics.TotalInferenceTimeMs,
+	tokensUsed/executionTime.Seconds(),
+)
+```
+</View>
+
+## Resource usage monitoring
+
+When running locally, monitor system resource usage and browser performance:
+
+<View title="TypeScript" icon="js">
+```typescript
+import * as os from "node:os";
+import { Stagehand } from "@browserbasehq/stagehand";
+
+class LocalResourceMonitor {
+  private cpuUsage: number[] = [];
+  private memoryUsage: number[] = [];
+
+  startMonitoring() {
+    const interval = setInterval(() => {
+      // Track system resources
+      const memUsage = process.memoryUsage();
+      this.memoryUsage.push(memUsage.heapUsed / 1024 / 1024); // MB
+
+      // Track CPU (simplified)
+      const loadAvg = os.loadavg()[0];
+      this.cpuUsage.push(loadAvg);
+    }, 1000);
+
+    return interval;
+  }
+
+  getResourceSummary() {
+    return {
+      avgMemoryUsage: this.memoryUsage.reduce((a, b) => a + b, 0) / this.memoryUsage.length,
+      peakMemoryUsage: Math.max(...this.memoryUsage),
+      avgCpuLoad: this.cpuUsage.reduce((a, b) => a + b, 0) / this.cpuUsage.length,
+      totalDataPoints: this.cpuUsage.length,
+    };
+  }
+}
+
+const monitor = new LocalResourceMonitor();
+const interval = monitor.startMonitoring();
+
+const stagehand = new Stagehand({ browser: { type: "local" } });
+
+// ... run automation
+
+clearInterval(interval);
+console.log("Resource Usage:", monitor.getResourceSummary());
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+import asyncio
+import os
+import resource
+
+from stagehand import Stagehand
+
+
+class LocalResourceMonitor:
+    def __init__(self) -> None:
+        self.cpu_usage: list[float] = []
+        self.memory_usage: list[float] = []
+        self._task: asyncio.Task | None = None
+
+    def start_monitoring(self) -> asyncio.Task:
+        async def sample() -> None:
+            while True:
+                # Track system resources
+                peak_kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+                self.memory_usage.append(peak_kb / 1024)  # MB
+
+                # Track CPU (simplified)
+                self.cpu_usage.append(os.getloadavg()[0])
+                await asyncio.sleep(1)
+
+        self._task = asyncio.create_task(sample())
+        return self._task
+
+    def get_resource_summary(self) -> dict[str, float]:
+        return {
+            "avg_memory_usage": sum(self.memory_usage) / len(self.memory_usage),
+            "peak_memory_usage": max(self.memory_usage),
+            "avg_cpu_load": sum(self.cpu_usage) / len(self.cpu_usage),
+            "total_data_points": len(self.cpu_usage),
+        }
+
+
+monitor = LocalResourceMonitor()
+task = monitor.start_monitoring()
+
+stagehand = Stagehand(browser="local")
+
+# ... run automation
+
+task.cancel()
+print("Resource Usage:", monitor.get_resource_summary())
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+type localResourceMonitor struct {
+	mu          sync.Mutex
+	cpuUsage    []float64
+	memoryUsage []float64
+}
+
+func (m *localResourceMonitor) startMonitoring(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				var stats runtime.MemStats
+				runtime.ReadMemStats(&stats)
+
+				m.mu.Lock()
+				// Track system resources
+				m.memoryUsage = append(m.memoryUsage, float64(stats.HeapAlloc)/1024/1024) // MB
+				// Track CPU (simplified)
+				m.cpuUsage = append(m.cpuUsage, float64(runtime.NumGoroutine()))
+				m.mu.Unlock()
+			}
+		}
+	}()
+}
+
+func (m *localResourceMonitor) getResourceSummary() map[string]float64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return map[string]float64{
+		"avgMemoryUsage":  average(m.memoryUsage),
+		"peakMemoryUsage": maxOf(m.memoryUsage),
+		"avgCpuLoad":      average(m.cpuUsage),
+		"totalDataPoints": float64(len(m.cpuUsage)),
+	}
+}
+
+monitorCtx, stopMonitor := context.WithCancel(ctx)
+monitor := &localResourceMonitor{}
+monitor.startMonitoring(monitorCtx)
+
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	Browser: stagehand.LocalBrowserSource{},
+})
+
+// ... run automation
+
+stopMonitor()
+fmt.Println("Resource Usage:", monitor.getResourceSummary())
+```
+</View>
+
+
+  <Card title="Speed and cost tuning" icon="chart-line" href="/v3/best-practices/cost-optimization">
+    Monitor token usage, costs, and speed. Set up automated alerting for critical failures. Implement cost tracking across different environments. Use session analytics to optimize automation workflows.
+  </Card>
+
+
+## Real-time metrics & monitoring
+
+### Basic usage tracking
+
+Monitor your automation's resource usage in real-time by calling the metrics method:
+
+{/* TODO: stagehand.metrics() is typed end to end but the runtime currently throws "Method not implemented". Verify before publishing. */}
+
+<View title="TypeScript" icon="js">
+```typescript
+import { Stagehand } from "@browserbasehq/stagehand";
+import { z } from "zod/v4";
+
+const UserSchema = z.object({ name: z.string(), email: z.string() });
+
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  browser: { type: "browserbase" },
+});
+await stagehand.init();
+
+// Metrics are fetched from the runtime, so the call is awaited
+const metrics = await stagehand.metrics();
+console.log(metrics);
+
+// Monitor during automation
+const startTime = Date.now();
+const initialMetrics = await stagehand.metrics();
+
+// ... perform automation tasks
+const page = await stagehand.context.activePage();
+if (!page) {
+  throw new Error("Stagehand initialized without an active page");
+}
+await page.goto("https://example.com");
+await stagehand.act("click the login button");
+const { data } = await stagehand.extract("extract user info", UserSchema);
+console.log(`Extracted ${data.name} <${data.email}>`);
+
+const finalMetrics = await stagehand.metrics();
+const executionTime = Date.now() - startTime;
+
+// Metrics are cumulative for the session, so subtract the baseline
+const tokensUsed =
+  finalMetrics.totalPromptTokens + finalMetrics.totalCompletionTokens -
+  (initialMetrics.totalPromptTokens + initialMetrics.totalCompletionTokens);
+
+console.log("Automation Summary:", {
+  tokensUsed,
+  executionTime: `${executionTime}ms`,
+  avgInferenceTime: `${finalMetrics.totalInferenceTimeMs / 3}ms`,
+});
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+from time import perf_counter
+
+from stagehand import Stagehand
+
+
+class User(BaseModel):
+    name: str
+    email: str
+
+
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    browser="browserbase",
+)
+await stagehand.init()
+
+# Metrics are fetched from the runtime, so the call is awaited
+metrics = await stagehand.metrics()
+print(metrics)
+
+# Monitor during automation
+start_time = perf_counter()
+initial_metrics = await stagehand.metrics()
+
+# ... perform automation tasks
+page = await stagehand.context.active_page()
+if page is None:
+    raise RuntimeError("Stagehand initialized without an active page")
+await page.goto("https://example.com")
+await stagehand.act("click the login button")
+data = (await stagehand.extract(instruction="extract user info", schema=User)).data
+print(f"Extracted {data.name} <{data.email}>")
+
+final_metrics = await stagehand.metrics()
+execution_time = (perf_counter() - start_time) * 1000
+
+# Metrics are cumulative for the session, so subtract the baseline
+tokens_used = (
+    final_metrics.total_prompt_tokens
+    + final_metrics.total_completion_tokens
+    - initial_metrics.total_prompt_tokens
+    - initial_metrics.total_completion_tokens
+)
+print("Automation Summary:", {
+    "tokens_used": tokens_used,
+    "execution_time": f"{execution_time:.0f}ms",
+    "avg_inference_time": f"{final_metrics.total_inference_time_ms / 3}ms",
+})
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+type user struct {
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
+var userSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {"name": {"type": "string"}, "email": {"type": "string"}},
+  "required": ["name", "email"],
+  "additionalProperties": false
+}`)
+
+apiKey := os.Getenv("BROWSERBASE_API_KEY")
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey:  &apiKey,
+	Browser: stagehand.BrowserbaseClientBrowserSource{},
+})
+if err := client.Init(ctx); err != nil {
+	return err
+}
+
+// Metrics are fetched from the runtime, so the call takes a context
+metrics, err := client.Metrics(ctx)
+if err != nil {
+	return err
+}
+fmt.Printf("%+v\n", metrics)
+
+// Monitor during automation
+startTime := time.Now()
+initialMetrics, err := client.Metrics(ctx)
+if err != nil {
+	return err
+}
+
+// ... perform automation tasks
+browserContext, err := client.Context()
+if err != nil {
+	return err
+}
+page, err := browserContext.ActivePage(ctx)
+if err != nil {
+	return err
+}
+if page == nil {
+	return errors.New("Stagehand initialized without an active page")
+}
+if err := page.Goto(ctx, "https://example.com", nil); err != nil {
+	return err
+}
+if _, err := client.Act(ctx, "click the login button", nil); err != nil {
+	return err
+}
+extracted, err := stagehand.ExtractAs[user](ctx, client, "extract user info", userSchema, nil)
+if err != nil {
+	return err
+}
+fmt.Printf("Extracted %s <%s>\n", extracted.Name, extracted.Email)
+
+finalMetrics, err := client.Metrics(ctx)
+if err != nil {
+	return err
+}
+executionTime := time.Since(startTime)
+
+// Metrics are cumulative for the session, so subtract the baseline
+tokensUsed := (finalMetrics.TotalPromptTokens + finalMetrics.TotalCompletionTokens) -
+	(initialMetrics.TotalPromptTokens + initialMetrics.TotalCompletionTokens)
+
+fmt.Printf(
+	"Automation Summary: tokensUsed=%.0f executionTime=%dms avgInferenceTime=%.0fms\n",
+	tokensUsed,
+	executionTime.Milliseconds(),
+	finalMetrics.TotalInferenceTimeMs/3,
+)
+```
+</View>
+
+### Understanding metrics data
+
+The metrics object provides a detailed breakdown by Stagehand operation:
+
+<View title="TypeScript" icon="js">
+```typescript
+interface StagehandMetrics {
+  // Act operation metrics
+  actPromptTokens: number;
+  actCompletionTokens: number;
+  actReasoningTokens: number;
+  actCachedInputTokens: number;
+  actInferenceTimeMs: number;
+
+  // Extract operation metrics
+  extractPromptTokens: number;
+  extractCompletionTokens: number;
+  extractReasoningTokens: number;
+  extractCachedInputTokens: number;
+  extractInferenceTimeMs: number;
+
+  // Observe operation metrics
+  observePromptTokens: number;
+  observeCompletionTokens: number;
+  observeReasoningTokens: number;
+  observeCachedInputTokens: number;
+  observeInferenceTimeMs: number;
+
+  // Cumulative totals
+  totalPromptTokens: number;
+  totalCompletionTokens: number;
+  totalReasoningTokens: number;
+  totalCachedInputTokens: number;
+  totalInferenceTimeMs: number;
+}
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+class StagehandMetrics(BaseModel):
+    # Act operation metrics
+    act_prompt_tokens: float
+    act_completion_tokens: float
+    act_reasoning_tokens: float
+    act_cached_input_tokens: float
+    act_inference_time_ms: float
+
+    # Extract operation metrics
+    extract_prompt_tokens: float
+    extract_completion_tokens: float
+    extract_reasoning_tokens: float
+    extract_cached_input_tokens: float
+    extract_inference_time_ms: float
+
+    # Observe operation metrics
+    observe_prompt_tokens: float
+    observe_completion_tokens: float
+    observe_reasoning_tokens: float
+    observe_cached_input_tokens: float
+    observe_inference_time_ms: float
+
+    # Cumulative totals
+    total_prompt_tokens: float
+    total_completion_tokens: float
+    total_reasoning_tokens: float
+    total_cached_input_tokens: float
+    total_inference_time_ms: float
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+type StagehandMetrics struct {
+	// Act operation metrics
+	ActPromptTokens      float64
+	ActCompletionTokens  float64
+	ActReasoningTokens   float64
+	ActCachedInputTokens float64
+	ActInferenceTimeMs   float64
+
+	// Extract operation metrics
+	ExtractPromptTokens      float64
+	ExtractCompletionTokens  float64
+	ExtractReasoningTokens   float64
+	ExtractCachedInputTokens float64
+	ExtractInferenceTimeMs   float64
+
+	// Observe operation metrics
+	ObservePromptTokens      float64
+	ObserveCompletionTokens  float64
+	ObserveReasoningTokens   float64
+	ObserveCachedInputTokens float64
+	ObserveInferenceTimeMs   float64
+
+	// Cumulative totals
+	TotalPromptTokens      float64
+	TotalCompletionTokens  float64
+	TotalReasoningTokens   float64
+	TotalCachedInputTokens float64
+	TotalInferenceTimeMs   float64
+}
+```
+</View>
+
+**Example metrics output:**
+
+<View title="TypeScript" icon="js">
+```typescript
+const metrics = await stagehand.metrics();
+console.log(metrics);
+
+// {
+//   actPromptTokens: 4011,
+//   actCompletionTokens: 51,
+//   actReasoningTokens: 12,
+//   actCachedInputTokens: 0,
+//   actInferenceTimeMs: 1688,
+//   extractPromptTokens: 4200,
+//   extractCompletionTokens: 243,
+//   extractReasoningTokens: 18,
+//   extractCachedInputTokens: 0,
+//   extractInferenceTimeMs: 4297,
+//   observePromptTokens: 347,
+//   observeCompletionTokens: 43,
+//   observeReasoningTokens: 5,
+//   observeCachedInputTokens: 0,
+//   observeInferenceTimeMs: 903,
+//   totalPromptTokens: 8558,
+//   totalCompletionTokens: 337,
+//   totalReasoningTokens: 35,
+//   totalCachedInputTokens: 0,
+//   totalInferenceTimeMs: 6888
+// }
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+metrics = await stagehand.metrics()
+print(metrics)
+
+# StagehandMetrics(
+#     act_prompt_tokens=4011,
+#     act_completion_tokens=51,
+#     act_reasoning_tokens=12,
+#     act_cached_input_tokens=0,
+#     act_inference_time_ms=1688,
+#     extract_prompt_tokens=4200,
+#     extract_completion_tokens=243,
+#     extract_reasoning_tokens=18,
+#     extract_cached_input_tokens=0,
+#     extract_inference_time_ms=4297,
+#     observe_prompt_tokens=347,
+#     observe_completion_tokens=43,
+#     observe_reasoning_tokens=5,
+#     observe_cached_input_tokens=0,
+#     observe_inference_time_ms=903,
+#     total_prompt_tokens=8558,
+#     total_completion_tokens=337,
+#     total_reasoning_tokens=35,
+#     total_cached_input_tokens=0,
+#     total_inference_time_ms=6888,
+# )
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+metrics, err := client.Metrics(ctx)
+if err != nil {
+	return err
+}
+fmt.Printf("%+v\n", metrics)
+
+// stagehand.StagehandMetrics{
+//     ActPromptTokens:          4011,
+//     ActCompletionTokens:      51,
+//     ActReasoningTokens:       12,
+//     ActCachedInputTokens:     0,
+//     ActInferenceTimeMs:       1688,
+//     ExtractPromptTokens:      4200,
+//     ExtractCompletionTokens:  243,
+//     ExtractReasoningTokens:   18,
+//     ExtractCachedInputTokens: 0,
+//     ExtractInferenceTimeMs:   4297,
+//     ObservePromptTokens:      347,
+//     ObserveCompletionTokens:  43,
+//     ObserveReasoningTokens:   5,
+//     ObserveCachedInputTokens: 0,
+//     ObserveInferenceTimeMs:   903,
+//     TotalPromptTokens:        8558,
+//     TotalCompletionTokens:    337,
+//     TotalReasoningTokens:     35,
+//     TotalCachedInputTokens:   0,
+//     TotalInferenceTimeMs:     6888,
+// }
+```
+</View>
+
+<Note>
+Cached input tokens are reported separately so you can see how much of your prompt spend was served from your provider's prompt cache. This is distinct from Stagehand's own [server-side result cache](/v3/best-practices/caching), which avoids the inference call entirely.
+</Note>
+
+### Tracing
+
+Stagehand emits OpenTelemetry spans for every operation and for every log record, and propagates W3C trace context across the SDK and runtime boundary. Point it at your own OTLP collector to see full traces alongside the rest of your system.
+
+<View title="TypeScript" icon="js">
+```typescript
+const stagehand = new Stagehand({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  telemetry: {
+    traces: {
+      endpoint: "https://otlp.example.com/v1/traces",
+      headers: { authorization: `Bearer ${process.env.OTLP_TOKEN}` },
+    },
+  },
+});
+```
+</View>
+
+<View title="Python" icon="python">
+```python
+from stagehand import Stagehand, TelemetryConfig
+
+stagehand = Stagehand(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    telemetry=TelemetryConfig.model_validate({
+        "traces": {
+            "endpoint": "https://otlp.example.com/v1/traces",
+            "headers": {"authorization": f"Bearer {os.environ['OTLP_TOKEN']}"},
+        }
+    }),
+)
+```
+</View>
+
+<View title="Go" icon="golang">
+```go
+apiKey := os.Getenv("BROWSERBASE_API_KEY")
+
+client := stagehand.New(stagehand.StagehandClientInitParams{
+	APIKey: &apiKey,
+	Telemetry: stagehand.TelemetryConfig{
+		Traces: stagehand.TelemetryTraces{
+			Endpoint: "https://otlp.example.com/v1/traces",
+			Headers: stagehand.TelemetryTracesHeaders{
+				"authorization": "Bearer " + os.Getenv("OTLP_TOKEN"),
+			},
+		},
+	},
+})
+
+if err := client.Init(ctx); err != nil {
+	return err
+}
+defer func() { err = errors.Join(err, client.Close(ctx)) }()
+```
+</View>
+
+| Field | Description |
+|-------|-------------|
+| endpoint | OTLP HTTP traces endpoint. Must end in `/v1/traces`. |
+| headers | Headers sent with every export, typically an authorization token. |
+
+<Note>
+Spans are tagged with a span type: `operation` spans wrap act, observe, and extract, and record exceptions and error status; `log` spans carry the structured data from each log record. Traces are sampled at 100%.
+</Note>
+
+{/* TODO: the default telemetry endpoint is still the https://example.com/v1/traces placeholder in the protocol defaults. Document the Browserbase ingestion endpoint and the opt-out story once they are settled. */}
+
+## Best practices
+
+<AccordionGroup>
+<Accordion title="Production monitoring">
+- Track session success rates and failure patterns
+- Monitor resource usage and scaling requirements
+- Set up automated alerting for critical failures
+- Implement cost tracking across different environments
+- Use session analytics to optimize automation workflows
+</Accordion>
+
+<Accordion title="Performance optimization">
+- Compare Browserbase vs local execution times
+- Monitor token usage and inference costs across models
+- Track geographic performance differences
+- Identify bottlenecks in automation workflows
+- Optimize for cost-effectiveness and speed
+</Accordion>
+
+<Accordion title="Operational insights">
+- Track session distribution across regions
+- Monitor concurrent session limits and scaling
+- Analyze failure patterns and common error scenarios
+- Use session recordings for root cause analysis
+- Implement custom metadata for workflow categorization
+</Accordion>
+
+<Accordion title="Integration & alerting">
+- Integrate session APIs with monitoring dashboards
+- Set up automated notifications for session failures
+- Track SLA compliance and performance benchmarks
+- Monitor resource costs and usage patterns
+- Use analytics data for capacity planning and optimization
+</Accordion>
+</AccordionGroup>
+
+## Next steps
+
+<CardGroup cols={2}>
+<Card title="Caching" icon="database" href="/v3/best-practices/caching">
+  Cut token spend and latency by serving repeated act, observe, and extract calls from the server-side cache.
+</Card>
+<Card title="Logging" icon="file-lines" href="/v4/configuration/logging">
+  Configure logging levels, custom loggers, and file-based session logging.
+</Card>
+</CardGroup>

--- a/packages/docs/v4/first-steps/installation.mdx
+++ b/packages/docs/v4/first-steps/installation.mdx
@@ -311,7 +311,7 @@ func run(ctx context.Context) (err error) {
   <Card
     title="Configuration"
     icon="gear"
-    href="/v3/configuration/browser"
+    href="/v4/configuration/browser"
   >
     Browser sources, Browserbase vs local, logging, timeouts, LLM customization
   </Card>

--- a/packages/docs/v4/first-steps/introduction.mdx
+++ b/packages/docs/v4/first-steps/introduction.mdx
@@ -127,7 +127,7 @@ Stagehand is designed for developers building production browser automations and
 
 ## Get started in 60 seconds
 <Info>
-  **Pro tip**: For best results, Browserbase recommends using Stagehand with [Browserbase](https://www.browserbase.com) for reliable cloud browser infrastructure. It is the default browser source, and it unlocks [server-side caching](/v3/best-practices/caching) and the [Model Gateway](/v3/configuration/models#model-gateway).
+  **Pro tip**: For best results, Browserbase recommends using Stagehand with [Browserbase](https://www.browserbase.com) for reliable cloud browser infrastructure. It is the default browser source, and it unlocks [server-side caching](/v3/best-practices/caching) and the [Model Gateway](/v4/configuration/models#model-gateway).
 </Info>
 <CardGroup cols={2}>
   <Card

--- a/packages/docs/v4/first-steps/quickstart.mdx
+++ b/packages/docs/v4/first-steps/quickstart.mdx
@@ -268,7 +268,7 @@ go run .                                 # Run the example script
 </View>
 
 <Tip>
-Prefer to run against a browser on your own machine while you develop? Swap the browser source for a local one and drop the Browserbase key. See [Browser configuration](/v3/configuration/browser).
+Prefer to run against a browser on your own machine while you develop? Swap the browser source for a local one and drop the Browserbase key. See [Browser configuration](/v4/configuration/browser).
 </Tip>
 
 ## Next steps


### PR DESCRIPTION
# why

Adding the docs in the "configuration" section
* Browser
* Models
* Logging
* Observability

# what changed

* Each page includes ts, py, and go snippets
* Documents in lower PR stack now have updated links to v4 docs
* TODOs in the code (hidden to the viewer) tracking a few feature gaps at time of writing

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ported the v3 Configuration docs into v4 and updated navigation to point to the new pages. This completes the v4 Configuration section for STG-2666.

- **New Features**
  - Added v4 pages: Browser (Browserbase, local, CDP), Models (with Model Gateway), and Observability; fully rewrote Logging with structured output, levels, debugging tools, and expanded Go logging guidance.
  - Included TypeScript, Python, and Go examples plus test snippets; added hidden TODOs for known gaps.
  - Updated `docs.json` and links in Basics and First Steps (webmcp, installation, introduction, quickstart) to `/v4/configuration/*` and `/v4/configuration/models#model-gateway`.

<sup>Written for commit de3e10963758bf8bb78a11377965587f96cef695. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



