### PR TITLE
Migrate SDK consumers to browser context

### DIFF
--- a/packages/docs/v4/basics/act.mdx
+++ b/packages/docs/v4/basics/act.mdx
@@ -329,9 +329,11 @@ When running on Browserbase, Stagehand can cache `act()` results server-side. Re
 <View title="TypeScript" icon="js">
 ```typescript
 // Enable server-side caching for the entire instance
-const stagehand = new Stagehand({
+const browser = await browserbase.launch({
   apiKey: process.env.BROWSERBASE_API_KEY,
-  browser: { type: "browserbase" },
+});
+const stagehand = await Stagehand.create({
+  browser,
   cache: true,
 });
 
@@ -352,9 +354,11 @@ console.log(result.metadata.cache.status); // "HIT", "MISS", or "DISABLED"
 from stagehand import CacheOptions, Stagehand
 
 # Enable server-side caching for the entire instance
-stagehand = Stagehand(
+browser = await browserbase.launch(
     api_key=os.environ["BROWSERBASE_API_KEY"],
-    browser="browserbase",
+)
+stagehand = await Stagehand.create(
+    browser=browser,
     cache=True,
 )
 
@@ -375,9 +379,12 @@ print(result.metadata.cache.status)  # "HIT", "MISS", or "DISABLED"
 // Enable server-side caching for the entire instance
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 instanceCache := stagehand.CacheEnabled(true)
-client := stagehand.New(stagehand.StagehandClientInitParams{
-	APIKey:  &apiKey,
-	Browser: stagehand.BrowserbaseClientBrowserSource{},
+browser, err := stagehand.LaunchBrowserbase(ctx, stagehand.BrowserbaseLaunchOptions{APIKey: apiKey})
+if err != nil {
+	return err
+}
+client, err := stagehand.Create(ctx, stagehand.CreateOptions{
+	Browser: browser,
 	Cache:   &instanceCache,
 })
 
@@ -416,14 +423,13 @@ Stagehand v4 drives the browser directly over the Chrome DevTools Protocol, so t
 
 <View title="TypeScript" icon="js">
 ```typescript
