### PR TITLE
fix(eve): close facade browser resources

### DIFF
--- a/packages/integrations/eve/src/session.ts
+++ b/packages/integrations/eve/src/session.ts
@@ -10,6 +10,7 @@ import {
   type StagehandBrowser,
 } from "@browserbasehq/stagehand";
 import {
+  BrowserbaseSessionReleaseError,
   releaseBrowserbaseSession,
   StagehandFacadeTools,
   stagehandFacadeConfigFromEnv,
@@ -238,6 +239,9 @@ async function attach(
   config: StagehandClientCreateConfig,
   session?: FacadeResources["session"],
 ): Promise<FacadeResources> {
+  const release = session
+    ? () => releaseSession(session.apiKey, session.id, session.baseUrl)
+    : undefined;
   try {
     const stagehand = await Stagehand.create({ browser, ...config });
     let tools: StagehandFacadeTools;
@@ -246,7 +250,20 @@ async function attach(
     });
     return { browser, stagehand, tools, ...(session ? { session } : {}) };
   } catch (error) {
-    await browser.close().catch(() => undefined);
+    let browserCloseFailed = false;
+    await browser.close().catch(() => {
+      browserCloseFailed = true;
+    });
+    if (browserCloseFailed && release && session) {
+      const released = await release();
+      if (released) {
+        clearOwnedSessionId(session.id);
+      } else {
+        // Keep the persisted ID as the recovery target. The next resource
+        // creation skips reconnecting to it and retries release first.
+        suspectSessionId = session.id;
+      }
+    }
     throw error;
   }
 }
@@ -264,15 +281,20 @@ async function closeResources(stale: FacadeResources, explicit = false): Promise
     );
     if (!released) {
       suspectSessionId = stale.session.id;
-      cleanupErrors.push(new Error("Failed to release the Browserbase session."));
-    } else if (browserbaseSessionId === stale.session.id) {
-      browserbaseSessionId = undefined;
-      suspectSessionId = undefined;
-      persistSessionId(undefined);
+      cleanupErrors.push(new BrowserbaseSessionReleaseError());
+    } else {
+      clearOwnedSessionId(stale.session.id);
     }
   }
 
   if (!explicit || cleanupErrors.length === 0) return;
   if (cleanupErrors.length === 1) throw cleanupErrors[0];
   throw new AggregateError(cleanupErrors, "Failed to close the browser session cleanly.");
+}
+
+function clearOwnedSessionId(sessionId: string): void {
+  if (browserbaseSessionId !== sessionId) return;
+  browserbaseSessionId = undefined;
+  suspectSessionId = undefined;
+  persistSessionId(undefined);
 }

--- a/packages/integrations/eve/src/session.ts
+++ b/packages/integrations/eve/src/session.ts
@@ -10,6 +10,7 @@ import {
   type StagehandBrowser,
 } from "@browserbasehq/stagehand";
 import {
+  releaseBrowserbaseSession,
   StagehandFacadeTools,
   stagehandFacadeConfigFromEnv,
 } from "@browserbasehq/stagehand-integrations/facade";
@@ -18,6 +19,11 @@ type FacadeResources = {
   browser: StagehandBrowser;
   stagehand: Stagehand;
   tools: StagehandFacadeTools;
+  session?: {
+    apiKey: string;
+    baseUrl: string | undefined;
+    id: string;
+  };
 };
 
 let resources: FacadeResources | undefined;
