### PR TITLE
evals: configurable trace sinks (env + `evals config tracing`)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,12 @@ BROWSERBASE_API_KEY=""
 # LANGSMITH_API_KEY=""
 # Enable LangSmith trace export when using the OTEL transport.
 # LANGSMITH_TRACING="true"
-# Route OTEL-transport Braintrust spans to a custom project/experiment
-# (e.g. "project_name:my-project"). Defaults to stagehand / stagehand-dev.
+# Braintrust project for eval runs (both transports). Defaults to
+# stagehand[-core][-dev] by tier/CI. Also settable via `evals config tracing`.
+# BRAINTRUST_PROJECT_NAME=""
+# Raw Braintrust OTEL parent override (e.g. "project_name:x" or
+# "experiment_id:..."); takes precedence over BRAINTRUST_PROJECT_NAME for the
+# OTEL transport only.
 # BRAINTRUST_OTEL_PARENT=""
+# LangSmith project for OTEL-exported traces (workspace default if unset).
+# LANGSMITH_PROJECT=""

--- a/packages/evals/framework/braintrust.ts
+++ b/packages/evals/framework/braintrust.ts
@@ -22,6 +22,23 @@ export function loadBraintrust(): Promise<typeof import("braintrust")> {
   return braintrustPromise;
 }
 
