### PR TITLE
evals: add the LLMExposure tool-surface contract

### DIFF
--- a/packages/evals/core/contracts/tool.ts
+++ b/packages/evals/core/contracts/tool.ts
@@ -5,6 +5,7 @@ import type { Artifact, BrowserOwnership, ConnectionMode, EnvironmentName } from
 
 export type ToolSurface =
   | "understudy_code"
+  | "stagehand_code"
   | "playwright_code"
   | "cdp_code"
   | "playwright_mcp"
@@ -146,9 +147,86 @@ export interface ToolStartResult {
 export interface CoreTool {
   id: ToolSurface;
   surface: "code" | "mcp" | "cli";
-  family: "understudy" | "playwright" | "cdp" | "stagehand_cli" | "chrome_devtools";
+  family: "understudy" | "stagehand" | "playwright" | "cdp" | "stagehand_cli" | "chrome_devtools";
   supportedStartupProfiles: StartupProfile[];
   supportedCapabilities: CoreCapability[];
   supportedTargetKinds: TargetKind[];
   start(input: ToolStartInput): Promise<ToolStartResult>;
+}
+
+/**
+ * The MCP server / tool name a `code_handles` exposure is mounted under by an
+ * agent harness. Surfaces reference the tool name in their prompt
+ * instructions; the harness mounts the single "run" tool under the server.
+ */
+export const LLM_RUN_TOOL_SERVER = "stagehand_browser";
+export const LLM_RUN_TOOL_NAME = `mcp__${LLM_RUN_TOOL_SERVER}__run`;
+
+/**
+ * `code_handles` only: the surface-specific pieces of the harness's single
+ * "run" tool. The harness owns the tool mechanics (timeouts, result
+ * stringification, logging); the surface owns the copy the model sees and
+ * the values bound into the snippet scope.
+ */
+export interface LLMRunToolSpec {
+  /** MCP tool description shown to the model. */
+  description: string;
+  /** Description of the tool's `code` parameter. */
+  codeParamDescription: string;
+  /** Denial message when the model requests a tool outside the allowlist. */
+  denyMessage: string;
+  /** Value bound to `task` in the snippet scope. */
+  task: Record<string, unknown>;
+  /**
+   * Value bound to `console` in the snippet scope. Defaults to the
+   * harness's logger-backed console when omitted.
+   */
+  console?: Pick<Console, "log" | "warn" | "error">;
+}
+
+/**
+ * Harness-observed terminal state of a run, captured through the surface
+ * itself after the agent finishes. This is what grounds grading in the task
+ * artifact: the verifier's final-screenshot anchor comes from the harness's
+ * own observation of the page, not from whatever image the agent chose to
+ * return (code surfaces stringify tool results, so agent-returned images
+ * don't exist there at all).
+ */
+export interface TerminalArtifact {
+  screenshot?: Buffer;
+  url?: string;
+}
+
+/**
+ * A harness-agnostic description of how an agent harness (claude_code,
+ * codex, ...) mounts a tool surface. Each surface implements this once;
+ * harness drivers keep exactly three mount points and no surface knowledge:
+ * - `code_handles` -> wrap `handles` in the harness's single run tool
+ * - `mcp_server`   -> mount `mcpServers` config directly
+ * - `cli`          -> spawn `command` with env
+ */
+export interface LLMExposure {
+  kind: "code_handles" | "mcp_server" | "cli";
+  /**
+   * code_handles: named values placed in the run-tool snippet scope. The
+   * harness derives the snippet argument names from these keys (plus
+   * startUrl, task, and console). Names, not order, bind the values.
+   */
+  handles?: Record<string, unknown>;
+  promptInstructions: string;
+  /** mcp_server: mounted as-is by the harness. */
+  mcpServers?: Record<string, unknown>;
+  /** cli: spawned with env by the harness. */
+  command?: { bin: string; env: Record<string, string> };
+  /** code_handles: surface-specific run-tool copy and snippet bindings. */
+  runTool?: LLMRunToolSpec;
+  /** Extra surface facts (session URLs etc.) that flow through to the harness. */
+  metadata?: Record<string, unknown>;
+  /**
+   * Capture the terminal page state (screenshot + URL) for artifact-grounded
+   * grading. Called by the harness after the agent finishes, before cleanup.
+   * Best-effort: implementations should swallow per-field failures.
+   */
+  captureFinalState?: () => Promise<TerminalArtifact>;
+  cleanup: () => Promise<void>;
 }

--- a/packages/evals/core/contracts/tool.ts
+++ b/packages/evals/core/contracts/tool.ts
@@ -1,3 +1,4 @@
+import type { ProbeEvidence } from "stagehand-v3";
 import type { EvalLogger } from "../../logger.js";
 import type { ActionTarget, FocusedTarget, TargetKind, WaitSpec } from "./targets.js";
 import type { PageRepresentation, RepresentationOpts } from "./representation.js";
@@ -135,6 +136,19 @@ export interface ToolStartInput {
 
 export interface ToolStartResult {
   session: CoreSession;
+  /**
+   * Optional agent-facing binding for this running surface. `via` describes
+   * delivery to the agent and is independent of `CoreTool.surface`; for
+   * example, a code surface may be delivered through MCP or a CLI wrapper.
+   */
+  agentMount?: AgentMount;
+  /**
+   * Best-effort evidence captured from the current surface state. Harnesses may
+   * call this after individual actions and once more at the end of a run.
+   * Implementations must swallow per-field failures and must not throw.
+   */
+  captureEvidence?: () => Promise<ProbeEvidence>;
+  /** Releases the runtime; `captureEvidence` is invalid after this resolves. */
   cleanup: () => Promise<void>;
   metadata: {
     environment: EnvironmentName;
@@ -155,78 +169,51 @@ export interface CoreTool {
 }
 
 /**
- * The MCP server / tool name a `code_handles` exposure is mounted under by an
- * agent harness. Surfaces reference the tool name in their prompt
- * instructions; the harness mounts the single "run" tool under the server.
+ * The MCP server / tool name used when an agent harness wraps handles in a
+ * code-execution tool.
  */
-export const LLM_RUN_TOOL_SERVER = "stagehand_browser";
-export const LLM_RUN_TOOL_NAME = `mcp__${LLM_RUN_TOOL_SERVER}__run`;
+export const AGENT_RUN_TOOL_SERVER = "stagehand_browser";
+export const AGENT_RUN_TOOL_NAME = `mcp__${AGENT_RUN_TOOL_SERVER}__run`;
+export const AGENT_RUN_TOOL_RESERVED_HANDLES = ["startUrl", "task", "console"] as const;
 
 /**
- * `code_handles` only: the surface-specific pieces of the harness's single
- * "run" tool. The harness owns the tool mechanics (timeouts, result
- * stringification, logging); the surface owns the copy the model sees and
- * the values bound into the snippet scope.
+ * Surface-specific copy for the harness's code-execution tool. The harness
+ * owns mechanics and task bindings; the surface owns what the agent sees.
  */
-export interface LLMRunToolSpec {
+export interface AgentRunToolSpec {
   /** MCP tool description shown to the model. */
   description: string;
   /** Description of the tool's `code` parameter. */
   codeParamDescription: string;
-  /** Denial message when the model requests a tool outside the allowlist. */
+  /** Message from the harness-owned tool allowlist when access is denied. */
   denyMessage: string;
-  /** Value bound to `task` in the snippet scope. */
-  task: Record<string, unknown>;
-  /**
-   * Value bound to `console` in the snippet scope. Defaults to the
-   * harness's logger-backed console when omitted.
-   */
-  console?: Pick<Console, "log" | "warn" | "error">;
 }
 
 /**
- * Harness-observed terminal state of a run, captured through the surface
- * itself after the agent finishes. This is what grounds grading in the task
- * artifact: the verifier's final-screenshot anchor comes from the harness's
- * own observation of the page, not from whatever image the agent chose to
- * return (code surfaces stringify tool results, so agent-returned images
- * don't exist there at all).
+ * How an agent harness reaches an already-running surface. This is independent
+ * of `CoreTool.surface`; harnesses switch on `via` and need no surface-specific
+ * mounting logic.
  */
-export interface TerminalArtifact {
-  screenshot?: Buffer;
-  url?: string;
-}
-
-/**
- * A harness-agnostic description of how an agent harness (claude_code,
- * codex, ...) mounts a tool surface. Each surface implements this once;
- * harness drivers keep exactly three mount points and no surface knowledge:
- * - `code_handles` -> wrap `handles` in the harness's single run tool
- * - `mcp_server`   -> mount `mcpServers` config directly
- * - `cli`          -> spawn `command` with env
- */
-export interface LLMExposure {
-  kind: "code_handles" | "mcp_server" | "cli";
-  /**
-   * code_handles: named values placed in the run-tool snippet scope. The
-   * harness derives the snippet argument names from these keys (plus
-   * startUrl, task, and console). Names, not order, bind the values.
-   */
-  handles?: Record<string, unknown>;
-  promptInstructions: string;
-  /** mcp_server: mounted as-is by the harness. */
-  mcpServers?: Record<string, unknown>;
-  /** cli: spawned with env by the harness. */
-  command?: { bin: string; env: Record<string, string> };
-  /** code_handles: surface-specific run-tool copy and snippet bindings. */
-  runTool?: LLMRunToolSpec;
-  /** Extra surface facts (session URLs etc.) that flow through to the harness. */
-  metadata?: Record<string, unknown>;
-  /**
-   * Capture the terminal page state (screenshot + URL) for artifact-grounded
-   * grading. Called by the harness after the agent finishes, before cleanup.
-   * Best-effort: implementations should swallow per-field failures.
-   */
-  captureFinalState?: () => Promise<TerminalArtifact>;
-  cleanup: () => Promise<void>;
-}
+export type AgentMount = { promptInstructions: string } & (
+  | {
+      via: "handles";
+      /**
+       * Named values placed in snippet scope. Names, not order, bind values.
+       * `AGENT_RUN_TOOL_RESERVED_HANDLES` are injected by the harness and may
+       * not appear here.
+       */
+      handles: Record<string, unknown>;
+      runTool: AgentRunToolSpec;
+    }
+  | { via: "mcp"; mcpServers: Record<string, unknown> }
+  | {
+      via: "cli";
+      command: {
+        bin: string;
+        args?: string[];
+        cwd?: string;
+        /** Extra variables merged over the harness environment. */
+        env?: Record<string, string>;
+      };
+    }
+);

--- a/packages/evals/tests/core/tool-contract.test.ts
+++ b/packages/evals/tests/core/tool-contract.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import type {
+  AgentMount,
+  CoreSession,
+  CoreTool,
+  ToolStartResult,
+} from "../../core/contracts/tool.js";
+
+describe("tool surface contract", () => {
+  it("keeps native surface and agent delivery independent", async () => {
+    const screenshot = Buffer.from("surface screenshot");
+    const cliMount = {
+      via: "cli",
+      promptInstructions: "Use the wrapper command.",
+      command: { bin: "stagehand-browser", env: {} },
+    } satisfies AgentMount;
+
+    const runningCodeSurface: ToolStartResult = {
+      session: {} as CoreSession,
+      agentMount: cliMount,
+      captureEvidence: async () => ({
+        screenshot,
+        url: "https://example.com",
+        ariaTree: "- document\n  - heading: Example",
+      }),
+      cleanup: async () => {},
+      metadata: {
+        environment: "local",
+        browserOwnership: "tool",
+        connectionMode: "launch",
+      },
+    };
+
+    const codeSurface: CoreTool = {
+      id: "playwright_code",
+      surface: "code",
+      family: "playwright",
+      supportedStartupProfiles: [],
+      supportedCapabilities: [],
+      supportedTargetKinds: [],
+      start: async () => runningCodeSurface,
+    };
+
+    expect(codeSurface.surface).toBe("code");
+    expect(runningCodeSurface.agentMount?.via).toBe("cli");
+    await expect(runningCodeSurface.captureEvidence?.()).resolves.toEqual({
+      screenshot,
+      url: "https://example.com",
+      ariaTree: "- document\n  - heading: Example",
+    });
+  });
+
+  it("describes injected handles without harness-owned task bindings", () => {
+    const mount = {
+      via: "handles",
+      promptInstructions: "Use the run tool.",
+      handles: { page: {} },
+      runTool: {
+        description: "Run browser code.",
+        codeParamDescription: "JavaScript to execute.",
+        denyMessage: "Use the run tool.",
+      },
+    } satisfies AgentMount;
+
+    expect(mount.via).toBe("handles");
+  });
+
+  it("requires delivery-specific fields at compile time", () => {
+    // @ts-expect-error CLI mounts require a command.
+    const invalidMount: AgentMount = {
+      via: "cli",
+      promptInstructions: "Use the CLI.",
+    };
+
+    expect(invalidMount.via).toBe("cli");
+  });
+});


### PR DESCRIPTION
A uniform declaration of what a tool surface offers a coding agent:
code_handles (in-scope objects the agent writes code against, mounted by
the harness as a single local-MCP run tool), mcp_server, or cli — plus
the LLM_RUN_TOOL_SERVER/LLM_RUN_TOOL_NAME bindings the mount uses.
Types and constants only; no surface or adapter changes.

Part 1/4 of the #2473 port onto the current SDK generation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the tool-surface contract to include agent delivery (`AgentMount`) and final-state evidence capture, keeping native `CoreTool.surface` independent from how it’s delivered to the agent. Types + tests only; supports STG-2671.

- **New Features**
  - Types: `AgentMount` (`via: handles | mcp | cli` with `promptInstructions`), `AgentRunToolSpec`; `ToolStartResult` gains optional `agentMount` and `captureEvidence(): Promise<ProbeEvidence>`.
  - Enums: `ToolSurface` adds `stagehand_code`; `CoreTool.family` adds `stagehand`.
  - Constants: `AGENT_RUN_TOOL_SERVER` ("stagehand_browser"), `AGENT_RUN_TOOL_NAME` (`mcp__stagehand_browser__run`), `AGENT_RUN_TOOL_RESERVED_HANDLES` (`startUrl`, `task`, `console`).
  - Contract semantics: delivery is independent of native surface; CLI env merges over harness env; reserved harness bindings; capture-before-cleanup ordering.
  - Tests: `tool-contract.test.ts` validates delivery independence, handle mounts, and evidence capture.

<sup>Written for commit d3ba958fcd4827dbf824951d743841435f0b52fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

