### PR TITLE
docs(v4): include Python input aliases in reference types

### DIFF
--- a/packages/docs/v4/reference/context.mdx
+++ b/packages/docs/v4/reference/context.mdx
@@ -436,7 +436,7 @@ Set or clear the context's domain policy.
 await stagehand.context.set_domain_policy(None)
 ```
 
-<ParamField path="policy" type="DomainPolicy | None">
+<ParamField path="policy" type="DomainPolicy | DomainPolicyInput | None">
   The policy to apply, or null/None to clear it.
 
 <ParamField path="policy.allowed_domains" type="list[str]" optional>

--- a/packages/docs/v4/reference/stagehand.mdx
+++ b/packages/docs/v4/reference/stagehand.mdx
@@ -784,7 +784,7 @@ Perform an action described in natural language.
 result = await stagehand.act("Click the sign in button")
 ```
 
-<ParamField path="instruction" type="Action | str">
+<ParamField path="instruction" type="Action | ActionInput | str">
   A natural-language action to perform, or an action returned by `observe()`.
 
   <ParamField path="instruction.selector" type="str">


### PR DESCRIPTION
Updates the Python `act` and `set_domain_policy` parameter types to include their public TypedDict input aliases. This restores the SDK-reference contract after the generated Python input types landed.

Tested: `pnpm --filter @browserbasehq/stagehand-docs test:unit` (19/19).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added Python input alias types to the v4 reference: `instruction` now shows `Action | ActionInput | str`, and `policy` shows `DomainPolicy | DomainPolicyInput | None`. This aligns the docs with the generated Python types and restores the expected SDK-reference contract.

<sup>Written for commit 072c672b0dd123fb45a02b65c53a98ac17735d3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

