### PR TITLE
feat(eve): add optional Browserbase web tool overrides

### DIFF
--- a/.changeset/shy-dodos-search.md
+++ b/.changeset/shy-dodos-search.md
@@ -1,0 +1,6 @@
+---
+"@browserbasehq/eve": patch
+---
+
+Export optional Browserbase Web Search and Web Fetch tool factories that Eve agents can mount at
+`web_search` and `web_fetch` to override the framework defaults.

--- a/packages/integrations/eve/README.md
+++ b/packages/integrations/eve/README.md
@@ -64,9 +64,10 @@ export default browserbaseWebFetch();
 
 The filenames perform the override: the model sees `web_search` and `web_fetch`, while the mounted
 extension still contributes only the three `browserbase__*` Code Mode tools. Each factory also
-accepts optional `apiKey`, `baseUrl`, `maxRetries`, and `timeoutMs` client settings. By default, the
-API key is resolved from `BROWSERBASE_API_KEY` on first execution so Eve can build an agent without
-requiring runtime secrets.
+accepts optional `apiKey`, `baseUrl`, `maxRetries`, and `timeoutMs` client settings. Building the
+agent does not require an API key. Executing either override does: pass `apiKey` or set
+`BROWSERBASE_API_KEY` in the runtime environment. The default factory resolves the environment
+variable lazily on first execution.
 
 ## Configuration
 

--- a/packages/integrations/eve/README.md
+++ b/packages/integrations/eve/README.md
@@ -42,6 +42,32 @@ Version 0.2 replaces the previous focused `search`, `fetch`, session, navigation
 extraction tools with this Code Mode surface. Eve's built-in `web_search` and `web_fetch` remain
 available unless the consuming agent explicitly overrides them.
 
+## Optional Web Search and Web Fetch overrides
+
+Browserbase Web Search and Web Fetch are exported as standalone tool factories. Importing them does
+not add tools to the extension mount. To replace Eve's built-ins, export each factory result from a
+root tool file with the matching name:
+
+```ts
+// agent/tools/web_search.ts
+import { browserbaseWebSearch } from "@browserbasehq/eve/tools";
+
+export default browserbaseWebSearch();
+```
+
+```ts
+// agent/tools/web_fetch.ts
+import { browserbaseWebFetch } from "@browserbasehq/eve/tools";
+
+export default browserbaseWebFetch();
+```
+
+The filenames perform the override: the model sees `web_search` and `web_fetch`, while the mounted
+extension still contributes only the three `browserbase__*` Code Mode tools. Each factory also
+accepts optional `apiKey`, `baseUrl`, `maxRetries`, and `timeoutMs` client settings. By default, the
+API key is resolved from `BROWSERBASE_API_KEY` on first execution so Eve can build an agent without
+requiring runtime secrets.
+
 ## Configuration
 
 | Option                  | Default               | Description                                                 |

--- a/packages/integrations/eve/package.json
+++ b/packages/integrations/eve/package.json
@@ -39,7 +39,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "pnpm run stage:facade && eve extension build",
+    "build": "pnpm run stage:facade && eve extension build && tsdown --config tsdown.tools.config.ts",
     "prepack": "pnpm run build",
     "stage:facade": "node scripts/stage-facade.mjs",
     "test": "pnpm run stage:facade && vitest run",
@@ -55,6 +55,7 @@
     "@types/node": "catalog:",
     "ai": "catalog:eve",
     "eve": "catalog:",
