### PR TITLE
Add context to browser handles

### DIFF
--- a/packages/sdk-go/browser.go
+++ b/packages/sdk-go/browser.go
@@ -32,6 +32,7 @@ type Browser struct {
 	provider       BrowserProvider
 	origin         BrowserOrigin
 	claimed        bool
+	browserContext *BrowserContext
 	closeRequested bool
 	closeResult    error
 	cdp            *cdpClient
@@ -72,6 +73,19 @@ func (browser *Browser) Closed() bool {
 	browser.mu.Lock()
 	defer browser.mu.Unlock()
 	return browser.closeRequested
+}
+
+// Context returns the Stagehand context attached to this browser.
+func (browser *Browser) Context() (*BrowserContext, error) {
+	if browser == nil {
+		return nil, ErrNotInitialized
+	}
+	browser.mu.Lock()
+	defer browser.mu.Unlock()
+	if browser.browserContext == nil {
+		return nil, ErrNotInitialized
+	}
+	return browser.browserContext, nil
 }
 
 // Close tears down the browser-owned resources once and memoizes the result.
@@ -159,5 +173,33 @@ func releaseBrowserClaim(browser *Browser) {
 	}
 	browser.mu.Lock()
 	browser.claimed = false
+	browser.mu.Unlock()
+}
+
+func attachBrowserContext(browser *Browser, browserContext *BrowserContext) error {
+	if browser == nil {
+		return errors.New("browser is required")
+	}
+	if browserContext == nil {
+		return errors.New("browser context is required")
+	}
+	browser.mu.Lock()
+	defer browser.mu.Unlock()
+	if !browser.claimed {
+		return errors.New("cannot attach a browser context before Stagehand claims the browser")
+	}
+	if browser.browserContext != nil {
+		return errors.New("this browser already has a Stagehand context")
+	}
+	browser.browserContext = browserContext
+	return nil
+}
+
+func detachBrowserContext(browser *Browser) {
+	if browser == nil {
+		return
+	}
+	browser.mu.Lock()
+	browser.browserContext = nil
 	browser.mu.Unlock()
 }

