### PR TITLE
Accept a nil-able options pointer in Go `BrowserContext.NewPage`

### DIFF
--- a/packages/sdk-go/browser_context.go
+++ b/packages/sdk-go/browser_context.go
@@ -34,7 +34,11 @@ func (c *BrowserContext) Pages(ctx context.Context) ([]*Page, error) {
 }
 
 // NewPage creates a page using the generated protocol parameters.
-func (c *BrowserContext) NewPage(ctx context.Context, params ContextNewPageParams) (*Page, error) {
+func (c *BrowserContext) NewPage(ctx context.Context, options *ContextNewPageParams) (*Page, error) {
+	params := ContextNewPageParams{}
+	if options != nil {
+		params = *options
+	}
 	var result PageRef
 	if err := c.rpc.call(ctx, "context.new_page", params, &result); err != nil {
 		return nil, err

--- a/packages/sdk-go/browser_context_test.go
+++ b/packages/sdk-go/browser_context_test.go
@@ -30,7 +30,7 @@ func TestBrowserContextMapsPagesAndCookies(t *testing.T) {
 	}
 	page, err := browserContext.NewPage(
 		context.Background(),
-		ContextNewPageParams{URL: &pageURL},
+		&ContextNewPageParams{URL: &pageURL},
 	)
 	if err != nil {
 		t.Fatalf("NewPage() error = %v", err)

--- a/packages/sdk-go/stagehand_live_test.go
+++ b/packages/sdk-go/stagehand_live_test.go
@@ -186,7 +186,7 @@ func TestStagehandExtractSendsScreenshotToClientLLM(t *testing.T) {
 		t.Fatalf("BrowserContext.ActivePage() error = %v", err)
 	}
 	if page == nil {
-		page, err = browserContext.NewPage(ctx, ContextNewPageParams{})
+		page, err = browserContext.NewPage(ctx, nil)
 		if err != nil {
 			t.Fatalf("BrowserContext.NewPage() error = %v", err)
 		}


### PR DESCRIPTION
## Summary

- change `NewPage` to take `*ContextNewPageParams` so callers can pass `nil` instead of an empty struct
- every other optional-options method in the Go SDK already uses a nil-able pointer (`Cookies`, `ClearCookies`, `SetDomainPolicy`, the clipboard methods), and the docs already describe the argument as optional

## Validation

- `gofmt -l`, `go vet`
- `go test` (SDK packages)
- `sh packages/sdk-go/scripts/check-examples.sh`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `BrowserContext.NewPage` accept a nil-able `*ContextNewPageParams` so callers can pass `nil` for no options. Aligns with other optional-options methods in the Go SDK and the docs; tests updated to pass pointers or `nil`.

- **Migration**
  - Update calls to `NewPage`: use `nil` for no options, or `&ContextNewPageParams{...}` when needed (e.g., replace `NewPage(ctx, ContextNewPageParams{})` with `NewPage(ctx, nil)`).

<sup>Written for commit a50b7fdbc8551a6ec08308e7483ea368746d841e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