+    "tsdown": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/integrations/eve/src/tools/client.ts
+++ b/packages/integrations/eve/src/tools/client.ts
@@ -1,0 +1,36 @@
+import Browserbase from "@browserbasehq/sdk";
+
+export interface BrowserbaseWebToolConfig {
+  apiKey?: string;
+  baseUrl?: string;
+  maxRetries?: number;
+  timeoutMs?: number;
+}
+
+export function createBrowserbaseWebClient(config: BrowserbaseWebToolConfig): Browserbase {
+  const apiKey = config.apiKey ?? process.env.BROWSERBASE_API_KEY;
+  if (typeof apiKey !== "string" || apiKey.trim().length === 0) {
+    throw new TypeError(
+      "Browserbase web tools require apiKey or the BROWSERBASE_API_KEY environment variable.",
+    );
+  }
+  if (
+    config.maxRetries !== undefined &&
+    (!Number.isInteger(config.maxRetries) || config.maxRetries < 0)
+  ) {
+    throw new TypeError("Browserbase web tool maxRetries must be a non-negative integer.");
+  }
+  if (
+    config.timeoutMs !== undefined &&
+    (!Number.isFinite(config.timeoutMs) || config.timeoutMs <= 0)
+  ) {
+    throw new TypeError("Browserbase web tool timeoutMs must be a positive number.");
+  }
+
+  return new Browserbase({
+    apiKey,
+    ...(config.baseUrl ? { baseURL: config.baseUrl.replace(/\/+$/u, "") } : {}),
+    ...(config.maxRetries === undefined ? {} : { maxRetries: config.maxRetries }),
+    ...(config.timeoutMs === undefined ? {} : { timeout: config.timeoutMs }),
+  });
+}

--- a/packages/integrations/eve/src/tools/index.ts
+++ b/packages/integrations/eve/src/tools/index.ts
@@ -1,0 +1,3 @@
+export type { BrowserbaseWebToolConfig } from "./client.js";
+export { browserbaseWebFetch } from "./web-fetch.js";
+export { browserbaseWebSearch } from "./web-search.js";

--- a/packages/integrations/eve/src/tools/web-fetch.ts
+++ b/packages/integrations/eve/src/tools/web-fetch.ts
@@ -1,0 +1,68 @@
+import { defineTool } from "eve/tools";
+import { z } from "zod";
+
+import { createBrowserbaseWebClient, type BrowserbaseWebToolConfig } from "./client.js";
+
+const jsonSchema = z
+  .record(z.string(), z.unknown())
+  .optional()
+  .describe(
+    "A JSON Schema for structured extraction. Required with the json format and invalid with other formats.",
+  );
+
+export const browserbaseWebFetchInputSchema = z
+  .object({
+    url: z.url().describe("The absolute URL to retrieve."),
+    format: z
+      .enum(["raw", "markdown", "json"])
+      .default("markdown")
+      .describe("The response content format."),
+    schema: jsonSchema,
+    allowRedirects: z.boolean().default(true).describe("Whether to follow HTTP redirects."),
+    allowInsecureSsl: z
+      .boolean()
+      .default(false)
+      .describe("Whether to bypass TLS certificate verification."),
+    proxies: z
+      .boolean()
+      .default(false)
+      .describe("Whether to route the request through Browserbase proxies."),
+  })
+  .superRefine(({ format, schema }, context) => {
+    if (format === "json" && !schema) {
+      context.addIssue({ code: "custom", message: "schema is required when format is json." });
+    }
+    if (format !== "json" && schema) {
+      context.addIssue({ code: "custom", message: "schema can only be used when format is json." });
+    }
+  });
+
+export function browserbaseWebFetch(config: BrowserbaseWebToolConfig = {}) {
+  return defineTool({
+    description:
+      "Retrieve a URL through Browserbase Fetch without starting a browser session. Use raw for the original response, markdown for agent-friendly content, or json with a schema for structured extraction.",
+    inputSchema: browserbaseWebFetchInputSchema,
+    outputSchema: z.object({
+      id: z.string(),
+      content: z.union([z.string(), z.record(z.string(), z.unknown())]),
+      contentType: z.string(),
+      encoding: z.string(),
+      headers: z.record(z.string(), z.string()),
+      statusCode: z.number().int(),
+    }),
+    execute({ url, format, schema, allowRedirects, allowInsecureSsl, proxies }, context) {
+      const browserbase = createBrowserbaseWebClient(config);
+      return browserbase.fetchAPI.create(
+        {
+          url,
+          format,
+          schema,
+          allowRedirects,
+          allowInsecureSsl,
+          proxies,
+        },
+        { signal: context.abortSignal },
+      );
+    },
+  });
+}

