### PR TITLE
ci: publish commit-addressed alpha releases of the Python SDK

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -2,6 +2,11 @@ name: Publish Python SDK
 
 on:
   workflow_call:
+    inputs:
+      alpha:
+        description: Publish a commit-addressed alpha (`<next>a0.dev<N>`) instead of the checked-in version.
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -15,6 +20,9 @@ jobs:
       version: ${{ steps.package-version.outputs.version }}
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          # Alphas number builds by commit count.
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
@@ -48,6 +56,13 @@ jobs:
       - uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
 
       - run: just install
+
+      - name: Apply alpha version
+        if: inputs.alpha
+        run: just _version-python-alpha
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - run: just build
 
       - name: Read package version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,6 +149,52 @@ jobs:
     uses: ./.github/workflows/publish-python.yml
     secrets: inherit
 
+  python-alpha-status:
+    name: Check Python alpha status
+    needs: release-typescript
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      should-publish: ${{ steps.status.outputs.should-publish }}
+      version: ${{ steps.status.outputs.version }}
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: "11.10.0"
+          run_install: false
+
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: "24"
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # Only packages with pending changesets receive a snapshot version, so this
+      # tells us whether the Python SDK has anything unreleased to publish.
+      - run: pnpm exec changeset version --snapshot
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check alpha version
+        id: status
+        run: pnpm exec tsx scripts/release/python-alpha-version.ts --check >> "$GITHUB_OUTPUT"
+
+  publish-python-alpha:
+    name: Release Python SDK alpha
+    needs: python-alpha-status
+    if: needs.python-alpha-status.outputs.should-publish == 'true'
+    uses: ./.github/workflows/publish-python.yml
+    with:
+      alpha: true
+    secrets: inherit
+
   publish-go:
     name: Release Go SDK
     needs: release-typescript

--- a/justfile
+++ b/justfile
@@ -96,3 +96,11 @@ _publish-typescript-alpha:
     pnpm exec changeset version --snapshot
     pnpm --filter ./packages/sdk-ts build
     pnpm exec changeset publish --tag alpha --no-git-tag
+
+# Rewrites the Python project to the commit-addressed alpha (`<next>a0.dev<N>`)
+# derived from the changesets snapshot version. Nothing is committed; the
+# working tree is discarded after publishing.
+_version-python-alpha:
+    pnpm exec changeset version --snapshot
+    pnpm exec tsx scripts/release/python-alpha-version.ts
+    uv --directory "{{python_dir}}" lock

--- a/scripts/release/python-alpha-version.test.ts
+++ b/scripts/release/python-alpha-version.test.ts
@@ -1,0 +1,95 @@
+import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { applyPythonAlphaVersion, pythonAlphaVersion } from "./python-alpha-version.ts";
+
+async function repositoryFixture(proxyVersion: string): Promise<string> {
+  const repositoryRoot = await mkdtemp(path.join(os.tmpdir(), "stagehand-python-alpha-"));
+  const pythonDirectory = path.join(repositoryRoot, "packages/sdk-python");
+  await mkdir(pythonDirectory, { recursive: true });
+  await writeFile(
+    path.join(pythonDirectory, "package.json"),
+    `${JSON.stringify({ version: proxyVersion }, null, 2)}\n`,
+  );
+  await writeFile(
+    path.join(pythonDirectory, "pyproject.toml"),
+    `[project]
+name = "stagehand"
+version = "4.0.2"
+`,
+  );
+  return repositoryRoot;
+}
+
+describe("pythonAlphaVersion", () => {
+  it("maps a snapshot version onto a PEP 440 developmental release", () => {
+    expect(pythonAlphaVersion("4.0.3-alpha-8b75044ee9163dc3c0d18fb11eed4a12246b4a03", 1451)).toBe(
+      "4.0.3a0.dev1451",
+    );
+  });
+
+  it("rejects versions that are not snapshots", () => {
+    expect(() => pythonAlphaVersion("4.0.3", 1)).toThrow("Not a changesets snapshot version");
+    expect(() => pythonAlphaVersion("4.0.3-beta-abc123", 1)).toThrow(
+      "Not a changesets snapshot version",
+    );
+  });
+
+  it("rejects invalid developmental release numbers", () => {
+    expect(() => pythonAlphaVersion("4.0.3-alpha-abc123", -1)).toThrow(
+      "Invalid developmental release number",
+    );
+    expect(() => pythonAlphaVersion("4.0.3-alpha-abc123", 1.5)).toThrow(
+      "Invalid developmental release number",
+    );
+  });
+});
+
+describe("applyPythonAlphaVersion", () => {
+  it("skips when the Python package did not receive a snapshot version", async () => {
+    const repositoryRoot = await repositoryFixture("4.0.2");
+    const devNumber = vi.fn();
+
+    await expect(applyPythonAlphaVersion({ repositoryRoot, devNumber })).resolves.toEqual({
+      shouldPublish: false,
+    });
+    expect(devNumber).not.toHaveBeenCalled();
+    await expect(
+      readFile(path.join(repositoryRoot, "packages/sdk-python/pyproject.toml"), "utf8"),
+    ).resolves.toContain('version = "4.0.2"');
+  });
+
+  it("writes the alpha version into pyproject.toml", async () => {
+    const repositoryRoot = await repositoryFixture("4.0.3-alpha-8b75044e");
+
+    await expect(
+      applyPythonAlphaVersion({ repositoryRoot, devNumber: async () => 1451 }),
+    ).resolves.toEqual({ shouldPublish: true, version: "4.0.3a0.dev1451" });
+    await expect(readFile(path.join(repositoryRoot, "packages/sdk-python/pyproject.toml"), "utf8"))
+      .resolves.toBe(`[project]
+name = "stagehand"
+version = "4.0.3a0.dev1451"
+`);
+  });
+
+  it("leaves pyproject.toml untouched in check mode", async () => {
+    const repositoryRoot = await repositoryFixture("4.0.3-alpha-8b75044e");
+
+    await expect(
+      applyPythonAlphaVersion({ repositoryRoot, checkOnly: true, devNumber: async () => 1451 }),
+    ).resolves.toEqual({ shouldPublish: true, version: "4.0.3a0.dev1451" });
+    await expect(
+      readFile(path.join(repositoryRoot, "packages/sdk-python/pyproject.toml"), "utf8"),
+    ).resolves.toContain('version = "4.0.2"');
+  });
+
+  it("rejects a missing proxy version", async () => {
+    const repositoryRoot = await repositoryFixture("4.0.2");
+    await writeFile(path.join(repositoryRoot, "packages/sdk-python/package.json"), "{}\n");
+
+    await expect(applyPythonAlphaVersion({ repositoryRoot })).rejects.toThrow(
+      "Python version proxy does not define a string version",
+    );
+  });
+});

