### PR TITLE
evals(v4): OTEL provider + LangSmith gating (unwired)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,14 @@ BROWSERBASE_API_KEY=""
 
 # Optional: set this only if Chrome cannot be detected automatically.
 # CHROME_PATH=""
+
+# Trace transport: "native" (default) or "otel" to fan out traces to
+# configured Braintrust and LangSmith sinks.
+# EVAL_TRACE_TRANSPORT="native"
+# LangSmith accepts either LANGSMITH_API_KEY or the legacy LANGCHAIN_API_KEY.
+# LANGSMITH_API_KEY=""
+# Enable LangSmith trace export when using the OTEL transport.
+# LANGSMITH_TRACING="true"
+# Route OTEL-transport Braintrust spans to a custom project/experiment
+# (e.g. "project_name:my-project"). Defaults to stagehand / stagehand-dev.
+# BRAINTRUST_OTEL_PARENT=""

--- a/packages/evals/framework/langsmith.ts
+++ b/packages/evals/framework/langsmith.ts
@@ -1,0 +1,30 @@
+let langSmithPromise: Promise<typeof import("langsmith")> | undefined;
+
+export function hasLangSmithApiKey(): boolean {
+  return Boolean(process.env.LANGSMITH_API_KEY || process.env.LANGCHAIN_API_KEY);
+}
+
+export function langSmithTracingEnabled(): boolean {
+  return hasLangSmithApiKey() && process.env.LANGSMITH_TRACING === "true";
+}
+
+let warnedUnknownTransport = false;
+
+export function resolveTraceTransport(): "native" | "otel" {
+  const value = process.env.EVAL_TRACE_TRANSPORT;
+  if (value === "otel") return "otel";
+  // Fail loud (once) on a typo'd value so a misconfiguration doesn't silently
+  // disable tracing by falling through to the native default.
+  if (value && value !== "native" && !warnedUnknownTransport) {
+    warnedUnknownTransport = true;
+    console.warn(
+      `[evals] Unrecognized EVAL_TRACE_TRANSPORT="${value}"; expected "native" or "otel". Falling back to "native".`,
+    );
+  }
+  return "native";
+}
+
+export function loadLangSmith(): Promise<typeof import("langsmith")> {
+  langSmithPromise ??= import("langsmith");
+  return langSmithPromise;
+}

