### PR TITLE
evals: run v4 bench tasks against a v4 Stagehand client

### DIFF
--- a/packages/evals/framework/benchHarness.ts
+++ b/packages/evals/framework/benchHarness.ts
@@ -15,6 +15,7 @@ import { endBrowserbaseSession } from "../browserbaseCleanup.js";
 import { EvalsError } from "../errors.js";
 import type { EvalLogger } from "../logger.js";
 import type { V3InitResult } from "../initV3.js";
+import type { StagehandInitResult } from "../initStagehand.js";
 import type { EvalInput } from "../types/evals.js";
 import { runClaudeCodeAgent } from "./claudeCodeRunner.js";
 import {
@@ -24,7 +25,7 @@ import {
 import { runCodexAgent } from "./codexRunner.js";
 import { prepareCodexToolAdapter, type PreparedCodexToolAdapter } from "./codexToolAdapter.js";
 import { buildExternalHarnessTaskPlan } from "./externalHarnessPlan.js";
-import type { DiscoveredTask, TaskResult } from "./types.js";
+import type { DiscoveredTask, EvalSdk, TaskResult } from "./types.js";
 import type { BenchMatrixRow, BenchTaskKind, Harness } from "./benchTypes.js";
 
 type Page = ReturnType<V3["context"]["pages"]>[number];
@@ -35,6 +36,8 @@ export interface BenchHarnessStartInput {
   row: BenchMatrixRow;
   logger: EvalLogger;
   verbose?: boolean;
+  /** SDK to initialize, read off the task definition by the bench runner. */
+  sdk?: EvalSdk;
 }
 
 export interface BenchHarnessExecuteInput extends BenchHarnessStartInput {
@@ -48,6 +51,10 @@ export interface BenchHarnessContext {
   v3?: V3;
   agent?: AgentInstance;
   page?: Page;
+  /** Stagehand v4 client (set only when the task runs with sdk: "v4"). */
+  stagehand?: StagehandInitResult["stagehand"];
+  /** v4 page object (set only when the task runs with sdk: "v4"). */
+  v4Page?: StagehandInitResult["page"];
   debugUrl: string;
   sessionUrl: string;
 }
@@ -132,6 +139,7 @@ export const stagehandHarness: BenchHarness = {
     row,
     logger,
     verbose,
+    sdk,
   }: BenchHarnessStartInput): Promise<StartedBenchHarness> {
     let v3Result: V3InitResult | undefined;
     const createAgent = isAgentTask(task);
@@ -143,6 +151,42 @@ export const stagehandHarness: BenchHarness = {
     const config = row.config;
     const agentMode = config.agentMode ?? input.agentMode;
     const isCUA = config.isCUA ?? input.isCUA;
+    const effectiveSdk: EvalSdk = sdk ?? "v3";
+
+    if (effectiveSdk === "v4") {
+      // The v4 SDK has no agent surface, and agent tasks are deliberately not
+      // ported. Fail loudly rather than silently fall back to v3 behavior.
+      if (createAgent || agentMode || isCUA) {
+        throw new EvalsError("The v4 SDK does not support agent tasks or agent modes.");
+      }
+      if (config.useApi) {
+        throw new EvalsError("--api is not supported with the v4 SDK.");
+      }
+      const { initStagehand } = await import("../initStagehand.js");
+      const v4Result = await initStagehand({
+        logger,
+        modelName: input.modelName,
+        environment: config.environment,
+      });
+      return {
+        ctx: {
+          harness: "stagehand",
+          row,
+          logger,
+          stagehand: v4Result.stagehand,
+          v4Page: v4Result.page,
+          debugUrl: "",
+          sessionUrl: v4Result.sessionUrl ?? "",
+        },
+        cleanup: async () => {
+          try {
+            await v4Result.stagehand.close();
+          } catch (closeError) {
+            console.error(`Warning: Error closing v4 Stagehand for ${input.name}:`, closeError);
+          }
+        },
+      };
+    }
 
     if (config.useApi) {
       const provider = resolveProvider(input.modelName);

--- a/packages/evals/framework/benchRunner.ts
+++ b/packages/evals/framework/benchRunner.ts
@@ -54,23 +54,33 @@ export async function executeBenchTask(
       });
     }
 
+    // Load the task module before starting the harness: which SDK to
+    // initialize is declared on the definition, and the client has to exist
+    // before the task function runs.
+    const taskModule = await loadTaskModuleFromPath(task.filePath, task.name);
+    // The definition is authoritative: defineBenchV4Task stamps sdk: "v4".
+    const sdk = taskModule.definition?.sdk ?? "v3";
+
     const startedHarness = await harness.start({
       task,
       input,
       row,
       logger,
       verbose: options.verbose,
+      sdk,
     });
     cleanup = onceAsync(startedHarness.cleanup);
     unregisterCleanup = registerActiveRunCleanup(cleanup);
 
     harnessCtx = startedHarness.ctx;
-    const taskModule = await loadTaskModuleFromPath(task.filePath, task.name);
     if (taskModule.definition) {
       const ctx = {
         v3: harnessCtx.v3,
         agent: harnessCtx.agent,
-        page: harnessCtx.page,
+        // v4 tasks receive the v4 client and its RPC-backed page in place of
+        // the V3 instance and the Playwright page.
+        stagehand: harnessCtx.stagehand,
+        page: harnessCtx.page ?? harnessCtx.v4Page,
         logger,
         input,
         modelName: input.modelName,
@@ -114,7 +124,7 @@ export async function executeBenchTask(
     return withBenchSessionUrls(
       {
         _success: false,
-        error: error instanceof Error ? JSON.parse(JSON.stringify(error, null, 2)) : String(error),
+        error: error instanceof Error ? error.message : String(error),
         logs: logger.getLogs(),
       },
       harnessCtx,

--- a/packages/evals/framework/defineTask.ts
+++ b/packages/evals/framework/defineTask.ts
@@ -56,6 +56,7 @@ export function defineBenchV4Task(
   return {
     __taskDefinition: true,
     meta,
+    sdk: "v4",
     // Fail fast with a clear message if a v3-context runner invokes a v4
     // task — the v4 init/dispatch path lands with the harness change.
     fn: (ctx) => {

--- a/packages/evals/framework/runner.ts
+++ b/packages/evals/framework/runner.ts
@@ -347,13 +347,17 @@ export async function runEvals(options: RunEvalsOptions): Promise<RunEvalsResult
   if (options.modelOverride) process.env.EVAL_MODEL_OVERRIDE = options.modelOverride;
   if (options.provider) process.env.EVAL_PROVIDER = options.provider;
 
-  const braintrustProjectName = hasCoreOnly
-    ? process.env.CI === "true"
-      ? "stagehand-core"
-      : "stagehand-core-dev"
-    : process.env.CI === "true"
-      ? "stagehand"
-      : "stagehand-dev";
+  // EVAL_BRAINTRUST_PROJECT routes a run to a specific project (e.g.
+  // stagehand-v4-deterministic); unset keeps the default core/bench routing.
+  const braintrustProjectName =
+    process.env.EVAL_BRAINTRUST_PROJECT ??
+    (hasCoreOnly
+      ? process.env.CI === "true"
+        ? "stagehand-core"
+        : "stagehand-core-dev"
+      : process.env.CI === "true"
+        ? "stagehand"
+        : "stagehand-dev");
 
   const scores = hasCoreOnly ? [passRate, errorMatch] : [exactMatch, errorMatch];
 

--- a/packages/evals/framework/taskLoader.ts
+++ b/packages/evals/framework/taskLoader.ts
@@ -1,12 +1,14 @@
 import fs from "node:fs";
 import { pathToFileURL } from "node:url";
 import { EvalsError } from "../errors.js";
-import type { TaskResult } from "./types.js";
+import type { EvalSdk, TaskResult } from "./types.js";
 
 export interface LoadedTaskDefinition {
   __taskDefinition: true;
   meta: unknown;
   fn: (ctx: unknown) => Promise<unknown>;
+  /** SDK the task was defined for (set by defineBenchV4Task; absent = v3). */
+  sdk?: EvalSdk;
 }
 
 export type LegacyTaskFn = (ctx: unknown) => Promise<TaskResult>;

--- a/packages/evals/framework/types.ts
+++ b/packages/evals/framework/types.ts
@@ -27,6 +27,9 @@ type V3Page = ReturnType<V3["context"]["pages"]>[number];
 
 export type Tier = "core" | "bench";
 
+/** Which Stagehand SDK a bench task needs. Declared by its define* wrapper. */
+export type EvalSdk = "v3" | "v4";
+
 export interface TaskMeta {
   /** Human-readable task name (e.g., "snapshot", "dropdown"). Inferred from filename if omitted. */
   name?: string;
@@ -135,6 +138,8 @@ export interface TaskDefinition {
   fn: (ctx: CoreTaskContext | BenchTaskContext | BenchV4TaskContext) => Promise<void | TaskResult>;
   /** Which tier this task was defined for (set during discovery from directory). */
   tier?: Tier;
+  /** SDK the task's context requires; set to "v4" by defineBenchV4Task. */
+  sdk?: EvalSdk;
 }
 
 export interface DiscoveredTask {

--- a/packages/evals/initStagehand.ts
+++ b/packages/evals/initStagehand.ts
@@ -1,0 +1,146 @@
+/** Initializes the Stagehand client used by benchmark tasks. */
+import {
+  Stagehand,
+  type Page,
+  type StagehandClientInitParams,
+  type StagehandClientLoggingConfig,
+} from "@browserbasehq/stagehand";
+import type { EvalLogger } from "./logger.js";
+import { resolveKey } from "./tui/welcomeStatus.js";
+
+export type InitStagehandArgs = {
+  logger: EvalLogger;
+  modelName: string;
+  systemPrompt?: string;
+  environment: "LOCAL" | "BROWSERBASE";
+};
+
+export type StagehandInitResult = {
+  stagehand: Stagehand;
+  page: Page;
+  sessionUrl?: string;
+};
+
+const PROVIDER_API_KEY_ENV: Record<string, string[]> = {
+  openai: ["OPENAI_API_KEY"],
+  anthropic: ["ANTHROPIC_API_KEY"],
+  google: ["GOOGLE_GENERATIVE_AI_API_KEY", "GEMINI_API_KEY"],
+  groq: ["GROQ_API_KEY"],
+  cerebras: ["CEREBRAS_API_KEY"],
+};
+
+type KeyLookup = (name: string) => string;
+
+const resolvePackageAwareKey: KeyLookup = (name) => resolveKey(name).value;
+
+export function resolveModelApiKey(
+  modelName: string,
+  lookup: KeyLookup = resolvePackageAwareKey,
+): string {
+  const provider = modelName.includes("/") ? modelName.split("/")[0].toLowerCase() : undefined;
+  const candidates = provider ? (PROVIDER_API_KEY_ENV[provider] ?? []) : [];
+  for (const envVar of candidates) {
+    const value = lookup(envVar);
+    if (value) return value;
+  }
+  throw new Error(
+    `Stagehand init: no API key found for model "${modelName}". ` +
+      `Stagehand requires an explicit model API key ` +
+      `(checked: ${candidates.join(", ") || "no known provider prefix"}).`,
+  );
+}
+
+export function requireBrowserbaseApiKey(lookup: KeyLookup = resolvePackageAwareKey): string {
+  const apiKey = lookup("BROWSERBASE_API_KEY") || lookup("BB_API_KEY");
+  if (!apiKey) {
+    throw new Error(
+      "Stagehand init: BROWSERBASE_API_KEY or BB_API_KEY is required for BROWSERBASE runs",
+    );
+  }
+  return apiKey;
+}
+
+type StagehandLogEvent = Parameters<NonNullable<StagehandClientLoggingConfig["onLog"]>>[0];
+
+function createStagehandOnLog(logger: EvalLogger): (event: StagehandLogEvent) => void {
+  return (event) => {
+    if (event.level === "debug") return;
+
+    const level = event.level === "error" ? 0 : event.level === "warn" ? 1 : 2;
+    const auxiliary =
+      Object.keys(event.data).length > 0
+        ? {
+            data: { value: JSON.stringify(event.data), type: "object" as const },
+          }
+        : undefined;
+
+    logger.log({
+      category: "stagehand-sdk",
+      message: event.message,
+      level,
+      ...(auxiliary ? { auxiliary } : {}),
+    });
+  };
+}
+
+export function buildStagehandInitParams(input: {
+  env: "LOCAL" | "BROWSERBASE";
+  model: NonNullable<StagehandClientInitParams["model"]>;
+  browserbaseApiKey?: string;
+  systemPrompt?: string;
+  logger: EvalLogger;
+}): StagehandClientInitParams {
+  return {
+    browser:
+      input.env === "BROWSERBASE"
+        ? { type: "browserbase" }
+        : {
+            type: "local",
+            headless: false,
+          },
+    ...(input.browserbaseApiKey ? { apiKey: input.browserbaseApiKey } : {}),
+    model: input.model,
+    selfHeal: true,
+    ...(input.systemPrompt ? { systemPrompt: input.systemPrompt } : {}),
+    logging: { onLog: createStagehandOnLog(input.logger) },
+  };
+}
+
+export async function initStagehand({
+  logger,
+  modelName,
+  systemPrompt,
+  environment,
+}: InitStagehandArgs): Promise<StagehandInitResult> {
+  const model = {
+    modelName,
+    apiKey: resolveModelApiKey(modelName),
+  } as NonNullable<StagehandClientInitParams["model"]>;
+
+  const stagehand = new Stagehand(
+    buildStagehandInitParams({
+      env: environment,
+      model,
+      browserbaseApiKey: environment === "BROWSERBASE" ? requireBrowserbaseApiKey() : undefined,
+      systemPrompt,
+      logger,
+    }),
+  );
+
+  await stagehand.init();
+
+  const page = await stagehand.context.activePage();
+  if (!page) {
+    await stagehand.close();
+    throw new Error("Stagehand init: Stagehand initialized without an active page");
+  }
+
+  const sessionId = stagehand.browser?.browserbaseSessionId;
+  const sessionUrl = sessionId ? `https://www.browserbase.com/sessions/${sessionId}` : undefined;
+
+  return {
+    stagehand,
+    page,
+    sessionUrl,
+  };
+}


### PR DESCRIPTION
The ported act/extract/observe tasks expect { stagehand, page } in their
context, but executeBenchTask only ever built a V3 instance, so every one of
them failed on defineBenchV4Task's guard before its own code ran.

The runner now loads the task module before starting the harness — the SDK a
task needs is declared on its definition (defineBenchV4Task stamps sdk: "v4"),
and the client has to exist before the task function runs. stagehandHarness
branches on that to build a v4 client via initStagehand, hands it to the task,
and closes it on cleanup.

initStagehand is carried unchanged from the closed #2472 rather than rewritten,
so the two do not drift: it already sets selfHeal: true (without which the
heal_* benchmarks silently measure nothing, since the server defaults it off)
and keeps debug lines out of the eval logger (bridging them produces ~18MB
Braintrust payloads that the API rejects).

command: dispatch reads the definition marker, so `evals run act` works.
EVAL_BRAINTRUST_PROJECT is included because without it v4 rows land in
stagehand-dev alongside the LLM-judge-graded runs, leaving the deterministic
suite unauditable.

Also fixes benchRunner's catch clause, which serialized errors with
JSON.stringify — that yields {} for an Error, since its properties are
non-enumerable, so every runner-level failure logged an empty object.

why: the ported act/extract/observe tasks expect `{ stagehand, page }` in their context, but
`executeBenchTask` only ever built a V3 instance, so every one of them failed on
`defineBenchV4Task`'s guard before its own code ran. We need this on #2494 the tasks
are ported but unrunnable until a v4 client reaches them.

what changed: The runner now loads the task module before starting the harness. The SDK a task
needs is declared on its definition (`defineBenchV4Task` stamps `sdk: "v4"`), and the
client has to exist before the task function runs. `stagehandHarness` branches on that
to build a v4 client via `initStagehand`, hands it to the task, and closes it on cleanup.

test plan



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run v4 bench tasks against a v4 Stagehand client by reading `sdk: "v4"` from the task definition and starting the right SDK before the harness. Adds `EVAL_BRAINTRUST_PROJECT` routing and fixes empty error logs.

- **New Features**
  - Auto-detect SDK from the task and init v3 or v4; no `--sdk` flag.
  - `stagehandHarness` starts v4 via `initStagehand`, passes `{ stagehand, page }`, returns `sessionUrl`; blocks agent tasks and `--api` on v4.
  - `initStagehand` uses `@browserbasehq/stagehand` with `selfHeal: true`, filtered logs, model/API key resolution, and LOCAL/BROWSERBASE support.

- **Bug Fixes**
  - Error reporting uses `error.message` instead of stringifying `Error`.

<sup>Written for commit 5097cae9e34afb1b2d6e25d14428f81aa8b51bbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



