### PR TITLE
evals(v4): OTEL o11y UX (doctor/welcome + cli shutdown)

### DIFF
--- a/.changeset/evals-otel-compat.md
+++ b/.changeset/evals-otel-compat.md
@@ -2,4 +2,4 @@
 "@browserbasehq/stagehand-evals": minor
 ---
 
-Add OpenTelemetry compatibility to the evals CLI (`EVAL_TRACE_TRANSPORT=otel` fans traces out to Braintrust and LangSmith).
+Adds OpenTelemetry (OTEL) compatibility to the evals CLI

--- a/.changeset/evals-otel-compat.md
+++ b/.changeset/evals-otel-compat.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand-evals": minor
+---
+
+Add OpenTelemetry compatibility to the evals CLI (`EVAL_TRACE_TRANSPORT=otel` fans traces out to Braintrust and LangSmith).

--- a/packages/evals/cli.ts
+++ b/packages/evals/cli.ts
@@ -86,6 +86,15 @@ const args = process.argv.slice(2);
     } catch {
       // ignore
     }
+    try {
+      const { resolveTraceTransport } = await import("./framework/langsmith.js");
+      if (resolveTraceTransport() === "otel") {
+        try {
+          const { shutdownTracing } = await import("./framework/otel.js");
+          await shutdownTracing();
+        } catch {}
+      }
+    } catch {}
     process.exit(code);
   };
   process.on("SIGINT", () => void handleSignal("SIGINT"));

--- a/packages/evals/tui/commands/doctor.ts
+++ b/packages/evals/tui/commands/doctor.ts
@@ -308,6 +308,10 @@ function renderHuman(report: DoctorReport): void {
     }`,
   );
   console.log(keyRow("BRAINTRUST_API_KEY", r.keys.braintrust, "(needed for `experiments`)"));
+  const langsmithLabel = r.keys.langsmith.var ?? "LANGSMITH_API_KEY";
+  console.log(
+    keyRow(langsmithLabel, r.keys.langsmith, "(optional; LANGCHAIN_API_KEY also supported)"),
+  );
   console.log("");
 
   console.log(`  ${bold("Status")}`);

--- a/packages/evals/tui/welcomeStatus.ts
+++ b/packages/evals/tui/welcomeStatus.ts
@@ -32,6 +32,11 @@ export type GoogleKeyEntry = ProviderKeyEntry & {
   var: "GOOGLE_GENERATIVE_AI_API_KEY" | "GEMINI_API_KEY" | null;
 };
 
+export type LangSmithKeyEntry = ProviderKeyEntry & {
+  /** Which env var actually held the value, or null if missing. */
+  var: "LANGSMITH_API_KEY" | "LANGCHAIN_API_KEY" | null;
+};
+
 export type BrowserbaseKeyEntry = {
   apiKey: KeyState;
   projectId: KeyState;
@@ -45,6 +50,7 @@ export type EnvSnapshot = {
   google: GoogleKeyEntry;
   browserbase: BrowserbaseKeyEntry;
   braintrust: ProviderKeyEntry;
+  langsmith: LangSmithKeyEntry;
 };
 
 // ---------------------------------------------------------------------------
@@ -101,6 +107,16 @@ function providerEntry(name: string): ProviderKeyEntry {
   return {
     state: r.value ? "set" : "missing",
     source: r.source,
+  };
+}
+
+function langSmithEntry(): LangSmithKeyEntry {
+  const primary = providerEntry("LANGSMITH_API_KEY");
+  if (primary.state === "set") return { ...primary, var: "LANGSMITH_API_KEY" };
+  const fallback = providerEntry("LANGCHAIN_API_KEY");
+  return {
+    ...fallback,
+    var: fallback.state === "set" ? "LANGCHAIN_API_KEY" : null,
   };
 }
 
@@ -166,6 +182,7 @@ export function snapshotEnv(): EnvSnapshot {
     google: googleEntry(),
     browserbase: browserbaseEntry(),
     braintrust: providerEntry("BRAINTRUST_API_KEY"),
+    langsmith: langSmithEntry(),
   };
 }
 


### PR DESCRIPTION
## Why
Stack 6/6.

## What
- `doctor` + `welcomeStatus` surface the LangSmith key.
- `cli.ts` flushes/shuts down the tracer on SIGINT/SIGTERM (otel-gated, error-swallowing).

## Testing
typecheck + unit + build green.

Base: #2761

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces the LangSmith API key in `doctor`/`welcome` and flushes OpenTelemetry traces on CLI shutdown. Previously these views omitted LangSmith and the CLI exited without flushing; now, when `EVAL_TRACE_TRANSPORT=otel`, the CLI waits for tracer shutdown on SIGINT/SIGTERM and ignores shutdown errors.

- `doctor` and `welcome` show the LangSmith key, preferring `LANGSMITH_API_KEY` with fallback to `LANGCHAIN_API_KEY`; `welcomeStatus` records which variable was used and `doctor` labels it accordingly.
- On shutdown, the CLI checks the resolved trace transport; if `otel`, it awaits `shutdownTracing()` before exit. Non-OTEL behavior is unchanged and shutdown errors are swallowed.
- Setting `EVAL_TRACE_TRANSPORT=otel` fans traces out to Braintrust and LangSmith.

<sup>Written for commit c92039f85be93ff457bc36520aa9f9c93b4b656a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

