### PR TITLE
[Docs] Reduce docs nesting and improve consistency

### DIFF
--- a/packages/docs/v4/basics/act.mdx
+++ b/packages/docs/v4/basics/act.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Act"
-description: "Interact with a web page."
+description: "Interact with a web page"
 ---
 
 ## What is `act()`?

--- a/packages/docs/v4/basics/extract.mdx
+++ b/packages/docs/v4/basics/extract.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Extract"
-description: "Extract structured data from a webpage."
+description: "Extract structured data from a webpage"
 ---
 
 ## What is `extract()`?

--- a/packages/docs/v4/basics/observe.mdx
+++ b/packages/docs/v4/basics/observe.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Observe"
-description: "Discover and plan executable actions on any web page."
+description: "Discover and plan executable actions on any web page"
 ---
 
 ## What is `observe()`?

--- a/packages/docs/v4/basics/webmcp.mdx
+++ b/packages/docs/v4/basics/webmcp.mdx
@@ -1,7 +1,7 @@
 ---
 title: "WebMCP"
 sidebarTitle: "WebMCP"
-description: "List and invoke tools registered by the current web page."
+description: "List and invoke tools registered by the current web page"
 ---
 
 ## What is WebMCP?

--- a/packages/docs/v4/best-practices/deployments.mdx
+++ b/packages/docs/v4/best-practices/deployments.mdx
@@ -481,8 +481,6 @@ See Vercel's [configuring functions](https://vercel.com/docs/functions/configuri
 
 Link your local folder to a Vercel project before configuring environment variables:
 
-<Tabs>
-<Tab title="TypeScript">
 ```bash
 # authenticate if needed
 vercel login
@@ -490,28 +488,6 @@ vercel login
 # link the current directory to a Vercel project (interactive)
 vercel link
 ```
-</Tab>
-
-<Tab title="Python">
-```bash
-# authenticate if needed
-vercel login
-
-# link the current directory to a Vercel project (interactive)
-vercel link
-```
-</Tab>
-
-<Tab title="Go">
-```bash
-# authenticate if needed
-vercel login
-
-# link the current directory to a Vercel project (interactive)
-vercel link
-```
-</Tab>
-</Tabs>
 
 </Step>
 
@@ -519,8 +495,6 @@ vercel link
 
 Never commit secrets. Add variables via the Vercel CLI, then read them in your handler and pass them where you launch the browser and create the Stagehand client. `CRON_SECRET` is the secret the handler compares against the `Authorization` header, and Vercel sends it automatically when a cron job invokes the function:
 
-<Tabs>
-<Tab title="TypeScript">
 ```bash
 vercel env add BROWSERBASE_API_KEY
 # (and your model key if needed)
@@ -530,32 +504,6 @@ vercel env add GOOGLE_API_KEY
 # generate one with: openssl rand -hex 32
 vercel env add CRON_SECRET
 ```
