### PR TITLE
Update go examples with typed actions

### DIFF
--- a/packages/docs/v4/basics/act.mdx
+++ b/packages/docs/v4/basics/act.mdx
@@ -19,7 +19,7 @@ await stagehand.act("click on add to cart")
 
 <View title="Go" icon="golang">
 ```go
-if _, err := client.Act(ctx, "click on add to cart", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("click on add to cart"), nil); err != nil {
 	return err
 }
 ```
@@ -70,7 +70,7 @@ await stagehand.act("click the add to cart button")
 if _, err := page.Goto(ctx, "https://example-store.com", nil); err != nil {
 	return err
 }
-if _, err := client.Act(ctx, "click the add to cart button", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("click the add to cart button"), nil); err != nil {
 	return err
 }
 ```
@@ -226,13 +226,13 @@ await stagehand.act("click the apply button")
 <View title="Go" icon="golang">
 ```go
 // Break it into single-step actions
-if _, err := client.Act(ctx, "open the filters panel", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("open the filters panel"), nil); err != nil {
 	return err
 }
-if _, err := client.Act(ctx, "choose 4-star rating", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("choose 4-star rating"), nil); err != nil {
 	return err
 }
-if _, err := client.Act(ctx, "click the apply button", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("click the apply button"), nil); err != nil {
 	return err
 }
 ```
@@ -259,7 +259,7 @@ await stagehand.act("open the filters panel, choose 4-star rating, and click app
 <View title="Go" icon="golang">
 ```go
 // Too complex - trying to do multiple things at once
-if _, err := client.Act(ctx, "open the filters panel, choose 4-star rating, and click apply", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("open the filters panel, choose 4-star rating, and click apply"), nil); err != nil {
 	return err
 }
 ```
@@ -312,7 +312,7 @@ model := stagehand.ModelConfig{
 }
 timeout := 10000.0
 
-if _, err := client.Act(ctx, "choose 'Peach' from the favorite color dropdown", &stagehand.StagehandClientActOptions{
+if _, err := client.Act(ctx, stagehand.ActInstruction("choose 'Peach' from the favorite color dropdown"), &stagehand.StagehandClientActOptions{
 	ActOptions: stagehand.ActOptions{
 		Model:   &model,
 		Timeout: &timeout,
@@ -399,7 +399,7 @@ client, err := stagehand.Create(ctx, stagehand.CreateOptions{
 
 // Or disable it for a single call
 off := stagehand.CacheEnabled(false)
-if _, err := client.Act(ctx, "click the login button", &stagehand.StagehandClientActOptions{
+if _, err := client.Act(ctx, stagehand.ActInstruction("click the login button"), &stagehand.StagehandClientActOptions{
 	ActOptions: stagehand.ActOptions{Cache: &off},
 }); err != nil {
 	return err
@@ -407,14 +407,14 @@ if _, err := client.Act(ctx, "click the login button", &stagehand.StagehandClien
 
 // Or lower the hit-count threshold for a single call
 eager := stagehand.CacheWithThreshold(1)
-if _, err := client.Act(ctx, "click the login button", &stagehand.StagehandClientActOptions{
+if _, err := client.Act(ctx, stagehand.ActInstruction("click the login button"), &stagehand.StagehandClientActOptions{
 	ActOptions: stagehand.ActOptions{Cache: &eager},
 }); err != nil {
 	return err
 }
 
 // Check whether a result was served from cache
-result, err := client.Act(ctx, "click the login button", nil)
+result, err := client.Act(ctx, stagehand.ActInstruction("click the login button"), nil)
 if err != nil {
 	return err
 }
@@ -491,7 +491,7 @@ if _, err := blogPage.Goto(ctx, "https://www.example.com/blog", nil); err != nil
 }
 
 // Use Act with that specific page
-_, err = client.Act(ctx, "click the next page button", &stagehand.StagehandClientActOptions{
+_, err = client.Act(ctx, stagehand.ActInstruction("click the next page button"), &stagehand.StagehandClientActOptions{
 	Page: blogPage,
 })
 ```
