### PR TITLE
fix(integrations): harden live browser tools

### DIFF
--- a/packages/integrations/README.md
+++ b/packages/integrations/README.md
@@ -33,6 +33,8 @@ The shared TypeScript implementation lives in `core/`. It provides both the in-p
 
 You need Node.js 24 or newer and pnpm 11.10.0. CrewAI and Deep Agents also require Python 3.11–3.13 and [uv](https://docs.astral.sh/uv/).
 
+Local browser mode also needs a current Google Chrome installation. Browserbase mode does not launch a browser on the host.
+
 From the repository root:
 
 ```bash
@@ -47,13 +49,16 @@ Then open the README for your framework and run its quickstart.
 
 The TypeScript integrations use these shared variables. Deep Agents uses `STAGEHAND_MODEL` instead of `STAGEHAND_MODEL_NAME`; see its README for the Python-specific configuration.
 
-| Variable                  | Purpose                                                                                                                  |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `STAGEHAND_BROWSER`       | `local` or `browserbase`. Defaults to Browserbase when `BROWSERBASE_API_KEY` is set; otherwise defaults to local Chrome. |
-| `BROWSERBASE_API_KEY`     | Required for the Browserbase backend.                                                                                    |
-| `BROWSERBASE_PROJECT_ID`  | Optional Browserbase project ID.                                                                                         |
-| `STAGEHAND_MODEL_NAME`    | Optional model for Stagehand AI methods called inside `run`.                                                             |
-| `STAGEHAND_MODEL_API_KEY` | Optional key for `STAGEHAND_MODEL_NAME`. The matching provider key is inferred when supported.                           |
+| Variable                     | Purpose                                                                                                                  |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `STAGEHAND_BROWSER`          | `local` or `browserbase`. Defaults to Browserbase when `BROWSERBASE_API_KEY` is set; otherwise defaults to local Chrome. |
+| `STAGEHAND_HEADLESS`         | Set to `true` to run local Chrome without a visible window. Defaults to `false`.                                         |
+| `STAGEHAND_CHROME_PATH`      | Optional path to a compatible Chrome executable for local mode.                                                          |
+| `STAGEHAND_CHROMIUM_SANDBOX` | Set to `false` only when local Chrome runs inside an already isolated container. Defaults to `true`.                     |
+| `BROWSERBASE_API_KEY`        | Required for the Browserbase backend.                                                                                    |
+| `BROWSERBASE_PROJECT_ID`     | Optional Browserbase project ID.                                                                                         |
+| `STAGEHAND_MODEL_NAME`       | Optional model for Stagehand AI methods called inside `run`.                                                             |
+| `STAGEHAND_MODEL_API_KEY`    | Optional key for `STAGEHAND_MODEL_NAME`. The matching provider key is inferred when supported.                           |
 
 Each framework has a separate variable for the agent's model. The agent model decides which tool to call; the optional Stagehand model powers AI methods such as `act`, `extract`, or `observe` when code passed to `run` uses them.
 
@@ -82,6 +87,8 @@ For a simple interaction, take a snapshot and pass its bracketed ID back to `run
 `run` executes model-authored JavaScript inside the Stagehand browser extension's service worker, not inside the agent host process. That code can control the browser and access data available to the browser, so treat it as privileged browser automation.
 
 Browserbase is the recommended isolation boundary for untrusted tasks because the browser is disposable and separate from the host machine. The MCP examples forward only `STAGEHAND_*` and `BROWSERBASE_*` configuration to the child process; agent-model credentials stay in the framework process.
+
+Disabling Chromium's sandbox weakens local isolation. Use `STAGEHAND_CHROMIUM_SANDBOX=false` only when the surrounding container is already the security boundary.
 
 ## Develop and verify
 

--- a/packages/integrations/core/src/facade/config.ts
+++ b/packages/integrations/core/src/facade/config.ts
@@ -29,6 +29,12 @@ export function stagehandFacadeConfigFromEnv(
   }
 
   const browserType = requestedBrowser ?? (browserbaseApiKey ? "browserbase" : "local");
+  const headless = booleanFromEnv("STAGEHAND_HEADLESS", env.STAGEHAND_HEADLESS) ?? false;
+  const chromePath = nonEmpty(env.STAGEHAND_CHROME_PATH);
+  const chromiumSandbox = booleanFromEnv(
+    "STAGEHAND_CHROMIUM_SANDBOX",
+    env.STAGEHAND_CHROMIUM_SANDBOX,
+  );
   if (browserType === "browserbase" && !browserbaseApiKey) {
     throw new StagehandFacadeConfigError(
       'BROWSERBASE_API_KEY is required when STAGEHAND_BROWSER="browserbase".',
@@ -79,7 +85,14 @@ export function stagehandFacadeConfigFromEnv(
               ...(browserbaseProjectId ? { projectId: browserbaseProjectId } : {}),
             },
           }
-        : { type: "local", launchOptions: { headless: false } },
+        : {
+            type: "local",
+            launchOptions: {
+              headless,
+              ...(chromePath ? { executablePath: chromePath } : {}),
+              ...(chromiumSandbox === undefined ? {} : { chromiumSandbox }),
+            },
+          },
     stagehand,
   };
 }
