### PR TITLE
docs(v4): clarify Stagehand browser ownership

### DIFF
--- a/packages/docs/tests/sdk-reference.test.ts
+++ b/packages/docs/tests/sdk-reference.test.ts
@@ -466,6 +466,8 @@ describe("SDK reference surface", () => {
         closeSectionStart,
         nextSectionStart === -1 ? undefined : nextSectionStart,
       );
+      expect(closeSection).toContain(lifecycle.closeStagehand);
+      expect(closeSection).toContain(lifecycle.closeBrowser);
       expect(closeSection.indexOf(lifecycle.closeBrowser)).toBeGreaterThan(
         closeSection.indexOf(lifecycle.closeStagehand),
       );

--- a/packages/docs/tests/sdk-reference.test.ts
+++ b/packages/docs/tests/sdk-reference.test.ts
@@ -430,6 +430,7 @@ describe("SDK reference surface", () => {
     const cases = [
       {
         language: "TypeScript",
+        closeHeading: "## close()",
         inlineLaunch: "browser: await localBrowser.launch()",
         launch: "const browser = await localBrowser.launch();",
         create: "Stagehand.create({ browser })",
@@ -438,6 +439,7 @@ describe("SDK reference surface", () => {
       },
       {
         language: "Python",
+        closeHeading: "## close()",
         inlineLaunch: "browser=await local_browser.launch()",
         launch: "browser = await local_browser.launch()",
         create: "Stagehand.create(browser=browser)",
@@ -454,10 +456,28 @@ describe("SDK reference surface", () => {
       expect(tab).toContain(lifecycle.closeStagehand);
       expect(tab).toContain(lifecycle.closeBrowser);
       expect(tab).toContain("The browser handle stays open");
-      expect(tab.indexOf(lifecycle.closeBrowser)).toBeGreaterThan(
-        tab.indexOf(lifecycle.closeStagehand),
+      const closeSectionStart = tab.indexOf(lifecycle.closeHeading);
+      expect(closeSectionStart).toBeGreaterThanOrEqual(0);
+      const nextSectionStart = tab.indexOf(
+        "\n## ",
+        closeSectionStart + lifecycle.closeHeading.length,
+      );
+      const closeSection = tab.slice(
+        closeSectionStart,
+        nextSectionStart === -1 ? undefined : nextSectionStart,
+      );
+      expect(closeSection.indexOf(lifecycle.closeBrowser)).toBeGreaterThan(
+        closeSection.indexOf(lifecycle.closeStagehand),
       );
     }
+
+    const goTab = languageTabSource(content, "Go");
+    const deferBrowser = "defer browser.Close(ctx)";
+    const deferStagehand = "defer client.Close(ctx)";
+    expect(goTab).toContain(deferBrowser);
+    expect(goTab).toContain(deferStagehand);
+    expect(goTab).toContain("The `Browser` handle stays open");
+    expect(goTab.indexOf(deferBrowser)).toBeLessThan(goTab.indexOf(deferStagehand));
   });
 
   it("resolves every internal v4 reference link and anchor", async () => {

--- a/packages/docs/tests/sdk-reference.test.ts
+++ b/packages/docs/tests/sdk-reference.test.ts
@@ -425,6 +425,41 @@ describe("SDK reference surface", () => {
     expect(problems, "Every supported value must appear in its owning language tab").toEqual([]);
   });
 
+  it("documents caller-owned browser cleanup in Stagehand lifecycle examples", async () => {
+    const content = await readFile(resolve(REFERENCE_ROOT, "stagehand.mdx"), "utf8");
+    const cases = [
+      {
+        language: "TypeScript",
+        inlineLaunch: "browser: await localBrowser.launch()",
+        launch: "const browser = await localBrowser.launch();",
+        create: "Stagehand.create({ browser })",
+        closeStagehand: "await stagehand.close();",
+        closeBrowser: "await browser.close();",
+      },
+      {
+        language: "Python",
+        inlineLaunch: "browser=await local_browser.launch()",
+        launch: "browser = await local_browser.launch()",
+        create: "Stagehand.create(browser=browser)",
+        closeStagehand: "await stagehand.close()",
+        closeBrowser: "await browser.close()",
+      },
+    ] as const;
+
+    for (const lifecycle of cases) {
+      const tab = languageTabSource(content, lifecycle.language);
+      expect(tab).not.toContain(lifecycle.inlineLaunch);
+      expect(tab).toContain(lifecycle.launch);
+      expect(tab).toContain(lifecycle.create);
+      expect(tab).toContain(lifecycle.closeStagehand);
+      expect(tab).toContain(lifecycle.closeBrowser);
+      expect(tab).toContain("The browser handle stays open");
+      expect(tab.indexOf(lifecycle.closeBrowser)).toBeGreaterThan(
+        tab.indexOf(lifecycle.closeStagehand),
+      );
+    }
+  });
+
   it("resolves every internal v4 reference link and anchor", async () => {
     const contentPages = (await listFiles(V4_DOCS_ROOT, shouldInspectDocsDirectory)).filter(
       (filePath) => extname(filePath) === ".mdx",

--- a/packages/docs/v4/reference/stagehand.mdx
+++ b/packages/docs/v4/reference/stagehand.mdx
@@ -4,7 +4,7 @@ description: "Initialize a browser session and run AI-powered actions, observati
 icon: "hand-horns"
 ---
 
-`Stagehand` owns the browser connection and exposes top-level lifecycle, metrics, and AI methods.
+`Stagehand` attaches to a browser connection and exposes top-level lifecycle, metrics, and AI methods. The browser handle remains caller-owned.
 
 <Tabs>
 <Tab title="TypeScript">
@@ -14,7 +14,18 @@ icon: "hand-horns"
 ```typescript
 import { localBrowser, Stagehand } from "@browserbasehq/stagehand";
 
-const stagehand = await Stagehand.create({ browser: await localBrowser.launch() });
+const browser = await localBrowser.launch();
+try {
+  const stagehand = await Stagehand.create({ browser });
+  try {
+    const page = await browser.context.activePage();
+    await page.goto("https://example.com");
+  } finally {
+    await stagehand.close();
+  }
+} finally {
+  await browser.close();
+}
 ```
 
 ## create()
@@ -22,7 +33,8 @@ const stagehand = await Stagehand.create({ browser: await localBrowser.launch() 
 Create a Stagehand instance and connect it to a browser. `Stagehand.create()` is the only way to build one; there is no public constructor, and the returned instance is already initialized.
 
 ```typescript
-const stagehand = await Stagehand.create({ browser: await localBrowser.launch() });
+const browser = await localBrowser.launch();
+const stagehand = await Stagehand.create({ browser });
 ```
 
 <ParamField path="browser" type="StagehandBrowser" required>
@@ -51,10 +63,11 @@ const page = await stagehand.browser.context.activePage();
 
 ## close()
 
-Close the Stagehand session and release browser resources.
+Close the Stagehand runtime and release its resources. The browser handle stays open; close it separately with `browser.close()`.
 
 ```typescript
 await stagehand.close();
+await browser.close();
 ```
 
 <ResponseField name="result" type="Promise<void>">
@@ -816,7 +829,16 @@ console.log(product.data, product.metadata.cache.status);
 ```python
 from stagehand import Stagehand, local_browser
 
-stagehand = await Stagehand.create(browser=await local_browser.launch())
+browser = await local_browser.launch()
+try:
+    stagehand = await Stagehand.create(browser=browser)
+    try:
+        page = await browser.context.active_page()
+        await page.goto("https://example.com")
+    finally:
+        await stagehand.close()
+finally:
+    await browser.close()
 ```
 
 ## create()
@@ -824,7 +846,8 @@ stagehand = await Stagehand.create(browser=await local_browser.launch())
 Create a Stagehand instance and connect it to a browser. `Stagehand.create()` is the only way to build one; there is no public constructor, and the returned instance is already initialized.
 
 ```python
-stagehand = await Stagehand.create(browser=await local_browser.launch())
+browser = await local_browser.launch()
+stagehand = await Stagehand.create(browser=browser)
 ```
 
 <ParamField path="browser" type="StagehandBrowser" required>
@@ -853,10 +876,11 @@ page = await stagehand.browser.context.active_page()
 
 ## close()
 
-Close the Stagehand session and release browser resources.
+Close the Stagehand runtime and release its resources. The browser handle stays open; close it separately with `browser.close()`.
 
 ```python
 await stagehand.close()
+await browser.close()
 ```
 
 <ResponseField name="result" type="None">


### PR DESCRIPTION
# why

The v4 Stagehand reference discarded the browser handle in its TypeScript and Python examples even though callers must close that handle separately. Its `close()` description also said Stagehand released browser resources, contradicting the documented and implemented ownership contract.

Fixes #2736

# what changed

- Retain browser handles in the TypeScript and Python create examples.
- Show exception-safe nested cleanup that closes Stagehand before closing the browser, including when creation or use fails.
- Clarify that `Stagehand.close()` releases Stagehand runtime resources and leaves the browser open.
- Add a docs regression that rejects inline browser launches and verifies both lifecycle handles and close order.

# test plan

- Docs unit suite (28 passed)
- Focused browser-ownership docs regression
- Mintlify build validation passed
- Mintlify accessibility check passed for all 138 MDX files
- Targeted Oxfmt and Oxlint checks
- `git diff --check`
- Mintlify broken-link validation was attempted; it reports the repository's existing 404-link backlog (404 links across 89 files), unrelated to this reference change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies Stagehand browser ownership in v4 docs so the browser remains caller‑owned. Old examples inlined browser launches and implied `Stagehand.close()` released the browser; new examples keep the browser handle, state `close()` leaves the browser open, and show closing Stagehand before the browser.

- Update TypeScript and Python examples in `@browserbasehq/stagehand`: allocate `browser` separately, use try/finally, and pass `browser` to `Stagehand.create`.
- Revise `close()` docs: explain it shuts down Stagehand runtime only; examples now call `await stagehand.close()` and then `await browser.close()`.
- Strengthen docs regression tests across SDKs: reject inline launches; require “browser stays open” language; require both close calls to appear inside the close() section in the right order; enforce Go tab `defer browser.Close(ctx)` before `defer client.Close(ctx)`.

<sup>Written for commit a8d7f929989af6b57c8eec86ae0327e525ebcad5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

