### PR TITLE
[Docs] Tab control for language selection

### DIFF
--- a/packages/docs/language-selector.js
+++ b/packages/docs/language-selector.js
@@ -1,5 +1,11 @@
 // Language switcher for Stagehand docs
 // Handles: 1) Sidebar language dropdown selection 2) Code block language syncing
+//
+// v3 ONLY — v4 switches languages with native <Tabs>. Mintlify injects every
+// root-level .js on every page, and the version switcher moves between v3 and v4
+// client-side, so a single guard at load would be wrong in both directions. Each
+// entry point checks isV3Page() instead. No DOM test environment here; verify by
+// hand in `mint dev` after changing this.
 
 (function () {
   // ============================================
@@ -36,16 +42,13 @@
   let currentSelectedLanguage = "TypeScript";
   let isSelecting = false;
 
-  // Everything in this file is v3-only DOM surgery. Mintlify injects it on every
-  // page, so it must stay inert elsewhere: v4 switches languages with native
-  // <Tabs>, and running the v3 logic there hides the version switcher and paints
-  // stale checkmarks into unrelated menus.
   const isV3Page = () => window.location.pathname.startsWith("/v3");
 
-  // Undo the body-level state this script sets, for when a reader leaves v3 by
-  // client-side navigation and the classes would otherwise persist.
-  function clearGlobalState() {
-    document.body.classList.remove("stagehand-hide-version-switcher", "stagehand-selecting");
+  // Drop everything this script owns: the body classes it sets and any in-flight
+  // code-block selection. Runs whenever we find ourselves off v3.
+  function resetState() {
+    isSelecting = false;
+    document.body.classList.remove("stagehand-selecting", "stagehand-hide-version-switcher");
   }
 
   // ============================================
@@ -257,6 +260,14 @@
   }
 
   function waitForCodeBlockMenuAndSelect(targetLanguage, attempts = 0) {
+    // A client-side navigation can land on v4 while this frame was already
+    // scheduled. Bail before touching the DOM so a v3 selection never clicks a
+    // v4 control.
+    if (!isV3Page()) {
+      resetState();
+      return;
+    }
+
     if (attempts > 30) {
       document.body.classList.remove("stagehand-selecting");
       document.body.click();
@@ -495,7 +506,7 @@
 
   function applyForCurrentPage() {
     if (!isV3Page()) {
-      clearGlobalState();
+      resetState();
       return;
     }
     restoreLanguageSelection();

--- a/packages/docs/language-selector.js
+++ b/packages/docs/language-selector.js
@@ -36,6 +36,18 @@
   let currentSelectedLanguage = "TypeScript";
   let isSelecting = false;
 
+  // Everything in this file is v3-only DOM surgery. Mintlify injects it on every
+  // page, so it must stay inert elsewhere: v4 switches languages with native
+  // <Tabs>, and running the v3 logic there hides the version switcher and paints
+  // stale checkmarks into unrelated menus.
+  const isV3Page = () => window.location.pathname.startsWith("/v3");
+
+  // Undo the body-level state this script sets, for when a reader leaves v3 by
+  // client-side navigation and the classes would otherwise persist.
+  function clearGlobalState() {
+    document.body.classList.remove("stagehand-hide-version-switcher", "stagehand-selecting");
+  }
+
   // ============================================
   // UTILITIES
   // ============================================
@@ -275,6 +287,9 @@
   }
 
   function selectCodeBlockLanguage(targetLanguage) {
+    // Guarded at the source: this is what sets `stagehand-selecting`, whose CSS
+    // blanks out every [role="menu"] on the page.
+    if (!isV3Page()) return;
     if (isSelecting) return;
 
     const current = getCodeBlockLanguageDropdown();
@@ -300,6 +315,7 @@
 
   function setupDropdownMenuObserver() {
     const menuObserver = new MutationObserver(() => {
+      if (!isV3Page()) return;
       const menu = getDropdownMenu();
       if (menu) {
         updateDropdownCheckIndicator();
@@ -317,6 +333,7 @@
     document.addEventListener(
       "click",
       (e) => {
+        if (!isV3Page()) return;
         const target = e.target;
 
         // Check if we clicked on a sidebar dropdown menu item
@@ -371,6 +388,7 @@
   }
 
   function restoreLanguageSelection() {
+    if (!isV3Page()) return;
     try {
       const stored = sessionStorage.getItem("stagehand-selected-language");
       if (stored && DROPDOWN_LANGUAGES.includes(stored)) {
@@ -395,6 +413,7 @@
     let sdkUpdatePending = false;
 
     const observer = new MutationObserver(() => {
+      if (!isV3Page()) return;
       // Check if button needs updating
       const button = getDropdownButton();
       if (button) {
@@ -440,6 +459,7 @@
     let lastCodeBlockDropdown = null;
 
     const observer = new MutationObserver(() => {
+      if (!isV3Page()) return;
       const dropdown = getCodeBlockLanguageDropdown();
       if (dropdown && dropdown.element !== lastCodeBlockDropdown) {
         lastCodeBlockDropdown = dropdown.element;
@@ -463,11 +483,21 @@
   // ============================================
 
   function init() {
+    // Listeners are always attached because a reader can reach v3 by client-side
+    // navigation; each one checks isV3Page() before touching the DOM.
     setupMenuClickHandler();
     setupDropdownMenuObserver();
     setupPageChangeObserver();
     setupCodeBlockObserver();
 
+    applyForCurrentPage();
+  }
+
+  function applyForCurrentPage() {
+    if (!isV3Page()) {
+      clearGlobalState();
+      return;
+    }
     restoreLanguageSelection();
     updateVersionSwitcherVisibility();
     updateSDKReferenceVisibility();
@@ -490,10 +520,8 @@
         item.classList.remove("stagehand-sdk-processed");
       });
       onNextFrame(() => {
-        restoreLanguageSelection();
+        applyForCurrentPage();
         syncCodeBlockLanguage();
-        updateVersionSwitcherVisibility();
-        updateSDKReferenceVisibility();
       });
     }
   });

--- a/packages/docs/tests/sdk-reference.test.ts
+++ b/packages/docs/tests/sdk-reference.test.ts
@@ -965,11 +965,10 @@ describe("Mintlify customization boundary", () => {
           const pagePath = relative(DOCS_ROOT, filePath).split(sep).join("/");
 
           return findElements(tree, "Tabs").flatMap((group) => {
-            const titles = (group.children ?? [])
-              .filter((child) => child.name === "Tab")
-              .map((tab) => stringAttribute(tab, "title") ?? "<missing title>");
-            const languages = titles.filter((title) => LANGUAGE_TAB_TITLES.has(title));
-            if (languages.length === 0 || languages.length === titles.length) return [];
+            const tabs = (group.children ?? []).filter((child) => child.name === "Tab");
+            const languages = tabs.filter(isLanguageTab);
+            if (languages.length === 0 || languages.length === tabs.length) return [];
+            const titles = tabs.map((tab) => stringAttribute(tab, "title") ?? "<missing title>");
             return [`${pagePath}: ${titles.join(", ")}`];
           });
         }),
@@ -1700,12 +1699,14 @@ function findElements(node: MdxNode, name: string): MdxNode[] {
   return matches.concat(node.children?.flatMap((child) => findElements(child, name)) ?? []);
 }
 
+function isLanguageTab(node: MdxNode): boolean {
+  const title = stringAttribute(node, "title");
+  return title !== undefined && LANGUAGE_TAB_TITLES.has(title);
+}
+
 // Document-order language tabs, ignoring tabs that switch on any other axis.
 function findLanguageTabs(node: MdxNode): MdxNode[] {
-  return findElements(node, "Tab").filter((tab) => {
-    const title = stringAttribute(tab, "title");
-    return title !== undefined && LANGUAGE_TAB_TITLES.has(title);
-  });
+  return findElements(node, "Tab").filter(isLanguageTab);
 }
 
 function mdxText(node: MdxNode): string {

--- a/packages/docs/tests/sdk-reference.test.ts
+++ b/packages/docs/tests/sdk-reference.test.ts
@@ -28,10 +28,10 @@ type MdxNode = {
 type ReferencePage = {
   classSlug: string;
   filePath: string;
-  views: ReferenceView[];
+  views: ReferenceTab[];
 };
 
-type ReferenceView = {
+type ReferenceTab = {
   methods: ReferenceMethod[];
   title?: string;
 };
@@ -137,6 +137,9 @@ const PROTOCOL_REGISTRY = fileURLToPath(
   new URL("../../protocol/schema-registry.ts", import.meta.url),
 );
 const LANGUAGES = ["TypeScript", "Python"] as const satisfies readonly Language[];
+// Language tabs are the selector; every other <Tab> on a page is a different axis
+// (model provider, output shape, ...). Go ships snippets but has no native reference pages.
+const LANGUAGE_TAB_TITLES = new Set(["TypeScript", "Python", "Go"]);
 const STAGEHAND_LIFECYCLE_METHODS = new Set(["create", "create-with-client-for-test", "init"]);
 // Cross-language concept references are validated as MDX content, not as one-to-one SDK objects.
 const SUPPLEMENTAL_REFERENCE_PAGES = new Set(["response"]);
@@ -219,7 +222,7 @@ describe("SDK reference surface", () => {
       await readFile(pagePath, "utf8"),
     ) as MdxNode;
     const views = new Map(
-      findElements(tree, "View").map((view) => [stringAttribute(view, "title"), view]),
+      findLanguageTabs(tree).map((view) => [stringAttribute(view, "title"), view]),
     );
     const [typescriptMembers, pythonMembers] = await Promise.all([
       readTypescriptResponseMembers(),
@@ -231,7 +234,7 @@ describe("SDK reference surface", () => {
       ["Python", pythonMembers],
     ] as const satisfies ReadonlyArray<readonly [Language, ResponseReferenceMember[]]>) {
       const view = views.get(language);
-      expect(view, `response.mdx must contain one ${language} View`).toBeDefined();
+      expect(view, `response.mdx must contain one ${language} tab`).toBeDefined();
       expect(
         responseMemberSignatures(readDocumentedResponseMembers(view as MdxNode, language)),
         `response.mdx ${language} signatures must match the public Response surface`,
@@ -264,11 +267,11 @@ describe("SDK reference surface", () => {
 
     expect(
       differences,
-      "Use each language's exact public method name in its consolidated page View",
+      "Use each language's exact public method name in its consolidated page tab",
     ).toEqual([]);
   });
 
-  it("uses exactly one TypeScript View and one Python View on every reference page", async () => {
+  it("uses exactly one TypeScript tab and one Python tab on every reference page", async () => {
     const invalidPages = (await readReferencePages()).flatMap((page) => {
       const titles = page.views.map(({ title }) => title ?? "<missing title>").sort();
       return arraysEqual(titles, [...LANGUAGES].sort())
@@ -278,11 +281,11 @@ describe("SDK reference surface", () => {
 
     expect(
       invalidPages,
-      "Each reference page must contain exactly the two native SDK Views",
+      "Each reference page must contain exactly the two native SDK language tabs",
     ).toEqual([]);
   });
 
-  it("documents the exact direct signature parameters inside each language View", async () => {
+  it("documents the exact direct signature parameters inside each language tab", async () => {
     const [typescriptMethods, pythonMethods, referencePages] = await Promise.all([
       readTypescriptMethods(),
       readPythonMethods(),
@@ -650,8 +653,8 @@ describe("SDK reference surface", () => {
     ).toEqual([]);
   });
 
-  it("documents one public response root inside every method View", async () => {
-    const invalidViews = (await readReferencePages()).flatMap((page) =>
+  it("documents one public response root inside every method tab", async () => {
+    const invalidTabs = (await readReferencePages()).flatMap((page) =>
       page.views.flatMap((view) =>
         view.methods.flatMap((method) =>
           method.responseNames.filter((name) => name === "result").length === 1
@@ -664,8 +667,8 @@ describe("SDK reference surface", () => {
     );
 
     expect(
-      invalidViews,
-      "Each SDK method View must contain exactly one top-level ResponseField named result",
+      invalidTabs,
+      "Each SDK method tab must contain exactly one top-level ResponseField named result",
     ).toEqual([]);
   });
 
@@ -802,7 +805,7 @@ describe("SDK reference surface", () => {
 });
 
 describe("Mintlify customization boundary", () => {
-  it("uses SDK-native field spellings inside each language View", async () => {
+  it("uses SDK-native field spellings inside each language tab", async () => {
     const [typescriptNames, pythonNames, contentPages] = await Promise.all([
       readTypescriptPublicFieldNames(),
       readPythonPublicFieldNames(),
@@ -825,7 +828,7 @@ describe("Mintlify customization boundary", () => {
         await readFile(filePath, "utf8"),
       ) as MdxNode;
       const pagePath = relative(DOCS_ROOT, filePath).split(sep).join("/");
-      for (const view of findElements(tree, "View")) {
+      for (const view of findLanguageTabs(tree)) {
         const language = stringAttribute(view, "title");
         if (language !== "TypeScript" && language !== "Python") continue;
         const spellings = language === "TypeScript" ? typescriptSpellings : pythonSpellings;
@@ -874,7 +877,7 @@ describe("Mintlify customization boundary", () => {
     );
   });
 
-  it("gives every View group the same complete language set", async () => {
+  it("gives every language tab group the same complete language set", async () => {
     const contentPages = (await listFiles(V4_DOCS_ROOT, shouldInspectDocsDirectory)).filter(
       (filePath) => extname(filePath) === ".mdx",
     );
@@ -884,7 +887,7 @@ describe("Mintlify customization boundary", () => {
           const tree = createProcessor({ format: "mdx" }).parse(
             await readFile(filePath, "utf8"),
           ) as MdxNode;
-          const views = findElements(tree, "View").map((view) => ({
+          const views = findLanguageTabs(tree).map((view) => ({
             title: stringAttribute(view, "title"),
             icon: stringAttribute(view, "icon"),
           }));
@@ -895,7 +898,7 @@ describe("Mintlify customization boundary", () => {
             (view): view is { title: string; icon: string | undefined } => view.title !== undefined,
           );
           if (titled.length !== views.length) {
-            found.push(`${pagePath}: a View is missing a title`);
+            found.push(`${pagePath}: a language tab is missing a title`);
           }
           if (titled.length === 0) return found;
 
@@ -909,7 +912,7 @@ describe("Mintlify customization boundary", () => {
           const short = tallies.filter(([, count]) => count !== expected);
           if (short.length > 0) {
             found.push(
-              `${pagePath}: uneven View groups (${tallies
+              `${pagePath}: uneven language tab groups (${tallies
                 .map(([title, count]) => `${title} x${count}`)
                 .join(", ")})`,
             );
@@ -928,10 +931,12 @@ describe("Mintlify customization boundary", () => {
             }
           }
 
-          // Two adjacent Views sharing a title means a malformed group.
+          // Two adjacent language tabs sharing a title means a malformed group.
           for (let index = 1; index < titled.length; index += 1) {
             if (titled[index].title === titled[index - 1].title) {
-              found.push(`${pagePath}: two adjacent Views both titled ${titled[index].title}`);
+              found.push(
+                `${pagePath}: two adjacent language tabs both titled ${titled[index].title}`,
+              );
               break;
             }
           }
@@ -943,7 +948,37 @@ describe("Mintlify customization boundary", () => {
 
     expect(
       problems,
-      "Every View group must offer the same languages, so switching never hides a snippet",
+      "Every language tab group must offer the same languages, so switching never hides a snippet",
+    ).toEqual([]);
+  });
+
+  it("never mixes language tabs with other tabs in one group", async () => {
+    const contentPages = (await listFiles(V4_DOCS_ROOT, shouldInspectDocsDirectory)).filter(
+      (filePath) => extname(filePath) === ".mdx",
+    );
+    const problems = (
+      await Promise.all(
+        contentPages.map(async (filePath) => {
+          const tree = createProcessor({ format: "mdx" }).parse(
+            await readFile(filePath, "utf8"),
+          ) as MdxNode;
+          const pagePath = relative(DOCS_ROOT, filePath).split(sep).join("/");
+
+          return findElements(tree, "Tabs").flatMap((group) => {
+            const titles = (group.children ?? [])
+              .filter((child) => child.name === "Tab")
+              .map((tab) => stringAttribute(tab, "title") ?? "<missing title>");
+            const languages = titles.filter((title) => LANGUAGE_TAB_TITLES.has(title));
+            if (languages.length === 0 || languages.length === titles.length) return [];
+            return [`${pagePath}: ${titles.join(", ")}`];
+          });
+        }),
+      )
+    ).flat();
+
+    expect(
+      problems,
+      "A tab group switches on exactly one axis: either language or something else, never both",
     ).toEqual([]);
   });
 
@@ -1569,7 +1604,7 @@ async function readReferencePages(): Promise<ReferencePage[]> {
         const tree = createProcessor({ format: "mdx" }).parse(
           await readFile(filePath, "utf8"),
         ) as MdxNode;
-        const views = findElements(tree, "View").map((view): ReferenceView => {
+        const views = findLanguageTabs(tree).map((view): ReferenceTab => {
           return {
             title: stringAttribute(view, "title"),
             methods: readReferenceMethods(view, filePath),
@@ -1594,7 +1629,7 @@ function readReferenceMethods(view: MdxNode, filePath: string): ReferenceMethod[
     const methodName = heading.match(/^([A-Za-z_$][A-Za-z0-9_$]*)\(\)$/u)?.[1];
     if (!methodName) {
       throw new Error(
-        `${filePath} View headings must be "Quick start" or an exact method name ending in (): ${heading}`,
+        `${filePath} language tab headings must be "Quick start" or an exact method name ending in (): ${heading}`,
       );
     }
 
@@ -1663,6 +1698,14 @@ function shouldInspectDocsDirectory(name: string): boolean {
 function findElements(node: MdxNode, name: string): MdxNode[] {
   const matches = node.name === name ? [node] : [];
   return matches.concat(node.children?.flatMap((child) => findElements(child, name)) ?? []);
+}
+
+// Document-order language tabs, ignoring tabs that switch on any other axis.
+function findLanguageTabs(node: MdxNode): MdxNode[] {
+  return findElements(node, "Tab").filter((tab) => {
+    const title = stringAttribute(tab, "title");
+    return title !== undefined && LANGUAGE_TAB_TITLES.has(title);
+  });
 }
 
 function mdxText(node: MdxNode): string {

--- a/packages/docs/v4/basics/act.mdx
+++ b/packages/docs/v4/basics/act.mdx
@@ -5,25 +5,27 @@ description: "Interact with a web page."
 
 ## What is `act()`?
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 await stagehand.act("click on add to cart");
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 await stagehand.act("click on add to cart")
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 if _, err := client.Act(ctx, stagehand.ActInstruction("click on add to cart"), nil); err != nil {
 	return err
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 `act` enables Stagehand to perform **individual** actions on a web page. Use it to build self-healing and deterministic automations that adapt to website changes.
 
@@ -51,21 +53,22 @@ if _, err := client.Act(ctx, stagehand.ActInstruction("click on add to cart"), n
 
 Use `act` to perform single actions in your automation. Here's how to click a button:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 await page.goto("https://example-store.com");
 await stagehand.act("click the add to cart button");
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 await page.goto("https://example-store.com")
 await stagehand.act("click the add to cart button")
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 if _, err := page.Goto(ctx, "https://example-store.com", nil); err != nil {
 	return err
@@ -74,7 +77,8 @@ if _, err := client.Act(ctx, stagehand.ActInstruction("click the add to cart but
 	return err
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Note>
 **iFrame and Shadow DOM support** Stagehand automatically handles iFrame traversal and shadow DOM elements without requiring additional configuration. Page snapshots merge every frame's accessibility tree by default.
@@ -103,7 +107,8 @@ The `method` column is the value you will see on an `Action` returned by [`obser
 ### Return value of `act()`?
 When you use `act()`, Stagehand returns a result with two fields: `data` holds the action payload, and `metadata` carries the action ID and server-side cache status.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 {
   data: {
@@ -131,9 +136,9 @@ When you use `act()`, Stagehand returns a result with two fields: `data` holds t
   }
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 ActResult(
     data=ActResultData(
@@ -161,9 +166,9 @@ ActResult(
     ),
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 clickMethod := "click"
 actionID := "act_01HZY..."
@@ -198,32 +203,34 @@ result := stagehand.ActResult{
 // Read the fields you care about off the result
 fmt.Println(result.Data.Message, result.Metadata.Cache.Status)
 ```
-</View>
+</Tab>
+</Tabs>
 
 
 <Tabs>
 <Tab title="Do this" icon="check">
 Break your task into single-step actions.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Break it into single-step actions
 await stagehand.act("open the filters panel");
 await stagehand.act("choose 4-star rating");
 await stagehand.act("click the apply button");
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # Break it into single-step actions
 await stagehand.act("open the filters panel")
 await stagehand.act("choose 4-star rating")
 await stagehand.act("click the apply button")
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Break it into single-step actions
 if _, err := client.Act(ctx, stagehand.ActInstruction("open the filters panel"), nil); err != nil {
@@ -236,34 +243,37 @@ if _, err := client.Act(ctx, stagehand.ActInstruction("click the apply button"),
 	return err
 }
 ```
-</View>
+</Tab>
+</Tabs>
 </Tab>
 
 <Tab title="Don't do this" icon="xmark">
 Multi-step instructions are unreliable. Sequence them yourself instead.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Too complex - trying to do multiple things at once
 await stagehand.act("open the filters panel, choose 4-star rating, and click apply");
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # Too complex - trying to do multiple things at once
 await stagehand.act("open the filters panel, choose 4-star rating, and click apply")
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Too complex - trying to do multiple things at once
 if _, err := client.Act(ctx, stagehand.ActInstruction("open the filters panel, choose 4-star rating, and click apply"), nil); err != nil {
 	return err
 }
 ```
-</View>
+</Tab>
+</Tabs>
 </Tab>
 </Tabs>
 
@@ -271,7 +281,8 @@ if _, err := client.Act(ctx, stagehand.ActInstruction("open the filters panel, c
 
 You can pass additional options to configure the model, timeout, variables, and target page:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Custom model configuration
 await stagehand.act("choose 'Peach' from the favorite color dropdown", {
@@ -282,9 +293,9 @@ await stagehand.act("choose 'Peach' from the favorite color dropdown", {
   timeout: 10000,
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # Custom model configuration
 import os
@@ -300,9 +311,9 @@ await stagehand.act(
     timeout=10000,
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Custom model configuration
 modelAPIKey := os.Getenv("GOOGLE_API_KEY")
@@ -321,7 +332,8 @@ if _, err := client.Act(ctx, stagehand.ActInstruction("choose 'Peach' from the f
 	return err
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 ### Server-side caching
 
@@ -331,7 +343,8 @@ if _, err := client.Act(ctx, stagehand.ActInstruction("choose 'Peach' from the f
 
 When running on Browserbase, Stagehand can cache `act()` results server-side. Repeated calls with the same inputs return instantly without consuming LLM tokens. Enable caching on the constructor and override it per call:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 
@@ -354,9 +367,9 @@ await stagehand.act("click the login button", { cache: { threshold: 1 } });
 const result = await stagehand.act("click the login button");
 console.log(result.metadata.cache.status); // "HIT", "MISS", or "DISABLED"
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import os
 
@@ -381,9 +394,9 @@ await stagehand.act("click the login button", cache=CacheOptions(threshold=1))
 result = await stagehand.act("click the login button")
 print(result.metadata.cache.status)  # "HIT", "MISS", or "DISABLED"
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Enable server-side caching for the entire instance
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
@@ -420,7 +433,8 @@ if err != nil {
 }
 fmt.Println(result.Metadata.Cache.Status) // "HIT", "MISS", or "DISABLED"
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Card title="Complete caching guide" icon="database" iconType="sharp-solid" href="/v4/best-practices/caching">
   Learn how the cache key is built, what the threshold does, and when results are invalidated.
@@ -430,7 +444,8 @@ fmt.Println(result.Metadata.Cache.Status) // "HIT", "MISS", or "DISABLED"
 
 Stagehand v4 drives the browser directly over the Chrome DevTools Protocol, so there is no Puppeteer, Playwright, or Patchright page interop. Instead, target any page Stagehand manages by passing the `page` option:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const browser = await browserbase.launch({
   apiKey: process.env.BROWSERBASE_API_KEY,
@@ -445,9 +460,9 @@ await stagehand.act("click the next page button", {
   page: blogPage,
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 browser = await browserbase.launch(
     api_key=os.environ["BROWSERBASE_API_KEY"],
@@ -460,9 +475,9 @@ blog_page = await browser.context.new_page("https://www.example.com/blog")
 # Use act with that specific page
 await stagehand.act("click the next page button", page=blog_page)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 browser, err := stagehand.LaunchBrowserbase(ctx, stagehand.BrowserbaseLaunchOptions{APIKey: apiKey})
@@ -490,7 +505,8 @@ _, err = client.Act(ctx, stagehand.ActInstruction("click the next page button"),
 	Page: blogPage,
 })
 ```
-</View>
+</Tab>
+</Tabs>
 
 This works with:
 - **Active page:** omit `page` and Stagehand uses `context.activePage()` (default)
@@ -511,7 +527,8 @@ This works with:
 
 Use `observe()` to discover candidate actions on the current page and plan reliably. It returns a list of suggested actions (with selector, description, method, and arguments). Inspect the action before you commit to it, then hand it straight back to `act`:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const { data: actions } = await stagehand.observe("click the login button");
 const [action] = actions;
@@ -521,9 +538,9 @@ if (action?.method === "click") {
   await stagehand.act(action);
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 result = await stagehand.observe("click the login button")
 
@@ -531,9 +548,9 @@ if result.data and result.data[0].method == "click":
     # No inference: Stagehand replays the observed action
     await stagehand.act(result.data[0])
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 instruction := "click the login button"
 observed, err := client.Observe(ctx, &instruction, nil)
@@ -548,7 +565,8 @@ if len(observed.Data) > 0 && observed.Data[0].Method != nil && *observed.Data[0]
 	}
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Note>
 Replaying an `Action` skips model inference, the page snapshot, and the DOM-settle wait, and it does not consult the server-side cache. If the recorded selector no longer resolves and `selfHeal` is on, Stagehand re-infers the action and retries once.
@@ -562,7 +580,8 @@ Replaying an `Action` skips model inference, the page snapshot, and the DOM-sett
 
 Enable server-side caching with `cache` when running on Browserbase. The first time an action runs it is cached; once the hit-count threshold is met, subsequent identical calls are served from the cache without an LLM call.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 
@@ -580,9 +599,9 @@ await stagehand.act("click the login button");
 // Second run is served from the cache
 await stagehand.act("click the login button");
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import os
 
@@ -602,9 +621,9 @@ await stagehand.act("click the login button")
 # Second run is served from the cache
 await stagehand.act("click the login button")
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 cache := stagehand.CacheWithThreshold(1) // Actions are cached after one identical result
@@ -628,7 +647,8 @@ if _, err := client.Act(ctx, stagehand.ActInstruction("click the login button"),
 	return err
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Note>
 The cache lives on Browserbase, keyed on the instruction, page content, and call options, so it persists across script executions and across machines. The model configuration is deliberately excluded from the key, so switching models does not invalidate your cache.
@@ -646,7 +666,8 @@ Variables are **not shared with LLM providers**. Use them for passwords, API key
 Load sensitive data from environment variables. Never hardcode API keys, passwords, or other secrets directly in your code.
 </Note>
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Variables use %variableName% syntax in the instruction
 await stagehand.act("type %username% into the email field", {
@@ -659,9 +680,9 @@ await stagehand.act("type %password% into the password field", {
 
 await stagehand.act("click the login button");
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # Variables use %variable_name% syntax in the instruction
 await stagehand.act(
@@ -676,9 +697,9 @@ await stagehand.act(
 
 await stagehand.act("click the login button")
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Variables use %variableName% syntax in the instruction
 if _, err := client.Act(ctx, stagehand.ActInstruction("type %username% into the email field"), &stagehand.StagehandClientActOptions{
@@ -706,7 +727,8 @@ if _, err := client.Act(ctx, stagehand.ActInstruction("click the login button"),
 	return err
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Warning>
 When handling sensitive data, turn logging off in your Stagehand configuration to prevent secrets from appearing in logs. See the [logging guide](/v4/configuration/logging) for more details.
@@ -731,7 +753,8 @@ When handling sensitive data, turn logging off in your Stagehand configuration t
 
 **Solution 1: Validate with observe**
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const prompt = "click the submit button";
 const expectedMethod = "click";
@@ -756,9 +779,9 @@ try {
   }
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 prompt = "click the submit button"
 expected_method = "click"
@@ -779,9 +802,9 @@ except Exception as error:
         method = action.method if action else None
         raise RuntimeError(f'Unsupported method: expected "{expected_method}", got "{method}"')
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 prompt := "click the submit button"
 expectedMethod := "click"
@@ -809,11 +832,13 @@ if _, err := client.Act(ctx, stagehand.ActInstruction(prompt), nil); err != nil 
 	}
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 **Solution 2: Retry with exponential backoff**
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Retry with exponential backoff for intermittent issues
 const prompt = "click the submit button";
@@ -837,9 +862,9 @@ for (let attempt = 0; attempt <= maxRetries; attempt++) {
   }
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # Retry with exponential backoff for intermittent issues
 import asyncio
@@ -860,9 +885,9 @@ for attempt in range(max_retries + 1):
         else:
             raise
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Retry with exponential backoff for intermittent issues
 prompt := "click the submit button"
@@ -889,7 +914,8 @@ for attempt := 0; attempt <= maxRetries; attempt++ {
 	}
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 </Accordion>
 
@@ -903,7 +929,8 @@ for attempt := 0; attempt <= maxRetries; attempt++ {
 - Use `observe()` first to verify element exists
 - Raise `domSettleTimeoutMs` on the constructor if the page keeps mutating after load
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Handle timeout and element not found issues
 try {
@@ -924,9 +951,9 @@ try {
   }
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # Handle timeout and element not found issues
 try:
@@ -945,9 +972,9 @@ except Exception:
         print("Element not found, trying alternative selector")
         await stagehand.act("click the button with text 'Submit'")
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Handle timeout and element not found issues
 timeout := 30000.0
@@ -978,7 +1005,8 @@ if _, err := client.Act(ctx, stagehand.ActInstruction("click the submit button")
 	}
 }
 ```
-</View>
+</Tab>
+</Tabs>
 </Accordion>
 
 <Accordion title="Incorrect element selected">
@@ -990,7 +1018,8 @@ if _, err := client.Act(ctx, stagehand.ActInstruction("click the submit button")
 - Add contextual information: "the search button in the header"
 - Use unique identifiers when available
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // More precise element targeting
 // Instead of:
@@ -1006,9 +1035,9 @@ if (action?.description.includes("checkout")) {
   await stagehand.act(action);
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # More precise element targeting
 # Instead of:
@@ -1024,9 +1053,9 @@ observed = await stagehand.observe(
 if observed.data and "checkout" in observed.data[0].description:
     await stagehand.act(observed.data[0])
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // More precise element targeting
 // Instead of:
@@ -1047,7 +1076,8 @@ if len(observed.Data) > 0 && strings.Contains(observed.Data[0].Description, "che
 	}
 }
 ```
-</View>
+</Tab>
+</Tabs>
 </Accordion>
 
 

--- a/packages/docs/v4/basics/extract.mdx
+++ b/packages/docs/v4/basics/extract.mdx
@@ -5,16 +5,17 @@ description: "Extract structured data from a webpage."
 
 ## What is `extract()`?
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 await stagehand.extract(
   "extract the name of the repository",
   z.object({ name: z.string() }),
 );
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 class Repository(BaseModel):
     name: str
@@ -25,9 +26,9 @@ await stagehand.extract(
     Repository,
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 type repository struct {
 	Name string `json:"name"`
@@ -41,7 +42,8 @@ extracted, err := stagehand.Extract[repository](
 	nil,
 )
 ```
-</View>
+</Tab>
+</Tabs>
 
 `extract()` grabs structured data from a webpage. Every call takes an instruction and an output shape: [Zod](https://github.com/colinhacks/zod) in TypeScript, [Pydantic](https://docs.pydantic.dev) in Python, and a Go type parameter whose JSON Schema Stagehand derives automatically. The result is validated against that shape before it is returned, so what you get back is already typed.
 
@@ -64,7 +66,8 @@ extracted, err := stagehand.Extract[repository](
 
 When extracting with an object schema, the return type is inferred from that schema:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const { data } = await stagehand.extract(
   "extract product details",
@@ -75,9 +78,9 @@ const { data } = await stagehand.extract(
   }),
 );
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 class Product(BaseModel):
     name: str
@@ -90,9 +93,9 @@ result = await stagehand.extract(
     Product,
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 type product struct {
 	Name    string  `json:"name"`
@@ -108,11 +111,13 @@ extracted, err := stagehand.Extract[product](
 	nil,
 )
 ```
-</View>
+</Tab>
+</Tabs>
 
 **Example result:**
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 {
   name: "Wireless Mouse",
@@ -120,27 +125,29 @@ extracted, err := stagehand.Extract[product](
   inStock: true
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 Product(name="Wireless Mouse", price=29.99, in_stock=True)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 result := product{Name: "Wireless Mouse", Price: 29.99, InStock: true}
 fmt.Println(result.Name, result.Price, result.InStock)
 ```
-</View>
+</Tab>
+</Tabs>
 
 </Tab>
 <Tab title="Array">
 
 To extract a list, wrap it in a field on your schema:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const { data } = await stagehand.extract(
   "extract all apartment listings",
@@ -155,9 +162,9 @@ const { data } = await stagehand.extract(
   }),
 );
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 class Apartment(BaseModel):
     address: str
@@ -174,9 +181,9 @@ result = await stagehand.extract(
     Apartments,
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 type apartment struct {
 	Address string `json:"address"`
@@ -196,11 +203,13 @@ extracted, err := stagehand.Extract[apartments](
 	nil,
 )
 ```
-</View>
+</Tab>
+</Tabs>
 
 **Example result:**
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 {
   apartments: [
@@ -217,18 +226,18 @@ extracted, err := stagehand.Extract[apartments](
   ]
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 Apartments(apartments=[
     Apartment(address="123 Main St", price="$1,200/mo", sqft=750),
     Apartment(address="456 Oak Ave", price="$1,500/mo", sqft=900),
 ])
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 result := apartments{Apartments: []apartment{
 	{Address: "123 Main St", Price: "$1,200/mo", Sqft: 750},
@@ -236,23 +245,25 @@ result := apartments{Apartments: []apartment{
 }}
 fmt.Println(result.Apartments[0].Address, result.Apartments[0].Sqft)
 ```
-</View>
+</Tab>
+</Tabs>
 
 </Tab>
 <Tab title="Primitive">
 
 To extract a single value, give it a named field:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const { data } = await stagehand.extract(
   "extract the price",
   z.object({ price: z.number() }),
 );
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 class Price(BaseModel):
     price: float
@@ -263,9 +274,9 @@ result = await stagehand.extract(
     Price,
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 type price struct {
 	Price float64 `json:"price"`
@@ -279,43 +290,47 @@ extracted, err := stagehand.Extract[price](
 	nil,
 )
 ```
-</View>
+</Tab>
+</Tabs>
 
 **Example result:**
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 {
   price: 19.99
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 Price(price=19.99)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 result := price{Price: 19.99}
 fmt.Println(result.Price)
 ```
-</View>
+</Tab>
+</Tabs>
 
 You can also extract strings, booleans, and URLs:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const { data } = await stagehand.extract(
   "extract the contact page link",
   z.object({ url: z.url() }),
 );
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 from pydantic import AnyUrl
 
@@ -329,9 +344,9 @@ result = await stagehand.extract(
     ContactLink,
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 type contactLink struct {
 	URL string `json:"url" jsonschema:"format=uri"`
@@ -345,7 +360,8 @@ extracted, err := stagehand.Extract[contactLink](
 	nil,
 )
 ```
-</View>
+</Tab>
+</Tabs>
 
 </Tab>
 </Tabs>
@@ -354,7 +370,8 @@ extracted, err := stagehand.Extract[contactLink](
 
 You can pass additional options to configure the model, timeout, selector scope, and whether to include a screenshot:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const result = await stagehand.extract(
   "extract the repository name",
@@ -369,9 +386,9 @@ const result = await stagehand.extract(
   },
 );
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import os
 
@@ -388,9 +405,9 @@ result = await stagehand.extract(
     selector="//header",  # Focus on specific area
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 
 modelAPIKey := os.Getenv("ANTHROPIC_API_KEY")
@@ -414,7 +431,8 @@ if err != nil {
 
 fmt.Println(result.Data.Name)
 ```
-</View>
+</Tab>
+</Tabs>
 
 ### Server-side caching
 
@@ -424,7 +442,8 @@ fmt.Println(result.Data.Name)
 
 When running on Browserbase, Stagehand can cache `extract()` results server-side. Repeated calls with the same inputs return instantly without consuming LLM tokens. Enable caching on `Stagehand.create()` and override it per call:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 
@@ -446,9 +465,9 @@ const result = await stagehand.extract(
 // Cache status travels on the result metadata
 console.log(result.metadata.cache.status); // "HIT", "MISS", or "DISABLED"
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import os
 
@@ -472,9 +491,9 @@ result = await stagehand.extract(
 # Cache status travels on the result metadata
 print(result.metadata.cache.status)  # "HIT", "MISS", or "DISABLED"
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 
 // Enable server-side caching for the entire instance
@@ -508,7 +527,8 @@ if err != nil {
 // Cache status travels on the result metadata
 fmt.Println(result.Metadata.Cache.Status) // "HIT", "MISS", or "DISABLED"
 ```
-</View>
+</Tab>
+</Tabs>
 
 ### Targeted extract
 
@@ -517,7 +537,8 @@ Pass a selector to `extract` to target a specific element on the page.
 This helps reduce the context passed to the LLM, optimizing token usage/speed and improving accuracy.
 </Tip>
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const { data: tableData } = await stagehand.extract(
   "Extract the values of the third row",
@@ -530,9 +551,9 @@ const { data: tableData } = await stagehand.extract(
   },
 );
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 class TableRow(BaseModel):
     values: list[str]
@@ -545,9 +566,9 @@ table_data = (await stagehand.extract(
     selector="xpath=/html/body/div/table/",
 )).data
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 type tableRow struct {
 	Values []string `json:"values"`
@@ -566,11 +587,13 @@ tableData, err := stagehand.Extract[tableRow](
 	},
 )
 ```
-</View>
+</Tab>
+</Tabs>
 
 You can also exclude specific nodes (including their descendant nodes) with the ignore-selectors option.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const { data: article } = await stagehand.extract(
   "extract the article title and body",
@@ -583,9 +606,9 @@ const { data: article } = await stagehand.extract(
   },
 );
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 class Article(BaseModel):
     title: str
@@ -598,9 +621,9 @@ article = (await stagehand.extract(
     ignore_selectors=[".ad", ".newsletter-modal", "nav.related-posts"],
 )).data
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 type article struct {
 	Title string `json:"title"`
@@ -619,7 +642,8 @@ extracted, err := stagehand.Extract[article](
 	},
 )
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Note>
   The ignore-selectors option removes all matches for each selector, along with each matched node's descendants. The selector option still scopes extraction to a single resolved subtree.
@@ -629,7 +653,8 @@ extracted, err := stagehand.Extract[article](
 
 Turn the screenshot option on when the extraction needs visual information from the current viewport in addition to the page accessibility tree.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const { data: saleBadge } = await stagehand.extract(
   "extract the text shown in the visible sale badge",
@@ -641,9 +666,9 @@ const { data: saleBadge } = await stagehand.extract(
   },
 );
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 class SaleBadge(BaseModel):
     text: str
@@ -655,9 +680,9 @@ sale_badge = (await stagehand.extract(
     screenshot=True,
 )).data
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 type saleBadge struct {
 	Text string `json:"text"`
@@ -675,7 +700,8 @@ saleBadgeData, err := stagehand.Extract[saleBadge](
 	},
 )
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Note>
   The screenshot option captures the current viewport, not the full page. Visual extractions always bypass the server-side cache, because a cache key is built from DOM state and cannot represent the pixels the model saw.
@@ -689,7 +715,8 @@ saleBadgeData, err := stagehand.Extract[saleBadge](
 
 You can provide additional context to your schema to help the model extract the data more accurately.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const { data } = await stagehand.extract(
   "Extract ALL the apartment listings and their details, including address, price, and square feet.",
@@ -704,9 +731,9 @@ const { data } = await stagehand.extract(
   }),
 );
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 from pydantic import BaseModel, Field
 
@@ -729,9 +756,9 @@ result = await stagehand.extract(
     Apartments,
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 type apartment struct {
 	Address    string `json:"address" jsonschema:"description=the address of the apartment"`
@@ -752,7 +779,8 @@ extracted, err := stagehand.Extract[apartments](
 	nil,
 )
 ```
-</View>
+</Tab>
+</Tabs>
 
 ### Link extraction
 <Note>
@@ -761,7 +789,8 @@ To extract links or URLs, define the relevant field as a URL type.
 
 Here is how an `extract` call might look for extracting a link or URL. This also works for image links.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const { data } = await stagehand.extract(
   "extract the link to the 'contact us' page",
@@ -771,9 +800,9 @@ const { data } = await stagehand.extract(
 
 console.log("the link to the contact us page is: ", data.contactLink);
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 from pydantic import AnyUrl, BaseModel
 
@@ -790,9 +819,9 @@ result = await stagehand.extract(
 
 print("the link to the contact us page is: ", result.data.contact_link)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 type contactLink struct {
 	ContactLink string `json:"contact_link" jsonschema:"format=uri"`
@@ -812,7 +841,8 @@ if err != nil {
 
 fmt.Println("the link to the contact us page is: ", extracted.Data.ContactLink)
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Tip>
 Inside Stagehand, extracting links works by asking the LLM to select an ID. Stagehand looks up that ID in a mapping of IDs to URLs. When logging the LLM trace, you should expect to see IDs. The actual URLs will be included in the final result.
@@ -831,7 +861,8 @@ Inside Stagehand, extracting links works by asking the LLM to select an ID. Stag
 
 **Solution: Wait for content before extracting**
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // waitForSelector reports whether the selector matched, so check it
 // before extracting: a timeout resolves to false without throwing.
@@ -850,9 +881,9 @@ const { data } = await stagehand.extract(
   }),
 );
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # wait_for_selector reports whether the selector matched, so check it
 # before extracting: a timeout returns False without raising.
@@ -875,9 +906,9 @@ result = await stagehand.extract(
     Products,
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // WaitForSelector returns (matched, error), so check matched before
 // extracting: a timeout reports false without returning an error.
@@ -911,7 +942,8 @@ if err != nil {
 
 fmt.Println("extracted", len(extracted.Data.Products), "products")
 ```
-</View>
+</Tab>
+</Tabs>
 </Accordion>
 
 <Accordion title="Schema validation errors">
@@ -924,7 +956,8 @@ fmt.Println("extracted", len(extracted.Data.Products), "products")
 
 **Solution: More flexible schema**
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const schema = z.object({
   price: z.string().describe("price including currency symbol, e.g., '$19.99'"),
@@ -932,18 +965,18 @@ const schema = z.object({
   rating: z.number().optional(),
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 class ProductDetails(BaseModel):
     price: str = Field(description="price including currency symbol, e.g., '$19.99'")
     availability: str | None = Field(default=None, description="stock status if available")
     rating: float | None = None
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Optional fields are pointers, and descriptions live in the JSON Schema
 type productDetails struct {
@@ -953,7 +986,8 @@ type productDetails struct {
 }
 
 ```
-</View>
+</Tab>
+</Tabs>
 </Accordion>
 
 <Accordion title="Inconsistent results">
@@ -966,7 +1000,8 @@ type productDetails struct {
 
 **Solution: Validate with observe first**
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // First observe to understand the page structure
 const { data: elements } = await stagehand.observe("find all product listings");
@@ -983,9 +1018,9 @@ const { data } = await stagehand.extract(
   }),
 );
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # First observe to understand the page structure
 observed = await stagehand.observe("find all product listings")
@@ -1007,9 +1042,9 @@ result = await stagehand.extract(
     Products,
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // First observe to understand the page structure
 instruction := "find all product listings"
@@ -1046,7 +1081,8 @@ for _, item := range extracted.Data.Products {
 	fmt.Println(item.Name, item.Price)
 }
 ```
-</View>
+</Tab>
+</Tabs>
 </Accordion>
 
 <Accordion title="Performance issues">
@@ -1060,7 +1096,8 @@ for _, item := range extracted.Data.Products {
 
 **Solution: Break down large extractions**
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Instead of extracting everything at once
 const allData = [];
@@ -1083,9 +1120,9 @@ for (const pageNum of pageNumbers) {
   allData.push(...data.products);
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # Instead of extracting everything at once
 all_data = []
@@ -1102,9 +1139,9 @@ for page_num in page_numbers:
 
     all_data.extend(result.data.products)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 type product struct {
 	Name  string  `json:"name"`
@@ -1140,7 +1177,8 @@ for pageNum := 1; pageNum <= 5; pageNum++ {
 	allData = append(allData, extracted.Data.Products...)
 }
 ```
-</View>
+</Tab>
+</Tabs>
 </Accordion>
 </AccordionGroup>
 

--- a/packages/docs/v4/basics/observe.mdx
+++ b/packages/docs/v4/basics/observe.mdx
@@ -5,26 +5,28 @@ description: "Discover and plan executable actions on any web page."
 
 ## What is `observe()`?
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 await stagehand.observe("find the login button");
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 await stagehand.observe("find the login button")
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 instruction := "find the login button"
 if _, err := client.Observe(ctx, &instruction, nil); err != nil {
 	return err
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 `observe()` discovers actionable elements on a page and returns structured actions you can execute or validate before acting. Use it to explore pages, plan multi-step workflows, cache actions, and validate elements before acting.
 
@@ -49,7 +51,8 @@ if _, err := client.Observe(ctx, &instruction, nil); err != nil {
 
 Use `observe()` to discover actionable elements on a page. Here's how to find a button:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const [page] = await browser.context.pages();
 if (!page) {
@@ -58,9 +61,9 @@ if (!page) {
 await page.goto("https://example.com");
 const { data: actions } = await stagehand.observe("find the learn more button");
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 page = (await browser.context.pages())[0]
 if page is None:
@@ -68,9 +71,9 @@ if page is None:
 await page.goto("https://example.com")
 result = await stagehand.observe("find the learn more button")
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 page, err := browserContext.ActivePage(ctx)
 if err != nil {
@@ -90,7 +93,8 @@ if err != nil {
 }
 fmt.Println("found", len(result.Data), "actions")
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Note>
 **iFrame and Shadow DOM support** Stagehand automatically handles iFrame traversal and shadow DOM elements without requiring additional configuration.
@@ -113,7 +117,8 @@ fmt.Println("found", len(result.Data), "actions")
 ### Return value of `observe()`?
 When you use `observe()`, Stagehand returns a result whose `data` field is a list of `Action` objects, alongside `metadata` carrying the action ID and server-side cache status. Each `Action` can be passed straight to [`act()`](/v4/basics/act) for deterministic replay:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 [
   {
@@ -124,9 +129,9 @@ When you use `observe()`, Stagehand returns a result whose `data` field is a lis
   }
 ]
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 [
     Action(
@@ -137,9 +142,9 @@ When you use `observe()`, Stagehand returns a result whose `data` field is a lis
     )
 ]
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 clickMethod := "click"
 
@@ -154,22 +159,24 @@ actions := []stagehand.Action{
 
 fmt.Println(actions[0].Description, *actions[0].Method, actions[0].Selector)
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Tabs>
 <Tab title="Do this">
 Use specific, descriptive instructions.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Clear and specific
 await stagehand.observe("find the primary call-to-action button in the hero section");
 await stagehand.observe("find all input fields in the checkout form");
 await stagehand.observe("find the delete account button in settings");
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # Clear and specific
 await stagehand.observe(
@@ -178,9 +185,9 @@ await stagehand.observe(
 await stagehand.observe("find all input fields in the checkout form")
 await stagehand.observe("find the delete account button in settings")
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Clear and specific
 hero := "find the primary call-to-action button in the hero section"
@@ -198,13 +205,15 @@ if _, err := client.Observe(ctx, &deleteButton, nil); err != nil {
 	return err
 }
 ```
-</View>
+</Tab>
+</Tabs>
 </Tab>
 
 <Tab title="Don't do this">
 Avoid vague or data-oriented queries.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Too vague
 await stagehand.observe("find buttons");
@@ -212,9 +221,9 @@ await stagehand.observe("find buttons");
 // Use extract() for data instead
 await stagehand.observe("what is the page title?");
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # Too vague
 await stagehand.observe("find buttons")
@@ -222,9 +231,9 @@ await stagehand.observe("find buttons")
 # Use extract() for data instead
 await stagehand.observe("what is the page title?")
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Too vague
 vague := "find buttons"
@@ -238,7 +247,8 @@ if _, err := client.Observe(ctx, &title, nil); err != nil {
 	return err
 }
 ```
-</View>
+</Tab>
+</Tabs>
 </Tab>
 </Tabs>
 
@@ -246,7 +256,8 @@ if _, err := client.Observe(ctx, &title, nil); err != nil {
 
 You can pass additional options to configure the model, timeout, selector scope, ignored page regions, and placeholder variables:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Custom model configuration
 const { data: actions } = await stagehand.observe("find navigation links", {
@@ -258,9 +269,9 @@ const { data: actions } = await stagehand.observe("find navigation links", {
   selector: "//header", // Focus on specific area
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import os
 
@@ -277,9 +288,9 @@ result = await stagehand.observe(
     selector="//header",  # Focus on specific area
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Custom model configuration
 modelAPIKey := os.Getenv("OPENAI_API_KEY")
@@ -303,11 +314,13 @@ if err != nil {
 }
 fmt.Println("found", len(result.Data), "navigation links")
 ```
-</View>
+</Tab>
+</Tabs>
 
 You can also exclude specific nodes, including their descendant nodes, with the ignore-selectors option.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const { data: actions } = await stagehand.observe("find the main call-to-action buttons", {
   ignoreSelectors: [
@@ -317,9 +330,9 @@ const { data: actions } = await stagehand.observe("find the main call-to-action 
   ],
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 result = await stagehand.observe(
     "find the main call-to-action buttons",
@@ -330,9 +343,9 @@ result = await stagehand.observe(
     ],
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 instruction := "find the main call-to-action buttons"
 result, err := client.Observe(ctx, &instruction, &stagehand.StagehandClientObserveOptions{
@@ -349,7 +362,8 @@ if err != nil {
 }
 fmt.Println("found", len(result.Data), "call-to-action buttons")
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Note>
   The ignore-selectors option removes all matches for each selector, along with each matched node's descendants. The selector option still scopes observation to a single resolved subtree.
@@ -359,7 +373,8 @@ fmt.Println("found", len(result.Data), "call-to-action buttons")
 
 For login and other safety-sensitive flows, use `observe()` to discover candidate actions, validate them, and then execute them. When you pass variables, `observe()` returns `%variableName%` placeholders in the suggested action arguments instead of raw secret values, so no secret ever reaches the model.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const { data: actions } = await stagehand.observe("find the login form fields", {
   variables: {
@@ -377,9 +392,9 @@ if (emailField && passwordField) {
   await stagehand.act(passwordField, { variables: { password: process.env.USER_PASSWORD } });
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 observed = await stagehand.observe(
     "find the login form fields",
@@ -406,9 +421,9 @@ if email_field is not None and password_field is not None:
         password_field, variables={"password": os.environ["USER_PASSWORD"]}
     )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 usernameDescription := "The login email"
 passwordDescription := "The login password"
@@ -465,7 +480,8 @@ if emailField != nil && passwordField != nil {
 	}
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Tip>
 `act()` supports the same variables option with either input form. Pass an instruction when you want Stagehand to locate the field for you, or pass the observed `Action` to replay a known target, in both cases keeping the value out of the prompt.
@@ -479,7 +495,8 @@ if emailField != nil && passwordField != nil {
 
 When running on Browserbase, Stagehand can cache `observe()` results server-side. Repeated calls with the same inputs return instantly without consuming LLM tokens. Enable caching on the constructor and override it per call:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 
@@ -495,9 +512,9 @@ const stagehand = await Stagehand.create({
 // Or disable it for a single call
 const { data: actions } = await stagehand.observe("find the login button", { cache: false });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import os
 
@@ -515,9 +532,9 @@ stagehand = await Stagehand.create(
 # Or disable it for a single call
 result = await stagehand.observe("find the login button", cache=False)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Enable server-side caching for the entire instance
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
@@ -543,7 +560,8 @@ if err != nil {
 
 fmt.Println(result.Metadata.Cache.Status) // "HIT", "MISS", or "DISABLED"
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Note>
   Cache status is reported on the result metadata, alongside the observed actions. You can also see it in the [Browserbase session replay dashboard](https://docs.browserbase.com/features/observability#stagehand) or in the session logs at debug level.
@@ -553,7 +571,8 @@ fmt.Println(result.Metadata.Cache.Status) // "HIT", "MISS", or "DISABLED"
 
 Stagehand v4 drives the browser directly over the Chrome DevTools Protocol, so there is no Puppeteer, Playwright, or Patchright page interop. Instead, target any page Stagehand manages by passing the `page` option:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const browser = await browserbase.launch({
   apiKey: process.env.BROWSERBASE_API_KEY,
@@ -568,9 +587,9 @@ const { data: actions } = await stagehand.observe("find all product cards", {
   page: productsPage,
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 browser = await browserbase.launch(
     api_key=os.environ["BROWSERBASE_API_KEY"],
@@ -586,9 +605,9 @@ result = await stagehand.observe(
     page=products_page,
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 browser, err := stagehand.LaunchBrowserbase(ctx, stagehand.BrowserbaseLaunchOptions{APIKey: apiKey})
@@ -621,7 +640,8 @@ if err != nil {
 }
 fmt.Println("found", len(result.Data), "product cards")
 ```
-</View>
+</Tab>
+</Tabs>
 
 This works with:
 - **Active page:** omit `page` and Stagehand uses the active page (default)
@@ -639,7 +659,8 @@ This works with:
 
 Discover all actions once, then feed each one back to `act()`. Passing an action rather than a string skips inference, so the loop below makes one model call for the whole form instead of one per field.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const { data: formFields } = await stagehand.observe("find all form input fields");
 
@@ -648,9 +669,9 @@ for (const field of formFields) {
   await stagehand.act(field);
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 observed = await stagehand.observe("find all form input fields")
 
@@ -658,9 +679,9 @@ for field in observed.data:
     # No LLM call: Stagehand replays the observed action
     await stagehand.act(field)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 instruction := "find all form input fields"
 observed, err := client.Observe(ctx, &instruction, nil)
@@ -675,7 +696,8 @@ for _, field := range observed.Data {
 	}
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Card title="Analyze pages with observe()" icon="magnifying-glass" href="/v4/reference/stagehand">
   Complete guide to planning actions with `observe()`.
@@ -685,7 +707,8 @@ for _, field := range observed.Data {
 
 Use `observe()` to find a container, then pass its selector to `extract()`. Extraction then sees only that subtree instead of the whole page, so token usage falls in proportion to how much of the page you exclude.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const PricingSchema = z.object({
   tiers: z.array(
@@ -709,9 +732,9 @@ for (const tier of pricing.tiers) {
   console.log(tier.name, tier.price);
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 class PricingTier(BaseModel):
     name: str
@@ -733,9 +756,9 @@ pricing = (await stagehand.extract(
 for tier in pricing.tiers:
     print(tier.name, tier.price)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 type pricingTier struct {
 	Name  string `json:"name"`
@@ -773,7 +796,8 @@ for _, tier := range pricing.Data.Tiers {
 	fmt.Println(tier.Name, tier.Price)
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Card title="Extract structured data" icon="table" href="/v4/basics/extract">
   Learn how to use `observe()` with `extract()` for precise data extraction.
@@ -783,7 +807,8 @@ for _, tier := range pricing.Data.Tiers {
 
 Check elements exist and verify their properties before performing critical operations.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const { data: buttons } = await stagehand.observe("find the delete account button");
 const [deleteButton] = buttons;
@@ -794,9 +819,9 @@ if (deleteButton?.method === "click") {
   throw new Error("Delete button not found");
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 observed = await stagehand.observe("find the delete account button")
 delete_button = observed.data[0] if observed.data else None
@@ -806,9 +831,9 @@ if delete_button is not None and delete_button.method == "click":
 else:
     raise RuntimeError("Delete button not found")
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 instruction := "find the delete account button"
 observed, err := client.Observe(ctx, &instruction, nil)
@@ -824,7 +849,8 @@ if _, err := client.Act(ctx, stagehand.ObservedAction(observed.Data[0]), nil); e
 	return err
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Card title="Execute actions with act()" icon="play" href="/v4/basics/act">
   Learn how to execute observed actions reliably.
@@ -834,7 +860,8 @@ if _, err := client.Act(ctx, stagehand.ObservedAction(observed.Data[0]), nil); e
 
 Store and reuse observed actions to eliminate redundant LLM calls. Build a simple in-process cache:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const actionCache = new Map<string, Action[]>();
 
@@ -848,9 +875,9 @@ async function cachedObserve(instruction: string) {
   return actions;
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 action_cache: dict[str, list[Action]] = {}
 
@@ -863,9 +890,9 @@ async def cached_observe(instruction: str) -> list[Action]:
     action_cache[instruction] = observed.data
     return observed.data
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 actionCache := map[string][]stagehand.Action{}
 
@@ -882,7 +909,8 @@ cachedObserve := func(ctx context.Context, instruction string) ([]stagehand.Acti
 	return observed.Data, nil
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Card title="Complete caching guide" icon="database" href="/v4/best-practices/caching">
   Learn advanced caching techniques and patterns for optimal performance.
@@ -901,7 +929,8 @@ cachedObserve := func(ctx context.Context, instruction string) ([]stagehand.Acti
 - Ensure page has fully loaded before calling `observe()`
 - Set the log level to `debug` in your Stagehand configuration to inspect detection behavior
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Check page state before observing
 const [page] = await browser.context.pages();
@@ -917,9 +946,9 @@ if (actions.length === 0) {
   const { data: altActions } = await stagehand.observe("find the button at the bottom of the form");
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # Check page state before observing
 page = (await browser.context.pages())[0]
@@ -935,9 +964,9 @@ if not observed.data:
         "find the button at the bottom of the form"
     )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Check page state before observing
 page, err := browserContext.ActivePage(ctx)
@@ -965,7 +994,8 @@ if len(observed.Data) == 0 {
 	}
 }
 ```
-</View>
+</Tab>
+</Tabs>
 </Accordion>
 
 <Accordion title="Inaccurate results">
@@ -976,7 +1006,8 @@ if len(observed.Data) == 0 {
 - Provide more context in your instruction (e.g., "find the submit button in the checkout form")
 - Set the log level to `debug` in your Stagehand configuration to inspect LLM reasoning
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // More specific instructions improve accuracy
 // Instead of:
@@ -985,9 +1016,9 @@ await stagehand.observe("find the button");
 // Use context:
 await stagehand.observe("find the red 'Delete' button in the user settings panel");
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # More specific instructions improve accuracy
 # Instead of:
@@ -998,9 +1029,9 @@ await stagehand.observe(
     "find the red 'Delete' button in the user settings panel"
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // More specific instructions improve accuracy
 // Instead of:
@@ -1015,7 +1046,8 @@ if _, err := client.Observe(ctx, &specific, nil); err != nil {
 	return err
 }
 ```
-</View>
+</Tab>
+</Tabs>
 </Accordion>
 
 <Accordion title="Wrong method suggested">
@@ -1026,7 +1058,8 @@ if _, err := client.Observe(ctx, &specific, nil); err != nil {
 - Check [supported actions](/v4/basics/act) for valid method names
 - Reach for a [locator](/v4/reference/stagehand) when you want to call a specific method instead of trusting the suggestion
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const { data: actions } = await stagehand.observe("find the submit button");
 const [action] = actions;
@@ -1039,9 +1072,9 @@ if (action && validMethods.includes(action.method || "")) {
   console.warn(`Unexpected method: ${action?.method}`);
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 observed = await stagehand.observe("find the submit button")
 action = observed.data[0] if observed.data else None
@@ -1053,9 +1086,9 @@ if action is not None and action.method in valid_methods:
 else:
     print(f"Unexpected method: {action.method if action else None}")
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 instruction := "find the submit button"
 observed, err := client.Observe(ctx, &instruction, nil)
@@ -1083,7 +1116,8 @@ if action != nil && slices.Contains(validMethods, method) {
 	fmt.Println("Unexpected method:", method)
 }
 ```
-</View>
+</Tab>
+</Tabs>
 </Accordion>
 
 </AccordionGroup>

--- a/packages/docs/v4/basics/webmcp.mdx
+++ b/packages/docs/v4/basics/webmcp.mdx
@@ -12,7 +12,8 @@ Some pages expose their own capabilities as callable tools rather than making yo
 
 {/* TODO(go): confirm the Go samples once a Go toolchain is available; they are symbol-checked but not compiled. */}
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const tools = await page.tools();
 const [checkout] = tools;
@@ -22,9 +23,9 @@ const response = await invocation.result();
 
 console.log(response.status, response.output);
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 tools = await page.tools()
 checkout = tools[0]
@@ -34,9 +35,9 @@ response = await invocation.result()
 
 print(response.status, response.output)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 tools, err := page.Tools(ctx, nil)
 if err != nil {
@@ -56,7 +57,8 @@ if err != nil {
 
 fmt.Println(response.Status, response.Output)
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Note>
 WebMCP tools are registered *by the page*. That makes them distinct from tools you wire into a model yourself: you do not define them, you discover whatever the site chose to publish.
@@ -78,7 +80,8 @@ Stagehand can only set launch flags on browsers it launches. If you attach to a 
 
 `page.tools()` takes a snapshot of what the page currently exposes. Call it again after navigating or after the page mounts new UI; the result is not live.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Wait up to 3 seconds for the page to register its tools
 const tools = await page.tools({ timeout: 3000 });
@@ -90,9 +93,9 @@ for (const tool of tools) {
   console.log(tool.frameId);       // the frame that registered the tool
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # Wait up to 3 seconds for the page to register its tools
 tools = await page.tools(timeout=3000)
@@ -103,9 +106,9 @@ for tool in tools:
     print(tool.annotations)   # read_only / untrusted_content / autosubmit
     print(tool.frame_id)      # the frame that registered the tool
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Wait up to 3 seconds for the page to register its tools
 timeout := 3000.0
@@ -122,7 +125,8 @@ for _, tool := range tools {
 	fmt.Println(descriptor.FrameID)      // the frame that registered the tool
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 The listing timeout defaults to 1000 ms. Tools declared in iframes are included, each tagged with the `frameId` that registered it.
 
@@ -141,7 +145,8 @@ Annotations are hints from the page, not guarantees enforced by the browser. Tre
 
 Invoking is two steps: `invoke()` hands the call to the browser and returns immediately with a handle, then `result()` waits for the terminal response. Splitting them means a long-running tool does not block you, and you can cancel while it is in flight.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const [search] = await page.tools();
 
@@ -153,9 +158,9 @@ console.log(invocation.invocationId, invocation.toolName, invocation.input);
 // Blocks until the tool reaches a terminal state
 const response = await invocation.result({ timeout: 30000 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 tools = await page.tools()
 search = tools[0]
@@ -168,9 +173,9 @@ print(invocation.invocation_id, invocation.tool_name, invocation.input)
 # Blocks until the tool reaches a terminal state
 response = await invocation.result(timeout=30000)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 tools, err := page.Tools(ctx, nil)
 if err != nil {
@@ -196,7 +201,8 @@ if err != nil {
 
 fmt.Println(response.Status, response.Output)
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Note>
 Omitting the input sends an empty object. Validate your input against the tool's `inputSchema` before invoking if you want a clear failure locally rather than an `Error` response from the page.
@@ -212,7 +218,8 @@ A terminal response reports one of three statuses:
 | `Canceled` | Cancellation was honored | neither |
 | `Error` | The tool failed | `errorText`, and `exception` when the page threw |
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const response = await invocation.result();
 
@@ -228,9 +235,9 @@ switch (response.status) {
     break;
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 response = await invocation.result()
 
@@ -241,9 +248,9 @@ elif response.status == "Canceled":
 else:
     print(response.error_text, response.exception)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 response, err := invocation.Result(ctx, nil)
 if err != nil {
@@ -267,13 +274,15 @@ case stagehand.WebMCPInvocationStatusError:
 	fmt.Println(response.ErrorText, response.Exception)
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 `result()` caches the terminal response, so calling it twice is cheap and returns the same value. A timeout or transport failure is not cached and can be retried.
 
 ### Canceling an invocation
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const invocation = await slowTool.invoke({ input: {} });
 
@@ -283,9 +292,9 @@ await invocation.cancel();
 const response = await invocation.result();
 console.log(response.status); // often "Canceled", but the tool may have finished first
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 invocation = await slow_tool.invoke(input={})
 
@@ -295,9 +304,9 @@ await invocation.cancel()
 response = await invocation.result()
 print(response.status)  # often "Canceled", but the tool may have finished first
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 invocation, err := slowTool.Invoke(ctx, nil)
 if err != nil {
@@ -315,7 +324,8 @@ if err != nil {
 }
 fmt.Println(response.Status) // often "Canceled", but the tool may have finished first
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Warning>
 Cancellation is a request, not a guarantee. Chrome decides the terminal status, so always read it from `result()` rather than assuming the invocation stopped.
@@ -334,7 +344,8 @@ Raise the listing timeout on pages that register tools after an async bootstrap.
 
 WebMCP and the primitives solve different problems, and mixing them is normal: use a tool where the page gives you one, and fall back to [`observe()`](/v4/basics/observe) and [`act()`](/v4/basics/act) where it does not.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const tools = await page.tools();
 const addToCart = tools.find((tool) => tool.name === "addToCart");
@@ -348,9 +359,9 @@ if (addToCart) {
   await stagehand.act("add the item to the cart");
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 tools = await page.tools()
 add_to_cart = next((tool for tool in tools if tool.name == "addToCart"), None)
@@ -363,9 +374,9 @@ else:
     # The page publishes no tool for this, so drive the UI
     await stagehand.act("add the item to the cart")
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 tools, err := page.Tools(ctx, nil)
 if err != nil {
@@ -396,7 +407,8 @@ if addToCart != nil {
 	}
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Tip>
 A tool invocation costs no LLM tokens and cannot pick the wrong element, so prefer one over an `act()` call whenever the page offers it.

--- a/packages/docs/v4/best-practices/caching.mdx
+++ b/packages/docs/v4/best-practices/caching.mdx
@@ -21,7 +21,8 @@ Caching requires a Browserbase browser and the Browserbase API key you passed to
 
 Pass `cache: true` to enable caching for all requests made by that instance:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 
@@ -39,9 +40,9 @@ await page.goto("https://example.com");
 // Cached after the hit-count threshold is met
 await stagehand.act("click the login button");
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import os
 
@@ -61,9 +62,9 @@ await page.goto("https://example.com")
 # Cached after the hit-count threshold is met
 await stagehand.act("click the login button")
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 cache := stagehand.CacheEnabled(true)
@@ -103,13 +104,15 @@ if _, err := client.Act(ctx, stagehand.ActInstruction("click the login button"),
 	return err
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 ### Disabling per call
 
 Override the instance setting for a single call by passing the cache option:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 
@@ -129,9 +132,9 @@ await stagehand.act("click the login button", { cache: false });
 // This call uses the cache as normal
 await stagehand.act("submit the form");
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import os
 
@@ -153,9 +156,9 @@ await stagehand.act("click the login button", cache=False)
 # This call uses the cache as normal
 await stagehand.act("submit the form")
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 cache := stagehand.CacheEnabled(true)
@@ -188,7 +191,8 @@ if _, err := client.Act(ctx, stagehand.ActInstruction("submit the form"), nil); 
 	return err
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 ### Cache threshold
 
@@ -196,7 +200,8 @@ The threshold controls how many times Browserbase must see an identical result b
 
 Set it on `Stagehand.create()` to change the default for the instance, or per call to tune a single step. It overrides the threshold configured on your Browserbase project.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const browser = await browserbase.launch({ apiKey: process.env.BROWSERBASE_API_KEY });
 
@@ -215,9 +220,9 @@ const { data } = await stagehand.extract(
 );
 console.log(data.companies);
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import os
 
@@ -243,9 +248,9 @@ result = await stagehand.extract(
 )
 print(result.data.companies)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 type companies struct {
 	Companies []string `json:"companies"`
@@ -286,27 +291,29 @@ if err != nil {
 
 fmt.Println(result.Data.Companies)
 ```
-</View>
+</Tab>
+</Tabs>
 
 ### Inspecting cache status
 
 Every result carries `metadata.cache`, so you can verify whether the cache served that result. The status is always present: `HIT`, `MISS`, or `DISABLED` when no cache lookup ran at all. A miss also carries a `missReason`, and a hit carries the tokens it saved.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const result = await stagehand.act("click the login button");
 console.log(result.metadata.cache.status); // "HIT", "MISS", or "DISABLED"
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 result = await stagehand.act("click the login button")
 print(result.metadata.cache.status)  # "HIT", "MISS", or "DISABLED"
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 result, err := client.Act(ctx, stagehand.ActInstruction("click the login button"), nil)
 if err != nil {
@@ -315,7 +322,8 @@ if err != nil {
 
 fmt.Println(result.Metadata.Cache.Status) // "HIT", "MISS", or "DISABLED"
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Tip>
 Cache behavior is also visible in the [Browserbase session replay dashboard](https://docs.browserbase.com/features/observability#stagehand) and in Stagehand's own logs at the `debug` level.
@@ -335,7 +343,8 @@ Cache behavior is also visible in the [Browserbase session replay dashboard](htt
 <Accordion title="Scope by selector">
 When targeting a specific part of a page, pass a selector to scope the accessibility tree snapshot to that container. This reduces token costs, speeds up inference, and, crucially for caching, means that changes *outside* the container don't affect the cache key.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 async function example(stagehand: Stagehand) {
   const page = await stagehand.browser.context.activePage();
@@ -350,9 +359,9 @@ async function example(stagehand: Stagehand) {
   });
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 async def example(stagehand: Stagehand) -> None:
     page = await stagehand.browser.context.active_page()
@@ -367,9 +376,9 @@ async def example(stagehand: Stagehand) -> None:
         selector="#rcnt",
     )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 func example(ctx context.Context, client *stagehand.Stagehand, page *stagehand.Page) error {
 	if _, err := page.Goto(ctx, "https://www.google.com/search?q=browserbase", nil); err != nil {
@@ -390,7 +399,8 @@ func example(ctx context.Context, client *stagehand.Stagehand, page *stagehand.P
 	return err
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Note>
 When you set a selector, Stagehand hashes only that subtree. If the selector fails to resolve, Stagehand skips caching for that call rather than falling back to the whole page.
@@ -404,7 +414,8 @@ Variables keep a literal value out of the instruction you write. Stagehand sends
 Do not assume two runs with different values share a cache entry. The variables you pass travel to the cache service with the rest of the request, so a different value may produce different key data and miss. Because Stagehand transmits them, pass `cache: false` on any call carrying a credential. See [prompting with variables](/v4/best-practices/prompting-best-practices) for the full caveat.
 </Warning>
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 async function example(stagehand: Stagehand) {
   const page = await stagehand.browser.context.activePage();
@@ -420,9 +431,9 @@ async function example(stagehand: Stagehand) {
   );
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 async def example(stagehand: Stagehand) -> None:
     page = await stagehand.browser.context.active_page()
@@ -437,9 +448,9 @@ async def example(stagehand: Stagehand) -> None:
         variables={"email": "alice@example.com"},
     )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 func example(ctx context.Context, client *stagehand.Stagehand, page *stagehand.Page) error {
 	if _, err := page.Goto(ctx, "https://example.com/login", nil); err != nil {
@@ -462,7 +473,8 @@ func example(ctx context.Context, client *stagehand.Stagehand, page *stagehand.P
 	return err
 }
 ```
-</View>
+</Tab>
+</Tabs>
 </Accordion>
 
 <Accordion title="Stabilize the environment">
@@ -472,7 +484,8 @@ Small differences in runtime state produce different accessibility trees and the
 - **Consistent user agent and locale:** set these in your browser launch options
 - **Block noisy third-party requests:** analytics, A/B testing scripts, and ad trackers can inject DOM nodes that shift the cache key on every load
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const page = await browser.context.activePage();
 
@@ -484,9 +497,9 @@ await browser.context.setDomainPolicy({
   blockedDomains: ["*.google-analytics.com", "*.doubleclick.net"],
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 page = await browser.context.active_page()
 
@@ -498,9 +511,9 @@ await browser.context.set_domain_policy(
     DomainPolicy(blocked_domains=["*.google-analytics.com", "*.doubleclick.net"])
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 browserContext, err := browser.Context()
 if err != nil {
@@ -526,7 +539,8 @@ if err := browserContext.SetDomainPolicy(ctx, &stagehand.DomainPolicy{
 	return err
 }
 ```
-</View>
+</Tab>
+</Tabs>
 </Accordion>
 
 <Accordion title="Keep prompts deterministic">
@@ -536,7 +550,8 @@ The instruction string is part of the cache key. Even minor wording changes (syn
 - Keep instructions short and free of filler words
 - Avoid instructions that contain runtime-variable text inline; use variables instead
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Good: anchored to the visible label, no variance
 await stagehand.act("click the Sign in button");
@@ -544,9 +559,9 @@ await stagehand.act("click the Sign in button");
 // Bad: inline dynamic value creates a new cache key every time
 await stagehand.act(`type ${email} into the Email address field`);
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # Good: anchored to the visible label, no variance
 await stagehand.act("click the Sign in button")
@@ -554,9 +569,9 @@ await stagehand.act("click the Sign in button")
 # Bad: inline dynamic value creates a new cache key every time
 await stagehand.act(f"type {email} into the Email address field")
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Good: anchored to the visible label, no variance
 if _, err := client.Act(ctx, stagehand.ActInstruction("click the Sign in button"), nil); err != nil {
@@ -568,13 +583,15 @@ if _, err := client.Act(ctx, stagehand.ActInstruction(fmt.Sprintf("type %s into 
 	return err
 }
 ```
-</View>
+</Tab>
+</Tabs>
 </Accordion>
 
 <Accordion title="Pair caching with the Model Gateway">
 Both server-side caching and the [Model Gateway](/v4/configuration/models#model-gateway) run off the same Browserbase session and the same API key. Using them together means one bill for inference, browsers, and cache, and no provider keys to rotate.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const browser = await browserbase.launch({ apiKey: process.env.BROWSERBASE_API_KEY });
 
@@ -584,9 +601,9 @@ const stagehand = await Stagehand.create({
   cache: true,                          // Served by Browserbase Cache
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 browser = await browserbase.launch(api_key=os.environ["BROWSERBASE_API_KEY"])
 
@@ -596,9 +613,9 @@ stagehand = await Stagehand.create(
     cache=True,            # Served by Browserbase Cache
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 // Routed through Model Gateway: no model API key
@@ -622,7 +639,8 @@ if err != nil {
 }
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 </Accordion>
 
 </AccordionGroup>

--- a/packages/docs/v4/best-practices/cost-optimization.mdx
+++ b/packages/docs/v4/best-practices/cost-optimization.mdx
@@ -10,7 +10,7 @@ Cost optimization in Stagehand involves balancing LLM inference costs and browse
 
 Start with these simple optimizations that can reduce costs:
 
-### 1. Use the right model for the job
+### Use the right model for the job
 
 Browserbase doesn't recommend using larger, more premium models for simple tasks. See the [evaluation results](https://stagehand.dev/evals) for model performance and cost comparisons across different task types.
 
@@ -124,7 +124,7 @@ fmt.Println(result.Data.Summary)
 </Card>
 </CardGroup>
 
-### 2. Implement caching
+### Implement caching
 
 Enable server-side caching to eliminate redundant LLM calls. Turn on the `cache` option when initializing Stagehand:
 
@@ -196,7 +196,7 @@ if _, err := client.Act(ctx, stagehand.ActInstruction("Click the sign in button"
 </Card>
 </CardGroup>
 
-### 3. Optimize browser sessions
+### Optimize browser sessions
 
 Reuse sessions when possible and set appropriate timeouts. See [Browser Configuration](/v4/configuration/browser) for details:
 

--- a/packages/docs/v4/best-practices/cost-optimization.mdx
+++ b/packages/docs/v4/best-practices/cost-optimization.mdx
@@ -16,7 +16,8 @@ Browserbase doesn't recommend using larger, more premium models for simple tasks
 
 Reach for a stronger model only on the calls that need it, with a per-call model override:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const stagehand = await Stagehand.create({
   browser: await browserbase.launch({ apiKey: process.env.BROWSERBASE_API_KEY }),
@@ -35,9 +36,9 @@ await stagehand.extract("summarize the contract terms", termsSchema, {
   },
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import os
 
@@ -64,9 +65,9 @@ await stagehand.extract(
     ),
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 type terms struct {
 	Summary string `json:"summary"`
@@ -111,7 +112,8 @@ if err != nil {
 
 fmt.Println(result.Data.Summary)
 ```
-</View>
+</Tab>
+</Tabs>
 
 <CardGroup cols={2}>
 <Card title="Model selection guide" icon="brain" href="/v4/configuration/models">
@@ -126,7 +128,8 @@ fmt.Println(result.Data.Summary)
 
 Enable server-side caching to eliminate redundant LLM calls. Turn on the `cache` option when initializing Stagehand:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const stagehand = await Stagehand.create({
   browser: await browserbase.launch({ apiKey: process.env.BROWSERBASE_API_KEY }),
@@ -137,9 +140,9 @@ const stagehand = await Stagehand.create({
 // Subsequent runs: reuses the cached action (no LLM cost)
 await stagehand.act("Click the sign in button");
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import os
 
@@ -156,9 +159,9 @@ stagehand = await Stagehand.create(
 # Subsequent runs: reuses the cached action (no LLM cost)
 await stagehand.act("Click the sign in button")
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 cache := stagehand.CacheWithThreshold(1) // Serve hits after one identical result
@@ -184,7 +187,8 @@ if _, err := client.Act(ctx, stagehand.ActInstruction("Click the sign in button"
 	return err
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 <CardGroup cols={1}>
 <Card title="Caching guide" icon="database" href="/v4/best-practices/caching">
@@ -196,7 +200,8 @@ if _, err := client.Act(ctx, stagehand.ActInstruction("Click the sign in button"
 
 Reuse sessions when possible and set appropriate timeouts. See [Browser Configuration](/v4/configuration/browser) for details:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const stagehand = await Stagehand.create({
   browser: await browserbase.launch({
@@ -206,9 +211,9 @@ const stagehand = await Stagehand.create({
   }),
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 browser = await browserbase.launch(
     api_key=os.environ["BROWSERBASE_API_KEY"],
@@ -218,9 +223,9 @@ browser = await browserbase.launch(
 
 stagehand = await Stagehand.create(browser=browser)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 timeout := 1800.0 // 30 minutes instead of default 1 hour
@@ -243,7 +248,8 @@ if err != nil {
 }
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 <CardGroup cols={1}>
 <Card title="Browserbase cost optimization" icon="window-maximize" href="https://docs.browserbase.com/guides/cost-optimization">
@@ -257,7 +263,8 @@ defer func() { err = errors.Join(err, client.Close(ctx)) }()
 
 Automatically fall back to cheaper models for simple tasks. Escalate on `observe()` rather than `act()`: `observe()` only plans and never touches the page, so a retry cannot repeat a click, submit, or purchase that already landed before the error surfaced. The winning plan is then handed to `act()` exactly once.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Use models from least to most expensive based on task complexity
 // See stagehand.dev/evals for performance comparisons
@@ -283,9 +290,9 @@ async function smartAct(stagehand: Stagehand, prompt: string) {
   throw new Error(`No model could complete: ${prompt}`);
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # Use models from least to most expensive based on task complexity
 # See stagehand.dev/evals for performance comparisons
@@ -315,9 +322,9 @@ async def smart_act(stagehand: Stagehand, prompt: str):
 
     raise RuntimeError(f"No model could complete: {prompt}")
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Use models from least to most expensive based on task complexity
 // See stagehand.dev/evals for performance comparisons
@@ -356,13 +363,15 @@ func smartAct(ctx context.Context, client *stagehand.Stagehand, prompt string) (
 	return stagehand.ActResult{}, fmt.Errorf("no model could complete: %s", prompt)
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 ### Session pooling
 
 Reuse browser sessions across multiple tasks:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 class SessionManager {
   // Store the in-flight promise, not the resolved instance: two callers racing
@@ -401,9 +410,9 @@ class SessionManager {
   }
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import os
 import asyncio
@@ -440,9 +449,9 @@ class SessionManager:
         sessions = await asyncio.gather(*tasks, return_exceptions=True)
         await asyncio.gather(*(s.close() for s in sessions if isinstance(s, Stagehand)))
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 type sessionManager struct {
 	mu       sync.Mutex
@@ -497,7 +506,8 @@ func (m *sessionManager) closeAll(ctx context.Context) error {
 	return errors.Join(errs...)
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 ## Cost monitoring
 
@@ -505,7 +515,8 @@ Track your spending to identify optimization opportunities. See the [observabili
 
 Stagehand reports token counts, not dollars. Keep prompt and completion tokens separate: providers bill them at different rates, so a single blended rate over the total is wrong for every model. Multiply each count by the input and output rates on your provider's pricing page to turn these into currency.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Monitor token usage
 const metrics = await stagehand.metrics();
@@ -515,9 +526,9 @@ console.log(`Completion tokens: ${metrics.totalCompletionTokens}`);
 // Tokens served from your provider's prompt cache cost less
 console.log(`Cached input tokens: ${metrics.totalCachedInputTokens}`);
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # Monitor token usage
 metrics = await stagehand.metrics()
@@ -527,9 +538,9 @@ print(f"Completion tokens: {metrics.total_completion_tokens}")
 # Tokens served from your provider's prompt cache cost less
 print(f"Cached input tokens: {metrics.total_cached_input_tokens}")
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Monitor token usage
 metrics, err := client.Metrics(ctx)
@@ -542,7 +553,8 @@ fmt.Printf("Completion tokens: %.0f\n", metrics.TotalCompletionTokens)
 // Tokens served from your provider's prompt cache cost less
 fmt.Printf("Cached input tokens: %.0f\n", metrics.TotalCachedInputTokens)
 ```
-</View>
+</Tab>
+</Tabs>
 
 <CardGroup cols={1}>
 <Card title="Observability & metrics" icon="chart-line" href="/v4/configuration/observability">
@@ -554,7 +566,8 @@ fmt.Printf("Cached input tokens: %.0f\n", metrics.TotalCachedInputTokens)
 
 Set spending limits to prevent unexpected costs:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 class BudgetGuard {
   private dailySpend = 0;
@@ -581,9 +594,9 @@ class BudgetGuard {
   }
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 from datetime import date
 
@@ -605,9 +618,9 @@ class BudgetGuard:
             raise RuntimeError(f"Daily budget exceeded: ${self.max_daily_budget}")
         self.daily_spend += estimated_cost
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 type budgetGuard struct {
 	mu             sync.Mutex
@@ -644,7 +657,8 @@ func (g *budgetGuard) checkBudget(estimatedCost float64) error {
 	return nil
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Tip>
 Using the [Model Gateway](/v4/configuration/models#model-gateway) puts inference, browsers, and caching on a single Browserbase bill, which makes spend easier to attribute and cap in one place.

--- a/packages/docs/v4/best-practices/deployments.mdx
+++ b/packages/docs/v4/best-practices/deployments.mdx
@@ -28,7 +28,8 @@ pnpm i -g vercel
 
 ### 2. Project layout
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```text
 your-project/
   api/
@@ -37,9 +38,9 @@ your-project/
   tsconfig.json
   vercel.json
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```text
 your-project/
   api/
@@ -47,9 +48,9 @@ your-project/
   requirements.txt
   vercel.json
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```text
 your-project/
   api/
@@ -57,35 +58,39 @@ your-project/
   go.mod
   vercel.json
 ```
-</View>
+</Tab>
+</Tabs>
 
 Create the structure with:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```bash
 mkdir -p api
 touch api/run.ts package.json vercel.json tsconfig.json
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```bash
 mkdir -p api
 touch api/run.py requirements.txt vercel.json
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```bash
 mkdir -p api
 touch api/run.go vercel.json
 go mod init example.com/bb-stagehand-on-vercel
 ```
-</View>
+</Tab>
+</Tabs>
 
 ### 3. `api/run.ts` (Node.js runtime)
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // api/run.ts
 import type { VercelRequest, VercelResponse } from "@vercel/node";
@@ -142,9 +147,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse): 
   }
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # api/run.py
 import json
@@ -211,9 +216,9 @@ class handler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(json.dumps(body).encode())
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // api/run.go
 package main
@@ -331,11 +336,13 @@ func main() {
 	_ = http.ListenAndServe(":"+port, nil)
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 ### 4. `package.json`
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```json
 {
     "name": "bb-stagehand-on-vercel",
@@ -353,17 +360,17 @@ func main() {
     }
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```text
 # requirements.txt
 stagehand
 anyio
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```text
 // go.mod
 module example.com/bb-stagehand-on-vercel
@@ -372,11 +379,13 @@ go 1.26.0
 
 require github.com/browserbase/stagehand/packages/sdk-go v4.0.0
 ```
-</View>
+</Tab>
+</Tabs>
 
 ### 5. `tsconfig.json`
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```json
 {
   "compilerOptions": {
@@ -392,25 +401,27 @@ require github.com/browserbase/stagehand/packages/sdk-go v4.0.0
   "include": ["api/**/*.ts"]
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```text
 Not applicable. Python functions on Vercel need no compiler configuration;
 declare your dependencies in requirements.txt instead.
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```text
 Not applicable. Go functions on Vercel need no compiler configuration;
 declare your dependencies in go.mod instead.
 ```
-</View>
+</Tab>
+</Tabs>
 
 ### 6. `vercel.json`
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```json
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
@@ -421,9 +432,9 @@ declare your dependencies in go.mod instead.
   }
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```json
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
@@ -434,9 +445,9 @@ declare your dependencies in go.mod instead.
   }
 }
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```json
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
@@ -447,7 +458,8 @@ declare your dependencies in go.mod instead.
   }
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 See Vercel's [configuring functions](https://vercel.com/docs/functions/configuring-functions) docs for more details.
 
@@ -455,7 +467,8 @@ See Vercel's [configuring functions](https://vercel.com/docs/functions/configuri
 
 Link your local folder to a Vercel project before configuring environment variables:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```bash
 # authenticate if needed
 vercel login
@@ -463,9 +476,9 @@ vercel login
 # link the current directory to a Vercel project (interactive)
 vercel link
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```bash
 # authenticate if needed
 vercel login
@@ -473,9 +486,9 @@ vercel login
 # link the current directory to a Vercel project (interactive)
 vercel link
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```bash
 # authenticate if needed
 vercel login
@@ -483,13 +496,15 @@ vercel login
 # link the current directory to a Vercel project (interactive)
 vercel link
 ```
-</View>
+</Tab>
+</Tabs>
 
 ### 8. Environment variables
 
 Never commit secrets. Add variables via the Vercel CLI, then read them in your handler and pass them to the Stagehand constructor. `CRON_SECRET` is the secret the handler compares against the `Authorization` header, and Vercel sends it automatically when a cron job invokes the function:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```bash
 vercel env add BROWSERBASE_API_KEY
 # (and your model key if needed)
@@ -499,9 +514,9 @@ vercel env add GOOGLE_API_KEY
 # generate one with: openssl rand -hex 32
 vercel env add CRON_SECRET
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```bash
 vercel env add BROWSERBASE_API_KEY
 # (and your model key if needed)
@@ -511,9 +526,9 @@ vercel env add GOOGLE_API_KEY
 # generate one with: openssl rand -hex 32
 vercel env add CRON_SECRET
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```bash
 vercel env add BROWSERBASE_API_KEY
 # (and your model key if needed)
@@ -523,7 +538,8 @@ vercel env add GOOGLE_API_KEY
 # generate one with: openssl rand -hex 32
 vercel env add CRON_SECRET
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Tip>
 Using the [Model Gateway](/v4/configuration/models#model-gateway) means `BROWSERBASE_API_KEY` is the only secret you need to deploy.
@@ -535,7 +551,8 @@ See also: [Browser Configuration](/v4/configuration/browser) for details on requ
 
 Replicate the Vercel environment locally to exercise your Function before deploying. Run from the project root.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```bash
 # ensure dependencies are installed
 npm install
@@ -543,9 +560,9 @@ npm install
 # start the local Vercel dev server
 vercel dev --listen 5005
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```bash
 # ensure dependencies are installed
 pip install -r requirements.txt
@@ -553,9 +570,9 @@ pip install -r requirements.txt
 # start the local Vercel dev server
 vercel dev --listen 5005
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```bash
 # ensure dependencies are installed
 go mod tidy
@@ -563,30 +580,33 @@ go mod tidy
 # start the local Vercel dev server
 vercel dev --listen 5005
 ```
-</View>
+</Tab>
+</Tabs>
 
 ### 10. Deploy
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```bash
 vercel
 vercel --prod
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```bash
 vercel
 vercel --prod
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```bash
 vercel
 vercel --prod
 ```
-</View>
+</Tab>
+</Tabs>
 
 ### Execute the function
 
@@ -603,38 +623,41 @@ If the deployment also sits behind Vercel Deployment Protection, create a Protec
 
 Then invoke the function with the bypass header:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```bash
 curl -X POST \
   -H "Authorization: Bearer <your-CRON_SECRET>" \
   -H "x-vercel-protection-bypass: <your-32-character-secret>" \
   https://<your-deployment>/api/run
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```bash
 curl -X POST \
   -H "Authorization: Bearer <your-CRON_SECRET>" \
   -H "x-vercel-protection-bypass: <your-32-character-secret>" \
   https://<your-deployment>/api/run
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```bash
 curl -X POST \
   -H "Authorization: Bearer <your-CRON_SECRET>" \
   -H "x-vercel-protection-bypass: <your-32-character-secret>" \
   https://<your-deployment>/api/run
 ```
-</View>
+</Tab>
+</Tabs>
 
 ### Optional: cron on Vercel
 
 Hit the same endpoint on a schedule by extending `vercel.json`. Cron invocations arrive as `GET` requests carrying `Authorization: Bearer $CRON_SECRET`, so the handler's secret check passes without extra configuration:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```json
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
@@ -648,9 +671,9 @@ Hit the same endpoint on a schedule by extending `vercel.json`. Cron invocations
   ]
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```json
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
@@ -664,9 +687,9 @@ Hit the same endpoint on a schedule by extending `vercel.json`. Cron invocations
   ]
 }
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```json
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
@@ -680,7 +703,8 @@ Hit the same endpoint on a schedule by extending `vercel.json`. Cron invocations
   ]
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 ### Features
 - **No local browsers needed** with a Browserbase browser. [Browserbase](https://www.browserbase.com/) provides the browsers, so your function ships without a Chrome binary.

--- a/packages/docs/v4/best-practices/deployments.mdx
+++ b/packages/docs/v4/best-practices/deployments.mdx
@@ -15,7 +15,9 @@ Run Stagehand on Browserbase inside a Vercel Function. This guide shows a minima
 Every request to this endpoint opens a Browserbase session and spends model tokens. Vercel serves production deployments publicly, so gate the handler before you deploy it. The handlers below reject any request that does not present `Authorization: Bearer $CRON_SECRET`, the same header Vercel sends on cron invocations.
 </Warning>
 
-### 1. Install Vercel CLI
+<Steps>
+
+<Step title="Install Vercel CLI">
 
 To download and install Vercel CLI, run one of the following commands:
 
@@ -26,7 +28,9 @@ pnpm i -g vercel
 # bun add -g vercel
 ```
 
-### 2. Project layout
+</Step>
+
+<Step title="Project layout">
 
 <Tabs>
 <Tab title="TypeScript">
@@ -87,7 +91,9 @@ go mod init example.com/bb-stagehand-on-vercel
 </Tab>
 </Tabs>
 
-### 3. `api/run.ts` (Node.js runtime)
+</Step>
+
+<Step title="api/run.ts (Node.js runtime)">
 
 <Tabs>
 <Tab title="TypeScript">
@@ -339,7 +345,9 @@ func main() {
 </Tab>
 </Tabs>
 
-### 4. `package.json`
+</Step>
+
+<Step title="package.json">
 
 <Tabs>
 <Tab title="TypeScript">
@@ -382,7 +390,9 @@ require github.com/browserbase/stagehand/packages/sdk-go v4.0.0
 </Tab>
 </Tabs>
 
-### 5. `tsconfig.json`
+</Step>
+
+<Step title="tsconfig.json">
 
 <Tabs>
 <Tab title="TypeScript">
@@ -418,7 +428,9 @@ declare your dependencies in go.mod instead.
 </Tab>
 </Tabs>
 
-### 6. `vercel.json`
+</Step>
+
+<Step title="vercel.json">
 
 <Tabs>
 <Tab title="TypeScript">
@@ -463,7 +475,9 @@ declare your dependencies in go.mod instead.
 
 See Vercel's [configuring functions](https://vercel.com/docs/functions/configuring-functions) docs for more details.
 
-### 7. Link your project
+</Step>
+
+<Step title="Link your project">
 
 Link your local folder to a Vercel project before configuring environment variables:
 
@@ -499,7 +513,9 @@ vercel link
 </Tab>
 </Tabs>
 
-### 8. Environment variables
+</Step>
+
+<Step title="Environment variables">
 
 Never commit secrets. Add variables via the Vercel CLI, then read them in your handler and pass them to the Stagehand constructor. `CRON_SECRET` is the secret the handler compares against the `Authorization` header, and Vercel sends it automatically when a cron job invokes the function:
 
@@ -547,7 +563,9 @@ Using the [Model Gateway](/v4/configuration/models#model-gateway) means `BROWSER
 
 See also: [Browser Configuration](/v4/configuration/browser) for details on required variables.
 
-### 9. Test locally
+</Step>
+
+<Step title="Test locally">
 
 Replicate the Vercel environment locally to exercise your Function before deploying. Run from the project root.
 
@@ -583,7 +601,9 @@ vercel dev --listen 5005
 </Tab>
 </Tabs>
 
-### 10. Deploy
+</Step>
+
+<Step title="Deploy">
 
 <Tabs>
 <Tab title="TypeScript">
@@ -608,11 +628,15 @@ vercel --prod
 </Tab>
 </Tabs>
 
-### Execute the function
+</Step>
+
+<Step title="Execute the function">
 
 Every request needs `Authorization: Bearer $CRON_SECRET`. Requests without it get a 401 and never reach Browserbase.
 
-#### Configure protection bypass for automation
+</Step>
+
+<Step title="Configure protection bypass for automation">
 
 If the deployment also sits behind Vercel Deployment Protection, create a Protection Bypass for Automation so scripted callers can reach it:
 
@@ -652,7 +676,9 @@ curl -X POST \
 </Tab>
 </Tabs>
 
-### Optional: cron on Vercel
+</Step>
+
+<Step title="Optional: cron on Vercel">
 
 Hit the same endpoint on a schedule by extending `vercel.json`. Cron invocations arrive as `GET` requests carrying `Authorization: Bearer $CRON_SECRET`, so the handler's secret check passes without extra configuration:
 
@@ -705,6 +731,9 @@ Hit the same endpoint on a schedule by extending `vercel.json`. Cron invocations
 ```
 </Tab>
 </Tabs>
+
+</Step>
+</Steps>
 
 ### Features
 - **No local browsers needed** with a Browserbase browser. [Browserbase](https://www.browserbase.com/) provides the browsers, so your function ships without a Chrome binary.

--- a/packages/docs/v4/best-practices/mcp-integrations.mdx
+++ b/packages/docs/v4/best-practices/mcp-integrations.mdx
@@ -13,7 +13,8 @@ In v3, MCP integrations attached external tool servers to a Stagehand agent. Sta
 
 Interleave your tool results with Stagehand's primitives. Because v4 has no autonomous loop, you are already writing the orchestration, so a tool call is one more step in the sequence.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Your MCP client, your credentials, your control flow
 const searchResults = await mcpClient.callTool("web_search", {
@@ -28,9 +29,9 @@ const { data } = await stagehand.extract(
   z.object({ pricing: z.array(z.object({ tier: z.string(), price: z.string() })) }),
 );
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # Your MCP client, your credentials, your control flow
 search_results = await mcp_client.call_tool(
@@ -56,9 +57,9 @@ result = await stagehand.extract(
 )
 pricing = result.data
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Your MCP client, your credentials, your control flow
 searchResults, err := mcpClient.CallTool(ctx, "web_search", map[string]any{
@@ -97,7 +98,8 @@ for _, t := range extracted.Data.Pricing {
 	fmt.Println(t.Tier, t.Price)
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Tip>
 MCP is still useful on the authoring side: wire the Stagehand docs MCP server into your coding assistant so it generates correct v4 code. See [AI Rules](/v4/first-steps/ai-rules#using-mcp-servers).

--- a/packages/docs/v4/best-practices/prompting-best-practices.mdx
+++ b/packages/docs/v4/best-practices/prompting-best-practices.mdx
@@ -9,7 +9,8 @@ Good prompts make Stagehand reliable. Bad prompts cause failures. Here's how to 
 
 Use `act()` for single actions on web pages. Each action should be focused and clear.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Good - Single, specific actions
 await stagehand.act("click the 'Add to Cart' button");
@@ -19,9 +20,9 @@ await stagehand.act("type 'user@example.com' into the email field");
 await stagehand.act("fill out the form and submit it");
 await stagehand.act("login with credentials and navigate to dashboard");
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # Good - Single, specific actions
 await stagehand.act("click the 'Add to Cart' button")
@@ -31,9 +32,9 @@ await stagehand.act("type 'user@example.com' into the email field")
 await stagehand.act("fill out the form and submit it")
 await stagehand.act("login with credentials and navigate to dashboard")
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Good - Single, specific actions
 if _, err := client.Act(ctx, stagehand.ActInstruction("click the 'Add to Cart' button"), nil); err != nil {
@@ -51,13 +52,15 @@ if _, err := client.Act(ctx, stagehand.ActInstruction("login with credentials an
 	return err
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 ### Use element types, not colors
 
 Describe elements by their type and function rather than visual attributes like color.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Good - Element types and descriptive text
 await stagehand.act("click the 'Sign In' button");
@@ -67,9 +70,9 @@ await stagehand.act("type into the email input field");
 await stagehand.act("click the blue button");
 await stagehand.act("type into the white input");
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # Good - Element types and descriptive text
 await stagehand.act("click the 'Sign In' button")
@@ -79,9 +82,9 @@ await stagehand.act("type into the email input field")
 await stagehand.act("click the blue button")
 await stagehand.act("type into the white input")
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Good - Element types and descriptive text
 if _, err := client.Act(ctx, stagehand.ActInstruction("click the 'Sign In' button"), nil); err != nil {
@@ -99,11 +102,13 @@ if _, err := client.Act(ctx, stagehand.ActInstruction("type into the white input
 	return err
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 ### Use descriptive language
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Good - Clear element identification
 await stagehand.act("click the 'Next' button at the bottom of the form");
@@ -113,9 +118,9 @@ await stagehand.act("type into the search bar at the top of the page");
 await stagehand.act("click next");
 await stagehand.act("type into search");
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # Good - Clear element identification
 await stagehand.act("click the 'Next' button at the bottom of the form")
@@ -125,9 +130,9 @@ await stagehand.act("type into the search bar at the top of the page")
 await stagehand.act("click next")
 await stagehand.act("type into search")
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Good - Clear element identification
 if _, err := client.Act(ctx, stagehand.ActInstruction("click the 'Next' button at the bottom of the form"), nil); err != nil {
@@ -145,7 +150,8 @@ if _, err := client.Act(ctx, stagehand.ActInstruction("type into search"), nil);
 	return err
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 ### Choose the right action verbs
 
@@ -155,7 +161,8 @@ if _, err := client.Act(ctx, stagehand.ActInstruction("type into search"), nil);
 - **Check/uncheck** for checkboxes
 - **Upload** for file inputs
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Good
 await stagehand.act("click the submit button");
@@ -165,9 +172,9 @@ await stagehand.act("select 'Option 1' from dropdown");
 await stagehand.act("click submit");
 await stagehand.act("choose option 1");
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # Good
 await stagehand.act("click the submit button")
@@ -177,9 +184,9 @@ await stagehand.act("select 'Option 1' from dropdown")
 await stagehand.act("click submit")
 await stagehand.act("choose option 1")
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Good
 if _, err := client.Act(ctx, stagehand.ActInstruction("click the submit button"), nil); err != nil {
@@ -197,7 +204,8 @@ if _, err := client.Act(ctx, stagehand.ActInstruction("choose option 1"), nil); 
 	return err
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 ### Protect sensitive data
 
@@ -207,7 +215,8 @@ Variables keep sensitive information out of prompts and logs. Stagehand shows th
 Variables are part of the payload that builds the [cache key](/v4/best-practices/caching). Caching is off by default, so the values stay inside the run unless you opt in. Once you enable it with `cache` on `Stagehand.create()` or on a call, the variables you pass travel to the cache service with the rest of the request, so pass `cache: false` on the calls that carry credentials.
 </Warning>
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Use variables for sensitive data
 await stagehand.act("type %username% into the email field", {
@@ -219,9 +228,9 @@ await stagehand.act("type %password% into the password field", {
   variables: { password: process.env.USER_PASSWORD },
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # Use variables for sensitive data
 await stagehand.act(
@@ -235,9 +244,9 @@ await stagehand.act(
     variables={"password": os.environ["USER_PASSWORD"]},
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Use variables for sensitive data
 if _, err := client.Act(ctx, stagehand.ActInstruction("type %username% into the email field"), &stagehand.StagehandClientActOptions{
@@ -263,7 +272,8 @@ if _, err := client.Act(ctx, stagehand.ActInstruction("type %password% into the 
 	return err
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Warning>
 Set the log level to `off` in your Stagehand config to prevent secrets from appearing in logs.
@@ -277,7 +287,8 @@ Use `extract()` to pull structured data from pages. Define clear schemas and pro
 
 Use descriptive field names, correct types, and detailed descriptions. Field descriptions provide context that helps the model understand exactly what to extract.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Good - Descriptive names, correct types, and helpful descriptions
 const { data: productData } = await stagehand.extract(
@@ -299,9 +310,9 @@ const { data } = await stagehand.extract(
   }),
 );
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 from pydantic import BaseModel, Field
 
@@ -330,9 +341,9 @@ class Data(BaseModel):
 
 data = (await stagehand.extract(instruction="Get product details", schema=Data)).data
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Good - Descriptive names, correct types, and helpful descriptions
 type productData struct {
@@ -348,13 +359,15 @@ type data struct {
 	Stock string `json:"stock"`
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 ### Use proper URL types
 
 Type link fields as URLs so Stagehand resolves them to real addresses instead of the internal element IDs the model chooses.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Good - Tells Stagehand to extract URLs
 const { data } = await stagehand.extract(
@@ -373,9 +386,9 @@ const { data: contact } = await stagehand.extract(
   z.object({ contactUrl: z.url() }),
 );
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 from pydantic import AnyUrl, BaseModel
 
@@ -406,9 +419,9 @@ contact = (await stagehand.extract(
     schema=ContactUrl,
 )).data
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Good - Tells Stagehand to extract URLs
 type link struct {
@@ -429,7 +442,8 @@ for _, l := range extracted.Data.Links {
 	fmt.Println(l.Text, l.URL)
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 ## Observe method
 
@@ -439,7 +453,8 @@ Use `observe()` to discover actionable elements before acting on them.
 
 Verify elements exist before taking action to avoid errors.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Check for elements first
 const { data: loginButtons } = await stagehand.observe("Find the login button");
@@ -450,9 +465,9 @@ if (loginButtons.length > 0) {
   console.log("No login button found");
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # Check for elements first
 login_buttons = (await stagehand.observe(instruction="Find the login button")).data
@@ -462,9 +477,9 @@ if login_buttons:
 else:
     print("No login button found")
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Check for elements first
 instruction := "Find the login button"
@@ -481,11 +496,13 @@ if len(observed.Data) > 0 {
 	fmt.Println("No login button found")
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 ### Be specific about element types
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Good - Specific element types
 const { data: submitButtons } = await stagehand.observe("Find submit button in the form");
@@ -495,9 +512,9 @@ const { data: dropdowns } = await stagehand.observe("Find the state dropdown men
 const { data: elements } = await stagehand.observe("Find submit stuff");
 const { data: things } = await stagehand.observe("Find state selection");
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # Good - Specific element types
 submit_buttons = (await stagehand.observe(instruction="Find submit button in the form")).data
@@ -507,9 +524,9 @@ dropdowns = (await stagehand.observe(instruction="Find the state dropdown menu")
 elements = (await stagehand.observe(instruction="Find submit stuff")).data
 things = (await stagehand.observe(instruction="Find state selection")).data
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Good - Specific element types
 submit := "Find submit button in the form"
@@ -537,7 +554,8 @@ if _, err := client.Observe(ctx, &alsoVague, nil); err != nil {
 	return err
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 ## Sequencing multi-step work
 
@@ -547,7 +565,8 @@ Stagehand v4 has no autonomous agent, so multi-step flows are your control flow.
 
 Don't put navigation inside an instruction. Handle it separately with `goto`.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Good - Navigate first, then act
 await page.goto("https://amazon.com");
@@ -556,9 +575,9 @@ await stagehand.act("type 'wireless headphones' into the search box");
 // Bad - Navigation inside the instruction
 await stagehand.act("go to Amazon and search for headphones");
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # Good - Navigate first, then act
 await page.goto("https://amazon.com")
@@ -567,9 +586,9 @@ await stagehand.act("type 'wireless headphones' into the search box")
 # Bad - Navigation inside the instruction
 await stagehand.act("go to Amazon and search for headphones")
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Good - Navigate first, then act
 if _, err := page.Goto(ctx, "https://amazon.com", nil); err != nil {
@@ -584,13 +603,15 @@ if _, err := client.Act(ctx, stagehand.ActInstruction("go to Amazon and search f
 	return err
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 ### Break work into steps
 
 One instruction per action. Sequence them yourself so each step is independently debuggable and cacheable.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Good - Explicit, ordered steps
 await stagehand.act("type 'wireless headphones' into the search box");
@@ -607,9 +628,9 @@ const { data } = await stagehand.extract(
 // Bad - One instruction carrying a whole workflow
 await stagehand.act("search for wireless headphones under $100 and add the best rated one to cart");
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # Good - Explicit, ordered steps
 await stagehand.act("type 'wireless headphones' into the search box")
@@ -636,9 +657,9 @@ await stagehand.act(
     "search for wireless headphones under $100 and add the best rated one to cart"
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Good - Explicit, ordered steps
 if _, err := client.Act(ctx, stagehand.ActInstruction("type 'wireless headphones' into the search box"), nil); err != nil {
@@ -680,13 +701,15 @@ if _, err := client.Act(ctx, stagehand.ActInstruction("search for wireless headp
 	return err
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 ### Include success criteria
 
 Verify each step landed instead of assuming it did.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Good - Verify the outcome
 await stagehand.act("click the add to cart button");
@@ -703,9 +726,9 @@ if (cart.itemCount !== 1) {
 // Bad - No validation
 await stagehand.act("add some items to cart");
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # Good - Verify the outcome
 await stagehand.act("click the add to cart button")
@@ -726,9 +749,9 @@ if cart.item_count != 1:
 # Bad - No validation
 await stagehand.act("add some items to cart")
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Good - Verify the outcome
 if _, err := client.Act(ctx, stagehand.ActInstruction("click the add to cart button"), nil); err != nil {
@@ -759,7 +782,8 @@ if _, err := client.Act(ctx, stagehand.ActInstruction("add some items to cart"),
 	return err
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 ## Common mistakes to avoid
 

--- a/packages/docs/v4/best-practices/speed-optimization.mdx
+++ b/packages/docs/v4/best-practices/speed-optimization.mdx
@@ -8,7 +8,7 @@ Stagehand performance depends on several factors: DOM processing speed, LLM infe
 
 ## Quick performance wins
 
-### 1. Plan ahead with observe
+### Plan ahead with observe
 
 Use a single `observe()` call to plan multiple actions, then replay each returned `Action` through `act()`:
 
@@ -78,7 +78,7 @@ for _, field := range observed.Data {
   Learn advanced caching patterns and cache invalidation strategies
 </Card>
 
-### 2. Optimize DOM processing
+### Optimize DOM processing
 
 Reduce DOM complexity before Stagehand processes the page. Scoping is usually the biggest win: pass a selector so Stagehand snapshots one container instead of the whole document, and prune known-noisy subtrees.
 
@@ -160,7 +160,7 @@ _, err := client.Act(ctx, stagehand.ActInstruction("Click the submit button"), n
 Removing iframes speeds up snapshots, but Stagehand traverses iframes by default. Only strip them when you know the content you need lives in the main frame.
 </Warning>
 
-### 3. Set appropriate timeouts
+### Set appropriate timeouts
 
 Use shorter timeouts for simple operations and longer ones for complex page loads. Lowering the DOM settle timeout also shaves time off every `act()` call on stable pages.
 

--- a/packages/docs/v4/best-practices/speed-optimization.mdx
+++ b/packages/docs/v4/best-practices/speed-optimization.mdx
@@ -12,7 +12,8 @@ Stagehand performance depends on several factors: DOM processing speed, LLM infe
 
 Use a single `observe()` call to plan multiple actions, then replay each returned `Action` through `act()`:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Instead of sequential operations with multiple LLM calls
 await stagehand.act("Fill name field");         // LLM call #1
@@ -27,9 +28,9 @@ for (const field of formFields) {
   await stagehand.act(field);
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # Instead of sequential operations with multiple LLM calls
 await stagehand.act("Fill name field")          # LLM call #1
@@ -43,9 +44,9 @@ form_fields = (await stagehand.observe(instruction="Find all form fields to fill
 for field in form_fields:
     await stagehand.act(field)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Instead of sequential operations with multiple LLM calls
 _, err := client.Act(ctx, stagehand.ActInstruction("Fill name field"), nil)          // LLM call #1
@@ -66,7 +67,8 @@ for _, field := range observed.Data {
 	}
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Note>
 **Performance tip**: Passing an observed `Action` back to `act()` replays its recorded method and arguments without another inference call. A planned workflow therefore costs one `observe()` inference instead of one per step, which is the recommended pattern for multi-step workflows.
@@ -80,7 +82,8 @@ for _, field := range observed.Data {
 
 Reduce DOM complexity before Stagehand processes the page. Scoping is usually the biggest win: pass a selector so Stagehand snapshots one container instead of the whole document, and prune known-noisy subtrees.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Scope the snapshot to the region you care about
 await stagehand.observe("Find the checkout actions", {
@@ -99,9 +102,9 @@ await page.evaluate(`
 // Then perform Stagehand operations
 await stagehand.act("Click the submit button");
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # Scope the snapshot to the region you care about
 await stagehand.observe(
@@ -121,9 +124,9 @@ await page.evaluate("""
 # Then perform Stagehand operations
 await stagehand.act("Click the submit button")
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Scope the snapshot to the region you care about
 selector := "#checkout"
@@ -150,7 +153,8 @@ if _, err := page.Evaluate(ctx, `
 // Then perform Stagehand operations
 _, err := client.Act(ctx, stagehand.ActInstruction("Click the submit button"), nil)
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Warning>
 Removing iframes speeds up snapshots, but Stagehand traverses iframes by default. Only strip them when you know the content you need lives in the main frame.
@@ -160,7 +164,8 @@ Removing iframes speeds up snapshots, but Stagehand traverses iframes by default
 
 Use shorter timeouts for simple operations and longer ones for complex page loads. Lowering the DOM settle timeout also shaves time off every `act()` call on stable pages.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Stable pages: shorten the settle wait (default is 5000ms)
 const browser = await browserbase.launch({ apiKey: process.env.BROWSERBASE_API_KEY });
@@ -182,9 +187,9 @@ await page.goto("https://heavy-spa.com", {
   timeout: 15000,
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # Stable pages: shorten the settle wait (default is 5000ms)
 browser = await browserbase.launch(api_key=os.environ["BROWSERBASE_API_KEY"])
@@ -205,9 +210,9 @@ await page.goto(
     timeout=15000,
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Stable pages: shorten the settle wait (default is 5000ms)
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
@@ -257,7 +262,8 @@ if _, err := page.Goto(ctx, "https://heavy-spa.com", &stagehand.PageNavigationOp
 	return err
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 ## Performance monitoring and benchmarking
 
@@ -265,7 +271,8 @@ Track performance metrics and measure optimization impact:
 
 ### Performance tracking
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 class PerformanceTracker {
   private speedMetrics: Map<string, number[]> = new Map();
@@ -291,9 +298,9 @@ class PerformanceTracker {
   }
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 from time import perf_counter
 
@@ -317,9 +324,9 @@ class PerformanceTracker:
         times = self.speed_metrics.get(prompt, [])
         return sum(times) / len(times) if times else 0.0
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 type performanceTracker struct {
 	mu           sync.Mutex
@@ -361,7 +368,8 @@ func (t *performanceTracker) getAverageTime(prompt string) time.Duration {
 	return total / time.Duration(len(times))
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 Example Output:
 ```
@@ -372,7 +380,8 @@ Action "Confirm submission" took 5000ms
 
 ### Before vs after benchmarking
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Before optimization
 console.time("workflow");
@@ -391,9 +400,9 @@ for (const action of workflowActions) {
 }
 console.timeEnd("workflow-optimized"); // 500ms
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 from time import perf_counter
 
@@ -415,9 +424,9 @@ for action in workflow_actions:
     await stagehand.act(action)
 print(f"workflow-optimized: {(perf_counter() - start) * 1000:.0f}ms")  # 500ms
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Before optimization
 start := time.Now()
@@ -448,7 +457,8 @@ for _, action := range observed.Data {
 }
 fmt.Printf("workflow-optimized: %dms\n", time.Since(start).Milliseconds()) // 500ms
 ```
-</View>
+</Tab>
+</Tabs>
 
 Example Output:
 ```

--- a/packages/docs/v4/best-practices/usecase-observe.mdx
+++ b/packages/docs/v4/best-practices/usecase-observe.mdx
@@ -8,7 +8,8 @@ description: Real-world patterns for planning automations with observe()
 
 ### E-commerce product discovery
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Discover product interaction elements
 const { data: productActions } = await stagehand.observe(
@@ -31,9 +32,9 @@ if (cartButtons.length > 0) {
   await page.locator(cartButtons[0].selector).click(); // Then add to cart
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # Discover product interaction elements
 product_actions = (await stagehand.observe(
@@ -50,9 +51,9 @@ if size_options:
 if cart_buttons:
     await page.locator(cart_buttons[0].selector).click()  # Then add to cart
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Discover product interaction elements
 instruction := "Find add to cart buttons, size selectors, and product images"
@@ -85,13 +86,15 @@ if len(cartButtons) > 0 {
 	}
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 ### Form handling & validation
 
 `valueFor` (`value_for` in Python) is a helper you supply: it maps an observed field description to the value you want to type.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Analyze form structure before filling
 const { data: formElements } = await stagehand.observe(
@@ -110,9 +113,9 @@ for (const field of requiredFields) {
   await page.locator(field.selector).fill(valueFor(field.description));
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # Analyze form structure before filling
 form_elements = (await stagehand.observe(
@@ -130,9 +133,9 @@ print(f"Found {len(required_fields)} required fields to complete")
 for field in required_fields:
     await page.locator(field.selector).fill(value_for(field.description))
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Analyze form structure before filling
 instruction := "Find form fields, validation messages, and submit buttons"
@@ -158,11 +161,13 @@ for _, field := range requiredFields {
 	}
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 ### Dynamic content & SPA navigation
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Wait for and discover dynamically loaded content
 await page.waitForLoadState("networkidle");
@@ -184,9 +189,9 @@ if (scrollTriggers.length > 0) {
   const { data: newContent } = await stagehand.observe("Find additional items");
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # Wait for and discover dynamically loaded content
 await page.wait_for_load_state("networkidle")
@@ -208,9 +213,9 @@ if scroll_triggers:
     # Recursively observe new content
     new_content = (await stagehand.observe(instruction="Find additional items")).data
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Wait for and discover dynamically loaded content
 if err := page.WaitForLoadState(ctx, stagehand.LoadStateNetworkIdle, nil); err != nil {
@@ -246,11 +251,13 @@ if len(scrollTriggers) > 0 {
 	}
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 ### Multi-step workflow planning
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Plan entire checkout flow upfront
 async function planCheckoutWorkflow() {
@@ -285,9 +292,9 @@ async function planCheckoutWorkflow() {
 const workflow = await planCheckoutWorkflow();
 // Fill shipping, then payment, then submit
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # Plan entire checkout flow upfront
 async def plan_checkout_workflow():
@@ -325,9 +332,9 @@ async def plan_checkout_workflow():
 workflow = await plan_checkout_workflow()
 # Fill shipping, then payment, then submit
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 type checkoutPlan struct {
 	ShippingFields []stagehand.Action
@@ -390,4 +397,5 @@ func planCheckoutWorkflow(
 plan, err := planCheckoutWorkflow(ctx, client, page)
 // Fill shipping, then payment, then submit
 ```
-</View>
+</Tab>
+</Tabs>

--- a/packages/docs/v4/best-practices/user-data.mdx
+++ b/packages/docs/v4/best-practices/user-data.mdx
@@ -12,7 +12,8 @@ Persist browser data between sessions.
 
 For local sessions, point `localBrowser.launch()` at a user data directory. Stagehand creates the directory if it does not exist and leaves it in place after the browser shuts down, so the next run starts from the same cookies and local storage:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { localBrowser, Stagehand } from "@browserbasehq/stagehand";
 
@@ -22,9 +23,9 @@ const stagehand = await Stagehand.create({
   }),
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 from stagehand import Stagehand, local_browser
 
@@ -32,9 +33,9 @@ browser = await local_browser.launch(user_data_dir="./browser-data")
 
 stagehand = await Stagehand.create(browser=browser)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 browser, err := stagehand.LaunchLocalBrowser(ctx, &stagehand.LocalBrowserLaunchOptions{
 	UserDataDir: "./browser-data",
@@ -51,7 +52,8 @@ if err != nil {
 }
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Note>
 When no user data directory is set, Stagehand launches Chrome against a temporary profile and deletes it on shutdown, so cookies and local storage do not carry over between runs. A directory you pass yourself is kept either way, so nothing extra is required for the setup above.
@@ -59,24 +61,27 @@ When no user data directory is set, Stagehand launches Chrome against a temporar
 
 The preserve flag governs only that generated temporary profile, never a directory you passed yourself:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 `preserveUserDataDir` keeps the generated temporary directory after shutdown when you turn it on.
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 `preserve_user_data_dir` keeps the generated temporary directory after shutdown when you turn it on.
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 `PreserveUserDataDir` keeps the generated temporary directory after shutdown when you turn it on.
-</View>
+</Tab>
+</Tabs>
 
 
 ### Browserbase sessions
 
 For Browserbase sessions, use [contexts](https://docs.browserbase.com/features/contexts) to persist browser data:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 
@@ -92,9 +97,9 @@ const stagehand = await Stagehand.create({
   }),
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import os
 
@@ -112,9 +117,9 @@ browser = await browserbase.launch(
 
 stagehand = await Stagehand.create(browser=browser)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 persist := true
@@ -140,7 +145,8 @@ if err != nil {
 }
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Warning>
 A persisted profile carries cookies, tokens, and site data across runs. Treat the directory or context ID as a credential: keep it out of version control and scope it to a single automation.

--- a/packages/docs/v4/best-practices/using-multiple-tabs.mdx
+++ b/packages/docs/v4/best-practices/using-multiple-tabs.mdx
@@ -11,7 +11,8 @@ Stagehand automatically adapts to multitab workflows. The active page always poi
 
 This means you can continue using familiar patterns:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const page = await browser.context.activePage();
 await page.goto("https://example.com");
@@ -24,9 +25,9 @@ const { data } = await stagehand.extract(
 );
 console.log(data.value);
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 page = await browser.context.active_page()
 await page.goto("https://example.com")
@@ -44,9 +45,9 @@ result = await stagehand.extract(
 )
 print(result.data.value)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 page, err := browserContext.ActivePage(ctx)
 if err != nil {
@@ -75,7 +76,8 @@ if err != nil {
 
 fmt.Println(extracted.Data.Value)
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Warning>
 **Important**: The page object you captured before the click still refers to the *original* tab. Re-read the active page, or hold an explicit reference to each tab, when you need to reach back to it.
@@ -85,7 +87,8 @@ fmt.Println(extracted.Data.Value)
 
 For more control or multitab workflows, you can manage multiple tabs explicitly. Set the active page when you want the default target to follow you:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Create a second page
 await browser.context.newPage();
@@ -111,9 +114,9 @@ console.log(`Stagehand-Python stars: ${stagehandPythonStars.data.stars}`);
 // Make one of them the default target for later calls
 await browser.context.setActivePage(githubPage);
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import asyncio
 
@@ -150,9 +153,9 @@ print(f"Stagehand-Python stars: {stagehand_python_stars.data.stars}")
 # Make one of them the default target for later calls
 await browser.context.set_active_page(github_page)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 type stars struct {
 	Stars int `json:"stars"`
@@ -206,7 +209,8 @@ if err := browserContext.SetActivePage(ctx, githubPage); err != nil {
 	return err
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Note>
 Locators belong to the page they were created on. `page.locator(selector)` carries that page's identity, so a locator from one tab never resolves against another.

--- a/packages/docs/v4/configuration/browser.mdx
+++ b/packages/docs/v4/configuration/browser.mdx
@@ -12,7 +12,8 @@ You get a browser from one of Stagehand's browser factories and hand it to `Stag
 
 Stagehand closes only the browsers it launched, so `browser.close()` is yours to call.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const cloud = await browserbase.launch({ apiKey: process.env.BROWSERBASE_API_KEY });
 const local = await localBrowser.launch({ headless: true });
@@ -20,9 +21,9 @@ const connected = await localBrowser.connect({ cdpUrl: "http://127.0.0.1:9222" }
 
 await Stagehand.create({ browser: cloud });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 cloud = await browserbase.launch(api_key=os.environ["BROWSERBASE_API_KEY"])
 local = await local_browser.launch(headless=True)
@@ -30,9 +31,9 @@ connected = await local_browser.connect(cdp_url="http://127.0.0.1:9222")
 
 await Stagehand.create(browser=cloud)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 
@@ -45,7 +46,8 @@ stagehand.ConnectLocalBrowser(ctx, stagehand.LocalBrowserConnectOptions{
 	CDPURL: "http://127.0.0.1:9222",
 })
 ```
-</View>
+</Tab>
+</Tabs>
 
 ## Browserbase environment
 
@@ -59,7 +61,8 @@ Browserbase provides managed cloud browser infrastructure optimized for web auto
 
 Browserbase runs browsers in four regions, so you can cut latency by starting the browser near your users or your target site, and keep session data in a required jurisdiction. Set the region on `browserbase.launch()`; `us-west-2` is the default.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 
@@ -69,9 +72,9 @@ const browser = await browserbase.launch({
 });
 const stagehand = await Stagehand.create({ browser });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import os
 
@@ -83,9 +86,9 @@ browser = await browserbase.launch(
 )
 stagehand = await Stagehand.create(browser=browser)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 region := stagehand.BrowserbaseRegionEUCentral1 // Browser runs in Frankfurt
@@ -106,7 +109,8 @@ if err != nil {
 }
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 Supported regions: `us-west-2` (default), `us-east-1`, `eu-central-1`, `ap-southeast-1`.
 
@@ -118,7 +122,8 @@ Supported regions: `us-west-2` (default), `us-east-1`, `eu-central-1`, `ap-south
 
 Browserbase session management and Stagehand managed services use separate APIs. Both default to the production service. The SDKs do not read either URL from an environment variable. Pass `baseUrl` to Browserbase and `apiUrl` to Stagehand when testing another deployment. Use the service origin without `/v1`.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const browser = await browserbase.launch({
   apiKey: process.env.BROWSERBASE_API_KEY,
@@ -130,9 +135,9 @@ const stagehand = await Stagehand.create({
   apiUrl: "https://api.stagehand.dev.browserbase.com",
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 browser = await browserbase.launch(
     api_key=os.environ["BROWSERBASE_API_KEY"],
@@ -144,9 +149,9 @@ stagehand = await Stagehand.create(
     api_url="https://api.stagehand.dev.browserbase.com",
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 stagehandAPIURL := "https://api.stagehand.dev.browserbase.com"
@@ -168,7 +173,8 @@ if err != nil {
 }
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 The Browserbase URL controls extension, session, and connection requests that `browserbase.launch()` and `browserbase.connect()` make. The Stagehand URL controls Model Gateway and managed-cache requests that the browser runtime makes.
 
@@ -176,23 +182,25 @@ The Browserbase URL controls extension, session, and connection requests that `b
 
 Before getting started, set up the required environment variables:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```bash
 export BROWSERBASE_API_KEY=your_api_key_here
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```bash
 export BROWSERBASE_API_KEY=your_api_key_here
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```bash
 export BROWSERBASE_API_KEY=your_api_key_here
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Tip>
 Get your API key from the [Browserbase Dashboard](https://browserbase.com/overview). Stagehand does not read this variable for you: read it in your own code and pass it to `browserbase.launch()`.
@@ -204,7 +212,8 @@ Get your API key from the [Browserbase Dashboard](https://browserbase.com/overvi
 
 The simplest way to get started is with default settings. `browserbase.launch()` needs nothing but your Browserbase API key:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 
@@ -213,9 +222,9 @@ const browser = await browserbase.launch({
 });
 const stagehand = await Stagehand.create({ browser });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import os
 
@@ -226,9 +235,9 @@ browser = await browserbase.launch(
 )
 stagehand = await Stagehand.create(browser=browser)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 
@@ -245,13 +254,15 @@ if err != nil {
 }
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 #### Advanced configuration
 
 Configure browser settings, proxy support, and other session parameters directly on `browserbase.launch()`:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 
@@ -266,9 +277,9 @@ const browser = await browserbase.launch({
 });
 const stagehand = await Stagehand.create({ browser });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import os
 
@@ -285,9 +296,9 @@ browser = await browserbase.launch(
 )
 stagehand = await Stagehand.create(browser=browser)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 region := stagehand.BrowserbaseRegionUSWest2
@@ -316,11 +327,13 @@ if err != nil {
 }
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Accordion title="Advanced Browserbase configuration example">
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const browser = await browserbase.launch({
   apiKey: process.env.BROWSERBASE_API_KEY,
@@ -344,9 +357,9 @@ const browser = await browserbase.launch({
   },
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 browser = await browserbase.launch(
     api_key=os.environ["BROWSERBASE_API_KEY"],
@@ -370,9 +383,9 @@ browser = await browserbase.launch(
 
 stagehand = await Stagehand.create(browser=browser)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 region := stagehand.BrowserbaseRegionUSWest2
@@ -418,18 +431,20 @@ if err != nil {
 
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 </Accordion>
 
 <Note>
-Stagehand provisions its own browser extension on every Browserbase session, so the `extensionId` session setting is not available on `browserbase.launch()`.
+Stagehand runs as a browser extension, so `browserbase.launch()` uploads that extension to your Browserbase account, starts the session against it, and deletes it again when you call `browser.close()`.
 </Note>
 
 ### Alternative: Browserbase SDK
 
 If you prefer to manage sessions directly, create the session with the Browserbase SDK and hand Stagehand the resulting session through `browserbase.connect()`:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { Browserbase } from "@browserbasehq/sdk";
 import { browserbase, Stagehand } from "@browserbasehq/stagehand";
@@ -450,9 +465,9 @@ const browser = await browserbase.connect({
 });
 const stagehand = await Stagehand.create({ browser });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import os
 
@@ -475,9 +490,9 @@ browser = await stagehand_browserbase.connect(
 )
 stagehand = await Stagehand.create(browser=browser)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Create the session with your Browserbase client of choice, then attach by
 // session ID so the browser keeps its Browserbase identity.
@@ -502,13 +517,15 @@ if err != nil {
 }
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 #### Connecting to an existing session
 
 `localBrowser.connect()` attaches to any Chromium browser that is already running and exposing a DevTools endpoint, whether that is a Browserbase session you created earlier or a browser on your own machine:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { localBrowser, Stagehand } from "@browserbasehq/stagehand";
 
@@ -517,9 +534,9 @@ const browser = await localBrowser.connect({
 });
 const stagehand = await Stagehand.create({ browser });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 from stagehand import Stagehand, local_browser
 
@@ -528,9 +545,9 @@ browser = await local_browser.connect(
 )
 stagehand = await Stagehand.create(browser=browser)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 browser, err := stagehand.ConnectLocalBrowser(ctx, stagehand.LocalBrowserConnectOptions{
 	CDPURL: "wss://connect.browserbase.com/?apiKey=...&sessionId=...",
@@ -546,7 +563,8 @@ if err != nil {
 }
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Note>
 Stagehand never closes a browser it did not launch. When you connect to an existing browser, `close()` tears down the Stagehand connection and leaves the browser running.
@@ -574,25 +592,26 @@ The local environment runs browsers directly on your machine, providing full con
 
 ### Basic local setup
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { localBrowser, Stagehand } from "@browserbasehq/stagehand";
 
 const browser = await localBrowser.launch();
 const stagehand = await Stagehand.create({ browser });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 from stagehand import Stagehand, local_browser
 
 browser = await local_browser.launch()
 stagehand = await Stagehand.create(browser=browser)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 browser, err := stagehand.LaunchLocalBrowser(ctx, &stagehand.LocalBrowserLaunchOptions{})
 if err != nil {
@@ -607,13 +626,15 @@ if err != nil {
 }
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 ### Advanced local configuration
 
 Customize browser launch options for local development:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { localBrowser, Stagehand } from "@browserbasehq/stagehand";
 
@@ -647,9 +668,9 @@ const browser = await localBrowser.launch({
 });
 const stagehand = await Stagehand.create({ browser });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 from stagehand import Stagehand, local_browser
 
@@ -680,9 +701,9 @@ browser = await local_browser.launch(
 )
 stagehand = await Stagehand.create(browser=browser)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 chromiumSandbox := false // Disable sandbox (adds --no-sandbox)
 acceptDownloads := true  // Allow downloads
@@ -728,7 +749,8 @@ if err != nil {
 }
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Note>
 Authenticated local proxies are not supported yet. Setting a proxy `username` or `password` raises in all three SDKs; a proxy `server` and `bypass` list work everywhere.
@@ -738,7 +760,8 @@ Authenticated local proxies are not supported yet. Setting a proxy `username` or
 
 When Stagehand launches a local browser, it adds the following Chrome arguments before any values you pass in the launch `args`:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 [
   "--enable-unsafe-extension-debugging",
@@ -747,9 +770,9 @@ When Stagehand launches a local browser, it adds the following Chrome arguments 
   "--enable-features=WebMCPTesting,DevToolsWebMCPSupport",
 ]
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 [
     "--enable-unsafe-extension-debugging",
@@ -758,9 +781,9 @@ When Stagehand launches a local browser, it adds the following Chrome arguments 
     "--enable-features=WebMCPTesting,DevToolsWebMCPSupport",
 ]
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 []string{
 	"--enable-unsafe-extension-debugging",
@@ -769,7 +792,8 @@ When Stagehand launches a local browser, it adds the following Chrome arguments 
 	"--enable-features=WebMCPTesting,DevToolsWebMCPSupport",
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Note>
 `--enable-unsafe-extension-debugging` is required: Stagehand runs as a browser extension and needs the debugger to reach its service worker. `--enable-features=WebMCPTesting,DevToolsWebMCPSupport` turns on the browser support behind [WebMCP](/v4/basics/webmcp). `--window-size` follows the `viewport` option and falls back to `1280,800` when you do not set one.
@@ -777,7 +801,8 @@ When Stagehand launches a local browser, it adds the following Chrome arguments 
 
 A larger set of standard Chrome automation flags (disabling background networking, component updates, sync, translation, and similar) is prepended as well. To remove some of them, list the exact flags in the ignore-default-args option:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const browser = await localBrowser.launch({
   ignoreDefaultArgs: ["--disable-sync"],
@@ -787,9 +812,9 @@ const browser = await localBrowser.launch({
   ],
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 browser = await local_browser.launch(
     ignore_default_args=["--disable-sync"],
@@ -801,9 +826,9 @@ browser = await local_browser.launch(
 
 stagehand = await Stagehand.create(browser=browser)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 browser, err := stagehand.LaunchLocalBrowser(ctx, &stagehand.LocalBrowserLaunchOptions{
 	IgnoreDefaultArgs: &stagehand.IgnoreDefaultArgs{
@@ -820,7 +845,8 @@ if err != nil {
 
 stagehand.Create(ctx, stagehand.CreateOptions{Browser: browser})
 ```
-</View>
+</Tab>
+</Tabs>
 
 Set the ignore-default-args option to `true` to remove all default arguments. Use a list to remove only exact matches while preserving the rest.
 
@@ -832,7 +858,8 @@ The keep-alive option controls whether the browser remains running after `close(
 
 By default, Stagehand terminates the browser it launched and cleans up all resources when it shuts down. Turning keep-alive on keeps the browser running independently so you can reconnect to it later.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { browserbase, localBrowser, Stagehand } from "@browserbasehq/stagehand";
 
@@ -850,9 +877,9 @@ await browser.close();
 const browser2 = await localBrowser.connect({ cdpUrl: existingConnectUrl });
 const stagehand2 = await Stagehand.create({ browser: browser2 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import os
 
@@ -872,9 +899,9 @@ await browser.close()
 browser2 = await local_browser.connect(cdp_url=existing_connect_url)
 stagehand2 = await Stagehand.create(browser=browser2)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 keepAlive := true
@@ -915,7 +942,8 @@ if err != nil {
 }
 defer func() { err = errors.Join(err, client2.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 #### Behavior by environment
 
@@ -929,7 +957,8 @@ defer func() { err = errors.Join(err, client2.Close(ctx)) }()
 
 When running locally with keep-alive on, Stagehand leaves the Chrome process running when your script exits. This is useful for debugging or for handing off a browser session to another process. Combine it with a fixed `port` so you can reattach with `localBrowser.connect()`.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const browser = await localBrowser.launch({
   keepAlive: true,
@@ -944,9 +973,9 @@ await page.goto("https://example.com");
 await stagehand.close();
 await browser.close();
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 browser = await local_browser.launch(
     keep_alive=True,
@@ -961,9 +990,9 @@ await page.goto("https://example.com")
 await stagehand.close()
 await browser.close()
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 browser, err := stagehand.LaunchLocalBrowser(ctx, &stagehand.LocalBrowserLaunchOptions{
 	KeepAlive: true,
@@ -997,7 +1026,8 @@ if _, err := page.Goto(ctx, "https://example.com", nil); err != nil {
 // Browser window stays open after the program exits
 return errors.Join(client.Close(ctx), browser.Close(ctx))
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Note>
 A temporary user data directory is deleted when a local browser shuts down. Set `userDataDir` (or turn on the preserve option) if you want the profile to survive.
@@ -1015,25 +1045,26 @@ Keeping sessions alive is available on the Browserbase Startup plan and above.
 
 Specify a fixed Chrome DevTools Protocol (CDP) debugging port instead of using a randomly assigned one.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { localBrowser, Stagehand } from "@browserbasehq/stagehand";
 
 const browser = await localBrowser.launch({ port: 9222 });
 const stagehand = await Stagehand.create({ browser });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 from stagehand import Stagehand, local_browser
 
 browser = await local_browser.launch(port=9222)
 stagehand = await Stagehand.create(browser=browser)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 browser, err := stagehand.LaunchLocalBrowser(ctx, &stagehand.LocalBrowserLaunchOptions{Port: 9222})
 if err != nil {
@@ -1048,7 +1079,8 @@ if err != nil {
 }
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Tip>
 If no port is specified, a random free port will be assigned.
@@ -1058,7 +1090,8 @@ If no port is specified, a random free port will be assigned.
 
 Configure how long Stagehand waits for the DOM to stabilize before taking actions. The default is 5000 ms.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const browser = await browserbase.launch({ apiKey: process.env.BROWSERBASE_API_KEY });
 const stagehand = await Stagehand.create({
@@ -1066,9 +1099,9 @@ const stagehand = await Stagehand.create({
   domSettleTimeoutMs: 3000, // Wait up to 3 seconds for DOM to settle
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 browser = await browserbase.launch(api_key=os.environ["BROWSERBASE_API_KEY"])
 stagehand = await Stagehand.create(
@@ -1076,9 +1109,9 @@ stagehand = await Stagehand.create(
     dom_settle_timeout_ms=3000,  # Wait up to 3 seconds for DOM to settle
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 domSettleTimeoutMs := 3000 // Wait up to 3 seconds for DOM to settle
@@ -1097,7 +1130,8 @@ if err != nil {
 
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Note>
 DOM settling applies to `act()`. `observe()` and `extract()` read a snapshot of the page as they find it.
@@ -1119,7 +1153,8 @@ Increase the DOM settle timeout for pages with:
 - Dynamic JavaScript frameworks (React, Vue, Angular)
 - Complex single-page applications
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // For fast, static pages
 const fastBrowser = await browserbase.launch({ apiKey: process.env.BROWSERBASE_API_KEY });
@@ -1135,9 +1170,9 @@ const dynamic = await Stagehand.create({
   domSettleTimeoutMs: 5000, // Longer wait for stability
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # For fast, static pages
 fast_browser = await browserbase.launch(api_key=os.environ["BROWSERBASE_API_KEY"])
@@ -1153,9 +1188,9 @@ dynamic = await Stagehand.create(
     dom_settle_timeout_ms=5000,  # Longer wait for stability
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 
@@ -1176,7 +1211,8 @@ if err != nil {
 }
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Warning>
 Setting the DOM settle timeout too low may cause actions to fail on elements that aren't ready. Setting it too high increases execution time unnecessarily.

--- a/packages/docs/v4/configuration/logging.mdx
+++ b/packages/docs/v4/configuration/logging.mdx
@@ -5,13 +5,14 @@ description: "Control terminal output and forward structured Stagehand logs."
 
 Stagehand provides comprehensive logging capabilities to help you debug automation workflows, track execution, and diagnose issues. Configure logging levels, structured output, and debugging tools for both development and production environments.
 
-All logging is configured through a single `logging` option on `Stagehand.create()`: a level, an output format, and a callback that receives each record. Use the language selector to see the exact shape your SDK accepts.
+All logging is configured through a single `logging` option on `Stagehand.create()`: a level, an output format, and a callback that receives each record.
 
 ## Quick start
 
 Choose your logging setup based on your environment:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { localBrowser, Stagehand } from "@browserbasehq/stagehand";
 
@@ -35,9 +36,9 @@ const stagehand = await Stagehand.create({
   // restOfYourConfiguration...
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 from stagehand import Stagehand, local_browser
 
@@ -63,9 +64,9 @@ stagehand = await Stagehand.create(
     # rest_of_your_configuration...
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Development: full debug output, human-readable
 development := &stagehand.StagehandClientLoggingConfig{
@@ -111,7 +112,8 @@ if err != nil {
 }
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 ---
 
@@ -127,7 +129,8 @@ Control how much detail you see in logs. The level is always applied at the sour
 <Tab title="Level: debug">
 **Use for:** Development, debugging specific issues
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const stagehand = await Stagehand.create({
   browser,
@@ -135,9 +138,9 @@ const stagehand = await Stagehand.create({
   // restOfYourConfiguration...
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 stagehand = await Stagehand.create(
     browser=browser,
@@ -145,9 +148,9 @@ stagehand = await Stagehand.create(
     # rest_of_your_configuration...
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 client, err := stagehand.Create(ctx, stagehand.CreateOptions{
 	Browser: browser,
@@ -162,7 +165,8 @@ if err != nil {
 
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Accordion title="Example output">
 
@@ -180,7 +184,8 @@ defer func() { err = errors.Join(err, client.Close(ctx)) }()
 <Tab title="Level: info (default)">
 **Use for:** Standard operations, staging, production
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const stagehand = await Stagehand.create({
   browser,
@@ -188,9 +193,9 @@ const stagehand = await Stagehand.create({
   // restOfYourConfiguration...
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 stagehand = await Stagehand.create(
     browser=browser,
@@ -198,9 +203,9 @@ stagehand = await Stagehand.create(
     # rest_of_your_configuration...
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 client, err := stagehand.Create(ctx, stagehand.CreateOptions{
 	Browser: browser,
@@ -215,7 +220,8 @@ if err != nil {
 
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 
 <Accordion title="Example output">
@@ -233,7 +239,8 @@ defer func() { err = errors.Join(err, client.Close(ctx)) }()
 <Tab title="Level: error or off">
 **Use for:** Production with external monitoring, minimal noise, or handling secrets
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const errorsOnly = { level: "error" } as const; // Errors only
 const silent = { level: "off" } as const; // Nothing at all
@@ -244,9 +251,9 @@ const stagehand = await Stagehand.create({
   // restOfYourConfiguration...
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 errors_only = {"level": "error"}  # Errors only
 silent = {"level": "off"}  # Nothing at all
@@ -257,9 +264,9 @@ stagehand = await Stagehand.create(
     # rest_of_your_configuration...
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Errors only
 errorsOnly := &stagehand.StagehandClientLoggingConfig{
@@ -287,7 +294,8 @@ if err != nil {
 }
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Accordion title="Example output">
 
@@ -316,7 +324,8 @@ Human-readable, single-line console output written to standard error.
 
 **When to use:** Development and interactive debugging
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Enabled by default: level "info", format "pretty"
 const stagehand = await Stagehand.create({
@@ -325,9 +334,9 @@ const stagehand = await Stagehand.create({
   // restOfYourConfiguration...
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # Enabled by default: level "info", format "pretty"
 stagehand = await Stagehand.create(
@@ -336,9 +345,9 @@ stagehand = await Stagehand.create(
     # rest_of_your_configuration...
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 client, err := stagehand.Create(ctx, stagehand.CreateOptions{
 	Browser: browser,
@@ -354,7 +363,8 @@ if err != nil {
 
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Accordion title="Output shape">
 Each line is `[stagehand] LEVEL message {json data}`, with the data object omitted when empty. Stagehand writes it to standard error so it never mixes with your program's own standard output.
@@ -366,7 +376,8 @@ One JSON object per line, ready for log shippers and structured search.
 
 **When to use:** Containers, CI, or anywhere a collector tails standard error
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const stagehand = await Stagehand.create({
   browser,
@@ -374,9 +385,9 @@ const stagehand = await Stagehand.create({
   // restOfYourConfiguration...
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 stagehand = await Stagehand.create(
     browser=browser,
@@ -384,9 +395,9 @@ stagehand = await Stagehand.create(
     # rest_of_your_configuration...
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 client, err := stagehand.Create(ctx, stagehand.CreateOptions{
 	Browser: browser,
@@ -402,7 +413,8 @@ if err != nil {
 
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Accordion title="Output shape">
 ```json
@@ -420,7 +432,8 @@ capabilities.
 
 <Step title="Create a simple logger">
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 
 // Simple logger without parsing (for basic console output)
@@ -438,9 +451,9 @@ const simpleLogger = (log: {
   }
 };
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 
 # Simple logger without parsing (for basic console output)
@@ -452,9 +465,9 @@ def simple_logger(log) -> None:
     if data:
         print("  Context:", data)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Simple logger without parsing (for basic console output)
 func simpleLogger(entry stagehand.StagehandLog) {
@@ -466,13 +479,15 @@ func simpleLogger(entry stagehand.StagehandLog) {
 	}
 }
 ```
-</View>
+</Tab>
+</Tabs>
 </Step>
 
 <Step title="Pass the logger in your Stagehand instance">
 Then pass the logger in your Stagehand instance:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const stagehand = await Stagehand.create({
   browser: await localBrowser.launch(),
@@ -483,9 +498,9 @@ const stagehand = await Stagehand.create({
   // restOfYourConfiguration...
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 browser = await local_browser.launch()
 
@@ -495,9 +510,9 @@ stagehand = await Stagehand.create(
     # rest_of_your_configuration...
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 browser, err := stagehand.LaunchLocalBrowser(ctx, &stagehand.LocalBrowserLaunchOptions{})
 if err != nil {
@@ -517,7 +532,8 @@ if err != nil {
 
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 </Step>
 </Steps>
@@ -540,7 +556,8 @@ The same callback, pointed at an observability platform.
 
 <Tab title="Sentry">
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import * as Sentry from "@sentry/node";
 
@@ -558,9 +575,9 @@ const productionLogger = (log: {
   }
 };
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import sentry_sdk
 
@@ -573,9 +590,9 @@ def production_logger(log) -> None:
             extras=log.data.model_dump(mode="json"),
         )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 func productionLogger(entry stagehand.StagehandLog) {
 	// Send errors to Sentry
@@ -593,12 +610,14 @@ func productionLogger(entry stagehand.StagehandLog) {
 	})
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 </Tab>
 <Tab title="DataDog">
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { datadogLogs } from "@datadog/browser-logs";
 
@@ -615,9 +634,9 @@ const productionLogger = (log: {
   });
 };
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 from datadog_api_client import ApiClient, Configuration
 from datadog_api_client.v2.api.logs_api import LogsApi
@@ -633,9 +652,9 @@ def production_logger(log) -> None:
         **log.data.model_dump(mode="json"),
     }])
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 func productionLogger(entry stagehand.StagehandLog) {
 	// Send all logs to DataDog
@@ -656,7 +675,8 @@ func productionLogger(entry stagehand.StagehandLog) {
 	_ = submitDataDogLog(payload)
 }
 ```
-</View>
+</Tab>
+</Tabs>
 </Tab>
 </Tabs>
 
@@ -664,7 +684,8 @@ func productionLogger(entry stagehand.StagehandLog) {
 
 <Step title="Pass the logger in your Stagehand instance">
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const stagehand = await Stagehand.create({
   browser: await localBrowser.launch(),
@@ -676,9 +697,9 @@ const stagehand = await Stagehand.create({
   // restOfYourConfiguration...
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 browser = await local_browser.launch()
 
@@ -692,9 +713,9 @@ stagehand = await Stagehand.create(
     # rest_of_your_configuration...
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 browser, err := stagehand.LaunchLocalBrowser(ctx, &stagehand.LocalBrowserLaunchOptions{})
 if err != nil {
@@ -714,7 +735,8 @@ if err != nil {
 
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 </Step>
 </Steps>
@@ -736,7 +758,8 @@ Route the log callback to a file to get a durable, per-session record of every S
 
 Pick a directory for your session logs and open a file per run:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { createWriteStream } from "node:fs";
 import { mkdirSync } from "node:fs";
@@ -745,9 +768,9 @@ mkdirSync("./stagehand-logs", { recursive: true });
 const sessionId = new Date().toISOString().replace(/[:.]/g, "-");
 const logFile = createWriteStream(`./stagehand-logs/${sessionId}.jsonl`, { flags: "a" });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 from datetime import datetime, timezone
 from pathlib import Path
@@ -756,9 +779,9 @@ Path("./stagehand-logs").mkdir(parents=True, exist_ok=True)
 session_id = datetime.now(timezone.utc).isoformat().replace(":", "-").replace(".", "-")
 log_file = open(f"./stagehand-logs/{session_id}.jsonl", "a", encoding="utf-8")
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 if err := os.MkdirAll("./stagehand-logs", 0o755); err != nil {
 	return err
@@ -775,13 +798,15 @@ if err != nil {
 }
 fmt.Fprintf(os.Stderr, "writing Stagehand logs to %s\n", logFile.Name())
 ```
-</View>
+</Tab>
+</Tabs>
 
 ### Usage
 
 Write each record as one JSON line, then run your Stagehand script as normal:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { finished } from "node:stream/promises";
 import { localBrowser, Stagehand } from "@browserbasehq/stagehand";
@@ -805,9 +830,9 @@ try {
   await finished(logFile);
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 from stagehand import Stagehand, local_browser
 
@@ -853,9 +878,9 @@ finally:
     await stagehand.close()
     log_file.close()
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 
 ```go
 client, err := stagehand.Create(ctx, stagehand.CreateOptions{
@@ -927,7 +952,8 @@ func run(ctx context.Context) (err error) {
 }
 ```
 
-</View>
+</Tab>
+</Tabs>
 
 ### Viewing logs
 
@@ -994,7 +1020,8 @@ This is especially useful for debugging long workflows where you need to trace t
 
 Run at the `debug` level to see the complete inference path: the snapshot that was captured, the prompt category, the model's chosen element, and the token counts for each call.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const stagehand = await Stagehand.create({
   browser: await localBrowser.launch(),
@@ -1010,9 +1037,9 @@ const stagehand = await Stagehand.create({
   },
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 def capture_inference(log) -> None:
     # Persist only the LLM records for offline analysis
@@ -1031,9 +1058,9 @@ stagehand = await Stagehand.create(
     },
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 func captureInference(inferenceFile *os.File) func(stagehand.StagehandLog) {
 	return func(entry stagehand.StagehandLog) {
@@ -1062,7 +1089,8 @@ if err != nil {
 
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 Debug-level records include:
 
@@ -1130,7 +1158,8 @@ Token counters are also aggregated across the whole session. See [Observability]
 
 All logging options are passed as a single object to `Stagehand.create()`:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // The shape of the `logging` value in the Stagehand.create() options.
 type StagehandClientLoggingConfig = {
@@ -1139,9 +1168,9 @@ type StagehandClientLoggingConfig = {
   onLog?: (log: StagehandLog) => void | Promise<void>; // default: undefined
 };
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 stagehand = await Stagehand.create(
     browser=browser,
@@ -1153,9 +1182,9 @@ stagehand = await Stagehand.create(
     },
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 client, err := stagehand.Create(ctx, stagehand.CreateOptions{
 	Browser: browser,
@@ -1173,7 +1202,8 @@ if err != nil {
 
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 | Option | Default | Description |
 |--------|---------|-------------|
@@ -1191,7 +1221,8 @@ The level is also forwarded to the Stagehand runtime, so suppressed records are 
 
 Each log entry follows a structured format:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 interface StagehandLog {
   level: "debug" | "info" | "warn" | "error"; // Severity
@@ -1199,18 +1230,18 @@ interface StagehandLog {
   data: Record<string, unknown>;              // Structured metadata, JSON-serializable
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 class StagehandLog(BaseModel):
     level: StagehandLogLevel  # "debug" | "info" | "warn" | "error"
     message: str              # "act completed successfully"
     data: StagehandLogData    # Structured metadata, JSON-serializable
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 type StagehandLog struct {
 	Level   StagehandLogLevel // "debug" | "info" | "warn" | "error"
@@ -1218,7 +1249,8 @@ type StagehandLog struct {
 	Data    StagehandLogData  // map[string]json.RawMessage
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Note>
 Unlike v3's `LogLine`, `data` is a flat JSON object: values are already typed, so there is no `{ value, type }` wrapper to parse. Fields such as `category` and `timestamp` appear inside `data` when the emitting operation provides them.

--- a/packages/docs/v4/configuration/models.mdx
+++ b/packages/docs/v4/configuration/models.mdx
@@ -14,7 +14,8 @@ Model Gateway lets you use Stagehand without wiring up model providers yourself.
 
 ### Setup
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 
@@ -22,9 +23,9 @@ const stagehand = await Stagehand.create({
   browser: await browserbase.launch({ apiKey: process.env.BROWSERBASE_API_KEY }),
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import os
 
@@ -34,9 +35,9 @@ browser = await browserbase.launch(api_key=os.environ["BROWSERBASE_API_KEY"])
 
 stagehand = await Stagehand.create(browser=browser)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 
@@ -56,7 +57,8 @@ if err != nil {
 }
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 When no model is configured, Stagehand routes inference through Model Gateway without a `model` field and Browserbase selects one automatically. An explicit model without a provider-specific API key still routes through Model Gateway, but pins that model instead.
 
@@ -71,16 +73,17 @@ With Model Gateway, switching between providers is a config change: no new accou
 <Tabs>
 <Tab title="OpenAI">
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const stagehand = await Stagehand.create({
   browser: await browserbase.launch({ apiKey: process.env.BROWSERBASE_API_KEY }),
   model: { modelName: "openai/gpt-5" },
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 browser = await browserbase.launch(api_key=os.environ["BROWSERBASE_API_KEY"])
 
@@ -89,9 +92,9 @@ stagehand = await Stagehand.create(
     model="openai/gpt-5",
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 // No model API key: requests route through Model Gateway
@@ -114,20 +117,22 @@ if err != nil {
 
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 </Tab>
 <Tab title="Anthropic">
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const stagehand = await Stagehand.create({
   browser: await browserbase.launch({ apiKey: process.env.BROWSERBASE_API_KEY }),
   model: { modelName: "anthropic/claude-sonnet-4-6" },
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 browser = await browserbase.launch(api_key=os.environ["BROWSERBASE_API_KEY"])
 
@@ -136,9 +141,9 @@ stagehand = await Stagehand.create(
     model="anthropic/claude-sonnet-4-6",
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 // No model API key: requests route through Model Gateway
@@ -161,20 +166,22 @@ if err != nil {
 
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 </Tab>
 <Tab title="Google">
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const stagehand = await Stagehand.create({
   browser: await browserbase.launch({ apiKey: process.env.BROWSERBASE_API_KEY }),
   model: { modelName: "google/gemini-3-flash-preview" },
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 browser = await browserbase.launch(api_key=os.environ["BROWSERBASE_API_KEY"])
 
@@ -183,9 +190,9 @@ stagehand = await Stagehand.create(
     model="google/gemini-3-flash-preview",
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 // No model API key: requests route through Model Gateway
@@ -208,7 +215,8 @@ if err != nil {
 
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 </Tab>
 </Tabs>
 
@@ -244,7 +252,8 @@ defer func() { err = errors.Join(err, client.Close(ctx)) }()
 
 Get started with Google Gemini (recommended for speed and cost):
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 
@@ -255,9 +264,9 @@ const stagehand = await Stagehand.create({
   },
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import os
 
@@ -271,9 +280,9 @@ stagehand = await Stagehand.create(
     model_api_key=os.environ["GOOGLE_GENERATIVE_AI_API_KEY"],
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 modelAPIKey := os.Getenv("GOOGLE_GENERATIVE_AI_API_KEY")
@@ -298,7 +307,8 @@ if err != nil {
 }
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Note>
 Model names for the providers below carry a `provider/` prefix, and the provider must be one of the five. Stagehand does not keep a list of valid model IDs: whatever follows the prefix is passed through to the provider untouched, so new model releases and early-access models work without a Stagehand upgrade. A model ID that the provider does not recognize, or that your key cannot reach, fails at request time with the provider's own error. The prefix is never optional: to reach an Azure OpenAI deployment, a self-hosted model, or anything else outside those five providers, use the [bring-your-own-LLM callback](#custom-models).
@@ -314,7 +324,8 @@ Use any model from the following supported providers.
 <Tabs>
 <Tab title="Google">
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 
@@ -325,9 +336,9 @@ const stagehand = await Stagehand.create({
   },
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import os
 
@@ -341,9 +352,9 @@ stagehand = await Stagehand.create(
     model_api_key=os.environ["GOOGLE_GENERATIVE_AI_API_KEY"],
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 modelAPIKey := os.Getenv("GOOGLE_GENERATIVE_AI_API_KEY")
@@ -368,7 +379,8 @@ if err != nil {
 }
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 Commonly used: `google/gemini-3.1-pro-preview`, `google/gemini-3-flash-preview`, `google/gemini-3.5-flash`, `google/gemini-2.5-flash`, `google/gemini-flash-latest`.
 
@@ -377,7 +389,8 @@ Commonly used: `google/gemini-3.1-pro-preview`, `google/gemini-3-flash-preview`,
 
 <Tab title="Anthropic">
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 
@@ -388,9 +401,9 @@ const stagehand = await Stagehand.create({
   },
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import os
 
@@ -404,9 +417,9 @@ stagehand = await Stagehand.create(
     model_api_key=os.environ["ANTHROPIC_API_KEY"],
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 modelAPIKey := os.Getenv("ANTHROPIC_API_KEY")
@@ -431,7 +444,8 @@ if err != nil {
 }
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 Commonly used: `anthropic/claude-sonnet-5`, `anthropic/claude-fable-5`, `anthropic/claude-opus-4-8`, `anthropic/claude-sonnet-4-6`, `anthropic/claude-haiku-4-5`.
 
@@ -440,7 +454,8 @@ Commonly used: `anthropic/claude-sonnet-5`, `anthropic/claude-fable-5`, `anthrop
 
 <Tab title="OpenAI">
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 
@@ -451,9 +466,9 @@ const stagehand = await Stagehand.create({
   },
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import os
 
@@ -467,9 +482,9 @@ stagehand = await Stagehand.create(
     model_api_key=os.environ["OPENAI_API_KEY"],
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 modelAPIKey := os.Getenv("OPENAI_API_KEY")
@@ -494,7 +509,8 @@ if err != nil {
 }
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 Commonly used: `openai/gpt-5.6`, `openai/gpt-5.5`, `openai/gpt-5.4`, `openai/gpt-5.4-mini`, `openai/gpt-5.4-nano`, `openai/o4-mini`.
 
@@ -507,7 +523,8 @@ OpenAI models are called through the Responses API.
 
 <Tab title="Groq">
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 
@@ -518,9 +535,9 @@ const stagehand = await Stagehand.create({
   },
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import os
 
@@ -534,9 +551,9 @@ stagehand = await Stagehand.create(
     model_api_key=os.environ["GROQ_API_KEY"],
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 modelAPIKey := os.Getenv("GROQ_API_KEY")
@@ -561,7 +578,8 @@ if err != nil {
 }
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 Commonly used: `groq/llama-3.3-70b-versatile`, `groq/openai/gpt-oss-120b`, `groq/moonshotai/kimi-k2-instruct-0905`, `groq/qwen/qwen3-32b`.
 
@@ -570,7 +588,8 @@ Commonly used: `groq/llama-3.3-70b-versatile`, `groq/openai/gpt-oss-120b`, `groq
 
 <Tab title="Cerebras">
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 
@@ -581,9 +600,9 @@ const stagehand = await Stagehand.create({
   },
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import os
 
@@ -597,9 +616,9 @@ stagehand = await Stagehand.create(
     model_api_key=os.environ["CEREBRAS_API_KEY"],
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 modelAPIKey := os.Getenv("CEREBRAS_API_KEY")
@@ -624,7 +643,8 @@ if err != nil {
 }
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 Commonly used: `cerebras/gpt-oss-120b`, `cerebras/qwen-3-235b-a22b-instruct-2507`, `cerebras/zai-glm-4.7`, `cerebras/llama3.1-8b`.
 
@@ -648,31 +668,34 @@ Stagehand sends a provider-neutral request (messages, system prompt, temperature
 <Step title="Install dependencies">
 Install your provider's SDK.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```bash
 npm install @aws-sdk/client-bedrock-runtime
 # pnpm add @aws-sdk/client-bedrock-runtime
 # yarn add @aws-sdk/client-bedrock-runtime
 # bun add @aws-sdk/client-bedrock-runtime
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```bash
 pip install boto3
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```bash
 go get github.com/aws/aws-sdk-go-v2/service/bedrockruntime
 ```
-</View>
+</Tab>
+</Tabs>
 </Step>
 
 <Step title="Write the generate callback">
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import {
   BedrockRuntimeClient,
@@ -739,9 +762,9 @@ async function generateWithBedrock(params: LLMGenerateParams) {
   };
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import base64
 import json
@@ -787,9 +810,9 @@ async def generate_with_bedrock(params):
         "structured_content": json.loads(text),
     })
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // A message's content is a slice of blocks, each one text, image, tool-use, or
 // tool-result. Converse takes its own content blocks, so map text to a text
@@ -853,21 +876,23 @@ func generateWithBedrock(
 	}), nil
 }
 ```
-</View>
+</Tab>
+</Tabs>
 </Step>
 
 <Step title="Pass the callback to Stagehand">
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const stagehand = await Stagehand.create({
   browser: await browserbase.launch({ apiKey: process.env.BROWSERBASE_API_KEY }),
   model: { generate: generateWithBedrock },
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 browser = await browserbase.launch(api_key=os.environ["BROWSERBASE_API_KEY"])
 
@@ -876,9 +901,9 @@ stagehand = await Stagehand.create(
     model=generate_with_bedrock,
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 
@@ -898,7 +923,8 @@ if err != nil {
 }
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 </Step>
 </Steps>
@@ -909,31 +935,34 @@ defer func() { err = errors.Join(err, client.Close(ctx)) }()
 <Step title="Install dependencies">
 Install your provider's SDK.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```bash
 npm install openai
 # pnpm add openai
 # yarn add openai
 # bun add openai
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```bash
 pip install openai
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```bash
 go get github.com/openai/openai-go
 ```
-</View>
+</Tab>
+</Tabs>
 </Step>
 
 <Step title="Write the generate callback">
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import OpenAI from "openai";
 
@@ -1004,9 +1033,9 @@ async function generateWithOpenAI(params: LLMGenerateParams) {
   };
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import os
 import json
@@ -1062,9 +1091,9 @@ async def generate_with_openai(params):
         "structured_content": json.loads(response.output_text),
     })
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 func generateWithOpenAI(
 	ctx context.Context,
@@ -1094,7 +1123,8 @@ func generateWithOpenAI(
 	}), nil
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Note>
 Reporting token usage is optional. To report it, add a `usage` field to the result and map your provider's own usage field names onto Stagehand's: input tokens, output tokens, and total tokens are required, while reasoning tokens and cached input tokens are optional. Providers spell these differently, so read the names off your provider's response type rather than assuming they match Stagehand's.
@@ -1103,16 +1133,17 @@ Reporting token usage is optional. To report it, add a `usage` field to the resu
 
 <Step title="Pass the callback to Stagehand">
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const stagehand = await Stagehand.create({
   browser: await browserbase.launch({ apiKey: process.env.BROWSERBASE_API_KEY }),
   model: { generate: generateWithOpenAI },
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 browser = await browserbase.launch(api_key=os.environ["BROWSERBASE_API_KEY"])
 
@@ -1121,9 +1152,9 @@ stagehand = await Stagehand.create(
     model=generate_with_openai,
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 
@@ -1143,7 +1174,8 @@ if err != nil {
 }
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 </Step>
 </Steps>
@@ -1158,7 +1190,8 @@ Install your provider's SDK.
 </Step>
 <Step title="Write the generate callback">
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // The shape Stagehand passes to your callback. The TypeScript SDK does not
 // re-export `LLMGenerateParams` yet, so spell out the fields you read.
@@ -1187,9 +1220,9 @@ async function generateWithYourProvider(params: LLMGenerateParams) {
   };
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 async def generate_with_your_provider(params):
     # params.messages         Conversation so far
@@ -1206,9 +1239,9 @@ async def generate_with_your_provider(params):
         "structured_content": json.loads(text),
     })
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 func generateWithYourProvider(
 	ctx context.Context,
@@ -1236,7 +1269,8 @@ func generateWithYourProvider(
 	}), nil
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Note>
 A message's content is one content block or an array of them. Text blocks carry a string, and image blocks carry base64 data plus a MIME type. [`extract()` with the screenshot option](/v4/basics/extract) sends a viewport screenshot as an image block, so map image blocks onto your provider's own image format. A callback that reads only the text blocks answers a visual extraction from the accessibility tree alone.
@@ -1244,16 +1278,17 @@ A message's content is one content block or an array of them. Text blocks carry 
 </Step>
 <Step title="Pass the callback to Stagehand">
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const stagehand = await Stagehand.create({
   browser: await browserbase.launch({ apiKey: process.env.BROWSERBASE_API_KEY }),
   model: { generate: generateWithYourProvider },
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 browser = await browserbase.launch(api_key=os.environ["BROWSERBASE_API_KEY"])
 
@@ -1262,9 +1297,9 @@ stagehand = await Stagehand.create(
     model=generate_with_your_provider,
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 
@@ -1284,7 +1319,8 @@ if err != nil {
 }
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 </Step>
 </Steps>
@@ -1325,7 +1361,8 @@ Different models excel at different tasks. Consider speed, accuracy, and cost fo
 
 Every primitive accepts a model configuration for a single call, so you can run cheap inference by default and reach for a stronger model only where it matters:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const PricingSchema = z.object({ summary: z.string() });
 
@@ -1349,9 +1386,9 @@ const { data } = await stagehand.extract("summarize the pricing table", PricingS
 
 console.log(data.summary);
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import os
 
@@ -1385,9 +1422,9 @@ data = (await stagehand.extract(
 
 print(data.summary)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 type pricing struct {
 	Summary string `json:"summary"`
@@ -1442,7 +1479,8 @@ if err != nil {
 
 fmt.Println(extracted.Data.Summary)
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Note>
 Model configuration is deliberately excluded from the [cache key](/v4/best-practices/caching), so switching models per call does not invalidate cached results.
@@ -1454,7 +1492,8 @@ Model configuration is deliberately excluded from the [cache key](/v4/best-pract
 
 Some enterprise gateways require extra headers on every model request. Attach them to the model configuration:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const stagehand = await Stagehand.create({
   browser: await browserbase.launch({ apiKey: process.env.BROWSERBASE_API_KEY }),
@@ -1464,9 +1503,9 @@ const stagehand = await Stagehand.create({
   },
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import os
 
@@ -1481,9 +1520,9 @@ stagehand = await Stagehand.create(
     model_headers={"x-tenant-id": "acme"},
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 modelAPIKey := os.Getenv("OPENAI_API_KEY")
@@ -1510,7 +1549,8 @@ if err != nil {
 
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Note>
 There is no base URL option. A model configuration always names one of the five supported providers, so Azure OpenAI deployments, self-hosted models, and any other custom endpoint go through the [bring-your-own-LLM callback](#custom-models) instead, where you own the client, the transport, and the credentials.
@@ -1522,7 +1562,8 @@ There is no base URL option. A model configuration always names one of the five 
 
 For advanced use cases like custom retries or caching logic, wrap your generate callback. Because the callback is ordinary code in your process, you can layer whatever behavior you need around it:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Generic in the callback's own params and result, so the wrapper stays
 // interchangeable with the callback it wraps.
@@ -1548,9 +1589,9 @@ const stagehand = await Stagehand.create({
   model: { generate: withRetries(generateWithOpenAI) },
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import asyncio
 import os
@@ -1576,9 +1617,9 @@ stagehand = await Stagehand.create(
     model=with_retries(generate_with_openai),
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 func withRetries(generate stagehand.LLMGenerateFunc, attempts int) stagehand.LLMGenerateFunc {
 	return func(ctx context.Context, params stagehand.LLMGenerateParams) (stagehand.LLMGenerateResult, error) {
@@ -1620,7 +1661,8 @@ if err != nil {
 
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Tip>
   Need result caching rather than request retries? Use the built-in [caching

--- a/packages/docs/v4/configuration/observability.mdx
+++ b/packages/docs/v4/configuration/observability.mdx
@@ -27,7 +27,8 @@ Browserbase provides real-time visibility into your automation sessions:
 
 **Session management & API access**
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { Browserbase } from "@browserbasehq/sdk";
 import { browserbase as stagehandBrowserbase, Stagehand } from "@browserbasehq/stagehand";
@@ -55,9 +56,9 @@ console.log("CPU usage:", sessionInfo.avgCpuUsage);
 console.log("Memory usage:", sessionInfo.memoryUsage);
 console.log("Proxy bytes:", sessionInfo.proxyBytes);
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import os
 
@@ -87,9 +88,9 @@ print("CPU usage:", session_info.avg_cpu_usage)
 print("Memory usage:", session_info.memory_usage)
 print("Proxy bytes:", session_info.proxy_bytes)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Create the session with your Browserbase client of choice so you hold the
 // session ID, then attach Stagehand to it.
@@ -125,7 +126,8 @@ fmt.Println("CPU usage:", info.AvgCPUUsage)
 fmt.Println("Memory usage:", info.MemoryUsage)
 fmt.Println("Proxy bytes:", info.ProxyBytes)
 ```
-</View>
+</Tab>
+</Tabs>
 
 ### Session analytics & insights
 
@@ -151,7 +153,8 @@ fmt.Println("Proxy bytes:", info.ProxyBytes)
 
 Query and monitor sessions by status and metadata:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { Browserbase } from "@browserbasehq/sdk";
 
@@ -201,9 +204,9 @@ async function querySessionsByMetadata(query: string) {
   return sessions;
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import os
 
@@ -234,9 +237,9 @@ def get_filtered_sessions():
 def query_sessions_by_metadata(query: str):
     return browserbase.sessions.list(q=query)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 type sessionSummary struct {
 	ID           string
@@ -279,7 +282,8 @@ func querySessionsByMetadata(ctx context.Context, query string) ([]browserbaseSe
 	return listBrowserbaseSessions(ctx, listOptions{Query: query})
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Tip>
 Tag every session with `userMetadata` on `browserbase.launch()` so you can slice these queries by workflow, customer, or deployment.
@@ -293,7 +297,8 @@ For local development, Stagehand provides performance monitoring and resource tr
 
 {/* TODO: these samples call stagehand.metrics(), which is typed end to end but currently throws "Method not implemented" in the runtime. Same caveat as the "Real-time metrics & monitoring" section below; verify both before publishing. */}
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { localBrowser, Stagehand } from "@browserbasehq/stagehand";
 import { z } from "zod/v4";
@@ -331,9 +336,9 @@ console.log("Local Performance Summary:", {
   tokensPerSecond: (tokensUsed / (executionTime / 1000)).toFixed(2),
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 from time import perf_counter
 
@@ -377,9 +382,9 @@ print("Local Performance Summary:", {
     "tokens_per_second": f"{tokens_used / (execution_time / 1000):.2f}",
 })
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 type data struct {
 	Title string `json:"title"`
@@ -448,13 +453,15 @@ fmt.Printf(
 	tokensUsed/executionTime.Seconds(),
 )
 ```
-</View>
+</Tab>
+</Tabs>
 
 ## Resource usage monitoring
 
 When running locally, monitor system resource usage and browser performance:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import * as os from "node:os";
 import { browserbase, Stagehand } from "@browserbasehq/stagehand";
@@ -498,9 +505,9 @@ const stagehand = await Stagehand.create({ browser });
 clearInterval(interval);
 console.log("Resource Usage:", monitor.getResourceSummary());
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import asyncio
 import os
@@ -547,9 +554,9 @@ stagehand = await Stagehand.create(browser=browser)
 task.cancel()
 print("Resource Usage:", monitor.get_resource_summary())
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 type localResourceMonitor struct {
 	mu          sync.Mutex
@@ -607,7 +614,8 @@ client, err := stagehand.Create(ctx, stagehand.CreateOptions{Browser: browser})
 stopMonitor()
 fmt.Println("Resource Usage:", monitor.getResourceSummary())
 ```
-</View>
+</Tab>
+</Tabs>
 
 
   <Card title="Speed and cost tuning" icon="chart-line" href="/v4/best-practices/cost-optimization">
@@ -623,7 +631,8 @@ Monitor your automation's resource usage in real-time by calling the metrics met
 
 {/* TODO: stagehand.metrics() is typed end to end but the runtime currently throws "Method not implemented". Verify before publishing. */}
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 import { z } from "zod/v4";
@@ -664,9 +673,9 @@ console.log("Automation Summary:", {
   avgInferenceTime: `${finalMetrics.totalInferenceTimeMs / 3}ms`,
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import os
 from time import perf_counter
@@ -715,9 +724,9 @@ print("Automation Summary:", {
     "avg_inference_time": f"{final_metrics.total_inference_time_ms / 3}ms",
 })
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 type user struct {
 	Name  string `json:"name"`
@@ -793,13 +802,15 @@ fmt.Printf(
 	finalMetrics.TotalInferenceTimeMs/3,
 )
 ```
-</View>
+</Tab>
+</Tabs>
 
 ### Understanding metrics data
 
 The metrics object provides a detailed breakdown by Stagehand operation:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 interface StagehandMetrics {
   // Act operation metrics
@@ -831,9 +842,9 @@ interface StagehandMetrics {
   totalInferenceTimeMs: number;
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 class StagehandMetrics(BaseModel):
     # Act operation metrics
@@ -864,9 +875,9 @@ class StagehandMetrics(BaseModel):
     total_cached_input_tokens: float
     total_inference_time_ms: float
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 type StagehandMetrics struct {
 	// Act operation metrics
@@ -898,11 +909,13 @@ type StagehandMetrics struct {
 	TotalInferenceTimeMs   float64
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 **Example metrics output:**
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const metrics = await stagehand.metrics();
 console.log(metrics);
@@ -930,9 +943,9 @@ console.log(metrics);
 //   totalInferenceTimeMs: 6888
 // }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 metrics = await stagehand.metrics()
 print(metrics)
@@ -960,9 +973,9 @@ print(metrics)
 #     total_inference_time_ms=6888,
 # )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 metrics, err := client.Metrics(ctx)
 if err != nil {
@@ -993,7 +1006,8 @@ fmt.Printf("%+v\n", metrics)
 //     TotalInferenceTimeMs:     6888,
 // }
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Note>
 Cached input tokens are reported separately so you can see how much of your prompt spend was served from your provider's prompt cache. This is distinct from Stagehand's own [server-side result cache](/v4/best-practices/caching), which avoids the inference call entirely.
@@ -1003,7 +1017,8 @@ Cached input tokens are reported separately so you can see how much of your prom
 
 Metrics give you the totals. When you want the sequence of what happened, build the timeline yourself from the log callback: every act, observe, and extract emits records with their structured data already attached. There is no history accessor on the `Stagehand` instance.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Record each log entry with the time you receive it
 const history: Array<{
@@ -1030,9 +1045,9 @@ const stagehand = await Stagehand.create({
 console.log(history.filter((entry) => entry.level === "error"));
 console.log(await stagehand.metrics());
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import os
 
@@ -1060,9 +1075,9 @@ stagehand = await Stagehand.create(
 print([entry for entry in history if entry["level"] == "error"])
 print(await stagehand.metrics())
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 var history []stagehand.StagehandLog
 var mu sync.Mutex
@@ -1113,7 +1128,8 @@ if err != nil {
 }
 fmt.Printf("%+v\n", metrics)
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Note>
 The records you capture depend on the level. Raise it to `debug` for the fullest timeline; the default is `info` and above.
@@ -1127,7 +1143,8 @@ On Browserbase, the session replay dashboard gives you the same timeline visuall
 
 Stagehand emits OpenTelemetry spans for every operation and for every log record, and propagates W3C trace context across the SDK and runtime boundary. Point it at your own OTLP collector to see full traces alongside the rest of your system.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 const browser = await browserbase.launch({
   apiKey: process.env.BROWSERBASE_API_KEY,
@@ -1142,9 +1159,9 @@ const stagehand = await Stagehand.create({
   },
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import os
 
@@ -1163,9 +1180,9 @@ stagehand = await Stagehand.create(
     }),
 )
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
 
@@ -1190,7 +1207,8 @@ if err != nil {
 
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
 ```
-</View>
+</Tab>
+</Tabs>
 
 | Field | Description |
 |-------|-------------|

--- a/packages/docs/v4/first-steps/ai-rules.mdx
+++ b/packages/docs/v4/first-steps/ai-rules.mdx
@@ -86,7 +86,8 @@ ie. **"Use the stagehand-docs MCP to fetch the act/observe guidelines, then gene
 Drop these in `.cursorrules`, `windsurfrules`, `claude.md`, or any agent rule framework:
 
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 
 ``````md
 # Stagehand Project
@@ -384,9 +385,9 @@ try {
 - DeepWiki MCP: https://mcp.deepwiki.com/
 ``````
 
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 
 ``````md
 # Stagehand Python Project
@@ -695,9 +696,9 @@ finally:
 - DeepWiki MCP: https://mcp.deepwiki.com/
 ``````
 
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 
 ``````md
 # Stagehand Go Project
@@ -1125,7 +1126,8 @@ func run(ctx context.Context) (err error) {
 - DeepWiki MCP: https://mcp.deepwiki.com/
 ``````
 
-</View>
+</Tab>
+</Tabs>
 
 ## Security notes
 

--- a/packages/docs/v4/first-steps/installation.mdx
+++ b/packages/docs/v4/first-steps/installation.mdx
@@ -13,28 +13,30 @@ Node.js is the recommended runtime environment for Stagehand scripts. Stagehand 
 
 ### Install dependencies
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```bash
 pnpm install @browserbasehq/stagehand zod
 # npm add @browserbasehq/stagehand zod
 # yarn add @browserbasehq/stagehand zod
 # bun add @browserbasehq/stagehand zod
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```bash
 pip install stagehand
 # uv add stagehand
 # poetry add stagehand
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```bash
 go get github.com/browserbase/stagehand/packages/sdk-go
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Tip>
 If you plan to run locally, you need to have [Chrome](https://www.google.com/chrome/) installed on your machine. For cloud browser sessions, skip this.
@@ -44,23 +46,25 @@ If you plan to run locally, you need to have [Chrome](https://www.google.com/chr
 
 Set your Browserbase API key. When no model is configured, Model Gateway selects one automatically, so no model provider key is required:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```bash
 export BROWSERBASE_API_KEY=your_api_key
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```bash
 export BROWSERBASE_API_KEY=your_api_key
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```bash
 export BROWSERBASE_API_KEY=your_api_key
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Note>
 Stagehand does not read environment variables on your behalf, and it does not auto-load env files.
@@ -69,7 +73,8 @@ This also applies to API routing: pass non-production Browserbase and Stagehand 
 
 Read the values in your own app code and pass them explicitly to the browser factory:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Optional: install dotenv first (pnpm add dotenv), then load an env file yourself
 import "dotenv/config";
@@ -79,9 +84,9 @@ const browser = await browserbase.launch({
 });
 const stagehand = await Stagehand.create({ browser });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import os
 
@@ -92,9 +97,9 @@ browser = await browserbase.launch(
 )
 stagehand = await Stagehand.create(browser=browser)
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // Every optional field is a pointer, so read your key into a variable first
 apiKey := os.Getenv("BROWSERBASE_API_KEY")
@@ -105,14 +110,16 @@ if err != nil {
 }
 client, err := stagehand.Create(ctx, stagehand.CreateOptions{Browser: browser})
 ```
-</View>
+</Tab>
+</Tabs>
 </Note>
 
 ### Use in your codebase
 
 Add Stagehand where you need browser automation.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 import { z } from "zod/v4";
@@ -151,9 +158,9 @@ main().catch((err) => {
   process.exit(1);
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import asyncio
 import os
@@ -192,9 +199,9 @@ async def main() -> None:
 
 asyncio.run(main())
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 package main
 
@@ -274,7 +281,8 @@ func run(ctx context.Context) (err error) {
 	return nil
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 ## Next steps
 

--- a/packages/docs/v4/first-steps/introduction.mdx
+++ b/packages/docs/v4/first-steps/introduction.mdx
@@ -30,7 +30,8 @@ Stagehand gives you the best of both worlds through three powerful primitives th
   </Card>
 </CardGroup>
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 // Act: execute natural language actions
 await stagehand.act("click the login button");
@@ -44,9 +45,9 @@ const { data } = await stagehand.extract(
 // Observe: discover available actions
 const { data: actions } = await stagehand.observe("find submit buttons");
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 # Act: execute natural language actions
 await stagehand.act("click the login button")
@@ -64,9 +65,9 @@ price = result.data.price
 # Observe: discover available actions
 actions = (await stagehand.observe("find submit buttons")).data
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // ctx and client come from the quickstart
 
@@ -95,7 +96,8 @@ if err != nil {
 }
 fmt.Println(len(observed.Data), "candidate actions")
 ```
-</View>
+</Tab>
+</Tabs>
 
 ## Why developers choose Stagehand
 

--- a/packages/docs/v4/first-steps/quickstart.mdx
+++ b/packages/docs/v4/first-steps/quickstart.mdx
@@ -5,7 +5,9 @@ description: "Build your first Stagehand automation with act, extract, and obser
 
 The quickest way to start with Stagehand is to install the SDK, point it at a browser, and write a script. This page gets you from an empty directory to a working automation in three steps.
 
-## 1) Create a sample project
+<Steps>
+
+<Step title="Create a sample project">
 
 <Tabs>
 <Tab title="TypeScript">
@@ -33,7 +35,9 @@ go get github.com/browserbase/stagehand/packages/sdk-go
 </Tab>
 </Tabs>
 
-## 2) Write the script
+</Step>
+
+<Step title="Write the script">
 
 Create the example script (`index.ts`, `main.py`, or `main.go`). It exercises all three primitives: act, extract, and observe.
 
@@ -215,7 +219,9 @@ func run(ctx context.Context) (err error) {
 Stagehand never reads environment variables on your behalf. Read the Browserbase API key in your own code and pass it to the browser factory, as the script above does. With no model configured, Browserbase selects one automatically for each inference call.
 </Note>
 
-## 3) Run it
+</Step>
+
+<Step title="Run it">
 
 Set your Browserbase API key, then run the script. Model Gateway selects and authenticates the model automatically, so no model provider key is required.
 
@@ -245,6 +251,9 @@ go run .                                 # Run the example script
 <Tip>
 Prefer to run against a browser on your own machine while you develop? Swap `browserbase.launch()` for `localBrowser.launch()` and drop the Browserbase key. See [Browser configuration](/v4/configuration/browser).
 </Tip>
+
+</Step>
+</Steps>
 
 ## Next steps
 

--- a/packages/docs/v4/first-steps/quickstart.mdx
+++ b/packages/docs/v4/first-steps/quickstart.mdx
@@ -5,41 +5,40 @@ description: "Build your first Stagehand automation with act, extract, and obser
 
 The quickest way to start with Stagehand is to install the SDK, point it at a browser, and write a script. This page gets you from an empty directory to a working automation in three steps.
 
-<Note>
-Use the language selector on this page to switch every code sample between TypeScript, Python, and Go.
-</Note>
-
 ## 1) Create a sample project
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```bash
 mkdir my-stagehand-app && cd my-stagehand-app
 pnpm init -y
 pnpm install @browserbasehq/stagehand zod
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```bash
 mkdir my-stagehand-app && cd my-stagehand-app
 python -m venv .venv && source .venv/bin/activate
 pip install stagehand
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```bash
 mkdir my-stagehand-app && cd my-stagehand-app
 go mod init example.com/my-stagehand-app
 go get github.com/browserbase/stagehand/packages/sdk-go
 ```
-</View>
+</Tab>
+</Tabs>
 
 ## 2) Write the script
 
 Create the example script (`index.ts`, `main.py`, or `main.go`). It exercises all three primitives: act, extract, and observe.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 import { z } from "zod/v4";
@@ -79,9 +78,9 @@ main().catch((err) => {
   process.exit(1);
 });
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import asyncio
 import os
@@ -124,9 +123,9 @@ async def main() -> None:
 
 asyncio.run(main())
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 package main
 
@@ -209,7 +208,8 @@ func run(ctx context.Context) (err error) {
 	return nil
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Note>
 Stagehand never reads environment variables on your behalf. Read the Browserbase API key in your own code and pass it to the browser factory, as the script above does. With no model configured, Browserbase selects one automatically for each inference call.
@@ -219,26 +219,28 @@ Stagehand never reads environment variables on your behalf. Read the Browserbase
 
 Set your Browserbase API key, then run the script. Model Gateway selects and authenticates the model automatically, so no model provider key is required.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```bash
 export BROWSERBASE_API_KEY="bb_live_..." # Your Browserbase API key
 npx tsx index.ts                         # Run the example script
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```bash
 export BROWSERBASE_API_KEY="bb_live_..." # Your Browserbase API key
 python main.py                           # Run the example script
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```bash
 export BROWSERBASE_API_KEY="bb_live_..." # Your Browserbase API key
 go run .                                 # Run the example script
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Tip>
 Prefer to run against a browser on your own machine while you develop? Swap `browserbase.launch()` for `localBrowser.launch()` and drop the Browserbase key. See [Browser configuration](/v4/configuration/browser).

--- a/packages/docs/v4/migrations/v3.mdx
+++ b/packages/docs/v4/migrations/v3.mdx
@@ -45,7 +45,8 @@ extract() for steps that need a model.
 
 What comes back should read like the script you would have written yourself:
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 import { z } from "zod/v4";
@@ -77,9 +78,9 @@ try {
   await browser.close();
 }
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 import asyncio
 import os
@@ -123,9 +124,9 @@ async def main() -> None:
 
 asyncio.run(main())
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 type comment struct {
 	Author string `json:"author"`
@@ -187,7 +188,8 @@ func run(ctx context.Context) (err error) {
 	return nil
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 Generated code should use `page.locator()` and `page.goto()` wherever a selector is stable, and spend a model call only where the page needs judgement. `agent()` couldn't make that split, because every step it ran was an inference call.
 
@@ -211,7 +213,8 @@ Expose the real API:
 
 `page.snapshot()` anchors the loop. It returns `formattedTree`, the accessibility tree, plus an `xpathMap`, so the model reads real page structure and hands back a selector you can drive deterministically.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 ```typescript
 import { z } from "zod/v4";
 
@@ -263,9 +266,9 @@ const tools = {
   },
 };
 ```
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 ```python
 async def goto(url: str) -> str:
     """Navigate to a URL."""
@@ -305,9 +308,9 @@ async def extract(instruction: str) -> str:
 
 TOOLS = [goto, snapshot, click, fill, read_text, act, extract]
 ```
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 ```go
 // One handler per tool. Register these with your agent framework's tool API.
 
@@ -346,7 +349,8 @@ func actTool(ctx context.Context, client *stagehand.Stagehand, instruction strin
 	return result.Data.Message, nil
 }
 ```
-</View>
+</Tab>
+</Tabs>
 
 <Tip>
 Escalate on `observe()`, never on `act()`. A failed `act()` may already have clicked, submitted, or paid before the error surfaced, so retrying it can repeat the side effect. `observe()` only plans, so retrying it is free. [Cost optimization](/v4/best-practices/cost-optimization) applies the same idea to model escalation.

--- a/packages/docs/v4/reference/clipboard.mdx
+++ b/packages/docs/v4/reference/clipboard.mdx
@@ -6,7 +6,8 @@ icon: "clipboard"
 
 Access `BrowserClipboard` from the browser context. Clipboard operations target the active page unless you provide another page.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 
 ## Quick start
 
@@ -147,9 +148,9 @@ await browser.context.clipboard.cut();
   Resolves after the clipboard operation completes.
 </ResponseField>
 
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 
 ## Quick start
 
@@ -266,4 +267,5 @@ await browser.context.clipboard.cut()
   Resolves after the clipboard operation completes.
 </ResponseField>
 
-</View>
+</Tab>
+</Tabs>

--- a/packages/docs/v4/reference/context.mdx
+++ b/packages/docs/v4/reference/context.mdx
@@ -6,7 +6,8 @@ icon: "window"
 
 Use `BrowserContext` to coordinate pages and browser state that is shared across them.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 
 ## Quick start
 
@@ -293,9 +294,9 @@ await browser.context.clearCookies({ domain: "example.com" });
   Resolves after the operation completes.
 </ResponseField>
 
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 
 ## Quick start
 
@@ -572,4 +573,5 @@ await browser.context.clear_cookies(domain="example.com")
   Resolves after the operation completes.
 </ResponseField>
 
-</View>
+</Tab>
+</Tabs>

--- a/packages/docs/v4/reference/locator.mdx
+++ b/packages/docs/v4/reference/locator.mdx
@@ -12,7 +12,8 @@ Selectors pierce shadow DOM, including closed roots.
 **Closed roots require a navigated page.** Piercing them needs a frame with a real origin, and a tab still sitting at `about:blank` has none, so a selector crossing a closed root will not match there. Open roots still resolve. Navigate the tab to an `http:` or `https:` URL first.
 </Warning>
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 
 ## Quick start
 
@@ -387,9 +388,9 @@ const third = locator.nth(2);
   The operation result.
 </ResponseField>
 
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 
 ## Quick start
 
@@ -746,4 +747,5 @@ third = locator.nth(2)
   The operation result.
 </ResponseField>
 
-</View>
+</Tab>
+</Tabs>

--- a/packages/docs/v4/reference/page.mdx
+++ b/packages/docs/v4/reference/page.mdx
@@ -6,7 +6,8 @@ icon: "page"
 
 A `Page` combines deterministic browser controls with Stagehand's natural-language `act`, `observe`, and `extract` methods. Navigation methods return the main-document [`Response`](/v4/reference/response), when the navigation produces one.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 
 ## Quick start
 
@@ -703,9 +704,9 @@ const locator = page.locator("button[type=submit]");
   The operation result.
 </ResponseField>
 
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 
 ## Quick start
 
@@ -1365,4 +1366,5 @@ locator = page.locator("button[type=submit]")
   The operation result.
 </ResponseField>
 
-</View>
+</Tab>
+</Tabs>

--- a/packages/docs/v4/reference/response.mdx
+++ b/packages/docs/v4/reference/response.mdx
@@ -12,7 +12,8 @@ The nullable result is not an error. Navigations to URLs such as `data:` and `ab
   Response bodies and complete metadata are retrieved lazily. Use the response while its Stagehand session is open. Response handles become invalid when the session closes and older handles may be collected after enough newer responses are created.
 </Note>
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 
 ## Navigation
 
@@ -79,9 +80,9 @@ response.finished(): Promise<null | Error>
 
 Body access is lazy. Each SDK call requests the body through the response handle; Stagehand reuses the underlying browser body retrieval. `json()` preserves JSON parse errors. `finished()` resolves to `null` after success or an `Error` describing the loading failure.
 
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 
 ## Navigation
 
@@ -147,9 +148,9 @@ await response.finished() -> Exception | None
 
 Body access is lazy. Each SDK call requests the body through the response handle; Stagehand reuses the underlying browser body retrieval. UTF-8 decoding and JSON parsing preserve their native errors. `finished()` returns `None` after success or an exception describing the loading failure.
 
-</View>
+</Tab>
 
-<View title="Go" icon="golang">
+<Tab title="Go">
 
 ## Navigation
 
@@ -223,4 +224,5 @@ func (r *Response) Finished(ctx context.Context) error
 
 Body access is lazy. Each SDK call requests the body through the response handle; Stagehand reuses the underlying browser body retrieval. `JSON()` decodes into the supplied destination. `Finished()` returns the loading failure or an RPC error, and returns `nil` after success.
 
-</View>
+</Tab>
+</Tabs>

--- a/packages/docs/v4/reference/stagehand.mdx
+++ b/packages/docs/v4/reference/stagehand.mdx
@@ -6,7 +6,8 @@ icon: "hand-horns"
 
 `Stagehand` owns the browser connection and exposes top-level lifecycle, metrics, and AI methods.
 
-<View title="TypeScript" icon="js">
+<Tabs>
+<Tab title="TypeScript">
 
 ## Quick start
 
@@ -818,9 +819,9 @@ console.log(product.data, product.metadata.cache.status);
   </ResponseField>
 </ResponseField>
 
-</View>
+</Tab>
 
-<View title="Python" icon="python">
+<Tab title="Python">
 
 ## Quick start
 
@@ -1574,4 +1575,5 @@ print(product.data, product.metadata.cache.status)
   </ResponseField>
 </ResponseField>
 
-</View>
+</Tab>
+</Tabs>


### PR DESCRIPTION
# why

Moves from language dropdown on the right side to labs per language. This is more similar to our browserbase docs

# what changed

# test plan

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched v4 docs from a right-side language dropdown to in-page tabs for TypeScript, Python, and Go to match Browserbase docs and improve readability. v3 keeps its existing selector; the v3 script is now scoped so it stays inert on v4 pages. Implements Linear STG-2799.

- **New Features**
  - Converted v4 MDX pages to language tabs with `Tabs`/`Tab` across basics, best-practices, configuration, first-steps, migrations, and reference pages.
  - Introduced Mintlify `Steps`/`Step` for sequential guides (Quickstart, Deployments) to improve scan-ability.
  - Updated docs tests to use language tabs as the selector and renamed types (View → Tab); tests recognize "TypeScript", "Python", and "Go" tabs.

- **Bug Fixes**
  - Scoped `packages/docs/language-selector.js` to v3 routes and clear body classes on client navigation to prevent hiding the version switcher and stale checkmarks on v4 pages.

<sup>Written for commit 587bb5cddb7421c63131841d4feb530a6062a701. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