@@ -87,6 +100,16 @@ export function stagehandFacadeConfigFromEnv(
 function nonEmpty(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
   return trimmed ? trimmed : undefined;
+}
+
+function booleanFromEnv(name: string, value: string | undefined): boolean | undefined {
+  const normalized = nonEmpty(value)?.toLowerCase();
+  if (normalized === undefined) return undefined;
+  if (["1", "true", "yes", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "off"].includes(normalized)) return false;
+  throw new StagehandFacadeConfigError(
+    `${name} must be one of true, false, 1, 0, yes, no, on, or off.`,
+  );
 }
 
 function providerName(modelName: string): string {

--- a/packages/integrations/core/tests/facade-contract.test.ts
+++ b/packages/integrations/core/tests/facade-contract.test.ts
@@ -16,6 +16,29 @@ describe("Stagehand facade contract", () => {
     });
   });
 
+  it("configures headless Chrome and its executable from allowlisted variables", () => {
+    expect(
+      stagehandFacadeConfigFromEnv({
+        STAGEHAND_HEADLESS: "true",
+        STAGEHAND_CHROME_PATH: "/opt/chrome",
+        STAGEHAND_CHROMIUM_SANDBOX: "false",
+      }).browser,
+    ).toStrictEqual({
+      type: "local",
+      launchOptions: {
+        headless: true,
+        executablePath: "/opt/chrome",
+        chromiumSandbox: false,
+      },
+    });
+  });
+
+  it("rejects invalid headless configuration", () => {
+    expect(() => stagehandFacadeConfigFromEnv({ STAGEHAND_HEADLESS: "sometimes" })).toThrow(
+      "STAGEHAND_HEADLESS must be one of",
+    );
+  });
+
   it("pins the three tool names and descriptions", () => {
     expect(FACADE_TOOLS.map((tool) => tool.name)).toStrictEqual(["run", "snapshot", "screenshot"]);
     expect(FACADE_TOOLS[0].description).toContain('"op" (never "kind")');

--- a/packages/integrations/crewai/README.md
+++ b/packages/integrations/crewai/README.md
@@ -8,6 +8,7 @@ Give a CrewAI agent one persistent Stagehand browser through the `run`, `snapsho
 - pnpm 11.10.0
 - Python 3.11–3.13
 - [uv](https://docs.astral.sh/uv/)
+- A current Google Chrome installation for local browser mode
 
 ## Quickstart
 
@@ -49,15 +50,18 @@ export BROWSERBASE_API_KEY="your-key"
 
 ## Configuration
 
-| Variable                  | Purpose                                                                   |
-| ------------------------- | ------------------------------------------------------------------------- |
-| `CREWAI_MODEL`            | CrewAI agent model. Defaults to `openai/gpt-5.6-luna`.                    |
-| `OPENAI_API_KEY`          | Credential for the default CrewAI model. It stays in the CrewAI process.  |
-| `STAGEHAND_BROWSER`       | `local` or `browserbase`. Inferred from `BROWSERBASE_API_KEY` when unset. |
-| `BROWSERBASE_API_KEY`     | Required for Browserbase.                                                 |
-| `BROWSERBASE_PROJECT_ID`  | Optional Browserbase project ID.                                          |
-| `STAGEHAND_MODEL_NAME`    | Optional model for Stagehand AI methods used inside `run`.                |
-| `STAGEHAND_MODEL_API_KEY` | Optional key for `STAGEHAND_MODEL_NAME`.                                  |
+| Variable                     | Purpose                                                                          |
+| ---------------------------- | -------------------------------------------------------------------------------- |
+| `CREWAI_MODEL`               | CrewAI agent model. Defaults to `openai/gpt-5.6-luna`.                           |
+| `OPENAI_API_KEY`             | Credential for the default CrewAI model. It stays in the CrewAI process.         |
+| `STAGEHAND_BROWSER`          | `local` or `browserbase`. Inferred from `BROWSERBASE_API_KEY` when unset.        |
+| `STAGEHAND_HEADLESS`         | Set to `true` to run local Chrome without a visible window. Defaults to `false`. |
+| `STAGEHAND_CHROME_PATH`      | Optional path to a compatible Chrome executable for local mode.                  |
+| `STAGEHAND_CHROMIUM_SANDBOX` | Set to `false` only in an already isolated container. Defaults to `true`.        |
+| `BROWSERBASE_API_KEY`        | Required for Browserbase.                                                        |
+| `BROWSERBASE_PROJECT_ID`     | Optional Browserbase project ID.                                                 |
+| `STAGEHAND_MODEL_NAME`       | Optional model for Stagehand AI methods used inside `run`.                       |
+| `STAGEHAND_MODEL_API_KEY`    | Optional key for `STAGEHAND_MODEL_NAME`.                                         |
 
 ## Verify the integration
 
@@ -78,3 +82,5 @@ CrewAI's current tool loop is text-only, and its standard MCP adapter drops imag
 `run` executes model-authored JavaScript inside the Stagehand browser extension's service worker, not in the CrewAI process. The MCP child receives only `STAGEHAND_*` and `BROWSERBASE_*` variables; provider credentials such as `OPENAI_API_KEY` are not forwarded.
 
 Use Browserbase as the isolation boundary for untrusted tasks. The browser can still reach any page or data available inside its own session.
+
+Disabling Chromium's sandbox weakens local isolation. Use `STAGEHAND_CHROMIUM_SANDBOX=false` only when the surrounding container is already the security boundary.

--- a/packages/integrations/crewai/agent.py
+++ b/packages/integrations/crewai/agent.py
@@ -29,10 +29,12 @@ FACADE_AGENT_INSTRUCTIONS = (
 
 
 class ImageSavingToolAdapter(CrewAIToolAdapter):
-    """CrewAIToolAdapter drops MCP ImageContent blocks (text-only conversion).
+    """Preserve MCP images and normalize CrewAI's optional arguments.
 
-    Wrap the tool callable so image blocks are saved to disk and replaced with
-    a text block naming the saved file before the text-only conversion runs.
+    CrewAI materializes omitted optional fields as ``None``, but MCP JSON schemas
+    represent omission by leaving the property out. Drop those synthetic nulls
+    before the MCP call. Also save image blocks to disk before CrewAI's text-only
+    conversion drops them.
     """
 
     def adapt(
@@ -41,7 +43,10 @@ class ImageSavingToolAdapter(CrewAIToolAdapter):
         mcp_tool: Tool,
     ) -> BaseTool:
         def wrapped(arguments: dict[str, Any] | None) -> CallToolResult:
-            result = func(arguments)
+            normalized_arguments = {
+                key: value for key, value in (arguments or {}).items() if value is not None
+            }
+            result = func(normalized_arguments)
             new_content: list[ContentBlock] = []
             for block in result.content:
                 if not isinstance(block, ImageContent):

--- a/packages/integrations/crewai/test_contract.py
+++ b/packages/integrations/crewai/test_contract.py
@@ -48,6 +48,30 @@ def test_image_saving_tool_adapter_preserves_screenshot() -> None:
         screenshot_path.unlink(missing_ok=True)
 
 
+def test_adapter_omits_crewai_nulls_before_mcp_call() -> None:
+    received: list[dict[str, Any] | None] = []
+
+    def fake_func(arguments: dict[str, Any] | None) -> CallToolResult:
+        received.append(arguments)
+        return CallToolResult(content=[TextContent(type="text", text="ok")])
+
+    mcp_tool = Tool(
+        name="run",
+        description="d",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "code": {"type": "string"},
+                "actions": {"type": "array", "items": {"type": "object"}},
+            },
+        },
+    )
+    tool = ImageSavingToolAdapter().adapt(fake_func, mcp_tool)
+
+    assert tool.run(code="return 1", actions=None) == "ok"
+    assert received == [{"code": "return 1"}]
+
+
 def test_instructions_match_canonical_constant() -> None:
     """Pin the hand-copied prompt to the TS source of truth when in-repo."""
     contract = Path(__file__).parent / ".." / "core" / "src" / "facade" / "contract.ts"

--- a/packages/integrations/deepagents/README.md
+++ b/packages/integrations/deepagents/README.md
@@ -14,6 +14,7 @@ This directory includes two deployment patterns:
 - Python 3.11–3.13
 - [uv](https://docs.astral.sh/uv/)
 - A model-provider credential for the Deep Agent
+- A current Google Chrome installation for local browser mode
 - A Browserbase API key for the managed example or optional local Browserbase use
 
 ## Run the local example
@@ -47,16 +48,18 @@ uv run --project examples/local --locked \
 
 ## Local server configuration
 
-| Variable                   | Default | Purpose                                                    |
-| -------------------------- | ------- | ---------------------------------------------------------- |
-| `STAGEHAND_BROWSER`        | `local` | `local` or `browserbase`.                                  |
-| `STAGEHAND_HEADLESS`       | `false` | Run local Chrome headlessly.                               |
-| `STAGEHAND_START_URL`      | Unset   | Open a URL when the MCP server starts.                     |
-| `STAGEHAND_MODEL`          | Unset   | Optional model for Stagehand AI methods used inside `run`. |
-| `STAGEHAND_MODEL_API_KEY`  | Unset   | Optional key for `STAGEHAND_MODEL`.                        |
-| `STAGEHAND_API_URL`        | Unset   | Optional Stagehand Model Gateway URL.                      |
-| `STAGEHAND_RUN_TIMEOUT_MS` | `60000` | Timeout for JavaScript and action batches.                 |
-| `BROWSERBASE_API_KEY`      | Unset   | Required for Browserbase.                                  |
+| Variable                     | Default | Purpose                                                         |
+| ---------------------------- | ------- | --------------------------------------------------------------- |
+| `STAGEHAND_BROWSER`          | `local` | `local` or `browserbase`.                                       |
+| `STAGEHAND_HEADLESS`         | `false` | Run local Chrome headlessly.                                    |
+| `STAGEHAND_CHROME_PATH`      | Unset   | Optional path to a compatible Chrome executable for local mode. |
+| `STAGEHAND_CHROMIUM_SANDBOX` | `true`  | Set to `false` only in an already isolated container.           |
+| `STAGEHAND_START_URL`        | Unset   | Open a URL when the MCP server starts.                          |
+| `STAGEHAND_MODEL`            | Unset   | Optional model for Stagehand AI methods used inside `run`.      |
+| `STAGEHAND_MODEL_API_KEY`    | Unset   | Optional key for `STAGEHAND_MODEL`.                             |
+| `STAGEHAND_API_URL`          | Unset   | Optional Stagehand Model Gateway URL.                           |
+| `STAGEHAND_RUN_TIMEOUT_MS`   | `60000` | Timeout for JavaScript and action batches.                      |
+| `BROWSERBASE_API_KEY`        | Unset   | Required for Browserbase.                                       |
 
 The server and client intentionally use separate Python environments. Stagehand requires `websockets>=16.1.1`, while the current LangGraph SDK used by Deep Agents requires `websockets<16`; stdio keeps those dependency sets isolated.
 
@@ -99,3 +102,5 @@ Running either example against a real browser is the end-to-end smoke test.
 `run` executes model-authored JavaScript inside the Stagehand browser extension's service worker, not in the Deep Agents process. The local MCP client forwards only `STAGEHAND_*` and `BROWSERBASE_*` variables, so the Deep Agent's provider key does not cross into the browser server.
 
 Use Browserbase as the isolation boundary for untrusted tasks. The browser can still reach any page or data available inside its own session.
+
+Disabling Chromium's sandbox weakens local isolation. Use `STAGEHAND_CHROMIUM_SANDBOX=false` only when the surrounding container is already the security boundary.

--- a/packages/integrations/deepagents/src/stagehand_deepagents/runtime.py
+++ b/packages/integrations/deepagents/src/stagehand_deepagents/runtime.py
@@ -44,6 +44,18 @@ def _env_bool(name: str, default: bool) -> bool:
     return value.lower() in {"1", "true", "yes", "on"}
 
 
+def _env_optional_bool(name: str) -> bool | None:
+    value = os.environ.get(name)
+    if value is None:
+        return None
+    normalized = value.lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"{name} must be a boolean")
+
+
 def _env_positive_int(name: str, default: int) -> int:
     value = os.environ.get(name)
     if value is None:
@@ -58,6 +70,8 @@ def _env_positive_int(name: str, default: int) -> int:
 class RuntimeConfig:
     provider: BrowserProvider = "local"
     headless: bool = False
+    chrome_path: str | None = None
+    chromium_sandbox: bool | None = None
     start_url: str | None = None
     stagehand_model: str | None = None
     stagehand_model_api_key: str | None = None
@@ -77,6 +91,8 @@ class RuntimeConfig:
         return cls(
             provider=raw_provider,
             headless=_env_bool("STAGEHAND_HEADLESS", False),
+            chrome_path=os.environ.get("STAGEHAND_CHROME_PATH") or None,
+            chromium_sandbox=_env_optional_bool("STAGEHAND_CHROMIUM_SANDBOX"),
             start_url=os.environ.get("STAGEHAND_START_URL") or None,
             stagehand_model=stagehand_model,
             stagehand_model_api_key=stagehand_model_api_key,
@@ -120,7 +136,11 @@ class BrowserTools:
                 browser_settings={"viewport": {"width": 1280.0, "height": 720.0}},
             )
         else:
-            browser = await local_browser.launch(headless=resolved.headless)
+            browser = await local_browser.launch(
+                headless=resolved.headless,
+                executable_path=resolved.chrome_path,
+                chromium_sandbox=resolved.chromium_sandbox,
+            )
 
         try:
             create_options: dict[str, object] = {}

--- a/packages/integrations/deepagents/tests/test_server.py
+++ b/packages/integrations/deepagents/tests/test_server.py
@@ -60,6 +60,32 @@ def test_runtime_config_defaults_local_browser_to_headed(
     assert RuntimeConfig.from_env().headless is False
 
 
+async def test_local_browser_uses_configured_headless_chrome(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    browser = AsyncMock()
+    stagehand = AsyncMock()
+    launch = AsyncMock(return_value=browser)
+    create = AsyncMock(return_value=stagehand)
+    monkeypatch.setattr(runtime_module, "local_browser", SimpleNamespace(launch=launch))
+    monkeypatch.setattr(runtime_module.Stagehand, "create", create)
+
+    tools = await BrowserTools.start(
+        RuntimeConfig(
+            headless=True,
+            chrome_path="/opt/chrome",
+            chromium_sandbox=False,
+        )
+    )
+    await tools.close()
+
+    launch.assert_awaited_once_with(
+        headless=True,
+        executable_path="/opt/chrome",
+        chromium_sandbox=False,
+    )
+
+
 def test_runtime_config_rejects_model_key_without_model(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/packages/integrations/eve/README.md
+++ b/packages/integrations/eve/README.md
@@ -7,6 +7,7 @@ Give an Eve agent native `run`, `snapshot`, and `screenshot` tools backed by one
 - Node.js 24 or newer
 - pnpm 11.10.0
 - A model-provider credential for Eve
+- A current Google Chrome installation for local browser mode
 
 ## Quickstart
 
@@ -40,6 +41,9 @@ corepack pnpm@11.10.0 --dir packages/integrations/eve dev
 | `EVE_STAGEHAND_MODEL`        | Eve agent model. Defaults to `gpt-5.6-luna`.                                                        |
 | `OPENAI_API_KEY`             | Credential for the default Eve model. Also inferred when an OpenAI Stagehand model is configured.   |
 | `STAGEHAND_BROWSER`          | `local` or `browserbase`. Inferred from `BROWSERBASE_API_KEY` when unset.                           |
+| `STAGEHAND_HEADLESS`         | Set to `true` to run local Chrome without a visible window. Defaults to `false`.                    |
+| `STAGEHAND_CHROME_PATH`      | Optional path to a compatible Chrome executable for local mode.                                     |
+| `STAGEHAND_CHROMIUM_SANDBOX` | Set to `false` only in an already isolated container. Defaults to `true`.                           |
 | `BROWSERBASE_API_KEY`        | Required for Browserbase.                                                                           |
 | `BROWSERBASE_PROJECT_ID`     | Optional Browserbase project ID.                                                                    |
 | `STAGEHAND_MODEL_NAME`       | Optional model for Stagehand AI methods used inside `run`.                                          |
@@ -70,3 +74,5 @@ Tool errors do not reset the browser. The integration creates a new session only
 ## Security boundary
 
 `run` executes model-authored JavaScript inside the Stagehand browser extension's service worker, not in the Eve world process. Use Browserbase as the isolation boundary for untrusted tasks. The browser can still reach any page or data available inside its own session.
+
+Disabling Chromium's sandbox weakens local isolation. Use `STAGEHAND_CHROMIUM_SANDBOX=false` only when the surrounding container is already the security boundary.

--- a/packages/integrations/mastra/README.md
+++ b/packages/integrations/mastra/README.md
@@ -7,6 +7,7 @@ Give a Mastra agent one persistent Stagehand browser through the `run`, `snapsho
 - Node.js 24 or newer
 - pnpm 11.10.0
 - An OpenAI API key for the example agent
+- A current Google Chrome installation for local browser mode
 
 ## Quickstart
 
@@ -35,15 +36,18 @@ export BROWSERBASE_API_KEY="your-key"
 
 ## Configuration
 
-| Variable                  | Purpose                                                                   |
-| ------------------------- | ------------------------------------------------------------------------- |
-| `MASTRA_STAGEHAND_MODEL`  | Mastra agent model. Defaults to `gpt-5.6-luna`.                           |
-| `OPENAI_API_KEY`          | Credential for the Mastra agent. It stays in the Mastra process.          |
-| `STAGEHAND_BROWSER`       | `local` or `browserbase`. Inferred from `BROWSERBASE_API_KEY` when unset. |
-| `BROWSERBASE_API_KEY`     | Required for Browserbase.                                                 |
-| `BROWSERBASE_PROJECT_ID`  | Optional Browserbase project ID.                                          |
-| `STAGEHAND_MODEL_NAME`    | Optional model for Stagehand AI methods used inside `run`.                |
-| `STAGEHAND_MODEL_API_KEY` | Optional key for `STAGEHAND_MODEL_NAME`.                                  |
+| Variable                     | Purpose                                                                          |
+| ---------------------------- | -------------------------------------------------------------------------------- |
+| `MASTRA_STAGEHAND_MODEL`     | Mastra agent model. Defaults to `gpt-5.6-luna`.                                  |
+| `OPENAI_API_KEY`             | Credential for the Mastra agent. It stays in the Mastra process.                 |
+| `STAGEHAND_BROWSER`          | `local` or `browserbase`. Inferred from `BROWSERBASE_API_KEY` when unset.        |
+| `STAGEHAND_HEADLESS`         | Set to `true` to run local Chrome without a visible window. Defaults to `false`. |
+| `STAGEHAND_CHROME_PATH`      | Optional path to a compatible Chrome executable for local mode.                  |
+| `STAGEHAND_CHROMIUM_SANDBOX` | Set to `false` only in an already isolated container. Defaults to `true`.        |
+| `BROWSERBASE_API_KEY`        | Required for Browserbase.                                                        |
+| `BROWSERBASE_PROJECT_ID`     | Optional Browserbase project ID.                                                 |
+| `STAGEHAND_MODEL_NAME`       | Optional model for Stagehand AI methods used inside `run`.                       |
+| `STAGEHAND_MODEL_API_KEY`    | Optional key for `STAGEHAND_MODEL_NAME`.                                         |
 
 ## Verify the integration
 
@@ -61,3 +65,5 @@ The quickstart command above is the live browser smoke test.
 `run` executes model-authored JavaScript inside the Stagehand browser extension's service worker, not in the Mastra process. The MCP child receives only `STAGEHAND_*` and `BROWSERBASE_*` variables plus a small set of process basics required to launch Node; the full host environment and `OPENAI_API_KEY` are not forwarded.
 
 Use Browserbase as the isolation boundary for untrusted tasks. The browser can still reach any page or data available inside its own session.
+
+Disabling Chromium's sandbox weakens local isolation. Use `STAGEHAND_CHROMIUM_SANDBOX=false` only when the surrounding container is already the security boundary.

--- a/packages/integrations/vercel-ai/README.md
+++ b/packages/integrations/vercel-ai/README.md
@@ -7,6 +7,7 @@ Give a Vercel AI SDK agent one persistent Stagehand browser through the `run`, `
 - Node.js 24 or newer
 - pnpm 11.10.0
 - An OpenAI API key for the example agent
+- A current Google Chrome installation for local browser mode
 
 ## Quickstart
 
@@ -35,15 +36,18 @@ export BROWSERBASE_API_KEY="your-key"
 
 ## Configuration
 
-| Variable                  | Purpose                                                                   |
-| ------------------------- | ------------------------------------------------------------------------- |
-| `AI_SDK_STAGEHAND_MODEL`  | AI SDK agent model. Defaults to `gpt-5.6-luna`.                           |
-| `OPENAI_API_KEY`          | Credential for the AI SDK agent. It stays in the host process.            |
-| `STAGEHAND_BROWSER`       | `local` or `browserbase`. Inferred from `BROWSERBASE_API_KEY` when unset. |
-| `BROWSERBASE_API_KEY`     | Required for Browserbase.                                                 |
-| `BROWSERBASE_PROJECT_ID`  | Optional Browserbase project ID.                                          |
-| `STAGEHAND_MODEL_NAME`    | Optional model for Stagehand AI methods used inside `run`.                |
-| `STAGEHAND_MODEL_API_KEY` | Optional key for `STAGEHAND_MODEL_NAME`.                                  |
+| Variable                     | Purpose                                                                          |
+| ---------------------------- | -------------------------------------------------------------------------------- |
+| `AI_SDK_STAGEHAND_MODEL`     | AI SDK agent model. Defaults to `gpt-5.6-luna`.                                  |
+| `OPENAI_API_KEY`             | Credential for the AI SDK agent. It stays in the host process.                   |
+| `STAGEHAND_BROWSER`          | `local` or `browserbase`. Inferred from `BROWSERBASE_API_KEY` when unset.        |
+| `STAGEHAND_HEADLESS`         | Set to `true` to run local Chrome without a visible window. Defaults to `false`. |
+| `STAGEHAND_CHROME_PATH`      | Optional path to a compatible Chrome executable for local mode.                  |
+| `STAGEHAND_CHROMIUM_SANDBOX` | Set to `false` only in an already isolated container. Defaults to `true`.        |
+| `BROWSERBASE_API_KEY`        | Required for Browserbase.                                                        |
+| `BROWSERBASE_PROJECT_ID`     | Optional Browserbase project ID.                                                 |
+| `STAGEHAND_MODEL_NAME`       | Optional model for Stagehand AI methods used inside `run`.                       |
+| `STAGEHAND_MODEL_API_KEY`    | Optional key for `STAGEHAND_MODEL_NAME`.                                         |
 
 ## Verify the integration
 
@@ -61,3 +65,5 @@ The quickstart command above is the live browser smoke test.
 `run` executes model-authored JavaScript inside the Stagehand browser extension's service worker, not in the AI SDK process. The MCP child receives only `STAGEHAND_*` and `BROWSERBASE_*` variables plus a small set of process basics required to launch Node; the full host environment and `OPENAI_API_KEY` are not forwarded.
 
 Use Browserbase as the isolation boundary for untrusted tasks. The browser can still reach any page or data available inside its own session.
+
+Disabling Chromium's sandbox weakens local isolation. Use `STAGEHAND_CHROMIUM_SANDBOX=false` only when the surrounding container is already the security boundary.

--- a/packages/sdk-ts/src/cdpClient.ts
+++ b/packages/sdk-ts/src/cdpClient.ts
@@ -764,7 +764,8 @@ function isExtensionsLoadUnpackedUnavailable(error: unknown): boolean {
 
   return (
     cause.data.method === "Extensions.loadUnpacked" &&
-    (cause.data.code === -32601 || /method not found|wasn't found/i.test(cause.data.message))
+    (cause.data.code === -32601 ||
+      /method not (?:found|available)|wasn't found/i.test(cause.data.message))
   );
 }
 

--- a/packages/sdk-ts/tests/cdpClient.test.ts
+++ b/packages/sdk-ts/tests/cdpClient.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   CDPClient,
   CDPConnectionClosedError,
+  loadUnpackedExtension,
   openCDPWebSocket,
   stagehandMessageExpression,
   waitForRuntimeReady,
@@ -85,6 +86,26 @@ class FakeWebSocket extends EventTarget {
 }
 
 describe("CDP WebSocket transport", () => {
+  it("explains when a Chrome build cannot load unpacked extensions", async () => {
+    const signal = new AbortController().signal;
+    const cdpError = new Error("Method not available.", {
+      cause: {
+        code: -32000,
+        message: "Method not available.",
+        method: "Extensions.loadUnpacked",
+      },
+    });
+    const cdp = {
+      sendCommand: vi.fn(async () => {
+        throw cdpError;
+      }),
+    };
+
+    await expect(loadUnpackedExtension(cdp, "/tmp/extension", signal)).rejects.toThrow(
+      "This Chrome build does not support Extensions.loadUnpacked",
+    );
+  });
+
   it("opens the built-in WebSocket transport", async () => {
     const signal = new AbortController().signal;
     const socket = new FakeWebSocket();


### PR DESCRIPTION
## Summary

- omit CrewAI-generated `null` values before invoking MCP tools so `run({ code })` satisfies the codemode schema
- add allowlisted local Chrome controls for headless mode, executable selection, and sandbox behavior in the TypeScript and Deep Agents runtimes
- turn unsupported `Extensions.loadUnpacked` CDP responses into an actionable compatible-Chrome error
- document the local Chrome requirements and security tradeoff

## End-to-end evidence

Using a public `https://example.com` task and a real Browserbase browser, I exercised `run`, `snapshot`, and `screenshot` through:

- core MCP
- CrewAI
- Deep Agents / LangChain MCP tools
- Eve native tools
- Mastra
- Vercel AI SDK

All six paths navigated successfully, returned the expected title/snapshot, and produced a PNG. The Eve keep-alive session used by the smoke test was explicitly released.

A local-browser smoke test also verified the new settings reach the launcher. The only Chromium available in the test host was Playwright's bundled build, which returns `Method not available` for `Extensions.loadUnpacked`; this PR now explains that a compatible Chrome build is required instead of surfacing the raw CDP error.

## Verification

- SDK: build + 187 unit tests
- integrations core: build, typecheck + 20 tests
- Eve: typecheck + 5 tests
- Mastra: typecheck + 2 tests
- Vercel AI SDK: typecheck + 2 tests
- CrewAI: Ruff + 4 tests
- Deep Agents: Ruff + 8 tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens live browser tools across integrations. Adds headless/executable/sandbox controls for local Chrome with env validation, clarifies unsupported extension-loading errors, and drops CrewAI nulls before MCP calls.

- New Features
  - Local Chrome controls and validation via `STAGEHAND_HEADLESS`, `STAGEHAND_CHROME_PATH`, `STAGEHAND_CHROMIUM_SANDBOX` in TS core and `deepagents`; local mode can run headless, pick an executable, and toggle the sandbox.
  - Docs: note the local Chrome requirement, Browserbase isolation, and sandbox tradeoffs across `crewai`, `deepagents`, `eve`, `mastra`, and `vercel-ai`.

- Bug Fixes
  - `crewai`: omit `None` values before MCP tool calls so `run({ code })` matches the schema.
  - `sdk-ts`: convert `"Extensions.loadUnpacked"` “method not found/available” responses into a clear “incompatible Chrome build” error.

<sup>Written for commit 6793c7d374110f3951c0468b78c831b02a340d6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

