### PR TITLE
fix(evals): honor disabled harness observations

### DIFF
--- a/packages/evals/framework/claudeCodeToolAdapter.ts
+++ b/packages/evals/framework/claudeCodeToolAdapter.ts
@@ -22,7 +22,7 @@ import {
 import type { ProbeEvidence } from "stagehand-v3";
 import { startAgentToolRuntime } from "./agentToolRuntime.js";
 import type { ExternalHarnessTaskPlan } from "./externalHarnessPlan.js";
-import { ObservationRecorder, type StepObservation } from "./observationRecorder.js";
+import { createObservationRecorder, type StepObservation } from "./observationRecorder.js";
 
 export { waitForCdpEvent } from "../core/tools/cdp_code.js";
 
@@ -419,9 +419,7 @@ async function prepareAgentMountAdapter(
     cwd = await fsp.mkdtemp(path.join(os.tmpdir(), `stagehand-evals-claude-${input.toolSurface}-`));
     const cleanupCwd = cwd;
     const env = { ...process.env } as Record<string, string>;
-    const recorder = running.captureEvidence
-      ? new ObservationRecorder(running.captureEvidence)
-      : undefined;
+    const recorder = createObservationRecorder(running.captureEvidence);
     // handles mounts wrap the surface in the harness's run tool (which owns
     // per-step observation); mcp mounts pass the agent's own server spec
     // through, and observation is triggered from the runner's tool_result

--- a/packages/evals/framework/observationRecorder.ts
+++ b/packages/evals/framework/observationRecorder.ts
@@ -19,6 +19,13 @@ export function harnessObservationsEnabled(): boolean {
   return (process.env[OBSERVATIONS_ENV] ?? "all") !== "none";
 }
 
+export function createObservationRecorder(
+  capture?: () => Promise<ProbeEvidence>,
+): ObservationRecorder | undefined {
+  if (!capture || !harnessObservationsEnabled()) return undefined;
+  return new ObservationRecorder(capture);
+}
+
 /**
  * Buffers per-step probe observations for an external-harness run. Each
  * record() consumes one run index (matching the harness's Nth run-tool

--- a/packages/evals/tests/framework/harnessObservations.test.ts
+++ b/packages/evals/tests/framework/harnessObservations.test.ts
@@ -4,6 +4,7 @@ import { AGENT_RUN_TOOL_NAME } from "../../core/contracts/tool.js";
 import { claudeCodeAdapter } from "../../framework/harnesses/claudeCodeAdapter.js";
 import { codexAdapter } from "../../framework/harnesses/codexAdapter.js";
 import {
+  createObservationRecorder,
   harnessObservationsEnabled,
   ObservationRecorder,
 } from "../../framework/observationRecorder.js";
@@ -26,6 +27,13 @@ describe("observation recorder", () => {
     expect(harnessObservationsEnabled()).toBe(true);
     process.env.EVAL_HARNESS_OBSERVATIONS = "none";
     expect(harnessObservationsEnabled()).toBe(false);
+  });
+
+  it("does not construct a recorder when observations are disabled", () => {
+    expect(createObservationRecorder(async () => ({ url: "https://example.com" }))).toBeDefined();
+
+    process.env.EVAL_HARNESS_OBSERVATIONS = "none";
+    expect(createObservationRecorder(async () => ({ url: "https://example.com" }))).toBeUndefined();
   });
 
   it("indexes observations by run and leaves gaps on capture failure", async () => {


### PR DESCRIPTION
## Summary

- honor `EVAL_HARNESS_OBSERVATIONS=none` when the Claude Code adapter mounts a browser tool
- centralize the recorder-construction gate
- add a regression test for the disabled-observation path

## Why

This surfaced while comparing the Eve package in #2822 with the `claude_code` + `stagehand_code` Online-Mind2Web baseline on live Browserbase sessions. The harness already exposes and tests `EVAL_HARNESS_OBSERVATIONS=none`, but the Claude Code adapter constructed `ObservationRecorder` unconditionally whenever the tool exposed `captureEvidence`.

That made the setting ineffective. On pages with stale or detached frames, every completed run-tool call started another accessibility-tree capture. The timeout returned control to the harness without cancelling the underlying capture, so the captures continued emitting `DOM.getFrameOwner` and `Accessibility.getFullAXTree` failures and prevented a useful baseline run.

Minimal reproduction before this change:

```bash
EVAL_HARNESS_OBSERVATIONS=none \
EVAL_ONLINEMIND2WEB_IDS=<task-id> \
node packages/evals/dist/cli/cli.js run b:onlineMind2Web \
  --harness claude_code --tool stagehand_code \
  -e browserbase -m anthropic/claude-haiku-4-5 -t 1 -c 1
```

Despite `none`, the adapter still invoked per-step evidence capture. After this change, the same five-case live run emitted no per-step stale-frame flood and all owned Browserbase sessions completed. A later normal-budget run exposed a separate unhandled `page.goto` RPC-timeout failure; that is not addressed here.

This is a generic eval-harness fix rather than an Eve adapter. Eve's native eval runner already provides the package/tool-call evidence needed for #2822.

## Validation

- 35 focused framework tests
- eval package typecheck
- eval CLI build
- live `claude_code` + `stagehand_code` Browserbase run with observations disabled

No changeset is included because the eval package is private.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors `EVAL_HARNESS_OBSERVATIONS=none` in the Claude Code adapter so the setting actually suppresses per-step evidence capture instead of always recording when the tool exposes `captureEvidence`.

- The adapter previously constructed an `ObservationRecorder` unconditionally on `captureEvidence`, so the `none` setting had no effect and per-step accessibility-tree captures kept running.
- Centralizes the recorder-construction gate in a new `createObservationRecorder()` that returns `undefined` when observations are disabled or no capture is provided.
- Adds a regression test covering the disabled-observation path; behavior with observations enabled is unchanged.

<sup>Written for commit 74ba0a9af0d910d6088ff34c8e965d471ca032fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

