### PR TITLE
Wire Stagehand lifecycle to browser context

### DIFF
--- a/packages/sdk-go/stagehand.go
+++ b/packages/sdk-go/stagehand.go
@@ -22,7 +22,6 @@ type Stagehand struct {
 	mu                        sync.RWMutex
 	rpc                       protocolClient
 	browser                   *Browser
-	context                   *BrowserContext
 	initialized               bool
 	closed                    bool
 	closeResult               error
@@ -114,7 +113,15 @@ func createWithAdapters(ctx context.Context, options CreateOptions, adapters cli
 		cancelCleanup()
 		return nil, errors.Join(err, closeErr, browserErr)
 	}
-	client.context = &BrowserContext{rpc: rpc}
+	if err := attachBrowserContext(client.browser, &BrowserContext{rpc: rpc}); err != nil {
+		if client.removeLLMHandler != nil {
+			client.removeLLMHandler()
+		}
+		client.removeNotificationHandler()
+		rpcErr := rpc.close()
+		releaseBrowserClaim(options.Browser)
+		return nil, errors.Join(err, rpcErr)
+	}
 	client.initialized = true
 	return client, nil
 }
@@ -122,11 +129,12 @@ func createWithAdapters(ctx context.Context, options CreateOptions, adapters cli
 // Context returns the initialized browser context.
 func (s *Stagehand) Context() (*BrowserContext, error) {
 	s.mu.RLock()
-	defer s.mu.RUnlock()
-	if s.context == nil {
+	browser := s.browser
+	s.mu.RUnlock()
+	if browser == nil {
 		return nil, ErrNotInitialized
 	}
-	return s.context, nil
+	return browser.Context()
 }
 
 // Browser returns the factory-created browser handle attached to Stagehand.
@@ -275,7 +283,7 @@ func (s *Stagehand) Close(ctx context.Context) error {
 	}
 
 	var closeErr error
-	if s.context != nil && s.rpc != nil {
+	if s.initialized && s.rpc != nil {
 		var result StagehandCloseResult
 		closeErr = s.rpc.call(ctx, "stagehand.close", EmptyParams{}, &result)
 		if errors.Is(closeErr, ErrCDPConnectionClosed) {
@@ -295,7 +303,7 @@ func (s *Stagehand) Close(ctx context.Context) error {
 		rpcErr = s.rpc.close()
 		s.rpc = nil
 	}
-	s.context = nil
+	detachBrowserContext(s.browser)
 	s.initialized = false
 	s.closed = true
 	s.closeResult = errors.Join(closeErr, rpcErr)
@@ -356,7 +364,7 @@ func (s *Stagehand) targetPage(ctx context.Context, page *Page) (*Page, error) {
 	if page != nil {
 		return page, nil
 	}
-	browserContext, err := s.Context()
+	browserContext, err := s.browser.Context()
 	if err != nil {
 		return nil, err
 	}

--- a/packages/sdk-python/src/stagehand/stagehand.py
+++ b/packages/sdk-python/src/stagehand/stagehand.py
@@ -39,7 +39,14 @@ from ._generated.models import (
     StagehandObserveParams,
 )
 from ._generated.protocol_version import STAGEHAND_PROTOCOL_VERSION
-from .browser import StagehandBrowser, _claim_browser, _ClaimedBrowser, _release_browser
+from .browser import (
+    StagehandBrowser,
+    _attach_browser_context,
+    _claim_browser,
+    _ClaimedBrowser,
+    _detach_browser_context,
+    _release_browser,
+)
 from .browser_context import BrowserContext
 from .cdp_client import CDPConnectionClosedError
 from .client_models import (
@@ -75,7 +82,6 @@ class Stagehand:
             )
         self._browser_handle = browser
         self._create_config = create_config
-        self._browser_context: BrowserContext | None = None
         self._rpc_client: RPCClient | None = None
         self._remove_notification_listener: Callable[[], None] | None = None
         self._remove_client_llm_handler: Callable[[], None] | None = None
@@ -152,9 +158,7 @@ class Stagehand:
 
     @property
     def context(self) -> BrowserContext:
-        if self._browser_context is None:
-            raise RuntimeError(_UNAVAILABLE_MESSAGE)
-        return self._browser_context
+        return self._browser_handle.context
 
     @property
     def browser(self) -> StagehandBrowser:
@@ -199,7 +203,7 @@ class Stagehand:
             init_params,
             StagehandInitResult,
         )
-        self._browser_context = BrowserContext(rpc_client)
+        _attach_browser_context(self._browser_handle, BrowserContext(rpc_client))
         self._initialized = True
 
     async def act(
@@ -224,7 +228,7 @@ class Stagehand:
             )
             if value is not None
         })
-        target_page = page or await self.context.active_page()
+        target_page = page or await self.browser.context.active_page()
         if target_page is None:
             raise RuntimeError("Stagehand has no active page")
         params = StagehandActParams.model_validate({
@@ -262,7 +266,7 @@ class Stagehand:
             )
             if value is not None
         })
-        target_page = page or await self.context.active_page()
+        target_page = page or await self.browser.context.active_page()
         if target_page is None:
             raise RuntimeError("Stagehand has no active page")
         params = StagehandObserveParams(page_id=target_page.page_id, instruction=instruction)
@@ -330,7 +334,7 @@ class Stagehand:
             )
             if value is not None
         })
