### PR TITLE
[AP-2892] Unlist Browser Use v4 migration guide

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -76,7 +76,7 @@
           },
           {
             "group": "Migration guide",
-            "pages": ["v4/migrations/v3", "v4/migrations/playwright", "v4/migrations/browser-use"]
+            "pages": ["v4/migrations/v3", "v4/migrations/playwright"]
           },
           {
             "group": "SDK reference",

--- a/packages/docs/v4/migrations/browser-use.mdx
+++ b/packages/docs/v4/migrations/browser-use.mdx
@@ -2,6 +2,7 @@
 title: Migrate Browser Use to v4
 sidebarTitle: Migrate Browser Use to v4
 icon: 'robot'
+noindex: true
 ---
 
 Browser Use hands a task to an autonomous agent: you write `Agent(task="...", llm=...)`, call `run()`, and the agent picks each action. Stagehand v4 has no equivalent object.


### PR DESCRIPTION
## Summary

Unlists the Browser Use → v4 migration guide (follow-up to #2756):

- Removes `v4/migrations/browser-use` from the Migration guide nav group in `packages/docs/docs.json`
- Adds `noindex: true` to the page frontmatter so search engines skip it

The page remains reachable at https://docs.stagehand.dev/v4/migrations/browser-use by direct link — it's just no longer in the sidebar or indexed.

## Test plan

- `jq empty packages/docs/docs.json` passes (valid JSON)

Requested by: shriya@browserbase.com
Linear: https://linear.app/browserbase/issue/AP-2892/unlist-browser-use-v4-migration-guide-from-docs-nav