### PR TITLE
fix: publish Go releases independently

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,6 @@ jobs:
 
   publish-go:
     name: Release Go SDK
-    needs: release-typescript
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,9 +115,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: "11.10.0"
+          run_install: false
+
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: "24"
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
 
       - name: Check Go release status
         id: status

--- a/scripts/release/go-publish-status.test.ts
+++ b/scripts/release/go-publish-status.test.ts
@@ -32,9 +32,17 @@ describe("goPublishStatus", () => {
     );
   });
 
-  it("does not tag while a changeset is pending", async () => {
+  it("does not tag while a Go SDK changeset is pending", async () => {
     const repositoryRoot = await repositoryFixture();
-    await writeFile(path.join(repositoryRoot, ".changeset/release.md"), "pending\n");
+    await writeFile(
+      path.join(repositoryRoot, ".changeset/release.md"),
+      `---
+"@browserbasehq/stagehand-go": patch
+---
+
+Fix the Go SDK.
+`,
+    );
     const tagExists = vi.fn();
 
     await expect(goPublishStatus({ repositoryRoot, tagExists })).resolves.toEqual({
@@ -42,6 +50,54 @@ describe("goPublishStatus", () => {
       tag: "packages/sdk-go/v4.0.0",
     });
     expect(tagExists).not.toHaveBeenCalled();
+  });
+
+  it("ignores changesets for other packages", async () => {
+    const repositoryRoot = await repositoryFixture();
+    await writeFile(
+      path.join(repositoryRoot, ".changeset/release.md"),
+      `---
+"@browserbasehq/stagehand": patch
+---
+
+Fix the TypeScript SDK.
+`,
+    );
+    const tagExists = vi.fn(async () => false);
+
+    await expect(goPublishStatus({ repositoryRoot, tagExists })).resolves.toEqual({
+      shouldTag: true,
+      tag: "packages/sdk-go/v4.0.0",
+    });
+    expect(tagExists).toHaveBeenCalledWith("packages/sdk-go/v4.0.0");
+  });
+
+  it("ignores Go SDK mentions outside changeset frontmatter", async () => {
+    const repositoryRoot = await repositoryFixture();
+    await writeFile(
+      path.join(repositoryRoot, ".changeset/release.md"),
+      `---
+"@browserbasehq/stagehand": patch
+---
+
+Keep @browserbasehq/stagehand-go compatible.
+`,
+    );
+    const tagExists = vi.fn(async () => false);
+
+    await expect(goPublishStatus({ repositoryRoot, tagExists })).resolves.toEqual({
+      shouldTag: true,
+      tag: "packages/sdk-go/v4.0.0",
+    });
+  });
+
+  it("rejects malformed changeset frontmatter", async () => {
+    const repositoryRoot = await repositoryFixture();
+    await writeFile(path.join(repositoryRoot, ".changeset/release.md"), "not a changeset\n");
+
+    await expect(goPublishStatus({ repositoryRoot })).rejects.toThrow(
+      "release.md does not contain changeset frontmatter",
+    );
   });
 
   it("does not recreate an existing tag", async () => {

--- a/scripts/release/go-publish-status.test.ts
+++ b/scripts/release/go-publish-status.test.ts
@@ -52,6 +52,26 @@ Fix the Go SDK.
     expect(tagExists).not.toHaveBeenCalled();
   });
 
+  it("recognizes valid flow-style Changeset frontmatter", async () => {
+    const repositoryRoot = await repositoryFixture();
+    await writeFile(
+      path.join(repositoryRoot, ".changeset/release.md"),
+      `---
+{"@browserbasehq/stagehand-go": patch}
+---
+
+Fix the Go SDK.
+`,
+    );
+    const tagExists = vi.fn();
+
+    await expect(goPublishStatus({ repositoryRoot, tagExists })).resolves.toEqual({
+      shouldTag: false,
+      tag: "packages/sdk-go/v4.0.0",
+    });
+    expect(tagExists).not.toHaveBeenCalled();
+  });
+
   it("ignores changesets for other packages", async () => {
     const repositoryRoot = await repositoryFixture();
     await writeFile(
@@ -89,6 +109,7 @@ Keep @browserbasehq/stagehand-go compatible.
       shouldTag: true,
       tag: "packages/sdk-go/v4.0.0",
     });
+    expect(tagExists).toHaveBeenCalledWith("packages/sdk-go/v4.0.0");
   });
 
   it("rejects malformed changeset frontmatter", async () => {
@@ -96,7 +117,7 @@ Keep @browserbasehq/stagehand-go compatible.
     await writeFile(path.join(repositoryRoot, ".changeset/release.md"), "not a changeset\n");
 
     await expect(goPublishStatus({ repositoryRoot })).rejects.toThrow(
-      "release.md does not contain changeset frontmatter",
+      "release.md does not contain valid changeset frontmatter",
     );
   });
 

--- a/scripts/release/go-publish-status.ts
+++ b/scripts/release/go-publish-status.ts
@@ -1,3 +1,4 @@
+import parseChangeset from "@changesets/parse";
 import { execFile } from "node:child_process";
 import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
@@ -7,8 +8,6 @@ import { pathToFileURL } from "node:url";
 const execFileAsync = promisify(execFile);
 const moduleBase = "github.com/browserbase/stagehand/packages/sdk-go";
 const packageVersionPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?$/u;
-const goPackageKeyPattern =
-  /^\s*(?:"@browserbasehq\/stagehand-go"|'@browserbasehq\/stagehand-go'|@browserbasehq\/stagehand-go)\s*:/mu;
 
 export type GoPublishStatusOptions = {
   repositoryRoot?: string;
@@ -33,11 +32,13 @@ async function localTagExists(repositoryRoot: string, tag: string): Promise<bool
 }
 
 function changesetReleasesGo(contents: string, file: string): boolean {
-  const frontmatter = /^---\r?\n(?<body>[\s\S]*?)\r?\n---(?:\r?\n|$)/u.exec(contents)?.groups?.body;
-  if (frontmatter === undefined) {
-    throw new Error(`${file} does not contain changeset frontmatter`);
+  try {
+    return parseChangeset(contents).releases.some(
+      ({ name }) => name === "@browserbasehq/stagehand-go",
+    );
+  } catch (error) {
+    throw new Error(`${file} does not contain valid changeset frontmatter`, { cause: error });
   }
-  return goPackageKeyPattern.test(frontmatter);
 }
 
 async function hasPendingGoRelease(repositoryRoot: string): Promise<boolean> {

--- a/scripts/release/go-publish-status.ts
+++ b/scripts/release/go-publish-status.ts
@@ -7,6 +7,8 @@ import { pathToFileURL } from "node:url";
 const execFileAsync = promisify(execFile);
 const moduleBase = "github.com/browserbase/stagehand/packages/sdk-go";
 const packageVersionPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?$/u;
+const goPackageKeyPattern =
+  /^\s*(?:"@browserbasehq\/stagehand-go"|'@browserbasehq\/stagehand-go'|@browserbasehq\/stagehand-go)\s*:/mu;
 
 export type GoPublishStatusOptions = {
   repositoryRoot?: string;
@@ -28,6 +30,28 @@ async function localTagExists(repositoryRoot: string, tag: string): Promise<bool
     if ((error as NodeJS.ErrnoException & { code?: number }).code === 1) return false;
     throw error;
   }
+}
+
+function changesetReleasesGo(contents: string, file: string): boolean {
+  const frontmatter = /^---\r?\n(?<body>[\s\S]*?)\r?\n---(?:\r?\n|$)/u.exec(contents)?.groups?.body;
+  if (frontmatter === undefined) {
+    throw new Error(`${file} does not contain changeset frontmatter`);
+  }
+  return goPackageKeyPattern.test(frontmatter);
+}
+
+async function hasPendingGoRelease(repositoryRoot: string): Promise<boolean> {
+  const changesetDirectory = path.join(repositoryRoot, ".changeset");
+  const files = (await readdir(changesetDirectory)).filter(
+    (file) => file.endsWith(".md") && file !== "README.md",
+  );
+
+  let pending = false;
+  for (const file of files) {
+    const contents = await readFile(path.join(changesetDirectory, file), "utf8");
+    pending = changesetReleasesGo(contents, file) || pending;
+  }
+  return pending;
 }
 
 export async function goPublishStatus({
@@ -54,10 +78,7 @@ export async function goPublishStatus({
   }
 
   const tag = `packages/sdk-go/v${version}`;
-  const pendingChangesets = (await readdir(path.join(repositoryRoot, ".changeset"))).some(
-    (file) => file.endsWith(".md") && file !== "README.md",
-  );
-  if (pendingChangesets) return { shouldTag: false, tag };
+  if (await hasPendingGoRelease(repositoryRoot)) return { shouldTag: false, tag };
 
   return { shouldTag: !(await tagExists(tag)), tag };
 }

--- a/scripts/release/release-workflow.test.ts
+++ b/scripts/release/release-workflow.test.ts
@@ -1,0 +1,13 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("release workflow", () => {
+  it("does not couple the Go release to another SDK release", async () => {
+    const workflow = await readFile(path.resolve(".github/workflows/release.yml"), "utf8");
+    const publishGo = /^  publish-go:\n(?<job>(?: {4}.*\n|\n)*)/mu.exec(workflow)?.groups?.job;
+
+    expect(publishGo).toBeDefined();
+    expect(publishGo).not.toMatch(/^ {4}needs:/mu);
+  });
+});


### PR DESCRIPTION
## Summary

- run the Go SDK release job independently from the TypeScript release job
- defer Go tagging only for a pending `@browserbasehq/stagehand-go` Changeset, rather than for unrelated package Changesets
- add regression coverage for both workflow independence and package-scoped release gating

## Why

The Go V4 module path and tag-generation logic landed in #2689, but `packages/sdk-go/v4.0.0` was never created. `publish-go` depended on `release-typescript`, so recent TypeScript release failures skipped the Go job entirely. Even without that job dependency, the current status script would still skip Go because `main` contains an unrelated TypeScript Changeset.

As a result, Go users can pin a commit-derived pseudo-version but cannot install the stable release with:

```bash
go get github.com/browserbase/stagehand/packages/sdk-go/v4@v4.0.0
```

After this merges, the Go job can create the missing `packages/sdk-go/v4.0.0` tag on a `main` push without waiting for an unrelated SDK release.

## E2E Test Matrix

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `node scripts/release/go-publish-status.ts` against current `main` state | `should-tag=true`; `tag=packages/sdk-go/v4.0.0` while a TypeScript-only Changeset is present | Proves the real release input now selects the missing Go tag. |
| Isolated repository clone with prospective `packages/sdk-go/v4.0.0` tag, then `go get github.com/browserbase/stagehand/packages/sdk-go/v4@v4.0.0` from a clean consumer | Go downloaded and added `github.com/browserbase/stagehand/packages/sdk-go/v4 v4.0.0`; `go mod verify` reported `all modules verified` | Proves the exact tag name resolves as the stable V4 module without creating the public tag before review. |
| `pnpm test:unit` | 18 files and 93 tests passed | Covers all release status and workflow regression tests. |
| `pnpm check` | All 12 workspace format, lint, and typecheck tasks passed | Covers repository-wide static validation. |
| `actionlint .github/workflows/release.yml` | Exited 0 with no findings | Validates the changed GitHub Actions workflow. |
| Go SDK packages, generator, and each standalone example built/tested with Go 1.26 | SDK packages passed; all standalone examples compiled; generator tests passed | Confirms the release target remains consumable and buildable. |

The public tag itself is intentionally not created by this PR; the corrected release workflow creates it after merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish Go SDK releases independently and only block tagging when a `@browserbasehq/stagehand-go` changeset is pending. Previously `publish-go` waited on the TypeScript job and any changeset; now it runs on its own and the status script gates only on Go-specific changes.

- Removes `needs: release-typescript` from `publish-go`; sets up `pnpm`, enables Node cache, and runs `pnpm install` so the status script can execute.
- Updates `go-publish-status.ts` to use `@changesets/parse`, support block and flow frontmatter, ignore mentions outside frontmatter, and throw on malformed frontmatter.
- Adds tests for package-scoped gating, flow-style frontmatter, ignoring non-Go changesets and out-of-frontmatter mentions, malformed frontmatter rejection, and a workflow test ensuring `publish-go` has no `needs`.
- Required: when changing the Go SDK, include `@browserbasehq/stagehand-go` in changeset frontmatter and ensure the frontmatter is valid YAML or JSON.

<sup>Written for commit ca1e64dcebeaddd334ea76764296e59023ea23d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


