### PR TITLE
evals: make agent mounting part of tool surfaces

### DIFF
--- a/packages/evals/core/contracts/tool.ts
+++ b/packages/evals/core/contracts/tool.ts
@@ -142,11 +142,12 @@ export interface ToolStartResult {
    */
   agentMount?: AgentMount;
   /**
-   * Best-effort terminal state captured before cleanup. Implementations must
-   * swallow per-field failures and must not throw.
+   * Best-effort evidence captured from the current surface state. Harnesses may
+   * call this after individual actions and once more at the end of a run.
+   * Implementations must swallow per-field failures and must not throw.
    */
-  captureFinalState?: () => Promise<TerminalArtifact>;
-  /** Releases the runtime; `captureFinalState` is invalid after this resolves. */
+  captureEvidence?: () => Promise<TerminalArtifact>;
+  /** Releases the runtime; `captureEvidence` is invalid after this resolves. */
   cleanup: () => Promise<void>;
   metadata: {
     environment: EnvironmentName;

--- a/packages/evals/core/contracts/tool.ts
+++ b/packages/evals/core/contracts/tool.ts
@@ -146,7 +146,7 @@ export interface ToolStartResult {
    * call this after individual actions and once more at the end of a run.
    * Implementations must swallow per-field failures and must not throw.
    */
-  captureEvidence?: () => Promise<TerminalArtifact>;
+  captureEvidence?: () => Promise<SurfaceEvidence>;
   /** Releases the runtime; `captureEvidence` is invalid after this resolves. */
   cleanup: () => Promise<void>;
   metadata: {
@@ -189,14 +189,12 @@ export interface AgentRunToolSpec {
 }
 
 /**
- * Harness-observed terminal state of a run, captured through the surface
- * itself after the agent finishes. This is what grounds grading in the task
- * artifact: the verifier's final-screenshot anchor comes from the harness's
- * own observation of the page, not from whatever image the agent chose to
- * return (code surfaces stringify tool results, so agent-returned images
- * don't exist there at all).
+ * Harness-observed evidence from the surface at a point in time. Harnesses can
+ * attach it to an individual action or use it as the run's final observation.
+ * It grounds grading in state observed independently of whatever output the
+ * agent chose to return.
  */
-export interface TerminalArtifact {
+export interface SurfaceEvidence {
   screenshot?: Buffer;
   url?: string;
 }

--- a/packages/evals/core/contracts/tool.ts
+++ b/packages/evals/core/contracts/tool.ts
@@ -135,6 +135,18 @@ export interface ToolStartInput {
 
 export interface ToolStartResult {
   session: CoreSession;
+  /**
+   * Optional agent-facing binding for this running surface. `via` describes
+   * delivery to the agent and is independent of `CoreTool.surface`; for
+   * example, a code surface may be delivered through MCP or a CLI wrapper.
+   */
+  agentMount?: AgentMount;
+  /**
+   * Best-effort terminal state captured before cleanup. Implementations must
+   * swallow per-field failures and must not throw.
+   */
+  captureFinalState?: () => Promise<TerminalArtifact>;
+  /** Releases the runtime; `captureFinalState` is invalid after this resolves. */
   cleanup: () => Promise<void>;
   metadata: {
     environment: EnvironmentName;
@@ -155,33 +167,24 @@ export interface CoreTool {
 }
 
 /**
- * The MCP server / tool name a `code_handles` exposure is mounted under by an
- * agent harness. Surfaces reference the tool name in their prompt
- * instructions; the harness mounts the single "run" tool under the server.
+ * The MCP server / tool name used when an agent harness wraps handles in a
+ * code-execution tool.
  */
-export const LLM_RUN_TOOL_SERVER = "stagehand_browser";
-export const LLM_RUN_TOOL_NAME = `mcp__${LLM_RUN_TOOL_SERVER}__run`;
+export const AGENT_RUN_TOOL_SERVER = "stagehand_browser";
+export const AGENT_RUN_TOOL_NAME = `mcp__${AGENT_RUN_TOOL_SERVER}__run`;
+export const AGENT_RUN_TOOL_RESERVED_HANDLES = ["startUrl", "task", "console"] as const;
 
 /**
- * `code_handles` only: the surface-specific pieces of the harness's single
- * "run" tool. The harness owns the tool mechanics (timeouts, result
- * stringification, logging); the surface owns the copy the model sees and
- * the values bound into the snippet scope.
+ * Surface-specific copy for the harness's code-execution tool. The harness
+ * owns mechanics and task bindings; the surface owns what the agent sees.
  */
-export interface LLMRunToolSpec {
+export interface AgentRunToolSpec {
   /** MCP tool description shown to the model. */
   description: string;
   /** Description of the tool's `code` parameter. */
   codeParamDescription: string;
-  /** Denial message when the model requests a tool outside the allowlist. */
+  /** Message from the harness-owned tool allowlist when access is denied. */
   denyMessage: string;
-  /** Value bound to `task` in the snippet scope. */
-  task: Record<string, unknown>;
-  /**
-   * Value bound to `console` in the snippet scope. Defaults to the
-   * harness's logger-backed console when omitted.
-   */
-  console?: Pick<Console, "log" | "warn" | "error">;
 }
 
 /**
@@ -198,35 +201,30 @@ export interface TerminalArtifact {
 }
 
 /**
- * A harness-agnostic description of how an agent harness (claude_code,
- * codex, ...) mounts a tool surface. Each surface implements this once;
- * harness drivers keep exactly three mount points and no surface knowledge:
- * - `code_handles` -> wrap `handles` in the harness's single run tool
- * - `mcp_server`   -> mount `mcpServers` config directly
- * - `cli`          -> spawn `command` with env
+ * How an agent harness reaches an already-running surface. This is independent
+ * of `CoreTool.surface`; harnesses switch on `via` and need no surface-specific
+ * mounting logic.
  */
-export interface LLMExposure {
-  kind: "code_handles" | "mcp_server" | "cli";
-  /**
-   * code_handles: named values placed in the run-tool snippet scope. The
-   * harness derives the snippet argument names from these keys (plus
-   * startUrl, task, and console). Names, not order, bind the values.
-   */
-  handles?: Record<string, unknown>;
-  promptInstructions: string;
-  /** mcp_server: mounted as-is by the harness. */
-  mcpServers?: Record<string, unknown>;
-  /** cli: spawned with env by the harness. */
-  command?: { bin: string; env: Record<string, string> };
-  /** code_handles: surface-specific run-tool copy and snippet bindings. */
-  runTool?: LLMRunToolSpec;
-  /** Extra surface facts (session URLs etc.) that flow through to the harness. */
-  metadata?: Record<string, unknown>;
-  /**
-   * Capture the terminal page state (screenshot + URL) for artifact-grounded
-   * grading. Called by the harness after the agent finishes, before cleanup.
-   * Best-effort: implementations should swallow per-field failures.
-   */
-  captureFinalState?: () => Promise<TerminalArtifact>;
-  cleanup: () => Promise<void>;
-}
+export type AgentMount = { promptInstructions: string } & (
+  | {
+      via: "handles";
+      /**
+       * Named values placed in snippet scope. Names, not order, bind values.
+       * `AGENT_RUN_TOOL_RESERVED_HANDLES` are injected by the harness and may
+       * not appear here.
+       */
+      handles: Record<string, unknown>;
+      runTool: AgentRunToolSpec;
+    }
+  | { via: "mcp"; mcpServers: Record<string, unknown> }
+  | {
+      via: "cli";
+      command: {
+        bin: string;
+        args?: string[];
+        cwd?: string;
+        /** Extra variables merged over the harness environment. */
+        env?: Record<string, string>;
+      };
+    }
+);

--- a/packages/evals/core/contracts/tool.ts
+++ b/packages/evals/core/contracts/tool.ts
@@ -1,3 +1,4 @@
+import type { ProbeEvidence } from "stagehand-v3";
 import type { EvalLogger } from "../../logger.js";
 import type { ActionTarget, FocusedTarget, TargetKind, WaitSpec } from "./targets.js";
 import type { PageRepresentation, RepresentationOpts } from "./representation.js";
@@ -146,7 +147,7 @@ export interface ToolStartResult {
    * call this after individual actions and once more at the end of a run.
    * Implementations must swallow per-field failures and must not throw.
    */
-  captureEvidence?: () => Promise<SurfaceEvidence>;
+  captureEvidence?: () => Promise<ProbeEvidence>;
   /** Releases the runtime; `captureEvidence` is invalid after this resolves. */
   cleanup: () => Promise<void>;
   metadata: {
@@ -186,17 +187,6 @@ export interface AgentRunToolSpec {
   codeParamDescription: string;
   /** Message from the harness-owned tool allowlist when access is denied. */
   denyMessage: string;
-}
-
-/**
- * Harness-observed evidence from the surface at a point in time. Harnesses can
- * attach it to an individual action or use it as the run's final observation.
- * It grounds grading in state observed independently of whatever output the
- * agent chose to return.
- */
-export interface SurfaceEvidence {
-  screenshot?: Buffer;
-  url?: string;
 }
 
 /**

--- a/packages/evals/tests/core/tool-contract.test.ts
+++ b/packages/evals/tests/core/tool-contract.test.ts
@@ -8,6 +8,7 @@ import type {
 
 describe("tool surface contract", () => {
   it("keeps native surface and agent delivery independent", async () => {
+    const screenshot = Buffer.from("surface screenshot");
     const cliMount = {
       via: "cli",
       promptInstructions: "Use the wrapper command.",
@@ -17,7 +18,11 @@ describe("tool surface contract", () => {
     const runningCodeSurface: ToolStartResult = {
       session: {} as CoreSession,
       agentMount: cliMount,
-      captureEvidence: async () => ({ url: "https://example.com" }),
+      captureEvidence: async () => ({
+        screenshot,
+        url: "https://example.com",
+        ariaTree: "- document\n  - heading: Example",
+      }),
       cleanup: async () => {},
       metadata: {
         environment: "local",
@@ -39,7 +44,9 @@ describe("tool surface contract", () => {
     expect(codeSurface.surface).toBe("code");
     expect(runningCodeSurface.agentMount?.via).toBe("cli");
     await expect(runningCodeSurface.captureEvidence?.()).resolves.toEqual({
+      screenshot,
       url: "https://example.com",
+      ariaTree: "- document\n  - heading: Example",
     });
   });
 

--- a/packages/evals/tests/core/tool-contract.test.ts
+++ b/packages/evals/tests/core/tool-contract.test.ts
@@ -7,7 +7,7 @@ import type {
 } from "../../core/contracts/tool.js";
 
 describe("tool surface contract", () => {
-  it("keeps native surface and agent delivery independent", () => {
+  it("keeps native surface and agent delivery independent", async () => {
     const cliMount = {
       via: "cli",
       promptInstructions: "Use the wrapper command.",
@@ -17,6 +17,7 @@ describe("tool surface contract", () => {
     const runningCodeSurface: ToolStartResult = {
       session: {} as CoreSession,
       agentMount: cliMount,
+      captureEvidence: async () => ({ url: "https://example.com" }),
       cleanup: async () => {},
       metadata: {
         environment: "local",
@@ -37,6 +38,9 @@ describe("tool surface contract", () => {
 
     expect(codeSurface.surface).toBe("code");
     expect(runningCodeSurface.agentMount?.via).toBe("cli");
+    await expect(runningCodeSurface.captureEvidence?.()).resolves.toEqual({
+      url: "https://example.com",
+    });
   });
 
   it("describes injected handles without harness-owned task bindings", () => {

--- a/packages/evals/tests/core/tool-contract.test.ts
+++ b/packages/evals/tests/core/tool-contract.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import type {
+  AgentMount,
+  CoreSession,
+  CoreTool,
+  ToolStartResult,
+} from "../../core/contracts/tool.js";
+
+describe("tool surface contract", () => {
+  it("keeps native surface and agent delivery independent", () => {
+    const cliMount = {
+      via: "cli",
+      promptInstructions: "Use the wrapper command.",
+      command: { bin: "stagehand-browser", env: {} },
+    } satisfies AgentMount;
+
+    const runningCodeSurface: ToolStartResult = {
+      session: {} as CoreSession,
+      agentMount: cliMount,
+      cleanup: async () => {},
+      metadata: {
+        environment: "local",
+        browserOwnership: "tool",
+        connectionMode: "launch",
+      },
+    };
+
+    const codeSurface: CoreTool = {
+      id: "playwright_code",
+      surface: "code",
+      family: "playwright",
+      supportedStartupProfiles: [],
+      supportedCapabilities: [],
+      supportedTargetKinds: [],
+      start: async () => runningCodeSurface,
+    };
+
+    expect(codeSurface.surface).toBe("code");
+    expect(runningCodeSurface.agentMount?.via).toBe("cli");
+  });
+
+  it("describes injected handles without harness-owned task bindings", () => {
+    const mount = {
+      via: "handles",
+      promptInstructions: "Use the run tool.",
+      handles: { page: {} },
+      runTool: {
+        description: "Run browser code.",
+        codeParamDescription: "JavaScript to execute.",
+        denyMessage: "Use the run tool.",
+      },
+    } satisfies AgentMount;
+
+    expect(mount.via).toBe("handles");
+  });
+
+  it("requires delivery-specific fields at compile time", () => {
+    // @ts-expect-error CLI mounts require a command.
+    const invalidMount: AgentMount = {
+      via: "cli",
+      promptInstructions: "Use the CLI.",
+    };
+
+    expect(invalidMount.via).toBe("cli");
+  });
+});


### PR DESCRIPTION
## Summary

- keep the existing `CoreTool` abstraction as the canonical tool-surface definition
- attach optional agent delivery and final-state capture to `ToolStartResult`, preserving one runtime lifecycle
- replace `LLMExposure` with a lifecycle-free `AgentMount` value using the independent `via: handles | mcp | cli` delivery axis
- keep native `CoreTool.surface` independent from agent delivery, so a code surface may be wrapped by MCP or CLI
- leave task, start URL, and default console binding with the harness
- define reserved harness bindings, CLI environment merge semantics, and capture-before-cleanup ordering

This is stacked on #2590. The revision deliberately defers broad naming/registry churn so the contract change remains a focused two-file diff.

## Verification

- `pnpm --filter @browserbasehq/stagehand-evals typecheck`
- `pnpm --filter @browserbasehq/stagehand-evals test:unit` (52 files, 413 tests)
- focused formatting check passed
- reviewed independently with Claude Opus 5 against the inline repository diff