--- a/packages/integrations/eve/src/tools/web-fetch.ts
+++ b/packages/integrations/eve/src/tools/web-fetch.ts
@@ -7,7 +7,7 @@ const jsonSchema = z
   .record(z.string(), z.unknown())
   .optional()
   .describe(
-    "A JSON Schema for structured extraction. Required with the json format and invalid with other formats.",
+    'A JSON Schema for structured extraction. It must declare a top-level type such as "object" or "array". Required with the json format and invalid with other formats.',
   );
 
 export const browserbaseWebFetchInputSchema = z
@@ -31,6 +31,17 @@ export const browserbaseWebFetchInputSchema = z
   .superRefine(({ format, schema }, context) => {
     if (format === "json" && !schema) {
       context.addIssue({ code: "custom", message: "schema is required when format is json." });
+    }
+    if (
+      format === "json" &&
+      schema &&
+      (typeof schema.type !== "string" || schema.type.length === 0)
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "schema.type must declare a top-level JSON Schema type.",
+        path: ["schema", "type"],
+      });
     }
     if (format !== "json" && schema) {
       context.addIssue({ code: "custom", message: "schema can only be used when format is json." });

--- a/packages/integrations/eve/src/tools/web-fetch.ts
+++ b/packages/integrations/eve/src/tools/web-fetch.ts
@@ -48,19 +48,21 @@ export const browserbaseWebFetchInputSchema = z
     }
   });
 
