### PR TITLE
fix(integrations): restore Eve catalog wiring

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -601,6 +601,34 @@ importers:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.1)(yaml@2.9.0))
 
+  packages/integrations/eve:
+    dependencies:
+      '@ai-sdk/openai':
+        specifier: 'catalog:'
+        version: 4.0.8(zod@4.4.3)
+      '@browserbasehq/stagehand':
+        specifier: workspace:*
+        version: link:../../sdk-ts
+      '@browserbasehq/stagehand-integrations':
+        specifier: workspace:*
+        version: link:../core
+      dotenv:
+        specifier: 'catalog:'
+        version: 17.4.2
+      eve:
+        specifier: 'catalog:'
+        version: 0.29.4(@opentelemetry/api@1.9.1)(ai@7.0.16(zod@4.4.3))(aws4fetch@1.0.20)(dotenv@17.4.2)(jiti@1.21.7)(lru-cache@11.5.2)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.1)(yaml@2.9.0))(xml2js@0.6.2)
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.2
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.1)(yaml@2.9.0))
+
   packages/integrations/mastra:
     dependencies:
       '@ai-sdk/openai':
@@ -7231,6 +7259,13 @@ packages:
     resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
+  undici@8.9.0:
+    resolution: {integrity: sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==}
+    engines: {node: '>=22.19.0'}
+
+  unenv@2.0.0-rc.24:
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
+
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
@@ -11440,10 +11475,10 @@ snapshots:
 
   etag@1.8.1: {}
 
-  eve@0.29.4(@opentelemetry/api@1.9.1)(ai@7.0.16(zod@4.4.3))(aws4fetch@1.0.20)(dotenv@17.4.2)(jiti@1.21.7)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.1)(yaml@2.9.0))(xml2js@0.6.2):
+  eve@0.29.4(@opentelemetry/api@1.9.1)(ai@7.0.16(zod@4.4.3))(aws4fetch@1.0.20)(dotenv@17.4.2)(jiti@1.21.7)(lru-cache@11.5.2)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.1)(yaml@2.9.0))(xml2js@0.6.2):
     dependencies:
       ai: 7.0.16(zod@4.4.3)
-      nitro: 3.0.260610-beta(aws4fetch@1.0.20)(dotenv@17.4.2)(jiti@1.21.7)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.1)(yaml@2.9.0))(xml2js@0.6.2)
+      nitro: 3.0.260610-beta(aws4fetch@1.0.20)(dotenv@17.4.2)(jiti@1.21.7)(lru-cache@11.5.2)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.1)(yaml@2.9.0))(xml2js@0.6.2)
       undici: 8.9.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -13442,7 +13477,7 @@ snapshots:
       jsonpath-plus: 10.4.0
       lodash.topath: 4.5.2
 
-  nitro@3.0.260610-beta(aws4fetch@1.0.20)(dotenv@17.4.2)(jiti@1.21.7)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.1)(yaml@2.9.0))(xml2js@0.6.2):
+  nitro@3.0.260610-beta(aws4fetch@1.0.20)(dotenv@17.4.2)(jiti@1.21.7)(lru-cache@11.5.2)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.23.1)(yaml@2.9.0))(xml2js@0.6.2):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.10(srvx@0.11.22)
@@ -13457,7 +13492,7 @@ snapshots:
       rolldown: 1.1.5
       srvx: 0.11.22
       unenv: 2.0.0-rc.24
-      unstorage: 2.0.0-alpha.7(aws4fetch@1.0.20)(db0@0.3.4)(ofetch@2.0.0-alpha.3)
+      unstorage: 2.0.0-alpha.7(aws4fetch@1.0.20)(db0@0.3.4)(lru-cache@11.5.2)(ofetch@2.0.0-alpha.3)
     optionalDependencies:
       dotenv: 17.4.2
       jiti: 1.21.7
@@ -15306,6 +15341,12 @@ snapshots:
 
   undici@7.29.0: {}
 
+  undici@8.9.0: {}
+
+  unenv@2.0.0-rc.24:
+    dependencies:
+      pathe: 2.0.3
+
   unicorn-magic@0.3.0: {}
 
   unified@11.0.5:
@@ -15404,10 +15445,11 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unstorage@2.0.0-alpha.7(aws4fetch@1.0.20)(db0@0.3.4)(ofetch@2.0.0-alpha.3):
+  unstorage@2.0.0-alpha.7(aws4fetch@1.0.20)(db0@0.3.4)(lru-cache@11.5.2)(ofetch@2.0.0-alpha.3):
     optionalDependencies:
       aws4fetch: 1.0.20
       db0: 0.3.4
+      lru-cache: 11.5.2
       ofetch: 2.0.0-alpha.3
 
   urijs@1.19.11: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,6 +33,7 @@ catalog:
   "@mastra/core": ^1.55.0
   "@mastra/mcp": ^1.15.0
   "@ai-sdk/mcp": 2.0.22
+  eve: 0.29.4
   "@ai-sdk/provider": ^4.0.2
   "@ai-sdk/openai": ^4.0.8
   "@ai-sdk/anthropic": ^4.0.8


### PR DESCRIPTION
## Summary

- restore the Eve dependency entry that was dropped from the root pnpm catalog during stacked-PR conflict resolution
- regenerate the lockfile so the Eve workspace importer and required transitive entries are present

## E2E Test Matrix

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `corepack pnpm install --lockfile-only --no-runtime --ignore-scripts` | Resolved all 12 workspace projects and exited 0; before the fix, the same command failed with `ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC` for `eve`. | Directly proves a normal lockfile update can resolve the merged Eve package. |
| `corepack pnpm install --frozen-lockfile --no-runtime --ignore-scripts` | Reported the lockfile up to date and installed 1,367 packages successfully. | Proves a clean frozen install accepts the repaired catalog and lockfile. |
| `corepack pnpm -w exec turbo run build --filter @browserbasehq/stagehand-integrations` | 4/4 build tasks succeeded. | Proves the exact local integration package dependency chain builds. |
| `corepack pnpm --filter @browserbasehq/stagehand-integrations-example-eve-facade typecheck` | `tsc --noEmit` exited 0. | Proves the Eve example typechecks against the repaired workspace. |
| `corepack pnpm --filter @browserbasehq/stagehand-integrations-example-eve-facade test` | 1 test file passed; 5/5 tests passed. | Proves the Eve contract and tool tests still pass. |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the missing `eve` catalog entry to fix pnpm install failures and unblock the Eve integration. Regenerates the lockfile so `packages/integrations/eve` resolves and builds cleanly, aligning with STG-2808.

- **Bug Fixes**
  - Added `eve: 0.29.4` to the root `catalog` in `pnpm-workspace.yaml` (STG-2808).
  - Regenerated `pnpm-lock.yaml` to include the Eve importer and required transitive updates (e.g., `undici@8.9.0`, `unenv@2.0.0-rc.24`, updated `nitro`/`unstorage` snapshots).

<sup>Written for commit 39be0188e9772d272643723fbb414e171df38e2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

