### PR TITLE
fix(ci): sync Python protocol for alpha releases

### DIFF
--- a/justfile
+++ b/justfile
@@ -104,3 +104,4 @@ _version-python-alpha:
     pnpm exec changeset version --snapshot
     pnpm exec tsx scripts/release/python-alpha-version.ts
     uv --directory "{{python_dir}}" lock
+    uv --directory "{{python_dir}}" run --locked python scripts/generate.py


### PR DESCRIPTION
# why

- Snapshot versioning bumps the protocol package to a prerelease before building the Python alpha.
- The extension embeds that snapshot protocol version, but the Python wheel retained the checked-in stable generated version.
- Protocol prereleases require an exact match, so the wheel smoke test attached to the service worker but waited forever for a compatible runtime receiver.

# what changed

- Regenerate the Python protocol bindings after snapshot versioning and lockfile refresh.
- This keeps the Python client protocol marker identical to the snapshot-versioned extension bundled in the wheel.

# test plan

- Reproduced the mismatch: protocol package 2.0.0-alpha-a700208... versus generated Python 1.0.0.
- Ran the added generation step and confirmed both became 2.0.0-alpha-a700208....
- Built stagehand-4.0.3a0.dev1472 wheel and source distribution.
- Ran the installed-wheel Chrome smoke test successfully.
- Ran the source-distribution extension smoke assertion successfully.
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Regenerates Python protocol bindings after snapshot versioning in alpha release CI to keep the wheel’s protocol marker in sync with the snapshot-bundled extension. Previously the wheel kept a stable protocol version, causing prerelease mismatches and hanging smoke tests.

- **Review notes**
  - Adds to `_version-python-alpha` in `justfile`: `uv --directory "{{python_dir}}" run --locked python scripts/generate.py`.
  - Old behavior: snapshot bumped the extension to a prerelease, but Python bindings stayed stable. New behavior: regenerate bindings post-bump so wheel and extension share the same prerelease protocol.
  - Side effect: smoke tests attach and complete instead of waiting for a compatible runtime.

<sup>Written for commit 74afbe3f16187f030ec0418d5725ec330f350332. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

