### PR TITLE
Define TypeScript Stagehand browser contracts

### DIFF
--- a/packages/sdk-ts/src/browser/README.md
+++ b/packages/sdk-ts/src/browser/README.md
@@ -1,0 +1,20 @@
+# Stagehand browser module
+
+This TypeScript SDK module defines the browser lifecycle boundary proposed for
+Stagehand v4. It intentionally contains no browser-launching, CDP, or RPC
+implementation yet; those arrive in later stack entries.
+
+The intended public SDK shape is:
+
+```ts
+const browser = await localBrowser.launch({ headless: true });
+const stagehand = await Stagehand.create({ browser, model });
+```
+
+`localBrowser` and `browserbase` each support `launch()` for resources owned by
+the handle and `connect()` for existing resources. Both produce a nominal
+`StagehandBrowser` whose extension must be ready before the promise resolves.
+
+The browser API remains TypeScript-local for v4. Other SDKs can implement the
+same protocol-backed shape independently, and shared packaging can follow once
+the language implementations have stabilized.

--- a/packages/sdk-ts/src/browser/index.ts
+++ b/packages/sdk-ts/src/browser/index.ts
@@ -1,0 +1,42 @@
+import type {
+  BrowserbaseConnectOptions,
+  BrowserbaseLaunchOptions,
+  LocalBrowserConnectOptions,
+  LocalBrowserLaunchOptions,
+} from "../clientSchemas.js";
+
+export type {
+  BrowserbaseConnectOptions,
+  BrowserbaseLaunchOptions,
+  LocalBrowserConnectOptions,
+  LocalBrowserLaunchOptions,
+};
+
+declare const stagehandBrowserBrand: unique symbol;
+
+export type StagehandBrowserProvider = "local" | "browserbase";
+export type StagehandBrowserOrigin = "launched" | "connected";
+
+/**
+ * A browser whose Stagehand extension is ready for its first RPC call.
+ *
+ * Browser handles are created by Stagehand's browser factories. The private
+ * brand prevents arbitrary CDP connections from being passed to Stagehand.
+ */
+export interface StagehandBrowser {
+  readonly [stagehandBrowserBrand]: true;
+  readonly provider: StagehandBrowserProvider;
+  readonly origin: StagehandBrowserOrigin;
+  readonly closed: boolean;
+  close(): Promise<void>;
+}
+
+export interface LocalBrowser {
+  launch(options?: LocalBrowserLaunchOptions): Promise<StagehandBrowser>;
+  connect(options: LocalBrowserConnectOptions): Promise<StagehandBrowser>;
+}
+
+export interface BrowserbaseBrowser {
+  launch(options: BrowserbaseLaunchOptions): Promise<StagehandBrowser>;
+  connect(options: BrowserbaseConnectOptions): Promise<StagehandBrowser>;
+}

--- a/packages/sdk-ts/src/clientSchemas.ts
+++ b/packages/sdk-ts/src/clientSchemas.ts
@@ -14,7 +14,6 @@ import {
   ExtractOptionsSchema,
   LLMGenerateParamsSchema,
   LLMGenerateResultSchema,
-  LocalBrowserLaunchOptionsSchema,
   ModelConfigSchema,
   ObserveOptionsSchema,
   StagehandInitParamsSchema,
@@ -38,9 +37,31 @@ export const BrowserbaseBrowserSourceSchema = BrowserbaseSessionCreateParamsSche
   })
   .meta({ id: "BrowserbaseClientBrowserSource" });
 
