### PR TITLE
feat(evals): add pi bench harness (integrations/pi-sdk)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,6 +258,7 @@ jobs:
             packages/integrations/claude-agent-sdk/dist/**
             packages/integrations/codex-sdk/dist/**
             packages/integrations/mastra-sdk/dist/**
+            packages/integrations/pi-sdk/dist/**
             packages/evals/dist/**
           retention-days: 1
 

--- a/packages/evals/README.md
+++ b/packages/evals/README.md
@@ -70,7 +70,7 @@ Use `Esc` to abort an in-flight run without exiting the REPL.
 | `-c, --concurrency <n>`                                           | Max parallel sessions                                       |
 | `-m, --model <id>`                                                | Override the model matrix                                   |
 | `--api`                                                           | Run via the Stagehand API instead of the SDK                |
-| `--harness <stagehand\|claude_code\|codex>`                       | Which agent harness drives the bench task                   |
+| `--harness <stagehand\|claude_code\|codex\|mastra\|pi>`           | Which agent harness drives the bench task                   |
 | `-l, --limit <n>` / `-s, --sample <n>` / `-f, --filter key=value` | Suite shaping for benchmark targets                         |
 | `--preview`                                                       | Print the resolved plan and exit — no browser, no LLM calls |
 

--- a/packages/evals/framework/benchHarness.ts
+++ b/packages/evals/framework/benchHarness.ts
@@ -13,6 +13,12 @@ import { CODEX_TOOL_SURFACES, prepareCodexToolAdapter } from "./codexToolAdapter
 import { runMastraAgent } from "./mastraRunner.js";
 import { MASTRA_TOOL_SURFACES, prepareMastraToolAdapter } from "./mastraToolAdapter.js";
 import {
+  CODEX_TOOL_SURFACES,
+  prepareCodexToolAdapter,
+} from "./codexToolAdapter.js";
+import { runPiAgent } from "./piRunner.js";
+import { PI_TOOL_SURFACES, preparePiToolAdapter } from "./piToolAdapter.js";
+import {
   buildExternalHarnessTaskPlan,
   type ExternalHarnessTaskPlan,
 } from "./externalHarnessPlan.js";
@@ -294,6 +300,12 @@ export const mastraHarness = defineExternalHarness({
   defaultModels: ["openai/gpt-5.4-mini" as AvailableModel],
   prepareToolAdapter: prepareMastraToolAdapter,
   runAgent: runMastraAgent,
+export const piHarness = defineExternalHarness({
+  harness: "pi",
+  supportedToolSurfaces: PI_TOOL_SURFACES,
+  defaultModels: ["openai/gpt-5.4-mini" as AvailableModel],
+  prepareToolAdapter: preparePiToolAdapter,
+  runAgent: runPiAgent,
 });
 
 const harnessRegistry = new Map<Harness, BenchHarness>([
@@ -301,6 +313,7 @@ const harnessRegistry = new Map<Harness, BenchHarness>([
   ["claude_code", claudeCodeHarness],
   ["codex", codexHarness],
   ["mastra", mastraHarness],
+  ["pi", piHarness],
 ]);
 
 export function registerBenchHarness(harness: BenchHarness): () => void {

--- a/packages/evals/framework/benchHarness.ts
+++ b/packages/evals/framework/benchHarness.ts
@@ -12,10 +12,6 @@ import { runCodexAgent } from "./codexRunner.js";
 import { CODEX_TOOL_SURFACES, prepareCodexToolAdapter } from "./codexToolAdapter.js";
 import { runMastraAgent } from "./mastraRunner.js";
 import { MASTRA_TOOL_SURFACES, prepareMastraToolAdapter } from "./mastraToolAdapter.js";
-import {
-  CODEX_TOOL_SURFACES,
-  prepareCodexToolAdapter,
-} from "./codexToolAdapter.js";
 import { runPiAgent } from "./piRunner.js";
 import { PI_TOOL_SURFACES, preparePiToolAdapter } from "./piToolAdapter.js";
 import {
@@ -300,6 +296,8 @@ export const mastraHarness = defineExternalHarness({
   defaultModels: ["openai/gpt-5.4-mini" as AvailableModel],
   prepareToolAdapter: prepareMastraToolAdapter,
   runAgent: runMastraAgent,
+});
+
 export const piHarness = defineExternalHarness({
   harness: "pi",
   supportedToolSurfaces: PI_TOOL_SURFACES,

--- a/packages/evals/framework/harnesses/piAdapter.ts
+++ b/packages/evals/framework/harnesses/piAdapter.ts
@@ -1,0 +1,155 @@
+/**
+ * piAdapter — converts pi AgentSession events into a verifier `Trajectory`.
+ *
+ * Assistant message_end events provide reasoning/tool calls/final text;
+ * tool_execution_start/end events provide arguments, results, errors, and images.
+ */
+import type { ProbeEvidence, TaskSpec, Trajectory } from "stagehand-v3";
+import type { StepObservation } from "../observationRecorder.js";
+import {
+  buildTrajectory,
+  type NormalizedToolCall,
+  type TrajectoryAdapter,
+} from "./trajectoryAdapter.js";
+
+export interface PiRunResult {
+  events: Array<Record<string, unknown>>;
+  finalAnswer?: string;
+  status?: Trajectory["status"];
+  usage?: Partial<Trajectory["usage"]>;
+  finalObservation?: ProbeEvidence;
+  stepObservations?: StepObservation[];
+  observedToolName?: (name: string) => boolean;
+}
+
+export class PiTrajectoryAdapter implements TrajectoryAdapter<PiRunResult> {
+  fromHarnessResult(result: PiRunResult, taskSpec: TaskSpec): Trajectory {
+    const toolCalls: NormalizedToolCall[] = [];
+    const registered = new Map<string, { name: string; args?: Record<string, unknown> }>();
+    const startedArgs = new Map<string, Record<string, unknown>>();
+    let pendingReasoning = "";
+    let latestAssistantText: string | undefined;
+
+    for (const event of result.events) {
+      const type = String(event.type ?? "");
+      if (type === "message_end" && isRecord(event.message)) {
+        const message = event.message;
+        if (message.role !== "assistant" || !Array.isArray(message.content)) continue;
+        const reasoningParts: string[] = [];
+        const toolBlocks: Record<string, unknown>[] = [];
+        for (const block of message.content) {
+          if (!isRecord(block)) continue;
+          if (block.type === "text" && typeof block.text === "string") {
+            reasoningParts.push(block.text);
+          } else if (block.type === "thinking" && typeof block.thinking === "string") {
+            reasoningParts.push(block.thinking);
+          } else if (block.type === "toolCall") {
+            toolBlocks.push(block);
+            if (typeof block.id === "string") {
+              registered.set(block.id, {
+                name: typeof block.name === "string" ? block.name : "tool",
+                ...(isRecord(block.arguments) && { args: block.arguments }),
+              });
+            }
+          }
+        }
+        const text = reasoningParts.join("\n");
+        if (toolBlocks.length > 0) {
+          pendingReasoning = text;
+        } else {
+          latestAssistantText = text;
+          pendingReasoning = "";
+        }
+        continue;
+      }
+
+      if (type === "tool_execution_start" && typeof event.toolCallId === "string") {
+        startedArgs.set(event.toolCallId, isRecord(event.args) ? event.args : {});
+        continue;
+      }
+
+      if (type === "tool_execution_end") {
+        const id = typeof event.toolCallId === "string" ? event.toolCallId : "";
+        const registration = registered.get(id);
+        const resultValue = event.result;
+        const normalized = normalizeResult(resultValue);
+        const isError = event.isError === true;
+        toolCalls.push({
+          name:
+            typeof event.toolName === "string" ? event.toolName : (registration?.name ?? "tool"),
+          args: registration?.args ?? startedArgs.get(id) ?? {},
+          result: normalized.result,
+          ok: !isError,
+          ...(isError && { error: normalized.text || "tool failed" }),
+          reasoning: pendingReasoning || undefined,
+          ...(normalized.images.length > 0 && { images: normalized.images }),
+        });
+        pendingReasoning = "";
+      }
+    }
+
+    const observations = result.stepObservations ?? [];
+    if (observations.length > 0) {
+      const observedCalls = toolCalls.filter((call) =>
+        result.observedToolName
+          ? result.observedToolName(call.name)
+          : call.name.startsWith("mcp__"),
+      );
+      const totalObservedRuns = Math.max(...observations.map((o) => o.runIndex)) + 1;
+      if (observedCalls.length === totalObservedRuns) {
+        const observationsByRunIndex = new Map(observations.map((o) => [o.runIndex, o.evidence]));
+        observedCalls.forEach((call, ordinal) => {
+          const observation = observationsByRunIndex.get(ordinal);
+          if (observation) call.probeEvidence = observation;
+        });
+      }
+    }
+
+    return buildTrajectory({
+      taskSpec,
+      toolCalls,
+      finalAnswer: result.finalAnswer ?? latestAssistantText,
+      status: result.status ?? "complete",
+      usage: result.usage,
+      ...(result.finalObservation?.screenshot && {
+        finalObservation: result.finalObservation,
+      }),
+    });
+  }
+}
+
+export const piAdapter = new PiTrajectoryAdapter();
+
+function normalizeResult(value: unknown): {
+  result: unknown;
+  text: string;
+  images: Array<{ bytes: Buffer; mediaType: string }>;
+} {
+  if (typeof value === "string") return { result: value, text: value, images: [] };
+  if (!isRecord(value)) return { result: value, text: "", images: [] };
+  const text: string[] = [];
+  const images: Array<{ bytes: Buffer; mediaType: string }> = [];
+  if (Array.isArray(value.content)) {
+    for (const block of value.content) {
+      if (!isRecord(block)) continue;
+      if (block.type === "text" && typeof block.text === "string") text.push(block.text);
+      if (
+        block.type === "image" &&
+        typeof block.data === "string" &&
+        typeof block.mimeType === "string"
+      ) {
+        images.push({ bytes: Buffer.from(block.data, "base64"), mediaType: block.mimeType });
+      }
+    }
+  }
+  const joined = text.join("\n");
+  return {
+    result: joined || (value.details !== undefined ? value.details : value),
+    text: joined,
+    images,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/packages/evals/framework/harnesses/piAdapter.ts
+++ b/packages/evals/framework/harnesses/piAdapter.ts
@@ -143,8 +143,11 @@ function normalizeResult(value: unknown): {
     }
   }
   const joined = text.join("\n");
+  const hasStructuredDetails =
+    value.details !== undefined &&
+    (!isRecord(value.details) || Object.keys(value.details).length > 0);
   return {
-    result: joined || (value.details !== undefined ? value.details : value),
+    result: hasStructuredDetails ? value.details : joined || value,
     text: joined,
     images,
   };

--- a/packages/evals/framework/piRunner.ts
+++ b/packages/evals/framework/piRunner.ts
@@ -1,0 +1,136 @@
+import {
+  buildPiTranscript,
+  runPiSession,
+  stringifyError,
+  type PiSdk,
+} from "@browserbasehq/stagehand-integrations-pi-sdk";
+import type { AvailableModel } from "stagehand-v3";
+import type { EvalLogger } from "../logger.js";
+import type { ExternalHarnessTaskPlan } from "./externalHarnessPlan.js";
+import {
+  buildExternalHarnessPrompt,
+  metricValue,
+  parseEvalResult,
+  runExternalHarnessTask,
+  type ParsedEvalResult,
+} from "./harnesses/externalRunner.js";
+import { piAdapter } from "./harnesses/piAdapter.js";
+import type { PreparedPiToolAdapter } from "./piToolAdapter.js";
+import type { TaskResult } from "./types.js";
+import type { ExternalHarnessVerifierConfig } from "./verifierAdapter.js";
+
+export type { PiSdk } from "@browserbasehq/stagehand-integrations-pi-sdk";
+export {
+  buildPiTranscript,
+  loadPiSdk,
+  normalizePiModel,
+  runPiSession,
+} from "@browserbasehq/stagehand-integrations-pi-sdk";
+
+export interface PiRunnerInput {
+  plan: ExternalHarnessTaskPlan;
+  model: AvailableModel;
+  logger: EvalLogger;
+  toolAdapter?: PreparedPiToolAdapter;
+  signal?: AbortSignal;
+  sdk?: PiSdk;
+  verifier?: ExternalHarnessVerifierConfig;
+}
+
+export interface ParsedPiResult extends ParsedEvalResult {}
+
+export function buildPiPrompt(plan: ExternalHarnessTaskPlan, toolInstructions?: string): string {
+  return buildExternalHarnessPrompt({ plan, toolInstructions, resultContract: "marker" });
+}
+
+export function parsePiResult(raw: string): ParsedPiResult {
+  return parseEvalResult(raw);
+}
+
+export async function runPiAgent(input: PiRunnerInput): Promise<TaskResult> {
+  const { plan, model, logger, toolAdapter, signal, sdk, verifier } = input;
+  return runExternalHarnessTask({
+    harness: "pi",
+    plan,
+    logger,
+    toolAdapter,
+    verifier,
+    resultContract: "marker",
+    fallbackErrorMessage: "pi did not report success",
+    runSession: async (prompt) => {
+      const sessionResult = await runPiSession({
+        prompt,
+        model,
+        logger,
+        sdk,
+        signal,
+        session: {
+          ...(toolAdapter?.cwd && { cwd: toolAdapter.cwd }),
+          systemPrompt:
+            "You are being evaluated. Do not edit repository files. Complete the browser task with the provided browser tools and emit the requested EVAL_RESULT line.",
+          maxTurns: readPiMaxTurns(),
+          ...(process.env.EVAL_PI_THINKING && {
+            thinkingLevel: process.env.EVAL_PI_THINKING,
+          }),
+          ...(toolAdapter?.mcpServers && { mcpServers: toolAdapter.mcpServers }),
+          ...(toolAdapter?.customTools && { customTools: toolAdapter.customTools }),
+        },
+        onToolResult: toolAdapter?.onToolResult,
+      });
+      const usage = sessionResult.tokenUsage;
+      return {
+        raw: sessionResult,
+        resultText: sessionResult.finalMessage,
+        transcriptText: buildPiTranscript(sessionResult.events),
+        iterationError: sessionResult.iterationError,
+        status: sessionResult.status,
+        stopReason:
+          sessionResult.stopReason ||
+          (sessionResult.status === "sdk_error"
+            ? stringifyError(sessionResult.iterationError) || undefined
+            : undefined),
+        usage: {
+          inputTokens: usage.inputTokens,
+          outputTokens: usage.outputTokens,
+          cachedInputTokens: usage.cacheReadTokens,
+          cacheCreationInputTokens: usage.cacheWriteTokens,
+          ...(usage.reasoningTokens !== undefined && {
+            reasoningOutputTokens: usage.reasoningTokens,
+          }),
+          totalTokens: usage.totalTokens,
+        },
+        ...(usage.costUsd > 0 && { costUsd: usage.costUsd }),
+        metrics: { pi_turns: metricValue(sessionResult.turns) },
+      };
+    },
+    toTrajectory: (
+      { raw, parsed, finalObservation, stepObservations, observedToolName, status },
+      taskSpec,
+    ) =>
+      piAdapter.fromHarnessResult(
+        {
+          events: raw.events,
+          ...(finalObservation && { finalObservation }),
+          ...(stepObservations?.length && { stepObservations }),
+          ...(observedToolName && { observedToolName }),
+          finalAnswer: parsed.finalAnswer ?? raw.finalMessage,
+          status,
+          usage: {
+            input_tokens: raw.tokenUsage.inputTokens,
+            output_tokens: raw.tokenUsage.outputTokens,
+            reasoning_tokens: raw.tokenUsage.reasoningTokens,
+            cached_input_tokens: raw.tokenUsage.cacheReadTokens,
+          },
+        },
+        taskSpec,
+      ),
+  });
+}
+
+function readPiMaxTurns(): number {
+  for (const key of ["EVAL_PI_MAX_TURNS", "AGENT_EVAL_MAX_STEPS"]) {
+    const parsed = Number.parseInt(process.env[key] ?? "", 10);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  return 50;
+}

--- a/packages/evals/framework/piToolAdapter.ts
+++ b/packages/evals/framework/piToolAdapter.ts
@@ -1,0 +1,327 @@
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  definePiCodeRunTool,
+  isPiMcpToolName,
+  type PiMcpServerSpec,
+  type PiToolDefinition,
+} from "@browserbasehq/stagehand-integrations-pi-sdk";
+import type { ProbeEvidence } from "stagehand-v3";
+import {
+  AGENT_RUN_TOOL_NAME,
+  type AgentMount,
+  type AgentRunToolSpec,
+  type StartupProfile,
+  type ToolSurface,
+} from "../core/contracts/tool.js";
+import { EvalsError } from "../errors.js";
+import type { EvalLogger } from "../logger.js";
+import { startAgentToolRuntime } from "./agentToolRuntime.js";
+import type { ExternalHarnessTaskPlan } from "./externalHarnessPlan.js";
+import { resolveStartupProfile, resolveToolSurface } from "./harnesses/toolSurfaceResolution.js";
+import { ObservationRecorder, type StepObservation } from "./observationRecorder.js";
+
+export const PI_TOOL_SURFACES: ToolSurface[] = [
+  "stagehand_facade",
+  "playwright_mcp",
+  "chrome_devtools_mcp",
+  "stagehand_code",
+  "playwright_code",
+  "cdp_code",
+];
+
+export interface PiToolAdapterInput {
+  toolSurface?: ToolSurface;
+  startupProfile?: StartupProfile;
+  environment: "LOCAL" | "BROWSERBASE";
+  plan: ExternalHarnessTaskPlan;
+  logger: EvalLogger;
+}
+
+export interface PreparedPiToolAdapter {
+  toolSurface: ToolSurface;
+  startupProfile: StartupProfile;
+  cwd: string;
+  env: Record<string, string>;
+  promptInstructions: string;
+  /** via:"mcp" mounts — bridged in-process by pi-sdk. */
+  mcpServers?: Record<string, PiMcpServerSpec>;
+  /** via:"handles" mounts — the harness run tool hosted in-process by pi. */
+  customTools?: PiToolDefinition[];
+  captureEvidence?: () => Promise<ProbeEvidence>;
+  drainStepObservations?: () => Promise<StepObservation[]>;
+  onToolResult?: (toolName: string) => void;
+  observedToolMatcher?: (toolName: string) => boolean;
+  cleanup: () => Promise<void>;
+}
+
+export function buildPiMountConfig(input: {
+  mount: AgentMount;
+  plan: ExternalHarnessTaskPlan;
+  logger: EvalLogger;
+  recordObservation?: () => void | Promise<void>;
+}): {
+  mcpServers?: Record<string, PiMcpServerSpec>;
+  customTools?: PiToolDefinition[];
+  observedToolMatcher: (name: string) => boolean;
+  promptInstructions: string;
+} {
+  const { mount } = input;
+  if (mount.via === "mcp") {
+    const mcpServers: Record<string, PiMcpServerSpec> = {};
+    for (const [name, value] of Object.entries(mount.mcpServers)) {
+      if (!isRecord(value) || typeof value.command !== "string") {
+        throw new EvalsError(`pi MCP server "${name}" requires a string command.`);
+      }
+      mcpServers[name] = value as PiMcpServerSpec;
+    }
+    const serverNames = Object.keys(mcpServers);
+    return {
+      mcpServers,
+      observedToolMatcher: (name) => serverNames.some((server) => isPiMcpToolName(name, server)),
+      promptInstructions: mount.promptInstructions,
+    };
+  }
+
+  if (mount.via === "handles") {
+    const tool = definePiCodeRunTool({
+      name: AGENT_RUN_TOOL_NAME,
+      label: "Browser run",
+      description: mount.runTool.description,
+      codeParamDescription: mount.runTool.codeParamDescription,
+      execute: async (code) => {
+        try {
+          const result = await withTimeout(
+            executeCodeExposureSnippet({
+              code,
+              handles: mount.handles,
+              runToolSpec: mount.runTool,
+              plan: input.plan,
+              logger: input.logger,
+            }),
+            readPositiveIntEnv("EVAL_PI_RUN_TOOL_TIMEOUT_MS", 60_000),
+          );
+          const text = stringifyToolResult(result);
+          input.logger.log({
+            category: "pi",
+            message: `run tool completed: ${clip(text, 500)}`,
+            level: 1,
+          });
+          await input.recordObservation?.();
+          return text;
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          input.logger.warn({ category: "pi", message: `run tool failed: ${message}`, level: 1 });
+          throw error;
+        }
+      },
+    });
+    return {
+      customTools: [tool],
+      observedToolMatcher: (name) => name === AGENT_RUN_TOOL_NAME,
+      promptInstructions: mount.promptInstructions,
+    };
+  }
+
+  throw new EvalsError(`pi does not support agent mounts delivered via "${mount.via}" yet.`);
+}
+
+export async function preparePiToolAdapter(
+  input: PiToolAdapterInput,
+): Promise<PreparedPiToolAdapter> {
+  const toolSurface = resolveToolSurface(
+    { harness: "pi", supportedToolSurfaces: PI_TOOL_SURFACES },
+    input.toolSurface,
+  );
+  if (toolSurface === undefined) throw new EvalsError("pi harness requires a tool surface.");
+  const startupProfile = resolveStartupProfile(
+    toolSurface,
+    input.environment,
+    input.startupProfile,
+  );
+  const runtime = await startAgentToolRuntime({
+    toolSurface,
+    startupProfile,
+    environment: input.environment,
+    logger: input.logger,
+  });
+  let cwd: string | undefined;
+  try {
+    const mount = runtime.running.agentMount;
+    if (!mount) {
+      throw new EvalsError(`Tool surface "${toolSurface}" does not provide an agent mount.`);
+    }
+    const recorder = runtime.running.captureEvidence
+      ? new ObservationRecorder(runtime.running.captureEvidence)
+      : undefined;
+    cwd = await fsp.mkdtemp(
+      path.join(os.tmpdir(), `stagehand-evals-pi-${toolSurface.replace(/_/g, "-")}-`),
+    );
+    const config = buildPiMountConfig({
+      mount,
+      plan: input.plan,
+      logger: input.logger,
+      ...(recorder && { recordObservation: () => recorder.record() }),
+    });
+    const capturedCwd = cwd;
+    let cleanupPromise: Promise<void> | undefined;
+    input.logger.log({
+      category: "pi",
+      message: `Initialized ${toolSurface} ${mount.via} mount for pi.`,
+      level: 1,
+      auxiliary: {
+        startupProfile: { value: startupProfile, type: "string" },
+        environment: { value: input.environment, type: "string" },
+      },
+    });
+    return {
+      toolSurface,
+      startupProfile,
+      cwd,
+      env: { ...process.env } as Record<string, string>,
+      promptInstructions: config.promptInstructions,
+      ...(config.mcpServers && { mcpServers: config.mcpServers }),
+      ...(config.customTools && { customTools: config.customTools }),
+      ...(runtime.running.captureEvidence && {
+        captureEvidence: boundedCaptureEvidence(runtime.running.captureEvidence),
+      }),
+      ...(recorder && {
+        drainStepObservations: async () => {
+          await recorder.settle();
+          return recorder.drain();
+        },
+      }),
+      ...(mount.via === "mcp" &&
+        recorder && {
+          onToolResult: (name: string) => {
+            if (config.observedToolMatcher(name)) void recorder.record();
+          },
+        }),
+      observedToolMatcher: config.observedToolMatcher,
+      cleanup: async () => {
+        cleanupPromise ??= (async () => {
+          try {
+            await withTimeout(
+              runtime.cleanup(),
+              readPositiveIntEnv("EVAL_AGENT_MOUNT_CLEANUP_TIMEOUT_MS", 30_000),
+            );
+          } catch {
+            // Cleanup is best-effort, but temp-dir cleanup must run.
+          } finally {
+            await fsp.rm(capturedCwd, { recursive: true, force: true });
+          }
+        })();
+        await cleanupPromise;
+      },
+    };
+  } catch (error) {
+    await withTimeout(
+      runtime.cleanup(),
+      readPositiveIntEnv("EVAL_AGENT_MOUNT_CLEANUP_TIMEOUT_MS", 30_000),
+    ).catch((): undefined => undefined);
+    if (cwd) await fsp.rm(cwd, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+function boundedCaptureEvidence(
+  capture: () => Promise<ProbeEvidence>,
+): () => Promise<ProbeEvidence> {
+  return async () => {
+    try {
+      return await withTimeout(
+        capture(),
+        readPositiveIntEnv("EVAL_CAPTURE_EVIDENCE_TIMEOUT_MS", 15_000),
+      );
+    } catch {
+      return {};
+    }
+  };
+}
+
+// Duplicated from claudeCodeToolAdapter.ts (private there); consolidate when a third harness needs it.
+async function executeCodeExposureSnippet(input: {
+  code: string;
+  handles: Record<string, unknown>;
+  runToolSpec: AgentRunToolSpec;
+  plan: ExternalHarnessTaskPlan;
+  logger: EvalLogger;
+}): Promise<unknown> {
+  const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor as new (
+    ...args: string[]
+  ) => (...values: unknown[]) => Promise<unknown>;
+  const fn = new AsyncFunction(
+    ...Object.keys(input.handles),
+    "startUrl",
+    "task",
+    "console",
+    input.code,
+  );
+  return fn(
+    ...Object.values(input.handles),
+    input.plan.startUrl,
+    {
+      dataset: input.plan.dataset,
+      id: input.plan.taskId,
+      startUrl: input.plan.startUrl,
+      instruction: input.plan.instruction,
+    },
+    buildRunToolConsole(input.logger),
+  );
+}
+
+function buildRunToolConsole(logger: EvalLogger): Pick<Console, "log" | "warn" | "error"> {
+  const write = (level: "log" | "warn" | "error", values: unknown[]) => {
+    logger.log({
+      category: "pi",
+      message: `run console.${level}: ${values.map(stringifyToolResult).join(" ")}`,
+      level: 1,
+    });
+  };
+  return {
+    log: (...values: unknown[]) => write("log", values),
+    warn: (...values: unknown[]) => write("warn", values),
+    error: (...values: unknown[]) => write("error", values),
+  };
+}
+
+function readPositiveIntEnv(key: string, fallback: number): number {
+  const parsed = Number.parseInt(process.env[key] ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error(`pi adapter operation timed out after ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+function stringifyToolResult(value: unknown): string {
+  if (value === undefined) return "undefined";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function clip(value: string, maxLength: number): string {
+  return value.length <= maxLength ? value : `${value.slice(0, maxLength - 1)}…`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/packages/evals/framework/piToolAdapter.ts
+++ b/packages/evals/framework/piToolAdapter.ts
@@ -349,7 +349,7 @@ function stringifyToolResult(value: unknown): string {
   if (value === undefined) return "undefined";
   if (typeof value === "string") return value;
   try {
-    return JSON.stringify(value);
+    return JSON.stringify(value) ?? String(value);
   } catch {
     return String(value);
   }

--- a/packages/evals/framework/piToolAdapter.ts
+++ b/packages/evals/framework/piToolAdapter.ts
@@ -90,17 +90,31 @@ export function buildPiMountConfig(input: {
       label: "Browser run",
       description: mount.runTool.description,
       codeParamDescription: mount.runTool.codeParamDescription,
-      execute: async (code) => {
+      execute: async (code, signal) => {
+        if (signal?.aborted) {
+          throw new Error(`run tool aborted before start: ${abortReason(signal)}`);
+        }
+        const snippet = executeCodeExposureSnippet({
+          code,
+          handles: mount.handles,
+          runToolSpec: mount.runTool,
+          plan: input.plan,
+          logger: input.logger,
+        });
         try {
           const result = await withTimeout(
-            executeCodeExposureSnippet({
-              code,
-              handles: mount.handles,
-              runToolSpec: mount.runTool,
-              plan: input.plan,
-              logger: input.logger,
-            }),
+            snippet,
             readPositiveIntEnv("EVAL_PI_RUN_TOOL_TIMEOUT_MS", 60_000),
+            signal,
+            (reason) => {
+              snippet.catch(() => {
+                input.logger.log({
+                  category: "pi",
+                  message: `orphaned run tool snippet rejected after ${reason}`,
+                  level: 1,
+                });
+              });
+            },
           );
           const text = stringifyToolResult(result);
           input.logger.log({
@@ -291,21 +305,44 @@ function readPositiveIntEnv(key: string, fallback: number): number {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
-async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  signal?: AbortSignal,
+  onAbandoned?: (reason: "abort" | "timeout") => void,
+): Promise<T> {
   let timeout: NodeJS.Timeout | undefined;
+  let onAbort: (() => void) | undefined;
   try {
     return await Promise.race([
       promise,
       new Promise<never>((_, reject) => {
-        timeout = setTimeout(
-          () => reject(new Error(`pi adapter operation timed out after ${timeoutMs}ms`)),
-          timeoutMs,
-        );
+        timeout = setTimeout(() => {
+          onAbandoned?.("timeout");
+          reject(new Error(`pi adapter operation timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
       }),
+      ...(signal
+        ? [
+            new Promise<never>((_, reject) => {
+              onAbort = () => {
+                onAbandoned?.("abort");
+                reject(new Error(`run tool aborted: ${abortReason(signal)}`));
+              };
+              signal.addEventListener("abort", onAbort, { once: true });
+            }),
+          ]
+        : []),
     ]);
   } finally {
     if (timeout) clearTimeout(timeout);
+    if (signal && onAbort) signal.removeEventListener("abort", onAbort);
   }
+}
+
+function abortReason(signal: AbortSignal): string {
+  if (signal.reason instanceof Error) return signal.reason.message;
+  return signal.reason === undefined ? "aborted" : String(signal.reason);
 }
 
 function stringifyToolResult(value: unknown): string {

--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -28,6 +28,7 @@
     "@browserbasehq/stagehand-integrations-claude-agent-sdk": "workspace:*",
     "@browserbasehq/stagehand-integrations-codex-sdk": "workspace:*",
     "@browserbasehq/stagehand-integrations-mastra-sdk": "workspace:*",
+    "@browserbasehq/stagehand-integrations-pi-sdk": "workspace:*",
     "@opentelemetry/api": "catalog:",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.220.0",
     "@opentelemetry/sdk-trace-base": "^2.9.0",

--- a/packages/evals/tests/framework/benchHarness.test.ts
+++ b/packages/evals/tests/framework/benchHarness.test.ts
@@ -7,28 +7,29 @@ import {
   getBenchHarness,
   isExecutableBenchHarness,
   listBenchHarnesses,
-  listBenchHarnessesForToolSurface,
   listExecutableBenchHarnesses,
-  mastraHarness,
   parseBenchHarness,
+  mastraHarness,
+  piHarness,
   registerBenchHarness,
 } from "../../framework/benchHarness.js";
-import type { BenchMatrixRow } from "../../framework/benchTypes.js";
 import { MASTRA_TOOL_SURFACES } from "../../framework/mastraToolAdapter.js";
+import { PI_TOOL_SURFACES } from "../../framework/piToolAdapter.js";
+import type { BenchMatrixRow } from "../../framework/benchTypes.js";
 import type { DiscoveredTask } from "../../framework/types.js";
 import type { EvalInput } from "../../types/evals.js";
 import { EvalLogger } from "../../logger.js";
 
 describe("bench harness registry", () => {
   it("lists registered harnesses in registration order", () => {
-    expect(listBenchHarnesses()).toEqual(["stagehand", "claude_code", "codex", "mastra"]);
+    expect(listBenchHarnesses()).toEqual(["stagehand", "claude_code", "codex", "mastra", "pi"]);
   });
 
   it("parses registered harnesses and defaults to stagehand", () => {
     expect(parseBenchHarness(undefined)).toBe("stagehand");
     expect(parseBenchHarness("codex")).toBe("codex");
     expect(() => parseBenchHarness("nope")).toThrow(
-      /Unknown harness "nope"\. Supported: stagehand, claude_code, codex, mastra\./,
+      /Unknown harness "nope"\. Supported: stagehand, claude_code, codex, mastra, pi\./,
     );
   });
 
@@ -71,8 +72,24 @@ describe("bench harness registry", () => {
     expect(harness.start).toBeUndefined();
     expect(harness.supportedToolSurfaces).toEqual(MASTRA_TOOL_SURFACES);
     expect(harness.supportedToolSurfaces[0]).toBe("stagehand_facade");
-    expect(harness.defaultModels).toEqual(["openai/gpt-5.4-mini"]);
     expect(listBenchHarnessesForToolSurface("stagehand_facade")).toContain("mastra");
+    expect(harness.defaultModels).toEqual(["openai/gpt-5.4-mini"]);
+  });
+
+  it("registers pi as a concrete executable harness", () => {
+    const harness = getBenchHarness("pi");
+
+    expect(harness).toBe(piHarness);
+    expect(parseBenchHarness("pi")).toBe("pi");
+    expect(isExecutableBenchHarness("pi")).toBe(true);
+    expect(harness.supportedTaskKinds).toEqual(["agent", "suite"]);
+    expect(harness.supportsApi).toBe(false);
+    expect(harness.execute).toBeDefined();
+    expect(harness.start).toBeUndefined();
+    expect(harness.supportedToolSurfaces).toEqual(PI_TOOL_SURFACES);
+    expect(harness.supportedToolSurfaces[0]).toBe("stagehand_facade");
+    expect(harness.supportedToolSurfaces).not.toContain("browse_cli");
+    expect(harness.defaultModels).toEqual(["openai/gpt-5.4-mini"]);
   });
 
   it("registers a new harness and rejects duplicate ids", () => {

--- a/packages/evals/tests/framework/benchHarness.test.ts
+++ b/packages/evals/tests/framework/benchHarness.test.ts
@@ -9,6 +9,7 @@ import {
   listBenchHarnesses,
   listExecutableBenchHarnesses,
   parseBenchHarness,
+  listBenchHarnessesForToolSurface,
   mastraHarness,
   piHarness,
   registerBenchHarness,

--- a/packages/evals/tests/framework/benchRunner.test.ts
+++ b/packages/evals/tests/framework/benchRunner.test.ts
@@ -3,6 +3,10 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AvailableModel } from "stagehand-v3";
+import {
+  formatBenchHarnessFlags,
+  listBenchHarnessesForTaskKind,
+} from "../../framework/benchHarness.js";
 import { executeBenchTask } from "../../framework/benchRunner.js";
 import type { DiscoveredTask, TaskRegistry } from "../../framework/types.js";
 
@@ -172,8 +176,8 @@ describe("bench runner", () => {
     );
 
     expect(result._success).toBe(false);
-    expect(String(result.error)).toMatch(
-      /--harness claude_code, --harness codex, or --harness mastra/,
+    expect(String(result.error)).toContain(
+      formatBenchHarnessFlags(listBenchHarnessesForTaskKind("suite")),
     );
     expect(closeMock).not.toHaveBeenCalled();
   });

--- a/packages/evals/tests/framework/context.test.ts
+++ b/packages/evals/tests/framework/context.test.ts
@@ -5,7 +5,11 @@ import {
   resolveDefaultCoreStartupProfile,
 } from "../../framework/context.js";
 import { prepareCoreBrowserTarget } from "../../core/targets/index.js";
-import { registerBenchHarness } from "../../framework/benchHarness.js";
+import {
+  formatBenchHarnessFlags,
+  listBenchHarnessesForToolSurface,
+  registerBenchHarness,
+} from "../../framework/benchHarness.js";
 
 describe("resolveDefaultCoreStartupProfile", () => {
   it("rejects agent-mount-only surfaces", () => {
@@ -13,7 +17,7 @@ describe("resolveDefaultCoreStartupProfile", () => {
       /available only as an agent harness mount/,
     );
     expect(() => rejectAgentMountOnlyCoreTool("stagehand_facade")).toThrow(
-      /--harness claude_code, --harness codex, or --harness mastra/,
+      formatBenchHarnessFlags(listBenchHarnessesForToolSurface("stagehand_facade")),
     );
   });
 
@@ -28,9 +32,11 @@ describe("resolveDefaultCoreStartupProfile", () => {
     });
 
     try {
-      expect(() => rejectAgentMountOnlyCoreTool("stagehand_facade")).toThrow(
-        /--harness claude_code, --harness codex, --harness mastra, or --harness context_facade_harness/,
+      const guidance = formatBenchHarnessFlags(
+        listBenchHarnessesForToolSurface("stagehand_facade"),
       );
+      expect(guidance).toContain("--harness context_facade_harness");
+      expect(() => rejectAgentMountOnlyCoreTool("stagehand_facade")).toThrow(guidance);
     } finally {
       unregister();
     }

--- a/packages/evals/tests/framework/piAdapter.test.ts
+++ b/packages/evals/tests/framework/piAdapter.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import type { TaskSpec } from "stagehand-v3";
+import { piAdapter } from "../../framework/harnesses/piAdapter.js";
+
+const taskSpec: TaskSpec = {
+  id: "pi-test",
+  instruction: "Do it",
+  initUrl: "https://example.com",
+};
+
+describe("pi trajectory adapter", () => {
+  it("maps reasoning, tool args/results/errors/images, and final answer", () => {
+    const image = Buffer.from("png");
+    const trajectory = piAdapter.fromHarnessResult(
+      {
+        events: [
+          {
+            type: "message_end",
+            message: {
+              role: "assistant",
+              content: [
+                { type: "text", text: "Inspecting" },
+                { type: "thinking", thinking: "carefully" },
+                { type: "toolCall", id: "one", name: "mcp__stagehand__run", arguments: { x: 1 } },
+              ],
+            },
+          },
+          { type: "tool_execution_start", toolCallId: "one", toolName: "ignored", args: { x: 2 } },
+          {
+            type: "tool_execution_end",
+            toolCallId: "one",
+            toolName: "mcp__stagehand__run",
+            result: {
+              content: [
+                { type: "text", text: "ok" },
+                { type: "image", data: image.toString("base64"), mimeType: "image/png" },
+              ],
+            },
+            isError: false,
+          },
+          {
+            type: "message_end",
+            message: {
+              role: "assistant",
+              content: [{ type: "toolCall", id: "two", name: "fallback" }],
+            },
+          },
+          { type: "tool_execution_start", toolCallId: "two", args: { y: 2 } },
+          {
+            type: "tool_execution_end",
+            toolCallId: "two",
+            toolName: "fallback",
+            result: { content: [{ type: "text", text: "failed" }] },
+            isError: true,
+          },
+          {
+            type: "message_end",
+            message: { role: "assistant", content: [{ type: "text", text: "all done" }] },
+          },
+        ],
+        status: "error",
+        usage: { input_tokens: 10, output_tokens: 2 },
+      },
+      taskSpec,
+    );
+
+    expect(trajectory.steps).toHaveLength(2);
+    expect(trajectory.steps[0]).toMatchObject({
+      actionName: "mcp__stagehand__run",
+      actionArgs: { x: 1 },
+      reasoning: "Inspecting\ncarefully",
+      toolOutput: { ok: true, result: "ok" },
+    });
+    const imageModality = trajectory.steps[0].agentEvidence.modalities.find(
+      (modality) => modality.type === "image",
+    ) as { bytes: Buffer; mediaType: string };
+    expect(imageModality.bytes.equals(image)).toBe(true);
+    expect(imageModality.mediaType).toBe("image/png");
+    expect(trajectory.steps[1]).toMatchObject({
+      actionArgs: { y: 2 },
+      toolOutput: { ok: false, error: "failed" },
+    });
+    expect(trajectory.finalAnswer).toBe("all done");
+    expect(trajectory.status).toBe("error");
+    expect(trajectory.usage).toMatchObject({ input_tokens: 10, output_tokens: 2 });
+  });
+
+  it("pairs observations only when observed call counts align", () => {
+    const events = [
+      { type: "tool_execution_start", toolCallId: "1", args: {} },
+      { type: "tool_execution_end", toolCallId: "1", toolName: "mcp__s__a", result: "a" },
+    ];
+    const aligned = piAdapter.fromHarnessResult(
+      {
+        events,
+        stepObservations: [{ runIndex: 0, evidence: { url: "https://after" } }],
+      },
+      taskSpec,
+    );
+    expect(aligned.steps[0].probeEvidence.url).toBe("https://after");
+
+    const misaligned = piAdapter.fromHarnessResult(
+      {
+        events,
+        stepObservations: [{ runIndex: 1, evidence: { url: "https://wrong" } }],
+      },
+      taskSpec,
+    );
+    expect(misaligned.steps[0].probeEvidence).toEqual({});
+  });
+});

--- a/packages/evals/tests/framework/piAdapter.test.ts
+++ b/packages/evals/tests/framework/piAdapter.test.ts
@@ -108,4 +108,29 @@ describe("pi trajectory adapter", () => {
     );
     expect(misaligned.steps[0].probeEvidence).toEqual({});
   });
+
+  it("prefers non-empty structured details over display text", () => {
+    const trajectory = piAdapter.fromHarnessResult(
+      {
+        events: [
+          { type: "tool_execution_start", toolCallId: "1", args: {} },
+          {
+            type: "tool_execution_end",
+            toolCallId: "1",
+            toolName: "mcp__s__verify",
+            result: {
+              content: [{ type: "text", text: "human-readable summary" }],
+              details: { passed: false, score: 0 },
+            },
+          },
+        ],
+      },
+      taskSpec,
+    );
+
+    expect(trajectory.steps[0].toolOutput).toEqual({
+      ok: true,
+      result: { passed: false, score: 0 },
+    });
+  });
 });

--- a/packages/evals/tests/framework/piRunner.test.ts
+++ b/packages/evals/tests/framework/piRunner.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import type { AvailableModel } from "stagehand-v3";
+import type { ExternalHarnessTaskPlan } from "../../framework/externalHarnessPlan.js";
+import { buildPiPrompt, parsePiResult, runPiAgent, type PiSdk } from "../../framework/piRunner.js";
+import { EvalLogger } from "../../logger.js";
+
+const plan: ExternalHarnessTaskPlan = {
+  dataset: "webvoyager",
+  taskId: "wv-1",
+  startUrl: "https://example.com",
+  instruction: "Find checkout",
+};
+
+describe("pi runner", () => {
+  it("builds and parses marker prompts", () => {
+    const prompt = buildPiPrompt(plan, "Use the browser tool.");
+    expect(prompt).toContain("Dataset: webvoyager");
+    expect(prompt).toContain("Task ID: wv-1");
+    expect(prompt).toContain("Start URL: https://example.com");
+    expect(prompt).toContain("Find checkout");
+    expect(prompt).toContain("EVAL_RESULT:");
+    expect(parsePiResult('{"success":true,"summary":"done"}').success).toBe(true);
+    expect(parsePiResult('EVAL_RESULT: {"success":true,"summary":"done"}').success).toBe(true);
+    expect(
+      parsePiResult('prefix EVAL_RESULT: {"success":true,"summary":"done"}\ntrailing').success,
+    ).toBe(true);
+  });
+
+  it("returns successful results and portable metrics", async () => {
+    let options: Record<string, unknown> | undefined;
+    const sdk: PiSdk = {
+      async createSession(input) {
+        options = input;
+        let listener: (event: Record<string, unknown>) => void = () => {};
+        return {
+          agent: { state: {} },
+          subscribe(next) {
+            listener = next;
+            return () => {};
+          },
+          async prompt() {
+            listener({
+              type: "message_end",
+              message: {
+                role: "assistant",
+                content: [
+                  {
+                    type: "text",
+                    text: 'EVAL_RESULT: {"success":true,"summary":"done","finalAnswer":"ok"}',
+                  },
+                ],
+                stopReason: "stop",
+                usage: {
+                  input: 100,
+                  output: 25,
+                  cacheRead: 10,
+                  cacheWrite: 5,
+                  reasoning: 3,
+                  totalTokens: 140,
+                  cost: { total: 0.42 },
+                },
+              },
+            });
+            listener({ type: "turn_end" });
+          },
+          async abort() {},
+          dispose() {},
+        };
+      },
+    };
+    const customTool = { name: "test" } as never;
+    const result = await runPiAgent({
+      plan,
+      model: "openai/gpt-5.4-mini" as AvailableModel,
+      logger: new EvalLogger(false),
+      sdk,
+      toolAdapter: {
+        toolSurface: "stagehand_facade",
+        startupProfile: "tool_launch_local",
+        cwd: "/tmp/pi-runner",
+        env: {},
+        promptInstructions: "Use browser.",
+        customTools: [customTool],
+        cleanup: async () => {},
+      },
+    });
+    const metrics = result.metrics as Record<string, { value: number }>;
+    expect(result._success).toBe(true);
+    expect(result.piStatus).toBe("completed");
+    expect(result.harnessStatus).toBe("completed");
+    expect(metrics.pi_turns.value).toBe(1);
+    expect(metrics.harness_input_tokens.value).toBe(100);
+    expect(metrics.harness_output_tokens.value).toBe(25);
+    expect(metrics.harness_cached_input_tokens.value).toBe(10);
+    expect(metrics.harness_cache_creation_input_tokens.value).toBe(5);
+    expect(metrics.harness_total_tokens.value).toBe(140);
+    expect(metrics.harness_cost_usd.value).toBe(0.42);
+    expect(options).toMatchObject({
+      cwd: "/tmp/pi-runner",
+      customTools: [customTool],
+    });
+    expect(String(options?.systemPrompt)).toContain("Do not edit repository files");
+  });
+
+  it("returns a failed task result for SDK failures", async () => {
+    const sdk: PiSdk = {
+      async createSession() {
+        throw new Error("pi failed");
+      },
+    };
+    const result = await runPiAgent({
+      plan,
+      model: "openai/gpt-5.4-mini" as AvailableModel,
+      logger: new EvalLogger(false),
+      sdk,
+    });
+    expect(result._success).toBe(false);
+    expect(result.piStatus).toBe("sdk_error");
+    expect(result.harnessStatus).toBe("sdk_error");
+    expect(result.harnessStopReason).toBeDefined();
+    expect(String(result.error)).toContain("pi failed");
+  });
+});

--- a/packages/evals/tests/framework/piRunner.test.ts
+++ b/packages/evals/tests/framework/piRunner.test.ts
@@ -22,8 +22,12 @@ describe("pi runner", () => {
     expect(parsePiResult('{"success":true,"summary":"done"}').success).toBe(true);
     expect(parsePiResult('EVAL_RESULT: {"success":true,"summary":"done"}').success).toBe(true);
     expect(
-      parsePiResult('prefix EVAL_RESULT: {"success":true,"summary":"done"}\ntrailing').success,
+      parsePiResult('intro line\nEVAL_RESULT: {"success":true,"summary":"done"}\ntrailing').success,
     ).toBe(true);
+    // Markers are line-anchored: an inline mention inside prose is not a report.
+    expect(
+      parsePiResult('prefix EVAL_RESULT: {"success":true,"summary":"done"}\ntrailing').success,
+    ).toBe(false);
   });
 
   it("returns successful results and portable metrics", async () => {

--- a/packages/evals/tests/framework/piToolAdapter.test.ts
+++ b/packages/evals/tests/framework/piToolAdapter.test.ts
@@ -95,6 +95,87 @@ describe("pi tool adapter", () => {
     expect(observed).toBe(true);
   });
 
+  it("does not start a handle snippet for an already-aborted signal", async () => {
+    const touched = vi.fn();
+    const config = buildPiMountConfig({
+      mount: handlesMount({ page: { touch: touched } }),
+      plan,
+      logger,
+    });
+    const controller = new AbortController();
+    controller.abort(new Error("row cancelled"));
+
+    await expect(
+      config.customTools![0].execute(
+        "id",
+        { code: "await page.touch(); throw new Error('must not run')" },
+        controller.signal,
+        undefined,
+        {} as never,
+      ),
+    ).rejects.toThrow(/aborted before start/);
+    expect(touched).not.toHaveBeenCalled();
+  });
+
+  it("aborts a running handle snippet and swallows a late rejection", async () => {
+    let rejectPending: (error: Error) => void = () => {};
+    const pending = new Promise<never>((_, reject) => {
+      rejectPending = reject;
+    });
+    const config = buildPiMountConfig({
+      mount: handlesMount({ page: { wait: vi.fn(() => pending) } }),
+      plan,
+      logger,
+    });
+    const controller = new AbortController();
+    const unhandled = vi.fn();
+    process.on("unhandledRejection", unhandled);
+    try {
+      const startedAt = Date.now();
+      const execution = config.customTools![0].execute(
+        "id",
+        { code: "return await page.wait();" },
+        controller.signal,
+        undefined,
+        {} as never,
+      );
+      controller.abort(new Error("row cancelled"));
+      await expect(execution).rejects.toThrow(/row cancelled|aborted/);
+      expect(Date.now() - startedAt).toBeLessThan(1_000);
+      rejectPending(new Error("late failure"));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(unhandled).not.toHaveBeenCalled();
+    } finally {
+      process.removeListener("unhandledRejection", unhandled);
+    }
+  });
+
+  it("times out a running handle snippet", async () => {
+    const previous = process.env.EVAL_PI_RUN_TOOL_TIMEOUT_MS;
+    process.env.EVAL_PI_RUN_TOOL_TIMEOUT_MS = "20";
+    try {
+      const config = buildPiMountConfig({
+        mount: handlesMount({
+          page: { wait: vi.fn(() => new Promise(() => {})) },
+        }),
+        plan,
+        logger,
+      });
+      await expect(
+        config.customTools![0].execute(
+          "id",
+          { code: "return await page.wait();" },
+          undefined,
+          undefined,
+          {} as never,
+        ),
+      ).rejects.toThrow(/timed out/);
+    } finally {
+      if (previous === undefined) delete process.env.EVAL_PI_RUN_TOOL_TIMEOUT_MS;
+      else process.env.EVAL_PI_RUN_TOOL_TIMEOUT_MS = previous;
+    }
+  });
+
   it("rejects CLI mounts", () => {
     expect(() =>
       buildPiMountConfig({
@@ -181,3 +262,16 @@ describe("pi tool adapter", () => {
     expect(runtimeMock).not.toHaveBeenCalled();
   });
 });
+
+function handlesMount(handles: Record<string, unknown>): AgentMount {
+  return {
+    via: "handles",
+    promptInstructions: `Use ${AGENT_RUN_TOOL_NAME}`,
+    handles,
+    runTool: {
+      description: "run browser code",
+      codeParamDescription: "code",
+      denyMessage: "no",
+    },
+  };
+}

--- a/packages/evals/tests/framework/piToolAdapter.test.ts
+++ b/packages/evals/tests/framework/piToolAdapter.test.ts
@@ -1,0 +1,183 @@
+import fsp from "node:fs/promises";
+import os from "node:os";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AGENT_RUN_TOOL_NAME, type AgentMount } from "../../core/contracts/tool.js";
+import type { ExternalHarnessTaskPlan } from "../../framework/externalHarnessPlan.js";
+import {
+  buildPiMountConfig,
+  PI_TOOL_SURFACES,
+  preparePiToolAdapter,
+} from "../../framework/piToolAdapter.js";
+import { EvalLogger } from "../../logger.js";
+
+const runtimeMock = vi.hoisted(() => vi.fn());
+vi.mock("../../framework/agentToolRuntime.js", () => ({
+  startAgentToolRuntime: runtimeMock,
+}));
+
+const plan: ExternalHarnessTaskPlan = {
+  dataset: "webvoyager",
+  taskId: "wv-1",
+  startUrl: "https://example.com",
+  instruction: "Inspect",
+};
+
+const logger = new EvalLogger(false);
+
+function mcpMount(): AgentMount {
+  return {
+    via: "mcp",
+    promptInstructions: "Use MCP",
+    mcpServers: { stagehand: { command: "node", args: ["server.js"] } },
+  };
+}
+
+afterEach(() => {
+  runtimeMock.mockReset();
+});
+
+describe("pi tool adapter", () => {
+  it("publishes the supported surfaces in default order", () => {
+    expect(PI_TOOL_SURFACES[0]).toBe("stagehand_facade");
+    expect(PI_TOOL_SURFACES).not.toContain("browse_cli");
+  });
+
+  it("maps and validates MCP mounts", () => {
+    const config = buildPiMountConfig({ mount: mcpMount(), plan, logger });
+    expect(config.mcpServers).toEqual({
+      stagehand: { command: "node", args: ["server.js"] },
+    });
+    expect(config.observedToolMatcher("mcp__stagehand__run")).toBe(true);
+    expect(config.observedToolMatcher("mcp__other__run")).toBe(false);
+    expect(() =>
+      buildPiMountConfig({
+        mount: {
+          via: "mcp",
+          promptInstructions: "bad",
+          mcpServers: { broken: { args: [] } },
+        },
+        plan,
+        logger,
+      }),
+    ).toThrow(/requires a string command/);
+  });
+
+  it("runs handle snippets and awaits observation capture", async () => {
+    let observed = false;
+    const config = buildPiMountConfig({
+      mount: {
+        via: "handles",
+        promptInstructions: `Use ${AGENT_RUN_TOOL_NAME}`,
+        handles: { page: { title: async () => "Example" } },
+        runTool: {
+          description: "run browser code",
+          codeParamDescription: "code",
+          denyMessage: "no",
+        },
+      },
+      plan,
+      logger,
+      recordObservation: async () => {
+        await Promise.resolve();
+        observed = true;
+      },
+    });
+    expect(config.customTools).toHaveLength(1);
+    expect(config.customTools?.[0].name).toBe(AGENT_RUN_TOOL_NAME);
+    const result = await config.customTools![0].execute(
+      "id",
+      { code: "return await page.title();" },
+      undefined,
+      undefined,
+      {} as never,
+    );
+    expect(result.content).toEqual([{ type: "text", text: "Example" }]);
+    expect(observed).toBe(true);
+  });
+
+  it("rejects CLI mounts", () => {
+    expect(() =>
+      buildPiMountConfig({
+        mount: {
+          via: "cli",
+          promptInstructions: "cli",
+          command: { bin: "browser" },
+        },
+        plan,
+        logger,
+      }),
+    ).toThrow(/does not support agent mounts delivered via "cli"/);
+  });
+
+  it("prepares, observes, and idempotently cleans an MCP runtime", async () => {
+    let cleanupCount = 0;
+    runtimeMock.mockResolvedValue({
+      running: {
+        agentMount: mcpMount(),
+        captureEvidence: async () => ({ url: "https://after" }),
+      },
+      cleanup: async () => {
+        cleanupCount += 1;
+      },
+    });
+    const adapter = await preparePiToolAdapter({
+      toolSurface: "stagehand_facade",
+      environment: "LOCAL",
+      plan,
+      logger,
+    });
+    expect(adapter.cwd.startsWith(os.tmpdir())).toBe(true);
+    await expect(fsp.stat(adapter.cwd)).resolves.toBeDefined();
+    adapter.onToolResult?.("mcp__stagehand__run");
+    const observations = await adapter.drainStepObservations?.();
+    expect(observations).toEqual([{ runIndex: 0, evidence: { url: "https://after" } }]);
+    await adapter.cleanup();
+    await adapter.cleanup();
+    expect(cleanupCount).toBe(1);
+    await expect(fsp.stat(adapter.cwd)).rejects.toThrow();
+  });
+
+  it("cleans runtime and temp directory after setup failure", async () => {
+    let cleanupCount = 0;
+    runtimeMock.mockResolvedValue({
+      running: {
+        agentMount: {
+          via: "cli",
+          promptInstructions: "cli",
+          command: { bin: "browser" },
+        },
+      },
+      cleanup: async () => {
+        cleanupCount += 1;
+      },
+    });
+    const before = new Set(
+      (await fsp.readdir(os.tmpdir())).filter((name) => name.startsWith("stagehand-evals-pi-")),
+    );
+    await expect(
+      preparePiToolAdapter({
+        toolSurface: "stagehand_facade",
+        environment: "LOCAL",
+        plan,
+        logger,
+      }),
+    ).rejects.toThrow(/via "cli"/);
+    expect(cleanupCount).toBe(1);
+    const after = (await fsp.readdir(os.tmpdir())).filter(
+      (name) => name.startsWith("stagehand-evals-pi-") && !before.has(name),
+    );
+    expect(after).toEqual([]);
+  });
+
+  it("rejects browse_cli before starting a runtime", async () => {
+    await expect(
+      preparePiToolAdapter({
+        toolSurface: "browse_cli",
+        environment: "LOCAL",
+        plan,
+        logger,
+      }),
+    ).rejects.toThrow(/Harness "pi" supports --tool/);
+    expect(runtimeMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/evals/tests/framework/piToolAdapter.test.ts
+++ b/packages/evals/tests/framework/piToolAdapter.test.ts
@@ -38,8 +38,14 @@ afterEach(() => {
 
 describe("pi tool adapter", () => {
   it("publishes the supported surfaces in default order", () => {
-    expect(PI_TOOL_SURFACES[0]).toBe("stagehand_facade");
-    expect(PI_TOOL_SURFACES).not.toContain("browse_cli");
+    expect(PI_TOOL_SURFACES).toEqual([
+      "stagehand_facade",
+      "playwright_mcp",
+      "chrome_devtools_mcp",
+      "stagehand_code",
+      "playwright_code",
+      "cdp_code",
+    ]);
   });
 
   it("maps and validates MCP mounts", () => {
@@ -169,11 +175,29 @@ describe("pi tool adapter", () => {
           undefined,
           {} as never,
         ),
-      ).rejects.toThrow(/timed out/);
+      ).rejects.toThrow("pi adapter operation timed out after 20ms");
     } finally {
       if (previous === undefined) delete process.env.EVAL_PI_RUN_TOOL_TIMEOUT_MS;
       else process.env.EVAL_PI_RUN_TOOL_TIMEOUT_MS = previous;
     }
+  });
+
+  it("stringifies values that JSON.stringify cannot represent", async () => {
+    const config = buildPiMountConfig({
+      mount: handlesMount({ page: {} }),
+      plan,
+      logger,
+    });
+
+    await expect(
+      config.customTools![0].execute(
+        "id",
+        { code: "return Symbol('result');" },
+        undefined,
+        undefined,
+        {} as never,
+      ),
+    ).resolves.toMatchObject({ content: [{ type: "text", text: "Symbol(result)" }] });
   });
 
   it("rejects CLI mounts", () => {

--- a/packages/evals/tests/tui/run.test.ts
+++ b/packages/evals/tests/tui/run.test.ts
@@ -5,7 +5,11 @@ import {
   deriveCategoryFilter,
   runCommand,
 } from "../../tui/commands/run.js";
-import { registerBenchHarness } from "../../framework/benchHarness.js";
+import {
+  formatBenchHarnessFlags,
+  listBenchHarnessesForTaskKind,
+  registerBenchHarness,
+} from "../../framework/benchHarness.js";
 
 const runEvalsMock = vi.hoisted(() =>
   vi.fn(async () => ({
@@ -169,8 +173,8 @@ describe("deriveCategoryFilter", () => {
 
     const payload = JSON.parse(String(log.mock.calls[0][0]));
     expect(payload.matrix).toEqual([]);
-    expect(String(payload.error)).toMatch(
-      /--harness claude_code, --harness codex, or --harness mastra/,
+    expect(String(payload.error)).toContain(
+      formatBenchHarnessFlags(listBenchHarnessesForTaskKind("suite")),
     );
     expect(process.exitCode).toBe(1);
     process.exitCode = undefined;
@@ -205,7 +209,7 @@ describe("deriveCategoryFilter", () => {
         },
         registry,
       ),
-    ).rejects.toThrow(/--harness claude_code, --harness codex, or --harness mastra/);
+    ).rejects.toThrow(formatBenchHarnessFlags(listBenchHarnessesForTaskKind("suite")));
   });
 
   it("prints claude_code dry-run matrices without stagehand agent modes", async () => {

--- a/packages/integrations/pi-sdk/package.json
+++ b/packages/integrations/pi-sdk/package.json
@@ -32,6 +32,6 @@
     "vitest": "catalog:"
   },
   "engines": {
-    "node": ">=22.18.0"
+    "node": ">=22.19.0"
   }
 }

--- a/packages/integrations/pi-sdk/package.json
+++ b/packages/integrations/pi-sdk/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@browserbasehq/stagehand-integrations-pi-sdk",
+  "version": "4.0.1",
+  "private": true,
+  "description": "pi (pi-coding-agent) SDK harness adapter for Stagehand integrations",
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs"
+    }
+  },
+  "scripts": {
+    "build": "tsdown",
+    "test": "pnpm run build && vitest run --root ../../.. packages/integrations/pi-sdk/tests",
+    "test:unit": "vitest run --root ../../.. packages/integrations/pi-sdk/tests",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "@browserbasehq/stagehand-integrations": "workspace:*",
+    "@earendil-works/pi-coding-agent": "catalog:",
+    "@modelcontextprotocol/sdk": "catalog:",
+    "typebox": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=22.18.0"
+  }
+}

--- a/packages/integrations/pi-sdk/src/index.ts
+++ b/packages/integrations/pi-sdk/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./session.js";
+export * from "./mcp.js";

--- a/packages/integrations/pi-sdk/src/mcp.ts
+++ b/packages/integrations/pi-sdk/src/mcp.ts
@@ -1,4 +1,5 @@
 import {
+  HarnessAdapterError,
   sanitizeErrorMessage,
   type HarnessLogger,
 } from "@browserbasehq/stagehand-integrations/harness";
@@ -142,7 +143,7 @@ export async function connectPiMcpServers(
               result as { content?: unknown; structuredContent?: unknown; isError?: unknown },
             );
             if (mapped.isError) {
-              throw new Error(piToolResultText(mapped) || "MCP tool failed");
+              throw new HarnessAdapterError("Pi MCP tool failed.");
             }
             return mapped;
           },
@@ -157,7 +158,7 @@ export async function connectPiMcpServers(
       level: 0,
     });
     await close();
-    throw error;
+    throw new HarnessAdapterError("Failed to connect pi MCP servers.");
   }
 }
 

--- a/packages/integrations/pi-sdk/src/mcp.ts
+++ b/packages/integrations/pi-sdk/src/mcp.ts
@@ -1,0 +1,135 @@
+import {
+  sanitizeErrorMessage,
+  type HarnessLogger,
+} from "@browserbasehq/stagehand-integrations/harness";
+import type { AgentToolResult } from "@earendil-works/pi-coding-agent";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import type { TSchema } from "typebox";
+import { isRecord, safeJson, type PiMcpServerSpec, type PiToolDefinition } from "./session.js";
+
+export const PI_MCP_TOOL_PREFIX = "mcp__";
+
+export function buildPiMcpToolName(server: string, tool: string): string {
+  return `${PI_MCP_TOOL_PREFIX}${sanitizeName(server)}__${sanitizeName(tool)}`;
+}
+
+export function isPiMcpToolName(name: string, server?: string): boolean {
+  return server === undefined
+    ? name.startsWith(PI_MCP_TOOL_PREFIX)
+    : name.startsWith(`${PI_MCP_TOOL_PREFIX}${sanitizeName(server)}__`);
+}
+
+export function mcpCallResultToPiToolResult(result: {
+  content?: unknown;
+  structuredContent?: unknown;
+  isError?: unknown;
+}): AgentToolResult<unknown> & { isError: boolean } {
+  const content = Array.isArray(result.content)
+    ? result.content.map((block) => {
+        if (isRecord(block) && block.type === "text" && typeof block.text === "string") {
+          return { type: "text" as const, text: block.text };
+        }
+        if (
+          isRecord(block) &&
+          block.type === "image" &&
+          typeof block.data === "string" &&
+          typeof block.mimeType === "string"
+        ) {
+          return { type: "image" as const, data: block.data, mimeType: block.mimeType };
+        }
+        return { type: "text" as const, text: safeJson(block) ?? String(block) };
+      })
+    : [];
+  return {
+    content,
+    details: result.structuredContent ?? {},
+    isError: result.isError === true,
+  };
+}
+
+export function piToolResultText(result: { content: unknown }): string {
+  if (!Array.isArray(result.content)) return "";
+  return result.content
+    .filter(
+      (block): block is { type: "text"; text: string } =>
+        isRecord(block) && block.type === "text" && typeof block.text === "string",
+    )
+    .map((block) => block.text)
+    .join("\n");
+}
+
+export async function connectPiMcpServers(
+  servers: Record<string, PiMcpServerSpec>,
+  opts: { logger: HarnessLogger; signal?: AbortSignal; callTimeoutMs?: number },
+): Promise<{ tools: PiToolDefinition[]; close: () => Promise<void> }> {
+  const clients: Client[] = [];
+  const tools: PiToolDefinition[] = [];
+  let closePromise: Promise<void> | undefined;
+  const close = async (): Promise<void> => {
+    closePromise ??= Promise.all(
+      clients.map((client) => client.close().catch(() => undefined)),
+    ).then(() => undefined);
+    await closePromise;
+  };
+
+  try {
+    for (const [serverName, spec] of Object.entries(servers)) {
+      const client = new Client({ name: `stagehand-evals-pi-${serverName}`, version: "1.0.0" });
+      const transport = new StdioClientTransport({ ...spec, stderr: "pipe" });
+      transport.stderr?.on("data", (chunk) => {
+        const message = sanitizeErrorMessage(String(chunk).trim());
+        if (message) opts.logger.log({ category: "pi_mcp", message, level: 1 });
+      });
+      await client.connect(transport, opts.signal ? { signal: opts.signal } : undefined);
+      clients.push(client);
+      const listed = await client.listTools(
+        undefined,
+        opts.signal ? { signal: opts.signal } : undefined,
+      );
+      if (listed.tools.length === 0) {
+        opts.logger.warn({
+          category: "pi_mcp",
+          message: `MCP server "${serverName}" exposed no tools.`,
+          level: 1,
+        });
+      }
+      for (const tool of listed.tools) {
+        tools.push({
+          name: buildPiMcpToolName(serverName, tool.name),
+          label: `${serverName}: ${tool.name}`,
+          description: tool.description ?? "",
+          parameters: tool.inputSchema as TSchema,
+          executionMode: "sequential",
+          async execute(_toolCallId, params, signal) {
+            const result = await client.callTool(
+              { name: tool.name, arguments: params as Record<string, unknown> },
+              undefined,
+              { signal, timeout: opts.callTimeoutMs ?? 120_000 },
+            );
+            const mapped = mcpCallResultToPiToolResult(
+              result as { content?: unknown; structuredContent?: unknown; isError?: unknown },
+            );
+            if (mapped.isError) {
+              throw new Error(piToolResultText(mapped) || "MCP tool failed");
+            }
+            return mapped;
+          },
+        } as PiToolDefinition);
+      }
+    }
+    return { tools, close };
+  } catch (error) {
+    opts.logger.warn({
+      category: "pi_mcp",
+      message: `Failed to connect pi MCP servers: ${sanitizeErrorMessage(error instanceof Error ? error.message : String(error))}`,
+      level: 0,
+    });
+    await close();
+    throw error;
+  }
+}
+
+function sanitizeName(value: string): string {
+  return value.replace(/[^A-Za-z0-9_-]/g, "_");
+}

--- a/packages/integrations/pi-sdk/src/mcp.ts
+++ b/packages/integrations/pi-sdk/src/mcp.ts
@@ -59,6 +59,38 @@ export function piToolResultText(result: { content: unknown }): string {
     .join("\n");
 }
 
+export function attachPiMcpStderrLogger(
+  stderr: NodeJS.ReadableStream,
+  logger: HarnessLogger,
+): void {
+  let buffer = "";
+  let flushed = false;
+  const encoded = stderr as NodeJS.ReadableStream & {
+    setEncoding?: (encoding: BufferEncoding) => unknown;
+  };
+  encoded.setEncoding?.("utf8");
+
+  const logLine = (line: string): void => {
+    const message = sanitizeErrorMessage(line.replace(/\r$/, "").trim());
+    if (message) logger.log({ category: "pi_mcp", message, level: 1 });
+  };
+  const flush = (): void => {
+    if (flushed) return;
+    flushed = true;
+    logLine(buffer);
+    buffer = "";
+  };
+
+  stderr.on("data", (chunk) => {
+    buffer += String(chunk);
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+    for (const line of lines) logLine(line);
+  });
+  stderr.on("end", flush);
+  stderr.on("close", flush);
+}
+
 export async function connectPiMcpServers(
   servers: Record<string, PiMcpServerSpec>,
   opts: { logger: HarnessLogger; signal?: AbortSignal; callTimeoutMs?: number },
@@ -77,10 +109,9 @@ export async function connectPiMcpServers(
     for (const [serverName, spec] of Object.entries(servers)) {
       const client = new Client({ name: `stagehand-evals-pi-${serverName}`, version: "1.0.0" });
       const transport = new StdioClientTransport({ ...spec, stderr: "pipe" });
-      transport.stderr?.on("data", (chunk) => {
-        const message = sanitizeErrorMessage(String(chunk).trim());
-        if (message) opts.logger.log({ category: "pi_mcp", message, level: 1 });
-      });
+      if (transport.stderr) {
+        attachPiMcpStderrLogger(transport.stderr as unknown as NodeJS.ReadableStream, opts.logger);
+      }
       await client.connect(transport, opts.signal ? { signal: opts.signal } : undefined);
       clients.push(client);
       const listed = await client.listTools(

--- a/packages/integrations/pi-sdk/src/session.ts
+++ b/packages/integrations/pi-sdk/src/session.ts
@@ -218,6 +218,14 @@ export async function runPiSession(input: {
           piSession.agent.state.errorMessage ||
           "pi reported an error",
       );
+    } else if (lastAssistant?.stopReason === "aborted") {
+      stopReason = sanitizeErrorMessage(
+        (typeof lastAssistant.errorMessage === "string" && lastAssistant.errorMessage) ||
+          piSession.agent.state.errorMessage ||
+          "pi aborted the run",
+      );
+    } else if (lastAssistant?.stopReason === "length") {
+      stopReason = "pi stopped: provider output length limit reached";
     } else if (turns >= maxTurns && lastAssistant?.stopReason === "toolUse") {
       stopReason = `turn budget exhausted (${maxTurns} turns)`;
     }
@@ -310,15 +318,24 @@ export function summarizePiEvent(event: PiEvent): { message: string; detail?: st
   const type = String(event.type ?? "unknown");
   if (type === "message_end" && isRecord(event.message)) {
     const text = assistantText(event.message);
-    return { message: `assistant: ${clip(text, 500)}`, detail: text || safeJson(event.message) };
-  }
-  if (type.startsWith("tool_execution_")) {
+    const detail = text || safeJson(event.message);
     return {
-      message: `${type}: ${String(event.toolName ?? "tool")}`,
-      detail: safeJson(event),
+      message: sanitizeErrorMessage(`assistant: ${clip(text, 500)}`),
+      ...(detail && { detail: sanitizeErrorMessage(detail) }),
     };
   }
-  return { message: `${type} event`, detail: safeJson(event) };
+  if (type.startsWith("tool_execution_")) {
+    const detail = safeJson(event);
+    return {
+      message: sanitizeErrorMessage(`${type}: ${String(event.toolName ?? "tool")}`),
+      ...(detail && { detail: sanitizeErrorMessage(detail) }),
+    };
+  }
+  const detail = safeJson(event);
+  return {
+    message: sanitizeErrorMessage(`${type} event`),
+    ...(detail && { detail: sanitizeErrorMessage(detail) }),
+  };
 }
 
 export function resolvePiStatus(input: {

--- a/packages/integrations/pi-sdk/src/session.ts
+++ b/packages/integrations/pi-sdk/src/session.ts
@@ -1,0 +1,418 @@
+import {
+  HarnessAdapterError,
+  sanitizeErrorMessage,
+  type HarnessLogger,
+} from "@browserbasehq/stagehand-integrations/harness";
+import type {
+  AgentToolResult,
+  CreateAgentSessionOptions,
+  ResourceLoader,
+  ToolDefinition,
+} from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import { connectPiMcpServers } from "./mcp.js";
+
+export type PiEvent = Record<string, unknown>;
+export type PiToolDefinition = ToolDefinition<any, any, any>;
+export type PiMcpServerSpec = {
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+  cwd?: string;
+};
+export type PiAgentSessionLike = {
+  subscribe(listener: (event: PiEvent) => void): () => void;
+  prompt(text: string): Promise<void>;
+  abort(): Promise<void>;
+  dispose(): void;
+  agent: {
+    shouldStopAfterTurn?: (...args: any[]) => boolean | Promise<boolean>;
+    state: { errorMessage?: string };
+  };
+};
+export type PiSdk = {
+  createSession(options: {
+    model: string;
+    cwd?: string;
+    systemPrompt?: string;
+    thinkingLevel?: string;
+    customTools: PiToolDefinition[];
+  }): Promise<PiAgentSessionLike>;
+};
+export type PiSessionConfig = {
+  cwd?: string;
+  systemPrompt?: string;
+  thinkingLevel?: string;
+  maxTurns?: number;
+  customTools?: PiToolDefinition[];
+  mcpServers?: Record<string, PiMcpServerSpec>;
+};
+export type PiTokenUsage = {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  reasoningTokens?: number;
+  totalTokens: number;
+  costUsd: number;
+};
+export type PiSessionResult = {
+  events: PiEvent[];
+  finalMessage: string;
+  turns: number;
+  status: "completed" | "max_turns" | "sdk_error";
+  stopReason?: string;
+  tokenUsage: PiTokenUsage;
+  iterationError?: unknown;
+};
+
+export const PI_SDK_PACKAGE = "@earendil-works/pi-coding-agent";
+
+export async function loadPiSdk(options: { logger?: HarnessLogger } = {}): Promise<PiSdk> {
+  let pi: typeof import("@earendil-works/pi-coding-agent");
+  try {
+    const specifier = PI_SDK_PACKAGE;
+    pi = await import(specifier);
+  } catch (error) {
+    const detail = sanitizeErrorMessage(stringifyError(error));
+    throw new HarnessAdapterError(
+      `pi SDK harness requires ${PI_SDK_PACKAGE}. Install it in the consuming workspace.${detail ? ` ${detail}` : ""}`,
+      { cause: error },
+    );
+  }
+
+  return {
+    async createSession(sessionOptions) {
+      try {
+        const cwd = sessionOptions.cwd ?? process.cwd();
+        const modelRuntime = await pi.ModelRuntime.create();
+        const resolved = pi.resolveCliModel({
+          cliModel: normalizePiModel(sessionOptions.model),
+          modelRuntime,
+        });
+        if (resolved.warning) {
+          options.logger?.log({ category: "pi", message: resolved.warning, level: 1 });
+        }
+        if (resolved.error || !resolved.model) {
+          throw new HarnessAdapterError(
+            sanitizeErrorMessage(
+              resolved.error ?? `Could not resolve pi model "${sessionOptions.model}".`,
+            ),
+          );
+        }
+        const settingsManager = pi.SettingsManager.inMemory({
+          compaction: { enabled: false },
+        });
+        const resourceLoader: ResourceLoader = {
+          getExtensions: () => ({
+            extensions: [],
+            errors: [],
+            runtime: pi.createExtensionRuntime(),
+          }),
+          getSkills: () => ({ skills: [], diagnostics: [] }),
+          getPrompts: () => ({ prompts: [], diagnostics: [] }),
+          getThemes: () => ({ themes: [], diagnostics: [] }),
+          getAgentsFiles: () => ({ agentsFiles: [] }),
+          getSystemPrompt: () =>
+            sessionOptions.systemPrompt ?? "You are a browser automation agent under evaluation.",
+          getSystemPromptSource: () => undefined,
+          getAppendSystemPrompt: () => [],
+          getAppendSystemPromptSources: () => [],
+          extendResources: () => {},
+          reload: async () => {},
+        };
+        const { session } = await pi.createAgentSession({
+          cwd,
+          modelRuntime,
+          model: resolved.model,
+          thinkingLevel: (sessionOptions.thinkingLevel ??
+            resolved.thinkingLevel ??
+            "off") as CreateAgentSessionOptions["thinkingLevel"],
+          resourceLoader,
+          sessionManager: pi.SessionManager.inMemory(cwd),
+          settingsManager,
+          customTools: sessionOptions.customTools,
+          tools: sessionOptions.customTools.map((tool) => tool.name),
+        });
+        return session as unknown as PiAgentSessionLike;
+      } catch (error) {
+        if (error instanceof HarnessAdapterError) throw error;
+        throw new HarnessAdapterError(
+          `Failed to initialize the pi SDK: ${sanitizeErrorMessage(stringifyError(error))}`,
+          { cause: error },
+        );
+      }
+    },
+  };
+}
+
+export function normalizePiModel(model: string): string {
+  return model === "pi/default" ? "openai/gpt-5.4-mini" : model;
+}
+
+export async function runPiSession(input: {
+  prompt: string;
+  model: string;
+  sdk?: PiSdk;
+  signal?: AbortSignal;
+  logger: HarnessLogger;
+  session: PiSessionConfig;
+  onToolResult?: (toolName: string) => void | Promise<void>;
+}): Promise<PiSessionResult> {
+  const sdk = input.sdk ?? (await loadPiSdk({ logger: input.logger }));
+  const events: PiEvent[] = [];
+  let iterationError: unknown;
+  let stopReason: string | undefined;
+  let piSession: PiAgentSessionLike | undefined;
+  let unsubscribe: (() => void) | undefined;
+  let disposed = false;
+  let turns = 0;
+  let notifications = Promise.resolve();
+  const maxTurns = positiveInteger(input.session.maxTurns, 50);
+  let mcp: Awaited<ReturnType<typeof connectPiMcpServers>> | undefined;
+  const forwardAbort = (): void => {
+    if (piSession) void piSession.abort();
+  };
+
+  try {
+    if (Object.keys(input.session.mcpServers ?? {}).length > 0) {
+      mcp = await connectPiMcpServers(input.session.mcpServers!, {
+        logger: input.logger,
+        signal: input.signal,
+      });
+    }
+    const customTools = [...(input.session.customTools ?? []), ...(mcp?.tools ?? [])];
+    piSession = await sdk.createSession({
+      model: input.model,
+      ...(input.session.cwd && { cwd: input.session.cwd }),
+      ...(input.session.systemPrompt && { systemPrompt: input.session.systemPrompt }),
+      ...(input.session.thinkingLevel && { thinkingLevel: input.session.thinkingLevel }),
+      customTools,
+    });
+    piSession.agent.shouldStopAfterTurn = () => turns >= maxTurns;
+    unsubscribe = piSession.subscribe((event) => {
+      if (event.type === "message_update") return;
+      events.push(event);
+      logPiEvent(input.logger, event);
+      if (event.type === "turn_end") turns += 1;
+      if (event.type === "tool_execution_end" && typeof event.toolName === "string") {
+        notifications = notifications.then(() => input.onToolResult?.(event.toolName as string));
+      }
+    });
+    input.signal?.addEventListener("abort", forwardAbort, { once: true });
+    if (input.signal?.aborted) {
+      // pi's abort() before a prompt is a no-op; skip the prompt entirely so a
+      // cancelled row never starts an LLM session.
+      await piSession.abort();
+    } else {
+      await piSession.prompt(input.prompt);
+    }
+    await notifications;
+
+    const lastAssistant = findLastAssistantMessage(events);
+    if (input.signal?.aborted) {
+      stopReason = sanitizeErrorMessage(stringifyError(input.signal.reason) || "aborted");
+    } else if (lastAssistant?.stopReason === "error") {
+      stopReason = sanitizeErrorMessage(
+        (typeof lastAssistant.errorMessage === "string" && lastAssistant.errorMessage) ||
+          piSession.agent.state.errorMessage ||
+          "pi reported an error",
+      );
+    } else if (turns >= maxTurns && lastAssistant?.stopReason === "toolUse") {
+      stopReason = `turn budget exhausted (${maxTurns} turns)`;
+    }
+  } catch (error) {
+    iterationError = error;
+    stopReason = input.signal?.aborted
+      ? sanitizeErrorMessage(stringifyError(input.signal.reason) || "aborted")
+      : sanitizeErrorMessage(stringifyError(error));
+    input.logger.warn({
+      category: "pi",
+      message: `pi stopped before a normal result: ${stopReason}`,
+      level: 0,
+      auxiliary: { error: { value: stopReason, type: "string" } },
+    });
+  } finally {
+    input.signal?.removeEventListener("abort", forwardAbort);
+    unsubscribe?.();
+    if (piSession && !disposed) {
+      disposed = true;
+      piSession.dispose();
+    }
+    await mcp?.close();
+  }
+
+  const lastAssistant = findLastAssistantMessage(events);
+  const budgetExhausted =
+    turns >= maxTurns && lastAssistant?.stopReason === "toolUse" && !iterationError;
+  return {
+    events,
+    finalMessage: assistantText(lastAssistant),
+    turns,
+    status: resolvePiStatus({ iterationError, stopReason, budgetExhausted }),
+    ...(stopReason && { stopReason }),
+    tokenUsage: extractPiTokenUsage(events),
+    ...(iterationError !== undefined && { iterationError }),
+  };
+}
+
+export function extractPiTokenUsage(events: PiEvent[]): PiTokenUsage {
+  const total: PiTokenUsage = {
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    totalTokens: 0,
+    costUsd: 0,
+  };
+  let sawReasoning = false;
+  let reasoningTokens = 0;
+  for (const event of events) {
+    if (event.type !== "message_end" || !isRecord(event.message)) continue;
+    const message = event.message;
+    if (message.role !== "assistant" || !isRecord(message.usage)) continue;
+    const usage = message.usage;
+    total.inputTokens += toFiniteNumber(usage.input);
+    total.outputTokens += toFiniteNumber(usage.output);
+    total.cacheReadTokens += toFiniteNumber(usage.cacheRead);
+    total.cacheWriteTokens += toFiniteNumber(usage.cacheWrite);
+    total.totalTokens += toFiniteNumber(usage.totalTokens);
+    if (usage.reasoning !== undefined) {
+      sawReasoning = true;
+      reasoningTokens += toFiniteNumber(usage.reasoning);
+    }
+    if (isRecord(usage.cost)) total.costUsd += toFiniteNumber(usage.cost.total);
+  }
+  return { ...total, ...(sawReasoning && { reasoningTokens }) };
+}
+
+export function buildPiTranscript(events: PiEvent[]): string {
+  return events
+    .map((event) => summarizePiEvent(event).detail)
+    .filter((detail): detail is string => Boolean(detail))
+    .join("\n");
+}
+
+export function logPiEvent(logger: HarnessLogger, event: PiEvent): void {
+  const summary = summarizePiEvent(event);
+  logger.log({
+    category: "pi",
+    message: summary.message,
+    level: 1,
+    auxiliary: {
+      type: { value: String(event.type ?? "unknown"), type: "string" },
+      ...(summary.detail && { detail: { value: summary.detail, type: "string" } }),
+    },
+  });
+}
+
+export function summarizePiEvent(event: PiEvent): { message: string; detail?: string } {
+  const type = String(event.type ?? "unknown");
+  if (type === "message_end" && isRecord(event.message)) {
+    const text = assistantText(event.message);
+    return { message: `assistant: ${clip(text, 500)}`, detail: text || safeJson(event.message) };
+  }
+  if (type.startsWith("tool_execution_")) {
+    return {
+      message: `${type}: ${String(event.toolName ?? "tool")}`,
+      detail: safeJson(event),
+    };
+  }
+  return { message: `${type} event`, detail: safeJson(event) };
+}
+
+export function resolvePiStatus(input: {
+  iterationError?: unknown;
+  stopReason?: string;
+  budgetExhausted: boolean;
+}): PiSessionResult["status"] {
+  if (input.iterationError) return "sdk_error";
+  if (input.budgetExhausted) return "max_turns";
+  if (input.stopReason) return "sdk_error";
+  return "completed";
+}
+
+export function definePiCodeRunTool(spec: {
+  name: string;
+  label?: string;
+  description: string;
+  codeParamDescription: string;
+  execute: (code: string, signal?: AbortSignal) => Promise<string>;
+}): PiToolDefinition {
+  const parameters = Type.Object({
+    code: Type.String({ description: spec.codeParamDescription }),
+  });
+  return {
+    name: spec.name,
+    label: spec.label ?? spec.name,
+    description: spec.description,
+    parameters,
+    executionMode: "sequential",
+    async execute(_toolCallId, params, signal): Promise<AgentToolResult<unknown>> {
+      const text = await spec.execute((params as { code: string }).code, signal);
+      return { content: [{ type: "text", text }], details: {} };
+    },
+  } as PiToolDefinition;
+}
+
+function findLastAssistantMessage(events: PiEvent[]): Record<string, unknown> | undefined {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    if (
+      event?.type === "message_end" &&
+      isRecord(event.message) &&
+      event.message.role === "assistant"
+    ) {
+      return event.message;
+    }
+  }
+  return undefined;
+}
+
+function assistantText(message: Record<string, unknown> | undefined): string {
+  if (!message || !Array.isArray(message.content)) return "";
+  return message.content
+    .filter((block): block is Record<string, unknown> => isRecord(block))
+    .filter((block) => block.type === "text" && typeof block.text === "string")
+    .map((block) => block.text as string)
+    .join("\n");
+}
+
+function positiveInteger(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.max(1, Math.floor(value))
+    : fallback;
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export function safeJson(value: unknown): string | undefined {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return undefined;
+  }
+}
+
+export function stringifyError(value: unknown): string {
+  if (!value) return "";
+  if (value instanceof Error) return value.message;
+  if (typeof value === "string") return value;
+  return safeJson(value) ?? String(value);
+}
+
+export function clip(value: string, maxLength: number): string {
+  return value.length <= maxLength ? value : `${value.slice(0, maxLength - 1)}…`;
+}
+
+export function toFiniteNumber(value: unknown): number {
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim()
+        ? Number(value)
+        : 0;
+  return Number.isFinite(parsed) ? parsed : 0;
+}

--- a/packages/integrations/pi-sdk/tests/mcp.test.ts
+++ b/packages/integrations/pi-sdk/tests/mcp.test.ts
@@ -1,6 +1,28 @@
 import { PassThrough } from "node:stream";
-import { describe, expect, it, vi } from "vitest";
-import { attachPiMcpStderrLogger } from "../src/index.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { attachPiMcpStderrLogger, connectPiMcpServers } from "../src/index.js";
+
+const clientMocks = vi.hoisted(() => ({
+  connect: vi.fn(),
+  listTools: vi.fn(),
+  callTool: vi.fn(),
+  close: vi.fn(),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: class {
+    connect = clientMocks.connect;
+    listTools = clientMocks.listTools;
+    callTool = clientMocks.callTool;
+    close = clientMocks.close;
+  },
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/stdio.js", () => ({
+  StdioClientTransport: class {
+    stderr = undefined;
+  },
+}));
 
 describe("pi MCP stderr logging", () => {
   it("buffers complete lines, redacts split secrets, and flushes trailing output", async () => {
@@ -34,5 +56,39 @@ describe("pi MCP stderr logging", () => {
       "second line",
     ]);
     stderr.end();
+  });
+});
+
+describe("pi MCP failures", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clientMocks.close.mockResolvedValue(undefined);
+  });
+
+  it("wraps connection failures without exposing the raw error", async () => {
+    const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    clientMocks.connect.mockRejectedValueOnce(new Error("spawn failed sk-secret1234567890"));
+
+    await expect(connectPiMcpServers({ test: { command: "broken" } }, { logger })).rejects.toThrow(
+      "Failed to connect pi MCP servers.",
+    );
+  });
+
+  it("turns server-declared tool failures into a fixed typed error", async () => {
+    const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    clientMocks.connect.mockResolvedValueOnce(undefined);
+    clientMocks.listTools.mockResolvedValueOnce({
+      tools: [{ name: "fail", description: "", inputSchema: {} }],
+    });
+    clientMocks.callTool.mockResolvedValueOnce({
+      isError: true,
+      content: [{ type: "text", text: "raw server secret sk-secret1234567890" }],
+    });
+    const connected = await connectPiMcpServers({ test: { command: "server" } }, { logger });
+
+    await expect(
+      connected.tools[0].execute("id", {}, undefined, undefined, {} as never),
+    ).rejects.toThrow("Pi MCP tool failed.");
+    await connected.close();
   });
 });

--- a/packages/integrations/pi-sdk/tests/mcp.test.ts
+++ b/packages/integrations/pi-sdk/tests/mcp.test.ts
@@ -1,0 +1,38 @@
+import { PassThrough } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import { attachPiMcpStderrLogger } from "../src/index.js";
+
+describe("pi MCP stderr logging", () => {
+  it("buffers complete lines, redacts split secrets, and flushes trailing output", async () => {
+    const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const stderr = new PassThrough();
+    attachPiMcpStderrLogger(stderr, logger);
+
+    stderr.write("Authorization: Bearer sk-live-abcd");
+    stderr.write("efghijklmnop1234 done\nsecond line\npart");
+    stderr.end();
+    await new Promise<void>((resolve) => stderr.once("close", resolve));
+
+    expect(logger.log).toHaveBeenCalledTimes(3);
+    const messages = logger.log.mock.calls.map(([line]) => line.message);
+    expect(messages[0]).toContain("[redacted]");
+    expect(messages[0]).not.toContain("efghijklmnop1234");
+    expect(messages[1]).toBe("second line");
+    expect(messages[2]).toBe("part");
+    expect(messages).not.toContain("Authorization: Bearer sk-live-abcd");
+  });
+
+  it("emits two entries for two complete lines in one chunk", () => {
+    const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const stderr = new PassThrough();
+    attachPiMcpStderrLogger(stderr, logger);
+
+    stderr.write("first line\r\nsecond line\n");
+
+    expect(logger.log.mock.calls.map(([line]) => line.message)).toEqual([
+      "first line",
+      "second line",
+    ]);
+    stderr.end();
+  });
+});

--- a/packages/integrations/pi-sdk/tests/session.test.ts
+++ b/packages/integrations/pi-sdk/tests/session.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildPiMcpToolName,
+  definePiCodeRunTool,
+  isPiMcpToolName,
+  mcpCallResultToPiToolResult,
+  normalizePiModel,
+  resolvePiStatus,
+  runPiSession,
+  type PiAgentSessionLike,
+  type PiEvent,
+  type PiSdk,
+} from "../src/index.js";
+
+const logger = { log: () => {}, warn: () => {}, error: () => {} };
+
+function scriptedSdk(events: PiEvent[], options?: { createError?: Error }) {
+  let disposeCount = 0;
+  let abortCount = 0;
+  let createOptions: Record<string, unknown> | undefined;
+  const sdk: PiSdk = {
+    async createSession(input) {
+      createOptions = input;
+      if (options?.createError) throw options.createError;
+      const listeners = new Set<(event: PiEvent) => void>();
+      const session: PiAgentSessionLike = {
+        agent: { state: {} },
+        subscribe(listener) {
+          listeners.add(listener);
+          return () => listeners.delete(listener);
+        },
+        async prompt() {
+          for (const event of events) {
+            for (const listener of listeners) listener(event);
+            if (event.type === "turn_end" && (await session.agent.shouldStopAfterTurn?.())) break;
+          }
+        },
+        async abort() {
+          abortCount += 1;
+        },
+        dispose() {
+          disposeCount += 1;
+        },
+      };
+      return session;
+    },
+  };
+  return {
+    sdk,
+    get disposeCount() {
+      return disposeCount;
+    },
+    get abortCount() {
+      return abortCount;
+    },
+    get createOptions() {
+      return createOptions;
+    },
+  };
+}
+
+function assistant(text: string, usage: Record<string, unknown>, stopReason = "stop"): PiEvent {
+  return {
+    type: "message_end",
+    message: {
+      role: "assistant",
+      content: [{ type: "text", text }],
+      usage,
+      stopReason,
+    },
+  };
+}
+
+describe("pi SDK session", () => {
+  it("collects output, usage, tool results, and forwarded options", async () => {
+    const fake = scriptedSdk([
+      assistant("working", {
+        input: 10,
+        output: 2,
+        cacheRead: 3,
+        cacheWrite: 4,
+        totalTokens: 19,
+        cost: { total: 0.1 },
+      }),
+      { type: "message_update", delta: "ignored" },
+      { type: "tool_execution_end", toolCallId: "1", toolName: "browser", result: {} },
+      { type: "turn_end" },
+      assistant("done", {
+        input: 5,
+        output: 6,
+        cacheRead: 1,
+        cacheWrite: 2,
+        reasoning: 7,
+        totalTokens: 14,
+        cost: { total: 0.2 },
+      }),
+      { type: "turn_end" },
+    ]);
+    const onToolResult = vi.fn();
+    const customTool = definePiCodeRunTool({
+      name: "browser",
+      description: "run",
+      codeParamDescription: "code",
+      execute: async () => "ok",
+    });
+    const result = await runPiSession({
+      prompt: "task",
+      model: "openai/gpt-5.4-mini",
+      sdk: fake.sdk,
+      logger,
+      session: {
+        cwd: "/tmp/pi-test",
+        systemPrompt: "system",
+        customTools: [customTool],
+      },
+      onToolResult,
+    });
+
+    expect(result.status).toBe("completed");
+    expect(result.finalMessage).toBe("done");
+    expect(result.turns).toBe(2);
+    expect(result.events.some((event) => event.type === "message_update")).toBe(false);
+    expect(result.tokenUsage).toEqual({
+      inputTokens: 15,
+      outputTokens: 8,
+      cacheReadTokens: 4,
+      cacheWriteTokens: 6,
+      reasoningTokens: 7,
+      totalTokens: 33,
+      costUsd: 0.30000000000000004,
+    });
+    expect(onToolResult).toHaveBeenCalledWith("browser");
+    expect(fake.createOptions).toMatchObject({
+      cwd: "/tmp/pi-test",
+      systemPrompt: "system",
+      customTools: [customTool],
+    });
+    expect(fake.disposeCount).toBe(1);
+  });
+
+  it("stops at the turn budget", async () => {
+    const fake = scriptedSdk([
+      assistant("one", {}, "toolUse"),
+      { type: "turn_end" },
+      assistant("two", {}, "toolUse"),
+      { type: "turn_end" },
+      assistant("three", {}, "toolUse"),
+      { type: "turn_end" },
+    ]);
+    const result = await runPiSession({
+      prompt: "task",
+      model: "model",
+      sdk: fake.sdk,
+      logger,
+      session: { maxTurns: 2 },
+    });
+    expect(result.status).toBe("max_turns");
+    expect(result.stopReason).toBe("turn budget exhausted (2 turns)");
+    expect(result.turns).toBe(2);
+    expect(fake.disposeCount).toBe(1);
+  });
+
+  it("redacts provider errors", async () => {
+    const event = assistant("", {}, "error");
+    (event.message as Record<string, unknown>).errorMessage = "bad sk-abcdef1234567890";
+    const fake = scriptedSdk([event]);
+    const result = await runPiSession({
+      prompt: "task",
+      model: "model",
+      sdk: fake.sdk,
+      logger,
+      session: {},
+    });
+    expect(result.status).toBe("sdk_error");
+    expect(result.stopReason).toBe("bad sk-abcdef[redacted]");
+    expect(fake.disposeCount).toBe(1);
+  });
+
+  it("captures createSession failures without throwing", async () => {
+    const fake = scriptedSdk([], { createError: new Error("create failed") });
+    const result = await runPiSession({
+      prompt: "task",
+      model: "model",
+      sdk: fake.sdk,
+      logger,
+      session: {},
+    });
+    expect(result.status).toBe("sdk_error");
+    expect(String(result.iterationError)).toContain("create failed");
+    expect(fake.disposeCount).toBe(0);
+  });
+
+  it("forwards an already-aborted signal", async () => {
+    const fake = scriptedSdk([]);
+    const controller = new AbortController();
+    controller.abort(new Error("cancelled"));
+    const result = await runPiSession({
+      prompt: "task",
+      model: "model",
+      sdk: fake.sdk,
+      signal: controller.signal,
+      logger,
+      session: {},
+    });
+    expect(fake.abortCount).toBe(1);
+    expect(fake.disposeCount).toBe(1);
+    expect(result.status).toBe("sdk_error");
+    expect(result.stopReason).toBe("cancelled");
+  });
+
+  it("normalizes models, MCP names/results, code tools, and statuses", async () => {
+    expect(normalizePiModel("pi/default")).toBe("openai/gpt-5.4-mini");
+    expect(normalizePiModel("google/gemini-2.5-pro")).toBe("google/gemini-2.5-pro");
+    expect(buildPiMcpToolName("stage.hand", "take shot")).toBe("mcp__stage_hand__take_shot");
+    expect(isPiMcpToolName("mcp__stage_hand__run", "stage.hand")).toBe(true);
+    expect(isPiMcpToolName("other")).toBe(false);
+    const mapped = mcpCallResultToPiToolResult({
+      content: [
+        { type: "text", text: "hello" },
+        { type: "image", data: "YWJj", mimeType: "image/png" },
+      ],
+      structuredContent: { ok: false },
+      isError: true,
+    });
+    expect(mapped).toMatchObject({ isError: true, details: { ok: false } });
+    expect(mapped.content).toHaveLength(2);
+
+    const execute = vi.fn(async (code: string) => `ran ${code}`);
+    const tool = definePiCodeRunTool({
+      name: "run",
+      description: "run code",
+      codeParamDescription: "snippet",
+      execute,
+    });
+    expect((tool.parameters as { properties: object }).properties).toHaveProperty("code");
+    const output = await tool.execute(
+      "id",
+      { code: "return 1" },
+      undefined,
+      undefined,
+      {} as never,
+    );
+    expect(output.content).toEqual([{ type: "text", text: "ran return 1" }]);
+    expect(execute).toHaveBeenCalledWith("return 1", undefined);
+
+    expect(
+      resolvePiStatus({ iterationError: undefined, stopReason: undefined, budgetExhausted: false }),
+    ).toBe("completed");
+    expect(
+      resolvePiStatus({ iterationError: undefined, stopReason: undefined, budgetExhausted: true }),
+    ).toBe("max_turns");
+    expect(resolvePiStatus({ iterationError: new Error("x"), budgetExhausted: false })).toBe(
+      "sdk_error",
+    );
+  });
+});

--- a/packages/integrations/pi-sdk/tests/session.test.ts
+++ b/packages/integrations/pi-sdk/tests/session.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   buildPiMcpToolName,
+  buildPiTranscript,
   definePiCodeRunTool,
   isPiMcpToolName,
   mcpCallResultToPiToolResult,
@@ -174,6 +175,75 @@ describe("pi SDK session", () => {
     expect(result.status).toBe("sdk_error");
     expect(result.stopReason).toBe("bad sk-abcdef[redacted]");
     expect(fake.disposeCount).toBe(1);
+  });
+
+  it("treats provider length limits as SDK errors", async () => {
+    const result = await runPiSession({
+      prompt: "task",
+      model: "model",
+      sdk: scriptedSdk([assistant("cut off", {}, "length")]).sdk,
+      logger,
+      session: {},
+    });
+    expect(result.status).toBe("sdk_error");
+    expect(result.stopReason).toMatch(/length limit/);
+  });
+
+  it("treats internal pi aborts as SDK errors", async () => {
+    const result = await runPiSession({
+      prompt: "task",
+      model: "model",
+      sdk: scriptedSdk([assistant("", {}, "aborted")]).sdk,
+      logger,
+      session: {},
+    });
+    expect(result.status).toBe("sdk_error");
+    expect(result.stopReason).toBe("pi aborted the run");
+  });
+
+  it("redacts internal pi abort errors", async () => {
+    const event = assistant("", {}, "aborted");
+    (event.message as Record<string, unknown>).errorMessage = "boom sk-abcdef1234567890";
+    const result = await runPiSession({
+      prompt: "task",
+      model: "model",
+      sdk: scriptedSdk([event]).sdk,
+      logger,
+      session: {},
+    });
+    expect(result.status).toBe("sdk_error");
+    expect(result.stopReason).toBe("boom sk-abcdef[redacted]");
+  });
+
+  it("redacts tool and unknown event summaries without mutating events", async () => {
+    const toolEvent: PiEvent = {
+      type: "tool_execution_end",
+      toolName: "browser",
+      args: { token: "sk-abcdef1234567890" },
+      result: { token: "sk-abcdef1234567890" },
+    };
+    const unknownEvent: PiEvent = {
+      type: "provider_notice",
+      errorMessage: "bb_live_abcd1234567890",
+    };
+    const recordingLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const result = await runPiSession({
+      prompt: "task",
+      model: "model",
+      sdk: scriptedSdk([toolEvent, unknownEvent]).sdk,
+      logger: recordingLogger,
+      session: {},
+    });
+
+    const logged = JSON.stringify(recordingLogger.log.mock.calls);
+    expect(logged).not.toContain("sk-abcdef1234567890");
+    expect(logged).not.toContain("bb_live_abcd1234567890");
+    const transcript = buildPiTranscript(result.events);
+    expect(transcript).toContain("sk-abcdef[redacted]");
+    expect(transcript).toContain("bb_live_abcd[redacted]");
+    expect(transcript).not.toContain("sk-abcdef1234567890");
+    expect(transcript).not.toContain("bb_live_abcd1234567890");
+    expect(toolEvent.result).toEqual({ token: "sk-abcdef1234567890" });
   });
 
   it("captures createSession failures without throwing", async () => {

--- a/packages/integrations/pi-sdk/tests/session.test.ts
+++ b/packages/integrations/pi-sdk/tests/session.test.ts
@@ -15,7 +15,10 @@ import {
 
 const logger = { log: () => {}, warn: () => {}, error: () => {} };
 
-function scriptedSdk(events: PiEvent[], options?: { createError?: Error }) {
+function scriptedSdk(
+  events: PiEvent[],
+  options?: { createError?: Error; promptUntilAbort?: boolean },
+) {
   let disposeCount = 0;
   let abortCount = 0;
   let createOptions: Record<string, unknown> | undefined;
@@ -24,6 +27,7 @@ function scriptedSdk(events: PiEvent[], options?: { createError?: Error }) {
       createOptions = input;
       if (options?.createError) throw options.createError;
       const listeners = new Set<(event: PiEvent) => void>();
+      let resolvePrompt: (() => void) | undefined;
       const session: PiAgentSessionLike = {
         agent: { state: {} },
         subscribe(listener) {
@@ -31,6 +35,11 @@ function scriptedSdk(events: PiEvent[], options?: { createError?: Error }) {
           return () => listeners.delete(listener);
         },
         async prompt() {
+          if (options?.promptUntilAbort) {
+            await new Promise<void>((resolve) => {
+              resolvePrompt = resolve;
+            });
+          }
           for (const event of events) {
             for (const listener of listeners) listener(event);
             if (event.type === "turn_end" && (await session.agent.shouldStopAfterTurn?.())) break;
@@ -38,6 +47,7 @@ function scriptedSdk(events: PiEvent[], options?: { createError?: Error }) {
         },
         async abort() {
           abortCount += 1;
+          resolvePrompt?.();
         },
         dispose() {
           disposeCount += 1;
@@ -276,6 +286,29 @@ describe("pi SDK session", () => {
     expect(fake.disposeCount).toBe(1);
     expect(result.status).toBe("sdk_error");
     expect(result.stopReason).toBe("cancelled");
+  });
+
+  it("forwards an active abort and removes the signal listener", async () => {
+    const fake = scriptedSdk([], { promptUntilAbort: true });
+    const controller = new AbortController();
+    const removeListener = vi.spyOn(controller.signal, "removeEventListener");
+    const execution = runPiSession({
+      prompt: "task",
+      model: "model",
+      sdk: fake.sdk,
+      signal: controller.signal,
+      logger,
+      session: {},
+    });
+    await vi.waitFor(() => expect(fake.createOptions).toBeDefined());
+
+    controller.abort(new Error("active cancellation"));
+    const result = await execution;
+
+    expect(fake.abortCount).toBe(1);
+    expect(result.status).toBe("sdk_error");
+    expect(result.stopReason).toBe("active cancellation");
+    expect(removeListener).toHaveBeenCalledWith("abort", expect.any(Function));
   });
 
   it("normalizes models, MCP names/results, code tools, and statuses", async () => {

--- a/packages/integrations/pi-sdk/tsconfig.json
+++ b/packages/integrations/pi-sdk/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "types": ["node"],
+    "rootDir": ".",
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts", "vitest.config.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/integrations/pi-sdk/tsdown.config.ts
+++ b/packages/integrations/pi-sdk/tsdown.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: {
+    index: "src/index.ts",
+  },
+  format: ["esm"],
+  platform: "node",
+  target: "node22",
+  dts: {
+    sourcemap: true,
+  },
+  sourcemap: true,
+  outDir: "dist",
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -272,6 +272,9 @@ importers:
       '@browserbasehq/stagehand-integrations-mastra-sdk':
         specifier: workspace:*
         version: link:../integrations/mastra-sdk
+      '@browserbasehq/stagehand-integrations-pi-sdk':
+        specifier: workspace:*
+        version: link:../integrations/pi-sdk
       '@opentelemetry/api':
         specifier: 'catalog:'
         version: 1.9.1
@@ -622,6 +625,34 @@ importers:
       typebox:
         specifier: 'catalog:'
         version: 1.3.7
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+
+  packages/integrations/pi-sdk:
+    dependencies:
+      '@browserbasehq/stagehand-integrations':
+        specifier: workspace:*
+        version: link:../core
+      '@earendil-works/pi-coding-agent':
+        specifier: 'catalog:'
+        version: 0.84.2(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(bufferutil@4.1.0)(ws@8.21.0(bufferutil@4.1.0))(zod@4.4.3)
+      '@modelcontextprotocol/sdk':
+        specifier: 'catalog:'
+        version: 1.29.0(zod@4.4.3)
+      typebox:
+        specifier: 'catalog:'
+        version: 1.3.7
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.2
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.3(publint@0.3.21)(tsx@4.23.1)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -2731,8 +2762,8 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@posthog/core@1.46.9':
-    resolution: {integrity: sha512-EXO6y5ih+jBkTCpUCuYgQmajuDZuvy6vMvflkub6pLQyi0GPlCPWVSvZZkOeQw9e2MxoD5GteeGCt9R8+UJ/yQ==}
+  '@posthog/core@1.39.6':
+    resolution: {integrity: sha512-o6ajIwN5zXoNP0D4H/QPmOyibNTUkSyOR6ya7AG5U2ywXx4awo72L2KnCoiZPQM5x/bXv6jPBdimH8M18Ax0aw==}
 
   '@posthog/core@1.7.1':
     resolution: {integrity: sha512-kjK0eFMIpKo9GXIbts8VtAknsoZ18oZorANdtuTj1CbgS28t4ZVq//HAWhnxEuXRTrtkd+SUJ6Ux3j2Af8NCuA==}
@@ -6553,8 +6584,8 @@ packages:
     resolution: {integrity: sha512-lz3YJOr0Nmiz0yHASaINEDHqoV+0bC3eD8aZAG+Ky292dAnVYul+ga/dMX8KCBXg8hHfKdxw0SztYD5j6dgUqQ==}
     engines: {node: '>=20'}
 
-  posthog-node@5.48.1:
-    resolution: {integrity: sha512-BxLX2SqGEQhPqCPTalpyo0RRv1NMbf7UaN7q9d/ED77ksD6XOmE7ko2vIKO8F0zPL1NtKxIi+DYXap9lvR0RaA==}
+  posthog-node@5.40.0:
+    resolution: {integrity: sha512-DrLfHuauO0W6qruF80iqr5JdmLysef74XzOB4eh36oRLRhxCySLraTqsi2Pj161LZnp9/JNdRDxwT8ei8VK2YA==}
     engines: {node: ^20.20.0 || >=22.22.0}
     peerDependencies:
       rxjs: ^7.0.0
@@ -9594,7 +9625,7 @@ snapshots:
       p-map: 7.0.6
       p-retry: 7.1.1
       picomatch: 4.0.5
-      posthog-node: 5.48.1(rxjs@7.8.2)
+      posthog-node: 5.40.0(rxjs@7.8.2)
       tokenx: 1.6.0
       ws: 8.21.0(bufferutil@4.1.0)
       xxhash-wasm: 1.1.0
@@ -10355,7 +10386,7 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@posthog/core@1.46.9':
+  '@posthog/core@1.39.6':
     dependencies:
       '@posthog/types': 1.402.2
 
@@ -14713,9 +14744,9 @@ snapshots:
     dependencies:
       '@posthog/core': 1.7.1
 
-  posthog-node@5.48.1(rxjs@7.8.2):
+  posthog-node@5.40.0(rxjs@7.8.2):
     dependencies:
-      '@posthog/core': 1.46.9
+      '@posthog/core': 1.39.6
     optionalDependencies:
       rxjs: 7.8.2
 

--- a/turbo.json
+++ b/turbo.json
@@ -42,6 +42,7 @@
       "outputs": ["dist/**"]
     },
     "@browserbasehq/stagehand-integrations-mastra-sdk#build": {
+    "@browserbasehq/stagehand-integrations-pi-sdk#build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", "!dist/**"],
       "outputs": ["dist/**"]
@@ -96,6 +97,7 @@
       "dependsOn": ["^build"]
     },
     "@browserbasehq/stagehand-integrations-mastra-sdk#typecheck": {
+    "@browserbasehq/stagehand-integrations-pi-sdk#typecheck": {
       "dependsOn": ["^build"]
     },
     "@browserbasehq/stagehand-integrations#test:unit": {
@@ -130,6 +132,8 @@
     },
     "@browserbasehq/stagehand-integrations-mastra-sdk#test:unit": {
       "dependsOn": ["^build", "@browserbasehq/stagehand-integrations-mastra-sdk#build"],
+    "@browserbasehq/stagehand-integrations-pi-sdk#test:unit": {
+      "dependsOn": ["^build", "@browserbasehq/stagehand-integrations-pi-sdk#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "tests/**",

--- a/turbo.json
+++ b/turbo.json
@@ -42,6 +42,10 @@
       "outputs": ["dist/**"]
     },
     "@browserbasehq/stagehand-integrations-mastra-sdk#build": {
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", "!dist/**"],
+      "outputs": ["dist/**"]
+    },
     "@browserbasehq/stagehand-integrations-pi-sdk#build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", "!dist/**"],
@@ -97,6 +101,8 @@
       "dependsOn": ["^build"]
     },
     "@browserbasehq/stagehand-integrations-mastra-sdk#typecheck": {
+      "dependsOn": ["^build"]
+    },
     "@browserbasehq/stagehand-integrations-pi-sdk#typecheck": {
       "dependsOn": ["^build"]
     },
@@ -132,6 +138,14 @@
     },
     "@browserbasehq/stagehand-integrations-mastra-sdk#test:unit": {
       "dependsOn": ["^build", "@browserbasehq/stagehand-integrations-mastra-sdk#build"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "tests/**",
+        "src/**",
+        "**/*.test.ts",
+        "$TURBO_ROOT$/vitest.config.ts"
+      ]
+    },
     "@browserbasehq/stagehand-integrations-pi-sdk#test:unit": {
       "dependsOn": ["^build", "@browserbasehq/stagehand-integrations-pi-sdk#build"],
       "inputs": [

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
       "packages/integrations/claude-agent-sdk/tests/**/*.test.ts",
       "packages/integrations/codex-sdk/tests/**/*.test.ts",
       "packages/integrations/mastra-sdk/tests/**/*.test.ts",
+      "packages/integrations/pi-sdk/tests/**/*.test.ts",
       "packages/extension/tests/**/*.test.ts",
       "packages/sdk-ts/tests/**/*.test.ts",
       "packages/extension/understudy/**/*.test.ts",


### PR DESCRIPTION
## What

Adds `--harness pi` to evals, backed by a new private `@browserbasehq/stagehand-integrations-pi-sdk` package.

- `packages/integrations/pi-sdk` — `runPiSession` over the programmatic `@earendil-works/pi-coding-agent` SDK (`createAgentSession`, hermetic tool allowlist so bash/edit/write are never exposed), in-process MCP bridge for facade tools, streamed `AgentSessionEvent`s → tool-call/result/usage, abort forwarding, redaction, status/stopReason normalization.
- `packages/evals/framework/piToolAdapter.ts` — `via:"mcp"` mounts (stagehand_facade first, playwright_mcp, chrome_devtools_mcp); `via:"handles"` run-tool via the in-process bridge.
- `packages/evals/framework/harnesses/piAdapter.ts` — events → `NormalizedToolCall[]`.
- Registered via `defineExternalHarness`.

## Testing

- Full unit gate green (evals + pi-sdk 12 + all other suites).
- Connected smoke (`evals run b:webvoyager --harness pi --tool stagehand_facade -l 1 -t 1 -e browserbase`): **10 Stagehand tool calls** via the facade, final answer produced.

Stacked on the mastra PR. Implemented with Codex (gpt-5.6) under supervision; review findings (redaction, stderr buffering, stop reasons, run-tool aborts) fixed in-branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `--harness pi` bench harness backed by a private `@browserbasehq/stagehand-integrations-pi-sdk`, enabling evals to run the PI coding agent with Stagehand tools while keeping tool exposure hermetic. PI stop reasons "aborted" and "length" now map to `sdk_error`; harness guidance strings derive from the registry dynamically.

- Registers `pi` with default model `openai/gpt-5.4-mini`; surfaces: `stagehand_facade` (default), `playwright_mcp`, `chrome_devtools_mcp`, `stagehand_code`, `playwright_code`, `cdp_code`.
- New pi-sdk: in-process session runner (turn budget, abort forwarding), token/cost extraction, transcript building, and a stdio MCP bridge with line-buffered, redacted stderr.
- Custom-tool allowlist hosts the harness run-tool in-process and respects AbortSignal and timeouts.
- Evals adapters: `piRunner` (marker contract, `pi_turns` metric), `piAdapter` (PI events to trajectories with reasoning, images, probe evidence), `piToolAdapter` (mounts, step observations, runtime/temp-dir cleanup, no unhandled rejections on late failures).
- Redacts provider errorMessage fields and tool args/results so logs never leak secrets; CI/Turbo build and tests are wired for the new package.

**Rollout**
- Run `evals run <task> --harness pi --tool stagehand_facade` (or another supported surface).
- Optional env: `EVAL_PI_MAX_TURNS` (or `AGENT_EVAL_MAX_STEPS`), `EVAL_PI_THINKING`, `EVAL_PI_RUN_TOOL_TIMEOUT_MS`, `EVAL_AGENT_MOUNT_CLEANUP_TIMEOUT_MS`, `EVAL_CAPTURE_EVIDENCE_TIMEOUT_MS`.
- For MCP usage, provide `mcpServers` in the mount; tools appear as `mcp__server__tool`.
- No migration required.

<sup>Written for commit 08c454b9f72464112cbd8388962de1a9f306bbe8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

