### PR TITLE
fix(core): detect Bedrock Anthropic model IDs

### DIFF
--- a/.changeset/bedrock-anthropic-provider-options.md
+++ b/.changeset/bedrock-anthropic-provider-options.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Fix provider-specific structured-output options for Anthropic models routed through AWS Bedrock.

--- a/packages/core/lib/v3/llm/aisdk.ts
+++ b/packages/core/lib/v3/llm/aisdk.ts
@@ -29,6 +29,16 @@ type ProviderOptionMap = Record<string, ProviderOptionValue>;
 
 function inferProviderName(modelId: string): string | undefined {
   const [providerName] = modelId.split("/");
+  if (providerName !== modelId) {
+    return providerName || undefined;
+  }
+
+  // Bedrock model IDs use `vendor.model` or `region.vendor.model` instead of
+  // the `provider/model` format used by the other AI SDK providers.
+  if (/^(?:[a-z0-9-]+\.)?anthropic\./i.test(modelId)) {
+    return "anthropic";
+  }
+
   return providerName || undefined;
 }
 

--- a/packages/core/tests/unit/aisdk-clients.test.ts
+++ b/packages/core/tests/unit/aisdk-clients.test.ts
@@ -40,6 +40,11 @@ describe("AISdkClient structured output provider options", () => {
 
   it.each([
     ["openai/gpt-4.1", { openai: { strictJsonSchema: true } }],
+    ["anthropic.claude-3", { anthropic: { structuredOutputMode: "auto" } }],
+    [
+      "us.anthropic.claude-sonnet-4-6[1m]",
+      { anthropic: { structuredOutputMode: "auto" } },
+    ],
     ["azure/gpt-4.1", { azure: { strictJsonSchema: true } }],
     ["google/gemini-2.5-pro", { google: { structuredOutputs: true } }],
     ["vertex/gemini-2.5-pro", { vertex: { structuredOutputs: true } }],


### PR DESCRIPTION
Fixes #2565

`AISdkClient` infers provider-specific options from the model ID. AWS Bedrock Anthropic IDs use `anthropic.<model>` or `region.anthropic.<model>`, so they do not match the existing `provider/model` format and miss Anthropic's `structuredOutputMode: "auto"` option.

This change:

- recognizes raw and cross-region Bedrock Anthropic model IDs
- leaves the existing slash-separated and legacy model ID behavior unchanged
- adds regression coverage for both Bedrock ID shapes
- includes a patch changeset for `@browserbasehq/stagehand`

Verification:

- Prettier check passed
- ESLint passed for the changed TypeScript files
- TypeScript typecheck passed
- ESM and CJS builds passed
- Focused Vitest suite passed (12 tests)
