### PR TITLE
fix(locator): serialize mouse move/press/release CDP dispatch sequence (#2486)

### DIFF
--- a/packages/extension/understudy/locator.ts
+++ b/packages/extension/understudy/locator.ts
@@ -319,39 +319,31 @@ export class Locator {
       if (!box.model) throw new Error(`Element not visible (no box model): ${this.selector}`);
       const { cx, cy } = this.centerFromBoxContent(box.model.content);
 
-      // Dispatch click events in a pipelined burst to reduce inter-click delay
-      // from network/CPU jitter between round trips.
-      const dispatches: Array<Promise<unknown>> = [];
-      dispatches.push(
-        session.send<never>("Input.dispatchMouseEvent", {
-          type: "mouseMoved",
-          x: cx,
-          y: cy,
-          button: "none",
-        } as Protocol.Input.DispatchMouseEventRequest),
-      );
+      // Dispatch click events sequentially (mouseMoved -> mousePressed -> mouseReleased)
+      // to ensure component pointer and hover states properly settle before press/release.
+      await session.send<never>("Input.dispatchMouseEvent", {
+        type: "mouseMoved",
+        x: cx,
+        y: cy,
+        button: "none",
+      } as Protocol.Input.DispatchMouseEventRequest);
 
       for (let i = 1; i <= clickCount; i++) {
-        dispatches.push(
-          session.send<never>("Input.dispatchMouseEvent", {
-            type: "mousePressed",
-            x: cx,
-            y: cy,
-            button,
-            clickCount: i,
-          } as Protocol.Input.DispatchMouseEventRequest),
-        );
-        dispatches.push(
-          session.send<never>("Input.dispatchMouseEvent", {
-            type: "mouseReleased",
-            x: cx,
-            y: cy,
-            button,
-            clickCount: i,
-          } as Protocol.Input.DispatchMouseEventRequest),
-        );
+        await session.send<never>("Input.dispatchMouseEvent", {
+          type: "mousePressed",
+          x: cx,
+          y: cy,
+          button,
+          clickCount: i,
+        } as Protocol.Input.DispatchMouseEventRequest);
+        await session.send<never>("Input.dispatchMouseEvent", {
+          type: "mouseReleased",
+          x: cx,
+          y: cy,
+          button,
+          clickCount: i,
+        } as Protocol.Input.DispatchMouseEventRequest);
       }
-      await Promise.all(dispatches);
     } finally {
       // release the element handle
       try {


### PR DESCRIPTION
## Summary
- Fixes #2486 by ensuring CDP mouse events (`mouseMoved`, `mousePressed`, `mouseReleased`) in `Understudy.Locator.click` are dispatched sequentially instead of being pipelined via `Promise.all`.
- Prevents race conditions where selectable component states (such as active hover/pointer states in React buttons/anchors) fail to commit before press/release.

## Test Plan
- Verified sequential CDP input dispatch order.
- Verified cleanly formatted TS diff matching the repo's Understudy locator contract.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2486 by serializing the CDP mouse event dispatch sequence in `Locator.click`. Previously, `mouseMoved`, `mousePressed`, and `mouseReleased` were fired concurrently via `Promise.all`, which could let press/release execute before the browser committed hover or pointer states, causing missed clicks on React buttons and anchors. The events now run sequentially in order, with press/release repeated per click count as before.

<sup>Written for commit a5fcf49e4fcf4606b8e99108360a1292024845c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

