### PR TITLE
evals: run act/extract/observe bench tasks on a v4 Stagehand client

### DIFF
--- a/packages/evals/framework/benchHarness.ts
+++ b/packages/evals/framework/benchHarness.ts
@@ -15,6 +15,7 @@ import { endBrowserbaseSession } from "../browserbaseCleanup.js";
 import { EvalsError } from "../errors.js";
 import type { EvalLogger } from "../logger.js";
 import type { V3InitResult } from "../initV3.js";
+import type { StagehandInitResult } from "../initStagehand.js";
 import type { EvalInput } from "../types/evals.js";
 import { runClaudeCodeAgent } from "./claudeCodeRunner.js";
 import {
@@ -48,6 +49,10 @@ export interface BenchHarnessContext {
   v3?: V3;
   agent?: AgentInstance;
   page?: Page;
+  /** Stagehand v4 client (set for act/extract/observe tasks). */
+  stagehand?: StagehandInitResult["stagehand"];
+  /** v4 page object (set for act/extract/observe tasks). */
+  v4Page?: StagehandInitResult["page"];
   debugUrl: string;
   sessionUrl: string;
 }
@@ -143,6 +148,58 @@ export const stagehandHarness: BenchHarness = {
     const config = row.config;
     const agentMode = config.agentMode ?? input.agentMode;
     const isCUA = config.isCUA ?? input.isCUA;
+
+    // The deterministic suite (act/extract/observe, ported to the v4 SDK in
+    // place) runs on a v4 client. Dispatch is by category — the directory a
+    // task lives in — so tasks carry no marker and the runner stays v4-only.
+    const isDeterministicTask = ["act", "extract", "observe"].includes(task.primaryCategory);
+
+    if (isDeterministicTask) {
+      // The v4 SDK has no agent surface, and agent tasks are deliberately not
+      // ported. Fail loudly rather than silently fall back to v3 behavior.
+      if (createAgent || agentMode || isCUA) {
+        throw new EvalsError("The v4 SDK does not support agent tasks or agent modes.");
+      }
+      if (config.useApi) {
+        throw new EvalsError("--api is not supported with the v4 SDK.");
+      }
+      const { initStagehand } = await import("../initStagehand.js");
+      const v4Result = await initStagehand({
+        logger,
+        modelName: input.modelName,
+        environment: config.environment,
+      });
+      return {
+        ctx: {
+          harness: "stagehand",
+          row,
+          logger,
+          stagehand: v4Result.stagehand,
+          v4Page: v4Result.page,
+          debugUrl: "",
+          // Neither is reachable from the v4 client: StagehandBrowser is an
+          // opaque handle with no browserbaseSessionId (#2517).
+          sessionUrl: "",
+        },
+        cleanup: async () => {
+          try {
+            await v4Result.stagehand.close();
+          } catch (closeError) {
+            console.error(`Warning: Error closing v4 Stagehand for ${input.name}:`, closeError);
+          }
+          // `stagehand.close()` tears down the RPC client and context but leaves
+          // the browser it was handed running. initStagehand launched that
+          // browser, so this harness owns closing it — without this every task
+          // leaks a Chrome process (LOCAL) or a live Browserbase session, and
+          // the run never exits once the suite finishes.
+          try {
+            await v4Result.stagehand.browser.close();
+          } catch (closeError) {
+            console.error(`Warning: Error closing v4 browser for ${input.name}:`, closeError);
+          }
+        },
+      };
+    }
 
     if (config.useApi) {
       const provider = resolveProvider(input.modelName);

--- a/packages/evals/framework/benchHarness.ts
+++ b/packages/evals/framework/benchHarness.ts
@@ -42,20 +42,31 @@ export interface BenchHarnessExecuteInput extends BenchHarnessStartInput {
   signal?: AbortSignal;
 }
 
-export interface BenchHarnessContext {
+interface BenchHarnessContextBase {
   harness: Harness;
   row: BenchMatrixRow;
   logger: EvalLogger;
-  v3?: V3;
-  agent?: AgentInstance;
-  page?: Page;
-  /** Stagehand v4 client (set for act/extract/observe tasks). */
-  stagehand?: StagehandInitResult["stagehand"];
-  /** v4 page object (set for act/extract/observe tasks). */
-  v4Page?: StagehandInitResult["page"];
   debugUrl: string;
   sessionUrl: string;
 }
+
+/**
+ * The two context shapes are mutually exclusive: act/extract/observe tasks
+ * run on the v4 SDK, everything else (agent) runs on stagehand-v3. The `sdk`
+ * discriminant lets the runner narrow instead of probing optional fields.
+ */
+export type BenchHarnessContext =
+  | (BenchHarnessContextBase & {
+      sdk: "v4";
+      stagehand: StagehandInitResult["stagehand"];
+      page: StagehandInitResult["page"];
+    })
+  | (BenchHarnessContextBase & {
+      sdk: "v3";
+      v3: V3;
+      agent?: AgentInstance;
+      page: Page;
+    });
 
 export interface StartedBenchHarness {
   ctx: BenchHarnessContext;
@@ -174,12 +185,11 @@ export const stagehandHarness: BenchHarness = {
           harness: "stagehand",
           row,
           logger,
+          sdk: "v4",
           stagehand: v4Result.stagehand,
-          v4Page: v4Result.page,
-          debugUrl: "",
-          // Neither is reachable from the v4 client: StagehandBrowser is an
-          // opaque handle with no browserbaseSessionId (#2517).
-          sessionUrl: "",
+          page: v4Result.page,
+          debugUrl: v4Result.debugUrl,
+          sessionUrl: v4Result.sessionUrl,
         },
         cleanup: async () => {
           try {
@@ -188,7 +198,7 @@ export const stagehandHarness: BenchHarness = {
             console.error(`Warning: Error closing v4 Stagehand for ${input.name}:`, closeError);
           }
           // `stagehand.close()` tears down the RPC client and context but leaves
-          // the browser it was handed running. initStagehand launched that
+          // the browser it was handed running. initStagehand acquired that
           // browser, so this harness owns closing it — without this every task
           // leaks a Chrome process (LOCAL) or a live Browserbase session, and
           // the run never exits once the suite finishes.
@@ -197,6 +207,9 @@ export const stagehandHarness: BenchHarness = {
           } catch (closeError) {
             console.error(`Warning: Error closing v4 browser for ${input.name}:`, closeError);
           }
+          // browser.close() on a connected handle disconnects; releasing the
+          // session is a separate, best-effort call.
+          await v4Result.endSession().catch(() => {});
         },
       };
     }
@@ -248,6 +261,7 @@ export const stagehandHarness: BenchHarness = {
         harness: "stagehand",
         row,
         logger,
+        sdk: "v3",
         v3: v3Result.v3,
         agent: v3Result.agent,
         page: v3Result.v3.context.pages()[0],

--- a/packages/evals/framework/benchRunner.ts
+++ b/packages/evals/framework/benchRunner.ts
@@ -70,7 +70,11 @@ export async function executeBenchTask(
       const ctx = {
         v3: harnessCtx.v3,
         agent: harnessCtx.agent,
-        page: harnessCtx.page,
+        // Deterministic (act/extract/observe) tasks run on the v4 SDK: they
+        // receive the v4 client and its RPC-backed page in place of the
+        // Playwright page the v3 harness provides.
+        stagehand: harnessCtx.stagehand,
+        page: harnessCtx.v4Page ?? harnessCtx.page,
         logger,
         input,
         modelName: input.modelName,

--- a/packages/evals/framework/benchRunner.ts
+++ b/packages/evals/framework/benchRunner.ts
@@ -67,23 +67,28 @@ export async function executeBenchTask(
     harnessCtx = startedHarness.ctx;
     const taskModule = await loadTaskModuleFromPath(task.filePath, task.name);
     if (taskModule.definition) {
-      const ctx = {
-        v3: harnessCtx.v3,
-        agent: harnessCtx.agent,
-        // Deterministic (act/extract/observe) tasks run on the v4 SDK: they
-        // receive the v4 client and its RPC-backed page in place of the
-        // Playwright page the v3 harness provides.
-        stagehand: harnessCtx.stagehand,
-        page: harnessCtx.v4Page ?? harnessCtx.page,
+      const common = {
         logger,
         input,
         modelName: input.modelName,
         debugUrl: harnessCtx.debugUrl,
         sessionUrl: harnessCtx.sessionUrl,
       };
+      // Deterministic (act/extract/observe) tasks run on the v4 SDK: they
+      // receive the v4 client and its RPC-backed page in place of the
+      // Playwright page the v3 harness provides.
+      const ctx =
+        harnessCtx.sdk === "v4"
+          ? { ...common, stagehand: harnessCtx.stagehand, page: harnessCtx.page }
+          : { ...common, v3: harnessCtx.v3, agent: harnessCtx.agent, page: harnessCtx.page };
       return withBenchSessionUrls((await taskModule.definition.fn(ctx)) as TaskResult, harnessCtx);
     }
     if (taskModule.legacyFn) {
+      if (harnessCtx.sdk === "v4") {
+        // Unreachable through category dispatch (legacy tasks only exist
+        // outside act/extract/observe), but the narrowing keeps it honest.
+        throw new EvalsError(`Legacy task ${task.name} cannot run on the v4 harness context.`);
+      }
       return withBenchSessionUrls(
         await taskModule.legacyFn({
           v3: harnessCtx.v3,

--- a/packages/evals/framework/benchRunner.ts
+++ b/packages/evals/framework/benchRunner.ts
@@ -118,7 +118,7 @@ export async function executeBenchTask(
     return withBenchSessionUrls(
       {
         _success: false,
-        error: error instanceof Error ? JSON.parse(JSON.stringify(error, null, 2)) : String(error),
+        error: error instanceof Error ? error.message : String(error),
         logs: logger.getLogs(),
       },
       harnessCtx,

--- a/packages/evals/framework/claudeCodeRunner.ts
+++ b/packages/evals/framework/claudeCodeRunner.ts
@@ -72,17 +72,15 @@ export function buildClaudeCodePrompt(
 export function parseClaudeCodeResult(raw: string): ParsedClaudeCodeResult {
   const marker = "EVAL_RESULT:";
   const markerIndex = raw.lastIndexOf(marker);
+  const resultText = markerIndex >= 0 ? raw.slice(markerIndex + marker.length).trim() : raw.trim();
   const candidates =
     markerIndex >= 0
       ? [
-          raw.slice(markerIndex + marker.length).trim(),
-          raw
-            .slice(markerIndex + marker.length)
-            .trim()
-            .split(/\r?\n/, 1)[0]
-            ?.trim(),
+          resultText,
+          resultText.split(/\r?\n/, 1)[0]?.trim(),
+          extractFirstJsonObject(resultText),
         ]
-      : [raw.trim()];
+      : [resultText];
 
   for (const candidate of candidates) {
     if (!candidate) continue;
@@ -96,6 +94,40 @@ export function parseClaudeCodeResult(raw: string): ParsedClaudeCodeResult {
   }
 
   return { success: false, raw };
+}
+
+function extractFirstJsonObject(value: string): string | undefined {
+  const start = value.indexOf("{");
+  if (start < 0) return undefined;
+
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let index = start; index < value.length; index += 1) {
+    const character = value[index];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (character === "\\") {
+        escaped = true;
+      } else if (character === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (character === '"') {
+      inString = true;
+    } else if (character === "{") {
+      depth += 1;
+    } else if (character === "}") {
+      depth -= 1;
+      if (depth === 0) return value.slice(start, index + 1);
+    }
+  }
+
+  return undefined;
 }
 
 function tryParseClaudeCodeJson(

--- a/packages/evals/framework/claudeCodeRunner.ts
+++ b/packages/evals/framework/claudeCodeRunner.ts
@@ -75,11 +75,7 @@ export function parseClaudeCodeResult(raw: string): ParsedClaudeCodeResult {
   const resultText = markerIndex >= 0 ? raw.slice(markerIndex + marker.length).trim() : raw.trim();
   const candidates =
     markerIndex >= 0
-      ? [
-          resultText,
-          resultText.split(/\r?\n/, 1)[0]?.trim(),
-          extractFirstJsonObject(resultText),
-        ]
+      ? [resultText, resultText.split(/\r?\n/, 1)[0]?.trim(), extractFirstJsonObject(resultText)]
       : [resultText];
 
   for (const candidate of candidates) {

--- a/packages/evals/framework/verifierAdapter.ts
+++ b/packages/evals/framework/verifierAdapter.ts
@@ -1,9 +1,11 @@
 import {
   V3Evaluator,
+  loadApiKeyFromEnv,
   normalizeRubric,
   type AgentInstance,
   type AgentExecuteOptions,
   type AgentResult,
+  type AvailableModel,
   type EvaluationResult,
   type Rubric,
   type TaskSpec,
@@ -17,6 +19,34 @@ import { persistAdapterTrajectory } from "./harnesses/persistTrajectory.js";
 import { RubricCache } from "./rubricCache.js";
 import { TrajectoryRecorder } from "./trajectoryRecorder.js";
 import type { TaskResult } from "./types.js";
+
+const VERIFIER_MODEL_ENV = "EVAL_VERIFIER_MODEL";
+
+/**
+ * Build the shared rubric verifier. By default V3Evaluator keeps its existing
+ * model selection; EVAL_VERIFIER_MODEL makes the verifier independently
+ * selectable for external harnesses and normal Stagehand runs alike.
+ */
+export function createVerifierEvaluator(v3: V3): V3Evaluator {
+  const modelName = process.env[VERIFIER_MODEL_ENV]?.trim();
+  if (!modelName) {
+    return new V3Evaluator(v3, { backend: "verifier" });
+  }
+
+  const provider = modelName.includes("/") ? modelName.slice(0, modelName.indexOf("/")) : undefined;
+  const apiKey = loadApiKeyFromEnv(provider, () => {});
+  if (!apiKey) {
+    throw new Error(
+      `${VERIFIER_MODEL_ENV} is set to "${modelName}", but no API key was found for provider "${provider ?? "unknown"}".`,
+    );
+  }
+
+  return new V3Evaluator(v3, {
+    backend: "verifier",
+    modelName: modelName as AvailableModel,
+    modelClientOptions: { apiKey },
+  });
+}
 
 export interface RunWithVerifierOptions {
   v3: V3;
@@ -219,7 +249,7 @@ export async function gradeExternalTrajectory({
 }: GradeExternalTrajectoryOptions): Promise<TaskResult> {
   try {
     const trajectory = buildTrajectory();
-    const evaluator = new V3Evaluator(verifier.v3, { backend: "verifier" });
+    const evaluator = createVerifierEvaluator(verifier.v3);
 
     // Hydrate rubric — use precomputed if present, otherwise cache-or-generate.
     const { rubric } = await resolveRubricTraced(evaluator, {
@@ -305,7 +335,7 @@ export async function runWithVerifier(
   opts: RunWithVerifierOptions,
 ): Promise<RunWithVerifierResult> {
   const { v3, agent, taskSpec, dataset, agentOptions, runId, trajectoryRoot } = opts;
-  const evaluator = new V3Evaluator(v3, { backend: "verifier" });
+  const evaluator = createVerifierEvaluator(v3);
 
   // ── Resolve rubric ──────────────────────────────────────────────────────
   const { rubric: resolvedRubric } = await resolveRubricTraced(evaluator, {

--- a/packages/evals/framework/verifierAdapter.ts
+++ b/packages/evals/framework/verifierAdapter.ts
@@ -21,6 +21,7 @@ import { TrajectoryRecorder } from "./trajectoryRecorder.js";
 import type { TaskResult } from "./types.js";
 
 const VERIFIER_MODEL_ENV = "EVAL_VERIFIER_MODEL";
+const KEYLESS_VERIFIER_PROVIDERS = new Set(["bedrock", "ollama"]);
 
 /**
  * Build the shared rubric verifier. By default V3Evaluator keeps its existing
@@ -35,7 +36,7 @@ export function createVerifierEvaluator(v3: V3): V3Evaluator {
 
   const provider = modelName.includes("/") ? modelName.slice(0, modelName.indexOf("/")) : undefined;
   const apiKey = loadApiKeyFromEnv(provider, () => {});
-  if (!apiKey) {
+  if (!apiKey && !KEYLESS_VERIFIER_PROVIDERS.has(provider ?? "")) {
     throw new Error(
       `${VERIFIER_MODEL_ENV} is set to "${modelName}", but no API key was found for provider "${provider ?? "unknown"}".`,
     );
@@ -44,7 +45,7 @@ export function createVerifierEvaluator(v3: V3): V3Evaluator {
   return new V3Evaluator(v3, {
     backend: "verifier",
     modelName: modelName as AvailableModel,
-    modelClientOptions: { apiKey },
+    ...(apiKey ? { modelClientOptions: { apiKey } } : {}),
   });
 }
 

--- a/packages/evals/initStagehand.ts
+++ b/packages/evals/initStagehand.ts
@@ -123,7 +123,7 @@ export async function initStagehand({
   // tears down the RPC client without closing the browser.
   let page: Page | null;
   try {
-    page = await stagehand.context.activePage();
+    page = await stagehand.browser.context.activePage();
     if (!page) {
       throw new Error("Stagehand init: Stagehand initialized without an active page");
     }

--- a/packages/evals/initStagehand.ts
+++ b/packages/evals/initStagehand.ts
@@ -1,0 +1,127 @@
+/** Initializes the Stagehand client used by benchmark tasks. */
+import {
+  Stagehand,
+  browserbase,
+  localBrowser,
+  type Page,
+  type StagehandClientLoggingConfig,
+  type StagehandCreateOptions,
+} from "@browserbasehq/stagehand";
+import type { EvalLogger } from "./logger.js";
+import { resolveKey } from "./tui/welcomeStatus.js";
+
+export type InitStagehandArgs = {
+  logger: EvalLogger;
+  modelName: string;
+  systemPrompt?: string;
+  environment: "LOCAL" | "BROWSERBASE";
+};
+
+export type StagehandInitResult = {
+  stagehand: Stagehand;
+  page: Page;
+};
+
+const PROVIDER_API_KEY_ENV: Record<string, string[]> = {
+  openai: ["OPENAI_API_KEY"],
+  anthropic: ["ANTHROPIC_API_KEY"],
+  google: ["GOOGLE_GENERATIVE_AI_API_KEY", "GEMINI_API_KEY"],
+  groq: ["GROQ_API_KEY"],
+  cerebras: ["CEREBRAS_API_KEY"],
+};
+
+type StagehandLogEvent = Parameters<NonNullable<StagehandClientLoggingConfig["onLog"]>>[0];
+
+function createStagehandOnLog(logger: EvalLogger): (event: StagehandLogEvent) => void {
+  return (event) => {
+    // Debug lines are dropped rather than bridged: bridging them produces
+    // ~18MB Braintrust payloads that the API rejects.
+    if (event.level === "debug") return;
+
+    const level = event.level === "error" ? 0 : event.level === "warn" ? 1 : 2;
+    const auxiliary =
+      Object.keys(event.data).length > 0
+        ? {
+            data: { value: JSON.stringify(event.data), type: "object" as const },
+          }
+        : undefined;
+
+    logger.log({
+      category: "stagehand-sdk",
+      message: event.message,
+      level,
+      ...(auxiliary ? { auxiliary } : {}),
+    });
+  };
+}
+
+export async function initStagehand({
+  logger,
+  modelName,
+  systemPrompt,
+  environment,
+}: InitStagehandArgs): Promise<StagehandInitResult> {
+  const provider = modelName.includes("/") ? modelName.split("/")[0].toLowerCase() : undefined;
+  const keyEnvVars = provider ? (PROVIDER_API_KEY_ENV[provider] ?? []) : [];
+  const apiKey = keyEnvVars.map((name) => resolveKey(name).value).find(Boolean);
+  if (!apiKey) {
+    throw new Error(
+      `Stagehand init: no API key found for model "${modelName}". ` +
+        `Stagehand requires an explicit model API key ` +
+        `(checked: ${keyEnvVars.join(", ") || "no known provider prefix"}).`,
+    );
+  }
+
+  // `browser` is a factory-built handle rather than a config object:
+  // StagehandBrowser is branded (#2517), so an object literal cannot satisfy it.
+  let browser;
+  if (environment === "BROWSERBASE") {
+    // Checked here rather than left to zod: BrowserbaseLaunchOptions requires a
+    // non-empty key, so an absent one would surface as a parse error instead.
+    const browserbaseApiKey =
+      resolveKey("BROWSERBASE_API_KEY").value || resolveKey("BB_API_KEY").value;
+    if (!browserbaseApiKey) {
+      throw new Error(
+        "Stagehand init: BROWSERBASE_API_KEY or BB_API_KEY is required for BROWSERBASE runs",
+      );
+    }
+    browser = await browserbase.launch({ apiKey: browserbaseApiKey });
+  } else {
+    browser = await localBrowser.launch({ headless: false });
+  }
+
+  // `Stagehand.create` does not reliably close the handle when init fails —
+  // without this a failed task leaks a Chrome process (LOCAL) or a live
+  // Browserbase session (BROWSERBASE) for the rest of the run.
+  let stagehand: Stagehand;
+  try {
+    stagehand = await Stagehand.create({
+      browser,
+      // selfHeal defaults off on the server; without it the heal_* benchmarks
+      // pass while measuring nothing.
+      selfHeal: true,
+      model: { modelName, apiKey } as NonNullable<StagehandCreateOptions["model"]>,
+      ...(systemPrompt ? { systemPrompt } : {}),
+      logging: { onLog: createStagehandOnLog(logger) },
+    });
+  } catch (error) {
+    await browser.close().catch(() => {});
+    throw error;
+  }
+
+  const page = await stagehand.context.activePage();
+  if (!page) {
+    await stagehand.close();
+    throw new Error("Stagehand init: Stagehand initialized without an active page");
+  }
+
+  // No sessionUrl: StagehandBrowser is an opaque branded handle and does not
+  // expose the Browserbase session id (#2517). To restore the Braintrust
+  // click-through to a session replay, create the session first (as
+  // core/targets/browserbase.ts does) and attach with
+  // `browserbase.connect({ sessionId })`.
+  return {
+    stagehand,
+    page,
+  };
+}

--- a/packages/evals/initStagehand.ts
+++ b/packages/evals/initStagehand.ts
@@ -85,7 +85,16 @@ export async function initStagehand({
         "Stagehand init: BROWSERBASE_API_KEY or BB_API_KEY is required for BROWSERBASE runs",
       );
     }
-    browser = await browserbase.launch({ apiKey: browserbaseApiKey });
+    // Passed explicitly, matching initV3 and core/targets/browserbase: the
+    // Browserbase SDK does not read BROWSERBASE_PROJECT_ID from the
+    // environment, and omitting it lands sessions in the key's default
+    // project — the wrong one for keys that own several.
+    const projectId =
+      resolveKey("BROWSERBASE_PROJECT_ID").value || resolveKey("BB_PROJECT_ID").value;
+    browser = await browserbase.launch({
+      apiKey: browserbaseApiKey,
+      ...(projectId ? { projectId } : {}),
+    });
   } else {
     browser = await localBrowser.launch({ headless: false });
   }
@@ -109,10 +118,19 @@ export async function initStagehand({
     throw error;
   }
 
-  const page = await stagehand.context.activePage();
-  if (!page) {
-    await stagehand.close();
-    throw new Error("Stagehand init: Stagehand initialized without an active page");
+  // Page acquisition failures need the same cleanup as create failures: the
+  // client is up and the browser is running, and stagehand.close() alone
+  // tears down the RPC client without closing the browser.
+  let page: Page | null;
+  try {
+    page = await stagehand.context.activePage();
+    if (!page) {
+      throw new Error("Stagehand init: Stagehand initialized without an active page");
+    }
+  } catch (error) {
+    await stagehand.close().catch(() => {});
+    await browser.close().catch(() => {});
+    throw error;
   }
 
   // No sessionUrl: StagehandBrowser is an opaque branded handle and does not

--- a/packages/evals/initStagehand.ts
+++ b/packages/evals/initStagehand.ts
@@ -8,18 +8,24 @@ import {
   type StagehandCreateOptions,
 } from "@browserbasehq/stagehand";
 import type { EvalLogger } from "./logger.js";
+import { launchRunnerProvidedBrowserbaseChrome } from "./core/targets/browserbase.js";
 import { resolveKey } from "./tui/welcomeStatus.js";
 
 export type InitStagehandArgs = {
   logger: EvalLogger;
   modelName: string;
-  systemPrompt?: string;
   environment: "LOCAL" | "BROWSERBASE";
 };
 
 export type StagehandInitResult = {
   stagehand: Stagehand;
   page: Page;
+  /** Session replay URL (Browserbase; empty for LOCAL). */
+  sessionUrl: string;
+  /** Live debugger URL (Browserbase, best-effort; empty for LOCAL). */
+  debugUrl: string;
+  /** Releases the Browserbase session (no-op for LOCAL). */
+  endSession: () => Promise<void>;
 };
 
 const PROVIDER_API_KEY_ENV: Record<string, string[]> = {
@@ -58,7 +64,6 @@ function createStagehandOnLog(logger: EvalLogger): (event: StagehandLogEvent) =>
 export async function initStagehand({
   logger,
   modelName,
-  systemPrompt,
   environment,
 }: InitStagehandArgs): Promise<StagehandInitResult> {
   const provider = modelName.includes("/") ? modelName.split("/")[0].toLowerCase() : undefined;
@@ -75,9 +80,12 @@ export async function initStagehand({
   // `browser` is a factory-built handle rather than a config object:
   // StagehandBrowser is branded (#2517), so an object literal cannot satisfy it.
   let browser;
+  let sessionUrl = "";
+  let debugUrl = "";
+  let endSession: () => Promise<void> = async () => {};
   if (environment === "BROWSERBASE") {
-    // Checked here rather than left to zod: BrowserbaseLaunchOptions requires a
-    // non-empty key, so an absent one would surface as a parse error instead.
+    // Checked here rather than left to zod: BrowserbaseConnectOptions requires
+    // a non-empty key, so an absent one would surface as a parse error instead.
     const browserbaseApiKey =
       resolveKey("BROWSERBASE_API_KEY").value || resolveKey("BB_API_KEY").value;
     if (!browserbaseApiKey) {
@@ -85,16 +93,26 @@ export async function initStagehand({
         "Stagehand init: BROWSERBASE_API_KEY or BB_API_KEY is required for BROWSERBASE runs",
       );
     }
-    // Passed explicitly, matching initV3 and core/targets/browserbase: the
-    // Browserbase SDK does not read BROWSERBASE_PROJECT_ID from the
-    // environment, and omitting it lands sessions in the key's default
-    // project — the wrong one for keys that own several.
-    const projectId =
-      resolveKey("BROWSERBASE_PROJECT_ID").value || resolveKey("BB_PROJECT_ID").value;
-    browser = await browserbase.launch({
-      apiKey: browserbaseApiKey,
-      ...(projectId ? { projectId } : {}),
-    });
+    // The session is created first and attached with connect() rather than
+    // launched through the SDK: StagehandBrowser is an opaque branded handle
+    // with no browserbaseSessionId (#2517), so launching would leave the
+    // harness without the session/debug URLs that TaskResults and the
+    // Braintrust replay click-through report. The shared creator also passes
+    // the project id explicitly (the Browserbase SDK does not read
+    // BROWSERBASE_PROJECT_ID from the environment).
+    const session = await launchRunnerProvidedBrowserbaseChrome();
+    sessionUrl = session.sessionUrl;
+    debugUrl = session.debugUrl ?? "";
+    endSession = session.cleanup;
+    try {
+      browser = await browserbase.connect({
+        apiKey: browserbaseApiKey,
+        sessionId: session.sessionId,
+      });
+    } catch (error) {
+      await endSession().catch(() => {});
+      throw error;
+    }
   } else {
     browser = await localBrowser.launch({ headless: false });
   }
@@ -110,11 +128,11 @@ export async function initStagehand({
       // pass while measuring nothing.
       selfHeal: true,
       model: { modelName, apiKey } as NonNullable<StagehandCreateOptions["model"]>,
-      ...(systemPrompt ? { systemPrompt } : {}),
       logging: { onLog: createStagehandOnLog(logger) },
     });
   } catch (error) {
     await browser.close().catch(() => {});
+    await endSession().catch(() => {});
     throw error;
   }
 
@@ -130,16 +148,15 @@ export async function initStagehand({
   } catch (error) {
     await stagehand.close().catch(() => {});
     await browser.close().catch(() => {});
+    await endSession().catch(() => {});
     throw error;
   }
 
-  // No sessionUrl: StagehandBrowser is an opaque branded handle and does not
-  // expose the Browserbase session id (#2517). To restore the Braintrust
-  // click-through to a session replay, create the session first (as
-  // core/targets/browserbase.ts does) and attach with
-  // `browserbase.connect({ sessionId })`.
   return {
     stagehand,
     page,
+    sessionUrl,
+    debugUrl,
+    endSession,
   };
 }

--- a/packages/evals/tests/framework/benchRunner.test.ts
+++ b/packages/evals/tests/framework/benchRunner.test.ts
@@ -76,11 +76,13 @@ describe("bench runner", () => {
       `,
     );
 
+    // A non-deterministic category: act/extract/observe route to the v4
+    // client, and legacy tasks with v3 session URLs only exist outside them.
     const task: DiscoveredTask = {
-      name: "act/session_url_task",
+      name: "combination/session_url_task",
       tier: "bench",
-      primaryCategory: "act",
-      categories: ["act"],
+      primaryCategory: "combination",
+      categories: ["combination"],
       tags: [],
       filePath: taskFile,
       isLegacy: true,

--- a/packages/evals/tests/framework/benchRunner.test.ts
+++ b/packages/evals/tests/framework/benchRunner.test.ts
@@ -110,4 +110,48 @@ describe("bench runner", () => {
     });
     expect(closeMock).toHaveBeenCalledTimes(1);
   });
+
+  it("preserves task error messages", async () => {
+    const taskDir = makeTempDir();
+    const taskFile = path.join(taskDir, "thrown_task.mjs");
+    fs.writeFileSync(
+      taskFile,
+      `
+      export const thrown_task = async () => {
+        throw new Error("diagnostic failure");
+      };
+      `,
+    );
+
+    const task: DiscoveredTask = {
+      name: "combination/thrown_task",
+      tier: "bench",
+      primaryCategory: "combination",
+      categories: ["combination"],
+      tags: [],
+      filePath: taskFile,
+      isLegacy: true,
+    };
+
+    const result = await executeBenchTask(
+      {
+        name: task.name,
+        modelName: "gpt-4o-mini" as AvailableModel,
+      },
+      task,
+      {
+        tasks: [task],
+        registry: makeRegistry([task]),
+        environment: "LOCAL",
+        harness: "stagehand",
+        verbose: false,
+      },
+    );
+
+    expect(result).toMatchObject({
+      _success: false,
+      error: "diagnostic failure",
+    });
+    expect(closeMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/evals/tests/framework/benchRunner.test.ts
+++ b/packages/evals/tests/framework/benchRunner.test.ts
@@ -77,12 +77,13 @@ describe("bench runner", () => {
     );
 
     // A non-deterministic category: act/extract/observe route to the v4
-    // client, and legacy tasks with v3 session URLs only exist outside them.
+    // client, and legacy v3 tasks only exist under agent/ now that the
+    // combination and experimental suites are gone.
     const task: DiscoveredTask = {
-      name: "combination/session_url_task",
+      name: "agent/session_url_task",
       tier: "bench",
-      primaryCategory: "combination",
-      categories: ["combination"],
+      primaryCategory: "agent",
+      categories: ["agent"],
       tags: [],
       filePath: taskFile,
       isLegacy: true,
@@ -124,10 +125,10 @@ describe("bench runner", () => {
     );
 
     const task: DiscoveredTask = {
-      name: "combination/thrown_task",
+      name: "agent/thrown_task",
       tier: "bench",
-      primaryCategory: "combination",
-      categories: ["combination"],
+      primaryCategory: "agent",
+      categories: ["agent"],
       tags: [],
       filePath: taskFile,
       isLegacy: true,

--- a/packages/evals/tests/framework/claudeCodeRunner.test.ts
+++ b/packages/evals/tests/framework/claudeCodeRunner.test.ts
@@ -70,6 +70,18 @@ describe("claude code runner helpers", () => {
     });
   });
 
+  it("parses result JSON wrapped in Markdown emphasis", () => {
+    expect(
+      parseClaudeCodeResult(
+        '**EVAL_RESULT: {"success":true,"summary":"found {the result}","finalAnswer":"done"}**',
+      ),
+    ).toMatchObject({
+      success: true,
+      summary: "found {the result}",
+      finalAnswer: "done",
+    });
+  });
+
   it("identifies max-turn SDK errors", () => {
     expect(isClaudeCodeMaxTurnsError(new Error("Reached maximum number of turns (20)"))).toBe(true);
     expect(isClaudeCodeMaxTurnsError("network failed")).toBe(false);

--- a/packages/evals/tests/framework/gradeExternalTrajectory.test.ts
+++ b/packages/evals/tests/framework/gradeExternalTrajectory.test.ts
@@ -9,11 +9,15 @@ const mockState = vi.hoisted(() => ({
     outcomeSuccess: true,
     processScore: 0.92,
   } as Record<string, unknown>,
+  evaluatorOptions: undefined as unknown,
 }));
 
 vi.mock("stagehand-v3", async (importOriginal) => {
   const mod = await importOriginal<typeof import("stagehand-v3")>();
   class FakeV3Evaluator {
+    constructor(_v3: unknown, options: unknown) {
+      mockState.evaluatorOptions = options;
+    }
     async verify() {
       return mockState.evaluationResult;
     }
@@ -62,14 +66,20 @@ describe("gradeExternalTrajectory", () => {
 
   let savedSuccessMode: string | undefined;
   let savedPersist: string | undefined;
+  let savedVerifierModel: string | undefined;
+  let savedGroqApiKey: string | undefined;
 
   beforeEach(() => {
     savedSuccessMode = process.env.EVAL_SUCCESS_MODE;
     savedPersist = process.env.VERIFIER_PERSIST_TRAJECTORIES;
+    savedVerifierModel = process.env.EVAL_VERIFIER_MODEL;
+    savedGroqApiKey = process.env.GROQ_API_KEY;
     delete process.env.EVAL_SUCCESS_MODE;
+    delete process.env.EVAL_VERIFIER_MODEL;
     // Keep persistAdapterTrajectory on its no-write path (it defaults to
     // persisting outside CI).
     process.env.VERIFIER_PERSIST_TRAJECTORIES = "0";
+    mockState.evaluatorOptions = undefined;
   });
 
   afterEach(() => {
@@ -77,6 +87,10 @@ describe("gradeExternalTrajectory", () => {
     else process.env.EVAL_SUCCESS_MODE = savedSuccessMode;
     if (savedPersist === undefined) delete process.env.VERIFIER_PERSIST_TRAJECTORIES;
     else process.env.VERIFIER_PERSIST_TRAJECTORIES = savedPersist;
+    if (savedVerifierModel === undefined) delete process.env.EVAL_VERIFIER_MODEL;
+    else process.env.EVAL_VERIFIER_MODEL = savedVerifierModel;
+    if (savedGroqApiKey === undefined) delete process.env.GROQ_API_KEY;
+    else process.env.GROQ_API_KEY = savedGroqApiKey;
     mockState.evaluationResult = { outcomeSuccess: true, processScore: 0.92 };
   });
 
@@ -112,5 +126,18 @@ describe("gradeExternalTrajectory", () => {
 
     expect(result._success).toBe(true);
     expect(result.processScore).toBe(0.95);
+  });
+
+  it("selects the verifier model independently from the harness model", async () => {
+    process.env.EVAL_VERIFIER_MODEL = " groq/llama-3.3-70b-versatile ";
+    process.env.GROQ_API_KEY = "test-groq-key";
+
+    await grade({});
+
+    expect(mockState.evaluatorOptions).toEqual({
+      backend: "verifier",
+      modelName: "groq/llama-3.3-70b-versatile",
+      modelClientOptions: { apiKey: "test-groq-key" },
+    });
   });
 });


### PR DESCRIPTION
The deterministic suite is ported to the v4 SDK in place (#2494), but the
bench harness only ever built a v3 instance, so every ported task failed
its defineBenchV4Task guard before its own code ran.

- initStagehand: v4 client factory beside initV3, mirroring its
  environment/key resolution. selfHeal is on (the server defaults it off,
  which would let the heal_* benchmarks pass while measuring nothing) and
  debug SDK log lines are dropped rather than bridged (bridging produces
  ~18MB Braintrust payloads the API rejects). If init fails after launch,
  the browser is closed rather than leaked.
- benchHarness: act/extract/observe dispatch to the v4 client by task
  category — the directory a task lives in — so tasks carry no marker and
  no flag exists. Agent tasks and --api fail loudly on the v4 path.
  Cleanup closes the browser as well as the client: stagehand.close()
  tears down the RPC client but leaves the browser running, which leaked
  one Chrome process (LOCAL) or live Browserbase session per task and
  kept the CLI from exiting.
- benchRunner: forwards { stagehand, page } from the harness context into
  the task context.
- benchRunner.test: the legacy-task fixture moves from category act to
  combination — act now correctly routes to the v4 client, and legacy v3
  tasks only exist outside the deterministic categories.

Merge after #2494: category dispatch assumes the a/e/o tasks are the v4
ports; with the v3 tasks still in place it hands them a v4 context.

Verified on Browserbase (3-model matrix, -c 10): act 35/40, extract
24/25, observe 11/12 union — at or above the v3 baseline per category.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs act/extract/observe benchmark tasks on the v4 `@browserbasehq/stagehand` client. Restores Browserbase session/debug URLs, makes the verifier model selectable, and hardens init/cleanup to prevent leaked browsers and lost errors.

- **New Features**
  - Added `initStagehand` to launch local or Browserbase with self‑heal on, resolve provider API keys, pass `BROWSERBASE_PROJECT_ID`/`BB_PROJECT_ID`, forward SDK logs (drop debug), and create the Browserbase session first, attach via `browserbase.connect`, and provide `sessionUrl`/`debugUrl` with explicit session release on cleanup and failures.
  - Dispatches act/extract/observe by category to v4; tasks receive `{ stagehand, page }`. Blocks agent tasks/modes and `--api` on the v4 path. Context is now discriminated (`sdk: "v4" | "v3"`); legacy tasks on a v4 context throw.
  - Verifier model selectable via `EVAL_VERIFIER_MODEL`; resolves provider key and applies it to the verifier backend, supporting keyless providers like `bedrock` and `ollama`.
  - Introduced `@browserbasehq/stagehand-integrations` with a persistent code‑mode executor, MCP stdio server, env config, and bundled `SKILL.md`/`REFERENCE.md`.

- **Bug Fixes**
  - Close the v4 client and launched browser on cleanup and on init/page‑acquisition failures; use the browser context to obtain `activePage`.
  - Preserve benchmark error messages (`error.message`); parse decorated Claude Code results by extracting the first JSON object after `EVAL_RESULT`.

<sup>Written for commit 555b7836668816721f22d3358b47eaa079a2d975. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

