### PR TITLE
evals: enable the MCP tool surfaces on the claude_code and codex harnesses

### DIFF
--- a/packages/evals/core/tools/chrome_devtools_mcp.ts
+++ b/packages/evals/core/tools/chrome_devtools_mcp.ts
@@ -1,3 +1,4 @@
+import type { ProbeEvidence } from "stagehand-v3";
 import type { PageRepresentation } from "../contracts/representation.js";
 import type { Artifact, ConnectionMode } from "../contracts/results.js";
 import type { ActionTarget, TargetKind, WaitSpec } from "../contracts/targets.js";
@@ -973,6 +974,47 @@ class ChromeDevtoolsMcpSession implements CoreSession {
   }
 }
 
+async function captureChromeDevtoolsMcpEvidence(session: CoreSession): Promise<ProbeEvidence> {
+  const page = await session.activePage().catch((): undefined => undefined);
+  if (!page) return {};
+
+  const evidence: ProbeEvidence = {};
+  try {
+    evidence.screenshot = await page.screenshot();
+  } catch {
+    // Best effort: preserve other evidence modalities.
+  }
+  try {
+    evidence.url = page.url();
+  } catch {
+    // Best effort: preserve other evidence modalities.
+  }
+  try {
+    evidence.ariaTree = (await page.represent?.())?.content;
+  } catch {
+    // Best effort: preserve other evidence modalities.
+  }
+  return evidence;
+}
+
+function buildChromeDevtoolsMcpAgentPromptInstructions(): string {
+  return [
+    "Browser tool surface: chrome_devtools_mcp.",
+    "Browser automation runs through the `chrome-devtools` MCP server's tools (navigate_page, click, fill, take_snapshot, ...). It is already attached to the task's browser.",
+    "The first browser action should usually be navigating to the start URL with navigate_page.",
+    "Never launch your own browser process; the MCP server is the only browser access.",
+    "Do not edit repository files.",
+  ].join("\n");
+}
+
+/** Launch spec for a chrome-devtools MCP server instance bound to this start input. */
+export function buildChromeDevtoolsMcpLaunchSpec(input: ToolStartInput): {
+  command: string;
+  args: string[];
+} {
+  return { command: resolvePnpmCommand(), args: buildChromeDevtoolsMcpArgs(input) };
+}
+
 function buildChromeDevtoolsMcpArgs(input: ToolStartInput): string[] {
   const args = [
     "dlx",
@@ -1050,6 +1092,21 @@ export class ChromeDevtoolsMcpTool implements CoreTool {
 
     return {
       session,
+      // The agent mount is the *spec* for a second server instance the agent
+      // harness spawns as the agent's own MCP client target. It requires a
+      // providedEndpoint so both instances attach to the same browser — under
+      // tool-owned launch the agent's copy would start a separate browser and
+      // the harness would observe the wrong one.
+      ...(input.providedEndpoint && {
+        agentMount: {
+          via: "mcp" as const,
+          promptInstructions: buildChromeDevtoolsMcpAgentPromptInstructions(),
+          mcpServers: {
+            "chrome-devtools": buildChromeDevtoolsMcpLaunchSpec(input),
+          },
+        },
+      }),
+      captureEvidence: () => captureChromeDevtoolsMcpEvidence(session),
       cleanup: async () => {
         await session.close();
       },

--- a/packages/evals/core/tools/chrome_devtools_mcp.ts
+++ b/packages/evals/core/tools/chrome_devtools_mcp.ts
@@ -18,6 +18,7 @@ import {
   parseLooseJson,
   resolvePnpmCommand,
   StdioMcpRuntime,
+  syncSessionToVisiblePage,
 } from "./mcpUtils.js";
 
 const DEFAULT_WAIT_TIMEOUT_MS = 15_000;
@@ -974,7 +975,14 @@ class ChromeDevtoolsMcpSession implements CoreSession {
   }
 }
 
-async function captureChromeDevtoolsMcpEvidence(session: CoreSession): Promise<ProbeEvidence> {
+async function captureChromeDevtoolsMcpEvidence(
+  session: CoreSession,
+  endpoint?: { kind: "ws" | "http"; url: string; headers?: Record<string, string> },
+): Promise<ProbeEvidence> {
+  // The agent drives its own MCP server instance; this observer session's tab
+  // selection does not follow the agent's tab switches. Re-point at the
+  // browser's visible tab before probing (best-effort).
+  await syncSessionToVisiblePage(session, endpoint);
   const page = await session.activePage().catch((): undefined => undefined);
   if (!page) return {};
 
@@ -1106,7 +1114,7 @@ export class ChromeDevtoolsMcpTool implements CoreTool {
           },
         },
       }),
-      captureEvidence: () => captureChromeDevtoolsMcpEvidence(session),
+      captureEvidence: () => captureChromeDevtoolsMcpEvidence(session, input.providedEndpoint),
       cleanup: async () => {
         await session.close();
       },

--- a/packages/evals/core/tools/mcpUtils.ts
+++ b/packages/evals/core/tools/mcpUtils.ts
@@ -320,3 +320,160 @@ export class StdioMcpRuntime {
     }
   }
 }
