### PR TITLE
fix(ci): keep pnpm logs out of Python alpha outputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,7 +184,7 @@ jobs:
 
       - name: Check alpha version
         id: status
-        run: pnpm exec tsx scripts/release/python-alpha-version.ts --check >> "$GITHUB_OUTPUT"
+        run: node scripts/release/python-alpha-version.ts --check >> "$GITHUB_OUTPUT"
 
   publish-python-alpha:
     name: Release Python SDK alpha


### PR DESCRIPTION
# why

- The Python alpha status step redirects command stdout into GITHUB_OUTPUT.
- After Changesets rewrites workspace manifests, pnpm 11 emits its workspace scope and dependency-check logs before the script output, causing Actions to reject Scope: all 15 workspace projects as an invalid output record.

# what changed

- Run the Python alpha version script directly with Node 24, matching the existing Go release status step.
- This bypasses pnpm so GITHUB_OUTPUT contains only the script-owned should-publish and version records.

# test plan

- actionlint -ignore SC2046 .github/workflows/release.yml
- ./node_modules/.bin/node scripts/release/python-alpha-version.ts --check
- ./node_modules/.bin/vitest run scripts/release/python-alpha-version.test.ts
- Reproduced the failing pnpm 11 output after changeset version --snapshot and confirmed the Node command emits only the expected output record.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs the Python alpha status step with Node 24 to avoid `pnpm` workspace logs in GITHUB_OUTPUT. Previously `pnpm exec tsx ...` emitted scope logs that Actions rejected as invalid outputs; now `node ...` writes only `should-publish` and `version`.

**Review notes**
- Ensure Node 24 is available in the workflow; this matches the Go release status step.
- No migration required; downstream steps still read `status.outputs.should-publish` and `status.outputs.version`.

<sup>Written for commit 9e3426d4bd56484a273141ae00d875249b97c4cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

