### PR TITLE
docs(integrations): rewrite codemode integration guides

### DIFF
--- a/packages/integrations/README.md
+++ b/packages/integrations/README.md
@@ -1,8 +1,93 @@
-# Stagehand integrations
+# Stagehand codemode integrations
 
-Private workspace package for Stagehand integration adapters.
+Bring Stagehand's codemode browser tools to CrewAI, Deep Agents, Eve, Mastra, and the Vercel AI SDK. Every integration gives an agent the same small, stateful tool surface while keeping browser control inside Stagehand.
 
-The code-mode stdio entrypoint currently provides the MCP host and process lifecycle used by later code-mode capabilities. It intentionally advertises no tools yet.
+> [!IMPORTANT]
+> These are experimental workspace integrations. Run them from this repository; the integration packages are not published as standalone adapters.
 
-The `deepagents/` Python project provides local and managed LangChain Deep Agents integrations. Both
-expose stateful `run`, `snapshot`, and `screenshot` browser tools using the Stagehand Python SDK.
+## What the agent gets
+
+| Tool         | Use it to                                                                                                                             |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `run`        | Execute JavaScript against a Playwright-shaped `page`, `context`, and `browser`, or batch actions using IDs from the latest snapshot. |
+| `snapshot`   | Read the active page's compact accessibility tree and hydrate element IDs for the next action.                                        |
+| `screenshot` | Inspect the active page as a PNG or JPEG.                                                                                             |
+
+The three tools share one persistent browser. Snapshot IDs belong to the latest snapshot of the active page, so take a new snapshot after navigation or when an ID becomes stale.
+
+## Choose an integration
+
+| Framework                              | Directory     | Connection                                        | Language   |
+| -------------------------------------- | ------------- | ------------------------------------------------- | ---------- |
+| [CrewAI](./crewai/README.md)           | `crewai/`     | MCP over stdio                                    | Python     |
+| [Deep Agents](./deepagents/README.md)  | `deepagents/` | MCP over stdio locally; native tools when managed | Python     |
+| [Eve](./eve/README.md)                 | `eve/`        | Native in-process tools                           | TypeScript |
+| [Mastra](./mastra/README.md)           | `mastra/`     | MCP over stdio                                    | TypeScript |
+| [Vercel AI SDK](./vercel-ai/README.md) | `vercel-ai/`  | MCP over stdio                                    | TypeScript |
+
+Use the MCP examples when your framework already supports MCP and you want a portable tool contract. Use a native integration when you want one process and direct control over browser-session ownership.
+
+The shared TypeScript implementation lives in `core/`. It provides both the in-process tools and the stdio MCP server used by the examples.
+
+## Build from source
+
+You need Node.js 24 or newer and pnpm 11.10.0. CrewAI and Deep Agents also require Python 3.11–3.13 and [uv](https://docs.astral.sh/uv/).
+
+From the repository root:
+
+```bash
+corepack pnpm@11.10.0 install --frozen-lockfile
+corepack pnpm@11.10.0 exec turbo run build \
+  --filter @browserbasehq/stagehand-integrations
+```
+
+Then open the README for your framework and run its quickstart.
+
+## Configure Stagehand
+
+The TypeScript integrations use these shared variables. Deep Agents uses `STAGEHAND_MODEL` instead of `STAGEHAND_MODEL_NAME`; see its README for the Python-specific configuration.
+
+| Variable                  | Purpose                                                                                                                  |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `STAGEHAND_BROWSER`       | `local` or `browserbase`. Defaults to Browserbase when `BROWSERBASE_API_KEY` is set; otherwise defaults to local Chrome. |
+| `BROWSERBASE_API_KEY`     | Required for the Browserbase backend.                                                                                    |
+| `BROWSERBASE_PROJECT_ID`  | Optional Browserbase project ID.                                                                                         |
+| `STAGEHAND_MODEL_NAME`    | Optional model for Stagehand AI methods called inside `run`.                                                             |
+| `STAGEHAND_MODEL_API_KEY` | Optional key for `STAGEHAND_MODEL_NAME`. The matching provider key is inferred when supported.                           |
+
+Each framework has a separate variable for the agent's model. The agent model decides which tool to call; the optional Stagehand model powers AI methods such as `act`, `extract`, or `observe` when code passed to `run` uses them.
+
+## How agents use the tools
+
+For deterministic navigation or multi-step work, call `run` with JavaScript:
+
+```json
+{
+  "code": "await page.goto('https://example.com'); return await page.title();"
+}
+```
+
+For a simple interaction, take a snapshot and pass its bracketed ID back to `run`:
+
+```json
+{
+  "actions": [{ "op": "click", "id": "1-42" }]
+}
+```
+
+`run` accepts exactly one of `code` or `actions`. Supported snapshot actions are `click`, `hover`, `fill`, `type`, `press`, and `select`.
+
+## Security boundary
+
+`run` executes model-authored JavaScript inside the Stagehand browser extension's service worker, not inside the agent host process. That code can control the browser and access data available to the browser, so treat it as privileged browser automation.
+
+Browserbase is the recommended isolation boundary for untrusted tasks because the browser is disposable and separate from the host machine. The MCP examples forward only `STAGEHAND_*` and `BROWSERBASE_*` configuration to the child process; agent-model credentials stay in the framework process.
+
+## Develop and verify
+
+Each framework README includes its exact test and smoke-test commands. For the shared TypeScript implementation, run:
+
+```bash
+corepack pnpm@11.10.0 exec turbo run typecheck test:unit \
+  --filter @browserbasehq/stagehand-integrations
+```

--- a/packages/integrations/crewai/README.md
+++ b/packages/integrations/crewai/README.md
@@ -1,54 +1,80 @@
-# CrewAI + Stagehand facade over MCP/stdio
+# CrewAI + Stagehand codemode tools
 
-This example connects CrewAI, via a screenshot-preserving subclass of `crewai-tools`' MCP
-adapter, to the Stagehand facade MCP server over stdio. It exposes the facade's `run`,
-`snapshot`, and `screenshot` tools to a CrewAI agent.
+Give a CrewAI agent one persistent Stagehand browser through the `run`, `snapshot`, and `screenshot` tools. CrewAI connects to the shared codemode tool server over MCP/stdio, so browser state survives across tool calls.
 
-## Setup
+## Prerequisites
 
-Node.js 24+ and [uv](https://docs.astral.sh/uv/) are required. From the repository root, build
-the integrations package first so its dist server entrypoint exists:
+- Node.js 24 or newer
+- pnpm 11.10.0
+- Python 3.11–3.13
+- [uv](https://docs.astral.sh/uv/)
 
-```sh
-pnpm install
-pnpm exec turbo run build --filter @browserbasehq/stagehand-integrations
+## Quickstart
+
+Build the Stagehand workspace from the repository root:
+
+```bash
+corepack pnpm@11.10.0 install --frozen-lockfile
+corepack pnpm@11.10.0 exec turbo run build \
+  --filter @browserbasehq/stagehand-integrations
 ```
 
-Then install the Python dependencies:
+Install the CrewAI example:
 
-```sh
+```bash
 cd packages/integrations/crewai
-uv sync
+uv sync --locked
 ```
 
-| Variable                                           | Purpose                                                                                                                                                               |
-| -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `STAGEHAND_BROWSER`                                | Browser backend. Defaults to `browserbase` when `BROWSERBASE_API_KEY` is set, otherwise `local`.                                                                      |
-| `BROWSERBASE_API_KEY`                              | Browserbase API key.                                                                                                                                                  |
-| `BROWSERBASE_PROJECT_ID`                           | Browserbase project ID.                                                                                                                                               |
-| `STAGEHAND_MODEL_NAME` / `STAGEHAND_MODEL_API_KEY` | Model used by the facade server and its key.                                                                                                                          |
-| `CREWAI_MODEL`                                     | CrewAI agent model; defaults to `openai/gpt-5.6-luna`.                                                                                                                |
-| `OPENAI_API_KEY`                                   | Used by the CrewAI agent model in the host process; NOT forwarded to the facade child process (the child env is an explicit `STAGEHAND_*`/`BROWSERBASE_*` allowlist). |
+Set the credential for your CrewAI model. The example defaults to an OpenAI model:
 
-## Run
+```bash
+export OPENAI_API_KEY="your-key"
+export CREWAI_MODEL="openai/gpt-5.6-luna"
+```
 
-From `packages/integrations/crewai/`:
+Run a browser task:
 
-```sh
+```bash
+uv run python agent.py \
+  "Open https://example.com and report the page title."
+```
+
+Local Chrome is the default. To run the browser on Browserbase:
+
+```bash
+export STAGEHAND_BROWSER="browserbase"
+export BROWSERBASE_API_KEY="your-key"
+```
+
+## Configuration
+
+| Variable                  | Purpose                                                                   |
+| ------------------------- | ------------------------------------------------------------------------- |
+| `CREWAI_MODEL`            | CrewAI agent model. Defaults to `openai/gpt-5.6-luna`.                    |
+| `OPENAI_API_KEY`          | Credential for the default CrewAI model. It stays in the CrewAI process.  |
+| `STAGEHAND_BROWSER`       | `local` or `browserbase`. Inferred from `BROWSERBASE_API_KEY` when unset. |
+| `BROWSERBASE_API_KEY`     | Required for Browserbase.                                                 |
+| `BROWSERBASE_PROJECT_ID`  | Optional Browserbase project ID.                                          |
+| `STAGEHAND_MODEL_NAME`    | Optional model for Stagehand AI methods used inside `run`.                |
+| `STAGEHAND_MODEL_API_KEY` | Optional key for `STAGEHAND_MODEL_NAME`.                                  |
+
+## Verify the integration
+
+The contract tests start the real stdio server and need no browser or API key:
+
+```bash
 uv run pytest
-uv run python agent.py "your instruction"
 ```
+
+The quickstart command above is the live browser smoke test.
 
 ## Screenshots
 
-CrewAI's tool loop is text-only in this version, and `crewai-tools`' MCP adapter drops MCP image
-blocks. This example saves each screenshot to a temporary file and returns its path to the agent;
-open the file to inspect it.
+CrewAI's current tool loop is text-only, and its standard MCP adapter drops image blocks. This example preserves screenshots by writing each image to a temporary file and returning the file path to the agent. Open that path to inspect the image.
 
-## Security model
+## Security boundary
 
-`run(code)` executes model-authored JavaScript in the extension service worker:
-it runs browser-side, never in the host process. Browserbase is the
-recommended isolation boundary. The Python host process spawns the facade server
-(a Node child process) and holds only the MCP connection; model-authored JavaScript
-does not execute inside the host process.
+`run` executes model-authored JavaScript inside the Stagehand browser extension's service worker, not in the CrewAI process. The MCP child receives only `STAGEHAND_*` and `BROWSERBASE_*` variables; provider credentials such as `OPENAI_API_KEY` are not forwarded.
+
+Use Browserbase as the isolation boundary for untrusted tasks. The browser can still reach any page or data available inside its own session.

--- a/packages/integrations/deepagents/README.md
+++ b/packages/integrations/deepagents/README.md
@@ -1,109 +1,101 @@
-# Stagehand Deep Agents integration
+# Deep Agents + Stagehand codemode tools
 
-This local integration exposes one stateful Stagehand browser to LangChain Deep Agents through a
-stdio MCP server. Its complete tool surface is `run`, `snapshot`, and `screenshot`.
+Give a LangChain Deep Agent the `run`, `snapshot`, and `screenshot` tools backed by one persistent Stagehand browser.
 
-## Run locally
+This directory includes two deployment patterns:
 
-Set a model-provider key and select the Deep Agents model:
+| Example             | Tool connection     | Browser lifecycle                          |
+| ------------------- | ------------------- | ------------------------------------------ |
+| `examples/local/`   | MCP over stdio      | One browser for the MCP client session     |
+| `examples/managed/` | Native Python tools | One Browserbase runtime per managed thread |
 
-```bash
-export OPENAI_API_KEY=...
-export DEEPAGENTS_MODEL=openai:gpt-5.6-luna
-```
+## Prerequisites
 
-The MCP server launches a visible local Chrome browser by default. Then run:
+- Python 3.11–3.13
+- [uv](https://docs.astral.sh/uv/)
+- A model-provider credential for the Deep Agent
+- A Browserbase API key for the managed example or optional local Browserbase use
+
+## Run the local example
+
+From the repository root:
 
 ```bash
 cd packages/integrations/deepagents
-uv run --project examples/local python examples/local/agent.py
+uv sync --locked
+uv sync --project examples/local --locked
 ```
 
-The model, instruction, and Pydantic response classes are declared directly in `agent.py` so the
-example can be edited and rerun without passing command-line arguments. Set `response_format` to a
-Pydantic model class for structured output, or `None` for the normal text response.
-
-`agents2.py` is a form-filling example inspired by Stagehand's sensible form-filling example. The
-Deep Agent navigates to the form, snapshots it, fills the requested fields with mock data, and
-returns a typed Pydantic summary without submitting the form:
+Set the credential for the model declared in `examples/local/agent.py`, then run it:
 
 ```bash
-uv run --project examples/local python examples/local/agents2.py
+export OPENAI_API_KEY="your-key"
+uv run --project examples/local --locked \
+  python examples/local/agent.py
 ```
 
-To use Browserbase instead:
+The example keeps the model, task, and optional Pydantic response schema in `agent.py` so you can edit and rerun one file. `agents2.py` is a structured-output form-filling example that uses mock data and does not submit the form.
+
+Local Chrome is visible by default. To use Browserbase instead:
 
 ```bash
-export STAGEHAND_BROWSER=browserbase
-export BROWSERBASE_API_KEY=...
-uv run --project examples/local python examples/local/agent.py
+export STAGEHAND_BROWSER="browserbase"
+export BROWSERBASE_API_KEY="your-key"
+uv run --project examples/local --locked \
+  python examples/local/agent.py
 ```
 
-Browserbase sessions use a 1280 × 720 viewport by default.
+## Local server configuration
 
-The server and client intentionally use separate Python environments. Stagehand currently requires
-`websockets>=16.1.1`, while the current LangGraph SDK used by Deep Agents requires `websockets<16`.
-The stdio transport isolates those dependency sets.
+| Variable                   | Default | Purpose                                                    |
+| -------------------------- | ------- | ---------------------------------------------------------- |
+| `STAGEHAND_BROWSER`        | `local` | `local` or `browserbase`.                                  |
+| `STAGEHAND_HEADLESS`       | `false` | Run local Chrome headlessly.                               |
+| `STAGEHAND_START_URL`      | Unset   | Open a URL when the MCP server starts.                     |
+| `STAGEHAND_MODEL`          | Unset   | Optional model for Stagehand AI methods used inside `run`. |
+| `STAGEHAND_MODEL_API_KEY`  | Unset   | Optional key for `STAGEHAND_MODEL`.                        |
+| `STAGEHAND_API_URL`        | Unset   | Optional Stagehand Model Gateway URL.                      |
+| `STAGEHAND_RUN_TIMEOUT_MS` | `60000` | Timeout for JavaScript and action batches.                 |
+| `BROWSERBASE_API_KEY`      | Unset   | Required for Browserbase.                                  |
 
-The example deliberately creates a persistent MCP `ClientSession`. Do not replace it with
-`MultiServerMCPClient.get_tools()`: the default stateless tools create a new stdio process for each
-call and therefore lose the browser and snapshot IDs.
+The server and client intentionally use separate Python environments. Stagehand requires `websockets>=16.1.1`, while the current LangGraph SDK used by Deep Agents requires `websockets<16`; stdio keeps those dependency sets isolated.
 
-## Server configuration
+The example also holds one persistent MCP `ClientSession`. Do not replace it with stateless `MultiServerMCPClient.get_tools()` calls: a new stdio process per call would lose the browser and snapshot IDs.
 
-| Variable                   | Default | Meaning                                                  |
-| -------------------------- | ------- | -------------------------------------------------------- |
-| `STAGEHAND_BROWSER`        | `local` | `local` or `browserbase`                                 |
-| `STAGEHAND_HEADLESS`       | `false` | Headless local Chrome                                    |
-| `STAGEHAND_START_URL`      | unset   | Optional URL opened when the server starts               |
-| `STAGEHAND_MODEL`          | unset   | Optional model used by Stagehand AI methods inside `run` |
-| `STAGEHAND_RUN_TIMEOUT_MS` | `60000` | Callback-batch timeout                                   |
-| `BROWSERBASE_API_KEY`      | unset   | Required for Browserbase                                 |
+## Deploy the managed example
 
-`run` accepts exactly one of JavaScript `code` or snapshot `actions`. JavaScript executes against
-the Playwright-shaped `page`, `context`, and `browser` facade. Snapshot actions use bracketed IDs
-from the most recent `snapshot` call.
-
-## Managed Deep Agents
-
-The managed example lives in `examples/managed`. Its authored LangChain tools run the Python
-Stagehand SDK directly and expose the same `run`, `snapshot`, and `screenshot` contract. The managed
-thread ID is injected by `ToolRuntime` and scopes an in-process Browserbase runtime; it is not
-exposed to the model.
-
-The current LangGraph SDK requires `websockets<16`, while Stagehand declares `websockets>=16.1.1`.
-For this spike, the managed project overrides the shared dependency to `websockets==15.0.1`. Remove
-the override once the SDK ranges converge. Browser continuity is guaranteed while the managed
-worker remains warm; durable reconnection after worker replacement is future work.
-
-### Develop and deploy the managed agent
-
-From `examples/managed`, copy `.env.example` to `.env` and configure:
-
-- `DEEPAGENTS_MODEL` and the matching provider key, such as `OPENAI_API_KEY`.
-- `BROWSERBASE_API_KEY` for the hosted browser.
-- Either `STAGEHAND_API_URL` for Browserbase Model Gateway, or `STAGEHAND_MODEL` plus
-  `STAGEHAND_MODEL_API_KEY` for direct-provider BYOK.
-
-Then run:
+The managed agent in `examples/managed/` uses native tools and a Browserbase browser. Export the variables from `.env.example` through your shell or deployment secret manager, then run:
 
 ```bash
-uv sync
+cd packages/integrations/deepagents/examples/managed
+uv sync --locked
 uv run mda dev .
 uv run mda deploy .
 ```
 
-Managed Deep Agents forwards non-reserved `.env` entries as deployment secrets. The agent model key
-and the optional Stagehand model key are independent: users can bring their own key for either,
-while Browserbase Model Gateway remains the zero-additional-key Stagehand path.
+At minimum, configure:
 
-The published `stagehand` wheel bundles the browser extension and `browserbase.launch` provisions
-it automatically. Set `STAGEHAND_EXTENSION_ID` to reuse a pre-uploaded extension instead.
+- `DEEPAGENTS_MODEL` and its provider credential, such as `OPENAI_API_KEY`
+- `BROWSERBASE_API_KEY`
+- `STAGEHAND_API_URL` for Browserbase Model Gateway, or both `STAGEHAND_MODEL` and `STAGEHAND_MODEL_API_KEY` for direct-provider BYOK
 
-## Security model
+The current LangGraph SDK still requires `websockets<16`, so the managed project pins `websockets==15.0.1`. Remove that override when the SDK ranges converge.
 
-The `run` tool executes model-authored JavaScript inside the Stagehand browser extension's service
-worker — browser-side, never in the host process. Browserbase is the recommended isolation
-boundary: the privileged execution environment is a disposable cloud browser with no access to the
-host machine. Only `STAGEHAND_*` and `BROWSERBASE_*` environment variables are forwarded to the
-browser session; host secrets such as the deep-agent model key never reach it.
+Browser state remains available while the managed worker is warm. Durable reconnection after worker replacement is not implemented yet.
+
+## Verify the integration
+
+The server contract tests need no browser or API key:
+
+```bash
+cd packages/integrations/deepagents
+uv run --locked pytest
+```
+
+Running either example against a real browser is the end-to-end smoke test.
+
+## Security boundary
+
+`run` executes model-authored JavaScript inside the Stagehand browser extension's service worker, not in the Deep Agents process. The local MCP client forwards only `STAGEHAND_*` and `BROWSERBASE_*` variables, so the Deep Agent's provider key does not cross into the browser server.
+
+Use Browserbase as the isolation boundary for untrusted tasks. The browser can still reach any page or data available inside its own session.

--- a/packages/integrations/eve/README.md
+++ b/packages/integrations/eve/README.md
@@ -1,64 +1,72 @@
-# Eve + Stagehand facade (native tools)
+# Eve + Stagehand codemode tools
 
-This example gives an Eve agent the native tools `run`, `snapshot`, and `screenshot`. The tools
-share a durable Stagehand session directly; no MCP connection or bridge process is required.
+Give an Eve agent native `run`, `snapshot`, and `screenshot` tools backed by one durable Stagehand session. The tools run in-process, with no MCP server or bridge process.
 
-## Setup
+## Prerequisites
 
-Use Node.js 24 or later. From the repository root, build the integrations package before running
-the example:
+- Node.js 24 or newer
+- pnpm 11.10.0
+- A model-provider credential for Eve
 
-```bash
-pnpm exec turbo run build --filter @browserbasehq/stagehand-integrations
-```
+## Quickstart
 
-Configure the environment as needed:
-
-| Variable                                                             | Purpose                                                                                                                                                 |
-| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `STAGEHAND_BROWSER`                                                  | Browser backend. Defaults to `browserbase` when `BROWSERBASE_API_KEY` is set, otherwise `local`.                                                        |
-| `BROWSERBASE_API_KEY`                                                | Browserbase API key; required when using the Browserbase backend.                                                                                       |
-| `BROWSERBASE_PROJECT_ID`                                             | Optional Browserbase project ID.                                                                                                                        |
-| `STAGEHAND_MODEL_NAME`                                               | Optional Stagehand model name, such as `openai/gpt-5.6-luna`.                                                                                           |
-| `STAGEHAND_MODEL_API_KEY`                                            | Optional explicit API key for `STAGEHAND_MODEL_NAME`; otherwise the matching provider key is inferred when supported.                                   |
-| `STAGEHAND_EVE_SESSION_FILE`                                         | Optional path used to persist the Browserbase session ID; defaults to a file in the system temporary directory.                                         |
-| `EVE_STAGEHAND_MODEL`                                                | Eve agent model; defaults to `gpt-5.6-luna`.                                                                                                            |
-| `OPENAI_API_KEY`                                                     | OpenAI credential used by the Eve agent model and inferred for an OpenAI Stagehand model.                                                               |
-| `GOOGLE_GENERATIVE_AI_API_KEY` / `GEMINI_API_KEY` / `GOOGLE_API_KEY` | Google credential inferred by Stagehand. If one is set without explicit Stagehand model configuration, the model defaults to `google/gemini-3.6-flash`. |
-
-## Run
-
-The tool contract tests need no network, browser, or API keys:
+From the repository root:
 
 ```bash
-pnpm --filter @browserbasehq/stagehand-integrations-example-eve-facade test
-pnpm --filter @browserbasehq/stagehand-integrations-example-eve-facade typecheck
+corepack pnpm@11.10.0 install --frozen-lockfile
+corepack pnpm@11.10.0 exec turbo run build \
+  --filter @browserbasehq/stagehand-integrations
 ```
 
-For interactive use, set the browser and model credentials, then run:
+The example defaults to local Chrome and an OpenAI model:
 
 ```bash
-pnpm --filter @browserbasehq/stagehand-integrations-example-eve-facade dev
+export OPENAI_API_KEY="your-key"
+corepack pnpm@11.10.0 --dir packages/integrations/eve dev
 ```
 
-## Security model
+To run the browser on Browserbase:
 
-`run(code)` executes model-authored JavaScript in the extension service worker: it runs
-browser-side, never in the host process. Browserbase is the recommended isolation boundary. The
-Eve world process holds only the browser session handle; model-authored JavaScript does not execute
-inside the world process.
+```bash
+export STAGEHAND_BROWSER="browserbase"
+export BROWSERBASE_API_KEY="your-key"
+corepack pnpm@11.10.0 --dir packages/integrations/eve dev
+```
+
+## Configuration
+
+| Variable                     | Purpose                                                                                             |
+| ---------------------------- | --------------------------------------------------------------------------------------------------- |
+| `EVE_STAGEHAND_MODEL`        | Eve agent model. Defaults to `gpt-5.6-luna`.                                                        |
+| `OPENAI_API_KEY`             | Credential for the default Eve model. Also inferred when an OpenAI Stagehand model is configured.   |
+| `STAGEHAND_BROWSER`          | `local` or `browserbase`. Inferred from `BROWSERBASE_API_KEY` when unset.                           |
+| `BROWSERBASE_API_KEY`        | Required for Browserbase.                                                                           |
+| `BROWSERBASE_PROJECT_ID`     | Optional Browserbase project ID.                                                                    |
+| `STAGEHAND_MODEL_NAME`       | Optional model for Stagehand AI methods used inside `run`.                                          |
+| `STAGEHAND_MODEL_API_KEY`    | Optional key for `STAGEHAND_MODEL_NAME`.                                                            |
+| `STAGEHAND_EVE_SESSION_FILE` | Optional file used to persist a Browserbase session ID. Defaults to the system temporary directory. |
+
+If a Google provider key is set and `STAGEHAND_MODEL_NAME` is unset, the Stagehand model defaults to `google/gemini-3.6-flash`.
+
+## Verify the integration
+
+The tool contract tests need no browser or API key:
+
+```bash
+corepack pnpm@11.10.0 --dir packages/integrations/eve test
+corepack pnpm@11.10.0 --dir packages/integrations/eve typecheck
+```
+
+Starting Eve with a real local or Browserbase browser is the end-to-end smoke test.
 
 ## Session lifecycle
 
-The example holds one shared browser session per Eve world process. Concurrent Eve sessions served
-by the same process share pages, authentication, and other browser state, so this example is
-intended for single-session use.
+One Eve world process owns one shared browser. Concurrent Eve sessions in that process share pages, authentication, and other browser state, so this example is intended for single-session use.
 
-On Browserbase, the example creates a `keepAlive: true` session and persists its ID to a temporary
-file. Set `STAGEHAND_EVE_SESSION_FILE` to override that path. Process restarts reattach to this
-session instead of creating and stranding another one. While awaiting reuse, the session keeps
-running and billing until it is reattached, released through the Browserbase dashboard or API, or
-reaches the project timeout.
+On Browserbase, the example creates a `keepAlive` session and writes its ID to a temporary file. A process restart reattaches to that session instead of silently creating another one. The session continues running—and can continue billing—until it is reattached, released through Browserbase, or reaches the project timeout.
 
-Errors from model-authored tool code do not reset the session. The browser session is recreated only
-when its connection is unhealthy.
+Tool errors do not reset the browser. The integration creates a new session only when the existing connection is unhealthy.
+
+## Security boundary
+
+`run` executes model-authored JavaScript inside the Stagehand browser extension's service worker, not in the Eve world process. Use Browserbase as the isolation boundary for untrusted tasks. The browser can still reach any page or data available inside its own session.

--- a/packages/integrations/mastra/README.md
+++ b/packages/integrations/mastra/README.md
@@ -1,52 +1,63 @@
-# Mastra + Stagehand facade over MCP/stdio
+# Mastra + Stagehand codemode tools
 
-This example connects Mastra to the Stagehand facade MCP server over stdio. It
-exposes the facade's `run`, `snapshot`, and `screenshot` tools to a Mastra agent,
-using agent instructions imported from the integrations package.
+Give a Mastra agent one persistent Stagehand browser through the `run`, `snapshot`, and `screenshot` tools. Mastra connects to the shared codemode tool server over MCP/stdio, so the same contract can be reused in other MCP-capable frameworks.
 
-This route wraps the facade as an MCP server over stdio, so any MCP-capable
-framework (here, Mastra) can consume the identical tool contract without
-Stagehand-specific glue, at the cost of a child process and JSON-RPC hop.
-Alternatively, the same contract can be bound as native in-process tools sharing
-a durable Stagehand session, with no bridge process but framework-specific code.
+## Prerequisites
 
-## Setup
+- Node.js 24 or newer
+- pnpm 11.10.0
+- An OpenAI API key for the example agent
 
-Node.js 24 or newer is required. From the repository root, build the integrations
-package first so its `dist` server entrypoint exists:
+## Quickstart
 
-```sh
-pnpm exec turbo run build --filter @browserbasehq/stagehand-integrations
+From the repository root:
+
+```bash
+corepack pnpm@11.10.0 install --frozen-lockfile
+corepack pnpm@11.10.0 exec turbo run build \
+  --filter @browserbasehq/stagehand-integrations
 ```
 
-Configure the environment as needed:
+Set the credential for the Mastra agent, then run a browser task:
 
-| Variable                  | Purpose                                                                                          |
-| ------------------------- | ------------------------------------------------------------------------------------------------ |
-| `STAGEHAND_BROWSER`       | Browser backend. Defaults to `browserbase` when `BROWSERBASE_API_KEY` is set, otherwise `local`. |
-| `BROWSERBASE_API_KEY`     | Browserbase API key.                                                                             |
-| `BROWSERBASE_PROJECT_ID`  | Browserbase project ID.                                                                          |
-| `STAGEHAND_MODEL_NAME`    | Model used by the facade server.                                                                 |
-| `STAGEHAND_MODEL_API_KEY` | API key for the facade server model.                                                             |
-| `MASTRA_STAGEHAND_MODEL`  | Mastra agent model; defaults to `gpt-5.6-luna`.                                                  |
-| `OPENAI_API_KEY`          | Used by the Mastra agent model in the host process. It is not forwarded to the facade server.    |
-
-## Run
-
-```sh
-pnpm --filter @browserbasehq/stagehand-integrations-example-mastra-facade test
-pnpm --filter @browserbasehq/stagehand-integrations-example-mastra-facade typecheck
-pnpm --filter @browserbasehq/stagehand-integrations-example-mastra-facade start "your instruction"
+```bash
+export OPENAI_API_KEY="your-key"
+corepack pnpm@11.10.0 --dir packages/integrations/mastra start -- \
+  "Open https://example.com and report the page title."
 ```
 
-## Security model
+Local Chrome is the default. To run the browser on Browserbase:
 
-`run(code)` executes model-authored JavaScript in the extension service worker:
-it runs browser-side, never in the Node host process. Browserbase is the
-recommended isolation boundary. The Node host process spawns the facade server
-and holds only the MCP connection; model-authored JavaScript does not execute
-inside the host process.
+```bash
+export STAGEHAND_BROWSER="browserbase"
+export BROWSERBASE_API_KEY="your-key"
+```
 
-The child process receives `STAGEHAND_*` and `BROWSERBASE_*` environment variables plus the MCP
-transport's safe defaults (HOME, PATH, SHELL, TERM, USER, LOGNAME) — never the full host
-variables; the host's complete environment is never forwarded.
+## Configuration
+
+| Variable                  | Purpose                                                                   |
+| ------------------------- | ------------------------------------------------------------------------- |
+| `MASTRA_STAGEHAND_MODEL`  | Mastra agent model. Defaults to `gpt-5.6-luna`.                           |
+| `OPENAI_API_KEY`          | Credential for the Mastra agent. It stays in the Mastra process.          |
+| `STAGEHAND_BROWSER`       | `local` or `browserbase`. Inferred from `BROWSERBASE_API_KEY` when unset. |
+| `BROWSERBASE_API_KEY`     | Required for Browserbase.                                                 |
+| `BROWSERBASE_PROJECT_ID`  | Optional Browserbase project ID.                                          |
+| `STAGEHAND_MODEL_NAME`    | Optional model for Stagehand AI methods used inside `run`.                |
+| `STAGEHAND_MODEL_API_KEY` | Optional key for `STAGEHAND_MODEL_NAME`.                                  |
+
+## Verify the integration
+
+The MCP contract tests need no browser or API key:
+
+```bash
+corepack pnpm@11.10.0 --dir packages/integrations/mastra test
+corepack pnpm@11.10.0 --dir packages/integrations/mastra typecheck
+```
+
+The quickstart command above is the live browser smoke test.
+
+## Security boundary
+
+`run` executes model-authored JavaScript inside the Stagehand browser extension's service worker, not in the Mastra process. The MCP child receives only `STAGEHAND_*` and `BROWSERBASE_*` variables plus a small set of process basics required to launch Node; the full host environment and `OPENAI_API_KEY` are not forwarded.
+
+Use Browserbase as the isolation boundary for untrusted tasks. The browser can still reach any page or data available inside its own session.

--- a/packages/integrations/vercel-ai/README.md
+++ b/packages/integrations/vercel-ai/README.md
@@ -1,5 +1,8 @@
 # Vercel AI SDK + Stagehand codemode tools
 
+> [!NOTE]
+> Looking to build with Eve? Start with the [Eve + Stagehand codemode integration](../eve/README.md).
+
 Give a Vercel AI SDK agent one persistent Stagehand browser through the `run`, `snapshot`, and `screenshot` tools. The AI SDK connects to the shared codemode tool server over MCP/stdio, so browser state survives across tool calls.
 
 ## Prerequisites

--- a/packages/integrations/vercel-ai/README.md
+++ b/packages/integrations/vercel-ai/README.md
@@ -1,49 +1,63 @@
-# Vercel AI SDK + Stagehand facade over MCP/stdio
+# Vercel AI SDK + Stagehand codemode tools
 
-This example connects the Vercel AI SDK to the Stagehand facade MCP server over
-stdio. It exposes the facade's `run`, `snapshot`, and `screenshot` tools to an AI
-SDK agent.
+Give a Vercel AI SDK agent one persistent Stagehand browser through the `run`, `snapshot`, and `screenshot` tools. The AI SDK connects to the shared codemode tool server over MCP/stdio, so browser state survives across tool calls.
 
-This route wraps the facade as an MCP server over stdio, so any MCP-capable
-framework (here, the Vercel AI SDK) can consume the identical tool contract
-without Stagehand-specific glue, at the cost of a child process and JSON-RPC
-hop. Alternatively, the same contract can be bound as native in-process tools
-sharing a durable Stagehand session, with no bridge process but
-framework-specific code.
+## Prerequisites
 
-## Setup
+- Node.js 24 or newer
+- pnpm 11.10.0
+- An OpenAI API key for the example agent
 
-Node.js 24 or newer is required. From the repository root, build the integrations
-package first so its `dist` server entrypoint exists:
+## Quickstart
 
-```sh
-pnpm exec turbo run build --filter @browserbasehq/stagehand-integrations
+From the repository root:
+
+```bash
+corepack pnpm@11.10.0 install --frozen-lockfile
+corepack pnpm@11.10.0 exec turbo run build \
+  --filter @browserbasehq/stagehand-integrations
 ```
 
-Configure the environment as needed:
+Set the credential for the AI SDK agent, then run a browser task:
 
-| Variable                  | Purpose                                                                                                                                                                                                           |
-| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `STAGEHAND_BROWSER`       | Browser backend. Defaults to `browserbase` when `BROWSERBASE_API_KEY` is set, otherwise `local`.                                                                                                                  |
-| `BROWSERBASE_API_KEY`     | Browserbase API key.                                                                                                                                                                                              |
-| `BROWSERBASE_PROJECT_ID`  | Browserbase project ID.                                                                                                                                                                                           |
-| `STAGEHAND_MODEL_NAME`    | Model used by the facade server.                                                                                                                                                                                  |
-| `STAGEHAND_MODEL_API_KEY` | API key for the facade server model.                                                                                                                                                                              |
-| `AI_SDK_STAGEHAND_MODEL`  | AI SDK agent model; defaults to `gpt-5.6-luna`.                                                                                                                                                                   |
-| `OPENAI_API_KEY`          | Used by the AI SDK agent model in the host process. It is not forwarded: it is neither allowlisted nor one of the host variables (`HOME`, `LOGNAME`, `PATH`, `SHELL`, `TERM`, `USER`) inherited by the transport. |
-
-## Run
-
-```sh
-pnpm --filter @browserbasehq/stagehand-integrations-example-vercel-ai-facade test
-pnpm --filter @browserbasehq/stagehand-integrations-example-vercel-ai-facade typecheck
-pnpm --filter @browserbasehq/stagehand-integrations-example-vercel-ai-facade start "your instruction"
+```bash
+export OPENAI_API_KEY="your-key"
+corepack pnpm@11.10.0 --dir packages/integrations/vercel-ai start -- \
+  "Open https://example.com and report the page title."
 ```
 
-## Security model
+Local Chrome is the default. To run the browser on Browserbase:
 
-`run(code)` executes model-authored JavaScript in the extension service worker:
-it runs browser-side, never in the Node host process. Browserbase is the
-recommended isolation boundary. The Node host process spawns the facade server
-and holds only the MCP connection; model-authored JavaScript does not execute
-inside the host process.
+```bash
+export STAGEHAND_BROWSER="browserbase"
+export BROWSERBASE_API_KEY="your-key"
+```
+
+## Configuration
+
+| Variable                  | Purpose                                                                   |
+| ------------------------- | ------------------------------------------------------------------------- |
+| `AI_SDK_STAGEHAND_MODEL`  | AI SDK agent model. Defaults to `gpt-5.6-luna`.                           |
+| `OPENAI_API_KEY`          | Credential for the AI SDK agent. It stays in the host process.            |
+| `STAGEHAND_BROWSER`       | `local` or `browserbase`. Inferred from `BROWSERBASE_API_KEY` when unset. |
+| `BROWSERBASE_API_KEY`     | Required for Browserbase.                                                 |
+| `BROWSERBASE_PROJECT_ID`  | Optional Browserbase project ID.                                          |
+| `STAGEHAND_MODEL_NAME`    | Optional model for Stagehand AI methods used inside `run`.                |
+| `STAGEHAND_MODEL_API_KEY` | Optional key for `STAGEHAND_MODEL_NAME`.                                  |
+
+## Verify the integration
+
+The MCP contract tests need no browser or API key:
+
+```bash
+corepack pnpm@11.10.0 --dir packages/integrations/vercel-ai test
+corepack pnpm@11.10.0 --dir packages/integrations/vercel-ai typecheck
+```
+
+The quickstart command above is the live browser smoke test.
+
+## Security boundary
+
+`run` executes model-authored JavaScript inside the Stagehand browser extension's service worker, not in the AI SDK process. The MCP child receives only `STAGEHAND_*` and `BROWSERBASE_*` variables plus a small set of process basics required to launch Node; the full host environment and `OPENAI_API_KEY` are not forwarded.
+
+Use Browserbase as the isolation boundary for untrusted tasks. The browser can still reach any page or data available inside its own session.


### PR DESCRIPTION
## Summary

- replace the stale package overview with a practical guide to the three codemode browser tools
- add a framework-selection table, build instructions, shared configuration, tool examples, and the security boundary
- rewrite the CrewAI, Deep Agents, Eve, Mastra, and Vercel AI SDK guides around runnable quickstarts
- remove the internal “facade” framing from all integration READMEs
- correct stale Deep Agents configuration guidance: the local example's model and task are source-defined in `agent.py`

## Impact

Developers can now choose an integration, understand MCP versus native transport, copy an exact setup flow, and see the session/security limitations before running agent-authored browser code.

## Verification

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `oxfmt --check <six integration READMEs>` | All six files matched repository formatting. | Proves Markdown formatting is consistent with the repo toolchain. |
| Core `typecheck test:unit` through Turbo | 18/18 tests passed; all dependency-aware tasks passed. | Covers the shared codemode contract, stdio lifecycle, server schema, and TypeScript types. |
| Eve `test` + `typecheck` | 5/5 tests passed; TypeScript passed. | Verifies the README's native-integration commands. |
| Mastra `test` + `typecheck` | 2/2 tests passed; TypeScript passed. | Verifies the README's MCP client commands. |
| Vercel AI SDK `test` + `typecheck` | 2/2 tests passed; TypeScript passed. | Verifies the README's MCP client commands. |
| CrewAI `uv run --locked pytest -q` | 3/3 tests passed. | Verifies the documented Python environment and MCP contract. |
| Deep Agents `uv run --locked pytest -q` | 7/7 tests passed. | Verifies the documented Python environment and server contract. |

Live-browser smoke results and any code fixes will follow in the next stacked PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrote and refreshed the codemode integration guides with runnable quickstarts, a consistent `run`/`snapshot`/`screenshot` tool contract, and clear security boundaries across CrewAI, Deep Agents (local + managed), Eve, Mastra, and Vercel AI SDK. Also updated the Vercel AI guide to point readers to the Eve native integration when appropriate.

- New Features
  - Unified quickstarts with exact build/run steps and prerequisites; build `@browserbasehq/stagehand-integrations` from source and run examples directly.
  - Root guide adds a choose-your-framework table, persistent browser and snapshot-ID rules, and supported snapshot actions.
  - Per-framework env config and verification commands; host model creds stay in the host, while MCP children only receive `STAGEHAND_*`/`BROWSERBASE_*`.
  - Documented Browserbase as the isolation boundary and added session lifecycle notes (Eve persistence, Deep Agents managed/runtime details).
  - Vercel AI README now includes a note directing users to the Eve integration for native in-process tools.

- Bug Fixes
  - Deep Agents: corrected local example config; the model, task, and optional schema live in `agent.py` (not CLI flags).

<sup>Written for commit b49e31021d53cbd9c991fb3089b4174fbe52574f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

