### PR TITLE
ci: restore commit-addressed alpha releases for the TypeScript SDK

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,9 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
   "commit": false,
   "linked": [],
-  "ignore": ["@browserbasehq/stagehand-evals"],
+  "ignore": [
+    "@browserbasehq/stagehand-evals"
+  ],
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "access": "public",
@@ -15,5 +17,9 @@
   "privatePackages": {
     "version": true,
     "tag": false
+  },
+  "snapshot": {
+    "useCalculatedVersion": true,
+    "prereleaseTemplate": "alpha-{commit}"
   }
 }

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,9 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
   "commit": false,
   "linked": [],
-  "ignore": [
-    "@browserbasehq/stagehand-evals"
-  ],
+  "ignore": ["@browserbasehq/stagehand-evals"],
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "access": "public",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,49 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CHANGESETS_ACTION_PRESERVE_CHANGELOGS: "true"
 
+  publish-typescript-alpha:
+    name: Publish TypeScript SDK alpha
+    needs: release-typescript
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: "11.10.0"
+          run_install: false
+
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: "24"
+          cache: pnpm
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install npm
+        run: npm install --global npm@11.16.0
+
+      - uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
+
+      - run: pnpm install --frozen-lockfile
+
+      # The TypeScript SDK bundles the extension, which in turn needs the protocol schema.
+      - run: pnpm exec turbo run build --filter=@browserbasehq/stagehand
+
+      # Versions every package with a pending changeset as `<next>-alpha-<sha>` and
+      # publishes the public ones under the `alpha` dist-tag. The working tree is
+      # discarded afterwards, so nothing is committed. No-op when there are no
+      # unreleased changesets (e.g. the push that just cut a stable release).
+      - name: Publish alpha
+        run: just _publish-typescript-alpha
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   python-release-status:
     name: Check Python release status
     needs: release-typescript

--- a/justfile
+++ b/justfile
@@ -88,3 +88,11 @@ _preview commit:
 _publish-typescript:
     pnpm --filter ./packages/sdk-ts build
     pnpm exec changeset publish
+
+# Publishes a commit-addressed alpha of the TypeScript SDK (`<next>-alpha-<sha>`)
+# under the `alpha` dist-tag. Only packages with pending changesets are versioned,
+# so this is a no-op when nothing is unreleased.
+_publish-typescript-alpha:
+    pnpm exec changeset version --snapshot
+    pnpm --filter ./packages/sdk-ts build
+    pnpm exec changeset publish --tag alpha --no-git-tag


### PR DESCRIPTION
## Why

On `v3`, every push published a snapshot of `@browserbasehq/stagehand` as `<next>-alpha-<sha>` under the `alpha` dist-tag (`release-canary` script + `snapshot` changesets config + a "Publish Canary" step in `release.yml`). The v4 release rewrite (#2671) dropped all three, so nothing newer than `4.0.0-alpha-49bc5b6…` has shipped to npm since.

## What

Port the v3 behavior onto the v4 release tooling:

- `.changeset/config.json` — restore `snapshot: { useCalculatedVersion, prereleaseTemplate: "alpha-{commit}" }` (the v3 `snapshot.tag` key was never part of the schema; the dist-tag comes from `--tag alpha` on publish).
- `justfile` — new `_publish-typescript-alpha` recipe: `changeset version --snapshot` → build `sdk-ts` → `changeset publish --tag alpha --no-git-tag`.
- `.github/workflows/release.yml` — new `publish-typescript-alpha` job after `release-typescript`. It's a separate job (rather than a trailing step as on v3) so an alpha failure can't block the Python/Go release jobs, and it only needs the node toolchain (`turbo run build --filter=@browserbasehq/stagehand` covers protocol → extension → sdk-ts).

Behavior matches v3: only packages with pending changesets are versioned, so the push that cuts a stable release is a no-op for the alpha job. Verified locally that `changeset version --snapshot` yields `4.0.3-alpha-8b75044ee9163dc3c0d18fb11eed4a12246b4a03`.

No changeset — CI/release infra only.

## Follow-up

Python alphas (`<next>a0.dev<N>` on PyPI — PEP 440 can't carry the sha) are coming in a separate PR. Go needs nothing: `go get …/sdk-go/v4@<sha>` already works via pseudo-versions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores commit-addressed alpha releases for the TypeScript SDK. v3 published `<next>-alpha-<sha>` to the `alpha` dist-tag on pushes; v4 dropped it. This brings back automated alphas without affecting stable releases.

- Restores Changesets snapshot config: `useCalculatedVersion` with `prereleaseTemplate: "alpha-{commit}"`.
- Adds `just _publish-typescript-alpha`: `changeset version --snapshot` → build `sdk-ts` → `changeset publish --tag alpha --no-git-tag`.
- Adds a separate `publish-typescript-alpha` job in `release.yml` after `release-typescript`; builds `@browserbasehq/stagehand` via `turbo` and does not block Python/Go if it fails.
- Behavior matches v3: publishes `<next>-alpha-<sha>` only when there are pending changesets; no-op on the stable-release commit; no git tags; CI-only. Aligns with Linear AP-2885.

<sup>Written for commit d98d0e481a6aa790494bcebc63a3669dd0328378. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

