### PR TITLE
fix(ci): run CI only for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,6 @@ name: CI
 
 on:
   pull_request:
-  push:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       pull_request_number:


### PR DESCRIPTION
## Summary

- stop running the full CI workflow again after every merge to main
- keep pull request CI unchanged
- preserve workflow_dispatch for trusted external-contributor handoff runs

This removes the main push trigger introduced in #2671. Shared protocol changes can activate every SDK filter, so merges such as #2790 repeated the complete test matrix after it had already passed on the PR.

## Test plan

- `actionlint -ignore SC2046 .github/workflows/ci.yml`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop running the CI workflow on pushes to `main` to avoid duplicate runs after merges; keep CI behavior for pull requests and manual dispatches unchanged.

- Removes the `push` trigger on `main`; retains `pull_request` and `workflow_dispatch` (with `pull_request_number` input) for trusted handoffs.
- Pushes to `main` no longer run CI. If any branch protection requires push-based checks, update it to rely on PR-based statuses.

<sup>Written for commit 3d4a3787adae5a06adc1b89892253cdcd9494333. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

