### PR TITLE
fix(extension): read text() from direct child text nodes

### DIFF
--- a/.changeset/xpath-text-node-predicates.md
+++ b/.changeset/xpath-text-node-predicates.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Match native XPath semantics for `text()` predicates when a shadow root routes locators through the composed-tree parser

--- a/packages/extension/dom/locatorScripts/xpathParser.ts
+++ b/packages/extension/dom/locatorScripts/xpathParser.ts
@@ -1,3 +1,12 @@
+/**
+ * Which string a text predicate reads.
+ *
+ * `self` is `.` — the string-value of the element, i.e. its whole subtree text.
+ * `text` is `text()` — the node-set of direct child text nodes, which is not the
+ * same string and does not compare the same way (see `evaluatePredicate`).
+ */
+export type XPathTextSource = "self" | "text";
+
 export type XPathPredicate =
   | { type: "index"; index: number }
   | { type: "attrEquals"; name: string; value: string; normalize?: boolean }
@@ -14,8 +23,8 @@ export type XPathPredicate =
       value: string;
       normalize?: boolean;
     }
-  | { type: "textEquals"; value: string; normalize?: boolean }
-  | { type: "textContains"; value: string; normalize?: boolean }
+  | { type: "textEquals"; value: string; normalize?: boolean; source?: XPathTextSource }
+  | { type: "textContains"; value: string; normalize?: boolean; source?: XPathTextSource }
   | { type: "and"; predicates: XPathPredicate[] }
   | { type: "or"; predicates: XPathPredicate[] }
   | { type: "not"; predicate: XPathPredicate };
@@ -39,7 +48,8 @@ export interface XPathStep {
  *  - Attribute equality predicates (`[@attr='value']`, `[@attr="value"]`)
  *  - Attribute existence (`[@attr]`)
  *  - Attribute contains/starts-with (`contains(@attr,'v')`, `starts-with(@attr,'v')`)
- *  - Text equality/contains (`[text()='v']`, `[contains(text(),'v')]`, `[.='v']`)
+ *  - Text equality/contains (`[text()='v']`, `[contains(text(),'v')]`, `[.='v']`),
+ *    where `text()` reads direct child text nodes and `.` the whole subtree
  *  - normalize-space on text/attributes (`[normalize-space(text())='v']`)
  *  - Basic boolean predicates (`and`, `or`, `not(...)`)
  *  - Multiple predicates per step (`[@class='foo'][2]`)
@@ -211,13 +221,14 @@ function parseAtomicPredicate(input: string): XPathPredicate | null {
   }
 
   const normalizeTextMatch = input.match(
-    new RegExp(`^normalize-space\\(\\s*(?:text\\(\\)|\\.)\\s*\\)\\s*=\\s*${quoted}$`),
+    new RegExp(`^normalize-space\\(\\s*(text\\(\\)|\\.)\\s*\\)\\s*=\\s*${quoted}$`),
   );
   if (normalizeTextMatch) {
     return {
       type: "textEquals",
-      value: normalizeTextMatch[1] ?? normalizeTextMatch[2] ?? "",
+      value: normalizeTextMatch[2] ?? normalizeTextMatch[3] ?? "",
       normalize: true,
+      source: textSource(normalizeTextMatch[1]),
     };
   }
 
@@ -257,21 +268,23 @@ function parseAtomicPredicate(input: string): XPathPredicate | null {
     };
   }
 
-  const textEqualsMatch = input.match(new RegExp(`^(?:text\\(\\)|\\.)\\s*=\\s*${quoted}$`));
+  const textEqualsMatch = input.match(new RegExp(`^(text\\(\\)|\\.)\\s*=\\s*${quoted}$`));
   if (textEqualsMatch) {
     return {
       type: "textEquals",
-      value: textEqualsMatch[1] ?? textEqualsMatch[2] ?? "",
+      value: textEqualsMatch[2] ?? textEqualsMatch[3] ?? "",
+      source: textSource(textEqualsMatch[1]),
     };
   }
 
   const textContainsMatch = input.match(
-    new RegExp(`^contains\\(\\s*(?:text\\(\\)|\\.)\\s*,\\s*${quoted}\\s*\\)$`),
+    new RegExp(`^contains\\(\\s*(text\\(\\)|\\.)\\s*,\\s*${quoted}\\s*\\)$`),
   );
   if (textContainsMatch) {
     return {
       type: "textContains",
-      value: textContainsMatch[1] ?? textContainsMatch[2] ?? "",
+      value: textContainsMatch[2] ?? textContainsMatch[3] ?? "",
+      source: textSource(textContainsMatch[1]),
     };
   }
 
