### PR TITLE
test(evals): make compiled path expectation portable

### DIFF
--- a/packages/evals/tests/runtimePaths.test.ts
+++ b/packages/evals/tests/runtimePaths.test.ts
@@ -15,7 +15,7 @@ describe("resolveRuntimeTasksRoot", () => {
     const caller = "/repo/packages/evals/dist/cli/cli.js";
 
     expect(resolveRuntimeTasksRoot(caller, packageRoot)).toBe(
-      path.join(packageRoot, "dist", "esm", "tasks"),
+      path.posix.join(packageRoot, "dist", "esm", "tasks"),
     );
   });
 });


### PR DESCRIPTION
# why

The compiled runtime-path test uses POSIX fixture paths, and `resolveRuntimeTasksRoot()` intentionally returns a forward-slash path for compiled callers. Building the expected value with host-native `path.join()` made that assertion fail deterministically on Windows.

Fixes #2734

# what changed

- Build the compiled fixture expectation with `path.posix.join()`.
- Preserve the existing host-native expectation for the source-mode branch.
- Leave runtime behavior unchanged.

# test plan

- `vitest run packages/evals/tests/runtimePaths.test.ts --reporter=verbose` (2 passed on Windows)
- Evals TypeScript type-check
- Targeted Oxfmt and Oxlint checks
- `git diff --check`
- Full evals suite attempted: 414 passed; 6 unrelated tests timed out under the aggregate Windows run.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the compiled runtime-path test portable by building the expected compiled path with path.posix.join() to match forward-slash outputs. Previously the test used host-native path.join(), which produced backslashes on Windows and failed deterministically; the source-mode branch still uses host-native joining and runtime behavior is unchanged.

<sup>Written for commit 49fef00c692acf44569d9a9ad446e10befcdec2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