@@ -548,7 +548,7 @@ if err != nil {
 
 if len(observed.Data) > 0 && observed.Data[0].Method != nil && *observed.Data[0].Method == "click" {
 	// No inference: Stagehand replays the observed action
-	if _, err := client.Act(ctx, observed.Data[0], nil); err != nil {
+	if _, err := client.Act(ctx, stagehand.ObservedAction(observed.Data[0]), nil); err != nil {
 		return err
 	}
 }
@@ -624,12 +624,12 @@ if err != nil {
 }
 
 // First run makes an LLM call and records the action
-if _, err := client.Act(ctx, "click the login button", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("click the login button"), nil); err != nil {
 	return err
 }
 
 // Second run is served from the cache
-if _, err := client.Act(ctx, "click the login button", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("click the login button"), nil); err != nil {
 	return err
 }
 ```
@@ -686,7 +686,7 @@ await stagehand.act("click the login button")
 <View title="Go" icon="golang">
 ```go
 // Variables use %variableName% syntax in the instruction
-if _, err := client.Act(ctx, "type %username% into the email field", &stagehand.StagehandClientActOptions{
+if _, err := client.Act(ctx, stagehand.ActInstruction("type %username% into the email field"), &stagehand.StagehandClientActOptions{
 	ActOptions: stagehand.ActOptions{
 		Variables: stagehand.Variables{
 			"username": stagehand.PrimitiveVariable(stagehand.StringVariable("user@example.com")),
@@ -697,7 +697,7 @@ if _, err := client.Act(ctx, "type %username% into the email field", &stagehand.
 }
 
 userPassword := os.Getenv("USER_PASSWORD")
-if _, err := client.Act(ctx, "type %password% into the password field", &stagehand.StagehandClientActOptions{
+if _, err := client.Act(ctx, stagehand.ActInstruction("type %password% into the password field"), &stagehand.StagehandClientActOptions{
 	ActOptions: stagehand.ActOptions{
 		Variables: stagehand.Variables{
 			"password": stagehand.PrimitiveVariable(stagehand.StringVariable(userPassword)),
@@ -707,7 +707,7 @@ if _, err := client.Act(ctx, "type %password% into the password field", &stageha
 	return err
 }
 
-if _, err := client.Act(ctx, "click the login button", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("click the login button"), nil); err != nil {
 	return err
 }
 ```
@@ -791,7 +791,7 @@ except Exception as error:
 prompt := "click the submit button"
 expectedMethod := "click"
 
-if _, err := client.Act(ctx, prompt, nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction(prompt), nil); err != nil {
 	if !strings.Contains(err.Error(), "method not supported") {
 		return err
 	}
@@ -809,7 +809,7 @@ if _, err := client.Act(ctx, prompt, nil); err != nil {
 	if action.Method == nil || *action.Method != expectedMethod {
 		return fmt.Errorf("unsupported method: expected %q, got %v", expectedMethod, action.Method)
 	}
-	if _, err := client.Act(ctx, action, nil); err != nil {
+	if _, err := client.Act(ctx, stagehand.ObservedAction(action), nil); err != nil {
 		return err
 	}
 }
@@ -875,7 +875,7 @@ const maxRetries = 3
 
 for attempt := 0; attempt <= maxRetries; attempt++ {
 	timeout := float64(10000 + attempt*5000)
-	_, err := client.Act(ctx, prompt, &stagehand.StagehandClientActOptions{
+	_, err := client.Act(ctx, stagehand.ActInstruction(prompt), &stagehand.StagehandClientActOptions{
 		ActOptions: stagehand.ActOptions{Timeout: &timeout},
 	})
 	if err == nil {
@@ -956,7 +956,7 @@ except Exception:
 ```go
 // Handle timeout and element not found issues
 timeout := 30000.0
-if _, err := client.Act(ctx, "click the submit button", &stagehand.StagehandClientActOptions{
+if _, err := client.Act(ctx, stagehand.ActInstruction("click the submit button"), &stagehand.StagehandClientActOptions{
 	ActOptions: stagehand.ActOptions{Timeout: &timeout},
 }); err != nil {
 	// Check if page is fully loaded
@@ -973,10 +973,10 @@ if _, err := client.Act(ctx, "click the submit button", &stagehand.StagehandClie
 
 	if len(observed.Data) > 0 {
 		fmt.Println("Element found, trying more specific instruction")
-		_, err = client.Act(ctx, "click the submit button at the bottom of the form", nil)
+		_, err = client.Act(ctx, stagehand.ActInstruction("click the submit button at the bottom of the form"), nil)
 	} else {
 		fmt.Println("Element not found, trying alternative selector")
-		_, err = client.Act(ctx, "click the button with text 'Submit'", nil)
+		_, err = client.Act(ctx, stagehand.ActInstruction("click the button with text 'Submit'"), nil)
 	}
 	if err != nil {
 		return err
@@ -1035,10 +1035,10 @@ if observed.data and "checkout" in observed.data[0].description:
 ```go
 // More precise element targeting
 // Instead of:
-_, err := client.Act(ctx, "click the button", nil)
+_, err := client.Act(ctx, stagehand.ActInstruction("click the button"), nil)
 
 // Use specific context:
-_, err = client.Act(ctx, "click the red 'Delete' button next to the user John Smith", nil)
+_, err = client.Act(ctx, stagehand.ActInstruction("click the red 'Delete' button next to the user John Smith"), nil)
 
 // Or preview with Observe first:
 instruction := "click the submit button in the checkout form"
@@ -1047,7 +1047,7 @@ if err != nil {
 	return err
 }
 if len(observed.Data) > 0 && strings.Contains(observed.Data[0].Description, "checkout") {
-	if _, err := client.Act(ctx, observed.Data[0], nil); err != nil {
+	if _, err := client.Act(ctx, stagehand.ObservedAction(observed.Data[0]), nil); err != nil {
 		return err
 	}
 }

--- a/packages/docs/v4/basics/extract.mdx
+++ b/packages/docs/v4/basics/extract.mdx
@@ -928,7 +928,7 @@ if err != nil {
 	return err
 }
 
-fmt.Println("the link to the contact us page is: ", extracted.ContactLink)
+fmt.Println("the link to the contact us page is: ", extracted.Data.ContactLink)
 ```
 </View>
 
@@ -1047,7 +1047,7 @@ if err != nil {
 	return err
 }
 
-fmt.Println("extracted", len(extracted.Products), "products")
+fmt.Println("extracted", len(extracted.Data.Products), "products")
 ```
 </View>
 </Accordion>
@@ -1210,7 +1210,7 @@ if err != nil {
 	return err
 }
 
-for _, item := range extracted.Products {
+for _, item := range extracted.Data.Products {
 	fmt.Println(item.Name, item.Price)
 }
 ```
@@ -1308,7 +1308,7 @@ var allData []product
 timeout := 60000.0 // 60 second timeout
 
 for pageNum := 1; pageNum <= 5; pageNum++ {
-	if _, err := client.Act(ctx, fmt.Sprintf("navigate to page %d", pageNum), nil); err != nil {
+	if _, err := client.Act(ctx, stagehand.ActInstruction(fmt.Sprintf("navigate to page %d", pageNum)), nil); err != nil {
 		return err
 	}
 
@@ -1325,7 +1325,7 @@ for pageNum := 1; pageNum <= 5; pageNum++ {
 		return err
 	}
 
-	allData = append(allData, extracted.Products...)
+	allData = append(allData, extracted.Data.Products...)
 }
 ```
 </View>

--- a/packages/docs/v4/basics/observe.mdx
+++ b/packages/docs/v4/basics/observe.mdx
@@ -445,7 +445,7 @@ for i, action := range result.Data {
 
 if emailField != nil && passwordField != nil {
 	// Replay the observed actions, resolving placeholders locally
-	if _, err := client.Act(ctx, *emailField, &stagehand.StagehandClientActOptions{
+	if _, err := client.Act(ctx, stagehand.ObservedAction(*emailField), &stagehand.StagehandClientActOptions{
 		ActOptions: stagehand.ActOptions{
 			Variables: stagehand.Variables{
 				"username": stagehand.PrimitiveVariable(stagehand.StringVariable("user@example.com")),
@@ -454,7 +454,7 @@ if emailField != nil && passwordField != nil {
 	}); err != nil {
 		return err
 	}
-	if _, err := client.Act(ctx, *passwordField, &stagehand.StagehandClientActOptions{
+	if _, err := client.Act(ctx, stagehand.ObservedAction(*passwordField), &stagehand.StagehandClientActOptions{
 		ActOptions: stagehand.ActOptions{
 			Variables: stagehand.Variables{
 				"password": stagehand.PrimitiveVariable(stagehand.StringVariable(password)),
@@ -675,7 +675,7 @@ if err != nil {
 
 for _, field := range observed.Data {
 	// No LLM call: Stagehand replays the observed action
-	if _, err := client.Act(ctx, field, nil); err != nil {
+	if _, err := client.Act(ctx, stagehand.ObservedAction(field), nil); err != nil {
 		return err
 	}
 }
@@ -794,7 +794,7 @@ if err != nil {
 	return err
 }
 
-for _, tier := range pricing.Tiers {
+for _, tier := range pricing.Data.Tiers {
 	fmt.Println(tier.Name, tier.Price)
 }
 ```
@@ -845,7 +845,7 @@ if len(observed.Data) == 0 || observed.Data[0].Method == nil || *observed.Data[0
 	return errors.New("Delete button not found")
 }
 
-if _, err := client.Act(ctx, observed.Data[0], nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ObservedAction(observed.Data[0]), nil); err != nil {
 	return err
 }
 ```
@@ -1101,7 +1101,7 @@ if action != nil && action.Method != nil {
 // Validate method before acting
 validMethods := []string{"click", "fill", "type", "press"}
 if action != nil && slices.Contains(validMethods, method) {
-	if _, err := client.Act(ctx, *action, nil); err != nil {
+	if _, err := client.Act(ctx, stagehand.ObservedAction(*action), nil); err != nil {
 		return err
 	}
 } else {

--- a/packages/docs/v4/basics/webmcp.mdx
+++ b/packages/docs/v4/basics/webmcp.mdx
@@ -391,7 +391,7 @@ if addToCart != nil {
 	}
 } else {
 	// The page publishes no tool for this, so drive the UI
-	if _, err := client.Act(ctx, "add the item to the cart", nil); err != nil {
+	if _, err := client.Act(ctx, stagehand.ActInstruction("add the item to the cart"), nil); err != nil {
 		return err
 	}
 }

--- a/packages/docs/v4/best-practices/caching.mdx
+++ b/packages/docs/v4/best-practices/caching.mdx
@@ -99,7 +99,7 @@ if _, err := page.Goto(ctx, "https://example.com", nil); err != nil {
 }
 
 // Cached after the hit-count threshold is met
-if _, err := client.Act(ctx, "click the login button", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("click the login button"), nil); err != nil {
 	return err
 }
 ```
@@ -177,14 +177,14 @@ if err != nil {
 
 // This call skips the cache
 off := stagehand.CacheEnabled(false)
-if _, err := client.Act(ctx, "click the login button", &stagehand.StagehandClientActOptions{
+if _, err := client.Act(ctx, stagehand.ActInstruction("click the login button"), &stagehand.StagehandClientActOptions{
 	ActOptions: stagehand.ActOptions{Cache: &off},
 }); err != nil {
 	return err
 }
 
 // This call uses the cache as normal
-if _, err := client.Act(ctx, "submit the form", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("submit the form"), nil); err != nil {
 	return err
 }
 ```
@@ -312,7 +312,7 @@ print(result.metadata.cache.status)  # "HIT", "MISS", or "DISABLED"
 
 <View title="Go" icon="golang">
 ```go
-result, err := client.Act(ctx, "click the login button", nil)
+result, err := client.Act(ctx, stagehand.ActInstruction("click the login button"), nil)
 if err != nil {
 	return err
 }
@@ -456,7 +456,7 @@ func example(ctx context.Context, client *stagehand.Stagehand, page *stagehand.P
 
 	// The model only ever sees %email%, and the logged action keeps the placeholder
 	// A different email value travels with the request, so expect a MISS
-	_, err := client.Act(ctx, "type %email% into the Email address field", &stagehand.StagehandClientActOptions{
+	_, err := client.Act(ctx, stagehand.ActInstruction("type %email% into the Email address field"), &stagehand.StagehandClientActOptions{
 		ActOptions: stagehand.ActOptions{
 			Variables: stagehand.Variables{
 				"email": stagehand.PrimitiveVariable(stagehand.StringVariable("alice@example.com")),
@@ -563,12 +563,12 @@ await stagehand.act(f"type {email} into the Email address field")
 <View title="Go" icon="golang">
 ```go
 // Good: anchored to the visible label, no variance
-if _, err := client.Act(ctx, "click the Sign in button", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("click the Sign in button"), nil); err != nil {
 	return err
 }
 
 // Bad: inline dynamic value creates a new cache key every time
-if _, err := client.Act(ctx, fmt.Sprintf("type %s into the Email address field", email), nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction(fmt.Sprintf("type %s into the Email address field", email)), nil); err != nil {
 	return err
 }
 ```

--- a/packages/docs/v4/best-practices/cost-optimization.mdx
+++ b/packages/docs/v4/best-practices/cost-optimization.mdx
@@ -182,7 +182,7 @@ if err != nil {
 
 // First run: uses LLM inference and records the action
 // Subsequent runs: reuses the cached action (no LLM cost)
-if _, err := client.Act(ctx, "Click the sign in button", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("Click the sign in button"), nil); err != nil {
 	return err
 }
 ```
@@ -350,7 +350,7 @@ func smartAct(ctx context.Context, client *stagehand.Stagehand, prompt string) (
 		}
 
 		// The page is touched once, by the first model that produced a plan
-		return client.Act(ctx, plan.Data[0], &stagehand.StagehandClientActOptions{
+		return client.Act(ctx, stagehand.ObservedAction(plan.Data[0]), &stagehand.StagehandClientActOptions{
 			ActOptions: stagehand.ActOptions{Model: &models[i]},
 		})
 	}

--- a/packages/docs/v4/best-practices/deployments.mdx
+++ b/packages/docs/v4/best-practices/deployments.mdx
@@ -310,7 +310,7 @@ func run(ctx context.Context) (result string, err error) {
 	if _, err := page.Goto(ctx, "https://www.stagehand.dev/", nil); err != nil {
 		return "", err
 	}
-	if _, err := client.Act(ctx, "click the evals button", nil); err != nil {
+	if _, err := client.Act(ctx, stagehand.ActInstruction("click the evals button"), nil); err != nil {
 		return "", err
 	}
 
@@ -325,7 +325,7 @@ func run(ctx context.Context) (result string, err error) {
 		return "", err
 	}
 
-	return extracted.FastestModel, nil
+	return extracted.Data.FastestModel, nil
 }
 
 func main() {

--- a/packages/docs/v4/best-practices/mcp-integrations.mdx
+++ b/packages/docs/v4/best-practices/mcp-integrations.mdx
@@ -113,7 +113,7 @@ if err != nil {
 	return err
 }
 
-for _, t := range extracted.Pricing {
+for _, t := range extracted.Data.Pricing {
 	fmt.Println(t.Tier, t.Price)
 }
 ```

--- a/packages/docs/v4/best-practices/prompting-best-practices.mdx
+++ b/packages/docs/v4/best-practices/prompting-best-practices.mdx
@@ -36,18 +36,18 @@ await stagehand.act("login with credentials and navigate to dashboard")
 <View title="Go" icon="golang">
 ```go
 // Good - Single, specific actions
-if _, err := client.Act(ctx, "click the 'Add to Cart' button", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("click the 'Add to Cart' button"), nil); err != nil {
 	return err
 }
-if _, err := client.Act(ctx, "type 'user@example.com' into the email field", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("type 'user@example.com' into the email field"), nil); err != nil {
 	return err
 }
 
 // Bad - Multiple actions combined
-if _, err := client.Act(ctx, "fill out the form and submit it", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("fill out the form and submit it"), nil); err != nil {
 	return err
 }
-if _, err := client.Act(ctx, "login with credentials and navigate to dashboard", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("login with credentials and navigate to dashboard"), nil); err != nil {
 	return err
 }
 ```
@@ -84,18 +84,18 @@ await stagehand.act("type into the white input")
 <View title="Go" icon="golang">
 ```go
 // Good - Element types and descriptive text
-if _, err := client.Act(ctx, "click the 'Sign In' button", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("click the 'Sign In' button"), nil); err != nil {
 	return err
 }
-if _, err := client.Act(ctx, "type into the email input field", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("type into the email input field"), nil); err != nil {
 	return err
 }
 
 // Bad - Color-based descriptions
-if _, err := client.Act(ctx, "click the blue button", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("click the blue button"), nil); err != nil {
 	return err
 }
-if _, err := client.Act(ctx, "type into the white input", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("type into the white input"), nil); err != nil {
 	return err
 }
 ```
@@ -130,18 +130,18 @@ await stagehand.act("type into search")
 <View title="Go" icon="golang">
 ```go
 // Good - Clear element identification
-if _, err := client.Act(ctx, "click the 'Next' button at the bottom of the form", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("click the 'Next' button at the bottom of the form"), nil); err != nil {
 	return err
 }
-if _, err := client.Act(ctx, "type into the search bar at the top of the page", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("type into the search bar at the top of the page"), nil); err != nil {
 	return err
 }
 
 // Bad - Vague descriptions
-if _, err := client.Act(ctx, "click next", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("click next"), nil); err != nil {
 	return err
 }
-if _, err := client.Act(ctx, "type into search", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("type into search"), nil); err != nil {
 	return err
 }
 ```
@@ -182,18 +182,18 @@ await stagehand.act("choose option 1")
 <View title="Go" icon="golang">
 ```go
 // Good
-if _, err := client.Act(ctx, "click the submit button", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("click the submit button"), nil); err != nil {
 	return err
 }
-if _, err := client.Act(ctx, "select 'Option 1' from dropdown", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("select 'Option 1' from dropdown"), nil); err != nil {
 	return err
 }
 
 // Bad
-if _, err := client.Act(ctx, "click submit", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("click submit"), nil); err != nil {
 	return err
 }
-if _, err := client.Act(ctx, "choose option 1", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("choose option 1"), nil); err != nil {
 	return err
 }
 ```
@@ -240,7 +240,7 @@ await stagehand.act(
 <View title="Go" icon="golang">
 ```go
 // Use variables for sensitive data
-if _, err := client.Act(ctx, "type %username% into the email field", &stagehand.StagehandClientActOptions{
+if _, err := client.Act(ctx, stagehand.ActInstruction("type %username% into the email field"), &stagehand.StagehandClientActOptions{
 	ActOptions: stagehand.ActOptions{
 		Variables: stagehand.Variables{
 			"username": stagehand.PrimitiveVariable(stagehand.StringVariable("user@example.com")),
@@ -253,7 +253,7 @@ if _, err := client.Act(ctx, "type %username% into the email field", &stagehand.
 // v4 reads no environment variables, so read the secret yourself
 password := os.Getenv("USER_PASSWORD")
 
-if _, err := client.Act(ctx, "type %password% into the password field", &stagehand.StagehandClientActOptions{
+if _, err := client.Act(ctx, stagehand.ActInstruction("type %password% into the password field"), &stagehand.StagehandClientActOptions{
 	ActOptions: stagehand.ActOptions{
 		Variables: stagehand.Variables{
 			"password": stagehand.PrimitiveVariable(stagehand.StringVariable(password)),
@@ -461,7 +461,7 @@ if err != nil {
 	return err
 }
 
-for _, l := range extracted.Links {
+for _, l := range extracted.Data.Links {
 	fmt.Println(l.Text, l.URL)
 }
 ```
@@ -611,12 +611,12 @@ await stagehand.act("go to Amazon and search for headphones")
 if _, err := page.Goto(ctx, "https://amazon.com", nil); err != nil {
 	return err
 }
-if _, err := client.Act(ctx, "type 'wireless headphones' into the search box", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("type 'wireless headphones' into the search box"), nil); err != nil {
 	return err
 }
 
 // Bad - Navigation inside the instruction
-if _, err := client.Act(ctx, "go to Amazon and search for headphones", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("go to Amazon and search for headphones"), nil); err != nil {
 	return err
 }
 ```
@@ -677,13 +677,13 @@ await stagehand.act(
 <View title="Go" icon="golang">
 ```go
 // Good - Explicit, ordered steps
-if _, err := client.Act(ctx, "type 'wireless headphones' into the search box", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("type 'wireless headphones' into the search box"), nil); err != nil {
 	return err
 }
-if _, err := client.Act(ctx, "press Enter in the search box", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("press Enter in the search box"), nil); err != nil {
 	return err
 }
-if _, err := client.Act(ctx, "click the 4 stars and up filter", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("click the 4 stars and up filter"), nil); err != nil {
 	return err
 }
 
@@ -727,12 +727,12 @@ if err != nil {
 	return err
 }
 
-for _, p := range extracted.Products {
+for _, p := range extracted.Data.Products {
 	fmt.Println(p.Name, p.Price)
 }
 
 // Bad - One instruction carrying a whole workflow
-if _, err := client.Act(ctx, "search for wireless headphones under $100 and add the best rated one to cart", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("search for wireless headphones under $100 and add the best rated one to cart"), nil); err != nil {
 	return err
 }
 ```
@@ -787,7 +787,7 @@ await stagehand.act("add some items to cart")
 <View title="Go" icon="golang">
 ```go
 // Good - Verify the outcome
-if _, err := client.Act(ctx, "click the add to cart button", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("click the add to cart button"), nil); err != nil {
 	return err
 }
 
@@ -813,12 +813,12 @@ if err != nil {
 	return err
 }
 
-if result.ItemCount != 1 {
-	return fmt.Errorf("expected 1 item in cart, found %d", result.ItemCount)
+if result.Data.ItemCount != 1 {
+	return fmt.Errorf("expected 1 item in cart, found %d", result.Data.ItemCount)
 }
 
 // Bad - No validation
-if _, err := client.Act(ctx, "add some items to cart", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("add some items to cart"), nil); err != nil {
 	return err
 }
 ```

--- a/packages/docs/v4/best-practices/speed-optimization.mdx
+++ b/packages/docs/v4/best-practices/speed-optimization.mdx
@@ -48,9 +48,9 @@ for field in form_fields:
 <View title="Go" icon="golang">
 ```go
 // Instead of sequential operations with multiple LLM calls
-_, err := client.Act(ctx, "Fill name field", nil)          // LLM call #1
-_, err = client.Act(ctx, "Fill email field", nil)          // LLM call #2
-_, err = client.Act(ctx, "Select country dropdown", nil)    // LLM call #3
+_, err := client.Act(ctx, stagehand.ActInstruction("Fill name field"), nil)          // LLM call #1
+_, err = client.Act(ctx, stagehand.ActInstruction("Fill email field"), nil)          // LLM call #2
+_, err = client.Act(ctx, stagehand.ActInstruction("Select country dropdown"), nil)    // LLM call #3
 
 // Use a single Observe to plan all form fields: one LLM call
 instruction := "Find all form fields to fill"
@@ -61,7 +61,7 @@ if err != nil {
 
 // Replay each observed action: no further LLM inference
 for _, field := range observed.Data {
-	if _, err := client.Act(ctx, field, nil); err != nil {
+	if _, err := client.Act(ctx, stagehand.ObservedAction(field), nil); err != nil {
 		return err
 	}
 }
@@ -148,7 +148,7 @@ if _, err := page.Evaluate(ctx, `
 }
 
 // Then perform Stagehand operations
-_, err := client.Act(ctx, "Click the submit button", nil)
+_, err := client.Act(ctx, stagehand.ActInstruction("Click the submit button"), nil)
 ```
 </View>
 
@@ -229,7 +229,7 @@ if err != nil {
 
 // Simple actions: reduce the action timeout
 timeout := 5000.0
-if _, err := client.Act(ctx, "Click the login button", &stagehand.StagehandClientActOptions{
+if _, err := client.Act(ctx, stagehand.ActInstruction("Click the login button"), &stagehand.StagehandClientActOptions{
 	ActOptions: stagehand.ActOptions{Timeout: &timeout},
 }); err != nil {
 	return err
@@ -332,7 +332,7 @@ func (t *performanceTracker) timedAct(
 	prompt string,
 ) (stagehand.ActResult, error) {
 	start := time.Now()
-	result, err := client.Act(ctx, prompt, nil)
+	result, err := client.Act(ctx, stagehand.ActInstruction(prompt), nil)
 	duration := time.Since(start)
 
 	t.mu.Lock()
@@ -421,13 +421,13 @@ print(f"workflow-optimized: {(perf_counter() - start) * 1000:.0f}ms")  # 500ms
 ```go
 // Before optimization
 start := time.Now()
-if _, err := client.Act(ctx, "Fill form", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("Fill form"), nil); err != nil {
 	return err
 }
-if _, err := client.Act(ctx, "Click submit", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("Click submit"), nil); err != nil {
 	return err
 }
-if _, err := client.Act(ctx, "Confirm submission", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("Confirm submission"), nil); err != nil {
 	return err
 }
 fmt.Printf("workflow: %dms\n", time.Since(start).Milliseconds()) // 8000ms
@@ -442,7 +442,7 @@ if err != nil {
 
 // Replay actions sequentially to avoid conflicts
 for _, action := range observed.Data {
-	if _, err := client.Act(ctx, action, nil); err != nil {
+	if _, err := client.Act(ctx, stagehand.ObservedAction(action), nil); err != nil {
 		return err
 	}
 }

--- a/packages/docs/v4/best-practices/using-multiple-tabs.mdx
+++ b/packages/docs/v4/best-practices/using-multiple-tabs.mdx
@@ -58,7 +58,7 @@ if page == nil {
 if _, err := page.Goto(ctx, "https://example.com", nil); err != nil {
 	return err
 }
-if _, err := client.Act(ctx, "click the button that opens a new tab", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("click the button that opens a new tab"), nil); err != nil {
 	return err
 }
 
@@ -79,7 +79,7 @@ if err != nil {
 	return err
 }
 
-fmt.Println(extracted.Value)
+fmt.Println(extracted.Data.Value)
 ```
 </View>
 

--- a/packages/docs/v4/configuration/models.mdx
+++ b/packages/docs/v4/configuration/models.mdx
@@ -1423,7 +1423,7 @@ if err != nil {
 }
 
 // Uses the instance model
-if _, err := client.Act(ctx, "click the login button", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("click the login button"), nil); err != nil {
 	return err
 }
 
@@ -1447,7 +1447,7 @@ if err != nil {
 	return err
 }
 
-fmt.Println(extracted.Summary)
+fmt.Println(extracted.Data.Summary)
 ```
 </View>
 

--- a/packages/docs/v4/configuration/observability.mdx
+++ b/packages/docs/v4/configuration/observability.mdx
@@ -429,7 +429,7 @@ page := pages[0]
 if _, err := page.Goto(ctx, "https://example.com", nil); err != nil {
 	return err
 }
-if _, err := client.Act(ctx, "click button", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("click button"), nil); err != nil {
 	return err
 }
 if _, err := stagehand.ExtractAs[data](ctx, client, "get data", dataSchema, nil); err != nil {
@@ -779,14 +779,14 @@ page := pages[0]
 if _, err := page.Goto(ctx, "https://example.com", nil); err != nil {
 	return err
 }
-if _, err := client.Act(ctx, "click the login button", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("click the login button"), nil); err != nil {
 	return err
 }
 extracted, err := stagehand.ExtractAs[user](ctx, client, "extract user info", userSchema, nil)
 if err != nil {
 	return err
 }
-fmt.Printf("Extracted %s <%s>\n", extracted.Name, extracted.Email)
+fmt.Printf("Extracted %s <%s>\n", extracted.Data.Name, extracted.Data.Email)
 
 finalMetrics, err := client.Metrics(ctx)
 if err != nil {

--- a/packages/docs/v4/first-steps/ai-rules.mdx
+++ b/packages/docs/v4/first-steps/ai-rules.mdx
@@ -126,7 +126,7 @@ const context = browser.context;
 const page2 = await browser.context.newPage();
 ```
 
-For Browserbase cloud browsers, pass a Browserbase API key at the top level:
+For Browserbase cloud browsers, pass the Browserbase API key to `browserbase.launch()`:
 
 ```typescript
 const browser = await browserbase.launch({
@@ -332,7 +332,7 @@ await stagehand.extract("get title", z.object({ title: z.string() }), { page: pa
 
 ### Caching
 
-Server-side caching requires a Browserbase browser source and a Browserbase API key:
+Server-side caching requires a Browserbase browser and a Browserbase API key:
 
 ```typescript
 const browser = await browserbase.launch({
@@ -413,7 +413,7 @@ All Stagehand methods are async. `act`, `observe`, and `extract` take `instructi
 ```python
 import os
 
-from stagehand import Stagehand, browserbase, local_browser
+from stagehand import Stagehand, local_browser
 
 browser = await local_browser.launch(headless=True)
 stagehand = await Stagehand.create(
@@ -503,15 +503,12 @@ Every primitive returns a result with `data` and `metadata`. Your extracted mode
 ```python
 from pydantic import BaseModel
 
-
 class Listing(BaseModel):
     price: str
     address: str
 
-
 class Listings(BaseModel):
     listings: list[Listing]
-
 
 result = await stagehand.extract(
     "extract all apartment listings with prices and addresses",
@@ -529,7 +526,6 @@ A schema is always required, so wrap single values in a model:
 class ButtonText(BaseModel):
     button_text: str
 
-
 result = await stagehand.extract(
     "extract the sign in button text",
     ButtonText,
@@ -546,7 +542,6 @@ Scope extraction to a specific element with `selector`, and prune noise with `ig
 class Reason(BaseModel):
     reason: str
 
-
 result = await stagehand.extract(
     "extract the reason why script injection fails",
     Reason,
@@ -562,10 +557,8 @@ When extracting links or URLs, type the field as a URL:
 ```python
 from pydantic import AnyUrl, BaseModel
 
-
 class Links(BaseModel):
     links: list[AnyUrl]
-
 
 result = await stagehand.extract(
     "extract all navigation links",
@@ -579,7 +572,6 @@ result = await stagehand.extract(
 class Placeholder(BaseModel):
     placeholder: str
 
-
 result = await stagehand.extract(
     "extract the placeholder text on the name field",
     Placeholder,
@@ -592,7 +584,6 @@ result = await stagehand.extract(
 ```python
 class Title(BaseModel):
     title: str
-
 
 result = await stagehand.extract(
     "extract the page title",
@@ -655,7 +646,7 @@ await stagehand.extract("get title", Title, page=page2)
 
 ### Caching
 
-Server-side caching requires a Browserbase browser source and a Browserbase API key:
+Server-side caching requires a Browserbase browser and a Browserbase API key:
 
 ```python
 browser = await browserbase.launch(
@@ -743,10 +734,14 @@ if err != nil {
 	return err
 }
 defer func() { err = errors.Join(err, browser.Close(ctx)) }()
-client, err := stagehand.Create(ctx, stagehand.CreateOptions{Browser: browser, Model: &model})
+client, err := stagehand.Create(ctx, stagehand.CreateOptions{
+	Browser: browser,
+	Model:   &model,
+})
 if err != nil {
 	return err
 }
+
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 
 // Access the browser context and pages
@@ -764,16 +759,23 @@ if len(pages) == 0 {
 page := pages[0]
 
 // Create new pages if needed
-page2, err := browserContext.NewPage(ctx, stagehand.ContextNewPageParams{})
+page2, err := browserContext.NewPage(ctx, nil)
 if err != nil {
 	return err
 }
-if err := page2.Goto(ctx, "https://example.com", nil); err != nil {
+if _, err := page2.Goto(ctx, "https://example.com", nil); err != nil {
+	return err
+}
+
+// Target a specific page by passing it in the options
+if _, err := client.Act(ctx, stagehand.ActInstruction("click the sign in button"), &stagehand.StagehandClientActOptions{
+	Page: page,
+}); err != nil {
 	return err
 }
 ```
 
-For Browserbase cloud browsers, pass a Browserbase API key at the top level:
+For Browserbase cloud browsers, pass the Browserbase API key to `stagehand.LaunchBrowserbase()`:
 
 ```go
 browserbaseAPIKey := os.Getenv("BROWSERBASE_API_KEY")
@@ -783,10 +785,14 @@ browser, err := stagehand.LaunchBrowserbase(ctx, stagehand.BrowserbaseLaunchOpti
 if err != nil {
 	return err
 }
-client, err := stagehand.Create(ctx, stagehand.CreateOptions{Browser: browser, Model: &model})
+client, err := stagehand.Create(ctx, stagehand.CreateOptions{
+	Browser: browser,
+	Model:   &model,
+})
 if err != nil {
 	return err
 }
+defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
 
 Stagehand never reads environment variables for you. Always pass keys explicitly.
@@ -797,12 +803,12 @@ Actions are called on the client (not the page). Use atomic, specific instructio
 
 ```go
 // Act on the current active page
-if _, err := client.Act(ctx, "click the sign in button", nil); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("click the sign in button"), nil); err != nil {
 	return err
 }
 
 // Act on a specific page (when you need to target a page that isn't currently active)
-if _, err := client.Act(ctx, "click the sign in button", &stagehand.StagehandClientActOptions{
+if _, err := client.Act(ctx, stagehand.ActInstruction("click the sign in button"), &stagehand.StagehandClientActOptions{
 	Page: page2,
 }); err != nil {
 	return err
@@ -812,7 +818,7 @@ if _, err := client.Act(ctx, "click the sign in button", &stagehand.StagehandCli
 `Act` takes either a `string` instruction or a `stagehand.Action`. It returns an `ActResult`: the action payload is on `result.Data`, and cache status is on `result.Metadata`:
 
 ```go
-result, err := client.Act(ctx, "click the sign in button", nil)
+result, err := client.Act(ctx, stagehand.ActInstruction("click the sign in button"), nil)
 if err != nil {
 	return err
 }
@@ -831,7 +837,7 @@ Use variables for secrets. Values are substituted locally and never sent to the 
 
 ```go
 password := os.Getenv("USER_PASSWORD")
-if _, err := client.Act(ctx, "type %password% into the password field", &stagehand.StagehandClientActOptions{
+if _, err := client.Act(ctx, stagehand.ActInstruction("type %password% into the password field"), &stagehand.StagehandClientActOptions{
 	ActOptions: stagehand.ActOptions{
 		Variables: stagehand.Variables{
 			"password": stagehand.PrimitiveVariable(stagehand.StringVariable(password)),
@@ -854,7 +860,7 @@ if err != nil {
 }
 
 if len(observed.Data) > 0 && observed.Data[0].Method != nil && *observed.Data[0].Method == "click" {
-	if _, err := client.Act(ctx, observed.Data[0], nil); err != nil {
+	if _, err := client.Act(ctx, stagehand.ObservedAction(observed.Data[0]), nil); err != nil {
 		return err
 	}
 }
@@ -907,7 +913,7 @@ if err != nil {
 	return err
 }
 
-fmt.Println(data.Listings)
+fmt.Println(data.Data.Listings)
 ```
 
 ### Working With the Raw Result
@@ -1059,7 +1065,7 @@ if err != nil {
 	return err
 }
 if len(observed.Data) > 0 {
-	if _, err := client.Act(ctx, observed.Data[0], &stagehand.StagehandClientActOptions{Page: page2}); err != nil {
+	if _, err := client.Act(ctx, stagehand.ObservedAction(observed.Data[0]), &stagehand.StagehandClientActOptions{Page: page2}); err != nil {
 		return err
 	}
 }
@@ -1088,32 +1094,32 @@ fmt.Println("results:", count)
 ### Multi-Page Workflows
 
 ```go
-page1, err := browserContext.NewPage(ctx, stagehand.ContextNewPageParams{})
+page1, err := browserContext.NewPage(ctx, nil)
 if err != nil {
 	return err
 }
-if err := page1.Goto(ctx, "https://example.com", nil); err != nil {
+if _, err := page1.Goto(ctx, "https://example.com", nil); err != nil {
 	return err
 }
 
-page2, err := browserContext.NewPage(ctx, stagehand.ContextNewPageParams{})
+page2, err := browserContext.NewPage(ctx, nil)
 if err != nil {
 	return err
 }
-if err := page2.Goto(ctx, "https://example2.com", nil); err != nil {
+if _, err := page2.Goto(ctx, "https://example2.com", nil); err != nil {
 	return err
 }
 
 // Act/Extract/Observe operate on the current active page by default
 // Pass Page in the options struct to target a specific page
-if _, err := client.Act(ctx, "click button", &stagehand.StagehandClientActOptions{Page: page1}); err != nil {
+if _, err := client.Act(ctx, stagehand.ActInstruction("click button"), &stagehand.StagehandClientActOptions{Page: page1}); err != nil {
 	return err
 }
 ```
 
 ### Caching
 
-Server-side caching requires a Browserbase browser source and a Browserbase API key:
+Server-side caching requires a Browserbase browser and a Browserbase API key:
 
 ```go
 cache := stagehand.CacheEnabled(true) // or stagehand.CacheWithThreshold(1)
@@ -1130,6 +1136,7 @@ client, err := stagehand.Create(ctx, stagehand.CreateOptions{
 if err != nil {
 	return err
 }
+defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
 
 ## Cleanup

--- a/packages/docs/v4/first-steps/ai-rules.mdx
+++ b/packages/docs/v4/first-steps/ai-rules.mdx
@@ -413,7 +413,7 @@ All Stagehand methods are async. `act`, `observe`, and `extract` take `instructi
 ```python
 import os
 
-from stagehand import Stagehand, local_browser
+from stagehand import Stagehand, browserbase, local_browser
 
 browser = await local_browser.launch(headless=True)
 stagehand = await Stagehand.create(

--- a/packages/docs/v4/first-steps/installation.mdx
+++ b/packages/docs/v4/first-steps/installation.mdx
@@ -83,6 +83,8 @@ const stagehand = await Stagehand.create({ browser });
 ```python
 import os
 
+from stagehand import Stagehand, browserbase
+
 browser = await browserbase.launch(
     api_key=os.environ["BROWSERBASE_API_KEY"],
 )
@@ -157,10 +159,8 @@ import os
 from pydantic import BaseModel
 from stagehand import Stagehand, browserbase
 
-
 class Description(BaseModel):
     description: str
-
 
 async def main() -> None:
     browser = await browserbase.launch(
@@ -187,7 +187,6 @@ async def main() -> None:
             await stagehand.close()
     finally:
         await browser.close()
-
 
 asyncio.run(main())
 ```
@@ -234,10 +233,14 @@ func run(ctx context.Context) (err error) {
 	}
 	defer func() { err = errors.Join(err, browser.Close(ctx)) }()
 
-	client, err := stagehand.Create(ctx, stagehand.CreateOptions{Browser: browser})
+
+	client, err := stagehand.Create(ctx, stagehand.CreateOptions{
+		Browser: browser,
+	})
 	if err != nil {
 		return err
 	}
+
 	defer func() { err = errors.Join(err, client.Close(ctx)) }()
 
 	browserContext, err := browser.Context()
@@ -253,12 +256,12 @@ func run(ctx context.Context) (err error) {
 	}
 	page := pages[0]
 
-	if err := page.Goto(ctx, "https://example.com", nil); err != nil {
+	if _, err := page.Goto(ctx, "https://example.com", nil); err != nil {
 		return err
 	}
 
 	// Act on the page
-	if _, err := client.Act(ctx, "Click the learn more button", nil); err != nil {
+	if _, err := client.Act(ctx, stagehand.ActInstruction("Click the learn more button"), nil); err != nil {
 		return err
 	}
 
@@ -274,7 +277,7 @@ func run(ctx context.Context) (err error) {
 		return err
 	}
 
-	fmt.Println(extracted.Description)
+	fmt.Println(extracted.Data.Description)
 	return nil
 }
 ```

--- a/packages/docs/v4/first-steps/introduction.mdx
+++ b/packages/docs/v4/first-steps/introduction.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Introduction"
 description: "Developers use Stagehand to reliably automate the web."
 ---
 
-Stagehand is a browser automation framework used to control web browsers with natural language and code. By combining the power of AI with the precision of code, Stagehand makes web automation flexible, maintainable, and actually reliable.
+Stagehand is a browser automation framework used to control web browsers with natural language and code. By combining the power of AI with the precision of code, Stagehand makes web automation flexible, maintainable, and predictable.
 
 ## The problem with browser automation
 
@@ -71,7 +71,7 @@ actions = (await stagehand.observe("find submit buttons")).data
 // ctx, client, and the encoding/json import come from the quickstart
 
 // Act: execute natural language actions
-actResult, err := client.Act(ctx, "click the login button", nil)
+actResult, err := client.Act(ctx, stagehand.ActInstruction("click the login button"), nil)
 if err != nil {
 	return err
 }
@@ -91,7 +91,7 @@ extracted, err := stagehand.ExtractAs[price](ctx, client, "extract the price", p
 if err != nil {
 	return err
 }
-fmt.Println(extracted.Price)
+fmt.Println(extracted.Data.Price)
 
 // Observe: discover available actions
 instruction := "find submit buttons"
@@ -127,7 +127,7 @@ Stagehand is designed for developers building production browser automations and
 
 ## Get started in 60 seconds
 <Info>
-  **Pro tip**: For best results, Browserbase recommends using Stagehand with [Browserbase](https://www.browserbase.com) for reliable cloud browser infrastructure. It is the default browser source, and it unlocks [server-side caching](/v4/best-practices/caching) and the [Model Gateway](/v4/configuration/models#model-gateway).
+  **Pro tip**: For best results, Browserbase recommends using Stagehand with [Browserbase](https://www.browserbase.com) for reliable cloud browser infrastructure. It unlocks [server-side caching](/v4/best-practices/caching) and the [Model Gateway](/v4/configuration/models#model-gateway).
 </Info>
 <CardGroup cols={2}>
   <Card

--- a/packages/docs/v4/first-steps/quickstart.mdx
+++ b/packages/docs/v4/first-steps/quickstart.mdx
@@ -188,7 +188,7 @@ func run(ctx context.Context) (err error) {
 	}
 	page := pages[0]
 
-	if err := page.Goto(ctx, "https://stagehand.dev", nil); err != nil {
+	if _, err := page.Goto(ctx, "https://stagehand.dev", nil); err != nil {
 		return err
 	}
 
@@ -204,7 +204,7 @@ func run(ctx context.Context) (err error) {
 	}
 	fmt.Printf("Extract result:\n%+v\n", extracted)
 
-	if _, err := client.Act(ctx, "Click the 'Evals' button.", nil); err != nil {
+	if _, err := client.Act(ctx, stagehand.ActInstruction("Click the 'Evals' button."), nil); err != nil {
 		return err
 	}
 
@@ -217,11 +217,12 @@ func run(ctx context.Context) (err error) {
 
 	return nil
 }
+	defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
 </View>
 
 <Note>
-Stagehand never reads environment variables on your behalf. Read the Browserbase API key in your own code and pass it to the constructor, as the script above does. With no model configured, Browserbase selects one automatically for each inference call.
+Stagehand never reads environment variables on your behalf. Read the Browserbase API key in your own code and pass it to the browser factory, as the script above does. With no model configured, Browserbase selects one automatically for each inference call.
 </Note>
 
 ## 3) Run it
@@ -250,7 +251,7 @@ go run .                                 # Run the example script
 </View>
 
 <Tip>
-Prefer to run against a browser on your own machine while you develop? Swap the browser source for a local one and drop the Browserbase key. See [Browser configuration](/v4/configuration/browser).
+Prefer to run against a browser on your own machine while you develop? Swap `browserbase.launch()` for `localBrowser.launch()` and drop the Browserbase key. See [Browser configuration](/v4/configuration/browser).
 </Tip>
 
 ## Next steps

--- a/packages/docs/v4/first-steps/quickstart.mdx
+++ b/packages/docs/v4/first-steps/quickstart.mdx
@@ -217,7 +217,6 @@ func run(ctx context.Context) (err error) {
 
 	return nil
 }
-	defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
 </View>
 

--- a/packages/docs/v4/reference/stagehand.mdx
+++ b/packages/docs/v4/reference/stagehand.mdx
@@ -11,22 +11,25 @@ icon: "hand-horns"
 ## Quick start
 
 ```typescript
-import { Stagehand } from "@browserbasehq/stagehand";
+import { localBrowser, Stagehand } from "@browserbasehq/stagehand";
 
-const stagehand = new Stagehand({ browser: { type: "local" } });
-await stagehand.init();
+const stagehand = await Stagehand.create({ browser: await localBrowser.launch() });
 ```
 
-## init()
+## create()
 
-Initialize Stagehand and connect to the configured browser.
+Create a Stagehand instance and connect it to a browser. `Stagehand.create()` is the only way to build one; there is no public constructor, and the returned instance is already initialized.
 
 ```typescript
-await stagehand.init();
+const stagehand = await Stagehand.create({ browser: await localBrowser.launch() });
 ```
 
-<ResponseField name="result" type="Promise<void>">
-  Resolves after the operation completes.
+<ResponseField name="browser" type="StagehandBrowser" required>
+  A browser handle from `browserbase.launch()`, `browserbase.connect()`, `localBrowser.launch()`, or `localBrowser.connect()`. Each handle can back only one Stagehand instance.
+</ResponseField>
+
+<ResponseField name="result" type="Promise<Stagehand>">
+  An initialized Stagehand instance.
 </ResponseField>
 
 ## close()
@@ -654,22 +657,25 @@ console.log(product.data, product.metadata.cache.status);
 ## Quick start
 
 ```python
-from stagehand import Stagehand
+from stagehand import Stagehand, local_browser
 
-stagehand = Stagehand(browser="local")
-await stagehand.init()
+stagehand = await Stagehand.create(browser=await local_browser.launch())
 ```
 
-## init()
+## create()
 
-Initialize Stagehand and connect to the configured browser.
+Create a Stagehand instance and connect it to a browser. `Stagehand.create()` is the only way to build one; there is no public constructor, and the returned instance is already initialized.
 
 ```python
-await stagehand.init()
+stagehand = await Stagehand.create(browser=await local_browser.launch())
 ```
 
-<ResponseField name="result" type="None">
-  Resolves after the operation completes.
+<ResponseField name="browser" type="StagehandBrowser" required>
+  A browser handle from `browserbase.launch()`, `browserbase.connect()`, `local_browser.launch()`, or `local_browser.connect()`. Each handle can back only one Stagehand instance.
+</ResponseField>
+
+<ResponseField name="result" type="Stagehand">
+  An initialized Stagehand instance.
 </ResponseField>
 
 ## close()

--- a/packages/docs/v4/reference/stagehand.mdx
+++ b/packages/docs/v4/reference/stagehand.mdx
@@ -24,9 +24,9 @@ Create a Stagehand instance and connect it to a browser. `Stagehand.create()` is
 const stagehand = await Stagehand.create({ browser: await localBrowser.launch() });
 ```
 
-<ResponseField name="browser" type="StagehandBrowser" required>
+<ParamField path="browser" type="StagehandBrowser" required>
   A browser handle from `browserbase.launch()`, `browserbase.connect()`, `localBrowser.launch()`, or `localBrowser.connect()`. Each handle can back only one Stagehand instance.
-</ResponseField>
+</ParamField>
 
 <ResponseField name="result" type="Promise<Stagehand>">
   An initialized Stagehand instance.
@@ -670,9 +670,9 @@ Create a Stagehand instance and connect it to a browser. `Stagehand.create()` is
 stagehand = await Stagehand.create(browser=await local_browser.launch())
 ```
 
-<ResponseField name="browser" type="StagehandBrowser" required>
+<ParamField path="browser" type="StagehandBrowser" required>
   A browser handle from `browserbase.launch()`, `browserbase.connect()`, `local_browser.launch()`, or `local_browser.connect()`. Each handle can back only one Stagehand instance.
-</ResponseField>
+</ParamField>
 
 <ResponseField name="result" type="Stagehand">
   An initialized Stagehand instance.


### PR DESCRIPTION
# why

Resolving source code drift

# what changed

* Adding stagehand.ActInstruction
* Removing a stray .init()
* Other minor syntax updates

# test plan

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update v4 docs to use typed Go actions with `stagehand.ActInstruction`/`stagehand.ObservedAction`, standardize result access via `.Data`, and align API usage with the current SDK. Also fixes minor import issues and Go return handling.

- **Refactors**
  - Use `stagehand.ActInstruction(...)` in `client.Act(...)`.
  - Wrap observed actions with `stagehand.ObservedAction(...)`.
  - Read extraction fields from `extracted.Data.*`.
  - Replace `init()` patterns with `Stagehand.create(...)` in TS/Python; mirror in Go snippets.
  - Clarify Browserbase setup: pass API keys to `browserbase.launch()`/`LaunchBrowserbase(...)`.
  - Go updates: capture `_, err := page.Goto(...)`; use `browserContext.NewPage(ctx, nil)`; pass `Page` in `StagehandClientActOptions`.
  - Fixes: add missing Python imports and clean up leftover Go lines.

- **Migration**
  - Wrap instructions: `client.Act(ctx, stagehand.ActInstruction("..."), ...)`.
  - Replay observed actions: `client.Act(ctx, stagehand.ObservedAction(action), ...)`.
  - Access extracted values via `result.Data`.
  - Create clients with `Stagehand.create(...)`; do not call `init()`.
  - Provide Browserbase keys to browser launch/connect functions, not the client.

<sup>Written for commit b932bf2d0621ee3a546a46f58aabb61408017c3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