+export type BraintrustProjectTier = "core" | "bench";
+
+/**
+ * Braintrust project a run logs to. `BRAINTRUST_PROJECT_NAME` overrides the
+ * default so users can route runs to their own project; otherwise the
+ * tier × CI matrix picks stagehand[-core][-dev]. Single source for both the
+ * native `Eval()` path and the OTEL `project_name:` parent so the two
+ * transports never disagree about where a run lands.
+ */
+export function resolveBraintrustProjectName(tier: BraintrustProjectTier = "bench"): string {
+  const override = process.env.BRAINTRUST_PROJECT_NAME?.trim();
+  if (override) return override;
+  const isCI = process.env.CI === "true";
+  if (tier === "core") return isCI ? "stagehand-core" : "stagehand-core-dev";
+  return isCI ? "stagehand" : "stagehand-dev";
+}
+
 /**
  * The only Span surface traced callbacks may use. Deliberately narrower than
  * Braintrust's `Span` so the no-key fallback below can satisfy it without

--- a/packages/evals/framework/otel.ts
+++ b/packages/evals/framework/otel.ts
@@ -7,6 +7,7 @@ import {
 // verify after install: @opentelemetry/sdk-trace-node exports NodeTracerProvider.
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 
+import { resolveBraintrustProjectName } from "./braintrust.js";
 import { langSmithTracingEnabled, resolveTraceTransport } from "./langsmith.js";
 
 const TRACER_NAME = "stagehand-evals";
@@ -43,14 +44,14 @@ async function initializeTracerProvider(braintrustParent?: string): Promise<void
   if (braintrustApiKey) {
     // verify after install: @braintrust/otel exports BraintrustSpanProcessor.
     const { BraintrustSpanProcessor } = await import("@braintrust/otel");
-    // Precedence: explicit user override (env) > caller-computed default >
-    // module fallback. The runner always passes `braintrustParent`, so the env
-    // var must win over it or it would never take effect for eval runs.
-    const braintrustProjectName = process.env.CI === "true" ? "stagehand" : "stagehand-dev";
+    // Precedence: raw parent override (env) > caller-computed default >
+    // project-name fallback (which itself honors BRAINTRUST_PROJECT_NAME). The
+    // runner always passes `braintrustParent`, so the env var must win over it
+    // or it would never take effect for eval runs.
     const parent =
       process.env.BRAINTRUST_OTEL_PARENT?.trim() ||
       braintrustParent ||
-      `project_name:${braintrustProjectName}`;
+      `project_name:${resolveBraintrustProjectName()}`;
     const braintrustOtelUrl = process.env.BRAINTRUST_OTEL_URL;
 
     spanProcessors.push(

--- a/packages/evals/framework/runner.ts
+++ b/packages/evals/framework/runner.ts
@@ -30,7 +30,12 @@ import type { Testcase, EvalInput } from "../types/evals.js";
 import { generateBenchTestcases } from "./benchPlanner.js";
 import { DEFAULT_BENCH_HARNESS, type Harness } from "./benchTypes.js";
 import { executeBenchTask } from "./benchRunner.js";
-import { hasBraintrustApiKey, loadBraintrust, tracedSpan } from "./braintrust.js";
+import {
+  hasBraintrustApiKey,
+  loadBraintrust,
+  resolveBraintrustProjectName,
+  tracedSpan,
+} from "./braintrust.js";
 import { onceAsync, registerActiveRunCleanup } from "./activeRunCleanup.js";
 import { loadTaskModuleFromPath } from "./taskLoader.js";
 import { resolveTraceTransport } from "./langsmith.js";
@@ -330,13 +335,7 @@ export function capForSpan(value: Record<string, unknown>): Record<string, unkno
 export async function runEvals(options: RunEvalsOptions): Promise<RunEvalsResult> {
   const traceTransport = resolveTraceTransport();
   const hasCoreOnly = options.tasks.every((t: DiscoveredTask) => t.tier === "core");
-  const braintrustProjectName = hasCoreOnly
-    ? process.env.CI === "true"
-      ? "stagehand-core"
-      : "stagehand-core-dev"
-    : process.env.CI === "true"
-      ? "stagehand"
-      : "stagehand-dev";
+  const braintrustProjectName = resolveBraintrustProjectName(hasCoreOnly ? "core" : "bench");
 
   try {
     const concurrency = options.concurrency ?? 3;

--- a/packages/evals/scripts/build-cli.ts
+++ b/packages/evals/scripts/build-cli.ts
@@ -58,6 +58,11 @@ if (fs.existsSync(distConfigPath)) {
     if (existing._meta) {
       sourceConfig._meta = { ...sourceConfig._meta, ...existing._meta };
     }
+    // Same for the user-owned `core` and `tracing` sections (set via
+    // `evals config core|tracing` on the built CLI) — the source config never
+    // carries them, so without this a rebuild would silently drop them.
+    if (existing.core) sourceConfig.core = { ...sourceConfig.core, ...existing.core };
+    if (existing.tracing) sourceConfig.tracing = { ...sourceConfig.tracing, ...existing.tracing };
   } catch {
     // invalid existing config – overwrite entirely
   }

--- a/packages/evals/tests/framework/braintrust-runner-nolog.test.ts
+++ b/packages/evals/tests/framework/braintrust-runner-nolog.test.ts
@@ -28,6 +28,7 @@ let mockHasKey = false;
 
 vi.mock("../../framework/braintrust.js", () => ({
   hasBraintrustApiKey: () => mockHasKey,
+  resolveBraintrustProjectName: () => "stagehand-dev",
   loadBraintrust: async () => ({
     Eval: mockEval,
     flush: mockFlush,

--- a/packages/evals/tests/framework/runner.test.ts
+++ b/packages/evals/tests/framework/runner.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import type { DiscoveredTask } from "../../framework/types.js";
 import { resolveBenchModelEntries, type RunEvalsOptions } from "../../framework/runner.js";
+import { resolveBraintrustProjectName } from "../../framework/braintrust.js";
 
 vi.mock("playwright", () => ({
   chromium: {},
@@ -29,50 +30,53 @@ function makeTask(overrides: Partial<DiscoveredTask>): DiscoveredTask {
 }
 
 describe("runner: Braintrust project selection", () => {
-  it("uses stagehand-core-dev for core-only tasks", async () => {
-    // The project selection logic is:
-    //   hasCoreOnly ? stagehand-core[-dev] : stagehand[-dev]
-    // We verify this logic directly
+  const saved = {
+    CI: process.env.CI,
+    BRAINTRUST_PROJECT_NAME: process.env.BRAINTRUST_PROJECT_NAME,
+  };
+  beforeEach(() => {
+    delete process.env.CI;
+    delete process.env.BRAINTRUST_PROJECT_NAME;
+  });
+  afterEach(() => {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  it("uses stagehand-core-dev for core-only tasks", () => {
     const tasks = [makeTask({ tier: "core", name: "open" })];
     const hasCoreOnly = tasks.every((t) => t.tier === "core");
-    expect(hasCoreOnly).toBe(true);
-
-    const project = hasCoreOnly ? "stagehand-core-dev" : "stagehand-dev";
-    expect(project).toBe("stagehand-core-dev");
+    expect(resolveBraintrustProjectName(hasCoreOnly ? "core" : "bench")).toBe("stagehand-core-dev");
   });
 
-  it("uses stagehand-dev for bench tasks", () => {
-    const tasks = [makeTask({ tier: "bench", name: "dropdown" })];
-    const hasCoreOnly = tasks.every((t) => t.tier === "core");
-    expect(hasCoreOnly).toBe(false);
-
-    const project = hasCoreOnly ? "stagehand-core-dev" : "stagehand-dev";
-    expect(project).toBe("stagehand-dev");
-  });
-
-  it("uses stagehand-dev for mixed tiers", () => {
-    const tasks = [
+  it("uses stagehand-dev for bench and mixed tiers", () => {
+    const mixed = [
       makeTask({ tier: "core", name: "open" }),
-      makeTask({ tier: "bench", name: "dropdown" }),
+      makeTask({ tier: "bench", name: "dd" }),
     ];
-    const hasCoreOnly = tasks.every((t) => t.tier === "core");
-    expect(hasCoreOnly).toBe(false);
-
-    const project = hasCoreOnly ? "stagehand-core-dev" : "stagehand-dev";
-    expect(project).toBe("stagehand-dev");
+    const hasCoreOnly = mixed.every((t) => t.tier === "core");
+    expect(resolveBraintrustProjectName(hasCoreOnly ? "core" : "bench")).toBe("stagehand-dev");
+    expect(resolveBraintrustProjectName()).toBe("stagehand-dev");
   });
 
-  it("uses stagehand in CI for core", () => {
-    const hasCoreOnly = true;
-    const isCI = true;
-    const project = hasCoreOnly
-      ? isCI
-        ? "stagehand-core"
-        : "stagehand-core-dev"
-      : isCI
-        ? "stagehand"
-        : "stagehand-dev";
-    expect(project).toBe("stagehand-core");
+  it("drops the -dev suffix in CI", () => {
+    process.env.CI = "true";
+    expect(resolveBraintrustProjectName("core")).toBe("stagehand-core");
+    expect(resolveBraintrustProjectName("bench")).toBe("stagehand");
+  });
+
+  it("BRAINTRUST_PROJECT_NAME overrides the tier/CI matrix for both tiers", () => {
+    process.env.CI = "true";
+    process.env.BRAINTRUST_PROJECT_NAME = "  my-team-evals ";
+    expect(resolveBraintrustProjectName("core")).toBe("my-team-evals");
+    expect(resolveBraintrustProjectName("bench")).toBe("my-team-evals");
+  });
+
+  it("ignores a blank BRAINTRUST_PROJECT_NAME", () => {
+    process.env.BRAINTRUST_PROJECT_NAME = "   ";
+    expect(resolveBraintrustProjectName()).toBe("stagehand-dev");
   });
 });
 

--- a/packages/evals/tests/tui/doctor.test.ts
+++ b/packages/evals/tests/tui/doctor.test.ts
@@ -15,6 +15,12 @@ const PROVIDER_KEYS = [
   "BB_API_KEY",
   "BB_PROJECT_ID",
   "BRAINTRUST_API_KEY",
+  "EVAL_TRACE_TRANSPORT",
+  "BRAINTRUST_PROJECT_NAME",
+  "LANGSMITH_PROJECT",
+  "LANGSMITH_API_KEY",
+  "LANGCHAIN_API_KEY",
+  "LANGSMITH_TRACING",
 ];
 
 const savedEnv: Record<string, string | undefined> = {};
@@ -109,6 +115,53 @@ describe("handleDoctor --json", () => {
     expect(report).toHaveProperty("keys.openai.state");
     expect(report).toHaveProperty("keys.browserbase.apiKey");
     expect(Array.isArray(report.reasons)).toBe(true);
+  });
+});
+
+describe("handleDoctor tracing block", () => {
+  it("reports defaults when nothing is configured", async () => {
+    const entryDir = makeTempEntryDir();
+    const { report } = await runDoctorJson(entryDir);
+    expect(report.tracing).toEqual({
+      transport: { value: null, source: "none" },
+      braintrustProject: { value: null, source: "none" },
+      langsmithProject: { value: null, source: "none" },
+      langsmithEnabled: false,
+    });
+  });
+
+  it("resolves env over evals.config.json tracing", async () => {
+    const entryDir = makeTempEntryDir();
+    fs.writeFileSync(
+      path.join(entryDir, "evals.config.json"),
+      JSON.stringify({
+        defaults: {},
+        benchmarks: {},
+        tracing: { transport: "otel", braintrustProject: "from-config" },
+      }),
+    );
+    process.env.BRAINTRUST_PROJECT_NAME = "from-env";
+    const { report } = await runDoctorJson(entryDir);
+    const tracing = report.tracing as Record<string, { value: string | null; source: string }>;
+    expect(tracing.transport).toEqual({ value: "otel", source: "config" });
+    expect(tracing.braintrustProject).toEqual({ value: "from-env", source: "env" });
+  });
+
+  it("warns when otel is selected but no sink is configured", async () => {
+    const entryDir = makeTempEntryDir();
+    process.env.OPENAI_API_KEY = "sk-test";
+    process.env.BROWSERBASE_API_KEY = "bb";
+    process.env.BROWSERBASE_PROJECT_ID = "pid";
+    process.env.BRAINTRUST_API_KEY = "bt";
+    process.env.EVAL_TRACE_TRANSPORT = "otel";
+    // Braintrust key present → sink exists → no tracing warning.
+    let { report } = await runDoctorJson(entryDir);
+    expect(report.reasons.some((r) => r.includes("no sink"))).toBe(false);
+
+    delete process.env.BRAINTRUST_API_KEY;
+    ({ report } = await runDoctorJson(entryDir));
+    expect(report.reasons.some((r) => r.includes("no sink"))).toBe(true);
+    expect(report.verdict).not.toBe("ok");
   });
 });
 

--- a/packages/evals/tests/tui/doctor.test.ts
+++ b/packages/evals/tests/tui/doctor.test.ts
@@ -147,6 +147,31 @@ describe("handleDoctor tracing block", () => {
     expect(tracing.braintrustProject).toEqual({ value: "from-env", source: "env" });
   });
 
+  it("reports an unrecognized transport as a native fallback and warns", async () => {
+    const entryDir = makeTempEntryDir();
+    process.env.OPENAI_API_KEY = "sk-test";
+    process.env.EVAL_TRACE_TRANSPORT = "jaeger";
+    const { report } = await runDoctorJson(entryDir);
+    const tracing = report.tracing as { transport: Record<string, unknown> };
+    expect(tracing.transport).toEqual({ value: "native", source: "env", invalid: "jaeger" });
+    expect(report.verdict).toBe("warn");
+    expect(
+      report.reasons.some((r) => r.includes('Unrecognized EVAL_TRACE_TRANSPORT="jaeger"')),
+    ).toBe(true);
+  });
+
+  it("only reports LangSmith export as on under the otel transport", async () => {
+    const entryDir = makeTempEntryDir();
+    process.env.LANGSMITH_API_KEY = "ls";
+    process.env.LANGSMITH_TRACING = "true";
+    let { report } = await runDoctorJson(entryDir);
+    expect((report.tracing as { langsmithEnabled: boolean }).langsmithEnabled).toBe(false);
+
+    process.env.EVAL_TRACE_TRANSPORT = "otel";
+    ({ report } = await runDoctorJson(entryDir));
+    expect((report.tracing as { langsmithEnabled: boolean }).langsmithEnabled).toBe(true);
+  });
+
   it("warns when otel is selected but no sink is configured", async () => {
     const entryDir = makeTempEntryDir();
     process.env.OPENAI_API_KEY = "sk-test";

--- a/packages/evals/tests/tui/parse.test.ts
+++ b/packages/evals/tests/tui/parse.test.ts
@@ -106,3 +106,38 @@ describe("withEnvOverrides", () => {
     expect(process.env.EVAL_TRAJECTORY_GROUP).toBe("pre-existing");
   });
 });
+
+describe("resolveRunOptions: tracing config → env overrides", () => {
+  it("applies persisted tracing defaults as env overrides when env is unset", () => {
+    const resolved = resolveRunOptions(
+      {},
+      {},
+      {},
+      {},
+      { transport: "otel", braintrustProject: "team-evals", langsmithProject: "ls-proj" },
+    );
+    expect(resolved.envOverrides.EVAL_TRACE_TRANSPORT).toBe("otel");
+    expect(resolved.envOverrides.BRAINTRUST_PROJECT_NAME).toBe("team-evals");
+    expect(resolved.envOverrides.LANGSMITH_PROJECT).toBe("ls-proj");
+  });
+
+  it("lets an already-set env var win over the persisted default", () => {
+    const resolved = resolveRunOptions(
+      {},
+      {},
+      { EVAL_TRACE_TRANSPORT: "native", BRAINTRUST_PROJECT_NAME: "from-env" },
+      {},
+      { transport: "otel", braintrustProject: "from-config", langsmithProject: "ls-proj" },
+    );
+    expect(resolved.envOverrides.EVAL_TRACE_TRANSPORT).toBeUndefined();
+    expect(resolved.envOverrides.BRAINTRUST_PROJECT_NAME).toBeUndefined();
+    expect(resolved.envOverrides.LANGSMITH_PROJECT).toBe("ls-proj");
+  });
+
+  it("emits no tracing overrides when the section is absent", () => {
+    const resolved = resolveRunOptions({}, {}, {});
+    expect(resolved.envOverrides.EVAL_TRACE_TRANSPORT).toBeUndefined();
+    expect(resolved.envOverrides.BRAINTRUST_PROJECT_NAME).toBeUndefined();
+    expect(resolved.envOverrides.LANGSMITH_PROJECT).toBeUndefined();
+  });
+});

--- a/packages/evals/tests/tui/tracing.test.ts
+++ b/packages/evals/tests/tui/tracing.test.ts
@@ -1,0 +1,130 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { readConfig, TRACING_ENV_VARS } from "../../tui/commands/config.js";
+import { handleTracing, resolveTracingValue } from "../../tui/commands/tracing.js";
+
+const tempDirs: string[] = [];
+const savedEnv: Record<string, string | undefined> = {};
+
+function makeTempEntryDir(tracing?: Record<string, unknown>): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "evals-tracing-"));
+  tempDirs.push(dir);
+  fs.writeFileSync(
+    path.join(dir, "evals.config.json"),
+    JSON.stringify({ defaults: {}, benchmarks: {}, ...(tracing ? { tracing } : {}) }, null, 2),
+  );
+  return dir;
+}
+
+beforeEach(() => {
+  for (const name of Object.values(TRACING_ENV_VARS)) {
+    savedEnv[name] = process.env[name];
+    delete process.env[name];
+  }
+  process.exitCode = undefined;
+});
+
+afterEach(() => {
+  for (const [name, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+  process.exitCode = undefined;
+  vi.restoreAllMocks();
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("config tracing set/reset", () => {
+  it("persists transport, braintrustProject and langsmithProject", async () => {
+    const entryDir = makeTempEntryDir();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await handleTracing(["set", "transport", "OTEL"], entryDir);
+    await handleTracing(["set", "braintrustProject", "team-evals"], entryDir);
+    await handleTracing(["set", "langsmithProject", "ls-proj"], entryDir);
+
+    expect(readConfig(entryDir).tracing).toEqual({
+      transport: "otel",
+      braintrustProject: "team-evals",
+      langsmithProject: "ls-proj",
+    });
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("rejects an invalid transport and unknown keys without writing", async () => {
+    const entryDir = makeTempEntryDir();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await handleTracing(["set", "transport", "jaeger"], entryDir);
+    await handleTracing(["set", "apiKey", "sk-nope"], entryDir);
+
+    expect(readConfig(entryDir).tracing).toBeUndefined();
+    expect(error).toHaveBeenCalledTimes(2);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("reset <key> prunes the key and reset with no key drops the section", async () => {
+    const entryDir = makeTempEntryDir({ transport: "otel", braintrustProject: "x" });
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await handleTracing(["reset", "braintrustProject"], entryDir);
+    expect(readConfig(entryDir).tracing).toEqual({ transport: "otel" });
+
+    await handleTracing(["reset"], entryDir);
+    expect(readConfig(entryDir).tracing).toBeUndefined();
+    expect(fs.readFileSync(path.join(entryDir, "evals.config.json"), "utf-8")).not.toContain(
+      "tracing",
+    );
+  });
+
+  it("does not touch other config sections", async () => {
+    const entryDir = makeTempEntryDir();
+    fs.writeFileSync(
+      path.join(entryDir, "evals.config.json"),
+      JSON.stringify({ defaults: { trials: 7 }, benchmarks: {}, core: { tool: "cdp_code" } }),
+    );
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await handleTracing(["set", "transport", "otel"], entryDir);
+
+    const config = readConfig(entryDir);
+    expect(config.defaults).toEqual({ trials: 7 });
+    expect(config.core).toEqual({ tool: "cdp_code" });
+  });
+});
+
+describe("resolveTracingValue", () => {
+  it("prefers env over config over nothing", () => {
+    const tracing = { transport: "otel" as const, braintrustProject: "cfg" };
+    expect(resolveTracingValue("transport", tracing, { EVAL_TRACE_TRANSPORT: "native" })).toEqual({
+      value: "native",
+      source: "env",
+    });
+    expect(resolveTracingValue("braintrustProject", tracing, {})).toEqual({
+      value: "cfg",
+      source: "config",
+    });
+    expect(resolveTracingValue("langsmithProject", tracing, {})).toEqual({
+      value: undefined,
+      source: "none",
+    });
+  });
+
+  it("treats a blank env var as unset", () => {
+    expect(
+      resolveTracingValue(
+        "braintrustProject",
+        { braintrustProject: "cfg" },
+        {
+          BRAINTRUST_PROJECT_NAME: "   ",
+        },
+      ),
+    ).toEqual({ value: "cfg", source: "config" });
+  });
+});

--- a/packages/evals/tui/commandTree.ts
+++ b/packages/evals/tui/commandTree.ts
@@ -378,7 +378,13 @@ export function buildCommandTree(): CommandNode {
 
       const flags = parseRunArgs(args);
       const configFile = readConfig(ctx.entryDir);
-      const resolved = resolveRunOptions(flags, configFile.defaults, process.env, configFile.core);
+      const resolved = resolveRunOptions(
+        flags,
+        configFile.defaults,
+        process.env,
+        configFile.core,
+        configFile.tracing,
+      );
 
       if (ctx.abortRef === null) {
         await runCommand(resolved);
@@ -482,6 +488,45 @@ export function buildCommandTree(): CommandNode {
     children: [configCorePath, configCoreSet, configCoreReset, configCoreSetup],
   };
 
+  const printConfigTracingHelpThunk = async () => (await help()).printConfigTracingHelp();
+  const configTracingPath: CommandNode = {
+    name: "path",
+    summary: "Print the config file path",
+    printHelp: printConfigTracingHelpThunk,
+    handler: async (_args, ctx) => {
+      const { handleTracing } = await import("./commands/tracing.js");
+      await handleTracing(["path"], ctx.entryDir);
+    },
+  };
+  const configTracingSet: CommandNode = {
+    name: "set",
+    summary: "Set transport / braintrustProject / langsmithProject",
+    printHelp: printConfigTracingHelpThunk,
+    handler: async (args, ctx) => {
+      const { handleTracing } = await import("./commands/tracing.js");
+      await handleTracing(["set", ...args], ctx.entryDir);
+    },
+  };
+  const configTracingReset: CommandNode = {
+    name: "reset",
+    summary: "Reset tracing configuration",
+    printHelp: printConfigTracingHelpThunk,
+    handler: async (args, ctx) => {
+      const { handleTracing } = await import("./commands/tracing.js");
+      await handleTracing(["reset", ...args], ctx.entryDir);
+    },
+  };
+  const configTracing: CommandNode = {
+    name: "tracing",
+    summary: "Configure trace transport + sink projects",
+    printHelp: printConfigTracingHelpThunk,
+    handler: async (args, ctx) => {
+      const { handleTracing } = await import("./commands/tracing.js");
+      await handleTracing(args, ctx.entryDir);
+    },
+    children: [configTracingPath, configTracingSet, configTracingReset],
+  };
+
   const configPath: CommandNode = {
     name: "path",
     summary: "Print the evals.config.json file path",
@@ -515,7 +560,7 @@ export function buildCommandTree(): CommandNode {
     summary: "Get/set default run configuration",
     printHelp: async () => (await help()).printConfigHelp(),
     handler: async (args, ctx) => {
-      // matchPath strips known children (path/set/reset/core) before
+      // matchPath strips known children (path/set/reset/core/tracing) before
       // we get here, so any args remaining are unknown subcommands —
       // delegate to handleConfig which prints the right error.
       const { handleConfig, printConfig } = await import("./commands/config.js");
@@ -525,7 +570,7 @@ export function buildCommandTree(): CommandNode {
       }
       await handleConfig(args, ctx.entryDir);
     },
-    children: [configPath, configSet, configReset, configCore],
+    children: [configPath, configSet, configReset, configCore, configTracing],
   };
 
   // ---- experiments (pure namespace) ----

--- a/packages/evals/tui/commands/config.ts
+++ b/packages/evals/tui/commands/config.ts
@@ -45,10 +45,34 @@ export type WelcomeMeta = {
   version?: number;
 };
 
+/**
+ * Trace sink configuration. Every key maps 1:1 to an env var, and the env var
+ * always wins — this section is a persisted default for users who don't want
+ * to export vars per shell. Owned by tui/commands/tracing.ts.
+ *
+ *   transport         → EVAL_TRACE_TRANSPORT   ("native" | "otel")
+ *   braintrustProject → BRAINTRUST_PROJECT_NAME (both transports)
+ *   langsmithProject  → LANGSMITH_PROJECT       (otel transport only)
+ */
+export type TracingConfigSection = {
+  transport?: TraceTransport;
+  braintrustProject?: string;
+  langsmithProject?: string;
+};
+
+export type TraceTransport = "native" | "otel";
+
+export const TRACING_ENV_VARS: Record<keyof TracingConfigSection, string> = {
+  transport: "EVAL_TRACE_TRANSPORT",
+  braintrustProject: "BRAINTRUST_PROJECT_NAME",
+  langsmithProject: "LANGSMITH_PROJECT",
+};
+
 export type ConfigFile = {
   defaults: Defaults;
   benchmarks?: Record<string, unknown>;
   core?: CoreConfigSection;
+  tracing?: TracingConfigSection;
   _meta?: WelcomeMeta;
 };
 
