### PR TITLE
feat(integrations): Claude Agent SDK harness example

### DIFF
--- a/packages/integrations/claude-code/.mcp.json
+++ b/packages/integrations/claude-code/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "stagehand": {
+      "command": "node",
+      "args": ["../core/dist/facade/stdio-server.mjs"]
+    }
+  }
+}

--- a/packages/integrations/claude-code/README.md
+++ b/packages/integrations/claude-code/README.md
@@ -1,0 +1,65 @@
+# Claude Agent SDK + Stagehand facade over MCP/stdio
+
+A runnable example embedding a Claude agent via `@anthropic-ai/claude-agent-sdk`, with the
+Stagehand facade (`run` / `snapshot` / `screenshot`) wired in as a stdio MCP server
+programmatically — install, export keys, one line to run.
+
+## Setup
+
+Use Node.js 24 or later. From the repository root, build the integrations package first:
+
+```bash
+pnpm install
+pnpm exec turbo run build --filter @browserbasehq/stagehand-integrations
+```
+
+Export credentials (Browserbase is the default and recommended backend):
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+export BROWSERBASE_API_KEY=bb_live_...
+export BROWSERBASE_PROJECT_ID=...
+```
+
+## Run
+
+```bash
+pnpm --filter @browserbasehq/stagehand-integrations-example-claude-code-facade start "Open https://example.com, snapshot it, and report the heading citing the snapshot ID."
+```
+
+| Variable                 | Purpose                                                                                          |
+| ------------------------ | ------------------------------------------------------------------------------------------------ |
+| `STAGEHAND_BROWSER`      | Browser backend. Defaults to `browserbase` when `BROWSERBASE_API_KEY` is set, otherwise `local`. |
+| `BROWSERBASE_API_KEY`    | Browserbase credential for the browser session.                                                  |
+| `BROWSERBASE_PROJECT_ID` | Optional Browserbase project.                                                                    |
+| `CLAUDE_STAGEHAND_MODEL` | Agent model; defaults to `claude-sonnet-5`.                                                      |
+| `ANTHROPIC_API_KEY`      | Claude Agent SDK credential (never forwarded to the browser).                                    |
+
+The agent is restricted to the three `mcp__stagehand__*` tools (`allowedTools` plus a
+`canUseTool` guard — headless runs hang on unanswered permission prompts otherwise), and its
+system prompt is the canonical `FACADE_AGENT_INSTRUCTIONS` imported from the facade package.
+
+## Connecting a running Claude Code CLI instead
+
+To use the facade from the interactive `claude` CLI rather than the SDK, the project-scoped
+`.mcp.json` in this directory is all that's needed — Claude Code inherits your shell
+environment, so the exports above are the only configuration:
+
+```bash
+cd packages/integrations/claude-code
+claude
+```
+
+Headless one-shot form:
+
+```bash
+claude -p "your instruction" --mcp-config .mcp.json --allowedTools "mcp__stagehand__run,mcp__stagehand__snapshot,mcp__stagehand__screenshot"
+```
+
+## Security model
+
+The `run` tool executes model-authored JavaScript inside the Stagehand browser extension's
+service worker — browser-side, never on your machine. Browserbase is the recommended isolation
+boundary: the privileged execution environment is a disposable cloud browser. The SDK example
+spawns the facade server with an explicit `STAGEHAND_*`/`BROWSERBASE_*` allowlist; your
+Anthropic credentials never reach the browser session.

--- a/packages/integrations/claude-code/package.json
+++ b/packages/integrations/claude-code/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@browserbasehq/stagehand-integrations-example-claude-code-facade",
+  "version": "4.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node src/agent.ts",
+    "test": "pnpm -w exec turbo run build --filter @browserbasehq/stagehand-integrations && vitest run",
+    "test:unit": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "catalog:",
+    "@browserbasehq/stagehand-integrations": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=24"
+  }
+}

--- a/packages/integrations/claude-code/src/agent.ts
+++ b/packages/integrations/claude-code/src/agent.ts
@@ -5,7 +5,7 @@ import {
 } from "@browserbasehq/stagehand-integrations/facade";
 import { fileURLToPath } from "node:url";
 
-import { buildAllowlistedEnv } from "./env.js";
+import { buildAllowlistedEnv } from "./env.ts";
 
 const serverPath = fileURLToPath(
   import.meta.resolve("@browserbasehq/stagehand-integrations/facade/stdio-server"),
@@ -53,8 +53,12 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch((error: unknown) => {
+if (import.meta.main) {
+  main().catch(handleFailure);
+}
+
+function handleFailure(error: unknown): void {
   // oxlint-disable-next-line no-console -- CLI example reports failures to stderr.
   console.error(error instanceof Error ? error.message : error);
   process.exitCode = 1;
-});
+}

--- a/packages/integrations/claude-code/src/agent.ts
+++ b/packages/integrations/claude-code/src/agent.ts
@@ -1,0 +1,60 @@
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import {
+  FACADE_AGENT_INSTRUCTIONS,
+  FACADE_TOOLS,
+} from "@browserbasehq/stagehand-integrations/facade";
+import { fileURLToPath } from "node:url";
+
+import { buildAllowlistedEnv } from "./env.js";
+
+const serverPath = fileURLToPath(
+  import.meta.resolve("@browserbasehq/stagehand-integrations/facade/stdio-server"),
+);
+
+export const STAGEHAND_TOOL_NAMES = FACADE_TOOLS.map((tool) => `mcp__stagehand__${tool.name}`);
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const instruction = (args[0] === "--" ? args.slice(1) : args).join(" ").trim();
+  if (!instruction) throw new Error('Usage: pnpm start "your instruction"');
+
+  const result = query({
+    prompt: instruction,
+    options: {
+      model: process.env.CLAUDE_STAGEHAND_MODEL ?? "claude-sonnet-5",
+      maxTurns: 20,
+      systemPrompt: FACADE_AGENT_INSTRUCTIONS,
+      mcpServers: {
+        stagehand: {
+          command: process.execPath,
+          args: [serverPath],
+          env: buildAllowlistedEnv(),
+        },
+      },
+      allowedTools: STAGEHAND_TOOL_NAMES,
+      // Headless runs hang on any unanswered permission prompt; allow exactly
+      // the stagehand tools and deny everything else.
+      canUseTool: async (toolName) =>
+        toolName.startsWith("mcp__stagehand__")
+          ? { behavior: "allow", updatedInput: undefined }
+          : { behavior: "deny", message: "Only stagehand browser tools are permitted." },
+    },
+  });
+
+  for await (const message of result) {
+    if (message.type === "result") {
+      if (message.subtype === "success") {
+        // oxlint-disable-next-line no-console -- CLI example prints the agent result.
+        console.log(message.result);
+        return;
+      }
+      throw new Error(`Agent did not finish: ${message.subtype}`);
+    }
+  }
+}
+
+main().catch((error: unknown) => {
+  // oxlint-disable-next-line no-console -- CLI example reports failures to stderr.
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});

--- a/packages/integrations/claude-code/src/agent.ts
+++ b/packages/integrations/claude-code/src/agent.ts
@@ -7,16 +7,18 @@ import { fileURLToPath } from "node:url";
 
 import { buildAllowlistedEnv } from "./env.ts";
 
-const serverPath = fileURLToPath(
-  import.meta.resolve("@browserbasehq/stagehand-integrations/facade/stdio-server"),
-);
-
 export const STAGEHAND_TOOL_NAMES = FACADE_TOOLS.map((tool) => `mcp__stagehand__${tool.name}`);
 
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
   const instruction = (args[0] === "--" ? args.slice(1) : args).join(" ").trim();
   if (!instruction) throw new Error('Usage: pnpm start "your instruction"');
+
+  // Resolved here (not at module load) so a missing build surfaces through
+  // handleFailure instead of an uncaught module error.
+  const serverPath = fileURLToPath(
+    import.meta.resolve("@browserbasehq/stagehand-integrations/facade/stdio-server"),
+  );
 
   const result = query({
     prompt: instruction,
@@ -51,6 +53,7 @@ async function main(): Promise<void> {
       throw new Error(`Agent did not finish: ${message.subtype}`);
     }
   }
+  throw new Error("Agent stream ended without a result message.");
 }
 
 if (import.meta.main) {

--- a/packages/integrations/claude-code/src/env.ts
+++ b/packages/integrations/claude-code/src/env.ts
@@ -1,0 +1,10 @@
+/** Only STAGEHAND_* and BROWSERBASE_* host env vars cross into the server. */
+export function buildAllowlistedEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (/^(STAGEHAND_|BROWSERBASE_)/.test(key) && value) {
+      env[key] = value;
+    }
+  }
+  return env;
+}

--- a/packages/integrations/claude-code/tests/agent.test.ts
+++ b/packages/integrations/claude-code/tests/agent.test.ts
@@ -1,0 +1,25 @@
+import { FACADE_TOOLS } from "@browserbasehq/stagehand-integrations/facade";
+import { describe, expect, it } from "vitest";
+
+import { STAGEHAND_TOOL_NAMES } from "../src/agent.js";
+import { buildAllowlistedEnv } from "../src/env.js";
+
+describe("claude-code stagehand example", () => {
+  it("allows exactly the namespaced facade tools", () => {
+    const expected = FACADE_TOOLS.map((tool) => `mcp__stagehand__${tool.name}`).sort();
+    expect([...STAGEHAND_TOOL_NAMES].sort()).toEqual(expected);
+  });
+
+  it("allowlist excludes non-STAGEHAND/BROWSERBASE host vars", () => {
+    process.env.STAGEHAND_BROWSER = "local";
+    process.env.NOT_ALLOWLISTED_SECRET = "must-not-cross";
+    try {
+      const env = buildAllowlistedEnv();
+      expect(env.STAGEHAND_BROWSER).toBe("local");
+      expect(env).not.toHaveProperty("NOT_ALLOWLISTED_SECRET");
+    } finally {
+      delete process.env.STAGEHAND_BROWSER;
+      delete process.env.NOT_ALLOWLISTED_SECRET;
+    }
+  });
+});

--- a/packages/integrations/claude-code/tests/agent.test.ts
+++ b/packages/integrations/claude-code/tests/agent.test.ts
@@ -1,8 +1,8 @@
 import { FACADE_TOOLS } from "@browserbasehq/stagehand-integrations/facade";
 import { describe, expect, it } from "vitest";
 
-import { STAGEHAND_TOOL_NAMES } from "../src/agent.js";
-import { buildAllowlistedEnv } from "../src/env.js";
+import { STAGEHAND_TOOL_NAMES } from "../src/agent.ts";
+import { buildAllowlistedEnv } from "../src/env.ts";
 
 describe("claude-code stagehand example", () => {
   it("allows exactly the namespaced facade tools", () => {

--- a/packages/integrations/claude-code/tsconfig.json
+++ b/packages/integrations/claude-code/tsconfig.json
@@ -6,5 +6,5 @@
     "moduleResolution": "nodenext",
     "skipLibCheck": true
   },
-  "include": ["extensions", "tests"]
+  "include": ["src/**/*.ts", "tests/**/*.ts", "vitest.config.ts"]
 }

--- a/packages/integrations/claude-code/tsconfig.json
+++ b/packages/integrations/claude-code/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "skipLibCheck": true
+  },
+  "include": ["extensions", "tests"]
+}

--- a/packages/integrations/claude-code/vitest.config.ts
+++ b/packages/integrations/claude-code/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+    hookTimeout: 20_000,
+    testTimeout: 20_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,6 +226,9 @@ catalogs:
     '@ai-sdk/provider':
       specifier: ^4.0.2
       version: 4.0.4
+    '@anthropic-ai/claude-agent-sdk':
+      specifier: 0.3.224
+      version: 0.3.224
     '@ast-grep/lang-go':
       specifier: 0.0.6
       version: 0.0.6
@@ -578,6 +581,25 @@ importers:
       vite:
         specifier: 8.1.3
         version: 8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+
+  packages/integrations/claude-code:
+    dependencies:
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: 'catalog:'
+        version: 0.3.224(@anthropic-ai/sdk@0.93.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
+      '@browserbasehq/stagehand-integrations':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.2
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
@@ -994,13 +1016,29 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.224':
+    resolution: {integrity: sha512-3J2uqD6quEzxDVXhD+SJuvZzK4/h4ePS1/84FOaCRCn6A2pGai0EsFshKGA0Vb1i0sOjTyiFPaaZweZHFoFSFw==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.141':
     resolution: {integrity: sha512-4iAdarJaQ+2R58s6QJswZCzUdz2WQmL5lYG7Y+FLzWbRSROFfcH0QYpmOqSaPXd2KRQhIJwEacqecDZd/Q1XKQ==}
     cpu: [x64]
     os: [darwin]
 
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.224':
+    resolution: {integrity: sha512-T2dBna5wHyPVF14qAEV5KmQOuQAPm7hGSeeYDZQBaVRGXQZOG/npwgB08ORBsGiZczKcP+0vKNWddkIx+KNWqg==}
+    cpu: [x64]
+    os: [darwin]
+
   '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.141':
     resolution: {integrity: sha512-6H1AJ/AVaWNnV22kubUPkOTRzZFH0+qP9k7WlhriHMN9gtgZcVAsITMddDeGjQsQJMCAdhXFd6sgi7TM1LdeOQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.224':
+    resolution: {integrity: sha512-hHHDFRwo8WXvx9f0V3W7qmQA1PJywKiQffUCN9Msz0MyCZrSgryrgGH8wr13kw5PlhAPkdjkbmS2YFFM8oG6EQ==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
@@ -1011,8 +1049,20 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.224':
+    resolution: {integrity: sha512-5a6HwjeXV5RPrD+J7hoOYjmjfxNGwV8+GqhjlVL80w1A/scOeMQQHzb2xcw0R2RMWmIZmpJyM7DFTKNyzGZ9zw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
   '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.141':
     resolution: {integrity: sha512-fTI1YuM4cxOa4nSgsyMAdB5ELizkWp+w5Ispo4JnnYtcczMAL4D9GBNjWPW0sUzKvjsJOUVim68SmWLWhUOpXQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.224':
+    resolution: {integrity: sha512-ewwIW8XorD5JiJCm9smoos0r3T1SuQwtYEfjVb5JmSy1LLfbvJPjL3ujgGVWnZil4E4svw7+3D5nSYCA9/DsLQ==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
@@ -1023,8 +1073,19 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.224':
+    resolution: {integrity: sha512-UwpgLmjxBqNyJfcKmj5PXHlVpYklhjkl0P+61/AQywyT3n3IeH7p2uggSzbVNLKjGO9YOmtpEgpYTARS0axU4g==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.141':
     resolution: {integrity: sha512-Wm10J6kfbufbPGFELokiJ/7Y5Oqug4Uag3HXFsV8g7TWCpaItx/oqVaJoiGptuAtXQB7xGLQVTuk082wER+Y5w==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.224':
+    resolution: {integrity: sha512-kjoao51rcpQYjco5qWAgrvSrXtKTvR7KHFSRAT/IFbnlGFK43oKuSEf/AAlE7RYF6vViSqXjArMQGEbl8vaWVw==}
     cpu: [arm64]
     os: [win32]
 
@@ -1033,10 +1094,23 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.224':
+    resolution: {integrity: sha512-qvNT/XBbEDrvYVhqUmsnpr3LUiwKzgsCkOUrNxxQWg0G27hiADXDMLrJ04z3xgoLayQMEuE3v4uGISXP+UHN5g==}
+    cpu: [x64]
+    os: [win32]
+
   '@anthropic-ai/claude-agent-sdk@0.2.141':
     resolution: {integrity: sha512-AIBacMWGcZIUcXlUoObqjwJ6pmJI3BayAqPAFXuvSq3DHJXdiuZVs7l/zTB5l3nRhRv5cqSrI2XbiDeHgZWizw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
+      zod: ^4.0.0
+
+  '@anthropic-ai/claude-agent-sdk@0.3.224':
+    resolution: {integrity: sha512-a4N8RcNf+8zqiTJjsntzJuYy3z/+J9K06/kVkZefNmAI8Yp4TmTZ+tpxUpKY8zhS8VewAxKSl9h0o/u7hKIdnA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@anthropic-ai/sdk': '>=0.93.0'
+      '@modelcontextprotocol/sdk': ^1.29.0
       zod: ^4.0.0
 
   '@anthropic-ai/sdk@0.39.0':
@@ -8325,25 +8399,49 @@ snapshots:
   '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.141':
     optional: true
 
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.224':
+    optional: true
+
   '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.141':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.224':
     optional: true
 
   '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.141':
     optional: true
 
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.224':
+    optional: true
+
   '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.141':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.224':
     optional: true
 
   '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.141':
     optional: true
 
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.224':
+    optional: true
+
   '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.141':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.224':
     optional: true
 
   '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.141':
     optional: true
 
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.224':
+    optional: true
+
   '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.141':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.224':
     optional: true
 
   '@anthropic-ai/claude-agent-sdk@0.2.141(zod@4.4.3)':
@@ -8363,6 +8461,21 @@ snapshots:
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - supports-color
+
+  '@anthropic-ai/claude-agent-sdk@0.3.224(@anthropic-ai/sdk@0.93.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.93.0(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      zod: 4.4.3
+    optionalDependencies:
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.224
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.224
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.224
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.224
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.224
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.224
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.224
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.224
 
   '@anthropic-ai/sdk@0.39.0':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,6 +30,7 @@ catalog:
   devtools-protocol: ^0.0.1657692
   chrome-launcher: ^1.2.1
   ai: ^7.0.16
+  "@anthropic-ai/claude-agent-sdk": 0.3.224
   typebox: 1.3.7
   "@earendil-works/pi-coding-agent": 0.84.2
   "@mastra/core": ^1.55.0

--- a/turbo.json
+++ b/turbo.json
@@ -93,6 +93,9 @@
     "@browserbasehq/stagehand-integrations-example-pi-facade#typecheck": {
       "dependsOn": ["^build"]
     },
+    "@browserbasehq/stagehand-integrations-example-claude-code-facade#typecheck": {
+      "dependsOn": ["^build"]
+    },
     "@browserbasehq/stagehand-docs#typecheck": {},
     "test:unit": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
Runnable project embedding a Claude agent via `@anthropic-ai/claude-agent-sdk`, with the `stagehand-facade` stdio server mounted programmatically — matching the pattern established by the evals `claude_code` harness (`query()` + `mcpServers`).

- `allowedTools` restricted to `mcp__stagehand__{run,snapshot,screenshot}` plus a `canUseTool` guard (headless runs hang on unanswered permission prompts).
- System prompt is `FACADE_AGENT_INSTRUCTIONS` imported from the facade package; server spawned with a `STAGEHAND_*`/`BROWSERBASE_*` env allowlist.
- One-line run after install + core build: `pnpm --filter @browserbasehq/stagehand-integrations-example-claude-code-facade start "your instruction"`
- Secondary README section: connecting a running Claude Code CLI via the project-scoped `.mcp.json` (verified: the CLI inherits the shell env; `${VAR}` in .mcp.json is not expanded).

Verified: contract + allowlist tests in CI; Browserbase smoke — *"The page heading is 'Example Domain', per snapshot element [0-19]"*.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a runnable Claude agent harness using `@anthropic-ai/claude-agent-sdk` that mounts the Stagehand facade MCP stdio server. Provides a one-command example and an optional `.mcp.json` for the Claude Code CLI; only `STAGEHAND_*`/`BROWSERBASE_*` env reach the browser.

- New package: `@browserbasehq/stagehand-integrations-example-claude-code-facade` (Node 24+). Run: `pnpm --filter @browserbasehq/stagehand-integrations-example-claude-code-facade start "your instruction"`. Choose model via `CLAUDE_STAGEHAND_MODEL` (default `claude-sonnet-5`).
- Spawns `@browserbasehq/stagehand-integrations/facade/stdio-server` with an env allowlist; `ANTHROPIC_API_KEY` is never forwarded.
- Restricts tools to `mcp__stagehand__{run,snapshot,screenshot}` via `allowedTools` and a deny-by-default `canUseTool`. Uses `FACADE_AGENT_INSTRUCTIONS` as the system prompt.
- `.mcp.json` enables the `claude` CLI in this directory; the CLI inherits the shell env (note: `${VAR}` is not expanded in `.mcp.json`).
- Tests cover the tool name contract and env allowlist. Robustness: resolve server path inside `main`, add `import.meta.main` guard, and exit nonzero if the agent stream ends without a result. Workspace updates add `@anthropic-ai/claude-agent-sdk` to the catalog/lockfile and a `turbo` typecheck target; no changes to other packages’ runtime behavior.

<sup>Written for commit 129610f5b49803ab50c1e1a60dc9076341cb2af8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