--- a/scripts/release/python-alpha-version.ts
+++ b/scripts/release/python-alpha-version.ts
@@ -1,0 +1,92 @@
+import { execFile } from "node:child_process";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import { pathToFileURL } from "node:url";
+import { updatePythonProjectVersion } from "./python-version.ts";
+
+const execFileAsync = promisify(execFile);
+
+// Produced by `changeset version --snapshot` with the `alpha-{commit}` template.
+const snapshotVersionPattern =
+  /^(?<base>(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*))-alpha-[0-9a-f]+$/u;
+
+/**
+ * Maps a changesets snapshot version (`4.0.3-alpha-<sha>`) onto the PEP 440
+ * developmental release `4.0.3a0.dev<N>`.
+ *
+ * PyPI rejects local versions (`+<sha>`) and PEP 440 only allows digits in the
+ * `.devN` segment, so the commit cannot be carried in the version itself. `a0`
+ * sorts the build below the stable `4.0.3` it precedes and keeps it out of
+ * `pip install stagehand` unless `--pre` is passed — the same role the `alpha`
+ * dist-tag plays on npm. `N` must increase between pushes; the
+ * `stagehand-python@<version>` git tag maps a build back to its commit.
+ */
+export function pythonAlphaVersion(snapshotVersion: string, devNumber: number): string {
+  const base = snapshotVersionPattern.exec(snapshotVersion)?.groups?.base;
+  if (base === undefined) {
+    throw new Error(`Not a changesets snapshot version: ${snapshotVersion}`);
+  }
+  if (!Number.isInteger(devNumber) || devNumber < 0) {
+    throw new Error(`Invalid developmental release number: ${String(devNumber)}`);
+  }
+  return `${base}a0.dev${String(devNumber)}`;
+}
+
+export type PythonAlphaVersionOptions = {
+  checkOnly?: boolean;
+  repositoryRoot?: string;
+  devNumber?: () => Promise<number>;
+};
+
+export type PythonAlphaVersionStatus =
+  | { shouldPublish: false }
+  | { shouldPublish: true; version: string };
+
+async function commitCount(repositoryRoot: string): Promise<number> {
+  const { stdout } = await execFileAsync("git", ["rev-list", "--count", "HEAD"], {
+    cwd: repositoryRoot,
+  });
+  return Number.parseInt(stdout.trim(), 10);
+}
+
+/**
+ * Expects `changeset version --snapshot` to have run already. When the Python
+ * proxy package received a snapshot version there is something unreleased to
+ * publish, so pyproject.toml is rewritten to the matching PEP 440 version.
+ * Otherwise nothing is touched and no alpha should be published.
+ */
+export async function applyPythonAlphaVersion({
+  checkOnly = false,
+  repositoryRoot = path.resolve(import.meta.dirname, "../.."),
+  devNumber = async () => await commitCount(repositoryRoot),
+}: PythonAlphaVersionOptions = {}): Promise<PythonAlphaVersionStatus> {
+  const pythonDirectory = path.join(repositoryRoot, "packages/sdk-python");
+  const proxyManifest = JSON.parse(
+    await readFile(path.join(pythonDirectory, "package.json"), "utf8"),
+  ) as { version?: unknown };
+  if (typeof proxyManifest.version !== "string") {
+    throw new TypeError("Python version proxy does not define a string version");
+  }
+  if (!snapshotVersionPattern.test(proxyManifest.version)) {
+    return { shouldPublish: false };
+  }
+
+  const version = pythonAlphaVersion(proxyManifest.version, await devNumber());
+  if (!checkOnly) {
+    const pyprojectPath = path.join(pythonDirectory, "pyproject.toml");
+    const pyproject = await readFile(pyprojectPath, "utf8");
+    await writeFile(pyprojectPath, updatePythonProjectVersion(pyproject, version));
+  }
+  return { shouldPublish: true, version };
+}
+
+const invokedPath = process.argv[1];
+if (
+  invokedPath !== undefined &&
+  import.meta.url === pathToFileURL(path.resolve(invokedPath)).href
+) {
+  const status = await applyPythonAlphaVersion({ checkOnly: process.argv.includes("--check") });
+  process.stdout.write(`should-publish=${String(status.shouldPublish)}\n`);
+  if (status.shouldPublish) process.stdout.write(`version=${status.version}\n`);
+}


