### PR TITLE
feat(ruby): eval suite — Ruby ports of all 77 bench tasks + runner

### DIFF
--- a/packages/docs/tests/sdk-reference.test.ts
+++ b/packages/docs/tests/sdk-reference.test.ts
@@ -1283,7 +1283,7 @@ describe("Mintlify customization boundary", () => {
       differences,
       "Language-scoped documentation must use field names derived from that SDK's public source",
     ).toEqual([]);
-  });
+  }, 30_000); // Parses every MDX page; cold CI runners exceed the 5s default.
 
   it("includes every indexed MDX content page in docs.json navigation", async () => {
     const docsConfig = JSON.parse(
@@ -1393,7 +1393,7 @@ describe("Mintlify customization boundary", () => {
       problems,
       "Every language tab group must offer the same languages, so switching never hides a snippet",
     ).toEqual([]);
-  });
+  }, 30_000); // Parses every MDX page; cold CI runners exceed the 5s default.
 
   it("never mixes language tabs with other tabs in one group", async () => {
     const contentPages = (await listFiles(V4_DOCS_ROOT, shouldInspectDocsDirectory)).filter(

--- a/packages/docs/tests/sdk-reference.test.ts
+++ b/packages/docs/tests/sdk-reference.test.ts
@@ -462,7 +462,7 @@ describe("SDK reference surface", () => {
     }
 
     expect(problems, "Internal v4 reference links must resolve to a page and heading").toEqual([]);
-  });
+  }, 30_000); // Parses every MDX page; cold CI runners exceed the 5s default.
 
   it("documents callable helper members as methods and metadata as properties", async () => {
     const webmcpPath = resolve(REFERENCE_ROOT, "webmcp.mdx");
@@ -1314,7 +1314,7 @@ describe("Mintlify customization boundary", () => {
       navigatedPages,
       "Every indexed MDX content page must be reachable from docs.json",
     ).toStrictEqual(indexedContentPages);
-  });
+  }, 30_000); // Parses every MDX page; cold CI runners exceed the 5s default.
 
   it("gives every language tab group the same complete language set", async () => {
     const contentPages = (await listFiles(V4_DOCS_ROOT, shouldInspectDocsDirectory)).filter(
@@ -1422,7 +1422,7 @@ describe("Mintlify customization boundary", () => {
       problems,
       "A tab group switches on exactly one axis: either language or something else, never both",
     ).toEqual([]);
-  });
+  }, 30_000); // Parses every MDX page; cold CI runners exceed the 5s default.
 
   it("uses no custom presentation code", async () => {
     const customPresentationFiles = (await listFiles(V4_DOCS_ROOT, shouldInspectDocsDirectory))
@@ -1438,7 +1438,7 @@ describe("Mintlify customization boundary", () => {
       customPresentationFiles,
       "Mintlify should use native components without custom CSS, JavaScript, JSX, or TSX",
     ).toStrictEqual([]);
-  });
+  }, 30_000); // Parses every MDX page; cold CI runners exceed the 5s default.
 });
 
 async function readTypescriptMethods(): Promise<SdkMethod[]> {

--- a/packages/sdk-ruby/.gitignore
+++ b/packages/sdk-ruby/.gitignore
@@ -4,3 +4,4 @@ dist/
 *.gem
 lib/stagehand/_extension/
 stagehand.jsonl
+evals/results/

--- a/packages/sdk-ruby/ESTIMATE.md
+++ b/packages/sdk-ruby/ESTIMATE.md
@@ -16,34 +16,34 @@ Python and Go SDKs are built.
 
 ## What the spike proved (de-risked)
 
-| Risk | Outcome |
-|---|---|
-| No JSON-Schema→Ruby codegen exists | Custom stdlib-only generator, 274 LOC, covers all 234 defs + method registries, `--check` drift mode wired into `just generate`/`just check` |
-| Wire casing | Free — the schema is already snake_case; opaque containers pass through verbatim (fixture round-trip tested) |
-| Sync Ruby ↔ bidirectional RPC | Background-reader-thread model (Go-style) works; `websocket-driver` + own TCP/SSL socket, no reactor framework needed |
-| Chrome without Playwright | Hand-rolled launcher ported from Python's `browser.py` works headless + headed on macOS |
-| Extension packaging | Ruby zip is **byte-identical** to the Python SDK's deterministic archive (same SHA-256) |
-| No Browserbase Ruby SDK exists | Hand-rolled 4-endpoint REST client (~130 LOC) suffices, mirroring Go |
-| End-to-end | `goto → observe → act → extract` verified live on a local Chrome (transport) and on a Browserbase session (full AI loop incl. extension upload + Model Gateway + session release) |
+| Risk                               | Outcome                                                                                                                                                                           |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| No JSON-Schema→Ruby codegen exists | Custom stdlib-only generator, 274 LOC, covers all 234 defs + method registries, `--check` drift mode wired into `just generate`/`just check`                                      |
+| Wire casing                        | Free — the schema is already snake_case; opaque containers pass through verbatim (fixture round-trip tested)                                                                      |
+| Sync Ruby ↔ bidirectional RPC      | Background-reader-thread model (Go-style) works; `websocket-driver` + own TCP/SSL socket, no reactor framework needed                                                             |
+| Chrome without Playwright          | Hand-rolled launcher ported from Python's `browser.py` works headless + headed on macOS                                                                                           |
+| Extension packaging                | Ruby zip is **byte-identical** to the Python SDK's deterministic archive (same SHA-256)                                                                                           |
+| No Browserbase Ruby SDK exists     | Hand-rolled 4-endpoint REST client (~130 LOC) suffices, mirroring Go                                                                                                              |
+| End-to-end                         | `goto → observe → act → extract` verified live on a local Chrome (transport) and on a Browserbase session (full AI loop incl. extension upload + Model Gateway + session release) |
 
 Spike size: ~2,400 hand-written LOC + ~2,000 generated + ~800 tests. Python comparison:
 ~4,900 hand-written + ~3,600 generated — a fair proxy for the finished Ruby size.
 
 ## Work breakdown to production parity
 
-| # | Item | Weeks |
-|---|---|---|
-| A | Walking skeleton (this spike) | 2.5–3 *(sunk)* |
-| B | Full method surface (~62 remaining: context 14, page ~26, locator 17, response 6, clipboard, webmcp, file upload, callback_batch passthrough) — mechanical wrapper + tests per method, batched by namespace | 3–4 |
-| C | Client-side LLM (`llm.generate` inbound handler, message/tool unions, custom-LLM example) | 1 |
-| D | Validation hardening: strict unions, input ergonomics, RBS signatures, thread-safety soak | 1–1.5 |
-| E | 11-example set + `example-parity` compliance | 0.5–1 |
-| F | Parity tooling: ast-grep Ruby lane (`@ast-grep/lang-ruby` availability is the biggest unknown; prism-based fallback +0.5–1 wk) + extend `rules/ast-grep/*` | 1–1.5 |
-| G | Docs: Ruby tabs across `docs/v4/reference/*` + guides + `sdk-reference.test.ts` | 1 |
-| H | Release + CI: turbo task, changesets version proxy, `sync-ruby-version.ts`, extension embedding in the gem, RubyGems trusted publishing + alpha lane, CI matrix (Ruby 3.2–3.4 × macOS/Linux), **Windows launcher** | 1.5–2 |
-| I | Beta hardening buffer (real-world sites, large payloads, memory/soak) | 1–1.5 |
-| | **Total beyond spike** | **10–13.5** |
-| | **Total including spike** | **~12.5–16.5** |
+| #   | Item                                                                                                                                                                                                               | Weeks          |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------- |
+| A   | Walking skeleton (this spike)                                                                                                                                                                                      | 2.5–3 _(sunk)_ |
+| B   | Full method surface (~62 remaining: context 14, page ~26, locator 17, response 6, clipboard, webmcp, file upload, callback_batch passthrough) — mechanical wrapper + tests per method, batched by namespace        | 3–4            |
+| C   | Client-side LLM (`llm.generate` inbound handler, message/tool unions, custom-LLM example)                                                                                                                          | 1              |
+| D   | Validation hardening: strict unions, input ergonomics, RBS signatures, thread-safety soak                                                                                                                          | 1–1.5          |
+| E   | 11-example set + `example-parity` compliance                                                                                                                                                                       | 0.5–1          |
+| F   | Parity tooling: ast-grep Ruby lane (`@ast-grep/lang-ruby` availability is the biggest unknown; prism-based fallback +0.5–1 wk) + extend `rules/ast-grep/*`                                                         | 1–1.5          |
+| G   | Docs: Ruby tabs across `docs/v4/reference/*` + guides + `sdk-reference.test.ts`                                                                                                                                    | 1              |
+| H   | Release + CI: turbo task, changesets version proxy, `sync-ruby-version.ts`, extension embedding in the gem, RubyGems trusted publishing + alpha lane, CI matrix (Ruby 3.2–3.4 × macOS/Linux), **Windows launcher** | 1.5–2          |
+| I   | Beta hardening buffer (real-world sites, large payloads, memory/soak)                                                                                                                                              | 1–1.5          |
+|     | **Total beyond spike**                                                                                                                                                                                             | **10–13.5**    |
+|     | **Total including spike**                                                                                                                                                                                          | **~12.5–16.5** |
 
 ## Ongoing cost
 

--- a/packages/sdk-ruby/README.md
+++ b/packages/sdk-ruby/README.md
@@ -109,6 +109,11 @@ SDK operations aligned with the sibling SDKs.
 `hybrid_news.rb`, `search_flow.rb`, `arctic_observe.rb`) plus their shared
 `example_helpers.rb`.
 
+### Evals
+
+`evals/` holds Ruby ports of the bench-tier eval tasks (act/extract/observe)
+with their own runner — see [`evals/README.md`](./evals/README.md).
+
 ## Development
 
 Requires Ruby >= 3.2 and the built extension (`pnpm --filter ./packages/extension build`).

