### PR TITLE
fix(extension): match button-like inputs on their value label

### DIFF
--- a/.changeset/text-selector-input-labels.md
+++ b/.changeset/text-selector-input-labels.md
@@ -1,0 +1,6 @@
+---
+"@browserbasehq/stagehand-extension": patch
+"@browserbasehq/stagehand": patch
+---
+
+Match `<input type="submit|reset|button">` on the label in its `value` when resolving `text=` selectors

--- a/packages/extension/dom/locatorScripts/counts.ts
+++ b/packages/extension/dom/locatorScripts/counts.ts
@@ -1,5 +1,6 @@
 import { countXPathMatches } from "./xpathResolver.js";
 import { getOpenOrClosedShadowRoot } from "./shadowRoots.js";
+import { attributeLabelText } from "./textLabels.js";
 
 export interface TextMatchSample {
   tag: string;
@@ -93,6 +94,8 @@ export function countTextMatches(rawNeedle: string): TextMatchResult {
   const extractText = (element: Element): string => {
     try {
       if (shouldSkip(element)) return "";
+      const label = attributeLabelText(element);
+      if (label !== null) return label;
       const inner = (element as HTMLElement).innerText;
       if (typeof inner === "string" && inner.trim()) return inner.trim();
     } catch {

--- a/packages/extension/dom/locatorScripts/selectors.ts
+++ b/packages/extension/dom/locatorScripts/selectors.ts
@@ -1,5 +1,6 @@
 import { resolveXPathAtIndex } from "./xpathResolver.js";
 import { getOpenOrClosedShadowRoot } from "./shadowRoots.js";
+import { attributeLabelText } from "./textLabels.js";
 
 const parseTargetIndex = (value: unknown): number => {
   const num = Number(value ?? 0);
@@ -90,6 +91,8 @@ export function resolveTextSelector(rawNeedle: string, targetIndexRaw?: number):
   const extractText = (node: Element): string => {
     try {
       if (shouldSkip(node)) return "";
+      const label = attributeLabelText(node);
+      if (label !== null) return label;
       const inner = (node as HTMLElement).innerText;
       if (typeof inner === "string" && inner.trim()) return inner.trim();
     } catch {

--- a/packages/extension/dom/locatorScripts/textLabels.ts
+++ b/packages/extension/dom/locatorScripts/textLabels.ts
@@ -1,0 +1,29 @@
+/*
+ * Runs inside the page context, same constraints as the other locator scripts:
+ * dependency-free and tolerant of exceptions.
+ */
+
+/** `<input>` types that carry their label in `value` instead of in a child text node. */
+const LABELLED_INPUT_TYPES = new Set(["button", "reset", "submit"]);
+
+/**
+ * The text a text selector should match an element on, when that text is not in the DOM.
+ *
+ * Returns `null` for elements that hold their text as child nodes, so callers keep reading
+ * `innerText`/`textContent` for those. An `<input>` never has child nodes, so it always
+ * answers here: its label for `button`, `reset` and `submit`, and the empty string for the
+ * types whose value is user data rather than a label.
+ */
+export function attributeLabelText(element: Element): string | null {
+  try {
+    if ((element.tagName ?? "").toUpperCase() !== "INPUT") return null;
+    const input = element as HTMLInputElement;
+    // The `type` property normalizes case and unknown values, so `type="SUBMIT"` lands here
+    // and `type="totally-made-up"` reads as `text`, exactly as the browser treats them.
+    const type = String(input.type ?? "").toLowerCase();
+    if (!LABELLED_INPUT_TYPES.has(type)) return "";
+    return String(input.value ?? "").trim();
+  } catch {
+    return null;
+  }
+}

--- a/packages/extension/tests/text-labels.test.ts
+++ b/packages/extension/tests/text-labels.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { attributeLabelText } from "../dom/locatorScripts/textLabels.js";
+
+const element = (props: Record<string, unknown>) => props as unknown as Element;
+
+describe("attributeLabelText", () => {
+  it("reads the label of button-like inputs from value", () => {
+    expect(
+      attributeLabelText(element({ tagName: "INPUT", type: "submit", value: "Publish" })),
+    ).toBe("Publish");
+    expect(attributeLabelText(element({ tagName: "INPUT", type: "reset", value: "Discard" }))).toBe(
+      "Discard",
+    );
+    expect(
+      attributeLabelText(element({ tagName: "INPUT", type: "button", value: "Preview" })),
+    ).toBe("Preview");
+  });
+
+  it("treats the value of every other input as data, not as a label", () => {
+    expect(attributeLabelText(element({ tagName: "INPUT", type: "text", value: "typed" }))).toBe(
+      "",
+    );
+    expect(attributeLabelText(element({ tagName: "INPUT", type: "image", value: "Send" }))).toBe(
+      "",
+    );
+    expect(attributeLabelText(element({ tagName: "INPUT", type: "file", value: "a.txt" }))).toBe(
+      "",
+    );
+  });
+
+  it("has no label to offer when value is absent", () => {
+    expect(attributeLabelText(element({ tagName: "INPUT", type: "submit" }))).toBe("");
+  });
+
+  it("trims the label and takes the type case-insensitively", () => {
+    // The browser normalizes `type` on the property already; the lowercasing is a safety net
+    // for anything that reaches this function with the raw attribute instead.
+    expect(
+      attributeLabelText(element({ tagName: "INPUT", type: "SUBMIT", value: "  Shout  " })),
+    ).toBe("Shout");
+  });
+
+  it("leaves elements that hold their text in the DOM to the caller", () => {
+    expect(attributeLabelText(element({ tagName: "BUTTON", textContent: "Save" }))).toBeNull();
+    expect(attributeLabelText(element({ tagName: "TEXTAREA", value: "Draft body" }))).toBeNull();
+  });
+});

--- a/packages/sdk-ts/tests/integration/locatorTextInputLabels.test.ts
+++ b/packages/sdk-ts/tests/integration/locatorTextInputLabels.test.ts
@@ -1,0 +1,65 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { Stagehand } from "../../src/index.js";
+import {
+  closeStagehand,
+  createStagehand,
+  firstPage,
+  startFixtureServer,
+  type FixtureServer,
+} from "./_support.js";
+
+// A button-like <input> keeps its label in `value` and has no child nodes at all, so the
+// text engine has to read the attribute to see it. Served over http because the locator
+// scripts only run against a real page.
+const FIXTURE = `<!doctype html>
+<html>
+  <body>
+    <input id="publish" type="submit" value="Publish" />
+    <input id="discard" type="reset" value="Discard" />
+    <input id="preview" type="button" value="Preview" />
+    <input id="typed" type="text" value="typed value" />
+    <input id="image" type="image" value="Send" alt="Upload" />
+    <button id="plain">Save</button>
+  </body>
+</html>`;
+
+describe("text selectors against inputs that label themselves", () => {
+  let fixtureServer: FixtureServer;
+  let stagehand: Stagehand;
+
+  beforeAll(async () => {
+    fixtureServer = await startFixtureServer(FIXTURE);
+    stagehand = await createStagehand();
+  });
+
+  afterAll(async () => {
+    await closeStagehand(stagehand);
+    await fixtureServer.close();
+  });
+
+  it("matches submit, reset and button inputs on their value", async () => {
+    const page = await firstPage(stagehand);
+    await page.goto(fixtureServer.url, { waitUntil: "load" });
+
+    await expect.poll(() => page.locator("text=Publish").count()).toBe(1);
+    await expect(page.locator("text=Discard").count()).resolves.toBe(1);
+    await expect(page.locator("text=Preview").count()).resolves.toBe(1);
+
+    // The match is the input itself, not some ancestor that happens to contain it.
+    await expect(page.locator("text=Publish").first().inputValue()).resolves.toBe("Publish");
+  });
+
+  it("leaves the value of other inputs alone", async () => {
+    const page = await firstPage(stagehand);
+    await page.goto(fixtureServer.url, { waitUntil: "load" });
+
+    // A typed-in value is data, not a label, and an image button is not labelled by either
+    // its value or its alt text.
+    await expect.poll(() => page.locator("text=typed value").count()).toBe(0);
+    await expect(page.locator("text=Send").count()).resolves.toBe(0);
+    await expect(page.locator("text=Upload").count()).resolves.toBe(0);
+
+    // Control: elements that carry their text as child nodes keep matching as before.
+    await expect(page.locator("text=Save").count()).resolves.toBe(1);
+  });
+});

--- a/scripts/test-integration.ts
+++ b/scripts/test-integration.ts
@@ -43,6 +43,7 @@ export const integrationTestGroups = {
     "locatorContentMethods",
     "locatorCount",
     "locatorNth",
+    "locatorTextInputLabels",
     "textSelectorInnermost",
   ],
   "local/locators-write": ["locatorFill", "locatorInputMethods", "locatorSelectOption"],


### PR DESCRIPTION
## why

`<input type="submit" value="Publish">` renders a button that says Publish, and `page.locator("text=Publish")` does not find it.

The text engine reads a candidate's text through `innerText` with a `textContent` fallback. An `<input>` is void: it has no child nodes, so both reads return the empty string no matter what the control says on screen. A `submit`, `reset` or `button` input carries its label in `value`, and nothing looks there.

The failure is a silent zero. `count()` returns 0, and an action on the locator reports that the element does not exist, which sends you looking at the page instead of at the read. Submit buttons written this way are ordinary markup, and they are exactly the elements a text locator is written for.

Measured on `main` against Playwright 1.56, one fixture served over http:

| markup | selector | today | Playwright |
| --- | --- | --- | --- |
| `<input type="submit" value="Publish">` | `text=Publish` | **0** | 1 |
| `<input type="reset" value="Discard">` | `text=Discard` | **0** | 1 |
| `<input type="button" value="Preview">` | `text=Preview` | **0** | 1 |
| `<input type="text" value="typed value">` | `text=typed value` | 0 | 0 |
| `<input type="submit">`, no `value` | `text=Submit` | 0 | 0 |
| `<input type="image" value="Send" alt="Upload">` | `text=Send`, `text=Upload` | 0 | 0 |
| `<textarea>Draft body</textarea>` | `text=Draft body` | 1 | 1 |

The bottom four rows are the boundary rather than the bug. A typed-in value is user data, not a label; an image button is labelled by neither `value` nor `alt`; a submit input with no `value` has no label to offer, even though the browser paints a default one; and a `<textarea>` already matches, because its content is a real text node.

## what changed

New `packages/extension/dom/locatorScripts/textLabels.ts` holds the whole rule as one dependency-free function, `attributeLabelText`. It answers for `<input>` and only for `<input>`: the trimmed `value` for `button`, `reset` and `submit`, the empty string for every other type, and `null` for anything that keeps its text in the DOM, which leaves the existing `innerText`/`textContent` read untouched for every element that has one. Reading the `type` property rather than the attribute is what makes `type="SUBMIT"` and unknown types behave the way the browser already treats them.

`resolveTextSelector` in `selectors.ts` and `countTextMatches` in `counts.ts` each consult it as the first step of `extractText`. Both, because the two functions are independent copies of the same matching logic, and fixing one would leave `count()` and `nth()` disagreeing about the same page. Deduplicating them is a larger change than this one and is deliberately not part of it.

## test plan

`packages/extension/tests/text-labels.test.ts` (new, unit): the table above as a rule, including the empty-value case and the types that must stay unlabelled.

`packages/sdk-ts/tests/integration/locatorTextInputLabels.test.ts` (new, integration): the same cases against real Chrome, plus `inputValue()` on the match to show the resolved node is the input itself and not an ancestor that happens to contain it. Listed in `scripts/test-integration.ts`, which discovery requires: an integration file that belongs to no group makes `groupIntegrationTests` throw.

The integration spec is the regression: on `main` it fails with `expected +0 to be 1`. The unit spec cannot fail on `main`, since it covers a function this PR introduces; it is there to pin the boundary rows so a later change has to decide about them on purpose.

The rest of `local/locators-read` stays green, `textSelectorInnermost` included, as do the neighbouring input specs `locatorFill`, `locatorInputMethods` and `waitForSelector`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `text=` selectors so they match `<input type="submit|reset|button">` on the `value` attribute, aligning with Playwright. Previously these inputs returned zero matches because they are void elements with no child text nodes, so the engine's `innerText`/`textContent` read came up empty. Now both `count()` and `nth()` consult the `value` label for those three types only; other input types (text, image, etc.) still don't match on value, and elements that hold their text as child nodes are unaffected.

<sup>Written for commit 4f63b600d08577389e3b8a4063205485cfa9640e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browserbase/stagehand/pull/2853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