### PR DESCRIPTION
> Stacked on #2786 (TypeScript alphas). Retarget to `main` once that merges.

## Why

#2786 restores `<next>-alpha-<sha>` npm releases on every push. This gives the Python SDK the equivalent channel.

PyPI rejects local versions (`+<sha>`) and PEP 440 only allows digits in a `.devN` segment, so the commit can't be carried in the version. The idiomatic analogue is a **developmental pre-release**: `4.0.3a0.dev<N>`.

- `a0` marks the alpha channel — sorts below the `4.0.3` it precedes and is hidden from `pip install stagehand` unless `--pre` is passed (same role as npm's `alpha` dist-tag).
- `N` = commit count on `main`, so successive pushes order correctly and re-running the workflow on the same commit is idempotent (PyPI rejects the duplicate rather than minting a second build).
- The existing `stagehand-python@<version>` git tag maps a build back to its commit.

## What

- `scripts/release/python-alpha-version.ts` (+ tests) — after `changeset version --snapshot`, reads the Python proxy `package.json`; if it got a snapshot version there's something unreleased, so rewrite `pyproject.toml` to `<base>a0.dev<N>`. Otherwise `should-publish=false`. `--check` mode doesn't write.
- `justfile` — `_version-python-alpha`: `changeset version --snapshot` → apply alpha version → `uv lock`.
- `publish-python.yml` — new `alpha` boolean input; when set, runs `just _version-python-alpha` between `just install` and `just build`. Everything downstream (version read, wheel/sdist smoke tests, `uv publish --trusted-publishing`, git tag) is unchanged and reused. Checkout is now `fetch-depth: 0` for the commit count.
- `release.yml` — `python-alpha-status` + `publish-python-alpha` jobs, mirroring the stable `python-release-status` + `publish-python` pair.

## Verified locally

With a throwaway changeset: snapshot → `should-publish=true version=4.0.3a0.dev1451`, `uv lock` updates cleanly, `uv build` produces `stagehand-4.0.3a0.dev1451-py3-none-any.whl` + sdist, and `packaging` confirms `4.0.2 < 4.0.3a0.dev1451 < 4.0.3` with `is_prerelease=True`. `pnpm exec vitest run scripts` → 66/66.

## Things to be aware of

- Trusted publishing is keyed on the workflow file + `pypi` environment, both reused here, so no PyPI config change is needed. If the `pypi` environment has required reviewers, every alpha will wait for approval — worth checking before merge.
- Dev builds accumulate on the PyPI project page forever (numpy et al. use a separate nightly index for this reason). Acceptable for now; flagging it.
- No changeset — CI/release infra only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes commit-addressed Python SDK alphas as PEP 440 developmental releases. Previously we only shipped stable versions; CI now publishes `<next>a0.dev<N>` when a changesets snapshot exists, ordered by commit count and requiring `--pre` to install `stagehand` (AP-2885).

- Adds `scripts/release/python-alpha-version.ts` (+ tests) to map snapshot versions (`<next>-alpha-<sha>`) to PEP 440, rewrite `pyproject.toml`, and support `--check`; outputs `should-publish` and `version`.
- Extends reusable `publish-python.yml` with an `alpha` input; applies the version via `just _version-python-alpha`, checks out with `fetch-depth: 0`, and reuses trusted publishing.
- Adds `python-alpha-status` and `publish-python-alpha` jobs in `release.yml` to gate alpha publishing on snapshot presence and reuse the publish workflow.

- Rollout: Reuses the existing `pypi` environment and trusted publishing; required reviewers will gate each alpha. Install with `pip install --pre stagehand`; dev builds will accumulate on PyPI.

<sup>Written for commit 8c2e573256b62309aca75ce9a01fbb797886e236. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

