### PR TITLE
Docs callout for about:blank limitation

### DIFF
--- a/packages/docs/v4/reference/locator.mdx
+++ b/packages/docs/v4/reference/locator.mdx
@@ -6,6 +6,12 @@ icon: "crosshairs"
 
 Create a `Locator` from a page selector, then reuse it for element interactions and state queries. `first()` and `nth()` refine the local locator descriptor; the resulting descriptor is sent with later operations.
 
+Selectors pierce shadow DOM, including closed roots.
+
+<Warning>
+**Closed roots require a navigated page.** Piercing them needs a frame with a real origin, and a tab still sitting at `about:blank` has none, so a selector crossing a closed root will not match there. Open roots still resolve. Navigate to an `http:` or `https:` URL first; Stagehand switches back automatically.
+</Warning>
+
 <View title="TypeScript" icon="js">
 
 ## Quick start

--- a/packages/docs/v4/reference/locator.mdx
+++ b/packages/docs/v4/reference/locator.mdx
@@ -9,7 +9,7 @@ Create a `Locator` from a page selector, then reuse it for element interactions 
 Selectors pierce shadow DOM, including closed roots.
 
 <Warning>
-**Closed roots require a navigated page.** Piercing them needs a frame with a real origin, and a tab still sitting at `about:blank` has none, so a selector crossing a closed root will not match there. Open roots still resolve. Navigate to an `http:` or `https:` URL first; Stagehand switches back automatically.
+**Closed roots require a navigated page.** Piercing them needs a frame with a real origin, and a tab still sitting at `about:blank` has none, so a selector crossing a closed root will not match there. Open roots still resolve. Navigate the tab to an `http:` or `https:` URL first.
 </Warning>
 
 <View title="TypeScript" icon="js">

--- a/packages/docs/v4/reference/page.mdx
+++ b/packages/docs/v4/reference/page.mdx
@@ -457,7 +457,7 @@ const matched = await page.waitForSelector("main");
   Options that configure this operation.
 
 <ParamField path="options.pierceShadow" type="boolean" optional>
-  Whether to traverse shadow roots.
+  Whether to traverse shadow roots. Closed roots require a navigated page; see the [locator reference](/v4/reference/locator).
 </ParamField>
 
 <ParamField path="options.state" type="string" optional>
@@ -1114,7 +1114,7 @@ matched = await page.wait_for_selector("main", state="visible")
 </ParamField>
 
 <ParamField path="pierce_shadow" type="bool | None" optional>
-  Whether to traverse shadow roots.
+  Whether to traverse shadow roots. Closed roots require a navigated page; see the [locator reference](/v4/reference/locator).
 </ParamField>
 
 <ResponseField name="result" type="bool">


### PR DESCRIPTION
# why

This is a tricky one! Gotta let em know

# what changed

Adds a section telling users they'll need to navigate before crossing a shadow root for about:blank tab

# test plan

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented the `about:blank` limitation for piercing closed shadow roots: selectors can cross shadow DOM (including closed roots) only after navigating to a real origin; open roots still resolve. Added a warning in the Locator reference and linked notes in `page.waitForSelector` and `page.wait_for_selector` options; addresses Linear STG-2665.

<sup>Written for commit bf68e1e089b25a80816501477c5af3689697629b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

