### PR TITLE
feat(integrations): Vercel AI SDK (MCP over stdio)

### DIFF
--- a/packages/integrations/vercel-ai/README.md
+++ b/packages/integrations/vercel-ai/README.md
@@ -1,0 +1,49 @@
+# Vercel AI SDK + Stagehand facade over MCP/stdio
+
+This example connects the Vercel AI SDK to the Stagehand facade MCP server over
+stdio. It exposes the facade's `run`, `snapshot`, and `screenshot` tools to an AI
+SDK agent.
+
+This route wraps the facade as an MCP server over stdio, so any MCP-capable
+framework (here, the Vercel AI SDK) can consume the identical tool contract
+without Stagehand-specific glue, at the cost of a child process and JSON-RPC
+hop. Alternatively, the same contract can be bound as native in-process tools
+sharing a durable Stagehand session, with no bridge process but
+framework-specific code.
+
+## Setup
+
+Node.js 24 or newer is required. From the repository root, build the integrations
+package first so its `dist` server entrypoint exists:
+
+```sh
+pnpm exec turbo run build --filter @browserbasehq/stagehand-integrations
+```
+
+Configure the environment as needed:
+
+| Variable                  | Purpose                                                                                                                                                                                                           |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `STAGEHAND_BROWSER`       | Browser backend. Defaults to `browserbase` when `BROWSERBASE_API_KEY` is set, otherwise `local`.                                                                                                                  |
+| `BROWSERBASE_API_KEY`     | Browserbase API key.                                                                                                                                                                                              |
+| `BROWSERBASE_PROJECT_ID`  | Browserbase project ID.                                                                                                                                                                                           |
+| `STAGEHAND_MODEL_NAME`    | Model used by the facade server.                                                                                                                                                                                  |
+| `STAGEHAND_MODEL_API_KEY` | API key for the facade server model.                                                                                                                                                                              |
+| `AI_SDK_STAGEHAND_MODEL`  | AI SDK agent model; defaults to `gpt-5.6-luna`.                                                                                                                                                                   |
+| `OPENAI_API_KEY`          | Used by the AI SDK agent model in the host process. It is not forwarded: it is neither allowlisted nor one of the host variables (`HOME`, `LOGNAME`, `PATH`, `SHELL`, `TERM`, `USER`) inherited by the transport. |
+
+## Run
+
+```sh
+pnpm --filter @browserbasehq/stagehand-integrations-example-vercel-ai-facade test
+pnpm --filter @browserbasehq/stagehand-integrations-example-vercel-ai-facade typecheck
+pnpm --filter @browserbasehq/stagehand-integrations-example-vercel-ai-facade start "your instruction"
+```
+
+## Security model
+
+`run(code)` executes model-authored JavaScript in the extension service worker:
+it runs browser-side, never in the Node host process. Browserbase is the
+recommended isolation boundary. The Node host process spawns the facade server
+and holds only the MCP connection; model-authored JavaScript does not execute
+inside the host process.

--- a/packages/integrations/vercel-ai/package.json
+++ b/packages/integrations/vercel-ai/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@browserbasehq/stagehand-integrations-example-vercel-ai-facade",
+  "version": "4.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node src/agent.ts",
+    "test": "pnpm -w exec turbo run build --filter @browserbasehq/stagehand-integrations && vitest run",
+    "typecheck": "tsc --noEmit",
+    "test:unit": "vitest run"
+  },
+  "dependencies": {
+    "@ai-sdk/mcp": "catalog:",
+    "@ai-sdk/openai": "catalog:",
+    "@browserbasehq/stagehand-integrations": "workspace:*",
+    "ai": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=24"
+  }
+}

