### PR TITLE
feat(cli): add native cookie sync command

### DIFF
--- a/.changeset/bright-cookies-sync.md
+++ b/.changeset/bright-cookies-sync.md
@@ -1,0 +1,5 @@
+---
+"browse": minor
+---
+
+Add `browse cookies sync` to securely copy scoped cookies from a debuggable local Chrome browser into a reusable Browserbase CLI session or persistent context.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -41,6 +41,18 @@ browse screenshot --path page.png
 browse stop
 ```
 
+To copy authenticated cookies from a local Chrome browser into a remote
+Browserbase session, enable Chrome remote debugging and run:
+
+```bash
+browse cookies sync --domain github.com --session github
+browse open https://github.com --session github
+```
+
+Use `--persist` to create a reusable Browserbase context, or `--context <id|name>`
+to refresh an existing one. Cookie sync requires explicit `--domain` flags;
+copying every local cookie requires the deliberate `--all` flag.
+
 ## How it works
 
 `browse` runs a lightweight per-session daemon. The first command starts it, and subsequent commands reuse the same browser — so cookies, tabs, and snapshot refs persist between invocations. Run multiple isolated browsers at once with `--session <name>` (or the `BROWSE_SESSION` env var), and shut a session down with `browse stop`.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -54,6 +54,9 @@
       "cloud:sessions:uploads": {
         "description": "Upload files to Browserbase sessions."
       },
+      "cookies": {
+        "description": "Manage browser cookies and authentication state."
+      },
       "functions": {
         "description": "Develop, publish, and invoke Browserbase Functions."
       },

--- a/packages/cli/skills/browse/SKILL.md
+++ b/packages/cli/skills/browse/SKILL.md
@@ -67,7 +67,7 @@ Use local mode for development, localhost, trusted sites, and fast iteration. Us
 
 `--local` requires Chrome or Chromium already installed on the machine. In containers, CI, and sandboxes with no browser installed, use `--remote` instead of `--local`. If `--local` fails with "No Chrome or Chromium found" and `BROWSERBASE_API_KEY` is set, switch to `--remote` — do not retry `--local`.
 
-For a Verified and/or proxied remote session, add `--verified` and/or `--proxies` to `--remote` — a single command that keeps the Browserbase session identity, so `browse status` and `browse doctor` report the session ID and live-view URL. `--verified` requires a Browserbase Scale plan. These flags only apply to `--remote` and are sticky for the session's lifetime, like `--headed`. Reach for `browse cloud sessions create` + `--cdp` only when you need session options `open` doesn't expose (region, keep-alive, contexts).
+For a Verified and/or proxied remote session, add `--verified` and/or `--proxies` to `--remote` — a single command that keeps the Browserbase session identity, so `browse status` and `browse doctor` report the session ID and live-view URL. `--verified` requires a Browserbase Scale plan. These flags only apply to `--remote` and are sticky for the session's lifetime, like `--headed`. Reach for `browse cloud sessions create` + `--cdp` only when you need session options `open` doesn't expose (region or keep-alive).
 
 Choose headed/headless and local/remote mode when starting a session. A running session keeps its mode: passing a conflicting flag such as `--headed` to an already-running headless session fails until you run `browse stop --session <name>` or target a different session.
 
@@ -249,6 +249,19 @@ For remote sessions with context persistence:
 browse cloud sessions create --context-id <context-id> --persist
 ```
 
+To move an existing login from local Chrome into a remote session, enable
+Chrome remote debugging and sync only the required cookie domains:
+
+```bash
+browse cookies sync --domain github.com --session github
+browse open https://github.com --session github
+```
+
+Use `--persist` to create a new reusable context, or `--context <id|name>` to
+refresh an existing context. Never use `--all` unless the user explicitly wants
+every local cookie copied; cookies are credentials and the domain-scoped form is
+the safe default.
+
 Contexts persist cookies and local storage (logins) across sessions. Name a
 context once with `--name` to save a local alias, then reuse the name anywhere a
 context ID is accepted instead of memorizing the ID:
