### PR TITLE
fix(ci): scope Python release builds

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -63,7 +63,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: just build
+      # Build only the extension bundled into the Python package and the Python
+      # distributions. Alpha versioning temporarily changes other workspace
+      # packages, so the repository-wide build would validate unrelated SDK
+      # artifacts against those ephemeral versions.
+      - run: pnpm --filter ./packages/extension build
+      - run: uv --directory packages/sdk-python run --locked python scripts/build.py
 
       - name: Read package version
         id: package-version


### PR DESCRIPTION
# why

- Python alpha versioning temporarily snapshots every workspace package with pending changes, including the browser extension.
- The reusable Python publish job then ran the repository-wide just build recipe, which compared that temporary alpha extension against the checked-in stable Go embed and failed after the Python distributions had already built successfully.
- The parent release job already runs the full repository build and checks before either Python publish job starts.

# what changed

- Build the browser extension that is bundled into the Python distributions.
- Build the Python wheel and source distribution directly.
- Stop running unrelated Go artifact validation inside the reusable Python publish workflow.

# test plan

- Built @browserbasehq/stagehand-extension with pnpm 11.10.0.
- actionlint -ignore SC2046 .github/workflows/publish-python.yml
- ./node_modules/.bin/oxfmt --check .github/workflows/publish-python.yml
- Confirmed the failing release job completed the same Python build command successfully before the unrelated Go embed check failed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes the Python publish workflow to build only the Python package and its bundled browser extension. Previously it ran the repo-wide `just build`, which validated unrelated Go artifacts and failed under alpha versioning; now it builds the extension and Python distributions directly and drops Go validation from this job.

**Review notes**
- Builds only the bundled extension via `pnpm --filter ./packages/extension build` and the Python wheel/sdist via `uv --directory packages/sdk-python run --locked python scripts/build.py`.
- Removes the repo-wide `just build` and Go embed validation from the reusable Python publish job; the parent release job still runs full repo checks.
- Expected impact: avoids spurious failures when alpha snapshots touch `@browserbasehq/stagehand-extension` and speeds up Python publishes.

<sup>Written for commit 387cbf9ee9cf45e0c0f20aff01c0dae362aeb344. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