@@ -370,8 +383,28 @@ function hasBalancedParens(input: string): boolean {
 
 const normalizeSpace = (value: string): string => value.replace(/\s+/g, " ").trim();
 
+const TEXT_NODE = 3;
+
+function textSource(token: string | undefined): XPathTextSource {
+  return token === "text()" ? "text" : "self";
+}
+
 function textValue(element: Element): string {
   return String(element.textContent ?? "");
+}
+
+/** The node-set `text()` selects: direct child text nodes, in document order. */
+function childTextValues(element: Element): string[] {
+  const values: string[] = [];
+  for (const node of Array.from(element.childNodes)) {
+    if (node.nodeType === TEXT_NODE) values.push(String(node.nodeValue ?? ""));
+  }
+  return values;
+}
+
+/** `string(node-set)` is the string-value of its first node, or `""` when empty. */
+function firstChildTextValue(element: Element): string {
+  return childTextValues(element)[0] ?? "";
 }
 
 function normalizeMaybe(value: string, normalize?: boolean): string {
@@ -411,12 +444,22 @@ export function evaluatePredicate(element: Element, predicate: XPathPredicate): 
       );
     }
     case "textEquals": {
-      const value = normalizeMaybe(textValue(element), predicate.normalize);
-      return value === normalizeMaybe(predicate.value, predicate.normalize);
+      const target = normalizeMaybe(predicate.value, predicate.normalize);
+      if (predicate.source === "text") {
+        // Comparing a node-set to a string is existential: true when any node matches.
+        // normalize-space() takes a string, so it collapses the node-set to its first node.
+        return predicate.normalize
+          ? normalizeSpace(firstChildTextValue(element)) === target
+          : childTextValues(element).some((value) => value === target);
+      }
+      return normalizeMaybe(textValue(element), predicate.normalize) === target;
     }
     case "textContains": {
-      const value = normalizeMaybe(textValue(element), predicate.normalize);
-      return value.includes(normalizeMaybe(predicate.value, predicate.normalize));
+      // contains() takes a string, so a node-set argument collapses to its first node.
+      const value = predicate.source === "text" ? firstChildTextValue(element) : textValue(element);
+      return normalizeMaybe(value, predicate.normalize).includes(
+        normalizeMaybe(predicate.value, predicate.normalize),
+      );
     }
     case "index":
       return true;

--- a/packages/extension/tests/xpath-text-predicates.test.ts
+++ b/packages/extension/tests/xpath-text-predicates.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { parseXPathSteps } from "../dom/locatorScripts/xpathParser.js";
+
+function predicatesOf(xpath: string) {
+  return parseXPathSteps(xpath)[0]?.predicates;
+}
+
+describe("parseXPathSteps text predicates", () => {
+  it("keeps text() and . apart", () => {
+    expect(predicatesOf("//button[text()='Save']")).toEqual([
+      { type: "textEquals", value: "Save", source: "text" },
+    ]);
+    expect(predicatesOf("//button[.='Save']")).toEqual([
+      { type: "textEquals", value: "Save", source: "self" },
+    ]);
+  });
+
+  it("keeps them apart inside contains() and normalize-space()", () => {
+    expect(predicatesOf("//button[contains(text(),'Sa')]")).toEqual([
+      { type: "textContains", value: "Sa", source: "text" },
+    ]);
+    expect(predicatesOf("//button[contains(.,'Sa')]")).toEqual([
+      { type: "textContains", value: "Sa", source: "self" },
+    ]);
+    expect(predicatesOf("//button[normalize-space(text())='Save']")).toEqual([
+      { type: "textEquals", value: "Save", normalize: true, source: "text" },
+    ]);
+    expect(predicatesOf("//button[normalize-space(.)='Save']")).toEqual([
+      { type: "textEquals", value: "Save", normalize: true, source: "self" },
+    ]);
+  });
+
+  it("carries the source through boolean predicates", () => {
+    expect(predicatesOf("//button[text()='Save' or .='Save']")).toEqual([
+      {
+        type: "or",
+        predicates: [
+          { type: "textEquals", value: "Save", source: "text" },
+          { type: "textEquals", value: "Save", source: "self" },
+        ],
+      },
+    ]);
+    expect(predicatesOf("//button[not(text()='Save')]")).toEqual([
+      { type: "not", predicate: { type: "textEquals", value: "Save", source: "text" } },
+    ]);
+  });
+});

