### PR TITLE
test: prevent SDK parity notification timeout

### DIFF
--- a/rules/ast-grep/sdk-parity.test.ts
+++ b/rules/ast-grep/sdk-parity.test.ts
@@ -208,7 +208,7 @@ describe("All language SDK operations remain in sync", () => {
         `Python must decode ${binding.notification} with its generated params model`,
       ).toBe(referencedModel(notification.properties.params.$ref));
     }
-  });
+  }, 15_000);
 
   it("exposes the same RPC-backed operations in every SDK", async () => {
     const registry = await stagehandMethodNames();


### PR DESCRIPTION
## Summary
- give the full cross-SDK notification parity scan a 15-second test timeout
- keep the default 5-second timeout for the rest of the unit suite

## Root cause
The notification parity test recursively parses the TypeScript, Python, and Go SDKs. Under concurrent CI load it took 5.066 seconds, narrowly exceeding Vitest's default 5-second timeout.

## Validation
- pnpm run test:unit (93 passed)
- pnpm exec oxfmt --check rules/ast-grep/sdk-parity.test.ts
- pnpm exec oxlint rules/ast-grep/sdk-parity.test.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents CI flakiness by increasing the `vitest` timeout for the notification parity test from 5s to 15s. Previously this test occasionally exceeded 5s under load and timed out; now only this test uses 15s, the rest keep the default 5s, and there’s no runtime impact.

<sup>Written for commit 0a47c54dca9ce99acd55906a4b8ec437de70d14c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

