### PR TITLE
feat(sdk-ts): expose sessionId on Browserbase browser handles

### DIFF
--- a/.changeset/browser-session-id.md
+++ b/.changeset/browser-session-id.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": minor
+---
+
+Expose `sessionId` on `StagehandBrowser` handles for Browserbase-backed browsers (`browserbase.launch` and `browserbase.connect`). Undefined for local browsers. This removes the need for out-of-band session-id recovery (metadata markers, session listing) when persisting sessions for reconnect.

--- a/.changeset/browser-session-id.md
+++ b/.changeset/browser-session-id.md
@@ -1,5 +1,0 @@
----
-"@browserbasehq/stagehand": minor
----
-
-Expose `sessionId` on `StagehandBrowser` handles for Browserbase-backed browsers (`browserbase.launch` and `browserbase.connect`). Undefined for local browsers. This removes the need for out-of-band session-id recovery (metadata markers, session listing) when persisting sessions for reconnect.

--- a/packages/sdk-ts/src/browser/factories.ts
+++ b/packages/sdk-ts/src/browser/factories.ts
@@ -262,6 +262,7 @@ async function connectBrowser(options: {
     return createStagehandBrowserHandle({
       provider: options.provider,
       origin: options.origin,
+      sessionId: options.workerInitMetadata.browser?.sessionId,
       attachment: {
         cdpClient: connectedClient,
         workerInitMetadata: options.workerInitMetadata,

--- a/packages/sdk-ts/src/browser/index.ts
+++ b/packages/sdk-ts/src/browser/index.ts
@@ -28,6 +28,8 @@ export interface StagehandBrowser {
   readonly [stagehandBrowserBrand]: true;
   readonly provider: StagehandBrowserProvider;
   readonly origin: StagehandBrowserOrigin;
+  /** Browserbase session id backing this browser; undefined for local browsers. */
+  readonly sessionId?: string;
   readonly context: BrowserContext;
   readonly closed: boolean;
   close(): Promise<void>;
@@ -60,6 +62,7 @@ class StagehandBrowserHandle implements StagehandBrowser {
     readonly provider: StagehandBrowserProvider,
     readonly origin: StagehandBrowserOrigin,
     internals: BrowserHandleInternals,
+    readonly sessionId?: string,
   ) {
     browserHandleInternals.set(this, internals);
   }
@@ -91,12 +94,18 @@ export function createStagehandBrowserHandle<Attachment>(options: {
   origin: StagehandBrowserOrigin;
   attachment: Attachment;
   close: () => Promise<void> | void;
+  sessionId?: string;
 }): StagehandBrowser {
-  return new StagehandBrowserHandle(options.provider, options.origin, {
-    claimed: false,
-    attachment: options.attachment,
-    close: options.close,
-  });
+  return new StagehandBrowserHandle(
+    options.provider,
+    options.origin,
+    {
+      claimed: false,
+      attachment: options.attachment,
+      close: options.close,
+    },
+    options.sessionId,
+  );
 }
 
 /** @internal */


### PR DESCRIPTION
Adds a readonly `sessionId` to `StagehandBrowser` for Browserbase-backed handles (`browserbase.launch` / `browserbase.connect`); undefined for local browsers. The id was already threaded internally through the worker init metadata — this only surfaces it.

**Why:** integration examples that persist sessions for reconnect-after-restart (Eve native tools in #2666, managed deep agents in #2653) currently have to recover the id out-of-band — stamping a `userMetadata` marker at launch and querying `sessions.list` — because the handle doesn't expose it. With this, that workaround collapses to `browser.sessionId`.

**Scope:** two files (`browser/index.ts`, `browser/factories.ts`) + changeset. No behavior change; purely additive surface. Gate: build, typecheck, 186/186 unit tests.

**Port parity:** TS is the contract — Python/Go should mirror (`session_id` on the Python browser handle) in follow-ups; the Python managed-deepagents example has the same workaround to delete.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a readonly `sessionId` to `StagehandBrowser` handles for Browserbase-backed browsers (`browserbase.launch` / `browserbase.connect`). It’s undefined for local browsers and makes reconnect-after-restart flows simpler.

- **New Features**
  - Access the Browserbase session id via `browser.sessionId`; avoids metadata markers + `sessions.list`.
  - Purely additive API; no behavior changes.

<sup>Written for commit 33bb0544e1d1cd4e06021d9892d234ee5760a7b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

