### PR TITLE
fix(docs): raise sdk-reference suite timeouts for slower CI runners

### DIFF
--- a/packages/docs/tests/sdk-reference.test.ts
+++ b/packages/docs/tests/sdk-reference.test.ts
@@ -215,7 +215,7 @@ const TYPESCRIPT_FIELD_SPELLINGS = uniqueSpellingsByWireName(
   await readTypescriptPublicFieldNames(),
 );
 
-describe("SDK reference surface", () => {
+describe("SDK reference surface", { timeout: 30_000 }, () => {
   it("keeps every public callable in sync across TypeScript, Python, Go, and reference pages", async () => {
     const [typescriptMethods, pythonMethods, goMethods, referencePages] = await Promise.all([
       readTypescriptMethods(),
@@ -1234,7 +1234,7 @@ describe("SDK reference surface", () => {
   });
 });
 
-describe("Mintlify customization boundary", () => {
+describe("Mintlify customization boundary", { timeout: 30_000 }, () => {
   it("uses SDK-native field spellings inside each language tab", async () => {
     const [typescriptNames, pythonNames, contentPages] = await Promise.all([
       readTypescriptPublicFieldNames(),


### PR DESCRIPTION
TypeScript unit is failing on every PR since #2698 merged: `packages/docs/tests/sdk-reference.test.ts` scans all v4 MDX files, #2698 grew the scan set, and CI runners now exceed the 5s vitest default (locally ~3.9s on M-series — right at the edge). Two consecutive CI runs failed identically on #2743.

One-line-per-suite fix: 30s suite timeout on both describes. Verified: 27/27 pass locally in 4.15s.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises `vitest` suite timeouts in the docs SDK reference tests to 30s to stabilize CI on slower runners. Previously both suites used the 5s default and timed out after #2698 expanded the MDX scan set.

- Touches only packages/docs/tests/sdk-reference.test.ts: adds `{ timeout: 30_000 }` to the "SDK reference surface" and "Mintlify customization boundary" `describe` blocks.
- Unblocks the TypeScript unit job that was failing in CI; local runs remain ~4.15s.
- No changes to test logic or assertions; only timeout configuration in `vitest`.

<sup>Written for commit d85f6cee3a999b99deb57cf63796ea3757453a5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

