### PR TITLE
feat(evals): add mastra bench harness (integrations/mastra-sdk)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,7 @@ jobs:
             packages/integrations/core/dist/**
             packages/integrations/claude-agent-sdk/dist/**
             packages/integrations/codex-sdk/dist/**
+            packages/integrations/mastra-sdk/dist/**
             packages/evals/dist/**
           retention-days: 1
 

--- a/packages/evals/framework/benchHarness.ts
+++ b/packages/evals/framework/benchHarness.ts
@@ -10,6 +10,8 @@ import {
 } from "./claudeCodeToolAdapter.js";
 import { runCodexAgent } from "./codexRunner.js";
 import { CODEX_TOOL_SURFACES, prepareCodexToolAdapter } from "./codexToolAdapter.js";
+import { runMastraAgent } from "./mastraRunner.js";
+import { MASTRA_TOOL_SURFACES, prepareMastraToolAdapter } from "./mastraToolAdapter.js";
 import {
   buildExternalHarnessTaskPlan,
   type ExternalHarnessTaskPlan,
@@ -286,10 +288,19 @@ export const codexHarness = defineExternalHarness({
   runAgent: runCodexAgent,
 });
 
+export const mastraHarness = defineExternalHarness({
+  harness: "mastra",
+  supportedToolSurfaces: MASTRA_TOOL_SURFACES,
+  defaultModels: ["openai/gpt-5.4-mini" as AvailableModel],
+  prepareToolAdapter: prepareMastraToolAdapter,
+  runAgent: runMastraAgent,
+});
+
 const harnessRegistry = new Map<Harness, BenchHarness>([
   ["stagehand", stagehandHarness],
   ["claude_code", claudeCodeHarness],
   ["codex", codexHarness],
+  ["mastra", mastraHarness],
 ]);
 
 export function registerBenchHarness(harness: BenchHarness): () => void {

--- a/packages/evals/framework/harnesses/mastraAdapter.ts
+++ b/packages/evals/framework/harnesses/mastraAdapter.ts
@@ -34,16 +34,23 @@ export class MastraTrajectoryAdapter implements TrajectoryAdapter<MastraRunResul
     const callsById = new Map<string, PendingCall>();
     const trailingTextParts: string[] = [];
     let pendingReasoning = "";
+    let lastDeltaType: "reasoning" | "text" | undefined;
 
     for (const event of result.events) {
       const type = String(event.type ?? "");
       const payload = isRecord(event.payload) ? event.payload : {};
       if (type === "reasoning-delta" && typeof payload.text === "string") {
-        pendingReasoning = appendText(pendingReasoning, payload.text);
+        pendingReasoning = appendDelta(
+          pendingReasoning,
+          payload.text,
+          lastDeltaType !== "reasoning",
+        );
+        lastDeltaType = "reasoning";
         continue;
       }
       if (type === "text-delta" && typeof payload.text === "string") {
-        pendingReasoning = appendText(pendingReasoning, payload.text);
+        pendingReasoning = appendDelta(pendingReasoning, payload.text, lastDeltaType !== "text");
+        lastDeltaType = "text";
         trailingTextParts.push(payload.text);
         continue;
       }
@@ -65,6 +72,7 @@ export class MastraTrajectoryAdapter implements TrajectoryAdapter<MastraRunResul
         calls.push(pending);
         callsById.set(id, pending);
         pendingReasoning = "";
+        lastDeltaType = undefined;
         trailingTextParts.length = 0;
         continue;
       }
@@ -173,9 +181,14 @@ function normalizeResult(value: unknown): {
   return { result: images.length > 0 ? text : value.content, text, images };
 }
 
-function appendText(buffer: string, addition: string): string {
+/**
+ * Streamed deltas are token fragments of one contiguous block — concatenate
+ * them directly; a newline is inserted only when a new block type starts
+ * (reasoning → text), never between fragments.
+ */
+function appendDelta(buffer: string, addition: string, startsNewBlock: boolean): string {
   if (!buffer) return addition;
-  return `${buffer}\n${addition}`;
+  return startsNewBlock ? `${buffer}\n${addition}` : buffer + addition;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/evals/framework/harnesses/mastraAdapter.ts
+++ b/packages/evals/framework/harnesses/mastraAdapter.ts
@@ -4,6 +4,7 @@
  * call belongs to that step, while text after the last call is the final answer.
  */
 import type { ProbeEvidence, TaskSpec, Trajectory } from "stagehand-v3";
+import { sanitizeErrorMessage } from "@browserbasehq/stagehand-integrations/harness";
 import type { StepObservation } from "../observationRecorder.js";
 import {
   buildTrajectory,
@@ -78,14 +79,18 @@ export class MastraTrajectoryAdapter implements TrajectoryAdapter<MastraRunResul
           payload.isError !== true &&
           rawRecord?.isError !== true &&
           !(rawRecord && rawRecord.ok === false);
-        pending.call.result = normalized.result;
+        pending.call.result =
+          typeof normalized.result === "string"
+            ? sanitizeErrorMessage(normalized.result)
+            : normalized.result;
         pending.call.ok = ok;
         pending.images = normalized.images;
         if (normalized.images.length > 0) pending.call.images = normalized.images;
         if (!ok) {
-          pending.call.error =
+          pending.call.error = sanitizeErrorMessage(
             normalized.text ||
-            (typeof rawRecord?.error === "string" ? rawRecord.error : stringifyError(rawResult));
+              (typeof rawRecord?.error === "string" ? rawRecord.error : stringifyError(rawResult)),
+          );
         }
         continue;
       }
@@ -93,7 +98,7 @@ export class MastraTrajectoryAdapter implements TrajectoryAdapter<MastraRunResul
         const id = typeof payload.toolCallId === "string" ? payload.toolCallId : "";
         const pending = callsById.get(id);
         if (!pending) continue;
-        const message = stringifyError(payload.error) || "tool error";
+        const message = sanitizeErrorMessage(stringifyError(payload.error) || "tool error");
         pending.call.result = message;
         pending.call.ok = false;
         pending.call.error = message;

--- a/packages/evals/framework/harnesses/mastraAdapter.ts
+++ b/packages/evals/framework/harnesses/mastraAdapter.ts
@@ -55,7 +55,7 @@ export class MastraTrajectoryAdapter implements TrajectoryAdapter<MastraRunResul
           id,
           call: {
             name: typeof payload.toolName === "string" ? payload.toolName : "tool",
-            args,
+            args: deepSanitize(args) as Record<string, unknown>,
             result: "",
             ok: true,
             reasoning: pendingReasoning.trim() || undefined,
@@ -79,10 +79,7 @@ export class MastraTrajectoryAdapter implements TrajectoryAdapter<MastraRunResul
           payload.isError !== true &&
           rawRecord?.isError !== true &&
           !(rawRecord && rawRecord.ok === false);
-        pending.call.result =
-          typeof normalized.result === "string"
-            ? sanitizeErrorMessage(normalized.result)
-            : normalized.result;
+        pending.call.result = deepSanitize(normalized.result);
         pending.call.ok = ok;
         pending.images = normalized.images;
         if (normalized.images.length > 0) pending.call.images = normalized.images;
@@ -183,6 +180,17 @@ function appendText(buffer: string, addition: string): string {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+function deepSanitize(value: unknown): unknown {
+  if (typeof value === "string") return sanitizeErrorMessage(value);
+  if (Array.isArray(value)) return value.map(deepSanitize);
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nestedValue]) => [key, deepSanitize(nestedValue)]),
+    );
+  }
+  return value;
 }
 
 function stringifyError(value: unknown): string {

--- a/packages/evals/framework/harnesses/mastraAdapter.ts
+++ b/packages/evals/framework/harnesses/mastraAdapter.ts
@@ -65,7 +65,7 @@ export class MastraTrajectoryAdapter implements TrajectoryAdapter<MastraRunResul
             args: deepSanitize(args) as Record<string, unknown>,
             result: "",
             ok: true,
-            reasoning: pendingReasoning.trim() || undefined,
+            reasoning: sanitizeErrorMessage(pendingReasoning.trim()) || undefined,
           },
           images: [],
         };
