### PR TITLE
Add Hermes browser benchmark harness to Stagehand evals

### DIFF
--- a/packages/evals/HERMES_PILOT.md
+++ b/packages/evals/HERMES_PILOT.md
@@ -1,0 +1,157 @@
+# Hermes × Stagehand verifier pilot
+
+This adapter runs Hermes's own agent loop against the unchanged public dataset
+rows and verifier path in `@browserbasehq/stagehand-evals`.
+
+The frozen pilot is `pilots/hermes-online-mind2web-hard-v1.json`: ten official
+Online-Mind2Web `hard` tasks curated before scoring across ten distinct public
+sites. The slice favors high reference lengths while excluding login, payment,
+irreversible, expired fixed-date, and relative-date tasks. The selection is
+validated by `tests/framework/hermesPilot.test.ts`; it is not the first ten
+rows or a post-result sample.
+
+## Arms
+
+- `--harness hermes --tool hermes_browser_legacy`: Hermes's twelve-tool
+  `browser_*` surface.
+- `--harness hermes --tool hermes_browser_exec`: Hermes's one-tool Browser Use
+  `browser_exec` surface.
+- `--harness hermes --tool hermes_stagehand_batch`: Hermes's one-tool
+  `browser_exec` surface backed by Stagehand V4 `experimental_batch`.
+
+All three arms use Hermes `--provider ai-gateway`, the exact model ID supplied by
+`--model`, the same Browserbase environment, the same task row, and the same
+Stagehand verifier. The verifier model is independently configured through
+`EVAL_VERIFIER_MODEL=gateway/google/gemini-2.5-flash` and uses
+`AI_GATEWAY_API_KEY`. A trajectory passes only when `outcome=true` and
+`process_score>=0.8`; the commands therefore use `--success both`.
+
+The Hermes child environment is allowlisted to the Gateway and Browserbase
+credentials plus runtime/networking variables. Unrelated service tokens are
+excluded so they cannot change capability discovery, tool schemas, or reach a
+model-driven subprocess.
+
+The methodology-target verifier, `gateway/openai/o4-mini`, was exercised
+through Vercel AI Gateway before the pilot. Its real rubric-generation request
+failed with `GatewayInternalServerError: The API deployment for this resource
+does not exist.` No browser or agent retry was made. The frozen fallback is
+`gateway/google/gemini-2.5-flash`, which successfully generated the same task's
+rubric through the Gateway. This provider substitution must be reported with
+the benchmark results.
+
+Set one durable `EVAL_RUBRIC_CACHE_ROOT` for the entire experiment. The first
+successful verifier pass generates one rubric per task and stores it under the
+task ID plus instruction hash; every later arm reads that exact cached rubric.
+Do not clear or change this directory between arms.
+
+The Stagehand arm imports the Python SDK from a clean checkout pinned at commit
+`4186c7d98d2f325b6fc85b3f760111e6c390d703`. It defaults to
+`/workspace/stagehand-v4-tip-4186`; `EVAL_STAGEHAND_V4_ROOT` may point to an
+equivalent clean checkout, but the adapter verifies the exact commit before a
+run and refuses a dirty or mismatched tree.
+
+Hermes's opt-in benchmark instrumentation captures URL and screenshot evidence
+after successful browser calls. The adapter attaches these frames to the
+corresponding Stagehand `TrajectoryStep`, retains the final observation, and
+preserves Hermes tool arguments/results, reasoning, final answer, and usage.
+
+## Preview without model or browser spend
+
+```bash
+OPUS_IDS=$(node -p "require('./packages/evals/pilots/hermes-online-mind2web-hard-v1.json').task_model_pairs.filter(x=>x.model.includes('opus')).map(x=>x.task_id).join(',')")
+pnpm --filter @browserbasehq/stagehand-evals eval run b:onlineMind2Web \
+  --harness hermes --tool hermes_browser_exec --env browserbase \
+  --model anthropic/claude-opus-4.8 --trials 1 --concurrency 1 \
+  --filter "ids=$OPUS_IDS" --preview
+```
+
+## Scored pilot
+
+Set these through managed environment injection, never in repository files:
+
+- `AI_GATEWAY_API_KEY`
+- `BROWSERBASE_API_KEY`
+- `BROWSERBASE_PROJECT_ID` is optional when the API key can see exactly one
+  project; the runner discovers that project for its child process without
+  logging or persisting the ID. Set it explicitly when the key sees more than
+  one project.
+
+The manifest-driven runner enforces the task/model pairing, task-level
+counterbalanced arm order, 30-minute timeout, source hash, source/runtime pins,
+and resumable row identities. Previewing prints the exact rows and creates no
+browser sessions or model calls:
+
+```bash
+export EVAL_HERMES_ROOT=/workspace/hermes-stagehand-batch
+export EVAL_STAGEHAND_V4_ROOT=/workspace/stagehand-v4-tip-4186
+export EVAL_VERIFIER_MODEL=gateway/google/gemini-2.5-flash
+export EVAL_RUBRIC_CACHE_ROOT=/workspace/stagehand-public-pilot-rubric-cache
+export EVAL_MAX_UNVERIFIABLE_CRITERIA=0
+pnpm --filter @browserbasehq/stagehand-evals benchmark:hermes-public-hard \
+  --phase canary --dry-run
+
+pnpm --filter @browserbasehq/stagehand-evals benchmark:hermes-public-hard \
+  --phase full --dry-run
+
+pnpm --filter @browserbasehq/stagehand-evals benchmark:hermes-public-hard \
+  --phase canary --confirm-billable --output /workspace/stagehand-evals-public-hard-canary
+
+pnpm --filter @browserbasehq/stagehand-evals benchmark:hermes-public-hard \
+  --phase full --confirm-billable --output /workspace/stagehand-evals-public-hard-full \
+  --canary-root /workspace/stagehand-evals-public-hard-canary
+```
+
+For raw Hermes audit artifacts, set `EVAL_HERMES_ARTIFACT_ROOT` to a directory
+outside the repository. When unset, raw subprocess state is removed after the
+normalized trajectory is built; the normal Stagehand trajectory artifact is
+still persisted.
+
+## Recover a retained artifact with a verifier sidecar
+
+If a runner record is `status: "error"` but its retained Hermes artifact is
+complete and independently evidenced, rerun only the Stagehand verifier. This
+is a billable verifier request, but it does not relaunch Hermes or a browser:
+
+```bash
+pnpm --filter @browserbasehq/stagehand-evals regrade:hermes -- \
+  --artifact /workspace/stagehand-public-pilot-hermes-artifacts/<run> \
+  --task-id <frozen-task-id> \
+  --surface hermes_browser_exec \
+  --trajectory-root /workspace/stagehand-public-pilot-regrade \
+  --result-json /workspace/stagehand-evals-public-hard-full/<run>/verifier-result.json
+```
+
+Choose the surface that matches the immutable raw record:
+`hermes_browser_legacy`, `hermes_browser_exec`, or
+`hermes_stagehand_batch`. Keep the same durable rubric cache and frozen
+`EVAL_VERIFIER_MODEL` used by the matrix.
+
+`record.json` remains immutable. The runner and reporting layer accept the
+adjacent `verifier-result.json` only when its schema version, task, surface,
+verifier model, criterion count, evidence-insufficient count, score, outcome,
+and retained trajectory directory are all valid. For the frozen `both` success
+mode, a pass requires `outcome=true`, `process_score>=0.8`, and zero
+evidence-insufficient criteria. A valid failed verdict remains a failed grade;
+a missing, malformed, or identity-mismatched sidecar fails closed. Reports
+retain the raw error status and count the sidecar as an effective regrade
+instead of rewriting the original record.
+
+## Final report handoff
+
+Keep canary/full roots, raw Hermes artifacts, trajectories, rubric caches, and
+runner logs outside this repository. After the full 30-record schedule stops:
+
+1. preserve the output root byte-for-byte;
+2. resolve any eligible retained-artifact regrades into adjacent sidecars;
+3. retain the original summary as historical runner output—the strict report
+   resolves raw records and sidecars independently; and
+4. hand the unchanged Stagehand evals root to the benchmark repository's
+   `benchmarks.public_hard.matched_analysis` command alongside the completed
+   Hermes-native root.
+
+The publishable bundle belongs in the benchmark repository under `reports/`,
+not in `packages/evals/artifacts/`. It should contain only the strict
+machine-readable analysis, Markdown/HTML rendering, runtime provenance,
+scheduled-record hashes, and methodology log. Do not publish screenshots,
+DOMs, browser profiles, state databases, raw trajectories, credentials, or
+transient partial-run summaries.

--- a/packages/evals/core/contracts/tool.ts
+++ b/packages/evals/core/contracts/tool.ts
@@ -15,7 +15,8 @@ export type ToolSurface =
   /** Hermes-owned browser surfaces. These are bench-harness surfaces, not CoreTools. */
   | "hermes_browser_legacy"
   | "hermes_browser_exec"
-  | "hermes_stagehand_batch";
+  | "hermes_stagehand_batch"
+  | "hermes_stagehand_facade";
 
 export type StartupProfile =
   | "runner_provided_local_cdp"

--- a/packages/evals/core/contracts/tool.ts
+++ b/packages/evals/core/contracts/tool.ts
@@ -11,7 +11,11 @@ export type ToolSurface =
   | "cdp_code"
   | "playwright_mcp"
   | "chrome_devtools_mcp"
-  | "browse_cli";
+  | "browse_cli"
+  /** Hermes-owned browser surfaces. These are bench-harness surfaces, not CoreTools. */
+  | "hermes_browser_legacy"
+  | "hermes_browser_exec"
+  | "hermes_stagehand_batch";
 
 export type StartupProfile =
   | "runner_provided_local_cdp"

--- a/packages/evals/framework/benchHarness.ts
+++ b/packages/evals/framework/benchHarness.ts
@@ -11,6 +11,7 @@ import {
 import { runCodexAgent } from "./codexRunner.js";
 import { prepareCodexToolAdapter, type PreparedCodexToolAdapter } from "./codexToolAdapter.js";
 import { buildExternalHarnessTaskPlan } from "./externalHarnessPlan.js";
+import { resolveHermesToolSurface, runHermesAgent } from "./hermesRunner.js";
 import type { DiscoveredTask, TaskResult } from "./types.js";
 import type { BenchMatrixRow, BenchTaskKind, Harness } from "./benchTypes.js";
 
@@ -236,10 +237,48 @@ export const codexHarness: BenchHarness = {
   },
 };
 
