### PR TITLE
Make `timeout` keyword-only in Python `Page.wait_for_load_state`

### DIFF
--- a/packages/sdk-python/src/stagehand/page.py
+++ b/packages/sdk-python/src/stagehand/page.py
@@ -322,6 +322,7 @@ class Page:
     async def wait_for_load_state(
         self,
         state: LoadState | Literal["load", "domcontentloaded", "networkidle"],
+        *,
         timeout: int | None = None,
     ) -> None:
         params = PageWaitForLoadStateParams.model_validate({

--- a/packages/sdk-python/tests/test_page.py
+++ b/packages/sdk-python/tests/test_page.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 from typing import cast
 
 import pytest
@@ -311,3 +312,23 @@ async def test_page_wraps_callable_webmcp_tools_and_invocations_with_owned_ident
             PageVoidResult,
         ),
     ]
+
+
+def test_optional_page_arguments_are_keyword_only() -> None:
+    """Required arguments are positional; anything with a default must be keyword-only."""
+    offenders: list[str] = []
+
+    for name in dir(Page):
+        if name.startswith("_"):
+            continue
+        attribute = inspect.getattr_static(Page, name)
+        if not (inspect.isfunction(attribute) or inspect.iscoroutinefunction(attribute)):
+            continue
+        for parameter in inspect.signature(attribute).parameters.values():
+            if (
+                parameter.kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+                and parameter.default is not inspect.Parameter.empty
+            ):
+                offenders.append(f"Page.{name}({parameter.name}=...)")
+
+    assert offenders == []


### PR DESCRIPTION
## Summary

- add the missing `*` so `timeout` is keyword-only, matching every other optional argument on `Page`
- the v4 docs already show `timeout=10_000`, so this aligns the signature with documented usage
- add a test asserting no public `Page` method accepts a defaulted argument positionally, which catches this drift across the whole class

## Validation

- `ruff format --check`, `ruff check`, `ty check`
- `pytest` (207 passed; verified the new test fails without the `*`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `timeout` keyword-only in `Page.wait_for_load_state` to match other `Page` methods and v4 docs; add a test that fails if any public `Page` method accepts a defaulted argument positionally.

<sup>Written for commit 00f6924576a4b2b645bd2eee2758ba661e606107. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

