### PR TITLE
evals: codex harness across all code tool surfaces

### DIFF
--- a/packages/evals/framework/codexCodeBridge.ts
+++ b/packages/evals/framework/codexCodeBridge.ts
@@ -1,0 +1,193 @@
+/**
+ * Code-execution bridge for the codex harness.
+ *
+ * codex-sdk has no in-process MCP server mounting (unlike claude-agent-sdk),
+ * and an external MCP process could not share this process's live surface
+ * handles (the Stagehand SDK client, playwright browser objects). So the
+ * codex mount for a handle binding is a loopback HTTP bridge:
+ * this process executes snippets against the in-memory handles; the codex
+ * workspace gets a tiny client script (`browser_run.mjs`) that posts a
+ * snippet file's contents to the bridge and prints the result.
+ *
+ * Scope semantics are identical to the claude_code run tool: the snippet
+ * runs inside an async function whose arguments are the mount's handle
+ * names plus startUrl, task, and console — names, not order, bind values.
+ */
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import type { AgentMount } from "../core/contracts/tool.js";
+import type { ExternalHarnessTaskPlan } from "./externalHarnessPlan.js";
+import type { EvalLogger } from "../logger.js";
+
+const DEFAULT_RUN_TIMEOUT_MS = 60_000;
+
+function readPositiveIntEnv(name: string, fallback: number): number {
+  const parsed = Number.parseInt(process.env[name] ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`run timed out after ${timeoutMs}ms`)),
+      timeoutMs,
+    );
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
+function stringifyResult(value: unknown): string {
+  if (typeof value === "undefined") return "undefined";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value, null, 2) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+/**
+ * Snippet errors can embed connection URLs whose query strings carry
+ * credentials (Browserbase connect URLs include signing keys). Redact
+ * credential-bearing fragments before the message crosses the HTTP boundary
+ * or reaches the logs; the rest stays intact so the agent can self-correct.
+ */
+export function sanitizeErrorMessage(message: string): string {
+  return message
+    .replace(/([?&](?:signingKey|apiKey|api_key|token|key)=)[^&\s"']+/gi, "$1[redacted]")
+    .replace(/\b(sk-[A-Za-z0-9_-]{6})[A-Za-z0-9_-]+/g, "$1[redacted]");
+}
+
+export interface CodeBridge {
+  port: number;
+  close: () => Promise<void>;
+}
+
+export async function startCodeBridge(input: {
+  mount: Extract<AgentMount, { via: "handles" }>;
+  plan: ExternalHarnessTaskPlan;
+  logger: EvalLogger;
+}): Promise<CodeBridge> {
+  const { mount, plan, logger } = input;
+  const handles = mount.handles;
+  const bridgeConsole = {
+    log: (...args: unknown[]) =>
+      logger.log({ category: "codex", level: 1, message: args.join(" ") }),
+    warn: (...args: unknown[]) =>
+      logger.warn({ category: "codex", level: 1, message: args.join(" ") }),
+    error: (...args: unknown[]) =>
+      logger.error({ category: "codex", level: 0, message: args.join(" ") }),
+  };
+
+  async function executeSnippet(code: string): Promise<unknown> {
+    const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor as new (
+      ...args: string[]
+    ) => (...values: unknown[]) => Promise<unknown>;
+    const fn = new AsyncFunction(...Object.keys(handles), "startUrl", "task", "console", code);
+    return fn(
+      ...Object.values(handles),
+      plan.startUrl,
+      {
+        dataset: plan.dataset,
+        id: plan.taskId,
+        instruction: plan.instruction,
+        startUrl: plan.startUrl,
+      },
+      bridgeConsole,
+    );
+  }
+
+  const server = http.createServer((req, res) => {
+    if (req.method !== "POST" || req.url !== "/run") {
+      res.writeHead(404).end();
+      return;
+    }
+    let body = "";
+    req.on("data", (chunk) => (body += chunk));
+    req.on("end", async () => {
+      let code: string;
+      try {
+        code = String((JSON.parse(body) as { code?: unknown }).code ?? "");
+      } catch {
+        res.writeHead(400).end(JSON.stringify({ ok: false, error: "invalid JSON body" }));
+        return;
+      }
+      try {
+        const result = await withTimeout(
+          executeSnippet(code),
+          readPositiveIntEnv("EVAL_CODEX_RUN_TOOL_TIMEOUT_MS", DEFAULT_RUN_TIMEOUT_MS),
+        );
+        const text = stringifyResult(result);
+        logger.log({
+          category: "codex",
+          level: 1,
+          message: `bridge run completed: ${text.slice(0, 500)}`,
+        });
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: true, result: text }));
+      } catch (error) {
+        const message = sanitizeErrorMessage(
+          error instanceof Error ? error.message : String(error),
+        );
+        logger.warn({
+          category: "codex",
+          level: 1,
+          message: `bridge run failed: ${message}`,
+        });
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: false, error: message }));
+      }
+    });
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const port = (server.address() as AddressInfo).port;
+
+  return {
+    port,
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve());
+        server.closeAllConnections?.();
+      }),
+  };
+}
+
+/**
+ * The workspace client codex invokes via shell. Kept dependency-free and
+ * tiny: read a snippet file (or stdin), post to the bridge, print the
+ * result text; non-zero exit on execution error so the agent notices.
+ */
+export function buildBridgeClientScript(port: number): string {
+  return `#!/usr/bin/env node
+// browser_run.mjs — execute a browser-automation snippet via the eval bridge.
+// Usage: node browser_run.mjs <snippet-file>   (or pipe the snippet on stdin)
+import { readFileSync } from "node:fs";
+
+const file = process.argv[2];
+const code = file ? readFileSync(file, "utf8") : readFileSync(0, "utf8");
+const res = await fetch("http://127.0.0.1:${port}/run", {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({ code }),
+});
+const payload = await res.json();
+if (payload.ok) {
+  console.log(payload.result);
+} else {
+  console.error("run failed: " + payload.error);
+  process.exit(1);
+}
+`;
+}

