### PR TITLE
fix(evals): clean up v4 run resources

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:unit": "vitest run rules/ast-grep scripts",
     "test:integration": "tsx scripts/test-integration.ts",
     "build": "turbo run build",
+    "build:cli": "turbo run build:cli",
     "generate:python": "uv --directory packages/sdk-python run --locked python scripts/generate.py",
     "generate:go": "go -C packages/sdk-go generate ./...",
     "build:wheel": "uv --directory packages/sdk-python run --locked python scripts/build.py"

--- a/packages/evals/core/runtime/coreDeps.ts
+++ b/packages/evals/core/runtime/coreDeps.ts
@@ -1,8 +1,16 @@
-import path from "node:path";
 import { createRequire } from "node:module";
-import { getRepoRootDir } from "../../runtimePaths.js";
+import path from "node:path";
+import type { ReadStream } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 type BrowserbaseConstructor = new (options: { apiKey: string }) => {
+  extensions: {
+    create: (payload: { file: ReadStream }) => Promise<{ id: string }>;
+    delete: (
+      extensionId: string,
+      options?: { headers?: Record<string, string | null> },
+    ) => Promise<unknown>;
+  };
   sessions: {
     create: (payload: Record<string, unknown>) => Promise<unknown>;
     update: (sessionId: string, payload: Record<string, unknown>) => Promise<unknown>;
@@ -24,26 +32,24 @@ type WsModule = {
   OPEN?: number;
 };
 
-let coreRequire: ReturnType<typeof createRequire> | null = null;
+// Resolve from this package's own dependency tree. Lazy requires keep these
+// CommonJS dependencies out of surfaces that never touch Browserbase or raw CDP.
+const evalsRequire = createRequire(import.meta.url);
 
-function requireFromCorePackage(specifier: string): unknown {
-  if (!coreRequire) {
-    const packageJsonPath = path.join(getRepoRootDir(), "packages", "core", "package.json");
-    coreRequire = createRequire(packageJsonPath);
-  }
-
-  return coreRequire(specifier);
+export function resolveStagehandExtensionArchivePath(): string {
+  const stagehandEntry = fileURLToPath(import.meta.resolve("@browserbasehq/stagehand"));
+  return path.join(path.dirname(stagehandEntry), "assets", "stagehand-extension.zip");
 }
 
 export function loadBrowserbaseSdk(): BrowserbaseConstructor {
-  const module = requireFromCorePackage("@browserbasehq/sdk") as {
+  const module = evalsRequire("@browserbasehq/sdk") as {
     default?: BrowserbaseConstructor;
   } & BrowserbaseConstructor;
   return module.default ?? (module as BrowserbaseConstructor);
 }
 
 export function loadWsModule(): WsModule {
-  const module = requireFromCorePackage("ws") as {
+  const module = evalsRequire("ws") as {
     default?: WsModule;
   } & WsModule;
   return module.default ?? (module as WsModule);

--- a/packages/evals/core/targets/browserbase.ts
+++ b/packages/evals/core/targets/browserbase.ts
@@ -1,6 +1,100 @@
-import { loadBrowserbaseSdk } from "../runtime/coreDeps.js";
+import { createReadStream } from "node:fs";
+import { AsyncLocalStorage } from "node:async_hooks";
+import { registerActiveRunCleanup } from "../../framework/activeRunCleanup.js";
+import { loadBrowserbaseSdk, resolveStagehandExtensionArchivePath } from "../runtime/coreDeps.js";
 
 const DEFAULT_VIEWPORT = { width: 1288, height: 711 };
+
+type BrowserbaseClient = InstanceType<ReturnType<typeof loadBrowserbaseSdk>>;
+
+type ExtensionScope = {
+  provision?: Promise<{ extensionId: string; deleteUpload: () => Promise<void> }>;
+  cleanupPromise?: Promise<void>;
+  unregisterCleanup?: () => void;
+  activeSessions: number;
+  drained?: Promise<void>;
+  resolveDrained?: () => void;
+};
+
+const extensionScopeStorage = new AsyncLocalStorage<ExtensionScope>();
+
+async function uploadStagehandExtension(
+  bb: BrowserbaseClient,
+): Promise<{ extensionId: string; deleteUpload: () => Promise<void> }> {
+  const uploaded = await bb.extensions.create({
+    file: createReadStream(resolveStagehandExtensionArchivePath()),
+  });
+  const extensionId = uploaded.id.trim();
+  if (!extensionId) {
+    throw new Error("Browserbase extension upload returned an empty extension ID");
+  }
+
+  let deletePromise: Promise<void> | undefined;
+  return {
+    extensionId,
+    deleteUpload: () => {
+      deletePromise ??= bb.extensions
+        .delete(extensionId, { headers: { "Content-Type": null } })
+        .then((): undefined => undefined)
+        .catch((): undefined => undefined);
+      return deletePromise;
+    },
+  };
+}
+
+async function cleanupExtensionScope(scope: ExtensionScope): Promise<void> {
+  scope.cleanupPromise ??= (async () => {
+    if (scope.activeSessions > 0) {
+      scope.drained ??= new Promise<void>((resolve) => {
+        scope.resolveDrained = resolve;
+      });
+      await scope.drained;
+    }
+    const provisioned = await scope.provision?.catch((): undefined => undefined);
+    await provisioned?.deleteUpload();
+    scope.unregisterCleanup?.();
+  })();
+  await scope.cleanupPromise;
+}
+
+/** Reuses one uploaded extension across every Browserbase session in a run. */
+export async function withBrowserbaseExtensionScope<T>(fn: () => Promise<T>): Promise<T> {
+  if (extensionScopeStorage.getStore()) return fn();
+
+  const scope: ExtensionScope = { activeSessions: 0 };
+  try {
+    return await extensionScopeStorage.run(scope, fn);
+  } finally {
+    await cleanupExtensionScope(scope);
+  }
+}
+
+async function acquireStagehandExtension(
+  bb: BrowserbaseClient,
+): Promise<{ extensionId: string; release: () => Promise<void> }> {
+  const scope = extensionScopeStorage.getStore();
+  if (!scope) {
+    const provisioned = await uploadStagehandExtension(bb);
+    return { extensionId: provisioned.extensionId, release: provisioned.deleteUpload };
+  }
+
+  if (!scope.provision) {
+    scope.provision = uploadStagehandExtension(bb);
+    scope.unregisterCleanup = registerActiveRunCleanup(() => cleanupExtensionScope(scope));
+  }
+  const provisioned = await scope.provision;
+  scope.activeSessions += 1;
+  let released = false;
+  return {
+    extensionId: provisioned.extensionId,
+    release: async () => {
+      if (released) return;
+      released = true;
+      scope.activeSessions -= 1;
+      if (scope.activeSessions === 0) scope.resolveDrained?.();
+    },
+  };
+}
 
 function loadBrowserbaseCredentials(): { apiKey: string; projectId?: string } {
   const apiKey = process.env.BROWSERBASE_API_KEY || process.env.BB_API_KEY || "";
@@ -18,14 +112,19 @@ export async function launchRunnerProvidedBrowserbaseChrome(): Promise<{
   sessionId: string;
   sessionUrl: string;
   debugUrl?: string;
+  extensionId: string;
   cleanup: () => Promise<void>;
 }> {
   const { apiKey, projectId } = loadBrowserbaseCredentials();
   const Browserbase = loadBrowserbaseSdk();
   const bb = new Browserbase({ apiKey });
 
+  const extension = await acquireStagehandExtension(bb);
+  const { extensionId } = extension;
+
   const createPayload: Record<string, unknown> = {
     ...(projectId ? { projectId } : {}),
+    extensionId,
     browserSettings: {
       viewport: DEFAULT_VIEWPORT,
     },
@@ -39,12 +138,42 @@ export async function launchRunnerProvidedBrowserbaseChrome(): Promise<{
     createPayload.region = process.env.BROWSERBASE_REGION;
   }
 
-  const created = (await bb.sessions.create(createPayload)) as {
+  const sessionPromise = bb.sessions.create(createPayload) as Promise<{
     id?: string;
     connectUrl?: string;
+  }>;
+  let created: { id?: string; connectUrl?: string } | undefined;
+  let cleanupPromise: Promise<void> | undefined;
+  const cleanupOwnedResources = (): Promise<void> => {
+    cleanupPromise ??= (async () => {
+      const session = created ?? (await sessionPromise.catch((): undefined => undefined));
+      if (session?.id) {
+        await bb.sessions
+          .update(session.id, {
+            status: "REQUEST_RELEASE",
+            ...(projectId ? { projectId } : {}),
+          })
+          .catch(() => {});
+      }
+      await extension.release();
+    })();
+    return cleanupPromise;
+  };
+  const unregisterCleanup = registerActiveRunCleanup(cleanupOwnedResources);
+  const cleanup = async (): Promise<void> => {
+    await cleanupOwnedResources();
+    unregisterCleanup();
   };
 
+  try {
+    created = await sessionPromise;
+  } catch (error) {
+    await cleanup();
+    throw error;
+  }
+
   if (!created.id || !created.connectUrl) {
+    await cleanup();
     throw new Error("Browserbase session creation returned an unexpected shape.");
   }
 
@@ -65,15 +194,7 @@ export async function launchRunnerProvidedBrowserbaseChrome(): Promise<{
     sessionId: created.id,
     sessionUrl: `https://www.browserbase.com/sessions/${created.id}`,
     debugUrl,
-    cleanup: async () => {
-      try {
-        await bb.sessions.update(created.id!, {
-          status: "REQUEST_RELEASE",
-          ...(projectId ? { projectId } : {}),
-        });
-      } catch {
-        // best-effort only
-      }
-    },
+    extensionId,
+    cleanup,
   };
 }

--- a/packages/evals/core/targets/browserbase.ts
+++ b/packages/evals/core/targets/browserbase.ts
@@ -4,6 +4,7 @@ import { registerActiveRunCleanup } from "../../framework/activeRunCleanup.js";
 import { loadBrowserbaseSdk, resolveStagehandExtensionArchivePath } from "../runtime/coreDeps.js";
 
 const DEFAULT_VIEWPORT = { width: 1288, height: 711 };
+const EXTENSION_SCOPE_DRAIN_TIMEOUT_MS = 5_000;
 
 type BrowserbaseClient = InstanceType<ReturnType<typeof loadBrowserbaseSdk>>;
 
@@ -48,7 +49,14 @@ async function cleanupExtensionScope(scope: ExtensionScope): Promise<void> {
       scope.drained ??= new Promise<void>((resolve) => {
         scope.resolveDrained = resolve;
       });
-      await scope.drained;
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      await Promise.race([
+        scope.drained,
+        new Promise<void>((resolve) => {
+          timeout = setTimeout(resolve, EXTENSION_SCOPE_DRAIN_TIMEOUT_MS);
+        }),
+      ]);
+      if (timeout) clearTimeout(timeout);
     }
     const provisioned = await scope.provision?.catch((): undefined => undefined);
     await provisioned?.deleteUpload();
@@ -79,8 +87,12 @@ async function acquireStagehandExtension(
   }
 
   if (!scope.provision) {
-    scope.provision = uploadStagehandExtension(bb);
-    scope.unregisterCleanup = registerActiveRunCleanup(() => cleanupExtensionScope(scope));
+    const provision = uploadStagehandExtension(bb);
+    scope.provision = provision;
+    scope.unregisterCleanup ??= registerActiveRunCleanup(() => cleanupExtensionScope(scope));
+    provision.catch(() => {
+      if (scope.provision === provision) scope.provision = undefined;
+    });
   }
   const provisioned = await scope.provision;
   scope.activeSessions += 1;
@@ -90,7 +102,7 @@ async function acquireStagehandExtension(
     release: async () => {
       if (released) return;
       released = true;
-      scope.activeSessions -= 1;
+      scope.activeSessions = Math.max(0, scope.activeSessions - 1);
       if (scope.activeSessions === 0) scope.resolveDrained?.();
     },
   };
@@ -167,9 +179,9 @@ export async function launchRunnerProvidedBrowserbaseChrome(): Promise<{
 
   try {
     created = await sessionPromise;
-  } catch (error) {
+  } catch {
     await cleanup();
-    throw error;
+    throw new Error("Browserbase session creation failed.");
   }
 
   if (!created.id || !created.connectUrl) {

--- a/packages/evals/framework/activeRunCleanup.ts
+++ b/packages/evals/framework/activeRunCleanup.ts
@@ -20,3 +20,13 @@ export async function cleanupActiveRunResources(): Promise<void> {
   const cleanups = [...activeRunCleanups.values()];
   await Promise.allSettled(cleanups.map((cleanup) => cleanup()));
 }
+
+export async function abortActiveRun(
+  controller: AbortController,
+  mode: "cooperative" | "aggressive",
+): Promise<void> {
+  // AbortController keeps the first reason forever. A second Escape therefore
+  // cannot upgrade a cooperative abort by calling abort("aggressive") again.
+  if (!controller.signal.aborted) controller.abort(mode);
+  if (mode === "aggressive") await cleanupActiveRunResources();
+}

--- a/packages/evals/framework/activeRunCleanup.ts
+++ b/packages/evals/framework/activeRunCleanup.ts
@@ -17,8 +17,9 @@ export function registerActiveRunCleanup(cleanup: () => Promise<void>): () => vo
 }
 
 export async function cleanupActiveRunResources(): Promise<void> {
-  const cleanups = [...activeRunCleanups.values()];
-  await Promise.allSettled(cleanups.map((cleanup) => cleanup()));
+  const cleanups = [...activeRunCleanups.entries()];
+  for (const [key] of cleanups) activeRunCleanups.delete(key);
+  await Promise.allSettled(cleanups.map(([, cleanup]) => cleanup()));
 }
 
 export async function abortActiveRun(

--- a/packages/evals/framework/activeRunCleanup.ts
+++ b/packages/evals/framework/activeRunCleanup.ts
@@ -19,7 +19,7 @@ export function registerActiveRunCleanup(cleanup: () => Promise<void>): () => vo
 export async function cleanupActiveRunResources(): Promise<void> {
   const cleanups = [...activeRunCleanups.entries()];
   for (const [key] of cleanups) activeRunCleanups.delete(key);
-  await Promise.allSettled(cleanups.map(([, cleanup]) => cleanup()));
+  await Promise.allSettled(cleanups.map(([, cleanup]) => Promise.resolve().then(cleanup)));
 }
 
 export async function abortActiveRun(

--- a/packages/evals/framework/benchHarness.ts
+++ b/packages/evals/framework/benchHarness.ts
@@ -191,26 +191,9 @@ export const stagehandHarness: BenchHarness = {
           debugUrl: v4Result.debugUrl,
           sessionUrl: v4Result.sessionUrl,
         },
-        cleanup: async () => {
-          try {
-            await v4Result.stagehand.close();
-          } catch (closeError) {
-            console.error(`Warning: Error closing v4 Stagehand for ${input.name}:`, closeError);
-          }
-          // `stagehand.close()` tears down the RPC client and context but leaves
-          // the browser it was handed running. initStagehand acquired that
-          // browser, so this harness owns closing it — without this every task
-          // leaks a Chrome process (LOCAL) or a live Browserbase session, and
-          // the run never exits once the suite finishes.
-          try {
-            await v4Result.stagehand.browser.close();
-          } catch (closeError) {
-            console.error(`Warning: Error closing v4 browser for ${input.name}:`, closeError);
-          }
-          // browser.close() on a connected handle disconnects; releasing the
-          // session is a separate, best-effort call.
-          await v4Result.endSession().catch(() => {});
-        },
+        // Registered as soon as initStagehand owns the browser, so Ctrl+C can
+        // release a session even while client/page initialization is in flight.
+        cleanup: v4Result.cleanup,
       };
     }
 

--- a/packages/evals/framework/runner.ts
+++ b/packages/evals/framework/runner.ts
@@ -39,6 +39,7 @@ export { inferEffectiveBenchCategory, resolveBenchModelEntries } from "./benchPl
 export type { Harness } from "./benchTypes.js";
 export { cleanupActiveRunResources } from "./activeRunCleanup.js";
 import { resolveDefaultCoreStartupProfile } from "./context.js";
+import { withBrowserbaseExtensionScope } from "../core/targets/browserbase.js";
 
 export interface RunProgressEvent {
   type: "planned" | "started" | "passed" | "failed" | "error";
@@ -373,80 +374,82 @@ export async function runEvals(options: RunEvalsOptions): Promise<RunEvalsResult
     void onAggressiveAbort();
   });
 
-  const evalResult = await Eval(
-    braintrustProjectName,
-    {
-      experimentName,
-      metadata: {
-        environment,
-        tier: hasCoreOnly ? "core" : "bench",
-        ...(effectiveCoreToolSurface && {
-          toolSurface: effectiveCoreToolSurface,
-        }),
-        ...(effectiveCoreStartupProfile && {
-          startupProfile: effectiveCoreStartupProfile,
-        }),
-        ...(effectiveBenchHarness && { harness: effectiveBenchHarness }),
-        ...(options.provider && { provider: options.provider }),
-        ...(options.modelOverride && { model: options.modelOverride }),
-        ...(options.useApi && { api: true }),
-      },
-      data: () => testcases,
-      task: async (input: EvalInput): Promise<TaskResult> => {
-        // Cooperative abort: skip any testcase that hasn't started yet
-        // when the signal has flipped. The in-flight task at the moment of
-        // abort still finishes its current step; this stops the next one
-        // from spinning up.
-        if (options.signal?.aborted) {
+  const evalResult = await withBrowserbaseExtensionScope(() =>
+    Eval(
+      braintrustProjectName,
+      {
+        experimentName,
+        metadata: {
+          environment,
+          tier: hasCoreOnly ? "core" : "bench",
+          ...(effectiveCoreToolSurface && {
+            toolSurface: effectiveCoreToolSurface,
+          }),
+          ...(effectiveCoreStartupProfile && {
+            startupProfile: effectiveCoreStartupProfile,
+          }),
+          ...(effectiveBenchHarness && { harness: effectiveBenchHarness }),
+          ...(options.provider && { provider: options.provider }),
+          ...(options.modelOverride && { model: options.modelOverride }),
+          ...(options.useApi && { api: true }),
+        },
+        data: () => testcases,
+        task: async (input: EvalInput): Promise<TaskResult> => {
+          // Cooperative abort: skip any testcase that hasn't started yet
+          // when the signal has flipped. The in-flight task at the moment of
+          // abort still finishes its current step; this stops the next one
+          // from spinning up.
+          if (options.signal?.aborted) {
+            options.onProgress?.({
+              type: "failed",
+              taskName: input.name,
+              modelName: input.modelName,
+              error: "aborted",
+            });
+            return {
+              _success: false,
+              error: "aborted by user",
+              logs: [],
+            };
+          }
+
+          const resolvedTask =
+            options.registry.byName.get(input.name) ??
+            (input.name.includes("/")
+              ? undefined
+              : options.registry.byName.get(`agent/${input.name}`));
+
+          if (!resolvedTask) {
+            throw new EvalsError(`Task "${input.name}" not found in registry.`);
+          }
+
           options.onProgress?.({
-            type: "failed",
+            type: "started",
             taskName: input.name,
             modelName: input.modelName,
-            error: "aborted",
           });
-          return {
-            _success: false,
-            error: "aborted by user",
-            logs: [],
-          };
-        }
 
-        const resolvedTask =
-          options.registry.byName.get(input.name) ??
-          (input.name.includes("/")
-            ? undefined
-            : options.registry.byName.get(`agent/${input.name}`));
+          const result = await executeTask(input, resolvedTask, options);
 
-        if (!resolvedTask) {
-          throw new EvalsError(`Task "${input.name}" not found in registry.`);
-        }
+          options.onProgress?.({
+            type: result._success ? "passed" : "failed",
+            taskName: input.name,
+            modelName: input.modelName,
+            error: result._success ? undefined : formatProgressError(result.error),
+          });
 
-        options.onProgress?.({
-          type: "started",
-          taskName: input.name,
-          modelName: input.modelName,
-        });
-
-        const result = await executeTask(input, resolvedTask, options);
-
-        options.onProgress?.({
-          type: result._success ? "passed" : "failed",
-          taskName: input.name,
-          modelName: input.modelName,
-          error: result._success ? undefined : formatProgressError(result.error),
-        });
-
-        return result;
+          return result;
+        },
+        scores: scores as unknown as never,
+        maxConcurrency: concurrency,
+        trialCount: trials,
       },
-      scores: scores as unknown as never,
-      maxConcurrency: concurrency,
-      trialCount: trials,
-    },
-    {
-      progress: silentBraintrustProgress,
-      reporter: silentBraintrustReporter,
-      ...(sendLogs ? {} : { noSendLogs: true }),
-    },
+      {
+        progress: silentBraintrustProgress,
+        reporter: silentBraintrustReporter,
+        ...(sendLogs ? {} : { noSendLogs: true }),
+      },
+    ),
   );
 
   if (sendLogs) {

--- a/packages/evals/initStagehand.ts
+++ b/packages/evals/initStagehand.ts
@@ -9,6 +9,7 @@ import {
 } from "@browserbasehq/stagehand";
 import type { EvalLogger } from "./logger.js";
 import { launchRunnerProvidedBrowserbaseChrome } from "./core/targets/browserbase.js";
+import { onceAsync, registerActiveRunCleanup } from "./framework/activeRunCleanup.js";
 import { resolveKey } from "./tui/welcomeStatus.js";
 
 export type InitStagehandArgs = {
@@ -24,8 +25,8 @@ export type StagehandInitResult = {
   sessionUrl: string;
   /** Live debugger URL (Browserbase, best-effort; empty for LOCAL). */
   debugUrl: string;
-  /** Releases the Browserbase session (no-op for LOCAL). */
-  endSession: () => Promise<void>;
+  /** Closes Stagehand, its browser handle, and the Browserbase session. */
+  cleanup: () => Promise<void>;
 };
 
 const PROVIDER_API_KEY_ENV: Record<string, string[]> = {
@@ -120,7 +121,18 @@ export async function initStagehand({
   // `Stagehand.create` does not reliably close the handle when init fails —
   // without this a failed task leaks a Chrome process (LOCAL) or a live
   // Browserbase session (BROWSERBASE) for the rest of the run.
-  let stagehand: Stagehand;
+  let stagehand: Stagehand | undefined;
+  const cleanupOwnedResources = onceAsync(async () => {
+    await stagehand?.close().catch(() => {});
+    await browser.close().catch(() => {});
+    await endSession().catch(() => {});
+  });
+  const unregisterCleanup = registerActiveRunCleanup(cleanupOwnedResources);
+  const cleanup = async (): Promise<void> => {
+    await cleanupOwnedResources();
+    unregisterCleanup();
+  };
+
   try {
     stagehand = await Stagehand.create({
       browser,
@@ -131,8 +143,7 @@ export async function initStagehand({
       logging: { onLog: createStagehandOnLog(logger) },
     });
   } catch (error) {
-    await browser.close().catch(() => {});
-    await endSession().catch(() => {});
+    await cleanup();
     throw error;
   }
 
@@ -146,9 +157,7 @@ export async function initStagehand({
       throw new Error("Stagehand init: Stagehand initialized without an active page");
     }
   } catch (error) {
-    await stagehand.close().catch(() => {});
-    await browser.close().catch(() => {});
-    await endSession().catch(() => {});
+    await cleanup();
     throw error;
   }
 
@@ -157,6 +166,6 @@ export async function initStagehand({
     page,
     sessionUrl,
     debugUrl,
-    endSession,
+    cleanup,
   };
 }

--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@ai-sdk/provider": "^2.0.0",
     "@anthropic-ai/claude-agent-sdk": "^0.2.141",
+    "@browserbasehq/sdk": "catalog:",
     "@browserbasehq/stagehand": "workspace:*",
     "@openai/codex-sdk": "0.125.0",
     "ai": "^5.0.133",
@@ -32,6 +33,7 @@
     "sharp": "^0.34.5",
     "stagehand-v3": "npm:@browserbasehq/stagehand@3.7.1",
     "tsx": "catalog:",
+    "ws": "^8.21.0",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/evals/tasks/bench/act/amazon_add_to_cart.ts
+++ b/packages/evals/tasks/bench/act/amazon_add_to_cart.ts
@@ -31,8 +31,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/bidnet.ts
+++ b/packages/evals/tasks/bench/act/bidnet.ts
@@ -27,8 +27,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/checkboxes.ts
+++ b/packages/evals/tasks/bench/act/checkboxes.ts
@@ -32,8 +32,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/csr_in_oopif.ts
+++ b/packages/evals/tasks/bench/act/csr_in_oopif.ts
@@ -49,8 +49,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/csr_in_spif.ts
+++ b/packages/evals/tasks/bench/act/csr_in_spif.ts
@@ -47,8 +47,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/custom_dropdown.ts
+++ b/packages/evals/tasks/bench/act/custom_dropdown.ts
@@ -43,8 +43,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/dropdown.ts
+++ b/packages/evals/tasks/bench/act/dropdown.ts
@@ -37,8 +37,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/google_flights.ts
+++ b/packages/evals/tasks/bench/act/google_flights.ts
@@ -30,8 +30,6 @@ export default defineBenchTask(
         "https://browserbase.github.io/stagehand-eval-sites/sites/google-flights/return-flight.html";
       const currentUrl = await page.url();
 
-      await stagehand.close();
-
       if (currentUrl === expectedUrl) {
         return {
           _success: true,
@@ -56,8 +54,6 @@ export default defineBenchTask(
         debugUrl,
         sessionUrl,
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/heal_custom_dropdown.ts
+++ b/packages/evals/tasks/bench/act/heal_custom_dropdown.ts
@@ -67,8 +67,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/heal_scroll_50.ts
+++ b/packages/evals/tasks/bench/act/heal_scroll_50.ts
@@ -61,8 +61,6 @@ export default defineBenchTask(
         debugUrl,
         sessionUrl,
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/heal_simple_google_search.ts
+++ b/packages/evals/tasks/bench/act/heal_simple_google_search.ts
@@ -53,8 +53,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/hidden_input_dropdown.ts
+++ b/packages/evals/tasks/bench/act/hidden_input_dropdown.ts
@@ -56,8 +56,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/iframe_form_filling.ts
+++ b/packages/evals/tasks/bench/act/iframe_form_filling.ts
@@ -54,8 +54,6 @@ export default defineBenchTask(
         debugUrl,
         sessionUrl,
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/iframe_same_proc.ts
+++ b/packages/evals/tasks/bench/act/iframe_same_proc.ts
@@ -52,8 +52,6 @@ export default defineBenchTask(
         debugUrl,
         sessionUrl,
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/iframe_scroll.ts
+++ b/packages/evals/tasks/bench/act/iframe_scroll.ts
@@ -53,8 +53,6 @@ export default defineBenchTask(
         debugUrl,
         sessionUrl,
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/iframes_nested.ts
+++ b/packages/evals/tasks/bench/act/iframes_nested.ts
@@ -42,8 +42,6 @@ export default defineBenchTask(
         debugUrl,
         sessionUrl,
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/ionwave.ts
+++ b/packages/evals/tasks/bench/act/ionwave.ts
@@ -27,8 +27,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/login.ts
+++ b/packages/evals/tasks/bench/act/login.ts
@@ -31,8 +31,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/multi_tab.ts
+++ b/packages/evals/tasks/bench/act/multi_tab.ts
@@ -86,8 +86,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/namespace_xpath.ts
+++ b/packages/evals/tasks/bench/act/namespace_xpath.ts
@@ -26,8 +26,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/nested_iframes_2.ts
+++ b/packages/evals/tasks/bench/act/nested_iframes_2.ts
@@ -43,8 +43,6 @@ export default defineBenchTask(
         sessionUrl,
         error,
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/next_chunk.ts
+++ b/packages/evals/tasks/bench/act/next_chunk.ts
@@ -59,8 +59,6 @@ export default defineBenchTask(
         debugUrl,
         sessionUrl,
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/no_js_click.ts
+++ b/packages/evals/tasks/bench/act/no_js_click.ts
@@ -45,8 +45,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/nonsense_action.ts
+++ b/packages/evals/tasks/bench/act/nonsense_action.ts
@@ -22,8 +22,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/oopif_in_csr.ts
+++ b/packages/evals/tasks/bench/act/oopif_in_csr.ts
@@ -47,8 +47,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/oopif_in_osr.ts
+++ b/packages/evals/tasks/bench/act/oopif_in_osr.ts
@@ -47,8 +47,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/os_dropdown.ts
+++ b/packages/evals/tasks/bench/act/os_dropdown.ts
@@ -44,8 +44,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/osr_in_oopif.ts
+++ b/packages/evals/tasks/bench/act/osr_in_oopif.ts
@@ -47,8 +47,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/osr_in_spif.ts
+++ b/packages/evals/tasks/bench/act/osr_in_spif.ts
@@ -47,8 +47,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/prev_chunk.ts
+++ b/packages/evals/tasks/bench/act/prev_chunk.ts
@@ -58,8 +58,6 @@ export default defineBenchTask(
         debugUrl,
         sessionUrl,
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/radio_btn.ts
+++ b/packages/evals/tasks/bench/act/radio_btn.ts
@@ -27,8 +27,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/scroll_50.ts
+++ b/packages/evals/tasks/bench/act/scroll_50.ts
@@ -43,8 +43,6 @@ export default defineBenchTask(
         debugUrl,
         sessionUrl,
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/scroll_75.ts
+++ b/packages/evals/tasks/bench/act/scroll_75.ts
@@ -43,8 +43,6 @@ export default defineBenchTask(
         debugUrl,
         sessionUrl,
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/shadow_dom.ts
+++ b/packages/evals/tasks/bench/act/shadow_dom.ts
@@ -38,8 +38,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/simple_google_search.ts
+++ b/packages/evals/tasks/bench/act/simple_google_search.ts
@@ -30,8 +30,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/spif_in_csr.ts
+++ b/packages/evals/tasks/bench/act/spif_in_csr.ts
@@ -46,8 +46,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/spif_in_osr.ts
+++ b/packages/evals/tasks/bench/act/spif_in_osr.ts
@@ -47,8 +47,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/tab_handling.ts
+++ b/packages/evals/tasks/bench/act/tab_handling.ts
@@ -49,8 +49,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/vantechjournal.ts
+++ b/packages/evals/tasks/bench/act/vantechjournal.ts
@@ -27,8 +27,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/act/wikipedia.ts
+++ b/packages/evals/tasks/bench/act/wikipedia.ts
@@ -28,8 +28,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/extract/extract_aigrant_targeted.ts
+++ b/packages/evals/tasks/bench/extract/extract_aigrant_targeted.ts
@@ -63,8 +63,6 @@ export default defineBenchTask(
         debugUrl,
         sessionUrl,
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/extract/extract_aigrant_targeted_2.ts
+++ b/packages/evals/tasks/bench/extract/extract_aigrant_targeted_2.ts
@@ -66,8 +66,6 @@ export default defineBenchTask(
         debugUrl,
         sessionUrl,
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/extract/extract_apartments.ts
+++ b/packages/evals/tasks/bench/extract/extract_apartments.ts
@@ -61,8 +61,6 @@ export default defineBenchTask(
         debugUrl,
         sessionUrl,
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/extract/extract_area_codes.ts
+++ b/packages/evals/tasks/bench/extract/extract_area_codes.ts
@@ -145,8 +145,6 @@ export default defineBenchTask(
         debugUrl,
         sessionUrl,
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/extract/extract_baptist_health.ts
+++ b/packages/evals/tasks/bench/extract/extract_baptist_health.ts
@@ -90,8 +90,6 @@ export default defineBenchTask(
         debugUrl,
         sessionUrl,
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/extract/extract_csa.ts
+++ b/packages/evals/tasks/bench/extract/extract_csa.ts
@@ -144,8 +144,6 @@ export default defineBenchTask(
         debugUrl,
         sessionUrl,
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/extract/extract_geniusee.ts
+++ b/packages/evals/tasks/bench/extract/extract_geniusee.ts
@@ -62,8 +62,6 @@ export default defineBenchTask(
         debugUrl,
         sessionUrl,
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/extract/extract_geniusee_2.ts
+++ b/packages/evals/tasks/bench/extract/extract_geniusee_2.ts
@@ -68,8 +68,6 @@ export default defineBenchTask(
         debugUrl,
         sessionUrl,
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/extract/extract_github_stars.ts
+++ b/packages/evals/tasks/bench/extract/extract_github_stars.ts
@@ -43,8 +43,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/extract/extract_hamilton_weather.ts
+++ b/packages/evals/tasks/bench/extract/extract_hamilton_weather.ts
@@ -62,8 +62,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/extract/extract_jfk_links.ts
+++ b/packages/evals/tasks/bench/extract/extract_jfk_links.ts
@@ -110,8 +110,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/extract/extract_jstor_news.ts
+++ b/packages/evals/tasks/bench/extract/extract_jstor_news.ts
@@ -128,8 +128,6 @@ export default defineBenchTask(
         debugUrl,
         sessionUrl,
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/extract/extract_memorial_healthcare.ts
+++ b/packages/evals/tasks/bench/extract/extract_memorial_healthcare.ts
@@ -183,8 +183,6 @@ export default defineBenchTask(
         debugUrl,
         sessionUrl,
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/extract/extract_nhl_stats.ts
+++ b/packages/evals/tasks/bench/extract/extract_nhl_stats.ts
@@ -113,8 +113,6 @@ export default defineBenchTask(
         debugUrl,
         sessionUrl,
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/extract/extract_professional_info.ts
+++ b/packages/evals/tasks/bench/extract/extract_professional_info.ts
@@ -19,9 +19,6 @@ export default defineBenchTask(
         }),
       );
 
-      // v3 closes mid-task here (and again in finally); preserved verbatim.
-      await stagehand.close();
-
       const { practices, phone, fax } = result;
 
       const expected = {
@@ -124,8 +121,6 @@ export default defineBenchTask(
         debugUrl,
         sessionUrl,
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/extract/extract_public_notices.ts
+++ b/packages/evals/tasks/bench/extract/extract_public_notices.ts
@@ -157,8 +157,6 @@ export default defineBenchTask(
         debugUrl,
         sessionUrl,
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/extract/extract_recipe.ts
+++ b/packages/evals/tasks/bench/extract/extract_recipe.ts
@@ -91,8 +91,6 @@ export default defineBenchTask(
         debugUrl,
         sessionUrl,
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/extract/extract_regulations_table.ts
+++ b/packages/evals/tasks/bench/extract/extract_regulations_table.ts
@@ -72,8 +72,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/extract/extract_repo_name.ts
+++ b/packages/evals/tasks/bench/extract/extract_repo_name.ts
@@ -42,8 +42,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/extract/extract_resistor_info.ts
+++ b/packages/evals/tasks/bench/extract/extract_resistor_info.ts
@@ -150,8 +150,6 @@ export default defineBenchTask(
         debugUrl,
         sessionUrl,
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/extract/extract_rockauto.ts
+++ b/packages/evals/tasks/bench/extract/extract_rockauto.ts
@@ -89,8 +89,6 @@ export default defineBenchTask(
         debugUrl,
         sessionUrl,
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/extract/extract_single_link.ts
+++ b/packages/evals/tasks/bench/extract/extract_single_link.ts
@@ -40,8 +40,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/extract/extract_staff_members.ts
+++ b/packages/evals/tasks/bench/extract/extract_staff_members.ts
@@ -134,8 +134,6 @@ export default defineBenchTask(
         debugUrl,
         sessionUrl,
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/extract/extract_zillow.ts
+++ b/packages/evals/tasks/bench/extract/extract_zillow.ts
@@ -19,8 +19,6 @@ export default defineBenchTask(
         }),
       );
 
-      // v3 closes mid-task here (and again in finally); preserved verbatim.
-      await stagehand.close();
       const listings = real_estate_listings.listings;
       const expectedLength = 38;
 
@@ -62,8 +60,6 @@ export default defineBenchTask(
         debugUrl,
         sessionUrl,
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/extract/iframe_hn.ts
+++ b/packages/evals/tasks/bench/extract/iframe_hn.ts
@@ -48,8 +48,6 @@ export default defineBenchTask(
         debugUrl,
         sessionUrl,
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/observe/ionwave_observe.ts
+++ b/packages/evals/tasks/bench/observe/ionwave_observe.ts
@@ -56,8 +56,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/observe/observe_amazon_add_to_cart.ts
+++ b/packages/evals/tasks/bench/observe/observe_amazon_add_to_cart.ts
@@ -45,8 +45,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/observe/observe_file_uploads.ts
+++ b/packages/evals/tasks/bench/observe/observe_file_uploads.ts
@@ -45,8 +45,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/observe/observe_github.ts
+++ b/packages/evals/tasks/bench/observe/observe_github.ts
@@ -74,8 +74,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/observe/observe_iframes1.ts
+++ b/packages/evals/tasks/bench/observe/observe_iframes1.ts
@@ -67,8 +67,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/observe/observe_iframes2.ts
+++ b/packages/evals/tasks/bench/observe/observe_iframes2.ts
@@ -78,8 +78,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/observe/observe_main_frame_element_ids.ts
+++ b/packages/evals/tasks/bench/observe/observe_main_frame_element_ids.ts
@@ -117,8 +117,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/observe/observe_simple_google_search.ts
+++ b/packages/evals/tasks/bench/observe/observe_simple_google_search.ts
@@ -40,8 +40,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/observe/observe_taxes.ts
+++ b/packages/evals/tasks/bench/observe/observe_taxes.ts
@@ -66,8 +66,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/observe/observe_vantechjournal.ts
+++ b/packages/evals/tasks/bench/observe/observe_vantechjournal.ts
@@ -49,8 +49,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/observe/observe_yc_startup.ts
+++ b/packages/evals/tasks/bench/observe/observe_yc_startup.ts
@@ -68,8 +68,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tasks/bench/observe/panamcs.ts
+++ b/packages/evals/tasks/bench/observe/panamcs.ts
@@ -56,8 +56,6 @@ export default defineBenchTask(
         sessionUrl,
         logs: logger.getLogs(),
       };
-    } finally {
-      await stagehand.close();
     }
   },
 );

--- a/packages/evals/tests/core/browserbase-target.test.ts
+++ b/packages/evals/tests/core/browserbase-target.test.ts
@@ -40,7 +40,9 @@ describe("runner-provided Browserbase target", () => {
     updateMock.mockResolvedValue(undefined);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await cleanupActiveRunResources();
+    vi.useRealTimers();
     process.env = { ...originalEnv };
   });
 
@@ -118,7 +120,9 @@ describe("runner-provided Browserbase target", () => {
     const { launchRunnerProvidedBrowserbaseChrome } =
       await import("../../core/targets/browserbase.js");
 
-    await expect(launchRunnerProvidedBrowserbaseChrome()).rejects.toThrow("session create failed");
+    await expect(launchRunnerProvidedBrowserbaseChrome()).rejects.toThrow(
+      "Browserbase session creation failed.",
+    );
     expect(extensionDeleteMock).toHaveBeenCalledWith("extension-123", {
       headers: { "Content-Type": null },
     });
@@ -191,5 +195,60 @@ describe("runner-provided Browserbase target", () => {
     });
 
     expect(extensionDeleteMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a transient extension upload failure within the same run", async () => {
+    extensionCreateMock
+      .mockRejectedValueOnce(new Error("temporary upload failure"))
+      .mockResolvedValueOnce({ id: "extension-retry" });
+    createMock.mockResolvedValue({
+      id: "session-retry",
+      connectUrl: "wss://connect.browserbase.test/devtools/browser/session-retry",
+    });
+
+    const { launchRunnerProvidedBrowserbaseChrome, withBrowserbaseExtensionScope } =
+      await import("../../core/targets/browserbase.js");
+
+    await withBrowserbaseExtensionScope(async () => {
+      await expect(launchRunnerProvidedBrowserbaseChrome()).rejects.toThrow(
+        "temporary upload failure",
+      );
+      const target = await launchRunnerProvidedBrowserbaseChrome();
+      expect(target.extensionId).toBe("extension-retry");
+      await target.cleanup();
+    });
+
+    expect(extensionCreateMock).toHaveBeenCalledTimes(2);
+    expect(extensionDeleteMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not hang scope cleanup when a session lease is not released", async () => {
+    vi.useFakeTimers();
+    createMock.mockResolvedValue({
+      id: "session-leaked",
+      connectUrl: "wss://connect.browserbase.test/devtools/browser/session-leaked",
+    });
+
+    const { launchRunnerProvidedBrowserbaseChrome, withBrowserbaseExtensionScope } =
+      await import("../../core/targets/browserbase.js");
+    let resolveTarget!: (
+      target: Awaited<ReturnType<typeof launchRunnerProvidedBrowserbaseChrome>>,
+    ) => void;
+    const targetReady = new Promise<
+      Awaited<ReturnType<typeof launchRunnerProvidedBrowserbaseChrome>>
+    >((resolve) => {
+      resolveTarget = resolve;
+    });
+    const scopePromise = withBrowserbaseExtensionScope(async () => {
+      resolveTarget(await launchRunnerProvidedBrowserbaseChrome());
+    });
+    const target = await targetReady;
+    await Promise.resolve();
+
+    await vi.runAllTimersAsync();
+    await scopePromise;
+
+    expect(extensionDeleteMock).toHaveBeenCalledTimes(1);
+    await target.cleanup();
   });
 });

--- a/packages/evals/tests/core/browserbase-target.test.ts
+++ b/packages/evals/tests/core/browserbase-target.test.ts
@@ -1,12 +1,20 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanupActiveRunResources } from "../../framework/activeRunCleanup.js";
 
 const createMock = vi.fn();
 const updateMock = vi.fn();
 const debugMock = vi.fn();
+const extensionCreateMock = vi.fn();
+const extensionDeleteMock = vi.fn();
 
 vi.mock("../../core/runtime/coreDeps.js", () => ({
+  resolveStagehandExtensionArchivePath: () => import.meta.filename,
   loadBrowserbaseSdk: () =>
     class FakeBrowserbase {
+      extensions = {
+        create: extensionCreateMock,
+        delete: extensionDeleteMock,
+      };
       sessions = {
         create: createMock,
         update: updateMock,
@@ -25,6 +33,11 @@ describe("runner-provided Browserbase target", () => {
     createMock.mockReset();
     updateMock.mockReset();
     debugMock.mockReset();
+    extensionCreateMock.mockReset();
+    extensionDeleteMock.mockReset();
+    extensionCreateMock.mockResolvedValue({ id: "extension-123" });
+    extensionDeleteMock.mockResolvedValue(undefined);
+    updateMock.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -49,9 +62,12 @@ describe("runner-provided Browserbase target", () => {
     expect(target.sessionId).toBe("session-123");
     expect(target.sessionUrl).toBe("https://www.browserbase.com/sessions/session-123");
     expect(target.debugUrl).toBe("https://debug.browserbase.test/session-123");
+    expect(target.extensionId).toBe("extension-123");
+    expect(extensionCreateMock).toHaveBeenCalledOnce();
     expect(createMock).toHaveBeenCalledWith(
       expect.objectContaining({
         projectId: "test-project-id",
+        extensionId: "extension-123",
         browserSettings: {
           viewport: { width: 1288, height: 711 },
         },
@@ -59,11 +75,17 @@ describe("runner-provided Browserbase target", () => {
     );
 
     await target.cleanup();
+    await target.cleanup();
 
     expect(updateMock).toHaveBeenCalledWith("session-123", {
       status: "REQUEST_RELEASE",
       projectId: "test-project-id",
     });
+    expect(extensionDeleteMock).toHaveBeenCalledWith("extension-123", {
+      headers: { "Content-Type": null },
+    });
+    expect(updateMock).toHaveBeenCalledTimes(1);
+    expect(extensionDeleteMock).toHaveBeenCalledTimes(1);
   });
 
   it("falls back to BB_* credentials when Browserbase env vars are empty", async () => {
@@ -88,5 +110,86 @@ describe("runner-provided Browserbase target", () => {
     );
 
     await target.cleanup();
+  });
+
+  it("deletes the uploaded extension when session creation fails", async () => {
+    createMock.mockRejectedValue(new Error("session create failed"));
+
+    const { launchRunnerProvidedBrowserbaseChrome } =
+      await import("../../core/targets/browserbase.js");
+
+    await expect(launchRunnerProvidedBrowserbaseChrome()).rejects.toThrow("session create failed");
+    expect(extensionDeleteMock).toHaveBeenCalledWith("extension-123", {
+      headers: { "Content-Type": null },
+    });
+  });
+
+  it("releases a session that finishes creating after an active-run abort", async () => {
+    let resolveCreate!: (value: { id: string; connectUrl: string }) => void;
+    createMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveCreate = resolve;
+      }),
+    );
+
+    const { launchRunnerProvidedBrowserbaseChrome } =
+      await import("../../core/targets/browserbase.js");
+    const launchPromise = launchRunnerProvidedBrowserbaseChrome();
+    await vi.waitFor(() => expect(createMock).toHaveBeenCalledOnce());
+
+    const abortCleanup = cleanupActiveRunResources();
+    resolveCreate({
+      id: "session-late",
+      connectUrl: "wss://connect.browserbase.test/devtools/browser/session-late",
+    });
+
+    const target = await launchPromise;
+    await abortCleanup;
+    await target.cleanup();
+
+    expect(updateMock).toHaveBeenCalledWith("session-late", {
+      status: "REQUEST_RELEASE",
+      projectId: "test-project-id",
+    });
+    expect(updateMock).toHaveBeenCalledTimes(1);
+    expect(extensionDeleteMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("uploads once and reuses the extension across concurrent session creates", async () => {
+    createMock
+      .mockResolvedValueOnce({
+        id: "session-a",
+        connectUrl: "wss://connect.browserbase.test/devtools/browser/session-a",
+      })
+      .mockResolvedValueOnce({
+        id: "session-b",
+        connectUrl: "wss://connect.browserbase.test/devtools/browser/session-b",
+      });
+
+    const { launchRunnerProvidedBrowserbaseChrome, withBrowserbaseExtensionScope } =
+      await import("../../core/targets/browserbase.js");
+
+    await withBrowserbaseExtensionScope(async () => {
+      const [first, second] = await Promise.all([
+        launchRunnerProvidedBrowserbaseChrome(),
+        launchRunnerProvidedBrowserbaseChrome(),
+      ]);
+
+      expect(extensionCreateMock).toHaveBeenCalledTimes(1);
+      expect(createMock).toHaveBeenCalledTimes(2);
+      expect(createMock).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ extensionId: "extension-123" }),
+      );
+      expect(createMock).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ extensionId: "extension-123" }),
+      );
+
+      await Promise.all([first.cleanup(), second.cleanup()]);
+      expect(extensionDeleteMock).not.toHaveBeenCalled();
+    });
+
+    expect(extensionDeleteMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/evals/tests/core/task-portability.test.ts
+++ b/packages/evals/tests/core/task-portability.test.ts
@@ -3,6 +3,9 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 const coreTasksRoot = path.resolve(__dirname, "../../core/tasks");
+const deterministicTaskRoots = ["act", "extract", "observe"].map((category) =>
+  path.resolve(__dirname, `../../tasks/bench/${category}`),
+);
 
 function walk(dir: string): string[] {
   const entries = fs.readdirSync(dir, { withFileTypes: true });
@@ -39,6 +42,15 @@ describe("core task portability", () => {
         expect(source, `${path.relative(coreTasksRoot, taskFile)} matched ${pattern}`).not.toMatch(
           pattern,
         );
+      }
+    }
+  });
+
+  it("leaves Stagehand lifecycle cleanup to the bench harness", () => {
+    for (const tasksRoot of deterministicTaskRoots) {
+      for (const taskFile of walk(tasksRoot)) {
+        const source = fs.readFileSync(taskFile, "utf8");
+        expect(source, path.relative(tasksRoot, taskFile)).not.toContain("stagehand.close(");
       }
     }
   });

--- a/packages/evals/tests/framework/activeRunCleanup.test.ts
+++ b/packages/evals/tests/framework/activeRunCleanup.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from "vitest";
+import { abortActiveRun, registerActiveRunCleanup } from "../../framework/activeRunCleanup.js";
+
+describe("active run cleanup", () => {
+  it("upgrades a cooperative abort by cleaning active resources", async () => {
+    const cleanup = vi.fn(async () => {});
+    const unregister = registerActiveRunCleanup(cleanup);
+    const controller = new AbortController();
+
+    await abortActiveRun(controller, "cooperative");
+    expect(controller.signal.reason).toBe("cooperative");
+    expect(cleanup).not.toHaveBeenCalled();
+
+    await abortActiveRun(controller, "aggressive");
+    expect(controller.signal.reason).toBe("cooperative");
+    expect(cleanup).toHaveBeenCalledTimes(1);
+
+    unregister();
+  });
+});

--- a/packages/evals/tests/framework/activeRunCleanup.test.ts
+++ b/packages/evals/tests/framework/activeRunCleanup.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { abortActiveRun, registerActiveRunCleanup } from "../../framework/activeRunCleanup.js";
+import {
+  abortActiveRun,
+  cleanupActiveRunResources,
+  registerActiveRunCleanup,
+} from "../../framework/activeRunCleanup.js";
 
 describe("active run cleanup", () => {
   it("upgrades a cooperative abort by cleaning active resources", async () => {
@@ -19,5 +23,19 @@ describe("active run cleanup", () => {
     expect(cleanup).toHaveBeenCalledTimes(1);
 
     unregister();
+  });
+
+  it("attempts every cleanup when one throws synchronously", async () => {
+    const synchronousFailure = vi.fn(() => {
+      throw new Error("synchronous cleanup failure");
+    }) as unknown as () => Promise<void>;
+    const laterCleanup = vi.fn(async () => {});
+    registerActiveRunCleanup(synchronousFailure);
+    registerActiveRunCleanup(laterCleanup);
+
+    await expect(cleanupActiveRunResources()).resolves.toBeUndefined();
+
+    expect(synchronousFailure).toHaveBeenCalledOnce();
+    expect(laterCleanup).toHaveBeenCalledOnce();
   });
 });

--- a/packages/evals/tests/framework/activeRunCleanup.test.ts
+++ b/packages/evals/tests/framework/activeRunCleanup.test.ts
@@ -15,6 +15,9 @@ describe("active run cleanup", () => {
     expect(controller.signal.reason).toBe("cooperative");
     expect(cleanup).toHaveBeenCalledTimes(1);
 
+    await abortActiveRun(controller, "aggressive");
+    expect(cleanup).toHaveBeenCalledTimes(1);
+
     unregister();
   });
 });

--- a/packages/evals/tui/repl.ts
+++ b/packages/evals/tui/repl.ts
@@ -115,14 +115,8 @@ export async function startRepl(entryDir: string, options: ReplOptions = {}): Pr
     void abortActiveRun(abortRef.current, "aggressive");
   };
 
-  const onKeypress = (_str: string, key: { name?: string; ctrl?: boolean } | undefined): void => {
-    if (!key) return;
-    if (key.ctrl && key.name === "c") {
-      if (abortRef.current) abortImmediately();
-      else rl.close();
-      return;
-    }
-    if (key.name !== "escape") return;
+  const onKeypress = (_str: string, key: { name?: string } | undefined): void => {
+    if (!key || key.name !== "escape") return;
     if (!abortRef.current) {
       // Idle Esc: pop one level if we're inside a context.
       if (contextPath.length > 0) {

--- a/packages/evals/tui/repl.ts
+++ b/packages/evals/tui/repl.ts
@@ -21,6 +21,7 @@ import { getRuntimeTasksRoot } from "../runtimePaths.js";
 import { printExtendedWelcome, printTipLine } from "./welcome.js";
 import { snapshotEnv, renderInlineWarning } from "./welcomeStatus.js";
 import { isFirstRun, markFirstRunComplete } from "./welcomeState.js";
+import { abortActiveRun } from "../framework/activeRunCleanup.js";
 
 export type ReplOptions = {
   /** Suppress banner, welcome, and any inline warnings. Output is just the prompt. */
@@ -108,8 +109,20 @@ export async function startRepl(entryDir: string, options: ReplOptions = {}): Pr
   let lastEscAt = 0;
   const DOUBLE_ESC_WINDOW_MS = 1500;
 
+  const abortImmediately = (): void => {
+    if (!abortRef.current) return;
+    console.log(red("\n  ✗ Aborting immediately…"));
+    void abortActiveRun(abortRef.current, "aggressive");
+  };
+
   const onKeypress = (_str: string, key: { name?: string; ctrl?: boolean } | undefined): void => {
-    if (!key || key.name !== "escape") return;
+    if (!key) return;
+    if (key.ctrl && key.name === "c") {
+      if (abortRef.current) abortImmediately();
+      else rl.close();
+      return;
+    }
+    if (key.name !== "escape") return;
     if (!abortRef.current) {
       // Idle Esc: pop one level if we're inside a context.
       if (contextPath.length > 0) {
@@ -124,16 +137,22 @@ export async function startRepl(entryDir: string, options: ReplOptions = {}): Pr
     const isDouble = now - lastEscAt < DOUBLE_ESC_WINDOW_MS;
     lastEscAt = now;
     if (isDouble) {
-      console.log(red("\n  ✗ Aborting immediately…"));
-      abortRef.current.abort("aggressive");
+      abortImmediately();
     } else {
       console.log(
         yellow("\n  ⚠ Aborting after current task… (press Esc again to abort immediately)"),
       );
-      abortRef.current.abort("cooperative");
+      void abortActiveRun(abortRef.current, "cooperative");
     }
   };
   process.stdin.on("keypress", onKeypress);
+
+  // readline consumes Ctrl+C in raw terminal mode and emits SIGINT on the
+  // interface instead of necessarily delivering it to process.on("SIGINT").
+  rl.on("SIGINT", () => {
+    if (abortRef.current) abortImmediately();
+    else rl.close();
+  });
 
   rl.prompt();
 
@@ -158,6 +177,7 @@ export async function startRepl(entryDir: string, options: ReplOptions = {}): Pr
   });
 
   rl.on("close", () => {
+    process.stdin.off("keypress", onKeypress);
     console.log(dim("\n  Goodbye.\n"));
     process.exit(0);
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -426,6 +426,9 @@ importers:
       '@anthropic-ai/claude-agent-sdk':
         specifier: ^0.2.141
         version: 0.2.141(zod@4.4.3)
+      '@browserbasehq/sdk':
+        specifier: 'catalog:'
+        version: 2.16.0
       '@browserbasehq/stagehand':
         specifier: workspace:*
         version: link:../sdk-ts
@@ -456,6 +459,9 @@ importers:
       tsx:
         specifier: 'catalog:'
         version: 4.23.1
+      ws:
+        specifier: ^8.21.0
+        version: 8.21.0(bufferutil@4.1.0)
       zod:
         specifier: 'catalog:'
         version: 4.4.3

--- a/turbo.json
+++ b/turbo.json
@@ -31,6 +31,11 @@
       "inputs": ["$TURBO_DEFAULT$", "!dist/**"],
       "outputs": ["dist/**"]
     },
+    "build:cli": {
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", "!dist/**"],
+      "outputs": ["dist/cli/**"]
+    },
     "//#generate:python": {
       "dependsOn": ["@browserbasehq/stagehand-protocol#build"],
       "inputs": ["$TURBO_DEFAULT$", "!packages/sdk-python/src/stagehand/_generated/**"],


### PR DESCRIPTION
# why

The v4 eval CLI leaked Browserbase sessions when runs were interrupted, uploaded the Stagehand extension once per testcase, and allowed task-owned Stagehand closes to race the harness cleanup. The root CLI build command was also missing from the v4 branch.

# what changed

- upload the Stagehand extension lazily once per eval run and reuse its ID across Browserbase session creates
- release Browserbase sessions and delete the shared extension after all sessions drain, including aggressive Ctrl+C / double-Escape cleanup
- centralize Stagehand and browser cleanup in the harness and remove task-owned closes from act, extract, and observe tasks
- restore the root build:cli Turbo task and make evals Browserbase dependencies explicit
- leave stale-frame logging behavior unchanged
- add regression coverage for extension reuse, late session creation during abort, idempotent cleanup, and task lifecycle ownership

# test plan

- pnpm --filter @browserbasehq/stagehand-evals test (52 files, 414 tests)
- pnpm --filter @browserbasehq/stagehand-evals typecheck
- pnpm build:cli
- oxfmt check on affected files
- oxlint on the runtime and regression-test files
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Browserbase session leaks and teardown races in v4 evals by scoping a single Stagehand extension per run and centralizing cleanup. Also isolates synchronous cleanup failures so all run cleanups execute reliably, even during Esc/Ctrl+C aborts or in-flight init.

- **Bug Fixes**
  - Isolate synchronous cleanup failures so every active-run cleanup runs; unregister before invoking and guard with Promise resolution.
  - Release sessions on cooperative and aggressive aborts, including in-flight and late-created sessions; delete the shared extension after sessions drain or a short timeout.
  - Delete the uploaded extension if session creation fails; upload lazily once per run, reuse its ID, retry transient upload failures, and delete the upload exactly once.

- **Refactors**
  - Add `withBrowserbaseExtensionScope` and `abortActiveRun`; run active-run cleanups exactly once; REPL Esc/Ctrl+C routes through this path.
  - Centralize lifecycle in init/harness with a single `cleanup()`; remove task-level `stagehand.close()` to prevent races and double-closes.
  - Lazy-load `@browserbasehq/sdk` and `ws`; resolve the Stagehand extension from package assets; declare explicit deps in `packages/evals`; restore `build:cli` via Turbo.

<sup>Written for commit 6f3ed576a10db9d3b38c1c94590810698126f792. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

