### PR TITLE
feat(ruby): M6c — release lane + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
       sdk-ts: ${{ steps.filter.outputs.sdk-ts }}
       sdk-python: ${{ steps.filter.outputs.sdk-python }}
       sdk-go: ${{ steps.filter.outputs.sdk-go }}
+      sdk-ruby: ${{ steps.filter.outputs.sdk-ruby }}
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
@@ -56,6 +57,11 @@ jobs:
               - '.github/**'
             sdk-go:
               - 'packages/sdk-go/**'
+              - 'packages/extension/**'
+              - 'packages/protocol/**'
+              - '.github/**'
+            sdk-ruby:
+              - 'packages/sdk-ruby/**'
               - 'packages/extension/**'
               - 'packages/protocol/**'
               - '.github/**'
@@ -300,6 +306,61 @@ jobs:
           uv run --isolated --no-project
           --with dist/*.whl
           python scripts/smoke.py
+        env:
+          CHROME_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
+
+  ruby-checks:
+    name: Ruby checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [determine-changes]
+    if: needs.determine-changes.outputs.sdk-ruby == 'true'
+    defaults:
+      run:
+        working-directory: packages/sdk-ruby
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64 # v1.299.0
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: packages/sdk-ruby
+
+      - run: ruby scripts/generate.rb --check
+      - run: bundle exec rake
+
+  ruby-gem-smoke:
+    name: Ruby gem smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [build, determine-changes]
+    if: needs.determine-changes.outputs.sdk-ruby == 'true'
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - uses: ./.github/actions/setup-node-pnpm
+        with:
+          use-prebuilt-artifacts: "true"
+
+      - uses: ./.github/actions/setup-chrome-verified
+        id: setup-chrome
+
+      - uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64 # v1.299.0
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: packages/sdk-ruby
+
+      - run: pnpm --filter ./packages/extension build
+      - run: ruby packages/sdk-ruby/scripts/build.rb
+
+      - name: Smoke test installed gem
+        run: |
+          export GEM_HOME="$RUNNER_TEMP/stagehand-gem-smoke"
+          export GEM_PATH="$GEM_HOME"
+          gem install --no-document packages/sdk-ruby/dist/*.gem
+          ruby packages/sdk-ruby/scripts/smoke.rb
         env:
           CHROME_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
 

--- a/.github/workflows/publish-ruby.yml
+++ b/.github/workflows/publish-ruby.yml
@@ -1,0 +1,135 @@
+name: Publish Ruby SDK
+
+# Callable from release.yml once the Ruby SDK reaches its release bar, and
+# manually dispatchable for the first publish. RubyGems trusted publishing
+# must be configured for this repository + workflow on rubygems.org
+# (the `stagehand` gem is Browserbase-owned; 3.x was the retired v3 client).
+on:
+  workflow_dispatch:
+    inputs:
+      alpha:
+        description: Publish a commit-addressed alpha (`<next>.pre.alpha.<N>`) instead of the checked-in version.
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      alpha:
+        description: Publish a commit-addressed alpha (`<next>.pre.alpha.<N>`) instead of the checked-in version.
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build Ruby gem
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    outputs:
+      version: ${{ steps.package-version.outputs.version }}
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          # Alphas number builds by commit count.
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: "11.10.0"
+          run_install: false
+
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: "24"
+          cache: pnpm
+
+      - uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd # v2.1.2
+        id: setup-chrome
+        with:
+          chrome-version: stable
+          install-dependencies: true
+
+      - uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64 # v1.299.0
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: packages/sdk-ruby
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Apply alpha version
+        if: inputs.alpha
+        run: |
+          pnpm exec changeset version --snapshot
+          pnpm exec tsx scripts/release/ruby-alpha-version.ts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Build only the extension bundled into the gem and the gem itself.
+      # Alpha versioning temporarily changes other workspace packages, so the
+      # repository-wide build would validate unrelated SDK artifacts against
+      # those ephemeral versions.
+      - run: pnpm --filter ./packages/extension build
+      - run: ruby packages/sdk-ruby/scripts/build.rb
+
+      - name: Read package version
+        id: package-version
+        run: |
+          VERSION="$(ruby -r ./packages/sdk-ruby/lib/stagehand/version.rb -e 'print Stagehand::VERSION')"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Smoke test installed gem
+        run: |
+          export GEM_HOME="$RUNNER_TEMP/stagehand-gem-smoke"
+          export GEM_PATH="$GEM_HOME"
+          gem install --no-document packages/sdk-ruby/dist/*.gem
+          ruby packages/sdk-ruby/scripts/smoke.rb
+        env:
+          CHROME_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ruby-gem
+          path: packages/sdk-ruby/dist/*.gem
+          if-no-files-found: error
+
+  publish:
+    name: Publish Ruby gem
+    needs: build
+    runs-on: ubuntu-latest
+    environment: rubygems
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ruby-gem
+          path: dist
+
+      - uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64 # v1.299.0
+        with:
+          ruby-version: "3.3"
+
+      - uses: rubygems/configure-rubygems-credentials@bc6dd217f8a4f919d6835fcfefd470ef821f5c44 # v1.0.0
+
+      - run: gem push dist/*.gem
+
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          fetch-depth: 0
+
+      - name: Tag Ruby release
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          TAG="stagehand-ruby@$VERSION"
+          if git rev-parse --verify --quiet "refs/tags/$TAG"; then
+            echo "$TAG already exists"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG" "$GITHUB_SHA"
+          git push origin "$TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,12 @@ jobs:
           enable-cache: true
           cache-dependency-glob: packages/sdk-python/uv.lock
 
+      - uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64 # v1.299.0
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: packages/sdk-ruby
+
       - uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
 
       - run: just install

--- a/justfile
+++ b/justfile
@@ -1,10 +1,12 @@
 python_dir := "packages/sdk-python"
+ruby_dir := "packages/sdk-ruby"
 go_dir := "packages/sdk-go"
 go_generator_dir := "packages/sdk-go/internal/generator"
 
 install:
     pnpm install
     uv --directory {{python_dir}} sync --locked
+    cd {{ruby_dir}} && bundle install
     go -C {{go_dir}} mod download
     go -C {{go_generator_dir}} mod download
 
@@ -19,6 +21,7 @@ check: check-go-examples
     pnpm exec tsx scripts/release/check-changesets.ts
     pnpm exec tsx scripts/release/consolidate-changelogs.ts --check
     pnpm exec tsx scripts/release/sync-python-version.ts --check
+    pnpm exec tsx scripts/release/sync-ruby-version.ts --check
     pnpm check
     uv --directory {{python_dir}} lock --check
     uv --directory {{python_dir}} run --locked python scripts/generate.py --check
@@ -39,6 +42,7 @@ check-go-examples:
 test:
     pnpm test
     uv --directory {{python_dir}} run --locked pytest
+    cd {{ruby_dir}} && bundle exec rake
     go -C {{go_dir}} test $(go -C {{go_dir}} list ./... | grep -v '/examples$')
     go -C {{go_generator_dir}} test ./...
 
@@ -62,6 +66,7 @@ fmt:
 build:
     pnpm build
     uv --directory {{python_dir}} run --locked python scripts/build.py
+    ruby {{ruby_dir}}/scripts/build.rb
     go -C {{go_dir}} run ./internal/extensionpack --check
     go -C {{go_dir}} build $(go -C {{go_dir}} list ./... | grep -v '/examples$')
     go -C {{go_generator_dir}} test -run '^$' ./...
@@ -79,9 +84,11 @@ _version:
     pnpm exec changeset version
     pnpm exec tsx scripts/release/consolidate-changelogs.ts
     pnpm exec tsx scripts/release/sync-python-version.ts
+    pnpm exec tsx scripts/release/sync-ruby-version.ts
     uv --directory "{{python_dir}}" lock
     just generate
     pnpm exec tsx scripts/release/sync-python-version.ts --check
+    pnpm exec tsx scripts/release/sync-ruby-version.ts --check
 
 # Builds the commit-addressed bundle used by labeled pull request previews.
 _preview commit:
@@ -106,3 +113,10 @@ _version-python-alpha:
     pnpm exec changeset version --snapshot
     pnpm exec tsx scripts/release/python-alpha-version.ts
     uv --directory "{{python_dir}}" lock
+
+# Rewrites the Ruby gem version to the commit-addressed alpha
+# (`<next>.pre.alpha.<N>`) derived from the changesets snapshot version.
+# Nothing is committed; the working tree is discarded after publishing.
+_version-ruby-alpha:
+    pnpm exec changeset version --snapshot
+    pnpm exec tsx scripts/release/ruby-alpha-version.ts

--- a/packages/docs/tests/sdk-reference.test.ts
+++ b/packages/docs/tests/sdk-reference.test.ts
@@ -1283,7 +1283,7 @@ describe("Mintlify customization boundary", () => {
       differences,
       "Language-scoped documentation must use field names derived from that SDK's public source",
     ).toEqual([]);
-  });
+  }, 30_000); // Parses every MDX page; cold CI runners exceed the 5s default.
 
   it("includes every indexed MDX content page in docs.json navigation", async () => {
     const docsConfig = JSON.parse(
@@ -1393,7 +1393,7 @@ describe("Mintlify customization boundary", () => {
       problems,
       "Every language tab group must offer the same languages, so switching never hides a snippet",
     ).toEqual([]);
-  });
+  }, 30_000); // Parses every MDX page; cold CI runners exceed the 5s default.
 
   it("never mixes language tabs with other tabs in one group", async () => {
     const contentPages = (await listFiles(V4_DOCS_ROOT, shouldInspectDocsDirectory)).filter(

--- a/packages/docs/tests/sdk-reference.test.ts
+++ b/packages/docs/tests/sdk-reference.test.ts
@@ -462,7 +462,7 @@ describe("SDK reference surface", () => {
     }
 
     expect(problems, "Internal v4 reference links must resolve to a page and heading").toEqual([]);
-  });
+  }, 30_000); // Parses every MDX page; cold CI runners exceed the 5s default.
 
   it("documents callable helper members as methods and metadata as properties", async () => {
     const webmcpPath = resolve(REFERENCE_ROOT, "webmcp.mdx");
@@ -1314,7 +1314,7 @@ describe("Mintlify customization boundary", () => {
       navigatedPages,
       "Every indexed MDX content page must be reachable from docs.json",
     ).toStrictEqual(indexedContentPages);
-  });
+  }, 30_000); // Parses every MDX page; cold CI runners exceed the 5s default.
 
   it("gives every language tab group the same complete language set", async () => {
     const contentPages = (await listFiles(V4_DOCS_ROOT, shouldInspectDocsDirectory)).filter(
@@ -1422,7 +1422,7 @@ describe("Mintlify customization boundary", () => {
       problems,
       "A tab group switches on exactly one axis: either language or something else, never both",
     ).toEqual([]);
-  });
+  }, 30_000); // Parses every MDX page; cold CI runners exceed the 5s default.
 
   it("uses no custom presentation code", async () => {
     const customPresentationFiles = (await listFiles(V4_DOCS_ROOT, shouldInspectDocsDirectory))
@@ -1438,7 +1438,7 @@ describe("Mintlify customization boundary", () => {
       customPresentationFiles,
       "Mintlify should use native components without custom CSS, JavaScript, JSX, or TSX",
     ).toStrictEqual([]);
-  });
+  }, 30_000); // Parses every MDX page; cold CI runners exceed the 5s default.
 });
 
 async function readTypescriptMethods(): Promise<SdkMethod[]> {

--- a/packages/sdk-ruby/.gitignore
+++ b/packages/sdk-ruby/.gitignore
@@ -1,6 +1,6 @@
 .bundle/
 vendor/
-Gemfile.lock
+dist/
 *.gem
 lib/stagehand/_extension/
 stagehand.jsonl

--- a/packages/sdk-ruby/ESTIMATE.md
+++ b/packages/sdk-ruby/ESTIMATE.md
@@ -16,34 +16,34 @@ Python and Go SDKs are built.
 
 ## What the spike proved (de-risked)
 
-| Risk | Outcome |
-|---|---|
-| No JSON-Schema→Ruby codegen exists | Custom stdlib-only generator, 274 LOC, covers all 234 defs + method registries, `--check` drift mode wired into `just generate`/`just check` |
-| Wire casing | Free — the schema is already snake_case; opaque containers pass through verbatim (fixture round-trip tested) |
-| Sync Ruby ↔ bidirectional RPC | Background-reader-thread model (Go-style) works; `websocket-driver` + own TCP/SSL socket, no reactor framework needed |
-| Chrome without Playwright | Hand-rolled launcher ported from Python's `browser.py` works headless + headed on macOS |
-| Extension packaging | Ruby zip is **byte-identical** to the Python SDK's deterministic archive (same SHA-256) |
-| No Browserbase Ruby SDK exists | Hand-rolled 4-endpoint REST client (~130 LOC) suffices, mirroring Go |
-| End-to-end | `goto → observe → act → extract` verified live on a local Chrome (transport) and on a Browserbase session (full AI loop incl. extension upload + Model Gateway + session release) |
+| Risk                               | Outcome                                                                                                                                                                           |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| No JSON-Schema→Ruby codegen exists | Custom stdlib-only generator, 274 LOC, covers all 234 defs + method registries, `--check` drift mode wired into `just generate`/`just check`                                      |
+| Wire casing                        | Free — the schema is already snake_case; opaque containers pass through verbatim (fixture round-trip tested)                                                                      |
+| Sync Ruby ↔ bidirectional RPC      | Background-reader-thread model (Go-style) works; `websocket-driver` + own TCP/SSL socket, no reactor framework needed                                                             |
+| Chrome without Playwright          | Hand-rolled launcher ported from Python's `browser.py` works headless + headed on macOS                                                                                           |
+| Extension packaging                | Ruby zip is **byte-identical** to the Python SDK's deterministic archive (same SHA-256)                                                                                           |
+| No Browserbase Ruby SDK exists     | Hand-rolled 4-endpoint REST client (~130 LOC) suffices, mirroring Go                                                                                                              |
+| End-to-end                         | `goto → observe → act → extract` verified live on a local Chrome (transport) and on a Browserbase session (full AI loop incl. extension upload + Model Gateway + session release) |
 
 Spike size: ~2,400 hand-written LOC + ~2,000 generated + ~800 tests. Python comparison:
 ~4,900 hand-written + ~3,600 generated — a fair proxy for the finished Ruby size.
 
 ## Work breakdown to production parity
 
-| # | Item | Weeks |
-|---|---|---|
-| A | Walking skeleton (this spike) | 2.5–3 *(sunk)* |
-| B | Full method surface (~62 remaining: context 14, page ~26, locator 17, response 6, clipboard, webmcp, file upload, callback_batch passthrough) — mechanical wrapper + tests per method, batched by namespace | 3–4 |
-| C | Client-side LLM (`llm.generate` inbound handler, message/tool unions, custom-LLM example) | 1 |
-| D | Validation hardening: strict unions, input ergonomics, RBS signatures, thread-safety soak | 1–1.5 |
-| E | 11-example set + `example-parity` compliance | 0.5–1 |
-| F | Parity tooling: ast-grep Ruby lane (`@ast-grep/lang-ruby` availability is the biggest unknown; prism-based fallback +0.5–1 wk) + extend `rules/ast-grep/*` | 1–1.5 |
-| G | Docs: Ruby tabs across `docs/v4/reference/*` + guides + `sdk-reference.test.ts` | 1 |
-| H | Release + CI: turbo task, changesets version proxy, `sync-ruby-version.ts`, extension embedding in the gem, RubyGems trusted publishing + alpha lane, CI matrix (Ruby 3.2–3.4 × macOS/Linux), **Windows launcher** | 1.5–2 |
-| I | Beta hardening buffer (real-world sites, large payloads, memory/soak) | 1–1.5 |
-| | **Total beyond spike** | **10–13.5** |
-| | **Total including spike** | **~12.5–16.5** |
+| #   | Item                                                                                                                                                                                                               | Weeks          |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------- |
+| A   | Walking skeleton (this spike)                                                                                                                                                                                      | 2.5–3 _(sunk)_ |
+| B   | Full method surface (~62 remaining: context 14, page ~26, locator 17, response 6, clipboard, webmcp, file upload, callback_batch passthrough) — mechanical wrapper + tests per method, batched by namespace        | 3–4            |
+| C   | Client-side LLM (`llm.generate` inbound handler, message/tool unions, custom-LLM example)                                                                                                                          | 1              |
+| D   | Validation hardening: strict unions, input ergonomics, RBS signatures, thread-safety soak                                                                                                                          | 1–1.5          |
+| E   | 11-example set + `example-parity` compliance                                                                                                                                                                       | 0.5–1          |
+| F   | Parity tooling: ast-grep Ruby lane (`@ast-grep/lang-ruby` availability is the biggest unknown; prism-based fallback +0.5–1 wk) + extend `rules/ast-grep/*`                                                         | 1–1.5          |
+| G   | Docs: Ruby tabs across `docs/v4/reference/*` + guides + `sdk-reference.test.ts`                                                                                                                                    | 1              |
+| H   | Release + CI: turbo task, changesets version proxy, `sync-ruby-version.ts`, extension embedding in the gem, RubyGems trusted publishing + alpha lane, CI matrix (Ruby 3.2–3.4 × macOS/Linux), **Windows launcher** | 1.5–2          |
+| I   | Beta hardening buffer (real-world sites, large payloads, memory/soak)                                                                                                                                              | 1–1.5          |
+|     | **Total beyond spike**                                                                                                                                                                                             | **10–13.5**    |
+|     | **Total including spike**                                                                                                                                                                                          | **~12.5–16.5** |
 
 ## Ongoing cost
 

--- a/packages/sdk-ruby/Gemfile.lock
+++ b/packages/sdk-ruby/Gemfile.lock
@@ -1,0 +1,45 @@
+PATH
+  remote: .
+  specs:
+    stagehand (4.0.0)
+      websocket-driver (~> 0.8)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    base64 (0.3.0)
+    logger (1.7.0)
+    minitest (5.27.0)
+    rake (13.4.2)
+    rbs (3.10.4)
+      logger
+      tsort
+    tsort (0.2.0)
+    websocket-driver (0.8.2)
+      base64
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+
+PLATFORMS
+  arm64-darwin-24
+  ruby
+
+DEPENDENCIES
+  minitest (~> 5.25)
+  rake (~> 13.2)
+  rbs (~> 3.9)
+  stagehand!
+
+CHECKSUMS
+  base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
+  rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+  rbs (3.10.4) sha256=b17d7c4be4bb31a11a3b529830f0aa206a807ca42f2e7921a3027dfc6b7e5ce8
+  stagehand (4.0.0)
+  tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
+  websocket-driver (0.8.2) sha256=97c556b019bf3410b4961002ac501621e9322d3f8a7bc02161a09301cc4c4146
+  websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
+
+BUNDLED WITH
+  4.0.16

--- a/packages/sdk-ruby/README.md
+++ b/packages/sdk-ruby/README.md
@@ -50,8 +50,8 @@ end to end but deliberately implements only a sliver of the API surface.
   and WebMCP (`tools` → invoke/result/cancel).
 - **Locator** — `page.locator(selector)` → all 17 locator methods
   (`click/fill/type/hover/scroll_to/count/text_content/inner_text/inner_html/
-  input_value/visible?/checked?/centroid/highlight/send_click_event/
-  select_option/set_input_files` + `first`/`nth`; file uploads take paths or
+input_value/visible?/checked?/centroid/highlight/send_click_event/
+select_option/set_input_files` + `first`/`nth`; file uploads take paths or
   `Stagehand::FilePayload`, 50 MiB/file).
 - **Context** — `pages/new_page/active_page/set_active_page/close`, cookies
   (`cookies/add_cookies/clear_cookies` with String/Regexp filters), clipboard
@@ -92,17 +92,17 @@ self-contained and runnable as `bundle exec ruby examples/<name>.rb
 [--browserbase]`. The `example-parity` ast-grep lane keeps their inventory and
 SDK operations aligned with the sibling SDKs.
 
-| Example | Notes |
-|---|---|
+| Example                              | Notes                                                                         |
+| ------------------------------------ | ----------------------------------------------------------------------------- |
 | `act.rb`, `observe.rb`, `extract.rb` | example.com; local runs need OPENAI_API_KEY, `--browserbase` uses the Gateway |
-| `model_gateway.rb` | Browserbase-only; no model configured (Gateway picks one) |
-| `caching.rb` | Browserbase-only; `cache: true` + `metadata.cache` round-trip |
-| `custom_logging.rb` | `on_log:` callback appending JSONL to `stagehand.jsonl` |
-| `file_upload.rb` | locator.set_input_files + evaluate; no LLM needed |
-| `batch.rb` | callback batch, no LLM needed |
-| `page_events.rb` | page.on console events + AI extract |
-| `custom_llm.rb` | bring-your-own-LLM via `llm.generate` (OPENAI_API_KEY or AI_GATEWAY_API_KEY) |
-| `webmcp.rb` | page-registered tools via `page.tools` → invoke → result; no LLM needed |
+| `model_gateway.rb`                   | Browserbase-only; no model configured (Gateway picks one)                     |
+| `caching.rb`                         | Browserbase-only; `cache: true` + `metadata.cache` round-trip                 |
+| `custom_logging.rb`                  | `on_log:` callback appending JSONL to `stagehand.jsonl`                       |
+| `file_upload.rb`                     | locator.set_input_files + evaluate; no LLM needed                             |
+| `batch.rb`                           | callback batch, no LLM needed                                                 |
+| `page_events.rb`                     | page.on console events + AI extract                                           |
+| `custom_llm.rb`                      | bring-your-own-LLM via `llm.generate` (OPENAI_API_KEY or AI_GATEWAY_API_KEY)  |
+| `webmcp.rb`                          | page-registered tools via `page.tools` → invoke → result; no LLM needed       |
 
 `examples/extras/` holds Ruby-only walkthroughs outside the canonical set
 (`demo.rb`, `page_interactions.rb`, `context_and_response.rb`,

--- a/packages/sdk-ruby/lib/stagehand/version.rb
+++ b/packages/sdk-ruby/lib/stagehand/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stagehand
-  VERSION = "0.0.1.pre.spike"
+  VERSION = "4.0.0"
 end

--- a/packages/sdk-ruby/package.json
+++ b/packages/sdk-ruby/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@browserbasehq/stagehand-ruby",
+  "version": "4.0.0",
+  "private": true,
+  "description": "Changesets version proxy for the Stagehand Ruby SDK"
+}

--- a/packages/sdk-ruby/scripts/build.rb
+++ b/packages/sdk-ruby/scripts/build.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Builds the distributable gem with the Stagehand extension embedded, the
+# analogue of packages/sdk-python/scripts/build.py. The extension build
+# output (packages/extension/dist) is staged into lib/stagehand/_extension —
+# the location ExtensionAssets checks first — so the installed gem is
+# self-contained; the staging directory is removed afterwards so the
+# development tree keeps resolving the monorepo build. Stdlib-only: runs with
+# plain `ruby scripts/build.rb`, no Bundler required.
+
+require "fileutils"
+require "rubygems"
+require "rubygems/package"
+
+package_root = File.expand_path("..", __dir__)
+extension_dist = File.expand_path("../extension/dist", package_root)
+staged_extension = File.join(package_root, "lib/stagehand/_extension")
+output_directory = File.join(package_root, "dist")
+
+unless File.file?(File.join(extension_dist, "manifest.json"))
+  abort "The Stagehand extension is not built. Run: pnpm --filter ./packages/extension build"
+end
+
+FileUtils.rm_rf(staged_extension)
+FileUtils.rm_rf(output_directory)
+FileUtils.mkdir_p(output_directory)
+
+begin
+  FileUtils.cp_r(extension_dist, staged_extension)
+
+  specification = Gem::Specification.load(File.join(package_root, "stagehand.gemspec"))
+  abort "Could not load stagehand.gemspec" if specification.nil?
+  gem_path = Dir.chdir(package_root) { Gem::Package.build(specification) }
+  built = File.join(package_root, gem_path)
+  target = File.join(output_directory, File.basename(gem_path))
+  FileUtils.mv(built, target)
+
+  # The gem must carry the extension and the signatures.
+  contents = []
+  Gem::Package.new(target).contents.each { |entry| contents << entry }
+  %w[lib/stagehand/_extension/manifest.json sig/stagehand.rbs].each do |required|
+    abort "Built gem is missing #{required}" unless contents.include?(required)
+  end
+
+  puts "Built #{target} (#{contents.size} files, extension embedded)"
+ensure
+  FileUtils.rm_rf(staged_extension)
+end

--- a/packages/sdk-ruby/scripts/build.rb
+++ b/packages/sdk-ruby/scripts/build.rb
@@ -28,9 +28,14 @@ FileUtils.mkdir_p(output_directory)
 begin
   FileUtils.cp_r(extension_dist, staged_extension)
 
-  specification = Gem::Specification.load(File.join(package_root, "stagehand.gemspec"))
-  abort "Could not load stagehand.gemspec" if specification.nil?
-  gem_path = Dir.chdir(package_root) { Gem::Package.build(specification) }
+  # The gemspec globs files relative to the working directory, so both the
+  # load and the build must run from the package root (CI invokes this
+  # script from the repository root).
+  gem_path = Dir.chdir(package_root) do
+    specification = Gem::Specification.load("stagehand.gemspec")
+    abort "Could not load stagehand.gemspec" if specification.nil?
+    Gem::Package.build(specification)
+  end
   built = File.join(package_root, gem_path)
   target = File.join(output_directory, File.basename(gem_path))
   FileUtils.mv(built, target)

--- a/packages/sdk-ruby/scripts/smoke.rb
+++ b/packages/sdk-ruby/scripts/smoke.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# Smoke test for the INSTALLED gem (the analogue of
+# packages/sdk-python/scripts/smoke.py): requires "stagehand" from the load
+# path — run it after `gem install dist/*.gem` — asserts the embedded
+# extension is present, then drives a real local Chrome against a local
+# fixture server. No LLM calls. CHROME_PATH selects the browser binary.
+
+require "socket"
+require "stagehand"
+
+FIXTURE_BODY = "<!doctype html><html><title>Stagehand package smoke</title></html>"
+
+def with_fixture_server
+  server = TCPServer.new("127.0.0.1", 0)
+  port = server.addr[1]
+  thread = Thread.new do
+    loop do
+      client = server.accept
+      begin
+        request_line = client.gets
+        client.gets until (line = client.gets).nil? || line == "\r\n" || line == "\n"
+        next if request_line.nil?
+        client.write(
+          "HTTP/1.1 200 OK\r\n" \
+          "Content-Type: text/html; charset=utf-8\r\n" \
+          "Content-Length: #{FIXTURE_BODY.bytesize}\r\n" \
+          "X-Stagehand-Fixture: ruby-navigation-response\r\n" \
+          "Connection: close\r\n\r\n#{FIXTURE_BODY}",
+        )
+      ensure
+        client.close
+      end
+    rescue IOError, Errno::EBADF
+      break
+    end
+  end
+  yield "http://127.0.0.1:#{port}"
+ensure
+  server&.close
+  thread&.kill
+end
+
+extension_directory = Stagehand::ExtensionAssets.extension_directory
+unless File.file?(File.join(extension_directory, "manifest.json"))
+  abort "Installed Stagehand gem is missing its browser extension"
+end
+unless File.basename(extension_directory) == "_extension"
+  abort "Extension resolved to #{extension_directory} instead of the embedded copy"
+end
+
+with_fixture_server do |fixture_url|
+  browser = Stagehand::LocalBrowser.launch(headless: true)
+  begin
+    stagehand = Stagehand.create(browser: browser, log_level: "warn")
+    begin
+      page = browser.context.pages.first
+      raise "Stagehand initialized without an active page" if page.nil?
+
+      response = page.goto(fixture_url)
+      raise "Unexpected navigation status: #{response&.status.inspect}" unless response&.status == 200
+      fixture_header = response.header_value("x-stagehand-fixture")
+      raise "Missing fixture header: #{fixture_header.inspect}" unless fixture_header == "ruby-navigation-response"
+      title = page.title
+      raise "Unexpected page title: #{title.inspect}" unless title == "Stagehand package smoke"
+
+      puts "Gem smoke passed: #{Stagehand::VERSION} (extension at #{extension_directory})"
+    ensure
+      stagehand.close
+    end
+  ensure
+    browser.close
+  end
+end

--- a/packages/sdk-ruby/stagehand.gemspec
+++ b/packages/sdk-ruby/stagehand.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.version = Stagehand::VERSION
   spec.authors = ["Browserbase"]
   spec.email = ["support@browserbase.com"]
-  spec.summary = "Stagehand v4 Ruby SDK (spike)"
+  spec.summary = "Stagehand v4 Ruby SDK"
   spec.description =
     "AI-powered browser automation. Ruby client for the Stagehand v4 runtime: " \
     "JSON-RPC over the Chrome DevTools Protocol to the embedded Stagehand extension."

--- a/packages/sdk-ruby/test/test_file_upload.rb
+++ b/packages/sdk-ruby/test/test_file_upload.rb
@@ -7,6 +7,7 @@ require "tempfile"
 class TestFileUpload < Minitest::Test
   def test_normalizes_a_path_into_a_wire_payload
     Tempfile.create(["report", ".csv"]) do |file|
+      file.binmode # keep the fixture byte-stable on Windows (no CRLF translation)
       file.write("a,b\n1,2\n")
       file.flush
       payloads = Stagehand::FileUpload.normalize_file_input(file.path)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -617,6 +617,8 @@ importers:
 
   packages/sdk-python: {}
 
+  packages/sdk-ruby: {}
+
   packages/sdk-ts:
     dependencies:
       '@browserbasehq/sdk':

--- a/scripts/release/check-changesets.ts
+++ b/scripts/release/check-changesets.ts
@@ -8,6 +8,7 @@ const allowedPackages = new Set([
   "@browserbasehq/stagehand-go",
   "@browserbasehq/stagehand-protocol",
   "@browserbasehq/stagehand-python",
+  "@browserbasehq/stagehand-ruby",
   "@browserbasehq/stagehand-extension",
 ]);
 

--- a/scripts/release/ruby-alpha-version.ts
+++ b/scripts/release/ruby-alpha-version.ts
@@ -1,0 +1,92 @@
+import { execFile } from "node:child_process";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import { pathToFileURL } from "node:url";
+import { readRubyGemVersion, updateRubyGemVersion } from "./ruby-version.ts";
+
+const execFileAsync = promisify(execFile);
+
+// Produced by `changeset version --snapshot` with the `alpha-{commit}` template.
+const snapshotVersionPattern =
+  /^(?<base>(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*))-alpha-[0-9a-f]+$/u;
+
+/**
+ * Maps a changesets snapshot version (`4.1.0-alpha-<sha>`) onto the RubyGems
+ * prerelease `4.1.0.pre.alpha.<N>`.
+ *
+ * RubyGems sorts `.pre.` versions below the stable release they precede and
+ * keeps them out of `gem install stagehand` unless `--pre` is passed — the
+ * same role the `alpha` dist-tag plays on npm. `N` must increase between
+ * pushes; the `stagehand-ruby@<version>` git tag maps a build back to its
+ * commit.
+ */
+export function rubyAlphaVersion(snapshotVersion: string, buildNumber: number): string {
+  const base = snapshotVersionPattern.exec(snapshotVersion)?.groups?.base;
+  if (base === undefined) {
+    throw new Error(`Not a changesets snapshot version: ${snapshotVersion}`);
+  }
+  if (!Number.isInteger(buildNumber) || buildNumber < 0) {
+    throw new Error(`Invalid prerelease build number: ${String(buildNumber)}`);
+  }
+  return `${base}.pre.alpha.${String(buildNumber)}`;
+}
+
+export type RubyAlphaVersionOptions = {
+  checkOnly?: boolean;
+  repositoryRoot?: string;
+  buildNumber?: () => Promise<number>;
+};
+
+export type RubyAlphaVersionStatus =
+  | { shouldPublish: false }
+  | { shouldPublish: true; version: string };
+
+async function commitCount(repositoryRoot: string): Promise<number> {
+  const { stdout } = await execFileAsync("git", ["rev-list", "--count", "HEAD"], {
+    cwd: repositoryRoot,
+  });
+  return Number.parseInt(stdout.trim(), 10);
+}
+
+/**
+ * Expects `changeset version --snapshot` to have run already. When the Ruby
+ * proxy package received a snapshot version there is something unreleased to
+ * publish, so lib/stagehand/version.rb is rewritten to the matching RubyGems
+ * prerelease. Otherwise nothing is touched and no alpha should be published.
+ */
+export async function applyRubyAlphaVersion({
+  checkOnly = false,
+  repositoryRoot = path.resolve(import.meta.dirname, "../.."),
+  buildNumber = async () => await commitCount(repositoryRoot),
+}: RubyAlphaVersionOptions = {}): Promise<RubyAlphaVersionStatus> {
+  const rubyDirectory = path.join(repositoryRoot, "packages/sdk-ruby");
+  const proxyManifest = JSON.parse(
+    await readFile(path.join(rubyDirectory, "package.json"), "utf8"),
+  ) as { version?: unknown };
+  if (typeof proxyManifest.version !== "string") {
+    throw new TypeError("Ruby version proxy does not define a string version");
+  }
+  if (!snapshotVersionPattern.test(proxyManifest.version)) {
+    return { shouldPublish: false };
+  }
+
+  const version = rubyAlphaVersion(proxyManifest.version, await buildNumber());
+  if (!checkOnly) {
+    const versionFilePath = path.join(rubyDirectory, "lib/stagehand/version.rb");
+    const versionFile = await readFile(versionFilePath, "utf8");
+    readRubyGemVersion(versionFile); // fail fast on an unexpected file shape
+    await writeFile(versionFilePath, updateRubyGemVersion(versionFile, version));
+  }
+  return { shouldPublish: true, version };
+}
+
+const invokedPath = process.argv[1];
+if (
+  invokedPath !== undefined &&
+  import.meta.url === pathToFileURL(path.resolve(invokedPath)).href
+) {
+  const status = await applyRubyAlphaVersion({ checkOnly: process.argv.includes("--check") });
+  process.stdout.write(`should-publish=${String(status.shouldPublish)}\n`);
+  if (status.shouldPublish) process.stdout.write(`version=${status.version}\n`);
+}

