### PR TITLE
evals(v4): braintrust tracedSpan OTEL branch

### DIFF
--- a/packages/evals/framework/braintrust.ts
+++ b/packages/evals/framework/braintrust.ts
@@ -7,7 +7,9 @@
  * the callback's value unchanged, so this is safe to call from offline tools
  * (e.g., `bench verify`).
  */
+import { SpanStatusCode } from "@opentelemetry/api";
 import type { Span, StartSpanArgs } from "braintrust";
+import { resolveTraceTransport } from "./langsmith.js";
 
 let braintrustPromise: Promise<typeof import("braintrust")> | undefined;
 
@@ -37,6 +39,53 @@ const NOOP_SPAN: SpanLike = {
 };
 
 export async function tracedSpan<T>(fn: TracedFn<T>, options: TracedSpanOptions): Promise<T> {
+  if (resolveTraceTransport() === "otel") {
+    // cappedJsonAttr keeps oversized attrs under the exporter limit; shared with
+    // otel.ts so there's a single serialization/cap path.
+    const { getTracer, cappedJsonAttr } = await import("./otel.js");
+    const input = options.event?.input;
+    return getTracer().startActiveSpan(
+      options.name,
+      {
+        attributes: {
+          "langsmith.span.kind": options.type === "llm" ? "llm" : "chain",
+          ...(input === undefined
+            ? {}
+            : {
+                "input.value": cappedJsonAttr(input),
+                "input.mime_type": "application/json",
+              }),
+        },
+      },
+      async (otelSpan) => {
+        const span: SpanLike = {
+          log: (event) => {
+            if (event.output !== undefined) {
+              otelSpan.setAttributes({
+                "output.value": cappedJsonAttr(event.output),
+                "output.mime_type": "application/json",
+              });
+            }
+            if (event.metadata !== undefined) {
+              otelSpan.setAttribute("langsmith.metadata", cappedJsonAttr(event.metadata));
+            }
+          },
+        };
+        try {
+          return await fn(span);
+        } catch (error) {
+          otelSpan.recordException(error instanceof Error ? error : String(error));
+          otelSpan.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: error instanceof Error ? error.message : String(error),
+          });
+          throw error;
+        } finally {
+          otelSpan.end();
+        }
+      },
+    );
+  }
   if (!hasBraintrustApiKey()) {
     return fn(NOOP_SPAN);
   }


### PR DESCRIPTION
## Why
Stack 4/6.

## What
- Prepend an otel branch to `tracedSpan` emitting LangSmith attrs (`langsmith.span.kind`, `input/output.value`, metadata).
- Native `traced()`/NOOP path below is byte-identical when `EVAL_TRACE_TRANSPORT` is unset.

## Testing
typecheck + unit + build green.

Base: #2759

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an OTEL path to `tracedSpan` in the `braintrust` evaluator to emit LangSmith-compatible span attributes when EVAL_TRACE_TRANSPORT=otel. When unset or not "otel", it uses the existing `traced()`/NOOP path and remains byte-identical.

- Emits: `langsmith.span.kind` (llm|chain); `input.value`/`input.mime_type` when input exists; `output.value`/`output.mime_type` on log; and `langsmith.metadata`. Values are JSON-serialized and size-capped; `mime_type` is `application/json`.
- Records exceptions, sets OTEL span status to error via `@opentelemetry/api`, and always ends the span.
- Enable with EVAL_TRACE_TRANSPORT=otel; no `braintrust` API key is required for the OTEL path.

<sup>Written for commit c1330165a4c75955a98ff432ff6eca453d608915. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

