### PR TITLE
Fix order of Go Chrome arguments

### DIFF
--- a/packages/sdk-go/chrome_launcher.go
+++ b/packages/sdk-go/chrome_launcher.go
@@ -220,7 +220,6 @@ func buildChromeArgs(options LocalBrowserLaunchOptions, port int, userDataDir st
 		fmt.Sprintf("--remote-debugging-port=%d", port),
 		"--user-data-dir="+userDataDir,
 	)
-	args = append(args, options.Args...)
 
 	if options.Headless {
 		args = append(args, "--headless")
@@ -259,6 +258,7 @@ func buildChromeArgs(options LocalBrowserLaunchOptions, port int, userDataDir st
 	if options.IgnoreHTTPSErrors {
 		args = append(args, "--ignore-certificate-errors")
 	}
+	args = append(args, options.Args...)
 	return append(args, "about:blank")
 }
 

--- a/packages/sdk-go/chrome_launcher_test.go
+++ b/packages/sdk-go/chrome_launcher_test.go
@@ -98,6 +98,19 @@ func TestBuildChromeArgsSupportsLocalBrowserOptions(t *testing.T) {
 	}
 }
 
+func TestBuildChromeArgsPutsCallerArgumentsLast(t *testing.T) {
+	t.Setenv("CI", "")
+	got := buildChromeArgs(LocalBrowserLaunchOptions{
+		Locale: "de-CH",
+		Args:   []string{"--lang=fr", "--custom-flag=value"},
+	}, 9_222, "/tmp/profile")
+	wantSuffix := []string{"--lang=fr", "--custom-flag=value", "about:blank"}
+	gotSuffix := got[len(got)-len(wantSuffix):]
+	if !slices.Equal(gotSuffix, wantSuffix) {
+		t.Fatalf("buildChromeArgs() suffix = %#v, want %#v", gotSuffix, wantSuffix)
+	}
+}
+
 func TestBuildChromeArgsCanIgnoreDefaultArgs(t *testing.T) {
 	t.Run("all", func(t *testing.T) {
 		got := buildChromeArgs(


### PR DESCRIPTION
## Summary

Put caller-provided Chrome arguments after SDK-generated arguments in Go, matching TypeScript and Python and allowing explicit overrides.

Adds regression coverage for argument ordering.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reordered Chrome launch args in the Go SDK so caller-provided args come last. This matches TypeScript and Python behavior and lets user flags override defaults.

- **Bug Fixes**
  - Append `options.Args` after SDK-generated args so user flags take precedence.
  - Added a regression test to confirm caller args are last and precede `about:blank`.

<sup>Written for commit d18c20467efce080aa2c016602765faf315ba170. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