--- a/packages/integrations/vercel-ai/src/agent.ts
+++ b/packages/integrations/vercel-ai/src/agent.ts
@@ -1,0 +1,39 @@
+import { openai } from "@ai-sdk/openai";
+import { FACADE_AGENT_INSTRUCTIONS } from "@browserbasehq/stagehand-integrations/facade";
+import { generateText, stepCountIs, type ToolSet } from "ai";
+
+import { createFacadeMCPClient } from "./client.ts";
+
+async function main() {
+  const args = process.argv.slice(2);
+  const instruction = (args[0] === "--" ? args.slice(1) : args).join(" ").trim();
+  if (!instruction) {
+    throw new Error('Usage: pnpm start -- "your instruction"');
+  }
+
+  const client = await createFacadeMCPClient();
+
+  try {
+    const result = await generateText({
+      model: openai(process.env.AI_SDK_STAGEHAND_MODEL ?? "gpt-5.6-luna"),
+      // `ai` and `@ai-sdk/mcp` pin different exact @ai-sdk/provider-utils
+      // versions, so their structurally identical schema types are nominally
+      // distinct (unique-symbol brand). The cast bridges that; runtime is fine.
+      tools: (await client.tools()) as ToolSet,
+      stopWhen: stepCountIs(20),
+      instructions: FACADE_AGENT_INSTRUCTIONS,
+      prompt: instruction,
+    });
+
+    // oxlint-disable-next-line no-console -- CLI example prints the agent result.
+    console.log(result.text);
+  } finally {
+    await client.close();
+  }
+}
+
+main().catch((error: unknown) => {
+  // oxlint-disable-next-line no-console -- CLI example reports failures to stderr.
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/packages/integrations/vercel-ai/src/client.ts
+++ b/packages/integrations/vercel-ai/src/client.ts
@@ -1,0 +1,45 @@
+import { createMCPClient } from "@ai-sdk/mcp";
+import { Experimental_StdioMCPTransport } from "@ai-sdk/mcp/mcp-stdio";
+import { fileURLToPath } from "node:url";
+
+export type FacadeMCPClientOptions = {
+  env?: Record<string, string>;
+};
+
+/** Only STAGEHAND_* and BROWSERBASE_* host env vars cross into the server. */
+export function buildAllowlistedEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (/^(STAGEHAND_|BROWSERBASE_)/.test(key) && value) {
+      env[key] = value;
+    }
+  }
+  return env;
+}
+
+/**
+ * Starts the stdio facade server as a child process and returns the AI SDK
+ * MCP client connected to it. Call `client.close()` when finished to stop the
+ * child process and the browser it manages.
+ */
+export async function createFacadeMCPClient(options: FacadeMCPClientOptions = {}) {
+  // Build @browserbasehq/stagehand-integrations first so this dist entrypoint exists.
+  const serverPath = fileURLToPath(
+    import.meta.resolve("@browserbasehq/stagehand-integrations/facade/stdio-server"),
+  );
+
+  // The transport adds HOME, LOGNAME, PATH, SHELL, TERM, and USER from the host
+  // on top of this allowlist, so options.env cannot override those variables.
+  const env = buildAllowlistedEnv();
+
+  Object.assign(env, options.env);
+
+  return createMCPClient({
+    clientName: "stagehand-facade-vercel-ai-example",
+    transport: new Experimental_StdioMCPTransport({
+      command: process.execPath,
+      args: [serverPath],
+      env,
+    }),
+  });
+}

--- a/packages/integrations/vercel-ai/tests/client.test.ts
+++ b/packages/integrations/vercel-ai/tests/client.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createFacadeMCPClient } from "../src/client.js";
+
+type FacadeClient = Awaited<ReturnType<typeof createFacadeMCPClient>>;
+
+describe("Stagehand facade MCP client", () => {
+  let client: FacadeClient | undefined;
+
+  afterEach(async () => {
+    await client?.close();
+    client = undefined;
+    delete process.env.STAGEHAND_BROWSER;
+    delete process.env.NOT_ALLOWLISTED_SECRET;
+  });
+
+  // The contract itself (tool names, descriptions, schemas) is pinned by
+  // core's facade tests; this test covers only what is unique to this
+  // example — the host-env allowlist actually reaching the spawned server.
+  it("forwards allowlisted host env vars and nothing else", async () => {
+    process.env.STAGEHAND_BROWSER = "invalid";
+    process.env.NOT_ALLOWLISTED_SECRET = "must-not-cross";
+    client = await createFacadeMCPClient();
+
+    const tools = await client.tools();
+    expect(Object.keys(tools).length).toBeGreaterThan(0);
+    const execute = tools.snapshot?.execute;
+    expect(execute).toBeDefined();
+    if (!execute) throw new Error("snapshot tool is missing an execute function");
+
+    const result = (await execute(
+      {},
+      { toolCallId: "test-call", messages: [], context: undefined },
+    )) as {
+      content: Array<{ type: string; text?: string }>;
+      isError?: boolean;
+    };
+
+    // The server saw STAGEHAND_BROWSER=invalid from the host environment via
+    // the allowlist filter — proving the filter path runs (an options.env
+    // injection would bypass it).
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "text",
+          text: expect.stringContaining("STAGEHAND_BROWSER must be either"),
+        }),
+      ]),
+    );
+  });
+
+  it("allowlist excludes non-STAGEHAND/BROWSERBASE host vars", async () => {
+    process.env.STAGEHAND_BROWSER = "local";
+    process.env.NOT_ALLOWLISTED_SECRET = "must-not-cross";
+    const { buildAllowlistedEnv } = await import("../src/client.js");
+    const env = buildAllowlistedEnv();
+    expect(env.STAGEHAND_BROWSER).toBe("local");
+    expect(env).not.toHaveProperty("NOT_ALLOWLISTED_SECRET");
+  });
+});

--- a/packages/integrations/vercel-ai/tsconfig.json
+++ b/packages/integrations/vercel-ai/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "types": ["node"],
+    "rootDir": ".",
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts", "vitest.config.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/integrations/vercel-ai/vitest.config.ts
+++ b/packages/integrations/vercel-ai/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+    hookTimeout: 20_000,
+    testTimeout: 20_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,6 +217,9 @@ catalogs:
     '@ai-sdk/groq':
       specifier: ^4.0.5
       version: 4.0.5