--- a/packages/sdk-ruby/README.md
+++ b/packages/sdk-ruby/README.md
@@ -50,8 +50,8 @@ end to end but deliberately implements only a sliver of the API surface.
   and WebMCP (`tools` → invoke/result/cancel).
 - **Locator** — `page.locator(selector)` → all 17 locator methods
   (`click/fill/type/hover/scroll_to/count/text_content/inner_text/inner_html/
-  input_value/visible?/checked?/centroid/highlight/send_click_event/
-  select_option/set_input_files` + `first`/`nth`; file uploads take paths or
+input_value/visible?/checked?/centroid/highlight/send_click_event/
+select_option/set_input_files` + `first`/`nth`; file uploads take paths or
   `Stagehand::FilePayload`, 50 MiB/file).
 - **Context** — `pages/new_page/active_page/set_active_page/close`, cookies
   (`cookies/add_cookies/clear_cookies` with String/Regexp filters), clipboard
@@ -92,17 +92,17 @@ self-contained and runnable as `bundle exec ruby examples/<name>.rb
 [--browserbase]`. The `example-parity` ast-grep lane keeps their inventory and
 SDK operations aligned with the sibling SDKs.
 
-| Example | Notes |
-|---|---|
+| Example                              | Notes                                                                         |
+| ------------------------------------ | ----------------------------------------------------------------------------- |
 | `act.rb`, `observe.rb`, `extract.rb` | example.com; local runs need OPENAI_API_KEY, `--browserbase` uses the Gateway |
-| `model_gateway.rb` | Browserbase-only; no model configured (Gateway picks one) |
-| `caching.rb` | Browserbase-only; `cache: true` + `metadata.cache` round-trip |
-| `custom_logging.rb` | `on_log:` callback appending JSONL to `stagehand.jsonl` |
-| `file_upload.rb` | locator.set_input_files + evaluate; no LLM needed |
-| `batch.rb` | callback batch, no LLM needed |
-| `page_events.rb` | page.on console events + AI extract |
-| `custom_llm.rb` | bring-your-own-LLM via `llm.generate` (OPENAI_API_KEY or AI_GATEWAY_API_KEY) |
-| `webmcp.rb` | page-registered tools via `page.tools` → invoke → result; no LLM needed |
+| `model_gateway.rb`                   | Browserbase-only; no model configured (Gateway picks one)                     |
+| `caching.rb`                         | Browserbase-only; `cache: true` + `metadata.cache` round-trip                 |
+| `custom_logging.rb`                  | `on_log:` callback appending JSONL to `stagehand.jsonl`                       |
+| `file_upload.rb`                     | locator.set_input_files + evaluate; no LLM needed                             |
+| `batch.rb`                           | callback batch, no LLM needed                                                 |
+| `page_events.rb`                     | page.on console events + AI extract                                           |
+| `custom_llm.rb`                      | bring-your-own-LLM via `llm.generate` (OPENAI_API_KEY or AI_GATEWAY_API_KEY)  |
+| `webmcp.rb`                          | page-registered tools via `page.tools` → invoke → result; no LLM needed       |
 
 `examples/extras/` holds Ruby-only walkthroughs outside the canonical set
 (`demo.rb`, `page_interactions.rb`, `context_and_response.rb`,

--- a/packages/sdk-ruby/evals/README.md
+++ b/packages/sdk-ruby/evals/README.md
@@ -1,0 +1,51 @@
+# Ruby SDK evals
+
+Ruby ports of the bench-tier eval tasks from `packages/evals/tasks/bench/`
+(`act`, `extract`, `observe`), run through the Ruby SDK. Tasks are
+auto-discovered from `tasks/<category>/*.rb`; each is a 1:1 semantic port of
+its TypeScript original (same URLs, same assertions).
+
+## Running
+
+From `packages/sdk-ruby` (a `.env` at the repo root is not loaded — export
+`BROWSERBASE_API_KEY` first):
+
+```bash
+bundle exec ruby evals/runner.rb                     # every task on Browserbase
+bundle exec ruby evals/runner.rb extract             # one category
+bundle exec ruby evals/runner.rb act/dropdown        # one task
+bundle exec ruby evals/runner.rb --trials 3 --concurrency 8
+bundle exec ruby evals/runner.rb --local             # local Chrome (needs a model key)
+```
+
+Model resolution: `--model` / `EVAL_MODEL` (+ `EVAL_MODEL_API_KEY` or
+`OPENAI_API_KEY`) when set; otherwise the Browserbase Model Gateway picks a
+model per inference call (Browserbase runs only).
+
+Each run gets a fresh Browserbase session (or local Chrome) per task × trial.
+Results stream to stdout and to `evals/results/<timestamp>.jsonl` (one JSON
+object per run, including the Browserbase `session_id` for postmortems). Exit
+status is non-zero when any run fails.
+
+## Writing tasks
+
+```ruby
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/<name>.ts
+
+Evals.define_task("<name>") do |t|
+  t.page.goto("https://…")
+  t.stagehand.act("…")
+  actual = t.page.locator("xpath=…").input_value
+  { _success: actual == "expected", actual: actual }
+end
+```
+
+The context exposes `t.stagehand`, `t.page` (the session's initial page), and
+`t.logger`. Raising counts as a failure — no rescue wrapper needed. Return a
+Hash with `_success:`; the harness appends timing, session id, and logs.
+
+Out of scope here (still TypeScript-only): the dataset-backed benchmark
+suites (WebVoyager, OnlineMind2Web, WebTailBench), agent-tier tasks, and the
+Braintrust reporting pipeline in `packages/evals`.

--- a/packages/sdk-ruby/evals/harness.rb
+++ b/packages/sdk-ruby/evals/harness.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+# Ruby port of the packages/evals bench-tier harness: tasks are auto-
+# discovered from evals/tasks/<category>/*.rb, receive a context with a live
+# Stagehand client, and return a Hash with `_success:`. Raising counts as a
+# failure (the TS tasks' per-task begin/rescue lives here instead).
+
+require_relative "../lib/stagehand"
+
+module Evals
+  Task = Struct.new(:name, :category, :file, :block, keyword_init: true)
+
+  # Mirrors the TS EvalLogger surface the bench tasks use.
+  class TaskLogger
+    attr_reader :logs
+
+    def initialize
+      @logs = []
+    end
+
+    def log(message, auxiliary = {})
+      @logs << { "level" => "info", "message" => message, "auxiliary" => auxiliary }
+    end
+
+    def error(message, auxiliary = {})
+      @logs << { "level" => "error", "message" => message, "auxiliary" => auxiliary }
+    end
+    alias warn log
+  end
+
+  # What a task block receives (`t.stagehand`, `t.page`, `t.logger`).
+  Context = Struct.new(:stagehand, :page, :logger, keyword_init: true)
+
+  class << self
+    def tasks
+      @tasks ||= []
+    end
+
+    # One extension upload per runner invocation: per-session uploads trip
+    # Browserbase's POST /v1/extensions rate limit under concurrency.
+    def shared_extension_id
+      @extension_mutex ||= Mutex.new
+      @extension_mutex.synchronize do
+        @shared_extension_id ||= Stagehand::BrowserbaseClient
+          .new(api_key: ENV.fetch("BROWSERBASE_API_KEY"), base_url: Stagehand::BrowserbaseSession::DEFAULT_BROWSERBASE_URL)
+          .upload_extension(Stagehand::ExtensionAssets.build_extension_archive)
+      end
+    end
+
+    def delete_shared_extension
+      return if @shared_extension_id.nil?
+      Stagehand::BrowserbaseClient
+        .new(api_key: ENV.fetch("BROWSERBASE_API_KEY"), base_url: Stagehand::BrowserbaseSession::DEFAULT_BROWSERBASE_URL)
+        .delete_extension(@shared_extension_id)
+      @shared_extension_id = nil
+    rescue StandardError
+      nil
+    end
+
+    def define_task(name, &block)
+      raise ArgumentError, "a task block is required" if block.nil?
+      tasks << Task.new(name: name, category: @loading_category, file: @loading_file, block: block)
+    end
+
+    def load_tasks(root = File.join(__dir__, "tasks"))
+      Dir.children(root).sort.each do |category|
+        directory = File.join(root, category)
+        next unless File.directory?(directory)
+        Dir.glob(File.join(directory, "*.rb")).sort.each do |file|
+          @loading_category = category
+          @loading_file = file
+          load file
+        end
+      end
+      @loading_category = @loading_file = nil
+      tasks
+    end
+
+    # Runs one task in a fresh browser + Stagehand instance and returns the
+    # task's result Hash (string keys) plus timing.
+    def run_task(task, browserbase: true, model: nil, model_api_key: nil, log_level: "error")
+      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      logger = TaskLogger.new
+      session_id = nil
+      result =
+        begin
+          browser =
+            if browserbase
+              Stagehand::Browserbase.launch(
+                api_key: ENV.fetch("BROWSERBASE_API_KEY"),
+                extension_id: shared_extension_id,
+              )
+            else
+              Stagehand::LocalBrowser.launch(headless: ENV["HEADED"].nil?)
+            end
+          begin
+            session_id = browser.session_id
+            # selfHeal defaults off on the server; without it the heal_*
+            # benchmarks pass while measuring nothing (mirrors the TS evals).
+            create_options = { browser: browser, log_level: log_level, self_heal: true }
+            if model
+              create_options[:model] = model
+              create_options[:model_api_key] = model_api_key if model_api_key
+            end
+            stagehand = Stagehand.create(**create_options)
+            begin
+              page = browser.context.pages.first
+              raise "Stagehand initialized without an active page" if page.nil?
+              raw = task.block.call(Context.new(stagehand: stagehand, page: page, logger: logger))
+              raw.is_a?(Hash) ? raw : { _success: false, error: "task returned #{raw.class} instead of a Hash" }
+            ensure
+              stagehand.close
+            end
+          ensure
+            browser.close
+          end
+        rescue StandardError => error
+          { _success: false, error: "#{error.class}: #{error.message}" }
+        end
+      duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started) * 1000).round
+      result.transform_keys(&:to_s).merge(
+        "task" => task.name,
+        "category" => task.category,
+        "duration_ms" => duration_ms,
+        "session_id" => session_id,
+        "logs" => logger.logs,
+      )
+    end
+  end
+end

--- a/packages/sdk-ruby/evals/runner.rb
+++ b/packages/sdk-ruby/evals/runner.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+# Runs the Ruby ports of the bench eval tasks. Usage from packages/sdk-ruby:
+#
+#   bundle exec ruby evals/runner.rb                     # every task, Browserbase
+#   bundle exec ruby evals/runner.rb extract             # one category
+#   bundle exec ruby evals/runner.rb extract/extract_csa # one task
+#   bundle exec ruby evals/runner.rb --trials 3 --concurrency 8
+#   bundle exec ruby evals/runner.rb --local             # local Chrome (needs OPENAI_API_KEY)
+#
+# Model: EVAL_MODEL (+ EVAL_MODEL_API_KEY / OPENAI_API_KEY) when set;
+# otherwise the Browserbase Model Gateway picks one per inference call.
+# Results stream to stdout and to evals/results/<timestamp>.jsonl.
+
+require "json"
+require "optparse"
+
+require_relative "harness"
+
+options = { trials: 1, concurrency: 4, browserbase: true }
+parser = OptionParser.new do |opts|
+  opts.banner = "Usage: ruby evals/runner.rb [target] [options]"
+  opts.on("--trials N", Integer, "Trials per task (default 1)") { |n| options[:trials] = n }
+  opts.on("--concurrency N", Integer, "Parallel sessions (default 4)") { |n| options[:concurrency] = n }
+  opts.on("--local", "Local Chrome instead of Browserbase") { options[:browserbase] = false }
+  opts.on("--model NAME", "Model name (default: Browserbase Model Gateway)") { |m| options[:model] = m }
+end
+targets = parser.parse(ARGV)
+
+model = options[:model] || ENV.fetch("EVAL_MODEL", nil)
+model = nil if model && model.empty?
+model_api_key = ENV["EVAL_MODEL_API_KEY"] || ENV.fetch("OPENAI_API_KEY", nil)
+model_api_key = nil if model_api_key && model_api_key.empty?
+if !options[:browserbase] && model.nil?
+  abort "Local runs need a model: set EVAL_MODEL (+ key) or pass --model (the Gateway is Browserbase-only)."
+end
+
+all_tasks = Evals.load_tasks
+tasks =
+  if targets.empty? || targets == ["all"]
+    all_tasks
+  else
+    selected = targets.flat_map do |target|
+      category, name = target.include?("/") ? target.split("/", 2) : [target, nil]
+      matches = all_tasks.select do |task|
+        if name
+          task.category == category && task.name == name
+        else
+          task.category == target || task.name == target
+        end
+      end
+      abort "No tasks match #{target.inspect}. Categories: #{all_tasks.map(&:category).uniq.join(", ")}" if matches.empty?
+      matches
+    end.uniq
+    selected
+  end
+
+jobs = Queue.new
+tasks.each { |task| options[:trials].times { |trial| jobs << [task, trial] } }
+total = jobs.size
+options[:concurrency].times { jobs << nil }
+
+require "fileutils"
+FileUtils.mkdir_p(File.join(__dir__, "results"))
+results_path = File.join(__dir__, "results", "#{Time.now.strftime("%Y%m%d-%H%M%S")}.jsonl")
+results_file = File.open(results_path, "a")
+io_mutex = Mutex.new
+results = []
+completed = 0
+
+puts "Running #{tasks.size} task(s) × #{options[:trials]} trial(s) = #{total} run(s) " \
+     "on #{options[:browserbase] ? "Browserbase" : "local Chrome"} " \
+     "(model: #{model || "Browserbase Model Gateway"}, concurrency #{options[:concurrency]})"
+
+# Upload the extension once up front; every session reuses it.
+Evals.shared_extension_id if options[:browserbase]
+at_exit { Evals.delete_shared_extension }
+
+workers = options[:concurrency].times.map do
+  Thread.new do
+    loop do
+      job = jobs.pop
+      break if job.nil?
+      task, trial = job
+      result = Evals.run_task(
+        task,
+        browserbase: options[:browserbase],
+        model: model,
+        model_api_key: model_api_key,
+      ).merge("trial" => trial)
+      io_mutex.synchronize do
+        results << result
+        completed += 1
+        status = result["_success"] ? "PASS" : "FAIL"
+        detail = result["_success"] ? "" : "  #{(result["error"] || "assertion failed").to_s.slice(0, 120)}"
+        puts format(
+          "[%<done>3d/%<total>d] %<status>s  %<name>-42s %<ms>6dms%<detail>s",
+          done: completed, total: total, status: status,
+          name: "#{task.category}/#{task.name}", ms: result["duration_ms"], detail: detail,
+        )
+        results_file.puts(JSON.generate(result))
+        results_file.flush
+      end
+    end
+  end
+end
+workers.each(&:join)
+results_file.close
+
+puts "\nResults: #{results_path}"
+summary = results.group_by { |result| result["category"] }.sort
+overall_passed = results.count { |result| result["_success"] }
+summary.each do |category, entries|
+  passed = entries.count { |entry| entry["_success"] }
+  puts format("  %<category>-10s %<passed>3d/%<total>d passed", category: category, passed: passed, total: entries.size)
+end
+puts format("  %<label>-10s %<passed>3d/%<total>d passed", label: "overall", passed: overall_passed, total: results.size)
+
+failures = results.reject { |result| result["_success"] }
+unless failures.empty?
+  puts "\nFailed runs:"
+  failures.each do |failure|
+    puts "  #{failure["category"]}/#{failure["task"]} (trial #{failure["trial"]}): " \
+         "#{(failure["error"] || "assertion failed").to_s.slice(0, 160)} [session #{failure["session_id"]}]"
+  end
+end
+
+exit(failures.empty? ? 0 : 1)

--- a/packages/sdk-ruby/evals/tasks/act/amazon_add_to_cart.rb
+++ b/packages/sdk-ruby/evals/tasks/act/amazon_add_to_cart.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/amazon_add_to_cart.ts
+
+Evals.define_task("amazon_add_to_cart") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/amazon/")
+
+  t.stagehand.act("click the 'Add to Cart' button")
+
+  t.stagehand.act("click the 'Proceed to checkout' button")
+
+  current_url = t.page.url
+  expected_url = "https://browserbase.github.io/stagehand-eval-sites/sites/amazon/sign-in.html"
+
+  t.logger.log("currentUrl #{current_url}")
+  t.logger.log("expectedUrl #{expected_url}")
+
+  { _success: current_url == expected_url, currentUrl: current_url }
+end

--- a/packages/sdk-ruby/evals/tasks/act/bidnet.rb
+++ b/packages/sdk-ruby/evals/tasks/act/bidnet.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/bidnet.ts
+
+Evals.define_task("bidnet") do |t|
+  t.page.goto("https://www.bidnetdirect.com/")
+
+  t.stagehand.act('Click on the "Construction" keyword')
+
+  expected_url = "https://www.bidnetdirect.com/public/solicitations/open?keywords=Construction"
+  current_url = t.page.url
+
+  { _success: current_url.start_with?(expected_url), currentUrl: current_url }
+end

--- a/packages/sdk-ruby/evals/tasks/act/checkboxes.rb
+++ b/packages/sdk-ruby/evals/tasks/act/checkboxes.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/checkboxes.ts
+
+Evals.define_task("checkboxes") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/checkboxes/")
+
+  t.stagehand.act("click the 'baseball' option")
+
+  t.stagehand.act("click the 'netball' option")
+
+  baseball_checked = t.page.locator('input[type="checkbox"][name="sports"][value="baseball"]').checked?
+
+  netball_checked = t.page.locator('input[type="checkbox"][name="sports"][value="netball"]').checked?
+
+  { _success: baseball_checked && netball_checked }
+end

--- a/packages/sdk-ruby/evals/tasks/act/csr_in_oopif.rb
+++ b/packages/sdk-ruby/evals/tasks/act/csr_in_oopif.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/csr_in_oopif.ts
+
+Evals.define_task("csr_in_oopif") do |t|
+  # this eval is designed to test whether stagehand can successfully
+  # click inside an CSR (closed mode shadow) root that is inside an
+  # OOPIF (out of process iframe)
+
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/closed-shadow-root-in-oopif/")
+  t.stagehand.act("click the button")
+
+  t.page.wait_for_timeout(1000)
+
+  # v3 used schemaless extract; v4 requires a schema.
+  # Single-word key to stay clear of the snake_case wire-casing bug (#14).
+  extraction = t.stagehand.extract(
+    "extract the entire page text",
+    schema: {
+      "type" => "object",
+      "properties" => { "extraction" => { "type" => "string" } },
+      "required" => ["extraction"],
+      "additionalProperties" => false,
+    },
+  ).data
+
+  page_text = extraction["extraction"]
+
+  if page_text.include?("button successfully clicked")
+    next { _success: true, message: "successfully clicked the button" }
+  end
+
+  { _success: false, message: "unable to click on the button" }
+end

--- a/packages/sdk-ruby/evals/tasks/act/csr_in_spif.rb
+++ b/packages/sdk-ruby/evals/tasks/act/csr_in_spif.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/csr_in_spif.ts
+
+Evals.define_task("csr_in_spif") do |t|
+  # this eval is designed to test whether stagehand can successfully
+  # click inside an CSR (closed mode shadow) root that is inside an
+  # SPIF (same process iframe)
+
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/closed-shadow-dom-in-spif/")
+  t.stagehand.act("click the button")
+
+  # v3 used schemaless extract; v4 requires a schema.
+  # Single-word key to stay clear of the snake_case wire-casing bug (#14).
+  extraction = t.stagehand.extract(
+    "extract the entire page text",
+    schema: {
+      "type" => "object",
+      "properties" => { "extraction" => { "type" => "string" } },
+      "required" => ["extraction"],
+      "additionalProperties" => false,
+    },
+  ).data
+
+  page_text = extraction["extraction"]
+
+  if page_text.include?("button successfully clicked")
+    next { _success: true, message: "successfully clicked the button" }
+  end
+
+  { _success: false, message: "unable to click on the button" }
+end

--- a/packages/sdk-ruby/evals/tasks/act/custom_dropdown.rb
+++ b/packages/sdk-ruby/evals/tasks/act/custom_dropdown.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/custom_dropdown.ts
+
+Evals.define_task("custom_dropdown") do |t|
+  # This eval is meant to test whether we do not incorrectly attempt
+  # the selectOptionFromDropdown method (defined in actHandlerUtils.ts) on a
+  # 'dropdown' that is not a <select> element.
+  #
+  # This kind of dropdown must be clicked to be expanded before being interacted
+  # with.
+
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/expand-dropdown/")
+
+  t.stagehand.act("choose Canada from the 'Select a Country' dropdown")
+
+  # read the rendered page text directly — no second model call
+  full_tree = t.page.locator("#chosenValue").inner_text
+
+  if full_tree.include?("Canada")
+    next { _success: true }
+  end
+
+  { _success: false, message: "unable to expand the dropdown" }
+end

--- a/packages/sdk-ruby/evals/tasks/act/dropdown.rb
+++ b/packages/sdk-ruby/evals/tasks/act/dropdown.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/dropdown.ts
+
+Evals.define_task("dropdown") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/dropdown/")
+
+  # click the dropdown element to expand it
+  t.page.locator("xpath=/html/body/div/div/button").click
+
+  # type into the input box (which should be hidden behind the expanded dropdown)
+  t.stagehand.act("type 'test fill' into the input field")
+
+  expected_value = "test fill"
+  actual_value = t.page.locator("xpath=/html/body/div/input").input_value
+
+  { _success: actual_value == expected_value, expectedValue: expected_value, actualValue: actual_value }
+end

--- a/packages/sdk-ruby/evals/tasks/act/google_flights.rb
+++ b/packages/sdk-ruby/evals/tasks/act/google_flights.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/google_flights.ts
+
+# This eval attempts to click on an element that should not pass the playwright actionability check
+# which happens by default if you call locator.click (more information here:
+# https://playwright.dev/docs/actionability)
+#
+# If this eval passes, it means that we have correctly set {force: true} in performPlaywrightMethod,
+# and the click was successful even though the target element (found by the xpath) did not
+# pass the actionability check.
+
+Evals.define_task("google_flights") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/google-flights/")
+
+  observe_result = Stagehand::Models::Action.new(
+    selector:
+      "xpath=/html/body/c-wiz[2]/div/div[2]/c-wiz/div[1]/c-wiz/div[2]/div[2]/div[2]/div/div[2]/div[1]/ul/li[1]/div/div[1]",
+    description: "the first departing flight",
+    method: "click",
+    arguments: [],
+  )
+  t.stagehand.act(observe_result)
+
+  expected_url =
+    "https://browserbase.github.io/stagehand-eval-sites/sites/google-flights/return-flight.html"
+  current_url = t.page.url
+
+  if current_url == expected_url
+    next { _success: true, currentUrl: current_url }
+  end
+
+  { _success: false, error: "The current URL does not match expected." }
+end

--- a/packages/sdk-ruby/evals/tasks/act/heal_custom_dropdown.rb
+++ b/packages/sdk-ruby/evals/tasks/act/heal_custom_dropdown.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/heal_custom_dropdown.ts
+
+Evals.define_task("heal_custom_dropdown") do |t|
+  # This eval is meant to test whether we do not incorrectly attempt
+  # the selectOptionFromDropdown method (defined in actHandlerUtils.ts) on a
+  # 'dropdown' that is not a <select> element.
+  #
+  # This kind of dropdown must be clicked to be expanded before being interacted
+  # with.
+
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/expand-dropdown/")
+
+  # Self-healing act(Action) replay (restored by
+  # stagehand#2427): same intentionally invalid selector as the v3
+  # twin — healing must re-locate "The 'Select a country' dropdown"
+  # and click it to expand.
+  healed = t.stagehand.act(Stagehand::Models::Action.new(
+    description: "The 'Select a country' dropdown",
+    selector: "/html/not-a-dropdown",
+    arguments: [],
+    method: "click",
+  )).data
+
+  # Report a failed heal directly rather than letting it surface as an
+  # absent dropdown option. Healing requires selfHeal: true at init; the
+  # server defaults it off and it cannot be set per-call.
+  unless healed.success
+    next { _success: false, message: "self-heal did not expand the dropdown: #{healed.message}" }
+  end
+
+  # If the dropdown expanded, its options are now rendered in the DOM.
+  # (v3 checked the schemaless-extract page text; v4 extract requires a
+  # schema, so read the rendered text directly — same signal, no LLM.)
+  page_text = t.page.evaluate("(() => document.body.innerText)()")
+
+  if page_text.include?("Canada")
+    next { _success: true }
+  end
+
+  { _success: false, message: "unable to expand the dropdown" }
+end

--- a/packages/sdk-ruby/evals/tasks/act/heal_scroll_50.rb
+++ b/packages/sdk-ruby/evals/tasks/act/heal_scroll_50.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/heal_scroll_50.ts
+
+Evals.define_task("heal_scroll_50") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/aigrant/")
+
+  # Self-healing act(Action) replay (restored by
+  # stagehand#2427): same supplied action as the v3 twin — a
+  # "scrollTo" with arguments ["50%"], exercising the deterministic
+  # executor with variable substitution and healing.
+  healed = t.stagehand.act(Stagehand::Models::Action.new(
+    description: "the element to scroll on",
+    selector: "/html/body/div/div/button",
+    arguments: ["50%"],
+    method: "scrollTo",
+  )).data
+
+  # Report a failed heal directly rather than letting it surface as an
+  # unchanged scroll position. Healing requires selfHeal: true at init;
+  # the server defaults it off and it cannot be set per-call.
+  unless healed.success
+    next { _success: false, message: "self-heal did not scroll the page: #{healed.message}" }
+  end
+
+  t.page.wait_for_timeout(5000)
+
+  scroll_info = t.page.evaluate(<<~JS)
+    (() => {
+      return {
+        scrollTop: window.scrollY + window.innerHeight / 2,
+        scrollHeight: document.documentElement.scrollHeight,
+      };
+    })()
+  JS
+
+  halfway_scroll = scroll_info["scrollHeight"] / 2.0
+  halfway_reached = (scroll_info["scrollTop"] - halfway_scroll).abs <= 200
+
+  result = { _success: halfway_reached }
+  unless halfway_reached
+    result[:message] =
+      "Scroll position (#{scroll_info["scrollTop"]}px) is not halfway down the page (#{halfway_scroll}px)."
+  end
+  result
+end

--- a/packages/sdk-ruby/evals/tasks/act/heal_simple_google_search.rb
+++ b/packages/sdk-ruby/evals/tasks/act/heal_simple_google_search.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/heal_simple_google_search.ts
+
+Evals.define_task("heal_simple_google_search") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/google/")
+
+  # Self-healing act(Action) replay (restored by
+  # stagehand#2427): same intentionally invalid selector as the v3
+  # twin — healing must re-locate "The search bar" and fill it.
+  healed = t.stagehand.act(Stagehand::Models::Action.new(
+    description: "The search bar",
+    selector: "/html/not-the-search-bar",
+    arguments: ["OpenAI"],
+    method: "fill",
+  )).data
+
+  # Without this the task presses Enter on an empty field and reports a
+  # URL mismatch, hiding why healing did not happen. Note that healing
+  # only runs when the client was initialized with selfHeal: true — the
+  # server defaults it to false (actService.ts), and it cannot be set
+  # per-call, so a failure here usually means an init-level difference.
+  unless healed.success
+    next { _success: false, message: "self-heal did not fill the search bar: #{healed.message}" }
+  end
+
+  t.stagehand.act("press enter")
+  t.page.wait_for_timeout(3000)
+
+  expected_url = "https://browserbase.github.io/stagehand-eval-sites/sites/google/openai.html"
+  current_url = t.page.url
+
+  { _success: current_url.start_with?(expected_url), currentUrl: current_url }
+end

--- a/packages/sdk-ruby/evals/tasks/act/hidden_input_dropdown.rb
+++ b/packages/sdk-ruby/evals/tasks/act/hidden_input_dropdown.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/hidden_input_dropdown.ts
+
+Evals.define_task("hidden_input_dropdown") do |t|
+  # This eval is meant to test whether we do not incorrectly attempt
+  # the selectOptionFromDropdown method (defined in actHandlerUtils.ts) on a
+  # hidden input 'dropdown'.
+  #
+  # This kind of dropdown must be clicked to be expanded before being interacted
+  # with.
+
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/hidden-input-dropdown/")
+
+  t.stagehand.act("click to expand the 'Favourite Colour' dropdown")
+
+  # we are expecting stagehand to click the dropdown to expand it,
+  # and therefore the available options should now be contained in the full
+  # a11y tree.
+
+  # to test, we'll grab the full a11y tree, and make sure it contains 'Green'
+  # v3 used schemaless extract; v4 requires a schema.
+  # Single-word key to stay clear of the snake_case wire-casing bug (#14).
+  extraction = t.stagehand.extract(
+    "extract the entire page text",
+    schema: {
+      "type" => "object",
+      "properties" => { "extraction" => { "type" => "string" } },
+      "required" => ["extraction"],
+      "additionalProperties" => false,
+    },
+  ).data
+  full_tree = extraction["extraction"]
+
+  if full_tree.include?("Green")
+    next { _success: true }
+  end
+
+  { _success: false, message: "unable to expand the dropdown" }
+end

--- a/packages/sdk-ruby/evals/tasks/act/iframe_form_filling.rb
+++ b/packages/sdk-ruby/evals/tasks/act/iframe_form_filling.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/iframe_form_filling.ts
+
+Evals.define_task("iframe_form_filling") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/iframe-form-filling/")
+
+  t.stagehand.act("type 'nunya' into the 'first name' field")
+  t.stagehand.act("type 'business' into the 'last name' field")
+  t.stagehand.act("type 'test@email.com' into the 'email' field")
+  t.stagehand.act("click 'phone' as the preferred contact method")
+  t.stagehand.act("type 'yooooooooooooooo' into the message box")
+
+  # The form lives in a cross-origin iframe, so main-frame evaluation
+  # cannot access its contentDocument. V4 locators resolve `>>` iframe
+  # hops server-side and can inspect the OOPIF directly.
+  first_name_value = t.page.locator('iframe >> input[placeholder="Jane"]').input_value
+
+  last_name_value = t.page.locator('iframe >> input[placeholder="Doe"]').input_value
+
+  email_value = t.page.locator('iframe >> input[placeholder="jane@example.com"]').input_value
+
+  contact_value = t.page
+                   .locator("iframe >> xpath=/html/body/main/section[1]/form/fieldset/label[2]/input")
+                   .checked?
+
+  message_value = t.page.locator('iframe >> textarea[placeholder="Say hello…"]').input_value
+
+  passed =
+    first_name_value.downcase.strip == "nunya" &&
+    last_name_value.downcase.strip == "business" &&
+    email_value.downcase == "test@email.com" &&
+    message_value.downcase == "yooooooooooooooo" &&
+    contact_value
+
+  { _success: passed }
+end

--- a/packages/sdk-ruby/evals/tasks/act/iframe_same_proc.rb
+++ b/packages/sdk-ruby/evals/tasks/act/iframe_same_proc.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/iframe_same_proc.ts
+
+Evals.define_task("iframe_same_proc") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/iframe-same-proc/")
+
+  t.stagehand.act("type 'stagehand' into the 'your name' field")
+
+  # overly specific prompting is okay here. we are just trying to evaluate whether
+  # we are properly traversing iframes
+  t.stagehand.act(
+    "select 'Green' from the favorite colour dropdown. Ensure the word 'Green' is capitalized. Choose the selectOption method.",
+  )
+
+  # v3 used page.frameLocator("iframe") for these assertions; v4 has no
+  # frameLocator, so the same checks are re-expressed in-page via the
+  # same-origin iframe's contentDocument.
+  values = t.page.evaluate(<<~JS)
+    (() => {
+      const doc = document.querySelector("iframe")?.contentDocument;
+      if (!doc) throw new Error("could not access iframe contentDocument");
+
+      const name = doc.querySelector('input[placeholder="Alice"]');
+      const color = doc.querySelector("select");
+
+      if (!name || !color) {
+        throw new Error("could not resolve form fields inside the iframe");
+      }
+
+      return {
+        nameValue: name.value,
+        colorValue: color.value,
+      };
+    })()
+  JS
+  name_value = values["nameValue"]
+  color_value = values["colorValue"]
+
+  passed =
+    name_value.downcase.strip == "stagehand" &&
+    color_value.downcase.strip == "green"
+
+  { _success: passed }
+end

--- a/packages/sdk-ruby/evals/tasks/act/iframe_scroll.rb
+++ b/packages/sdk-ruby/evals/tasks/act/iframe_scroll.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/iframe_scroll.ts
+
+Evals.define_task("iframe_scroll") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/iframe-same-proc-scroll/")
+  t.stagehand.act("scroll down 50% inside the iframe")
+
+  t.page.wait_for_timeout(5000)
+
+  # v3 evaluated inside page.frames()[1]; v4 exposes no frames() list,
+  # so the same measurement is re-expressed via the same-origin iframe's
+  # contentWindow/contentDocument.
+  scroll_info = t.page.evaluate(<<~JS)
+    (() => {
+      const iframe = document.querySelector("iframe");
+      const win = iframe?.contentWindow;
+      const doc = iframe?.contentDocument;
+      if (!win || !doc) {
+        throw new Error("could not access iframe content");
+      }
+      return {
+        scrollTop: win.scrollY + win.innerHeight / 2,
+        scrollHeight: doc.documentElement.scrollHeight,
+      };
+    })()
+  JS
+
+  scroll_top = scroll_info["scrollTop"]
+  halfway_scroll = scroll_info["scrollHeight"] / 2.0
+  halfway_reached = (scroll_top - halfway_scroll).abs <= 1
+
+  if halfway_reached
+    { _success: true }
+  else
+    {
+      _success: false,
+      message: "Scroll position (#{scroll_top}px) is not halfway down the page (#{halfway_scroll}px).",
+    }
+  end
+end

--- a/packages/sdk-ruby/evals/tasks/act/iframes_nested.rb
+++ b/packages/sdk-ruby/evals/tasks/act/iframes_nested.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/iframes_nested.ts
+
+Evals.define_task("iframes_nested") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/nested-iframes/")
+
+  t.stagehand.act("type 'stagehand' into the 'username' field")
+
+  # v3 chained frameLocator lvl1 -> lvl2 -> lvl3 (form lives in level 3);
+  # v4 has no frameLocator, so the same check is re-expressed in-page by
+  # walking the same-origin iframes' contentDocuments.
+  username_text = t.page.evaluate(<<~JS)
+    (() => {
+      const lvl1 = document.querySelector("iframe.lvl1")?.contentDocument; // level 1
+      const lvl2 = lvl1?.querySelector("iframe.lvl2")?.contentDocument; // level 2
+      const lvl3 = lvl2?.querySelector("iframe.lvl3")?.contentDocument; // level 3 – form lives here
+
+      const input = lvl3?.querySelector('input[name="username"]');
+      if (!input) {
+        throw new Error("could not resolve the username input in the nested iframes");
+      }
+      return input.value;
+    })()
+  JS
+
+  passed = username_text.downcase.strip == "stagehand"
+
+  { _success: passed }
+end

--- a/packages/sdk-ruby/evals/tasks/act/ionwave.rb
+++ b/packages/sdk-ruby/evals/tasks/act/ionwave.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/ionwave.ts
+
+Evals.define_task("ionwave") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/ionwave/")
+
+  t.stagehand.act('Click on "Closed Bids"')
+
+  expected_url = "https://browserbase.github.io/stagehand-eval-sites/sites/ionwave/closed-bids.html"
+  current_url = t.page.url
+
+  { _success: current_url.start_with?(expected_url), currentUrl: current_url }
+end

--- a/packages/sdk-ruby/evals/tasks/act/login.rb
+++ b/packages/sdk-ruby/evals/tasks/act/login.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/login.ts
+
+Evals.define_task("login") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/login/")
+
+  t.stagehand.act("type %nunya% into the username field",
+                  variables: { "nunya" => "business" })
+
+  actual_value = t.page.locator("xpath=/html/body/main/form/div[1]/input").input_value
+
+  expected_value = "business"
+
+  { _success: actual_value == expected_value, expectedValue: expected_value, actualValue: actual_value }
+end

--- a/packages/sdk-ruby/evals/tasks/act/multi_tab.rb
+++ b/packages/sdk-ruby/evals/tasks/act/multi_tab.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/multi_tab.ts
+
+Evals.define_task("multi_tab") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/five-tab/")
+
+  # v3-parity form: activePage() polls until Chrome's active target
+  # registers (stagehand#2458), and act resolves its target through it,
+  # so back-to-back tab-opening acts chain without explicit waits.
+  t.stagehand.act("click the button to open the other page")
+  t.stagehand.act("click the button to open the other page")
+  t.stagehand.act("click the button to open the other page")
+  t.stagehand.act("click the button to open the other page")
+  active_page = t.stagehand.browser.context.active_page
+  raise "no active page after opening tabs" unless active_page
+
+  current_page_url = active_page.url
+  expected_url = "https://browserbase.github.io/stagehand-eval-sites/sites/five-tab/page5.html"
+
+  if current_page_url != expected_url
+    next { _success: false, message: "expected URL does not match current URL" }
+  end
+
+  # try acting on the first page again
+  pages = t.stagehand.browser.context.pages
+  page1 = pages[0]
+  t.stagehand.act("click the button to open the other page", page: page1)
+
+  active_page = t.stagehand.browser.context.active_page
+  raise "no active page after acting on page 1" unless active_page
+
+  current_page_url = active_page.url
+  expected_url = "https://browserbase.github.io/stagehand-eval-sites/sites/five-tab/page2.html"
+  if current_page_url != expected_url
+    next { _success: false, message: "expected URL does not match current URL" }
+  end
+
+  # Target the page the URL assertion just verified. Without { page },
+  # extract resolves its own target through activePage() again, so a
+  # focus change between the check and the extract would silently move
+  # the assertion to another tab. v3 also used schemaless extract; v4
+  # requires a schema. Single-word key to stay clear of the snake_case
+  # wire-casing bug (#14).
+  page2text = t.stagehand.extract(
+    "extract the entire page text",
+    schema: {
+      "type" => "object",
+      "properties" => { "extraction" => { "type" => "string" } },
+      "required" => ["extraction"],
+      "additionalProperties" => false,
+    },
+    page: active_page,
+  ).data
+  expected_page2text = "You've made it to page 2"
+
+  if page2text["extraction"].include?(expected_page2text)
+    next { _success: true }
+  end
+
+  {
+    _success: false,
+    message: "extracted page text: #{page2text["extraction"]} does not match expected page text: #{expected_page2text}",
+  }
+end

--- a/packages/sdk-ruby/evals/tasks/act/namespace_xpath.rb
+++ b/packages/sdk-ruby/evals/tasks/act/namespace_xpath.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/namespace_xpath.ts
+
+Evals.define_task("namespace_xpath") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/namespaced-xpath/")
+
+  t.stagehand.act("fill 'nunya' into the 'type here' form")
+
+  input_value = t.page.locator("#ns-text").input_value
+  # confirm that the form was filled
+  form_has_been_filled = input_value == "nunya"
+
+  { _success: form_has_been_filled }
+end

--- a/packages/sdk-ruby/evals/tasks/act/nested_iframes_2.rb
+++ b/packages/sdk-ruby/evals/tasks/act/nested_iframes_2.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/nested_iframes_2.ts
+
+Evals.define_task("nested_iframes_2") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/nested-iframes-2/")
+
+  t.stagehand.act("click the button called 'click me (inner 2)'")
+
+  # v3 chained frameLocator iframe2.html -> inner2.html; v4 has no
+  # frameLocator, so the same check is re-expressed in-page by walking
+  # the same-origin iframes' contentDocuments.
+  message_text = t.page.evaluate(<<~JS)
+    (() => {
+      const outer = document.querySelector('iframe[src="iframe2.html"]')?.contentDocument;
+      const inner = outer?.querySelector('iframe[src="inner2.html"]')?.contentDocument;
+
+      const msg = inner?.querySelector("#msg");
+      if (!msg) {
+        throw new Error("could not resolve #msg in the nested iframes");
+      }
+      return msg.textContent ?? "";
+    })()
+  JS
+
+  passed = message_text.downcase.strip == "clicked the button in the second inner iframe"
+
+  { _success: passed }
+end

--- a/packages/sdk-ruby/evals/tasks/act/next_chunk.rb
+++ b/packages/sdk-ruby/evals/tasks/act/next_chunk.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/next_chunk.ts
+
+Evals.define_task("next_chunk") do |t|
+  t.page.goto("https://www.apartments.com/san-francisco-ca/", wait_until: "domcontentloaded")
+  t.stagehand.act("click on the all filters button")
+
+  measurements = t.page.evaluate(<<~JS)
+    (() => {
+      const container = document.querySelector("#advancedFilters > div");
+      if (!container) {
+        console.warn("Could not find #advancedFilters > div. Returning 0 for measurements.");
+        return { initialScrollTop: 0, chunkHeight: 0 };
+      }
+      return {
+        initialScrollTop: container.scrollTop,
+        chunkHeight: container.getBoundingClientRect().height,
+      };
+    })()
+  JS
+  initial_scroll_top = measurements["initialScrollTop"]
+  chunk_height = measurements["chunkHeight"]
+
+  t.stagehand.act("scroll down one chunk on the filters modal")
+
+  t.page.wait_for_timeout(2000)
+
+  new_scroll_top = t.page.evaluate(<<~JS)
+    (() => {
+      const container = document.querySelector("#advancedFilters > div");
+      return container?.scrollTop ?? 0;
+    })()
+  JS
+
+  actual_diff = new_scroll_top - initial_scroll_top
+  threshold = 20 # allowable difference in px
+  scrolled_one_chunk = (actual_diff - chunk_height).abs <= threshold
+
+  if scrolled_one_chunk
+    { _success: true,
+      message: "Successfully scrolled ~one chunk: expected ~#{chunk_height}, got #{actual_diff}" }
+  else
+    { _success: false,
+      message: "Scroll difference expected ~#{chunk_height} but only scrolled #{actual_diff}." }
+  end
+end

--- a/packages/sdk-ruby/evals/tasks/act/no_js_click.rb
+++ b/packages/sdk-ruby/evals/tasks/act/no_js_click.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/no_js_click.ts
+
+Evals.define_task("no_js_click") do |t|
+  # This eval is meant to test whether our `clickElement` function
+  # (inside actHandlerUtils.ts) is able to click elements even if
+  # the site blocks programmatic JS click events.
+
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/no-js-click/")
+
+  observe_result = Stagehand::Models::Action.new(
+    method: "click",
+    selector: "xpath=/html/body/button",
+    description: "the button to click",
+    arguments: [],
+  )
+  t.stagehand.act(observe_result)
+
+  text = t.page.locator("#success-msg").text_content
+  if text&.strip == "click succeeded"
+    next { _success: true }
+  end
+
+  { _success: false, message: "unable to click element on website that blocks JS click events" }
+end

--- a/packages/sdk-ruby/evals/tasks/act/nonsense_action.rb
+++ b/packages/sdk-ruby/evals/tasks/act/nonsense_action.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/nonsense_action.ts
+
+Evals.define_task("nonsense_action") do |t|
+  t.page.goto("https://www.homedepot.com/")
+
+  result = t.stagehand.act("what is the capital of the moon?").data
+
+  # We expect this to fail
+  { _success: !result.success }
+end

--- a/packages/sdk-ruby/evals/tasks/act/oopif_in_csr.rb
+++ b/packages/sdk-ruby/evals/tasks/act/oopif_in_csr.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/oopif_in_csr.ts
+
+Evals.define_task("oopif_in_csr") do |t|
+  # this eval is designed to test whether stagehand can successfully
+  # fill a form inside a OOPIF (out of process iframe) that is inside an
+  # CSR (closed mode shadow) root
+
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/oopif-in-open-shadow-dom/")
+  t.stagehand.act("fill 'nunya' into the first name field")
+
+  # v3 used schemaless extract; v4 requires a schema.
+  # Single-word key to stay clear of the snake_case wire-casing bug (#14).
+  extraction = t.stagehand.extract(
+    "extract the entire page text",
+    schema: {
+      "type" => "object",
+      "properties" => { "extraction" => { "type" => "string" } },
+      "required" => ["extraction"],
+      "additionalProperties" => false,
+    },
+  ).data
+
+  page_text = extraction["extraction"]
+
+  if page_text.include?("nunya")
+    next { _success: true, message: "successfully filled the form" }
+  end
+
+  { _success: false, message: "unable to fill the form" }
+end

--- a/packages/sdk-ruby/evals/tasks/act/oopif_in_osr.rb
+++ b/packages/sdk-ruby/evals/tasks/act/oopif_in_osr.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/oopif_in_osr.ts
+
+Evals.define_task("oopif_in_osr") do |t|
+  # this eval is designed to test whether stagehand can successfully
+  # fill a form inside a OOPIF (out of process iframe) that is inside an
+  # OSR (open mode shadow) root
+
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/oopif-in-open-shadow-dom/")
+  t.stagehand.act("fill 'nunya' into the first name field")
+
+  # v3 used schemaless extract; v4 requires a schema.
+  # Single-word key to stay clear of the snake_case wire-casing bug (#14).
+  extraction = t.stagehand.extract(
+    "extract the entire page text",
+    schema: {
+      "type" => "object",
+      "properties" => { "extraction" => { "type" => "string" } },
+      "required" => ["extraction"],
+      "additionalProperties" => false,
+    },
+  ).data
+
+  page_text = extraction["extraction"]
+
+  if page_text.include?("nunya")
+    next { _success: true, message: "successfully filled the form" }
+  end
+
+  { _success: false, message: "unable to fill the form" }
+end

--- a/packages/sdk-ruby/evals/tasks/act/os_dropdown.rb
+++ b/packages/sdk-ruby/evals/tasks/act/os_dropdown.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/os_dropdown.ts
+
+Evals.define_task("os_dropdown") do |t|
+  # This eval is meant to test whether we can correctly select an element
+  # from an OS level dropdown
+
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/nested-dropdown/")
+
+  t.stagehand.act("choose 'Smog Check Technician' from the 'License Type' dropdown")
+  # v3 used page.locator("#licenseType >> option:checked"); v4 locator has
+  # no ">>" chaining, so the same check is re-expressed in-page.
+  selected_option = t.page.evaluate(<<~JS)
+    (() => {
+      const option = document.querySelector("#licenseType option:checked");
+      return option?.textContent ?? null;
+    })()
+  JS
+
+  if selected_option == "Smog Check Technician"
+    next { _success: true }
+  end
+
+  { _success: false, message: "incorrect option selected from the dropdown" }
+end

--- a/packages/sdk-ruby/evals/tasks/act/osr_in_oopif.rb
+++ b/packages/sdk-ruby/evals/tasks/act/osr_in_oopif.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/osr_in_oopif.ts
+
+Evals.define_task("osr_in_oopif") do |t|
+  # this eval is designed to test whether stagehand can successfully
+  # click inside an OSR (open mode shadow) root that is inside an
+  # OOPIF (out of process iframe)
+
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/open-shadow-root-in-oopif/")
+  t.stagehand.act("click the button")
+
+  # v3 used schemaless extract; v4 requires a schema.
+  # Single-word key to stay clear of the snake_case wire-casing bug (#14).
+  extraction = t.stagehand.extract(
+    "extract the entire page text",
+    schema: {
+      "type" => "object",
+      "properties" => { "extraction" => { "type" => "string" } },
+      "required" => ["extraction"],
+      "additionalProperties" => false,
+    },
+  ).data
+
+  page_text = extraction["extraction"]
+
+  if page_text.include?("button successfully clicked")
+    next { _success: true, message: "successfully clicked the button" }
+  end
+
+  { _success: false, message: "unable to click on the button" }
+end

--- a/packages/sdk-ruby/evals/tasks/act/osr_in_spif.rb
+++ b/packages/sdk-ruby/evals/tasks/act/osr_in_spif.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/osr_in_spif.ts
+
+Evals.define_task("osr_in_spif") do |t|
+  # this eval is designed to test whether stagehand can successfully
+  # click inside an OSR (open mode shadow) root that is inside an
+  # SPIF (same process iframe)
+
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/open-shadow-root-in-spif/")
+  t.stagehand.act("click the button")
+
+  # v3 used schemaless extract; v4 requires a schema.
+  # Single-word key to stay clear of the snake_case wire-casing bug (#14).
+  extraction = t.stagehand.extract(
+    "extract the entire page text",
+    schema: {
+      "type" => "object",
+      "properties" => { "extraction" => { "type" => "string" } },
+      "required" => ["extraction"],
+      "additionalProperties" => false,
+    },
+  ).data
+
+  page_text = extraction["extraction"]
+
+  if page_text.include?("button successfully clicked")
+    next { _success: true, message: "successfully clicked the button" }
+  end
+
+  { _success: false, message: "unable to click on the button" }
+end

--- a/packages/sdk-ruby/evals/tasks/act/prev_chunk.rb
+++ b/packages/sdk-ruby/evals/tasks/act/prev_chunk.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/prev_chunk.ts
+
+Evals.define_task("prev_chunk") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/aigrant/")
+  t.page.wait_for_timeout(2000)
+  measurements = t.page.evaluate(<<~JS)
+    (() => {
+      const halfPage = document.body.scrollHeight / 2;
+
+      window.scrollTo({
+        top: halfPage,
+        left: 0,
+        behavior: "instant",
+      });
+
+      const chunk = window.innerHeight;
+
+      return {
+        initialScrollTop: window.scrollY,
+        chunkHeight: chunk,
+      };
+    })()
+  JS
+  initial_scroll_top = measurements["initialScrollTop"]
+  chunk_height = measurements["chunkHeight"]
+
+  t.page.wait_for_timeout(2000)
+  t.stagehand.act("scroll up one chunk")
+
+  t.page.wait_for_timeout(5000)
+
+  final_scroll_top = t.page.evaluate("(() => window.scrollY)()")
+
+  actual_diff = initial_scroll_top - final_scroll_top
+  threshold = 20 # px tolerance
+  scrolled_one_chunk = (actual_diff - chunk_height).abs <= threshold
+
+  if scrolled_one_chunk
+    { _success: true,
+      message: "Successfully scrolled ~one chunk UP: expected ~#{chunk_height}, got #{actual_diff}." }
+  else
+    { _success: false,
+      message: "Scroll difference expected ~#{chunk_height} but only scrolled #{actual_diff}." }
+  end
+end

--- a/packages/sdk-ruby/evals/tasks/act/radio_btn.rb
+++ b/packages/sdk-ruby/evals/tasks/act/radio_btn.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/radio_btn.ts
+
+Evals.define_task("radio_btn") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/paneer-pizza/")
+
+  t.stagehand.act("click the 'medium' option")
+
+  # confirm that the Medium radio is now checked
+  radio_btn_clicked = t.page.locator('input[type="radio"][name="Pizza"][value="Medium"]').checked?
+
+  { _success: radio_btn_clicked }
+end

--- a/packages/sdk-ruby/evals/tasks/act/scroll_50.rb
+++ b/packages/sdk-ruby/evals/tasks/act/scroll_50.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/scroll_50.ts
+
+Evals.define_task("scroll_50") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/aigrant/")
+  t.stagehand.act("Scroll 50% down the page")
+
+  t.page.wait_for_timeout(5000)
+
+  # Get the current scroll position and total scroll height
+  scroll_info = t.page.evaluate(<<~JS)
+    (() => {
+      return {
+        scrollTop: window.scrollY + window.innerHeight / 2,
+        scrollHeight: document.documentElement.scrollHeight,
+      };
+    })()
+  JS
+
+  halfway_scroll = scroll_info["scrollHeight"] / 2.0
+  halfway_reached = (scroll_info["scrollTop"] - halfway_scroll).abs <= 200
+
+  if halfway_reached
+    { _success: true }
+  else
+    {
+      _success: false,
+      message: "Scroll position (#{scroll_info["scrollTop"]}px) is not halfway down the page (#{halfway_scroll}px).",
+    }
+  end
+end

--- a/packages/sdk-ruby/evals/tasks/act/scroll_75.rb
+++ b/packages/sdk-ruby/evals/tasks/act/scroll_75.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/scroll_75.ts
+
+Evals.define_task("scroll_75") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/aigrant/")
+  t.stagehand.act("Scroll 75% down the page")
+
+  t.page.wait_for_timeout(5000)
+
+  # Get the current scroll position and total scroll height
+  scroll_info = t.page.evaluate(<<~JS)
+    (() => {
+      return {
+        scrollTop: window.scrollY + window.innerHeight * 0.75,
+        scrollHeight: document.documentElement.scrollHeight,
+      };
+    })()
+  JS
+
+  three_quarters_scroll = scroll_info["scrollHeight"] * 0.75
+  three_quarters_reached = (scroll_info["scrollTop"] - three_quarters_scroll).abs <= 200
+
+  if three_quarters_reached
+    { _success: true }
+  else
+    {
+      _success: false,
+      message: "Scroll position (#{scroll_info["scrollTop"]}px) is not three quarters down the page (#{three_quarters_scroll}px).",
+    }
+  end
+end

--- a/packages/sdk-ruby/evals/tasks/act/shadow_dom.rb
+++ b/packages/sdk-ruby/evals/tasks/act/shadow_dom.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/shadow_dom.ts
+
+Evals.define_task("shadow_dom") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/shadow-dom/")
+  t.stagehand.act("click the button")
+  # v3 used schemaless extract; v4 requires a schema.
+  # Single-word key to stay clear of the snake_case wire-casing bug (#14).
+  extraction = t.stagehand.extract(
+    "extract the page text",
+    schema: {
+      "type" => "object",
+      "properties" => { "extraction" => { "type" => "string" } },
+      "required" => ["extraction"],
+      "additionalProperties" => false,
+    },
+  ).data
+
+  page_text = extraction["extraction"]
+
+  { _success: page_text.include?("button successfully clicked") }
+end

--- a/packages/sdk-ruby/evals/tasks/act/simple_google_search.rb
+++ b/packages/sdk-ruby/evals/tasks/act/simple_google_search.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/simple_google_search.ts
+
+Evals.define_task("simple_google_search") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/google/")
+
+  t.stagehand.act('type "OpenAI" into the search bar')
+
+  t.stagehand.act("press enter")
+  t.page.wait_for_timeout(3000)
+
+  expected_url = "https://browserbase.github.io/stagehand-eval-sites/sites/google/openai.html"
+  current_url = t.page.url
+
+  { _success: current_url.start_with?(expected_url), currentUrl: current_url }
+end

--- a/packages/sdk-ruby/evals/tasks/act/spif_in_csr.rb
+++ b/packages/sdk-ruby/evals/tasks/act/spif_in_csr.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/spif_in_csr.ts
+
+# this eval is designed to test whether stagehand can successfully
+# click inside a SPIF (same process iframe) that is inside an
+# CSR (closed mode shadow) root
+Evals.define_task("spif_in_csr") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/spif-in-closed-shadow-dom/")
+  t.stagehand.act("click the button")
+
+  # v3 used schemaless extract; v4 requires a schema.
+  # Single-word key to stay clear of the snake_case wire-casing bug (#14).
+  extraction = t.stagehand.extract(
+    "extract the entire page text",
+    schema: {
+      "type" => "object",
+      "properties" => { "extraction" => { "type" => "string" } },
+      "required" => ["extraction"],
+      "additionalProperties" => false,
+    },
+  ).data
+
+  page_text = extraction["extraction"]
+
+  if page_text.include?("button successfully clicked")
+    { _success: true, message: "successfully clicked the button" }
+  else
+    { _success: false, message: "unable to click on the button" }
+  end
+end

--- a/packages/sdk-ruby/evals/tasks/act/spif_in_osr.rb
+++ b/packages/sdk-ruby/evals/tasks/act/spif_in_osr.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/spif_in_osr.ts
+
+# this eval is designed to test whether stagehand can successfully
+# click inside a SPIF (same process iframe) that is inside an
+# OSR (open mode shadow) root
+Evals.define_task("spif_in_osr") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/spif-in-open-shadow-dom/")
+  t.stagehand.act("click the button")
+
+  # v3 used schemaless extract; v4 requires a schema.
+  # Single-word key to stay clear of the snake_case wire-casing bug (#14).
+  extraction = t.stagehand.extract(
+    "extract the entire page text",
+    schema: {
+      "type" => "object",
+      "properties" => { "extraction" => { "type" => "string" } },
+      "required" => ["extraction"],
+      "additionalProperties" => false,
+    },
+  ).data
+
+  page_text = extraction["extraction"]
+
+  if page_text.include?("button successfully clicked")
+    { _success: true, message: "successfully clicked the button" }
+  else
+    { _success: false, message: "unable to click on the button" }
+  end
+end

--- a/packages/sdk-ruby/evals/tasks/act/tab_handling.rb
+++ b/packages/sdk-ruby/evals/tasks/act/tab_handling.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/tab_handling.ts
+
+Evals.define_task("tab_handling") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/new-tab/")
+
+  t.stagehand.act("click the button to open the other page")
+
+  # active_page polls until the popup registers (stagehand#2458), so
+  # the page list is complete after this settles.
+  t.stagehand.browser.context.active_page
+
+  pages = t.stagehand.browser.context.pages
+  page1 = pages[0]
+  page2 = pages[1]
+
+  # v3 used schemaless extract; v4 requires a schema.
+  schema = {
+    "type" => "object",
+    "properties" => { "extraction" => { "type" => "string" } },
+    "required" => ["extraction"],
+    "additionalProperties" => false,
+  }
+
+  # extract all the text from the first page
+  extraction1 = t.stagehand.extract("extract the entire page text", schema: schema, page: page1).data
+  # extract all the text from the second page
+  extraction2 = t.stagehand.extract("extract the entire page text", schema: schema, page: page2).data
+
+  extraction1_success = extraction1["extraction"].include?("Welcome!")
+  extraction2_success = extraction2["extraction"].include?("You’re on the other page")
+
+  { _success: extraction1_success && extraction2_success }
+end

--- a/packages/sdk-ruby/evals/tasks/act/vantechjournal.rb
+++ b/packages/sdk-ruby/evals/tasks/act/vantechjournal.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/vantechjournal.ts
+
+Evals.define_task("vantechjournal") do |t|
+  t.page.goto("https://vantechjournal.com")
+
+  t.stagehand.act("click on page 'recommendations'")
+
+  expected_url = "https://vantechjournal.com/recommendations"
+  current_url = t.page.url
+
+  { _success: current_url == expected_url, currentUrl: current_url, expectedUrl: expected_url }
+end

--- a/packages/sdk-ruby/evals/tasks/act/wikipedia.rb
+++ b/packages/sdk-ruby/evals/tasks/act/wikipedia.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/act/wikipedia.ts
+
+Evals.define_task("wikipedia") do |t|
+  t.page.goto("https://en.wikipedia.org/wiki/Baseball")
+  t.stagehand.act('click the "hit and run" link in this article', timeout: 360_000)
+
+  url = "https://en.wikipedia.org/wiki/Hit_and_run_(baseball)"
+  current_url = t.page.url
+
+  { _success: current_url == url, expected: url, actual: current_url }
+end

--- a/packages/sdk-ruby/evals/tasks/extract/extract_aigrant_targeted.rb
+++ b/packages/sdk-ruby/evals/tasks/extract/extract_aigrant_targeted.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/extract/extract_aigrant_targeted.ts
+
+Evals.define_task("extract_aigrant_targeted") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/aigrant/")
+  # The locator engine prefix is required for XPath selectors.
+  locator = t.page.locator("xpath=/html/body/div/ul[5]/li[28]")
+  result = t.stagehand.extract(
+    "Extract the company name.",
+    schema: {
+      "type" => "object",
+      "properties" => { "company_name" => { "type" => "string" } },
+      "required" => ["company_name"],
+      "additionalProperties" => false,
+    },
+    locator: locator,
+  )
+
+  company_name = result.data["company_name"]
+  expected_name = "Coframe"
+
+  if company_name != expected_name
+    t.logger.error("extracted company name does not match expected",
+                   { expected: expected_name, actual: company_name })
+    next { _success: false, error: "Company name does not match expected" }
+  end
+
+  { _success: true, companyName: company_name }
+end

--- a/packages/sdk-ruby/evals/tasks/extract/extract_aigrant_targeted_2.rb
+++ b/packages/sdk-ruby/evals/tasks/extract/extract_aigrant_targeted_2.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/extract/extract_aigrant_targeted_2.ts
+
+Evals.define_task("extract_aigrant_targeted_2") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/aigrant/")
+  # The locator engine prefix is required for XPath selectors.
+  locator = t.page.locator("xpath=/html/body/div/ul[5]/li[28]")
+  result = t.stagehand.extract(
+    "Extract the name of the company that comes after 'Coframe'.",
+    schema: {
+      "type" => "object",
+      "properties" => { "company_name" => { "type" => "string" } },
+      "required" => ["company_name"],
+      "additionalProperties" => false,
+    },
+    locator: locator,
+  )
+  company_name = result.data["company_name"]
+
+  # name_we_should_not_get matches the name of the company that comes after
+  # CoFrame on the website. Since we are using targeted_extract here,
+  # and passing in a selector that does NOT contain the name_we_should_not_get,
+  # the LLM should have no visibility into what comes after 'CoFrame' if
+  # targeted_extract is performing correctly
+  name_we_should_not_get = "OpusClip"
+
+  if company_name == name_we_should_not_get
+    t.logger.error("extracted company name matches the company name that we SHOULD NOT get",
+                   { expected: name_we_should_not_get, actual: company_name })
+    next {
+      _success: false,
+      error: "extracted company name matches the company name that we SHOULD NOT get",
+    }
+  end
+
+  { _success: true, companyName: company_name }
+end

--- a/packages/sdk-ruby/evals/tasks/extract/extract_apartments.rb
+++ b/packages/sdk-ruby/evals/tasks/extract/extract_apartments.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/extract/extract_apartments.ts
+
+Evals.define_task("extract_apartments") do |t|
+  t.page.goto("https://www.apartments.com/san-francisco-ca/2-bedrooms/", wait_until: "load")
+  result = t.stagehand.extract(
+    "Extract all the apartment listings with their prices and their addresses.",
+    schema: {
+      "type" => "object",
+      "properties" => {
+        "listings" => {
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "price" => { "type" => "string", "description" => "The price of the listing" },
+              "address" => { "type" => "string", "description" => "The address of the listing" },
+            },
+            "required" => %w[price address],
+            "additionalProperties" => false,
+          },
+        },
+      },
+      "required" => ["listings"],
+      "additionalProperties" => false,
+    },
+  )
+
+  listings = result.data["listings"]
+  expected_length = 40
+
+  if listings.length < expected_length
+    t.logger.error("Incorrect number of listings extracted",
+                   { expected: expected_length, actual: listings.length })
+    next { _success: false, error: "Incorrect number of listings extracted" }
+  end
+
+  { _success: true, listingCount: listings.length }
+end

--- a/packages/sdk-ruby/evals/tasks/extract/extract_area_codes.rb
+++ b/packages/sdk-ruby/evals/tasks/extract/extract_area_codes.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/extract/extract_area_codes.ts
+
+Evals.define_task("extract_area_codes") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/ncc-area-codes/",
+              wait_until: "domcontentloaded")
+
+  result = t.stagehand.extract(
+    "Extract ALL the Primary Center names and their corresponding Area Code, " \
+    "and the name of their corresponding Zone.",
+    schema: {
+      "type" => "object",
+      "properties" => {
+        "primary_center_list" => {
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "zone_name" => {
+                "type" => "string",
+                "description" =>
+                  "The name of the Zone that the Primary Center is in. For example, 'North Central Zone'.",
+              },
+              "primary_center_name" => {
+                "type" => "string",
+                "description" =>
+                  "The name of the Primary Center. I.e., this is the name of the city or town.",
+              },
+              "area_code" => {
+                "type" => "string",
+                "description" =>
+                  "The area code for the Primary Center. This will either be 2 or 3 digits.",
+              },
+            },
+            "required" => %w[zone_name primary_center_name area_code],
+            "additionalProperties" => false,
+          },
+        },
+      },
+      "required" => ["primary_center_list"],
+      "additionalProperties" => false,
+    },
+  )
+
+  primary_center_list = result.data["primary_center_list"]
+  expected_length = 56
+
+  expected_first_item = {
+    "zone_name" => "Lagos Zone",
+    "primary_center_name" => "Lagos",
+    "area_code" => "01",
+  }
+
+  expected_last_item = {
+    "zone_name" => "South-East",
+    "primary_center_name" => "Yenagoa",
+    "area_code" => "089",
+  }
+
+  if primary_center_list.length != expected_length
+    t.logger.error("Incorrect number of primary centers extracted",
+                   { expected: expected_length, actual: primary_center_list.length })
+    next { _success: false, error: "Incorrect number of primary centers extracted" }
+  end
+
+  first_item = primary_center_list.first
+  first_item_matches =
+    first_item["zone_name"] == expected_first_item["zone_name"] &&
+    first_item["primary_center_name"] == expected_first_item["primary_center_name"] &&
+    first_item["area_code"] == expected_first_item["area_code"]
+
+  unless first_item_matches
+    t.logger.error("First primary center extracted does not match expected",
+                   { expected: expected_first_item, actual: first_item })
+    next { _success: false, error: "First primary center extracted does not match expected" }
+  end
+
+  last_item = primary_center_list.last
+  last_item_matches =
+    last_item["zone_name"] == expected_last_item["zone_name"] &&
+    last_item["primary_center_name"] == expected_last_item["primary_center_name"] &&
+    last_item["area_code"] == expected_last_item["area_code"]
+
+  unless last_item_matches
+    t.logger.error("Last primary center extracted does not match expected",
+                   { expected: expected_last_item, actual: last_item })
+    next { _success: false, error: "Last primary center extracted does not match expected" }
+  end
+
+  { _success: true }
+end

--- a/packages/sdk-ruby/evals/tasks/extract/extract_baptist_health.rb
+++ b/packages/sdk-ruby/evals/tasks/extract/extract_baptist_health.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/extract/extract_baptist_health.ts
+
+Evals.define_task("extract_baptist_health") do |t|
+  # Inline port of packages/evals/utils.ts normalizeString + compareStrings
+  # (Jaro-Winkler similarity); the Ruby harness has no shared string-scoring helper.
+  normalize_string = lambda do |str|
+    str.downcase
+       .gsub(/\s+/, " ")
+       .gsub(/[;\/#!$%^&*:{}=\-_`~()]/, "")
+       .gsub(/\s*,\s*/, ", ")
+       .strip
+  end
+
+  jaro_winkler = lambda do |s1, s2|
+    next 1.0 if s1 == s2
+    len1 = s1.length
+    len2 = s2.length
+    next 0.0 if len1.zero? || len2.zero?
+
+    match_distance = [([len1, len2].max / 2) - 1, 0].max
+    s1_matches = Array.new(len1, false)
+    s2_matches = Array.new(len2, false)
+    matches = 0
+    len1.times do |i|
+      low = [0, i - match_distance].max
+      high = [i + match_distance, len2 - 1].min
+      (low..high).each do |j|
+        next if s2_matches[j] || s1[i] != s2[j]
+        s1_matches[i] = true
+        s2_matches[j] = true
+        matches += 1
+        break
+      end
+    end
+    next 0.0 if matches.zero?
+
+    transpositions = 0
+    k = 0
+    len1.times do |i|
+      next unless s1_matches[i]
+      k += 1 until s2_matches[k]
+      transpositions += 1 if s1[i] != s2[k]
+      k += 1
+    end
+
+    jaro = ((matches.to_f / len1) + (matches.to_f / len2) +
+            ((matches - (transpositions / 2.0)) / matches)) / 3.0
+    prefix = 0
+    [len1, len2, 4].min.times do |i|
+      break if s1[i] != s2[i]
+      prefix += 1
+    end
+    jaro + (prefix * 0.1 * (1 - jaro))
+  end
+
+  compare_strings = lambda do |actual, expected, threshold|
+    similarity = jaro_winkler.call(normalize_string.call(actual), normalize_string.call(expected))
+    { similarity: similarity, meets_threshold: similarity >= threshold }
+  end
+
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/baptist-health/")
+
+  result = t.stagehand.extract(
+    "Extract the address, phone number, and fax number of the healthcare location.",
+    schema: {
+      "type" => "object",
+      "properties" => {
+        "address" => { "type" => "string" },
+        "phone" => { "type" => "string" },
+        "fax" => { "type" => "string" },
+      },
+      "required" => %w[address phone fax],
+      "additionalProperties" => false,
+    },
+  )
+
+  address = result.data["address"]
+  phone = result.data["phone"]
+  fax = result.data["fax"]
+  expected = {
+    "address" => "2055 East South Blvd; Suite 908 Montgomery, AL 36116",
+    "phone" => "334-747-2273",
+    "fax" => "334-747-7501",
+  }
+
+  similarity_threshold = 0.85
+  failed_fields = []
+
+  compare_field = lambda do |actual_val, expected_val, field_name|
+    comparison = compare_strings.call(actual_val, expected_val, similarity_threshold)
+
+    unless comparison[:meets_threshold]
+      failed_fields << {
+        field: field_name,
+        similarity: comparison[:similarity],
+        expected: expected_val,
+        actual: actual_val,
+      }
+      t.logger.error("#{field_name} extracted does not meet similarity threshold",
+                     {
+                       field: field_name,
+                       similarity: format("%.2f", comparison[:similarity]),
+                       expected: expected_val,
+                       actual: actual_val,
+                     })
+    end
+
+    comparison[:meets_threshold]
+  end
+
+  address_ok = compare_field.call(address, expected["address"], "Address")
+  phone_ok = compare_field.call(phone, expected["phone"], "Phone number")
+  fax_ok = compare_field.call(fax, expected["fax"], "Fax number")
+
+  if !address_ok || !phone_ok || !fax_ok
+    next {
+      _success: false,
+      error: "Some fields did not meet similarity threshold",
+      failedFields: failed_fields,
+    }
+  end
+
+  { _success: true }
+end

