### PR TITLE
[docs]: add experimental note to batch docs

### DIFF
--- a/packages/docs/v4/reference/stagehand.mdx
+++ b/packages/docs/v4/reference/stagehand.mdx
@@ -68,6 +68,8 @@ Operations made through the supplied batch context route directly through the wo
 SDK-to-browser round trip for every command.
 
 <Note>
+  This API is experimental and can change in patch releases.
+
   Batch callbacks execute in the Stagehand service worker, not the webpage. Treat callback source
   as application code rather than untrusted input.
 </Note>
@@ -869,6 +871,8 @@ Python-to-browser round trip for every command. Python source is not translated 
 this method accepts an explicit JavaScript function string.
 
 <Note>
+  This API is experimental and can change in patch releases.
+
   Batch callbacks execute in the Stagehand service worker, not the webpage. Treat callback source
   as application code rather than untrusted input.
 </Note>
@@ -1657,6 +1661,8 @@ Go-to-browser round trip for every command. Go source is not translated to JavaS
 accepts an explicit JavaScript function string.
 
 <Note>
+  This API is experimental and can change in patch releases.
+
   Batch callbacks execute in the Stagehand service worker, not the webpage. Treat callback source
   as application code rather than untrusted input.
 </Note>


### PR DESCRIPTION
# what changed
- adds a note explaining that the experimental batch api can change in patch releases


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an “experimental” note to the batch API docs to clarify that the API may change in patch releases. The note is added to the JS, Python, and Go batch sections to set expectations consistently.

<sup>Written for commit d7eeeb46149830f6ab9c225fca15572f5711391b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

