### PR TITLE
evals(v4): wire OTEL transport into runEvals

### DIFF
--- a/packages/evals/framework/runner.ts
+++ b/packages/evals/framework/runner.ts
@@ -33,6 +33,9 @@ import { executeBenchTask } from "./benchRunner.js";
 import { hasBraintrustApiKey, loadBraintrust, tracedSpan } from "./braintrust.js";
 import { onceAsync, registerActiveRunCleanup } from "./activeRunCleanup.js";
 import { loadTaskModuleFromPath } from "./taskLoader.js";
+import { resolveTraceTransport } from "./langsmith.js";
+import { buildTracerProvider, shutdownTracing } from "./otel.js";
+import { randomUUID } from "node:crypto";
 
 export { discoverTasks, resolveTarget } from "./discovery.js";
 export { inferEffectiveBenchCategory, resolveBenchModelEntries } from "./benchPlanner.js";
@@ -291,59 +294,42 @@ function formatProgressError(error: unknown): string | undefined {
   }
 }
 
-export async function runEvals(options: RunEvalsOptions): Promise<RunEvalsResult> {
-  const concurrency = options.concurrency ?? 3;
-  const trials = options.trials ?? 3;
-  const environment = options.environment ?? "LOCAL";
+const MAX_SPAN_PAYLOAD_BYTES = 2_000_000;
 
-  const testcases = generateTestcases(options.tasks, options);
-  options.onProgress?.({
-    type: "planned",
-    total: testcases.length,
-  });
-  if (testcases.length === 0) {
-    console.log("No testcases to run.");
-    return {
-      experimentName: "empty",
-      summary: { passed: 0, failed: 0, total: 0 },
-      results: [],
+export function capForSpan(value: Record<string, unknown>): Record<string, unknown> {
+  const byteLength = (candidate: Record<string, unknown>): number =>
+    Buffer.byteLength(JSON.stringify(candidate), "utf8");
+
+  try {
+    if (byteLength(value) <= MAX_SPAN_PAYLOAD_BYTES) return value;
+
+    const truncated: Record<string, unknown> = {
+      ...value,
+      _truncated: `Span payload exceeded ${MAX_SPAN_PAYLOAD_BYTES} UTF-8 bytes.`,
     };
+    if (Array.isArray(value.logs)) {
+      let retainedLogs = value.logs;
+      while (retainedLogs.length > 0) {
+        const retainedCount = Math.floor(retainedLogs.length / 2);
+        retainedLogs = retainedCount === 0 ? [] : retainedLogs.slice(-retainedCount);
+        truncated.logs = retainedLogs;
+        if (byteLength(truncated) <= MAX_SPAN_PAYLOAD_BYTES) return truncated;
+      }
+    }
+    delete truncated.logs;
+    if (byteLength(truncated) <= MAX_SPAN_PAYLOAD_BYTES) return truncated;
+  } catch {
+    // Fall through to a small, serializable replacement.
   }
 
+  return {
+    _truncated: `Span payload exceeded ${MAX_SPAN_PAYLOAD_BYTES} UTF-8 bytes; non-log fields were dropped.`,
+  };
+}
+
+export async function runEvals(options: RunEvalsOptions): Promise<RunEvalsResult> {
+  const traceTransport = resolveTraceTransport();
   const hasCoreOnly = options.tasks.every((t: DiscoveredTask) => t.tier === "core");
-  const effectiveCoreToolSurface = hasCoreOnly
-    ? (options.coreToolSurface ?? "understudy_code")
-    : undefined;
-  const effectiveCoreStartupProfile =
-    hasCoreOnly && effectiveCoreToolSurface
-      ? (options.coreStartupProfile ??
-        resolveDefaultCoreStartupProfile(effectiveCoreToolSurface, environment))
-      : undefined;
-  const effectiveBenchHarness = hasCoreOnly
-    ? undefined
-    : (options.harness ?? DEFAULT_BENCH_HARNESS);
-  const experimentName = generateExperimentName({
-    evalName: options.tasks.length === 1 ? options.tasks[0].name : undefined,
-    category: options.categoryFilter ?? undefined,
-    environment,
-    toolSurface: effectiveCoreToolSurface,
-    startupProfile: effectiveCoreStartupProfile,
-  });
-  const runModel = resolveUnambiguousModel(testcases.map((testcase) => testcase.input?.modelName));
-
-  // Stamp the run-scoped trajectory group; the token is generated once here and
-  // reused for the completion-time experiment link. Local persistence only.
-  const trajectoryGroup = buildTrajectoryGroupSlug({
-    experimentName,
-    model: runModel,
-    runToken: generateRunToken(),
-  });
-  process.env.EVAL_EXPERIMENT_NAME = experimentName;
-  process.env.EVAL_TRAJECTORY_GROUP = trajectoryGroup;
-  if (runModel) process.env.EVAL_TRAJECTORY_MODEL = runModel;
-  else delete process.env.EVAL_TRAJECTORY_MODEL;
-  if (options.modelOverride) process.env.EVAL_MODEL_OVERRIDE = options.modelOverride;
-
   const braintrustProjectName = hasCoreOnly
     ? process.env.CI === "true"
       ? "stagehand-core"
@@ -352,156 +338,252 @@ export async function runEvals(options: RunEvalsOptions): Promise<RunEvalsResult
       ? "stagehand"
       : "stagehand-dev";
 
-  const scores = hasCoreOnly ? [passRate, errorMatch] : [exactMatch, errorMatch];
+  try {
+    const concurrency = options.concurrency ?? 3;
+    const trials = options.trials ?? 3;
+    const environment = options.environment ?? "LOCAL";
 
-  const { Eval, flush } = await loadBraintrust();
-  const sendLogs = hasBraintrustApiKey();
+    const testcases = generateTestcases(options.tasks, options);
+    options.onProgress?.({
+      type: "planned",
+      total: testcases.length,
+    });
+    if (testcases.length === 0) {
+      console.log("No testcases to run.");
+      return {
+        experimentName: "empty",
+        summary: { passed: 0, failed: 0, total: 0 },
+        results: [],
+      };
+    }
 
-  // Aggressive abort: when the caller flips signal.reason to "aggressive",
-  // close every active session so any in-flight task throws on its next
-  // page operation. The cleanup path inside executeBenchTask handles the
-  // throw; finished tasks' cleanup is a no-op via onceAsync.
-  const onAggressiveAbort = async (): Promise<void> => {
-    if (readAbortMode(options.signal) !== "aggressive") return;
-    const { cleanupActiveRunResources } = await import("./activeRunCleanup.js");
-    await cleanupActiveRunResources();
-  };
-  options.signal?.addEventListener("abort", () => {
-    void onAggressiveAbort();
-  });
+    const effectiveCoreToolSurface = hasCoreOnly
+      ? (options.coreToolSurface ?? "understudy_code")
+      : undefined;
+    const effectiveCoreStartupProfile =
+      hasCoreOnly && effectiveCoreToolSurface
+        ? (options.coreStartupProfile ??
+          resolveDefaultCoreStartupProfile(effectiveCoreToolSurface, environment))
+        : undefined;
+    const effectiveBenchHarness = hasCoreOnly
+      ? undefined
+      : (options.harness ?? DEFAULT_BENCH_HARNESS);
+    const experimentName = generateExperimentName({
+      evalName: options.tasks.length === 1 ? options.tasks[0].name : undefined,
+      category: options.categoryFilter ?? undefined,
+      environment,
+      toolSurface: effectiveCoreToolSurface,
+      startupProfile: effectiveCoreStartupProfile,
+    });
+    // Path-safe (LangSmith addresses threads by URL segment) + collision-resistant
+    // (random suffix so two runs in the same millisecond don't share a thread).
+    const traceThreadId = `${experimentName.replace(/[^A-Za-z0-9._-]+/g, "__")}-${Date.now().toString(36)}-${randomUUID().slice(0, 8)}`;
+    const runModel = resolveUnambiguousModel(
+      testcases.map((testcase) => testcase.input?.modelName),
+    );
 
-  const evalResult = await withBrowserbaseExtensionScope(() =>
-    Eval(
-      braintrustProjectName,
-      {
-        experimentName,
-        metadata: {
-          environment,
-          tier: hasCoreOnly ? "core" : "bench",
-          ...(effectiveCoreToolSurface && {
-            toolSurface: effectiveCoreToolSurface,
-          }),
-          ...(effectiveCoreStartupProfile && {
-            startupProfile: effectiveCoreStartupProfile,
-          }),
-          ...(effectiveBenchHarness && { harness: effectiveBenchHarness }),
-          ...(options.modelOverride && { model: options.modelOverride }),
-          ...(options.useApi && { api: true }),
-        },
-        data: () => testcases,
-        task: async (input: EvalInput): Promise<TaskResult> => {
-          // Cooperative abort: skip any testcase that hasn't started yet
-          // when the signal has flipped. The in-flight task at the moment of
-          // abort still finishes its current step; this stops the next one
-          // from spinning up.
-          if (options.signal?.aborted) {
+    // Stamp the run-scoped trajectory group; the token is generated once here and
+    // reused for the completion-time experiment link. Local persistence only.
+    const trajectoryGroup = buildTrajectoryGroupSlug({
+      experimentName,
+      model: runModel,
+      runToken: generateRunToken(),
+    });
+    process.env.EVAL_EXPERIMENT_NAME = experimentName;
+    process.env.EVAL_TRAJECTORY_GROUP = trajectoryGroup;
+    if (runModel) process.env.EVAL_TRAJECTORY_MODEL = runModel;
+    else delete process.env.EVAL_TRAJECTORY_MODEL;
+    if (options.modelOverride) process.env.EVAL_MODEL_OVERRIDE = options.modelOverride;
+
+    const scores = hasCoreOnly ? [passRate, errorMatch] : [exactMatch, errorMatch];
+
+    if (traceTransport === "otel") {
+      await buildTracerProvider({ braintrustParent: `project_name:${braintrustProjectName}` });
+    }
+
+    const { Eval, flush } = await loadBraintrust();
+    const sendLogs = hasBraintrustApiKey();
+
+    // Aggressive abort: when the caller flips signal.reason to "aggressive",
+    // close every active session so any in-flight task throws on its next
+    // page operation. The cleanup path inside executeBenchTask handles the
+    // throw; finished tasks' cleanup is a no-op via onceAsync.
+    const onAggressiveAbort = async (): Promise<void> => {
+      if (readAbortMode(options.signal) !== "aggressive") return;
+      const { cleanupActiveRunResources } = await import("./activeRunCleanup.js");
+      await cleanupActiveRunResources();
+    };
+    options.signal?.addEventListener("abort", () => {
+      void onAggressiveAbort();
+    });
+
+    const evalResult = await withBrowserbaseExtensionScope(() =>
+      Eval(
+        braintrustProjectName,
+        {
+          experimentName,
+          metadata: {
+            environment,
+            tier: hasCoreOnly ? "core" : "bench",
+            ...(effectiveCoreToolSurface && {
+              toolSurface: effectiveCoreToolSurface,
+            }),
+            ...(effectiveCoreStartupProfile && {
+              startupProfile: effectiveCoreStartupProfile,
+            }),
+            ...(effectiveBenchHarness && { harness: effectiveBenchHarness }),
+            ...(options.modelOverride && { model: options.modelOverride }),
+            ...(options.useApi && { api: true }),
+          },
+          data: () => testcases,
+          task: async (input: EvalInput): Promise<TaskResult> => {
+            // Cooperative abort: skip any testcase that hasn't started yet
+            // when the signal has flipped. The in-flight task at the moment of
+            // abort still finishes its current step; this stops the next one
+            // from spinning up.
+            if (options.signal?.aborted) {
+              options.onProgress?.({
+                type: "failed",
+                taskName: input.name,
+                modelName: input.modelName,
+                error: "aborted",
+              });
+              return {
+                _success: false,
+                error: "aborted by user",
+                logs: [],
+              };
+            }
+
+            const resolvedTask =
+              options.registry.byName.get(input.name) ??
+              (input.name.includes("/")
+                ? undefined
+                : options.registry.byName.get(`agent/${input.name}`));
+
+            if (!resolvedTask) {
+              throw new EvalsError(`Task "${input.name}" not found in registry.`);
+            }
+
             options.onProgress?.({
-              type: "failed",
+              type: "started",
               taskName: input.name,
               modelName: input.modelName,
-              error: "aborted",
             });
-            return {
-              _success: false,
-              error: "aborted by user",
-              logs: [],
-            };
-          }
 
-          const resolvedTask =
-            options.registry.byName.get(input.name) ??
-            (input.name.includes("/")
-              ? undefined
-              : options.registry.byName.get(`agent/${input.name}`));
+            const result =
+              traceTransport === "otel"
+                ? await tracedSpan(
+                    async (span) => {
+                      const r = await executeTask(input, resolvedTask, options);
+                      span?.log({
+                        output: capForSpan({
+                          _success: r._success,
+                          ...(r.error === undefined ? {} : { error: r.error }),
+                          ...(r.metrics === undefined ? {} : { metrics: r.metrics }),
+                          ...(r.logs === undefined ? {} : { logs: r.logs }),
+                        }),
+                        metadata: {
+                          experiment_name: experimentName,
+                          thread_id: traceThreadId,
+                          model: input.modelName,
+                          task: input.name,
+                        },
+                      });
+                      return r;
+                    },
+                    {
+                      name: input.name,
+                      type: "task",
+                      event: { input: { task: input.name, model: input.modelName } },
+                    },
+                  )
+                : await executeTask(input, resolvedTask, options);
 
-          if (!resolvedTask) {
-            throw new EvalsError(`Task "${input.name}" not found in registry.`);
-          }
+            options.onProgress?.({
+              type: result._success ? "passed" : "failed",
+              taskName: input.name,
+              modelName: input.modelName,
+              error: result._success ? undefined : formatProgressError(result.error),
+            });
 
-          options.onProgress?.({
-            type: "started",
-            taskName: input.name,
-            modelName: input.modelName,
-          });
-
-          const result = await executeTask(input, resolvedTask, options);
-
-          options.onProgress?.({
-            type: result._success ? "passed" : "failed",
-            taskName: input.name,
-            modelName: input.modelName,
-            error: result._success ? undefined : formatProgressError(result.error),
-          });
-
-          return result;
+            return result;
+          },
+          scores: scores as unknown as never,
+          maxConcurrency: concurrency,
+          trialCount: trials,
         },
-        scores: scores as unknown as never,
-        maxConcurrency: concurrency,
-        trialCount: trials,
-      },
+        {
+          progress: silentBraintrustProgress,
+          reporter: silentBraintrustReporter,
+          ...(sendLogs ? {} : { noSendLogs: true }),
+        },
+      ),
+    );
+
+    if (sendLogs) {
+      await flush();
+    }
+
+    const summaryResults = evalResult.results.map((result) => {
+      const output =
+        typeof result.output === "boolean" ? { _success: result.output } : result.output;
+      const categories = Array.isArray(result.metadata?.categories)
+        ? result.metadata.categories.filter(
+            (category): category is string => typeof category === "string",
+          )
+        : undefined;
+
+      return {
+        input: result.input,
+        output,
+        name: result.input.name,
+        score: output._success ? 1 : 0,
+        ...(categories && { categories }),
+      };
+    });
+
+    const resolvedExperimentName = evalResult.summary?.experimentName ?? experimentName;
+    const resolvedExperimentUrl = evalResult.summary?.experimentUrl;
+
+    // Cross-link local trajectories to the resolved Braintrust experiment. The
+    // hashed name (e.g. `agent/onlineMind2Web-92918006`) is only known now, after
+    // Eval() resolves — so write it once at the group-dir root of the group this
+    // run recorded into.
+    await writeExperimentLink(
+      resolveTrajectoryRoot(),
+      trajectoryGroup,
       {
-        progress: silentBraintrustProgress,
-        reporter: silentBraintrustReporter,
-        ...(sendLogs ? {} : { noSendLogs: true }),
+        braintrustExperiment: resolvedExperimentName,
+        braintrustExperimentId: evalResult.summary?.experimentId ?? null,
+        braintrustExperimentUrl: resolvedExperimentUrl ?? null,
+        braintrustProject: evalResult.summary?.projectName ?? braintrustProjectName,
+        braintrustProjectUrl: evalResult.summary?.projectUrl ?? null,
+        requestedExperimentName: experimentName,
       },
-    ),
-  );
+      { persist: !hasCoreOnly && shouldPersistTrajectory(undefined) },
+    );
 
-  if (sendLogs) {
-    await flush();
-  }
+    await generateSummary(
+      summaryResults,
+      resolvedExperimentName,
+      resolvedExperimentUrl,
+      evalResult.summary?.scores,
+    );
 
-  const summaryResults = evalResult.results.map((result) => {
-    const output = typeof result.output === "boolean" ? { _success: result.output } : result.output;
-    const categories = Array.isArray(result.metadata?.categories)
-      ? result.metadata.categories.filter(
-          (category): category is string => typeof category === "string",
-        )
-      : undefined;
+    const passed = summaryResults.filter((r) => r.output._success).length;
+    const failed = summaryResults.filter((r) => !r.output._success).length;
 
     return {
-      input: result.input,
-      output,
-      name: result.input.name,
-      score: output._success ? 1 : 0,
-      ...(categories && { categories }),
+      experimentName: resolvedExperimentName,
+      summary: { passed, failed, total: summaryResults.length },
+      results: summaryResults,
     };
-  });
-
-  const resolvedExperimentName = evalResult.summary?.experimentName ?? experimentName;
-  const resolvedExperimentUrl = evalResult.summary?.experimentUrl;
-
-  // Cross-link local trajectories to the resolved Braintrust experiment. The
-  // hashed name (e.g. `agent/onlineMind2Web-92918006`) is only known now, after
-  // Eval() resolves — so write it once at the group-dir root of the group this
-  // run recorded into.
-  await writeExperimentLink(
-    resolveTrajectoryRoot(),
-    trajectoryGroup,
-    {
-      braintrustExperiment: resolvedExperimentName,
-      braintrustExperimentId: evalResult.summary?.experimentId ?? null,
-      braintrustExperimentUrl: resolvedExperimentUrl ?? null,
-      braintrustProject: evalResult.summary?.projectName ?? braintrustProjectName,
-      braintrustProjectUrl: evalResult.summary?.projectUrl ?? null,
-      requestedExperimentName: experimentName,
-    },
-    { persist: !hasCoreOnly && shouldPersistTrajectory(undefined) },
-  );
-
-  await generateSummary(
-    summaryResults,
-    resolvedExperimentName,
-    resolvedExperimentUrl,
-    evalResult.summary?.scores,
-  );
-
-  const passed = summaryResults.filter((r) => r.output._success).length;
-  const failed = summaryResults.filter((r) => !r.output._success).length;
-
-  return {
-    experimentName: resolvedExperimentName,
-    summary: { passed, failed, total: summaryResults.length },
-    results: summaryResults,
-  };
+  } finally {
+    if (traceTransport === "otel") {
+      try {
+        await shutdownTracing();
+      } catch {}
+    }
+  }
 }

--- a/packages/evals/tests/framework/capforspan.test.ts
+++ b/packages/evals/tests/framework/capforspan.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { capForSpan } from "../../framework/runner.js";
+
+const MAX = 2_000_000;
+const bytes = (v: unknown): number => Buffer.byteLength(JSON.stringify(v), "utf8");
+
+describe("capForSpan", () => {
+  it("returns small payloads unchanged", () => {
+    const value = { _success: true, metrics: { steps: 3 }, logs: ["a", "b"] };
+    expect(capForSpan(value)).toBe(value);
+  });
+
+  it("keeps a trailing slice of logs when the payload exceeds the cap", () => {
+    // ~4MB: 400 entries x ~10KB. Distinguishable so we can assert the tail survives.
+    const logs = Array.from({ length: 400 }, (_, i) => `entry-${i}-${"x".repeat(10_000)}`);
+    const capped = capForSpan({ _success: false, logs });
+
+    expect(bytes(capped)).toBeLessThanOrEqual(MAX);
+    const kept = capped.logs as string[];
+    expect(kept.length).toBeGreaterThan(0);
+    expect(kept.length).toBeLessThan(logs.length);
+    // Tail-preserving: kept entries are a contiguous suffix of the input.
+    expect(kept).toEqual(logs.slice(logs.length - kept.length));
+    expect(capped._truncated).toMatch(/exceeded/);
+  });
+
+  it("drops oversized non-log payloads so the result is always within the cap", () => {
+    const capped = capForSpan({
+      _success: false,
+      error: "e".repeat(2_500_000),
+      logs: ["a"],
+    });
+    expect(bytes(capped)).toBeLessThanOrEqual(MAX);
+    expect(capped.error).toBeUndefined();
+    expect(capped._truncated).toMatch(/non-log fields were dropped/);
+  });
+
+  it("measures UTF-8 bytes, not UTF-16 code units", () => {
+    // "€" = 1 UTF-16 unit but 3 UTF-8 bytes: JSON char length is under the cap
+    // while the byte length is over — a char-counting cap would wrongly pass it.
+    const value = { note: "€".repeat(700_000) };
+    expect(JSON.stringify(value).length).toBeLessThan(MAX);
+    expect(bytes(value)).toBeGreaterThan(MAX);
+
+    const capped = capForSpan(value);
+    expect(bytes(capped)).toBeLessThanOrEqual(MAX);
+    expect(capped.note).toBeUndefined();
+    expect(capped._truncated).toBeDefined();
+  });
+
+  it("falls back to a serializable marker when the payload can't be stringified", () => {
+    const circular: Record<string, unknown> = { _success: true };
+    circular.self = circular;
+    const capped = capForSpan(circular);
+    expect(capped._truncated).toBeDefined();
+    expect(() => JSON.stringify(capped)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Why
Stack 3/6. Wires the provider into the run loop.

## What
- `buildTracerProvider`/`shutdownTracing` in a try/finally (otel only).
- Gated task-root `tracedSpan` carrying `capForSpan(TaskResult)` (UTF-8 byte cap, tail-trim) + path-safe, collision-resistant `thread_id`.
- Trajectory persistence (`writeExperimentLink`/persist gate) left byte-identical; native task path unchanged.

## Testing
typecheck + unit + build green.

Base: #2758

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OpenTelemetry tracing to `runEvals` when the trace transport is `otel`, emitting a task-root span per task while keeping non-OTel runs and Braintrust logging unchanged. Enables per-task traces with capped outputs and URL-safe, collision-resistant thread IDs.

- Gate on `resolveTraceTransport() === "otel"`; initialize `buildTracerProvider({ braintrustParent: "project_name:<project>" })` and always `shutdownTracing()` in a `finally`.
- Wrap each task in `tracedSpan` (name = task, type = "task"; event includes `{ input: { task, model } }`); span logs `{ output, metadata }` where output is a capped subset and metadata includes `experiment_name`, `thread_id`, `model`, `task`.
- Add `capForSpan` with a 2 MB UTF-8 cap: tail-preserves `logs` by halving, then drops `logs`; if still too large or not serializable, replace with minimal `{ _truncated }`.
- Generate per-run `thread_id` as `<sanitized experimentName>-<base36 timestamp>-<uuid8>` for URL-safe LangSmith threads.
- Add tests in `packages/evals/tests/framework/capforspan.test.ts` covering small payloads, tail-preserving log trimming, non-log drops, UTF-8 byte sizing, and circular fallback.

<sup>Written for commit 1358d414d28085013aecb9eae8093e1c87e55ed1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