@@ -136,7 +136,12 @@ export class MastraTrajectoryAdapter implements TrajectoryAdapter<MastraRunResul
     return buildTrajectory({
       taskSpec,
       toolCalls: calls.map(({ call }) => call),
-      finalAnswer: result.finalAnswer ?? (trailing || undefined),
+      finalAnswer:
+        result.finalAnswer !== undefined
+          ? sanitizeErrorMessage(result.finalAnswer)
+          : trailing
+            ? sanitizeErrorMessage(trailing)
+            : undefined,
       status: result.status ?? "complete",
       usage: result.usage,
       ...(finalObservation && { finalObservation }),

--- a/packages/evals/framework/harnesses/mastraAdapter.ts
+++ b/packages/evals/framework/harnesses/mastraAdapter.ts
@@ -1,0 +1,192 @@
+/**
+ * mastraAdapter converts Mastra `fullStream` chunks into verifier trajectories.
+ * Tool calls and results are paired by toolCallId; reasoning/text preceding a
+ * call belongs to that step, while text after the last call is the final answer.
+ */
+import type { ProbeEvidence, TaskSpec, Trajectory } from "stagehand-v3";
+import type { StepObservation } from "../observationRecorder.js";
+import {
+  buildTrajectory,
+  type NormalizedToolCall,
+  type TrajectoryAdapter,
+} from "./trajectoryAdapter.js";
+
+export interface MastraRunResult {
+  events: Array<Record<string, unknown>>;
+  finalAnswer?: string;
+  status?: Trajectory["status"];
+  usage?: Partial<Trajectory["usage"]>;
+  finalObservation?: ProbeEvidence;
+  stepObservations?: StepObservation[];
+  observedToolName?: (name: string) => boolean;
+}
+
+interface PendingCall {
+  id: string;
+  call: NormalizedToolCall;
+  images: Array<{ bytes: Buffer; mediaType: string }>;
+}
+
+export class MastraTrajectoryAdapter implements TrajectoryAdapter<MastraRunResult> {
+  fromHarnessResult(result: MastraRunResult, taskSpec: TaskSpec): Trajectory {
+    const calls: PendingCall[] = [];
+    const callsById = new Map<string, PendingCall>();
+    const trailingTextParts: string[] = [];
+    let pendingReasoning = "";
+
+    for (const event of result.events) {
+      const type = String(event.type ?? "");
+      const payload = isRecord(event.payload) ? event.payload : {};
+      if (type === "reasoning-delta" && typeof payload.text === "string") {
+        pendingReasoning = appendText(pendingReasoning, payload.text);
+        continue;
+      }
+      if (type === "text-delta" && typeof payload.text === "string") {
+        pendingReasoning = appendText(pendingReasoning, payload.text);
+        trailingTextParts.push(payload.text);
+        continue;
+      }
+      if (type === "tool-call") {
+        const id = typeof payload.toolCallId === "string" ? payload.toolCallId : "";
+        const args = isRecord(payload.args) ? { ...payload.args } : {};
+        delete args.__mastraMetadata;
+        const pending: PendingCall = {
+          id,
+          call: {
+            name: typeof payload.toolName === "string" ? payload.toolName : "tool",
+            args,
+            result: "",
+            ok: true,
+            reasoning: pendingReasoning.trim() || undefined,
+          },
+          images: [],
+        };
+        calls.push(pending);
+        callsById.set(id, pending);
+        pendingReasoning = "";
+        trailingTextParts.length = 0;
+        continue;
+      }
+      if (type === "tool-result") {
+        const id = typeof payload.toolCallId === "string" ? payload.toolCallId : "";
+        const pending = callsById.get(id);
+        if (!pending) continue;
+        const normalized = normalizeResult(payload.result);
+        const rawResult = payload.result;
+        const rawRecord = isRecord(rawResult) ? rawResult : undefined;
+        const ok =
+          payload.isError !== true &&
+          rawRecord?.isError !== true &&
+          !(rawRecord && rawRecord.ok === false);
+        pending.call.result = normalized.result;
+        pending.call.ok = ok;
+        pending.images = normalized.images;
+        if (normalized.images.length > 0) pending.call.images = normalized.images;
+        if (!ok) {
+          pending.call.error =
+            normalized.text ||
+            (typeof rawRecord?.error === "string" ? rawRecord.error : stringifyError(rawResult));
+        }
+        continue;
+      }
+      if (type === "tool-error") {
+        const id = typeof payload.toolCallId === "string" ? payload.toolCallId : "";
+        const pending = callsById.get(id);
+        if (!pending) continue;
+        const message = stringifyError(payload.error) || "tool error";
+        pending.call.result = message;
+        pending.call.ok = false;
+        pending.call.error = message;
+      }
+    }
+
+    const observationsByRunIndex = new Map(
+      (result.stepObservations ?? []).map((observation) => [
+        observation.runIndex,
+        observation.evidence,
+      ]),
+    );
+    const isObserved = result.observedToolName ?? (() => true);
+    let runOrdinal = 0;
+    for (const pending of calls) {
+      if (!isObserved(pending.call.name)) continue;
+      const observation = observationsByRunIndex.get(runOrdinal++);
+      if (observation) pending.call.probeEvidence = observation;
+    }
+
+    let finalObservation = result.finalObservation?.screenshot
+      ? result.finalObservation
+      : undefined;
+    for (let index = calls.length - 1; !finalObservation && index >= 0; index -= 1) {
+      const image = calls[index]?.images.at(-1);
+      if (image) finalObservation = { screenshot: image.bytes };
+    }
+    const trailing = trailingTextParts.join("").trim();
+
+    return buildTrajectory({
+      taskSpec,
+      toolCalls: calls.map(({ call }) => call),
+      finalAnswer: result.finalAnswer ?? (trailing || undefined),
+      status: result.status ?? "complete",
+      usage: result.usage,
+      ...(finalObservation && { finalObservation }),
+    });
+  }
+}
+
+export const mastraAdapter = new MastraTrajectoryAdapter();
+
+function normalizeResult(value: unknown): {
+  result: unknown;
+  text: string;
+  images: Array<{ bytes: Buffer; mediaType: string }>;
+} {
+  if (!isRecord(value) || !Array.isArray(value.content)) {
+    return {
+      result: value ?? "",
+      text:
+        typeof value === "string"
+          ? value
+          : isRecord(value) && typeof value.error === "string"
+            ? value.error
+            : "",
+      images: [],
+    };
+  }
+  const parts: string[] = [];
+  const images: Array<{ bytes: Buffer; mediaType: string }> = [];
+  for (const block of value.content) {
+    if (!isRecord(block)) continue;
+    if (block.type === "text" && typeof block.text === "string") {
+      parts.push(block.text);
+    } else if (block.type === "image" && typeof block.data === "string") {
+      images.push({
+        bytes: Buffer.from(block.data, "base64"),
+        mediaType: typeof block.mimeType === "string" ? block.mimeType : "image/png",
+      });
+      parts.push("[image]");
+    }
+  }
+  const text = parts.join("\n");
+  return { result: images.length > 0 ? text : value.content, text, images };
+}
+
+function appendText(buffer: string, addition: string): string {
+  if (!buffer) return addition;
+  return `${buffer}\n${addition}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function stringifyError(value: unknown): string {
+  if (value instanceof Error) return value.message;
+  if (typeof value === "string") return value;
+  if (isRecord(value) && typeof value.message === "string") return value.message;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value ?? "");
+  }
+}

--- a/packages/evals/framework/mastraRunner.ts
+++ b/packages/evals/framework/mastraRunner.ts
@@ -1,4 +1,3 @@
-// Phase 1: prompt/parse duplicated from codexRunner.ts on purpose; Phase 2 switches to the shared externalRunner skeleton.
 import {
   buildMastraTranscript,
   loadMastraSdk,
@@ -6,15 +5,25 @@ import {
   stringifyError,
   toFiniteNumber,
   type MastraSdk,
+  type MastraSessionResult,
   type MastraTokenUsage,
 } from "@browserbasehq/stagehand-integrations-mastra-sdk";
 import type { AvailableModel } from "stagehand-v3";
 import type { EvalLogger } from "../logger.js";
-import { datasetPromptGuidance, type ExternalHarnessTaskPlan } from "./externalHarnessPlan.js";
+import type { ExternalHarnessTaskPlan } from "./externalHarnessPlan.js";
+import {
+  buildExternalHarnessPrompt,
+  parseEvalResult,
+  runExternalHarnessTask,
+  type ExternalHarnessSessionOutcome,
+  type ExternalHarnessToolAdapterLike,
+  type ExternalHarnessUsage,
+  type ParsedEvalResult,
+} from "./harnesses/externalRunner.js";
 import { mastraAdapter } from "./harnesses/mastraAdapter.js";
 import type { PreparedMastraToolAdapter } from "./mastraToolAdapter.js";
 import type { TaskResult } from "./types.js";
-import { gradeExternalTrajectory, type ExternalHarnessVerifierConfig } from "./verifierAdapter.js";
+import type { ExternalHarnessVerifierConfig } from "./verifierAdapter.js";
 
 export type { MastraSdk } from "@browserbasehq/stagehand-integrations-mastra-sdk";
 export {
@@ -23,8 +32,7 @@ export {
   normalizeMastraModel,
   runMastraSession,
 } from "@browserbasehq/stagehand-integrations-mastra-sdk";
-
-type MetricValue = { count: number; value: number };
+export { EVAL_RESULT_SCHEMA } from "./harnesses/externalRunner.js";
 
 export interface MastraRunnerInput {
   plan: ExternalHarnessTaskPlan;
@@ -36,52 +44,21 @@ export interface MastraRunnerInput {
   verifier?: ExternalHarnessVerifierConfig;
 }
 
-export interface ParsedMastraResult {
-  success: boolean;
-  summary?: string;
-  finalAnswer?: string;
-  raw: string;
-}
+export interface ParsedMastraResult extends ParsedEvalResult {}
 
-export function buildMastraPrompt(plan: ExternalHarnessTaskPlan): string {
-  return [
-    "You are running a browser benchmark task.",
-    "",
-    `Dataset: ${plan.dataset}`,
-    plan.taskId ? `Task ID: ${plan.taskId}` : undefined,
-    `Start URL: ${plan.startUrl}`,
-    "",
-    "Instruction:",
-    plan.instruction,
-    "",
-    datasetPromptGuidance(plan.dataset),
-    "When finished, your final message must be compact JSON matching this schema:",
-    '{"success": boolean, "summary": string, "finalAnswer": string}',
-  ]
-    .filter(Boolean)
-    .join("\n");
+export function buildMastraPrompt(
+  plan: ExternalHarnessTaskPlan,
+  toolInstructions?: string,
+): string {
+  return buildExternalHarnessPrompt({
+    plan,
+    toolInstructions,
+    resultContract: "structured_output",
+  });
 }
 
 export function parseMastraResult(raw: string): ParsedMastraResult {
-  const marker = "EVAL_RESULT:";
-  const markerIndex = raw.lastIndexOf(marker);
-  const candidates =
-    markerIndex >= 0
-      ? [
-          raw.slice(markerIndex + marker.length).trim(),
-          raw
-            .slice(markerIndex + marker.length)
-            .trim()
-            .split(/\r?\n/, 1)[0]
-            ?.trim(),
-        ]
-      : [raw.trim(), raw.trim().split(/\r?\n/, 1)[0]?.trim()];
-  for (const candidate of candidates) {
-    if (!candidate) continue;
-    const parsed = tryParseMastraJson(candidate);
-    if (parsed) return { ...parsed, raw };
-  }
-  return { success: false, raw };
+  return parseEvalResult(raw);
 }
 
 export async function runMastraAgent({
@@ -93,72 +70,71 @@ export async function runMastraAgent({
   sdk,
   verifier,
 }: MastraRunnerInput): Promise<TaskResult> {
-  const prompt = buildMastraPrompt(plan);
-  const sessionResult = await runMastraSession({
-    prompt,
-    model,
-    logger,
-    sdk: sdk ?? (await loadMastraSdk()),
-    signal,
-    session: {
-      instructions: toolAdapter?.promptInstructions,
-      maxSteps: readMastraMaxSteps(),
-      mcpServers: toolAdapter?.mcpServers,
-      tools: toolAdapter?.tools,
-      mcpTimeoutMs: readPositiveIntEnv("EVAL_MASTRA_MCP_TIMEOUT_MS"),
-    },
-    onToolResult: toolAdapter?.onToolResult,
-  });
-  const { events, finalText, iterationError, status, stopReason, tokenUsage } = sessionResult;
-  const transcript = buildMastraTranscript(events);
-  const iterationErrorMessage = stringifyError(iterationError);
-  const rawResult = [finalText, transcript, iterationErrorMessage].filter(Boolean).join("\n\n");
-  const parsed = parseMastraResult(rawResult);
-  const errorMessage =
-    parsed.summary ??
-    stopReason ??
-    (iterationErrorMessage || finalText || transcript || "Mastra did not report success");
-  const baseResult: TaskResult = {
-    _success: parsed.success,
-    error: !parsed.success ? errorMessage : undefined,
-    reasoning: parsed.summary,
-    finalAnswer: parsed.finalAnswer,
-    rawResult: parsed.raw,
-    mastraStatus: status,
-    ...(stopReason && { mastraStopReason: stopReason }),
-    logs: logger.getLogs(),
-    metrics: buildMastraMetrics(tokenUsage),
+  const adapterLike: ExternalHarnessToolAdapterLike | undefined = toolAdapter && {
+    promptInstructions: toolAdapter.promptInstructions,
+    captureEvidence: toolAdapter.captureEvidence,
+    drainStepObservations: toolAdapter.drainStepObservations,
+    observedToolMatcher: toolAdapter.observedToolMatcher,
   };
-  if (!verifier) return baseResult;
-
-  const finalObservation = await toolAdapter?.captureEvidence?.().catch((): undefined => undefined);
-  const stepObservations = await toolAdapter?.drainStepObservations?.();
-  return gradeExternalTrajectory({
-    buildTrajectory: () =>
+  return runExternalHarnessTask({
+    harness: "mastra",
+    plan,
+    logger,
+    toolAdapter: adapterLike,
+    verifier,
+    resultContract: "structured_output",
+    fallbackErrorMessage: "Mastra did not report success",
+    runSession: async (prompt): Promise<ExternalHarnessSessionOutcome<MastraSessionResult>> => {
+      const sessionResult = await runMastraSession({
+        prompt,
+        model,
+        logger,
+        sdk: sdk ?? (await loadMastraSdk()),
+        signal,
+        session: {
+          maxSteps: readMastraMaxSteps(),
+          mcpServers: toolAdapter?.mcpServers,
+          tools: toolAdapter?.tools,
+          mcpTimeoutMs: readPositiveIntEnv("EVAL_MASTRA_MCP_TIMEOUT_MS"),
+        },
+        onToolResult: toolAdapter?.onToolResult,
+      });
+      return {
+        raw: sessionResult,
+        resultText: sessionResult.finalText,
+        transcriptText: buildMastraTranscript(sessionResult.events),
+        iterationError: sessionResult.iterationError,
+        status: sessionResult.status,
+        stopReason:
+          sessionResult.stopReason ||
+          (sessionResult.status === "sdk_error"
+            ? stringifyError(sessionResult.iterationError) || undefined
+            : undefined),
+        usage: normalizeMastraUsage(sessionResult.tokenUsage),
+        metrics: {},
+      };
+    },
+    toTrajectory: (
+      { raw, parsed, finalObservation, stepObservations, observedToolName, status },
+      taskSpec,
+    ) =>
       mastraAdapter.fromHarnessResult(
         {
-          events,
+          events: raw.events,
           ...(finalObservation && { finalObservation }),
           ...(stepObservations?.length && { stepObservations }),
-          ...(toolAdapter?.observedToolMatcher && {
-            observedToolName: toolAdapter.observedToolMatcher,
-          }),
-          finalAnswer: parsed.finalAnswer ?? finalText,
-          status: status === "completed" ? "complete" : "error",
+          ...(observedToolName && { observedToolName }),
+          finalAnswer: parsed.finalAnswer ?? raw.finalText,
+          status,
           usage: {
-            input_tokens: tokenUsage.inputTokens,
-            output_tokens: tokenUsage.outputTokens,
-            reasoning_tokens: tokenUsage.reasoningTokens,
-            cached_input_tokens: tokenUsage.cachedInputTokens,
+            input_tokens: raw.tokenUsage.inputTokens,
+            output_tokens: raw.tokenUsage.outputTokens,
+            reasoning_tokens: raw.tokenUsage.reasoningTokens,
+            cached_input_tokens: raw.tokenUsage.cachedInputTokens,
           },
         },
-        verifier.taskSpec,
+        taskSpec,
       ),
-    verifier,
-    baseResult,
-    errorMessage,
-    category: "mastra",
-    logger,
   });
 }
 
@@ -175,33 +151,14 @@ function readPositiveIntEnv(key: string): number | undefined {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
 }
 
-function tryParseMastraJson(candidate: string): Omit<ParsedMastraResult, "raw"> | undefined {
-  try {
-    const parsed = JSON.parse(candidate) as {
-      success?: unknown;
-      summary?: unknown;
-      finalAnswer?: unknown;
-    };
-    return {
-      success: parsed.success === true,
-      summary: typeof parsed.summary === "string" ? parsed.summary : undefined,
-      finalAnswer: typeof parsed.finalAnswer === "string" ? parsed.finalAnswer : undefined,
-    };
-  } catch {
-    return undefined;
-  }
-}
-
-function buildMastraMetrics(usage: MastraTokenUsage): Record<string, MetricValue> {
+function normalizeMastraUsage(usage: MastraTokenUsage): ExternalHarnessUsage {
+  const inputTokens = toFiniteNumber(usage.inputTokens);
+  const outputTokens = toFiniteNumber(usage.outputTokens);
   return {
-    mastra_input_tokens: metricValue(usage.inputTokens),
-    mastra_cached_input_tokens: metricValue(usage.cachedInputTokens),
-    mastra_output_tokens: metricValue(usage.outputTokens),
-    mastra_reasoning_output_tokens: metricValue(usage.reasoningTokens),
-    mastra_total_tokens: metricValue(usage.totalTokens),
+    inputTokens,
+    outputTokens,
+    cachedInputTokens: toFiniteNumber(usage.cachedInputTokens),
+    reasoningOutputTokens: toFiniteNumber(usage.reasoningTokens),
+    totalTokens: inputTokens + outputTokens,
   };
-}
-
-function metricValue(value: unknown): MetricValue {
-  return { count: 1, value: toFiniteNumber(value) };
 }

--- a/packages/evals/framework/mastraRunner.ts
+++ b/packages/evals/framework/mastraRunner.ts
@@ -76,7 +76,7 @@ export async function runMastraAgent({
     drainStepObservations: toolAdapter.drainStepObservations,
     observedToolMatcher: toolAdapter.observedToolMatcher,
   };
-  return runExternalHarnessTask({
+  const result = await runExternalHarnessTask({
     harness: "mastra",
     plan,
     logger,
@@ -101,7 +101,7 @@ export async function runMastraAgent({
       });
       return {
         raw: sessionResult,
-        resultText: sessionResult.finalText,
+        resultText: sessionResult.status === "sdk_error" ? "" : sessionResult.finalText,
         transcriptText: buildMastraTranscript(sessionResult.events),
         iterationError: sessionResult.iterationError,
         status: sessionResult.status,
@@ -136,6 +136,14 @@ export async function runMastraAgent({
         taskSpec,
       ),
   });
+  if (!verifier && result.harnessStatus === "sdk_error" && result._success === true) {
+    return {
+      ...result,
+      _success: false,
+      error: result.harnessStopReason ?? "Mastra did not report success",
+    };
+  }
+  return result;
 }
 
 function readMastraMaxSteps(): number {

--- a/packages/evals/framework/mastraRunner.ts
+++ b/packages/evals/framework/mastraRunner.ts
@@ -1,0 +1,207 @@
+// Phase 1: prompt/parse duplicated from codexRunner.ts on purpose; Phase 2 switches to the shared externalRunner skeleton.
+import {
+  buildMastraTranscript,
+  loadMastraSdk,
+  runMastraSession,
+  stringifyError,
+  toFiniteNumber,
+  type MastraSdk,
+  type MastraTokenUsage,
+} from "@browserbasehq/stagehand-integrations-mastra-sdk";
+import type { AvailableModel } from "stagehand-v3";
+import type { EvalLogger } from "../logger.js";
+import { datasetPromptGuidance, type ExternalHarnessTaskPlan } from "./externalHarnessPlan.js";
+import { mastraAdapter } from "./harnesses/mastraAdapter.js";
+import type { PreparedMastraToolAdapter } from "./mastraToolAdapter.js";
+import type { TaskResult } from "./types.js";
+import { gradeExternalTrajectory, type ExternalHarnessVerifierConfig } from "./verifierAdapter.js";
+
+export type { MastraSdk } from "@browserbasehq/stagehand-integrations-mastra-sdk";
+export {
+  buildMastraTranscript,
+  loadMastraSdk,
+  normalizeMastraModel,
+  runMastraSession,
+} from "@browserbasehq/stagehand-integrations-mastra-sdk";
+
+type MetricValue = { count: number; value: number };
+
+export interface MastraRunnerInput {
+  plan: ExternalHarnessTaskPlan;
+  model: AvailableModel;
+  logger: EvalLogger;
+  toolAdapter?: PreparedMastraToolAdapter;
+  signal?: AbortSignal;
+  sdk?: MastraSdk;
+  verifier?: ExternalHarnessVerifierConfig;
+}
+
+export interface ParsedMastraResult {
+  success: boolean;
+  summary?: string;
+  finalAnswer?: string;
+  raw: string;
+}
+
+export function buildMastraPrompt(plan: ExternalHarnessTaskPlan): string {
+  return [
+    "You are running a browser benchmark task.",
+    "",
+    `Dataset: ${plan.dataset}`,
+    plan.taskId ? `Task ID: ${plan.taskId}` : undefined,
+    `Start URL: ${plan.startUrl}`,
+    "",
+    "Instruction:",
+    plan.instruction,
+    "",
+    datasetPromptGuidance(plan.dataset),
+    "When finished, your final message must be compact JSON matching this schema:",
+    '{"success": boolean, "summary": string, "finalAnswer": string}',
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+export function parseMastraResult(raw: string): ParsedMastraResult {
+  const marker = "EVAL_RESULT:";
+  const markerIndex = raw.lastIndexOf(marker);
+  const candidates =
+    markerIndex >= 0
+      ? [
+          raw.slice(markerIndex + marker.length).trim(),
+          raw
+            .slice(markerIndex + marker.length)
+            .trim()
+            .split(/\r?\n/, 1)[0]
+            ?.trim(),
+        ]
+      : [raw.trim(), raw.trim().split(/\r?\n/, 1)[0]?.trim()];
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    const parsed = tryParseMastraJson(candidate);
+    if (parsed) return { ...parsed, raw };
+  }
+  return { success: false, raw };
+}
+
+export async function runMastraAgent({
+  plan,
+  model,
+  logger,
+  toolAdapter,
+  signal,
+  sdk,
+  verifier,
+}: MastraRunnerInput): Promise<TaskResult> {
+  const prompt = buildMastraPrompt(plan);
+  const sessionResult = await runMastraSession({
+    prompt,
+    model,
+    logger,
+    sdk: sdk ?? (await loadMastraSdk()),
+    signal,
+    session: {
+      instructions: toolAdapter?.promptInstructions,
+      maxSteps: readMastraMaxSteps(),
+      mcpServers: toolAdapter?.mcpServers,
+      tools: toolAdapter?.tools,
+      mcpTimeoutMs: readPositiveIntEnv("EVAL_MASTRA_MCP_TIMEOUT_MS"),
+    },
+    onToolResult: toolAdapter?.onToolResult,
+  });
+  const { events, finalText, iterationError, status, stopReason, tokenUsage } = sessionResult;
+  const transcript = buildMastraTranscript(events);
+  const iterationErrorMessage = stringifyError(iterationError);
+  const rawResult = [finalText, transcript, iterationErrorMessage].filter(Boolean).join("\n\n");
+  const parsed = parseMastraResult(rawResult);
+  const errorMessage =
+    parsed.summary ??
+    stopReason ??
+    (iterationErrorMessage || finalText || transcript || "Mastra did not report success");
+  const baseResult: TaskResult = {
+    _success: parsed.success,
+    error: !parsed.success ? errorMessage : undefined,
+    reasoning: parsed.summary,
+    finalAnswer: parsed.finalAnswer,
+    rawResult: parsed.raw,
+    mastraStatus: status,
+    ...(stopReason && { mastraStopReason: stopReason }),
+    logs: logger.getLogs(),
+    metrics: buildMastraMetrics(tokenUsage),
+  };
+  if (!verifier) return baseResult;
+
+  const finalObservation = await toolAdapter?.captureEvidence?.().catch((): undefined => undefined);
+  const stepObservations = await toolAdapter?.drainStepObservations?.();
+  return gradeExternalTrajectory({
+    buildTrajectory: () =>
+      mastraAdapter.fromHarnessResult(
+        {
+          events,
+          ...(finalObservation && { finalObservation }),
+          ...(stepObservations?.length && { stepObservations }),
+          ...(toolAdapter?.observedToolMatcher && {
+            observedToolName: toolAdapter.observedToolMatcher,
+          }),
+          finalAnswer: parsed.finalAnswer ?? finalText,
+          status: status === "completed" ? "complete" : "error",
+          usage: {
+            input_tokens: tokenUsage.inputTokens,
+            output_tokens: tokenUsage.outputTokens,
+            reasoning_tokens: tokenUsage.reasoningTokens,
+            cached_input_tokens: tokenUsage.cachedInputTokens,
+          },
+        },
+        verifier.taskSpec,
+      ),
+    verifier,
+    baseResult,
+    errorMessage,
+    category: "mastra",
+    logger,
+  });
+}
+
+function readMastraMaxSteps(): number {
+  for (const key of ["EVAL_MASTRA_MAX_STEPS", "AGENT_EVAL_MAX_STEPS"]) {
+    const value = readPositiveIntEnv(key);
+    if (value) return value;
+  }
+  return 50;
+}
+
+function readPositiveIntEnv(key: string): number | undefined {
+  const parsed = Number.parseInt(process.env[key] ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function tryParseMastraJson(candidate: string): Omit<ParsedMastraResult, "raw"> | undefined {
+  try {
+    const parsed = JSON.parse(candidate) as {
+      success?: unknown;
+      summary?: unknown;
+      finalAnswer?: unknown;
+    };
+    return {
+      success: parsed.success === true,
+      summary: typeof parsed.summary === "string" ? parsed.summary : undefined,
+      finalAnswer: typeof parsed.finalAnswer === "string" ? parsed.finalAnswer : undefined,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function buildMastraMetrics(usage: MastraTokenUsage): Record<string, MetricValue> {
+  return {
+    mastra_input_tokens: metricValue(usage.inputTokens),
+    mastra_cached_input_tokens: metricValue(usage.cachedInputTokens),
+    mastra_output_tokens: metricValue(usage.outputTokens),
+    mastra_reasoning_output_tokens: metricValue(usage.reasoningTokens),
+    mastra_total_tokens: metricValue(usage.totalTokens),
+  };
+}
+
+function metricValue(value: unknown): MetricValue {
+  return { count: 1, value: toFiniteNumber(value) };
+}

--- a/packages/evals/framework/mastraToolAdapter.ts
+++ b/packages/evals/framework/mastraToolAdapter.ts
@@ -1,0 +1,363 @@
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  loadMastraSdk,
+  type MastraSdk,
+  type MastraStdioServerDefinition,
+} from "@browserbasehq/stagehand-integrations-mastra-sdk";
+import { z } from "zod";
+import type { ProbeEvidence } from "stagehand-v3";
+import {
+  AGENT_RUN_TOOL_NAME,
+  type StartupProfile,
+  type ToolSurface,
+} from "../core/contracts/tool.js";
+import { EvalsError } from "../errors.js";
+import type { EvalLogger } from "../logger.js";
+import { startAgentToolRuntime } from "./agentToolRuntime.js";
+import { startCodeBridge } from "./codexCodeBridge.js";
+import type { ExternalHarnessTaskPlan } from "./externalHarnessPlan.js";
+import { ObservationRecorder, type StepObservation } from "./observationRecorder.js";
+
+export const MASTRA_RUN_TOOL_NAME = "stagehand_browser_run";
+
+export interface MastraToolAdapterInput {
+  toolSurface?: ToolSurface;
+  startupProfile?: StartupProfile;
+  environment: "LOCAL" | "BROWSERBASE";
+  plan: ExternalHarnessTaskPlan;
+  logger: EvalLogger;
+  sdk?: MastraSdk;
+  /** Test seam for runtime mounts. */
+  startRuntime?: typeof startAgentToolRuntime;
+}
+
+export interface PreparedMastraToolAdapter {
+  toolSurface: ToolSurface;
+  startupProfile: StartupProfile;
+  cwd: string;
+  env: Record<string, string>;
+  promptInstructions: string;
+  mcpServers?: Record<string, MastraStdioServerDefinition>;
+  tools?: Record<string, unknown>;
+  captureEvidence?: () => Promise<ProbeEvidence>;
+  drainStepObservations?: () => Promise<StepObservation[]>;
+  onToolResult?: (toolName: string) => void;
+  observedToolMatcher?: (name: string) => boolean;
+  cleanup: () => Promise<void>;
+}
+
+const CODE_SURFACES = new Set<ToolSurface>(["stagehand_code", "playwright_code", "cdp_code"]);
+const MCP_SURFACES = new Set<ToolSurface>([
+  "stagehand_facade",
+  "playwright_mcp",
+  "chrome_devtools_mcp",
+]);
+
+export async function prepareMastraToolAdapter(
+  input: MastraToolAdapterInput,
+): Promise<PreparedMastraToolAdapter> {
+  const toolSurface = resolveMastraToolSurface(input.toolSurface);
+  const startupProfile = resolveMastraStartupProfile(
+    toolSurface,
+    input.environment,
+    input.startupProfile,
+  );
+  const startRuntime = input.startRuntime ?? startAgentToolRuntime;
+  const runtime = await startRuntime({
+    toolSurface,
+    startupProfile,
+    environment: input.environment,
+    logger: input.logger,
+  });
+  let cwd: string | undefined;
+  let bridge: Awaited<ReturnType<typeof startCodeBridge>> | undefined;
+
+  try {
+    const mount = runtime.running.agentMount;
+    if (!mount) {
+      throw new EvalsError(`Tool surface "${toolSurface}" does not provide an agent mount.`);
+    }
+    cwd = await fsp.mkdtemp(
+      path.join(os.tmpdir(), `stagehand-evals-mastra-${toolSurface.replaceAll("_", "-")}-`),
+    );
+    const capturedCwd = cwd;
+    const recorder = runtime.running.captureEvidence
+      ? new ObservationRecorder(runtime.running.captureEvidence)
+      : undefined;
+    const evidenceFields = buildEvidenceFields(runtime.running.captureEvidence, recorder);
+
+    if (mount.via === "mcp") {
+      const mcpServers = buildMastraMcpServers(mount.mcpServers, cwd);
+      const serverNames = Object.keys(mount.mcpServers);
+      const matcher = mastraToolNameMatcher(serverNames);
+      input.logger.log({
+        category: "mastra",
+        message: `Initialized ${toolSurface} MCP mount for Mastra (servers: ${serverNames.join(", ")}).`,
+        level: 1,
+        auxiliary: {
+          startupProfile: { value: startupProfile, type: "string" },
+          environment: { value: input.environment, type: "string" },
+        },
+      });
+      let cleanupPromise: Promise<void> | undefined;
+      return {
+        toolSurface,
+        startupProfile,
+        cwd,
+        env: copyProcessEnv(),
+        promptInstructions: mount.promptInstructions,
+        mcpServers,
+        ...evidenceFields,
+        ...(recorder && {
+          onToolResult: (name: string) => {
+            if (matcher(name)) void recorder.record();
+          },
+        }),
+        observedToolMatcher: matcher,
+        cleanup: async () => {
+          cleanupPromise ??= cleanupRuntime(runtime.cleanup, capturedCwd);
+          await cleanupPromise;
+        },
+      };
+    }
+
+    if (mount.via === "handles") {
+      bridge = await startCodeBridge({
+        mount,
+        plan: input.plan,
+        logger: input.logger,
+        onRunExecuted: recorder ? () => recorder.record() : undefined,
+      });
+      const sdk = input.sdk ?? (await loadMastraSdk());
+      const tool = sdk.createTool({
+        id: MASTRA_RUN_TOOL_NAME,
+        description: mount.runTool.description,
+        inputSchema: z.object({
+          code: z.string().describe(mount.runTool.codeParamDescription),
+        }),
+        execute: async (toolInput: Record<string, unknown>) =>
+          executeViaCodeBridge(bridge!.port, String(toolInput.code)),
+      });
+      const scopeNames = [...Object.keys(mount.handles), "startUrl", "task", "console"].join(", ");
+      const promptInstructions = [
+        `Browser automation runs through the \`${MASTRA_RUN_TOOL_NAME}\` tool: pass a JavaScript snippet in \`code\`; it runs inside an async function with ${scopeNames} in scope; use await directly and return a JSON-serializable value.`,
+        mount.promptInstructions.replaceAll(AGENT_RUN_TOOL_NAME, MASTRA_RUN_TOOL_NAME),
+      ].join("\n");
+      const capturedBridge = bridge;
+      let cleanupPromise: Promise<void> | undefined;
+      return {
+        toolSurface,
+        startupProfile,
+        cwd,
+        env: copyProcessEnv(),
+        promptInstructions,
+        tools: { [MASTRA_RUN_TOOL_NAME]: tool },
+        ...evidenceFields,
+        observedToolMatcher: (name) => name === MASTRA_RUN_TOOL_NAME,
+        cleanup: async () => {
+          cleanupPromise ??= (async () => {
+            try {
+              await capturedBridge.close();
+            } catch {
+              // Best-effort teardown continues through the remaining owners.
+            }
+            await cleanupRuntime(runtime.cleanup, capturedCwd);
+          })();
+          await cleanupPromise;
+        },
+      };
+    }
+
+    throw new EvalsError(`Mastra does not support agent mounts delivered via "${mount.via}" yet.`);
+  } catch (error) {
+    await bridge?.close().catch((): undefined => undefined);
+    await withCaptureTimeout(
+      runtime.cleanup(),
+      readCapturePositiveIntEnv("EVAL_AGENT_MOUNT_CLEANUP_TIMEOUT_MS", 30_000),
+    ).catch((): undefined => undefined);
+    if (cwd) await fsp.rm(cwd, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+export function resolveMastraToolSurface(requested?: ToolSurface): ToolSurface {
+  if (!requested) return "stagehand_facade";
+  if (CODE_SURFACES.has(requested) || MCP_SURFACES.has(requested)) return requested;
+  throw new EvalsError(
+    `Mastra harness supports --tool stagehand_facade, playwright_mcp, chrome_devtools_mcp, stagehand_code, playwright_code, or cdp_code; received "${requested}".`,
+  );
+}
+
+export function resolveMastraStartupProfile(
+  toolSurface: ToolSurface,
+  environment: "LOCAL" | "BROWSERBASE",
+  requested?: StartupProfile,
+): StartupProfile {
+  if (requested) return requested;
+  if (toolSurface === "stagehand_code" || toolSurface === "stagehand_facade") {
+    return environment === "BROWSERBASE" ? "tool_create_browserbase" : "tool_launch_local";
+  }
+  if (CODE_SURFACES.has(toolSurface) || MCP_SURFACES.has(toolSurface)) {
+    return environment === "BROWSERBASE"
+      ? "runner_provided_browserbase_cdp"
+      : "runner_provided_local_cdp";
+  }
+  throw new EvalsError(
+    `No Mastra startup profile default for tool "${toolSurface}" in ${environment}.`,
+  );
+}
+
+export function buildMastraMcpServers(
+  mcpServers: Record<string, unknown>,
+  cwd: string,
+): Record<string, MastraStdioServerDefinition> {
+  return Object.fromEntries(
+    Object.entries(mcpServers).map(([name, raw]) => {
+      if (!isRecord(raw) || "url" in raw || typeof raw.command !== "string") {
+        throw new EvalsError(
+          `Mastra MCP server "${name}" must use a stdio definition with a string command.`,
+        );
+      }
+      const args = raw.args;
+      const env = raw.env;
+      const definition: MastraStdioServerDefinition = { command: raw.command, cwd };
+      if (args !== undefined) {
+        if (!isStringArray(args)) {
+          throw new EvalsError(`Mastra MCP server "${name}" has invalid args; expected strings.`);
+        }
+        definition.args = args;
+      }
+      if (env !== undefined) {
+        if (!isStringRecord(env)) {
+          throw new EvalsError(
+            `Mastra MCP server "${name}" has invalid env; expected string values.`,
+          );
+        }
+        definition.env = env;
+      }
+      return [name, definition] as const;
+    }),
+  );
+}
+
+export function mastraToolNameMatcher(serverNames: string[]): (name: string) => boolean {
+  return (name) => serverNames.some((server) => name.startsWith(`${server}_`));
+}
+
+export async function executeViaCodeBridge(
+  port: number,
+  code: string,
+): Promise<{ ok: true; result: string } | { ok: false; error: string }> {
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/run`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ code }),
+    });
+    const payload: unknown = await response.json();
+    if (isRecord(payload) && payload.ok === true) {
+      return { ok: true, result: String(payload.result ?? "") };
+    }
+    return {
+      ok: false,
+      error: isRecord(payload) && typeof payload.error === "string" ? payload.error : "run failed",
+    };
+  } catch (error) {
+    return { ok: false, error: stringifyError(error) };
+  }
+}
+
+function buildEvidenceFields(
+  captureEvidence: (() => Promise<ProbeEvidence>) | undefined,
+  recorder: ObservationRecorder | undefined,
+): Pick<PreparedMastraToolAdapter, "captureEvidence" | "drainStepObservations"> {
+  return {
+    ...(captureEvidence && { captureEvidence: boundedCaptureEvidence(captureEvidence) }),
+    ...(recorder && {
+      drainStepObservations: async () => {
+        await recorder.settle();
+        return recorder.drain();
+      },
+    }),
+  };
+}
+
+function boundedCaptureEvidence(
+  capture: () => Promise<ProbeEvidence>,
+): () => Promise<ProbeEvidence> {
+  return async () => {
+    try {
+      return await withCaptureTimeout(
+        capture(),
+        readCapturePositiveIntEnv("EVAL_CAPTURE_EVIDENCE_TIMEOUT_MS", 15_000),
+      );
+    } catch {
+      return {};
+    }
+  };
+}
+
+async function cleanupRuntime(cleanup: () => Promise<void>, cwd: string): Promise<void> {
+  try {
+    await cleanup();
+  } catch {
+    // The temporary workspace is still removed when runtime cleanup fails.
+  }
+  await fsp.rm(cwd, { recursive: true, force: true });
+}
+
+function readCapturePositiveIntEnv(key: string, fallback: number): number {
+  const parsed = Number.parseInt(process.env[key] ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function withCaptureTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`mastra adapter operation timed out after ${timeoutMs}ms`)),
+      timeoutMs,
+    );
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
+function copyProcessEnv(): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(process.env).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string",
+    ),
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  return isRecord(value) && Object.values(value).every((entry) => typeof entry === "string");
+}
+
+function stringifyError(value: unknown): string {
+  if (value instanceof Error) return value.message;
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/packages/evals/framework/mastraToolAdapter.ts
+++ b/packages/evals/framework/mastraToolAdapter.ts
@@ -46,7 +46,6 @@ export interface PreparedMastraToolAdapter {
   toolSurface: ToolSurface;
   startupProfile: StartupProfile;
   cwd: string;
-  env: Record<string, string>;
   promptInstructions: string;
   mcpServers?: Record<string, MastraStdioServerDefinition>;
   tools?: Record<string, unknown>;
@@ -114,7 +113,6 @@ export async function prepareMastraToolAdapter(
         toolSurface,
         startupProfile,
         cwd,
-        env: copyProcessEnv(),
         promptInstructions: mount.promptInstructions,
         mcpServers,
         ...evidenceFields,
@@ -159,7 +157,6 @@ export async function prepareMastraToolAdapter(
         toolSurface,
         startupProfile,
         cwd,
-        env: copyProcessEnv(),
         promptInstructions,
         tools: { [MASTRA_RUN_TOOL_NAME]: tool },
         ...evidenceFields,
@@ -282,7 +279,10 @@ function boundedCaptureEvidence(
 
 async function cleanupRuntime(cleanup: () => Promise<void>, cwd: string): Promise<void> {
   try {
-    await cleanup();
+    await withCaptureTimeout(
+      cleanup(),
+      readCapturePositiveIntEnv("EVAL_AGENT_MOUNT_CLEANUP_TIMEOUT_MS", 30_000),
+    );
   } catch {
     // The temporary workspace is still removed when runtime cleanup fails.
   }
@@ -311,14 +311,6 @@ function withCaptureTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<
       },
     );
   });
-}
-
-function copyProcessEnv(): Record<string, string> {
-  return Object.fromEntries(
-    Object.entries(process.env).filter(
-      (entry): entry is [string, string] => typeof entry[1] === "string",
-    ),
-  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/evals/framework/mastraToolAdapter.ts
+++ b/packages/evals/framework/mastraToolAdapter.ts
@@ -18,9 +18,18 @@ import type { EvalLogger } from "../logger.js";
 import { startAgentToolRuntime } from "./agentToolRuntime.js";
 import { startCodeBridge } from "./codexCodeBridge.js";
 import type { ExternalHarnessTaskPlan } from "./externalHarnessPlan.js";
+import { resolveStartupProfile, resolveToolSurface } from "./harnesses/toolSurfaceResolution.js";
 import { ObservationRecorder, type StepObservation } from "./observationRecorder.js";
 
 export const MASTRA_RUN_TOOL_NAME = "stagehand_browser_run";
+export const MASTRA_TOOL_SURFACES: ToolSurface[] = [
+  "stagehand_facade",
+  "playwright_mcp",
+  "chrome_devtools_mcp",
+  "stagehand_code",
+  "playwright_code",
+  "cdp_code",
+];
 
 export interface MastraToolAdapterInput {
   toolSurface?: ToolSurface;
@@ -48,18 +57,17 @@ export interface PreparedMastraToolAdapter {
   cleanup: () => Promise<void>;
 }
 
-const CODE_SURFACES = new Set<ToolSurface>(["stagehand_code", "playwright_code", "cdp_code"]);
-const MCP_SURFACES = new Set<ToolSurface>([
-  "stagehand_facade",
-  "playwright_mcp",
-  "chrome_devtools_mcp",
-]);
-
 export async function prepareMastraToolAdapter(
   input: MastraToolAdapterInput,
 ): Promise<PreparedMastraToolAdapter> {
-  const toolSurface = resolveMastraToolSurface(input.toolSurface);
-  const startupProfile = resolveMastraStartupProfile(
+  const toolSurface = resolveToolSurface(
+    { harness: "mastra", supportedToolSurfaces: MASTRA_TOOL_SURFACES },
+    input.toolSurface,
+  );
+  if (toolSurface === undefined) {
+    throw new EvalsError("Mastra harness requires a tool surface.");
+  }
+  const startupProfile = resolveStartupProfile(
     toolSurface,
     input.environment,
     input.startupProfile,
@@ -180,33 +188,6 @@ export async function prepareMastraToolAdapter(
     if (cwd) await fsp.rm(cwd, { recursive: true, force: true });
     throw error;
   }
-}
-
-export function resolveMastraToolSurface(requested?: ToolSurface): ToolSurface {
-  if (!requested) return "stagehand_facade";
-  if (CODE_SURFACES.has(requested) || MCP_SURFACES.has(requested)) return requested;
-  throw new EvalsError(
-    `Mastra harness supports --tool stagehand_facade, playwright_mcp, chrome_devtools_mcp, stagehand_code, playwright_code, or cdp_code; received "${requested}".`,
-  );
-}
-
-export function resolveMastraStartupProfile(
-  toolSurface: ToolSurface,
-  environment: "LOCAL" | "BROWSERBASE",
-  requested?: StartupProfile,
-): StartupProfile {
-  if (requested) return requested;
-  if (toolSurface === "stagehand_code" || toolSurface === "stagehand_facade") {
-    return environment === "BROWSERBASE" ? "tool_create_browserbase" : "tool_launch_local";
-  }
-  if (CODE_SURFACES.has(toolSurface) || MCP_SURFACES.has(toolSurface)) {
-    return environment === "BROWSERBASE"
-      ? "runner_provided_browserbase_cdp"
-      : "runner_provided_local_cdp";
-  }
-  throw new EvalsError(
-    `No Mastra startup profile default for tool "${toolSurface}" in ${environment}.`,
-  );
 }
 
 export function buildMastraMcpServers(

--- a/packages/evals/framework/mastraToolAdapter.ts
+++ b/packages/evals/framework/mastraToolAdapter.ts
@@ -73,16 +73,17 @@ export async function prepareMastraToolAdapter(
     input.startupProfile,
   );
   const startRuntime = input.startRuntime ?? startAgentToolRuntime;
-  const runtime = await startRuntime({
-    toolSurface,
-    startupProfile,
-    environment: input.environment,
-    logger: input.logger,
-  });
+  let runtime: Awaited<ReturnType<typeof startAgentToolRuntime>> | undefined;
   let cwd: string | undefined;
   let bridge: Awaited<ReturnType<typeof startCodeBridge>> | undefined;
 
   try {
+    runtime = await startRuntime({
+      toolSurface,
+      startupProfile,
+      environment: input.environment,
+      logger: input.logger,
+    });
     const mount = runtime.running.agentMount;
     if (!mount) {
       throw new EvalsError(`Tool surface "${toolSurface}" does not provide an agent mount.`);
@@ -179,10 +180,12 @@ export async function prepareMastraToolAdapter(
     throw new EvalsError(`Mastra does not support agent mounts delivered via "${mount.via}" yet.`);
   } catch (error) {
     await bridge?.close().catch((): undefined => undefined);
-    await withCaptureTimeout(
-      runtime.cleanup(),
-      readCapturePositiveIntEnv("EVAL_AGENT_MOUNT_CLEANUP_TIMEOUT_MS", 30_000),
-    ).catch((): undefined => undefined);
+    if (runtime) {
+      await withCaptureTimeout(
+        runtime.cleanup(),
+        readCapturePositiveIntEnv("EVAL_AGENT_MOUNT_CLEANUP_TIMEOUT_MS", 30_000),
+      ).catch((): undefined => undefined);
+    }
     if (cwd) await fsp.rm(cwd, { recursive: true, force: true });
     throw new EvalsError(
       `mastra tool adapter setup failed: ${sanitizeErrorMessage(stringifyError(error))}`,

--- a/packages/evals/framework/mastraToolAdapter.ts
+++ b/packages/evals/framework/mastraToolAdapter.ts
@@ -6,6 +6,7 @@ import {
   type MastraSdk,
   type MastraStdioServerDefinition,
 } from "@browserbasehq/stagehand-integrations-mastra-sdk";
+import { sanitizeErrorMessage } from "@browserbasehq/stagehand-integrations/harness";
 import { z } from "zod";
 import type { ProbeEvidence } from "stagehand-v3";
 import {
@@ -183,7 +184,10 @@ export async function prepareMastraToolAdapter(
       readCapturePositiveIntEnv("EVAL_AGENT_MOUNT_CLEANUP_TIMEOUT_MS", 30_000),
     ).catch((): undefined => undefined);
     if (cwd) await fsp.rm(cwd, { recursive: true, force: true });
-    throw error;
+    throw new EvalsError(
+      `mastra tool adapter setup failed: ${sanitizeErrorMessage(stringifyError(error))}`,
+      { cause: error },
+    );
   }
 }
 

--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -27,6 +27,7 @@
     "@browserbasehq/stagehand-integrations": "workspace:*",
     "@browserbasehq/stagehand-integrations-claude-agent-sdk": "workspace:*",
     "@browserbasehq/stagehand-integrations-codex-sdk": "workspace:*",
+    "@browserbasehq/stagehand-integrations-mastra-sdk": "workspace:*",
     "@opentelemetry/api": "catalog:",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.220.0",
     "@opentelemetry/sdk-trace-base": "^2.9.0",

--- a/packages/evals/tests/framework/benchHarness.test.ts
+++ b/packages/evals/tests/framework/benchHarness.test.ts
@@ -7,25 +7,28 @@ import {
   getBenchHarness,
   isExecutableBenchHarness,
   listBenchHarnesses,
+  listBenchHarnessesForToolSurface,
   listExecutableBenchHarnesses,
+  mastraHarness,
   parseBenchHarness,
   registerBenchHarness,
 } from "../../framework/benchHarness.js";
 import type { BenchMatrixRow } from "../../framework/benchTypes.js";
+import { MASTRA_TOOL_SURFACES } from "../../framework/mastraToolAdapter.js";
 import type { DiscoveredTask } from "../../framework/types.js";
 import type { EvalInput } from "../../types/evals.js";
 import { EvalLogger } from "../../logger.js";
 
 describe("bench harness registry", () => {
   it("lists registered harnesses in registration order", () => {
-    expect(listBenchHarnesses()).toEqual(["stagehand", "claude_code", "codex"]);
+    expect(listBenchHarnesses()).toEqual(["stagehand", "claude_code", "codex", "mastra"]);
   });
 
   it("parses registered harnesses and defaults to stagehand", () => {
     expect(parseBenchHarness(undefined)).toBe("stagehand");
     expect(parseBenchHarness("codex")).toBe("codex");
     expect(() => parseBenchHarness("nope")).toThrow(
-      /Unknown harness "nope"\. Supported: stagehand, claude_code, codex\./,
+      /Unknown harness "nope"\. Supported: stagehand, claude_code, codex, mastra\./,
     );
   });
 
@@ -54,6 +57,22 @@ describe("bench harness registry", () => {
     expect(harness.supportsApi).toBe(false);
     expect(harness.execute).toBeDefined();
     expect(harness.defaultModels).toEqual(["openai/gpt-5.4-mini"]);
+  });
+
+  it("registers mastra as a concrete executable harness", () => {
+    const harness = getBenchHarness("mastra");
+
+    expect(harness).toBe(mastraHarness);
+    expect(parseBenchHarness("mastra")).toBe("mastra");
+    expect(isExecutableBenchHarness("mastra")).toBe(true);
+    expect(harness.supportedTaskKinds).toEqual(["agent", "suite"]);
+    expect(harness.supportsApi).toBe(false);
+    expect(harness.execute).toBeDefined();
+    expect(harness.start).toBeUndefined();
+    expect(harness.supportedToolSurfaces).toEqual(MASTRA_TOOL_SURFACES);
+    expect(harness.supportedToolSurfaces[0]).toBe("stagehand_facade");
+    expect(harness.defaultModels).toEqual(["openai/gpt-5.4-mini"]);
+    expect(listBenchHarnessesForToolSurface("stagehand_facade")).toContain("mastra");
   });
 
   it("registers a new harness and rejects duplicate ids", () => {

--- a/packages/evals/tests/framework/benchPlanner.test.ts
+++ b/packages/evals/tests/framework/benchPlanner.test.ts
@@ -41,6 +41,15 @@ describe("benchPlanner", () => {
     });
   });
 
+  it("uses the registry-derived Mastra model override environment key", async () => {
+    expect(defaultModelsEnvKey("mastra")).toBe("EVAL_MASTRA_MODELS");
+    await withEnvOverrides({ EVAL_MASTRA_MODELS: "openai/custom-mastra" }, async () => {
+      expect(resolveBenchModelEntries([makeTask()], { harness: "mastra" }).modelEntries).toEqual([
+        { modelName: "openai/custom-mastra", mode: "hybrid", cua: false },
+      ]);
+    });
+  });
+
   it("plans registered pass-through harness rows generically", () => {
     registerBenchHarness({
       harness: "fake_planner_harness",

--- a/packages/evals/tests/framework/benchRunner.test.ts
+++ b/packages/evals/tests/framework/benchRunner.test.ts
@@ -172,7 +172,9 @@ describe("bench runner", () => {
     );
 
     expect(result._success).toBe(false);
-    expect(String(result.error)).toMatch(/--harness claude_code or --harness codex/);
+    expect(String(result.error)).toMatch(
+      /--harness claude_code, --harness codex, or --harness mastra/,
+    );
     expect(closeMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/evals/tests/framework/context.test.ts
+++ b/packages/evals/tests/framework/context.test.ts
@@ -13,7 +13,7 @@ describe("resolveDefaultCoreStartupProfile", () => {
       /available only as an agent harness mount/,
     );
     expect(() => rejectAgentMountOnlyCoreTool("stagehand_facade")).toThrow(
-      /--harness claude_code or --harness codex/,
+      /--harness claude_code, --harness codex, or --harness mastra/,
     );
   });
 
@@ -29,7 +29,7 @@ describe("resolveDefaultCoreStartupProfile", () => {
 
     try {
       expect(() => rejectAgentMountOnlyCoreTool("stagehand_facade")).toThrow(
-        /--harness claude_code, --harness codex, or --harness context_facade_harness/,
+        /--harness claude_code, --harness codex, --harness mastra, or --harness context_facade_harness/,
       );
     } finally {
       unregister();

--- a/packages/evals/tests/framework/mastraAdapter.test.ts
+++ b/packages/evals/tests/framework/mastraAdapter.test.ts
@@ -92,6 +92,22 @@ describe("Mastra trajectory adapter", () => {
     ]);
   });
 
+  it("sanitizes string results and tool errors", () => {
+    const trajectory = mastraAdapter.fromHarnessResult(
+      {
+        events: [
+          toolCall("1", "one", {}),
+          toolResult("1", "one", "bb_live_ABCDEFGHIJKLMNOP"),
+          toolCall("2", "two", {}),
+          toolError("2", "two", "failed?apiKey=secret123"),
+        ],
+      },
+      TASK_SPEC,
+    );
+    expect(JSON.stringify(trajectory.steps)).not.toContain("bb_live_ABCDEFGHIJKLMNOP");
+    expect(JSON.stringify(trajectory.steps)).not.toContain("secret123");
+  });
+
   it("folds pre-call reasoning and text while keeping trailing text as the answer", () => {
     const trajectory = mastraAdapter.fromHarnessResult(
       {

--- a/packages/evals/tests/framework/mastraAdapter.test.ts
+++ b/packages/evals/tests/framework/mastraAdapter.test.ts
@@ -184,6 +184,29 @@ describe("Mastra trajectory adapter", () => {
     expect(explicit.finalAnswer).toBe("explicit");
   });
 
+  it("sanitizes reasoning and explicit or trailing final answers", () => {
+    const secretUrl = "https://x.test?apiKey=secret123";
+    const trailing = mastraAdapter.fromHarnessResult(
+      {
+        events: [
+          reasoningDelta(`reason ${secretUrl}`),
+          toolCall("1", "run", {}),
+          toolResult("1", "run", "ok"),
+          textDelta(`finished ${secretUrl}`),
+        ],
+      },
+      TASK_SPEC,
+    );
+    const explicit = mastraAdapter.fromHarnessResult(
+      { events: [], finalAnswer: `explicit ${secretUrl}` },
+      TASK_SPEC,
+    );
+
+    expect(trailing.steps[0]?.reasoning).toBe("reason https://x.test?apiKey=[redacted]");
+    expect(trailing.finalAnswer).toBe("finished https://x.test?apiKey=[redacted]");
+    expect(explicit.finalAnswer).toBe("explicit https://x.test?apiKey=[redacted]");
+  });
+
   it("attaches observations only to matching tool ordinals", () => {
     const trajectory = mastraAdapter.fromHarnessResult(
       {

--- a/packages/evals/tests/framework/mastraAdapter.test.ts
+++ b/packages/evals/tests/framework/mastraAdapter.test.ts
@@ -48,6 +48,7 @@ describe("Mastra trajectory adapter", () => {
   });
 
   it("extracts MCP content images and uses the last image as final observation", () => {
+    const earlierBytes = Buffer.from("earlier screen");
     const bytes = Buffer.from("screen");
     const trajectory = mastraAdapter.fromHarnessResult(
       {
@@ -56,6 +57,11 @@ describe("Mastra trajectory adapter", () => {
           toolResult("1", "stagehand_screenshot", {
             content: [
               { type: "text", text: "captured" },
+              {
+                type: "image",
+                data: earlierBytes.toString("base64"),
+                mimeType: "image/png",
+              },
               { type: "image", data: bytes.toString("base64"), mimeType: "image/png" },
             ],
           }),
@@ -63,10 +69,10 @@ describe("Mastra trajectory adapter", () => {
       },
       TASK_SPEC,
     );
-    expect(trajectory.steps[0]?.toolOutput.result).toBe("captured\n[image]");
+    expect(trajectory.steps[0]?.toolOutput.result).toBe("captured\n[image]\n[image]");
     expect(
       trajectory.steps[0]?.agentEvidence.modalities.filter((item) => item.type === "image"),
-    ).toHaveLength(1);
+    ).toHaveLength(2);
     expect(trajectory.finalObservation?.screenshot).toEqual(bytes);
   });
 
@@ -106,6 +112,33 @@ describe("Mastra trajectory adapter", () => {
     );
     expect(JSON.stringify(trajectory.steps)).not.toContain("bb_live_ABCDEFGHIJKLMNOP");
     expect(JSON.stringify(trajectory.steps)).not.toContain("secret123");
+  });
+
+  it("deeply sanitizes tool arguments and structured results", () => {
+    const trajectory = mastraAdapter.fromHarnessResult(
+      {
+        events: [
+          toolCall("1", "one", {
+            nested: { url: "https://x?apiKey=secret123" },
+          }),
+          toolResult("1", "one", {
+            nested: [{ url: "https://x?apiKey=secret123" }],
+            count: 1,
+            enabled: true,
+          }),
+        ],
+      },
+      TASK_SPEC,
+    );
+
+    expect(trajectory.steps[0]?.actionArgs).toEqual({
+      nested: { url: "https://x?apiKey=[redacted]" },
+    });
+    expect(trajectory.steps[0]?.toolOutput.result).toEqual({
+      nested: [{ url: "https://x?apiKey=[redacted]" }],
+      count: 1,
+      enabled: true,
+    });
   });
 
   it("folds pre-call reasoning and text while keeping trailing text as the answer", () => {

--- a/packages/evals/tests/framework/mastraAdapter.test.ts
+++ b/packages/evals/tests/framework/mastraAdapter.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import type { TaskSpec } from "stagehand-v3";
+import { mastraAdapter } from "../../framework/harnesses/mastraAdapter.js";
+
+const TASK_SPEC: TaskSpec = { id: "task", instruction: "Do it" };
+
+function toolCall(id: string, name: string, args: Record<string, unknown>) {
+  return { type: "tool-call", payload: { toolCallId: id, toolName: name, args } };
+}
+
+function toolResult(id: string, name: string, result: unknown, isError?: boolean) {
+  return {
+    type: "tool-result",
+    payload: { toolCallId: id, toolName: name, result, ...(isError && { isError }) },
+  };
+}
+
+function textDelta(text: string) {
+  return { type: "text-delta", payload: { text } };
+}
+
+function reasoningDelta(text: string) {
+  return { type: "reasoning-delta", payload: { text } };
+}
+
+function toolError(id: string, name: string, error: unknown) {
+  return { type: "tool-error", payload: { toolCallId: id, toolName: name, error } };
+}
+
+describe("Mastra trajectory adapter", () => {
+  it("maps arguments, results, and success", () => {
+    const trajectory = mastraAdapter.fromHarnessResult(
+      {
+        events: [
+          toolCall("1", "stagehand_run", { query: "x", __mastraMetadata: { hidden: true } }),
+          toolResult("1", "stagehand_run", { value: 42 }),
+        ],
+      },
+      TASK_SPEC,
+    );
+    expect(trajectory.steps[0]).toMatchObject({
+      actionName: "stagehand_run",
+      actionArgs: { query: "x" },
+      toolOutput: { ok: true, result: { value: 42 } },
+    });
+    expect(trajectory.steps[0]?.actionArgs).not.toHaveProperty("__mastraMetadata");
+    expect(trajectory.status).toBe("complete");
+  });
+
+  it("extracts MCP content images and uses the last image as final observation", () => {
+    const bytes = Buffer.from("screen");
+    const trajectory = mastraAdapter.fromHarnessResult(
+      {
+        events: [
+          toolCall("1", "stagehand_screenshot", {}),
+          toolResult("1", "stagehand_screenshot", {
+            content: [
+              { type: "text", text: "captured" },
+              { type: "image", data: bytes.toString("base64"), mimeType: "image/png" },
+            ],
+          }),
+        ],
+      },
+      TASK_SPEC,
+    );
+    expect(trajectory.steps[0]?.toolOutput.result).toBe("captured\n[image]");
+    expect(
+      trajectory.steps[0]?.agentEvidence.modalities.filter((item) => item.type === "image"),
+    ).toHaveLength(1);
+    expect(trajectory.finalObservation?.screenshot).toEqual(bytes);
+  });
+
+  it("maps explicit error signals and failed structured results", () => {
+    const trajectory = mastraAdapter.fromHarnessResult(
+      {
+        events: [
+          toolCall("1", "one", {}),
+          toolResult("1", "one", { content: [{ type: "text", text: "denied" }] }, true),
+          toolCall("2", "two", {}),
+          toolResult("2", "two", { ok: false, error: "bad result" }),
+          toolCall("3", "three", {}),
+          toolError("3", "three", { message: "crashed" }),
+        ],
+      },
+      TASK_SPEC,
+    );
+    expect(trajectory.steps.map((step) => step.toolOutput.ok)).toEqual([false, false, false]);
+    expect(trajectory.steps.map((step) => step.toolOutput.error)).toEqual([
+      "denied",
+      "bad result",
+      "crashed",
+    ]);
+  });
+
+  it("folds pre-call reasoning and text while keeping trailing text as the answer", () => {
+    const trajectory = mastraAdapter.fromHarnessResult(
+      {
+        events: [
+          reasoningDelta("reason"),
+          textDelta("plan"),
+          toolCall("1", "run", {}),
+          toolResult("1", "run", "ok"),
+          textDelta("finished"),
+        ],
+      },
+      TASK_SPEC,
+    );
+    expect(trajectory.steps[0]?.reasoning).toBe("reason\nplan");
+    expect(trajectory.finalAnswer).toBe("finished");
+
+    const explicit = mastraAdapter.fromHarnessResult(
+      { events: [textDelta("fallback")], finalAnswer: "explicit" },
+      TASK_SPEC,
+    );
+    expect(explicit.finalAnswer).toBe("explicit");
+  });
+
+  it("attaches observations only to matching tool ordinals", () => {
+    const trajectory = mastraAdapter.fromHarnessResult(
+      {
+        events: [
+          toolCall("1", "unrelated", {}),
+          toolCall("2", "stagehand_one", {}),
+          toolCall("3", "stagehand_two", {}),
+        ],
+        observedToolName: (name) => name.startsWith("stagehand_"),
+        stepObservations: [
+          { runIndex: 0, evidence: { url: "https://example.com/one" } },
+          { runIndex: 1, evidence: { url: "https://example.com/two" } },
+        ],
+      },
+      TASK_SPEC,
+    );
+    expect(trajectory.steps.map((step) => step.probeEvidence.url)).toEqual([
+      undefined,
+      "https://example.com/one",
+      "https://example.com/two",
+    ]);
+  });
+
+  it("passes usage and explicit status through", () => {
+    const trajectory = mastraAdapter.fromHarnessResult(
+      {
+        events: [],
+        status: "error",
+        usage: { input_tokens: 10, output_tokens: 4, reasoning_tokens: 2 },
+      },
+      TASK_SPEC,
+    );
+    expect(trajectory.status).toBe("error");
+    expect(trajectory.usage).toMatchObject({
+      input_tokens: 10,
+      output_tokens: 4,
+      reasoning_tokens: 2,
+    });
+  });
+});

--- a/packages/evals/tests/framework/mastraAdapter.test.ts
+++ b/packages/evals/tests/framework/mastraAdapter.test.ts
@@ -28,6 +28,26 @@ function toolError(id: string, name: string, error: unknown) {
 }
 
 describe("Mastra trajectory adapter", () => {
+  it("concatenates streamed token deltas without inserting newlines", () => {
+    const trajectory = mastraAdapter.fromHarnessResult(
+      {
+        events: [
+          reasoningDelta("I will"),
+          reasoningDelta(" click"),
+          reasoningDelta(" checkout"),
+          textDelta("Proceeding"),
+          textDelta(" now"),
+          toolCall("1", "stagehand_run", {}),
+          toolResult("1", "stagehand_run", "ok"),
+        ],
+      },
+      TASK_SPEC,
+    );
+    // Fragments of one block join directly; only the reasoning → text block
+    // boundary gets a newline.
+    expect(trajectory.steps[0]?.reasoning).toBe("I will click checkout\nProceeding now");
+  });
+
   it("maps arguments, results, and success", () => {
     const trajectory = mastraAdapter.fromHarnessResult(
       {

--- a/packages/evals/tests/framework/mastraRunner.test.ts
+++ b/packages/evals/tests/framework/mastraRunner.test.ts
@@ -18,14 +18,13 @@ const plan: ExternalHarnessTaskPlan = {
 
 describe("Mastra runner", () => {
   it("builds the benchmark prompt and result schema", () => {
-    const prompt = buildMastraPrompt(plan);
+    const prompt = buildMastraPrompt(plan, "Use Stagehand via MCP.");
     expect(prompt).toContain("Dataset: webvoyager");
     expect(prompt).toContain("Task ID: wv-1");
     expect(prompt).toContain("Start URL: https://example.com");
     expect(prompt).toContain("Find the checkout button");
-    expect(prompt).toContain("When finished");
+    expect(prompt).toContain("Use Stagehand via MCP.");
     expect(prompt).toContain('"success": boolean');
-    expect(prompt).not.toContain("Do not edit repository files.");
   });
 
   it("parses direct JSON results", () => {
@@ -102,19 +101,20 @@ describe("Mastra runner", () => {
     });
     const metrics = result.metrics as Record<string, { value: number }>;
     expect(result._success).toBe(true);
+    expect(result.harnessStatus).toBe("completed");
     expect(result.mastraStatus).toBe("completed");
     expect(result.finalAnswer).toBe("ok");
-    expect(agentConfig).toMatchObject({
-      model: "openai/gpt-5.4-mini",
-      instructions: "Use Stagehand.",
-    });
+    expect(agentConfig).toMatchObject({ model: "openai/gpt-5.4-mini" });
+    expect(agentConfig?.instructions).not.toBe("Use Stagehand.");
     expect(streamOptions).toMatchObject({ maxSteps: 50 });
     expect(mcpServers?.stagehand).toMatchObject({ command: "node", onToolError: "return" });
-    expect(metrics.mastra_input_tokens.value).toBe(100);
-    expect(metrics.mastra_cached_input_tokens.value).toBe(10);
-    expect(metrics.mastra_output_tokens.value).toBe(25);
-    expect(metrics.mastra_reasoning_output_tokens.value).toBe(5);
-    expect(metrics.mastra_total_tokens.value).toBe(125);
+    expect(metrics.harness_input_tokens.value).toBe(100);
+    expect(metrics.harness_cached_input_tokens.value).toBe(10);
+    expect(metrics.harness_output_tokens.value).toBe(25);
+    expect(metrics.harness_reasoning_output_tokens.value).toBe(5);
+    expect(metrics.harness_total_tokens.value).toBe(125);
+    expect(metrics.harness_cost_usd).toBeUndefined();
+    expect(Object.keys(metrics).some((key) => key.startsWith("mastra_"))).toBe(false);
   });
 
   it("returns a failed task result for SDK errors", async () => {
@@ -126,7 +126,9 @@ describe("Mastra runner", () => {
       sdk,
     });
     expect(result._success).toBe(false);
+    expect(result.harnessStatus).toBe("sdk_error");
     expect(result.mastraStatus).toBe("sdk_error");
+    expect(result.harnessStopReason).toBeDefined();
     expect(String(result.error)).toContain("mastra failed");
   });
 });

--- a/packages/evals/tests/framework/mastraRunner.test.ts
+++ b/packages/evals/tests/framework/mastraRunner.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+import type { AvailableModel } from "stagehand-v3";
+import type { MastraEvent, MastraSdk } from "@browserbasehq/stagehand-integrations-mastra-sdk";
+import type { ExternalHarnessTaskPlan } from "../../framework/externalHarnessPlan.js";
+import {
+  buildMastraPrompt,
+  parseMastraResult,
+  runMastraAgent,
+} from "../../framework/mastraRunner.js";
+import { EvalLogger } from "../../logger.js";
+
+const plan: ExternalHarnessTaskPlan = {
+  dataset: "webvoyager",
+  taskId: "wv-1",
+  startUrl: "https://example.com",
+  instruction: "Find the checkout button",
+};
+
+describe("Mastra runner", () => {
+  it("builds the benchmark prompt and result schema", () => {
+    const prompt = buildMastraPrompt(plan);
+    expect(prompt).toContain("Dataset: webvoyager");
+    expect(prompt).toContain("Task ID: wv-1");
+    expect(prompt).toContain("Start URL: https://example.com");
+    expect(prompt).toContain("Find the checkout button");
+    expect(prompt).toContain("When finished");
+    expect(prompt).toContain('"success": boolean');
+    expect(prompt).not.toContain("Do not edit repository files.");
+  });
+
+  it("parses direct JSON results", () => {
+    expect(parseMastraResult('{"success":true,"summary":"done","finalAnswer":"clicked"}')).toEqual({
+      success: true,
+      summary: "done",
+      finalAnswer: "clicked",
+      raw: '{"success":true,"summary":"done","finalAnswer":"clicked"}',
+    });
+  });
+
+  it("parses EVAL_RESULT marker JSON", () => {
+    expect(
+      parseMastraResult('assistant text\nEVAL_RESULT: {"success":true,"summary":"done"}'),
+    ).toMatchObject({ success: true, summary: "done" });
+  });
+
+  it("streams a successful result, reports metrics, and forwards session options", async () => {
+    let agentConfig: Record<string, unknown> | undefined;
+    let streamOptions: Record<string, unknown> | undefined;
+    let mcpServers: Record<string, unknown> | undefined;
+    const sdk = fakeSdk(
+      [
+        {
+          type: "tool-call",
+          payload: { toolCallId: "1", toolName: "stagehand_run", args: {} },
+        },
+        {
+          type: "tool-result",
+          payload: { toolCallId: "1", toolName: "stagehand_run", result: "done" },
+        },
+        {
+          type: "text-delta",
+          payload: {
+            text: '{"success":true,"summary":"done","finalAnswer":"ok"}',
+          },
+        },
+        { type: "step-finish", payload: { output: { usage: {} } } },
+        {
+          type: "finish",
+          payload: {
+            stepResult: { reason: "stop" },
+            output: {
+              usage: {
+                inputTokens: 100,
+                cachedInputTokens: 10,
+                outputTokens: 25,
+                reasoningTokens: 5,
+              },
+            },
+          },
+        },
+      ],
+      {
+        agentConfig: (value) => (agentConfig = value),
+        streamOptions: (value) => (streamOptions = value),
+        mcpServers: (value) => (mcpServers = value),
+      },
+    );
+    const result = await runMastraAgent({
+      plan,
+      model: "openai/gpt-5.4-mini" as AvailableModel,
+      logger: new EvalLogger(false),
+      sdk,
+      toolAdapter: {
+        toolSurface: "stagehand_facade",
+        startupProfile: "tool_launch_local",
+        cwd: "/tmp/mastra-test",
+        env: {},
+        promptInstructions: "Use Stagehand.",
+        mcpServers: { stagehand: { command: "node", args: ["server.mjs"] } },
+        cleanup: async () => {},
+      },
+    });
+    const metrics = result.metrics as Record<string, { value: number }>;
+    expect(result._success).toBe(true);
+    expect(result.mastraStatus).toBe("completed");
+    expect(result.finalAnswer).toBe("ok");
+    expect(agentConfig).toMatchObject({
+      model: "openai/gpt-5.4-mini",
+      instructions: "Use Stagehand.",
+    });
+    expect(streamOptions).toMatchObject({ maxSteps: 50 });
+    expect(mcpServers?.stagehand).toMatchObject({ command: "node", onToolError: "return" });
+    expect(metrics.mastra_input_tokens.value).toBe(100);
+    expect(metrics.mastra_cached_input_tokens.value).toBe(10);
+    expect(metrics.mastra_output_tokens.value).toBe(25);
+    expect(metrics.mastra_reasoning_output_tokens.value).toBe(5);
+    expect(metrics.mastra_total_tokens.value).toBe(125);
+  });
+
+  it("returns a failed task result for SDK errors", async () => {
+    const sdk = fakeSdk([], { streamError: new Error("mastra failed") });
+    const result = await runMastraAgent({
+      plan,
+      model: "openai/gpt-5.4-mini" as AvailableModel,
+      logger: new EvalLogger(false),
+      sdk,
+    });
+    expect(result._success).toBe(false);
+    expect(result.mastraStatus).toBe("sdk_error");
+    expect(String(result.error)).toContain("mastra failed");
+  });
+});
+
+function fakeSdk(
+  events: MastraEvent[],
+  options: {
+    agentConfig?: (config: Record<string, unknown>) => void;
+    streamOptions?: (options: Record<string, unknown> | undefined) => void;
+    mcpServers?: (servers: Record<string, unknown>) => void;
+    streamError?: Error;
+  } = {},
+): MastraSdk {
+  return {
+    createAgent: (config: Record<string, unknown>) => {
+      options.agentConfig?.(config);
+      return {
+        stream: async (_prompt: string, streamOptions?: Record<string, unknown>) => {
+          options.streamOptions?.(streamOptions);
+          if (options.streamError) throw options.streamError;
+          return {
+            fullStream: (async function* () {
+              yield* events;
+            })(),
+          };
+        },
+      };
+    },
+    createMcpClient: (clientOptions: Parameters<MastraSdk["createMcpClient"]>[0]) => {
+      options.mcpServers?.(clientOptions.servers);
+      return {
+        listToolsWithErrors: async () => ({ tools: {}, errors: {} }),
+        disconnect: async () => {},
+      };
+    },
+    createTool: (toolOptions: Parameters<MastraSdk["createTool"]>[0]) => toolOptions,
+  };
+}

--- a/packages/evals/tests/framework/mastraRunner.test.ts
+++ b/packages/evals/tests/framework/mastraRunner.test.ts
@@ -93,7 +93,6 @@ describe("Mastra runner", () => {
         toolSurface: "stagehand_facade",
         startupProfile: "tool_launch_local",
         cwd: "/tmp/mastra-test",
-        env: {},
         promptInstructions: "Use Stagehand.",
         mcpServers: { stagehand: { command: "node", args: ["server.mjs"] } },
         cleanup: async () => {},
@@ -130,6 +129,25 @@ describe("Mastra runner", () => {
     expect(result.mastraStatus).toBe("sdk_error");
     expect(result.harnessStopReason).toBeDefined();
     expect(String(result.error)).toContain("mastra failed");
+  });
+
+  it("does not accept success JSON emitted before an SDK error", async () => {
+    const sdk = fakeSdk([
+      {
+        type: "text-delta",
+        payload: { text: '{"success":true,"summary":"done","finalAnswer":"x"}' },
+      },
+      { type: "error", payload: { error: "boom" } },
+    ]);
+    const result = await runMastraAgent({
+      plan,
+      model: "openai/gpt-5.4-mini" as AvailableModel,
+      logger: new EvalLogger(false),
+      sdk,
+    });
+    expect(result._success).toBe(false);
+    expect(result.harnessStatus).toBe("sdk_error");
+    expect(String(result.error)).toContain("boom");
   });
 });
 

--- a/packages/evals/tests/framework/mastraToolAdapter.test.ts
+++ b/packages/evals/tests/framework/mastraToolAdapter.test.ts
@@ -115,6 +115,7 @@ describe("Mastra tool adapter", () => {
       startRuntime,
     });
     expect(adapter.cwd.startsWith(os.tmpdir())).toBe(true);
+    expect(adapter).not.toHaveProperty("env");
     await expect(fsp.access(adapter.cwd)).resolves.toBeUndefined();
     expect(adapter.mcpServers?.stagehand).toMatchObject({
       command: "node",
@@ -174,6 +175,31 @@ describe("Mastra tool adapter", () => {
     await adapter.cleanup();
     expect(cleanup).toHaveBeenCalledOnce();
     await expect(fsp.access(adapter.cwd)).rejects.toThrow();
+  });
+
+  it("removes the temporary workspace when runtime cleanup times out", async () => {
+    const previous = process.env.EVAL_AGENT_MOUNT_CLEANUP_TIMEOUT_MS;
+    process.env.EVAL_AGENT_MOUNT_CLEANUP_TIMEOUT_MS = "20";
+    try {
+      const adapter = await prepareMastraToolAdapter({
+        environment: "LOCAL",
+        plan,
+        logger: new EvalLogger(false),
+        startRuntime: fakeStartRuntime(
+          {
+            via: "mcp",
+            promptInstructions: "p",
+            mcpServers: { stagehand: { command: "node" } },
+          },
+          () => new Promise<void>(() => {}),
+        ),
+      });
+      await expect(adapter.cleanup()).resolves.toBeUndefined();
+      await expect(fsp.access(adapter.cwd)).rejects.toThrow();
+    } finally {
+      if (previous === undefined) delete process.env.EVAL_AGENT_MOUNT_CLEANUP_TIMEOUT_MS;
+      else process.env.EVAL_AGENT_MOUNT_CLEANUP_TIMEOUT_MS = previous;
+    }
   });
 
   it("returns a structured error when the bridge port is closed", async () => {

--- a/packages/evals/tests/framework/mastraToolAdapter.test.ts
+++ b/packages/evals/tests/framework/mastraToolAdapter.test.ts
@@ -240,6 +240,22 @@ describe("Mastra tool adapter", () => {
     expect(cleanup).toHaveBeenCalledOnce();
   });
 
+  it("wraps runtime startup failures in a sanitized EvalsError", async () => {
+    await expect(
+      prepareMastraToolAdapter({
+        environment: "LOCAL",
+        plan,
+        logger: new EvalLogger(false),
+        startRuntime: async () => {
+          throw new Error("failed https://x.test?apiKey=secret123");
+        },
+      }),
+    ).rejects.toMatchObject({
+      name: "EvalsError",
+      message: "mastra tool adapter setup failed: failed https://x.test?apiKey=[redacted]",
+    });
+  });
+
   it("returns a structured error when the bridge port is closed", async () => {
     await expect(executeViaCodeBridge(1, "return 1")).resolves.toMatchObject({
       ok: false,

--- a/packages/evals/tests/framework/mastraToolAdapter.test.ts
+++ b/packages/evals/tests/framework/mastraToolAdapter.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { MastraSdk } from "@browserbasehq/stagehand-integrations-mastra-sdk";
 import type { AgentMount, ToolStartResult } from "../../core/contracts/tool.js";
 import { AGENT_RUN_TOOL_NAME } from "../../core/contracts/tool.js";
+import { EvalsError } from "../../errors.js";
 import type { startAgentToolRuntime } from "../../framework/agentToolRuntime.js";
 import {
   buildMastraMcpServers,
@@ -200,6 +201,43 @@ describe("Mastra tool adapter", () => {
       if (previous === undefined) delete process.env.EVAL_AGENT_MOUNT_CLEANUP_TIMEOUT_MS;
       else process.env.EVAL_AGENT_MOUNT_CLEANUP_TIMEOUT_MS = previous;
     }
+  });
+
+  it("wraps setup failures in a sanitized EvalsError after cleanup", async () => {
+    const cleanup = vi.fn(async () => {});
+    const cause = new Error("invalid?apiKey=secret123");
+
+    let thrown: unknown;
+    try {
+      await prepareMastraToolAdapter({
+        environment: "LOCAL",
+        plan,
+        logger: new EvalLogger(false),
+        startRuntime: fakeStartRuntime(
+          {
+            via: "mcp",
+            promptInstructions: "p",
+            mcpServers: {
+              stagehand: {
+                get command() {
+                  throw cause;
+                },
+              },
+            },
+          },
+          cleanup,
+        ),
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(EvalsError);
+    expect((thrown as Error).message).toBe(
+      "mastra tool adapter setup failed: invalid?apiKey=[redacted]",
+    );
+    expect((thrown as Error).cause).toBe(cause);
+    expect(cleanup).toHaveBeenCalledOnce();
   });
 
   it("returns a structured error when the bridge port is closed", async () => {

--- a/packages/evals/tests/framework/mastraToolAdapter.test.ts
+++ b/packages/evals/tests/framework/mastraToolAdapter.test.ts
@@ -1,0 +1,210 @@
+import fsp from "node:fs/promises";
+import os from "node:os";
+import { describe, expect, it, vi } from "vitest";
+import type { MastraSdk } from "@browserbasehq/stagehand-integrations-mastra-sdk";
+import type { AgentMount, ToolStartResult } from "../../core/contracts/tool.js";
+import { AGENT_RUN_TOOL_NAME } from "../../core/contracts/tool.js";
+import type { startAgentToolRuntime } from "../../framework/agentToolRuntime.js";
+import {
+  buildMastraMcpServers,
+  executeViaCodeBridge,
+  MASTRA_RUN_TOOL_NAME,
+  mastraToolNameMatcher,
+  prepareMastraToolAdapter,
+  resolveMastraStartupProfile,
+  resolveMastraToolSurface,
+} from "../../framework/mastraToolAdapter.js";
+import { EvalLogger } from "../../logger.js";
+
+const plan = {
+  dataset: "webvoyager" as const,
+  taskId: "wv-1",
+  startUrl: "https://example.com",
+  instruction: "Do it",
+};
+
+describe("Mastra tool adapter", () => {
+  it("resolves supported surfaces and rejects unsupported ones", () => {
+    expect(resolveMastraToolSurface()).toBe("stagehand_facade");
+    for (const surface of [
+      "stagehand_facade",
+      "playwright_mcp",
+      "chrome_devtools_mcp",
+      "stagehand_code",
+      "playwright_code",
+      "cdp_code",
+    ] as const) {
+      expect(resolveMastraToolSurface(surface)).toBe(surface);
+    }
+    expect(() => resolveMastraToolSurface("browse_cli")).toThrow(/Mastra harness supports/);
+    expect(() => resolveMastraToolSurface("understudy_code")).toThrow(/received/);
+  });
+
+  it("resolves startup profiles for each surface and environment", () => {
+    for (const surface of ["stagehand_facade", "stagehand_code"] as const) {
+      expect(resolveMastraStartupProfile(surface, "LOCAL")).toBe("tool_launch_local");
+      expect(resolveMastraStartupProfile(surface, "BROWSERBASE")).toBe("tool_create_browserbase");
+    }
+    for (const surface of [
+      "playwright_mcp",
+      "chrome_devtools_mcp",
+      "playwright_code",
+      "cdp_code",
+    ] as const) {
+      expect(resolveMastraStartupProfile(surface, "LOCAL")).toBe("runner_provided_local_cdp");
+      expect(resolveMastraStartupProfile(surface, "BROWSERBASE")).toBe(
+        "runner_provided_browserbase_cdp",
+      );
+    }
+  });
+
+  it("maps stdio MCP definitions and rejects non-stdio definitions", () => {
+    expect(
+      buildMastraMcpServers(
+        { stagehand: { command: "node", args: ["server.mjs"], env: { A: "1" } } },
+        "/tmp/work",
+      ),
+    ).toEqual({
+      stagehand: {
+        command: "node",
+        args: ["server.mjs"],
+        env: { A: "1" },
+        cwd: "/tmp/work",
+      },
+    });
+    expect(() =>
+      buildMastraMcpServers({ remote: { url: "https://example.com/mcp" } }, "/tmp/work"),
+    ).toThrow(/remote.*stdio/);
+    expect(() => buildMastraMcpServers({ broken: {} }, "/tmp/work")).toThrow(/broken.*command/);
+  });
+
+  it("matches Mastra's server-prefixed tool names", () => {
+    const matcher = mastraToolNameMatcher(["stagehand", "playwright"]);
+    expect(matcher("stagehand_run")).toBe(true);
+    expect(matcher("playwright_click")).toBe(true);
+    expect(matcher("other_tool")).toBe(false);
+  });
+
+  it("prepares an MCP mount, records observations, and cleans up idempotently", async () => {
+    const cleanup = vi.fn(async () => {});
+    const startRuntime = fakeStartRuntime(
+      {
+        via: "mcp",
+        promptInstructions: "p",
+        mcpServers: {
+          stagehand: { command: "node", args: ["s.mjs"], env: { A: "1" } },
+        },
+      },
+      cleanup,
+      async () => ({ url: "https://x" }),
+    );
+    const adapter = await prepareMastraToolAdapter({
+      environment: "LOCAL",
+      plan,
+      logger: new EvalLogger(false),
+      startRuntime,
+    });
+    expect(adapter.cwd.startsWith(os.tmpdir())).toBe(true);
+    await expect(fsp.access(adapter.cwd)).resolves.toBeUndefined();
+    expect(adapter.mcpServers?.stagehand).toMatchObject({
+      command: "node",
+      args: ["s.mjs"],
+      env: { A: "1" },
+      cwd: adapter.cwd,
+    });
+    adapter.onToolResult?.("other_tool");
+    adapter.onToolResult?.("stagehand_run");
+    expect(await adapter.drainStepObservations?.()).toHaveLength(1);
+    await adapter.cleanup();
+    await adapter.cleanup();
+    expect(cleanup).toHaveBeenCalledOnce();
+    await expect(fsp.access(adapter.cwd)).rejects.toThrow();
+  });
+
+  it("creates an in-process code tool backed by the real bridge", async () => {
+    const cleanup = vi.fn(async () => {});
+    const sdk: MastraSdk = {
+      createAgent: () => {
+        throw new Error("unused");
+      },
+      createMcpClient: () => {
+        throw new Error("unused");
+      },
+      createTool: (options: Parameters<MastraSdk["createTool"]>[0]) => options,
+    };
+    const adapter = await prepareMastraToolAdapter({
+      toolSurface: "stagehand_code",
+      environment: "LOCAL",
+      plan,
+      logger: new EvalLogger(false),
+      sdk,
+      startRuntime: fakeStartRuntime(
+        {
+          via: "handles",
+          promptInstructions: `Call ${AGENT_RUN_TOOL_NAME}.`,
+          handles: { marker: 42 },
+          runTool: {
+            description: "Run browser code",
+            codeParamDescription: "JavaScript",
+            denyMessage: "denied",
+          },
+        },
+        cleanup,
+      ),
+    });
+    const tool = adapter.tools?.[MASTRA_RUN_TOOL_NAME];
+    expect(tool).toBeDefined();
+    expect(adapter.promptInstructions).not.toContain(AGENT_RUN_TOOL_NAME);
+    expect(adapter.promptInstructions).toContain(MASTRA_RUN_TOOL_NAME);
+    const execute = readExecute(tool);
+    await expect(execute({ code: "return marker" }, {})).resolves.toEqual({
+      ok: true,
+      result: "42",
+    });
+    await adapter.cleanup();
+    expect(cleanup).toHaveBeenCalledOnce();
+    await expect(fsp.access(adapter.cwd)).rejects.toThrow();
+  });
+
+  it("returns a structured error when the bridge port is closed", async () => {
+    await expect(executeViaCodeBridge(1, "return 1")).resolves.toMatchObject({
+      ok: false,
+      error: expect.any(String),
+    });
+  });
+});
+
+function fakeStartRuntime(
+  agentMount: AgentMount,
+  cleanup: () => Promise<void>,
+  captureEvidence?: ToolStartResult["captureEvidence"],
+): typeof startAgentToolRuntime {
+  return (async () => ({
+    running: {
+      session: {},
+      agentMount,
+      captureEvidence,
+      cleanup: async () => {},
+      metadata: {
+        environment: "LOCAL",
+        browserOwnership: "tool",
+        connectionMode: "launch",
+      },
+    },
+    cleanup,
+  })) as unknown as typeof startAgentToolRuntime;
+}
+
+function readExecute(
+  value: unknown,
+): (input: Record<string, unknown>, context: Record<string, unknown>) => Promise<unknown> {
+  if (!value || typeof value !== "object" || !("execute" in value)) {
+    throw new Error("tool execute missing");
+  }
+  const execute = value.execute;
+  if (typeof execute !== "function") throw new Error("tool execute invalid");
+  return execute as (
+    input: Record<string, unknown>,
+    context: Record<string, unknown>,
+  ) => Promise<unknown>;
+}

--- a/packages/evals/tests/framework/mastraToolAdapter.test.ts
+++ b/packages/evals/tests/framework/mastraToolAdapter.test.ts
@@ -9,11 +9,14 @@ import {
   buildMastraMcpServers,
   executeViaCodeBridge,
   MASTRA_RUN_TOOL_NAME,
+  MASTRA_TOOL_SURFACES,
   mastraToolNameMatcher,
   prepareMastraToolAdapter,
-  resolveMastraStartupProfile,
-  resolveMastraToolSurface,
 } from "../../framework/mastraToolAdapter.js";
+import {
+  resolveStartupProfile,
+  resolveToolSurface,
+} from "../../framework/harnesses/toolSurfaceResolution.js";
 import { EvalLogger } from "../../logger.js";
 
 const plan = {
@@ -24,26 +27,35 @@ const plan = {
 };
 
 describe("Mastra tool adapter", () => {
-  it("resolves supported surfaces and rejects unsupported ones", () => {
-    expect(resolveMastraToolSurface()).toBe("stagehand_facade");
-    for (const surface of [
+  it("lists supported surfaces with stagehand_facade first", () => {
+    expect(MASTRA_TOOL_SURFACES).toEqual([
       "stagehand_facade",
       "playwright_mcp",
       "chrome_devtools_mcp",
       "stagehand_code",
       "playwright_code",
       "cdp_code",
-    ] as const) {
-      expect(resolveMastraToolSurface(surface)).toBe(surface);
+    ]);
+  });
+
+  it("resolves supported surfaces and rejects unsupported ones", () => {
+    const harness = { harness: "mastra", supportedToolSurfaces: MASTRA_TOOL_SURFACES };
+    expect(resolveToolSurface(harness)).toBe("stagehand_facade");
+    for (const surface of MASTRA_TOOL_SURFACES) {
+      expect(resolveToolSurface(harness, surface)).toBe(surface);
     }
-    expect(() => resolveMastraToolSurface("browse_cli")).toThrow(/Mastra harness supports/);
-    expect(() => resolveMastraToolSurface("understudy_code")).toThrow(/received/);
+    expect(() => resolveToolSurface(harness, "browse_cli")).toThrow(
+      /Harness "mastra" supports --tool/,
+    );
+    expect(() => resolveToolSurface(harness, "understudy_code")).toThrow(
+      /Harness "mastra" supports --tool/,
+    );
   });
 
   it("resolves startup profiles for each surface and environment", () => {
     for (const surface of ["stagehand_facade", "stagehand_code"] as const) {
-      expect(resolveMastraStartupProfile(surface, "LOCAL")).toBe("tool_launch_local");
-      expect(resolveMastraStartupProfile(surface, "BROWSERBASE")).toBe("tool_create_browserbase");
+      expect(resolveStartupProfile(surface, "LOCAL")).toBe("tool_launch_local");
+      expect(resolveStartupProfile(surface, "BROWSERBASE")).toBe("tool_create_browserbase");
     }
     for (const surface of [
       "playwright_mcp",
@@ -51,10 +63,8 @@ describe("Mastra tool adapter", () => {
       "playwright_code",
       "cdp_code",
     ] as const) {
-      expect(resolveMastraStartupProfile(surface, "LOCAL")).toBe("runner_provided_local_cdp");
-      expect(resolveMastraStartupProfile(surface, "BROWSERBASE")).toBe(
-        "runner_provided_browserbase_cdp",
-      );
+      expect(resolveStartupProfile(surface, "LOCAL")).toBe("runner_provided_local_cdp");
+      expect(resolveStartupProfile(surface, "BROWSERBASE")).toBe("runner_provided_browserbase_cdp");
     }
   });
 

--- a/packages/evals/tests/tui/run.test.ts
+++ b/packages/evals/tests/tui/run.test.ts
@@ -169,7 +169,9 @@ describe("deriveCategoryFilter", () => {
 
     const payload = JSON.parse(String(log.mock.calls[0][0]));
     expect(payload.matrix).toEqual([]);
-    expect(String(payload.error)).toMatch(/--harness claude_code or --harness codex/);
+    expect(String(payload.error)).toMatch(
+      /--harness claude_code, --harness codex, or --harness mastra/,
+    );
     expect(process.exitCode).toBe(1);
     process.exitCode = undefined;
   });
@@ -203,7 +205,7 @@ describe("deriveCategoryFilter", () => {
         },
         registry,
       ),
-    ).rejects.toThrow(/--harness claude_code or --harness codex/);
+    ).rejects.toThrow(/--harness claude_code, --harness codex, or --harness mastra/);
   });
 
   it("prints claude_code dry-run matrices without stagehand agent modes", async () => {

--- a/packages/integrations/mastra-sdk/package.json
+++ b/packages/integrations/mastra-sdk/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@browserbasehq/stagehand-integrations-mastra-sdk",
+  "version": "4.0.1",
+  "private": true,
+  "description": "Mastra harness adapter for Stagehand integrations",
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs"
+    }
+  },
+  "scripts": {
+    "build": "tsdown",
+    "test": "pnpm run build && vitest run --root ../../.. packages/integrations/mastra-sdk/tests",
+    "test:unit": "vitest run --root ../../.. packages/integrations/mastra-sdk/tests",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "@browserbasehq/stagehand-integrations": "workspace:*",
+    "@mastra/core": "catalog:",
+    "@mastra/mcp": "catalog:",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=22.18.0"
+  }
+}

--- a/packages/integrations/mastra-sdk/src/index.ts
+++ b/packages/integrations/mastra-sdk/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./session.js";

--- a/packages/integrations/mastra-sdk/src/session.ts
+++ b/packages/integrations/mastra-sdk/src/session.ts
@@ -1,0 +1,452 @@
+import {
+  HarnessAdapterError,
+  sanitizeErrorMessage,
+  type HarnessLogger,
+} from "@browserbasehq/stagehand-integrations/harness";
+
+export type MastraEvent = Record<string, unknown>;
+
+export type MastraStdioServerDefinition = {
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+  cwd?: string;
+  timeout?: number;
+  onToolError?: "throw" | "return";
+};
+
+export type MastraAgentLike = {
+  stream: (
+    prompt: string,
+    options?: Record<string, unknown>,
+  ) => Promise<{
+    fullStream: AsyncIterable<MastraEvent>;
+    text?: Promise<string>;
+    error?: unknown;
+  }>;
+};
+
+export type MastraMcpClientLike = {
+  listToolsWithErrors: () => Promise<{
+    tools: Record<string, unknown>;
+    errors: Record<string, string>;
+  }>;
+  disconnect: () => Promise<void>;
+};
+
+export type MastraSdk = {
+  createAgent: (config: Record<string, unknown>) => MastraAgentLike;
+  createMcpClient: (options: {
+    id?: string;
+    servers: Record<string, MastraStdioServerDefinition>;
+    timeout?: number;
+  }) => MastraMcpClientLike;
+  createTool: (options: {
+    id: string;
+    description: string;
+    inputSchema: unknown;
+    execute: (input: Record<string, unknown>, context: Record<string, unknown>) => Promise<unknown>;
+  }) => unknown;
+};
+
+export type MastraSessionConfig = {
+  instructions?: string;
+  maxSteps?: number;
+  mcpServers?: Record<string, MastraStdioServerDefinition>;
+  tools?: Record<string, unknown>;
+  agentId?: string;
+  agentName?: string;
+  modelSettings?: Record<string, unknown>;
+  mcpTimeoutMs?: number;
+};
+
+export type MastraTokenUsage = {
+  inputTokens: number;
+  outputTokens: number;
+  reasoningTokens: number;
+  cachedInputTokens: number;
+  totalTokens: number;
+};
+
+export type MastraSessionResult = {
+  events: MastraEvent[];
+  finalText: string;
+  status: "completed" | "max_turns" | "sdk_error";
+  stopReason?: string;
+  finishReason?: string;
+  stepCount: number;
+  tokenUsage: MastraTokenUsage;
+  iterationError?: unknown;
+};
+
+export const MASTRA_CORE_PACKAGE = "@mastra/core";
+export const MASTRA_MCP_PACKAGE = "@mastra/mcp";
+
+export async function loadMastraSdk(): Promise<MastraSdk> {
+  try {
+    const agentSpecifier = `${MASTRA_CORE_PACKAGE}/agent`;
+    const toolsSpecifier = `${MASTRA_CORE_PACKAGE}/tools`;
+    const mcpSpecifier = MASTRA_MCP_PACKAGE;
+    const agentModule = (await import(agentSpecifier)) as Record<string, unknown>;
+    const toolsModule = (await import(toolsSpecifier)) as Record<string, unknown>;
+    const mcpModule = (await import(mcpSpecifier)) as Record<string, unknown>;
+    if (typeof agentModule.Agent !== "function") throw new Error("Agent export missing");
+    if (typeof toolsModule.createTool !== "function") throw new Error("createTool export missing");
+    if (typeof mcpModule.MCPClient !== "function") throw new Error("MCPClient export missing");
+
+    const AgentConstructor = agentModule.Agent as new (
+      config: Record<string, unknown>,
+    ) => MastraAgentLike;
+    const McpClientConstructor = mcpModule.MCPClient as new (options: {
+      id?: string;
+      servers: Record<string, MastraStdioServerDefinition>;
+      timeout?: number;
+    }) => MastraMcpClientLike;
+    const createTool = toolsModule.createTool as MastraSdk["createTool"];
+    return {
+      createAgent: (config) => new AgentConstructor(config),
+      createMcpClient: (options) => new McpClientConstructor(options),
+      createTool,
+    };
+  } catch (error) {
+    const detail = sanitizeErrorMessage(stringifyError(error));
+    throw new HarnessAdapterError(
+      `Mastra harness requires ${MASTRA_CORE_PACKAGE} and ${MASTRA_MCP_PACKAGE}. Install them in the consuming workspace.${detail ? ` ${detail}` : ""}`,
+      { cause: error },
+    );
+  }
+}
+
+export function normalizeMastraModel(model: string): string {
+  if (model === "mastra/default") return "openai/gpt-5.4-mini";
+  return model.includes("/") ? model : `openai/${model}`;
+}
+
+export async function runMastraSession(input: {
+  prompt: string;
+  model: string;
+  sdk?: MastraSdk;
+  signal?: AbortSignal;
+  logger: HarnessLogger;
+  session: MastraSessionConfig;
+  onToolResult?: (toolName: string) => void | Promise<void>;
+}): Promise<MastraSessionResult> {
+  const sdk = input.sdk ?? (await loadMastraSdk());
+  const events: MastraEvent[] = [];
+  const maxSteps = positiveInteger(input.session.maxSteps, 50);
+  const controller = new AbortController();
+  const forwardAbort = (): void => controller.abort(input.signal?.reason);
+  if (input.signal) {
+    if (input.signal.aborted) controller.abort(input.signal.reason);
+    else input.signal.addEventListener("abort", forwardAbort, { once: true });
+  }
+
+  let client: MastraMcpClientLike | undefined;
+  let finalText = "";
+  let textBuffer = "";
+  let stopReason: string | undefined;
+  let finishReason: string | undefined;
+  let iterationError: unknown;
+  let stepCount = 0;
+  let tokenUsage = extractMastraTokenUsage(undefined);
+  let summedStepUsage = extractMastraTokenUsage(undefined);
+
+  try {
+    let mcpTools: Record<string, unknown> = {};
+    if (input.session.mcpServers && Object.keys(input.session.mcpServers).length > 0) {
+      const servers = Object.fromEntries(
+        Object.entries(input.session.mcpServers).map(([name, server]) => [
+          name,
+          { ...server, onToolError: server.onToolError ?? "return" },
+        ]),
+      );
+      client = sdk.createMcpClient({
+        id: "stagehand-evals-mastra",
+        servers,
+        ...(positiveIntegerOrUndefined(input.session.mcpTimeoutMs) && {
+          timeout: positiveIntegerOrUndefined(input.session.mcpTimeoutMs),
+        }),
+      });
+      const discovery = await client.listToolsWithErrors();
+      if (Object.keys(discovery.errors).length > 0) {
+        stopReason = sanitizeErrorMessage(
+          `MCP server discovery failed: ${Object.entries(discovery.errors)
+            .map(([server, error]) => `${server}: ${error}`)
+            .join("; ")}`,
+        );
+        input.logger.warn({ category: "mastra", message: stopReason, level: 0 });
+      } else {
+        mcpTools = discovery.tools;
+      }
+    }
+
+    if (!stopReason) {
+      const agent = sdk.createAgent({
+        id: input.session.agentId ?? "stagehand-evals-mastra",
+        name: input.session.agentName ?? "Stagehand Evals Mastra Agent",
+        instructions:
+          input.session.instructions ?? "Use the available browser/web tools to complete the task.",
+        model: normalizeMastraModel(input.model),
+        tools: { ...mcpTools, ...input.session.tools },
+      });
+      const stream = await agent.stream(input.prompt, {
+        maxSteps,
+        abortSignal: controller.signal,
+        ...(input.session.modelSettings && { modelSettings: input.session.modelSettings }),
+      });
+
+      for await (const event of stream.fullStream) {
+        events.push(event);
+        logMastraEvent(input.logger, event);
+        const payload = isRecord(event.payload) ? event.payload : {};
+        if (event.type === "tool-call") {
+          textBuffer = "";
+        } else if (event.type === "text-delta" && typeof payload.text === "string") {
+          textBuffer += payload.text;
+        } else if (event.type === "tool-result" || event.type === "tool-error") {
+          if (typeof payload.toolName === "string") {
+            await input.onToolResult?.(payload.toolName);
+          }
+        } else if (event.type === "step-finish") {
+          stepCount += 1;
+          const output = isRecord(payload.output) ? payload.output : undefined;
+          if (isRecord(output?.usage)) {
+            summedStepUsage = addTokenUsage(summedStepUsage, extractMastraTokenUsage(output.usage));
+          }
+        } else if (event.type === "finish") {
+          const stepResult = isRecord(payload.stepResult) ? payload.stepResult : undefined;
+          finishReason = typeof stepResult?.reason === "string" ? stepResult.reason : finishReason;
+          const output = isRecord(payload.output) ? payload.output : undefined;
+          if (isRecord(output?.usage)) tokenUsage = extractMastraTokenUsage(output.usage);
+        } else if (event.type === "error") {
+          stopReason = sanitizeErrorMessage(stringifyError(payload.error) || "error");
+        } else if (event.type === "abort") {
+          stopReason = sanitizeErrorMessage(stringifyError(input.signal?.reason) || "aborted");
+        }
+      }
+      finalText = textBuffer;
+      if (!finalText && stream.text) {
+        try {
+          finalText = await stream.text;
+        } catch {
+          // The stream's explicit error is reported below when available.
+        }
+      }
+      if (stream.error && !stopReason) {
+        stopReason = sanitizeErrorMessage(stringifyError(stream.error));
+      }
+      if (isEmptyTokenUsage(tokenUsage)) tokenUsage = summedStepUsage;
+    }
+  } catch (error) {
+    iterationError = error;
+    input.logger.warn({
+      category: "mastra",
+      message: `Mastra stopped before a normal result: ${sanitizeErrorMessage(stringifyError(error))}`,
+      level: 0,
+      auxiliary: {
+        error: { value: sanitizeErrorMessage(stringifyError(error)), type: "string" },
+      },
+    });
+  } finally {
+    input.signal?.removeEventListener("abort", forwardAbort);
+    if (client) {
+      try {
+        await client.disconnect();
+      } catch (error) {
+        input.logger.warn({
+          category: "mastra",
+          message: `Mastra MCP disconnect failed: ${sanitizeErrorMessage(stringifyError(error))}`,
+          level: 1,
+        });
+      }
+    }
+  }
+
+  const status = resolveMastraStatus({
+    iterationError,
+    stopReason,
+    finishReason,
+    stepCount,
+    maxSteps,
+  });
+  if (status === "max_turns") stopReason ??= `step budget exhausted (${maxSteps} steps)`;
+  return {
+    events,
+    finalText,
+    status,
+    ...(stopReason && { stopReason: sanitizeErrorMessage(stopReason) }),
+    ...(finishReason && { finishReason }),
+    stepCount,
+    tokenUsage,
+    ...(iterationError !== undefined && { iterationError }),
+  };
+}
+
+export function resolveMastraStatus(args: {
+  iterationError: unknown;
+  stopReason?: string;
+  finishReason?: string;
+  stepCount: number;
+  maxSteps: number;
+}): "completed" | "max_turns" | "sdk_error" {
+  if (args.iterationError || args.stopReason) return "sdk_error";
+  if (
+    args.finishReason === "tool-calls" ||
+    (args.stepCount >= args.maxSteps && args.finishReason !== "stop")
+  ) {
+    return "max_turns";
+  }
+  return "completed";
+}
+
+export function extractMastraTokenUsage(
+  usage: Record<string, unknown> | undefined,
+): MastraTokenUsage {
+  const inputTokens = toFiniteNumber(usage?.inputTokens);
+  const outputTokens = toFiniteNumber(usage?.outputTokens);
+  return {
+    inputTokens,
+    outputTokens,
+    reasoningTokens: toFiniteNumber(usage?.reasoningTokens),
+    cachedInputTokens: toFiniteNumber(usage?.cachedInputTokens),
+    totalTokens: toFiniteNumber(usage?.totalTokens) || inputTokens + outputTokens,
+  };
+}
+
+export function buildMastraTranscript(events: MastraEvent[]): string {
+  return events
+    .filter((event) =>
+      ["tool-call", "tool-result", "tool-error", "text-delta", "error"].includes(
+        String(event.type ?? ""),
+      ),
+    )
+    .map((event) => summarizeMastraEvent(event).detail)
+    .filter((detail): detail is string => Boolean(detail))
+    .join("\n");
+}
+
+export function logMastraEvent(logger: HarnessLogger, event: MastraEvent): void {
+  const summary = summarizeMastraEvent(event);
+  const type = String(event.type ?? "unknown");
+  logger.log({
+    category: "mastra",
+    message: summary.message,
+    level: type === "text-delta" || type === "reasoning-delta" ? 2 : 1,
+    auxiliary: {
+      type: { value: type, type: "string" },
+      ...(summary.detail && { detail: { value: summary.detail, type: "string" } }),
+    },
+  });
+}
+
+export function summarizeMastraEvent(event: MastraEvent): {
+  message: string;
+  detail?: string;
+} {
+  const type = String(event.type ?? "unknown");
+  const payload = isRecord(event.payload) ? event.payload : {};
+  const toolName = typeof payload.toolName === "string" ? payload.toolName : "tool";
+  if (type === "tool-call") {
+    const args = safeJson(payload.args) ?? "{}";
+    return { message: `tool: ${toolName} ${clip(args, 500)}`, detail: args };
+  }
+  if (type === "tool-result") {
+    const text = flattenMcpResult(payload.result);
+    return { message: `tool result: ${toolName} ${clip(text, 500)}`, detail: text };
+  }
+  if (type === "tool-error") {
+    const message = stringifyError(payload.error) || "tool error";
+    return { message: `tool error: ${toolName} ${clip(message, 500)}`, detail: message };
+  }
+  if (type === "text-delta" && typeof payload.text === "string") {
+    return { message: `assistant: ${clip(payload.text, 500)}`, detail: payload.text };
+  }
+  if (type === "reasoning-delta" && typeof payload.text === "string") {
+    return { message: `reasoning: ${clip(payload.text, 500)}`, detail: payload.text };
+  }
+  if (type === "finish") {
+    const stepResult = isRecord(payload.stepResult) ? payload.stepResult : undefined;
+    const reason = String(stepResult?.reason ?? "unknown");
+    const output = isRecord(payload.output) ? payload.output : undefined;
+    return { message: `finish: ${reason}`, detail: safeJson(output?.usage) };
+  }
+  if (type === "error") {
+    const message = stringifyError(payload.error) || "error";
+    return { message: `error: ${clip(message, 500)}`, detail: message };
+  }
+  return { message: `${type} event`, detail: safeJson(event) };
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export function safeJson(value: unknown): string | undefined {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return undefined;
+  }
+}
+
+export function stringifyError(value: unknown): string {
+  if (!value) return "";
+  if (value instanceof Error) return value.message;
+  if (typeof value === "string") return value;
+  if (isRecord(value) && typeof value.message === "string") return value.message;
+  return safeJson(value) ?? String(value);
+}
+
+export function clip(value: string, maxLength: number): string {
+  return value.length <= maxLength ? value : `${value.slice(0, maxLength - 1)}…`;
+}
+
+export function toFiniteNumber(value: unknown): number {
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim()
+        ? Number(value)
+        : 0;
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function positiveInteger(value: unknown, fallback: number): number {
+  return positiveIntegerOrUndefined(value) ?? fallback;
+}
+
+function positiveIntegerOrUndefined(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.max(1, Math.floor(value))
+    : undefined;
+}
+
+function flattenMcpResult(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (isRecord(value) && Array.isArray(value.content)) {
+    return value.content
+      .map((block) => {
+        if (!isRecord(block)) return "";
+        if (block.type === "text" && typeof block.text === "string") return block.text;
+        if (block.type === "image") return "[image]";
+        return typeof block.text === "string" ? block.text : "";
+      })
+      .filter(Boolean)
+      .join("\n");
+  }
+  return safeJson(value) ?? String(value ?? "");
+}
+
+function addTokenUsage(left: MastraTokenUsage, right: MastraTokenUsage): MastraTokenUsage {
+  return {
+    inputTokens: left.inputTokens + right.inputTokens,
+    outputTokens: left.outputTokens + right.outputTokens,
+    reasoningTokens: left.reasoningTokens + right.reasoningTokens,
+    cachedInputTokens: left.cachedInputTokens + right.cachedInputTokens,
+    totalTokens: left.totalTokens + right.totalTokens,
+  };
+}
+
+function isEmptyTokenUsage(usage: MastraTokenUsage): boolean {
+  return Object.values(usage).every((value) => value === 0);
+}

--- a/packages/integrations/mastra-sdk/src/session.ts
+++ b/packages/integrations/mastra-sdk/src/session.ts
@@ -236,6 +236,11 @@ export async function runMastraSession(input: {
           stopReason = sanitizeErrorMessage(stringifyError(input.signal?.reason) || "aborted");
         }
       }
+      if (controller.signal.aborted && !stopReason) {
+        stopReason = sanitizeErrorMessage(
+          stringifyError(controller.signal.reason) || "Mastra session aborted",
+        );
+      }
       finalText = textBuffer;
       if (!finalText && stream.text) {
         try {
@@ -291,7 +296,7 @@ export async function runMastraSession(input: {
   if (status === "max_turns") stopReason ??= `step budget exhausted (${maxSteps} steps)`;
   return {
     events,
-    finalText,
+    finalText: sanitizeErrorMessage(finalText),
     status,
     ...(stopReason && { stopReason: sanitizeErrorMessage(stopReason) }),
     ...(finishReason && { finishReason }),

--- a/packages/integrations/mastra-sdk/src/session.ts
+++ b/packages/integrations/mastra-sdk/src/session.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import {
   HarnessAdapterError,
   sanitizeErrorMessage,
@@ -58,6 +59,7 @@ export type MastraSessionConfig = {
   agentName?: string;
   modelSettings?: Record<string, unknown>;
   mcpTimeoutMs?: number;
+  disconnectTimeoutMs?: number;
 };
 
 export type MastraTokenUsage = {
@@ -134,6 +136,7 @@ export async function runMastraSession(input: {
   const sdk = input.sdk ?? (await loadMastraSdk());
   const events: MastraEvent[] = [];
   const maxSteps = positiveInteger(input.session.maxSteps, 50);
+  const disconnectTimeoutMs = positiveInteger(input.session.disconnectTimeoutMs, 30_000);
   const controller = new AbortController();
   const forwardAbort = (): void => controller.abort(input.signal?.reason);
   if (input.signal) {
@@ -161,21 +164,27 @@ export async function runMastraSession(input: {
         ]),
       );
       client = sdk.createMcpClient({
-        id: "stagehand-evals-mastra",
+        id: `stagehand-evals-mastra-${randomUUID()}`,
         servers,
         ...(positiveIntegerOrUndefined(input.session.mcpTimeoutMs) && {
           timeout: positiveIntegerOrUndefined(input.session.mcpTimeoutMs),
         }),
       });
-      const discovery = await client.listToolsWithErrors();
-      if (Object.keys(discovery.errors).length > 0) {
+      let discovery: { tools: Record<string, unknown>; errors: Record<string, string> } | undefined;
+      try {
+        discovery = await raceAbort(client.listToolsWithErrors(), controller.signal);
+      } catch (error) {
+        if (!controller.signal.aborted) throw error;
+        stopReason = sanitizeErrorMessage(stringifyError(controller.signal.reason) || "aborted");
+      }
+      if (discovery && Object.keys(discovery.errors).length > 0) {
         stopReason = sanitizeErrorMessage(
           `MCP server discovery failed: ${Object.entries(discovery.errors)
             .map(([server, error]) => `${server}: ${error}`)
             .join("; ")}`,
         );
         input.logger.warn({ category: "mastra", message: stopReason, level: 0 });
-      } else {
+      } else if (discovery) {
         mcpTools = discovery.tools;
       }
     }
@@ -251,11 +260,18 @@ export async function runMastraSession(input: {
     input.signal?.removeEventListener("abort", forwardAbort);
     if (client) {
       try {
-        await client.disconnect();
+        await withTimeout(
+          client.disconnect(),
+          disconnectTimeoutMs,
+          `Mastra MCP disconnect timed out after ${disconnectTimeoutMs}ms`,
+        );
       } catch (error) {
+        const detail = sanitizeErrorMessage(stringifyError(error));
         input.logger.warn({
           category: "mastra",
-          message: `Mastra MCP disconnect failed: ${sanitizeErrorMessage(stringifyError(error))}`,
+          message: detail.startsWith("Mastra MCP disconnect timed out")
+            ? detail
+            : `Mastra MCP disconnect failed: ${detail}`,
           level: 1,
         });
       }
@@ -348,33 +364,33 @@ export function summarizeMastraEvent(event: MastraEvent): {
   const toolName = typeof payload.toolName === "string" ? payload.toolName : "tool";
   if (type === "tool-call") {
     const args = safeJson(payload.args) ?? "{}";
-    return { message: `tool: ${toolName} ${clip(args, 500)}`, detail: args };
+    return sanitizeMastraSummary(`tool: ${toolName} ${clip(args, 500)}`, args);
   }
   if (type === "tool-result") {
     const text = flattenMcpResult(payload.result);
-    return { message: `tool result: ${toolName} ${clip(text, 500)}`, detail: text };
+    return sanitizeMastraSummary(`tool result: ${toolName} ${clip(text, 500)}`, text);
   }
   if (type === "tool-error") {
     const message = stringifyError(payload.error) || "tool error";
-    return { message: `tool error: ${toolName} ${clip(message, 500)}`, detail: message };
+    return sanitizeMastraSummary(`tool error: ${toolName} ${clip(message, 500)}`, message);
   }
   if (type === "text-delta" && typeof payload.text === "string") {
-    return { message: `assistant: ${clip(payload.text, 500)}`, detail: payload.text };
+    return sanitizeMastraSummary(`assistant: ${clip(payload.text, 500)}`, payload.text);
   }
   if (type === "reasoning-delta" && typeof payload.text === "string") {
-    return { message: `reasoning: ${clip(payload.text, 500)}`, detail: payload.text };
+    return sanitizeMastraSummary(`reasoning: ${clip(payload.text, 500)}`, payload.text);
   }
   if (type === "finish") {
     const stepResult = isRecord(payload.stepResult) ? payload.stepResult : undefined;
     const reason = String(stepResult?.reason ?? "unknown");
     const output = isRecord(payload.output) ? payload.output : undefined;
-    return { message: `finish: ${reason}`, detail: safeJson(output?.usage) };
+    return sanitizeMastraSummary(`finish: ${reason}`, safeJson(output?.usage));
   }
   if (type === "error") {
     const message = stringifyError(payload.error) || "error";
-    return { message: `error: ${clip(message, 500)}`, detail: message };
+    return sanitizeMastraSummary(`error: ${clip(message, 500)}`, message);
   }
-  return { message: `${type} event`, detail: safeJson(event) };
+  return sanitizeMastraSummary(`${type} event`, safeJson(event));
 }
 
 export function isRecord(value: unknown): value is Record<string, unknown> {
@@ -419,6 +435,54 @@ function positiveIntegerOrUndefined(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) && value > 0
     ? Math.max(1, Math.floor(value))
     : undefined;
+}
+
+function sanitizeMastraSummary(
+  message: string,
+  detail?: string,
+): { message: string; detail?: string } {
+  return {
+    message: sanitizeErrorMessage(message),
+    ...(detail !== undefined && { detail: sanitizeErrorMessage(detail) }),
+  };
+}
+
+function raceAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  void promise.catch((): undefined => undefined);
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = (): void => reject(signal.reason ?? new Error("aborted"));
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
 }
 
 function flattenMcpResult(value: unknown): string {

--- a/packages/integrations/mastra-sdk/src/session.ts
+++ b/packages/integrations/mastra-sdk/src/session.ts
@@ -178,12 +178,15 @@ export async function runMastraSession(input: {
         stopReason = sanitizeErrorMessage(stringifyError(controller.signal.reason) || "aborted");
       }
       if (discovery && Object.keys(discovery.errors).length > 0) {
-        stopReason = sanitizeErrorMessage(
-          `MCP server discovery failed: ${Object.entries(discovery.errors)
-            .map(([server, error]) => `${server}: ${error}`)
-            .join("; ")}`,
-        );
-        input.logger.warn({ category: "mastra", message: stopReason, level: 0 });
+        const failedServers = Object.keys(discovery.errors);
+        stopReason = `MCP server discovery failed for: ${failedServers.join(", ")}`;
+        for (const [server, error] of Object.entries(discovery.errors)) {
+          input.logger.warn({
+            category: "mastra",
+            message: `MCP server discovery error for ${server}: ${sanitizeErrorMessage(error)}`,
+            level: 1,
+          });
+        }
       } else if (discovery) {
         mcpTools = discovery.tools;
       }

--- a/packages/integrations/mastra-sdk/tests/mastraMcpClientIds.test.ts
+++ b/packages/integrations/mastra-sdk/tests/mastraMcpClientIds.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+import { loadMastraSdk, runMastraSession, type MastraSdk } from "../src/index.js";
+
+const logger = { log: () => {}, warn: () => {}, error: () => {} };
+
+function stdioServer(port: string) {
+  return {
+    stagehand: {
+      command: "node",
+      args: ["-e", "setTimeout(()=>{}, 1e6)"],
+      env: { PORT: port },
+    },
+  };
+}
+
+describe("Mastra MCP client IDs", () => {
+  it("uses unique session IDs that do not disconnect another real client", async () => {
+    const ids: string[] = [];
+    const sdk: MastraSdk = {
+      createAgent: () => ({
+        stream: async () => ({
+          fullStream: (async function* () {})(),
+        }),
+      }),
+      createMcpClient: (options) => {
+        if (options.id) ids.push(options.id);
+        return {
+          listToolsWithErrors: async () => ({ tools: {}, errors: {} }),
+          disconnect: async () => {},
+        };
+      },
+      createTool: (options) => options,
+    };
+
+    for (const port of ["50001", "50002"]) {
+      await runMastraSession({
+        prompt: "task",
+        model: "openai/gpt-5.4-mini",
+        logger,
+        sdk,
+        session: { mcpServers: stdioServer(port) },
+      });
+    }
+
+    expect(ids).toHaveLength(2);
+    expect(ids[0]).toMatch(/^stagehand-evals-mastra-/);
+    expect(ids[1]).toMatch(/^stagehand-evals-mastra-/);
+    expect(ids[0]).not.toBe(ids[1]);
+    const [firstId, secondId] = ids;
+    if (!firstId || !secondId) throw new Error("expected two MCP client IDs");
+
+    // Construct REAL @mastra/mcp MCPClient instances through the production
+    // loader. @mastra/mcp caches live clients by id and disconnects a cached
+    // client when a new one reuses its id with different server configs, so
+    // the per-session ids must keep concurrent rows from tearing each other down.
+    const real = await loadMastraSdk();
+    const first = real.createMcpClient({ id: firstId, servers: stdioServer("50001") });
+    const disconnect = vi.spyOn(first, "disconnect");
+    let second: ReturnType<MastraSdk["createMcpClient"]> | undefined;
+    try {
+      second = real.createMcpClient({ id: secondId, servers: stdioServer("50002") });
+      expect(disconnect).not.toHaveBeenCalled();
+      expect(second).not.toBe(first);
+    } finally {
+      disconnect.mockRestore();
+      await Promise.all([first.disconnect(), second?.disconnect()]);
+    }
+  });
+});

--- a/packages/integrations/mastra-sdk/tests/session.test.ts
+++ b/packages/integrations/mastra-sdk/tests/session.test.ts
@@ -1,0 +1,250 @@
+/* eslint-disable require-yield */
+import { describe, expect, it, vi } from "vitest";
+import {
+  normalizeMastraModel,
+  runMastraSession,
+  type MastraEvent,
+  type MastraSdk,
+} from "../src/index.js";
+
+const logger = { log: () => {}, warn: () => {}, error: () => {} };
+
+function streamEvents(events: MastraEvent[]): AsyncIterable<MastraEvent> {
+  return (async function* () {
+    yield* events;
+  })();
+}
+
+function fakeSdk(
+  input: {
+    events?: MastraEvent[];
+    streamError?: Error;
+    discoveryErrors?: Record<string, string>;
+    agentConfig?: (config: Record<string, unknown>) => void;
+    streamOptions?: (options: Record<string, unknown> | undefined) => void;
+    servers?: (servers: Record<string, unknown>) => void;
+    disconnect?: () => void;
+    createAgent?: () => void;
+  } = {},
+): MastraSdk {
+  return {
+    createAgent: (config) => {
+      input.createAgent?.();
+      input.agentConfig?.(config);
+      return {
+        stream: async (_prompt, options) => {
+          input.streamOptions?.(options);
+          if (input.streamError) throw input.streamError;
+          return {
+            fullStream: streamEvents(input.events ?? []),
+            text: Promise.resolve("fallback text"),
+          };
+        },
+      };
+    },
+    createMcpClient: (options) => {
+      input.servers?.(options.servers);
+      return {
+        listToolsWithErrors: async () => ({
+          tools: { stagehand_run: { id: "run" } },
+          errors: input.discoveryErrors ?? {},
+        }),
+        disconnect: async () => input.disconnect?.(),
+      };
+    },
+    createTool: (options) => options,
+  };
+}
+
+describe("Mastra SDK session", () => {
+  it("normalizes provider-prefixed, bare, and default models", () => {
+    expect(normalizeMastraModel("anthropic/claude-sonnet-4-6")).toBe("anthropic/claude-sonnet-4-6");
+    expect(normalizeMastraModel("gpt-5.4")).toBe("openai/gpt-5.4");
+    expect(normalizeMastraModel("mastra/default")).toBe("openai/gpt-5.4-mini");
+  });
+
+  it("forwards agent and stream options and merges MCP tools", async () => {
+    let agentConfig: Record<string, unknown> | undefined;
+    let streamOptions: Record<string, unknown> | undefined;
+    let servers: Record<string, unknown> | undefined;
+    const signal = new AbortController().signal;
+    await runMastraSession({
+      prompt: "task",
+      model: "anthropic/claude-sonnet-4-6",
+      logger,
+      signal,
+      sdk: fakeSdk({
+        agentConfig: (value) => (agentConfig = value),
+        streamOptions: (value) => (streamOptions = value),
+        servers: (value) => (servers = value),
+      }),
+      session: {
+        instructions: "Use the browser.",
+        maxSteps: 7,
+        mcpServers: { stagehand: { command: "node" } },
+        tools: { local: { id: "local" } },
+      },
+    });
+    expect(agentConfig).toMatchObject({
+      model: "anthropic/claude-sonnet-4-6",
+      instructions: "Use the browser.",
+      tools: { stagehand_run: { id: "run" }, local: { id: "local" } },
+    });
+    expect(streamOptions).toMatchObject({ maxSteps: 7 });
+    expect(streamOptions?.abortSignal).toBeInstanceOf(AbortSignal);
+    expect(servers?.stagehand).toMatchObject({ command: "node", onToolError: "return" });
+  });
+
+  it("collects final text after the last tool call and finish usage", async () => {
+    const result = await runMastraSession({
+      prompt: "task",
+      model: "gpt-5.4-mini",
+      logger,
+      sdk: fakeSdk({
+        events: [
+          { type: "text-delta", payload: { text: "planning" } },
+          {
+            type: "tool-call",
+            payload: { toolCallId: "1", toolName: "stagehand_run", args: {} },
+          },
+          { type: "text-delta", payload: { text: "final " } },
+          { type: "text-delta", payload: { text: "answer" } },
+          { type: "step-finish", payload: { output: { usage: {} } } },
+          {
+            type: "finish",
+            payload: {
+              stepResult: { reason: "stop" },
+              output: {
+                usage: {
+                  inputTokens: 100,
+                  outputTokens: 25,
+                  reasoningTokens: 5,
+                  cachedInputTokens: 10,
+                },
+              },
+            },
+          },
+        ],
+      }),
+      session: {},
+    });
+    expect(result.events).toHaveLength(6);
+    expect(result.finalText).toBe("final answer");
+    expect(result.finishReason).toBe("stop");
+    expect(result.stepCount).toBe(1);
+    expect(result.tokenUsage).toEqual({
+      inputTokens: 100,
+      outputTokens: 25,
+      reasoningTokens: 5,
+      cachedInputTokens: 10,
+      totalTokens: 125,
+    });
+  });
+
+  it("notifies for tool results and tool errors", async () => {
+    const observed: string[] = [];
+    await runMastraSession({
+      prompt: "task",
+      model: "gpt-5.4-mini",
+      logger,
+      sdk: fakeSdk({
+        events: [
+          { type: "tool-result", payload: { toolName: "one", result: "ok" } },
+          { type: "tool-error", payload: { toolName: "two", error: "no" } },
+        ],
+      }),
+      session: {},
+      onToolResult: (name) => {
+        observed.push(name);
+      },
+    });
+    expect(observed).toEqual(["one", "two"]);
+  });
+
+  it("returns discovery errors and disconnects without creating an agent", async () => {
+    const disconnect = vi.fn();
+    const createAgent = vi.fn();
+    const result = await runMastraSession({
+      prompt: "task",
+      model: "gpt-5.4-mini",
+      logger,
+      sdk: fakeSdk({
+        discoveryErrors: { stagehand: "not found" },
+        disconnect,
+        createAgent,
+      }),
+      session: { mcpServers: { stagehand: { command: "node" } } },
+    });
+    expect(result.status).toBe("sdk_error");
+    expect(result.stopReason).toContain("stagehand");
+    expect(result.events).toEqual([]);
+    expect(disconnect).toHaveBeenCalledOnce();
+    expect(createAgent).not.toHaveBeenCalled();
+  });
+
+  it("reports stream exceptions and still disconnects", async () => {
+    const disconnect = vi.fn();
+    const result = await runMastraSession({
+      prompt: "task",
+      model: "gpt-5.4-mini",
+      logger,
+      sdk: fakeSdk({ streamError: new Error("stream failed"), disconnect }),
+      session: { mcpServers: { stagehand: { command: "node" } } },
+    });
+    expect(result.status).toBe("sdk_error");
+    expect(String(result.iterationError)).toContain("stream failed");
+    expect(disconnect).toHaveBeenCalledOnce();
+  });
+
+  it("maps a tool-calls finish reason to max_turns", async () => {
+    const result = await runMastraSession({
+      prompt: "task",
+      model: "gpt-5.4-mini",
+      logger,
+      sdk: fakeSdk({
+        events: [
+          {
+            type: "finish",
+            payload: { stepResult: { reason: "tool-calls" }, output: { usage: {} } },
+          },
+        ],
+      }),
+      session: {},
+    });
+    expect(result.status).toBe("max_turns");
+    expect(result.stopReason).toContain("step budget exhausted");
+  });
+
+  it("sanitizes error chunks", async () => {
+    const secret = "sk-abcdefghijklmnopqrstuvwxyz123456";
+    const result = await runMastraSession({
+      prompt: "task",
+      model: "gpt-5.4-mini",
+      logger,
+      sdk: fakeSdk({
+        events: [{ type: "error", payload: { error: `bad key ${secret}` } }],
+      }),
+      session: {},
+    });
+    expect(result.status).toBe("sdk_error");
+    expect(result.stopReason).not.toContain(secret);
+  });
+
+  it("forwards external aborts", async () => {
+    const caller = new AbortController();
+    let streamSignal: AbortSignal | undefined;
+    const pending = runMastraSession({
+      prompt: "task",
+      model: "gpt-5.4-mini",
+      logger,
+      signal: caller.signal,
+      sdk: fakeSdk({
+        streamOptions: (options) => (streamSignal = options?.abortSignal as AbortSignal),
+      }),
+      session: {},
+    });
+    caller.abort("stop");
+    await pending;
+    expect(streamSignal?.aborted).toBe(true);
+  });
+});

--- a/packages/integrations/mastra-sdk/tests/session.test.ts
+++ b/packages/integrations/mastra-sdk/tests/session.test.ts
@@ -288,6 +288,25 @@ describe("Mastra SDK session", () => {
     }
   });
 
+  it("sanitizes the returned final text", async () => {
+    const result = await runMastraSession({
+      prompt: "task",
+      model: "gpt-5.4-mini",
+      logger,
+      sdk: fakeSdk({
+        events: [
+          {
+            type: "text-delta",
+            payload: { text: "done https://x.test?apiKey=secret123" },
+          },
+        ],
+      }),
+      session: {},
+    });
+
+    expect(result.finalText).toBe("done https://x.test?apiKey=[redacted]");
+  });
+
   it("aborts MCP discovery and disconnects without creating an agent", async () => {
     const caller = new AbortController();
     caller.abort("cancelled");
@@ -341,7 +360,9 @@ describe("Mastra SDK session", () => {
       session: {},
     });
     caller.abort("stop");
-    await pending;
+    const result = await pending;
     expect(streamSignal?.aborted).toBe(true);
+    expect(result.status).toBe("sdk_error");
+    expect(result.stopReason).toBe("stop");
   });
 });

--- a/packages/integrations/mastra-sdk/tests/session.test.ts
+++ b/packages/integrations/mastra-sdk/tests/session.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable require-yield */
 import { describe, expect, it, vi } from "vitest";
 import {
+  buildMastraTranscript,
   normalizeMastraModel,
   runMastraSession,
   type MastraEvent,
@@ -23,7 +24,11 @@ function fakeSdk(
     agentConfig?: (config: Record<string, unknown>) => void;
     streamOptions?: (options: Record<string, unknown> | undefined) => void;
     servers?: (servers: Record<string, unknown>) => void;
-    disconnect?: () => void;
+    listToolsWithErrors?: () => Promise<{
+      tools: Record<string, unknown>;
+      errors: Record<string, string>;
+    }>;
+    disconnect?: () => void | Promise<void>;
     createAgent?: () => void;
   } = {},
 ): MastraSdk {
@@ -45,10 +50,12 @@ function fakeSdk(
     createMcpClient: (options) => {
       input.servers?.(options.servers);
       return {
-        listToolsWithErrors: async () => ({
-          tools: { stagehand_run: { id: "run" } },
-          errors: input.discoveryErrors ?? {},
-        }),
+        listToolsWithErrors:
+          input.listToolsWithErrors ??
+          (async () => ({
+            tools: { stagehand_run: { id: "run" } },
+            errors: input.discoveryErrors ?? {},
+          })),
         disconnect: async () => input.disconnect?.(),
       };
     },
@@ -215,19 +222,83 @@ describe("Mastra SDK session", () => {
     expect(result.stopReason).toContain("step budget exhausted");
   });
 
-  it("sanitizes error chunks", async () => {
-    const secret = "sk-abcdefghijklmnopqrstuvwxyz123456";
+  it("sanitizes event transcripts and logs", async () => {
+    const secrets = [
+      "sk-abcdefghijklmnopqrstuvwxyz123456",
+      "bb_live_ABCDEFGHIJKLMNOP",
+      "secret123",
+    ];
+    const log = vi.fn();
+    const result = await runMastraSession({
+      prompt: "task",
+      model: "gpt-5.4-mini",
+      logger: { ...logger, log },
+      sdk: fakeSdk({
+        events: [
+          {
+            type: "tool-call",
+            payload: { toolName: "fill", args: { value: secrets[0] } },
+          },
+          {
+            type: "tool-result",
+            payload: {
+              toolName: "fill",
+              result: { content: [{ type: "text", text: secrets[1] }] },
+            },
+          },
+          {
+            type: "tool-error",
+            payload: { toolName: "fill", error: `failed?apiKey=${secrets[2]}` },
+          },
+        ],
+      }),
+      session: {},
+    });
+    const logged = JSON.stringify(log.mock.calls);
+    const sanitizedTranscript = buildMastraTranscript(result.events);
+    for (const secret of secrets) {
+      expect(sanitizedTranscript).not.toContain(secret);
+      expect(logged).not.toContain(secret);
+    }
+  });
+
+  it("aborts MCP discovery and disconnects without creating an agent", async () => {
+    const caller = new AbortController();
+    caller.abort("cancelled");
+    const disconnect = vi.fn();
+    const createAgent = vi.fn();
     const result = await runMastraSession({
       prompt: "task",
       model: "gpt-5.4-mini",
       logger,
+      signal: caller.signal,
       sdk: fakeSdk({
-        events: [{ type: "error", payload: { error: `bad key ${secret}` } }],
+        listToolsWithErrors: () => new Promise(() => {}),
+        disconnect,
+        createAgent,
       }),
-      session: {},
+      session: { mcpServers: { stagehand: { command: "node" } } },
     });
     expect(result.status).toBe("sdk_error");
-    expect(result.stopReason).not.toContain(secret);
+    expect(result.stopReason).toContain("cancelled");
+    expect(createAgent).not.toHaveBeenCalled();
+    expect(disconnect).toHaveBeenCalledOnce();
+  });
+
+  it("bounds MCP disconnect and returns after a timeout", async () => {
+    const warn = vi.fn();
+    const result = await runMastraSession({
+      prompt: "task",
+      model: "gpt-5.4-mini",
+      logger: { ...logger, warn },
+      sdk: fakeSdk({ disconnect: () => new Promise(() => {}) }),
+      session: {
+        mcpServers: { stagehand: { command: "node" } },
+        disconnectTimeoutMs: 20,
+      },
+    });
+    expect(result.status).toBe("completed");
+    expect(JSON.stringify(warn.mock.calls)).toContain("disconnect timed out after 20ms");
   });
 
   it("forwards external aborts", async () => {

--- a/packages/integrations/mastra-sdk/tests/session.test.ts
+++ b/packages/integrations/mastra-sdk/tests/session.test.ts
@@ -171,19 +171,45 @@ describe("Mastra SDK session", () => {
   it("returns discovery errors and disconnects without creating an agent", async () => {
     const disconnect = vi.fn();
     const createAgent = vi.fn();
+    const warn = vi.fn();
     const result = await runMastraSession({
       prompt: "task",
       model: "gpt-5.4-mini",
-      logger,
+      logger: { ...logger, warn },
       sdk: fakeSdk({
-        discoveryErrors: { stagehand: "not found" },
+        discoveryErrors: {
+          stagehand: "not found?apiKey=secret123",
+          playwright: "connection refused",
+        },
         disconnect,
         createAgent,
       }),
-      session: { mcpServers: { stagehand: { command: "node" } } },
+      session: {
+        mcpServers: {
+          stagehand: { command: "node" },
+          playwright: { command: "node" },
+        },
+      },
     });
     expect(result.status).toBe("sdk_error");
-    expect(result.stopReason).toContain("stagehand");
+    expect(result.stopReason).toBe("MCP server discovery failed for: stagehand, playwright");
+    expect(result.stopReason).not.toContain("secret123");
+    expect(warn.mock.calls).toEqual([
+      [
+        {
+          category: "mastra",
+          message: "MCP server discovery error for stagehand: not found?apiKey=[redacted]",
+          level: 1,
+        },
+      ],
+      [
+        {
+          category: "mastra",
+          message: "MCP server discovery error for playwright: connection refused",
+          level: 1,
+        },
+      ],
+    ]);
     expect(result.events).toEqual([]);
     expect(disconnect).toHaveBeenCalledOnce();
     expect(createAgent).not.toHaveBeenCalled();

--- a/packages/integrations/mastra-sdk/tsconfig.json
+++ b/packages/integrations/mastra-sdk/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "types": ["node"],
+    "rootDir": ".",
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts", "vitest.config.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/integrations/mastra-sdk/tsdown.config.ts
+++ b/packages/integrations/mastra-sdk/tsdown.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: {
+    index: "src/index.ts",
+  },
+  format: ["esm"],
+  platform: "node",
+  target: "node22",
+  dts: {
+    sourcemap: true,
+  },
+  sourcemap: true,
+  outDir: "dist",
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,202 +1,3 @@
----
-lockfileVersion: '9.0'
-
-importers:
-
-  .:
-    configDependencies: {}
-    packageManagerDependencies:
-      '@pnpm/exe':
-        specifier: 11.10.0
-        version: 11.10.0
-      pnpm:
-        specifier: 11.10.0
-        version: 11.10.0
-
-packages:
-
-  '@pnpm/exe@11.10.0':
-    resolution: {integrity: sha512-mrmfi2C7LpZkyq0voKKye6MzrK8/K7tYQRiSB/jqOiwnFtQxxcA3xGTY9cEsrGpNl2ClPecQofLuj+BO8AIsxw==}
-    hasBin: true
-
-  '@pnpm/linux-arm64@11.10.0':
-    resolution: {integrity: sha512-NbvDeUfs0SJuli9OPvgVvmnlbo2DvJ861XGXKrzgLu5AuTnLDLXgbZEEUd8mJ5I0YNrqOVXSWVfWEqiAazWzPA==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@pnpm/linux-x64@11.10.0':
-    resolution: {integrity: sha512-kdgb8BXZ/3XQ0x2cOmgLmsij7+SUIqd1bcV6OZhdGzQiDrOY6FAPrR+Y2Bp+NjrrhjzMHVm5pZrrmdeC67ymSQ==}
-    cpu: [x64]
-    os: [linux]
-
-  '@pnpm/linuxstatic-arm64@11.10.0':
-    resolution: {integrity: sha512-JE1WrSyKGvqGQgWzqrMXn//ehedpiRax3hi1oP+v6mhvcnlJD1lpfXsjSfIFl9weTWC5KVtFbxSNKbKWfP+v6g==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@pnpm/linuxstatic-x64@11.10.0':
-    resolution: {integrity: sha512-1TBZVRkWb78GnsusIfVgwz20MOOW0fyehW+qLL3MxE9vT0IedNWsAhe3KWXgEvtC4M7NtMt55uQQJm+1egwBkA==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@pnpm/macos-arm64@11.10.0':
-    resolution: {integrity: sha512-94AVpPixBqyNT6SHYvIKFb1bfaHR5vxBzZsiFJahNSlGkgyPrgzmcqDiloZ/Jl+zxJd8L5PU1ddP0Q9PZnRqlA==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@pnpm/win-arm64@11.10.0':
-    resolution: {integrity: sha512-g2Ymnq+LgVyZaWsGBQSlpIcBCOOxyLky2UX+kTwGiIXnj6k/xXqZR0ZJLuxeiGNh/CVmhftOqokpyJNzyj8kng==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@pnpm/win-x64@11.10.0':
-    resolution: {integrity: sha512-kCHYZudUEBjrEchgnJUnNHCdvLXpUZun2z0rMAeP5DymsaXwEVvVzGj220iR/NyhgDocJUmgtTKtwL/ejL785Q==}
-    cpu: [x64]
-    os: [win32]
-
-  '@reflink/reflink-darwin-arm64@0.1.19':
-    resolution: {integrity: sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@reflink/reflink-darwin-x64@0.1.19':
-    resolution: {integrity: sha512-By85MSWrMZa+c26TcnAy8SDk0sTUkYlNnwknSchkhHpGXOtjNDUOxJE9oByBnGbeuIE1PiQsxDG3Ud+IVV9yuA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@reflink/reflink-linux-arm64-gnu@0.1.19':
-    resolution: {integrity: sha512-7P+er8+rP9iNeN+bfmccM4hTAaLP6PQJPKWSA4iSk2bNvo6KU6RyPgYeHxXmzNKzPVRcypZQTpFgstHam6maVg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@reflink/reflink-linux-arm64-musl@0.1.19':
-    resolution: {integrity: sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@reflink/reflink-linux-x64-gnu@0.1.19':
-    resolution: {integrity: sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@reflink/reflink-linux-x64-musl@0.1.19':
-    resolution: {integrity: sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@reflink/reflink-win32-arm64-msvc@0.1.19':
-    resolution: {integrity: sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@reflink/reflink-win32-x64-msvc@0.1.19':
-    resolution: {integrity: sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-
-  '@reflink/reflink@0.1.19':
-    resolution: {integrity: sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==}
-    engines: {node: '>= 10'}
-
-  detect-libc@2.1.2:
-    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
-    engines: {node: '>=8'}
-
-  pnpm@11.10.0:
-    resolution: {integrity: sha512-C3+LmAYAMZBMAX46QesYehbUDuuCm5XE+MsDaBdh/Eq1PdIZEVubRH9NzhoFohR2RGHn03AzkqnzL5URzoyGyA==}
-    engines: {node: '>=22.13'}
-    hasBin: true
-
-snapshots:
-
-  '@pnpm/exe@11.10.0':
-    dependencies:
-      '@reflink/reflink': 0.1.19
-      detect-libc: 2.1.2
-    optionalDependencies:
-      '@pnpm/linux-arm64': 11.10.0
-      '@pnpm/linux-x64': 11.10.0
-      '@pnpm/linuxstatic-arm64': 11.10.0
-      '@pnpm/linuxstatic-x64': 11.10.0
-      '@pnpm/macos-arm64': 11.10.0
-      '@pnpm/win-arm64': 11.10.0
-      '@pnpm/win-x64': 11.10.0
-
-  '@pnpm/linux-arm64@11.10.0':
-    optional: true
-
-  '@pnpm/linux-x64@11.10.0':
-    optional: true
-
-  '@pnpm/linuxstatic-arm64@11.10.0':
-    optional: true
-
-  '@pnpm/linuxstatic-x64@11.10.0':
-    optional: true
-
-  '@pnpm/macos-arm64@11.10.0':
-    optional: true
-
-  '@pnpm/win-arm64@11.10.0':
-    optional: true
-
-  '@pnpm/win-x64@11.10.0':
-    optional: true
-
-  '@reflink/reflink-darwin-arm64@0.1.19':
-    optional: true
-
-  '@reflink/reflink-darwin-x64@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-arm64-gnu@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-arm64-musl@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-x64-gnu@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-x64-musl@0.1.19':
-    optional: true
-
-  '@reflink/reflink-win32-arm64-msvc@0.1.19':
-    optional: true
-
-  '@reflink/reflink-win32-x64-msvc@0.1.19':
-    optional: true
-
-  '@reflink/reflink@0.1.19':
-    optionalDependencies:
-      '@reflink/reflink-darwin-arm64': 0.1.19
-      '@reflink/reflink-darwin-x64': 0.1.19
-      '@reflink/reflink-linux-arm64-gnu': 0.1.19
-      '@reflink/reflink-linux-arm64-musl': 0.1.19
-      '@reflink/reflink-linux-x64-gnu': 0.1.19
-      '@reflink/reflink-linux-x64-musl': 0.1.19
-      '@reflink/reflink-win32-arm64-msvc': 0.1.19
-      '@reflink/reflink-win32-x64-msvc': 0.1.19
-
-  detect-libc@2.1.2: {}
-
-  pnpm@11.10.0: {}
-
----
 lockfileVersion: '9.0'
 
 settings:
@@ -440,7 +241,7 @@ importers:
         version: 3.1.1
       mint:
         specifier: 'catalog:'
-        version: 4.2.788(@base-ui/react@1.7.0(@types/react@19.2.17)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/node@24.13.2)(@types/react@19.2.17)(bufferutil@4.1.0)(react-dom@18.3.1(react@19.2.3))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 4.2.788(@base-ui/react@1.7.0(@types/react@19.2.17)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/node@25.9.4)(@types/react@19.2.17)(bufferutil@4.1.0)(react-dom@18.3.1(react@19.2.3))(typescript@5.9.3)
 
   packages/evals:
     dependencies:
@@ -468,6 +269,9 @@ importers:
       '@browserbasehq/stagehand-integrations-codex-sdk':
         specifier: workspace:*
         version: link:../integrations/codex-sdk
+      '@browserbasehq/stagehand-integrations-mastra-sdk':
+        specifier: workspace:*
+        version: link:../integrations/mastra-sdk
       '@opentelemetry/api':
         specifier: 'catalog:'
         version: 1.9.1
@@ -765,6 +569,34 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.2
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+
+  packages/integrations/mastra-sdk:
+    dependencies:
+      '@browserbasehq/stagehand-integrations':
+        specifier: workspace:*
+        version: link:../core
+      '@mastra/core':
+        specifier: 'catalog:'
+        version: 1.57.0(ai@7.0.16(zod@4.4.3))(bufferutil@4.1.0)(express@5.2.1)(rxjs@7.8.2)(zod@4.4.3)
+      '@mastra/mcp':
+        specifier: 'catalog:'
+        version: 1.15.1(@mastra/core@1.57.0(ai@7.0.16(zod@4.4.3))(bufferutil@4.1.0)(express@5.2.1)(rxjs@7.8.2)(zod@4.4.3))(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(zod@4.4.3)
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.2
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.3(publint@0.3.21)(tsx@4.23.1)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -9489,51 +9321,51 @@ snapshots:
 
   '@inquirer/ansi@1.0.2': {}
 
-  '@inquirer/checkbox@4.3.2(@types/node@24.13.2)':
+  '@inquirer/checkbox@4.3.2(@types/node@25.9.4)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@24.13.2)
+      '@inquirer/core': 10.3.2(@types/node@25.9.4)
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@24.13.2)
+      '@inquirer/type': 3.0.10(@types/node@25.9.4)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.13.2
+      '@types/node': 25.9.4
 
-  '@inquirer/confirm@5.1.21(@types/node@24.13.2)':
+  '@inquirer/confirm@5.1.21(@types/node@25.9.4)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.13.2)
-      '@inquirer/type': 3.0.10(@types/node@24.13.2)
+      '@inquirer/core': 10.3.2(@types/node@25.9.4)
+      '@inquirer/type': 3.0.10(@types/node@25.9.4)
     optionalDependencies:
-      '@types/node': 24.13.2
+      '@types/node': 25.9.4
 
-  '@inquirer/core@10.3.2(@types/node@24.13.2)':
+  '@inquirer/core@10.3.2(@types/node@25.9.4)':
     dependencies:
       '@inquirer/ansi': 1.0.2
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@24.13.2)
+      '@inquirer/type': 3.0.10(@types/node@25.9.4)
       cli-width: 4.1.0
       mute-stream: 2.0.0
       signal-exit: 4.1.0
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.13.2
+      '@types/node': 25.9.4
 
-  '@inquirer/editor@4.2.23(@types/node@24.13.2)':
+  '@inquirer/editor@4.2.23(@types/node@25.9.4)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.13.2)
-      '@inquirer/external-editor': 1.0.3(@types/node@24.13.2)
-      '@inquirer/type': 3.0.10(@types/node@24.13.2)
+      '@inquirer/core': 10.3.2(@types/node@25.9.4)
+      '@inquirer/external-editor': 1.0.3(@types/node@25.9.4)
+      '@inquirer/type': 3.0.10(@types/node@25.9.4)
     optionalDependencies:
-      '@types/node': 24.13.2
+      '@types/node': 25.9.4
 
-  '@inquirer/expand@4.0.23(@types/node@24.13.2)':
+  '@inquirer/expand@4.0.23(@types/node@25.9.4)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.13.2)
-      '@inquirer/type': 3.0.10(@types/node@24.13.2)
+      '@inquirer/core': 10.3.2(@types/node@25.9.4)
+      '@inquirer/type': 3.0.10(@types/node@25.9.4)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.13.2
+      '@types/node': 25.9.4
 
   '@inquirer/external-editor@1.0.3(@types/node@24.13.2)':
     dependencies:
@@ -9542,75 +9374,82 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.13.2
 
+  '@inquirer/external-editor@1.0.3(@types/node@25.9.4)':
+    dependencies:
+      chardet: 2.2.0
+      iconv-lite: 0.7.3
+    optionalDependencies:
+      '@types/node': 25.9.4
+
   '@inquirer/figures@1.0.15': {}
 
-  '@inquirer/input@4.3.1(@types/node@24.13.2)':
+  '@inquirer/input@4.3.1(@types/node@25.9.4)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.13.2)
-      '@inquirer/type': 3.0.10(@types/node@24.13.2)
+      '@inquirer/core': 10.3.2(@types/node@25.9.4)
+      '@inquirer/type': 3.0.10(@types/node@25.9.4)
     optionalDependencies:
-      '@types/node': 24.13.2
+      '@types/node': 25.9.4
 
-  '@inquirer/number@3.0.23(@types/node@24.13.2)':
+  '@inquirer/number@3.0.23(@types/node@25.9.4)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.13.2)
-      '@inquirer/type': 3.0.10(@types/node@24.13.2)
+      '@inquirer/core': 10.3.2(@types/node@25.9.4)
+      '@inquirer/type': 3.0.10(@types/node@25.9.4)
     optionalDependencies:
-      '@types/node': 24.13.2
+      '@types/node': 25.9.4
 
-  '@inquirer/password@4.0.23(@types/node@24.13.2)':
-    dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@24.13.2)
-      '@inquirer/type': 3.0.10(@types/node@24.13.2)
-    optionalDependencies:
-      '@types/node': 24.13.2
-
-  '@inquirer/prompts@7.9.0(@types/node@24.13.2)':
-    dependencies:
-      '@inquirer/checkbox': 4.3.2(@types/node@24.13.2)
-      '@inquirer/confirm': 5.1.21(@types/node@24.13.2)
-      '@inquirer/editor': 4.2.23(@types/node@24.13.2)
-      '@inquirer/expand': 4.0.23(@types/node@24.13.2)
-      '@inquirer/input': 4.3.1(@types/node@24.13.2)
-      '@inquirer/number': 3.0.23(@types/node@24.13.2)
-      '@inquirer/password': 4.0.23(@types/node@24.13.2)
-      '@inquirer/rawlist': 4.1.11(@types/node@24.13.2)
-      '@inquirer/search': 3.2.2(@types/node@24.13.2)
-      '@inquirer/select': 4.4.2(@types/node@24.13.2)
-    optionalDependencies:
-      '@types/node': 24.13.2
-
-  '@inquirer/rawlist@4.1.11(@types/node@24.13.2)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.13.2)
-      '@inquirer/type': 3.0.10(@types/node@24.13.2)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 24.13.2
-
-  '@inquirer/search@3.2.2(@types/node@24.13.2)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.13.2)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@24.13.2)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 24.13.2
-
-  '@inquirer/select@4.4.2(@types/node@24.13.2)':
+  '@inquirer/password@4.0.23(@types/node@25.9.4)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@24.13.2)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@24.13.2)
+      '@inquirer/core': 10.3.2(@types/node@25.9.4)
+      '@inquirer/type': 3.0.10(@types/node@25.9.4)
+    optionalDependencies:
+      '@types/node': 25.9.4
+
+  '@inquirer/prompts@7.9.0(@types/node@25.9.4)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.2(@types/node@25.9.4)
+      '@inquirer/confirm': 5.1.21(@types/node@25.9.4)
+      '@inquirer/editor': 4.2.23(@types/node@25.9.4)
+      '@inquirer/expand': 4.0.23(@types/node@25.9.4)
+      '@inquirer/input': 4.3.1(@types/node@25.9.4)
+      '@inquirer/number': 3.0.23(@types/node@25.9.4)
+      '@inquirer/password': 4.0.23(@types/node@25.9.4)
+      '@inquirer/rawlist': 4.1.11(@types/node@25.9.4)
+      '@inquirer/search': 3.2.2(@types/node@25.9.4)
+      '@inquirer/select': 4.4.2(@types/node@25.9.4)
+    optionalDependencies:
+      '@types/node': 25.9.4
+
+  '@inquirer/rawlist@4.1.11(@types/node@25.9.4)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@25.9.4)
+      '@inquirer/type': 3.0.10(@types/node@25.9.4)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.13.2
+      '@types/node': 25.9.4
 
-  '@inquirer/type@3.0.10(@types/node@24.13.2)':
+  '@inquirer/search@3.2.2(@types/node@25.9.4)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@25.9.4)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@25.9.4)
+      yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 24.13.2
+      '@types/node': 25.9.4
+
+  '@inquirer/select@4.4.2(@types/node@25.9.4)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@25.9.4)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@25.9.4)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 25.9.4
+
+  '@inquirer/type@3.0.10(@types/node@25.9.4)':
+    optionalDependencies:
+      '@types/node': 25.9.4
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -9830,9 +9669,9 @@ snapshots:
       '@types/react': 19.2.17
       react: 19.2.3
 
-  '@mintlify/cli@4.0.1391(@base-ui/react@1.7.0(@types/react@19.2.17)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/node@24.13.2)(@types/react@19.2.17)(bufferutil@4.1.0)(react-dom@18.3.1(react@19.2.3))(supports-color@8.1.1)(typescript@5.9.3)':
+  '@mintlify/cli@4.0.1391(@base-ui/react@1.7.0(@types/react@19.2.17)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/node@25.9.4)(@types/react@19.2.17)(bufferutil@4.1.0)(react-dom@18.3.1(react@19.2.3))(typescript@5.9.3)':
     dependencies:
-      '@inquirer/prompts': 7.9.0(@types/node@24.13.2)
+      '@inquirer/prompts': 7.9.0(@types/node@25.9.4)
       '@mintlify/common': 1.0.1080(@base-ui/react@1.7.0(@types/react@19.2.17)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       '@mintlify/link-rot': 3.0.1278(@base-ui/react@1.7.0(@types/react@19.2.17)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/react@19.2.17)(bufferutil@4.1.0)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       '@mintlify/models': 0.0.347
@@ -9842,10 +9681,10 @@ snapshots:
       adm-zip: 0.6.0
       chalk: 5.2.0
       color: 4.2.3
-      detect-port: 1.5.1(supports-color@8.1.1)
+      detect-port: 1.5.1
       fs-extra: 11.2.0
       ink: 6.3.0(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.3)
-      inquirer: 12.3.0(@types/node@24.13.2)
+      inquirer: 12.3.0(@types/node@25.9.4)
       js-yaml: 4.3.1
       jsonc-parser: 3.3.1
       mdast-util-mdx-jsx: 3.2.0
@@ -11948,7 +11787,7 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  detect-port@1.5.1(supports-color@8.1.1):
+  detect-port@1.5.1:
     dependencies:
       address: 1.2.2
       debug: 4.4.3(supports-color@8.1.1)
@@ -13222,12 +13061,12 @@ snapshots:
 
   inline-style-parser@0.2.7: {}
 
-  inquirer@12.3.0(@types/node@24.13.2):
+  inquirer@12.3.0(@types/node@25.9.4):
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@24.13.2)
-      '@inquirer/prompts': 7.9.0(@types/node@24.13.2)
-      '@inquirer/type': 3.0.10(@types/node@24.13.2)
-      '@types/node': 24.13.2
+      '@inquirer/core': 10.3.2(@types/node@25.9.4)
+      '@inquirer/prompts': 7.9.0(@types/node@25.9.4)
+      '@inquirer/type': 3.0.10(@types/node@25.9.4)
+      '@types/node': 25.9.4
       ansi-escapes: 4.3.2
       mute-stream: 2.0.0
       run-async: 3.0.0
@@ -14245,9 +14084,9 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  mint@4.2.788(@base-ui/react@1.7.0(@types/react@19.2.17)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/node@24.13.2)(@types/react@19.2.17)(bufferutil@4.1.0)(react-dom@18.3.1(react@19.2.3))(supports-color@8.1.1)(typescript@5.9.3):
+  mint@4.2.788(@base-ui/react@1.7.0(@types/react@19.2.17)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/node@25.9.4)(@types/react@19.2.17)(bufferutil@4.1.0)(react-dom@18.3.1(react@19.2.3))(typescript@5.9.3):
     dependencies:
-      '@mintlify/cli': 4.0.1391(@base-ui/react@1.7.0(@types/react@19.2.17)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/node@24.13.2)(@types/react@19.2.17)(bufferutil@4.1.0)(react-dom@18.3.1(react@19.2.3))(supports-color@8.1.1)(typescript@5.9.3)
+      '@mintlify/cli': 4.0.1391(@base-ui/react@1.7.0(@types/react@19.2.17)(react-dom@18.3.1(react@19.2.3))(react@19.2.3))(@types/node@25.9.4)(@types/react@19.2.17)(bufferutil@4.1.0)(react-dom@18.3.1(react@19.2.3))(typescript@5.9.3)
     transitivePeerDependencies:
       - '@base-ui/react'
       - '@types/node'

--- a/turbo.json
+++ b/turbo.json
@@ -41,6 +41,11 @@
       "inputs": ["$TURBO_DEFAULT$", "!dist/**"],
       "outputs": ["dist/**"]
     },
+    "@browserbasehq/stagehand-integrations-mastra-sdk#build": {
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", "!dist/**"],
+      "outputs": ["dist/**"]
+    },
     "@browserbasehq/stagehand-evals#build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", "!dist/**"],
@@ -90,6 +95,9 @@
     "@browserbasehq/stagehand-integrations-codex-sdk#typecheck": {
       "dependsOn": ["^build"]
     },
+    "@browserbasehq/stagehand-integrations-mastra-sdk#typecheck": {
+      "dependsOn": ["^build"]
+    },
     "@browserbasehq/stagehand-integrations#test:unit": {
       "dependsOn": ["^build", "@browserbasehq/stagehand-integrations#build"],
       "inputs": [
@@ -112,6 +120,16 @@
     },
     "@browserbasehq/stagehand-integrations-codex-sdk#test:unit": {
       "dependsOn": ["^build", "@browserbasehq/stagehand-integrations-codex-sdk#build"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "tests/**",
+        "src/**",
+        "**/*.test.ts",
+        "$TURBO_ROOT$/vitest.config.ts"
+      ]
+    },
+    "@browserbasehq/stagehand-integrations-mastra-sdk#test:unit": {
+      "dependsOn": ["^build", "@browserbasehq/stagehand-integrations-mastra-sdk#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "tests/**",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
       "packages/integrations/core/tests/**/*.test.ts",
       "packages/integrations/claude-agent-sdk/tests/**/*.test.ts",
       "packages/integrations/codex-sdk/tests/**/*.test.ts",
+      "packages/integrations/mastra-sdk/tests/**/*.test.ts",
       "packages/extension/tests/**/*.test.ts",
       "packages/sdk-ts/tests/**/*.test.ts",
       "packages/extension/understudy/**/*.test.ts",


### PR DESCRIPTION
## What

Adds `--harness mastra` to evals, backed by a new private `@browserbasehq/stagehand-integrations-mastra-sdk` package.

- `packages/integrations/mastra-sdk` — `runMastraSession`: in-process `@mastra/core` Agent + `@mastra/mcp` MCPClient (per-session UUID id), streamed tool-call/result/usage events, abort forwarding, status/stopReason normalization, redaction.
- `packages/evals/framework/mastraToolAdapter.ts` — `via:"mcp"` mounts (stagehand_facade, playwright_mcp, chrome_devtools_mcp) with idempotent cleanup; step observations recorded.
- `packages/evals/framework/harnesses/mastraAdapter.ts` — events → `NormalizedToolCall[]`.
- Registered via `defineExternalHarness` on the shared external-runner skeleton from the base PR.

## Testing

- Full unit gate green: evals 488, mastra-sdk 12, all other suites unchanged.
- Connected smoke (`evals run b:webvoyager --harness mastra --tool stagehand_facade -l 1 -t 1 -e browserbase`): harness drove **7 Stagehand tool calls** through the facade and produced a final answer.

Stacked on the wave-core PR. Implemented with Codex (gpt-5.6) under supervision; Claude + `codex exec review` findings (MCPClient id collision, env leakage, redaction) fixed in-branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a selectable `mastra` eval harness backed by the private `@browserbasehq/stagehand-integrations-mastra-sdk` package. Evals can now run tasks through `@mastra/core` and `@mastra/mcp`, sharing the external-runner prompt, parsing, grading, and metrics flow used by the other agent harnesses.

- Wraps `Agent.stream` and `MCPClient` with per-session client IDs, abort forwarding, bounded discovery and cleanup, normalized usage, and sanitized output.
- Mounts `stagehand_facade`, `playwright_mcp`, and `chrome_devtools_mcp` over stdio MCP, while exposing code surfaces through the existing in-process bridge.
- Converts Mastra stream events into sanitized trajectories with paired tool calls and results, image extraction, and correctly concatenated reasoning and text fragments.
- Treats an SDK error as a failed run even when the model emitted valid-looking success JSON first.
- Registers `mastra` with `stagehand_facade` as the default tool surface, `openai/gpt-5.4-mini` as the default model, and `EVAL_MASTRA_MODELS` as the override.
- Adds workspace dependencies, lockfile and Turbo targets, CI build caching, and unit coverage for the SDK, adapters, runner, registry, and planner.
- Mastra requires `@mastra/core` and `@mastra/mcp`; MCP definitions must use stdio servers with a string `command`.
- Supports step, MCP, evidence-capture, and teardown limits through `EVAL_MASTRA_MAX_STEPS`, `EVAL_MASTRA_MCP_TIMEOUT_MS`, `EVAL_CAPTURE_EVIDENCE_TIMEOUT_MS`, and `EVAL_AGENT_MOUNT_CLEANUP_TIMEOUT_MS`.

<sup>Written for commit b9180990d29d12840ba61f6d876f9270fb5e75f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