@@ -260,7 +273,7 @@ browse cloud sessions create --context-id github --persist
 browse cloud contexts list                          # show saved names
 ```
 
-Use `--verified` when the task needs Browserbase Verified browser mode. To drive a Verified/proxied session directly, prefer `browse open <url> --remote --verified --proxies` over create-then-attach — it keeps the session identity so `browse status`/`browse doctor` can report it. Use `browse cloud sessions create` for session options the driver flags don't cover (region, keep-alive, contexts, full `--stdin` body).
+Use `--verified` when the task needs Browserbase Verified browser mode. To drive a Verified/proxied session directly, prefer `browse open <url> --remote --verified --proxies` over create-then-attach — it keeps the session identity so `browse status`/`browse doctor` can report it. Use `browse cloud sessions create` for session options the driver flags don't cover (region, keep-alive, full `--stdin` body).
 
 Use `browse cloud fetch` when the user needs a simple HTTP fetch without browser interaction. It returns markdown-formatted page content by default; pass `--format raw` for the original response body or `--format json --schema <schema>` for structured extraction. Use `browse cloud search` when the user asks for web search results.
 

--- a/packages/cli/src/commands/cookies/sync.ts
+++ b/packages/cli/src/commands/cookies/sync.ts
@@ -1,0 +1,100 @@
+import { Flags } from "@oclif/core";
+
+import { BrowseCommand } from "../../base.js";
+import {
+  createBrowserbaseClient,
+  withBrowserbaseApi,
+} from "../../lib/cloud/api.js";
+import { resolveContextRefOrFail } from "../../lib/cloud/contexts-resolve.js";
+import { fail } from "../../lib/errors.js";
+import { sessionFlag, sessionName } from "../../lib/driver/flags.js";
+import { runDriverCommandWithTarget } from "../../lib/driver/runtime.js";
+import type { RemoteConnectionTarget } from "../../lib/driver/types.js";
+import { outputJson } from "../../lib/output.js";
+
+export default class CookiesSync extends BrowseCommand {
+  static override description =
+    "Copy cookies from a debuggable local Chrome browser into a Browserbase session.";
+
+  static override examples = [
+    "browse cookies sync --domain github.com",
+    "browse cookies sync --domain github.com --domain google.com --session work",
+    "browse cookies sync --domain github.com --persist --session github",
+    "browse cookies sync --domain github.com --context github --verified",
+    "browse cookies sync --all --source-cdp 9222",
+  ];
+
+  static override flags = {
+    all: Flags.boolean({
+      description:
+        "Sync every cookie from local Chrome. Required when --domain is omitted.",
+      exclusive: ["domain"],
+    }),
+    context: Flags.string({
+      description:
+        "Existing Browserbase context ID or saved name. Changes are persisted.",
+      helpValue: "<id|name>",
+    }),
+    domain: Flags.string({
+      description:
+        "Cookie domain to sync, including its subdomains. Repeat for multiple domains.",
+      helpValue: "<domain>",
+      multiple: true,
+    }),
+    persist: Flags.boolean({
+      description:
+        "Create a Browserbase context and persist the synced cookies for future sessions.",
+    }),
+    proxies: Flags.boolean({
+      description: "Route the remote session through Browserbase proxies.",
+    }),
+    session: sessionFlag,
+    "source-cdp": Flags.string({
+      description:
+        "Local Chrome CDP endpoint or port. Defaults to automatic discovery.",
+      helpValue: "<url|port>",
+    }),
+    verified: Flags.boolean({
+      description:
+        "Use Browserbase Verified browser mode. Requires a Browserbase Scale plan.",
+    }),
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse(CookiesSync);
+    const domains = flags.domain ?? [];
+    if (!flags.all && domains.length === 0) {
+      fail("Pass at least one --domain, or explicitly pass --all.");
+    }
+
+    let contextId: string | undefined;
+    if (flags.context) {
+      contextId = await resolveContextRefOrFail(flags.context);
+    } else if (flags.persist) {
+      contextId = await withBrowserbaseApi("contexts", async () => {
+        const context = await createBrowserbaseClient({}).contexts.create({});
+        if (!context.id) fail("Browserbase created a context without an ID.");
+        return context.id;
+      });
+    }
+
+    const target: RemoteConnectionTarget = {
+      kind: "remote",
+      ...(contextId ? { contextId, persist: true } : {}),
+      ...(flags.proxies ? { proxies: true } : {}),
+      ...(flags.verified ? { verified: true } : {}),
+    };
+    const result = (await runDriverCommandWithTarget(
+      sessionName(flags.session),
+      target,
+      "cookies.sync",
+      {
+        all: flags.all,
+        domains,
+        sourceCdp: flags["source-cdp"],
+      },
+    )) as Record<string, unknown>;
+
+    outputJson({ ...result, ...(contextId ? { contextId } : {}) });
+  }
+}

--- a/packages/cli/src/lib/driver/commands/cookies.ts
+++ b/packages/cli/src/lib/driver/commands/cookies.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+import type { DriverCommandHandlers } from "./types.js";
+
+const CookieSyncSchema = z.object({
+  all: z.boolean().optional(),
+  domains: z.array(z.string().min(1)).default([]),
+  sourceCdp: z.string().min(1).optional(),
+});
+
+export const cookieHandlers: DriverCommandHandlers = {
+  async "cookies.sync"(manager, params) {
+    return manager.syncCookiesFromLocal(CookieSyncSchema.parse(params));
+  },
+};

--- a/packages/cli/src/lib/driver/commands/registry.ts
+++ b/packages/cli/src/lib/driver/commands/registry.ts
@@ -1,4 +1,5 @@
 import type { DriverSessionManager } from "../session-manager.js";
+import { cookieHandlers } from "./cookies.js";
 import { elementsHandlers } from "./elements.js";
 import { keyboardHandlers } from "./keyboard.js";
 import { mouseHandlers } from "./mouse.js";
@@ -12,6 +13,7 @@ import type { DriverCommandHandlers, DriverCommandName } from "./types.js";
 
 const handlers: DriverCommandHandlers = {
   ...navigationHandlers,
+  ...cookieHandlers,
   ...elementsHandlers,
   ...keyboardHandlers,
   ...mouseHandlers,

--- a/packages/cli/src/lib/driver/commands/types.ts
+++ b/packages/cli/src/lib/driver/commands/types.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 export const DRIVER_COMMAND_NAMES = [
   "back",
   "click",
+  "cookies.sync",
   "cursor",
   "eval",
   "fill",

--- a/packages/cli/src/lib/driver/cookie-sync.ts
+++ b/packages/cli/src/lib/driver/cookie-sync.ts
@@ -1,0 +1,27 @@
+import type { DriverContext } from "./session-manager.js";
+
+type BrowserCookie = Awaited<ReturnType<DriverContext["cookies"]>>[number];
+
+export function normalizeCookieDomains(domains: string[]): string[] {
+  return [
+    ...new Set(
+      domains.map((domain) => domain.trim().replace(/^\./, "").toLowerCase()),
+    ),
+  ].filter(Boolean);
+}
+
+export function filterCookiesByDomains(
+  cookies: BrowserCookie[],
+  domains: string[],
+): BrowserCookie[] {
+  const normalizedDomains = normalizeCookieDomains(domains);
+  if (normalizedDomains.length === 0) return cookies;
+
+  return cookies.filter((cookie) => {
+    const cookieDomain = cookie.domain.replace(/^\./, "").toLowerCase();
+    return normalizedDomains.some(
+      (domain) =>
+        cookieDomain === domain || cookieDomain.endsWith(`.${domain}`),
+    );
+  });
+}

--- a/packages/cli/src/lib/driver/daemon/client.ts
+++ b/packages/cli/src/lib/driver/daemon/client.ts
@@ -87,13 +87,17 @@ export async function runDriverCommandViaDaemon(
   command: DriverCommandName,
   params?: unknown,
 ): Promise<unknown> {
-  return sendDriverRequest(session, {
-    command,
-    forwardedEnv: await collectForwardedEnv(),
-    id: requestId(),
-    params,
-    type: "command",
-  });
+  return sendDriverRequest(
+    session,
+    {
+      command,
+      forwardedEnv: await collectForwardedEnv(),
+      id: requestId(),
+      params,
+      type: "command",
+    },
+    command === "cookies.sync" ? 90_000 : undefined,
+  );
 }
 
 export async function getDriverStatus(
@@ -165,6 +169,7 @@ async function tryDriverStatus(session: string): Promise<DriverStatus | null> {
 async function sendDriverRequest<T>(
   session: string,
   request: DriverRequest,
+  timeoutMs = 35_000,
 ): Promise<T> {
   const socketPath = getSocketPath(session);
   return new Promise<T>((resolve, reject) => {
@@ -203,7 +208,7 @@ async function sendDriverRequest<T>(
           { resultCode: "daemon_socket_timeout" },
         ),
       );
-    }, 35_000);
+    }, timeoutMs);
 
     socket.on("connect", () => {
       socket.write(`${JSON.stringify(request)}\n`);

--- a/packages/cli/src/lib/driver/mode.ts
+++ b/packages/cli/src/lib/driver/mode.ts
@@ -203,7 +203,10 @@ export function targetsCompatible(
     // like headless, forcing an explicit stop-and-reopen.
     return (
       Boolean(left.verified) === Boolean(right.verified) &&
-      Boolean(left.proxies) === Boolean(right.proxies)
+      Boolean(left.proxies) === Boolean(right.proxies) &&
+      left.contextId === right.contextId &&
+      (left.persist ?? Boolean(left.contextId)) ===
+        (right.persist ?? Boolean(right.contextId))
     );
   }
   return true;

--- a/packages/cli/src/lib/driver/remote.ts
+++ b/packages/cli/src/lib/driver/remote.ts
@@ -74,12 +74,24 @@ export async function remoteStagehandOptions(
     userMetadata.install_id = toMetadataValue(installId);
   }
 
+  const browserSettings = {
+    ...(target?.verified ? { verified: true } : {}),
+    ...(target?.contextId
+      ? {
+          context: {
+            id: target.contextId,
+            persist: target.persist ?? true,
+          },
+        }
+      : {}),
+  };
+
   return {
     apiKey,
     browserbaseSessionCreateParams: {
       userMetadata,
       ...(target?.proxies ? { proxies: true } : {}),
-      ...(target?.verified ? { browserSettings: { verified: true } } : {}),
+      ...(Object.keys(browserSettings).length > 0 ? { browserSettings } : {}),
     },
     disableAPI: true,
     disablePino: true,

--- a/packages/cli/src/lib/driver/session-manager.ts
+++ b/packages/cli/src/lib/driver/session-manager.ts
@@ -12,9 +12,14 @@ import {
   type ForwardedEnv,
 } from "./daemon/forwarded-env.js";
 import { DriverError } from "./errors.js";
+import {
+  filterCookiesByDomains,
+  normalizeCookieDomains,
+} from "./cookie-sync.js";
 import { discoverLocalCdp } from "./local-cdp-discovery.js";
 import { NetworkCapture } from "./network-capture.js";
 import { getRemote } from "./remote-binding.js";
+import { resolveWsTarget } from "./resolve-ws.js";
 import type {
   BrowserbaseIdentity,
   ConnectionTarget,
@@ -149,6 +154,73 @@ export class DriverSessionManager {
     }
 
     return this.stagehand;
+  }
+
+  async syncCookiesFromLocal(options: {
+    all?: boolean;
+    domains: string[];
+    sourceCdp?: string;
+  }): Promise<Record<string, unknown>> {
+    if (this.target.kind !== "remote") {
+      throw new DriverError(
+        "Cookie sync requires a remote Browserbase session.",
+        {
+          code: "cookie_sync_requires_remote",
+        },
+      );
+    }
+
+    const domains = normalizeCookieDomains(options.domains);
+    if (!options.all && domains.length === 0) {
+      throw new DriverError(
+        "Cookie sync requires at least one domain, or an explicit all-cookies opt-in.",
+        { code: "cookie_sync_scope_required" },
+      );
+    }
+
+    const endpoint = options.sourceCdp
+      ? await resolveWsTarget(options.sourceCdp)
+      : (await discoverLocalCdp())?.wsUrl;
+    if (!endpoint) {
+      throw new DriverError(
+        "No debuggable local browser found. Enable Chrome remote debugging, or pass --source-cdp <url|port>.",
+        { code: "cookie_sync_source_not_found" },
+      );
+    }
+
+    const source = new Stagehand({
+      disablePino: true,
+      env: "LOCAL",
+      localBrowserLaunchOptions: { cdpUrl: endpoint },
+      verbose: 0,
+    });
+
+    try {
+      await source.init();
+      const sourceCookies = await source.context.cookies();
+      const cookies = options.all
+        ? sourceCookies
+        : filterCookiesByDomains(sourceCookies, domains);
+      if (cookies.length === 0) {
+        throw new DriverError(
+          options.all
+            ? "Local Chrome has no cookies to sync."
+            : `Local Chrome has no cookies matching: ${domains.join(", ")}.`,
+          { code: "cookie_sync_no_matches" },
+        );
+      }
+      const destination = await this.browserContext();
+      await destination.addCookies(cookies);
+
+      return {
+        ...this.browserbaseIdentity(),
+        domains: options.all ? ["*"] : domains,
+        session: this.session,
+        syncedCookies: cookies.length,
+      };
+    } finally {
+      await source.close().catch(() => undefined);
+    }
   }
 
   async status(): Promise<DriverStatus> {

--- a/packages/cli/src/lib/driver/types.ts
+++ b/packages/cli/src/lib/driver/types.ts
@@ -5,7 +5,13 @@ export type ConnectionTarget =
       kind: "managed-local";
       headless: boolean;
     }
-  | { kind: "remote"; verified?: boolean; proxies?: boolean }
+  | {
+      contextId?: string;
+      kind: "remote";
+      persist?: boolean;
+      proxies?: boolean;
+      verified?: boolean;
+    }
   | { kind: "auto-connect" }
   | { kind: "cdp"; endpoint: string; targetId?: string };
 

--- a/packages/cli/tests/cli-surface.test.ts
+++ b/packages/cli/tests/cli-surface.test.ts
@@ -98,6 +98,23 @@ describe("CLI surface", () => {
     expect(result.stdout).toContain("cloud sessions");
   });
 
+  it("documents safe cookie sync scoping", async () => {
+    const result = await runCli(["cookies", "sync", "--help"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("--domain");
+    expect(result.stdout).toContain("--all");
+    expect(result.stdout).toContain("--persist");
+    expect(result.stdout).toContain("--source-cdp");
+  });
+
+  it("requires an explicit cookie sync scope before starting a browser", async () => {
+    const result = await runCli(["cookies", "sync"]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain(
+      "Pass at least one --domain, or explicitly pass --all.",
+    );
+  });
+
   it.each(cloudCommandsWithExamples)(
     "prints descriptive help for %j",
     async (...command) => {

--- a/packages/cli/tests/driver-commands.test.ts
+++ b/packages/cli/tests/driver-commands.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
 import { resolveSelector } from "../src/lib/driver/commands/selectors.js";
+import { cookieHandlers } from "../src/lib/driver/commands/cookies.js";
 import { formatSnapshotTree } from "../src/lib/driver/commands/snapshot-format.js";
 import { snapshotHandlers } from "../src/lib/driver/commands/snapshot.js";
 import { runtimeHandlers } from "../src/lib/driver/commands/runtime.js";
@@ -15,6 +16,10 @@ import { hasExplicitDriverTarget } from "../src/lib/driver/command-cli.js";
 import { getSocketPath } from "../src/lib/driver/daemon/paths.js";
 import { parseRequest } from "../src/lib/driver/daemon/protocol.js";
 import { NetworkCapture } from "../src/lib/driver/network-capture.js";
+import {
+  filterCookiesByDomains,
+  normalizeCookieDomains,
+} from "../src/lib/driver/cookie-sync.js";
 import { runCli } from "./helpers/run-cli.js";
 
 describe("driver commands", () => {
@@ -22,6 +27,7 @@ describe("driver commands", () => {
     expect([...DRIVER_COMMAND_NAMES].sort()).toEqual(
       expect.arrayContaining([
         "click",
+        "cookies.sync",
         "mouse.click",
         "snapshot",
         "tab.switch",
@@ -38,6 +44,43 @@ describe("driver commands", () => {
         "network_enable",
       ]),
     );
+  });
+
+  it("normalizes cookie domains and includes matching subdomains", () => {
+    const cookies = [
+      cookie("host", "github.com"),
+      cookie("parent", ".github.com"),
+      cookie("subdomain", "api.github.com"),
+      cookie("lookalike", "notgithub.com"),
+      cookie("other", "google.com"),
+    ];
+
+    expect(normalizeCookieDomains([" GitHub.com ", ".github.com"])).toEqual([
+      "github.com",
+    ]);
+    expect(
+      filterCookiesByDomains(cookies, ["github.com"]).map(({ name }) => name),
+    ).toEqual(["host", "parent", "subdomain"]);
+  });
+
+  it("keeps cookie values inside the manager command", async () => {
+    const syncCookiesFromLocal = vi
+      .fn()
+      .mockResolvedValue({ syncedCookies: 2 });
+    const manager = { syncCookiesFromLocal } as unknown as Parameters<
+      NonNullable<(typeof cookieHandlers)["cookies.sync"]>
+    >[0];
+
+    await expect(
+      cookieHandlers["cookies.sync"]!(manager, {
+        domains: ["github.com"],
+        sourceCdp: "9222",
+      }),
+    ).resolves.toEqual({ syncedCookies: 2 });
+    expect(syncCookiesFromLocal).toHaveBeenCalledWith({
+      domains: ["github.com"],
+      sourceCdp: "9222",
+    });
   });
 
   it("resolves snapshot refs while leaving normal selectors unchanged", () => {
@@ -459,6 +502,19 @@ describe("driver commands", () => {
     }
   });
 });
+
+function cookie(name: string, domain: string) {
+  return {
+    domain,
+    expires: -1,
+    httpOnly: false,
+    name,
+    path: "/",
+    sameSite: "Lax" as const,
+    secure: true,
+    value: "secret",
+  };
+}
 
 class FakeCdpSession {
   private readonly listeners = new Map<

--- a/packages/cli/tests/remote-options.test.ts
+++ b/packages/cli/tests/remote-options.test.ts
@@ -77,6 +77,34 @@ describe("remote.ts (Browserbase capability)", () => {
     expect(params?.browserSettings).toEqual({ verified: true });
   });
 
+  it("threads a persistent context into browserSettings", async () => {
+    const params = (
+      await remoteStagehandOptions({
+        contextId: "ctx_test",
+        kind: "remote",
+        persist: true,
+      })
+    ).browserbaseSessionCreateParams;
+    expect(params?.browserSettings).toEqual({
+      context: { id: "ctx_test", persist: true },
+    });
+  });
+
+  it("combines verified mode with a persistent context", async () => {
+    const params = (
+      await remoteStagehandOptions({
+        contextId: "ctx_test",
+        kind: "remote",
+        persist: true,
+        verified: true,
+      })
+    ).browserbaseSessionCreateParams;
+    expect(params?.browserSettings).toEqual({
+      context: { id: "ctx_test", persist: true },
+      verified: true,
+    });
+  });
+
   it("requires an API key", async () => {
     delete process.env.BROWSERBASE_API_KEY;
     await expect(remoteStagehandOptions({ kind: "remote" })).rejects.toThrow(

--- a/packages/cli/tsconfig.local-only.json
+++ b/packages/cli/tsconfig.local-only.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "exclude": [
     "src/commands/cloud",
+    "src/commands/cookies",
     "src/commands/functions",
     "src/commands/skills",
     "src/commands/templates",


### PR DESCRIPTION
## What changed

- add `browse cookies sync` for copying cookies from debuggable local Chrome into a daemon-managed Browserbase session
- require explicit `--domain` scopes, with `--all` as an intentional opt-in
- support persistent Browserbase contexts, saved context names, Verified mode, proxies, named sessions, and explicit source CDP endpoints
- keep cookie values inside the local driver daemon and out of CLI arguments and output
- document the workflow in the CLI README and bundled browse skill

## Why

The existing cookie-sync skill had to create a keep-alive session outside `browse`, inject cookies over raw CDP, and then warn that normal `browse` commands could not reconnect. Making sync native lets the CLI own the destination session from the beginning, so subsequent commands reuse it normally.

## E2E Test Matrix

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `pnpm turbo run build --filter=browse...` | The local `browse` build completed successfully from the stacked branch. | Proves the exact CLI and Stagehand core code under review compile together. |
| `pnpm --filter browse lint` | Prettier, ESLint, and TypeScript checks passed. | Static validation only; supports but does not replace runtime proof. |
| `pnpm --filter browse exec vitest run tests/cli-surface.test.ts tests/driver-commands.test.ts tests/remote-options.test.ts tests/local-cdp-discovery.test.ts` | 4 files passed; 76 tests passed. | Covers the CLI surface, driver routing, remote options, cookie-sync handlers, and stale local-CDP discovery. |
| `node packages/cli/bin/run.js cookies sync --domain superhuman.com --persist --session <sync-session>` | Synced 27 domain-scoped cookies from a debuggable local Chrome into a newly created Browserbase context. Auto-discovery recovered from a stale cached Chrome target on the live debug port. | Proves the native command transfers real authenticated cookies and exercises the stacked discovery fix; cookie values and live resource IDs are omitted. |
| Release the sync session, create a new Browserbase session from the new context, then open the public account dashboard and assert DOM auth state. | The fresh session reached the authenticated dashboard with `authenticatedDashboard: true` and `redirectedToLogin: false`; release completed with context persistence. | Proves the newly created context preserves real login state across independent cloud sessions. It does not validate every SSO provider or every site's session-binding policy. |