--- a/scripts/release/ruby-publish-status.ts
+++ b/scripts/release/ruby-publish-status.ts
@@ -1,0 +1,60 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { readRubyGemVersion } from "./ruby-version.ts";
+
+type StatusResponse = {
+  ok: boolean;
+  status: number;
+};
+
+export type RubyPublishStatusOptions = {
+  repositoryRoot?: string;
+  fetchStatus?: (url: string) => Promise<StatusResponse>;
+};
+
+/**
+ * The `stagehand` gem name is shared with the retired v3 HTTP-API client
+ * (last published as 3.x from browserbase/stagehand-ruby); v4 continues the
+ * name at 4.x. Prerelease checked-in versions never auto-publish.
+ */
+export async function shouldPublishRuby({
+  repositoryRoot = path.resolve(import.meta.dirname, "../.."),
+  fetchStatus = async (url) => await fetch(url),
+}: RubyPublishStatusOptions = {}): Promise<boolean> {
+  const changesetDirectory = path.join(repositoryRoot, ".changeset");
+  const pendingChangesets = (await readdir(changesetDirectory)).filter(
+    (file) => file.endsWith(".md") && file !== "README.md",
+  );
+
+  if (pendingChangesets.length > 0) {
+    return false;
+  }
+
+  const versionFile = await readFile(
+    path.join(repositoryRoot, "packages/sdk-ruby/lib/stagehand/version.rb"),
+    "utf8",
+  );
+  const version = readRubyGemVersion(versionFile);
+  if (version.includes("pre")) {
+    return false;
+  }
+  const response = await fetchStatus(
+    `https://rubygems.org/api/v2/rubygems/stagehand/versions/${version}.json`,
+  );
+  if (response.status === 404) {
+    return true;
+  }
+  if (response.ok) {
+    return false;
+  }
+  throw new Error(`RubyGems returned ${response.status} while checking stagehand ${version}`);
+}
+
+const invokedPath = process.argv[1];
+if (
+  invokedPath !== undefined &&
+  import.meta.url === pathToFileURL(path.resolve(invokedPath)).href
+) {
+  process.stdout.write(`${String(await shouldPublishRuby())}\n`);
+}

