### PR TITLE
feat(ruby): M3 — inbound dispatcher + client-side LLMs (77/77)

### DIFF
--- a/packages/sdk-ruby/ESTIMATE.md
+++ b/packages/sdk-ruby/ESTIMATE.md
@@ -16,34 +16,34 @@ Python and Go SDKs are built.
 
 ## What the spike proved (de-risked)
 
-| Risk | Outcome |
-|---|---|
-| No JSON-Schema→Ruby codegen exists | Custom stdlib-only generator, 274 LOC, covers all 234 defs + method registries, `--check` drift mode wired into `just generate`/`just check` |
-| Wire casing | Free — the schema is already snake_case; opaque containers pass through verbatim (fixture round-trip tested) |
-| Sync Ruby ↔ bidirectional RPC | Background-reader-thread model (Go-style) works; `websocket-driver` + own TCP/SSL socket, no reactor framework needed |
-| Chrome without Playwright | Hand-rolled launcher ported from Python's `browser.py` works headless + headed on macOS |
-| Extension packaging | Ruby zip is **byte-identical** to the Python SDK's deterministic archive (same SHA-256) |
-| No Browserbase Ruby SDK exists | Hand-rolled 4-endpoint REST client (~130 LOC) suffices, mirroring Go |
-| End-to-end | `goto → observe → act → extract` verified live on a local Chrome (transport) and on a Browserbase session (full AI loop incl. extension upload + Model Gateway + session release) |
+| Risk                               | Outcome                                                                                                                                                                           |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| No JSON-Schema→Ruby codegen exists | Custom stdlib-only generator, 274 LOC, covers all 234 defs + method registries, `--check` drift mode wired into `just generate`/`just check`                                      |
+| Wire casing                        | Free — the schema is already snake_case; opaque containers pass through verbatim (fixture round-trip tested)                                                                      |
+| Sync Ruby ↔ bidirectional RPC      | Background-reader-thread model (Go-style) works; `websocket-driver` + own TCP/SSL socket, no reactor framework needed                                                             |
+| Chrome without Playwright          | Hand-rolled launcher ported from Python's `browser.py` works headless + headed on macOS                                                                                           |
+| Extension packaging                | Ruby zip is **byte-identical** to the Python SDK's deterministic archive (same SHA-256)                                                                                           |
+| No Browserbase Ruby SDK exists     | Hand-rolled 4-endpoint REST client (~130 LOC) suffices, mirroring Go                                                                                                              |
+| End-to-end                         | `goto → observe → act → extract` verified live on a local Chrome (transport) and on a Browserbase session (full AI loop incl. extension upload + Model Gateway + session release) |
 
 Spike size: ~2,400 hand-written LOC + ~2,000 generated + ~800 tests. Python comparison:
 ~4,900 hand-written + ~3,600 generated — a fair proxy for the finished Ruby size.
 
 ## Work breakdown to production parity
 
-| # | Item | Weeks |
-|---|---|---|
-| A | Walking skeleton (this spike) | 2.5–3 *(sunk)* |
-| B | Full method surface (~62 remaining: context 14, page ~26, locator 17, response 6, clipboard, webmcp, file upload, callback_batch passthrough) — mechanical wrapper + tests per method, batched by namespace | 3–4 |
-| C | Client-side LLM (`llm.generate` inbound handler, message/tool unions, custom-LLM example) | 1 |
-| D | Validation hardening: strict unions, input ergonomics, RBS signatures, thread-safety soak | 1–1.5 |
-| E | 11-example set + `example-parity` compliance | 0.5–1 |
-| F | Parity tooling: ast-grep Ruby lane (`@ast-grep/lang-ruby` availability is the biggest unknown; prism-based fallback +0.5–1 wk) + extend `rules/ast-grep/*` | 1–1.5 |
-| G | Docs: Ruby tabs across `docs/v4/reference/*` + guides + `sdk-reference.test.ts` | 1 |
-| H | Release + CI: turbo task, changesets version proxy, `sync-ruby-version.ts`, extension embedding in the gem, RubyGems trusted publishing + alpha lane, CI matrix (Ruby 3.2–3.4 × macOS/Linux), **Windows launcher** | 1.5–2 |
-| I | Beta hardening buffer (real-world sites, large payloads, memory/soak) | 1–1.5 |
-| | **Total beyond spike** | **10–13.5** |
-| | **Total including spike** | **~12.5–16.5** |
+| #   | Item                                                                                                                                                                                                               | Weeks          |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------- |
+| A   | Walking skeleton (this spike)                                                                                                                                                                                      | 2.5–3 _(sunk)_ |
+| B   | Full method surface (~62 remaining: context 14, page ~26, locator 17, response 6, clipboard, webmcp, file upload, callback_batch passthrough) — mechanical wrapper + tests per method, batched by namespace        | 3–4            |
+| C   | Client-side LLM (`llm.generate` inbound handler, message/tool unions, custom-LLM example)                                                                                                                          | 1              |
+| D   | Validation hardening: strict unions, input ergonomics, RBS signatures, thread-safety soak                                                                                                                          | 1–1.5          |
+| E   | 11-example set + `example-parity` compliance                                                                                                                                                                       | 0.5–1          |
+| F   | Parity tooling: ast-grep Ruby lane (`@ast-grep/lang-ruby` availability is the biggest unknown; prism-based fallback +0.5–1 wk) + extend `rules/ast-grep/*`                                                         | 1–1.5          |
+| G   | Docs: Ruby tabs across `docs/v4/reference/*` + guides + `sdk-reference.test.ts`                                                                                                                                    | 1              |
+| H   | Release + CI: turbo task, changesets version proxy, `sync-ruby-version.ts`, extension embedding in the gem, RubyGems trusted publishing + alpha lane, CI matrix (Ruby 3.2–3.4 × macOS/Linux), **Windows launcher** | 1.5–2          |
+| I   | Beta hardening buffer (real-world sites, large payloads, memory/soak)                                                                                                                                              | 1–1.5          |
+|     | **Total beyond spike**                                                                                                                                                                                             | **10–13.5**    |
+|     | **Total including spike**                                                                                                                                                                                          | **~12.5–16.5** |
 
 ## Ongoing cost
 

