### PR TITLE
fix: build before release checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,8 +54,9 @@ jobs:
       - uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
 
       - run: just install
-      - run: just check
+      # Generate and format checked-in artifacts before validating the worktree.
       - run: just build
+      - run: just check
 
       - name: Create release pull request or publish TypeScript
         id: changesets


### PR DESCRIPTION
## Summary

- build generated artifacts before running release validation
- match the ordering already used by the normal CI workflow
- prevent the protocol schema generator from racing the root formatting check

## Why

The TypeScript release job ran `just check` before `just build`. During `pnpm check`, Turbo could run the root formatter while the protocol typecheck triggered a build that rewrites and formats `packages/protocol/stagehand.v4.json`. The failed release runner observed that file mid-generation and reported formatting drift even though the same commit passed normal CI, which builds first.

This keeps the same release steps and only fixes their order. It also allows downstream release jobs to proceed once the TypeScript release job succeeds; decoupling the Go release dependency remains covered separately by #2707.

## Testing

- `pnpm build`
- `git diff --exit-code -- packages/protocol/stagehand.v4.json`
- `CI=1 pnpm check`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build generated artifacts before running release validation to match CI and avoid formatting drift. Previously the release workflow ran `just check` before `just build`; now it builds first, eliminating races that flagged `packages/protocol/stagehand.v4.json` mid-generation.

- **Review notes**
  - Only changes `.github/workflows/release.yml`: run `just build` before `just check`.
  - No change to release contents or logic; aligns with normal CI and stabilizes the TypeScript release job.

<sup>Written for commit b64d1c6eccd1172afdff68377d1669f537044179. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