--- a/packages/sdk-ruby/evals/tasks/extract/extract_csa.rb
+++ b/packages/sdk-ruby/evals/tasks/extract/extract_csa.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/extract/extract_csa.ts
+
+Evals.define_task("extract_csa") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/csa/")
+
+  result = t.stagehand.extract(
+    "Extract all the publications on the page including the publication date, " \
+    "session type, publication type, and annotation",
+    schema: {
+      "type" => "object",
+      "properties" => {
+        "publications" => {
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "publication_date" => { "type" => "string" },
+              "session_type" => { "type" => "string" },
+              "publication_type" => { "type" => "string" },
+              "annotation" => { "type" => "string" },
+            },
+            "required" => %w[publication_date session_type publication_type annotation],
+            "additionalProperties" => false,
+          },
+        },
+      },
+      "required" => ["publications"],
+      "additionalProperties" => false,
+    },
+    page: t.page,
+  )
+
+  publications = result.data["publications"]
+  expected_length = 14
+
+  expected_first_item = {
+    "publication_date" => "11-30-2024",
+    "session_type" => "Regular Session",
+    "publication_type" => "Assembly Weekly History",
+    "annotation" =>
+      "2024 -- This publication includes the complete histories of second-year bills. " \
+      "The complete electronic history of all bills is always available at leginfo.legislature.ca.gov",
+  }
+
+  expected_last_item = {
+    "publication_date" => "11-30-2016",
+    "session_type" => "1st Extraordinary Session",
+    "publication_type" => "Assembly Weekly History",
+    "annotation" => "",
+  }
+
+  if publications.length < expected_length
+    t.logger.error("Incorrect number of publications extracted",
+                   { expected: ">= #{expected_length}", actual: publications.length })
+    next { _success: false, error: "Incorrect number of publications extracted" }
+  end
+
+  has_expected_first_item = publications.any? do |publication|
+    publication["publication_date"] == expected_first_item["publication_date"] &&
+      publication["session_type"] == expected_first_item["session_type"] &&
+      publication["publication_type"] == expected_first_item["publication_type"] &&
+      publication["annotation"] == expected_first_item["annotation"]
+  end
+
+  unless has_expected_first_item
+    t.logger.error("Expected 'first' item not found in publications",
+                   { expected: expected_first_item, actual: publications })
+    next { _success: false, error: "Expected 'first' item not found in publications" }
+  end
+
+  has_expected_last_item = publications.any? do |publication|
+    publication["publication_date"] == expected_last_item["publication_date"] &&
+      publication["session_type"] == expected_last_item["session_type"] &&
+      publication["publication_type"] == expected_last_item["publication_type"] &&
+      publication["annotation"] == expected_last_item["annotation"]
+  end
+
+  unless has_expected_last_item
+    t.logger.error("Expected 'last' item not found in publications",
+                   { expected: expected_last_item, actual: publications })
+    next { _success: false, error: "Expected 'last' item not found in publications" }
+  end
+
+  { _success: true }
+end

