### PR TITLE
feat: publish the Stagehand code-mode MCP

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,7 +6,8 @@
       "@browserbasehq/stagehand",
       "@browserbasehq/stagehand-python",
       "@browserbasehq/stagehand-go",
-      "@browserbasehq/stagehand-extension"
+      "@browserbasehq/stagehand-extension",
+      "@browserbasehq/stagehand-codemode"
     ]
   ],
   "linked": [],

--- a/.changeset/famous-poems-dream.md
+++ b/.changeset/famous-poems-dream.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand-codemode": patch
+---
+
+Publish the Stagehand code-mode MCP server and its agent guidance as a public package.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,15 @@ jobs:
         with:
           use-prebuilt-artifacts: "true"
 
-      - run: pnpm exec turbo run test:unit --filter @browserbasehq/stagehand-integrations
+      - uses: ./.github/actions/setup-chrome-verified
+        id: setup-chrome
+
+      - run: pnpm exec turbo run test:unit --filter @browserbasehq/stagehand-codemode
+      - run: pnpm --filter @browserbasehq/stagehand-codemode smoke:package
+        env:
+          BROWSERBASE_API_KEY: ${{ secrets.BROWSERBASE_API_KEY }}
+          CHROME_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
+          CI: "true"
 
   browser-ts:
     name: TypeScript browser

--- a/justfile
+++ b/justfile
@@ -88,4 +88,5 @@ _preview commit:
 
 _publish-typescript:
     pnpm --filter ./packages/sdk-ts build
+    pnpm --filter @browserbasehq/stagehand-codemode build
     pnpm exec changeset publish

--- a/packages/integrations/LICENSE
+++ b/packages/integrations/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Browserbase Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/integrations/README.md
+++ b/packages/integrations/README.md
@@ -1,52 +1,43 @@
-# Stagehand integrations
+# Stagehand code mode
 
-This package contains shared integration surfaces for Stagehand V4. It is private while the public API and packaging contract are validated.
+`@browserbasehq/stagehand-codemode` is a stateful Model Context Protocol (MCP) server that gives an
+agent one `code_execute` tool backed by Stagehand. One server process owns one browser session, so
+pages, cookies, JavaScript state, and navigation persist across tool calls.
 
-## Code mode
+> **Security:** `stagehand-codemode` executes arbitrary JavaScript with the permissions of its own
+> process. The package is not a sandbox. Run it inside an isolation boundary when code is generated
+> by a model or is otherwise untrusted.
 
-The `./codemode` export gives an agent one `code_execute` tool backed by a persistent Stagehand browser. Frameworks can either launch the thin local MCP server or wrap `StagehandCodeExecutor` as a native tool.
+## Install and run
 
-```ts
-import {
-  StagehandCodeExecutor,
-  stagehandCodeConfigFromEnv,
-} from "@browserbasehq/stagehand-integrations/codemode";
+Use an exact version in MCP client configuration:
 
-const executor = new StagehandCodeExecutor(stagehandCodeConfigFromEnv());
-
-try {
-  const result = await executor.execute({
-    code: `
-      await page.goto("https://example.com", { waitUntil: "domcontentloaded" });
-      return { title: await page.title(), url: await page.url() };
-    `,
-  });
-  console.log(result);
-} finally {
-  await executor.close();
+```json
+{
+  "mcpServers": {
+    "stagehand": {
+      "command": "npx",
+      "args": ["-y", "@browserbasehq/stagehand-codemode@4.0.0"],
+      "env": {
+        "STAGEHAND_BROWSER": "browserbase",
+        "BROWSERBASE_API_KEY": "<browserbase-api-key>",
+        "BROWSERBASE_PROJECT_ID": "<browserbase-project-id>"
+      }
+    }
+  }
 }
 ```
 
-The executor initializes the browser on the first valid call, serializes calls, and preserves pages, cookies, and navigation state until its owner closes it.
+For a trusted local browser:
 
-### Low-level eval integration
-
-Eval harnesses that already own Stagehand and browser initialization should call `executeStagehandSnippet` directly. This reuses the exact generated-code semantics without replacing the eval harness's startup, cleanup, task bindings, or metrics collection.
-
-### Local MCP integration
-
-The `./codemode/stdio-server` export is an internal process entrypoint. It is not a command-line interface and accepts no arguments. The owning framework launches one process per agent run and selects local or Browserbase startup through its environment:
-
-```text
-STAGEHAND_BROWSER=local
-STAGEHAND_BROWSER=browserbase
+```bash
+STAGEHAND_BROWSER=local npx -y @browserbasehq/stagehand-codemode@4.0.0
 ```
 
