### PR TITLE
feat(evals v4): OTEL agent spans for claude_code/codex harnesses

### DIFF
--- a/packages/evals/framework/benchHarness.ts
+++ b/packages/evals/framework/benchHarness.ts
@@ -11,6 +11,7 @@ import {
 import { runCodexAgent } from "./codexRunner.js";
 import { prepareCodexToolAdapter, type PreparedCodexToolAdapter } from "./codexToolAdapter.js";
 import { buildExternalHarnessTaskPlan } from "./externalHarnessPlan.js";
+import { withHarnessAgentSpan } from "./otel.js";
 import type { DiscoveredTask, TaskResult } from "./types.js";
 import type { BenchMatrixRow, BenchTaskKind, Harness } from "./benchTypes.js";
 
@@ -160,18 +161,27 @@ export const claudeCodeHarness: BenchHarness = {
         plan,
         logger,
       });
-      return await runClaudeCodeAgent({
-        plan,
-        model: input.modelName,
-        logger,
-        toolAdapter,
-        signal,
-        verifier: {
-          v3: carrierV3,
-          taskSpec: buildExternalHarnessTaskSpec(plan, input),
-          dataset: plan.dataset,
+      return await withHarnessAgentSpan(
+        {
+          harness: "claude_code",
+          model: input.modelName,
+          task: input.name,
+          instruction: plan.instruction,
         },
-      });
+        () =>
+          runClaudeCodeAgent({
+            plan,
+            model: input.modelName,
+            logger,
+            toolAdapter,
+            signal,
+            verifier: {
+              v3: carrierV3,
+              taskSpec: buildExternalHarnessTaskSpec(plan, input),
+              dataset: plan.dataset,
+            },
+          }),
+      );
     } finally {
       await toolAdapter?.cleanup();
       // Deregister the never-init()-ed carrier (instance registry, event
@@ -209,18 +219,27 @@ export const codexHarness: BenchHarness = {
         plan,
         logger,
       });
-      return await runCodexAgent({
-        plan,
-        model: input.modelName,
-        logger,
-        toolAdapter,
-        signal,
-        verifier: {
-          v3: carrierV3,
-          taskSpec: buildExternalHarnessTaskSpec(plan, input),
-          dataset: plan.dataset,
+      return await withHarnessAgentSpan(
+        {
+          harness: "codex",
+          model: input.modelName,
+          task: input.name,
+          instruction: plan.instruction,
         },
-      });
+        () =>
+          runCodexAgent({
+            plan,
+            model: input.modelName,
+            logger,
+            toolAdapter,
+            signal,
+            verifier: {
+              v3: carrierV3,
+              taskSpec: buildExternalHarnessTaskSpec(plan, input),
+              dataset: plan.dataset,
+            },
+          }),
+      );
     } finally {
       await toolAdapter?.cleanup();
       // Deregister the never-init()-ed carrier (instance registry, event


### PR DESCRIPTION
## Why
Stack 5/6. External harnesses drive their own SDKs (claude-agent-sdk/codex-sdk) which emit no OTEL.

## What
- Wrap `runClaudeCodeAgent`/`runCodexAgent` in `withHarnessAgentSpan` so their runs nest an agent node under the eval task-root span — parity with the `stagehand` harness (whose native RPC spans flow in via the global provider).
- No-op when `EVAL_TRACE_TRANSPORT` is unset.

## Testing
Validated live: a claude_code run on Browserbase produced an 85-span LangSmith trace (task-root → agent.claude_code → native page/act/observe spans).

Base: #2760

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OTEL agent spans for `claude_code` and `codex` harness runs so eval traces show a nested agent span under the task root. Previously these harnesses emitted no OTEL; now each run sets harness, model, task, and instruction span attributes without changing execution.

- Wraps `runClaudeCodeAgent` and `runCodexAgent` with `withHarnessAgentSpan` in packages/evals/framework/benchHarness.ts.
- No-op unless EVAL_TRACE_TRANSPORT is set; parity with the `stagehand` harness; no migration required.

<sup>Written for commit 92237ccbcc54f8877cb8bbfbe205c19abf53d819. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

