### PR TITLE
Migrate TypeScript consumers to Stagehand.create

### DIFF
--- a/packages/sdk-ts/README.md
+++ b/packages/sdk-ts/README.md
@@ -3,28 +3,37 @@
 TypeScript object wrapper for the Stagehand v4 service-worker protocol.
 
 ```ts
-import { Stagehand } from "@browserbasehq/stagehand";
+import { localBrowser, Stagehand } from "@browserbasehq/stagehand";
 
-const stagehand = new Stagehand({ client });
-await stagehand.init();
+const browser = await localBrowser.launch({ headless: true });
+let stagehand: Stagehand | undefined;
 
-const page = (await stagehand.context.pages())[0] ?? (await stagehand.context.newPage());
+try {
+  stagehand = await Stagehand.create({ browser });
+  const page = (await stagehand.context.pages())[0] ?? (await stagehand.context.newPage());
 
-await page.goto("https://example.com");
-const currentUrl = await page.url();
+  await page.goto("https://example.com");
+  const currentUrl = await page.url();
 
-const actions = await stagehand.observe("Find the sign-in button");
-await stagehand.act("Click the sign-in button");
+  const actions = await stagehand.observe("Find the sign-in button");
+  await stagehand.act("Click the sign-in button");
 
-await page.locator("#email").fill("user@example.com");
-await page.locator("button[type=submit]").click();
-
-await stagehand.close();
+  await page.locator("#email").fill("user@example.com");
+  await page.locator("button[type=submit]").click();
+} finally {
+  try {
+    await stagehand?.close();
+  } finally {
+    await browser.close();
+  }
+}
 ```
 
 ## object model
 
-- `Stagehand` owns a protocol client and exposes `context`
+- `localBrowser` and `browserbase` launch or connect an extension-ready browser
+- `Stagehand.create()` attaches to a browser and exposes `context`
+- `Stagehand.close()` closes the Stagehand runtime; `browser.close()` owns browser cleanup
 - `Stagehand.act()`, `Stagehand.observe()`, and `Stagehand.extract()` use the active page by default and accept an SDK `Page` in their options
 - `BrowserContext.pages()` returns `Page` objects from `context.pages`
 - `BrowserContext.newPage()` wraps the `context.new_page` result

--- a/packages/sdk-ts/README.md
+++ b/packages/sdk-ts/README.md
@@ -6,27 +6,20 @@ TypeScript object wrapper for the Stagehand v4 service-worker protocol.
 import { localBrowser, Stagehand } from "@browserbasehq/stagehand";
 
 const browser = await localBrowser.launch({ headless: true });
-let stagehand: Stagehand | undefined;
+const stagehand = await Stagehand.create({ browser });
+const page = (await stagehand.context.pages())[0] ?? (await stagehand.context.newPage());
 