+
+// ---------------------------------------------------------------------------
+// Visible-tab resolution
+// ---------------------------------------------------------------------------
+
+interface CdpEndpoint {
+  kind: "ws" | "http";
+  url: string;
+  headers?: Record<string, string>;
+}
+
+/**
+ * Resolves the URL of the browser's currently visible page tab over a direct
+ * CDP connection, independent of any MCP server's own tab selection.
+ *
+ * Two MCP server instances (the agent's and the harness observer's) attach to
+ * the same browser but track tab selection separately — when the agent
+ * switches tabs, the observer keeps probing its stale selection. The browser
+ * itself knows which tab is visible (`document.visibilityState`), so evidence
+ * capture asks it directly and re-points the observer session before probing.
+ *
+ * Best-effort: returns undefined on any failure or when no tab reports
+ * visible (e.g. a minimized headful window).
+ */
+export async function resolveVisiblePageUrl(
+  endpoint: CdpEndpoint,
+  timeoutMs = 4_000,
+): Promise<string | undefined> {
+  if (endpoint.kind !== "ws") return undefined;
+  // Typed locally: the evals package ships ws without @types/ws.
+  type WsLike = {
+    send(data: string, cb?: (err?: Error) => void): void;
+    on(event: "message", cb: (raw: unknown) => void): void;
+    once(event: "open" | "error", cb: (arg?: unknown) => void): void;
+    close(): void;
+  };
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const { WebSocket: WsCtor } = (await import("ws" as string)) as unknown as {
+    WebSocket: new (
+      url: string,
+      opts?: { headers?: Record<string, string>; maxPayload?: number },
+    ) => WsLike;
+  };
+  const socket = new WsCtor(endpoint.url, {
+    headers: endpoint.headers,
+    maxPayload: 32 * 1024 * 1024,
+  });
+
+  let nextId = 1;
+  const inflight = new Map<number, (result: Record<string, unknown>) => void>();
+
+  const send = (
+    method: string,
+    params: Record<string, unknown> = {},
+    sessionId?: string,
+  ): Promise<Record<string, unknown>> =>
+    new Promise((resolve, reject) => {
+      const id = nextId++;
+      inflight.set(id, resolve);
+      socket.send(
+        JSON.stringify({ id, method, params, ...(sessionId && { sessionId }) }),
+        (err?: Error) => {
+          if (err) {
+            inflight.delete(id);
+            reject(err);
+          }
+        },
+      );
+    });
+
+  const resolveVisible = async (): Promise<string | undefined> => {
+    await new Promise<void>((resolve, reject) => {
+      socket.once("open", () => resolve());
+      socket.once("error", (error) => reject(error));
+    });
+    socket.on("message", (raw: unknown) => {
+      try {
+        const message = JSON.parse(String(raw)) as {
+          id?: number;
+          result?: Record<string, unknown>;
+          error?: { message?: string };
+        };
+        if (typeof message.id === "number") {
+          inflight.get(message.id)?.(message.result ?? {});
+          inflight.delete(message.id);
+        }
+      } catch {
+        // ignore malformed frames
+      }
+    });
+
+    const targets = (await send("Target.getTargets")) as {
+      targetInfos?: Array<{ targetId: string; type: string; url: string }>;
+    };
+    const pages = (targets.targetInfos ?? []).filter(
+      (t) => t.type === "page" && !t.url.startsWith("devtools://"),
+    );
+    for (const target of pages) {
+      const attached = (await send("Target.attachToTarget", {
+        targetId: target.targetId,
+        flatten: true,
+      })) as { sessionId?: string };
+      if (!attached.sessionId) continue;
+      const evaluated = (await send(
+        "Runtime.evaluate",
+        { expression: "document.visibilityState", returnByValue: true },
+        attached.sessionId,
+      )) as { result?: { value?: unknown } };
+      if (evaluated.result?.value === "visible") {
+        return target.url;
+      }
+    }
+    return undefined;
+  };
+
+  const timeout = new Promise<undefined>((resolve) => setTimeout(resolve, timeoutMs, undefined));
+  try {
+    return await Promise.race([resolveVisible().catch((): undefined => undefined), timeout]);
+  } finally {
+    socket.close();
+  }
+}
+
+/**
+ * Points `session` at the browser's visible tab before an evidence capture.
+ * No-ops (best-effort) when resolution fails, the URL is ambiguous across
+ * tabs, or the session is already there. Selecting the visible tab is safe:
+ * the underlying bringToFront is a no-op for a tab that is already front.
+ */
+export async function syncSessionToVisiblePage(
+  session: {
+    listPages(): Promise<Array<{ id: string; url(): string }>>;
+    activePage(): Promise<{ id: string }>;
+    selectPage(pageId: string): Promise<void>;
+  },
+  endpoint: CdpEndpoint | undefined,
+): Promise<void> {
+  if (!endpoint) return;
+  try {
+    const visibleUrl = await resolveVisiblePageUrl(endpoint);
+    if (!visibleUrl) return;
+    const pages = await session.listPages();
+    const matches = pages.filter((page) => {
+      try {
+        return page.url() === visibleUrl;
+      } catch {
+        return false;
+      }
+    });
+    if (matches.length !== 1) return;
+    const active = await session.activePage().catch((): undefined => undefined);
+    if (active?.id === matches[0].id) return;
+    await session.selectPage(matches[0].id);
+  } catch {
+    // best-effort only — capture falls back to the session's own selection
+  }
+}

--- a/packages/evals/core/tools/playwright_mcp.ts
+++ b/packages/evals/core/tools/playwright_mcp.ts
@@ -13,7 +13,12 @@ import type {
   ToolStartInput,
   ToolStartResult,
 } from "../contracts/tool.js";
-import { extractMcpImage, resolvePnpmCommand, StdioMcpRuntime } from "./mcpUtils.js";
+import {
+  extractMcpImage,
+  resolvePnpmCommand,
+  StdioMcpRuntime,
+  syncSessionToVisiblePage,
+} from "./mcpUtils.js";
 
 const SUPPORTED_CAPABILITIES: CoreCapability[] = [
   "session",
@@ -981,7 +986,14 @@ class PlaywrightMcpSession implements CoreSession {
   }
 }
 
-async function capturePlaywrightMcpEvidence(session: CoreSession): Promise<ProbeEvidence> {
+async function capturePlaywrightMcpEvidence(
+  session: CoreSession,
+  endpoint?: { kind: "ws" | "http"; url: string; headers?: Record<string, string> },
+): Promise<ProbeEvidence> {
+  // The agent drives its own MCP server instance; this observer session's tab
+  // selection does not follow the agent's tab switches. Re-point at the
+  // browser's visible tab before probing (best-effort).
+  await syncSessionToVisiblePage(session, endpoint);
   const page = await session.activePage().catch((): undefined => undefined);
   if (!page) return {};
 
@@ -1103,7 +1115,7 @@ export class PlaywrightMcpTool implements CoreTool {
           },
         },
       }),
-      captureEvidence: () => capturePlaywrightMcpEvidence(session),
+      captureEvidence: () => capturePlaywrightMcpEvidence(session, input.providedEndpoint),
       cleanup: async () => {
         await session.close();
       },

--- a/packages/evals/core/tools/playwright_mcp.ts
+++ b/packages/evals/core/tools/playwright_mcp.ts
@@ -1,4 +1,5 @@
 import { resolveLocalChromeExecutablePath } from "../targets/localChrome.js";
+import type { ProbeEvidence } from "stagehand-v3";
 import type { PageRepresentation } from "../contracts/representation.js";
 import type { Artifact, ConnectionMode } from "../contracts/results.js";
 import type { ActionTarget, TargetKind, WaitSpec } from "../contracts/targets.js";
@@ -980,6 +981,47 @@ class PlaywrightMcpSession implements CoreSession {
   }
 }
 
