### PR TITLE
test(python): make browser path assertions portable

### DIFF
--- a/packages/sdk-python/tests/test_browser.py
+++ b/packages/sdk-python/tests/test_browser.py
@@ -347,17 +347,18 @@ async def test_launch_configures_downloads_on_the_root_session(
         captured.append(options)
         return source
 
+    downloads_path = Path("/tmp/downloads")
     monkeypatch.setattr(browser, "_launch_local_browser", launch)
     handle = await local_browser.launch(
-        downloads_path=Path("/tmp/downloads"),
+        downloads_path=downloads_path,
         accept_downloads=True,
     )
 
-    assert captured[-1].downloads_path == "/tmp/downloads"
+    assert captured[-1].downloads_path == str(downloads_path)
     assert fake_cdp.instances[-1].commands == [
         (
             "Browser.setDownloadBehavior",
-            {"behavior": "allow", "downloadPath": "/tmp/downloads"},
+            {"behavior": "allow", "downloadPath": str(downloads_path)},
         )
     ]
     await handle.close()
@@ -445,7 +446,8 @@ async def test_connect_uses_extension_id_or_packaged_extension_and_never_owns_so
     packaged = await local_browser.connect(cdp_url="http://browser")
     arguments = fake_cdp.connect_arguments[-1]
     assert arguments["extension_id"] is None
-    assert str(arguments["extension_dir"]).endswith(("stagehand/_extension", "extension/dist"))
+    extension_parts = Path(cast(str, arguments["extension_dir"])).parts
+    assert extension_parts[-2:] in {("stagehand", "_extension"), ("extension", "dist")}
     assert arguments["service_worker_url_includes"] == "service-worker.js"
     assert set(arguments) == {
         "cdp_url",


### PR DESCRIPTION
# why

Two Python browser tests compared native filesystem paths to hard-coded POSIX strings. Valid Windows paths therefore failed the SDK test gate even though the production browser code correctly preserved the platform-native representation.

Fixes #2733

# what changed

- Reuse the caller's `Path` conversion when asserting the forwarded downloads path and CDP command.
- Compare the packaged extension directory by its final path components instead of slash-delimited string suffixes.
- Keep production code unchanged; this is a test-portability correction only.

# test plan

- `pytest tests/test_browser.py` (32 passed on Windows)
- Full Python SDK suite (457 passed, 2 skipped on Windows)
- Generated-model freshness check
- Ruff format check
- Ruff lint check
- `git diff --check`
- `ty check` was attempted; it reaches one unrelated pre-existing Windows diagnostic for `os.mkfifo` in `tests/test_locator.py`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Python browser tests path-portable so Windows passes. Previously tests compared hard-coded POSIX strings; now they use the caller’s `Path` and path components. No production behavior changes.

**Review notes**
- Assert `downloads_path` via `str(downloads_path)` and mirror that in the CDP command payload.
- Validate the packaged extension directory by its last two path components instead of a slash-delimited suffix.
- Only `packages/sdk-python/tests/test_browser.py` changed.

**Rollout**
- Tests only; no migration or configuration changes.

<sup>Written for commit 1cdd93fa6c9328550fb9165f3db2b61bc9a495d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