-</Tab>
-
-<Tab title="Python">
-```bash
-vercel env add BROWSERBASE_API_KEY
-# (and your model key if needed)
-vercel env add GOOGLE_API_KEY
-
-# the shared secret the handler requires on every request
-# generate one with: openssl rand -hex 32
-vercel env add CRON_SECRET
-```
-</Tab>
-
-<Tab title="Go">
-```bash
-vercel env add BROWSERBASE_API_KEY
-# (and your model key if needed)
-vercel env add GOOGLE_API_KEY
-
-# the shared secret the handler requires on every request
-# generate one with: openssl rand -hex 32
-vercel env add CRON_SECRET
-```
-</Tab>
-</Tabs>
 
 <Tip>
 Using the [Model Gateway](/v4/configuration/models#model-gateway) means `BROWSERBASE_API_KEY` is the only secret you need to deploy.
@@ -605,28 +553,10 @@ vercel dev --listen 5005
 
 <Step title="Deploy">
 
-<Tabs>
-<Tab title="TypeScript">
 ```bash
 vercel
 vercel --prod
 ```
-</Tab>
-
-<Tab title="Python">
-```bash
-vercel
-vercel --prod
-```
-</Tab>
-
-<Tab title="Go">
-```bash
-vercel
-vercel --prod
-```
-</Tab>
-</Tabs>
 
 </Step>
 
@@ -647,34 +577,12 @@ If the deployment also sits behind Vercel Deployment Protection, create a Protec
 
 Then invoke the function with the bypass header:
 
-<Tabs>
-<Tab title="TypeScript">
 ```bash
 curl -X POST \
   -H "Authorization: Bearer <your-CRON_SECRET>" \
   -H "x-vercel-protection-bypass: <your-32-character-secret>" \
   https://<your-deployment>/api/run
 ```
-</Tab>
-
-<Tab title="Python">
-```bash
-curl -X POST \
-  -H "Authorization: Bearer <your-CRON_SECRET>" \
-  -H "x-vercel-protection-bypass: <your-32-character-secret>" \
-  https://<your-deployment>/api/run
-```
-</Tab>
-
-<Tab title="Go">
-```bash
-curl -X POST \
-  -H "Authorization: Bearer <your-CRON_SECRET>" \
-  -H "x-vercel-protection-bypass: <your-32-character-secret>" \
-  https://<your-deployment>/api/run
-```
-</Tab>
-</Tabs>
 
 </Step>
 

--- a/packages/docs/v4/best-practices/usecase-observe.mdx
+++ b/packages/docs/v4/best-practices/usecase-observe.mdx
@@ -1,6 +1,6 @@
 ---
 title: Observe use cases
-sidebarTitle: Use cases
+sidebarTitle: Observe use cases
 description: Real-world patterns for planning automations with observe()
 ---
 

--- a/packages/docs/v4/best-practices/user-data.mdx
+++ b/packages/docs/v4/best-practices/user-data.mdx
@@ -1,14 +1,9 @@
 ---
-title: User data directory
+title: User data
 sidebarTitle: User data
 description: Persist browser data between sessions
 ---
-
-## User data directory
-
-Persist browser data between sessions.
-
-### Local sessions
+## Local sessions
 
 For local sessions, point `localBrowser.launch()` at a user data directory. Stagehand creates the directory if it does not exist and leaves it in place after the browser shuts down, so the next run starts from the same cookies and local storage:
 
@@ -76,7 +71,7 @@ The preserve flag governs only that generated temporary profile, never a directo
 </Tabs>
 
 
-### Browserbase sessions
+## Browserbase sessions
 
 For Browserbase sessions, use [contexts](https://docs.browserbase.com/features/contexts) to persist browser data:
 

--- a/packages/docs/v4/configuration/browser.mdx
+++ b/packages/docs/v4/configuration/browser.mdx
@@ -182,25 +182,9 @@ The Browserbase URL controls extension, session, and connection requests that `b
 
 Before getting started, set up the required environment variables:
 
-<Tabs>
-<Tab title="TypeScript">
 ```bash
 export BROWSERBASE_API_KEY=your_api_key_here
 ```
-</Tab>
-
-<Tab title="Python">
-```bash
-export BROWSERBASE_API_KEY=your_api_key_here
-```
-</Tab>
-
-<Tab title="Go">
-```bash
-export BROWSERBASE_API_KEY=your_api_key_here
-```
-</Tab>
-</Tabs>
 
 <Tip>
 Get your API key from the [Browserbase Dashboard](https://browserbase.com/overview). Stagehand does not read this variable for you: read it in your own code and pass it to `browserbase.launch()`.

--- a/packages/docs/v4/configuration/logging.mdx
+++ b/packages/docs/v4/configuration/logging.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Logging"
-description: "Control terminal output and forward structured Stagehand logs."
+description: "Control terminal output and forward structured Stagehand logs"
 ---
 
 Configure logging through a single `logging` option on `Stagehand.create()`: a level, an output format, and a callback that receives each record. Use the language selector to see the exact shape your SDK accepts.
@@ -314,7 +314,7 @@ Turning logging off suppresses the record callback as well as console output. Do
 
 ### Log destinations
 
-Send logs to your console or to an external observability platform. The record callback drives every destination, so anything your own code can write to is a valid sink:
+Send logs to your console or through your own callback. The record callback drives every destination, so anything your own code can write to is a valid sink. To forward records to an observability platform, see [External logging platforms](#external-logging-platforms).
 
 <Tabs>
 <Tab title="Pretty (default)">
@@ -540,19 +540,21 @@ defer func() { err = errors.Join(err, client.Close(ctx)) }()
 The callback receives every record that passes the level gate, so do any finer filtering inside it. It runs in addition to the console output rather than instead of it: the level gates both and `off` silences both. Keep the level at the lowest severity you want to receive, and redirect standard error if the console itself needs to stay quiet.
 </Note>
 </Tab>
+</Tabs>
 
-<Tab title="External logger (production)">
-The same callback, pointed at an observability platform.
+---
 
-**When to use:** Production with DataDog, Sentry, CloudWatch, or custom observability platforms for centralized monitoring and error alerting. Here are examples using Sentry and DataDog:
+### External logging platforms
+
+The same log callback, pointed at an observability platform.
+
+**When to use:** Production with Sentry, DataDog, CloudWatch, or a custom observability platform for centralized monitoring and error alerting.
+
+#### Sentry
 
 <Steps>
 
 <Step title="Create a production logger">
-
-<Tabs>
-
-<Tab title="Sentry">
 
 <Tabs>
 <Tab title="TypeScript">
@@ -611,8 +613,74 @@ func productionLogger(entry stagehand.StagehandLog) {
 </Tab>
 </Tabs>
 
+</Step>
+
+<Step title="Pass the logger in your Stagehand instance">
+
+<Tabs>
+<Tab title="TypeScript">
+```typescript
+const stagehand = await Stagehand.create({
+  browser: await localBrowser.launch(),
+  logging: {
+    level: "info",
+    format: "json",
+    onLog: productionLogger,
+  },
+  // restOfYourConfiguration...
+});
+```
 </Tab>
-<Tab title="DataDog">
+
+<Tab title="Python">
+```python
+browser = await local_browser.launch()
+
+stagehand = await Stagehand.create(
+    browser=browser,
+    logging={
+        "level": "info",
+        "format": "json",
+        "on_log": production_logger,
+    },
+    # rest_of_your_configuration...
+)
+```
+</Tab>
+
+<Tab title="Go">
+```go
+browser, err := stagehand.LaunchLocalBrowser(ctx, &stagehand.LocalBrowserLaunchOptions{})
+if err != nil {
+	return err
+}
+
+client, err := stagehand.Create(ctx, stagehand.CreateOptions{
+	Browser: browser,
+	Logging: &stagehand.StagehandClientLoggingConfig{
+		Level:  stagehand.StagehandClientLogLevelInfo,
+		Format: stagehand.StagehandClientLogFormatJSON,
+		OnLog:  productionLogger,
+	},
+	// restOfYourConfiguration...
+})
+if err != nil {
+	return err
+}
+
+defer func() { err = errors.Join(err, client.Close(ctx)) }()
+```
+</Tab>
+</Tabs>
+
+</Step>
+</Steps>
+
+#### DataDog
+
+<Steps>
+
+<Step title="Create a production logger">
 
 <Tabs>
 <Tab title="TypeScript">
@@ -675,8 +743,6 @@ func productionLogger(entry stagehand.StagehandLog) {
 ```
 </Tab>
 </Tabs>
-</Tab>
-</Tabs>
 
 </Step>
 
@@ -723,7 +789,9 @@ if err != nil {
 client, err := stagehand.Create(ctx, stagehand.CreateOptions{
 	Browser: browser,
 	Logging: &stagehand.StagehandClientLoggingConfig{
-		OnLog: productionLogger,
+		Level:  stagehand.StagehandClientLogLevelInfo,
+		Format: stagehand.StagehandClientLogFormatJSON,
+		OnLog:  productionLogger,
 	},
 	// restOfYourConfiguration...
 })
@@ -742,9 +810,6 @@ defer func() { err = errors.Join(err, client.Close(ctx)) }()
 <Note>
 Failures inside your callback are caught and reported on standard error, so a failing logger will not take down your automation. That covers exceptions and rejected promises in TypeScript and Python, and a panic in Go.
 </Note>
-
-</Tab>
-</Tabs>
 
 ---
 
@@ -838,33 +903,8 @@ browser = await local_browser.launch()
 
 stagehand = await Stagehand.create(
     browser=browser,
-    logging={"level": "info", "format": "pretty"},
-)
-```
-
-| Option   | Default  | Values                                  |
-| -------- | -------- | --------------------------------------- |
-| `level`  | `info`   | `debug`, `info`, `warn`, `error`, `off` |
-| `format` | `pretty` | `pretty`, `json`                        |
-
-`format` only changes the built-in terminal output. It does not change structured logs passed
-to a callback.
-
-## Forward structured logs
-
-Use `on_log` to send each displayed log to a file or your application logger. The callback is
-additive: Stagehand continues to write its normal terminal output.
-
-```python
-from stagehand import Stagehand
-
-log_file = open("stagehand.jsonl", "a", encoding="utf-8")
-
-stagehand = await Stagehand.create(
-    browser=browser,
-    # ...
     logging={
-        "level": "info",
+        "level": "debug",
         "format": "pretty",
         "on_log": lambda log: print(log.model_dump_json(), file=log_file),
     },
@@ -881,73 +921,24 @@ finally:
 <Tab title="Go">
 
 ```go
+defer func() { err = errors.Join(err, logFile.Close()) }()
+
 client, err := stagehand.Create(ctx, stagehand.CreateOptions{
 	Browser: browser,
 	Logging: &stagehand.StagehandClientLoggingConfig{
-		Level:  stagehand.StagehandClientLogLevelInfo,
+		Level:  stagehand.StagehandClientLogLevelDebug,
 		Format: stagehand.StagehandClientLogFormatPretty,
+		OnLog: func(log stagehand.StagehandLog) {
+			_ = json.NewEncoder(logFile).Encode(log)
+		},
 	},
-	// ...
 })
 if err != nil {
 	return err
 }
 defer func() { err = errors.Join(err, client.Close(ctx)) }()
-```
 
-| Option   | Default  | Values                                  |
-| -------- | -------- | --------------------------------------- |
-| `Level`  | `info`   | `debug`, `info`, `warn`, `error`, `off` |
-| `Format` | `pretty` | `pretty`, `json`                        |
-
-`Format` only changes the built-in terminal output. It does not change structured logs passed
-to a callback.
-
-## Forward structured logs
-
-Use `OnLog` to send each displayed log to a file or your application logger. The callback is
-additive: Stagehand continues to write its normal terminal output.
-
-```go
-import (
-	"context"
-	"encoding/json"
-	"errors"
-	"os"
-
-	stagehand "github.com/browserbase/stagehand/packages/sdk-go"
-)
-
-func run(ctx context.Context) (err error) {
-	logFile, err := os.OpenFile(
-		"stagehand.jsonl",
-		os.O_APPEND|os.O_CREATE|os.O_WRONLY,
-		0o600,
-	)
-	if err != nil {
-		return err
-	}
-	defer func() { err = errors.Join(err, logFile.Close()) }()
-
-	client, err := stagehand.Create(ctx, stagehand.CreateOptions{
-		Browser: browser,
-		Logging: &stagehand.StagehandClientLoggingConfig{
-			Level:  stagehand.StagehandClientLogLevelInfo,
-			Format: stagehand.StagehandClientLogFormatPretty,
-			OnLog: func(log stagehand.StagehandLog) {
-				_ = json.NewEncoder(logFile).Encode(log)
-			},
-		},
-		// ...
-	})
-	if err != nil {
-		return err
-	}
-	defer func() { err = errors.Join(err, client.Close(ctx)) }()
-
-	// Use the initialized client here.
-	return nil
-}
+// ... your automation
 ```
 
 </Tab>

--- a/packages/docs/v4/first-steps/installation.mdx
+++ b/packages/docs/v4/first-steps/installation.mdx
@@ -46,30 +46,15 @@ If you plan to run locally, you need to have [Chrome](https://www.google.com/chr
 
 Set your Browserbase API key. When no model is configured, Model Gateway selects one automatically, so no model provider key is required:
 
-<Tabs>
-<Tab title="TypeScript">
 ```bash
 export BROWSERBASE_API_KEY=your_api_key
 ```
-</Tab>
-
-<Tab title="Python">
-```bash
-export BROWSERBASE_API_KEY=your_api_key
-```
-</Tab>
-
-<Tab title="Go">
-```bash
-export BROWSERBASE_API_KEY=your_api_key
-```
-</Tab>
-</Tabs>
 
 <Note>
 Stagehand does not read environment variables on your behalf, and it does not auto-load env files.
 
 This also applies to API routing: pass non-production Browserbase and Stagehand API URLs explicitly rather than setting `BROWSERBASE_BASE_URL` or `STAGEHAND_API_URL`. See [API endpoint overrides](/v4/configuration/browser#api-endpoint-overrides).
+</Note>
 
 Read the values in your own app code and pass them explicitly to the browser factory:
 
@@ -112,7 +97,6 @@ client, err := stagehand.Create(ctx, stagehand.CreateOptions{Browser: browser})
 ```
 </Tab>
 </Tabs>
-</Note>
 
 ### Use in your codebase
 

--- a/packages/docs/v4/reference/clipboard.mdx
+++ b/packages/docs/v4/reference/clipboard.mdx
@@ -1,6 +1,6 @@
 ---
 title: "clipboard"
-description: "Read, write, and dispatch clipboard operations in the browser."
+description: "Read, write, and dispatch clipboard operations in the browser"
 icon: "clipboard"
 ---
 

--- a/packages/docs/v4/reference/context.mdx
+++ b/packages/docs/v4/reference/context.mdx
@@ -1,6 +1,6 @@
 ---
 title: "context"
-description: "Manage pages, cookies, headers, policies, and clipboard access within a browser context."
+description: "Manage pages, cookies, headers, policies, and clipboard access within a browser context"
 icon: "window"
 ---
 

--- a/packages/docs/v4/reference/locator.mdx
+++ b/packages/docs/v4/reference/locator.mdx
@@ -1,6 +1,6 @@
 ---
 title: "locator"
-description: "Target elements and perform focused DOM interactions."
+description: "Target elements and perform focused DOM interactions"
 icon: "crosshairs"
 ---
 

--- a/packages/docs/v4/reference/page.mdx
+++ b/packages/docs/v4/reference/page.mdx
@@ -1,6 +1,6 @@
 ---
 title: "page"
-description: "Navigate, inspect, and interact with a browser page."
+description: "Navigate, inspect, and interact with a browser page"
 icon: "page"
 ---
 

--- a/packages/docs/v4/reference/response.mdx
+++ b/packages/docs/v4/reference/response.mdx
@@ -1,6 +1,6 @@
 ---
 title: "response"
-description: "Inspect the main-document network response returned by page navigation."
+description: "Inspect the main-document network response returned by page navigation"
 icon: "globe"
 ---
 

--- a/packages/docs/v4/reference/stagehand.mdx
+++ b/packages/docs/v4/reference/stagehand.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Stagehand"
-description: "Initialize a browser session and run AI-powered actions, observations, and extractions."
+description: "Initialize a browser session and run AI-powered actions, observations, and extractions"
 icon: "hand-horns"
 ---
 


### PR DESCRIPTION
# why

* Reduces docs nesting (e.g. don't have code snippet inside warning)
* Removes `.` from sub-headers for consistency
* Removes the language tabs when the snippet is language-agnostic bash

# what changed

# test plan


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flattens Stagehand v4 docs to reduce nested notes and unify code examples for clearer, more consistent rendering. Fixes chopped code blocks in nested notes and removes language tabs for `bash` snippets (STG-2804).

- Refactors
  - Un-nested code blocks from notes/warnings to fix nested-note rendering (STG-2804).
  - Removed language tabs where snippets are language-agnostic `bash`.
  - Standardized subheaders by removing trailing periods; aligned titles (e.g., “User data”, “Observe use cases”).
  - Collapsed duplicate CLI/env examples across languages into a single `bash` block.
  - Reworked logging docs: clarified destinations, split external platforms into Sentry and DataDog with setup steps, and added examples for passing a production logger via `logging.onLog`.

<sup>Written for commit 10dc1b564b6b9f29fbabde567a52b19737d3fb21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

