### PR TITLE
fix: preserve changelogs for Changesets Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
           commit: release Stagehand packages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CHANGESETS_ACTION_PRESERVE_CHANGELOGS: "true"
 
   python-release-status:
     name: Check Python release status

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ vendor-repos/
 requirements.md
 to dos.md
 .turbo
+
+# Changesets Action reads these after the version command consolidates them.
+/packages/*/CHANGELOG.md
+/packages/integrations/*/CHANGELOG.md

--- a/scripts/release/consolidate-changelogs.test.ts
+++ b/scripts/release/consolidate-changelogs.test.ts
@@ -144,7 +144,7 @@ describe("cleanupGeneratedChangelogs", () => {
     const { directory, changelogPath } = await createTemporaryChangelog();
 
     try {
-      await cleanupGeneratedChangelogs([changelogPath], "true");
+      await cleanupGeneratedChangelogs([changelogPath], true);
 
       await expect(readFile(changelogPath, "utf8")).resolves.toBe("## 4.0.1\n");
     } finally {
@@ -152,18 +152,15 @@ describe("cleanupGeneratedChangelogs", () => {
     }
   });
 
-  it.each([undefined, "false"])(
-    "deletes package changelogs when the preserve setting is %s",
-    async (preservePackageChangelogs) => {
-      const { directory, changelogPath } = await createTemporaryChangelog();
+  it("deletes package changelogs when preservation is disabled", async () => {
+    const { directory, changelogPath } = await createTemporaryChangelog();
 
-      try {
-        await cleanupGeneratedChangelogs([changelogPath], preservePackageChangelogs);
+    try {
+      await cleanupGeneratedChangelogs([changelogPath], false);
 
-        await expect(readFile(changelogPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
-      } finally {
-        await rm(directory, { recursive: true, force: true });
-      }
-    },
-  );
+      await expect(readFile(changelogPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
 });

--- a/scripts/release/consolidate-changelogs.test.ts
+++ b/scripts/release/consolidate-changelogs.test.ts
@@ -6,6 +6,7 @@ import {
   cleanupGeneratedChangelogs,
   consolidateChangelog,
   formatPackageChangelog,
+  shouldPreservePackageChangelogs,
 } from "./consolidate-changelogs.ts";
 
 async function createTemporaryChangelog(): Promise<{
@@ -162,5 +163,15 @@ describe("cleanupGeneratedChangelogs", () => {
     } finally {
       await rm(directory, { recursive: true, force: true });
     }
+  });
+});
+
+describe("shouldPreservePackageChangelogs", () => {
+  it.each([
+    { value: "true", expected: true },
+    { value: "false", expected: false },
+    { value: undefined, expected: false },
+  ])("returns $expected for $value", ({ value, expected }) => {
+    expect(shouldPreservePackageChangelogs(value)).toBe(expected);
   });
 });

--- a/scripts/release/consolidate-changelogs.test.ts
+++ b/scripts/release/consolidate-changelogs.test.ts
@@ -1,5 +1,22 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { consolidateChangelog, formatPackageChangelog } from "./consolidate-changelogs.ts";
+import {
+  cleanupGeneratedChangelogs,
+  consolidateChangelog,
+  formatPackageChangelog,
+} from "./consolidate-changelogs.ts";
+
+async function createTemporaryChangelog(): Promise<{
+  directory: string;
+  changelogPath: string;
+}> {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "stagehand-changelog-"));
+  const changelogPath = path.join(directory, "CHANGELOG.md");
+  await writeFile(changelogPath, "## 4.0.1\n");
+  return { directory, changelogPath };
+}
 
 describe("formatPackageChangelog", () => {
   it("labels generated version headings and removes the package title", () => {
@@ -120,4 +137,33 @@ Release notes for the public SDKs.
       "The root changelog contains only part of",
     );
   });
+});
+
+describe("cleanupGeneratedChangelogs", () => {
+  it("preserves package changelogs when the release action requests it", async () => {
+    const { directory, changelogPath } = await createTemporaryChangelog();
+
+    try {
+      await cleanupGeneratedChangelogs([changelogPath], "true");
+
+      await expect(readFile(changelogPath, "utf8")).resolves.toBe("## 4.0.1\n");
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it.each([undefined, "false"])(
+    "deletes package changelogs when the preserve setting is %s",
+    async (preservePackageChangelogs) => {
+      const { directory, changelogPath } = await createTemporaryChangelog();
+
+      try {
+        await cleanupGeneratedChangelogs([changelogPath], preservePackageChangelogs);
+
+        await expect(readFile(changelogPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+      } finally {
+        await rm(directory, { recursive: true, force: true });
+      }
+    },
+  );
 });

--- a/scripts/release/consolidate-changelogs.ts
+++ b/scripts/release/consolidate-changelogs.ts
@@ -105,6 +105,10 @@ export async function cleanupGeneratedChangelogs(
   }
 }
 
+export function shouldPreservePackageChangelogs(value: string | undefined): boolean {
+  return value === "true";
+}
+
 async function checkPackageChangelogsAreTemporary(): Promise<void> {
   const existingPaths: string[] = [];
   for (const changelog of packageChangelogs) {
@@ -154,7 +158,7 @@ async function main(): Promise<void> {
   // changesets/action reads each versioned package changelog after this command exits.
   await cleanupGeneratedChangelogs(
     generated.map(({ path: generatedPath }) => generatedPath),
-    process.env.CHANGESETS_ACTION_PRESERVE_CHANGELOGS === "true",
+    shouldPreservePackageChangelogs(process.env.CHANGESETS_ACTION_PRESERVE_CHANGELOGS),
   );
 }
 

--- a/scripts/release/consolidate-changelogs.ts
+++ b/scripts/release/consolidate-changelogs.ts
@@ -138,8 +138,11 @@ async function main(): Promise<void> {
     await writeFile(rootChangelogPath, nextRootChangelog);
   }
 
-  for (const { path: generatedPath } of generated) {
-    await unlink(generatedPath);
+  // changesets/action reads each versioned package changelog after this command exits.
+  if (process.env.CHANGESETS_ACTION_PRESERVE_CHANGELOGS !== "true") {
+    for (const { path: generatedPath } of generated) {
+      await unlink(generatedPath);
+    }
   }
 }
 

--- a/scripts/release/consolidate-changelogs.ts
+++ b/scripts/release/consolidate-changelogs.ts
@@ -92,6 +92,19 @@ export function consolidateChangelog(rootChangelog: string, sections: string[]):
   return `${introduction}\n\n${additions.join("\n\n")}\n\n${history}\n`;
 }
 
+export async function cleanupGeneratedChangelogs(
+  generatedPaths: string[],
+  preservePackageChangelogs: string | undefined,
+): Promise<void> {
+  if (preservePackageChangelogs === "true") {
+    return;
+  }
+
+  for (const generatedPath of generatedPaths) {
+    await unlink(generatedPath);
+  }
+}
+
 async function checkPackageChangelogsAreTemporary(): Promise<void> {
   const existingPaths: string[] = [];
   for (const changelog of packageChangelogs) {
@@ -139,11 +152,10 @@ async function main(): Promise<void> {
   }
 
   // changesets/action reads each versioned package changelog after this command exits.
-  if (process.env.CHANGESETS_ACTION_PRESERVE_CHANGELOGS !== "true") {
-    for (const { path: generatedPath } of generated) {
-      await unlink(generatedPath);
-    }
-  }
+  await cleanupGeneratedChangelogs(
+    generated.map(({ path: generatedPath }) => generatedPath),
+    process.env.CHANGESETS_ACTION_PRESERVE_CHANGELOGS,
+  );
 }
 
 const invokedPath = process.argv[1];

--- a/scripts/release/consolidate-changelogs.ts
+++ b/scripts/release/consolidate-changelogs.ts
@@ -94,9 +94,9 @@ export function consolidateChangelog(rootChangelog: string, sections: string[]):
 
 export async function cleanupGeneratedChangelogs(
   generatedPaths: string[],
-  preservePackageChangelogs: string | undefined,
+  preservePackageChangelogs: boolean,
 ): Promise<void> {
-  if (preservePackageChangelogs === "true") {
+  if (preservePackageChangelogs) {
     return;
   }
 
@@ -154,7 +154,7 @@ async function main(): Promise<void> {
   // changesets/action reads each versioned package changelog after this command exits.
   await cleanupGeneratedChangelogs(
     generated.map(({ path: generatedPath }) => generatedPath),
-    process.env.CHANGESETS_ACTION_PRESERVE_CHANGELOGS,
+    process.env.CHANGESETS_ACTION_PRESERVE_CHANGELOGS === "true",
   );
 }
 


### PR DESCRIPTION
## Summary

- preserve generated package changelogs only while Changesets Action reads them
- ignore transient workspace changelogs so release PRs still commit only the consolidated root changelog
- cover the preserve/delete gate with focused real-filesystem regression tests

## Root cause

The custom `just _version` command runs `changeset version`, consolidates package changelogs into the root `CHANGELOG.md`, and deletes the generated package files. The pinned Changesets Action then unconditionally rereads `CHANGELOG.md` from every workspace whose version changed to construct the release PR body. That caused the release workflow to fail with `ENOENT` for `packages/sdk-go/CHANGELOG.md` after calculating 4.0.1.

The release workflow now sets a release-only flag that skips the existing deletion loop. The generated files remain available to the action but are ignored by Git, so the release branch continues to contain only the consolidated root changelog.

## Scope

The production change remains the minimum behavioral cut while retaining the pinned Changesets Action and Stagehand's root-only changelog convention. A focused cleanup helper makes the release-critical preserve/delete behavior directly testable without exporting or restructuring the full CLI entrypoint. The PR does not change SDK build artifacts or publish a package directly.

Failed run: https://github.com/browserbase/stagehand/actions/runs/31729429558/job/94545819582

## Testing

- `CI=1 pnpm check` — passed
- `pnpm exec vitest run scripts/release/consolidate-changelogs.test.ts` — 13 passed, including real-file cleanup coverage and explicit parsing coverage for `"true"`, `"false"`, and a missing environment value
- `pnpm test:unit` — 93 passed
- rehearsed the pending release with `changeset version` and the release-only preservation flag:
  - all seven version-changed workspaces retained readable 4.0.1 changelog entries
  - TypeScript, Python, and Go entries were consolidated into the root changelog
  - all seven generated package changelogs remained ignored
  - simulated `git add .` staged zero package changelogs
