### PR TITLE
fix(pi): close facade browser resources

### DIFF
--- a/packages/integrations/pi/extensions/stagehand.ts
+++ b/packages/integrations/pi/extensions/stagehand.ts
@@ -24,6 +24,7 @@ import {
   SNAPSHOT_TOOL_DESCRIPTION,
   SnapshotInputSchema,
   StagehandFacadeTools,
+  releaseBrowserbaseSession,
   stagehandFacadeConfigFromEnv,
 } from "@browserbasehq/stagehand-integrations/facade";
 
@@ -31,6 +32,7 @@ type FacadeResources = {
   browser: StagehandBrowser;
   stagehand: Stagehand;
   tools: StagehandFacadeTools;
+  releaseSession?: () => Promise<void>;
 };
 
 // TypeBox mirrors of the wire schemas (pi validates params with TypeBox; the
@@ -65,24 +67,52 @@ export default function stagehandExtension(pi: ExtensionAPI) {
   // browser launches lazily on first tool call and closes on shutdown.
   let resources: FacadeResources | undefined;
   let resourcesPromise: Promise<FacadeResources> | undefined;
+  let cleanupPromise: Promise<void> = Promise.resolve();
+  const cleanupTargets = new Set<() => Promise<void>>();
 
   async function facadeTools(): Promise<StagehandFacadeTools> {
     if (resources && !resources.browser.closed) return resources.tools;
     resources = undefined;
-    resourcesPromise ??= (async () => {
+    resourcesPromise ??= cleanupPromise.then(retryCleanupTargets).then(async () => {
       const config = stagehandFacadeConfigFromEnv();
       const browser =
         config.browser.type === "browserbase"
           ? await browserbase.launch(config.browser.launchOptions)
           : await localBrowser.launch(config.browser.launchOptions);
+      const sessionId = browser.sessionId;
+      let releaseSession: (() => Promise<void>) | undefined;
+      if (config.browser.type === "browserbase" && sessionId) {
+        const { apiKey, baseUrl } = config.browser.launchOptions;
+        releaseSession = () => releaseBrowserbaseSession({ apiKey, baseUrl, sessionId });
+      }
       try {
         const stagehand = await Stagehand.create({ browser, ...config.stagehand });
-        return { browser, stagehand, tools: new StagehandFacadeTools(stagehand) };
+        let tools: StagehandFacadeTools;
+        tools = new StagehandFacadeTools(stagehand, {
+          close: () => closeResources(tools, true),
+        });
+        return { browser, stagehand, tools, ...(releaseSession ? { releaseSession } : {}) };
       } catch (error) {
-        await browser.close().catch(() => undefined);
-        throw error;
+        const cleanupErrors: unknown[] = [error];
+        let browserCloseFailed = false;
+        await browser.close().catch((cleanupError) => {
+          browserCloseFailed = true;
+          cleanupErrors.push(cleanupError);
+        });
+        if (browserCloseFailed && releaseSession) {
+          await releaseSession().catch((releaseError) => {
+            cleanupTargets.add(releaseSession);
+            cleanupErrors.push(releaseError);
+          });
+        }
+        if (cleanupErrors.length === 1) throw error;
+        throw new AggregateError(
+          cleanupErrors,
+          "Stagehand initialization failed and browser cleanup also failed.",
+          { cause: error },
+        );
       }
-    })();
+    });
     try {
       resources = await resourcesPromise;
       return resources.tools;
@@ -91,19 +121,63 @@ export default function stagehandExtension(pi: ExtensionAPI) {
     }
   }
 
-  async function closeResources(): Promise<void> {
+  async function closeResources(
+    expected?: StagehandFacadeTools,
+    reportErrors = false,
+  ): Promise<void> {
     // A shutdown can race a still-pending launch; wait for it so the browser
     // it produces is closed rather than leaked.
     const pending = resourcesPromise;
-    if (pending) await pending.catch(() => undefined);
-    const current = resources;
+    const launched = await pending?.catch(() => undefined);
+    const current = resources ?? launched;
+    if (expected && current?.tools !== expected) return;
     resources = undefined;
-    if (!current) return;
-    await current.stagehand.close().catch(() => undefined);
-    await current.browser.close().catch(() => undefined);
+    if (!current) {
+      if (!reportErrors) {
+        await cleanupPromise;
+        await retryCleanupTargets().catch(() => undefined);
+      }
+      return;
+    }
+    const closeResult = cleanupPromise.then(() => closeResource(current));
+    cleanupPromise = closeResult.then(
+      () => undefined,
+      () => undefined,
+    );
+    if (!reportErrors) {
+      await closeResult.catch(() => undefined);
+      await retryCleanupTargets().catch(() => undefined);
+      return;
+    }
+    await closeResult;
   }
 
-  pi.on("session_shutdown", closeResources);
+  async function closeResource(current: FacadeResources): Promise<void> {
+    const cleanupErrors: unknown[] = [];
+    let browserCloseFailed = false;
+    await current.stagehand.close().catch((error) => cleanupErrors.push(error));
+    await current.browser.close().catch((error) => {
+      browserCloseFailed = true;
+      cleanupErrors.push(error);
+    });
+    if (browserCloseFailed && current.releaseSession) {
+      cleanupTargets.add(current.releaseSession);
+    } else if (current.releaseSession) {
+      cleanupTargets.delete(current.releaseSession);
+    }
+    if (cleanupErrors.length === 0) return;
+    if (cleanupErrors.length === 1) throw cleanupErrors[0];
+    throw new AggregateError(cleanupErrors, "Failed to close the browser session cleanly.");
+  }
+
+  async function retryCleanupTargets(): Promise<void> {
+    for (const releaseSession of cleanupTargets) {
+      await releaseSession();
+      cleanupTargets.delete(releaseSession);
+    }
+  }
+
+  pi.on("session_shutdown", () => closeResources());
 
   pi.registerTool({
     name: "run",

--- a/packages/integrations/pi/extensions/stagehand.ts
+++ b/packages/integrations/pi/extensions/stagehand.ts
@@ -35,6 +35,14 @@ type FacadeResources = {
   releaseSession?: () => Promise<void>;
 };
 
+export class StagehandFacadeCleanupError extends Error {
+  override readonly name = "StagehandFacadeCleanupError";
+
+  constructor() {
+    super("Failed to close the browser session cleanly.");
+  }
+}
+
 // TypeBox mirrors of the wire schemas (pi validates params with TypeBox; the
 // zod validators from the contract re-enforce semantics like code XOR actions
 // at execute time). Kept permissive on action items — the contract validator
@@ -166,8 +174,9 @@ export default function stagehandExtension(pi: ExtensionAPI) {
       cleanupTargets.delete(current.releaseSession);
     }
     if (cleanupErrors.length === 0) return;
-    if (cleanupErrors.length === 1) throw cleanupErrors[0];
-    throw new AggregateError(cleanupErrors, "Failed to close the browser session cleanly.");
+    // Pi surfaces rejected tool executions directly. Keep SDK/CDP details out
+    // of the model-visible error, including Error.cause and AggregateError.errors.
+    throw new StagehandFacadeCleanupError();
   }
 
   async function retryCleanupTargets(): Promise<void> {

--- a/packages/integrations/pi/tests/lifecycle.test.ts
+++ b/packages/integrations/pi/tests/lifecycle.test.ts
@@ -87,11 +87,12 @@ describe("pi stagehand lifecycle", () => {
       .mockResolvedValueOnce({ ok: false })
       .mockResolvedValueOnce({ ok: true });
     vi.stubGlobal("fetch", release);
+    const { StagehandFacadeCleanupError } = await import("../extensions/stagehand.js");
     const { tools } = await registerExtension();
     const run = tools.find((tool) => tool.name === "run");
 
-    await expect(run?.execute("call-1", { code: "await browser.close();" })).rejects.toThrow(
-      "browser close failed",
+    await expect(run?.execute("call-1", { code: "await browser.close();" })).rejects.toBeInstanceOf(
+      StagehandFacadeCleanupError,
     );
     const snapshot = tools.find((tool) => tool.name === "snapshot");
     await expect(snapshot?.execute("call-2", {})).rejects.toThrow(

--- a/packages/integrations/pi/tests/lifecycle.test.ts
+++ b/packages/integrations/pi/tests/lifecycle.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  launch: vi.fn(),
+  create: vi.fn(),
+}));
+
+vi.mock("@browserbasehq/stagehand", () => ({
+  browserbase: { launch: mocks.launch },
+  localBrowser: { launch: vi.fn() },
+  Stagehand: { create: mocks.create },
+}));
+
+vi.mock("@browserbasehq/stagehand-integrations/facade", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@browserbasehq/stagehand-integrations/facade")>();
+  return {
+    ...original,
+    stagehandFacadeConfigFromEnv: () => ({
+      browser: { type: "browserbase", launchOptions: { apiKey: "test-key" } },
+      stagehand: {},
+    }),
+    releaseBrowserbaseSession: async (session: { sessionId: string }) => {
+      const response = await fetch(`https://api.browserbase.com/v1/sessions/${session.sessionId}`, {
+        method: "POST",
+      });
+      if (!response.ok) throw new Error("Failed to release the Browserbase session.");
+    },
+    StagehandFacadeTools: class {
+      constructor(
+        _stagehand: unknown,
+        private readonly lifecycle: { close(): Promise<void> },
+      ) {}
+
+      async run(): Promise<string> {
+        await this.lifecycle.close();
+        return "closed";
+      }
+
+      async runActions(): Promise<object> {
+        return {};
+      }
+
+      async snapshot(): Promise<string> {
+        return "snapshot";
+      }
+
+      async screenshot(): Promise<{ data: string; mimeType: "image/png" }> {
+        return { data: "", mimeType: "image/png" };
+      }
+    },
+  };
+});
+
+type RegisteredTool = {
+  name: string;
+  execute(toolCallId: string, params: unknown): Promise<unknown>;
+};
+
+describe("pi stagehand lifecycle", () => {
+  beforeEach(() => {
+    mocks.launch.mockReset();
+    mocks.create.mockReset();
+  });
+
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("surfaces cleanup failures and releases them before launching fresh resources", async () => {
+    const browser = {
+      closed: false,
+      sessionId: "session-one",
+      close: vi.fn(async () => {
+        throw new Error("browser close failed");
+      }),
+    };
+    const freshBrowser = {
+      closed: false,
+      sessionId: "session-two",
+      close: vi.fn(async () => undefined),
+    };
+    mocks.launch.mockResolvedValueOnce(browser).mockResolvedValueOnce(freshBrowser);
+    mocks.create
+      .mockResolvedValueOnce({ close: vi.fn(async () => undefined) })
+      .mockResolvedValueOnce({ close: vi.fn(async () => undefined) });
+    const release = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false })
+      .mockResolvedValueOnce({ ok: true });
+    vi.stubGlobal("fetch", release);
+    const { tools } = await registerExtension();
+    const run = tools.find((tool) => tool.name === "run");
+
+    await expect(run?.execute("call-1", { code: "await browser.close();" })).rejects.toThrow(
+      "browser close failed",
+    );
+    const snapshot = tools.find((tool) => tool.name === "snapshot");
+    await expect(snapshot?.execute("call-2", {})).rejects.toThrow(
+      "Failed to release the Browserbase session.",
+    );
+    expect(mocks.launch).toHaveBeenCalledOnce();
+
+    await expect(snapshot?.execute("call-3", {})).resolves.toBeDefined();
+    expect(release).toHaveBeenCalledTimes(2);
+    expect(mocks.launch).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps session shutdown cleanup best-effort", async () => {
+    const browser = {
+      closed: false,
+      sessionId: "session-shutdown",
+      close: vi.fn(async () => {
+        throw new Error("browser close failed");
+      }),
+    };
+    mocks.launch.mockResolvedValueOnce(browser);
+    mocks.create.mockResolvedValueOnce({
+      close: vi.fn(async () => {
+        throw new Error("stagehand close failed");
+      }),
+    });
+    const release = vi.fn(async () => ({ ok: true }));
+    vi.stubGlobal("fetch", release);
+    const { tools, shutdown } = await registerExtension();
+    const snapshot = tools.find((tool) => tool.name === "snapshot");
+    await snapshot?.execute("call-1", {});
+
+    await expect(shutdown?.()).resolves.toBeUndefined();
+    expect(browser.close).toHaveBeenCalledOnce();
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("releases the Browserbase session when Stagehand initialization cleanup fails", async () => {
+    const browser = {
+      closed: false,
+      sessionId: "session-init-failed",
+      close: vi.fn(async () => {
+        throw new Error("browser close failed");
+      }),
+    };
+    const freshBrowser = {
+      closed: false,
+      sessionId: "session-after-init-failure",
+      close: vi.fn(async () => undefined),
+    };
+    mocks.launch.mockResolvedValueOnce(browser).mockResolvedValueOnce(freshBrowser);
+    mocks.create
+      .mockRejectedValueOnce(new Error("Stagehand init failed"))
+      .mockResolvedValueOnce({ close: vi.fn(async () => undefined) });
+    const release = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false })
+      .mockResolvedValueOnce({ ok: true });
+    vi.stubGlobal("fetch", release);
+    const { tools } = await registerExtension();
+    const snapshot = tools.find((tool) => tool.name === "snapshot");
+
+    await expect(snapshot?.execute("call-1", {})).rejects.toThrow(
+      "Stagehand initialization failed and browser cleanup also failed.",
+    );
+    expect(browser.close).toHaveBeenCalledOnce();
+    expect(release).toHaveBeenCalledOnce();
+    expect(mocks.launch).toHaveBeenCalledOnce();
+
+    await expect(snapshot?.execute("call-2", {})).resolves.toBeDefined();
+    expect(release).toHaveBeenCalledTimes(2);
+    expect(mocks.launch).toHaveBeenCalledTimes(2);
+  });
+});
+
+async function registerExtension(): Promise<{
+  tools: RegisteredTool[];
+  shutdown: (() => Promise<void>) | undefined;
+}> {
+  const { default: stagehandExtension } = await import("../extensions/stagehand.js");
+  const tools: RegisteredTool[] = [];
+  let shutdown: (() => Promise<void>) | undefined;
+  stagehandExtension({
+    registerTool: (tool: RegisteredTool) => tools.push(tool),
+    on: (event: string, handler: () => Promise<void>) => {
+      if (event === "session_shutdown") shutdown = handler;
+    },
+  } as never);
+  return { tools, shutdown };
+}


### PR DESCRIPTION
# why

This is PR 3 of the facade-close stack. It depends on #2793, which in turn depends on #2788.

Pi is a separate native facade host with its own launch and shutdown lifecycle. Once the shared facade propagates `browser.close()`, Pi must provide a real host callback; otherwise the compatibility boundary correctly reports that cleanup is unsupported. Keeping this adapter in a separate PR makes Pi's shutdown and retry policy reviewable without mixing it into the Eve implementation.

# what changed

- Pi supplies the shared facade lifecycle callback and detaches the expected tools before cleanup.
- Cleanup is serialized so shutdown, explicit close, and replacement cannot race ownership.
- Model-requested close surfaces Stagehand/browser failures; `session_shutdown` remains best-effort.
- Browserbase release is captured immediately after launch, before `Stagehand.create()`, so an initialization failure cannot lose the remote session.
- A rejected memoized browser close retains a fresh SDK release operation for retry before the next launch and during final shutdown.
- Explicit cleanup failures are surfaced as a dedicated `StagehandFacadeCleanupError` with a fixed sanitized message and no raw SDK/CDP causes or aggregate members.
- Focused tests cover explicit-close failure/retry, best-effort shutdown, and failed initialization followed by retained-release retry.

# behavior before and after

| Pi lifecycle | Before | After |
| --- | --- | --- |
| `await browser.close()` | No host lifecycle callback. | Awaits Pi-owned cleanup. |
| Explicit cleanup failure | Can be swallowed while the tool succeeds. | Surfaced to the caller. |
| Shutdown cleanup | Best-effort but can lose failed ownership. | Best-effort with retained release targets. |
| Init + browser-close failure | Remote release path can be lost. | Release is attempted immediately and retained on failure. |
| Next launch | Can race or bypass failed cleanup. | Waits for serialized cleanup/retry first. |

# test plan

- Pi tests: 6/6
- Pi typecheck
- Focused oxfmt/oxlint
- Core tests on PR #2788: 37/37
- Eve tests on PR #2793: 9/9

This PR does not claim a separate live Pi-agent E2E; the shared remote lifecycle behavior is covered by the Eve live A/B in #2793, while this PR focuses on Pi-specific ownership, error, retry, and shutdown paths.

No changeset is included because the Pi integration is a private example.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pi now closes facade-launched browser resources and serializes cleanup. Previously model-requested `browser.close()` had no host callback and failures could be swallowed; now explicit close surfaces a sanitized error while shutdown remains best-effort.

- Routes `browser.close()` through a lifecycle callback in `StagehandFacadeTools`; `session_shutdown` uses the same path.
- Serializes teardown via a shared cleanup promise and retries queued Browserbase releases before any re-launch; avoids closing replaced resources.
- For Browserbase, captures a release operation at launch; on Stagehand init failure, attempts browser close and session release, queues failed releases for retry, and throws a combined init/cleanup error.
- Explicit-close failures throw `StagehandFacadeCleanupError` (sanitized); shutdown suppresses errors but retains release targets for retry.
- Adds focused tests in `packages/integrations/pi/tests/lifecycle.test.ts`.

<sup>Written for commit a34f2817d407d1bde5f87c48ca450f824f39a4a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

