### PR TITLE
fix: add proper mapping to browser.close() so agents can close sessio…

### DIFF
--- a/packages/integrations/core/src/facade/runtime.ts
+++ b/packages/integrations/core/src/facade/runtime.ts
@@ -110,6 +110,7 @@ export type PlaywrightCompatRuntime = {
   browser: unknown;
   telemetry: () => PlaywrightCompatTelemetry;
   artifacts: () => Array<{ path: string; base64: string }>;
+  closeRequested: () => boolean;
 };
 
 /**
@@ -624,6 +625,7 @@ export async function createPlaywrightCompatRuntime(
   const pageKey = (page: RawPage): PageKey => page.pageId ?? page;
   const compatPages = new Map<PageKey, unknown>();
   const closedPages = new Set<PageKey>();
+  let closeRequested = false;
   const contextPageListeners = new Map<unknown, boolean>();
   const screenshotArtifacts: Array<{ path: string; base64: string }> = [];
   const encodeBase64 = (bytes: Uint8Array): string => {
@@ -2002,7 +2004,14 @@ export async function createPlaywrightCompatRuntime(
   const context = guard("context", contextObject);
   const browser = guard("browser", {
     contexts: () => [context],
-    isConnected: () => true,
+    isConnected: () => !closeRequested,
+    // Do not close Chrome from inside experimentalBatch — the callback is
+    // running in that browser. Host-side run() reads closeRequested() and
+    // tears down Stagehand + the keep-alive session after the batch returns.
+    close: async () => {
+      record("calls", "browser.close");
+      closeRequested = true;
+    },
     // Stagehand v4 exposes one attached context. Returning that context preserves
     // Playwright-shaped control flow without pretending an isolated context exists.
     newContext: async () => {
@@ -2018,5 +2027,6 @@ export async function createPlaywrightCompatRuntime(
     browser,
     telemetry: () => ({ calls: { ...stats.calls }, misses: { ...stats.misses } }),
     artifacts: () => screenshotArtifacts.map((artifact) => ({ ...artifact })),
+    closeRequested: () => closeRequested,
   };
 }

--- a/packages/integrations/eve/agent/instructions.md
+++ b/packages/integrations/eve/agent/instructions.md
@@ -4,7 +4,7 @@ You control one persistent browser through exactly three tools:
 - run: provide either snapshot actions or JavaScript using the Playwright-shaped page API.
 - screenshot: inspect the rendered page visually.
 
-Use snapshot actions for simple interactions and run code for multi-step workflows. 
-Pass run exactly one of code or actions; every action uses "op" and "id", never "kind" or "ref". 
-Snapshot IDs are valid only for the latest snapshot of the active page; snapshot again after navigation or stale IDs. 
-Do not launch another browser. To end a session you must run browser.close() to close the browser. 
+Use snapshot actions for simple interactions and run code for multi-step workflows.
+Pass run exactly one of code or actions; every action uses "op" and "id", never "kind" or "ref".
+Snapshot IDs are valid only for the latest snapshot of the active page; snapshot again after navigation or stale IDs.
+Do not launch another browser. To end a session you must run browser.close() to close the browser.

--- a/packages/integrations/eve/agent/instructions.md
+++ b/packages/integrations/eve/agent/instructions.md
@@ -4,4 +4,7 @@ You control one persistent browser through exactly three tools:
 - run: provide either snapshot actions or JavaScript using the Playwright-shaped page API.
 - screenshot: inspect the rendered page visually.
 
-Use snapshot actions for simple interactions and run code for multi-step workflows. Pass run exactly one of code or actions; every action uses "op" and "id", never "kind" or "ref". Snapshot IDs are valid only for the latest snapshot of the active page; snapshot again after navigation or stale IDs. Do not launch another browser.
+Use snapshot actions for simple interactions and run code for multi-step workflows. 
+Pass run exactly one of code or actions; every action uses "op" and "id", never "kind" or "ref". 
+Snapshot IDs are valid only for the latest snapshot of the active page; snapshot again after navigation or stale IDs. 
+Do not launch another browser. To end a session you must run browser.close() to close the browser. 


### PR DESCRIPTION
…ns using the fascade

# why

The integration MCP didn't by the way, to close a browser session since there wasn't a clean mapping to `browser.close`

# what changed

This PR updates some of the instructions and the eve integration and also adds the ability to close browser sessions through the MCP tool. 

# test plan
Tested locally 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Maps browser.close() in the Stagehand MCP facade so agents can end sessions cleanly. Previously close was unmapped and browser.isConnected() always returned true; now close sets a closeRequested flag, isConnected() reflects it, and the host tears down Stagehand after the batch. Addresses Linear GRO-2174.

- In `packages/integrations/core/src/facade/runtime.ts`: add closeRequested state and accessor to PlaywrightCompatRuntime; implement browser.close() to record the call and set the flag; make browser.isConnected() return !closeRequested.
- In `packages/integrations/eve/agent/instructions.md`: document that agents must call browser.close() to end a session and must not launch another browser.
- Closing does not kill Chrome mid-batch; the host reads closeRequested and shuts down after the batch returns.

<sup>Written for commit b6ca2e853ad8c41877b109dfc8822a5e7b5c6ba9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

