### PR TITLE
feat(sdk-go): expose SessionID on Browserbase browser handles

### DIFF
--- a/packages/sdk-go/browser.go
+++ b/packages/sdk-go/browser.go
@@ -65,6 +65,15 @@ func (browser *Browser) Origin() BrowserOrigin {
 	return browser.origin
 }
 
+// SessionID returns the Browserbase session id backing this browser, or an
+// empty string for local browsers.
+func (browser *Browser) SessionID() string {
+	if browser == nil || browser.workerBrowser == nil {
+		return ""
+	}
+	return browser.workerBrowser.SessionID
+}
+
 // Closed reports whether browser teardown has been requested.
 func (browser *Browser) Closed() bool {
 	if browser == nil {


### PR DESCRIPTION
Go port of #2672 (TS contract) alongside the Python port #2673: nil-safe `SessionID()` accessor on `Browser`, sourced from the worker session metadata the handle already carries; empty string for local browsers.

Gate: gofmt clean, go vet clean, package tests pass (examples build failure in `go test ./...` is pre-existing on v4-spike; `scripts/check-examples.sh` passes).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a nil-safe `SessionID()` method to the Go SDK `Browser` to get the Browserbase session ID. It returns an empty string for local browsers or when the handle is nil.

<sup>Written for commit 72f3cb25ca43ef7cd32b6f39e91057e8325653c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