--- a/packages/sdk-ruby/evals/tasks/extract/extract_geniusee.rb
+++ b/packages/sdk-ruby/evals/tasks/extract/extract_geniusee.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/extract/extract_geniusee.ts
+
+Evals.define_task("extract_geniusee") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/geniusee/")
+  # The locator engine prefix is required for XPath selectors.
+  locator = t.page.locator("xpath=/html/body/main/div[2]/div[2]/div[2]/table")
+  result = t.stagehand.extract(
+    "Extract the scalability comment in the table for Gemini (Google)",
+    schema: {
+      "type" => "object",
+      "properties" => { "scalability" => { "type" => "string" } },
+      "required" => ["scalability"],
+      "additionalProperties" => false,
+    },
+    locator: locator,
+  )
+
+  scalability_comment = result.data["scalability"]
+  expected_scalability_comment = "Scalable architecture with API access"
+
+  if scalability_comment != expected_scalability_comment
+    t.logger.error("extracted scalability comment does not match expected",
+                   { expected: expected_scalability_comment, actual: scalability_comment })
+    next { _success: false, error: "extracted scalability comment does not match expected" }
+  end
+
+  { _success: true, scalabilityComment: scalability_comment }
+end

--- a/packages/sdk-ruby/evals/tasks/extract/extract_geniusee_2.rb
+++ b/packages/sdk-ruby/evals/tasks/extract/extract_geniusee_2.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/extract/extract_geniusee_2.ts
+
+Evals.define_task("extract_geniusee_2") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/geniusee/")
+  # The locator engine prefix is required for XPath selectors.
+  locator = t.page.locator("xpath=/html/body/main/div[2]/div[2]/div[2]/table/tbody/tr[9]")
+  result = t.stagehand.extract(
+    "Extract the scalability comment in the table for Gemini (Google)",
+    schema: {
+      "type" => "object",
+      "properties" => { "scalability" => { "type" => "string" } },
+      "required" => ["scalability"],
+      "additionalProperties" => false,
+    },
+    locator: locator,
+  )
+
+  scalability_comment = result.data["scalability"]
+
+  # scalability_comment_we_should_not_get matches a scalability comment in the table,
+  # but since we are using targeted_extract here,
+  # and passing in a selector that does NOT contain the scalability_comment_we_should_not_get,
+  # the LLM should have no visibility into scalability_comment_we_should_not_get if
+  # targeted_extract is performing correctly
+  scalability_comment_we_should_not_get = "Scalable architecture with API access"
+
+  if scalability_comment == scalability_comment_we_should_not_get
+    t.logger.error("extracted scalability comment matches the scalability comment that we SHOULD NOT get",
+                   { expected: scalability_comment_we_should_not_get, actual: scalability_comment })
+    next {
+      _success: false,
+      error: "scalability comment matches the scalability comment that we SHOULD NOT get",
+    }
+  end
+
+  { _success: true, scalabilityComment: scalability_comment }
+end

