### PR TITLE
fix(cli): clone the advertised template source

### DIFF
--- a/.changeset/fair-templates-clone.md
+++ b/.changeset/fair-templates-clone.md
@@ -1,5 +1,0 @@
----
-"browse": patch
----
-
-Resolve language-specific template source names and print setup commands that respect each project’s package manager and Python manifest.

--- a/.changeset/fair-templates-clone.md
+++ b/.changeset/fair-templates-clone.md
@@ -1,0 +1,5 @@
+---
+"browse": patch
+---
+
+Resolve language-specific template source names and print setup commands that respect each project’s package manager and Python manifest.

--- a/packages/cli/src/lib/templates/scaffold.ts
+++ b/packages/cli/src/lib/templates/scaffold.ts
@@ -68,6 +68,10 @@ export async function cloneTemplate(
   const parentDir = dirname(dest);
   const projectName = basename(dest);
   const scaffolder = getScaffolder(language);
+  const scaffolderTemplate = resolveScaffolderTemplateName(
+    options.template,
+    language,
+  );
   await mkdir(parentDir, { recursive: true });
   const existingEntries = await getDirectoryEntryNames(parentDir);
 
@@ -80,12 +84,7 @@ export async function cloneTemplate(
   try {
     runCommand(
       scaffolder.command,
-      [
-        ...scaffolder.argsPrefix,
-        projectName,
-        "--template",
-        options.template.slug,
-      ],
+      [...scaffolder.argsPrefix, projectName, "--template", scaffolderTemplate],
       parentDir,
     );
 
@@ -145,6 +144,34 @@ function templateSupportsLanguage(
     commands.includes("uvx create-browser-app") ||
     commands.includes("uv tool run create-browser-app")
   );
+}
+
+export function resolveScaffolderTemplateName(
+  template: Template,
+  language: TemplateLanguage,
+): string {
+  const commandPrefix =
+    language === "typescript"
+      ? /^\s*(?:npx|npm\s+exec\b)/i
+      : /^\s*(?:uvx\b|uv\s+tool\s+run\b)/i;
+
+  for (const command of template.commands) {
+    if (
+      !commandPrefix.test(command) ||
+      !command.includes("create-browser-app")
+    ) {
+      continue;
+    }
+
+    const match = command.match(
+      /(?:^|\s)--template(?:=|\s+)([a-z0-9][a-z0-9-]*)/i,
+    );
+    if (match?.[1]) {
+      return match[1].toLowerCase();
+    }
+  }
+
+  return template.slug;
 }
 
 function commandExists(
@@ -258,7 +285,7 @@ async function findCreatedProjectDir(
   return null;
 }
 
-async function buildNextSteps(
+export async function buildNextSteps(
   dest: string,
   displayPath: string,
   language: TemplateLanguage,
@@ -266,22 +293,23 @@ async function buildNextSteps(
   const nextSteps = [`cd ${displayPath}`];
 
   if (language === "typescript") {
-    if (existsSync(join(dest, "package.json"))) {
-      nextSteps.push("npm install");
+    const packageJson = await readPackageJson(dest);
+    const packageManager = resolvePackageManager(packageJson?.packageManager);
+    if (packageJson) {
+      nextSteps.push(`${packageManager} install`);
     }
 
     if (existsSync(join(dest, ".env.example"))) {
       nextSteps.push("cp .env.example .env");
     }
 
-    const packageJson = await readPackageJson(dest);
     if (packageJson?.scripts?.dev) {
-      nextSteps.push("npm run dev");
+      nextSteps.push(runPackageScript(packageManager, "dev"));
       return nextSteps;
     }
 
     if (packageJson?.scripts?.start) {
-      nextSteps.push("npm start");
+      nextSteps.push(runPackageScript(packageManager, "start"));
       return nextSteps;
     }
 
@@ -292,10 +320,12 @@ async function buildNextSteps(
     return nextSteps;
   }
 
-  if (existsSync(join(dest, "pyproject.toml"))) {
+  const hasPyproject = existsSync(join(dest, "pyproject.toml"));
+  const hasRequirements = existsSync(join(dest, "requirements.txt"));
+  if (hasPyproject) {
     nextSteps.push("uv sync");
-  } else if (existsSync(join(dest, "requirements.txt"))) {
-    nextSteps.push("pip install -r requirements.txt");
+  } else if (hasRequirements) {
+    nextSteps.push("uv venv && uv pip install -r requirements.txt");
   }
 
   if (existsSync(join(dest, ".env.example"))) {
@@ -303,15 +333,40 @@ async function buildNextSteps(
   }
 
   if (existsSync(join(dest, "main.py"))) {
-    nextSteps.push("python main.py");
+    nextSteps.push(
+      hasPyproject || hasRequirements
+        ? "uv run python main.py"
+        : ((await readUvRunCommand(dest)) ?? "uv run python main.py"),
+    );
   }
 
   return nextSteps;
 }
 
-async function readPackageJson(
-  dest: string,
-): Promise<{ scripts?: Record<string, string> } | null> {
+async function readUvRunCommand(dest: string): Promise<string | null> {
+  const readmePath = join(dest, "README.md");
+  if (!existsSync(readmePath)) {
+    return null;
+  }
+
+  try {
+    const readme = await readFile(readmePath, "utf8");
+    const match = readme.match(
+      /^\s*(?:\d+\.\s*)?(uvx|uv\s+run)((?:\s+--with\s+[^\s]+)+)\s+python\s+main\.py\s*$/im,
+    );
+    if (!match?.[2]) {
+      return null;
+    }
+    return `uv run${match[2]} python main.py`;
+  } catch {
+    return null;
+  }
+}
+
+async function readPackageJson(dest: string): Promise<{
+  packageManager?: string;
+  scripts?: Record<string, string>;
+} | null> {
   const packageJsonPath = join(dest, "package.json");
   if (!existsSync(packageJsonPath)) {
     return null;
@@ -319,8 +374,31 @@ async function readPackageJson(
 
   try {
     const contents = await readFile(packageJsonPath, "utf8");
-    return JSON.parse(contents) as { scripts?: Record<string, string> };
+    return JSON.parse(contents) as {
+      packageManager?: string;
+      scripts?: Record<string, string>;
+    };
   } catch {
     return null;
   }
+}
+
+type PackageManager = "bun" | "npm" | "pnpm" | "yarn";
+
+function resolvePackageManager(packageManager?: string): PackageManager {
+  const name = packageManager?.split("@")[0];
+  if (name === "bun" || name === "pnpm" || name === "yarn") {
+    return name;
+  }
+  return "npm";
+}
+
+function runPackageScript(
+  packageManager: PackageManager,
+  script: string,
+): string {
+  if (packageManager === "npm" || packageManager === "bun") {
+    return `${packageManager} run ${script}`;
+  }
+  return `${packageManager} ${script}`;
 }

--- a/packages/cli/tests/cli-templates.test.ts
+++ b/packages/cli/tests/cli-templates.test.ts
@@ -11,6 +11,10 @@ import {
 } from "./helpers/fake-browserbase-server.js";
 import { runCli } from "./helpers/run-cli.js";
 import { itPosix } from "./helpers/platform.js";
+import {
+  buildNextSteps,
+  resolveScaffolderTemplateName,
+} from "../src/lib/templates/scaffold.js";
 
 interface TemplateFixture {
   category: string[];
@@ -78,6 +82,37 @@ afterEach(async () => {
 });
 
 describe("templates commands", () => {
+  it("resolves language-specific scaffold names from catalog commands", () => {
+    const template = {
+      ...templates[0],
+      slug: "playwright",
+      commands: [
+        "npx create-browser-app --template quickstart-playwright",
+        "uvx create-browser-app --template quickstart-playwright",
+      ],
+    };
+
+    expect(resolveScaffolderTemplateName(template, "typescript")).toBe(
+      "quickstart-playwright",
+    );
+    expect(resolveScaffolderTemplateName(template, "python")).toBe(
+      "quickstart-playwright",
+    );
+  });
+
+  it("uses README uv dependencies when a Python template has no manifest", async () => {
+    const dest = await createTempDir("browse-templates-readme-uv-");
+    await writeFile(join(dest, "main.py"), "print('hello')\n");
+    await writeFile(
+      join(dest, "README.md"),
+      "4. uvx --with browserbase --with selenium --with python-dotenv python main.py\n",
+    );
+
+    await expect(buildNextSteps(dest, dest, "python")).resolves.toContain(
+      "uv run --with browserbase --with selenium --with python-dotenv python main.py",
+    );
+  });
+
   it("lists templates from the templates API", async () => {
     await withTemplatesApi(async ({ baseUrl, requests }) => {
       const result = await runCli(["templates", "list", "--format", "table"], {
@@ -257,7 +292,7 @@ describe("templates commands", () => {
           'printf \'npx %s\\n\' "$*" >> "$BB_STUB_LOG"',
           'project="$2"',
           'mkdir -p "$project"',
-          'printf \'{"name":"stub-app","scripts":{"dev":"tsx index.ts"}}\\n\' > "$project/package.json"',
+          'printf \'{"name":"stub-app","packageManager":"pnpm@10.24.0","scripts":{"dev":"tsx index.ts"}}\\n\' > "$project/package.json"',
           "printf 'BROWSERBASE_API_KEY=\\n' > \"$project/.env.example\"",
         ].join("\n"),
       );
@@ -288,9 +323,9 @@ describe("templates commands", () => {
         );
         expect(result.stdout).toContain(`Template scaffolded to ${dest}`);
         expect(result.stdout).toContain(`cd ${dest}`);
-        expect(result.stdout).toContain("npm install");
+        expect(result.stdout).toContain("pnpm install");
         expect(result.stdout).toContain("cp .env.example .env");
-        expect(result.stdout).toContain("npm run dev");
+        expect(result.stdout).toContain("pnpm dev");
         expect(await readFile(join(dest, "package.json"), "utf8")).toContain(
           "stub-app",
         );
@@ -349,7 +384,7 @@ describe("templates commands", () => {
         );
         expect(result.stdout).toContain("uv sync");
         expect(result.stdout).toContain("cp .env.example .env");
-        expect(result.stdout).toContain("python main.py");
+        expect(result.stdout).toContain("uv run python main.py");
         expect(await readFile(join(dest, "main.py"), "utf8")).toContain(
           "hello",
         );


### PR DESCRIPTION
## Summary

- resolve the language-specific `--template` name from catalog command metadata
- respect `packageManager` when printing TypeScript install/run steps
- use `uv` consistently for Python setup and execution
- preserve README-declared `uv --with` dependencies for manifestless templates

## Why

The catalog intentionally maps page slugs such as `playwright` to nested source names such as `quickstart-playwright`. Browse previously discarded that mapping and passed the page slug to the downstream scaffolder. It also printed npm commands for pnpm-pinned projects and bare Python commands for uv projects.

## Fresh verification

- template CLI contract tests: **14/14 PASS**
- TypeScript check, ESLint, and Prettier: PASS
- Browse CLI build and manifest generation: PASS
- local candidate-stack clone matrix: **4/4 PASS**
  - pnpm TypeScript Stagehand app
  - nested TypeScript Playwright
  - nested Python Selenium
  - pyproject-based Python Context
- every generated entrypoint byte-matched its merged template source
- every returned `nextSteps` sequence matched the generated manifest/README
- Browse-generated `browser-agent-demo`: clean pnpm install and live Search → Fetch → Stagehand code-mode run completed successfully

This targets `v3`, where the published `browse` package is maintained. The repository changesets config ignores `browse`, so this PR intentionally has no changeset.