### PR TITLE
feat(sdk-ts): env overrides for extension asset paths

### DIFF
--- a/.changeset/extension-asset-env.md
+++ b/.changeset/extension-asset-env.md
@@ -2,4 +2,4 @@
 "@browserbasehq/stagehand": patch
 ---
 
-Allow overriding the extension asset locations via `STAGEHAND_EXTENSION_ARCHIVE_PATH` and `STAGEHAND_EXTENSION_DIRECTORY_PATH` environment variables. Bundlers that inline the SDK (nitro, eve) re-anchor `import.meta.url`, breaking the derived paths; the env vars let hosts point at the real installed assets.
+Allow overriding the extension asset locations via `STAGEHAND_EXTENSION_ARCHIVE_PATH` and `STAGEHAND_EXTENSION_DIRECTORY_PATH`

--- a/packages/sdk-ts/src/extensionAssets.ts
+++ b/packages/sdk-ts/src/extensionAssets.ts
@@ -6,10 +6,15 @@ const packageRoot = new URL("../", import.meta.url);
 // compiler) that inline this module and re-anchor import.meta.url away from
 // the installed package, leaving the derived paths pointing at files the
 // bundle does not carry.
+function nonEmpty(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
 export const STAGEHAND_EXTENSION_ARCHIVE_PATH =
-  process.env.STAGEHAND_EXTENSION_ARCHIVE_PATH ??
+  nonEmpty(process.env.STAGEHAND_EXTENSION_ARCHIVE_PATH) ??
   fileURLToPath(new URL("dist/assets/stagehand-extension.zip", packageRoot));
 
 export const STAGEHAND_EXTENSION_DIRECTORY_PATH =
-  process.env.STAGEHAND_EXTENSION_DIRECTORY_PATH ??
+  nonEmpty(process.env.STAGEHAND_EXTENSION_DIRECTORY_PATH) ??
   fileURLToPath(new URL("dist/extension/", packageRoot));


### PR DESCRIPTION
Small targeted change: `STAGEHAND_EXTENSION_ARCHIVE_PATH` / `STAGEHAND_EXTENSION_DIRECTORY_PATH` env overrides for the two derived asset constants.

**Why:** bundlers that inline the SDK re-anchor `import.meta.url`, breaking the derived paths. Hit twice in the Eve integration: `eve build` (nitro bundle missing the zip → 'Failed to upload the Stagehand extension') and now `eve dev` (authored-module bundle → CDP `Extensions.loadUnpacked` fails with 'File path cannot be resolved' for local browsers). The env override is the standard escape hatch; the Eve example sets them from a tiny wrapper that resolves the real installed paths outside any bundle.

Gate: build, typecheck, 186/186 unit tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds env overrides for extension asset paths in `@browserbasehq/stagehand` so bundled builds can point to real assets. Trims whitespace so empty override values are ignored.

- **New Features**
  - Support `STAGEHAND_EXTENSION_ARCHIVE_PATH` and `STAGEHAND_EXTENSION_DIRECTORY_PATH` via `process.env`, falling back to `import.meta.url`-derived paths when unset or blank.

<sup>Written for commit c6145486622b1e57e3858c7ced45d6d1fab3468a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

