### PR TITLE
Restore v3-aligned timeout defaults in v4

### DIFF
--- a/packages/sdk-go/rpc_client.go
+++ b/packages/sdk-go/rpc_client.go
@@ -31,8 +31,44 @@ const (
 )
 
 var (
-	ErrRPCClientClosed = errors.New("stagehand RPC client is closed")
-	rpcTracePropagator = propagation.TraceContext{}
+	ErrRPCClientClosed       = errors.New("stagehand RPC client is closed")
+	rpcTracePropagator       = propagation.TraceContext{}
+	defaultOperationTimeouts = map[string]time.Duration{
+		"page.goto":                15 * time.Second,
+		"page.reload":              15 * time.Second,
+		"page.go_back":             15 * time.Second,
+		"page.go_forward":          15 * time.Second,
+		"page.wait_for_load_state": 15 * time.Second,
+		"page.wait_for_selector":   30 * time.Second,
+		"page.webmcp_tools":        time.Second,
+	}
+	unboundedByDefaultMethods = map[string]struct{}{
+		"stagehand.init":                 {},
+		"stagehand.close":                {},
+		"stagehand.act":                  {},
+		"stagehand.extract":              {},
+		"stagehand.observe":              {},
+		"context.new_page":               {},
+		"context.close":                  {},
+		"context.add_init_script":        {},
+		"context.set_extra_http_headers": {},
+		"context.get_domain_policy":      {},
+		"context.set_domain_policy":      {},
+		"context.cookies":                {},
+		"context.add_cookies":            {},
+		"context.clear_cookies":          {},
+		"context.clipboard_read_text":    {},
+		"context.clipboard_write_text":   {},
+		"context.clipboard_clear":        {},
+		"context.clipboard_paste":        {},
+		"context.clipboard_copy":         {},
+		"context.clipboard_cut":          {},
+		"page.close":                     {},
+		"page.evaluate":                  {},
+		"page.screenshot":                {},
+		"page.snapshot":                  {},
+		"page.webmcp_invocation_result":  {},
+	}
 )
 
 // RPCError is a JSON-RPC error returned by the Stagehand worker.
