### PR TITLE
Add Stagehand.create browser attachment

### DIFF
--- a/packages/docs/tests/sdk-reference.test.ts
+++ b/packages/docs/tests/sdk-reference.test.ts
@@ -129,6 +129,7 @@ const PROTOCOL_REGISTRY = fileURLToPath(
   new URL("../../protocol/schema-registry.ts", import.meta.url),
 );
 const LANGUAGES = ["TypeScript", "Python"] as const satisfies readonly Language[];
+const STAGEHAND_LIFECYCLE_METHODS = new Set(["create", "create-with-client-for-test", "init"]);
 
 const SDK_OBJECTS = [
   {
@@ -917,7 +918,7 @@ async function readTypescriptMethods(): Promise<SdkMethod[]> {
     }),
   );
 
-  return deduplicateMethods(methods.flat(), "TypeScript");
+  return deduplicateMethods(methods.flat(), "TypeScript").filter(participatesInReferenceParity);
 }
 
 async function readRegistryMethodNames(): Promise<Map<string, string>> {
@@ -1020,7 +1021,7 @@ async function readPythonMethods(): Promise<SdkMethod[]> {
     }),
   );
 
-  return deduplicateMethods(methods.flat(), "Python");
+  return deduplicateMethods(methods.flat(), "Python").filter(participatesInReferenceParity);
 }
 
 function findClass(
@@ -1389,6 +1390,13 @@ function methodKey({ classSlug, methodSlug }: SdkMethod): string {
   return `${classSlug}/${methodSlug}`;
 }
 
+function participatesInReferenceParity({
+  classSlug,
+  methodSlug,
+}: Pick<SdkMethod, "classSlug" | "methodSlug">): boolean {
+  return classSlug !== "stagehand" || !STAGEHAND_LIFECYCLE_METHODS.has(methodSlug);
+}
+
 type DocumentedMethodLocation = {
   classSlug: string;
   filePath: string;
@@ -1400,11 +1408,18 @@ function documentedMethods(pages: ReferencePage[], language: Language): Document
     page.views
       .filter(({ title }) => title === language)
       .flatMap(({ methods }) =>
-        methods.map((method) => ({
-          classSlug: page.classSlug,
-          filePath: page.filePath,
-          method,
-        })),
+        methods
+          .filter((method) =>
+            participatesInReferenceParity({
+              classSlug: page.classSlug,
+              methodSlug: method.methodSlug,
+            }),
+          )
+          .map((method) => ({
+            classSlug: page.classSlug,
+            filePath: page.filePath,
+            method,
+          })),
       ),
   );
 }

