### PR TITLE
sdk: give LLM-backed RPCs a real default deadline

### DIFF
--- a/packages/sdk-ts/src/rpcClient.ts
+++ b/packages/sdk-ts/src/rpcClient.ts
@@ -58,6 +58,12 @@ const TRACER = trace.getTracer("@browserbasehq/stagehand");
 const W3C_TRACE_CONTEXT_PROPAGATOR = new W3CTraceContextPropagator();
 const MAX_PENDING_NOTIFICATIONS = 100;
 const RPC_RESPONSE_GRACE_MS = 10_000;
+/**
+ * Default budget for LLM-backed operations when the caller sets no timeout.
+ * act/extract/observe are LLM round trips over full-page context — routinely
+ * longer than the grace window alone, which is sized for transport stalls.
+ */
+const RPC_LLM_DEFAULT_TIMEOUT_MS = 180_000;
 
 const RPCClientOptionsBaseSchema = z
   .object({
@@ -482,6 +488,12 @@ function rpcResponseTimeoutMs(method: string, params: unknown): number | undefin
     case StagehandMethods.stagehandAct.name:
     case StagehandMethods.stagehandExtract.name:
     case StagehandMethods.stagehandObserve.name:
+      // Without a caller timeout the deadline would be the grace window alone
+      // (10s) — an LLM round trip rarely fits, so bare calls fail with
+      // "RPC request timed out" on any slow page or remote browser.
+      operationTimeoutMs =
+        numericProperty(recordProperty(params, "options"), "timeout") ?? RPC_LLM_DEFAULT_TIMEOUT_MS;
+      break;
     case StagehandMethods.pageGoto.name:
     case StagehandMethods.pageReload.name:
     case StagehandMethods.pageGoBack.name:


### PR DESCRIPTION
act/extract/observe with no caller timeout were capped at the bare
response grace window (10s), which is sized for transport stalls — an
LLM round trip over full-page context routinely exceeds it, so bare
calls failed with "RPC request timed out: stagehand.extract" on slow
pages and remote browsers. Callers passing options.timeout were
unaffected, which is why only default-config usage broke.

LLM-backed methods now default to a 180s operation budget plus grace
when the caller sets none. Navigation and wait methods keep their
existing behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set a real default timeout for LLM-backed RPCs to prevent failures when no caller timeout is set. `act`, `extract`, and `observe` now use a 180s operation budget plus the 10s grace window.

- **Bug Fixes**
  - If `options.timeout` is not provided, LLM-backed methods default to 180,000 ms instead of 10,000 ms to avoid "RPC request timed out" on slow pages or remote browsers.
  - Navigation and wait RPCs are unchanged. Explicit `options.timeout` still takes precedence.

<sup>Written for commit 862a5eec0a8f9111da8da2eb97a23aba43aad69c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

