### PR TITLE
evals: consume agent mounts generically in the claude_code tool adapter

### DIFF
--- a/packages/evals/framework/agentToolRuntime.ts
+++ b/packages/evals/framework/agentToolRuntime.ts
@@ -1,0 +1,63 @@
+import type { StartupProfile, ToolStartResult, ToolSurface } from "../core/contracts/tool.js";
+import { prepareCoreBrowserTarget } from "../core/targets/index.js";
+import { getCoreTool } from "../core/tools/registry.js";
+import { EvalsError } from "../errors.js";
+import type { EvalLogger } from "../logger.js";
+
+export interface AgentToolRuntimeInput {
+  toolSurface: ToolSurface;
+  startupProfile: StartupProfile;
+  environment: "LOCAL" | "BROWSERBASE";
+  logger: EvalLogger;
+}
+
+export interface StartedAgentToolRuntime {
+  running: ToolStartResult;
+  /** Closes the tool-owned runtime, then the runner-owned browser target. */
+  cleanup: () => Promise<void>;
+}
+
+/**
+ * Starts a CoreTool for an external agent harness without interpreting its
+ * agent mount. Harness adapters own delivery; this function owns the shared
+ * tool/target lifecycle and makes cleanup idempotent.
+ */
+export async function startAgentToolRuntime(
+  input: AgentToolRuntimeInput,
+): Promise<StartedAgentToolRuntime> {
+  const tool = getCoreTool(input.toolSurface);
+  if (!tool.supportedStartupProfiles.includes(input.startupProfile)) {
+    throw new EvalsError(
+      `Tool surface "${input.toolSurface}" does not support startup profile "${input.startupProfile}".`,
+    );
+  }
+
+  const target = await prepareCoreBrowserTarget(input);
+  let running: ToolStartResult;
+  try {
+    running = await tool.start({
+      logger: input.logger,
+      environment: input.environment,
+      startupProfile: input.startupProfile,
+      providedEndpoint: target.providedEndpoint,
+    });
+  } catch (error) {
+    await target.cleanup().catch((): undefined => undefined);
+    throw error;
+  }
+
+  let cleanupPromise: Promise<void> | undefined;
+  return {
+    running,
+    cleanup: async () => {
+      cleanupPromise ??= (async () => {
+        try {
+          await running.cleanup();
+        } finally {
+          await target.cleanup();
+        }
+      })();
+      await cleanupPromise;
+    },
+  };
+}

--- a/packages/evals/framework/claudeCodeToolAdapter.ts
+++ b/packages/evals/framework/claudeCodeToolAdapter.ts
@@ -3,7 +3,6 @@ import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import matter from "gray-matter";
-import type { Browser, BrowserContext, Page } from "playwright";
 import { z } from "zod/v4";
 import { EvalsError } from "../errors.js";
 import type { EvalLogger } from "../logger.js";
@@ -13,10 +12,18 @@ import {
   BROWSE_CLI_PACKAGE_JSON,
   BROWSE_SKILL_SOURCE,
 } from "../browseCliPaths.js";
-import type { StartupProfile, ToolSurface } from "../core/contracts/tool.js";
-import { prepareCoreBrowserTarget } from "../core/targets/index.js";
-import { CdpConnection, type CdpEventMessage } from "../core/tools/cdp_code.js";
+import {
+  AGENT_RUN_TOOL_NAME,
+  AGENT_RUN_TOOL_SERVER,
+  type AgentRunToolSpec,
+  type StartupProfile,
+  type ToolSurface,
+} from "../core/contracts/tool.js";
+import type { ProbeEvidence } from "stagehand-v3";
+import { startAgentToolRuntime } from "./agentToolRuntime.js";
 import type { ExternalHarnessTaskPlan } from "./externalHarnessPlan.js";
+
+export { waitForCdpEvent } from "../core/tools/cdp_code.js";
 
 export interface ClaudeCodeToolAdapterInput {
   toolSurface?: ToolSurface;
@@ -39,6 +46,8 @@ export interface PreparedClaudeCodeToolAdapter {
     toolName: string,
     input: Record<string, unknown>,
   ) => Promise<Record<string, unknown>>;
+  /** Best-effort evidence from the currently running tool surface. */
+  captureEvidence?: () => Promise<ProbeEvidence>;
   cleanup: () => Promise<void>;
 }
 
