### PR TITLE
docs(integrations): stop recommending Corepack for pnpm

### DIFF
--- a/packages/docs/v4/integrations/crewai.mdx
+++ b/packages/docs/v4/integrations/crewai.mdx
@@ -25,8 +25,8 @@ Stagehand ships this experimental integration from the repository rather than pu
 ```bash
 git clone https://github.com/browserbase/stagehand.git
 cd stagehand
-corepack pnpm@11.10.0 install --frozen-lockfile
-corepack pnpm@11.10.0 exec turbo run build \
+pnpm install --frozen-lockfile
+pnpm exec turbo run build \
   --filter @browserbasehq/stagehand-integrations
 ```
   </Step>

--- a/packages/docs/v4/integrations/eve.mdx
+++ b/packages/docs/v4/integrations/eve.mdx
@@ -23,8 +23,8 @@ Stagehand ships this experimental integration from the repository rather than pu
 ```bash
 git clone https://github.com/browserbase/stagehand.git
 cd stagehand
-corepack pnpm@11.10.0 install --frozen-lockfile
-corepack pnpm@11.10.0 exec turbo run build \
+pnpm install --frozen-lockfile
+pnpm exec turbo run build \
   --filter @browserbasehq/stagehand-integrations
 ```
   </Step>
@@ -47,7 +47,7 @@ export BROWSERBASE_API_KEY="your-browserbase-api-key"
   </Step>
   <Step title="Start Eve">
 ```bash
-corepack pnpm@11.10.0 --dir packages/integrations/eve dev
+pnpm --dir packages/integrations/eve dev
 ```
   </Step>
   <Step title="Run a browser task">

--- a/packages/docs/v4/integrations/mastra.mdx
+++ b/packages/docs/v4/integrations/mastra.mdx
@@ -23,8 +23,8 @@ Stagehand ships this experimental integration from the repository rather than pu
 ```bash
 git clone https://github.com/browserbase/stagehand.git
 cd stagehand
-corepack pnpm@11.10.0 install --frozen-lockfile
-corepack pnpm@11.10.0 exec turbo run build \
+pnpm install --frozen-lockfile
+pnpm exec turbo run build \
   --filter @browserbasehq/stagehand-integrations
 ```
   </Step>
@@ -45,7 +45,7 @@ export BROWSERBASE_API_KEY="your-browserbase-api-key"
   </Step>
   <Step title="Run a browser task">
 ```bash
-corepack pnpm@11.10.0 --dir packages/integrations/mastra start -- \
+pnpm --dir packages/integrations/mastra start -- \
   "Open https://example.com and report the page title."
 ```
   </Step>

--- a/packages/docs/v4/integrations/overview.mdx
+++ b/packages/docs/v4/integrations/overview.mdx
@@ -76,19 +76,19 @@ Do not create a new MCP process for every tool call. Doing so starts a new brows
 
 ## Run the integrations from source
 
-CrewAI, Mastra, and the Vercel AI SDK use the shared TypeScript Stagehand facade MCP server. Eve uses native in-process bindings from the same package. These integrations require Node.js 24 or newer and pnpm 11.10.0. CrewAI also requires Python 3.11–3.13 and [uv](https://docs.astral.sh/uv/).
+CrewAI, Mastra, and the Vercel AI SDK use the shared TypeScript Stagehand facade MCP server. Eve uses native in-process bindings from the same package. These integrations require Node.js 24 or newer and [pnpm](https://pnpm.io/installation) 11.10.0. CrewAI also requires Python 3.11–3.13 and [uv](https://docs.astral.sh/uv/).
 
 <Steps>
   <Step title="Clone and install Stagehand">
 ```bash
 git clone https://github.com/browserbase/stagehand.git
 cd stagehand
-corepack pnpm@11.10.0 install --frozen-lockfile
+pnpm install --frozen-lockfile
 ```
   </Step>
   <Step title="Build the shared integration package">
 ```bash
-corepack pnpm@11.10.0 exec turbo run build \
+pnpm exec turbo run build \
   --filter @browserbasehq/stagehand-integrations
 ```
   </Step>

--- a/packages/docs/v4/integrations/vercel-ai-sdk.mdx
+++ b/packages/docs/v4/integrations/vercel-ai-sdk.mdx
@@ -27,8 +27,8 @@ Stagehand ships this experimental integration from its repository and does not p
 ```bash
 git clone https://github.com/browserbase/stagehand.git
 cd stagehand
-corepack pnpm@11.10.0 install --frozen-lockfile
-corepack pnpm@11.10.0 exec turbo run build \
+pnpm install --frozen-lockfile
+pnpm exec turbo run build \
   --filter @browserbasehq/stagehand-integrations
 ```
   </Step>
@@ -49,7 +49,7 @@ export BROWSERBASE_API_KEY="your-browserbase-api-key"
   </Step>
   <Step title="Run a browser task">
 ```bash
-corepack pnpm@11.10.0 --dir packages/integrations/vercel-ai start -- \
+pnpm --dir packages/integrations/vercel-ai start -- \
   "Open https://example.com and report the page title."
 ```
   </Step>


### PR DESCRIPTION
<img width="433" height="66" alt="Screenshot 2026-08-14 at 10 09 40 PM" src="https://github.com/user-attachments/assets/b9b4783f-3c1f-451a-aa15-69fe4568b87f" />

## Summary
- Replace `corepack pnpm@11.10.0` with plain `pnpm` in the v4 integration docs (overview, Mastra, Eve, Vercel AI SDK, CrewAI).
- Link the integrations overview to the [official pnpm install docs](https://pnpm.io/installation).

pnpm now says not to install via Corepack (Node also stopped shipping Corepack from v25). We already pin `pnpm@11.10.0` via `devEngines.packageManager`, and CI uses `pnpm/action-setup`, so the docs only used Corepack as a one-shot version pin.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop recommending Corepack for `pnpm` in v4 integration docs and switch commands to plain `pnpm`. This aligns with `pnpm` guidance and Node 25 removing Corepack while keeping our version pinning and CI setup intact.

**Review notes**
- Replaced `corepack pnpm@11.10.0` with `pnpm` in `crewai.mdx`, `eve.mdx`, `mastra.mdx`, `vercel-ai-sdk.mdx`, and `overview.mdx`.
- Linked the overview to the official `pnpm` installation docs and kept the requirement at `pnpm` 11.10.0.
- No code, build, or runtime changes; docs only.

<sup>Written for commit 2efa8a946ad33c6430c4bc668aa2e4d31e2d3006. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

