### PR TITLE
fix(ci): remove private evals changeset

### DIFF
--- a/.changeset/evals-otel-compat.md
+++ b/.changeset/evals-otel-compat.md
@@ -1,5 +1,0 @@
----
-"@browserbasehq/stagehand-evals": minor
----
-
-Adds OpenTelemetry (OTEL) compatibility to the evals CLI


### PR DESCRIPTION
# why

- The merged OTEL evals stack added a changeset for @browserbasehq/stagehand-evals.
- That package is private and intentionally non-versioned, so the release workflow fails the changeset validator before it can publish anything.

# what changed

- Remove the invalid evals-otel-compat changeset.
- The OTEL evals implementation remains unchanged; only the inapplicable release request is removed.

# test plan

- ./node_modules/.bin/tsx scripts/release/check-changesets.ts
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes an invalid changeset for the private package `@browserbasehq/stagehand-evals` to unblock the release workflow. Previously the changeset validator failed because the package is private and non-versioned; now validation should pass with no publish attempts for that package.

**Impact**
- Deletes `.changeset/evals-otel-compat.md`; no code, runtime, or CLI behavior changes. OTEL evals code remains unchanged.
- Action: re-run the release checks (e.g., ./node_modules/.bin/tsx scripts/release/check-changesets.ts) to confirm CI passes.

<sup>Written for commit 7945dc8c4b8f063fab6eaa92f42167f7a80c248d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

