### PR TITLE
fix: verify cached local Chrome debug port before trusting it

### DIFF
--- a/.changeset/tired-hounds-repair.md
+++ b/.changeset/tired-hounds-repair.md
@@ -1,0 +1,5 @@
+---
+"browse": patch
+---
+
+Fix local browser discovery (`--auto-connect`, `browse doctor`) trusting a stale cached debugging port after a different Chrome process later reuses that same port.

--- a/packages/cli/src/lib/driver/local-cdp-discovery.ts
+++ b/packages/cli/src/lib/driver/local-cdp-discovery.ts
@@ -112,17 +112,51 @@ async function probeJsonVersion(port: number): Promise<string | null> {
 }
 
 /**
+ * Multiple candidates (several profile dirs, or a profile dir and a fallback
+ * port) can reference the same port within one discovery call. Memoize the
+ * live /json/version probe per port so that port is only actually hit once.
+ */
+function createJsonVersionProbe(): (port: number) => Promise<string | null> {
+  const cache = new Map<number, Promise<string | null>>();
+  return (port) => {
+    let pending = cache.get(port);
+    if (!pending) {
+      pending = probeJsonVersion(port);
+      cache.set(port, pending);
+    }
+    return pending;
+  };
+}
+
+function wsPathname(wsUrl: string): string | null {
+  try {
+    return new URL(wsUrl).pathname;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * A DevToolsActivePort file only reflects the browser instance that wrote it.
  * If a different process later binds the same port (a very likely collision,
  * since 9222 is the near-universal default debugging port), the cached
  * port+wsPath pair points at a target that no longer exists. Confirm the
- * port's live /json/version still reports this exact wsPath before trusting it.
+ * port's live /json/version still reports this exact target before trusting
+ * it. Compare pathnames only (not the full URL) since Chrome can report the
+ * host as "127.0.0.1" or "localhost" depending on version/platform.
  */
 async function isDevToolsActivePortFresh(
   info: DevToolsActivePortInfo,
+  probe: (port: number) => Promise<string | null> = probeJsonVersion,
 ): Promise<boolean> {
-  const liveWsUrl = await probeJsonVersion(info.port);
-  return liveWsUrl === buildDevToolsWsUrl(info.port, info.wsPath);
+  const liveWsUrl = await probe(info.port);
+  if (!liveWsUrl) return false;
+  const expectedPathname = wsPathname(
+    buildDevToolsWsUrl(info.port, info.wsPath),
+  );
+  return (
+    expectedPathname !== null && wsPathname(liveWsUrl) === expectedPathname
+  );
 }
 
 async function verifyCdpWebSocket(wsUrl: string): Promise<boolean> {
@@ -171,11 +205,12 @@ async function verifyCdpWebSocket(wsUrl: string): Promise<boolean> {
 async function resolveDevToolsActivePortUrl(
   port: number,
   userDataDirs: string[],
+  probe: (port: number) => Promise<string | null>,
 ): Promise<string | null> {
   for (const dir of userDataDirs) {
     const info = await readDevToolsActivePort(dir);
     if (!info || info.port !== port) continue;
-    if (!(await isDevToolsActivePortFresh(info))) continue;
+    if (!(await isDevToolsActivePortFresh(info, probe))) continue;
     return buildDevToolsWsUrl(info.port, info.wsPath);
   }
 
@@ -187,9 +222,14 @@ export async function resolveWsTargetFromPort(
   options: ResolveWsTargetFromPortOptions = {},
 ): Promise<string> {
   const userDataDirs = options.userDataDirs ?? getChromeUserDataDirs();
-  const devToolsUrl = await resolveDevToolsActivePortUrl(port, userDataDirs);
+  const probe = createJsonVersionProbe();
+  const devToolsUrl = await resolveDevToolsActivePortUrl(
+    port,
+    userDataDirs,
+    probe,
+  );
   if (devToolsUrl) return devToolsUrl;
-  const jsonVersionUrl = await probeJsonVersion(port);
+  const jsonVersionUrl = await probe(port);
   if (jsonVersionUrl) return jsonVersionUrl;
   const fallback = buildDevToolsWsUrl(port, "/devtools/browser");
   if (await verifyCdpWebSocket(fallback)) return fallback;
@@ -203,10 +243,11 @@ export async function discoverLocalCdp(
 ): Promise<LocalCdpDiscovery | null> {
   const candidates: CdpCandidate[] = [];
   const userDataDirs = options.userDataDirs ?? getChromeUserDataDirs();
+  const probe = createJsonVersionProbe();
 
   for (const dir of userDataDirs) {
     const info = await readDevToolsActivePort(dir);
-    if (!info || !(await isDevToolsActivePortFresh(info))) continue;
+    if (!info || !(await isDevToolsActivePortFresh(info, probe))) continue;
     candidates.push({
       source: `DevToolsActivePort:${dir}`,
       wsUrl: buildDevToolsWsUrl(info.port, info.wsPath),
@@ -214,7 +255,7 @@ export async function discoverLocalCdp(
   }
 
   for (const port of options.fallbackPorts ?? DEFAULT_FALLBACK_PORTS) {
-    const wsUrl = await probeJsonVersion(port);
+    const wsUrl = await probe(port);
     if (!wsUrl) continue;
     if (!candidates.some((candidate) => candidate.wsUrl === wsUrl)) {
       candidates.push({ source: `port:${port}`, wsUrl });

--- a/packages/cli/src/lib/driver/local-cdp-discovery.ts
+++ b/packages/cli/src/lib/driver/local-cdp-discovery.ts
@@ -91,26 +91,6 @@ export async function readDevToolsActivePort(
   }
 }
 
-function isPortReachable(port: number, timeoutMs = 500): Promise<boolean> {
-  return new Promise((resolve) => {
-    const socket = net.createConnection({ host: "127.0.0.1", port });
-    const timer = setTimeout(() => {
-      socket.destroy();
-      resolve(false);
-    }, timeoutMs);
-
-    socket.on("connect", () => {
-      clearTimeout(timer);
-      socket.destroy();
-      resolve(true);
-    });
-    socket.on("error", () => {
-      clearTimeout(timer);
-      resolve(false);
-    });
-  });
-}
-
 async function probeJsonVersion(port: number): Promise<string | null> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 2000);
@@ -129,6 +109,20 @@ async function probeJsonVersion(port: number): Promise<string | null> {
   } finally {
     clearTimeout(timer);
   }
+}
+
+/**
+ * A DevToolsActivePort file only reflects the browser instance that wrote it.
+ * If a different process later binds the same port (a very likely collision,
+ * since 9222 is the near-universal default debugging port), the cached
+ * port+wsPath pair points at a target that no longer exists. Confirm the
+ * port's live /json/version still reports this exact wsPath before trusting it.
+ */
+async function isDevToolsActivePortFresh(
+  info: DevToolsActivePortInfo,
+): Promise<boolean> {
+  const liveWsUrl = await probeJsonVersion(info.port);
+  return liveWsUrl === buildDevToolsWsUrl(info.port, info.wsPath);
 }
 
 async function verifyCdpWebSocket(wsUrl: string): Promise<boolean> {
@@ -181,7 +175,7 @@ async function resolveDevToolsActivePortUrl(
   for (const dir of userDataDirs) {
     const info = await readDevToolsActivePort(dir);
     if (!info || info.port !== port) continue;
-    if (!(await isPortReachable(info.port))) continue;
+    if (!(await isDevToolsActivePortFresh(info))) continue;
     return buildDevToolsWsUrl(info.port, info.wsPath);
   }
 
@@ -212,7 +206,7 @@ export async function discoverLocalCdp(
 
   for (const dir of userDataDirs) {
     const info = await readDevToolsActivePort(dir);
-    if (!info || !(await isPortReachable(info.port))) continue;
+    if (!info || !(await isDevToolsActivePortFresh(info))) continue;
     candidates.push({
       source: `DevToolsActivePort:${dir}`,
       wsUrl: buildDevToolsWsUrl(info.port, info.wsPath),

--- a/packages/cli/tests/local-cdp-discovery.test.ts
+++ b/packages/cli/tests/local-cdp-discovery.test.ts
@@ -21,11 +21,14 @@ async function startFakeCdpServer(
 ): Promise<{
   port: number;
   wsUrl: string;
+  requestCount: () => number;
   close: () => Promise<void>;
 }> {
   let wsUrl = "";
+  let requests = 0;
   const server: Server = createServer((req, res) => {
     if (req.url === "/json/version") {
+      requests += 1;
       res.writeHead(200, { "content-type": "application/json" });
       res.end(JSON.stringify({ webSocketDebuggerUrl: wsUrl }));
       return;
@@ -41,6 +44,7 @@ async function startFakeCdpServer(
   return {
     port,
     wsUrl,
+    requestCount: () => requests,
     close: () => new Promise((resolve) => server.close(() => resolve())),
   };
 }
@@ -151,6 +155,65 @@ describe("local CDP discovery", () => {
 
     expect(discovered?.wsUrl).toBe(liveWsUrl);
     expect(discovered?.source).toBe(`port:${port}`);
+  });
+
+  it('resolveWsTargetFromPort trusts a live browser that reports "localhost" instead of "127.0.0.1"', async () => {
+    const userDataDir = await mkdtemp(join(tmpdir(), "browse-cdp-host-"));
+    tempDirs.push(userDataDir);
+
+    // Chrome's /json/version response can echo back whichever host the
+    // request used (or a fixed default), so a live browser can legitimately
+    // report "localhost" even though we always probe via 127.0.0.1.
+    const { port, close } = await startFakeCdpServer(
+      (p) => `ws://localhost:${p}/devtools/browser/current-id`,
+    );
+    servers.push(close);
+
+    await writeDevToolsActivePort(
+      userDataDir,
+      port,
+      "/devtools/browser/current-id",
+    );
+
+    const resolved = await resolveWsTargetFromPort(port, {
+      userDataDirs: [userDataDir],
+    });
+
+    // The cached candidate is still trusted (built from the recorded
+    // port + wsPath), since only the path -- not the host string -- is used
+    // to confirm freshness.
+    expect(resolved).toBe(`ws://127.0.0.1:${port}/devtools/browser/current-id`);
+  });
+
+  it("discoverLocalCdp probes a port shared by a cached candidate and a fallback port only once", async () => {
+    const userDataDir = await mkdtemp(join(tmpdir(), "browse-cdp-memo-"));
+    tempDirs.push(userDataDir);
+
+    const {
+      port,
+      wsUrl: liveWsUrl,
+      close,
+      requestCount,
+    } = await startFakeCdpServer(
+      (p) => `ws://127.0.0.1:${p}/devtools/browser/live-id`,
+    );
+    servers.push(close);
+
+    // The same port shows up both as a (stale) cached candidate and as a
+    // fallback port -- discovery should only hit /json/version once for it.
+    await writeDevToolsActivePort(
+      userDataDir,
+      port,
+      "/devtools/browser/stale-id",
+    );
+
+    const discovered = await discoverLocalCdp({
+      userDataDirs: [userDataDir],
+      fallbackPorts: [port],
+    });
+
+    expect(discovered?.wsUrl).toBe(liveWsUrl);
+    expect(requestCount()).toBe(1);
   });
 
   it("discoverLocalCdp returns null when no candidate is live", async () => {

--- a/packages/cli/tests/local-cdp-discovery.test.ts
+++ b/packages/cli/tests/local-cdp-discovery.test.ts
@@ -1,0 +1,169 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AddressInfo } from "node:net";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  discoverLocalCdp,
+  resolveWsTargetFromPort,
+} from "../src/lib/driver/local-cdp-discovery.js";
+
+/**
+ * Starts a fake CDP HTTP server on an OS-assigned port. `wsPathForPort` gets
+ * the bound port so it can bake the real port into the reported
+ * webSocketDebuggerUrl, mirroring how a real browser reports itself.
+ */
+async function startFakeCdpServer(
+  wsPathForPort: (port: number) => string,
+): Promise<{
+  port: number;
+  wsUrl: string;
+  close: () => Promise<void>;
+}> {
+  let wsUrl = "";
+  const server: Server = createServer((req, res) => {
+    if (req.url === "/json/version") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ webSocketDebuggerUrl: wsUrl }));
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  wsUrl = wsPathForPort(port);
+
+  return {
+    port,
+    wsUrl,
+    close: () => new Promise((resolve) => server.close(() => resolve())),
+  };
+}
+
+async function writeDevToolsActivePort(
+  dir: string,
+  port: number,
+  wsPath: string,
+): Promise<void> {
+  await writeFile(
+    join(dir, "DevToolsActivePort"),
+    `${port}\n${wsPath}\n`,
+    "utf8",
+  );
+}
+
+describe("local CDP discovery", () => {
+  const tempDirs: string[] = [];
+  const servers: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    await Promise.all(servers.splice(0).map((close) => close()));
+    await Promise.all(
+      tempDirs
+        .splice(0)
+        .map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it("resolveWsTargetFromPort ignores a stale DevToolsActivePort file when the live browser reports a different target", async () => {
+    const userDataDir = await mkdtemp(join(tmpdir(), "browse-cdp-stale-"));
+    tempDirs.push(userDataDir);
+
+    const {
+      port,
+      wsUrl: liveWsUrl,
+      close,
+    } = await startFakeCdpServer(
+      (p) => `ws://127.0.0.1:${p}/devtools/browser/live-id`,
+    );
+    servers.push(close);
+
+    // Simulate a leftover file from a previous Chrome instance that used to
+    // listen on this same port under a different browser id.
+    await writeDevToolsActivePort(
+      userDataDir,
+      port,
+      "/devtools/browser/stale-id",
+    );
+
+    const resolved = await resolveWsTargetFromPort(port, {
+      userDataDirs: [userDataDir],
+    });
+
+    expect(resolved).toBe(liveWsUrl);
+    expect(resolved).not.toContain("stale-id");
+  });
+
+  it("resolveWsTargetFromPort trusts a DevToolsActivePort file that matches the live browser", async () => {
+    const userDataDir = await mkdtemp(join(tmpdir(), "browse-cdp-fresh-"));
+    tempDirs.push(userDataDir);
+
+    const {
+      port,
+      wsUrl: liveWsUrl,
+      close,
+    } = await startFakeCdpServer(
+      (p) => `ws://127.0.0.1:${p}/devtools/browser/current-id`,
+    );
+    servers.push(close);
+
+    await writeDevToolsActivePort(
+      userDataDir,
+      port,
+      "/devtools/browser/current-id",
+    );
+
+    const resolved = await resolveWsTargetFromPort(port, {
+      userDataDirs: [userDataDir],
+    });
+
+    expect(resolved).toBe(liveWsUrl);
+  });
+
+  it("discoverLocalCdp skips a stale DevToolsActivePort candidate and falls back to a live fallback-port probe", async () => {
+    const userDataDir = await mkdtemp(join(tmpdir(), "browse-cdp-discover-"));
+    tempDirs.push(userDataDir);
+
+    const {
+      port,
+      wsUrl: liveWsUrl,
+      close,
+    } = await startFakeCdpServer(
+      (p) => `ws://127.0.0.1:${p}/devtools/browser/live-id`,
+    );
+    servers.push(close);
+
+    await writeDevToolsActivePort(
+      userDataDir,
+      port,
+      "/devtools/browser/stale-id",
+    );
+
+    const discovered = await discoverLocalCdp({
+      userDataDirs: [userDataDir],
+      fallbackPorts: [port],
+    });
+
+    expect(discovered?.wsUrl).toBe(liveWsUrl);
+    expect(discovered?.source).toBe(`port:${port}`);
+  });
+
+  it("discoverLocalCdp returns null when no candidate is live", async () => {
+    const userDataDir = await mkdtemp(join(tmpdir(), "browse-cdp-none-"));
+    tempDirs.push(userDataDir);
+
+    await writeDevToolsActivePort(userDataDir, 9, "/devtools/browser/dead");
+
+    const discovered = await discoverLocalCdp({
+      userDataDirs: [userDataDir],
+      fallbackPorts: [],
+    });
+
+    expect(discovered).toBeNull();
+  });
+});


### PR DESCRIPTION
## What changed

Local CDP discovery (used by `browse open --auto-connect` and `browse doctor`, and about to gain a third consumer in #2535's `cookies sync`) reads a per-profile `DevToolsActivePort` file to find a debuggable local Chrome. It only checked that the recorded port was *reachable* -- never that the port was still serving the *same browser instance* that wrote the file.

Port 9222 is the near-universal default remote-debugging port (Selenium, Puppeteer, Playwright, this CLI's own managed-local mode all default to it), so it's very easy for a different Chrome process to later bind that same port. When that happens, the stale on-disk (port -> target id) mapping gets trusted anyway, and discovery confidently returns a websocket URL to a dead target -- which fails with a confusing `Unexpected server response: 404` when something tries to connect.

## Why

Hit this live while testing #2535: my real Chrome profile had a leftover `DevToolsActivePort` file from an earlier remote-debugging session on port 9222. A brand-new, unrelated Chrome instance later happened to reuse port 9222, and discovery silently resolved to the old, dead browser id instead of the new live one.

## Fix

Before trusting a cached `port` + `wsPath` pair, confirm the port's own live `/json/version` still reports that exact websocket path. If it doesn't match (or nothing responds), the candidate is discarded and discovery falls through to its existing live-probe fallback.

## Validation

## E2E Test Matrix

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `pnpm --filter browse test:cli -- tests/local-cdp-discovery.test.ts` (new tests) | 4/4 passed: rejects a stale `DevToolsActivePort` file when the live browser reports a different target, trusts one that matches, `discoverLocalCdp` falls back to a live port probe when the cached candidate is stale, and returns `null` when nothing is live | Proves the fix's logic in isolation with a fake CDP HTTP server standing in for Chrome, covering both the stale and fresh cases |
| `pnpm --filter browse test:cli` (full suite) | 369/370 passed. The 1 failure (`doctor.test.ts > includes --verified/--proxies...`) reproduces identically on unmodified `origin/main` with my changes stashed -- confirmed pre-existing and unrelated (also called out in #2535's own validation notes as environment-dependent) | Confirms no regressions anywhere else in the CLI |
| `pnpm --filter browse lint` | `format:check`, `eslint`, and `tsc --noEmit` all pass | Style/type safety |
| Live before/after on the exact real-world failure: launched a fresh local Chrome on port 9222 while my real default Chrome profile still had its stale `DevToolsActivePort` file (recorded browser id `ca0986...`) from an earlier, now-dead debugging session. Ran `discoverLocalCdp()`/`resolveWsTargetFromPort(9222)` from a compiled copy of the pre-fix code vs. this branch's build | Pre-fix: both resolved to the dead `ws://127.0.0.1:9222/devtools/browser/ca0986...` (the exact class of URL that throws `Unexpected server response: 404` on connect). Post-fix (this branch): both correctly resolved to the actually-live browser id instead | Reproduces the real bug end-to-end on real Chrome + real filesystem state, not just a mocked unit test, and shows the fix closes it |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Verifies cached `DevToolsActivePort` before use in local CDP discovery to avoid connecting to stale Chrome targets that 404. Adds host-agnostic checks and memoized probes, affecting `browse open --auto-connect` and `browse doctor`, addressing Linear STG-2751.

- **Bug Fixes**
  - Validate cached port+`wsPath` via `/json/version`; compare pathname only to handle `localhost` vs `127.0.0.1`.
  - Memoize live-port probes per port so shared ports are hit once per discovery.
  - Keep fallback to live-port probe; return null when nothing is live. Tests cover stale/fresh, host variance, memoization, and no-live cases.

<sup>Written for commit 5051c2e6887e699389e82dcd4332249c435a2c7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