--- a/scripts/release/ruby-version.ts
+++ b/scripts/release/ruby-version.ts
@@ -1,0 +1,33 @@
+const versionPattern = /^(?<prefix>\s*VERSION = ")(?<version>[^"]+)(?<suffix>")\s*$/mu;
+
+export function readRubyGemVersion(contents: string): string {
+  const version = versionPattern.exec(contents)?.groups?.version;
+  if (version === undefined) {
+    throw new Error("Could not find VERSION in lib/stagehand/version.rb");
+  }
+  return version;
+}
+
+export function updateRubyGemVersion(contents: string, version: string): string {
+  if (!versionPattern.test(contents)) {
+    throw new Error("Could not find VERSION in lib/stagehand/version.rb");
+  }
+  return contents.replace(
+    versionPattern,
+    (_, prefix: string, __, suffix: string) => `${prefix}${version}${suffix}`,
+  );
+}
+
+/**
+ * Maps a semver version onto RubyGems conventions: prerelease segments use
+ * `.pre.` and dots instead of hyphens (`4.1.0-alpha.1` → `4.1.0.pre.alpha.1`),
+ * so `gem install stagehand` never resolves to them without `--pre`.
+ */
+export function rubyGemVersion(semver: string): string {
+  const [release, ...prerelease] = semver.split("-");
+  if (!/^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/u.test(release ?? "")) {
+    throw new Error(`Not a semver version: ${semver}`);
+  }
+  if (prerelease.length === 0) return semver;
+  return `${release}.pre.${prerelease.join(".").replaceAll("-", ".")}`;
+}

--- a/scripts/release/sync-ruby-version.test.ts
+++ b/scripts/release/sync-ruby-version.test.ts
@@ -1,0 +1,133 @@
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { rubyAlphaVersion } from "./ruby-alpha-version.ts";
+import { readRubyGemVersion, rubyGemVersion, updateRubyGemVersion } from "./ruby-version.ts";
+import { syncRubyVersion } from "./sync-ruby-version.ts";
+
+const versionFile = (version: string): string => `# frozen_string_literal: true
+
+module Stagehand
+  VERSION = "${version}"
+end
+`;
+
+async function repositoryFixture({
+  expected = "4.1.0",
+  gem = "4.1.0",
+  lockfile = "4.1.0",
+}: { expected?: string; gem?: string; lockfile?: string } = {}): Promise<string> {
+  const repositoryRoot = await mkdtemp(path.join(os.tmpdir(), "stagehand-ruby-sync-"));
+  const rubyDirectory = path.join(repositoryRoot, "packages/sdk-ruby/lib/stagehand");
+  await mkdir(rubyDirectory, { recursive: true });
+  await writeFile(
+    path.join(repositoryRoot, "packages/sdk-ruby/package.json"),
+    `${JSON.stringify({ version: expected }, null, 2)}\n`,
+  );
+  await writeFile(path.join(rubyDirectory, "version.rb"), versionFile(gem));
+  await writeFile(
+    path.join(repositoryRoot, "packages/sdk-ruby/Gemfile.lock"),
+    `PATH
+  remote: .
+  specs:
+    stagehand (${lockfile})
+      websocket-driver (~> 0.8)
+`,
+  );
+  return repositoryRoot;
+}
+
+describe("rubyGemVersion", () => {
+  it("keeps release versions as-is", () => {
+    expect(rubyGemVersion("4.1.0")).toBe("4.1.0");
+  });
+
+  it("maps semver prereleases onto .pre. segments", () => {
+    expect(rubyGemVersion("4.1.0-alpha.1")).toBe("4.1.0.pre.alpha.1");
+    expect(rubyGemVersion("4.1.0-alpha-3f2a1b")).toBe("4.1.0.pre.alpha.3f2a1b");
+  });
+
+  it("rejects non-semver versions", () => {
+    expect(() => rubyGemVersion("4.1")).toThrow("Not a semver version");
+  });
+});
+
+describe("ruby version.rb parsing", () => {
+  it("round-trips the VERSION constant", () => {
+    const contents = versionFile("4.1.0");
+    expect(readRubyGemVersion(contents)).toBe("4.1.0");
+    expect(readRubyGemVersion(updateRubyGemVersion(contents, "4.2.0"))).toBe("4.2.0");
+  });
+
+  it("rejects files without a VERSION constant", () => {
+    expect(() => readRubyGemVersion("module Stagehand\nend\n")).toThrow("Could not find VERSION");
+  });
+});
+
+describe("syncRubyVersion", () => {
+  it("accepts synchronized versions in check mode", async () => {
+    const repositoryRoot = await repositoryFixture();
+    await expect(syncRubyVersion({ checkOnly: true, repositoryRoot })).resolves.toBeUndefined();
+  });
+
+  it("reports a version.rb mismatch in check mode", async () => {
+    const repositoryRoot = await repositoryFixture({ gem: "4.0.0" });
+    await expect(syncRubyVersion({ checkOnly: true, repositoryRoot })).rejects.toThrow(
+      "version.rb is 4.0.0; expected 4.1.0",
+    );
+  });
+
+  it("reports a Gemfile.lock mismatch in check mode", async () => {
+    const repositoryRoot = await repositoryFixture({ lockfile: "4.0.0" });
+    await expect(syncRubyVersion({ checkOnly: true, repositoryRoot })).rejects.toThrow(
+      "Gemfile.lock is 4.0.0; expected 4.1.0",
+    );
+  });
+
+  it("rewrites the Gemfile.lock PATH entry", async () => {
+    const repositoryRoot = await repositoryFixture({ gem: "4.0.0", lockfile: "4.0.0" });
+    await syncRubyVersion({ repositoryRoot });
+    const lockfile = await readFile(
+      path.join(repositoryRoot, "packages/sdk-ruby/Gemfile.lock"),
+      "utf8",
+    );
+    expect(lockfile).toContain("stagehand (4.1.0)");
+  });
+
+  it("rewrites version.rb to the proxy version", async () => {
+    const repositoryRoot = await repositoryFixture({ gem: "4.0.0" });
+    await syncRubyVersion({ repositoryRoot });
+    const rewritten = await readFile(
+      path.join(repositoryRoot, "packages/sdk-ruby/lib/stagehand/version.rb"),
+      "utf8",
+    );
+    expect(readRubyGemVersion(rewritten)).toBe("4.1.0");
+  });
+
+  it("converts prerelease proxy versions to gem conventions", async () => {
+    const repositoryRoot = await repositoryFixture({
+      expected: "4.1.0-alpha-abc123",
+      gem: "4.0.0",
+    });
+    await syncRubyVersion({ repositoryRoot });
+    const rewritten = await readFile(
+      path.join(repositoryRoot, "packages/sdk-ruby/lib/stagehand/version.rb"),
+      "utf8",
+    );
+    expect(readRubyGemVersion(rewritten)).toBe("4.1.0.pre.alpha.abc123");
+  });
+});
+
+describe("rubyAlphaVersion", () => {
+  it("maps snapshot versions onto RubyGems prereleases", () => {
+    expect(rubyAlphaVersion("4.1.0-alpha-3f2a1b", 4321)).toBe("4.1.0.pre.alpha.4321");
+  });
+
+  it("rejects non-snapshot versions", () => {
+    expect(() => rubyAlphaVersion("4.1.0", 1)).toThrow("Not a changesets snapshot version");
+    expect(() => rubyAlphaVersion("4.1.0-alpha-3f2a1b", -1)).toThrow(
+      "Invalid prerelease build number",
+    );
+  });
+});

--- a/scripts/release/sync-ruby-version.ts
+++ b/scripts/release/sync-ruby-version.ts
@@ -1,0 +1,75 @@
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { readRubyGemVersion, rubyGemVersion, updateRubyGemVersion } from "./ruby-version.ts";
+
+export type SyncRubyVersionOptions = {
+  checkOnly?: boolean;
+  repositoryRoot?: string;
+};
+
+// The Bundler lockfile pins the gem's own version under its PATH source.
+const lockfileVersionPattern = /^(?<prefix>    stagehand \()(?<version>[^)]+)(?<suffix>\))$/mu;
+
+export async function syncRubyVersion({
+  checkOnly = false,
+  repositoryRoot = path.resolve(import.meta.dirname, "../.."),
+}: SyncRubyVersionOptions = {}): Promise<void> {
+  const rubyDirectory = path.join(repositoryRoot, "packages/sdk-ruby");
+  const proxyManifestPath = path.join(rubyDirectory, "package.json");
+  const versionFilePath = path.join(rubyDirectory, "lib/stagehand/version.rb");
+  const lockfilePath = path.join(rubyDirectory, "Gemfile.lock");
+
+  const proxyManifest = JSON.parse(await readFile(proxyManifestPath, "utf8")) as {
+    version?: unknown;
+  };
+  if (typeof proxyManifest.version !== "string") {
+    throw new TypeError("Ruby version proxy does not define a string version");
+  }
+  const expectedVersion = rubyGemVersion(proxyManifest.version);
+
+  const versionFile = await readFile(versionFilePath, "utf8");
+  const gemVersion = readRubyGemVersion(versionFile);
+  const lockfile = await readFile(lockfilePath, "utf8");
+  const lockfileVersion = lockfileVersionPattern.exec(lockfile)?.groups?.version;
+  if (lockfileVersion === undefined) {
+    throw new Error("Could not find the stagehand PATH entry in Gemfile.lock");
+  }
+
+  if (!checkOnly) {
+    if (gemVersion !== expectedVersion) {
+      await writeFile(versionFilePath, updateRubyGemVersion(versionFile, expectedVersion));
+    }
+    if (lockfileVersion !== expectedVersion) {
+      await writeFile(
+        lockfilePath,
+        lockfile.replace(
+          lockfileVersionPattern,
+          (_, prefix: string, __, suffix: string) => `${prefix}${expectedVersion}${suffix}`,
+        ),
+      );
+    }
+    return;
+  }
+
+  const mismatches = [
+    gemVersion === expectedVersion
+      ? undefined
+      : `version.rb is ${gemVersion}; expected ${expectedVersion}`,
+    lockfileVersion === expectedVersion
+      ? undefined
+      : `Gemfile.lock is ${lockfileVersion}; expected ${expectedVersion}`,
+  ].filter((message): message is string => message !== undefined);
+
+  if (mismatches.length > 0) {
+    throw new Error(`Ruby versions are out of sync:\n${mismatches.join("\n")}`);
+  }
+}
+
+const invokedPath = process.argv[1];
+if (
+  invokedPath !== undefined &&
+  import.meta.url === pathToFileURL(path.resolve(invokedPath)).href
+) {
+  await syncRubyVersion({ checkOnly: process.argv.includes("--check") });
+}