-        target_page = page or await self.context.active_page()
+        target_page = page or await self.browser.context.active_page()
         if target_page is None:
             raise RuntimeError("Stagehand has no active page")
         params = StagehandExtractParams(
@@ -352,7 +356,7 @@ class Stagehand:
     async def close(self) -> None:
         async def close_impl() -> None:
             try:
-                if self._browser_context is not None and self._rpc_client is not None:
+                if self._initialized and self._rpc_client is not None:
                     try:
                         await self._rpc_client.send(
                             "stagehand.close",
@@ -428,7 +432,7 @@ class Stagehand:
             self._remove_notification_listener = None
         rpc_client = self._rpc_client
         self._rpc_client = None
-        self._browser_context = None
+        _detach_browser_context(self._browser_handle)
         self._initialized = False
         if rpc_client is not None:
             await rpc_client.close(RuntimeError("Stagehand closed"), close_transport=False)

--- a/packages/sdk-python/tests/test_stagehand.py
+++ b/packages/sdk-python/tests/test_stagehand.py
@@ -462,7 +462,7 @@ async def test_close_is_memoized_and_never_closes_browser_or_transport(
     assert recording.close_transport_flags == [False]
     assert browser.closed is False
     assert transport.close_calls == 0
-    with pytest.raises(RuntimeError, match="Stagehand is unavailable.*Stagehand.create"):
+    with pytest.raises(RuntimeError, match="Browser context is unavailable.*Stagehand.create"):
         _ = stagehand.context
     with pytest.raises(RuntimeError, match="Stagehand is unavailable.*Stagehand.create"):
         await stagehand.metrics()

--- a/packages/sdk-ts/src/stagehand.ts
+++ b/packages/sdk-ts/src/stagehand.ts
@@ -36,6 +36,7 @@ import {
   type ClaimedStagehandBrowser,
   type StagehandBrowser,
 } from "./browser/factories.js";
+import { attachStagehandBrowserContext, detachStagehandBrowserContext } from "./browser/index.js";
 import { withStagehandInitDeadline } from "./timeouts.js";
 
 type ProtocolExtractResult = import("../../protocol/types.js").ExtractResult;
@@ -53,7 +54,6 @@ const isZodSchema = (value: unknown): value is z.ZodType =>
   typeof value.safeParse === "function";
 
 export class Stagehand {
-  browserContext: BrowserContext | undefined;
   isInitialized = false;
   rpcClient: RPCClient | undefined;
   removeNotificationListener: (() => void) | undefined;
@@ -99,12 +99,7 @@ export class Stagehand {
   }
 
   get context(): BrowserContext {
-    if (!this.browserContext) {
-      throw new Error(
-        "Stagehand is unavailable. Create a new instance with await Stagehand.create().",
-      );
-    }
-    return this.browserContext;
+    return this.browserHandle.context;
   }
 
   get browser(): StagehandBrowser {
@@ -140,7 +135,7 @@ export class Stagehand {
         stagehandCreateParamsForWorker(createConfig, browser),
         signal,
       );
-      this.browserContext = new BrowserContext(rpcClient);
+      attachStagehandBrowserContext(this.browserHandle, new BrowserContext(rpcClient));
     } catch (error) {
       this.removeClientLLMHandler?.();
       this.removeClientLLMHandler = undefined;
@@ -161,7 +156,7 @@ export class Stagehand {
   async act(instruction: Action, options?: StagehandClientActOptions): Promise<ActResult>;
   async act(instruction: string | Action, options?: StagehandClientActOptions): Promise<ActResult> {
     const { page, ...protocolOptions } = StagehandClientActOptionsSchema.parse(options ?? {});
-    const targetPage = page ?? (await this.context.activePage());
+    const targetPage = page ?? (await this.browser.context.activePage());
     if (!targetPage) throw new Error("Stagehand has no active page.");
     const response = await this.connectedRpcClient.send(StagehandMethods.stagehandAct, {
       pageId: targetPage.pageId,
@@ -177,7 +172,7 @@ export class Stagehand {
     options?: StagehandClientObserveOptions,
   ): Promise<ObserveResult> {
     const { page, ...protocolOptions } = StagehandClientObserveOptionsSchema.parse(options ?? {});
-    const targetPage = page ?? (await this.context.activePage());
+    const targetPage = page ?? (await this.browser.context.activePage());
     if (!targetPage) throw new Error("Stagehand has no active page.");
     const response = await this.connectedRpcClient.send(StagehandMethods.stagehandObserve, {
       pageId: targetPage.pageId,
@@ -208,7 +203,7 @@ export class Stagehand {
     const { page, ...protocolOptions } = StagehandClientExtractOptionsSchema.parse(
       resolvedOptions ?? {},
     );
-    const targetPage = page ?? (await this.context.activePage());
+    const targetPage = page ?? (await this.browser.context.activePage());
     if (!targetPage) throw new Error("Stagehand has no active page.");
     const response = await this.connectedRpcClient.send(StagehandMethods.stagehandExtract, {
       pageId: targetPage.pageId,
@@ -225,9 +220,8 @@ export class Stagehand {
 
   close(): Promise<void> {
     this.closePromise ??= (async () => {
-      const context = this.browserContext;
       try {
-        if (context) {
+        if (this.isInitialized) {
           try {
             await this.rpcClient?.send(StagehandMethods.stagehandClose, {});
           } catch (error) {
@@ -241,7 +235,7 @@ export class Stagehand {
         this.removeNotificationListener = undefined;
         this.rpcClient?.close(new Error("Stagehand closed"), { closeTransport: false });
         this.rpcClient = undefined;
-        this.browserContext = undefined;
+        detachStagehandBrowserContext(this.browserHandle);
         this.isInitialized = false;
       }
     })();

--- a/packages/sdk-ts/tests/object-wrapper.test.ts
+++ b/packages/sdk-ts/tests/object-wrapper.test.ts
@@ -16,6 +16,11 @@ import {
   WebMCPTool,
 } from "../src/index.js";
 import { RPCClient } from "../src/rpcClient.js";
+import {
+  attachStagehandBrowserContext,
+  claimStagehandBrowserHandle,
+  createStagehandBrowserHandle,
+} from "../src/browser/index.js";
 
 type ProtocolCall = { method: string; params: unknown };
 
@@ -68,10 +73,17 @@ class FakeProtocolClient extends RPCClient {
 }
 
 function createStagehandWithClientForTest(client: RPCClient): Stagehand {
-  // This lightweight wrapper intentionally has no browser handle; these tests must not use .browser.
+  const browser = createStagehandBrowserHandle({
+    provider: "local",
+    origin: "connected",
+    attachment: {},
+    close: () => {},
+  });
+  claimStagehandBrowserHandle(browser);
+  attachStagehandBrowserContext(browser, new BrowserContext(client));
   const stagehand = Object.create(Stagehand.prototype) as Stagehand;
+  Object.assign(stagehand, { browserHandle: browser });
   stagehand.rpcClient = client;
-  stagehand.browserContext = new BrowserContext(client);
   stagehand.isInitialized = true;
   return stagehand;
 }

--- a/packages/sdk-ts/tests/stagehandCreate.test.ts
+++ b/packages/sdk-ts/tests/stagehandCreate.test.ts
@@ -70,10 +70,15 @@ describe("Stagehand.create", () => {
     });
     const browser = await localBrowser.connect({ cdpUrl: cdp.webSocketDebuggerUrl });
 
+    expect(() => browser.context).toThrow(
+      "Browser context is unavailable. Attach the browser with await Stagehand.create({ browser }).",
+    );
+
     const stagehand = await Stagehand.create({ browser, apiKey: "bb_worker_key" });
 
     expect(stagehand.initialized).toBe(true);
     expect(stagehand.browser).toBe(browser);
+    expect(browser.context).toBe(stagehand.context);
     expect("init" in stagehand).toBe(false);
     expect(cdp.requests[0]).toMatchObject({
       method: "stagehand.init",
@@ -421,8 +426,8 @@ describe("Stagehand.create", () => {
     expect(stagehand.initialized).toBe(false);
     expect(cdp.requestsFor("stagehand.close")).toHaveLength(1);
     expect(cdp.close).not.toHaveBeenCalled();
-    expect(() => stagehand.context).toThrow(
-      "Stagehand is unavailable. Create a new instance with await Stagehand.create().",
+    expect(() => browser.context).toThrow(
+      "Browser context is unavailable. Attach the browser with await Stagehand.create({ browser }).",
     );
     await expect(stagehand.metrics()).rejects.toThrow(
       "Stagehand is unavailable. Create a new instance with await Stagehand.create().",


### PR DESCRIPTION
# why

The browser-owned context must track Stagehand initialization and teardown without changing browser resource ownership.

# what changed

Attaches context after successful Stagehand creation, routes default-page lookup through the browser, and detaches context on close across all SDKs.

No changeset: this targets the unreleased v4 API.

# test plan

- TypeScript Stagehand lifecycle tests
- Python Stagehand lifecycle tests
- Go SDK tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired the Stagehand lifecycle to the Browser so a shared `browser.context` attaches on init and detaches on close. Also adds file upload via `locator.setInputFiles()` and lets `extract()` run without a schema by default.

- **New Features**
  - Upload files to `<input type="file">` with `locator.setInputFiles()` across `sdk-ts`, `sdk-python`, and `sdk-go` (local paths or in-memory payloads; 50 MiB limit; pass empty to clear).
  - `extract()` schema is now optional; defaults to an object with a string `extraction` field when omitted.

- **Migration**
  - Use `browser.context` instead of `stagehand.context` (STG-2763); default page lookup goes through `browser.context.activePage()`.
  - `close()` sends `stagehand.close` only when initialized and never closes the Browser or transport.
  - Before attach, `browser.context` throws “Browser context is unavailable … Attach the browser with await Stagehand.create({ browser }).”; after `Stagehand.create`, access it via `stagehand.browser.context`.

<sup>Written for commit 17230359c8e6b442298d7638b2cfbbeccbe5386d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