-export const LocalBrowserSourceSchema = LocalBrowserLaunchOptionsSchema.extend({
+export const LocalBrowserSourceSchema = ProtocolSchemas.LocalBrowserLaunchOptionsSchema.extend({
   type: z.literal("local"),
 }).meta({ id: "LocalBrowserSource" });
+
+export const LocalBrowserLaunchOptionsSchema = ProtocolSchemas.LocalBrowserLaunchOptionsSchema;
+
+export const LocalBrowserConnectOptionsSchema = z
+  .strictObject({
+    cdpUrl: z.string().min(1),
+    connectTimeoutMs: z.number().int().positive().optional(),
+    extensionId: z.string().min(1).optional(),
+  })
+  .meta({ id: "LocalBrowserConnectOptions" });
+
+export const BrowserbaseLaunchOptionsSchema = BrowserbaseSessionCreateParamsSchema.extend({
+  apiKey: z.string().min(1),
+}).meta({ id: "BrowserbaseLaunchOptions" });
+
+export const BrowserbaseConnectOptionsSchema = z
+  .strictObject({
+    apiKey: z.string().min(1),
+    sessionId: z.string().min(1),
+    connectTimeoutMs: z.number().int().positive().optional(),
+  })
+  .meta({ id: "BrowserbaseConnectOptions" });
 
 export const CdpBrowserSourceSchema = z
   .strictObject({
@@ -143,6 +164,10 @@ export type StagehandClientActOptions = z.input<typeof StagehandClientActOptions
 export type StagehandClientObserveOptions = z.input<typeof StagehandClientObserveOptionsSchema>;
 export type StagehandClientExtractOptions = z.input<typeof StagehandClientExtractOptionsSchema>;
 export type BrowserSource = z.infer<typeof BrowserSourceSchema>;
+export type LocalBrowserLaunchOptions = z.infer<typeof LocalBrowserLaunchOptionsSchema>;
+export type LocalBrowserConnectOptions = z.infer<typeof LocalBrowserConnectOptionsSchema>;
+export type BrowserbaseLaunchOptions = z.infer<typeof BrowserbaseLaunchOptionsSchema>;
+export type BrowserbaseConnectOptions = z.infer<typeof BrowserbaseConnectOptionsSchema>;
 export type StagehandClientInitParams = z.input<typeof StagehandClientInitParamsSchema>;
 export type ResolvedStagehandClientInitParams = z.output<typeof StagehandClientInitParamsSchema>;
 export type WebMCPToolsOptions = z.infer<typeof WebMCPToolsOptionsSchema>;

--- a/packages/sdk-ts/tests/browser/contracts.test.ts
+++ b/packages/sdk-ts/tests/browser/contracts.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import {
+  BrowserbaseConnectOptionsSchema,
+  BrowserbaseLaunchOptionsSchema,
+  LocalBrowserConnectOptionsSchema,
+  LocalBrowserLaunchOptionsSchema,
+} from "../../src/clientSchemas.js";
+import type {
+  BrowserbaseBrowser,
+  BrowserbaseConnectOptions,
+  BrowserbaseLaunchOptions,
+  LocalBrowser,
+  LocalBrowserConnectOptions,
+  LocalBrowserLaunchOptions,
+  StagehandBrowser,
+  StagehandBrowserOrigin,
+  StagehandBrowserProvider,
+} from "../../src/browser/index.js";
+
+describe("browser API contracts", () => {
+  it("defines nominal, provider-independent browser handles", () => {
+    expectTypeOf<StagehandBrowser["provider"]>().toEqualTypeOf<StagehandBrowserProvider>();
+    expectTypeOf<StagehandBrowserProvider>().toEqualTypeOf<"local" | "browserbase">();
+    expectTypeOf<StagehandBrowser["origin"]>().toEqualTypeOf<StagehandBrowserOrigin>();
+    expectTypeOf<StagehandBrowserOrigin>().toEqualTypeOf<"launched" | "connected">();
+    expectTypeOf<StagehandBrowser["close"]>().returns.toEqualTypeOf<Promise<void>>();
+    expectTypeOf<{
+      provider: "local";
+      origin: "launched";
+      closed: boolean;
+      close(): Promise<void>;
+    }>().not.toExtend<StagehandBrowser>();
+  });
+
+  it("defines local launch and connect separately", () => {
+    expectTypeOf<Parameters<LocalBrowser["launch"]>>().toEqualTypeOf<
+      [options?: LocalBrowserLaunchOptions]
+    >();
+    expectTypeOf<ReturnType<LocalBrowser["launch"]>>().toEqualTypeOf<Promise<StagehandBrowser>>();
+    expectTypeOf<Parameters<LocalBrowser["connect"]>>().toEqualTypeOf<
+      [options: LocalBrowserConnectOptions]
+    >();
+    expectTypeOf<LocalBrowserConnectOptions>().toExtend<{
+      cdpUrl: string;
+      connectTimeoutMs?: number;
+      extensionId?: string;
+    }>();
+  });
+
+  it("defines Browserbase launch and connect separately", () => {
+    expectTypeOf<Parameters<BrowserbaseBrowser["launch"]>>().toEqualTypeOf<
+      [options: BrowserbaseLaunchOptions]
+    >();
+    expectTypeOf<ReturnType<BrowserbaseBrowser["launch"]>>().toEqualTypeOf<
+      Promise<StagehandBrowser>
+    >();
+    expectTypeOf<Parameters<BrowserbaseBrowser["connect"]>>().toEqualTypeOf<
+      [options: BrowserbaseConnectOptions]
+    >();
+    expectTypeOf<BrowserbaseConnectOptions>().toExtend<{
+      apiKey: string;
+      sessionId: string;
+      connectTimeoutMs?: number;
+    }>();
+  });
+
+  it("defines every browser input as a strict client-side schema", () => {
+    expect(LocalBrowserLaunchOptionsSchema.parse({ headless: true })).toStrictEqual({
+      headless: true,
+    });
+    expect(LocalBrowserConnectOptionsSchema.parse({ cdpUrl: "ws://127.0.0.1:9222" })).toStrictEqual(
+      { cdpUrl: "ws://127.0.0.1:9222" },
+    );
+    expect(BrowserbaseLaunchOptionsSchema.parse({ apiKey: "bb_key" })).toStrictEqual({
+      apiKey: "bb_key",
+    });
+    expect(
+      BrowserbaseConnectOptionsSchema.parse({ apiKey: "bb_key", sessionId: "session_123" }),
+    ).toStrictEqual({ apiKey: "bb_key", sessionId: "session_123" });
+    expect(() =>
+      LocalBrowserConnectOptionsSchema.parse({
+        cdpUrl: "ws://127.0.0.1:9222",
+        unexpected: true,
+      }),
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
# why

The Stagehand v4 browser lifecycle work in draft PR #2506 currently combines API design, transport changes, browser implementation, and the `Stagehand.create()` migration. This is the bottom PR in an incremental stack that isolates the browser contract for review before any runtime behavior is introduced.

Reference implementation: #2506

# what changed

- adds a dedicated `packages/sdk-ts/src/browser/` module inside the TypeScript SDK
- defines the nominal `StagehandBrowser` handle returned only by Stagehand browser factories
- defines separate `LocalBrowser` and `BrowserbaseBrowser` launch/connect interfaces
- defines browser input schemas in `clientSchemas.ts`, reusing protocol-generated schemas where possible
- derives every browser option type with `z.infer` instead of maintaining parallel TypeScript shapes
- adds compile-time contract tests to the TypeScript SDK suite
- documents the intended `localBrowser` / `browserbase` / `Stagehand.create()` shape

# intentionally not included

- no browser launch or connection behavior
- no CDP or RPC transport changes
- no runtime factory exports
- no changes to the current Stagehand constructor or `init()`
- no public SDK exports

# stack

1. **#2517 TypeScript browser contract and module scaffold** — this PR
2. #2518 Transport foundations
3. #2519 Implement `localBrowser` and `browserbase`
4. #2520 Add `Stagehand.create()`
5. #2521 Migrate consumers
6. #2523 Remove the constructor/`init()` lifecycle

# test plan

- browser contract tests cover schema parsing, strict unknown-key rejection, and nominal handles
- TypeScript SDK build passed
- full `pnpm check` passed, including build, publint, lint, TypeScript, and docs validation
