### PR TITLE
Remove Stagehand context accessors

### DIFF
--- a/packages/sdk-go/client_test.go
+++ b/packages/sdk-go/client_test.go
@@ -89,6 +89,13 @@ func (c *recordingProtocolClient) close() error {
 	return nil
 }
 
+func TestStagehandDoesNotExposeContext(t *testing.T) {
+	t.Parallel()
+	if _, ok := reflect.TypeOf((*Stagehand)(nil)).MethodByName("Context"); ok {
+		t.Fatal("Stagehand.Context() remains in the public API")
+	}
+}
+
 func TestThinClientUsesGeneratedBoundaryTypes(t *testing.T) {
 	t.Parallel()
 

--- a/packages/sdk-go/stagehand.go
+++ b/packages/sdk-go/stagehand.go
@@ -126,17 +126,6 @@ func createWithAdapters(ctx context.Context, options CreateOptions, adapters cli
 	return client, nil
 }
 
-// Context returns the initialized browser context.
-func (s *Stagehand) Context() (*BrowserContext, error) {
-	s.mu.RLock()
-	browser := s.browser
-	s.mu.RUnlock()
-	if browser == nil {
-		return nil, ErrNotInitialized
-	}
-	return browser.Context()
-}
-
 // Browser returns the factory-created browser handle attached to Stagehand.
 func (s *Stagehand) Browser() *Browser {
 	s.mu.RLock()

--- a/packages/sdk-python/src/stagehand/stagehand.py
+++ b/packages/sdk-python/src/stagehand/stagehand.py
@@ -157,10 +157,6 @@ class Stagehand:
         return stagehand
 
     @property
-    def context(self) -> BrowserContext:
-        return self._browser_handle.context
-
-    @property
     def browser(self) -> StagehandBrowser:
         return self._browser_handle
 

--- a/packages/sdk-python/tests/test_stagehand.py
+++ b/packages/sdk-python/tests/test_stagehand.py
@@ -135,6 +135,10 @@ def test_stagehand_constructor_is_private() -> None:
         Stagehand()
 
 
+def test_stagehand_does_not_expose_context() -> None:
+    assert not hasattr(Stagehand, "context")
+
+
 @pytest.mark.asyncio
 async def test_create_requires_a_factory_browser_before_validating_config() -> None:
     with pytest.raises(TypeError, match="browser must be created by local_browser or browserbase"):

--- a/packages/sdk-ts/src/stagehand.ts
+++ b/packages/sdk-ts/src/stagehand.ts
@@ -98,10 +98,6 @@ export class Stagehand {
     }
   }
 
-  get context(): BrowserContext {
-    return this.browserHandle.context;
-  }
-
   get browser(): StagehandBrowser {
     return this.browserHandle;
   }

--- a/packages/sdk-ts/tests/package-contract.test.ts
+++ b/packages/sdk-ts/tests/package-contract.test.ts
@@ -61,6 +61,9 @@ describe("published TypeScript SDK", () => {
             if ("init" in Stagehand.prototype) {
               throw new Error("legacy Stagehand.init is still published");
             }
+            if ("context" in Stagehand.prototype) {
+              throw new Error("legacy Stagehand.context is still published");
+            }
             if (typeof localBrowser?.launch !== "function") {
               throw new Error("localBrowser export is unavailable");
             }

--- a/packages/sdk-ts/tests/stagehandCreate.test.ts
+++ b/packages/sdk-ts/tests/stagehandCreate.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import type { JSONRPCMessage } from "../../protocol/json-rpc/types.js";
 import type {
   LLMGenerateParams,
@@ -66,6 +66,11 @@ class FakeCDPClient {
 }
 
 describe("Stagehand.create", () => {
+  it("does not expose context directly on Stagehand", () => {
+    expectTypeOf<"context" extends keyof Stagehand ? true : false>().toEqualTypeOf<false>();
+    expect("context" in Stagehand.prototype).toBe(false);
+  });
+
   afterEach(() => vi.restoreAllMocks());
 
   it("attaches to a ready browser without taking transport ownership", async () => {

--- a/rules/ast-grep/sdk-parity.test.ts
+++ b/rules/ast-grep/sdk-parity.test.ts
@@ -86,7 +86,7 @@ type PythonRpcCall = {
 type GoRpcCall = PythonRpcCall;
 
 const goAccessors: Readonly<Record<string, ReadonlySet<string>>> = {
-  Stagehand: new Set(["Browser", "Context", "Initialized"]),
+  Stagehand: new Set(["Browser", "Initialized"]),
   BrowserContext: new Set(["Clipboard"]),
   BrowserClipboard: new Set(),
   Page: new Set(["PageID", "Ref"]),
@@ -277,6 +277,13 @@ describe("All language SDK operations remain in sync", () => {
     expect(python, "Stagehand Python accessors must remain in sync").toStrictEqual(typescript);
     expect(goClient, "Stagehand Go accessors must remain in sync").toStrictEqual(typescript);
     expect(typescript.length, "Stagehand must expose public accessors").toBeGreaterThan(0);
+    for (const [language, accessors] of [
+      ["TypeScript", typescript],
+      ["Python", python],
+      ["Go", goClient],
+    ] as const) {
+      expect(accessors, `${language} Stagehand must not expose context`).not.toContain("context");
+    }
 
     for (const [, , , goFile, goType] of sdkObjects) {
       const root = parse("go", await readFile(new URL(goFile, goSource), "utf8")).root();


### PR DESCRIPTION
# why

With consumers migrated, keeping Stagehand context aliases would preserve an API we do not want to support in v4.

# what changed

Removes Stagehand context accessors from TypeScript, Python, and Go and adds API regression guards plus updated parity expectations.

No changeset: this targets the unreleased v4 API.

# test plan

- TypeScript SDK build and unit tests
- Full Python SDK suite
- Go SDK suite
- Cross-language parity tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `Stagehand` context accessors in TypeScript, Python, and Go so only `stagehand.browser.context` remains public. Adds parity and test guards to lock this for v4 (STG-2763).

- **Migration**
  - TypeScript: change `stagehand.context` to `stagehand.browser.context`.
  - Python: change `stagehand.context` to `stagehand.browser.context`.
  - Go: change `Stagehand.Context()` to `Stagehand.Browser().Context()`.

- **Parity and Tests**
  - TypeScript: package contract test rejects `Stagehand.prototype.context`; type-level and runtime checks added in `stagehandCreate.test.ts`.
  - Python: new test asserts `Stagehand` has no `context`.
  - Go: reflection test ensures `Stagehand.Context()` is not public.
  - Parity: `rules/ast-grep` removes Go `Context` accessor and asserts no SDK exposes `context`.

<sup>Written for commit a59eb4c16a652d581a517415f671b405c42f6292. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

