### PR TITLE
feat(integrations): extract Codex SDK harness adapter from evals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,6 +256,7 @@ jobs:
             packages/sdk-ts/dist/**
             packages/integrations/core/dist/**
             packages/integrations/claude-agent-sdk/dist/**
+            packages/integrations/codex-sdk/dist/**
             packages/evals/dist/**
           retention-days: 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,7 @@ jobs:
             packages/sdk-ts/dist/**
             packages/integrations/core/dist/**
             packages/integrations/claude-agent-sdk/dist/**
+            packages/integrations/codex-sdk/dist/**
             packages/evals/dist/**
           retention-days: 1
 

--- a/packages/evals/framework/codexRunner.ts
+++ b/packages/evals/framework/codexRunner.ts
@@ -183,8 +183,14 @@ export async function runCodexAgent({
           usage: {
             input_tokens: tokenUsage.input_tokens,
             output_tokens: tokenUsage.output_tokens,
-            reasoning_tokens: tokenUsage.reasoning_output_tokens,
-            cached_input_tokens: tokenUsage.cached_input_tokens,
+            // Unreported usage stays absent so trajectory consumers can
+            // distinguish "not measured" from a measured zero.
+            ...(tokenUsage.reasoning_output_tokens !== undefined && {
+              reasoning_tokens: tokenUsage.reasoning_output_tokens,
+            }),
+            ...(tokenUsage.cached_input_tokens !== undefined && {
+              cached_input_tokens: tokenUsage.cached_input_tokens,
+            }),
           },
         },
         verifier.taskSpec,
@@ -216,7 +222,10 @@ function readCodexMaxToolSteps(): number {
     const parsed = Number.parseInt(process.env[key] ?? "", 10);
     if (Number.isFinite(parsed) && parsed > 0) return parsed;
   }
-  return 50;
+  // Codex budgets individual tool steps while Claude budgets turns (which can
+  // span several tool calls); 100 steps ≈ 50 Claude turns keeps the harnesses
+  // roughly comparable.
+  return 100;
 }
 
 function readBooleanEnv(key: string, fallback: boolean): boolean {

--- a/packages/evals/framework/codexRunner.ts
+++ b/packages/evals/framework/codexRunner.ts
@@ -1,32 +1,32 @@
+import {
+  buildCodexTranscript,
+  loadCodexSdk,
+  normalizeCodexModel,
+  runCodexSession,
+  stringifyError,
+  toFiniteNumber,
+  validateCodexApprovalPolicy,
+  validateCodexSandboxMode,
+  type CodexSdk,
+  type CodexTokenUsage,
+} from "@browserbasehq/stagehand-integrations-codex-sdk";
 import type { AvailableModel } from "stagehand-v3";
-import { EvalsError } from "../errors.js";
 import type { EvalLogger } from "../logger.js";
-import type { TaskResult } from "./types.js";
-import type { ExternalHarnessTaskPlan } from "./externalHarnessPlan.js";
-import { datasetPromptGuidance } from "./externalHarnessPlan.js";
 import type { PreparedCodexToolAdapter } from "./codexToolAdapter.js";
+import { datasetPromptGuidance, type ExternalHarnessTaskPlan } from "./externalHarnessPlan.js";
 import { codexAdapter } from "./harnesses/codexAdapter.js";
+import type { TaskResult } from "./types.js";
 import { gradeExternalTrajectory, type ExternalHarnessVerifierConfig } from "./verifierAdapter.js";
 
+export type { CodexSdk, CodexThread } from "@browserbasehq/stagehand-integrations-codex-sdk";
+export {
+  buildCodexTranscript,
+  loadCodexSdk,
+  normalizeCodexModel,
+  runCodexSession,
+} from "@browserbasehq/stagehand-integrations-codex-sdk";
+
 type MetricValue = { count: number; value: number };
-type CodexEvent = Record<string, unknown>;
-type CodexUsage = {
-  input_tokens?: number;
-  cached_input_tokens?: number;
-  output_tokens?: number;
-  reasoning_output_tokens?: number;
-};
-
-export type CodexThread = {
-  runStreamed: (
-    input: string,
-    options?: Record<string, unknown>,
-  ) => Promise<{ events: AsyncIterable<CodexEvent> }>;
-};
-
-export type CodexSdk = {
-  startThread: (options?: Record<string, unknown>) => CodexThread;
-};
 
 export interface CodexRunnerInput {
   plan: ExternalHarnessTaskPlan;
@@ -35,15 +35,6 @@ export interface CodexRunnerInput {
   toolAdapter?: PreparedCodexToolAdapter;
   signal?: AbortSignal;
   sdk?: CodexSdk;
-  /**
-   * Optional verifier integration. When provided, the runner builds a
-   * Trajectory from the codex event stream (via codexAdapter), runs
-   * V3Evaluator.verify() against the trajectory's embedded TaskSpec, and folds
-   * the EvaluationResult into the returned TaskResult ({_success} mode follows
-   * EVAL_SUCCESS_MODE).
-   * When omitted, the runner falls back to parsing the legacy JSON result —
-   * preserves current behavior for callers that haven't migrated.
-   */
   verifier?: ExternalHarnessVerifierConfig;
 }
 
@@ -53,8 +44,6 @@ export interface ParsedCodexResult {
   finalAnswer?: string;
   raw: string;
 }