--- a/packages/sdk-ts/tests/integration/locatorXPathTextPredicates.test.ts
+++ b/packages/sdk-ts/tests/integration/locatorXPathTextPredicates.test.ts
@@ -1,0 +1,73 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { Stagehand } from "../../src/index.js";
+import {
+  closeStagehand,
+  createStagehand,
+  firstPage,
+  startFixtureServer,
+  type FixtureServer,
+} from "./_support.js";
+
+// A shadow root anywhere in the document routes XPath through the composed-tree parser
+// instead of document.evaluate(), and that parser is only reachable over http: data: URLs
+// keep the native engine, so these cases have to be served to exercise it at all.
+const FIXTURE = `<!doctype html>
+<html>
+  <body>
+    <button id="wrapped"><span>Save</span></button>
+    <button id="direct">Save</button>
+    <div id="mixed">a<span>b</span></div>
+    <div id="split">x<br />y</div>
+    <div id="widget"></div>
+    <script>
+      document.getElementById("widget").attachShadow({ mode: "open" }).innerHTML =
+        "<span>unrelated widget</span>";
+    </script>
+  </body>
+</html>`;
+
+describe("XPath text() predicates with a shadow root in the document", () => {
+  let fixtureServer: FixtureServer;
+  let stagehand: Stagehand;
+
+  beforeAll(async () => {
+    fixtureServer = await startFixtureServer(FIXTURE);
+    stagehand = await createStagehand();
+  });
+
+  afterAll(async () => {
+    await closeStagehand(stagehand);
+    await fixtureServer.close();
+  });
+
+  it("reads text() from direct child text nodes only", async () => {
+    const page = await firstPage(stagehand);
+    await page.goto(fixtureServer.url, { waitUntil: "load" });
+
+    // #wrapped holds its label in a <span>, so it has no direct text child to match.
+    await expect.poll(() => page.locator("xpath=//button[text()='Save']").count()).toBe(1);
+    await expect(page.locator("xpath=//button[text()='Save']").innerHtml()).resolves.toBe("Save");
+
+    // `.` is the string-value of the element, so it still sees the whole subtree.
+    await expect(page.locator("xpath=//button[.='Save']").count()).resolves.toBe(2);
+
+    await expect(page.locator("xpath=//div[text()='a']").count()).resolves.toBe(1);
+    await expect(page.locator("xpath=//div[contains(text(),'b')]").count()).resolves.toBe(0);
+  });
+
+  it("compares a node-set existentially and collapses it inside functions", async () => {
+    const page = await firstPage(stagehand);
+    await page.goto(fixtureServer.url, { waitUntil: "load" });
+
+    // #split has two text nodes, `x` and `y`: `=` holds when either one matches.
+    await expect.poll(() => page.locator("xpath=//div[@id='split'][text()='y']").count()).toBe(1);
+
+    // contains() and normalize-space() take a string, so the node-set collapses to `x`.
+    await expect(
+      page.locator("xpath=//div[@id='split'][contains(text(),'y')]").count(),
+    ).resolves.toBe(0);
+    await expect(
+      page.locator("xpath=//div[@id='split'][normalize-space(text())='x']").count(),
+    ).resolves.toBe(1);
+  });
+});

--- a/scripts/test-integration.ts
+++ b/scripts/test-integration.ts
@@ -43,6 +43,7 @@ export const integrationTestGroups = {
     "locatorContentMethods",
     "locatorCount",
     "locatorNth",
+    "locatorXPathTextPredicates",
     "textSelectorInnermost",
   ],
   "local/locators-write": ["locatorFill", "locatorInputMethods", "locatorSelectOption"],