@@ -82,6 +106,7 @@ export function readConfig(entryDir: string): ConfigFile {
       defaults: raw.defaults ?? {},
       benchmarks: raw.benchmarks ?? {},
       core: raw.core ?? undefined,
+      tracing: raw.tracing ?? undefined,
       _meta: raw._meta ?? undefined,
     };
   } catch (error) {
@@ -128,6 +153,9 @@ export function printConfig(entryDir: string): void {
   if (env.USE_API) overrides.push(`USE_API=${env.USE_API}`);
   if (env.STAGEHAND_BROWSER_TARGET)
     overrides.push(`STAGEHAND_BROWSER_TARGET=${env.STAGEHAND_BROWSER_TARGET}`);
+  for (const name of Object.values(TRACING_ENV_VARS)) {
+    if (env[name]) overrides.push(`${name}=${env[name]}`);
+  }
 
   if (overrides.length > 0) {
     console.log(`\n    ${dim("Env overrides:")}`);
@@ -156,6 +184,12 @@ export async function handleConfig(args: string[], entryDir: string): Promise<vo
   if (sub === "core") {
     const { handleCore } = await import("./core.js");
     await handleCore(args.slice(1), entryDir);
+    return;
+  }
+
+  if (sub === "tracing") {
+    const { handleTracing } = await import("./tracing.js");
+    await handleTracing(args.slice(1), entryDir);
     return;
   }
 
@@ -222,7 +256,7 @@ export async function handleConfig(args: string[], entryDir: string): Promise<vo
   }
 
   console.error(red(`  Unknown config subcommand "${sub}"`));
-  console.log(dim("  Usage: config [set <key> <value> | reset [key] | path]"));
+  console.log(dim("  Usage: config [set <key> <value> | reset [key] | path | core | tracing]"));
   process.exitCode = 1;
 }
 

--- a/packages/evals/tui/commands/doctor.ts
+++ b/packages/evals/tui/commands/doctor.ts
@@ -23,7 +23,9 @@
 import fs from "node:fs";
 import path from "node:path";
 import { bold, cyan, dim, gray, green, red, yellow, padRight } from "../format.js";
-import { readConfig, resolveConfigPath } from "./config.js";
+import { readConfig, resolveConfigPath, type TracingConfigSection } from "./config.js";
+import { resolveTracingValue } from "./tracing.js";
+import { langSmithTracingEnabled } from "../../framework/langsmith.js";
 import { resolveKey, snapshotEnv, type EnvSnapshot } from "../welcomeStatus.js";
 import { getPackageRootDir, getRuntimeTasksRoot } from "../../runtimePaths.js";
 import { discoverTasks } from "../../framework/discovery.js";
@@ -45,6 +47,16 @@ type ConfigSummary = {
   core: { tool: string | null; startup: string | null };
 };
 
+type TracingValue = { value: string | null; source: "env" | "config" | "none" };
+
+/** Effective trace-sink settings (env > evals.config.json `tracing` > none). */
+type TracingSummary = {
+  transport: TracingValue;
+  braintrustProject: TracingValue;
+  langsmithProject: TracingValue;
+  langsmithEnabled: boolean;
+};
+
 type DiscoverySummary = {
   ok: boolean;
   total: number;
@@ -59,6 +71,7 @@ type DoctorReport = {
   runtime: RuntimeInfo;
   config: ConfigSummary;
   discovery: DiscoverySummary;
+  tracing: TracingSummary;
   keys: EnvSnapshot;
   reasons: string[];
 };
@@ -137,6 +150,25 @@ function summarizeConfig(entryDir: string): ConfigSummary {
     trials,
     concurrency,
     core: { tool: coreTool, startup: coreStartup },
+  };
+}
+
+function summarizeTracing(entryDir: string): TracingSummary {
+  let tracing: TracingConfigSection | undefined;
+  try {
+    tracing = readConfig(entryDir).tracing;
+  } catch {
+    // Missing/invalid config is reported under Config; fall through to env-only.
+  }
+  const pick = (key: keyof TracingConfigSection): TracingValue => {
+    const r = resolveTracingValue(key, tracing);
+    return { value: r.value ?? null, source: r.source };
+  };
+  return {
+    transport: pick("transport"),
+    braintrustProject: pick("braintrustProject"),
+    langsmithProject: pick("langsmithProject"),
+    langsmithEnabled: langSmithTracingEnabled(),
   };
 }
 
@@ -223,10 +255,23 @@ async function buildReport(entryDir: string): Promise<DoctorReport> {
     mode: detectMode(entryDir),
   };
   const config = summarizeConfig(entryDir);
+  const tracing = summarizeTracing(entryDir);
   const discovery = await summarizeDiscovery();
   const keys = snapshotEnv();
-  const { verdict, reasons } = computeVerdict(keys, config, discovery);
-  return { verdict, runtime, config, discovery, keys, reasons };
+  const computed = computeVerdict(keys, config, discovery);
+  let verdict = computed.verdict;
+  const reasons = [...computed.reasons];
+  if (
+    tracing.transport.value === "otel" &&
+    keys.braintrust.state === "missing" &&
+    !tracing.langsmithEnabled
+  ) {
+    if (verdict === "ok") verdict = "warn";
+    reasons.push(
+      "EVAL_TRACE_TRANSPORT=otel but no sink is configured — set BRAINTRUST_API_KEY and/or LANGSMITH_API_KEY + LANGSMITH_TRACING=true.",
+    );
+  }
+  return { verdict, runtime, config, tracing, discovery, keys, reasons };
 }
 
 // ---------------------------------------------------------------------------
