### PR TITLE
chore(cli): prepare browse 0.9.7 release

### DIFF
--- a/.changeset/warm-functions-parity.md
+++ b/.changeset/warm-functions-parity.md
@@ -1,5 +1,0 @@
----
-"browse": patch
----
-
-Align `browse functions` with the Browserbase Functions SDK by supporting optional project overrides, matching local invocation context and error payloads, and accepting the SDK's `--api-url` option.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - v4-spike-cli
 
 permissions:
   contents: write
@@ -15,8 +16,114 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  release-browse:
+    name: Release Browse CLI
+    if: github.ref == 'refs/heads/v4-spike-cli'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: "11.10.0"
+          run_install: false
+
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: "24"
+          cache: pnpm
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install npm
+        run: npm install --global npm@11.16.0
+
+      - name: Check release status
+        id: release
+        shell: bash
+        run: |
+          package_name="$(node -p "require('./packages/cli/package.json').name")"
+          package_version="$(node -p "require('./packages/cli/package.json').version")"
+          test "$package_name" = "browse"
+
+          published_versions="$(npm view "$package_name" versions --json)"
+          if jq -e --arg version "$package_version" 'index($version) != null' \
+            <<<"$published_versions" >/dev/null; then
+            echo "browse@$package_version is already published; nothing to do."
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Publishing browse@$package_version from $GITHUB_SHA."
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "version=$package_version" >> "$GITHUB_OUTPUT"
+
+      - name: Install dependencies
+        if: steps.release.outputs.should_publish == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint Browse
+        if: steps.release.outputs.should_publish == 'true'
+        run: pnpm --filter browse lint
+
+      - name: Test Browse
+        if: steps.release.outputs.should_publish == 'true'
+        run: pnpm --filter browse test
+
+      - name: Pack Browse
+        if: steps.release.outputs.should_publish == 'true'
+        id: pack
+        shell: bash
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          pack_dir="$RUNNER_TEMP/browse-pack"
+          mkdir -p "$pack_dir"
+          pnpm --filter browse pack --pack-destination "$pack_dir"
+
+          tarball="$pack_dir/browse-$VERSION.tgz"
+          test -f "$tarball"
+          tar -xOf "$tarball" package/package.json | \
+            jq -e --arg version "$VERSION" '.name == "browse" and .version == $version' >/dev/null
+          echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
+
+      - name: Smoke-test packed CLI
+        if: steps.release.outputs.should_publish == 'true'
+        shell: bash
+        env:
+          TARBALL: ${{ steps.pack.outputs.tarball }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          smoke_dir="$RUNNER_TEMP/browse-smoke"
+          mkdir -p "$smoke_dir"
+          npm install --prefix "$smoke_dir" "$TARBALL"
+          "$smoke_dir/node_modules/.bin/browse" --version | grep -F "$VERSION"
+          "$smoke_dir/node_modules/.bin/browse" functions --help | grep -F "functions publish"
+
+      - name: Publish Browse
+        if: steps.release.outputs.should_publish == 'true'
+        env:
+          TARBALL: ${{ steps.pack.outputs.tarball }}
+        run: npm publish "$TARBALL" --access public --provenance
+
+      - name: Tag Browse release
+        if: steps.release.outputs.should_publish == 'true'
+        shell: bash
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          tag="browse@$VERSION"
+          git tag "$tag" "$GITHUB_SHA"
+          git push origin "refs/tags/$tag"
+
   release-typescript:
     name: Release TypeScript SDK
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # browse
 
+## 0.9.7
+
+### Patch Changes
+
+- [#2700](https://github.com/browserbase/stagehand/pull/2700) [`da283f3`](https://github.com/browserbase/stagehand/commit/da283f38846cb585ef101a040fa15ef91fb8fe96) Thanks [@shrey150](https://github.com/shrey150)! - Repair `browse functions` parity with the Browserbase Functions SDK: infer the project from the API key by default, preserve optional project overrides, and align scaffolding, local invocation, runtime errors, archive limits, and the `--api-url` option.
+
 ## 0.9.6
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browse",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "private": false,
   "description": "Unified Browserbase CLI for browser automation and cloud APIs.",
   "homepage": "https://github.com/browserbase/stagehand/tree/main/packages/cli#readme",


### PR DESCRIPTION
## BLUF

Prepare the smallest auditable release path for the tactical Browse Functions hotfix: publish only `browse@0.9.7` from the legacy CLI line, through npm trusted publishing, after the full package test and packed-artifact smoke gates pass.

This PR is intentionally stacked on #2700 so reviewers see only release mechanics. Merge #2700 into `v4-spike-cli` first, then retarget this PR to `v4-spike-cli`; merging this PR will trigger the publish.

## Why this path

- `packages/cli` is no longer on `main`, so the normal main release job cannot consume its changeset.
- A local/manual `npm publish` would bypass the repository's existing OIDC provenance path.
- Running the monorepo-wide `changeset publish` from `v4-spike-cli` risks touching unrelated Stagehand v4 packages.
- The existing npm trusted publisher recognizes `.github/workflows/release.yml`, so this adds a branch-gated Browse-only job to that workflow.

## Changes

- consume the tactical changeset and version Browse from `0.9.6` to `0.9.7`
- add a `v4-spike-cli` release path that can publish only the `browse` package
- skip safely when the version already exists
- lint, test, build, pack, inspect, and install-smoke the exact tarball before publishing it
- publish that exact tarball with npm provenance and tag the release commit
- keep the existing Stagehand TypeScript release job restricted to `main`

## Validation

- `pnpm --filter browse lint`
- `pnpm --filter browse test` — 25 files, 367 tests passed
- packed `browse-0.9.7.tgz`; verified package name/version
- installed the tarball into a clean temporary directory
- verified installed `browse --version` reports `0.9.7`
- verified installed `browse functions --help` exposes publish/dev/invoke/init
- `actionlint .github/workflows/release.yml`
- confirmed `browse@0.9.7` is not present on npm

The live Functions E2E matrix for the exact tactical source is documented on #2700, including fresh scaffold install, local dev, cloud publish, synchronous invoke, asynchronous invoke/status, and API-key-based project inference.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes `browse@0.9.7` through a branch‑gated, provenance-enabled workflow to ship the Functions parity hotfix with an auditable path. Previously, the release workflow only published from `main`; now a `v4-spike-cli` job publishes only `browse` after tests and tarball smoke checks, leaving other packages and the `main` release path unchanged.

- Bumps `browse` to 0.9.7 and updates its changelog; removes the consumed changeset.
- Adds a `Release Browse CLI` job in `.github/workflows/release.yml` that runs only on `v4-spike-cli`.
- Skips safely if the version already exists on npm.
- Runs lint, tests, packs the exact tarball, verifies name/version, and smoke-installs to assert `--version` and `functions` help.
- Publishes that tarball with npm provenance and tags the release. No migration required.

<sup>Written for commit f412bffe0ad040aa8bfae72d29d92338df658c8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

