### PR TITLE
Fix duplicate Go logging documentation view

### DIFF
--- a/packages/docs/v4/configuration/logging.mdx
+++ b/packages/docs/v4/configuration/logging.mdx
@@ -875,7 +875,7 @@ finally:
 ```
 </View>
 
-<View title="Go" icon="go">
+<View title="Go" icon="golang">
 
 ```go
 client := stagehand.New(stagehand.StagehandClientInitParams{
@@ -941,29 +941,6 @@ func run(ctx context.Context) (err error) {
 }
 ```
 
-</View>
-
-Each callback receives the event as a structured log:
-<View title="Go" icon="golang">
-```go
-client := stagehand.New(stagehand.StagehandClientInitParams{
-	Browser: stagehand.LocalBrowserSource{},
-	Logging: &stagehand.StagehandClientLoggingConfig{
-		OnLog: func(entry stagehand.StagehandLog) {
-			_ = json.NewEncoder(logFile).Encode(entry)
-		},
-	},
-})
-
-if err := client.Init(ctx); err != nil {
-	return err
-}
-defer func() {
-	err = errors.Join(err, client.Close(ctx), logFile.Close())
-}()
-
-// ... your automation
-```
 </View>
 
 ### Viewing logs


### PR DESCRIPTION
## Summary

- remove a stale duplicate Go-only logging `<View>`
- use the same `golang` icon as the other Go logging views
- restore the complete TypeScript/Python/Go language set expected by the docs reference checks

## Test plan

- `pnpm --filter @browserbasehq/stagehand-docs test:unit` (18 tests passed)
- `git diff --check`

This is a small prerequisite for the Stagehand browser API stack so its otherwise unrelated CI is green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a duplicate Go logging view in the docs and aligns the icon with other Go examples. Restores the full TypeScript/Python/Go tab set so docs reference checks pass.

- **Bug Fixes**
  - Removed stale duplicate Go-only logging `<View>`.
  - Switched icon from `go` to `golang` for consistency.
  - Restored TS/Python/Go language set expected by reference checks.

<sup>Written for commit 682843e466c92641041dedc9099e3cf61bd33520. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

