### PR TITLE
evals: wire the verifier into third-party harnesses for evidence collection

### DIFF
--- a/packages/evals/framework/claudeCodeRunner.ts
+++ b/packages/evals/framework/claudeCodeRunner.ts
@@ -266,6 +266,13 @@ export async function runClaudeCodeAgent({
     return baseResult;
   }
 
+  // Artifact-grounded grading: capture the terminal page state through the
+  // tool surface (harness-observed, independent of the agent's self-report)
+  // before cleanup, and drain the per-step probe observations collected by
+  // the run tool.
+  const finalObservation = await toolAdapter?.captureEvidence?.().catch((): undefined => undefined);
+  const stepObservations = toolAdapter?.drainStepObservations?.();
+
   // Build a Trajectory from the SDK message stream and grade it with the
   // rubric verifier; any failure in that path folds into `verifierError`.
   return gradeExternalTrajectory({
@@ -273,6 +280,8 @@ export async function runClaudeCodeAgent({
       claudeCodeAdapter.fromHarnessResult(
         {
           messages,
+          ...(finalObservation && { finalObservation }),
+          ...(stepObservations?.length && { stepObservations }),
           finalAnswer: parsed.finalAnswer ?? resultText,
           status: status === "completed" ? "complete" : "error",
           usage: {

--- a/packages/evals/framework/claudeCodeToolAdapter.ts
+++ b/packages/evals/framework/claudeCodeToolAdapter.ts
@@ -22,6 +22,7 @@ import {
 import type { ProbeEvidence } from "stagehand-v3";
 import { startAgentToolRuntime } from "./agentToolRuntime.js";
 import type { ExternalHarnessTaskPlan } from "./externalHarnessPlan.js";
+import { ObservationRecorder, type StepObservation } from "./observationRecorder.js";
 
 export { waitForCdpEvent } from "../core/tools/cdp_code.js";
 
@@ -48,6 +49,7 @@ export interface PreparedClaudeCodeToolAdapter {
   ) => Promise<Record<string, unknown>>;
   /** Best-effort evidence from the currently running tool surface. */
   captureEvidence?: () => Promise<ProbeEvidence>;
+  drainStepObservations?: () => StepObservation[];
   cleanup: () => Promise<void>;
 }
 
@@ -390,11 +392,15 @@ async function prepareAgentMountAdapter(
     cwd = await fsp.mkdtemp(path.join(os.tmpdir(), `stagehand-evals-claude-${input.toolSurface}-`));
     const cleanupCwd = cwd;
     const env = { ...process.env } as Record<string, string>;
+    const recorder = running.captureEvidence
+      ? new ObservationRecorder(running.captureEvidence)
+      : undefined;
     const mcpServers = await buildCodeExposureRunMcpServers({
       handles: mount.handles,
       runToolSpec: mount.runTool,
       plan: input.plan,
       logger: input.logger,
+      recordObservation: recorder ? () => recorder.record() : undefined,
     });
     let cleanupPromise: Promise<void> | undefined;
 
@@ -428,6 +434,7 @@ async function prepareAgentMountAdapter(
           }
         },
       }),
+      ...(recorder && { drainStepObservations: () => recorder.drain() }),
       cleanup: async () => {
         cleanupPromise ??= (async () => {
           try {
@@ -457,6 +464,7 @@ async function buildCodeExposureRunMcpServers(input: {
   runToolSpec: AgentRunToolSpec;
   plan: ExternalHarnessTaskPlan;
   logger: EvalLogger;
+  recordObservation?: () => Promise<void>;
 }): Promise<Record<string, unknown>> {
   const sdk = (await import("@anthropic-ai/claude-agent-sdk")) as unknown as {
     createSdkMcpServer: SdkMcpServerFactory;
@@ -470,13 +478,15 @@ async function buildCodeExposureRunMcpServers(input: {
       code: z.string().describe(input.runToolSpec.codeParamDescription),
     },
     async ({ code }) => {
-      return executeCodeExposureRunTool({
+      const result = await executeCodeExposureRunTool({
         code,
         handles: input.handles,
         runToolSpec: input.runToolSpec,
         plan: input.plan,
         logger: input.logger,
       });
+      await input.recordObservation?.();
+      return result;
     },
     { alwaysLoad: true },
   );

--- a/packages/evals/framework/codexCodeBridge.ts
+++ b/packages/evals/framework/codexCodeBridge.ts
@@ -76,6 +76,8 @@ export async function startCodeBridge(input: {
   mount: Extract<AgentMount, { via: "handles" }>;
   plan: ExternalHarnessTaskPlan;
   logger: EvalLogger;
+  /** Awaited after every bridge run, success or failure (per-step probe). */
+  onRunExecuted?: () => Promise<void>;
 }): Promise<CodeBridge> {
   const { mount, plan, logger } = input;
   const handles = mount.handles;
@@ -132,6 +134,7 @@ export async function startCodeBridge(input: {
           level: 1,
           message: `bridge run completed: ${text.slice(0, 500)}`,
         });
+        await input.onRunExecuted?.();
         res.writeHead(200, { "content-type": "application/json" });
         res.end(JSON.stringify({ ok: true, result: text }));
       } catch (error) {
@@ -143,6 +146,7 @@ export async function startCodeBridge(input: {
           level: 1,
           message: `bridge run failed: ${message}`,
         });
+        await input.onRunExecuted?.();
         res.writeHead(200, { "content-type": "application/json" });
         res.end(JSON.stringify({ ok: false, error: message }));
       }

--- a/packages/evals/framework/codexCodeBridge.ts
+++ b/packages/evals/framework/codexCodeBridge.ts
@@ -108,6 +108,16 @@ export async function startCodeBridge(input: {
     );
   }
 
+  // Evidence collection is best-effort: a probe failure must never hang a
+  // bridge request or turn a successful run into an error response.
+  async function notifyRunExecuted(): Promise<void> {
+    try {
+      await input.onRunExecuted?.();
+    } catch {
+      // best-effort only
+    }
+  }
+
   const server = http.createServer((req, res) => {
     if (req.method !== "POST" || req.url !== "/run") {
       res.writeHead(404).end();
@@ -134,7 +144,7 @@ export async function startCodeBridge(input: {
           level: 1,
           message: `bridge run completed: ${text.slice(0, 500)}`,
         });
-        await input.onRunExecuted?.();
+        await notifyRunExecuted();
         res.writeHead(200, { "content-type": "application/json" });
         res.end(JSON.stringify({ ok: true, result: text }));
       } catch (error) {
@@ -146,7 +156,7 @@ export async function startCodeBridge(input: {
           level: 1,
           message: `bridge run failed: ${message}`,
         });
-        await input.onRunExecuted?.();
+        await notifyRunExecuted();
         res.writeHead(200, { "content-type": "application/json" });
         res.end(JSON.stringify({ ok: false, error: message }));
       }

--- a/packages/evals/framework/codexRunner.ts
+++ b/packages/evals/framework/codexRunner.ts
@@ -219,6 +219,10 @@ export async function runCodexAgent({
     toolAdapter && "captureEvidence" in toolAdapter
       ? await toolAdapter.captureEvidence?.().catch((): undefined => undefined)
       : undefined;
+  const stepObservations =
+    toolAdapter && "drainStepObservations" in toolAdapter
+      ? toolAdapter.drainStepObservations?.()
+      : undefined;
 
   // Build a Trajectory from the codex event stream and grade it with the
   // rubric verifier; any failure in that path folds into `verifierError`.
@@ -228,6 +232,7 @@ export async function runCodexAgent({
         {
           events,
           ...(finalObservation && { finalObservation }),
+          ...(stepObservations?.length && { stepObservations }),
           finalAnswer: parsed.finalAnswer ?? finalResponse,
           status: status === "completed" ? "complete" : "error",
           usage: {

--- a/packages/evals/framework/codexToolAdapter.ts
+++ b/packages/evals/framework/codexToolAdapter.ts
@@ -12,6 +12,7 @@ import type { ProbeEvidence } from "stagehand-v3";
 import { startAgentToolRuntime } from "./agentToolRuntime.js";
 import type { ExternalHarnessTaskPlan } from "./externalHarnessPlan.js";
 import { buildBridgeClientScript, startCodeBridge } from "./codexCodeBridge.js";
+import { ObservationRecorder, type StepObservation } from "./observationRecorder.js";
 import {
   prepareBrowseCliHarnessAdapter,
   type PreparedBrowseCliHarnessAdapter,
@@ -34,6 +35,7 @@ export interface PreparedCodexCodeAdapter {
   promptInstructions: string;
   /** Best-effort evidence from the currently running tool surface. */
   captureEvidence?: () => Promise<ProbeEvidence>;
+  drainStepObservations?: () => StepObservation[];
   cleanup: () => Promise<void>;
 }
 
@@ -78,10 +80,14 @@ export async function prepareCodexToolAdapter(
     if (mount.via !== "handles") {
       throw new EvalsError(`Codex does not support agent mounts delivered via "${mount.via}" yet.`);
     }
+    const recorder = runtime.running.captureEvidence
+      ? new ObservationRecorder(runtime.running.captureEvidence)
+      : undefined;
     bridge = await startCodeBridge({
       mount,
       plan: input.plan,
       logger: input.logger,
+      onRunExecuted: recorder ? () => recorder.record() : undefined,
     });
     cwd = await fsp.mkdtemp(
       path.join(os.tmpdir(), `stagehand-evals-codex-${toolSurface.replace(/_/g, "-")}-`),
@@ -109,6 +115,7 @@ export async function prepareCodexToolAdapter(
       ...(runtime.running.captureEvidence && {
         captureEvidence: runtime.running.captureEvidence,
       }),
+      ...(recorder && { drainStepObservations: () => recorder.drain() }),
       cleanup: async () => {
         try {
           await capturedBridge.close();

--- a/packages/evals/framework/harnesses/claudeCodeAdapter.ts
+++ b/packages/evals/framework/harnesses/claudeCodeAdapter.ts
@@ -24,6 +24,8 @@
  *     can't ground.
  */
 import type { ProbeEvidence, TaskSpec, Trajectory } from "stagehand-v3";
+import { AGENT_RUN_TOOL_NAME } from "../../core/contracts/tool.js";
+import type { StepObservation } from "../observationRecorder.js";
 import {
   buildTrajectory,
   type NormalizedToolCall,
@@ -40,6 +42,13 @@ export interface ClaudeCodeRunResult {
   status?: Trajectory["status"];
   /** Optional usage to fold into Trajectory.usage. */
   usage?: Partial<Trajectory["usage"]>;
+  /**
+   * Harness-observed terminal page state (captured through the tool surface
+   * after the agent finished) — anchors the verifier's final observation.
+   */
+  finalObservation?: ProbeEvidence;
+  /** Per-step probe observations, indexed by run-tool execution order. */
+  stepObservations?: StepObservation[];
 }
 
 interface ToolUseBlock {
@@ -141,10 +150,18 @@ export class ClaudeCodeTrajectoryAdapter implements TrajectoryAdapter<ClaudeCode
       }
     }
 
+    const observationsByRunIndex = new Map(
+      (result.stepObservations ?? []).map((o) => [o.runIndex, o.evidence]),
+    );
+    let runOrdinal = 0;
     const toolCalls: NormalizedToolCall[] = toolUses.map((use) => {
       const matched = toolResults.get(use.id);
       const ok = matched ? !matched.isError : true;
       const resultPayload = matched?.raw !== undefined ? matched.raw : (matched?.text ?? "");
+      // The Nth run-tool call pairs with the Nth recorded observation; other
+      // tools (Bash etc.) never consume an index.
+      const observation =
+        use.name === AGENT_RUN_TOOL_NAME ? observationsByRunIndex.get(runOrdinal++) : undefined;
       return {
         name: use.name,
         args: use.input,
@@ -153,6 +170,7 @@ export class ClaudeCodeTrajectoryAdapter implements TrajectoryAdapter<ClaudeCode
         ...(matched?.isError && matched.text && { error: matched.text }),
         reasoning: use.reasoningPrefix.trim() || undefined,
         ...(matched?.images.length && { images: matched.images }),
+        ...(observation && { probeEvidence: observation }),
       };
     });
 
@@ -160,17 +178,18 @@ export class ClaudeCodeTrajectoryAdapter implements TrajectoryAdapter<ClaudeCode
     const finalAnswer =
       result.finalAnswer ?? resultMessageText ?? (trailing.length > 0 ? trailing : undefined);
 
-    // Anchor the closing frame with the most recent screenshot the agent
-    // captured. Claude Code doesn't run a post-task probe, so the last
-    // tool_result image is the best proxy for "terminal observation" — without
-    // it the verifier's final-screenshot anchor (evidence.ts:136-143) is empty.
-    let finalObservation: ProbeEvidence | undefined;
-    for (let i = toolUses.length - 1; i >= 0; i--) {
+    // Anchor the closing frame with the harness-observed terminal artifact
+    // when the runner captured one; otherwise fall back to the most recent
+    // screenshot the agent captured — without either, the verifier's
+    // final-screenshot anchor (evidence.ts:136-143) is empty.
+    let finalObservation: ProbeEvidence | undefined = result.finalObservation?.screenshot
+      ? result.finalObservation
+      : undefined;
+    for (let i = toolUses.length - 1; !finalObservation && i >= 0; i--) {
       const matched = toolResults.get(toolUses[i].id);
       const lastImage = matched?.images[matched.images.length - 1];
       if (lastImage) {
         finalObservation = { screenshot: lastImage.bytes };
-        break;
       }
     }
 

--- a/packages/evals/framework/harnesses/codexAdapter.ts
+++ b/packages/evals/framework/harnesses/codexAdapter.ts
@@ -27,6 +27,7 @@
  *   - todo_list items → not surfaced as tool calls (they aren't actions).
  */
 import type { ProbeEvidence, TaskSpec, Trajectory } from "stagehand-v3";
+import type { StepObservation } from "../observationRecorder.js";
 import {
   buildTrajectory,
   type NormalizedToolCall,
@@ -47,6 +48,8 @@ export interface CodexRunResult {
    * after the agent finished) — anchors the verifier's final observation.
    */
   finalObservation?: ProbeEvidence;
+  /** Per-step probe observations, indexed by bridge-run execution order. */
+  stepObservations?: StepObservation[];
 }
 
 export class CodexTrajectoryAdapter implements TrajectoryAdapter<CodexRunResult> {
@@ -82,6 +85,22 @@ export class CodexTrajectoryAdapter implements TrajectoryAdapter<CodexRunResult>
     }
 
     const finalAnswer = result.finalAnswer ?? latestAgentMessage;
+
+    const observationsByRunIndex = new Map(
+      (result.stepObservations ?? []).map((o) => [o.runIndex, o.evidence]),
+    );
+    if (observationsByRunIndex.size > 0) {
+      let runOrdinal = 0;
+      for (const call of toolCalls) {
+        if (
+          typeof call.args.command === "string" &&
+          call.args.command.includes("browser_run.mjs")
+        ) {
+          const observation = observationsByRunIndex.get(runOrdinal++);
+          if (observation) call.probeEvidence = observation;
+        }
+      }
+    }
 
     return buildTrajectory({
       taskSpec,

--- a/packages/evals/framework/harnesses/codexAdapter.ts
+++ b/packages/evals/framework/harnesses/codexAdapter.ts
@@ -99,7 +99,7 @@ export class CodexTrajectoryAdapter implements TrajectoryAdapter<CodexRunResult>
       // runIndex counts every bridge run (failed captures leave gaps), so
       // max+1 is the number of runs the recorder actually saw.
       const totalBridgeRuns = Math.max(...observations.map((o) => o.runIndex)) + 1;
-      if (bridgeCalls.length >= totalBridgeRuns) {
+      if (bridgeCalls.length === totalBridgeRuns) {
         const observationsByRunIndex = new Map(observations.map((o) => [o.runIndex, o.evidence]));
         bridgeCalls.forEach((call, ordinal) => {
           const observation = observationsByRunIndex.get(ordinal);

--- a/packages/evals/framework/harnesses/codexAdapter.ts
+++ b/packages/evals/framework/harnesses/codexAdapter.ts
@@ -84,23 +84,31 @@ export class CodexTrajectoryAdapter implements TrajectoryAdapter<CodexRunResult>
       }
     }
 
-    const finalAnswer = result.finalAnswer ?? latestAgentMessage;
-
-    const observationsByRunIndex = new Map(
-      (result.stepObservations ?? []).map((o) => [o.runIndex, o.evidence]),
-    );
-    if (observationsByRunIndex.size > 0) {
-      let runOrdinal = 0;
-      for (const call of toolCalls) {
-        if (
-          typeof call.args.command === "string" &&
-          call.args.command.includes("browser_run.mjs")
-        ) {
-          const observation = observationsByRunIndex.get(runOrdinal++);
+    // The Nth recorded observation pairs with the Nth bridge run — the
+    // command_execution items that invoke browser_run.mjs, in stream order.
+    // If a bridge run is not visible under that filter (the agent reached
+    // the bridge some other way), ordinals would shift and attach evidence
+    // to the wrong steps — misattribution is worse than a gap, so attach
+    // nothing and let the verifier take its evidence_insufficient path.
+    const observations = result.stepObservations ?? [];
+    if (observations.length > 0) {
+      const bridgeCalls = toolCalls.filter(
+        (call) =>
+          typeof call.args.command === "string" && call.args.command.includes("browser_run.mjs"),
+      );
+      // runIndex counts every bridge run (failed captures leave gaps), so
+      // max+1 is the number of runs the recorder actually saw.
+      const totalBridgeRuns = Math.max(...observations.map((o) => o.runIndex)) + 1;
+      if (bridgeCalls.length >= totalBridgeRuns) {
+        const observationsByRunIndex = new Map(observations.map((o) => [o.runIndex, o.evidence]));
+        bridgeCalls.forEach((call, ordinal) => {
+          const observation = observationsByRunIndex.get(ordinal);
           if (observation) call.probeEvidence = observation;
-        }
+        });
       }
     }
+
+    const finalAnswer = result.finalAnswer ?? latestAgentMessage;
 
     return buildTrajectory({
       taskSpec,

--- a/packages/evals/framework/harnesses/trajectoryAdapter.ts
+++ b/packages/evals/framework/harnesses/trajectoryAdapter.ts
@@ -44,6 +44,11 @@ export interface NormalizedToolCall {
    * the verifier can ground visual criteria against them.
    */
   images?: Array<{ bytes: Buffer; mediaType: string }>;
+  /**
+   * Harness-observed page state after this call (url/screenshot probe).
+   * Attached by adapters when the run collected per-step observations.
+   */
+  probeEvidence?: ProbeEvidence;
 }
 
 /**
@@ -107,10 +112,10 @@ export function toolCallToTrajectoryStep(call: NormalizedToolCall): TrajectorySt
     actionArgs: call.args,
     reasoning: call.reasoning ?? "",
     agentEvidence: actionToAgentEvidence(call),
-    // External harnesses don't natively produce screenshots/aria/scroll, so
-    // probeEvidence stays empty. The verifier handles this via the
+    // Runs that collected per-step observations carry them here; otherwise
+    // probeEvidence stays empty and the verifier degrades via the
     // evidence_insufficient path.
-    probeEvidence: {},
+    probeEvidence: call.probeEvidence ?? {},
     toolOutput: {
       ok: call.ok,
       result: call.result,

--- a/packages/evals/framework/observationRecorder.ts
+++ b/packages/evals/framework/observationRecorder.ts
@@ -1,0 +1,73 @@
+import type { ProbeEvidence } from "stagehand-v3";
+
+/** A probe observation captured after the Nth run-tool execution (0-based). */
+export interface StepObservation {
+  runIndex: number;
+  evidence: ProbeEvidence;
+}
+
+const OBSERVATIONS_ENV = "EVAL_HARNESS_OBSERVATIONS";
+const OBSERVATION_TIMEOUT_ENV = "EVAL_OBSERVATION_TIMEOUT_MS";
+const DEFAULT_OBSERVATION_TIMEOUT_MS = 10_000;
+
+/**
+ * Whether this run collects per-step observations. Sampling is a run-level
+ * decision: batch tooling sets EVAL_HARNESS_OBSERVATIONS=none on runs it
+ * excludes from evidence collection; the default is to observe.
+ */
+export function harnessObservationsEnabled(): boolean {
+  return (process.env[OBSERVATIONS_ENV] ?? "all") !== "none";
+}
+
+/**
+ * Buffers per-step probe observations for an external-harness run. Each
+ * record() consumes one run index (matching the harness's Nth run-tool
+ * execution); a failed capture leaves a gap at its index rather than
+ * shifting later observations onto the wrong step.
+ */
+export class ObservationRecorder {
+  private readonly observations: StepObservation[] = [];
+  private runIndex = 0;
+
+  constructor(private readonly capture: () => Promise<ProbeEvidence>) {}
+
+  async record(): Promise<void> {
+    const runIndex = this.runIndex++;
+    try {
+      const evidence = await withTimeout(this.capture(), observationTimeoutMs());
+      if (evidence.screenshot || evidence.url || evidence.ariaTree) {
+        this.observations.push({ runIndex, evidence });
+      }
+    } catch {
+      // best-effort only — a failed probe must never fail the run tool
+    }
+  }
+
+  drain(): StepObservation[] {
+    return this.observations.splice(0);
+  }
+}
+
+function observationTimeoutMs(): number {
+  const parsed = Number.parseInt(process.env[OBSERVATION_TIMEOUT_ENV] ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_OBSERVATION_TIMEOUT_MS;
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`observation timed out after ${timeoutMs}ms`)),
+      timeoutMs,
+    );
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}

--- a/packages/evals/framework/verifierGate.ts
+++ b/packages/evals/framework/verifierGate.ts
@@ -1,0 +1,57 @@
+/**
+ * Per-arm verifiability accounting for bench batches (STG-2752).
+ *
+ * Each graded run reports `criterionCount` and `evidenceInsufficient` (the
+ * rubric criteria the verifier could not ground in evidence). This module
+ * aggregates those per arm — one (harness × tool surface × model) cell of
+ * the bench matrix — so unverifiable-criteria counts are reported per arm
+ * and, when EVAL_MAX_UNVERIFIABLE_CRITERIA is set, gate the batch.
+ */
+import type { EvalInput } from "../types/evals.js";
+
+export interface ArmVerifiability {
+  arm: string;
+  /** Runs the verifier graded (criterionCount present). */
+  gradedRuns: number;
+  unverifiableCriteria: number;
+  totalCriteria: number;
+}
+
+const GATE_ENV = "EVAL_MAX_UNVERIFIABLE_CRITERIA";
+
+export function summarizeArmVerifiability(
+  results: Array<{ input: EvalInput; output: Record<string, unknown> }>,
+  harness: string,
+): ArmVerifiability[] {
+  const arms = new Map<string, ArmVerifiability>();
+  for (const { input, output } of results) {
+    if (typeof output.criterionCount !== "number") continue;
+    const toolSurface =
+      typeof input.params?.toolSurface === "string" ? input.params.toolSurface : undefined;
+    const key = [harness, toolSurface, input.modelName].filter(Boolean).join(" × ");
+    const arm = arms.get(key) ?? {
+      arm: key,
+      gradedRuns: 0,
+      unverifiableCriteria: 0,
+      totalCriteria: 0,
+    };
+    arm.gradedRuns += 1;
+    arm.totalCriteria += output.criterionCount;
+    arm.unverifiableCriteria += Array.isArray(output.evidenceInsufficient)
+      ? output.evidenceInsufficient.length
+      : 0;
+    arms.set(key, arm);
+  }
+  return [...arms.values()];
+}
+
+/** Per-arm ceiling on unverifiable criteria. Unset or invalid = report only. */
+export function resolveUnverifiableCriteriaLimit(): number | undefined {
+  const parsed = Number.parseInt(process.env[GATE_ENV] ?? "", 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+/** Arms whose unverifiable-criteria count exceeds the limit. */
+export function armsOverLimit(arms: ArmVerifiability[], limit: number): ArmVerifiability[] {
+  return arms.filter((arm) => arm.unverifiableCriteria > limit);
+}

--- a/packages/evals/framework/verifierGate.ts
+++ b/packages/evals/framework/verifierGate.ts
@@ -45,10 +45,15 @@ export function summarizeArmVerifiability(
   return [...arms.values()];
 }
 
-/** Per-arm ceiling on unverifiable criteria. Unset or invalid = report only. */
+/**
+ * Per-arm ceiling on unverifiable criteria. Unset or invalid = report only.
+ * Strict integer parsing: a malformed value ("1.5", "10foo") must not be
+ * coerced into an unintended gate.
+ */
 export function resolveUnverifiableCriteriaLimit(): number | undefined {
-  const parsed = Number.parseInt(process.env[GATE_ENV] ?? "", 10);
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+  const raw = process.env[GATE_ENV]?.trim();
+  if (!raw || !/^\d+$/.test(raw)) return undefined;
+  return Number(raw);
 }
 
 /** Arms whose unverifiable-criteria count exceeds the limit. */

--- a/packages/evals/tests/framework/harnessObservations.test.ts
+++ b/packages/evals/tests/framework/harnessObservations.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { TaskSpec } from "stagehand-v3";
+import { AGENT_RUN_TOOL_NAME } from "../../core/contracts/tool.js";
+import { claudeCodeAdapter } from "../../framework/harnesses/claudeCodeAdapter.js";
+import { codexAdapter } from "../../framework/harnesses/codexAdapter.js";
+import {
+  harnessObservationsEnabled,
+  ObservationRecorder,
+} from "../../framework/observationRecorder.js";
+import {
+  armsOverLimit,
+  resolveUnverifiableCriteriaLimit,
+  summarizeArmVerifiability,
+} from "../../framework/verifierGate.js";
+
+const TASK_SPEC: TaskSpec = { id: "t", instruction: "do the thing" };
+
+describe("observation recorder", () => {
+  afterEach(() => {
+    delete process.env.EVAL_HARNESS_OBSERVATIONS;
+    delete process.env.EVAL_MAX_UNVERIFIABLE_CRITERIA;
+  });
+
+  it("observes by default and can be disabled per run", () => {
+    expect(harnessObservationsEnabled()).toBe(true);
+    process.env.EVAL_HARNESS_OBSERVATIONS = "none";
+    expect(harnessObservationsEnabled()).toBe(false);
+  });
+
+  it("indexes observations by run and leaves gaps on capture failure", async () => {
+    let call = 0;
+    const recorder = new ObservationRecorder(async () => {
+      call += 1;
+      if (call === 2) throw new Error("probe failed");
+      return { url: `https://example.com/${call}` };
+    });
+    await recorder.record();
+    await recorder.record();
+    await recorder.record();
+    expect(recorder.drain().map((o) => [o.runIndex, o.evidence.url])).toEqual([
+      [0, "https://example.com/1"],
+      [2, "https://example.com/3"],
+    ]);
+    expect(recorder.drain()).toEqual([]);
+  });
+
+  it("drops empty artifacts", async () => {
+    const recorder = new ObservationRecorder(async () => ({}));
+    await recorder.record();
+    expect(recorder.drain()).toEqual([]);
+  });
+});
+
+describe("per-step observations in trajectories", () => {
+  it("attaches claude_code observations to run-tool steps only", () => {
+    const messages = [
+      assistantToolUse("u1", "Bash", { command: "ls" }),
+      toolResult("u1", "ok"),
+      assistantToolUse("u2", AGENT_RUN_TOOL_NAME, { code: "await page.goto(startUrl)" }),
+      toolResult("u2", "done"),
+      assistantToolUse("u3", AGENT_RUN_TOOL_NAME, { code: "await page.title()" }),
+      toolResult("u3", "Example"),
+    ];
+    const trajectory = claudeCodeAdapter.fromHarnessResult(
+      {
+        messages,
+        stepObservations: [
+          { runIndex: 0, evidence: { url: "https://example.com/a" } },
+          { runIndex: 1, evidence: { url: "https://example.com/b" } },
+        ],
+        finalObservation: {
+          url: "https://example.com/final",
+          screenshot: Buffer.from("final"),
+        },
+      },
+      TASK_SPEC,
+    );
+    expect(trajectory.steps.map((s) => s.probeEvidence.url)).toEqual([
+      undefined,
+      "https://example.com/a",
+      "https://example.com/b",
+    ]);
+    expect(trajectory.finalObservation?.url).toBe("https://example.com/final");
+  });
+
+  it("attaches codex observations to bridge-run steps only", () => {
+    const events = [
+      commandExecution("cat notes.txt"),
+      commandExecution("node browser_run.mjs snippet.js"),
+      commandExecution("node browser_run.mjs snippet2.js"),
+    ];
+    const trajectory = codexAdapter.fromHarnessResult(
+      {
+        events,
+        stepObservations: [{ runIndex: 1, evidence: { url: "https://example.com/second" } }],
+      },
+      TASK_SPEC,
+    );
+    expect(trajectory.steps.map((s) => s.probeEvidence.url)).toEqual([
+      undefined,
+      undefined,
+      "https://example.com/second",
+    ]);
+  });
+});
+
+describe("verifiability gate", () => {
+  afterEach(() => {
+    delete process.env.EVAL_MAX_UNVERIFIABLE_CRITERIA;
+  });
+
+  it("aggregates unverifiable criteria per arm and skips ungraded runs", () => {
+    const arms = summarizeArmVerifiability(
+      [
+        row("model-a", "stagehand_code", { criterionCount: 4, evidenceInsufficient: ["c1"] }),
+        row("model-a", "stagehand_code", { criterionCount: 3, evidenceInsufficient: [] }),
+        row("model-a", "playwright_code", {
+          criterionCount: 5,
+          evidenceInsufficient: ["c1", "c2"],
+        }),
+        row("model-a", "stagehand_code", {}),
+      ],
+      "claude_code",
+    );
+    expect(arms).toEqual([
+      {
+        arm: "claude_code × stagehand_code × model-a",
+        gradedRuns: 2,
+        unverifiableCriteria: 1,
+        totalCriteria: 7,
+      },
+      {
+        arm: "claude_code × playwright_code × model-a",
+        gradedRuns: 1,
+        unverifiableCriteria: 2,
+        totalCriteria: 5,
+      },
+    ]);
+  });
+
+  it("gates arms over the limit; unset env reports only", () => {
+    expect(resolveUnverifiableCriteriaLimit()).toBeUndefined();
+    process.env.EVAL_MAX_UNVERIFIABLE_CRITERIA = "1";
+    expect(resolveUnverifiableCriteriaLimit()).toBe(1);
+    const arms = [
+      { arm: "a", gradedRuns: 1, unverifiableCriteria: 1, totalCriteria: 4 },
+      { arm: "b", gradedRuns: 1, unverifiableCriteria: 2, totalCriteria: 4 },
+    ];
+    expect(armsOverLimit(arms, 1).map((a) => a.arm)).toEqual(["b"]);
+  });
+});
+
+function assistantToolUse(
+  id: string,
+  name: string,
+  input: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    type: "assistant",
+    message: { content: [{ type: "tool_use", id, name, input }] },
+  };
+}
+
+function toolResult(toolUseId: string, text: string): Record<string, unknown> {
+  return {
+    type: "user",
+    message: {
+      content: [{ type: "tool_result", tool_use_id: toolUseId, content: text }],
+    },
+  };
+}
+
+function commandExecution(command: string): Record<string, unknown> {
+  return {
+    type: "item.completed",
+    item: {
+      type: "command_execution",
+      command,
+      aggregated_output: "ok",
+      exit_code: 0,
+      status: "completed",
+    },
+  };
+}
+
+function row(
+  modelName: string,
+  toolSurface: string,
+  output: Record<string, unknown>,
+): {
+  input: { name: string; modelName: never; params: Record<string, unknown> };
+  output: Record<string, unknown>;
+} {
+  return {
+    input: {
+      name: "task",
+      modelName: modelName as never,
+      params: { toolSurface },
+    },
+    output,
+  };
+}

--- a/packages/evals/tests/framework/harnessObservations.test.ts
+++ b/packages/evals/tests/framework/harnessObservations.test.ts
@@ -102,6 +102,46 @@ describe("per-step observations in trajectories", () => {
       "https://example.com/second",
     ]);
   });
+
+  it("maps the Nth codex observation to the Nth bridge run", () => {
+    const events = [
+      commandExecution("node browser_run.mjs a.js"),
+      commandExecution("ls"),
+      commandExecution("node browser_run.mjs b.js"),
+    ];
+    const trajectory = codexAdapter.fromHarnessResult(
+      {
+        events,
+        stepObservations: [
+          { runIndex: 0, evidence: { url: "https://example.com/a" } },
+          { runIndex: 1, evidence: { url: "https://example.com/b" } },
+        ],
+      },
+      TASK_SPEC,
+    );
+    expect(trajectory.steps.map((s) => s.probeEvidence.url)).toEqual([
+      "https://example.com/a",
+      undefined,
+      "https://example.com/b",
+    ]);
+  });
+
+  it("attaches no codex observations when bridge runs outnumber matched steps", () => {
+    // Two recorded bridge runs but only one command matches the filter —
+    // ordinals could be shifted, so misattribution must be refused.
+    const events = [commandExecution("node browser_run.mjs a.js"), commandExecution("ls")];
+    const trajectory = codexAdapter.fromHarnessResult(
+      {
+        events,
+        stepObservations: [
+          { runIndex: 0, evidence: { url: "https://example.com/a" } },
+          { runIndex: 1, evidence: { url: "https://example.com/b" } },
+        ],
+      },
+      TASK_SPEC,
+    );
+    expect(trajectory.steps.every((s) => s.probeEvidence.url === undefined)).toBe(true);
+  });
 });
 
 describe("verifiability gate", () => {
@@ -147,6 +187,15 @@ describe("verifiability gate", () => {
       { arm: "b", gradedRuns: 1, unverifiableCriteria: 2, totalCriteria: 4 },
     ];
     expect(armsOverLimit(arms, 1).map((a) => a.arm)).toEqual(["b"]);
+  });
+
+  it("treats malformed limit values as report-only", () => {
+    for (const raw of ["1.5", "10foo", "-2", "", " "]) {
+      process.env.EVAL_MAX_UNVERIFIABLE_CRITERIA = raw;
+      expect(resolveUnverifiableCriteriaLimit()).toBeUndefined();
+    }
+    process.env.EVAL_MAX_UNVERIFIABLE_CRITERIA = " 3 ";
+    expect(resolveUnverifiableCriteriaLimit()).toBe(3);
   });
 });
 

--- a/packages/evals/tui/commands/run.ts
+++ b/packages/evals/tui/commands/run.ts
@@ -309,6 +309,7 @@ export async function runCommand(
       }
 
       const arms = summarizeArmVerifiability(result.results, options.harness);
+      const unverifiableLimit = resolveUnverifiableCriteriaLimit();
       if (arms.length > 0) {
         for (const arm of arms) {
           console.log(
@@ -317,18 +318,27 @@ export async function runCommand(
             ),
           );
         }
-        const limit = resolveUnverifiableCriteriaLimit();
-        if (limit !== undefined) {
-          const over = armsOverLimit(arms, limit);
+        if (unverifiableLimit !== undefined) {
+          const over = armsOverLimit(arms, unverifiableLimit);
           for (const arm of over) {
             console.error(
-              `  ✗ verifiability gate: ${arm.arm} has ${arm.unverifiableCriteria} unverifiable criteria (limit ${limit})`,
+              `  ✗ verifiability gate: ${arm.arm} has ${arm.unverifiableCriteria} unverifiable criteria (limit ${unverifiableLimit})`,
             );
           }
           if (over.length > 0) {
             process.exitCode = 1;
           }
         }
+      } else if (
+        unverifiableLimit !== undefined &&
+        result.results.some((row) => row.output.verifierError !== undefined)
+      ) {
+        // A configured gate must never be silently bypassed: verifier-backed
+        // runs happened, but none produced a graded arm to measure.
+        console.error(
+          `  ✗ verifiability gate: EVAL_MAX_UNVERIFIABLE_CRITERIA=${unverifiableLimit} is set but no runs were graded`,
+        );
+        process.exitCode = 1;
       }
 
       console.log(dim(`  Experiment: ${result.experimentName}`));

--- a/packages/evals/tui/commands/run.ts
+++ b/packages/evals/tui/commands/run.ts
@@ -20,6 +20,11 @@ import type { ResolvedRunOptions } from "./parse.js";
 import { withEnvOverrides } from "./parse.js";
 import { getRuntimeTasksRoot } from "../../runtimePaths.js";
 import { isExecutableBenchHarness, type Harness } from "../../framework/benchTypes.js";
+import {
+  armsOverLimit,
+  resolveUnverifiableCriteriaLimit,
+  summarizeArmVerifiability,
+} from "../../framework/verifierGate.js";
 
 type RunProgressEvent = {
   type: "planned" | "started" | "passed" | "failed" | "error";
@@ -301,6 +306,29 @@ export async function runCommand(
         printResultsTable(result.results);
       } else if (result.results.length > 0) {
         printModelSummary(result.results);
+      }
+
+      const arms = summarizeArmVerifiability(result.results, options.harness);
+      if (arms.length > 0) {
+        for (const arm of arms) {
+          console.log(
+            dim(
+              `  Verifiability: ${arm.arm} — ${arm.unverifiableCriteria}/${arm.totalCriteria} criteria unverifiable across ${arm.gradedRuns} graded runs`,
+            ),
+          );
+        }
+        const limit = resolveUnverifiableCriteriaLimit();
+        if (limit !== undefined) {
+          const over = armsOverLimit(arms, limit);
+          for (const arm of over) {
+            console.error(
+              `  ✗ verifiability gate: ${arm.arm} has ${arm.unverifiableCriteria} unverifiable criteria (limit ${limit})`,
+            );
+          }
+          if (over.length > 0) {
+            process.exitCode = 1;
+          }
+        }
       }
 
       console.log(dim(`  Experiment: ${result.experimentName}`));


### PR DESCRIPTION
## Summary

STG-2752: external-harness runs now carry per-step observations and a final observation grounded in harness-captured evidence, and unverifiable-criteria counts are reported per arm and can gate the batch.

- `ToolStartResult.captureEvidence` (optional hook): each code surface captures current page state (url + screenshot + aria tree) through its own handles — one shared capture per surface, resolved through `session.activePage()` at capture time
- `observationRecorder.ts` (new): run-indexed probe buffer; a failed capture leaves a gap instead of shifting later observations onto the wrong step; `EVAL_HARNESS_OBSERVATIONS=none` excludes a run from evidence collection
- Probes record after each run-tool execution in `claude_code` and each bridge run in `codex`; the trajectory adapters attach them to code steps only, and refuse attachment when counts mismatch (misattribution is worse than a gap)
- `tui run` prints per-arm verifiability and enforces the `EVAL_MAX_UNVERIFIABLE_CRITERIA` gate

Verified live: in webvoyager runs the verifier now rejects agent claims that the collected step evidence does not support (e.g. asserted ingredients absent from the extracted list).

Stacked follow-ups: #2649 extends the gate to count verifier-failed (ungraded, self-reported) rows per arm and fail gated batches containing any; #2650 extends per-step observation to the MCP tool surfaces via the runner event streams.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires verifier-backed evidence capture into `claude_code` and `codex` so runs include per-step URL/screenshot probes and a harness-observed final artifact. Adds per-arm verifiability reporting and an optional gate for STG-2752.

- **New Features**
  - Added `ObservationRecorder` for per-step probes; opt out with `EVAL_HARNESS_OBSERVATIONS=none`, timeout via `EVAL_OBSERVATION_TIMEOUT_MS`.
  - Probes record after each `run_tool` in `claude_code` and each bridge run in `codex`; adapters attach only to code steps (`LLM_RUN_TOOL_NAME`, `browser_run.mjs`) as `probeEvidence`. Final observation prefers the harness-captured artifact, else the last agent screenshot.
  - `tui run` prints per-arm verifiability and enforces the `EVAL_MAX_UNVERIFIABLE_CRITERIA` gate.

- **Bug Fixes**
  - Bridge probe callbacks are non-blocking; failed captures leave indexed gaps instead of shifting evidence.
  - `codex` only attaches observations when recorded bridge runs match filtered steps; `claude_code` captures a terminal artifact before cleanup; final observation requires a screenshot.
  - Strict integer parsing for `EVAL_MAX_UNVERIFIABLE_CRITERIA`; the gate fails loudly when set but no arms were graded.

<sup>Written for commit 88d32fda08c10656817aeb169978a0ec8530e03c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