-const stagehand = new Stagehand({
+const browser = await browserbase.launch({
   apiKey: process.env.BROWSERBASE_API_KEY,
-  browser: { type: "browserbase" },
 });
-await stagehand.init();
+const stagehand = await Stagehand.create({ browser });
 
 // Open a second page in the same browser context
-const blogPage = await stagehand.context.newPage();
+const blogPage = await browser.context.newPage();
 await blogPage.goto("https://www.example.com/blog");
 
 // Use act with that specific page
@@ -435,14 +441,13 @@ await stagehand.act("click the next page button", {
 
 <View title="Python" icon="python">
 ```python
-stagehand = Stagehand(
+browser = await browserbase.launch(
     api_key=os.environ["BROWSERBASE_API_KEY"],
-    browser="browserbase",
 )
-await stagehand.init()
+stagehand = await Stagehand.create(browser=browser)
 
 # Open a second page in the same browser context
-blog_page = await stagehand.context.new_page()
+blog_page = await browser.context.new_page()
 await blog_page.goto("https://www.example.com/blog")
 
 # Use act with that specific page
@@ -453,15 +458,16 @@ await stagehand.act("click the next page button", page=blog_page)
 <View title="Go" icon="golang">
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
-client := stagehand.New(stagehand.StagehandClientInitParams{
-	APIKey:  &apiKey,
-	Browser: stagehand.BrowserbaseClientBrowserSource{},
-})
-if err := client.Init(ctx); err != nil {
+browser, err := stagehand.LaunchBrowserbase(ctx, stagehand.BrowserbaseLaunchOptions{APIKey: apiKey})
+if err != nil {
+	return err
+}
+client, err := stagehand.Create(ctx, stagehand.CreateOptions{Browser: browser})
+if err != nil {
 	return err
 }
 
-browserContext, err := client.Context()
+browserContext, err := browser.Context()
 if err != nil {
 	return err
 }
@@ -554,15 +560,15 @@ Enable server-side caching with `cache` when running on Browserbase. The first t
 
 <View title="TypeScript" icon="js">
 ```typescript
-import { Stagehand } from "@browserbasehq/stagehand";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 
-const stagehand = new Stagehand({
+const browser = await browserbase.launch({
   apiKey: process.env.BROWSERBASE_API_KEY,
-  browser: { type: "browserbase" },
+});
+const stagehand = await Stagehand.create({
+  browser,
   cache: { threshold: 1 }, // Actions are cached after one identical result
 });
-
-await stagehand.init();
 
 // First run makes an LLM call and records the action
 await stagehand.act("click the login button");
@@ -574,15 +580,15 @@ await stagehand.act("click the login button");
 
 <View title="Python" icon="python">
 ```python
-from stagehand import CacheOptions, Stagehand
+from stagehand import CacheOptions, Stagehand, browserbase
 
-stagehand = Stagehand(
+browser = await browserbase.launch(
     api_key=os.environ["BROWSERBASE_API_KEY"],
-    browser="browserbase",
+)
+stagehand = await Stagehand.create(
+    browser=browser,
     cache=CacheOptions(threshold=1),  # Actions are cached after one identical result
 )
-
-await stagehand.init()
 
 # First run makes an LLM call and records the action
 await stagehand.act("click the login button")
@@ -597,13 +603,12 @@ await stagehand.act("click the login button")
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 cache := stagehand.CacheWithThreshold(1) // Actions are cached after one identical result
 
-client := stagehand.New(stagehand.StagehandClientInitParams{
-	APIKey:  &apiKey,
-	Browser: stagehand.BrowserbaseClientBrowserSource{},
-	Cache:   &cache,
-})
-
-if err := client.Init(ctx); err != nil {
+browser, err := stagehand.LaunchBrowserbase(ctx, stagehand.BrowserbaseLaunchOptions{APIKey: apiKey})
+if err != nil {
+	return err
+}
+client, err := stagehand.Create(ctx, stagehand.CreateOptions{Browser: browser, Cache: &cache})
+if err != nil {
 	return err
 }
 

--- a/packages/docs/v4/basics/observe.mdx
+++ b/packages/docs/v4/basics/observe.mdx
@@ -51,7 +51,7 @@ Use `observe()` to discover actionable elements on a page. Here's how to find a 
 
 <View title="TypeScript" icon="js">
 ```typescript
-const page = await stagehand.context.activePage();
+const [page] = await browser.context.pages();
 if (!page) {
   throw new Error("Stagehand initialized without an active page");
 }
@@ -62,7 +62,7 @@ const { data: actions } = await stagehand.observe("find the learn more button");
 
 <View title="Python" icon="python">
 ```python
-page = await stagehand.context.active_page()
+page = (await browser.context.pages())[0]
 if page is None:
     raise RuntimeError("Stagehand initialized without an active page")
 await page.goto("https://example.com")
@@ -478,9 +478,11 @@ When running on Browserbase, Stagehand can cache `observe()` results server-side
 <View title="TypeScript" icon="js">
 ```typescript
 // Enable server-side caching for the entire instance
-const stagehand = new Stagehand({
+const browser = await browserbase.launch({
   apiKey: process.env.BROWSERBASE_API_KEY,
-  browser: { type: "browserbase" },
+});
+const stagehand = await Stagehand.create({
+  browser,
   cache: true,
 });
 
@@ -494,9 +496,11 @@ const { data: actions } = await stagehand.observe("find the login button", { cac
 from stagehand import Stagehand
 
 # Enable server-side caching for the entire instance
-stagehand = Stagehand(
+browser = await browserbase.launch(
     api_key=os.environ["BROWSERBASE_API_KEY"],
-    browser="browserbase",
+)
+stagehand = await Stagehand.create(
+    browser=browser,
     cache=True,
 )
 
@@ -510,9 +514,12 @@ result = await stagehand.observe("find the login button", cache=False)
 // Enable server-side caching for the entire instance
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 instanceCache := stagehand.CacheEnabled(true)
-client := stagehand.New(stagehand.StagehandClientInitParams{
-	APIKey:  &apiKey,
-	Browser: stagehand.BrowserbaseClientBrowserSource{},
+browser, err := stagehand.LaunchBrowserbase(ctx, stagehand.BrowserbaseLaunchOptions{APIKey: apiKey})
+if err != nil {
+	return err
+}
+client, err := stagehand.Create(ctx, stagehand.CreateOptions{
+	Browser: browser,
 	Cache:   &instanceCache,
 })
 
@@ -540,14 +547,13 @@ Stagehand v4 drives the browser directly over the Chrome DevTools Protocol, so t
 
 <View title="TypeScript" icon="js">
 ```typescript
-const stagehand = new Stagehand({
+const browser = await browserbase.launch({
   apiKey: process.env.BROWSERBASE_API_KEY,
-  browser: { type: "browserbase" },
 });
-await stagehand.init();
+const stagehand = await Stagehand.create({ browser });
 
 // Open a second page in the same browser context
-const productsPage = await stagehand.context.newPage();
+const productsPage = await browser.context.newPage();
 await productsPage.goto("https://www.example.com/products");
 
 // Use observe with that specific page
@@ -559,14 +565,13 @@ const { data: actions } = await stagehand.observe("find all product cards", {
 
 <View title="Python" icon="python">
 ```python
-stagehand = Stagehand(
+browser = await browserbase.launch(
     api_key=os.environ["BROWSERBASE_API_KEY"],
-    browser="browserbase",
 )
-await stagehand.init()
+stagehand = await Stagehand.create(browser=browser)
 
 # Open a second page in the same browser context
-products_page = await stagehand.context.new_page()
+products_page = await browser.context.new_page()
 await products_page.goto("https://www.example.com/products")
 
 # Use observe with that specific page
@@ -580,15 +585,16 @@ result = await stagehand.observe(
 <View title="Go" icon="golang">
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
-client := stagehand.New(stagehand.StagehandClientInitParams{
-	APIKey:  &apiKey,
-	Browser: stagehand.BrowserbaseClientBrowserSource{},
-})
-if err := client.Init(ctx); err != nil {
+browser, err := stagehand.LaunchBrowserbase(ctx, stagehand.BrowserbaseLaunchOptions{APIKey: apiKey})
+if err != nil {
+	return err
+}
+client, err := stagehand.Create(ctx, stagehand.CreateOptions{Browser: browser})
+if err != nil {
 	return err
 }
 
-browserContext, err := client.Context()
+browserContext, err := browser.Context()
 if err != nil {
 	return err
 }
@@ -915,7 +921,7 @@ cachedObserve := func(ctx context.Context, instruction string) ([]stagehand.Acti
 <View title="TypeScript" icon="js">
 ```typescript
 // Check page state before observing
-const page = await stagehand.context.activePage();
+const [page] = await browser.context.pages();
 if (!page) {
   throw new Error("Stagehand initialized without an active page");
 }
@@ -933,7 +939,7 @@ if (actions.length === 0) {
 <View title="Python" icon="python">
 ```python
 # Check page state before observing
-page = await stagehand.context.active_page()
+page = (await browser.context.pages())[0]
 if page is None:
     raise RuntimeError("Stagehand initialized without an active page")
 await page.wait_for_load_state("domcontentloaded")

--- a/packages/docs/v4/configuration/browser.mdx
+++ b/packages/docs/v4/configuration/browser.mdx
@@ -12,17 +12,21 @@ Stagehand connects to a browser through a browser source. There are three:
 
 <View title="TypeScript" icon="js">
 ```typescript
-new Stagehand({ apiKey: process.env.BROWSERBASE_API_KEY, browser: { type: "browserbase" } }); // default
-new Stagehand({ browser: { type: "local", headless: true } });
-new Stagehand({ browser: { type: "cdp", cdpUrl: "http://127.0.0.1:9222" } });
+const cloud = await browserbase.launch({ apiKey: process.env.BROWSERBASE_API_KEY });
+const local = await localBrowser.launch({ headless: true });
+const connected = await localBrowser.connect({ cdpUrl: "http://127.0.0.1:9222" });
+
+await Stagehand.create({ browser: cloud });
 ```
 </View>
 
 <View title="Python" icon="python">
 ```python
-Stagehand(api_key=os.environ["BROWSERBASE_API_KEY"], browser="browserbase")  # default
-Stagehand(browser="local", headless=True)
-Stagehand(browser="cdp", cdp_url="http://127.0.0.1:9222")
+cloud = await browserbase.launch(api_key=os.environ["BROWSERBASE_API_KEY"])
+local = await local_browser.launch(headless=True)
+connected = await local_browser.connect(cdp_url="http://127.0.0.1:9222")
+
+await Stagehand.create(browser=cloud)
 ```
 </View>
 
@@ -30,16 +34,13 @@ Stagehand(browser="cdp", cdp_url="http://127.0.0.1:9222")
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 
-stagehand.New(stagehand.StagehandClientInitParams{ // default
-	APIKey:  &apiKey,
-	Browser: stagehand.BrowserbaseClientBrowserSource{},
+cloud, _ := stagehand.LaunchBrowserbase(ctx, stagehand.BrowserbaseLaunchOptions{APIKey: apiKey})
+local, _ := stagehand.LaunchLocalBrowser(ctx, &stagehand.LocalBrowserLaunchOptions{Headless: true})
+connected, _ := stagehand.ConnectLocalBrowser(ctx, stagehand.LocalBrowserConnectOptions{
+	CDPURL: "http://127.0.0.1:9222",
 })
-stagehand.New(stagehand.StagehandClientInitParams{
-	Browser: stagehand.LocalBrowserSource{Headless: true},
-})
-stagehand.New(stagehand.StagehandClientInitParams{
-	Browser: stagehand.CDPBrowserSource{CDPURL: "http://127.0.0.1:9222"},
-})
+
+client, _ := stagehand.Create(ctx, stagehand.CreateOptions{Browser: cloud})
 ```
 </View>
 
@@ -57,31 +58,25 @@ Browserbase runs browsers in four regions, so you can cut latency by starting th
 
 <View title="TypeScript" icon="js">
 ```typescript
-import { Stagehand } from "@browserbasehq/stagehand";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 
-const stagehand = new Stagehand({
+const browser = await browserbase.launch({
   apiKey: process.env.BROWSERBASE_API_KEY,
-  browser: {
-    type: "browserbase",
-    region: "eu-central-1", // Browser runs in Frankfurt
-  },
+  region: "eu-central-1", // Browser runs in Frankfurt
 });
-
-await stagehand.init();
+const stagehand = await Stagehand.create({ browser });
 ```
 </View>
 
 <View title="Python" icon="python">
 ```python
-from stagehand import Stagehand
+from stagehand import Stagehand, browserbase
 
-stagehand = Stagehand(
+browser = await browserbase.launch(
     api_key=os.environ["BROWSERBASE_API_KEY"],
-    browser="browserbase",
     region="eu-central-1",  # Browser runs in Frankfurt
 )
-
-await stagehand.init()
+stagehand = await Stagehand.create(browser=browser)
 ```
 </View>
 
@@ -90,14 +85,15 @@ await stagehand.init()
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 region := stagehand.BrowserbaseRegionEUCentral1 // Browser runs in Frankfurt
 
-client := stagehand.New(stagehand.StagehandClientInitParams{
-	APIKey: &apiKey,
-	Browser: stagehand.BrowserbaseClientBrowserSource{
-		Region: &region,
-	},
+browser, err := stagehand.LaunchBrowserbase(ctx, stagehand.BrowserbaseLaunchOptions{
+	APIKey: apiKey,
+	Region: &region,
 })
-
-if err := client.Init(ctx); err != nil {
+if err != nil {
+	return err
+}
+client, err := stagehand.Create(ctx, stagehand.CreateOptions{Browser: browser})
+if err != nil {
 	return err
 }
 ```
@@ -143,25 +139,23 @@ The simplest way to get started is with default settings. Browserbase is the def
 
 <View title="TypeScript" icon="js">
 ```typescript
-import { Stagehand } from "@browserbasehq/stagehand";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 
-const stagehand = new Stagehand({
+const browser = await browserbase.launch({
   apiKey: process.env.BROWSERBASE_API_KEY,
 });
-
-await stagehand.init();
+const stagehand = await Stagehand.create({ browser });
 ```
 </View>
 
 <View title="Python" icon="python">
 ```python
-from stagehand import Stagehand
+from stagehand import Stagehand, browserbase
 
-stagehand = Stagehand(
+browser = await browserbase.launch(
     api_key=os.environ["BROWSERBASE_API_KEY"],
 )
-
-await stagehand.init()
+stagehand = await Stagehand.create(browser=browser)
 ```
 </View>
 
@@ -169,11 +163,12 @@ await stagehand.init()
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 
-client := stagehand.New(stagehand.StagehandClientInitParams{
-	APIKey: &apiKey,
-})
-
-if err := client.Init(ctx); err != nil {
+browser, err := stagehand.LaunchBrowserbase(ctx, stagehand.BrowserbaseLaunchOptions{APIKey: apiKey})
+if err != nil {
+	return err
+}
+client, err := stagehand.Create(ctx, stagehand.CreateOptions{Browser: browser})
+if err != nil {
 	return err
 }
 ```
@@ -187,32 +182,27 @@ Configure browser settings, proxy support, and other session parameters directly
 
 <View title="TypeScript" icon="js">
 ```typescript
-import { Stagehand } from "@browserbasehq/stagehand";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 
-const stagehand = new Stagehand({
+const browser = await browserbase.launch({
   apiKey: process.env.BROWSERBASE_API_KEY,
-  browser: {
-    type: "browserbase",
-    proxies: true,
-    region: "us-west-2",
-    browserSettings: {
-      viewport: { width: 1920, height: 1080 },
-      blockAds: true,
-    },
+  proxies: true,
+  region: "us-west-2",
+  browserSettings: {
+    viewport: { width: 1920, height: 1080 },
+    blockAds: true,
   },
 });
-
-await stagehand.init();
+const stagehand = await Stagehand.create({ browser });
 ```
 </View>
 
 <View title="Python" icon="python">
 ```python
-from stagehand import BrowserbaseBrowserSettings, Stagehand
+from stagehand import BrowserbaseBrowserSettings, Stagehand, browserbase
 
-stagehand = Stagehand(
+browser = await browserbase.launch(
     api_key=os.environ["BROWSERBASE_API_KEY"],
-    browser="browserbase",
     proxies=True,
     region="us-west-2",
     browser_settings=BrowserbaseBrowserSettings.model_validate({
@@ -220,8 +210,7 @@ stagehand = Stagehand(
         "block_ads": True,
     }),
 )
-
-await stagehand.init()
+stagehand = await Stagehand.create(browser=browser)
 ```
 </View>
 
@@ -233,19 +222,20 @@ proxies := stagehand.BrowserbaseProxyEnabled(true)
 blockAds := true
 width, height := 1920.0, 1080.0
 
-client := stagehand.New(stagehand.StagehandClientInitParams{
-	APIKey: &apiKey,
-	Browser: stagehand.BrowserbaseClientBrowserSource{
-		Proxies: &proxies,
-		Region:  &region,
-		BrowserSettings: &stagehand.BrowserbaseBrowserSettings{
-			Viewport: &stagehand.BrowserbaseViewport{Width: &width, Height: &height},
-			BlockAds: &blockAds,
-		},
+browser, err := stagehand.LaunchBrowserbase(ctx, stagehand.BrowserbaseLaunchOptions{
+	APIKey:   apiKey,
+	Proxies:  &proxies,
+	Region:   &region,
+	BrowserSettings: &stagehand.BrowserbaseBrowserSettings{
+		Viewport: &stagehand.BrowserbaseViewport{Width: &width, Height: &height},
+		BlockAds: &blockAds,
 	},
 })
-
-if err := client.Init(ctx); err != nil {
+if err != nil {
+	return err
+}
+client, err := stagehand.Create(ctx, stagehand.CreateOptions{Browser: browser})
+if err != nil {
 	return err
 }
 ```
@@ -255,28 +245,25 @@ if err := client.Init(ctx); err != nil {
 
 <View title="TypeScript" icon="js">
 ```typescript
-const stagehand = new Stagehand({
+const browser = await browserbase.launch({
   apiKey: process.env.BROWSERBASE_API_KEY,
-  browser: {
-    type: "browserbase",
-    proxies: true,
-    region: "us-west-2",
-    timeout: 3600, // 1 hour session timeout
-    keepAlive: true, // Available on Startup plan
-    browserSettings: {
-      verified: false, // this is a Scale Plan feature - reach out to support@browserbase.com to enable
-      blockAds: true,
-      solveCaptchas: true,
-      recordSession: false,
-      viewport: {
-        width: 1920,
-        height: 1080,
-      },
+  proxies: true,
+  region: "us-west-2",
+  timeout: 3600, // 1 hour session timeout
+  keepAlive: true, // Available on Startup plan
+  browserSettings: {
+    verified: false, // this is a Scale Plan feature - reach out to support@browserbase.com to enable
+    blockAds: true,
+    solveCaptchas: true,
+    recordSession: false,
+    viewport: {
+      width: 1920,
+      height: 1080,
     },
-    userMetadata: {
-      userId: "automation-user-123",
-      environment: "production",
-    },
+  },
+  userMetadata: {
+    userId: "automation-user-123",
+    environment: "production",
   },
 });
 ```
@@ -284,9 +271,8 @@ const stagehand = new Stagehand({
 
 <View title="Python" icon="python">
 ```python
-stagehand = Stagehand(
+browser = await browserbase.launch(
     api_key=os.environ["BROWSERBASE_API_KEY"],
-    browser="browserbase",
     proxies=True,
     region="us-west-2",
     timeout=3600,  # 1 hour session timeout
@@ -322,28 +308,29 @@ solveCaptchas := true
 recordSession := false
 width, height := 1920.0, 1080.0
 
-client := stagehand.New(stagehand.StagehandClientInitParams{
-	APIKey: &apiKey,
-	Browser: stagehand.BrowserbaseClientBrowserSource{
-		Proxies:   &proxies,
-		Region:    &region,
-		Timeout:   &timeout,
-		KeepAlive: &keepAlive,
-		BrowserSettings: &stagehand.BrowserbaseBrowserSettings{
-			Verified:      &verified,
-			BlockAds:      &blockAds,
-			SolveCaptchas: &solveCaptchas,
-			RecordSession: &recordSession,
-			Viewport:      &stagehand.BrowserbaseViewport{Width: &width, Height: &height},
-		},
-		UserMetadata: map[string]json.RawMessage{
-			"userId":      json.RawMessage(`"automation-user-123"`),
-			"environment": json.RawMessage(`"production"`),
-		},
+browser, err := stagehand.LaunchBrowserbase(ctx, stagehand.BrowserbaseLaunchOptions{
+	APIKey:    apiKey,
+	Proxies:   &proxies,
+	Region:    &region,
+	Timeout:   &timeout,
+	KeepAlive: &keepAlive,
+	BrowserSettings: &stagehand.BrowserbaseBrowserSettings{
+		Verified:      &verified,
+		BlockAds:      &blockAds,
+		SolveCaptchas: &solveCaptchas,
+		RecordSession: &recordSession,
+		Viewport:      &stagehand.BrowserbaseViewport{Width: &width, Height: &height},
+	},
+	UserMetadata: map[string]json.RawMessage{
+		"userId":      json.RawMessage(`"automation-user-123"`),
+		"environment": json.RawMessage(`"production"`),
 	},
 })
-
-if err := client.Init(ctx); err != nil {
+if err != nil {
+	return err
+}
+client, err := stagehand.Create(ctx, stagehand.CreateOptions{Browser: browser})
+if err != nil {
 	return err
 }
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
@@ -362,7 +349,7 @@ If you prefer to manage sessions directly, create the session with the Browserba
 <View title="TypeScript" icon="js">
 ```typescript
 import { Browserbase } from "@browserbasehq/sdk";
-import { Stagehand } from "@browserbasehq/stagehand";
+import { localBrowser, Stagehand } from "@browserbasehq/stagehand";
 
 const bb = new Browserbase({
   apiKey: process.env.BROWSERBASE_API_KEY!,
@@ -373,11 +360,8 @@ const session = await bb.sessions.create({
   // Add configuration options here
 });
 
-const stagehand = new Stagehand({
-  browser: { type: "cdp", cdpUrl: session.connectUrl },
-});
-
-await stagehand.init();
+const browser = await localBrowser.connect({ cdpUrl: session.connectUrl });
+const stagehand = await Stagehand.create({ browser });
 ```
 </View>
 
@@ -385,7 +369,7 @@ await stagehand.init();
 ```python
 from browserbase import Browserbase
 
-from stagehand import Stagehand
+from stagehand import Stagehand, local_browser
 
 bb = Browserbase(api_key=os.environ["BROWSERBASE_API_KEY"])
 
@@ -394,12 +378,8 @@ session = bb.sessions.create(
     # Add configuration options here
 )
 
-stagehand = Stagehand(
-    browser="cdp",
-    cdp_url=session.connect_url,
-)
-
-await stagehand.init()
+browser = await local_browser.connect(cdp_url=session.connect_url)
+stagehand = await Stagehand.create(browser=browser)
 ```
 </View>
 
@@ -412,11 +392,14 @@ if err != nil {
 	return err
 }
 
-client := stagehand.New(stagehand.StagehandClientInitParams{
-	Browser: stagehand.CDPBrowserSource{CDPURL: connectURL},
+browser, err := stagehand.ConnectLocalBrowser(ctx, stagehand.LocalBrowserConnectOptions{
+	CDPURL: connectURL,
 })
-
-if err := client.Init(ctx); err != nil {
+if err != nil {
+	return err
+}
+client, err := stagehand.Create(ctx, stagehand.CreateOptions{Browser: browser})
+if err != nil {
 	return err
 }
 ```
@@ -428,44 +411,36 @@ The `cdp` browser source attaches to any Chromium browser that is already runnin
 
 <View title="TypeScript" icon="js">
 ```typescript
-import { Stagehand } from "@browserbasehq/stagehand";
+import { localBrowser, Stagehand } from "@browserbasehq/stagehand";
 
-const stagehand = new Stagehand({
-  browser: {
-    type: "cdp",
-    cdpUrl: "wss://connect.browserbase.com/?apiKey=...&sessionId=...",
-    headers: { "x-my-header": "value" },
-  },
+const browser = await localBrowser.connect({
+  cdpUrl: "wss://connect.browserbase.com/?apiKey=...&sessionId=...",
 });
-
-await stagehand.init();
+const stagehand = await Stagehand.create({ browser });
 ```
 </View>
 
 <View title="Python" icon="python">
 ```python
-from stagehand import Stagehand
+from stagehand import Stagehand, local_browser
 
-stagehand = Stagehand(
-    browser="cdp",
+browser = await local_browser.connect(
     cdp_url=connect_url,  # from your Browserbase session
-    headers={"x-my-header": "value"},
 )
-
-await stagehand.init()
+stagehand = await Stagehand.create(browser=browser)
 ```
 </View>
 
 <View title="Go" icon="golang">
 ```go
-client := stagehand.New(stagehand.StagehandClientInitParams{
-	Browser: stagehand.CDPBrowserSource{
-		CDPURL:  "wss://connect.browserbase.com/?apiKey=...&sessionId=...",
-		Headers: map[string]string{"x-my-header": "value"},
-	},
+browser, err := stagehand.ConnectLocalBrowser(ctx, stagehand.LocalBrowserConnectOptions{
+	CDPURL: "wss://connect.browserbase.com/?apiKey=...&sessionId=...",
 })
-
-if err := client.Init(ctx); err != nil {
+if err != nil {
+	return err
+}
+client, err := stagehand.Create(ctx, stagehand.CreateOptions{Browser: browser})
+if err != nil {
 	return err
 }
 ```
@@ -474,8 +449,6 @@ if err := client.Init(ctx); err != nil {
 <Note>
 Stagehand never closes a browser it did not launch. With the `cdp` source, `close()` tears down the Stagehand connection and leaves the browser running.
 </Note>
-
-{/* TODO: custom CDP headers only work in Go (sdk-go/browser_source.go:163 forwards them to the handshake). TypeScript accepts and resolves them (sdk-ts/src/browserSource.ts:83) then drops them: sdk-ts/src/stagehand.ts:88 is an explicit TODO and CDPClientOptions (sdk-ts/src/cdpClient.ts:30) has no headers field, so the header is silently ignored rather than failing. Python is worse: sdk-python/src/stagehand/browser_source.py:76 raises NotImplementedError("CDP headers are not implemented yet"), so the Python View fails at init() whenever headers is set. The cdp source itself works in all three languages without headers. Verify before publishing. */}
 
 ## Local environment
 
@@ -501,33 +474,30 @@ The local environment runs browsers directly on your machine, providing full con
 
 <View title="TypeScript" icon="js">
 ```typescript
-import { Stagehand } from "@browserbasehq/stagehand";
+import { localBrowser, Stagehand } from "@browserbasehq/stagehand";
 
-const stagehand = new Stagehand({
-  browser: { type: "local" },
-});
-
-await stagehand.init();
+const browser = await localBrowser.launch();
+const stagehand = await Stagehand.create({ browser });
 ```
 </View>
 
 <View title="Python" icon="python">
 ```python
-from stagehand import Stagehand
+from stagehand import Stagehand, local_browser
 
-stagehand = Stagehand(browser="local")
-
-await stagehand.init()
+browser = await local_browser.launch()
+stagehand = await Stagehand.create(browser=browser)
 ```
 </View>
 
 <View title="Go" icon="golang">
 ```go
-client := stagehand.New(stagehand.StagehandClientInitParams{
-	Browser: stagehand.LocalBrowserSource{},
-})
-
-if err := client.Init(ctx); err != nil {
+browser, err := stagehand.LaunchLocalBrowser(ctx, &stagehand.LocalBrowserLaunchOptions{})
+if err != nil {
+	return err
+}
+client, err := stagehand.Create(ctx, stagehand.CreateOptions{Browser: browser})
+if err != nil {
 	return err
 }
 ```
@@ -539,12 +509,10 @@ Customize browser launch options for local development:
 
 <View title="TypeScript" icon="js">
 ```typescript
-import { Stagehand } from "@browserbasehq/stagehand";
+import { localBrowser, Stagehand } from "@browserbasehq/stagehand";
 
-const stagehand = new Stagehand({
-  browser: {
-    type: "local",
-    headless: false, // Show browser window
+const browser = await localBrowser.launch({
+  headless: false, // Show browser window
     devtools: true, // Open developer tools
     viewport: { width: 1280, height: 720 },
     executablePath: "/opt/google/chrome/chrome", // Custom Chrome path
@@ -570,19 +538,16 @@ const stagehand = new Stagehand({
     },
     downloadsPath: "./downloads", // Download directory
     acceptDownloads: true, // Allow downloads
-  },
 });
-
-await stagehand.init();
+const stagehand = await Stagehand.create({ browser });
 ```
 </View>
 
 <View title="Python" icon="python">
 ```python
-from stagehand import Stagehand
+from stagehand import Stagehand, local_browser
 
-stagehand = Stagehand(
-    browser="local",
+browser = await local_browser.launch(
     headless=False,  # Show browser window
     devtools=True,  # Open developer tools
     viewport_width=1280,
@@ -607,8 +572,7 @@ stagehand = Stagehand(
     downloads_path="./downloads",  # Download directory
     accept_downloads=True,  # Allow downloads
 )
-
-await stagehand.init()
+stagehand = await Stagehand.create(browser=browser)
 ```
 </View>
 
@@ -618,8 +582,7 @@ chromiumSandbox := false // Disable sandbox (adds --no-sandbox)
 acceptDownloads := true  // Allow downloads
 deviceScaleFactor := 1.0 // Display scaling
 
-client := stagehand.New(stagehand.StagehandClientInitParams{
-	Browser: stagehand.LocalBrowserSource{
+browser, err := stagehand.LaunchLocalBrowser(ctx, &stagehand.LocalBrowserLaunchOptions{
 		Headless:       false,                            // Show browser window
 		Devtools:       true,                             // Open developer tools
 		Viewport:       &stagehand.LocalViewport{Width: 1280, Height: 720},
@@ -646,10 +609,12 @@ client := stagehand.New(stagehand.StagehandClientInitParams{
 		},
 		DownloadsPath:    "./downloads", // Download directory
 		AcceptDownloads:  &acceptDownloads,
-	},
 })
-
-if err := client.Init(ctx); err != nil {
+if err != nil {
+	return err
+}
+client, err := stagehand.Create(ctx, stagehand.CreateOptions{Browser: browser})
+if err != nil {
 	return err
 }
 ```
@@ -705,23 +670,19 @@ A larger set of standard Chrome automation flags (disabling background networkin
 
 <View title="TypeScript" icon="js">
 ```typescript
-const stagehand = new Stagehand({
-  browser: {
-    type: "local",
-    ignoreDefaultArgs: ["--disable-sync"],
-    args: [
-      "--disable-features=site-per-process,IsolateOrigins",
-      "--renderer-process-limit=6",
-    ],
-  },
+const browser = await localBrowser.launch({
+  ignoreDefaultArgs: ["--disable-sync"],
+  args: [
+    "--disable-features=site-per-process,IsolateOrigins",
+    "--renderer-process-limit=6",
+  ],
 });
 ```
 </View>
 
 <View title="Python" icon="python">
 ```python
-stagehand = Stagehand(
-    browser="local",
+browser = await local_browser.launch(
     ignore_default_args=["--disable-sync"],
     args=[
         "--disable-features=site-per-process,IsolateOrigins",
@@ -733,22 +694,18 @@ stagehand = Stagehand(
 
 <View title="Go" icon="golang">
 ```go
-client := stagehand.New(stagehand.StagehandClientInitParams{
-	Browser: stagehand.LocalBrowserSource{
-		IgnoreDefaultArgs: &stagehand.IgnoreDefaultArgs{
-			Args: []string{"--disable-sync"},
-		},
-		Args: []string{
-			"--disable-features=site-per-process,IsolateOrigins",
-			"--renderer-process-limit=6",
-		},
+browser, err := stagehand.LaunchLocalBrowser(ctx, &stagehand.LocalBrowserLaunchOptions{
+	IgnoreDefaultArgs: &stagehand.IgnoreDefaultArgs{
+		Args: []string{"--disable-sync"},
+	},
+	Args: []string{
+		"--disable-features=site-per-process,IsolateOrigins",
+		"--renderer-process-limit=6",
 	},
 })
-
-if err := client.Init(ctx); err != nil {
+if err != nil {
 	return err
 }
-defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
 </View>
 
@@ -764,44 +721,41 @@ By default, Stagehand terminates the browser it launched and cleans up all resou
 
 <View title="TypeScript" icon="js">
 ```typescript
-import { Stagehand } from "@browserbasehq/stagehand";
+import { browserbase, localBrowser, Stagehand } from "@browserbasehq/stagehand";
 
-const stagehand = new Stagehand({
+const browser = await browserbase.launch({
   apiKey: process.env.BROWSERBASE_API_KEY,
-  browser: { type: "browserbase", keepAlive: true },
+  keepAlive: true,
 });
-
-await stagehand.init();
+const stagehand = await Stagehand.create({ browser });
 
 // The browser session continues running after close()
 await stagehand.close();
+await browser.close();
 
 // Later, reconnect to the same session over CDP
-const stagehand2 = new Stagehand({
-  browser: { type: "cdp", cdpUrl: existingConnectUrl },
-});
-await stagehand2.init();
+const browser2 = await localBrowser.connect({ cdpUrl: existingConnectUrl });
+const stagehand2 = await Stagehand.create({ browser: browser2 });
 ```
 </View>
 
 <View title="Python" icon="python">
 ```python
-from stagehand import Stagehand
+from stagehand import Stagehand, browserbase, local_browser
 
-stagehand = Stagehand(
+browser = await browserbase.launch(
     api_key=os.environ["BROWSERBASE_API_KEY"],
-    browser="browserbase",
     keep_alive=True,
 )
-
-await stagehand.init()
+stagehand = await Stagehand.create(browser=browser)
 
 # The browser session continues running after close()
 await stagehand.close()
+await browser.close()
 
 # Later, reconnect to the same session over CDP
-stagehand2 = Stagehand(browser="cdp", cdp_url=existing_connect_url)
-await stagehand2.init()
+browser2 = await local_browser.connect(cdp_url=existing_connect_url)
+stagehand2 = await Stagehand.create(browser=browser2)
 ```
 </View>
 
@@ -810,14 +764,15 @@ await stagehand2.init()
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 keepAlive := true
 
-client := stagehand.New(stagehand.StagehandClientInitParams{
-	APIKey: &apiKey,
-	Browser: stagehand.BrowserbaseClientBrowserSource{
-		KeepAlive: &keepAlive,
-	},
+browser, err := stagehand.LaunchBrowserbase(ctx, stagehand.BrowserbaseLaunchOptions{
+	APIKey:    apiKey,
+	KeepAlive: &keepAlive,
 })
-
-if err := client.Init(ctx); err != nil {
+if err != nil {
+	return err
+}
+client, err := stagehand.Create(ctx, stagehand.CreateOptions{Browser: browser})
+if err != nil {
 	return err
 }
 
@@ -825,12 +780,19 @@ if err := client.Init(ctx); err != nil {
 if err := client.Close(ctx); err != nil {
 	return err
 }
+if err := browser.Close(ctx); err != nil {
+	return err
+}
 
 // Later, reconnect to the same session over CDP
-client2 := stagehand.New(stagehand.StagehandClientInitParams{
-	Browser: stagehand.CDPBrowserSource{CDPURL: existingConnectURL},
+browser2, err := stagehand.ConnectLocalBrowser(ctx, stagehand.LocalBrowserConnectOptions{
+	CDPURL: existingConnectURL,
 })
-if err := client2.Init(ctx); err != nil {
+if err != nil {
+	return err
+}
+client2, err := stagehand.Create(ctx, stagehand.CreateOptions{Browser: browser2})
+if err != nil {
 	return err
 }
 ```
@@ -850,78 +812,71 @@ When running locally with keep-alive on, Stagehand leaves the Chrome process run
 
 <View title="TypeScript" icon="js">
 ```typescript
-const stagehand = new Stagehand({
-  browser: {
-    type: "local",
-    keepAlive: true,
-    headless: false,
-    port: 9222,
-  },
+const browser = await localBrowser.launch({
+  keepAlive: true,
+  headless: false,
+  port: 9222,
 });
-
-await stagehand.init();
-const page = await stagehand.context.activePage();
-if (!page) {
-  throw new Error("Stagehand initialized without an active page");
-}
+const stagehand = await Stagehand.create({ browser });
+const [page] = await browser.context.pages();
 await page.goto("https://example.com");
 
 // Browser window stays open after the script exits
 await stagehand.close();
+await browser.close();
 ```
 </View>
 
 <View title="Python" icon="python">
 ```python
-stagehand = Stagehand(
-    browser="local",
+browser = await local_browser.launch(
     keep_alive=True,
     headless=False,
     port=9222,
 )
-
-await stagehand.init()
-page = await stagehand.context.active_page()
-if page is None:
-    raise RuntimeError("Stagehand initialized without an active page")
+stagehand = await Stagehand.create(browser=browser)
+page = (await browser.context.pages())[0]
 await page.goto("https://example.com")
 
 # Browser window stays open after the script exits
 await stagehand.close()
+await browser.close()
 ```
 </View>
 
 <View title="Go" icon="golang">
 ```go
-client := stagehand.New(stagehand.StagehandClientInitParams{
-	Browser: stagehand.LocalBrowserSource{
-		KeepAlive: true,
-		Headless:  false,
-		Port:      9222,
-	},
+browser, err := stagehand.LaunchLocalBrowser(ctx, &stagehand.LocalBrowserLaunchOptions{
+	KeepAlive: true,
+	Headless:  false,
+	Port:      9222,
 })
-
-if err := client.Init(ctx); err != nil {
-	return err
-}
-
-browserContext, err := client.Context()
 if err != nil {
 	return err
 }
-page, err := browserContext.ActivePage(ctx)
+client, err := stagehand.Create(ctx, stagehand.CreateOptions{Browser: browser})
 if err != nil {
 	return err
 }
-if page == nil {
+
+browserContext, err := browser.Context()
+if err != nil {
+	return err
+}
+pages, err := browserContext.Pages(ctx)
+if err != nil {
+	return err
+}
+if len(pages) == 0 {
 	return errors.New("Stagehand initialized without an active page")
 }
+page := pages[0]
 if err := page.Goto(ctx, "https://example.com", nil); err != nil {
 	return err
 }
 
 // Browser window stays open after the program exits
-return client.Close(ctx)
+return errors.Join(client.Close(ctx), browser.Close(ctx))
 ```
 </View>
 
@@ -943,41 +898,30 @@ Specify a fixed Chrome DevTools Protocol (CDP) debugging port instead of using a
 
 <View title="TypeScript" icon="js">
 ```typescript
-import { Stagehand } from "@browserbasehq/stagehand";
+import { localBrowser, Stagehand } from "@browserbasehq/stagehand";
 
-const stagehand = new Stagehand({
-  browser: {
-    type: "local",
-    port: 9222,
-  },
-});
-
-await stagehand.init();
+const browser = await localBrowser.launch({ port: 9222 });
+const stagehand = await Stagehand.create({ browser });
 ```
 </View>
 
 <View title="Python" icon="python">
 ```python
-from stagehand import Stagehand
+from stagehand import Stagehand, local_browser
 
-stagehand = Stagehand(
-    browser="local",
-    port=9222,
-)
-
-await stagehand.init()
+browser = await local_browser.launch(port=9222)
+stagehand = await Stagehand.create(browser=browser)
 ```
 </View>
 
 <View title="Go" icon="golang">
 ```go
-client := stagehand.New(stagehand.StagehandClientInitParams{
-	Browser: stagehand.LocalBrowserSource{
-		Port: 9222,
-	},
-})
-
-if err := client.Init(ctx); err != nil {
+browser, err := stagehand.LaunchLocalBrowser(ctx, &stagehand.LocalBrowserLaunchOptions{Port: 9222})
+if err != nil {
+	return err
+}
+client, err := stagehand.Create(ctx, stagehand.CreateOptions{Browser: browser})
+if err != nil {
 	return err
 }
 ```
@@ -993,8 +937,9 @@ Configure how long Stagehand waits for the DOM to stabilize before taking action
 
 <View title="TypeScript" icon="js">
 ```typescript
-const stagehand = new Stagehand({
-  apiKey: process.env.BROWSERBASE_API_KEY,
+const browser = await browserbase.launch({ apiKey: process.env.BROWSERBASE_API_KEY });
+const stagehand = await Stagehand.create({
+  browser,
   domSettleTimeoutMs: 3000, // Wait up to 3 seconds for DOM to settle
 });
 ```
@@ -1002,8 +947,9 @@ const stagehand = new Stagehand({
 
 <View title="Python" icon="python">
 ```python
-stagehand = Stagehand(
-    api_key=os.environ["BROWSERBASE_API_KEY"],
+browser = await browserbase.launch(api_key=os.environ["BROWSERBASE_API_KEY"])
+stagehand = await Stagehand.create(
+    browser=browser,
     dom_settle_timeout_ms=3000,  # Wait up to 3 seconds for DOM to settle
 )
 ```
@@ -1014,12 +960,15 @@ stagehand = Stagehand(
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 domSettleTimeoutMs := 3000 // Wait up to 3 seconds for DOM to settle
 
-client := stagehand.New(stagehand.StagehandClientInitParams{
-	APIKey:             &apiKey,
+browser, err := stagehand.LaunchBrowserbase(ctx, stagehand.BrowserbaseLaunchOptions{APIKey: apiKey})
+if err != nil {
+	return err
+}
+client, err := stagehand.Create(ctx, stagehand.CreateOptions{
+	Browser:            browser,
 	DOMSettleTimeoutMs: &domSettleTimeoutMs,
 })
-
-if err := client.Init(ctx); err != nil {
+if err != nil {
 	return err
 }
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
@@ -1049,14 +998,16 @@ Increase the DOM settle timeout for pages with:
 <View title="TypeScript" icon="js">
 ```typescript
 // For fast, static pages
-const fast = new Stagehand({
-  apiKey: process.env.BROWSERBASE_API_KEY,
+const fastBrowser = await browserbase.launch({ apiKey: process.env.BROWSERBASE_API_KEY });
+const fast = await Stagehand.create({
+  browser: fastBrowser,
   domSettleTimeoutMs: 500, // Minimal wait
 });
 
 // For dynamic, animated pages
-const dynamic = new Stagehand({
-  apiKey: process.env.BROWSERBASE_API_KEY,
+const dynamicBrowser = await browserbase.launch({ apiKey: process.env.BROWSERBASE_API_KEY });
+const dynamic = await Stagehand.create({
+  browser: dynamicBrowser,
   domSettleTimeoutMs: 5000, // Longer wait for stability
 });
 ```
@@ -1065,14 +1016,16 @@ const dynamic = new Stagehand({
 <View title="Python" icon="python">
 ```python
 # For fast, static pages
-fast = Stagehand(
-    api_key=os.environ["BROWSERBASE_API_KEY"],
+fast_browser = await browserbase.launch(api_key=os.environ["BROWSERBASE_API_KEY"])
+fast = await Stagehand.create(
+    browser=fast_browser,
     dom_settle_timeout_ms=500,  # Minimal wait
 )
 
 # For dynamic, animated pages
-dynamic = Stagehand(
-    api_key=os.environ["BROWSERBASE_API_KEY"],
+dynamic_browser = await browserbase.launch(api_key=os.environ["BROWSERBASE_API_KEY"])
+dynamic = await Stagehand.create(
+    browser=dynamic_browser,
     dom_settle_timeout_ms=5000,  # Longer wait for stability
 )
 ```
@@ -1082,26 +1035,19 @@ dynamic = Stagehand(
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 
-// For fast, static pages
-fastSettle := 500 // Minimal wait
-fast := stagehand.New(stagehand.StagehandClientInitParams{
-	APIKey:             &apiKey,
-	DOMSettleTimeoutMs: &fastSettle,
-})
-
-// For dynamic, animated pages
-slowSettle := 5000 // Longer wait for stability
-dynamic := stagehand.New(stagehand.StagehandClientInitParams{
-	APIKey:             &apiKey,
-	DOMSettleTimeoutMs: &slowSettle,
-})
-
-// Pick the client that matches the pages you are about to automate
-client := fast
-if os.Getenv("PAGE_PROFILE") == "dynamic" {
-	client = dynamic
+browser, err := stagehand.LaunchBrowserbase(ctx, stagehand.BrowserbaseLaunchOptions{APIKey: apiKey})
+if err != nil {
+	return err
 }
-if err := client.Init(ctx); err != nil {
+settleTimeout := 500 // Fast, static pages
+if os.Getenv("PAGE_PROFILE") == "dynamic" {
+	settleTimeout = 5000 // Dynamic, animated pages
+}
+client, err := stagehand.Create(ctx, stagehand.CreateOptions{
+	Browser:            browser,
+	DOMSettleTimeoutMs: &settleTimeout,
+})
+if err != nil {
 	return err
 }
 defer func() { err = errors.Join(err, client.Close(ctx)) }()

--- a/packages/docs/v4/configuration/observability.mdx
+++ b/packages/docs/v4/configuration/observability.mdx
@@ -30,21 +30,19 @@ Browserbase provides real-time visibility into your automation sessions:
 <View title="TypeScript" icon="js">
 ```typescript
 import { Browserbase } from "@browserbasehq/sdk";
-import { Stagehand } from "@browserbasehq/stagehand";
+import { browserbase as stagehandBrowserbase, Stagehand } from "@browserbasehq/stagehand";
 
 const browserbase = new Browserbase({
   apiKey: process.env.BROWSERBASE_API_KEY,
 });
 
-const stagehand = new Stagehand({
+const browser = await stagehandBrowserbase.launch({
   apiKey: process.env.BROWSERBASE_API_KEY,
-  browser: { type: "browserbase" },
 });
-
-await stagehand.init();
+const stagehand = await Stagehand.create({ browser });
 
 // The resolved browser source carries the Browserbase session ID
-const sessionId = stagehand.browser.browserbaseSessionId;
+const sessionId = browser.browserbaseSessionId;
 const sessionInfo = await browserbase.sessions.retrieve(sessionId);
 
 console.log("Session status:", sessionInfo.status);
@@ -61,7 +59,7 @@ import os
 
 from browserbase import Browserbase
 
-from stagehand import Stagehand
+from stagehand import Stagehand, local_browser
 
 browserbase = Browserbase(api_key=os.environ["BROWSERBASE_API_KEY"])
 
@@ -70,9 +68,8 @@ session = browserbase.sessions.create(
     project_id=os.environ["BROWSERBASE_PROJECT_ID"],
 )
 
-stagehand = Stagehand(browser="cdp", cdp_url=session.connect_url)
-
-await stagehand.init()
+browser = await local_browser.connect(cdp_url=session.connect_url)
+stagehand = await Stagehand.create(browser=browser)
 
 session_info = browserbase.sessions.retrieve(session.id)
 
@@ -93,11 +90,14 @@ if err != nil {
 	return err
 }
 
-client := stagehand.New(stagehand.StagehandClientInitParams{
-	Browser: stagehand.CDPBrowserSource{CDPURL: session.ConnectURL},
+browser, err := stagehand.ConnectLocalBrowser(ctx, stagehand.LocalBrowserConnectOptions{
+	CDPURL: session.ConnectURL,
 })
-
-if err := client.Init(ctx); err != nil {
+if err != nil {
+	return err
+}
+client, err := stagehand.Create(ctx, stagehand.CreateOptions{Browser: browser})
+if err != nil {
 	return err
 }
 
@@ -287,22 +287,18 @@ import { z } from "zod/v4";
 
 const DataSchema = z.object({ title: z.string() });
 
-const stagehand = new Stagehand({
-  browser: { type: "local" },
+const browser = await localBrowser.launch();
+const stagehand = await Stagehand.create({
+  browser,
   logging: { level: "info" }, // Monitor performance without debug noise
 });
-
-await stagehand.init();
 
 // Track local automation metrics
 const startTime = Date.now();
 const initialMetrics = await stagehand.metrics();
 
 // ... perform automation tasks
-const page = await stagehand.context.activePage();
-if (!page) {
-  throw new Error("Stagehand initialized without an active page");
-}
+const [page] = await browser.context.pages();
 await page.goto("https://example.com");
 await stagehand.act("click button");
 await stagehand.extract("get data", DataSchema);
@@ -330,28 +326,25 @@ from time import perf_counter
 
 from pydantic import BaseModel
 
-from stagehand import Stagehand
+from stagehand import Stagehand, local_browser
 
 
 class Data(BaseModel):
     title: str
 
 
-stagehand = Stagehand(
-    browser="local",
+browser = await local_browser.launch()
+stagehand = await Stagehand.create(
+    browser=browser,
     logging={"level": "info"},  # Monitor without debug noise
 )
-
-await stagehand.init()
 
 # Track local automation metrics
 start_time = perf_counter()
 initial_metrics = await stagehand.metrics()
 
 # ... perform automation tasks
-page = await stagehand.context.active_page()
-if page is None:
-    raise RuntimeError("Stagehand initialized without an active page")
+page = (await browser.context.pages())[0]
 await page.goto("https://example.com")
 await stagehand.act("click button")
 await stagehand.extract("get data", Data)
@@ -388,8 +381,12 @@ var dataSchema = json.RawMessage(`{
   "additionalProperties": false
 }`)
 
-client := stagehand.New(stagehand.StagehandClientInitParams{
-	Browser: stagehand.LocalBrowserSource{},
+browser, err := stagehand.LaunchLocalBrowser(ctx, &stagehand.LocalBrowserLaunchOptions{})
+if err != nil {
+	return err
+}
+client, err := stagehand.Create(ctx, stagehand.CreateOptions{
+	Browser: browser,
 	Logging: &stagehand.StagehandClientLoggingConfig{
 		OnLog: func(entry stagehand.StagehandLog) {
 			if entry.Level == stagehand.StagehandLogLevelDebug {
@@ -399,8 +396,7 @@ client := stagehand.New(stagehand.StagehandClientInitParams{
 		},
 	},
 })
-
-if err := client.Init(ctx); err != nil {
+if err != nil {
 	return err
 }
 
@@ -412,17 +408,18 @@ if err != nil {
 }
 
 // ... perform automation tasks
-browserContext, err := client.Context()
+browserContext, err := browser.Context()
 if err != nil {
 	return err
 }
-page, err := browserContext.ActivePage(ctx)
+pages, err := browserContext.Pages(ctx)
 if err != nil {
 	return err
 }
-if page == nil {
+if len(pages) == 0 {
 	return errors.New("Stagehand initialized without an active page")
 }
+page := pages[0]
 if err := page.Goto(ctx, "https://example.com", nil); err != nil {
 	return err
 }
@@ -460,7 +457,7 @@ When running locally, monitor system resource usage and browser performance:
 <View title="TypeScript" icon="js">
 ```typescript
 import * as os from "node:os";
-import { Stagehand } from "@browserbasehq/stagehand";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 
 class LocalResourceMonitor {
   private cpuUsage: number[] = [];
@@ -493,7 +490,8 @@ class LocalResourceMonitor {
 const monitor = new LocalResourceMonitor();
 const interval = monitor.startMonitoring();
 
-const stagehand = new Stagehand({ browser: { type: "local" } });
+const browser = await localBrowser.launch();
+const stagehand = await Stagehand.create({ browser });
 
 // ... run automation
 
@@ -543,7 +541,8 @@ class LocalResourceMonitor:
 monitor = LocalResourceMonitor()
 task = monitor.start_monitoring()
 
-stagehand = Stagehand(browser="local")
+browser = await local_browser.launch()
+stagehand = await Stagehand.create(browser=browser)
 
 # ... run automation
 
@@ -599,9 +598,11 @@ monitorCtx, stopMonitor := context.WithCancel(ctx)
 monitor := &localResourceMonitor{}
 monitor.startMonitoring(monitorCtx)
 
-client := stagehand.New(stagehand.StagehandClientInitParams{
-	Browser: stagehand.LocalBrowserSource{},
-})
+browser, err := stagehand.LaunchLocalBrowser(ctx, &stagehand.LocalBrowserLaunchOptions{})
+if err != nil {
+	return err
+}
+client, err := stagehand.Create(ctx, stagehand.CreateOptions{Browser: browser})
 
 // ... run automation
 
@@ -631,11 +632,10 @@ import { z } from "zod/v4";
 
 const UserSchema = z.object({ name: z.string(), email: z.string() });
 
-const stagehand = new Stagehand({
+const browser = await browserbase.launch({
   apiKey: process.env.BROWSERBASE_API_KEY,
-  browser: { type: "browserbase" },
 });
-await stagehand.init();
+const stagehand = await Stagehand.create({ browser });
 
 // Metrics are fetched from the runtime, so the call is awaited
 const metrics = await stagehand.metrics();
@@ -646,10 +646,7 @@ const startTime = Date.now();
 const initialMetrics = await stagehand.metrics();
 
 // ... perform automation tasks
-const page = await stagehand.context.activePage();
-if (!page) {
-  throw new Error("Stagehand initialized without an active page");
-}
+const [page] = await browser.context.pages();
 await page.goto("https://example.com");
 await stagehand.act("click the login button");
 const { data } = await stagehand.extract("extract user info", UserSchema);
@@ -675,7 +672,7 @@ console.log("Automation Summary:", {
 ```python
 from time import perf_counter
 
-from stagehand import Stagehand
+from stagehand import Stagehand, browserbase
 
 
 class User(BaseModel):
@@ -683,11 +680,10 @@ class User(BaseModel):
     email: str
 
 
-stagehand = Stagehand(
+browser = await browserbase.launch(
     api_key=os.environ["BROWSERBASE_API_KEY"],
-    browser="browserbase",
 )
-await stagehand.init()
+stagehand = await Stagehand.create(browser=browser)
 
 # Metrics are fetched from the runtime, so the call is awaited
 metrics = await stagehand.metrics()
@@ -698,9 +694,7 @@ start_time = perf_counter()
 initial_metrics = await stagehand.metrics()
 
 # ... perform automation tasks
-page = await stagehand.context.active_page()
-if page is None:
-    raise RuntimeError("Stagehand initialized without an active page")
+page = (await browser.context.pages())[0]
 await page.goto("https://example.com")
 await stagehand.act("click the login button")
 data = (await stagehand.extract("extract user info", User)).data
@@ -739,11 +733,12 @@ var userSchema = json.RawMessage(`{
 }`)
 
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
-client := stagehand.New(stagehand.StagehandClientInitParams{
-	APIKey:  &apiKey,
-	Browser: stagehand.BrowserbaseClientBrowserSource{},
-})
-if err := client.Init(ctx); err != nil {
+browser, err := stagehand.LaunchBrowserbase(ctx, stagehand.BrowserbaseLaunchOptions{APIKey: apiKey})
+if err != nil {
+	return err
+}
+client, err := stagehand.Create(ctx, stagehand.CreateOptions{Browser: browser})
+if err != nil {
 	return err
 }
 
@@ -762,17 +757,18 @@ if err != nil {
 }
 
 // ... perform automation tasks
-browserContext, err := client.Context()
+browserContext, err := browser.Context()
 if err != nil {
 	return err
 }
-page, err := browserContext.ActivePage(ctx)
+pages, err := browserContext.Pages(ctx)
 if err != nil {
 	return err
 }
-if page == nil {
+if len(pages) == 0 {
 	return errors.New("Stagehand initialized without an active page")
 }
+page := pages[0]
 if err := page.Goto(ctx, "https://example.com", nil); err != nil {
 	return err
 }
@@ -1014,8 +1010,11 @@ Stagehand emits OpenTelemetry spans for every operation and for every log record
 
 <View title="TypeScript" icon="js">
 ```typescript
-const stagehand = new Stagehand({
+const browser = await browserbase.launch({
   apiKey: process.env.BROWSERBASE_API_KEY,
+});
+const stagehand = await Stagehand.create({
+  browser,
   telemetry: {
     traces: {
       endpoint: "https://otlp.example.com/v1/traces",
@@ -1028,10 +1027,13 @@ const stagehand = new Stagehand({
 
 <View title="Python" icon="python">
 ```python
-from stagehand import Stagehand, TelemetryConfig
+from stagehand import Stagehand, TelemetryConfig, browserbase
 
-stagehand = Stagehand(
+browser = await browserbase.launch(
     api_key=os.environ["BROWSERBASE_API_KEY"],
+)
+stagehand = await Stagehand.create(
+    browser=browser,
     telemetry=TelemetryConfig.model_validate({
         "traces": {
             "endpoint": "https://otlp.example.com/v1/traces",
@@ -1046,8 +1048,12 @@ stagehand = Stagehand(
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 
-client := stagehand.New(stagehand.StagehandClientInitParams{
-	APIKey: &apiKey,
+browser, err := stagehand.LaunchBrowserbase(ctx, stagehand.BrowserbaseLaunchOptions{APIKey: apiKey})
+if err != nil {
+	return err
+}
+client, err := stagehand.Create(ctx, stagehand.CreateOptions{
+	Browser: browser,
 	Telemetry: stagehand.TelemetryConfig{
 		Traces: stagehand.TelemetryTraces{
 			Endpoint: "https://otlp.example.com/v1/traces",
@@ -1057,8 +1063,7 @@ client := stagehand.New(stagehand.StagehandClientInitParams{
 		},
 	},
 })
-
-if err := client.Init(ctx); err != nil {
+if err != nil {
 	return err
 }
 defer func() { err = errors.Join(err, client.Close(ctx)) }()

--- a/packages/docs/v4/first-steps/ai-rules.mdx
+++ b/packages/docs/v4/first-steps/ai-rules.mdx
@@ -98,19 +98,19 @@ The main class can be imported as `Stagehand` from `@browserbasehq/stagehand`.
 **Key Classes:**
 
 - `Stagehand`: Main orchestrator class providing `act`, `extract`, and `observe` methods
-- `stagehand.context`: A `BrowserContext` object that manages pages, cookies, and the clipboard
-- `page`: Individual page objects accessed via `stagehand.context.activePage()`, `stagehand.context.pages()`, or created with `stagehand.context.newPage()`
+- `browser.context`: A `BrowserContext` object that manages pages, cookies, and the clipboard
+- `page`: Individual page objects accessed via `browser.context.activePage()`, `browser.context.pages()`, or created with `browser.context.newPage()`
 
 There is no `agent` API in v4. Compose `observe`, `act`, and `extract` in your own control flow instead.
 
 ## Initialize
 
 ```typescript
-import { Stagehand } from "@browserbasehq/stagehand";
+import { browserbase, localBrowser, Stagehand } from "@browserbasehq/stagehand";
 
-const stagehand = new Stagehand({
-  // Browser source: "browserbase" (default), "local", or "cdp"
-  browser: { type: "local", headless: true },
+const browser = await localBrowser.launch({ headless: true });
+const stagehand = await Stagehand.create({
+  browser,
   model: {
     modelName: "openai/gpt-5.4-mini",
     apiKey: process.env.OPENAI_API_KEY,
@@ -118,22 +118,22 @@ const stagehand = new Stagehand({
   logging: { level: "info", format: "pretty" },
 });
 
-await stagehand.init();
-
 // Access the browser context and pages
-const page = await stagehand.context.activePage();
-const context = stagehand.context;
+const [page] = await browser.context.pages();
+const context = browser.context;
 
 // Create new pages if needed
-const page2 = await stagehand.context.newPage();
+const page2 = await browser.context.newPage();
 ```
 
 For Browserbase cloud browsers, pass a Browserbase API key at the top level:
 
 ```typescript
-const stagehand = new Stagehand({
+const browser = await browserbase.launch({
   apiKey: process.env.BROWSERBASE_API_KEY,
-  browser: { type: "browserbase" },
+});
+const stagehand = await Stagehand.create({
+  browser,
   model: { modelName: "openai/gpt-5.4-mini", apiKey: process.env.OPENAI_API_KEY },
 });
 ```
@@ -318,10 +318,10 @@ const count = await page.locator("li.result").count();
 ### Multi-Page Workflows
 
 ```typescript
-const page1 = await stagehand.context.newPage();
+const page1 = await browser.context.newPage();
 await page1.goto("https://example.com");
 
-const page2 = await stagehand.context.newPage();
+const page2 = await browser.context.newPage();
 await page2.goto("https://example2.com");
 
 // Act/extract/observe operate on the current active page by default
@@ -335,31 +335,37 @@ await stagehand.extract("get title", z.object({ title: z.string() }), { page: pa
 Server-side caching requires a Browserbase browser source and a Browserbase API key:
 
 ```typescript
-const stagehand = new Stagehand({
+const browser = await browserbase.launch({
   apiKey: process.env.BROWSERBASE_API_KEY,
-  browser: { type: "browserbase" },
+});
+const stagehand = await Stagehand.create({
+  browser,
   cache: true, // or { threshold: 1 }
 });
 ```
 
 ## Cleanup
 
-Always close Stagehand in a `finally` block:
+Close Stagehand before closing its browser:
 
 ```typescript
 try {
-  await stagehand.init();
-  // ...
+  const stagehand = await Stagehand.create({ browser });
+  try {
+    // ...
+  } finally {
+    await stagehand.close();
+  }
 } finally {
-  await stagehand.close();
+  await browser.close();
 }
 ```
 
 ## Project Structure Best Practices
 
 - Read configuration from environment variables and pass it explicitly to the `Stagehand` constructor
-- Construct and initialize `Stagehand` in one place, then pass the instance into your automation functions
-- Use `async`/`await` consistently; `init`, `act`, `extract`, `observe`, and `close` all return promises
+- Create the browser first, pass it to `Stagehand.create()`, then pass the instance into your automation functions
+- Use `async`/`await` consistently; `create`, `act`, `extract`, `observe`, and `close` all return promises
 - Keep Zod schemas next to the code that consumes them and reuse `z.infer` for the decoded type
 - Wrap every workflow in `try`/`finally` so `close` runs even when a step throws
 - Prefer narrow, atomic instructions over one instruction that describes a whole workflow
@@ -394,8 +400,8 @@ The main class can be imported as `Stagehand` from `stagehand`.
 **Key Classes:**
 
 - `Stagehand`: Main orchestrator class providing `act`, `extract`, and `observe` methods
-- `stagehand.context`: A `BrowserContext` object that manages pages, cookies, and the clipboard
-- `page`: Individual page objects accessed via `stagehand.context.active_page()`, `stagehand.context.pages()`, or created with `stagehand.context.new_page()`
+- `browser.context`: A `BrowserContext` object that manages pages, cookies, and the clipboard
+- `page`: Individual page objects accessed via `browser.context.active_page()`, `browser.context.pages()`, or created with `browser.context.new_page()`
 
 There is no `agent` API in v4. Compose `observe`, `act`, and `extract` in your own control flow instead.
 
@@ -407,34 +413,31 @@ All Stagehand methods are async. `act`, `observe`, and `extract` take `instructi
 ```python
 import os
 
-from stagehand import Stagehand
+from stagehand import Stagehand, browserbase, local_browser
 
-stagehand = Stagehand(
-    # Browser source: "browserbase" (default), "local", or "cdp"
-    browser="local",
-    headless=True,
+browser = await local_browser.launch(headless=True)
+stagehand = await Stagehand.create(
+    browser=browser,
     model="openai/gpt-5.4-mini",
     model_api_key=os.environ["OPENAI_API_KEY"],
     logging={"level": "info", "format": "pretty"},
 )
 
-await stagehand.init()
-
 # Access the browser context and pages
-page = await stagehand.context.active_page()
-context = stagehand.context
+page = (await browser.context.pages())[0]
+context = browser.context
 
 # Create new pages if needed
-page2 = await stagehand.context.new_page()
+page2 = await browser.context.new_page()
 ```
 
 For Browserbase cloud browsers, pass a Browserbase API key:
 
 ```python
-stagehand = Stagehand(
+browser = await browserbase.launch(
     api_key=os.environ["BROWSERBASE_API_KEY"],
-    browser="browserbase",
 )
+stagehand = await Stagehand.create(browser=browser)
 ```
 
 With no model configured, Browserbase Model Gateway selects one automatically for each inference call.
@@ -638,10 +641,10 @@ count = await page.locator("li.result").count()
 ### Multi-Page Workflows
 
 ```python
-page1 = await stagehand.context.new_page()
+page1 = await browser.context.new_page()
 await page1.goto("https://example.com")
 
-page2 = await stagehand.context.new_page()
+page2 = await browser.context.new_page()
 await page2.goto("https://example2.com")
 
 # Act/extract/observe operate on the current active page by default
@@ -655,20 +658,29 @@ await stagehand.extract("get title", Title, page=page2)
 Server-side caching requires a Browserbase browser source and a Browserbase API key:
 
 ```python
-stagehand = Stagehand(
+browser = await browserbase.launch(
     api_key=os.environ["BROWSERBASE_API_KEY"],
-    browser="browserbase",
+)
+stagehand = await Stagehand.create(
+    browser=browser,
     cache=True,  # or CacheOptions(threshold=1)
 )
 ```
 
 ## Cleanup
 
-Use the async context manager, or always close in a `finally` block:
+Close Stagehand before closing its browser:
 
 ```python
-async with Stagehand(browser="local", headless=True) as stagehand:
-    ...
+browser = await local_browser.launch(headless=True)
+try:
+    stagehand = await Stagehand.create(browser=browser)
+    try:
+        ...
+    finally:
+        await stagehand.close()
+finally:
+    await browser.close()
 ```
 
 ## Project Structure Best Practices
@@ -709,8 +721,8 @@ Import the package as `stagehand "github.com/browserbase/stagehand/packages/sdk-
 
 **Key Types:**
 
-- `*stagehand.Stagehand`: Main client, constructed with `stagehand.New`, providing `Act`, `Extract`, and `Observe`
-- `*stagehand.BrowserContext`: Returned by `client.Context()`, manages pages, cookies, and the clipboard
+- `*stagehand.Stagehand`: Main client, constructed with `stagehand.Create`, providing `Act`, `Extract`, and `Observe`
+- `*stagehand.BrowserContext`: Returned by `browser.Context()`, manages pages, cookies, and the clipboard
 - `*stagehand.Page`: Individual pages from `browserContext.ActivePage(ctx)`, `browserContext.Pages(ctx)`, or `browserContext.NewPage(ctx, params)`
 
 There is no agent API in v4. Compose `Observe`, `Act`, and `Extract` in your own control flow instead.
@@ -721,34 +733,35 @@ Every method takes a `context.Context` as its first argument and returns an `err
 
 ```go
 apiKey := os.Getenv("OPENAI_API_KEY")
-model := stagehand.KnownModel(stagehand.KnownModelConfig{
+model := stagehand.ModelConfig{
 	ModelName: "openai/gpt-5.4-mini",
 	APIKey:    &apiKey,
-})
+}
 
-// Browser source: BrowserbaseClientBrowserSource (default), LocalBrowserSource, or CDPBrowserSource
-client := stagehand.New(stagehand.StagehandClientInitParams{
-	Browser: stagehand.LocalBrowserSource{Headless: true},
-	Model:   &model,
-})
-
-if err := client.Init(ctx); err != nil {
+browser, err := stagehand.LaunchLocalBrowser(ctx, &stagehand.LocalBrowserLaunchOptions{Headless: true})
+if err != nil {
+	return err
+}
+defer func() { err = errors.Join(err, browser.Close(ctx)) }()
+client, err := stagehand.Create(ctx, stagehand.CreateOptions{Browser: browser, Model: &model})
+if err != nil {
 	return err
 }
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 
 // Access the browser context and pages
-browserContext, err := client.Context()
+browserContext, err := browser.Context()
 if err != nil {
 	return err
 }
-page, err := browserContext.ActivePage(ctx)
+pages, err := browserContext.Pages(ctx)
 if err != nil {
 	return err
 }
-if page == nil {
+if len(pages) == 0 {
 	return errors.New("Stagehand initialized without an active page")
 }
+page := pages[0]
 
 // Create new pages if needed
 page2, err := browserContext.NewPage(ctx, stagehand.ContextNewPageParams{})
@@ -764,12 +777,14 @@ For Browserbase cloud browsers, pass a Browserbase API key at the top level:
 
 ```go
 browserbaseAPIKey := os.Getenv("BROWSERBASE_API_KEY")
-client := stagehand.New(stagehand.StagehandClientInitParams{
-	APIKey:  &browserbaseAPIKey,
-	Browser: stagehand.BrowserbaseClientBrowserSource{},
-	Model:   &model,
+browser, err := stagehand.LaunchBrowserbase(ctx, stagehand.BrowserbaseLaunchOptions{
+	APIKey: browserbaseAPIKey,
 })
-if err := client.Init(ctx); err != nil {
+if err != nil {
+	return err
+}
+client, err := stagehand.Create(ctx, stagehand.CreateOptions{Browser: browser, Model: &model})
+if err != nil {
 	return err
 }
 ```
@@ -1102,12 +1117,17 @@ Server-side caching requires a Browserbase browser source and a Browserbase API 
 
 ```go
 cache := stagehand.CacheEnabled(true) // or stagehand.CacheWithThreshold(1)
-client := stagehand.New(stagehand.StagehandClientInitParams{
-	APIKey:  &browserbaseAPIKey,
-	Browser: stagehand.BrowserbaseClientBrowserSource{},
+browser, err := stagehand.LaunchBrowserbase(ctx, stagehand.BrowserbaseLaunchOptions{
+	APIKey: browserbaseAPIKey,
+})
+if err != nil {
+	return err
+}
+client, err := stagehand.Create(ctx, stagehand.CreateOptions{
+	Browser: browser,
 	Cache:   &cache,
 })
-if err := client.Init(ctx); err != nil {
+if err != nil {
 	return err
 }
 ```
@@ -1118,10 +1138,13 @@ Always close the client. The idiomatic pattern is a named error return plus a de
 
 ```go
 func run(ctx context.Context) (err error) {
-	client := stagehand.New(stagehand.StagehandClientInitParams{
-		Browser: stagehand.LocalBrowserSource{Headless: true},
-	})
-	if err := client.Init(ctx); err != nil {
+	browser, err := stagehand.LaunchLocalBrowser(ctx, &stagehand.LocalBrowserLaunchOptions{Headless: true})
+	if err != nil {
+		return err
+	}
+	defer func() { err = errors.Join(err, browser.Close(ctx)) }()
+	client, err := stagehand.Create(ctx, stagehand.CreateOptions{Browser: browser})
+	if err != nil {
 		return err
 	}
 	defer func() { err = errors.Join(err, client.Close(ctx)) }()

--- a/packages/docs/v4/first-steps/installation.mdx
+++ b/packages/docs/v4/first-steps/installation.mdx
@@ -65,16 +65,17 @@ export BROWSERBASE_API_KEY=your_api_key
 <Note>
 Stagehand does not read environment variables on your behalf, and it does not auto-load env files.
 
-Read the values in your own app code and pass them explicitly to the constructor:
+Read the values in your own app code and pass them explicitly to the browser factory:
 
 <View title="TypeScript" icon="js">
 ```typescript
 // Optional: install dotenv first (pnpm add dotenv), then load an env file yourself
 import "dotenv/config";
 
-const stagehand = new Stagehand({
+const browser = await browserbase.launch({
   apiKey: process.env.BROWSERBASE_API_KEY,
 });
+const stagehand = await Stagehand.create({ browser });
 ```
 </View>
 
@@ -82,9 +83,10 @@ const stagehand = new Stagehand({
 ```python
 import os
 
-stagehand = Stagehand(
+browser = await browserbase.launch(
     api_key=os.environ["BROWSERBASE_API_KEY"],
 )
+stagehand = await Stagehand.create(browser=browser)
 ```
 </View>
 
@@ -93,9 +95,11 @@ stagehand = Stagehand(
 // Every optional field is a pointer, so read your key into a variable first
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 
-client := stagehand.New(stagehand.StagehandClientInitParams{
-	APIKey: &apiKey,
-})
+browser, err := stagehand.LaunchBrowserbase(ctx, stagehand.BrowserbaseLaunchOptions{APIKey: apiKey})
+if err != nil {
+	return err
+}
+client, err := stagehand.Create(ctx, stagehand.CreateOptions{Browser: browser})
 ```
 </View>
 </Note>
@@ -106,36 +110,35 @@ Add Stagehand where you need browser automation.
 
 <View title="TypeScript" icon="js">
 ```typescript
-import { Stagehand } from "@browserbasehq/stagehand";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 import { z } from "zod/v4";
 
 async function main() {
-  const stagehand = new Stagehand({
+  const browser = await browserbase.launch({
     apiKey: process.env.BROWSERBASE_API_KEY,
-    browser: { type: "browserbase" },
   });
-
-  await stagehand.init();
-
-  // Close in a finally block so the session is released even if a step throws
   try {
-    const page = await stagehand.context.activePage();
-    if (!page) throw new Error("Stagehand initialized without an active page");
+    const stagehand = await Stagehand.create({ browser });
+    try {
+      const [page] = await browser.context.pages();
 
-    await page.goto("https://example.com");
+      await page.goto("https://example.com");
 
-    // Act on the page
-    await stagehand.act("Click the learn more button");
+      // Act on the page
+      await stagehand.act("Click the learn more button");
 
-    // Extract structured data
-    const { data } = await stagehand.extract(
-      "extract the description",
-      z.object({ description: z.string() }),
-    );
+      // Extract structured data
+      const { data } = await stagehand.extract(
+        "extract the description",
+        z.object({ description: z.string() }),
+      );
 
-    console.log(data.description);
+      console.log(data.description);
+    } finally {
+      await stagehand.close();
+    }
   } finally {
-    await stagehand.close();
+    await browser.close();
   }
 }
 
@@ -152,7 +155,7 @@ import asyncio
 import os
 
 from pydantic import BaseModel
-from stagehand import Stagehand
+from stagehand import Stagehand, browserbase
 
 
 class Description(BaseModel):
@@ -160,33 +163,30 @@ class Description(BaseModel):
 
 
 async def main() -> None:
-    stagehand = Stagehand(
+    browser = await browserbase.launch(
         api_key=os.environ["BROWSERBASE_API_KEY"],
-        browser="browserbase",
     )
-
-    await stagehand.init()
-
-    # Close in a finally block so the session is released even if a step raises
     try:
-        page = await stagehand.context.active_page()
-        if page is None:
-            raise RuntimeError("Stagehand initialized without an active page")
+        stagehand = await Stagehand.create(browser=browser)
+        try:
+            page = (await browser.context.pages())[0]
 
-        await page.goto("https://example.com")
+            await page.goto("https://example.com")
 
-        # Act on the page
-        await stagehand.act("Click the learn more button")
+            # Act on the page
+            await stagehand.act("Click the learn more button")
 
-        # Extract structured data
-        result = await stagehand.extract(
-            "extract the description",
-            Description,
-        )
+            # Extract structured data
+            result = await stagehand.extract(
+                "extract the description",
+                Description,
+            )
 
-        print(result.data.description)
+            print(result.data.description)
+        finally:
+            await stagehand.close()
     finally:
-        await stagehand.close()
+        await browser.close()
 
 
 asyncio.run(main())
@@ -228,27 +228,30 @@ func main() {
 func run(ctx context.Context) (err error) {
 	apiKey := os.Getenv("BROWSERBASE_API_KEY")
 
-	client := stagehand.New(stagehand.StagehandClientInitParams{
-		APIKey:  &apiKey,
-		Browser: stagehand.BrowserbaseClientBrowserSource{},
-	})
+	browser, err := stagehand.LaunchBrowserbase(ctx, stagehand.BrowserbaseLaunchOptions{APIKey: apiKey})
+	if err != nil {
+		return err
+	}
+	defer func() { err = errors.Join(err, browser.Close(ctx)) }()
 
-	if err := client.Init(ctx); err != nil {
+	client, err := stagehand.Create(ctx, stagehand.CreateOptions{Browser: browser})
+	if err != nil {
 		return err
 	}
 	defer func() { err = errors.Join(err, client.Close(ctx)) }()
 
-	browserContext, err := client.Context()
+	browserContext, err := browser.Context()
 	if err != nil {
 		return err
 	}
-	page, err := browserContext.ActivePage(ctx)
+	pages, err := browserContext.Pages(ctx)
 	if err != nil {
 		return err
 	}
-	if page == nil {
+	if len(pages) == 0 {
 		return errors.New("Stagehand initialized without an active page")
 	}
+	page := pages[0]
 
 	if err := page.Goto(ctx, "https://example.com", nil); err != nil {
 		return err

--- a/packages/docs/v4/first-steps/quickstart.mdx
+++ b/packages/docs/v4/first-steps/quickstart.mdx
@@ -41,38 +41,36 @@ Create the example script (`index.ts`, `main.py`, or `main.go`). It exercises al
 
 <View title="TypeScript" icon="js">
 ```typescript
-import { Stagehand } from "@browserbasehq/stagehand";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 import { z } from "zod/v4";
 
 async function main() {
-  const stagehand = new Stagehand({
+  const browser = await browserbase.launch({
     apiKey: process.env.BROWSERBASE_API_KEY,
-    browser: { type: "browserbase" },
   });
-
-  await stagehand.init();
-
-  console.log("Stagehand session started");
-
   try {
-    const page = await stagehand.context.activePage();
-    if (!page) throw new Error("Stagehand initialized without an active page");
+    const stagehand = await Stagehand.create({ browser });
+    console.log("Stagehand session started");
+    try {
+      const [page] = await browser.context.pages();
 
-    await page.goto("https://stagehand.dev");
+      await page.goto("https://stagehand.dev");
 
-    const extractResult = await stagehand.extract(
-      "Extract the value proposition from the page.",
-      z.object({ valueProposition: z.string() }),
-    );
-    console.log("Extract result:\n", extractResult.data);
+      const extractResult = await stagehand.extract(
+        "Extract the value proposition from the page.",
+        z.object({ valueProposition: z.string() }),
+      );
+      console.log("Extract result:\n", extractResult.data);
 
-    await stagehand.act("Click the 'Evals' button.");
+      await stagehand.act("Click the 'Evals' button.");
 
-    const observeResult = await stagehand.observe("What can I click on this page?");
-    console.log("Observe result:\n", observeResult.data);
+      const observeResult = await stagehand.observe("What can I click on this page?");
+      console.log("Observe result:\n", observeResult.data);
+    } finally {
+      await stagehand.close();
+    }
   } finally {
-    // Always release the session, even when a step above throws
-    await stagehand.close();
+    await browser.close();
   }
 }
 
@@ -89,7 +87,7 @@ import asyncio
 import os
 
 from pydantic import BaseModel
-from stagehand import Stagehand
+from stagehand import Stagehand, browserbase
 
 
 class ValueProposition(BaseModel):
@@ -97,35 +95,31 @@ class ValueProposition(BaseModel):
 
 
 async def main() -> None:
-    stagehand = Stagehand(
+    browser = await browserbase.launch(
         api_key=os.environ["BROWSERBASE_API_KEY"],
-        browser="browserbase",
     )
-
-    await stagehand.init()
-
-    print("Stagehand session started")
-
     try:
-        page = await stagehand.context.active_page()
-        if page is None:
-            raise RuntimeError("Stagehand initialized without an active page")
+        stagehand = await Stagehand.create(browser=browser)
+        print("Stagehand session started")
+        try:
+            page = (await browser.context.pages())[0]
 
-        await page.goto("https://stagehand.dev")
+            await page.goto("https://stagehand.dev")
 
-        extract_result = await stagehand.extract(
-            "Extract the value proposition from the page.",
-            ValueProposition,
-        )
-        print("Extract result:\n", extract_result.data)
+            extract_result = await stagehand.extract(
+                "Extract the value proposition from the page.",
+                ValueProposition,
+            )
+            print("Extract result:\n", extract_result.data)
 
-        await stagehand.act("Click the 'Evals' button.")
+            await stagehand.act("Click the 'Evals' button.")
 
-        observe_result = await stagehand.observe("What can I click on this page?")
-        print("Observe result:\n", observe_result.data)
+            observe_result = await stagehand.observe("What can I click on this page?")
+            print("Observe result:\n", observe_result.data)
+        finally:
+            await stagehand.close()
     finally:
-        # Always release the session, even when a step above raises
-        await stagehand.close()
+        await browser.close()
 
 
 asyncio.run(main())
@@ -167,29 +161,32 @@ func main() {
 func run(ctx context.Context) (err error) {
 	apiKey := os.Getenv("BROWSERBASE_API_KEY")
 
-	client := stagehand.New(stagehand.StagehandClientInitParams{
-		APIKey:  &apiKey,
-		Browser: stagehand.BrowserbaseClientBrowserSource{},
-	})
+	browser, err := stagehand.LaunchBrowserbase(ctx, stagehand.BrowserbaseLaunchOptions{APIKey: apiKey})
+	if err != nil {
+		return err
+	}
+	defer func() { err = errors.Join(err, browser.Close(ctx)) }()
 
-	if err := client.Init(ctx); err != nil {
+	client, err := stagehand.Create(ctx, stagehand.CreateOptions{Browser: browser})
+	if err != nil {
 		return err
 	}
 	defer func() { err = errors.Join(err, client.Close(ctx)) }()
 
 	fmt.Println("Stagehand session started")
 
-	browserContext, err := client.Context()
+	browserContext, err := browser.Context()
 	if err != nil {
 		return err
 	}
-	page, err := browserContext.ActivePage(ctx)
+	pages, err := browserContext.Pages(ctx)
 	if err != nil {
 		return err
 	}
-	if page == nil {
+	if len(pages) == 0 {
 		return errors.New("Stagehand initialized without an active page")
 	}
+	page := pages[0]
 
 	if err := page.Goto(ctx, "https://stagehand.dev", nil); err != nil {
 		return err

--- a/packages/docs/v4/index.mdx
+++ b/packages/docs/v4/index.mdx
@@ -19,18 +19,19 @@ pnpm add @browserbasehq/stagehand
 **Initialize Stagehand**
 
 ```typescript
-import { Stagehand } from "@browserbasehq/stagehand";
+import { localBrowser, Stagehand } from "@browserbasehq/stagehand";
 
-const stagehand = new Stagehand({
-  browser: { type: "local" },
-});
-
+const browser = await localBrowser.launch();
 try {
-  await stagehand.init();
-  const page = await stagehand.context.newPage();
-  await page.goto("https://example.com");
+  const stagehand = await Stagehand.create({ browser });
+  try {
+    const [page] = await browser.context.pages();
+    await page.goto("https://example.com");
+  } finally {
+    await stagehand.close();
+  }
 } finally {
-  await stagehand.close();
+  await browser.close();
 }
 ```
 
@@ -49,17 +50,20 @@ pip install stagehand
 ```python
 import asyncio
 
-from stagehand import Stagehand
+from stagehand import Stagehand, local_browser
 
 
 async def main() -> None:
-    stagehand = Stagehand(browser="local")
+    browser = await local_browser.launch()
     try:
-        await stagehand.init()
-        page = await stagehand.context.new_page()
-        await page.goto("https://example.com")
+        stagehand = await Stagehand.create(browser=browser)
+        try:
+            page = (await browser.context.pages())[0]
+            await page.goto("https://example.com")
+        finally:
+            await stagehand.close()
     finally:
-        await stagehand.close()
+        await browser.close()
 
 
 asyncio.run(main())

--- a/packages/docs/v4/reference/clipboard.mdx
+++ b/packages/docs/v4/reference/clipboard.mdx
@@ -11,7 +11,7 @@ Access `BrowserClipboard` from the browser context. Clipboard operations target 
 ## Quick start
 
 ```typescript
-const clipboard = stagehand.context.clipboard;
+const clipboard = browser.context.clipboard;
 await clipboard.writeText("Hello");
 ```
 
@@ -20,7 +20,7 @@ await clipboard.writeText("Hello");
 Read plain text from the browser clipboard.
 
 ```typescript
-const text = await stagehand.context.clipboard.readText();
+const text = await browser.context.clipboard.readText();
 ```
 
 <ParamField path="options" type="ClipboardOptions" optional>
@@ -40,7 +40,7 @@ const text = await stagehand.context.clipboard.readText();
 Write plain text to the browser clipboard.
 
 ```typescript
-await stagehand.context.clipboard.writeText("Hello");
+await browser.context.clipboard.writeText("Hello");
 ```
 
 <ParamField path="text" type="string">
@@ -64,7 +64,7 @@ await stagehand.context.clipboard.writeText("Hello");
 Clear the browser clipboard.
 
 ```typescript
-await stagehand.context.clipboard.clear();
+await browser.context.clipboard.clear();
 ```
 
 <ParamField path="options" type="ClipboardOptions" optional>
@@ -84,7 +84,7 @@ await stagehand.context.clipboard.clear();
 Paste the clipboard contents into the active element.
 
 ```typescript
-await stagehand.context.clipboard.paste();
+await browser.context.clipboard.paste();
 ```
 
 <ParamField path="options" type="ClipboardPasteOptions" optional>
@@ -112,7 +112,7 @@ await stagehand.context.clipboard.paste();
 Copy the current selection to the browser clipboard.
 
 ```typescript
-await stagehand.context.clipboard.copy();
+await browser.context.clipboard.copy();
 ```
 
 <ParamField path="options" type="ClipboardOptions" optional>
@@ -132,7 +132,7 @@ await stagehand.context.clipboard.copy();
 Cut the current selection to the browser clipboard.
 
 ```typescript
-await stagehand.context.clipboard.cut();
+await browser.context.clipboard.cut();
 ```
 
 <ParamField path="options" type="ClipboardOptions" optional>
@@ -154,7 +154,7 @@ await stagehand.context.clipboard.cut();
 ## Quick start
 
 ```python
-clipboard = stagehand.context.clipboard
+clipboard = browser.context.clipboard
 await clipboard.write_text("Hello")
 ```
 
@@ -163,7 +163,7 @@ await clipboard.write_text("Hello")
 Read plain text from the browser clipboard.
 
 ```python
-text = await stagehand.context.clipboard.read_text()
+text = await browser.context.clipboard.read_text()
 ```
 
 <ParamField path="page" type="Page | None" optional>
@@ -179,7 +179,7 @@ text = await stagehand.context.clipboard.read_text()
 Write plain text to the browser clipboard.
 
 ```python
-await stagehand.context.clipboard.write_text("Hello")
+await browser.context.clipboard.write_text("Hello")
 ```
 
 <ParamField path="text" type="str">
@@ -199,7 +199,7 @@ await stagehand.context.clipboard.write_text("Hello")
 Clear the browser clipboard.
 
 ```python
-await stagehand.context.clipboard.clear()
+await browser.context.clipboard.clear()
 ```
 
 <ParamField path="page" type="Page | None" optional>
@@ -215,7 +215,7 @@ await stagehand.context.clipboard.clear()
 Paste the clipboard contents into the active element.
 
 ```python
-await stagehand.context.clipboard.paste()
+await browser.context.clipboard.paste()
 ```
 
 <ParamField path="page" type="Page | None" optional>
@@ -239,7 +239,7 @@ await stagehand.context.clipboard.paste()
 Copy the current selection to the browser clipboard.
 
 ```python
-await stagehand.context.clipboard.copy()
+await browser.context.clipboard.copy()
 ```
 
 <ParamField path="page" type="Page | None" optional>
@@ -255,7 +255,7 @@ await stagehand.context.clipboard.copy()
 Cut the current selection to the browser clipboard.
 
 ```python
-await stagehand.context.clipboard.cut()
+await browser.context.clipboard.cut()
 ```
 
 <ParamField path="page" type="Page | None" optional>

--- a/packages/docs/v4/reference/context.mdx
+++ b/packages/docs/v4/reference/context.mdx
@@ -11,7 +11,7 @@ Use `BrowserContext` to coordinate pages and browser state that is shared across
 ## Quick start
 
 ```typescript
-const context = stagehand.context;
+const context = browser.context;
 const page = await context.newPage();
 ```
 
@@ -20,7 +20,7 @@ const page = await context.newPage();
 Return every open page in the browser context.
 
 ```typescript
-const pages = await stagehand.context.pages();
+const pages = await browser.context.pages();
 ```
 
 <ResponseField name="result" type="Promise<Page[]>">
@@ -32,7 +32,7 @@ const pages = await stagehand.context.pages();
 Create a new page in the browser context.
 
 ```typescript
-const page = await stagehand.context.newPage({ url: "https://example.com" });
+const page = await browser.context.newPage({ url: "https://example.com" });
 ```
 
 <ParamField path="options" type="ContextNewPageParams" optional>
@@ -52,7 +52,7 @@ const page = await stagehand.context.newPage({ url: "https://example.com" });
 Return the page that is currently active.
 
 ```typescript
-const page = await stagehand.context.activePage();
+const [page] = await browser.context.pages();
 ```
 
 <ResponseField name="result" type="Promise<Page | undefined>">
@@ -64,7 +64,7 @@ const page = await stagehand.context.activePage();
 Make a page the active page in the browser context.
 
 ```typescript
-await stagehand.context.setActivePage(page);
+await browser.context.setActivePage(page);
 ```
 
 <ParamField path="page" type="Page">
@@ -80,7 +80,7 @@ await stagehand.context.setActivePage(page);
 Close the remote browser context.
 
 ```typescript
-await stagehand.context.close();
+await browser.context.close();
 ```
 
 <ResponseField name="result" type="Promise<void>">
@@ -92,7 +92,7 @@ await stagehand.context.close();
 Run a script before scripts on every newly created page.
 
 ```typescript
-await stagehand.context.addInitScript(() => {
+await browser.context.addInitScript(() => {
   window.localStorage.clear();
 });
 ```
@@ -114,7 +114,7 @@ await stagehand.context.addInitScript(() => {
 Set additional HTTP headers for every page in the context.
 
 ```typescript
-await stagehand.context.setExtraHTTPHeaders({ "x-test": "true" });
+await browser.context.setExtraHTTPHeaders({ "x-test": "true" });
 ```
 
 <ParamField path="headers" type="Record<string, string>">
@@ -130,7 +130,7 @@ await stagehand.context.setExtraHTTPHeaders({ "x-test": "true" });
 Return the context's current domain policy.
 
 ```typescript
-const policy = await stagehand.context.getDomainPolicy();
+const policy = await browser.context.getDomainPolicy();
 ```
 
 <ResponseField name="result" type="Promise<DomainPolicy | null>">
@@ -150,7 +150,7 @@ const policy = await stagehand.context.getDomainPolicy();
 Set or clear the context's domain policy.
 
 ```typescript
-await stagehand.context.setDomainPolicy(null);
+await browser.context.setDomainPolicy(null);
 ```
 
 <ParamField path="policy" type="DomainPolicy | null">
@@ -174,7 +174,7 @@ await stagehand.context.setDomainPolicy(null);
 Return cookies, optionally filtered to one or more URLs.
 
 ```typescript
-const cookies = await stagehand.context.cookies("https://example.com");
+const cookies = await browser.context.cookies("https://example.com");
 ```
 
 <ParamField path="urls" type="string | string[]" optional>
@@ -222,7 +222,7 @@ const cookies = await stagehand.context.cookies("https://example.com");
 Add cookies to the browser context.
 
 ```typescript
-await stagehand.context.addCookies([cookie]);
+await browser.context.addCookies([cookie]);
 ```
 
 <ParamField path="cookies" type="CookieParam[]">
@@ -274,7 +274,7 @@ await stagehand.context.addCookies([cookie]);
 Clear cookies that match optional name, domain, and path filters.
 
 ```typescript
-await stagehand.context.clearCookies({ domain: "example.com" });
+await browser.context.clearCookies({ domain: "example.com" });
 ```
 
 <ParamField path="options" type="ClearCookieOptions" optional>
@@ -304,7 +304,7 @@ await stagehand.context.clearCookies({ domain: "example.com" });
 ## Quick start
 
 ```python
-context = stagehand.context
+context = browser.context
 page = await context.new_page()
 ```
 
@@ -313,7 +313,7 @@ page = await context.new_page()
 Return every open page in the browser context.
 
 ```python
-pages = await stagehand.context.pages()
+pages = await browser.context.pages()
 ```
 
 <ResponseField name="result" type="list[Page]">
@@ -325,7 +325,7 @@ pages = await stagehand.context.pages()
 Create a new page in the browser context.
 
 ```python
-page = await stagehand.context.new_page(url="https://example.com")
+page = await browser.context.new_page(url="https://example.com")
 ```
 
 <ParamField path="url" type="str | None" optional>
@@ -341,7 +341,7 @@ page = await stagehand.context.new_page(url="https://example.com")
 Return the page that is currently active.
 
 ```python
-page = await stagehand.context.active_page()
+page = (await browser.context.pages())[0]
 ```
 
 <ResponseField name="result" type="Page | None">
@@ -353,7 +353,7 @@ page = await stagehand.context.active_page()
 Make a page the active page in the browser context.
 
 ```python
-await stagehand.context.set_active_page(page)
+await browser.context.set_active_page(page)
 ```
 
 <ParamField path="page" type="Page">
@@ -369,7 +369,7 @@ await stagehand.context.set_active_page(page)
 Close the remote browser context.
 
 ```python
-await stagehand.context.close()
+await browser.context.close()
 ```
 
 <ResponseField name="result" type="None">
@@ -381,7 +381,7 @@ await stagehand.context.close()
 Run a script before scripts on every newly created page.
 
 ```python
-await stagehand.context.add_init_script("window.localStorage.clear()")
+await browser.context.add_init_script("window.localStorage.clear()")
 ```
 
 <ParamField path="source" type="str | Path">
@@ -397,7 +397,7 @@ await stagehand.context.add_init_script("window.localStorage.clear()")
 Set additional HTTP headers for every page in the context.
 
 ```python
-await stagehand.context.set_extra_http_headers({"x-test": "true"})
+await browser.context.set_extra_http_headers({"x-test": "true"})
 ```
 
 <ParamField path="headers" type="Mapping[str, str]">
@@ -413,7 +413,7 @@ await stagehand.context.set_extra_http_headers({"x-test": "true"})
 Return the context's current domain policy.
 
 ```python
-policy = await stagehand.context.get_domain_policy()
+policy = await browser.context.get_domain_policy()
 ```
 
 <ResponseField name="result" type="DomainPolicy | None">
@@ -433,7 +433,7 @@ policy = await stagehand.context.get_domain_policy()
 Set or clear the context's domain policy.
 
 ```python
-await stagehand.context.set_domain_policy(None)
+await browser.context.set_domain_policy(None)
 ```
 
 <ParamField path="policy" type="DomainPolicy | DomainPolicyInput | None">
@@ -457,7 +457,7 @@ await stagehand.context.set_domain_policy(None)
 Return cookies, optionally filtered to one or more URLs.
 
 ```python
-cookies = await stagehand.context.cookies("https://example.com")
+cookies = await browser.context.cookies("https://example.com")
 ```
 
 <ParamField path="urls" type="str | Sequence[str] | None" optional>
@@ -505,7 +505,7 @@ cookies = await stagehand.context.cookies("https://example.com")
 Add cookies to the browser context.
 
 ```python
-await stagehand.context.add_cookies([cookie])
+await browser.context.add_cookies([cookie])
 ```
 
 <ParamField path="cookies" type="Sequence[CookieParam]">
@@ -557,7 +557,7 @@ await stagehand.context.add_cookies([cookie])
 Clear cookies that match optional name, domain, and path filters.
 
 ```python
-await stagehand.context.clear_cookies(domain="example.com")
+await browser.context.clear_cookies(domain="example.com")
 ```
 
 <ParamField path="name" type="str | re.Pattern[str] | None" optional>

--- a/packages/docs/v4/reference/page.mdx
+++ b/packages/docs/v4/reference/page.mdx
@@ -11,7 +11,7 @@ A `Page` combines deterministic browser controls with Stagehand's natural-langua
 ## Quick start
 
 ```typescript
-const page = await stagehand.context.newPage();
+const page = await browser.context.newPage();
 const response = await page.goto("https://example.com");
 ```
 
@@ -670,7 +670,7 @@ const locator = page.locator("button[type=submit]");
 ## Quick start
 
 ```python
-page = await stagehand.context.new_page()
+page = await browser.context.new_page()
 response = await page.goto("https://example.com")
 ```
 

--- a/packages/sdk-go/client_test.go
+++ b/packages/sdk-go/client_test.go
@@ -106,7 +106,7 @@ func TestThinClientUsesGeneratedBoundaryTypes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create() error = %v", err)
 	}
-	browserContext, err := client.Context()
+	browserContext, err := client.Browser().Context()
 	if err != nil {
 		t.Fatalf("Context() error = %v", err)
 	}

--- a/packages/sdk-go/examples/act.go
+++ b/packages/sdk-go/examples/act.go
@@ -34,17 +34,18 @@ func run(ctx context.Context) (err error) {
 	}
 	defer func() { err = errors.Join(err, client.Close(ctx)) }()
 
-	browserContext, err := client.Context()
+	browserContext, err := browser.Context()
 	if err != nil {
 		return err
 	}
-	page, err := browserContext.ActivePage(ctx)
+	pages, err := browserContext.Pages(ctx)
 	if err != nil {
 		return err
 	}
-	if page == nil {
+	if len(pages) == 0 {
 		return errors.New("Stagehand initialized without an active page")
 	}
+	page := pages[0]
 	if _, err := page.Goto(ctx, "https://example.com", nil); err != nil {
 		return err
 	}

--- a/packages/sdk-go/examples/caching.go
+++ b/packages/sdk-go/examples/caching.go
@@ -68,17 +68,18 @@ func run(ctx context.Context) (err error) {
 	}
 	defer func() { err = errors.Join(err, client.Close(ctx)) }()
 
-	browserContext, err := client.Context()
+	browserContext, err := browser.Context()
 	if err != nil {
 		return err
 	}
-	page, err := browserContext.ActivePage(ctx)
+	pages, err := browserContext.Pages(ctx)
 	if err != nil {
 		return err
 	}
-	if page == nil {
+	if len(pages) == 0 {
 		return errors.New("Stagehand initialized without an active page")
 	}
+	page := pages[0]
 	if _, err := page.Goto(ctx, "https://aigrant.com", nil); err != nil {
 		return err
 	}

--- a/packages/sdk-go/examples/custom-llm.go
+++ b/packages/sdk-go/examples/custom-llm.go
@@ -42,17 +42,18 @@ func run(ctx context.Context) (err error) {
 	}
 	defer func() { err = errors.Join(err, client.Close(ctx)) }()
 
-	browserContext, err := client.Context()
+	browserContext, err := browser.Context()
 	if err != nil {
 		return err
 	}
-	page, err := browserContext.ActivePage(ctx)
+	pages, err := browserContext.Pages(ctx)
 	if err != nil {
 		return err
 	}
-	if page == nil {
+	if len(pages) == 0 {
 		return errors.New("Stagehand initialized without an active page")
 	}
+	page := pages[0]
 	if _, err := page.Goto(ctx, "https://example.com", nil); err != nil {
 		return err
 	}

--- a/packages/sdk-go/examples/custom-logging.go
+++ b/packages/sdk-go/examples/custom-logging.go
@@ -54,17 +54,18 @@ func run(ctx context.Context) (err error) {
 	}
 	defer func() { err = errors.Join(err, client.Close(ctx)) }()
 
-	browserContext, err := client.Context()
+	browserContext, err := browser.Context()
 	if err != nil {
 		return err
 	}
-	page, err := browserContext.ActivePage(ctx)
+	pages, err := browserContext.Pages(ctx)
 	if err != nil {
 		return err
 	}
-	if page == nil {
+	if len(pages) == 0 {
 		return errors.New("Stagehand initialized without an active page")
 	}
+	page := pages[0]
 	if _, err := page.Goto(ctx, "https://example.com", nil); err != nil {
 		return err
 	}

--- a/packages/sdk-go/examples/extract.go
+++ b/packages/sdk-go/examples/extract.go
@@ -49,17 +49,18 @@ func run(ctx context.Context) (err error) {
 	}
 	defer func() { err = errors.Join(err, client.Close(ctx)) }()
 
-	browserContext, err := client.Context()
+	browserContext, err := browser.Context()
 	if err != nil {
 		return err
 	}
-	page, err := browserContext.ActivePage(ctx)
+	pages, err := browserContext.Pages(ctx)
 	if err != nil {
 		return err
 	}
-	if page == nil {
+	if len(pages) == 0 {
 		return errors.New("Stagehand initialized without an active page")
 	}
+	page := pages[0]
 	if _, err := page.Goto(ctx, "https://example.com", nil); err != nil {
 		return err
 	}

--- a/packages/sdk-go/examples/file-upload.go
+++ b/packages/sdk-go/examples/file-upload.go
@@ -44,7 +44,7 @@ func run(ctx context.Context) (err error) {
 	}
 	defer func() { err = errors.Join(err, client.Close(ctx)) }()
 
-	browserContext, err := client.Context()
+	browserContext, err := browser.Context()
 	if err != nil {
 		return err
 	}

--- a/packages/sdk-go/examples/model-gateway.go
+++ b/packages/sdk-go/examples/model-gateway.go
@@ -51,17 +51,18 @@ func run(ctx context.Context) (err error) {
 	}
 	defer func() { err = errors.Join(err, client.Close(ctx)) }()
 
-	browserContext, err := client.Context()
+	browserContext, err := browser.Context()
 	if err != nil {
 		return err
 	}
-	page, err := browserContext.ActivePage(ctx)
+	pages, err := browserContext.Pages(ctx)
 	if err != nil {
 		return err
 	}
-	if page == nil {
+	if len(pages) == 0 {
 		return errors.New("Stagehand initialized without an active page")
 	}
+	page := pages[0]
 	if _, err := page.Goto(ctx, "https://example.com", nil); err != nil {
 		return err
 	}

--- a/packages/sdk-go/examples/observe.go
+++ b/packages/sdk-go/examples/observe.go
@@ -34,17 +34,18 @@ func run(ctx context.Context) (err error) {
 	}
 	defer func() { err = errors.Join(err, client.Close(ctx)) }()
 
-	browserContext, err := client.Context()
+	browserContext, err := browser.Context()
 	if err != nil {
 		return err
 	}
-	page, err := browserContext.ActivePage(ctx)
+	pages, err := browserContext.Pages(ctx)
 	if err != nil {
 		return err
 	}
-	if page == nil {
+	if len(pages) == 0 {
 		return errors.New("Stagehand initialized without an active page")
 	}
+	page := pages[0]
 	if _, err := page.Goto(ctx, "https://example.com", nil); err != nil {
 		return err
 	}

--- a/packages/sdk-go/examples/webmcp.go
+++ b/packages/sdk-go/examples/webmcp.go
@@ -30,17 +30,18 @@ func run(ctx context.Context) (err error) {
 	}
 	defer func() { err = errors.Join(err, client.Close(ctx)) }()
 
-	browserContext, err := client.Context()
+	browserContext, err := browser.Context()
 	if err != nil {
 		return err
 	}
-	page, err := browserContext.ActivePage(ctx)
+	pages, err := browserContext.Pages(ctx)
 	if err != nil {
 		return err
 	}
-	if page == nil {
+	if len(pages) == 0 {
 		return errors.New("Stagehand initialized without an active page")
 	}
+	page := pages[0]
 	if _, err := page.Goto(ctx, webMCPTestSite, nil); err != nil {
 		return err
 	}

--- a/packages/sdk-go/idiomatic_go.md
+++ b/packages/sdk-go/idiomatic_go.md
@@ -53,14 +53,20 @@ type Page struct {
 - Preserve the same conceptual object graph as TypeScript and Python even when access syntax differs. A Go `Context()` method may correspond to a TypeScript/Python property.
 
 ```go
-client, err := stagehand.NewLocal(stagehand.LocalOptions{
-	Headless: stagehand.Bool(true),
-})
+browser, err := stagehand.LaunchLocalBrowser(ctx, &stagehand.LocalBrowserLaunchOptions{Headless: true})
 if err != nil {
 	return err
 }
+defer func() {
+	closeCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := browser.Close(closeCtx); err != nil {
+		logger.Printf("close browser: %v", err)
+	}
+}()
 
-if err := client.Init(ctx); err != nil {
+client, err := stagehand.Create(ctx, stagehand.CreateOptions{Browser: browser})
+if err != nil {
 	return err
 }
 defer func() {
@@ -71,17 +77,18 @@ defer func() {
 	}
 }()
 
-browserContext, err := client.Context()
+browserContext, err := browser.Context()
 if err != nil {
 	return err
 }
-page, err := browserContext.ActivePage(ctx)
+pages, err := browserContext.Pages(ctx)
 if err != nil {
 	return err
 }
-if page == nil {
+if len(pages) == 0 {
 	return errors.New("stagehand: initialized without an active page")
 }
+page := pages[0]
 if _, err := page.Goto(ctx, "https://example.com", nil); err != nil {
 	return err
 }

--- a/packages/sdk-go/stagehand_live_test.go
+++ b/packages/sdk-go/stagehand_live_test.go
@@ -67,9 +67,9 @@ func assertNavigationResponse(
 	fixtureBody []byte,
 ) {
 	t.Helper()
-	browserContext, err := client.Context()
+	browserContext, err := client.Browser().Context()
 	if err != nil {
-		t.Fatalf("Stagehand.Context() error = %v", err)
+		t.Fatalf("Browser.Context() error = %v", err)
 	}
 	page, err := browserContext.ActivePage(ctx)
 	if err != nil {
@@ -249,9 +249,9 @@ func TestStagehandExtractSendsScreenshotToClientLLM(t *testing.T) {
 		t.Fatalf("Create() with screenshot LLM error = %v", err)
 	}
 	closeStagehandAfterTest(t, client, browser)
-	browserContext, err := client.Context()
+	browserContext, err := client.Browser().Context()
 	if err != nil {
-		t.Fatalf("Stagehand.Context() error = %v", err)
+		t.Fatalf("Browser.Context() error = %v", err)
 	}
 	page, err := browserContext.ActivePage(ctx)
 	if err != nil {
@@ -360,9 +360,9 @@ func assertLiveStagehand(
 	if !client.Initialized() {
 		t.Fatal("Stagehand.Initialized() = false after Create")
 	}
-	browserContext, err := client.Context()
+	browserContext, err := client.Browser().Context()
 	if err != nil {
-		t.Fatalf("Stagehand.Context() error = %v", err)
+		t.Fatalf("Browser.Context() error = %v", err)
 	}
 	page, err := browserContext.ActivePage(ctx)
 	if err != nil {

--- a/packages/sdk-python/README.md
+++ b/packages/sdk-python/README.md
@@ -13,7 +13,7 @@ async def main() -> None:
     try:
         stagehand = await Stagehand.create(browser=browser)
         try:
-            page = await stagehand.context.active_page()
+            page = (await browser.context.pages())[0]
             if page is None:
                 raise RuntimeError("Stagehand initialized without an active page")
             response = await page.goto("https://example.com")

--- a/packages/sdk-python/examples/act.py
+++ b/packages/sdk-python/examples/act.py
@@ -18,7 +18,7 @@ async def main() -> None:
             model_api_key=OPENAI_API_KEY,
         )
         try:
-            page = await stagehand.context.active_page()
+            page = (await browser.context.pages())[0]
             if page is None:
                 raise RuntimeError("Stagehand initialized without an active page")
             await page.goto("https://example.com")

--- a/packages/sdk-python/examples/caching.py
+++ b/packages/sdk-python/examples/caching.py
@@ -34,7 +34,7 @@ async def main() -> None:
             model_api_key=OPENAI_API_KEY,
         )
         try:
-            page = await stagehand.context.active_page()
+            page = (await browser.context.pages())[0]
             if page is None:
                 raise RuntimeError("Stagehand initialized without an active page")
             await page.goto("https://aigrant.com")

--- a/packages/sdk-python/examples/custom_llm.py
+++ b/packages/sdk-python/examples/custom_llm.py
@@ -40,7 +40,7 @@ async def main() -> None:
     try:
         stagehand = await Stagehand.create(browser=browser, model=generate_with_openai)
         try:
-            page = await stagehand.context.active_page()
+            page = (await browser.context.pages())[0]
             if page is None:
                 raise RuntimeError("Stagehand initialized without an active page")
             await page.goto("https://example.com")

--- a/packages/sdk-python/examples/custom_logging.py
+++ b/packages/sdk-python/examples/custom_logging.py
@@ -23,7 +23,7 @@ async def main() -> None:
                 },
             )
             try:
-                page = await stagehand.context.active_page()
+                page = (await browser.context.pages())[0]
                 if page is None:
                     raise RuntimeError
 

--- a/packages/sdk-python/examples/extract.py
+++ b/packages/sdk-python/examples/extract.py
@@ -25,7 +25,7 @@ async def main() -> None:
             model_api_key=OPENAI_API_KEY,
         )
         try:
-            page = await stagehand.context.active_page()
+            page = (await browser.context.pages())[0]
             if page is None:
                 raise RuntimeError("Stagehand initialized without an active page")
             await page.goto("https://example.com")

--- a/packages/sdk-python/examples/file_upload.py
+++ b/packages/sdk-python/examples/file_upload.py
@@ -14,9 +14,7 @@ async def main() -> None:
         try:
             stagehand = await Stagehand.create(browser=browser)
             try:
-                page = await stagehand.context.active_page()
-                if page is None:
-                    raise RuntimeError("Stagehand initialized without an active page")
+                page = (await browser.context.pages())[0]
 
                 await page.goto('data:text/html,<input id="upload" type="file">')
                 await page.locator("#upload").set_input_files(file_path)

--- a/packages/sdk-python/examples/model_gateway.py
+++ b/packages/sdk-python/examples/model_gateway.py
@@ -23,7 +23,7 @@ async def main() -> None:
     try:
         stagehand = await Stagehand.create(browser=browser)
         try:
-            page = await stagehand.context.active_page()
+            page = (await browser.context.pages())[0]
             if page is None:
                 raise RuntimeError("Stagehand initialized without an active page")
             await page.goto("https://example.com")

--- a/packages/sdk-python/examples/observe.py
+++ b/packages/sdk-python/examples/observe.py
@@ -18,7 +18,7 @@ async def main() -> None:
             model_api_key=OPENAI_API_KEY,
         )
         try:
-            page = await stagehand.context.active_page()
+            page = (await browser.context.pages())[0]
             if page is None:
                 raise RuntimeError("Stagehand initialized without an active page")
             await page.goto("https://example.com")

--- a/packages/sdk-python/examples/webmcp.py
+++ b/packages/sdk-python/examples/webmcp.py
@@ -10,7 +10,7 @@ async def main() -> None:
     try:
         stagehand = await Stagehand.create(browser=browser)
         try:
-            page = await stagehand.context.active_page()
+            page = (await browser.context.pages())[0]
             if page is None:
                 raise RuntimeError("Stagehand initialized without an active page")
             await page.goto(WEBMCP_TEST_SITE)

--- a/packages/sdk-python/scripts/smoke.py
+++ b/packages/sdk-python/scripts/smoke.py
@@ -53,7 +53,7 @@ async def main() -> None:
         try:
             stagehand = await Stagehand.create(browser=browser)
             try:
-                page = await stagehand.context.new_page()
+                page = await browser.context.new_page()
                 response = await page.goto(fixture_url)
                 if response is None:
                     raise RuntimeError("HTTP navigation did not return a response")

--- a/packages/sdk-python/tests/test_stagehand.py
+++ b/packages/sdk-python/tests/test_stagehand.py
@@ -463,7 +463,7 @@ async def test_close_is_memoized_and_never_closes_browser_or_transport(
     assert browser.closed is False
     assert transport.close_calls == 0
     with pytest.raises(RuntimeError, match="Browser context is unavailable.*Stagehand.create"):
-        _ = stagehand.context
+        _ = stagehand.browser.context
     with pytest.raises(RuntimeError, match="Stagehand is unavailable.*Stagehand.create"):
         await stagehand.metrics()
 

--- a/packages/sdk-ts/README.md
+++ b/packages/sdk-ts/README.md
@@ -7,7 +7,7 @@ import { localBrowser, Stagehand } from "@browserbasehq/stagehand";
 
 const browser = await localBrowser.launch({ headless: true });
 const stagehand = await Stagehand.create({ browser });
-const page = (await stagehand.context.pages())[0] ?? (await stagehand.context.newPage());
+const [page] = await browser.context.pages();
 
 const response = await page.goto("https://example.com");
 if (response) {
@@ -28,11 +28,11 @@ await browser.close();
 ## object model
 
 - `localBrowser` and `browserbase` launch or connect an extension-ready browser
-- `Stagehand.create()` attaches to a browser and exposes `context`
+- `Stagehand.create()` attaches to a browser and makes `browser.context` available
 - `Stagehand.close()` closes the Stagehand runtime; `browser.close()` owns browser cleanup
 - `Stagehand.act()`, `Stagehand.observe()`, and `Stagehand.extract()` use the active page by default and accept an SDK `Page` in their options
-- `BrowserContext.pages()` returns `Page` objects from `context.pages`
-- `BrowserContext.newPage()` wraps the `context.new_page` result
+- `browser.context.pages()` returns the context's `Page` objects
+- `browser.context.newPage()` creates and wraps a new `Page`
 - `Page.goto()`, `reload()`, `goBack()`, and `goForward()` return the main-document `Response`, or `null` when navigation does not produce one
 - `Response` exposes immediate status and header metadata and retrieves complete headers and bodies lazily
 - `Page` routes `url`, `title`, and `close` to page protocol methods

--- a/packages/sdk-ts/examples/act.ts
+++ b/packages/sdk-ts/examples/act.ts
@@ -13,10 +13,7 @@ const stagehand = await Stagehand.create({
   },
 });
 
-const page = await stagehand.context.activePage();
-if (!page) {
-  throw new Error("Stagehand initialized without an active page");
-}
+const [page] = await browser.context.pages();
 await page.goto("https://example.com");
 
 const result = await stagehand.act(

--- a/packages/sdk-ts/examples/caching.ts
+++ b/packages/sdk-ts/examples/caching.ts
@@ -28,10 +28,7 @@ const stagehand = await Stagehand.create({
   },
 });
 
-const page = await stagehand.context.activePage();
-if (!page) {
-  throw new Error("Stagehand initialized without an active page");
-}
+const [page] = await browser.context.pages();
 await page.goto("https://aigrant.com");
 
 // With a threshold of 1, a single identical result is enough for the cache

--- a/packages/sdk-ts/examples/custom-llm.ts
+++ b/packages/sdk-ts/examples/custom-llm.ts
@@ -25,10 +25,7 @@ const stagehand = await Stagehand.create({
   },
 });
 
-const page = await stagehand.context.activePage();
-if (!page) {
-  throw new Error("Stagehand initialized without an active page");
-}
+const [page] = await browser.context.pages();
 await page.goto("https://example.com");
 
 const pageInfo = await stagehand.extract(

--- a/packages/sdk-ts/examples/custom_logging.ts
+++ b/packages/sdk-ts/examples/custom_logging.ts
@@ -24,8 +24,7 @@ const stagehand = await Stagehand.create({
   },
 });
 
-const page = await stagehand.context.activePage();
-if (!page) throw new Error();
+const [page] = await browser.context.pages();
 
 await page.goto("https://example.com");
 console.log(await stagehand.observe("Find the Learn more link"));

--- a/packages/sdk-ts/examples/extract.ts
+++ b/packages/sdk-ts/examples/extract.ts
@@ -14,10 +14,7 @@ const stagehand = await Stagehand.create({
   },
 });
 
-const page = await stagehand.context.activePage();
-if (!page) {
-  throw new Error("Stagehand initialized without an active page");
-}
+const [page] = await browser.context.pages();
 await page.goto("https://example.com");
 
 const pageInfo = await stagehand.extract(

--- a/packages/sdk-ts/examples/file-upload.ts
+++ b/packages/sdk-ts/examples/file-upload.ts
@@ -13,7 +13,7 @@ try {
   try {
     const stagehand = await Stagehand.create({ browser });
     try {
-      const page = await stagehand.context.activePage();
+      const page = await browser.context.activePage();
       if (!page) throw new Error("Stagehand initialized without an active page");
 
       await page.goto(`data:text/html,${encodeURIComponent('<input id="upload" type="file">')}`);

--- a/packages/sdk-ts/examples/model-gateway.ts
+++ b/packages/sdk-ts/examples/model-gateway.ts
@@ -13,10 +13,7 @@ const browser = await browserbase.launch({
 const stagehand = await Stagehand.create({ browser });
 
 try {
-  const page = await stagehand.context.activePage();
-  if (!page) {
-    throw new Error("Stagehand initialized without an active page");
-  }
+  const [page] = await browser.context.pages();
   await page.goto("https://example.com");
 
   const result = await stagehand.extract(

--- a/packages/sdk-ts/examples/observe.ts
+++ b/packages/sdk-ts/examples/observe.ts
@@ -13,10 +13,7 @@ const stagehand = await Stagehand.create({
   },
 });
 
-const page = await stagehand.context.activePage();
-if (!page) {
-  throw new Error("Stagehand initialized without an active page");
-}
+const [page] = await browser.context.pages();
 await page.goto("https://example.com");
 
 const actions = await stagehand.observe(

--- a/packages/sdk-ts/examples/webmcp.ts
+++ b/packages/sdk-ts/examples/webmcp.ts
@@ -5,10 +5,7 @@ const webMCPTestSite = "https://browserbase.github.io/stagehand-eval-sites/sites
 const browser = await localBrowser.launch({ headless: false });
 const stagehand = await Stagehand.create({ browser });
 
-const page = await stagehand.context.activePage();
-if (!page) {
-  throw new Error("Stagehand initialized without an active page");
-}
+const [page] = await browser.context.pages();
 await page.goto(webMCPTestSite);
 
 const tools = await page.tools({ timeout: 5_000 });

--- a/packages/sdk-ts/tests/browser-runtime/stagehand-browserbase-smoke.test.ts
+++ b/packages/sdk-ts/tests/browser-runtime/stagehand-browserbase-smoke.test.ts
@@ -39,7 +39,8 @@ describe.runIf(shouldRun)("Stagehand TS SDK Browserbase smoke", () => {
       throw new Error("Stagehand was not initialized");
     }
 
-    const page = (await stagehand.context.pages())[0] ?? (await stagehand.context.newPage());
+    const page =
+      (await stagehand.browser.context.pages())[0] ?? (await stagehand.browser.context.newPage());
 
     await page.goto("https://example.com", { waitUntil: "load" });
 
@@ -53,7 +54,8 @@ describe.runIf(shouldRun)("Stagehand TS SDK Browserbase smoke", () => {
       throw new Error("Stagehand was not initialized");
     }
 
-    const page = (await stagehand.context.pages())[0] ?? (await stagehand.context.newPage());
+    const page =
+      (await stagehand.browser.context.pages())[0] ?? (await stagehand.browser.context.newPage());
 
     await page.goto(webMCPTestSite, { waitUntil: "load" });
 
@@ -85,7 +87,8 @@ describe.runIf(shouldRun)("Stagehand TS SDK Browserbase smoke", () => {
     const filePath = path.join(directory, "hello.txt");
     await writeFile(filePath, "hello from Browserbase");
     try {
-      const page = (await stagehand.context.pages())[0] ?? (await stagehand.context.newPage());
+      const page =
+        (await stagehand.browser.context.pages())[0] ?? (await stagehand.browser.context.newPage());
       await page.goto(`data:text/html,${encodeURIComponent('<input id="upload" type="file">')}`);
       const input = page.locator("#upload");
 

--- a/packages/sdk-ts/tests/browser-runtime/stagehand-launch-connect-smoke.test.ts
+++ b/packages/sdk-ts/tests/browser-runtime/stagehand-launch-connect-smoke.test.ts
@@ -179,7 +179,8 @@ describe("Stagehand TS SDK launch/connect smoke", () => {
     const activeStagehand = requireStagehand(stagehand);
     const activeFixtureServer = requireFixtureServer(fixtureServer);
     const page =
-      (await activeStagehand.context.pages())[0] ?? (await activeStagehand.context.newPage());
+      (await activeStagehand.browser.context.pages())[0] ??
+      (await activeStagehand.browser.context.newPage());
 
     await page.goto(activeFixtureServer.url);
     await page.locator("#locator-input").fill("user@example.com");
@@ -207,7 +208,7 @@ describe("Stagehand TS SDK launch/connect smoke", () => {
   it("navigates and runs scripts through the page wrapper", async () => {
     const activeStagehand = requireStagehand(stagehand);
     const activeFixtureServer = requireFixtureServer(fixtureServer);
-    const page = await activeStagehand.context.newPage();
+    const page = await activeStagehand.browser.context.newPage();
     const secondUrl = new URL("/second", activeFixtureServer.url).href;
 
     await page.addInitScript({
@@ -244,7 +245,7 @@ describe("Stagehand TS SDK launch/connect smoke", () => {
   it("uses page-level interactions and waits", async () => {
     const activeStagehand = requireStagehand(stagehand);
     const activeFixtureServer = requireFixtureServer(fixtureServer);
-    const page = await activeStagehand.context.newPage({ url: activeFixtureServer.url });
+    const page = await activeStagehand.browser.context.newPage({ url: activeFixtureServer.url });
 
     await page.waitForLoadState("load");
     await expect(
@@ -268,7 +269,7 @@ describe("Stagehand TS SDK launch/connect smoke", () => {
   it("applies page configuration and captures browser state", async () => {
     const activeStagehand = requireStagehand(stagehand);
     const activeFixtureServer = requireFixtureServer(fixtureServer);
-    const page = await activeStagehand.context.newPage();
+    const page = await activeStagehand.browser.context.newPage();
     const headersUrl = new URL("/headers", activeFixtureServer.url).href;
 
     await page.setExtraHTTPHeaders({ "X-Stagehand-Smoke": "header-value" });
@@ -295,7 +296,8 @@ describe("Stagehand TS SDK launch/connect smoke", () => {
     const activeStagehand = requireStagehand(stagehand);
     const activeFixtureServer = requireFixtureServer(fixtureServer);
     const page =
-      (await activeStagehand.context.pages())[0] ?? (await activeStagehand.context.newPage());
+      (await activeStagehand.browser.context.pages())[0] ??
+      (await activeStagehand.browser.context.newPage());
     await page.goto(activeFixtureServer.url);
     extractionScreenshots.length = 0;
     rawOperationUsages.length = 0;
@@ -347,7 +349,8 @@ describe("Stagehand TS SDK launch/connect smoke", () => {
     const activeStagehand = requireStagehand(stagehand);
     const activeFixtureServer = requireFixtureServer(fixtureServer);
     const page =
-      (await activeStagehand.context.pages())[0] ?? (await activeStagehand.context.newPage());
+      (await activeStagehand.browser.context.pages())[0] ??
+      (await activeStagehand.browser.context.newPage());
     await page.goto(activeFixtureServer.url);
     rawOperationUsages.length = 0;
 
@@ -379,7 +382,9 @@ describe("Stagehand TS SDK launch/connect smoke", () => {
 
     try {
       for (const marker of ["one", "two", "three", "four"]) {
-        const page = await activeStagehand.context.newPage({ url: activeFixtureServer.url });
+        const page = await activeStagehand.browser.context.newPage({
+          url: activeFixtureServer.url,
+        });
         createdPages.push(page);
         await page.evaluate((value: string) => {
           (
@@ -388,7 +393,7 @@ describe("Stagehand TS SDK launch/connect smoke", () => {
             }
           ).__stagehandActivePageMarker = value;
         }, marker);
-        await waitForActivePageId(activeStagehand.context, page.pageId);
+        await waitForActivePageId(activeStagehand.browser.context, page.pageId);
       }
 
       expect(new Set(createdPages.map((page) => page.pageId)).size).toBe(4);
@@ -406,11 +411,11 @@ describe("Stagehand TS SDK launch/connect smoke", () => {
         createdPages[1]!,
       ];
       for (const page of selectionOrder) {
-        await activeStagehand.context.setActivePage(page);
+        await activeStagehand.browser.context.setActivePage(page);
       }
 
       const selectedPage = await waitForActivePageId(
-        activeStagehand.context,
+        activeStagehand.browser.context,
         createdPages[1]!.pageId,
       );
       await expect(selectedPage.evaluate("globalThis.__stagehandActivePageMarker")).resolves.toBe(
@@ -418,18 +423,18 @@ describe("Stagehand TS SDK launch/connect smoke", () => {
       );
 
       await createdPages[0]!.close();
-      await waitForPageRemoval(activeStagehand.context, createdPages[0]!.pageId);
-      await waitForActivePageId(activeStagehand.context, createdPages[1]!.pageId);
+      await waitForPageRemoval(activeStagehand.browser.context, createdPages[0]!.pageId);
+      await waitForActivePageId(activeStagehand.browser.context, createdPages[1]!.pageId);
 
       const closedActivePageId = createdPages[1]!.pageId;
       await createdPages[1]!.close();
-      await waitForPageRemoval(activeStagehand.context, closedActivePageId);
+      await waitForPageRemoval(activeStagehand.browser.context, closedActivePageId);
       const replacement = await waitForActivePageOtherThan(
-        activeStagehand.context,
+        activeStagehand.browser.context,
         closedActivePageId,
       );
       const livePageIds = new Set(
-        (await activeStagehand.context.pages()).map((page) => page.pageId),
+        (await activeStagehand.browser.context.pages()).map((page) => page.pageId),
       );
       expect(livePageIds.has(replacement.pageId)).toBe(true);
     } finally {
@@ -443,17 +448,19 @@ describe("Stagehand TS SDK launch/connect smoke", () => {
     const createdPages: Page[] = [];
 
     try {
-      const opener = await activeStagehand.context.newPage({ url: activeFixtureServer.url });
+      const opener = await activeStagehand.browser.context.newPage({
+        url: activeFixtureServer.url,
+      });
       createdPages.push(opener);
-      await activeStagehand.context.setActivePage(opener);
-      await waitForActivePageId(activeStagehand.context, opener.pageId);
+      await activeStagehand.browser.context.setActivePage(opener);
+      await waitForActivePageId(activeStagehand.browser.context, opener.pageId);
 
       const pageIdsBeforePopup = new Set(
-        (await activeStagehand.context.pages()).map((page) => page.pageId),
+        (await activeStagehand.browser.context.pages()).map((page) => page.pageId),
       );
       await opener.locator("#popup-button").click();
 
-      const popup = await activeStagehand.context.activePage();
+      const popup = await activeStagehand.browser.context.activePage();
       if (!popup) {
         throw new Error("Stagehand did not resolve the active popup");
       }
@@ -466,15 +473,18 @@ describe("Stagehand TS SDK launch/connect smoke", () => {
       await expect(popup.title()).resolves.toBe("Stagehand SDK Smoke");
 
       await popup.close();
-      await waitForPageRemoval(activeStagehand.context, popup.pageId);
-      const replacement = await waitForActivePageOtherThan(activeStagehand.context, popup.pageId);
+      await waitForPageRemoval(activeStagehand.browser.context, popup.pageId);
+      const replacement = await waitForActivePageOtherThan(
+        activeStagehand.browser.context,
+        popup.pageId,
+      );
       const livePageIds = new Set(
-        (await activeStagehand.context.pages()).map((page) => page.pageId),
+        (await activeStagehand.browser.context.pages()).map((page) => page.pageId),
       );
       expect(livePageIds.has(replacement.pageId)).toBe(true);
 
-      await activeStagehand.context.setActivePage(opener);
-      await waitForActivePageId(activeStagehand.context, opener.pageId);
+      await activeStagehand.browser.context.setActivePage(opener);
+      await waitForActivePageId(activeStagehand.browser.context, opener.pageId);
     } finally {
       await closePages(createdPages);
     }
@@ -485,13 +495,13 @@ describe("Stagehand TS SDK launch/connect smoke", () => {
     const activeFixtureServer = requireFixtureServer(fixtureServer);
     const headersUrl = new URL("/headers", activeFixtureServer.url).href;
 
-    await activeStagehand.context.addInitScript({
+    await activeStagehand.browser.context.addInitScript({
       content: "globalThis.__stagehandContextSmokeInit = 'context-ready';",
     });
-    await activeStagehand.context.setExtraHTTPHeaders({
+    await activeStagehand.browser.context.setExtraHTTPHeaders({
       "X-Stagehand-Context-Smoke": "context-header-value",
     });
-    const page = await activeStagehand.context.newPage();
+    const page = await activeStagehand.browser.context.newPage();
     await page.goto(headersUrl, { waitUntil: "load" });
 
     await expect(page.evaluate("globalThis.__stagehandContextSmokeInit")).resolves.toBe(
@@ -509,7 +519,7 @@ describe("Stagehand TS SDK launch/connect smoke", () => {
     const removeCookieName = "stagehand-context-remove";
     const cookieNames = [keepCookieName, removeCookieName];
 
-    await activeStagehand.context.addCookies([
+    await activeStagehand.browser.context.addCookies([
       {
         name: keepCookieName,
         value: "keep",
@@ -524,7 +534,7 @@ describe("Stagehand TS SDK launch/connect smoke", () => {
       },
     ]);
 
-    const addedCookies = await activeStagehand.context.cookies(activeFixtureServer.url);
+    const addedCookies = await activeStagehand.browser.context.cookies(activeFixtureServer.url);
     expect(
       addedCookies
         .filter((cookie) => cookieNames.includes(cookie.name))
@@ -532,34 +542,37 @@ describe("Stagehand TS SDK launch/connect smoke", () => {
         .sort(),
     ).toStrictEqual([...cookieNames].sort());
 
-    await activeStagehand.context.clearCookies({ name: /-remove$/ });
-    const filteredCookies = await activeStagehand.context.cookies(activeFixtureServer.url);
+    await activeStagehand.browser.context.clearCookies({ name: /-remove$/ });
+    const filteredCookies = await activeStagehand.browser.context.cookies(activeFixtureServer.url);
     expect(filteredCookies.find((cookie) => cookie.name === keepCookieName)?.value).toBe("keep");
     expect(filteredCookies.some((cookie) => cookie.name === removeCookieName)).toBe(false);
 
-    await activeStagehand.context.clearCookies({ name: /^stagehand-context-/ });
-    const clearedCookies = await activeStagehand.context.cookies(activeFixtureServer.url);
+    await activeStagehand.browser.context.clearCookies({ name: /^stagehand-context-/ });
+    const clearedCookies = await activeStagehand.browser.context.cookies(activeFixtureServer.url);
     expect(clearedCookies.some((cookie) => cookieNames.includes(cookie.name))).toBe(false);
   });
 
   it("reads, writes, and clears clipboard text against an explicit page", async () => {
     const activeStagehand = requireStagehand(stagehand);
     const activeFixtureServer = requireFixtureServer(fixtureServer);
-    const page = await activeStagehand.context.newPage({ url: activeFixtureServer.url });
+    const page = await activeStagehand.browser.context.newPage({ url: activeFixtureServer.url });
 
-    await activeStagehand.context.clipboard.writeText("stagehand clipboard smoke", { page });
-    await expect(activeStagehand.context.clipboard.readText({ page })).resolves.toBe(
+    await activeStagehand.browser.context.clipboard.writeText("stagehand clipboard smoke", {
+      page,
+    });
+    await expect(activeStagehand.browser.context.clipboard.readText({ page })).resolves.toBe(
       "stagehand clipboard smoke",
     );
-    await activeStagehand.context.clipboard.clear({ page });
-    await expect(activeStagehand.context.clipboard.readText({ page })).resolves.toBe("");
+    await activeStagehand.browser.context.clipboard.clear({ page });
+    await expect(activeStagehand.browser.context.clipboard.readText({ page })).resolves.toBe("");
   });
 
   it("acts on a real page through the connected SDK", async () => {
     const activeStagehand = requireStagehand(stagehand);
     const activeFixtureServer = requireFixtureServer(fixtureServer);
     const page =
-      (await activeStagehand.context.pages())[0] ?? (await activeStagehand.context.newPage());
+      (await activeStagehand.browser.context.pages())[0] ??
+      (await activeStagehand.browser.context.newPage());
     await page.goto(activeFixtureServer.url);
     rawOperationUsages.length = 0;
 
@@ -606,7 +619,8 @@ describe("Stagehand TS SDK launch/connect smoke", () => {
     const activeStagehand = requireStagehand(stagehand);
     const activeFixtureServer = requireFixtureServer(fixtureServer);
     const page =
-      (await activeStagehand.context.pages())[0] ?? (await activeStagehand.context.newPage());
+      (await activeStagehand.browser.context.pages())[0] ??
+      (await activeStagehand.browser.context.newPage());
     await page.goto(activeFixtureServer.url);
     rawOperationUsages.length = 0;
 
@@ -638,7 +652,8 @@ describe("Stagehand TS SDK launch/connect smoke", () => {
     const activeStagehand = requireStagehand(stagehand);
     const activeFixtureServer = requireFixtureServer(fixtureServer);
     const page =
-      (await activeStagehand.context.pages())[0] ?? (await activeStagehand.context.newPage());
+      (await activeStagehand.browser.context.pages())[0] ??
+      (await activeStagehand.browser.context.newPage());
     await page.goto(activeFixtureServer.url);
     rawMetricsSnapshots.length = 0;
 

--- a/packages/sdk-ts/tests/integration/_support.ts
+++ b/packages/sdk-ts/tests/integration/_support.ts
@@ -73,8 +73,8 @@ export function closeStagehand(stagehand?: Stagehand | null): Promise<void> {
  * truthy Promise and a silently passing test rather than a type error.
  */
 export async function firstPage(stagehand: Stagehand) {
-  const pages = await stagehand.context.pages();
-  return pages[0] ?? (await stagehand.context.newPage());
+  const pages = await stagehand.browser.context.pages();
+  return pages[0] ?? (await stagehand.browser.context.newPage());
 }
 
 export async function startFixtureServer(

--- a/packages/sdk-ts/tests/integration/clipboard.test.ts
+++ b/packages/sdk-ts/tests/integration/clipboard.test.ts
@@ -74,17 +74,17 @@ describe("context.clipboard", () => {
     const page = await firstPage(stagehand);
     await setupTextarea(page, fixture.url, { id: "target" });
 
-    await stagehand.context.clipboard.writeText("hello");
+    await stagehand.browser.context.clipboard.writeText("hello");
 
-    await expect(stagehand.context.clipboard.readText()).resolves.toBe("hello");
+    await expect(stagehand.browser.context.clipboard.readText()).resolves.toBe("hello");
   });
 
   it("paste() inserts clipboard text into the focused textarea", async () => {
     const page = await firstPage(stagehand);
     await setupTextarea(page, fixture.url, { id: "target" });
 
-    await stagehand.context.clipboard.writeText("hello");
-    await stagehand.context.clipboard.paste();
+    await stagehand.browser.context.clipboard.writeText("hello");
+    await stagehand.browser.context.clipboard.paste();
 
     await expect(textareaValue(page, "target")).resolves.toBe("hello");
   });
@@ -94,9 +94,9 @@ describe("context.clipboard", () => {
     await setupTextarea(page, fixture.url, { id: "target", value: "copy me" });
     await selectTextareaContents(page, "target");
 
-    await stagehand.context.clipboard.copy();
+    await stagehand.browser.context.clipboard.copy();
 
-    await expect(stagehand.context.clipboard.readText()).resolves.toBe("copy me");
+    await expect(stagehand.browser.context.clipboard.readText()).resolves.toBe("copy me");
   });
 
   it("cut() cuts selected textarea text and updates clipboard", async () => {
@@ -104,9 +104,9 @@ describe("context.clipboard", () => {
     await setupTextarea(page, fixture.url, { id: "target", value: "cut me" });
     await selectTextareaContents(page, "target");
 
-    await stagehand.context.clipboard.cut();
+    await stagehand.browser.context.clipboard.cut();
 
-    await expect(stagehand.context.clipboard.readText()).resolves.toBe("cut me");
+    await expect(stagehand.browser.context.clipboard.readText()).resolves.toBe("cut me");
     await expect(textareaValue(page, "target")).resolves.toBe("");
   });
 
@@ -121,19 +121,21 @@ describe("context.clipboard", () => {
     // page's clipboard write; no permissions are pre-granted on the page.
     await page.locator("#copy-button").click();
 
-    await expect.poll(() => stagehand.context.clipboard.readText()).toBe("Hello I'm some text");
+    await expect
+      .poll(() => stagehand.browser.context.clipboard.readText())
+      .toBe("Hello I'm some text");
   });
 
   it("defaults actions to the active page", async () => {
     const page1 = await firstPage(stagehand);
     await setupTextarea(page1, fixture.url, { id: "first" });
 
-    const page2 = await stagehand.context.newPage();
+    const page2 = await stagehand.browser.context.newPage();
     await setupTextarea(page2, fixture.url, { id: "second" });
-    await stagehand.context.setActivePage(page2);
+    await stagehand.browser.context.setActivePage(page2);
 
-    await stagehand.context.clipboard.writeText("active page text");
-    await stagehand.context.clipboard.paste();
+    await stagehand.browser.context.clipboard.writeText("active page text");
+    await stagehand.browser.context.clipboard.paste();
 
     await expect(textareaValue(page1, "first")).resolves.toBe("");
     await expect(textareaValue(page2, "second")).resolves.toBe("active page text");
@@ -143,14 +145,14 @@ describe("context.clipboard", () => {
     const page1 = await firstPage(stagehand);
     await setupTextarea(page1, fixture.url, { id: "first" });
 
-    const page2 = await stagehand.context.newPage();
+    const page2 = await stagehand.browser.context.newPage();
     await setupTextarea(page2, fixture.url, { id: "second" });
 
-    await stagehand.context.clipboard.writeText("explicit page text", {
+    await stagehand.browser.context.clipboard.writeText("explicit page text", {
       page: page1,
     });
-    await stagehand.context.setActivePage(page2);
-    await stagehand.context.clipboard.paste({ page: page1 });
+    await stagehand.browser.context.setActivePage(page2);
+    await stagehand.browser.context.clipboard.paste({ page: page1 });
 
     await expect(textareaValue(page1, "first")).resolves.toBe("explicit page text");
     await expect(textareaValue(page2, "second")).resolves.toBe("");

--- a/packages/sdk-ts/tests/integration/context-addInitScript.test.ts
+++ b/packages/sdk-ts/tests/integration/context-addInitScript.test.ts
@@ -76,7 +76,7 @@ describe("context.addInitScript", () => {
   beforeEach(async () => {
     fixture = await startFixtureServer("<!doctype html><body>fixture</body>");
     stagehand = await createStagehand();
-    ctx = stagehand.context;
+    ctx = stagehand.browser.context;
   });
 
   afterEach(async () => {

--- a/packages/sdk-ts/tests/integration/context-domain-policy.test.ts
+++ b/packages/sdk-ts/tests/integration/context-domain-policy.test.ts
@@ -50,14 +50,14 @@ describe("context.setDomainPolicy", () => {
 
   it("blocks matching requests on existing pages", async () => {
     const page = await firstPage(stagehand);
-    await stagehand.context.setDomainPolicy({ blockedDomains: ["127.0.0.1"] });
+    await stagehand.browser.context.setDomainPolicy({ blockedDomains: ["127.0.0.1"] });
 
     await expect(imageLoads(page, allowedUrl)).resolves.toBe(false);
   });
 
   it("applies to pages created after setting the policy", async () => {
-    await stagehand.context.setDomainPolicy({ blockedDomains: ["127.0.0.1"] });
-    const page = await stagehand.context.newPage();
+    await stagehand.browser.context.setDomainPolicy({ blockedDomains: ["127.0.0.1"] });
+    const page = await stagehand.browser.context.newPage();
 
     await expect(imageLoads(page, allowedUrl)).resolves.toBe(false);
   });
@@ -68,18 +68,18 @@ describe("context.setDomainPolicy", () => {
     // so the later chrome-error can only be attributed to domain policy.
     const initialResponse = await page.goto(alternateHostUrl);
     expect(initialResponse?.ok()).toBe(true);
-    await stagehand.context.setDomainPolicy({ allowedDomains: ["127.0.0.1"] });
+    await stagehand.browser.context.setDomainPolicy({ allowedDomains: ["127.0.0.1"] });
 
     const allowedResponse = await page.goto(allowedUrl);
     expect(allowedResponse?.ok()).toBe(true);
-    const blockedPage = await stagehand.context.newPage();
+    const blockedPage = await stagehand.browser.context.newPage();
     await blockedPage.goto(alternateHostUrl);
     await expect(blockedPage.url()).resolves.toMatch(/^chrome-error:/);
   });
 
   it("blocked domains take precedence over allowed domains", async () => {
     const page = await firstPage(stagehand);
-    await stagehand.context.setDomainPolicy({
+    await stagehand.browser.context.setDomainPolicy({
       allowedDomains: ["127.0.0.1"],
       blockedDomains: ["127.0.0.1"],
     });
@@ -88,8 +88,8 @@ describe("context.setDomainPolicy", () => {
   });
 
   it("allowed domains apply to pages created afterward", async () => {
-    await stagehand.context.setDomainPolicy({ allowedDomains: ["127.0.0.1"] });
-    const page = await stagehand.context.newPage();
+    await stagehand.browser.context.setDomainPolicy({ allowedDomains: ["127.0.0.1"] });
+    const page = await stagehand.browser.context.newPage();
 
     const response = await page.goto(allowedUrl);
     expect(response?.ok()).toBe(true);
@@ -98,12 +98,12 @@ describe("context.setDomainPolicy", () => {
   it("does not retain a popup targeting a blocked domain", async () => {
     const page = await firstPage(stagehand);
     const popupUrl = new URL("/popup", fixture.url).href;
-    await stagehand.context.setDomainPolicy({ blockedDomains: ["127.0.0.1"] });
+    await stagehand.browser.context.setDomainPolicy({ blockedDomains: ["127.0.0.1"] });
     await page.goto(
       `data:text/html,${encodeURIComponent(`<button id="open" onclick="window.__blockedPopup = window.open('${popupUrl}')">open</button>`)}`,
     );
     const knownPageIds = new Set(
-      (await stagehand.context.pages()).map((candidate) => candidate.pageId),
+      (await stagehand.browser.context.pages()).map((candidate) => candidate.pageId),
     );
     await page.locator("#open").click();
 
@@ -121,7 +121,7 @@ describe("context.setDomainPolicy", () => {
     await expect
       .poll(
         async () =>
-          (await stagehand.context.pages()).every((candidate) =>
+          (await stagehand.browser.context.pages()).every((candidate) =>
             knownPageIds.has(candidate.pageId),
           ),
         { timeout: 5_000, interval: 50 },

--- a/packages/sdk-ts/tests/integration/context-extra-http-headers.test.ts
+++ b/packages/sdk-ts/tests/integration/context-extra-http-headers.test.ts
@@ -25,7 +25,7 @@ describe("context.setExtraHTTPHeaders", () => {
   });
 
   it("applies headers to navigation requests", async () => {
-    await stagehand.context.setExtraHTTPHeaders({ "x-stagehand-test": "yes" });
+    await stagehand.browser.context.setExtraHTTPHeaders({ "x-stagehand-test": "yes" });
     const page = await firstPage(stagehand);
     await page.goto(fixture.url);
 

--- a/packages/sdk-ts/tests/integration/cookies.test.ts
+++ b/packages/sdk-ts/tests/integration/cookies.test.ts
@@ -25,7 +25,7 @@ describe("cookies", () => {
   });
 
   it("addCookies sets a cookie visible to the page", async () => {
-    const ctx = stagehand.context;
+    const ctx = stagehand.browser.context;
     const page = (await ctx.pages())[0];
     expect(page).toBeDefined();
     await page!.goto(fixtureServer.url);
@@ -41,7 +41,7 @@ describe("cookies", () => {
   });
 
   it("cookies() with no URL returns all cookies", async () => {
-    const ctx = stagehand.context;
+    const ctx = stagehand.browser.context;
     const page = (await ctx.pages())[0]!;
     await page.goto(fixtureServer.url);
 
@@ -53,7 +53,7 @@ describe("cookies", () => {
   });
 
   it("clearCookies() removes all cookies", async () => {
-    const ctx = stagehand.context;
+    const ctx = stagehand.browser.context;
     const page = (await ctx.pages())[0]!;
     await page.goto(fixtureServer.url);
     await ctx.addCookies([
@@ -72,7 +72,7 @@ describe("cookies", () => {
   });
 
   it("clearCookies() with name filter removes only matching cookies", async () => {
-    const ctx = stagehand.context;
+    const ctx = stagehand.browser.context;
     const page = (await ctx.pages())[0]!;
     await page.goto(fixtureServer.url);
     await ctx.addCookies([
@@ -87,7 +87,7 @@ describe("cookies", () => {
   });
 
   it("clearCookies() with regex filter removes matching cookies", async () => {
-    const ctx = stagehand.context;
+    const ctx = stagehand.browser.context;
     const page = (await ctx.pages())[0]!;
     await page.goto(fixtureServer.url);
     await ctx.addCookies([
@@ -104,7 +104,7 @@ describe("cookies", () => {
   });
 
   it("cookies are visible from a second page on the same domain", async () => {
-    const ctx = stagehand.context;
+    const ctx = stagehand.browser.context;
     const page1 = (await ctx.pages())[0]!;
     await page1.goto(fixtureServer.url);
 
@@ -119,7 +119,7 @@ describe("cookies", () => {
   });
 
   it("cookies persist across navigation to a different path", async () => {
-    const ctx = stagehand.context;
+    const ctx = stagehand.browser.context;
     const page = (await ctx.pages())[0]!;
     await page.goto(fixtureServer.url);
 
@@ -140,7 +140,7 @@ describe("cookies", () => {
   });
 
   it("httpOnly cookie is hidden from document.cookie but returned by cookies()", async () => {
-    const ctx = stagehand.context;
+    const ctx = stagehand.browser.context;
     const page = (await ctx.pages())[0]!;
     await page.goto(fixtureServer.url);
 
@@ -158,7 +158,7 @@ describe("cookies", () => {
   });
 
   it("cookies() returns correct shape for a fully-specified cookie", async () => {
-    const ctx = stagehand.context;
+    const ctx = stagehand.browser.context;
     const page = (await ctx.pages())[0]!;
     await page.goto(fixtureServer.url);
 

--- a/packages/sdk-ts/tests/integration/default-page-tracking.test.ts
+++ b/packages/sdk-ts/tests/integration/default-page-tracking.test.ts
@@ -37,8 +37,8 @@ describe("default page tracking", () => {
   });
 
   it("activePage points to the initial page", async () => {
-    const pages = await stagehand.context.pages();
-    const active = await stagehand.context.activePage();
+    const pages = await stagehand.browser.context.pages();
+    const active = await stagehand.browser.context.activePage();
 
     expect(pages.length).toBeGreaterThanOrEqual(1);
     expect(active?.pageId).toBe(pages[0]?.pageId);
@@ -46,8 +46,8 @@ describe("default page tracking", () => {
 
   it("activePage switches to the most recently created page", async () => {
     const initial = await firstPage(stagehand);
-    const created = await stagehand.context.newPage({ url: fixture.url });
-    const active = await waitForActivePage(stagehand.context, initial.pageId);
+    const created = await stagehand.browser.context.newPage({ url: fixture.url });
+    const active = await waitForActivePage(stagehand.browser.context, initial.pageId);
 
     expect(active.pageId).toBe(created.pageId);
   });
@@ -57,16 +57,16 @@ describe("default page tracking", () => {
     await root.goto(fixture.url);
     await root.locator("#open").click();
 
-    const page2 = await waitForActivePage(stagehand.context, root.pageId);
+    const page2 = await waitForActivePage(stagehand.browser.context, root.pageId);
     await expect.poll(() => page2.url()).toBe(new URL("/page2", fixture.url).href);
     await page2.locator("#open").click();
 
-    const page3 = await waitForActivePage(stagehand.context, page2.pageId);
+    const page3 = await waitForActivePage(stagehand.browser.context, page2.pageId);
     await expect.poll(() => page3.url()).toBe(new URL("/page3", fixture.url).href);
     await page3.close();
 
     await expect
-      .poll(async () => (await stagehand.context.activePage())?.pageId, {
+      .poll(async () => (await stagehand.browser.context.activePage())?.pageId, {
         timeout: 5_000,
         interval: 25,
       })

--- a/packages/sdk-ts/tests/integration/locator-fill.test.ts
+++ b/packages/sdk-ts/tests/integration/locator-fill.test.ts
@@ -113,7 +113,7 @@ describe("Locator.fill()", () => {
 });
 
 async function poisonLocatorWorld(stagehand: Stagehand, selector: string): Promise<void> {
-  const sdkPage = (await stagehand.context.pages())[0];
+  const sdkPage = (await stagehand.browser.context.pages())[0];
   if (!sdkPage) throw new Error("Stagehand did not expose its initial page");
 
   await sdkPage.locator(selector).count();

--- a/packages/sdk-ts/tests/integration/page-addInitScript.test.ts
+++ b/packages/sdk-ts/tests/integration/page-addInitScript.test.ts
@@ -17,7 +17,7 @@ describe("page.addInitScript", () => {
   beforeEach(async () => {
     fixture = await startFixtureServer("<!doctype html><body>fixture</body>");
     stagehand = await createStagehand();
-    ctx = stagehand.context;
+    ctx = stagehand.browser.context;
   });
 
   afterEach(async () => {

--- a/packages/sdk-ts/tests/integration/wait-for-selector.test.ts
+++ b/packages/sdk-ts/tests/integration/wait-for-selector.test.ts
@@ -22,9 +22,9 @@ describe("Page.waitForSelector tests", () => {
   });
 
   beforeEach(async () => {
-    const pages = await stagehand.context.pages();
+    const pages = await stagehand.browser.context.pages();
     if (pages.length === 0) {
-      await stagehand.context.newPage({ url: "about:blank" });
+      await stagehand.browser.context.newPage({ url: "about:blank" });
       return;
     }
 
@@ -33,7 +33,7 @@ describe("Page.waitForSelector tests", () => {
       await page.close().catch(() => {});
     }
 
-    await stagehand.context.setActivePage(primary);
+    await stagehand.browser.context.setActivePage(primary);
     await primary.goto("about:blank", {
       waitUntil: "load",
       timeout: 15_000,

--- a/packages/sdk-ts/tests/object-wrapper.test.ts
+++ b/packages/sdk-ts/tests/object-wrapper.test.ts
@@ -108,7 +108,7 @@ describe("Stagehand TS object wrapper", () => {
     const stagehand = createStagehandWithClientForTest(client);
 
     expect(stagehand.initialized).toBe(true);
-    expect(stagehand.context).toBeInstanceOf(BrowserContext);
+    expect(stagehand.browser.context).toBeInstanceOf(BrowserContext);
     expect(client.calls).toStrictEqual([]);
   });
 
@@ -131,7 +131,7 @@ describe("Stagehand TS object wrapper", () => {
     ]);
     const stagehand = createStagehandWithClientForTest(client);
 
-    const pages = await stagehand.context.pages();
+    const pages = await stagehand.browser.context.pages();
 
     expect(client.calls).toStrictEqual([requestCall(StagehandMethods.contextPages, {})]);
     expect(pages).toHaveLength(2);
@@ -153,7 +153,7 @@ describe("Stagehand TS object wrapper", () => {
     });
     const stagehand = createStagehandWithClientForTest(client);
 
-    const page = await stagehand.context.newPage({ url: "https://browserbase.com" });
+    const page = await stagehand.browser.context.newPage({ url: "https://browserbase.com" });
 
     expect(client.calls).toStrictEqual([
       requestCall(StagehandMethods.contextNewPage, { url: "https://browserbase.com" }),
@@ -175,8 +175,8 @@ describe("Stagehand TS object wrapper", () => {
     client.queueResponse(StagehandMethods.contextActivePage, null);
     const stagehand = createStagehandWithClientForTest(client);
 
-    const activePage = await stagehand.context.activePage();
-    const missingActivePage = await stagehand.context.activePage();
+    const activePage = await stagehand.browser.context.activePage();
+    const missingActivePage = await stagehand.browser.context.activePage();
 
     expect(activePage).toBeInstanceOf(Page);
     expect(activePage?.ref).toStrictEqual({
@@ -197,8 +197,8 @@ describe("Stagehand TS object wrapper", () => {
     const stagehand = createStagehandWithClientForTest(client);
     const page = new Page(client, { pageId: "page-1" });
 
-    await stagehand.context.setActivePage(page);
-    await stagehand.context.close();
+    await stagehand.browser.context.setActivePage(page);
+    await stagehand.browser.context.close();
 
     expect(client.calls).toStrictEqual([
       requestCall(StagehandMethods.contextSetActivePage, { pageId: "page-1" }),
@@ -215,8 +215,8 @@ describe("Stagehand TS object wrapper", () => {
       globalThis.document.title = String(arg.ready);
     };
 
-    await stagehand.context.addInitScript({ content: "globalThis.fromContent = true" });
-    await stagehand.context.addInitScript(script, { ready: true });
+    await stagehand.browser.context.addInitScript({ content: "globalThis.fromContent = true" });
+    await stagehand.browser.context.addInitScript(script, { ready: true });
 
     expect(client.calls).toStrictEqual([
       requestCall(StagehandMethods.contextAddInitScript, {
@@ -240,17 +240,17 @@ describe("Stagehand TS object wrapper", () => {
     client.queueResponse(StagehandMethods.contextSetDomainPolicy, { ok: true });
     const stagehand = createStagehandWithClientForTest(client);
 
-    await stagehand.context.setExtraHTTPHeaders({
+    await stagehand.browser.context.setExtraHTTPHeaders({
       "X-Request-ID": "request-1",
       doNotRenameMe: "value",
     });
-    await expect(stagehand.context.getDomainPolicy()).resolves.toStrictEqual({
+    await expect(stagehand.browser.context.getDomainPolicy()).resolves.toStrictEqual({
       allowedDomains: ["example.com"],
       blockedDomains: ["blocked.example.com"],
     });
-    await expect(stagehand.context.getDomainPolicy()).resolves.toBeNull();
-    await stagehand.context.setDomainPolicy({ allowedDomains: ["example.test"] });
-    await stagehand.context.setDomainPolicy(null);
+    await expect(stagehand.browser.context.getDomainPolicy()).resolves.toBeNull();
+    await stagehand.browser.context.setDomainPolicy({ allowedDomains: ["example.test"] });
+    await stagehand.browser.context.setDomainPolicy(null);
 
     expect(client.calls).toStrictEqual([
       requestCall(StagehandMethods.contextSetExtraHTTPHeaders, {
@@ -291,17 +291,17 @@ describe("Stagehand TS object wrapper", () => {
       sameSite: "Lax" as const,
     };
 
-    await expect(stagehand.context.cookies("https://example.test/account")).resolves.toStrictEqual([
-      cookie,
-    ]);
-    await expect(stagehand.context.cookies()).resolves.toStrictEqual([]);
-    await stagehand.context.addCookies([cookieParam]);
-    await stagehand.context.clearCookies({
+    await expect(
+      stagehand.browser.context.cookies("https://example.test/account"),
+    ).resolves.toStrictEqual([cookie]);
+    await expect(stagehand.browser.context.cookies()).resolves.toStrictEqual([]);
+    await stagehand.browser.context.addCookies([cookieParam]);
+    await stagehand.browser.context.clearCookies({
       name: /^session-/gi,
       domain: "example.test",
       path: /^\/account/,
     });
-    await stagehand.context.clearCookies();
+    await stagehand.browser.context.clearCookies();
 
     expect(client.calls).toStrictEqual([
       requestCall(StagehandMethods.contextCookies, {
@@ -331,9 +331,9 @@ describe("Stagehand TS object wrapper", () => {
     const stagehand = createStagehandWithClientForTest(client);
     const page = new Page(client, { pageId: "page-1" });
 
-    const clipboard = stagehand.context.clipboard;
+    const clipboard = stagehand.browser.context.clipboard;
     expect(clipboard).toBeInstanceOf(BrowserClipboard);
-    expect(stagehand.context.clipboard).toBe(clipboard);
+    expect(stagehand.browser.context.clipboard).toBe(clipboard);
     expect(client.calls).toStrictEqual([]);
 
     await expect(clipboard.readText({ page })).resolves.toBe("clipboard text");

--- a/packages/sdk-ts/tests/stagehandCreate.test.ts
+++ b/packages/sdk-ts/tests/stagehandCreate.test.ts
@@ -5,7 +5,12 @@ import type {
   LLMGenerateResult,
   StagehandMetrics,
 } from "../../protocol/types.js";
-import { Stagehand, StagehandCreateOptionsSchema, type StagehandBrowser } from "../src/index.js";
+import {
+  BrowserContext,
+  Stagehand,
+  StagehandCreateOptionsSchema,
+  type StagehandBrowser,
+} from "../src/index.js";
 import { createBrowserFactoriesForTest } from "../src/browser/factories.js";
 import { CDPConnectionClosedError, type CDPClient } from "../src/cdpClient.js";
 
@@ -78,7 +83,7 @@ describe("Stagehand.create", () => {
 
     expect(stagehand.initialized).toBe(true);
     expect(stagehand.browser).toBe(browser);
-    expect(browser.context).toBe(stagehand.context);
+    expect(browser.context).toBeInstanceOf(BrowserContext);
     expect("init" in stagehand).toBe(false);
     expect(cdp.requests[0]).toMatchObject({
       method: "stagehand.init",


### PR DESCRIPTION
# why

Consumers must move to the browser-owned context before the Stagehand accessors can be removed.

# what changed

Migrates TypeScript, Python, and Go examples, tests, smoke coverage, and v4 documentation to browser context access.

No changeset: this targets the unreleased v4 API.

# test plan

- SDK unit tests
- Cross-language example parity tests
- Documentation reference checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch all SDK docs, examples, and tests to use the browser-owned context with browser factories and `Stagehand.create({ browser })`. Completes STG-2763 by replacing `stagehand.context` with `browser.context` (or `stagehand.browser.context` when accessed via Stagehand).

- **Migration**
  - TypeScript/Python: replace `stagehand.context.*` with `browser.context.*` (or `stagehand.browser.context.*` as needed). Prefer `const [page] = await browser.context.pages()` over `activePage()`. Examples, READMEs, and quickstarts updated; no `.init()`.
  - Docs: v4 basics, first steps, configuration, quickstart, and references now use `browserbase.launch`, `localBrowser.launch`/`connect`, and `Stagehand.create({ browser })`. Observability reads the session ID from `browser.browserbaseSessionId`. Clipboard/context/page references use `browser.context`. Install guides say to pass env values to the browser factory.
  - Go: adopt `LaunchLocalBrowser` + `Create` flow; examples use `browser.Context().Pages()[0]` instead of `ActivePage()`. Tests (and thin client) use `client.Browser().Context()`. Guidance in `idiomatic_go.md` updated.
  - TS tests: access context via `stagehand.browser.context`; smoke/integration and object-model/create tests updated to reflect no `.init` and no `stagehand.context` access.

<sup>Written for commit c3d09c443f2cd91c0086edd4cfad28799ae768ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