--- a/packages/sdk-ruby/evals/tasks/extract/extract_github_stars.rb
+++ b/packages/sdk-ruby/evals/tasks/extract/extract_github_stars.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/extract/extract_github_stars.ts
+
+Evals.define_task("extract_github_stars") do |t|
+  t.page.goto("https://github.com/facebook/react")
+
+  result = t.stagehand.extract(
+    "Extract the number of stars for the project",
+    schema: {
+      "type" => "object",
+      "properties" => {
+        "stars" => { "type" => "number", "description" => "the number of stars for the project" },
+      },
+      "required" => ["stars"],
+      "additionalProperties" => false,
+    },
+  )
+  stars = result.data["stars"]
+
+  expected_stars_string = t.page.locator("#repo-stars-counter-star").first.inner_html
+
+  expected_stars =
+    if expected_stars_string.downcase.end_with?("k")
+      expected_stars_string[0...-1].to_f * 1000
+    else
+      expected_stars_string.to_f
+    end
+
+  tolerance = 1000
+  is_within_tolerance = (stars - expected_stars).abs <= tolerance
+
+  { _success: is_within_tolerance, stars: stars }
+end

--- a/packages/sdk-ruby/evals/tasks/extract/extract_hamilton_weather.rb
+++ b/packages/sdk-ruby/evals/tasks/extract/extract_hamilton_weather.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/extract/extract_hamilton_weather.ts
+
+Evals.define_task("extract_hamilton_weather") do |t|
+  # Inline port of packages/evals/utils.ts normalizeString + compareStrings
+  # (Jaro-Winkler similarity); the Ruby harness has no shared string-scoring helper.
+  normalize_string = lambda do |str|
+    str.downcase
+       .gsub(/\s+/, " ")
+       .gsub(/[;\/#!$%^&*:{}=\-_`~()]/, "")
+       .gsub(/\s*,\s*/, ", ")
+       .strip
+  end
+
+  jaro_winkler = lambda do |s1, s2|
+    next 1.0 if s1 == s2
+    len1 = s1.length
+    len2 = s2.length
+    next 0.0 if len1.zero? || len2.zero?
+
+    match_distance = [([len1, len2].max / 2) - 1, 0].max
+    s1_matches = Array.new(len1, false)
+    s2_matches = Array.new(len2, false)
+    matches = 0
+    len1.times do |i|
+      low = [0, i - match_distance].max
+      high = [i + match_distance, len2 - 1].min
+      (low..high).each do |j|
+        next if s2_matches[j] || s1[i] != s2[j]
+        s1_matches[i] = true
+        s2_matches[j] = true
+        matches += 1
+        break
+      end
+    end
+    next 0.0 if matches.zero?
+
+    transpositions = 0
+    k = 0
+    len1.times do |i|
+      next unless s1_matches[i]
+      k += 1 until s2_matches[k]
+      transpositions += 1 if s1[i] != s2[k]
+      k += 1
+    end
+
+    jaro = ((matches.to_f / len1) + (matches.to_f / len2) +
+            ((matches - (transpositions / 2.0)) / matches)) / 3.0
+    prefix = 0
+    [len1, len2, 4].min.times do |i|
+      break if s1[i] != s2[i]
+      prefix += 1
+    end
+    jaro + (prefix * 0.1 * (1 - jaro))
+  end
+
+  meets_threshold = lambda do |actual, expected, threshold|
+    jaro_winkler.call(normalize_string.call(actual), normalize_string.call(expected)) >= threshold
+  end
+
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/hamilton-weather/")
+  # The locator engine prefix is required for XPath selectors.
+  locator = t.page.locator(
+    "xpath=/html/body[1]/div[5]/main[1]/article[1]/div[6]/div[2]/div[1]/table[1]",
+  )
+
+  result = t.stagehand.extract(
+    "extract the weather data for Sun, Feb 23 at 11PM",
+    schema: {
+      "type" => "object",
+      "properties" => {
+        "temperature" => { "type" => "string" },
+        "weather_description" => { "type" => "string" },
+        "wind" => { "type" => "string" },
+        "humidity" => { "type" => "string" },
+        "barometer" => { "type" => "string" },
+        "visibility" => { "type" => "string" },
+      },
+      "required" => %w[temperature weather_description wind humidity barometer visibility],
+      "additionalProperties" => false,
+    },
+    locator: locator,
+  )
+  weather_data = result.data
+
+  # Define the expected weather data
+  expected_weather_data = {
+    "temperature" => "27 °F",
+    "weather_description" => "Light snow. Overcast.",
+    "wind" => "6 mph",
+    "humidity" => "93%",
+    "barometer" => "30.07 \"Hg",
+    "visibility" => "10 mi",
+  }
+
+  # Check that every field matches the expected value
+  is_weather_correct =
+    expected_weather_data.keys.all? do |field|
+      meets_threshold.call(weather_data[field], expected_weather_data[field], 0.9)
+    end
+
+  { _success: is_weather_correct, weatherData: weather_data }
+end

--- a/packages/sdk-ruby/evals/tasks/extract/extract_jfk_links.rb
+++ b/packages/sdk-ruby/evals/tasks/extract/extract_jfk_links.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/extract/extract_jfk_links.ts
+
+Evals.define_task("extract_jfk_links") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/jfk/")
+
+  result = t.stagehand.extract(
+    "extract all the record file name and their corresponding links",
+    schema: {
+      "type" => "object",
+      "properties" => {
+        "records" => {
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "file_name" => { "type" => "string", "description" => "the file name of the record" },
+              "link" => { "type" => "string", "format" => "uri" },
+            },
+            "required" => %w[file_name link],
+            "additionalProperties" => false,
+          },
+        },
+      },
+      "required" => ["records"],
+      "additionalProperties" => false,
+    },
+  )
+
+  # The list of records we expect to see
+  expected_records = [
+    {
+      "file_name" => "104-10003-10041.pdf",
+      "link" => "https://www.archives.gov/files/research/jfk/releases/2025/0318/104-10003-10041.pdf",
+    },
+    {
+      "file_name" => "104-10004-10143 (C06932208).pdf",
+      "link" => "https://www.archives.gov/files/research/jfk/releases/2025/0318/104-10004-10143%20(C06932208).pdf",
+    },
+    {
+      "file_name" => "104-10004-10143.pdf",
+      "link" => "https://www.archives.gov/files/research/jfk/releases/2025/0318/104-10004-10143.pdf",
+    },
+    {
+      "file_name" => "104-10004-10156.pdf",
+      "link" => "https://www.archives.gov/files/research/jfk/releases/2025/0318/104-10004-10156.pdf",
+    },
+    {
+      "file_name" => "104-10004-10213.pdf",
+      "link" => "https://www.archives.gov/files/research/jfk/releases/2025/0318/104-10004-10213.pdf",
+    },
+    {
+      "file_name" => "104-10005-10321.pdf",
+      "link" => "https://www.archives.gov/files/research/jfk/releases/2025/0318/104-10005-10321.pdf",
+    },
+    {
+      "file_name" => "104-10006-10247.pdf",
+      "link" => "https://www.archives.gov/files/research/jfk/releases/2025/0318/104-10006-10247.pdf",
+    },
+    {
+      "file_name" => "104-10007-10345.pdf",
+      "link" => "https://www.archives.gov/files/research/jfk/releases/2025/0318/104-10007-10345.pdf",
+    },
+    {
+      "file_name" => "104-10009-10021.pdf",
+      "link" => "https://www.archives.gov/files/research/jfk/releases/2025/0318/104-10009-10021.pdf",
+    },
+    {
+      "file_name" => "104-10009-10222.pdf",
+      "link" => "https://www.archives.gov/files/research/jfk/releases/2025/0318/104-10009-10222.pdf",
+    },
+  ]
+
+  extracted_records = result.data["records"]
+
+  # Check that all expected records exist in the extraction
+  missing_records = expected_records.reject do |expected|
+    extracted_records.any? do |r|
+      r["file_name"] == expected["file_name"] && r["link"] == expected["link"]
+    end
+  end
+
+  # Check that the extraction array is exactly length 10
+  if extracted_records.length != 10
+    next {
+      _success: false,
+      reason: "Extraction has #{extracted_records.length} records (expected 10).",
+    }
+  end
+
+  unless missing_records.empty?
+    next {
+      _success: false,
+      reason: "Missing one or more expected records.",
+      missingRecords: missing_records,
+      extractedRecords: extracted_records,
+    }
+  end
+
+  # If we reach here, the number of records is correct, and all are present
+  { _success: true }
+end

--- a/packages/sdk-ruby/evals/tasks/extract/extract_jstor_news.rb
+++ b/packages/sdk-ruby/evals/tasks/extract/extract_jstor_news.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/extract/extract_jstor_news.ts
+
+Evals.define_task("extract_jstor_news") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/jstor/", wait_until: "load")
+  t.stagehand.act("close the cookie")
+
+  result = t.stagehand.extract(
+    "Extract ALL the news report titles and their dates.",
+    schema: {
+      "type" => "object",
+      "properties" => {
+        "reports" => {
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "report_name" => {
+                "type" => "string",
+                "description" => "The name or title of the news report.",
+              },
+              "publish_date" => {
+                "type" => "string",
+                "description" => "The date the news report was published.",
+              },
+            },
+            "required" => %w[report_name publish_date],
+            "additionalProperties" => false,
+          },
+        },
+      },
+      "required" => ["reports"],
+      "additionalProperties" => false,
+    },
+  )
+
+  reports = result.data["reports"]
+  expected_length = 10
+
+  expected_first_item = {
+    "report_name" => "JSTOR retires Publisher Sales Service",
+    "publish_date" => "December 9, 2024",
+  }
+
+  expected_last_item = {
+    "report_name" => "Path to Open announces 2024 titles",
+    "publish_date" => "May 10, 2024",
+  }
+
+  if reports.length != expected_length
+    t.logger.error("Incorrect number of reports extracted",
+                   { expected: expected_length, actual: reports.length })
+    next { _success: false, error: "Incorrect number of reports extracted" }
+  end
+
+  first_item_matches =
+    reports.first["report_name"] == expected_first_item["report_name"] &&
+    reports.first["publish_date"] == expected_first_item["publish_date"]
+
+  unless first_item_matches
+    t.logger.error("First report extracted does not match expected",
+                   { expected: expected_first_item, actual: reports.first })
+    next { _success: false, error: "First report extracted does not match expected" }
+  end
+
+  last_item_matches =
+    reports.last["report_name"] == expected_last_item["report_name"] &&
+    reports.last["publish_date"] == expected_last_item["publish_date"]
+
+  unless last_item_matches
+    t.logger.error("Last report extracted does not match expected",
+                   { expected: expected_last_item, actual: reports.last })
+    next { _success: false, error: "Last report extracted does not match expected" }
+  end
+
+  { _success: true }
+end

--- a/packages/sdk-ruby/evals/tasks/extract/extract_memorial_healthcare.rb
+++ b/packages/sdk-ruby/evals/tasks/extract/extract_memorial_healthcare.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/extract/extract_memorial_healthcare.ts
+
+Evals.define_task("extract_memorial_healthcare") do |t|
+  # Inline port of packages/evals/utils.ts normalizeString + compareStrings
+  # (Jaro-Winkler similarity); the Ruby harness has no shared string-scoring helper.
+  normalize_string = lambda do |str|
+    str.downcase
+       .gsub(/\s+/, " ")
+       .gsub(/[;\/#!$%^&*:{}=\-_`~()]/, "")
+       .gsub(/\s*,\s*/, ", ")
+       .strip
+  end
+
+  jaro_winkler = lambda do |s1, s2|
+    next 1.0 if s1 == s2
+    len1 = s1.length
+    len2 = s2.length
+    next 0.0 if len1.zero? || len2.zero?
+
+    match_distance = [([len1, len2].max / 2) - 1, 0].max
+    s1_matches = Array.new(len1, false)
+    s2_matches = Array.new(len2, false)
+    matches = 0
+    len1.times do |i|
+      low = [0, i - match_distance].max
+      high = [i + match_distance, len2 - 1].min
+      (low..high).each do |j|
+        next if s2_matches[j] || s1[i] != s2[j]
+        s1_matches[i] = true
+        s2_matches[j] = true
+        matches += 1
+        break
+      end
+    end
+    next 0.0 if matches.zero?
+
+    transpositions = 0
+    k = 0
+    len1.times do |i|
+      next unless s1_matches[i]
+      k += 1 until s2_matches[k]
+      transpositions += 1 if s1[i] != s2[k]
+      k += 1
+    end
+
+    jaro = ((matches.to_f / len1) + (matches.to_f / len2) +
+            ((matches - (transpositions / 2.0)) / matches)) / 3.0
+    prefix = 0
+    [len1, len2, 4].min.times do |i|
+      break if s1[i] != s2[i]
+      prefix += 1
+    end
+    jaro + (prefix * 0.1 * (1 - jaro))
+  end
+
+  compare_strings = lambda do |actual, expected, threshold|
+    similarity = jaro_winkler.call(normalize_string.call(actual), normalize_string.call(expected))
+    { similarity: similarity, meets_threshold: similarity >= threshold }
+  end
+
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/mycmh/")
+
+  result = t.stagehand.extract(
+    "extract a list of the first three healthcare centers on this page, " \
+    "with their name, full address, and phone number",
+    schema: {
+      "type" => "object",
+      "properties" => {
+        "health_centers" => {
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "name" => { "type" => "string" },
+              "phone_number" => { "type" => "string" },
+              "address" => { "type" => "string" },
+            },
+            "required" => %w[name phone_number address],
+            "additionalProperties" => false,
+          },
+        },
+      },
+      "required" => ["health_centers"],
+      "additionalProperties" => false,
+    },
+  )
+
+  health_centers = result.data["health_centers"]
+
+  expected_length = 3
+  similarity_threshold = 0.85
+
+  expected_first_item = {
+    "name" => "Community Memorial Breast Center",
+    "phone_number" => "805-948-5093",
+    "address" => "168 North Brent Street, Suite 401, Ventura, CA 93003",
+  }
+
+  expected_last_item = {
+    "name" => "Community Memorial Dermatology and Mohs Surgery",
+    "phone_number" => "805-948-6920",
+    "address" => "168 North Brent Street, Suite 403, Ventura, CA 93003",
+  }
+
+  if health_centers.length != expected_length
+    t.logger.error("Incorrect number of health centers extracted",
+                   { expected: expected_length, actual: health_centers.length })
+    next { _success: false, error: "Incorrect number of health centers extracted" }
+  end
+
+  validate_health_center = lambda do |center|
+    fields_present =
+      !center["name"].to_s.empty? && !center["phone_number"].to_s.empty? && !center["address"].to_s.empty?
+    next center if fields_present
+
+    t.logger.error("Invalid health center data", { center: center })
+    nil
+  end
+
+  valid_health_centers = health_centers.map { |center| validate_health_center.call(center) }.compact
+
+  if valid_health_centers.length < expected_length
+    next { _success: false, error: "One or more health centers have missing fields" }
+  end
+
+  compare_field = lambda do |actual, expected, field_name|
+    comparison = compare_strings.call(actual, expected, similarity_threshold)
+
+    unless comparison[:meets_threshold]
+      t.logger.error("Field \"#{field_name}\" does not meet similarity threshold",
+                     {
+                       field: field_name,
+                       similarity: format("%.2f", comparison[:similarity]),
+                       expected: expected,
+                       actual: actual,
+                     })
+    end
+
+    comparison[:meets_threshold]
+  end
+
+  compare_item = lambda do |actual, expected, position|
+    %w[name phone_number address].all? do |field|
+      compare_field.call(actual[field], expected[field], "#{position} #{field}")
+    end
+  end
+
+  first_item_matches = compare_item.call(valid_health_centers.first, expected_first_item, "First")
+  last_item_matches = compare_item.call(valid_health_centers.last, expected_last_item, "Last")
+
+  if !first_item_matches || !last_item_matches
+    next { _success: false, error: "One or more fields do not match expected values" }
+  end
+
+  { _success: true }
+end

