### PR TITLE
[fix]: fail fast on `.connect()` when no ext found

### DIFF
--- a/.changeset/good-worms-sneeze.md
+++ b/.changeset/good-worms-sneeze.md
@@ -1,0 +1,7 @@
+---
+"@browserbasehq/stagehand-python": patch
+"@browserbasehq/stagehand-go": patch
+"@browserbasehq/stagehand": patch
+---
+
+fail fast on browserbase.connect() when extension is not present

--- a/packages/docs/tests/sdk-reference.test.ts
+++ b/packages/docs/tests/sdk-reference.test.ts
@@ -1285,26 +1285,35 @@ describe("Mintlify customization boundary", () => {
     ).toEqual([]);
   });
 
-  it("includes every MDX content page in docs.json navigation", async () => {
+  it("includes every indexed MDX content page in docs.json navigation", async () => {
     const docsConfig = JSON.parse(
       await readFile(resolve(DOCS_ROOT, "docs.json"), "utf8"),
     ) as unknown;
     const navigatedPages = [...collectNavigationPages(docsConfig)]
       .filter((page) => page.startsWith("v4/"))
       .sort();
-    const contentPages = (await listFiles(V4_DOCS_ROOT, shouldInspectDocsDirectory))
-      .filter((filePath) => extname(filePath) === ".mdx")
-      .map((filePath) =>
-        relative(DOCS_ROOT, filePath)
-          .split(sep)
-          .join("/")
-          .replace(/\.mdx$/u, ""),
+    const contentFiles = (await listFiles(V4_DOCS_ROOT, shouldInspectDocsDirectory)).filter(
+      (filePath) => extname(filePath) === ".mdx",
+    );
+    const indexedContentPages = (
+      await Promise.all(
+        contentFiles.map(async (filePath) => ({
+          indexed: !hasNoIndexFrontmatter(await readFile(filePath, "utf8")),
+          page: relative(DOCS_ROOT, filePath)
+            .split(sep)
+            .join("/")
+            .replace(/\.mdx$/u, ""),
+        })),
       )
+    )
+      .filter(({ indexed }) => indexed)
+      .map(({ page }) => page)
       .sort();
 
-    expect(navigatedPages, "Every MDX content page must be reachable from docs.json").toStrictEqual(
-      contentPages,
-    );
+    expect(
+      navigatedPages,
+      "Every indexed MDX content page must be reachable from docs.json",
+    ).toStrictEqual(indexedContentPages);
   });
 
   it("gives every language tab group the same complete language set", async () => {
@@ -3240,6 +3249,11 @@ function collectNavigationPages(value: unknown, pages = new Set<string>()): Set<
     collectNavigationPages(child, pages);
   }
   return pages;
+}
+
+function hasNoIndexFrontmatter(source: string): boolean {
+  const frontmatter = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/u.exec(source)?.[1];
+  return frontmatter !== undefined && /^noindex:\s*true\s*$/mu.test(frontmatter);
 }
 
 function snakeCase(name: string): string {

--- a/packages/docs/v4/configuration/browser.mdx
+++ b/packages/docs/v4/configuration/browser.mdx
@@ -425,7 +425,11 @@ When `browserbase.launch()` creates a session without an `extensionId`, Stagehan
 
 ### Alternative: Browserbase SDK
 
-If you prefer to manage sessions directly, create the session with the Browserbase SDK and hand Stagehand the resulting session through `browserbase.connect()`:
+If you prefer to manage sessions directly, upload the Stagehand extension to Browserbase first and include that uploaded extension when you create the session. Extensions cannot be added after a browser session starts. You can then hand Stagehand the resulting session through `browserbase.connect()`:
+
+<Note>
+The extension ID used to create the session is the uploaded-extension resource ID returned by the Browserbase Extensions API. `browserbase.launch()` handles this upload and session configuration automatically.
+</Note>
 
 <Tabs>
 <Tab title="TypeScript">
@@ -439,6 +443,7 @@ const bb = new Browserbase({
 
 const session = await bb.sessions.create({
   projectId: process.env.BROWSERBASE_PROJECT_ID!,
+  extensionId: process.env.BROWSERBASE_STAGEHAND_EXTENSION_ID!,
   // Add configuration options here
 });
 
@@ -464,6 +469,7 @@ bb = Browserbase(api_key=os.environ["BROWSERBASE_API_KEY"])
 
 session = bb.sessions.create(
     project_id=os.environ["BROWSERBASE_PROJECT_ID"],
+    extension_id=os.environ["BROWSERBASE_STAGEHAND_EXTENSION_ID"],
     # Add configuration options here
 )
 
@@ -478,9 +484,10 @@ stagehand = await Stagehand.create(browser=browser)
 
 <Tab title="Go">
 ```go
-// Create the session with your Browserbase client of choice, then attach by
-// session ID so the browser keeps its Browserbase identity.
-session, err := createBrowserbaseSession(ctx)
+// Create the session with your Browserbase client of choice, including the
+// uploaded Stagehand extension, then attach by session ID.
+extensionID := os.Getenv("BROWSERBASE_STAGEHAND_EXTENSION_ID")
+session, err := createBrowserbaseSession(ctx, extensionID)
 if err != nil {
 	return err
 }
@@ -504,9 +511,9 @@ defer func() { err = errors.Join(err, client.Close(ctx)) }()
 </Tab>
 </Tabs>
 
-#### Connecting to an existing session
+#### Connecting over CDP
 
-`localBrowser.connect()` attaches to any Chromium browser that is already running and exposing a DevTools endpoint, whether that is a Browserbase session you created earlier or a browser on your own machine:
+`localBrowser.connect()` attaches to a Chromium browser that is already running and exposing a DevTools endpoint. By default, it loads Stagehand's extension from the SDK host, so use it when the SDK and browser share a filesystem. For an existing Browserbase session, use `browserbase.connect()` with its session ID as shown above.
 
 <Tabs>
 <Tab title="TypeScript">
@@ -514,7 +521,7 @@ defer func() { err = errors.Join(err, client.Close(ctx)) }()
 import { localBrowser, Stagehand } from "@browserbasehq/stagehand";
 
 const browser = await localBrowser.connect({
-  cdpUrl: "wss://connect.browserbase.com/?apiKey=...&sessionId=...",
+  cdpUrl: "http://127.0.0.1:9222",
 });
 const stagehand = await Stagehand.create({ browser });
 ```
@@ -525,7 +532,7 @@ const stagehand = await Stagehand.create({ browser });
 from stagehand import Stagehand, local_browser
 
 browser = await local_browser.connect(
-    cdp_url=connect_url,  # from your Browserbase session
+    cdp_url="http://127.0.0.1:9222",
 )
 stagehand = await Stagehand.create(browser=browser)
 ```
@@ -534,7 +541,7 @@ stagehand = await Stagehand.create(browser=browser)
 <Tab title="Go">
 ```go
 browser, err := stagehand.ConnectLocalBrowser(ctx, stagehand.LocalBrowserConnectOptions{
-	CDPURL: "wss://connect.browserbase.com/?apiKey=...&sessionId=...",
+	CDPURL: "http://127.0.0.1:9222",
 })
 if err != nil {
 	return err
@@ -845,20 +852,24 @@ By default, Stagehand terminates the browser it launched and cleans up all resou
 <Tabs>
 <Tab title="TypeScript">
 ```typescript
-import { browserbase, localBrowser, Stagehand } from "@browserbasehq/stagehand";
+import { browserbase, Stagehand } from "@browserbasehq/stagehand";
 
 const browser = await browserbase.launch({
   apiKey: process.env.BROWSERBASE_API_KEY,
   keepAlive: true,
 });
 const stagehand = await Stagehand.create({ browser });
+const sessionId = browser.sessionId!;
 
 // The browser session continues running after close()
 await stagehand.close();
 await browser.close();
 
-// Later, reconnect to the same session over CDP
-const browser2 = await localBrowser.connect({ cdpUrl: existingConnectUrl });
+// Later, reconnect to the same Browserbase session
+const browser2 = await browserbase.connect({
+  apiKey: process.env.BROWSERBASE_API_KEY,
+  sessionId,
+});
 const stagehand2 = await Stagehand.create({ browser: browser2 });
 ```
 </Tab>
@@ -867,20 +878,25 @@ const stagehand2 = await Stagehand.create({ browser: browser2 });
 ```python
 import os
 
-from stagehand import Stagehand, browserbase, local_browser
+from stagehand import Stagehand, browserbase
 
 browser = await browserbase.launch(
     api_key=os.environ["BROWSERBASE_API_KEY"],
     keep_alive=True,
 )
 stagehand = await Stagehand.create(browser=browser)
+session_id = browser.session_id
+assert session_id is not None
 
 # The browser session continues running after close()
 await stagehand.close()
 await browser.close()
 
-# Later, reconnect to the same session over CDP
-browser2 = await local_browser.connect(cdp_url=existing_connect_url)
+# Later, reconnect to the same Browserbase session
+browser2 = await browserbase.connect(
+    api_key=os.environ["BROWSERBASE_API_KEY"],
+    session_id=session_id,
+)
 stagehand2 = await Stagehand.create(browser=browser2)
 ```
 </Tab>
@@ -901,6 +917,7 @@ client, err := stagehand.Create(ctx, stagehand.CreateOptions{Browser: browser})
 if err != nil {
 	return err
 }
+sessionID := browser.SessionID()
 
 // The browser session continues running after Close()
 if err := client.Close(ctx); err != nil {
@@ -910,9 +927,10 @@ if err := browser.Close(ctx); err != nil {
 	return err
 }
 
-// Later, reconnect to the same session over CDP
-browser2, err := stagehand.ConnectLocalBrowser(ctx, stagehand.LocalBrowserConnectOptions{
-	CDPURL: existingConnectURL,
+// Later, reconnect to the same Browserbase session
+browser2, err := stagehand.ConnectBrowserbase(ctx, stagehand.BrowserbaseConnectOptions{
+	APIKey:    apiKey,
+	SessionID: sessionID,
 })
 if err != nil {
 	return err

--- a/packages/protocol/tests/rpc-client/cdp-client.test.ts
+++ b/packages/protocol/tests/rpc-client/cdp-client.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { STAGEHAND_PROTOCOL_VERSION } from "../../schemas.ts";
 import {
+  discoverInstalledStagehandExtensionId,
   loadUnpackedExtension,
   resolveBrowserWebSocketUrl,
   StagehandRuntimeIncompatibleError,
-  waitForPreloadedStagehandServiceWorker,
   waitForRuntimeReady,
   waitForServiceWorker,
 } from "../../../sdk-ts/src/cdpClient.ts";
@@ -189,6 +189,7 @@ describe("waitForServiceWorker", () => {
 
     await expect(
       waitForServiceWorker(cdp, {
+        extensionId: "stagehandext",
         delayFn: async () => {},
         signal: lifecycleSignal,
       }),
@@ -227,167 +228,38 @@ describe("waitForServiceWorker", () => {
   });
 });
 
-describe("waitForPreloadedStagehandServiceWorker", () => {
-  it("probes candidate workers and returns the one with the Stagehand runtime", async () => {
-    const wrongWorker = target("wrong-worker", "chrome-extension://otherext/service-worker.js");
-    const stagehandWorker = target(
-      "stagehand-worker",
-      "chrome-extension://stagehandext/service-worker.js",
-    );
-    const attachedSessions = ["wrong-session", "stagehand-session"];
-    const readiness = [
+describe("discoverInstalledStagehandExtensionId", () => {
+  it("returns the enabled Stagehand extension id from Chrome's inventory", async () => {
+    const cdp = new FakeCdp().on("Extensions.getExtensions", () => ({
+      extensions: [
+        installedExtension("otherext", "Other Extension"),
+        installedExtension("stagehandext", "Stagehand Runtime"),
+      ],
+    }));
+
+    await expect(
+      discoverInstalledStagehandExtensionId(cdp, { signal: lifecycleSignal }),
+    ).resolves.toBe("stagehandext");
+
+    expect(cdp.calls).toStrictEqual([
       {
-        marker: {
-          protocolVersion: STAGEHAND_PROTOCOL_VERSION,
-          serverInfo: { name: "other", version: "1" },
-        },
-        hasReceiver: false,
+        method: "Extensions.getExtensions",
+        params: {},
+        sessionId: undefined,
+        signal: lifecycleSignal,
       },
-      readyRuntime(),
-    ];
-    const cdp = new FakeCdp()
-      .on("Target.getTargets", () => ({ targetInfos: [wrongWorker, stagehandWorker] }))
-      .on("Target.attachToTarget", () => ({ sessionId: attachedSessions.shift() }))
-      .on("Runtime.evaluate", () => ({ result: { value: readiness.shift() } }))
-      .on("Target.detachFromTarget", () => ({}));
-
-    await expect(
-      waitForPreloadedStagehandServiceWorker(cdp, {
-        delayFn: async () => {},
-        signal: lifecycleSignal,
-      }),
-    ).resolves.toStrictEqual({
-      serviceWorker: stagehandWorker,
-      sessionId: "stagehand-session",
-    });
-
-    expect(cdp.calls).toContainEqual({
-      method: "Target.detachFromTarget",
-      params: { sessionId: "wrong-session" },
-      sessionId: undefined,
-      signal: lifecycleSignal,
-    });
-    expect(cdp.calls.some((call) => call.method === "Extensions.loadUnpacked")).toBe(false);
+    ]);
   });
 
-  it("skips a stale Stagehand runtime and selects the compatible version", async () => {
-    const staleWorker = target("stale-worker", "chrome-extension://staleext/service-worker.js");
-    const currentWorker = target(
-      "current-worker",
-      "chrome-extension://currentext/service-worker.js",
-    );
-    const attachedSessions = ["stale-session", "current-session"];
-    const readiness = [runtimeReadiness("2.0.0"), readyRuntime()];
-    const cdp = new FakeCdp()
-      .on("Target.getTargets", () => ({ targetInfos: [staleWorker, currentWorker] }))
-      .on("Target.attachToTarget", () => ({ sessionId: attachedSessions.shift() }))
-      .on("Runtime.evaluate", () => ({ result: { value: readiness.shift() } }))
-      .on("Target.detachFromTarget", () => ({}));
+  it("fails immediately when Stagehand is absent from Chrome's inventory", async () => {
+    const cdp = new FakeCdp().on("Extensions.getExtensions", () => ({
+      extensions: [installedExtension("otherext", "Other Extension")],
+    }));
 
     await expect(
-      waitForPreloadedStagehandServiceWorker(cdp, {
-        delayFn: async () => {},
-        signal: lifecycleSignal,
-      }),
-    ).resolves.toStrictEqual({
-      serviceWorker: currentWorker,
-      sessionId: "current-session",
-    });
-
-    expect(cdp.calls).toContainEqual({
-      method: "Target.detachFromTarget",
-      params: { sessionId: "stale-session" },
-      sessionId: undefined,
-      signal: lifecycleSignal,
-    });
-  });
-
-  it("keeps looking past a stale runtime until initialization is cancelled", async () => {
-    const controller = new AbortController();
-    const reason = new Error("initialization cancelled");
-    const staleWorker = target("stale-worker", "chrome-extension://staleext/service-worker.js");
-    const cdp = new FakeCdp()
-      .on("Target.getTargets", () => ({ targetInfos: [staleWorker] }))
-      .on("Target.attachToTarget", () => ({ sessionId: "stale-session" }))
-      .on("Runtime.evaluate", () => ({
-        result: { value: runtimeReadiness("2.0.0") },
-      }))
-      .on("Target.detachFromTarget", () => ({}));
-
-    const error = await rejectedError(
-      waitForPreloadedStagehandServiceWorker(cdp, {
-        pollIntervalMs: 1,
-        signal: controller.signal,
-        delayFn: async () => {
-          controller.abort(reason);
-        },
-      }),
-    );
-
-    expect(error).toBe(reason);
-
-    expect(cdp.calls).toContainEqual({
-      method: "Target.detachFromTarget",
-      params: { sessionId: "stale-session" },
-      sessionId: undefined,
-      signal: controller.signal,
-    });
-  });
-
-  it("throws for a stale runtime when fallback installation is disabled", async () => {
-    const staleWorker = target("stale-worker", "chrome-extension://staleext/service-worker.js");
-    const cdp = new FakeCdp()
-      .on("Target.getTargets", () => ({ targetInfos: [staleWorker] }))
-      .on("Target.attachToTarget", () => ({ sessionId: "stale-session" }))
-      .on("Runtime.evaluate", () => ({ result: { value: runtimeReadiness("2.0.0") } }))
-      .on("Target.detachFromTarget", () => ({}));
-
-    await expect(
-      waitForPreloadedStagehandServiceWorker(cdp, {
-        allowFallbackInstall: false,
-        signal: lifecycleSignal,
-      }),
-    ).rejects.toBeInstanceOf(StagehandRuntimeIncompatibleError);
-
-    expect(cdp.calls).toContainEqual({
-      method: "Target.detachFromTarget",
-      params: { sessionId: "stale-session" },
-      sessionId: undefined,
-      signal: lifecycleSignal,
-    });
-  });
-
-  it("continues past a stale runtime when fallback installation is disabled", async () => {
-    const staleWorker = target("stale-worker", "chrome-extension://staleext/service-worker.js");
-    const currentWorker = target(
-      "current-worker",
-      "chrome-extension://currentext/service-worker.js",
-    );
-    const attachedSessions = ["stale-session", "current-session"];
-    const readiness = [runtimeReadiness("2.0.0"), readyRuntime()];
-    const cdp = new FakeCdp()
-      .on("Target.getTargets", () => ({ targetInfos: [staleWorker, currentWorker] }))
-      .on("Target.attachToTarget", () => ({ sessionId: attachedSessions.shift() }))
-      .on("Runtime.evaluate", () => ({ result: { value: readiness.shift() } }))
-      .on("Target.detachFromTarget", () => ({}));
-
-    await expect(
-      waitForPreloadedStagehandServiceWorker(cdp, {
-        allowFallbackInstall: false,
-        delayFn: async () => {},
-        signal: lifecycleSignal,
-      }),
-    ).resolves.toStrictEqual({
-      serviceWorker: currentWorker,
-      sessionId: "current-session",
-    });
-
-    expect(cdp.calls).toContainEqual({
-      method: "Target.detachFromTarget",
-      params: { sessionId: "stale-session" },
-      sessionId: undefined,
-      signal: lifecycleSignal,
-    });
+      discoverInstalledStagehandExtensionId(cdp, { signal: lifecycleSignal }),
+    ).rejects.toThrow("Stagehand extension is not installed in the connected browser");
+    expect(cdp.calls).toHaveLength(1);
   });
 });
 
@@ -583,6 +455,16 @@ function target(targetId: string, url: string): TargetInfo {
     type: "service_worker",
     title: "Service Worker",
     url,
+  };
+}
+
+function installedExtension(id: string, name: string): Record<string, unknown> {
+  return {
+    id,
+    name,
+    version: "1.0.0",
+    path: `/extensions/${id}`,
+    enabled: true,
   };
 }
 

--- a/packages/protocol/tests/rpc-client/cdp-client.test.ts
+++ b/packages/protocol/tests/rpc-client/cdp-client.test.ts
@@ -462,7 +462,7 @@ function installedExtension(id: string, name: string): Record<string, unknown> {
   return {
     id,
     name,
-    version: "1.0.0",
+    version: "0.0.1",
     path: `/extensions/${id}`,
     enabled: true,
   };

--- a/packages/sdk-go/cdp_client.go
+++ b/packages/sdk-go/cdp_client.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -20,6 +21,7 @@ import (
 const (
 	stagehandSendToHostBinding       = "__stagehandSendToHost"
 	stagehandReceiveFromHostFunction = "__stagehandReceiveFromHost"
+	stagehandExtensionName           = "Stagehand Runtime"
 
 	defaultCDPPollInterval    = 100 * time.Millisecond
 	defaultCDPResolveInterval = 250 * time.Millisecond
@@ -110,6 +112,14 @@ type cdpTargetInfo struct {
 	Type     string `json:"type"`
 	Title    string `json:"title"`
 	URL      string `json:"url"`
+}
+
+type cdpInstalledExtension struct {
+	ID      string  `json:"id"`
+	Name    *string `json:"name"`
+	Version *string `json:"version"`
+	Path    *string `json:"path"`
+	Enabled *bool   `json:"enabled"`
 }
 
 type cdpServiceWorkerInfo struct {
@@ -290,55 +300,51 @@ func (c *cdpClient) initialize(ctx context.Context, options cdpClientOptions) er
 	var (
 		serviceWorker cdpTargetInfo
 		sessionID     string
-		extensionID   string
 		err           error
 	)
 
-	if options.preloadedExtension {
-		serviceWorker, sessionID, err = c.waitForPreloadedServiceWorker(
-			ctx,
-			options.serviceWorkerURLIncludes,
-			options.pollInterval,
-		)
+	extensionID := options.extensionID
+	if options.extensionDir != "" {
+		extensionID, err = c.loadUnpackedExtension(ctx, options.extensionDir)
 		if err != nil {
 			return err
 		}
-		extensionID = extensionIDFromURL(serviceWorker.URL)
-	} else {
-		extensionID = options.extensionID
-		if options.extensionDir != "" {
-			extensionID, err = c.loadUnpackedExtension(ctx, options.extensionDir)
-			if err != nil {
-				return err
-			}
-		}
-		serviceWorker, err = c.waitForServiceWorker(
-			ctx,
-			extensionID,
-			options.serviceWorkerURLIncludes,
-			options.activationDelay,
-			options.pollInterval,
-		)
-		if err != nil {
-			return err
-		}
-		var attached struct {
-			SessionID string `json:"sessionId"`
-		}
-		if err := c.sendCommand(
-			ctx,
-			"Target.attachToTarget",
-			map[string]any{"targetId": serviceWorker.TargetID, "flatten": true},
-			"",
-			&attached,
-		); err != nil {
-			return err
-		}
-		if attached.SessionID == "" {
-			return errors.New("Target.attachToTarget did not return sessionId")
-		}
-		sessionID = attached.SessionID
 	}
+	if options.preloadedExtension {
+		extensionID, err = c.discoverInstalledStagehandExtensionID(ctx)
+		if err != nil {
+			return err
+		}
+	}
+	if extensionID == "" {
+		return errors.New("Stagehand extension ID was not resolved")
+	}
+	serviceWorker, err = c.waitForServiceWorker(
+		ctx,
+		extensionID,
+		options.serviceWorkerURLIncludes,
+		options.activationDelay,
+		options.pollInterval,
+	)
+	if err != nil {
+		return err
+	}
+	var attached struct {
+		SessionID string `json:"sessionId"`
+	}
+	if err := c.sendCommand(
+		ctx,
+		"Target.attachToTarget",
+		map[string]any{"targetId": serviceWorker.TargetID, "flatten": true},
+		"",
+		&attached,
+	); err != nil {
+		return err
+	}
+	if attached.SessionID == "" {
+		return errors.New("Target.attachToTarget did not return sessionId")
+	}
+	sessionID = attached.SessionID
 
 	c.mu.Lock()
 	c.sessionID = sessionID
@@ -802,6 +808,68 @@ func (c *cdpClient) loadUnpackedExtension(
 	return loaded.ID, nil
 }
 
+func (c *cdpClient) discoverInstalledStagehandExtensionID(
+	ctx context.Context,
+) (string, error) {
+	var response struct {
+		Extensions *[]cdpInstalledExtension `json:"extensions"`
+	}
+	if err := c.sendCommand(
+		ctx,
+		"Extensions.getExtensions",
+		map[string]any{},
+		"",
+		&response,
+	); err != nil {
+		return "", err
+	}
+	if response.Extensions == nil {
+		return "", errors.New("Extensions.getExtensions did not return extensions")
+	}
+
+	installed := false
+	enabledIDs := make([]string, 0, 1)
+	for _, extension := range *response.Extensions {
+		if extension.ID == "" ||
+			extension.Name == nil ||
+			extension.Version == nil ||
+			extension.Path == nil ||
+			extension.Enabled == nil {
+			return "", errors.New(
+				"Extensions.getExtensions returned an invalid extension entry",
+			)
+		}
+		if *extension.Name != stagehandExtensionName {
+			continue
+		}
+		installed = true
+		if *extension.Enabled {
+			enabledIDs = append(enabledIDs, extension.ID)
+		}
+	}
+
+	switch len(enabledIDs) {
+	case 1:
+		return enabledIDs[0], nil
+	case 0:
+		if installed {
+			return "", errors.New(
+				"Stagehand extension is installed in the connected browser but is disabled.",
+			)
+		}
+		return "", errors.New(
+			"Stagehand extension is not installed in the connected browser. " +
+				"The extension must be included when the Browserbase session is created.",
+		)
+	default:
+		slices.Sort(enabledIDs)
+		return "", fmt.Errorf(
+			"Multiple enabled Stagehand extensions are installed: %s",
+			strings.Join(enabledIDs, ", "),
+		)
+	}
+}
+
 func (c *cdpClient) waitForServiceWorker(
 	ctx context.Context,
 	extensionID string,
@@ -842,8 +910,7 @@ func (c *cdpClient) waitForServiceWorker(
 			}
 		}
 
-		if extensionID != "" &&
-			activationTargetID == "" &&
+		if activationTargetID == "" &&
 			time.Since(startedAt) >= activationDelay {
 			var activation struct {
 				TargetID string `json:"targetId"`
@@ -862,59 +929,6 @@ func (c *cdpClient) waitForServiceWorker(
 			) == nil {
 				activationTargetID = activation.TargetID
 			}
-		}
-		if err := waitForCDPPoll(ctx, pollInterval); err != nil {
-			continue
-		}
-	}
-}
-
-func (c *cdpClient) waitForPreloadedServiceWorker(
-	ctx context.Context,
-	urlIncludes string,
-	pollInterval time.Duration,
-) (cdpTargetInfo, string, error) {
-	var lastTargets []cdpTargetInfo
-
-	for {
-		if err := ctx.Err(); err != nil {
-			return cdpTargetInfo{}, "", fmt.Errorf(
-				"discover preloaded Stagehand service worker: %w; observed targets: %s",
-				err,
-				formatCDPTargets(lastTargets),
-			)
-		}
-		targets, err := c.getTargets(ctx)
-		if err != nil {
-			return cdpTargetInfo{}, "", err
-		}
-		lastTargets = targets
-		for _, target := range targets {
-			if !isStagehandServiceWorker(target, "", urlIncludes) {
-				continue
-			}
-			var attached struct {
-				SessionID string `json:"sessionId"`
-			}
-			err := c.sendCommand(
-				ctx,
-				"Target.attachToTarget",
-				map[string]any{"targetId": target.TargetID, "flatten": true},
-				"",
-				&attached,
-			)
-			if err != nil || attached.SessionID == "" {
-				continue
-			}
-			ready, _ := c.evaluateRuntimeReadiness(ctx, attached.SessionID)
-			if ready {
-				return target, attached.SessionID, nil
-			}
-			c.bestEffortCommand(
-				ctx,
-				"Target.detachFromTarget",
-				map[string]any{"sessionId": attached.SessionID},
-			)
 		}
 		if err := waitForCDPPoll(ctx, pollInterval); err != nil {
 			continue
@@ -1143,20 +1157,7 @@ func isStagehandServiceWorker(
 		!strings.Contains(target.URL, urlIncludes) {
 		return false
 	}
-	if extensionID == "" {
-		return true
-	}
 	return strings.HasPrefix(target.URL, "chrome-extension://"+extensionID+"/")
-}
-
-func extensionIDFromURL(value string) string {
-	const prefix = "chrome-extension://"
-	if !strings.HasPrefix(value, prefix) {
-		return ""
-	}
-	remainder := strings.TrimPrefix(value, prefix)
-	extensionID, _, _ := strings.Cut(remainder, "/")
-	return extensionID
 }
 
 func formatCDPTargets(targets []cdpTargetInfo) string {

--- a/packages/sdk-go/cdp_client_test.go
+++ b/packages/sdk-go/cdp_client_test.go
@@ -413,14 +413,29 @@ func TestCDPClientDiscoversPreloadedExtension(t *testing.T) {
 		_ map[string]json.RawMessage,
 	) map[string]any {
 		switch method {
+		case "Extensions.getExtensions":
+			return map[string]any{"result": map[string]any{
+				"extensions": []map[string]any{
+					installedExtension("other-extension", "Other Extension", true),
+					installedExtension("preloaded-extension", "Stagehand Runtime", true),
+				},
+			}}
 		case "Target.getTargets":
 			return map[string]any{"result": map[string]any{
-				"targetInfos": []map[string]any{{
-					"targetId": "worker-target",
-					"type":     "service_worker",
-					"title":    "Stagehand",
-					"url":      "chrome-extension://preloaded-extension/service-worker.js",
-				}},
+				"targetInfos": []map[string]any{
+					{
+						"targetId": "other-worker",
+						"type":     "service_worker",
+						"title":    "Other",
+						"url":      "chrome-extension://other-extension/service-worker.js",
+					},
+					{
+						"targetId": "worker-target",
+						"type":     "service_worker",
+						"title":    "Stagehand",
+						"url":      "chrome-extension://preloaded-extension/service-worker.js",
+					},
+				},
 			}}
 		case "Target.attachToTarget":
 			return map[string]any{"result": map[string]any{"sessionId": "worker-session"}}
@@ -447,17 +462,138 @@ func TestCDPClientDiscoversPreloadedExtension(t *testing.T) {
 	client.mu.Lock()
 	service := client.service
 	client.mu.Unlock()
-	if service.ExtensionID != "preloaded-extension" {
-		t.Fatalf("extension ID = %q", service.ExtensionID)
+	if service.ExtensionID != "preloaded-extension" || service.TargetID != "worker-target" {
+		t.Fatalf("service worker = %#v", service)
 	}
 	actualMethods := drainMethods(methods)
-	if len(actualMethods) == 0 || actualMethods[0] != "Target.getTargets" {
-		t.Fatalf("CDP methods = %#v", actualMethods)
+	expectedMethods := []string{
+		"Extensions.getExtensions",
+		"Target.getTargets",
+		"Target.attachToTarget",
+		"Runtime.enable",
+		"Runtime.addBinding",
+		"Runtime.evaluate",
 	}
-	for _, method := range actualMethods {
-		if method == "Extensions.loadUnpacked" {
-			t.Fatalf("preloaded extension unexpectedly called %s", method)
-		}
+	if !reflect.DeepEqual(actualMethods, expectedMethods) {
+		t.Fatalf("CDP methods = %#v, want %#v", actualMethods, expectedMethods)
+	}
+}
+
+func TestDiscoverInstalledStagehandExtensionID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		extensions any
+		wantID     string
+		wantError  string
+	}{
+		{
+			name: "single enabled match",
+			extensions: []map[string]any{
+				installedExtension("other", "Other Extension", true),
+				installedExtension("stagehand", "Stagehand Runtime", true),
+			},
+			wantID: "stagehand",
+		},
+		{
+			name: "missing",
+			extensions: []map[string]any{
+				installedExtension("other", "Other Extension", true),
+			},
+			wantError: "Stagehand extension is not installed in the connected browser. " +
+				"The extension must be included when the Browserbase session is created.",
+		},
+		{
+			name: "disabled",
+			extensions: []map[string]any{
+				installedExtension("stagehand", "Stagehand Runtime", false),
+			},
+			wantError: "Stagehand extension is installed in the connected browser but is disabled.",
+		},
+		{
+			name: "multiple enabled matches",
+			extensions: []map[string]any{
+				installedExtension("stagehand-z", "Stagehand Runtime", true),
+				installedExtension("stagehand-a", "Stagehand Runtime", true),
+			},
+			wantError: "Multiple enabled Stagehand extensions are installed: " +
+				"stagehand-a, stagehand-z",
+		},
+		{
+			name: "malformed entry",
+			extensions: []map[string]any{
+				{
+					"id":      "stagehand",
+					"name":    "Stagehand Runtime",
+					"version": "4.0.2",
+					"path":    "/remote/stagehand",
+				},
+			},
+			wantError: "Extensions.getExtensions returned an invalid extension entry",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			socket := newFakeCDPWebSocket()
+			methods := make(chan string, 2)
+			socket.writeHook = responseHook(t, socket, methods, func(
+				string,
+				map[string]json.RawMessage,
+			) map[string]any {
+				return map[string]any{"result": map[string]any{"extensions": test.extensions}}
+			})
+			client := newTestCDPClient(
+				t,
+				socket,
+				"ws://127.0.0.1/devtools/browser/test",
+			)
+
+			got, err := client.discoverInstalledStagehandExtensionID(context.Background())
+			if test.wantError != "" {
+				if err == nil || err.Error() != test.wantError {
+					t.Fatalf("error = %v, want %q", err, test.wantError)
+				}
+			} else if err != nil || got != test.wantID {
+				t.Fatalf("result = %q, %v, want %q, nil", got, err, test.wantID)
+			}
+			if actual := drainMethods(methods); !reflect.DeepEqual(
+				actual,
+				[]string{"Extensions.getExtensions"},
+			) {
+				t.Fatalf("CDP methods = %#v", actual)
+			}
+		})
+	}
+}
+
+func TestDiscoverInstalledStagehandExtensionIDPropagatesCommandError(t *testing.T) {
+	t.Parallel()
+
+	socket := newFakeCDPWebSocket()
+	methods := make(chan string, 2)
+	socket.writeHook = responseHook(t, socket, methods, func(
+		string,
+		map[string]json.RawMessage,
+	) map[string]any {
+		return map[string]any{"error": map[string]any{
+			"code": -32601, "message": "Method not available",
+		}}
+	})
+	client := newTestCDPClient(t, socket, "ws://127.0.0.1/devtools/browser/test")
+
+	_, err := client.discoverInstalledStagehandExtensionID(context.Background())
+	var commandError *cdpCommandError
+	if !errors.As(err, &commandError) || commandError.Method != "Extensions.getExtensions" {
+		t.Fatalf("error = %T %v, want Extensions.getExtensions command error", err, err)
+	}
+	if actual := drainMethods(methods); !reflect.DeepEqual(
+		actual,
+		[]string{"Extensions.getExtensions"},
+	) {
+		t.Fatalf("CDP methods = %#v", actual)
 	}
 }
 
@@ -971,6 +1107,16 @@ func readyRuntimeResponse() map[string]any {
 			},
 		},
 	}}
+}
+
+func installedExtension(id string, name string, enabled bool) map[string]any {
+	return map[string]any{
+		"id":      id,
+		"name":    name,
+		"version": "4.0.2",
+		"path":    "/remote/extensions/" + id,
+		"enabled": enabled,
+	}
 }
 
 func receiveCDPWrite(t *testing.T, socket *fakeCDPWebSocket) []byte {

--- a/packages/sdk-python/src/stagehand/cdp_client.py
+++ b/packages/sdk-python/src/stagehand/cdp_client.py
@@ -17,6 +17,7 @@ from stagehand._generated.protocol_version import (
 
 STAGEHAND_SEND_TO_HOST_BINDING = "__stagehandSendToHost"
 _RUNTIME_NAME = "stagehand"
+_STAGEHAND_EXTENSION_NAME = "Stagehand Runtime"
 _PROTOCOL_SEMVER_PATTERN = re.compile(PROTOCOL_SEMVER_PATTERN)
 
 # Constant on purpose: the TypeScript SDK evaluates the identical expression, so the two cannot
@@ -113,6 +114,15 @@ class ServiceWorkerInfo:
     extension_id: str | None = None
 
 
+@dataclass(frozen=True)
+class _InstalledExtension:
+    id: str
+    name: str
+    version: str
+    path: str
+    enabled: bool
+
+
 class _CDPCommandError(RuntimeError):
     def __init__(self, method: str, error: Mapping[str, object]) -> None:
         self.method = method
@@ -169,25 +179,23 @@ class CDPClient:
         client = cls(socket, web_socket_debugger_url)
 
         try:
+            resolved_extension_id = extension_id
+            if extension_dir is not None:
+                resolved_extension_id = await client._load_unpacked_extension(extension_dir)
             if preloaded_extension:
-                worker, session_id = await client._wait_for_preloaded_service_worker(
-                    service_worker_url_includes or "service-worker.js",
-                )
-                resolved_extension_id = _extension_id_from_url(worker.url)
-            else:
-                resolved_extension_id = extension_id
-                if extension_dir is not None:
-                    resolved_extension_id = await client._load_unpacked_extension(extension_dir)
+                resolved_extension_id = await client._discover_installed_stagehand_extension_id()
+            if resolved_extension_id is None:
+                raise RuntimeError("Stagehand extension ID was not resolved")
 
-                worker = await client._wait_for_service_worker(
-                    resolved_extension_id,
-                    service_worker_url_includes or "service-worker.js",
-                )
-                attached = await client.send_command(
-                    "Target.attachToTarget",
-                    {"targetId": worker.target_id, "flatten": True},
-                )
-                session_id = _required_string(attached, "sessionId", "Target.attachToTarget")
+            worker = await client._wait_for_service_worker(
+                resolved_extension_id,
+                service_worker_url_includes or "service-worker.js",
+            )
+            attached = await client.send_command(
+                "Target.attachToTarget",
+                {"targetId": worker.target_id, "flatten": True},
+            )
+            session_id = _required_string(attached, "sessionId", "Target.attachToTarget")
             client._session_id = session_id
             client._service_worker = ServiceWorkerInfo(
                 target_id=worker.target_id,
@@ -394,9 +402,32 @@ class CDPClient:
             raise
         return _required_string(loaded, "id", "Extensions.loadUnpacked")
 
+    async def _discover_installed_stagehand_extension_id(self) -> str:
+        response = await self.send_command("Extensions.getExtensions")
+        installed = [
+            extension
+            for extension in _parse_installed_extensions(response)
+            if extension.name == _STAGEHAND_EXTENSION_NAME
+        ]
+        enabled = [extension for extension in installed if extension.enabled]
+
+        if len(enabled) == 1:
+            return enabled[0].id
+        if len(enabled) > 1:
+            ids = ", ".join(sorted(extension.id for extension in enabled))
+            raise RuntimeError(f"Multiple enabled Stagehand extensions are installed: {ids}")
+        if installed:
+            raise RuntimeError(
+                "Stagehand extension is installed in the connected browser but is disabled."
+            )
+        raise RuntimeError(
+            "Stagehand extension is not installed in the connected browser. "
+            "The extension must be included when the Browserbase session is created."
+        )
+
     async def _wait_for_service_worker(
         self,
-        extension_id: str | None,
+        extension_id: str,
         url_includes: str,
     ) -> ServiceWorkerInfo:
         started = time.monotonic()
@@ -416,10 +447,7 @@ class CDPClient:
                         target_info.get("type") == "service_worker"
                         and isinstance(url, str)
                         and url.startswith("chrome-extension://")
-                        and (
-                            extension_id is None
-                            or url.startswith(f"chrome-extension://{extension_id}/")
-                        )
+                        and url.startswith(f"chrome-extension://{extension_id}/")
                         and url_includes in url
                     ):
                         return ServiceWorkerInfo(
@@ -431,11 +459,7 @@ class CDPClient:
                             extension_id=extension_id,
                         )
 
-                if (
-                    extension_id is not None
-                    and activation_target_id is None
-                    and (time.monotonic() - started) >= 1
-                ):
+                if activation_target_id is None and (time.monotonic() - started) >= 1:
                     with suppress(Exception):
                         activation = await self.send_command(
                             "Target.createTarget",
@@ -449,83 +473,6 @@ class CDPClient:
                 self._schedule_best_effort_command(
                     "Target.closeTarget", {"targetId": activation_target_id}
                 )
-
-    async def _wait_for_preloaded_service_worker(
-        self,
-        url_includes: str,
-    ) -> tuple[ServiceWorkerInfo, str]:
-        """Return a discovered worker and its flat CDP session, left attached for the caller.
-
-        Each candidate must be attached to evaluate readiness; unready or incompatible
-        candidates are detached before the next poll.
-        """
-        while True:
-            response = await self.send_command("Target.getTargets")
-            targets = response.get("targetInfos")
-            target_infos = cast(list[object], targets) if isinstance(targets, list) else []
-            for target in target_infos:
-                if not isinstance(target, dict):
-                    continue
-                target_info = cast(dict[str, object], target)
-                url = target_info.get("url")
-                if not (
-                    target_info.get("type") == "service_worker"
-                    and isinstance(url, str)
-                    and url.startswith("chrome-extension://")
-                    and url_includes in url
-                ):
-                    continue
-
-                session_id: str | None = None
-                keep_attached = False
-                try:
-                    attached = await self.send_command(
-                        "Target.attachToTarget",
-                        {
-                            "targetId": _required_string(
-                                target_info, "targetId", "Target.getTargets"
-                            ),
-                            "flatten": True,
-                        },
-                    )
-                    session_id = _required_string(attached, "sessionId", "Target.attachToTarget")
-                    evaluated = await self.send_command(
-                        "Runtime.evaluate",
-                        {
-                            "expression": _RUNTIME_READINESS_EXPRESSION,
-                            "returnByValue": True,
-                        },
-                        session_id=session_id,
-                    )
-                    if not isinstance(evaluated.get("exceptionDetails"), Mapping):
-                        result = evaluated.get("result")
-                        value = result.get("value") if isinstance(result, Mapping) else None
-                        if isinstance(value, Mapping):
-                            compatible, _ = _negotiate_runtime(value.get("marker"))
-                            if compatible and value.get("hasReceiver") is True:
-                                service_worker = ServiceWorkerInfo(
-                                    target_id=_required_string(
-                                        target_info, "targetId", "Target.getTargets"
-                                    ),
-                                    title=_required_string(
-                                        target_info, "title", "Target.getTargets"
-                                    ),
-                                    url=url,
-                                    extension_id=_extension_id_from_url(url),
-                                )
-                                keep_attached = True
-                                return service_worker, session_id
-                except Exception:
-                    # The worker may still be starting. Detach and retry until cancellation.
-                    pass
-                finally:
-                    if session_id is not None and not keep_attached:
-                        with suppress(Exception):
-                            await self.send_command(
-                                "Target.detachFromTarget",
-                                {"sessionId": session_id},
-                            )
-            await asyncio.sleep(0.1)
 
     async def _wait_for_runtime_receiver(self, session_id: str) -> None:
         while True:
@@ -605,9 +552,36 @@ def _required_string(value: Mapping[str, object], key: str, method: str) -> str:
     return result
 
 
-def _extension_id_from_url(url: str) -> str | None:
-    prefix = "chrome-extension://"
-    if not url.startswith(prefix):
-        return None
-    extension_id, separator, _ = url.removeprefix(prefix).partition("/")
-    return extension_id if separator and extension_id else None
+def _parse_installed_extensions(response: Mapping[str, object]) -> list[_InstalledExtension]:
+    raw_extensions = response.get("extensions")
+    if not isinstance(raw_extensions, list):
+        raise RuntimeError("Extensions.getExtensions did not return extensions")
+
+    extensions: list[_InstalledExtension] = []
+    for value in raw_extensions:
+        if not isinstance(value, Mapping):
+            raise RuntimeError("Extensions.getExtensions returned an invalid extension entry")
+        extension_id = value.get("id")
+        name = value.get("name")
+        version = value.get("version")
+        path = value.get("path")
+        enabled = value.get("enabled")
+        if (
+            not isinstance(extension_id, str)
+            or not extension_id
+            or not isinstance(name, str)
+            or not isinstance(version, str)
+            or not isinstance(path, str)
+            or not isinstance(enabled, bool)
+        ):
+            raise RuntimeError("Extensions.getExtensions returned an invalid extension entry")
+        extensions.append(
+            _InstalledExtension(
+                id=extension_id,
+                name=name,
+                version=version,
+                path=path,
+                enabled=enabled,
+            )
+        )
+    return extensions

--- a/packages/sdk-python/tests/test_cdp_client.py
+++ b/packages/sdk-python/tests/test_cdp_client.py
@@ -27,6 +27,21 @@ def _ready_marker() -> dict[str, object]:
     }
 
 
+def _installed_extension(
+    extension_id: str = "stagehand-extension",
+    *,
+    name: str = "Stagehand Runtime",
+    enabled: object = True,
+) -> dict[str, object]:
+    return {
+        "id": extension_id,
+        "name": name,
+        "version": "4.0.2",
+        "path": f"/remote/extensions/{extension_id}",
+        "enabled": enabled,
+    }
+
+
 def test_callback_batch_source_allows_native_code_text() -> None:
     expression = cdp_client._callback_batch_expression(
         message={
@@ -476,6 +491,15 @@ async def test_connect_discovers_a_ready_preloaded_extension(
 ) -> None:
     def response_for(message: dict[str, object]) -> dict[str, object]:
         method = message["method"]
+        if method == "Extensions.getExtensions":
+            return {
+                "result": {
+                    "extensions": [
+                        _installed_extension("other", name="Other Extension"),
+                        _installed_extension("preloaded"),
+                    ]
+                }
+            }
         if method == "Target.getTargets":
             return {
                 "result": {
@@ -511,276 +535,70 @@ async def test_connect_discovers_a_ready_preloaded_extension(
     )
     try:
         assert client.service_worker.extension_id == "preloaded"
-        assert "Extensions.loadUnpacked" not in [message["method"] for message in socket.sent]
-    finally:
-        await client.close()
-
-
-async def test_preloaded_discovery_detaches_stale_worker_then_accepts_ready_worker(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    get_targets_calls = 0
-
-    def response_for(message: dict[str, object]) -> dict[str, object]:
-        nonlocal get_targets_calls
-        method = message["method"]
-        if method == "Target.getTargets":
-            get_targets_calls += 1
-            name = "stale" if get_targets_calls == 1 else "ready"
-            return {
-                "result": {
-                    "targetInfos": [
-                        {
-                            "targetId": name,
-                            "type": "service_worker",
-                            "title": name,
-                            "url": f"chrome-extension://{name}/service-worker.js",
-                        }
-                    ]
-                }
-            }
-        if method == "Target.attachToTarget":
-            target_id = cast(dict[str, object], message["params"])["targetId"]
-            return {"result": {"sessionId": f"{target_id}-session"}}
-        if method == "Runtime.evaluate":
-            if message.get("sessionId") == "stale-session":
-                stale = _ready_marker()
-                stale["hasReceiver"] = False
-                return {"result": {"result": {"value": stale}}}
-            return {"result": {"result": {"value": _ready_marker()}}}
-        return {"result": {}}
-
-    socket = FakeWebSocket(response_for)
-
-    async def resolve(_: str) -> str:
-        return "ws://127.0.0.1/devtools/browser/test"
-
-    async def connect(_: str) -> FakeWebSocket:
-        return socket
-
-    monkeypatch.setattr(cdp_client, "_resolve_browser_web_socket_url", resolve)
-    monkeypatch.setattr(cdp_client, "_connect_web_socket", connect)
-    client = await CDPClient.connect(
-        cdp_url="wss://browserbase",
-        preloaded_extension=True,
-    )
-    try:
-        assert client.service_worker.target_id == "ready"
-        detach = [
-            message for message in socket.sent if message["method"] == "Target.detachFromTarget"
+        assert [message["method"] for message in socket.sent] == [
+            "Extensions.getExtensions",
+            "Target.getTargets",
+            "Target.attachToTarget",
+            "Runtime.enable",
+            "Runtime.addBinding",
+            "Runtime.evaluate",
         ]
-        assert cast(dict[str, object], detach[0]["params"])["sessionId"] == "stale-session"
     finally:
         await client.close()
 
 
-async def test_preloaded_discovery_detaches_incompatible_worker_then_accepts_ready_worker(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    get_targets_calls = 0
-
-    def response_for(message: dict[str, object]) -> dict[str, object]:
-        nonlocal get_targets_calls
-        method = message["method"]
-        if method == "Target.getTargets":
-            get_targets_calls += 1
-            name = "foreign" if get_targets_calls == 1 else "ready"
-            return {
-                "result": {
-                    "targetInfos": [
-                        {
-                            "targetId": name,
-                            "type": "service_worker",
-                            "title": name,
-                            "url": f"chrome-extension://{name}/service-worker.js",
-                        }
-                    ]
-                }
-            }
-        if method == "Target.attachToTarget":
-            target_id = cast(dict[str, object], message["params"])["targetId"]
-            return {"result": {"sessionId": f"{target_id}-session"}}
-        if method == "Runtime.evaluate":
-            if message.get("sessionId") == "foreign-session":
-                incompatible = _ready_marker()
-                incompatible["marker"] = {
-                    "protocolVersion": STAGEHAND_PROTOCOL_VERSION,
-                    "serverInfo": {"name": "foreign-extension", "version": "1.0.0"},
-                    "state": "ready",
-                }
-                return {"result": {"result": {"value": incompatible}}}
-            return {"result": {"result": {"value": _ready_marker()}}}
-        return {"result": {}}
-
-    socket = FakeWebSocket(response_for)
-
-    async def resolve(_: str) -> str:
-        return "ws://127.0.0.1/devtools/browser/test"
-
-    async def connect(_: str) -> FakeWebSocket:
-        return socket
-
-    monkeypatch.setattr(cdp_client, "_resolve_browser_web_socket_url", resolve)
-    monkeypatch.setattr(cdp_client, "_connect_web_socket", connect)
-    client = await CDPClient.connect(
-        cdp_url="wss://browserbase",
-        preloaded_extension=True,
-    )
+async def _discover_extension_from_result(result: dict[str, object]) -> str:
+    socket = FakeWebSocket(lambda _: {"result": result})
+    client = CDPClient(socket, "ws://127.0.0.1/devtools/browser/test")
     try:
-        assert client.service_worker.target_id == "ready"
-        detach = [
-            message for message in socket.sent if message["method"] == "Target.detachFromTarget"
-        ]
-        assert cast(dict[str, object], detach[0]["params"])["sessionId"] == "foreign-session"
+        return await client._discover_installed_stagehand_extension_id()
     finally:
         await client.close()
 
 
-async def test_preloaded_discovery_accepts_worker_without_extension_id(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    def response_for(message: dict[str, object]) -> dict[str, object]:
-        method = message["method"]
-        if method == "Target.getTargets":
-            return {
-                "result": {
-                    "targetInfos": [
-                        {
-                            "targetId": "worker-target",
-                            "type": "service_worker",
-                            "title": "Stagehand",
-                            "url": "chrome-extension:///service-worker.js",
-                        }
-                    ]
-                }
-            }
-        if method == "Target.attachToTarget":
-            return {"result": {"sessionId": "worker-session"}}
-        if method == "Runtime.evaluate":
-            return {"result": {"result": {"value": _ready_marker()}}}
-        return {"result": {}}
+async def test_installed_extension_discovery_reports_missing_stagehand() -> None:
+    with pytest.raises(
+        RuntimeError,
+        match="Stagehand extension is not installed in the connected browser",
+    ):
+        await _discover_extension_from_result({
+            "extensions": [_installed_extension("other", name="Other Extension")]
+        })
 
-    socket = FakeWebSocket(response_for)
 
-    async def resolve(_: str) -> str:
-        return "ws://127.0.0.1/devtools/browser/test"
+async def test_installed_extension_discovery_reports_disabled_stagehand() -> None:
+    with pytest.raises(RuntimeError, match="installed in the connected browser but is disabled"):
+        await _discover_extension_from_result({"extensions": [_installed_extension(enabled=False)]})
 
-    async def connect(_: str) -> FakeWebSocket:
-        return socket
 
-    monkeypatch.setattr(cdp_client, "_resolve_browser_web_socket_url", resolve)
-    monkeypatch.setattr(cdp_client, "_connect_web_socket", connect)
-    client = await CDPClient.connect(
-        cdp_url="wss://browserbase",
-        preloaded_extension=True,
-    )
+async def test_installed_extension_discovery_reports_enabled_matches_in_id_order() -> None:
+    with pytest.raises(
+        RuntimeError,
+        match="Multiple enabled Stagehand extensions are installed: stagehand-a, stagehand-z",
+    ):
+        await _discover_extension_from_result({
+            "extensions": [
+                _installed_extension("stagehand-z"),
+                _installed_extension("stagehand-a"),
+            ]
+        })
+
+
+async def test_installed_extension_discovery_rejects_malformed_inventory() -> None:
+    with pytest.raises(RuntimeError, match="invalid extension entry"):
+        await _discover_extension_from_result({"extensions": [_installed_extension(enabled="yes")]})
+
+
+async def test_installed_extension_discovery_propagates_cdp_command_errors() -> None:
+    socket = FakeWebSocket(lambda _: {"error": {"code": -32601, "message": "Method not available"}})
+    client = CDPClient(socket, "ws://127.0.0.1/devtools/browser/test")
     try:
-        assert client.service_worker.extension_id is None
+        with pytest.raises(RuntimeError, match="Extensions.getExtensions: Method not available"):
+            await client._discover_installed_stagehand_extension_id()
     finally:
         await client.close()
 
-
-async def test_preloaded_discovery_detaches_ready_worker_with_missing_title(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    get_targets_calls = 0
-
-    def response_for(message: dict[str, object]) -> dict[str, object]:
-        nonlocal get_targets_calls
-        method = message["method"]
-        if method == "Target.getTargets":
-            get_targets_calls += 1
-            if get_targets_calls == 1:
-                target = {
-                    "targetId": "missing-title",
-                    "type": "service_worker",
-                    "url": "chrome-extension://missing-title/service-worker.js",
-                }
-            else:
-                target = {
-                    "targetId": "ready",
-                    "type": "service_worker",
-                    "title": "ready",
-                    "url": "chrome-extension://ready/service-worker.js",
-                }
-            return {"result": {"targetInfos": [target]}}
-        if method == "Target.attachToTarget":
-            target_id = cast(dict[str, object], message["params"])["targetId"]
-            return {"result": {"sessionId": f"{target_id}-session"}}
-        if method == "Runtime.evaluate":
-            return {"result": {"result": {"value": _ready_marker()}}}
-        return {"result": {}}
-
-    socket = FakeWebSocket(response_for)
-
-    async def resolve(_: str) -> str:
-        return "ws://127.0.0.1/devtools/browser/test"
-
-    async def connect(_: str) -> FakeWebSocket:
-        return socket
-
-    monkeypatch.setattr(cdp_client, "_resolve_browser_web_socket_url", resolve)
-    monkeypatch.setattr(cdp_client, "_connect_web_socket", connect)
-    client = await CDPClient.connect(
-        cdp_url="wss://browserbase",
-        preloaded_extension=True,
-    )
-    try:
-        assert client.service_worker.target_id == "ready"
-        detach = [
-            message for message in socket.sent if message["method"] == "Target.detachFromTarget"
-        ]
-        assert cast(dict[str, object], detach[0]["params"])["sessionId"] == (
-            "missing-title-session"
-        )
-    finally:
-        await client.close()
-
-
-async def test_preloaded_discovery_remains_open_until_the_caller_cancels(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    discovery_started = asyncio.Event()
-
-    def response_for(message: dict[str, object]) -> dict[str, object]:
-        if message["method"] == "Target.getTargets":
-            discovery_started.set()
-            return {
-                "result": {
-                    "targetInfos": [
-                        {
-                            "targetId": "page",
-                            "type": "page",
-                            "title": "Page",
-                            "url": "https://example.com",
-                        }
-                    ]
-                }
-            }
-        return {"result": {}}
-
-    socket = FakeWebSocket(response_for)
-
-    async def resolve(_: str) -> str:
-        return "ws://127.0.0.1/devtools/browser/test"
-
-    async def connect(_: str) -> FakeWebSocket:
-        return socket
-
-    monkeypatch.setattr(cdp_client, "_resolve_browser_web_socket_url", resolve)
-    monkeypatch.setattr(cdp_client, "_connect_web_socket", connect)
-    connecting = asyncio.create_task(
-        CDPClient.connect(
-            cdp_url="wss://browserbase",
-            preloaded_extension=True,
-        )
-    )
-    await asyncio.wait_for(discovery_started.wait(), timeout=1)
-    await asyncio.sleep(0.01)
-    connecting.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await asyncio.wait_for(connecting, timeout=1)
-    assert socket.closed is True
+    assert [message["method"] for message in socket.sent] == ["Extensions.getExtensions"]
 
 
 class TestNegotiateRuntime:

--- a/packages/sdk-ts/src/cdpClient.ts
+++ b/packages/sdk-ts/src/cdpClient.ts
@@ -158,6 +158,20 @@ const RuntimeReadinessEnvelopeSchema = z.looseObject({
   hasReceiver: z.boolean(),
 });
 
+const InstalledExtensionSchema = z.looseObject({
+  id: z.string().min(1),
+  name: z.string(),
+  version: z.string(),
+  path: z.string(),
+  enabled: z.boolean(),
+});
+
+const InstalledExtensionsResultSchema = z.looseObject({
+  extensions: z.array(InstalledExtensionSchema),
+});
+
+const STAGEHAND_EXTENSION_NAME = "Stagehand Runtime";
+
 export class CDPConnectionClosedError extends Error {
   constructor() {
     super("CDP connection closed");
@@ -213,39 +227,32 @@ export class CDPClient {
     const client = new CDPClient(socket, webSocketDebuggerUrl);
 
     try {
-      let serviceWorker: TargetInfo;
-      let attached: { sessionId: string };
-      let extensionId: string | undefined;
-
-      if (options.preloadedExtension) {
-        const discovered = await waitForPreloadedStagehandServiceWorker(client, {
-          urlIncludes: options.serviceWorkerUrlIncludes,
-          runtimeRequirement: options.runtimeRequirement,
-          allowFallbackInstall: options.allowFallbackInstall,
-          signal,
-        });
-        serviceWorker = discovered.serviceWorker;
-        attached = { sessionId: discovered.sessionId };
-        extensionId = extensionIdFromUrl(serviceWorker.url);
+      let extensionId: string;
+      if (options.extensionDir) {
+        extensionId = await loadUnpackedExtension(client, options.extensionDir, signal);
+      } else if (options.extensionId) {
+        extensionId = options.extensionId;
+      } else if (options.preloadedExtension) {
+        extensionId = await discoverInstalledStagehandExtensionId(client, { signal });
       } else {
-        extensionId = options.extensionDir
-          ? await loadUnpackedExtension(client, options.extensionDir, signal)
-          : options.extensionId;
-        serviceWorker = await waitForServiceWorker(client, {
-          extensionId,
-          urlIncludes: options.serviceWorkerUrlIncludes,
-          signal,
-        });
-        attached = await client.sendCommand<{ sessionId: string }>(
-          "Target.attachToTarget",
-          {
-            targetId: serviceWorker.targetId,
-            flatten: true,
-          },
-          undefined,
-          signal,
+        throw new Error(
+          "Exactly one of extensionDir, extensionId, or preloadedExtension is required",
         );
       }
+      const serviceWorker = await waitForServiceWorker(client, {
+        extensionId,
+        urlIncludes: options.serviceWorkerUrlIncludes,
+        signal,
+      });
+      const attached = await client.sendCommand<{ sessionId: string }>(
+        "Target.attachToTarget",
+        {
+          targetId: serviceWorker.targetId,
+          flatten: true,
+        },
+        undefined,
+        signal,
+      );
 
       client.sessionId = attached.sessionId;
       client.attachedServiceWorker = {
@@ -496,82 +503,37 @@ export async function waitForRuntimeReady(
   }
 }
 
-export async function waitForPreloadedStagehandServiceWorker(
+export async function discoverInstalledStagehandExtensionId(
   cdp: CDPCommandSender,
-  options: {
-    urlIncludes?: string;
-    pollIntervalMs?: number;
-    delayFn?: (ms: number) => Promise<void>;
-    runtimeRequirement?: RuntimeRequirement;
-    allowFallbackInstall?: boolean;
-    signal: AbortSignal;
-  },
-): Promise<{ serviceWorker: TargetInfo; sessionId: string }> {
-  const pollIntervalMs = options.pollIntervalMs ?? 100;
-  const delayFn = options.delayFn ?? delay;
-  const workerUrlIncludes = options.urlIncludes ?? "service-worker.js";
+  options: { signal: AbortSignal },
+): Promise<string> {
+  throwIfAborted(options.signal);
+  const response = await cdp.sendCommand<unknown>(
+    "Extensions.getExtensions",
+    {},
+    undefined,
+    options.signal,
+  );
+  const installed = InstalledExtensionsResultSchema.parse(response).extensions.filter(
+    (extension) => extension.name === STAGEHAND_EXTENSION_NAME,
+  );
+  const enabled = installed.filter((extension) => extension.enabled);
 
-  while (true) {
-    throwIfAborted(options.signal);
-    const targets = await cdp.sendCommand<{ targetInfos: TargetInfo[] }>(
-      "Target.getTargets",
-      {},
-      undefined,
-      options.signal,
-    );
-    const candidates = targets.targetInfos.filter(
-      (target) =>
-        target.type === "service_worker" &&
-        target.url.startsWith("chrome-extension://") &&
-        target.url.includes(workerUrlIncludes),
-    );
-    let incompatibleRuntime: Extract<RuntimeCompatibility, { kind: "incompatible" }> | undefined;
-    for (const serviceWorker of candidates) {
-      let sessionId: string | undefined;
-      let keepAttached = false;
-      try {
-        const attached = await cdp.sendCommand<{ sessionId: string }>(
-          "Target.attachToTarget",
-          {
-            targetId: serviceWorker.targetId,
-            flatten: true,
-          },
-          undefined,
-          options.signal,
-        );
-        sessionId = attached.sessionId;
-        const evaluated = await evaluateRuntimeReadiness(cdp, sessionId, options.signal);
-        if (!evaluated.exceptionDetails) {
-          const readiness = parseRuntimeReadiness(evaluated.result?.value);
-          const compatibility = negotiateRuntimeCompatibility(
-            options.runtimeRequirement ?? DEFAULT_RUNTIME_REQUIREMENT,
-            readiness.marker,
-          );
-          if (compatibility.kind === "compatible" && readiness.hasReceiver) {
-            keepAttached = true;
-            return { serviceWorker, sessionId };
-          }
-          if (compatibility.kind === "incompatible" && options.allowFallbackInstall === false) {
-            incompatibleRuntime = compatibility;
-          }
-        }
-      } catch {
-        throwIfAborted(options.signal);
-        // The worker may still be starting. Detach and retry until initialization is cancelled.
-      } finally {
-        if (sessionId && !keepAttached) {
-          await cdp
-            .sendCommand("Target.detachFromTarget", { sessionId }, undefined, options.signal)
-            .catch(() => undefined);
-        }
-      }
-    }
-
-    if (incompatibleRuntime) {
-      throw new StagehandRuntimeIncompatibleError(incompatibleRuntime);
-    }
-    await abortable(delayFn(pollIntervalMs), options.signal);
+  if (enabled.length === 1) return enabled[0].id;
+  if (enabled.length > 1) {
+    const ids = enabled
+      .map((extension) => extension.id)
+      .sort()
+      .join(", ");
+    throw new Error(`Multiple enabled Stagehand extensions are installed: ${ids}`);
   }
+  if (installed.length > 0) {
+    throw new Error("Stagehand extension is installed in the connected browser but is disabled.");
+  }
+  throw new Error(
+    "Stagehand extension is not installed in the connected browser. " +
+      "The extension must be included when the Browserbase session is created.",
+  );
 }
 
 async function evaluateRuntimeReadiness(
@@ -598,15 +560,10 @@ function parseRuntimeReadiness(value: unknown): z.output<typeof RuntimeReadiness
   return parsed.success ? parsed.data : { marker: null, hasReceiver: false };
 }
 
-function extensionIdFromUrl(url: string): string | undefined {
-  const match = /^chrome-extension:\/\/([^/]+)\//u.exec(url);
-  return match?.[1];
-}
-
 export async function waitForServiceWorker(
   cdp: CDPCommandSender,
   options: {
-    extensionId?: string;
+    extensionId: string;
     urlIncludes?: string;
     activationDelayMs?: number;
     pollIntervalMs?: number;
@@ -634,19 +591,13 @@ export async function waitForServiceWorker(
         (target) =>
           target.type === "service_worker" &&
           target.url.startsWith("chrome-extension://") &&
-          (options.extensionId
-            ? target.url.startsWith(`chrome-extension://${options.extensionId}/`)
-            : true) &&
+          target.url.startsWith(`chrome-extension://${options.extensionId}/`) &&
           target.url.includes(workerUrlIncludes),
       );
 
       if (serviceWorker) return serviceWorker;
 
-      if (
-        options.extensionId &&
-        !activationTargetId &&
-        Date.now() - startedAt >= activationDelayMs
-      ) {
+      if (!activationTargetId && Date.now() - startedAt >= activationDelayMs) {
         const activation = await cdp
           .sendCommand<{ targetId?: string }>(
             "Target.createTarget",

--- a/packages/sdk-ts/tests/browser/factories.test.ts
+++ b/packages/sdk-ts/tests/browser/factories.test.ts
@@ -95,10 +95,11 @@ describe("Stagehand browser factories", () => {
       close: closeSource,
     }));
     const cdp = fakeCdpClient();
+    const connectCdp = vi.fn(async (_options: CDPClientOptions) => cdp);
     const createBrowserbaseSessionClient = vi.fn(() => ({ createSession }));
     const { browserbase } = createBrowserFactoriesForTest({
       createBrowserbaseSessionClient,
-      connectCdp: async () => cdp,
+      connectCdp,
     });
 
     const browser = await browserbase.launch({
@@ -117,6 +118,7 @@ describe("Stagehand browser factories", () => {
       "bb_key",
       "https://api.dev.browserbase.com",
     );
+    expect(connectCdp).toHaveBeenCalledWith(expect.objectContaining({ preloadedExtension: true }));
     expect(claimed.workerInitMetadata).toStrictEqual({
       apiKey: "bb_key",
       browser: {
@@ -167,6 +169,28 @@ describe("Stagehand browser factories", () => {
         region: "eu-central-1",
       },
     });
+  });
+
+  it("discovers Stagehand when connecting without a Chrome extension ID", async () => {
+    const connectSession = vi.fn(async () => ({
+      sessionId: "session_123",
+      cdpUrl: "wss://connect.browserbase.com/devtools/browser/session_123",
+    }));
+    const connectCdp = vi.fn(async (_options: CDPClientOptions) => fakeCdpClient());
+    const { browserbase } = createBrowserFactoriesForTest({
+      createBrowserbaseSessionClient: () => ({
+        createSession: vi.fn(),
+        connectSession,
+      }),
+      connectCdp,
+    });
+
+    await browserbase.connect({
+      apiKey: "bb_key",
+      sessionId: "session_123",
+    });
+
+    expect(connectCdp).toHaveBeenCalledWith(expect.objectContaining({ preloadedExtension: true }));
   });
 
   it("rejects a second Stagehand claim", async () => {

--- a/packages/sdk-ts/tests/cdpClient.test.ts
+++ b/packages/sdk-ts/tests/cdpClient.test.ts
@@ -1,13 +1,48 @@
 import { runInNewContext } from "node:vm";
 import { describe, expect, it, vi } from "vitest";
+import { STAGEHAND_PROTOCOL_VERSION } from "../../protocol/schemas.js";
 import {
   CDPClient,
   CDPConnectionClosedError,
+  discoverInstalledStagehandExtensionId,
   openCDPWebSocket,
   stagehandMessageExpression,
   waitForRuntimeReady,
   waitForServiceWorker,
 } from "../src/cdpClient.js";
+
+function extension(
+  overrides: Partial<Record<"id" | "name" | "version" | "path" | "enabled", unknown>> = {},
+) {
+  return {
+    id: "stagehand-extension",
+    name: "Stagehand Runtime",
+    version: "4.0.2",
+    path: "/remote/stagehand-extension",
+    enabled: true,
+    ...overrides,
+  };
+}
+
+function commandSender(
+  sendCommand: (
+    method: string,
+    params?: Record<string, unknown>,
+    sessionId?: string,
+    signal?: AbortSignal,
+  ) => Promise<unknown>,
+) {
+  return {
+    async sendCommand<Result = Record<string, unknown>>(
+      method: string,
+      params?: Record<string, unknown>,
+      sessionId?: string,
+      signal?: AbortSignal,
+    ): Promise<Result> {
+      return (await sendCommand(method, params, sessionId, signal)) as Result;
+    },
+  };
+}
 
 describe("callback batch expression", () => {
   it("serializes input separately from executable callback source", () => {
@@ -113,6 +148,103 @@ describe("CDP WebSocket transport", () => {
     expect(onerror).toHaveBeenCalledWith(error);
   });
 
+  it("discovers an installed extension before attaching to its ready worker", async () => {
+    const signal = new AbortController().signal;
+    const socket = new FakeWebSocket();
+    const originalWebSocket = globalThis.WebSocket;
+    const createSocket = vi.fn(function WebSocket() {
+      return socket;
+    });
+    Object.defineProperty(createSocket, "OPEN", { value: 1 });
+    vi.stubGlobal("WebSocket", createSocket);
+    socket.send.mockImplementation((raw: string) => {
+      const command = JSON.parse(raw) as {
+        id: number;
+        method: string;
+        sessionId?: string;
+      };
+      const result = (() => {
+        switch (command.method) {
+          case "Extensions.getExtensions":
+            return { extensions: [extension({ id: "installed-stagehand" })] };
+          case "Target.getTargets":
+            return {
+              targetInfos: [
+                {
+                  targetId: "stagehand-worker",
+                  type: "service_worker",
+                  title: "Stagehand",
+                  url: "chrome-extension://installed-stagehand/service-worker.js",
+                },
+              ],
+            };
+          case "Target.attachToTarget":
+            return { sessionId: "worker-session" };
+          case "Runtime.evaluate":
+            return {
+              result: {
+                value: {
+                  marker: {
+                    protocolVersion: STAGEHAND_PROTOCOL_VERSION,
+                    serverInfo: { name: "stagehand", version: "4.0.2" },
+                  },
+                  hasReceiver: true,
+                },
+              },
+            };
+          default:
+            return {};
+        }
+      })();
+
+      queueMicrotask(() => {
+        socket.dispatchEvent(
+          new MessageEvent("message", {
+            data: JSON.stringify({
+              id: command.id,
+              result,
+              ...(command.sessionId ? { sessionId: command.sessionId } : {}),
+            }),
+          }),
+        );
+      });
+    });
+    try {
+      const connecting = CDPClient.connect({
+        cdpUrl: "wss://browser.example/devtools/browser/session",
+        preloadedExtension: true,
+        signal,
+      });
+
+      await vi.waitFor(() => expect(createSocket).toHaveBeenCalledOnce());
+      socket.open();
+
+      const client = await connecting;
+      expect(createSocket).toHaveBeenCalledWith("wss://browser.example/devtools/browser/session");
+      expect(client.serviceWorker).toStrictEqual({
+        targetId: "stagehand-worker",
+        title: "Stagehand",
+        url: "chrome-extension://installed-stagehand/service-worker.js",
+        extensionId: "installed-stagehand",
+      });
+      expect(
+        socket.send.mock.calls.map(
+          ([raw]) => (JSON.parse(raw as string) as { method: string }).method,
+        ),
+      ).toStrictEqual([
+        "Extensions.getExtensions",
+        "Target.getTargets",
+        "Target.attachToTarget",
+        "Runtime.enable",
+        "Runtime.addBinding",
+        "Runtime.evaluate",
+      ]);
+      client.close();
+    } finally {
+      vi.stubGlobal("WebSocket", originalWebSocket);
+    }
+  });
+
   it("fails runtime readiness immediately when CDP disconnects", async () => {
     const disconnect = new CDPConnectionClosedError();
     const delayFn = vi.fn(async () => {});
@@ -176,5 +308,123 @@ describe("CDP WebSocket transport", () => {
       undefined,
       undefined,
     );
+  });
+});
+
+describe("installed Stagehand extension discovery", () => {
+  it("returns the Chrome ID of the single enabled Stagehand extension", async () => {
+    const signal = new AbortController().signal;
+    const sendCommand = vi.fn(async () => ({
+      extensions: [
+        extension({ id: "unrelated", name: "Other Extension" }),
+        extension({ id: "installed-stagehand" }),
+      ],
+    }));
+
+    await expect(
+      discoverInstalledStagehandExtensionId(commandSender(sendCommand), { signal }),
+    ).resolves.toBe("installed-stagehand");
+    expect(sendCommand).toHaveBeenCalledOnce();
+    expect(sendCommand).toHaveBeenCalledWith("Extensions.getExtensions", {}, undefined, signal);
+  });
+
+  it("reports a missing extension immediately from the installed inventory", async () => {
+    const signal = new AbortController().signal;
+    const sendCommand = vi.fn(async () => ({
+      extensions: [extension({ id: "unrelated", name: "Other Extension" })],
+    }));
+
+    await expect(
+      discoverInstalledStagehandExtensionId(commandSender(sendCommand), { signal }),
+    ).rejects.toThrow(
+      "Stagehand extension is not installed in the connected browser. " +
+        "The extension must be included when the Browserbase session is created.",
+    );
+    expect(sendCommand).toHaveBeenCalledOnce();
+  });
+
+  it("reports an installed but disabled Stagehand extension", async () => {
+    const signal = new AbortController().signal;
+    const sendCommand = vi.fn(async () => ({ extensions: [extension({ enabled: false })] }));
+
+    await expect(
+      discoverInstalledStagehandExtensionId(commandSender(sendCommand), { signal }),
+    ).rejects.toThrow("Stagehand extension is installed in the connected browser but is disabled.");
+  });
+
+  it("reports multiple enabled Stagehand extensions in deterministic ID order", async () => {
+    const signal = new AbortController().signal;
+    const sendCommand = vi.fn(async () => ({
+      extensions: [extension({ id: "stagehand-z" }), extension({ id: "stagehand-a" })],
+    }));
+
+    await expect(
+      discoverInstalledStagehandExtensionId(commandSender(sendCommand), { signal }),
+    ).rejects.toThrow(
+      "Multiple enabled Stagehand extensions are installed: stagehand-a, stagehand-z",
+    );
+  });
+
+  it("rejects malformed extension inventory responses", async () => {
+    const signal = new AbortController().signal;
+    const sendCommand = vi.fn(async () => ({
+      extensions: [extension({ enabled: "yes" })],
+    }));
+
+    await expect(
+      discoverInstalledStagehandExtensionId(commandSender(sendCommand), { signal }),
+    ).rejects.toThrow();
+  });
+
+  it("propagates inventory command failures without scanning targets", async () => {
+    const signal = new AbortController().signal;
+    const commandError = new Error("Method not available");
+    const sendCommand = vi.fn(async (method: string) => {
+      if (method === "Extensions.getExtensions") throw commandError;
+      return {};
+    });
+
+    await expect(
+      discoverInstalledStagehandExtensionId(commandSender(sendCommand), { signal }),
+    ).rejects.toBe(commandError);
+    expect(sendCommand).toHaveBeenCalledOnce();
+  });
+});
+
+describe("Stagehand service worker discovery", () => {
+  it("selects only the service worker belonging to the resolved extension ID", async () => {
+    const signal = new AbortController().signal;
+    const sendCommand = vi
+      .fn()
+      .mockResolvedValueOnce({
+        targetInfos: [
+          {
+            targetId: "other-worker",
+            type: "service_worker",
+            title: "Other",
+            url: "chrome-extension://other-extension/service-worker.js",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        targetInfos: [
+          {
+            targetId: "stagehand-worker",
+            type: "service_worker",
+            title: "Stagehand",
+            url: "chrome-extension://stagehand-extension/service-worker.js",
+          },
+        ],
+      });
+
+    await expect(
+      waitForServiceWorker(commandSender(sendCommand), {
+        extensionId: "stagehand-extension",
+        activationDelayMs: 60_000,
+        delayFn: async () => {},
+        signal,
+      }),
+    ).resolves.toMatchObject({ targetId: "stagehand-worker" });
+    expect(sendCommand).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/sdk-ts/tests/rpcClient.test.ts
+++ b/packages/sdk-ts/tests/rpcClient.test.ts
@@ -7,7 +7,12 @@ import {
   MAX_CALLBACK_BATCH_TIMEOUT_MS,
   STAGEHAND_PROTOCOL_VERSION,
 } from "../../protocol/schemas.js";
-import { RPCClient, rpcResponseTimeoutMs, type CDPTransport } from "../src/rpcClient.js";
+import {
+  RPCClient,
+  RPCClientOptionsSchema,
+  rpcResponseTimeoutMs,
+  type CDPTransport,
+} from "../src/rpcClient.js";
 
 const UppercaseMethod = {
   name: "test.uppercase",
@@ -64,6 +69,34 @@ class ManualCDPTransport implements CDPTransport {
     this.closeCalls += 1;
   }
 }
+
+describe("RPCClientOptionsSchema", () => {
+  it("accepts the preloaded-extension option", () => {
+    const signal = new AbortController().signal;
+
+    expect(
+      RPCClientOptionsSchema.parse({
+        cdpUrl: "ws://browser.example",
+        preloadedExtension: true,
+        signal,
+      }),
+    ).toStrictEqual({
+      cdpUrl: "ws://browser.example",
+      preloadedExtension: true,
+      signal,
+    });
+  });
+
+  it("rejects an installed-extension discovery policy", () => {
+    expect(() =>
+      RPCClientOptionsSchema.parse({
+        cdpUrl: "ws://browser.example",
+        discoverExtension: "require",
+        signal: new AbortController().signal,
+      }),
+    ).toThrow();
+  });
+});
 
 describe("RPCClient", () => {
   it("keeps callback batches in the ordinary pending RPC path", async () => {


### PR DESCRIPTION
# why
- connecting Stagehand to an existing Browserbase session created without the Stagehand extension currently fails after a 60s timeout. this is a poor developer experience, & a generic timeout error is not informative at all

# what changed
- changed client side extension discovery to use CDP `Extensions.getExtensions`
  - this searches for the `Stagehand Runtime`
- extension discovery fails immediately when Stagehand is missing, disabled, or when multiple stagehand extensions are enabled
- updated Browserbase `.connect()` docs so externally managed sessions include a previously uploaded Stagehand extension when they are created
- also added clarification in docs mentioning that extensions cannot be added after session startup, direct CDP attachment expects the browser to share the SDK filesystem, and Browserbase keep-alive sessions reconnect through`browserbase.connect()` by session ID

# test plan
- TS: tests extension discovery, exact worker selection, invalid inventories, and command failures
- python: tests the connection flow, invalid inventories, and command failures
- go: tests extension discovery, exact worker selection, invalid inventories, and command failures


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail fast on `.connect()` to Browserbase sessions without the Stagehand extension. Previously it waited ~60s and timed out; now it reads Chrome’s installed extensions and errors immediately when the extension is missing, disabled, or duplicated.

- Uses CDP `Extensions.getExtensions` to find the single enabled “Stagehand Runtime,” then waits for and attaches to its service worker by ID. Removes preloaded‑worker probing in TypeScript/Go/Python; `waitForServiceWorker` now requires and matches the resolved `extensionId` only.
- Clear errors: “Stagehand extension is not installed…”, “installed but is disabled,” or “Multiple enabled Stagehand extensions are installed: …”.
- Keeps `browserbase.launch()` behavior unchanged; it uploads and configures the extension automatically.
- SDK/tests: unified attach flow; added installed‑extension discovery; replaced preloaded‑path tests with inventory parsing, deterministic multi‑ID ordering, exact worker selection, invalid inventories, and command failure coverage. Docs tests updated to ignore `noindex` MDX pages.
- Docs: externally created sessions must include the uploaded Stagehand extension; extensions cannot be added after startup; `localBrowser.connect()` targets local CDP only; keep‑alive sessions reconnect via `browserbase.connect()` with the session ID. Examples show passing the uploaded‑extension resource ID from the Browserbase Extensions API.

**Rollout / migration**
- Externally managed Browserbase sessions must include the uploaded Stagehand extension at creation time. Required: upload the extension, then pass its uploaded‑extension resource ID as `extensionId` to the Browserbase Sessions API.
- For keep‑alive sessions, reconnect with `browserbase.connect({ sessionId })`. Do not use `localBrowser.connect()` for Browserbase sessions.
- Expect earlier, explicit errors on `.connect()` if the extension is missing, disabled, or installed more than once.

<sup>Written for commit 1c71c572749af79b1d3751c63f7fdf9341ba25dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