+export const hermesHarness: BenchHarness = {
+  harness: "hermes",
+  supportedTaskKinds: ["agent", "suite"],
+  supportsApi: false,
+  async execute({ input, row, logger, signal }: BenchHarnessExecuteInput): Promise<TaskResult> {
+    const plan = buildExternalHarnessTaskPlan(input);
+    if (row.config.harness !== "hermes") {
+      throw new EvalsError(`Expected hermes harness config, received "${row.config.harness}".`);
+    }
+    const carrierV3 = buildVerifierCarrierV3(logger);
+    try {
+      const taskSpec = buildExternalHarnessTaskSpec(plan, input);
+      return await runHermesAgent({
+        plan,
+        taskSpec,
+        model: input.modelName,
+        surface: resolveHermesToolSurface(row.config.toolSurface),
+        environment: row.config.environment,
+        logger,
+        signal,
+        verifier: {
+          v3: carrierV3,
+          taskSpec,
+          dataset: plan.dataset,
+        },
+      });
+    } finally {
+      await carrierV3.close().catch(() => {});
+    }
+  },
+  async start(): Promise<StartedBenchHarness> {
+    throw new EvalsError(
+      "Hermes harness execution uses the external harness execute path. Use --dry-run to inspect its bench matrix, or run with --harness hermes.",
+    );
+  },
+};
+
 const harnessRegistry = new Map<Harness, BenchHarness>([
   ["stagehand", stagehandHarness],
   ["claude_code", claudeCodeHarness],
   ["codex", codexHarness],
+  ["hermes", hermesHarness],
 ]);
 
 export function getBenchHarness(harness: Harness): BenchHarness {

--- a/packages/evals/framework/benchPlanner.ts
+++ b/packages/evals/framework/benchPlanner.ts
@@ -21,11 +21,16 @@ import {
   resolveClaudeCodeToolSurface,
 } from "./claudeCodeToolAdapter.js";
 import { resolveCodexStartupProfile, resolveCodexToolSurface } from "./codexToolAdapter.js";
+import { resolveHermesStartupProfile, resolveHermesToolSurface } from "./hermesRunner.js";
 
 const DEFAULT_CLAUDE_CODE_MODELS: AvailableModel[] = [
   "anthropic/claude-sonnet-4-6" as AvailableModel,
 ];
 const DEFAULT_CODEX_MODELS: AvailableModel[] = ["openai/gpt-5.4-mini" as AvailableModel];
+const DEFAULT_HERMES_MODELS: AvailableModel[] = [
+  "anthropic/claude-opus-4.8" as AvailableModel,
+  "moonshotai/kimi-k3" as AvailableModel,
+];
 
 export interface BenchPlanOptions {
   environment?: "LOCAL" | "BROWSERBASE";
@@ -107,6 +112,14 @@ function resolveDefaultModelEntries(
 
   if (harness === "codex") {
     return readModelListEnv("EVAL_CODEX_MODELS", DEFAULT_CODEX_MODELS).map((modelName) => ({
+      modelName,
+      mode: "hybrid",
+      cua: false,
+    }));
+  }
+
+  if (harness === "hermes") {
+    return readModelListEnv("EVAL_HERMES_MODELS", DEFAULT_HERMES_MODELS).map((modelName) => ({
       modelName,
       mode: "hybrid",
       cua: false,
@@ -246,7 +259,11 @@ export function generateBenchTestcases(
   const suiteTestcases = generateSuiteTestcases(plannedTasks, options, modelEntries);
   const allTestcases = [...suiteTestcases.testcases];
 
-  if (options.harness === "claude_code" || options.harness === "codex") {
+  if (
+    options.harness === "claude_code" ||
+    options.harness === "codex" ||
+    options.harness === "hermes"
+  ) {
     if (suiteTestcases.remainingTasks.length > 0) {
       const unsupported = suiteTestcases.remainingTasks
         .map((task) => task.name)
@@ -308,6 +325,9 @@ function resolveBenchRowToolSurface(
   if (harness === "codex") {
     return resolveCodexToolSurface(requested);
   }
+  if (harness === "hermes") {
+    return resolveHermesToolSurface(requested);
+  }
   return requested;
 }
 
@@ -322,6 +342,13 @@ function resolveBenchRowStartupProfile(
   }
   if (harness === "codex") {
     return resolveCodexStartupProfile(toolSurface ?? "browse_cli", environment, requested);
+  }
+  if (harness === "hermes") {
+    return resolveHermesStartupProfile(
+      toolSurface ?? "hermes_browser_exec",
+      environment,
+      requested,
+    );
   }
   return requested;
 }

--- a/packages/evals/framework/benchTypes.ts
+++ b/packages/evals/framework/benchTypes.ts
@@ -1,7 +1,7 @@
 import type { AvailableModel } from "stagehand-v3";
 import type { StartupProfile, ToolSurface } from "../core/contracts/tool.js";
 
-export type Harness = "stagehand" | "claude_code" | "codex";
+export type Harness = "stagehand" | "claude_code" | "codex" | "hermes";
 
 export const DEFAULT_BENCH_HARNESS: Harness = "stagehand";
 
@@ -9,12 +9,14 @@ export const SUPPORTED_BENCH_HARNESSES = [
   "stagehand",
   "claude_code",
   "codex",
+  "hermes",
 ] as const satisfies readonly Harness[];
 
 export const EXECUTABLE_BENCH_HARNESSES = [
   "stagehand",
   "claude_code",
   "codex",
+  "hermes",
 ] as const satisfies readonly Harness[];
 
 export function isBenchHarness(value: string): value is Harness {
@@ -64,10 +66,15 @@ export interface CodexHarnessConfig extends ExternalHarnessConfig {
   harness: "codex";
 }
 
+export interface HermesHarnessConfig extends ExternalHarnessConfig {
+  harness: "hermes";
+}
+
 export type BenchHarnessConfig =
   | StagehandHarnessConfig
   | ClaudeCodeHarnessConfig
-  | CodexHarnessConfig;
+  | CodexHarnessConfig
+  | HermesHarnessConfig;
 
 export interface BenchMatrixRow {
   harness: Harness;

--- a/packages/evals/framework/hermesPilotReporting.ts
+++ b/packages/evals/framework/hermesPilotReporting.ts
@@ -1,0 +1,177 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export type HermesPilotSuccessMode = "outcome" | "process" | "both";
+
+export interface HermesPilotRecordContext {
+  record: Record<string, unknown>;
+  runDir: string;
+  identity: {
+    taskId: string;
+    surface: string;
+    verifierModel: string;
+  };
+  successMode: HermesPilotSuccessMode;
+}
+
+export interface ValidVerifierSidecar {
+  schema_version: 1;
+  task_id: string;
+  surface: string;
+  verifier_model: string;
+  outcome: boolean;
+  process_score: number;
+  criterion_count: number;
+  evidence_insufficient_count: number;
+  trajectory_dir: string;
+}
+
+export interface EffectiveHermesPilotRecord {
+  record: Record<string, unknown>;
+  regraded: boolean;
+}
+
+function readRecord(file: string): Record<string, unknown> {
+  const value = JSON.parse(fs.readFileSync(file, "utf8")) as unknown;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Malformed verifier regrade: ${file}`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isNonnegativeInteger(value: unknown): value is number {
+  return Number.isInteger(value) && Number(value) >= 0;
+}
+
+/**
+ * Read and validate the optional verifier-result.json next to a raw record.
+ * Missing sidecars are not errors; present but malformed or mismatched sidecars
+ * fail closed so they can never silently change benchmark results.
+ */
+export function readValidVerifierSidecar(
+  context: HermesPilotRecordContext,
+): ValidVerifierSidecar | undefined {
+  const file = path.join(context.runDir, "verifier-result.json");
+  if (!fs.existsSync(file)) return undefined;
+
+  const value = readRecord(file);
+  const expected = {
+    schema_version: 1,
+    task_id: context.identity.taskId,
+    surface: context.identity.surface,
+    verifier_model: context.identity.verifierModel,
+  };
+  for (const [key, expectedValue] of Object.entries(expected)) {
+    if (value[key] !== expectedValue) {
+      throw new Error(`Verifier regrade identity mismatch at ${key}`);
+    }
+  }
+
+  if (
+    typeof value.outcome !== "boolean" ||
+    !isFiniteNumber(value.process_score) ||
+    value.process_score < 0 ||
+    value.process_score > 1 ||
+    !isNonnegativeInteger(value.criterion_count) ||
+    value.criterion_count < 1 ||
+    !isNonnegativeInteger(value.evidence_insufficient_count) ||
+    typeof value.trajectory_dir !== "string" ||
+    value.trajectory_dir.trim().length === 0
+  ) {
+    throw new Error("Verifier regrade is incomplete");
+  }
+  let trajectoryIsDirectory = false;
+  try {
+    trajectoryIsDirectory = fs.statSync(value.trajectory_dir).isDirectory();
+  } catch {
+    // Report the same stable validation error for absent and unreadable paths.
+  }
+  if (!trajectoryIsDirectory) throw new Error("Verifier regrade is incomplete");
+
+  return value as unknown as ValidVerifierSidecar;
+}
+
+export function hermesPilotVerifierSucceeded(
+  sidecar: Pick<ValidVerifierSidecar, "outcome" | "process_score" | "evidence_insufficient_count">,
+  successMode: HermesPilotSuccessMode,
+): boolean {
+  if (sidecar.evidence_insufficient_count !== 0) return false;
+  const processSucceeded = sidecar.process_score >= 0.8;
+  if (successMode === "outcome") return sidecar.outcome;
+  if (successMode === "process") return processSucceeded;
+  return sidecar.outcome && processSucceeded;
+}
+
+/** Resolve an immutable effective view while retaining record.json as provenance. */
+export function resolveEffectiveHermesPilotRecord(
+  context: HermesPilotRecordContext,
+): EffectiveHermesPilotRecord {
+  if (context.record.status !== "error") {
+    return { record: context.record, regraded: false };
+  }
+  const sidecar = readValidVerifierSidecar(context);
+  if (!sidecar) return { record: context.record, regraded: false };
+
+  const success = hermesPilotVerifierSucceeded(sidecar, context.successMode);
+  return {
+    regraded: true,
+    record: {
+      ...context.record,
+      status: success ? "verified_passed" : "verified_failed",
+      accuracy: success,
+      verifier_graded: true,
+      outcome: sidecar.outcome,
+      process_score: sidecar.process_score,
+      criterion_count: sidecar.criterion_count,
+      evidence_insufficient_count: sidecar.evidence_insufficient_count,
+      verifier_error: null,
+      trajectory_dir: sidecar.trajectory_dir,
+    },
+  };
+}
+
+function countStatuses(records: Array<Record<string, unknown>>): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const record of records) {
+    const status = String(record.status);
+    counts[status] = (counts[status] ?? 0) + 1;
+  }
+  return counts;
+}
+
+function numeric(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+export function summarizeHermesPilotRecords(
+  contexts: HermesPilotRecordContext[],
+  phase: string,
+): Record<string, unknown> {
+  const resolved = contexts.map(resolveEffectiveHermesPilotRecord);
+  const rawRecords = contexts.map((context) => context.record);
+  const effectiveRecords = resolved.map((result) => result.record);
+  const graded = effectiveRecords.filter((record) => record.verifier_graded === true);
+  const passed = graded.filter((record) => record.accuracy === true).length;
+  const failed = graded.filter((record) => record.accuracy === false).length;
+
+  const totalCostUsd = rawRecords.reduce((sum, record) => sum + numeric(record.cost_usd), 0);
+  return {
+    phase,
+    records: rawRecords.length,
+    effective_statuses: countStatuses(effectiveRecords),
+    effective_accuracy: {
+      graded: graded.length,
+      passed,
+      failed,
+      ungraded: rawRecords.length - graded.length,
+      rate: graded.length > 0 ? passed / graded.length : null,
+    },
+    raw_statuses: countStatuses(rawRecords),
+    regraded_records: resolved.filter((result) => result.regraded).length,
+    total_cost_usd: Number(totalCostUsd.toFixed(12)),
+  };
+}

--- a/packages/evals/framework/hermesRunner.ts
+++ b/packages/evals/framework/hermesRunner.ts
@@ -20,6 +20,7 @@ export const HERMES_BROWSER_SURFACES = [
   "hermes_browser_legacy",
   "hermes_browser_exec",
   "hermes_stagehand_batch",
+  "hermes_stagehand_facade",
 ] as const;
 export type HermesBrowserSurface = (typeof HERMES_BROWSER_SURFACES)[number];
 
@@ -121,6 +122,7 @@ const EXPECTED_TOOL_SCHEMAS: Record<HermesBrowserSurface, HermesToolSchema> = {
   },
   hermes_browser_exec: { bytes: 10_387, names: ["browser_exec"] },
   hermes_stagehand_batch: { bytes: 10_461, names: ["browser_exec"] },
+  hermes_stagehand_facade: { bytes: 3_694, names: ["run", "screenshot", "snapshot"] },
 };
 const PINNED_BROWSER_USE = {
   packageVersion: "0.13.7",
@@ -138,12 +140,13 @@ export function resolveHermesToolSurface(requested?: ToolSurface): HermesBrowser
   if (
     requested === "hermes_browser_legacy" ||
     requested === "hermes_browser_exec" ||
-    requested === "hermes_stagehand_batch"
+    requested === "hermes_stagehand_batch" ||
+    requested === "hermes_stagehand_facade"
   ) {
     return requested;
   }
   throw new EvalsError(
-    `Hermes harness supports --tool hermes_browser_legacy, --tool hermes_browser_exec, or --tool hermes_stagehand_batch; received "${requested}".`,
+    `Hermes harness supports --tool hermes_browser_legacy, --tool hermes_browser_exec, --tool hermes_stagehand_batch, or --tool hermes_stagehand_facade; received "${requested}".`,
   );
 }
 
@@ -153,7 +156,10 @@ export function resolveHermesStartupProfile(
   requested?: StartupProfile,
 ): StartupProfile {
   resolveHermesToolSurface(toolSurface);
-  if (toolSurface === "hermes_stagehand_batch" && environment !== "BROWSERBASE") {
+  if (
+    (toolSurface === "hermes_stagehand_batch" || toolSurface === "hermes_stagehand_facade") &&
+    environment !== "BROWSERBASE"
+  ) {
     throw new EvalsError(
       "Hermes Stagehand batch launches through Browserbase and requires --env browserbase.",
     );
@@ -181,6 +187,8 @@ export function applyHermesSurfaceEnvironment(
     ].join(path.delimiter);
     return;
   }
+
+  if (surface === "hermes_stagehand_facade") return;
 
   env.HERMES_BENCHMARK_BROWSER_EXEC_ONLY = "1";
   if (surface === "hermes_browser_exec") {
@@ -520,6 +528,10 @@ async function executeHermes(input: HermesRunnerInput): Promise<HermesRunArtifac
   validateHermesBenchmarkRoot(root);
   const stagehandV4Root =
     input.surface === "hermes_stagehand_batch" ? resolvePinnedStagehandV4Root() : undefined;
+  const stagehandFacadeRoot =
+    input.surface === "hermes_stagehand_facade"
+      ? path.resolve(process.env.EVAL_STAGEHAND_FACADE_ROOT?.trim() || "/workspace/stagehand")
+      : undefined;
   const python =
     process.env.EVAL_HERMES_PYTHON?.trim() || path.join(root, ".venv", "bin", "python");
   const hermesEntrypoint = path.join(root, "hermes");
@@ -535,6 +547,24 @@ async function executeHermes(input: HermesRunnerInput): Promise<HermesRunArtifac
     ]) {
       if (!fs.existsSync(required)) {
         throw new EvalsError(`Hermes Stagehand batch prerequisite is missing: ${required}`);
+      }
+    }
+  }
+  if (input.surface === "hermes_stagehand_facade") {
+    for (const required of [
+      path.join(stagehandFacadeRoot!, "packages", "sdk-ts", "dist", "index.mjs"),
+      path.join(
+        stagehandFacadeRoot!,
+        "packages",
+        "integrations",
+        "core",
+        "dist",
+        "facade",
+        "index.mjs",
+      ),
+    ]) {
+      if (!fs.existsSync(required)) {
+        throw new EvalsError(`Hermes Stagehand facade prerequisite is missing: ${required}`);
       }
     }
   }
@@ -560,14 +590,22 @@ async function executeHermes(input: HermesRunnerInput): Promise<HermesRunArtifac
   ]);
   await fsp.writeFile(
     path.join(hermesHome, "config.yaml"),
-    buildHermesConfig(input.surface, input.environment, root, stagehandV4Root),
+    buildHermesConfig(
+      input.surface,
+      input.environment,
+      root,
+      stagehandV4Root,
+      stagehandFacadeRoot,
+    ),
     "utf8",
   );
 
   const usagePath = path.join(runDir, "usage.json");
   const childBaseEnvironment = buildHermesChildBaseEnvironment(process.env);
   const browserbaseEnvironment =
-    input.environment === "BROWSERBASE" && input.surface !== "hermes_stagehand_batch"
+    input.environment === "BROWSERBASE" &&
+    input.surface !== "hermes_stagehand_batch" &&
+    input.surface !== "hermes_stagehand_facade"
       ? await resolveBrowserbaseChildEnvironment(childBaseEnvironment)
       : childBaseEnvironment;
   const env: NodeJS.ProcessEnv = {
@@ -674,6 +712,7 @@ function buildHermesConfig(
   environment: "LOCAL" | "BROWSERBASE",
   hermesRoot: string,
   stagehandV4Root?: string,
+  stagehandFacadeRoot?: string,
 ): string {
   const browserLines = ["browser:"];
   if (surface === "hermes_browser_exec") browserLines.push("  backend: browser-use");
@@ -688,10 +727,21 @@ function buildHermesConfig(
     browserLines.push(
       `  stagehand_python_executable: ${path.join(hermesRoot, ".stagehand-venv", "bin", "python")}`,
     );
+  } else if (surface === "hermes_stagehand_facade") {
+    if (!stagehandFacadeRoot) {
+      throw new EvalsError("Hermes Stagehand facade requires a validated integration root.");
+    }
+    browserLines.push("  backend: stagehand-facade");
+    browserLines.push(`  stagehand_facade_root: ${stagehandFacadeRoot}`);
+    browserLines.push(`  stagehand_facade_node_executable: ${process.execPath}`);
   } else if (environment === "BROWSERBASE") {
     browserLines.push("  cloud_provider: browserbase");
   }
-  return `${browserLines.join("\n")}\n`;
+  const toolSearchLines =
+    surface === "hermes_stagehand_facade"
+      ? ["tools:", "  tool_search:", "    enabled: off"]
+      : [];
+  return `${[...browserLines, ...toolSearchLines].join("\n")}\n`;
 }
 
 function resolveHermesRoot(): string {
@@ -979,7 +1029,12 @@ export async function resolveHermesToolSchema(input: {
   env: NodeJS.ProcessEnv;
   surface: HermesBrowserSurface;
 }): Promise<HermesToolSchema> {
-  const toolset = input.surface === "hermes_browser_legacy" ? "browser" : "browser-use";
+  const toolset =
+    input.surface === "hermes_browser_legacy"
+      ? "browser"
+      : input.surface === "hermes_stagehand_facade"
+        ? "stagehand-facade"
+        : "browser-use";
   const source = [
     "import json",
     "from hermes_cli.oneshot import _validate_explicit_toolsets",

--- a/packages/evals/framework/hermesRunner.ts
+++ b/packages/evals/framework/hermesRunner.ts
@@ -1,0 +1,1333 @@
+import { execFile, execFileSync } from "node:child_process";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import type { AvailableModel, ProbeEvidence, TaskSpec, Trajectory } from "stagehand-v3";
+import type { StartupProfile, ToolSurface } from "../core/contracts/tool.js";
+import { EvalsError } from "../errors.js";
+import type { EvalLogger } from "../logger.js";
+import { getRepoRootDir } from "../runtimePaths.js";
+import { buildTrajectory, type NormalizedToolCall } from "./harnesses/trajectoryAdapter.js";
+import type { ExternalHarnessTaskPlan } from "./externalHarnessPlan.js";
+import { datasetPromptGuidance } from "./externalHarnessPlan.js";
+import { gradeExternalTrajectory, type ExternalHarnessVerifierConfig } from "./verifierAdapter.js";
+import type { TaskResult } from "./types.js";
+
+export const HERMES_BROWSER_SURFACES = [
+  "hermes_browser_legacy",
+  "hermes_browser_exec",
+  "hermes_stagehand_batch",
+] as const;
+export type HermesBrowserSurface = (typeof HERMES_BROWSER_SURFACES)[number];
+
+export interface HermesUsage {
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cache_write_tokens: number;
+  reasoning_tokens: number;
+  api_calls: number;
+  estimated_cost_usd?: number;
+  session_id?: string;
+  completed?: boolean;
+  failed?: boolean;
+}
+
+export interface HermesToolSchema {
+  bytes: number;
+  names: string[];
+}
+
+export interface HermesMessageRow {
+  id: number;
+  role: string;
+  content: string | null;
+  tool_call_id: string | null;
+  tool_calls: string | null;
+  tool_name: string | null;
+  reasoning: string | null;
+  reasoning_content: string | null;
+}
+
+export interface HermesRunArtifact {
+  surface: HermesBrowserSurface;
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  messages: HermesMessageRow[];
+  usage: HermesUsage;
+  innerUsage?: HermesUsage;
+  toolCallCount: number;
+  finalObservation?: ProbeEvidence;
+  /** Successful browser-call evidence indexed by one-based Hermes action order. */
+  stepObservations?: Array<ProbeEvidence | undefined>;
+  toolSchema?: HermesToolSchema;
+  toolMetrics?: Array<Record<string, unknown>>;
+  agentWallMs?: number;
+  browserWallMs?: number;
+  sessionSetupMs?: number;
+  artifactDir?: string;
+}
+
+export interface HermesRunnerInput {
+  plan: ExternalHarnessTaskPlan;
+  taskSpec: TaskSpec;
+  model: AvailableModel;
+  surface: HermesBrowserSurface;
+  environment: "LOCAL" | "BROWSERBASE";
+  logger: EvalLogger;
+  signal?: AbortSignal;
+  verifier: ExternalHarnessVerifierConfig;
+}
+
+export interface HermesArtifactGradeInput {
+  artifact: HermesRunArtifact;
+  taskSpec: TaskSpec;
+  logger: EvalLogger;
+  verifier: ExternalHarnessVerifierConfig;
+}
+
+interface ProcessResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+const HERMES_PROVIDER = "ai-gateway";
+export const PINNED_HERMES_BASE_COMMIT = "e65664f512ded961ec7b2fdbeb4a88008f439866";
+export const PINNED_STAGEHAND_V4_COMMIT = "4186c7d98d2f325b6fc85b3f760111e6c390d703";
+export const DEFAULT_STAGEHAND_V4_ROOT = "/workspace/stagehand-v4-tip-4186";
+const TOOL_SCHEMA_PREFIX = "__STAGEHAND_EVALS_HERMES_TOOL_SCHEMA__";
+const EXPECTED_TOOL_SCHEMAS: Record<HermesBrowserSurface, HermesToolSchema> = {
+  hermes_browser_legacy: {
+    bytes: 11_322,
+    names: [
+      "browser_back",
+      "browser_cdp",
+      "browser_click",
+      "browser_console",
+      "browser_dialog",
+      "browser_get_images",
+      "browser_navigate",
+      "browser_press",
+      "browser_scroll",
+      "browser_snapshot",
+      "browser_type",
+      "browser_vision",
+    ],
+  },
+  hermes_browser_exec: { bytes: 10_387, names: ["browser_exec"] },
+  hermes_stagehand_batch: { bytes: 1_794, names: ["browser_exec"] },
+};
+const PINNED_BROWSER_USE = {
+  packageVersion: "0.13.7",
+  harnessVersion: "0.1.8",
+  freezeSha256: "1fbd36e2939e5790583941b62137e543f743973f3e32c8bbdf700d638dcfbd4d",
+  skillBytes: 7_745,
+  skillSha256: "0f3ca9aab1dec2c66ae849004a02f2b4ff24a97e6c1be6ebefed8ce4dc26f4d4",
+  nodeVersion: "agent-browser 0.26.0",
+  nodeLockSha256: "d45eea8072bbfdc078158d0029c7cad29ebd81421f8193aa854795704e65f1b8",
+} as const;
+const validatedHermesRoots = new Set<string>();
+
+export function resolveHermesToolSurface(requested?: ToolSurface): HermesBrowserSurface {
+  if (!requested) return "hermes_browser_exec";
+  if (
+    requested === "hermes_browser_legacy" ||
+    requested === "hermes_browser_exec" ||
+    requested === "hermes_stagehand_batch"
+  ) {
+    return requested;
+  }
+  throw new EvalsError(
+    `Hermes harness supports --tool hermes_browser_legacy, --tool hermes_browser_exec, or --tool hermes_stagehand_batch; received "${requested}".`,
+  );
+}
+
+export function resolveHermesStartupProfile(
+  toolSurface: ToolSurface,
+  environment: "LOCAL" | "BROWSERBASE",
+  requested?: StartupProfile,
+): StartupProfile {
+  resolveHermesToolSurface(toolSurface);
+  if (toolSurface === "hermes_stagehand_batch" && environment !== "BROWSERBASE") {
+    throw new EvalsError(
+      "Hermes Stagehand batch launches through Browserbase and requires --env browserbase.",
+    );
+  }
+  const expected = environment === "BROWSERBASE" ? "tool_create_browserbase" : "tool_launch_local";
+  if (requested && requested !== expected) {
+    throw new EvalsError(
+      `Hermes owns its browser lifecycle; ${environment} requires startup profile "${expected}", not "${requested}".`,
+    );
+  }
+  return expected;
+}
+
+export function applyHermesSurfaceEnvironment(
+  env: NodeJS.ProcessEnv,
+  surface: HermesBrowserSurface,
+  hermesRoot: string,
+): void {
+  if (surface === "hermes_browser_legacy") {
+    env.HERMES_BENCHMARK_STATIC_BROWSER = "1";
+    env.PATH = [
+      path.join(hermesRoot, ".browser-use-node", "node_modules", ".bin"),
+      path.join(hermesRoot, ".browser-use-venv", "bin"),
+      env.PATH ?? "",
+    ].join(path.delimiter);
+    return;
+  }
+
+  env.HERMES_BENCHMARK_BROWSER_EXEC_ONLY = "1";
+  if (surface === "hermes_browser_exec") {
+    // The public A/B/D contract compares the same full Browser Use skill arm
+    // as the Hermes-native executor, not the smaller pinned-digest C arm.
+    env.HERMES_BENCHMARK_BROWSER_USE_DESCRIPTION = "full";
+    env.PATH = [
+      path.join(hermesRoot, ".browser-use-node", "node_modules", ".bin"),
+      path.join(hermesRoot, ".browser-use-venv", "bin"),
+      env.PATH ?? "",
+    ].join(path.delimiter);
+  }
+}
+
+export function buildHermesPrompt(plan: ExternalHarnessTaskPlan): string {
+  return [
+    "You are running a browser benchmark task.",
+    "",
+    `Dataset: ${plan.dataset}`,
+    plan.taskId ? `Task ID: ${plan.taskId}` : undefined,
+    `Start URL: ${plan.startUrl}`,
+    "",
+    "Instruction:",
+    plan.instruction,
+    "",
+    datasetPromptGuidance(plan.dataset),
+    "Use only the browser tools provided by this Hermes run. Navigate to the Start URL before working on the task.",
+    "Complete the task and put the requested result in your final response.",
+  ]
+    .filter((value): value is string => value !== undefined)
+    .join("\n");
+}
+
+export function hermesArtifactToTrajectory(
+  artifact: HermesRunArtifact,
+  taskSpec: TaskSpec,
+): Trajectory {
+  const toolResults = new Map<string, HermesMessageRow>();
+  const unkeyedToolResults: HermesMessageRow[] = [];
+  for (const row of artifact.messages) {
+    if (row.role !== "tool") continue;
+    if (row.tool_call_id) toolResults.set(row.tool_call_id, row);
+    else unkeyedToolResults.push(row);
+  }
+
+  const calls: NormalizedToolCall[] = [];
+  let callIndex = 0;
+  let unkeyedResultIndex = 0;
+  for (const row of artifact.messages) {
+    if (row.role !== "assistant" || !row.tool_calls) continue;
+    const parsedCalls = parseToolCalls(row.tool_calls);
+    let reasoning = firstNonempty(row.reasoning_content, row.reasoning, row.content) ?? undefined;
+    for (const rawCall of parsedCalls) {
+      const callId = readString(rawCall, "call_id") ?? readString(rawCall, "id");
+      const fn = asRecord(rawCall.function);
+      const name = fn ? readString(fn, "name") : undefined;
+      if (!name) continue;
+      const resultRow =
+        (callId ? toolResults.get(callId) : undefined) ?? unkeyedToolResults[unkeyedResultIndex++];
+      const result = parseHermesToolResult(resultRow?.content ?? "");
+      const args = parseToolArguments(fn?.arguments);
+      calls.push({
+        name,
+        args,
+        result: result.value,
+        ok: result.ok,
+        ...(!result.ok && { error: result.error ?? "Hermes tool call failed" }),
+        ...(reasoning && { reasoning }),
+        ...(artifact.stepObservations?.[callIndex] && {
+          probeEvidence: artifact.stepObservations[callIndex],
+        }),
+      });
+      callIndex += 1;
+      reasoning = undefined;
+    }
+  }
+
+  const finalAnswer = [...artifact.messages]
+    .reverse()
+    .find((row) => row.role === "assistant" && !row.tool_calls && row.content?.trim())
+    ?.content?.trim();
+
+  const combinedUsage = addUsage(artifact.usage, artifact.innerUsage ?? emptyUsage(false));
+  return buildTrajectory({
+    taskSpec,
+    toolCalls: calls,
+    finalAnswer: finalAnswer || artifact.stdout.trim() || undefined,
+    status: artifact.exitCode === 0 && artifact.usage.failed !== true ? "complete" : "error",
+    usage: {
+      input_tokens: combinedUsage.input_tokens,
+      output_tokens: combinedUsage.output_tokens,
+      cached_input_tokens: combinedUsage.cache_read_tokens,
+      reasoning_tokens: combinedUsage.reasoning_tokens,
+    },
+    ...(artifact.finalObservation?.screenshot && {
+      finalObservation: artifact.finalObservation,
+    }),
+  });
+}
+
+/** Refuse to send an incomplete or methodology-drifting run to the judge. */
+export function validateHermesArtifact(artifact: HermesRunArtifact): void {
+  const failures: string[] = [];
+  if (
+    artifact.exitCode !== 0 ||
+    artifact.usage.completed !== true ||
+    artifact.usage.failed === true
+  ) {
+    failures.push("Hermes usage does not mark the run complete");
+  }
+  if (!artifact.usage.session_id) failures.push("Hermes usage has no session_id");
+  if (artifact.messages.length === 0) failures.push("Hermes session has no messages");
+  const finalAnswer = [...artifact.messages]
+    .reverse()
+    .find((row) => row.role === "assistant" && !row.tool_calls && row.content?.trim())
+    ?.content?.trim();
+  if (!finalAnswer) failures.push("Hermes session has no final response");
+
+  const resultIds = new Set(
+    artifact.messages
+      .filter((row) => row.role === "tool" && row.tool_call_id)
+      .map((row) => row.tool_call_id as string),
+  );
+  let parsedCalls = 0;
+  const parsedNames: string[] = [];
+  for (const row of artifact.messages) {
+    if (row.role !== "assistant" || !row.tool_calls) continue;
+    let value: unknown;
+    try {
+      value = JSON.parse(row.tool_calls);
+    } catch {
+      failures.push(`assistant message ${row.id} has malformed tool_calls JSON`);
+      continue;
+    }
+    if (!Array.isArray(value)) {
+      failures.push(`assistant message ${row.id} tool_calls is not an array`);
+      continue;
+    }
+    for (const rawCall of value) {
+      if (!isRecord(rawCall)) {
+        failures.push(`assistant message ${row.id} contains a malformed tool call`);
+        continue;
+      }
+      const fn = asRecord(rawCall.function);
+      const name = fn ? readString(fn, "name") : undefined;
+      const callId = readString(rawCall, "call_id") ?? readString(rawCall, "id");
+      if (!name) failures.push(`assistant message ${row.id} tool call has no name`);
+      else parsedNames.push(name);
+      if (!callId || !resultIds.has(callId)) {
+        failures.push(`assistant message ${row.id} tool call has no matching result`);
+      }
+      parsedCalls += 1;
+    }
+  }
+  if (parsedCalls === 0) failures.push("Hermes session has no model-visible browser calls");
+  if (artifact.toolCallCount !== parsedCalls) {
+    failures.push(
+      `stored tool_call_count ${artifact.toolCallCount} disagrees with ${parsedCalls} parsed calls`,
+    );
+  }
+  const allowedNames = new Set(EXPECTED_TOOL_SCHEMAS[artifact.surface].names);
+  const unexpectedNames = parsedNames.filter((name) => !allowedNames.has(name));
+  if (unexpectedNames.length > 0) {
+    failures.push(`unexpected model-visible tools: ${[...new Set(unexpectedNames)].join(", ")}`);
+  }
+
+  const expectedSchema = EXPECTED_TOOL_SCHEMAS[artifact.surface];
+  if (!artifact.toolSchema) {
+    failures.push("exact model-visible tool schema was not captured");
+  } else if (
+    artifact.toolSchema.bytes !== expectedSchema.bytes ||
+    artifact.toolSchema.names.length !== expectedSchema.names.length ||
+    [...artifact.toolSchema.names].sort().join("\n") !== [...expectedSchema.names].sort().join("\n")
+  ) {
+    failures.push(
+      `model-visible tool schema drifted: ${artifact.toolSchema.bytes} bytes [${artifact.toolSchema.names.join(", ")}]`,
+    );
+  }
+
+  if ((artifact.toolMetrics?.length ?? 0) !== parsedCalls) {
+    failures.push(
+      `tool metrics count ${artifact.toolMetrics?.length ?? 0} disagrees with ${parsedCalls} parsed calls`,
+    );
+  }
+  for (const [index, metric] of (artifact.toolMetrics ?? []).entries()) {
+    if (typeof metric.success !== "boolean") {
+      failures.push(`tool metric ${index + 1} has no boolean success status`);
+      continue;
+    }
+    if (metric.success === true) {
+      const evidence = artifact.stepObservations?.[index];
+      if (!evidence?.screenshot || !evidence.url?.startsWith("https://")) {
+        failures.push(
+          `successful tool call ${index + 1} has no independently captured HTTPS URL and screenshot`,
+        );
+      }
+    }
+    if (metric.success === true && metric.evidence_error) {
+      failures.push(`evidence capture: ${String(metric.evidence_error)}`);
+    }
+  }
+  const inner = artifact.innerUsage ?? emptyUsage(false);
+  if (
+    inner.input_tokens +
+      inner.output_tokens +
+      inner.cache_read_tokens +
+      inner.cache_write_tokens +
+      inner.reasoning_tokens >
+    0
+  ) {
+    failures.push("Stagehand inner model usage is forbidden");
+  }
+  if (failures.length > 0) {
+    throw new EvalsError(`Hermes artifact is not benchmark-scorable: ${failures.join("; ")}`);
+  }
+}
+
+export async function runHermesAgent(input: HermesRunnerInput): Promise<TaskResult> {
+  const artifact = await executeHermes(input);
+  return gradeHermesArtifact({
+    artifact,
+    taskSpec: input.taskSpec,
+    logger: input.logger,
+    verifier: input.verifier,
+  });
+}
+
+/**
+ * Regrade an already-completed Hermes artifact without launching Hermes, a
+ * browser, or the agent model again. This is the recovery path for verifier
+ * outages after an expensive trajectory has completed successfully.
+ */
+export async function gradeHermesArtifact(input: HermesArtifactGradeInput): Promise<TaskResult> {
+  const { artifact } = input;
+  const finalAnswer = [...artifact.messages]
+    .reverse()
+    .find((row) => row.role === "assistant" && !row.tool_calls && row.content?.trim())
+    ?.content?.trim();
+  const completed =
+    artifact.exitCode === 0 && artifact.usage.completed === true && artifact.usage.failed !== true;
+  const innerUsage = artifact.innerUsage ?? emptyUsage(false);
+  const combinedUsage = addUsage(artifact.usage, innerUsage);
+  const baseResult: TaskResult = {
+    _success: completed,
+    ...(!completed && {
+      error: artifact.stderr.trim() || `Hermes exited with status ${artifact.exitCode}`,
+    }),
+    finalAnswer: finalAnswer || artifact.stdout.trim() || undefined,
+    rawResult: artifact.stdout,
+    hermesSurface: artifact.surface,
+    hermesProvider: HERMES_PROVIDER,
+    toolCallCount: artifact.toolCallCount,
+    ...(artifact.artifactDir && { hermesArtifactDir: artifact.artifactDir }),
+    rawMetrics: {
+      outer: artifact.usage,
+      inner: innerUsage,
+      combined: combinedUsage,
+      tool_call_count: artifact.toolCallCount,
+      tool_schema: artifact.toolSchema,
+      agent_wall_ms: artifact.agentWallMs,
+      browser_wall_ms: artifact.browserWallMs,
+      session_setup_ms: artifact.sessionSetupMs,
+    },
+    logs: input.logger.getLogs(),
+  };
+
+  const verifierStartedAt = Date.now();
+  const graded = await gradeExternalTrajectory({
+    buildTrajectory: () => {
+      validateHermesArtifact(artifact);
+      return hermesArtifactToTrajectory(artifact, input.taskSpec);
+    },
+    verifier: input.verifier,
+    baseResult,
+    errorMessage: "Hermes trajectory did not satisfy the benchmark rubric",
+    category: "hermes",
+    logger: input.logger,
+    failClosedOnVerifierError: true,
+  });
+  return {
+    ...graded,
+    rawMetrics: {
+      ...asRecord(graded.rawMetrics),
+      verifier_wall_ms: Date.now() - verifierStartedAt,
+    },
+  };
+}
+
+/** Load the immutable inputs required to replay grading from a retained run directory. */
+export async function loadHermesArtifactDirectory(
+  artifactDirectory: string,
+  surface: HermesBrowserSurface,
+): Promise<HermesRunArtifact> {
+  const artifactDir = path.resolve(artifactDirectory);
+  const usagePath = path.join(artifactDir, "usage.json");
+  const stateDb = path.join(artifactDir, "hermes-home", "state.db");
+  const evidenceDir = path.join(artifactDir, "evidence");
+  for (const required of [usagePath, stateDb, evidenceDir]) {
+    if (!fs.existsSync(required)) {
+      throw new EvalsError(`Retained Hermes artifact is missing: ${required}`);
+    }
+  }
+
+  const usage = await readUsage(usagePath);
+  const { messages, toolCallCount } = readHermesState(stateDb, usage.session_id);
+  if (messages.length === 0) {
+    throw new EvalsError(`Retained Hermes artifact has no session messages: ${artifactDir}`);
+  }
+  const finalObservation = await readFinalObservation(evidenceDir);
+  const stepObservations = await readStepObservations(evidenceDir);
+  const toolMetrics = await readToolMetrics(evidenceDir);
+  const innerUsage = readStagehandInnerUsage(toolMetrics);
+  const toolSchema = await readToolSchemaArtifact(path.join(artifactDir, "tool-schema.json"));
+  const retainedTiming = await readRetainedTiming(artifactDir);
+  const completed = usage.completed === true && usage.failed !== true;
+
+  return {
+    surface,
+    stdout: "",
+    stderr: completed ? "" : "Retained Hermes usage does not mark the run complete.",
+    exitCode: completed ? 0 : 1,
+    messages,
+    usage,
+    innerUsage,
+    toolCallCount,
+    toolMetrics,
+    ...(toolSchema && { toolSchema }),
+    ...retainedTiming,
+    ...(finalObservation && { finalObservation }),
+    ...(stepObservations.length > 0 && { stepObservations }),
+    artifactDir,
+  };
+}
+
+async function executeHermes(input: HermesRunnerInput): Promise<HermesRunArtifact> {
+  const root = resolveHermesRoot();
+  validateHermesBenchmarkRoot(root);
+  const stagehandV4Root =
+    input.surface === "hermes_stagehand_batch" ? resolvePinnedStagehandV4Root() : undefined;
+  const python =
+    process.env.EVAL_HERMES_PYTHON?.trim() || path.join(root, ".venv", "bin", "python");
+  const hermesEntrypoint = path.join(root, "hermes");
+  for (const required of [python, hermesEntrypoint]) {
+    if (!fs.existsSync(required)) {
+      throw new EvalsError(`Hermes harness prerequisite is missing: ${required}`);
+    }
+  }
+  if (input.surface === "hermes_stagehand_batch") {
+    for (const required of [
+      path.join(root, ".stagehand-venv", "bin", "python"),
+      path.join(stagehandV4Root!, "packages", "sdk-python"),
+    ]) {
+      if (!fs.existsSync(required)) {
+        throw new EvalsError(`Hermes Stagehand batch prerequisite is missing: ${required}`);
+      }
+    }
+  }
+  if (!process.env.AI_GATEWAY_API_KEY?.trim()) {
+    throw new EvalsError("Hermes harness uses Vercel AI Gateway and requires AI_GATEWAY_API_KEY.");
+  }
+  if (input.environment === "BROWSERBASE" && !process.env.BROWSERBASE_API_KEY?.trim()) {
+    throw new EvalsError("Hermes Browserbase runs require BROWSERBASE_API_KEY.");
+  }
+
+  const artifactRoot = process.env.EVAL_HERMES_ARTIFACT_ROOT?.trim();
+  const runDir = artifactRoot
+    ? await fsp.mkdtemp(path.join(await ensureDirectory(artifactRoot), "hermes-eval-"))
+    : await fsp.mkdtemp(path.join(os.tmpdir(), "stagehand-evals-hermes-"));
+  const preserve = Boolean(artifactRoot);
+  const hermesHome = path.join(runDir, "hermes-home");
+  const evidenceDir = path.join(runDir, "evidence");
+  const cwd = path.join(runDir, "workspace");
+  await Promise.all([
+    fsp.mkdir(hermesHome, { recursive: true }),
+    fsp.mkdir(evidenceDir, { recursive: true }),
+    fsp.mkdir(cwd, { recursive: true }),
+  ]);
+  await fsp.writeFile(
+    path.join(hermesHome, "config.yaml"),
+    buildHermesConfig(input.surface, input.environment, root, stagehandV4Root),
+    "utf8",
+  );
+
+  const usagePath = path.join(runDir, "usage.json");
+  const childBaseEnvironment = buildHermesChildBaseEnvironment(process.env);
+  const browserbaseEnvironment =
+    input.environment === "BROWSERBASE" && input.surface !== "hermes_stagehand_batch"
+      ? await resolveBrowserbaseChildEnvironment(childBaseEnvironment)
+      : childBaseEnvironment;
+  const env: NodeJS.ProcessEnv = {
+    ...browserbaseEnvironment,
+    HERMES_HOME: hermesHome,
+    HERMES_YOLO_MODE: "1",
+    HERMES_ACCEPT_HOOKS: "1",
+    HERMES_BENCHMARK_EVIDENCE_DIR: evidenceDir,
+    HERMES_BENCHMARK_EVIDENCE_HISTORY: "1",
+    HERMES_BENCHMARK_TASK_ID: input.plan.taskId ?? input.taskSpec.id,
+    BROWSERBASE_KEEP_ALIVE: "false",
+  };
+  applyHermesSurfaceEnvironment(env, input.surface, root);
+
+  input.logger.log({
+    category: "hermes",
+    message: `Starting ${input.surface} through ${HERMES_PROVIDER} (${input.model}).`,
+    level: 1,
+  });
+
+  let explicitSession: { id: string; cdpUrl: string } | undefined;
+  const agentStartedAt = Date.now();
+  let sessionSetupMs = 0;
+  try {
+    if (input.surface === "hermes_browser_legacy" && input.environment === "BROWSERBASE") {
+      const sessionStartedAt = Date.now();
+      explicitSession = await createBrowserbaseBenchmarkSession(env);
+      sessionSetupMs = Date.now() - sessionStartedAt;
+      env.BROWSER_CDP_URL = explicitSession.cdpUrl;
+    }
+    const toolSchema = await resolveHermesToolSchema({
+      python,
+      cwd,
+      env,
+      surface: input.surface,
+    });
+    await fsp.writeFile(
+      path.join(runDir, "tool-schema.json"),
+      `${JSON.stringify(toolSchema, null, 2)}\n`,
+      "utf8",
+    );
+    const processResult = await runProcess(
+      python,
+      [
+        hermesEntrypoint,
+        "--provider",
+        HERMES_PROVIDER,
+        "--model",
+        String(input.model),
+        "--toolsets",
+        input.surface === "hermes_browser_legacy" ? "browser" : "browser-use",
+        "--usage-file",
+        usagePath,
+        "--oneshot",
+        buildHermesPrompt(input.plan),
+      ],
+      {
+        cwd,
+        env,
+        signal: input.signal,
+        timeoutMs: readPositiveIntEnv("EVAL_HERMES_TIMEOUT_MS", 30 * 60_000),
+      },
+    );
+    const usage = await readUsage(usagePath);
+    const stateDb = path.join(hermesHome, "state.db");
+    const { messages, toolCallCount } = fs.existsSync(stateDb)
+      ? readHermesState(stateDb, usage.session_id)
+      : { messages: [], toolCallCount: 0 };
+    const finalObservation = await readFinalObservation(evidenceDir);
+    const stepObservations = await readStepObservations(evidenceDir);
+    const toolMetrics = await readToolMetrics(evidenceDir);
+    const innerUsage = readStagehandInnerUsage(toolMetrics);
+    const browserWallMs = toolMetrics.reduce(
+      (total, metric) => total + nonnegativeInt(metric.duration_ms),
+      0,
+    );
+
+    return {
+      surface: input.surface,
+      ...processResult,
+      messages,
+      usage,
+      innerUsage,
+      toolCallCount,
+      toolSchema,
+      toolMetrics,
+      agentWallMs: Date.now() - agentStartedAt,
+      browserWallMs,
+      sessionSetupMs,
+      ...(finalObservation && { finalObservation }),
+      ...(stepObservations.length > 0 && { stepObservations }),
+      ...(preserve && { artifactDir: runDir }),
+    };
+  } finally {
+    if (explicitSession) await releaseBrowserbaseBenchmarkSession(env, explicitSession.id);
+    if (!preserve) {
+      await fsp.rm(runDir, { recursive: true, force: true });
+    }
+  }
+}
+
+function buildHermesConfig(
+  surface: HermesBrowserSurface,
+  environment: "LOCAL" | "BROWSERBASE",
+  hermesRoot: string,
+  stagehandV4Root?: string,
+): string {
+  const browserLines = ["browser:"];
+  if (surface === "hermes_browser_exec") browserLines.push("  backend: browser-use");
+  if (surface === "hermes_stagehand_batch") {
+    if (!stagehandV4Root) {
+      throw new EvalsError("Hermes Stagehand batch requires a validated Stagehand V4 root.");
+    }
+    browserLines.push("  backend: stagehand-batch");
+    browserLines.push(
+      `  stagehand_sdk_python_path: ${path.join(stagehandV4Root, "packages", "sdk-python")}`,
+    );
+    browserLines.push(
+      `  stagehand_python_executable: ${path.join(hermesRoot, ".stagehand-venv", "bin", "python")}`,
+    );
+  } else if (environment === "BROWSERBASE") {
+    browserLines.push("  cloud_provider: browserbase");
+  }
+  return `${browserLines.join("\n")}\n`;
+}
+
+function resolveHermesRoot(): string {
+  return path.resolve(
+    process.env.EVAL_HERMES_ROOT?.trim() ||
+      path.join(getRepoRootDir(), "..", "hermes-stagehand-batch"),
+  );
+}
+
+export function resolvePinnedStagehandV4Root(): string {
+  const configured = process.env.EVAL_STAGEHAND_V4_ROOT?.trim();
+  return validatePinnedStagehandV4Root(configured || DEFAULT_STAGEHAND_V4_ROOT);
+}
+
+export function validatePinnedStagehandV4Root(
+  candidate: string,
+  expectedCommit = PINNED_STAGEHAND_V4_COMMIT,
+): string {
+  const root = path.resolve(candidate);
+  const sdkRoot = path.join(root, "packages", "sdk-python");
+  if (!fs.existsSync(sdkRoot)) {
+    throw new EvalsError(`Pinned Stagehand V4 Python SDK is missing: ${sdkRoot}`);
+  }
+
+  let head: string;
+  let status: string;
+  try {
+    head = execFileSync("git", ["-C", root, "rev-parse", "HEAD"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+    status = execFileSync("git", ["-C", root, "status", "--porcelain"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch (cause) {
+    throw new EvalsError(`Unable to validate pinned Stagehand V4 checkout at ${root}.`, {
+      cause,
+    });
+  }
+
+  if (head !== expectedCommit) {
+    throw new EvalsError(
+      `Stagehand V4 checkout ${root} is at ${head}; expected pinned commit ${expectedCommit}.`,
+    );
+  }
+  if (status) {
+    throw new EvalsError(
+      `Stagehand V4 checkout ${root} has local changes; use a clean checkout of ${expectedCommit}.`,
+    );
+  }
+  return root;
+}
+
+export function validateHermesBenchmarkRoot(
+  candidate: string,
+  expectedBaseCommit = PINNED_HERMES_BASE_COMMIT,
+): string {
+  const root = path.resolve(candidate);
+  if (validatedHermesRoots.has(root)) return root;
+  const python = path.join(root, ".browser-use-venv", "bin", "python");
+  const browserUseCli = path.join(root, ".browser-use-venv", "bin", "browser-use");
+  const agentBrowser = path.join(
+    root,
+    ".browser-use-node",
+    "node_modules",
+    ".bin",
+    "agent-browser",
+  );
+  const skill = path.join(root, "benchmarks", "browser-use-full-skill-0.1.8.md");
+  const nodeLock = path.join(root, "benchmarks", "browser-use-node-package-lock.json");
+  for (const required of [
+    path.join(root, "hermes"),
+    python,
+    browserUseCli,
+    agentBrowser,
+    skill,
+    nodeLock,
+  ]) {
+    if (!fs.existsSync(required)) {
+      throw new EvalsError(`Pinned Hermes benchmark prerequisite is missing: ${required}`);
+    }
+  }
+  try {
+    execFileSync("git", ["-C", root, "merge-base", "--is-ancestor", expectedBaseCommit, "HEAD"], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const versions = execFileSync(
+      python,
+      [
+        "-c",
+        "from importlib import metadata; print(metadata.version('browser-use')); print(metadata.version('browser-harness'))",
+      ],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    )
+      .trim()
+      .split(/\r?\n/);
+    if (
+      versions[0] !== PINNED_BROWSER_USE.packageVersion ||
+      versions[1] !== PINNED_BROWSER_USE.harnessVersion
+    ) {
+      throw new Error(`Browser Use versions drifted: ${versions.join(", ")}`);
+    }
+    const freeze = execFileSync(python, ["-m", "pip", "freeze"], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    if (sha256(freeze) !== PINNED_BROWSER_USE.freezeSha256) {
+      throw new Error("Browser Use environment freeze drifted");
+    }
+    execFileSync(python, ["-m", "pip", "check"], { stdio: ["ignore", "pipe", "pipe"] });
+    const browserUseVersion = execFileSync(browserUseCli, ["--version"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+    if (browserUseVersion !== PINNED_BROWSER_USE.harnessVersion) {
+      throw new Error(`Browser Use CLI drifted: ${browserUseVersion}`);
+    }
+    const nodeVersion = execFileSync(agentBrowser, ["--version"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+    if (nodeVersion !== PINNED_BROWSER_USE.nodeVersion) {
+      throw new Error(`agent-browser drifted: ${nodeVersion}`);
+    }
+    const skillBytes = fs.statSync(skill).size;
+    if (
+      skillBytes !== PINNED_BROWSER_USE.skillBytes ||
+      sha256(fs.readFileSync(skill)) !== PINNED_BROWSER_USE.skillSha256
+    ) {
+      throw new Error("full Browser Use skill snapshot drifted");
+    }
+    if (sha256(fs.readFileSync(nodeLock)) !== PINNED_BROWSER_USE.nodeLockSha256) {
+      throw new Error("agent-browser lockfile drifted");
+    }
+  } catch (cause) {
+    throw new EvalsError(
+      `Hermes benchmark checkout ${root} does not satisfy the frozen source/runtime pins.`,
+      { cause },
+    );
+  }
+  validatedHermesRoots.add(root);
+  return root;
+}
+
+async function resolveBrowserbaseChildEnvironment(
+  base: NodeJS.ProcessEnv,
+): Promise<NodeJS.ProcessEnv> {
+  if (base.BROWSERBASE_PROJECT_ID?.trim()) return { ...base };
+  const apiKey = base.BROWSERBASE_API_KEY?.trim();
+  if (!apiKey) throw new EvalsError("Hermes Browserbase runs require BROWSERBASE_API_KEY.");
+  let response: Response;
+  try {
+    response = await fetch("https://api.browserbase.com/v1/projects", {
+      headers: { "X-BB-API-Key": apiKey, Accept: "application/json" },
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch (cause) {
+    throw new EvalsError("Browserbase project discovery failed.", { cause });
+  }
+  if (!response.ok) {
+    throw new EvalsError(`Browserbase project discovery returned HTTP ${response.status}.`);
+  }
+  const payload = (await response.json()) as unknown;
+  const record = asRecord(payload);
+  const projects = Array.isArray(payload)
+    ? payload
+    : Array.isArray(record?.projects)
+      ? record.projects
+      : [];
+  if (projects.length !== 1) {
+    throw new EvalsError(
+      `Browserbase project discovery requires exactly one visible project; found ${projects.length}.`,
+    );
+  }
+  const projectId = readString(asRecord(projects[0]), "id");
+  if (!projectId)
+    throw new EvalsError("Browserbase project discovery returned an invalid project.");
+  return { ...base, BROWSERBASE_PROJECT_ID: projectId };
+}
+
+function buildHermesChildBaseEnvironment(base: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const allowed = [
+    "PATH",
+    "LANG",
+    "LC_ALL",
+    "TERM",
+    "TZ",
+    "TMPDIR",
+    "HOME",
+    "USER",
+    "LOGNAME",
+    "SSL_CERT_FILE",
+    "REQUESTS_CA_BUNDLE",
+    "CURL_CA_BUNDLE",
+    "NODE_EXTRA_CA_CERTS",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+    "AI_GATEWAY_API_KEY",
+    "AI_GATEWAY_BASE_URL",
+    "BROWSERBASE_API_KEY",
+    "BROWSERBASE_PROJECT_ID",
+    "BROWSERBASE_BASE_URL",
+    "BROWSERBASE_REGION",
+  ] as const;
+  const child: NodeJS.ProcessEnv = {};
+  for (const key of allowed) {
+    if (base[key] !== undefined) child[key] = base[key];
+  }
+  return child;
+}
+
+async function createBrowserbaseBenchmarkSession(
+  env: NodeJS.ProcessEnv,
+): Promise<{ id: string; cdpUrl: string }> {
+  const apiKey = env.BROWSERBASE_API_KEY?.trim();
+  const projectId = env.BROWSERBASE_PROJECT_ID?.trim();
+  if (!apiKey || !projectId) {
+    throw new EvalsError("Explicit Browserbase benchmark session requires API key and project ID.");
+  }
+  const baseUrl = (env.BROWSERBASE_BASE_URL?.trim() || "https://api.browserbase.com").replace(
+    /\/$/,
+    "",
+  );
+  const create = async (proxies: boolean): Promise<Response> =>
+    fetch(`${baseUrl}/v1/sessions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "X-BB-API-Key": apiKey },
+      body: JSON.stringify({ projectId, ...(proxies && { proxies: true }) }),
+      signal: AbortSignal.timeout(30_000),
+    });
+  let response: Response;
+  try {
+    response = await create(true);
+    if (response.status === 402) response = await create(false);
+  } catch (cause) {
+    throw new EvalsError("Browserbase benchmark session creation failed.", { cause });
+  }
+  if (!response.ok) {
+    throw new EvalsError(
+      `Browserbase benchmark session creation returned HTTP ${response.status}.`,
+    );
+  }
+  const value = asRecord((await response.json()) as unknown);
+  const id = readString(value, "id");
+  const cdpUrl = readString(value, "connectUrl");
+  if (!id || !cdpUrl || !/^wss?:\/\//.test(cdpUrl)) {
+    throw new EvalsError("Browserbase benchmark session response was malformed.");
+  }
+  return { id, cdpUrl };
+}
+
+async function releaseBrowserbaseBenchmarkSession(
+  env: NodeJS.ProcessEnv,
+  sessionId: string,
+): Promise<void> {
+  const apiKey = env.BROWSERBASE_API_KEY?.trim();
+  const projectId = env.BROWSERBASE_PROJECT_ID?.trim();
+  if (!apiKey || !projectId || !sessionId) {
+    throw new EvalsError("Cannot release the explicit Browserbase benchmark session.");
+  }
+  const baseUrl = (env.BROWSERBASE_BASE_URL?.trim() || "https://api.browserbase.com").replace(
+    /\/$/,
+    "",
+  );
+  let response: Response;
+  try {
+    response = await fetch(`${baseUrl}/v1/sessions/${sessionId}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "X-BB-API-Key": apiKey },
+      body: JSON.stringify({ projectId, status: "REQUEST_RELEASE" }),
+      signal: AbortSignal.timeout(15_000),
+    });
+  } catch (cause) {
+    throw new EvalsError("Browserbase benchmark session release failed.", { cause });
+  }
+  if (!response.ok) {
+    throw new EvalsError(`Browserbase benchmark session release returned HTTP ${response.status}.`);
+  }
+}
+
+export async function resolveHermesToolSchema(input: {
+  python: string;
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  surface: HermesBrowserSurface;
+}): Promise<HermesToolSchema> {
+  const toolset = input.surface === "hermes_browser_legacy" ? "browser" : "browser-use";
+  const source = [
+    "import json",
+    "from hermes_cli.oneshot import _validate_explicit_toolsets",
+    `valid,error=_validate_explicit_toolsets(${JSON.stringify(toolset)})`,
+    "assert error is None and valid is not None",
+    "import model_tools",
+    "definitions=model_tools.get_tool_definitions(enabled_toolsets=valid,quiet_mode=True,skip_tool_search_assembly=True)",
+    "canonical=json.dumps({'tools':definitions},ensure_ascii=False,sort_keys=True,separators=(',',':')).encode('utf-8')",
+    `print(${JSON.stringify(TOOL_SCHEMA_PREFIX)}+json.dumps({'bytes':len(canonical),'names':[item.get('function',{}).get('name') for item in definitions]},sort_keys=True,separators=(',',':')))`,
+  ].join("\n");
+  const result = await runProcess(input.python, ["-c", source], {
+    cwd: input.cwd,
+    env: input.env,
+    timeoutMs: 60_000,
+  });
+  const line = result.stdout
+    .split(/\r?\n/)
+    .reverse()
+    .find((candidate) => candidate.startsWith(TOOL_SCHEMA_PREFIX));
+  if (result.exitCode !== 0 || !line) {
+    throw new EvalsError("Could not resolve the exact Hermes model-visible tool schema.");
+  }
+  const value = JSON.parse(line.slice(TOOL_SCHEMA_PREFIX.length)) as Record<string, unknown>;
+  const schema: HermesToolSchema = {
+    bytes: nonnegativeInt(value.bytes),
+    names: Array.isArray(value.names)
+      ? value.names.filter((name): name is string => typeof name === "string")
+      : [],
+  };
+  const expected = EXPECTED_TOOL_SCHEMAS[input.surface];
+  if (
+    schema.bytes !== expected.bytes ||
+    [...schema.names].sort().join("\n") !== [...expected.names].sort().join("\n")
+  ) {
+    throw new EvalsError(
+      `Unexpected Hermes tool schema for ${input.surface}: ${schema.bytes} bytes [${schema.names.join(", ")}].`,
+    );
+  }
+  return schema;
+}
+
+function sha256(value: Uint8Array): string {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+async function ensureDirectory(directory: string): Promise<string> {
+  const resolved = path.resolve(directory);
+  await fsp.mkdir(resolved, { recursive: true });
+  return resolved.endsWith(path.sep) ? resolved : `${resolved}${path.sep}`;
+}
+
+function runProcess(
+  executable: string,
+  args: string[],
+  options: { cwd: string; env: NodeJS.ProcessEnv; signal?: AbortSignal; timeoutMs: number },
+): Promise<ProcessResult> {
+  return new Promise((resolve) => {
+    execFile(
+      executable,
+      args,
+      {
+        cwd: options.cwd,
+        env: options.env,
+        signal: options.signal,
+        timeout: options.timeoutMs,
+        maxBuffer: 32 * 1024 * 1024,
+        encoding: "utf8",
+      },
+      (error, stdout, stderr) => {
+        const errorCode = asRecord(error)?.code;
+        const exitCode = typeof errorCode === "number" ? errorCode : error ? 1 : 0;
+        resolve({ stdout: stdout ?? "", stderr: stderr ?? "", exitCode });
+      },
+    );
+  });
+}
+
+async function readUsage(usagePath: string): Promise<HermesUsage> {
+  if (!fs.existsSync(usagePath)) {
+    return emptyUsage();
+  }
+  const raw = JSON.parse(await fsp.readFile(usagePath, "utf8")) as Record<string, unknown>;
+  const usageNumber = (key: string): number => {
+    const value = raw[key];
+    if (value == null) return 0;
+    if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+      throw new EvalsError(`Hermes usage field ${key} is invalid.`);
+    }
+    return Math.trunc(value);
+  };
+  const estimatedCost = raw.estimated_cost_usd;
+  if (
+    estimatedCost != null &&
+    (typeof estimatedCost !== "number" || !Number.isFinite(estimatedCost) || estimatedCost < 0)
+  ) {
+    throw new EvalsError("Hermes estimated_cost_usd is invalid.");
+  }
+  return {
+    input_tokens: usageNumber("input_tokens"),
+    output_tokens: usageNumber("output_tokens"),
+    cache_read_tokens: usageNumber("cache_read_tokens"),
+    cache_write_tokens: usageNumber("cache_write_tokens"),
+    reasoning_tokens: usageNumber("reasoning_tokens"),
+    api_calls: usageNumber("api_calls"),
+    ...(typeof estimatedCost === "number" && {
+      estimated_cost_usd: estimatedCost,
+    }),
+    ...(typeof raw.session_id === "string" && { session_id: raw.session_id }),
+    ...(typeof raw.completed === "boolean" && { completed: raw.completed }),
+    ...(typeof raw.failed === "boolean" && { failed: raw.failed }),
+  };
+}
+
+function emptyUsage(failed = true): HermesUsage {
+  return {
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_read_tokens: 0,
+    cache_write_tokens: 0,
+    reasoning_tokens: 0,
+    api_calls: 0,
+    ...(failed && { failed: true }),
+  };
+}
+
+function addUsage(left: HermesUsage, right: HermesUsage): HermesUsage {
+  return {
+    input_tokens: left.input_tokens + right.input_tokens,
+    output_tokens: left.output_tokens + right.output_tokens,
+    cache_read_tokens: left.cache_read_tokens + right.cache_read_tokens,
+    cache_write_tokens: left.cache_write_tokens + right.cache_write_tokens,
+    reasoning_tokens: left.reasoning_tokens + right.reasoning_tokens,
+    api_calls: left.api_calls + right.api_calls,
+  };
+}
+
+async function readToolMetrics(evidenceDir: string): Promise<Array<Record<string, unknown>>> {
+  const metricsPath = path.join(evidenceDir, "tool-metrics.jsonl");
+  if (!fs.existsSync(metricsPath)) return [];
+  const rows: Array<Record<string, unknown>> = [];
+  let lineNumber = 0;
+  for (const line of (await fsp.readFile(metricsPath, "utf8")).split(/\r?\n/)) {
+    lineNumber += 1;
+    if (!line.trim()) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch (cause) {
+      throw new EvalsError(`Malformed Hermes tool metric at line ${lineNumber}.`, { cause });
+    }
+    if (!isRecord(parsed)) {
+      throw new EvalsError(`Hermes tool metric at line ${lineNumber} is not an object.`);
+    }
+    rows.push(parsed);
+  }
+  return rows;
+}
+
+function readStagehandInnerUsage(metrics: Array<Record<string, unknown>>): HermesUsage {
+  const usage = emptyUsage(false);
+  const fieldMap = {
+    total_prompt_tokens: "input_tokens",
+    total_completion_tokens: "output_tokens",
+    total_cached_input_tokens: "cache_read_tokens",
+    total_reasoning_tokens: "reasoning_tokens",
+  } as const;
+  for (const metric of metrics) {
+    const stagehand = asRecord(metric.stagehand_metrics);
+    const delta = asRecord(stagehand?.delta);
+    if (!delta) continue;
+    for (const [source, destination] of Object.entries(fieldMap)) {
+      usage[destination] += nonnegativeInt(delta[source]);
+    }
+  }
+  return usage;
+}
+
+async function readToolSchemaArtifact(schemaPath: string): Promise<HermesToolSchema | undefined> {
+  if (!fs.existsSync(schemaPath)) return undefined;
+  const value = JSON.parse(await fsp.readFile(schemaPath, "utf8")) as Record<string, unknown>;
+  return {
+    bytes: nonnegativeInt(value.bytes),
+    names: Array.isArray(value.names)
+      ? value.names.filter((name): name is string => typeof name === "string")
+      : [],
+  };
+}
+
+async function readRetainedTiming(
+  artifactDir: string,
+): Promise<Pick<HermesRunArtifact, "agentWallMs" | "browserWallMs" | "sessionSetupMs">> {
+  const recordPath = path.join(artifactDir, "record.json");
+  if (!fs.existsSync(recordPath)) return {};
+  const record = JSON.parse(await fsp.readFile(recordPath, "utf8")) as Record<string, unknown>;
+  const timing = asRecord(record.timing);
+  const agentWallMs = nonnegativeInt(timing?.agent_wall_ms);
+  const browserWallMs = nonnegativeInt(timing?.browser_wall_ms);
+  const sessionSetupMs = nonnegativeInt(timing?.session_setup_ms);
+  return {
+    ...(agentWallMs > 0 && { agentWallMs }),
+    ...(browserWallMs > 0 && { browserWallMs }),
+    ...(sessionSetupMs > 0 && { sessionSetupMs }),
+  };
+}
+
+function readHermesState(
+  databasePath: string,
+  requestedSessionId?: string,
+): { messages: HermesMessageRow[]; toolCallCount: number } {
+  const database = new DatabaseSync(databasePath, { readOnly: true });
+  try {
+    const session = requestedSessionId
+      ? database
+          .prepare("SELECT id, tool_call_count FROM sessions WHERE id = ?")
+          .get(requestedSessionId)
+      : database
+          .prepare("SELECT id, tool_call_count FROM sessions ORDER BY started_at DESC LIMIT 1")
+          .get();
+    const sessionRecord = asRecord(session);
+    const sessionId = readString(sessionRecord, "id");
+    if (!sessionId) return { messages: [], toolCallCount: 0 };
+    const rows = database
+      .prepare(
+        "SELECT id, role, content, tool_call_id, tool_calls, tool_name, reasoning, reasoning_content FROM messages WHERE session_id = ? ORDER BY id",
+      )
+      .all(sessionId) as unknown as HermesMessageRow[];
+    return {
+      messages: rows,
+      toolCallCount: nonnegativeInt(sessionRecord?.tool_call_count),
+    };
+  } finally {
+    database.close();
+  }
+}
+
+async function readFinalObservation(evidenceDir: string): Promise<ProbeEvidence | undefined> {
+  const screenshotPath = path.join(evidenceDir, "screenshot.png");
+  if (!fs.existsSync(screenshotPath)) return undefined;
+  const finalUrlPath = path.join(evidenceDir, "final-url.txt");
+  return {
+    screenshot: await fsp.readFile(screenshotPath),
+    ...(fs.existsSync(finalUrlPath) && {
+      url: (await fsp.readFile(finalUrlPath, "utf8")).trim(),
+    }),
+  };
+}
+
+async function readStepObservations(
+  evidenceDir: string,
+): Promise<Array<ProbeEvidence | undefined>> {
+  const stepsDir = path.join(evidenceDir, "steps");
+  if (!fs.existsSync(stepsDir)) return [];
+  const metadataFiles = (await fsp.readdir(stepsDir))
+    .filter((name) => /^step-\d+\.json$/.test(name))
+    .sort();
+  const observations: Array<ProbeEvidence | undefined> = [];
+  for (const filename of metadataFiles) {
+    try {
+      const metadata = JSON.parse(
+        await fsp.readFile(path.join(stepsDir, filename), "utf8"),
+      ) as Record<string, unknown>;
+      const actionIndex = nonnegativeInt(metadata.action_index);
+      const screenshotName = readString(metadata, "screenshot");
+      if (actionIndex < 1 || !screenshotName || path.basename(screenshotName) !== screenshotName) {
+        continue;
+      }
+      const screenshotPath = path.join(stepsDir, screenshotName);
+      if (!fs.existsSync(screenshotPath)) continue;
+      observations[actionIndex - 1] = {
+        screenshot: await fsp.readFile(screenshotPath),
+        ...(readString(metadata, "final_url") && {
+          url: readString(metadata, "final_url"),
+        }),
+      };
+    } catch {
+      // One malformed frame must not discard other independently captured evidence.
+    }
+  }
+  return observations;
+}
+
+function parseToolCalls(value: string): Record<string, unknown>[] {
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.filter(isRecord) : [];
+  } catch {
+    return [];
+  }
+}
+
+function parseToolArguments(value: unknown): Record<string, unknown> {
+  if (isRecord(value)) return value;
+  if (typeof value !== "string") return {};
+  try {
+    const parsed = JSON.parse(value);
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return { raw: value };
+  }
+}
+
+function parseHermesToolResult(content: string): {
+  value: unknown;
+  ok: boolean;
+  error?: string;
+} {
+  const match = content.match(
+    /<untrusted_tool_result[^>]*>\s*[\s\S]*?\n\n([\s\S]*?)\s*<\/untrusted_tool_result>/,
+  );
+  const candidate = match?.[1]?.trim() ?? content.trim();
+  try {
+    const value = JSON.parse(candidate) as unknown;
+    const record = asRecord(value);
+    const ok = record?.success !== false && record?.error === undefined;
+    return {
+      value,
+      ok,
+      ...(!ok && { error: String(record?.error ?? "Hermes tool returned success=false") }),
+    };
+  } catch {
+    return { value: content, ok: !/\b(?:error|failed)\b/i.test(content) };
+  }
+}
+
+function readPositiveIntEnv(key: string, fallback: number): number {
+  const value = Number.parseInt(process.env[key] ?? "", 10);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function nonnegativeInt(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? Math.trunc(value) : 0;
+}
+
+function firstNonempty(...values: Array<string | null | undefined>): string | undefined {
+  return values.find(
+    (value): value is string => typeof value === "string" && value.trim().length > 0,
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return isRecord(value) ? value : undefined;
+}
+
+function readString(value: Record<string, unknown> | undefined, key: string): string | undefined {
+  const item = value?.[key];
+  return typeof item === "string" && item.length > 0 ? item : undefined;
+}

--- a/packages/evals/framework/hermesRunner.ts
+++ b/packages/evals/framework/hermesRunner.ts
@@ -120,7 +120,7 @@ const EXPECTED_TOOL_SCHEMAS: Record<HermesBrowserSurface, HermesToolSchema> = {
     ],
   },
   hermes_browser_exec: { bytes: 10_387, names: ["browser_exec"] },
-  hermes_stagehand_batch: { bytes: 1_794, names: ["browser_exec"] },
+  hermes_stagehand_batch: { bytes: 10_461, names: ["browser_exec"] },
 };
 const PINNED_BROWSER_USE = {
   packageVersion: "0.13.7",

--- a/packages/evals/framework/rubricCache.ts
+++ b/packages/evals/framework/rubricCache.ts
@@ -18,10 +18,12 @@ import path from "node:path";
 import crypto from "node:crypto";
 
 import type { Rubric, TaskSpec } from "stagehand-v3";
+import { getPackageRootDir } from "../runtimePaths.js";
 
 export interface RubricCacheOptions {
   /**
    * Root directory for cached rubrics. Defaults to
+   * `EVAL_RUBRIC_CACHE_ROOT` when set, otherwise
    * `<packages/evals>/.rubric-cache`.
    */
   cacheRoot?: string;
@@ -47,7 +49,9 @@ export class RubricCache {
   private readonly cacheDir: string;
 
   constructor(opts: RubricCacheOptions) {
-    const root = opts.cacheRoot ?? path.join(process.cwd(), "packages/evals/.rubric-cache");
+    const configuredRoot = process.env.EVAL_RUBRIC_CACHE_ROOT?.trim();
+    const root =
+      opts.cacheRoot ?? configuredRoot ?? path.join(getPackageRootDir(), ".rubric-cache");
     this.cacheDir = path.join(root, opts.dataset);
   }
 

--- a/packages/evals/framework/verifierAdapter.ts
+++ b/packages/evals/framework/verifierAdapter.ts
@@ -19,6 +19,15 @@ import type { TaskResult } from "./types.js";
 const VERIFIER_MODEL_ENV = "EVAL_VERIFIER_MODEL";
 const KEYLESS_VERIFIER_PROVIDERS = new Set(["bedrock", "ollama"]);
 
+export function loadVerifierApiKey(provider: string | undefined): string | undefined {
+  // Stagehand v3's key loader predates the AI SDK `gateway/*` provider
+  // prefix. Vercel AI Gateway uses the same key as Hermes's ai-gateway route.
+  if (provider === "gateway") {
+    return process.env.AI_GATEWAY_API_KEY?.trim() || undefined;
+  }
+  return loadApiKeyFromEnv(provider, () => {});
+}
+
 /**
  * Build the shared rubric verifier. By default V3Evaluator keeps its existing
  * model selection; EVAL_VERIFIER_MODEL makes the verifier independently
@@ -31,7 +40,7 @@ export function createVerifierEvaluator(v3: V3): V3Evaluator {
   }
 
   const provider = modelName.includes("/") ? modelName.slice(0, modelName.indexOf("/")) : undefined;
-  const apiKey = loadApiKeyFromEnv(provider, () => {});
+  const apiKey = loadVerifierApiKey(provider);
   if (!apiKey && !KEYLESS_VERIFIER_PROVIDERS.has(provider ?? "")) {
     throw new Error(
       `${VERIFIER_MODEL_ENV} is set to "${modelName}", but no API key was found for provider "${provider ?? "unknown"}".`,
@@ -201,13 +210,16 @@ export interface GradeExternalTrajectoryOptions {
   /** Logger category ("claude_code" | "codex"). */
   category: string;
   logger: EvalLogger;
+  /** Treat verifier/trajectory failures as benchmark failures, never agent passes. */
+  failClosedOnVerifierError?: boolean;
 }
 
 /**
  * Grade an external-harness run with the rubric verifier and fold the verdict
  * into the TaskResult. Never throws: on any failure in the verifier path the
- * self-reported result is returned with `verifierError` set, so downstream
- * consumers can tell an ungraded run apart from a graded one.
+ * the result is returned with `verifierError` set. Callers evaluating a
+ * benchmark contract can additionally fail closed instead of inheriting the
+ * agent's self-reported status.
  */
 export async function gradeExternalTrajectory({
   buildTrajectory,
@@ -216,6 +228,7 @@ export async function gradeExternalTrajectory({
   errorMessage,
   category,
   logger,
+  failClosedOnVerifierError = false,
 }: GradeExternalTrajectoryOptions): Promise<TaskResult> {
   try {
     const trajectory = buildTrajectory();
@@ -274,10 +287,14 @@ export async function gradeExternalTrajectory({
         error: { value: message, type: "string" },
       },
     });
-    // Surface the failure on the result — `_success` falls back to the
-    // agent's self-report, and downstream consumers must be able to tell
-    // this run apart from one the verifier actually graded.
-    return { ...baseResult, verifierError: message };
+    return {
+      ...baseResult,
+      ...(failClosedOnVerifierError && {
+        _success: false,
+        error: baseResult.error ?? `verifier integration failed: ${message}`,
+      }),
+      verifierError: message,
+    };
   }
 }
 

--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -17,6 +17,7 @@
     "test:evals": "tsx scripts/test-evals.ts --cli packages/evals/dist/cli/cli.js",
     "eval": "tsx cli.ts",
     "regrade:hermes": "tsx scripts/regrade-hermes-artifact.ts",
+    "freeze:hermes-rubrics": "tsx scripts/freeze-hermes-rubrics.ts",
     "benchmark:hermes-public-hard": "tsx scripts/run-hermes-public-hard.ts",
     "report:core": "tsx scripts/render-braintrust-core-report.ts"
   },

--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -16,6 +16,8 @@
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "test:evals": "tsx scripts/test-evals.ts --cli packages/evals/dist/cli/cli.js",
     "eval": "tsx cli.ts",
+    "regrade:hermes": "tsx scripts/regrade-hermes-artifact.ts",
+    "benchmark:hermes-public-hard": "tsx scripts/run-hermes-public-hard.ts",
     "report:core": "tsx scripts/render-braintrust-core-report.ts"
   },
   "dependencies": {

--- a/packages/evals/pilots/hermes-online-mind2web-hard-v1.json
+++ b/packages/evals/pilots/hermes-online-mind2web-hard-v1.json
@@ -1,0 +1,130 @@
+{
+  "id": "hermes-online-mind2web-hard-v1",
+  "dataset": "onlineMind2Web",
+  "dataset_file": "datasets/onlineMind2Web/onlineMind2Web.jsonl",
+  "dataset_file_sha256": "d10a837d6ea67349dca8541cd697eb2636ff61b937ba0f09596f775e1b327b30",
+  "selection": {
+    "candidate_filter": "level == hard",
+    "method": "curated frozen public-track slice",
+    "constraints": [
+      "ten distinct website hostnames",
+      "high reference length where feasible",
+      "no login, payment, irreversible, expired fixed-date, or relative-date tasks",
+      "assigned start sites live at preflight"
+    ],
+    "count": 10
+  },
+  "task_ids": [
+    "d02d236836924919f35f2438d9ed2374",
+    "c39d6c245f8243993e707d54d2f4acec",
+    "8f2611047de227a2ca8bda13f6e2e5fb",
+    "b64f938af842f6a1b4489d0e49a785a7",
+    "ec78d3a635e417bc2a80d03ca93d7165",
+    "1b867afecf072cb877ebfa4069263746",
+    "bb5d90e6f2fbc0ae146f7c1998c2b4a1",
+    "c577a14301a725e09ccd269a3e0b271e",
+    "a5c87cc1c94a090c9a8dc2c8b6a125d0",
+    "1ab384fb3a791edfb410213cc6b82151"
+  ],
+  "arms": [
+    {
+      "harness": "hermes",
+      "tool": "hermes_browser_legacy"
+    },
+    {
+      "harness": "hermes",
+      "tool": "hermes_browser_exec"
+    },
+    {
+      "harness": "hermes",
+      "tool": "hermes_stagehand_batch"
+    }
+  ],
+  "agent_provider": "ai-gateway",
+  "task_model_pairs": [
+    { "task_id": "d02d236836924919f35f2438d9ed2374", "model": "anthropic/claude-opus-4.8" },
+    { "task_id": "c39d6c245f8243993e707d54d2f4acec", "model": "moonshotai/kimi-k3" },
+    { "task_id": "8f2611047de227a2ca8bda13f6e2e5fb", "model": "anthropic/claude-opus-4.8" },
+    { "task_id": "b64f938af842f6a1b4489d0e49a785a7", "model": "moonshotai/kimi-k3" },
+    { "task_id": "ec78d3a635e417bc2a80d03ca93d7165", "model": "anthropic/claude-opus-4.8" },
+    { "task_id": "1b867afecf072cb877ebfa4069263746", "model": "moonshotai/kimi-k3" },
+    { "task_id": "bb5d90e6f2fbc0ae146f7c1998c2b4a1", "model": "anthropic/claude-opus-4.8" },
+    { "task_id": "c577a14301a725e09ccd269a3e0b271e", "model": "moonshotai/kimi-k3" },
+    { "task_id": "a5c87cc1c94a090c9a8dc2c8b6a125d0", "model": "anthropic/claude-opus-4.8" },
+    { "task_id": "1ab384fb3a791edfb410213cc6b82151", "model": "moonshotai/kimi-k3" }
+  ],
+  "verifier_model": "gateway/google/gemini-2.5-flash",
+  "verifier_selection": {
+    "methodology_target": "gateway/openai/o4-mini",
+    "methodology_target_status": "unavailable_through_vercel_ai_gateway",
+    "diagnostic": "GatewayInternalServerError: The API deployment for this resource does not exist.",
+    "selected_fallback": "gateway/google/gemini-2.5-flash"
+  },
+  "rubric_policy": "generate once per task, freeze by task id plus instruction hash, and reuse byte-identical cached rubric across every arm",
+  "environment": "BROWSERBASE",
+  "trials": 1,
+  "concurrency": 1,
+  "timeout_seconds": 1800,
+  "success_mode": "both",
+  "run_plan": [
+    {
+      "task_id": "d02d236836924919f35f2438d9ed2374",
+      "model": "anthropic/claude-opus-4.8",
+      "arm_order": ["A", "B", "D"]
+    },
+    {
+      "task_id": "c39d6c245f8243993e707d54d2f4acec",
+      "model": "moonshotai/kimi-k3",
+      "arm_order": ["B", "D", "A"]
+    },
+    {
+      "task_id": "8f2611047de227a2ca8bda13f6e2e5fb",
+      "model": "anthropic/claude-opus-4.8",
+      "arm_order": ["D", "A", "B"]
+    },
+    {
+      "task_id": "b64f938af842f6a1b4489d0e49a785a7",
+      "model": "moonshotai/kimi-k3",
+      "arm_order": ["A", "B", "D"]
+    },
+    {
+      "task_id": "ec78d3a635e417bc2a80d03ca93d7165",
+      "model": "anthropic/claude-opus-4.8",
+      "arm_order": ["B", "D", "A"]
+    },
+    {
+      "task_id": "1b867afecf072cb877ebfa4069263746",
+      "model": "moonshotai/kimi-k3",
+      "arm_order": ["D", "A", "B"]
+    },
+    {
+      "task_id": "bb5d90e6f2fbc0ae146f7c1998c2b4a1",
+      "model": "anthropic/claude-opus-4.8",
+      "arm_order": ["A", "B", "D"]
+    },
+    {
+      "task_id": "c577a14301a725e09ccd269a3e0b271e",
+      "model": "moonshotai/kimi-k3",
+      "arm_order": ["B", "D", "A"]
+    },
+    {
+      "task_id": "a5c87cc1c94a090c9a8dc2c8b6a125d0",
+      "model": "anthropic/claude-opus-4.8",
+      "arm_order": ["D", "A", "B"]
+    },
+    {
+      "task_id": "1ab384fb3a791edfb410213cc6b82151",
+      "model": "moonshotai/kimi-k3",
+      "arm_order": ["A", "B", "D"]
+    }
+  ],
+  "canary_plan": {
+    "task_id": "1b867afecf072cb877ebfa4069263746",
+    "model": "moonshotai/kimi-k3",
+    "arm_order": ["A", "B", "D"]
+  },
+  "verifiability_gate": {
+    "max_unverifiable_criteria": 0,
+    "ungraded_runs_allowed": 0
+  }
+}

--- a/packages/evals/scripts/freeze-hermes-rubrics.ts
+++ b/packages/evals/scripts/freeze-hermes-rubrics.ts
@@ -71,6 +71,8 @@ async function main(): Promise<void> {
     throw new Error("Rubric block range is outside the frozen manifest");
   }
   const tasks = manifest.tasks.slice(firstBlock - 1, lastBlock);
+  const concurrency = optionalPositiveIntArg("--concurrency") ?? 1;
+  if (concurrency > 8) throw new Error("--concurrency must be at most 8");
   process.env.EVAL_RUBRIC_CACHE_ROOT = cacheRoot;
   process.env.EVAL_VERIFIER_MODEL = manifest.grading.primary_verifier.model;
 
@@ -87,31 +89,41 @@ async function main(): Promise<void> {
   const evaluator = createVerifierEvaluator(carrier);
   let cached = 0;
   let generated = 0;
-  const identities: Array<Record<string, unknown>> = [];
+  let completed = 0;
+  let cursor = 0;
+  const identities: Array<Record<string, unknown> | undefined> = new Array(tasks.length);
   try {
-    for (const task of tasks) {
-      const taskSpec: TaskSpec = {
-        id: task.task_id,
-        instruction: task.confirmed_task,
-        initUrl: task.website,
-      };
-      const resolved = await resolveRubricTraced(evaluator, {
-        taskSpec,
-        dataset: "onlineMind2Web",
-        cacheRoot,
-      });
-      if (resolved.source === "cached") cached += 1;
-      else generated += 1;
-      identities.push({
-        task_id: task.task_id,
-        source: resolved.source,
-        criterion_count: resolved.rubric.items.length,
-        rubric_sha256: sha256(JSON.stringify(resolved.rubric)),
-      });
-      process.stderr.write(
-        `[rubric-freeze] ${cached + generated}/${tasks.length} ${task.task_id} ${resolved.source}\n`,
-      );
-    }
+    const worker = async (): Promise<void> => {
+      while (cursor < tasks.length) {
+        const index = cursor++;
+        const task = tasks[index];
+        const taskSpec: TaskSpec = {
+          id: task.task_id,
+          instruction: task.confirmed_task,
+          initUrl: task.website,
+        };
+        const resolved = await resolveRubricTraced(evaluator, {
+          taskSpec,
+          dataset: "onlineMind2Web",
+          cacheRoot,
+        });
+        if (resolved.source === "cached") cached += 1;
+        else generated += 1;
+        identities[index] = {
+          task_id: task.task_id,
+          source: resolved.source,
+          criterion_count: resolved.rubric.items.length,
+          rubric_sha256: sha256(JSON.stringify(resolved.rubric)),
+        };
+        completed += 1;
+        process.stderr.write(
+          `[rubric-freeze] ${completed}/${tasks.length} ${task.task_id} ${resolved.source}\n`,
+        );
+      }
+    };
+    await Promise.all(
+      Array.from({ length: Math.min(concurrency, tasks.length) }, async () => worker()),
+    );
   } finally {
     void carrier.close().catch(() => {});
   }
@@ -126,9 +138,13 @@ async function main(): Promise<void> {
     first_block: firstBlock,
     last_block: lastBlock,
     task_count: tasks.length,
+    concurrency,
     cached,
     generated,
-    identities,
+    identities: identities.map((identity, index) => {
+      if (!identity) throw new Error(`Missing rubric identity at selected index ${index}`);
+      return identity;
+    }),
   };
   const output = path.resolve(requiredArg("--output"));
   fs.mkdirSync(path.dirname(output), { recursive: true });

--- a/packages/evals/scripts/freeze-hermes-rubrics.ts
+++ b/packages/evals/scripts/freeze-hermes-rubrics.ts
@@ -1,0 +1,147 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+import { V3, type TaskSpec } from "stagehand-v3";
+
+import { createVerifierEvaluator, resolveRubricTraced } from "../framework/verifierAdapter.js";
+import { EvalLogger } from "../logger.js";
+
+interface ManifestTask {
+  task_id: string;
+  confirmed_task: string;
+  website: string;
+}
+
+interface ScaledManifest {
+  schema_version: "1";
+  suite: { id: string; task_count: number };
+  grading: { primary_verifier: { model: string; rubric_policy: string } };
+  tasks: ManifestTask[];
+}
+
+function requiredArg(name: string): string {
+  const index = process.argv.indexOf(name);
+  const value = index >= 0 ? process.argv[index + 1]?.trim() : undefined;
+  if (!value || value.startsWith("--")) throw new Error(`Missing required argument ${name}`);
+  return value;
+}
+
+function optionalPositiveIntArg(name: string): number | undefined {
+  const index = process.argv.indexOf(name);
+  const value = index >= 0 ? process.argv[index + 1]?.trim() : undefined;
+  if (!value) return undefined;
+  if (!/^\d+$/.test(value) || Number(value) < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return Number(value);
+}
+
+function sha256(value: Uint8Array | string): string {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+function readManifest(file: string, expectedSha256: string): ScaledManifest {
+  const bytes = fs.readFileSync(file);
+  const observed = sha256(bytes);
+  if (observed !== expectedSha256) {
+    throw new Error(`Manifest digest mismatch: expected ${expectedSha256}, observed ${observed}`);
+  }
+  const manifest = JSON.parse(bytes.toString("utf8")) as ScaledManifest;
+  if (
+    manifest.schema_version !== "1" ||
+    !manifest.suite.id.startsWith("online-mind2web-paired-bd-") ||
+    manifest.tasks.length !== manifest.suite.task_count ||
+    manifest.grading.primary_verifier.rubric_policy !==
+      "Generate and freeze every selected task rubric before either arm runs; reuse it byte-for-byte for B and D."
+  ) {
+    throw new Error("Manifest is not a frozen scaled B/D declaration");
+  }
+  return manifest;
+}
+
+async function main(): Promise<void> {
+  const manifestPath = path.resolve(requiredArg("--manifest"));
+  const manifestSha256 = requiredArg("--manifest-sha256");
+  const cacheRoot = path.resolve(requiredArg("--cache-root"));
+  const manifest = readManifest(manifestPath, manifestSha256);
+  const firstBlock = optionalPositiveIntArg("--first-block") ?? 1;
+  const lastBlock = optionalPositiveIntArg("--last-block") ?? manifest.tasks.length;
+  if (firstBlock > lastBlock || lastBlock > manifest.tasks.length) {
+    throw new Error("Rubric block range is outside the frozen manifest");
+  }
+  const tasks = manifest.tasks.slice(firstBlock - 1, lastBlock);
+  process.env.EVAL_RUBRIC_CACHE_ROOT = cacheRoot;
+  process.env.EVAL_VERIFIER_MODEL = manifest.grading.primary_verifier.model;
+
+  const logger = new EvalLogger(true);
+  const carrier = new V3({
+    env: "LOCAL",
+    logger: logger.log.bind(logger),
+    disablePino: true,
+    disableAPI: true,
+    experimental: true,
+    verbose: 0,
+  });
+  logger.init(carrier);
+  const evaluator = createVerifierEvaluator(carrier);
+  let cached = 0;
+  let generated = 0;
+  const identities: Array<Record<string, unknown>> = [];
+  try {
+    for (const task of tasks) {
+      const taskSpec: TaskSpec = {
+        id: task.task_id,
+        instruction: task.confirmed_task,
+        initUrl: task.website,
+      };
+      const resolved = await resolveRubricTraced(evaluator, {
+        taskSpec,
+        dataset: "onlineMind2Web",
+        cacheRoot,
+      });
+      if (resolved.source === "cached") cached += 1;
+      else generated += 1;
+      identities.push({
+        task_id: task.task_id,
+        source: resolved.source,
+        criterion_count: resolved.rubric.items.length,
+        rubric_sha256: sha256(JSON.stringify(resolved.rubric)),
+      });
+      process.stderr.write(
+        `[rubric-freeze] ${cached + generated}/${tasks.length} ${task.task_id} ${resolved.source}\n`,
+      );
+    }
+  } finally {
+    void carrier.close().catch(() => {});
+  }
+
+  const report = {
+    schema_version: 1,
+    suite_id: manifest.suite.id,
+    manifest_sha256: manifestSha256,
+    verifier_model: manifest.grading.primary_verifier.model,
+    cache_root: cacheRoot,
+    suite_task_count: manifest.tasks.length,
+    first_block: firstBlock,
+    last_block: lastBlock,
+    task_count: tasks.length,
+    cached,
+    generated,
+    identities,
+  };
+  const output = path.resolve(requiredArg("--output"));
+  fs.mkdirSync(path.dirname(output), { recursive: true });
+  const temporary = `${output}.tmp-${process.pid}`;
+  fs.writeFileSync(temporary, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  fs.renameSync(temporary, output);
+  console.log(JSON.stringify({ task_count: tasks.length, cached, generated, output }));
+}
+
+main().then(
+  () => process.exit(0),
+  (error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  },
+);

--- a/packages/evals/scripts/regrade-hermes-artifact.ts
+++ b/packages/evals/scripts/regrade-hermes-artifact.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { V3, type TaskSpec } from "stagehand-v3";
@@ -22,6 +23,13 @@ interface PilotManifest {
   verifier_model: string;
 }
 
+interface BenchmarkManifest {
+  schema_version: "1";
+  suite: { id: string };
+  grading: { primary_verifier: { model: string } };
+  tasks: OnlineMind2WebRow[];
+}
+
 function readRequiredArg(name: string): string {
   const index = process.argv.indexOf(name);
   const value = index >= 0 ? process.argv[index + 1]?.trim() : undefined;
@@ -35,6 +43,14 @@ function readOptionalArg(name: string): string | undefined {
   const index = process.argv.indexOf(name);
   const value = index >= 0 ? process.argv[index + 1]?.trim() : undefined;
   return value && !value.startsWith("--") ? value : undefined;
+}
+
+function taskSpec(row: OnlineMind2WebRow): TaskSpec {
+  return {
+    id: row.task_id,
+    instruction: row.confirmed_task,
+    initUrl: row.website,
+  };
 }
 
 function readTask(taskId: string): TaskSpec {
@@ -51,11 +67,33 @@ function readTask(taskId: string): TaskSpec {
     .map((line) => JSON.parse(line) as OnlineMind2WebRow)
     .find((candidate) => candidate.task_id === taskId);
   if (!row) throw new Error(`OnlineMind2Web task not found: ${taskId}`);
-  return {
-    id: row.task_id,
-    instruction: row.confirmed_task,
-    initUrl: row.website,
-  };
+  return taskSpec(row);
+}
+
+function readBenchmarkTask(
+  file: string,
+  expectedSha256: string,
+  taskId: string,
+): { task: TaskSpec; verifierModel: string } {
+  const bytes = fs.readFileSync(file);
+  const observed = crypto.createHash("sha256").update(bytes).digest("hex");
+  if (observed !== expectedSha256) {
+    throw new Error(
+      `Benchmark manifest digest mismatch: expected ${expectedSha256}, observed ${observed}`,
+    );
+  }
+  const manifest = JSON.parse(bytes.toString("utf8")) as BenchmarkManifest;
+  if (
+    manifest.schema_version !== "1" ||
+    typeof manifest.suite?.id !== "string" ||
+    !Array.isArray(manifest.tasks) ||
+    typeof manifest.grading?.primary_verifier?.model !== "string"
+  ) {
+    throw new Error("Benchmark manifest is malformed");
+  }
+  const row = manifest.tasks.find((candidate) => candidate.task_id === taskId);
+  if (!row) throw new Error(`Task ${taskId} is not part of the retained benchmark manifest.`);
+  return { task: taskSpec(row), verifierModel: manifest.grading.primary_verifier.model };
 }
 
 async function main(): Promise<void> {
@@ -64,15 +102,36 @@ async function main(): Promise<void> {
   const trajectoryRoot = path.resolve(readRequiredArg("--trajectory-root"));
   const resultJsonArg = readOptionalArg("--result-json");
   const resultJson = resultJsonArg ? path.resolve(resultJsonArg) : undefined;
-  const packageRoot = getPackageRootDir();
-  const manifest = JSON.parse(
-    fs.readFileSync(
-      path.join(packageRoot, "pilots", "hermes-online-mind2web-hard-v1.json"),
-      "utf8",
-    ),
-  ) as PilotManifest;
-  if (!manifest.task_ids.includes(taskId)) {
-    throw new Error(`Task ${taskId} is not part of the frozen Hermes pilot.`);
+  const benchmarkManifestArg = readOptionalArg("--benchmark-manifest");
+  const benchmarkManifestSha256 = readOptionalArg("--benchmark-manifest-sha256");
+  if (Boolean(benchmarkManifestArg) !== Boolean(benchmarkManifestSha256)) {
+    throw new Error(
+      "--benchmark-manifest and --benchmark-manifest-sha256 must be supplied together",
+    );
+  }
+  let task: TaskSpec;
+  let declaredVerifierModel: string;
+  if (benchmarkManifestArg && benchmarkManifestSha256) {
+    const retained = readBenchmarkTask(
+      path.resolve(benchmarkManifestArg),
+      benchmarkManifestSha256,
+      taskId,
+    );
+    task = retained.task;
+    declaredVerifierModel = retained.verifierModel;
+  } else {
+    const packageRoot = getPackageRootDir();
+    const manifest = JSON.parse(
+      fs.readFileSync(
+        path.join(packageRoot, "pilots", "hermes-online-mind2web-hard-v1.json"),
+        "utf8",
+      ),
+    ) as PilotManifest;
+    if (!manifest.task_ids.includes(taskId)) {
+      throw new Error(`Task ${taskId} is not part of the frozen Hermes pilot.`);
+    }
+    task = readTask(taskId);
+    declaredVerifierModel = manifest.verifier_model;
   }
 
   const surfaceValue = readOptionalArg("--surface") ?? "hermes_stagehand_batch";
@@ -80,11 +139,16 @@ async function main(): Promise<void> {
     throw new Error(`Unsupported Hermes surface: ${surfaceValue}`);
   }
   const surface = surfaceValue as HermesBrowserSurface;
-  const verifierModel = readOptionalArg("--verifier-model") ?? manifest.verifier_model;
+  const verifierModel = readOptionalArg("--verifier-model") ?? declaredVerifierModel;
+  if (verifierModel !== declaredVerifierModel) {
+    throw new Error(
+      `Verifier model ${verifierModel} differs from retained declaration ${declaredVerifierModel}`,
+    );
+  }
   process.env.EVAL_VERIFIER_MODEL = verifierModel;
   process.env.VERIFIER_PERSIST_TRAJECTORIES = "1";
 
-  const taskSpec = readTask(taskId);
+  const taskSpec = task;
   const artifact = await loadHermesArtifactDirectory(artifactDir, surface);
   const logger = new EvalLogger(true);
   const carrier = new V3({

--- a/packages/evals/scripts/regrade-hermes-artifact.ts
+++ b/packages/evals/scripts/regrade-hermes-artifact.ts
@@ -1,0 +1,191 @@
+import fs from "node:fs";
+import path from "node:path";
+import { V3, type TaskSpec } from "stagehand-v3";
+
+import { EvalLogger } from "../logger.js";
+import { getPackageRootDir } from "../runtimePaths.js";
+import {
+  gradeHermesArtifact,
+  HERMES_BROWSER_SURFACES,
+  loadHermesArtifactDirectory,
+  type HermesBrowserSurface,
+} from "../framework/hermesRunner.js";
+
+interface OnlineMind2WebRow {
+  task_id: string;
+  confirmed_task: string;
+  website: string;
+}
+
+interface PilotManifest {
+  task_ids: string[];
+  verifier_model: string;
+}
+
+function readRequiredArg(name: string): string {
+  const index = process.argv.indexOf(name);
+  const value = index >= 0 ? process.argv[index + 1]?.trim() : undefined;
+  if (!value || value.startsWith("--")) {
+    throw new Error(`Missing required argument ${name}`);
+  }
+  return value;
+}
+
+function readOptionalArg(name: string): string | undefined {
+  const index = process.argv.indexOf(name);
+  const value = index >= 0 ? process.argv[index + 1]?.trim() : undefined;
+  return value && !value.startsWith("--") ? value : undefined;
+}
+
+function readTask(taskId: string): TaskSpec {
+  const datasetPath = path.join(
+    getPackageRootDir(),
+    "datasets",
+    "onlineMind2Web",
+    "onlineMind2Web.jsonl",
+  );
+  const row = fs
+    .readFileSync(datasetPath, "utf8")
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as OnlineMind2WebRow)
+    .find((candidate) => candidate.task_id === taskId);
+  if (!row) throw new Error(`OnlineMind2Web task not found: ${taskId}`);
+  return {
+    id: row.task_id,
+    instruction: row.confirmed_task,
+    initUrl: row.website,
+  };
+}
+
+async function main(): Promise<void> {
+  const artifactDir = path.resolve(readRequiredArg("--artifact"));
+  const taskId = readRequiredArg("--task-id");
+  const trajectoryRoot = path.resolve(readRequiredArg("--trajectory-root"));
+  const resultJsonArg = readOptionalArg("--result-json");
+  const resultJson = resultJsonArg ? path.resolve(resultJsonArg) : undefined;
+  const packageRoot = getPackageRootDir();
+  const manifest = JSON.parse(
+    fs.readFileSync(
+      path.join(packageRoot, "pilots", "hermes-online-mind2web-hard-v1.json"),
+      "utf8",
+    ),
+  ) as PilotManifest;
+  if (!manifest.task_ids.includes(taskId)) {
+    throw new Error(`Task ${taskId} is not part of the frozen Hermes pilot.`);
+  }
+
+  const surfaceValue = readOptionalArg("--surface") ?? "hermes_stagehand_batch";
+  if (!HERMES_BROWSER_SURFACES.includes(surfaceValue as HermesBrowserSurface)) {
+    throw new Error(`Unsupported Hermes surface: ${surfaceValue}`);
+  }
+  const surface = surfaceValue as HermesBrowserSurface;
+  const verifierModel = readOptionalArg("--verifier-model") ?? manifest.verifier_model;
+  process.env.EVAL_VERIFIER_MODEL = verifierModel;
+  process.env.VERIFIER_PERSIST_TRAJECTORIES = "1";
+
+  const taskSpec = readTask(taskId);
+  const artifact = await loadHermesArtifactDirectory(artifactDir, surface);
+  const logger = new EvalLogger(true);
+  const carrier = new V3({
+    env: "LOCAL",
+    logger: logger.log.bind(logger),
+    disablePino: true,
+    disableAPI: true,
+    experimental: true,
+    verbose: 0,
+  });
+  logger.init(carrier);
+
+  try {
+    const result = await gradeHermesArtifact({
+      artifact,
+      taskSpec,
+      logger,
+      verifier: {
+        v3: carrier,
+        taskSpec,
+        dataset: "onlineMind2Web",
+        trajectoryRoot,
+        runId: `regrade-${path.basename(artifactDir)}`,
+      },
+    });
+    const rawMetrics = result.rawMetrics as
+      | { outer?: { total_tokens?: number }; combined?: Record<string, number> }
+      | undefined;
+    const summary = {
+      artifactDir,
+      taskId,
+      surface,
+      verifierModel,
+      agentCompleted:
+        artifact.exitCode === 0 &&
+        artifact.usage.completed === true &&
+        artifact.usage.failed !== true,
+      agentApiCalls: artifact.usage.api_calls,
+      agentTotalTokens:
+        artifact.usage.input_tokens +
+        artifact.usage.output_tokens +
+        artifact.usage.cache_read_tokens +
+        artifact.usage.cache_write_tokens,
+      toolCallCount: artifact.toolCallCount,
+      evidenceStepCount: artifact.stepObservations?.filter(Boolean).length ?? 0,
+      verifierGraded: !result.verifierError,
+      benchmarkSuccess: result._success,
+      outcomeSuccess: result.outcomeSuccess,
+      processScore: result.processScore,
+      criterionCount: result.criterionCount,
+      evidenceInsufficientCount: Array.isArray(result.evidenceInsufficient)
+        ? result.evidenceInsufficient.length
+        : undefined,
+      trajectoryDir: result.trajectoryDir,
+      verifierError: result.verifierError,
+      combinedUsage: rawMetrics?.combined,
+    };
+    console.log(JSON.stringify(summary, null, 2));
+
+    if (result.verifierError) {
+      process.exitCode = 1;
+      return;
+    }
+    if (typeof result.outcomeSuccess !== "boolean" || typeof result.processScore !== "number") {
+      throw new Error("Verifier returned neither a boolean outcome nor a numeric process score.");
+    }
+    if (resultJson) {
+      const verifierResult = {
+        schema_version: 1,
+        task_id: taskId,
+        surface,
+        verifier_model: verifierModel,
+        outcome: result.outcomeSuccess,
+        process_score: result.processScore,
+        criterion_count: result.criterionCount,
+        evidence_insufficient_count: summary.evidenceInsufficientCount,
+        trajectory_dir: result.trajectoryDir,
+      };
+      fs.mkdirSync(path.dirname(resultJson), { recursive: true });
+      const temporary = `${resultJson}.tmp-${process.pid}`;
+      fs.writeFileSync(temporary, `${JSON.stringify(verifierResult, null, 2)}\n`, "utf8");
+      fs.renameSync(temporary, resultJson);
+    }
+  } finally {
+    // Best-effort cleanup only. Some provider clients retain an idle handle
+    // while closing; the durable JSON/trajectory writes above are the hook's
+    // commit point and the explicit process exit below bounds this CLI.
+    void carrier.close().catch(() => {});
+  }
+}
+
+main().then(
+  () => {
+    // V3Evaluator's HTTP clients can retain idle connection handles after the
+    // result and trajectory have been durably written. This script is also the
+    // native benchmark's bounded post-run hook, so leaving those handles alive
+    // would turn a successful grade into a 15-minute hook timeout.
+    process.exit(process.exitCode ?? 0);
+  },
+  (error) => {
+    console.error(error instanceof Error ? (error.stack ?? error.message) : String(error));
+    process.exit(1);
+  },
+);

--- a/packages/evals/scripts/run-hermes-public-hard.ts
+++ b/packages/evals/scripts/run-hermes-public-hard.ts
@@ -1,0 +1,532 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+
+import { V3, type AvailableModel, type TaskSpec } from "stagehand-v3";
+
+import { EvalLogger } from "../logger.js";
+import { getPackageRootDir } from "../runtimePaths.js";
+import {
+  runHermesAgent,
+  validateHermesBenchmarkRoot,
+  type HermesBrowserSurface,
+} from "../framework/hermesRunner.js";
+import {
+  hermesPilotVerifierSucceeded,
+  resolveEffectiveHermesPilotRecord,
+  summarizeHermesPilotRecords,
+  type HermesPilotRecordContext,
+} from "../framework/hermesPilotReporting.js";
+
+type Arm = "A" | "B" | "D";
+type Phase = "canary" | "full";
+
+interface DatasetRow {
+  task_id: string;
+  confirmed_task: string;
+  website: string;
+}
+
+interface PlanRow {
+  task_id: string;
+  model: string;
+  arm_order: Arm[];
+}
+
+interface PilotManifest {
+  id: string;
+  dataset: string;
+  dataset_file: string;
+  dataset_file_sha256: string;
+  task_ids: string[];
+  verifier_model: string;
+  success_mode: "both";
+  timeout_seconds: number;
+  run_plan: PlanRow[];
+  canary_plan: PlanRow;
+}
+
+interface RunRow extends PlanRow {
+  block: number;
+  arm: Arm;
+  run: number;
+}
+
+const SURFACES: Record<Arm, HermesBrowserSurface> = {
+  A: "hermes_browser_legacy",
+  B: "hermes_browser_exec",
+  D: "hermes_stagehand_batch",
+};
+
+function requiredArg(name: string): string {
+  const index = process.argv.indexOf(name);
+  const value = index >= 0 ? process.argv[index + 1]?.trim() : undefined;
+  if (!value || value.startsWith("--")) throw new Error(`Missing required argument ${name}`);
+  return value;
+}
+
+function optionalArg(name: string): string | undefined {
+  const index = process.argv.indexOf(name);
+  const value = index >= 0 ? process.argv[index + 1]?.trim() : undefined;
+  return value && !value.startsWith("--") ? value : undefined;
+}
+
+function positiveIntArg(name: string, fallback: number): number {
+  const value = optionalArg(name);
+  if (!value) return fallback;
+  if (!/^\d+$/.test(value) || Number(value) < 1) throw new Error(`${name} must be positive`);
+  return Number(value);
+}
+
+function sha256(value: Uint8Array | string): string {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+function safe(value: string): string {
+  return value.replace(/[^A-Za-z0-9._-]+/g, "_").replace(/^[._]+|[._]+$/g, "") || "run";
+}
+
+async function writeJsonAtomic(file: string, value: unknown): Promise<void> {
+  await fsp.mkdir(path.dirname(file), { recursive: true });
+  const temporary = `${file}.tmp-${process.pid}`;
+  await fsp.writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+  await fsp.rename(temporary, file);
+}
+
+function readManifest(): { manifest: PilotManifest; bytes: Buffer; packageRoot: string } {
+  const packageRoot = getPackageRootDir();
+  const manifestPath = path.join(packageRoot, "pilots", "hermes-online-mind2web-hard-v1.json");
+  const bytes = fs.readFileSync(manifestPath);
+  const manifest = JSON.parse(bytes.toString("utf8")) as PilotManifest;
+  if (
+    manifest.run_plan.length !== 10 ||
+    manifest.task_ids.length !== 10 ||
+    manifest.run_plan.flatMap((row) => row.arm_order).length !== 30
+  ) {
+    throw new Error("Frozen Hermes public-hard manifest has an invalid schedule");
+  }
+  return { manifest, bytes, packageRoot };
+}
+
+function readDataset(packageRoot: string, manifest: PilotManifest): Map<string, DatasetRow> {
+  const datasetPath = path.join(packageRoot, manifest.dataset_file);
+  const bytes = fs.readFileSync(datasetPath);
+  const observed = sha256(bytes);
+  if (observed !== manifest.dataset_file_sha256) {
+    throw new Error(
+      `Online-Mind2Web source drifted: expected ${manifest.dataset_file_sha256}, observed ${observed}`,
+    );
+  }
+  const rows = bytes
+    .toString("utf8")
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as DatasetRow);
+  const selected = new Map(rows.map((row) => [row.task_id, row]));
+  for (const taskId of manifest.task_ids) {
+    if (!selected.has(taskId)) throw new Error(`Frozen task is absent from the source: ${taskId}`);
+  }
+  return selected;
+}
+
+function schedule(manifest: PilotManifest, phase: Phase): RunRow[] {
+  const blocks = phase === "canary" ? [manifest.canary_plan] : manifest.run_plan;
+  let run = 0;
+  return blocks.flatMap((block, index) =>
+    block.arm_order.map((arm) => ({ ...block, block: index + 1, arm, run: ++run })),
+  );
+}
+
+function runDirectory(outputRoot: string, row: RunRow, phase: Phase): string {
+  return path.join(
+    outputRoot,
+    `${phase}-block-${String(row.block).padStart(2, "0")}-${safe(row.model)}-${row.task_id}`,
+    row.arm,
+  );
+}
+
+function readRecord(file: string): Record<string, unknown> {
+  const value = JSON.parse(fs.readFileSync(file, "utf8")) as unknown;
+  if (!value || typeof value !== "object") throw new Error(`Malformed record: ${file}`);
+  return value as Record<string, unknown>;
+}
+
+function validateRecordIdentity(
+  record: Record<string, unknown>,
+  row: RunRow,
+  phase: Phase,
+  manifestSha256: string,
+): void {
+  const expected = {
+    suite_id: "hermes-online-mind2web-hard-v1",
+    manifest_sha256: manifestSha256,
+    phase,
+    task_id: row.task_id,
+    model_id: row.model,
+    arm: row.arm,
+  };
+  for (const [key, value] of Object.entries(expected)) {
+    if (record[key] !== value) throw new Error(`Resumed record identity mismatch at ${key}`);
+  }
+}
+
+function canaryGate(root: string, manifest: PilotManifest, manifestSha256: string): void {
+  for (const row of schedule(manifest, "canary")) {
+    const recordPath = path.join(runDirectory(root, row, "canary"), "record.json");
+    if (!fs.existsSync(recordPath)) throw new Error(`Canary record is missing for arm ${row.arm}`);
+    const record = readRecord(recordPath);
+    validateRecordIdentity(record, row, "canary", manifestSha256);
+    const effective = resolveEffectiveHermesPilotRecord(
+      reportingContext(record, path.dirname(recordPath), row, manifest),
+    ).record;
+    if (effective.verifier_graded !== true || effective.status === "error") {
+      throw new Error(`Canary did not produce a valid graded trajectory for arm ${row.arm}`);
+    }
+  }
+}
+
+function reportingContext(
+  record: Record<string, unknown>,
+  runDir: string,
+  row: RunRow,
+  manifest: PilotManifest,
+): HermesPilotRecordContext {
+  return {
+    record,
+    runDir,
+    identity: {
+      taskId: row.task_id,
+      surface: SURFACES[row.arm],
+      verifierModel: manifest.verifier_model,
+    },
+    successMode: manifest.success_mode,
+  };
+}
+
+async function verifyGatewayModels(manifest: PilotManifest): Promise<void> {
+  let response: Response;
+  try {
+    response = await fetch("https://ai-gateway.vercel.sh/v1/models", {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch (cause) {
+    throw new Error(
+      `Vercel AI Gateway catalog verification failed: ${
+        cause instanceof Error ? cause.message : String(cause)
+      }`,
+    );
+  }
+  if (!response.ok) throw new Error(`Vercel AI Gateway catalog returned HTTP ${response.status}`);
+  const payload = asRecord((await response.json()) as unknown);
+  const items = Array.isArray(payload?.data) ? payload.data : [];
+  const byId = new Map(
+    items
+      .map((item) => asRecord(item))
+      .filter((item): item is Record<string, unknown> => Boolean(item))
+      .map((item) => [String(item.id), item]),
+  );
+  for (const model of new Set(manifest.run_plan.map((row) => row.model))) {
+    const item = byId.get(model);
+    const tags = item?.tags;
+    const pricing = asRecord(item?.pricing);
+    if (
+      item?.type !== "language" ||
+      !Array.isArray(tags) ||
+      !tags.includes("tool-use") ||
+      number(pricing?.input) <= 0 ||
+      number(pricing?.output) <= 0
+    ) {
+      throw new Error(`Vercel AI Gateway model contract is unavailable or invalid: ${model}`);
+    }
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
+}
+
+function number(value: unknown): number {
+  const parsed = typeof value === "number" ? value : typeof value === "string" ? Number(value) : 0;
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+async function executeRow(input: {
+  row: RunRow;
+  phase: Phase;
+  runDir: string;
+  task: DatasetRow;
+  manifest: PilotManifest;
+  manifestSha256: string;
+}): Promise<Record<string, unknown>> {
+  const { row, phase, runDir, task, manifest, manifestSha256 } = input;
+  const artifactRoot = path.join(runDir, "artifacts");
+  process.env.EVAL_HERMES_ARTIFACT_ROOT = artifactRoot;
+  process.env.EVAL_VERIFIER_MODEL = manifest.verifier_model;
+  process.env.EVAL_SUCCESS_MODE = manifest.success_mode;
+  process.env.EVAL_MAX_UNVERIFIABLE_CRITERIA = "0";
+  process.env.EVAL_HERMES_TIMEOUT_MS = String(manifest.timeout_seconds * 1_000);
+
+  const logger = new EvalLogger(true);
+  const carrier = new V3({
+    env: "LOCAL",
+    logger: logger.log.bind(logger),
+    disablePino: true,
+    disableAPI: true,
+    experimental: true,
+    verbose: 0,
+  });
+  logger.init(carrier);
+  const taskSpec: TaskSpec = {
+    id: task.task_id,
+    instruction: task.confirmed_task,
+    initUrl: task.website,
+  };
+  const startedAt = Date.now();
+  try {
+    const result = await runHermesAgent({
+      plan: {
+        dataset: "onlineMind2Web",
+        taskId: task.task_id,
+        startUrl: task.website,
+        instruction: task.confirmed_task,
+      },
+      taskSpec,
+      model: row.model as AvailableModel,
+      surface: SURFACES[row.arm],
+      environment: "BROWSERBASE",
+      logger,
+      verifier: {
+        v3: carrier,
+        taskSpec,
+        dataset: "onlineMind2Web",
+        successMode: "both",
+        trajectoryRoot: path.join(runDir, "stagehand-verifier"),
+        runId: `${phase}-${String(row.block).padStart(2, "0")}-${row.arm}`,
+      },
+    });
+    const metrics = asRecord(result.rawMetrics);
+    const outer = asRecord(metrics?.outer);
+    const combined = asRecord(metrics?.combined);
+    const outcomeSuccess = result.outcomeSuccess;
+    const processScore = result.processScore;
+    const evidenceInsufficientCount = Array.isArray(result.evidenceInsufficient)
+      ? result.evidenceInsufficient.length
+      : undefined;
+    const verifierGraded =
+      !result.verifierError &&
+      typeof result.criterionCount === "number" &&
+      result.criterionCount > 0 &&
+      typeof outcomeSuccess === "boolean" &&
+      typeof processScore === "number" &&
+      typeof evidenceInsufficientCount === "number";
+    const benchmarkSuccess =
+      verifierGraded &&
+      typeof outcomeSuccess === "boolean" &&
+      typeof processScore === "number" &&
+      typeof evidenceInsufficientCount === "number" &&
+      hermesPilotVerifierSucceeded(
+        {
+          outcome: outcomeSuccess,
+          process_score: processScore,
+          evidence_insufficient_count: evidenceInsufficientCount,
+        },
+        "both",
+      );
+    const record: Record<string, unknown> = {
+      schema_version: 1,
+      suite_id: "hermes-online-mind2web-hard-v1",
+      manifest_sha256: manifestSha256,
+      phase,
+      block: row.block,
+      run: row.run,
+      task_id: row.task_id,
+      model_id: row.model,
+      arm: row.arm,
+      arm_order: row.arm_order,
+      surface: SURFACES[row.arm],
+      status: verifierGraded ? (benchmarkSuccess ? "verified_passed" : "verified_failed") : "error",
+      accuracy: verifierGraded ? benchmarkSuccess : null,
+      verifier_graded: verifierGraded,
+      outcome: result.outcomeSuccess ?? null,
+      process_score: result.processScore ?? null,
+      criterion_count: result.criterionCount ?? null,
+      evidence_insufficient_count: evidenceInsufficientCount ?? null,
+      verifier_error: result.verifierError ?? null,
+      trajectory_dir: result.trajectoryDir ?? null,
+      artifact_dir: result.hermesArtifactDir ?? null,
+      final_answer: result.finalAnswer ?? null,
+      final_answer_sha256:
+        typeof result.finalAnswer === "string" ? sha256(result.finalAnswer) : null,
+      tool_calls: number(result.toolCallCount),
+      usage: {
+        input_tokens: number(combined?.input_tokens),
+        output_tokens: number(combined?.output_tokens),
+        cache_read_tokens: number(combined?.cache_read_tokens),
+        cache_write_tokens: number(combined?.cache_write_tokens),
+        reasoning_tokens: number(combined?.reasoning_tokens),
+        api_calls: number(combined?.api_calls),
+      },
+      cost_usd: number(outer?.estimated_cost_usd),
+      timing: {
+        total_wall_ms: Date.now() - startedAt,
+        agent_wall_ms: number(metrics?.agent_wall_ms),
+        browser_wall_ms: number(metrics?.browser_wall_ms),
+        session_setup_ms: number(metrics?.session_setup_ms),
+        verifier_wall_ms: number(metrics?.verifier_wall_ms),
+      },
+      created_at: new Date().toISOString(),
+    };
+    await writeJsonAtomic(path.join(runDir, "record.json"), record);
+    return record;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const record: Record<string, unknown> = {
+      schema_version: 1,
+      suite_id: "hermes-online-mind2web-hard-v1",
+      manifest_sha256: manifestSha256,
+      phase,
+      block: row.block,
+      run: row.run,
+      task_id: row.task_id,
+      model_id: row.model,
+      arm: row.arm,
+      arm_order: row.arm_order,
+      surface: SURFACES[row.arm],
+      status: "error",
+      accuracy: null,
+      verifier_graded: false,
+      error: message,
+      created_at: new Date().toISOString(),
+    };
+    await writeJsonAtomic(path.join(runDir, "record.json"), record);
+    return record;
+  } finally {
+    await carrier.close().catch(() => {});
+  }
+}
+
+async function main(): Promise<void> {
+  const phase = requiredArg("--phase") as Phase;
+  if (phase !== "canary" && phase !== "full") throw new Error("--phase must be canary or full");
+  const dryRun = process.argv.includes("--dry-run");
+  const confirmBillable = process.argv.includes("--confirm-billable");
+  if (dryRun === confirmBillable) {
+    throw new Error("Choose exactly one of --dry-run or --confirm-billable");
+  }
+  const outputRoot = path.resolve(optionalArg("--output") ?? "/tmp/stagehand-evals-public-hard");
+  const firstBlock = positiveIntArg("--first-block", 1);
+  const lastBlock = positiveIntArg("--last-block", 10);
+  const canaryRootArg = optionalArg("--canary-root");
+  const { manifest, bytes: manifestBytes, packageRoot } = readManifest();
+  const manifestSha256 = sha256(manifestBytes);
+  const dataset = readDataset(packageRoot, manifest);
+  const hermesRoot = path.resolve(
+    process.env.EVAL_HERMES_ROOT?.trim() ||
+      path.join(packageRoot, "..", "..", "..", "hermes-stagehand-batch"),
+  );
+  validateHermesBenchmarkRoot(hermesRoot);
+  const rows = schedule(manifest, phase).filter(
+    (row) => phase === "canary" || (row.block >= firstBlock && row.block <= lastBlock),
+  );
+  if (rows.length === 0) throw new Error("Selected block range is empty");
+
+  if (dryRun) {
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          ok: true,
+          dry_run: true,
+          phase,
+          suite_id: manifest.id,
+          manifest_sha256: manifestSha256,
+          dataset_sha256: manifest.dataset_file_sha256,
+          rows,
+          model_calls: 0,
+          browser_sessions: 0,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    return;
+  }
+  if (!process.env.EVAL_RUBRIC_CACHE_ROOT?.trim()) {
+    throw new Error("EVAL_RUBRIC_CACHE_ROOT must identify one durable shared cache");
+  }
+  if (!process.env.AI_GATEWAY_API_KEY?.trim()) {
+    throw new Error("AI_GATEWAY_API_KEY is required for billable runs");
+  }
+  if (!process.env.BROWSERBASE_API_KEY?.trim()) {
+    throw new Error("BROWSERBASE_API_KEY is required for billable runs");
+  }
+  await verifyGatewayModels(manifest);
+  if (phase === "full") {
+    if (!canaryRootArg) throw new Error("Full phase requires --canary-root");
+    canaryGate(path.resolve(canaryRootArg), manifest, manifestSha256);
+  }
+  await fsp.mkdir(outputRoot, { recursive: true });
+  const outputManifest = path.join(outputRoot, "manifest.json");
+  if (fs.existsSync(outputManifest)) {
+    if (sha256(fs.readFileSync(outputManifest)) !== manifestSha256) {
+      throw new Error("Output root belongs to a different manifest");
+    }
+  } else {
+    await fsp.writeFile(outputManifest, manifestBytes);
+  }
+
+  const records: Array<Record<string, unknown>> = [];
+  const completedRows: RunRow[] = [];
+  for (const row of rows) {
+    const runDir = runDirectory(outputRoot, row, phase);
+    const recordPath = path.join(runDir, "record.json");
+    if (fs.existsSync(recordPath)) {
+      const record = readRecord(recordPath);
+      validateRecordIdentity(record, row, phase, manifestSha256);
+      records.push(record);
+      completedRows.push(row);
+      continue;
+    }
+    if (fs.existsSync(runDir) && fs.readdirSync(runDir).length > 0) {
+      throw new Error(`Partial run directory requires audit before resume: ${runDir}`);
+    }
+    await fsp.mkdir(runDir, { recursive: true });
+    const task = dataset.get(row.task_id);
+    if (!task) throw new Error(`Task disappeared from dataset: ${row.task_id}`);
+    records.push(await executeRow({ row, phase, runDir, task, manifest, manifestSha256 }));
+    completedRows.push(row);
+    await writeJsonAtomic(
+      path.join(outputRoot, "summary.json"),
+      summarize(records, completedRows, outputRoot, phase, manifest),
+    );
+  }
+  if (phase === "canary") canaryGate(outputRoot, manifest, manifestSha256);
+  const summary = summarize(records, completedRows, outputRoot, phase, manifest);
+  await writeJsonAtomic(path.join(outputRoot, "summary.json"), summary);
+  process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+}
+
+function summarize(
+  records: Array<Record<string, unknown>>,
+  rows: RunRow[],
+  outputRoot: string,
+  phase: Phase,
+  manifest: PilotManifest,
+): Record<string, unknown> {
+  const contexts = records.map((record, index) => {
+    const row = rows[index];
+    if (!row) throw new Error("Benchmark summary row alignment failed");
+    return reportingContext(record, runDirectory(outputRoot, row, phase), row, manifest);
+  });
+  return summarizeHermesPilotRecords(contexts, phase);
+}
+
+main().catch((error) => {
+  process.stderr.write(
+    `Stagehand evals public-hard benchmark failed closed: ${
+      error instanceof Error ? error.message : String(error)
+    }\n`,
+  );
+  process.exitCode = 4;
+});

--- a/packages/evals/tests/framework/benchHarness.test.ts
+++ b/packages/evals/tests/framework/benchHarness.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { claudeCodeHarness, codexHarness, getBenchHarness } from "../../framework/benchHarness.js";
+import {
+  claudeCodeHarness,
+  codexHarness,
+  getBenchHarness,
+  hermesHarness,
+} from "../../framework/benchHarness.js";
 
 describe("bench harness registry", () => {
   it("registers claude_code as a concrete executable harness", () => {
@@ -15,6 +20,15 @@ describe("bench harness registry", () => {
     const harness = getBenchHarness("codex");
 
     expect(harness).toBe(codexHarness);
+    expect(harness.supportedTaskKinds).toEqual(["agent", "suite"]);
+    expect(harness.supportsApi).toBe(false);
+    expect(harness.execute).toBeDefined();
+  });
+
+  it("registers hermes as a concrete executable harness", () => {
+    const harness = getBenchHarness("hermes");
+
+    expect(harness).toBe(hermesHarness);
     expect(harness.supportedTaskKinds).toEqual(["agent", "suite"]);
     expect(harness.supportsApi).toBe(false);
     expect(harness.execute).toBeDefined();

--- a/packages/evals/tests/framework/benchPlanner.test.ts
+++ b/packages/evals/tests/framework/benchPlanner.test.ts
@@ -134,6 +134,54 @@ describe("benchPlanner", () => {
     expect(testcases[0].metadata.agentMode).toBeUndefined();
   });
 
+  it("plans Hermes browser_exec against an unchanged OnlineMind2Web row", async () => {
+    const testcases = await withEnvOverrides(
+      {
+        EVAL_MAX_K: "1",
+        EVAL_ONLINEMIND2WEB_LIMIT: "1",
+      },
+      async () =>
+        generateBenchTestcases([makeSuiteTask("agent/onlineMind2Web")], {
+          modelOverride: "anthropic/claude-opus-4.8",
+          datasetFilter: "onlineMind2Web",
+          harness: "hermes",
+          environment: "BROWSERBASE",
+          coreToolSurface: "hermes_browser_exec",
+        }),
+    );
+
+    expect(testcases).toHaveLength(1);
+    expect(testcases[0].input.name).toBe("agent/onlineMind2Web");
+    expect(testcases[0].input.params?.confirmed_task).toBeTruthy();
+    expect(testcases[0].metadata).toMatchObject({
+      dataset: "onlineMind2Web",
+      harness: "hermes",
+      toolSurface: "hermes_browser_exec",
+      startupProfile: "tool_create_browserbase",
+      provider: "anthropic",
+    });
+  });
+
+  it("plans Hermes Stagehand batch as a Browserbase-owned one-tool arm", async () => {
+    const testcases = await withEnvOverrides(
+      { EVAL_MAX_K: "1", EVAL_ONLINEMIND2WEB_LIMIT: "1" },
+      async () =>
+        generateBenchTestcases([makeSuiteTask("agent/onlineMind2Web")], {
+          modelOverride: "anthropic/claude-opus-4.8",
+          datasetFilter: "onlineMind2Web",
+          harness: "hermes",
+          environment: "BROWSERBASE",
+          coreToolSurface: "hermes_stagehand_batch",
+        }),
+    );
+
+    expect(testcases[0].metadata).toMatchObject({
+      harness: "hermes",
+      toolSurface: "hermes_stagehand_batch",
+      startupProfile: "tool_create_browserbase",
+    });
+  });
+
   it("rejects unsupported Claude Code tasks from broad targets", async () => {
     const generate = () =>
       withEnvOverrides(

--- a/packages/evals/tests/framework/hermesPilot.test.ts
+++ b/packages/evals/tests/framework/hermesPilot.test.ts
@@ -1,0 +1,257 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  hermesPilotVerifierSucceeded,
+  readValidVerifierSidecar,
+  resolveEffectiveHermesPilotRecord,
+  summarizeHermesPilotRecords,
+  type HermesPilotRecordContext,
+} from "../../framework/hermesPilotReporting.js";
+import { getPackageRootDir } from "../../runtimePaths.js";
+
+interface Mind2WebRow {
+  task_id: string;
+  level: string;
+  website: string;
+}
+
+describe("Hermes OnlineMind2Web hard pilot", () => {
+  it("requires zero evidence-insufficient criteria for a benchmark pass", () => {
+    expect(
+      hermesPilotVerifierSucceeded(
+        { outcome: true, process_score: 1, evidence_insufficient_count: 0 },
+        "both",
+      ),
+    ).toBe(true);
+    expect(
+      hermesPilotVerifierSucceeded(
+        { outcome: true, process_score: 1, evidence_insufficient_count: 1 },
+        "both",
+      ),
+    ).toBe(false);
+  });
+
+  it("freezes ten curated hard tasks across unique hosts and a balanced model split", () => {
+    const packageRoot = getPackageRootDir();
+    const manifest = JSON.parse(
+      fs.readFileSync(
+        path.join(packageRoot, "pilots", "hermes-online-mind2web-hard-v1.json"),
+        "utf8",
+      ),
+    ) as {
+      selection: { count: number };
+      task_ids: string[];
+      arms: Array<{ tool: string }>;
+      task_model_pairs: Array<{ task_id: string; model: string }>;
+      verifier_model: string;
+      verifier_selection: {
+        methodology_target: string;
+        methodology_target_status: string;
+        selected_fallback: string;
+      };
+      rubric_policy: string;
+      success_mode: string;
+      timeout_seconds: number;
+      dataset_file_sha256: string;
+      run_plan: Array<{ task_id: string; model: string; arm_order: string[] }>;
+      canary_plan: { task_id: string; model: string; arm_order: string[] };
+    };
+    const rows = fs
+      .readFileSync(
+        path.join(packageRoot, "datasets", "onlineMind2Web", "onlineMind2Web.jsonl"),
+        "utf8",
+      )
+      .trim()
+      .split(/\r?\n/)
+      .map((line) => JSON.parse(line) as Mind2WebRow);
+    const byId = new Map(rows.map((row) => [row.task_id, row]));
+    const selected = manifest.task_ids
+      .map((id) => byId.get(id))
+      .filter((row): row is Mind2WebRow => Boolean(row));
+
+    expect(manifest.task_ids).toHaveLength(10);
+    expect(selected.map((row) => row.task_id)).toEqual(manifest.task_ids);
+    expect(new Set(selected.map((row) => new URL(row.website).hostname)).size).toBe(10);
+    expect(selected.every((row) => row.level === "hard")).toBe(true);
+    expect(manifest.arms.map((arm) => arm.tool)).toEqual([
+      "hermes_browser_legacy",
+      "hermes_browser_exec",
+      "hermes_stagehand_batch",
+    ]);
+    expect(manifest.task_model_pairs.map((pair) => pair.task_id)).toEqual(manifest.task_ids);
+    expect(manifest.task_model_pairs.filter((pair) => pair.model.includes("opus"))).toHaveLength(5);
+    expect(manifest.task_model_pairs.filter((pair) => pair.model.includes("kimi"))).toHaveLength(5);
+    expect(manifest.verifier_model).toBe("gateway/google/gemini-2.5-flash");
+    expect(manifest.verifier_selection).toMatchObject({
+      methodology_target: "gateway/openai/o4-mini",
+      methodology_target_status: "unavailable_through_vercel_ai_gateway",
+      selected_fallback: "gateway/google/gemini-2.5-flash",
+    });
+    expect(manifest.rubric_policy).toContain("reuse byte-identical cached rubric");
+    expect(manifest.success_mode).toBe("both");
+    expect(manifest.timeout_seconds).toBe(1800);
+    expect(manifest.dataset_file_sha256).toBe(
+      "d10a837d6ea67349dca8541cd697eb2636ff61b937ba0f09596f775e1b327b30",
+    );
+    expect(manifest.run_plan).toHaveLength(10);
+    expect(manifest.run_plan.map((row) => row.task_id)).toEqual(manifest.task_ids);
+    expect(manifest.run_plan.flatMap((row) => row.arm_order)).toHaveLength(30);
+    expect(manifest.run_plan.map((row) => row.arm_order.join(""))).toEqual([
+      "ABD",
+      "BDA",
+      "DAB",
+      "ABD",
+      "BDA",
+      "DAB",
+      "ABD",
+      "BDA",
+      "DAB",
+      "ABD",
+    ]);
+    expect(manifest.canary_plan.arm_order).toEqual(["A", "B", "D"]);
+
+    const instructions = fs.readFileSync(path.join(packageRoot, "HERMES_PILOT.md"), "utf8");
+    expect(instructions).not.toContain(" eval -- run ");
+    expect(
+      instructions.match(/pnpm --filter @browserbasehq\/stagehand-evals eval run/g),
+    ).toHaveLength(1);
+    expect(
+      instructions.match(
+        /pnpm --filter @browserbasehq\/stagehand-evals benchmark:hermes-public-hard/g,
+      ),
+    ).toHaveLength(4);
+  });
+
+  it("reports a valid verifier sidecar as the effective result without mutating provenance", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "hermes-pilot-reporting-"));
+    try {
+      const trajectoryDir = path.join(root, "trajectory");
+      fs.mkdirSync(trajectoryDir);
+      const rawRecord: Record<string, unknown> = {
+        status: "error",
+        accuracy: null,
+        verifier_graded: false,
+        cost_usd: 0.42,
+      };
+      fs.writeFileSync(
+        path.join(root, "verifier-result.json"),
+        `${JSON.stringify({
+          schema_version: 1,
+          task_id: "task-1",
+          surface: "hermes_stagehand_batch",
+          verifier_model: "gateway/google/gemini-2.5-flash",
+          outcome: true,
+          process_score: 1,
+          criterion_count: 4,
+          evidence_insufficient_count: 0,
+          trajectory_dir: trajectoryDir,
+        })}\n`,
+      );
+      const context: HermesPilotRecordContext = {
+        record: rawRecord,
+        runDir: root,
+        identity: {
+          taskId: "task-1",
+          surface: "hermes_stagehand_batch",
+          verifierModel: "gateway/google/gemini-2.5-flash",
+        },
+        successMode: "both",
+      };
+
+      expect(readValidVerifierSidecar(context)).toMatchObject({ outcome: true, process_score: 1 });
+      expect(resolveEffectiveHermesPilotRecord(context)).toMatchObject({
+        regraded: true,
+        record: {
+          status: "verified_passed",
+          accuracy: true,
+          verifier_graded: true,
+          outcome: true,
+          process_score: 1,
+        },
+      });
+      expect(rawRecord).toEqual({
+        status: "error",
+        accuracy: null,
+        verifier_graded: false,
+        cost_usd: 0.42,
+      });
+      expect(summarizeHermesPilotRecords([context], "canary")).toEqual({
+        phase: "canary",
+        records: 1,
+        effective_statuses: { verified_passed: 1 },
+        effective_accuracy: { graded: 1, passed: 1, failed: 0, ungraded: 0, rate: 1 },
+        raw_statuses: { error: 1 },
+        regraded_records: 1,
+        total_cost_usd: 0.42,
+      });
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when a verifier sidecar has the wrong identity or incomplete fields", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "hermes-pilot-reporting-"));
+    try {
+      const trajectoryDir = path.join(root, "trajectory");
+      fs.mkdirSync(trajectoryDir);
+      const context: HermesPilotRecordContext = {
+        record: { status: "error" },
+        runDir: root,
+        identity: {
+          taskId: "task-1",
+          surface: "hermes_browser_exec",
+          verifierModel: "gateway/google/gemini-2.5-flash",
+        },
+        successMode: "both",
+      };
+      const sidecar = {
+        schema_version: 1,
+        task_id: "task-1",
+        surface: "hermes_stagehand_batch",
+        verifier_model: "gateway/google/gemini-2.5-flash",
+        outcome: true,
+        process_score: 1,
+        criterion_count: 4,
+        evidence_insufficient_count: 0,
+        trajectory_dir: trajectoryDir,
+      };
+      fs.writeFileSync(path.join(root, "verifier-result.json"), JSON.stringify(sidecar));
+      expect(() => readValidVerifierSidecar(context)).toThrow(
+        "Verifier regrade identity mismatch at surface",
+      );
+
+      fs.writeFileSync(
+        path.join(root, "verifier-result.json"),
+        JSON.stringify({ ...sidecar, surface: "hermes_browser_exec", criterion_count: null }),
+      );
+      expect(() => summarizeHermesPilotRecords([context], "canary")).toThrow(
+        "Verifier regrade is incomplete",
+      );
+
+      fs.writeFileSync(
+        path.join(root, "verifier-result.json"),
+        JSON.stringify({ ...sidecar, surface: "hermes_browser_exec", criterion_count: 0 }),
+      );
+      expect(() => summarizeHermesPilotRecords([context], "canary")).toThrow(
+        "Verifier regrade is incomplete",
+      );
+
+      fs.writeFileSync(
+        path.join(root, "verifier-result.json"),
+        JSON.stringify({
+          ...sidecar,
+          surface: "hermes_browser_exec",
+          evidence_insufficient_count: 1,
+        }),
+      );
+      expect(resolveEffectiveHermesPilotRecord(context)).toMatchObject({
+        regraded: true,
+        record: { status: "verified_failed", accuracy: false },
+      });
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/evals/tests/framework/hermesRunner.test.ts
+++ b/packages/evals/tests/framework/hermesRunner.test.ts
@@ -192,10 +192,26 @@ describe("Hermes runner", () => {
     };
 
     expect(() => validateHermesArtifact(artifact)).not.toThrow();
-    expect(() => validateHermesArtifact({ ...artifact, stepObservations: [] })).toThrow(
-      /independently captured/,
+    expect(() =>
+      validateHermesArtifact({
+        ...artifact,
+        surface: "hermes_stagehand_batch",
+        toolSchema: { bytes: 10_461, names: ["browser_exec"] },
+      }),
+    ).not.toThrow();
+    expect(() =>
+      validateHermesArtifact({
+        ...artifact,
+        surface: "hermes_stagehand_batch",
+        toolSchema: { bytes: 1_794, names: ["browser_exec"] },
+      }),
+    ).toThrow(/schema drifted/);
+    expect(() =>
+      validateHermesArtifact({ ...artifact, stepObservations: [] }),
+    ).toThrow(/independently captured/);
+    expect(() => validateHermesArtifact({ ...artifact, toolCallCount: 2 })).toThrow(
+      /disagrees/,
     );
-    expect(() => validateHermesArtifact({ ...artifact, toolCallCount: 2 })).toThrow(/disagrees/);
     expect(() =>
       validateHermesArtifact({
         ...artifact,

--- a/packages/evals/tests/framework/hermesRunner.test.ts
+++ b/packages/evals/tests/framework/hermesRunner.test.ts
@@ -30,10 +30,16 @@ describe("Hermes runner", () => {
     expect(resolveHermesToolSurface()).toBe("hermes_browser_exec");
     expect(resolveHermesToolSurface("hermes_browser_legacy")).toBe("hermes_browser_legacy");
     expect(resolveHermesToolSurface("hermes_stagehand_batch")).toBe("hermes_stagehand_batch");
+    expect(resolveHermesToolSurface("hermes_stagehand_facade")).toBe(
+      "hermes_stagehand_facade",
+    );
     expect(resolveHermesStartupProfile("hermes_browser_exec", "BROWSERBASE")).toBe(
       "tool_create_browserbase",
     );
     expect(() => resolveHermesStartupProfile("hermes_stagehand_batch", "LOCAL")).toThrow(
+      /requires --env browserbase/,
+    );
+    expect(() => resolveHermesStartupProfile("hermes_stagehand_facade", "LOCAL")).toThrow(
       /requires --env browserbase/,
     );
     expect(() => resolveHermesToolSurface("browse_cli")).toThrow(/Hermes harness supports/);

--- a/packages/evals/tests/framework/hermesRunner.test.ts
+++ b/packages/evals/tests/framework/hermesRunner.test.ts
@@ -1,0 +1,318 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import type { TaskSpec } from "stagehand-v3";
+import {
+  PINNED_HERMES_BASE_COMMIT,
+  PINNED_STAGEHAND_V4_COMMIT,
+  applyHermesSurfaceEnvironment,
+  buildHermesPrompt,
+  hermesArtifactToTrajectory,
+  loadHermesArtifactDirectory,
+  resolveHermesStartupProfile,
+  resolveHermesToolSurface,
+  validateHermesArtifact,
+  validatePinnedStagehandV4Root,
+  type HermesRunArtifact,
+} from "../../framework/hermesRunner.js";
+
+const taskSpec: TaskSpec = {
+  id: "om2w-hard-1",
+  instruction: "Find the assigned record and submit the requested value.",
+  initUrl: "https://example.com/start",
+};
+
+describe("Hermes runner", () => {
+  it("defaults to browser_exec and keeps Hermes browser ownership explicit", () => {
+    expect(resolveHermesToolSurface()).toBe("hermes_browser_exec");
+    expect(resolveHermesToolSurface("hermes_browser_legacy")).toBe("hermes_browser_legacy");
+    expect(resolveHermesToolSurface("hermes_stagehand_batch")).toBe("hermes_stagehand_batch");
+    expect(resolveHermesStartupProfile("hermes_browser_exec", "BROWSERBASE")).toBe(
+      "tool_create_browserbase",
+    );
+    expect(() => resolveHermesStartupProfile("hermes_stagehand_batch", "LOCAL")).toThrow(
+      /requires --env browserbase/,
+    );
+    expect(() => resolveHermesToolSurface("browse_cli")).toThrow(/Hermes harness supports/);
+  });
+
+  it("preserves OnlineMind2Web's assigned-site constraint in the prompt", () => {
+    const prompt = buildHermesPrompt({
+      dataset: "onlineMind2Web",
+      taskId: taskSpec.id,
+      startUrl: taskSpec.initUrl!,
+      instruction: taskSpec.instruction,
+    });
+    expect(prompt).toBe(
+      [
+        "You are running a browser benchmark task.",
+        "",
+        "Dataset: onlineMind2Web",
+        `Task ID: ${taskSpec.id}`,
+        `Start URL: ${taskSpec.initUrl}`,
+        "",
+        "Instruction:",
+        taskSpec.instruction,
+        "",
+        "ALWAYS OPERATE WITHIN THE PAGE OPENED BY THE USER, WHICHEVER TASK YOU ARE ATTEMPTING TO COMPLETE CAN BE ACCOMPLISHED WITHIN THE PAGE.",
+        "Use only the browser tools provided by this Hermes run. Navigate to the Start URL before working on the task.",
+        "Complete the task and put the requested result in your final response.",
+      ].join("\n"),
+    );
+  });
+
+  it("selects the full Browser Use skill for the public browser_exec arm", () => {
+    const env: NodeJS.ProcessEnv = { PATH: "/usr/bin" };
+    applyHermesSurfaceEnvironment(env, "hermes_browser_exec", "/tmp/hermes");
+
+    expect(env.HERMES_BENCHMARK_BROWSER_EXEC_ONLY).toBe("1");
+    expect(env.HERMES_BENCHMARK_BROWSER_USE_DESCRIPTION).toBe("full");
+    expect(env.HERMES_BENCHMARK_STATIC_BROWSER).toBeUndefined();
+    expect(env.PATH).toContain("/tmp/hermes/.browser-use-node/node_modules/.bin");
+    expect(env.PATH).toContain("/tmp/hermes/.browser-use-venv/bin");
+
+    const legacyEnv: NodeJS.ProcessEnv = { PATH: "/usr/bin" };
+    applyHermesSurfaceEnvironment(legacyEnv, "hermes_browser_legacy", "/tmp/hermes");
+    expect(legacyEnv.HERMES_BENCHMARK_STATIC_BROWSER).toBe("1");
+    expect(legacyEnv.PATH).toContain("/tmp/hermes/.browser-use-node/node_modules/.bin");
+  });
+
+  it("accepts only a clean checkout at the pinned Stagehand V4 commit", () => {
+    expect(PINNED_HERMES_BASE_COMMIT).toBe("e65664f512ded961ec7b2fdbeb4a88008f439866");
+    expect(PINNED_STAGEHAND_V4_COMMIT).toBe("4186c7d98d2f325b6fc85b3f760111e6c390d703");
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "stagehand-v4-pin-test-"));
+    try {
+      const sdkRoot = path.join(root, "packages", "sdk-python");
+      fs.mkdirSync(sdkRoot, { recursive: true });
+      fs.writeFileSync(path.join(sdkRoot, "README.md"), "pinned SDK\n", "utf8");
+      execFileSync("git", ["init", "--quiet", root]);
+      execFileSync("git", ["-C", root, "add", "."]);
+      execFileSync("git", [
+        "-C",
+        root,
+        "-c",
+        "user.name=Stagehand Evals",
+        "-c",
+        "user.email=evals@example.invalid",
+        "commit",
+        "--quiet",
+        "-m",
+        "fixture",
+      ]);
+      const head = execFileSync("git", ["-C", root, "rev-parse", "HEAD"], {
+        encoding: "utf8",
+      }).trim();
+
+      expect(validatePinnedStagehandV4Root(root, head)).toBe(root);
+      expect(() =>
+        validatePinnedStagehandV4Root(root, "0000000000000000000000000000000000000000"),
+      ).toThrow(/expected pinned commit/);
+
+      fs.writeFileSync(path.join(sdkRoot, "README.md"), "dirty SDK\n", "utf8");
+      expect(() => validatePinnedStagehandV4Root(root, head)).toThrow(/local changes/);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("converts Hermes state rows into evidence-backed Stagehand trajectory steps", () => {
+    const screenshot = Buffer.from("fake-png");
+    const artifact: HermesRunArtifact = {
+      surface: "hermes_browser_exec",
+      stdout: "record saved",
+      stderr: "",
+      exitCode: 0,
+      usage: {
+        input_tokens: 100,
+        output_tokens: 20,
+        cache_read_tokens: 30,
+        cache_write_tokens: 0,
+        reasoning_tokens: 5,
+        api_calls: 2,
+        session_id: "session-1",
+        completed: true,
+      },
+      toolCallCount: 1,
+      innerUsage: {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_read_tokens: 0,
+        cache_write_tokens: 0,
+        reasoning_tokens: 0,
+        api_calls: 0,
+      },
+      messages: [
+        {
+          id: 1,
+          role: "assistant",
+          content: "I will inspect and submit the assigned record.",
+          tool_call_id: null,
+          tool_calls: JSON.stringify([
+            {
+              id: "call-1",
+              function: {
+                name: "browser_exec",
+                arguments: JSON.stringify({ code: "open(startUrl); submit('value')" }),
+              },
+            },
+          ]),
+          tool_name: null,
+          reasoning: "Use the assigned page.",
+          reasoning_content: null,
+        },
+        {
+          id: 2,
+          role: "tool",
+          content:
+            '<untrusted_tool_result source="browser_exec">\nmetadata\n\n{"success":true,"output":{"saved":true}}\n</untrusted_tool_result>',
+          tool_call_id: "call-1",
+          tool_calls: null,
+          tool_name: "browser_exec",
+          reasoning: null,
+          reasoning_content: null,
+        },
+        {
+          id: 3,
+          role: "assistant",
+          content: "record saved",
+          tool_call_id: null,
+          tool_calls: null,
+          tool_name: null,
+          reasoning: null,
+          reasoning_content: null,
+        },
+      ],
+      stepObservations: [{ screenshot, url: "https://example.com/done" }],
+      toolSchema: { bytes: 10_387, names: ["browser_exec"] },
+      toolMetrics: [{ success: true, duration_ms: 12 }],
+      finalObservation: { screenshot, url: "https://example.com/done" },
+    };
+
+    expect(() => validateHermesArtifact(artifact)).not.toThrow();
+    expect(() => validateHermesArtifact({ ...artifact, stepObservations: [] })).toThrow(
+      /independently captured/,
+    );
+    expect(() => validateHermesArtifact({ ...artifact, toolCallCount: 2 })).toThrow(/disagrees/);
+    expect(() =>
+      validateHermesArtifact({
+        ...artifact,
+        stepObservations: [],
+        toolMetrics: [{ success: false, duration_ms: 12 }],
+      }),
+    ).not.toThrow();
+
+    const trajectory = hermesArtifactToTrajectory(artifact, taskSpec);
+    expect(trajectory.task).toBe(taskSpec);
+    expect(trajectory.status).toBe("complete");
+    expect(trajectory.finalAnswer).toBe("record saved");
+    expect(trajectory.finalObservation?.url).toBe("https://example.com/done");
+    expect(trajectory.steps).toHaveLength(1);
+    expect(trajectory.steps[0].actionName).toBe("browser_exec");
+    expect(trajectory.steps[0].probeEvidence?.url).toBe("https://example.com/done");
+    expect(trajectory.usage).toMatchObject({
+      input_tokens: 100,
+      output_tokens: 20,
+      cached_input_tokens: 30,
+      reasoning_tokens: 5,
+    });
+  });
+
+  it("loads a completed retained artifact without launching Hermes", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "hermes-retained-artifact-test-"));
+    try {
+      const hermesHome = path.join(root, "hermes-home");
+      const evidenceDir = path.join(root, "evidence");
+      const stepsDir = path.join(evidenceDir, "steps");
+      fs.mkdirSync(hermesHome, { recursive: true });
+      fs.mkdirSync(stepsDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(root, "usage.json"),
+        JSON.stringify({
+          input_tokens: 10,
+          output_tokens: 2,
+          cache_read_tokens: 3,
+          cache_write_tokens: 0,
+          reasoning_tokens: 1,
+          api_calls: 2,
+          session_id: "session-1",
+          completed: true,
+          failed: false,
+        }),
+      );
+      fs.writeFileSync(path.join(evidenceDir, "screenshot.png"), "final-shot");
+      fs.writeFileSync(path.join(evidenceDir, "final-url.txt"), "https://example.com/done\n");
+      fs.writeFileSync(path.join(stepsDir, "step-0001.png"), "step-shot");
+      fs.writeFileSync(
+        path.join(stepsDir, "step-0001.json"),
+        JSON.stringify({
+          action_index: 1,
+          screenshot: "step-0001.png",
+          final_url: "https://example.com/done",
+        }),
+      );
+
+      const database = new DatabaseSync(path.join(hermesHome, "state.db"));
+      database.exec(
+        "CREATE TABLE sessions (id TEXT PRIMARY KEY, tool_call_count INTEGER, started_at TEXT);" +
+          "CREATE TABLE messages (id INTEGER PRIMARY KEY, session_id TEXT, role TEXT, content TEXT, tool_call_id TEXT, tool_calls TEXT, tool_name TEXT, reasoning TEXT, reasoning_content TEXT);",
+      );
+      database
+        .prepare("INSERT INTO sessions (id, tool_call_count, started_at) VALUES (?, ?, ?)")
+        .run("session-1", 1, "2026-08-12T00:00:00Z");
+      database
+        .prepare(
+          "INSERT INTO messages (id, session_id, role, content, tool_call_id, tool_calls, tool_name, reasoning, reasoning_content) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run(
+          1,
+          "session-1",
+          "assistant",
+          null,
+          null,
+          JSON.stringify([
+            {
+              id: "call-1",
+              function: { name: "browser_exec", arguments: JSON.stringify({ code: "done()" }) },
+            },
+          ]),
+          null,
+          null,
+          null,
+        );
+      database
+        .prepare(
+          "INSERT INTO messages (id, session_id, role, content, tool_call_id, tool_calls, tool_name, reasoning, reasoning_content) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run(
+          2,
+          "session-1",
+          "tool",
+          '{"success":true}',
+          "call-1",
+          null,
+          "browser_exec",
+          null,
+          null,
+        );
+      database
+        .prepare(
+          "INSERT INTO messages (id, session_id, role, content, tool_call_id, tool_calls, tool_name, reasoning, reasoning_content) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .run(3, "session-1", "assistant", "complete", null, null, null, null, null);
+      database.close();
+
+      const artifact = await loadHermesArtifactDirectory(root, "hermes_stagehand_batch");
+      expect(artifact.exitCode).toBe(0);
+      expect(artifact.toolCallCount).toBe(1);
+      expect(artifact.messages).toHaveLength(3);
+      expect(artifact.finalObservation?.url).toBe("https://example.com/done");
+      expect(artifact.stepObservations?.filter(Boolean)).toHaveLength(1);
+      expect(artifact.artifactDir).toBe(root);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/evals/tests/framework/rubricCache.test.ts
+++ b/packages/evals/tests/framework/rubricCache.test.ts
@@ -28,6 +28,7 @@ describe("RubricCache", () => {
 
   afterEach(async () => {
     warn.mockRestore();
+    delete process.env.EVAL_RUBRIC_CACHE_ROOT;
     await fs.rm(tmpRoot, { recursive: true, force: true });
   });
 
@@ -41,5 +42,16 @@ describe("RubricCache", () => {
     await expect(cache.read(taskB)).resolves.toBeUndefined();
     await expect(cache.read(taskA)).resolves.toEqual(rubric);
     expect(warn).toHaveBeenCalledWith("[rubric-cache] task-id mismatch for task:a; regenerating");
+  });
+
+  it("uses one explicit durable cache root across separate cache instances", async () => {
+    process.env.EVAL_RUBRIC_CACHE_ROOT = tmpRoot;
+    const task: TaskSpec = { id: "task-1", instruction: "frozen instruction" };
+
+    await new RubricCache({ dataset: "onlineMind2Web" }).write(task, rubric);
+
+    await expect(new RubricCache({ dataset: "onlineMind2Web" }).read(task)).resolves.toEqual(
+      rubric,
+    );
   });
 });

--- a/packages/evals/tests/framework/verifierAdapter.test.ts
+++ b/packages/evals/tests/framework/verifierAdapter.test.ts
@@ -1,10 +1,48 @@
-import { describe, expect, it } from "vitest";
-import type { EvaluationResult } from "stagehand-v3";
+import { afterEach, describe, expect, it } from "vitest";
+import { V3, type EvaluationResult } from "stagehand-v3";
+import { EvalLogger } from "../../logger.js";
 
 import {
+  gradeExternalTrajectory,
   evaluationResultToSuccess,
+  createVerifierEvaluator,
+  loadVerifierApiKey,
   resolveEvalSuccessMode,
 } from "../../framework/verifierAdapter.js";
+
+afterEach(() => {
+  delete process.env.AI_GATEWAY_API_KEY;
+  delete process.env.EVAL_VERIFIER_MODEL;
+});
+
+describe("loadVerifierApiKey", () => {
+  it("maps the AI SDK gateway provider to the Vercel AI Gateway key", () => {
+    process.env.AI_GATEWAY_API_KEY = "test-gateway-key";
+    expect(loadVerifierApiKey("gateway")).toBe("test-gateway-key");
+  });
+
+  it("does not treat an empty gateway key as configured", () => {
+    process.env.AI_GATEWAY_API_KEY = "  ";
+    expect(loadVerifierApiKey("gateway")).toBeUndefined();
+  });
+
+  it("initializes the OnlineMind2Web Gemini verifier through Vercel Gateway", async () => {
+    process.env.AI_GATEWAY_API_KEY = "test-gateway-key";
+    process.env.EVAL_VERIFIER_MODEL = "gateway/google/gemini-2.5-flash";
+    const carrier = new V3({
+      env: "LOCAL",
+      disablePino: true,
+      disableAPI: true,
+      experimental: true,
+      verbose: 0,
+    });
+    try {
+      expect(createVerifierEvaluator(carrier)).toBeDefined();
+    } finally {
+      await carrier.close();
+    }
+  });
+});
 
 const baseResult: EvaluationResult = {
   outcomeSuccess: true,
@@ -35,5 +73,40 @@ describe("evaluationResultToSuccess", () => {
     expect(evaluationResultToSuccess(outcomeOnly, "outcome")).toBe(true);
     expect(evaluationResultToSuccess(outcomeOnly, "process")).toBe(false);
     expect(evaluationResultToSuccess(outcomeOnly, "both")).toBe(false);
+  });
+});
+
+describe("gradeExternalTrajectory", () => {
+  it("can fail closed when trajectory parsing or verification fails", async () => {
+    const logger = new EvalLogger(true);
+    const carrier = new V3({
+      env: "LOCAL",
+      disablePino: true,
+      disableAPI: true,
+      experimental: true,
+      verbose: 0,
+    });
+    logger.init(carrier);
+    try {
+      const result = await gradeExternalTrajectory({
+        buildTrajectory: () => {
+          throw new Error("incomplete trace");
+        },
+        verifier: {
+          v3: carrier,
+          taskSpec: { id: "task-1", instruction: "Inspect the page." },
+          dataset: "onlineMind2Web",
+        },
+        baseResult: { _success: true, logs: [] },
+        errorMessage: "rubric failed",
+        category: "hermes",
+        logger,
+        failClosedOnVerifierError: true,
+      });
+      expect(result._success).toBe(false);
+      expect(result.verifierError).toContain("incomplete trace");
+    } finally {
+      await carrier.close();
+    }
   });
 });

--- a/packages/evals/tests/scripts/runHermesPublicHard.test.ts
+++ b/packages/evals/tests/scripts/runHermesPublicHard.test.ts
@@ -1,0 +1,189 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const validateHermesBenchmarkRoot = vi.fn((candidate: string) => path.resolve(candidate));
+const runHermesAgent = vi.fn(() => {
+  throw new Error("dry-run gate launched Hermes");
+});
+
+vi.mock("../../framework/hermesRunner.js", () => ({
+  validateHermesBenchmarkRoot,
+  runHermesAgent,
+}));
+
+const originalArgv = [...process.argv];
+const originalExitCode = process.exitCode;
+const managedEnvironment = [
+  "AI_GATEWAY_API_KEY",
+  "BROWSERBASE_API_KEY",
+  "EVAL_HERMES_ROOT",
+  "EVAL_RUBRIC_CACHE_ROOT",
+] as const;
+const originalEnvironment = Object.fromEntries(
+  managedEnvironment.map((key) => [key, process.env[key]]),
+);
+
+afterEach(() => {
+  process.argv = [...originalArgv];
+  process.exitCode = originalExitCode;
+  for (const key of managedEnvironment) {
+    const value = originalEnvironment[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  validateHermesBenchmarkRoot.mockClear();
+  runHermesAgent.mockClear();
+});
+
+interface ScriptResult {
+  stdout: string;
+  stderr: string;
+  exitCode: string | number | null | undefined;
+}
+
+async function runScript(
+  args: string[],
+  options: { gatewayCatalog?: boolean } = {},
+): Promise<ScriptResult> {
+  vi.resetModules();
+  process.argv = [process.execPath, "run-hermes-public-hard.ts", ...args];
+  process.exitCode = undefined;
+  process.env.EVAL_HERMES_ROOT = "/tmp/non-billable-hermes-fixture";
+  delete process.env.AI_GATEWAY_API_KEY;
+  delete process.env.BROWSERBASE_API_KEY;
+  delete process.env.EVAL_RUBRIC_CACHE_ROOT;
+
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+    stdout.push(String(chunk));
+    return true;
+  }) as typeof process.stdout.write);
+  const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(((chunk: unknown) => {
+    stderr.push(String(chunk));
+    return true;
+  }) as typeof process.stderr.write);
+
+  if (options.gatewayCatalog) {
+    process.env.AI_GATEWAY_API_KEY = "non-secret-test-value";
+    process.env.BROWSERBASE_API_KEY = "non-secret-test-value";
+    process.env.EVAL_RUBRIC_CACHE_ROOT = "/tmp/non-billable-rubric-cache";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          data: [
+            {
+              id: "anthropic/claude-opus-4.8",
+              type: "language",
+              tags: ["tool-use"],
+              pricing: { input: "0.000001", output: "0.000002" },
+            },
+            {
+              id: "moonshotai/kimi-k3",
+              type: "language",
+              tags: ["tool-use"],
+              pricing: { input: "0.000001", output: "0.000002" },
+            },
+          ],
+        }),
+      })),
+    );
+  } else {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => {
+        throw new Error("dry-run attempted a network request");
+      }),
+    );
+  }
+
+  try {
+    await import("../../scripts/run-hermes-public-hard.js");
+    await new Promise((resolve) => setImmediate(resolve));
+    return {
+      stdout: stdout.join(""),
+      stderr: stderr.join(""),
+      exitCode: process.exitCode,
+    };
+  } finally {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+  }
+}
+
+describe("run-hermes-public-hard non-billable gates", () => {
+  it.each([
+    ["canary", 3],
+    ["full", 30],
+  ])(
+    "prints the exact %s dry-run schedule without credentials or runtime calls",
+    async (phase, count) => {
+      const output = fs.mkdtempSync(path.join(os.tmpdir(), `hermes-${phase}-dry-run-`));
+      fs.rmSync(output, { recursive: true, force: true });
+      try {
+        const result = await runScript(["--phase", phase, "--dry-run", "--output", output]);
+
+        expect(result.exitCode).toBeUndefined();
+        expect(result.stderr).toBe("");
+        const payload = JSON.parse(result.stdout) as {
+          dry_run: boolean;
+          phase: string;
+          rows: Array<{ arm: string }>;
+          model_calls: number;
+          browser_sessions: number;
+        };
+        expect(payload.dry_run).toBe(true);
+        expect(payload.phase).toBe(phase);
+        expect(payload.rows).toHaveLength(count);
+        expect(new Set(payload.rows.map((row) => row.arm))).toEqual(new Set(["A", "B", "D"]));
+        expect(payload.model_calls).toBe(0);
+        expect(payload.browser_sessions).toBe(0);
+        expect(runHermesAgent).not.toHaveBeenCalled();
+        expect(fetch).not.toHaveBeenCalled();
+        expect(fs.existsSync(output)).toBe(false);
+      } finally {
+        fs.rmSync(output, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it("requires exactly one explicit billing mode", async () => {
+    const missing = await runScript(["--phase", "canary"]);
+    expect(missing.exitCode).toBe(4);
+    expect(missing.stderr).toContain("Choose exactly one of --dry-run or --confirm-billable");
+
+    const conflicting = await runScript(["--phase", "canary", "--dry-run", "--confirm-billable"]);
+    expect(conflicting.exitCode).toBe(4);
+    expect(conflicting.stderr).toContain("Choose exactly one of --dry-run or --confirm-billable");
+    expect(runHermesAgent).not.toHaveBeenCalled();
+  });
+
+  it("rejects a full run without a complete canary before creating output", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "hermes-full-gate-"));
+    const canary = path.join(root, "empty-canary");
+    const output = path.join(root, "full-output");
+    fs.mkdirSync(canary);
+    try {
+      const result = await runScript(
+        ["--phase", "full", "--confirm-billable", "--canary-root", canary, "--output", output],
+        { gatewayCatalog: true },
+      );
+
+      expect(result.exitCode).toBe(4);
+      expect(result.stderr).toContain("Canary record is missing for arm A");
+      expect(runHermesAgent).not.toHaveBeenCalled();
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(fs.existsSync(output)).toBe(false);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/evals/tests/tui/parse.test.ts
+++ b/packages/evals/tests/tui/parse.test.ts
@@ -25,6 +25,7 @@ describe("resolveRunOptions", () => {
   it("accepts known bench harnesses", () => {
     const resolved = resolveRunOptions({ harness: "claude_code" }, {}, {});
     expect(resolved.harness).toBe("claude_code");
+    expect(resolveRunOptions({ harness: "hermes" }, {}, {}).harness).toBe("hermes");
   });
 
   it("rejects unknown bench harnesses", () => {

--- a/packages/evals/tui/commands/help.ts
+++ b/packages/evals/tui/commands/help.ts
@@ -76,7 +76,7 @@ export function printRunHelp(): void {
     "",
     row(
       `${cyan("--harness")} ${dim("<name>")}`,
-      `Bench harness ${gray("(stagehand | claude_code | codex)")}`,
+      `Bench harness ${gray("(stagehand | claude_code | codex | hermes)")}`,
     ),
     row(
       `${cyan("--success")} ${dim("<mode>")}`,

--- a/packages/evals/tui/commands/run.ts
+++ b/packages/evals/tui/commands/run.ts
@@ -184,7 +184,7 @@ export async function runCommand(
 
   if (!canExecuteBenchHarness(options.harness) && tasks.some((t) => t.tier === "bench")) {
     throw new Error(
-      `Harness "${options.harness}" is dry-run only for now. Use --harness stagehand, --harness claude_code, or --harness codex for executable bench runs.`,
+      `Harness "${options.harness}" is dry-run only for now. Use --harness stagehand, --harness claude_code, --harness codex, or --harness hermes for executable bench runs.`,
     );
   }
   const matrix = await buildDryRunMatrix(options, tasks, registry);


### PR DESCRIPTION
## What changed

- Adds `hermes` as a first-class executable harness in `packages/evals`.
- Supports three surfaces through the existing eval CLI: `hermes_browser_legacy`, `hermes_browser_exec` (Browser Use), and `hermes_stagehand_batch` (Stagehand V4 `experimental_batch`).
- Adds a frozen ten-task Online-Mind2Web hard slice, counterbalanced A/B/D runner, strict canary gate, resumable records, Vercel AI Gateway routing, and Browserbase execution.
- Converts retained Hermes state plus independently captured URL/screenshot evidence into normal Stagehand verifier trajectories.
- Adds cached-rubric grading, identity-bound verifier recovery, `benchmark:hermes-public-hard`, and `regrade:hermes`.

## Why

The public Nous/Hermes result did not publish its six prompts, trajectories, grader, or website snapshots. This adapter tests the same tool-surface hypothesis through Stagehand's existing eval infrastructure while preserving Hermes's agent loop.

Companion native runner and audited report: browserbase/hermes-browser-agent-benchmarks#1.

## Final matched result

Two independent 30-trajectory matrices completed over the same ten tasks and schedule.

| Orchestrator | A · Hermes legacy | B · Browser Use | D · Stagehand batch |
| --- | ---: | ---: | ---: |
| Hermes-native strict scheduled success | 6/10 | 7/10 | **8/10** |
| Stagehand evals strict scheduled success | 5/10 | 5/10 | **8/10** |

Relative to Browser Use:

- Native: Stagehand used 19.6% fewer tool calls, but 55.5% more trajectory tokens and cost 17.5% more.
- Stagehand evals: Stagehand used 22.4% fewer tool calls and 9.1% less agent wall time, but 17.2% more trajectory tokens and cost 40.0% more.

Stagehand improved scheduled reliability and tool-call count, but did **not** reproduce the Nous 60–66% token reduction or satisfy the conjunctive accuracy-and-token-efficiency win rule.

## Claim boundary

- These are ten frozen public proxies, not the unreleased six Nous tasks.
- Current Hermes exposes twelve legacy tools; the published Nous baseline reportedly had eight.
- Native B/D and evals B lack complete verifier coverage. Scheduled success counts those rows as failures.
- A first-write rubric-cache race produced two retained rubric digests for one task. No full-matrix trajectory was retried, discarded, or regraded; the report preserves both and withholds a strong claim.
- The executed matrix remains provenance-bound to its original run checkout; this PR ports the same harness cleanly onto current `main`.

## Validation

- Full eval suite: 57 files / 442 tests passed.
- Evals typecheck and build, SDK TypeScript build, extension build, Oxfmt, and clean diff checks passed.
- Strict three-arm live canary passed; retained verifier recovery did not rerun the agent or browser.
- Full Stagehand-evals matrix completed 30/30 scheduled trajectories.

## Published report

[Open the SSO-gated matched HTML report](https://agentshtml-browserbase.vercel.app/shrey/hermes-stagehand-public-hard-n10-2026-08-12/).