### PR TITLE
evals: promote agent-mount contract to v4-spike

### DIFF
--- a/packages/evals/core/contracts/tool.ts
+++ b/packages/evals/core/contracts/tool.ts
@@ -1,3 +1,4 @@
+import type { ProbeEvidence } from "stagehand-v3";
 import type { EvalLogger } from "../../logger.js";
 import type { ActionTarget, FocusedTarget, TargetKind, WaitSpec } from "./targets.js";
 import type { PageRepresentation, RepresentationOpts } from "./representation.js";
@@ -5,6 +6,7 @@ import type { Artifact, BrowserOwnership, ConnectionMode, EnvironmentName } from
 
 export type ToolSurface =
   | "understudy_code"
+  | "stagehand_code"
   | "playwright_code"
   | "cdp_code"
   | "playwright_mcp"
@@ -134,6 +136,19 @@ export interface ToolStartInput {
 
 export interface ToolStartResult {
   session: CoreSession;
+  /**
+   * Optional agent-facing binding for this running surface. `via` describes
+   * delivery to the agent and is independent of `CoreTool.surface`; for
+   * example, a code surface may be delivered through MCP or a CLI wrapper.
+   */
+  agentMount?: AgentMount;
+  /**
+   * Best-effort evidence captured from the current surface state. Harnesses may
+   * call this after individual actions and once more at the end of a run.
+   * Implementations must swallow per-field failures and must not throw.
+   */
+  captureEvidence?: () => Promise<ProbeEvidence>;
+  /** Releases the runtime; `captureEvidence` is invalid after this resolves. */
   cleanup: () => Promise<void>;
   metadata: {
     environment: EnvironmentName;
@@ -146,9 +161,59 @@ export interface ToolStartResult {
 export interface CoreTool {
   id: ToolSurface;
   surface: "code" | "mcp" | "cli";
-  family: "understudy" | "playwright" | "cdp" | "stagehand_cli" | "chrome_devtools";
+  family: "understudy" | "stagehand" | "playwright" | "cdp" | "stagehand_cli" | "chrome_devtools";
   supportedStartupProfiles: StartupProfile[];
   supportedCapabilities: CoreCapability[];
   supportedTargetKinds: TargetKind[];
   start(input: ToolStartInput): Promise<ToolStartResult>;
 }
+
+/**
+ * The MCP server / tool name used when an agent harness wraps handles in a
+ * code-execution tool.
+ */
+export const AGENT_RUN_TOOL_SERVER = "stagehand_browser";
+export const AGENT_RUN_TOOL_NAME = `mcp__${AGENT_RUN_TOOL_SERVER}__run`;
+export const AGENT_RUN_TOOL_RESERVED_HANDLES = ["startUrl", "task", "console"] as const;
+
+/**
+ * Surface-specific copy for the harness's code-execution tool. The harness
+ * owns mechanics and task bindings; the surface owns what the agent sees.
+ */
+export interface AgentRunToolSpec {
+  /** MCP tool description shown to the model. */
+  description: string;
+  /** Description of the tool's `code` parameter. */
+  codeParamDescription: string;
+  /** Message from the harness-owned tool allowlist when access is denied. */
+  denyMessage: string;
+}
+
+/**
+ * How an agent harness reaches an already-running surface. This is independent
+ * of `CoreTool.surface`; harnesses switch on `via` and need no surface-specific
+ * mounting logic.
+ */
+export type AgentMount = { promptInstructions: string } & (
+  | {
+      via: "handles";
+      /**
+       * Named values placed in snippet scope. Names, not order, bind values.
+       * `AGENT_RUN_TOOL_RESERVED_HANDLES` are injected by the harness and may
+       * not appear here.
+       */
+      handles: Record<string, unknown>;
+      runTool: AgentRunToolSpec;
+    }
+  | { via: "mcp"; mcpServers: Record<string, unknown> }
+  | {
+      via: "cli";
+      command: {
+        bin: string;
+        args?: string[];
+        cwd?: string;
+        /** Extra variables merged over the harness environment. */
+        env?: Record<string, string>;
+      };
+    }
+);

--- a/packages/evals/tests/core/tool-contract.test.ts
+++ b/packages/evals/tests/core/tool-contract.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import type {
+  AgentMount,
+  CoreSession,
+  CoreTool,
+  ToolStartResult,
+} from "../../core/contracts/tool.js";
+
+describe("tool surface contract", () => {
+  it("keeps native surface and agent delivery independent", async () => {
+    const screenshot = Buffer.from("surface screenshot");
+    const cliMount = {
+      via: "cli",
+      promptInstructions: "Use the wrapper command.",
+      command: { bin: "stagehand-browser", env: {} },
+    } satisfies AgentMount;
+
+    const runningCodeSurface: ToolStartResult = {
+      session: {} as CoreSession,
+      agentMount: cliMount,
+      captureEvidence: async () => ({
+        screenshot,
+        url: "https://example.com",
+        ariaTree: "- document\n  - heading: Example",
+      }),
+      cleanup: async () => {},
+      metadata: {
+        environment: "local",
+        browserOwnership: "tool",
+        connectionMode: "launch",
+      },
+    };
+
+    const codeSurface: CoreTool = {
+      id: "playwright_code",
+      surface: "code",
+      family: "playwright",
+      supportedStartupProfiles: [],
+      supportedCapabilities: [],
+      supportedTargetKinds: [],
+      start: async () => runningCodeSurface,
+    };
+
+    expect(codeSurface.surface).toBe("code");
+    expect(runningCodeSurface.agentMount?.via).toBe("cli");
+    await expect(runningCodeSurface.captureEvidence?.()).resolves.toEqual({
+      screenshot,
+      url: "https://example.com",
+      ariaTree: "- document\n  - heading: Example",
+    });
+  });
+
+  it("describes injected handles without harness-owned task bindings", () => {
+    const mount = {
+      via: "handles",
+      promptInstructions: "Use the run tool.",
+      handles: { page: {} },
+      runTool: {
+        description: "Run browser code.",
+        codeParamDescription: "JavaScript to execute.",
+        denyMessage: "Use the run tool.",
+      },
+    } satisfies AgentMount;
+
+    expect(mount.via).toBe("handles");
+  });
+
+  it("requires delivery-specific fields at compile time", () => {
+    // @ts-expect-error CLI mounts require a command.
+    const invalidMount: AgentMount = {
+      via: "cli",
+      promptInstructions: "Use the CLI.",
+    };
+
+    expect(invalidMount.via).toBe("cli");
+  });
+});


### PR DESCRIPTION
## Summary

Corrects the base-target mistake from #2590 by landing its merged agent-mount contract on v4-spike.

This branch is exactly current v4-spike plus the #2590 squash commit:
- AgentMount is the lifecycle-free agent delivery binding
- ToolStartResult owns the single runtime lifecycle and captureEvidence
- contract tests cover independent surface/mount modalities

After merge, #2591 and the remaining stack will be rebased directly onto v4-spike.

## Verification

- pnpm --filter @browserbasehq/stagehand-evals typecheck
- contract and downstream stack suites validated during restack

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes the agent-mount tool-surface contract to `v4-spike`, adding type-safe agent delivery bindings and best-effort evidence capture, independent of `CoreTool.surface`. Types and tests only; no runtime changes.

- **New Features**
  - `ToolStartResult` adds optional `agentMount` and `captureEvidence(): Promise<ProbeEvidence>`.
  - New `AgentMount` union (`via: handles | mcp | cli`) with `promptInstructions`; plus `AgentRunToolSpec`.
  - Constants: `AGENT_RUN_TOOL_SERVER`, `AGENT_RUN_TOOL_NAME`, `AGENT_RUN_TOOL_RESERVED_HANDLES`. Enums: `ToolSurface` adds `stagehand_code`; `CoreTool.family` adds `stagehand`.
  - Tests (`packages/evals/tests/core/tool-contract.test.ts`) validate surface/delivery independence, handle mounts, and evidence capture.

<sup>Written for commit fd742103c706db7daa6789d5d4029f72bb567c48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