--- a/packages/sdk-ruby/README.md
+++ b/packages/sdk-ruby/README.md
@@ -16,8 +16,9 @@ end to end but deliberately implements only a sliver of the API surface.
   attach (with wake nudge), `__stagehandSendToHost` binding, runtime marker + semver
   negotiation, `Runtime.evaluate` double-JSON envelope delivery.
 - **JSON-RPC client** (`rpc_client.rb`) — strict envelopes, per-method timeout table,
-  notification buffering (`stagehand.log` → stderr), inbound requests answered with
-  `-32601`, deterministic shutdown.
+  notification buffering (`stagehand.log` → stderr), an inbound dispatcher thread
+  serving server→client requests (`on_request`, used for `llm.generate`) and
+  notification listeners, deterministic shutdown.
 - **Local Chrome** (`browser.rb`) — hand-rolled launcher (no Playwright): Chrome
   discovery, temp profile, the Stagehand flag set, `Extensions.loadUnpacked`.
 - **Browserbase** (`browserbase_client.rb`, `browserbase_session.rb`,
@@ -26,9 +27,11 @@ end to end but deliberately implements only a sliver of the API surface.
   and `Stagehand::Browserbase.session_logs(api_key:, session_id:)` to fetch a
   session's raw CDP event log for post-run verification.
 - **Client surface** — `Stagehand.create` / `close`, `act`, `extract` (plain JSON
-  Schema hashes), `observe`, `metrics`, and `experimental_batch` (trusted
+  Schema hashes), `observe`, `metrics`, `experimental_batch` (trusted
   JavaScript against the worker-local object model via the callback-batch
-  CDP delivery path).
+  CDP delivery path), and client-side LLMs: pass a callable as `model:` and
+  every model call comes back as an inbound `llm.generate` request with
+  decoded params (see `examples/custom_llm.rb`).
 - **Page** — navigation (`goto/reload/go_back/go_forward`, returning a
   `Stagehand::Response` with `status/headers/body/security_details/finished`),
   `url/title/close`, input (`click/hover/scroll/drag_and_drop/type/key_press`),
@@ -91,11 +94,11 @@ each runnable as `bundle exec ruby examples/<name>.rb [--browserbase]`:
 | `batch.rb` | mirrors the Python example; callback batch, no LLM needed |
 | `page_events.rb` | mirrors the Python example; page.on console events + AI extract |
 | `context_and_response.rb` | Response/cookies/clipboard/viewport/snapshot tour; no LLM needed |
+| `custom_llm.rb` | mirrors the Python example; bring-your-own-LLM via `llm.generate` (OPENAI_API_KEY or AI_GATEWAY_API_KEY) |
 | `demo.rb`, `arctic_observe.rb` | spike walkthroughs (not part of the canonical set) |
 
-The remaining canonical examples need `llm.generate` inbound dispatch (priced
-in `ESTIMATE.md`): `custom_llm`; `webmcp` additionally needs a WebMCP-enabled
-target page.
+The one remaining canonical example is `webmcp`, which needs a WebMCP-enabled
+target page (the `page.webmcp_*` methods themselves are wrapped and tested).
 
 ## Development
 
@@ -109,15 +112,15 @@ ruby scripts/generate.rb      # regenerate models (also part of `just generate`)
 
 ## Spike shortcuts (not production behavior)
 
-- 76 of the 77 protocol methods are wrapped — the complete outbound surface.
-  The one remaining method, `llm.generate` (client-side LLM), is inbound
-  (extension→SDK) and needs a request dispatcher thread.
+- All 77 protocol methods are wrapped — the complete method surface,
+  including inbound `llm.generate` (client-side LLMs).
 - Unions decode laxly (first structurally-matching variant); no strict scalar
   validation (the extension re-validates everything server-side).
 - No OpenTelemetry trace propagation (`traceparent` is simply omitted).
 - `Browserbase.launch(browser_settings:)` is a camelCase passthrough hash.
 - Windows Chrome launching is not implemented.
-- Notification listeners (including `page.on` event blocks) run on the RPC
-  reader thread and must not issue RPC calls.
+- Inbound work (request handlers, notification listeners including `page.on`
+  blocks) runs on one dispatcher thread: handlers may issue RPC calls, but a
+  slow handler delays later inbound work (Python runs these concurrently).
 - Not wired into ast-grep parity tests, docs tabs, CI, or release tooling
   (each is priced in `ESTIMATE.md`).

