### PR TITLE
Implement Stagehand browser factories

### DIFF
--- a/packages/sdk-ts/src/browser/README.md
+++ b/packages/sdk-ts/src/browser/README.md
@@ -1,8 +1,8 @@
 # Stagehand browser module
 
 This TypeScript SDK module defines the browser lifecycle boundary proposed for
-Stagehand v4. It intentionally contains no browser-launching, CDP, or RPC
-implementation yet; those arrive in later stack entries.
+Stagehand v4. Browser factories in this directory own launch/connect behavior,
+extension readiness, and the lifetime of their CDP transport.
 
 The intended public SDK shape is:
 

--- a/packages/sdk-ts/src/browser/browserbaseSession.ts
+++ b/packages/sdk-ts/src/browser/browserbaseSession.ts
@@ -1,26 +1,35 @@
 import Browserbase from "@browserbasehq/sdk";
-import type { BrowserbaseSessionCreateParams } from "../../protocol/types.js";
 import {
   createBrowserbaseExtensionClient,
   provisionBrowserbaseExtension,
   type BrowserbaseExtensionClient,
   type BrowserbaseExtensionSdk,
   type ProvisionedBrowserbaseExtension,
-} from "./browserbaseExtension.js";
-import { STAGEHAND_SESSION_METADATA } from "./sdkIdentity.js";
+} from "../browserbaseExtension.js";
+import { STAGEHAND_SESSION_METADATA } from "../sdkIdentity.js";
+import {
+  BrowserbaseSessionConnectionSchema,
+  BrowserbaseSessionCreateResultSchema,
+  BrowserbaseSessionRetrieveResultSchema,
+  type BrowserbaseSessionConnection,
+  type BrowserbaseSessionCreateResult,
+  type BrowserbaseSessionRetrieveResult,
+} from "../clientSchemas.js";
+
+type OwnedBrowserbaseSession = BrowserbaseSessionConnection & {
+  close?: () => Promise<void> | void;
+};
 
 export type BrowserbaseSessionClient = {
-  createSession(
-    params: BrowserbaseSessionCreateParams,
-  ): Promise<{ sessionId: string; cdpUrl: string; close?: () => Promise<void> | void }>;
+  createSession(params: Browserbase.SessionCreateParams): Promise<OwnedBrowserbaseSession>;
+  connectSession?(sessionId: string): Promise<BrowserbaseSessionConnection>;
 };
 
 export type BrowserbaseSessionClientFactory = (apiKey: string) => BrowserbaseSessionClient;
 
 export type BrowserbaseApiClient = BrowserbaseExtensionClient & {
-  createSession(
-    params: BrowserbaseSessionCreateParams,
-  ): Promise<{ id: string; connectUrl: string }>;
+  createSession(params: Browserbase.SessionCreateParams): Promise<BrowserbaseSessionCreateResult>;
+  retrieveSession(sessionId: string): Promise<BrowserbaseSessionRetrieveResult>;
   releaseSession(sessionId: string): Promise<void>;
 };
 
