### PR TITLE
docs: remove stale metrics() not-implemented TODOs

### DIFF
--- a/packages/docs/v4/configuration/observability.mdx
+++ b/packages/docs/v4/configuration/observability.mdx
@@ -295,8 +295,6 @@ For local development, Stagehand provides performance monitoring and resource tr
 
 ### Performance tracking
 
-{/* TODO: these samples call stagehand.metrics(), which is typed end to end but currently throws "Method not implemented" in the runtime. Same caveat as the "Real-time metrics & monitoring" section below; verify both before publishing. */}
-
 <Tabs>
 <Tab title="TypeScript">
 ```typescript
@@ -628,8 +626,6 @@ fmt.Println("Resource Usage:", monitor.getResourceSummary())
 ### Basic usage tracking
 
 Monitor your automation's resource usage in real-time by calling the metrics method:
-
-{/* TODO: stagehand.metrics() is typed end to end but the runtime currently throws "Method not implemented". Verify before publishing. */}
 
 <Tabs>
 <Tab title="TypeScript">


### PR DESCRIPTION
## Summary
- Remove outdated TODOs in observability docs that claim `metrics()` is not implemented.
- `metrics()` is already available in the TypeScript and Python SDKs.

## Test plan
- [ ] Confirm observability docs no longer say metrics are unimplemented
- [ ] Spot-check that the remaining OTLP endpoint TODO (if any) is intentionally left alone

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes stale TODO comments in the observability docs that claimed metrics() was not implemented. The docs previously warned that stagehand.metrics() threw “Method not implemented”; they now reflect that metrics() is available in the TypeScript and Python SDKs.

- Deletes two inline TODOs in `packages/docs/v4/configuration/observability.mdx`; no example or content changes.
- Docs-only change; no runtime impact. Unrelated OTLP endpoint TODOs remain.

<sup>Written for commit c4c301c653e20f0ae9418b40dae8869de6001de6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

