### PR TITLE
fix: resolve leaked extract() element IDs on z.string() URL fields

### DIFF
--- a/packages/extension/prompt.ts
+++ b/packages/extension/prompt.ts
@@ -65,8 +65,7 @@ ONLY print the content using the print_extracted_data tool provided.
     : "";
 
   const additionalInstructions =
-    "If a user is attempting to extract links or URLs, you MUST respond with ONLY the IDs of the link elements. \n" +
-    "Do not attempt to extract links directly from the text unless absolutely necessary. ";
+    'Hrefs are not shown in the DOM list. For any value that should be a URL, return the matching link element\'s ID in the form frameId-backendId (e.g. "0-432"), without square brackets. Do not invent hrefs. For every other field, print the exact visible text and never return element IDs.';
 
   const userInstructions = buildUserInstructionsString(userProvidedInstructions);
 

--- a/packages/extension/services/extractService.ts
+++ b/packages/extension/services/extractService.ts
@@ -14,7 +14,7 @@ import type { StagehandLogger } from "../logger.js";
 import { bytesToBase64 } from "../understudy/fileUploadUtils.js";
 import type { Page } from "../understudy/page.js";
 import type { EncodedId, ZodPathSegments } from "../types/private/internal.js";
-import { injectUrls, transformSchema } from "../utils.js";
+import { injectUrls, replaceElementIdsWithUrls, transformSchema } from "../utils.js";
 import { createTimeoutGuard } from "../handlers/handlerUtils/timeoutGuard.js";
 import * as cacheService from "./cacheService.js";
 import * as llmService from "./llmService.js";
@@ -164,6 +164,7 @@ export async function extract({
         idToUrl as unknown as Record<string, string>,
       );
     }
+    replaceElementIdsWithUrls(output, idToUrl as unknown as Record<string, string>);
     if (!isObjectSchema && output && typeof output === "object") {
       output = (output as Record<string, unknown>)[wrapKey] as z.infer<z.ZodObject>;
     }

--- a/packages/extension/tests/extract.test.ts
+++ b/packages/extension/tests/extract.test.ts
@@ -4,6 +4,7 @@ import { z } from "zod/v4";
 import type { LLMGenerateParams, LLMGenerateResult } from "../../protocol/types.js";
 import type { CacheClient } from "../clients/cacheClient.js";
 import { extract } from "../inference.js";
+import { replaceElementIdsWithUrls, transformSchema } from "../utils.js";
 import { StagehandLogger } from "../logger.js";
 import * as cacheService from "../services/cacheService.js";
 import * as extractService from "../services/extractService.js";
@@ -61,6 +62,8 @@ describe("extract inference", () => {
       cached_input_tokens: 2,
     });
     expect(generate).toHaveBeenCalledTimes(2);