@@ -237,10 +273,6 @@ func (c *rpcClient) call(ctx context.Context, method string, params any, result 
 }
 
 func rpcResponseTimeout(method string, params json.RawMessage) (time.Duration, bool) {
-	if method == "stagehand.init" {
-		return 0, false
-	}
-
 	var path []string
 	switch method {
 	case "stagehand.act",
@@ -259,11 +291,23 @@ func rpcResponseTimeout(method string, params json.RawMessage) (time.Duration, b
 		path = []string{"timeout"}
 	case "page.wait_for_timeout":
 		path = []string{"ms"}
-	default:
-		return rpcResponseGrace, true
 	}
 
-	durationMilliseconds := jsonNumberAtPath(params, path...)
+	if durationMilliseconds, found := jsonNumberAtPath(params, path...); found {
+		return rpcResponseTimeoutForDuration(durationMilliseconds), true
+	}
+	if defaultTimeout, found := defaultOperationTimeouts[method]; found {
+		return rpcResponseGrace + defaultTimeout, true
+	}
+	// These operations had no v3 deadline. Keep the server as the owner of their
+	// lifetime instead of turning the transport grace period into a 10s ceiling.
+	if _, found := unboundedByDefaultMethods[method]; found || strings.HasPrefix(method, "locator.") {
+		return 0, false
+	}
+	return rpcResponseGrace, true
+}
+
+func rpcResponseTimeoutForDuration(durationMilliseconds float64) time.Duration {
 	if durationMilliseconds < 0 {
 		durationMilliseconds = 0
 	}
@@ -271,40 +315,43 @@ func rpcResponseTimeout(method string, params json.RawMessage) (time.Duration, b
 	operationNanoseconds := durationMilliseconds * float64(time.Millisecond)
 	if math.IsInf(operationNanoseconds, 1) ||
 		operationNanoseconds >= float64(maxOperationDuration) {
-		return maxRPCResponseTimeout, true
+		return maxRPCResponseTimeout
 	}
-	return rpcResponseGrace + time.Duration(operationNanoseconds), true
+	return rpcResponseGrace + time.Duration(operationNanoseconds)
 }
 
-func jsonNumberAtPath(encoded json.RawMessage, path ...string) float64 {
+func jsonNumberAtPath(encoded json.RawMessage, path ...string) (float64, bool) {
+	if len(path) == 0 {
+		return 0, false
+	}
 	decoder := json.NewDecoder(bytes.NewReader(encoded))
 	decoder.UseNumber()
 	var current any
 	if err := decoder.Decode(&current); err != nil {
-		return 0
+		return 0, false
 	}
 	for _, property := range path {
 		object, ok := current.(map[string]any)
 		if !ok {
-			return 0
+			return 0, false
 		}
 		current, ok = object[property]
 		if !ok {
-			return 0
+			return 0, false
 		}
 	}
 	number, ok := current.(json.Number)
 	if !ok {
-		return 0
+		return 0, false
 	}
 	value, err := number.Float64()
 	if err != nil {
 		if math.IsInf(value, 1) {
-			return value
+			return value, true
 		}
-		return 0
+		return 0, false
 	}
-	return value
+	return value, true
 }
 
 func (c *rpcClient) onRequest(method string, handler requestHandler) func() {

--- a/packages/sdk-go/rpc_client_test.go
+++ b/packages/sdk-go/rpc_client_test.go
@@ -135,6 +135,72 @@ func TestRPCResponseTimeoutPolicy(t *testing.T) {
 		t.Fatalf("stagehand.init timeout = %v, true; want no nested RPC deadline", timeout)
 	}
 
+	defaultTimeouts := map[string]time.Duration{
+		"page.goto":                25 * time.Second,
+		"page.reload":              25 * time.Second,
+		"page.go_back":             25 * time.Second,
+		"page.go_forward":          25 * time.Second,
+		"page.wait_for_load_state": 25 * time.Second,
+		"page.wait_for_selector":   40 * time.Second,
+		"page.webmcp_tools":        11 * time.Second,
+	}
+	for method, expected := range defaultTimeouts {
+		timeout, ok := rpcResponseTimeout(method, json.RawMessage(`{}`))
+		if !ok || timeout != expected {
+			t.Errorf("%s timeout = %v, %t; want %v, true", method, timeout, ok, expected)
+		}
+	}
+
+	unboundedMethods := []string{
+		"stagehand.init",
+		"stagehand.close",
+		"stagehand.act",
+		"stagehand.extract",
+		"stagehand.observe",
+		"context.new_page",
+		"context.close",
+		"context.add_init_script",
+		"context.set_extra_http_headers",
+		"context.get_domain_policy",
+		"context.set_domain_policy",
+		"context.cookies",
+		"context.add_cookies",
+		"context.clear_cookies",
+		"context.clipboard_read_text",
+		"context.clipboard_write_text",
+		"context.clipboard_clear",
+		"context.clipboard_paste",
+		"context.clipboard_copy",
+		"context.clipboard_cut",
+		"page.close",
+		"page.evaluate",
+		"page.screenshot",
+		"page.snapshot",
+		"page.webmcp_invocation_result",
+		"locator.click",
+		"locator.fill",
+		"locator.hover",
+		"locator.count",
+		"locator.is_checked",
+		"locator.input_value",
+		"locator.is_visible",
+		"locator.inner_text",
+		"locator.inner_html",
+		"locator.text_content",
+		"locator.scroll_to",
+		"locator.centroid",
+		"locator.highlight",
+		"locator.send_click_event",
+		"locator.type",
+		"locator.select_option",
+		"locator.set_input_files",
+	}
+	for _, method := range unboundedMethods {
+		if timeout, ok := rpcResponseTimeout(method, json.RawMessage(`{}`)); ok {
+			t.Errorf("%s timeout = %v, true; want no response deadline", method, timeout)
+		}
+	}
+
 	hugeTimeout, ok := rpcResponseTimeout(
 		"stagehand.act",
 		json.RawMessage(`{"options":{"timeout":1e1000}}`),

--- a/packages/sdk-python/src/stagehand/rpc_client.py
+++ b/packages/sdk-python/src/stagehand/rpc_client.py
@@ -20,6 +20,42 @@ from pydantic import (
 _MAX_REQUEST_ID = 9_007_199_254_740_991
 _MAX_PENDING_NOTIFICATIONS = 100
 _RPC_RESPONSE_GRACE_MS = 10_000
+_DEFAULT_OPERATION_TIMEOUT_MS = {
+    "page.goto": 15_000,
+    "page.reload": 15_000,
+    "page.go_back": 15_000,
+    "page.go_forward": 15_000,
+    "page.wait_for_load_state": 15_000,
+    "page.wait_for_selector": 30_000,
+    "page.webmcp_tools": 1_000,
+}
+_UNBOUNDED_BY_DEFAULT_METHODS = {
+    "stagehand.init",
+    "stagehand.close",
+    "stagehand.act",
+    "stagehand.extract",
+    "stagehand.observe",
+    "context.new_page",
+    "context.close",
+    "context.add_init_script",
+    "context.set_extra_http_headers",
+    "context.get_domain_policy",
+    "context.set_domain_policy",
+    "context.cookies",
+    "context.add_cookies",
+    "context.clear_cookies",
+    "context.clipboard_read_text",
+    "context.clipboard_write_text",
+    "context.clipboard_clear",
+    "context.clipboard_paste",
+    "context.clipboard_copy",
+    "context.clipboard_cut",
+    "page.close",
+    "page.evaluate",
+    "page.screenshot",
+    "page.snapshot",
+    "page.webmcp_invocation_result",
+}
 
 ParamsT = TypeVar("ParamsT", bound=BaseModel)
 ResultT = TypeVar("ResultT", bound=BaseModel)
@@ -491,9 +527,6 @@ class RPCClient:
 
 
 def _rpc_response_timeout_seconds(method: str, params: BaseModel) -> float | None:
-    if method == "stagehand.init":
-        return None
-
     operation_timeout_ms: float | int | None = None
     if method in {
         "stagehand.act",
@@ -514,7 +547,18 @@ def _rpc_response_timeout_seconds(method: str, params: BaseModel) -> float | Non
     elif method == "page.wait_for_timeout":
         operation_timeout_ms = _numeric_property(params, "ms")
 
-    return (_RPC_RESPONSE_GRACE_MS + max(0, operation_timeout_ms or 0)) / 1_000
+    if operation_timeout_ms is not None:
+        return (_RPC_RESPONSE_GRACE_MS + max(0, operation_timeout_ms)) / 1_000
+
+    if (default_timeout_ms := _DEFAULT_OPERATION_TIMEOUT_MS.get(method)) is not None:
+        return (_RPC_RESPONSE_GRACE_MS + default_timeout_ms) / 1_000
+
+    # These operations had no v3 deadline. Keep the server as the owner of their
+    # lifetime instead of turning the transport grace period into a 10s ceiling.
+    if method in _UNBOUNDED_BY_DEFAULT_METHODS or method.startswith("locator."):
+        return None
+
+    return _RPC_RESPONSE_GRACE_MS / 1_000
 
 
 def _property(value: object, name: str) -> object:

--- a/packages/sdk-python/tests/test_rpc_client.py
+++ b/packages/sdk-python/tests/test_rpc_client.py
@@ -483,6 +483,73 @@ def test_response_deadline_uses_operation_parameters_and_skips_stagehand_init() 
     assert rpc_client._rpc_response_timeout_seconds("stagehand.init", models.EmptyParams()) is None
 
 
+def test_response_deadline_uses_v3_operation_defaults() -> None:
+    params = models.EmptyParams()
+    expected = {
+        "page.goto": 25,
+        "page.reload": 25,
+        "page.go_back": 25,
+        "page.go_forward": 25,
+        "page.wait_for_load_state": 25,
+        "page.wait_for_selector": 40,
+        "page.webmcp_tools": 11,
+    }
+
+    for method, timeout in expected.items():
+        assert rpc_client._rpc_response_timeout_seconds(method, params) == timeout
+
+
+def test_response_deadline_preserves_v3_unbounded_operations() -> None:
+    params = models.EmptyParams()
+    methods = {
+        "stagehand.init",
+        "stagehand.close",
+        "stagehand.act",
+        "stagehand.extract",
+        "stagehand.observe",
+        "context.new_page",
+        "context.close",
+        "context.add_init_script",
+        "context.set_extra_http_headers",
+        "context.get_domain_policy",
+        "context.set_domain_policy",
+        "context.cookies",
+        "context.add_cookies",
+        "context.clear_cookies",
+        "context.clipboard_read_text",
+        "context.clipboard_write_text",
+        "context.clipboard_clear",
+        "context.clipboard_paste",
+        "context.clipboard_copy",
+        "context.clipboard_cut",
+        "page.close",
+        "page.evaluate",
+        "page.screenshot",
+        "page.snapshot",
+        "page.webmcp_invocation_result",
+        "locator.click",
+        "locator.fill",
+        "locator.hover",
+        "locator.count",
+        "locator.is_checked",
+        "locator.input_value",
+        "locator.is_visible",
+        "locator.inner_text",
+        "locator.inner_html",
+        "locator.text_content",
+        "locator.scroll_to",
+        "locator.centroid",
+        "locator.highlight",
+        "locator.send_click_event",
+        "locator.type",
+        "locator.select_option",
+        "locator.set_input_files",
+    }
+
+    for method in methods:
+        assert rpc_client._rpc_response_timeout_seconds(method, params) is None
+
+
 @pytest.mark.asyncio
 async def test_invalid_response_closes_client_and_rejects_pending_request() -> None:
     transport = QueueTransport()

--- a/packages/sdk-ts/src/rpcClient.ts
+++ b/packages/sdk-ts/src/rpcClient.ts
@@ -58,6 +58,42 @@ const TRACER = trace.getTracer("@browserbasehq/stagehand");
 const W3C_TRACE_CONTEXT_PROPAGATOR = new W3CTraceContextPropagator();
 const MAX_PENDING_NOTIFICATIONS = 100;
 const RPC_RESPONSE_GRACE_MS = 10_000;
+const DEFAULT_OPERATION_TIMEOUT_MS = new Map<string, number>([
+  [StagehandMethods.pageGoto.name, 15_000],
+  [StagehandMethods.pageReload.name, 15_000],
+  [StagehandMethods.pageGoBack.name, 15_000],
+  [StagehandMethods.pageGoForward.name, 15_000],
+  [StagehandMethods.pageWaitForLoadState.name, 15_000],
+  [StagehandMethods.pageWaitForSelector.name, 30_000],
+  [StagehandMethods.pageWebMCPTools.name, 1_000],
+]);
+const UNBOUNDED_BY_DEFAULT_METHODS = new Set<string>([
+  StagehandMethods.stagehandInit.name,
+  StagehandMethods.stagehandClose.name,
+  StagehandMethods.stagehandAct.name,
+  StagehandMethods.stagehandExtract.name,
+  StagehandMethods.stagehandObserve.name,
+  StagehandMethods.contextNewPage.name,
+  StagehandMethods.contextClose.name,
+  StagehandMethods.contextAddInitScript.name,
+  StagehandMethods.contextSetExtraHTTPHeaders.name,
+  StagehandMethods.contextGetDomainPolicy.name,
+  StagehandMethods.contextSetDomainPolicy.name,
+  StagehandMethods.contextCookies.name,
+  StagehandMethods.contextAddCookies.name,
+  StagehandMethods.contextClearCookies.name,
+  StagehandMethods.contextClipboardReadText.name,
+  StagehandMethods.contextClipboardWriteText.name,
+  StagehandMethods.contextClipboardClear.name,
+  StagehandMethods.contextClipboardPaste.name,
+  StagehandMethods.contextClipboardCopy.name,
+  StagehandMethods.contextClipboardCut.name,
+  StagehandMethods.pageClose.name,
+  StagehandMethods.pageEvaluate.name,
+  StagehandMethods.pageScreenshot.name,
+  StagehandMethods.pageSnapshot.name,
+  StagehandMethods.pageWebMCPInvocationResult.name,
+]);
 
 const RPCClientOptionsBaseSchema = z
   .object({
@@ -474,9 +510,7 @@ function asError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
 }
 
-function rpcResponseTimeoutMs(method: string, params: unknown): number | undefined {
-  if (method === StagehandMethods.stagehandInit.name) return undefined;
-
+export function rpcResponseTimeoutMs(method: string, params: unknown): number | undefined {
   let operationTimeoutMs: number | undefined;
   switch (method) {
     case StagehandMethods.stagehandAct.name:
@@ -500,7 +534,22 @@ function rpcResponseTimeoutMs(method: string, params: unknown): number | undefin
       break;
   }
 
-  return RPC_RESPONSE_GRACE_MS + Math.max(0, operationTimeoutMs ?? 0);
+  if (operationTimeoutMs !== undefined) {
+    return RPC_RESPONSE_GRACE_MS + Math.max(0, operationTimeoutMs);
+  }
+
+  const defaultOperationTimeoutMs = DEFAULT_OPERATION_TIMEOUT_MS.get(method);
+  if (defaultOperationTimeoutMs !== undefined) {
+    return RPC_RESPONSE_GRACE_MS + defaultOperationTimeoutMs;
+  }
+
+  // These operations had no v3 deadline. Keep the server as the owner of their
+  // lifetime instead of turning the transport grace period into a 10s ceiling.
+  if (UNBOUNDED_BY_DEFAULT_METHODS.has(method) || method.startsWith("locator.")) {
+    return undefined;
+  }
+
+  return RPC_RESPONSE_GRACE_MS;
 }
 
 function recordProperty(value: unknown, property: string): unknown {

--- a/packages/sdk-ts/tests/rpcClient.test.ts
+++ b/packages/sdk-ts/tests/rpcClient.test.ts
@@ -4,7 +4,7 @@ import { JSONRPCErrorCodes, type RPCMethod } from "../../protocol/json-rpc/schem
 import type { JSONRPCMessage } from "../../protocol/json-rpc/types.js";
 import { StagehandMethods } from "../../protocol/schema-registry.js";
 import { STAGEHAND_PROTOCOL_VERSION } from "../../protocol/schemas.js";
-import { RPCClient, type CDPTransport } from "../src/rpcClient.js";
+import { RPCClient, rpcResponseTimeoutMs, type CDPTransport } from "../src/rpcClient.js";
 
 const UppercaseMethod = {
   name: "test.uppercase",
@@ -343,6 +343,55 @@ describe("RPCClient", () => {
     } finally {
       client.close();
       vi.useRealTimers();
+    }
+  });
+
+  it.each([
+    [StagehandMethods.pageGoto.name, 25_000],
+    [StagehandMethods.pageReload.name, 25_000],
+    [StagehandMethods.pageGoBack.name, 25_000],
+    [StagehandMethods.pageGoForward.name, 25_000],
+    [StagehandMethods.pageWaitForLoadState.name, 25_000],
+    [StagehandMethods.pageWaitForSelector.name, 40_000],
+    [StagehandMethods.pageWebMCPTools.name, 11_000],
+  ])("uses the v3 operation default plus transport grace for %s", (method, timeout) => {
+    expect(rpcResponseTimeoutMs(method, {})).toBe(timeout);
+  });
+
+  it("does not impose response deadlines on operations that were unbounded in v3", () => {
+    const methods = [
+      StagehandMethods.stagehandInit.name,
+      StagehandMethods.stagehandClose.name,
+      StagehandMethods.stagehandAct.name,
+      StagehandMethods.stagehandExtract.name,
+      StagehandMethods.stagehandObserve.name,
+      StagehandMethods.contextNewPage.name,
+      StagehandMethods.contextClose.name,
+      StagehandMethods.contextAddInitScript.name,
+      StagehandMethods.contextSetExtraHTTPHeaders.name,
+      StagehandMethods.contextGetDomainPolicy.name,
+      StagehandMethods.contextSetDomainPolicy.name,
+      StagehandMethods.contextCookies.name,
+      StagehandMethods.contextAddCookies.name,
+      StagehandMethods.contextClearCookies.name,
+      StagehandMethods.contextClipboardReadText.name,
+      StagehandMethods.contextClipboardWriteText.name,
+      StagehandMethods.contextClipboardClear.name,
+      StagehandMethods.contextClipboardPaste.name,
+      StagehandMethods.contextClipboardCopy.name,
+      StagehandMethods.contextClipboardCut.name,
+      StagehandMethods.pageClose.name,
+      StagehandMethods.pageEvaluate.name,
+      StagehandMethods.pageScreenshot.name,
+      StagehandMethods.pageSnapshot.name,
+      StagehandMethods.pageWebMCPInvocationResult.name,
+      ...Object.values(StagehandMethods)
+        .map(({ name }) => name)
+        .filter((name) => name.startsWith("locator.")),
+    ];
+
+    for (const method of methods) {
+      expect(rpcResponseTimeoutMs(method, {}), method).toBeUndefined();
     }
   });
 


### PR DESCRIPTION
## Summary

- preserve the centralized JSON-RPC timeout design while distinguishing operation defaults from transport grace
- use v3/server operation defaults for navigation and load-state calls (15s), selector waits (30s), and WebMCP tool discovery (1s), with the existing 10s response grace layered on top
- remove the implicit 10s client ceiling for v3-unbounded Stagehand AI calls, close operations, evaluate/snapshot/screenshot, cookies, clipboard, context configuration, WebMCP invocation results, and every locator method across TypeScript, Python, and Go
- continue deriving the response deadline from an explicit caller timeout plus 10s grace

## Intentional exceptions

- `stagehand.init` still uses the internal 60s lifecycle signal; this does not restore the old 5s initial top-level-page fallback
- `context.new_page` keeps the improved server attach/terminal-failure semantics and has no new client-side ceiling, avoiding detached server work or duplicate-tab behavior
- ordinary fast RPCs retain the 10s response guard
- existing init-failure browser invalidation/cleanup behavior is unchanged and covered by the lifecycle tests

## Tests

- `pnpm exec vitest run packages/sdk-ts/tests/rpcClient.test.ts`
- `pnpm exec vitest run packages/sdk-ts/tests/stagehandCreate.test.ts`
- `uv run --locked pytest tests/test_rpc_client.py`
- `uv run --locked pytest tests/test_stagehand.py` (23 passed, 1 skipped)
- `go test .`
- TypeScript/Python lint, Python type checking, and `go vet .`

The TypeScript SDK build compiled its outputs successfully, then stopped in the existing post-build copy step because `packages/server/artifacts/stagehand-extension.zip` is not present in a clean checkout.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore v3-aligned default timeouts in the v4 SDKs and remove the 10s client ceiling from operations that were unbounded in v3 to prevent premature timeouts. Aligns v4 with v3 per STG-2773.

- **Bug Fixes**
  - Apply v3 defaults + 10s grace: navigation/load-state 15s (25s total), selector waits 30s (40s), WebMCP tool discovery 1s (11s).
  - Remove the implicit 10s deadline for v3-unbounded ops (Stagehand AI, context/page lifecycle, evaluate/snapshot/screenshot, cookies/clipboard, WebMCP invocation results, all `locator.*`), keeping the server as the owner of long-running work.
  - Response deadline = explicit timeout + 10s grace; exceptions: `stagehand.init` keeps the 60s lifecycle signal, `context.new_page` retains improved attach semantics with no client ceiling, and fast RPCs keep the 10s guard. Implemented in `packages/sdk-ts`, `packages/sdk-python`, and `packages/sdk-go` with unit tests covering defaults and unbounded cases.

<sup>Written for commit e9cd4334e1693322f6cf590e39c05f3ed3078e42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