--- a/packages/sdk-ts/src/browser/factories.ts
+++ b/packages/sdk-ts/src/browser/factories.ts
@@ -9,6 +9,7 @@ import {
   claimStagehandBrowserHandle,
   createStagehandBrowserHandle,
   isStagehandBrowser,
+  releaseStagehandBrowserHandle,
   type BrowserbaseBrowser,
   type LocalBrowser,
   type StagehandBrowser,
@@ -187,6 +188,11 @@ export function createBrowserFactoriesForTest(
 /** @internal */
 export function claimStagehandBrowser(browser: StagehandBrowser): ClaimedStagehandBrowser {
   return claimStagehandBrowserHandle<ClaimedStagehandBrowser>(browser);
+}
+
+/** @internal */
+export function releaseStagehandBrowser(browser: StagehandBrowser): void {
+  releaseStagehandBrowserHandle(browser);
 }
 
 async function connectBrowser(options: {

--- a/packages/sdk-ts/src/browser/index.ts
+++ b/packages/sdk-ts/src/browser/index.ts
@@ -99,6 +99,12 @@ export function claimStagehandBrowserHandle<Attachment>(browser: StagehandBrowse
   return internals.attachment as Attachment;
 }
 
+/** @internal */
+export function releaseStagehandBrowserHandle(browser: StagehandBrowser): void {
+  const internals = requireBrowserHandleInternals(browser);
+  internals.claimed = false;
+}
+
 export function isStagehandBrowser(value: unknown): value is StagehandBrowser {
   return (
     typeof value === "object" &&

--- a/packages/sdk-ts/src/clientSchemas.ts
+++ b/packages/sdk-ts/src/clientSchemas.ts
@@ -22,6 +22,7 @@ import {
   StagehandLogSchema,
 } from "../../protocol/schemas.js";
 import { Page } from "./page.js";
+import { isStagehandBrowser, type StagehandBrowser } from "./browser/index.js";
 
 /** Browserbase source fields exposed by the TS SDK. */
 export const BrowserbaseBrowserSourceSchema = BrowserbaseSessionCreateParamsSchema.extend({
@@ -211,6 +212,34 @@ export const StagehandClientInitParamsSchema = StagehandInitParamsSchema.omit({
   })
   .meta({ id: "StagehandClientInitParams" });
 
+export const StagehandClientCreateConfigSchema = StagehandInitParamsSchema.omit({
+  protocolVersion: true,
+  clientInfo: true,
+  browserCdpUrl: true,
+  logLevel: true,
+  browser: true,
+})
+  .extend({
+    model: z.union([ModelConfigSchema, ClientLLMSchema]).optional(),
+    logging: StagehandClientLoggingConfigSchema.default({
+      level: "info",
+      format: "pretty",
+    }),
+  })
+  .strict()
+  .meta({ id: "StagehandClientCreateConfig" });
+
+export const StagehandBrowserSchema = z
+  .custom<StagehandBrowser>(
+    isStagehandBrowser,
+    "browser must be created by localBrowser or browserbase",
+  )
+  .meta({ id: "StagehandBrowser" });
+
+export const StagehandCreateOptionsSchema = StagehandClientCreateConfigSchema.extend({
+  browser: StagehandBrowserSchema,
+}).meta({ id: "StagehandCreateOptions" });
+
 export type ClientLLM = z.infer<typeof ClientLLMSchema>;
 export type StagehandClientLoggingConfig = z.input<typeof StagehandClientLoggingConfigSchema>;
 export type ResolvedStagehandClientLoggingConfig = z.output<
@@ -231,6 +260,12 @@ export type BrowserbaseSessionRetrieveResult = z.infer<
 export type BrowserbaseSessionConnection = z.infer<typeof BrowserbaseSessionConnectionSchema>;
 export type StagehandClientInitParams = z.input<typeof StagehandClientInitParamsSchema>;
 export type ResolvedStagehandClientInitParams = z.output<typeof StagehandClientInitParamsSchema>;
+export type StagehandClientCreateConfig = z.input<typeof StagehandClientCreateConfigSchema>;
+export type ResolvedStagehandClientCreateConfig = z.output<
+  typeof StagehandClientCreateConfigSchema
+>;
+export type StagehandCreateOptions = z.input<typeof StagehandCreateOptionsSchema>;
+export type ResolvedStagehandCreateOptions = z.output<typeof StagehandCreateOptionsSchema>;
 export type WebMCPToolsOptions = z.infer<typeof WebMCPToolsOptionsSchema>;
 export type WebMCPInvokeOptions = z.infer<typeof WebMCPInvokeOptionsSchema>;
 export type WebMCPResultOptions = z.infer<typeof WebMCPResultOptionsSchema>;

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -15,6 +15,18 @@ export { Page, type ScreenshotOptions } from "./page.js";
 export { WebMCPInvocation, WebMCPTool } from "./webmcp.js";
 export type { InitScriptSource } from "./pageScripts.js";
 export { Stagehand, type ExtractResult } from "./stagehand.js";
+export { browserbase, localBrowser } from "./browser/factories.js";
+export type {
+  BrowserbaseBrowser,
+  BrowserbaseConnectOptions,
+  BrowserbaseLaunchOptions,
+  LocalBrowser,
+  LocalBrowserConnectOptions,
+  LocalBrowserLaunchOptions,
+  StagehandBrowser,
+  StagehandBrowserOrigin,
+  StagehandBrowserProvider,
+} from "./browser/index.js";
 export type {
   Action,
   ActResultData,
@@ -30,14 +42,21 @@ export type {
 } from "../../protocol/types.js";
 export {
   BrowserSourceSchema,
+  BrowserbaseConnectOptionsSchema,
   BrowserbaseBrowserSourceSchema,
+  BrowserbaseLaunchOptionsSchema,
   CdpBrowserSourceSchema,
   ClientLLMSchema,
   LocalBrowserSourceSchema,
+  LocalBrowserConnectOptionsSchema,
+  LocalBrowserLaunchOptionsSchema,
   StagehandClientLogFormatSchema,
   StagehandClientLoggingConfigSchema,
   StagehandClientLogLevelSchema,
   StagehandClientInitParamsSchema,
+  StagehandClientCreateConfigSchema,
+  StagehandBrowserSchema,
+  StagehandCreateOptionsSchema,
   WebMCPInvokeOptionsSchema,
   WebMCPResultOptionsSchema,
   WebMCPToolsOptionsSchema,
@@ -47,6 +66,9 @@ export {
   type ResolvedStagehandClientInitParams,
   type StagehandClientLoggingConfig,
   type StagehandClientInitParams,
+  type StagehandClientCreateConfig,
+  type StagehandCreateOptions,
+  type ResolvedStagehandCreateOptions,
   type WebMCPInvokeOptions,
   type WebMCPResultOptions,
   type WebMCPToolsOptions,

--- a/packages/sdk-ts/src/stagehand.ts
+++ b/packages/sdk-ts/src/stagehand.ts
@@ -1,4 +1,4 @@
-import { connectRPCClient, type RPCClient, type RPCClientOptions } from "./rpcClient.js";
+import { connectRPCClient, RPCClient, type RPCClientOptions } from "./rpcClient.js";
 import { STAGEHAND_PROTOCOL_VERSION, StagehandInitParamsSchema } from "../../protocol/schemas.js";
 import { StagehandMethods } from "../../protocol/schema-registry.js";
 import type {
@@ -15,17 +15,26 @@ import {
   StagehandClientActOptionsSchema,
   StagehandClientExtractOptionsSchema,
   StagehandClientInitParamsSchema,
+  StagehandCreateOptionsSchema,
   StagehandClientObserveOptionsSchema,
   type StagehandClientActOptions,
   type StagehandClientExtractOptions,
   type ResolvedStagehandClientLoggingConfig,
   type ResolvedStagehandClientInitParams,
+  type ResolvedStagehandClientCreateConfig,
+  type StagehandCreateOptions,
   type StagehandClientInitParams,
   type StagehandClientObserveOptions,
 } from "./clientSchemas.js";
 import { CDPConnectionClosedError } from "./cdpClient.js";
 import { STAGEHAND_EXTENSION_DIRECTORY_PATH } from "./extensionAssets.js";
 import { STAGEHAND_SDK_CLIENT_INFO } from "./sdkIdentity.js";
+import {
+  claimStagehandBrowser,
+  releaseStagehandBrowser,
+  type ClaimedStagehandBrowser,
+  type StagehandBrowser,
+} from "./browser/factories.js";
 
 type StagehandAdapters = {
   resolveBrowserSource?: (initParams: StagehandClientInitParams) => Promise<ResolvedBrowserSource>;
@@ -47,9 +56,36 @@ export class Stagehand {
   removeNotificationListener: (() => void) | undefined;
   removeClientLLMHandler: (() => void) | undefined;
   private resolvedBrowser: ResolvedBrowserSource | undefined;
+  private attachedBrowser: StagehandBrowser | undefined;
+  private ownsRpcTransport = true;
   closePromise: Promise<void> | undefined;
 
   constructor(readonly initParams: StagehandClientInitParams) {}
+
+  static async create(input: StagehandCreateOptions): Promise<Stagehand> {
+    const { browser, ...createConfig } = StagehandCreateOptionsSchema.parse(input);
+    const claimedBrowser = claimStagehandBrowser(browser);
+    const stagehand = new Stagehand({
+      browser: {
+        type: "cdp",
+        cdpUrl: claimedBrowser.cdpClient.webSocketDebuggerUrl,
+      },
+    });
+    stagehand.attachedBrowser = browser;
+    stagehand.ownsRpcTransport = false;
+    stagehand.resolvedBrowser = {
+      cdpUrl: claimedBrowser.cdpClient.webSocketDebuggerUrl,
+      residentBrowserConnection: false,
+      keepAlive: true,
+    };
+    try {
+      await stagehand.initializeAttached(createConfig, claimedBrowser);
+      return stagehand;
+    } catch (error) {
+      releaseStagehandBrowser(browser);
+      throw error;
+    }
+  }
 
   get context(): BrowserContext {
     if (!this.browserContext) {
@@ -76,6 +112,9 @@ export class Stagehand {
   async init(): Promise<void> {
     if (this.isInitialized) {
       return;
+    }
+    if (this.attachedBrowser) {
+      throw new Error("A Stagehand created with Stagehand.create() cannot be reinitialized");
     }
 
     const clientInitParams = StagehandClientInitParamsSchema.parse(this.initParams);
@@ -124,6 +163,45 @@ export class Stagehand {
           { cause: error },
         );
       }
+      throw error;
+    }
+
+    this.isInitialized = true;
+    this.closePromise = undefined;
+  }
+
+  private async initializeAttached(
+    createConfig: ResolvedStagehandClientCreateConfig,
+    browser: ClaimedStagehandBrowser,
+  ): Promise<void> {
+    const rpcClient = new RPCClient(browser.cdpClient, browser.commandTimeoutMs);
+    this.rpcClient = rpcClient;
+
+    try {
+      this.removeNotificationListener = rpcClient.onNotification((notification) =>
+        handleStagehandNotification(notification, createConfig.logging),
+      );
+      if (createConfig.model && "generate" in createConfig.model) {
+        this.removeClientLLMHandler = rpcClient.onRequest(
+          StagehandMethods.llmGenerate,
+          createConfig.model.generate,
+        );
+      }
+
+      await rpcClient.send(
+        StagehandMethods.stagehandInit,
+        stagehandCreateParamsForWorker(createConfig, browser),
+      );
+      this.browserContext = new BrowserContext(rpcClient);
+    } catch (error) {
+      this.removeClientLLMHandler?.();
+      this.removeClientLLMHandler = undefined;
+      this.removeNotificationListener?.();
+      this.removeNotificationListener = undefined;
+      rpcClient.close(new Error("Stagehand initialization failed", { cause: error }), {
+        closeTransport: false,
+      });
+      this.rpcClient = undefined;
       throw error;
     }
 
@@ -200,8 +278,12 @@ export class Stagehand {
         this.removeClientLLMHandler = undefined;
         this.removeNotificationListener?.();
         this.removeNotificationListener = undefined;
-        this.rpcClient?.close();
-        await this.closeBrowserSource();
+        this.rpcClient?.close(new Error("Stagehand closed"), {
+          closeTransport: this.ownsRpcTransport,
+        });
+        if (!this.attachedBrowser) {
+          await this.closeBrowserSource();
+        }
         this.rpcClient = undefined;
         this.browserContext = undefined;
         this.isInitialized = false;
@@ -225,6 +307,24 @@ export class Stagehand {
     }
     await browser.close?.();
   }
+}
+
+function stagehandCreateParamsForWorker(
+  createConfig: ResolvedStagehandClientCreateConfig,
+  browser: ClaimedStagehandBrowser,
+) {
+  const { logging, model, ...protocolParams } = createConfig;
+  const protocolModel = model && "generate" in model ? { source: "client" as const } : model;
+
+  return StagehandInitParamsSchema.parse({
+    protocolVersion: STAGEHAND_PROTOCOL_VERSION,
+    clientInfo: STAGEHAND_SDK_CLIENT_INFO,
+    browserCdpUrl: browser.cdpClient.webSocketDebuggerUrl,
+    logLevel: logging.level,
+    ...protocolParams,
+    ...browser.workerInitMetadata,
+    ...(protocolModel === undefined ? {} : { model: protocolModel }),
+  });
 }
 
 function stagehandInitParamsForWorker(

--- a/packages/sdk-ts/tests/package-contract.test.ts
+++ b/packages/sdk-ts/tests/package-contract.test.ts
@@ -45,6 +45,10 @@ describe("published TypeScript SDK", () => {
             import { access, readFile } from "node:fs/promises";
             import { fileURLToPath } from "node:url";
             import {
+              browserbase,
+              BrowserbaseConnectOptionsSchema,
+              localBrowser,
+              LocalBrowserConnectOptionsSchema,
               Stagehand,
               WebMCPInvocation,
               WebMCPTool,
@@ -52,6 +56,14 @@ describe("published TypeScript SDK", () => {
             } from "@browserbasehq/stagehand";
 
             if (typeof Stagehand !== "function") throw new Error("Stagehand export is unavailable");
+            if (typeof localBrowser?.launch !== "function") {
+              throw new Error("localBrowser export is unavailable");
+            }
+            if (typeof browserbase?.connect !== "function") {
+              throw new Error("browserbase export is unavailable");
+            }
+            LocalBrowserConnectOptionsSchema.parse({ cdpUrl: "ws://127.0.0.1:9222" });
+            BrowserbaseConnectOptionsSchema.parse({ apiKey: "bb_key", sessionId: "session_123" });
             if (typeof WebMCPTool !== "function") throw new Error("WebMCPTool export is unavailable");
             if (typeof WebMCPInvocation !== "function") {
               throw new Error("WebMCPInvocation export is unavailable");

--- a/packages/sdk-ts/tests/stagehandCreate.test.ts
+++ b/packages/sdk-ts/tests/stagehandCreate.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from "vitest";
+import type { JSONRPCMessage } from "../../protocol/json-rpc/types.js";
+import { Stagehand, StagehandCreateOptionsSchema } from "../src/index.js";
+import { createBrowserFactoriesForTest } from "../src/browser/factories.js";
+import type { CDPClient } from "../src/cdpClient.js";
+
+class FakeCDPClient {
+  readonly webSocketDebuggerUrl = "ws://127.0.0.1:9222/devtools/browser/test";
+  readonly serviceWorker = {
+    targetId: "worker-target",
+    url: "chrome-extension://stagehand/service-worker.js",
+    title: "Stagehand",
+    extensionId: "stagehand",
+  };
+  onmessage?: (message: unknown) => void | Promise<void>;
+  onclose?: (reason?: Error) => void;
+  onerror?: (error: Error) => void;
+  close = vi.fn();
+  initError: Error | undefined;
+  readonly requests: JSONRPCMessage[] = [];
+
+  async send(message: JSONRPCMessage): Promise<void> {
+    this.requests.push(message);
+    if (!("id" in message) || !("method" in message)) return;
+    if (message.method === "stagehand.init" && this.initError) {
+      throw this.initError;
+    }
+
+    const result =
+      message.method === "stagehand.init"
+        ? { initialized: true, pages: [] }
+        : message.method === "stagehand.close"
+          ? { closed: true }
+          : {};
+    await this.onmessage?.({ jsonrpc: "2.0", id: message.id, result });
+  }
+}
+
+describe("Stagehand.create", () => {
+  it("attaches to a ready browser without taking transport ownership", async () => {
+    const cdp = new FakeCDPClient();
+    const { localBrowser } = createBrowserFactoriesForTest({
+      connectCdp: async () => cdp as unknown as CDPClient,
+    });
+    const browser = await localBrowser.connect({ cdpUrl: cdp.webSocketDebuggerUrl });
+
+    const stagehand = await Stagehand.create({ browser, apiKey: "bb_worker_key" });
+
+    expect(stagehand.initialized).toBe(true);
+    expect(cdp.requests[0]).toMatchObject({
+      method: "stagehand.init",
+      params: {
+        browser_cdp_url: cdp.webSocketDebuggerUrl,
+        log_level: "info",
+        api_key: "bb_worker_key",
+      },
+    });
+
+    await stagehand.close();
+    expect(cdp.close).not.toHaveBeenCalled();
+    await expect(stagehand.init()).rejects.toThrow("cannot be reinitialized");
+
+    await browser.close();
+    expect(cdp.close).toHaveBeenCalledOnce();
+  });
+
+  it("releases the browser claim when initialization fails", async () => {
+    const cdp = new FakeCDPClient();
+    cdp.initError = new Error("worker initialization failed");
+    const { localBrowser } = createBrowserFactoriesForTest({
+      connectCdp: async () => cdp as unknown as CDPClient,
+    });
+    const browser = await localBrowser.connect({ cdpUrl: cdp.webSocketDebuggerUrl });
+
+    await expect(Stagehand.create({ browser })).rejects.toThrow("worker initialization failed");
+
+    cdp.initError = undefined;
+    const stagehand = await Stagehand.create({ browser });
+    expect(stagehand.initialized).toBe(true);
+
+    await stagehand.close();
+    await browser.close();
+  });
+
+  it("rejects browser-like objects not created by a Stagehand factory", async () => {
+    await expect(
+      Stagehand.create({
+        browser: {
+          provider: "local",
+          origin: "connected",
+          closed: false,
+          close: async () => {},
+        } as never,
+      }),
+    ).rejects.toThrow("browser must be created by localBrowser or browserbase");
+  });
+
+  it("rejects unknown create options at the public boundary", async () => {
+    const cdp = new FakeCDPClient();
+    const { localBrowser } = createBrowserFactoriesForTest({
+      connectCdp: async () => cdp as unknown as CDPClient,
+    });
+    const browser = await localBrowser.connect({ cdpUrl: cdp.webSocketDebuggerUrl });
+
+    expect(() => StagehandCreateOptionsSchema.parse({ browser, unexpected: true })).toThrow(
+      "Unrecognized key",
+    );
+
+    await browser.close();
+  });
+});

--- a/rules/ast-grep/sdk-parity.test.ts
+++ b/rules/ast-grep/sdk-parity.test.ts
@@ -93,6 +93,12 @@ const goAccessors: Readonly<Record<string, ReadonlySet<string>>> = {
   PageLocator: new Set(["Descriptor"]),
 };
 
+// Browser lifecycle construction is intentionally language-specific while the v4 clients migrate
+// independently: TypeScript uses create(), while Python and Go still expose init(). RPC-backed
+// feature methods remain subject to strict cross-language parity below.
+const stagehandLifecycleMethods = new Set(["create", "init"]);
+const internalTypescriptMethods = new Set(["create_with_client_for_test"]);
+
 describe("All language SDK operations remain in sync", () => {
   it("sends protocol version and client identity in stagehand.init", async () => {
     const configurations = [
@@ -522,6 +528,8 @@ async function publicOperations(
     .flatMap((method) => {
       const publicMethod = methodName(method.node, language);
       if (!publicMethod) return [];
+      const normalizedMethod = snakeCase(publicMethod.text());
+      if (!participatesInSurfaceParity(className, language, normalizedMethod)) return [];
 
       return protocolCalls(method.node, language).map((call) => {
         const methodNode = protocolMethodNode(call, language);
@@ -530,7 +538,7 @@ async function publicOperations(
         const wireMethod = wireMethodForCall(methodNode, language, registry);
 
         return {
-          publicMethod: snakeCase(publicMethod.text()),
+          publicMethod: normalizedMethod,
           wireMethod,
         };
       });
@@ -559,10 +567,23 @@ async function publicCallableMethods(
         .filter((method) => isPublicCallable(method, language))
         .flatMap((method) => {
           const name = methodName(method.node, language);
-          return name ? [snakeCase(name.text())] : [];
+          if (!name) return [];
+          const normalizedMethod = snakeCase(name.text());
+          return participatesInSurfaceParity(className, language, normalizedMethod)
+            ? [normalizedMethod]
+            : [];
         }),
     ),
   ].sort();
+}
+
+function participatesInSurfaceParity(
+  className: string,
+  language: SdkLanguage,
+  method: string,
+): boolean {
+  if (className === "Stagehand" && stagehandLifecycleMethods.has(method)) return false;
+  return language !== "typescript" || !internalTypescriptMethods.has(method);
 }
 
 async function publicAccessors(


### PR DESCRIPTION
# why

The browser factories now resolve only after the extension transport is ready. This stack entry introduces the new attachment lifecycle as an additive public API while preserving the current constructor and `init()` path for compatibility.

Reference implementation: #2506

# what changed

- publicly exports `localBrowser` and `browserbase`
- adds `await Stagehand.create({ browser, ...config })`
- defines `StagehandBrowserSchema` and `StagehandCreateOptionsSchema` in `clientSchemas.ts`, with public types inferred from those schemas
- parses the complete `Stagehand.create()` input immediately at the client boundary, including nominal browser-handle validation and unknown-key rejection
- claims each browser for one Stagehand instance
- releases the claim when worker initialization fails so callers can retry
- initializes the worker over the browser-owned CDP transport
- accepts an explicit worker-service `apiKey` for local browser handles while Browserbase handles retain their owned credential metadata
- keeps `stagehand.close()` from closing the browser-owned transport
- exports browser option schemas, their inferred types, and create-option types from the published SDK
- extends the packed-package contract to verify the new exports
- keeps cross-language parity strict for feature APIs while excluding the intentionally language-specific `init()` / `create()` lifecycle during independent SDK migrations

# compatibility

- `new Stagehand(...)` and `await stagehand.init()` remain supported
- a `Stagehand.create()` instance cannot re-enter the legacy `init()` path after close
- no examples or existing consumers are migrated in this PR
- the breaking removal is deferred to the final stack entry

# stack

1. #2517 — TypeScript browser contract and module scaffold
2. #2518 — transport foundations
3. #2519 — browser factory implementation
4. **Additive `Stagehand.create()`** — this PR
5. #2521 Migrate consumers
6. #2523 Remove the constructor/`init()` lifecycle

# test plan

- focused `Stagehand.create()` tests pass, including full-boundary Zod validation
- 137 non-runtime SDK tests pass on the final stack
- full workspace formatting, lint, and typecheck pass
- SDK build and `publint` pass
- generated declarations inspected; `Stagehand.create`, schemas, and factory types are present