--- a/packages/sdk-ruby/README.md
+++ b/packages/sdk-ruby/README.md
@@ -41,8 +41,8 @@ end to end but deliberately implements only a sliver of the API surface.
   and WebMCP (`tools` → invoke/result/cancel).
 - **Locator** — `page.locator(selector)` → all 17 locator methods
   (`click/fill/type/hover/scroll_to/count/text_content/inner_text/inner_html/
-  input_value/visible?/checked?/centroid/highlight/send_click_event/
-  select_option/set_input_files` + `first`/`nth`; file uploads take paths or
+input_value/visible?/checked?/centroid/highlight/send_click_event/
+select_option/set_input_files` + `first`/`nth`; file uploads take paths or
   `Stagehand::FilePayload`, 50 MiB/file).
 - **Context** — `pages/new_page/active_page/set_active_page/close`, cookies
   (`cookies/add_cookies/clear_cookies` with String/Regexp filters), clipboard
@@ -81,21 +81,21 @@ Browserbase sessions.
 Ruby ports of the canonical example set (`packages/sdk-{ts,python,go}/examples`),
 each runnable as `bundle exec ruby examples/<name>.rb [--browserbase]`:
 
-| Example | Notes |
-|---|---|
-| `act.rb`, `observe.rb`, `extract.rb` | example.com, mirror the Python examples |
-| `model_gateway.rb` | Browserbase-only; no model configured (Gateway picks one) |
-| `caching.rb` | Browserbase-only; `cache: true` + `metadata.cache` round-trip |
-| `custom_logging.rb` | `on_log:` callback appending JSONL to `stagehand.jsonl` |
-| `file_upload.rb` | mirrors the Python example; no LLM needed (runs local or Browserbase) |
-| `page_interactions.rb` | locator fill/type/click/readers, evaluate, screenshot, history; no LLM needed |
-| `hybrid_news.rb` | AI extract + deterministic locators/pagination/screenshot on Hacker News |
-| `search_flow.rb` | locator-driven search on DuckDuckGo + AI extraction of the results |
-| `batch.rb` | mirrors the Python example; callback batch, no LLM needed |
-| `page_events.rb` | mirrors the Python example; page.on console events + AI extract |
-| `context_and_response.rb` | Response/cookies/clipboard/viewport/snapshot tour; no LLM needed |
-| `custom_llm.rb` | mirrors the Python example; bring-your-own-LLM via `llm.generate` (OPENAI_API_KEY or AI_GATEWAY_API_KEY) |
-| `demo.rb`, `arctic_observe.rb` | spike walkthroughs (not part of the canonical set) |
+| Example                              | Notes                                                                                                    |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| `act.rb`, `observe.rb`, `extract.rb` | example.com, mirror the Python examples                                                                  |
+| `model_gateway.rb`                   | Browserbase-only; no model configured (Gateway picks one)                                                |
+| `caching.rb`                         | Browserbase-only; `cache: true` + `metadata.cache` round-trip                                            |
+| `custom_logging.rb`                  | `on_log:` callback appending JSONL to `stagehand.jsonl`                                                  |
+| `file_upload.rb`                     | mirrors the Python example; no LLM needed (runs local or Browserbase)                                    |
+| `page_interactions.rb`               | locator fill/type/click/readers, evaluate, screenshot, history; no LLM needed                            |
+| `hybrid_news.rb`                     | AI extract + deterministic locators/pagination/screenshot on Hacker News                                 |
+| `search_flow.rb`                     | locator-driven search on DuckDuckGo + AI extraction of the results                                       |
+| `batch.rb`                           | mirrors the Python example; callback batch, no LLM needed                                                |
+| `page_events.rb`                     | mirrors the Python example; page.on console events + AI extract                                          |
+| `context_and_response.rb`            | Response/cookies/clipboard/viewport/snapshot tour; no LLM needed                                         |
+| `custom_llm.rb`                      | mirrors the Python example; bring-your-own-LLM via `llm.generate` (OPENAI_API_KEY or AI_GATEWAY_API_KEY) |
+| `demo.rb`, `arctic_observe.rb`       | spike walkthroughs (not part of the canonical set)                                                       |
 
 The one remaining canonical example is `webmcp`, which needs a WebMCP-enabled
 target page (the `page.webmcp_*` methods themselves are wrapped and tested).

--- a/packages/sdk-ruby/examples/custom_llm.rb
+++ b/packages/sdk-ruby/examples/custom_llm.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+# Bring-your-own-LLM: pass a callable as `model:` and Stagehand routes every
+# model call back to it as an inbound llm.generate request (mirrors
+# packages/sdk-python/examples/custom_llm.py). The callable receives decoded
+# LLMStructuredGenerateParams / LLMMessageGenerateParams and must return a
+# matching *GenerateResult.
+#
+# Provider: OPENAI_API_KEY (api.openai.com) or AI_GATEWAY_API_KEY (Vercel AI
+# Gateway, OpenAI-compatible). Both use the chat completions JSON-schema
+# response format.
+#
+#   ruby examples/custom_llm.rb                # local Chrome
+#   ruby examples/custom_llm.rb --browserbase  # Browserbase session
+
+require "json"
+require "net/http"
+require "uri"
+
+require_relative "../lib/stagehand"
+require_relative "example_helpers"
+
+if ExampleHelpers.env("OPENAI_API_KEY")
+  LLM_URL = URI("https://api.openai.com/v1/chat/completions")
+  LLM_API_KEY = ExampleHelpers.env("OPENAI_API_KEY")
+  LLM_MODEL = "gpt-5.4-mini"
+elsif ExampleHelpers.env("AI_GATEWAY_API_KEY")
+  LLM_URL = URI("https://ai-gateway.vercel.sh/v1/chat/completions")
+  LLM_API_KEY = ExampleHelpers.env("AI_GATEWAY_API_KEY")
+  LLM_MODEL = "openai/gpt-5.4-mini"
+else
+  abort "Set OPENAI_API_KEY or AI_GATEWAY_API_KEY."
+end
+
+GENERATION_NAMES = []
+
+def message_text(content)
+  blocks = content.is_a?(Array) ? content : [content]
+  blocks.map do |block|
+    unless block.is_a?(Stagehand::Models::LLMTextContent)
+      kind = block.respond_to?(:type) ? block.type : block.class.name
+      raise ArgumentError, "This example does not support #{kind} message blocks"
+    end
+    block.text
+  end.join("\n")
+end
+
+# The llm.generate handler. Runs on the SDK's dispatcher thread.
+def generate_with_openai(params)
+  unless params.is_a?(Stagehand::Models::LLMStructuredGenerateParams)
+    raise ArgumentError, "This example only supports structured generation"
+  end
+
+  response_format = params.response_format
+  raise ArgumentError, "OpenAI structured output requires a JSON Schema" unless response_format.schema.is_a?(Hash)
+
+  GENERATION_NAMES << response_format.name
+  json_schema = { "name" => response_format.name, "schema" => response_format.schema, "strict" => true }
+  json_schema["description"] = response_format.description unless response_format.description.nil?
+  messages = []
+  messages << { "role" => "system", "content" => params.system_prompt } unless params.system_prompt.nil?
+  params.messages.each { |message| messages << { "role" => message.role, "content" => message_text(message.content) } }
+  body = {
+    "model" => LLM_MODEL,
+    "messages" => messages,
+    "response_format" => { "type" => "json_schema", "json_schema" => json_schema },
+  }
+  body["temperature"] = params.temperature unless params.temperature.nil?
+
+  http_response = Net::HTTP.post(
+    LLM_URL,
+    JSON.generate(body),
+    "Authorization" => "Bearer #{LLM_API_KEY}",
+    "Content-Type" => "application/json",
+  )
+  raise "LLM request failed: #{http_response.code} #{http_response.body[0, 300]}" unless http_response.code == "200"
+
+  payload = JSON.parse(http_response.body)
+  choice = payload.fetch("choices").first
+  output_text = choice.dig("message", "content")
+  raise "LLM returned no output text" if output_text.nil? || output_text.empty?
+
+  usage = payload["usage"]
+  values = {
+    role: "assistant",
+    content: Stagehand::Models::LLMTextContent.new(type: "text", text: output_text),
+    output_format: "json_schema",
+    structured_content: JSON.parse(output_text),
+  }
+  values[:stop_reason] = choice["finish_reason"] unless choice["finish_reason"].nil?
+  unless usage.nil?
+    usage_values = {
+      input_tokens: usage["prompt_tokens"],
+      output_tokens: usage["completion_tokens"],
+      total_tokens: usage["total_tokens"],
+    }
+    reasoning = usage.dig("completion_tokens_details", "reasoning_tokens")
+    cached = usage.dig("prompt_tokens_details", "cached_tokens")
+    usage_values[:reasoning_tokens] = reasoning unless reasoning.nil?
+    usage_values[:cached_input_tokens] = cached unless cached.nil?
+    values[:usage] = Stagehand::Models::LLMUsage.new(**usage_values)
+  end
+  Stagehand::Models::LLMStructuredGenerateResult.new(**values)
+end
+
+PAGE_INFO_SCHEMA = {
+  "type" => "object",
+  "properties" => {
+    "heading" => { "type" => "string" },
+    "description" => { "type" => "string" },
+  },
+  "required" => %w[heading description],
+  "additionalProperties" => false,
+}.freeze
+
+browser =
+  if ARGV.include?("--browserbase")
+    api_key = ExampleHelpers.env("BROWSERBASE_API_KEY") or abort "Set BROWSERBASE_API_KEY."
+    puts "Creating a Browserbase session..."
+    Stagehand::Browserbase.launch(api_key: api_key)
+  else
+    puts "Launching local Chrome..."
+    Stagehand::LocalBrowser.launch(headless: ENV["HEADED"].nil?)
+  end
+
+begin
+  stagehand = Stagehand.create(
+    browser: browser,
+    model: method(:generate_with_openai),
+    log_level: ENV.fetch("STAGEHAND_LOG_LEVEL", "warn"),
+  )
+  begin
+    page = browser.context.pages.first
+    raise "Stagehand initialized without an active page" if page.nil?
+    page.goto("https://example.com")
+
+    extract_result = stagehand.extract("Extract the page heading and description", schema: PAGE_INFO_SCHEMA)
+    observe_result = stagehand.observe("Find the link that provides more information about Example Domain")
+    act_result = stagehand.act("Click the link that provides more information about Example Domain")
+
+    puts JSON.pretty_generate({
+      "page_info" => extract_result.data,
+      "actions" => observe_result.data.map(&:to_wire),
+      "action_result" => act_result.data.to_wire,
+      "generation_names" => GENERATION_NAMES,
+    })
+
+    raise "observe() returned no matching actions" if observe_result.data.empty?
+    raise "act() failed: #{act_result.data.message}" unless act_result.data.success
+  ensure
+    stagehand.close
+  end
+ensure
+  browser.close
+end
+puts "Closed."

--- a/packages/sdk-ruby/examples/page_events.rb
+++ b/packages/sdk-ruby/examples/page_events.rb
@@ -22,7 +22,7 @@ PAGE_INFO = {
 ExampleHelpers.with_stagehand do |stagehand, page|
   console_events = Thread::Queue.new
   subscription = page.on("console") do |event|
-    # Runs on the RPC reader thread: only hand the event over, no RPC calls.
+    # Runs on the RPC dispatcher thread: keep it quick, hand the event over.
     console_events << event if event.params.is_a?(Hash) && event.params["type"] == "log"
   end
 

--- a/packages/sdk-ruby/lib/stagehand/client.rb
+++ b/packages/sdk-ruby/lib/stagehand/client.rb
@@ -35,6 +35,12 @@ module Stagehand
         if model.nil? && (model_api_key || model_headers)
           raise ArgumentError, "model connection options require a model name"
         end
+        if model.respond_to?(:call) && (model_api_key || model_headers)
+          raise ArgumentError, "model connection options cannot be used with an LLM callback"
+        end
+        unless model.nil? || model.is_a?(String) || model.respond_to?(:call)
+          raise ArgumentError, "model must be a model name String or a callable LLM generate handler"
+        end
         unless LOG_LEVEL_PRIORITY.key?(log_level)
           raise ArgumentError, "log_level must be one of #{LOG_LEVEL_PRIORITY.keys.join(", ")}"
         end
@@ -77,6 +83,7 @@ module Stagehand
       @config = config
       @rpc_client = nil
       @remove_log_listener = nil
+      @remove_client_llm_handler = nil
       @initialized = false
       @close_mutex = Mutex.new
       @closed = false
@@ -171,6 +178,10 @@ module Stagehand
       rpc_client = RPCClient.new(@cdp_client)
       @rpc_client = rpc_client
       @remove_log_listener = rpc_client.on_notification("stagehand.log") { |log| handle_log(log) }
+      if client_llm?
+        client_llm = @config[:model]
+        @remove_client_llm_handler = rpc_client.on_request("llm.generate") { |params| client_llm.call(params) }
+      end
       rpc_client.send("stagehand.init", Models::StagehandInitParams.new(**worker_init_values), "StagehandInitResult")
       @browser.__attach_context(BrowserContext.new(rpc_client))
       @initialized = true
@@ -178,6 +189,8 @@ module Stagehand
     end
 
     def __release_resources
+      @remove_client_llm_handler&.call
+      @remove_client_llm_handler = nil
       @remove_log_listener&.call
       @remove_log_listener = nil
       rpc_client = @rpc_client
@@ -189,6 +202,12 @@ module Stagehand
     end
 
     private
+
+    # A callable model (anything responding to #call, e.g. a Proc) is a
+    # client-side LLM: the worker sends llm.generate requests back to it.
+    def client_llm?
+      @config[:model].respond_to?(:call)
+    end
 
     def connected_rpc_client
       unless @initialized && @rpc_client
@@ -234,7 +253,9 @@ module Stagehand
       values[:system_prompt] = @config[:system_prompt] unless @config[:system_prompt].nil?
       values[:self_heal] = @config[:self_heal] unless @config[:self_heal].nil?
       values[:dom_settle_timeout_ms] = @config[:dom_settle_timeout_ms] unless @config[:dom_settle_timeout_ms].nil?
-      unless @config[:model].nil?
+      if client_llm?
+        values[:model] = Models::ClientModelReference.new(source: "client")
+      elsif !@config[:model].nil?
         model_values = { model_name: @config[:model] }
         model_values[:api_key] = @config[:model_api_key] unless @config[:model_api_key].nil?
         model_values[:headers] = @config[:model_headers] unless @config[:model_headers].nil?

--- a/packages/sdk-ruby/lib/stagehand/page.rb
+++ b/packages/sdk-ruby/lib/stagehand/page.rb
@@ -180,8 +180,8 @@ module Stagehand
 
     # Subscribes to a page event ("console", ...); the block receives each
     # Models::PageCDPEvent. Returns a CDPSubscription. The block runs on the
-    # RPC reader thread, so it must not issue RPC calls itself — hand the
-    # event to another thread/queue for anything beyond recording it.
+    # RPC dispatcher thread and may issue RPC calls, but a slow block delays
+    # other inbound work (later events, llm.generate requests).
     def on(event, &listener)
       raise ArgumentError, "a listener block is required" if listener.nil?
 

--- a/packages/sdk-ruby/lib/stagehand/rpc_client.rb
+++ b/packages/sdk-ruby/lib/stagehand/rpc_client.rb
@@ -9,14 +9,13 @@ require_relative "generated/models"
 
 module Stagehand
   # JSON-RPC 2.0 client over a Stagehand transport (the CDP client). Port of
-  # packages/sdk-python/src/stagehand/rpc_client.py onto a background reader
-  # thread with per-request queues.
-  #
-  # Spike notes:
-  # - Inbound server->client requests (llm.generate) are answered with
-  #   -32601 Method not found; client-LLM support needs a dispatcher thread.
-  # - Notification listeners (stagehand.log, page.cdp_event) run inline on
-  #   the reader thread, so they must not issue RPC calls themselves.
+  # packages/sdk-python/src/stagehand/rpc_client.py onto two background
+  # threads: a reader that routes responses to per-request queues, and a
+  # dispatcher that runs inbound work (server->client requests such as
+  # llm.generate, and notification listeners). Handlers and listeners run on
+  # the dispatcher thread and may issue RPC calls themselves; inbound work is
+  # processed one item at a time, so a slow handler delays later inbound
+  # requests and notifications (Python runs these as concurrent tasks).
   class RPCClient
     MAX_REQUEST_ID = 9_007_199_254_740_991
     MAX_PENDING_NOTIFICATIONS = 100
@@ -57,10 +56,14 @@ module Stagehand
       @next_request_id = 1
       @state_mutex = Mutex.new
       @pending = {}
+      @request_handlers = {}
       @notification_listeners = Hash.new { |hash, key| hash[key] = [] }
       @pending_notifications = []
+      @inbound = Thread::Queue.new
       @closed = false
       @close_reason = nil
+      @dispatcher = Thread.new { dispatch_loop }
+      @dispatcher.name = "stagehand-rpc-dispatcher"
       @reader = Thread.new { read_loop }
       @reader.name = "stagehand-rpc-reader"
     end
@@ -101,9 +104,31 @@ module Stagehand
       end
     end
 
+    # Registers the handler for an inbound server->client request (e.g.
+    # llm.generate). Params arrive decoded via Models::METHODS; the handler's
+    # return value (a wire model or Hash matching the result definition) is
+    # sent back as the JSON-RPC result. The handler runs on the dispatcher
+    # thread and may issue RPC calls. Returns a proc that removes the handler
+    # (a no-op if another handler replaced it in the meantime).
+    def on_request(method, &handler)
+      raise StagehandError, "RPC client is closed" if @closed
+      raise ArgumentError, "a handler block is required" if handler.nil?
+
+      token = Object.new
+      @state_mutex.synchronize { @request_handlers[method] = { token: token, handler: handler } }
+      lambda do
+        @state_mutex.synchronize do
+          registered = @request_handlers[method]
+          @request_handlers.delete(method) if registered && registered[:token].equal?(token)
+        end
+      end
+    end
+
     # Registers a listener for a server notification. Params are decoded via
-    # Models::NOTIFICATIONS when the method is a known notification. Returns
-    # a proc that removes the listener.
+    # Models::NOTIFICATIONS when the method is a known notification. Listeners
+    # run on the dispatcher thread (never the caller's), so a notification
+    # buffered before registration is also replayed asynchronously. Returns a
+    # proc that removes the listener.
     def on_notification(method, &listener)
       raise StagehandError, "RPC client is closed" if @closed
       raise ArgumentError, "a listener block is required" if listener.nil?
@@ -114,7 +139,7 @@ module Stagehand
         @pending_notifications.reject! { |entry| entry.fetch("method") == method }
         buffered
       end
-      replayable.each { |entry| dispatch_notification(method, entry["params"], [listener]) }
+      replayable.each { |entry| @inbound << [:notification, method, entry["params"], [listener]] }
 
       lambda do
         @state_mutex.synchronize do
@@ -130,16 +155,22 @@ module Stagehand
         return if @closed
         @closed = true
         @close_reason = reason || StagehandError.new("RPC client closed")
+        @request_handlers.clear
         @notification_listeners.clear
         @pending_notifications.clear
         @pending.each_value { |queue| queue << @close_reason }
         @pending.clear
       end
+      @inbound << :close
       @transport.close if close_transport
       unless Thread.current == @reader
         # The real transport unblocks the reader on close; the kill is a
         # backstop for transports that cannot (it is parked in receive).
         @reader.kill unless @reader.join(2)
+      end
+      unless Thread.current == @dispatcher
+        # The kill is a backstop for a handler stuck in slow user code.
+        @dispatcher.kill unless @dispatcher.join(2)
       end
       nil
     end
@@ -259,7 +290,21 @@ module Stagehand
           registered.dup
         end
       end
-      dispatch_notification(method, message["params"], listeners) if listeners
+      @inbound << [:notification, method, message["params"], listeners] if listeners
+    end
+
+    def dispatch_loop
+      loop do
+        entry = @inbound.pop
+        break if entry == :close
+        kind, *rest = entry
+        case kind
+        when :notification then dispatch_notification(*rest)
+        when :request then handle_request(rest.first)
+        end
+      end
+    rescue Exception => error
+      close(error) unless @closed
     end
 
     def dispatch_notification(method, params, listeners)
@@ -289,7 +334,69 @@ module Stagehand
         return
       end
 
-      send_error(message["id"], -32_601, "Method not found")
+      @inbound << [:request, message]
+    end
+
+    # Runs on the dispatcher thread: decode params, run the registered
+    # handler, validate its result against the method's wire definition, and
+    # answer. Errors map to JSON-RPC codes the same way the Python SDK does.
+    def handle_request(message)
+      request_id = message["id"]
+      registered = @state_mutex.synchronize { @request_handlers[message["method"]] }
+      if registered.nil?
+        send_error(request_id, -32_601, "Method not found")
+        return
+      end
+
+      entry = Models::METHODS[message["method"]]
+      params =
+        begin
+          decoded = entry ? Wire.decode(message["params"], entry[:params]) : message["params"]
+          # Union params must decode to a wire model (unions are otherwise lax).
+          raise WireError, "params match no union variant" if entry && union_descriptor?(entry[:params]) && !decoded.is_a?(Wire::Model)
+          decoded
+        rescue WireError
+          send_error(request_id, -32_602, "Invalid params")
+          return
+        end
+
+      result =
+        begin
+          registered[:handler].call(params)
+        rescue StandardError => error
+          send_error(request_id, -32_603, error.message, { "name" => error.class.name })
+          return
+        end
+
+      wire_result =
+        begin
+          encoded = Wire.encode(result)
+          if entry
+            decoded = Wire.decode(encoded, entry[:result])
+            # Unions decode laxly (raw value when no variant matches), so a
+            # union result must round-trip back to a wire model to be valid.
+            raise WireError, "result matches no union variant" if union_descriptor?(entry[:result]) && !decoded.is_a?(Wire::Model)
+          end
+          encoded
+        rescue StandardError
+          send_error(request_id, -32_603, "Internal error")
+          return
+        end
+
+      begin
+        @transport.send({ "jsonrpc" => "2.0", "id" => request_id, "result" => wire_result })
+      rescue StandardError
+        nil
+      end
+    end
+
+    def union_descriptor?(descriptor, depth = 0)
+      return false if depth > 16
+      case descriptor
+      when String then union_descriptor?(Models::DEFS[descriptor], depth + 1)
+      when Array then descriptor.first == :union
+      else false
+      end
     end
 
     def send_error(request_id, code, message, data = nil)

--- a/packages/sdk-ruby/lib/stagehand/wire.rb
+++ b/packages/sdk-ruby/lib/stagehand/wire.rb
@@ -58,7 +58,8 @@ module Stagehand
       end
     end
 
-    def decode_union(value, variants)
+    def decode_union(value, variants, depth = 0)
+      return value if depth > 16
       if value.is_a?(Hash)
         variants.each do |variant|
           model = resolve_model(variant)
@@ -67,10 +68,20 @@ module Stagehand
         end
       end
       variants.each do |variant|
-        next unless variant.is_a?(Array)
-        kind = variant.first
-        return decode(value, variant) if kind == :array && value.is_a?(Array)
-        return decode(value, variant) if kind == :map && value.is_a?(Hash)
+        descriptor = variant.is_a?(String) ? Models::DEFS[variant] : variant
+        next unless descriptor.is_a?(Array)
+        kind = descriptor.first
+        case kind
+        when :array
+          return decode(value, descriptor) if value.is_a?(Array)
+        when :map
+          return decode(value, descriptor) if value.is_a?(Hash)
+        when :union
+          # A reference to another union (e.g. LLMMessageContentBlock): decode
+          # through it and keep the result when a nested variant matched.
+          decoded = decode_union(value, descriptor.last, depth + 1)
+          return decoded unless decoded.equal?(value)
+        end
       end
       value
     end

--- a/packages/sdk-ruby/test/test_client_llm.rb
+++ b/packages/sdk-ruby/test/test_client_llm.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require_relative "support/fake_transport"
+
+# Client-side LLM (bring-your-own-model): a callable `model:` registers an
+# llm.generate handler and announces itself to the worker as
+# ClientModelReference(source: "client").
+class TestClientLLM < Minitest::Test
+  def build_client(model:)
+    transport = FakeTransport.new
+    def transport.web_socket_debugger_url = "ws://127.0.0.1:9222/devtools/browser/fake"
+    browser = Object.new
+    def browser.__attach_context(context) = @context = context
+
+    client = Stagehand::Client.allocate
+    client.instance_variable_set(:@browser, browser)
+    client.instance_variable_set(:@cdp_client, transport)
+    client.instance_variable_set(:@worker_init_metadata, Stagehand::WorkerInitMetadata.new(api_key: nil, browser: nil))
+    client.instance_variable_set(:@config, { model: model, log_level: "warn" })
+    client.instance_variable_set(:@rpc_client, nil)
+    client.instance_variable_set(:@remove_log_listener, nil)
+    client.instance_variable_set(:@remove_client_llm_handler, nil)
+    client.instance_variable_set(:@initialized, false)
+    [client, transport]
+  end
+
+  def test_worker_init_announces_client_model_and_serves_llm_generate
+    calls = []
+    model = lambda do |params|
+      calls << params
+      Stagehand::Models::LLMStructuredGenerateResult.new(
+        role: "assistant",
+        content: Stagehand::Models::LLMTextContent.new(type: "text", text: "{}"),
+        output_format: "json_schema",
+        structured_content: { "heading" => "Example Domain" },
+      )
+    end
+    client, transport = build_client(model: model)
+
+    responder = Thread.new do
+      request = transport.next_sent
+      transport.push({ "jsonrpc" => "2.0", "id" => request["id"],
+                       "result" => { "initialized" => true, "pages" => [] } })
+      request
+    end
+    client.__initialize_runtime
+    init_request = responder.value
+    assert_equal "stagehand.init", init_request["method"]
+    assert_equal({ "source" => "client" }, init_request["params"]["model"])
+
+    transport.push({
+      "jsonrpc" => "2.0", "id" => 3, "method" => "llm.generate",
+      "params" => {
+        "messages" => [{ "role" => "user", "content" => { "type" => "text", "text" => "extract" } }],
+        "response_format" => { "type" => "json_schema", "name" => "page_info", "schema" => { "type" => "object" } },
+      },
+    })
+    reply = transport.next_sent
+    assert_equal 3, reply["id"]
+    assert_equal "Example Domain", reply.dig("result", "structured_content", "heading")
+    assert_equal 1, calls.size
+    assert_instance_of Stagehand::Models::LLMStructuredGenerateParams, calls.first
+
+    # Close the transport first so the RPC reader unblocks without the kill
+    # backstop's 2s join; then release exactly like Client#close does.
+    transport.close
+    client.__release_resources
+    assert_nil client.instance_variable_get(:@remove_client_llm_handler)
+  end
+
+  def test_string_model_still_sends_model_config
+    client, transport = build_client(model: nil)
+    client.instance_variable_set(:@config, { model: "openai/gpt-5-mini", model_api_key: "sk-test", log_level: "warn" })
+    values = client.send(:worker_init_values)
+    assert_instance_of Stagehand::Models::ModelConfig, values[:model]
+    assert_equal "openai/gpt-5-mini", values[:model].model_name
+    transport.close
+  end
+
+  def test_create_rejects_connection_options_with_callback
+    browser = Stagehand::StagehandBrowser.allocate
+    error = assert_raises(ArgumentError) do
+      Stagehand::Client.create(browser: browser, model: ->(params) { params }, model_api_key: "sk-test")
+    end
+    assert_equal "model connection options cannot be used with an LLM callback", error.message
+  end
+
+  def test_create_rejects_non_string_non_callable_model
+    browser = Stagehand::StagehandBrowser.allocate
+    error = assert_raises(ArgumentError) do
+      Stagehand::Client.create(browser: browser, model: 42)
+    end
+    assert_match(/model name String or a callable/, error.message)
+  end
+end

--- a/packages/sdk-ruby/test/test_rpc_client.rb
+++ b/packages/sdk-ruby/test/test_rpc_client.rb
@@ -21,6 +21,32 @@ class TestRPCClient < Minitest::Test
     end
   end
 
+  # Inbound work (notifications, requests) is dispatched asynchronously.
+  def wait_until(timeout: 2)
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+    until yield
+      flunk "condition not met within #{timeout}s" if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+      sleep 0.005
+    end
+  end
+
+  LLM_REQUEST = {
+    "jsonrpc" => "2.0", "id" => 11, "method" => "llm.generate",
+    "params" => {
+      "messages" => [{ "role" => "user", "content" => { "type" => "text", "text" => "hi" } }],
+      "response_format" => { "type" => "json_schema", "name" => "extract", "schema" => { "type" => "object" } },
+    },
+  }.freeze
+
+  def structured_result(text: "{}", structured_content: {})
+    Stagehand::Models::LLMStructuredGenerateResult.new(
+      role: "assistant",
+      content: Stagehand::Models::LLMTextContent.new(type: "text", text: text),
+      output_format: "json_schema",
+      structured_content: structured_content,
+    )
+  end
+
   def test_request_response_round_trip
     responder = respond_to_next_request do |request|
       assert_equal "2.0", request["jsonrpc"]
@@ -84,15 +110,93 @@ class TestRPCClient < Minitest::Test
     @client.on_notification("stagehand.log") { |log| seen << log }
     @client.receive({ "jsonrpc" => "2.0", "method" => "stagehand.log",
                       "params" => { "level" => "warn", "message" => "late", "data" => {} } })
+    wait_until { seen.size == 2 }
     assert_equal %w[early late], seen.map(&:message)
     assert_instance_of Stagehand::Models::StagehandLog, seen.first
   end
 
-  def test_inbound_request_gets_method_not_found
+  def test_inbound_request_without_handler_gets_method_not_found
     @client.receive({ "jsonrpc" => "2.0", "id" => 7, "method" => "llm.generate", "params" => {} })
     reply = @transport.next_sent
     assert_equal 7, reply["id"]
     assert_equal(-32_601, reply.dig("error", "code"))
+  end
+
+  def test_on_request_round_trip
+    seen = nil
+    @client.on_request("llm.generate") do |params|
+      seen = params
+      structured_result(structured_content: { "greeting" => "hello" })
+    end
+    @client.receive(LLM_REQUEST.dup)
+    reply = @transport.next_sent
+    assert_equal 11, reply["id"]
+    assert_equal(
+      { "role" => "assistant", "content" => { "type" => "text", "text" => "{}" },
+        "output_format" => "json_schema", "structured_content" => { "greeting" => "hello" } },
+      reply["result"],
+    )
+    assert_instance_of Stagehand::Models::LLMStructuredGenerateParams, seen
+    assert_equal "extract", seen.response_format.name
+    assert_equal "hi", seen.messages.first.content.text
+  end
+
+  def test_request_handler_may_issue_rpc_calls
+    @client.on_request("llm.generate") do |_params|
+      title = @client.send("page.title", Stagehand::Models::PageIdParams.new(page_id: "page-1"), "PageTitleResult")
+      structured_result(structured_content: { "title" => title })
+    end
+    @client.receive(LLM_REQUEST.dup)
+    inner = @transport.next_sent
+    assert_equal "page.title", inner["method"]
+    @transport.push({ "jsonrpc" => "2.0", "id" => inner["id"], "result" => "Example Domain" })
+    reply = @transport.next_sent
+    assert_equal 11, reply["id"]
+    assert_equal "Example Domain", reply.dig("result", "structured_content", "title")
+  end
+
+  def test_request_handler_error_maps_to_internal_error_with_name
+    @client.on_request("llm.generate") { raise "llm exploded" }
+    @client.receive(LLM_REQUEST.dup)
+    reply = @transport.next_sent
+    assert_equal 11, reply["id"]
+    assert_equal(-32_603, reply.dig("error", "code"))
+    assert_equal "llm exploded", reply.dig("error", "message")
+    assert_equal({ "name" => "RuntimeError" }, reply.dig("error", "data"))
+  end
+
+  def test_request_with_unmatched_union_params_gets_invalid_params
+    @client.on_request("llm.generate") { |params| params }
+    @client.receive({ "jsonrpc" => "2.0", "id" => 4, "method" => "llm.generate", "params" => { "foo" => 1 } })
+    reply = @transport.next_sent
+    assert_equal 4, reply["id"]
+    assert_equal(-32_602, reply.dig("error", "code"))
+  end
+
+  def test_invalid_handler_result_maps_to_internal_error
+    @client.on_request("llm.generate") { { "bogus" => true } }
+    @client.receive(LLM_REQUEST.dup)
+    reply = @transport.next_sent
+    assert_equal(-32_603, reply.dig("error", "code"))
+    assert_equal "Internal error", reply.dig("error", "message")
+  end
+
+  def test_on_request_remove_restores_method_not_found
+    remove = @client.on_request("llm.generate") { structured_result }
+    replaced = @client.on_request("llm.generate") { structured_result }
+    remove.call # stale removal is a no-op: the second registration stays
+    @client.receive(LLM_REQUEST.dup)
+    assert_equal 11, @transport.next_sent["id"]
+    replaced.call
+    @client.receive(LLM_REQUEST.merge("id" => 12))
+    reply = @transport.next_sent
+    assert_equal 12, reply["id"]
+    assert_equal(-32_601, reply.dig("error", "code"))
+  end
+
+  def test_on_request_after_close_raises
+    @client.close
+    assert_raises(Stagehand::StagehandError) { @client.on_request("llm.generate") { nil } }
   end
 
   def test_malformed_json_gets_parse_error


### PR DESCRIPTION
Part of the AP-2857 parity stack:

**Stack:** #2820 (spike) ← #2854 (M1–M2) ← **this PR (M3)** ← M4 (#2851)

The 77th and final protocol method — inbound `llm.generate`:

- `RPCClient` gains a dedicated dispatcher thread for inbound work and an `on_request` API: params decoded and results validated via the generated wire registry, JSON-RPC error mapping matching Python (`-32601`/`-32602`/`-32603` with the error class name as data)
- Notification listeners (including `page.on` blocks) now run on the dispatcher and may issue RPC calls (the reader-thread restriction is gone)
- `Stagehand.create(model: ->(params) { … })` registers an `llm.generate` handler and announces `ClientModelReference(source: "client")` in `stagehand.init`
- Wire unions follow nested union references, so LLM message content decodes to typed blocks
- `examples/custom_llm.rb`: port of `custom_llm.py` over an OpenAI-compatible chat completions endpoint (OPENAI_API_KEY or Vercel AI Gateway)

## Verification
- 108 unit tests / 711 assertions
- Live on local Chrome **and** Browserbase: `custom_llm.rb` runs extract/observe/act with every model call served by the Ruby callback (4 `llm.generate` round trips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)