--- a/packages/sdk-ruby/evals/tasks/extract/extract_nhl_stats.rb
+++ b/packages/sdk-ruby/evals/tasks/extract/extract_nhl_stats.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/extract/extract_nhl_stats.ts
+
+Evals.define_task("extract_nhl_stats") do |t|
+  # Port of the evals framework's normalizeString helper.
+  normalize = lambda do |str|
+    str.downcase
+       .gsub(/\s+/, " ")
+       .gsub(/[;\/#!$%^&*:{}=\-_`~()]/, "")
+       .gsub(/\s*,\s*/, ", ")
+       .strip
+  end
+
+  t.page.goto("https://www.hockeydb.com/ihdb/stats/top_league.php?lid=nhl1927&sid=1990",
+              wait_until: "domcontentloaded")
+
+  result = t.stagehand.extract(
+    "Extract the name of the goal scoring leader, their number of goals they scored, and the team they played for.",
+    schema: {
+      "type" => "object",
+      "properties" => {
+        "name" => { "type" => "string" },
+        "num_goals" => { "type" => "string" },
+        "team" => { "type" => "string" },
+      },
+      "required" => %w[name num_goals team],
+      "additionalProperties" => false,
+    },
+  )
+
+  name = result.data["name"]
+  num_goals = result.data["num_goals"]
+  team = result.data["team"]
+
+  expected = {
+    "name" => "Brett Hull",
+    "num_goals" => "72",
+    "team" => "St. Louis",
+  }
+
+  if normalize.call(name) != normalize.call(expected["name"])
+    t.logger.error("Player name extracted does not match expected",
+                   { expected: normalize.call(expected["name"]), actual: normalize.call(name) })
+    next { _success: false, error: "Player name extracted does not match expected" }
+  end
+
+  if normalize.call(num_goals) != normalize.call(expected["num_goals"])
+    t.logger.error("Number of goals extracted does not match expected",
+                   { expected: normalize.call(expected["num_goals"]), actual: normalize.call(num_goals) })
+    next { _success: false, error: "Number of goals extracted does not match expected" }
+  end
+
+  if normalize.call(team) != normalize.call(expected["team"])
+    t.logger.error("Player team extracted does not match expected",
+                   { expected: normalize.call(expected["team"]), actual: normalize.call(team) })
+    next { _success: false, error: "Player team extracted does not match expected" }
+  end
+
+  { _success: true }
+end

--- a/packages/sdk-ruby/evals/tasks/extract/extract_professional_info.rb
+++ b/packages/sdk-ruby/evals/tasks/extract/extract_professional_info.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/extract/extract_professional_info.ts
+
+Evals.define_task("extract_professional_info") do |t|
+  # Port of the evals framework's normalizeString helper.
+  normalize = lambda do |str|
+    str.downcase
+       .gsub(/\s+/, " ")
+       .gsub(/[;\/#!$%^&*:{}=\-_`~()]/, "")
+       .gsub(/\s*,\s*/, ", ")
+       .strip
+  end
+
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/professional-info/")
+
+  result = t.stagehand.extract(
+    "Extract the list of Practices, phone number, and fax number of the professional.",
+    schema: {
+      "type" => "object",
+      "properties" => {
+        "practices" => { "type" => "array", "items" => { "type" => "string" } },
+        "phone" => { "type" => "string" },
+        "fax" => { "type" => "string" },
+      },
+      "required" => %w[practices phone fax],
+      "additionalProperties" => false,
+    },
+  )
+
+  practices = result.data["practices"]
+  phone = result.data["phone"]
+  fax = result.data["fax"]
+
+  expected = {
+    "practices" => [
+      "Restructuring",
+      "Finance",
+      "Hybrid Capital & Special Situations",
+      "Private Credit",
+    ],
+    "phone" => "+1-212-373-3262",
+    "fax" => "+1-212-492-0262",
+  }
+
+  if practices.map { |p| normalize.call(p) } != expected["practices"].map { |p| normalize.call(p) }
+    t.logger.error("Practices extracted do not match expected",
+                   { expected: expected["practices"], actual: practices })
+    next { _success: false, error: "Practices extracted do not match expected" }
+  end
+
+  if normalize.call(phone) != normalize.call(expected["phone"])
+    t.logger.error("Phone number extracted does not match expected",
+                   { expected: normalize.call(expected["phone"]), actual: normalize.call(phone) })
+    next { _success: false, error: "Phone number extracted does not match expected" }
+  end
+
+  if normalize.call(fax) != normalize.call(expected["fax"])
+    t.logger.error("Fax number extracted does not match expected",
+                   { expected: normalize.call(expected["fax"]), actual: normalize.call(fax) })
+    next { _success: false, error: "Fax number extracted does not match expected" }
+  end
+
+  { _success: true }
+end

--- a/packages/sdk-ruby/evals/tasks/extract/extract_public_notices.rb
+++ b/packages/sdk-ruby/evals/tasks/extract/extract_public_notices.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/extract/extract_public_notices.ts
+
+Evals.define_task("extract_public_notices") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/sars/",
+              wait_until: "load")
+
+  result = t.stagehand.extract(
+    "Extract ALL the public notice descriptions with their corresponding, GG number and publication date. Extract ALL notices from 2024 through 2020. Do not include the Notice number.",
+    schema: {
+      "type" => "object",
+      "properties" => {
+        "public_notices" => {
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "notice_description" => {
+                "type" => "string",
+                "description" => "the description of the notice. Do not include the Notice number",
+              },
+              "gg_number" => {
+                "type" => "string",
+                "description" => "the GG number of the notice. For example, GG 12345",
+              },
+              "publication_date" => {
+                "type" => "string",
+                "description" => "the publication date of the notice. For example, 8 December 2021",
+              },
+            },
+            "required" => %w[notice_description gg_number publication_date],
+            "additionalProperties" => false,
+          },
+        },
+      },
+      "required" => ["public_notices"],
+      "additionalProperties" => false,
+    },
+  )
+
+  public_notices = result.data["public_notices"]
+  expected_length = 24
+
+  expected_first_item = {
+    "notice_description" =>
+      "Additional considerations in terms of section 80(2) in respect of which an application for a binding private ruling or a binding class ruling may be rejected",
+    "gg_number" => "GG 51526",
+    "publication_date" => "8 November 2024",
+  }
+
+  expected_last_item = {
+    "notice_description" =>
+      "Notice in terms of section 25, read with section 66(1) of the Income Tax Act, 1962, for submission of 2020 income tax returns",
+    "gg_number" => "GG 43495",
+    "publication_date" => "3 July 2020",
+  }
+
+  if public_notices.length != expected_length
+    t.logger.error("Incorrect number of public notices extracted",
+                   { expected: expected_length, actual: public_notices.length })
+    next { _success: false, error: "Incorrect number of public notices extracted" }
+  end
+
+  # NOTE (preserved v3 quirk): in the TS task, compareStrings returns an
+  # object, which is always truthy — the `&&` chains never actually gate on
+  # similarity, so the first/last item checks always pass. Ported 1:1.
+  first_item_matches = true
+  last_item_matches = true
+
+  unless first_item_matches
+    t.logger.error("First public notice extracted does not match expected",
+                   { expected: expected_first_item, actual: public_notices[0] })
+    next { _success: false, error: "First public notice extracted does not match expected" }
+  end
+
+  unless last_item_matches
+    t.logger.error("Last public notice extracted does not match expected",
+                   { expected: expected_last_item, actual: public_notices[-1] })
+    next { _success: false, error: "Last public notice extracted does not match expected" }
+  end
+
+  { _success: true }
+end

--- a/packages/sdk-ruby/evals/tasks/extract/extract_recipe.rb
+++ b/packages/sdk-ruby/evals/tasks/extract/extract_recipe.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/extract/extract_recipe.ts
+
+Evals.define_task("extract_recipe") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/allrecipes-extract/",
+              wait_until: "domcontentloaded")
+
+  # The locator engine prefix is required for XPath selectors.
+  locator = t.page.locator("xpath=/html/body/main/article/div[3]/div[3]/div[4]")
+  result = t.stagehand.extract(
+    "Extract the title of the number of tablespoons of olive oil needed for the steak, and the number of teaspoons of lemon juice needed for the mushroom pan sauce.",
+    schema: {
+      "type" => "object",
+      "properties" => {
+        "tablespoons_olive_oil" => {
+          "type" => "number",
+          "description" => "the number of tablespoons of olive oil needed for the steak",
+        },
+        "teaspoons_lemon_juice" => {
+          "type" => "number",
+          "description" => "the number of teaspoons of lemon juice needed for the mushroom pan sauce",
+        },
+      },
+      "required" => %w[tablespoons_olive_oil teaspoons_lemon_juice],
+      "additionalProperties" => false,
+    },
+    locator: locator,
+  )
+
+  tablespoons_olive_oil = result.data["tablespoons_olive_oil"]
+  teaspoons_lemon_juice = result.data["teaspoons_lemon_juice"]
+  expected_tablespoons = 2
+  expected_teaspoons = 2
+
+  if tablespoons_olive_oil != expected_tablespoons || teaspoons_lemon_juice != expected_teaspoons
+    errors = []
+    if tablespoons_olive_oil != expected_tablespoons
+      errors << {
+        message: "Extracted tablespoons of olive oil do not match the extracted tablespoons of olive oil",
+        expected: expected_tablespoons.to_s,
+        actual: tablespoons_olive_oil.to_s,
+      }
+    end
+    if teaspoons_lemon_juice != expected_teaspoons
+      errors << {
+        message: "Extracted teaspoons of lemon juice do not match the extracted teaspoons of lemon juice",
+        expected: expected_teaspoons.to_s,
+        actual: teaspoons_lemon_juice.to_s,
+      }
+    end
+
+    t.logger.error("Failed to extract correct recipe details", { errors: errors })
+
+    next { _success: false, error: "Recipe details extraction validation failed" }
+  end
+
+  {
+    _success: true,
+    recipeDetails: {
+      tablespoons_olive_oil: expected_tablespoons,
+      teaspoons_lemon_juice: expected_teaspoons,
+    },
+  }
+end

--- a/packages/sdk-ruby/evals/tasks/extract/extract_regulations_table.rb
+++ b/packages/sdk-ruby/evals/tasks/extract/extract_regulations_table.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/extract/extract_regulations_table.ts
+
+Evals.define_task("extract_regulations_table") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/ncc-numbering-plan/")
+
+  # The locator engine prefix is required for XPath selectors.
+  locator = t.page.locator(
+    "xpath=/html/body/div[3]/main/div[2]/div[2]/div/div/div[2]/article/div[2]/div[1]/div/table",
+  )
+
+  result = t.stagehand.extract(
+    "Extract ALL of the Allottees and their corresponding name, area, and area code.",
+    schema: {
+      "type" => "object",
+      "properties" => {
+        "allottee_list" => {
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "allottee_name" => { "type" => "string" },
+              "area" => { "type" => "string" },
+              "area_code" => { "type" => "string" },
+              "access_code" => { "type" => "string" },
+            },
+            "required" => %w[allottee_name area area_code access_code],
+            "additionalProperties" => false,
+          },
+        },
+      },
+      "required" => ["allottee_list"],
+      "additionalProperties" => false,
+    },
+    locator: locator,
+  )
+
+  allottees = result.data
+
+  allottees_expected_first = {
+    "allottee_name" => "101 Communications Limited",
+    "area" => "Lagos",
+    "area_code" => "0201",
+    "access_code" => "249",
+  }
+
+  allottees_expected_last = {
+    "allottee_name" => "Airtel Networks Limited",
+    "area" => "National",
+    "area_code" => "0708",
+    "access_code" => "708",
+  }
+
+  expected_length = 25
+
+  allottee_list = allottees["allottee_list"]
+
+  # Check that the first entry, last entry, and total number match expectations
+  is_first_correct = allottee_list[0] == allottees_expected_first
+  is_last_correct = allottee_list[-1] == allottees_expected_last
+  is_length_correct = allottee_list.length == expected_length
+
+  is_regulations_correct = is_first_correct && is_last_correct && is_length_correct
+
+  { _success: is_regulations_correct, regulationsData: allottees }
+end

--- a/packages/sdk-ruby/evals/tasks/extract/extract_repo_name.rb
+++ b/packages/sdk-ruby/evals/tasks/extract/extract_repo_name.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/extract/extract_repo_name.ts
+
+Evals.define_task("extract_repo_name") do |t|
+  t.page.goto("https://github.com/facebook/react")
+
+  # v3 used schemaless extract; v4 requires a schema.
+  # Single-word key to stay clear of the snake_case wire-casing bug (#14).
+  result = t.stagehand.extract(
+    "extract the title of the Github repository. Do not include the owner of the repository.",
+    schema: {
+      "type" => "object",
+      "properties" => { "extraction" => { "type" => "string" } },
+      "required" => ["extraction"],
+      "additionalProperties" => false,
+    },
+  )
+
+  extraction = result.data["extraction"]
+
+  t.logger.log("Extracted repo title", { repo_name: extraction })
+
+  { _success: extraction == "react", extraction: extraction }
+end

--- a/packages/sdk-ruby/evals/tasks/extract/extract_resistor_info.rb
+++ b/packages/sdk-ruby/evals/tasks/extract/extract_resistor_info.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/extract/extract_resistor_info.ts
+
+Evals.define_task("extract_resistor_info") do |t|
+  # Port of the evals framework's normalizeString helper.
+  normalize = lambda do |str|
+    str.downcase
+       .gsub(/\s+/, " ")
+       .gsub(/[;\/#!$%^&*:{}=\-_`~()]/, "")
+       .gsub(/\s*,\s*/, ", ")
+       .strip
+  end
+
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/resistor/")
+
+  result = t.stagehand.extract(
+    "Extract the manufacturer standard lead time, tolerance percentage, resistance, and operating temperature range of the resistor.",
+    schema: {
+      "type" => "object",
+      "properties" => {
+        "manufacturer_standard_lead_time" => { "type" => "string" },
+        "tolerance_percentage" => { "type" => "string" },
+        "resistance" => { "type" => "string" },
+        "operating_temperature_range" => { "type" => "string" },
+      },
+      "required" => %w[
+        manufacturer_standard_lead_time
+        tolerance_percentage
+        resistance
+        operating_temperature_range
+      ],
+      "additionalProperties" => false,
+    },
+  )
+
+  manufacturer_standard_lead_time = result.data["manufacturer_standard_lead_time"]
+  tolerance_percentage = result.data["tolerance_percentage"]
+  resistance = result.data["resistance"]
+  operating_temperature_range = result.data["operating_temperature_range"]
+
+  expected = {
+    "manufacturer_standard_lead_time" => "11 Weeks",
+    "tolerance_percentage" => "±5",
+    "resistance" => "330 ohms",
+    "operating_temperature_range" => "-55°C ~ 155°C",
+  }
+
+  if normalize.call(manufacturer_standard_lead_time) != normalize.call(expected["manufacturer_standard_lead_time"])
+    t.logger.error("manufacturer standard lead time extracted does not match expected",
+                   { expected: normalize.call(expected["manufacturer_standard_lead_time"]),
+                     actual: normalize.call(manufacturer_standard_lead_time) })
+    next { _success: false, error: "manufacturer standard lead time extracted does not match expected" }
+  end
+
+  if normalize.call(tolerance_percentage) != normalize.call(expected["tolerance_percentage"])
+    t.logger.error("Tolerance percentage extracted does not match expected",
+                   { expected: normalize.call(expected["tolerance_percentage"]),
+                     actual: normalize.call(tolerance_percentage) })
+    next { _success: false, error: "Tolerance percentage extracted does not match expected" }
+  end
+
+  if normalize.call(resistance) != normalize.call(expected["resistance"])
+    t.logger.error("resistance extracted does not match expected",
+                   { expected: normalize.call(expected["resistance"]),
+                     actual: normalize.call(resistance) })
+    next { _success: false, error: "resistance extracted does not match expected" }
+  end
+
+  if normalize.call(operating_temperature_range) != normalize.call(expected["operating_temperature_range"])
+    t.logger.error("Operating temperature range extracted does not match expected",
+                   { expected: normalize.call(expected["operating_temperature_range"]),
+                     actual: normalize.call(operating_temperature_range) })
+    next { _success: false, error: "Operating temperature range extracted does not match expected" }
+  end
+
+  { _success: true }
+end

--- a/packages/sdk-ruby/evals/tasks/extract/extract_rockauto.rb
+++ b/packages/sdk-ruby/evals/tasks/extract/extract_rockauto.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/extract/extract_rockauto.ts
+
+Evals.define_task("extract_rockauto") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/rockauto/")
+  t.page.wait_for_timeout(5000)
+
+  result = t.stagehand.extract(
+    "Extract the part number of all the coolant and antifreeze products in the 'economy' category. " \
+    "Do not include the manufacturer name. Do not include products from the premium category.",
+    schema: {
+      "type" => "object",
+      "properties" => {
+        "coolant_products" => {
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "part_number" => { "type" => "string" },
+            },
+            "required" => ["part_number"],
+            "additionalProperties" => false,
+          },
+        },
+      },
+      "required" => ["coolant_products"],
+      "additionalProperties" => false,
+    },
+  )
+
+  coolant_products = result.data["coolant_products"]
+  expected_part_numbers = %w[GREEN5050GAL 719009 AF3300 AF3100 MV5050GAL]
+  expected_length = expected_part_numbers.length
+
+  if coolant_products.length != expected_length
+    t.logger.error("Incorrect number of coolant products extracted",
+                   { expected: expected_length, actual: coolant_products.length })
+    next { _success: false, error: "Incorrect number of coolant products extracted" }
+  end
+
+  missing_parts = expected_part_numbers.reject do |expected_part|
+    coolant_products.any? { |p| p["part_number"] == expected_part }
+  end
+
+  unless missing_parts.empty?
+    t.logger.error("Missing expected part number(s)",
+                   { missingParts: missing_parts, actualExtracted: coolant_products })
+    next {
+      _success: false,
+      error: "One or more expected part numbers were not found: #{missing_parts.join(', ')}",
+    }
+  end
+
+  { _success: true }
+end

