### PR TITLE
feat(extension): add resident browser proxy CDP resolver

### DIFF
--- a/packages/extension/service-worker-lifecycle/resident-browser-proxy.ts
+++ b/packages/extension/service-worker-lifecycle/resident-browser-proxy.ts
@@ -1,0 +1,90 @@
+import { z } from "zod/v4";
+
+const BrowserVersionSchema = z.object({
+  webSocketDebuggerUrl: z.string().min(1),
+});
+
+const DEFAULT_RESOLVE_TIMEOUT_MS = 5_000;
+
+export type ResidentBrowserProxyResolverOptions = {
+  fetch?: typeof globalThis.fetch;
+  timeoutMs?: number;
+};
+
+export async function resolveResidentBrowserWebSocketUrl(
+  browserProxyUrl: string,
+  options: ResidentBrowserProxyResolverOptions = {},
+): Promise<string> {
+  const proxyUrl = parseBrowserProxyUrl(browserProxyUrl);
+  const abortController = new AbortController();
+  const timeoutMs = options.timeoutMs ?? DEFAULT_RESOLVE_TIMEOUT_MS;
+  const timeout = setTimeout(
+    () =>
+      abortController.abort(
+        new Error(`Resident browser proxy version request timed out after ${timeoutMs}ms`),
+      ),
+    timeoutMs,
+  );
+
+  try {
+    const versionUrl = new URL("/json/version", proxyUrl);
+    const response = await (options.fetch ?? globalThis.fetch)(versionUrl, {
+      redirect: "error",
+      signal: abortController.signal,
+    });
+    if (!response.ok) {
+      throw new Error(`Browser proxy version request failed with HTTP ${response.status}`);
+    }
+
+    const { webSocketDebuggerUrl } = BrowserVersionSchema.parse(await response.json());
+    return rewriteDebuggerUrl(webSocketDebuggerUrl, proxyUrl);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function parseBrowserProxyUrl(rawUrl: string): URL {
+  const url = new URL(rawUrl);
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("Resident browser proxy URL must use http: or https:");
+  }
+  if (!isLoopbackHostname(url.hostname)) {
+    throw new Error("Resident browser proxy URL must point to loopback");
+  }
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error("Resident browser proxy URL must not include credentials, query, or fragment");
+  }
+  if (url.pathname !== "/") {
+    throw new Error("Resident browser proxy URL must contain only an origin");
+  }
+  return url;
+}
+
+function rewriteDebuggerUrl(rawUrl: string, proxyUrl: URL): string {
+  const debuggerUrl = new URL(rawUrl);
+  if (
+    debuggerUrl.protocol !== "ws:" &&
+    !(debuggerUrl.protocol === "wss:" && proxyUrl.protocol === "https:")
+  ) {
+    throw new Error("Chromium webSocketDebuggerUrl must use ws: (or wss: for an https proxy)");
+  }
+  if (!isLoopbackHostname(debuggerUrl.hostname)) {
+    throw new Error("Chromium webSocketDebuggerUrl must point to loopback");
+  }
+  if (debuggerUrl.username || debuggerUrl.password || debuggerUrl.hash) {
+    throw new Error("Chromium webSocketDebuggerUrl must not include credentials or a fragment");
+  }
+  if (
+    !debuggerUrl.pathname.startsWith("/devtools/browser/") ||
+    debuggerUrl.pathname.endsWith("/")
+  ) {
+    throw new Error("Chromium webSocketDebuggerUrl must identify a browser target");
+  }
+
+  const websocketProtocol = proxyUrl.protocol === "https:" ? "wss:" : "ws:";
+  return `${websocketProtocol}//${proxyUrl.host}${debuggerUrl.pathname}${debuggerUrl.search}`;
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  return hostname === "127.0.0.1" || hostname === "localhost" || hostname === "[::1]";
+}

