### PR TITLE
fix(go): clean up invalid extension uploads

### DIFF
--- a/.changeset/clean-invalid-go-extensions.md
+++ b/.changeset/clean-invalid-go-extensions.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand-go": patch
+---
+
+Delete owned Browserbase extensions when upload response validation fails.

--- a/packages/sdk-go/browserbase_session.go
+++ b/packages/sdk-go/browserbase_session.go
@@ -99,6 +99,7 @@ func (client *browserbaseSessionClient) createSession(
 					context.WithoutCancel(ctx),
 					extensionID,
 					ownsExtension,
+					"failed to delete the Browserbase extension after upload validation failed",
 				),
 			)
 		}
@@ -117,6 +118,7 @@ func (client *browserbaseSessionClient) createSession(
 				context.WithoutCancel(ctx),
 				extensionID,
 				ownsExtension,
+				"failed to delete the Browserbase extension after a session failure",
 			),
 		)
 	}
@@ -252,14 +254,13 @@ func (client *browserbaseSessionClient) deleteExtensionBestEffort(
 	ctx context.Context,
 	extensionID string,
 	ownsExtension bool,
+	cleanupError string,
 ) error {
 	if !ownsExtension || extensionID == "" {
 		return nil
 	}
 	if err := client.api.deleteExtension(ctx, extensionID); err != nil {
-		return errors.New(
-			"failed to delete the Browserbase extension after a session failure",
-		)
+		return errors.New(cleanupError)
 	}
 	return nil
 }

--- a/packages/sdk-go/browserbase_session.go
+++ b/packages/sdk-go/browserbase_session.go
@@ -89,13 +89,19 @@ func (client *browserbaseSessionClient) createSession(
 				err,
 			)
 		}
+		if extension.ID != nil {
+			extensionID = strings.TrimSpace(*extension.ID)
+		}
 		if err := extension.validate(); err != nil {
-			return resolvedBrowserSource{}, fmt.Errorf(
-				"validate Browserbase extension upload: %w",
-				err,
+			return resolvedBrowserSource{}, errors.Join(
+				fmt.Errorf("validate Browserbase extension upload: %w", err),
+				client.deleteExtensionBestEffort(
+					context.WithoutCancel(ctx),
+					extensionID,
+					ownsExtension,
+				),
 			)
 		}
-		extensionID = strings.TrimSpace(*extension.ID)
 		if extensionID == "" {
 			return resolvedBrowserSource{}, errors.New(
 				"Browserbase extension upload returned an empty extension ID",
@@ -247,7 +253,7 @@ func (client *browserbaseSessionClient) deleteExtensionBestEffort(
 	extensionID string,
 	ownsExtension bool,
 ) error {
-	if !ownsExtension {
+	if !ownsExtension || extensionID == "" {
 		return nil
 	}
 	if err := client.api.deleteExtension(ctx, extensionID); err != nil {

--- a/packages/sdk-go/browserbase_session_test.go
+++ b/packages/sdk-go/browserbase_session_test.go
@@ -661,7 +661,10 @@ func TestBrowserbaseSessionClientCleansInvalidUploadResponse(t *testing.T) {
 
 	_, err := client.createSession(ctx, BrowserbaseLaunchOptions{})
 	if err == nil || !strings.Contains(err.Error(), "required field createdAt is missing") ||
-		!strings.Contains(err.Error(), "failed to delete the Browserbase extension") {
+		!strings.Contains(
+			err.Error(),
+			"failed to delete the Browserbase extension after upload validation failed",
+		) {
 		t.Fatalf("createSession() error = %v", err)
 	}
 	if deletedExtensionID != "ext_orphaned" {

--- a/packages/sdk-go/browserbase_session_test.go
+++ b/packages/sdk-go/browserbase_session_test.go
@@ -626,6 +626,47 @@ func TestBrowserbaseSessionClientRejectsInvalidUploadResponse(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "empty extension ID") {
 		t.Fatalf("createSession() error = %v, want empty extension ID", err)
 	}
+	if api.deleteExtensionCalls != 0 || api.createSessionCalls != 0 {
+		t.Fatalf(
+			"calls = delete %d, create %d; want zero",
+			api.deleteExtensionCalls,
+			api.createSessionCalls,
+		)
+	}
+}
+
+func TestBrowserbaseSessionClientCleansInvalidUploadResponse(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	deleteErr := errors.New("extension deletion failed")
+	deletedExtensionID := ""
+	api := &fakeBrowserbaseAPI{
+		uploadExtensionFunc: func(
+			context.Context,
+			[]byte,
+		) (browserbaseExtensionResponse, error) {
+			cancel()
+			response := validBrowserbaseExtensionResponse("ext_orphaned")
+			response.CreatedAt = nil
+			return response, nil
+		},
+		deleteExtensionFunc: func(ctx context.Context, extensionID string) error {
+			if err := ctx.Err(); err != nil {
+				t.Fatalf("deleteExtension() context error = %v", err)
+			}
+			deletedExtensionID = extensionID
+			return deleteErr
+		},
+	}
+	client := newBrowserbaseTestSessionClient(t, api)
+
+	_, err := client.createSession(ctx, BrowserbaseLaunchOptions{})
+	if err == nil || !strings.Contains(err.Error(), "required field createdAt is missing") ||
+		!strings.Contains(err.Error(), "failed to delete the Browserbase extension") {
+		t.Fatalf("createSession() error = %v", err)
+	}
+	if deletedExtensionID != "ext_orphaned" {
+		t.Fatalf("deleted extension = %q, want ext_orphaned", deletedExtensionID)
+	}
 }
 
 func TestBrowserbaseSessionClientValidatesBeforeUploadingExtension(t *testing.T) {


### PR DESCRIPTION
# why

The Go SDK validates Browserbase's extension upload response after the upload has already created an account resource. If metadata validation failed while a usable extension ID was present, `createSession` returned without deleting the owned extension.

Fixes #2725

# what changed

- Capture a non-empty uploaded extension ID before validating the remaining response metadata.
- Best-effort delete that owned extension with a non-canceled context when validation fails.
- Join cleanup failures with the original validation error.
- Avoid issuing deletion requests when the response contains no usable extension ID.
- Add a Go SDK patch changeset.

# test plan

- `go test $(go list ./... | grep -v '/examples$')` (all Go SDK packages pass)
- `go -C packages/sdk-go/internal/generator test ./...`
- `go vet` for the Go SDK and generator packages
- `gofmt -l packages/sdk-go/browserbase_session.go packages/sdk-go/browserbase_session_test.go`
- `pnpm exec tsx scripts/release/check-changesets.ts`

The full monorepo suites were also attempted on Windows. Unrelated existing failures remain in cross-platform path assertions, docs link validation, generated extension archive comparison, and the checkout-wide CRLF formatting check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deletes owned Browserbase extensions when upload response validation fails and clarifies cleanup errors. Previously, `createSession` could orphan an uploaded extension; now cleanup runs best-effort and reports the failure context.

- Capture a non-empty extension ID before validation and delete using a non-canceled context when validation fails.
- Skip deletion when there is no usable extension ID or the SDK does not own the extension.
- Join cleanup failures with the validation error and use contextual messages for validation vs. session failures.
- Add tests for invalid-response cleanup and avoiding deletes on empty IDs; add a patch changeset for `@browserbasehq/stagehand-go`.

<sup>Written for commit 5b85ccf6db57ba544966071695eaf4e329a83a82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

