### PR TITLE
accept locators for screenshot mask in golang sdk

### DIFF
--- a/packages/sdk-go/client_options.go
+++ b/packages/sdk-go/client_options.go
@@ -104,3 +104,20 @@ type StagehandClientExtractOptions struct {
 	Locator        *PageLocator
 	IgnoreLocators []*PageLocator
 }
+
+// ScreenshotOptions configures page screenshot capture. PageLocator wrappers
+// never cross the JSON-RPC boundary.
+type ScreenshotOptions struct {
+	Animations     *PageScreenshotOptionsAnimations
+	Caret          *PageScreenshotOptionsCaret
+	Clip           *PageScreenshotClip
+	FullPage       *bool
+	Mask           []*PageLocator
+	MaskColor      *string
+	OmitBackground *bool
+	Quality        *int
+	Scale          *PageScreenshotOptionsScale
+	Style          *string
+	Timeout        *float64
+	Type           *PageScreenshotOptionsType
+}

--- a/packages/sdk-go/page.go
+++ b/packages/sdk-go/page.go
@@ -384,10 +384,9 @@ func screenshotProtocolOptions(options *ScreenshotOptions, pageID string) (*Page
 
 func locatorDescriptorsForScreenshot(locators []*PageLocator, pageID string) ([]LocatorDescriptor, error) {
 	descriptors := make([]LocatorDescriptor, 0, len(locators))
-	for _, locator := range locators {
+	for index, locator := range locators {
 		if locator == nil {
-			descriptors = append(descriptors, LocatorDescriptor{})
-			continue
+			return nil, fmt.Errorf("page.Screenshot: mask locator at index %d is nil", index)
 		}
 		descriptor := locator.Descriptor()
 		if descriptor.PageID != pageID {

--- a/packages/sdk-go/page.go
+++ b/packages/sdk-go/page.go
@@ -337,8 +337,13 @@ func (p *Page) WaitForSelector(
 }
 
 // Screenshot captures the page and decodes the protocol's base64 payload.
-func (p *Page) Screenshot(ctx context.Context, options *PageScreenshotOptions) ([]byte, error) {
-	params := PageScreenshotParams{PageID: p.PageID(), Options: options}
+func (p *Page) Screenshot(ctx context.Context, options *ScreenshotOptions) ([]byte, error) {
+	pageID := p.PageID()
+	protocolOptions, err := screenshotProtocolOptions(options, pageID)
+	if err != nil {
+		return nil, err
+	}
+	params := PageScreenshotParams{PageID: pageID, Options: protocolOptions}
 	var result PageScreenshotResult
 	if err := p.rpc.call(ctx, "page.screenshot", params, &result); err != nil {
 		return nil, err
@@ -348,6 +353,49 @@ func (p *Page) Screenshot(ctx context.Context, options *PageScreenshotOptions) (
 		return nil, fmt.Errorf("decode page.screenshot result: %w", err)
 	}
 	return data, nil
+}
+
+func screenshotProtocolOptions(options *ScreenshotOptions, pageID string) (*PageScreenshotOptions, error) {
+	if options == nil {
+		return nil, nil
+	}
+	protocolOptions := PageScreenshotOptions{
+		Animations:     options.Animations,
+		Caret:          options.Caret,
+		Clip:           options.Clip,
+		FullPage:       options.FullPage,
+		MaskColor:      options.MaskColor,
+		OmitBackground: options.OmitBackground,
+		Quality:        options.Quality,
+		Scale:          options.Scale,
+		Style:          options.Style,
+		Timeout:        options.Timeout,
+		Type:           options.Type,
+	}
+	if options.Mask != nil {
+		mask, err := locatorDescriptorsForScreenshot(options.Mask, pageID)
+		if err != nil {
+			return nil, err
+		}
+		protocolOptions.Mask = mask
+	}
+	return &protocolOptions, nil
+}
+
+func locatorDescriptorsForScreenshot(locators []*PageLocator, pageID string) ([]LocatorDescriptor, error) {
+	descriptors := make([]LocatorDescriptor, 0, len(locators))
+	for _, locator := range locators {
+		if locator == nil {
+			descriptors = append(descriptors, LocatorDescriptor{})
+			continue
+		}
+		descriptor := locator.Descriptor()
+		if descriptor.PageID != pageID {
+			return nil, errors.New("page.Screenshot: mask locator must belong to the target page")
+		}
+		descriptors = append(descriptors, descriptor)
+	}
+	return descriptors, nil
 }
 
 // Snapshot returns the generated accessibility snapshot result.

--- a/packages/sdk-go/page_test.go
+++ b/packages/sdk-go/page_test.go
@@ -305,6 +305,95 @@ func TestPageRefreshesReferenceAndDecodesScreenshot(t *testing.T) {
 	}
 }
 
+func TestPageScreenshotSerializesOptionsAndMaskLocators(t *testing.T) {
+	t.Parallel()
+
+	rpc := &recordingProtocolClient{responses: map[string]any{
+		"page.screenshot": PageScreenshotResult{
+			Data: "cG5nLWJ5dGVz",
+			Type: PageScreenshotResultTypePNG,
+		},
+	}}
+	page := &Page{rpc: rpc, ref: PageRef{PageID: "page-1"}}
+	fullPage := true
+	maskColor := "#ff00ff"
+	quality := 80
+	timeout := 2500.0
+	screenshotType := PageScreenshotOptionsTypeJPEG
+	scale := PageScreenshotOptionsScaleCSS
+	animations := PageScreenshotOptionsAnimationsDisabled
+	caret := PageScreenshotOptionsCaretHide
+	omitBackground := true
+	style := "body { color: red; }"
+	maskIndex := 2
+	mask := mustNth(t, page.Locator(".secret"), 2)
+
+	_, err := page.Screenshot(context.Background(), &ScreenshotOptions{
+		Animations:     &animations,
+		Caret:          &caret,
+		Clip:           &PageScreenshotClip{X: 1, Y: 2, Width: 300, Height: 200},
+		FullPage:       &fullPage,
+		Mask:           []*PageLocator{mask},
+		MaskColor:      &maskColor,
+		OmitBackground: &omitBackground,
+		Quality:        &quality,
+		Scale:          &scale,
+		Style:          &style,
+		Timeout:        &timeout,
+		Type:           &screenshotType,
+	})
+	if err != nil {
+		t.Fatalf("Screenshot() error = %v", err)
+	}
+
+	params, ok := rpc.calls[0].params.(PageScreenshotParams)
+	if !ok || params.PageID != "page-1" || params.Options == nil {
+		t.Fatalf("Screenshot() params = %#v", rpc.calls[0].params)
+	}
+	options := params.Options
+	if options.Animations != &animations ||
+		options.Caret != &caret ||
+		options.Clip == nil ||
+		options.Clip.X != 1 ||
+		options.Clip.Y != 2 ||
+		options.Clip.Width != 300 ||
+		options.Clip.Height != 200 ||
+		options.FullPage != &fullPage ||
+		options.MaskColor != &maskColor ||
+		options.OmitBackground != &omitBackground ||
+		options.Quality != &quality ||
+		options.Scale != &scale ||
+		options.Style != &style ||
+		options.Timeout != &timeout ||
+		options.Type != &screenshotType {
+		t.Fatalf("Screenshot() options = %#v", options)
+	}
+	wantMask := []LocatorDescriptor{{PageID: "page-1", Selector: ".secret", Nth: &maskIndex}}
+	if !reflect.DeepEqual(options.Mask, wantMask) {
+		t.Fatalf("Screenshot() mask = %#v, want %#v", options.Mask, wantMask)
+	}
+}
+
+func TestPageScreenshotRejectsCrossPageMaskLocators(t *testing.T) {
+	t.Parallel()
+
+	rpc := &recordingProtocolClient{responses: map[string]any{
+		"page.screenshot": PageScreenshotResult{Data: "cG5nLWJ5dGVz", Type: PageScreenshotResultTypePNG},
+	}}
+	page := &Page{rpc: rpc, ref: PageRef{PageID: "page-1"}}
+	otherPage := &Page{rpc: rpc, ref: PageRef{PageID: "page-2"}}
+
+	_, err := page.Screenshot(context.Background(), &ScreenshotOptions{
+		Mask: []*PageLocator{otherPage.Locator(".secret")},
+	})
+	if err == nil || !strings.Contains(err.Error(), "mask locator must belong to the target page") {
+		t.Fatalf("Screenshot() error = %v", err)
+	}
+	if len(rpc.calls) != 0 {
+		t.Fatalf("Screenshot() RPC calls = %#v", rpc.calls)
+	}
+}
+
 func TestPageNavigationMethodsReturnNilWithoutNetworkResponse(t *testing.T) {
 	t.Parallel()
 

--- a/packages/sdk-go/page_test.go
+++ b/packages/sdk-go/page_test.go
@@ -394,6 +394,25 @@ func TestPageScreenshotRejectsCrossPageMaskLocators(t *testing.T) {
 	}
 }
 
+func TestPageScreenshotRejectsNilMaskLocators(t *testing.T) {
+	t.Parallel()
+
+	rpc := &recordingProtocolClient{responses: map[string]any{
+		"page.screenshot": PageScreenshotResult{Data: "cG5nLWJ5dGVz", Type: PageScreenshotResultTypePNG},
+	}}
+	page := &Page{rpc: rpc, ref: PageRef{PageID: "page-1"}}
+
+	_, err := page.Screenshot(context.Background(), &ScreenshotOptions{
+		Mask: []*PageLocator{nil},
+	})
+	if err == nil || !strings.Contains(err.Error(), "page.Screenshot: mask locator at index 0 is nil") {
+		t.Fatalf("Screenshot() error = %v", err)
+	}
+	if len(rpc.calls) != 0 {
+		t.Fatalf("Screenshot() RPC calls = %#v", rpc.calls)
+	}
+}
+
 func TestPageNavigationMethodsReturnNilWithoutNetworkResponse(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
# why
- for consistency with TS/Python screenshot masks, Go should accept page-bound locator wrappers instead of generated locator descriptor schemas

# what changed
- adds a handwritten Go `ScreenshotOptions` type for `Page.Screenshot`
- changes `ScreenshotOptions.Mask` to accept `[]*PageLocator`
- converts mask locators to generated `LocatorDescriptor` values before sending the `page.screenshot` RPC
- validates that mask locators belong to the screenshot target page before sending the request
- preserves existing screenshot options like animations, caret, clip, full page, mask color, omit background, quality, scale, style, timeout, and type

## SDK Shape

Go:

```go
png, err := page.Screenshot(ctx, &stagehand.ScreenshotOptions{
	FullPage: &fullPage,
	Mask: []*stagehand.PageLocator{
		page.Locator(".secret"),
	},
	MaskColor: &maskColor,
})
```

## behavioural notes:
- `Page.Screenshot` still returns decoded screenshot bytes
- `nil` screenshot options still send no protocol options
- mask locators serialize to generated `LocatorDescriptor` values internally, including `pageId`, `selector`, and optional `nth`
- mask locators from another page are rejected before RPC
- non-mask screenshot options continue to pass through unchanged
- TS/Python screenshot behavior and protocol schemas are unchanged

# test plan
- Go SDK tests cover handwritten `ScreenshotOptions` conversion to generated protocol options
- Go SDK tests cover `*PageLocator` mask serialization, including `nth`
- Go SDK tests cover cross-page mask locator rejection before RPC
- Go SDK tests cover preservation of existing non-mask screenshot options


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Go SDK: Page.Screenshot now accepts page-bound locator masks with strict validation while keeping screenshot behavior unchanged. This also moves act/observe/extract to locator-based scoping across SDKs, updates snapshotting, and standardizes examples to read result data via `.data`.

- **New Features**
  - `Page.Screenshot` `Mask` accepts `[]*PageLocator`; nil and cross-page locators are rejected; converts to protocol descriptors before RPC.
  - `act`/`observe`/`extract` accept `locator` and `ignoreLocators` (with `.nth`), validate same-page locators, and serialize in TS batch callbacks.
  - Snapshot capture uses `focusLocator`/`ignoreLocators`; locator-scoped calls bypass server cache (responses show cache status `DISABLED`).

- **Migration**
  - Go: replace `*PageScreenshotOptions` with `*ScreenshotOptions`; pass `page.Locator("...")` in `Mask`.
  - Replace `selector`/`ignoreSelectors` with `locator`/`ignoreLocators` for `act`/`observe`/`extract` in TS/Python/Go; use `.nth(index)` when needed.
  - Examples now access `result.data` instead of the full response.

<sup>Written for commit 0baf98c35cb168ec51d333ef5ee0fd79e7614175. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