-try {
-  stagehand = await Stagehand.create({ browser });
-  const page = (await stagehand.context.pages())[0] ?? (await stagehand.context.newPage());
+await page.goto("https://example.com");
+const currentUrl = await page.url();
 
-  await page.goto("https://example.com");
-  const currentUrl = await page.url();
+const actions = await stagehand.observe("Find the sign-in button");
+await stagehand.act("Click the sign-in button");
 
-  const actions = await stagehand.observe("Find the sign-in button");
-  await stagehand.act("Click the sign-in button");
+await page.locator("#email").fill("user@example.com");
+await page.locator("button[type=submit]").click();
 
-  await page.locator("#email").fill("user@example.com");
-  await page.locator("button[type=submit]").click();
-} finally {
-  try {
-    await stagehand?.close();
-  } finally {
-    await browser.close();
-  }
-}
+await stagehand.close();
+await browser.close();
 ```
 
 ## object model

--- a/packages/sdk-ts/examples/act.ts
+++ b/packages/sdk-ts/examples/act.ts
@@ -1,22 +1,20 @@
 import "dotenv/config";
-import { Stagehand } from "../src/index.js";
+import { localBrowser, Stagehand } from "../src/index.js";
 
 const { OPENAI_API_KEY } = process.env;
 if (!OPENAI_API_KEY) throw new Error();
 
-const stagehand = new Stagehand({
-  browser: {
-    type: "local",
-    headless: true,
-  },
-  model: {
-    modelName: "openai/gpt-5.4-mini",
-    apiKey: OPENAI_API_KEY,
-  },
-});
+const browser = await localBrowser.launch({ headless: true });
+let stagehand: Stagehand | undefined;
 
 try {
-  await stagehand.init();
+  stagehand = await Stagehand.create({
+    browser,
+    model: {
+      modelName: "openai/gpt-5.4-mini",
+      apiKey: OPENAI_API_KEY,
+    },
+  });
 
   const page = await stagehand.context.activePage();
   if (!page) {
@@ -34,5 +32,9 @@ try {
     throw new Error(`act() failed: ${result.data.message}`);
   }
 } finally {
-  await stagehand.close();
+  try {
+    await stagehand?.close();
+  } finally {
+    await browser.close();
+  }
 }

--- a/packages/sdk-ts/examples/act.ts
+++ b/packages/sdk-ts/examples/act.ts
@@ -5,36 +5,29 @@ const { OPENAI_API_KEY } = process.env;
 if (!OPENAI_API_KEY) throw new Error();
 
 const browser = await localBrowser.launch({ headless: true });
-let stagehand: Stagehand | undefined;
+const stagehand = await Stagehand.create({
+  browser,
+  model: {
+    modelName: "openai/gpt-5.4-mini",
+    apiKey: OPENAI_API_KEY,
+  },
+});
 
-try {
-  stagehand = await Stagehand.create({
-    browser,
-    model: {
-      modelName: "openai/gpt-5.4-mini",
-      apiKey: OPENAI_API_KEY,
-    },
-  });
-
-  const page = await stagehand.context.activePage();
-  if (!page) {
-    throw new Error("Stagehand initialized without an active page");
-  }
-  await page.goto("https://example.com");
-
-  const result = await stagehand.act(
-    "Click the link that provides more information about Example Domain",
-  );
-
-  console.log(JSON.stringify(result, null, 2));
-
-  if (!result.data.success) {
-    throw new Error(`act() failed: ${result.data.message}`);
-  }
-} finally {
-  try {
-    await stagehand?.close();
-  } finally {
-    await browser.close();
-  }
+const page = await stagehand.context.activePage();
+if (!page) {
+  throw new Error("Stagehand initialized without an active page");
 }
+await page.goto("https://example.com");
+
+const result = await stagehand.act(
+  "Click the link that provides more information about Example Domain",
+);
+
+console.log(JSON.stringify(result, null, 2));
+
+if (!result.data.success) {
+  throw new Error(`act() failed: ${result.data.message}`);
+}
+
+await stagehand.close();
+await browser.close();

--- a/packages/sdk-ts/examples/caching.ts
+++ b/packages/sdk-ts/examples/caching.ts
@@ -9,7 +9,6 @@ if (!BROWSERBASE_API_KEY || !OPENAI_API_KEY) throw new Error();
 const browser = await browserbase.launch({
   apiKey: BROWSERBASE_API_KEY,
 });
-let stagehand: Stagehand | undefined;
 
 const companiesSchema = z.object({
   companies: z.array(
@@ -20,46 +19,41 @@ const companiesSchema = z.object({
   ),
 });
 
-try {
-  stagehand = await Stagehand.create({
-    browser,
-    model: {
-      modelName: "openai/gpt-5.4-mini",
-      apiKey: OPENAI_API_KEY,
-    },
-  });
+const stagehand = await Stagehand.create({
+  browser,
+  model: {
+    modelName: "openai/gpt-5.4-mini",
+    apiKey: OPENAI_API_KEY,
+  },
+});
 
-  const page = await stagehand.context.activePage();
-  if (!page) {
-    throw new Error("Stagehand initialized without an active page");
-  }
-  await page.goto("https://aigrant.com");
-
-  // With a threshold of 1, a single identical result is enough for the cache
-  // to start serving hits, so the second call below is served from the cache.
-  const extractCompanies = async () => {
-    const start = performance.now();
-    const result = await stagehand.extract(
-      "Extract the names and descriptions of the first five companies listed on the page",
-      companiesSchema,
-      { page, cache: { threshold: 1 } },
-    );
-    return { result, durationMs: Math.round(performance.now() - start) };
-  };
-
-  const first = await extractCompanies();
-  console.log(`First extraction (expected cache miss, ${first.durationMs}ms):`);
-  console.log(JSON.stringify(first.result.data, null, 2));
-  console.log(`Cache status: ${first.result.metadata.cacheStatus ?? "disabled"}`);
-
-  const second = await extractCompanies();
-  console.log(`Second extraction (expected cache hit, ${second.durationMs}ms):`);
-  console.log(JSON.stringify(second.result.data, null, 2));
-  console.log(`Cache status: ${second.result.metadata.cacheStatus ?? "disabled"}`);
-} finally {
-  try {
-    await stagehand?.close();
-  } finally {
-    await browser.close();
-  }
+const page = await stagehand.context.activePage();
+if (!page) {
+  throw new Error("Stagehand initialized without an active page");
 }
+await page.goto("https://aigrant.com");
+
+// With a threshold of 1, a single identical result is enough for the cache
+// to start serving hits, so the second call below is served from the cache.
+const extractCompanies = async () => {
+  const start = performance.now();
+  const result = await stagehand.extract(
+    "Extract the names and descriptions of the first five companies listed on the page",
+    companiesSchema,
+    { page, cache: { threshold: 1 } },
+  );
+  return { result, durationMs: Math.round(performance.now() - start) };
+};
+
+const first = await extractCompanies();
+console.log(`First extraction (expected cache miss, ${first.durationMs}ms):`);
+console.log(JSON.stringify(first.result.data, null, 2));
+console.log(`Cache status: ${first.result.metadata.cacheStatus ?? "disabled"}`);
+
+const second = await extractCompanies();
+console.log(`Second extraction (expected cache hit, ${second.durationMs}ms):`);
+console.log(JSON.stringify(second.result.data, null, 2));
+console.log(`Cache status: ${second.result.metadata.cacheStatus ?? "disabled"}`);
+
+await stagehand.close();
+await browser.close();

--- a/packages/sdk-ts/examples/caching.ts
+++ b/packages/sdk-ts/examples/caching.ts
@@ -1,21 +1,15 @@
 import "dotenv/config";
 import { z } from "zod/v4";
-import { Stagehand } from "../src/index.js";
+import { browserbase, Stagehand } from "../src/index.js";
 
 const { BROWSERBASE_API_KEY, OPENAI_API_KEY } = process.env;
 if (!BROWSERBASE_API_KEY || !OPENAI_API_KEY) throw new Error();
 
 // Server-side caching requires a Browserbase browser session.
-const stagehand = new Stagehand({
+const browser = await browserbase.launch({
   apiKey: BROWSERBASE_API_KEY,
-  browser: {
-    type: "browserbase",
-  },
-  model: {
-    modelName: "openai/gpt-5.4-mini",
-    apiKey: OPENAI_API_KEY,
-  },
 });
+let stagehand: Stagehand | undefined;
 
 const companiesSchema = z.object({
   companies: z.array(
@@ -27,7 +21,13 @@ const companiesSchema = z.object({
 });
 
 try {
-  await stagehand.init();
+  stagehand = await Stagehand.create({
+    browser,
+    model: {
+      modelName: "openai/gpt-5.4-mini",
+      apiKey: OPENAI_API_KEY,
+    },
+  });
 
   const page = await stagehand.context.activePage();
   if (!page) {
@@ -57,5 +57,9 @@ try {
   console.log(JSON.stringify(second.result.data, null, 2));
   console.log(`Cache status: ${second.result.metadata.cacheStatus ?? "disabled"}`);
 } finally {
-  await stagehand.close();
+  try {
+    await stagehand?.close();
+  } finally {
+    await browser.close();
+  }
 }

--- a/packages/sdk-ts/examples/custom-llm.ts
+++ b/packages/sdk-ts/examples/custom-llm.ts
@@ -18,51 +18,44 @@ const openai = new OpenAI({
 const generationNames: string[] = [];
 
 const browser = await localBrowser.launch({ headless: true });
-let stagehand: Stagehand | undefined;
+const stagehand = await Stagehand.create({
+  browser,
+  model: {
+    generate: generateWithOpenAI,
+  },
+});
 
-try {
-  stagehand = await Stagehand.create({
-    browser,
-    model: {
-      generate: generateWithOpenAI,
-    },
-  });
-
-  const page = await stagehand.context.activePage();
-  if (!page) {
-    throw new Error("Stagehand initialized without an active page");
-  }
-  await page.goto("https://example.com");
-
-  const pageInfo = await stagehand.extract(
-    "Extract the page heading and description",
-    z.object({
-      heading: z.string(),
-      description: z.string(),
-    }),
-  );
-  const actions = await stagehand.observe(
-    "Find the link that provides more information about Example Domain",
-  );
-  const actionResult = await stagehand.act(
-    "Click the link that provides more information about Example Domain",
-  );
-
-  console.log(JSON.stringify({ pageInfo, actions, actionResult, generationNames }, null, 2));
-
-  if (actions.data.length === 0) {
-    throw new Error("observe() returned no matching actions");
-  }
-  if (!actionResult.data.success) {
-    throw new Error(`act() failed: ${actionResult.data.message}`);
-  }
-} finally {
-  try {
-    await stagehand?.close();
-  } finally {
-    await browser.close();
-  }
+const page = await stagehand.context.activePage();
+if (!page) {
+  throw new Error("Stagehand initialized without an active page");
 }
+await page.goto("https://example.com");
+
+const pageInfo = await stagehand.extract(
+  "Extract the page heading and description",
+  z.object({
+    heading: z.string(),
+    description: z.string(),
+  }),
+);
+const actions = await stagehand.observe(
+  "Find the link that provides more information about Example Domain",
+);
+const actionResult = await stagehand.act(
+  "Click the link that provides more information about Example Domain",
+);
+
+console.log(JSON.stringify({ pageInfo, actions, actionResult, generationNames }, null, 2));
+
+if (actions.data.length === 0) {
+  throw new Error("observe() returned no matching actions");
+}
+if (!actionResult.data.success) {
+  throw new Error(`act() failed: ${actionResult.data.message}`);
+}
+
+await stagehand.close();
+await browser.close();
 
 async function generateWithOpenAI(params: LLMGenerateParams): Promise<LLMGenerateResult> {
   if (params.responseFormat?.type !== "json_schema") {

--- a/packages/sdk-ts/examples/custom-llm.ts
+++ b/packages/sdk-ts/examples/custom-llm.ts
@@ -7,7 +7,7 @@ import type {
   LLMGenerateResult,
   LLMMessageContentBlock,
 } from "../../protocol/types.js";
-import { Stagehand } from "../src/index.js";
+import { localBrowser, Stagehand } from "../src/index.js";
 
 const { OPENAI_API_KEY } = process.env;
 if (!OPENAI_API_KEY) throw new Error();
@@ -17,18 +17,16 @@ const openai = new OpenAI({
 });
 const generationNames: string[] = [];
 
-const stagehand = new Stagehand({
-  browser: {
-    type: "local",
-    headless: true,
-  },
-  model: {
-    generate: generateWithOpenAI,
-  },
-});
+const browser = await localBrowser.launch({ headless: true });
+let stagehand: Stagehand | undefined;
 
 try {
-  await stagehand.init();
+  stagehand = await Stagehand.create({
+    browser,
+    model: {
+      generate: generateWithOpenAI,
+    },
+  });
 
   const page = await stagehand.context.activePage();
   if (!page) {
@@ -59,7 +57,11 @@ try {
     throw new Error(`act() failed: ${actionResult.data.message}`);
   }
 } finally {
-  await stagehand.close();
+  try {
+    await stagehand?.close();
+  } finally {
+    await browser.close();
+  }
 }
 
 async function generateWithOpenAI(params: LLMGenerateParams): Promise<LLMGenerateResult> {

--- a/packages/sdk-ts/examples/custom_logging.ts
+++ b/packages/sdk-ts/examples/custom_logging.ts
@@ -1,33 +1,31 @@
 import "dotenv/config";
 import { createWriteStream } from "node:fs";
 import { finished } from "node:stream/promises";
-import { Stagehand } from "../src/index.js";
+import { localBrowser, Stagehand } from "../src/index.js";
 
 const { OPENAI_API_KEY } = process.env;
 if (!OPENAI_API_KEY) throw new Error();
 
 const logFile = createWriteStream("stagehand.jsonl", { flags: "a" });
 
-const stagehand = new Stagehand({
-  browser: {
-    type: "local",
-    headless: true,
-  },
-  model: {
-    modelName: "openai/gpt-5.4-mini",
-    apiKey: OPENAI_API_KEY,
-  },
-  logging: {
-    level: "info",
-    format: "pretty",
-    onLog(log) {
-      logFile.write(`${JSON.stringify(log)}\n`);
-    },
-  },
-});
+const browser = await localBrowser.launch({ headless: true });
+let stagehand: Stagehand | undefined;
 
 try {
-  await stagehand.init();
+  stagehand = await Stagehand.create({
+    browser,
+    model: {
+      modelName: "openai/gpt-5.4-mini",
+      apiKey: OPENAI_API_KEY,
+    },
+    logging: {
+      level: "info",
+      format: "pretty",
+      onLog(log) {
+        logFile.write(`${JSON.stringify(log)}\n`);
+      },
+    },
+  });
 
   const page = await stagehand.context.activePage();
   if (!page) throw new Error();
@@ -35,7 +33,14 @@ try {
   await page.goto("https://example.com");
   console.log(await stagehand.observe("Find the Learn more link"));
 } finally {
-  await stagehand.close();
-  logFile.end();
-  await finished(logFile);
+  try {
+    try {
+      await stagehand?.close();
+    } finally {
+      await browser.close();
+    }
+  } finally {
+    logFile.end();
+    await finished(logFile);
+  }
 }

--- a/packages/sdk-ts/examples/custom_logging.ts
+++ b/packages/sdk-ts/examples/custom_logging.ts
@@ -9,38 +9,28 @@ if (!OPENAI_API_KEY) throw new Error();
 const logFile = createWriteStream("stagehand.jsonl", { flags: "a" });
 
 const browser = await localBrowser.launch({ headless: true });
-let stagehand: Stagehand | undefined;
-
-try {
-  stagehand = await Stagehand.create({
-    browser,
-    model: {
-      modelName: "openai/gpt-5.4-mini",
-      apiKey: OPENAI_API_KEY,
+const stagehand = await Stagehand.create({
+  browser,
+  model: {
+    modelName: "openai/gpt-5.4-mini",
+    apiKey: OPENAI_API_KEY,
+  },
+  logging: {
+    level: "info",
+    format: "pretty",
+    onLog(log) {
+      logFile.write(`${JSON.stringify(log)}\n`);
     },
-    logging: {
-      level: "info",
-      format: "pretty",
-      onLog(log) {
-        logFile.write(`${JSON.stringify(log)}\n`);
-      },
-    },
-  });
+  },
+});
 
-  const page = await stagehand.context.activePage();
-  if (!page) throw new Error();
+const page = await stagehand.context.activePage();
+if (!page) throw new Error();
 
-  await page.goto("https://example.com");
-  console.log(await stagehand.observe("Find the Learn more link"));
-} finally {
-  try {
-    try {
-      await stagehand?.close();
-    } finally {
-      await browser.close();
-    }
-  } finally {
-    logFile.end();
-    await finished(logFile);
-  }
-}
+await page.goto("https://example.com");
+console.log(await stagehand.observe("Find the Learn more link"));
+
+await stagehand.close();
+await browser.close();
+logFile.end();
+await finished(logFile);

--- a/packages/sdk-ts/examples/extract.ts
+++ b/packages/sdk-ts/examples/extract.ts
@@ -6,36 +6,29 @@ const { OPENAI_API_KEY } = process.env;
 if (!OPENAI_API_KEY) throw new Error();
 
 const browser = await localBrowser.launch({ headless: true });
-let stagehand: Stagehand | undefined;
+const stagehand = await Stagehand.create({
+  browser,
+  model: {
+    modelName: "openai/gpt-5.4-mini",
+    apiKey: OPENAI_API_KEY,
+  },
+});
 
-try {
-  stagehand = await Stagehand.create({
-    browser,
-    model: {
-      modelName: "openai/gpt-5.4-mini",
-      apiKey: OPENAI_API_KEY,
-    },
-  });
-
-  const page = await stagehand.context.activePage();
-  if (!page) {
-    throw new Error("Stagehand initialized without an active page");
-  }
-  await page.goto("https://example.com");
-
-  const pageInfo = await stagehand.extract(
-    "Extract the page heading and description",
-    z.object({
-      heading: z.string(),
-      description: z.string(),
-    }),
-  );
-
-  console.log(JSON.stringify(pageInfo, null, 2));
-} finally {
-  try {
-    await stagehand?.close();
-  } finally {
-    await browser.close();
-  }
+const page = await stagehand.context.activePage();
+if (!page) {
+  throw new Error("Stagehand initialized without an active page");
 }
+await page.goto("https://example.com");
+
+const pageInfo = await stagehand.extract(
+  "Extract the page heading and description",
+  z.object({
+    heading: z.string(),
+    description: z.string(),
+  }),
+);
+
+console.log(JSON.stringify(pageInfo, null, 2));
+
+await stagehand.close();
+await browser.close();

--- a/packages/sdk-ts/examples/extract.ts
+++ b/packages/sdk-ts/examples/extract.ts
@@ -1,23 +1,21 @@
 import "dotenv/config";
 import { z } from "zod/v4";
-import { Stagehand } from "../src/index.js";
+import { localBrowser, Stagehand } from "../src/index.js";
 
 const { OPENAI_API_KEY } = process.env;
 if (!OPENAI_API_KEY) throw new Error();
 
-const stagehand = new Stagehand({
-  browser: {
-    type: "local",
-    headless: true,
-  },
-  model: {
-    modelName: "openai/gpt-5.4-mini",
-    apiKey: OPENAI_API_KEY,
-  },
-});
+const browser = await localBrowser.launch({ headless: true });
+let stagehand: Stagehand | undefined;
 
 try {
-  await stagehand.init();
+  stagehand = await Stagehand.create({
+    browser,
+    model: {
+      modelName: "openai/gpt-5.4-mini",
+      apiKey: OPENAI_API_KEY,
+    },
+  });
 
   const page = await stagehand.context.activePage();
   if (!page) {
@@ -35,5 +33,9 @@ try {
 
   console.log(JSON.stringify(pageInfo, null, 2));
 } finally {
-  await stagehand.close();
+  try {
+    await stagehand?.close();
+  } finally {
+    await browser.close();
+  }
 }

--- a/packages/sdk-ts/examples/observe.ts
+++ b/packages/sdk-ts/examples/observe.ts
@@ -1,22 +1,20 @@
 import "dotenv/config";
-import { Stagehand } from "../src/index.js";
+import { localBrowser, Stagehand } from "../src/index.js";
 
 const { OPENAI_API_KEY } = process.env;
 if (!OPENAI_API_KEY) throw new Error();
 
-const stagehand = new Stagehand({
-  browser: {
-    type: "local",
-    headless: true,
-  },
-  model: {
-    modelName: "openai/gpt-5.4-mini",
-    apiKey: OPENAI_API_KEY,
-  },
-});
+const browser = await localBrowser.launch({ headless: true });
+let stagehand: Stagehand | undefined;
 
 try {
-  await stagehand.init();
+  stagehand = await Stagehand.create({
+    browser,
+    model: {
+      modelName: "openai/gpt-5.4-mini",
+      apiKey: OPENAI_API_KEY,
+    },
+  });
 
   const page = await stagehand.context.activePage();
   if (!page) {
@@ -34,5 +32,9 @@ try {
     throw new Error("observe() returned no matching actions");
   }
 } finally {
-  await stagehand.close();
+  try {
+    await stagehand?.close();
+  } finally {
+    await browser.close();
+  }
 }

--- a/packages/sdk-ts/examples/observe.ts
+++ b/packages/sdk-ts/examples/observe.ts
@@ -5,36 +5,29 @@ const { OPENAI_API_KEY } = process.env;
 if (!OPENAI_API_KEY) throw new Error();
 
 const browser = await localBrowser.launch({ headless: true });
-let stagehand: Stagehand | undefined;
+const stagehand = await Stagehand.create({
+  browser,
+  model: {
+    modelName: "openai/gpt-5.4-mini",
+    apiKey: OPENAI_API_KEY,
+  },
+});
 
-try {
-  stagehand = await Stagehand.create({
-    browser,
-    model: {
-      modelName: "openai/gpt-5.4-mini",
-      apiKey: OPENAI_API_KEY,
-    },
-  });
-
-  const page = await stagehand.context.activePage();
-  if (!page) {
-    throw new Error("Stagehand initialized without an active page");
-  }
-  await page.goto("https://example.com");
-
-  const actions = await stagehand.observe(
-    "Find the link that provides more information about Example Domain",
-  );
-
-  console.log(JSON.stringify(actions, null, 2));
-
-  if (actions.data.length === 0) {
-    throw new Error("observe() returned no matching actions");
-  }
-} finally {
-  try {
-    await stagehand?.close();
-  } finally {
-    await browser.close();
-  }
+const page = await stagehand.context.activePage();
+if (!page) {
+  throw new Error("Stagehand initialized without an active page");
 }
+await page.goto("https://example.com");
+
+const actions = await stagehand.observe(
+  "Find the link that provides more information about Example Domain",
+);
+
+console.log(JSON.stringify(actions, null, 2));
+
+if (actions.data.length === 0) {
+  throw new Error("observe() returned no matching actions");
+}
+
+await stagehand.close();
+await browser.close();

--- a/packages/sdk-ts/examples/webmcp.ts
+++ b/packages/sdk-ts/examples/webmcp.ts
@@ -3,33 +3,26 @@ import { localBrowser, Stagehand } from "../src/index.js";
 const webMCPTestSite = "https://browserbase.github.io/stagehand-eval-sites/sites/webmcp-test/";
 
 const browser = await localBrowser.launch({ headless: false });
-let stagehand: Stagehand | undefined;
+const stagehand = await Stagehand.create({ browser });
 
-try {
-  stagehand = await Stagehand.create({ browser });
-
-  const page = await stagehand.context.activePage();
-  if (!page) {
-    throw new Error("Stagehand initialized without an active page");
-  }
-  await page.goto(webMCPTestSite);
-
-  const tools = await page.tools({ timeout: 5_000 });
-  const calculateSum = tools.find((tool) => tool.name === "calculateSum");
-  if (!calculateSum) {
-    throw new Error("calculateSum was not registered by the page");
-  }
-
-  const invocation = await calculateSum.invoke({
-    input: { a: 19, b: 23 },
-  });
-  const result = await invocation.result();
-
-  console.log(result);
-} finally {
-  try {
-    await stagehand?.close();
-  } finally {
-    await browser.close();
-  }
+const page = await stagehand.context.activePage();
+if (!page) {
+  throw new Error("Stagehand initialized without an active page");
 }
+await page.goto(webMCPTestSite);
+
+const tools = await page.tools({ timeout: 5_000 });
+const calculateSum = tools.find((tool) => tool.name === "calculateSum");
+if (!calculateSum) {
+  throw new Error("calculateSum was not registered by the page");
+}
+
+const invocation = await calculateSum.invoke({
+  input: { a: 19, b: 23 },
+});
+const result = await invocation.result();
+
+console.log(result);
+
+await stagehand.close();
+await browser.close();

--- a/packages/sdk-ts/examples/webmcp.ts
+++ b/packages/sdk-ts/examples/webmcp.ts
@@ -1,16 +1,12 @@
-import { Stagehand } from "../src/index.js";
+import { localBrowser, Stagehand } from "../src/index.js";
 
 const webMCPTestSite = "https://browserbase.github.io/stagehand-eval-sites/sites/webmcp-test/";
 
-const stagehand = new Stagehand({
-  browser: {
-    type: "local",
-    headless: false,
-  },
-});
+const browser = await localBrowser.launch({ headless: false });
+let stagehand: Stagehand | undefined;
 
 try {
-  await stagehand.init();
+  stagehand = await Stagehand.create({ browser });
 
   const page = await stagehand.context.activePage();
   if (!page) {
@@ -31,5 +27,9 @@ try {
 
   console.log(result);
 } finally {
-  await stagehand.close();
+  try {
+    await stagehand?.close();
+  } finally {
+    await browser.close();
+  }
 }

--- a/packages/sdk-ts/tests/browser-runtime/stagehand-browserbase-smoke.test.ts
+++ b/packages/sdk-ts/tests/browser-runtime/stagehand-browserbase-smoke.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { Stagehand } from "../../src/index.js";
+import { browserbase, Stagehand, type StagehandBrowser } from "../../src/index.js";
 
 const browserbaseApiKey = process.env.BROWSERBASE_API_KEY;
 const shouldRun = process.env.BROWSERBASE_SMOKE === "1" || Boolean(browserbaseApiKey);
@@ -7,26 +7,28 @@ const webMCPTestSite = "https://browserbase.github.io/stagehand-eval-sites/sites
 
 describe.runIf(shouldRun)("Stagehand TS SDK Browserbase smoke", () => {
   let stagehand: Stagehand | undefined;
+  let browser: StagehandBrowser | undefined;
 
   beforeAll(async () => {
     if (!browserbaseApiKey) {
       throw new Error("BROWSERBASE_API_KEY is required for the Browserbase smoke test");
     }
 
-    stagehand = new Stagehand({
+    browser = await browserbase.launch({
       apiKey: browserbaseApiKey,
-      browser: {
-        type: "browserbase",
-        userMetadata: {
-          suite: "stagehand-browserbase-smoke",
-        },
+      userMetadata: {
+        suite: "stagehand-browserbase-smoke",
       },
     });
-    await stagehand.init();
+    stagehand = await Stagehand.create({ browser });
   }, 90_000);
 
   afterAll(async () => {
-    await stagehand?.close();
+    try {
+      await stagehand?.close();
+    } finally {
+      await browser?.close();
+    }
   }, 30_000);
 
   it("drives a Browserbase browser through the public TS object model", async () => {

--- a/packages/sdk-ts/tests/browser-runtime/stagehand-launch-connect-smoke.test.ts
+++ b/packages/sdk-ts/tests/browser-runtime/stagehand-launch-connect-smoke.test.ts
@@ -2,7 +2,13 @@ import { createServer, type Server } from "node:http";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { z } from "zod/v4";
 import type { LLMGenerateResult, LLMImageContent } from "../../../protocol/types.js";
-import { Stagehand, type BrowserContext, type Page } from "../../src/index.js";
+import {
+  localBrowser,
+  Stagehand,
+  type BrowserContext,
+  type Page,
+  type StagehandBrowser,
+} from "../../src/index.js";
 
 type FixtureServer = {
   url: string;
@@ -12,15 +18,14 @@ type FixtureServer = {
 describe("Stagehand TS SDK launch/connect smoke", () => {
   let fixtureServer: FixtureServer | undefined;
   let stagehand: Stagehand | undefined;
+  let browser: StagehandBrowser | undefined;
   const extractionScreenshots: LLMImageContent[] = [];
 
   beforeAll(async () => {
     fixtureServer = await startFixtureServer();
-    stagehand = new Stagehand({
-      browser: {
-        type: "local",
-        headless: true,
-      },
+    browser = await localBrowser.launch({ headless: true });
+    stagehand = await Stagehand.create({
+      browser,
       model: {
         generate: async (params): Promise<LLMGenerateResult> => {
           if (params.responseFormat?.type !== "json_schema") {
@@ -123,12 +128,18 @@ describe("Stagehand TS SDK launch/connect smoke", () => {
         level: "off",
       },
     });
-    await stagehand.init();
   }, 45_000);
 
   afterAll(async () => {
-    await stagehand?.close();
-    await fixtureServer?.close();
+    try {
+      await stagehand?.close();
+    } finally {
+      try {
+        await browser?.close();
+      } finally {
+        await fixtureServer?.close();
+      }
+    }
   });
 
   it("drives a real browser through the public TS object model", async () => {

--- a/rules/ast-grep/example-parity.test.ts
+++ b/rules/ast-grep/example-parity.test.ts
@@ -96,11 +96,13 @@ describe("All language examples remain in sync", () => {
         expect(stagehand, `${language} ${example.file} must construct Stagehand`).toBeDefined();
         if (language === "typescript") {
           expect(
-            root.find({ rule: { pattern: `${stagehand} = await Stagehand.create($$$ARGS)` } }),
+            root.find({
+              rule: { pattern: `const ${stagehand} = await Stagehand.create($$$ARGS)` },
+            }),
             `${language} ${example.file} must create Stagehand asynchronously`,
           ).not.toBeNull();
           expect(
-            root.find({ rule: { pattern: `await ${stagehand}?.close()` } }),
+            root.find({ rule: { pattern: `await ${stagehand}.close()` } }),
             `${language} ${example.file} must close Stagehand`,
           ).not.toBeNull();
         } else if (language === "go") {
@@ -150,7 +152,7 @@ function stagehandVariable(root: SgNode, language: ExampleLanguage): string | un
     rule: {
       pattern:
         language === "typescript"
-          ? "$STAGEHAND = await Stagehand.create($$$ARGS)"
+          ? "const $STAGEHAND = await Stagehand.create($$$ARGS)"
           : language === "python"
             ? "$STAGEHAND = Stagehand($$$ARGS)"
             : "$STAGEHAND := stagehand.New($$$ARGS)",

--- a/rules/ast-grep/example-parity.test.ts
+++ b/rules/ast-grep/example-parity.test.ts
@@ -94,7 +94,16 @@ describe("All language examples remain in sync", () => {
           ).toBe(true);
         }
         expect(stagehand, `${language} ${example.file} must construct Stagehand`).toBeDefined();
-        if (language === "go") {
+        if (language === "typescript") {
+          expect(
+            root.find({ rule: { pattern: `${stagehand} = await Stagehand.create($$$ARGS)` } }),
+            `${language} ${example.file} must create Stagehand asynchronously`,
+          ).not.toBeNull();
+          expect(
+            root.find({ rule: { pattern: `await ${stagehand}?.close()` } }),
+            `${language} ${example.file} must close Stagehand`,
+          ).not.toBeNull();
+        } else if (language === "go") {
           expect(
             goCalls(root).some(({ object, method }) => object === stagehand && method === "Init"),
             `${language} ${example.file} must initialize Stagehand`,
@@ -141,7 +150,7 @@ function stagehandVariable(root: SgNode, language: ExampleLanguage): string | un
     rule: {
       pattern:
         language === "typescript"
-          ? "const $STAGEHAND = new Stagehand($$$ARGS)"
+          ? "$STAGEHAND = await Stagehand.create($$$ARGS)"
           : language === "python"
             ? "$STAGEHAND = Stagehand($$$ARGS)"
             : "$STAGEHAND := stagehand.New($$$ARGS)",
@@ -178,7 +187,9 @@ function publicSdkOperations(root: SgNode, language: ExampleLanguage): string[] 
       const method = call.getMatch("METHOD")?.text();
       if (!object || !method) return [];
 
-      if (object === stagehand) return [`stagehand.${snakeCase(method)}`];
+      if (object === stagehand && method !== "init" && method !== "close") {
+        return [`stagehand.${snakeCase(method)}`];
+      }
       if (object === `${stagehand}.context`) return [`context.${snakeCase(method)}`];
       if (pageObjects.has(object)) return [`page.${snakeCase(method)}`];
       return [];
@@ -203,7 +214,7 @@ function goPublicSdkOperations(root: SgNode, stagehand: string): string[] {
 
   return goCalls(root)
     .flatMap(({ object, method }) => {
-      if (object === stagehand && method !== "Context") {
+      if (object === stagehand && method !== "Context" && method !== "Init" && method !== "Close") {
         return [`stagehand.${snakeCase(method)}`];
       }
       if (contextObjects.has(object)) return [`context.${snakeCase(method)}`];


### PR DESCRIPTION
## Summary

Migrates the TypeScript SDK's examples, README, parity checks, and browser-runtime smoke tests to the explicit browser lifecycle introduced by the preceding stack:

```ts
const browser = await localBrowser.launch();
const stagehand = await Stagehand.create({ browser, model });
```

This keeps the compatibility lifecycle available for one more layer while proving the new API against real local-browser startup and representative consumers.

Browser cleanup is nested in `finally` blocks throughout the migrated examples and smoke tests, so a failed `stagehand.close()` cannot leak a local process or billable Browserbase session.

Reference spike: #2506

## Stack

- #2517 — browser contracts
- #2518 — transport foundations
- #2519 — browser factories
- #2520 — additive `Stagehand.create`
- **this PR** — consumer migration
- #2523 — remove the legacy constructor/init lifecycle

## Verification

- focused example-parity and local-browser smoke tests (15 passed)
- `pnpm --filter @browserbasehq/stagehand test:browser` (12 passed, 2 skipped)
- `pnpm build`
- `pnpm check`
