### PR TITLE
fix(extension): initialize selectors after DOM ready

### DIFF
--- a/.changeset/fix-wait-selector-dom-ready.md
+++ b/.changeset/fix-wait-selector-dom-ready.md
@@ -1,0 +1,8 @@
+---
+"@browserbasehq/stagehand": patch
+"@browserbasehq/stagehand-go": patch
+"@browserbasehq/stagehand-python": patch
+"@browserbasehq/stagehand-extension": patch
+---
+
+Initialize selector observers after the document root becomes available.

--- a/packages/extension/dom/locatorScripts/waitForSelector.ts
+++ b/packages/extension/dom/locatorScripts/waitForSelector.ts
@@ -248,30 +248,6 @@ export function waitForSelector(
       }
     };
 
-    // Handle case where document.body is not ready yet
-    const observeRoot = document.body || document.documentElement;
-    if (!observeRoot) {
-      domReadyHandler = (): void => {
-        document.removeEventListener("DOMContentLoaded", domReadyHandler!);
-        domReadyHandler = null;
-        check();
-        setupObservers();
-      };
-      document.addEventListener("DOMContentLoaded", domReadyHandler);
-      timeoutId = setTimeout(() => {
-        if (settled) return;
-        settled = true;
-        clearTimer();
-        cleanup();
-        reject(
-          new Error(
-            `waitForSelector: Timeout ${timeout}ms exceeded waiting for "${selector}" to be ${state}`,
-          ),
-        );
-      }, timeout);
-      return;
-    }
-
     const setupObservers = (): void => {
       const root = document.body || document.documentElement;
       if (!root) return;
@@ -298,6 +274,30 @@ export function waitForSelector(
         }, 100);
       }
     };
+
+    // Handle case where document.body is not ready yet
+    const observeRoot = document.body || document.documentElement;
+    if (!observeRoot) {
+      domReadyHandler = (): void => {
+        document.removeEventListener("DOMContentLoaded", domReadyHandler!);
+        domReadyHandler = null;
+        check();
+        if (!settled) setupObservers();
+      };
+      document.addEventListener("DOMContentLoaded", domReadyHandler);
+      timeoutId = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        clearTimer();
+        cleanup();
+        reject(
+          new Error(
+            `waitForSelector: Timeout ${timeout}ms exceeded waiting for "${selector}" to be ${state}`,
+          ),
+        );
+      }, timeout);
+      return;
+    }
 
     setupObservers();
 

