### PR TITLE
docs: close browser handles in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,37 +86,45 @@ const browser = await browserbase.launch({
   apiKey: BROWSERBASE_API_KEY,
 });
 
-const stagehand = await Stagehand.create({
-  browser,
-  model: {
-    modelName: "openai/gpt-5.4-mini",
-    apiKey: OPENAI_API_KEY,
-  },
-});
+try {
+  const stagehand = await Stagehand.create({
+    browser,
+    model: {
+      modelName: "openai/gpt-5.4-mini",
+      apiKey: OPENAI_API_KEY,
+    },
+  });
 
-// Stagehand's CDP engine provides an optimized, low level interface to the browser built for automation
-const [page] = await browser.context.pages();
-await page.goto("https://github.com/browserbase");
+  try {
+    // Stagehand's CDP engine provides an optimized, low level interface to the browser built for automation
+    const [page] = await browser.context.pages();
+    await page.goto("https://github.com/browserbase");
 
-// Use act() to execute individual actions
-await stagehand.act("click on the stagehand repo");
+    // Use act() to execute individual actions
+    await stagehand.act("click on the stagehand repo");
 
-// Use observe() to see what's actionable on the page
-const { data: actions } = await stagehand.observe("find the latest PR");
+    // Use observe() to see what's actionable on the page
+    const { data: actions } = await stagehand.observe("find the latest PR");
 
-// Use locators for deterministic Playwright-style actions
-await page.locator(actions[0].selector).click();
+    // Use locators for deterministic Playwright-style actions
+    await page.locator(actions[0].selector).click();
 
-// Use extract() to get structured data from the page
-const {
-  data: { author, title },
-} = await stagehand.extract(
-  "extract the author and title of the PR",
-  z.object({
-    author: z.string().describe("The username of the PR author"),
-    title: z.string().describe("The title of the PR"),
-  }),
-);
+    // Use extract() to get structured data from the page
+    const {
+      data: { author, title },
+    } = await stagehand.extract(
+      "extract the author and title of the PR",
+      z.object({
+        author: z.string().describe("The username of the PR author"),
+        title: z.string().describe("The title of the PR"),
+      }),
+    );
+  } finally {
+    await stagehand.close();
+  }
+} finally {
+  await browser.close();
+}
 ```
 
 See the [Python](./packages/sdk-python/README.md) and [Go](./packages/sdk-go/README.md) READMEs for equivalent examples.

--- a/rules/ast-grep/example-parity.test.ts
+++ b/rules/ast-grep/example-parity.test.ts
@@ -33,6 +33,27 @@ describe("example name normalization", () => {
   });
 });
 
+describe("root README example", () => {
+  it("closes Stagehand before its owned browser on every exit path", async () => {
+    const readme = await readFile(new URL("../../README.md", import.meta.url), "utf8");
+    const source = readme.match(/## Example\s+[\s\S]*?```typescript\r?\n([\s\S]*?)\r?\n```/)?.[1];
+    expect(source, "README must contain its primary TypeScript example").toBeDefined();
+    if (!source) return;
+
+    const root = parse("typescript", source).root();
+    const browserCleanup = root.find({
+      rule: { pattern: "try { $$$BODY } finally { await browser.close() }" },
+    });
+    expect(browserCleanup, "README example must always close its browser").not.toBeNull();
+    expect(
+      browserCleanup?.find({
+        rule: { pattern: "try { $$$BODY } finally { await stagehand.close() }" },
+      }),
+      "README example must close Stagehand before its browser",
+    ).not.toBeNull();
+  });
+});
+
 describe("All language examples remain in sync", () => {
   it("provides the same examples in every SDK", async () => {
     const inventories = {


### PR DESCRIPTION
# why

The root TypeScript example launches a Browserbase session and creates a Stagehand runtime but never closes either handle. Copying the example can therefore leave remote sessions and owned extension resources alive after success or an exception.

Fixes #2726

# what changed

- Wrap Stagehand creation and use in nested `try`/`finally` blocks.
- Close Stagehand before closing the Browserbase browser handle.
- Add an AST-based regression test that extracts the primary TypeScript README example and enforces the nested cleanup order.

# test plan

- `pnpm exec vitest run rules/ast-grep/example-parity.test.ts` (11/11 tests pass)
- `pnpm lint` (passes with existing warnings)
- `pnpm exec oxfmt --check README.md rules/ast-grep/example-parity.test.ts`
- `pnpm exec vitest run rules/ast-grep` (34 pass; one unrelated Windows CRLF false positive in `stale-identity.test.ts`)

The full `pnpm test` suite was also attempted. It reaches the new regression successfully, then fails on the same unrelated Windows CRLF identity assertion and a Windows drive-path construction in the protocol browser smoke test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the README TypeScript example always closes resources. Previously it launched a `Browserbase` session and `Stagehand` runtime without closing them; now it closes `Stagehand` first, then the browser, on all exit paths to prevent orphaned remote sessions and extension resources.

- Wrap the example in nested try/finally blocks; call `stagehand.close()` before `browser.close()`.
- Add an AST-based regression test that extracts the README example and enforces this cleanup order.
- No SDK/runtime changes; docs and tests only.

<sup>Written for commit 43967aa8268bc02e5313105820a13c4c0dd9da5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