@@ -44,6 +50,17 @@ export function discardFacadeTools(expected: StagehandFacadeTools): void {
   resources = undefined;
   resourcesPromise = undefined;
   cleanupPromise = cleanupPromise.then(() => closeResources(stale));
+}
+
+async function closeRequestedFacadeTools(expected: StagehandFacadeTools): Promise<void> {
+  if (resources?.tools !== expected) return;
+
+  const stale = resources;
+  resources = undefined;
+  resourcesPromise = undefined;
+  const closeResult = cleanupPromise.then(() => closeResources(stale, true));
+  cleanupPromise = closeResult.catch(() => undefined);
+  await closeResult;
 }
 
 export async function discardFacadeToolsIfUnhealthy(expected: StagehandFacadeTools): Promise<void> {
@@ -95,7 +112,13 @@ async function createResources(): Promise<FacadeResources> {
     // broken, so reattaching would loop forever (the "no brick" invariant).
     if (browserbaseSessionId !== suspectSessionId) {
       const browser = await connectToSession(apiKey, browserbaseSessionId, baseUrl);
-      if (browser) return attach(browser, config.stagehand);
+      if (browser) {
+        return attach(browser, config.stagehand, {
+          apiKey,
+          baseUrl,
+          id: browserbaseSessionId,
+        });
+      }
     }
 
     // Recovery is bounded: release the old keep-alive session best-effort so
@@ -120,7 +143,11 @@ async function createResources(): Promise<FacadeResources> {
     browserbaseSessionId = browser.sessionId;
     persistSessionId(browser.sessionId);
   }
-  return attach(browser, config.stagehand);
+  return attach(
+    browser,
+    config.stagehand,
+    browser.sessionId ? { apiKey, baseUrl, id: browser.sessionId } : undefined,
+  );
 }
 
 async function connectToSession(
@@ -154,21 +181,14 @@ async function releaseSession(
   apiKey: string,
   sessionId: string,
   baseUrl: string | undefined,
-): Promise<void> {
-  // Best-effort raw REST release so the keep-alive session doesn't keep
-  // billing after we abandon it. Failures are swallowed: the session may
-  // already be gone, and release must never block the fresh launch.
+): Promise<boolean> {
   try {
-    await fetch(`${baseUrl ?? "https://api.browserbase.com"}/v1/sessions/${sessionId}`, {
-      method: "POST",
-      headers: {
-        "x-bb-api-key": apiKey,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ status: "REQUEST_RELEASE" }),
-    });
+    await releaseBrowserbaseSession({ apiKey, baseUrl, sessionId });
+    return true;
   } catch {
-    // Swallow — best-effort only.
+    // Recovery paths are best-effort; explicit close turns false into a stable
+    // lifecycle error so the model cannot falsely report successful cleanup.
+    return false;
   }
 }
 
@@ -216,17 +236,43 @@ function sessionFilePath(): string {
 async function attach(
   browser: StagehandBrowser,
   config: StagehandClientCreateConfig,
+  session?: FacadeResources["session"],
 ): Promise<FacadeResources> {
   try {
     const stagehand = await Stagehand.create({ browser, ...config });
-    return { browser, stagehand, tools: new StagehandFacadeTools(stagehand) };
+    let tools: StagehandFacadeTools;
+    tools = new StagehandFacadeTools(stagehand, {
+      close: () => closeRequestedFacadeTools(tools),
+    });
+    return { browser, stagehand, tools, ...(session ? { session } : {}) };
   } catch (error) {
     await browser.close().catch(() => undefined);
     throw error;
   }
 }
 
-async function closeResources(stale: FacadeResources): Promise<void> {
-  await stale.stagehand.close().catch(() => undefined);
-  await stale.browser.close().catch(() => undefined);
+async function closeResources(stale: FacadeResources, explicit = false): Promise<void> {
+  const cleanupErrors: unknown[] = [];
+  await stale.stagehand.close().catch((error) => cleanupErrors.push(error));
+  await stale.browser.close().catch((error) => cleanupErrors.push(error));
+
+  if (explicit && stale.session) {
+    const released = await releaseSession(
+      stale.session.apiKey,
+      stale.session.id,
+      stale.session.baseUrl,
+    );
+    if (!released) {
+      suspectSessionId = stale.session.id;
+      cleanupErrors.push(new Error("Failed to release the Browserbase session."));
+    } else if (browserbaseSessionId === stale.session.id) {
+      browserbaseSessionId = undefined;
+      suspectSessionId = undefined;
+      persistSessionId(undefined);
+    }
+  }
+
+  if (!explicit || cleanupErrors.length === 0) return;
+  if (cleanupErrors.length === 1) throw cleanupErrors[0];
+  throw new AggregateError(cleanupErrors, "Failed to close the browser session cleanly.");
 }

--- a/packages/integrations/eve/tests/session-lifecycle.test.ts
+++ b/packages/integrations/eve/tests/session-lifecycle.test.ts
@@ -1,0 +1,117 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  launch: vi.fn(),
+  connect: vi.fn(),
+  create: vi.fn(),
+  release: vi.fn(),
+}));
+
+vi.mock("@browserbasehq/stagehand", () => ({
+  browserbase: { launch: mocks.launch, connect: mocks.connect },
+  localBrowser: { launch: vi.fn() },
+  Stagehand: { create: mocks.create },
+}));
+
+vi.mock("@browserbasehq/stagehand-integrations/facade", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@browserbasehq/stagehand-integrations/facade")>()),
+  releaseBrowserbaseSession: mocks.release,
+  stagehandFacadeConfigFromEnv: () => ({
+    browser: { type: "browserbase", launchOptions: { apiKey: "test-api-key" } },
+    stagehand: {},
+  }),
+}));
+
+describe("Eve facade session lifecycle", () => {
+  let temporaryDirectory: string;
+
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.launch.mockReset();
+    mocks.connect.mockReset();
+    mocks.create.mockReset();
+    mocks.release.mockReset();
+    mocks.release.mockResolvedValue(undefined);
+    temporaryDirectory = mkdtempSync(path.join(os.tmpdir(), "stagehand-eve-session-test-"));
+    process.env.STAGEHAND_EVE_SESSION_FILE = path.join(temporaryDirectory, "session.json");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.STAGEHAND_EVE_SESSION_FILE;
+    rmSync(temporaryDirectory, { force: true, recursive: true });
+  });
+
+  it("releases an explicit browser close and creates fresh resources on the next call", async () => {
+    const first = createResources("session-one");
+    const second = createResources("session-two");
+    mocks.launch.mockResolvedValueOnce(first.browser).mockResolvedValueOnce(second.browser);
+    mocks.create.mockResolvedValueOnce(first.stagehand).mockResolvedValueOnce(second.stagehand);
+    const { getFacadeTools } = await import("../src/session.js");
+
+    const firstTools = await getFacadeTools();
+    await expect(firstTools.run("await browser.close();")).resolves.toBe("closed");
+
+    expect(first.stagehand.close).toHaveBeenCalledOnce();
+    expect(first.browser.close).toHaveBeenCalledOnce();
+    expect(mocks.release).toHaveBeenCalledWith({
+      apiKey: "test-api-key",
+      baseUrl: undefined,
+      sessionId: "session-one",
+    });
+
+    const secondTools = await getFacadeTools();
+    expect(secondTools).not.toBe(firstTools);
+    expect(mocks.launch).toHaveBeenCalledTimes(2);
+  });
+
+  it("surfaces a failed release instead of reporting close success", async () => {
+    const resources = createResources("session-failed-release");
+    mocks.launch.mockResolvedValueOnce(resources.browser);
+    mocks.create.mockResolvedValueOnce(resources.stagehand);
+    mocks.release.mockRejectedValueOnce(new Error("release failed"));
+    const { getFacadeTools } = await import("../src/session.js");
+
+    const tools = await getFacadeTools();
+    await expect(tools.run("await browser.close();")).rejects.toThrow(
+      "Failed to release the Browserbase session.",
+    );
+  });
+
+  it("surfaces a browser close failure even when Browserbase release succeeds", async () => {
+    const resources = createResources("session-browser-close-failed");
+    resources.browser.close.mockRejectedValueOnce(new Error("browser close failed"));
+    mocks.launch.mockResolvedValueOnce(resources.browser);
+    mocks.create.mockResolvedValueOnce(resources.stagehand);
+    const { getFacadeTools } = await import("../src/session.js");
+
+    const tools = await getFacadeTools();
+    await expect(tools.run("await browser.close();")).rejects.toThrow("browser close failed");
+    expect(mocks.release).toHaveBeenCalledOnce();
+  });
+});
+
+function createResources(sessionId: string) {
+  const page = { pageId: `page-${sessionId}` };
+  const browser = {
+    closed: false,
+    sessionId,
+    context: { pages: vi.fn(async () => [page]) },
+    close: vi.fn(async function (this: { closed: boolean }) {
+      this.closed = true;
+    }),
+  };
+  const stagehand = {
+    browser: { context: { activePage: vi.fn(async () => page) } },
+    close: vi.fn(async () => undefined),
+    experimentalBatch: vi.fn(async () => ({
+      __stagehandPlaywrightCompat: true,
+      value: "closed",
+      closeRequested: true,
+    })),
+  };
+  return { browser, stagehand };
+}