--- a/packages/evals/framework/otel.ts
+++ b/packages/evals/framework/otel.ts
@@ -1,0 +1,208 @@
+import { SpanStatusCode, trace, type ProxyTracerProvider, type Tracer } from "@opentelemetry/api";
+import {
+  BatchSpanProcessor,
+  type SpanExporter,
+  type SpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+// verify after install: @opentelemetry/sdk-trace-node exports NodeTracerProvider.
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+
+import { langSmithTracingEnabled, resolveTraceTransport } from "./langsmith.js";
+
+const TRACER_NAME = "stagehand-evals";
+const SHUTDOWN_TIMEOUT_MS = 10_000;
+const MAX_SPAN_ATTR_BYTES = 200_000;
+
+let currentProvider: NodeTracerProvider | ProxyTracerProvider | null = null;
+let providerPromise: Promise<void> | null = null;
+let providerRegistered = false;
+
+export async function buildTracerProvider({
+  braintrustParent,
+}: {
+  braintrustParent?: string;
+}): Promise<void> {
+  // Self-gate: never register a global provider off the otel transport, so the
+  // native/Braintrust path is untouched even if a caller invokes this directly.
+  if (resolveTraceTransport() !== "otel") return;
+  if (providerRegistered || currentProvider) return;
+  if (providerPromise) return providerPromise;
+
+  providerPromise = initializeTracerProvider(braintrustParent);
+  try {
+    await providerPromise;
+  } finally {
+    providerPromise = null;
+  }
+}
+
+async function initializeTracerProvider(braintrustParent?: string): Promise<void> {
+  const spanProcessors: SpanProcessor[] = [];
+  const braintrustApiKey = process.env.BRAINTRUST_API_KEY;
+
+  if (braintrustApiKey) {
+    // verify after install: @braintrust/otel exports BraintrustSpanProcessor.
+    const { BraintrustSpanProcessor } = await import("@braintrust/otel");
+    // Precedence: explicit user override (env) > caller-computed default >
+    // module fallback. The runner always passes `braintrustParent`, so the env
+    // var must win over it or it would never take effect for eval runs.
+    const braintrustProjectName = process.env.CI === "true" ? "stagehand" : "stagehand-dev";
+    const parent =
+      process.env.BRAINTRUST_OTEL_PARENT?.trim() ||
+      braintrustParent ||
+      `project_name:${braintrustProjectName}`;
+    const braintrustOtelUrl = process.env.BRAINTRUST_OTEL_URL;
+
+    spanProcessors.push(
+      new BraintrustSpanProcessor({
+        apiKey: braintrustApiKey,
+        parent,
+        filterAISpans: false,
+        ...(braintrustOtelUrl && {
+          apiUrl: braintrustOtelUrl.replace(/otel\/v1\/traces\/?$/, ""),
+        }),
+      }),
+    );
+  }
+
+  if (langSmithTracingEnabled()) {
+    // verify after install: this subpath exports LangSmithOTLPTraceExporter.
+    const { LangSmithOTLPTraceExporter } = await import("langsmith/experimental/otel/exporter");
+    // LangSmith's exporter inherits the full OTLP exporter implementation at
+    // runtime, but its declaration omits the inherited shutdown() method when
+    // the optional OTLP peer's types are not installed directly.
+    const exporter = new LangSmithOTLPTraceExporter() as unknown as SpanExporter;
+    spanProcessors.push(new BatchSpanProcessor(exporter));
+  }
+
+  const provider = new NodeTracerProvider({ spanProcessors });
+  provider.register();
+  currentProvider = provider;
+  providerRegistered = true;
+}
+
+export function getTracer(): Tracer {
+  return currentProvider?.getTracer(TRACER_NAME) ?? trace.getTracer(TRACER_NAME);
+}
+
+export function jsonAttr(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return "[unserializable]";
+  }
+}
+
+/** JSON attribute value, replaced with a truncation marker if oversized. */
+export function cappedJsonAttr(value: unknown): string {
+  const serialized = jsonAttr(value);
+  if (Buffer.byteLength(serialized, "utf8") <= MAX_SPAN_ATTR_BYTES) return serialized;
+  return jsonAttr({
+    _truncated: `attribute exceeded ${MAX_SPAN_ATTR_BYTES} UTF-8 bytes; see the task-root span payload / .trajectories for the full record`,
+  });
+}
+
+export interface HarnessAgentSpanInfo {
+  /** Harness name, e.g. "claude_code" | "codex". */
+  harness: string;
+  model: string;
+  task: string;
+  instruction?: string;
+}
+
+/**
+ * Wrap an external-harness (claude_code / codex) agent run in an OTEL span so
+ * it appears as an agent node under the eval's task-root span in LangSmith /
+ * Braintrust — parity with the `stagehand` harness, whose native RPC spans are
+ * captured directly via the global tracer. These harnesses drive their own
+ * SDKs (claude-agent-sdk / codex-sdk), which do not emit OTEL, so this span +
+ * the trajectory payload on the task-root span are the trace's agent record.
+ *
+ * No-op (runs `fn` directly, creates no span) unless the OTEL transport is
+ * active, so the native/Braintrust path stays byte-identical.
+ */
+export async function withHarnessAgentSpan<T extends { _success?: boolean }>(
+  info: HarnessAgentSpanInfo,
+  fn: () => Promise<T>,
+): Promise<T> {
+  if (resolveTraceTransport() !== "otel") return fn();
+
+  return getTracer().startActiveSpan(
+    `agent.${info.harness}`,
+    {
+      attributes: {
+        "langsmith.span.kind": "chain",
+        "langsmith.metadata": jsonAttr({
+          harness: info.harness,
+          model: info.model,
+          task: info.task,
+        }),
+        "input.value": cappedJsonAttr({
+          instruction: info.instruction,
+          model: info.model,
+          task: info.task,
+        }),
+        "input.mime_type": "application/json",
+      },
+    },
+    async (span) => {
+      try {
+        const result = await fn();
+        span.setAttributes({
+          "output.value": cappedJsonAttr(result),
+          "output.mime_type": "application/json",
+        });
+        return result;
+      } catch (error) {
+        span.recordException(error instanceof Error ? error : String(error));
+        span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: error instanceof Error ? error.message : String(error),
+        });
+        throw error;
+      } finally {
+        span.end();
+      }
+    },
+  );
+}
+
+export async function shutdownTracing(): Promise<void> {
+  const provider = currentProvider;
+  currentProvider = null;
+  providerPromise = null;
+  // Clear the init guard so a later runEvals in the same process can register a
+  // fresh provider (otherwise buildTracerProvider() short-circuits and drops spans).
+  providerRegistered = false;
+
+  if (!(provider instanceof NodeTracerProvider)) return;
+
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeout = setTimeout(
+      () => reject(new Error(`Tracing shutdown timed out after ${SHUTDOWN_TIMEOUT_MS}ms.`)),
+      SHUTDOWN_TIMEOUT_MS,
+    );
+    timeout.unref?.();
+  });
+
+  try {
+    await Promise.race([
+      provider
+        .forceFlush()
+        .catch(() => {})
+        .then(() => provider.shutdown()),
+      timeoutPromise,
+    ]);
+  } catch {
+    // Tracing teardown must never mask an eval result.
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+export function resetTracingStateForTests(): void {
+  currentProvider = null;
+  providerPromise = null;
+  providerRegistered = false;
+}


### PR DESCRIPTION
## Why
Stack 2/6. Adds the tracing transport surface; no call sites yet.

## What
- `framework/langsmith.ts`: transport gating (`EVAL_TRACE_TRANSPORT` = native (default) | otel).
- `framework/otel.ts`: NodeTracerProvider (Braintrust processor + LangSmith exporter) with **global** `provider.register()` so Stagehand 4.0 native RPC spans are captured; `withHarnessAgentSpan` helper. Only builds/registers under otel — native path untouched.
- `.env.example`: LangSmith + `EVAL_TRACE_TRANSPORT` vars.

## Testing
typecheck + unit + build green.

Base: #2757

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an OpenTelemetry tracing transport for evals to export spans to Braintrust and optionally LangSmith. Old behavior: native-only tracing. New behavior: when `EVAL_TRACE_TRANSPORT="otel"`, a global OTEL provider exports to configured sinks; defaults remain and no call sites initialize it yet.

- Builds a `NodeTracerProvider` (`@opentelemetry/sdk-trace-node`) with Braintrust `BraintrustSpanProcessor` (`@braintrust/otel`) and optional LangSmith OTLP exporter (`langsmith/experimental/otel/exporter`); registers globally under OTEL to capture Stagehand RPC spans; caps JSON span attributes at 200kB; exposes `shutdownTracing` (10s timeout) and `resetTracingStateForTests`.
- Gating: `resolveTraceTransport()` returns `native` or `otel` and warns once on unknown values. LangSmith export requires `LANGSMITH_TRACING="true"` plus `LANGSMITH_API_KEY` or `LANGCHAIN_API_KEY`.
- Adds `withHarnessAgentSpan` to wrap external harness runs; it is a no-op unless the OTEL transport is active.
- Updates `.env.example` to document `EVAL_TRACE_TRANSPORT`, LangSmith keys, `LANGSMITH_TRACING`, and Braintrust vars (`BRAINTRUST_API_KEY`, optional `BRAINTRUST_OTEL_PARENT`/`BRAINTRUST_OTEL_URL`; default parent varies by `CI`).

<sup>Written for commit e4f34a7f5ff85587a4bb460ffde31383db97cae3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