--- a/packages/extension/tests/wait-for-selector.test.ts
+++ b/packages/extension/tests/wait-for-selector.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { waitForSelector } from "../dom/locatorScripts/waitForSelector.js";
+
+class FakeMutationObserver {
+  static instances: FakeMutationObserver[] = [];
+
+  readonly disconnect = vi.fn();
+  readonly observe = vi.fn();
+
+  constructor(readonly callback: MutationCallback) {
+    FakeMutationObserver.instances.push(this);
+  }
+}
+
+type FakeDocument = {
+  body: object | null;
+  documentElement: object | null;
+  querySelector: ReturnType<typeof vi.fn>;
+  addEventListener: ReturnType<typeof vi.fn>;
+  removeEventListener: ReturnType<typeof vi.fn>;
+};
+
+function installDocument(): {
+  document: FakeDocument;
+  dispatchDOMContentLoaded: () => void;
+} {
+  let domContentLoadedHandler: (() => void) | undefined;
+  const document = {
+    body: null,
+    documentElement: null,
+    querySelector: vi.fn(() => null),
+    addEventListener: vi.fn((event: string, handler: () => void) => {
+      if (event === "DOMContentLoaded") domContentLoadedHandler = handler;
+    }),
+    removeEventListener: vi.fn(),
+  };
+
+  vi.stubGlobal("document", document);
+  vi.stubGlobal("MutationObserver", FakeMutationObserver);
+
+  return {
+    document,
+    dispatchDOMContentLoaded: () => {
+      expect(domContentLoadedHandler).toBeTypeOf("function");
+      domContentLoadedHandler?.();
+    },
+  };
+}
+
+describe("waitForSelector", () => {
+  afterEach(() => {
+    FakeMutationObserver.instances = [];
+    vi.unstubAllGlobals();
+  });
+
+  it("resolves immediately when the selector already matches", async () => {
+    const { document } = installDocument();
+    document.body = {};
+    document.querySelector.mockReturnValue({});
+
+    await expect(waitForSelector("#target", "attached", 100, false)).resolves.toBe(true);
+
+    expect(document.addEventListener).not.toHaveBeenCalled();
+    expect(FakeMutationObserver.instances).toHaveLength(0);
+  });
+
+  it("checks again when DOMContentLoaded creates the document root", async () => {
+    const { document, dispatchDOMContentLoaded } = installDocument();
+    const result = waitForSelector("#target", "attached", 100, false);
+
+    document.documentElement = {};
+    document.querySelector.mockReturnValue({});
+    expect(dispatchDOMContentLoaded).not.toThrow();
+
+    await expect(result).resolves.toBe(true);
+    expect(document.removeEventListener).toHaveBeenCalledWith(
+      "DOMContentLoaded",
+      expect.any(Function),
+    );
+    expect(FakeMutationObserver.instances).toHaveLength(0);
+  });
+
+  it("observes mutations after DOMContentLoaded when the selector is still absent", async () => {
+    const { document, dispatchDOMContentLoaded } = installDocument();
+    const result = waitForSelector("#target", "attached", 100, false);
+
+    document.documentElement = {};
+    dispatchDOMContentLoaded();
+
+    const observer = FakeMutationObserver.instances[0];
+    expect(observer).toBeDefined();
+    expect(observer?.observe).toHaveBeenCalledWith(document.documentElement, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ["style", "class", "hidden", "disabled"],
+    });
+
+    document.querySelector.mockReturnValue({});
+    observer?.callback([], observer as unknown as MutationObserver);
+
+    await expect(result).resolves.toBe(true);
+    expect(observer?.disconnect).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
# why

`waitForSelector()` registers a `DOMContentLoaded` handler when the document root is not ready, but that handler referenced `setupObservers` before its `const` initializer could execute. The handler therefore threw a temporal-dead-zone `ReferenceError` and left the selector wait to time out.

Fixes #2731

# what changed

- Initialize the observer setup closure before the early document-ready branch.
- Skip observer installation when the DOM-ready recheck already satisfies the selector.
- Add focused coverage for immediate matches, matches present at DOM ready, and matches delivered by a later mutation.
- Add patch Changesets for the extension and the SDKs that embed it.

# test plan

- `vitest run packages/extension/tests/wait-for-selector.test.ts --reporter=verbose` (3 passed)
- `vitest run packages/extension/tests packages/extension/understudy --reporter=dot` (46 files passed; 336 passed, 10 existing TODOs)
- `vite build --config packages/extension/vite.config.ts`
- `oxfmt --check` on changed files
- `oxlint` on changed TypeScript files
- `tsx scripts/release/check-changesets.ts`
- Go SDK tests excluding the intentionally separate examples package (passed)
- Go generator tests (passed)
- Full Python suite attempted: 455 passed, 2 skipped; only the two pre-existing Windows path assertions tracked by #2733 failed
- Full JavaScript suite attempted: stopped on the pre-existing Windows CRLF/path failures tracked by #2734/#2735 and the existing protocol smoke `C:\C:\...` path construction


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a temporal-dead-zone crash in `waitForSelector()` when the document root is not ready. Previously the DOMContentLoaded handler referenced an uninitialized closure, throwing and causing waits to time out; now it initializes the observer setup earlier and rechecks on DOM ready, installing observers only if still needed.

- Define the observer setup before the early DOM-ready branch; on DOMContentLoaded, recheck the selector and skip observers when already satisfied.
- Add focused tests for immediate matches, DOM-ready matches, and mutation-driven matches.
- Publish patch releases for `@browserbasehq/stagehand`, `@browserbasehq/stagehand-go`, `@browserbasehq/stagehand-python`, and `@browserbasehq/stagehand-extension`; no API changes or migration required.

<sup>Written for commit c0711e21fd9794d065ecda78453bde0c58536296. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

