### PR TITLE
fix(integrations): propagate facade close requests

### DIFF
--- a/packages/integrations/core/src/facade/index.ts
+++ b/packages/integrations/core/src/facade/index.ts
@@ -18,7 +18,7 @@ export {
   type RefAction,
   type CodeModeRunInput,
 } from "./contract.js";
-export { StagehandFacadeTools } from "./tools.js";
+export { StagehandFacadeTools, type StagehandFacadeToolsOptions } from "./tools.js";
 export {
   StagehandFacadeConfigError,
   stagehandFacadeConfigFromEnv,

--- a/packages/integrations/core/src/facade/index.ts
+++ b/packages/integrations/core/src/facade/index.ts
@@ -18,7 +18,11 @@ export {
   type RefAction,
   type CodeModeRunInput,
 } from "./contract.js";
-export { StagehandFacadeTools, type StagehandFacadeToolsOptions } from "./tools.js";
+export {
+  StagehandFacadeCleanupError,
+  StagehandFacadeTools,
+  type StagehandFacadeToolsOptions,
+} from "./tools.js";
 export {
   StagehandFacadeConfigError,
   stagehandFacadeConfigFromEnv,

--- a/packages/integrations/core/src/facade/stdio-server.ts
+++ b/packages/integrations/core/src/facade/stdio-server.ts
@@ -10,7 +10,6 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { closeCodeModeStdio } from "../codemode/stdio-lifecycle.js";
-import { sanitizeErrorMessage } from "../harness/redact.js";
 import { stagehandFacadeConfigFromEnv } from "./config.js";
 import {
   CodeModeRunInputSchema,

--- a/packages/integrations/core/src/facade/stdio-server.ts
+++ b/packages/integrations/core/src/facade/stdio-server.ts
@@ -24,7 +24,7 @@ import {
   captureScreenshotWithinBase64Budget,
   screenshotBase64BudgetFromArgs,
 } from "./screenshot-transport.js";
-import { StagehandFacadeTools } from "./tools.js";
+import { sanitizeFacadeErrorMessage, StagehandFacadeTools } from "./tools.js";
 
 type FacadeResources = {
   browser: StagehandBrowser;
@@ -35,6 +35,7 @@ type FacadeResources = {
 const server = new McpServer({ name: "stagehand-facade", version: "4.0.0" });
 const screenshotBase64Budget = screenshotBase64BudgetFromArgs(process.argv.slice(2));
 let resourcesPromise: Promise<FacadeResources> | undefined;
+const resourceCleanups = new Map<FacadeResources, Promise<void>>();
 let closing = false;
 
 server.registerTool(
@@ -140,9 +141,25 @@ async function createResources(): Promise<FacadeResources> {
 async function closeResources(expected: FacadeResources): Promise<void> {
   const current = await resourcesPromise?.catch(() => undefined);
   if (current !== expected) return;
+  const cleanup = startResourceCleanup(expected);
   resourcesPromise = undefined;
-  await expected.stagehand.close().catch(() => undefined);
-  await expected.browser.close();
+  await cleanup;
+}
+
+function startResourceCleanup(resources: FacadeResources): Promise<void> {
+  const existing = resourceCleanups.get(resources);
+  if (existing) return existing;
+
+  const cleanup = (async () => {
+    await resources.stagehand.close().catch(() => undefined);
+    await resources.browser.close();
+  })();
+  resourceCleanups.set(resources, cleanup);
+  cleanup.then(
+    () => resourceCleanups.delete(resources),
+    () => resourceCleanups.delete(resources),
+  );
+  return cleanup;
 }
 
 function textResult(text: string) {
@@ -150,7 +167,9 @@ function textResult(text: string) {
 }
 
 function errorResult(error: unknown) {
-  const message = sanitizeErrorMessage(error instanceof Error ? error.message : String(error));
+  const message = sanitizeFacadeErrorMessage(
+    error instanceof Error ? error.message : String(error),
+  );
   return { content: [{ type: "text" as const, text: message }], isError: true };
 }
 
@@ -172,13 +191,11 @@ async function shutdown(code: number): Promise<void> {
     new Promise<undefined>((resolve) => setTimeout(resolve, 5_000)),
   ]);
   const clean = await closeCodeModeStdio([
+    ...[...resourceCleanups.values()].map((cleanup) => ({ close: () => cleanup })),
     ...(resources
       ? [
           {
-            close: async () => {
-              await resources.stagehand.close().catch(() => undefined);
-              await resources.browser.close();
-            },
+            close: () => startResourceCleanup(resources),
           },
         ]
       : []),
@@ -198,7 +215,7 @@ try {
   process.stderr.write("Stagehand facade MCP host listening on stdio\n");
 } catch (error) {
   process.stderr.write(
-    sanitizeErrorMessage(error instanceof Error ? error.message : String(error)) + "\n",
+    sanitizeFacadeErrorMessage(error instanceof Error ? error.message : String(error)) + "\n",
   );
   await shutdown(1);
 }

--- a/packages/integrations/core/src/facade/stdio-server.ts
+++ b/packages/integrations/core/src/facade/stdio-server.ts
@@ -125,11 +125,24 @@ async function createResources(): Promise<FacadeResources> {
       : await localBrowser.launch(config.browser.launchOptions);
   try {
     const stagehand = await Stagehand.create({ browser, ...config.stagehand });
-    return { browser, stagehand, tools: new StagehandFacadeTools(stagehand) };
+    let resources!: FacadeResources;
+    const tools = new StagehandFacadeTools(stagehand, {
+      onCloseRequested: () => closeResources(resources),
+    });
+    resources = { browser, stagehand, tools };
+    return resources;
   } catch (error) {
     await browser.close().catch(() => undefined);
     throw error;
   }
+}
+
+async function closeResources(expected: FacadeResources): Promise<void> {
+  const current = await resourcesPromise?.catch(() => undefined);
+  if (current !== expected) return;
+  resourcesPromise = undefined;
+  await expected.stagehand.close().catch(() => undefined);
+  await expected.browser.close();
 }
 
 function textResult(text: string) {

--- a/packages/integrations/core/src/facade/tools.ts
+++ b/packages/integrations/core/src/facade/tools.ts
@@ -15,7 +15,7 @@ type RunEnvelope = {
   __stagehandPlaywrightCompat: true;
   value: unknown;
   closeRequested: boolean;
-  executionError?: { name: string; message: string; stack?: string };
+  executionError?: { name: string; message: string };
 };
 
 export type StagehandFacadeToolsOptions = {
@@ -26,6 +26,14 @@ export type StagehandFacadeScreenshot = {
   data: string;
   mimeType: "image/png" | "image/jpeg";
 };
+
+export class StagehandFacadeCleanupError extends Error {
+  override readonly name = "StagehandFacadeCleanupError";
+
+  constructor() {
+    super("Failed to close the Stagehand browser session.");
+  }
+}
 
 const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor as new (
   ...args: string[]
@@ -76,7 +84,6 @@ const FACADE_EPILOGUE = `
   executionError = {
     name: typeof error?.name === "string" ? error.name : "Error",
     message: typeof error?.message === "string" ? error.message : String(error),
-    ...(typeof error?.stack === "string" ? { stack: error.stack } : {}),
   };
 }
 return {
@@ -180,22 +187,22 @@ export class StagehandFacadeTools {
       {},
       { page, timeout: 60_000 },
     );
-    let closeError: unknown;
-    if (envelope.closeRequested && this.options.onCloseRequested) {
-      try {
-        await this.options.onCloseRequested();
-      } catch (error) {
-        closeError = error;
+    let closeError: StagehandFacadeCleanupError | undefined;
+    if (envelope.closeRequested) {
+      if (!this.options.onCloseRequested) {
+        closeError = new StagehandFacadeCleanupError();
+      } else {
+        try {
+          await this.options.onCloseRequested();
+        } catch {
+          closeError = new StagehandFacadeCleanupError();
+        }
       }
     }
     if (envelope.executionError) {
-      const error = new Error(envelope.executionError.message);
-      error.name = envelope.executionError.name;
-      if (envelope.executionError.stack) error.stack = envelope.executionError.stack;
+      const error = executionErrorFromEnvelope(envelope.executionError);
       if (closeError) {
-        throw new AggregateError([error, closeError], "Run failed and cleanup also failed.", {
-          cause: error,
-        });
+        throw new AggregateError([error, closeError], "Run failed and cleanup also failed.");
       }
       throw error;
     }
@@ -221,4 +228,22 @@ export class StagehandFacadeTools {
 
 function trimTrailingTextNode(path: string | undefined): string | undefined {
   return path?.replace(/\/text\(\)(\[\d+\])?$/iu, "");
+}
+
+function executionErrorFromEnvelope(envelope: { name: string; message: string }): Error {
+  const error = new Error(sanitizeFacadeErrorMessage(envelope.message));
+  error.name = /^[A-Za-z][A-Za-z0-9]*Error$/u.test(envelope.name) ? envelope.name : "Error";
+  // The worker stack can contain browser internals or sensitive model-authored values.
+  // Keep the useful error category and sanitized message without transporting that stack.
+  error.stack = undefined;
+  return error;
+}
+
+export function sanitizeFacadeErrorMessage(message: string): string {
+  return message
+    .replace(/([?&](?:signingKey|apiKey|api_key|token|key)=)[^&\s"']+/giu, "$1[redacted]")
+    .replace(/\b(sk-[A-Za-z0-9_-]{6})[A-Za-z0-9_-]+/gu, "$1[redacted]")
+    .replace(/\b(bb_(?:live|test)_[A-Za-z0-9]{4})[A-Za-z0-9_-]+/gu, "$1[redacted]")
+    .replace(/\bAIza[0-9A-Za-z_-]{30,}/gu, "AIza[redacted]")
+    .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{8,}/giu, "$1[redacted]");
 }

--- a/packages/integrations/core/src/facade/tools.ts
+++ b/packages/integrations/core/src/facade/tools.ts
@@ -14,7 +14,12 @@ type ActionResult = { completed: number };
 type RunEnvelope = {
   __stagehandPlaywrightCompat: true;
   value: unknown;
+  closeRequested: boolean;
   executionError?: { name: string; message: string; stack?: string };
+};
+
+export type StagehandFacadeToolsOptions = {
+  onCloseRequested?: () => Promise<void>;
 };
 
 export type StagehandFacadeScreenshot = {
@@ -77,6 +82,7 @@ const FACADE_EPILOGUE = `
 return {
   __stagehandPlaywrightCompat: true,
   value,
+  closeRequested: runtime.closeRequested(),
   executionError,
 };`;
 
@@ -84,7 +90,10 @@ export class StagehandFacadeTools {
   private readonly snapshotsByPage = new Map<string, SnapshotState>();
   private queue: Promise<void> = Promise.resolve();
 
-  constructor(private readonly stagehand: Stagehand) {}
+  constructor(
+    private readonly stagehand: Stagehand,
+    private readonly options: StagehandFacadeToolsOptions = {},
+  ) {}
 
   snapshot(options: { includeIframes?: boolean } = {}): Promise<string> {
     return this.enqueue(() => this.snapshotNow(options));
@@ -171,12 +180,26 @@ export class StagehandFacadeTools {
       {},
       { page, timeout: 60_000 },
     );
+    let closeError: unknown;
+    if (envelope.closeRequested && this.options.onCloseRequested) {
+      try {
+        await this.options.onCloseRequested();
+      } catch (error) {
+        closeError = error;
+      }
+    }
     if (envelope.executionError) {
       const error = new Error(envelope.executionError.message);
       error.name = envelope.executionError.name;
       if (envelope.executionError.stack) error.stack = envelope.executionError.stack;
+      if (closeError) {
+        throw new AggregateError([error, closeError], "Run failed and cleanup also failed.", {
+          cause: error,
+        });
+      }
       throw error;
     }
+    if (closeError) throw closeError;
     return envelope.value;
   }
 

--- a/packages/integrations/core/src/facade/tools.ts
+++ b/packages/integrations/core/src/facade/tools.ts
@@ -232,7 +232,8 @@ function trimTrailingTextNode(path: string | undefined): string | undefined {
 
 function executionErrorFromEnvelope(envelope: { name: string; message: string }): Error {
   const error = new Error(sanitizeFacadeErrorMessage(envelope.message));
-  error.name = /^[A-Za-z][A-Za-z0-9]*Error$/u.test(envelope.name) ? envelope.name : "Error";
+  const name = sanitizeFacadeErrorMessage(envelope.name);
+  error.name = /^[A-Za-z][A-Za-z0-9]*Error$/u.test(name) ? name : "Error";
   // The worker stack can contain browser internals or sensitive model-authored values.
   // Keep the useful error category and sanitized message without transporting that stack.
   error.stack = undefined;

--- a/packages/integrations/core/tests/facade-tools.test.ts
+++ b/packages/integrations/core/tests/facade-tools.test.ts
@@ -1,0 +1,48 @@
+import type { Stagehand } from "@browserbasehq/stagehand";
+import { describe, expect, it, vi } from "vitest";
+
+import { StagehandFacadeTools } from "../src/facade/tools.js";
+
+describe("StagehandFacadeTools", () => {
+  it("propagates browser.close requests to host cleanup", async () => {
+    const onCloseRequested = vi.fn(async () => undefined);
+    const { experimentalBatch, stagehand } = createStagehand({
+      __stagehandPlaywrightCompat: true,
+      value: "closed",
+      closeRequested: true,
+    });
+    const tools = new StagehandFacadeTools(stagehand, { onCloseRequested });
+
+    await expect(tools.run('await browser.close(); return "closed";')).resolves.toBe("closed");
+    expect(onCloseRequested).toHaveBeenCalledOnce();
+
+    const callback = (experimentalBatch.mock.calls as unknown[][])[0]?.[0];
+    expect(String(callback)).toContain("closeRequested: runtime.closeRequested()");
+  });
+
+  it("closes before surfacing a model-authored error", async () => {
+    const onCloseRequested = vi.fn(async () => undefined);
+    const { stagehand } = createStagehand({
+      __stagehandPlaywrightCompat: true,
+      value: undefined,
+      closeRequested: true,
+      executionError: { name: "Error", message: "boom" },
+    });
+    const tools = new StagehandFacadeTools(stagehand, { onCloseRequested });
+
+    await expect(tools.run('await browser.close(); throw new Error("boom");')).rejects.toThrow(
+      "boom",
+    );
+    expect(onCloseRequested).toHaveBeenCalledOnce();
+  });
+});
+
+function createStagehand(envelope: Record<string, unknown>) {
+  const page = { pageId: "page-1", url: vi.fn(async () => "https://example.com") };
+  const experimentalBatch = vi.fn(async () => envelope);
+  const stagehand = {
+    browser: { context: { activePage: vi.fn(async () => page) } },
+    experimentalBatch,
+  } as unknown as Stagehand;
+  return { experimentalBatch, stagehand };
+}

--- a/packages/integrations/core/tests/facade-tools.test.ts
+++ b/packages/integrations/core/tests/facade-tools.test.ts
@@ -82,6 +82,21 @@ describe("StagehandFacadeTools", () => {
     );
   });
 
+  it("sanitizes model-authored error names", async () => {
+    const credential = `AIza${"A".repeat(35)}Error`;
+    const { stagehand } = createStagehand({
+      __stagehandPlaywrightCompat: true,
+      value: undefined,
+      closeRequested: false,
+      executionError: { name: credential, message: "failed" },
+    });
+    const tools = new StagehandFacadeTools(stagehand);
+
+    const error = await tools.run("throw new Error('failed');").catch((caught) => caught);
+    expect(error).toMatchObject({ name: "Error", message: "failed", stack: undefined });
+    expect(String(error)).not.toContain(credential);
+  });
+
   it("reports an unsupported host instead of dropping a close request", async () => {
     const { stagehand } = createStagehand({
       __stagehandPlaywrightCompat: true,

--- a/packages/integrations/core/tests/facade-tools.test.ts
+++ b/packages/integrations/core/tests/facade-tools.test.ts
@@ -1,7 +1,7 @@
 import type { Stagehand } from "@browserbasehq/stagehand";
 import { describe, expect, it, vi } from "vitest";
 
-import { StagehandFacadeTools } from "../src/facade/tools.js";
+import { StagehandFacadeCleanupError, StagehandFacadeTools } from "../src/facade/tools.js";
 
 describe("StagehandFacadeTools", () => {
   it("propagates browser.close requests to host cleanup", async () => {
@@ -34,6 +34,65 @@ describe("StagehandFacadeTools", () => {
       "boom",
     );
     expect(onCloseRequested).toHaveBeenCalledOnce();
+  });
+
+  it("sanitizes model errors and cleanup errors when both fail", async () => {
+    const onCloseRequested = vi.fn(async () => {
+      throw new Error("provider rejected bb_live_1234secret");
+    });
+    const { stagehand } = createStagehand({
+      __stagehandPlaywrightCompat: true,
+      value: undefined,
+      closeRequested: true,
+      executionError: {
+        name: "TypeError",
+        message: "model failed with sk-123456secret",
+        stack: "raw worker stack bb_live_1234secret",
+      },
+    });
+    const tools = new StagehandFacadeTools(stagehand, { onCloseRequested });
+
+    const error = await tools.run("throw new TypeError('failed');").catch((caught) => caught);
+    expect(error).toBeInstanceOf(AggregateError);
+    if (!(error instanceof AggregateError)) throw new Error("Expected AggregateError");
+    expect(error.cause).toBeUndefined();
+    expect(error.errors).toHaveLength(2);
+    expect(error.errors[0]).toMatchObject({
+      name: "TypeError",
+      message: "model failed with sk-123456[redacted]",
+      stack: undefined,
+    });
+    expect(error.errors[1]).toBeInstanceOf(StagehandFacadeCleanupError);
+    expect(error.errors.map(String).join("\n")).not.toContain("secret");
+  });
+
+  it("uses a fixed cleanup error when host cleanup fails", async () => {
+    const onCloseRequested = vi.fn(async () => {
+      throw new Error("provider rejected bb_live_1234secret");
+    });
+    const { stagehand } = createStagehand({
+      __stagehandPlaywrightCompat: true,
+      value: "closed",
+      closeRequested: true,
+    });
+    const tools = new StagehandFacadeTools(stagehand, { onCloseRequested });
+
+    await expect(tools.run('await browser.close(); return "closed";')).rejects.toEqual(
+      new StagehandFacadeCleanupError(),
+    );
+  });
+
+  it("reports an unsupported host instead of dropping a close request", async () => {
+    const { stagehand } = createStagehand({
+      __stagehandPlaywrightCompat: true,
+      value: "closed",
+      closeRequested: true,
+    });
+    const tools = new StagehandFacadeTools(stagehand);
+
+    await expect(tools.run('await browser.close(); return "closed";')).rejects.toBeInstanceOf(
+      StagehandFacadeCleanupError,
+    );
   });
 });
 

--- a/packages/sdk-ts/tests/browser-runtime/stagehandLaunchConnectSmoke.test.ts
+++ b/packages/sdk-ts/tests/browser-runtime/stagehandLaunchConnectSmoke.test.ts
@@ -749,7 +749,7 @@ describe("Stagehand TS SDK launch/connect smoke", () => {
     stagehand = undefined;
     await activeBrowser.close();
     expect(activeBrowser.closed).toBe(true);
-  });
+  }, 15_000);
 });
 
 function operationUsageFromRawRpcMessage(message: unknown): Record<string, unknown> | undefined {


### PR DESCRIPTION
> **Superseded by #2821 (September 17).** #2892 already landed browser-close propagation in current main. The remaining host cleanup callback, sanitized combined failures, and stdio reset behavior from this PR are now incorporated into #2821 and verified against current main. #2821 targets main directly; #2822 is its optional web-tools child. Closing this PR avoids landing the older overlapping Core implementation. Existing branches and review history are retained.

---

## Summary

- carry the existing Playwright-compatibility `closeRequested` signal through `StagehandFacadeTools`
- let each host provide the resource cleanup callback it owns
- make the Core stdio host detach and close its Stagehand/browser resources
- preserve both model-execution and cleanup failures when they happen together

## Why

The Stagehand V4 compatibility runtime already recognizes `await browser.close()`, but the facade previously dropped that signal when returning the model value. Code Mode could therefore report a successful close while the Node host still retained its browser resources. Cleanup belongs in the host because the browser-side worker does not own host credentials or session state.

This is complementary to #2818: `stagehand.close()` now disposes a Stagehand instance while intentionally leaving its browser open; this PR transports a model-authored compatibility `browser.close()` request to the host that owns and can terminate that browser.

## Discovery and reproduction

This was found experimentally while running the official Eve integration against live Browserbase sessions, not from a type or mock failure. A browser task returned successfully after model code called `await browser.close()`, but the Browserbase API still reported the session as `RUNNING`, and the next tool call reused the same facade and session.

The trace led to the dropped boundary: the worker-side runtime set `closeRequested`, while `StagehandFacadeTools` returned only the model value/error and the host never saw the close request.

Minimal live reproduction on the affected implementation:

1. Launch the facade on a Browserbase session and retain it as the host's current resources.
2. Run `await browser.close(); return "closed";` through `StagehandFacadeTools.run()`.
3. Observe that the call returns `"closed"`.
4. Request the facade again or make another tool call.
5. Observe the same resources are reused and the remote session remains `RUNNING`.

The signal-loss bug is deterministic whenever execution reaches compatibility `browser.close()`: the flag had no path out of the batch result. Agent-level symptoms can look less consistent when a model omits close or an earlier browser error prevents it from reaching close. In the exact live A/B, the baseline reproduced on 1/1 close attempt; in the broader eight-task official-integration baseline, cleanup succeeded through this path on 0/8 tasks.

This is distinct from the intermittent Undici socket-close error seen during earlier Eve-fork teardown testing: that was a false-negative reported by 1/3 focused close calls even though all three remote sessions reached `COMPLETED`. #2824 fixes the official facade's deterministic loss of `closeRequested`, where the remote session actually remained `RUNNING`.

| Behavior | Before | After |
| --- | --- | --- |
| Worker close request | Recorded inside the compatibility runtime, then discarded | Returned in the batch envelope |
| Facade result | Returned before host cleanup | Awaits the host lifecycle callback |
| Next tool call | Reused the same facade/session | Creates fresh resources after cleanup |
| Remote Browserbase state | Remained `RUNNING` in the exact repro | Reached `COMPLETED` |
| Execution plus cleanup failure | Only the execution path was represented | Both errors are preserved |

This is the prerequisite for #2821; #2822 remains the optional web-tool follow-up.

## E2E Test Matrix

Rebased onto `main` (`9f4f878e9`) and revalidated on 2026-09-09 through the locally packed Eve consumer at the top of the stack, using published Stagehand 4.1.0.

| Command / flow | Observed output | What this establishes |
| --- | --- | --- |
| Core tests, typecheck and build | 38/38 tests passed; typecheck/build passed | Close propagation and error handling |
| Real Eve model loop | All five tools completed, final IANA title/URL reported, close requested, remote session `COMPLETED` | Close reaches the host through an actual agent run |
| Packed lifecycle probe | State/error recovery passed; close completed the first session; a later call created and completed a fresh session | Both owned sessions released; closed resources were not reused |

No changeset is included because the Core integration package is private.
