### PR TITLE
feat(sdk-python): expose session_id on Browserbase browser handles

### DIFF
--- a/packages/sdk-python/src/stagehand/browser.py
+++ b/packages/sdk-python/src/stagehand/browser.py
@@ -102,6 +102,7 @@ class StagehandBrowser:
         "_context",
         "_origin",
         "_provider",
+        "_session_id",
     )
 
     def __init__(
@@ -111,6 +112,7 @@ class StagehandBrowser:
         attachment: _ClaimedBrowser,
         close: Callable[[], Awaitable[None]],
         *,
+        session_id: str | None = None,
         _token: object | None = None,
     ) -> None:
         if _token is not _BROWSER_TOKEN:
@@ -122,6 +124,7 @@ class StagehandBrowser:
         self._claimed = False
         self._close_task: asyncio.Task[None] | None = None
         self._context: BrowserContext | None = None
+        self._session_id = session_id
 
     @property
     def provider(self) -> Literal["local", "browserbase"]:
@@ -130,6 +133,11 @@ class StagehandBrowser:
     @property
     def origin(self) -> Literal["launched", "connected"]:
         return self._origin
+
+    @property
+    def session_id(self) -> str | None:
+        """Browserbase session id backing this browser; None for local browsers."""
+        return self._session_id
 
     @property
     def closed(self) -> bool:
@@ -296,6 +304,9 @@ async def _connect_browser(
             worker_init_metadata=worker_init_metadata,
         ),
         close,
+        session_id=(
+            worker_init_metadata.browser.session_id if worker_init_metadata.browser else None
+        ),
         _token=_BROWSER_TOKEN,
     )
 


### PR DESCRIPTION
Python port of #2672 (TS is the contract; this mirrors it exactly): readonly `session_id` property on `StagehandBrowser`, populated from the worker init metadata for Browserbase launch/connect, `None` for local browsers.

Kills the out-of-band session-id recovery in the managed deep-agents example (#2653), same as #2672 does for the Eve example (#2666).

Gate: ruff format/check, ty check, 457 passed / 1 skipped.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a read-only session_id property to StagehandBrowser in `sdk-python`, populated from worker init metadata for Browserbase and None for local. This lets clients persist the Browserbase session ID for reconnects without out-of-band recovery.

<sup>Written for commit dad895e8487d4d2d20b444f0dda8bff5ef46cb56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

