### PR TITLE
feat(integrations): Codex SDK harness example

### DIFF
--- a/packages/integrations/codex/README.md
+++ b/packages/integrations/codex/README.md
@@ -56,6 +56,10 @@ codex exec \
   "your instruction"
 ```
 
+Note: the SDK's config overrides _merge_ with any `[mcp_servers]` already in your
+`~/.codex/config.toml` rather than replacing them; set `CODEX_HOME` to a scratch directory if
+you need isolation.
+
 ## Security model
 
 The `run` tool executes model-authored JavaScript inside the Stagehand browser extension's

--- a/packages/integrations/codex/README.md
+++ b/packages/integrations/codex/README.md
@@ -1,0 +1,65 @@
+# Codex SDK + Stagehand facade over MCP/stdio
+
+A runnable example embedding a Codex agent via `@openai/codex-sdk`, with the Stagehand facade
+(`run` / `snapshot` / `screenshot`) mounted as a stdio MCP server through the SDK's config
+override — install, export keys, one line to run. The SDK spawns the bundled Codex runtime;
+MCP servers are supplied config.toml-style because codex-sdk has no in-process MCP mounting
+(the same mechanism the evals codex harness uses).
+
+## Setup
+
+Use Node.js 24 or later. From the repository root, build the integrations package first:
+
+```bash
+pnpm install
+pnpm exec turbo run build --filter @browserbasehq/stagehand-integrations
+```
+
+Export credentials (Browserbase is the default and recommended backend). Codex auth comes from
+`OPENAI_API_KEY` or an existing `codex login`:
+
+```bash
+export OPENAI_API_KEY=sk-...
+export BROWSERBASE_API_KEY=bb_live_...
+export BROWSERBASE_PROJECT_ID=...
+```
+
+## Run
+
+```bash
+pnpm --filter @browserbasehq/stagehand-integrations-example-codex-facade start "Open https://example.com, snapshot it, and report the heading citing the snapshot ID."
+```
+
+| Variable                 | Purpose                                                                                                                                                       |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `STAGEHAND_BROWSER`      | Browser backend. Defaults to `browserbase` when `BROWSERBASE_API_KEY` is set, otherwise `local`.                                                              |
+| `BROWSERBASE_API_KEY`    | Browserbase credential for the browser session.                                                                                                               |
+| `BROWSERBASE_PROJECT_ID` | Optional Browserbase project.                                                                                                                                 |
+| `CODEX_STAGEHAND_MODEL`  | Optional model override; by default Codex uses its own harness-tuned model.                                                                                   |
+| `OPENAI_API_KEY`         | Codex SDK credential (never forwarded to the browser).                                                                                                        |
+| `CODEX_PATH_OVERRIDE`    | Path to a locally installed `codex` binary if your package manager skips the SDK's vendored-binary postinstall (`export CODEX_PATH_OVERRIDE=$(which codex)`). |
+
+The local sandbox stays `read-only` — all browser work happens inside the MCP server. Note
+Codex has no native turn limit; long tasks run until the model finishes.
+
+## Connecting a running Codex CLI instead
+
+To use the facade from the interactive `codex` CLI rather than the SDK, merge the
+`config.toml` in this directory into `~/.codex/config.toml` (Codex does not expand shell
+variables in config values), or pass everything per-invocation:
+
+```bash
+codex exec \
+  -c mcp_servers.stagehand.command=node \
+  -c 'mcp_servers.stagehand.args=["/absolute/path/to/packages/integrations/core/dist/facade/stdio-server.mjs"]' \
+  -c 'mcp_servers.stagehand.env={ STAGEHAND_BROWSER = "browserbase", BROWSERBASE_API_KEY = "bb_live_..." }' \
+  "your instruction"
+```
+
+## Security model
+
+The `run` tool executes model-authored JavaScript inside the Stagehand browser extension's
+service worker — browser-side, never on your machine. Browserbase is the recommended isolation
+boundary: the privileged execution environment is a disposable cloud browser. The SDK example
+spawns the facade server with an explicit `STAGEHAND_*`/`BROWSERBASE_*` allowlist; Codex's own
+model credentials never reach the browser session.

--- a/packages/integrations/codex/config.toml
+++ b/packages/integrations/codex/config.toml
@@ -1,0 +1,14 @@
+# Codex CLI MCP server entry for the Stagehand facade.
+# Merge this block into ~/.codex/config.toml (or pass per-invocation with
+# `codex -c`), adjusting the absolute path to your checkout.
+
+[mcp_servers.stagehand]
+command = "node"
+args = ["/absolute/path/to/stagehand/packages/integrations/core/dist/facade/stdio-server.mjs"]
+
+[mcp_servers.stagehand.env]
+STAGEHAND_BROWSER = "browserbase"
+# Codex does not expand shell variables in config values; paste the real keys
+# or generate this file from your environment.
+BROWSERBASE_API_KEY = "bb_live_..."
+BROWSERBASE_PROJECT_ID = "..."

--- a/packages/integrations/codex/package.json
+++ b/packages/integrations/codex/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@browserbasehq/stagehand-integrations-example-codex-facade",
+  "version": "4.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node src/agent.ts",
+    "test": "pnpm -w exec turbo run build --filter @browserbasehq/stagehand-integrations && vitest run",
+    "test:unit": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@browserbasehq/stagehand-integrations": "workspace:*",
+    "@openai/codex-sdk": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=24"
+  }
+}

--- a/packages/integrations/codex/src/agent.ts
+++ b/packages/integrations/codex/src/agent.ts
@@ -1,0 +1,82 @@
+import { Codex, type CodexOptions } from "@openai/codex-sdk";
+import { fileURLToPath } from "node:url";
+
+import { buildAllowlistedEnv } from "./env.ts";
+
+const serverPath = fileURLToPath(
+  import.meta.resolve("@browserbasehq/stagehand-integrations/facade/stdio-server"),
+);
+
+/**
+ * codex-sdk has no in-process MCP mounting; MCP servers are supplied through
+ * the config override (config.toml shape), the same mechanism the evals codex
+ * harness uses.
+ */
+export function buildCodexConfig(): NonNullable<CodexOptions["config"]> {
+  return {
+    mcp_servers: {
+      stagehand: {
+        command: process.execPath,
+        args: [serverPath],
+        env: buildAllowlistedEnv(),
+      },
+    },
+  };
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const instruction = (args[0] === "--" ? args.slice(1) : args).join(" ").trim();
+  if (!instruction) throw new Error('Usage: pnpm start "your instruction"');
+
+  const codex = new Codex({
+    ...(process.env.OPENAI_API_KEY ? { apiKey: process.env.OPENAI_API_KEY } : {}),
+    // pnpm can skip the SDK's vendored-binary postinstall; point at a locally
+    // installed codex when that happens (same escape hatch the evals harness
+    // uses).
+    ...(process.env.CODEX_PATH_OVERRIDE
+      ? { codexPathOverride: process.env.CODEX_PATH_OVERRIDE }
+      : {}),
+    config: buildCodexConfig(),
+  });
+  const thread = codex.startThread({
+    // Codex picks its own harness-tuned default model; override only via env.
+    ...(process.env.CODEX_STAGEHAND_MODEL ? { model: process.env.CODEX_STAGEHAND_MODEL } : {}),
+    // The browser work happens in the MCP server; the local sandbox can stay
+    // read-only.
+    sandboxMode: "read-only",
+    // Headless policy chosen empirically: "on-failure" lets MCP tool calls
+    // complete; "never" and "untrusted" auto-cancel them ("user cancelled
+    // MCP tool call").
+    approvalPolicy: "on-failure",
+    skipGitRepoCheck: true,
+  });
+
+  const streamed = await thread.runStreamed(instruction);
+  let finalResponse = "";
+  for await (const event of streamed.events) {
+    if (
+      event.type === "item.completed" &&
+      typeof event.item === "object" &&
+      event.item !== null &&
+      "type" in event.item &&
+      event.item.type === "agent_message" &&
+      "text" in event.item &&
+      typeof event.item.text === "string"
+    ) {
+      finalResponse = event.item.text;
+    }
+  }
+  // oxlint-disable-next-line no-console -- CLI example prints the agent result.
+  console.log(finalResponse);
+}
+
+if (import.meta.main) {
+  main().catch(handleFailure);
+}
+
+function handleFailure(error: unknown): void {
+  // oxlint-disable-next-line no-console -- CLI example reports failures to stderr.
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+}

--- a/packages/integrations/codex/src/agent.ts
+++ b/packages/integrations/codex/src/agent.ts
@@ -14,11 +14,18 @@ const serverPath = fileURLToPath(
  */
 export function buildCodexConfig(): NonNullable<CodexOptions["config"]> {
   return {
+    // Required for headless MCP calls on machines without a global
+    // approvals_reviewer: without it, tool calls die with "user cancelled
+    // MCP tool call" regardless of approvalPolicy.
+    approvals_reviewer: "auto_review",
     mcp_servers: {
       stagehand: {
         command: process.execPath,
         args: [serverPath],
         env: buildAllowlistedEnv(),
+        // Browser launches exceed the default MCP timeouts.
+        startup_timeout_sec: 60,
+        tool_timeout_sec: 300,
       },
     },
   };

--- a/packages/integrations/codex/src/env.ts
+++ b/packages/integrations/codex/src/env.ts
@@ -1,0 +1,10 @@
+/** Only STAGEHAND_* and BROWSERBASE_* host env vars cross into the server. */
+export function buildAllowlistedEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (/^(STAGEHAND_|BROWSERBASE_)/.test(key) && value) {
+      env[key] = value;
+    }
+  }
+  return env;
+}

--- a/packages/integrations/codex/tests/agent.test.ts
+++ b/packages/integrations/codex/tests/agent.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { buildCodexConfig } from "../src/agent.ts";
+import { buildAllowlistedEnv } from "../src/env.ts";
+
+describe("codex stagehand example", () => {
+  it("mounts the facade server in the config override", () => {
+    const config = buildCodexConfig() as {
+      mcp_servers: { stagehand: { command: string; args: string[]; env: Record<string, string> } };
+    };
+    expect(config.mcp_servers.stagehand.command).toBe(process.execPath);
+    expect(config.mcp_servers.stagehand.args[0]).toMatch(/facade\/stdio-server\.mjs$/);
+  });
+
+  it("allowlist excludes non-STAGEHAND/BROWSERBASE host vars", () => {
+    process.env.STAGEHAND_BROWSER = "local";
+    process.env.NOT_ALLOWLISTED_SECRET = "must-not-cross";
+    try {
+      const env = buildAllowlistedEnv();
+      expect(env.STAGEHAND_BROWSER).toBe("local");
+      expect(env).not.toHaveProperty("NOT_ALLOWLISTED_SECRET");
+    } finally {
+      delete process.env.STAGEHAND_BROWSER;
+      delete process.env.NOT_ALLOWLISTED_SECRET;
+    }
+  });
+});

--- a/packages/integrations/codex/tsconfig.json
+++ b/packages/integrations/codex/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "types": ["node"],
+    "rootDir": ".",
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts", "vitest.config.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/integrations/codex/vitest.config.ts
+++ b/packages/integrations/codex/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+    hookTimeout: 20_000,
+    testTimeout: 20_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -262,6 +262,9 @@ catalogs:
     '@modelcontextprotocol/sdk':
       specifier: 1.29.0
       version: 1.29.0
+    '@openai/codex-sdk':
+      specifier: 0.147.0
+      version: 0.147.0
     '@opentelemetry/api':
       specifier: 1.9.1
       version: 1.9.1
@@ -593,6 +596,25 @@ importers:
       '@browserbasehq/stagehand-integrations':
         specifier: workspace:*
         version: link:../core
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.2
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+
+  packages/integrations/codex:
+    dependencies:
+      '@browserbasehq/stagehand-integrations':
+        specifier: workspace:*
+        version: link:../core
+      '@openai/codex-sdk':
+        specifier: 'catalog:'
+        version: 0.147.0
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -2527,6 +2549,10 @@ packages:
     resolution: {integrity: sha512-1xCIHdSbQVF880nJ2aVWdPIsWZbSpKODwuP9y/gvtChDYhYfYEW0DKp2H8ZlctkzIjlzS/WzYmP6ZZPHIvs2Dg==}
     engines: {node: '>=18'}
 
+  '@openai/codex-sdk@0.147.0':
+    resolution: {integrity: sha512-nJL0maDBZy31uEArs+u46tW22veNdHjfs96AGaFTnI3jF+g8U+a422uaPiDZwEKmyxcNwStTRz6sIh6C7XxGFQ==}
+    engines: {node: '>=18'}
+
   '@openai/codex@0.125.0':
     resolution: {integrity: sha512-GiE9wlgL95u/5BRirY5d3EaRLU1tu7Y1R09R8lCHHVmcQdSmhS809FdPDWH3gIYHS7ZriAPqXwJ3aLA0WKl40Q==}
     engines: {node: '>=16'}
@@ -2564,6 +2590,47 @@ packages:
 
   '@openai/codex@0.125.0-win32-x64':
     resolution: {integrity: sha512-ofpOK+OWH5QFuUZ9pTM0d/PcXUXiIP5z5DpRcE9MlucJoyOl4Zy4Nu3NcuHF4YzCkZMQb6x3j0tjDEPHKqNQzw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@openai/codex@0.147.0':
+    resolution: {integrity: sha512-EQLEXecAG2ptxI7UpBMo2TR/ga5596/c/OsYF/0LoUDh5JANZ7IoGqlzBEWbuEVQ76JePIbtTW/ihCkp1a7Z3w==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  '@openai/codex@0.147.0-darwin-arm64':
+    resolution: {integrity: sha512-BEUVkiOW7kLcRyrMLfAr/h9wF8sRVJyZDy6OHtVn6QGDXiv3BvAZVTY1Pu9xF7KdIdkYXbp4uayN0aDQQaAUJw==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@openai/codex@0.147.0-darwin-x64':
+    resolution: {integrity: sha512-Tb8McE5SvJIH0Vs5R6sq7u+quiC931yan2KOOl6km1OdZ82+Wi7eF5XrSFPs5CF7xCgoIK4Vs+byMbT5hN+ZUw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@openai/codex@0.147.0-linux-arm64':
+    resolution: {integrity: sha512-SLC1JXw2TYfr/c3HhrJubyyLelq7vTOLWVmiThFA+z0+WgzCPmaseJ/kzDD3Gge/TO7fCnnj7UcPmC0d2c8XAg==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@openai/codex@0.147.0-linux-x64':
+    resolution: {integrity: sha512-0W9MBxPpWW0cSkNqrTDN2jR7rzzT7oNMhQY5446lT2Lw5cz5yhDTck4Va9rjkQEm+HlFzP/dmEMSZbXfJsINmw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@openai/codex@0.147.0-win32-arm64':
+    resolution: {integrity: sha512-e2ZstJ8zT8Rm1nvR7CUVO+Gr3cTChE41+VfOzGhynzDXEoW0wfbjUQbc2bWbh1arG94LMm4y3dqBtUIbSrfeGA==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@openai/codex@0.147.0-win32-x64':
+    resolution: {integrity: sha512-oT7Ss5fAPf2fiWE9QNURqZcQGAAawSVxmIUdgPzckq4KFZAM+pRz9JbM4Rr498CjtbNgTOjWvDJ+DXvIBSfOPA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -10302,6 +10369,10 @@ snapshots:
     dependencies:
       '@openai/codex': 0.125.0
 
+  '@openai/codex-sdk@0.147.0':
+    dependencies:
+      '@openai/codex': 0.147.0
+
   '@openai/codex@0.125.0':
     optionalDependencies:
       '@openai/codex-darwin-arm64': '@openai/codex@0.125.0-darwin-arm64'
@@ -10327,6 +10398,33 @@ snapshots:
     optional: true
 
   '@openai/codex@0.125.0-win32-x64':
+    optional: true
+
+  '@openai/codex@0.147.0':
+    optionalDependencies:
+      '@openai/codex-darwin-arm64': '@openai/codex@0.147.0-darwin-arm64'
+      '@openai/codex-darwin-x64': '@openai/codex@0.147.0-darwin-x64'
+      '@openai/codex-linux-arm64': '@openai/codex@0.147.0-linux-arm64'
+      '@openai/codex-linux-x64': '@openai/codex@0.147.0-linux-x64'
+      '@openai/codex-win32-arm64': '@openai/codex@0.147.0-win32-arm64'
+      '@openai/codex-win32-x64': '@openai/codex@0.147.0-win32-x64'
+
+  '@openai/codex@0.147.0-darwin-arm64':
+    optional: true
+
+  '@openai/codex@0.147.0-darwin-x64':
+    optional: true
+
+  '@openai/codex@0.147.0-linux-arm64':
+    optional: true
+
+  '@openai/codex@0.147.0-linux-x64':
+    optional: true
+
+  '@openai/codex@0.147.0-win32-arm64':
+    optional: true
+
+  '@openai/codex@0.147.0-win32-x64':
     optional: true
 
   '@openapi-contrib/openapi-schema-to-json-schema@3.2.0':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,6 +30,7 @@ catalog:
   devtools-protocol: ^0.0.1657692
   chrome-launcher: ^1.2.1
   ai: ^7.0.16
+  "@openai/codex-sdk": 0.147.0
   "@anthropic-ai/claude-agent-sdk": 0.3.224
   typebox: 1.3.7
   "@earendil-works/pi-coding-agent": 0.84.2

--- a/turbo.json
+++ b/turbo.json
@@ -96,6 +96,9 @@
     "@browserbasehq/stagehand-integrations-example-claude-code-facade#typecheck": {
       "dependsOn": ["^build"]
     },
+    "@browserbasehq/stagehand-integrations-example-codex-facade#typecheck": {
+      "dependsOn": ["^build"]
+    },
     "@browserbasehq/stagehand-docs#typecheck": {},
     "test:unit": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
Runnable project embedding a Codex agent via `@openai/codex-sdk` (pinned to the evals-proven 0.125.0), with the `stagehand-facade` stdio server mounted through the SDK's config override — `config: { mcp_servers: ... }`, the same mechanism the evals codex harness uses (codex-sdk has no in-process MCP mounting).

- `approvalPolicy: "on-failure"` chosen empirically: `never` and `untrusted` auto-cancel MCP tool calls ("user cancelled MCP tool call"); `on-failure` completes them. Local sandbox stays `read-only` — browser work happens in the MCP server.
- Env allowlist (`STAGEHAND_*`/`BROWSERBASE_*`) to the spawned server; Codex model default left harness-tuned (`CODEX_STAGEHAND_MODEL` to override).
- `CODEX_PATH_OVERRIDE` escape hatch (evals' `EVAL_CODEX_PATH` pattern) for package managers that skip the SDK's vendored-binary postinstall — pnpm does.
- One-line run after install + core build: `pnpm --filter @browserbasehq/stagehand-integrations-example-codex-facade start "your instruction"`
- Secondary README section: connecting a running `codex` CLI (config.toml template or per-invocation `-c` overrides).

Verified: config + allowlist tests in CI; Browserbase smoke — *"The page heading is 'Example Domain' [0-19]"* (run → snapshot sequence confirmed via event stream).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a runnable `@openai/codex-sdk` example that mounts the Stagehand facade MCP server via the SDK config override, enabling Codex-driven browser work without touching existing packages. Sets `approvals_reviewer: "auto_review"`, longer MCP timeouts, and pins `@openai/codex-sdk` to 0.147.0 so headless tool calls succeed on clean installs.

- Builds MCP config in code (`mcp_servers.stagehand` → `node <facade/stdio-server>`), allowlists only `STAGEHAND_*`/`BROWSERBASE_*` env vars, and uses `approvalPolicy: "on-failure"` with `sandboxMode: "read-only"`.
- Supports `OPENAI_API_KEY`, optional `CODEX_STAGEHAND_MODEL`, and `CODEX_PATH_OVERRIDE` for environments missing the SDK’s vendored binary. Includes a `config.toml` and CLI README for wiring a running `codex` CLI via `-c` overrides. Adds `@browserbasehq/stagehand-integrations-example-codex-facade` and a `turbo` typecheck target; tests cover MCP mounting and env allowlisting.

**Run/rollout**
- Requires Node 24+. Build `@browserbasehq/stagehand-integrations` first, then run: pnpm --filter `@browserbasehq/stagehand-integrations-example-codex-facade` start "instruction".
- Set `OPENAI_API_KEY` (or use `codex login`) and Browserbase vars: `BROWSERBASE_API_KEY`, optional `BROWSERBASE_PROJECT_ID`. Optional: `CODEX_STAGEHAND_MODEL`, `CODEX_PATH_OVERRIDE`.
- No migrations; the workspace pins `@openai/codex-sdk@0.147.0`.

<sup>Written for commit 29acbd2338cc45c6bf222643c54b23790c24e606. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

