### PR TITLE
feat(evals): add eve bench harness (integrations/eve-sdk)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,7 @@ jobs:
             packages/integrations/codex-sdk/dist/**
             packages/integrations/mastra-sdk/dist/**
             packages/integrations/pi-sdk/dist/**
+            packages/integrations/eve-sdk/dist/**
             packages/evals/dist/**
           retention-days: 1
 

--- a/packages/evals/framework/benchHarness.ts
+++ b/packages/evals/framework/benchHarness.ts
@@ -14,6 +14,8 @@ import { runMastraAgent } from "./mastraRunner.js";
 import { MASTRA_TOOL_SURFACES, prepareMastraToolAdapter } from "./mastraToolAdapter.js";
 import { runPiAgent } from "./piRunner.js";
 import { PI_TOOL_SURFACES, preparePiToolAdapter } from "./piToolAdapter.js";
+import { runEveAgent } from "./eveRunner.js";
+import { EVE_TOOL_SURFACES, prepareEveToolAdapter } from "./eveToolAdapter.js";
 import {
   buildExternalHarnessTaskPlan,
   type ExternalHarnessTaskPlan,
@@ -306,12 +308,21 @@ export const piHarness = defineExternalHarness({
   runAgent: runPiAgent,
 });
 
+export const eveHarness = defineExternalHarness({
+  harness: "eve",
+  supportedToolSurfaces: EVE_TOOL_SURFACES,
+  defaultModels: ["openai/gpt-5.4-mini" as AvailableModel],
+  prepareToolAdapter: prepareEveToolAdapter,
+  runAgent: runEveAgent,
+});
+
 const harnessRegistry = new Map<Harness, BenchHarness>([
   ["stagehand", stagehandHarness],
   ["claude_code", claudeCodeHarness],
   ["codex", codexHarness],
   ["mastra", mastraHarness],
   ["pi", piHarness],
+  ["eve", eveHarness],
 ]);
 
 export function registerBenchHarness(harness: BenchHarness): () => void {

--- a/packages/evals/framework/eveRunner.ts
+++ b/packages/evals/framework/eveRunner.ts
@@ -1,0 +1,195 @@
+import {
+  buildEveTranscript,
+  runEveSession,
+  stringifyError,
+  toFiniteNumber,
+  type EveClientLike,
+  type EveTokenUsage,
+} from "@browserbasehq/stagehand-integrations-eve-sdk";
+import type { AvailableModel } from "stagehand-v3";
+import { EvalsError } from "../errors.js";
+import type { EvalLogger } from "../logger.js";
+import type { ExternalHarnessTaskPlan } from "./externalHarnessPlan.js";
+import type { PreparedEveToolAdapter } from "./eveToolAdapter.js";
+import { writeEveAgentDefinition } from "./eveToolAdapter.js";
+import { eveAdapter } from "./harnesses/eveAdapter.js";
+import {
+  buildExternalHarnessPrompt,
+  metricValue,
+  parseEvalResult,
+  runExternalHarnessTask,
+  type ExternalHarnessToolAdapterLike,
+  type MetricValue,
+  type ParsedEvalResult,
+} from "./harnesses/externalRunner.js";
+import type { TaskResult } from "./types.js";
+import type { ExternalHarnessVerifierConfig } from "./verifierAdapter.js";
+
+export interface EveRunnerInput {
+  plan: ExternalHarnessTaskPlan;
+  model: AvailableModel;
+  logger: EvalLogger;
+  toolAdapter?: PreparedEveToolAdapter;
+  signal?: AbortSignal;
+  client?: EveClientLike;
+  serverUrl?: string;
+  verifier?: ExternalHarnessVerifierConfig;
+}
+
+export interface ParsedEveResult extends ParsedEvalResult {}
+
+export function buildEvePrompt(plan: ExternalHarnessTaskPlan, toolInstructions?: string): string {
+  return buildExternalHarnessPrompt({
+    plan,
+    toolInstructions,
+    resultContract: "structured_output",
+  });
+}
+
+export function parseEveResult(raw: string): ParsedEveResult {
+  return parseEvalResult(raw);
+}
+
+export async function runEveAgent({
+  plan,
+  model,
+  logger,
+  toolAdapter,
+  signal,
+  client,
+  serverUrl,
+  verifier,
+}: EveRunnerInput): Promise<TaskResult> {
+  const adapterLike: ExternalHarnessToolAdapterLike | undefined = toolAdapter && {
+    promptInstructions: toolAdapter.promptInstructions,
+    captureEvidence: toolAdapter.captureEvidence,
+    drainStepObservations: toolAdapter.drainStepObservations,
+    observedToolMatcher: toolAdapter.observedToolMatcher,
+  };
+  return runExternalHarnessTask({
+    harness: "eve",
+    plan,
+    logger,
+    toolAdapter: adapterLike,
+    verifier,
+    resultContract: "structured_output",
+    fallbackErrorMessage: "Eve did not report success",
+    runSession: async (prompt) => {
+      const server = serverUrl
+        ? { url: serverUrl }
+        : toolAdapter
+          ? await prepareGeneratedServer(toolAdapter, model)
+          : undefined;
+      if (!server) {
+        throw new EvalsError(
+          "Eve harness needs a prepared tool adapter (generated app) or a serverUrl.",
+        );
+      }
+      const sessionResult = await runEveSession({
+        prompt,
+        model,
+        logger,
+        signal,
+        server,
+        client,
+        maxToolSteps: readEveMaxToolSteps(),
+        onToolResult: (name) => {
+          if (toolAdapter?.observedToolMatcher(name)) toolAdapter.recordObservation?.();
+        },
+      });
+      const usage = normalizeEveUsage(sessionResult.tokenUsage);
+      return {
+        raw: sessionResult,
+        resultText: sessionResult.finalMessage,
+        transcriptText: buildEveTranscript(sessionResult.events),
+        iterationError: sessionResult.iterationError,
+        status: sessionResult.status,
+        stopReason:
+          sessionResult.stopReason ||
+          (sessionResult.status === "sdk_error"
+            ? stringifyError(sessionResult.iterationError) || undefined
+            : undefined),
+        usage,
+        ...(sessionResult.tokenUsage.costUsd !== undefined && {
+          costUsd: sessionResult.tokenUsage.costUsd,
+        }),
+        metrics: buildEveMetrics(sessionResult.tokenUsage),
+      };
+    },
+    toTrajectory: (
+      { raw, parsed, finalObservation, stepObservations, observedToolName, status },
+      taskSpec,
+    ) =>
+      eveAdapter.fromHarnessResult(
+        {
+          events: raw.events,
+          ...(finalObservation && { finalObservation }),
+          ...(stepObservations?.length && { stepObservations }),
+          ...(observedToolName && { observedToolName }),
+          finalAnswer: parsed.finalAnswer ?? raw.finalMessage,
+          status,
+          usage: {
+            input_tokens: raw.tokenUsage.inputTokens,
+            output_tokens: raw.tokenUsage.outputTokens,
+            cached_input_tokens: raw.tokenUsage.cacheReadTokens,
+          },
+        },
+        taskSpec,
+      ),
+  });
+}
+
+async function prepareGeneratedServer(
+  toolAdapter: PreparedEveToolAdapter,
+  model: AvailableModel,
+): Promise<{ appRoot: string; env: Record<string, string>; readyTimeoutMs: number }> {
+  await writeEveAgentDefinition(toolAdapter.appRoot, model);
+  return {
+    appRoot: toolAdapter.appRoot,
+    env: stringOnly({ ...process.env, ...toolAdapter.env }),
+    readyTimeoutMs: readPositiveIntEnv("EVAL_EVE_READY_TIMEOUT_MS", 120_000),
+  };
+}
+
+function readEveMaxToolSteps(): number {
+  for (const key of ["EVAL_EVE_MAX_STEPS", "AGENT_EVAL_MAX_STEPS"]) {
+    const parsed = Number.parseInt(process.env[key] ?? "", 10);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  return 50;
+}
+
+function readPositiveIntEnv(key: string, fallback: number): number {
+  const parsed = Number.parseInt(process.env[key] ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function stringOnly(
+  env: NodeJS.ProcessEnv | Record<string, string | undefined>,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(env).filter((entry): entry is [string, string] => typeof entry[1] === "string"),
+  );
+}
+
+function normalizeEveUsage(usage: EveTokenUsage) {
+  return {
+    inputTokens: toFiniteNumber(usage.inputTokens),
+    outputTokens: toFiniteNumber(usage.outputTokens),
+    cachedInputTokens: toFiniteNumber(usage.cacheReadTokens),
+    cacheCreationInputTokens: toFiniteNumber(usage.cacheWriteTokens),
+    totalTokens: toFiniteNumber(usage.totalTokens),
+  };
+}
+
+function buildEveMetrics(usage: EveTokenUsage): Record<string, MetricValue> {
+  const normalized = normalizeEveUsage(usage);
+  return {
+    eve_input_tokens: metricValue(normalized.inputTokens),
+    eve_output_tokens: metricValue(normalized.outputTokens),
+    eve_cache_read_tokens: metricValue(normalized.cachedInputTokens),
+    eve_cache_write_tokens: metricValue(normalized.cacheCreationInputTokens),
+    eve_total_tokens: metricValue(normalized.totalTokens),
+    ...(usage.costUsd !== undefined && { eve_cost_usd: metricValue(usage.costUsd) }),
+  };
+}

--- a/packages/evals/framework/eveRunner.ts
+++ b/packages/evals/framework/eveRunner.ts
@@ -1,11 +1,5 @@
-import {
-  buildEveTranscript,
-  runEveSession,
-  stringifyError,
-  toFiniteNumber,
-  type EveClientLike,
-  type EveTokenUsage,
-} from "@browserbasehq/stagehand-integrations-eve-sdk";
+import { sanitizeErrorMessage } from "@browserbasehq/stagehand-integrations/harness";
+import type { EveClientLike, EveTokenUsage } from "@browserbasehq/stagehand-integrations-eve-sdk";
 import type { AvailableModel } from "stagehand-v3";
 import { EvalsError } from "../errors.js";
 import type { EvalLogger } from "../logger.js";
@@ -75,6 +69,8 @@ export async function runEveAgent({
     resultContract: "structured_output",
     fallbackErrorMessage: "Eve did not report success",
     runSession: async (prompt) => {
+      const { buildEveTranscript, runEveSession, stringifyError } =
+        await import("@browserbasehq/stagehand-integrations-eve-sdk");
       const server = serverUrl
         ? { url: serverUrl }
         : toolAdapter
@@ -98,17 +94,16 @@ export async function runEveAgent({
         },
       });
       const usage = normalizeEveUsage(sessionResult.tokenUsage);
+      const iterationError = sanitizeErrorMessage(stringifyError(sessionResult.iterationError));
       return {
         raw: sessionResult,
         resultText: sessionResult.finalMessage,
-        transcriptText: buildEveTranscript(sessionResult.events),
-        iterationError: sessionResult.iterationError,
+        transcriptText: sanitizeErrorMessage(buildEveTranscript(sessionResult.events)),
+        ...(iterationError && { iterationError }),
         status: sessionResult.status,
         stopReason:
           sessionResult.stopReason ||
-          (sessionResult.status === "sdk_error"
-            ? stringifyError(sessionResult.iterationError) || undefined
-            : undefined),
+          (sessionResult.status === "sdk_error" ? iterationError || undefined : undefined),
         usage,
         ...(sessionResult.tokenUsage.costUsd !== undefined && {
           costUsd: sessionResult.tokenUsage.costUsd,
@@ -180,6 +175,16 @@ function normalizeEveUsage(usage: EveTokenUsage) {
     cacheCreationInputTokens: toFiniteNumber(usage.cacheWriteTokens),
     totalTokens: toFiniteNumber(usage.totalTokens),
   };
+}
+
+function toFiniteNumber(value: unknown): number {
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim()
+        ? Number(value)
+        : 0;
+  return Number.isFinite(parsed) ? parsed : 0;
 }
 
 function buildEveMetrics(usage: EveTokenUsage): Record<string, MetricValue> {

--- a/packages/evals/framework/eveRunner.ts
+++ b/packages/evals/framework/eveRunner.ts
@@ -1,5 +1,10 @@
 import { sanitizeErrorMessage } from "@browserbasehq/stagehand-integrations/harness";
-import type { EveClientLike, EveTokenUsage } from "@browserbasehq/stagehand-integrations-eve-sdk";
+import type {
+  EveClientLike,
+  EveEvent,
+  EveSessionResult,
+  EveTokenUsage,
+} from "@browserbasehq/stagehand-integrations-eve-sdk";
 import type { AvailableModel } from "stagehand-v3";
 import { EvalsError } from "../errors.js";
 import type { EvalLogger } from "../logger.js";
@@ -95,9 +100,10 @@ export async function runEveAgent({
       });
       const usage = normalizeEveUsage(sessionResult.tokenUsage);
       const iterationError = sanitizeErrorMessage(stringifyError(sessionResult.iterationError));
+      const sanitizedSessionResult = sanitizeEveSessionResult(sessionResult, iterationError);
       return {
-        raw: sessionResult,
-        resultText: sessionResult.finalMessage,
+        raw: sanitizedSessionResult,
+        resultText: sanitizedSessionResult.finalMessage,
         transcriptText: sanitizeErrorMessage(buildEveTranscript(sessionResult.events)),
         ...(iterationError && { iterationError }),
         status: sessionResult.status,
@@ -132,6 +138,32 @@ export async function runEveAgent({
         taskSpec,
       ),
   });
+}
+
+export function sanitizeEveSessionResult(
+  result: EveSessionResult,
+  sanitizedIterationError = sanitizeErrorMessage(String(result.iterationError ?? "")),
+): EveSessionResult {
+  return {
+    ...result,
+    events: sanitizeEveValue(result.events) as EveEvent[],
+    finalMessage: sanitizeErrorMessage(result.finalMessage),
+    ...(result.stopReason && { stopReason: sanitizeErrorMessage(result.stopReason) }),
+    ...(result.iterationError !== undefined && {
+      iterationError: sanitizedIterationError || "Eve session failed.",
+    }),
+  };
+}
+
+function sanitizeEveValue(value: unknown): unknown {
+  if (typeof value === "string") return sanitizeErrorMessage(value);
+  if (Array.isArray(value)) return value.map(sanitizeEveValue);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, sanitizeEveValue(entry)]),
+    );
+  }
+  return value;
 }
 
 async function prepareGeneratedServer(

--- a/packages/evals/framework/eveToolAdapter.ts
+++ b/packages/evals/framework/eveToolAdapter.ts
@@ -69,6 +69,7 @@ export const EVE_DISABLED_FRAMEWORK_TOOLS = [
   "agent",
   "ask_question",
   "todo",
+  "load_skill",
 ] as const;
 
 export type EveModelProvider = {

--- a/packages/evals/framework/eveToolAdapter.ts
+++ b/packages/evals/framework/eveToolAdapter.ts
@@ -1,7 +1,6 @@
 import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { resolveEveAppNodeModulesDir } from "@browserbasehq/stagehand-integrations-eve-sdk";
 import { connectToMCPServer, type ProbeEvidence } from "stagehand-v3";
 import type { StartupProfile, ToolSurface } from "../core/contracts/tool.js";
 import { EvalsError } from "../errors.js";
@@ -276,9 +275,12 @@ export async function prepareEveToolAdapter(
       servers[name] = tools;
     }
     const files = buildEveAgentAppFiles({ instructions: mount.promptInstructions, servers });
+    const nodeModulesDir =
+      input.nodeModulesDir ??
+      (await import("@browserbasehq/stagehand-integrations-eve-sdk")).resolveEveAppNodeModulesDir();
     appRoot = await writeEveAgentApp({
       files,
-      nodeModulesDir: input.nodeModulesDir ?? resolveEveAppNodeModulesDir(),
+      nodeModulesDir,
       tmpRoot: input.tmpRoot,
       prefix: `stagehand-evals-eve-${toolSurface.replace(/_/g, "-")}-`,
     });

--- a/packages/evals/framework/eveToolAdapter.ts
+++ b/packages/evals/framework/eveToolAdapter.ts
@@ -1,0 +1,445 @@
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { resolveEveAppNodeModulesDir } from "@browserbasehq/stagehand-integrations-eve-sdk";
+import { connectToMCPServer, type ProbeEvidence } from "stagehand-v3";
+import type { StartupProfile, ToolSurface } from "../core/contracts/tool.js";
+import { EvalsError } from "../errors.js";
+import type { EvalLogger } from "../logger.js";
+import { startAgentToolRuntime } from "./agentToolRuntime.js";
+import type { ExternalHarnessTaskPlan } from "./externalHarnessPlan.js";
+import { resolveStartupProfile, resolveToolSurface } from "./harnesses/toolSurfaceResolution.js";
+import { ObservationRecorder, type StepObservation } from "./observationRecorder.js";
+
+export interface EveToolAdapterInput {
+  toolSurface?: ToolSurface;
+  startupProfile?: StartupProfile;
+  environment: "LOCAL" | "BROWSERBASE";
+  plan: ExternalHarnessTaskPlan;
+  logger: EvalLogger;
+  listMcpTools?: (spec: EveMcpServerSpec) => Promise<EveMcpToolDescriptor[]>;
+  nodeModulesDir?: string;
+  tmpRoot?: string;
+}
+
+export interface EveMcpServerSpec {
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+export interface EveMcpToolDescriptor {
+  name: string;
+  description?: string;
+  inputSchema: Record<string, unknown>;
+}
+
+export interface PreparedEveToolAdapter {
+  toolSurface: ToolSurface;
+  startupProfile: StartupProfile;
+  appRoot: string;
+  env: Record<string, string>;
+  promptInstructions: string;
+  serverNames: string[];
+  toolNames: string[];
+  captureEvidence?: () => Promise<ProbeEvidence>;
+  drainStepObservations?: () => Promise<StepObservation[]>;
+  recordObservation?: () => void;
+  observedToolMatcher: (name: string) => boolean;
+  cleanup: () => Promise<void>;
+}
+
+export const EVE_TOOL_SURFACES: ToolSurface[] = [
+  "stagehand_facade",
+  "playwright_mcp",
+  "chrome_devtools_mcp",
+];
+
+export const EVE_MCP_SERVERS_ENV = "STAGEHAND_EVE_MCP_SERVERS";
+
+export const EVE_DISABLED_FRAMEWORK_TOOLS = [
+  "bash",
+  "read_file",
+  "write_file",
+  "glob",
+  "grep",
+  "web_fetch",
+  "web_search",
+  "agent",
+  "ask_question",
+  "todo",
+] as const;
+
+export type EveModelProvider = {
+  pkg: "@ai-sdk/openai" | "@ai-sdk/anthropic" | "@ai-sdk/google";
+  factory: "openai" | "anthropic" | "google";
+  modelId: string;
+};
+
+export function eveToolSlug(server: string, tool: string): string {
+  const sanitize = (value: string): string => value.replace(/[^A-Za-z0-9_]/g, "_");
+  return `${sanitize(server)}__${sanitize(tool)}`;
+}
+
+export function resolveEveModelProvider(model: string): EveModelProvider {
+  const separator = model.indexOf("/");
+  const prefix = separator >= 0 ? model.slice(0, separator) : "openai";
+  const modelId = separator >= 0 ? model.slice(separator + 1) : model;
+  if (prefix === "openai") return { pkg: "@ai-sdk/openai", factory: "openai", modelId };
+  if (prefix === "anthropic") {
+    return { pkg: "@ai-sdk/anthropic", factory: "anthropic", modelId };
+  }
+  if (prefix === "google") return { pkg: "@ai-sdk/google", factory: "google", modelId };
+  throw new EvalsError(
+    `Eve model "${model}" uses an unsupported provider. Supported prefixes: openai/, anthropic/, google/.`,
+  );
+}
+
+export function buildEveAgentDefinitionSource(model: string): string {
+  const provider = resolveEveModelProvider(model);
+  return [
+    `import { ${provider.factory} } from ${JSON.stringify(provider.pkg)};`,
+    'import { defineAgent } from "eve";',
+    "",
+    "export default defineAgent({",
+    `  model: ${provider.factory}(${JSON.stringify(provider.modelId)}),`,
+    "  limits: { maxInputTokensPerSession: false, maxOutputTokensPerSession: false },",
+    "});",
+    "",
+  ].join("\n");
+}
+
+export function buildEveAgentAppFiles(options: {
+  instructions: string;
+  servers: Record<string, EveMcpToolDescriptor[]>;
+}): Record<string, string> {
+  const files: Record<string, string> = {
+    "package.json": `${JSON.stringify(
+      { name: "stagehand-evals-eve-agent", private: true, type: "module" },
+      null,
+      2,
+    )}\n`,
+    "tsconfig.json": `${JSON.stringify(
+      {
+        compilerOptions: {
+          module: "NodeNext",
+          moduleResolution: "NodeNext",
+          target: "ES2022",
+          strict: true,
+          noEmit: true,
+          skipLibCheck: true,
+        },
+        include: ["agent/**/*.ts"],
+      },
+      null,
+      2,
+    )}\n`,
+    "agent/instructions.md": `${options.instructions}\n\nNever ask the user questions; decide yourself and continue.\nReturn the final answer as the requested compact JSON in your last message.\n`,
+    "agent/lib/mcp-bridge.ts": buildMcpBridgeSource(),
+  };
+  const usedSlugs = new Set<string>(EVE_DISABLED_FRAMEWORK_TOOLS);
+  for (const [server, tools] of Object.entries(options.servers)) {
+    for (const tool of tools) {
+      const slug = eveToolSlug(server, tool.name);
+      if (usedSlugs.has(slug)) {
+        throw new EvalsError(`Eve tool slug collision for "${slug}".`);
+      }
+      usedSlugs.add(slug);
+      files[`agent/tools/${slug}.ts`] = buildMcpToolSource(server, tool);
+    }
+  }
+  for (const name of EVE_DISABLED_FRAMEWORK_TOOLS) {
+    files[`agent/tools/${name}.ts`] =
+      'import { disableTool } from "eve/tools";\nexport default disableTool();\n';
+  }
+  return files;
+}
+
+export async function writeEveAgentApp(options: {
+  files: Record<string, string>;
+  nodeModulesDir: string;
+  tmpRoot?: string;
+  prefix: string;
+}): Promise<string> {
+  const appRoot = await fsp.mkdtemp(path.join(options.tmpRoot ?? os.tmpdir(), options.prefix));
+  for (const [relativePath, contents] of Object.entries(options.files)) {
+    const destination = path.join(appRoot, relativePath);
+    await fsp.mkdir(path.dirname(destination), { recursive: true });
+    await fsp.writeFile(destination, contents, "utf8");
+  }
+  await fsp.symlink(options.nodeModulesDir, path.join(appRoot, "node_modules"), "dir");
+  return appRoot;
+}
+
+export async function writeEveAgentDefinition(appRoot: string, model: string): Promise<void> {
+  const destination = path.join(appRoot, "agent", "agent.ts");
+  await fsp.mkdir(path.dirname(destination), { recursive: true });
+  await fsp.writeFile(destination, buildEveAgentDefinitionSource(model), "utf8");
+}
+
+export async function listMcpServerTools(spec: EveMcpServerSpec): Promise<EveMcpToolDescriptor[]> {
+  const client = await connectToMCPServer({
+    command: spec.command,
+    args: spec.args ?? [],
+    env: stringOnly({ ...process.env, ...spec.env }),
+  });
+  try {
+    const response = await client.listTools();
+    return response.tools.map((tool) => ({
+      name: tool.name,
+      ...(tool.description && { description: tool.description }),
+      inputSchema: tool.inputSchema as Record<string, unknown>,
+    }));
+  } finally {
+    await client.close();
+  }
+}
+
+export async function prepareEveToolAdapter(
+  input: EveToolAdapterInput,
+): Promise<PreparedEveToolAdapter> {
+  const toolSurface = resolveToolSurface(
+    { harness: "eve", supportedToolSurfaces: EVE_TOOL_SURFACES },
+    input.toolSurface,
+  );
+  if (!toolSurface) throw new EvalsError("Eve harness requires a tool surface.");
+  const startupProfile = resolveStartupProfile(
+    toolSurface,
+    input.environment,
+    input.startupProfile,
+  );
+  const runtime = await startAgentToolRuntime({
+    toolSurface,
+    startupProfile,
+    environment: input.environment,
+    logger: input.logger,
+  });
+  let appRoot: string | undefined;
+  try {
+    const mount = runtime.running.agentMount;
+    if (!mount) {
+      throw new EvalsError(`Tool surface "${toolSurface}" does not provide an agent mount.`);
+    }
+    if (mount.via !== "mcp") {
+      throw new EvalsError(
+        `Eve runs authored tools inside its own dev-server process; agent mounts delivered via "${mount.via}" are not supported yet.`,
+      );
+    }
+    const listTools = input.listMcpTools ?? listMcpServerTools;
+    const servers: Record<string, EveMcpToolDescriptor[]> = {};
+    for (const [name, rawSpec] of Object.entries(mount.mcpServers)) {
+      if (!isRecord(rawSpec) || typeof rawSpec.command !== "string") {
+        throw new EvalsError(`Eve MCP server "${name}" must provide a string command.`);
+      }
+      const spec = rawSpec as unknown as EveMcpServerSpec;
+      const tools = await listTools(spec);
+      if (tools.length === 0) {
+        throw new EvalsError(`Eve MCP server "${name}" listed no tools.`);
+      }
+      servers[name] = tools;
+    }
+    const files = buildEveAgentAppFiles({ instructions: mount.promptInstructions, servers });
+    appRoot = await writeEveAgentApp({
+      files,
+      nodeModulesDir: input.nodeModulesDir ?? resolveEveAppNodeModulesDir(),
+      tmpRoot: input.tmpRoot,
+      prefix: `stagehand-evals-eve-${toolSurface.replace(/_/g, "-")}-`,
+    });
+    const capturedAppRoot = appRoot;
+    const serverNames = Object.keys(servers);
+    const toolNames = Object.entries(servers).flatMap(([server, tools]) =>
+      tools.map((tool) => eveToolSlug(server, tool.name)),
+    );
+    const recorder = runtime.running.captureEvidence
+      ? new ObservationRecorder(runtime.running.captureEvidence)
+      : undefined;
+    let cleanupPromise: Promise<void> | undefined;
+
+    input.logger.log({
+      category: "eve",
+      message: `Initialized ${toolSurface} MCP mount for Eve (servers: ${serverNames.join(", ")}; tools: ${toolNames.length}).`,
+      level: 1,
+      auxiliary: {
+        startupProfile: { value: startupProfile, type: "string" },
+        environment: { value: input.environment, type: "string" },
+      },
+    });
+
+    return {
+      toolSurface,
+      startupProfile,
+      appRoot,
+      env: { [EVE_MCP_SERVERS_ENV]: JSON.stringify(mount.mcpServers) },
+      promptInstructions: mount.promptInstructions,
+      serverNames,
+      toolNames,
+      ...(runtime.running.captureEvidence && {
+        captureEvidence: boundedCaptureEvidence(runtime.running.captureEvidence),
+      }),
+      ...(recorder && {
+        drainStepObservations: async () => {
+          await recorder.settle();
+          return recorder.drain();
+        },
+        recordObservation: () => void recorder.record(),
+      }),
+      observedToolMatcher: (name: string) =>
+        serverNames.some((server) => name.startsWith(eveToolSlug(server, ""))),
+      cleanup: async () => {
+        cleanupPromise ??= (async () => {
+          await runtime.cleanup().catch((): undefined => undefined);
+          await fsp.rm(capturedAppRoot, { recursive: true, force: true });
+        })();
+        await cleanupPromise;
+      },
+    };
+  } catch (error) {
+    await withCaptureTimeout(
+      runtime.cleanup(),
+      readPositiveIntEnv("EVAL_AGENT_MOUNT_CLEANUP_TIMEOUT_MS", 30_000),
+    ).catch((): undefined => undefined);
+    if (appRoot) await fsp.rm(appRoot, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+function buildMcpToolSource(server: string, tool: EveMcpToolDescriptor): string {
+  const description = tool.description ?? `MCP tool ${tool.name} from ${server}`;
+  return [
+    'import { defineTool } from "eve/tools";',
+    'import { callMcpTool, toModelOutput } from "../lib/mcp-bridge.js";',
+    "",
+    "export default defineTool({",
+    `  description: ${JSON.stringify(description)},`,
+    `  inputSchema: ${JSON.stringify(tool.inputSchema, null, 2)},`,
+    "  async execute(input) {",
+    `    return callMcpTool(${JSON.stringify(server)}, ${JSON.stringify(tool.name)}, (input ?? {}) as Record<string, unknown>);`,
+    "  },",
+    "  toModelOutput,",
+    "});",
+    "",
+  ].join("\n");
+}
+
+function buildMcpBridgeSource(): string {
+  return [
+    'import { Client } from "@modelcontextprotocol/sdk/client/index.js";',
+    'import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";',
+    'import { toolOutput, toolOutputPart } from "eve/tools";',
+    "",
+    `const SERVERS_ENV = ${JSON.stringify(EVE_MCP_SERVERS_ENV)};`,
+    "type ServerSpec = { command: string; args?: string[]; env?: Record<string, string> };",
+    "const clients = new Map<string, Promise<Client>>();",
+    "",
+    "function stringOnly(env: NodeJS.ProcessEnv | Record<string, string | undefined>): Record<string, string> {",
+    '  return Object.fromEntries(Object.entries(env).filter((entry): entry is [string, string] => typeof entry[1] === "string"));',
+    "}",
+    "",
+    "function readServerSpecs(): Record<string, ServerSpec> {",
+    "  const raw = process.env[SERVERS_ENV];",
+    "  if (!raw) throw new Error(`Missing ${SERVERS_ENV}.`);",
+    "  let parsed: unknown;",
+    "  try { parsed = JSON.parse(raw); } catch { throw new Error(`Invalid JSON in ${SERVERS_ENV}.`); }",
+    '  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error(`Invalid server map in ${SERVERS_ENV}.`);',
+    "  for (const [name, spec] of Object.entries(parsed)) {",
+    '    if (!spec || typeof spec !== "object" || Array.isArray(spec) || typeof (spec as ServerSpec).command !== "string") {',
+    "      throw new Error(`Invalid MCP server specification for ${name}.`);",
+    "    }",
+    "  }",
+    "  return parsed as Record<string, ServerSpec>;",
+    "}",
+    "",
+    "async function getClient(server: string): Promise<Client> {",
+    "  const existing = clients.get(server);",
+    "  if (existing) return existing;",
+    "  const pending = (async () => {",
+    "    const spec = readServerSpecs()[server];",
+    "    if (!spec) throw new Error(`Unknown MCP server ${server}.`);",
+    '    const client = new Client({ name: "stagehand-evals-eve", version: "0.0.0" });',
+    "    await client.connect(new StdioClientTransport({ command: spec.command, args: spec.args ?? [], env: stringOnly({ ...process.env, ...spec.env }) }));",
+    "    return client;",
+    "  })();",
+    "  clients.set(server, pending);",
+    "  try { return await pending; } catch (error) { clients.delete(server); throw error; }",
+    "}",
+    "",
+    "export type McpBridgeResult = { content: Array<{ type: string; text?: string; data?: string; mimeType?: string }>; isError?: boolean; structuredContent?: unknown };",
+    "",
+    "export async function callMcpTool(server: string, tool: string, args: Record<string, unknown>): Promise<McpBridgeResult> {",
+    "  const client = await getClient(server);",
+    "  const raw = await client.callTool({ name: tool, arguments: args });",
+    "  const content = Array.isArray(raw.content) ? raw.content.map((block) => {",
+    '    if (block.type === "text") return { type: "text", text: block.text };',
+    '    if (block.type === "image") return { type: "image", data: block.data, mimeType: block.mimeType };',
+    "    return { type: String(block.type) };",
+    "  }) : [];",
+    "  const result: McpBridgeResult = { content, ...(raw.isError === true && { isError: true }), ...(raw.structuredContent !== undefined && { structuredContent: raw.structuredContent }) };",
+    "  if (result.isError) {",
+    '    const message = result.content.filter((block) => block.type === "text" && block.text).map((block) => block.text).join("\\n");',
+    "    throw new Error(message || `MCP tool ${tool} failed`);",
+    "  }",
+    "  return result;",
+    "}",
+    "",
+    "export function toModelOutput(result: McpBridgeResult) {",
+    "  const parts = result.content.flatMap((block) => {",
+    '    if (block.type === "text" && block.text) return [toolOutputPart.text(block.text)];',
+    '    if (block.type === "image" && block.data) return [toolOutputPart.file(block.data, { mediaType: block.mimeType ?? "image/png" })];',
+    "    return [];",
+    "  });",
+    "  return parts.length > 0 ? toolOutput.content(parts) : toolOutput.json(result.structuredContent ?? result);",
+    "}",
+    "",
+  ].join("\n");
+}
+
+function stringOnly(
+  env: NodeJS.ProcessEnv | Record<string, string | undefined>,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(env).filter((entry): entry is [string, string] => typeof entry[1] === "string"),
+  );
+}
+
+function boundedCaptureEvidence(
+  capture: () => Promise<ProbeEvidence>,
+): () => Promise<ProbeEvidence> {
+  return async () => {
+    try {
+      return await withCaptureTimeout(
+        capture(),
+        readPositiveIntEnv("EVAL_CAPTURE_EVIDENCE_TIMEOUT_MS", 15_000),
+      );
+    } catch {
+      return {};
+    }
+  };
+}
+
+function readPositiveIntEnv(key: string, fallback: number): number {
+  const parsed = Number.parseInt(process.env[key] ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function withCaptureTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`eve adapter operation timed out after ${timeoutMs}ms`)),
+      timeoutMs,
+    );
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/packages/evals/framework/eveToolAdapter.ts
+++ b/packages/evals/framework/eveToolAdapter.ts
@@ -37,6 +37,7 @@ export interface EveMcpToolDescriptor {
 export interface PreparedEveToolAdapter {
   toolSurface: ToolSurface;
   startupProfile: StartupProfile;
+  /** The runner writes the agent definition via writeEveAgentDefinition before boot. */
   appRoot: string;
   env: Record<string, string>;
   promptInstructions: string;
@@ -162,13 +163,18 @@ export async function writeEveAgentApp(options: {
   prefix: string;
 }): Promise<string> {
   const appRoot = await fsp.mkdtemp(path.join(options.tmpRoot ?? os.tmpdir(), options.prefix));
-  for (const [relativePath, contents] of Object.entries(options.files)) {
-    const destination = path.join(appRoot, relativePath);
-    await fsp.mkdir(path.dirname(destination), { recursive: true });
-    await fsp.writeFile(destination, contents, "utf8");
+  try {
+    for (const [relativePath, contents] of Object.entries(options.files)) {
+      const destination = path.join(appRoot, relativePath);
+      await fsp.mkdir(path.dirname(destination), { recursive: true });
+      await fsp.writeFile(destination, contents, "utf8");
+    }
+    await fsp.symlink(options.nodeModulesDir, path.join(appRoot, "node_modules"), "dir");
+    return appRoot;
+  } catch (error) {
+    await fsp.rm(appRoot, { recursive: true, force: true });
+    throw error;
   }
-  await fsp.symlink(options.nodeModulesDir, path.join(appRoot, "node_modules"), "dir");
-  return appRoot;
 }
 
 export async function writeEveAgentDefinition(appRoot: string, model: string): Promise<void> {
@@ -177,21 +183,51 @@ export async function writeEveAgentDefinition(appRoot: string, model: string): P
   await fsp.writeFile(destination, buildEveAgentDefinitionSource(model), "utf8");
 }
 
-export async function listMcpServerTools(spec: EveMcpServerSpec): Promise<EveMcpToolDescriptor[]> {
-  const client = await connectToMCPServer({
+export async function listMcpServerTools(
+  spec: EveMcpServerSpec,
+  options?: { connect?: typeof connectToMCPServer; timeoutMs?: number },
+): Promise<EveMcpToolDescriptor[]> {
+  const timeoutMs =
+    options?.timeoutMs ?? readPositiveIntEnv("EVAL_EVE_MCP_LIST_TOOLS_TIMEOUT_MS", 60_000);
+  const connect = options?.connect ?? connectToMCPServer;
+  const connectPromise = connect({
     command: spec.command,
     args: spec.args ?? [],
     env: stringOnly({ ...process.env, ...spec.env }),
   });
+  let connectTimedOut = false;
+  let client: Awaited<ReturnType<typeof connectToMCPServer>>;
   try {
-    const response = await client.listTools();
+    client = await withCaptureTimeout(connectPromise, timeoutMs, () => {
+      connectTimedOut = true;
+      return new EvalsError(
+        `Eve MCP server command "${spec.command}" timed out after ${timeoutMs}ms while connecting.`,
+      );
+    });
+  } catch (error) {
+    if (connectTimedOut) {
+      void connectPromise
+        .then((lateClient) => lateClient.close())
+        .catch((): undefined => undefined);
+    }
+    throw error;
+  }
+  try {
+    const response = await withCaptureTimeout(
+      client.listTools(),
+      timeoutMs,
+      () =>
+        new EvalsError(
+          `Eve MCP server command "${spec.command}" timed out after ${timeoutMs}ms while listing tools.`,
+        ),
+    );
     return response.tools.map((tool) => ({
       name: tool.name,
       ...(tool.description && { description: tool.description }),
       inputSchema: tool.inputSchema as Record<string, unknown>,
     }));
   } finally {
-    await client.close();
+    await withCaptureTimeout(client.close(), timeoutMs).catch((): undefined => undefined);
   }
 }
 
@@ -287,8 +323,16 @@ export async function prepareEveToolAdapter(
         serverNames.some((server) => name.startsWith(eveToolSlug(server, ""))),
       cleanup: async () => {
         cleanupPromise ??= (async () => {
-          await runtime.cleanup().catch((): undefined => undefined);
-          await fsp.rm(capturedAppRoot, { recursive: true, force: true });
+          try {
+            await withCaptureTimeout(
+              runtime.cleanup(),
+              readPositiveIntEnv("EVAL_AGENT_MOUNT_CLEANUP_TIMEOUT_MS", 30_000),
+            );
+          } catch {
+            // Cleanup is best-effort, but temp-dir cleanup must run.
+          } finally {
+            await fsp.rm(capturedAppRoot, { recursive: true, force: true });
+          }
         })();
         await cleanupPromise;
       },
@@ -421,12 +465,14 @@ function readPositiveIntEnv(key: string, fallback: number): number {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
-function withCaptureTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+function withCaptureTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  timeoutError: () => Error = () =>
+    new Error(`eve adapter operation timed out after ${timeoutMs}ms`),
+): Promise<T> {
   return new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(
-      () => reject(new Error(`eve adapter operation timed out after ${timeoutMs}ms`)),
-      timeoutMs,
-    );
+    const timer = setTimeout(() => reject(timeoutError()), timeoutMs);
     promise.then(
       (value) => {
         clearTimeout(timer);

--- a/packages/evals/framework/eveToolAdapter.ts
+++ b/packages/evals/framework/eveToolAdapter.ts
@@ -1,7 +1,9 @@
 import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { connectToMCPServer, type ProbeEvidence } from "stagehand-v3";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import type { ProbeEvidence } from "stagehand-v3";
 import type { StartupProfile, ToolSurface } from "../core/contracts/tool.js";
 import { EvalsError } from "../errors.js";
 import type { EvalLogger } from "../logger.js";
@@ -32,6 +34,12 @@ export interface EveMcpToolDescriptor {
   description?: string;
   inputSchema: Record<string, unknown>;
 }
+
+type EveMcpClient = Pick<Client, "listTools" | "close">;
+type EveMcpConnect = (
+  spec: EveMcpServerSpec & { env: Record<string, string> },
+  signal?: AbortSignal,
+) => Promise<EveMcpClient>;
 
 export interface PreparedEveToolAdapter {
   toolSurface: ToolSurface;
@@ -185,21 +193,26 @@ export async function writeEveAgentDefinition(appRoot: string, model: string): P
 
 export async function listMcpServerTools(
   spec: EveMcpServerSpec,
-  options?: { connect?: typeof connectToMCPServer; timeoutMs?: number },
+  options?: { connect?: EveMcpConnect; timeoutMs?: number },
 ): Promise<EveMcpToolDescriptor[]> {
   const timeoutMs =
     options?.timeoutMs ?? readPositiveIntEnv("EVAL_EVE_MCP_LIST_TOOLS_TIMEOUT_MS", 60_000);
-  const connect = options?.connect ?? connectToMCPServer;
-  const connectPromise = connect({
-    command: spec.command,
-    args: spec.args ?? [],
-    env: stringOnly({ ...process.env, ...spec.env }),
-  });
+  const connect = options?.connect ?? connectEveMcpServer;
+  const connectController = new AbortController();
+  const connectPromise = connect(
+    {
+      command: spec.command,
+      args: spec.args ?? [],
+      env: stringOnly({ ...process.env, ...spec.env }),
+    },
+    connectController.signal,
+  );
   let connectTimedOut = false;
-  let client: Awaited<ReturnType<typeof connectToMCPServer>>;
+  let client: EveMcpClient;
   try {
     client = await withCaptureTimeout(connectPromise, timeoutMs, () => {
       connectTimedOut = true;
+      connectController.abort(new Error("Eve MCP connection timed out."));
       return new EvalsError(
         `Eve MCP server command "${spec.command}" timed out after ${timeoutMs}ms while connecting.`,
       );
@@ -228,6 +241,22 @@ export async function listMcpServerTools(
     }));
   } finally {
     await withCaptureTimeout(client.close(), timeoutMs).catch((): undefined => undefined);
+  }
+}
+
+async function connectEveMcpServer(
+  spec: EveMcpServerSpec & { env: Record<string, string> },
+  signal?: AbortSignal,
+): Promise<EveMcpClient> {
+  const client = new Client({ name: "stagehand-evals-eve", version: "1.0.0" });
+  const transport = new StdioClientTransport(spec);
+  try {
+    await client.connect(transport, signal ? { signal } : undefined);
+    await client.ping(signal ? { signal } : undefined);
+    return client;
+  } catch (error) {
+    await client.close().catch((): undefined => undefined);
+    throw error;
   }
 }
 

--- a/packages/evals/framework/harnesses/eveAdapter.ts
+++ b/packages/evals/framework/harnesses/eveAdapter.ts
@@ -1,0 +1,171 @@
+/**
+ * eveAdapter — converts Eve's streamed session events into verifier tool
+ * calls. Tool requests retain their inputs by callId; results, reasoning,
+ * usage, images, and page observations are folded in when their events arrive.
+ */
+import type { EveEvent } from "@browserbasehq/stagehand-integrations-eve-sdk";
+import type { ProbeEvidence, TaskSpec, Trajectory } from "stagehand-v3";
+import type { StepObservation } from "../observationRecorder.js";
+import {
+  buildTrajectory,
+  type NormalizedToolCall,
+  type TrajectoryAdapter,
+} from "./trajectoryAdapter.js";
+
+export interface EveRunResult {
+  events: EveEvent[];
+  finalAnswer?: string;
+  status?: Trajectory["status"];
+  usage?: Partial<Trajectory["usage"]>;
+  finalObservation?: ProbeEvidence;
+  stepObservations?: StepObservation[];
+  observedToolName?: (name: string) => boolean;
+}
+
+export class EveTrajectoryAdapter implements TrajectoryAdapter<EveRunResult> {
+  fromHarnessResult(result: EveRunResult, taskSpec: TaskSpec): Trajectory {
+    const requests = new Map<string, { toolName: string; input: Record<string, unknown> }>();
+    const toolCalls: NormalizedToolCall[] = [];
+    let pendingReasoning = "";
+    let latestAgentMessage: string | undefined;
+    const fallbackUsage = { input_tokens: 0, output_tokens: 0, cached_input_tokens: 0 };
+    let failed = false;
+
+    for (const event of result.events) {
+      const data = isRecord(event.data) ? event.data : undefined;
+      if (event.type === "actions.requested" && Array.isArray(data?.actions)) {
+        for (const action of data.actions) {
+          if (!isRecord(action) || action.kind !== "tool-call") continue;
+          if (typeof action.callId !== "string" || typeof action.toolName !== "string") continue;
+          requests.set(action.callId, {
+            toolName: action.toolName,
+            input: isRecord(action.input) ? action.input : {},
+          });
+        }
+        continue;
+      }
+      if (event.type === "reasoning.completed" && typeof data?.reasoning === "string") {
+        pendingReasoning = pendingReasoning
+          ? `${pendingReasoning}\n${data.reasoning}`
+          : data.reasoning;
+        continue;
+      }
+      if (event.type === "action.result") {
+        const actionResult = isRecord(data?.result) ? data.result : undefined;
+        if (actionResult?.kind !== "tool-result") continue;
+        const callId = typeof actionResult.callId === "string" ? actionResult.callId : "";
+        const request = requests.get(callId);
+        const toolName =
+          typeof actionResult.toolName === "string"
+            ? actionResult.toolName
+            : (request?.toolName ?? "tool");
+        const status = typeof data?.status === "string" ? data.status : "failed";
+        const ok = status === "completed" && actionResult.isError !== true;
+        const errorMessage =
+          isRecord(data?.error) && typeof data.error.message === "string"
+            ? data.error.message
+            : undefined;
+        const normalized = normalizeOutput(actionResult.output);
+        toolCalls.push({
+          name: toolName,
+          args: request?.input ?? {},
+          result: normalized.result,
+          ok,
+          ...(!ok && { error: errorMessage ?? `tool ${status}` }),
+          ...(pendingReasoning && { reasoning: pendingReasoning }),
+          ...(normalized.images.length > 0 && { images: normalized.images }),
+        });
+        pendingReasoning = "";
+        requests.delete(callId);
+        continue;
+      }
+      if (event.type === "message.completed" && typeof data?.message === "string") {
+        pendingReasoning = "";
+        latestAgentMessage = data.message;
+        continue;
+      }
+      if (event.type === "step.completed") {
+        const usage = isRecord(data?.usage) ? data.usage : undefined;
+        fallbackUsage.input_tokens += finiteNumber(usage?.inputTokens);
+        fallbackUsage.output_tokens += finiteNumber(usage?.outputTokens);
+        fallbackUsage.cached_input_tokens += finiteNumber(usage?.cacheReadTokens);
+        continue;
+      }
+      if (
+        event.type === "step.failed" ||
+        event.type === "turn.failed" ||
+        event.type === "session.failed"
+      ) {
+        failed = true;
+      }
+    }
+
+    pairStepObservations(toolCalls, result.stepObservations, result.observedToolName);
+    return buildTrajectory({
+      taskSpec,
+      toolCalls,
+      finalAnswer: result.finalAnswer ?? latestAgentMessage,
+      status: result.status ?? (failed ? "error" : "complete"),
+      usage: result.usage ?? fallbackUsage,
+      ...(result.finalObservation?.screenshot && { finalObservation: result.finalObservation }),
+    });
+  }
+}
+
+export const eveAdapter = new EveTrajectoryAdapter();
+
+function normalizeOutput(output: unknown): {
+  result: unknown;
+  images: Array<{ bytes: Buffer; mediaType: string }>;
+} {
+  if (!isRecord(output) || !Array.isArray(output.content)) {
+    return { result: output, images: [] };
+  }
+  const images: Array<{ bytes: Buffer; mediaType: string }> = [];
+  const text: string[] = [];
+  for (const block of output.content) {
+    if (!isRecord(block)) continue;
+    if (block.type === "text" && typeof block.text === "string") text.push(block.text);
+    else if (block.type === "image" && typeof block.data === "string") {
+      text.push("[image]");
+      images.push({
+        bytes: Buffer.from(block.data, "base64"),
+        mediaType: typeof block.mimeType === "string" ? block.mimeType : "image/png",
+      });
+    }
+  }
+  return {
+    result: output.structuredContent !== undefined ? output.structuredContent : text.join("\n"),
+    images,
+  };
+}
+
+function pairStepObservations(
+  toolCalls: NormalizedToolCall[],
+  observations: StepObservation[] | undefined,
+  observedToolName: ((name: string) => boolean) | undefined,
+): void {
+  if (!observations?.length) return;
+  const observedCalls = toolCalls.filter((call) =>
+    observedToolName ? observedToolName(call.name) : true,
+  );
+  const totalObservedRuns =
+    Math.max(...observations.map((observation) => observation.runIndex)) + 1;
+  if (observedCalls.length !== totalObservedRuns) return;
+  const byRunIndex = new Map(
+    observations.map((observation) => [observation.runIndex, observation.evidence]),
+  );
+  observedCalls.forEach((call, ordinal) => {
+    const observation = byRunIndex.get(ordinal);
+    if (observation) call.probeEvidence = observation;
+  });
+}
+
+function finiteNumber(value: unknown): number {
+  const parsed = typeof value === "number" ? value : Number(value ?? 0);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -27,6 +27,7 @@
     "@browserbasehq/stagehand-integrations": "workspace:*",
     "@browserbasehq/stagehand-integrations-claude-agent-sdk": "workspace:*",
     "@browserbasehq/stagehand-integrations-codex-sdk": "workspace:*",
+    "@browserbasehq/stagehand-integrations-eve-sdk": "workspace:*",
     "@browserbasehq/stagehand-integrations-mastra-sdk": "workspace:*",
     "@browserbasehq/stagehand-integrations-pi-sdk": "workspace:*",
     "@opentelemetry/api": "catalog:",

--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -30,6 +30,7 @@
     "@browserbasehq/stagehand-integrations-eve-sdk": "workspace:*",
     "@browserbasehq/stagehand-integrations-mastra-sdk": "workspace:*",
     "@browserbasehq/stagehand-integrations-pi-sdk": "workspace:*",
+    "@modelcontextprotocol/sdk": "catalog:",
     "@opentelemetry/api": "catalog:",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.220.0",
     "@opentelemetry/sdk-trace-base": "^2.9.0",
@@ -55,5 +56,8 @@
     "string-comparison": "^1.3.0",
     "vite": "catalog:",
     "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=24.0.0"
   }
 }

--- a/packages/evals/tests/framework/benchHarness.test.ts
+++ b/packages/evals/tests/framework/benchHarness.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../../framework/benchHarness.js";
 import { MASTRA_TOOL_SURFACES } from "../../framework/mastraToolAdapter.js";
 import { PI_TOOL_SURFACES } from "../../framework/piToolAdapter.js";
+import { defaultModelsEnvKey } from "../../framework/benchPlanner.js";
 import type { BenchMatrixRow } from "../../framework/benchTypes.js";
 import type { DiscoveredTask } from "../../framework/types.js";
 import type { EvalInput } from "../../types/evals.js";

--- a/packages/evals/tests/framework/benchHarness.test.ts
+++ b/packages/evals/tests/framework/benchHarness.test.ts
@@ -25,7 +25,14 @@ import { EvalLogger } from "../../logger.js";
 
 describe("bench harness registry", () => {
   it("lists registered harnesses in registration order", () => {
-    expect(listBenchHarnesses()).toEqual(["stagehand", "claude_code", "codex", "mastra", "pi", "eve"]);
+    expect(listBenchHarnesses()).toEqual([
+      "stagehand",
+      "claude_code",
+      "codex",
+      "mastra",
+      "pi",
+      "eve",
+    ]);
   });
 
   it("parses registered harnesses and defaults to stagehand", () => {

--- a/packages/evals/tests/framework/benchHarness.test.ts
+++ b/packages/evals/tests/framework/benchHarness.test.ts
@@ -12,6 +12,7 @@ import {
   listBenchHarnessesForToolSurface,
   mastraHarness,
   piHarness,
+  eveHarness,
   registerBenchHarness,
 } from "../../framework/benchHarness.js";
 import { MASTRA_TOOL_SURFACES } from "../../framework/mastraToolAdapter.js";
@@ -23,14 +24,14 @@ import { EvalLogger } from "../../logger.js";
 
 describe("bench harness registry", () => {
   it("lists registered harnesses in registration order", () => {
-    expect(listBenchHarnesses()).toEqual(["stagehand", "claude_code", "codex", "mastra", "pi"]);
+    expect(listBenchHarnesses()).toEqual(["stagehand", "claude_code", "codex", "mastra", "pi", "eve"]);
   });
 
   it("parses registered harnesses and defaults to stagehand", () => {
     expect(parseBenchHarness(undefined)).toBe("stagehand");
     expect(parseBenchHarness("codex")).toBe("codex");
     expect(() => parseBenchHarness("nope")).toThrow(
-      /Unknown harness "nope"\. Supported: stagehand, claude_code, codex, mastra, pi\./,
+      /Unknown harness "nope"\. Supported: stagehand, claude_code, codex, mastra, pi, eve\./,
     );
   });
 
@@ -91,6 +92,25 @@ describe("bench harness registry", () => {
     expect(harness.supportedToolSurfaces[0]).toBe("stagehand_facade");
     expect(harness.supportedToolSurfaces).not.toContain("browse_cli");
     expect(harness.defaultModels).toEqual(["openai/gpt-5.4-mini"]);
+  });
+
+  it("registers eve as a concrete executable harness", () => {
+    const harness = getBenchHarness("eve");
+
+    expect(harness).toBe(eveHarness);
+    expect(parseBenchHarness("eve")).toBe("eve");
+    expect(isExecutableBenchHarness("eve")).toBe(true);
+    expect(harness.supportedTaskKinds).toEqual(["agent", "suite"]);
+    expect(harness.supportsApi).toBe(false);
+    expect(harness.execute).toBeDefined();
+    expect(harness.start).toBeUndefined();
+    expect(harness.supportedToolSurfaces).toEqual([
+      "stagehand_facade",
+      "playwright_mcp",
+      "chrome_devtools_mcp",
+    ]);
+    expect(harness.defaultModels).toEqual(["openai/gpt-5.4-mini"]);
+    expect(defaultModelsEnvKey("eve")).toBe("EVAL_EVE_MODELS");
   });
 
   it("registers a new harness and rejects duplicate ids", () => {

--- a/packages/evals/tests/framework/eveAdapter.test.ts
+++ b/packages/evals/tests/framework/eveAdapter.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import type { EveEvent } from "@browserbasehq/stagehand-integrations-eve-sdk";
+import type { TaskSpec } from "stagehand-v3";
+import { eveAdapter } from "../../framework/harnesses/eveAdapter.js";
+
+const taskSpec: TaskSpec = {
+  id: "eve-test",
+  instruction: "Use the browser",
+  initUrl: "https://example.com",
+};
+
+function toolEvents(
+  options: {
+    status?: string;
+    isError?: boolean;
+    error?: string;
+    output?: unknown;
+    name?: string;
+  } = {},
+): EveEvent[] {
+  const name = options.name ?? "stagehand__run";
+  return [
+    {
+      type: "actions.requested",
+      data: {
+        actions: [{ kind: "tool-call", callId: "call-1", toolName: name, input: { code: "go" } }],
+      },
+    },
+    {
+      type: "action.result",
+      data: {
+        status: options.status ?? "completed",
+        ...(options.error && { error: { message: options.error } }),
+        result: {
+          kind: "tool-result",
+          callId: "call-1",
+          toolName: name,
+          output: options.output ?? { ok: true },
+          ...(options.isError && { isError: true }),
+        },
+      },
+    },
+  ];
+}
+
+describe("Eve trajectory adapter", () => {
+  it("maps a tool request and result into one trajectory step", () => {
+    const trajectory = eveAdapter.fromHarnessResult({ events: toolEvents() }, taskSpec);
+    expect(trajectory.steps).toHaveLength(1);
+    expect(trajectory.steps[0]).toMatchObject({
+      actionName: "stagehand__run",
+      actionArgs: { code: "go" },
+      toolOutput: { ok: true, result: { ok: true } },
+    });
+  });
+
+  it("maps failed results with the event error message", () => {
+    const trajectory = eveAdapter.fromHarnessResult(
+      {
+        events: toolEvents({ status: "failed", isError: true, error: "browser failed" }),
+      },
+      taskSpec,
+    );
+    expect(trajectory.steps[0].toolOutput).toMatchObject({
+      ok: false,
+      error: "browser failed",
+    });
+  });
+
+  it("extracts bridge text and image evidence", () => {
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    const trajectory = eveAdapter.fromHarnessResult(
+      {
+        events: toolEvents({
+          output: {
+            content: [
+              { type: "text", text: "screenshot" },
+              { type: "image", data: png.toString("base64"), mimeType: "image/png" },
+            ],
+          },
+        }),
+      },
+      taskSpec,
+    );
+    expect(trajectory.steps[0].toolOutput.result).toBe("screenshot\n[image]");
+    const images = trajectory.steps[0].agentEvidence.modalities.filter(
+      (modality) => modality.type === "image",
+    );
+    expect(images).toHaveLength(1);
+    expect(images[0]).toMatchObject({ mediaType: "image/png" });
+    expect((images[0] as { bytes: Buffer }).bytes.equals(png)).toBe(true);
+  });
+
+  it("folds completed reasoning into the next tool call", () => {
+    const trajectory = eveAdapter.fromHarnessResult(
+      {
+        events: [
+          { type: "reasoning.completed", data: { reasoning: "inspect first" } },
+          ...toolEvents(),
+        ],
+      },
+      taskSpec,
+    );
+    expect(trajectory.steps[0].reasoning).toBe("inspect first");
+  });
+
+  it("uses the last completed message as the final answer", () => {
+    const trajectory = eveAdapter.fromHarnessResult(
+      {
+        events: [
+          { type: "message.completed", data: { message: "first" } },
+          { type: "message.completed", data: { message: "last" } },
+        ],
+      },
+      taskSpec,
+    );
+    expect(trajectory.finalAnswer).toBe("last");
+  });
+
+  it("sums step usage when explicit usage is absent", () => {
+    const trajectory = eveAdapter.fromHarnessResult(
+      {
+        events: [
+          {
+            type: "step.completed",
+            data: { usage: { inputTokens: 10, outputTokens: 2, cacheReadTokens: 3 } },
+          },
+          {
+            type: "step.completed",
+            data: { usage: { inputTokens: 5, outputTokens: 4, cacheReadTokens: 1 } },
+          },
+        ],
+      },
+      taskSpec,
+    );
+    expect(trajectory.usage).toMatchObject({
+      input_tokens: 15,
+      output_tokens: 6,
+      cached_input_tokens: 4,
+    });
+  });
+
+  it("pairs observations only with matching observed tool calls", () => {
+    const events = [
+      ...toolEvents({ name: "unrelated" }),
+      ...toolEvents({ name: "stagehand__run" }).map((event) => {
+        const serialized = JSON.stringify(event).replaceAll("call-1", "call-2");
+        return JSON.parse(serialized) as EveEvent;
+      }),
+    ];
+    const screenshot = Buffer.from("png");
+    const trajectory = eveAdapter.fromHarnessResult(
+      {
+        events,
+        observedToolName: (name) => name.startsWith("stagehand__"),
+        stepObservations: [{ runIndex: 0, evidence: { url: "https://done", screenshot } }],
+      },
+      taskSpec,
+    );
+    expect(trajectory.steps[0].probeEvidence).toEqual({});
+    expect(trajectory.steps[1].probeEvidence).toMatchObject({ url: "https://done" });
+  });
+});

--- a/packages/evals/tests/framework/eveRunner.test.ts
+++ b/packages/evals/tests/framework/eveRunner.test.ts
@@ -102,13 +102,45 @@ describe("Eve runner helpers", () => {
     expect(metrics.harness_cost_usd.value).toBe(0.12);
   });
 
+  it("redacts secrets from tool results before copying the transcript into rawResult", async () => {
+    const client = fakeClient([
+      {
+        type: "action.result",
+        data: {
+          status: "completed",
+          result: {
+            kind: "tool-result",
+            toolName: "stagehand__run",
+            output: "key sk-abc123SUPERSECRET",
+          },
+        },
+      },
+      {
+        type: "message.completed",
+        data: { message: '{"success":true,"summary":"done"}' },
+      },
+      { type: "turn.completed" },
+    ]);
+
+    const result = await runEveAgent({
+      plan,
+      model: "openai/gpt-5.4-mini" as AvailableModel,
+      logger: new EvalLogger(false),
+      client,
+      serverUrl: "http://eve",
+    });
+
+    expect(result.rawResult).toContain("sk-abc123[redacted]");
+    expect(result.rawResult).not.toContain("SUPERSECRET");
+  });
+
   it("returns a failed task result when Eve send throws", async () => {
     const client: EveClientLike = {
       health: async () => ({}),
       session: () => ({
         cancel: async () => ({}),
         send: async () => {
-          throw new Error("eve send failed");
+          throw new Error("eve send failed with sk-abc123SUPERSECRET");
         },
       }),
     };
@@ -124,6 +156,8 @@ describe("Eve runner helpers", () => {
     expect(result.harnessStatus).toBe("sdk_error");
     expect(result.harnessStopReason).toBeDefined();
     expect(result.error).toEqual(expect.stringContaining("eve send failed"));
+    expect(JSON.stringify(result)).toContain("sk-abc123[redacted]");
+    expect(JSON.stringify(result)).not.toContain("SUPERSECRET");
   });
 
   it("rejects when no generated app or server URL is available", async () => {

--- a/packages/evals/tests/framework/eveRunner.test.ts
+++ b/packages/evals/tests/framework/eveRunner.test.ts
@@ -2,7 +2,12 @@
 import { describe, expect, it } from "vitest";
 import type { EveClientLike, EveEvent } from "@browserbasehq/stagehand-integrations-eve-sdk";
 import type { AvailableModel } from "stagehand-v3";
-import { buildEvePrompt, parseEveResult, runEveAgent } from "../../framework/eveRunner.js";
+import {
+  buildEvePrompt,
+  parseEveResult,
+  runEveAgent,
+  sanitizeEveSessionResult,
+} from "../../framework/eveRunner.js";
 import type { ExternalHarnessTaskPlan } from "../../framework/externalHarnessPlan.js";
 import { EvalLogger } from "../../logger.js";
 
@@ -134,6 +139,34 @@ describe("Eve runner helpers", () => {
     expect(result.rawResult).not.toContain("SUPERSECRET");
   });
 
+  it("redacts structured event payloads before trajectory conversion", () => {
+    const sanitized = sanitizeEveSessionResult({
+      events: [
+        {
+          type: "action.result",
+          data: {
+            result: {
+              kind: "tool-result",
+              output: { token: "sk-abc123SUPERSECRET" },
+            },
+          },
+        },
+      ],
+      finalMessage: "done sk-abc123SUPERSECRET",
+      status: "completed",
+      tokenUsage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        totalTokens: 0,
+      },
+    });
+
+    expect(JSON.stringify(sanitized)).toContain("sk-abc123[redacted]");
+    expect(JSON.stringify(sanitized)).not.toContain("SUPERSECRET");
+  });
+
   it("returns a failed task result when Eve send throws", async () => {
     const client: EveClientLike = {
       health: async () => ({}),
@@ -155,7 +188,7 @@ describe("Eve runner helpers", () => {
     expect(result.eveStatus).toBe("sdk_error");
     expect(result.harnessStatus).toBe("sdk_error");
     expect(result.harnessStopReason).toBeDefined();
-    expect(result.error).toEqual(expect.stringContaining("eve send failed"));
+    expect(result.error).toBe("Eve session failed.");
     expect(JSON.stringify(result)).toContain("sk-abc123[redacted]");
     expect(JSON.stringify(result)).not.toContain("SUPERSECRET");
   });

--- a/packages/evals/tests/framework/eveRunner.test.ts
+++ b/packages/evals/tests/framework/eveRunner.test.ts
@@ -1,0 +1,138 @@
+/* eslint-disable require-yield */
+import { describe, expect, it } from "vitest";
+import type { EveClientLike, EveEvent } from "@browserbasehq/stagehand-integrations-eve-sdk";
+import type { AvailableModel } from "stagehand-v3";
+import { buildEvePrompt, parseEveResult, runEveAgent } from "../../framework/eveRunner.js";
+import type { ExternalHarnessTaskPlan } from "../../framework/externalHarnessPlan.js";
+import { EvalLogger } from "../../logger.js";
+
+const plan: ExternalHarnessTaskPlan = {
+  dataset: "webvoyager",
+  taskId: "wv-1",
+  startUrl: "https://example.com",
+  instruction: "Find the checkout button",
+};
+
+function fakeClient(events: EveEvent[]): EveClientLike {
+  return {
+    health: async () => ({}),
+    session: () => ({
+      cancel: async () => ({}),
+      send: async () =>
+        Object.assign(
+          {
+            async *[Symbol.asyncIterator]() {
+              yield* events;
+            },
+          },
+          { sessionId: "eve-session" },
+        ),
+    }),
+  };
+}
+
+describe("Eve runner helpers", () => {
+  it("builds the shared structured-result browser prompt", () => {
+    const prompt = buildEvePrompt(plan, "Use the mounted Eve tools.");
+    expect(prompt).toContain("Dataset: webvoyager");
+    expect(prompt).toContain("Task ID: wv-1");
+    expect(prompt).toContain("Start URL: https://example.com");
+    expect(prompt).toContain("Find the checkout button");
+    expect(prompt).toContain("Use the mounted Eve tools.");
+    expect(prompt).toContain('"success": boolean');
+  });
+
+  it("parses direct and marker JSON results", () => {
+    expect(parseEveResult('{"success":true,"summary":"done","finalAnswer":"ok"}')).toMatchObject({
+      success: true,
+      summary: "done",
+      finalAnswer: "ok",
+    });
+    expect(parseEveResult('text\nEVAL_RESULT: {"success":true,"summary":"legacy"}')).toMatchObject({
+      success: true,
+      summary: "legacy",
+    });
+  });
+
+  it("streams an Eve turn into native and normalized metrics", async () => {
+    const client = fakeClient([
+      {
+        type: "step.completed",
+        data: {
+          usage: {
+            inputTokens: 100,
+            outputTokens: 25,
+            cacheReadTokens: 10,
+            cacheWriteTokens: 4,
+            costUsd: 0.12,
+          },
+        },
+      },
+      {
+        type: "message.completed",
+        data: {
+          message: '{"success":true,"summary":"done","finalAnswer":"clicked"}',
+        },
+      },
+      { type: "turn.completed" },
+    ]);
+    const result = await runEveAgent({
+      plan,
+      model: "openai/gpt-5.4-mini" as AvailableModel,
+      logger: new EvalLogger(false),
+      client,
+      serverUrl: "http://eve",
+    });
+    const metrics = result.metrics as Record<string, { value: number }>;
+    expect(result._success).toBe(true);
+    expect(result.eveStatus).toBe("completed");
+    expect(result.harnessStatus).toBe("completed");
+    expect(result.finalAnswer).toBe("clicked");
+    expect(metrics.eve_input_tokens.value).toBe(100);
+    expect(metrics.eve_output_tokens.value).toBe(25);
+    expect(metrics.eve_cache_read_tokens.value).toBe(10);
+    expect(metrics.eve_cache_write_tokens.value).toBe(4);
+    expect(metrics.eve_total_tokens.value).toBe(139);
+    expect(metrics.eve_cost_usd.value).toBe(0.12);
+    expect(metrics.harness_input_tokens.value).toBe(100);
+    expect(metrics.harness_cached_input_tokens.value).toBe(10);
+    expect(metrics.harness_cache_creation_input_tokens.value).toBe(4);
+    expect(metrics.harness_output_tokens.value).toBe(25);
+    expect(metrics.harness_total_tokens.value).toBe(139);
+    expect(metrics.harness_cost_usd.value).toBe(0.12);
+  });
+
+  it("returns a failed task result when Eve send throws", async () => {
+    const client: EveClientLike = {
+      health: async () => ({}),
+      session: () => ({
+        cancel: async () => ({}),
+        send: async () => {
+          throw new Error("eve send failed");
+        },
+      }),
+    };
+    const result = await runEveAgent({
+      plan,
+      model: "openai/gpt-5.4-mini" as AvailableModel,
+      logger: new EvalLogger(false),
+      client,
+      serverUrl: "http://eve",
+    });
+    expect(result._success).toBe(false);
+    expect(result.eveStatus).toBe("sdk_error");
+    expect(result.harnessStatus).toBe("sdk_error");
+    expect(result.harnessStopReason).toBeDefined();
+    expect(result.error).toEqual(expect.stringContaining("eve send failed"));
+  });
+
+  it("rejects when no generated app or server URL is available", async () => {
+    await expect(
+      runEveAgent({
+        plan,
+        model: "openai/gpt-5.4-mini" as AvailableModel,
+        logger: new EvalLogger(false),
+      }),
+    ).rejects.toThrow("Eve harness needs a prepared tool adapter (generated app) or a serverUrl.");
+  });
+});

--- a/packages/evals/tests/framework/eveToolAdapter.test.ts
+++ b/packages/evals/tests/framework/eveToolAdapter.test.ts
@@ -123,6 +123,27 @@ describe("Eve tool adapter helpers", () => {
     }
   });
 
+  it("removes the temp app when generation fails after mkdtemp", async () => {
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), "eve-adapter-failure-test-"));
+    const nodeModulesDir = path.join(root, "modules");
+    const tmpRoot = path.join(root, "tmp");
+    await fsp.mkdir(nodeModulesDir);
+    await fsp.mkdir(tmpRoot);
+    try {
+      await expect(
+        writeEveAgentApp({
+          files: { node_modules: "not a dir" },
+          nodeModulesDir,
+          tmpRoot,
+          prefix: "app-",
+        }),
+      ).rejects.toThrow();
+      expect(await fsp.readdir(tmpRoot)).toEqual([]);
+    } finally {
+      await fsp.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("defaults to the facade and lists all supported surfaces in errors", () => {
     expect(EVE_TOOL_SURFACES[0]).toBe("stagehand_facade");
     expect(resolveToolSurface({ harness: "eve", supportedToolSurfaces: EVE_TOOL_SURFACES })).toBe(

--- a/packages/evals/tests/framework/eveToolAdapter.test.ts
+++ b/packages/evals/tests/framework/eveToolAdapter.test.ts
@@ -73,6 +73,7 @@ describe("Eve tool adapter helpers", () => {
     for (const name of EVE_DISABLED_FRAMEWORK_TOOLS) {
       expect(files[`agent/tools/${name}.ts`]).toContain("disableTool");
     }
+    expect(files["agent/tools/load_skill.ts"]).toContain("disableTool");
     expect(files["agent/instructions.md"]).toContain("Use the mounted browser.");
     expect(files["agent/instructions.md"]).toContain("Never ask the user questions");
     expect(files["agent/instructions.md"]).toContain("requested compact JSON");

--- a/packages/evals/tests/framework/eveToolAdapter.test.ts
+++ b/packages/evals/tests/framework/eveToolAdapter.test.ts
@@ -1,0 +1,138 @@
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { EvalsError } from "../../errors.js";
+import {
+  EVE_DISABLED_FRAMEWORK_TOOLS,
+  EVE_TOOL_SURFACES,
+  buildEveAgentAppFiles,
+  buildEveAgentDefinitionSource,
+  eveToolSlug,
+  resolveEveModelProvider,
+  writeEveAgentApp,
+  writeEveAgentDefinition,
+} from "../../framework/eveToolAdapter.js";
+import { resolveToolSurface } from "../../framework/harnesses/toolSurfaceResolution.js";
+
+describe("Eve tool adapter helpers", () => {
+  it("sanitizes Eve tool slugs", () => {
+    expect(eveToolSlug("stage-hand.v1", "run/tool-now")).toBe("stage_hand_v1__run_tool_now");
+  });
+
+  it("resolves supported model providers and defaults bare ids to OpenAI", () => {
+    expect(resolveEveModelProvider("openai/gpt-5.4-mini")).toEqual({
+      pkg: "@ai-sdk/openai",
+      factory: "openai",
+      modelId: "gpt-5.4-mini",
+    });
+    expect(resolveEveModelProvider("anthropic/claude-sonnet-4-6")).toEqual({
+      pkg: "@ai-sdk/anthropic",
+      factory: "anthropic",
+      modelId: "claude-sonnet-4-6",
+    });
+    expect(resolveEveModelProvider("google/gemini-2.5-pro")).toEqual({
+      pkg: "@ai-sdk/google",
+      factory: "google",
+      modelId: "gemini-2.5-pro",
+    });
+    expect(resolveEveModelProvider("gpt-5.4-mini").factory).toBe("openai");
+    expect(() => resolveEveModelProvider("mistral/x")).toThrow(EvalsError);
+    expect(() => resolveEveModelProvider("mistral/x")).toThrow(/openai\/, anthropic\/, google\//);
+  });
+
+  it("builds an agent definition with the selected model and uncapped token limits", () => {
+    const source = buildEveAgentDefinitionSource("anthropic/claude-sonnet-4-6");
+    expect(source).toContain('from "@ai-sdk/anthropic"');
+    expect(source).toContain('anthropic("claude-sonnet-4-6")');
+    expect(source).toContain("maxInputTokensPerSession: false");
+    expect(source).toContain("maxOutputTokensPerSession: false");
+  });
+
+  it("builds authored MCP tools, bridge, instructions, and disabled built-ins", () => {
+    const files = buildEveAgentAppFiles({
+      instructions: "Use the mounted browser.",
+      servers: {
+        stagehand: [
+          {
+            name: "run",
+            description: "Run browser code",
+            inputSchema: {
+              type: "object",
+              properties: { code: { type: "string" } },
+              required: ["code"],
+            },
+          },
+        ],
+      },
+    });
+    const tool = files["agent/tools/stagehand__run.ts"];
+    expect(tool).toContain('"stagehand"');
+    expect(tool).toContain('"run"');
+    expect(tool).toContain('"code"');
+    for (const name of EVE_DISABLED_FRAMEWORK_TOOLS) {
+      expect(files[`agent/tools/${name}.ts`]).toContain("disableTool");
+    }
+    expect(files["agent/instructions.md"]).toContain("Use the mounted browser.");
+    expect(files["agent/instructions.md"]).toContain("Never ask the user questions");
+    expect(files["agent/instructions.md"]).toContain("requested compact JSON");
+    expect(files["agent/lib/mcp-bridge.ts"]).toContain("STAGEHAND_EVE_MCP_SERVERS");
+    expect(files["agent/lib/mcp-bridge.ts"]).toContain("@modelcontextprotocol/sdk/client/index.js");
+    expect(files["agent/lib/mcp-bridge.ts"]).toContain("@modelcontextprotocol/sdk/client/stdio.js");
+    expect(files).not.toHaveProperty("agent/agent.ts");
+  });
+
+  it("rejects generated slug collisions", () => {
+    expect(() =>
+      buildEveAgentAppFiles({
+        instructions: "test",
+        servers: {
+          "server-one": [{ name: "tool.name", inputSchema: { type: "object" } }],
+          server_one: [{ name: "tool/name", inputSchema: { type: "object" } }],
+        },
+      }),
+    ).toThrow(/slug collision/);
+  });
+
+  it("writes an Eve app with a safe node_modules symlink and agent definition", async () => {
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), "eve-adapter-test-"));
+    const nodeModulesDir = path.join(root, "modules");
+    await fsp.mkdir(nodeModulesDir);
+    await fsp.writeFile(path.join(nodeModulesDir, "marker"), "keep");
+    const appRoot = await writeEveAgentApp({
+      files: buildEveAgentAppFiles({ instructions: "test", servers: {} }),
+      nodeModulesDir,
+      tmpRoot: root,
+      prefix: "app-",
+    });
+    try {
+      expect(await fsp.readFile(path.join(appRoot, "package.json"), "utf8")).toContain(
+        "stagehand-evals-eve-agent",
+      );
+      const stat = await fsp.lstat(path.join(appRoot, "node_modules"));
+      expect(stat.isSymbolicLink()).toBe(true);
+      expect(await fsp.readlink(path.join(appRoot, "node_modules"))).toBe(nodeModulesDir);
+      await writeEveAgentDefinition(appRoot, "google/gemini-2.5-pro");
+      expect(await fsp.readFile(path.join(appRoot, "agent", "agent.ts"), "utf8")).toContain(
+        'google("gemini-2.5-pro")',
+      );
+      await fsp.rm(appRoot, { recursive: true, force: true });
+      expect(await fsp.readFile(path.join(nodeModulesDir, "marker"), "utf8")).toBe("keep");
+    } finally {
+      await fsp.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("defaults to the facade and lists all supported surfaces in errors", () => {
+    expect(EVE_TOOL_SURFACES[0]).toBe("stagehand_facade");
+    expect(resolveToolSurface({ harness: "eve", supportedToolSurfaces: EVE_TOOL_SURFACES })).toBe(
+      "stagehand_facade",
+    );
+    expect(() =>
+      resolveToolSurface(
+        { harness: "eve", supportedToolSurfaces: EVE_TOOL_SURFACES },
+        "browse_cli",
+      ),
+    ).toThrow(/stagehand_facade, playwright_mcp, or chrome_devtools_mcp/);
+  });
+});

--- a/packages/evals/tests/framework/eveToolAdapterLazyLoad.test.ts
+++ b/packages/evals/tests/framework/eveToolAdapterLazyLoad.test.ts
@@ -1,0 +1,13 @@
+import { expect, it, vi } from "vitest";
+
+vi.mock("@browserbasehq/stagehand-integrations-eve-sdk", () => {
+  throw new Error("eve-sdk must not load while importing the harness registry");
+});
+
+it("imports the benchmark harness registry without loading eve-sdk", async () => {
+  vi.resetModules();
+
+  const { listBenchHarnesses } = await import("../../framework/benchHarness.js");
+
+  expect(listBenchHarnesses()).toContain("eve");
+});

--- a/packages/evals/tests/framework/eveToolAdapterPrepare.test.ts
+++ b/packages/evals/tests/framework/eveToolAdapterPrepare.test.ts
@@ -280,10 +280,15 @@ describe("listMcpServerTools", () => {
   type Connect = NonNullable<Options["connect"]>;
 
   it("times out a connection that never resolves", async () => {
-    const connect = vi.fn(() => new Promise<never>(() => undefined)) as unknown as Connect;
+    let receivedSignal: AbortSignal | undefined;
+    const connect = vi.fn((_spec, signal) => {
+      receivedSignal = signal;
+      return new Promise<never>(() => undefined);
+    }) as unknown as Connect;
     await expect(
       listMcpServerTools({ command: "stuck-server" }, { connect, timeoutMs: 20 }),
     ).rejects.toThrow(/stuck-server.*timed out/);
+    expect(receivedSignal?.aborted).toBe(true);
   });
 
   it("closes a client that finishes connecting after the timeout", async () => {

--- a/packages/evals/tests/framework/eveToolAdapterPrepare.test.ts
+++ b/packages/evals/tests/framework/eveToolAdapterPrepare.test.ts
@@ -1,0 +1,324 @@
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AgentMount } from "../../core/contracts/tool.js";
+import { EvalsError } from "../../errors.js";
+import type { ExternalHarnessTaskPlan } from "../../framework/externalHarnessPlan.js";
+import {
+  EVE_MCP_SERVERS_ENV,
+  listMcpServerTools,
+  prepareEveToolAdapter,
+} from "../../framework/eveToolAdapter.js";
+import { EvalLogger } from "../../logger.js";
+
+const { startAgentToolRuntimeMock } = vi.hoisted(() => ({
+  startAgentToolRuntimeMock: vi.fn(),
+}));
+
+vi.mock("../../framework/agentToolRuntime.js", () => ({
+  startAgentToolRuntime: startAgentToolRuntimeMock,
+}));
+
+const plan: ExternalHarnessTaskPlan = {
+  dataset: "webvoyager",
+  taskId: "wv-1",
+  startUrl: "https://example.com",
+  instruction: "Find the checkout button",
+};
+
+const tempRoots = new Set<string>();
+
+afterEach(async () => {
+  startAgentToolRuntimeMock.mockReset();
+  await Promise.all([...tempRoots].map((root) => fsp.rm(root, { recursive: true, force: true })));
+  tempRoots.clear();
+});
+
+async function tempInput() {
+  const root = await fsp.mkdtemp(path.join(os.tmpdir(), "eve-adapter-prepare-test-"));
+  tempRoots.add(root);
+  const nodeModulesDir = path.join(root, "modules");
+  const tmpRoot = path.join(root, "tmp");
+  await fsp.mkdir(nodeModulesDir);
+  await fsp.mkdir(tmpRoot);
+  await fsp.writeFile(path.join(nodeModulesDir, "marker"), "keep");
+  return { nodeModulesDir, tmpRoot };
+}
+
+function setRuntime(
+  agentMount: AgentMount,
+  options?: { captureEvidence?: () => Promise<{ url: string }>; cleanup?: () => Promise<void> },
+) {
+  const cleanup = vi.fn(options?.cleanup ?? (async () => undefined));
+  startAgentToolRuntimeMock.mockResolvedValue({
+    running: {
+      agentMount,
+      ...(options?.captureEvidence && { captureEvidence: options.captureEvidence }),
+    },
+    cleanup,
+  });
+  return cleanup;
+}
+
+function adapterInput(paths: Awaited<ReturnType<typeof tempInput>>) {
+  return {
+    environment: "LOCAL" as const,
+    plan,
+    logger: new EvalLogger(false),
+    ...paths,
+  };
+}
+
+describe("prepareEveToolAdapter", () => {
+  it("rejects non-MCP mounts and cleans up the runtime", async () => {
+    const paths = await tempInput();
+    const cleanup = setRuntime({
+      via: "handles",
+      promptInstructions: "Use the browser.",
+      handles: {},
+      runTool: { description: "run", codeParamDescription: "code", denyMessage: "denied" },
+    });
+
+    await expect(prepareEveToolAdapter(adapterInput(paths))).rejects.toMatchObject({
+      name: EvalsError.name,
+      message: expect.stringMatching(/not supported yet/),
+    });
+    expect(cleanup).toHaveBeenCalledOnce();
+  });
+
+  it("rejects malformed server specs without leaking an app directory", async () => {
+    const paths = await tempInput();
+    const cleanup = setRuntime({
+      via: "mcp",
+      promptInstructions: "Use the browser.",
+      mcpServers: { stagehand: { args: [] } },
+    });
+
+    await expect(prepareEveToolAdapter(adapterInput(paths))).rejects.toThrow(
+      /must provide a string command/,
+    );
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(await fsp.readdir(paths.tmpRoot)).toEqual([]);
+  });
+
+  it("rejects MCP servers that list no tools", async () => {
+    const paths = await tempInput();
+    const cleanup = setRuntime({
+      via: "mcp",
+      promptInstructions: "Use the browser.",
+      mcpServers: { stagehand: { command: "node" } },
+    });
+
+    await expect(
+      prepareEveToolAdapter({
+        ...adapterInput(paths),
+        listMcpTools: vi.fn(async () => []),
+      }),
+    ).rejects.toThrow(/listed no tools/);
+    expect(cleanup).toHaveBeenCalledOnce();
+  });
+
+  it("wires the MCP mount, generated app, matcher, and environment", async () => {
+    const paths = await tempInput();
+    const spec = { command: "node", args: ["server.js"], env: { A: "1" } };
+    const mcpServers = { stagehand: spec };
+    const listMcpTools = vi.fn(async () => [{ name: "act", inputSchema: { type: "object" } }]);
+    setRuntime({
+      via: "mcp",
+      promptInstructions: "Use the mounted tools.",
+      mcpServers,
+    });
+
+    const result = await prepareEveToolAdapter({
+      ...adapterInput(paths),
+      listMcpTools,
+    });
+    expect(listMcpTools).toHaveBeenCalledWith(spec);
+    expect(JSON.parse(result.env[EVE_MCP_SERVERS_ENV] ?? "null")).toEqual(mcpServers);
+    expect(result.serverNames).toEqual(["stagehand"]);
+    expect(result.toolNames).toEqual(["stagehand__act"]);
+    expect(result.observedToolMatcher("stagehand__act")).toBe(true);
+    expect(result.observedToolMatcher("other__act")).toBe(false);
+    expect(result.observedToolMatcher("bash")).toBe(false);
+    expect(result.promptInstructions).toBe("Use the mounted tools.");
+    expect(path.dirname(result.appRoot)).toBe(paths.tmpRoot);
+    expect(
+      await fsp.stat(path.join(result.appRoot, "agent", "tools", "stagehand__act.ts")),
+    ).toBeDefined();
+    expect((await fsp.lstat(path.join(result.appRoot, "node_modules"))).isSymbolicLink()).toBe(
+      true,
+    );
+    await result.cleanup();
+  });
+
+  it("records evidence observations and omits capture hooks when unavailable", async () => {
+    const paths = await tempInput();
+    const captureEvidence = vi.fn(async () => ({ url: "https://example.com" }));
+    setRuntime(
+      {
+        via: "mcp",
+        promptInstructions: "Use the browser.",
+        mcpServers: { stagehand: { command: "node" } },
+      },
+      { captureEvidence },
+    );
+    const result = await prepareEveToolAdapter({
+      ...adapterInput(paths),
+      listMcpTools: vi.fn(async () => [{ name: "act", inputSchema: { type: "object" } }]),
+    });
+
+    expect(result.captureEvidence).toBeDefined();
+    expect(result.recordObservation).toBeDefined();
+    expect(result.drainStepObservations).toBeDefined();
+    result.recordObservation?.();
+    result.recordObservation?.();
+    expect(await result.drainStepObservations?.()).toEqual([
+      { runIndex: 0, evidence: { url: "https://example.com" } },
+      { runIndex: 1, evidence: { url: "https://example.com" } },
+    ]);
+    await result.cleanup();
+
+    const pathsWithoutCapture = await tempInput();
+    setRuntime({
+      via: "mcp",
+      promptInstructions: "Use the browser.",
+      mcpServers: { stagehand: { command: "node" } },
+    });
+    const withoutCapture = await prepareEveToolAdapter({
+      ...adapterInput(pathsWithoutCapture),
+      listMcpTools: vi.fn(async () => [{ name: "act", inputSchema: { type: "object" } }]),
+    });
+    expect(withoutCapture.captureEvidence).toBeUndefined();
+    expect(withoutCapture.recordObservation).toBeUndefined();
+    expect(withoutCapture.drainStepObservations).toBeUndefined();
+    await withoutCapture.cleanup();
+  });
+
+  it("makes cleanup idempotent and preserves shared node_modules", async () => {
+    const paths = await tempInput();
+    const cleanup = setRuntime({
+      via: "mcp",
+      promptInstructions: "Use the browser.",
+      mcpServers: { stagehand: { command: "node" } },
+    });
+    const result = await prepareEveToolAdapter({
+      ...adapterInput(paths),
+      listMcpTools: vi.fn(async () => [{ name: "act", inputSchema: { type: "object" } }]),
+    });
+
+    await Promise.all([result.cleanup(), result.cleanup()]);
+    await result.cleanup();
+    expect(cleanup).toHaveBeenCalledOnce();
+    await expect(fsp.stat(result.appRoot)).rejects.toThrow();
+    expect(await fsp.readFile(path.join(paths.nodeModulesDir, "marker"), "utf8")).toBe("keep");
+  });
+
+  it("removes the app when runtime cleanup rejects or times out", async () => {
+    const rejectedPaths = await tempInput();
+    setRuntime(
+      {
+        via: "mcp",
+        promptInstructions: "Use the browser.",
+        mcpServers: { stagehand: { command: "node" } },
+      },
+      { cleanup: async () => Promise.reject(new Error("cleanup failed")) },
+    );
+    const rejected = await prepareEveToolAdapter({
+      ...adapterInput(rejectedPaths),
+      listMcpTools: vi.fn(async () => [{ name: "act", inputSchema: { type: "object" } }]),
+    });
+    await expect(rejected.cleanup()).resolves.toBeUndefined();
+    await expect(fsp.stat(rejected.appRoot)).rejects.toThrow();
+
+    const previousTimeout = process.env.EVAL_AGENT_MOUNT_CLEANUP_TIMEOUT_MS;
+    process.env.EVAL_AGENT_MOUNT_CLEANUP_TIMEOUT_MS = "20";
+    try {
+      const timedOutPaths = await tempInput();
+      setRuntime(
+        {
+          via: "mcp",
+          promptInstructions: "Use the browser.",
+          mcpServers: { stagehand: { command: "node" } },
+        },
+        { cleanup: () => new Promise<void>(() => undefined) },
+      );
+      const timedOut = await prepareEveToolAdapter({
+        ...adapterInput(timedOutPaths),
+        listMcpTools: vi.fn(async () => [{ name: "act", inputSchema: { type: "object" } }]),
+      });
+      await expect(timedOut.cleanup()).resolves.toBeUndefined();
+      await expect(fsp.stat(timedOut.appRoot)).rejects.toThrow();
+    } finally {
+      if (previousTimeout === undefined) delete process.env.EVAL_AGENT_MOUNT_CLEANUP_TIMEOUT_MS;
+      else process.env.EVAL_AGENT_MOUNT_CLEANUP_TIMEOUT_MS = previousTimeout;
+    }
+  });
+
+  it("cleans up runtime and temp files when tool discovery throws", async () => {
+    const paths = await tempInput();
+    const cleanup = setRuntime({
+      via: "mcp",
+      promptInstructions: "Use the browser.",
+      mcpServers: { stagehand: { command: "node" } },
+    });
+    const failure = new Error("list failed");
+
+    await expect(
+      prepareEveToolAdapter({
+        ...adapterInput(paths),
+        listMcpTools: vi.fn(async () => Promise.reject(failure)),
+      }),
+    ).rejects.toBe(failure);
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(await fsp.readdir(paths.tmpRoot)).toEqual([]);
+  });
+});
+
+describe("listMcpServerTools", () => {
+  type Options = NonNullable<Parameters<typeof listMcpServerTools>[1]>;
+  type Connect = NonNullable<Options["connect"]>;
+
+  it("times out a connection that never resolves", async () => {
+    const connect = vi.fn(() => new Promise<never>(() => undefined)) as unknown as Connect;
+    await expect(
+      listMcpServerTools({ command: "stuck-server" }, { connect, timeoutMs: 20 }),
+    ).rejects.toThrow(/stuck-server.*timed out/);
+  });
+
+  it("times out tool listing and still closes the client", async () => {
+    const close = vi.fn(async () => undefined);
+    const client = { listTools: () => new Promise<never>(() => undefined), close };
+    const connect = vi.fn(async () => client) as unknown as Connect;
+    await expect(
+      listMcpServerTools({ command: "node" }, { connect, timeoutMs: 20 }),
+    ).rejects.toThrow(/timed out/);
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("returns listed tools, closes the client, and passes string-only environment values", async () => {
+    const close = vi.fn(async () => undefined);
+    const tools = [{ name: "act", description: "Act", inputSchema: { type: "object" } }];
+    const client = { listTools: vi.fn(async () => ({ tools })), close };
+    const connectMock = vi.fn(
+      async (_config: { command: string; args?: string[]; env?: Record<string, string> }) => client,
+    );
+    const connect = connectMock as unknown as Connect;
+
+    await expect(
+      listMcpServerTools(
+        { command: "node", args: ["server.js"], env: { EVE_TEST_VALUE: "1" } },
+        { connect, timeoutMs: 20 },
+      ),
+    ).resolves.toEqual(tools);
+    expect(close).toHaveBeenCalledOnce();
+    expect(connectMock).toHaveBeenCalledOnce();
+    const config = connectMock.mock.calls[0]?.[0];
+    expect(config).toMatchObject({
+      command: "node",
+      args: ["server.js"],
+      env: expect.objectContaining({ EVE_TEST_VALUE: "1" }),
+    });
+    expect(Object.values(config?.env ?? {}).every((value) => typeof value === "string")).toBe(true);
+  });
+});

--- a/packages/evals/tests/framework/eveToolAdapterPrepare.test.ts
+++ b/packages/evals/tests/framework/eveToolAdapterPrepare.test.ts
@@ -286,6 +286,26 @@ describe("listMcpServerTools", () => {
     ).rejects.toThrow(/stuck-server.*timed out/);
   });
 
+  it("closes a client that finishes connecting after the timeout", async () => {
+    const close = vi.fn(async () => undefined);
+    const client = { listTools: vi.fn(), close };
+    let finishConnect: ((value: typeof client) => void) | undefined;
+    const connect = vi.fn(
+      () =>
+        new Promise<typeof client>((resolve) => {
+          finishConnect = resolve;
+        }),
+    ) as unknown as Connect;
+
+    await expect(
+      listMcpServerTools({ command: "slow-server" }, { connect, timeoutMs: 20 }),
+    ).rejects.toThrow(/slow-server.*timed out/);
+    finishConnect?.(client);
+
+    await vi.waitFor(() => expect(close).toHaveBeenCalledOnce());
+    expect(client.listTools).not.toHaveBeenCalled();
+  });
+
   it("times out tool listing and still closes the client", async () => {
     const close = vi.fn(async () => undefined);
     const client = { listTools: () => new Promise<never>(() => undefined), close };

--- a/packages/integrations/eve-sdk/package.json
+++ b/packages/integrations/eve-sdk/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@browserbasehq/stagehand-integrations-eve-sdk",
+  "version": "4.0.1",
+  "private": true,
+  "description": "Eve (Vercel) harness adapter for Stagehand integrations",
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs"
+    }
+  },
+  "scripts": {
+    "build": "tsdown",
+    "test": "pnpm run build && vitest run --root ../../.. packages/integrations/eve-sdk/tests",
+    "test:unit": "vitest run --root ../../.. packages/integrations/eve-sdk/tests",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "@ai-sdk/anthropic": "catalog:",
+    "@ai-sdk/google": "catalog:",
+    "@ai-sdk/openai": "catalog:",
+    "@browserbasehq/stagehand-integrations": "workspace:*",
+    "@modelcontextprotocol/sdk": "catalog:",
+    "ai": "catalog:",
+    "eve": "catalog:",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=24"
+  }
+}

--- a/packages/integrations/eve-sdk/package.json
+++ b/packages/integrations/eve-sdk/package.json
@@ -25,7 +25,7 @@
     "@ai-sdk/openai": "catalog:",
     "@browserbasehq/stagehand-integrations": "workspace:*",
     "@modelcontextprotocol/sdk": "catalog:",
-    "ai": "catalog:",
+    "ai": "^7.0.38",
     "eve": "catalog:",
     "zod": "catalog:"
   },

--- a/packages/integrations/eve-sdk/src/index.ts
+++ b/packages/integrations/eve-sdk/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./session.js";

--- a/packages/integrations/eve-sdk/src/session.ts
+++ b/packages/integrations/eve-sdk/src/session.ts
@@ -183,6 +183,7 @@ export async function runEveSession(input: {
         port?: number;
         readyTimeoutMs?: number;
         eveBinPath?: string;
+        spawn?: typeof nodeSpawn;
       }
     | { url: string };
   client?: EveClientLike;
@@ -199,9 +200,19 @@ export async function runEveSession(input: {
   let turnCompleted = false;
   let maxTurns = false;
   let serverHandle: EveDevServerHandle | undefined;
+  let session: EveClientSessionLike | undefined;
+  let cancelled = false;
   const maxToolSteps = positiveInteger(input.maxToolSteps, 50);
   const controller = new AbortController();
-  const forwardAbort = (): void => controller.abort(input.signal?.reason);
+  const cancelSession = (): Promise<unknown> | undefined => {
+    if (!session || cancelled) return undefined;
+    cancelled = true;
+    return session.cancel().catch((): undefined => undefined);
+  };
+  const forwardAbort = (): void => {
+    controller.abort(input.signal?.reason);
+    void cancelSession();
+  };
   if (input.signal?.aborted) controller.abort(input.signal.reason);
   else input.signal?.addEventListener("abort", forwardAbort, { once: true });
 
@@ -224,7 +235,8 @@ export async function runEveSession(input: {
     }
     const client = input.client ?? (await loadEveClient(serverUrl));
     await client.health();
-    const session = client.session();
+    session = client.session();
+    if (input.signal?.aborted) void cancelSession();
     const response = await session.send({ message: input.prompt, signal: controller.signal });
     sessionId = response.sessionId;
     let toolStepCount = 0;
@@ -247,7 +259,7 @@ export async function runEveSession(input: {
           if (toolStepCount >= maxToolSteps && !maxTurns) {
             maxTurns = true;
             stopReason = `tool step budget exhausted (${maxToolSteps} steps)`;
-            await session.cancel().catch((): undefined => undefined);
+            await cancelSession();
             controller.abort(new Error(stopReason));
           }
         }
@@ -262,7 +274,7 @@ export async function runEveSession(input: {
           .map((request) => (isRecord(request) ? String(request.kind ?? "unknown") : "unknown"))
           .join(", ");
         stopReason = `eve parked for human input (${kinds})`;
-        await session.cancel().catch((): undefined => undefined);
+        await cancelSession();
         controller.abort(new Error(stopReason));
       } else if (
         event.type === "step.failed" ||
@@ -355,13 +367,15 @@ export function buildEveTranscript(events: EveEvent[]): string {
 
 export function logEveEvent(logger: HarnessLogger, event: EveEvent): void {
   const summary = summarizeEveEvent(event);
+  const message = sanitizeErrorMessage(summary.message);
+  const detail = summary.detail ? sanitizeErrorMessage(summary.detail) : undefined;
   logger.log({
     category: "eve",
-    message: summary.message,
+    message,
     level: 1,
     auxiliary: {
       type: { value: event.type, type: "string" },
-      ...(summary.detail && { detail: { value: summary.detail, type: "string" } }),
+      ...(detail && { detail: { value: detail, type: "string" } }),
     },
   });
 }

--- a/packages/integrations/eve-sdk/src/session.ts
+++ b/packages/integrations/eve-sdk/src/session.ts
@@ -210,10 +210,11 @@ export async function runEveSession(input: {
     return session.cancel().catch((): undefined => undefined);
   };
   const forwardAbort = (): void => {
+    stopReason = sanitizeErrorMessage(stringifyError(input.signal?.reason) || "aborted");
     controller.abort(input.signal?.reason);
     void cancelSession();
   };
-  if (input.signal?.aborted) controller.abort(input.signal.reason);
+  if (input.signal?.aborted) forwardAbort();
   else input.signal?.addEventListener("abort", forwardAbort, { once: true });
 
   input.logger.log({
@@ -426,10 +427,13 @@ async function closeChild(child: ChildProcess, timeoutMs: number): Promise<void>
   if (child.exitCode !== null || child.signalCode !== null) return;
   const exited = new Promise<void>((resolve) => child.once("exit", () => resolve()));
   child.kill("SIGTERM");
+  let shutdownTimer: ReturnType<typeof setTimeout> | undefined;
   const graceful = await Promise.race([
     exited.then(() => true),
-    new Promise<false>((resolve) => setTimeout(() => resolve(false), timeoutMs)),
-  ]);
+    new Promise<false>((resolve) => {
+      shutdownTimer = setTimeout(() => resolve(false), timeoutMs);
+    }),
+  ]).finally(() => clearTimeout(shutdownTimer));
   if (!graceful && child.exitCode === null && child.signalCode === null) {
     child.kill("SIGKILL");
     await exited;

--- a/packages/integrations/eve-sdk/src/session.ts
+++ b/packages/integrations/eve-sdk/src/session.ts
@@ -1,4 +1,5 @@
-import { spawn as nodeSpawn, type ChildProcess } from "node:child_process";
+import * as childProcess from "node:child_process";
+import type { ChildProcess } from "node:child_process";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -102,9 +103,9 @@ export async function startEveDevServer(input: {
   readyTimeoutMs?: number;
   shutdownTimeoutMs?: number;
   eveBinPath?: string;
-  spawn?: typeof nodeSpawn;
+  spawn?: typeof childProcess.spawn;
 }): Promise<EveDevServerHandle> {
-  const spawn = input.spawn ?? nodeSpawn;
+  const spawn = input.spawn ?? childProcess.spawn;
   const readyTimeoutMs = positiveInteger(input.readyTimeoutMs, 120_000);
   const shutdownTimeoutMs = positiveInteger(input.shutdownTimeoutMs, 10_000);
   const outputLines: string[] = [];
@@ -183,7 +184,7 @@ export async function runEveSession(input: {
         port?: number;
         readyTimeoutMs?: number;
         eveBinPath?: string;
-        spawn?: typeof nodeSpawn;
+        spawn?: typeof childProcess.spawn;
       }
     | { url: string };
   client?: EveClientLike;

--- a/packages/integrations/eve-sdk/src/session.ts
+++ b/packages/integrations/eve-sdk/src/session.ts
@@ -254,19 +254,20 @@ export async function runEveSession(input: {
         for (const action of data.actions) {
           if (!isRecord(action) || action.kind !== "tool-call") continue;
           const toolName = typeof action.toolName === "string" ? action.toolName : "tool";
-          toolStepCount += 1;
           await input.onToolStep?.(toolName);
-          if (toolStepCount >= maxToolSteps && !maxTurns) {
-            maxTurns = true;
-            stopReason = `tool step budget exhausted (${maxToolSteps} steps)`;
-            await cancelSession();
-            controller.abort(new Error(stopReason));
-          }
         }
       } else if (event.type === "action.result") {
         const result = isRecord(data?.result) ? data.result : undefined;
         if (result?.kind === "tool-result" && typeof result.toolName === "string") {
           await input.onToolResult?.(result.toolName);
+          toolStepCount += 1;
+          if (toolStepCount >= maxToolSteps && !maxTurns) {
+            maxTurns = true;
+            stopReason = `tool step budget exhausted (${maxToolSteps} steps)`;
+            await cancelSession();
+            controller.abort(new Error(stopReason));
+            break;
+          }
         }
       } else if (event.type === "input.requested") {
         const requests = Array.isArray(data?.requests) ? data.requests : [];

--- a/packages/integrations/eve-sdk/src/session.ts
+++ b/packages/integrations/eve-sdk/src/session.ts
@@ -1,0 +1,461 @@
+import { spawn as nodeSpawn, type ChildProcess } from "node:child_process";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  HarnessAdapterError,
+  sanitizeErrorMessage,
+  type HarnessLogger,
+} from "@browserbasehq/stagehand-integrations/harness";
+
+export type EveEvent = {
+  readonly type: string;
+  readonly data?: unknown;
+  readonly meta?: { readonly at?: string; readonly id?: string };
+};
+
+export type EveTokenUsage = {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  totalTokens: number;
+  costUsd?: number;
+};
+
+export type EveSessionStatus = "completed" | "max_turns" | "sdk_error";
+
+export type EveSessionResult = {
+  events: EveEvent[];
+  finalMessage: string;
+  status: EveSessionStatus;
+  stopReason?: string;
+  tokenUsage: EveTokenUsage;
+  sessionId?: string;
+  serverUrl?: string;
+  iterationError?: unknown;
+};
+
+export type EveMessageResponseLike = AsyncIterable<EveEvent> & { readonly sessionId: string };
+export type EveClientSessionLike = {
+  send(input: { message: string; signal?: AbortSignal }): Promise<EveMessageResponseLike>;
+  cancel(options?: { turnId?: string }): Promise<unknown>;
+};
+export type EveClientLike = {
+  health(): Promise<unknown>;
+  session(): EveClientSessionLike;
+};
+
+export const EVE_PACKAGE = "eve";
+
+export function resolveEveBinPath(): string {
+  try {
+    const packagePath = createRequire(import.meta.url).resolve(`${EVE_PACKAGE}/package.json`);
+    return path.join(path.dirname(packagePath), "bin", "eve.js");
+  } catch (error) {
+    const detail = sanitizeErrorMessage(stringifyError(error));
+    throw new HarnessAdapterError(
+      `Eve harness requires ${EVE_PACKAGE}. Install it in the consuming workspace.${detail ? ` ${detail}` : ""}`,
+      { cause: error },
+    );
+  }
+}
+
+export function resolveEveAppNodeModulesDir(): string {
+  return path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "node_modules");
+}
+
+export async function loadEveClient(host: string): Promise<EveClientLike> {
+  try {
+    const specifier = `${EVE_PACKAGE}/client`;
+    const mod = (await import(specifier)) as {
+      Client?: new (options: { host: string }) => EveClientLike;
+    };
+    if (typeof mod.Client !== "function") throw new Error("Client export missing");
+    return new mod.Client({ host });
+  } catch (error) {
+    const detail = sanitizeErrorMessage(stringifyError(error));
+    throw new HarnessAdapterError(
+      `Eve harness requires ${EVE_PACKAGE}/client. Install it in the consuming workspace.${detail ? ` ${detail}` : ""}`,
+      { cause: error },
+    );
+  }
+}
+
+export function parseEveDevServerUrl(line: string): string | undefined {
+  const match = line.match(/\[DEV\] server listening at (https?:\/\/\S+)/);
+  return match?.[1]?.replace(/\/+$/, "");
+}
+
+export type EveDevServerHandle = {
+  url: string;
+  pid?: number;
+  close(): Promise<void>;
+};
+
+export async function startEveDevServer(input: {
+  appRoot: string;
+  env: Record<string, string>;
+  logger: HarnessLogger;
+  signal?: AbortSignal;
+  port?: number;
+  readyTimeoutMs?: number;
+  shutdownTimeoutMs?: number;
+  eveBinPath?: string;
+  spawn?: typeof nodeSpawn;
+}): Promise<EveDevServerHandle> {
+  const spawn = input.spawn ?? nodeSpawn;
+  const readyTimeoutMs = positiveInteger(input.readyTimeoutMs, 120_000);
+  const shutdownTimeoutMs = positiveInteger(input.shutdownTimeoutMs, 10_000);
+  const outputLines: string[] = [];
+  const child = spawn(
+    process.execPath,
+    [input.eveBinPath ?? resolveEveBinPath(), "dev", "--no-ui", "--port", String(input.port ?? 0)],
+    { cwd: input.appRoot, env: input.env, stdio: ["ignore", "pipe", "pipe"] },
+  ) as ChildProcess;
+
+  let closePromise: Promise<void> | undefined;
+  const close = async (): Promise<void> => {
+    closePromise ??= closeChild(child, shutdownTimeoutMs);
+    await closePromise;
+  };
+  const abort = (): void => void close();
+  if (input.signal?.aborted) abort();
+  else input.signal?.addEventListener("abort", abort, { once: true });
+
+  try {
+    const url = await new Promise<string>((resolve, reject) => {
+      let settled = false;
+      const finish = (fn: () => void): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        fn();
+      };
+      const fail = (message: string, cause?: unknown): void => {
+        const tail = outputLines.slice(-20).join("\n");
+        finish(() =>
+          reject(
+            new HarnessAdapterError(`${message}${tail ? `\n${tail}` : ""}`, {
+              ...(cause !== undefined && { cause }),
+            }),
+          ),
+        );
+      };
+      const onLine = (line: string): void => {
+        const sanitized = sanitizeErrorMessage(line);
+        outputLines.push(sanitized);
+        input.logger.log({ category: "eve", message: sanitized, level: 2 });
+        const serverUrl = parseEveDevServerUrl(line);
+        if (serverUrl) finish(() => resolve(serverUrl));
+      };
+      lineBuffer(child.stdout, onLine);
+      lineBuffer(child.stderr, onLine);
+      child.once("error", (error) => fail("Eve dev server failed before it was ready.", error));
+      child.once("exit", (code, signal) =>
+        fail(
+          `Eve dev server exited before it was ready (code ${String(code)}, signal ${String(signal)}).`,
+        ),
+      );
+      const timer = setTimeout(
+        () => fail(`Eve dev server did not become ready within ${readyTimeoutMs}ms.`),
+        readyTimeoutMs,
+      );
+    });
+    return { url, ...(child.pid !== undefined && { pid: child.pid }), close };
+  } catch (error) {
+    await close();
+    throw error;
+  } finally {
+    input.signal?.removeEventListener("abort", abort);
+  }
+}
+
+export async function runEveSession(input: {
+  prompt: string;
+  model: string;
+  logger: HarnessLogger;
+  signal?: AbortSignal;
+  server:
+    | {
+        appRoot: string;
+        env: Record<string, string>;
+        port?: number;
+        readyTimeoutMs?: number;
+        eveBinPath?: string;
+      }
+    | { url: string };
+  client?: EveClientLike;
+  maxToolSteps?: number;
+  onToolStep?: (toolName: string) => void | Promise<void>;
+  onToolResult?: (toolName: string) => void | Promise<void>;
+}): Promise<EveSessionResult> {
+  const events: EveEvent[] = [];
+  let finalMessage = "";
+  let stopReason: string | undefined;
+  let iterationError: unknown;
+  let sessionId: string | undefined;
+  let serverUrl: string | undefined;
+  let turnCompleted = false;
+  let maxTurns = false;
+  let serverHandle: EveDevServerHandle | undefined;
+  const maxToolSteps = positiveInteger(input.maxToolSteps, 50);
+  const controller = new AbortController();
+  const forwardAbort = (): void => controller.abort(input.signal?.reason);
+  if (input.signal?.aborted) controller.abort(input.signal.reason);
+  else input.signal?.addEventListener("abort", forwardAbort, { once: true });
+
+  input.logger.log({
+    category: "eve",
+    message: `Starting Eve session with model ${input.model}.`,
+    level: 1,
+  });
+
+  try {
+    if ("appRoot" in input.server) {
+      serverHandle = await startEveDevServer({
+        ...input.server,
+        logger: input.logger,
+        signal: input.signal,
+      });
+      serverUrl = serverHandle.url;
+    } else {
+      serverUrl = input.server.url.replace(/\/+$/, "");
+    }
+    const client = input.client ?? (await loadEveClient(serverUrl));
+    await client.health();
+    const session = client.session();
+    const response = await session.send({ message: input.prompt, signal: controller.signal });
+    sessionId = response.sessionId;
+    let toolStepCount = 0;
+
+    for await (const event of response) {
+      events.push(event);
+      logEveEvent(input.logger, event);
+      const data = isRecord(event.data) ? event.data : undefined;
+
+      if (event.type === "message.completed" && typeof data?.message === "string") {
+        finalMessage = data.message;
+      } else if (event.type === "step.completed") {
+        // Usage is aggregated from the complete event list below.
+      } else if (event.type === "actions.requested" && Array.isArray(data?.actions)) {
+        for (const action of data.actions) {
+          if (!isRecord(action) || action.kind !== "tool-call") continue;
+          const toolName = typeof action.toolName === "string" ? action.toolName : "tool";
+          toolStepCount += 1;
+          await input.onToolStep?.(toolName);
+          if (toolStepCount >= maxToolSteps && !maxTurns) {
+            maxTurns = true;
+            stopReason = `tool step budget exhausted (${maxToolSteps} steps)`;
+            await session.cancel().catch((): undefined => undefined);
+            controller.abort(new Error(stopReason));
+          }
+        }
+      } else if (event.type === "action.result") {
+        const result = isRecord(data?.result) ? data.result : undefined;
+        if (result?.kind === "tool-result" && typeof result.toolName === "string") {
+          await input.onToolResult?.(result.toolName);
+        }
+      } else if (event.type === "input.requested") {
+        const requests = Array.isArray(data?.requests) ? data.requests : [];
+        const kinds = requests
+          .map((request) => (isRecord(request) ? String(request.kind ?? "unknown") : "unknown"))
+          .join(", ");
+        stopReason = `eve parked for human input (${kinds})`;
+        await session.cancel().catch((): undefined => undefined);
+        controller.abort(new Error(stopReason));
+      } else if (
+        event.type === "step.failed" ||
+        event.type === "turn.failed" ||
+        event.type === "session.failed"
+      ) {
+        stopReason = readEveFailureMessage(data) ?? event.type;
+      } else if (event.type === "turn.completed") {
+        turnCompleted = true;
+      }
+    }
+
+    if (!turnCompleted && !stopReason && !maxTurns) {
+      stopReason = "eve stream ended without a turn boundary";
+    }
+  } catch (error) {
+    iterationError = error;
+    input.logger.warn({
+      category: "eve",
+      message: `Eve stopped before a normal result: ${sanitizeErrorMessage(stringifyError(error))}`,
+      level: 0,
+      auxiliary: {
+        error: { value: sanitizeErrorMessage(stringifyError(error)), type: "string" },
+      },
+    });
+  } finally {
+    input.signal?.removeEventListener("abort", forwardAbort);
+    await serverHandle?.close();
+  }
+
+  return {
+    events,
+    finalMessage,
+    status: resolveEveStatus(iterationError, stopReason, turnCompleted, maxTurns),
+    ...(stopReason && { stopReason: sanitizeErrorMessage(stopReason) }),
+    tokenUsage: extractEveTokenUsage(events),
+    ...(sessionId && { sessionId }),
+    ...(serverUrl && { serverUrl }),
+    ...(iterationError !== undefined && { iterationError }),
+  };
+}
+
+export function resolveEveStatus(
+  iterationError: unknown,
+  stopReason: string | undefined,
+  turnCompleted: boolean,
+  maxTurns = false,
+): EveSessionStatus {
+  if (maxTurns) return "max_turns";
+  return !iterationError && !stopReason && turnCompleted ? "completed" : "sdk_error";
+}
+
+export function extractEveTokenUsage(events: EveEvent[]): EveTokenUsage {
+  const usage = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 };
+  let costUsd = 0;
+  let hasCostUsd = false;
+  for (const event of events) {
+    if (event.type !== "step.completed") continue;
+    const data = isRecord(event.data) ? event.data : undefined;
+    const stepUsage = isRecord(data?.usage) ? data.usage : undefined;
+    usage.inputTokens += toFiniteNumber(stepUsage?.inputTokens);
+    usage.outputTokens += toFiniteNumber(stepUsage?.outputTokens);
+    usage.cacheReadTokens += toFiniteNumber(stepUsage?.cacheReadTokens);
+    usage.cacheWriteTokens += toFiniteNumber(stepUsage?.cacheWriteTokens);
+    if (isFiniteNumeric(stepUsage?.costUsd)) {
+      costUsd += Number(stepUsage.costUsd);
+      hasCostUsd = true;
+    }
+  }
+  return {
+    ...usage,
+    totalTokens: Object.values(usage).reduce((sum, value) => sum + value, 0),
+    ...(hasCostUsd && { costUsd }),
+  };
+}
+
+function isFiniteNumeric(value: unknown): boolean {
+  return (
+    (typeof value === "number" && Number.isFinite(value)) ||
+    (typeof value === "string" && value.trim().length > 0 && Number.isFinite(Number(value)))
+  );
+}
+
+export function buildEveTranscript(events: EveEvent[]): string {
+  return events
+    .map((event) => summarizeEveEvent(event).detail)
+    .filter((detail): detail is string => Boolean(detail))
+    .join("\n");
+}
+
+export function logEveEvent(logger: HarnessLogger, event: EveEvent): void {
+  const summary = summarizeEveEvent(event);
+  logger.log({
+    category: "eve",
+    message: summary.message,
+    level: 1,
+    auxiliary: {
+      type: { value: event.type, type: "string" },
+      ...(summary.detail && { detail: { value: summary.detail, type: "string" } }),
+    },
+  });
+}
+
+export function summarizeEveEvent(event: EveEvent): { message: string; detail?: string } {
+  const data = isRecord(event.data) ? event.data : undefined;
+  if (event.type === "message.completed" && typeof data?.message === "string") {
+    return { message: `agent: ${clip(data.message, 500)}`, detail: data.message };
+  }
+  if (event.type === "action.result") {
+    const result = isRecord(data?.result) ? data.result : undefined;
+    return {
+      message: `tool: ${String(result?.toolName ?? "")} ${String(data?.status ?? "")}`.trim(),
+      detail: safeJson(data),
+    };
+  }
+  if (event.type === "step.completed") {
+    return { message: "step completed", detail: safeJson(data?.usage) };
+  }
+  if (event.type.endsWith(".failed")) {
+    const message = readEveFailureMessage(data) ?? event.type;
+    return { message: `${event.type.replace(".", " ")}: ${clip(message, 500)}`, detail: message };
+  }
+  return { message: `${event.type} event`, detail: safeJson(event) };
+}
+
+function readEveFailureMessage(data: Record<string, unknown> | undefined): string | undefined {
+  return typeof data?.message === "string" ? data.message : undefined;
+}
+
+function lineBuffer(stream: ChildProcess["stdout"], onLine: (line: string) => void): void {
+  if (!stream) return;
+  let pending = "";
+  stream.setEncoding("utf8");
+  stream.on("data", (chunk: string) => {
+    pending += chunk;
+    const lines = pending.split(/\r?\n/);
+    pending = lines.pop() ?? "";
+    for (const line of lines) onLine(line);
+  });
+  stream.on("end", () => {
+    if (pending) onLine(pending);
+  });
+}
+
+async function closeChild(child: ChildProcess, timeoutMs: number): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  const exited = new Promise<void>((resolve) => child.once("exit", () => resolve()));
+  child.kill("SIGTERM");
+  const graceful = await Promise.race([
+    exited.then(() => true),
+    new Promise<false>((resolve) => setTimeout(() => resolve(false), timeoutMs)),
+  ]);
+  if (!graceful && child.exitCode === null && child.signalCode === null) {
+    child.kill("SIGKILL");
+    await exited;
+  }
+}
+
+export function toFiniteNumber(value: unknown): number {
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim()
+        ? Number(value)
+        : 0;
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function positiveInteger(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.max(1, Math.floor(value))
+    : fallback;
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export function safeJson(value: unknown): string | undefined {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return undefined;
+  }
+}
+
+export function stringifyError(value: unknown): string {
+  if (!value) return "";
+  if (value instanceof Error) return value.message;
+  if (typeof value === "string") return value;
+  return safeJson(value) ?? String(value);
+}
+
+export function clip(value: string, maxLength: number): string {
+  return value.length <= maxLength ? value : `${value.slice(0, maxLength - 1)}…`;
+}

--- a/packages/integrations/eve-sdk/src/session.ts
+++ b/packages/integrations/eve-sdk/src/session.ts
@@ -145,6 +145,7 @@ export async function startEveDevServer(input: {
       };
       const onLine = (line: string): void => {
         const sanitized = sanitizeErrorMessage(line);
+        if (outputLines.length >= 20) outputLines.shift();
         outputLines.push(sanitized);
         input.logger.log({ category: "eve", message: sanitized, level: 2 });
         const serverUrl = parseEveDevServerUrl(line);
@@ -262,13 +263,15 @@ export async function runEveSession(input: {
         const result = isRecord(data?.result) ? data.result : undefined;
         if (result?.kind === "tool-result" && typeof result.toolName === "string") {
           await input.onToolResult?.(result.toolName);
-          toolStepCount += 1;
-          if (toolStepCount >= maxToolSteps && !maxTurns) {
-            maxTurns = true;
-            stopReason = `tool step budget exhausted (${maxToolSteps} steps)`;
-            await cancelSession();
-            controller.abort(new Error(stopReason));
-            break;
+          if (data?.status === "completed" && result.isError !== true) {
+            toolStepCount += 1;
+            if (toolStepCount >= maxToolSteps && !maxTurns) {
+              maxTurns = true;
+              stopReason = `tool step budget exhausted (${maxToolSteps} steps)`;
+              await cancelSession();
+              controller.abort(new Error(stopReason));
+              break;
+            }
           }
         }
       } else if (event.type === "input.requested") {
@@ -294,7 +297,7 @@ export async function runEveSession(input: {
       stopReason = "eve stream ended without a turn boundary";
     }
   } catch (error) {
-    iterationError = error;
+    iterationError = new HarnessAdapterError("Eve session failed.");
     input.logger.warn({
       category: "eve",
       message: `Eve stopped before a normal result: ${sanitizeErrorMessage(stringifyError(error))}`,
@@ -303,6 +306,7 @@ export async function runEveSession(input: {
         error: { value: sanitizeErrorMessage(stringifyError(error)), type: "string" },
       },
     });
+    await cancelSession();
   } finally {
     input.signal?.removeEventListener("abort", forwardAbort);
     await serverHandle?.close();

--- a/packages/integrations/eve-sdk/tests/session.test.ts
+++ b/packages/integrations/eve-sdk/tests/session.test.ts
@@ -4,6 +4,7 @@ import { PassThrough } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import { HarnessAdapterError } from "@browserbasehq/stagehand-integrations/harness";
 import {
+  logEveEvent,
   parseEveDevServerUrl,
   runEveSession,
   startEveDevServer,
@@ -263,6 +264,163 @@ describe("Eve SDK session", () => {
       client: setup.client,
     });
     expect(setup.send.mock.calls[0]?.[0].signal).toMatchObject({ aborted: true });
+  });
+
+  it("cancels exactly once when the caller aborts mid-stream", async () => {
+    const controller = new AbortController();
+    let releaseStream: (() => void) | undefined;
+    const blocked = new Promise<void>((resolve) => {
+      releaseStream = resolve;
+    });
+    let firstEventSeen: (() => void) | undefined;
+    const sawFirstEvent = new Promise<void>((resolve) => {
+      firstEventSeen = resolve;
+    });
+    const cancel = vi.fn(async () => ({}));
+    const client: EveClientLike = {
+      health: vi.fn(async () => ({})),
+      session: () => ({
+        cancel,
+        send: vi.fn(async () =>
+          Object.assign(
+            {
+              async *[Symbol.asyncIterator]() {
+                yield {
+                  type: "actions.requested",
+                  data: { actions: [{ kind: "tool-call", toolName: "stagehand__act" }] },
+                };
+                await blocked;
+              },
+            },
+            { sessionId: "session-1" },
+          ),
+        ),
+      }),
+    };
+    const pending = runEveSession({
+      prompt: "task",
+      model: "gpt",
+      logger,
+      signal: controller.signal,
+      server: { url: "http://eve" },
+      client,
+      onToolStep: () => firstEventSeen?.(),
+    });
+    await sawFirstEvent;
+    controller.abort(new Error("bench timeout"));
+    releaseStream?.();
+
+    const result = await pending;
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(result.status).toBe("sdk_error");
+  });
+
+  it("kills the generated dev server and cancels Eve on a mid-stream abort", async () => {
+    const child = fakeChild();
+    let childKilled: (() => void) | undefined;
+    const killed = new Promise<void>((resolve) => {
+      childKilled = resolve;
+    });
+    child.kill.mockImplementation(() => {
+      childKilled?.();
+      return true;
+    });
+    const controller = new AbortController();
+    let releaseStream: (() => void) | undefined;
+    const blocked = new Promise<void>((resolve) => {
+      releaseStream = resolve;
+    });
+    let streamStarted: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      streamStarted = resolve;
+    });
+    const cancel = vi.fn(async () => ({}));
+    const client: EveClientLike = {
+      health: vi.fn(async () => ({})),
+      session: () => ({
+        cancel,
+        send: vi.fn(async () =>
+          Object.assign(
+            {
+              async *[Symbol.asyncIterator]() {
+                streamStarted?.();
+                await blocked;
+                if (controller.signal.aborted) throw controller.signal.reason;
+              },
+            },
+            { sessionId: "session-1" },
+          ),
+        ),
+      }),
+    };
+    const pending = runEveSession({
+      prompt: "task",
+      model: "gpt",
+      logger,
+      signal: controller.signal,
+      server: {
+        appRoot: "/tmp/eve-app",
+        env: {},
+        eveBinPath: "/tmp/eve.js",
+        spawn: (() => child) as unknown as NonNullable<
+          Extract<Parameters<typeof runEveSession>[0]["server"], { appRoot: string }>["spawn"]
+        >,
+      },
+      client,
+    });
+    child.stdout.write("[DEV] server listening at http://127.0.0.1:61439/\n");
+    await started;
+    controller.abort(new Error("bench timeout"));
+    releaseStream?.();
+    await killed;
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(cancel).toHaveBeenCalledOnce();
+    child.exitCode = 0;
+    child.emit("exit", 0, null);
+
+    const result = await pending;
+    expect(result.status).toBe("sdk_error");
+  });
+
+  it("redacts event messages and persisted event details", () => {
+    const eventLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    logEveEvent(eventLogger, {
+      type: "action.result",
+      data: {
+        status: "completed",
+        result: { kind: "tool-result", toolName: "act", output: "sk-abc123SUPERSECRET" },
+      },
+    });
+    logEveEvent(eventLogger, {
+      type: "authorization.requested",
+      data: { challenge: "Bearer aaaaaaaaaaaaaaaaaaaa" },
+    });
+    logEveEvent(eventLogger, {
+      type: "message.completed",
+      data: { message: "answer sk-abc123SUPERSECRET" },
+    });
+
+    const serialized = JSON.stringify(eventLogger.log.mock.calls);
+    expect(serialized).toContain("sk-abc123[redacted]");
+    expect(serialized).toContain("Bearer [redacted]");
+    expect(serialized).not.toContain("SUPERSECRET");
+    expect(serialized).not.toContain("aaaaaaaaaaaaaaaaaaaa");
+    expect(eventLogger.log.mock.calls[0]?.[0]).toMatchObject({
+      auxiliary: { detail: { value: expect.stringContaining("sk-abc123[redacted]") } },
+    });
+    expect(eventLogger.log.mock.calls[1]?.[0]).toMatchObject({
+      auxiliary: { detail: { value: expect.stringContaining("Bearer [redacted]") } },
+    });
+    expect(eventLogger.log).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("sk-abc123[redacted]"),
+        auxiliary: expect.objectContaining({
+          detail: expect.objectContaining({
+            value: expect.stringContaining("sk-abc123[redacted]"),
+          }),
+        }),
+      }),
+    );
   });
 
   it("errors when the stream ends without a turn boundary", async () => {

--- a/packages/integrations/eve-sdk/tests/session.test.ts
+++ b/packages/integrations/eve-sdk/tests/session.test.ts
@@ -105,6 +105,25 @@ describe("Eve SDK session", () => {
     expect(String(error.message)).not.toContain("SUPERSECRET");
   });
 
+  it("keeps only the last 20 dev-server output lines in startup errors", async () => {
+    const child = fakeChild();
+    const pending = startEveDevServer({
+      appRoot: "/tmp/eve-app",
+      env: {},
+      logger,
+      eveBinPath: "/tmp/eve.js",
+      spawn: (() => child) as unknown as Parameters<typeof startEveDevServer>[0]["spawn"],
+    });
+    for (let index = 1; index <= 25; index += 1) child.stderr.write(`output-${index}\n`);
+    child.exitCode = 1;
+    child.emit("exit", 1, null);
+
+    const error = await pending.catch((value) => value);
+    expect(String(error.message)).not.toContain("output-5\n");
+    expect(String(error.message)).toContain("output-6\n");
+    expect(String(error.message)).toContain("output-25");
+  });
+
   it("closes the dev server with SIGTERM and waits for exit", async () => {
     const child = fakeChild();
     const pending = startEveDevServer({
@@ -324,6 +343,44 @@ describe("Eve SDK session", () => {
     expect(result.stopReason).toContain("budget exhausted");
   });
 
+  it("does not count failed tool results against the completed-step budget", async () => {
+    const setup = clientFor([
+      {
+        type: "action.result",
+        data: {
+          status: "failed",
+          result: {
+            kind: "tool-result",
+            toolName: "stagehand__run",
+            isError: true,
+          },
+        },
+      },
+      {
+        type: "action.result",
+        data: {
+          status: "completed",
+          result: { kind: "tool-result", toolName: "stagehand__run" },
+        },
+      },
+    ]);
+    const onToolResult = vi.fn();
+    const result = await runEveSession({
+      prompt: "task",
+      model: "gpt",
+      logger,
+      server: { url: "http://eve" },
+      client: setup.client,
+      maxToolSteps: 1,
+      onToolResult,
+    });
+
+    expect(onToolResult).toHaveBeenCalledTimes(2);
+    expect(result.events).toHaveLength(2);
+    expect(setup.cancel).toHaveBeenCalledOnce();
+    expect(result.status).toBe("max_turns");
+  });
+
   it("cancels and errors when Eve requests human input", async () => {
     const setup = clientFor([
       { type: "input.requested", data: { requests: [{ kind: "question" }] } },
@@ -530,7 +587,7 @@ describe("Eve SDK session", () => {
     expect(result.stopReason).toContain("without a turn boundary");
   });
 
-  it("reports health failures as iteration errors", async () => {
+  it("reports health failures as fixed typed iteration errors", async () => {
     const client: EveClientLike = {
       health: vi.fn(async () => {
         throw new Error("health failed");
@@ -545,6 +602,34 @@ describe("Eve SDK session", () => {
       client,
     });
     expect(result.status).toBe("sdk_error");
-    expect(String(result.iterationError)).toContain("health failed");
+    expect(result.iterationError).toBeInstanceOf(HarnessAdapterError);
+    expect(String(result.iterationError)).toBe("HarnessAdapterError: Eve session failed.");
+    expect(JSON.stringify(result.iterationError)).not.toContain("health failed");
+  });
+
+  it("cancels the Eve session when a tool callback throws", async () => {
+    const setup = clientFor([
+      {
+        type: "action.result",
+        data: {
+          status: "completed",
+          result: { kind: "tool-result", toolName: "stagehand__run" },
+        },
+      },
+    ]);
+    const result = await runEveSession({
+      prompt: "task",
+      model: "gpt",
+      logger,
+      server: { url: "http://eve" },
+      client: setup.client,
+      onToolResult: () => {
+        throw new Error("callback leaked sk-abc123SUPERSECRET");
+      },
+    });
+
+    expect(setup.cancel).toHaveBeenCalledOnce();
+    expect(result.iterationError).toBeInstanceOf(HarnessAdapterError);
+    expect(JSON.stringify(result)).not.toContain("SUPERSECRET");
   });
 });

--- a/packages/integrations/eve-sdk/tests/session.test.ts
+++ b/packages/integrations/eve-sdk/tests/session.test.ts
@@ -216,13 +216,26 @@ describe("Eve SDK session", () => {
     expect(result.stopReason).not.toContain("SUPERSECRET");
   });
 
-  it("cancels when the tool-step budget is exhausted", async () => {
+  it("executes and records one tool result before exhausting a one-step budget", async () => {
     const setup = clientFor([
       {
         type: "actions.requested",
         data: { actions: [{ kind: "tool-call", callId: "1", toolName: "stagehand__run" }] },
       },
+      {
+        type: "action.result",
+        data: {
+          status: "completed",
+          result: { kind: "tool-result", callId: "1", toolName: "stagehand__run" },
+        },
+      },
+      {
+        type: "actions.requested",
+        data: { actions: [{ kind: "tool-call", callId: "2", toolName: "stagehand__run" }] },
+      },
     ]);
+    const onToolStep = vi.fn(() => expect(setup.cancel).not.toHaveBeenCalled());
+    const onToolResult = vi.fn(() => expect(setup.cancel).not.toHaveBeenCalled());
     const result = await runEveSession({
       prompt: "task",
       model: "gpt",
@@ -230,7 +243,57 @@ describe("Eve SDK session", () => {
       server: { url: "http://eve" },
       client: setup.client,
       maxToolSteps: 1,
+      onToolStep,
+      onToolResult,
     });
+    expect(onToolStep).toHaveBeenCalledOnce();
+    expect(onToolResult).toHaveBeenCalledOnce();
+    expect(result.events.filter((event) => event.type === "action.result")).toHaveLength(1);
+    expect(setup.cancel).toHaveBeenCalledOnce();
+    expect(result.status).toBe("max_turns");
+    expect(result.stopReason).toContain("budget exhausted");
+  });
+
+  it("records two tool results before exhausting a two-step budget", async () => {
+    const setup = clientFor([
+      {
+        type: "actions.requested",
+        data: { actions: [{ kind: "tool-call", callId: "1", toolName: "stagehand__run" }] },
+      },
+      {
+        type: "action.result",
+        data: {
+          status: "completed",
+          result: { kind: "tool-result", callId: "1", toolName: "stagehand__run" },
+        },
+      },
+      {
+        type: "actions.requested",
+        data: { actions: [{ kind: "tool-call", callId: "2", toolName: "stagehand__run" }] },
+      },
+      {
+        type: "action.result",
+        data: {
+          status: "completed",
+          result: { kind: "tool-result", callId: "2", toolName: "stagehand__run" },
+        },
+      },
+      { type: "message.completed", data: { message: "should not be read" } },
+    ]);
+    const onToolResult = vi.fn(() => expect(setup.cancel).not.toHaveBeenCalled());
+    const result = await runEveSession({
+      prompt: "task",
+      model: "gpt",
+      logger,
+      server: { url: "http://eve" },
+      client: setup.client,
+      maxToolSteps: 2,
+      onToolResult,
+    });
+
+    expect(onToolResult).toHaveBeenCalledTimes(2);
+    expect(result.events.filter((event) => event.type === "action.result")).toHaveLength(2);
+    expect(result.events.at(-1)?.type).toBe("action.result");
     expect(setup.cancel).toHaveBeenCalledOnce();
     expect(result.status).toBe("max_turns");
     expect(result.stopReason).toContain("budget exhausted");

--- a/packages/integrations/eve-sdk/tests/session.test.ts
+++ b/packages/integrations/eve-sdk/tests/session.test.ts
@@ -1,0 +1,298 @@
+/* eslint-disable require-yield */
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import { HarnessAdapterError } from "@browserbasehq/stagehand-integrations/harness";
+import {
+  parseEveDevServerUrl,
+  runEveSession,
+  startEveDevServer,
+  type EveClientLike,
+  type EveEvent,
+} from "../src/index.js";
+
+const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+function response(events: EveEvent[], sessionId = "session-1") {
+  return Object.assign(
+    {
+      async *[Symbol.asyncIterator]() {
+        yield* events;
+      },
+    },
+    { sessionId },
+  );
+}
+
+function clientFor(events: EveEvent[]) {
+  const cancel = vi.fn(async () => ({}));
+  const send = vi.fn(async (_input: { message: string; signal?: AbortSignal }) => response(events));
+  const client: EveClientLike = {
+    health: vi.fn(async () => ({})),
+    session: () => ({ send, cancel }),
+  };
+  return { client, send, cancel };
+}
+
+function fakeChild() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: PassThrough;
+    stderr: PassThrough;
+    pid: number;
+    exitCode: number | null;
+    signalCode: NodeJS.Signals | null;
+    kill: ReturnType<typeof vi.fn>;
+  };
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.pid = 1234;
+  child.exitCode = null;
+  child.signalCode = null;
+  child.kill = vi.fn(() => true);
+  return child;
+}
+
+describe("Eve SDK session", () => {
+  it("parses only the dev server ready line", () => {
+    expect(parseEveDevServerUrl("☰eve  v0.29.4")).toBeUndefined();
+    expect(parseEveDevServerUrl("[DEV] server listening at http://127.0.0.1:61439/")).toBe(
+      "http://127.0.0.1:61439",
+    );
+  });
+
+  it("starts the dev server, sanitizes logs, and passes CLI options", async () => {
+    const child = fakeChild();
+    const spawn = vi.fn(() => child);
+    const pending = startEveDevServer({
+      appRoot: "/tmp/eve-app",
+      env: { PATH: "/bin" },
+      logger,
+      eveBinPath: "/tmp/eve.js",
+      spawn: spawn as unknown as Parameters<typeof startEveDevServer>[0]["spawn"],
+    });
+    child.stdout.write("token sk-abc123SUPERSECRET\n");
+    child.stdout.write("[DEV] server listening at http://127.0.0.1:61439/\n");
+    const handle = await pending;
+
+    expect(handle.url).toBe("http://127.0.0.1:61439");
+    expect(spawn).toHaveBeenCalledWith(
+      process.execPath,
+      ["/tmp/eve.js", "dev", "--no-ui", "--port", "0"],
+      expect.objectContaining({ cwd: "/tmp/eve-app" }),
+    );
+    expect(logger.log).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining("sk-abc123[redacted]") }),
+    );
+  });
+
+  it("reports a sanitized output tail on early exit", async () => {
+    const child = fakeChild();
+    const pending = startEveDevServer({
+      appRoot: "/tmp/eve-app",
+      env: {},
+      logger,
+      eveBinPath: "/tmp/eve.js",
+      spawn: (() => child) as unknown as Parameters<typeof startEveDevServer>[0]["spawn"],
+    });
+    child.stderr.write("failed with sk-abc123SUPERSECRET\n");
+    child.exitCode = 1;
+    child.emit("exit", 1, null);
+
+    const error = await pending.catch((value) => value);
+    expect(error).toBeInstanceOf(HarnessAdapterError);
+    expect(String(error.message)).toContain("sk-abc123[redacted]");
+    expect(String(error.message)).not.toContain("SUPERSECRET");
+  });
+
+  it("closes the dev server with SIGTERM and waits for exit", async () => {
+    const child = fakeChild();
+    const pending = startEveDevServer({
+      appRoot: "/tmp/eve-app",
+      env: {},
+      logger,
+      eveBinPath: "/tmp/eve.js",
+      spawn: (() => child) as unknown as Parameters<typeof startEveDevServer>[0]["spawn"],
+    });
+    child.stdout.write("[DEV] server listening at http://127.0.0.1:61439\n");
+    const handle = await pending;
+    const closing = handle.close();
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    child.exitCode = 0;
+    child.emit("exit", 0, null);
+    await closing;
+  });
+
+  it("collects a completed turn, tool callbacks, usage, cost, and session id", async () => {
+    const onToolStep = vi.fn();
+    const onToolResult = vi.fn();
+    const { client } = clientFor([
+      {
+        type: "actions.requested",
+        data: { actions: [{ kind: "tool-call", callId: "1", toolName: "stagehand__run" }] },
+      },
+      {
+        type: "action.result",
+        data: {
+          status: "completed",
+          result: { kind: "tool-result", callId: "1", toolName: "stagehand__run" },
+        },
+      },
+      {
+        type: "step.completed",
+        data: {
+          usage: {
+            inputTokens: 10,
+            outputTokens: 4,
+            cacheReadTokens: 2,
+            cacheWriteTokens: 1,
+            costUsd: 0.01,
+          },
+        },
+      },
+      {
+        type: "step.completed",
+        data: { usage: { inputTokens: 5, outputTokens: 3, costUsd: "0.02" } },
+      },
+      { type: "message.completed", data: { message: "done" } },
+      { type: "turn.completed" },
+    ]);
+    const result = await runEveSession({
+      prompt: "task",
+      model: "gpt",
+      logger,
+      server: { url: "http://eve/" },
+      client,
+      onToolStep,
+      onToolResult,
+    });
+
+    expect(result).toMatchObject({
+      finalMessage: "done",
+      status: "completed",
+      sessionId: "session-1",
+      serverUrl: "http://eve",
+      tokenUsage: {
+        inputTokens: 15,
+        outputTokens: 7,
+        cacheReadTokens: 2,
+        cacheWriteTokens: 1,
+        totalTokens: 25,
+        costUsd: 0.03,
+      },
+    });
+    expect(onToolStep).toHaveBeenCalledWith("stagehand__run");
+    expect(onToolResult).toHaveBeenCalledWith("stagehand__run");
+  });
+
+  it("omits cost when no completed step reports it", async () => {
+    const { client } = clientFor([
+      { type: "step.completed", data: { usage: { inputTokens: 1 } } },
+      { type: "turn.completed" },
+    ]);
+    const result = await runEveSession({
+      prompt: "task",
+      model: "gpt",
+      logger,
+      server: { url: "http://eve" },
+      client,
+    });
+    expect(result.tokenUsage).not.toHaveProperty("costUsd");
+  });
+
+  it("sanitizes turn failures", async () => {
+    const { client } = clientFor([
+      { type: "turn.failed", data: { message: "bad sk-abc123SUPERSECRET" } },
+    ]);
+    const result = await runEveSession({
+      prompt: "task",
+      model: "gpt",
+      logger,
+      server: { url: "http://eve" },
+      client,
+    });
+    expect(result.status).toBe("sdk_error");
+    expect(result.stopReason).toContain("sk-abc123[redacted]");
+    expect(result.stopReason).not.toContain("SUPERSECRET");
+  });
+
+  it("cancels when the tool-step budget is exhausted", async () => {
+    const setup = clientFor([
+      {
+        type: "actions.requested",
+        data: { actions: [{ kind: "tool-call", callId: "1", toolName: "stagehand__run" }] },
+      },
+    ]);
+    const result = await runEveSession({
+      prompt: "task",
+      model: "gpt",
+      logger,
+      server: { url: "http://eve" },
+      client: setup.client,
+      maxToolSteps: 1,
+    });
+    expect(setup.cancel).toHaveBeenCalledOnce();
+    expect(result.status).toBe("max_turns");
+    expect(result.stopReason).toContain("budget exhausted");
+  });
+
+  it("cancels and errors when Eve requests human input", async () => {
+    const setup = clientFor([
+      { type: "input.requested", data: { requests: [{ kind: "question" }] } },
+    ]);
+    const result = await runEveSession({
+      prompt: "task",
+      model: "gpt",
+      logger,
+      server: { url: "http://eve" },
+      client: setup.client,
+    });
+    expect(setup.cancel).toHaveBeenCalledOnce();
+    expect(result.status).toBe("sdk_error");
+  });
+
+  it("forwards caller aborts to send", async () => {
+    const setup = clientFor([{ type: "turn.completed" }]);
+    const controller = new AbortController();
+    controller.abort(new Error("stop"));
+    await runEveSession({
+      prompt: "task",
+      model: "gpt",
+      logger,
+      signal: controller.signal,
+      server: { url: "http://eve" },
+      client: setup.client,
+    });
+    expect(setup.send.mock.calls[0]?.[0].signal).toMatchObject({ aborted: true });
+  });
+
+  it("errors when the stream ends without a turn boundary", async () => {
+    const { client } = clientFor([{ type: "message.completed", data: { message: "partial" } }]);
+    const result = await runEveSession({
+      prompt: "task",
+      model: "gpt",
+      logger,
+      server: { url: "http://eve" },
+      client,
+    });
+    expect(result.status).toBe("sdk_error");
+    expect(result.stopReason).toContain("without a turn boundary");
+  });
+
+  it("reports health failures as iteration errors", async () => {
+    const client: EveClientLike = {
+      health: vi.fn(async () => {
+        throw new Error("health failed");
+      }),
+      session: vi.fn(),
+    };
+    const result = await runEveSession({
+      prompt: "task",
+      model: "gpt",
+      logger,
+      server: { url: "http://eve" },
+      client,
+    });
+    expect(result.status).toBe("sdk_error");
+    expect(String(result.iterationError)).toContain("health failed");
+  });
+});

--- a/packages/integrations/eve-sdk/tests/session.test.ts
+++ b/packages/integrations/eve-sdk/tests/session.test.ts
@@ -123,6 +123,31 @@ describe("Eve SDK session", () => {
     await closing;
   });
 
+  it("clears the graceful shutdown timer after the child exits", async () => {
+    vi.useFakeTimers();
+    try {
+      const child = fakeChild();
+      const pending = startEveDevServer({
+        appRoot: "/tmp/eve-app",
+        env: {},
+        logger,
+        eveBinPath: "/tmp/eve.js",
+        spawn: (() => child) as unknown as Parameters<typeof startEveDevServer>[0]["spawn"],
+      });
+      child.stdout.write("[DEV] server listening at http://127.0.0.1:61439\n");
+      const handle = await pending;
+      const closing = handle.close();
+      child.exitCode = 0;
+      child.emit("exit", 0, null);
+
+      await closing;
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  });
+
   it("collects a completed turn, tool callbacks, usage, cost, and session id", async () => {
     const onToolStep = vi.fn();
     const onToolResult = vi.fn();
@@ -314,11 +339,11 @@ describe("Eve SDK session", () => {
     expect(result.status).toBe("sdk_error");
   });
 
-  it("forwards caller aborts to send", async () => {
+  it("reports a pre-aborted caller signal as a sanitized SDK error", async () => {
     const setup = clientFor([{ type: "turn.completed" }]);
     const controller = new AbortController();
-    controller.abort(new Error("stop"));
-    await runEveSession({
+    controller.abort(new Error("stop sk-abc123SUPERSECRET"));
+    const result = await runEveSession({
       prompt: "task",
       model: "gpt",
       logger,
@@ -327,6 +352,9 @@ describe("Eve SDK session", () => {
       client: setup.client,
     });
     expect(setup.send.mock.calls[0]?.[0].signal).toMatchObject({ aborted: true });
+    expect(result.status).toBe("sdk_error");
+    expect(result.stopReason).toContain("stop sk-abc123[redacted]");
+    expect(result.stopReason).not.toContain("SUPERSECRET");
   });
 
   it("cancels exactly once when the caller aborts mid-stream", async () => {
@@ -353,6 +381,7 @@ describe("Eve SDK session", () => {
                   data: { actions: [{ kind: "tool-call", toolName: "stagehand__act" }] },
                 };
                 await blocked;
+                yield { type: "turn.completed" };
               },
             },
             { sessionId: "session-1" },
@@ -370,12 +399,14 @@ describe("Eve SDK session", () => {
       onToolStep: () => firstEventSeen?.(),
     });
     await sawFirstEvent;
-    controller.abort(new Error("bench timeout"));
+    controller.abort(new Error("bench timeout sk-abc123SUPERSECRET"));
     releaseStream?.();
 
     const result = await pending;
     expect(cancel).toHaveBeenCalledOnce();
     expect(result.status).toBe("sdk_error");
+    expect(result.stopReason).toContain("bench timeout sk-abc123[redacted]");
+    expect(result.stopReason).not.toContain("SUPERSECRET");
   });
 
   it("kills the generated dev server and cancels Eve on a mid-stream abort", async () => {

--- a/packages/integrations/eve-sdk/tsconfig.json
+++ b/packages/integrations/eve-sdk/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "types": ["node"],
+    "rootDir": ".",
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts", "vitest.config.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/integrations/eve-sdk/tsdown.config.ts
+++ b/packages/integrations/eve-sdk/tsdown.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: {
+    index: "src/index.ts",
+  },
+  format: ["esm"],
+  platform: "node",
+  target: "node22",
+  dts: {
+    sourcemap: true,
+  },
+  sourcemap: true,
+  outDir: "dist",
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1200,10 +1200,6 @@ packages:
     resolution: {integrity: sha512-jaTESuJlQsoUZ44f/i2puyPt8VlF/dMMJ9HM3cStYtk7eKX4N9UWi83OLixUkoOJH3BwWlPLCq9YIK9nfWhVBg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-node@3.972.71':
-    resolution: {integrity: sha512-HIg7Q2osBzajQwL+1Vkyh2E7Gim3eTNb9RHIsOxDGjW0eZg4oEKtRs5sioCnc73ilhaOm4gX2lHVF8J7+nt2rg==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-node@3.972.79':
     resolution: {integrity: sha512-RIw5dof1EHkWubrZzPC941CDtnFG1iAXsxbFgLkhdYZXHc4icU13c/uxSMI0J5eUx9bxa7LjfpdjfClBB1QsDA==}
     engines: {node: '>=20.0.0'}
@@ -1252,8 +1248,8 @@ packages:
     resolution: {integrity: sha512-ECAqfpNsef+7MO8qtR0h9KcFIBAygaE7Cm6UOiQl+ft+uVap+1G7bNEjs4mdJE2OnA4m6k7i8peH8uGIAsOMGw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/util-locate-window@3.965.8':
-    resolution: {integrity: sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==}
+  '@aws-sdk/util-locate-window@3.965.9':
+    resolution: {integrity: sha512-wB/ho7pTJKqWz3WYDt2ZWDWI8bxQpN/xwf+5ZQ1zWaj+HDY9B8Fn434i6qZ6j6ZG3aCiIJtZaQVqwajx5xYsQA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/xml-builder@3.972.38':
@@ -8464,7 +8460,7 @@ snapshots:
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
       '@aws-sdk/types': 3.974.3
-      '@aws-sdk/util-locate-window': 3.965.8
+      '@aws-sdk/util-locate-window': 3.965.9
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
@@ -8489,16 +8485,16 @@ snapshots:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-sdk/core': 3.977.7
-      '@aws-sdk/credential-provider-node': 3.972.71
+      '@aws-sdk/credential-provider-node': 3.972.79
       '@aws-sdk/eventstream-handler-node': 3.972.32
       '@aws-sdk/middleware-eventstream': 3.972.27
       '@aws-sdk/middleware-websocket': 3.972.50
       '@aws-sdk/token-providers': 3.1048.0
       '@aws-sdk/types': 3.974.3
-      '@smithy/core': 3.32.0
+      '@smithy/core': 3.30.0
       '@smithy/fetch-http-handler': 5.7.0
-      '@smithy/node-http-handler': 4.10.0
-      '@smithy/types': 4.17.0
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/core@3.977.7':
@@ -8555,20 +8551,6 @@ snapshots:
       '@smithy/types': 4.17.0
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-node@3.972.71':
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.68
-      '@aws-sdk/credential-provider-http': 3.972.70
-      '@aws-sdk/credential-provider-ini': 3.973.13
-      '@aws-sdk/credential-provider-process': 3.972.68
-      '@aws-sdk/credential-provider-sso': 3.973.12
-      '@aws-sdk/credential-provider-web-identity': 3.972.74
-      '@aws-sdk/types': 3.974.3
-      '@smithy/core': 3.32.0
-      '@smithy/credential-provider-imds': 4.5.0
-      '@smithy/types': 4.17.0
-      tslib: 2.8.1
-
   '@aws-sdk/credential-provider-node@3.972.79':
     dependencies:
       '@aws-sdk/credential-provider-env': 3.972.68
@@ -8582,7 +8564,6 @@ snapshots:
       '@smithy/credential-provider-imds': 4.5.0
       '@smithy/types': 4.17.0
       tslib: 2.8.1
-    optional: true
 
   '@aws-sdk/credential-provider-process@3.972.68':
     dependencies:
@@ -8615,14 +8596,14 @@ snapshots:
     dependencies:
       '@aws-sdk/types': 3.974.3
       '@smithy/core': 3.32.0
-      '@smithy/types': 4.17.0
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-eventstream@3.972.27':
     dependencies:
       '@aws-sdk/types': 3.974.3
       '@smithy/core': 3.32.0
-      '@smithy/types': 4.17.0
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-websocket@3.972.50':
@@ -8632,7 +8613,7 @@ snapshots:
       '@smithy/core': 3.32.0
       '@smithy/fetch-http-handler': 5.7.0
       '@smithy/signature-v4': 5.7.0
-      '@smithy/types': 4.17.0
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/nested-clients@3.997.42':
@@ -8658,8 +8639,8 @@ snapshots:
       '@aws-sdk/core': 3.977.7
       '@aws-sdk/nested-clients': 3.997.42
       '@aws-sdk/types': 3.974.3
-      '@smithy/core': 3.32.0
-      '@smithy/types': 4.17.0
+      '@smithy/core': 3.30.0
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.1108.0':
@@ -8676,7 +8657,7 @@ snapshots:
       '@smithy/types': 4.17.0
       tslib: 2.8.1
 
-  '@aws-sdk/util-locate-window@3.965.8':
+  '@aws-sdk/util-locate-window@3.965.9':
     dependencies:
       tslib: 2.8.1
 
@@ -10627,7 +10608,6 @@ snapshots:
     dependencies:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
-    optional: true
 
   '@smithy/core@3.32.0':
     dependencies:
@@ -10664,8 +10644,8 @@ snapshots:
 
   '@smithy/node-http-handler@4.7.3':
     dependencies:
-      '@smithy/core': 3.32.0
-      '@smithy/types': 4.17.0
+      '@smithy/core': 3.30.0
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/signature-v4@5.7.0':
@@ -10677,7 +10657,6 @@ snapshots:
   '@smithy/types@4.16.1':
     dependencies:
       tslib: 2.8.1
-    optional: true
 
   '@smithy/types@4.17.0':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -545,7 +545,7 @@ importers:
         version: 17.4.2
       eve:
         specifier: 'catalog:'
-        version: 0.29.4(@opentelemetry/api@1.9.1)(ai@7.0.16(zod@4.4.3))(aws4fetch@1.0.20)(braintrust@3.28.0(@aws-sdk/credential-provider-web-identity@3.972.74)(zod@4.4.3))(dotenv@17.4.2)(jiti@2.7.0)(lru-cache@11.5.2)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(xml2js@0.6.2)
+        version: 0.29.4(@opentelemetry/api@1.9.1)(ai@7.0.77(zod@4.4.3))(aws4fetch@1.0.20)(braintrust@3.28.0(@aws-sdk/credential-provider-web-identity@3.972.74)(zod@4.4.3))(dotenv@17.4.2)(jiti@2.7.0)(lru-cache@11.5.2)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(xml2js@0.6.2)
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -575,11 +575,11 @@ importers:
         specifier: 'catalog:'
         version: 1.29.0(zod@4.4.3)
       ai:
-        specifier: 'catalog:'
-        version: 7.0.16(zod@4.4.3)
+        specifier: ^7.0.38
+        version: 7.0.77(zod@4.4.3)
       eve:
         specifier: 'catalog:'
-        version: 0.29.4(@opentelemetry/api@1.9.1)(ai@7.0.16(zod@4.4.3))(aws4fetch@1.0.20)(braintrust@3.28.0(@aws-sdk/credential-provider-web-identity@3.972.74)(zod@4.4.3))(dotenv@17.4.2)(jiti@2.7.0)(lru-cache@11.5.2)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(xml2js@0.6.2)
+        version: 0.29.4(@opentelemetry/api@1.9.1)(ai@7.0.77(zod@4.4.3))(aws4fetch@1.0.20)(braintrust@3.28.0(@aws-sdk/credential-provider-web-identity@3.972.74)(zod@4.4.3))(dotenv@17.4.2)(jiti@2.7.0)(lru-cache@11.5.2)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(xml2js@0.6.2)
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -607,10 +607,10 @@ importers:
         version: link:../core
       '@mastra/core':
         specifier: 'catalog:'
-        version: 1.57.0(ai@7.0.16(zod@4.4.3))(bufferutil@4.1.0)(express@5.2.1)(rxjs@7.8.2)(zod@4.4.3)
+        version: 1.57.0(ai@7.0.77(zod@4.4.3))(bufferutil@4.1.0)(express@5.2.1)(rxjs@7.8.2)(zod@4.4.3)
       '@mastra/mcp':
         specifier: 'catalog:'
-        version: 1.15.1(@mastra/core@1.57.0(ai@7.0.16(zod@4.4.3))(bufferutil@4.1.0)(express@5.2.1)(rxjs@7.8.2)(zod@4.4.3))(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(zod@4.4.3)
+        version: 1.15.1(@mastra/core@1.57.0(ai@7.0.77(zod@4.4.3))(bufferutil@4.1.0)(express@5.2.1)(rxjs@7.8.2)(zod@4.4.3))(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(zod@4.4.3)
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -629,10 +629,10 @@ importers:
         version: link:../core
       '@mastra/core':
         specifier: 'catalog:'
-        version: 1.57.0(ai@7.0.16(zod@4.4.3))(bufferutil@4.1.0)(express@5.2.1)(rxjs@7.8.2)(zod@4.4.3)
+        version: 1.57.0(ai@7.0.77(zod@4.4.3))(bufferutil@4.1.0)(express@5.2.1)(rxjs@7.8.2)(zod@4.4.3)
       '@mastra/mcp':
         specifier: 'catalog:'
-        version: 1.15.1(@mastra/core@1.57.0(ai@7.0.16(zod@4.4.3))(bufferutil@4.1.0)(express@5.2.1)(rxjs@7.8.2)(zod@4.4.3))(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(zod@4.4.3)
+        version: 1.15.1(@mastra/core@1.57.0(ai@7.0.77(zod@4.4.3))(bufferutil@4.1.0)(express@5.2.1)(rxjs@7.8.2)(zod@4.4.3))(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(zod@4.4.3)
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -859,6 +859,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/gateway@4.0.62':
+    resolution: {integrity: sha512-zR3pustGWhw5eUZHG+fJZx/V/PBe+LxdDpc5hDFWxozG/3MB/+eY62jn+YiR+9uOH+Hx63e5zJoeKLfZfPktWQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/google-vertex@3.0.158':
     resolution: {integrity: sha512-Z9sY69vlrOR574Bb+3Tjp1P2W1QK4ut7fTUgA3F3lcvNxAvlAyxp24T4bodaBTWP6Q74pCB1IQGL5NaPDN1r2A==}
     engines: {node: '>=18'}
@@ -955,6 +961,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@5.0.29':
+    resolution: {integrity: sha512-7EIbwXiXKGa7EFk6tDZpuZBs6lxhEJpOuHeqrDb3Vd85uYdjwkdRuHnZDVDIIb2+QTSRmyph2NrXcbvuO/KAjQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider-utils@5.0.5':
     resolution: {integrity: sha512-oI0t3dvCoqWNV1I8o1Rybi2DXDvHES5r/TrwtJW90tuFLVepgJlftPxrcjh8vaSvjqC2diTuA2vXyjKAyHJm4A==}
     engines: {node: '>=22'}
@@ -975,6 +987,10 @@ packages:
 
   '@ai-sdk/provider@4.0.4':
     resolution: {integrity: sha512-tbHKNLirllUNF3ZlkCsXnwab2ZV1Sl4b1H/Cp9ruCce15IBmskE8Gwkk0yo9xDWY+jho2of7lVXtwSsyrq7cwQ==}
+    engines: {node: '>=22'}
+
+  '@ai-sdk/provider@4.0.7':
+    resolution: {integrity: sha512-6or44XprPzKbr8zkmzosowSE0pxkvJcoojBL+mCZvPUt3kvXp3XSNqeVun9golb1acEfSo6yaEBRT18h2VU+1Q==}
     engines: {node: '>=22'}
 
   '@ai-sdk/togetherai@1.0.49':
@@ -3407,6 +3423,12 @@ packages:
 
   ai@7.0.16:
     resolution: {integrity: sha512-OuA+uz6ZUVId+SVeB5bThi25Ofee/FmLvffAA368tlgqYCe2qAhqZUpfHL0dd9QC/iPiszdvCQYENJavSo/0gw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  ai@7.0.77:
+    resolution: {integrity: sha512-muLtBSTAUCreR77L16w4AFBiX2gK/RNt84EKp8m03SN9+MfNlC5EGqYYttRjYKV3xe0a33yj1Zawj1EnjejIWw==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -8144,6 +8166,13 @@ snapshots:
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
+  '@ai-sdk/gateway@4.0.62(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.29(zod@4.4.3)
+      '@vercel/oidc': 3.2.0
+      zod: 4.4.3
+
   '@ai-sdk/google-vertex@3.0.158(zod@4.4.3)':
     dependencies:
       '@ai-sdk/anthropic': 2.0.91(zod@4.4.3)
@@ -8261,6 +8290,15 @@ snapshots:
       undici: 7.29.0
       zod: 4.4.3
 
+  '@ai-sdk/provider-utils@5.0.29(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.7
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      undici: 7.29.0
+      zod: 4.4.3
+
   '@ai-sdk/provider-utils@5.0.5(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 4.0.2
@@ -8282,6 +8320,10 @@ snapshots:
       json-schema: 0.4.0
 
   '@ai-sdk/provider@4.0.4':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@4.0.7':
     dependencies:
       json-schema: 0.4.0
 
@@ -9639,7 +9681,7 @@ snapshots:
       '@mariozechner/clipboard-win32-x64-msvc': 0.3.9
     optional: true
 
-  '@mastra/core@1.57.0(ai@7.0.16(zod@4.4.3))(bufferutil@4.1.0)(express@5.2.1)(rxjs@7.8.2)(zod@4.4.3)':
+  '@mastra/core@1.57.0(ai@7.0.77(zod@4.4.3))(bufferutil@4.1.0)(express@5.2.1)(rxjs@7.8.2)(zod@4.4.3)':
     dependencies:
       '@a2a-js/sdk': 0.3.14(express@5.2.1)
       '@ai-sdk/provider-utils-v5': '@ai-sdk/provider-utils@3.0.30(zod@4.4.3)'
@@ -9655,7 +9697,7 @@ snapshots:
       '@sindresorhus/slugify': 2.2.1
       '@standard-schema/spec': 1.1.0
       ajv: 8.20.0
-      chat: 4.37.0(ai@7.0.16(zod@4.4.3))(zod@4.4.3)
+      chat: 4.37.0(ai@7.0.77(zod@4.4.3))(zod@4.4.3)
       croner: 10.0.1
       dotenv: 17.4.2
       execa: 9.6.1
@@ -9685,9 +9727,9 @@ snapshots:
       - utf-8-validate
       - workflow
 
-  '@mastra/mcp@1.15.1(@mastra/core@1.57.0(ai@7.0.16(zod@4.4.3))(bufferutil@4.1.0)(express@5.2.1)(rxjs@7.8.2)(zod@4.4.3))(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(zod@4.4.3)':
+  '@mastra/mcp@1.15.1(@mastra/core@1.57.0(ai@7.0.77(zod@4.4.3))(bufferutil@4.1.0)(express@5.2.1)(rxjs@7.8.2)(zod@4.4.3))(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(zod@4.4.3)':
     dependencies:
-      '@mastra/core': 1.57.0(ai@7.0.16(zod@4.4.3))(bufferutil@4.1.0)(express@5.2.1)(rxjs@7.8.2)(zod@4.4.3)
+      '@mastra/core': 1.57.0(ai@7.0.77(zod@4.4.3))(bufferutil@4.1.0)(express@5.2.1)(rxjs@7.8.2)(zod@4.4.3)
       '@modelcontextprotocol/ext-apps': 1.7.5(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(zod@4.4.3)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
       exit-hook: 5.1.0
@@ -11096,6 +11138,13 @@ snapshots:
       '@ai-sdk/provider-utils': 5.0.5(zod@4.4.3)
       zod: 4.4.3
 
+  ai@7.0.77(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 4.0.62(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.29(zod@4.4.3)
+      zod: 4.4.3
+
   ajv-draft-04@1.0.0(ajv@8.20.0):
     optionalDependencies:
       ajv: 8.20.0
@@ -11537,7 +11586,7 @@ snapshots:
 
   chardet@2.2.0: {}
 
-  chat@4.37.0(ai@7.0.16(zod@4.4.3))(zod@4.4.3):
+  chat@4.37.0(ai@7.0.77(zod@4.4.3))(zod@4.4.3):
     dependencies:
       '@workflow/serde': 4.1.0-beta.2
       mdast-util-to-string: 4.0.0
@@ -11547,7 +11596,7 @@ snapshots:
       remend: 1.3.0
       unified: 11.0.5
     optionalDependencies:
-      ai: 7.0.16(zod@4.4.3)
+      ai: 7.0.77(zod@4.4.3)
       zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -12206,9 +12255,9 @@ snapshots:
 
   etag@1.8.1: {}
 
-  eve@0.29.4(@opentelemetry/api@1.9.1)(ai@7.0.16(zod@4.4.3))(aws4fetch@1.0.20)(braintrust@3.28.0(@aws-sdk/credential-provider-web-identity@3.972.74)(zod@4.4.3))(dotenv@17.4.2)(jiti@2.7.0)(lru-cache@11.5.2)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(xml2js@0.6.2):
+  eve@0.29.4(@opentelemetry/api@1.9.1)(ai@7.0.77(zod@4.4.3))(aws4fetch@1.0.20)(braintrust@3.28.0(@aws-sdk/credential-provider-web-identity@3.972.74)(zod@4.4.3))(dotenv@17.4.2)(jiti@2.7.0)(lru-cache@11.5.2)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(xml2js@0.6.2):
     dependencies:
-      ai: 7.0.16(zod@4.4.3)
+      ai: 7.0.77(zod@4.4.3)
       nitro: 3.0.260610-beta(aws4fetch@1.0.20)(dotenv@17.4.2)(jiti@2.7.0)(lru-cache@11.5.2)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(xml2js@0.6.2)
       undici: 8.9.0
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,6 +269,9 @@ importers:
       '@browserbasehq/stagehand-integrations-codex-sdk':
         specifier: workspace:*
         version: link:../integrations/codex-sdk
+      '@browserbasehq/stagehand-integrations-eve-sdk':
+        specifier: workspace:*
+        version: link:../integrations/eve-sdk
       '@browserbasehq/stagehand-integrations-mastra-sdk':
         specifier: workspace:*
         version: link:../integrations/mastra-sdk
@@ -547,6 +550,46 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.13.2
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+
+  packages/integrations/eve-sdk:
+    dependencies:
+      '@ai-sdk/anthropic':
+        specifier: 'catalog:'
+        version: 4.0.8(zod@4.4.3)
+      '@ai-sdk/google':
+        specifier: 'catalog:'
+        version: 4.0.8(zod@4.4.3)
+      '@ai-sdk/openai':
+        specifier: 'catalog:'
+        version: 4.0.8(zod@4.4.3)
+      '@browserbasehq/stagehand-integrations':
+        specifier: workspace:*
+        version: link:../core
+      '@modelcontextprotocol/sdk':
+        specifier: 'catalog:'
+        version: 1.29.0(zod@4.4.3)
+      ai:
+        specifier: 'catalog:'
+        version: 7.0.16(zod@4.4.3)
+      eve:
+        specifier: 'catalog:'
+        version: 0.29.4(@opentelemetry/api@1.9.1)(ai@7.0.16(zod@4.4.3))(aws4fetch@1.0.20)(braintrust@3.28.0(@aws-sdk/credential-provider-web-identity@3.972.74)(zod@4.4.3))(dotenv@17.4.2)(jiti@2.7.0)(lru-cache@11.5.2)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(xml2js@0.6.2)
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.2
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.3(publint@0.3.21)(tsx@4.23.1)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -1157,6 +1200,10 @@ packages:
     resolution: {integrity: sha512-jaTESuJlQsoUZ44f/i2puyPt8VlF/dMMJ9HM3cStYtk7eKX4N9UWi83OLixUkoOJH3BwWlPLCq9YIK9nfWhVBg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-node@3.972.71':
+    resolution: {integrity: sha512-HIg7Q2osBzajQwL+1Vkyh2E7Gim3eTNb9RHIsOxDGjW0eZg4oEKtRs5sioCnc73ilhaOm4gX2lHVF8J7+nt2rg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-node@3.972.79':
     resolution: {integrity: sha512-RIw5dof1EHkWubrZzPC941CDtnFG1iAXsxbFgLkhdYZXHc4icU13c/uxSMI0J5eUx9bxa7LjfpdjfClBB1QsDA==}
     engines: {node: '>=20.0.0'}
@@ -1205,8 +1252,8 @@ packages:
     resolution: {integrity: sha512-ECAqfpNsef+7MO8qtR0h9KcFIBAygaE7Cm6UOiQl+ft+uVap+1G7bNEjs4mdJE2OnA4m6k7i8peH8uGIAsOMGw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/util-locate-window@3.965.9':
-    resolution: {integrity: sha512-wB/ho7pTJKqWz3WYDt2ZWDWI8bxQpN/xwf+5ZQ1zWaj+HDY9B8Fn434i6qZ6j6ZG3aCiIJtZaQVqwajx5xYsQA==}
+  '@aws-sdk/util-locate-window@3.965.8':
+    resolution: {integrity: sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/xml-builder@3.972.38':
@@ -1646,8 +1693,8 @@ packages:
       '@modelcontextprotocol/sdk':
         optional: true
 
-  '@hono/node-server@1.19.15':
-    resolution: {integrity: sha512-Za2ai6TLdKjUvnur+eenO6nuYYipVAEhyCAdaV8IRvmU9kK8crOZUSYvIXn72E4f8fJqyAbpcJuTsYYmZp9Deg==}
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
@@ -4938,8 +4985,8 @@ packages:
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
-  hono@4.12.32:
-    resolution: {integrity: sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==}
+  hono@4.12.31:
+    resolution: {integrity: sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==}
     engines: {node: '>=16.9.0'}
 
   hookable@6.1.1:
@@ -5663,8 +5710,8 @@ packages:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
-  media-typer@1.1.1:
-    resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
 
   merge-descriptors@1.0.3:
@@ -8417,7 +8464,7 @@ snapshots:
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
       '@aws-sdk/types': 3.974.3
-      '@aws-sdk/util-locate-window': 3.965.9
+      '@aws-sdk/util-locate-window': 3.965.8
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
@@ -8442,16 +8489,16 @@ snapshots:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-sdk/core': 3.977.7
-      '@aws-sdk/credential-provider-node': 3.972.79
+      '@aws-sdk/credential-provider-node': 3.972.71
       '@aws-sdk/eventstream-handler-node': 3.972.32
       '@aws-sdk/middleware-eventstream': 3.972.27
       '@aws-sdk/middleware-websocket': 3.972.50
       '@aws-sdk/token-providers': 3.1048.0
       '@aws-sdk/types': 3.974.3
-      '@smithy/core': 3.30.0
+      '@smithy/core': 3.32.0
       '@smithy/fetch-http-handler': 5.7.0
-      '@smithy/node-http-handler': 4.7.3
-      '@smithy/types': 4.16.1
+      '@smithy/node-http-handler': 4.10.0
+      '@smithy/types': 4.17.0
       tslib: 2.8.1
 
   '@aws-sdk/core@3.977.7':
@@ -8508,6 +8555,20 @@ snapshots:
       '@smithy/types': 4.17.0
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-node@3.972.71':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.68
+      '@aws-sdk/credential-provider-http': 3.972.70
+      '@aws-sdk/credential-provider-ini': 3.973.13
+      '@aws-sdk/credential-provider-process': 3.972.68
+      '@aws-sdk/credential-provider-sso': 3.973.12
+      '@aws-sdk/credential-provider-web-identity': 3.972.74
+      '@aws-sdk/types': 3.974.3
+      '@smithy/core': 3.32.0
+      '@smithy/credential-provider-imds': 4.5.0
+      '@smithy/types': 4.17.0
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-node@3.972.79':
     dependencies:
       '@aws-sdk/credential-provider-env': 3.972.68
@@ -8521,6 +8582,7 @@ snapshots:
       '@smithy/credential-provider-imds': 4.5.0
       '@smithy/types': 4.17.0
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/credential-provider-process@3.972.68':
     dependencies:
@@ -8553,14 +8615,14 @@ snapshots:
     dependencies:
       '@aws-sdk/types': 3.974.3
       '@smithy/core': 3.32.0
-      '@smithy/types': 4.16.1
+      '@smithy/types': 4.17.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-eventstream@3.972.27':
     dependencies:
       '@aws-sdk/types': 3.974.3
       '@smithy/core': 3.32.0
-      '@smithy/types': 4.16.1
+      '@smithy/types': 4.17.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-websocket@3.972.50':
@@ -8570,7 +8632,7 @@ snapshots:
       '@smithy/core': 3.32.0
       '@smithy/fetch-http-handler': 5.7.0
       '@smithy/signature-v4': 5.7.0
-      '@smithy/types': 4.16.1
+      '@smithy/types': 4.17.0
       tslib: 2.8.1
 
   '@aws-sdk/nested-clients@3.997.42':
@@ -8596,8 +8658,8 @@ snapshots:
       '@aws-sdk/core': 3.977.7
       '@aws-sdk/nested-clients': 3.997.42
       '@aws-sdk/types': 3.974.3
-      '@smithy/core': 3.30.0
-      '@smithy/types': 4.16.1
+      '@smithy/core': 3.32.0
+      '@smithy/types': 4.17.0
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.1108.0':
@@ -8614,7 +8676,7 @@ snapshots:
       '@smithy/types': 4.17.0
       tslib: 2.8.1
 
-  '@aws-sdk/util-locate-window@3.965.9':
+  '@aws-sdk/util-locate-window@3.965.8':
     dependencies:
       tslib: 2.8.1
 
@@ -9175,9 +9237,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@hono/node-server@1.19.15(hono@4.12.32)':
+  '@hono/node-server@1.19.14(hono@4.12.31)':
     dependencies:
-      hono: 4.12.32
+      hono: 4.12.31
 
   '@img/colour@1.1.0': {}
 
@@ -10019,7 +10081,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.15(hono@4.12.32)
+      '@hono/node-server': 1.19.14(hono@4.12.31)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -10029,7 +10091,7 @@ snapshots:
       eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.6.0(express@5.2.1)
-      hono: 4.12.32
+      hono: 4.12.31
       jose: 6.2.4
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -10565,6 +10627,7 @@ snapshots:
     dependencies:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
+    optional: true
 
   '@smithy/core@3.32.0':
     dependencies:
@@ -10601,8 +10664,8 @@ snapshots:
 
   '@smithy/node-http-handler@4.7.3':
     dependencies:
-      '@smithy/core': 3.30.0
-      '@smithy/types': 4.16.1
+      '@smithy/core': 3.32.0
+      '@smithy/types': 4.17.0
       tslib: 2.8.1
 
   '@smithy/signature-v4@5.7.0':
@@ -10614,6 +10677,7 @@ snapshots:
   '@smithy/types@4.16.1':
     dependencies:
       tslib: 2.8.1
+    optional: true
 
   '@smithy/types@4.17.0':
     dependencies:
@@ -12955,7 +13019,7 @@ snapshots:
 
   highlight.js@10.7.3: {}
 
-  hono@4.12.32: {}
+  hono@4.12.31: {}
 
   hookable@6.1.1: {}
 
@@ -13772,7 +13836,7 @@ snapshots:
 
   media-typer@0.3.0: {}
 
-  media-typer@1.1.1: {}
+  media-typer@1.1.0: {}
 
   merge-descriptors@1.0.3: {}
 
@@ -16029,7 +16093,7 @@ snapshots:
   type-is@2.1.0:
     dependencies:
       content-type: 2.0.0
-      media-typer: 1.1.1
+      media-typer: 1.1.0
       mime-types: 3.0.2
 
   typebox@1.3.7: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,6 +278,9 @@ importers:
       '@browserbasehq/stagehand-integrations-pi-sdk':
         specifier: workspace:*
         version: link:../integrations/pi-sdk
+      '@modelcontextprotocol/sdk':
+        specifier: 'catalog:'
+        version: 1.29.0(zod@4.4.3)
       '@opentelemetry/api':
         specifier: 'catalog:'
         version: 1.9.1

--- a/turbo.json
+++ b/turbo.json
@@ -51,6 +51,11 @@
       "inputs": ["$TURBO_DEFAULT$", "!dist/**"],
       "outputs": ["dist/**"]
     },
+    "@browserbasehq/stagehand-integrations-eve-sdk#build": {
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", "!dist/**"],
+      "outputs": ["dist/**"]
+    },
     "@browserbasehq/stagehand-evals#build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", "!dist/**"],
@@ -156,6 +161,16 @@
         "$TURBO_ROOT$/vitest.config.ts"
       ]
     },
+    "@browserbasehq/stagehand-integrations-eve-sdk#test:unit": {
+      "dependsOn": ["^build", "@browserbasehq/stagehand-integrations-eve-sdk#build"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "tests/**",
+        "src/**",
+        "**/*.test.ts",
+        "$TURBO_ROOT$/vitest.config.ts"
+      ]
+    },
     "@browserbasehq/stagehand-integrations-example-mastra-facade#typecheck": {
       "dependsOn": ["^build"]
     },
@@ -169,6 +184,9 @@
       "dependsOn": ["^build"]
     },
     "@browserbasehq/stagehand-integrations-example-codex-facade#typecheck": {
+      "dependsOn": ["^build"]
+    },
+    "@browserbasehq/stagehand-integrations-eve-sdk#typecheck": {
       "dependsOn": ["^build"]
     },
     "@browserbasehq/stagehand-docs#typecheck": {},

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
       "packages/integrations/codex-sdk/tests/**/*.test.ts",
       "packages/integrations/mastra-sdk/tests/**/*.test.ts",
       "packages/integrations/pi-sdk/tests/**/*.test.ts",
+      "packages/integrations/eve-sdk/tests/**/*.test.ts",
       "packages/extension/tests/**/*.test.ts",
       "packages/sdk-ts/tests/**/*.test.ts",
       "packages/extension/understudy/**/*.test.ts",


### PR DESCRIPTION
## What

Adds `--harness eve` to evals, backed by a new private `@browserbasehq/stagehand-integrations-eve-sdk` package.

- `packages/integrations/eve-sdk` — `runEveSession`: eve 0.29.4 has no in-process run-agent SDK and no stdio MCP support, so the session layer spawns `eve dev --no-ui --port 0` per row against a generated agent app and consumes the HTTP NDJSON event stream (`actions.requested` / `action.result` / turn boundaries); tool-step budget counted on completed results; abort → `session.cancel()` + dev-server SIGTERM; redaction.
- `packages/evals/framework/eveToolAdapter.ts` — generates the eve agent app (`agent/tools/<server>__<tool>.ts` proxies over an `@modelcontextprotocol/sdk` stdio client) for `via:"mcp"` mounts; bounded `listTools`/cleanup; mkdtemp rollback; `load_skill` and other non-browser framework tools disabled.
- `packages/evals/framework/harnesses/eveAdapter.ts` — events → `NormalizedToolCall[]`.
- Registered via `defineExternalHarness`. Requires Node ≥ 24 (eve's own floor).

## Testing

- Full unit gate green (evals + eve-sdk 16 + all other suites).
- Connected smoke (`evals run b:webvoyager --harness eve --tool stagehand_facade -l 1 -t 1 -e browserbase`), run twice (before/after the budget fix): 5 and 3 Stagehand tool calls via the facade, final answer produced.

Stacked on the pi PR. Implemented with Codex (gpt-5.6) under supervision; Claude + `codex exec review` findings (abort cancel, unredacted logs, unbounded listTools/cleanup, tmpdir leak, budget off-by-one) fixed in-branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Eve external harness to evals via a new private `@browserbasehq/stagehand-integrations-eve-sdk`, enabling `evals run ... --harness eve`. Eve wasn't supported before; now tasks run with MCP-bridged tools, correct cancellation, redacted transcripts, and budget counted only on completed tool results.

**Implementation**
- Session layer spawns `eve dev` per task (no UI, random port), streams NDJSON, extracts usage/cost, and on abort cancels the Eve session exactly once and kills the dev server.
- Tool adapter generates a temporary Eve agent app whose tools proxy to MCP servers, with bounded connect/listTools/close and cleanup timeouts, late-client close, and `mkdtemp` rollback.
- Runner maps Eve events to normalized tool calls, usage, image evidence, and metrics, and registers `"eve"` with default model `openai/gpt-5.4-mini`.
- Non-browser framework tools like `load_skill` are disabled; the Eve SDK is lazy-loaded to avoid import-time side effects.
- Adds the package to Turbo/CI/Vitest with tests covering abort/kill/redaction, tool-adapter prep/cleanup/timeouts, `mkdtemp` rollback, lazy-load, and registry updates.

**Rollout**
- Requires Node 24+; provide MCP mounts via `STAGEHAND_EVE_MCP_SERVERS` (JSON array).
- Run with `evals run b:<dataset> --harness eve --tool <tool> -e browserbase`.
- Optional timeouts: `EVAL_EVE_MCP_LIST_TOOLS_TIMEOUT_MS` (default 60s) and `EVAL_AGENT_MOUNT_CLEANUP_TIMEOUT_MS`.
- Configure models with `EVAL_EVE_MODELS`; defaults to `openai/gpt-5.4-mini`.

<sup>Written for commit 0407ad725405c148d348d37b928236295a86005a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