--- a/packages/extension/tests/resident-browser-proxy.test.ts
+++ b/packages/extension/tests/resident-browser-proxy.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveResidentBrowserWebSocketUrl } from "../service-worker-lifecycle/resident-browser-proxy.js";
+
+function response(body: unknown, init: { ok?: boolean; status?: number } = {}): Response {
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    json: async () => body,
+  } as Response;
+}
+
+describe("resident browser proxy resolver", () => {
+  it("resolves Chromium and preserves the exact browser target path and query", async () => {
+    const fetch = vi.fn(async () =>
+      response({
+        webSocketDebuggerUrl:
+          "ws://127.0.0.1:9222/devtools/browser/a%2Fb?token=one%2Ftwo&token=three",
+      }),
+    );
+
+    await expect(
+      resolveResidentBrowserWebSocketUrl("http://127.0.0.1:9333", { fetch }),
+    ).resolves.toBe("ws://127.0.0.1:9333/devtools/browser/a%2Fb?token=one%2Ftwo&token=three");
+    expect(fetch).toHaveBeenCalledWith(
+      new URL("http://127.0.0.1:9333/json/version"),
+      expect.objectContaining({ redirect: "error", signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it("uses secure WebSockets for an HTTPS proxy and supports default ports", async () => {
+    await expect(
+      resolveResidentBrowserWebSocketUrl("https://127.0.0.1", {
+        fetch: async () =>
+          response({
+            webSocketDebuggerUrl: "ws://localhost/devtools/browser/browser-id?token=one",
+          }),
+      }),
+    ).resolves.toBe("wss://127.0.0.1/devtools/browser/browser-id?token=one");
+  });
+
+  it("accepts a secure upstream WebSocket for an HTTPS proxy", async () => {
+    await expect(
+      resolveResidentBrowserWebSocketUrl("https://127.0.0.1", {
+        fetch: async () =>
+          response({
+            webSocketDebuggerUrl: "wss://127.0.0.1:9224/devtools/browser/browser-id?token=one",
+          }),
+      }),
+    ).resolves.toBe("wss://127.0.0.1/devtools/browser/browser-id?token=one");
+  });
+
+  it("rejects a secure upstream WebSocket for an HTTP proxy", async () => {
+    await expect(
+      resolveResidentBrowserWebSocketUrl("http://127.0.0.1:9224", {
+        fetch: async () =>
+          response({
+            webSocketDebuggerUrl: "wss://127.0.0.1:9222/devtools/browser/id",
+          }),
+      }),
+    ).rejects.toThrow("must use ws:");
+  });
+
+  it("preserves an identity rewrite from the proxy", async () => {
+    await expect(
+      resolveResidentBrowserWebSocketUrl("http://127.0.0.1:9224", {
+        fetch: async () =>
+          response({
+            webSocketDebuggerUrl: "ws://127.0.0.1:9224/devtools/browser/browser-id",
+          }),
+      }),
+    ).resolves.toBe("ws://127.0.0.1:9224/devtools/browser/browser-id");
+  });
+
+  it("accepts an IPv6 loopback upstream", async () => {
+    await expect(
+      resolveResidentBrowserWebSocketUrl("http://127.0.0.1:9224", {
+        fetch: async () =>
+          response({
+            webSocketDebuggerUrl: "ws://[::1]:9222/devtools/browser/browser-id",
+          }),
+      }),
+    ).resolves.toBe("ws://127.0.0.1:9224/devtools/browser/browser-id");
+  });
+
+  it("rejects malformed JSON", async () => {
+    const fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new SyntaxError("Unexpected token");
+      },
+    })) as unknown as typeof globalThis.fetch;
+
+    await expect(
+      resolveResidentBrowserWebSocketUrl("http://127.0.0.1:9333", { fetch }),
+    ).rejects.toThrow("Unexpected token");
+  });
+
+  it.each([
+    [{}, "webSocketDebuggerUrl"],
+    [{ webSocketDebuggerUrl: "http://127.0.0.1:9222/devtools/browser/id" }, "must use ws:"],
+    [{ webSocketDebuggerUrl: "ws://browser.example:9222/devtools/browser/id" }, "loopback"],
+    [{ webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/id" }, "browser target"],
+    [{ webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/browser/id/" }, "browser target"],
+    [{ webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/browser/id#frag" }, "fragment"],
+  ])("rejects invalid version metadata %#", async (body, message) => {
+    await expect(
+      resolveResidentBrowserWebSocketUrl("http://127.0.0.1:9333", {
+        fetch: async () => response(body),
+      }),
+    ).rejects.toThrow(message);
+  });
+
+  it("rejects HTTP failures", async () => {
+    await expect(
+      resolveResidentBrowserWebSocketUrl("http://127.0.0.1:9333", {
+        fetch: async () => response({}, { ok: false, status: 503 }),
+      }),
+    ).rejects.toThrow("HTTP 503");
+  });
+
+  it("aborts a request after the bounded timeout", async () => {
+    const fetch = vi.fn(
+      async (_input: URL | RequestInfo, init?: RequestInit): Promise<Response> =>
+        await new Promise((_, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(init?.signal?.reason), {
+            once: true,
+          });
+        }),
+    );
+
+    await expect(
+      resolveResidentBrowserWebSocketUrl("http://127.0.0.1:9333", { fetch, timeoutMs: 1 }),
+    ).rejects.toThrow("timed out after 1ms");
+  });
+
+  it.each([
+    "ws://127.0.0.1:9333",
+    "http://browser.example:9333",
+    "http://127.0.0.1:9333/path",
+    "http://user:secret@127.0.0.1:9333",
+  ])("rejects invalid proxy configuration %s", async (browserProxyUrl) => {
+    await expect(resolveResidentBrowserWebSocketUrl(browserProxyUrl)).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
Stack A/5 (resident Stagehand on `main`): **`feat/resident-main-a-transport`** (this PR) → `-b-target-safety` → `-c-gateway-runtime` → `-d-artifacts` → `-e-browserbase-opt-in`. Supersedes #2463 (archived v4-spike base).

Adds the resident browser proxy CDP resolver (`packages/extension/service-worker-lifecycle/resident-browser-proxy.ts`) used by the image-resident extension to find Chromium through pid2's loopback filtered proxy (`127.0.0.1:9224`, Go #3193–#3196): fetch `/json/version` from a loopback-only http(s) origin, validate that Chromium returned a loopback `ws(s)://…/devtools/browser/<id>` URL, and rewrite only scheme+authority to the proxy while preserving the exact target path/query.

Inert in this PR: nothing imports the module yet (wired in stack C). No ordinary-session behavior changes.

Changes vs the v4-spike version, from the 2026-08-20 review: accepts `wss:` when the proxy is `https:` (matches the Go side), emits path/query from the validated URL (not a raw slice), abort reason carries the proxy URL and budget, timeout raised 1 s → 5 s to match the Go upstream dial timeout, tests for identity rewrite / `[::1]` / trailing slash / fragment.

## Validation
`pnpm check`, extension unit tests (incl. extension-source-compatibility), protocol tests — green. Verified end to end on a devbox k3d stack with the real image bytes (see stack E).
