### PR TITLE
fix(v3): preserve provider for structured output

### DIFF
--- a/.changeset/bright-owls-decode.md
+++ b/.changeset/bright-owls-decode.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+Fix Anthropic structured output options for provider-prefixed models

--- a/packages/core/lib/v3/llm/aisdk.ts
+++ b/packages/core/lib/v3/llm/aisdk.ts
@@ -27,8 +27,8 @@ import { toJsonSchema } from "../zodCompat.js";
 type ProviderOptionValue = JSONValue;
 type ProviderOptionMap = Record<string, ProviderOptionValue>;
 
-function inferProviderName(modelId: string): string | undefined {
-  const [providerName] = modelId.split("/");
+function inferProviderName(model: LanguageModelV2): string | undefined {
+  const [providerName] = model.provider?.split(".") ?? model.modelId.split("/");
   return providerName || undefined;
 }
 
@@ -160,7 +160,7 @@ export class AISdkClient extends LLMClient {
     const userReasoningEffort = this.clientOptions?.reasoningEffort;
     const resolvedReasoningEffort =
       userReasoningEffort ?? (isGPT5SubModel ? "none" : undefined);
-    const providerName = inferProviderName(this.model.modelId);
+    const providerName = inferProviderName(this.model);
 
     // Models that lack native structured-output support need a prompt-based
     // JSON fallback instead of response_format: { type: "json_schema" }.

--- a/packages/core/tests/unit/aisdk-clients.test.ts
+++ b/packages/core/tests/unit/aisdk-clients.test.ts
@@ -3,6 +3,7 @@ import { generateObject, generateText } from "ai";
 import { z } from "zod";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AISdkClient } from "../../lib/v3/llm/aisdk.js";
+import { LLMProvider } from "../../lib/v3/llm/LLMProvider.js";
 
 vi.mock("ai", async () => {
   const actual = await vi.importActual<typeof import("ai")>("ai");
@@ -75,6 +76,31 @@ describe("AISdkClient structured output provider options", () => {
       );
     },
   );
+
+  it("passes Anthropic options through LLMProvider", async () => {
+    const client = new LLMProvider(vi.fn()).getClient(
+      "anthropic/claude-opus-4-8",
+    );
+
+    await client.createChatCompletion({
+      options: {
+        messages: [{ role: "user", content: "hello" }],
+        response_model: {
+          name: "test",
+          schema: z.object({ ok: z.boolean() }),
+        },
+      },
+      logger: vi.fn(),
+    });
+
+    expect(mockGenerateObject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerOptions: {
+          anthropic: { structuredOutputMode: "auto" },
+        },
+      }),
+    );
+  });
 
   it("omits temperature for claude-opus-4-7 structured calls", async () => {
     const client = new AISdkClient({


### PR DESCRIPTION
## Summary
- infer provider options from the AI SDK model provider identity
- preserve Anthropic structured output configuration after LLMProvider removes the model prefix
- add a regression test for anthropic/claude-opus-4-8 and a patch changeset

## Why
LLMProvider passes the bare claude-opus-4-8 model ID to the Anthropic AI SDK provider. AISdkClient previously inferred the provider only from that bare model ID, so extract() omitted structuredOutputMode: auto and did not opt into Anthropic native structured outputs.

## Testing
- pnpm --filter @browserbasehq/stagehand run build:esm
- pnpm --filter @browserbasehq/stagehand run test:core -- packages/core/dist/esm/tests/unit/aisdk-clients.test.js
- pnpm --filter @browserbasehq/stagehand run lint
- mocked HTTP smoke with @ai-sdk/anthropic@2.0.81 confirmed output_config.format.type is json_schema for claude-opus-4-8
- live V3 LOCAL browser smoke: extract() with anthropic/claude-opus-4-8 returned the expected typed product object through Anthropic's API