### PR TITLE
test(extension): replace model-resolution it.todo placeholders

### DIFF
--- a/packages/extension/tests/model-resolution.test.ts
+++ b/packages/extension/tests/model-resolution.test.ts
@@ -133,12 +133,136 @@ describe("model configuration", () => {
   });
 
   describe("direct inference", () => {
-    it.todo("uses direct inference when provider authentication is provided");
-    it.todo("prefers direct inference when using a Browserbase browser with provider auth");
+    it("uses direct inference when provider authentication is provided", async () => {
+      const act = vi.spyOn(actService, "act").mockResolvedValue({
+        data: { success: true, message: "", actionDescription: "", actions: [] },
+        metadata,
+      });
+      const extract = vi.spyOn(extractService, "extract").mockResolvedValue({
+        data: {},
+        metadata,
+      });
+      const observe = vi.spyOn(observeService, "observe").mockResolvedValue({
+        data: [],
+        metadata,
+      });
+      const model = {
+        modelName: "openai/gpt-5.4-mini" as const,
+        apiKey: "sk-provider",
+      };
+      const controller = createStagehandController(
+        runtimeWith({ model } as StagehandInitParams),
+      );
+
+      await controller.act({ pageId: "page-1", instruction: "Click" }, handlerContext);
+      await controller.extract(
+        { pageId: "page-1", instruction: "Extract", schema: {} },
+        handlerContext,
+      );
+      await controller.observe({ pageId: "page-1" }, handlerContext);
+
+      for (const service of [act, extract, observe]) {
+        expect(service).toHaveBeenCalledWith(
+          expect.objectContaining({
+            model,
+            gateway: undefined,
+          }),
+        );
+      }
+    });
+
+    it("prefers direct inference when using a Browserbase browser with provider auth", async () => {
+      const act = vi.spyOn(actService, "act").mockResolvedValue({
+        data: { success: true, message: "", actionDescription: "", actions: [] },
+        metadata,
+      });
+      const extract = vi.spyOn(extractService, "extract").mockResolvedValue({
+        data: {},
+        metadata,
+      });
+      const observe = vi.spyOn(observeService, "observe").mockResolvedValue({
+        data: [],
+        metadata,
+      });
+      const model = {
+        modelName: "openai/gpt-5.4-mini" as const,
+        apiKey: "sk-provider",
+      };
+      const controller = createStagehandController(
+        runtimeWith({
+          apiKey: "bb-api-key",
+          browser: { sessionId: "session-123", region: "eu-central-1" },
+          model,
+        } as StagehandInitParams),
+      );
+
+      await controller.act({ pageId: "page-1", instruction: "Click" }, handlerContext);
+      await controller.extract(
+        { pageId: "page-1", instruction: "Extract", schema: {} },
+        handlerContext,
+      );
+      await controller.observe({ pageId: "page-1" }, handlerContext);
+
+      // Gateway is still passed; llmService prefers direct inference when apiKey is set.
+      for (const service of [act, extract, observe]) {
+        expect(service).toHaveBeenCalledWith(
+          expect.objectContaining({
+            model,
+            gateway: {
+              apiUrl: "https://api.euc1.stagehand.browserbase.com/v1",
+              apiKey: "bb-api-key",
+              sessionId: "session-123",
+            },
+          }),
+        );
+      }
+    });
   });
 
   describe("Browserbase managed inference", () => {
-    it.todo("uses Browserbase managed inference for an explicit model without provider auth");
+    it("uses Browserbase managed inference for an explicit model without provider auth", async () => {
+      const act = vi.spyOn(actService, "act").mockResolvedValue({
+        data: { success: true, message: "", actionDescription: "", actions: [] },
+        metadata,
+      });
+      const extract = vi.spyOn(extractService, "extract").mockResolvedValue({
+        data: {},
+        metadata,
+      });
+      const observe = vi.spyOn(observeService, "observe").mockResolvedValue({
+        data: [],
+        metadata,
+      });
+      const model = { modelName: "openai/gpt-5.4-mini" as const };
+      const controller = createStagehandController(
+        runtimeWith({
+          apiKey: "bb-api-key",
+          browser: { sessionId: "session-123", region: "eu-central-1" },
+          model,
+        } as StagehandInitParams),
+      );
+
+      await controller.act({ pageId: "page-1", instruction: "Click" }, handlerContext);
+      await controller.extract(
+        { pageId: "page-1", instruction: "Extract", schema: {} },
+        handlerContext,
+      );
+      await controller.observe({ pageId: "page-1" }, handlerContext);
+
+      for (const service of [act, extract, observe]) {
+        expect(service).toHaveBeenCalledWith(
+          expect.objectContaining({
+            model,
+            gateway: {
+              apiUrl: "https://api.euc1.stagehand.browserbase.com/v1",
+              apiKey: "bb-api-key",
+              sessionId: "session-123",
+            },
+          }),
+        );
+      }
+    });
+
     it("routes every primitive without a model through the Browserbase gateway", async () => {
       const act = vi.spyOn(actService, "act").mockResolvedValue({
         data: { success: true, message: "", actionDescription: "", actions: [] },
@@ -203,18 +327,277 @@ describe("model configuration", () => {
       expect(extract).not.toHaveBeenCalled();
       expect(observe).not.toHaveBeenCalled();
     });
-    it.todo("rejects Browserbase managed inference when using a local browser");
-    it.todo("rejects an explicit model without provider auth when using a local browser");
-    it.todo("rejects a missing model when using a local browser");
+
+    it("rejects Browserbase managed inference when using a local browser", async () => {
+      const act = vi.spyOn(actService, "act");
+      const extract = vi.spyOn(extractService, "extract");
+      const observe = vi.spyOn(observeService, "observe");
+      const controller = createStagehandController(
+        runtimeWith({
+          apiKey: "bb-api-key",
+          browserCdpUrl: "ws://localhost:9222",
+        } as StagehandInitParams),
+      );
+
+      await expect(
+        controller.act({ pageId: "page-1", instruction: "Click" }, handlerContext),
+      ).rejects.toThrow("An LLM was not configured during Stagehand initialization");
+      await expect(
+        controller.extract(
+          { pageId: "page-1", instruction: "Extract", schema: {} },
+          handlerContext,
+        ),
+      ).rejects.toThrow("An LLM was not configured during Stagehand initialization");
+      await expect(controller.observe({ pageId: "page-1" }, handlerContext)).rejects.toThrow(
+        "An LLM was not configured during Stagehand initialization",
+      );
+
+      expect(act).not.toHaveBeenCalled();
+      expect(extract).not.toHaveBeenCalled();
+      expect(observe).not.toHaveBeenCalled();
+    });
+
+    it("forwards an explicit keyless model when using a local browser", async () => {
+      const act = vi.spyOn(actService, "act").mockResolvedValue({
+        data: { success: true, message: "", actionDescription: "", actions: [] },
+        metadata,
+      });
+      const extract = vi.spyOn(extractService, "extract").mockResolvedValue({
+        data: {},
+        metadata,
+      });
+      const observe = vi.spyOn(observeService, "observe").mockResolvedValue({
+        data: [],
+        metadata,
+      });
+      const model = { modelName: "openai/gpt-5.4-mini" as const };
+      const controller = createStagehandController(
+        runtimeWith({
+          browserCdpUrl: "ws://localhost:9222",
+          model,
+        } as StagehandInitParams),
+      );
+
+      // Controller forwards keyless models; llmService rejects later without a gateway.
+      await controller.act({ pageId: "page-1", instruction: "Click" }, handlerContext);
+      await controller.extract(
+        { pageId: "page-1", instruction: "Extract", schema: {} },
+        handlerContext,
+      );
+      await controller.observe({ pageId: "page-1" }, handlerContext);
+
+      for (const service of [act, extract, observe]) {
+        expect(service).toHaveBeenCalledWith(
+          expect.objectContaining({
+            model,
+            gateway: undefined,
+          }),
+        );
+      }
+    });
+
+    it("rejects a missing model when using a local browser", async () => {
+      const act = vi.spyOn(actService, "act");
+      const extract = vi.spyOn(extractService, "extract");
+      const observe = vi.spyOn(observeService, "observe");
+      const controller = createStagehandController(
+        runtimeWith({
+          browserCdpUrl: "ws://localhost:9222",
+        } as StagehandInitParams),
+      );
+
+      await expect(
+        controller.act({ pageId: "page-1", instruction: "Click" }, handlerContext),
+      ).rejects.toThrow("An LLM was not configured during Stagehand initialization");
+      await expect(
+        controller.extract(
+          { pageId: "page-1", instruction: "Extract", schema: {} },
+          handlerContext,
+        ),
+      ).rejects.toThrow("An LLM was not configured during Stagehand initialization");
+      await expect(controller.observe({ pageId: "page-1" }, handlerContext)).rejects.toThrow(
+        "An LLM was not configured during Stagehand initialization",
+      );
+
+      expect(act).not.toHaveBeenCalled();
+      expect(extract).not.toHaveBeenCalled();
+      expect(observe).not.toHaveBeenCalled();
+    });
   });
 
   describe("client inference", () => {
-    it.todo("uses the connected SDK when a client LLM callback is provided");
+    it("uses the connected SDK when a client LLM callback is provided", async () => {
+      const act = vi.spyOn(actService, "act").mockResolvedValue({
+        data: { success: true, message: "", actionDescription: "", actions: [] },
+        metadata,
+      });
+      const extract = vi.spyOn(extractService, "extract").mockResolvedValue({
+        data: {},
+        metadata,
+      });
+      const observe = vi.spyOn(observeService, "observe").mockResolvedValue({
+        data: [],
+        metadata,
+      });
+      const model = { source: "client" as const };
+      const runtime = runtimeWith({ model } as StagehandInitParams);
+      const controller = createStagehandController(runtime);
+
+      await controller.act({ pageId: "page-1", instruction: "Click" }, handlerContext);
+      await controller.extract(
+        { pageId: "page-1", instruction: "Extract", schema: {} },
+        handlerContext,
+      );
+      await controller.observe({ pageId: "page-1" }, handlerContext);
+
+      for (const service of [act, extract, observe]) {
+        expect(service).toHaveBeenCalledWith(
+          expect.objectContaining({
+            model,
+            clientLLMGenerate: runtime.adapters.clientLLMGenerate,
+            gateway: undefined,
+          }),
+        );
+      }
+    });
   });
 
   describe("per-call models", () => {
-    it.todo("uses the initialized model when a call does not provide one");
-    it.todo("uses the complete per-call model when a call provides one");
-    it.todo("does not inherit initialized credentials into a per-call model");
+    it("uses the initialized model when a call does not provide one", async () => {
+      const act = vi.spyOn(actService, "act").mockResolvedValue({
+        data: { success: true, message: "", actionDescription: "", actions: [] },
+        metadata,
+      });
+      const extract = vi.spyOn(extractService, "extract").mockResolvedValue({
+        data: {},
+        metadata,
+      });
+      const observe = vi.spyOn(observeService, "observe").mockResolvedValue({
+        data: [],
+        metadata,
+      });
+      const model = {
+        modelName: "openai/gpt-5.4-mini" as const,
+        apiKey: "sk-init",
+      };
+      const controller = createStagehandController(
+        runtimeWith({ model } as StagehandInitParams),
+      );
+
+      await controller.act({ pageId: "page-1", instruction: "Click" }, handlerContext);
+      await controller.extract(
+        { pageId: "page-1", instruction: "Extract", schema: {} },
+        handlerContext,
+      );
+      await controller.observe({ pageId: "page-1" }, handlerContext);
+
+      for (const service of [act, extract, observe]) {
+        expect(service).toHaveBeenCalledWith(
+          expect.objectContaining({
+            model,
+          }),
+        );
+      }
+    });
+
+    it("uses the complete per-call model when a call provides one", async () => {
+      const act = vi.spyOn(actService, "act").mockResolvedValue({
+        data: { success: true, message: "", actionDescription: "", actions: [] },
+        metadata,
+      });
+      const extract = vi.spyOn(extractService, "extract").mockResolvedValue({
+        data: {},
+        metadata,
+      });
+      const observe = vi.spyOn(observeService, "observe").mockResolvedValue({
+        data: [],
+        metadata,
+      });
+      const initModel = {
+        modelName: "openai/gpt-5.4-mini" as const,
+        apiKey: "sk-init",
+      };
+      const callModel = {
+        modelName: "anthropic/claude-sonnet-4-6" as const,
+        apiKey: "sk-call",
+        headers: { "x-call": "1" },
+      };
+      const controller = createStagehandController(
+        runtimeWith({ model: initModel } as StagehandInitParams),
+      );
+
+      await controller.act(
+        { pageId: "page-1", instruction: "Click", options: { model: callModel } },
+        handlerContext,
+      );
+      await controller.extract(
+        {
+          pageId: "page-1",
+          instruction: "Extract",
+          schema: {},
+          options: { model: callModel },
+        },
+        handlerContext,
+      );
+      await controller.observe(
+        { pageId: "page-1", options: { model: callModel } },
+        handlerContext,
+      );
+
+      for (const service of [act, extract, observe]) {
+        expect(service).toHaveBeenCalledWith(
+          expect.objectContaining({
+            model: callModel,
+          }),
+        );
+      }
+    });
+
+    it("does not inherit initialized credentials into a per-call model", async () => {
+      const act = vi.spyOn(actService, "act").mockResolvedValue({
+        data: { success: true, message: "", actionDescription: "", actions: [] },
+        metadata,
+      });
+      const extract = vi.spyOn(extractService, "extract").mockResolvedValue({
+        data: {},
+        metadata,
+      });
+      const observe = vi.spyOn(observeService, "observe").mockResolvedValue({
+        data: [],
+        metadata,
+      });
+      const initModel = {
+        modelName: "openai/gpt-5.4-mini" as const,
+        apiKey: "sk-init",
+        headers: { "x-init": "1" },
+      };
+      // Keyless per-call model is forwarded as-is; llmService rejects later without a gateway.
+      const callModel = { modelName: "anthropic/claude-sonnet-4-6" as const };
+      const controller = createStagehandController(
+        runtimeWith({ model: initModel } as StagehandInitParams),
+      );
+
+      await controller.act(
+        { pageId: "page-1", instruction: "Click", options: { model: callModel } },
+        handlerContext,
+      );
+      await controller.extract(
+        {
+          pageId: "page-1",
+          instruction: "Extract",
+          schema: {},
+          options: { model: callModel },
+        },
+        handlerContext,
+      );
+      await controller.observe(
+        { pageId: "page-1", options: { model: callModel } },
+        handlerContext,
+      );
+
+      for (const service of [act, extract, observe]) {
+        expect(service.mock.calls[0]?.[0].model).toEqual(callModel);
+      }
+    });
   });
 });

--- a/packages/extension/tests/model-resolution.test.ts
+++ b/packages/extension/tests/model-resolution.test.ts
@@ -43,6 +43,12 @@ const handlerContext = {
   telemetryScope: Symbol("model-resolution-test"),
 } as unknown as HandlerContext;
 
+const browserbaseGateway = {
+  apiUrl: "https://api.euc1.stagehand.browserbase.com/v1",
+  apiKey: "bb-api-key",
+  sessionId: "session-123",
+} as const;
+
 function runtimeWith(initParams: StagehandInitParams): StagehandRuntime {
   return {
     state: { getState: () => ({ status: "initialized", initParams }) },
@@ -53,6 +59,79 @@ function runtimeWith(initParams: StagehandInitParams): StagehandRuntime {
     runWithTelemetryContext: async (_scope: symbol, _logger: unknown, run: () => unknown) =>
       await run(),
   } as unknown as StagehandRuntime;
+}
+
+function spyPrimitiveServices(options?: { resolve?: boolean }) {
+  const resolve = options?.resolve ?? true;
+  const act = vi.spyOn(actService, "act");
+  const extract = vi.spyOn(extractService, "extract");
+  const observe = vi.spyOn(observeService, "observe");
+  if (resolve) {
+    act.mockResolvedValue({
+      data: { success: true, message: "", actionDescription: "", actions: [] },
+      metadata,
+    });
+    extract.mockResolvedValue({ data: {}, metadata });
+    observe.mockResolvedValue({ data: [], metadata });
+  }
+  return { act, extract, observe };
+}
+
+async function callPrimitives(
+  controller: ReturnType<typeof createStagehandController>,
+  model?: StagehandInitParams["model"],
+) {
+  const options = model === undefined ? undefined : { model };
+  await controller.act(
+    { pageId: "page-1", instruction: "Click", ...(options ? { options } : {}) },
+    handlerContext,
+  );
+  await controller.extract(
+    {
+      pageId: "page-1",
+      instruction: "Extract",
+      schema: {},
+      ...(options ? { options } : {}),
+    },
+    handlerContext,
+  );
+  await controller.observe(
+    { pageId: "page-1", ...(options ? { options } : {}) },
+    handlerContext,
+  );
+}
+
+async function expectPrimitivesReject(
+  controller: ReturnType<typeof createStagehandController>,
+  message: string,
+) {
+  await expect(
+    controller.act({ pageId: "page-1", instruction: "Click" }, handlerContext),
+  ).rejects.toThrow(message);
+  await expect(
+    controller.extract(
+      { pageId: "page-1", instruction: "Extract", schema: {} },
+      handlerContext,
+    ),
+  ).rejects.toThrow(message);
+  await expect(controller.observe({ pageId: "page-1" }, handlerContext)).rejects.toThrow(
+    message,
+  );
+}
+
+function expectForwarded(
+  services: ReturnType<typeof spyPrimitiveServices>,
+  expected: Record<string, unknown>,
+) {
+  for (const service of [services.act, services.extract, services.observe]) {
+    expect(service).toHaveBeenCalledWith(expect.objectContaining(expected));
+  }
+}
+
+function expectNotCalled(services: ReturnType<typeof spyPrimitiveServices>) {
+  expect(services.act).not.toHaveBeenCalled();
+  expect(services.extract).not.toHaveBeenCalled();
+  expect(services.observe).not.toHaveBeenCalled();
 }
 
 describe("model configuration", () => {
@@ -134,18 +213,7 @@ describe("model configuration", () => {
 
   describe("direct inference", () => {
     it("uses direct inference when provider authentication is provided", async () => {
-      const act = vi.spyOn(actService, "act").mockResolvedValue({
-        data: { success: true, message: "", actionDescription: "", actions: [] },
-        metadata,
-      });
-      const extract = vi.spyOn(extractService, "extract").mockResolvedValue({
-        data: {},
-        metadata,
-      });
-      const observe = vi.spyOn(observeService, "observe").mockResolvedValue({
-        data: [],
-        metadata,
-      });
+      const services = spyPrimitiveServices();
       const model = {
         modelName: "openai/gpt-5.4-mini" as const,
         apiKey: "sk-provider",
@@ -154,36 +222,12 @@ describe("model configuration", () => {
         runtimeWith({ model } as StagehandInitParams),
       );
 
-      await controller.act({ pageId: "page-1", instruction: "Click" }, handlerContext);
-      await controller.extract(
-        { pageId: "page-1", instruction: "Extract", schema: {} },
-        handlerContext,
-      );
-      await controller.observe({ pageId: "page-1" }, handlerContext);
-
-      for (const service of [act, extract, observe]) {
-        expect(service).toHaveBeenCalledWith(
-          expect.objectContaining({
-            model,
-            gateway: undefined,
-          }),
-        );
-      }
+      await callPrimitives(controller);
+      expectForwarded(services, { model, gateway: undefined });
     });
 
     it("prefers direct inference when using a Browserbase browser with provider auth", async () => {
-      const act = vi.spyOn(actService, "act").mockResolvedValue({
-        data: { success: true, message: "", actionDescription: "", actions: [] },
-        metadata,
-      });
-      const extract = vi.spyOn(extractService, "extract").mockResolvedValue({
-        data: {},
-        metadata,
-      });
-      const observe = vi.spyOn(observeService, "observe").mockResolvedValue({
-        data: [],
-        metadata,
-      });
+      const services = spyPrimitiveServices();
       const model = {
         modelName: "openai/gpt-5.4-mini" as const,
         apiKey: "sk-provider",
@@ -196,43 +240,15 @@ describe("model configuration", () => {
         } as StagehandInitParams),
       );
 
-      await controller.act({ pageId: "page-1", instruction: "Click" }, handlerContext);
-      await controller.extract(
-        { pageId: "page-1", instruction: "Extract", schema: {} },
-        handlerContext,
-      );
-      await controller.observe({ pageId: "page-1" }, handlerContext);
-
+      await callPrimitives(controller);
       // Gateway is still passed; llmService prefers direct inference when apiKey is set.
-      for (const service of [act, extract, observe]) {
-        expect(service).toHaveBeenCalledWith(
-          expect.objectContaining({
-            model,
-            gateway: {
-              apiUrl: "https://api.euc1.stagehand.browserbase.com/v1",
-              apiKey: "bb-api-key",
-              sessionId: "session-123",
-            },
-          }),
-        );
-      }
+      expectForwarded(services, { model, gateway: browserbaseGateway });
     });
   });
 
   describe("Browserbase managed inference", () => {
     it("uses Browserbase managed inference for an explicit model without provider auth", async () => {
-      const act = vi.spyOn(actService, "act").mockResolvedValue({
-        data: { success: true, message: "", actionDescription: "", actions: [] },
-        metadata,
-      });
-      const extract = vi.spyOn(extractService, "extract").mockResolvedValue({
-        data: {},
-        metadata,
-      });
-      const observe = vi.spyOn(observeService, "observe").mockResolvedValue({
-        data: [],
-        metadata,
-      });
+      const services = spyPrimitiveServices();
       const model = { modelName: "openai/gpt-5.4-mini" as const };
       const controller = createStagehandController(
         runtimeWith({
@@ -242,40 +258,12 @@ describe("model configuration", () => {
         } as StagehandInitParams),
       );
 
-      await controller.act({ pageId: "page-1", instruction: "Click" }, handlerContext);
-      await controller.extract(
-        { pageId: "page-1", instruction: "Extract", schema: {} },
-        handlerContext,
-      );
-      await controller.observe({ pageId: "page-1" }, handlerContext);
-
-      for (const service of [act, extract, observe]) {
-        expect(service).toHaveBeenCalledWith(
-          expect.objectContaining({
-            model,
-            gateway: {
-              apiUrl: "https://api.euc1.stagehand.browserbase.com/v1",
-              apiKey: "bb-api-key",
-              sessionId: "session-123",
-            },
-          }),
-        );
-      }
+      await callPrimitives(controller);
+      expectForwarded(services, { model, gateway: browserbaseGateway });
     });
 
     it("routes every primitive without a model through the Browserbase gateway", async () => {
-      const act = vi.spyOn(actService, "act").mockResolvedValue({
-        data: { success: true, message: "", actionDescription: "", actions: [] },
-        metadata,
-      });
-      const extract = vi.spyOn(extractService, "extract").mockResolvedValue({
-        data: {},
-        metadata,
-      });
-      const observe = vi.spyOn(observeService, "observe").mockResolvedValue({
-        data: [],
-        metadata,
-      });
+      const services = spyPrimitiveServices();
       const controller = createStagehandController(
         runtimeWith({
           apiKey: "bb-api-key",
@@ -283,55 +271,23 @@ describe("model configuration", () => {
         } as StagehandInitParams),
       );
 
-      await controller.act({ pageId: "page-1", instruction: "Click" }, handlerContext);
-      await controller.extract(
-        { pageId: "page-1", instruction: "Extract", schema: {} },
-        handlerContext,
-      );
-      await controller.observe({ pageId: "page-1" }, handlerContext);
-
-      for (const service of [act, extract, observe]) {
-        expect(service).toHaveBeenCalledWith(
-          expect.objectContaining({
-            model: undefined,
-            gateway: {
-              apiUrl: "https://api.euc1.stagehand.browserbase.com/v1",
-              apiKey: "bb-api-key",
-              sessionId: "session-123",
-            },
-          }),
-        );
-      }
+      await callPrimitives(controller);
+      expectForwarded(services, { model: undefined, gateway: browserbaseGateway });
     });
 
     it("rejects every primitive without a model or Browserbase gateway", async () => {
-      const act = vi.spyOn(actService, "act");
-      const extract = vi.spyOn(extractService, "extract");
-      const observe = vi.spyOn(observeService, "observe");
+      const services = spyPrimitiveServices({ resolve: false });
       const controller = createStagehandController(runtimeWith({} as StagehandInitParams));
 
-      await expect(
-        controller.act({ pageId: "page-1", instruction: "Click" }, handlerContext),
-      ).rejects.toThrow("An LLM was not configured during Stagehand initialization");
-      await expect(
-        controller.extract(
-          { pageId: "page-1", instruction: "Extract", schema: {} },
-          handlerContext,
-        ),
-      ).rejects.toThrow("An LLM was not configured during Stagehand initialization");
-      await expect(controller.observe({ pageId: "page-1" }, handlerContext)).rejects.toThrow(
+      await expectPrimitivesReject(
+        controller,
         "An LLM was not configured during Stagehand initialization",
       );
-
-      expect(act).not.toHaveBeenCalled();
-      expect(extract).not.toHaveBeenCalled();
-      expect(observe).not.toHaveBeenCalled();
+      expectNotCalled(services);
     });
 
     it("rejects Browserbase managed inference when using a local browser", async () => {
-      const act = vi.spyOn(actService, "act");
-      const extract = vi.spyOn(extractService, "extract");
-      const observe = vi.spyOn(observeService, "observe");
+      const services = spyPrimitiveServices({ resolve: false });
       const controller = createStagehandController(
         runtimeWith({
           apiKey: "bb-api-key",
@@ -339,37 +295,15 @@ describe("model configuration", () => {
         } as StagehandInitParams),
       );
 
-      await expect(
-        controller.act({ pageId: "page-1", instruction: "Click" }, handlerContext),
-      ).rejects.toThrow("An LLM was not configured during Stagehand initialization");
-      await expect(
-        controller.extract(
-          { pageId: "page-1", instruction: "Extract", schema: {} },
-          handlerContext,
-        ),
-      ).rejects.toThrow("An LLM was not configured during Stagehand initialization");
-      await expect(controller.observe({ pageId: "page-1" }, handlerContext)).rejects.toThrow(
+      await expectPrimitivesReject(
+        controller,
         "An LLM was not configured during Stagehand initialization",
       );
-
-      expect(act).not.toHaveBeenCalled();
-      expect(extract).not.toHaveBeenCalled();
-      expect(observe).not.toHaveBeenCalled();
+      expectNotCalled(services);
     });
 
     it("forwards an explicit keyless model when using a local browser", async () => {
-      const act = vi.spyOn(actService, "act").mockResolvedValue({
-        data: { success: true, message: "", actionDescription: "", actions: [] },
-        metadata,
-      });
-      const extract = vi.spyOn(extractService, "extract").mockResolvedValue({
-        data: {},
-        metadata,
-      });
-      const observe = vi.spyOn(observeService, "observe").mockResolvedValue({
-        data: [],
-        metadata,
-      });
+      const services = spyPrimitiveServices();
       const model = { modelName: "openai/gpt-5.4-mini" as const };
       const controller = createStagehandController(
         runtimeWith({
@@ -379,103 +313,45 @@ describe("model configuration", () => {
       );
 
       // Controller forwards keyless models; llmService rejects later without a gateway.
-      await controller.act({ pageId: "page-1", instruction: "Click" }, handlerContext);
-      await controller.extract(
-        { pageId: "page-1", instruction: "Extract", schema: {} },
-        handlerContext,
-      );
-      await controller.observe({ pageId: "page-1" }, handlerContext);
-
-      for (const service of [act, extract, observe]) {
-        expect(service).toHaveBeenCalledWith(
-          expect.objectContaining({
-            model,
-            gateway: undefined,
-          }),
-        );
-      }
+      await callPrimitives(controller);
+      expectForwarded(services, { model, gateway: undefined });
     });
 
     it("rejects a missing model when using a local browser", async () => {
-      const act = vi.spyOn(actService, "act");
-      const extract = vi.spyOn(extractService, "extract");
-      const observe = vi.spyOn(observeService, "observe");
+      const services = spyPrimitiveServices({ resolve: false });
       const controller = createStagehandController(
         runtimeWith({
           browserCdpUrl: "ws://localhost:9222",
         } as StagehandInitParams),
       );
 
-      await expect(
-        controller.act({ pageId: "page-1", instruction: "Click" }, handlerContext),
-      ).rejects.toThrow("An LLM was not configured during Stagehand initialization");
-      await expect(
-        controller.extract(
-          { pageId: "page-1", instruction: "Extract", schema: {} },
-          handlerContext,
-        ),
-      ).rejects.toThrow("An LLM was not configured during Stagehand initialization");
-      await expect(controller.observe({ pageId: "page-1" }, handlerContext)).rejects.toThrow(
+      await expectPrimitivesReject(
+        controller,
         "An LLM was not configured during Stagehand initialization",
       );
-
-      expect(act).not.toHaveBeenCalled();
-      expect(extract).not.toHaveBeenCalled();
-      expect(observe).not.toHaveBeenCalled();
+      expectNotCalled(services);
     });
   });
 
   describe("client inference", () => {
     it("uses the connected SDK when a client LLM callback is provided", async () => {
-      const act = vi.spyOn(actService, "act").mockResolvedValue({
-        data: { success: true, message: "", actionDescription: "", actions: [] },
-        metadata,
-      });
-      const extract = vi.spyOn(extractService, "extract").mockResolvedValue({
-        data: {},
-        metadata,
-      });
-      const observe = vi.spyOn(observeService, "observe").mockResolvedValue({
-        data: [],
-        metadata,
-      });
+      const services = spyPrimitiveServices();
       const model = { source: "client" as const };
       const runtime = runtimeWith({ model } as StagehandInitParams);
       const controller = createStagehandController(runtime);
 
-      await controller.act({ pageId: "page-1", instruction: "Click" }, handlerContext);
-      await controller.extract(
-        { pageId: "page-1", instruction: "Extract", schema: {} },
-        handlerContext,
-      );
-      await controller.observe({ pageId: "page-1" }, handlerContext);
-
-      for (const service of [act, extract, observe]) {
-        expect(service).toHaveBeenCalledWith(
-          expect.objectContaining({
-            model,
-            clientLLMGenerate: runtime.adapters.clientLLMGenerate,
-            gateway: undefined,
-          }),
-        );
-      }
+      await callPrimitives(controller);
+      expectForwarded(services, {
+        model,
+        clientLLMGenerate: runtime.adapters.clientLLMGenerate,
+        gateway: undefined,
+      });
     });
   });
 
   describe("per-call models", () => {
     it("uses the initialized model when a call does not provide one", async () => {
-      const act = vi.spyOn(actService, "act").mockResolvedValue({
-        data: { success: true, message: "", actionDescription: "", actions: [] },
-        metadata,
-      });
-      const extract = vi.spyOn(extractService, "extract").mockResolvedValue({
-        data: {},
-        metadata,
-      });
-      const observe = vi.spyOn(observeService, "observe").mockResolvedValue({
-        data: [],
-        metadata,
-      });
+      const services = spyPrimitiveServices();
       const model = {
         modelName: "openai/gpt-5.4-mini" as const,
         apiKey: "sk-init",
@@ -484,35 +360,12 @@ describe("model configuration", () => {
         runtimeWith({ model } as StagehandInitParams),
       );
 
-      await controller.act({ pageId: "page-1", instruction: "Click" }, handlerContext);
-      await controller.extract(
-        { pageId: "page-1", instruction: "Extract", schema: {} },
-        handlerContext,
-      );
-      await controller.observe({ pageId: "page-1" }, handlerContext);
-
-      for (const service of [act, extract, observe]) {
-        expect(service).toHaveBeenCalledWith(
-          expect.objectContaining({
-            model,
-          }),
-        );
-      }
+      await callPrimitives(controller);
+      expectForwarded(services, { model });
     });
 
     it("uses the complete per-call model when a call provides one", async () => {
-      const act = vi.spyOn(actService, "act").mockResolvedValue({
-        data: { success: true, message: "", actionDescription: "", actions: [] },
-        metadata,
-      });
-      const extract = vi.spyOn(extractService, "extract").mockResolvedValue({
-        data: {},
-        metadata,
-      });
-      const observe = vi.spyOn(observeService, "observe").mockResolvedValue({
-        data: [],
-        metadata,
-      });
+      const services = spyPrimitiveServices();
       const initModel = {
         modelName: "openai/gpt-5.4-mini" as const,
         apiKey: "sk-init",
@@ -526,46 +379,12 @@ describe("model configuration", () => {
         runtimeWith({ model: initModel } as StagehandInitParams),
       );
 
-      await controller.act(
-        { pageId: "page-1", instruction: "Click", options: { model: callModel } },
-        handlerContext,
-      );
-      await controller.extract(
-        {
-          pageId: "page-1",
-          instruction: "Extract",
-          schema: {},
-          options: { model: callModel },
-        },
-        handlerContext,
-      );
-      await controller.observe(
-        { pageId: "page-1", options: { model: callModel } },
-        handlerContext,
-      );
-
-      for (const service of [act, extract, observe]) {
-        expect(service).toHaveBeenCalledWith(
-          expect.objectContaining({
-            model: callModel,
-          }),
-        );
-      }
+      await callPrimitives(controller, callModel);
+      expectForwarded(services, { model: callModel });
     });
 
     it("does not inherit initialized credentials into a per-call model", async () => {
-      const act = vi.spyOn(actService, "act").mockResolvedValue({
-        data: { success: true, message: "", actionDescription: "", actions: [] },
-        metadata,
-      });
-      const extract = vi.spyOn(extractService, "extract").mockResolvedValue({
-        data: {},
-        metadata,
-      });
-      const observe = vi.spyOn(observeService, "observe").mockResolvedValue({
-        data: [],
-        metadata,
-      });
+      const services = spyPrimitiveServices();
       const initModel = {
         modelName: "openai/gpt-5.4-mini" as const,
         apiKey: "sk-init",
@@ -577,25 +396,8 @@ describe("model configuration", () => {
         runtimeWith({ model: initModel } as StagehandInitParams),
       );
 
-      await controller.act(
-        { pageId: "page-1", instruction: "Click", options: { model: callModel } },
-        handlerContext,
-      );
-      await controller.extract(
-        {
-          pageId: "page-1",
-          instruction: "Extract",
-          schema: {},
-          options: { model: callModel },
-        },
-        handlerContext,
-      );
-      await controller.observe(
-        { pageId: "page-1", options: { model: callModel } },
-        handlerContext,
-      );
-
-      for (const service of [act, extract, observe]) {
+      await callPrimitives(controller, callModel);
+      for (const service of [services.act, services.extract, services.observe]) {
         expect(service.mock.calls[0]?.[0].model).toEqual(callModel);
       }
     });


### PR DESCRIPTION
## Summary
- Replace `it.todo` placeholders in `packages/extension/tests/model-resolution.test.ts` with controller-level coverage for model string and object resolution paths.
- Align a misleading test name with current controller behavior (keyless models are forwarded; rejection happens later in `llmService`).

## Test plan
- [ ] `pnpm --filter @browserbasehq/stagehand-extension exec vitest run tests/model-resolution.test.ts` (or equivalent package filter) passes
- [ ] Confirm no remaining `it.todo` in that file

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces it.todo tests in `packages/extension/tests/model-resolution.test.ts` with controller-level coverage for model resolution and Browserbase gateway routing, and dedupes primitive spy scaffolding via shared helpers. Increases confidence in inference selection without changing runtime behavior.

- Direct inference: uses provider auth; preferred even when a Browserbase session exists (gateway still forwarded; selection happens in `llmService`).
- Browserbase managed inference: keyless explicit model or no model routes via the gateway; rejects when no model and no gateway; rejects managed inference with a local browser; forwards a keyless explicit model with a local browser (later rejected by `llmService`); rejects a missing model with a local browser.
- Client inference: `model.source: "client"` uses the connected SDK callback.
- Per-call models: uses the initialized model by default; a per-call model fully overrides; initialized credentials do not inherit into per-call models.
- Aligns a misleading test name with current controller behavior.

<sup>Written for commit 74c6825e26a0fdbab6008dade52ad54232efc2a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