@@ -93,8 +102,8 @@ the guidance below:
   requested by the harness prompt.
 `;
 const ALLOW_UNSANDBOXED_LOCAL_ENV = "EVAL_CLAUDE_CODE_ALLOW_UNSANDBOXED_LOCAL";
-const RUN_TOOL_SERVER = "stagehand_browser";
-const RUN_TOOL_NAME = `mcp__${RUN_TOOL_SERVER}__run`;
+const RUN_TOOL_SERVER = AGENT_RUN_TOOL_SERVER;
+const RUN_TOOL_NAME = AGENT_RUN_TOOL_NAME;
 
 type ClaudeToolResult = {
   content: Array<{ type: "text"; text: string }>;
@@ -115,28 +124,6 @@ type SdkMcpServerFactory = (options: {
   tools?: unknown[];
   alwaysLoad?: boolean;
 }) => unknown;
-
-type ActiveCdpPage = {
-  targetId: string;
-  sessionId: string;
-  url: string;
-};
-
-type CdpRuntime = {
-  readonly targetId: string;
-  readonly sessionId: string;
-  send<T = unknown>(method: string, params?: Record<string, unknown>): Promise<T>;
-  browser<T = unknown>(method: string, params?: Record<string, unknown>): Promise<T>;
-  on(method: string, listener: (event: CdpEventMessage) => unknown | Promise<unknown>): () => void;
-  off(method: string, listener: (event: CdpEventMessage) => unknown | Promise<unknown>): void;
-  once(
-    method: string,
-    listenerOrTimeout?: ((event: CdpEventMessage) => unknown | Promise<unknown>) | number,
-    timeoutMs?: number,
-  ): Promise<CdpEventMessage> | (() => void);
-  waitForEvent(method: string, timeoutMs?: number): Promise<CdpEventMessage>;
-  wait(ms: number): Promise<void>;
-};
 
 export interface BrowseCliToolMetadata {
   toolCommand: "browse";
@@ -178,31 +165,33 @@ export async function prepareClaudeCodeToolAdapter(
         startupProfile,
       });
     case "playwright_code":
-      return preparePlaywrightCodeAdapter({
-        ...input,
-        toolSurface,
-        startupProfile,
-      });
     case "cdp_code":
-      return prepareCdpCodeAdapter({
+    case "stagehand_code": {
+      return prepareMountedCoreToolAdapter({
         ...input,
         toolSurface,
         startupProfile,
       });
+    }
     default:
       throw new EvalsError(
-        `Claude Code harness supports --tool browse_cli, playwright_code, or cdp_code for execution right now; received "${toolSurface}".`,
+        `Claude Code harness supports --tool browse_cli, playwright_code, cdp_code, or stagehand_code for execution right now; received "${toolSurface}".`,
       );
   }
 }
 
 export function resolveClaudeCodeToolSurface(requested?: ToolSurface): ToolSurface {
   if (!requested) return "browse_cli";
-  if (requested === "browse_cli" || requested === "playwright_code" || requested === "cdp_code") {
+  if (
+    requested === "browse_cli" ||
+    requested === "playwright_code" ||
+    requested === "cdp_code" ||
+    requested === "stagehand_code"
+  ) {
     return requested;
   }
   throw new EvalsError(
-    `Claude Code harness supports --tool browse_cli, playwright_code, or cdp_code for execution right now; received "${requested}".`,
+    `Claude Code harness supports --tool browse_cli, playwright_code, cdp_code, or stagehand_code for execution right now; received "${requested}".`,
   );
 }
 
@@ -213,7 +202,9 @@ export function resolveClaudeCodeStartupProfile(
 ): StartupProfile {
   if (requested) return requested;
 
-  if (toolSurface === "browse_cli") {
+  // browse_cli and stagehand_code own their browser (the Stagehand SDK launches or
+  // creates it via the extension stack), so no runner-provided CDP endpoint.
+  if (toolSurface === "browse_cli" || toolSurface === "stagehand_code") {
     return environment === "BROWSERBASE" ? "tool_create_browserbase" : "tool_launch_local";
   }
   if (toolSurface === "playwright_code" || toolSurface === "cdp_code") {
@@ -283,7 +274,7 @@ export async function prepareBrowseCliHarnessAdapter(
   const missingArtifact = BROWSE_CLI_BUILD_ARTIFACTS.find((artifact) => !fs.existsSync(artifact));
   if (missingArtifact) {
     throw new EvalsError(
-      `browse_cli dependency is incomplete; missing ${missingArtifact}. Reinstall workspace dependencies.`,
+      `browse_cli requires built CLI artifacts; missing ${missingArtifact}. Run pnpm --dir packages/cli build first.`,
     );
   }
 
@@ -349,77 +340,66 @@ export async function prepareBrowseCliHarnessAdapter(
   };
 }
 
-async function preparePlaywrightCodeAdapter(
+/**
+ * Starts a CoreTool once and mounts the returned agent binding. The harness
+ * switches only on the binding modality, never on the tool surface identity.
+ */
+async function prepareMountedCoreToolAdapter(
   input: ClaudeCodeToolAdapterInput & {
-    toolSurface: "playwright_code";
+    toolSurface: ToolSurface;
     startupProfile: StartupProfile;
   },
 ): Promise<PreparedClaudeCodeToolAdapter> {
-  if (
-    input.startupProfile !== "runner_provided_local_cdp" &&
-    input.startupProfile !== "runner_provided_browserbase_cdp"
-  ) {
-    throw new EvalsError(
-      `playwright_code startup profile "${input.startupProfile}" is not valid for Claude Code. Use runner_provided_local_cdp or runner_provided_browserbase_cdp.`,
-    );
-  }
-
-  const cwd = await fsp.mkdtemp(path.join(os.tmpdir(), "stagehand-evals-claude-playwright-"));
-  const env = { ...process.env } as Record<string, string>;
-  let browser: Browser | undefined;
-  let targetCleanup: () => Promise<void> = async () => {};
-
+  const runtime = await startAgentToolRuntime(input);
   try {
-    const target = await prepareCoreBrowserTarget({
-      environment: input.environment,
-      toolSurface: "playwright_code",
-      startupProfile: input.startupProfile,
-    });
-    targetCleanup = target.cleanup;
-    if (!target.providedEndpoint?.url) {
+    return await prepareAgentMountAdapter(runtime.running, runtime.cleanup, input);
+  } catch (error) {
+    await runtime.cleanup().catch((): undefined => undefined);
+    throw error;
+  }
+}
+
+/**
+ * The generic mount point for handle bindings: wraps the binding's handles in
+ * the harness's MCP "run" tool, whose executor runs
+ * snippet code in an AsyncFunction scope over the handle names plus
+ * startUrl, task, and console. Surface specifics (handles, prompt
+ * instructions, run-tool copy, snippet task/console bindings, cleanup) all
+ * come from the mount — this function owns only harness mechanics.
+ */
+async function prepareAgentMountAdapter(
+  running: Awaited<ReturnType<typeof startAgentToolRuntime>>["running"],
+  cleanupRuntime: () => Promise<void>,
+  input: ClaudeCodeToolAdapterInput & {
+    toolSurface: ToolSurface;
+    startupProfile: StartupProfile;
+  },
+): Promise<PreparedClaudeCodeToolAdapter> {
+  let cwd: string | undefined;
+  try {
+    const mount = running.agentMount;
+    if (!mount) {
+      throw new EvalsError(`Tool surface "${input.toolSurface}" does not provide an agent mount.`);
+    }
+    if (mount.via !== "handles") {
       throw new EvalsError(
-        `playwright_code requires a runner-provided CDP endpoint for startup profile "${input.startupProfile}".`,
+        `Claude Code does not support agent mounts delivered via "${mount.via}" yet.`,
       );
     }
 
-    const { chromium } = await import("playwright");
-    browser = await chromium.connectOverCDP(target.providedEndpoint.url, {
-      headers: target.providedEndpoint.headers,
-    });
-    const context = browser.contexts()[0] ?? (await browser.newContext());
-    const page = context.pages()[0] ?? (await context.newPage());
-    const mcpServers = await buildPlaywrightRunMcpServers({
-      browser,
-      context,
-      page,
+    cwd = await fsp.mkdtemp(path.join(os.tmpdir(), `stagehand-evals-claude-${input.toolSurface}-`));
+    const cleanupCwd = cwd;
+    const env = { ...process.env } as Record<string, string>;
+    const mcpServers = await buildCodeExposureRunMcpServers({
+      handles: mount.handles,
+      runToolSpec: mount.runTool,
       plan: input.plan,
       logger: input.logger,
     });
-
-    input.logger.log({
-      category: "claude_code",
-      message: `Initialized playwright_code browser runtime for Claude Code run tool.`,
-      level: 1,
-      auxiliary: {
-        startupProfile: {
-          value: input.startupProfile,
-          type: "string",
-        },
-        environment: {
-          value: input.environment,
-          type: "string",
-        },
-        ...(target.metadata && {
-          targetMetadata: {
-            value: JSON.stringify(target.metadata),
-            type: "object",
-          },
-        }),
-      },
-    });
+    let cleanupPromise: Promise<void> | undefined;
 
     return {
-      toolSurface: "playwright_code",
+      toolSurface: input.toolSurface,
       startupProfile: input.startupProfile,
       cwd,
       env,
@@ -432,150 +412,49 @@ async function preparePlaywrightCodeAdapter(
         }
         return {
           behavior: "deny",
-          message: `Use Bash for inspection and ${RUN_TOOL_NAME} for browser automation.`,
+          message: mount.runTool.denyMessage,
         };
       },
-      promptInstructions: buildPlaywrightCodePromptInstructions(input.plan),
+      promptInstructions: mount.promptInstructions,
+      ...(running.captureEvidence && {
+        captureEvidence: async (): Promise<ProbeEvidence> => {
+          try {
+            return await withTimeout(
+              running.captureEvidence!(),
+              readPositiveIntEnv("EVAL_CAPTURE_EVIDENCE_TIMEOUT_MS", 15_000),
+            );
+          } catch {
+            return {};
+          }
+        },
+      }),
       cleanup: async () => {
-        try {
-          await browser?.close();
-        } catch {
-          // best-effort only
-        } finally {
-          await targetCleanup();
-          await fsp.rm(cwd, { recursive: true, force: true });
-        }
+        cleanupPromise ??= (async () => {
+          try {
+            await withTimeout(
+              cleanupRuntime(),
+              readPositiveIntEnv("EVAL_AGENT_MOUNT_CLEANUP_TIMEOUT_MS", 30_000),
+            );
+          } catch {
+            // Cleanup is best-effort, but temp-dir cleanup must run.
+          } finally {
+            await fsp.rm(cleanupCwd, { recursive: true, force: true });
+          }
+        })();
+        await cleanupPromise;
       },
     };
   } catch (error) {
-    try {
-      await browser?.close();
-    } catch {
-      // best-effort only
+    if (cwd) {
+      await fsp.rm(cwd, { recursive: true, force: true });
     }
-    await targetCleanup();
-    await fsp.rm(cwd, { recursive: true, force: true });
     throw error;
   }
 }
 
-async function prepareCdpCodeAdapter(
-  input: ClaudeCodeToolAdapterInput & {
-    toolSurface: "cdp_code";
-    startupProfile: StartupProfile;
-  },
-): Promise<PreparedClaudeCodeToolAdapter> {
-  if (
-    input.startupProfile !== "runner_provided_local_cdp" &&
-    input.startupProfile !== "runner_provided_browserbase_cdp"
-  ) {
-    throw new EvalsError(
-      `cdp_code startup profile "${input.startupProfile}" is not valid for Claude Code. Use runner_provided_local_cdp or runner_provided_browserbase_cdp.`,
-    );
-  }
-
-  const cwd = await fsp.mkdtemp(path.join(os.tmpdir(), "stagehand-evals-claude-cdp-"));
-  const env = { ...process.env } as Record<string, string>;
-  let connection: CdpConnection | undefined;
-  let targetCleanup: () => Promise<void> = async () => {};
-
-  try {
-    const target = await prepareCoreBrowserTarget({
-      environment: input.environment,
-      toolSurface: "cdp_code",
-      startupProfile: input.startupProfile,
-    });
-    targetCleanup = target.cleanup;
-    if (!target.providedEndpoint?.url) {
-      throw new EvalsError(
-        `cdp_code requires a runner-provided CDP endpoint for startup profile "${input.startupProfile}".`,
-      );
-    }
-
-    connection = await CdpConnection.connect(target.providedEndpoint);
-    const activePage = await attachActiveCdpPage(connection);
-    const mcpServers = await buildCdpRunMcpServers({
-      connection,
-      activePage,
-      plan: input.plan,
-      logger: input.logger,
-    });
-
-    input.logger.log({
-      category: "claude_code",
-      message: `Initialized cdp_code browser runtime for Claude Code run tool.`,
-      level: 1,
-      auxiliary: {
-        startupProfile: {
-          value: input.startupProfile,
-          type: "string",
-        },
-        environment: {
-          value: input.environment,
-          type: "string",
-        },
-        targetId: {
-          value: activePage.targetId,
-          type: "string",
-        },
-        sessionId: {
-          value: activePage.sessionId,
-          type: "string",
-        },
-        ...(target.metadata && {
-          targetMetadata: {
-            value: JSON.stringify(target.metadata),
-            type: "object",
-          },
-        }),
-      },
-    });
-
-    return {
-      toolSurface: "cdp_code",
-      startupProfile: input.startupProfile,
-      cwd,
-      env,
-      allowedTools: ["Bash", RUN_TOOL_NAME],
-      settingSources: [],
-      mcpServers,
-      canUseTool: async (toolName, commandInput) => {
-        if (toolName === RUN_TOOL_NAME || toolName === "Bash") {
-          return { behavior: "allow", updatedInput: commandInput };
-        }
-        return {
-          behavior: "deny",
-          message: `Use Bash for inspection and ${RUN_TOOL_NAME} for CDP browser automation.`,
-        };
-      },
-      promptInstructions: buildCdpCodePromptInstructions(input.plan),
-      cleanup: async () => {
-        try {
-          await connection?.close();
-        } catch {
-          // best-effort only
-        } finally {
-          await targetCleanup();
-          await fsp.rm(cwd, { recursive: true, force: true });
-        }
-      },
-    };
-  } catch (error) {
-    try {
-      await connection?.close();
-    } catch {
-      // best-effort only
-    }
-    await targetCleanup();
-    await fsp.rm(cwd, { recursive: true, force: true });
-    throw error;
-  }
-}
-
-async function buildPlaywrightRunMcpServers(input: {
-  browser: Browser;
-  context: BrowserContext;
-  page: Page;
+async function buildCodeExposureRunMcpServers(input: {
+  handles: Record<string, unknown>;
+  runToolSpec: AgentRunToolSpec;
   plan: ExternalHarnessTaskPlan;
   logger: EvalLogger;
 }): Promise<Record<string, unknown>> {
@@ -586,24 +465,15 @@ async function buildPlaywrightRunMcpServers(input: {
 
   const runTool = sdk.tool(
     "run",
-    [
-      "Execute JavaScript against the initialized Playwright browser.",
-      "The snippet runs inside an async function with page, context, browser, startUrl, task, and console in scope.",
-      "Use await directly. Return a JSON-serializable value when useful.",
-    ].join(" "),
+    input.runToolSpec.description,
     {
-      code: z
-        .string()
-        .describe(
-          "JavaScript function body to execute. page/context/browser/startUrl/task are already in scope.",
-        ),
+      code: z.string().describe(input.runToolSpec.codeParamDescription),
     },
     async ({ code }) => {
-      return executePlaywrightRunTool({
+      return executeCodeExposureRunTool({
         code,
-        browser: input.browser,
-        context: input.context,
-        page: input.page,
+        handles: input.handles,
+        runToolSpec: input.runToolSpec,
         plan: input.plan,
         logger: input.logger,
       });
@@ -621,17 +491,16 @@ async function buildPlaywrightRunMcpServers(input: {
   };
 }
 
-async function executePlaywrightRunTool(input: {
+async function executeCodeExposureRunTool(input: {
   code: string;
-  browser: Browser;
-  context: BrowserContext;
-  page: Page;
+  handles: Record<string, unknown>;
+  runToolSpec: AgentRunToolSpec;
   plan: ExternalHarnessTaskPlan;
   logger: EvalLogger;
 }): Promise<ClaudeToolResult> {
   try {
     const result = await withTimeout(
-      executePlaywrightSnippet(input),
+      executeCodeExposureSnippet(input),
       readPositiveIntEnv("EVAL_CLAUDE_CODE_RUN_TOOL_TIMEOUT_MS", 60_000),
     );
     const text = stringifyToolResult(result);
@@ -657,30 +526,28 @@ async function executePlaywrightRunTool(input: {
   }
 }
 
-async function executePlaywrightSnippet(input: {
+async function executeCodeExposureSnippet(input: {
   code: string;
-  browser: Browser;
-  context: BrowserContext;
-  page: Page;
+  handles: Record<string, unknown>;
+  runToolSpec: AgentRunToolSpec;
   plan: ExternalHarnessTaskPlan;
   logger: EvalLogger;
 }): Promise<unknown> {
   const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor as new (
     ...args: string[]
   ) => (...values: unknown[]) => Promise<unknown>;
+  // Snippet scope = the exposure's handle names plus startUrl/task/console.
+  // Object.keys/Object.values over the same object are guaranteed to align,
+  // so names — not positions — bind the values.
   const fn = new AsyncFunction(
-    "page",
-    "context",
-    "browser",
+    ...Object.keys(input.handles),
     "startUrl",
     "task",
     "console",
     input.code,
   );
   return fn(
-    input.page,
-    input.context,
-    input.browser,
+    ...Object.values(input.handles),
     input.plan.startUrl,
     {
       dataset: input.plan.dataset,
@@ -690,284 +557,6 @@ async function executePlaywrightSnippet(input: {
     },
     buildRunToolConsole(input.logger),
   );
-}
-
-async function buildCdpRunMcpServers(input: {
-  connection: CdpConnection;
-  activePage: ActiveCdpPage;
-  plan: ExternalHarnessTaskPlan;
-  logger: EvalLogger;
-}): Promise<Record<string, unknown>> {
-  const sdk = (await import("@anthropic-ai/claude-agent-sdk")) as unknown as {
-    createSdkMcpServer: SdkMcpServerFactory;
-    tool: SdkToolFactory;
-  };
-
-  const runTool = sdk.tool(
-    "run",
-    [
-      "Execute JavaScript against the initialized Chrome DevTools Protocol browser.",
-      "The snippet runs inside an async function with cdp, startUrl, task, and console in scope.",
-      "Use await directly. Return a JSON-serializable value when useful.",
-    ].join(" "),
-    {
-      code: z
-        .string()
-        .describe("JavaScript function body to execute. cdp/startUrl/task are already in scope."),
-    },
-    async ({ code }) => {
-      return executeCdpRunTool({
-        code,
-        connection: input.connection,
-        activePage: input.activePage,
-        plan: input.plan,
-        logger: input.logger,
-      });
-    },
-    { alwaysLoad: true },
-  );
-
-  return {
-    [RUN_TOOL_SERVER]: sdk.createSdkMcpServer({
-      name: RUN_TOOL_SERVER,
-      version: "1.0.0",
-      tools: [runTool],
-      alwaysLoad: true,
-    }),
-  };
-}
-
-async function executeCdpRunTool(input: {
-  code: string;
-  connection: CdpConnection;
-  activePage: ActiveCdpPage;
-  plan: ExternalHarnessTaskPlan;
-  logger: EvalLogger;
-}): Promise<ClaudeToolResult> {
-  try {
-    const result = await withTimeout(
-      executeCdpSnippet(input),
-      readPositiveIntEnv("EVAL_CLAUDE_CODE_RUN_TOOL_TIMEOUT_MS", 60_000),
-    );
-    const text = stringifyToolResult(result);
-    input.logger.log({
-      category: "claude_code",
-      message: `run tool completed: ${clip(text, 500)}`,
-      level: 1,
-    });
-    return {
-      content: [{ type: "text", text }],
-    };
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    input.logger.warn({
-      category: "claude_code",
-      message: `run tool failed: ${message}`,
-      level: 1,
-    });
-    return {
-      isError: true,
-      content: [{ type: "text", text: message }],
-    };
-  }
-}
-
-async function executeCdpSnippet(input: {
-  code: string;
-  connection: CdpConnection;
-  activePage: ActiveCdpPage;
-  plan: ExternalHarnessTaskPlan;
-  logger: EvalLogger;
-}): Promise<unknown> {
-  const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor as new (
-    ...args: string[]
-  ) => (...values: unknown[]) => Promise<unknown>;
-  const fn = new AsyncFunction("cdp", "startUrl", "task", "console", input.code);
-  return fn(
-    buildCdpRuntime(input.connection, input.activePage, input.logger),
-    input.plan.startUrl,
-    {
-      dataset: input.plan.dataset,
-      id: input.plan.taskId,
-      startUrl: input.plan.startUrl,
-      instruction: input.plan.instruction,
-    },
-    buildRunToolConsole(input.logger),
-  );
-}
-
-function buildCdpRuntime(
-  connection: CdpConnection,
-  activePage: ActiveCdpPage,
-  logger: EvalLogger,
-): CdpRuntime {
-  const listenerUnsubscribes = new Map<
-    (event: CdpEventMessage) => unknown | Promise<unknown>,
-    () => void
-  >();
-  return {
-    targetId: activePage.targetId,
-    sessionId: activePage.sessionId,
-    send: <T = unknown>(method: string, params?: Record<string, unknown>): Promise<T> =>
-      connection.send<T>(method, params, activePage.sessionId),
-    browser: <T = unknown>(method: string, params?: Record<string, unknown>): Promise<T> =>
-      connection.send<T>(method, params),
-    on: (
-      method: string,
-      listener: (event: CdpEventMessage) => unknown | Promise<unknown>,
-    ): (() => void) => {
-      const unsubscribe = onCdpEvent(connection, activePage.sessionId, method, listener, logger);
-      listenerUnsubscribes.set(listener, unsubscribe);
-      return () => {
-        listenerUnsubscribes.delete(listener);
-        unsubscribe();
-      };
-    },
-    off: (
-      _method: string,
-      listener: (event: CdpEventMessage) => unknown | Promise<unknown>,
-    ): void => {
-      const unsubscribe = listenerUnsubscribes.get(listener);
-      listenerUnsubscribes.delete(listener);
-      unsubscribe?.();
-    },
-    once: (
-      method: string,
-      listenerOrTimeout?: ((event: CdpEventMessage) => unknown | Promise<unknown>) | number,
-      timeoutMs = 15_000,
-    ): Promise<CdpEventMessage> | (() => void) => {
-      if (typeof listenerOrTimeout === "function") {
-        const listener = listenerOrTimeout;
-        const unsubscribe = onCdpEvent(
-          connection,
-          activePage.sessionId,
-          method,
-          (event) => {
-            unsubscribe?.();
-            listenerUnsubscribes.delete(listener);
-            return listener(event);
-          },
-          logger,
-        );
-        listenerUnsubscribes.set(listener, unsubscribe);
-        return () => {
-          listenerUnsubscribes.delete(listener);
-          unsubscribe?.();
-        };
-      }
-      return waitForCdpEvent(
-        connection,
-        activePage.sessionId,
-        method,
-        listenerOrTimeout ?? timeoutMs,
-      );
-    },
-    waitForEvent: (method: string, timeoutMs = 15_000): Promise<CdpEventMessage> =>
-      waitForCdpEvent(connection, activePage.sessionId, method, timeoutMs),
-    wait: sleep,
-  };
-}
-
-function onCdpEvent(
-  connection: CdpConnection,
-  sessionId: string,
-  method: string,
-  listener: (event: CdpEventMessage) => unknown | Promise<unknown>,
-  logger: EvalLogger,
-): () => void {
-  return connection.onEvent((event) => {
-    if (event.method !== method || (event.sessionId && event.sessionId !== sessionId)) {
-      return;
-    }
-    try {
-      const result = listener(event);
-      if (isPromiseLike(result)) {
-        result.catch((error: unknown) => {
-          logger.warn({
-            category: "claude_code",
-            message: `cdp event listener failed: ${error instanceof Error ? error.message : String(error)}`,
-            level: 1,
-          });
-        });
-      }
-    } catch (error) {
-      logger.warn({
-        category: "claude_code",
-        message: `cdp event listener failed: ${error instanceof Error ? error.message : String(error)}`,
-        level: 1,
-      });
-    }
-  });
-}
-
-async function attachActiveCdpPage(connection: CdpConnection): Promise<ActiveCdpPage> {
-  const targets = await connection.send<{
-    targetInfos: Array<{
-      targetId: string;
-      type: string;
-      url?: string;
-    }>;
-  }>("Target.getTargets");
-
-  const existingPage = targets.targetInfos.find(
-    (target) => target.type === "page" && !target.url?.startsWith("devtools://"),
-  );
-  const targetId =
-    existingPage?.targetId ??
-    (
-      await connection.send<{ targetId: string }>("Target.createTarget", {
-        url: "about:blank",
-      })
-    ).targetId;
-  const attached = await connection.send<{ sessionId: string }>("Target.attachToTarget", {
-    targetId,
-    flatten: true,
-  });
-
-  await connection.send("Page.enable", {}, attached.sessionId);
-  await connection.send("Runtime.enable", {}, attached.sessionId);
-  await connection.send("DOM.enable", {}, attached.sessionId);
-  await connection.send("Page.setLifecycleEventsEnabled", { enabled: true }, attached.sessionId);
-
-  return {
-    targetId,
-    sessionId: attached.sessionId,
-    url: existingPage?.url ?? "about:blank",
-  };
-}
-
-export function waitForCdpEvent(
-  connection: CdpConnection,
-  sessionId: string,
-  method: string,
-  timeoutMs: number,
-): Promise<CdpEventMessage> {
-  let timeout: NodeJS.Timeout | undefined;
-  let unsubscribe: (() => void) | undefined;
-  const promise = new Promise<CdpEventMessage>((resolve, reject) => {
-    const cleanup = () => {
-      if (timeout) clearTimeout(timeout);
-      unsubscribe?.();
-    };
-    unsubscribe = connection.onEvent((event) => {
-      if (event.method !== method || (event.sessionId && event.sessionId !== sessionId)) {
-        return;
-      }
-      cleanup();
-      resolve(event);
-    });
-    timeout = setTimeout(() => {
-      cleanup();
-      reject(new Error(`Timed out waiting for CDP event "${method}"`));
-    }, timeoutMs);
-  });
-
-  // Claude-generated snippets often assign an event wait promise before a CDP
-  // action and may abandon it after another branch finishes. Keep the promise
-  // rejectable for awaited callers, but prevent abandoned waits from crashing
-  // the eval process as unhandled rejections.
-  promise.catch((): undefined => undefined);
-  return promise;
 }
 
 function buildRunToolConsole(logger: EvalLogger): Pick<Console, "log" | "warn" | "error"> {
@@ -983,32 +572,6 @@ function buildRunToolConsole(logger: EvalLogger): Pick<Console, "log" | "warn" |
     warn: (...values: unknown[]) => write("warn", values),
     error: (...values: unknown[]) => write("error", values),
   };
-}
-
-function buildPlaywrightCodePromptInstructions(plan: ExternalHarnessTaskPlan): string {
-  void plan;
-  return [
-    "Browser tool surface: playwright_code.",
-    `Use the ${RUN_TOOL_NAME} tool for browser automation. It exposes an initialized Playwright page, context, browser, startUrl, and task object.`,
-    "Use Bash for inspection and lightweight scripting. Do not create a separate browser process.",
-    "The first browser action should usually be: await page.goto(startUrl, { waitUntil: 'domcontentloaded' }).",
-    "Do not edit repository files.",
-    "Return useful JSON-serializable values from run snippets so you can inspect progress.",
-  ].join("\n");
-}
-
-function buildCdpCodePromptInstructions(plan: ExternalHarnessTaskPlan): string {
-  void plan;
-  return [
-    "Browser tool surface: cdp_code.",
-    `Use the ${RUN_TOOL_NAME} tool for browser automation. It exposes an initialized cdp object, startUrl, and task object.`,
-    "Use cdp.send(method, params) for page-scoped CDP commands and cdp.browser(method, params) for browser-level commands.",
-    "Helpers available: cdp.on(method, listener), cdp.once(method), cdp.waitForEvent(method, timeoutMs), cdp.wait(ms), cdp.targetId, cdp.sessionId.",
-    'The first browser action should usually be: const loaded = cdp.waitForEvent("Page.loadEventFired"); await cdp.send("Page.navigate", { url: startUrl }); await loaded.',
-    "Use Bash for inspection and lightweight scripting. Do not create a separate browser process.",
-    "Do not edit repository files.",
-    "Return useful JSON-serializable values from run snippets so you can inspect progress.",
-  ].join("\n");
 }
 
 function buildBrowseCliPromptInstructions(plan: ExternalHarnessTaskPlan): string {
@@ -1097,10 +660,6 @@ function readPositiveIntEnv(key: string, fallback: number): number {
   return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
   let timeout: NodeJS.Timeout | undefined;
   try {
@@ -1130,19 +689,6 @@ function stringifyToolResult(value: unknown): string {
 
 function clip(value: string, maxLength: number): string {
   return value.length <= maxLength ? value : `${value.slice(0, maxLength - 1)}…`;
-}
-
-function isPromiseLike(value: unknown): value is PromiseLike<unknown> & {
-  catch: (handler: (error: unknown) => void) => unknown;
-} {
-  return (
-    value !== null &&
-    typeof value === "object" &&
-    "then" in value &&
-    typeof (value as { then?: unknown }).then === "function" &&
-    "catch" in value &&
-    typeof (value as { catch?: unknown }).catch === "function"
-  );
 }
 
 function createBrowseSessionName(): string {

--- a/packages/evals/tests/framework/claudeCodeToolAdapter.test.ts
+++ b/packages/evals/tests/framework/claudeCodeToolAdapter.test.ts
@@ -51,8 +51,16 @@ describe("claude code tool adapter resolution", () => {
 
   it("rejects unsupported Claude Code tool surfaces for now", () => {
     expect(() => resolveClaudeCodeToolSurface("understudy_code")).toThrow(
-      /supports --tool browse_cli, playwright_code, or cdp_code/,
+      /supports --tool browse_cli, playwright_code, cdp_code, or stagehand_code/,
     );
+  });
+
+  it("accepts stagehand_code with SDK-owned startup profiles", () => {
+    expect(resolveClaudeCodeToolSurface("stagehand_code")).toBe("stagehand_code");
+    expect(resolveClaudeCodeStartupProfile("stagehand_code", "BROWSERBASE")).toBe(
+      "tool_create_browserbase",
+    );
+    expect(resolveClaudeCodeStartupProfile("stagehand_code", "LOCAL")).toBe("tool_launch_local");
   });
 
   it("supports browse_cli as the first Codex tool surface", () => {


### PR DESCRIPTION
Replaces the per-surface logic inside the adapter with one generic
mount consumer: any surface declaring an agent mount gets its handles
mounted as the single local-MCP run tool, with the surface's own prompt
instructions. Net deletion — the bespoke playwright_code/cdp_code blocks
move behind the contract, and adding a surface no longer means editing
the adapter.

Part of the nondeterministic-evals stack (#2591 → #2611). Requires the
three mount declarations below it.

Verified across the stack: tsc and oxlint per part, evals vitest, live
core runs on Browserbase for --tool stagehand_code, playwright_code, and
cdp_code (3/3 each, prompt exit), one long-horizon row (webvoyager x
claude_code x stagehand_code, 3/3), and the paired webvoyager acceptance
run (stagehand_code 2/3 vs playwright_code 3/3, both cells traced to
Braintrust).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consume LLM exposure mounts generically in the `claude_code` adapter so all code surfaces expose their handles as a single MCP run tool. This aligns with STG-2671 and adds optional evidence capture while removing surface-specific logic.

- **New Features**
  - Generic agent mount consumption across `playwright_code`, `cdp_code`, and `stagehand_code`; prompt text, run-tool copy/deny messages, and `task`/`console` bindings come from the mount.
  - Optional `captureEvidence()` for grading (timeout `EVAL_CAPTURE_EVIDENCE_TIMEOUT_MS`); standardized identifiers via `AGENT_RUN_TOOL_NAME` and `AGENT_RUN_TOOL_SERVER`.

- **Refactors**
  - One mount consumer replaces bespoke surface code; snippets run with handle names plus `startUrl`/`task`/`console`. Re-exports `waitForCdpEvent`.
  - Shared tool/target lifecycle via `startAgentToolRuntime` with idempotent cleanup (timeout `EVAL_AGENT_MOUNT_CLEANUP_TIMEOUT_MS`); startup profiles: `browse_cli`/`stagehand_code` own the browser, `playwright_code`/`cdp_code` expect runner-provided CDP. Improved `browse_cli` build-artifacts error.

<sup>Written for commit 5a1a4ea19ef2fb46526fc44ba6b49df00c4ea792. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

