### PR TITLE
test(evals): relax core config CLI timeout

### DIFF
--- a/packages/evals/tests/cli.test.ts
+++ b/packages/evals/tests/cli.test.ts
@@ -346,7 +346,7 @@ describe.sequential("core config", () => {
     expect(code).toBe(0);
     const payload = JSON.parse(stdout);
     expect(payload.runOptions.coreToolSurface).toBe("understudy_code");
-  });
+  }, 15_000);
 
   it("rejects unknown tool", async () => {
     resetConfig();


### PR DESCRIPTION
## Summary
- give the persisted `core.tool` dry-run test a 15-second timeout
- keep the adjustment local to the two-subprocess test

The full-suite CI run took 5.025s for this test, just over Vitest’s 5-second default. Adjacent multi-process CLI tests already use explicit 15–30 second timeouts.

## Test plan
- `pnpm exec vitest run packages/evals/tests/cli.test.ts` (61 passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase timeout to 15s for the persisted `core.tool` dry-run CLI test to avoid CI flakiness from the 5s Vitest default. The change is local to that multi-process test only.

<sup>Written for commit 82c5f3618b61139cc6440ff71efce1f6b0de4564. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

