### PR TITLE
chore(cli): prepare browse 0.9.7 from v3

### DIFF
--- a/.changeset/warm-functions-parity.md
+++ b/.changeset/warm-functions-parity.md
@@ -1,5 +1,0 @@
----
-"browse": patch
----
-
-Align `browse functions` with the Browserbase Functions SDK by supporting optional project overrides, matching local invocation context and error payloads, and accepting the SDK's `--api-url` option.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - v3-cli
 
 permissions:
   contents: write
@@ -14,8 +15,117 @@ permissions:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
+  release-browse:
+    name: Release Browse CLI
+    if: github.ref == 'refs/heads/v3-cli'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-node-pnpm-turbo
+        with:
+          use-prebuilt-artifacts: "false"
+
+      - name: Configure npm registry for Trusted Publishing
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20.x
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Update npm for Trusted Publishing
+        run: npm install -g npm@11.18.0
+
+      - name: Check release status
+        id: release
+        shell: bash
+        run: |
+          package_name="$(node -p "require('./packages/cli/package.json').name")"
+          package_version="$(node -p "require('./packages/cli/package.json').version")"
+          test "$package_name" = "browse"
+
+          published_versions="$(npm view "$package_name" versions --json)"
+          if jq -e --arg version "$package_version" 'index($version) != null' \
+            <<<"$published_versions" >/dev/null; then
+            echo "browse@$package_version is already published; nothing to do."
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Publishing browse@$package_version from $GITHUB_SHA."
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "version=$package_version" >> "$GITHUB_OUTPUT"
+
+      - name: Lint Browse
+        if: steps.release.outputs.should_publish == 'true'
+        run: pnpm --filter browse lint
+
+      - name: Test Browse
+        if: steps.release.outputs.should_publish == 'true'
+        run: pnpm --filter browse test
+
+      - name: Pack Browse
+        if: steps.release.outputs.should_publish == 'true'
+        id: pack
+        shell: bash
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          pack_dir="$RUNNER_TEMP/browse-pack"
+          mkdir -p "$pack_dir"
+          pnpm --dir packages/cli pack --pack-destination "$pack_dir"
+
+          tarball="$pack_dir/browse-$VERSION.tgz"
+          test -f "$tarball"
+          tar -xOf "$tarball" package/package.json | \
+            jq -e --arg version "$VERSION" '.name == "browse" and .version == $version' >/dev/null
+          echo "tarball=$tarball" >> "$GITHUB_OUTPUT"
+
+      - name: Smoke-test packed CLI
+        if: steps.release.outputs.should_publish == 'true'
+        shell: bash
+        env:
+          TARBALL: ${{ steps.pack.outputs.tarball }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          smoke_dir="$RUNNER_TEMP/browse-smoke"
+          mkdir -p "$smoke_dir"
+          npm install --prefix "$smoke_dir" "$TARBALL"
+          "$smoke_dir/node_modules/.bin/browse" --version | grep -F "$VERSION"
+          "$smoke_dir/node_modules/.bin/browse" functions --help | grep -F "functions publish"
+
+      - name: Publish Browse
+        if: steps.release.outputs.should_publish == 'true'
+        env:
+          TARBALL: ${{ steps.pack.outputs.tarball }}
+        run: npm publish "$TARBALL" --access public --provenance
+
+      - name: Tag Browse release
+        if: steps.release.outputs.should_publish == 'true'
+        shell: bash
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          tag="browse@$VERSION"
+          if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+            echo "Tag $tag already exists."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "$tag" "$GITHUB_SHA"
+          git push origin "refs/tags/$tag"
+
   release:
     name: Release
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,10 @@ jobs:
         if: steps.release.outputs.should_publish == 'true'
         run: pnpm --filter browse test
 
+      - name: Build Browse for packaging
+        if: steps.release.outputs.should_publish == 'true'
+        run: pnpm --filter browse build
+
       - name: Pack Browse
         if: steps.release.outputs.should_publish == 'true'
         id: pack
@@ -107,14 +111,19 @@ jobs:
         run: npm publish "$TARBALL" --access public --provenance
 
       - name: Tag Browse release
-        if: steps.release.outputs.should_publish == 'true'
+        if: ${{ !cancelled() && steps.release.outputs.version != '' }}
         shell: bash
         env:
           VERSION: ${{ steps.release.outputs.version }}
         run: |
           tag="browse@$VERSION"
-          if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
-            echo "Tag $tag already exists."
+          if ! npm view "browse@$VERSION" version >/dev/null 2>&1; then
+            echo "browse@$VERSION is not published; skipping tag."
+            exit 0
+          fi
+
+          if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
+            echo "Remote tag $tag already exists."
             exit 0
           fi
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # browse
 
+## 0.9.7
+
+### Patch Changes
+
+- [#2704](https://github.com/browserbase/stagehand/pull/2704) - Repair `browse functions` parity with the Browserbase Functions SDK: infer the project from the API key by default, preserve optional project overrides, and align scaffolding, local invocation, runtime errors, archive limits, and the `--api-url` option.
+
 ## 0.9.6
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browse",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Unified Browserbase CLI for browser automation and cloud APIs.",
   "type": "module",
   "private": false,


### PR DESCRIPTION
## Summary

- version Browse from `0.9.6` to `0.9.7` and consume the Functions parity changeset
- add a `v3-cli`-only trusted-publishing job for Browse
- keep the existing monorepo release job restricted to `main`
- lint, test, pack, inspect, install-smoke, publish with npm provenance, and tag the exact Browse artifact

This is stacked on #2704 and supersedes #2703, whose `v4-spike-cli` base contains unrelated CLI migration work.

## Why this release path

`v3-cli` starts at the last pre-v4 `main` commit, and its `packages/cli` tree is identical to the published `browse@0.9.6` tag. This lets `0.9.7` contain the tactical Functions fix without also shipping unreleased v4-branch CLI changes.

The workflow publishes only `packages/cli`; it does not run the monorepo-wide Changesets publish path. npm authentication remains the repository's existing OIDC/trusted-publishing flow with provenance.

## E2E Test Matrix

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `actionlint .github/workflows/release.yml` | Passed with no findings | Validates workflow syntax and expressions |
| `pnpm --filter browse lint` | Formatting, ESLint, and TypeScript checks passed for `browse@0.9.7` | Proves the exact release tree is statically valid |
| `pnpm --filter browse test` under the CI-standard umask | 25 files and 369/369 tests passed | Proves the exact versioned release tree is green |
| `pnpm --dir packages/cli pack --pack-destination <temp>` | Produced `browse-0.9.7.tgz` with 142 entries | Exercises the exact v3-compatible pack command used by CI |
| Inspect packed `package/package.json` | Name/version are `browse@0.9.7`; workspace dependency resolves to `@browserbasehq/stagehand@3.7.1` | Proves no v4 Stagehand dependency leaks into the artifact |
| Install tarball into a clean temp prefix | `browse/0.9.7`; `browse functions --help` exposes `functions publish` | Proves the packed artifact installs and its CLI entry point runs |
| `npm view browse@0.9.7` | Version is not published | Confirms merging this PR will create, not overwrite, the release |

## Merge and publish order

1. Merge #2704 into `v3-cli`.
2. Retarget this PR from `agent/fix-functions-parity-v3` to `v3-cli`.
3. Merge this PR. The push to `v3-cli` triggers the Browse-only job and publishes `browse@0.9.7`.