+export const browserbaseWebFetchOutputSchema = z.object({
+  id: z.string(),
+  content: z.union([z.string(), z.record(z.string(), z.unknown()), z.array(z.unknown())]),
+  contentType: z.string(),
+  encoding: z.string(),
+  headers: z.record(z.string(), z.string()),
+  statusCode: z.number().int(),
+});
+
 export function browserbaseWebFetch(config: BrowserbaseWebToolConfig = {}) {
   return defineTool({
     description:
       "Retrieve a URL through Browserbase Fetch without starting a browser session. Use raw for the original response, markdown for agent-friendly content, or json with a schema for structured extraction.",
     inputSchema: browserbaseWebFetchInputSchema,
-    outputSchema: z.object({
-      id: z.string(),
-      content: z.union([z.string(), z.record(z.string(), z.unknown())]),
-      contentType: z.string(),
-      encoding: z.string(),
-      headers: z.record(z.string(), z.string()),
-      statusCode: z.number().int(),
-    }),
+    outputSchema: browserbaseWebFetchOutputSchema,
     execute({ url, format, schema, allowRedirects, allowInsecureSsl, proxies }, context) {
       const browserbase = createBrowserbaseWebClient(config);
       return browserbase.fetchAPI.create(

--- a/packages/integrations/eve/src/tools/web-search.ts
+++ b/packages/integrations/eve/src/tools/web-search.ts
@@ -1,0 +1,40 @@
+import { defineTool } from "eve/tools";
+import { z } from "zod";
+
+import { createBrowserbaseWebClient, type BrowserbaseWebToolConfig } from "./client.js";
+
+const searchResultSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  url: z.string(),
+  author: z.string().optional(),
+  favicon: z.string().optional(),
+  image: z.string().optional(),
+  publishedDate: z.string().optional(),
+});
+
+export function browserbaseWebSearch(config: BrowserbaseWebToolConfig = {}) {
+  return defineTool({
+    description:
+      "Search the public web with Browserbase Search. Use this to discover relevant URLs before fetching content or opening a browser session.",
+    inputSchema: z.object({
+      query: z.string().min(1).max(200).describe("The web search query."),
+      numResults: z
+        .number()
+        .int()
+        .min(1)
+        .max(25)
+        .default(10)
+        .describe("The number of results to return."),
+    }),
+    outputSchema: z.object({
+      query: z.string(),
+      requestId: z.string(),
+      results: z.array(searchResultSchema),
+    }),
+    execute({ query, numResults }, context) {
+      const browserbase = createBrowserbaseWebClient(config);
+      return browserbase.search.web({ query, numResults }, { signal: context.abortSignal });
+    },
+  });
+}

--- a/packages/integrations/eve/src/tools/web-search.ts
+++ b/packages/integrations/eve/src/tools/web-search.ts
@@ -7,10 +7,16 @@ const searchResultSchema = z.object({
   id: z.string(),
   title: z.string(),
   url: z.string(),
-  author: z.string().optional(),
-  favicon: z.string().optional(),
-  image: z.string().optional(),
-  publishedDate: z.string().optional(),
+  author: z.string().nullish(),
+  favicon: z.string().nullish(),
+  image: z.string().nullish(),
+  publishedDate: z.string().nullish(),
+});
+
+export const browserbaseWebSearchOutputSchema = z.object({
+  query: z.string(),
+  requestId: z.string(),
+  results: z.array(searchResultSchema),
 });
 
 export function browserbaseWebSearch(config: BrowserbaseWebToolConfig = {}) {
@@ -27,11 +33,7 @@ export function browserbaseWebSearch(config: BrowserbaseWebToolConfig = {}) {
         .default(10)
         .describe("The number of results to return."),
     }),
-    outputSchema: z.object({
-      query: z.string(),
-      requestId: z.string(),
-      results: z.array(searchResultSchema),
-    }),
+    outputSchema: browserbaseWebSearchOutputSchema,
     execute({ query, numResults }, context) {
       const browserbase = createBrowserbaseWebClient(config);
       return browserbase.search.web({ query, numResults }, { signal: context.abortSignal });

--- a/packages/integrations/eve/tests/web-tools.test.ts
+++ b/packages/integrations/eve/tests/web-tools.test.ts
@@ -1,0 +1,177 @@
+import type { ToolContext } from "eve/tools";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { browserbaseWebFetch, browserbaseWebSearch } from "../src/tools/index.js";
+import { browserbaseWebFetchInputSchema } from "../src/tools/web-fetch.js";
+
+const mocks = vi.hoisted(() => ({
+  createClient: vi.fn(),
+  fetch: vi.fn(),
+  search: vi.fn(),
+}));
+
+vi.mock("@browserbasehq/sdk", () => ({
+  default: class Browserbase {
+    readonly fetchAPI = { create: mocks.fetch };
+    readonly search = { web: mocks.search };
+
+    constructor(options: unknown) {
+      mocks.createClient(options);
+    }
+  },
+}));
+
+const abortSignal = new AbortController().signal;
+const toolContext = { abortSignal } as ToolContext;
+
+describe("Browserbase Eve web tools", () => {
+  beforeEach(() => {
+    mocks.createClient.mockReset();
+    mocks.fetch.mockReset();
+    mocks.search.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("creates a reusable Browserbase web search tool", async () => {
+    const response = { query: "stagehand", requestId: "request-one", results: [] };
+    mocks.search.mockResolvedValueOnce(response);
+    const tool = browserbaseWebSearch({
+      apiKey: "test-key",
+      baseUrl: "https://api.example.test///",
+      maxRetries: 1,
+      timeoutMs: 5_000,
+    });
+
+    await expect(tool.execute({ query: "stagehand", numResults: 5 }, toolContext)).resolves.toBe(
+      response,
+    );
+    expect(mocks.createClient).toHaveBeenCalledWith({
+      apiKey: "test-key",
+      baseURL: "https://api.example.test",
+      maxRetries: 1,
+      timeout: 5_000,
+    });
+    expect(mocks.search).toHaveBeenCalledWith(
+      { query: "stagehand", numResults: 5 },
+      { signal: abortSignal },
+    );
+  });
+
+  it("creates a reusable Browserbase web fetch tool", async () => {
+    const response = {
+      id: "fetch-one",
+      content: "# Example",
+      contentType: "text/markdown",
+      encoding: "utf-8",
+      headers: {},
+      statusCode: 200,
+    };
+    mocks.fetch.mockResolvedValueOnce(response);
+    const tool = browserbaseWebFetch({ apiKey: "test-key" });
+
+    await expect(
+      tool.execute(
+        {
+          url: "https://example.com",
+          format: "markdown",
+          schema: undefined,
+          allowRedirects: true,
+          allowInsecureSsl: false,
+          proxies: false,
+        },
+        toolContext,
+      ),
+    ).resolves.toBe(response);
+    expect(mocks.fetch).toHaveBeenCalledWith(
+      {
+        url: "https://example.com",
+        format: "markdown",
+        schema: undefined,
+        allowRedirects: true,
+        allowInsecureSsl: false,
+        proxies: false,
+      },
+      { signal: abortSignal },
+    );
+  });
+
+  it("resolves the default API key lazily from the runtime environment", async () => {
+    const response = { query: "stagehand", requestId: "request-two", results: [] };
+    mocks.search.mockResolvedValueOnce(response);
+    const tool = browserbaseWebSearch();
+
+    expect(mocks.createClient).not.toHaveBeenCalled();
+    vi.stubEnv("BROWSERBASE_API_KEY", "runtime-key");
+
+    await expect(tool.execute({ query: "stagehand", numResults: 10 }, toolContext)).resolves.toBe(
+      response,
+    );
+    expect(mocks.createClient).toHaveBeenCalledWith({ apiKey: "runtime-key" });
+  });
+
+  it("validates structured fetch inputs and applies safe defaults", async () => {
+    const missingSchema = await browserbaseWebFetchInputSchema["~standard"].validate({
+      url: "https://example.com",
+      format: "json",
+    });
+    const misplacedSchema = await browserbaseWebFetchInputSchema["~standard"].validate({
+      url: "https://example.com",
+      format: "markdown",
+      schema: { type: "object" },
+    });
+    const valid = await browserbaseWebFetchInputSchema["~standard"].validate({
+      url: "https://example.com",
+    });
+
+    expect("issues" in missingSchema).toBe(true);
+    expect("issues" in misplacedSchema).toBe(true);
+    expect(valid).toMatchObject({
+      value: {
+        url: "https://example.com",
+        format: "markdown",
+        allowRedirects: true,
+        allowInsecureSsl: false,
+        proxies: false,
+      },
+    });
+  });
+
+  it("rejects invalid client options on first execution", () => {
+    const search = browserbaseWebSearch({ apiKey: "" });
+    const retries = browserbaseWebFetch({ apiKey: "test-key", maxRetries: -1 });
+    const timeout = browserbaseWebFetch({ apiKey: "test-key", timeoutMs: 0 });
+
+    expect(() => search.execute({ query: "stagehand", numResults: 10 }, toolContext)).toThrow(
+      "Browserbase web tools require apiKey or the BROWSERBASE_API_KEY environment variable.",
+    );
+    expect(() =>
+      retries.execute(
+        {
+          url: "https://example.com",
+          format: "markdown",
+          schema: undefined,
+          allowRedirects: true,
+          allowInsecureSsl: false,
+          proxies: false,
+        },
+        toolContext,
+      ),
+    ).toThrow("Browserbase web tool maxRetries must be a non-negative integer.");
+    expect(() =>
+      timeout.execute(
+        {
+          url: "https://example.com",
+          format: "markdown",
+          schema: undefined,
+          allowRedirects: true,
+          allowInsecureSsl: false,
+          proxies: false,
+        },
+        toolContext,
+      ),
+    ).toThrow("Browserbase web tool timeoutMs must be a positive number.");
+  });
+});

--- a/packages/integrations/eve/tests/web-tools.test.ts
+++ b/packages/integrations/eve/tests/web-tools.test.ts
@@ -2,7 +2,11 @@ import type { ToolContext } from "eve/tools";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { browserbaseWebFetch, browserbaseWebSearch } from "../src/tools/index.js";
-import { browserbaseWebFetchInputSchema } from "../src/tools/web-fetch.js";
+import {
+  browserbaseWebFetchInputSchema,
+  browserbaseWebFetchOutputSchema,
+} from "../src/tools/web-fetch.js";
+import { browserbaseWebSearchOutputSchema } from "../src/tools/web-search.js";
 
 const mocks = vi.hoisted(() => ({
   createClient: vi.fn(),
@@ -36,7 +40,21 @@ describe("Browserbase Eve web tools", () => {
   });
 
   it("creates a reusable Browserbase web search tool", async () => {
-    const response = { query: "stagehand", requestId: "request-one", results: [] };
+    const response = {
+      query: "stagehand",
+      requestId: "request-one",
+      results: [
+        {
+          id: "result-one",
+          title: "Stagehand",
+          url: "https://www.stagehand.dev",
+          author: null,
+          favicon: null,
+          image: null,
+          publishedDate: null,
+        },
+      ],
+    };
     mocks.search.mockResolvedValueOnce(response);
     const tool = browserbaseWebSearch({
       apiKey: "test-key",
@@ -58,6 +76,9 @@ describe("Browserbase Eve web tools", () => {
       { query: "stagehand", numResults: 5 },
       { signal: abortSignal },
     );
+    expect(browserbaseWebSearchOutputSchema["~standard"].validate(response)).toEqual({
+      value: response,
+    });
   });
 
   it("creates a reusable Browserbase web fetch tool", async () => {
@@ -96,6 +117,21 @@ describe("Browserbase Eve web tools", () => {
       },
       { signal: abortSignal },
     );
+  });
+
+  it("accepts array-valued structured fetch results", async () => {
+    const response = {
+      id: "fetch-array",
+      content: [{ title: "Example" }, { title: "Domain" }],
+      contentType: "application/json",
+      encoding: "utf-8",
+      headers: {},
+      statusCode: 200,
+    };
+
+    expect(browserbaseWebFetchOutputSchema["~standard"].validate(response)).toEqual({
+      value: response,
+    });
   });
 
   it("resolves the default API key lazily from the runtime environment", async () => {

--- a/packages/integrations/eve/tests/web-tools.test.ts
+++ b/packages/integrations/eve/tests/web-tools.test.ts
@@ -122,12 +122,26 @@ describe("Browserbase Eve web tools", () => {
       format: "markdown",
       schema: { type: "object" },
     });
+    const missingTopLevelType = await browserbaseWebFetchInputSchema["~standard"].validate({
+      url: "https://example.com",
+      format: "json",
+      schema: { properties: { title: { type: "string" } } },
+    });
+    const structured = await browserbaseWebFetchInputSchema["~standard"].validate({
+      url: "https://example.com",
+      format: "json",
+      schema: { type: "object", properties: { title: { type: "string" } } },
+    });
     const valid = await browserbaseWebFetchInputSchema["~standard"].validate({
       url: "https://example.com",
     });
 
     expect("issues" in missingSchema).toBe(true);
     expect("issues" in misplacedSchema).toBe(true);
+    expect(missingTopLevelType).toMatchObject({
+      issues: [{ message: "schema.type must declare a top-level JSON Schema type." }],
+    });
+    expect("issues" in structured).toBe(false);
     expect(valid).toMatchObject({
       value: {
         url: "https://example.com",

--- a/packages/integrations/eve/tsconfig.json
+++ b/packages/integrations/eve/tsconfig.json
@@ -11,5 +11,5 @@
     "noEmit": true,
     "types": ["node", "vitest/globals"]
   },
-  "include": ["extension/**/*.ts", "tests/**/*.ts"]
+  "include": ["extension/**/*.ts", "src/**/*.ts", "tests/**/*.ts", "tsdown.tools.config.ts"]
 }

--- a/packages/integrations/eve/tsdown.tools.config.ts
+++ b/packages/integrations/eve/tsdown.tools.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: "src/tools/index.ts",
+  format: ["esm"],
+  platform: "node",
+  target: "node24",
+  outDir: "dist/tools",
+  dts: true,
+  clean: true,
+  deps: {
+    skipNodeModulesBundle: true,
+  },
+  outExtensions: () => ({ js: ".mjs", dts: ".d.ts" }),
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -806,6 +806,9 @@ importers:
       eve:
         specifier: 'catalog:'
         version: 0.44.4(@opentelemetry/api@1.9.1)(ai@7.0.77(zod@4.4.3))(aws4fetch@1.0.20)(braintrust@3.28.0(@aws-sdk/credential-provider-web-identity@3.972.74)(zod@4.4.3))(dotenv@17.4.2)(jiti@2.7.0)(lru-cache@11.5.2)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(xml2js@0.6.2)
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.3(publint@0.3.21)(tsx@4.23.1)(typescript@5.9.3)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3


### PR DESCRIPTION
Add opt-in Browserbase-backed replacements for Eve's built-in `web_search` and `web_fetch`. An existing Eve agent opts in by creating `agent/tools/web_search.ts` and `agent/tools/web_fetch.ts`, exporting `browserbaseWebSearch()` and `browserbaseWebFetch()` from `@browserbasehq/eve/tools`.

This is the **optional child of #2821**, which now targets main directly and includes the remaining cleanup work formerly in #2824. The native browser extension can ship without this PR. #2824 is superseded and is no longer part of the active stack.

## Behavior

- Eve's root tool filenames provide the supported override mechanism. The browser extension still contributes only `browserbase__run`, `browserbase__snapshot`, and `browserbase__screenshot`.
- Resolve `BROWSERBASE_API_KEY` lazily on execution so credential-free builds work. Preserve abort signals, configurable retry/timeout behavior, and structured Fetch responses through the Browserbase SDK.
- Add public quickstart instructions as well as package documentation for the optional overrides and their pending release.
- Keep a separate patch changeset: landing with #2821 produces 0.2; landing after the native extension release can produce its own patch release.

## E2E Test Matrix

Verified September 17 with the locally packed package, Eve 0.44.4, and published Stagehand 4.1.0.

| Command / flow | Observed output | Confidence / sufficiency |
| --- | --- | --- |
| Eve typecheck and unit tests | 50 tests passed | Native lifecycle plus lazy credentials, cancellation, request options, and response shaping |
| Extension build, tools build, pack, and `publint` | Passed; both package entry points lint cleanly | Consumable native extension and optional factory exports |
| Packed web factories against public targets | Search returned results; raw, markdown, and structured-object Fetch returned HTTP 200 with Example Domain content | Live Browserbase Search/Fetch from the packed exports |
| Credential-free consumer `eve build` | Passed | Root tool overrides and extension mount build without runtime credentials |
| Real Eve agent: `eve eval all-tools --strict --json --verbose` | 1 passed, 0 failed; all five tools used, no failed actions; IANA title/URL verified | Native browser tools and root overrides work in one real model/tool loop |
| Owned-session audit | Both sessions `COMPLETED` without audit fallback; zero running afterward | Cleanup from the live agent run |
| Frozen lockfile and public docs compilation | Passed | Updated dependency graph and MDX guide |

Core/release tests and the independent native-only packed lifecycle and agent checks are recorded in #2821. No package was published during this update.

The review follow-up also verifies fixed, typed Fetch/Search errors against real SDK HTTP failures containing synthetic sensitive details. HTTP(S)-only input validation rejects ftp/file/data/javascript URLs, and cancellation retains a sanitized AbortError. Live packed Search and all three Fetch formats still pass.

## Docs preview

Isolated rendering of the changed optional-tools MDX section. The child branch has no Mintlify preview; this capture uses neutral styles rather than the full docs shell.

![Eve documentation preview](https://raw.githubusercontent.com/browserbase/stagehand/444611f72d3bd24b6fe3f94c0f37f1e9fb448fc2/eve-web-tools-isolated.png)
