### PR TITLE
test: handle CRLF in stale identity guard

### DIFF
--- a/rules/ast-grep/stale-identity.test.ts
+++ b/rules/ast-grep/stale-identity.test.ts
@@ -14,7 +14,28 @@ const allowedLegacyCleanupMatches = new Set([
   `packages/sdk-python/tests/test_build.py:"${legacyDistributionName}-0.1.0.tar.gz",`,
 ]);
 
+const findUnexpectedMatches = (stdout: string): string[] =>
+  stdout
+    .trim()
+    .split(/\r?\n/u)
+    .filter(Boolean)
+    .flatMap((match) => {
+      const parsed = /^(?<file>[^:]+):\d+:(?<contents>.*)$/u.exec(match)?.groups;
+      if (!parsed?.file || parsed.contents === undefined) return [match];
+      const identity = `${parsed.file}:${parsed.contents.trim()}`;
+      return allowedLegacyCleanupMatches.has(identity) ? [] : [match];
+    });
+
 describe("Retired package identities", () => {
+  it("accepts exact legacy cleanup matches with CRLF line endings", () => {
+    const output = [
+      `packages/sdk-python/scripts/build.py:18:        "${legacyDistributionName}-*.whl",`,
+      `packages/sdk-python/tests/test_build.py:13:        "${legacyDistributionName}-0.1.0.tar.gz",`,
+    ].join("\r\n");
+
+    expect(findUnexpectedMatches(output)).toEqual([]);
+  });
+
   it("does not reintroduce a Stagehand v4 package or test identity", async () => {
     const pattern = ["stagehand", "[-_]v4"].join("");
     let stdout = "";
@@ -27,16 +48,7 @@ describe("Retired package identities", () => {
       if (grepError.code !== 1) throw error;
       stdout = grepError.stdout ?? "";
     }
-    const unexpected = stdout
-      .trim()
-      .split("\n")
-      .filter(Boolean)
-      .flatMap((match) => {
-        const parsed = /^(?<file>[^:]+):\d+:(?<contents>.*)$/u.exec(match)?.groups;
-        if (!parsed?.file || parsed.contents === undefined) return [match];
-        const identity = `${parsed.file}:${parsed.contents.trim()}`;
-        return allowedLegacyCleanupMatches.has(identity) ? [] : [match];
-      });
+    const unexpected = findUnexpectedMatches(stdout);
 
     expect(
       unexpected,

--- a/rules/ast-grep/stale-identity.test.ts
+++ b/rules/ast-grep/stale-identity.test.ts
@@ -17,6 +17,7 @@ const allowedLegacyCleanupMatches = new Set([
 const findUnexpectedMatches = (stdout: string): string[] =>
   stdout
     .trim()
+    // Windows git writes CRLF; retaining the carriage return breaks the anchored parser below.
     .split(/\r?\n/u)
     .filter(Boolean)
     .flatMap((match) => {


### PR DESCRIPTION
# why

The stale-identity guard split `git grep` output only on `\n`. Windows CRLF output therefore left a trailing `\r` on every line except the last, causing explicitly allowed legacy cleanup strings to be reported as forbidden identities.

Fixes #2735

# what changed

- Split grep output on both LF and CRLF line endings.
- Extract the match parser so the real guard and regression fixture exercise the same behavior.
- Add a synthetic CRLF regression test that also runs on non-Windows CI.

# test plan

- `vitest run rules/ast-grep/stale-identity.test.ts --reporter=verbose` (2 passed on Windows)
- Full `rules/ast-grep` suite (7 files passed, 35 tests passed)
- Targeted Oxfmt and Oxlint checks
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parses CRLF line endings in the stale identity guard test to avoid Windows-only false positives. Previously we split `git grep` output on LF only; now we split on LF or CRLF via a shared parser.

- Extracts and reuses `findUnexpectedMatches` to parse matches consistently.
- Adds a CRLF regression test that runs on all CI platforms and documents the parsing rationale.
- No behavior change for LF-only environments; reduces false positives on Windows.

<sup>Written for commit 36a4c3fee37cfba3b6e103fa2bc018376bf9a22d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