+    '@ai-sdk/mcp':
+      specifier: 2.0.22
+      version: 2.0.22
     '@ai-sdk/openai':
       specifier: ^4.0.8
       version: 4.0.8
@@ -620,6 +623,31 @@ importers:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.1)(yaml@2.9.0))
 
+  packages/integrations/vercel-ai:
+    dependencies:
+      '@ai-sdk/mcp':
+        specifier: 'catalog:'
+        version: 2.0.22(zod@4.4.3)
+      '@ai-sdk/openai':
+        specifier: 'catalog:'
+        version: 4.0.8(zod@4.4.3)
+      '@browserbasehq/stagehand-integrations':
+        specifier: workspace:*
+        version: link:../core
+      ai:
+        specifier: 'catalog:'
+        version: 7.0.16(zod@4.4.3)
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.2
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.1)(yaml@2.9.0))
+
   packages/protocol:
     dependencies:
       camelcase-keys:
@@ -787,6 +815,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/mcp@2.0.22':
+    resolution: {integrity: sha512-j3jPwKFTffZCJzYGpN69yKu/y646uu2gWoEwh1jgVyYVpzfu6ErFU+YAd/+xTPxsUTx8FEIEUHTlEsDuOe+ytQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/mistral@2.0.40':
     resolution: {integrity: sha512-NNrF4+7bXqYwGYTxfWifw4P6HbtPasBFaSfhMhMQ/f0DrXNZhd9EaL4WktwB/3A8F3rMkSwoehHch2Ps6EJG0A==}
     engines: {node: '>=18'}
@@ -837,6 +871,12 @@ packages:
 
   '@ai-sdk/provider-utils@5.0.13':
     resolution: {integrity: sha512-fScDJMDnTbx32kLDQqp0MvPjvwkgiwvlBxlmIg7XW5PbS91LG6JjH3PQG+34oMFglqfpQA355e24OdGj5PPoDw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.18':
+    resolution: {integrity: sha512-UBNCrkxS5llgN2/RXLBRkjCFTIuL6YB1Goq5c+yRecnznhtX4XPjTwLHz2hrsTltTVZ0rqVegtnwFXdPBkjDHA==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -7044,6 +7084,10 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+    engines: {node: '>=20.18.1'}
+
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
@@ -7555,6 +7599,13 @@ snapshots:
       '@ai-sdk/provider-utils': 5.0.5(zod@4.4.3)
       zod: 4.4.3
 
+  '@ai-sdk/mcp@2.0.22(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.4
+      '@ai-sdk/provider-utils': 5.0.18(zod@4.4.3)
+      pkce-challenge: 5.0.1
+      zod: 4.4.3
+
   '@ai-sdk/mistral@2.0.40(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 2.0.3
@@ -7615,6 +7666,15 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       '@workflow/serde': 4.1.0
       eventsource-parser: 3.1.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@5.0.18(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.4
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      undici: 7.29.0
       zod: 4.4.3
 
   '@ai-sdk/provider-utils@5.0.5(zod@4.4.3)':
@@ -14886,6 +14946,8 @@ snapshots:
   undici-types@7.18.2: {}
 
   undici-types@7.24.6: {}
+
+  undici@7.29.0: {}
 
   unicorn-magic@0.3.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,6 +32,7 @@ catalog:
   ai: ^7.0.16
   "@mastra/core": ^1.55.0
   "@mastra/mcp": ^1.15.0
+  "@ai-sdk/mcp": 2.0.22
   "@ai-sdk/provider": ^4.0.2
   "@ai-sdk/openai": ^4.0.8
   "@ai-sdk/anthropic": ^4.0.8

--- a/turbo.json
+++ b/turbo.json
@@ -87,6 +87,9 @@
     "@browserbasehq/stagehand-integrations-example-mastra-facade#typecheck": {
       "dependsOn": ["^build"]
     },
+    "@browserbasehq/stagehand-integrations-example-vercel-ai-facade#typecheck": {
+      "dependsOn": ["^build"]
+    },
     "@browserbasehq/stagehand-docs#typecheck": {},
     "test:unit": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
Vercel AI SDK example for the Stagehand facade tool surface, consuming it as a standard MCP server over stdio.

- **Tools:** `run` / `snapshot` / `screenshot` — the shared facade contract; system prompt from `FACADE_AGENT_INSTRUCTIONS`.
- **Transport:** `experimental_createMCPClient` + stdio, spawning the workspace `stagehand-facade` bin with an env allowlist (`STAGEHAND_*`/`BROWSERBASE_*` only); client closed in `finally`.
- **Run:** `packages/integrations/vercel-ai/README.md`.

Verified: contract test in CI (three tools discovered, no browser on connect); Browserbase smoke passed (heading cited with snapshot ID, clean child exit).

Stacked on #2665.