--- a/packages/sdk-go/browser_test.go
+++ b/packages/sdk-go/browser_test.go
@@ -20,6 +20,37 @@ func newBrowserTestCDP(t *testing.T) *cdpClient {
 }
 
 func TestBrowserClaimAndCloseSemantics(t *testing.T) {
+	t.Run("context requires a Stagehand attachment", func(t *testing.T) {
+		browser := &Browser{}
+		if _, err := browser.Context(); !errors.Is(err, ErrNotInitialized) {
+			t.Fatalf("Context() error = %v, want ErrNotInitialized", err)
+		}
+		if err := attachBrowserContext(browser, nil); err == nil || err.Error() != "browser context is required" {
+			t.Fatalf("attachBrowserContext(nil) error = %v", err)
+		}
+		if err := attachBrowserContext(browser, &BrowserContext{}); err == nil {
+			t.Fatal("attachBrowserContext() before claim error = nil")
+		}
+		if _, err := claimBrowser(browser); err != nil {
+			t.Fatalf("claimBrowser() error = %v", err)
+		}
+		browserContext := &BrowserContext{}
+		if err := attachBrowserContext(browser, browserContext); err != nil {
+			t.Fatalf("attachBrowserContext() error = %v", err)
+		}
+		got, err := browser.Context()
+		if err != nil || got != browserContext {
+			t.Fatalf("Context() = %p, %v; want %p, nil", got, err, browserContext)
+		}
+		if err := attachBrowserContext(browser, &BrowserContext{}); err == nil {
+			t.Fatal("second attachBrowserContext() error = nil")
+		}
+		detachBrowserContext(browser)
+		if _, err := browser.Context(); !errors.Is(err, ErrNotInitialized) {
+			t.Fatalf("Context() after detach error = %v, want ErrNotInitialized", err)
+		}
+	})
+
 	t.Run("claim release and reclaim", func(t *testing.T) {
 		browser := &Browser{}
 		if _, err := claimBrowser(browser); err != nil {

--- a/packages/sdk-python/src/stagehand/browser.py
+++ b/packages/sdk-python/src/stagehand/browser.py
@@ -10,7 +10,10 @@ import tempfile
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Literal, Protocol
+from typing import TYPE_CHECKING, Any, Literal, Protocol
+
+if TYPE_CHECKING:
+    from .browser_context import BrowserContext
 
 from ._generated.input_types import BrowserbaseBrowserSettings, ProxyConfig
 from ._generated.models import (
@@ -96,6 +99,7 @@ class StagehandBrowser:
         "_claimed",
         "_close_callback",
         "_close_task",
+        "_context",
         "_origin",
         "_provider",
     )
@@ -117,6 +121,7 @@ class StagehandBrowser:
         self._close_callback = close
         self._claimed = False
         self._close_task: asyncio.Task[None] | None = None
+        self._context: BrowserContext | None = None
 
     @property
     def provider(self) -> Literal["local", "browserbase"]:
@@ -129,6 +134,15 @@ class StagehandBrowser:
     @property
     def closed(self) -> bool:
         return self._close_task is not None
+
+    @property
+    def context(self) -> BrowserContext:
+        if self._context is None:
+            raise RuntimeError(
+                "Browser context is unavailable. Attach the browser with "
+                "await Stagehand.create(browser=browser)."
+            )
+        return self._context
 
     def close(self) -> Awaitable[None]:
         if self._close_task is None:
@@ -157,6 +171,21 @@ def _release_browser(browser: StagehandBrowser) -> None:
     if not isinstance(browser, StagehandBrowser):
         raise TypeError("browser must be created by local_browser or browserbase")
     browser._claimed = False
+
+
+def _attach_browser_context(
+    browser: StagehandBrowser,
+    context: BrowserContext,
+) -> None:
+    if not browser._claimed:
+        raise RuntimeError("Cannot attach a browser context before Stagehand claims the browser")
+    if browser._context is not None:
+        raise RuntimeError("This browser already has a Stagehand context")
+    browser._context = context
+
+
+def _detach_browser_context(browser: StagehandBrowser) -> None:
+    browser._context = None
 
 
 def _browser_session_metadata(

--- a/packages/sdk-python/tests/test_browser.py
+++ b/packages/sdk-python/tests/test_browser.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
-from typing import ClassVar, Literal
+from typing import ClassVar, Literal, cast
 
 import pytest
 from pydantic import ValidationError
@@ -17,8 +17,10 @@ from stagehand.browser import (
     _DEFAULT_CHROME_FLAGS,
     _WEBMCP_CHROME_FLAG,
     StagehandBrowser,
+    _attach_browser_context,
     _claim_browser,
     _connect_browser,
+    _detach_browser_context,
     _launch_local_browser,
     _local_browser_flags,
     _release_browser,
@@ -26,6 +28,7 @@ from stagehand.browser import (
     browserbase,
     local_browser,
 )
+from stagehand.browser_context import BrowserContext
 from stagehand.client_models import LocalBrowserLaunchOptions, LocalViewport
 
 
@@ -149,6 +152,31 @@ async def test_claim_release_reclaim_and_errors(fake_cdp: type[FakeCDPClient]) -
         _claim_browser(handle)
     with pytest.raises(TypeError, match="browser must be created by local_browser or browserbase"):
         _claim_browser(object())
+
+
+async def test_context_requires_stagehand_attachment(fake_cdp: type[FakeCDPClient]) -> None:
+    handle = await _connected_handle(FakeSource(keep_alive=True))
+    context = cast(BrowserContext, object())
+    try:
+        with pytest.raises(RuntimeError, match="Browser context is unavailable"):
+            _ = handle.context
+        with pytest.raises(RuntimeError, match="before Stagehand claims"):
+            _attach_browser_context(handle, context)
+
+        _claim_browser(handle)
+        _attach_browser_context(handle, context)
+        assert handle.context is context
+
+        with pytest.raises(RuntimeError, match="already has a Stagehand context"):
+            _attach_browser_context(handle, cast(BrowserContext, object()))
+
+        _detach_browser_context(handle)
+        with pytest.raises(RuntimeError, match="Browser context is unavailable"):
+            _ = handle.context
+    finally:
+        _detach_browser_context(handle)
+        _release_browser(handle)
+        await handle.close()
 
 
 def test_handle_construction_is_nominal() -> None:

--- a/packages/sdk-ts/src/browser/index.ts
+++ b/packages/sdk-ts/src/browser/index.ts
@@ -4,6 +4,7 @@ import type {
   LocalBrowserConnectOptions,
   LocalBrowserLaunchOptions,
 } from "../clientSchemas.js";
+import type { BrowserContext } from "../browserContext.js";
 
 export type {
   BrowserbaseConnectOptions,
@@ -27,6 +28,7 @@ export interface StagehandBrowser {
   readonly [stagehandBrowserBrand]: true;
   readonly provider: StagehandBrowserProvider;
   readonly origin: StagehandBrowserOrigin;
+  readonly context: BrowserContext;
   readonly closed: boolean;
   close(): Promise<void>;
 }
@@ -44,6 +46,7 @@ export interface BrowserbaseBrowser {
 type BrowserHandleInternals = {
   claimed: boolean;
   attachment: unknown;
+  context?: BrowserContext;
   close: () => Promise<void> | void;
   closePromise?: Promise<void>;
 };
@@ -63,6 +66,16 @@ class StagehandBrowserHandle implements StagehandBrowser {
 
   get closed(): boolean {
     return browserHandleInternals.get(this)?.closePromise !== undefined;
+  }
+
+  get context(): BrowserContext {
+    const context = requireBrowserHandleInternals(this).context;
+    if (!context) {
+      throw new Error(
+        "Browser context is unavailable. Attach the browser with await Stagehand.create({ browser }).",
+      );
+    }
+    return context;
   }
 
   close(): Promise<void> {
@@ -103,6 +116,27 @@ export function claimStagehandBrowserHandle<Attachment>(browser: StagehandBrowse
 export function releaseStagehandBrowserHandle(browser: StagehandBrowser): void {
   const internals = requireBrowserHandleInternals(browser);
   internals.claimed = false;
+}
+
+/** @internal */
+export function attachStagehandBrowserContext(
+  browser: StagehandBrowser,
+  context: BrowserContext,
+): void {
+  const internals = requireBrowserHandleInternals(browser);
+  if (!internals.claimed) {
+    throw new Error("Cannot attach a browser context before Stagehand claims the browser");
+  }
+  if (internals.context) {
+    throw new Error("This browser already has a Stagehand context");
+  }
+  internals.context = context;
+}
+
+/** @internal */
+export function detachStagehandBrowserContext(browser: StagehandBrowser): void {
+  const internals = requireBrowserHandleInternals(browser);
+  internals.context = undefined;
 }
 
 export function isStagehandBrowser(value: unknown): value is StagehandBrowser {

--- a/packages/sdk-ts/tests/browser/context.test.ts
+++ b/packages/sdk-ts/tests/browser/context.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+import type { BrowserContext } from "../../src/browserContext.js";
+import {
+  attachStagehandBrowserContext,
+  claimStagehandBrowserHandle,
+  createStagehandBrowserHandle,
+  detachStagehandBrowserContext,
+} from "../../src/browser/index.js";
+
+function createBrowser() {
+  return createStagehandBrowserHandle({
+    provider: "local",
+    origin: "launched",
+    attachment: {},
+    close: vi.fn(),
+  });
+}
+
+describe("Stagehand browser context", () => {
+  it("is unavailable until Stagehand claims the browser and attaches a context", () => {
+    const browser = createBrowser();
+    const context = {} as BrowserContext;
+
+    expect(() => browser.context).toThrow(
+      "Browser context is unavailable. Attach the browser with await Stagehand.create({ browser }).",
+    );
+    expect(() => attachStagehandBrowserContext(browser, context)).toThrow(
+      "before Stagehand claims the browser",
+    );
+
+    claimStagehandBrowserHandle(browser);
+    attachStagehandBrowserContext(browser, context);
+
+    expect(browser.context).toBe(context);
+  });
+
+  it("rejects replacement and becomes unavailable after detachment", () => {
+    const browser = createBrowser();
+    const context = {} as BrowserContext;
+    claimStagehandBrowserHandle(browser);
+    attachStagehandBrowserContext(browser, context);
+
+    expect(() => attachStagehandBrowserContext(browser, {} as BrowserContext)).toThrow(
+      "already has a Stagehand context",
+    );
+
+    detachStagehandBrowserContext(browser);
+
+    expect(() => browser.context).toThrow("Browser context is unavailable");
+  });
+});

--- a/packages/sdk-ts/tests/browser/contracts.test.ts
+++ b/packages/sdk-ts/tests/browser/contracts.test.ts
@@ -17,6 +17,7 @@ import type {
   StagehandBrowserOrigin,
   StagehandBrowserProvider,
 } from "../../src/browser/index.js";
+import type { BrowserContext } from "../../src/browserContext.js";
 
 describe("browser API contracts", () => {
   it("defines nominal, provider-independent browser handles", () => {
@@ -24,6 +25,7 @@ describe("browser API contracts", () => {
     expectTypeOf<StagehandBrowserProvider>().toEqualTypeOf<"local" | "browserbase">();
     expectTypeOf<StagehandBrowser["origin"]>().toEqualTypeOf<StagehandBrowserOrigin>();
     expectTypeOf<StagehandBrowserOrigin>().toEqualTypeOf<"launched" | "connected">();
+    expectTypeOf<StagehandBrowser["context"]>().toEqualTypeOf<BrowserContext>();
     expectTypeOf<StagehandBrowser["close"]>().returns.toEqualTypeOf<Promise<void>>();
     expectTypeOf<{
       provider: "local";


### PR DESCRIPTION
# why

Browser context belongs to the factory-created browser handle and should only become available after Stagehand attaches.

# what changed

Adds guarded context access plus internal attach/detach primitives across TypeScript, Python, and Go. Includes focused lifecycle tests.

No changeset: this targets the unreleased v4 API.

# test plan

- TypeScript browser contract tests
- Python browser tests
- Go browser tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `browser.context` to Stagehand browser handles and gates it behind Stagehand claim + attach. Aligns the v4 API with STG-2763 by preferring `browser.context` over `stagehand.context`.

- **New Features**
  - Exposes typed `browser.context` on handles in TypeScript (`packages/sdk-ts`), Python (`packages/sdk-python`), and Go (`packages/sdk-go`); available only after claim + attach; errors on early access or re-attach; cleared on detach.
  - Adds attach/detach helpers and lifecycle tests across SDKs: `attachStagehandBrowserContext`/`detachStagehandBrowserContext` (TS), `_attach_browser_context`/`_detach_browser_context` (Python), and `attachBrowserContext`/`detachBrowserContext` (Go); includes a new TS context test and a contract update.

<sup>Written for commit abafcbc0397b77a17c5cccb6799a5d3733643162. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

