### PR TITLE
docs(extension): clarify LLMParsedResponseSchema validation path

### DIFF
--- a/packages/extension/llm/schemas.ts
+++ b/packages/extension/llm/schemas.ts
@@ -156,8 +156,7 @@ export const LLMParsedResponseSchema: z.ZodType<
   LLMParsedResponse<unknown>
 > = z
   .object({
-    // TODO: wire response_model through JSON Schema so parsed data can be
-    // validated against a concrete schema instead of remaining unknown.
+    // AISdkClient validates structured output via AI SDK Output.object(response_model.schema).
     data: z.unknown(),
     usage: LLMUsageSchema.optional(),
   })


### PR DESCRIPTION
## Summary
- Replace the stale `response_model` TODO on `LLMParsedResponseSchema` with a note that `AISdkClient` already validates structured output through AI SDK `Output.object`.
- Avoid a redundant second Zod `.parse()` that can break `transform`/`pipe` schemas (per review feedback).

## Test plan
- [ ] Confirm `AISdkClient.createChatCompletion` still returns `objectResponse.output` for structured responses
- [ ] No behavior change expected beyond comment accuracy