### PR TITLE
Add browser transport foundations

### DIFF
--- a/packages/sdk-ts/src/cdpClient.ts
+++ b/packages/sdk-ts/src/cdpClient.ts
@@ -156,7 +156,7 @@ export class CDPClient {
   ) {
     this.webSocketDebuggerUrl = webSocketDebuggerUrl;
     this.socket.addEventListener("message", (event) => {
-      this.handleMessage(event.data).catch((error: unknown) => {
+      this.handleMessage((event as MessageEvent).data).catch((error: unknown) => {
         const normalized = asError(error);
         this.rejectPending(normalized);
         this.onerror?.(normalized);
@@ -170,37 +170,19 @@ export class CDPClient {
       this.rejectPending(reason);
       this.onclose?.(reason);
     });
+
+    this.socket.addEventListener("error", (event) => {
+      const error = asError((event as Event & { error?: unknown }).error ?? event);
+      this.rejectPending(error);
+      this.onerror?.(error);
+    });
   }
 
   static async connect(options: CDPClientOptions): Promise<CDPClient> {
     const webSocketDebuggerUrl = await resolveBrowserWebSocketUrl(options.cdpUrl, {
       timeout: options.cdpConnectTimeoutMs,
     });
-    const socket = new WebSocket(webSocketDebuggerUrl);
-
-    await new Promise<void>((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        reject(new Error("Timed out opening CDP WebSocket"));
-      }, options.cdpConnectTimeoutMs);
-
-      socket.addEventListener(
-        "open",
-        () => {
-          clearTimeout(timeout);
-          resolve();
-        },
-        { once: true },
-      );
-
-      socket.addEventListener(
-        "error",
-        () => {
-          clearTimeout(timeout);
-          reject(new Error("Failed to open CDP WebSocket"));
-        },
-        { once: true },
-      );
-    });
+    const socket = await openCDPWebSocket(webSocketDebuggerUrl, options.cdpConnectTimeoutMs);
 
     const client = new CDPClient(socket, webSocketDebuggerUrl, options.commandTimeoutMs);
 
@@ -381,6 +363,42 @@ export class CDPClient {
     }
     this.pending.clear();
   }
+}
+
+type CDPWebSocketFactory = (url: string) => WebSocket;
+
+export async function openCDPWebSocket(
+  url: string,
+  timeoutMs: number,
+  createSocket: CDPWebSocketFactory = (socketUrl) => new WebSocket(socketUrl),
+): Promise<WebSocket> {
+  const socket = createSocket(url);
+
+  await new Promise<void>((resolve, reject) => {
+    const onOpen = () => {
+      cleanup();
+      resolve();
+    };
+    const onError = () => {
+      cleanup();
+      reject(new Error("Failed to open CDP WebSocket"));
+    };
+    const timeout = setTimeout(() => {
+      cleanup();
+      socket.close();
+      reject(new Error("Timed out opening CDP WebSocket"));
+    }, timeoutMs);
+    const cleanup = () => {
+      clearTimeout(timeout);
+      socket.removeEventListener("open", onOpen);
+      socket.removeEventListener("error", onError);
+    };
+
+    socket.addEventListener("open", onOpen);
+    socket.addEventListener("error", onError);
+  });
+
+  return socket;
 }
 
 type CDPCommandSender = Pick<CDPClient, "sendCommand">;

--- a/packages/sdk-ts/src/rpcClient.ts
+++ b/packages/sdk-ts/src/rpcClient.ts
@@ -196,7 +196,7 @@ export class RPCClient {
 
   close(
     reason: Error = new Error("RPC client closed"),
-    options: { closeTransport?: boolean } = {},
+    { closeTransport = true }: { closeTransport?: boolean } = {},
   ): void {
     if (this.closed) return;
     this.closed = true;

--- a/packages/sdk-ts/src/rpcClient.ts
+++ b/packages/sdk-ts/src/rpcClient.ts
@@ -194,7 +194,10 @@ export class RPCClient {
     return () => this.notificationListeners.delete(listener);
   }
 
-  close(reason: Error = new Error("RPC client closed")): void {
+  close(
+    reason: Error = new Error("RPC client closed"),
+    options: { closeTransport?: boolean } = {},
+  ): void {
     if (this.closed) return;
     this.closed = true;
     this.requestHandlers.clear();
@@ -204,7 +207,9 @@ export class RPCClient {
     this.cdp.onmessage = undefined;
     this.cdp.onclose = undefined;
     this.cdp.onerror = undefined;
-    this.cdp.close();
+    if (options.closeTransport ?? true) {
+      this.cdp.close();
+    }
   }
 
   waitForResponse(id: number, method: RPCMethod): Promise<unknown> {

--- a/packages/sdk-ts/src/rpcClient.ts
+++ b/packages/sdk-ts/src/rpcClient.ts
@@ -207,7 +207,7 @@ export class RPCClient {
     this.cdp.onmessage = undefined;
     this.cdp.onclose = undefined;
     this.cdp.onerror = undefined;
-    if (options.closeTransport ?? true) {
+    if (closeTransport) {
       this.cdp.close();
     }
   }

--- a/packages/sdk-ts/tests/cdpClient.test.ts
+++ b/packages/sdk-ts/tests/cdpClient.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import { CDPClient, openCDPWebSocket } from "../src/cdpClient.js";
+
+class FakeWebSocket extends EventTarget {
+  readyState = 0;
+  send = vi.fn();
+  close = vi.fn();
+
+  open(): void {
+    this.readyState = 1;
+    this.dispatchEvent(new Event("open"));
+  }
+
+  fail(error: Error): void {
+    const event = new Event("error");
+    Object.defineProperty(event, "error", { value: error });
+    this.dispatchEvent(event);
+  }
+}
+
+describe("CDP WebSocket transport", () => {
+  it("opens the built-in WebSocket transport", async () => {
+    const socket = new FakeWebSocket();
+    const createSocket = vi.fn(() => socket as never);
+    const connecting = openCDPWebSocket(
+      "wss://browser.example/devtools/browser/session",
+      1_000,
+      createSocket,
+    );
+
+    socket.open();
+
+    await expect(connecting).resolves.toBe(socket);
+    expect(createSocket).toHaveBeenCalledWith("wss://browser.example/devtools/browser/session");
+  });
+
+  it("forwards socket errors that occur after connection", () => {
+    const socket = new FakeWebSocket();
+    const client = new CDPClient(
+      socket as never,
+      "wss://browser.example/devtools/browser/session",
+      1_000,
+    );
+    const onerror = vi.fn();
+    const error = new Error("socket reset");
+    client.onerror = onerror;
+
+    socket.fail(error);
+
+    expect(onerror).toHaveBeenCalledWith(error);
+  });
+});

--- a/packages/sdk-ts/tests/rpcClient.test.ts
+++ b/packages/sdk-ts/tests/rpcClient.test.ts
@@ -46,6 +46,7 @@ class ManualCDPTransport implements CDPTransport {
   onclose?: (reason?: Error) => void;
   onerror?: (error: Error) => void;
   readonly sent: JSONRPCMessage[] = [];
+  closeCalls = 0;
 
   async send(message: JSONRPCMessage): Promise<void> {
     this.sent.push(message);
@@ -55,7 +56,9 @@ class ManualCDPTransport implements CDPTransport {
     await this.onmessage?.(message);
   }
 
-  close(): void {}
+  close(): void {
+    this.closeCalls += 1;
+  }
 }
 
 describe("RPCClient", () => {
@@ -335,5 +338,15 @@ describe("RPCClient", () => {
 
     expect(calls).toBe(0);
     expect(cdp.sent).toStrictEqual([]);
+  });
+
+  it("can close without taking ownership of the CDP transport", () => {
+    const cdp = new ManualCDPTransport();
+    const client = new RPCClient(cdp, 1_000);
+
+    client.close(new Error("detached"), { closeTransport: false });
+
+    expect(client.closed).toBe(true);
+    expect(cdp.closeCalls).toBe(0);
   });
 });


### PR DESCRIPTION
# why

Browser handles need to establish CDP connections and later hand those connections to Stagehand without losing transport ownership. This is the second PR in the browser lifecycle stack and contains only those transport prerequisites.

Reference implementation: #2506

# what changed

- opens CDP connections with the built-in WebSocket runtime
- keeps a persistent post-connect socket error handler and forwards failures into RPC shutdown
- lets an RPC client close without closing its underlying CDP transport
- adds focused discovery, connection, socket-error, and ownership tests

# compatibility

- existing `connectRPCClient()` behavior remains unchanged by default
- existing RPC close behavior still closes its transport unless explicitly disabled
- no browser factories or Stagehand public API changes are introduced

# stack

1. #2517 — TypeScript browser contract and module scaffold
2. **Transport foundations** — this PR
3. #2519 Implement `localBrowser` and `browserbase`
4. #2520 Add `Stagehand.create()`
5. #2521 Migrate consumers
6. #2523 Remove the constructor/`init()` lifecycle

# test plan

- focused CDP/RPC tests: 36 passed
- full `pnpm build` passed
- full `pnpm check` passed, including docs validation
- SDK build and `publint` passed