### PR DESCRIPTION
Part of the AP-2857 parity stack:

**Stack:** #2820 ← #2854 (M1–M2) ← #2855 (M3) ← #2851 (M4) ← #2857 (M5) ← #2858 (M6a) ← **this PR (M6c)** ← M6d

Release plumbing for the Ruby SDK, mirroring the Python lane:

- **Changesets version proxy** `@browserbasehq/stagehand-ruby` (allowed in check-changesets). Version baseline 4.0.0: the RubyGems `stagehand` name is Browserbase-owned — the retired v3 HTTP client last published 3.21.0 from browserbase/stagehand-ruby — and v4 continues the name at 4.x, exactly like PyPI/npm.
- **Version sync** — `sync-ruby-version.ts` keeps `version.rb` + `Gemfile.lock` in lock-step with the proxy (semver → gem `.pre.` conversion), wired into `just _version` and `just check`; `ruby-alpha-version.ts` maps snapshot versions onto `<next>.pre.alpha.<N>`; `ruby-publish-status.ts` gates publishing (pending changesets / prerelease / already published). 13 new tests.
- **Gem build** (`scripts/build.rb`, stdlib-only) stages the extension into `lib/stagehand/_extension` — the path `ExtensionAssets` resolves first — and verifies the built gem carries it plus the RBS signatures. **Smoke test** (`scripts/smoke.rb`) runs against the *installed* gem: embedded extension + real Chrome against a local fixture server.
- **publish-ruby.yml** — build → smoke → RubyGems trusted publishing → `stagehand-ruby@<version>` tag. `workflow_dispatch` for the first release plus `workflow_call` for release.yml wiring; deliberately **not** wired into release.yml yet (docs are still pending, and the first v4 publish over the 3.x gem is a product call). Ops prerequisite: configure RubyGems trusted publishing for this repo + workflow.
- **CI** — `sdk-ruby` change filter, `ruby-checks` (rake: 123 tests + RBS validation, generator drift) and `ruby-gem-smoke` jobs; release.yml sets up Ruby; `Gemfile.lock` is now committed for reproducible CI.

Verified locally: gem builds with extension embedded, installs into a clean GEM_HOME, smoke passes against real Chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)