### PR TITLE
docs: point unversioned redirects at v4 where a v4 page exists

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -489,16 +489,52 @@
       "destination": "/v4/basics/observe"
     },
     {
+      "source": "/basics/webmcp",
+      "destination": "/v4/basics/webmcp"
+    },
+    {
       "source": "/basics/:slug*",
       "destination": "/v3/basics/:slug*"
     },
     {
-      "source": "/configuration/logging",
-      "destination": "/v4/configuration/logging"
+      "source": "/configuration/:slug*",
+      "destination": "/v4/configuration/:slug*"
     },
     {
-      "source": "/configuration/:slug*",
-      "destination": "/v3/configuration/:slug*"
+      "source": "/best-practices/caching",
+      "destination": "/v4/best-practices/caching"
+    },
+    {
+      "source": "/best-practices/cost-optimization",
+      "destination": "/v4/best-practices/cost-optimization"
+    },
+    {
+      "source": "/best-practices/deployments",
+      "destination": "/v4/best-practices/deployments"
+    },
+    {
+      "source": "/best-practices/mcp-integrations",
+      "destination": "/v4/best-practices/mcp-integrations"
+    },
+    {
+      "source": "/best-practices/prompting-best-practices",
+      "destination": "/v4/best-practices/prompting-best-practices"
+    },
+    {
+      "source": "/best-practices/speed-optimization",
+      "destination": "/v4/best-practices/speed-optimization"
+    },
+    {
+      "source": "/best-practices/usecase-observe",
+      "destination": "/v4/best-practices/usecase-observe"
+    },
+    {
+      "source": "/best-practices/user-data",
+      "destination": "/v4/best-practices/user-data"
+    },
+    {
+      "source": "/best-practices/using-multiple-tabs",
+      "destination": "/v4/best-practices/using-multiple-tabs"
     },
     {
       "source": "/best-practices/:slug*",
@@ -531,6 +567,14 @@
     {
       "source": "/reference/:slug*",
       "destination": "/v4/reference/:slug*"
+    },
+    {
+      "source": "/migrations/playwright",
+      "destination": "/v4/migrations/playwright"
+    },
+    {
+      "source": "/migrations/v3",
+      "destination": "/v4/migrations/v3"
     },
     {
       "source": "/migrations/:slug*",


### PR DESCRIPTION
## Problem

Unversioned docs paths redirect to **v3** even when a v4 page exists.

```
docs.stagehand.dev/best-practices/caching  →  /v3/best-practices/caching
```

The v3 caching page still documents `serverCache: false` and `env: "BROWSERBASE"` — the pre-v4 API. The v4 page at `/v4/best-practices/caching` documents the current `cache` option, but you only reach it by clicking a version-pinned link.

The cause isn't the default version (that's already v4 — `docs.stagehand.dev/` lands on `/v4/first-steps/introduction`). It's the `redirects` table in `packages/docs/docs.json`, which was written when v4 had only a handful of pages. Broad catch-alls like `/best-practices/:slug*` → `/v3/best-practices/:slug*` have been shadowing v4 pages as they landed.

## Change

Add explicit v4 redirects for every unversioned path that now has a v4 page. Mintlify matches redirects top-down, so the v3 catch-alls stay last and continue to serve pages that only exist in v3.

| Section | Now → v4 | Still → v3 (v3-only pages) |
| --- | --- | --- |
| `best-practices` | caching, cost-optimization, deployments, mcp-integrations, prompting-best-practices, speed-optimization, usecase-observe, user-data, using-multiple-tabs | agent-fallbacks, computer-use, deterministic-agent, history |
| `configuration` | catch-all → v4 (v4 has all four pages) | — |
| `basics` | + webmcp (act/extract/observe already were) | agent, evals |
| `migrations` | playwright, v3 | python, v2 |

`first-steps` and `reference` already pointed at v4 and are unchanged.

## E2E Test Matrix

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| `mint validate` (in `packages/docs`, catalog-pinned version) | `success build validation passed` — 24 OpenAPI definitions valid | Proves `docs.json` parses and the nav/redirect config is structurally valid. Does not prove the redirects point anywhere useful. |
| `mint broken-links --check-anchors --check-redirects --check-snippets` | `success no broken links found` | This is the load-bearing row: `--check-redirects` resolves every redirect destination. Confirms all 15 new concrete destinations exist and no existing link broke. |
| Script over `docs.json` + the `v3/**` / `v4/**` MDX tree | `concrete redirects checked: 15` / `BROKEN: none` / `missing explicit redirect (would fall through to v3): none` | Independently confirms the v4 best-practices set is fully covered (9/9) and enumerates the 4 v3-only pages that intentionally still fall through. Cross-checks the mint result against the actual file tree. |
| `curl -sIL docs.stagehand.dev/best-practices/caching` (live, pre-merge) | `final: .../v3/best-practices/caching` | Reproduces the bug on production. Post-merge behavior is not yet observable — that needs a deploy, so it remains unproven here. |

Redirect behavior on the deployed site can only be confirmed after this merges and the docs redeploy.

## Notes

- Docs-only, no changeset.
- Scope note: the report that kicked this off was about `/best-practices/caching` specifically. I extended it to `configuration`, `basics/webmcp`, and `migrations` because they are the same bug and the same one-line-each fix. Happy to trim to `best-practices` only if you'd rather keep the diff minimal.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unversioned docs paths that have a v4 page now redirect to v4 instead of v3, so users land on current content. v3-only pages still redirect to v3. Addresses Linear AP-2887.

- Added explicit v4 redirects in `packages/docs/docs.json` for `best-practices` (caching, cost-optimization, deployments, mcp-integrations, prompting-best-practices, speed-optimization, usecase-observe, user-data, using-multiple-tabs), `configuration` (catch-all), `basics/webmcp`, and `migrations` (playwright, v3).
- Kept v3 catch-alls last; these still resolve to v3: `best-practices` (agent-fallbacks, computer-use, deterministic-agent, history), `basics` (agent, evals), `migrations` (python, v2).
- Validated with `mint validate` and `mint broken-links --check-redirects`; production behavior updates after the docs deploy.

<sup>Written for commit e27ff99ded8ec2acd180a215861f7908a4d11b15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