--- a/packages/sdk-ruby/evals/tasks/extract/extract_single_link.rb
+++ b/packages/sdk-ruby/evals/tasks/extract/extract_single_link.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/extract/extract_single_link.ts
+
+Evals.define_task("extract_single_link") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/geniusee/")
+
+  result = t.stagehand.extract(
+    "extract the link to the 'contact us' page",
+    schema: {
+      "type" => "object",
+      "properties" => { "link" => { "type" => "string", "format" => "uri" } },
+      "required" => ["link"],
+      "additionalProperties" => false,
+    },
+  )
+
+  extracted_link = result.data["link"]
+  expected_link = "https://browserbase.github.io/stagehand-eval-sites/sites/geniusee/#contact"
+
+  if extracted_link == expected_link
+    next { _success: true }
+  end
+
+  {
+    _success: false,
+    reason: "Extracted link: #{extracted_link} does not match expected link: #{expected_link}",
+  }
+end

--- a/packages/sdk-ruby/evals/tasks/extract/extract_staff_members.rb
+++ b/packages/sdk-ruby/evals/tasks/extract/extract_staff_members.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/extract/extract_staff_members.ts
+
+Evals.define_task("extract_staff_members") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/panamcs/")
+
+  result = t.stagehand.extract(
+    "extract a list of ALL the staff members on this page, with their name and their job title",
+    schema: {
+      "type" => "object",
+      "properties" => {
+        "staff_members" => {
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "name" => { "type" => "string" },
+              "job_title" => { "type" => "string" },
+            },
+            "required" => %w[name job_title],
+            "additionalProperties" => false,
+          },
+        },
+      },
+      "required" => ["staff_members"],
+      "additionalProperties" => false,
+    },
+  )
+
+  staff_members = result.data["staff_members"]
+
+  expected_length = 50
+
+  expected_first_item = {
+    "name" => "Louis Alvarez",
+    "job_title" => "School Resource Officer",
+  }
+
+  expected_last_item = {
+    "name" => "Jessica Zipin",
+    "job_title" => "School Based Therapist",
+  }
+
+  if staff_members.length != expected_length
+    t.logger.error("Incorrect number of items extracted",
+                   { expected: expected_length, actual: staff_members.length })
+    next { _success: false, error: "Incorrect number of staff members extracted" }
+  end
+
+  # Check for the presence of the expected items
+  first_item_exists = staff_members.any? do |member|
+    member["name"] == expected_first_item["name"] &&
+      member["job_title"] == expected_first_item["job_title"]
+  end
+
+  unless first_item_exists
+    t.logger.error("Expected first staff member not found in extracted data",
+                   { expected: expected_first_item, actual: staff_members })
+    next { _success: false, error: "Expected first staff member not found in extracted data" }
+  end
+
+  last_item_exists = staff_members.any? do |member|
+    member["name"] == expected_last_item["name"] &&
+      member["job_title"] == expected_last_item["job_title"]
+  end
+
+  unless last_item_exists
+    t.logger.error("Expected last staff member not found in extracted data",
+                   { expected: expected_last_item, actual: staff_members })
+    next { _success: false, error: "Expected last staff member not found in extracted data" }
+  end
+
+  { _success: true }
+end

--- a/packages/sdk-ruby/evals/tasks/extract/extract_zillow.rb
+++ b/packages/sdk-ruby/evals/tasks/extract/extract_zillow.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/extract/extract_zillow.ts
+
+Evals.define_task("extract_zillow") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/zillow/")
+
+  result = t.stagehand.extract(
+    "Extract EACH AND EVERY HOME PRICE AND ADDRESS ON THE PAGE. DO NOT MISS ANY OF THEM.",
+    schema: {
+      "type" => "object",
+      "properties" => {
+        "listings" => {
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "properties" => {
+              "price" => { "type" => "string", "description" => "The price of the home" },
+              "trails" => { "type" => "string", "description" => "The address of the home" },
+            },
+            "required" => %w[price trails],
+            "additionalProperties" => false,
+          },
+        },
+      },
+      "required" => ["listings"],
+      "additionalProperties" => false,
+    },
+  )
+
+  listings = result.data["listings"]
+  expected_length = 38
+
+  if listings.length < expected_length
+    t.logger.error("Incorrect number of listings extracted",
+                   { expected: expected_length, actual: listings.length })
+    next { _success: false, error: "Incorrect number of listings extracted" }
+  end
+
+  { _success: true }
+end

--- a/packages/sdk-ruby/evals/tasks/extract/iframe_hn.rb
+++ b/packages/sdk-ruby/evals/tasks/extract/iframe_hn.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/extract/iframe_hn.ts
+
+Evals.define_task("iframe_hn") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/iframe-hn/")
+
+  # NOTE: the target content lives inside an iframe, but the task relies
+  # entirely on extract() to see into it (no frame API usage in v3 or
+  # v4), so this ported 1:1 — iframe handling is the SDK's responsibility.
+  result = t.stagehand.extract(
+    "extract the title of the first hackernews story",
+    schema: {
+      "type" => "object",
+      "properties" => { "story_title" => { "type" => "string" } },
+      "required" => ["story_title"],
+      "additionalProperties" => false,
+    },
+  )
+
+  title = result.data["story_title"].downcase
+  expected_title_substring = "overengineered anchor links"
+
+  unless title.include?(expected_title_substring)
+    t.logger.error("Extracted title: #{title} does not contain expected substring: #{expected_title_substring}")
+    next {
+      _success: false,
+      error: "Extracted title: #{title} does not contain expected substring: #{expected_title_substring}",
+    }
+  end
+
+  { _success: true }
+end

--- a/packages/sdk-ruby/evals/tasks/observe/ionwave_observe.rb
+++ b/packages/sdk-ruby/evals/tasks/observe/ionwave_observe.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/observe/ionwave_observe.ts
+
+Evals.define_task("ionwave_observe") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/ionwave/")
+
+  observations = t.stagehand.observe.data
+
+  if observations.empty?
+    next { _success: false, observations: observations.map(&:to_wire) }
+  end
+
+  expected_result = t.page.locator("#Form1 > div:nth-child(5) > div:nth-child(1) > a").first.inner_text
+
+  found_match = observations.any? do |observation|
+    t.page.locator(observation.selector).first.inner_text == expected_result
+  rescue StandardError
+    false
+  end
+
+  { _success: found_match, expected: expected_result, observations: observations.map(&:to_wire) }
+end

--- a/packages/sdk-ruby/evals/tasks/observe/observe_amazon_add_to_cart.rb
+++ b/packages/sdk-ruby/evals/tasks/observe/observe_amazon_add_to_cart.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/observe/observe_amazon_add_to_cart.ts
+
+Evals.define_task("observe_amazon_add_to_cart") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/amazon/")
+
+  observations1 = t.stagehand.observe("Find and click the 'Add to Cart' button").data
+
+  # Example of using performPlaywrightMethod if you have the xpath
+  t.stagehand.act(observations1[0]) unless observations1.empty?
+
+  observations2 = t.stagehand.observe("Find and click the 'Proceed to checkout' button").data
+
+  # Example of using performPlaywrightMethod if you have the xpath
+  t.stagehand.act(observations2[0]) unless observations2.empty?
+
+  current_url = t.page.url
+  expected_url_prefix = "https://browserbase.github.io/stagehand-eval-sites/sites/amazon/sign-in.html"
+
+  { _success: current_url.start_with?(expected_url_prefix), currentUrl: current_url }
+end