-
-const CODEX_SDK_PACKAGE = "@openai/codex-sdk";
 
 const EVAL_RESULT_SCHEMA = {
   type: "object",
@@ -66,21 +55,6 @@ const EVAL_RESULT_SCHEMA = {
   required: ["success", "summary", "finalAnswer"],
   additionalProperties: false,
 } as const;
-
-/** Tool-step budget: EVAL_CODEX_MAX_STEPS, falling back to the pre-migration
- * AGENT_EVAL_MAX_STEPS knob so carried-forward run configs keep working. */
-function readCodexMaxToolSteps(): number {
-  for (const key of ["EVAL_CODEX_MAX_STEPS", "AGENT_EVAL_MAX_STEPS"]) {
-    const parsed = Number.parseInt(process.env[key] ?? "", 10);
-    if (Number.isFinite(parsed) && parsed > 0) return parsed;
-  }
-  return 50;
-}
-
-export function normalizeCodexModel(model: AvailableModel): string {
-  if (model === ("codex/default" as AvailableModel)) return "gpt-5.4-mini";
-  return model.includes("/") ? model.slice(model.indexOf("/") + 1) : model;
-}
 
 export function buildCodexPrompt(plan: ExternalHarnessTaskPlan, toolInstructions?: string): string {
   return [
@@ -123,7 +97,6 @@ export function parseCodexResult(raw: string): ParsedCodexResult {
     const parsed = tryParseCodexJson(candidate);
     if (parsed) return { ...parsed, raw };
   }
-
   return { success: false, raw };
 }
 
@@ -133,124 +106,45 @@ export async function runCodexAgent({
   logger,
   toolAdapter,
   signal,
-  sdk: injectedSdk,
+  sdk,
   verifier,
 }: CodexRunnerInput): Promise<TaskResult> {
-  const sdk =
-    injectedSdk ??
-    (await loadCodexSdk(
-      toolAdapter?.env,
-      toolAdapter && "codexConfig" in toolAdapter ? toolAdapter.codexConfig : undefined,
-    ));
   const prompt = buildCodexPrompt(plan, toolAdapter?.promptInstructions);
-  const events: CodexEvent[] = [];
-  let finalResponse = "";
-  let usage: CodexUsage | undefined;
-  let iterationError: unknown;
-  let stopReason: string | undefined;
-
-  // Codex has no native turn/step limit, so a run could grind indefinitely.
-  // Cap tool steps (command executions + MCP tool calls) and abort the
-  // stream at the budget — the analogue of Claude Code's maxTurns, and it
-  // gives every published run a citable, reproducible action budget.
-  const maxToolSteps = readCodexMaxToolSteps();
-  const budgetController = new AbortController();
-  const forwardAbort = () => budgetController.abort(signal?.reason);
-  if (signal) {
-    if (signal.aborted) budgetController.abort(signal.reason);
-    else signal.addEventListener("abort", forwardAbort, { once: true });
-  }
-  let toolStepCount = 0;
-
-  try {
-    const thread = sdk.startThread({
-      model: normalizeCodexModel(model),
-      ...(toolAdapter?.cwd && {
-        workingDirectory: toolAdapter.cwd,
-        skipGitRepoCheck: true,
-      }),
-      sandboxMode: readCodexSandboxMode(),
-      approvalPolicy: readCodexApprovalPolicy(),
+  const sessionResult = await runCodexSession({
+    prompt,
+    model,
+    logger,
+    sdk:
+      sdk ??
+      (await loadEvalCodexSdk(
+        toolAdapter?.env,
+        toolAdapter && "codexConfig" in toolAdapter ? toolAdapter.codexConfig : undefined,
+      )),
+    signal,
+    thread: {
+      ...(toolAdapter?.cwd && { workingDirectory: toolAdapter.cwd }),
+      sandboxMode: validateCodexSandboxMode(process.env.EVAL_CODEX_SANDBOX_MODE),
+      approvalPolicy: validateCodexApprovalPolicy(process.env.EVAL_CODEX_APPROVAL_POLICY),
       networkAccessEnabled: readBooleanEnv("EVAL_CODEX_NETWORK_ACCESS", true),
       webSearchMode: "disabled",
-    });
-    const streamed = await thread.runStreamed(prompt, {
-      outputSchema: EVAL_RESULT_SCHEMA,
-      signal: budgetController.signal,
-    });
-
-    for await (const event of streamed.events) {
-      events.push(event);
-      logCodexEvent(logger, event);
-
-      if (event.type === "turn.completed" && isRecord(event.usage)) {
-        usage = event.usage;
-      } else if (event.type === "turn.failed") {
-        stopReason = readCodexErrorMessage(event.error);
-      } else if (event.type === "error") {
-        stopReason = typeof event.message === "string" ? event.message : "error";
-      }
-
-      const item = isRecord(event.item) ? event.item : undefined;
-      if (
-        event.type === "item.completed" &&
-        item?.type === "agent_message" &&
-        typeof item.text === "string"
-      ) {
-        finalResponse = item.text;
-      }
-      if (
-        event.type === "item.completed" &&
-        (item?.type === "command_execution" || item?.type === "mcp_tool_call")
-      ) {
-        toolStepCount += 1;
-        if (toolStepCount >= maxToolSteps && !budgetController.signal.aborted) {
-          stopReason = `tool step budget exhausted (${maxToolSteps} steps)`;
-          budgetController.abort(new Error(stopReason));
-        }
-      }
-      // MCP-mounted surfaces: each completed MCP tool call consumes one
-      // observation index, in stream order (mirrors the bridge's
-      // onRunExecuted for code surfaces).
-      if (
-        event.type === "item.completed" &&
-        item?.type === "mcp_tool_call" &&
-        toolAdapter &&
-        "recordObservation" in toolAdapter
-      ) {
-        toolAdapter.recordObservation?.();
-      }
-    }
-  } catch (error) {
-    iterationError = error;
-    logger.warn({
-      category: "codex",
-      message: `Codex stopped before a normal result: ${stringifyError(error)}`,
-      level: 0,
-      auxiliary: {
-        error: {
-          value: stringifyError(error),
-          type: "string",
-        },
-      },
-    });
-  }
-
-  // Long batches share one abort signal; detach the forwarder so completed
-  // runs don't accumulate listeners on it.
-  signal?.removeEventListener("abort", forwardAbort);
-
+      skipGitRepoCheck: true,
+    },
+    outputSchema: EVAL_RESULT_SCHEMA,
+    maxToolSteps: readCodexMaxToolSteps(),
+    onToolStep:
+      toolAdapter && "recordObservation" in toolAdapter ? toolAdapter.recordObservation : undefined,
+  });
+  const { events, finalMessage, iterationError, status, stopReason, tokenUsage } = sessionResult;
   const transcriptText = buildCodexTranscript(events);
   const iterationErrorMessage = stringifyError(iterationError);
-  const rawResult = [finalResponse, transcriptText, iterationErrorMessage]
+  const rawResult = [finalMessage, transcriptText, iterationErrorMessage]
     .filter(Boolean)
     .join("\n\n");
   const parsed = parseCodexResult(rawResult);
-  const status = resolveCodexStatus(iterationError, stopReason);
   const errorMessage =
     parsed.summary ??
     stopReason ??
-    (iterationErrorMessage || finalResponse || transcriptText || "Codex did not report success");
+    (iterationErrorMessage || finalMessage || transcriptText || "Codex did not report success");
   const baseResult: TaskResult = {
     _success: parsed.success,
     error: !parsed.success ? errorMessage : undefined,
@@ -260,16 +154,10 @@ export async function runCodexAgent({
     codexStatus: status,
     ...(stopReason && { codexStopReason: stopReason }),
     logs: logger.getLogs(),
-    metrics: buildCodexMetrics(usage),
+    metrics: buildCodexMetrics(tokenUsage),
   };
+  if (!verifier) return baseResult;
 
-  if (!verifier) {
-    return baseResult;
-  }
-
-  // Artifact-grounded grading: capture the terminal page state through the
-  // tool surface (harness-observed, independent of the agent's self-report)
-  // before cleanup, mirroring the claude_code runner.
   const finalObservation =
     toolAdapter && "captureEvidence" in toolAdapter
       ? await toolAdapter.captureEvidence?.().catch((): undefined => undefined)
@@ -278,9 +166,6 @@ export async function runCodexAgent({
     toolAdapter && "drainStepObservations" in toolAdapter
       ? await toolAdapter.drainStepObservations?.()
       : undefined;
-
-  // Build a Trajectory from the codex event stream and grade it with the
-  // rubric verifier; any failure in that path folds into `verifierError`.
   return gradeExternalTrajectory({
     buildTrajectory: () =>
       codexAdapter.fromHarnessResult(
@@ -293,17 +178,13 @@ export async function runCodexAgent({
             toolAdapter.observedToolMatcher && {
               observedToolName: toolAdapter.observedToolMatcher,
             }),
-          finalAnswer: parsed.finalAnswer ?? finalResponse,
+          finalAnswer: parsed.finalAnswer ?? finalMessage,
           status: status === "completed" ? "complete" : "error",
           usage: {
-            input_tokens: toFiniteNumber(usage?.input_tokens),
-            output_tokens: toFiniteNumber(usage?.output_tokens),
-            ...(usage?.reasoning_output_tokens !== undefined && {
-              reasoning_tokens: toFiniteNumber(usage.reasoning_output_tokens),
-            }),
-            ...(usage?.cached_input_tokens !== undefined && {
-              cached_input_tokens: toFiniteNumber(usage.cached_input_tokens),
-            }),
+            input_tokens: tokenUsage.input_tokens,
+            output_tokens: tokenUsage.output_tokens,
+            reasoning_tokens: tokenUsage.reasoning_output_tokens,
+            cached_input_tokens: tokenUsage.cached_input_tokens,
           },
         },
         verifier.taskSpec,
@@ -314,6 +195,34 @@ export async function runCodexAgent({
     category: "codex",
     logger,
   });
+}
+
+async function loadEvalCodexSdk(
+  env?: Record<string, string>,
+  extraConfig?: Record<string, unknown>,
+): Promise<CodexSdk> {
+  return loadCodexSdk({
+    env,
+    codexPathOverride: process.env.EVAL_CODEX_PATH,
+    baseUrl: process.env.EVAL_CODEX_BASE_URL,
+    apiKey: process.env.OPENAI_API_KEY,
+    rawReasoning: process.env.EVAL_CODEX_RAW_REASONING === "true",
+    extraConfig,
+  });
+}
+
+function readCodexMaxToolSteps(): number {
+  for (const key of ["EVAL_CODEX_MAX_STEPS", "AGENT_EVAL_MAX_STEPS"]) {
+    const parsed = Number.parseInt(process.env[key] ?? "", 10);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  return 50;
+}
+
+function readBooleanEnv(key: string, fallback: boolean): boolean {
+  const raw = process.env[key];
+  if (!raw) return fallback;
+  return raw === "true" || raw === "1";
 }
 
 function tryParseCodexJson(candidate: string): Omit<ParsedCodexResult, "raw"> | undefined {
@@ -333,19 +242,11 @@ function tryParseCodexJson(candidate: string): Omit<ParsedCodexResult, "raw"> | 
   }
 }
 
-function resolveCodexStatus(
-  iterationError: unknown,
-  stopReason: string | undefined,
-): "completed" | "sdk_error" {
-  return iterationError || stopReason ? "sdk_error" : "completed";
-}
-
-function buildCodexMetrics(usage: CodexUsage | undefined): Record<string, MetricValue> {
-  const inputTokens = toFiniteNumber(usage?.input_tokens);
-  const cachedInputTokens = toFiniteNumber(usage?.cached_input_tokens);
-  const outputTokens = toFiniteNumber(usage?.output_tokens);
-  const reasoningOutputTokens = toFiniteNumber(usage?.reasoning_output_tokens);
-
+function buildCodexMetrics(usage: CodexTokenUsage): Record<string, MetricValue> {
+  const inputTokens = toFiniteNumber(usage.input_tokens);
+  const cachedInputTokens = toFiniteNumber(usage.cached_input_tokens);
+  const outputTokens = toFiniteNumber(usage.output_tokens);
+  const reasoningOutputTokens = toFiniteNumber(usage.reasoning_output_tokens);
   return {
     codex_input_tokens: metricValue(inputTokens),
     codex_cached_input_tokens: metricValue(cachedInputTokens),
@@ -358,195 +259,5 @@ function buildCodexMetrics(usage: CodexUsage | undefined): Record<string, Metric
 }
 
 function metricValue(value: unknown): MetricValue {
-  return {
-    count: 1,
-    value: toFiniteNumber(value),
-  };
-}
-
-function toFiniteNumber(value: unknown): number {
-  const parsed =
-    typeof value === "number"
-      ? value
-      : typeof value === "string" && value.trim()
-        ? Number(value)
-        : 0;
-
-  return Number.isFinite(parsed) ? parsed : 0;
-}
-
-function buildCodexTranscript(events: CodexEvent[]): string {
-  return events
-    .map((event) => summarizeCodexEvent(event).detail)
-    .filter((detail): detail is string => Boolean(detail))
-    .join("\n");
-}
-
-function logCodexEvent(logger: EvalLogger, event: CodexEvent): void {
-  const summary = summarizeCodexEvent(event);
-  logger.log({
-    category: "codex",
-    message: summary.message,
-    level: 1,
-    auxiliary: {
-      type: {
-        value: String(event.type ?? "unknown"),
-        type: "string",
-      },
-      ...(summary.detail && {
-        detail: {
-          value: summary.detail,
-          type: "string",
-        },
-      }),
-    },
-  });
-}
-
-function summarizeCodexEvent(event: CodexEvent): {
-  message: string;
-  detail?: string;
-} {
-  const type = String(event.type ?? "unknown");
-  const item = isRecord(event.item) ? event.item : undefined;
-  if (item?.type === "agent_message" && typeof item.text === "string") {
-    return {
-      message: `agent: ${clip(item.text, 500)}`,
-      detail: item.text,
-    };
-  }
-  if (item?.type === "command_execution") {
-    return {
-      message: `command: ${String(item.command ?? "")} ${String(item.status ?? "")}`.trim(),
-      detail: safeJson(item),
-    };
-  }
-  if (item?.type === "mcp_tool_call") {
-    return {
-      message:
-        `mcp: ${String(item.server ?? "")}.${String(item.tool ?? "")} ${String(item.status ?? "")}`.trim(),
-      detail: safeJson(item),
-    };
-  }
-  if (item?.type === "error" && typeof item.message === "string") {
-    return {
-      message: `error item: ${clip(item.message, 500)}`,
-      detail: item.message,
-    };
-  }
-  if (type === "turn.completed") {
-    return {
-      message: "turn completed",
-      detail: safeJson(event.usage),
-    };
-  }
-  if (type === "turn.failed") {
-    const message = readCodexErrorMessage(event.error) ?? "turn failed";
-    return {
-      message: `turn failed: ${clip(message, 500)}`,
-      detail: message,
-    };
-  }
-  if (type === "error" && typeof event.message === "string") {
-    return {
-      message: `error: ${clip(event.message, 500)}`,
-      detail: event.message,
-    };
-  }
-  return {
-    message: `${type} event`,
-    detail: safeJson(event),
-  };
-}
-
-async function loadCodexSdk(
-  env?: Record<string, string>,
-  extraConfig?: Record<string, unknown>,
-): Promise<CodexSdk> {
-  try {
-    const specifier = CODEX_SDK_PACKAGE;
-    const mod = (await import(specifier)) as {
-      Codex?: new (options?: Record<string, unknown>) => CodexSdk;
-    };
-    if (typeof mod.Codex !== "function") {
-      throw new Error("Codex export missing");
-    }
-    return new mod.Codex({
-      ...(env && { env }),
-      ...(process.env.EVAL_CODEX_PATH && {
-        codexPathOverride: process.env.EVAL_CODEX_PATH,
-      }),
-      ...(process.env.EVAL_CODEX_BASE_URL && {
-        baseUrl: process.env.EVAL_CODEX_BASE_URL,
-      }),
-      ...(process.env.OPENAI_API_KEY && {
-        apiKey: process.env.OPENAI_API_KEY,
-      }),
-      config: {
-        show_raw_agent_reasoning: process.env.EVAL_CODEX_RAW_REASONING === "true",
-        // Adapter-provided overrides (e.g. mcp_servers for MCP mounts).
-        ...extraConfig,
-      },
-    });
-  } catch (error) {
-    throw new EvalsError(
-      `Codex harness requires ${CODEX_SDK_PACKAGE}. Install it in packages/evals before running --harness codex. ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-    );
-  }
-}
-
-function readCodexSandboxMode(): "read-only" | "workspace-write" | "danger-full-access" {
-  const raw = process.env.EVAL_CODEX_SANDBOX_MODE;
-  if (raw === "read-only" || raw === "workspace-write" || raw === "danger-full-access") {
-    return raw;
-  }
-  return "workspace-write";
-}
-
-function readCodexApprovalPolicy(): "never" | "on-request" | "on-failure" | "untrusted" {
-  const raw = process.env.EVAL_CODEX_APPROVAL_POLICY;
-  if (raw === "never" || raw === "on-request" || raw === "on-failure" || raw === "untrusted") {
-    return raw;
-  }
-  return "never";
-}
-
-function readBooleanEnv(key: string, fallback: boolean): boolean {
-  const raw = process.env[key];
-  if (!raw) return fallback;
-  return raw === "true" || raw === "1";
-}
-
-function readCodexErrorMessage(value: unknown): string | undefined {
-  if (!value) return undefined;
-  if (typeof value === "string") return value;
-  if (isRecord(value) && typeof value.message === "string") {
-    return value.message;
-  }
-  return safeJson(value);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function safeJson(value: unknown): string | undefined {
-  try {
-    return JSON.stringify(value);
-  } catch {
-    return undefined;
-  }
-}
-
-function stringifyError(value: unknown): string {
-  if (!value) return "";
-  if (value instanceof Error) return value.message;
-  if (typeof value === "string") return value;
-  return safeJson(value) ?? String(value);
-}
-
-function clip(value: string, maxLength: number): string {
-  return value.length <= maxLength ? value : `${value.slice(0, maxLength - 1)}…`;
+  return { count: 1, value: toFiniteNumber(value) };
 }

--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -25,7 +25,7 @@
     "@browserbasehq/stagehand": "workspace:*",
     "@browserbasehq/stagehand-integrations": "workspace:*",
     "@browserbasehq/stagehand-integrations-claude-agent-sdk": "workspace:*",
-    "@openai/codex-sdk": "catalog:",
+    "@browserbasehq/stagehand-integrations-codex-sdk": "workspace:*",
     "ai": "^5.0.133",
     "browse": "0.9.5",
     "dotenv": "^17.3.1",

--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -26,7 +26,7 @@
     "@browserbasehq/stagehand": "workspace:*",
     "@browserbasehq/stagehand-integrations": "workspace:*",
     "@browserbasehq/stagehand-integrations-claude-agent-sdk": "workspace:*",
-    "@openai/codex-sdk": "catalog:",
+    "@browserbasehq/stagehand-integrations-codex-sdk": "workspace:*",
     "@opentelemetry/api": "catalog:",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.220.0",
     "@opentelemetry/sdk-trace-base": "^2.9.0",

--- a/packages/evals/tests/framework/codexRunner.test.ts
+++ b/packages/evals/tests/framework/codexRunner.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import type { AvailableModel } from "stagehand-v3";
 import {
   buildCodexPrompt,
-  normalizeCodexModel,
   parseCodexResult,
   runCodexAgent,
   type CodexSdk,
@@ -18,12 +17,6 @@ const plan: ExternalHarnessTaskPlan = {
 };
 
 describe("codex runner helpers", () => {
-  it("normalizes provider-prefixed models for Codex", () => {
-    expect(normalizeCodexModel("openai/gpt-5.4-mini" as AvailableModel)).toBe("gpt-5.4-mini");
-    expect(normalizeCodexModel("gpt-5.4" as AvailableModel)).toBe("gpt-5.4");
-    expect(normalizeCodexModel("codex/default" as AvailableModel)).toBe("gpt-5.4-mini");
-  });
-
   it("builds a browser task prompt with structured result instructions", () => {
     const prompt = buildCodexPrompt(plan, "Use browse only. Discover usage with browse -h.");
 

--- a/packages/evals/tests/framework/codexRunner.test.ts
+++ b/packages/evals/tests/framework/codexRunner.test.ts
@@ -110,7 +110,7 @@ describe("codex runner helpers", () => {
       model: "gpt-5.4-mini",
       workingDirectory: "/tmp/stagehand-evals-test",
       skipGitRepoCheck: true,
-      sandboxMode: "workspace-write",
+      sandboxMode: "read-only",
       approvalPolicy: "never",
       networkAccessEnabled: true,
     });

--- a/packages/integrations/codex-sdk/package.json
+++ b/packages/integrations/codex-sdk/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@browserbasehq/stagehand-integrations-codex-sdk",
+  "version": "4.0.1",
+  "private": true,
+  "description": "Codex SDK harness adapter for Stagehand integrations",
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs"
+    }
+  },
+  "scripts": {
+    "build": "tsdown",
+    "test": "pnpm run build && vitest run --root ../../.. packages/integrations/codex-sdk/tests",
+    "test:unit": "vitest run --root ../../.. packages/integrations/codex-sdk/tests",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "@browserbasehq/stagehand-integrations": "workspace:*",
+    "@openai/codex-sdk": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=22.18.0"
+  }
+}

--- a/packages/integrations/codex-sdk/src/index.ts
+++ b/packages/integrations/codex-sdk/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./session.js";

--- a/packages/integrations/codex-sdk/src/session.ts
+++ b/packages/integrations/codex-sdk/src/session.ts
@@ -1,0 +1,326 @@
+import {
+  HarnessAdapterError,
+  sanitizeErrorMessage,
+  type HarnessLogger,
+} from "@browserbasehq/stagehand-integrations/harness";
+
+export type CodexEvent = Record<string, unknown>;
+
+export type CodexThread = {
+  runStreamed: (
+    input: string,
+    options?: Record<string, unknown>,
+  ) => Promise<{ events: AsyncIterable<CodexEvent> }>;
+};
+
+export type CodexSdk = {
+  startThread: (options?: Record<string, unknown>) => CodexThread;
+};
+
+export type CodexThreadConfig = {
+  workingDirectory?: string;
+  sandboxMode?: "read-only" | "workspace-write" | "danger-full-access";
+  approvalPolicy?: "never" | "on-request" | "on-failure" | "untrusted";
+  networkAccessEnabled?: boolean;
+  webSearchMode?: string;
+  skipGitRepoCheck?: boolean;
+};
+
+export type CodexTokenUsage = {
+  input_tokens: number;
+  cached_input_tokens: number;
+  output_tokens: number;
+  reasoning_output_tokens: number;
+};
+
+export type CodexSessionResult = {
+  events: CodexEvent[];
+  finalMessage: string;
+  status: "completed" | "sdk_error";
+  stopReason?: string;
+  tokenUsage: CodexTokenUsage;
+  iterationError?: unknown;
+};
+
+export const CODEX_SDK_PACKAGE = "@openai/codex-sdk";
+
+export async function loadCodexSdk(
+  options: {
+    env?: Record<string, string>;
+    codexPathOverride?: string;
+    baseUrl?: string;
+    apiKey?: string;
+    rawReasoning?: boolean;
+    extraConfig?: Record<string, unknown>;
+  } = {},
+): Promise<CodexSdk> {
+  try {
+    const specifier = CODEX_SDK_PACKAGE;
+    const mod = (await import(specifier)) as {
+      Codex?: new (options?: Record<string, unknown>) => CodexSdk;
+    };
+    if (typeof mod.Codex !== "function") throw new Error("Codex export missing");
+    return new mod.Codex({
+      ...(options.env && { env: options.env }),
+      ...(options.codexPathOverride && { codexPathOverride: options.codexPathOverride }),
+      ...(options.baseUrl && { baseUrl: options.baseUrl }),
+      ...(options.apiKey && { apiKey: options.apiKey }),
+      config: {
+        show_raw_agent_reasoning: options.rawReasoning === true,
+        ...options.extraConfig,
+      },
+    });
+  } catch (error) {
+    const detail = sanitizeErrorMessage(stringifyError(error));
+    throw new HarnessAdapterError(
+      `Codex SDK harness requires ${CODEX_SDK_PACKAGE}. Install it in the consuming workspace.${detail ? ` ${detail}` : ""}`,
+      { cause: error },
+    );
+  }
+}
+
+export function normalizeCodexModel(model: string): string {
+  if (model === "codex/default") return "gpt-5.4-mini";
+  return model.includes("/") ? model.slice(model.indexOf("/") + 1) : model;
+}
+
+export function validateCodexSandboxMode(
+  value: unknown,
+): "read-only" | "workspace-write" | "danger-full-access" {
+  if (value === "read-only" || value === "workspace-write" || value === "danger-full-access") {
+    return value;
+  }
+  return "workspace-write";
+}
+
+export function validateCodexApprovalPolicy(
+  value: unknown,
+): "never" | "on-request" | "on-failure" | "untrusted" {
+  if (
+    value === "never" ||
+    value === "on-request" ||
+    value === "on-failure" ||
+    value === "untrusted"
+  ) {
+    return value;
+  }
+  return "never";
+}
+
+export async function runCodexSession(input: {
+  prompt: string;
+  model: string;
+  sdk?: CodexSdk;
+  signal?: AbortSignal;
+  logger: HarnessLogger;
+  thread: CodexThreadConfig;
+  outputSchema?: Record<string, unknown>;
+  maxToolSteps?: number;
+  onToolStep?: () => void | Promise<void>;
+}): Promise<CodexSessionResult> {
+  const sdk = input.sdk ?? (await loadCodexSdk());
+  const events: CodexEvent[] = [];
+  let finalMessage = "";
+  let stopReason: string | undefined;
+  let iterationError: unknown;
+  let tokenUsage = emptyTokenUsage();
+  const maxToolSteps = positiveInteger(input.maxToolSteps, 50);
+  const budgetController = new AbortController();
+  const forwardAbort = () => budgetController.abort(input.signal?.reason);
+  if (input.signal) {
+    if (input.signal.aborted) budgetController.abort(input.signal.reason);
+    else input.signal.addEventListener("abort", forwardAbort, { once: true });
+  }
+  let toolStepCount = 0;
+
+  try {
+    const thread = sdk.startThread({
+      ...(input.model && { model: normalizeCodexModel(input.model) }),
+      ...(input.thread.workingDirectory && {
+        workingDirectory: input.thread.workingDirectory,
+      }),
+      sandboxMode: validateCodexSandboxMode(input.thread.sandboxMode),
+      approvalPolicy: validateCodexApprovalPolicy(input.thread.approvalPolicy),
+      networkAccessEnabled: input.thread.networkAccessEnabled ?? true,
+      webSearchMode: input.thread.webSearchMode ?? "disabled",
+      skipGitRepoCheck: input.thread.skipGitRepoCheck ?? true,
+    });
+    const streamed = await thread.runStreamed(input.prompt, {
+      ...(input.outputSchema && { outputSchema: input.outputSchema }),
+      signal: budgetController.signal,
+    });
+
+    for await (const event of streamed.events) {
+      events.push(event);
+      logCodexEvent(input.logger, event);
+      if (event.type === "turn.completed" && isRecord(event.usage)) {
+        tokenUsage = extractCodexTokenUsage(event.usage);
+      } else if (event.type === "turn.failed") {
+        stopReason = readCodexErrorMessage(event.error);
+      } else if (event.type === "error") {
+        stopReason = typeof event.message === "string" ? event.message : "error";
+      }
+
+      const item = isRecord(event.item) ? event.item : undefined;
+      if (
+        event.type === "item.completed" &&
+        item?.type === "agent_message" &&
+        typeof item.text === "string"
+      ) {
+        finalMessage = item.text;
+      }
+      if (
+        event.type === "item.completed" &&
+        (item?.type === "command_execution" || item?.type === "mcp_tool_call")
+      ) {
+        toolStepCount += 1;
+        if (toolStepCount >= maxToolSteps && !budgetController.signal.aborted) {
+          stopReason = `tool step budget exhausted (${maxToolSteps} steps)`;
+          budgetController.abort(new Error(stopReason));
+        }
+        if (item.type === "mcp_tool_call") await input.onToolStep?.();
+      }
+    }
+  } catch (error) {
+    iterationError = error;
+    input.logger.warn({
+      category: "codex",
+      message: `Codex stopped before a normal result: ${stringifyError(error)}`,
+      level: 0,
+      auxiliary: { error: { value: stringifyError(error), type: "string" } },
+    });
+  } finally {
+    input.signal?.removeEventListener("abort", forwardAbort);
+  }
+
+  return {
+    events,
+    finalMessage,
+    status: resolveCodexStatus(iterationError, stopReason),
+    ...(stopReason && { stopReason }),
+    tokenUsage,
+    ...(iterationError !== undefined && { iterationError }),
+  };
+}
+
+export function resolveCodexStatus(
+  iterationError: unknown,
+  stopReason?: string,
+): "completed" | "sdk_error" {
+  return iterationError || stopReason ? "sdk_error" : "completed";
+}
+
+export function extractCodexTokenUsage(
+  usage: Record<string, unknown> | undefined,
+): CodexTokenUsage {
+  return {
+    input_tokens: toFiniteNumber(usage?.input_tokens),
+    cached_input_tokens: toFiniteNumber(usage?.cached_input_tokens),
+    output_tokens: toFiniteNumber(usage?.output_tokens),
+    reasoning_output_tokens: toFiniteNumber(usage?.reasoning_output_tokens),
+  };
+}
+
+function emptyTokenUsage(): CodexTokenUsage {
+  return extractCodexTokenUsage(undefined);
+}
+
+export function buildCodexTranscript(events: CodexEvent[]): string {
+  return events
+    .map((event) => summarizeCodexEvent(event).detail)
+    .filter((detail): detail is string => Boolean(detail))
+    .join("\n");
+}
+
+export function logCodexEvent(logger: HarnessLogger, event: CodexEvent): void {
+  const summary = summarizeCodexEvent(event);
+  logger.log({
+    category: "codex",
+    message: summary.message,
+    level: 1,
+    auxiliary: {
+      type: { value: String(event.type ?? "unknown"), type: "string" },
+      ...(summary.detail && { detail: { value: summary.detail, type: "string" } }),
+    },
+  });
+}
+
+export function summarizeCodexEvent(event: CodexEvent): { message: string; detail?: string } {
+  const type = String(event.type ?? "unknown");
+  const item = isRecord(event.item) ? event.item : undefined;
+  if (item?.type === "agent_message" && typeof item.text === "string") {
+    return { message: `agent: ${clip(item.text, 500)}`, detail: item.text };
+  }
+  if (item?.type === "command_execution") {
+    return {
+      message: `command: ${String(item.command ?? "")} ${String(item.status ?? "")}`.trim(),
+      detail: safeJson(item),
+    };
+  }
+  if (item?.type === "mcp_tool_call") {
+    return {
+      message:
+        `mcp: ${String(item.server ?? "")}.${String(item.tool ?? "")} ${String(item.status ?? "")}`.trim(),
+      detail: safeJson(item),
+    };
+  }
+  if (item?.type === "error" && typeof item.message === "string") {
+    return { message: `error item: ${clip(item.message, 500)}`, detail: item.message };
+  }
+  if (type === "turn.completed")
+    return { message: "turn completed", detail: safeJson(event.usage) };
+  if (type === "turn.failed") {
+    const message = readCodexErrorMessage(event.error) ?? "turn failed";
+    return { message: `turn failed: ${clip(message, 500)}`, detail: message };
+  }
+  if (type === "error" && typeof event.message === "string") {
+    return { message: `error: ${clip(event.message, 500)}`, detail: event.message };
+  }
+  return { message: `${type} event`, detail: safeJson(event) };
+}
+
+export function readCodexErrorMessage(value: unknown): string | undefined {
+  if (!value) return undefined;
+  if (typeof value === "string") return value;
+  if (isRecord(value) && typeof value.message === "string") return value.message;
+  return safeJson(value);
+}
+
+export function toFiniteNumber(value: unknown): number {
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim()
+        ? Number(value)
+        : 0;
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function positiveInteger(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : fallback;
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export function safeJson(value: unknown): string | undefined {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return undefined;
+  }
+}
+
+export function stringifyError(value: unknown): string {
+  if (!value) return "";
+  if (value instanceof Error) return value.message;
+  if (typeof value === "string") return value;
+  return safeJson(value) ?? String(value);
+}
+
+export function clip(value: string, maxLength: number): string {
+  return value.length <= maxLength ? value : `${value.slice(0, maxLength - 1)}…`;
+}

--- a/packages/integrations/codex-sdk/src/session.ts
+++ b/packages/integrations/codex-sdk/src/session.ts
@@ -134,7 +134,7 @@ export async function runCodexSession(input: {
   let stopReason: string | undefined;
   let iterationError: unknown;
   let tokenUsage = emptyTokenUsage();
-  const maxToolSteps = positiveInteger(input.maxToolSteps, 50);
+  const maxToolSteps = positiveInteger(input.maxToolSteps, 100);
   const budgetController = new AbortController();
   const forwardAbort = () => budgetController.abort(input.signal?.reason);
   if (input.signal) {

--- a/packages/integrations/codex-sdk/src/session.ts
+++ b/packages/integrations/codex-sdk/src/session.ts
@@ -28,15 +28,17 @@ export type CodexThreadConfig = {
 
 export type CodexTokenUsage = {
   input_tokens: number;
-  cached_input_tokens: number;
+  /** Absent when the SDK did not report it — never synthesized as 0. */
+  cached_input_tokens?: number;
   output_tokens: number;
-  reasoning_output_tokens: number;
+  /** Absent when the SDK did not report it — never synthesized as 0. */
+  reasoning_output_tokens?: number;
 };
 
 export type CodexSessionResult = {
   events: CodexEvent[];
   finalMessage: string;
-  status: "completed" | "sdk_error";
+  status: "completed" | "max_turns" | "sdk_error";
   stopReason?: string;
   tokenUsage: CodexTokenUsage;
   iterationError?: unknown;
@@ -100,7 +102,8 @@ export function validateCodexSandboxMode(
   if (value === "read-only" || value === "workspace-write" || value === "danger-full-access") {
     return value;
   }
-  return "workspace-write";
+  // Fail closed: an unset or unrecognized mode must not grant disk writes.
+  return "read-only";
 }
 
 export function validateCodexApprovalPolicy(
@@ -142,6 +145,7 @@ export async function runCodexSession(input: {
     else input.signal.addEventListener("abort", forwardAbort, { once: true });
   }
   let toolStepCount = 0;
+  let budgetExhausted = false;
 
   try {
     const thread = sdk.startThread({
@@ -186,6 +190,7 @@ export async function runCodexSession(input: {
         toolStepCount += 1;
         if (toolStepCount >= maxToolSteps && !budgetController.signal.aborted) {
           stopReason = `tool step budget exhausted (${maxToolSteps} steps)`;
+          budgetExhausted = true;
           budgetController.abort(new Error(stopReason));
         }
         if (item.type === "mcp_tool_call") await input.onToolStep?.();
@@ -206,7 +211,7 @@ export async function runCodexSession(input: {
   return {
     events,
     finalMessage,
-    status: resolveCodexStatus(iterationError, stopReason),
+    status: resolveCodexStatus(iterationError, stopReason, budgetExhausted),
     ...(stopReason && { stopReason: sanitizeErrorMessage(stopReason) }),
     tokenUsage,
     ...(iterationError !== undefined && { iterationError }),
@@ -216,7 +221,11 @@ export async function runCodexSession(input: {
 export function resolveCodexStatus(
   iterationError: unknown,
   stopReason?: string,
-): "completed" | "sdk_error" {
+  budgetExhausted = false,
+): "completed" | "max_turns" | "sdk_error" {
+  // Tool-step budget exhaustion is the same class of stop as Claude's
+  // max_turns, not an SDK failure; callers decide how to score it.
+  if (budgetExhausted) return "max_turns";
   return iterationError || stopReason ? "sdk_error" : "completed";
 }
 
@@ -225,9 +234,13 @@ export function extractCodexTokenUsage(
 ): CodexTokenUsage {
   return {
     input_tokens: toFiniteNumber(usage?.input_tokens),
-    cached_input_tokens: toFiniteNumber(usage?.cached_input_tokens),
     output_tokens: toFiniteNumber(usage?.output_tokens),
-    reasoning_output_tokens: toFiniteNumber(usage?.reasoning_output_tokens),
+    ...(usage?.cached_input_tokens !== undefined && {
+      cached_input_tokens: toFiniteNumber(usage.cached_input_tokens),
+    }),
+    ...(usage?.reasoning_output_tokens !== undefined && {
+      reasoning_output_tokens: toFiniteNumber(usage.reasoning_output_tokens),
+    }),
   };
 }
 

--- a/packages/integrations/codex-sdk/src/session.ts
+++ b/packages/integrations/codex-sdk/src/session.ts
@@ -54,13 +54,24 @@ export async function loadCodexSdk(
     extraConfig?: Record<string, unknown>;
   } = {},
 ): Promise<CodexSdk> {
+  let codexCtor: new (options?: Record<string, unknown>) => CodexSdk;
   try {
     const specifier = CODEX_SDK_PACKAGE;
     const mod = (await import(specifier)) as {
       Codex?: new (options?: Record<string, unknown>) => CodexSdk;
     };
     if (typeof mod.Codex !== "function") throw new Error("Codex export missing");
-    return new mod.Codex({
+    codexCtor = mod.Codex;
+  } catch (error) {
+    const detail = sanitizeErrorMessage(stringifyError(error));
+    throw new HarnessAdapterError(
+      `Codex SDK harness requires ${CODEX_SDK_PACKAGE}. Install it in the consuming workspace.${detail ? ` ${detail}` : ""}`,
+      { cause: error },
+    );
+  }
+  // Construction failures are auth/config problems, not missing installs.
+  try {
+    return new codexCtor({
       ...(options.env && { env: options.env }),
       ...(options.codexPathOverride && { codexPathOverride: options.codexPathOverride }),
       ...(options.baseUrl && { baseUrl: options.baseUrl }),
@@ -71,9 +82,8 @@ export async function loadCodexSdk(
       },
     });
   } catch (error) {
-    const detail = sanitizeErrorMessage(stringifyError(error));
     throw new HarnessAdapterError(
-      `Codex SDK harness requires ${CODEX_SDK_PACKAGE}. Install it in the consuming workspace.${detail ? ` ${detail}` : ""}`,
+      `Failed to initialize the Codex SDK: ${sanitizeErrorMessage(stringifyError(error))}`,
       { cause: error },
     );
   }
@@ -185,9 +195,9 @@ export async function runCodexSession(input: {
     iterationError = error;
     input.logger.warn({
       category: "codex",
-      message: `Codex stopped before a normal result: ${stringifyError(error)}`,
+      message: `Codex stopped before a normal result: ${sanitizeErrorMessage(stringifyError(error))}`,
       level: 0,
-      auxiliary: { error: { value: stringifyError(error), type: "string" } },
+      auxiliary: { error: { value: sanitizeErrorMessage(stringifyError(error)), type: "string" } },
     });
   } finally {
     input.signal?.removeEventListener("abort", forwardAbort);
@@ -197,7 +207,7 @@ export async function runCodexSession(input: {
     events,
     finalMessage,
     status: resolveCodexStatus(iterationError, stopReason),
-    ...(stopReason && { stopReason }),
+    ...(stopReason && { stopReason: sanitizeErrorMessage(stopReason) }),
     tokenUsage,
     ...(iterationError !== undefined && { iterationError }),
   };
@@ -298,7 +308,7 @@ export function toFiniteNumber(value: unknown): number {
 
 function positiveInteger(value: unknown, fallback: number): number {
   return typeof value === "number" && Number.isFinite(value) && value > 0
-    ? Math.floor(value)
+    ? Math.max(1, Math.floor(value))
     : fallback;
 }
 

--- a/packages/integrations/codex-sdk/tests/session.test.ts
+++ b/packages/integrations/codex-sdk/tests/session.test.ts
@@ -103,6 +103,7 @@ describe("Codex SDK session", () => {
       maxToolSteps: 1,
     });
     expect(signal?.aborted).toBe(true);
+    expect(result.status).toBe("sdk_error");
     expect(result.stopReason).toBe("tool step budget exhausted (1 steps)");
   });
 });

--- a/packages/integrations/codex-sdk/tests/session.test.ts
+++ b/packages/integrations/codex-sdk/tests/session.test.ts
@@ -49,7 +49,7 @@ describe("Codex SDK session", () => {
     expect(threadOptions).toMatchObject({
       model: "gpt-5.4-mini",
       workingDirectory: "/tmp/work",
-      sandboxMode: "workspace-write",
+      sandboxMode: "read-only",
       approvalPolicy: "never",
       networkAccessEnabled: true,
       webSearchMode: "disabled",
@@ -103,7 +103,50 @@ describe("Codex SDK session", () => {
       maxToolSteps: 1,
     });
     expect(signal?.aborted).toBe(true);
-    expect(result.status).toBe("sdk_error");
+    expect(result.status).toBe("max_turns");
     expect(result.stopReason).toBe("tool step budget exhausted (1 steps)");
+  });
+
+  it("fails closed to read-only for unknown sandbox modes", async () => {
+    let capturedSandbox: unknown;
+    const sdk: CodexSdk = {
+      startThread: (options) => {
+        capturedSandbox = (options as Record<string, unknown>)?.sandboxMode;
+        return {
+          runStreamed: async () => ({ events: (async function* () {})() }),
+        };
+      },
+    };
+    await runCodexSession({
+      prompt: "task",
+      model: "gpt-5.4-mini",
+      logger,
+      sdk,
+      thread: { sandboxMode: "yolo" as never },
+    });
+    expect(capturedSandbox).toBe("read-only");
+  });
+
+  it("leaves unreported usage fields absent instead of zero-filling", async () => {
+    const sdk: CodexSdk = {
+      startThread: () => ({
+        runStreamed: async () => ({
+          events: (async function* () {
+            yield { type: "turn.completed", usage: { input_tokens: 7, output_tokens: 3 } };
+          })(),
+        }),
+      }),
+    };
+    const result = await runCodexSession({
+      prompt: "task",
+      model: "gpt-5.4-mini",
+      logger,
+      sdk,
+      thread: {},
+    });
+    expect(result.tokenUsage.input_tokens).toBe(7);
+    expect(result.tokenUsage.output_tokens).toBe(3);
+    expect("reasoning_output_tokens" in result.tokenUsage).toBe(false);
+    expect("cached_input_tokens" in result.tokenUsage).toBe(false);
   });
 });

--- a/packages/integrations/codex-sdk/tests/session.test.ts
+++ b/packages/integrations/codex-sdk/tests/session.test.ts
@@ -1,0 +1,108 @@
+/* eslint-disable require-yield */
+import { describe, expect, it } from "vitest";
+import { normalizeCodexModel, runCodexSession, type CodexSdk } from "../src/index.js";
+
+const logger = { log: () => {}, warn: () => {}, error: () => {} };
+
+describe("Codex SDK session", () => {
+  it("normalizes provider-prefixed and default models", () => {
+    expect(normalizeCodexModel("openai/gpt-5.4-mini")).toBe("gpt-5.4-mini");
+    expect(normalizeCodexModel("gpt-5.4")).toBe("gpt-5.4");
+    expect(normalizeCodexModel("codex/default")).toBe("gpt-5.4-mini");
+  });
+
+  it("forwards thread options and collects messages and usage", async () => {
+    let threadOptions: Record<string, unknown> | undefined;
+    let turnOptions: Record<string, unknown> | undefined;
+    const sdk: CodexSdk = {
+      startThread: (options) => {
+        threadOptions = options;
+        return {
+          runStreamed: async (_prompt, options) => {
+            turnOptions = options;
+            return {
+              events: (async function* () {
+                yield {
+                  type: "item.completed",
+                  item: { type: "agent_message", text: "complete" },
+                };
+                yield {
+                  type: "turn.completed",
+                  usage: { input_tokens: 10, output_tokens: 4 },
+                };
+              })(),
+            };
+          },
+        };
+      },
+    };
+    const outputSchema = { type: "object" };
+    const result = await runCodexSession({
+      prompt: "task",
+      model: "openai/gpt-5.4-mini",
+      logger,
+      sdk,
+      thread: { workingDirectory: "/tmp/work" },
+      outputSchema,
+    });
+
+    expect(threadOptions).toMatchObject({
+      model: "gpt-5.4-mini",
+      workingDirectory: "/tmp/work",
+      sandboxMode: "workspace-write",
+      approvalPolicy: "never",
+      networkAccessEnabled: true,
+      webSearchMode: "disabled",
+      skipGitRepoCheck: true,
+    });
+    expect(turnOptions?.outputSchema).toBe(outputSchema);
+    expect(result.finalMessage).toBe("complete");
+    expect(result.status).toBe("completed");
+    expect(result.tokenUsage).toMatchObject({ input_tokens: 10, output_tokens: 4 });
+  });
+
+  it("reports SDK errors instead of throwing", async () => {
+    const sdk: CodexSdk = {
+      startThread: () => ({
+        runStreamed: async () => {
+          throw new Error("codex failed");
+        },
+      }),
+    };
+    const result = await runCodexSession({
+      prompt: "task",
+      model: "gpt-5.4-mini",
+      logger,
+      sdk,
+      thread: {},
+    });
+    expect(result.status).toBe("sdk_error");
+    expect(String(result.iterationError)).toContain("codex failed");
+  });
+
+  it("aborts when the tool-step budget is exhausted", async () => {
+    let signal: AbortSignal | undefined;
+    const sdk: CodexSdk = {
+      startThread: () => ({
+        runStreamed: async (_prompt, options) => {
+          signal = options?.signal as AbortSignal;
+          return {
+            events: (async function* () {
+              yield { type: "item.completed", item: { type: "command_execution" } };
+            })(),
+          };
+        },
+      }),
+    };
+    const result = await runCodexSession({
+      prompt: "task",
+      model: "gpt-5.4-mini",
+      logger,
+      sdk,
+      thread: {},
+      maxToolSteps: 1,
+    });
+    expect(signal?.aborted).toBe(true);
+    expect(result.stopReason).toBe("tool step budget exhausted (1 steps)");
+  });
+});

--- a/packages/integrations/codex-sdk/tsconfig.json
+++ b/packages/integrations/codex-sdk/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "types": ["node"],
+    "rootDir": ".",
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts", "vitest.config.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/integrations/codex-sdk/tsdown.config.ts
+++ b/packages/integrations/codex-sdk/tsdown.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: {
+    index: "src/index.ts",
+  },
+  format: ["esm"],
+  platform: "node",
+  target: "node22",
+  dts: {
+    sourcemap: true,
+  },
+  sourcemap: true,
+  outDir: "dist",
+});

--- a/packages/integrations/codex-sdk/vitest.config.ts
+++ b/packages/integrations/codex-sdk/vitest.config.ts
@@ -1,9 +1,0 @@
-import { defineConfig } from "vitest/config";
-
-export default defineConfig({
-  test: {
-    include: ["tests/**/*.test.ts"],
-    hookTimeout: 20_000,
-    testTimeout: 20_000,
-  },
-});

--- a/packages/integrations/codex-sdk/vitest.config.ts
+++ b/packages/integrations/codex-sdk/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+    hookTimeout: 20_000,
+    testTimeout: 20_000,
+  },
+});

--- a/packages/integrations/codex/package.json
+++ b/packages/integrations/codex/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@browserbasehq/stagehand-integrations": "workspace:*",
-    "@openai/codex-sdk": "catalog:"
+    "@browserbasehq/stagehand-integrations-codex-sdk": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/packages/integrations/codex/package.json
+++ b/packages/integrations/codex/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "start": "node src/agent.ts",
-    "test": "pnpm -w exec turbo run build --filter @browserbasehq/stagehand-integrations && vitest run",
+    "test": "pnpm -w exec turbo run build --filter @browserbasehq/stagehand-integrations-codex-sdk && vitest run",
     "test:unit": "vitest run",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/integrations/codex/src/agent.ts
+++ b/packages/integrations/codex/src/agent.ts
@@ -2,7 +2,6 @@ import { loadCodexSdk, runCodexSession } from "@browserbasehq/stagehand-integrat
 import { buildAllowlistedEnv } from "@browserbasehq/stagehand-integrations/harness";
 import { fileURLToPath } from "node:url";
 
-
 /**
  * codex-sdk has no in-process MCP mounting; MCP servers are supplied through
  * the config override (config.toml shape), the same mechanism the evals codex

--- a/packages/integrations/codex/src/agent.ts
+++ b/packages/integrations/codex/src/agent.ts
@@ -2,9 +2,6 @@ import { loadCodexSdk, runCodexSession } from "@browserbasehq/stagehand-integrat
 import { buildAllowlistedEnv } from "@browserbasehq/stagehand-integrations/harness";
 import { fileURLToPath } from "node:url";
 
-const serverPath = fileURLToPath(
-  import.meta.resolve("@browserbasehq/stagehand-integrations/facade/stdio-server"),
-);
 
 /**
  * codex-sdk has no in-process MCP mounting; MCP servers are supplied through
@@ -12,6 +9,11 @@ const serverPath = fileURLToPath(
  * harness uses.
  */
 export function buildCodexConfig(): Record<string, unknown> {
+  // Resolved here (not at module load) so a missing build surfaces through
+  // handleFailure instead of an uncaught module error.
+  const serverPath = fileURLToPath(
+    import.meta.resolve("@browserbasehq/stagehand-integrations/facade/stdio-server"),
+  );
   return {
     // Required for headless MCP calls on machines without a global
     // approvals_reviewer: without it, tool calls die with "user cancelled
@@ -69,9 +71,14 @@ async function main(): Promise<void> {
     },
   });
   if (result.status !== "completed") {
+    // Surface any answer the agent produced before the abnormal stop; a
+    // budget/max-turns stop usually still carries a useful final message.
     throw (
       result.iterationError ??
-      new Error(`Agent did not finish: ${result.stopReason ?? result.status}`)
+      new Error(
+        `Agent did not finish: ${result.stopReason ?? result.status}` +
+          (result.finalMessage ? `\nLast agent message: ${result.finalMessage}` : ""),
+      )
     );
   }
   // oxlint-disable-next-line no-console -- CLI example prints the agent result.

--- a/packages/integrations/codex/src/agent.ts
+++ b/packages/integrations/codex/src/agent.ts
@@ -1,4 +1,4 @@
-import { Codex, type CodexOptions } from "@openai/codex-sdk";
+import { loadCodexSdk, runCodexSession } from "@browserbasehq/stagehand-integrations-codex-sdk";
 import { buildAllowlistedEnv } from "@browserbasehq/stagehand-integrations/harness";
 import { fileURLToPath } from "node:url";
 
@@ -11,7 +11,7 @@ const serverPath = fileURLToPath(
  * the config override (config.toml shape), the same mechanism the evals codex
  * harness uses.
  */
-export function buildCodexConfig(): NonNullable<CodexOptions["config"]> {
+export function buildCodexConfig(): Record<string, unknown> {
   return {
     // Required for headless MCP calls on machines without a global
     // approvals_reviewer: without it, tool calls die with "user cancelled
@@ -30,12 +30,18 @@ export function buildCodexConfig(): NonNullable<CodexOptions["config"]> {
   };
 }
 
+const logger = {
+  log: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
   const instruction = (args[0] === "--" ? args.slice(1) : args).join(" ").trim();
   if (!instruction) throw new Error('Usage: pnpm start "your instruction"');
 
-  const codex = new Codex({
+  const sdk = await loadCodexSdk({
     ...(process.env.OPENAI_API_KEY ? { apiKey: process.env.OPENAI_API_KEY } : {}),
     // pnpm can skip the SDK's vendored-binary postinstall; point at a locally
     // installed codex when that happens (same escape hatch the evals harness
@@ -43,38 +49,33 @@ async function main(): Promise<void> {
     ...(process.env.CODEX_PATH_OVERRIDE
       ? { codexPathOverride: process.env.CODEX_PATH_OVERRIDE }
       : {}),
-    config: buildCodexConfig(),
+    extraConfig: buildCodexConfig(),
   });
-  const thread = codex.startThread({
+  const result = await runCodexSession({
+    prompt: instruction,
     // Codex picks its own harness-tuned default model; override only via env.
-    ...(process.env.CODEX_STAGEHAND_MODEL ? { model: process.env.CODEX_STAGEHAND_MODEL } : {}),
-    // The browser work happens in the MCP server; the local sandbox can stay
-    // read-only.
-    sandboxMode: "read-only",
-    // Headless policy chosen empirically: "on-failure" lets MCP tool calls
-    // complete; "never" and "untrusted" auto-cancel them ("user cancelled
-    // MCP tool call").
-    approvalPolicy: "on-failure",
-    skipGitRepoCheck: true,
+    model: process.env.CODEX_STAGEHAND_MODEL ?? "",
+    sdk,
+    logger,
+    thread: {
+      // The browser work happens in the MCP server; the local sandbox can stay
+      // read-only.
+      sandboxMode: "read-only",
+      // Headless policy chosen empirically: "on-failure" lets MCP tool calls
+      // complete; "never" and "untrusted" auto-cancel them ("user cancelled
+      // MCP tool call").
+      approvalPolicy: "on-failure",
+      skipGitRepoCheck: true,
+    },
   });
-
-  const streamed = await thread.runStreamed(instruction);
-  let finalResponse = "";
-  for await (const event of streamed.events) {
-    if (
-      event.type === "item.completed" &&
-      typeof event.item === "object" &&
-      event.item !== null &&
-      "type" in event.item &&
-      event.item.type === "agent_message" &&
-      "text" in event.item &&
-      typeof event.item.text === "string"
-    ) {
-      finalResponse = event.item.text;
-    }
+  if (result.status !== "completed") {
+    throw (
+      result.iterationError ??
+      new Error(`Agent did not finish: ${result.stopReason ?? result.status}`)
+    );
   }
   // oxlint-disable-next-line no-console -- CLI example prints the agent result.
-  console.log(finalResponse);
+  console.log(result.finalMessage);
 }
 
 if (import.meta.main) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -465,9 +465,9 @@ importers:
       '@browserbasehq/stagehand-integrations-claude-agent-sdk':
         specifier: workspace:*
         version: link:../integrations/claude-agent-sdk
-      '@openai/codex-sdk':
-        specifier: 'catalog:'
-        version: 0.147.0
+      '@browserbasehq/stagehand-integrations-codex-sdk':
+        specifier: workspace:*
+        version: link:../integrations/codex-sdk
       '@opentelemetry/api':
         specifier: 'catalog:'
         version: 1.9.1
@@ -658,6 +658,25 @@ importers:
       '@browserbasehq/stagehand-integrations':
         specifier: workspace:*
         version: link:../core
+      '@browserbasehq/stagehand-integrations-codex-sdk':
+        specifier: workspace:*
+        version: link:../codex-sdk
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.2
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+
+  packages/integrations/codex-sdk:
+    dependencies:
+      '@browserbasehq/stagehand-integrations':
+        specifier: workspace:*
+        version: link:../core
       '@openai/codex-sdk':
         specifier: 'catalog:'
         version: 0.147.0
@@ -665,6 +684,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.2
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.3(publint@0.3.21)(tsx@4.23.1)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,9 +266,9 @@ importers:
       '@browserbasehq/stagehand-integrations-claude-agent-sdk':
         specifier: workspace:*
         version: link:../integrations/claude-agent-sdk
-      '@openai/codex-sdk':
-        specifier: 'catalog:'
-        version: 0.147.0
+      '@browserbasehq/stagehand-integrations-codex-sdk':
+        specifier: workspace:*
+        version: link:../integrations/codex-sdk
       ai:
         specifier: ^5.0.133
         version: 5.0.220(zod@4.4.3)
@@ -444,6 +444,25 @@ importers:
       '@browserbasehq/stagehand-integrations':
         specifier: workspace:*
         version: link:../core
+      '@browserbasehq/stagehand-integrations-codex-sdk':
+        specifier: workspace:*
+        version: link:../codex-sdk
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.2
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+
+  packages/integrations/codex-sdk:
+    dependencies:
+      '@browserbasehq/stagehand-integrations':
+        specifier: workspace:*
+        version: link:../core
       '@openai/codex-sdk':
         specifier: 'catalog:'
         version: 0.147.0
@@ -451,6 +470,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.2
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.3(publint@0.3.21)(tsx@4.23.1)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3

--- a/turbo.json
+++ b/turbo.json
@@ -36,6 +36,11 @@
       "inputs": ["$TURBO_DEFAULT$", "!dist/**"],
       "outputs": ["dist/**"]
     },
+    "@browserbasehq/stagehand-integrations-codex-sdk#build": {
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", "!dist/**"],
+      "outputs": ["dist/**"]
+    },
     "@browserbasehq/stagehand-evals#build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", "!dist/**"],
@@ -82,6 +87,9 @@
     "@browserbasehq/stagehand-integrations-claude-agent-sdk#typecheck": {
       "dependsOn": ["^build"]
     },
+    "@browserbasehq/stagehand-integrations-codex-sdk#typecheck": {
+      "dependsOn": ["^build"]
+    },
     "@browserbasehq/stagehand-integrations#test:unit": {
       "dependsOn": ["^build", "@browserbasehq/stagehand-integrations#build"],
       "inputs": [
@@ -94,6 +102,16 @@
     },
     "@browserbasehq/stagehand-integrations-claude-agent-sdk#test:unit": {
       "dependsOn": ["^build", "@browserbasehq/stagehand-integrations-claude-agent-sdk#build"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "tests/**",
+        "src/**",
+        "**/*.test.ts",
+        "$TURBO_ROOT$/vitest.config.ts"
+      ]
+    },
+    "@browserbasehq/stagehand-integrations-codex-sdk#test:unit": {
+      "dependsOn": ["^build", "@browserbasehq/stagehand-integrations-codex-sdk#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "tests/**",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
       "packages/evals/tests/**/*.test.ts",
       "packages/integrations/core/tests/**/*.test.ts",
       "packages/integrations/claude-agent-sdk/tests/**/*.test.ts",
+      "packages/integrations/codex-sdk/tests/**/*.test.ts",
       "packages/extension/tests/**/*.test.ts",
       "packages/sdk-ts/tests/**/*.test.ts",
       "packages/extension/understudy/**/*.test.ts",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
       "packages/evals/tests/**/*.test.ts",
       "packages/integrations/core/tests/**/*.test.ts",
       "packages/integrations/claude-agent-sdk/tests/**/*.test.ts",
+      "packages/integrations/codex-sdk/tests/**/*.test.ts",
       "packages/extension/tests/**/*.test.ts",
       "packages/sdk-ts/tests/**/*.test.ts",
       "packages/extension/understudy/**/*.test.ts",


### PR DESCRIPTION
Stacked on #2748. Part 3 of the harness consolidation stack. **Reshaped after review feedback: thin session layer only.**

## What

New thin package `@browserbasehq/stagehand-integrations-codex-sdk`: `loadCodexSdk` + `runCodexSession` — the `startThread`/`runStreamed` event loop (thread config, tool-step budget with abort + listener detach, usage/stop-reason capture) with explicit options and no `EVAL_*` env reads. Evals' codex runner and the codex facade example both call it.

**Deliberately NOT extracted** (stays in evals): the loopback code bridge and mount machinery — they expose evals' in-process tool surfaces to codex and have no integrations consumer. `codexCodeBridge.ts` is back in evals unchanged (still using the shared redaction from #2746).

The example keeps its posture (read-only sandbox, on-failure approvals, harness-tuned default model) and now exits non-zero on failed sessions instead of printing nothing and exiting 0.

Net diff +674/−420 — scaffolding plus the session module; logic is a move.

## Verification

- Full gates ✅; session tests moved with the code
- Connected smoke re-run on the reshaped code — results in PR comment; step-budget semantics previously verified identical to main (50 counted command executions)

## Review updates (2026-08-29)

- **Fail-closed sandbox**: `validateCodexSandboxMode` falls back to `read-only` for unset/unknown modes (was `workspace-write`).
- **Budget stops are `max_turns`**: tool-step budget exhaustion now reports `status: "max_turns"` (matching claude-agent-sdk) instead of `sdk_error`.
- **Absent-vs-zero usage**: `cached_input_tokens`/`reasoning_output_tokens` stay absent when the SDK never reported them; the evals runner forwards them conditionally so trajectories don't record synthetic zeros.
- Default tool-step budget is 100 (session + evals fallback) — codex budgets per tool call while claude budgets per turn.
- Codex example: server resolution moved inside `buildCodexConfig` (fails through `handleFailure`), non-completed runs surface the agent's last message, and the `test` script builds the codex-sdk package it imports.