### PR DESCRIPTION
## why

The composed-tree XPath parser evaluates `text()` and `.` through the same helper, `element.textContent`. In XPath these are not the same thing: `.` is the string-value of the element, so it covers the whole subtree, while `text()` is the node-set of the element's **direct child text nodes**.

This parser is not a rare path. It takes over whenever the document contains a shadow root anywhere, so a single unrelated web component on the page changes what a locator matches, silently and with no error.

Measured against `document.evaluate()` on a build of `main` (`a73da68b`), fixture served over http. The only difference between a run that matches native and a run that does not is one unrelated `attachShadow()` call elsewhere in the same document:

| XPath | `document.evaluate()` | Stagehand |
| --- | --- | --- |
| `//button[text()='Save']` | 1 | 2 |
| `//div[text()='a']` | 1 | 0 |
| `//div[contains(text(),'b')]` | 0 | 1 |
| `//div[@id='split'][text()='y']` | 1 | 0 |
| `//div[@id='split'][contains(text(),'y')]` | 0 | 1 |
| `//div[@id='split'][normalize-space(text())='x']` | 1 | 0 |
| `//button[.='Save']` | 2 | 2 (control: `.` is already correct) |

Fixture: `<button id="wrapped"><span>Save</span></button>` before `<button id="direct">Save</button>`, plus `<div id="mixed">a<span>b</span></div>` and `<div id="split">x<br/>y</div>`.

The count is not the worst part. The button whose label sits inside a `<span>` comes first in document order, so `//button[text()='Save']` returns it first and `.first().click()` clicks the wrong button. Nothing throws, nothing logs, and the run continues on the wrong element. The other direction is a silent zero on markup as ordinary as `a<span>b</span>`.

## what changed

`text()` now reads its own node-set, and `.` keeps exactly the meaning it has today:

- `text()='v'` is true when **any** direct child text node equals `v`. Comparing a node-set to a string is existential in XPath.
- `contains(text(),'v')` and `normalize-space(text())='v'` read the string-value of the **first** node, because both functions take a string, so the node-set collapses.
- `.='v'`, `contains(.,'v')` and `normalize-space(.)='v'` keep reading the string-value of the element, unchanged.

Mechanically, in `packages/extension/dom/locatorScripts/xpathParser.ts`: the three patterns that accepted `(?:text\(\)|\.)` now capture which token they matched, and `textEquals` / `textContains` carry a `source: "self" | "text"` field that `evaluatePredicate` reads. The field is optional and absent means `self`, so predicates constructed anywhere else keep their current behavior. `and`, `or` and `not` carry it through without changes.

## test plan

`packages/extension/tests/xpath-text-predicates.test.ts` (new, unit): the parser keeps `text()` and `.` apart for `=`, `contains()` and `normalize-space()`, and carries the source through `or` and `not`.

`packages/sdk-ts/tests/integration/locatorXPathTextPredicates.test.ts` (new, integration): the table above against real Chrome. It has to be served over http, since `data:` URLs stay on the native engine and never reach this parser at all. Registered in `scripts/test-integration.ts` next to the other locator groups.

Both are red on `main` and green with the change. On `main` the wrong-button case fails with `expected 2 to be 1` and the silent-zero case with `expected +0 to be 1`.

Context: #1679 consolidated the parser copies and #1683 taught this one `text()`, `contains()` and `normalize-space()`. This is the same layer, one step further in.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the composed-tree XPath parser so `text()` reads only direct child text nodes. Previously it read `element.textContent` (same as `.`), causing diverging matches and wrong clicks on pages with any shadow root.

- Old: `text()` behaved like `.`. New: `text()` evaluates direct child text nodes; `.` still reads the element’s subtree string-value. This aligns with `document.evaluate()`.

- If a locator relied on `text()` to match nested text, use `.` instead.

- Adds unit and integration tests; integration runs over http and is registered in scripts/test-integration.ts.

- `text()='v'` is existential across child text nodes; `contains(text(),'v')` and `normalize-space(text())='v'` collapse to the first text node.

- The parser records whether a predicate used `text()` or `.` and preserves it through boolean operators.

<sup>Written for commit ee14180aad7812e27dcb5ecdab25126787049440. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