--- a/packages/sdk-ruby/evals/tasks/observe/observe_file_uploads.rb
+++ b/packages/sdk-ruby/evals/tasks/observe/observe_file_uploads.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/observe/observe_file_uploads.ts
+
+Evals.define_task("observe_file_uploads") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/file-uploads-3/")
+
+  observations = t.stagehand.observe("find the file upload element").data
+
+  if observations.empty?
+    next {
+      _success: false,
+      message: "observe returned no results",
+      observations: observations.map(&:to_wire),
+    }
+  end
+
+  expected_locator = "xpath=/html/body/input"
+
+  # v3 compares backendNodeIds; the v4 Locator exposes no node identity
+  # so the same element-identity check is
+  # re-expressed in-page: resolve the observed selector and the expected
+  # selector and compare element references.
+  matched = t.page.evaluate(<<~JS)
+    (() => {
+      const observedSelector = #{observations[0].selector.to_json};
+      const candidateSelectors = #{[expected_locator].to_json};
+      const resolve = (selector) => {
+        const raw = selector.startsWith("xpath=") ? selector.slice("xpath=".length) : selector;
+        if (raw.startsWith("/") || raw.startsWith("(")) {
+          const result = document.evaluate(raw, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
+          return result.singleNodeValue;
+        }
+        return document.querySelector(raw);
+      };
+      const observed = resolve(observedSelector);
+      if (!observed) return null;
+      for (const candidate of candidateSelectors) {
+        if (resolve(candidate) === observed) return candidate;
+      }
+      return null;
+    })()
+  JS
+  found_match = !matched.nil?
+
+  { _success: found_match, observations: observations.map(&:to_wire) }
+end

--- a/packages/sdk-ruby/evals/tasks/observe/observe_github.rb
+++ b/packages/sdk-ruby/evals/tasks/observe/observe_github.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/observe/observe_github.ts
+
+Evals.define_task("observe_github") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/github/")
+
+  observations = t.stagehand.observe("find the scrollable element that holds the repos file tree.").data
+
+  if observations.empty?
+    next { _success: false, observations: observations.map(&:to_wire) }
+  end
+
+  possible_locators = [
+    "#repo-content-pjax-container > react-app > div > div > div.prc-PageLayout-PageLayoutRoot-1zlEO > div > div > div.Box-sc-g0xbh4-0.gISSDQ",
+    "#repo-content-pjax-container > react-app > div > div > div.prc-PageLayout-PageLayoutRoot-1zlEO > div > div > div.Box-sc-g0xbh4-0.gISSDQ > div",
+    "#repo-content-pjax-container > react-app > div > div > div.prc-PageLayout-PageLayoutRoot-1zlEO > div > div > div.Box-sc-g0xbh4-0.gISSDQ > div > div.prc-PageLayout-Pane-Vl5LI",
+    "#repo-content-pjax-container > react-app > div > div > div.prc-PageLayout-PageLayoutRoot-1zlEO > div > div > div.Box-sc-g0xbh4-0.gISSDQ > div > div.prc-PageLayout-Pane-Vl5LI > div",
+    "#repos-file-tree > div.Box-sc-g0xbh4-0.ReposFileTreePane-module__Box_5--tQNH_",
+    "#repos-file-tree > div.Box-sc-g0xbh4-0.ReposFileTreePane-module__Box_5--tQNH_ > div",
+    "#repos-file-tree > div.Box-sc-g0xbh4-0.ReposFileTreePane-module__Box_5--tQNH_ > div > div",
+    "#repos-file-tree > div.Box-sc-g0xbh4-0.ReposFileTreePane-module__Box_5--tQNH_ > div > div > div > nav",
+    "#repos-file-tree > div.Box-sc-g0xbh4-0.ReposFileTreePane-module__Box_5--tQNH_ > div > div > div > nav > ul",
+  ]
+
+  # v3 compares backendNodeIds; the v4 Locator exposes no node identity
+  # so the same element-identity check is
+  # re-expressed in-page: resolve the observed selector and each
+  # candidate selector and compare element references. Candidates that
+  # fail to resolve are ignored, as in v3.
+  matching_selector = lambda do |observed_selector, candidate_selectors|
+    t.page.evaluate(<<~JS)
+      (() => {
+        const observedSelector = #{observed_selector.to_json};
+        const candidateSelectors = #{candidate_selectors.to_json};
+        const resolve = (selector) => {
+          const raw = selector.startsWith("xpath=") ? selector.slice("xpath=".length) : selector;
+          if (raw.startsWith("/") || raw.startsWith("(")) {
+            const result = document.evaluate(raw, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
+            return result.singleNodeValue;
+          }
+          return document.querySelector(raw);
+        };
+        const observed = resolve(observedSelector);
+        if (!observed) return null;
+        for (const candidate of candidateSelectors) {
+          if (resolve(candidate) === observed) return candidate;
+        }
+        return null;
+      })()
+    JS
+  end
+
+  found_match = false
+  matched_locator = nil
+
+  observations.each do |observation|
+    matched = matching_selector.call(observation.selector, possible_locators)
+    if matched
+      found_match = true
+      matched_locator = matched
+      break
+    end
+  rescue StandardError => e
+    t.logger.log("Failed to check observation with selector #{observation.selector}: #{e.message}")
+    next
+  end
+
+  {
+    _success: found_match,
+    matchedLocator: matched_locator,
+    observations: observations.map(&:to_wire),
+  }
+end

--- a/packages/sdk-ruby/evals/tasks/observe/observe_iframes1.rb
+++ b/packages/sdk-ruby/evals/tasks/observe/observe_iframes1.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/observe/observe_iframes1.ts
+
+Evals.define_task("observe_iframes1") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/iframe-hn/")
+
+  observations = t.stagehand.observe("find the main header of the page").data
+
+  if observations.empty?
+    next { _success: false, observations: observations.map(&:to_wire) }
+  end
+
+  possible_locators = [
+    "body > main > section.iframe-wrapper > iframe",
+    "body > header > h1",
+  ]
+
+  # v3 compares backendNodeIds; the v4 Locator exposes no node identity
+  # so the same element-identity check is
+  # re-expressed in-page. Both candidate selectors live in the main
+  # frame, so main-frame resolution preserves the v3 pass criterion:
+  # an observed selector that points inside the iframe never had a
+  # backendNodeId equal to either main-frame candidate in v3 (no match),
+  # and here it simply fails to resolve in the main document (no match).
+  matching_selector = lambda do |observed_selector, candidate_selectors|
+    t.page.evaluate(<<~JS)
+      (() => {
+        const observedSelector = #{observed_selector.to_json};
+        const candidateSelectors = #{candidate_selectors.to_json};
+        const resolve = (selector) => {
+          const raw = selector.startsWith("xpath=") ? selector.slice("xpath=".length) : selector;
+          if (raw.startsWith("/") || raw.startsWith("(")) {
+            const result = document.evaluate(raw, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
+            return result.singleNodeValue;
+          }
+          return document.querySelector(raw);
+        };
+        const observed = resolve(observedSelector);
+        if (!observed) return null;
+        for (const candidate of candidateSelectors) {
+          if (resolve(candidate) === observed) return candidate;
+        }
+        return null;
+      })()
+    JS
+  end
+
+  found_match = false
+  matched_locator = nil
+
+  observations.each do |observation|
+    matched = matching_selector.call(observation.selector, possible_locators)
+    if matched
+      found_match = true
+      matched_locator = matched
+      break
+    end
+  rescue StandardError => e
+    t.logger.log("Failed to check observation with selector #{observation.selector}: #{e.message}")
+    next
+  end
+
+  {
+    _success: found_match,
+    matchedLocator: matched_locator,
+    observations: observations.map(&:to_wire),
+  }
+end

--- a/packages/sdk-ruby/evals/tasks/observe/observe_iframes2.rb
+++ b/packages/sdk-ruby/evals/tasks/observe/observe_iframes2.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/observe/observe_iframes2.ts
+
+Evals.define_task("observe_iframes2") do |t|
+  t.page.goto("https://iframetester.com/?url=https://shopify.com")
+  t.page.wait_for_timeout(5000)
+
+  observations = nil
+  begin
+    observations = t.stagehand.observe("find the main header of the page").data
+  rescue StandardError => e
+    next { _success: false, message: e.message }
+  end
+
+  if observations.empty?
+    next { _success: false, observations: observations.map(&:to_wire) }
+  end
+
+  possible_locators = [
+    "#iframe-window",
+    "body > header > h1",
+  ]
+
+  # v3 compares backendNodeIds; the v4 Locator exposes no node identity
+  # so the same element-identity check is
+  # re-expressed in-page. Both candidate selectors live in the main
+  # frame (the shopify iframe is cross-origin and unreachable from the
+  # main document either way): an observed selector that pierces into
+  # the iframe never had a backendNodeId equal to either main-frame
+  # candidate in v3 (no match), and here it simply fails to resolve in
+  # the main document (no match) — the pass criterion is preserved.
+  matching_selector = lambda do |observed_selector, candidate_selectors|
+    t.page.evaluate(<<~JS)
+      (() => {
+        const observedSelector = #{observed_selector.to_json};
+        const candidateSelectors = #{candidate_selectors.to_json};
+        const resolve = (selector) => {
+          const raw = selector.startsWith("xpath=") ? selector.slice("xpath=".length) : selector;
+          if (raw.startsWith("/") || raw.startsWith("(")) {
+            const result = document.evaluate(raw, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
+            return result.singleNodeValue;
+          }
+          return document.querySelector(raw);
+        };
+        const observed = resolve(observedSelector);
+        if (!observed) return null;
+        for (const candidate of candidateSelectors) {
+          if (resolve(candidate) === observed) return candidate;
+        }
+        return null;
+      })()
+    JS
+  end
+
+  found_match = false
+  matched_locator = nil
+
+  observations.each do |observation|
+    matched = matching_selector.call(observation.selector, possible_locators)
+    if matched
+      found_match = true
+      matched_locator = matched
+      break
+    end
+  rescue StandardError => e
+    t.logger.log("Failed to check observation with selector #{observation.selector}: #{e.message}")
+    next
+  end
+
+  {
+    _success: found_match,
+    matchedLocator: matched_locator,
+    observations: observations.map(&:to_wire),
+  }
+end

--- a/packages/sdk-ruby/evals/tasks/observe/observe_main_frame_element_ids.rb
+++ b/packages/sdk-ruby/evals/tasks/observe/observe_main_frame_element_ids.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/observe/observe_main_frame_element_ids.ts
+
+Evals.define_task("observe_main_frame_element_ids") do |t|
+  # Keep backend node IDs large enough to exercise Anthropic's bare-id failure mode.
+  filler = (0...2500).map { |index| "<span hidden data-filler=\"#{index}\">filler #{index}</span>" }.join
+
+  cases = [
+    { instruction: "Find the Target Checkout button", marker: "checkout", label: "Target Checkout" },
+    { instruction: "Find the Pricing Plans button", marker: "pricing", label: "Pricing Plans" },
+    { instruction: "Find the Request Demo button", marker: "demo", label: "Request Demo" },
+  ]
+
+  buttons = cases.map do |c|
+    <<~HTML
+      #{filler}
+      <section>
+        <button onclick="document.body.dataset.clicked = '#{c[:marker]}'">
+          #{c[:label]}
+        </button>
+      </section>
+    HTML
+  end.join
+
+  html = <<~HTML
+    <!doctype html>
+    <html>
+      <body>
+        <main>#{buttons}</main>
+      </body>
+    </html>
+  HTML
+
+  # Equivalent of JS encodeURIComponent (escape everything outside its unreserved set).
+  encoded = html.gsub(/[^A-Za-z0-9\-_.!~*'()]/) { |c| c.each_byte.map { |b| format("%%%02X", b) }.join }
+
+  t.page.goto("data:text/html,#{encoded}")
+
+  results = []
+  failure = nil
+
+  cases.each do |test_case|
+    t.page.evaluate("(() => { delete document.body.dataset.clicked; })()")
+
+    observations = t.stagehand.observe(test_case[:instruction]).data
+    if observations.empty?
+      failure = {
+        _success: false,
+        failedInstruction: test_case[:instruction],
+        reason: "observe returned no elements",
+        results: results,
+      }
+      break
+    end
+
+    t.stagehand.act(observations[0])
+    clicked = t.page.evaluate("(() => document.body.dataset.clicked)()")
+    results << {
+      instruction: test_case[:instruction],
+      clicked: clicked,
+      observations: observations.map(&:to_wire),
+    }
+
+    if clicked != test_case[:marker]
+      failure = {
+        _success: false,
+        failedInstruction: test_case[:instruction],
+        expectedClicked: test_case[:marker],
+        clicked: clicked,
+        results: results,
+      }
+      break
+    end
+  end
+
+  failure || { _success: true, results: results }
+end

--- a/packages/sdk-ruby/evals/tasks/observe/observe_simple_google_search.rb
+++ b/packages/sdk-ruby/evals/tasks/observe/observe_simple_google_search.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/observe/observe_simple_google_search.ts
+
+Evals.define_task("observe_simple_google_search") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/google/")
+
+  observation1 = t.stagehand.observe("Find the search bar and type 'OpenAI'").data
+  t.stagehand.act(observation1[0]) unless observation1.empty?
+
+  observation2 = t.stagehand.observe("Press enter").data
+  t.stagehand.act(observation2[0]) unless observation2.empty?
+
+  t.page.wait_for_timeout(3000)
+
+  expected_url = "https://browserbase.github.io/stagehand-eval-sites/sites/google/openai.html"
+  current_url = t.page.url
+
+  { _success: current_url.start_with?(expected_url), currentUrl: current_url }
+end

--- a/packages/sdk-ruby/evals/tasks/observe/observe_taxes.rb
+++ b/packages/sdk-ruby/evals/tasks/observe/observe_taxes.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/observe/observe_taxes.ts
+
+Evals.define_task("observe_taxes") do |t|
+  t.page.goto("https://file.1040.com/estimate/")
+
+  observations = t.stagehand.observe("Find all the form input elements under the 'Income' section").data
+
+  if observations.empty? || observations.length < 13
+    next { _success: false, observations: observations.map(&:to_wire) }
+  end
+
+  expected_locator = "#tpWages"
+
+  expected_result = t.page.locator(expected_locator).first.inner_text
+
+  found_match = observations.any? do |observation|
+    t.page.locator(observation.selector).first.inner_text == expected_result
+  rescue StandardError => e
+    t.logger.log("Failed to check observation with selector #{observation.selector}: #{e.message}")
+    false
+  end
+
+  { _success: found_match, expected: expected_result, observations: observations.map(&:to_wire) }
+end

--- a/packages/sdk-ruby/evals/tasks/observe/observe_vantechjournal.rb
+++ b/packages/sdk-ruby/evals/tasks/observe/observe_vantechjournal.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/observe/observe_vantechjournal.ts
+
+Evals.define_task("observe_vantechjournal") do |t|
+  t.page.goto("https://vantechjournal.com/archive")
+
+  observations = t.stagehand.observe("Find the 'load more' link").data
+
+  if observations.empty?
+    next { _success: false, observations: observations.map(&:to_wire) }
+  end
+
+  expected_locators = [
+    "xpath=/html/body/div[2]/div/div/section/div/div/div[3]/a",
+    "xpath=/html/body/div[2]/div/div/section/div/div/div[3]/a/span",
+  ]
+
+  # v3 compares backendNodeIds (first observation vs. each expected
+  # locator); the v4 Locator exposes no node identity
+  # so the same element-identity check is
+  # re-expressed in-page: resolve the observed selector and each
+  # expected selector and compare element references. Expected locators
+  # that fail to resolve are skipped, as in v3.
+  matched = t.page.evaluate(<<~JS)
+    (() => {
+      const observedSelector = #{observations[0].selector.to_json};
+      const candidateSelectors = #{expected_locators.to_json};
+      const resolve = (selector) => {
+        const raw = selector.startsWith("xpath=") ? selector.slice("xpath=".length) : selector;
+        if (raw.startsWith("/") || raw.startsWith("(")) {
+          const result = document.evaluate(raw, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
+          return result.singleNodeValue;
+        }
+        return document.querySelector(raw);
+      };
+      const observed = resolve(observedSelector);
+      if (!observed) return null;
+      for (const candidate of candidateSelectors) {
+        if (resolve(candidate) === observed) return candidate;
+      }
+      return null;
+    })()
+  JS
+  found_match = !matched.nil?
+
+  {
+    _success: found_match,
+    expected: expected_locators,
+    observations: observations.map(&:to_wire),
+  }
+end

--- a/packages/sdk-ruby/evals/tasks/observe/observe_yc_startup.rb
+++ b/packages/sdk-ruby/evals/tasks/observe/observe_yc_startup.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/observe/observe_yc_startup.ts
+
+Evals.define_task("observe_yc_startup") do |t|
+  t.page.goto("https://www.ycombinator.com/companies", wait_until: "networkidle")
+
+  observations = t.stagehand.observe(
+    "Click the container element that holds links to each of the startup companies. " \
+    "The companies each have a name, a description, and a link to their website.",
+  ).data
+
+  if observations.empty?
+    next { _success: false, observations: observations.map(&:to_wire) }
+  end
+
+  possible_locators = [
+    "div._rightCol_18olp_594",
+    "div._section_18olp_165._results_18olp_345",
+  ]
+
+  # v3 compares backendNodeIds; the v4 Locator exposes no node identity
+  # so the same element-identity check is
+  # re-expressed in-page: resolve the observed selector and each
+  # candidate selector and compare element references.
+  matching_selector = lambda do |observed_selector, candidate_selectors|
+    t.page.evaluate(<<~JS)
+      (() => {
+        const observedSelector = #{observed_selector.to_json};
+        const candidateSelectors = #{candidate_selectors.to_json};
+        const resolve = (selector) => {
+          const raw = selector.startsWith("xpath=") ? selector.slice("xpath=".length) : selector;
+          if (raw.startsWith("/") || raw.startsWith("(")) {
+            const result = document.evaluate(raw, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
+            return result.singleNodeValue;
+          }
+          return document.querySelector(raw);
+        };
+        const observed = resolve(observedSelector);
+        if (!observed) return null;
+        for (const candidate of candidateSelectors) {
+          if (resolve(candidate) === observed) return candidate;
+        }
+        return null;
+      })()
+    JS
+  end
+
+  found_match = false
+  matched_locator = nil
+
+  observations.each do |observation|
+    matched = matching_selector.call(observation.selector, possible_locators)
+    if matched
+      found_match = true
+      matched_locator = matched
+      break
+    end
+  rescue StandardError => e
+    t.logger.log("Failed to check observation with selector #{observation.selector}: #{e.message}")
+    next
+  end
+
+  {
+    _success: found_match,
+    matchedLocator: matched_locator,
+    observations: observations.map(&:to_wire),
+  }
+end

--- a/packages/sdk-ruby/evals/tasks/observe/panamcs.rb
+++ b/packages/sdk-ruby/evals/tasks/observe/panamcs.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Port of packages/evals/tasks/bench/observe/panamcs.ts
+
+Evals.define_task("panamcs") do |t|
+  t.page.goto("https://browserbase.github.io/stagehand-eval-sites/sites/panamcs/")
+
+  observations = t.stagehand.observe("click the 'about us' link").data
+
+  if observations.empty?
+    next { _success: false, observations: observations.map(&:to_wire) }
+  end
+
+  expected_locator = "#menu > li:nth-child(1) > a"
+
+  expected_result = t.page.locator(expected_locator).first.inner_text
+
+  found_match = observations.any? do |observation|
+    t.page.locator(observation.selector).first.inner_text == expected_result
+  rescue StandardError => e
+    t.logger.log("Failed to check observation with selector #{observation.selector}: #{e.message}")
+    false
+  end
+
+  { _success: found_match, expected: expected_result, observations: observations.map(&:to_wire) }
+end

--- a/packages/sdk-ruby/lib/stagehand/client.rb
+++ b/packages/sdk-ruby/lib/stagehand/client.rb
@@ -107,28 +107,40 @@ module Stagehand
       @initialized
     end
 
-    def act(instruction, page: nil, model: nil, variables: nil, timeout: nil, cache: nil)
-      params = { page_id: target_page_id(page), instruction: encode_instruction(instruction) }
-      options = call_options(model: model, variables: variables, timeout: timeout, cache: cache)
-      params[:options] = options unless options.nil?
+    def act(instruction, page: nil, model: nil, variables: nil, timeout: nil,
+            locator: nil, ignore_locators: nil, cache: nil)
+      page_id = target_page_id(page)
+      params = { page_id: page_id, instruction: encode_instruction(instruction) }
+      options = call_options(model: model, variables: variables, timeout: timeout, cache: cache,
+                             locator: serialize_locator(locator, page_id, "act"),
+                             ignore_locators: serialize_locators(ignore_locators, page_id, "act"))
+      params[:options] = Models::ActOptions.new(**options) unless options.nil?
       connected_rpc_client.send("stagehand.act", Models::StagehandActParams.new(**params), "ActResult")
     end
 
-    def observe(instruction = nil, page: nil, model: nil, variables: nil, timeout: nil, cache: nil)
-      params = { page_id: target_page_id(page) }
+    def observe(instruction = nil, page: nil, model: nil, variables: nil, timeout: nil,
+                locator: nil, ignore_locators: nil, cache: nil)
+      page_id = target_page_id(page)
+      params = { page_id: page_id }
       params[:instruction] = instruction unless instruction.nil?
-      options = call_options(model: model, variables: variables, timeout: timeout, cache: cache)
-      params[:options] = options unless options.nil?
+      options = call_options(model: model, variables: variables, timeout: timeout, cache: cache,
+                             locator: serialize_locator(locator, page_id, "observe"),
+                             ignore_locators: serialize_locators(ignore_locators, page_id, "observe"))
+      params[:options] = Models::ObserveOptions.new(**options) unless options.nil?
       connected_rpc_client.send("stagehand.observe", Models::StagehandObserveParams.new(**params), "ObserveResult")
     end
 
     # schema is a plain JSON Schema Hash; the extracted data comes back as raw
     # JSON matching it. Defaults to { extraction: string }.
-    def extract(instruction, schema: nil, page: nil, model: nil, timeout: nil, screenshot: nil, cache: nil)
-      params = { page_id: target_page_id(page), instruction: instruction }
+    def extract(instruction, schema: nil, page: nil, model: nil, timeout: nil, screenshot: nil,
+                locator: nil, ignore_locators: nil, cache: nil)
+      page_id = target_page_id(page)
+      params = { page_id: page_id, instruction: instruction }
       params[:schema] = schema unless schema.nil?
-      options = call_options(model: model, timeout: timeout, screenshot: screenshot, cache: cache)
-      params[:options] = options unless options.nil?
+      options = call_options(model: model, timeout: timeout, screenshot: screenshot, cache: cache,
+                             locator: serialize_locator(locator, page_id, "extract"),
+                             ignore_locators: serialize_locators(ignore_locators, page_id, "extract"))
+      params[:options] = Models::ExtractOptions.new(**options) unless options.nil?
       connected_rpc_client.send("stagehand.extract", Models::StagehandExtractParams.new(**params), "ExtractResult")
     end
 
@@ -240,14 +252,34 @@ module Stagehand
       end
     end
 
-    def call_options(model: nil, variables: nil, timeout: nil, screenshot: nil, cache: nil)
+    def call_options(model: nil, variables: nil, timeout: nil, screenshot: nil,
+                     locator: nil, ignore_locators: nil, cache: nil)
       values = {}
       values[:model] = model.is_a?(String) ? Models::ModelConfig.new(model_name: model) : model unless model.nil?
       values[:variables] = variables unless variables.nil?
       values[:timeout] = timeout unless timeout.nil?
       values[:screenshot] = screenshot unless screenshot.nil?
+      values[:locator] = locator unless locator.nil?
+      values[:ignore_locators] = ignore_locators unless ignore_locators.nil?
       values[:cache] = Validation.cache_config(cache) unless cache.nil?
       values.empty? ? nil : values
+    end
+
+    # Locator targets must belong to the page the operation runs on (port of
+    # Python's _serialize_locator).
+    def serialize_locator(locator, page_id, method)
+      return nil if locator.nil?
+      unless locator.is_a?(Locator) && locator.page_id == page_id
+        raise ArgumentError, "#{method}() locator must belong to the target page"
+      end
+      values = { selector: locator.selector }
+      values[:nth] = locator.nth_index unless locator.nth_index.nil?
+      Models::Locator.new(**values)
+    end
+
+    def serialize_locators(locators, page_id, method)
+      return nil if locators.nil?
+      locators.map { |locator| serialize_locator(locator, page_id, method) }
     end
 
     def worker_init_values

--- a/packages/sdk-ruby/scripts/build.rb
+++ b/packages/sdk-ruby/scripts/build.rb
@@ -28,9 +28,14 @@ FileUtils.mkdir_p(output_directory)
 begin
   FileUtils.cp_r(extension_dist, staged_extension)
 
-  specification = Gem::Specification.load(File.join(package_root, "stagehand.gemspec"))
-  abort "Could not load stagehand.gemspec" if specification.nil?
-  gem_path = Dir.chdir(package_root) { Gem::Package.build(specification) }
+  # The gemspec globs files relative to the working directory, so both the
+  # load and the build must run from the package root (CI invokes this
+  # script from the repository root).
+  gem_path = Dir.chdir(package_root) do
+    specification = Gem::Specification.load("stagehand.gemspec")
+    abort "Could not load stagehand.gemspec" if specification.nil?
+    Gem::Package.build(specification)
+  end
   built = File.join(package_root, gem_path)
   target = File.join(output_directory, File.basename(gem_path))
   FileUtils.mv(built, target)

--- a/packages/sdk-ruby/sig/stagehand.rbs
+++ b/packages/sdk-ruby/sig/stagehand.rbs
@@ -102,9 +102,9 @@ module Stagehand
 
     attr_reader browser: StagehandBrowser
     def initialized?: () -> bool
-    def act: (untyped instruction, ?page: Page?, ?model: untyped, ?variables: Hash[Symbol | String, untyped]?, ?timeout: Numeric?, ?cache: cache_input?) -> untyped
-    def observe: (?String? instruction, ?page: Page?, ?model: untyped, ?variables: Hash[Symbol | String, untyped]?, ?timeout: Numeric?, ?cache: cache_input?) -> untyped
-    def extract: (String instruction, ?schema: Hash[String, untyped]?, ?page: Page?, ?model: untyped, ?timeout: Numeric?, ?screenshot: bool?, ?cache: cache_input?) -> untyped
+    def act: (untyped instruction, ?page: Page?, ?model: untyped, ?variables: Hash[Symbol | String, untyped]?, ?timeout: Numeric?, ?locator: Locator?, ?ignore_locators: Array[Locator]?, ?cache: cache_input?) -> untyped
+    def observe: (?String? instruction, ?page: Page?, ?model: untyped, ?variables: Hash[Symbol | String, untyped]?, ?timeout: Numeric?, ?locator: Locator?, ?ignore_locators: Array[Locator]?, ?cache: cache_input?) -> untyped
+    def extract: (String instruction, ?schema: Hash[String, untyped]?, ?page: Page?, ?model: untyped, ?timeout: Numeric?, ?screenshot: bool?, ?locator: Locator?, ?ignore_locators: Array[Locator]?, ?cache: cache_input?) -> untyped
     def metrics: () -> untyped
     def experimental_batch: (String source, ?untyped input, ?timeout: Integer, ?page: Page?) -> untyped
     def close: () -> nil

--- a/packages/sdk-ruby/test/test_client_operations.rb
+++ b/packages/sdk-ruby/test/test_client_operations.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require_relative "support/fake_transport"
+
+# Wire encoding of the AI operations' locator targeting options.
+class TestClientOperations < Minitest::Test
+  include RPCHarness
+
+  def setup
+    start_rpc
+    @client = Stagehand::Client.allocate
+    @client.instance_variable_set(:@rpc_client, @rpc_client)
+    @client.instance_variable_set(:@initialized, true)
+    @page = Stagehand::Page.new(
+      @rpc_client,
+      Stagehand::Models::PageRef.from_wire({ "page_id" => "page-1", "url" => "about:blank" }),
+    )
+  end
+
+  def teardown
+    stop_rpc
+  end
+
+  ACT_RESULT = {
+    "data" => {
+      "success" => true, "message" => "ok", "action_description" => "d",
+      "actions" => [{ "selector" => "#a", "description" => "d", "method" => "click" }],
+    },
+    "metadata" => {
+      "cache" => { "status" => "DISABLED" },
+      "usage" => { "input_tokens" => 0, "output_tokens" => 0, "inference_time_ms" => 0 },
+    },
+  }.freeze
+
+  def test_act_sends_locator_and_ignore_locators
+    locator = @page.locator("#login").nth(2)
+    ignored = [@page.locator("#banner")]
+    request = expect_rpc(result: ACT_RESULT) do
+      @client.act("click login", page: @page, locator: locator, ignore_locators: ignored)
+    end
+    assert_equal(
+      { "locator" => { "selector" => "#login", "nth" => 2 },
+        "ignore_locators" => [{ "selector" => "#banner" }] },
+      request["params"]["options"],
+    )
+  end
+
+  def test_extract_sends_locator
+    request = expect_rpc(result: ACT_RESULT.merge("data" => {})) do
+      @client.extract("extract it", page: @page, locator: @page.locator("xpath=/html/body/div"))
+    end
+    assert_equal({ "locator" => { "selector" => "xpath=/html/body/div" } }, request["params"]["options"])
+  end
+
+  def test_locator_must_belong_to_the_target_page
+    other_page = Stagehand::Page.new(
+      @rpc_client,
+      Stagehand::Models::PageRef.from_wire({ "page_id" => "page-2", "url" => "about:blank" }),
+    )
+    error = assert_raises(ArgumentError) do
+      @client.observe("find it", page: @page, locator: other_page.locator("#x"))
+    end
+    assert_equal "observe() locator must belong to the target page", error.message
+  end
+end

--- a/packages/sdk-ruby/test/test_file_upload.rb
+++ b/packages/sdk-ruby/test/test_file_upload.rb
@@ -7,6 +7,7 @@ require "tempfile"
 class TestFileUpload < Minitest::Test
   def test_normalizes_a_path_into_a_wire_payload
     Tempfile.create(["report", ".csv"]) do |file|
+      file.binmode # keep the fixture byte-stable on Windows (no CRLF translation)
       file.write("a,b\n1,2\n")
       file.flush
       payloads = Stagehand::FileUpload.normalize_file_input(file.path)


### PR DESCRIPTION
Part of the AP-2857 parity stack:

**Stack:** … ← #2858 (M6a) ← #2859 (M6c) ← #2860 (M6d) ← **this PR (evals)**

Ruby ports of the entire bench-tier eval set from `packages/evals/tasks/bench/` — **all 77 tasks** (40 act, 25 extract, 12 observe), each a 1:1 semantic port (same URLs, same assertions) — plus a runner (`packages/sdk-ruby/evals/`): auto-discovery, fresh Browserbase session per run, one shared extension upload per invocation (per-session uploads trip the `POST /v1/extensions` rate limit), `self_heal: true` like the TS harness, trials/concurrency/target selection, JSONL results + per-category summary.

## SDK changes the port forced
- `act`/`observe`/`extract` gain `locator:` / `ignore_locators:` — protocol options TS/Python already exposed and the eval tasks use — with page-ownership validation; call options now encode through their wire models (`ActOptions`/`ObserveOptions`/`ExtractOptions`). RBS updated; suite at 123 runs / 807 assertions.

## Results (Browserbase + Model Gateway)

| Category | Passed |
|---|---|
| act | 39/40 |
| extract | 24/25 |
| observe | 10/12 |
| **overall** | **73/77** |

The 4 failures were probed individually and are not Ruby defects:
- `extract/extract_apartments` — apartments.com returns Akamai **Access Denied** to this infra
- `observe/observe_taxes` — 1040.com serves a bot-check interstitial; the form never renders
- `observe/observe_vantechjournal` — site drift: the hardcoded expected XPath no longer exists on the live page
- `act/vantechjournal` — navigation-timing race shared with the TS task: the SDK clicks the correct link and navigation completes (verified: `page.url` reads `/recommendations` 3s later), but the task samples `page.url` before the navigation commits

Porting note that generalizes: `z.string().url()` fields must reach the wire as `"format": "uri"` (zod's JSON-Schema interchange) for the extension to resolve element references into absolute URLs — plain `"type": "string"` returns reference ids.

Out of scope: dataset-backed suites (WebVoyager, OnlineMind2Web, WebTailBench), agent-tier tasks, Braintrust reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)