### PR TITLE
[V3]: fix xpath building logic for coordinates inside of iframes

### DIFF
--- a/.changeset/social-dingos-obey.md
+++ b/.changeset/social-dingos-obey.md
@@ -1,0 +1,5 @@
+---
+"@browserbasehq/stagehand": patch
+---
+
+fix cross-frame xpaths building logic for coordinates inside of iframes.

--- a/packages/core/lib/v3/launch/local.ts
+++ b/packages/core/lib/v3/launch/local.ts
@@ -12,8 +12,8 @@ const STAGEHAND_DEFAULT_FLAGS = [
   "--no-first-run",
   "--no-default-browser-check",
   "--disable-dev-shm-usage",
-  "--site-per-process",
   "--enable-features=WebMCPTesting,DevToolsWebMCPSupport",
+  "--disable-features=SitePerProcess",
 ];
 
 export async function launchLocalChrome(

--- a/packages/core/lib/v3/understudy/a11y/snapshot/coordinateResolver.ts
+++ b/packages/core/lib/v3/understudy/a11y/snapshot/coordinateResolver.ts
@@ -86,11 +86,26 @@ export async function resolveXpathForLocation(
         reportedFrameId &&
         reportedFrameId !== curFrameId
       ) {
-        const abs = await buildAbsoluteXPathFromChain(
-          iframeChain,
-          curSession,
-          be,
-        );
+        const chain = [...iframeChain];
+        try {
+          const parentSession = parentByFrame.get(reportedFrameId)
+            ? page.getSessionForFrame(parentByFrame.get(reportedFrameId)!)
+            : curSession;
+          const { backendNodeId } = await parentSession.send<{
+            backendNodeId?: number;
+          }>("DOM.getFrameOwner", { frameId: reportedFrameId });
+          if (typeof backendNodeId === "number") {
+            chain.push({
+              parentSession,
+              iframeBackendNodeId: backendNodeId,
+            });
+          }
+        } catch {
+          //
+        }
+
+        const leafSession = page.getSessionForFrame(reportedFrameId);
+        const abs = await buildAbsoluteXPathFromChain(chain, leafSession, be);
         return abs
           ? { frameId: reportedFrameId, backendNodeId: be, absoluteXPath: abs }
           : null;

--- a/packages/core/lib/v3/understudy/a11y/snapshot/coordinateResolver.ts
+++ b/packages/core/lib/v3/understudy/a11y/snapshot/coordinateResolver.ts
@@ -87,21 +87,32 @@ export async function resolveXpathForLocation(
         reportedFrameId !== curFrameId
       ) {
         const chain = [...iframeChain];
-        try {
-          const parentSession = parentByFrame.get(reportedFrameId)
-            ? page.getSessionForFrame(parentByFrame.get(reportedFrameId)!)
-            : curSession;
-          const { backendNodeId } = await parentSession.send<{
-            backendNodeId?: number;
-          }>("DOM.getFrameOwner", { frameId: reportedFrameId });
-          if (typeof backendNodeId === "number") {
-            chain.push({
-              parentSession,
-              iframeBackendNodeId: backendNodeId,
-            });
+        const framePath: string[] = [];
+        let frameId: string | null | undefined = reportedFrameId;
+        while (frameId && frameId !== curFrameId) {
+          framePath.unshift(frameId);
+          frameId = parentByFrame.get(frameId);
+        }
+
+        if (frameId === curFrameId) {
+          for (const childFrameId of framePath) {
+            const parentFrameId = parentByFrame.get(childFrameId);
+            if (!parentFrameId) continue;
+            try {
+              const parentSession = page.getSessionForFrame(parentFrameId);
+              const { backendNodeId } = await parentSession.send<{
+                backendNodeId?: number;
+              }>("DOM.getFrameOwner", { frameId: childFrameId });
+              if (typeof backendNodeId !== "number") continue;
+
+              chain.push({
+                parentSession,
+                iframeBackendNodeId: backendNodeId,
+              });
+            } catch {
+              //
+            }
           }
-        } catch {
-          //
         }
 
         const leafSession = page.getSessionForFrame(reportedFrameId);

--- a/packages/core/lib/v3/understudy/a11y/snapshot/coordinateResolver.ts
+++ b/packages/core/lib/v3/understudy/a11y/snapshot/coordinateResolver.ts
@@ -122,21 +122,6 @@ export async function resolveXpathForLocation(
               break;
             }
           }
-        } else if (!parentByFrame.has(reportedFrameId)) {
-          try {
-            const { backendNodeId } = await curSession.send<{
-              backendNodeId?: number;
-            }>("DOM.getFrameOwner", { frameId: reportedFrameId });
-            if (typeof backendNodeId === "number") {
-              chain.push({
-                parentSession: curSession,
-                iframeBackendNodeId: backendNodeId,
-              });
-              resolvedFramePath = true;
-            }
-          } catch {
-            //
-          }
         }
 
         if (!resolvedFramePath) {

--- a/packages/core/lib/v3/understudy/a11y/snapshot/coordinateResolver.ts
+++ b/packages/core/lib/v3/understudy/a11y/snapshot/coordinateResolver.ts
@@ -94,25 +94,53 @@ export async function resolveXpathForLocation(
           frameId = parentByFrame.get(frameId);
         }
 
+        let resolvedFramePath = false;
         if (frameId === curFrameId) {
+          resolvedFramePath = true;
           for (const childFrameId of framePath) {
             const parentFrameId = parentByFrame.get(childFrameId);
-            if (!parentFrameId) continue;
+            if (!parentFrameId) {
+              resolvedFramePath = false;
+              break;
+            }
             try {
               const parentSession = page.getSessionForFrame(parentFrameId);
               const { backendNodeId } = await parentSession.send<{
                 backendNodeId?: number;
               }>("DOM.getFrameOwner", { frameId: childFrameId });
-              if (typeof backendNodeId !== "number") continue;
+              if (typeof backendNodeId !== "number") {
+                resolvedFramePath = false;
+                break;
+              }
 
               chain.push({
                 parentSession,
                 iframeBackendNodeId: backendNodeId,
               });
             } catch {
-              //
+              resolvedFramePath = false;
+              break;
             }
           }
+        } else if (!parentByFrame.has(reportedFrameId)) {
+          try {
+            const { backendNodeId } = await curSession.send<{
+              backendNodeId?: number;
+            }>("DOM.getFrameOwner", { frameId: reportedFrameId });
+            if (typeof backendNodeId === "number") {
+              chain.push({
+                parentSession: curSession,
+                iframeBackendNodeId: backendNodeId,
+              });
+              resolvedFramePath = true;
+            }
+          } catch {
+            //
+          }
+        }
+
+        if (!resolvedFramePath) {
+          return null;
         }
 
         const leafSession = page.getSessionForFrame(reportedFrameId);

--- a/packages/core/tests/unit/launch-local-ignore-default-args.test.ts
+++ b/packages/core/tests/unit/launch-local-ignore-default-args.test.ts
@@ -197,20 +197,15 @@ describe("launchLocalChrome ignoreDefaultArgs", () => {
     expect(args.chromeFlags).toContain("--disable-extensions");
   });
 
-  it("allows users to disable the Stagehand --site-per-process default", async () => {
+  it("allows users to override the Stagehand SitePerProcess default", async () => {
     const args = await getLaunchArgs({
-      args: [
-        "--disable-features=site-per-process,IsolateOrigins",
-        "--renderer-process-limit=6",
-      ],
-      ignoreDefaultArgs: ["--site-per-process"],
+      args: ["--site-per-process", "--renderer-process-limit=6"],
+      ignoreDefaultArgs: ["--disable-features=SitePerProcess"],
     });
 
     expect(args.ignoreDefaultFlags).toBe(true);
-    expect(args.chromeFlags).not.toContain("--site-per-process");
-    expect(args.chromeFlags).toContain(
-      "--disable-features=site-per-process,IsolateOrigins",
-    );
+    expect(args.chromeFlags).not.toContain("--disable-features=SitePerProcess");
+    expect(args.chromeFlags).toContain("--site-per-process");
     expect(args.chromeFlags).toContain("--renderer-process-limit=6");
     expect(args.chromeFlags).toContain("--remote-allow-origins=*");
   });


### PR DESCRIPTION
# why
coordinate based targeting can resolve elements inside iframes differently depending on chrome's frame site isolation behavior. when chrome reports the inner frame directly, stagehand was returning the element path inside the iframe without the owning iframe path from the parent page. this caused the `xpath-for-location-deep.spec.ts` test to fail

this showed up in when using the `--disable-features=SitePerProcess` chrome flag

this PR also replaces the incorrect `-disable-features=site-per-process` flag with the correct `--disable-features=SitePerProcess` flag

# what changed
- updated coordinate xpath resolution to handle direct child frame hits from chrome
- when `DOM.getNodeForLocation` reports a different `frameId`, stagehand now looks up that frame's owning iframe with `DOM.getFrameOwner`
- the owning iframe is added to the xpath chain before resolving the inner-frame node
- this keeps coordinate based iframe targeting consistent across same-process and isolated iframe behavior

# test plan
- e2e test for `resolveNodeForLocationDeep` now passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes coordinate-based iframe targeting so XPath resolution stays consistent when `DOM.getNodeForLocation` reports a frame other than the current one, including nested iframes.

- Resolves each intermediate owning iframe via `DOM.getFrameOwner` and prepends them to the XPath chain.
- Returns no XPath when the reported frame's ancestry can't be fully traced to the current frame.
- Replaces the incorrect `--site-per-process` flag with `--disable-features=SitePerProcess`.

<sup>Written for commit f48ea1167681adf7b62543a9871bf69f07d2ec3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

