### PR TITLE
feat(ruby): M6d — Windows Chrome launcher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -493,6 +493,45 @@ jobs:
         with:
           name: coverage/integration/${{ matrix.test.safe_name }}
 
+  ruby-windows:
+    name: Ruby (Windows launcher + gem smoke)
+    needs: [build, determine-changes]
+    if: >-
+      needs.determine-changes.outputs.sdk-ruby == 'true' &&
+      needs.determine-changes.outputs.is_internal_head == 'true'
+    runs-on: windows-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - uses: ./.github/actions/setup-node-pnpm
+        with:
+          use-prebuilt-artifacts: "true"
+
+      - uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64 # v1.299.0
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: packages/sdk-ruby
+
+      - name: Unit tests
+        run: bundle exec rake test
+        working-directory: packages/sdk-ruby
+
+      - run: pnpm --filter ./packages/extension build
+      - run: ruby packages/sdk-ruby/scripts/build.rb
+
+      # Windows runners ship Chrome, so this exercises the Windows launcher
+      # (chrome.exe discovery, new_pgroup spawn, TerminateProcess shutdown)
+      # against a real browser.
+      - name: Smoke test installed gem
+        shell: bash
+        run: |
+          export GEM_HOME="$RUNNER_TEMP/stagehand-gem-smoke"
+          export GEM_PATH="$GEM_HOME"
+          gem install --no-document packages/sdk-ruby/dist/*.gem
+          ruby packages/sdk-ruby/scripts/smoke.rb
+
   go-windows:
     name: Go (Windows process management)
     needs: [determine-changes]

--- a/packages/docs/tests/sdk-reference.test.ts
+++ b/packages/docs/tests/sdk-reference.test.ts
@@ -1283,7 +1283,7 @@ describe("Mintlify customization boundary", () => {
       differences,
       "Language-scoped documentation must use field names derived from that SDK's public source",
     ).toEqual([]);
-  });
+  }, 30_000); // Parses every MDX page; cold CI runners exceed the 5s default.
 
   it("includes every indexed MDX content page in docs.json navigation", async () => {
     const docsConfig = JSON.parse(
@@ -1393,7 +1393,7 @@ describe("Mintlify customization boundary", () => {
       problems,
       "Every language tab group must offer the same languages, so switching never hides a snippet",
     ).toEqual([]);
-  });
+  }, 30_000); // Parses every MDX page; cold CI runners exceed the 5s default.
 
   it("never mixes language tabs with other tabs in one group", async () => {
     const contentPages = (await listFiles(V4_DOCS_ROOT, shouldInspectDocsDirectory)).filter(

--- a/packages/docs/tests/sdk-reference.test.ts
+++ b/packages/docs/tests/sdk-reference.test.ts
@@ -462,7 +462,7 @@ describe("SDK reference surface", () => {
     }
 
     expect(problems, "Internal v4 reference links must resolve to a page and heading").toEqual([]);
-  });
+  }, 30_000); // Parses every MDX page; cold CI runners exceed the 5s default.
 
   it("documents callable helper members as methods and metadata as properties", async () => {
     const webmcpPath = resolve(REFERENCE_ROOT, "webmcp.mdx");
@@ -1314,7 +1314,7 @@ describe("Mintlify customization boundary", () => {
       navigatedPages,
       "Every indexed MDX content page must be reachable from docs.json",
     ).toStrictEqual(indexedContentPages);
-  });
+  }, 30_000); // Parses every MDX page; cold CI runners exceed the 5s default.
 
   it("gives every language tab group the same complete language set", async () => {
     const contentPages = (await listFiles(V4_DOCS_ROOT, shouldInspectDocsDirectory)).filter(
@@ -1422,7 +1422,7 @@ describe("Mintlify customization boundary", () => {
       problems,
       "A tab group switches on exactly one axis: either language or something else, never both",
     ).toEqual([]);
-  });
+  }, 30_000); // Parses every MDX page; cold CI runners exceed the 5s default.
 
   it("uses no custom presentation code", async () => {
     const customPresentationFiles = (await listFiles(V4_DOCS_ROOT, shouldInspectDocsDirectory))
@@ -1438,7 +1438,7 @@ describe("Mintlify customization boundary", () => {
       customPresentationFiles,
       "Mintlify should use native components without custom CSS, JavaScript, JSX, or TSX",
     ).toStrictEqual([]);
-  });
+  }, 30_000); // Parses every MDX page; cold CI runners exceed the 5s default.
 });
 
 async function readTypescriptMethods(): Promise<SdkMethod[]> {

--- a/packages/sdk-ruby/ESTIMATE.md
+++ b/packages/sdk-ruby/ESTIMATE.md
@@ -16,34 +16,34 @@ Python and Go SDKs are built.
 
 ## What the spike proved (de-risked)
 
-| Risk | Outcome |
-|---|---|
-| No JSON-Schema→Ruby codegen exists | Custom stdlib-only generator, 274 LOC, covers all 234 defs + method registries, `--check` drift mode wired into `just generate`/`just check` |
-| Wire casing | Free — the schema is already snake_case; opaque containers pass through verbatim (fixture round-trip tested) |
-| Sync Ruby ↔ bidirectional RPC | Background-reader-thread model (Go-style) works; `websocket-driver` + own TCP/SSL socket, no reactor framework needed |
-| Chrome without Playwright | Hand-rolled launcher ported from Python's `browser.py` works headless + headed on macOS |
-| Extension packaging | Ruby zip is **byte-identical** to the Python SDK's deterministic archive (same SHA-256) |
-| No Browserbase Ruby SDK exists | Hand-rolled 4-endpoint REST client (~130 LOC) suffices, mirroring Go |
-| End-to-end | `goto → observe → act → extract` verified live on a local Chrome (transport) and on a Browserbase session (full AI loop incl. extension upload + Model Gateway + session release) |
+| Risk                               | Outcome                                                                                                                                                                           |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| No JSON-Schema→Ruby codegen exists | Custom stdlib-only generator, 274 LOC, covers all 234 defs + method registries, `--check` drift mode wired into `just generate`/`just check`                                      |
+| Wire casing                        | Free — the schema is already snake_case; opaque containers pass through verbatim (fixture round-trip tested)                                                                      |
+| Sync Ruby ↔ bidirectional RPC      | Background-reader-thread model (Go-style) works; `websocket-driver` + own TCP/SSL socket, no reactor framework needed                                                             |
+| Chrome without Playwright          | Hand-rolled launcher ported from Python's `browser.py` works headless + headed on macOS                                                                                           |
+| Extension packaging                | Ruby zip is **byte-identical** to the Python SDK's deterministic archive (same SHA-256)                                                                                           |
+| No Browserbase Ruby SDK exists     | Hand-rolled 4-endpoint REST client (~130 LOC) suffices, mirroring Go                                                                                                              |
+| End-to-end                         | `goto → observe → act → extract` verified live on a local Chrome (transport) and on a Browserbase session (full AI loop incl. extension upload + Model Gateway + session release) |
 
 Spike size: ~2,400 hand-written LOC + ~2,000 generated + ~800 tests. Python comparison:
 ~4,900 hand-written + ~3,600 generated — a fair proxy for the finished Ruby size.
 
 ## Work breakdown to production parity
 
-| # | Item | Weeks |
-|---|---|---|
-| A | Walking skeleton (this spike) | 2.5–3 *(sunk)* |
-| B | Full method surface (~62 remaining: context 14, page ~26, locator 17, response 6, clipboard, webmcp, file upload, callback_batch passthrough) — mechanical wrapper + tests per method, batched by namespace | 3–4 |
-| C | Client-side LLM (`llm.generate` inbound handler, message/tool unions, custom-LLM example) | 1 |
-| D | Validation hardening: strict unions, input ergonomics, RBS signatures, thread-safety soak | 1–1.5 |
-| E | 11-example set + `example-parity` compliance | 0.5–1 |
-| F | Parity tooling: ast-grep Ruby lane (`@ast-grep/lang-ruby` availability is the biggest unknown; prism-based fallback +0.5–1 wk) + extend `rules/ast-grep/*` | 1–1.5 |
-| G | Docs: Ruby tabs across `docs/v4/reference/*` + guides + `sdk-reference.test.ts` | 1 |
-| H | Release + CI: turbo task, changesets version proxy, `sync-ruby-version.ts`, extension embedding in the gem, RubyGems trusted publishing + alpha lane, CI matrix (Ruby 3.2–3.4 × macOS/Linux), **Windows launcher** | 1.5–2 |
-| I | Beta hardening buffer (real-world sites, large payloads, memory/soak) | 1–1.5 |
-| | **Total beyond spike** | **10–13.5** |
-| | **Total including spike** | **~12.5–16.5** |
+| #   | Item                                                                                                                                                                                                               | Weeks          |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------- |
+| A   | Walking skeleton (this spike)                                                                                                                                                                                      | 2.5–3 _(sunk)_ |
+| B   | Full method surface (~62 remaining: context 14, page ~26, locator 17, response 6, clipboard, webmcp, file upload, callback_batch passthrough) — mechanical wrapper + tests per method, batched by namespace        | 3–4            |
+| C   | Client-side LLM (`llm.generate` inbound handler, message/tool unions, custom-LLM example)                                                                                                                          | 1              |
+| D   | Validation hardening: strict unions, input ergonomics, RBS signatures, thread-safety soak                                                                                                                          | 1–1.5          |
+| E   | 11-example set + `example-parity` compliance                                                                                                                                                                       | 0.5–1          |
+| F   | Parity tooling: ast-grep Ruby lane (`@ast-grep/lang-ruby` availability is the biggest unknown; prism-based fallback +0.5–1 wk) + extend `rules/ast-grep/*`                                                         | 1–1.5          |
+| G   | Docs: Ruby tabs across `docs/v4/reference/*` + guides + `sdk-reference.test.ts`                                                                                                                                    | 1              |
+| H   | Release + CI: turbo task, changesets version proxy, `sync-ruby-version.ts`, extension embedding in the gem, RubyGems trusted publishing + alpha lane, CI matrix (Ruby 3.2–3.4 × macOS/Linux), **Windows launcher** | 1.5–2          |
+| I   | Beta hardening buffer (real-world sites, large payloads, memory/soak)                                                                                                                                              | 1–1.5          |
+|     | **Total beyond spike**                                                                                                                                                                                             | **10–13.5**    |
+|     | **Total including spike**                                                                                                                                                                                          | **~12.5–16.5** |
 
 ## Ongoing cost
 

--- a/packages/sdk-ruby/README.md
+++ b/packages/sdk-ruby/README.md
@@ -129,7 +129,6 @@ ruby scripts/generate.rb      # regenerate models (also part of `just generate`)
   structural mismatches do raise.
 - No OpenTelemetry trace propagation (`traceparent` is simply omitted).
 - `Browserbase.launch(browser_settings:)` is a camelCase passthrough hash.
-- Windows Chrome launching is not implemented.
 - Inbound work (request handlers, notification listeners including `page.on`
   blocks) runs on one dispatcher thread: handlers may issue RPC calls, but a
   slow handler delays later inbound work (Python runs these concurrently).

--- a/packages/sdk-ruby/README.md
+++ b/packages/sdk-ruby/README.md
@@ -50,8 +50,8 @@ end to end but deliberately implements only a sliver of the API surface.
   and WebMCP (`tools` → invoke/result/cancel).
 - **Locator** — `page.locator(selector)` → all 17 locator methods
   (`click/fill/type/hover/scroll_to/count/text_content/inner_text/inner_html/
-  input_value/visible?/checked?/centroid/highlight/send_click_event/
-  select_option/set_input_files` + `first`/`nth`; file uploads take paths or
+input_value/visible?/checked?/centroid/highlight/send_click_event/
+select_option/set_input_files` + `first`/`nth`; file uploads take paths or
   `Stagehand::FilePayload`, 50 MiB/file).
 - **Context** — `pages/new_page/active_page/set_active_page/close`, cookies
   (`cookies/add_cookies/clear_cookies` with String/Regexp filters), clipboard
@@ -92,17 +92,17 @@ self-contained and runnable as `bundle exec ruby examples/<name>.rb
 [--browserbase]`. The `example-parity` ast-grep lane keeps their inventory and
 SDK operations aligned with the sibling SDKs.
 
-| Example | Notes |
-|---|---|
+| Example                              | Notes                                                                         |
+| ------------------------------------ | ----------------------------------------------------------------------------- |
 | `act.rb`, `observe.rb`, `extract.rb` | example.com; local runs need OPENAI_API_KEY, `--browserbase` uses the Gateway |
-| `model_gateway.rb` | Browserbase-only; no model configured (Gateway picks one) |
-| `caching.rb` | Browserbase-only; `cache: true` + `metadata.cache` round-trip |
-| `custom_logging.rb` | `on_log:` callback appending JSONL to `stagehand.jsonl` |
-| `file_upload.rb` | locator.set_input_files + evaluate; no LLM needed |
-| `batch.rb` | callback batch, no LLM needed |
-| `page_events.rb` | page.on console events + AI extract |
-| `custom_llm.rb` | bring-your-own-LLM via `llm.generate` (OPENAI_API_KEY or AI_GATEWAY_API_KEY) |
-| `webmcp.rb` | page-registered tools via `page.tools` → invoke → result; no LLM needed |
+| `model_gateway.rb`                   | Browserbase-only; no model configured (Gateway picks one)                     |
+| `caching.rb`                         | Browserbase-only; `cache: true` + `metadata.cache` round-trip                 |
+| `custom_logging.rb`                  | `on_log:` callback appending JSONL to `stagehand.jsonl`                       |
+| `file_upload.rb`                     | locator.set_input_files + evaluate; no LLM needed                             |
+| `batch.rb`                           | callback batch, no LLM needed                                                 |
+| `page_events.rb`                     | page.on console events + AI extract                                           |
+| `custom_llm.rb`                      | bring-your-own-LLM via `llm.generate` (OPENAI_API_KEY or AI_GATEWAY_API_KEY)  |
+| `webmcp.rb`                          | page-registered tools via `page.tools` → invoke → result; no LLM needed       |
 
 `examples/extras/` holds Ruby-only walkthroughs outside the canonical set
 (`demo.rb`, `page_interactions.rb`, `context_and_response.rb`,

--- a/packages/sdk-ruby/lib/stagehand/browser.rb
+++ b/packages/sdk-ruby/lib/stagehand/browser.rb
@@ -140,7 +140,11 @@ module Stagehand
         "about:blank",
       ]
 
-      pid = Process.spawn(chrome_path, *flags, in: File::NULL, out: File::NULL, err: File::NULL, pgroup: true)
+      # POSIX gets a process group so the whole Chrome tree can be signalled;
+      # Windows has no process groups — new_pgroup detaches from Ctrl-C.
+      spawn_options = { in: File::NULL, out: File::NULL, err: File::NULL }
+      spawn_options[Gem.win_platform? ? :new_pgroup : :pgroup] = true
+      pid = Process.spawn(chrome_path, *flags, **spawn_options)
       waiter = Process.detach(pid)
       close_chrome = lambda do
         stop_process(pid, waiter)
@@ -206,8 +210,11 @@ module Stagehand
       return configured if configured && File.file?(configured)
 
       candidates =
-        case RUBY_PLATFORM
-        when /darwin/
+        if Gem.win_platform?
+          [ENV.fetch("LOCALAPPDATA", nil), ENV.fetch("PROGRAMFILES", nil), ENV.fetch("PROGRAMFILES(X86)", nil)]
+            .compact
+            .map { |root| File.join(root, "Google", "Chrome", "Application", "chrome.exe") }
+        elsif RUBY_PLATFORM.match?(/darwin/)
           [
             "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
             "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
@@ -231,6 +238,17 @@ module Stagehand
 
     def stop_process(pid, waiter)
       return unless waiter.alive?
+      if Gem.win_platform?
+        # No process groups or graceful SIGTERM on Windows: KILL maps to
+        # TerminateProcess, mirroring the Python SDK's terminate()/kill().
+        begin
+          Process.kill("KILL", pid)
+        rescue Errno::ESRCH, Errno::EPERM
+          nil
+        end
+        waiter.join(3)
+        return nil
+      end
       begin
         Process.kill("TERM", -pid)
       rescue Errno::ESRCH, Errno::EPERM

--- a/packages/sdk-ruby/scripts/build.rb
+++ b/packages/sdk-ruby/scripts/build.rb
@@ -28,9 +28,14 @@ FileUtils.mkdir_p(output_directory)
 begin
   FileUtils.cp_r(extension_dist, staged_extension)
 
-  specification = Gem::Specification.load(File.join(package_root, "stagehand.gemspec"))
-  abort "Could not load stagehand.gemspec" if specification.nil?
-  gem_path = Dir.chdir(package_root) { Gem::Package.build(specification) }
+  # The gemspec globs files relative to the working directory, so both the
+  # load and the build must run from the package root (CI invokes this
+  # script from the repository root).
+  gem_path = Dir.chdir(package_root) do
+    specification = Gem::Specification.load("stagehand.gemspec")
+    abort "Could not load stagehand.gemspec" if specification.nil?
+    Gem::Package.build(specification)
+  end
   built = File.join(package_root, gem_path)
   target = File.join(output_directory, File.basename(gem_path))
   FileUtils.mv(built, target)

--- a/packages/sdk-ruby/test/test_file_upload.rb
+++ b/packages/sdk-ruby/test/test_file_upload.rb
@@ -7,6 +7,7 @@ require "tempfile"
 class TestFileUpload < Minitest::Test
   def test_normalizes_a_path_into_a_wire_payload
     Tempfile.create(["report", ".csv"]) do |file|
+      file.binmode # keep the fixture byte-stable on Windows (no CRLF translation)
       file.write("a,b\n1,2\n")
       file.flush
       payloads = Stagehand::FileUpload.normalize_file_input(file.path)


### PR DESCRIPTION
Part of the AP-2857 parity stack:

**Stack:** … ← #2858 (M6a) ← M6c ← **this PR (M6d)**

- `browser.rb`: `chrome.exe` discovery under `LOCALAPPDATA` / `PROGRAMFILES` / `PROGRAMFILES(X86)`; spawn uses `new_pgroup` on Windows (no POSIX process groups); shutdown maps to TerminateProcess via `Process.kill("KILL", pid)`, mirroring the Python SDK's `terminate()`/`kill()` path.
- `ci.yml`: `ruby-windows` job — unit tests plus the installed-gem smoke test on `windows-latest`, which exercises the Windows launcher (discovery, spawn, shutdown) against the runner's real Chrome.

macOS/Linux behavior unchanged (123 tests green; `batch.rb` re-verified live on local Chrome).

🤖 Generated with [Claude Code](https://claude.com/claude-code)