### PR TITLE
fix(extension): preserve native XPath predicates

### DIFF
--- a/.changeset/tame-xpaths-preserve-predicates.md
+++ b/.changeset/tame-xpaths-preserve-predicates.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Preserve native XPath predicate semantics when a page contains an unrelated shadow root.

--- a/packages/extension/dom/locatorScripts/xpathParser.ts
+++ b/packages/extension/dom/locatorScripts/xpathParser.ts
@@ -1,5 +1,5 @@
 export type XPathPredicate =
-  | { type: "unsupported" }
+  | { type: "unsupported"; source: string }
   | { type: "index"; index: number }
   | { type: "attrEquals"; name: string; value: string; normalize?: boolean }
   | { type: "attrExists"; name: string }
@@ -53,8 +53,8 @@ export interface XPathStep {
  *  - Union operator (`|`)
  *  - Grouped expressions (`(//div)[n]`)
  *
- * Unsupported predicates never match in the composed-tree fallback. Native
- * XPath evaluation still handles them when the selector matches the light DOM.
+ * Unsupported predicates throw in the composed-tree fallback so callers never
+ * receive a broadened or incomplete result that looks authoritative.
  */
 export function parseXPathSteps(input: string): XPathStep[] {
   const path = String(input || "")
@@ -153,7 +153,7 @@ function parseStep(raw: string): {
 
   for (const inner of extractPredicates(predicateStr)) {
     const parsed = parsePredicateExpression(inner);
-    predicates.push(parsed ?? { type: "unsupported" });
+    predicates.push(parsed ?? { type: "unsupported", source: inner });
   }
 
   return { tag, predicates };
@@ -382,7 +382,9 @@ function normalizeMaybe(value: string, normalize?: boolean): string {
 export function evaluatePredicate(element: Element, predicate: XPathPredicate): boolean {
   switch (predicate.type) {
     case "unsupported":
-      return false;
+      throw new Error(
+        `Unsupported XPath predicate in composed-tree traversal: ${predicate.source}`,
+      );
     case "and":
       return predicate.predicates.every((p) => evaluatePredicate(element, p));
     case "or":

--- a/packages/extension/dom/locatorScripts/xpathParser.ts
+++ b/packages/extension/dom/locatorScripts/xpathParser.ts
@@ -1,4 +1,5 @@
 export type XPathPredicate =
+  | { type: "unsupported" }
   | { type: "index"; index: number }
   | { type: "attrEquals"; name: string; value: string; normalize?: boolean }
   | { type: "attrExists"; name: string }
@@ -52,8 +53,8 @@ export interface XPathStep {
  *  - Union operator (`|`)
  *  - Grouped expressions (`(//div)[n]`)
  *
- * Unsupported predicates are silently ignored — the step still matches
- * by tag name, but the unrecognized predicate has no filtering effect.
+ * Unsupported predicates never match in the composed-tree fallback. Native
+ * XPath evaluation still handles them when the selector matches the light DOM.
  */
 export function parseXPathSteps(input: string): XPathStep[] {
   const path = String(input || "")
@@ -152,7 +153,7 @@ function parseStep(raw: string): {
 
   for (const inner of extractPredicates(predicateStr)) {
     const parsed = parsePredicateExpression(inner);
-    if (parsed) predicates.push(parsed);
+    predicates.push(parsed ?? { type: "unsupported" });
   }
 
   return { tag, predicates };
@@ -195,7 +196,7 @@ function parseAtomicPredicate(input: string): XPathPredicate | null {
   const quoted = "(?:'([^']*)'|\"([^\"]*)\")";
 
   if (/^\d+$/.test(input)) {
-    return { type: "index", index: Math.max(1, Number(input)) };
+    return { type: "index", index: Number(input) };
   }
 
   const normalizeAttrMatch = input.match(
@@ -380,6 +381,8 @@ function normalizeMaybe(value: string, normalize?: boolean): string {
 
 export function evaluatePredicate(element: Element, predicate: XPathPredicate): boolean {
   switch (predicate.type) {
+    case "unsupported":
+      return false;
     case "and":
       return predicate.predicates.every((p) => evaluatePredicate(element, p));
     case "or":

--- a/packages/extension/dom/locatorScripts/xpathResolver.ts
+++ b/packages/extension/dom/locatorScripts/xpathResolver.ts
@@ -1,4 +1,9 @@
-import { applyPredicates, parseXPathSteps, type XPathStep } from "./xpathParser.js";
+import {
+  applyPredicates,
+  parseXPathSteps,
+  type XPathPredicate,
+  type XPathStep,
+} from "./xpathParser.js";
 import { documentHasShadowRoot, getOpenOrClosedShadowRoot } from "./shadowRoots.js";
 
 type ShadowRootGetter = (host: Element) => ShadowRoot | null;
@@ -54,9 +59,12 @@ export function resolveXPathAtIndex(
   const shadowHopMatches = resolveStagehandShadowHopMatches(xp, shadowCtx.getShadowRoot);
   if (shadowHopMatches.length > 0) return shadowHopMatches[targetIndex] ?? null;
 
-  const native = resolveNativeMatchesWithError(xp);
+  const native = resolveNativeMatches(xp);
+  if (native.length > 0 && requiresNativePredicateSemantics(xp)) {
+    return native[targetIndex] ?? null;
+  }
   const composed = resolveXPathComposedMatches(xp, shadowCtx.getShadowRoot);
-  const matches = mergeXPathMatches(native.values, composed, shadowCtx.getShadowRoot);
+  const matches = mergeXPathMatches(native, composed, shadowCtx.getShadowRoot);
   return matches[targetIndex] ?? null;
 }
 
@@ -84,9 +92,31 @@ export function countXPathMatches(rawXp: string, options?: XPathResolveOptions):
   const shadowHopCount = resolveStagehandShadowHopMatches(xp, shadowCtx.getShadowRoot).length;
   if (shadowHopCount > 0) return shadowHopCount;
 
-  const native = resolveNativeMatchesWithError(xp);
+  const native = resolveNativeMatches(xp);
+  if (native.length > 0 && requiresNativePredicateSemantics(xp)) {
+    return native.length;
+  }
   const composed = resolveXPathComposedMatches(xp, shadowCtx.getShadowRoot);
-  return mergeXPathMatches(native.values, composed, shadowCtx.getShadowRoot).length;
+  return mergeXPathMatches(native, composed, shadowCtx.getShadowRoot).length;
+}
+
+function requiresNativePredicateSemantics(xp: string): boolean {
+  return parseXPathSteps(xp).some((step) => step.predicates.some(isPositionalOrUnsupported));
+}
+
+function isPositionalOrUnsupported(predicate: XPathPredicate): boolean {
+  switch (predicate.type) {
+    case "index":
+    case "unsupported":
+      return true;
+    case "and":
+    case "or":
+      return predicate.predicates.some(isPositionalOrUnsupported);
+    case "not":
+      return isPositionalOrUnsupported(predicate.predicate);
+    default:
+      return false;
+  }
 }
 
 export function resolveXPathComposedMatches(
@@ -285,7 +315,7 @@ function mergeXPathMatches(
   );
 }
 
-function resolveNativeMatchesWithError(xp: string): { values: Element[]; error: boolean } {
+function resolveNativeMatches(xp: string): Element[] {
   try {
     const snapshot = document.evaluate(
       xp,
@@ -299,9 +329,9 @@ function resolveNativeMatchesWithError(xp: string): { values: Element[]; error: 
       const value = snapshot.snapshotItem(index);
       if (value instanceof Element) values.push(value);
     }
-    return { values, error: false };
+    return values;
   } catch {
-    return { values: [], error: true };
+    return [];
   }
 }
 

--- a/packages/extension/dom/locatorScripts/xpathResolver.ts
+++ b/packages/extension/dom/locatorScripts/xpathResolver.ts
@@ -36,6 +36,10 @@ export function resolveXPathAtIndex(
   const pierceShadow = options?.pierceShadow !== false;
   const shadowCtx = pierceShadow ? getShadowContext() : null;
 
+  if (xp.startsWith("(")) {
+    return resolveNativeAtIndexWithError(xp, targetIndex).value;
+  }
+
   if (!pierceShadow) {
     return resolveNativeAtIndexWithError(xp, targetIndex).value;
   }
@@ -50,11 +54,10 @@ export function resolveXPathAtIndex(
   const shadowHopMatches = resolveStagehandShadowHopMatches(xp, shadowCtx.getShadowRoot);
   if (shadowHopMatches.length > 0) return shadowHopMatches[targetIndex] ?? null;
 
-  const native = resolveNativeAtIndexWithError(xp, targetIndex);
-  if (!native.error && native.count > 0) return native.value;
-
+  const native = resolveNativeMatchesWithError(xp);
   const composed = resolveXPathComposedMatches(xp, shadowCtx.getShadowRoot);
-  return composed[targetIndex] ?? null;
+  const matches = mergeXPathMatches(native.values, composed, shadowCtx.getShadowRoot);
+  return matches[targetIndex] ?? null;
 }
 
 export function countXPathMatches(rawXp: string, options?: XPathResolveOptions): number {
@@ -63,6 +66,10 @@ export function countXPathMatches(rawXp: string, options?: XPathResolveOptions):
 
   const pierceShadow = options?.pierceShadow !== false;
   const shadowCtx = pierceShadow ? getShadowContext() : null;
+
+  if (xp.startsWith("(")) {
+    return resolveNativeCountWithError(xp).count;
+  }
 
   if (!pierceShadow) {
     return resolveNativeCountWithError(xp).count;
@@ -77,10 +84,9 @@ export function countXPathMatches(rawXp: string, options?: XPathResolveOptions):
   const shadowHopCount = resolveStagehandShadowHopMatches(xp, shadowCtx.getShadowRoot).length;
   if (shadowHopCount > 0) return shadowHopCount;
 
-  const native = resolveNativeCountWithError(xp);
-  if (!native.error && native.count > 0) return native.count;
-
-  return resolveXPathComposedMatches(xp, shadowCtx.getShadowRoot).length;
+  const native = resolveNativeMatchesWithError(xp);
+  const composed = resolveXPathComposedMatches(xp, shadowCtx.getShadowRoot);
+  return mergeXPathMatches(native.values, composed, shadowCtx.getShadowRoot).length;
 }
 
 export function resolveXPathComposedMatches(
@@ -260,6 +266,43 @@ function composedDescendants(
   }
 
   return out;
+}
+
+function mergeXPathMatches(
+  native: Element[],
+  composed: Element[],
+  getShadowRoot: ShadowRootGetter | null,
+): Element[] {
+  const shadowMatches = composed.filter((element) => element.getRootNode() instanceof ShadowRoot);
+  const matches = Array.from(new Set([...native, ...shadowMatches]));
+  const composedOrder = new Map(
+    composedDescendants(document, getShadowRoot).map((element, index) => [element, index]),
+  );
+  return matches.sort(
+    (left, right) =>
+      (composedOrder.get(left) ?? Number.MAX_SAFE_INTEGER) -
+      (composedOrder.get(right) ?? Number.MAX_SAFE_INTEGER),
+  );
+}
+
+function resolveNativeMatchesWithError(xp: string): { values: Element[]; error: boolean } {
+  try {
+    const snapshot = document.evaluate(
+      xp,
+      document,
+      null,
+      XPathResult.ORDERED_NODE_SNAPSHOT_TYPE,
+      null,
+    );
+    const values: Element[] = [];
+    for (let index = 0; index < snapshot.snapshotLength; index += 1) {
+      const value = snapshot.snapshotItem(index);
+      if (value instanceof Element) values.push(value);
+    }
+    return { values, error: false };
+  } catch {
+    return { values: [], error: true };
+  }
 }
 
 function resolveNativeAtIndexWithError(

--- a/packages/extension/dom/locatorScripts/xpathResolver.ts
+++ b/packages/extension/dom/locatorScripts/xpathResolver.ts
@@ -50,6 +50,9 @@ export function resolveXPathAtIndex(
   const shadowHopMatches = resolveStagehandShadowHopMatches(xp, shadowCtx.getShadowRoot);
   if (shadowHopMatches.length > 0) return shadowHopMatches[targetIndex] ?? null;
 
+  const native = resolveNativeAtIndexWithError(xp, targetIndex);
+  if (!native.error && native.count > 0) return native.value;
+
   const composed = resolveXPathComposedMatches(xp, shadowCtx.getShadowRoot);
   return composed[targetIndex] ?? null;
 }
@@ -73,6 +76,9 @@ export function countXPathMatches(rawXp: string, options?: XPathResolveOptions):
 
   const shadowHopCount = resolveStagehandShadowHopMatches(xp, shadowCtx.getShadowRoot).length;
   if (shadowHopCount > 0) return shadowHopCount;
+
+  const native = resolveNativeCountWithError(xp);
+  if (!native.error && native.count > 0) return native.count;
 
   return resolveXPathComposedMatches(xp, shadowCtx.getShadowRoot).length;
 }
@@ -259,7 +265,7 @@ function composedDescendants(
 function resolveNativeAtIndexWithError(
   xp: string,
   index: number,
-): { value: Element | null; error: boolean } {
+): { value: Element | null; count: number; error: boolean } {
   try {
     const snapshot = document.evaluate(
       xp,
@@ -270,10 +276,11 @@ function resolveNativeAtIndexWithError(
     );
     return {
       value: snapshot.snapshotItem(index) as Element | null,
+      count: snapshot.snapshotLength,
       error: false,
     };
   } catch {
-    return { value: null, error: true };
+    return { value: null, count: 0, error: true };
   }
 }
 

--- a/packages/extension/dom/locatorScripts/xpathResolver.ts
+++ b/packages/extension/dom/locatorScripts/xpathResolver.ts
@@ -60,11 +60,11 @@ export function resolveXPathAtIndex(
   if (shadowHopMatches.length > 0) return shadowHopMatches[targetIndex] ?? null;
 
   const native = resolveNativeMatches(xp);
-  if (native.length > 0 && requiresNativePredicateSemantics(xp)) {
-    return native[targetIndex] ?? null;
+  if (!native.error && requiresNativePredicateSemantics(xp)) {
+    return native.values[targetIndex] ?? null;
   }
   const composed = resolveXPathComposedMatches(xp, shadowCtx.getShadowRoot);
-  const matches = mergeXPathMatches(native, composed, shadowCtx.getShadowRoot);
+  const matches = mergeXPathMatches(native.values, composed, shadowCtx.getShadowRoot);
   return matches[targetIndex] ?? null;
 }
 
@@ -93,11 +93,11 @@ export function countXPathMatches(rawXp: string, options?: XPathResolveOptions):
   if (shadowHopCount > 0) return shadowHopCount;
 
   const native = resolveNativeMatches(xp);
-  if (native.length > 0 && requiresNativePredicateSemantics(xp)) {
-    return native.length;
+  if (!native.error && requiresNativePredicateSemantics(xp)) {
+    return native.values.length;
   }
   const composed = resolveXPathComposedMatches(xp, shadowCtx.getShadowRoot);
-  return mergeXPathMatches(native, composed, shadowCtx.getShadowRoot).length;
+  return mergeXPathMatches(native.values, composed, shadowCtx.getShadowRoot).length;
 }
 
 function requiresNativePredicateSemantics(xp: string): boolean {
@@ -315,7 +315,7 @@ function mergeXPathMatches(
   );
 }
 
-function resolveNativeMatches(xp: string): Element[] {
+function resolveNativeMatches(xp: string): { values: Element[]; error: boolean } {
   try {
     const snapshot = document.evaluate(
       xp,
@@ -329,9 +329,9 @@ function resolveNativeMatches(xp: string): Element[] {
       const value = snapshot.snapshotItem(index);
       if (value instanceof Element) values.push(value);
     }
-    return values;
+    return { values, error: false };
   } catch {
-    return [];
+    return { values: [], error: true };
   }
 }
 

--- a/packages/extension/tests/xpath-parser.test.ts
+++ b/packages/extension/tests/xpath-parser.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { applyPredicates, parseXPathSteps } from "../dom/locatorScripts/xpathParser.js";
+
+describe("composed XPath predicate safety", () => {
+  const elements = [{}, {}, {}] as Element[];
+
+  it("does not coerce XPath index zero to the first match", () => {
+    const [step] = parseXPathSteps("//div[0]");
+
+    expect(applyPredicates(elements, step!.predicates)).toEqual([]);
+  });
+
+  it("does not silently ignore unsupported predicates", () => {
+    const [step] = parseXPathSteps("//div[position() > 10]");
+
+    expect(applyPredicates(elements, step!.predicates)).toEqual([]);
+  });
+});

--- a/packages/extension/tests/xpath-parser.test.ts
+++ b/packages/extension/tests/xpath-parser.test.ts
@@ -4,15 +4,23 @@ import { applyPredicates, parseXPathSteps } from "../dom/locatorScripts/xpathPar
 describe("composed XPath predicate safety", () => {
   const elements = [{}, {}, {}] as Element[];
 
+  it("still applies supported index predicates", () => {
+    const [step] = parseXPathSteps("//div[2]");
+
+    expect(applyPredicates(elements, step!.predicates)).toEqual([elements[1]]);
+  });
+
   it("does not coerce XPath index zero to the first match", () => {
     const [step] = parseXPathSteps("//div[0]");
 
     expect(applyPredicates(elements, step!.predicates)).toEqual([]);
   });
 
-  it("does not silently ignore unsupported predicates", () => {
+  it("rejects unsupported predicates instead of silently broadening matches", () => {
     const [step] = parseXPathSteps("//div[position() > 10]");
 
-    expect(applyPredicates(elements, step!.predicates)).toEqual([]);
+    expect(() => applyPredicates(elements, step!.predicates)).toThrow(
+      "Unsupported XPath predicate in composed-tree traversal: position() > 10",
+    );
   });
 });

--- a/packages/extension/understudy/deepLocator.test.ts
+++ b/packages/extension/understudy/deepLocator.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Frame } from "./frame.js";
 import type { Page } from "./page.js";
-import { DeepLocatorDelegate } from "./deepLocator.js";
+import { DeepLocatorDelegate, resolveLocatorTarget } from "./deepLocator.js";
 
 describe("DeepLocatorDelegate match selection", () => {
   const createDelegate = () => {
@@ -27,5 +27,14 @@ describe("DeepLocatorDelegate match selection", () => {
 
     await expect(locator.resolveNode()).resolves.toEqual({ objectId: "node-1", nodeId: null });
     expect(resolveAtIndex).toHaveBeenCalledWith(locator.selectorQuery, 0);
+  });
+
+  it("preserves grouped XPath expressions for native evaluation", async () => {
+    const frame = {} as Frame;
+
+    await expect(resolveLocatorTarget({} as Page, frame, "xpath=(//div)[2]")).resolves.toEqual({
+      frame,
+      selector: "xpath=(//div)[2]",
+    });
   });
 });

--- a/packages/extension/understudy/deepLocator.ts
+++ b/packages/extension/understudy/deepLocator.ts
@@ -85,7 +85,7 @@ export async function resolveLocatorTarget(
   }
 
   // No hops — delegate to XPath-aware deep resolver when needed
-  const isXPath = sel.startsWith("xpath=") || sel.startsWith("/");
+  const isXPath = sel.startsWith("xpath=") || sel.startsWith("/") || sel.startsWith("(");
   if (isXPath) {
     return resolveDeepXPathTarget(page, root, sel);
   }
@@ -219,6 +219,7 @@ async function resolveDeepXPathTarget(
 ): Promise<ResolvedLocatorTarget> {
   let path = xpathOrSelector.trim();
   if (path.startsWith("xpath=")) path = path.slice("xpath=".length).trim();
+  if (path.startsWith("(")) return { frame: root, selector: `xpath=${path}` };
   if (!path.startsWith("/")) path = "/" + path;
 
   const steps = parseXPath(path);

--- a/packages/extension/understudy/selectorResolver.test.ts
+++ b/packages/extension/understudy/selectorResolver.test.ts
@@ -3,7 +3,7 @@ import type { Frame } from "./frame.js";
 import { FrameSelectorResolver } from "./selectorResolver.js";
 
 describe("FrameSelectorResolver XPath failures", () => {
-  it("propagates main-world XPath evaluation errors", async () => {
+  it("propagates a sanitized unsupported-predicate error", async () => {
     const send = vi.fn().mockResolvedValue({
       exceptionDetails: {
         text: "Uncaught",
@@ -19,8 +19,22 @@ describe("FrameSelectorResolver XPath failures", () => {
     } as unknown as Frame;
     const resolver = new FrameSelectorResolver(frame);
 
-    await expect(resolver.evaluateXPathElement("countXPathMatchesMainWorld()", 1)).rejects.toThrow(
-      "Unsupported XPath predicate in composed-tree traversal: last()",
-    );
+    await expect(
+      resolver.evaluateXPathElement("countXPathMatchesMainWorld()", 1),
+    ).rejects.toThrow("Unsupported XPath predicate in composed-tree traversal");
+  });
+
+  it("returns null for transient main-world XPath evaluation errors", async () => {
+    const send = vi.fn().mockResolvedValue({
+      exceptionDetails: { text: "Execution context was destroyed" },
+      result: {},
+    });
+    const frame = {
+      frameId: "frame-1",
+      session: { send },
+    } as unknown as Frame;
+    const resolver = new FrameSelectorResolver(frame);
+
+    await expect(resolver.evaluateXPathElement("countXPathMatchesMainWorld()", 1)).resolves.toBeNull();
   });
 });

--- a/packages/extension/understudy/selectorResolver.test.ts
+++ b/packages/extension/understudy/selectorResolver.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Frame } from "./frame.js";
+import { FrameSelectorResolver } from "./selectorResolver.js";
+
+describe("FrameSelectorResolver XPath failures", () => {
+  it("propagates main-world XPath evaluation errors", async () => {
+    const send = vi.fn().mockResolvedValue({
+      exceptionDetails: {
+        text: "Uncaught",
+        exception: {
+          description: "Error: Unsupported XPath predicate in composed-tree traversal: last()",
+        },
+      },
+      result: {},
+    });
+    const frame = {
+      frameId: "frame-1",
+      session: { send },
+    } as unknown as Frame;
+    const resolver = new FrameSelectorResolver(frame);
+
+    await expect(resolver.evaluateXPathElement("countXPathMatchesMainWorld()", 1)).rejects.toThrow(
+      "Unsupported XPath predicate in composed-tree traversal: last()",
+    );
+  });
+});

--- a/packages/extension/understudy/selectorResolver.ts
+++ b/packages/extension/understudy/selectorResolver.ts
@@ -3,6 +3,13 @@ import type { Frame } from "./frame.js";
 import { executionContexts } from "./executionContextRegistry.js";
 import { buildLocatorInvocation } from "./locatorInvocation.js";
 
+const UNSUPPORTED_XPATH_PREDICATE = "Unsupported XPath predicate in composed-tree traversal";
+
+function isUnsupportedXPathPredicate(details: Protocol.Runtime.ExceptionDetails): boolean {
+  const description = details.exception?.description ?? details.text ?? "";
+  return description.includes(UNSUPPORTED_XPATH_PREDICATE);
+}
+
 export type SelectorQuery =
   | { kind: "css"; value: string }
   | { kind: "text"; value: string }
@@ -246,11 +253,10 @@ export class FrameSelectorResolver {
       });
 
       if (evalRes.exceptionDetails) {
-        throw new Error(
-          evalRes.exceptionDetails.exception?.description ??
-            evalRes.exceptionDetails.text ??
-            "XPath evaluation failed",
-        );
+        if (isUnsupportedXPathPredicate(evalRes.exceptionDetails)) {
+          throw new Error(UNSUPPORTED_XPATH_PREDICATE);
+        }
+        return 0;
       }
 
       const num =
@@ -260,7 +266,8 @@ export class FrameSelectorResolver {
       if (!Number.isFinite(num)) return 0;
       return Math.max(0, Math.floor(num));
     } catch (error) {
-      throw error instanceof Error ? error : new Error(String(error));
+      if (error instanceof Error && error.message === UNSUPPORTED_XPATH_PREDICATE) throw error;
+      return 0;
     }
   }
 
@@ -337,21 +344,25 @@ export class FrameSelectorResolver {
     contextId: Protocol.Runtime.ExecutionContextId,
   ): Promise<ResolvedNode | null> {
     const session = this.frame.session;
-    const evalRes = await session.send<Protocol.Runtime.EvaluateResponse>("Runtime.evaluate", {
-      expression,
-      contextId,
-      returnByValue: false,
-      awaitPromise: true,
-    });
+    try {
+      const evalRes = await session.send<Protocol.Runtime.EvaluateResponse>("Runtime.evaluate", {
+        expression,
+        contextId,
+        returnByValue: false,
+        awaitPromise: true,
+      });
 
-    if (evalRes.exceptionDetails) {
-      throw new Error(
-        evalRes.exceptionDetails.exception?.description ??
-          evalRes.exceptionDetails.text ??
-          "XPath evaluation failed",
-      );
+      if (evalRes.exceptionDetails) {
+        if (isUnsupportedXPathPredicate(evalRes.exceptionDetails)) {
+          throw new Error(UNSUPPORTED_XPATH_PREDICATE);
+        }
+        return null;
+      }
+      if (!evalRes.result.objectId) return null;
+      return this.resolveFromObjectId(evalRes.result.objectId);
+    } catch (error) {
+      if (error instanceof Error && error.message === UNSUPPORTED_XPATH_PREDICATE) throw error;
+      return null;
     }
-    if (!evalRes.result.objectId) return null;
-    return this.resolveFromObjectId(evalRes.result.objectId);
   }
 }

--- a/packages/extension/understudy/selectorResolver.ts
+++ b/packages/extension/understudy/selectorResolver.ts
@@ -161,7 +161,7 @@ export class FrameSelectorResolver {
         JSON.stringify(value),
         String(index),
       ]);
-      const resolved = await this.evaluateElement(expr, ctxId);
+      const resolved = await this.evaluateXPathElement(expr, ctxId);
       if (!resolved) break;
       results.push(resolved);
     }
@@ -246,7 +246,11 @@ export class FrameSelectorResolver {
       });
 
       if (evalRes.exceptionDetails) {
-        return 0;
+        throw new Error(
+          evalRes.exceptionDetails.exception?.description ??
+            evalRes.exceptionDetails.text ??
+            "XPath evaluation failed",
+        );
       }
 
       const num =
@@ -255,8 +259,8 @@ export class FrameSelectorResolver {
           : Number(evalRes.result.value);
       if (!Number.isFinite(num)) return 0;
       return Math.max(0, Math.floor(num));
-    } catch {
-      return 0;
+    } catch (error) {
+      throw error instanceof Error ? error : new Error(String(error));
     }
   }
 
@@ -326,5 +330,28 @@ export class FrameSelectorResolver {
     } catch {
       return null;
     }
+  }
+
+  async evaluateXPathElement(
+    expression: string,
+    contextId: Protocol.Runtime.ExecutionContextId,
+  ): Promise<ResolvedNode | null> {
+    const session = this.frame.session;
+    const evalRes = await session.send<Protocol.Runtime.EvaluateResponse>("Runtime.evaluate", {
+      expression,
+      contextId,
+      returnByValue: false,
+      awaitPromise: true,
+    });
+
+    if (evalRes.exceptionDetails) {
+      throw new Error(
+        evalRes.exceptionDetails.exception?.description ??
+          evalRes.exceptionDetails.text ??
+          "XPath evaluation failed",
+      );
+    }
+    if (!evalRes.result.objectId) return null;
+    return this.resolveFromObjectId(evalRes.result.objectId);
   }
 }

--- a/packages/sdk-ts/tests/integration/locatorCount.test.ts
+++ b/packages/sdk-ts/tests/integration/locatorCount.test.ts
@@ -1,16 +1,24 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { Stagehand } from "../../src/index.js";
-import { closeStagehand, createStagehand, firstPage } from "./_support.js";
+import {
+  closeStagehand,
+  createStagehand,
+  firstPage,
+  startFixtureServer,
+  type FixtureServer,
+} from "./_support.js";
 
 describe("Locator count() method tests", () => {
   let stagehand: Stagehand;
+  let fixtureServer: FixtureServer | undefined;
 
   beforeEach(async () => {
     stagehand = await createStagehand();
   });
 
   afterEach(async () => {
-    await closeStagehand(stagehand);
+    await Promise.all([closeStagehand(stagehand), fixtureServer?.close()]);
+    fixtureServer = undefined;
   });
 
   it("count() returns correct number for CSS selectors", async () => {
@@ -52,22 +60,33 @@ describe("Locator count() method tests", () => {
 
   it("preserves native XPath predicates when an unrelated shadow root exists", async () => {
     const page = await firstPage(stagehand);
-
-    await page.goto(
-      "data:text/html," +
-        encodeURIComponent(
-          '<section><div class="row">A1</div><div class="row">A2</div></section>' +
-            '<section><div class="row">B1</div><div class="row">B2</div></section>' +
-            '<div id="widget"></div>' +
-            "<script>document.getElementById('widget').attachShadow({mode: 'open'})</script>",
-        ),
+    fixtureServer = await startFixtureServer(
+      '<section><div class="row">A1</div><div class="row">A2</div></section>' +
+        '<section><div class="row">B1</div><div class="row">B2</div></section>' +
+        '<div id="widget"></div>' +
+        "<script>document.getElementById('widget').attachShadow({mode: 'open'})</script>",
     );
+    await page.goto(fixtureServer.url);
 
-    await expect(page.locator("xpath=//div[position() > 1]").count()).resolves.toBe(2);
-    await expect(page.locator("xpath=//div[position() > 1]").first().textContent()).resolves.toBe(
-      "A2",
-    );
+    await expect(page.locator("xpath=//div[2]").count()).resolves.toBe(2);
     await expect(page.locator("xpath=//div[0]").count()).resolves.toBe(0);
+    await expect(page.locator("xpath=(//div)[2]").count()).resolves.toBe(1);
+    await expect(page.locator("xpath=//div[position() > 1]").count()).rejects.toThrow(
+      "Unsupported XPath predicate in composed-tree traversal: position() > 1",
+    );
+  });
+
+  it("keeps both light and shadow DOM matches for supported XPath", async () => {
+    const page = await firstPage(stagehand);
+    fixtureServer = await startFixtureServer(
+      '<button id="light">light</button><div id="host"></div>' +
+        "<script>document.getElementById('host').attachShadow({mode: 'open'}).innerHTML=" +
+        "'<button id=\"shadow\">shadow</button>'</script>",
+    );
+    await page.goto(fixtureServer.url);
+
+    await expect(page.locator("xpath=//button").count()).resolves.toBe(2);
+    await expect(page.locator("xpath=//button").first().textContent()).resolves.toBe("light");
   });
 
   it("count() works with text selectors", async () => {

--- a/packages/sdk-ts/tests/integration/locatorCount.test.ts
+++ b/packages/sdk-ts/tests/integration/locatorCount.test.ts
@@ -71,9 +71,8 @@ describe("Locator count() method tests", () => {
     await expect(page.locator("xpath=//div[2]").count()).resolves.toBe(2);
     await expect(page.locator("xpath=//div[0]").count()).resolves.toBe(0);
     await expect(page.locator("xpath=(//div)[2]").count()).resolves.toBe(1);
-    await expect(page.locator("xpath=//div[position() > 1]").count()).rejects.toThrow(
-      "Unsupported XPath predicate in composed-tree traversal: position() > 1",
-    );
+    await expect(page.locator("xpath=//div[position() > 1]").count()).resolves.toBe(2);
+    await expect(page.locator("xpath=//button[last()]").count()).resolves.toBe(0);
   });
 
   it("keeps both light and shadow DOM matches for supported XPath", async () => {

--- a/packages/sdk-ts/tests/integration/locatorCount.test.ts
+++ b/packages/sdk-ts/tests/integration/locatorCount.test.ts
@@ -50,6 +50,26 @@ describe("Locator count() method tests", () => {
     expect(count).toBe(3);
   });
 
+  it("preserves native XPath predicates when an unrelated shadow root exists", async () => {
+    const page = await firstPage(stagehand);
+
+    await page.goto(
+      "data:text/html," +
+        encodeURIComponent(
+          '<section><div class="row">A1</div><div class="row">A2</div></section>' +
+            '<section><div class="row">B1</div><div class="row">B2</div></section>' +
+            '<div id="widget"></div>' +
+            "<script>document.getElementById('widget').attachShadow({mode: 'open'})</script>",
+        ),
+    );
+
+    await expect(page.locator("xpath=//div[position() > 1]").count()).resolves.toBe(2);
+    await expect(page.locator("xpath=//div[position() > 1]").first().textContent()).resolves.toBe(
+      "A2",
+    );
+    await expect(page.locator("xpath=//div[0]").count()).resolves.toBe(0);
+  });
+
   it("count() works with text selectors", async () => {
     const page = await firstPage(stagehand);
 


### PR DESCRIPTION
﻿## Summary

- prefer native XPath results for light-DOM matches even when the document contains a shadow root
- make the composed-tree fallback fail closed for unsupported predicates and preserve XPath index-zero semantics
- add parser-level tests and an extension-backed locator regression for an unrelated shadow root

## Why

An unrelated shadow root currently switches every XPath locator to Stagehand's subset parser. Predicates such as `position()` and `last()` are then silently ignored, so the same locator can count or click different elements depending on unrelated page content.

This keeps composed-tree lookup for selectors that need shadow traversal while preserving native XPath semantics whenever the browser can resolve a light-DOM match.

## Testing

- `focused Vitest coverage for parser, grouped XPath routing, and error propagation (7 passed)
- `oxfmt --check` on all changed files
- `oxlint` on all changed TypeScript files
- attempted `packages/sdk-ts/tests/integration/locatorCount.test.ts` with the new HTTP fixture; all 8 tests, including unchanged baselines, reach browser startup but are blocked locally because Chrome cannot resolve the extension source path under the workspace's non-ASCII parent directory (`File path cannot be resolved`). The HTTP and mixed light/shadow cases are included for CI on GitHub's ASCII workspace.

Closes #2693


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves native XPath predicate semantics when pages include unrelated shadow roots. Previously the composed-tree fallback ignored positional predicates and treated index 0 as the first match; now grouped XPaths like `(//div)[2]` and any path with positional/unsupported predicates evaluate natively, and unsupported predicates in composed traversal throw.

- Resolver: evaluate grouped `(`...`)` paths natively; if predicates are positional or unsupported, prefer native results; otherwise merge native light‑DOM results with shadow‑root matches, dedupe, and order by composed‑tree document order; distinguish empty native results from native errors before fallback.
- Parser/runtime: add an `unsupported` predicate that throws in composed traversal; keep XPath index‑zero semantics (index 0 matches nothing).
- Understudy: preserve grouped XPath strings for native evaluation; expose `evaluateXPathElement`; sanitize “Unsupported XPath predicate in composed-tree traversal” at the CDP boundary; transient main‑world errors still return null/0.
- Tests: cover parser safety, grouped routing, error propagation, native zero‑match semantics, and mixed light/shadow ordering.

**Migration**
- Locators that relied on ignored predicates or index‑0 coercion may now throw or return different counts. Update affected locators/tests to handle thrown XPath errors in `@browserbasehq/stagehand`.

<sup>Written for commit 303ed5f95589a9f5c6d8e1ab5fe037c5609318df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