-The process stays alive across calls and closes when its input stream ends. `SIGINT` and `SIGTERM` perform bounded graceful cleanup and preserve signal-style exit codes. If generated JavaScript blocks the JavaScript event loop, the server cannot run its cleanup handlers. The owner must terminate the entire process tree, escalate to `SIGKILL` after its own deadline, and start a new process before accepting more work. Killing only the Node process can leave its local browser child alive.
+The executable writes MCP protocol frames only to stdout. Readiness and diagnostics go to stderr.
+It exposes exactly one MCP tool: `code_execute`.
 
-### Configuration
-
-`stagehandCodeConfigFromEnv()` recognizes:
+## Configuration
 
 | Variable                                                           | Purpose                                                          |
 | ------------------------------------------------------------------ | ---------------------------------------------------------------- |
@@ -58,14 +49,29 @@ The process stays alive across calls and closes when its input stream ends. `SIG
 | Provider API keys                                                  | Supplies the key for a matching explicit model provider          |
 | `GEMINI_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`, `GOOGLE_API_KEY` | Selects `google/gemini-2.5-flash-lite` when no model is explicit |
 
-Without a browser override, the helper selects Browserbase when `BROWSERBASE_API_KEY` exists and a headless local browser otherwise.
+Without a browser override, the server selects Browserbase when `BROWSERBASE_API_KEY` exists and a
+headless local browser otherwise.
 
-Native callers run generated JavaScript in their own process. An `AbortSignal` can cancel queued work before the snippet begins, but it cannot safely preempt arbitrary JavaScript already running in the same process. Native integrations that require hard time limits should put the executor behind a child-process boundary, as the stdio MCP integration does.
+## Lifecycle and hard timeouts
 
-### Skill and reference
+The process stays alive until stdin ends. `SIGINT` and `SIGTERM` perform bounded graceful cleanup and
+preserve conventional signal exit codes.
 
-`codemode/SKILL.md` is the concise agent guide. `codemode/REFERENCE.md` is the longer API lookup. Both are exported as raw package assets and as bundle-safe JavaScript strings.
+JavaScript that blocks the Node.js event loop cannot be interrupted by an in-process timer. The
+owning sandbox or process supervisor must enforce a wall-clock deadline, terminate the complete
+process tree, escalate to `SIGKILL` when needed, and create a fresh process before accepting more
+work. Killing only the Node.js process can leave a local browser child running.
 
-### Security boundary
+For model-generated code, run the executable inside a disposable microVM or equivalent isolation
+boundary. Apply separate filesystem, egress, credential, quota, and browser-navigation policies for
+the authority your application intends to grant.
 
-The code-mode executor does not provide a sandbox. Generated JavaScript runs in the host process and inherits that process's filesystem, network, and environment access. A framework may place the tool inside its own sandbox, container, or other isolation boundary.
+## Agent guidance
+
+The published package includes the model-facing assets as exported package files:
+
+- `@browserbasehq/stagehand-codemode/SKILL.md`
+- `@browserbasehq/stagehand-codemode/REFERENCE.md`
+
+The first public release intentionally supports the executable and these two assets only. Internal
+implementation modules and an in-process arbitrary-code executor are not public package APIs.

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -1,29 +1,50 @@
 {
-  "name": "@browserbasehq/stagehand-integrations",
+  "name": "@browserbasehq/stagehand-codemode",
   "version": "4.0.0",
-  "private": true,
-  "description": "Shared integration surfaces for Stagehand V4",
+  "description": "A stateful code-execution MCP server for Stagehand",
+  "keywords": [
+    "ai",
+    "browser",
+    "mcp",
+    "stagehand"
+  ],
+  "homepage": "https://stagehand.dev",
+  "bugs": {
+    "url": "https://github.com/browserbase/stagehand/issues"
+  },
+  "license": "MIT",
+  "author": "Browserbase",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/browserbase/stagehand.git",
+    "directory": "packages/integrations"
+  },
+  "bin": {
+    "stagehand-codemode": "dist/codemode/stdio-server.mjs"
+  },
   "files": [
     "dist",
     "codemode/SKILL.md",
-    "codemode/REFERENCE.md"
+    "codemode/REFERENCE.md",
+    "LICENSE",
+    "README.md"
   ],
   "type": "module",
   "exports": {
-    "./codemode": {
-      "types": "./dist/codemode/index.d.mts",
-      "import": "./dist/codemode/index.mjs"
-    },
-    "./codemode/stdio-server": {
-      "import": "./dist/codemode/stdio-server.mjs"
-    },
-    "./codemode/SKILL.md": "./codemode/SKILL.md",
-    "./codemode/REFERENCE.md": "./codemode/REFERENCE.md"
+    "./SKILL.md": "./codemode/SKILL.md",
+    "./REFERENCE.md": "./codemode/REFERENCE.md"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
   },
   "scripts": {
-    "build": "pnpm run check:generated && tsdown",
+    "build": "pnpm run check:generated && tsdown && node scripts/prepare-package.mjs",
     "check:generated": "node scripts/generate-codemode-content.mjs --check",
     "generate": "node scripts/generate-codemode-content.mjs",
+    "lint:package": "publint",
+    "prepack": "pnpm run build && pnpm run lint:package",
+    "smoke:package": "node scripts/package-smoke.mjs",
     "test": "pnpm run build && vitest run --root ../.. packages/integrations/tests",
     "test:unit": "vitest run --root ../.. packages/integrations/tests",
     "typecheck": "pnpm run check:generated && tsc --noEmit -p tsconfig.json"
@@ -35,6 +56,7 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
+    "publint": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/packages/integrations/scripts/package-smoke.mjs
+++ b/packages/integrations/scripts/package-smoke.mjs
@@ -1,0 +1,363 @@
+import assert from "node:assert/strict";
+import { execFile, spawn } from "node:child_process";
+import { constants } from "node:fs";
+import { access, mkdir, mkdtemp, readFile, readdir, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const packageRoot = fileURLToPath(new URL("..", import.meta.url));
+const repositoryRoot = path.resolve(packageRoot, "../..");
+const sdkRoot = path.join(repositoryRoot, "packages", "sdk-ts");
+const temporaryRoot = await mkdtemp(path.join(tmpdir(), "stagehand-codemode-package-"));
+const artifactRoot = path.join(temporaryRoot, "artifacts");
+const installRoot = path.join(temporaryRoot, "install");
+
+try {
+  await Promise.all([
+    mkdir(artifactRoot, { recursive: true }),
+    mkdir(installRoot, { recursive: true }),
+  ]);
+  await execFileAsync(
+    "pnpm",
+    ["exec", "turbo", "run", "build", "--filter", "@browserbasehq/stagehand-codemode"],
+    { cwd: repositoryRoot },
+  );
+  await execFileAsync("pnpm", ["pack", "--pack-destination", artifactRoot], {
+    cwd: sdkRoot,
+  });
+  await execFileAsync("pnpm", ["pack", "--pack-destination", artifactRoot], {
+    cwd: packageRoot,
+  });
+
+  const artifacts = await readdir(artifactRoot);
+  const sdkTarball = requiredArtifact(artifacts, "browserbasehq-stagehand-4.0.0.tgz");
+  const codeModeTarball = requiredArtifact(artifacts, "browserbasehq-stagehand-codemode-4.0.0.tgz");
+  const codeModeTarballPath = path.join(artifactRoot, codeModeTarball);
+  const { stdout: tarList } = await execFileAsync("tar", ["-tzf", codeModeTarballPath]);
+  const files = tarList.trim().split("\n").sort();
+  for (const expected of [
+    "package/LICENSE",
+    "package/README.md",
+    "package/codemode/REFERENCE.md",
+    "package/codemode/SKILL.md",
+    "package/dist/codemode/stdio-server.mjs",
+    "package/package.json",
+  ]) {
+    assert.ok(files.includes(expected), `packed artifact is missing ${expected}`);
+  }
+  assert.equal(
+    files.some((file) => /package\/(?:src|tests|examples)\//.test(file)),
+    false,
+    "packed artifact includes repository-only source or test files",
+  );
+  const { stdout: verboseTarList } = await execFileAsync("tar", ["-tvzf", codeModeTarballPath]);
+  assert.match(
+    verboseTarList,
+    /^-rwxr-xr-x\s+[^\n]*package\/dist\/codemode\/stdio-server\.mjs$/m,
+    "packed stagehand-codemode executable is not mode 755",
+  );
+
+  await execFileAsync(
+    "npm",
+    [
+      "install",
+      "--ignore-scripts",
+      "--no-audit",
+      "--no-fund",
+      path.join(artifactRoot, sdkTarball),
+      codeModeTarballPath,
+    ],
+    { cwd: installRoot },
+  );
+
+  const installedPackageRoot = path.join(
+    installRoot,
+    "node_modules",
+    "@browserbasehq",
+    "stagehand-codemode",
+  );
+  const manifest = JSON.parse(
+    await readFile(path.join(installedPackageRoot, "package.json"), "utf8"),
+  );
+  assert.equal(manifest.name, "@browserbasehq/stagehand-codemode");
+  assert.equal(manifest.dependencies?.["@browserbasehq/stagehand"], "4.0.0");
+  assert.deepEqual(manifest.bin, {
+    "stagehand-codemode": "dist/codemode/stdio-server.mjs",
+  });
+
+  const executable = path.join(installRoot, "node_modules", ".bin", "stagehand-codemode");
+  await access(executable, constants.X_OK);
+  await verifyDiscoveryAndEof(executable);
+  await verifySignals(executable);
+  const localBrowser = process.env.CHROME_PATH
+    ? await verifyLocalBrowserAndHardTimeout(executable)
+    : "SKIPPED";
+  const browserbase = process.env.BROWSERBASE_API_KEY
+    ? await verifyBrowserbasePersistence(executable)
+    : "SKIPPED";
+
+  process.stdout.write(
+    `${JSON.stringify({
+      status: "PASS",
+      package: manifest.name,
+      version: manifest.version,
+      stagehandDependency: manifest.dependencies["@browserbasehq/stagehand"],
+      executable: "stagehand-codemode",
+      tools: ["code_execute"],
+      eof: "PASS",
+      signals: ["SIGINT", "SIGTERM"],
+      localBrowser,
+      hardTimeout: localBrowser === "PASS" ? "PASS" : "SKIPPED",
+      browserbase,
+      tarballBytes: (await stat(codeModeTarballPath)).size,
+      files: files.length,
+    })}\n`,
+  );
+} finally {
+  await rm(temporaryRoot, { force: true, recursive: true });
+}
+
+function requiredArtifact(artifacts, suffix) {
+  const matches = artifacts.filter((artifact) => artifact.endsWith(suffix));
+  assert.equal(matches.length, 1, `expected one artifact ending in ${suffix}`);
+  return matches[0];
+}
+
+async function verifyDiscoveryAndEof(executable) {
+  const { rpc, server } = await initializedServer(executable, "local");
+  try {
+    const listed = await rpc.request("tools/list", {});
+    assert.deepEqual(
+      listed.tools?.map((tool) => tool.name),
+      ["code_execute"],
+    );
+    server.stdin.end();
+    assert.deepEqual(await waitForExit(server), { code: 0, signal: null });
+  } finally {
+    if (server.exitCode === null && server.signalCode === null) server.kill("SIGKILL");
+  }
+}
+
+async function verifySignals(executable) {
+  for (const [signal, expectedCode] of [
+    ["SIGINT", 130],
+    ["SIGTERM", 143],
+  ]) {
+    const { server } = await initializedServer(executable, "local");
+    try {
+      server.kill(signal);
+      assert.deepEqual(await waitForExit(server), { code: expectedCode, signal: null });
+    } finally {
+      if (server.exitCode === null && server.signalCode === null) server.kill("SIGKILL");
+    }
+  }
+}
+
+async function verifyLocalBrowserAndHardTimeout(executable) {
+  const { rpc, server } = await initializedServer(executable, "local");
+  try {
+    const result = await rpc.request("tools/call", {
+      name: "code_execute",
+      arguments: {
+        code: `
+          await page.goto("https://example.com", { waitUntil: "domcontentloaded" });
+          return { title: await page.title(), url: await page.url() };
+        `,
+      },
+    });
+    assert.equal(result.isError ?? false, false);
+    assert.deepEqual(result.structuredContent?.value, {
+      title: "Example Domain",
+      url: "https://example.com/",
+    });
+    server.stdin.end();
+    assert.deepEqual(await waitForExit(server), { code: 0, signal: null });
+  } finally {
+    if (server.exitCode === null && server.signalCode === null) server.kill("SIGKILL");
+  }
+
+  const blocked = await initializedServer(executable, "local", true);
+  try {
+    const initialized = await blocked.rpc.request("tools/call", {
+      name: "code_execute",
+      arguments: { code: "return { ready: true };" },
+    });
+    assert.equal(initialized.structuredContent?.value?.ready, true);
+    const neverFinishes = blocked.rpc
+      .request("tools/call", {
+        name: "code_execute",
+        arguments: { code: "while (true) {}" },
+      })
+      .then(
+        () => "resolved",
+        () => "rejected",
+      );
+    assert.equal(await Promise.race([neverFinishes, delay(500).then(() => "blocked")]), "blocked");
+    killProcessGroup(blocked.server, "SIGKILL");
+    assert.deepEqual(await waitForExit(blocked.server), { code: null, signal: "SIGKILL" });
+    assert.equal(await neverFinishes, "rejected");
+  } finally {
+    if (blocked.server.exitCode === null && blocked.server.signalCode === null) {
+      killProcessGroup(blocked.server, "SIGKILL");
+    }
+  }
+  return "PASS";
+}
+
+async function verifyBrowserbasePersistence(executable) {
+  const marker = `package-${Date.now()}`;
+  const { rpc, server } = await initializedServer(executable, "browserbase");
+  try {
+    const first = await rpc.request("tools/call", {
+      name: "code_execute",
+      arguments: {
+        code: `
+          await page.goto("https://example.com", { waitUntil: "domcontentloaded" });
+          await page.evaluate((marker) => {
+            document.documentElement.dataset.packageSmoke = marker;
+          }, ${JSON.stringify(marker)});
+          return { title: await page.title(), pageId: page.pageId };
+        `,
+      },
+    });
+    const second = await rpc.request("tools/call", {
+      name: "code_execute",
+      arguments: {
+        code: `
+          return {
+            title: await page.title(),
+            pageId: page.pageId,
+            marker: await page.evaluate(
+              () => document.documentElement.dataset.packageSmoke,
+            ),
+          };
+        `,
+      },
+    });
+    assert.equal(first.isError ?? false, false);
+    assert.equal(second.isError ?? false, false);
+    assert.equal(first.structuredContent?.value?.title, "Example Domain");
+    assert.equal(second.structuredContent?.value?.title, "Example Domain");
+    assert.equal(second.structuredContent?.value?.pageId, first.structuredContent?.value?.pageId);
+    assert.equal(second.structuredContent?.value?.marker, marker);
+    server.stdin.end();
+    assert.deepEqual(await waitForExit(server), { code: 0, signal: null });
+  } finally {
+    if (server.exitCode === null && server.signalCode === null) server.kill("SIGKILL");
+  }
+  return "PASS";
+}
+
+async function initializedServer(executable, browser, detached = false) {
+  const server = spawn(executable, [], {
+    cwd: installRoot,
+    detached,
+    env: runtimeEnvironment(browser),
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  let stderr = "";
+  server.stderr.on("data", (chunk) => {
+    stderr += chunk.toString();
+  });
+  try {
+    const rpc = jsonRpcClient(server);
+    const initialized = await rpc.request("initialize", {
+      protocolVersion: "2025-11-25",
+      capabilities: {},
+      clientInfo: { name: "stagehand-codemode-package-smoke", version: "1.0.0" },
+    });
+    assert.equal(initialized.serverInfo?.name, "stagehand-codemode");
+    rpc.notify("notifications/initialized", {});
+    return { rpc, server };
+  } catch (error) {
+    if (server.exitCode === null && server.signalCode === null) server.kill("SIGKILL");
+    throw new Error(`Installed stagehand-codemode failed to initialize: ${stderr}`, {
+      cause: error,
+    });
+  }
+}
+
+function runtimeEnvironment(browser) {
+  const environment = {
+    PATH: process.env.PATH ?? "",
+    STAGEHAND_BROWSER: browser,
+  };
+  const names = ["CHROME_PATH", "CI", "HOME", "TMPDIR"];
+  if (browser === "browserbase") {
+    names.push("BROWSERBASE_API_KEY", "BROWSERBASE_PROJECT_ID");
+  }
+  for (const name of names) {
+    const value = process.env[name];
+    if (value) environment[name] = value;
+  }
+  return environment;
+}
+
+function jsonRpcClient(child) {
+  let nextId = 1;
+  let buffered = "";
+  const pending = new Map();
+  child.stdout.on("data", (chunk) => {
+    buffered += chunk.toString();
+    while (buffered.includes("\n")) {
+      const newline = buffered.indexOf("\n");
+      const line = buffered.slice(0, newline);
+      buffered = buffered.slice(newline + 1);
+      if (!line) continue;
+      const message = JSON.parse(line);
+      if (message.id === undefined) continue;
+      const waiter = pending.get(message.id);
+      if (!waiter) continue;
+      pending.delete(message.id);
+      if (message.error) waiter.reject(new Error(`MCP error ${message.error.code}`));
+      else waiter.resolve(message.result);
+    }
+  });
+  child.once("close", () => {
+    for (const waiter of pending.values()) waiter.reject(new Error("MCP process closed"));
+    pending.clear();
+  });
+
+  const send = (message) => child.stdin.write(`${JSON.stringify(message)}\n`);
+  return {
+    notify(method, params) {
+      send({ jsonrpc: "2.0", method, params });
+    },
+    request(method, params) {
+      const id = nextId++;
+      const response = new Promise((resolve, reject) => pending.set(id, { resolve, reject }));
+      send({ jsonrpc: "2.0", id, method, params });
+      return withTimeout(response, `Timed out waiting for MCP ${method}`);
+    },
+  };
+}
+
+function killProcessGroup(child, signal) {
+  assert.ok(child.pid, "detached MCP server has no process ID");
+  process.kill(-child.pid, signal);
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function waitForExit(child) {
+  return withTimeout(
+    new Promise((resolve, reject) => {
+      child.once("error", reject);
+      child.once("close", (code, signal) => resolve({ code, signal }));
+    }),
+    "Installed stagehand-codemode did not exit",
+  );
+}
+
+function withTimeout(promise, message) {
+  let timeout;
+  const deadline = new Promise((_, reject) => {
+    timeout = setTimeout(() => reject(new Error(message)), 15_000);
+  });
+  return Promise.race([promise, deadline]).finally(() => clearTimeout(timeout));
+}

--- a/packages/integrations/scripts/prepare-package.mjs
+++ b/packages/integrations/scripts/prepare-package.mjs
@@ -1,0 +1,11 @@
+import { access, chmod, readFile } from "node:fs/promises";
+import { constants } from "node:fs";
+
+const executable = new URL("../dist/codemode/stdio-server.mjs", import.meta.url);
+const contents = await readFile(executable, "utf8");
+if (!contents.startsWith("#!/usr/bin/env node\n")) {
+  throw new Error("The compiled stagehand-codemode executable is missing its Node shebang");
+}
+
+await chmod(executable, 0o755);
+await access(executable, constants.X_OK);

--- a/packages/integrations/src/codemode/stdio-server.ts
+++ b/packages/integrations/src/codemode/stdio-server.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { stagehandCodeConfigFromEnv } from "./config.js";
 import { StagehandCodeExecutor } from "./executor.js";
 import { createCodeModeMcpServer } from "./mcp-server.js";

--- a/packages/integrations/tests/generated-content.test.ts
+++ b/packages/integrations/tests/generated-content.test.ts
@@ -34,12 +34,9 @@ describe("generated code-mode content", () => {
 
   it("resolves the raw Markdown assets through package exports", async () => {
     const [skill, reference] = await Promise.all([
+      readFile(new URL(import.meta.resolve("@browserbasehq/stagehand-codemode/SKILL.md")), "utf8"),
       readFile(
-        new URL(import.meta.resolve("@browserbasehq/stagehand-integrations/codemode/SKILL.md")),
-        "utf8",
-      ),
-      readFile(
-        new URL(import.meta.resolve("@browserbasehq/stagehand-integrations/codemode/REFERENCE.md")),
+        new URL(import.meta.resolve("@browserbasehq/stagehand-codemode/REFERENCE.md")),
         "utf8",
       ),
     ]);

--- a/packages/integrations/tsdown.config.ts
+++ b/packages/integrations/tsdown.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from "tsdown";
 
 export default defineConfig({
   entry: {
-    "codemode/index": "src/codemode/index.ts",
     "codemode/stdio-server": "src/codemode/stdio-server.ts",
   },
   format: ["esm"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -579,6 +579,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.2
+      publint:
+        specifier: 'catalog:'
+        version: 0.3.21
       tsdown:
         specifier: 'catalog:'
         version: 0.22.3(publint@0.3.21)(tsx@4.23.1)(typescript@5.9.3)

--- a/scripts/release/check-changesets.test.ts
+++ b/scripts/release/check-changesets.test.ts
@@ -10,6 +10,7 @@ describe("validateChangeset", () => {
 "@browserbasehq/stagehand-python": patch
 "@browserbasehq/stagehand-go": patch
 "@browserbasehq/stagehand-extension": patch
+"@browserbasehq/stagehand-codemode": patch
 ---
 
 Release the SDKs.

--- a/scripts/release/check-changesets.ts
+++ b/scripts/release/check-changesets.ts
@@ -9,6 +9,7 @@ const allowedPackages = new Set([
   "@browserbasehq/stagehand-protocol",
   "@browserbasehq/stagehand-python",
   "@browserbasehq/stagehand-extension",
+  "@browserbasehq/stagehand-codemode",
 ]);
 
 export function validateChangeset(contents: string, file: string): void {

--- a/turbo.json
+++ b/turbo.json
@@ -26,7 +26,7 @@
       "inputs": ["$TURBO_DEFAULT$", "!dist/**"],
       "outputs": ["dist/**"]
     },
-    "@browserbasehq/stagehand-integrations#build": {
+    "@browserbasehq/stagehand-codemode#build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", "!dist/**"],
       "outputs": ["dist/**"]
@@ -71,11 +71,11 @@
     "@browserbasehq/stagehand-evals#typecheck": {
       "dependsOn": ["^build"]
     },
-    "@browserbasehq/stagehand-integrations#typecheck": {
+    "@browserbasehq/stagehand-codemode#typecheck": {
       "dependsOn": ["^build"]
     },
-    "@browserbasehq/stagehand-integrations#test:unit": {
-      "dependsOn": ["^build", "@browserbasehq/stagehand-integrations#build"],
+    "@browserbasehq/stagehand-codemode#test:unit": {
+      "dependsOn": ["^build", "@browserbasehq/stagehand-codemode#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "tests/**",


### PR DESCRIPTION
## Why

The code-mode MCP needs one stable distribution contract before sandbox and framework integrations can stop cloning the monorepo or depending on internal build paths.

## Public contract

- npm package: `@browserbasehq/stagehand-codemode`
- executable: `stagehand-codemode`
- versioning: coupled to the Stagehand V4 fixed group
- exported assets: `SKILL.md` and `REFERENCE.md`
- intentionally not public: internal implementation modules and the in-process arbitrary-code executor

The executable exposes exactly one stateful MCP tool, `code_execute`, and reserves stdout for MCP protocol frames.

## Release wiring

- enables public npm publication with provenance
- adds the package to Changesets validation and the V4 fixed group
- explicitly builds it before `changeset publish`
- adds `publint`, a shebang/executable-mode check, and a package-specific clean-install smoke
- relies on the reviewed `main` Changesets workflow; this PR does not perform an ad hoc publish

The package is already versioned 4.0.0 alongside the unpublished Stagehand V4 packages. There is no changeset in this PR: once the V4 stack reaches `main`, the normal release workflow can publish the previously unpublished 4.0.0 artifacts together.

## Security

`stagehand-codemode` executes arbitrary JavaScript with its process permissions. It is not a sandbox. The README puts this warning before the installation examples and requires a separate isolation boundary for model-generated or otherwise untrusted code.

## Verification

| Gate | Result |
| --- | --- |
| Build + generated-content drift check | PASS |
| `publint` | PASS |
| Pack exact review artifact | PASS: 8 files, 26,674-byte tarball |
| Tarball file/mode audit | PASS: no source/tests/examples; executable mode 0755 |
| Clean temporary npm install | PASS using exact local Stagehand V4 and code-mode tarballs, no workspace links |
| Installed executable initialize + tools/list | PASS: exactly `code_execute` |
| Installed executable EOF, SIGINT, SIGTERM | PASS |
| Installed artifact + Google Chrome stable navigation | PASS: Example Domain |
| Hard-timeout owner/process-group kill | PASS |
| Browserbase two-call state persistence | Required CI gate using the repository secret |
| `npm publish --dry-run --json` | PASS |
| Package/release unit tests | 71/71 PASS |
| Full repository `pnpm check` | 9/9 tasks PASS |

The configured registry returned 404 for both `@browserbasehq/stagehand-codemode` and `@browserbasehq/stagehand@4.0.0` before this PR was opened.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish the Stagehand code‑mode MCP as a public npm package `@browserbasehq/stagehand-codemode` with the `stagehand-codemode` executable and a stable distribution contract. This unblocks STG‑2765 by giving agent integrations a versioned MCP tool they can run without cloning the repo.

- **New Features**
  - New package `@browserbasehq/stagehand-codemode` with executable `stagehand-codemode` (stdio MCP server exposing one tool: `code_execute`; stdout reserved for MCP frames).
  - One server process owns one browser; pages, cookies, and JS state persist across tool calls.
  - Exports `SKILL.md` and `REFERENCE.md` as package assets; internal JS APIs and the in‑process executor are not public.
  - Release/CI: added to V4 fixed group and Changesets (patch entry included); MIT license + README; provenance publish; shebang + 0755 enforcement; `publint`; package smoke tests in CI (local Chrome and Browserbase).

- **Migration**
  - Use via MCP: `npx -y @browserbasehq/stagehand-codemode@4.0.0`; set `STAGEHAND_BROWSER=browserbase|local` and relevant env (`BROWSERBASE_API_KEY`, `BROWSERBASE_PROJECT_ID`, `CHROME_PATH`).
  - Replace any internal imports from `@browserbasehq/stagehand-integrations/codemode`; run the executable instead. Asset paths: `@browserbasehq/stagehand-codemode/SKILL.md` and `@browserbasehq/stagehand-codemode/REFERENCE.md`.

<sup>Written for commit 54302fc5f13be5ad8e717d8e1388502de22be2ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