@@ -33,12 +42,20 @@ type BrowserbaseSessionClientDependencies = {
 
 type BrowserbaseSdk = BrowserbaseExtensionSdk & {
   sessions: {
-    create(params: Browserbase.SessionCreateParams): Promise<{ id: string; connectUrl: string }>;
+    create(params: Browserbase.SessionCreateParams): Promise<unknown>;
+    retrieve(sessionId: string): Promise<unknown>;
     update(sessionId: string, params: { status: "REQUEST_RELEASE" }): Promise<unknown>;
   };
 };
 
 type BrowserbaseSdkFactory = (apiKey: string) => BrowserbaseSdk;
+
+export class BrowserbaseSessionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BrowserbaseSessionError";
+  }
+}
 
 export function createBrowserbaseSessionClient(
   apiKey: string,
@@ -49,21 +66,23 @@ export function createBrowserbaseSessionClient(
 
   return {
     async createSession(params) {
-      const extension = await provisionExtension(browserbase);
-      let session: { id: string; connectUrl: string };
+      const callerExtensionId = params.extensionId ?? params.browserSettings?.extensionId;
+      const extension =
+        callerExtensionId === undefined ? await provisionExtension(browserbase) : undefined;
+      let session: BrowserbaseSessionCreateResult;
 
       try {
         session = await browserbase.createSession({
           ...params,
-          extensionId: extension.extensionId,
+          ...(extension === undefined ? {} : { extensionId: extension.extensionId }),
           userMetadata: {
             ...params.userMetadata,
             ...STAGEHAND_SESSION_METADATA,
           },
         });
-      } catch (error) {
-        await extension.cleanup().catch(() => undefined);
-        throw new Error("Failed to create a Browserbase session", { cause: error });
+      } catch {
+        await extension?.cleanup().catch(() => undefined);
+        throw new BrowserbaseSessionError("Failed to create a Browserbase session");
       }
 
       const sessionId = session.id.trim();
@@ -78,10 +97,10 @@ export function createBrowserbaseSessionClient(
       }
 
       let sessionReleased = false;
-      let extensionCleaned = false;
+      let extensionCleaned = extension === undefined;
+      const connection = BrowserbaseSessionConnectionSchema.parse({ sessionId, cdpUrl });
       return {
-        sessionId,
-        cdpUrl,
+        ...connection,
         async close() {
           let releaseError: unknown;
           if (!sessionReleased) {
@@ -94,7 +113,7 @@ export function createBrowserbaseSessionClient(
           }
 
           let extensionCleanupError: unknown;
-          if (!extensionCleaned) {
+          if (!extensionCleaned && extension) {
             try {
               await extension.cleanup();
               extensionCleaned = true;
@@ -107,6 +126,28 @@ export function createBrowserbaseSessionClient(
           if (extensionCleanupError) throw extensionCleanupError;
         },
       };
+    },
+    async connectSession(sessionId) {
+      const normalizedSessionId = sessionId.trim();
+      if (normalizedSessionId.length === 0) {
+        throw new BrowserbaseSessionError("A Browserbase session ID is required");
+      }
+
+      let session: Awaited<ReturnType<BrowserbaseApiClient["retrieveSession"]>>;
+      try {
+        session = await browserbase.retrieveSession(normalizedSessionId);
+      } catch {
+        throw new BrowserbaseSessionError("Failed to retrieve the Browserbase session");
+      }
+      const cdpUrl = session.connectUrl?.trim();
+      if (!cdpUrl) {
+        throw new BrowserbaseSessionError("Browserbase session is not available for connection");
+      }
+      return BrowserbaseSessionConnectionSchema.parse({
+        sessionId: session.id.trim() || normalizedSessionId,
+        cdpUrl,
+        ...(session.region === undefined ? {} : { region: session.region }),
+      });
     },
   };
 }
@@ -122,7 +163,11 @@ export function createBrowserbaseApiClient(
     ...extensionClient,
     async createSession(params) {
       const session = await sdk.sessions.create(params as Browserbase.SessionCreateParams);
-      return { id: session.id, connectUrl: session.connectUrl };
+      return BrowserbaseSessionCreateResultSchema.parse(session);
+    },
+    async retrieveSession(sessionId) {
+      const session = await sdk.sessions.retrieve(sessionId);
+      return BrowserbaseSessionRetrieveResultSchema.parse(session);
     },
     async releaseSession(sessionId) {
       await sdk.sessions.update(sessionId, { status: "REQUEST_RELEASE" });
@@ -133,10 +178,10 @@ export function createBrowserbaseApiClient(
 async function cleanupInvalidSession(
   browserbase: BrowserbaseApiClient,
   sessionId: string,
-  extension: ProvisionedBrowserbaseExtension,
+  extension: ProvisionedBrowserbaseExtension | undefined,
 ): Promise<void> {
   if (sessionId.length > 0) {
     await browserbase.releaseSession(sessionId).catch(() => undefined);
   }
-  await extension.cleanup().catch(() => undefined);
+  await extension?.cleanup().catch(() => undefined);
 }

--- a/packages/sdk-ts/src/browser/factories.ts
+++ b/packages/sdk-ts/src/browser/factories.ts
@@ -1,0 +1,250 @@
+import type { StagehandInitParams } from "../../../protocol/types.js";
+import {
+  BrowserbaseConnectOptionsSchema,
+  BrowserbaseLaunchOptionsSchema,
+  LocalBrowserConnectOptionsSchema,
+  LocalBrowserLaunchOptionsSchema,
+} from "../clientSchemas.js";
+import {
+  claimStagehandBrowserHandle,
+  createStagehandBrowserHandle,
+  isStagehandBrowser,
+  type BrowserbaseBrowser,
+  type LocalBrowser,
+  type StagehandBrowser,
+  type StagehandBrowserOrigin,
+  type StagehandBrowserProvider,
+} from "./index.js";
+import { CDPClient, type CDPClientOptions } from "../cdpClient.js";
+import {
+  createBrowserbaseSessionClient,
+  type BrowserbaseSessionClient,
+} from "./browserbaseSession.js";
+import { launchLocalBrowser, type LocalBrowserLauncher } from "./localBrowser.js";
+import { STAGEHAND_EXTENSION_DIRECTORY_PATH } from "../extensionAssets.js";
+
+export { isStagehandBrowser };
+export type { BrowserbaseBrowser, LocalBrowser, StagehandBrowser } from "./index.js";
+
+export type StagehandWorkerInitMetadata = Pick<StagehandInitParams, "apiKey" | "browser">;
+
+export type ClaimedStagehandBrowser = {
+  cdpClient: CDPClient;
+  commandTimeoutMs: number;
+  workerInitMetadata: StagehandWorkerInitMetadata;
+};
+
+type BrowserFactoryDependencies = {
+  launchLocalBrowser?: LocalBrowserLauncher;
+  createBrowserbaseSessionClient?: (apiKey: string) => BrowserbaseSessionClient;
+  connectCdp?: (options: CDPClientOptions) => Promise<CDPClient>;
+};
+
+type BrowserConnectionSource = {
+  cdpUrl: string;
+  keepAlive: boolean;
+  close?: () => Promise<void> | void;
+};
+
+function createBrowserFactories(dependencies: BrowserFactoryDependencies = {}): {
+  localBrowser: LocalBrowser;
+  browserbase: BrowserbaseBrowser;
+} {
+  const launchLocal = dependencies.launchLocalBrowser ?? launchLocalBrowser;
+  const createBrowserbase =
+    dependencies.createBrowserbaseSessionClient ?? createBrowserbaseSessionClient;
+  const connectCdp = dependencies.connectCdp ?? ((options) => CDPClient.connect(options));
+
+  return {
+    localBrowser: {
+      async launch(input = {}) {
+        const options = LocalBrowserLaunchOptionsSchema.parse(input);
+        if (options.acceptDownloads === true && options.downloadsPath === undefined) {
+          throw new Error("downloadsPath is required when acceptDownloads is true");
+        }
+        const launched = await launchLocal(options);
+        const source: BrowserConnectionSource = {
+          cdpUrl: launched.cdpUrl,
+          keepAlive: options.keepAlive ?? false,
+          close: launched.close,
+        };
+        return await connectBrowser({
+          provider: "local",
+          origin: "launched",
+          source,
+          connectCdp,
+          extension: { extensionDir: STAGEHAND_EXTENSION_DIRECTORY_PATH },
+          connectTimeoutMs: options.connectTimeoutMs,
+          afterConnect:
+            options.acceptDownloads === undefined && options.downloadsPath === undefined
+              ? undefined
+              : async (cdpClient) => {
+                  await cdpClient.sendCommand("Browser.setDownloadBehavior", {
+                    behavior: options.acceptDownloads === false ? "deny" : "allow",
+                    ...(options.downloadsPath === undefined
+                      ? {}
+                      : { downloadPath: options.downloadsPath }),
+                  });
+                },
+          workerInitMetadata: {},
+        });
+      },
+
+      async connect(options) {
+        const parsed = LocalBrowserConnectOptionsSchema.parse(options);
+        const source: BrowserConnectionSource = {
+          cdpUrl: parsed.cdpUrl,
+          keepAlive: true,
+        };
+        return await connectBrowser({
+          provider: "local",
+          origin: "connected",
+          source,
+          connectCdp,
+          extension:
+            parsed.extensionId === undefined
+              ? { extensionDir: STAGEHAND_EXTENSION_DIRECTORY_PATH }
+              : { extensionId: parsed.extensionId },
+          connectTimeoutMs: parsed.connectTimeoutMs,
+          workerInitMetadata: {},
+        });
+      },
+    },
+
+    browserbase: {
+      async launch(input) {
+        const { apiKey, ...sessionOptions } = BrowserbaseLaunchOptionsSchema.parse(input);
+        const session = await createBrowserbase(apiKey).createSession(sessionOptions);
+        const source: BrowserConnectionSource = {
+          cdpUrl: session.cdpUrl,
+          keepAlive: sessionOptions.keepAlive ?? false,
+          close: session.close,
+        };
+        return await connectBrowser({
+          provider: "browserbase",
+          origin: "launched",
+          source,
+          connectCdp,
+          extension: { preloadedExtension: true },
+          connectTimeoutMs: undefined,
+          workerInitMetadata: {
+            apiKey,
+            browser: {
+              type: "browserbase",
+              sessionId: session.sessionId,
+              ...(sessionOptions.region === undefined ? {} : { region: sessionOptions.region }),
+            },
+          },
+        });
+      },
+
+      async connect(input) {
+        const options = BrowserbaseConnectOptionsSchema.parse(input);
+        const client = createBrowserbase(options.apiKey);
+        if (!client.connectSession) {
+          throw new Error("Browserbase session connection is not supported by this client");
+        }
+        const session = await client.connectSession(options.sessionId);
+        const source: BrowserConnectionSource = {
+          cdpUrl: session.cdpUrl,
+          keepAlive: true,
+        };
+        return await connectBrowser({
+          provider: "browserbase",
+          origin: "connected",
+          source,
+          connectCdp,
+          extension:
+            options.extensionId === undefined
+              ? { preloadedExtension: true }
+              : { extensionId: options.extensionId },
+          connectTimeoutMs: options.connectTimeoutMs,
+          workerInitMetadata: {
+            apiKey: options.apiKey,
+            browser: {
+              type: "browserbase",
+              sessionId: session.sessionId,
+              ...(session.region === undefined ? {} : { region: session.region }),
+            },
+          },
+        });
+      },
+    },
+  };
+}
+
+const factories = createBrowserFactories();
+export const localBrowser = factories.localBrowser;
+export const browserbase = factories.browserbase;
+
+/** @internal */
+export function createBrowserFactoriesForTest(
+  dependencies: BrowserFactoryDependencies,
+): ReturnType<typeof createBrowserFactories> {
+  return createBrowserFactories(dependencies);
+}
+
+/** @internal */
+export function claimStagehandBrowser(browser: StagehandBrowser): ClaimedStagehandBrowser {
+  return claimStagehandBrowserHandle<ClaimedStagehandBrowser>(browser);
+}
+
+async function connectBrowser(options: {
+  provider: StagehandBrowserProvider;
+  origin: StagehandBrowserOrigin;
+  source: BrowserConnectionSource;
+  connectCdp: (options: CDPClientOptions) => Promise<CDPClient>;
+  extension: { extensionDir: string } | { extensionId: string } | { preloadedExtension: true };
+  connectTimeoutMs: number | undefined;
+  afterConnect?: (cdpClient: CDPClient) => Promise<void>;
+  workerInitMetadata: StagehandWorkerInitMetadata;
+}): Promise<StagehandBrowser> {
+  const commandTimeoutMs = 10_000;
+  const ownsSource = options.origin === "launched" && !options.source.keepAlive;
+  let cdpClient: CDPClient | undefined;
+  try {
+    cdpClient = await options.connectCdp({
+      cdpUrl: options.source.cdpUrl,
+      ...options.extension,
+      serviceWorkerUrlIncludes: "service-worker.js",
+      discoveryTimeoutMs: options.connectTimeoutMs ?? 10_000,
+      cdpConnectTimeoutMs: options.connectTimeoutMs ?? 10_000,
+      commandTimeoutMs,
+    });
+    await options.afterConnect?.(cdpClient);
+    const connectedClient = cdpClient;
+    return createStagehandBrowserHandle({
+      provider: options.provider,
+      origin: options.origin,
+      attachment: {
+        cdpClient: connectedClient,
+        commandTimeoutMs,
+        workerInitMetadata: options.workerInitMetadata,
+      } satisfies ClaimedStagehandBrowser,
+      close: async () => {
+        connectedClient.close();
+        if (ownsSource) {
+          await closeSource(options.source);
+        }
+      },
+    });
+  } catch (error) {
+    cdpClient?.close();
+    if (ownsSource) {
+      try {
+        await closeSource(options.source);
+      } catch (cleanupError) {
+        throw new AggregateError(
+          [error, cleanupError],
+          "Browser connection failed and browser cleanup also failed",
+          { cause: error },
+        );
+      }
+    }
+    throw error;
+  }
+}
+
+async function closeSource(source: BrowserConnectionSource): Promise<void> {
+  await source.close?.();
+}

--- a/packages/sdk-ts/src/browser/index.ts
+++ b/packages/sdk-ts/src/browser/index.ts
@@ -12,7 +12,7 @@ export type {
   LocalBrowserLaunchOptions,
 };
 
-declare const stagehandBrowserBrand: unique symbol;
+const stagehandBrowserBrand: unique symbol = Symbol("StagehandBrowser");
 
 export type StagehandBrowserProvider = "local" | "browserbase";
 export type StagehandBrowserOrigin = "launched" | "connected";
@@ -39,4 +39,78 @@ export interface LocalBrowser {
 export interface BrowserbaseBrowser {
   launch(options: BrowserbaseLaunchOptions): Promise<StagehandBrowser>;
   connect(options: BrowserbaseConnectOptions): Promise<StagehandBrowser>;
+}
+
+type BrowserHandleInternals = {
+  claimed: boolean;
+  attachment: unknown;
+  close: () => Promise<void> | void;
+  closePromise?: Promise<void>;
+};
+
+const browserHandleInternals = new WeakMap<StagehandBrowser, BrowserHandleInternals>();
+
+class StagehandBrowserHandle implements StagehandBrowser {
+  readonly [stagehandBrowserBrand] = true as const;
+
+  constructor(
+    readonly provider: StagehandBrowserProvider,
+    readonly origin: StagehandBrowserOrigin,
+    internals: BrowserHandleInternals,
+  ) {
+    browserHandleInternals.set(this, internals);
+  }
+
+  get closed(): boolean {
+    return browserHandleInternals.get(this)?.closePromise !== undefined;
+  }
+
+  close(): Promise<void> {
+    const internals = requireBrowserHandleInternals(this);
+    internals.closePromise ??= Promise.resolve().then(internals.close);
+    return internals.closePromise;
+  }
+}
+
+/** @internal */
+export function createStagehandBrowserHandle<Attachment>(options: {
+  provider: StagehandBrowserProvider;
+  origin: StagehandBrowserOrigin;
+  attachment: Attachment;
+  close: () => Promise<void> | void;
+}): StagehandBrowser {
+  return new StagehandBrowserHandle(options.provider, options.origin, {
+    claimed: false,
+    attachment: options.attachment,
+    close: options.close,
+  });
+}
+
+/** @internal */
+export function claimStagehandBrowserHandle<Attachment>(browser: StagehandBrowser): Attachment {
+  const internals = requireBrowserHandleInternals(browser);
+  if (internals.closePromise) {
+    throw new Error("Cannot attach Stagehand to a closed browser");
+  }
+  if (internals.claimed) {
+    throw new Error("This browser is already attached to a Stagehand instance");
+  }
+  internals.claimed = true;
+  return internals.attachment as Attachment;
+}
+
+export function isStagehandBrowser(value: unknown): value is StagehandBrowser {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    browserHandleInternals.has(value as StagehandBrowser)
+  );
+}
+
+function requireBrowserHandleInternals(browser: StagehandBrowser): BrowserHandleInternals {
+  const internals = browserHandleInternals.get(browser);
+  if (!internals) {
+    throw new TypeError("browser must be created by localBrowser or browserbase");
+  }
+  return internals;
 }

--- a/packages/sdk-ts/src/browser/localBrowser.ts
+++ b/packages/sdk-ts/src/browser/localBrowser.ts
@@ -1,0 +1,80 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { LocalBrowserLaunchOptions } from "../clientSchemas.js";
+
+export const WEBMCP_CHROME_FLAG = "--enable-features=WebMCPTesting,DevToolsWebMCPSupport";
+
+const STAGEHAND_DEFAULT_CHROME_FLAGS = [
+  "--enable-unsafe-extension-debugging",
+  "--remote-allow-origins=*",
+] as const;
+
+export type LocalBrowserLauncher = (
+  options: LocalBrowserLaunchOptions,
+) => Promise<{ cdpUrl: string; close: () => Promise<void> | void }>;
+
+export const launchLocalBrowser: LocalBrowserLauncher = async (options) => {
+  if (options.proxy?.username !== undefined || options.proxy?.password !== undefined) {
+    throw new Error("Authenticated local browser proxies are not supported yet");
+  }
+  const { getChromePath, launch, Launcher } = await import("chrome-launcher");
+  const userDataDir =
+    options.userDataDir ??
+    (options.preserveUserDataDir === true
+      ? await mkdtemp(path.join(tmpdir(), "stagehand-chrome-"))
+      : undefined);
+  const chrome = await launch({
+    chromePath: options.executablePath ?? getChromePath(),
+    startingUrl: "about:blank",
+    ignoreDefaultFlags: true,
+    chromeFlags: localBrowserChromeFlags(options, Launcher.defaultFlags(), Boolean(process.env.CI)),
+    userDataDir,
+    ...(options.port === undefined ? {} : { port: options.port }),
+    logLevel: "silent",
+  });
+
+  return {
+    cdpUrl: `http://127.0.0.1:${chrome.port}`,
+    close: () => chrome.kill(),
+  };
+};
+
+export function localBrowserChromeFlags(
+  options: LocalBrowserLaunchOptions,
+  launcherDefaultFlags: string[],
+  isCI: boolean,
+): string[] {
+  const ignoredDefaultArgs = options.ignoreDefaultArgs;
+  const ignoredFlags = new Set(Array.isArray(ignoredDefaultArgs) ? ignoredDefaultArgs : []);
+  const includeDefaults = ignoredDefaultArgs !== true;
+  const viewport = options.viewport ?? { width: 1280, height: 800 };
+  const windowSizeFlag = `--window-size=${viewport.width},${viewport.height}`;
+
+  return [
+    ...(includeDefaults
+      ? launcherDefaultFlags.filter(
+          (flag) => flag !== "--disable-extensions" && !ignoredFlags.has(flag),
+        )
+      : []),
+    ...(includeDefaults
+      ? STAGEHAND_DEFAULT_CHROME_FLAGS.filter((flag) => !ignoredFlags.has(flag))
+      : []),
+    ...(options.viewport !== undefined || (includeDefaults && !ignoredFlags.has(windowSizeFlag))
+      ? [windowSizeFlag]
+      : []),
+    ...(includeDefaults && !ignoredFlags.has(WEBMCP_CHROME_FLAG) ? [WEBMCP_CHROME_FLAG] : []),
+    ...(options.headless === true ? ["--headless"] : []),
+    ...(options.devtools ? ["--auto-open-devtools-for-tabs"] : []),
+    ...(isCI || options.chromiumSandbox === false ? ["--no-sandbox"] : []),
+    ...(options.proxy ? [`--proxy-server=${options.proxy.server}`] : []),
+    ...(options.proxy?.bypass ? [`--proxy-bypass-list=${options.proxy.bypass}`] : []),
+    ...(options.locale ? [`--lang=${options.locale}`] : []),
+    ...(options.deviceScaleFactor === undefined
+      ? []
+      : [`--force-device-scale-factor=${options.deviceScaleFactor}`]),
+    ...(options.hasTouch === true ? ["--touch-events=enabled"] : []),
+    ...(options.ignoreHTTPSErrors === true ? ["--ignore-certificate-errors"] : []),
+    ...(options.args ?? []),
+  ];
+}

--- a/packages/sdk-ts/src/browserSource.ts
+++ b/packages/sdk-ts/src/browserSource.ts
@@ -1,27 +1,17 @@
-import { StagehandClientInitParamsSchema, type BrowserSource } from "./clientSchemas.js";
 import {
-  BrowserbaseSessionCreateParamsSchema,
   LocalBrowserLaunchOptionsSchema,
-} from "../../protocol/schemas.js";
+  StagehandClientInitParamsSchema,
+} from "./clientSchemas.js";
+import { BrowserbaseSessionCreateParamsSchema } from "../../protocol/schemas.js";
 import {
   createBrowserbaseSessionClient,
   type BrowserbaseSessionClient,
   type BrowserbaseSessionClientFactory,
-} from "./browserbaseSession.js";
+} from "./browser/browserbaseSession.js";
+import { launchLocalBrowser, type LocalBrowserLauncher } from "./browser/localBrowser.js";
 
 export type { BrowserbaseSessionClient, BrowserbaseSessionClientFactory };
-
-type LocalBrowserSource = Extract<BrowserSource, { type: "local" }>;
-type LocalBrowserLaunchOptions = Omit<LocalBrowserSource, "type">;
-
-export const WEBMCP_CHROME_FLAG = "--enable-features=WebMCPTesting,DevToolsWebMCPSupport";
-
-const STAGEHAND_DEFAULT_CHROME_FLAGS = [
-  "--enable-unsafe-extension-debugging",
-  "--remote-allow-origins=*",
-  "--window-size=1280,800",
-  WEBMCP_CHROME_FLAG,
-] as const;
+export { localBrowserChromeFlags, WEBMCP_CHROME_FLAG } from "./browser/localBrowser.js";
 
 export type ResolvedBrowserSource = {
   cdpUrl: string;
@@ -32,10 +22,6 @@ export type ResolvedBrowserSource = {
   keepAlive: boolean;
   close?: () => Promise<void> | void;
 };
-
-export type LocalBrowserLauncher = (
-  options: LocalBrowserLaunchOptions,
-) => Promise<{ cdpUrl: string; close: () => Promise<void> | void }>;
 
 export type BrowserSourceResolverDependencies = {
   launchLocalBrowser?: LocalBrowserLauncher;
@@ -71,7 +57,8 @@ export async function resolveBrowserSource(
   }
 
   if (browser.type === "local") {
-    const launchOptions = LocalBrowserLaunchOptionsSchema.strip().parse(browser);
+    const { type: _, ...localOptions } = browser;
+    const launchOptions = LocalBrowserLaunchOptionsSchema.parse(localOptions);
     const launched = await (dependencies.launchLocalBrowser ?? launchLocalBrowser)(launchOptions);
     return {
       cdpUrl: launched.cdpUrl,
@@ -87,49 +74,4 @@ export async function resolveBrowserSource(
     residentBrowserConnection: false,
     keepAlive: true,
   };
-}
-
-async function launchLocalBrowser(
-  options: LocalBrowserLaunchOptions,
-): Promise<{ cdpUrl: string; close: () => void }> {
-  const { getChromePath, launch, Launcher } = await import("chrome-launcher");
-  const chrome = await launch({
-    chromePath: getChromePath(),
-    startingUrl: "about:blank",
-    ignoreDefaultFlags: true,
-    chromeFlags: localBrowserChromeFlags(options, Launcher.defaultFlags(), Boolean(process.env.CI)),
-    userDataDir: options.userDataDir,
-    ...(options.port === undefined ? {} : { port: options.port }),
-    logLevel: "silent",
-  });
-
-  return {
-    cdpUrl: `http://127.0.0.1:${chrome.port}`,
-    close: () => chrome.kill(),
-  };
-}
-
-export function localBrowserChromeFlags(
-  options: LocalBrowserLaunchOptions,
-  launcherDefaultFlags: string[],
-  isCI: boolean,
-): string[] {
-  const ignoredDefaultArgs = options.ignoreDefaultArgs;
-  const ignoredFlags = new Set(Array.isArray(ignoredDefaultArgs) ? ignoredDefaultArgs : []);
-  const includeDefaults = ignoredDefaultArgs !== true;
-
-  return [
-    ...(includeDefaults
-      ? launcherDefaultFlags.filter(
-          (flag) => flag !== "--disable-extensions" && !ignoredFlags.has(flag),
-        )
-      : []),
-    ...(includeDefaults
-      ? STAGEHAND_DEFAULT_CHROME_FLAGS.filter((flag) => !ignoredFlags.has(flag))
-      : []),
-    ...(options.headless === true ? ["--headless"] : []),
-    ...(options.devtools ? ["--auto-open-devtools-for-tabs"] : []),
-    ...(isCI ? ["--no-sandbox"] : []),
-    ...(options.args ?? []),
-  ];
 }

--- a/packages/sdk-ts/src/clientSchemas.ts
+++ b/packages/sdk-ts/src/clientSchemas.ts
@@ -6,10 +6,11 @@
  */
 
 import { z } from "zod/v4";
+import type Browserbase from "@browserbasehq/sdk";
 import * as ProtocolSchemas from "../../protocol/schemas.js";
 import {
   ActOptionsSchema,
-  BrowserbaseBrowserSettingsSchema,
+  BrowserbaseRegionSchema,
   BrowserbaseSessionCreateParamsSchema,
   ExtractOptionsSchema,
   LLMGenerateParamsSchema,
@@ -22,26 +23,45 @@ import {
 } from "../../protocol/schemas.js";
 import { Page } from "./page.js";
 
-const BrowserbaseClientBrowserSettingsSchema = BrowserbaseBrowserSettingsSchema.omit({
-  extensionId: true,
-});
-
-/** Browserbase source fields exposed by the TS SDK. Stagehand provisions its own extension. */
-export const BrowserbaseBrowserSourceSchema = BrowserbaseSessionCreateParamsSchema.omit({
-  browserSettings: true,
-  extensionId: true,
-})
-  .extend({
-    type: z.literal("browserbase"),
-    browserSettings: BrowserbaseClientBrowserSettingsSchema.optional(),
-  })
-  .meta({ id: "BrowserbaseClientBrowserSource" });
+/** Browserbase source fields exposed by the TS SDK. */
+export const BrowserbaseBrowserSourceSchema = BrowserbaseSessionCreateParamsSchema.extend({
+  type: z.literal("browserbase"),
+}).meta({ id: "BrowserbaseClientBrowserSource" });
 
 export const LocalBrowserSourceSchema = ProtocolSchemas.LocalBrowserLaunchOptionsSchema.extend({
   type: z.literal("local"),
 }).meta({ id: "LocalBrowserSource" });
 
-export const LocalBrowserLaunchOptionsSchema = ProtocolSchemas.LocalBrowserLaunchOptionsSchema;
+export const LocalBrowserLaunchOptionsSchema = z
+  .strictObject({
+    args: z.array(z.string()).optional(),
+    executablePath: z.string().optional(),
+    port: z.number().optional(),
+    userDataDir: z.string().optional(),
+    preserveUserDataDir: z.boolean().optional(),
+    headless: z.boolean().optional(),
+    devtools: z.boolean().optional(),
+    chromiumSandbox: z.boolean().optional(),
+    ignoreDefaultArgs: z.union([z.boolean(), z.array(z.string())]).optional(),
+    proxy: z
+      .strictObject({
+        server: z.string(),
+        bypass: z.string().optional(),
+        username: z.string().optional(),
+        password: z.string().optional(),
+      })
+      .optional(),
+    locale: z.string().optional(),
+    viewport: z.strictObject({ width: z.number(), height: z.number() }).optional(),
+    deviceScaleFactor: z.number().optional(),
+    hasTouch: z.boolean().optional(),
+    ignoreHTTPSErrors: z.boolean().optional(),
+    connectTimeoutMs: z.number().optional(),
+    downloadsPath: z.string().optional(),
+    acceptDownloads: z.boolean().optional(),
+    keepAlive: z.boolean().optional(),
+  })
+  .meta({ id: "LocalBrowserLaunchOptions" });
 
 export const LocalBrowserConnectOptionsSchema = z
   .strictObject({
@@ -51,17 +71,53 @@ export const LocalBrowserConnectOptionsSchema = z
   })
   .meta({ id: "LocalBrowserConnectOptions" });
 
-export const BrowserbaseLaunchOptionsSchema = BrowserbaseSessionCreateParamsSchema.extend({
-  apiKey: z.string().min(1),
-}).meta({ id: "BrowserbaseLaunchOptions" });
+type BrowserbaseLaunchOptionsInput = Browserbase.SessionCreateParams & { apiKey: string };
+
+/**
+ * Browserbase owns the session option surface. Keep this object loose so newly added SDK options
+ * pass through without requiring a Stagehand protocol or schema update.
+ */
+export const BrowserbaseLaunchOptionsSchema = z
+  .looseObject({
+    apiKey: z.string().min(1),
+    type: z.never().optional(),
+  })
+  .meta({ id: "BrowserbaseLaunchOptions" }) as z.ZodType<BrowserbaseLaunchOptionsInput>;
 
 export const BrowserbaseConnectOptionsSchema = z
   .strictObject({
     apiKey: z.string().min(1),
     sessionId: z.string().min(1),
     connectTimeoutMs: z.number().int().positive().optional(),
+    extensionId: z.string().min(1).optional(),
   })
   .meta({ id: "BrowserbaseConnectOptions" });
+
+/** Data returned by the Browserbase SDK after creating a session. */
+export const BrowserbaseSessionCreateResultSchema = z
+  .object({
+    id: z.string(),
+    connectUrl: z.string(),
+  })
+  .meta({ id: "BrowserbaseSessionCreateResult" });
+
+/** Data returned by the Browserbase SDK when retrieving a session. */
+export const BrowserbaseSessionRetrieveResultSchema = z
+  .object({
+    id: z.string(),
+    connectUrl: z.string().optional(),
+    region: BrowserbaseRegionSchema.optional(),
+  })
+  .meta({ id: "BrowserbaseSessionRetrieveResult" });
+
+/** Normalized connection data shared by Browserbase launch and connect flows. */
+export const BrowserbaseSessionConnectionSchema = z
+  .strictObject({
+    sessionId: z.string().trim().min(1),
+    cdpUrl: z.string().trim().min(1),
+    region: BrowserbaseRegionSchema.optional(),
+  })
+  .meta({ id: "BrowserbaseSessionConnection" });
 
 export const CdpBrowserSourceSchema = z
   .strictObject({
@@ -168,6 +224,11 @@ export type LocalBrowserLaunchOptions = z.infer<typeof LocalBrowserLaunchOptions
 export type LocalBrowserConnectOptions = z.infer<typeof LocalBrowserConnectOptionsSchema>;
 export type BrowserbaseLaunchOptions = z.infer<typeof BrowserbaseLaunchOptionsSchema>;
 export type BrowserbaseConnectOptions = z.infer<typeof BrowserbaseConnectOptionsSchema>;
+export type BrowserbaseSessionCreateResult = z.infer<typeof BrowserbaseSessionCreateResultSchema>;
+export type BrowserbaseSessionRetrieveResult = z.infer<
+  typeof BrowserbaseSessionRetrieveResultSchema
+>;
+export type BrowserbaseSessionConnection = z.infer<typeof BrowserbaseSessionConnectionSchema>;
 export type StagehandClientInitParams = z.input<typeof StagehandClientInitParamsSchema>;
 export type ResolvedStagehandClientInitParams = z.output<typeof StagehandClientInitParamsSchema>;
 export type WebMCPToolsOptions = z.infer<typeof WebMCPToolsOptionsSchema>;

--- a/packages/sdk-ts/tests/browser/browserbaseSession.test.ts
+++ b/packages/sdk-ts/tests/browser/browserbaseSession.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  BrowserbaseSessionError,
   createBrowserbaseApiClient,
   createBrowserbaseSessionClient,
   type BrowserbaseApiClient,
-} from "../src/browserbaseSession.js";
+} from "../../src/browser/browserbaseSession.js";
 
 describe("Browserbase session creation", () => {
   it("maps session creation and release to the official SDK surface", async () => {
@@ -12,12 +13,17 @@ describe("Browserbase session creation", () => {
       connectUrl: "wss://connect.browserbase.com/devtools/browser/session_123",
     }));
     const update = vi.fn(async () => ({}));
+    const retrieve = vi.fn(async () => ({
+      id: "session_123",
+      connectUrl: "wss://connect.browserbase.com/devtools/browser/session_123",
+      region: "us-west-2" as const,
+    }));
     const createSdk = vi.fn(() => ({
       extensions: {
         create: vi.fn(async () => ({ id: "ext_stagehand" })),
         delete: vi.fn(async () => {}),
       },
-      sessions: { create, update },
+      sessions: { create, retrieve, update },
     }));
     const client = createBrowserbaseApiClient("bb_key", createSdk);
 
@@ -26,10 +32,88 @@ describe("Browserbase session creation", () => {
       connectUrl: "wss://connect.browserbase.com/devtools/browser/session_123",
     });
     await client.releaseSession("session_123");
+    await expect(client.retrieveSession("session_123")).resolves.toStrictEqual({
+      id: "session_123",
+      connectUrl: "wss://connect.browserbase.com/devtools/browser/session_123",
+      region: "us-west-2",
+    });
 
     expect(createSdk).toHaveBeenCalledWith("bb_key");
     expect(create).toHaveBeenCalledWith({ region: "us-west-2" });
     expect(update).toHaveBeenCalledWith("session_123", { status: "REQUEST_RELEASE" });
+    expect(retrieve).toHaveBeenCalledWith("session_123");
+  });
+
+  it("validates session data returned by the Browserbase SDK", async () => {
+    const client = createBrowserbaseApiClient("bb_key", () => ({
+      extensions: {
+        create: vi.fn(async () => ({ id: "ext_stagehand" })),
+        delete: vi.fn(async () => {}),
+      },
+      sessions: {
+        create: vi.fn(async () => ({ id: "session_123", connectUrl: 42 })),
+        retrieve: vi.fn(async () => ({
+          id: "session_123",
+          connectUrl: "wss://connect.browserbase.com/devtools/browser/session_123",
+          region: "moon-1",
+        })),
+        update: vi.fn(async () => ({})),
+      },
+    }));
+
+    await expect(client.createSession({})).rejects.toThrow();
+    await expect(client.retrieveSession("session_123")).rejects.toThrow();
+  });
+
+  it("connects to an existing running session without taking release ownership", async () => {
+    const retrieveSession = vi.fn(async () => ({
+      id: "session_123",
+      connectUrl: "wss://connect.browserbase.com/devtools/browser/session_123",
+      region: "eu-central-1" as const,
+    }));
+    const releaseSession = vi.fn(async () => {});
+    const client = createBrowserbaseSessionClient("bb_key", {
+      browserbase: fakeBrowserbaseApiClient({ retrieveSession, releaseSession }),
+      provisionExtension: vi.fn(),
+    });
+
+    await expect(client.connectSession?.("session_123")).resolves.toStrictEqual({
+      sessionId: "session_123",
+      cdpUrl: "wss://connect.browserbase.com/devtools/browser/session_123",
+      region: "eu-central-1",
+    });
+    expect(retrieveSession).toHaveBeenCalledWith("session_123");
+    expect(releaseSession).not.toHaveBeenCalled();
+  });
+
+  it("rejects a Browserbase session without a connection URL", async () => {
+    const client = createBrowserbaseSessionClient("bb_key", {
+      browserbase: fakeBrowserbaseApiClient({
+        retrieveSession: async () => ({ id: "session_123" }),
+      }),
+      provisionExtension: vi.fn(),
+    });
+
+    await expect(client.connectSession?.("session_123")).rejects.toThrow(
+      "not available for connection",
+    );
+  });
+
+  it("sanitizes Browserbase session retrieval failures", async () => {
+    const client = createBrowserbaseSessionClient("bb_key", {
+      browserbase: fakeBrowserbaseApiClient({
+        retrieveSession: async () => {
+          throw new Error("request failed for bb_secret at wss://private.example");
+        },
+      }),
+      provisionExtension: vi.fn(),
+    });
+
+    const error = await client.connectSession?.("session_123").catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(BrowserbaseSessionError);
+    expect((error as Error).message).toBe("Failed to retrieve the Browserbase session");
+    expect((error as Error).cause).toBeUndefined();
   });
 
   it("creates a session with the provisioned extension and maps its connection URL", async () => {
@@ -80,6 +164,36 @@ describe("Browserbase session creation", () => {
     expect(cleanupExtension).toHaveBeenCalledOnce();
   });
 
+  it.each([{ extensionId: "ext_caller" }, { browserSettings: { extensionId: "ext_caller" } }])(
+    "reuses a caller-owned extension without provisioning or deleting it",
+    async (params) => {
+      const createSession = vi.fn(async () => ({
+        id: "session_123",
+        connectUrl: "wss://connect.browserbase.com/devtools/browser/session_123",
+      }));
+      const releaseSession = vi.fn(async () => {});
+      const provisionExtension = vi.fn();
+      const client = createBrowserbaseSessionClient("bb_key", {
+        browserbase: fakeBrowserbaseApiClient({ createSession, releaseSession }),
+        provisionExtension,
+      });
+
+      const session = await client.createSession(params);
+
+      expect(provisionExtension).not.toHaveBeenCalled();
+      expect(createSession).toHaveBeenCalledWith({
+        ...params,
+        userMetadata: {
+          stagehand: "true",
+          stagehand_sdk_language: "typescript",
+        },
+      });
+
+      await session.close?.();
+      expect(releaseSession).toHaveBeenCalledWith("session_123");
+    },
+  );
+
   it("deletes the uploaded extension when session creation fails", async () => {
     const createError = new Error("concurrency limit reached");
     const cleanupExtension = vi.fn(async () => {});
@@ -97,9 +211,9 @@ describe("Browserbase session creation", () => {
     });
 
     const error = await client.createSession({}).catch((caught: unknown) => caught);
-    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(BrowserbaseSessionError);
     expect((error as Error).message).toBe("Failed to create a Browserbase session");
-    expect((error as Error).cause).toBe(createError);
+    expect((error as Error).cause).toBeUndefined();
     expect(cleanupExtension).toHaveBeenCalledOnce();
   });
 
@@ -195,6 +309,12 @@ function fakeBrowserbaseApiClient(
       return {
         id: "session_123",
         connectUrl: "wss://connect.browserbase.com/devtools/browser/session_123",
+      };
+    },
+    async retrieveSession(sessionId) {
+      return {
+        id: sessionId,
+        connectUrl: `wss://connect.browserbase.com/devtools/browser/${sessionId}`,
       };
     },
     async releaseSession() {},

--- a/packages/sdk-ts/tests/browser/contracts.test.ts
+++ b/packages/sdk-ts/tests/browser/contracts.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
+import type Browserbase from "@browserbasehq/sdk";
 import {
   BrowserbaseConnectOptionsSchema,
   BrowserbaseLaunchOptionsSchema,
@@ -54,6 +55,9 @@ describe("browser API contracts", () => {
     expectTypeOf<ReturnType<BrowserbaseBrowser["launch"]>>().toEqualTypeOf<
       Promise<StagehandBrowser>
     >();
+    expectTypeOf<
+      Omit<BrowserbaseLaunchOptions, "apiKey">
+    >().toEqualTypeOf<Browserbase.SessionCreateParams>();
     expectTypeOf<Parameters<BrowserbaseBrowser["connect"]>>().toEqualTypeOf<
       [options: BrowserbaseConnectOptions]
     >();
@@ -61,6 +65,7 @@ describe("browser API contracts", () => {
       apiKey: string;
       sessionId: string;
       connectTimeoutMs?: number;
+      extensionId?: string;
     }>();
   });
 
@@ -75,8 +80,41 @@ describe("browser API contracts", () => {
       apiKey: "bb_key",
     });
     expect(
-      BrowserbaseConnectOptionsSchema.parse({ apiKey: "bb_key", sessionId: "session_123" }),
-    ).toStrictEqual({ apiKey: "bb_key", sessionId: "session_123" });
+      BrowserbaseLaunchOptionsSchema.parse({
+        apiKey: "bb_key",
+        projectId: "project_123",
+        proxySettings: { caCertificates: ["certificate_123"] },
+        extensionId: "user-extension",
+      }),
+    ).toStrictEqual({
+      apiKey: "bb_key",
+      projectId: "project_123",
+      proxySettings: { caCertificates: ["certificate_123"] },
+      extensionId: "user-extension",
+    });
+    expect(
+      BrowserbaseLaunchOptionsSchema.parse({
+        apiKey: "bb_key",
+        browserSettings: { extensionId: "user-extension" },
+      }),
+    ).toStrictEqual({
+      apiKey: "bb_key",
+      browserSettings: { extensionId: "user-extension" },
+    });
+    expect(() =>
+      BrowserbaseLaunchOptionsSchema.parse({ apiKey: "bb_key", type: "browserbase" }),
+    ).toThrow();
+    expect(
+      BrowserbaseConnectOptionsSchema.parse({
+        apiKey: "bb_key",
+        sessionId: "session_123",
+        extensionId: "user-extension",
+      }),
+    ).toStrictEqual({
+      apiKey: "bb_key",
+      sessionId: "session_123",
+      extensionId: "user-extension",
+    });
     expect(() =>
       LocalBrowserConnectOptionsSchema.parse({
         cdpUrl: "ws://127.0.0.1:9222",

--- a/packages/sdk-ts/tests/browser/factories.test.ts
+++ b/packages/sdk-ts/tests/browser/factories.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  claimStagehandBrowser,
+  createBrowserFactoriesForTest,
+} from "../../src/browser/factories.js";
+import type { CDPClient, CDPClientOptions } from "../../src/cdpClient.js";
+
+function fakeCdpClient(close = vi.fn()) {
+  return { close } as unknown as CDPClient;
+}
+
+describe("Stagehand browser factories", () => {
+  it("launches a local browser and prepares the packaged extension", async () => {
+    const closeSource = vi.fn();
+    const launchLocalBrowser = vi.fn(async () => ({
+      cdpUrl: "http://127.0.0.1:9222",
+      close: closeSource,
+    }));
+    const closeCdp = vi.fn();
+    const cdp = fakeCdpClient(closeCdp);
+    const connectCdp = vi.fn(async (_options: CDPClientOptions) => cdp);
+    const { localBrowser } = createBrowserFactoriesForTest({
+      launchLocalBrowser,
+      connectCdp,
+    });
+
+    const browser = await localBrowser.launch({ headless: true, connectTimeoutMs: 2_000 });
+
+    expect(browser).toMatchObject({ provider: "local", origin: "launched", closed: false });
+    expect(launchLocalBrowser).toHaveBeenCalledWith({
+      headless: true,
+      connectTimeoutMs: 2_000,
+    });
+    expect(connectCdp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cdpUrl: "http://127.0.0.1:9222",
+        extensionDir: expect.stringContaining("dist/extension") as string,
+        discoveryTimeoutMs: 2_000,
+        cdpConnectTimeoutMs: 2_000,
+      }),
+    );
+
+    await Promise.all([browser.close(), browser.close()]);
+    expect(closeCdp).toHaveBeenCalledOnce();
+    expect(closeSource).toHaveBeenCalledOnce();
+  });
+
+  it("connects to local CDP with a preloaded extension ID", async () => {
+    const cdp = fakeCdpClient();
+    const connectCdp = vi.fn(async (_options: CDPClientOptions) => cdp);
+    const { localBrowser } = createBrowserFactoriesForTest({ connectCdp });
+
+    const browser = await localBrowser.connect({
+      cdpUrl: "wss://browser.example/devtools/browser/session",
+      extensionId: "extension-id",
+    });
+
+    expect(connectCdp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        extensionId: "extension-id",
+      }),
+    );
+    expect(browser).toMatchObject({ provider: "local", origin: "connected" });
+  });
+
+  it("disconnects without closing a launched source configured to stay alive", async () => {
+    const closeSource = vi.fn();
+    const closeCdp = vi.fn();
+    const { localBrowser } = createBrowserFactoriesForTest({
+      launchLocalBrowser: async () => ({
+        cdpUrl: "http://127.0.0.1:9222",
+        close: closeSource,
+      }),
+      connectCdp: async () => fakeCdpClient(closeCdp),
+    });
+
+    const browser = await localBrowser.launch({ keepAlive: true });
+    await browser.close();
+
+    expect(closeCdp).toHaveBeenCalledOnce();
+    expect(closeSource).not.toHaveBeenCalled();
+  });
+
+  it("launches Browserbase with worker initialization metadata", async () => {
+    const closeSource = vi.fn();
+    const createSession = vi.fn(async () => ({
+      cdpUrl: "wss://connect.browserbase.com/devtools/browser/session_123",
+      sessionId: "session_123",
+      close: closeSource,
+    }));
+    const cdp = fakeCdpClient();
+    const { browserbase } = createBrowserFactoriesForTest({
+      createBrowserbaseSessionClient: () => ({ createSession }),
+      connectCdp: async () => cdp,
+    });
+
+    const browser = await browserbase.launch({
+      apiKey: "bb_key",
+      projectId: "project_123",
+      region: "us-west-2",
+    });
+    const claimed = claimStagehandBrowser(browser);
+
+    expect(createSession).toHaveBeenCalledWith({
+      projectId: "project_123",
+      region: "us-west-2",
+    });
+    expect(claimed.workerInitMetadata).toStrictEqual({
+      apiKey: "bb_key",
+      browser: {
+        type: "browserbase",
+        sessionId: "session_123",
+        region: "us-west-2",
+      },
+    });
+    expect(browser).toMatchObject({ provider: "browserbase", origin: "launched" });
+  });
+
+  it("connects to an existing Browserbase session without owning its release", async () => {
+    const connectSession = vi.fn(async () => ({
+      sessionId: "session_123",
+      cdpUrl: "wss://connect.browserbase.com/devtools/browser/session_123",
+      region: "eu-central-1" as const,
+    }));
+    const cdp = fakeCdpClient();
+    const connectCdp = vi.fn(async () => cdp);
+    const { browserbase } = createBrowserFactoriesForTest({
+      createBrowserbaseSessionClient: () => ({
+        createSession: vi.fn(),
+        connectSession,
+      }),
+      connectCdp,
+    });
+
+    const browser = await browserbase.connect({
+      apiKey: "bb_key",
+      sessionId: "session_123",
+      extensionId: "extension-id",
+    });
+
+    expect(connectSession).toHaveBeenCalledWith("session_123");
+    expect(connectCdp).toHaveBeenCalledWith(
+      expect.objectContaining({ extensionId: "extension-id" }),
+    );
+    expect(browser).toMatchObject({ provider: "browserbase", origin: "connected" });
+    expect(claimStagehandBrowser(browser).workerInitMetadata).toStrictEqual({
+      apiKey: "bb_key",
+      browser: {
+        type: "browserbase",
+        sessionId: "session_123",
+        region: "eu-central-1",
+      },
+    });
+  });
+
+  it("rejects a second Stagehand claim", async () => {
+    const { localBrowser } = createBrowserFactoriesForTest({
+      connectCdp: async () => fakeCdpClient(),
+    });
+    const browser = await localBrowser.connect({ cdpUrl: "ws://browser.example" });
+
+    claimStagehandBrowser(browser);
+
+    expect(() => claimStagehandBrowser(browser)).toThrow("already attached");
+  });
+
+  it("cleans up a launched source if extension preparation fails", async () => {
+    const closeSource = vi.fn();
+    const { localBrowser } = createBrowserFactoriesForTest({
+      launchLocalBrowser: async () => ({
+        cdpUrl: "http://127.0.0.1:9222",
+        close: closeSource,
+      }),
+      connectCdp: async () => {
+        throw new Error("extension failed");
+      },
+    });
+
+    await expect(localBrowser.launch()).rejects.toThrow("extension failed");
+    expect(closeSource).toHaveBeenCalledOnce();
+  });
+
+  it("keeps a launched source alive if extension preparation fails", async () => {
+    const closeSource = vi.fn();
+    const { localBrowser } = createBrowserFactoriesForTest({
+      launchLocalBrowser: async () => ({
+        cdpUrl: "http://127.0.0.1:9222",
+        close: closeSource,
+      }),
+      connectCdp: async () => {
+        throw new Error("extension failed");
+      },
+    });
+
+    await expect(localBrowser.launch({ keepAlive: true })).rejects.toThrow("extension failed");
+    expect(closeSource).not.toHaveBeenCalled();
+  });
+});

--- a/packages/sdk-ts/tests/browserSource.test.ts
+++ b/packages/sdk-ts/tests/browserSource.test.ts
@@ -204,6 +204,19 @@ describe("localBrowserChromeFlags", () => {
     expect(flags).toContain("--enable-unsafe-extension-debugging");
   });
 
+  it("selectively omits the default window-size flag", () => {
+    const flags = localBrowserChromeFlags(
+      {
+        ignoreDefaultArgs: ["--window-size=1280,800"],
+      },
+      launcherDefaults,
+      false,
+    );
+
+    expect(flags).not.toContain("--window-size=1280,800");
+    expect(flags).toContain(WEBMCP_CHROME_FLAG);
+  });
+
   it("appends launch options and user arguments after defaults", () => {
     const flags = localBrowserChromeFlags(
       {

--- a/packages/sdk-ts/tests/stagehand-client-init-params.test.ts
+++ b/packages/sdk-ts/tests/stagehand-client-init-params.test.ts
@@ -85,7 +85,7 @@ describe("Stagehand client browser sources", () => {
     ).toThrow();
   });
 
-  it("rejects Browserbase extension IDs because the SDK provisions its own extension", () => {
+  it("accepts caller-owned Browserbase extension IDs", () => {
     const browserSources = [
       {
         type: "browserbase",
@@ -98,7 +98,10 @@ describe("Stagehand client browser sources", () => {
     ];
 
     for (const browser of browserSources) {
-      expect(() => StagehandClientInitParamsSchema.parse({ apiKey: "bb_key", browser })).toThrow();
+      expect(StagehandClientInitParamsSchema.parse({ apiKey: "bb_key", browser })).toMatchObject({
+        apiKey: "bb_key",
+        browser,
+      });
     }
   });
 


### PR DESCRIPTION
# why

With the browser contract and transport ownership established, this stack entry implements browser acquisition and extension readiness without exposing the factories publicly or changing Stagehand yet.

Reference implementation: #2506

# what changed

- implements nominal browser handles with one-time Stagehand claiming and idempotent cleanup
- implements internal `localBrowser.launch()` and `localBrowser.connect()` factories
- implements internal `browserbase.launch()` and `browserbase.connect()` factories
- parses every launch/connect input immediately with client-side Zod schemas
- defines Browserbase launch options as the official `Browserbase.SessionCreateParams` surface plus the client authentication `apiKey`
- forwards the complete Browserbase session-create payload, including future SDK fields accepted by the client schema
- rejects the legacy `type` discriminator from both local and Browserbase factory inputs
- keeps local launch configuration owned by the TypeScript client instead of the cross-language protocol schema
- accepts caller-owned Browserbase extension IDs at both the top-level and `browserSettings` launch shapes
- skips extension upload and deletion when the caller supplies an extension; Stagehand provisions and owns cleanup only for its fallback extension
- accepts an explicit runtime extension ID when connecting to an existing Browserbase session
- validates Browserbase SDK create/retrieve results and normalized connection data with Zod-derived client schemas
- acquires browsers directly rather than routing factory calls through the legacy browser-source resolver
- waits for the Stagehand extension/CDP transport before resolving each factory promise
- adds Browserbase existing-session retrieval without taking release ownership
- sanitizes Browserbase create/retrieve failures behind a typed session error
- maps the full local launch option surface into Chrome flags
- preserves selective `ignoreDefaultArgs` handling for the default window-size flag
- preserves launched-versus-connected resource ownership during cleanup
- honors `keepAlive` on normal close and failed extension preparation without leaking the CDP transport

# compatibility

- factories remain internal and are not re-exported from the public SDK
- current `Stagehand` constructor and `init()` remain unchanged at this stack layer
- existing browser-source behavior remains temporarily available to the legacy lifecycle

# stack

1. #2517 — TypeScript browser contract and module scaffold
2. #2518 — transport foundations
3. **Implement browser factories** — this PR
4. #2520 — add `Stagehand.create()`
5. #2521 — migrate consumers
6. #2523 — remove the constructor/`init()` lifecycle

# test plan

- all applicable non-runtime SDK tests at this stack layer: 149 passed
- full workspace formatting, lint, typecheck, and build passed
- SDK build and `publint` passed
