### PR TITLE
fix(protocol): preserve extract schema keys

### DIFF
--- a/packages/protocol/schema-registry.ts
+++ b/packages/protocol/schema-registry.ts
@@ -504,7 +504,7 @@ export const StagehandMethodSchema = z
 const stagehandRpcRequestSchemas = Object.values(StagehandMethods).map((method) =>
   JSONRPCRequestSchema.extend({
     method: z.literal(method.name),
-    params: wireSchema(method.params),
+    params: wireSchema(method.params, "paramsWire" in method ? method.paramsWire : undefined),
   }),
 );
 

--- a/packages/protocol/tests/protocol/wire-casing.test.ts
+++ b/packages/protocol/tests/protocol/wire-casing.test.ts
@@ -2,7 +2,11 @@ import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 import { z } from "zod/v4";
 import { encodeWireValue, toWireJsonSchema, wireSchema } from "../../json-rpc/wire-casing.js";
-import { StagehandNotifications, StagehandMethods } from "../../schema-registry.js";
+import {
+  StagehandNotifications,
+  StagehandMethods,
+  StagehandRpcRequestSchema,
+} from "../../schema-registry.js";
 import { STAGEHAND_PROTOCOL_VERSION } from "../../schemas.js";
 
 const snakeCaseKey = /^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$/;
@@ -536,6 +540,32 @@ describe("JSON-RPC wire casing", () => {
     expect(wireSchema(definition.params, definition.paramsWire).parse(wireValue)).toStrictEqual(
       apiValue,
     );
+  });
+
+  it("preserves extraction schema keys through the JSON-RPC request envelope", () => {
+    const request = StagehandRpcRequestSchema.parse({
+      jsonrpc: "2.0",
+      id: 1,
+      method: StagehandMethods.stagehandExtract.name,
+      params: {
+        page_id: "page_1",
+        instruction: "Extract the company name",
+        schema: {
+          type: "object",
+          properties: { company_name: { type: "string" } },
+          required: ["company_name"],
+          additionalProperties: false,
+        },
+      },
+    });
+
+    expect(request.params).toMatchObject({
+      pageId: "page_1",
+      schema: {
+        properties: { company_name: { type: "string" } },
+        required: ["company_name"],
+      },
+    });
   });
 
   it("cases structured act and observe result data while preserving extracted JSON", () => {


### PR DESCRIPTION
# why

The aggregate JSON-RPC request schema decoded method params without each method's wire-casing options. For stagehand.extract, that changed arbitrary schema properties such as company_name to companyName while leaving required entries unchanged, producing invalid OpenAI schemas and response-validation failures for other providers.

# what changed

- apply paramsWire while constructing each method-specific request envelope schema
- add a regression test that sends a snake_case extraction schema through the full JSON-RPC request envelope and verifies its property and required keys remain aligned

# test plan

- confirmed the new regression test fails before the fix with company_name becoming companyName
- pnpm --filter @browserbasehq/stagehand-protocol test (24 files, 348 tests)
- pnpm --filter @browserbasehq/stagehand-protocol typecheck
- pnpm --filter @browserbasehq/stagehand-extension test:unit (42 files, 289 passed, 10 todo)
- oxlint on both changed files
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves snake_case keys in extraction schemas when sent via JSON-RPC by applying per-method params wire-casing. Prevents property/required mismatches that caused invalid provider schemas and response validation errors.

- **Bug Fixes**
  - Apply `paramsWire` when building each method-specific request schema so `stagehand.extract` keeps original schema keys.
  - Add regression test to verify snake_case schema properties and required keys remain aligned through `StagehandRpcRequestSchema`.

<sup>Written for commit 147e9544db0f51060247e0c94a7b8d221767a023. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