--- a/packages/integrations/eve/tests/session-lifecycle.test.ts
+++ b/packages/integrations/eve/tests/session-lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -62,10 +62,13 @@ describe("Eve facade session lifecycle", () => {
       baseUrl: undefined,
       sessionId: "session-one",
     });
+    expect(existsSync(process.env.STAGEHAND_EVE_SESSION_FILE!)).toBe(false);
 
     const secondTools = await getFacadeTools();
     expect(secondTools).not.toBe(firstTools);
     expect(mocks.launch).toHaveBeenCalledTimes(2);
+    expect(mocks.connect).not.toHaveBeenCalled();
+    expect(existsSync(process.env.STAGEHAND_EVE_SESSION_FILE!)).toBe(true);
   });
 
   it("surfaces a failed release instead of reporting close success", async () => {
@@ -74,10 +77,12 @@ describe("Eve facade session lifecycle", () => {
     mocks.create.mockResolvedValueOnce(resources.stagehand);
     mocks.release.mockRejectedValueOnce(new Error("release failed"));
     const { getFacadeTools } = await import("../src/session.js");
+    const { BrowserbaseSessionReleaseError } =
+      await import("@browserbasehq/stagehand-integrations/facade");
 
     const tools = await getFacadeTools();
-    await expect(tools.run("await browser.close();")).rejects.toThrow(
-      "Failed to release the Browserbase session.",
+    await expect(tools.run("await browser.close();")).rejects.toBeInstanceOf(
+      BrowserbaseSessionReleaseError,
     );
   });
 
@@ -91,6 +96,23 @@ describe("Eve facade session lifecycle", () => {
     const tools = await getFacadeTools();
     await expect(tools.run("await browser.close();")).rejects.toThrow("browser close failed");
     expect(mocks.release).toHaveBeenCalledOnce();
+  });
+
+  it("releases a persisted session when Stagehand initialization cleanup fails", async () => {
+    const resources = createResources("session-init-failed");
+    resources.browser.close.mockRejectedValueOnce(new Error("browser close failed"));
+    mocks.launch.mockResolvedValueOnce(resources.browser);
+    mocks.create.mockRejectedValueOnce(new Error("Stagehand init failed"));
+    const { getFacadeTools } = await import("../src/session.js");
+
+    await expect(getFacadeTools()).rejects.toThrow("Stagehand init failed");
+    expect(resources.browser.close).toHaveBeenCalledOnce();
+    expect(mocks.release).toHaveBeenCalledWith({
+      apiKey: "test-api-key",
+      baseUrl: undefined,
+      sessionId: "session-init-failed",
+    });
+    expect(existsSync(process.env.STAGEHAND_EVE_SESSION_FILE!)).toBe(false);
   });
 });
 


### PR DESCRIPTION
# why

This is PR 2 of the facade-close stack and depends on #2788.

The shared facade now propagates `browser.close()` to a host lifecycle callback, but Eve owns additional state that core cannot clean up generically: a keep-alive Browserbase session, its persisted session ID, reconnect/recovery decisions, and the currently cached facade tools. Eve must consume the signal at that ownership boundary.

Before this change, model-authored `await browser.close()` could return successfully while Eve retained the same facade and persisted Browserbase session. A later call could reuse authentication/cookie state from a browser the agent believed it had closed.

# what changed

- Eve detaches the current facade before cleanup and serializes cleanup with later resource creation.
- Explicit close attempts both Stagehand and browser cleanup, then uses the shared Browserbase SDK release helper.
- Persisted ownership is cleared only after release succeeds; an ambiguous or failed release is marked suspect and surfaced.
- A later tool call creates fresh resources instead of reusing the closed facade.
- A model-code error does not poison the operation queue or discard a healthy browser.
- Initialization cleanup captures Browserbase release before `Stagehand.create()`; if local close fails, release is attempted immediately and persisted ownership is either cleared or retained for retry.
- Failed explicit release uses the shared typed `BrowserbaseSessionReleaseError`.
- Focused tests cover successful close/fresh creation, failed release reporting, local browser-close failure, persisted-ID clearing, and initialization cleanup.

# behavior before and after

| Eve lifecycle | Before | After |
| --- | --- | --- |
| `await browser.close()` | Returns while retaining Eve-owned resources. | Awaits Eve-owned cleanup and release. |
| Browserbase state | Session can remain `RUNNING`. | Release is requested and verified through the shared helper. |
| Persisted session ID | Remains eligible for reconnect. | Cleared only after successful release. |
| Failed release | Can be masked by a successful tool result. | Surfaced and retained as suspect ownership. |
| Next call | Reuses the same facade/browser. | Creates fresh resources. |
| Browser close + release success | Local failure can be hidden. | Local cleanup failure is still surfaced. |

# end-to-end evidence

An exact-base live A/B probe navigated to `example.com`, called `await browser.close()`, then requested facade tools again:

| Lifecycle result | Current `main` | Stack through this PR |
| --- | --- | --- |
| Close call returned | Yes | Yes |
| Next call reused the same facade | Yes | No |
| Remote session after close | `RUNNING` | `COMPLETED` |

The follow-up call on the changed implementation created a fresh session and closed it; both changed-side sessions reached `COMPLETED`. The intentionally leaked base session was released after recording the result.

The same eight public Online-Mind2Web-style prompts were run through the official Eve example on real Browserbase sessions. Each required navigation, multiple facade calls, snapshot/screenshot evidence, exact final title/URL, and browser close:

| Result | Before | After |
| --- | ---: | ---: |
| Manually correct task outcome | 8/8 | 8/8 |
| LLM-judge pass | 7/8 | 7/8 |
| All seven strict harness gates | 2/8 | 5/8 |
| Operationally clean trace | 2/8 | 6/8 |
| Browserbase cleanup | 0/8 sessions | 9/9 sessions |

Nine sessions were created after the change because one unhealthy resource was replaced; all nine reached `COMPLETED`. The unchanged judge miss was a canonical-hostname false negative. Remaining strict failures were snapshot transport churn and facade/navigation limitations, not lifecycle failures.

# test plan

- Eve tests: 9/9
- Eve typecheck
- Eve consumer `eve build`
- Core tests on the base PR: 37/37
- Focused oxfmt/oxlint

No changeset is included because the Eve integration is a private example.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eve now closes and releases its facade-owned Browserbase session when model code calls await browser.close(), preventing reuse of a closed session and surfacing cleanup failures instead of hiding them. Before, close returned while Eve kept the session; now we await local cleanup, release via the shared helper, and create fresh resources on the next call.

- Adds a close hook on StagehandFacadeTools so explicit close triggers Eve-side cleanup and calls `releaseBrowserbaseSession` from `@browserbasehq/stagehand-integrations/facade` (replacing the prior best-effort REST call).
- Persists session metadata (apiKey, baseUrl, id) on the facade; clears the stored ID only after a successful release; a failed release marks the session suspect and throws `BrowserbaseSessionReleaseError`.
- Serializes cleanup with creation; reconnection skips a suspect session and launches fresh, and the next call after an explicit close creates new resources.
- Aggregates cleanup errors on explicit close: throws the single failure or an `AggregateError` when multiple occur; a browser-close failure still surfaces even if remote release succeeds.
- On Stagehand initialization failure after launch, attempts release and clears persisted ownership; marks the session suspect if release fails.
- Tests cover explicit close → fresh creation, failed release surfacing, browser-close failure with successful release, and init-failure cleanup.

<sup>Written for commit 96be869a2ca988d3a5139785ab0b75c4501fd746. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