--- a/packages/evals/framework/codexRunner.ts
+++ b/packages/evals/framework/codexRunner.ts
@@ -212,6 +212,14 @@ export async function runCodexAgent({
     return baseResult;
   }
 
+  // Artifact-grounded grading: capture the terminal page state through the
+  // tool surface (harness-observed, independent of the agent's self-report)
+  // before cleanup, mirroring the claude_code runner.
+  const finalObservation =
+    toolAdapter && "captureEvidence" in toolAdapter
+      ? await toolAdapter.captureEvidence?.().catch((): undefined => undefined)
+      : undefined;
+
   // Build a Trajectory from the codex event stream and grade it with the
   // rubric verifier; any failure in that path folds into `verifierError`.
   return gradeExternalTrajectory({
@@ -219,6 +227,7 @@ export async function runCodexAgent({
       codexAdapter.fromHarnessResult(
         {
           events,
+          ...(finalObservation && { finalObservation }),
           finalAnswer: parsed.finalAnswer ?? finalResponse,
           status: status === "completed" ? "complete" : "error",
           usage: {

--- a/packages/evals/framework/codexToolAdapter.ts
+++ b/packages/evals/framework/codexToolAdapter.ts
@@ -1,7 +1,17 @@
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { EvalsError } from "../errors.js";
 import type { EvalLogger } from "../logger.js";
-import type { StartupProfile, ToolSurface } from "../core/contracts/tool.js";
+import {
+  AGENT_RUN_TOOL_NAME,
+  type StartupProfile,
+  type ToolSurface,
+} from "../core/contracts/tool.js";
+import type { ProbeEvidence } from "stagehand-v3";
+import { startAgentToolRuntime } from "./agentToolRuntime.js";
 import type { ExternalHarnessTaskPlan } from "./externalHarnessPlan.js";
+import { buildBridgeClientScript, startCodeBridge } from "./codexCodeBridge.js";
 import {
   prepareBrowseCliHarnessAdapter,
   type PreparedBrowseCliHarnessAdapter,
@@ -15,7 +25,21 @@ export interface CodexToolAdapterInput {
   logger: EvalLogger;
 }
 
-export type PreparedCodexToolAdapter = PreparedBrowseCliHarnessAdapter;
+/** Code-surface variant: same runner-facing fields as the browse_cli shape. */
+export interface PreparedCodexCodeAdapter {
+  toolSurface: ToolSurface;
+  startupProfile: StartupProfile;
+  cwd: string;
+  env: Record<string, string>;
+  promptInstructions: string;
+  /** Best-effort evidence from the currently running tool surface. */
+  captureEvidence?: () => Promise<ProbeEvidence>;
+  cleanup: () => Promise<void>;
+}
+
+export type PreparedCodexToolAdapter = PreparedBrowseCliHarnessAdapter | PreparedCodexCodeAdapter;
+
+const CODE_SURFACES = new Set<ToolSurface>(["stagehand_code", "playwright_code", "cdp_code"]);
 
 export async function prepareCodexToolAdapter(
   input: CodexToolAdapterInput,
@@ -27,20 +51,117 @@ export async function prepareCodexToolAdapter(
     input.startupProfile,
   );
 
-  return prepareBrowseCliHarnessAdapter({
+  if (toolSurface === "browse_cli") {
+    return prepareBrowseCliHarnessAdapter({
+      startupProfile,
+      environment: input.environment,
+      plan: input.plan,
+      logger: input.logger,
+      logCategory: "codex",
+    });
+  }
+
+  const runtime = await startAgentToolRuntime({
+    toolSurface,
     startupProfile,
     environment: input.environment,
-    plan: input.plan,
     logger: input.logger,
-    logCategory: "codex",
   });
+
+  let cwd: string | undefined;
+  let bridge: Awaited<ReturnType<typeof startCodeBridge>> | undefined;
+  try {
+    const mount = runtime.running.agentMount;
+    if (!mount) {
+      throw new EvalsError(`Tool surface "${toolSurface}" does not provide an agent mount.`);
+    }
+    if (mount.via !== "handles") {
+      throw new EvalsError(`Codex does not support agent mounts delivered via "${mount.via}" yet.`);
+    }
+    bridge = await startCodeBridge({
+      mount,
+      plan: input.plan,
+      logger: input.logger,
+    });
+    cwd = await fsp.mkdtemp(
+      path.join(os.tmpdir(), `stagehand-evals-codex-${toolSurface.replace(/_/g, "-")}-`),
+    );
+    await fsp.writeFile(path.join(cwd, "browser_run.mjs"), buildBridgeClientScript(bridge.port));
+
+    input.logger.log({
+      category: "codex",
+      message: `Initialized ${toolSurface} bridge runtime for Codex (port ${bridge.port}).`,
+      level: 1,
+      auxiliary: {
+        startupProfile: { value: startupProfile, type: "string" },
+        environment: { value: input.environment, type: "string" },
+      },
+    });
+
+    const capturedBridge = bridge;
+    const capturedCwd = cwd;
+    return {
+      toolSurface,
+      startupProfile,
+      cwd,
+      env: { ...process.env } as Record<string, string>,
+      promptInstructions: buildCodexCodePromptInstructions(mount, toolSurface),
+      ...(runtime.running.captureEvidence && {
+        captureEvidence: runtime.running.captureEvidence,
+      }),
+      cleanup: async () => {
+        try {
+          await capturedBridge.close();
+        } catch {
+          // best-effort only
+        }
+        try {
+          await runtime.cleanup();
+        } catch {
+          // best-effort only
+        }
+        await fsp.rm(capturedCwd, { recursive: true, force: true });
+      },
+    };
+  } catch (error) {
+    await bridge?.close().catch((): undefined => undefined);
+    await runtime.cleanup().catch((): undefined => undefined);
+    if (cwd) await fsp.rm(cwd, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+/**
+ * Codex has no MCP run tool — snippets go through the workspace bridge
+ * client. Reuse the surface's own API guidance, rewriting the claude-style
+ * run-tool reference to the codex invocation.
+ */
+function buildCodexCodePromptInstructions(
+  mount: { promptInstructions: string; handles: Record<string, unknown> },
+  toolSurface: ToolSurface,
+): string {
+  const scopeNames = [...Object.keys(mount.handles), "startUrl", "task", "console"].join(", ");
+  const surfaceGuidance = mount.promptInstructions.replaceAll(
+    AGENT_RUN_TOOL_NAME,
+    "browser_run.mjs",
+  );
+  return [
+    `Browser automation for this task runs through a snippet bridge, not a browser you launch.`,
+    `Write a JavaScript snippet to a file (e.g. snippet.js), then execute it with: node browser_run.mjs snippet.js`,
+    `The snippet runs inside an async function with ${scopeNames} in scope. Use await directly; return a JSON-serializable value to inspect it.`,
+    `Never launch your own browser process; browser_run.mjs is the only browser access.`,
+    surfaceGuidance,
+    `Surface: ${toolSurface}.`,
+  ].join("\n");
 }
 
 export function resolveCodexToolSurface(requested?: ToolSurface): ToolSurface {
   if (!requested) return "browse_cli";
-  if (requested === "browse_cli") return requested;
+  if (requested === "browse_cli" || CODE_SURFACES.has(requested)) {
+    return requested;
+  }
   throw new EvalsError(
-    `Codex harness supports --tool browse_cli for execution right now; received "${requested}".`,
+    `Codex harness supports --tool browse_cli, playwright_code, cdp_code, or stagehand_code for execution right now; received "${requested}".`,
   );
 }
 
@@ -51,8 +172,15 @@ export function resolveCodexStartupProfile(
 ): StartupProfile {
   if (requested) return requested;
 
-  if (toolSurface === "browse_cli") {
+  // browse_cli and stagehand_code own their browser; playwright/cdp attach to a
+  // runner-provided CDP endpoint (same defaults as the claude_code harness).
+  if (toolSurface === "browse_cli" || toolSurface === "stagehand_code") {
     return environment === "BROWSERBASE" ? "tool_create_browserbase" : "tool_launch_local";
+  }
+  if (toolSurface === "playwright_code" || toolSurface === "cdp_code") {
+    return environment === "BROWSERBASE"
+      ? "runner_provided_browserbase_cdp"
+      : "runner_provided_local_cdp";
   }
 
   throw new EvalsError(

--- a/packages/evals/framework/harnesses/codexAdapter.ts
+++ b/packages/evals/framework/harnesses/codexAdapter.ts
@@ -26,7 +26,7 @@
  *     query in args.
  *   - todo_list items → not surfaced as tool calls (they aren't actions).
  */
-import type { TaskSpec, Trajectory } from "stagehand-v3";
+import type { ProbeEvidence, TaskSpec, Trajectory } from "stagehand-v3";
 import {
   buildTrajectory,
   type NormalizedToolCall,
@@ -42,6 +42,11 @@ export interface CodexRunResult {
   status?: Trajectory["status"];
   /** Optional usage to fold into Trajectory.usage. */
   usage?: Partial<Trajectory["usage"]>;
+  /**
+   * Harness-observed terminal page state (captured through the tool surface
+   * after the agent finished) — anchors the verifier's final observation.
+   */
+  finalObservation?: ProbeEvidence;
 }
 
 export class CodexTrajectoryAdapter implements TrajectoryAdapter<CodexRunResult> {
@@ -84,6 +89,9 @@ export class CodexTrajectoryAdapter implements TrajectoryAdapter<CodexRunResult>
       finalAnswer,
       status: result.status ?? "complete",
       usage: result.usage,
+      ...(result.finalObservation?.screenshot && {
+        finalObservation: result.finalObservation,
+      }),
     });
   }
 }

--- a/packages/evals/tests/framework/claudeCodeToolAdapter.test.ts
+++ b/packages/evals/tests/framework/claudeCodeToolAdapter.test.ts
@@ -63,14 +63,23 @@ describe("claude code tool adapter resolution", () => {
     expect(resolveClaudeCodeStartupProfile("stagehand_code", "LOCAL")).toBe("tool_launch_local");
   });
 
-  it("supports browse_cli as the first Codex tool surface", () => {
+  it("supports browse_cli and the code surfaces on Codex", () => {
     expect(resolveCodexToolSurface()).toBe("browse_cli");
     expect(resolveCodexToolSurface("browse_cli")).toBe("browse_cli");
+    expect(resolveCodexToolSurface("stagehand_code")).toBe("stagehand_code");
+    expect(resolveCodexToolSurface("playwright_code")).toBe("playwright_code");
+    expect(resolveCodexToolSurface("cdp_code")).toBe("cdp_code");
+    expect(resolveCodexStartupProfile("stagehand_code", "BROWSERBASE")).toBe(
+      "tool_create_browserbase",
+    );
+    expect(resolveCodexStartupProfile("playwright_code", "BROWSERBASE")).toBe(
+      "runner_provided_browserbase_cdp",
+    );
+    expect(() => resolveCodexToolSurface("playwright_mcp")).toThrow(
+      /browse_cli, playwright_code, cdp_code, or stagehand_code/,
+    );
     expect(resolveCodexStartupProfile("browse_cli", "LOCAL")).toBe("tool_launch_local");
     expect(resolveCodexStartupProfile("browse_cli", "BROWSERBASE")).toBe("tool_create_browserbase");
-    expect(() => resolveCodexToolSurface("playwright_code")).toThrow(
-      /Codex harness supports --tool browse_cli/,
-    );
   });
 
   it("allows only direct browse commands through Bash", () => {

--- a/packages/evals/tests/framework/codexCodeBridge.test.ts
+++ b/packages/evals/tests/framework/codexCodeBridge.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, afterEach } from "vitest";
+import {
+  buildBridgeClientScript,
+  startCodeBridge,
+  type CodeBridge,
+} from "../../framework/codexCodeBridge.js";
+import { EvalLogger } from "../../logger.js";
+import type { AgentMount } from "../../core/contracts/tool.js";
+import type { ExternalHarnessTaskPlan } from "../../framework/externalHarnessPlan.js";
+
+const plan: ExternalHarnessTaskPlan = {
+  dataset: "webvoyager",
+  taskId: "test-1",
+  startUrl: "https://example.com",
+  instruction: "do the thing",
+};
+
+function mountWith(handles: Record<string, unknown>): Extract<AgentMount, { via: "handles" }> {
+  return {
+    via: "handles",
+    handles,
+    promptInstructions: "test",
+    runTool: {
+      description: "test run tool",
+      codeParamDescription: "code",
+      denyMessage: "deny",
+    },
+  };
+}
+
+async function post(bridge: CodeBridge, code: string) {
+  const res = await fetch(`http://127.0.0.1:${bridge.port}/run`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ code }),
+  });
+  return (await res.json()) as { ok: boolean; result?: string; error?: string };
+}
+
+let bridge: CodeBridge | undefined;
+afterEach(async () => {
+  await bridge?.close();
+  bridge = undefined;
+});
+
+describe("codex code bridge", () => {
+  it("executes snippets with handles, startUrl, and task in scope", async () => {
+    const page = { url: async () => "https://example.com/live" };
+    bridge = await startCodeBridge({
+      mount: mountWith({ page, marker: 42 }),
+      plan,
+      logger: new EvalLogger(),
+    });
+    const out = await post(
+      bridge,
+      "return { url: await page.url(), marker, startUrl, instruction: task.instruction };",
+    );
+    expect(out.ok).toBe(true);
+    expect(JSON.parse(out.result!)).toEqual({
+      url: "https://example.com/live",
+      marker: 42,
+      startUrl: "https://example.com",
+      instruction: "do the thing",
+    });
+  });
+
+  it("reports snippet errors without killing the bridge", async () => {
+    bridge = await startCodeBridge({
+      mount: mountWith({}),
+      plan,
+      logger: new EvalLogger(),
+    });
+    const bad = await post(bridge, "throw new Error('boom');");
+    expect(bad).toEqual({ ok: false, error: "boom" });
+    const good = await post(bridge, "return 'still alive';");
+    expect(good).toEqual({ ok: true, result: "still alive" });
+  });
+
+  it("times out runaway snippets", async () => {
+    process.env.EVAL_CODEX_RUN_TOOL_TIMEOUT_MS = "150";
+    try {
+      bridge = await startCodeBridge({
+        mount: mountWith({}),
+        plan,
+        logger: new EvalLogger(),
+      });
+      const out = await post(bridge, "await new Promise(() => {});");
+      expect(out.ok).toBe(false);
+      expect(out.error).toMatch(/timed out after 150ms/);
+    } finally {
+      delete process.env.EVAL_CODEX_RUN_TOOL_TIMEOUT_MS;
+    }
+  });
+
+  it("client script embeds the bridge port and pipes code", () => {
+    const script = buildBridgeClientScript(45678);
+    expect(script).toContain("http://127.0.0.1:45678/run");
+    expect(script).toContain("process.argv[2]");
+  });
+
+  it("redacts credentials from snippet error messages", async () => {
+    bridge = await startCodeBridge({
+      mount: mountWith({}),
+      plan,
+      logger: new EvalLogger(false),
+    });
+    const payload = await post(
+      bridge,
+      `throw new Error("connect failed: wss://connect.example.com/session?signingKey=sk-secret-value&x=1 (key sk-abcdef1234567890)")`,
+    );
+    expect(payload.ok).toBe(false);
+    expect(payload.error).not.toContain("sk-secret-value");
+    expect(payload.error).not.toContain("sk-abcdef1234567890");
+    expect(payload.error).toContain("signingKey=[redacted]");
+    expect(payload.error).toContain("connect failed");
+  });
+});


### PR DESCRIPTION
## Summary

Codex joins claude_code as an external harness across all three code tool surfaces (`stagehand_code`, `playwright_code`, `cdp_code`) — recreating #2397 on the LLMExposure architecture.

codex-sdk has no in-process MCP mounting (unlike claude-agent-sdk), and an external MCP process could not share this process's live surface handles. So the codex mount for a `code_handles` exposure is a loopback HTTP bridge: this process executes snippets against the in-memory handles; the codex workspace gets a tiny `browser_run.mjs` client that posts a snippet file to the bridge and prints the result. Scope semantics are identical to the claude_code run tool.

- `codexCodeBridge.ts` (new): the bridge server + generated workspace client
- `codexToolAdapter.ts`: code-surface mounting (exposure selection, bridge lifecycle, tmpdir cwd, prompt rewrite from run-tool to `browser_run.mjs` invocation)
- `codexRunner.ts` / `harnesses/codexAdapter.ts`: harness-observed terminal artifact anchors the verifier's final observation, mirroring the claude_code runner
- Tests: bridge round-trip + widened surface resolution

Part of the nondeterministic-evals stack; stacks on the exposure-adapter PR.

Follow-up on top of the stack: #2650 adds the MCP tool surfaces (playwright_mcp / chrome_devtools_mcp) to both external harnesses; MCP tool calls there count against the codex tool-step budget introduced in #2649.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Codex on `stagehand_code`, `playwright_code`, and `cdp_code` via a loopback HTTP bridge that runs snippets against in-memory handles, with terminal artifact capture in the runner for grounded grading. `browse_cli` remains supported with sane startup defaults, and code surfaces now have clear `browser_run.mjs` guidance.

- **New Features**
  - Bridge server/client in `codexCodeBridge.ts`: `browser_run.mjs` posts snippet code to `/run`; executes with `handles`, `startUrl`, `task`, and `console`; timeout via `EVAL_CODEX_RUN_TOOL_TIMEOUT_MS`; non-zero exit on failure.
  - Tool adapter and runner: `codexToolAdapter.ts` mounts `browse_cli`, `stagehand_code`, `playwright_code`, `cdp_code`; defaults to tool-owned browsers for `browse_cli`/`stagehand_code` and runner-provided CDP for `playwright_code`/`cdp_code`; writes `browser_run.mjs` and rewrites `AGENT_RUN_TOOL_NAME`; captures evidence via `captureEvidence` and passes it to `codexAdapter.ts`; robust cleanup.

- **Bug Fixes**
  - Final observation is only anchored when a screenshot is present; URL-only artifacts no longer qualify.
  - Redacts credential fragments (e.g., `signingKey`, `sk-*`) from snippet error messages before crossing the bridge or hitting logs.

<sup>Written for commit a710ed6842ec012ca4cab2f328e0e92aa4915ee5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

