### PR TITLE
evals: restore session URLs on the v4 path and split the harness context

### DIFF
--- a/packages/evals/framework/benchHarness.ts
+++ b/packages/evals/framework/benchHarness.ts
@@ -42,20 +42,31 @@ export interface BenchHarnessExecuteInput extends BenchHarnessStartInput {
   signal?: AbortSignal;
 }
 
-export interface BenchHarnessContext {
+interface BenchHarnessContextBase {
   harness: Harness;
   row: BenchMatrixRow;
   logger: EvalLogger;
-  v3?: V3;
-  agent?: AgentInstance;
-  page?: Page;
-  /** Stagehand v4 client (set for act/extract/observe tasks). */
-  stagehand?: StagehandInitResult["stagehand"];
-  /** v4 page object (set for act/extract/observe tasks). */
-  v4Page?: StagehandInitResult["page"];
   debugUrl: string;
   sessionUrl: string;
 }
+
+/**
+ * The two context shapes are mutually exclusive: act/extract/observe tasks
+ * run on the v4 SDK, everything else (agent) runs on stagehand-v3. The `sdk`
+ * discriminant lets the runner narrow instead of probing optional fields.
+ */
+export type BenchHarnessContext =
+  | (BenchHarnessContextBase & {
+      sdk: "v4";
+      stagehand: StagehandInitResult["stagehand"];
+      page: StagehandInitResult["page"];
+    })
+  | (BenchHarnessContextBase & {
+      sdk: "v3";
+      v3: V3;
+      agent?: AgentInstance;
+      page: Page;
+    });
 
 export interface StartedBenchHarness {
   ctx: BenchHarnessContext;
@@ -174,12 +185,11 @@ export const stagehandHarness: BenchHarness = {
           harness: "stagehand",
           row,
           logger,
+          sdk: "v4",
           stagehand: v4Result.stagehand,
-          v4Page: v4Result.page,
-          debugUrl: "",
-          // Neither is reachable from the v4 client: StagehandBrowser is an
-          // opaque handle with no browserbaseSessionId (#2517).
-          sessionUrl: "",
+          page: v4Result.page,
+          debugUrl: v4Result.debugUrl,
+          sessionUrl: v4Result.sessionUrl,
         },
         cleanup: async () => {
           try {
@@ -188,7 +198,7 @@ export const stagehandHarness: BenchHarness = {
             console.error(`Warning: Error closing v4 Stagehand for ${input.name}:`, closeError);
           }
           // `stagehand.close()` tears down the RPC client and context but leaves
-          // the browser it was handed running. initStagehand launched that
+          // the browser it was handed running. initStagehand acquired that
           // browser, so this harness owns closing it — without this every task
           // leaks a Chrome process (LOCAL) or a live Browserbase session, and
           // the run never exits once the suite finishes.
@@ -197,6 +207,9 @@ export const stagehandHarness: BenchHarness = {
           } catch (closeError) {
             console.error(`Warning: Error closing v4 browser for ${input.name}:`, closeError);
           }
+          // browser.close() on a connected handle disconnects; releasing the
+          // session is a separate, best-effort call.
+          await v4Result.endSession().catch(() => {});
         },
       };
     }
@@ -248,6 +261,7 @@ export const stagehandHarness: BenchHarness = {
         harness: "stagehand",
         row,
         logger,
+        sdk: "v3",
         v3: v3Result.v3,
         agent: v3Result.agent,
         page: v3Result.v3.context.pages()[0],

--- a/packages/evals/framework/benchRunner.ts
+++ b/packages/evals/framework/benchRunner.ts
@@ -67,23 +67,28 @@ export async function executeBenchTask(
     harnessCtx = startedHarness.ctx;
     const taskModule = await loadTaskModuleFromPath(task.filePath, task.name);
     if (taskModule.definition) {
-      const ctx = {
-        v3: harnessCtx.v3,
-        agent: harnessCtx.agent,
-        // Deterministic (act/extract/observe) tasks run on the v4 SDK: they
-        // receive the v4 client and its RPC-backed page in place of the
-        // Playwright page the v3 harness provides.
-        stagehand: harnessCtx.stagehand,
-        page: harnessCtx.v4Page ?? harnessCtx.page,
+      const common = {
         logger,
         input,
         modelName: input.modelName,
         debugUrl: harnessCtx.debugUrl,
         sessionUrl: harnessCtx.sessionUrl,
       };
+      // Deterministic (act/extract/observe) tasks run on the v4 SDK: they
+      // receive the v4 client and its RPC-backed page in place of the
+      // Playwright page the v3 harness provides.
+      const ctx =
+        harnessCtx.sdk === "v4"
+          ? { ...common, stagehand: harnessCtx.stagehand, page: harnessCtx.page }
+          : { ...common, v3: harnessCtx.v3, agent: harnessCtx.agent, page: harnessCtx.page };
       return withBenchSessionUrls((await taskModule.definition.fn(ctx)) as TaskResult, harnessCtx);
     }
     if (taskModule.legacyFn) {
+      if (harnessCtx.sdk === "v4") {
+        // Unreachable through category dispatch (legacy tasks only exist
+        // outside act/extract/observe), but the narrowing keeps it honest.
+        throw new EvalsError(`Legacy task ${task.name} cannot run on the v4 harness context.`);
+      }
       return withBenchSessionUrls(
         await taskModule.legacyFn({
           v3: harnessCtx.v3,

--- a/packages/evals/initStagehand.ts
+++ b/packages/evals/initStagehand.ts
@@ -8,18 +8,24 @@ import {
   type StagehandCreateOptions,
 } from "@browserbasehq/stagehand";
 import type { EvalLogger } from "./logger.js";
+import { launchRunnerProvidedBrowserbaseChrome } from "./core/targets/browserbase.js";
 import { resolveKey } from "./tui/welcomeStatus.js";
 
 export type InitStagehandArgs = {
   logger: EvalLogger;
   modelName: string;
-  systemPrompt?: string;
   environment: "LOCAL" | "BROWSERBASE";
 };
 
 export type StagehandInitResult = {
   stagehand: Stagehand;
   page: Page;
+  /** Session replay URL (Browserbase; empty for LOCAL). */
+  sessionUrl: string;
+  /** Live debugger URL (Browserbase, best-effort; empty for LOCAL). */
+  debugUrl: string;
+  /** Releases the Browserbase session (no-op for LOCAL). */
+  endSession: () => Promise<void>;
 };
 
 const PROVIDER_API_KEY_ENV: Record<string, string[]> = {
@@ -58,7 +64,6 @@ function createStagehandOnLog(logger: EvalLogger): (event: StagehandLogEvent) =>
 export async function initStagehand({
   logger,
   modelName,
-  systemPrompt,
   environment,
 }: InitStagehandArgs): Promise<StagehandInitResult> {
   const provider = modelName.includes("/") ? modelName.split("/")[0].toLowerCase() : undefined;
@@ -75,9 +80,12 @@ export async function initStagehand({
   // `browser` is a factory-built handle rather than a config object:
   // StagehandBrowser is branded (#2517), so an object literal cannot satisfy it.
   let browser;
+  let sessionUrl = "";
+  let debugUrl = "";
+  let endSession: () => Promise<void> = async () => {};
   if (environment === "BROWSERBASE") {
-    // Checked here rather than left to zod: BrowserbaseLaunchOptions requires a
-    // non-empty key, so an absent one would surface as a parse error instead.
+    // Checked here rather than left to zod: BrowserbaseConnectOptions requires
+    // a non-empty key, so an absent one would surface as a parse error instead.
     const browserbaseApiKey =
       resolveKey("BROWSERBASE_API_KEY").value || resolveKey("BB_API_KEY").value;
     if (!browserbaseApiKey) {
@@ -85,16 +93,26 @@ export async function initStagehand({
         "Stagehand init: BROWSERBASE_API_KEY or BB_API_KEY is required for BROWSERBASE runs",
       );
     }
-    // Passed explicitly, matching initV3 and core/targets/browserbase: the
-    // Browserbase SDK does not read BROWSERBASE_PROJECT_ID from the
-    // environment, and omitting it lands sessions in the key's default
-    // project — the wrong one for keys that own several.
-    const projectId =
-      resolveKey("BROWSERBASE_PROJECT_ID").value || resolveKey("BB_PROJECT_ID").value;
-    browser = await browserbase.launch({
-      apiKey: browserbaseApiKey,
-      ...(projectId ? { projectId } : {}),
-    });
+    // The session is created first and attached with connect() rather than
+    // launched through the SDK: StagehandBrowser is an opaque branded handle
+    // with no browserbaseSessionId (#2517), so launching would leave the
+    // harness without the session/debug URLs that TaskResults and the
+    // Braintrust replay click-through report. The shared creator also passes
+    // the project id explicitly (the Browserbase SDK does not read
+    // BROWSERBASE_PROJECT_ID from the environment).
+    const session = await launchRunnerProvidedBrowserbaseChrome();
+    sessionUrl = session.sessionUrl;
+    debugUrl = session.debugUrl ?? "";
+    endSession = session.cleanup;
+    try {
+      browser = await browserbase.connect({
+        apiKey: browserbaseApiKey,
+        sessionId: session.sessionId,
+      });
+    } catch (error) {
+      await endSession().catch(() => {});
+      throw error;
+    }
   } else {
     browser = await localBrowser.launch({ headless: false });
   }
@@ -110,11 +128,11 @@ export async function initStagehand({
       // pass while measuring nothing.
       selfHeal: true,
       model: { modelName, apiKey } as NonNullable<StagehandCreateOptions["model"]>,
-      ...(systemPrompt ? { systemPrompt } : {}),
       logging: { onLog: createStagehandOnLog(logger) },
     });
   } catch (error) {
     await browser.close().catch(() => {});
+    await endSession().catch(() => {});
     throw error;
   }
 
@@ -130,16 +148,15 @@ export async function initStagehand({
   } catch (error) {
     await stagehand.close().catch(() => {});
     await browser.close().catch(() => {});
+    await endSession().catch(() => {});
     throw error;
   }
 
-  // No sessionUrl: StagehandBrowser is an opaque branded handle and does not
-  // expose the Browserbase session id (#2517). To restore the Braintrust
-  // click-through to a session replay, create the session first (as
-  // core/targets/browserbase.ts does) and attach with
-  // `browserbase.connect({ sessionId })`.
   return {
     stagehand,
     page,
+    sessionUrl,
+    debugUrl,
+    endSession,
   };
 }

--- a/packages/evals/tests/framework/benchRunner.test.ts
+++ b/packages/evals/tests/framework/benchRunner.test.ts
@@ -77,12 +77,13 @@ describe("bench runner", () => {
     );
 
     // A non-deterministic category: act/extract/observe route to the v4
-    // client, and legacy tasks with v3 session URLs only exist outside them.
+    // client, and legacy v3 tasks only exist under agent/ now that the
+    // combination and experimental suites are gone.
     const task: DiscoveredTask = {
-      name: "combination/session_url_task",
+      name: "agent/session_url_task",
       tier: "bench",
-      primaryCategory: "combination",
-      categories: ["combination"],
+      primaryCategory: "agent",
+      categories: ["agent"],
       tags: [],
       filePath: taskFile,
       isLegacy: true,
@@ -124,10 +125,10 @@ describe("bench runner", () => {
     );
 
     const task: DiscoveredTask = {
-      name: "combination/thrown_task",
+      name: "agent/thrown_task",
       tier: "bench",
-      primaryCategory: "combination",
-      categories: ["combination"],
+      primaryCategory: "agent",
+      categories: ["agent"],
       tags: [],
       filePath: taskFile,
       isLegacy: true,


### PR DESCRIPTION
## Summary

Review follow-up for #2570, implemented. Three fixes and one test cleanup; only functional change is the session-URL restoration.

- **Session/debug URLs on the v4 path** (the one functional gap): `initStagehand` now creates the Browserbase session first via the shared `launchRunnerProvidedBrowserbaseChrome()` creator and attaches with `browserbase.connect({ apiKey, sessionId })`, instead of `browserbase.launch` (which hides the session id behind the opaque `StagehandBrowser` handle, #2517). `sessionUrl`/`debugUrl` flow into every TaskResult and the Braintrust replay click-through again, and the session is explicitly released (`REQUEST_RELEASE`) on cleanup and on every init failure path — `browser.close()` on a connected handle only disconnects.
- **`BenchHarnessContext` → discriminated union** (`sdk: "v4" | "v3"`): the runner narrows on the discriminant instead of probing five optional fields; the `v4Page ?? page` fallback is gone, and a legacy task reaching a v4 context is an explicit `EvalsError` instead of `v3: undefined`.
- **Dead `systemPrompt` parameter dropped** from `initStagehand` — nothing passes it, and the v3 equivalent is agent-only.
- **Test fixtures off the deleted `combination` category** → `agent`, the only non-deterministic category left after #2587.

Not touched, for reviewer attention on #2570 itself: the `EVAL_VERIFIER_MODEL` / keyless-provider and Claude Code result-parsing commits are orthogonal to running a/e/o on v4 (they only affect the agent/external-harness grading paths and change nothing unless the env var is set) — candidates for splitting into their own PR.

## Verification

- typecheck, fmt, and 410/410 unit tests green
- LOCAL end-to-end through the built CLI: `run dropdown -e local -t 1 -m google/gemini-2.5-flash` → **1/1 passed** (first full v4 pass through the harness; requires `packages/extension` built for the local launch's extension preload)
- BROWSERBASE connect path not exercised here (no key in this environment) — needs one `run dropdown -e browserbase -t 1` to confirm sessionUrl lands in results

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores session and debug URLs for v4 eval runs by creating Browserbase sessions first and connecting, and simplifies the harness context with an explicit v3/v4 split for clearer task handling.

- **Bug Fixes**
  - Restored `sessionUrl` and `debugUrl` for v4 tasks. `initStagehand` now creates the session via `launchRunnerProvidedBrowserbaseChrome` and attaches with `browserbase.connect({ apiKey, sessionId })`.
  - Releases the session on cleanup and on init failure paths.

- **Refactors**
  - `BenchHarnessContext` is now a discriminated union (`sdk: "v4" | "v3"`). Removes `v4Page ?? page` fallback and throws on legacy tasks reaching the v4 context.
  - Dropped the unused `systemPrompt` from `initStagehand` in `@browserbasehq/stagehand` v4 flow.
  - Moved legacy test fixtures from `combination` to `agent`.

<sup>Written for commit e31cb7209ce71783f99cfd18fe88b65abca6cb75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