+    expect(generate.mock.calls[0]?.[0].systemPrompt).toContain("frameId-backendId");
+    expect(generate.mock.calls[0]?.[0].systemPrompt).not.toContain("ONLY the IDs");
     expect(generate.mock.calls[0]?.[0]).toMatchObject({
       responseFormat: { type: "json_schema", name: "Extraction" },
       messages: [
@@ -512,6 +515,83 @@ describe("extract service", () => {
       expect(frame.getAccessibilityTree).not.toHaveBeenCalled();
     },
   );
+});
+
+describe("extract URL id resolution", () => {
+  it("transforms z.url() fields but leaves plain strings alone", () => {
+    const schema = z.object({
+      title: z.string(),
+      url: z.url(),
+      href: z.string(),
+    });
+    const [, urlPaths] = transformSchema(schema, []);
+    expect(urlPaths).toStrictEqual([{ segments: ["url"] }]);
+  });
+
+  it("replaces leaked element IDs in plain string fields", () => {
+    const output = {
+      title: "Example Domain",
+      url: "0-74",
+      stories: "[0-74]\n[0-112]",
+      rank1_url: "0-3152",
+      hrefs: "0-74, see notes",
+      already: "https://keep.example/",
+      score: "0-74",
+      notes: "see [0-74]",
+      unresolved: "[9-9]",
+    };
+    replaceElementIdsWithUrls(output, {
+      "0-74": "https://example.com/",
+      "0-112": "https://example.com/about",
+      "0-3152": "https://news.ycombinator.com/item?id=1",
+    });
+    expect(output).toStrictEqual({
+      title: "Example Domain",
+      url: "https://example.com/",
+      stories: "https://example.com/\nhttps://example.com/about",
+      rank1_url: "https://news.ycombinator.com/item?id=1",
+      hrefs: "https://example.com/, see notes",
+      already: "https://keep.example/",
+      score: "0-74",
+      notes: "see https://example.com/",
+      unresolved: "[9-9]",
+    });
+  });
+
+  it("resolves IDs returned in z.string() URL fields after extraction", async () => {
+    const generate = vi.fn(async (params: LLMGenerateParams): Promise<LLMGenerateResult> => {
+      const name = params.responseFormat?.type === "json_schema" && params.responseFormat.name;
+      return structuredResult(
+        name === "Extraction"
+          ? { title: "Example Domain", url: "0-74" }
+          : { progress: "Extracted the story", completed: true },
+      );
+    });
+
+    const result = await extractService.extract({
+      params: {
+        pageId: "page-1",
+        instruction: "Extract the first story title and its destination URL",
+        schema: z.json().parse(z.toJSONSchema(z.object({ title: z.string(), url: z.string() }))),
+      },
+      page: {
+        captureSnapshot: async () => ({
+          combinedTree: "[0-74] link: Example Domain",
+          combinedXpathMap: {},
+          combinedUrlMap: { "0-74": "https://example.com/" },
+        }),
+        screenshot: async () => new Uint8Array(),
+      },
+      model: { source: "client" },
+      clientLLMGenerate: generate,
+      logger: testLogger(),
+    });
+
+    expect(result.data).toStrictEqual({
+      title: "Example Domain",
+      url: "https://example.com/",
+    });
+  });
 });
 
 function structuredResult(

--- a/packages/extension/utils.ts
+++ b/packages/extension/utils.ts
@@ -2,6 +2,7 @@ import { z } from "zod/v4";
 import { ZodPathSegments } from "./types/private/internal.js";
 
 const ID_PATTERN = /^\d+-\d+$/;
+const URL_STRING_FORMATS = new Set(["url", "uri", "uri-reference"]);
 
 const TYPE_NAME_MAP: Record<string, string> = {
   string: "string",
@@ -151,11 +152,11 @@ export function transformSchema(
         };
         return (
           candidate.kind === "url" ||
-          candidate.format === "url" ||
+          URL_STRING_FORMATS.has(candidate.format ?? "") ||
           candidate._zod?.def?.check === "url" ||
-          candidate._zod?.def?.format === "url"
+          URL_STRING_FORMATS.has(candidate._zod?.def?.format ?? "")
         );
-      }) || format === "url";
+      }) || URL_STRING_FORMATS.has(format ?? "");
 
     if (hasUrlCheck) {
       return [makeIdStringSchema(schema), [{ segments: [] }]];
@@ -337,6 +338,115 @@ export function injectUrls(
       }
     } else {
       injectUrls(record[key], rest, idToUrlMapping);
+    }
+  }
+}
+
+function isUrlFieldName(name: string | undefined): boolean {
+  if (!name) return false;
+  return (
+    /^(urls?|hrefs?|uris?|links?)$/i.test(name) ||
+    /[_-](urls?|hrefs?|uris?|links?)$/i.test(name) ||
+    /(URL|URLs|Href|Hrefs|Uri|Uris|Link|Links)$/.test(name)
+  );
+}
+
+function lookupMappedUrl(id: string, idToUrlMapping: Record<string, string>): string | undefined {
+  // Leave unknown IDs in place rather than blanking the field. A missing
+  // href is more useful than an empty string, and the token may not be an ID.
+  return Object.hasOwn(idToUrlMapping, id) ? idToUrlMapping[id] : undefined;
+}
+
+function lookupBareId(raw: string, idToUrlMapping: Record<string, string>): string | undefined {
+  const trimmed = raw.trim();
+  if (!ID_PATTERN.test(trimmed)) return undefined;
+  return lookupMappedUrl(trimmed, idToUrlMapping);
+}
+
+function replaceBracketedIds(value: string, idToUrlMapping: Record<string, string>): string {
+  return value.replace(/\[(\d+-\d+)\]/g, (match, id: string) => {
+    return lookupMappedUrl(id, idToUrlMapping) ?? match;
+  });
+}
+
+function replaceBareIdSegment(segment: string, idToUrlMapping: Record<string, string>): string {
+  const url = lookupBareId(segment, idToUrlMapping);
+  if (url === undefined) return segment;
+  const leading = segment.match(/^(\s*)/)?.[1] ?? "";
+  const trailing = segment.match(/(\s*)$/)?.[1] ?? "";
+  return `${leading}${url}${trailing}`;
+}
+
+function replaceIdTokensInString(
+  value: string,
+  idToUrlMapping: Record<string, string>,
+  allowBareIds: boolean,
+): string {
+  const next = replaceBracketedIds(value, idToUrlMapping);
+  if (!allowBareIds) {
+    return next;
+  }
+
+  const whole = lookupBareId(next, idToUrlMapping);
+  if (whole !== undefined) {
+    return whole;
+  }
+
+  if (next.includes("\n")) {
+    return next
+      .split("\n")
+      .map((line) => replaceBareIdSegment(line, idToUrlMapping))
+      .join("\n");
+  }
+
+  if (next.includes(",")) {
+    return next
+      .split(",")
+      .map((part) => replaceBareIdSegment(part, idToUrlMapping))
+      .join(",");
+  }
+
+  return next;
+}
+
+/**
+ * Replace accessibility-tree element IDs that leaked into extracted strings
+ * with the hrefs from the snapshot URL map. Typed `z.url()` fields are already
+ * handled by {@link injectUrls}.
+ *
+ * Bracketed IDs (`[0-74]`) match the a11y-tree encoding and are rewritten in
+ * any string. Bare IDs (`0-74`) are only rewritten on URL-ish field names so
+ * scores/versions like `"3-2"` are left alone.
+ */
+export function replaceElementIdsWithUrls(
+  value: unknown,
+  idToUrlMapping: Record<string, string>,
+  allowBareIds = false,
+): void {
+  if (typeof value === "string" || value === null || value === undefined) {
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i += 1) {
+      const item = value[i];
+      if (typeof item === "string") {
+        value[i] = replaceIdTokensInString(item, idToUrlMapping, allowBareIds);
+      } else {
+        replaceElementIdsWithUrls(item, idToUrlMapping, false);
+      }
+    }
+    return;
+  }
+  if (typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    for (const key of Object.keys(record)) {
+      const item = record[key];
+      const fieldAllowsBareIds = isUrlFieldName(key);
+      if (typeof item === "string") {
+        record[key] = replaceIdTokensInString(item, idToUrlMapping, fieldAllowsBareIds);
+      } else {
+        replaceElementIdsWithUrls(item, idToUrlMapping, fieldAllowsBareIds);
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- `extract()` leaked accessibility-tree IDs (`[0-74]`, `0-74`) when the schema used plain `z.string()` for URL fields. `injectUrls` only ran for `z.url()` / `format: uri`.
- Agents and callers that extract links as strings (for example `{ stories: z.string() }` or `{ rank1_url: z.string(), ... }` on a page like Hacker News) got raw element IDs back. `z.url()` fields already resolved correctly.
- Fix: tell the model to return `frameId-backendId` only for URL values, then `replaceElementIdsWithUrls` maps leaked IDs through `combinedUrlMap`. Bracketed IDs rewrite in any string; bare IDs only on URL-ish field names.

## Before

{ "stories": "[0-74]\n[0-112]\n[0-150]\n[0-188]\n[0-226]" }

{
  "rank1_title": "GrapheneOS in 2027 available on high-end Motorola phones",
  "rank1_url": "0-74",
  "rank2_url": "0-112",
  "rank3_url": "0-150",
  "rank4_url": "0-188",
  "rank5_url": "0-226"
}

## After (this fix)

{
  "stories": "https://grapheneos.social/@GrapheneOS/117078064184215730\nhttps://yassa9.github.io/osint/gralhix-004/\nhttps://www.raphaelbauer.com/posts/postgresql-everything/\nhttps://sprocketfox.io/xssfox/2026/08/19/sondehub-and-war/\nhttps://openlogi.org/en"
}

{
  "rank1_title": "GrapheneOS in 2027 available on high-end Motorola phones",
  "rank1_url": "https://grapheneos.social/@GrapheneOS/117078064184215730",
  "rank2_url": "https://yassa9.github.io/osint/gralhix-004/",
  "rank3_url": "https://www.raphaelbauer.com/posts/postgresql-everything/",
  "rank4_url": "https://sprocketfox.io/xssfox/2026/08/19/sondehub-and-war/",
  "rank5_url": "https://openlogi.org/en"
}

## Test plan
- [x] `pnpm exec vitest run --root . packages/extension/tests/extract.test.ts`
- [x] `extract()` on a page with links using `z.object({ title: z.string(), url: z.url() })` still returns real hrefs
- [x] Same instruction with `z.object({ title: z.string(), url: z.string() })` returns real hrefs, not element IDs
- [x] `extract("Extract the first 5 story URLs", z.object({ urls: z.string() }))` returns real URLs, not `[0-74]` / `0-74`
- [x] Non-URL strings that look like IDs (e.g. `score: "0-74"`) are left unchanged


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `extract()` leaking accessibility-tree element IDs when URL fields use `z.string()`. Before, only `z.url()` fields resolved to hrefs; now both string and `z.url()` URL fields return real URLs, and non-URL fields never return element IDs.

- Updates the system prompt so URL values return the link element ID as `frameId-backendId` (no brackets) and all other fields return only visible text.
- Adds `replaceElementIdsWithUrls` to map leaked IDs to hrefs via the snapshot `combinedUrlMap`; bracketed IDs are replaced anywhere, bare IDs only on URL-like field names, and unknown IDs are left as-is.
- Extends `transformSchema` to treat `url`, `uri`, and `uri-reference` as URL formats, preserving `injectUrls` behavior for typed `z.url()` fields.
- No API changes. Migration: callers relying on raw element IDs in string fields should update that logic to accept real URLs.

<sup>Written for commit 82c7b2259ee9cb9bfb77e06779d93272156a1138. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



