### PR TITLE
Make the v4 examples consistent around `.data` wrapping

### DIFF
--- a/packages/sdk-go/examples/act.go
+++ b/packages/sdk-go/examples/act.go
@@ -60,7 +60,7 @@ func run(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	output, err := json.MarshalIndent(result, "", "  ")
+	output, err := json.MarshalIndent(result.Data, "", "  ")
 	if err != nil {
 		return err
 	}

--- a/packages/sdk-go/examples/custom_llm.go
+++ b/packages/sdk-go/examples/custom_llm.go
@@ -53,7 +53,7 @@ func run(ctx context.Context) (err error) {
 		return err
 	}
 
-	extracted, err := stagehand.Extract[pageInfo](
+	extractResult, err := stagehand.Extract[pageInfo](
 		ctx,
 		client,
 		"Extract the page heading and description",
@@ -63,11 +63,11 @@ func run(ctx context.Context) (err error) {
 		return err
 	}
 	instruction := "Find the link that provides more information about Example Domain"
-	actions, err := client.Observe(ctx, &instruction, nil)
+	observeResult, err := client.Observe(ctx, &instruction, nil)
 	if err != nil {
 		return err
 	}
-	actionResult, err := client.Act(
+	actResult, err := client.Act(
 		ctx,
 		stagehand.ActInstruction(
 			"Click the link that provides more information about Example Domain",
@@ -78,17 +78,17 @@ func run(ctx context.Context) (err error) {
 		return err
 	}
 	output, err := json.MarshalIndent(map[string]any{
-		"page_info": extracted.Data, "actions": actions, "action_result": actionResult,
+		"page_info": extractResult.Data, "actions": observeResult.Data, "action_result": actResult.Data,
 	}, "", "  ")
 	if err != nil {
 		return err
 	}
 	fmt.Println(string(output))
-	if len(actions.Data) == 0 {
+	if len(observeResult.Data) == 0 {
 		return errors.New("observe returned no matching actions")
 	}
-	if !actionResult.Data.Success {
-		return fmt.Errorf("act failed: %s", actionResult.Data.Message)
+	if !actResult.Data.Success {
+		return fmt.Errorf("act failed: %s", actResult.Data.Message)
 	}
 	return nil
 }

--- a/packages/sdk-go/examples/custom_logging.go
+++ b/packages/sdk-go/examples/custom_logging.go
@@ -70,10 +70,10 @@ func run(ctx context.Context) (err error) {
 		return err
 	}
 	instruction := "Find the Learn more link"
-	actions, err := client.Observe(ctx, &instruction, nil)
+	result, err := client.Observe(ctx, &instruction, nil)
 	if err != nil {
 		return err
 	}
-	fmt.Println(actions)
+	fmt.Println(result.Data)
 	return nil
 }

--- a/packages/sdk-go/examples/observe.go
+++ b/packages/sdk-go/examples/observe.go
@@ -51,16 +51,16 @@ func run(ctx context.Context) (err error) {
 	}
 
 	instruction := "Find the link that provides more information about Example Domain"
-	actions, err := client.Observe(ctx, &instruction, nil)
+	result, err := client.Observe(ctx, &instruction, nil)
 	if err != nil {
 		return err
 	}
-	output, err := json.MarshalIndent(actions, "", "  ")
+	output, err := json.MarshalIndent(result.Data, "", "  ")
 	if err != nil {
 		return err
 	}
 	fmt.Println(string(output))
-	if len(actions.Data) == 0 {
+	if len(result.Data) == 0 {
 		return errors.New("observe returned no matching actions")
 	}
 	return nil

--- a/packages/sdk-python/examples/act.py
+++ b/packages/sdk-python/examples/act.py
@@ -27,7 +27,7 @@ async def main() -> None:
                 "Click the link that provides more information about Example Domain"
             )
 
-            print(json.dumps(result.model_dump(mode="json", by_alias=True), indent=2))
+            print(json.dumps(result.data.model_dump(mode="json", by_alias=True), indent=2))
 
             if not result.data.success:
                 raise RuntimeError(f"act() failed: {result.data.message}")

--- a/packages/sdk-python/examples/custom_llm.py
+++ b/packages/sdk-python/examples/custom_llm.py
@@ -45,35 +45,36 @@ async def main() -> None:
                 raise RuntimeError("Stagehand initialized without an active page")
             await page.goto("https://example.com")
 
-            page_info = await stagehand.extract(
+            extract_result = await stagehand.extract(
                 "Extract the page heading and description",
                 PageInfo,
             )
-            actions = await stagehand.observe(
+            observe_result = await stagehand.observe(
                 "Find the link that provides more information about Example Domain",
             )
-            action_result = await stagehand.act(
+            act_result = await stagehand.act(
                 "Click the link that provides more information about Example Domain"
             )
 
             print(
                 json.dumps(
                     {
-                        "page_info": page_info.model_dump(mode="json"),
+                        "page_info": extract_result.data.model_dump(mode="json"),
                         "actions": [
-                            action.model_dump(mode="json", by_alias=True) for action in actions.data
+                            action.model_dump(mode="json", by_alias=True)
+                            for action in observe_result.data
                         ],
-                        "action_result": action_result.model_dump(mode="json", by_alias=True),
+                        "action_result": act_result.data.model_dump(mode="json", by_alias=True),
                         "generation_names": generation_names,
                     },
                     indent=2,
                 )
             )
 
-            if not actions.data:
+            if not observe_result.data:
                 raise RuntimeError("observe() returned no matching actions")
-            if not action_result.data.success:
-                raise RuntimeError(f"act() failed: {action_result.data.message}")
+            if not act_result.data.success:
+                raise RuntimeError(f"act() failed: {act_result.data.message}")
         finally:
             await stagehand.close()
     finally:

--- a/packages/sdk-python/examples/custom_logging.py
+++ b/packages/sdk-python/examples/custom_logging.py
@@ -28,7 +28,7 @@ async def main() -> None:
                     raise RuntimeError
 
                 await page.goto("https://example.com")
-                print(await stagehand.observe("Find the Learn more link"))
+                print((await stagehand.observe("Find the Learn more link")).data)
             finally:
                 await stagehand.close()
         finally:

--- a/packages/sdk-python/examples/extract.py
+++ b/packages/sdk-python/examples/extract.py
@@ -30,12 +30,12 @@ async def main() -> None:
                 raise RuntimeError("Stagehand initialized without an active page")
             await page.goto("https://example.com")
 
-            page_info = await stagehand.extract(
+            result = await stagehand.extract(
                 "Extract the page heading and description",
                 PageInfo,
             )
 
-            print(json.dumps(page_info.model_dump(mode="json"), indent=2))
+            print(json.dumps(result.data.model_dump(mode="json"), indent=2))
         finally:
             await stagehand.close()
     finally:

--- a/packages/sdk-python/examples/model_gateway.py
+++ b/packages/sdk-python/examples/model_gateway.py
@@ -28,12 +28,12 @@ async def main() -> None:
                 raise RuntimeError("Stagehand initialized without an active page")
             await page.goto("https://example.com")
 
-            page_info = await stagehand.extract(
+            result = await stagehand.extract(
                 "Extract the page heading and the domain this page says it is for",
                 PageInfo,
             )
 
-            print(json.dumps(page_info.model_dump(mode="json"), indent=2))
+            print(json.dumps(result.data.model_dump(mode="json"), indent=2))
         finally:
             await stagehand.close()
     finally:

--- a/packages/sdk-python/examples/observe.py
+++ b/packages/sdk-python/examples/observe.py
@@ -23,18 +23,18 @@ async def main() -> None:
                 raise RuntimeError("Stagehand initialized without an active page")
             await page.goto("https://example.com")
 
-            actions = await stagehand.observe(
+            result = await stagehand.observe(
                 "Find the link that provides more information about Example Domain",
             )
 
             print(
                 json.dumps(
-                    [action.model_dump(mode="json", by_alias=True) for action in actions.data],
+                    [action.model_dump(mode="json", by_alias=True) for action in result.data],
                     indent=2,
                 )
             )
 
-            if not actions.data:
+            if not result.data:
                 raise RuntimeError("observe() returned no matching actions")
         finally:
             await stagehand.close()

--- a/packages/sdk-ts/examples/act.ts
+++ b/packages/sdk-ts/examples/act.ts
@@ -20,7 +20,7 @@ const result = await stagehand.act(
   "Click the link that provides more information about Example Domain",
 );
 
-console.log(JSON.stringify(result, null, 2));
+console.log(JSON.stringify(result.data, null, 2));
 
 if (!result.data.success) {
   throw new Error(`act() failed: ${result.data.message}`);

--- a/packages/sdk-ts/examples/customLlm.ts
+++ b/packages/sdk-ts/examples/customLlm.ts
@@ -28,27 +28,38 @@ const stagehand = await Stagehand.create({
 const [page] = await browser.context.pages();
 await page.goto("https://example.com");
 
-const pageInfo = await stagehand.extract(
+const extractResult = await stagehand.extract(
   "Extract the page heading and description",
   z.object({
     heading: z.string(),
     description: z.string(),
   }),
 );
-const actions = await stagehand.observe(
+const observeResult = await stagehand.observe(
   "Find the link that provides more information about Example Domain",
 );
-const actionResult = await stagehand.act(
+const actResult = await stagehand.act(
   "Click the link that provides more information about Example Domain",
 );
 
-console.log(JSON.stringify({ pageInfo, actions, actionResult, generationNames }, null, 2));
+console.log(
+  JSON.stringify(
+    {
+      pageInfo: extractResult.data,
+      actions: observeResult.data,
+      actionResult: actResult.data,
+      generationNames,
+    },
+    null,
+    2,
+  ),
+);
 
-if (actions.data.length === 0) {
+if (observeResult.data.length === 0) {
   throw new Error("observe() returned no matching actions");
 }
-if (!actionResult.data.success) {
-  throw new Error(`act() failed: ${actionResult.data.message}`);
+if (!actResult.data.success) {
+  throw new Error(`act() failed: ${actResult.data.message}`);
 }
 
 await stagehand.close();

--- a/packages/sdk-ts/examples/customLogging.ts
+++ b/packages/sdk-ts/examples/customLogging.ts
@@ -27,7 +27,7 @@ const stagehand = await Stagehand.create({
 const [page] = await browser.context.pages();
 
 await page.goto("https://example.com");
-console.log(await stagehand.observe("Find the Learn more link"));
+console.log((await stagehand.observe("Find the Learn more link")).data);
 
 await stagehand.close();
 await browser.close();

--- a/packages/sdk-ts/examples/extract.ts
+++ b/packages/sdk-ts/examples/extract.ts
@@ -17,7 +17,7 @@ const stagehand = await Stagehand.create({
 const [page] = await browser.context.pages();
 await page.goto("https://example.com");
 
-const pageInfo = await stagehand.extract(
+const result = await stagehand.extract(
   "Extract the page heading and description",
   z.object({
     heading: z.string(),
@@ -25,7 +25,7 @@ const pageInfo = await stagehand.extract(
   }),
 );
 
-console.log(JSON.stringify(pageInfo, null, 2));
+console.log(JSON.stringify(result.data, null, 2));
 
 await stagehand.close();
 await browser.close();

--- a/packages/sdk-ts/examples/modelGateway.ts
+++ b/packages/sdk-ts/examples/modelGateway.ts
@@ -21,7 +21,7 @@ try {
     z.object({ heading: z.string(), domain: z.string() }),
   );
 
-  console.log(JSON.stringify(result, null, 2));
+  console.log(JSON.stringify(result.data, null, 2));
 } finally {
   await stagehand.close();
   await browser.close();

--- a/packages/sdk-ts/examples/observe.ts
+++ b/packages/sdk-ts/examples/observe.ts
@@ -16,13 +16,13 @@ const stagehand = await Stagehand.create({
 const [page] = await browser.context.pages();
 await page.goto("https://example.com");
 
-const actions = await stagehand.observe(
+const result = await stagehand.observe(
   "Find the link that provides more information about Example Domain",
 );
 
-console.log(JSON.stringify(actions, null, 2));
+console.log(JSON.stringify(result.data, null, 2));
 
-if (actions.data.length === 0) {
+if (result.data.length === 0) {
   throw new Error("observe() returned no matching actions");
 }
 


### PR DESCRIPTION
# why

Standardizing the example snippets with `.data` wrapping

# what changed

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized all v4 examples to read and print from `.data` instead of the full response, ensuring consistent payload handling across Go, Python, and TypeScript. Addresses Linear STG-2796.

- **Refactors**
  - Go (`packages/sdk-go/examples`): use `result.Data` in prints/checks for `act`, `observe`, and aggregated outputs; adopt `extractResult/observeResult/actResult` names.
  - Python (`packages/sdk-python/examples`): use `result.data` for `model_dump` and validations; rename to `extract_result/observe_result/act_result`; update `custom_llm`, `custom_logging`, `extract`, `model_gateway`, `observe`.
  - TypeScript (`packages/sdk-ts/examples`): log `result.data` and validate on `.data`; rename to `extractResult/observeResult/actResult`; update `act`, `observe`, `extract`, `modelGateway`, `customLlm`, `customLogging`.

<sup>Written for commit 55e390b6ffd9704b5d21f94fa6ed3e3689b49264. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