+async function capturePlaywrightMcpEvidence(session: CoreSession): Promise<ProbeEvidence> {
+  const page = await session.activePage().catch((): undefined => undefined);
+  if (!page) return {};
+
+  const evidence: ProbeEvidence = {};
+  try {
+    evidence.screenshot = await page.screenshot();
+  } catch {
+    // Best effort: preserve other evidence modalities.
+  }
+  try {
+    evidence.url = page.url();
+  } catch {
+    // Best effort: preserve other evidence modalities.
+  }
+  try {
+    evidence.ariaTree = (await page.represent?.())?.content;
+  } catch {
+    // Best effort: preserve other evidence modalities.
+  }
+  return evidence;
+}
+
+function buildPlaywrightMcpAgentPromptInstructions(): string {
+  return [
+    "Browser tool surface: playwright_mcp.",
+    "Browser automation runs through the `playwright` MCP server's tools (browser_navigate, browser_click, browser_type, browser_snapshot, ...). It is already attached to the task's browser.",
+    "The first browser action should usually be navigating to the start URL with browser_navigate.",
+    "Never launch your own browser process; the MCP server is the only browser access.",
+    "Do not edit repository files.",
+  ].join("\n");
+}
+
+/** Launch spec for a playwright MCP server instance bound to this start input. */
+export function buildPlaywrightMcpLaunchSpec(input: ToolStartInput): {
+  command: string;
+  args: string[];
+} {
+  return { command: resolvePnpmCommand(), args: buildPlaywrightMcpArgs(input) };
+}
+
 function buildPlaywrightMcpArgs(input: ToolStartInput): string[] {
   const args = ["dlx", "@playwright/mcp@latest"];
 
@@ -1047,6 +1089,21 @@ export class PlaywrightMcpTool implements CoreTool {
 
     return {
       session,
+      // The agent mount is the *spec* for a second server instance the agent
+      // harness spawns as the agent's own MCP client target. It requires a
+      // providedEndpoint so both instances attach to the same browser — under
+      // tool_launch_local the agent's copy would launch a separate isolated
+      // browser and the harness would observe the wrong one.
+      ...(input.providedEndpoint && {
+        agentMount: {
+          via: "mcp" as const,
+          promptInstructions: buildPlaywrightMcpAgentPromptInstructions(),
+          mcpServers: {
+            playwright: buildPlaywrightMcpLaunchSpec(input),
+          },
+        },
+      }),
+      captureEvidence: () => capturePlaywrightMcpEvidence(session),
       cleanup: async () => {
         await session.close();
       },

--- a/packages/evals/framework/claudeCodeRunner.ts
+++ b/packages/evals/framework/claudeCodeRunner.ts
@@ -277,7 +277,7 @@ export async function runClaudeCodeAgent({
   // before cleanup, and drain the per-step probe observations collected by
   // the run tool.
   const finalObservation = await toolAdapter?.captureEvidence?.().catch((): undefined => undefined);
-  const stepObservations = toolAdapter?.drainStepObservations?.();
+  const stepObservations = await toolAdapter?.drainStepObservations?.();
 
   // Build a Trajectory from the SDK message stream and grade it with the
   // rubric verifier; any failure in that path folds into `verifierError`.

--- a/packages/evals/framework/claudeCodeRunner.ts
+++ b/packages/evals/framework/claudeCodeRunner.ts
@@ -180,6 +180,9 @@ export async function runClaudeCodeAgent({
   let resultText = "";
   let resultMessage: ClaudeSdkMessage | undefined;
   let iterationError: unknown;
+  // tool_use id -> tool name, so tool_result blocks (which carry only the id)
+  // can be attributed for per-step observation triggers.
+  const toolUseNames = new Map<string, string>();
 
   try {
     for await (const message of sdk.query({
@@ -215,6 +218,7 @@ export async function runClaudeCodeAgent({
     })) {
       messages.push(message);
       logClaudeCodeMessage(logger, message);
+      notifyToolResults(message, toolUseNames, toolAdapter?.onToolResult);
       if (message.type === "result") {
         resultMessage = message;
         if (typeof message.result === "string") {
@@ -284,6 +288,9 @@ export async function runClaudeCodeAgent({
           messages,
           ...(finalObservation && { finalObservation }),
           ...(stepObservations?.length && { stepObservations }),
+          ...(toolAdapter?.observedToolMatcher && {
+            observedToolName: toolAdapter.observedToolMatcher,
+          }),
           finalAnswer: parsed.finalAnswer ?? resultText,
           status: status === "completed" ? "complete" : "error",
           usage: {
@@ -300,6 +307,41 @@ export async function runClaudeCodeAgent({
     category: "claude_code",
     logger,
   });
+}
+
+/**
+ * Surfaces completed tool_results to the tool adapter. Assistant messages
+ * register tool_use id -> name; user messages carry the tool_result blocks.
+ * onToolResult is called in stream order, so observation indexes assigned at
+ * call time line up with tool_use ordinals in the trajectory adapter.
+ */
+function notifyToolResults(
+  message: ClaudeSdkMessage,
+  toolUseNames: Map<string, string>,
+  onToolResult?: (toolName: string) => void,
+): void {
+  const type = String((message as Record<string, unknown>).type ?? "");
+  const inner = (message as Record<string, unknown>).message;
+  if (!isRecord(inner) || !Array.isArray(inner.content)) return;
+
+  if (type === "assistant") {
+    for (const block of inner.content) {
+      if (!isRecord(block) || block.type !== "tool_use") continue;
+      if (typeof block.id === "string" && typeof block.name === "string") {
+        toolUseNames.set(block.id, block.name);
+      }
+    }
+    return;
+  }
+
+  if (type === "user" && onToolResult) {
+    for (const block of inner.content) {
+      if (!isRecord(block) || block.type !== "tool_result") continue;
+      const toolUseId = typeof block.tool_use_id === "string" ? block.tool_use_id : "";
+      const name = toolUseNames.get(toolUseId);
+      if (name) onToolResult(name);
+    }
+  }
 }
 
 function buildClaudeCodeMetrics(

--- a/packages/evals/framework/claudeCodeToolAdapter.ts
+++ b/packages/evals/framework/claudeCodeToolAdapter.ts
@@ -49,7 +49,7 @@ export interface PreparedClaudeCodeToolAdapter {
   ) => Promise<Record<string, unknown>>;
   /** Best-effort evidence from the currently running tool surface. */
   captureEvidence?: () => Promise<ProbeEvidence>;
-  drainStepObservations?: () => StepObservation[];
+  drainStepObservations?: () => Promise<StepObservation[]>;
   /**
    * Runner calls this on every completed tool_result with the originating
    * tool name; MCP-mounted surfaces use it to record per-step observations
@@ -486,7 +486,12 @@ async function prepareAgentMountAdapter(
           }
         },
       }),
-      ...(recorder && { drainStepObservations: () => recorder.drain() }),
+      ...(recorder && {
+        drainStepObservations: async () => {
+          await recorder.settle();
+          return recorder.drain();
+        },
+      }),
       cleanup: async () => {
         cleanupPromise ??= (async () => {
           try {

--- a/packages/evals/framework/claudeCodeToolAdapter.ts
+++ b/packages/evals/framework/claudeCodeToolAdapter.ts
@@ -50,6 +50,14 @@ export interface PreparedClaudeCodeToolAdapter {
   /** Best-effort evidence from the currently running tool surface. */
   captureEvidence?: () => Promise<ProbeEvidence>;
   drainStepObservations?: () => StepObservation[];
+  /**
+   * Runner calls this on every completed tool_result with the originating
+   * tool name; MCP-mounted surfaces use it to record per-step observations
+   * (their tool calls never pass through harness code).
+   */
+  onToolResult?: (toolName: string) => void;
+  /** Which tool names consume observation indexes in the trajectory adapter. */
+  observedToolMatcher?: (toolName: string) => boolean;
   cleanup: () => Promise<void>;
 }
 
@@ -168,7 +176,9 @@ export async function prepareClaudeCodeToolAdapter(
       });
     case "playwright_code":
     case "cdp_code":
-    case "stagehand_code": {
+    case "stagehand_code":
+    case "playwright_mcp":
+    case "chrome_devtools_mcp": {
       return prepareMountedCoreToolAdapter({
         ...input,
         toolSurface,
@@ -177,7 +187,7 @@ export async function prepareClaudeCodeToolAdapter(
     }
     default:
       throw new EvalsError(
-        `Claude Code harness supports --tool browse_cli, playwright_code, cdp_code, or stagehand_code for execution right now; received "${toolSurface}".`,
+        `Claude Code harness supports --tool browse_cli, playwright_code, cdp_code, stagehand_code, playwright_mcp, or chrome_devtools_mcp for execution right now; received "${toolSurface}".`,
       );
   }
 }
@@ -188,12 +198,14 @@ export function resolveClaudeCodeToolSurface(requested?: ToolSurface): ToolSurfa
     requested === "browse_cli" ||
     requested === "playwright_code" ||
     requested === "cdp_code" ||
-    requested === "stagehand_code"
+    requested === "stagehand_code" ||
+    requested === "playwright_mcp" ||
+    requested === "chrome_devtools_mcp"
   ) {
     return requested;
   }
   throw new EvalsError(
-    `Claude Code harness supports --tool browse_cli, playwright_code, cdp_code, or stagehand_code for execution right now; received "${requested}".`,
+    `Claude Code harness supports --tool browse_cli, playwright_code, cdp_code, stagehand_code, playwright_mcp, or chrome_devtools_mcp for execution right now; received "${requested}".`,
   );
 }
 
@@ -209,7 +221,15 @@ export function resolveClaudeCodeStartupProfile(
   if (toolSurface === "browse_cli" || toolSurface === "stagehand_code") {
     return environment === "BROWSERBASE" ? "tool_create_browserbase" : "tool_launch_local";
   }
-  if (toolSurface === "playwright_code" || toolSurface === "cdp_code") {
+  // The MCP surfaces need a runner-provided endpoint so the harness-side
+  // session (evidence capture) and the agent's own server instance attach to
+  // the same browser.
+  if (
+    toolSurface === "playwright_code" ||
+    toolSurface === "cdp_code" ||
+    toolSurface === "playwright_mcp" ||
+    toolSurface === "chrome_devtools_mcp"
+  ) {
     return environment === "BROWSERBASE"
       ? "runner_provided_browserbase_cdp"
       : "runner_provided_local_cdp";
@@ -388,11 +408,13 @@ async function prepareAgentMountAdapter(
     if (!mount) {
       throw new EvalsError(`Tool surface "${input.toolSurface}" does not provide an agent mount.`);
     }
-    if (mount.via !== "handles") {
+    if (mount.via !== "handles" && mount.via !== "mcp") {
       throw new EvalsError(
         `Claude Code does not support agent mounts delivered via "${mount.via}" yet.`,
       );
     }
+    const handlesMount = mount.via === "handles" ? mount : undefined;
+    const mcpMount = mount.via === "mcp" ? mount : undefined;
 
     cwd = await fsp.mkdtemp(path.join(os.tmpdir(), `stagehand-evals-claude-${input.toolSurface}-`));
     const cleanupCwd = cwd;
@@ -400,13 +422,29 @@ async function prepareAgentMountAdapter(
     const recorder = running.captureEvidence
       ? new ObservationRecorder(running.captureEvidence)
       : undefined;
-    const mcpServers = await buildCodeExposureRunMcpServers({
-      handles: mount.handles,
-      runToolSpec: mount.runTool,
-      plan: input.plan,
-      logger: input.logger,
-      recordObservation: recorder ? () => recorder.record() : undefined,
-    });
+    // handles mounts wrap the surface in the harness's run tool (which owns
+    // per-step observation); mcp mounts pass the agent's own server spec
+    // through, and observation is triggered from the runner's tool_result
+    // stream instead.
+    const mcpServers = handlesMount
+      ? await buildCodeExposureRunMcpServers({
+          handles: handlesMount.handles,
+          runToolSpec: handlesMount.runTool,
+          plan: input.plan,
+          logger: input.logger,
+          recordObservation: recorder ? () => recorder.record() : undefined,
+        })
+      : mcpMount!.mcpServers;
+    // "mcp__<server>" allows every tool the named server exposes.
+    const mcpToolPrefixes = mcpMount
+      ? Object.keys(mcpMount.mcpServers).map((name) => `mcp__${name}`)
+      : [];
+    const isMountToolName = (toolName: string): boolean =>
+      handlesMount
+        ? toolName === RUN_TOOL_NAME
+        : mcpToolPrefixes.some(
+            (prefix) => toolName === prefix || toolName.startsWith(`${prefix}__`),
+          );
     let cleanupPromise: Promise<void> | undefined;
 
     return {
@@ -414,18 +452,27 @@ async function prepareAgentMountAdapter(
       startupProfile: input.startupProfile,
       cwd,
       env,
-      allowedTools: ["Bash", RUN_TOOL_NAME],
+      allowedTools: ["Bash", ...(handlesMount ? [RUN_TOOL_NAME] : mcpToolPrefixes)],
       settingSources: [],
       mcpServers,
       canUseTool: async (toolName, commandInput) => {
-        if (toolName === RUN_TOOL_NAME || toolName === "Bash") {
+        if (toolName === "Bash" || isMountToolName(toolName)) {
           return { behavior: "allow", updatedInput: commandInput };
         }
         return {
           behavior: "deny",
-          message: mount.runTool.denyMessage,
+          message:
+            handlesMount?.runTool.denyMessage ??
+            `Only Bash and the ${mcpToolPrefixes.join(", ")} tools are allowed.`,
         };
       },
+      ...(mcpMount &&
+        recorder && {
+          onToolResult: (toolName: string) => {
+            if (isMountToolName(toolName)) void recorder.record();
+          },
+          observedToolMatcher: isMountToolName,
+        }),
       promptInstructions: mount.promptInstructions,
       ...(running.captureEvidence && {
         captureEvidence: async (): Promise<ProbeEvidence> => {

--- a/packages/evals/framework/codexRunner.ts
+++ b/packages/evals/framework/codexRunner.ts
@@ -136,7 +136,12 @@ export async function runCodexAgent({
   sdk: injectedSdk,
   verifier,
 }: CodexRunnerInput): Promise<TaskResult> {
-  const sdk = injectedSdk ?? (await loadCodexSdk(toolAdapter?.env));
+  const sdk =
+    injectedSdk ??
+    (await loadCodexSdk(
+      toolAdapter?.env,
+      toolAdapter && "codexConfig" in toolAdapter ? toolAdapter.codexConfig : undefined,
+    ));
   const prompt = buildCodexPrompt(plan, toolAdapter?.promptInstructions);
   const events: CodexEvent[] = [];
   let finalResponse = "";
@@ -203,6 +208,17 @@ export async function runCodexAgent({
           stopReason = `tool step budget exhausted (${maxToolSteps} steps)`;
           budgetController.abort(new Error(stopReason));
         }
+      }
+      // MCP-mounted surfaces: each completed MCP tool call consumes one
+      // observation index, in stream order (mirrors the bridge's
+      // onRunExecuted for code surfaces).
+      if (
+        event.type === "item.completed" &&
+        item?.type === "mcp_tool_call" &&
+        toolAdapter &&
+        "recordObservation" in toolAdapter
+      ) {
+        toolAdapter.recordObservation?.();
       }
     }
   } catch (error) {
@@ -272,6 +288,11 @@ export async function runCodexAgent({
           events,
           ...(finalObservation && { finalObservation }),
           ...(stepObservations?.length && { stepObservations }),
+          ...(toolAdapter &&
+            "observedToolMatcher" in toolAdapter &&
+            toolAdapter.observedToolMatcher && {
+              observedToolName: toolAdapter.observedToolMatcher,
+            }),
           finalAnswer: parsed.finalAnswer ?? finalResponse,
           status: status === "completed" ? "complete" : "error",
           usage: {
@@ -438,7 +459,10 @@ function summarizeCodexEvent(event: CodexEvent): {
   };
 }
 
-async function loadCodexSdk(env?: Record<string, string>): Promise<CodexSdk> {
+async function loadCodexSdk(
+  env?: Record<string, string>,
+  extraConfig?: Record<string, unknown>,
+): Promise<CodexSdk> {
   try {
     const specifier = CODEX_SDK_PACKAGE;
     const mod = (await import(specifier)) as {
@@ -460,6 +484,8 @@ async function loadCodexSdk(env?: Record<string, string>): Promise<CodexSdk> {
       }),
       config: {
         show_raw_agent_reasoning: process.env.EVAL_CODEX_RAW_REASONING === "true",
+        // Adapter-provided overrides (e.g. mcp_servers for MCP mounts).
+        ...extraConfig,
       },
     });
   } catch (error) {

--- a/packages/evals/framework/codexRunner.ts
+++ b/packages/evals/framework/codexRunner.ts
@@ -276,7 +276,7 @@ export async function runCodexAgent({
       : undefined;
   const stepObservations =
     toolAdapter && "drainStepObservations" in toolAdapter
-      ? toolAdapter.drainStepObservations?.()
+      ? await toolAdapter.drainStepObservations?.()
       : undefined;
 
   // Build a Trajectory from the codex event stream and grade it with the

--- a/packages/evals/framework/codexToolAdapter.ts
+++ b/packages/evals/framework/codexToolAdapter.ts
@@ -37,7 +37,7 @@ export interface PreparedCodexCodeAdapter {
   codexConfig?: Record<string, unknown>;
   /** Best-effort evidence from the currently running tool surface. */
   captureEvidence?: () => Promise<ProbeEvidence>;
-  drainStepObservations?: () => StepObservation[];
+  drainStepObservations?: () => Promise<StepObservation[]>;
   /**
    * Runner calls this on every completed mcp_tool_call event; MCP mounts use
    * it to record per-step observations (their tool calls never pass through
@@ -54,6 +54,22 @@ export type PreparedCodexToolAdapter = PreparedBrowseCliHarnessAdapter | Prepare
 const CODE_SURFACES = new Set<ToolSurface>(["stagehand_code", "playwright_code", "cdp_code"]);
 const MCP_SURFACES = new Set<ToolSurface>(["playwright_mcp", "chrome_devtools_mcp"]);
 
+/** Mirrors the claude adapter's bounded, best-effort terminal capture. */
+function boundedCaptureEvidence(
+  capture: () => Promise<ProbeEvidence>,
+): () => Promise<ProbeEvidence> {
+  return async () => {
+    try {
+      return await withCaptureTimeout(
+        capture(),
+        readCapturePositiveIntEnv("EVAL_CAPTURE_EVIDENCE_TIMEOUT_MS", 15_000),
+      );
+    } catch {
+      return {};
+    }
+  };
+}
+
 function readCapturePositiveIntEnv(key: string, fallback: number): number {
   const parsed = Number.parseInt(process.env[key] ?? "", 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
@@ -62,7 +78,7 @@ function readCapturePositiveIntEnv(key: string, fallback: number): number {
 function withCaptureTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     const timer = setTimeout(
-      () => reject(new Error(`codex adapter teardown timed out after ${timeoutMs}ms`)),
+      () => reject(new Error(`codex adapter operation timed out after ${timeoutMs}ms`)),
       timeoutMs,
     );
     promise.then(
@@ -143,10 +159,13 @@ export async function prepareCodexToolAdapter(
         promptInstructions: mount.promptInstructions,
         codexConfig: { mcp_servers: mount.mcpServers },
         ...(runtime.running.captureEvidence && {
-          captureEvidence: runtime.running.captureEvidence,
+          captureEvidence: boundedCaptureEvidence(runtime.running.captureEvidence),
         }),
         ...(recorder && {
-          drainStepObservations: () => recorder.drain(),
+          drainStepObservations: async () => {
+            await recorder.settle();
+            return recorder.drain();
+          },
           recordObservation: () => void recorder.record(),
         }),
         observedToolMatcher: (name: string) =>
@@ -197,9 +216,14 @@ export async function prepareCodexToolAdapter(
       env: { ...process.env } as Record<string, string>,
       promptInstructions: buildCodexCodePromptInstructions(mount, toolSurface),
       ...(runtime.running.captureEvidence && {
-        captureEvidence: runtime.running.captureEvidence,
+        captureEvidence: boundedCaptureEvidence(runtime.running.captureEvidence),
       }),
-      ...(recorder && { drainStepObservations: () => recorder.drain() }),
+      ...(recorder && {
+        drainStepObservations: async () => {
+          await recorder.settle();
+          return recorder.drain();
+        },
+      }),
       cleanup: async () => {
         try {
           await capturedBridge.close();

--- a/packages/evals/framework/codexToolAdapter.ts
+++ b/packages/evals/framework/codexToolAdapter.ts
@@ -33,15 +33,26 @@ export interface PreparedCodexCodeAdapter {
   cwd: string;
   env: Record<string, string>;
   promptInstructions: string;
+  /** Extra Codex `--config` overrides (e.g. mcp_servers for MCP mounts). */
+  codexConfig?: Record<string, unknown>;
   /** Best-effort evidence from the currently running tool surface. */
   captureEvidence?: () => Promise<ProbeEvidence>;
   drainStepObservations?: () => StepObservation[];
+  /**
+   * Runner calls this on every completed mcp_tool_call event; MCP mounts use
+   * it to record per-step observations (their tool calls never pass through
+   * the workspace bridge).
+   */
+  recordObservation?: () => void;
+  /** Which normalized tool-call names consume observation indexes. */
+  observedToolMatcher?: (name: string) => boolean;
   cleanup: () => Promise<void>;
 }
 
 export type PreparedCodexToolAdapter = PreparedBrowseCliHarnessAdapter | PreparedCodexCodeAdapter;
 
 const CODE_SURFACES = new Set<ToolSurface>(["stagehand_code", "playwright_code", "cdp_code"]);
+const MCP_SURFACES = new Set<ToolSurface>(["playwright_mcp", "chrome_devtools_mcp"]);
 
 function readCapturePositiveIntEnv(key: string, fallback: number): number {
   const parsed = Number.parseInt(process.env[key] ?? "", 10);
@@ -100,6 +111,55 @@ export async function prepareCodexToolAdapter(
     const mount = runtime.running.agentMount;
     if (!mount) {
       throw new EvalsError(`Tool surface "${toolSurface}" does not provide an agent mount.`);
+    }
+    if (mount.via === "mcp") {
+      // MCP mounts skip the workspace bridge entirely: the agent gets its own
+      // server instance via Codex mcp_servers config, and per-step
+      // observations are triggered from the runner's mcp_tool_call events.
+      const recorder = runtime.running.captureEvidence
+        ? new ObservationRecorder(runtime.running.captureEvidence)
+        : undefined;
+      cwd = await fsp.mkdtemp(
+        path.join(os.tmpdir(), `stagehand-evals-codex-${toolSurface.replace(/_/g, "-")}-`),
+      );
+      const capturedCwd = cwd;
+      const serverNames = Object.keys(mount.mcpServers);
+
+      input.logger.log({
+        category: "codex",
+        message: `Initialized ${toolSurface} MCP mount for Codex (servers: ${serverNames.join(", ")}).`,
+        level: 1,
+        auxiliary: {
+          startupProfile: { value: startupProfile, type: "string" },
+          environment: { value: input.environment, type: "string" },
+        },
+      });
+
+      return {
+        toolSurface,
+        startupProfile,
+        cwd,
+        env: { ...process.env } as Record<string, string>,
+        promptInstructions: mount.promptInstructions,
+        codexConfig: { mcp_servers: mount.mcpServers },
+        ...(runtime.running.captureEvidence && {
+          captureEvidence: runtime.running.captureEvidence,
+        }),
+        ...(recorder && {
+          drainStepObservations: () => recorder.drain(),
+          recordObservation: () => void recorder.record(),
+        }),
+        observedToolMatcher: (name: string) =>
+          serverNames.some((server) => name.startsWith(`${server}.`)),
+        cleanup: async () => {
+          try {
+            await runtime.cleanup();
+          } catch {
+            // best-effort only
+          }
+          await fsp.rm(capturedCwd, { recursive: true, force: true });
+        },
+      };
     }
     if (mount.via !== "handles") {
       throw new EvalsError(`Codex does not support agent mounts delivered via "${mount.via}" yet.`);
@@ -193,11 +253,11 @@ function buildCodexCodePromptInstructions(
 
 export function resolveCodexToolSurface(requested?: ToolSurface): ToolSurface {
   if (!requested) return "browse_cli";
-  if (requested === "browse_cli" || CODE_SURFACES.has(requested)) {
+  if (requested === "browse_cli" || CODE_SURFACES.has(requested) || MCP_SURFACES.has(requested)) {
     return requested;
   }
   throw new EvalsError(
-    `Codex harness supports --tool browse_cli, playwright_code, cdp_code, or stagehand_code for execution right now; received "${requested}".`,
+    `Codex harness supports --tool browse_cli, playwright_code, cdp_code, stagehand_code, playwright_mcp, or chrome_devtools_mcp for execution right now; received "${requested}".`,
   );
 }
 
@@ -213,7 +273,13 @@ export function resolveCodexStartupProfile(
   if (toolSurface === "browse_cli" || toolSurface === "stagehand_code") {
     return environment === "BROWSERBASE" ? "tool_create_browserbase" : "tool_launch_local";
   }
-  if (toolSurface === "playwright_code" || toolSurface === "cdp_code") {
+  // MCP surfaces need a runner-provided endpoint so the harness-side session
+  // (evidence capture) and the agent's own server instance share one browser.
+  if (
+    toolSurface === "playwright_code" ||
+    toolSurface === "cdp_code" ||
+    MCP_SURFACES.has(toolSurface)
+  ) {
     return environment === "BROWSERBASE"
       ? "runner_provided_browserbase_cdp"
       : "runner_provided_local_cdp";

--- a/packages/evals/framework/harnesses/claudeCodeAdapter.ts
+++ b/packages/evals/framework/harnesses/claudeCodeAdapter.ts
@@ -49,6 +49,12 @@ export interface ClaudeCodeRunResult {
   finalObservation?: ProbeEvidence;
   /** Per-step probe observations, indexed by run-tool execution order. */
   stepObservations?: StepObservation[];
+  /**
+   * Which tool names consume step-observation indexes. Defaults to the
+   * harness run tool; MCP mounts match their server's `mcp__<server>__*`
+   * tools instead.
+   */
+  observedToolName?: (name: string) => boolean;
 }
 
 interface ToolUseBlock {
@@ -154,14 +160,17 @@ export class ClaudeCodeTrajectoryAdapter implements TrajectoryAdapter<ClaudeCode
       (result.stepObservations ?? []).map((o) => [o.runIndex, o.evidence]),
     );
     let runOrdinal = 0;
+    const isObservedTool =
+      result.observedToolName ?? ((name: string) => name === AGENT_RUN_TOOL_NAME);
     const toolCalls: NormalizedToolCall[] = toolUses.map((use) => {
       const matched = toolResults.get(use.id);
       const ok = matched ? !matched.isError : true;
       const resultPayload = matched?.raw !== undefined ? matched.raw : (matched?.text ?? "");
-      // The Nth run-tool call pairs with the Nth recorded observation; other
-      // tools (Bash etc.) never consume an index.
-      const observation =
-        use.name === AGENT_RUN_TOOL_NAME ? observationsByRunIndex.get(runOrdinal++) : undefined;
+      // The Nth observed tool call pairs with the Nth recorded observation;
+      // other tools (Bash etc.) never consume an index.
+      const observation = isObservedTool(use.name)
+        ? observationsByRunIndex.get(runOrdinal++)
+        : undefined;
       return {
         name: use.name,
         args: use.input,

--- a/packages/evals/framework/harnesses/codexAdapter.ts
+++ b/packages/evals/framework/harnesses/codexAdapter.ts
@@ -50,6 +50,12 @@ export interface CodexRunResult {
   finalObservation?: ProbeEvidence;
   /** Per-step probe observations, indexed by bridge-run execution order. */
   stepObservations?: StepObservation[];
+  /**
+   * Which normalized tool-call names consume observation indexes. Defaults
+   * to bridge runs (command_execution invoking browser_run.mjs); MCP mounts
+   * match their server's `<server>.<tool>` calls instead.
+   */
+  observedToolName?: (name: string) => boolean;
 }
 
 export class CodexTrajectoryAdapter implements TrajectoryAdapter<CodexRunResult> {
@@ -92,16 +98,17 @@ export class CodexTrajectoryAdapter implements TrajectoryAdapter<CodexRunResult>
     // nothing and let the verifier take its evidence_insufficient path.
     const observations = result.stepObservations ?? [];
     if (observations.length > 0) {
-      const bridgeCalls = toolCalls.filter(
-        (call) =>
-          typeof call.args.command === "string" && call.args.command.includes("browser_run.mjs"),
+      const observedCalls = toolCalls.filter((call) =>
+        result.observedToolName
+          ? result.observedToolName(call.name)
+          : typeof call.args.command === "string" && call.args.command.includes("browser_run.mjs"),
       );
-      // runIndex counts every bridge run (failed captures leave gaps), so
+      // runIndex counts every observed run (failed captures leave gaps), so
       // max+1 is the number of runs the recorder actually saw.
-      const totalBridgeRuns = Math.max(...observations.map((o) => o.runIndex)) + 1;
-      if (bridgeCalls.length === totalBridgeRuns) {
+      const totalObservedRuns = Math.max(...observations.map((o) => o.runIndex)) + 1;
+      if (observedCalls.length === totalObservedRuns) {
         const observationsByRunIndex = new Map(observations.map((o) => [o.runIndex, o.evidence]));
-        bridgeCalls.forEach((call, ordinal) => {
+        observedCalls.forEach((call, ordinal) => {
           const observation = observationsByRunIndex.get(ordinal);
           if (observation) call.probeEvidence = observation;
         });

--- a/packages/evals/framework/observationRecorder.ts
+++ b/packages/evals/framework/observationRecorder.ts
@@ -27,19 +27,39 @@ export function harnessObservationsEnabled(): boolean {
  */
 export class ObservationRecorder {
   private readonly observations: StepObservation[] = [];
+  private readonly pending = new Set<Promise<void>>();
   private runIndex = 0;
 
   constructor(private readonly capture: () => Promise<ProbeEvidence>) {}
 
   async record(): Promise<void> {
     const runIndex = this.runIndex++;
-    try {
-      const evidence = await withTimeout(this.capture(), observationTimeoutMs());
-      if (evidence.screenshot || evidence.url || evidence.ariaTree) {
-        this.observations.push({ runIndex, evidence });
+    const attempt = (async () => {
+      try {
+        const evidence = await withTimeout(this.capture(), observationTimeoutMs());
+        if (evidence.screenshot || evidence.url || evidence.ariaTree) {
+          this.observations.push({ runIndex, evidence });
+        }
+      } catch {
+        // best-effort only — a failed probe must never fail the run tool
       }
-    } catch {
-      // best-effort only — a failed probe must never fail the run tool
+    })();
+    this.pending.add(attempt);
+    try {
+      await attempt;
+    } finally {
+      this.pending.delete(attempt);
+    }
+  }
+
+  /**
+   * Waits for in-flight captures. Callers that fire record() without
+   * awaiting it (MCP tool-result streams) must settle() before drain(), or
+   * the last observations of a run race the drain and silently go missing.
+   */
+  async settle(): Promise<void> {
+    while (this.pending.size > 0) {
+      await Promise.allSettled([...this.pending]);
     }
   }
 

--- a/packages/evals/tests/framework/claudeCodeToolAdapter.test.ts
+++ b/packages/evals/tests/framework/claudeCodeToolAdapter.test.ts
@@ -51,7 +51,18 @@ describe("claude code tool adapter resolution", () => {
 
   it("rejects unsupported Claude Code tool surfaces for now", () => {
     expect(() => resolveClaudeCodeToolSurface("understudy_code")).toThrow(
-      /supports --tool browse_cli, playwright_code, cdp_code, or stagehand_code/,
+      /supports --tool browse_cli, playwright_code, cdp_code, stagehand_code, playwright_mcp, or chrome_devtools_mcp/,
+    );
+  });
+
+  it("supports the MCP surfaces with runner-provided startup profiles", () => {
+    expect(resolveClaudeCodeToolSurface("playwright_mcp")).toBe("playwright_mcp");
+    expect(resolveClaudeCodeToolSurface("chrome_devtools_mcp")).toBe("chrome_devtools_mcp");
+    expect(resolveClaudeCodeStartupProfile("playwright_mcp", "LOCAL")).toBe(
+      "runner_provided_local_cdp",
+    );
+    expect(resolveClaudeCodeStartupProfile("chrome_devtools_mcp", "BROWSERBASE")).toBe(
+      "runner_provided_browserbase_cdp",
     );
   });
 
@@ -75,11 +86,22 @@ describe("claude code tool adapter resolution", () => {
     expect(resolveCodexStartupProfile("playwright_code", "BROWSERBASE")).toBe(
       "runner_provided_browserbase_cdp",
     );
-    expect(() => resolveCodexToolSurface("playwright_mcp")).toThrow(
-      /browse_cli, playwright_code, cdp_code, or stagehand_code/,
+    expect(() => resolveCodexToolSurface("understudy_code")).toThrow(
+      /browse_cli, playwright_code, cdp_code, stagehand_code, playwright_mcp, or chrome_devtools_mcp/,
     );
     expect(resolveCodexStartupProfile("browse_cli", "LOCAL")).toBe("tool_launch_local");
     expect(resolveCodexStartupProfile("browse_cli", "BROWSERBASE")).toBe("tool_create_browserbase");
+  });
+
+  it("supports the MCP surfaces on Codex with runner-provided startup profiles", () => {
+    expect(resolveCodexToolSurface("playwright_mcp")).toBe("playwright_mcp");
+    expect(resolveCodexToolSurface("chrome_devtools_mcp")).toBe("chrome_devtools_mcp");
+    expect(resolveCodexStartupProfile("playwright_mcp", "BROWSERBASE")).toBe(
+      "runner_provided_browserbase_cdp",
+    );
+    expect(resolveCodexStartupProfile("chrome_devtools_mcp", "LOCAL")).toBe(
+      "runner_provided_local_cdp",
+    );
   });
 
   it("allows only direct browse commands through Bash", () => {

--- a/packages/evals/tests/framework/harnessObservations.test.ts
+++ b/packages/evals/tests/framework/harnessObservations.test.ts
@@ -45,6 +45,23 @@ describe("observation recorder", () => {
     expect(recorder.drain()).toEqual([]);
   });
 
+  it("settle() waits for in-flight captures before drain", async () => {
+    let release: (() => void) | undefined;
+    const recorder = new ObservationRecorder(
+      () =>
+        new Promise((resolve) => {
+          release = () => resolve({ url: "https://example.com/late" });
+        }),
+    );
+    // Fire-and-forget, as the MCP tool-result stream does.
+    void recorder.record();
+    expect(recorder.drain()).toEqual([]);
+    const settled = recorder.settle();
+    release?.();
+    await settled;
+    expect(recorder.drain().map((o) => o.evidence.url)).toEqual(["https://example.com/late"]);
+  });
+
   it("drops empty artifacts", async () => {
     const recorder = new ObservationRecorder(async () => ({}));
     await recorder.record();

--- a/packages/evals/tests/framework/harnessObservations.test.ts
+++ b/packages/evals/tests/framework/harnessObservations.test.ts
@@ -127,6 +127,57 @@ describe("per-step observations in trajectories", () => {
     ]);
   });
 
+  it("attaches claude_code observations to MCP tool steps under an observedToolName matcher", () => {
+    const messages = [
+      assistantToolUse("u1", "Bash", { command: "ls" }),
+      toolResult("u1", "ok"),
+      assistantToolUse("u2", "mcp__playwright__browser_navigate", { url: "https://example.com" }),
+      toolResult("u2", "navigated"),
+      assistantToolUse("u3", "mcp__playwright__browser_click", { selector: "#go" }),
+      toolResult("u3", "clicked"),
+    ];
+    const trajectory = claudeCodeAdapter.fromHarnessResult(
+      {
+        messages,
+        stepObservations: [
+          { runIndex: 0, evidence: { url: "https://example.com/a" } },
+          { runIndex: 1, evidence: { url: "https://example.com/b" } },
+        ],
+        observedToolName: (name) => name.startsWith("mcp__playwright__"),
+      },
+      TASK_SPEC,
+    );
+    expect(trajectory.steps.map((s) => s.probeEvidence.url)).toEqual([
+      undefined,
+      "https://example.com/a",
+      "https://example.com/b",
+    ]);
+  });
+
+  it("attaches codex observations to mcp_tool_call steps under an observedToolName matcher", () => {
+    const events = [
+      commandExecution("ls"),
+      mcpToolCall("playwright", "browser_navigate"),
+      mcpToolCall("playwright", "browser_click"),
+    ];
+    const trajectory = codexAdapter.fromHarnessResult(
+      {
+        events,
+        stepObservations: [
+          { runIndex: 0, evidence: { url: "https://example.com/a" } },
+          { runIndex: 1, evidence: { url: "https://example.com/b" } },
+        ],
+        observedToolName: (name) => name.startsWith("playwright."),
+      },
+      TASK_SPEC,
+    );
+    expect(trajectory.steps.map((s) => s.probeEvidence.url)).toEqual([
+      undefined,
+      "https://example.com/a",
+      "https://example.com/b",
+    ]);
+  });
+
   it("attaches no codex observations when bridge runs outnumber matched steps", () => {
     // Two recorded bridge runs but only one command matches the filter —
     // ordinals could be shifted, so misattribution must be refused.
@@ -238,6 +289,19 @@ function toolResult(toolUseId: string, text: string): Record<string, unknown> {
     type: "user",
     message: {
       content: [{ type: "tool_result", tool_use_id: toolUseId, content: text }],
+    },
+  };
+}
+
+function mcpToolCall(server: string, tool: string): Record<string, unknown> {
+  return {
+    type: "item.completed",
+    item: {
+      type: "mcp_tool_call",
+      server,
+      tool,
+      arguments: {},
+      status: "completed",
     },
   };
 }


### PR DESCRIPTION
## Summary

Stacked on #2649. `--tool playwright_mcp` and `--tool chrome_devtools_mcp` now execute on `--harness claude_code` and `--harness codex` — the first wiring of the MCP surfaces into the agent harnesses (previously core-tier only).

**Design**: the generic `agentMount { via: "mcp", mcpServers }` contract variant, produced by the tools and delivered by the adapters — no surface-specific adapter code. The agent spawns its own MCP server instance against the runner-provided CDP browser; the harness keeps its own session on the same browser for evidence capture.

- **Tools**: export the mount (via new `buildPlaywrightMcpLaunchSpec` / `buildChromeDevtoolsMcpLaunchSpec` helpers — named for the facade branch to rebase onto) + `captureEvidence`. Mount requires a `providedEndpoint`, so a tool-launched isolated browser can never split agent and observer.
- **claude_code**: `mcpServers` passthrough to the SDK, `mcp__<server>` tool allowlisting, per-step observation triggered from the runner's `tool_result` stream keyed by `tool_use` id.
- **codex**: `mcp_servers` via SDK config overrides; observation on `mcp_tool_call` completion events; MCP calls count against the #2649 tool-step budget.
- **Trajectory adapters**: `observedToolName` matcher generalizes observation attachment to MCP steps; the strict `===` count guard is kept (the facade's `>=` relaxation is deliberately not adopted — it reintroduces positional misattribution; the trailing-capture undercount wants an attempted-run count instead, follow-up).

Deliberately out (punted with the facade): `stagehand_playwright_code`, callback batching, the facade's codex-only `prepareCodexPlaywrightMcpAdapter` (superseded by the generic path).

## Verification

- typecheck / oxfmt clean, **420/420** unit tests (4 new: surface resolution both harnesses, MCP observation attachment both adapters)
- Live smoke (claude_code × playwright_mcp, WebVoyager, LOCAL): agent drove `mcp__playwright__*` tools for 50 steps, per-step url/aria probe evidence attached to MCP steps only, verifier graded a 5-criterion rubric (0 unverifiable)
- codex × chrome_devtools_mcp: config injection + server spawn validated on Browserbase (run failed on an unrelated model-pairing error; `mcp_servers` reached Codex and servers started)

Known rough edge: probe screenshots through the harness-side `playwright_mcp` session are flaky under the 10s observation timeout (url/aria reliable; ~1/40 screenshots in the smoke). Follow-up: bump timeout for MCP surfaces or capture via raw CDP.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable MCP browser tool surfaces on the `claude_code` and `codex` harnesses. `--tool playwright_mcp` and `--tool chrome_devtools_mcp` now run end-to-end with per-step evidence attached to MCP steps; plus reliability fixes for capture and tab syncing.

- **New Features**
  - Tools export an MCP agent mount (`via: "mcp"`) with `buildPlaywrightMcpLaunchSpec` / `buildChromeDevtoolsMcpLaunchSpec`, plus `captureEvidence`.
  - Claude Code: passes `mcpServers` to the SDK, allows `mcp__<server>` tools, and attaches observations from the `tool_result` stream (tracks `tool_use` id → name).
  - Codex: injects `mcp_servers` via SDK config overrides; records observations on `mcp_tool_call` completion; MCP calls count toward the tool-step budget.
  - Trajectory adapters: add an `observedToolName` matcher so observations attach to MCP steps; strict count guard remains to avoid misattribution.
  - Startup: MCP surfaces use runner-provided CDP endpoints (local or Browserbase) so agent and harness share the same browser.

- **Bug Fixes**
  - Evidence capture re-points the harness session to the browser’s visible tab via CDP before probing (best-effort fallback if unavailable).
  - Observation recorder settles in-flight captures before drain; `drainStepObservations` is async on both harnesses to avoid missing last-step evidence.
  - Codex `captureEvidence` is bounded by `EVAL_CAPTURE_EVIDENCE_TIMEOUT_MS` (default 15s) to prevent stalls.

<sup>Written for commit 544b54afc15bb47f10688dd944e197268a6d1603. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

