### PR TITLE
Update example path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ git clone https://github.com/browserbase/stagehand.git
 cd stagehand
 pnpm install
 pnpm run build
-pnpm run example # run the blank script at ./examples/example.ts
 ```
 
 Stagehand is best when you have an API key for an LLM provider and Browserbase credentials. To add these to your project, run:
@@ -128,6 +127,14 @@ Stagehand is best when you have an API key for an LLM provider and Browserbase c
 cp .env.example .env
 nano .env # Edit the .env file to add API keys
 ```
+
+Then run any of the scripts in [`packages/sdk-ts/examples`](./packages/sdk-ts/examples):
+
+```bash
+pnpm exec tsx packages/sdk-ts/examples/act.ts
+```
+
+If you have [`just`](https://github.com/casey/just) installed, `just example act` runs the same script and rebuilds the packages it depends on first. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full TypeScript, Python, and Go setup.
 
 ### Installing from a branch
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ const {
 );
 ```
 
+See the [Python](./packages/sdk-python/README.md) and [Go](./packages/sdk-go/README.md) READMEs for equivalent examples.
+
 ## Documentation
 
 Visit [docs.stagehand.dev](https://docs.stagehand.dev) to view the full documentation.

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Visit [docs.stagehand.dev](https://docs.stagehand.dev) to view the full document
 
 ### Build and Run from Source
 
+Stagehand is a TypeScript, Python, and Go monorepo. We use [`just`](https://github.com/casey/just) to drive `pnpm`, `uv`, and `go` together.
+
 ```bash
 git clone https://github.com/browserbase/stagehand.git
 cd stagehand
@@ -133,20 +135,20 @@ just generate
 just build
 ```
 
-Stagehand is best when you have an API key for an LLM provider and Browserbase credentials. To add these to your project, run:
+Stagehand is best when you have an API key for an LLM provider and Browserbase credentials. Export them so they're available on `process.env`:
 
 ```bash
-cp .env.example .env
-nano .env # Edit the .env file to add API keys
+export OPENAI_API_KEY="your-openai-api-key"
+export BROWSERBASE_API_KEY="your-browserbase-api-key"
 ```
 
 Then run any of the scripts in [`packages/sdk-ts/examples`](./packages/sdk-ts/examples):
 
 ```bash
-pnpm exec tsx packages/sdk-ts/examples/act.ts
+just example act # runs packages/sdk-ts/examples/act.ts
 ```
 
-If you have [`just`](https://github.com/casey/just) installed, `just example act` runs the same script and rebuilds the packages it depends on first. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full TypeScript, Python, and Go setup.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full TypeScript, Python, and Go setup.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -80,11 +80,22 @@ Here's how to build a sample browser automation with Stagehand:
 import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 import { z } from "zod/v4";
 
-const browser = await browserbase.launch();
-const stagehand = await Stagehand.create({ browser });
+const { BROWSERBASE_API_KEY, OPENAI_API_KEY } = process.env;
+
+const browser = await browserbase.launch({
+  apiKey: BROWSERBASE_API_KEY,
+});
+
+const stagehand = await Stagehand.create({
+  browser,
+  model: {
+    modelName: "openai/gpt-5.4-mini",
+    apiKey: OPENAI_API_KEY,
+  },
+});
 
 // Stagehand's CDP engine provides an optimized, low level interface to the browser built for automation
-const page = await browser.context.pages()[0];
+const [page] = await browser.context.pages();
 await page.goto("https://github.com/browserbase");
 
 // Use act() to execute individual actions
@@ -117,8 +128,9 @@ Visit [docs.stagehand.dev](https://docs.stagehand.dev) to view the full document
 ```bash
 git clone https://github.com/browserbase/stagehand.git
 cd stagehand
-pnpm install
-pnpm run build
+just install
+just generate
+just build
 ```
 
 Stagehand is best when you have an API key for an LLM provider and Browserbase credentials. To add these to your project, run:
@@ -135,20 +147,6 @@ pnpm exec tsx packages/sdk-ts/examples/act.ts
 ```
 
 If you have [`just`](https://github.com/casey/just) installed, `just example act` runs the same script and rebuilds the packages it depends on first. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full TypeScript, Python, and Go setup.
-
-### Installing from a branch
-
-To install Stagehand directly from a GitHub branch, install the core package subdirectory:
-
-```bash
-pnpm add "github:browserbase/stagehand#<branchName>&path:/packages/core"
-```
-
-Or set it in your project's `package.json`:
-
-```json
-"@browserbasehq/stagehand": "github:browserbase/stagehand#<branchName>&path:/packages/core"
-```
 
 ## Contributing
 

--- a/packages/sdk-go/README.md
+++ b/packages/sdk-go/README.md
@@ -52,6 +52,98 @@ Agents use fewer tokens, recover when websites change, and complete tasks more r
 
 For the full overview, examples, and contributing guide, see the [main README](https://github.com/browserbase/stagehand/blob/main/README.md).
 
+## Example
+
+```go
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+
+	stagehand "github.com/browserbase/stagehand/packages/sdk-go"
+)
+
+type pullRequest struct {
+	Author string `json:"author"`
+	Title  string `json:"title"`
+}
+
+func main() {
+	if err := run(context.Background()); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run(ctx context.Context) (err error) {
+	browser, err := stagehand.LaunchLocalBrowser(ctx, &stagehand.LocalBrowserLaunchOptions{Headless: true})
+	if err != nil {
+		return err
+	}
+	defer func() { err = errors.Join(err, browser.Close(ctx)) }()
+
+	modelAPIKey := os.Getenv("OPENAI_API_KEY")
+	client, err := stagehand.Create(ctx, stagehand.CreateOptions{
+		Browser: browser,
+		Model: &stagehand.ModelConfig{
+			ModelName: "openai/gpt-5.4-mini",
+			APIKey:    &modelAPIKey,
+		},
+	})
+	if err != nil {
+		return err
+	}
+	defer func() { err = errors.Join(err, client.Close(ctx)) }()
+
+	browserContext, err := browser.Context()
+	if err != nil {
+		return err
+	}
+	pages, err := browserContext.Pages(ctx)
+	if err != nil {
+		return err
+	}
+	page := pages[0]
+	if _, err := page.Goto(ctx, "https://github.com/browserbase", nil); err != nil {
+		return err
+	}
+
+	// Act executes individual actions
+	if _, err := client.Act(ctx, stagehand.ActInstruction("click on the stagehand repo"), nil); err != nil {
+		return err
+	}
+
+	// Observe reports what is actionable on the page
+	instruction := "find the latest PR"
+	observed, err := client.Observe(ctx, &instruction, nil)
+	if err != nil {
+		return err
+	}
+
+	// Locators give deterministic, Playwright-style actions
+	if err := page.Locator(observed.Data[0].Selector).Click(ctx, nil); err != nil {
+		return err
+	}
+
+	// Extract returns structured data decoded into a Go type
+	extracted, err := stagehand.Extract[pullRequest](
+		ctx,
+		client,
+		"extract the author and title of the PR",
+		nil,
+	)
+	if err != nil {
+		return err
+	}
+	fmt.Println(extracted.Data.Author, extracted.Data.Title)
+
+	return nil
+}
+```
+
 ## Navigation
 
 Navigation methods return the main-document response when the browser performs a network request:
@@ -97,7 +189,7 @@ fmt.Println(result.Data.Stories)
 
 Fields omitted with `json:",omitempty"` are optional in the generated schema. Add constraints such as `jsonschema:"format=uri"` or `jsonschema:"description=the displayed price"` when the Go type alone is not specific enough.
 
-## Examples
+## More Examples
 
 Run the flat examples directly from the repository:
 

--- a/packages/sdk-python/README.md
+++ b/packages/sdk-python/README.md
@@ -58,23 +58,45 @@ The async Python SDK for Stagehand browser automation:
 
 ```python
 import asyncio
+import os
+
+from pydantic import BaseModel
 
 from stagehand import Stagehand, local_browser
+
+
+class PullRequest(BaseModel):
+    author: str
+    title: str
 
 
 async def main() -> None:
     browser = await local_browser.launch(headless=True)
     try:
-        stagehand = await Stagehand.create(browser=browser)
+        stagehand = await Stagehand.create(
+            browser=browser,
+            model="openai/gpt-5.4-mini",
+            model_api_key=os.environ["OPENAI_API_KEY"],
+        )
         try:
             page = (await browser.context.pages())[0]
-            if page is None:
-                raise RuntimeError("Stagehand initialized without an active page")
-            response = await page.goto("https://example.com")
-            if response is not None:
-                print(response.status, await response.text())
-            await stagehand.observe("Find the more information link")
-            print(await page.title())
+            await page.goto("https://github.com/browserbase")
+
+            # act() executes individual actions
+            await stagehand.act("click on the stagehand repo")
+
+            # observe() reports what is actionable on the page
+            observed = await stagehand.observe("find the latest PR")
+
+            # Locators give deterministic, Playwright-style actions
+            await page.locator(observed.data[0].selector).click()
+
+            # extract() returns structured data validated by a pydantic model
+            result = await stagehand.extract(
+                "extract the author and title of the PR",
+                PullRequest,
+            )
+            print(result.data.author, result.data.title)
         finally:
             await stagehand.close()
     finally:


### PR DESCRIPTION
# why

Fixing a path for the examples in the README

# what changed

# test plan

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix root README by removing the invalid `pnpm run example` step (prevents `ERR_PNPM_NO_SCRIPT`), adopting `just` tasks (`just install`, `just generate`, `just build`) and running examples from `packages/sdk-ts/examples` via `just example act`; update the TS example to pass `OPENAI_API_KEY`/`BROWSERBASE_API_KEY` and set `openai/gpt-5.4-mini`. Also add equivalent examples to the Python and Go READMEs and replace .env file guidance with exported env vars; aligns with STG-2812.

<sup>Written for commit d6665d41d729b39722ba1d4072a5e80b8b78b335. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

