### PR TITLE
feat(evals): add Cursor agent bench harness (integrations/cursor-sdk)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,6 +266,7 @@ jobs:
             packages/integrations/eve-sdk/dist/**
             packages/integrations/deepagents-sdk/dist/**
             packages/integrations/fx-sdk/dist/**
+            packages/integrations/cursor-sdk/dist/**
             packages/evals/dist/**
           retention-days: 1
 

--- a/packages/evals/framework/benchHarness.ts
+++ b/packages/evals/framework/benchHarness.ts
@@ -21,10 +21,7 @@ import { DEEPAGENTS_TOOL_SURFACES, prepareDeepagentsToolAdapter } from "./deepag
 import { runFxAgent } from "./fxRunner.js";
 import { FX_TOOL_SURFACES, prepareFxToolAdapter } from "./fxToolAdapter.js";
 import { runCursorAgent } from "./cursorRunner.js";
-import {
-  CURSOR_TOOL_SURFACES,
-  prepareCursorToolAdapter,
-} from "./cursorToolAdapter.js";
+import { CURSOR_TOOL_SURFACES, prepareCursorToolAdapter } from "./cursorToolAdapter.js";
 import {
   buildExternalHarnessTaskPlan,
   type ExternalHarnessTaskPlan,

--- a/packages/evals/framework/benchHarness.ts
+++ b/packages/evals/framework/benchHarness.ts
@@ -20,6 +20,11 @@ import { runDeepagentsAgent } from "./deepagentsRunner.js";
 import { DEEPAGENTS_TOOL_SURFACES, prepareDeepagentsToolAdapter } from "./deepagentsToolAdapter.js";
 import { runFxAgent } from "./fxRunner.js";
 import { FX_TOOL_SURFACES, prepareFxToolAdapter } from "./fxToolAdapter.js";
+import { runCursorAgent } from "./cursorRunner.js";
+import {
+  CURSOR_TOOL_SURFACES,
+  prepareCursorToolAdapter,
+} from "./cursorToolAdapter.js";
 import {
   buildExternalHarnessTaskPlan,
   type ExternalHarnessTaskPlan,
@@ -336,6 +341,14 @@ export const fxHarness = defineExternalHarness({
   runAgent: runFxAgent,
 });
 
+export const cursorHarness = defineExternalHarness({
+  harness: "cursor",
+  supportedToolSurfaces: CURSOR_TOOL_SURFACES,
+  defaultModels: ["cursor/auto" as AvailableModel],
+  prepareToolAdapter: prepareCursorToolAdapter,
+  runAgent: runCursorAgent,
+});
+
 const harnessRegistry = new Map<Harness, BenchHarness>([
   ["stagehand", stagehandHarness],
   ["claude_code", claudeCodeHarness],
@@ -345,6 +358,7 @@ const harnessRegistry = new Map<Harness, BenchHarness>([
   ["eve", eveHarness],
   ["deepagents", deepagentsHarness],
   ["fx", fxHarness],
+  ["cursor", cursorHarness],
 ]);
 
 export function registerBenchHarness(harness: BenchHarness): () => void {

--- a/packages/evals/framework/cursorRunner.ts
+++ b/packages/evals/framework/cursorRunner.ts
@@ -1,4 +1,3 @@
-// PHASE 1: buildCursorPrompt/parseCursorResult intentionally duplicate codexRunner.ts; Phase 2 moves both onto the shared externalRunner skeleton once harness/wave-core lands.
 import {
   buildCursorTranscript,
   extractCursorToolCall,
@@ -10,14 +9,21 @@ import {
 import type { AvailableModel } from "stagehand-v3";
 import type { EvalLogger } from "../logger.js";
 import type { PreparedCursorToolAdapter } from "./cursorToolAdapter.js";
-import { datasetPromptGuidance, type ExternalHarnessTaskPlan } from "./externalHarnessPlan.js";
+import type { ExternalHarnessTaskPlan } from "./externalHarnessPlan.js";
 import { cursorAdapter } from "./harnesses/cursorAdapter.js";
+import {
+  buildExternalHarnessPrompt,
+  metricValue,
+  parseEvalResult,
+  runExternalHarnessTask,
+  type ExternalHarnessToolAdapterLike,
+  type MetricValue,
+  type ParsedEvalResult,
+} from "./harnesses/externalRunner.js";
 import type { TaskResult } from "./types.js";
-import { gradeExternalTrajectory, type ExternalHarnessVerifierConfig } from "./verifierAdapter.js";
+import type { ExternalHarnessVerifierConfig } from "./verifierAdapter.js";
 
 export type { CursorProcessRunner } from "@browserbasehq/stagehand-integrations-cursor-sdk";
-
-type MetricValue = { count: number; value: number };
 
 export interface CursorRunnerInput {
   plan: ExternalHarnessTaskPlan;
@@ -29,59 +35,34 @@ export interface CursorRunnerInput {
   verifier?: ExternalHarnessVerifierConfig;
 }
 
-export interface ParsedCursorResult {
-  success: boolean;
-  summary?: string;
-  finalAnswer?: string;
-  raw: string;
+export interface ParsedCursorResult extends ParsedEvalResult {}
+
+const MCP_ONLY_LINE =
+  "Your only browser access is the MCP server configured in this workspace; never launch a browser yourself or run shell commands to browse.";
+
+function composeCursorToolInstructions(toolInstructions?: string): string {
+  return [
+    toolInstructions ?? "Use the available browser/web tools to complete the task.",
+    MCP_ONLY_LINE,
+    "Do not edit repository files.",
+  ].join("\n");
 }
 
 export function buildCursorPrompt(
   plan: ExternalHarnessTaskPlan,
   toolInstructions?: string,
 ): string {
-  return [
-    "You are running a browser benchmark task.",
-    "",
-    `Dataset: ${plan.dataset}`,
-    plan.taskId ? `Task ID: ${plan.taskId}` : undefined,
-    `Start URL: ${plan.startUrl}`,
-    "",
-    "Instruction:",
-    plan.instruction,
-    "",
-    datasetPromptGuidance(plan.dataset),
-    toolInstructions ?? "Use the available browser/web tools to complete the task.",
-    "Your only browser access is the MCP server configured in this workspace; never launch a browser yourself or run shell commands to browse.",
-    "Do not edit repository files.",
-    "At the end, return compact JSON matching this schema:",
-    '{"success": boolean, "summary": string, "finalAnswer": string}',
-  ]
-    .filter(Boolean)
-    .join("\n");
+  return buildExternalHarnessPrompt({
+    plan,
+    toolInstructions: composeCursorToolInstructions(toolInstructions),
+    resultContract: "marker",
+  });
 }
 
 export function parseCursorResult(raw: string): ParsedCursorResult {
-  const marker = "EVAL_RESULT:";
-  const markerIndex = raw.lastIndexOf(marker);
-  const candidates =
-    markerIndex >= 0
-      ? [
-          raw.slice(markerIndex + marker.length).trim(),
-          raw
-            .slice(markerIndex + marker.length)
-            .trim()
-            .split(/\r?\n/, 1)[0]
-            ?.trim(),
-        ]
-      : [raw.trim(), raw.trim().split(/\r?\n/, 1)[0]?.trim()];
-
-  for (const candidate of candidates) {
-    if (!candidate) continue;
-    const parsed = tryParseCursorJson(stripJsonFence(candidate));
-    if (parsed) return { ...parsed, raw };
-  }
-  return { success: false, raw };
+  const parsed = parseEvalResult(raw);
+  if (parsed.success) return parsed;
+  return { ...parseEvalResult(`EVAL_RESULT: ${raw}`), raw };
 }
 
 export async function runCursorAgent({
@@ -93,82 +74,90 @@ export async function runCursorAgent({
   runProcess,
   verifier,
 }: CursorRunnerInput): Promise<TaskResult> {
-  const prompt = buildCursorPrompt(plan, toolAdapter?.promptInstructions);
-  const sessionResult = await runCursorAgentSession({
-    prompt,
-    model,
-    logger,
-    signal,
-    runProcess,
-    session: {
-      ...(toolAdapter?.cwd && { cwd: toolAdapter.cwd }),
-      ...(toolAdapter?.env && { env: toolAdapter.env }),
-      ...(process.env.EVAL_CURSOR_AGENT_PATH && {
-        binaryPath: process.env.EVAL_CURSOR_AGENT_PATH,
-      }),
-      // CURSOR_API_KEY reaches the CLI through the inherited environment;
-      // never pass it as --api-key, which would expose it in process listings.
-      ...(readCursorSandbox(process.env.EVAL_CURSOR_SANDBOX) && {
-        sandbox: readCursorSandbox(process.env.EVAL_CURSOR_SANDBOX),
-      }),
-      force: true,
-      trust: true,
-      approveMcps: true,
-    },
-    maxToolSteps: readCursorMaxToolSteps(),
-    onToolResult: toolAdapter?.onToolResult ? (name) => toolAdapter.onToolResult!(name) : undefined,
-  });
-  const { events, resultEvent, resultText, iterationError, status, stopReason, tokenUsage } =
-    sessionResult;
-  const transcriptText = buildCursorTranscript(events);
-  const iterationErrorMessage = stringifyError(iterationError);
-  const rawResult = [resultText, transcriptText, iterationErrorMessage]
-    .filter(Boolean)
-    .join("\n\n");
-  const parsed = parseCursorResult(rawResult);
-  const errorMessage =
-    parsed.summary ??
-    stopReason ??
-    (iterationErrorMessage || resultText || transcriptText || "Cursor did not report success");
-  const baseResult: TaskResult = {
-    _success: parsed.success,
-    error: !parsed.success ? errorMessage : undefined,
-    reasoning: parsed.summary,
-    finalAnswer: parsed.finalAnswer,
-    rawResult: parsed.raw,
-    cursorStatus: status,
-    ...(stopReason && { cursorStopReason: stopReason }),
-    logs: logger.getLogs(),
-    metrics: buildCursorMetrics(tokenUsage, resultEvent, events),
+  const adapterLike: ExternalHarnessToolAdapterLike = {
+    promptInstructions: composeCursorToolInstructions(toolAdapter?.promptInstructions),
+    captureEvidence: toolAdapter?.captureEvidence,
+    drainStepObservations: toolAdapter?.drainStepObservations,
+    observedToolMatcher: toolAdapter?.observedToolMatcher,
   };
-  if (!verifier) return baseResult;
-
-  const finalObservation = await toolAdapter?.captureEvidence?.().catch((): undefined => undefined);
-  const stepObservations = await toolAdapter?.drainStepObservations?.();
-  return gradeExternalTrajectory({
-    buildTrajectory: () =>
+  return runExternalHarnessTask({
+    harness: "cursor",
+    plan,
+    logger,
+    toolAdapter: adapterLike,
+    verifier,
+    resultContract: "marker",
+    fallbackErrorMessage: "Cursor did not report success",
+    runSession: async (prompt) => {
+      const sessionResult = await runCursorAgentSession({
+        prompt,
+        model,
+        logger,
+        signal,
+        runProcess,
+        session: {
+          ...(toolAdapter?.cwd && { cwd: toolAdapter.cwd }),
+          ...(toolAdapter?.env && { env: toolAdapter.env }),
+          ...(process.env.EVAL_CURSOR_AGENT_PATH && {
+            binaryPath: process.env.EVAL_CURSOR_AGENT_PATH,
+          }),
+          // CURSOR_API_KEY reaches the CLI through the inherited environment;
+          // never pass it as --api-key, which would expose it in process listings.
+          ...(readCursorSandbox(process.env.EVAL_CURSOR_SANDBOX) && {
+            sandbox: readCursorSandbox(process.env.EVAL_CURSOR_SANDBOX),
+          }),
+          force: true,
+          trust: true,
+          approveMcps: true,
+        },
+        maxToolSteps: readCursorMaxToolSteps(),
+        onToolResult: toolAdapter?.onToolResult
+          ? (name) => toolAdapter.onToolResult!(name)
+          : undefined,
+      });
+      const usage = sessionResult.tokenUsage;
+      return {
+        raw: sessionResult,
+        resultText: sessionResult.resultText,
+        transcriptText: buildCursorTranscript(sessionResult.events),
+        iterationError: sessionResult.iterationError,
+        status: sessionResult.status,
+        stopReason:
+          sessionResult.stopReason ||
+          (sessionResult.status === "sdk_error"
+            ? stringifyError(sessionResult.iterationError) || undefined
+            : undefined),
+        usage: {
+          inputTokens: usage.inputTokens,
+          outputTokens: usage.outputTokens,
+          totalTokens: usage.totalTokens,
+        },
+        metrics: buildCursorMetrics(
+          usage,
+          sessionResult.resultEvent,
+          sessionResult.events,
+        ),
+      };
+    },
+    toTrajectory: (
+      { raw, parsed, finalObservation, stepObservations, observedToolName, status },
+      taskSpec,
+    ) =>
       cursorAdapter.fromHarnessResult(
         {
-          events,
+          events: raw.events,
           ...(finalObservation && { finalObservation }),
           ...(stepObservations?.length && { stepObservations }),
-          ...(toolAdapter?.observedToolMatcher && {
-            observedToolName: toolAdapter.observedToolMatcher,
-          }),
-          finalAnswer: parsed.finalAnswer ?? resultText,
-          status: status === "completed" ? "complete" : "error",
+          ...(observedToolName && { observedToolName }),
+          finalAnswer: parsed.finalAnswer ?? raw.resultText,
+          status,
           usage: {
             input_tokens: 0,
             output_tokens: 0,
           },
         },
-        verifier.taskSpec,
+        taskSpec,
       ),
-    verifier,
-    baseResult,
-    errorMessage,
-    category: "cursor",
-    logger,
   });
 }
 
@@ -182,28 +171,6 @@ export function readCursorMaxToolSteps(): number {
     if (Number.isFinite(parsed) && parsed > 0) return parsed;
   }
   return 50;
-}
-
-function stripJsonFence(candidate: string): string {
-  const match = candidate.match(/^```json\s*([\s\S]*?)\s*```$/i);
-  return match?.[1]?.trim() ?? candidate;
-}
-
-function tryParseCursorJson(candidate: string): Omit<ParsedCursorResult, "raw"> | undefined {
-  try {
-    const parsed = JSON.parse(candidate) as {
-      success?: unknown;
-      summary?: unknown;
-      finalAnswer?: unknown;
-    };
-    return {
-      success: parsed.success === true,
-      summary: typeof parsed.summary === "string" ? parsed.summary : undefined,
-      finalAnswer: typeof parsed.finalAnswer === "string" ? parsed.finalAnswer : undefined,
-    };
-  } catch {
-    return undefined;
-  }
 }
 
 function buildCursorMetrics(
@@ -222,18 +189,4 @@ function buildCursorMetrics(
     cursor_duration_ms: metricValue(resultEvent?.duration_ms),
     cursor_tool_steps: metricValue(toolSteps),
   };
-}
-
-function metricValue(value: unknown): MetricValue {
-  return { count: 1, value: toFiniteNumber(value) };
-}
-
-function toFiniteNumber(value: unknown): number {
-  const parsed =
-    typeof value === "number"
-      ? value
-      : typeof value === "string" && value.trim()
-        ? Number(value)
-        : 0;
-  return Number.isFinite(parsed) ? parsed : 0;
 }

--- a/packages/evals/framework/cursorRunner.ts
+++ b/packages/evals/framework/cursorRunner.ts
@@ -88,6 +88,9 @@ export async function runCursorAgent({
     verifier,
     resultContract: "marker",
     fallbackErrorMessage: "Cursor did not report success",
+    // Cursor often emits the result as fenced/prose JSON without the marker;
+    // the lenient retry only runs after the strict parse fails.
+    parseResult: parseCursorResult,
     runSession: async (prompt) => {
       const sessionResult = await runCursorAgentSession({
         prompt,

--- a/packages/evals/framework/cursorRunner.ts
+++ b/packages/evals/framework/cursorRunner.ts
@@ -1,0 +1,239 @@
+// PHASE 1: buildCursorPrompt/parseCursorResult intentionally duplicate codexRunner.ts; Phase 2 moves both onto the shared externalRunner skeleton once harness/wave-core lands.
+import {
+  buildCursorTranscript,
+  extractCursorToolCall,
+  runCursorAgentSession,
+  stringifyError,
+  type CursorProcessRunner,
+  type CursorTokenUsage,
+} from "@browserbasehq/stagehand-integrations-cursor-sdk";
+import type { AvailableModel } from "stagehand-v3";
+import type { EvalLogger } from "../logger.js";
+import type { PreparedCursorToolAdapter } from "./cursorToolAdapter.js";
+import { datasetPromptGuidance, type ExternalHarnessTaskPlan } from "./externalHarnessPlan.js";
+import { cursorAdapter } from "./harnesses/cursorAdapter.js";
+import type { TaskResult } from "./types.js";
+import { gradeExternalTrajectory, type ExternalHarnessVerifierConfig } from "./verifierAdapter.js";
+
+export type { CursorProcessRunner } from "@browserbasehq/stagehand-integrations-cursor-sdk";
+
+type MetricValue = { count: number; value: number };
+
+export interface CursorRunnerInput {
+  plan: ExternalHarnessTaskPlan;
+  model: AvailableModel;
+  logger: EvalLogger;
+  toolAdapter?: PreparedCursorToolAdapter;
+  signal?: AbortSignal;
+  runProcess?: CursorProcessRunner;
+  verifier?: ExternalHarnessVerifierConfig;
+}
+
+export interface ParsedCursorResult {
+  success: boolean;
+  summary?: string;
+  finalAnswer?: string;
+  raw: string;
+}
+
+export function buildCursorPrompt(
+  plan: ExternalHarnessTaskPlan,
+  toolInstructions?: string,
+): string {
+  return [
+    "You are running a browser benchmark task.",
+    "",
+    `Dataset: ${plan.dataset}`,
+    plan.taskId ? `Task ID: ${plan.taskId}` : undefined,
+    `Start URL: ${plan.startUrl}`,
+    "",
+    "Instruction:",
+    plan.instruction,
+    "",
+    datasetPromptGuidance(plan.dataset),
+    toolInstructions ?? "Use the available browser/web tools to complete the task.",
+    "Your only browser access is the MCP server configured in this workspace; never launch a browser yourself or run shell commands to browse.",
+    "Do not edit repository files.",
+    "At the end, return compact JSON matching this schema:",
+    '{"success": boolean, "summary": string, "finalAnswer": string}',
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+export function parseCursorResult(raw: string): ParsedCursorResult {
+  const marker = "EVAL_RESULT:";
+  const markerIndex = raw.lastIndexOf(marker);
+  const candidates =
+    markerIndex >= 0
+      ? [
+          raw.slice(markerIndex + marker.length).trim(),
+          raw
+            .slice(markerIndex + marker.length)
+            .trim()
+            .split(/\r?\n/, 1)[0]
+            ?.trim(),
+        ]
+      : [raw.trim(), raw.trim().split(/\r?\n/, 1)[0]?.trim()];
+
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    const parsed = tryParseCursorJson(stripJsonFence(candidate));
+    if (parsed) return { ...parsed, raw };
+  }
+  return { success: false, raw };
+}
+
+export async function runCursorAgent({
+  plan,
+  model,
+  logger,
+  toolAdapter,
+  signal,
+  runProcess,
+  verifier,
+}: CursorRunnerInput): Promise<TaskResult> {
+  const prompt = buildCursorPrompt(plan, toolAdapter?.promptInstructions);
+  const sessionResult = await runCursorAgentSession({
+    prompt,
+    model,
+    logger,
+    signal,
+    runProcess,
+    session: {
+      ...(toolAdapter?.cwd && { cwd: toolAdapter.cwd }),
+      ...(toolAdapter?.env && { env: toolAdapter.env }),
+      ...(process.env.EVAL_CURSOR_AGENT_PATH && {
+        binaryPath: process.env.EVAL_CURSOR_AGENT_PATH,
+      }),
+      // CURSOR_API_KEY reaches the CLI through the inherited environment;
+      // never pass it as --api-key, which would expose it in process listings.
+      ...(readCursorSandbox(process.env.EVAL_CURSOR_SANDBOX) && {
+        sandbox: readCursorSandbox(process.env.EVAL_CURSOR_SANDBOX),
+      }),
+      force: true,
+      trust: true,
+      approveMcps: true,
+    },
+    maxToolSteps: readCursorMaxToolSteps(),
+    onToolResult: toolAdapter?.onToolResult ? (name) => toolAdapter.onToolResult!(name) : undefined,
+  });
+  const { events, resultEvent, resultText, iterationError, status, stopReason, tokenUsage } =
+    sessionResult;
+  const transcriptText = buildCursorTranscript(events);
+  const iterationErrorMessage = stringifyError(iterationError);
+  const rawResult = [resultText, transcriptText, iterationErrorMessage]
+    .filter(Boolean)
+    .join("\n\n");
+  const parsed = parseCursorResult(rawResult);
+  const errorMessage =
+    parsed.summary ??
+    stopReason ??
+    (iterationErrorMessage || resultText || transcriptText || "Cursor did not report success");
+  const baseResult: TaskResult = {
+    _success: parsed.success,
+    error: !parsed.success ? errorMessage : undefined,
+    reasoning: parsed.summary,
+    finalAnswer: parsed.finalAnswer,
+    rawResult: parsed.raw,
+    cursorStatus: status,
+    ...(stopReason && { cursorStopReason: stopReason }),
+    logs: logger.getLogs(),
+    metrics: buildCursorMetrics(tokenUsage, resultEvent, events),
+  };
+  if (!verifier) return baseResult;
+
+  const finalObservation = await toolAdapter?.captureEvidence?.().catch((): undefined => undefined);
+  const stepObservations = await toolAdapter?.drainStepObservations?.();
+  return gradeExternalTrajectory({
+    buildTrajectory: () =>
+      cursorAdapter.fromHarnessResult(
+        {
+          events,
+          ...(finalObservation && { finalObservation }),
+          ...(stepObservations?.length && { stepObservations }),
+          ...(toolAdapter?.observedToolMatcher && {
+            observedToolName: toolAdapter.observedToolMatcher,
+          }),
+          finalAnswer: parsed.finalAnswer ?? resultText,
+          status: status === "completed" ? "complete" : "error",
+          usage: {
+            input_tokens: 0,
+            output_tokens: 0,
+          },
+        },
+        verifier.taskSpec,
+      ),
+    verifier,
+    baseResult,
+    errorMessage,
+    category: "cursor",
+    logger,
+  });
+}
+
+export function readCursorSandbox(value: unknown): "enabled" | "disabled" | undefined {
+  return value === "enabled" || value === "disabled" ? value : undefined;
+}
+
+export function readCursorMaxToolSteps(): number {
+  for (const key of ["EVAL_CURSOR_MAX_STEPS", "AGENT_EVAL_MAX_STEPS"]) {
+    const parsed = Number.parseInt(process.env[key] ?? "", 10);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  return 50;
+}
+
+function stripJsonFence(candidate: string): string {
+  const match = candidate.match(/^```json\s*([\s\S]*?)\s*```$/i);
+  return match?.[1]?.trim() ?? candidate;
+}
+
+function tryParseCursorJson(candidate: string): Omit<ParsedCursorResult, "raw"> | undefined {
+  try {
+    const parsed = JSON.parse(candidate) as {
+      success?: unknown;
+      summary?: unknown;
+      finalAnswer?: unknown;
+    };
+    return {
+      success: parsed.success === true,
+      summary: typeof parsed.summary === "string" ? parsed.summary : undefined,
+      finalAnswer: typeof parsed.finalAnswer === "string" ? parsed.finalAnswer : undefined,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function buildCursorMetrics(
+  usage: CursorTokenUsage,
+  resultEvent: Record<string, unknown> | undefined,
+  events: Array<Record<string, unknown>>,
+): Record<string, MetricValue> {
+  const toolSteps = events.filter((event) => {
+    const view = extractCursorToolCall(event);
+    return view?.subtype === "completed";
+  }).length;
+  return {
+    cursor_input_tokens: metricValue(usage.inputTokens),
+    cursor_output_tokens: metricValue(usage.outputTokens),
+    cursor_total_tokens: metricValue(usage.totalTokens),
+    cursor_duration_ms: metricValue(resultEvent?.duration_ms),
+    cursor_tool_steps: metricValue(toolSteps),
+  };
+}
+
+function metricValue(value: unknown): MetricValue {
+  return { count: 1, value: toFiniteNumber(value) };
+}
+
+function toFiniteNumber(value: unknown): number {
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim()
+        ? Number(value)
+        : 0;
+  return Number.isFinite(parsed) ? parsed : 0;
+}

--- a/packages/evals/framework/cursorRunner.ts
+++ b/packages/evals/framework/cursorRunner.ts
@@ -132,11 +132,7 @@ export async function runCursorAgent({
           outputTokens: usage.outputTokens,
           totalTokens: usage.totalTokens,
         },
-        metrics: buildCursorMetrics(
-          usage,
-          sessionResult.resultEvent,
-          sessionResult.events,
-        ),
+        metrics: buildCursorMetrics(usage, sessionResult.resultEvent, sessionResult.events),
       };
     },
     toTrajectory: (

--- a/packages/evals/framework/cursorToolAdapter.ts
+++ b/packages/evals/framework/cursorToolAdapter.ts
@@ -7,10 +7,7 @@ import { EvalsError } from "../errors.js";
 import type { EvalLogger } from "../logger.js";
 import { startAgentToolRuntime } from "./agentToolRuntime.js";
 import type { ExternalHarnessTaskPlan } from "./externalHarnessPlan.js";
-import {
-  resolveStartupProfile,
-  resolveToolSurface,
-} from "./harnesses/toolSurfaceResolution.js";
+import { resolveStartupProfile, resolveToolSurface } from "./harnesses/toolSurfaceResolution.js";
 import { ObservationRecorder, type StepObservation } from "./observationRecorder.js";
 
 export interface CursorToolAdapterInput {

--- a/packages/evals/framework/cursorToolAdapter.ts
+++ b/packages/evals/framework/cursorToolAdapter.ts
@@ -66,7 +66,8 @@ export function isCursorMountToolName(serverNames: string[], toolName: string): 
       toolName === server ||
       toolName.startsWith(`${server}.`) ||
       toolName.startsWith(`${server}__`) ||
-      toolName.startsWith(`mcp__${server}`) ||
+      toolName === `mcp__${server}` ||
+      toolName.startsWith(`mcp__${server}__`) ||
       toolName.startsWith(`${server}:`),
   );
 }

--- a/packages/evals/framework/cursorToolAdapter.ts
+++ b/packages/evals/framework/cursorToolAdapter.ts
@@ -7,6 +7,10 @@ import { EvalsError } from "../errors.js";
 import type { EvalLogger } from "../logger.js";
 import { startAgentToolRuntime } from "./agentToolRuntime.js";
 import type { ExternalHarnessTaskPlan } from "./externalHarnessPlan.js";
+import {
+  resolveStartupProfile,
+  resolveToolSurface,
+} from "./harnesses/toolSurfaceResolution.js";
 import { ObservationRecorder, type StepObservation } from "./observationRecorder.js";
 
 export interface CursorToolAdapterInput {
@@ -32,11 +36,11 @@ export interface PreparedCursorToolAdapter {
   cleanup: () => Promise<void>;
 }
 
-export const CURSOR_MCP_SURFACES: ReadonlySet<ToolSurface> = new Set([
+export const CURSOR_TOOL_SURFACES: ToolSurface[] = [
   "stagehand_facade",
   "playwright_mcp",
   "chrome_devtools_mcp",
-]);
+];
 
 export function buildCursorMcpConfig(mcpServers: Record<string, unknown>): {
   mcpServers: Record<string, unknown>;
@@ -70,38 +74,15 @@ export function isCursorMountToolName(serverNames: string[], toolName: string): 
   );
 }
 
-export function resolveCursorToolSurface(requested?: ToolSurface): ToolSurface {
-  if (!requested) return "stagehand_facade";
-  if (CURSOR_MCP_SURFACES.has(requested)) return requested;
-  throw new EvalsError(
-    `Cursor harness supports --tool stagehand_facade, playwright_mcp, or chrome_devtools_mcp; received "${requested}".`,
-  );
-}
-
-export function resolveCursorStartupProfile(
-  toolSurface: ToolSurface,
-  environment: "LOCAL" | "BROWSERBASE",
-  requested?: StartupProfile,
-): StartupProfile {
-  if (requested) return requested;
-  if (toolSurface === "stagehand_facade") {
-    return environment === "BROWSERBASE" ? "tool_create_browserbase" : "tool_launch_local";
-  }
-  if (CURSOR_MCP_SURFACES.has(toolSurface)) {
-    return environment === "BROWSERBASE"
-      ? "runner_provided_browserbase_cdp"
-      : "runner_provided_local_cdp";
-  }
-  throw new EvalsError(
-    `No Cursor startup profile default for tool "${toolSurface}" in ${environment}.`,
-  );
-}
-
 export async function prepareCursorToolAdapter(
   input: CursorToolAdapterInput,
 ): Promise<PreparedCursorToolAdapter> {
-  const toolSurface = resolveCursorToolSurface(input.toolSurface);
-  const startupProfile = resolveCursorStartupProfile(
+  const toolSurface = resolveToolSurface(
+    { harness: "cursor", supportedToolSurfaces: CURSOR_TOOL_SURFACES },
+    input.toolSurface,
+  );
+  if (toolSurface === undefined) throw new EvalsError("cursor harness requires a tool surface.");
+  const startupProfile = resolveStartupProfile(
     toolSurface,
     input.environment,
     input.startupProfile,

--- a/packages/evals/framework/cursorToolAdapter.ts
+++ b/packages/evals/framework/cursorToolAdapter.ts
@@ -1,0 +1,235 @@
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { ProbeEvidence } from "stagehand-v3";
+import type { StartupProfile, ToolSurface } from "../core/contracts/tool.js";
+import { EvalsError } from "../errors.js";
+import type { EvalLogger } from "../logger.js";
+import { startAgentToolRuntime } from "./agentToolRuntime.js";
+import type { ExternalHarnessTaskPlan } from "./externalHarnessPlan.js";
+import { ObservationRecorder, type StepObservation } from "./observationRecorder.js";
+
+export interface CursorToolAdapterInput {
+  toolSurface?: ToolSurface;
+  startupProfile?: StartupProfile;
+  environment: "LOCAL" | "BROWSERBASE";
+  plan: ExternalHarnessTaskPlan;
+  logger: EvalLogger;
+}
+
+export interface PreparedCursorToolAdapter {
+  toolSurface: ToolSurface;
+  startupProfile: StartupProfile;
+  cwd: string;
+  env: Record<string, string>;
+  mcpConfigPath: string;
+  mcpServerNames: string[];
+  promptInstructions: string;
+  captureEvidence?: () => Promise<ProbeEvidence>;
+  drainStepObservations?: () => Promise<StepObservation[]>;
+  onToolResult?: (toolName: string) => void;
+  observedToolMatcher?: (name: string) => boolean;
+  cleanup: () => Promise<void>;
+}
+
+export const CURSOR_MCP_SURFACES: ReadonlySet<ToolSurface> = new Set([
+  "stagehand_facade",
+  "playwright_mcp",
+  "chrome_devtools_mcp",
+]);
+
+export function buildCursorMcpConfig(mcpServers: Record<string, unknown>): {
+  mcpServers: Record<string, unknown>;
+} {
+  return { mcpServers };
+}
+
+export async function writeCursorWorkspace(
+  cwd: string,
+  mcpServers: Record<string, unknown>,
+): Promise<{ mcpConfigPath: string }> {
+  const configDir = path.join(cwd, ".cursor");
+  const mcpConfigPath = path.join(configDir, "mcp.json");
+  await fsp.mkdir(configDir, { recursive: true });
+  await fsp.writeFile(
+    mcpConfigPath,
+    `${JSON.stringify(buildCursorMcpConfig(mcpServers), null, 2)}\n`,
+    { mode: 0o600 },
+  );
+  return { mcpConfigPath };
+}
+
+export function isCursorMountToolName(serverNames: string[], toolName: string): boolean {
+  return serverNames.some(
+    (server) =>
+      toolName === server ||
+      toolName.startsWith(`${server}.`) ||
+      toolName.startsWith(`${server}__`) ||
+      toolName.startsWith(`mcp__${server}`) ||
+      toolName.startsWith(`${server}:`),
+  );
+}
+
+export function resolveCursorToolSurface(requested?: ToolSurface): ToolSurface {
+  if (!requested) return "stagehand_facade";
+  if (CURSOR_MCP_SURFACES.has(requested)) return requested;
+  throw new EvalsError(
+    `Cursor harness supports --tool stagehand_facade, playwright_mcp, or chrome_devtools_mcp; received "${requested}".`,
+  );
+}
+
+export function resolveCursorStartupProfile(
+  toolSurface: ToolSurface,
+  environment: "LOCAL" | "BROWSERBASE",
+  requested?: StartupProfile,
+): StartupProfile {
+  if (requested) return requested;
+  if (toolSurface === "stagehand_facade") {
+    return environment === "BROWSERBASE" ? "tool_create_browserbase" : "tool_launch_local";
+  }
+  if (CURSOR_MCP_SURFACES.has(toolSurface)) {
+    return environment === "BROWSERBASE"
+      ? "runner_provided_browserbase_cdp"
+      : "runner_provided_local_cdp";
+  }
+  throw new EvalsError(
+    `No Cursor startup profile default for tool "${toolSurface}" in ${environment}.`,
+  );
+}
+
+export async function prepareCursorToolAdapter(
+  input: CursorToolAdapterInput,
+): Promise<PreparedCursorToolAdapter> {
+  const toolSurface = resolveCursorToolSurface(input.toolSurface);
+  const startupProfile = resolveCursorStartupProfile(
+    toolSurface,
+    input.environment,
+    input.startupProfile,
+  );
+  const runtime = await startAgentToolRuntime({
+    toolSurface,
+    startupProfile,
+    environment: input.environment,
+    logger: input.logger,
+  });
+
+  let cwd: string | undefined;
+  try {
+    const mount = runtime.running.agentMount;
+    if (!mount) {
+      throw new EvalsError(`Tool surface "${toolSurface}" does not provide an agent mount.`);
+    }
+    if (mount.via !== "mcp") {
+      throw new EvalsError(
+        `Cursor does not support agent mounts delivered via "${mount.via}" yet.`,
+      );
+    }
+
+    cwd = await fsp.mkdtemp(
+      path.join(os.tmpdir(), `stagehand-evals-cursor-${toolSurface.replace(/_/g, "-")}-`),
+    );
+    const capturedCwd = cwd;
+    const { mcpConfigPath } = await writeCursorWorkspace(cwd, mount.mcpServers);
+    const mcpServerNames = Object.keys(mount.mcpServers);
+    const recorder = runtime.running.captureEvidence
+      ? new ObservationRecorder(runtime.running.captureEvidence)
+      : undefined;
+    const observedToolMatcher = (name: string): boolean =>
+      isCursorMountToolName(mcpServerNames, name);
+    let cleanupPromise: Promise<void> | undefined;
+
+    input.logger.log({
+      category: "cursor",
+      message: `Initialized ${toolSurface} MCP mount for Cursor (servers: ${mcpServerNames.join(", ")}).`,
+      level: 1,
+      auxiliary: {
+        startupProfile: { value: startupProfile, type: "string" },
+        environment: { value: input.environment, type: "string" },
+      },
+    });
+
+    return {
+      toolSurface,
+      startupProfile,
+      cwd,
+      env: { ...process.env } as Record<string, string>,
+      mcpConfigPath,
+      mcpServerNames,
+      promptInstructions: mount.promptInstructions,
+      ...(runtime.running.captureEvidence && {
+        captureEvidence: boundedCaptureEvidence(runtime.running.captureEvidence),
+      }),
+      ...(recorder && {
+        drainStepObservations: async () => {
+          await recorder.settle();
+          return recorder.drain();
+        },
+        onToolResult: (toolName: string) => {
+          if (observedToolMatcher(toolName)) void recorder.record();
+        },
+      }),
+      observedToolMatcher,
+      cleanup: async () => {
+        cleanupPromise ??= (async () => {
+          try {
+            await withTimeout(
+              runtime.cleanup(),
+              readPositiveIntEnv("EVAL_AGENT_MOUNT_CLEANUP_TIMEOUT_MS", 30_000),
+            );
+          } catch {
+            // best-effort only
+          } finally {
+            await fsp.rm(capturedCwd, { recursive: true, force: true });
+          }
+        })();
+        await cleanupPromise;
+      },
+    };
+  } catch (error) {
+    await withTimeout(
+      runtime.cleanup(),
+      readPositiveIntEnv("EVAL_AGENT_MOUNT_CLEANUP_TIMEOUT_MS", 30_000),
+    ).catch((): undefined => undefined);
+    if (cwd) await fsp.rm(cwd, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+function boundedCaptureEvidence(
+  capture: () => Promise<ProbeEvidence>,
+): () => Promise<ProbeEvidence> {
+  return async () => {
+    try {
+      return await withTimeout(
+        capture(),
+        readPositiveIntEnv("EVAL_CAPTURE_EVIDENCE_TIMEOUT_MS", 15_000),
+      );
+    } catch {
+      return {};
+    }
+  };
+}
+
+function readPositiveIntEnv(key: string, fallback: number): number {
+  const parsed = Number.parseInt(process.env[key] ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`cursor adapter operation timed out after ${timeoutMs}ms`)),
+      timeoutMs,
+    );
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}

--- a/packages/evals/framework/harnesses/cursorAdapter.ts
+++ b/packages/evals/framework/harnesses/cursorAdapter.ts
@@ -78,6 +78,15 @@ export class CursorTrajectoryAdapter implements TrajectoryAdapter<CursorRunResul
       }
     }
 
+    // A 'started' call with no 'completed' envelope (stream aborted, CLI
+    // killed mid-call) must not read as a successful step — mirror the
+    // deepagents adapter's unmatched-call handling.
+    for (const open of openCalls.values()) {
+      open.ok = false;
+      open.result = "no tool result";
+      open.error = "no tool result";
+    }
+
     attachStepObservations(toolCalls, result);
     const trailing = trailingTextParts.join("\n").trim();
     const finalAnswer =

--- a/packages/evals/framework/harnesses/cursorAdapter.ts
+++ b/packages/evals/framework/harnesses/cursorAdapter.ts
@@ -1,0 +1,223 @@
+/**
+ * cursorAdapter — converts Cursor CLI stream-json events into a `Trajectory`
+ * the verifier can consume.
+ *
+ * Mapping:
+ *   - assistant text preceding a tool call becomes that call's reasoning;
+ *     trailing assistant text is the final-answer fallback.
+ *   - tool_call started/completed pairs by call_id. Completed-only events are
+ *     retained, because Cursor may omit a started event in captured output.
+ *   - documented result.success/error envelopes become normalized tool output.
+ *     The currently undocumented MCP shape is parsed defensively by the shared
+ *     cursor-sdk helper.
+ *   - result.result is the preferred stream final-answer fallback.
+ */
+import { extractCursorToolCall } from "@browserbasehq/stagehand-integrations-cursor-sdk";
+import type { ProbeEvidence, TaskSpec, Trajectory } from "stagehand-v3";
+import type { StepObservation } from "../observationRecorder.js";
+import {
+  buildTrajectory,
+  type NormalizedToolCall,
+  type TrajectoryAdapter,
+} from "./trajectoryAdapter.js";
+
+export interface CursorRunResult {
+  events: Array<Record<string, unknown>>;
+  finalAnswer?: string;
+  status?: Trajectory["status"];
+  usage?: Partial<Trajectory["usage"]>;
+  finalObservation?: ProbeEvidence;
+  stepObservations?: StepObservation[];
+  observedToolName?: (name: string) => boolean;
+}
+
+export class CursorTrajectoryAdapter implements TrajectoryAdapter<CursorRunResult> {
+  fromHarnessResult(result: CursorRunResult, taskSpec: TaskSpec): Trajectory {
+    const toolCalls: NormalizedToolCall[] = [];
+    const openCalls = new Map<string, NormalizedToolCall>();
+    const trailingTextParts: string[] = [];
+    let pendingReasoning = "";
+    let resultMessageText: string | undefined;
+
+    for (const event of result.events) {
+      const type = String(event.type ?? "");
+      if (type === "assistant") {
+        for (const text of extractAssistantText(event)) {
+          pendingReasoning = appendText(pendingReasoning, text);
+          trailingTextParts.push(text);
+        }
+        continue;
+      }
+      if (type === "result") {
+        if (typeof event.result === "string" && event.result.trim()) {
+          resultMessageText = event.result;
+        }
+        continue;
+      }
+
+      const view = extractCursorToolCall(event);
+      if (!view) continue;
+      if (view.subtype === "started") {
+        const call = normalizeToolCall(view, pendingReasoning);
+        toolCalls.push(call);
+        if (view.callId) openCalls.set(view.callId, call);
+        pendingReasoning = "";
+        trailingTextParts.length = 0;
+        continue;
+      }
+      if (view.subtype === "completed") {
+        const open = view.callId ? openCalls.get(view.callId) : undefined;
+        if (open) {
+          applyCompletedToolCall(open, view);
+          openCalls.delete(view.callId);
+        } else {
+          toolCalls.push(normalizeToolCall(view, pendingReasoning));
+          pendingReasoning = "";
+          trailingTextParts.length = 0;
+        }
+      }
+    }
+
+    attachStepObservations(toolCalls, result);
+    const trailing = trailingTextParts.join("\n").trim();
+    const finalAnswer =
+      result.finalAnswer ?? resultMessageText ?? (trailing.length > 0 ? trailing : undefined);
+    const finalObservation = resolveFinalObservation(result.finalObservation, toolCalls);
+
+    return buildTrajectory({
+      taskSpec,
+      toolCalls,
+      finalAnswer,
+      status: result.status ?? "complete",
+      usage: result.usage,
+      ...(finalObservation && { finalObservation }),
+    });
+  }
+}
+
+export const cursorAdapter = new CursorTrajectoryAdapter();
+
+type CursorToolView = NonNullable<ReturnType<typeof extractCursorToolCall>>;
+
+function normalizeToolCall(view: CursorToolView, reasoning: string): NormalizedToolCall {
+  const content = normalizeToolResult(view.result);
+  return {
+    name: view.name,
+    args: view.args,
+    result: content.result,
+    ok: view.ok,
+    ...(view.error && { error: view.error }),
+    reasoning: reasoning.trim() || undefined,
+    ...(content.images.length && { images: content.images }),
+  };
+}
+
+function applyCompletedToolCall(call: NormalizedToolCall, view: CursorToolView): void {
+  const content = normalizeToolResult(view.result);
+  call.name = view.name;
+  call.args = view.args;
+  call.result = content.result;
+  call.ok = view.ok;
+  if (view.error) call.error = view.error;
+  else delete call.error;
+  if (content.images.length) call.images = content.images;
+}
+
+function normalizeToolResult(result: unknown): {
+  result: unknown;
+  images: Array<{ bytes: Buffer; mediaType: string }>;
+} {
+  if (!isRecord(result) || !Array.isArray(result.content)) {
+    return { result, images: [] };
+  }
+  const parts: string[] = [];
+  const images: Array<{ bytes: Buffer; mediaType: string }> = [];
+  for (const block of result.content) {
+    if (!isRecord(block)) continue;
+    if (block.type === "text" && typeof block.text === "string") {
+      parts.push(block.text);
+    } else if (block.type === "image") {
+      const image = decodeImageBlock(block);
+      if (image) {
+        images.push(image);
+        parts.push("[image]");
+      }
+    } else if (typeof block.text === "string") {
+      parts.push(block.text);
+    }
+  }
+  return { result: parts.join("\n"), images };
+}
+
+function decodeImageBlock(
+  block: Record<string, unknown>,
+): { bytes: Buffer; mediaType: string } | undefined {
+  const source = isRecord(block.source) ? block.source : undefined;
+  const data =
+    source?.type === "base64" && typeof source.data === "string"
+      ? source.data
+      : typeof block.data === "string"
+        ? block.data
+        : undefined;
+  if (!data) return undefined;
+  const mediaType =
+    typeof source?.media_type === "string"
+      ? source.media_type
+      : typeof block.mimeType === "string"
+        ? block.mimeType
+        : "image/png";
+  try {
+    return { bytes: Buffer.from(data, "base64"), mediaType };
+  } catch {
+    return undefined;
+  }
+}
+
+function attachStepObservations(toolCalls: NormalizedToolCall[], result: CursorRunResult): void {
+  const observations = result.stepObservations ?? [];
+  if (observations.length === 0) return;
+  const isObservedTool =
+    result.observedToolName ?? ((name: string) => name.startsWith("mcp") || name.includes("."));
+  const observedCalls = toolCalls.filter((call) => isObservedTool(call.name));
+  const totalObservedRuns =
+    Math.max(...observations.map((observation) => observation.runIndex)) + 1;
+  if (observedCalls.length !== totalObservedRuns) return;
+  const observationsByRunIndex = new Map(
+    observations.map((observation) => [observation.runIndex, observation.evidence]),
+  );
+  observedCalls.forEach((call, ordinal) => {
+    const observation = observationsByRunIndex.get(ordinal);
+    if (observation) call.probeEvidence = observation;
+  });
+}
+
+function resolveFinalObservation(
+  finalObservation: ProbeEvidence | undefined,
+  toolCalls: NormalizedToolCall[],
+): ProbeEvidence | undefined {
+  if (finalObservation?.screenshot) return finalObservation;
+  for (let index = toolCalls.length - 1; index >= 0; index -= 1) {
+    const images = toolCalls[index].images;
+    const image = images?.[images.length - 1];
+    if (image) return { screenshot: image.bytes };
+  }
+  return undefined;
+}
+
+function extractAssistantText(event: Record<string, unknown>): string[] {
+  const message = isRecord(event.message) ? event.message : undefined;
+  if (!Array.isArray(message?.content)) return [];
+  return message.content
+    .filter(isRecord)
+    .filter((block) => block.type === "text" && typeof block.text === "string")
+    .map((block) => block.text as string);
+}
+
+function appendText(buffer: string, addition: string): string {
+  if (!addition) return buffer;
+  return buffer ? `${buffer}\n${addition}` : addition;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/packages/evals/framework/harnesses/externalRunner.ts
+++ b/packages/evals/framework/harnesses/externalRunner.ts
@@ -146,6 +146,8 @@ export interface RunExternalHarnessTaskInput<TRaw> {
   verifier?: ExternalHarnessVerifierConfig;
   resultContract: EvalResultContract;
   fallbackErrorMessage: string;
+  /** Harness-specific result parser; defaults to the strict parseEvalResult. */
+  parseResult?: (raw: string) => ParsedEvalResult;
   runSession: (prompt: string) => Promise<ExternalHarnessSessionOutcome<TRaw>>;
   toTrajectory: (input: ExternalHarnessTrajectoryInput<TRaw>, taskSpec: TaskSpec) => Trajectory;
 }
@@ -163,6 +165,7 @@ export async function runExternalHarnessTask<TRaw>({
   verifier,
   resultContract,
   fallbackErrorMessage,
+  parseResult,
   runSession,
   toTrajectory,
 }: RunExternalHarnessTaskInput<TRaw>): Promise<TaskResult> {
@@ -177,7 +180,7 @@ export async function runExternalHarnessTask<TRaw>({
     .filter(Boolean)
     .join("\n\n");
   const trustedResultText = outcome.resultText.trim();
-  const parsed = { ...parseEvalResult(trustedResultText), raw: rawResult };
+  const parsed = { ...(parseResult ?? parseEvalResult)(trustedResultText), raw: rawResult };
   const sanitizedStopReason = outcome.stopReason
     ? sanitizeErrorMessage(outcome.stopReason)
     : undefined;

--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -27,6 +27,7 @@
     "@browserbasehq/stagehand-integrations": "workspace:*",
     "@browserbasehq/stagehand-integrations-claude-agent-sdk": "workspace:*",
     "@browserbasehq/stagehand-integrations-codex-sdk": "workspace:*",
+    "@browserbasehq/stagehand-integrations-cursor-sdk": "workspace:*",
     "@browserbasehq/stagehand-integrations-deepagents-sdk": "workspace:*",
     "@browserbasehq/stagehand-integrations-eve-sdk": "workspace:*",
     "@browserbasehq/stagehand-integrations-fx-sdk": "workspace:*",

--- a/packages/evals/tests/framework/benchHarness.test.ts
+++ b/packages/evals/tests/framework/benchHarness.test.ts
@@ -12,6 +12,7 @@ import {
   listBenchHarnessesForToolSurface,
   mastraHarness,
   piHarness,
+  cursorHarness,
   fxHarness,
   deepagentsHarness,
   eveHarness,
@@ -19,6 +20,7 @@ import {
 } from "../../framework/benchHarness.js";
 import { MASTRA_TOOL_SURFACES } from "../../framework/mastraToolAdapter.js";
 import { PI_TOOL_SURFACES } from "../../framework/piToolAdapter.js";
+import { CURSOR_TOOL_SURFACES } from "../../framework/cursorToolAdapter.js";
 import { defaultModelsEnvKey } from "../../framework/benchPlanner.js";
 import type { BenchMatrixRow } from "../../framework/benchTypes.js";
 import type { DiscoveredTask } from "../../framework/types.js";
@@ -36,6 +38,7 @@ describe("bench harness registry", () => {
       "eve",
       "deepagents",
       "fx",
+      "cursor",
     ]);
   });
 
@@ -43,7 +46,7 @@ describe("bench harness registry", () => {
     expect(parseBenchHarness(undefined)).toBe("stagehand");
     expect(parseBenchHarness("codex")).toBe("codex");
     expect(() => parseBenchHarness("nope")).toThrow(
-      /Unknown harness "nope"\. Supported: stagehand, claude_code, codex, mastra, pi, eve, deepagents, fx\./,
+      /Unknown harness "nope"\. Supported: stagehand, claude_code, codex, mastra, pi, eve, deepagents, fx, cursor\./,
     );
   });
 
@@ -158,6 +161,28 @@ describe("bench harness registry", () => {
     ]);
     expect(harness.defaultModels).toEqual(["openai/gpt-5.4-mini"]);
     expect(isExecutableBenchHarness("fx")).toBe(true);
+  });
+
+  it("registers cursor as a concrete executable harness", () => {
+    const harness = getBenchHarness("cursor");
+
+    expect(harness).toBe(cursorHarness);
+    expect(parseBenchHarness("cursor")).toBe("cursor");
+    expect(isExecutableBenchHarness("cursor")).toBe(true);
+    expect(harness.supportedTaskKinds).toEqual(["agent", "suite"]);
+    expect(harness.supportsApi).toBe(false);
+    expect(harness.execute).toBeDefined();
+    expect(harness.start).toBeUndefined();
+    expect(harness.supportedToolSurfaces).toEqual(CURSOR_TOOL_SURFACES);
+    expect(harness.supportedToolSurfaces).toEqual([
+      "stagehand_facade",
+      "playwright_mcp",
+      "chrome_devtools_mcp",
+    ]);
+    expect(harness.supportedToolSurfaces[0]).toBe("stagehand_facade");
+    expect(harness.supportedToolSurfaces).not.toContain("browse_cli");
+    expect(harness.supportedToolSurfaces).not.toContain("stagehand_code");
+    expect(harness.defaultModels).toEqual(["cursor/auto"]);
   });
 
   it("registers a new harness and rejects duplicate ids", () => {

--- a/packages/evals/tests/framework/cursorAdapter.test.ts
+++ b/packages/evals/tests/framework/cursorAdapter.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import type { TaskSpec } from "stagehand-v3";
+import { cursorAdapter } from "../../framework/harnesses/cursorAdapter.js";
+
+const taskSpec: TaskSpec = { id: "cursor-test", instruction: "do the task" };
+
+describe("cursor trajectory adapter", () => {
+  it("maps assistant reasoning, read calls, and result text", () => {
+    const trajectory = cursorAdapter.fromHarnessResult(
+      {
+        events: [
+          assistant("I will read it."),
+          toolCall("started", "c1", "readToolCall", { path: "file.txt" }),
+          toolCall("completed", "c1", "readToolCall", { path: "file.txt" }, { success: "ok" }),
+          { type: "result", result: "finished" },
+        ],
+      },
+      taskSpec,
+    );
+    expect(trajectory.steps).toHaveLength(1);
+    expect(trajectory.steps[0]).toMatchObject({
+      actionName: "read",
+      reasoning: "I will read it.",
+      toolOutput: { ok: true, result: "ok" },
+    });
+    expect(trajectory.finalAnswer).toBe("finished");
+  });
+
+  it("decodes MCP content images and uses the last image as final observation", () => {
+    const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    const args = {
+      providerIdentifier: "stagehand",
+      name: "screenshot",
+      args: { fullPage: false },
+    };
+    const success = {
+      content: [
+        { type: "text", text: "captured" },
+        {
+          type: "image",
+          source: { type: "base64", media_type: "image/png", data: bytes.toString("base64") },
+        },
+      ],
+    };
+    const trajectory = cursorAdapter.fromHarnessResult(
+      {
+        events: [
+          toolCall("started", "m1", "mcpToolCall", args),
+          toolCall("completed", "m1", "mcpToolCall", args, { success }),
+        ],
+      },
+      taskSpec,
+    );
+    expect(trajectory.steps[0].actionName).toBe("stagehand.screenshot");
+    expect(
+      trajectory.steps[0].agentEvidence.modalities.filter((m) => m.type === "image"),
+    ).toHaveLength(1);
+    expect(trajectory.finalObservation?.screenshot?.equals(bytes)).toBe(true);
+  });
+
+  it("maps completed error envelopes", () => {
+    const trajectory = cursorAdapter.fromHarnessResult(
+      {
+        events: [toolCall("completed", "c1", "writeToolCall", { path: "x" }, { error: "denied" })],
+      },
+      taskSpec,
+    );
+    expect(trajectory.steps[0].toolOutput).toMatchObject({ ok: false, error: "denied" });
+  });
+
+  it("attaches observations only when observed-call ordinals match", () => {
+    const events = [
+      toolCall("completed", "r1", "readToolCall", { path: "x" }, { success: "ok" }),
+      toolCall(
+        "completed",
+        "m1",
+        "mcpToolCall",
+        { server: "stagehand", tool: "run", args: {} },
+        { success: "one" },
+      ),
+      toolCall(
+        "completed",
+        "m2",
+        "mcpToolCall",
+        { server: "stagehand", tool: "snapshot", args: {} },
+        { success: "two" },
+      ),
+    ];
+    const matched = cursorAdapter.fromHarnessResult(
+      {
+        events,
+        observedToolName: (name) => name.startsWith("stagehand."),
+        stepObservations: [
+          { runIndex: 0, evidence: { url: "https://example.com/a" } },
+          { runIndex: 1, evidence: { url: "https://example.com/b" } },
+        ],
+      },
+      taskSpec,
+    );
+    expect(matched.steps.map((step) => step.probeEvidence.url)).toEqual([
+      undefined,
+      "https://example.com/a",
+      "https://example.com/b",
+    ]);
+
+    const mismatched = cursorAdapter.fromHarnessResult(
+      {
+        events,
+        observedToolName: (name) => name.startsWith("stagehand."),
+        stepObservations: [
+          { runIndex: 0, evidence: { url: "https://example.com/a" } },
+          { runIndex: 2, evidence: { url: "https://example.com/c" } },
+        ],
+      },
+      taskSpec,
+    );
+    expect(mismatched.steps.every((step) => step.probeEvidence.url === undefined)).toBe(true);
+  });
+
+  it("passes status through", () => {
+    const trajectory = cursorAdapter.fromHarnessResult({ events: [], status: "error" }, taskSpec);
+    expect(trajectory.status).toBe("error");
+  });
+});
+
+function assistant(text: string): Record<string, unknown> {
+  return { type: "assistant", message: { content: [{ type: "text", text }] } };
+}
+
+function toolCall(
+  subtype: "started" | "completed",
+  callId: string,
+  kind: string,
+  args: Record<string, unknown>,
+  result?: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    type: "tool_call",
+    subtype,
+    call_id: callId,
+    tool_call: { [kind]: { args, ...(result && { result }) } },
+  };
+}

--- a/packages/evals/tests/framework/cursorAdapter.test.ts
+++ b/packages/evals/tests/framework/cursorAdapter.test.ts
@@ -27,7 +27,8 @@ describe("cursor trajectory adapter", () => {
   });
 
   it("decodes MCP content images and uses the last image as final observation", () => {
-    const bytes = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    const firstBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+    const lastBytes = Buffer.from([0xff, 0xd8, 0xff, 0xe0]);
     const args = {
       providerIdentifier: "stagehand",
       name: "screenshot",
@@ -38,7 +39,19 @@ describe("cursor trajectory adapter", () => {
         { type: "text", text: "captured" },
         {
           type: "image",
-          source: { type: "base64", media_type: "image/png", data: bytes.toString("base64") },
+          source: {
+            type: "base64",
+            media_type: "image/png",
+            data: firstBytes.toString("base64"),
+          },
+        },
+        {
+          type: "image",
+          source: {
+            type: "base64",
+            media_type: "image/jpeg",
+            data: lastBytes.toString("base64"),
+          },
         },
       ],
     };
@@ -54,8 +67,8 @@ describe("cursor trajectory adapter", () => {
     expect(trajectory.steps[0].actionName).toBe("stagehand.screenshot");
     expect(
       trajectory.steps[0].agentEvidence.modalities.filter((m) => m.type === "image"),
-    ).toHaveLength(1);
-    expect(trajectory.finalObservation?.screenshot?.equals(bytes)).toBe(true);
+    ).toHaveLength(2);
+    expect(trajectory.finalObservation?.screenshot?.equals(lastBytes)).toBe(true);
   });
 
   it("maps completed error envelopes", () => {

--- a/packages/evals/tests/framework/cursorRunner.test.ts
+++ b/packages/evals/tests/framework/cursorRunner.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import type { AvailableModel } from "stagehand-v3";
+import type { CursorProcessRunner } from "@browserbasehq/stagehand-integrations-cursor-sdk";
+import {
+  buildCursorPrompt,
+  parseCursorResult,
+  runCursorAgent,
+} from "../../framework/cursorRunner.js";
+import type { ExternalHarnessTaskPlan } from "../../framework/externalHarnessPlan.js";
+import { EvalLogger } from "../../logger.js";
+
+const plan: ExternalHarnessTaskPlan = {
+  dataset: "webvoyager",
+  taskId: "wv-1",
+  startUrl: "https://example.com",
+  instruction: "Report the heading",
+};
+
+describe("cursor runner", () => {
+  it("builds an MCP-only browser prompt", () => {
+    const prompt = buildCursorPrompt(plan, "Use stagehand.run.");
+    expect(prompt).toContain("Dataset: webvoyager");
+    expect(prompt).toContain("Task ID: wv-1");
+    expect(prompt).toContain("Start URL: https://example.com");
+    expect(prompt).toContain("Report the heading");
+    expect(prompt).toContain("Use stagehand.run.");
+    expect(prompt).toContain("Your only browser access is the MCP server");
+    expect(prompt).toContain('"success": boolean');
+  });
+
+  it("parses direct, marked, and fenced JSON results", () => {
+    expect(parseCursorResult('{"success":true,"summary":"done","finalAnswer":"ok"}')).toMatchObject(
+      { success: true, summary: "done", finalAnswer: "ok" },
+    );
+    expect(
+      parseCursorResult('text\nEVAL_RESULT: {"success":true,"summary":"marked"}'),
+    ).toMatchObject({ success: true, summary: "marked" });
+    expect(parseCursorResult('```json\n{"success":true,"summary":"fenced"}\n```')).toMatchObject({
+      success: true,
+      summary: "fenced",
+    });
+  });
+
+  it("runs the CLI stream and reports Cursor metrics", async () => {
+    const result = await runCursorAgent({
+      plan,
+      model: "cursor/auto" as AvailableModel,
+      logger: new EvalLogger(false),
+      runProcess: scriptedRunner([
+        {
+          type: "tool_call",
+          subtype: "completed",
+          call_id: "1",
+          tool_call: { readToolCall: { args: {}, result: { success: "one" } } },
+        },
+        {
+          type: "tool_call",
+          subtype: "completed",
+          call_id: "2",
+          tool_call: { readToolCall: { args: {}, result: { success: "two" } } },
+        },
+        {
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          duration_ms: 1234,
+          result: '{"success":true,"summary":"done","finalAnswer":"ok"}',
+        },
+      ]),
+    });
+    const metrics = result.metrics as Record<string, { value: number; count: number }>;
+    expect(result._success).toBe(true);
+    expect(result.cursorStatus).toBe("completed");
+    expect(result.finalAnswer).toBe("ok");
+    expect(metrics.cursor_tool_steps.value).toBe(2);
+    expect(metrics.cursor_duration_ms.value).toBe(1234);
+    expect(metrics.cursor_input_tokens).toEqual({ count: 1, value: 0 });
+    expect(metrics.cursor_output_tokens).toEqual({ count: 1, value: 0 });
+    expect(metrics.cursor_total_tokens).toEqual({ count: 1, value: 0 });
+  });
+
+  it("returns a failed task result for a non-zero exit without a result", async () => {
+    const result = await runCursorAgent({
+      plan,
+      model: "cursor/auto" as AvailableModel,
+      logger: new EvalLogger(false),
+      runProcess: scriptedRunner([], 1),
+    });
+    expect(result._success).toBe(false);
+    expect(result.cursorStatus).toBe("sdk_error");
+    expect(String(result.error)).toContain("exited with code 1");
+  });
+});
+
+function scriptedRunner(events: Array<Record<string, unknown>>, exitCode = 0): CursorProcessRunner {
+  return async (input) => {
+    for (const event of events) await input.onStdoutLine(JSON.stringify(event));
+    return { exitCode, signal: null };
+  };
+}

--- a/packages/evals/tests/framework/cursorRunner.test.ts
+++ b/packages/evals/tests/framework/cursorRunner.test.ts
@@ -25,6 +25,8 @@ describe("cursor runner", () => {
     expect(prompt).toContain("Report the heading");
     expect(prompt).toContain("Use stagehand.run.");
     expect(prompt).toContain("Your only browser access is the MCP server");
+    expect(prompt).toContain("Do not edit repository files.");
+    expect(prompt).toContain("EVAL_RESULT:");
     expect(prompt).toContain('"success": boolean');
   });
 
@@ -70,6 +72,7 @@ describe("cursor runner", () => {
     });
     const metrics = result.metrics as Record<string, { value: number; count: number }>;
     expect(result._success).toBe(true);
+    expect(result.harnessStatus).toBe("completed");
     expect(result.cursorStatus).toBe("completed");
     expect(result.finalAnswer).toBe("ok");
     expect(metrics.cursor_tool_steps.value).toBe(2);
@@ -77,6 +80,10 @@ describe("cursor runner", () => {
     expect(metrics.cursor_input_tokens).toEqual({ count: 1, value: 0 });
     expect(metrics.cursor_output_tokens).toEqual({ count: 1, value: 0 });
     expect(metrics.cursor_total_tokens).toEqual({ count: 1, value: 0 });
+    expect(metrics.harness_input_tokens).toEqual({ count: 1, value: 0 });
+    expect(metrics.harness_output_tokens).toEqual({ count: 1, value: 0 });
+    expect(metrics.harness_total_tokens).toEqual({ count: 1, value: 0 });
+    expect(metrics.harness_cost_usd).toBeUndefined();
   });
 
   it("returns a failed task result for a non-zero exit without a result", async () => {
@@ -87,6 +94,7 @@ describe("cursor runner", () => {
       runProcess: scriptedRunner([], 1),
     });
     expect(result._success).toBe(false);
+    expect(result.harnessStatus).toBe("sdk_error");
     expect(result.cursorStatus).toBe("sdk_error");
     expect(String(result.error)).toContain("exited with code 1");
   });

--- a/packages/evals/tests/framework/cursorToolAdapter.test.ts
+++ b/packages/evals/tests/framework/cursorToolAdapter.test.ts
@@ -4,11 +4,11 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   buildCursorMcpConfig,
+  CURSOR_TOOL_SURFACES,
   isCursorMountToolName,
-  resolveCursorStartupProfile,
-  resolveCursorToolSurface,
   writeCursorWorkspace,
 } from "../../framework/cursorToolAdapter.js";
+import { resolveToolSurface } from "../../framework/harnesses/toolSurfaceResolution.js";
 
 const tempDirs: string[] = [];
 
@@ -17,25 +17,22 @@ afterEach(async () => {
 });
 
 describe("cursor tool adapter helpers", () => {
-  it("resolves supported surfaces and startup profiles", () => {
-    expect(resolveCursorToolSurface()).toBe("stagehand_facade");
-    expect(resolveCursorToolSurface("playwright_mcp")).toBe("playwright_mcp");
-    expect(resolveCursorToolSurface("chrome_devtools_mcp")).toBe("chrome_devtools_mcp");
-    expect(() => resolveCursorToolSurface("browse_cli")).toThrow(
+  it("declares supported surfaces and resolves them through the shared helper", () => {
+    const harness = { harness: "cursor", supportedToolSurfaces: CURSOR_TOOL_SURFACES };
+    expect(CURSOR_TOOL_SURFACES).toEqual([
+      "stagehand_facade",
+      "playwright_mcp",
+      "chrome_devtools_mcp",
+    ]);
+    expect(resolveToolSurface(harness, undefined)).toBe("stagehand_facade");
+    expect(resolveToolSurface(harness, "stagehand_facade")).toBe("stagehand_facade");
+    expect(resolveToolSurface(harness, "playwright_mcp")).toBe("playwright_mcp");
+    expect(resolveToolSurface(harness, "chrome_devtools_mcp")).toBe("chrome_devtools_mcp");
+    expect(() => resolveToolSurface(harness, "browse_cli")).toThrow(
       /stagehand_facade, playwright_mcp, or chrome_devtools_mcp.*browse_cli/,
     );
-    expect(() => resolveCursorToolSurface("stagehand_code")).toThrow(
+    expect(() => resolveToolSurface(harness, "stagehand_code")).toThrow(
       /stagehand_facade, playwright_mcp, or chrome_devtools_mcp.*stagehand_code/,
-    );
-    expect(resolveCursorStartupProfile("stagehand_facade", "LOCAL")).toBe("tool_launch_local");
-    expect(resolveCursorStartupProfile("stagehand_facade", "BROWSERBASE")).toBe(
-      "tool_create_browserbase",
-    );
-    expect(resolveCursorStartupProfile("playwright_mcp", "LOCAL")).toBe(
-      "runner_provided_local_cdp",
-    );
-    expect(resolveCursorStartupProfile("chrome_devtools_mcp", "BROWSERBASE")).toBe(
-      "runner_provided_browserbase_cdp",
     );
   });
 

--- a/packages/evals/tests/framework/cursorToolAdapter.test.ts
+++ b/packages/evals/tests/framework/cursorToolAdapter.test.ts
@@ -1,0 +1,74 @@
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildCursorMcpConfig,
+  isCursorMountToolName,
+  resolveCursorStartupProfile,
+  resolveCursorToolSurface,
+  writeCursorWorkspace,
+} from "../../framework/cursorToolAdapter.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fsp.rm(dir, { recursive: true, force: true })));
+});
+
+describe("cursor tool adapter helpers", () => {
+  it("resolves supported surfaces and startup profiles", () => {
+    expect(resolveCursorToolSurface()).toBe("stagehand_facade");
+    expect(resolveCursorToolSurface("playwright_mcp")).toBe("playwright_mcp");
+    expect(resolveCursorToolSurface("chrome_devtools_mcp")).toBe("chrome_devtools_mcp");
+    expect(() => resolveCursorToolSurface("browse_cli")).toThrow(
+      /stagehand_facade, playwright_mcp, or chrome_devtools_mcp.*browse_cli/,
+    );
+    expect(() => resolveCursorToolSurface("stagehand_code")).toThrow(
+      /stagehand_facade, playwright_mcp, or chrome_devtools_mcp.*stagehand_code/,
+    );
+    expect(resolveCursorStartupProfile("stagehand_facade", "LOCAL")).toBe("tool_launch_local");
+    expect(resolveCursorStartupProfile("stagehand_facade", "BROWSERBASE")).toBe(
+      "tool_create_browserbase",
+    );
+    expect(resolveCursorStartupProfile("playwright_mcp", "LOCAL")).toBe(
+      "runner_provided_local_cdp",
+    );
+    expect(resolveCursorStartupProfile("chrome_devtools_mcp", "BROWSERBASE")).toBe(
+      "runner_provided_browserbase_cdp",
+    );
+  });
+
+  it("wraps MCP config without changing the server map", () => {
+    const servers = { stagehand: { command: "node", args: ["server.mjs"] } };
+    expect(buildCursorMcpConfig(servers)).toEqual({ mcpServers: servers });
+    expect(buildCursorMcpConfig(servers).mcpServers).toBe(servers);
+  });
+
+  it("writes project MCP configuration", async () => {
+    const cwd = await fsp.mkdtemp(path.join(os.tmpdir(), "cursor-workspace-test-"));
+    tempDirs.push(cwd);
+    const servers = { stagehand: { command: "node", args: ["server.mjs"] } };
+    const result = await writeCursorWorkspace(cwd, servers);
+    expect(result.mcpConfigPath).toBe(path.join(cwd, ".cursor", "mcp.json"));
+    expect(JSON.parse(await fsp.readFile(result.mcpConfigPath, "utf8"))).toEqual({
+      mcpServers: servers,
+    });
+  });
+
+  it("matches tolerant Cursor MCP tool names", () => {
+    const matches = (name: string) => isCursorMountToolName(["stagehand"], name);
+    for (const name of [
+      "stagehand.run",
+      "stagehand__run",
+      "mcp__stagehand__run",
+      "stagehand",
+      "stagehand:run",
+    ]) {
+      expect(matches(name)).toBe(true);
+    }
+    for (const name of ["shell", "read", "playwright.click"]) {
+      expect(matches(name)).toBe(false);
+    }
+  });
+});

--- a/packages/evals/tests/framework/cursorToolAdapter.test.ts
+++ b/packages/evals/tests/framework/cursorToolAdapter.test.ts
@@ -64,7 +64,7 @@ describe("cursor tool adapter helpers", () => {
     ]) {
       expect(matches(name)).toBe(true);
     }
-    for (const name of ["shell", "read", "playwright.click"]) {
+    for (const name of ["shell", "read", "playwright.click", "mcp__stagehand_extra__run"]) {
       expect(matches(name)).toBe(false);
     }
   });

--- a/packages/evals/tests/framework/externalRunner.test.ts
+++ b/packages/evals/tests/framework/externalRunner.test.ts
@@ -216,6 +216,41 @@ describe("external harness runner", () => {
     expect(result.reasoning).toBeUndefined();
   });
 
+  it("uses a harness-specific result parser while retaining the default parser", async () => {
+    const run = (parseResult?: (raw: string) => ReturnType<typeof parseEvalResult>) =>
+      runExternalHarnessTask({
+        harness: "custom",
+        plan,
+        logger: new EvalLogger(false),
+        resultContract: "marker",
+        fallbackErrorMessage: "missing result",
+        ...(parseResult && { parseResult }),
+        runSession: async () => ({
+          raw: { events: [] },
+          resultText: "custom wire result",
+          transcriptText: "",
+          status: "completed" as const,
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          metrics: {},
+        }),
+        toTrajectory: () => {
+          throw new Error("not called without a verifier");
+        },
+      });
+    const customParser = vi.fn(() => ({
+      success: true,
+      summary: "custom parser used",
+      raw: "custom wire result",
+    }));
+
+    const custom = await run(customParser);
+    const defaults = await run();
+
+    expect(customParser).toHaveBeenCalledWith("custom wire result");
+    expect(custom).toMatchObject({ _success: true, reasoning: "custom parser used" });
+    expect(defaults).toMatchObject({ _success: false, reasoning: undefined });
+  });
+
   it("forces SDK errors to fail while preserving the parsed report", async () => {
     const result = await runExternalHarnessTask({
       harness: "codex",

--- a/packages/integrations/README.md
+++ b/packages/integrations/README.md
@@ -13,6 +13,7 @@ else, never restated.
 | `core/`        | The `@browserbasehq/stagehand-integrations` package: the facade contract, `StagehandFacadeTools`, the `stagehand-facade` stdio MCP bin, and the code-mode MCP host scaffold. |
 | `claude-code/` | Claude Agent SDK example (programmatic MCP mount) plus a `.mcp.json` for connecting a running Claude Code CLI.                                                               |
 | `codex/`       | Codex SDK example (config-override MCP mount) plus a `config.toml` template for the codex CLI.                                                                               |
+| `cursor/`      | Cursor agent CLI configuration template (`.cursor/mcp.json`) and AGENTS.md guidance — the CLI consumes the facade as a project MCP server.                                   |
 | `crewai/`      | Python CrewAI example over MCP/stdio (uv project).                                                                                                                           |
 | `deepagents/`  | Python LangChain Deep Agents integrations: a local stdio MCP server and a Managed Deep Agents project with native tools.                                                     |
 | `eve/`         | Eve example with the tools bound natively via `defineTool` (Eve has no external-process tool mounting).                                                                      |

--- a/packages/integrations/cursor-sdk/package.json
+++ b/packages/integrations/cursor-sdk/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@browserbasehq/stagehand-integrations-cursor-sdk",
+  "version": "4.0.1",
+  "private": true,
+  "description": "Cursor agent CLI harness adapter for Stagehand integrations",
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs"
+    }
+  },
+  "scripts": {
+    "build": "tsdown",
+    "test": "pnpm run build && vitest run --root ../../.. packages/integrations/cursor-sdk/tests",
+    "test:unit": "vitest run --root ../../.. packages/integrations/cursor-sdk/tests",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "@browserbasehq/stagehand-integrations": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=22.18.0"
+  }
+}

--- a/packages/integrations/cursor-sdk/src/index.ts
+++ b/packages/integrations/cursor-sdk/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./session.js";

--- a/packages/integrations/cursor-sdk/src/session.ts
+++ b/packages/integrations/cursor-sdk/src/session.ts
@@ -1,0 +1,490 @@
+import { spawn } from "node:child_process";
+import {
+  HarnessAdapterError,
+  sanitizeErrorMessage,
+  type HarnessLogger,
+} from "@browserbasehq/stagehand-integrations/harness";
+
+export type CursorEvent = Record<string, unknown>;
+
+export type CursorProcessExit = {
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+};
+
+export type CursorProcessRunner = (input: {
+  command: string;
+  args: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+  signal: AbortSignal;
+  onStdoutLine: (line: string) => void | Promise<void>;
+  onStderr: (chunk: string) => void;
+}) => Promise<CursorProcessExit>;
+
+export type CursorSessionConfig = {
+  cwd?: string;
+  env?: Record<string, string>;
+  binaryPath?: string;
+  apiKey?: string;
+  force?: boolean;
+  trust?: boolean;
+  approveMcps?: boolean;
+  sandbox?: "enabled" | "disabled";
+  extraArgs?: string[];
+};
+
+export type CursorTokenUsage = {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  reported: false;
+};
+
+export type CursorSessionResult = {
+  events: CursorEvent[];
+  resultEvent?: CursorEvent;
+  resultText: string;
+  status: "completed" | "max_turns" | "sdk_error";
+  stopReason?: string;
+  tokenUsage: CursorTokenUsage;
+  exit?: CursorProcessExit;
+  stderr: string;
+  iterationError?: unknown;
+};
+
+export type CursorToolCallView = {
+  callId: string;
+  subtype: "started" | "completed" | string;
+  kind: string;
+  name: string;
+  args: Record<string, unknown>;
+  result?: unknown;
+  ok: boolean;
+  error?: string;
+};
+
+export const CURSOR_AGENT_BINARY = "agent";
+const STDERR_LIMIT = 64 * 1024;
+
+export function resolveCursorAgentBinary(override?: string): string {
+  return override ?? process.env.CURSOR_AGENT_PATH ?? CURSOR_AGENT_BINARY;
+}
+
+export function normalizeCursorModel(model: string): string | undefined {
+  if (model === "cursor/auto" || model === "auto") return undefined;
+  return model.includes("/") ? model.slice(model.indexOf("/") + 1) : model;
+}
+
+export function buildCursorAgentArgs(input: {
+  prompt: string;
+  model?: string;
+  session: CursorSessionConfig;
+}): string[] {
+  const { session } = input;
+  return [
+    "-p",
+    "--output-format",
+    "stream-json",
+    ...(session.force !== false ? ["--force"] : []),
+    ...(session.trust !== false ? ["--trust"] : []),
+    ...(session.approveMcps !== false ? ["--approve-mcps"] : []),
+    ...(session.sandbox ? ["--sandbox", session.sandbox] : []),
+    ...(session.cwd ? ["--workspace", session.cwd] : []),
+    ...(input.model ? ["--model", input.model] : []),
+    ...(session.apiKey ? ["--api-key", session.apiKey] : []),
+    ...(session.extraArgs ?? []),
+    input.prompt,
+  ];
+}
+
+export function parseCursorStreamLine(line: string): CursorEvent | undefined {
+  const trimmed = line.trim();
+  if (!trimmed) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    return isRecord(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function extractCursorToolCall(event: CursorEvent): CursorToolCallView | undefined {
+  if (event.type !== "tool_call" || !isRecord(event.tool_call)) return undefined;
+  const entry = Object.entries(event.tool_call)[0];
+  if (!entry || !isRecord(entry[1])) return undefined;
+  const [rawKind, call] = entry;
+  const kind = rawKind === "function" ? "function" : rawKind.replace(/ToolCall$/, "");
+  const rawArgs = isRecord(call.args) ? call.args : {};
+  let name = kind;
+  let args = rawArgs;
+
+  if (kind === "function") {
+    name = typeof call.name === "string" ? call.name : "function";
+    const value = call.arguments;
+    if (typeof value === "string") {
+      try {
+        const parsed: unknown = JSON.parse(value);
+        args = isRecord(parsed) ? parsed : {};
+      } catch {
+        args = {};
+      }
+    } else {
+      args = isRecord(value) ? value : {};
+    }
+  } else if (kind === "mcp") {
+    // Cursor has not documented its MCP stream-json payload. Accept the
+    // observed candidate fields without requiring any one unverified shape.
+    const server = readString(rawArgs, ["providerIdentifier", "server", "provider"]) ?? "mcp";
+    const tool = readString(rawArgs, ["name", "toolName", "tool"]) ?? "tool";
+    name = `${server}.${tool}`;
+    args = isRecord(rawArgs.args)
+      ? rawArgs.args
+      : isRecord(rawArgs.arguments)
+        ? rawArgs.arguments
+        : rawArgs;
+  }
+
+  const resultEnvelope = isRecord(call.result) ? call.result : undefined;
+  let result: unknown;
+  let ok = true;
+  let error: string | undefined;
+  if (resultEnvelope && "success" in resultEnvelope) {
+    result = resultEnvelope.success;
+  } else if (resultEnvelope) {
+    for (const key of ["error", "rejected", "failure"] as const) {
+      if (key in resultEnvelope) {
+        ok = false;
+        error = stringifyError(resultEnvelope[key]);
+        break;
+      }
+    }
+  }
+
+  return {
+    callId: typeof event.call_id === "string" ? event.call_id : "",
+    subtype: typeof event.subtype === "string" ? event.subtype : "",
+    kind,
+    name,
+    args,
+    ...(result !== undefined && { result }),
+    ok,
+    ...(error && { error }),
+  };
+}
+
+export const defaultCursorProcessRunner: CursorProcessRunner = async (input) => {
+  return new Promise<CursorProcessExit>((resolve, reject) => {
+    const child = spawn(input.command, input.args, {
+      ...(input.cwd && { cwd: input.cwd }),
+      ...(input.env && { env: input.env }),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdoutBuffer = "";
+    let lineQueue = Promise.resolve();
+    let killTimer: NodeJS.Timeout | undefined;
+    let settled = false;
+
+    const queueLine = (line: string): void => {
+      lineQueue = lineQueue.then(() => input.onStdoutLine(line));
+    };
+    const removeAbort = (): void => input.signal.removeEventListener("abort", abort);
+    const abort = (): void => {
+      if (child.exitCode !== null || child.signalCode !== null) return;
+      child.kill("SIGTERM");
+      killTimer = setTimeout(() => {
+        if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+      }, 5_000);
+      killTimer.unref();
+    };
+
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdoutBuffer += chunk;
+      const lines = stdoutBuffer.split(/\r?\n/);
+      stdoutBuffer = lines.pop() ?? "";
+      for (const line of lines) queueLine(line);
+    });
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => input.onStderr(chunk));
+    child.on("error", (error: NodeJS.ErrnoException) => {
+      if (settled) return;
+      settled = true;
+      removeAbort();
+      if (killTimer) clearTimeout(killTimer);
+      if (error.code === "ENOENT") {
+        reject(
+          new HarnessAdapterError(
+            sanitizeErrorMessage(
+              "Cursor agent CLI harness requires the `agent` binary (install: curl https://cursor.com/install -fsS | bash, or set CURSOR_AGENT_PATH)",
+            ),
+            { cause: error },
+          ),
+        );
+        return;
+      }
+      reject(error);
+    });
+    child.on("close", (exitCode, signal) => {
+      if (settled) return;
+      settled = true;
+      removeAbort();
+      if (killTimer) clearTimeout(killTimer);
+      if (stdoutBuffer) queueLine(stdoutBuffer);
+      lineQueue.then(
+        () => resolve({ exitCode, signal }),
+        (error) => reject(error),
+      );
+    });
+
+    if (input.signal.aborted) abort();
+    else input.signal.addEventListener("abort", abort, { once: true });
+  });
+};
+
+export async function runCursorAgentSession(input: {
+  prompt: string;
+  model: string;
+  signal?: AbortSignal;
+  logger: HarnessLogger;
+  session: CursorSessionConfig;
+  runProcess?: CursorProcessRunner;
+  maxToolSteps?: number;
+  onToolResult?: (toolName: string, view: CursorToolCallView) => void | Promise<void>;
+}): Promise<CursorSessionResult> {
+  const events: CursorEvent[] = [];
+  const budgetController = new AbortController();
+  const forwardAbort = (): void => budgetController.abort(input.signal?.reason);
+  if (input.signal) {
+    if (input.signal.aborted) budgetController.abort(input.signal.reason);
+    else input.signal.addEventListener("abort", forwardAbort, { once: true });
+  }
+
+  let resultEvent: CursorEvent | undefined;
+  let resultText = "";
+  let lastAssistantText = "";
+  let stderr = "";
+  let exit: CursorProcessExit | undefined;
+  let iterationError: unknown;
+  let budgetStopReason: string | undefined;
+  const maxToolSteps = positiveInteger(input.maxToolSteps, 50);
+  let toolStepCount = 0;
+
+  try {
+    const model = normalizeCursorModel(input.model);
+    exit = await (input.runProcess ?? defaultCursorProcessRunner)({
+      command: resolveCursorAgentBinary(input.session.binaryPath),
+      args: buildCursorAgentArgs({ prompt: input.prompt, model, session: input.session }),
+      ...(input.session.cwd && { cwd: input.session.cwd }),
+      env: stringEnv({ ...process.env, ...input.session.env }),
+      signal: budgetController.signal,
+      onStdoutLine: async (line) => {
+        const event = parseCursorStreamLine(line);
+        if (!event) return;
+        events.push(event);
+        logCursorEvent(input.logger, event);
+        if (event.type === "assistant") {
+          lastAssistantText = extractAssistantTextBlocks(event).at(-1) ?? lastAssistantText;
+        }
+        if (event.type === "result") {
+          resultEvent = event;
+          resultText = typeof event.result === "string" ? event.result : "";
+        }
+        const view = extractCursorToolCall(event);
+        if (view?.subtype === "completed") {
+          toolStepCount += 1;
+          await input.onToolResult?.(view.name, view);
+          if (toolStepCount >= maxToolSteps && !budgetController.signal.aborted) {
+            budgetStopReason = `tool step budget exhausted (${maxToolSteps} steps)`;
+            budgetController.abort(new Error(budgetStopReason));
+          }
+        }
+      },
+      onStderr: (chunk) => {
+        input.logger.log({ category: "cursor", message: chunk, level: 1 });
+        stderr = `${stderr}${chunk}`.slice(-STDERR_LIMIT);
+      },
+    });
+  } catch (error) {
+    iterationError = error;
+    input.logger.warn({
+      category: "cursor",
+      message: `Cursor stopped before a normal result: ${sanitizeErrorMessage(stringifyError(error))}`,
+      level: 0,
+      auxiliary: {
+        error: { value: sanitizeErrorMessage(stringifyError(error)), type: "string" },
+      },
+    });
+  } finally {
+    input.signal?.removeEventListener("abort", forwardAbort);
+  }
+
+  if (!resultText) resultText = lastAssistantText;
+  const externalAbortReason = input.signal?.aborted
+    ? stringifyError(input.signal.reason) || "Cursor agent session aborted"
+    : undefined;
+  const stopReason = buildCursorStopReason(
+    resultEvent,
+    iterationError,
+    exit,
+    stderr,
+    budgetStopReason,
+    externalAbortReason,
+  );
+  return {
+    events,
+    ...(resultEvent && { resultEvent }),
+    resultText,
+    status: resolveCursorStatus(resultEvent, iterationError, stopReason, Boolean(budgetStopReason)),
+    ...(stopReason && { stopReason: sanitizeErrorMessage(stopReason) }),
+    // Cursor's CLI does not report token usage in any output format.
+    tokenUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0, reported: false },
+    ...(exit && { exit }),
+    stderr,
+    ...(iterationError !== undefined && { iterationError }),
+  };
+}
+
+export function resolveCursorStatus(
+  resultEvent: CursorEvent | undefined,
+  iterationError: unknown,
+  stopReason?: string,
+  budgetExhausted = false,
+): "completed" | "max_turns" | "sdk_error" {
+  if (budgetExhausted) return "max_turns";
+  if (iterationError || stopReason || resultEvent?.is_error === true) return "sdk_error";
+  return "completed";
+}
+
+export function buildCursorStopReason(
+  resultEvent: CursorEvent | undefined,
+  iterationError: unknown,
+  exit: CursorProcessExit | undefined,
+  stderr: string,
+  budgetStopReason?: string,
+  externalAbortReason?: string,
+): string | undefined {
+  if (budgetStopReason) return sanitizeErrorMessage(budgetStopReason);
+  if (externalAbortReason) return sanitizeErrorMessage(externalAbortReason);
+  if (iterationError) return sanitizeErrorMessage(stringifyError(iterationError));
+  if (resultEvent?.is_error === true) {
+    return sanitizeErrorMessage(
+      typeof resultEvent.result === "string" && resultEvent.result.trim()
+        ? resultEvent.result.trim()
+        : "Cursor agent returned an error result",
+    );
+  }
+  if (!resultEvent && exit?.exitCode !== 0) {
+    const lastLine = stderr
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .at(-1);
+    return sanitizeErrorMessage(
+      `cursor agent exited with code ${String(exit?.exitCode ?? "unknown")}${lastLine ? `: ${lastLine}` : ""}`,
+    );
+  }
+  return undefined;
+}
+
+export function buildCursorTranscript(events: CursorEvent[]): string {
+  return events
+    .map((event) => summarizeCursorEvent(event).detail)
+    .filter((detail): detail is string => Boolean(detail))
+    .join("\n");
+}
+
+export function logCursorEvent(logger: HarnessLogger, event: CursorEvent): void {
+  const summary = summarizeCursorEvent(event);
+  logger.log({
+    category: "cursor",
+    message: summary.message,
+    level: 1,
+    auxiliary: {
+      type: { value: String(event.type ?? "unknown"), type: "string" },
+      ...(summary.detail && { detail: { value: summary.detail, type: "string" } }),
+    },
+  });
+}
+
+export function summarizeCursorEvent(event: CursorEvent): { message: string; detail?: string } {
+  const type = String(event.type ?? "unknown");
+  if (type === "assistant") {
+    const text = extractAssistantText(event);
+    return { message: text ? `assistant: ${clip(text, 500)}` : "assistant message", detail: text };
+  }
+  if (type === "tool_call") {
+    const view = extractCursorToolCall(event);
+    return {
+      message: view
+        ? `tool: ${view.name} ${view.subtype}${view.ok ? "" : " failed"}`
+        : "tool_call event",
+      detail: safeJson(event),
+    };
+  }
+  if (type === "result") {
+    return {
+      message: `result: ${String(event.subtype ?? "done")}`,
+      detail: typeof event.result === "string" ? event.result : safeJson(event),
+    };
+  }
+  return { message: `${type} event`, detail: safeJson(event) };
+}
+
+function extractAssistantText(event: CursorEvent): string | undefined {
+  const parts = extractAssistantTextBlocks(event);
+  return parts.length > 0 ? parts.join("\n") : undefined;
+}
+
+function extractAssistantTextBlocks(event: CursorEvent): string[] {
+  const message = isRecord(event.message) ? event.message : undefined;
+  if (!Array.isArray(message?.content)) return [];
+  return message.content
+    .filter(isRecord)
+    .filter((block) => block.type === "text" && typeof block.text === "string")
+    .map((block) => block.text as string);
+}
+
+function readString(record: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    if (typeof record[key] === "string") return record[key];
+  }
+  return undefined;
+}
+
+function stringEnv(
+  env: NodeJS.ProcessEnv | Record<string, string | undefined>,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(env).filter((entry): entry is [string, string] => typeof entry[1] === "string"),
+  );
+}
+
+function positiveInteger(value: unknown, fallback: number): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.max(1, Math.floor(value))
+    : fallback;
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export function safeJson(value: unknown): string | undefined {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return undefined;
+  }
+}
+
+export function stringifyError(value: unknown): string {
+  if (!value) return "";
+  if (value instanceof Error) return value.message;
+  if (typeof value === "string") return value;
+  return safeJson(value) ?? String(value);
+}
+
+export function clip(value: string, maxLength: number): string {
+  return value.length <= maxLength ? value : `${value.slice(0, maxLength - 1)}…`;
+}

--- a/packages/integrations/cursor-sdk/src/session.ts
+++ b/packages/integrations/cursor-sdk/src/session.ts
@@ -279,8 +279,9 @@ export async function runCursorAgentSession(input: {
       env: stringEnv({ ...process.env, ...input.session.env }),
       signal: budgetController.signal,
       onStdoutLine: async (line) => {
-        const event = parseCursorStreamLine(line);
-        if (!event) return;
+        const parsedEvent = parseCursorStreamLine(line);
+        if (!parsedEvent) return;
+        const event = deepSanitizeCursorEvent(parsedEvent);
         events.push(event);
         logCursorEvent(input.logger, event);
         if (event.type === "assistant") {
@@ -296,17 +297,18 @@ export async function runCursorAgentSession(input: {
           await input.onToolResult?.(view.name, view);
           if (toolStepCount >= maxToolSteps && !budgetController.signal.aborted) {
             budgetStopReason = `tool step budget exhausted (${maxToolSteps} steps)`;
-            budgetController.abort(new Error(budgetStopReason));
+            budgetController.abort(new HarnessAdapterError(budgetStopReason));
           }
         }
       },
       onStderr: (chunk) => {
-        input.logger.log({ category: "cursor", message: chunk, level: 1 });
         stderr = `${stderr}${chunk}`.slice(-STDERR_LIMIT);
       },
     });
   } catch (error) {
-    iterationError = error;
+    iterationError = new HarnessAdapterError(
+      sanitizeErrorMessage(stringifyError(error)) || "Cursor agent session failed.",
+    );
     input.logger.warn({
       category: "cursor",
       message: `Cursor stopped before a normal result: ${sanitizeErrorMessage(stringifyError(error))}`,
@@ -318,6 +320,9 @@ export async function runCursorAgentSession(input: {
   } finally {
     input.signal?.removeEventListener("abort", forwardAbort);
   }
+
+  stderr = sanitizeErrorMessage(stderr);
+  if (stderr) input.logger.log({ category: "cursor", message: stderr, level: 1 });
 
   if (!resultText) resultText = lastAssistantText;
   const externalAbortReason = input.signal?.aborted
@@ -374,14 +379,16 @@ export function buildCursorStopReason(
         : "Cursor agent returned an error result",
     );
   }
-  if (!resultEvent && exit?.exitCode !== 0) {
+  if (!resultEvent) {
     const lastLine = stderr
       .split(/\r?\n/)
       .map((line) => line.trim())
       .filter(Boolean)
       .at(-1);
     return sanitizeErrorMessage(
-      `cursor agent exited with code ${String(exit?.exitCode ?? "unknown")}${lastLine ? `: ${lastLine}` : ""}`,
+      exit?.exitCode !== 0
+        ? `cursor agent exited with code ${String(exit?.exitCode ?? "unknown")}${lastLine ? `: ${lastLine}` : ""}`
+        : "Cursor agent exited without a terminal result event",
     );
   }
   return undefined;
@@ -411,7 +418,11 @@ export function summarizeCursorEvent(event: CursorEvent): { message: string; det
   const type = String(event.type ?? "unknown");
   if (type === "assistant") {
     const text = extractAssistantText(event);
-    return { message: text ? `assistant: ${clip(text, 500)}` : "assistant message", detail: text };
+    const sanitized = text ? sanitizeErrorMessage(text) : undefined;
+    return {
+      message: sanitized ? `assistant: ${clip(sanitized, 500)}` : "assistant message",
+      detail: sanitized,
+    };
   }
   if (type === "tool_call") {
     const view = extractCursorToolCall(event);
@@ -419,16 +430,33 @@ export function summarizeCursorEvent(event: CursorEvent): { message: string; det
       message: view
         ? `tool: ${view.name} ${view.subtype}${view.ok ? "" : " failed"}`
         : "tool_call event",
-      detail: safeJson(event),
+      detail: sanitizeOptional(safeJson(event)),
     };
   }
   if (type === "result") {
     return {
       message: `result: ${String(event.subtype ?? "done")}`,
-      detail: typeof event.result === "string" ? event.result : safeJson(event),
+      detail: sanitizeOptional(typeof event.result === "string" ? event.result : safeJson(event)),
     };
   }
-  return { message: `${type} event`, detail: safeJson(event) };
+  return { message: `${type} event`, detail: sanitizeOptional(safeJson(event)) };
+}
+
+function sanitizeOptional(value: string | undefined): string | undefined {
+  return value === undefined ? undefined : sanitizeErrorMessage(value);
+}
+
+function deepSanitizeCursorEvent(event: CursorEvent): CursorEvent {
+  return deepSanitizeCursorValue(event) as CursorEvent;
+}
+
+function deepSanitizeCursorValue(value: unknown): unknown {
+  if (typeof value === "string") return sanitizeErrorMessage(value);
+  if (Array.isArray(value)) return value.map(deepSanitizeCursorValue);
+  if (!isRecord(value)) return value;
+  return Object.fromEntries(
+    Object.entries(value).map(([key, child]) => [key, deepSanitizeCursorValue(child)]),
+  );
 }
 
 function extractAssistantText(event: CursorEvent): string | undefined {

--- a/packages/integrations/cursor-sdk/tests/session.test.ts
+++ b/packages/integrations/cursor-sdk/tests/session.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildCursorAgentArgs,
+  extractCursorToolCall,
+  normalizeCursorModel,
+  parseCursorStreamLine,
+  resolveCursorAgentBinary,
+  runCursorAgentSession,
+  type CursorProcessRunner,
+} from "../src/index.js";
+
+const logger = { log: () => {}, warn: () => {}, error: () => {} };
+const originalAgentPath = process.env.CURSOR_AGENT_PATH;
+
+afterEach(() => {
+  if (originalAgentPath === undefined) delete process.env.CURSOR_AGENT_PATH;
+  else process.env.CURSOR_AGENT_PATH = originalAgentPath;
+});
+
+describe("Cursor CLI session", () => {
+  it("builds ordered arguments and normalizes models", () => {
+    const args = buildCursorAgentArgs({
+      prompt: "do it",
+      model: "sonnet-4",
+      session: {
+        cwd: "/tmp/work",
+        apiKey: "key",
+        sandbox: "enabled",
+        extraArgs: ["--header", "X-Test: yes"],
+      },
+    });
+    expect(args.slice(0, 3)).toEqual(["-p", "--output-format", "stream-json"]);
+    expect(args).toContain("--force");
+    expect(args).toContain("--trust");
+    expect(args).toContain("--approve-mcps");
+    expect(args).toContain("--workspace");
+    expect(args).toContain("--model");
+    expect(args).toContain("--api-key");
+    expect(args).toContain("--sandbox");
+    expect(args.at(-1)).toBe("do it");
+
+    const disabled = buildCursorAgentArgs({
+      prompt: "task",
+      session: { force: false, trust: false, approveMcps: false },
+    });
+    expect(disabled).not.toContain("--force");
+    expect(disabled).not.toContain("--trust");
+    expect(disabled).not.toContain("--approve-mcps");
+    expect(normalizeCursorModel("cursor/auto")).toBeUndefined();
+    expect(normalizeCursorModel("auto")).toBeUndefined();
+    expect(normalizeCursorModel("cursor/sonnet-4")).toBe("sonnet-4");
+    expect(normalizeCursorModel("anthropic/claude-sonnet-4")).toBe("claude-sonnet-4");
+    expect(normalizeCursorModel("sonnet-4")).toBe("sonnet-4");
+  });
+
+  it("collects stream events, results, usage, and completed tool callbacks", async () => {
+    const completed = vi.fn();
+    const lines = [
+      { type: "system", subtype: "init" },
+      { type: "user", message: { role: "user", content: [{ type: "text", text: "task" }] } },
+      {
+        type: "assistant",
+        message: { role: "assistant", content: [{ type: "text", text: "reading" }] },
+      },
+      {
+        type: "tool_call",
+        subtype: "started",
+        call_id: "c1",
+        tool_call: { readToolCall: { args: { path: "file.txt" } } },
+      },
+      {
+        type: "tool_call",
+        subtype: "completed",
+        call_id: "c1",
+        tool_call: {
+          readToolCall: { args: { path: "file.txt" }, result: { success: { content: "ok" } } },
+        },
+      },
+      { type: "result", subtype: "success", is_error: false, result: "done" },
+    ];
+    const result = await runCursorAgentSession({
+      prompt: "task",
+      model: "cursor/auto",
+      logger,
+      session: {},
+      runProcess: scriptedRunner(lines),
+      onToolResult: completed,
+    });
+
+    expect(result.status).toBe("completed");
+    expect(result.resultText).toBe("done");
+    expect(result.events).toHaveLength(6);
+    expect(result.tokenUsage).toEqual({
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+      reported: false,
+    });
+    expect(completed).toHaveBeenCalledOnce();
+    expect(completed.mock.calls[0][0]).toBe("read");
+  });
+
+  it("parses defensive MCP and function tool-call shapes", () => {
+    const mcp = extractCursorToolCall({
+      type: "tool_call",
+      subtype: "completed",
+      call_id: "m1",
+      tool_call: {
+        mcpToolCall: {
+          args: { providerIdentifier: "stagehand", name: "run", args: { code: "return 1" } },
+          result: { success: { content: [] } },
+        },
+      },
+    });
+    expect(mcp).toMatchObject({ name: "stagehand.run", args: { code: "return 1" } });
+
+    const fn = extractCursorToolCall({
+      type: "tool_call",
+      subtype: "completed",
+      call_id: "f1",
+      tool_call: {
+        function: {
+          name: "custom_tool",
+          arguments: '{"value":2}',
+          result: { success: "ok" },
+        },
+      },
+    });
+    expect(fn).toMatchObject({ name: "custom_tool", args: { value: 2 } });
+  });
+
+  it("ignores blank and non-JSON output", () => {
+    expect(parseCursorStreamLine("  ")).toBeUndefined();
+    expect(parseCursorStreamLine("Cursor Agent v1")).toBeUndefined();
+    expect(parseCursorStreamLine('{"type":"system"}')).toEqual({ type: "system" });
+  });
+
+  it("classifies and sanitizes result and process failures", async () => {
+    const errorResult = await runCursorAgentSession({
+      prompt: "task",
+      model: "auto",
+      logger,
+      session: {},
+      runProcess: scriptedRunner([
+        {
+          type: "result",
+          subtype: "error",
+          is_error: true,
+          result: "failed with sk-abcdef1234567890",
+        },
+      ]),
+    });
+    expect(errorResult.status).toBe("sdk_error");
+    expect(errorResult.stopReason).toContain("sk-abcdef[redacted]");
+
+    const exitResult = await runCursorAgentSession({
+      prompt: "task",
+      model: "auto",
+      logger,
+      session: {},
+      runProcess: scriptedRunner([], {
+        exitCode: 2,
+        stderr: "bb_live_abcdefghi https://x.test?apiKey=secret-value\n",
+      }),
+    });
+    expect(exitResult.status).toBe("sdk_error");
+    expect(exitResult.stopReason).toContain("exited with code 2");
+    expect(exitResult.stopReason).toContain("bb_live_abcd[redacted]");
+    expect(exitResult.stopReason).toContain("apiKey=[redacted]");
+    expect(exitResult.stopReason).not.toContain("secret-value");
+  });
+
+  it("aborts when the completed tool-step budget is exhausted", async () => {
+    let processSignal: AbortSignal | undefined;
+    const runner: CursorProcessRunner = async (input) => {
+      processSignal = input.signal;
+      for (const callId of ["1", "2"]) {
+        await input.onStdoutLine(
+          JSON.stringify({
+            type: "tool_call",
+            subtype: "completed",
+            call_id: callId,
+            tool_call: { readToolCall: { args: {}, result: { success: {} } } },
+          }),
+        );
+      }
+      return { exitCode: null, signal: "SIGTERM" };
+    };
+    const result = await runCursorAgentSession({
+      prompt: "task",
+      model: "auto",
+      logger,
+      session: {},
+      runProcess: runner,
+      maxToolSteps: 1,
+    });
+    expect(processSignal?.aborted).toBe(true);
+    expect(result.status).toBe("max_turns");
+    expect(result.stopReason).toBe("tool step budget exhausted (1 steps)");
+  });
+
+  it("removes the caller abort forwarder after completion", async () => {
+    const added: string[] = [];
+    const removed: string[] = [];
+    const signal = {
+      aborted: false,
+      reason: undefined,
+      addEventListener: (type: string) => added.push(type),
+      removeEventListener: (type: string) => removed.push(type),
+    } as unknown as AbortSignal;
+    await runCursorAgentSession({
+      prompt: "task",
+      model: "auto",
+      logger,
+      signal,
+      session: {},
+      runProcess: scriptedRunner([{ type: "result", result: "done" }]),
+    });
+    expect(added).toEqual(["abort"]);
+    expect(removed).toEqual(["abort"]);
+  });
+
+  it("resolves the binary override before environment and default", () => {
+    process.env.CURSOR_AGENT_PATH = "/env/agent";
+    expect(resolveCursorAgentBinary("/override/agent")).toBe("/override/agent");
+    expect(resolveCursorAgentBinary()).toBe("/env/agent");
+    delete process.env.CURSOR_AGENT_PATH;
+    expect(resolveCursorAgentBinary()).toBe("agent");
+  });
+});
+
+function scriptedRunner(
+  events: Array<Record<string, unknown>>,
+  options: { exitCode?: number; stderr?: string } = {},
+): CursorProcessRunner {
+  return async (input) => {
+    input.onStderr(options.stderr ?? "");
+    await input.onStdoutLine("Cursor banner");
+    await input.onStdoutLine(" ");
+    for (const event of events) await input.onStdoutLine(JSON.stringify(event));
+    return { exitCode: options.exitCode ?? 0, signal: null };
+  };
+}

--- a/packages/integrations/cursor-sdk/tests/session.test.ts
+++ b/packages/integrations/cursor-sdk/tests/session.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { HarnessAdapterError } from "@browserbasehq/stagehand-integrations/harness";
 import {
   buildCursorAgentArgs,
   extractCursorToolCall,
@@ -168,6 +169,61 @@ describe("Cursor CLI session", () => {
     expect(exitResult.stopReason).toContain("bb_live_abcd[redacted]");
     expect(exitResult.stopReason).toContain("apiKey=[redacted]");
     expect(exitResult.stopReason).not.toContain("secret-value");
+    expect(exitResult.stderr).not.toContain("secret-value");
+  });
+
+  it("sanitizes stored event payloads and typed process errors", async () => {
+    const secret = "sk-abcdef1234567890";
+    const eventResult = await runCursorAgentSession({
+      prompt: "task",
+      model: "auto",
+      logger,
+      session: {},
+      runProcess: scriptedRunner([
+        {
+          type: "tool_call",
+          subtype: "completed",
+          call_id: "1",
+          tool_call: {
+            readToolCall: { args: {}, result: { error: `failed with ${secret}` } },
+          },
+        },
+        { type: "result", result: "done" },
+      ]),
+    });
+    expect(JSON.stringify(eventResult.events)).toContain("sk-abcdef[redacted]");
+    expect(JSON.stringify(eventResult.events)).not.toContain(secret);
+
+    const processResult = await runCursorAgentSession({
+      prompt: "task",
+      model: "auto",
+      logger,
+      session: {},
+      runProcess: async () => {
+        throw new Error(`process failed with ${secret}`);
+      },
+    });
+    expect(processResult.iterationError).toBeInstanceOf(HarnessAdapterError);
+    expect(String(processResult.iterationError)).toContain("sk-abcdef[redacted]");
+    expect(String(processResult.iterationError)).not.toContain(secret);
+  });
+
+  it("fails closed when a successful process emits no result event", async () => {
+    const result = await runCursorAgentSession({
+      prompt: "task",
+      model: "auto",
+      logger,
+      session: {},
+      runProcess: scriptedRunner([
+        {
+          type: "assistant",
+          message: { content: [{ type: "text", text: "partial answer" }] },
+        },
+      ]),
+    });
+
+    expect(result.status).toBe("sdk_error");
+    expect(result.stopReason).toBe("Cursor agent exited without a terminal result event");
   });
 
   it("aborts when the completed tool-step budget is exhausted", async () => {

--- a/packages/integrations/cursor-sdk/tsconfig.json
+++ b/packages/integrations/cursor-sdk/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "types": ["node"],
+    "rootDir": ".",
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts", "vitest.config.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/integrations/cursor-sdk/tsdown.config.ts
+++ b/packages/integrations/cursor-sdk/tsdown.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: {
+    index: "src/index.ts",
+  },
+  format: ["esm"],
+  platform: "node",
+  target: "node22",
+  dts: {
+    sourcemap: true,
+  },
+  sourcemap: true,
+  outDir: "dist",
+});

--- a/packages/integrations/cursor/AGENTS.md
+++ b/packages/integrations/cursor/AGENTS.md
@@ -1,0 +1,9 @@
+# Stagehand browser tools in Cursor
+
+The `stagehand` MCP server exposes the `run`, `snapshot`, and `screenshot` tools. Cursor surfaces
+MCP tools by server and tool name; use the tools belonging to the `stagehand` server.
+
+There is no separate navigate or start tool. Open URLs with `run`, for example
+`await page.goto("https://example.com"); return { url: await page.url() };`. Use `snapshot` for
+the accessibility tree and element IDs, and `screenshot` only when visual pixels are needed.
+Never launch a separate browser or use shell commands for browsing.

--- a/packages/integrations/cursor/README.md
+++ b/packages/integrations/cursor/README.md
@@ -10,6 +10,7 @@ project MCP server through `.cursor/mcp.json`.
 Use Node.js 24 or newer. From the repository root, build the integrations package first:
 
 ```bash
+pnpm install --frozen-lockfile
 pnpm exec turbo run build --filter @browserbasehq/stagehand-integrations
 ```
 

--- a/packages/integrations/cursor/README.md
+++ b/packages/integrations/cursor/README.md
@@ -1,0 +1,45 @@
+# Cursor agent CLI + Stagehand facade over MCP/stdio
+
+Cursor's `agent` CLI consumes the Stagehand facade (`run` / `snapshot` / `screenshot`) as a
+project MCP server through `.cursor/mcp.json`.
+
+<!-- Verified against cursor.com/docs/cli as of 2026-08; the `agent` binary was not available to run locally, so flags are from the published reference. -->
+
+## Setup
+
+Use Node.js 24 or newer. From the repository root, build the integrations package first:
+
+```bash
+pnpm exec turbo run build --filter @browserbasehq/stagehand-integrations
+```
+
+Install the Cursor agent CLI, then authenticate with an existing login or an API key:
+
+```bash
+curl https://cursor.com/install -fsS | bash
+agent login
+# or: export CURSOR_API_KEY=...
+```
+
+## Configure
+
+Copy `mcp.json` from this directory to `<project>/.cursor/mcp.json`, or merge its `mcpServers`
+entry into `~/.cursor/mcp.json`. Fill in the absolute path to your checkout and replace the
+`BROWSERBASE_API_KEY` placeholder with your key.
+
+Verify that Cursor can load the mount:
+
+```bash
+agent mcp list-tools stagehand
+```
+
+## Run
+
+Run from this directory so Cursor reads the `AGENTS.md` browser-tool guidance at the workspace
+root:
+
+```bash
+agent -p --force --approve-mcps --trust --output-format stream-json "Use the stagehand MCP tools: open https://example.com, snapshot it, and report the heading citing the snapshot ID."
+```
+
+Cursor's CLI does not emit token usage in any output format.

--- a/packages/integrations/cursor/mcp.json
+++ b/packages/integrations/cursor/mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "stagehand": {
+      "command": "node",
+      "args": [
+        "/absolute/path/to/stagehand/packages/integrations/core/dist/facade/stdio-server.mjs",
+        "--max-screenshot-base64-bytes=60000"
+      ],
+      "env": {
+        "STAGEHAND_BROWSER": "browserbase",
+        "BROWSERBASE_API_KEY": "bb_live_..."
+      }
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2894,8 +2894,8 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@posthog/core@1.46.9':
-    resolution: {integrity: sha512-EXO6y5ih+jBkTCpUCuYgQmajuDZuvy6vMvflkub6pLQyi0GPlCPWVSvZZkOeQw9e2MxoD5GteeGCt9R8+UJ/yQ==}
+  '@posthog/core@1.39.6':
+    resolution: {integrity: sha512-o6ajIwN5zXoNP0D4H/QPmOyibNTUkSyOR6ya7AG5U2ywXx4awo72L2KnCoiZPQM5x/bXv6jPBdimH8M18Ax0aw==}
 
   '@posthog/core@1.7.1':
     resolution: {integrity: sha512-kjK0eFMIpKo9GXIbts8VtAknsoZ18oZorANdtuTj1CbgS28t4ZVq//HAWhnxEuXRTrtkd+SUJ6Ux3j2Af8NCuA==}
@@ -3132,10 +3132,6 @@ packages:
 
   '@smithy/signature-v4@5.7.0':
     resolution: {integrity: sha512-hCynhm22wMJ8wTF9crcwu8mxggtUrSLLJgDcGUvYFBqpofxycYJCGKOMYg4xtPPFtgNiDJSYmhsWLTrcU/g59Q==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/types@4.16.1':
-    resolution: {integrity: sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/types@4.17.0':
@@ -6722,8 +6718,8 @@ packages:
     resolution: {integrity: sha512-lz3YJOr0Nmiz0yHASaINEDHqoV+0bC3eD8aZAG+Ky292dAnVYul+ga/dMX8KCBXg8hHfKdxw0SztYD5j6dgUqQ==}
     engines: {node: '>=20'}
 
-  posthog-node@5.48.1:
-    resolution: {integrity: sha512-BxLX2SqGEQhPqCPTalpyo0RRv1NMbf7UaN7q9d/ED77ksD6XOmE7ko2vIKO8F0zPL1NtKxIi+DYXap9lvR0RaA==}
+  posthog-node@5.40.0:
+    resolution: {integrity: sha512-DrLfHuauO0W6qruF80iqr5JdmLysef74XzOB4eh36oRLRhxCySLraTqsi2Pj161LZnp9/JNdRDxwT8ei8VK2YA==}
     engines: {node: ^20.20.0 || >=22.22.0}
     peerDependencies:
       rxjs: ^7.0.0
@@ -9798,7 +9794,7 @@ snapshots:
       p-map: 7.0.6
       p-retry: 7.1.1
       picomatch: 4.0.5
-      posthog-node: 5.48.1(rxjs@7.8.2)
+      posthog-node: 5.40.0(rxjs@7.8.2)
       tokenx: 1.6.0
       ws: 8.21.0(bufferutil@4.1.0)
       xxhash-wasm: 1.1.0
@@ -10559,7 +10555,7 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@posthog/core@1.46.9':
+  '@posthog/core@1.39.6':
     dependencies:
       '@posthog/types': 1.402.2
 
@@ -10736,7 +10732,7 @@ snapshots:
 
   '@smithy/core@3.30.0':
     dependencies:
-      '@smithy/types': 4.16.1
+      '@smithy/types': 4.17.0
       tslib: 2.8.1
     optional: true
 
@@ -10784,11 +10780,6 @@ snapshots:
       '@smithy/core': 3.32.0
       '@smithy/types': 4.17.0
       tslib: 2.8.1
-
-  '@smithy/types@4.16.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
 
   '@smithy/types@4.17.0':
     dependencies:
@@ -14926,9 +14917,9 @@ snapshots:
     dependencies:
       '@posthog/core': 1.7.1
 
-  posthog-node@5.48.1(rxjs@7.8.2):
+  posthog-node@5.40.0(rxjs@7.8.2):
     dependencies:
-      '@posthog/core': 1.46.9
+      '@posthog/core': 1.39.6
     optionalDependencies:
       rxjs: 7.8.2
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,6 +269,9 @@ importers:
       '@browserbasehq/stagehand-integrations-codex-sdk':
         specifier: workspace:*
         version: link:../integrations/codex-sdk
+      '@browserbasehq/stagehand-integrations-cursor-sdk':
+        specifier: workspace:*
+        version: link:../integrations/cursor-sdk
       '@browserbasehq/stagehand-integrations-deepagents-sdk':
         specifier: workspace:*
         version: link:../integrations/deepagents-sdk
@@ -524,6 +527,25 @@ importers:
       zod:
         specifier: 'catalog:'
         version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.13.2
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.3(publint@0.3.21)(tsx@4.23.1)(typescript@5.9.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+
+  packages/integrations/cursor-sdk:
+    dependencies:
+      '@browserbasehq/stagehand-integrations':
+        specifier: workspace:*
+        version: link:../core
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -2872,8 +2894,8 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@posthog/core@1.39.6':
-    resolution: {integrity: sha512-o6ajIwN5zXoNP0D4H/QPmOyibNTUkSyOR6ya7AG5U2ywXx4awo72L2KnCoiZPQM5x/bXv6jPBdimH8M18Ax0aw==}
+  '@posthog/core@1.46.9':
+    resolution: {integrity: sha512-EXO6y5ih+jBkTCpUCuYgQmajuDZuvy6vMvflkub6pLQyi0GPlCPWVSvZZkOeQw9e2MxoD5GteeGCt9R8+UJ/yQ==}
 
   '@posthog/core@1.7.1':
     resolution: {integrity: sha512-kjK0eFMIpKo9GXIbts8VtAknsoZ18oZorANdtuTj1CbgS28t4ZVq//HAWhnxEuXRTrtkd+SUJ6Ux3j2Af8NCuA==}
@@ -6700,8 +6722,8 @@ packages:
     resolution: {integrity: sha512-lz3YJOr0Nmiz0yHASaINEDHqoV+0bC3eD8aZAG+Ky292dAnVYul+ga/dMX8KCBXg8hHfKdxw0SztYD5j6dgUqQ==}
     engines: {node: '>=20'}
 
-  posthog-node@5.40.0:
-    resolution: {integrity: sha512-DrLfHuauO0W6qruF80iqr5JdmLysef74XzOB4eh36oRLRhxCySLraTqsi2Pj161LZnp9/JNdRDxwT8ei8VK2YA==}
+  posthog-node@5.48.1:
+    resolution: {integrity: sha512-BxLX2SqGEQhPqCPTalpyo0RRv1NMbf7UaN7q9d/ED77ksD6XOmE7ko2vIKO8F0zPL1NtKxIi+DYXap9lvR0RaA==}
     engines: {node: ^20.20.0 || >=22.22.0}
     peerDependencies:
       rxjs: ^7.0.0
@@ -9776,7 +9798,7 @@ snapshots:
       p-map: 7.0.6
       p-retry: 7.1.1
       picomatch: 4.0.5
-      posthog-node: 5.40.0(rxjs@7.8.2)
+      posthog-node: 5.48.1(rxjs@7.8.2)
       tokenx: 1.6.0
       ws: 8.21.0(bufferutil@4.1.0)
       xxhash-wasm: 1.1.0
@@ -10537,7 +10559,7 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@posthog/core@1.39.6':
+  '@posthog/core@1.46.9':
     dependencies:
       '@posthog/types': 1.402.2
 
@@ -14904,9 +14926,9 @@ snapshots:
     dependencies:
       '@posthog/core': 1.7.1
 
-  posthog-node@5.40.0(rxjs@7.8.2):
+  posthog-node@5.48.1(rxjs@7.8.2):
     dependencies:
-      '@posthog/core': 1.39.6
+      '@posthog/core': 1.46.9
     optionalDependencies:
       rxjs: 7.8.2
 

--- a/turbo.json
+++ b/turbo.json
@@ -66,6 +66,11 @@
       "inputs": ["$TURBO_DEFAULT$", "!dist/**"],
       "outputs": ["dist/**"]
     },
+    "@browserbasehq/stagehand-integrations-cursor-sdk#build": {
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", "!dist/**"],
+      "outputs": ["dist/**"]
+    },
     "@browserbasehq/stagehand-evals#build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", "!dist/**"],
@@ -201,6 +206,16 @@
         "$TURBO_ROOT$/vitest.config.ts"
       ]
     },
+    "@browserbasehq/stagehand-integrations-cursor-sdk#test:unit": {
+      "dependsOn": ["^build", "@browserbasehq/stagehand-integrations-cursor-sdk#build"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "tests/**",
+        "src/**",
+        "**/*.test.ts",
+        "$TURBO_ROOT$/vitest.config.ts"
+      ]
+    },
     "@browserbasehq/stagehand-integrations-example-mastra-facade#typecheck": {
       "dependsOn": ["^build"]
     },
@@ -223,6 +238,9 @@
       "dependsOn": ["^build"]
     },
     "@browserbasehq/stagehand-integrations-fx-sdk#typecheck": {
+      "dependsOn": ["^build"]
+    },
+    "@browserbasehq/stagehand-integrations-cursor-sdk#typecheck": {
       "dependsOn": ["^build"]
     },
     "@browserbasehq/stagehand-docs#typecheck": {},

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
       "packages/integrations/eve-sdk/tests/**/*.test.ts",
       "packages/integrations/deepagents-sdk/tests/**/*.test.ts",
       "packages/integrations/fx-sdk/tests/**/*.test.ts",
+      "packages/integrations/cursor-sdk/tests/**/*.test.ts",
       "packages/extension/tests/**/*.test.ts",
       "packages/sdk-ts/tests/**/*.test.ts",
       "packages/extension/understudy/**/*.test.ts",


### PR DESCRIPTION
## What

Adds `--harness cursor` to evals, backed by a new private `@browserbasehq/stagehand-integrations-cursor-sdk` package, plus a minimal `packages/integrations/cursor` facade example (mcp.json + README, fx-package shape). The Cursor agent is CLI-only (`agent`, legacy `cursor-agent`; no npm SDK).

- `packages/integrations/cursor-sdk` — `runCursorSession`: spawns `agent -p --output-format stream-json` with a project-local `.cursor/mcp.json` pointing at the stagehand facade stdio server, parses the stream into tool-call/result/usage events, abort → child kill, redaction, status/stopReason normalization.
- `packages/evals/framework/cursorToolAdapter.ts` — `via:"mcp"` mounts only (stagehand_facade first, playwright_mcp, chrome_devtools_mcp; browse_cli/code surfaces rejected).
- `packages/evals/framework/harnesses/cursorAdapter.ts` — events → `NormalizedToolCall[]`.
- Registered via `defineExternalHarness` on the shared external-runner skeleton.

## Testing

- Full unit gate green (evals + cursor-sdk 8 + all other suites).
- Connected smoke **not yet run**: the `agent` CLI is not installed on the dev machine (`curl https://cursor.com/install -fsS | bash`). Command when available: `evals run b:webvoyager --harness cursor --tool stagehand_facade -l 1 -t 1 -e browserbase`.

Stacked on the fx PR; top of the harness stack. Implemented with Codex (gpt-5.6) under supervision.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a registered Cursor agent CLI harness so evals can run with `--harness cursor` over MCP-only mounts, without launching a browser or modifying files. The Cursor CLI reports no token usage, so token metrics are zero.

- Supported tool surfaces: `stagehand_facade` (default), `playwright_mcp`, `chrome_devtools_mcp`; other surfaces (e.g., `browse_cli`, code mounts) are rejected.
- Registration: `cursor` is in the bench harness registry with default model `cursor/auto`; wired into CI, `turbo`, and `vitest` with unit tests for registry, runner, adapter, and SDK.
- Process/workspace: writes a temp `.cursor/mcp.json` for active MCP servers, inherits env, and cleans up. Override the binary with `EVAL_CURSOR_AGENT_PATH`; toggle sandbox via `EVAL_CURSOR_SANDBOX=enabled|disabled`; cap completed tool steps via `EVAL_CURSOR_MAX_STEPS` or `AGENT_EVAL_MAX_STEPS` (default 50).
- CLI invocation: runs `agent -p --output-format stream-json --force --trust --approve-mcps`; API keys are never passed on the command line, and stream output is sanitized for secrets.
- Metrics: `cursor_input_tokens`, `cursor_output_tokens`, `cursor_total_tokens` (always zero), `cursor_duration_ms`, `cursor_tool_steps`.
- Trajectory mapping: assistant text becomes reasoning; started/completed `tool_call` pairs become steps, and started calls without a completed envelope (abort/kill mid-call) fail closed; MCP images become evidence with a final-observation fallback; step observations attach by MCP tool ordinal. Results are parsed strictly first, then leniently for fenced/prose JSON.
- New private package `@browserbasehq/stagehand-integrations-cursor-sdk` adds the process runner and parsers; `packages/integrations/cursor` provides an `mcp.json` template and AGENTS.md guidance.
- Run locally: install the Cursor CLI (`curl https://cursor.com/install -fsS | bash`), set `CURSOR_API_KEY`, then e.g. `evals run b:webvoyager --harness cursor --tool stagehand_facade -l 1 -t 1 -e browserbase`.

<sup>Written for commit c20d28b0536b02de91d35420eb07b208c48684ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