@@ -244,6 +289,11 @@ function keyRow(
       : red("✗ missing");
   const suffix = note ? `        ${dim(note)}` : "";
   return `    ${padRight(label, 30)} ${value}${suffix}`;
+}
+
+function tracingCell(v: TracingValue, fallback: string): string {
+  if (v.value === null) return gray(`(default: ${fallback})`);
+  return `${cyan(v.value)}  ${dim(`(${v.source})`)}`;
 }
 
 function renderHuman(report: DoctorReport): void {
@@ -273,6 +323,16 @@ function renderHuman(report: DoctorReport): void {
   if (r.config.core.startup) {
     console.log(`    ${padRight("core.startup", 22)} ${cyan(r.config.core.startup)}`);
   }
+  console.log("");
+
+  console.log(`  ${bold("Tracing")}`);
+  console.log(`    ${padRight("transport", 22)} ${tracingCell(r.tracing.transport, "native")}`);
+  console.log(
+    `    ${padRight("braintrust project", 22)} ${tracingCell(r.tracing.braintrustProject, "stagehand[-core][-dev]")}`,
+  );
+  console.log(
+    `    ${padRight("langsmith project", 22)} ${tracingCell(r.tracing.langsmithProject, "workspace default")}  ${dim(r.tracing.langsmithEnabled ? "(export on)" : "(export off)")}`,
+  );
   console.log("");
 
   console.log(`  ${bold("Discovery")}`);
@@ -341,6 +401,7 @@ function renderJson(report: DoctorReport): void {
     verdict: report.verdict,
     runtime: report.runtime,
     config: report.config,
+    tracing: report.tracing,
     discovery: {
       ok: report.discovery.ok,
       total: report.discovery.total,

--- a/packages/evals/tui/commands/doctor.ts
+++ b/packages/evals/tui/commands/doctor.ts
@@ -25,7 +25,6 @@ import path from "node:path";
 import { bold, cyan, dim, gray, green, red, yellow, padRight } from "../format.js";
 import { readConfig, resolveConfigPath, type TracingConfigSection } from "./config.js";
 import { resolveTracingValue } from "./tracing.js";
-import { langSmithTracingEnabled } from "../../framework/langsmith.js";
 import { resolveKey, snapshotEnv, type EnvSnapshot } from "../welcomeStatus.js";
 import { getPackageRootDir, getRuntimeTasksRoot } from "../../runtimePaths.js";
 import { discoverTasks } from "../../framework/discovery.js";
@@ -47,13 +46,19 @@ type ConfigSummary = {
   core: { tool: string | null; startup: string | null };
 };
 
-type TracingValue = { value: string | null; source: "env" | "config" | "none" };
+type TracingValue = {
+  value: string | null;
+  source: "env" | "config" | "none";
+  /** Set when the configured value was unrecognized and `value` is the runtime fallback. */
+  invalid?: string;
+};
 
 /** Effective trace-sink settings (env > evals.config.json `tracing` > none). */
 type TracingSummary = {
   transport: TracingValue;
   braintrustProject: TracingValue;
   langsmithProject: TracingValue;
+  /** LangSmith export will actually happen: otel transport + key + LANGSMITH_TRACING=true. */
   langsmithEnabled: boolean;
 };
 
@@ -153,7 +158,7 @@ function summarizeConfig(entryDir: string): ConfigSummary {
   };
 }
 
-function summarizeTracing(entryDir: string): TracingSummary {
+function summarizeTracing(entryDir: string, keys: EnvSnapshot): TracingSummary {
   let tracing: TracingConfigSection | undefined;
   try {
     tracing = readConfig(entryDir).tracing;
@@ -164,11 +169,24 @@ function summarizeTracing(entryDir: string): TracingSummary {
     const r = resolveTracingValue(key, tracing);
     return { value: r.value ?? null, source: r.source };
   };
+  // Mirror resolveTraceTransport(): anything other than "otel" runs native, so
+  // report the fallback rather than echoing a typo as if it were effective.
+  const transport = pick("transport");
+  if (transport.value !== null && transport.value !== "otel" && transport.value !== "native") {
+    transport.invalid = transport.value;
+    transport.value = "native";
+  }
+  // Same process.env + packages/evals/.env resolution as the Keys block, so the
+  // two sections cannot disagree about whether a LangSmith key exists.
+  const langsmithEnabled =
+    transport.value === "otel" &&
+    keys.langsmith.state === "set" &&
+    resolveKey("LANGSMITH_TRACING").value === "true";
   return {
-    transport: pick("transport"),
+    transport,
     braintrustProject: pick("braintrustProject"),
     langsmithProject: pick("langsmithProject"),
-    langsmithEnabled: langSmithTracingEnabled(),
+    langsmithEnabled,
   };
 }
 
@@ -255,12 +273,18 @@ async function buildReport(entryDir: string): Promise<DoctorReport> {
     mode: detectMode(entryDir),
   };
   const config = summarizeConfig(entryDir);
-  const tracing = summarizeTracing(entryDir);
-  const discovery = await summarizeDiscovery();
   const keys = snapshotEnv();
+  const tracing = summarizeTracing(entryDir, keys);
+  const discovery = await summarizeDiscovery();
   const computed = computeVerdict(keys, config, discovery);
   let verdict = computed.verdict;
   const reasons = [...computed.reasons];
+  if (tracing.transport.invalid) {
+    if (verdict === "ok") verdict = "warn";
+    reasons.push(
+      `Unrecognized EVAL_TRACE_TRANSPORT="${tracing.transport.invalid}" (expected "native" or "otel") — the runner falls back to native.`,
+    );
+  }
   if (
     tracing.transport.value === "otel" &&
     keys.braintrust.state === "missing" &&
@@ -293,6 +317,8 @@ function keyRow(
 
 function tracingCell(v: TracingValue, fallback: string): string {
   if (v.value === null) return gray(`(default: ${fallback})`);
+  if (v.invalid)
+    return `${cyan(v.value)}  ${yellow(`(fallback — ignored invalid "${v.invalid}" from ${v.source})`)}`;
   return `${cyan(v.value)}  ${dim(`(${v.source})`)}`;
 }
 

--- a/packages/evals/tui/commands/help.ts
+++ b/packages/evals/tui/commands/help.ts
@@ -160,6 +160,7 @@ export function printConfigHelp(): void {
     ),
     row(`${cyan("reset")} ${dim("[key]")}`, "Reset one key or all defaults"),
     row(`${cyan("core")} ${dim("[...]")}`, "Configure core tier tool + startup defaults"),
+    row(`${cyan("tracing")} ${dim("[...]")}`, "Configure trace transport + sink projects"),
     "",
     `  ${bold("Core subcommands:")} ${dim("(under `evals config core`)")}`,
     "",
@@ -179,6 +180,7 @@ export function printConfigHelp(): void {
     `    ${dim("$")} evals config set trials 5`,
     `    ${dim("$")} evals config core set tool understudy_code`,
     `    ${dim("$")} evals config core set startup tool_launch_local`,
+    `    ${dim("$")} evals config tracing set transport otel`,
     `    ${dim("$")} evals config core reset`,
     "",
   ]);
@@ -315,6 +317,46 @@ export function printExperimentsHelp(subcommand?: "list" | "show" | "open" | "co
     `    ${dim("$")} evals experiments show observe-90b34916`,
     `    ${dim("$")} evals experiments open extract-a12c91de`,
     `    ${dim("$")} evals experiments compare exp1 exp2 --project stagehand-core-dev`,
+    "",
+  ]);
+}
+
+export function printConfigTracingHelp(): void {
+  print([
+    "",
+    `  ${dustyCyanHeader("evals config tracing")} ${dim("[subcommand]")}`,
+    "",
+    "  Persisted defaults for the trace transport and where traces land.",
+    `  Each key backs one env var; the env var always wins when set.`,
+    "",
+    `  ${bold("Subcommands:")}`,
+    "",
+    row(dim("(none)"), "Print current tracing configuration"),
+    row(cyan("path"), "Print the config file path"),
+    row(`${cyan("set")} ${dim("<key> <value>")}`, "Set one key (see below)"),
+    row(`${cyan("reset")} ${dim("[key]")}`, "Reset one key or the whole tracing section"),
+    "",
+    `  ${bold("Keys:")}`,
+    "",
+    row(
+      `${cyan("transport")} ${dim("native|otel")}`,
+      `${gray("EVAL_TRACE_TRANSPORT")} — otel fans out to Braintrust + LangSmith`,
+    ),
+    row(
+      `${cyan("braintrustProject")} ${dim("<name>")}`,
+      `${gray("BRAINTRUST_PROJECT_NAME")} — both transports; default stagehand[-core][-dev]`,
+    ),
+    row(
+      `${cyan("langsmithProject")} ${dim("<name>")}`,
+      `${gray("LANGSMITH_PROJECT")} — otel only; needs LANGSMITH_API_KEY + LANGSMITH_TRACING=true`,
+    ),
+    "",
+    `  ${bold("Examples:")}`,
+    "",
+    `    ${dim("$")} evals config tracing set transport otel`,
+    `    ${dim("$")} evals config tracing set braintrustProject my-team-evals`,
+    `    ${dim("$")} evals config tracing set langsmithProject stagehand-evals`,
+    `    ${dim("$")} evals config tracing reset`,
     "",
   ]);
 }

--- a/packages/evals/tui/commands/parse.ts
+++ b/packages/evals/tui/commands/parse.ts
@@ -18,6 +18,7 @@ import {
   parseBenchHarness,
   type Harness,
 } from "../../framework/benchTypes.js";
+import { TRACING_ENV_VARS } from "./config.js";
 
 export interface RunFlags {
   target?: string;
@@ -323,11 +324,19 @@ export interface CoreConfig {
   startup?: string;
 }
 
+/** Persisted trace-sink defaults (evals.config.json `tracing`). Env wins. */
+export interface TracingConfig {
+  transport?: string;
+  braintrustProject?: string;
+  langsmithProject?: string;
+}
+
 export function resolveRunOptions(
   flags: RunFlags,
   defaults: ConfigDefaults,
   env: NodeJS.ProcessEnv,
   core: CoreConfig = {},
+  tracing: TracingConfig = {},
 ): ResolvedRunOptions {
   const parseIntEnv = (value: string | undefined): number | undefined => {
     if (!value) return undefined;
@@ -360,6 +369,14 @@ export function resolveRunOptions(
 
   const datasetFilter = shorthandDatasetFilter ?? env.EVAL_DATASET ?? undefined;
   const harness = parseBenchHarness(flags.harness ?? DEFAULT_BENCH_HARNESS);
+
+  // Trace-sink defaults from config are applied as env overrides only when the
+  // corresponding env var is unset, so a shell export or CI secret always wins.
+  for (const key of Object.keys(TRACING_ENV_VARS) as Array<keyof TracingConfig>) {
+    const value = tracing[key]?.trim();
+    const envName = TRACING_ENV_VARS[key];
+    if (value && !env[envName]?.trim()) envOverrides[envName] = value;
+  }
 
   envOverrides.EVAL_ENV = environment;
   envOverrides.USE_API = String(Boolean(useApi));

--- a/packages/evals/tui/commands/tracing.ts
+++ b/packages/evals/tui/commands/tracing.ts
@@ -1,0 +1,204 @@
+/**
+ * `evals config tracing` — persisted defaults for the trace transport and
+ * its sinks. Namespaced under `config` so it lives beside run defaults.
+ *
+ * Subcommands (what this module sees after `config tracing` is stripped):
+ *   (none)                print current tracing section + effective values
+ *   path                  print the config file path
+ *   set <k> <v>           set transport | braintrustProject | langsmithProject
+ *   reset [key]           reset one key or the whole tracing section
+ *
+ * Each key is a default for one env var (see TRACING_ENV_VARS). The env var
+ * always wins, so a shell export or CI secret overrides whatever is stored
+ * here. Credentials (API keys) are never stored in config — they stay in
+ * .env / the shell, surfaced by `evals doctor`.
+ */
+
+import { bold, cyan, dim, gray, green, red } from "../format.js";
+import {
+  readConfig,
+  writeConfig,
+  resolveConfigPath,
+  TRACING_ENV_VARS,
+  type TraceTransport,
+  type TracingConfigSection,
+} from "./config.js";
+
+type TracingKey = keyof TracingConfigSection;
+const VALID_KEYS: TracingKey[] = ["transport", "braintrustProject", "langsmithProject"];
+const TRANSPORTS: TraceTransport[] = ["native", "otel"];
+
+export async function handleTracing(args: string[], entryDir: string): Promise<void> {
+  const sub = args[0];
+
+  if (!sub) {
+    printTracingConfig(entryDir);
+    return;
+  }
+
+  if (sub === "help" || sub === "-h" || sub === "--help") {
+    const { printConfigTracingHelp } = await import("./help.js");
+    printConfigTracingHelp();
+    return;
+  }
+
+  // Per-sub help. Only intercepted at args[1] (immediately after the verb)
+  // so leaf values like `set transport --help` aren't swallowed as help.
+  if (args[1] === "--help" || args[1] === "-h" || args[1] === "help") {
+    const { printConfigTracingHelp } = await import("./help.js");
+    printConfigTracingHelp();
+    return;
+  }
+
+  if (sub === "path") {
+    console.log(resolveConfigPath(entryDir));
+    return;
+  }
+
+  if (sub === "set") {
+    if (args.length < 3) {
+      console.error(
+        red("  Usage: config tracing set <transport|braintrustProject|langsmithProject> <value>"),
+      );
+      process.exitCode = 1;
+      return;
+    }
+    setTracingKey(entryDir, args[1] as TracingKey, args.slice(2).join(" "));
+    return;
+  }
+
+  if (sub === "reset") {
+    resetTracingKey(entryDir, args[1] as TracingKey | undefined);
+    return;
+  }
+
+  console.error(red(`  Unknown "config tracing" subcommand "${sub}"`));
+  console.log(dim("  Usage: config tracing [set <k> <v>|reset [key]|path]"));
+  process.exitCode = 1;
+}
+
+/**
+ * Effective value for one tracing key: env var if set, else the persisted
+ * config value, else undefined. Exported so `doctor` reports the same
+ * resolution the runner sees.
+ */
+export function resolveTracingValue(
+  key: TracingKey,
+  tracing: TracingConfigSection | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): { value: string | undefined; source: "env" | "config" | "none" } {
+  const fromEnv = env[TRACING_ENV_VARS[key]]?.trim();
+  if (fromEnv) return { value: fromEnv, source: "env" };
+  const fromConfig = tracing?.[key];
+  if (fromConfig) return { value: fromConfig, source: "config" };
+  return { value: undefined, source: "none" };
+}
+
+export function printTracingConfig(entryDir: string): void {
+  const config = readConfig(entryDir);
+  const tracing = config.tracing ?? {};
+
+  console.log(`\n  ${bold("Tracing configuration:")}\n`);
+  for (const key of VALID_KEYS) {
+    const stored = tracing[key];
+    const effective = resolveTracingValue(key, tracing);
+    const label = key.padEnd(18);
+    const shown = stored ?? gray(defaultHint(key));
+    const envNote =
+      effective.source === "env"
+        ? dim(`  (overridden by ${TRACING_ENV_VARS[key]}=${effective.value})`)
+        : "";
+    console.log(`    ${cyan(label)} ${shown}${envNote}`);
+  }
+  console.log("");
+  console.log(
+    dim(`  Env vars win over these defaults: ${Object.values(TRACING_ENV_VARS).join(", ")}`),
+  );
+  console.log(dim(`  Config file: ${resolveConfigPath(entryDir)}`));
+  console.log("");
+}
+
+function defaultHint(key: TracingKey): string {
+  switch (key) {
+    case "transport":
+      return "(default: native)";
+    case "braintrustProject":
+      return "(default: stagehand[-core][-dev] by tier/CI)";
+    case "langsmithProject":
+      return "(default: LangSmith workspace default)";
+  }
+}
+
+function setTracingKey(entryDir: string, key: TracingKey, value: string): void {
+  if (!VALID_KEYS.includes(key)) {
+    console.error(red(`  Unknown tracing key "${key}"`));
+    console.log(dim(`  Valid keys: ${VALID_KEYS.join(", ")}`));
+    process.exitCode = 1;
+    return;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    console.error(
+      red(`  ${key} cannot be empty — use \`config tracing reset ${key}\` to clear it.`),
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const config = readConfig(entryDir);
+  const tracing: TracingConfigSection = { ...config.tracing };
+
+  if (key === "transport") {
+    const normalized = trimmed.toLowerCase() as TraceTransport;
+    if (!TRANSPORTS.includes(normalized)) {
+      console.error(red(`  transport must be one of: ${TRANSPORTS.join(", ")}`));
+      process.exitCode = 1;
+      return;
+    }
+    tracing.transport = normalized;
+  } else {
+    tracing[key] = trimmed;
+  }
+
+  config.tracing = pruneTracing(tracing);
+  writeConfig(entryDir, config);
+  console.log(green(`  ✓ Set tracing.${key} to ${tracing[key]}`));
+  const env = process.env[TRACING_ENV_VARS[key]];
+  if (env) {
+    console.log(
+      dim(`  Note: ${TRACING_ENV_VARS[key]}=${env} is set in this shell and will take precedence.`),
+    );
+  }
+}
+
+function resetTracingKey(entryDir: string, key: TracingKey | undefined): void {
+  const config = readConfig(entryDir);
+
+  if (!key) {
+    config.tracing = undefined;
+    writeConfig(entryDir, config);
+    console.log(green("  ✓ Reset tracing configuration"));
+    return;
+  }
+
+  if (!VALID_KEYS.includes(key)) {
+    console.error(red(`  Unknown tracing key "${key}"`));
+    process.exitCode = 1;
+    return;
+  }
+
+  const tracing: TracingConfigSection = { ...config.tracing };
+  tracing[key] = undefined;
+  config.tracing = pruneTracing(tracing);
+  writeConfig(entryDir, config);
+  console.log(green(`  ✓ Reset tracing.${key}`));
+}
+
+function pruneTracing(tracing: TracingConfigSection): TracingConfigSection | undefined {
+  const pruned: TracingConfigSection = {};
+  if (tracing.transport) pruned.transport = tracing.transport;
+  if (tracing.braintrustProject) pruned.braintrustProject = tracing.braintrustProject;
+  if (tracing.langsmithProject) pruned.langsmithProject = tracing.langsmithProject;
+  return Object.keys(pruned).length > 0 ? pruned : undefined;
+}


### PR DESCRIPTION
# why

Follow-up to @akeimach's comment on #2758 (https://github.com/browserbase/stagehand/pull/2758#discussion_r3847215967): the OTEL transport hardcoded the Braintrust project to `stagehand[-core][-dev]` and offered no way to pick a LangSmith project short of editing code. #2758 shipped the precedence fix for `BRAINTRUST_OTEL_PARENT`; this PR adds proper sink configurability via env vars and the TUI.

# what changed

<img width="1600" height="842" alt="image" src="https://github.com/user-attachments/assets/768910f8-6aef-4046-9291-00871b410854" />


**Shared resolver** — `resolveBraintrustProjectName(tier)` in `framework/braintrust.ts` centralizes the tier × CI project matrix and honors `BRAINTRUST_PROJECT_NAME`. `runner.ts` (native `Eval(...)`, otel parent, summary) and `otel.ts` (fallback parent) both use it, removing otel.ts's duplicated default. Parent precedence stays `BRAINTRUST_OTEL_PARENT` > runner-computed > `project_name:<resolved>`.

**`evals config tracing`** — new `tracing` section in `evals.config.json` with `set <key> <value>` / `reset [key]` / `path`. Each key is a persisted default for exactly one env var, and the env var always wins:

| key | env var | applies to |
|---|---|---|
| `transport` (`native` \| `otel`) | `EVAL_TRACE_TRANSPORT` | — |
| `braintrustProject` | `BRAINTRUST_PROJECT_NAME` | both transports |
| `langsmithProject` | `LANGSMITH_PROJECT` | otel only (read natively by the LangSmith exporter) |

`resolveRunOptions` turns the config section into env overrides only when the env var is unset. API keys are never stored in config.

**`evals doctor`** — new Tracing block (human + `--json`) showing the effective transport / braintrust project / langsmith project with its source (`env` / `config` / `none`) and whether LangSmith export is on. Verdict bumps to `warn` when `EVAL_TRACE_TRANSPORT=otel` but no sink is configured.

**Docs** — `.env.example` documents `BRAINTRUST_PROJECT_NAME`, `BRAINTRUST_OTEL_PARENT`, `LANGSMITH_PROJECT`; `evals config tracing help` added.

No changeset: `@browserbasehq/stagehand-evals` is in the changeset `ignore` list.

# test plan

- [x] `pnpm --filter @browserbasehq/stagehand-evals typecheck`, `oxlint`, `oxfmt --check`
- [x] `vitest run packages/evals/tests` — 56 files / 438 tests pass
  - `tests/framework/runner.test.ts`: `resolveBraintrustProjectName` matrix, override, blank override
  - `tests/tui/parse.test.ts`: tracing config → env overrides; env wins over config
  - `tests/tui/tracing.test.ts` (new): set/reset/invalid transport/unknown key, other sections untouched, `resolveTracingValue` precedence
  - `tests/tui/doctor.test.ts`: tracing block in `--json`, env-over-config, no-sink warning
- [ ] Manual: `evals config tracing set braintrustProject <proj>` then `EVAL_TRACE_TRANSPORT=otel evals run ...` lands the experiment in `<proj>`; `BRAINTRUST_PROJECT_NAME=other` in the shell overrides it

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configures trace sinks for eval runs via env and `evals config tracing`, unifies Braintrust project resolution, and upgrades `evals doctor` to show effective tracing and warn on misconfigurations. Previously OTEL hardcoded Braintrust projects; now users can set projects without code changes.

- Centralizes Braintrust project selection in `resolveBraintrustProjectName(tier)`. It honors `BRAINTRUST_PROJECT_NAME` and defaults to stagehand[-core][-dev] by tier/CI; both the runner and OTEL use it. Parent precedence stays: `BRAINTRUST_OTEL_PARENT` > runner-computed > `project_name:<resolved>`.
- Adds `evals config tracing` with `set <key> <value>`, `reset [key]`, and `path`. Keys map 1:1 to env vars and env always wins:
  - `transport` → `EVAL_TRACE_TRANSPORT` (`native` | `otel`)
  - `braintrustProject` → `BRAINTRUST_PROJECT_NAME`
  - `langsmithProject` → `LANGSMITH_PROJECT` (OTEL only)
  `resolveRunOptions` applies these as env overrides only when the env var is unset. API keys are never stored in `evals.config.json`.
- `evals doctor` adds a Tracing block (human and `--json`) with value sources. It mirrors `resolveTraceTransport()` by treating an unrecognized `EVAL_TRACE_TRANSPORT` as a native fallback and warning, reports LangSmith export as on only under OTEL, and warns when `EVAL_TRACE_TRANSPORT=otel` but no sink is configured.
- `.env.example` documents `BRAINTRUST_PROJECT_NAME`, `BRAINTRUST_OTEL_PARENT`, and `LANGSMITH_PROJECT`. The build step preserves user-owned `core` and `tracing` sections when regenerating the built `evals.config.json`.

- Rollout: to use OTEL, set `EVAL_TRACE_TRANSPORT=otel` and configure a sink via `BRAINTRUST_API_KEY` or `LANGSMITH_API_KEY` with `LANGSMITH_TRACING=true`; optionally set `BRAINTRUST_PROJECT_NAME`/`LANGSMITH_PROJECT` or persist via `evals config tracing`.

<sup>Written for commit 0734457cb7581bf2e852fa5ba6757d340d82878e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

