### PR TITLE
docs: fix broken Discord invite links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,14 +5,14 @@ contributor needs: how the packages fit together, how to run the checks, and wha
 carry before it can be released.
 
 > [!NOTE]
-> For questions or support, join the [Discord community](https://stagehand.dev/discord).
+> For questions or support, join the [Discord community](https://discord.gg/stagehand).
 
 ## Where to start
 
 Browserbase prioritizes reliability, extensibility, speed, and cost, in that order. Bug fixes and
 small improvements are the best way to get started.
 
-For anything larger, raise it in [Discord](https://stagehand.dev/discord) first. A quick
+For anything larger, raise it in [Discord](https://discord.gg/stagehand) first. A quick
 conversation is the best way to confirm the direction fits the roadmap before you invest time in
 building it.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
       <img alt="MIT License" src="media/light_license.svg" />
     </picture>
   </a>
-  <a href="https://stagehand.dev/discord">
+  <a href="https://discord.gg/stagehand">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="media/dark_discord.svg" />
       <img alt="Discord Community" src="media/light_discord.svg" />
@@ -155,9 +155,9 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full TypeScript, Python, and Go
 ## Contributing
 
 > [!NOTE]
-> We highly value contributions to Stagehand! For questions or support, please join our [Discord community](https://stagehand.dev/discord).
+> We highly value contributions to Stagehand! For questions or support, please join our [Discord community](https://discord.gg/stagehand).
 
-We're focused on improving reliability, extensibility, speed, and cost in that order of priority. If you're interested in contributing, **bug fixes and small improvements are the best way to get started**. For more involved features, we strongly recommend reaching out to [Miguel Gonzalez](https://x.com/miguel_gonzf) or [Paul Klein](https://x.com/pk_iv) in our [Discord community](https://stagehand.dev/discord) before starting to ensure that your contribution aligns with our goals.
+We're focused on improving reliability, extensibility, speed, and cost in that order of priority. If you're interested in contributing, **bug fixes and small improvements are the best way to get started**. For more involved features, we strongly recommend reaching out to [Miguel Gonzalez](https://x.com/miguel_gonzf) or [Paul Klein](https://x.com/pk_iv) in our [Discord community](https://discord.gg/stagehand) before starting to ensure that your contribution aligns with our goals.
 
 <!-- For more information, please see our [CONTRIBUTING.md](CONTRIBUTING.md) -->
 

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -407,7 +407,7 @@
       "anchors": [
         {
           "anchor": "Discord",
-          "href": "https://stagehand.dev/discord",
+          "href": "https://discord.gg/stagehand",
           "icon": "discord"
         },
         {
@@ -432,7 +432,7 @@
     "links": [
       {
         "label": "Discord",
-        "href": "https://stagehand.dev/discord"
+        "href": "https://discord.gg/stagehand"
       },
       {
         "label": "Support",
@@ -442,7 +442,7 @@
   },
   "footer": {
     "socials": {
-      "discord": "https://stagehand.dev/discord",
+      "discord": "https://discord.gg/stagehand",
       "x": "https://x.com/stagehanddev",
       "github": "https://github.com/browserbase/stagehand",
       "linkedin": "https://linkedin.com/company/browserbasehq"

--- a/packages/docs/v2/best-practices/contributing.mdx
+++ b/packages/docs/v2/best-practices/contributing.mdx
@@ -16,15 +16,15 @@ Any contribution must be explicitly approved by a codeowner. Officially, Stageha
 
 Special thanks to [Jeremy Press](https://github.com/jeremypress), [Navid Pour](https://github.com/navidkpr), and [all the contributors](https://github.com/browserbase/stagehand/graphs/contributors) for your help in making Stagehand the best browser automation framework.
 
-***Please do not hesitate to reach out to anyone listed here in the [public Discord server](https://stagehand.dev/discord)***
+***Please do not hesitate to reach out to anyone listed here in the [public Discord server](https://discord.gg/stagehand)***
 
 ## General Workflow
 
 Get listed as [one of our beloved contributors](https://github.com/browserbase/stagehand/graphs/contributors)!
 
-1. **Discuss your proposed contribution before starting.** Not doing this runs you the risk of entirely discarding something you put considerable time and effort into. You can DM Miguel on [Discord](https://stagehand.dev/discord) for a 1on1 call.
+1. **Discuss your proposed contribution before starting.** Not doing this runs you the risk of entirely discarding something you put considerable time and effort into. You can DM Miguel on [Discord](https://discord.gg/stagehand) for a 1on1 call.
 2. **Open a Pull Request.** Create a fork of this repository, and follow [GitHub’s instructions to create a Pull Request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork). This allows our team to review your contribution and leave comments. 
-3. **Wait for Review**. We'll do our best to get to your contribution as soon as possible. If it's been 2-3 days and you have yet to receive any comments, DM Miguel on [Discord](https://stagehand.dev/discord)
+3. **Wait for Review**. We'll do our best to get to your contribution as soon as possible. If it's been 2-3 days and you have yet to receive any comments, DM Miguel on [Discord](https://discord.gg/stagehand)
 4. **Merge into `evals` branch.** We don’t let external contributors [run our CI via GitHub Actions](https://github.com/browserbase/stagehand/blob/main/.github/workflows/ci.yml) to prevent spam and misuse. If your contribution passes an initial screen, we’ll run our evals on it
     1. By default, all PRs run the following tests that you can also run from the repo source:
         1. Lint (`npm run lint`) - Runs `prettier` and `eslint`. If this fails, you can most likely run `npm run format` to fix some simple linting errors.

--- a/packages/docs/v2/first-steps/introduction.mdx
+++ b/packages/docs/v2/first-steps/introduction.mdx
@@ -124,7 +124,7 @@ Stagehand is designed for developers building production browser automations and
   <Card
     title="Join Discord"
     icon="discord"
-    href="https://stagehand.dev/discord"
+    href="https://discord.gg/stagehand"
   >
     Get help from the community
   </Card>

--- a/packages/docs/v3/first-steps/introduction.mdx
+++ b/packages/docs/v3/first-steps/introduction.mdx
@@ -103,7 +103,7 @@ Stagehand is designed for developers building production browser automations and
   <Card
     title="Join Discord"
     icon="discord"
-    href="https://stagehand.dev/discord"
+    href="https://discord.gg/stagehand"
   >
     Get help from the community
   </Card>

--- a/packages/docs/v4/first-steps/introduction.mdx
+++ b/packages/docs/v4/first-steps/introduction.mdx
@@ -197,7 +197,7 @@ Stagehand is designed for developers building production browser automations and
   <Card
     title="Join Discord"
     icon="discord"
-    href="https://stagehand.dev/discord"
+    href="https://discord.gg/stagehand"
   >
     Get help from the community
   </Card>

--- a/packages/sdk-go/README.md
+++ b/packages/sdk-go/README.md
@@ -20,7 +20,7 @@
       <img alt="MIT License" src="https://raw.githubusercontent.com/browserbase/stagehand/main/media/light_license.svg" />
     </picture>
   </a>
-  <a href="https://stagehand.dev/discord">
+  <a href="https://discord.gg/stagehand">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/browserbase/stagehand/main/media/dark_discord.svg" />
       <img alt="Discord Community" src="https://raw.githubusercontent.com/browserbase/stagehand/main/media/light_discord.svg" />

--- a/packages/sdk-python/README.md
+++ b/packages/sdk-python/README.md
@@ -20,7 +20,7 @@
       <img alt="MIT License" src="https://raw.githubusercontent.com/browserbase/stagehand/main/media/light_license.svg" />
     </picture>
   </a>
-  <a href="https://stagehand.dev/discord">
+  <a href="https://discord.gg/stagehand">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/browserbase/stagehand/main/media/dark_discord.svg" />
       <img alt="Discord Community" src="https://raw.githubusercontent.com/browserbase/stagehand/main/media/light_discord.svg" />


### PR DESCRIPTION
## Problem

Every Discord link in the repo points to `https://stagehand.dev/discord`, which currently 404s:

```
$ curl -sIL https://stagehand.dev/discord
HTTP/2 308  ->  https://www.stagehand.dev/discord
HTTP/2 404
```

Since that URL is the only support/contribution entry point the docs offer, it's currently broken from every direction:

- **`README.md`** — the Discord badge and the two Contributing links (also what npm renders on the `@browserbasehq/stagehand` package page)
- **`packages/sdk-python/README.md`** — rendered on PyPI
- **`packages/sdk-go/README.md`** — rendered on pkg.go.dev
- **`CONTRIBUTING.md`** — both places that tell contributors to raise larger changes in Discord first
- **`packages/docs/docs.json`** — the docs site nav item, CTA and footer social link
- **`packages/docs/v2|v3|v4/first-steps/introduction.mdx`** — the "Join the community" card
- **`packages/docs/v2/best-practices/contributing.mdx`** — the "DM Miguel on Discord" instructions

## Fix

Replaced all 16 occurrences with `https://discord.gg/stagehand` — the canonical invite already linked from stagehand.dev, verified live (server "Stagehand (by Browserbase)").

Link swap only; no other content changed. `docs.json` re-validated as JSON.

## Note

If you'd rather keep the branded `stagehand.dev/discord` vanity URL and restore the redirect on the website instead, happy to close this — though the repo-side fix also covers the READMEs already published to npm/PyPI/pkg.go.dev, which the redirect can't reach retroactively.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix broken Discord links by replacing `https://stagehand.dev/discord` (404) with `https://discord.gg/stagehand` across the repo so users can reach the community from docs and READMEs.

- **Bug Fixes**
  - Updated 16 links in `README.md`, `CONTRIBUTING.md`, `packages/sdk-python/README.md`, `packages/sdk-go/README.md`, and docs (`packages/docs/docs.json`, `v2|v3|v4` introductions, best-practices).
  - Verified the new invite resolves to the Stagehand server; re-validated `packages/docs/docs.json`.

<sup>Written for commit 444dc3b14a60589c2414d2038a97eac200a2bd4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

