### PR TITLE
docs: link v4 integrations overview from the v3 migration guide

### DIFF
--- a/packages/docs/v4/migrations/v3.mdx
+++ b/packages/docs/v4/migrations/v3.mdx
@@ -356,7 +356,7 @@ func actTool(ctx context.Context, client *stagehand.Stagehand, instruction strin
 Escalate on `observe()`, never on `act()`. A failed `act()` may already have clicked, submitted, or paid before the error surfaced, so retrying it can repeat the side effect. `observe()` only plans, so retrying it is free. [Cost optimization](/v4/best-practices/cost-optimization) applies the same idea to model escalation.
 </Tip>
 
-{/* TODO: Link to agent integrations overview page */}
+If you previously wrapped Stagehand in an agent framework rather than calling `agent()` directly, start from the [integrations overview](/v4/integrations/overview) for CrewAI, Deep Agents, Eve, Mastra, and the Vercel AI SDK.
 
 ## Let a coding assistant do the rest
 


### PR DESCRIPTION
## Summary
- Replace the stale `TODO: Link to agent integrations overview page` in `packages/docs/v4/migrations/v3.mdx`.
- Point readers who wrapped Stagehand in an agent framework to `/v4/integrations/overview`.

## Test plan
- [ ] Open `/v4/migrations/v3` and confirm the new sentence links to the integrations overview
- [ ] Confirm `/v4/integrations/overview` exists in the docs nav

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Links the v4 integrations overview from the v3 migration guide where a TODO placeholder existed. Previously, readers who wrapped Stagehand in an agent framework had no next step; now we direct them to /v4/integrations/overview to reduce confusion.

**Review**
- Open /v4/migrations/v3 and verify the new link points to /v4/integrations/overview.
- Confirm /v4/integrations/overview exists in the docs nav.

<sup>Written for commit 14fd17380e593d572026268e4873c36fd2b17652. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

