### PR TITLE
feat(ruby): close the four remaining parity gaps

### DIFF
--- a/packages/docs/tests/sdk-reference.test.ts
+++ b/packages/docs/tests/sdk-reference.test.ts
@@ -1341,7 +1341,7 @@ describe("Mintlify customization boundary", () => {
       differences,
       "Language-scoped documentation must use field names derived from that SDK's public source",
     ).toEqual([]);
-  });
+  }, 30_000); // Parses every MDX page; cold CI runners exceed the 5s default.
 
   it("includes every indexed MDX content page in docs.json navigation", async () => {
     const docsConfig = JSON.parse(
@@ -1451,7 +1451,7 @@ describe("Mintlify customization boundary", () => {
       problems,
       "Every language tab group must offer the same languages, so switching never hides a snippet",
     ).toEqual([]);
-  });
+  }, 30_000); // Parses every MDX page; cold CI runners exceed the 5s default.
 
   it("never mixes language tabs with other tabs in one group", async () => {
     const contentPages = (await listFiles(V4_DOCS_ROOT, shouldInspectDocsDirectory)).filter(

--- a/packages/docs/tests/sdk-reference.test.ts
+++ b/packages/docs/tests/sdk-reference.test.ts
@@ -503,7 +503,7 @@ describe("SDK reference surface", () => {
     }
 
     expect(problems, "Internal v4 reference links must resolve to a page and heading").toEqual([]);
-  });
+  }, 30_000); // Parses every MDX page; cold CI runners exceed the 5s default.
 
   it("documents callable helper members as methods and metadata as properties", async () => {
     const webmcpPath = resolve(REFERENCE_ROOT, "webmcp.mdx");
@@ -1372,7 +1372,7 @@ describe("Mintlify customization boundary", () => {
       navigatedPages,
       "Every indexed MDX content page must be reachable from docs.json",
     ).toStrictEqual(indexedContentPages);
-  });
+  }, 30_000); // Parses every MDX page; cold CI runners exceed the 5s default.
 
   it("gives every language tab group the same complete language set", async () => {
     const contentPages = (await listFiles(V4_DOCS_ROOT, shouldInspectDocsDirectory)).filter(
@@ -1480,7 +1480,7 @@ describe("Mintlify customization boundary", () => {
       problems,
       "A tab group switches on exactly one axis: either language or something else, never both",
     ).toEqual([]);
-  });
+  }, 30_000); // Parses every MDX page; cold CI runners exceed the 5s default.
 
   it("uses no custom presentation code", async () => {
     const customPresentationFiles = (await listFiles(V4_DOCS_ROOT, shouldInspectDocsDirectory))
@@ -1496,7 +1496,7 @@ describe("Mintlify customization boundary", () => {
       customPresentationFiles,
       "Mintlify should use native components without custom CSS, JavaScript, JSX, or TSX",
     ).toStrictEqual([]);
-  });
+  }, 30_000); // Parses every MDX page; cold CI runners exceed the 5s default.
 });
 
 async function readTypescriptMethods(): Promise<SdkMethod[]> {

--- a/packages/docs/v4/best-practices/user-data.mdx
+++ b/packages/docs/v4/best-practices/user-data.mdx
@@ -80,7 +80,7 @@ The preserve flag governs only that generated temporary profile, never a directo
 </Tab>
 
 <Tab title="Ruby">
-The Ruby SDK has no preserve flag: the generated temporary directory is always deleted on shutdown, while a `user_data_dir:` you pass yourself is always kept.
+`preserve_user_data_dir` keeps the generated temporary directory after shutdown when you turn it on.
 </Tab>
 </Tabs>
 

--- a/packages/docs/v4/configuration/browser.mdx
+++ b/packages/docs/v4/configuration/browser.mdx
@@ -877,26 +877,36 @@ require "stagehand"
 browser = Stagehand::LocalBrowser.launch(
   headless: false, # Show browser window
   devtools: true, # Open developer tools
-  viewport_width: 1280,
-  viewport_height: 720,
+  viewport: { width: 1280, height: 720 },
   executable_path: "/opt/google/chrome/chrome", # Custom Chrome path
   port: 9222, # Fixed CDP debugging port
+  ignore_default_args: ["--disable-sync"], # Remove specific default launch args
   args: [
     "--disable-web-security",
     "--allow-running-insecure-content",
   ],
-  user_data_dir: "./chrome-user-data", # Persist browser data (kept after close)
+  user_data_dir: "./chrome-user-data", # Persist browser data
+  preserve_user_data_dir: true, # Keep data after closing
   chromium_sandbox: false, # Disable sandbox (adds --no-sandbox)
+  ignore_https_errors: true, # Ignore certificate errors
+  locale: "en-US", # Set browser language
+  device_scale_factor: 1.0, # Display scaling
+  has_touch: false, # Emulate touch input
+  proxy: {
+    server: "http://proxy.example.com:8080",
+    username: "user",
+    password: "pass",
+  },
+  downloads_path: "./downloads", # Download directory
+  accept_downloads: true, # Allow downloads
 )
 stagehand = Stagehand.create(browser: browser)
 ```
-
-The Ruby launcher supports this subset of options. It does not take the ignore-default-args, preserve-user-data-dir, HTTPS-error, locale, device-scale-factor, touch, proxy, or downloads options the other SDKs document. A `user_data_dir` you pass is always preserved; only the temporary profile Stagehand creates for you is deleted on close. When `executable_path` is not set, Stagehand looks for Chrome in the standard install locations and honors the `CHROME_PATH` environment variable.
 </Tab>
 </Tabs>
 
 <Note>
-Authenticated local proxies are not supported yet. Setting a proxy `username` or `password` raises in all three SDKs; a proxy `server` and `bypass` list work everywhere.
+Authenticated local proxies are not supported yet. Setting a proxy `username` or `password` raises in every SDK; a proxy `server` and `bypass` list work everywhere.
 </Note>
 
 #### Default local launch arguments
@@ -946,8 +956,6 @@ When Stagehand launches a local browser, it adds the following Chrome arguments 
   "--enable-features=WebMCPTesting,DevToolsWebMCPSupport",
 ]
 ```
-
-In Ruby, `--window-size` follows the `viewport_width` and `viewport_height` options and defaults to `1280,800`.
 </Tab>
 </Tabs>
 
@@ -1006,6 +1014,7 @@ stagehand.Create(ctx, stagehand.CreateOptions{Browser: browser})
 <Tab title="Ruby">
 ```ruby
 browser = Stagehand::LocalBrowser.launch(
+  ignore_default_args: ["--disable-sync"],
   args: [
     "--disable-features=site-per-process,IsolateOrigins",
     "--renderer-process-limit=6",
@@ -1014,8 +1023,6 @@ browser = Stagehand::LocalBrowser.launch(
 
 stagehand = Stagehand.create(browser: browser)
 ```
-
-The Ruby launcher does not have an ignore-default-args option yet: the default flags always apply, and `args` only appends additional flags.
 </Tab>
 </Tabs>
 
@@ -1236,15 +1243,17 @@ return errors.Join(client.Close(ctx), browser.Close(ctx))
 </Tab>
 
 <Tab title="Ruby">
-The Ruby launcher does not have a keep-alive option yet: `browser.close` always terminates a Chrome that `Stagehand::LocalBrowser.launch` started. To keep a local browser running across scripts, start Chrome yourself with a fixed debugging port and attach over CDP — Stagehand never closes a browser it did not launch:
-
 ```ruby
-browser = Stagehand::LocalBrowser.connect(cdp_url: "http://127.0.0.1:9222")
+browser = Stagehand::LocalBrowser.launch(
+  keep_alive: true,
+  headless: false,
+  port: 9222,
+)
 stagehand = Stagehand.create(browser: browser)
 page = browser.context.pages.first
 page.goto("https://example.com")
 
-# Stagehand disconnects and leaves the browser running
+# Browser window stays open after the script exits
 stagehand.close
 browser.close
 ```

--- a/packages/docs/v4/configuration/models.mdx
+++ b/packages/docs/v4/configuration/models.mdx
@@ -1373,7 +1373,8 @@ def message_content(message)
   blocks.map { |block| content_part(block) }
 end
 
-# The llm.generate handler. Runs synchronously on the SDK's dispatcher thread.
+# The llm.generate handler. Each request runs on its own SDK thread, so
+# concurrent generations are possible.
 def generate_with_openai(params)
   response_format = params.response_format
   text_format = {
@@ -1579,8 +1580,8 @@ func generateWithYourProvider(
 <Tab title="Ruby">
 ```ruby
 # The callback receives a decoded Models::LLMStructuredGenerateParams or
-# Models::LLMMessageGenerateParams and runs synchronously on the SDK's
-# dispatcher thread.
+# Models::LLMMessageGenerateParams; each request runs on its own SDK
+# thread, so concurrent generations are possible.
 def generate_with_your_provider(params)
   # params.messages         Conversation so far
   # params.system_prompt    System instructions

--- a/packages/docs/v4/configuration/observability.mdx
+++ b/packages/docs/v4/configuration/observability.mdx
@@ -1412,8 +1412,8 @@ stagehand = Stagehand.create(
 # ... run your automation
 
 # Inspect what happened, or write it to disk alongside the metrics.
-# Copy under the mutex: on_log runs on the SDK's dispatcher thread, so
-# iterating over `history` directly would race with an incoming log.
+# Copy under the mutex: on_log runs on SDK inbound threads (deliveries can
+# be concurrent), so iterating over `history` directly would race.
 captured = history_mutex.synchronize { history.dup }
 pp captured.select { |entry| entry["level"] == "error" }
 pp stagehand.metrics.to_wire

--- a/packages/docs/v4/reference/page.mdx
+++ b/packages/docs/v4/reference/page.mdx
@@ -2476,8 +2476,8 @@ subscription.unsubscribe
 
 <ParamField path="listener" type="Proc">
   A required block that receives each `Models::PageCDPEvent` with the event method, raw
-  parameters, session ID, target ID, and page ID. The block runs on the SDK's dispatcher
-  thread, so a slow block delays other inbound work.
+  parameters, session ID, target ID, and page ID. Each delivery runs on its own SDK
+  thread and deliveries can be concurrent, so synchronize any shared state.
 </ParamField>
 
 <ResponseField name="result" type="CDPSubscription">

--- a/packages/sdk-ruby/ESTIMATE.md
+++ b/packages/sdk-ruby/ESTIMATE.md
@@ -16,34 +16,34 @@ Python and Go SDKs are built.
 
 ## What the spike proved (de-risked)
 
-| Risk | Outcome |
-|---|---|
-| No JSON-Schema→Ruby codegen exists | Custom stdlib-only generator, 274 LOC, covers all 234 defs + method registries, `--check` drift mode wired into `just generate`/`just check` |
-| Wire casing | Free — the schema is already snake_case; opaque containers pass through verbatim (fixture round-trip tested) |
-| Sync Ruby ↔ bidirectional RPC | Background-reader-thread model (Go-style) works; `websocket-driver` + own TCP/SSL socket, no reactor framework needed |
-| Chrome without Playwright | Hand-rolled launcher ported from Python's `browser.py` works headless + headed on macOS |
-| Extension packaging | Ruby zip is **byte-identical** to the Python SDK's deterministic archive (same SHA-256) |
-| No Browserbase Ruby SDK exists | Hand-rolled 4-endpoint REST client (~130 LOC) suffices, mirroring Go |
-| End-to-end | `goto → observe → act → extract` verified live on a local Chrome (transport) and on a Browserbase session (full AI loop incl. extension upload + Model Gateway + session release) |
+| Risk                               | Outcome                                                                                                                                                                           |
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| No JSON-Schema→Ruby codegen exists | Custom stdlib-only generator, 274 LOC, covers all 234 defs + method registries, `--check` drift mode wired into `just generate`/`just check`                                      |
+| Wire casing                        | Free — the schema is already snake_case; opaque containers pass through verbatim (fixture round-trip tested)                                                                      |
+| Sync Ruby ↔ bidirectional RPC      | Background-reader-thread model (Go-style) works; `websocket-driver` + own TCP/SSL socket, no reactor framework needed                                                             |
+| Chrome without Playwright          | Hand-rolled launcher ported from Python's `browser.py` works headless + headed on macOS                                                                                           |
+| Extension packaging                | Ruby zip is **byte-identical** to the Python SDK's deterministic archive (same SHA-256)                                                                                           |
+| No Browserbase Ruby SDK exists     | Hand-rolled 4-endpoint REST client (~130 LOC) suffices, mirroring Go                                                                                                              |
+| End-to-end                         | `goto → observe → act → extract` verified live on a local Chrome (transport) and on a Browserbase session (full AI loop incl. extension upload + Model Gateway + session release) |
 
 Spike size: ~2,400 hand-written LOC + ~2,000 generated + ~800 tests. Python comparison:
 ~4,900 hand-written + ~3,600 generated — a fair proxy for the finished Ruby size.
 
 ## Work breakdown to production parity
 
-| # | Item | Weeks |
-|---|---|---|
-| A | Walking skeleton (this spike) | 2.5–3 *(sunk)* |
-| B | Full method surface (~62 remaining: context 14, page ~26, locator 17, response 6, clipboard, webmcp, file upload, callback_batch passthrough) — mechanical wrapper + tests per method, batched by namespace | 3–4 |
-| C | Client-side LLM (`llm.generate` inbound handler, message/tool unions, custom-LLM example) | 1 |
-| D | Validation hardening: strict unions, input ergonomics, RBS signatures, thread-safety soak | 1–1.5 |
-| E | 11-example set + `example-parity` compliance | 0.5–1 |
-| F | Parity tooling: ast-grep Ruby lane (`@ast-grep/lang-ruby` availability is the biggest unknown; prism-based fallback +0.5–1 wk) + extend `rules/ast-grep/*` | 1–1.5 |
-| G | Docs: Ruby tabs across `docs/v4/reference/*` + guides + `sdk-reference.test.ts` | 1 |
-| H | Release + CI: turbo task, changesets version proxy, `sync-ruby-version.ts`, extension embedding in the gem, RubyGems trusted publishing + alpha lane, CI matrix (Ruby 3.2–3.4 × macOS/Linux), **Windows launcher** | 1.5–2 |
-| I | Beta hardening buffer (real-world sites, large payloads, memory/soak) | 1–1.5 |
-| | **Total beyond spike** | **10–13.5** |
-| | **Total including spike** | **~12.5–16.5** |
+| #   | Item                                                                                                                                                                                                               | Weeks          |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------- |
+| A   | Walking skeleton (this spike)                                                                                                                                                                                      | 2.5–3 _(sunk)_ |
+| B   | Full method surface (~62 remaining: context 14, page ~26, locator 17, response 6, clipboard, webmcp, file upload, callback_batch passthrough) — mechanical wrapper + tests per method, batched by namespace        | 3–4            |
+| C   | Client-side LLM (`llm.generate` inbound handler, message/tool unions, custom-LLM example)                                                                                                                          | 1              |
+| D   | Validation hardening: strict unions, input ergonomics, RBS signatures, thread-safety soak                                                                                                                          | 1–1.5          |
+| E   | 11-example set + `example-parity` compliance                                                                                                                                                                       | 0.5–1          |
+| F   | Parity tooling: ast-grep Ruby lane (`@ast-grep/lang-ruby` availability is the biggest unknown; prism-based fallback +0.5–1 wk) + extend `rules/ast-grep/*`                                                         | 1–1.5          |
+| G   | Docs: Ruby tabs across `docs/v4/reference/*` + guides + `sdk-reference.test.ts`                                                                                                                                    | 1              |
+| H   | Release + CI: turbo task, changesets version proxy, `sync-ruby-version.ts`, extension embedding in the gem, RubyGems trusted publishing + alpha lane, CI matrix (Ruby 3.2–3.4 × macOS/Linux), **Windows launcher** | 1.5–2          |
+| I   | Beta hardening buffer (real-world sites, large payloads, memory/soak)                                                                                                                                              | 1–1.5          |
+|     | **Total beyond spike**                                                                                                                                                                                             | **10–13.5**    |
+|     | **Total including spike**                                                                                                                                                                                          | **~12.5–16.5** |
 
 ## Ongoing cost
 

--- a/packages/sdk-ruby/Gemfile.lock
+++ b/packages/sdk-ruby/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     stagehand (4.0.0)
+      opentelemetry-api (~> 1.5)
       websocket-driver (~> 0.8)
 
 GEM
@@ -10,6 +11,8 @@ GEM
     base64 (0.3.0)
     logger (1.7.0)
     minitest (5.27.0)
+    opentelemetry-api (1.11.0)
+      logger
     rake (13.4.2)
     rbs (3.10.4)
       logger
@@ -34,6 +37,7 @@ CHECKSUMS
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
+  opentelemetry-api (1.11.0) sha256=218c840170fa473974756668b32b6989570de07c7d3864627960209f189247e2
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
   rbs (3.10.4) sha256=b17d7c4be4bb31a11a3b529830f0aa206a807ca42f2e7921a3027dfc6b7e5ce8
   stagehand (4.0.0)

--- a/packages/sdk-ruby/README.md
+++ b/packages/sdk-ruby/README.md
@@ -127,14 +127,24 @@ SOAK=20 bundle exec rake test # scale up the thread-safety soak suite
 ruby scripts/generate.rb      # regenerate models (also part of `just generate`)
 ```
 
-## Known deviations from the sibling SDKs
+## Parity status
 
 - All 77 protocol methods are wrapped — the complete method surface,
   including inbound `llm.generate` (client-side LLMs).
+- `LocalBrowser.launch` carries the full sibling option set (proxy, locale,
+  viewport, downloads, keep_alive, ignore_default_args, …); the
+  `sdk-client-schema-parity` lane holds the kwargs equal to the TS schemas.
 - Wire models validate strictly: scalar and enum fields check types on
   decode and construction; union and structural mismatches raise.
-- No OpenTelemetry trace propagation (`traceparent` is simply omitted).
-- `Browserbase.launch(browser_settings:)` is a camelCase passthrough hash.
+- Outbound requests carry W3C `traceparent`/`tracestate` when an
+  OpenTelemetry span is current (`opentelemetry-api` is a runtime
+  dependency, like the sibling SDKs).
+- Inbound requests and notification deliveries each run on their own
+  thread, like Python's per-item tasks. One retained deviation: a
+  notification listener that raises is logged and skipped rather than
+  tearing down the client.
+- `Browserbase.launch(browser_settings:)` is a camelCase passthrough hash
+  (matches the TS open schema).
 - Wired into every ast-grep parity lane (`rpc`, `cdp`, `example`, `sdk`,
   `sdk-field-pipeline`, `sdk-client-schema-parity`), the docs reference
   validation (`packages/docs/tests`), CI, and the release tooling. Ruby tabs

--- a/packages/sdk-ruby/README.md
+++ b/packages/sdk-ruby/README.md
@@ -52,8 +52,8 @@ example set, eval-task ports, docs tabs, and cross-language parity lanes.
   and WebMCP (`tools` → invoke/result/cancel).
 - **Locator** — `page.locator(selector)` → all 17 locator methods
   (`click/fill/type/hover/scroll_to/count/text_content/inner_text/inner_html/
-  input_value/visible?/checked?/centroid/highlight/send_click_event/
-  select_option/set_input_files` + `first`/`nth`; file uploads take paths or
+input_value/visible?/checked?/centroid/highlight/send_click_event/
+select_option/set_input_files` + `first`/`nth`; file uploads take paths or
   `Stagehand::FilePayload`, 50 MiB/file).
 - **Context** — `pages/new_page/active_page/set_active_page/close`, cookies
   (`cookies/add_cookies/clear_cookies` with String/Regexp filters), clipboard
@@ -94,17 +94,17 @@ self-contained and runnable as `bundle exec ruby examples/<name>.rb
 [--browserbase]`. The `example-parity` ast-grep lane keeps their inventory and
 SDK operations aligned with the sibling SDKs.
 
-| Example | Notes |
-|---|---|
+| Example                              | Notes                                                                         |
+| ------------------------------------ | ----------------------------------------------------------------------------- |
 | `act.rb`, `observe.rb`, `extract.rb` | example.com; local runs need OPENAI_API_KEY, `--browserbase` uses the Gateway |
-| `model_gateway.rb` | Browserbase-only; no model configured (Gateway picks one) |
-| `caching.rb` | Browserbase-only; `cache: true` + `metadata.cache` round-trip |
-| `custom_logging.rb` | `on_log:` callback appending JSONL to `stagehand.jsonl` |
-| `file_upload.rb` | locator.set_input_files + evaluate; no LLM needed |
-| `batch.rb` | callback batch, no LLM needed |
-| `page_events.rb` | page.on console events + AI extract |
-| `custom_llm.rb` | bring-your-own-LLM via `llm.generate` (OPENAI_API_KEY or AI_GATEWAY_API_KEY) |
-| `webmcp.rb` | page-registered tools via `page.tools` → invoke → result; no LLM needed |
+| `model_gateway.rb`                   | Browserbase-only; no model configured (Gateway picks one)                     |
+| `caching.rb`                         | Browserbase-only; `cache: true` + `metadata.cache` round-trip                 |
+| `custom_logging.rb`                  | `on_log:` callback appending JSONL to `stagehand.jsonl`                       |
+| `file_upload.rb`                     | locator.set_input_files + evaluate; no LLM needed                             |
+| `batch.rb`                           | callback batch, no LLM needed                                                 |
+| `page_events.rb`                     | page.on console events + AI extract                                           |
+| `custom_llm.rb`                      | bring-your-own-LLM via `llm.generate` (OPENAI_API_KEY or AI_GATEWAY_API_KEY)  |
+| `webmcp.rb`                          | page-registered tools via `page.tools` → invoke → result; no LLM needed       |
 
 `examples/extras/` holds Ruby-only walkthroughs outside the canonical set
 (`demo.rb`, `page_interactions.rb`, `context_and_response.rb`,

--- a/packages/sdk-ruby/README.md
+++ b/packages/sdk-ruby/README.md
@@ -17,9 +17,10 @@ example set, eval-task ports, docs tabs, and cross-language parity lanes.
   attach (with wake nudge), `__stagehandSendToHost` binding, runtime marker + semver
   negotiation, `Runtime.evaluate` double-JSON envelope delivery.
 - **JSON-RPC client** (`rpc_client.rb`) — strict envelopes, per-method timeout table,
-  notification buffering (`stagehand.log` → stderr), an inbound dispatcher thread
-  serving server→client requests (`on_request`, used for `llm.generate`) and
-  notification listeners, deterministic shutdown.
+  notification buffering (`stagehand.log` → stderr), inbound server→client
+  requests (`on_request`, used for `llm.generate`) and notification listeners
+  each running on their own tracked thread (like Python's per-item tasks),
+  deterministic shutdown.
 - **Local Chrome** (`browser.rb`) — hand-rolled launcher (no Playwright): Chrome
   discovery, temp profile, the Stagehand flag set, `Extensions.loadUnpacked`.
 - **Browserbase** (`browserbase_client.rb`, `browserbase_session.rb`,
@@ -135,9 +136,6 @@ ruby scripts/generate.rb      # regenerate models (also part of `just generate`)
   structural mismatches do raise.
 - No OpenTelemetry trace propagation (`traceparent` is simply omitted).
 - `Browserbase.launch(browser_settings:)` is a camelCase passthrough hash.
-- Inbound work (request handlers, notification listeners including `page.on`
-  blocks) runs on one dispatcher thread: handlers may issue RPC calls, but a
-  slow handler delays later inbound work (Python runs these concurrently).
 - Wired into every ast-grep parity lane (`rpc`, `cdp`, `example`, `sdk`,
   `sdk-field-pipeline`, `sdk-client-schema-parity`), the docs reference
   validation (`packages/docs/tests`), CI, and the release tooling. Ruby tabs

--- a/packages/sdk-ruby/README.md
+++ b/packages/sdk-ruby/README.md
@@ -131,9 +131,8 @@ ruby scripts/generate.rb      # regenerate models (also part of `just generate`)
 
 - All 77 protocol methods are wrapped — the complete method surface,
   including inbound `llm.generate` (client-side LLMs).
-- No strict scalar validation inside wire models (field types are not
-  checked; the extension re-validates everything server-side). Union and
-  structural mismatches do raise.
+- Wire models validate strictly: scalar and enum fields check types on
+  decode and construction; union and structural mismatches raise.
 - No OpenTelemetry trace propagation (`traceparent` is simply omitted).
 - `Browserbase.launch(browser_settings:)` is a camelCase passthrough hash.
 - Wired into every ast-grep parity lane (`rpc`, `cdp`, `example`, `sdk`,

--- a/packages/sdk-ruby/examples/custom_llm.rb
+++ b/packages/sdk-ruby/examples/custom_llm.rb
@@ -44,7 +44,8 @@ def message_text(content)
   end.join("\n")
 end
 
-# The llm.generate handler. Runs on the SDK's dispatcher thread.
+# The llm.generate handler. Each request runs on its own SDK thread, so
+# concurrent generations are possible.
 def generate_with_openai(params)
   unless params.is_a?(Stagehand::Models::LLMStructuredGenerateParams)
     raise ArgumentError, "This example only supports structured generation"

--- a/packages/sdk-ruby/examples/page_events.rb
+++ b/packages/sdk-ruby/examples/page_events.rb
@@ -46,7 +46,8 @@ begin
 
     console_events = Thread::Queue.new
     subscription = page.on("console") do |event|
-      # Runs on the RPC dispatcher thread: keep it quick, hand the event over.
+      # Runs on an SDK inbound thread (deliveries may be concurrent): hand
+      # the event over to the queue rather than doing work here.
       console_events << event if event.params.is_a?(Hash) && event.params["type"] == "log"
     end
 

--- a/packages/sdk-ruby/lib/stagehand/browser.rb
+++ b/packages/sdk-ruby/lib/stagehand/browser.rb
@@ -9,6 +9,7 @@ require_relative "timeouts"
 require_relative "cdp_client"
 require_relative "extension_assets"
 require_relative "browserbase_session"
+require_relative "validation"
 require_relative "generated/models"
 
 module Stagehand
@@ -110,47 +111,82 @@ module Stagehand
     module_function
 
     def launch(
-      headless: nil,
-      devtools: nil,
-      chromium_sandbox: nil,
       args: nil,
       executable_path: nil,
       port: nil,
       user_data_dir: nil,
-      viewport_width: 1280,
-      viewport_height: 800
+      preserve_user_data_dir: nil,
+      headless: nil,
+      devtools: nil,
+      chromium_sandbox: nil,
+      ignore_default_args: nil,
+      proxy: nil,
+      locale: nil,
+      viewport: nil,
+      device_scale_factor: nil,
+      has_touch: nil,
+      ignore_https_errors: nil,
+      downloads_path: nil,
+      accept_downloads: nil,
+      keep_alive: nil
     )
+      proxy = normalize_proxy(proxy)
+      viewport = normalize_viewport(viewport)
+      Validation.positive_integer!(port, "port", max: 65_535) unless port.nil?
+      unless ignore_default_args.nil? || ignore_default_args == true || ignore_default_args.is_a?(Array)
+        raise ArgumentError, "ignore_default_args must be true or an Array of flag strings"
+      end
+      if accept_downloads == true && downloads_path.nil?
+        raise ArgumentError, "downloads_path is required when accept_downloads is true"
+      end
+
       deadline = Deadline.stagehand_init
       chrome_path = executable_path || find_chrome_path
       debug_port = port || available_port
       temporary_profile = user_data_dir.nil?
       profile_dir = user_data_dir || Dir.mktmpdir("stagehand-chrome-")
 
-      flags = [
-        *DEFAULT_CHROME_FLAGS,
-        *STAGEHAND_DEFAULT_FLAGS,
-        "--window-size=#{viewport_width},#{viewport_height}",
-        WEBMCP_CHROME_FLAG,
-        "--remote-debugging-port=#{debug_port}",
-        "--user-data-dir=#{profile_dir}",
-        *(headless ? ["--headless"] : []),
-        *(devtools ? ["--auto-open-devtools-for-tabs"] : []),
-        *(ENV["CI"] || chromium_sandbox == false ? ["--no-sandbox"] : []),
-        *(args || []),
-        "about:blank",
-      ]
+      flags = launch_flags(
+        debug_port: debug_port,
+        profile_dir: profile_dir,
+        headless: headless,
+        devtools: devtools,
+        chromium_sandbox: chromium_sandbox,
+        args: args,
+        ignore_default_args: ignore_default_args,
+        proxy: proxy,
+        locale: locale,
+        viewport: viewport,
+        device_scale_factor: device_scale_factor,
+        has_touch: has_touch,
+        ignore_https_errors: ignore_https_errors,
+      )
+
+      remove_profile = lambda do
+        FileUtils.remove_entry(profile_dir, true) if temporary_profile && preserve_user_data_dir != true
+      end
 
       # POSIX gets a process group so the whole Chrome tree can be signalled;
       # Windows has no process groups — new_pgroup detaches from Ctrl-C.
       spawn_options = { in: File::NULL, out: File::NULL, err: File::NULL }
       spawn_options[Gem.win_platform? ? :new_pgroup : :pgroup] = true
-      pid = Process.spawn(chrome_path, *flags, **spawn_options)
+      begin
+        pid = Process.spawn(chrome_path, *flags, **spawn_options)
+      rescue StandardError
+        remove_profile.call
+        raise
+      end
       waiter = Process.detach(pid)
       close_chrome = lambda do
         stop_process(pid, waiter)
       ensure
-        FileUtils.remove_entry(profile_dir, true) if temporary_profile
+        remove_profile.call
       end
+
+      # keep_alive relinquishes ownership: close tears down only the CDP
+      # client, leaving Chrome running and the profile in place.
+      close_source = keep_alive ? nil : close_chrome
+      set_download_behavior = download_behavior_hook(downloads_path, accept_downloads)
 
       begin
         connect_browser(
@@ -160,12 +196,53 @@ module Stagehand
           extension_dir: ExtensionAssets.extension_directory,
           deadline: deadline,
           worker_init_metadata: WorkerInitMetadata.new(api_key: nil, browser: nil),
-          close_source: close_chrome,
+          close_source: close_source,
+          after_connect: set_download_behavior,
         )
       rescue Exception
-        close_chrome.call
+        close_chrome.call unless keep_alive
         raise
       end
+    end
+
+    # Pure options -> Chrome flag list mapping (unit-testable without Chrome).
+    # `ignore_default_args` filters exactly the default groups: the shared
+    # Chrome defaults, the Stagehand pair, the default --window-size, and the
+    # WebMCP flag. An explicit viewport always re-adds --window-size.
+    def launch_flags(
+      debug_port:, profile_dir:, headless: nil, devtools: nil, chromium_sandbox: nil,
+      args: nil, ignore_default_args: nil, proxy: nil, locale: nil, viewport: nil,
+      device_scale_factor: nil, has_touch: nil, ignore_https_errors: nil, ci: !ENV["CI"].nil?
+    )
+      drop_all = ignore_default_args == true
+      ignored = ignore_default_args.is_a?(Array) ? ignore_default_args : []
+      keep = ->(flag) { !drop_all && !ignored.include?(flag) }
+
+      flags = (DEFAULT_CHROME_FLAGS + STAGEHAND_DEFAULT_FLAGS).select(&keep)
+      size = viewport ? "--window-size=#{viewport[:width]},#{viewport[:height]}" : "--window-size=1280,800"
+      flags << size if viewport || keep.call(size)
+      flags << WEBMCP_CHROME_FLAG if keep.call(WEBMCP_CHROME_FLAG)
+      flags << "--remote-debugging-port=#{debug_port}"
+      flags << "--user-data-dir=#{profile_dir}"
+      flags << "--headless" if headless == true
+      flags << "--auto-open-devtools-for-tabs" if devtools == true
+      flags << "--no-sandbox" if ci || chromium_sandbox == false
+      unless proxy.nil?
+        flags << "--proxy-server=#{proxy[:server]}"
+        bypass = proxy[:bypass]
+        flags << "--proxy-bypass-list=#{bypass}" if bypass && !bypass.to_s.empty?
+      end
+      flags << "--lang=#{locale}" unless locale.nil?
+      unless device_scale_factor.nil?
+        # Shortest-form number: 2 rather than 2.0 (matches the Go launcher).
+        scale = (device_scale_factor % 1).zero? ? device_scale_factor.to_i : device_scale_factor
+        flags << "--force-device-scale-factor=#{scale}"
+      end
+      flags << "--touch-events=enabled" if has_touch == true
+      flags << "--ignore-certificate-errors" if ignore_https_errors == true
+      flags.concat(args) unless args.nil?
+      flags << "about:blank"
+      flags
     end
 
     def connect(cdp_url:, extension_id: nil)
@@ -181,8 +258,46 @@ module Stagehand
       )
     end
 
+    # Normalizes a proxy option Hash; authenticated local proxies are
+    # rejected before launch, like the sibling SDKs.
+    def normalize_proxy(proxy)
+      return nil if proxy.nil?
+      raise ArgumentError, "proxy must be a Hash with a :server key" unless proxy.is_a?(Hash)
+      proxy = proxy.transform_keys(&:to_sym)
+      server = proxy[:server]
+      if (server.nil? || server.to_s.empty?) && (proxy[:bypass] || proxy[:username] || proxy[:password])
+        raise ArgumentError, "proxy server is required when configuring a local proxy"
+      end
+      raise ArgumentError, "proxy must be a Hash with a :server key" if server.nil? || server.to_s.empty?
+      if proxy[:username] || proxy[:password]
+        raise NotImplementedError, "Authenticated local browser proxies are not implemented yet"
+      end
+      proxy
+    end
+
+    def normalize_viewport(viewport)
+      return nil if viewport.nil?
+      raise ArgumentError, "viewport must be a Hash with :width and :height" unless viewport.is_a?(Hash)
+      viewport = viewport.transform_keys(&:to_sym)
+      Validation.positive_integer!(viewport[:width], "viewport width")
+      Validation.positive_integer!(viewport[:height], "viewport height")
+      viewport
+    end
+
+    # Downloads configure through CDP after connect (no Chrome flags), only
+    # when either option is provided — mirroring the sibling SDKs.
+    def download_behavior_hook(downloads_path, accept_downloads)
+      return nil if downloads_path.nil? && accept_downloads.nil?
+      lambda do |cdp_client|
+        params = { "behavior" => accept_downloads == false ? "deny" : "allow" }
+        params["downloadPath"] = downloads_path.to_s unless downloads_path.nil?
+        cdp_client.send_command("Browser.setDownloadBehavior", params)
+      end
+    end
+
     def connect_browser(provider:, origin:, cdp_url:, deadline:, worker_init_metadata:, close_source:,
-                        extension_dir: nil, extension_id: nil, preloaded_extension: false, session_id: nil)
+                        extension_dir: nil, extension_id: nil, preloaded_extension: false, session_id: nil,
+                        after_connect: nil)
       cdp_client = CDPClient.connect(
         cdp_url: cdp_url,
         extension_dir: extension_dir&.to_s,
@@ -190,6 +305,12 @@ module Stagehand
         preloaded_extension: preloaded_extension,
         deadline: deadline,
       )
+      begin
+        after_connect&.call(cdp_client)
+      rescue Exception
+        cdp_client.close
+        raise
+      end
       close_callback = lambda do
         cdp_client.close
       ensure

--- a/packages/sdk-ruby/lib/stagehand/generated/models.rb
+++ b/packages/sdk-ruby/lib/stagehand/generated/models.rb
@@ -10,19 +10,19 @@ module Stagehand
 
     class StagehandInitParams < Stagehand::Wire::Model
       FIELDS = {
-        "protocol_version" => nil,
+        "protocol_version" => :string,
         "client_info" => "ImplementationInfo",
-        "browser_cdp_url" => nil,
-        "api_key" => nil,
-        "api_url" => nil,
+        "browser_cdp_url" => :string,
+        "api_key" => :string,
+        "api_url" => :string,
         "browser" => "BrowserSessionMetadata",
         "model" => [:union, ["ModelConfig", "ClientModelReference"].freeze].freeze,
         "telemetry" => "TelemetryConfig",
-        "log_level" => nil,
-        "system_prompt" => nil,
-        "self_heal" => nil,
-        "dom_settle_timeout_ms" => nil,
-        "cache" => nil,
+        "log_level" => :string,
+        "system_prompt" => :string,
+        "self_heal" => :boolean,
+        "dom_settle_timeout_ms" => :integer,
+        "cache" => "Caching",
       }.freeze
       REQUIRED = %w[protocol_version client_info].freeze
       attr_reader :protocol_version, :client_info, :browser_cdp_url, :api_key, :api_url, :browser, :model, :telemetry, :log_level, :system_prompt, :self_heal, :dom_settle_timeout_ms, :cache
@@ -30,8 +30,8 @@ module Stagehand
 
     class ImplementationInfo < Stagehand::Wire::Model
       FIELDS = {
-        "name" => nil,
-        "version" => nil,
+        "name" => :string,
+        "version" => :string,
       }.freeze
       REQUIRED = %w[name version].freeze
       attr_reader :name, :version
@@ -39,8 +39,8 @@ module Stagehand
 
     class BrowserSessionMetadata < Stagehand::Wire::Model
       FIELDS = {
-        "session_id" => nil,
-        "region" => nil,
+        "session_id" => :string,
+        "region" => "BrowserbaseRegion",
       }.freeze
       REQUIRED = %w[session_id].freeze
       attr_reader :session_id, :region
@@ -52,9 +52,9 @@ module Stagehand
 
     class ModelConfig < Stagehand::Wire::Model
       FIELDS = {
-        "api_key" => nil,
-        "headers" => nil,
-        "model_name" => nil,
+        "api_key" => :string,
+        "headers" => [:map, :string].freeze,
+        "model_name" => "ModelName",
       }.freeze
       REQUIRED = %w[model_name].freeze
       attr_reader :api_key, :headers, :model_name
@@ -62,7 +62,7 @@ module Stagehand
 
     class ClientModelReference < Stagehand::Wire::Model
       FIELDS = {
-        "source" => nil,
+        "source" => :string,
       }.freeze
       REQUIRED = %w[source].freeze
       attr_reader :source
@@ -78,8 +78,8 @@ module Stagehand
 
     class TelemetryTraces < Stagehand::Wire::Model
       FIELDS = {
-        "endpoint" => nil,
-        "headers" => nil,
+        "endpoint" => :string,
+        "headers" => [:map, :string].freeze,
       }.freeze
       REQUIRED = %w[endpoint].freeze
       attr_reader :endpoint, :headers
@@ -87,7 +87,7 @@ module Stagehand
 
     class StagehandInitResult < Stagehand::Wire::Model
       FIELDS = {
-        "initialized" => nil,
+        "initialized" => :boolean,
         "pages" => [:array, "PageRef"].freeze,
       }.freeze
       REQUIRED = %w[initialized pages].freeze
@@ -96,9 +96,9 @@ module Stagehand
 
     class PageRef < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
-        "url" => nil,
-        "title" => nil,
+        "page_id" => :string,
+        "url" => :string,
+        "title" => :string,
       }.freeze
       REQUIRED = %w[page_id].freeze
       attr_reader :page_id, :url, :title
@@ -111,7 +111,7 @@ module Stagehand
 
     class StagehandCloseResult < Stagehand::Wire::Model
       FIELDS = {
-        "closed" => nil,
+        "closed" => :boolean,
       }.freeze
       REQUIRED = %w[closed].freeze
       attr_reader :closed
@@ -119,8 +119,8 @@ module Stagehand
 
     class StagehandActParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
-        "instruction" => [:union, ["Action", nil].freeze].freeze,
+        "page_id" => :string,
+        "instruction" => [:union, [:string, "Action"].freeze].freeze,
         "options" => "ActOptions",
       }.freeze
       REQUIRED = %w[page_id instruction].freeze
@@ -129,10 +129,10 @@ module Stagehand
 
     class Action < Stagehand::Wire::Model
       FIELDS = {
-        "selector" => nil,
-        "description" => nil,
-        "method" => nil,
-        "arguments" => nil,
+        "selector" => :string,
+        "description" => :string,
+        "method" => :string,
+        "arguments" => [:array, :string].freeze,
       }.freeze
       REQUIRED = %w[selector description].freeze
       attr_reader :selector, :description, :method, :arguments
@@ -142,10 +142,10 @@ module Stagehand
       FIELDS = {
         "model" => "ModelConfig",
         "variables" => "Variables",
-        "timeout" => nil,
+        "timeout" => :number,
         "locator" => "Locator",
         "ignore_locators" => [:array, "Locator"].freeze,
-        "cache" => nil,
+        "cache" => "Caching",
       }.freeze
       REQUIRED = [].freeze
       attr_reader :model, :variables, :timeout, :locator, :ignore_locators, :cache
@@ -153,8 +153,8 @@ module Stagehand
 
     class DescribedVariableValue < Stagehand::Wire::Model
       FIELDS = {
-        "value" => nil,
-        "description" => nil,
+        "value" => "VariablePrimitive",
+        "description" => :string,
       }.freeze
       REQUIRED = %w[value].freeze
       attr_reader :value, :description
@@ -162,8 +162,8 @@ module Stagehand
 
     class Locator < Stagehand::Wire::Model
       FIELDS = {
-        "selector" => nil,
-        "nth" => nil,
+        "selector" => :string,
+        "nth" => :integer,
       }.freeze
       REQUIRED = %w[selector].freeze
       attr_reader :selector, :nth
@@ -180,9 +180,9 @@ module Stagehand
 
     class ActResultData < Stagehand::Wire::Model
       FIELDS = {
-        "success" => nil,
-        "message" => nil,
-        "action_description" => nil,
+        "success" => :boolean,
+        "message" => :string,
+        "action_description" => :string,
         "actions" => [:array, "Action"].freeze,
       }.freeze
       REQUIRED = %w[success message action_description actions].freeze
@@ -191,7 +191,7 @@ module Stagehand
 
     class StagehandResultMetadata < Stagehand::Wire::Model
       FIELDS = {
-        "action_id" => nil,
+        "action_id" => :string,
         "cache" => "CacheMetadata",
         "usage" => "StagehandResultUsage",
       }.freeze
@@ -205,9 +205,9 @@ module Stagehand
 
     class CacheTokenSavings < Stagehand::Wire::Model
       FIELDS = {
-        "input_tokens" => nil,
-        "output_tokens" => nil,
-        "total_tokens" => nil,
+        "input_tokens" => :integer,
+        "output_tokens" => :integer,
+        "total_tokens" => :integer,
       }.freeze
       REQUIRED = [].freeze
       attr_reader :input_tokens, :output_tokens, :total_tokens
@@ -215,10 +215,10 @@ module Stagehand
 
     class CacheMetadata < Stagehand::Wire::Model
       FIELDS = {
-        "status" => nil,
-        "count" => nil,
-        "threshold" => nil,
-        "miss_reason" => nil,
+        "status" => "CacheStatus",
+        "count" => :integer,
+        "threshold" => :integer,
+        "miss_reason" => :string,
         "tokens_saved" => "CacheTokenSavings",
       }.freeze
       REQUIRED = %w[status].freeze
@@ -227,11 +227,11 @@ module Stagehand
 
     class StagehandResultUsage < Stagehand::Wire::Model
       FIELDS = {
-        "input_tokens" => nil,
-        "output_tokens" => nil,
-        "reasoning_tokens" => nil,
-        "cached_input_tokens" => nil,
-        "inference_time_ms" => nil,
+        "input_tokens" => :integer,
+        "output_tokens" => :integer,
+        "reasoning_tokens" => :integer,
+        "cached_input_tokens" => :integer,
+        "inference_time_ms" => :integer,
       }.freeze
       REQUIRED = [].freeze
       attr_reader :input_tokens, :output_tokens, :reasoning_tokens, :cached_input_tokens, :inference_time_ms
@@ -239,8 +239,8 @@ module Stagehand
 
     class StagehandObserveParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
-        "instruction" => nil,
+        "page_id" => :string,
+        "instruction" => :string,
         "options" => "ObserveOptions",
       }.freeze
       REQUIRED = %w[page_id].freeze
@@ -251,10 +251,10 @@ module Stagehand
       FIELDS = {
         "model" => "ModelConfig",
         "variables" => "Variables",
-        "timeout" => nil,
+        "timeout" => :number,
         "locator" => "Locator",
         "ignore_locators" => [:array, "Locator"].freeze,
-        "cache" => nil,
+        "cache" => "Caching",
       }.freeze
       REQUIRED = [].freeze
       attr_reader :model, :variables, :timeout, :locator, :ignore_locators, :cache
@@ -271,9 +271,9 @@ module Stagehand
 
     class StagehandExtractParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
-        "instruction" => nil,
-        "schema" => nil,
+        "page_id" => :string,
+        "instruction" => :string,
+        "schema" => "__schema0",
         "options" => "ExtractOptions",
       }.freeze
       REQUIRED = %w[page_id instruction].freeze
@@ -283,11 +283,11 @@ module Stagehand
     class ExtractOptions < Stagehand::Wire::Model
       FIELDS = {
         "model" => "ModelConfig",
-        "timeout" => nil,
+        "timeout" => :number,
         "locator" => "Locator",
         "ignore_locators" => [:array, "Locator"].freeze,
-        "screenshot" => nil,
-        "cache" => nil,
+        "screenshot" => :boolean,
+        "cache" => "Caching",
       }.freeze
       REQUIRED = [].freeze
       attr_reader :model, :timeout, :locator, :ignore_locators, :screenshot, :cache
@@ -295,7 +295,7 @@ module Stagehand
 
     class ExtractResult < Stagehand::Wire::Model
       FIELDS = {
-        "data" => nil,
+        "data" => "__schema1",
         "metadata" => "StagehandResultMetadata",
       }.freeze
       REQUIRED = %w[data metadata].freeze
@@ -304,26 +304,26 @@ module Stagehand
 
     class StagehandMetrics < Stagehand::Wire::Model
       FIELDS = {
-        "act_prompt_tokens" => nil,
-        "act_completion_tokens" => nil,
-        "act_reasoning_tokens" => nil,
-        "act_cached_input_tokens" => nil,
-        "act_inference_time_ms" => nil,
-        "extract_prompt_tokens" => nil,
-        "extract_completion_tokens" => nil,
-        "extract_reasoning_tokens" => nil,
-        "extract_cached_input_tokens" => nil,
-        "extract_inference_time_ms" => nil,
-        "observe_prompt_tokens" => nil,
-        "observe_completion_tokens" => nil,
-        "observe_reasoning_tokens" => nil,
-        "observe_cached_input_tokens" => nil,
-        "observe_inference_time_ms" => nil,
-        "total_prompt_tokens" => nil,
-        "total_completion_tokens" => nil,
-        "total_reasoning_tokens" => nil,
-        "total_cached_input_tokens" => nil,
-        "total_inference_time_ms" => nil,
+        "act_prompt_tokens" => :number,
+        "act_completion_tokens" => :number,
+        "act_reasoning_tokens" => :number,
+        "act_cached_input_tokens" => :number,
+        "act_inference_time_ms" => :number,
+        "extract_prompt_tokens" => :number,
+        "extract_completion_tokens" => :number,
+        "extract_reasoning_tokens" => :number,
+        "extract_cached_input_tokens" => :number,
+        "extract_inference_time_ms" => :number,
+        "observe_prompt_tokens" => :number,
+        "observe_completion_tokens" => :number,
+        "observe_reasoning_tokens" => :number,
+        "observe_cached_input_tokens" => :number,
+        "observe_inference_time_ms" => :number,
+        "total_prompt_tokens" => :number,
+        "total_completion_tokens" => :number,
+        "total_reasoning_tokens" => :number,
+        "total_cached_input_tokens" => :number,
+        "total_inference_time_ms" => :number,
       }.freeze
       REQUIRED = %w[act_prompt_tokens act_completion_tokens act_reasoning_tokens act_cached_input_tokens act_inference_time_ms extract_prompt_tokens extract_completion_tokens extract_reasoning_tokens extract_cached_input_tokens extract_inference_time_ms observe_prompt_tokens observe_completion_tokens observe_reasoning_tokens observe_cached_input_tokens observe_inference_time_ms total_prompt_tokens total_completion_tokens total_reasoning_tokens total_cached_input_tokens total_inference_time_ms].freeze
       attr_reader :act_prompt_tokens, :act_completion_tokens, :act_reasoning_tokens, :act_cached_input_tokens, :act_inference_time_ms, :extract_prompt_tokens, :extract_completion_tokens, :extract_reasoning_tokens, :extract_cached_input_tokens, :extract_inference_time_ms, :observe_prompt_tokens, :observe_completion_tokens, :observe_reasoning_tokens, :observe_cached_input_tokens, :observe_inference_time_ms, :total_prompt_tokens, :total_completion_tokens, :total_reasoning_tokens, :total_cached_input_tokens, :total_inference_time_ms
@@ -331,8 +331,8 @@ module Stagehand
 
     class CallbackBatchParams < Stagehand::Wire::Model
       FIELDS = {
-        "callback_source" => nil,
-        "input" => nil,
+        "callback_source" => :string,
+        "input" => "__schema2",
         "options" => "CallbackBatchOptions",
       }.freeze
       REQUIRED = %w[callback_source options].freeze
@@ -341,8 +341,8 @@ module Stagehand
 
     class CallbackBatchOptions < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
-        "timeout" => nil,
+        "page_id" => :string,
+        "timeout" => :integer,
       }.freeze
       REQUIRED = [].freeze
       attr_reader :page_id, :timeout
@@ -350,7 +350,7 @@ module Stagehand
 
     class CallbackBatchResult < Stagehand::Wire::Model
       FIELDS = {
-        "value" => nil,
+        "value" => "__schema3",
       }.freeze
       REQUIRED = [].freeze
       attr_reader :value
@@ -359,9 +359,9 @@ module Stagehand
     class LLMStructuredGenerateParams < Stagehand::Wire::Model
       FIELDS = {
         "messages" => [:array, "LLMMessage"].freeze,
-        "system_prompt" => nil,
-        "temperature" => nil,
-        "stop_sequences" => nil,
+        "system_prompt" => :string,
+        "temperature" => :number,
+        "stop_sequences" => [:array, :string].freeze,
         "response_format" => "LLMJsonSchemaResponseFormat",
       }.freeze
       REQUIRED = %w[messages response_format].freeze
@@ -370,7 +370,7 @@ module Stagehand
 
     class LLMMessage < Stagehand::Wire::Model
       FIELDS = {
-        "role" => nil,
+        "role" => "LLMRole",
         "content" => [:union, ["LLMMessageContentBlock", [:array, "LLMMessageContentBlock"].freeze].freeze].freeze,
       }.freeze
       REQUIRED = %w[role content].freeze
@@ -383,8 +383,8 @@ module Stagehand
 
     class LLMTextContent < Stagehand::Wire::Model
       FIELDS = {
-        "type" => nil,
-        "text" => nil,
+        "type" => :string,
+        "text" => :string,
         "annotations" => "LLMAnnotations",
       }.freeze
       REQUIRED = %w[type text].freeze
@@ -393,9 +393,9 @@ module Stagehand
 
     class LLMAnnotations < Stagehand::Wire::Model
       FIELDS = {
-        "audience" => nil,
-        "priority" => nil,
-        "last_modified" => nil,
+        "audience" => [:array, "LLMRole"].freeze,
+        "priority" => :number,
+        "last_modified" => :string,
       }.freeze
       REQUIRED = [].freeze
       attr_reader :audience, :priority, :last_modified
@@ -403,9 +403,9 @@ module Stagehand
 
     class LLMImageContent < Stagehand::Wire::Model
       FIELDS = {
-        "type" => nil,
-        "data" => nil,
-        "mime_type" => nil,
+        "type" => :string,
+        "data" => :string,
+        "mime_type" => :string,
         "annotations" => "LLMAnnotations",
       }.freeze
       REQUIRED = %w[type data mime_type].freeze
@@ -414,10 +414,10 @@ module Stagehand
 
     class LLMToolUseContent < Stagehand::Wire::Model
       FIELDS = {
-        "type" => nil,
-        "id" => nil,
-        "name" => nil,
-        "input" => nil,
+        "type" => :string,
+        "id" => :string,
+        "name" => :string,
+        "input" => [:map, "__schema4"].freeze,
       }.freeze
       REQUIRED = %w[type id name input].freeze
       attr_reader :type, :id, :name, :input
@@ -425,11 +425,11 @@ module Stagehand
 
     class LLMToolResultContent < Stagehand::Wire::Model
       FIELDS = {
-        "type" => nil,
-        "tool_use_id" => nil,
+        "type" => :string,
+        "tool_use_id" => :string,
         "content" => [:array, "LLMToolResultContentBlock"].freeze,
-        "structured_content" => nil,
-        "is_error" => nil,
+        "structured_content" => [:map, "__schema5"].freeze,
+        "is_error" => :boolean,
       }.freeze
       REQUIRED = %w[type tool_use_id content].freeze
       attr_reader :type, :tool_use_id, :content, :structured_content, :is_error
@@ -437,10 +437,10 @@ module Stagehand
 
     class LLMJsonSchemaResponseFormat < Stagehand::Wire::Model
       FIELDS = {
-        "type" => nil,
-        "name" => nil,
-        "description" => nil,
-        "schema" => nil,
+        "type" => :string,
+        "name" => :string,
+        "description" => :string,
+        "schema" => "__schema6",
       }.freeze
       REQUIRED = %w[type name schema].freeze
       attr_reader :type, :name, :description, :schema
@@ -449,9 +449,9 @@ module Stagehand
     class LLMMessageGenerateParams < Stagehand::Wire::Model
       FIELDS = {
         "messages" => [:array, "LLMMessage"].freeze,
-        "system_prompt" => nil,
-        "temperature" => nil,
-        "stop_sequences" => nil,
+        "system_prompt" => :string,
+        "temperature" => :number,
+        "stop_sequences" => [:array, :string].freeze,
         "tools" => [:array, "LLMClientTool"].freeze,
         "tool_choice" => "LLMToolChoice",
         "response_format" => "LLMTextResponseFormat",
@@ -462,10 +462,10 @@ module Stagehand
 
     class LLMClientTool < Stagehand::Wire::Model
       FIELDS = {
-        "name" => nil,
-        "title" => nil,
+        "name" => :string,
+        "title" => :string,
         "icons" => [:array, "LLMToolIcon"].freeze,
-        "description" => nil,
+        "description" => :string,
         "input_schema" => nil,
         "execution" => "LLMToolExecution",
         "output_schema" => nil,
@@ -477,10 +477,10 @@ module Stagehand
 
     class LLMToolIcon < Stagehand::Wire::Model
       FIELDS = {
-        "src" => nil,
-        "mime_type" => nil,
-        "sizes" => nil,
-        "theme" => nil,
+        "src" => :string,
+        "mime_type" => :string,
+        "sizes" => [:array, :string].freeze,
+        "theme" => :string,
       }.freeze
       REQUIRED = %w[src].freeze
       attr_reader :src, :mime_type, :sizes, :theme
@@ -488,7 +488,7 @@ module Stagehand
 
     class LLMToolExecution < Stagehand::Wire::Model
       FIELDS = {
-        "task_support" => nil,
+        "task_support" => :string,
       }.freeze
       REQUIRED = [].freeze
       attr_reader :task_support
@@ -496,11 +496,11 @@ module Stagehand
 
     class LLMToolAnnotations < Stagehand::Wire::Model
       FIELDS = {
-        "title" => nil,
-        "read_only_hint" => nil,
-        "destructive_hint" => nil,
-        "idempotent_hint" => nil,
-        "open_world_hint" => nil,
+        "title" => :string,
+        "read_only_hint" => :boolean,
+        "destructive_hint" => :boolean,
+        "idempotent_hint" => :boolean,
+        "open_world_hint" => :boolean,
       }.freeze
       REQUIRED = [].freeze
       attr_reader :title, :read_only_hint, :destructive_hint, :idempotent_hint, :open_world_hint
@@ -508,7 +508,7 @@ module Stagehand
 
     class LLMToolChoice < Stagehand::Wire::Model
       FIELDS = {
-        "mode" => nil,
+        "mode" => :string,
       }.freeze
       REQUIRED = [].freeze
       attr_reader :mode
@@ -516,7 +516,7 @@ module Stagehand
 
     class LLMTextResponseFormat < Stagehand::Wire::Model
       FIELDS = {
-        "type" => nil,
+        "type" => :string,
       }.freeze
       REQUIRED = %w[type].freeze
       attr_reader :type
@@ -524,11 +524,11 @@ module Stagehand
 
     class LLMMessageGenerateResult < Stagehand::Wire::Model
       FIELDS = {
-        "role" => nil,
+        "role" => "LLMRole",
         "content" => [:union, ["LLMMessageContentBlock", [:array, "LLMMessageContentBlock"].freeze].freeze].freeze,
-        "stop_reason" => nil,
+        "stop_reason" => :string,
         "usage" => "LLMUsage",
-        "output_format" => nil,
+        "output_format" => :string,
       }.freeze
       REQUIRED = %w[role content output_format].freeze
       attr_reader :role, :content, :stop_reason, :usage, :output_format
@@ -536,11 +536,11 @@ module Stagehand
 
     class LLMUsage < Stagehand::Wire::Model
       FIELDS = {
-        "input_tokens" => nil,
-        "output_tokens" => nil,
-        "total_tokens" => nil,
-        "reasoning_tokens" => nil,
-        "cached_input_tokens" => nil,
+        "input_tokens" => :integer,
+        "output_tokens" => :integer,
+        "total_tokens" => :integer,
+        "reasoning_tokens" => :integer,
+        "cached_input_tokens" => :integer,
       }.freeze
       REQUIRED = %w[input_tokens output_tokens total_tokens].freeze
       attr_reader :input_tokens, :output_tokens, :total_tokens, :reasoning_tokens, :cached_input_tokens
@@ -548,12 +548,12 @@ module Stagehand
 
     class LLMStructuredGenerateResult < Stagehand::Wire::Model
       FIELDS = {
-        "role" => nil,
+        "role" => "LLMRole",
         "content" => [:union, ["LLMMessageContentBlock", [:array, "LLMMessageContentBlock"].freeze].freeze].freeze,
-        "stop_reason" => nil,
+        "stop_reason" => :string,
         "usage" => "LLMUsage",
-        "output_format" => nil,
-        "structured_content" => nil,
+        "output_format" => :string,
+        "structured_content" => "__schema8",
       }.freeze
       REQUIRED = %w[role content output_format structured_content].freeze
       attr_reader :role, :content, :stop_reason, :usage, :output_format, :structured_content
@@ -561,7 +561,7 @@ module Stagehand
 
     class ContextNewPageParams < Stagehand::Wire::Model
       FIELDS = {
-        "url" => nil,
+        "url" => :string,
       }.freeze
       REQUIRED = [].freeze
       attr_reader :url
@@ -569,7 +569,7 @@ module Stagehand
 
     class ContextSetActivePageParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
+        "page_id" => :string,
       }.freeze
       REQUIRED = %w[page_id].freeze
       attr_reader :page_id
@@ -577,7 +577,7 @@ module Stagehand
 
     class ContextVoidResult < Stagehand::Wire::Model
       FIELDS = {
-        "ok" => nil,
+        "ok" => :boolean,
       }.freeze
       REQUIRED = %w[ok].freeze
       attr_reader :ok
@@ -585,7 +585,7 @@ module Stagehand
 
     class ContextCloseResult < Stagehand::Wire::Model
       FIELDS = {
-        "closed" => nil,
+        "closed" => :boolean,
       }.freeze
       REQUIRED = %w[closed].freeze
       attr_reader :closed
@@ -593,7 +593,7 @@ module Stagehand
 
     class ContextAddInitScriptParams < Stagehand::Wire::Model
       FIELDS = {
-        "source" => nil,
+        "source" => :string,
       }.freeze
       REQUIRED = %w[source].freeze
       attr_reader :source
@@ -601,7 +601,7 @@ module Stagehand
 
     class ContextSetExtraHTTPHeadersParams < Stagehand::Wire::Model
       FIELDS = {
-        "headers" => nil,
+        "headers" => [:map, :string].freeze,
       }.freeze
       REQUIRED = %w[headers].freeze
       attr_reader :headers
@@ -609,8 +609,8 @@ module Stagehand
 
     class DomainPolicy < Stagehand::Wire::Model
       FIELDS = {
-        "allowed_domains" => nil,
-        "blocked_domains" => nil,
+        "allowed_domains" => [:array, :string].freeze,
+        "blocked_domains" => [:array, :string].freeze,
       }.freeze
       REQUIRED = [].freeze
       attr_reader :allowed_domains, :blocked_domains
@@ -618,7 +618,7 @@ module Stagehand
 
     class ContextSetDomainPolicyParams < Stagehand::Wire::Model
       FIELDS = {
-        "policy" => [:union, ["DomainPolicy", nil].freeze].freeze,
+        "policy" => [:union, ["DomainPolicy", :null].freeze].freeze,
       }.freeze
       REQUIRED = %w[policy].freeze
       attr_reader :policy
@@ -626,7 +626,7 @@ module Stagehand
 
     class ContextCookiesParams < Stagehand::Wire::Model
       FIELDS = {
-        "urls" => nil,
+        "urls" => [:union, [:string, [:array, :string].freeze].freeze].freeze,
       }.freeze
       REQUIRED = [].freeze
       attr_reader :urls
@@ -634,14 +634,14 @@ module Stagehand
 
     class Cookie < Stagehand::Wire::Model
       FIELDS = {
-        "name" => nil,
-        "value" => nil,
-        "domain" => nil,
-        "path" => nil,
-        "expires" => nil,
-        "http_only" => nil,
-        "secure" => nil,
-        "same_site" => nil,
+        "name" => :string,
+        "value" => :string,
+        "domain" => :string,
+        "path" => :string,
+        "expires" => :number,
+        "http_only" => :boolean,
+        "secure" => :boolean,
+        "same_site" => :string,
       }.freeze
       REQUIRED = %w[name value domain path expires http_only secure same_site].freeze
       attr_reader :name, :value, :domain, :path, :expires, :http_only, :secure, :same_site
@@ -657,15 +657,15 @@ module Stagehand
 
     class CookieParam < Stagehand::Wire::Model
       FIELDS = {
-        "name" => nil,
-        "value" => nil,
-        "url" => nil,
-        "domain" => nil,
-        "path" => nil,
-        "expires" => nil,
-        "http_only" => nil,
-        "secure" => nil,
-        "same_site" => nil,
+        "name" => :string,
+        "value" => :string,
+        "url" => :string,
+        "domain" => :string,
+        "path" => :string,
+        "expires" => :number,
+        "http_only" => :boolean,
+        "secure" => :boolean,
+        "same_site" => :string,
       }.freeze
       REQUIRED = %w[name value].freeze
       attr_reader :name, :value, :url, :domain, :path, :expires, :http_only, :secure, :same_site
@@ -691,8 +691,8 @@ module Stagehand
 
     class CookieRegex < Stagehand::Wire::Model
       FIELDS = {
-        "source" => nil,
-        "flags" => nil,
+        "source" => :string,
+        "flags" => :string,
       }.freeze
       REQUIRED = %w[source].freeze
       attr_reader :source, :flags
@@ -700,7 +700,7 @@ module Stagehand
 
     class ContextClipboardTarget < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
+        "page_id" => :string,
       }.freeze
       REQUIRED = [].freeze
       attr_reader :page_id
@@ -708,8 +708,8 @@ module Stagehand
 
     class ContextClipboardWriteTextParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
-        "text" => nil,
+        "page_id" => :string,
+        "text" => :string,
       }.freeze
       REQUIRED = %w[text].freeze
       attr_reader :page_id, :text
@@ -717,8 +717,8 @@ module Stagehand
 
     class ContextClipboardPasteParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
-        "shortcut" => nil,
+        "page_id" => :string,
+        "shortcut" => :string,
       }.freeze
       REQUIRED = [].freeze
       attr_reader :page_id, :shortcut
@@ -726,8 +726,8 @@ module Stagehand
 
     class PageGotoParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
-        "url" => nil,
+        "page_id" => :string,
+        "url" => :string,
         "options" => "PageNavigationOptions",
       }.freeze
       REQUIRED = %w[page_id url].freeze
@@ -736,8 +736,8 @@ module Stagehand
 
     class PageNavigationOptions < Stagehand::Wire::Model
       FIELDS = {
-        "wait_until" => nil,
-        "timeout" => nil,
+        "wait_until" => "LoadState",
+        "timeout" => :integer,
       }.freeze
       REQUIRED = [].freeze
       attr_reader :wait_until, :timeout
@@ -750,7 +750,7 @@ module Stagehand
     class PageNavigationResult < Stagehand::Wire::Model
       FIELDS = {
         "page" => "PageRef",
-        "response" => [:union, ["NavigationResponseDescriptor", nil].freeze].freeze,
+        "response" => [:union, ["NavigationResponseDescriptor", :null].freeze].freeze,
       }.freeze
       REQUIRED = %w[page response].freeze
       attr_reader :page, :response
@@ -758,12 +758,12 @@ module Stagehand
 
     class NavigationResponseDescriptor < Stagehand::Wire::Model
       FIELDS = {
-        "response_id" => nil,
-        "url" => nil,
-        "status" => nil,
-        "status_text" => nil,
-        "headers" => nil,
-        "from_service_worker" => nil,
+        "response_id" => :string,
+        "url" => :string,
+        "status" => :integer,
+        "status_text" => :string,
+        "headers" => [:map, :string].freeze,
+        "from_service_worker" => :boolean,
       }.freeze
       REQUIRED = %w[response_id url status status_text headers from_service_worker].freeze
       attr_reader :response_id, :url, :status, :status_text, :headers, :from_service_worker
@@ -771,7 +771,7 @@ module Stagehand
 
     class PageIdParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
+        "page_id" => :string,
       }.freeze
       REQUIRED = %w[page_id].freeze
       attr_reader :page_id
@@ -779,7 +779,7 @@ module Stagehand
 
     class PageCloseResult < Stagehand::Wire::Model
       FIELDS = {
-        "closed" => nil,
+        "closed" => :boolean,
       }.freeze
       REQUIRED = %w[closed].freeze
       attr_reader :closed
@@ -787,7 +787,7 @@ module Stagehand
 
     class PageReloadParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
+        "page_id" => :string,
         "options" => "PageReloadOptions",
       }.freeze
       REQUIRED = %w[page_id].freeze
@@ -796,9 +796,9 @@ module Stagehand
 
     class PageReloadOptions < Stagehand::Wire::Model
       FIELDS = {
-        "wait_until" => nil,
-        "timeout" => nil,
-        "ignore_cache" => nil,
+        "wait_until" => "LoadState",
+        "timeout" => :integer,
+        "ignore_cache" => :boolean,
       }.freeze
       REQUIRED = [].freeze
       attr_reader :wait_until, :timeout, :ignore_cache
@@ -806,7 +806,7 @@ module Stagehand
 
     class PageGoBackParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
+        "page_id" => :string,
         "options" => "PageNavigationOptions",
       }.freeze
       REQUIRED = %w[page_id].freeze
@@ -815,7 +815,7 @@ module Stagehand
 
     class PageGoForwardParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
+        "page_id" => :string,
         "options" => "PageNavigationOptions",
       }.freeze
       REQUIRED = %w[page_id].freeze
@@ -824,9 +824,9 @@ module Stagehand
 
     class PageClickParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
-        "x" => nil,
-        "y" => nil,
+        "page_id" => :string,
+        "x" => :number,
+        "y" => :number,
         "options" => "PageClickOptions",
       }.freeze
       REQUIRED = %w[page_id x y].freeze
@@ -835,8 +835,8 @@ module Stagehand
 
     class PageClickOptions < Stagehand::Wire::Model
       FIELDS = {
-        "button" => nil,
-        "click_count" => nil,
+        "button" => "MouseButton",
+        "click_count" => :integer,
       }.freeze
       REQUIRED = [].freeze
       attr_reader :button, :click_count
@@ -848,7 +848,7 @@ module Stagehand
 
     class PageVoidResult < Stagehand::Wire::Model
       FIELDS = {
-        "ok" => nil,
+        "ok" => :boolean,
       }.freeze
       REQUIRED = %w[ok].freeze
       attr_reader :ok
@@ -856,9 +856,9 @@ module Stagehand
 
     class PageHoverParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
-        "x" => nil,
-        "y" => nil,
+        "page_id" => :string,
+        "x" => :number,
+        "y" => :number,
       }.freeze
       REQUIRED = %w[page_id x y].freeze
       attr_reader :page_id, :x, :y
@@ -866,11 +866,11 @@ module Stagehand
 
     class PageScrollParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
-        "x" => nil,
-        "y" => nil,
-        "delta_x" => nil,
-        "delta_y" => nil,
+        "page_id" => :string,
+        "x" => :number,
+        "y" => :number,
+        "delta_x" => :number,
+        "delta_y" => :number,
       }.freeze
       REQUIRED = %w[page_id x y delta_x delta_y].freeze
       attr_reader :page_id, :x, :y, :delta_x, :delta_y
@@ -878,11 +878,11 @@ module Stagehand
 
     class PageDragAndDropParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
-        "from_x" => nil,
-        "from_y" => nil,
-        "to_x" => nil,
-        "to_y" => nil,
+        "page_id" => :string,
+        "from_x" => :number,
+        "from_y" => :number,
+        "to_x" => :number,
+        "to_y" => :number,
         "options" => "PageDragAndDropOptions",
       }.freeze
       REQUIRED = %w[page_id from_x from_y to_x to_y].freeze
@@ -891,9 +891,9 @@ module Stagehand
 
     class PageDragAndDropOptions < Stagehand::Wire::Model
       FIELDS = {
-        "button" => nil,
-        "steps" => nil,
-        "delay" => nil,
+        "button" => "MouseButton",
+        "steps" => :integer,
+        "delay" => :number,
         "route" => [:array, "PageDragAndDropRoutePoint"].freeze,
       }.freeze
       REQUIRED = [].freeze
@@ -902,8 +902,8 @@ module Stagehand
 
     class PageDragAndDropRoutePoint < Stagehand::Wire::Model
       FIELDS = {
-        "x" => nil,
-        "y" => nil,
+        "x" => :number,
+        "y" => :number,
       }.freeze
       REQUIRED = %w[x y].freeze
       attr_reader :x, :y
@@ -911,8 +911,8 @@ module Stagehand
 
     class PageTypeParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
-        "text" => nil,
+        "page_id" => :string,
+        "text" => :string,
         "options" => "PageTypeOptions",
       }.freeze
       REQUIRED = %w[page_id text].freeze
@@ -921,8 +921,8 @@ module Stagehand
 
     class PageTypeOptions < Stagehand::Wire::Model
       FIELDS = {
-        "delay" => nil,
-        "with_mistakes" => nil,
+        "delay" => :number,
+        "with_mistakes" => :boolean,
       }.freeze
       REQUIRED = [].freeze
       attr_reader :delay, :with_mistakes
@@ -930,8 +930,8 @@ module Stagehand
 
     class PageKeyPressParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
-        "key" => nil,
+        "page_id" => :string,
+        "key" => :string,
         "options" => "PageKeyPressOptions",
       }.freeze
       REQUIRED = %w[page_id key].freeze
@@ -940,7 +940,7 @@ module Stagehand
 
     class PageKeyPressOptions < Stagehand::Wire::Model
       FIELDS = {
-        "delay" => nil,
+        "delay" => :number,
       }.freeze
       REQUIRED = [].freeze
       attr_reader :delay
@@ -948,8 +948,8 @@ module Stagehand
 
     class PageEvaluateParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
-        "expression" => nil,
+        "page_id" => :string,
+        "expression" => :string,
       }.freeze
       REQUIRED = %w[page_id expression].freeze
       attr_reader :page_id, :expression
@@ -957,7 +957,7 @@ module Stagehand
 
     class PageEvaluateResult < Stagehand::Wire::Model
       FIELDS = {
-        "value" => nil,
+        "value" => "__schema9",
       }.freeze
       REQUIRED = %w[value].freeze
       attr_reader :value
@@ -965,8 +965,8 @@ module Stagehand
 
     class PageAddInitScriptParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
-        "source" => nil,
+        "page_id" => :string,
+        "source" => :string,
       }.freeze
       REQUIRED = %w[page_id source].freeze
       attr_reader :page_id, :source
@@ -974,9 +974,9 @@ module Stagehand
 
     class PageOnParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
-        "subscription_id" => nil,
-        "event" => nil,
+        "page_id" => :string,
+        "subscription_id" => :string,
+        "event" => "PageEventName",
       }.freeze
       REQUIRED = %w[page_id subscription_id event].freeze
       attr_reader :page_id, :subscription_id, :event
@@ -988,7 +988,7 @@ module Stagehand
 
     class PageOffParams < Stagehand::Wire::Model
       FIELDS = {
-        "subscription_id" => nil,
+        "subscription_id" => :string,
       }.freeze
       REQUIRED = %w[subscription_id].freeze
       attr_reader :subscription_id
@@ -996,8 +996,8 @@ module Stagehand
 
     class PageSetExtraHTTPHeadersParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
-        "headers" => nil,
+        "page_id" => :string,
+        "headers" => [:map, :string].freeze,
       }.freeze
       REQUIRED = %w[page_id headers].freeze
       attr_reader :page_id, :headers
@@ -1005,7 +1005,7 @@ module Stagehand
 
     class PageScreenshotParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
+        "page_id" => :string,
         "options" => "PageScreenshotOptions",
       }.freeze
       REQUIRED = %w[page_id].freeze
@@ -1014,18 +1014,18 @@ module Stagehand
 
     class PageScreenshotOptions < Stagehand::Wire::Model
       FIELDS = {
-        "animations" => nil,
-        "caret" => nil,
+        "animations" => :string,
+        "caret" => :string,
         "clip" => "PageScreenshotClip",
-        "full_page" => nil,
+        "full_page" => :boolean,
         "mask" => [:array, "LocatorDescriptor"].freeze,
-        "mask_color" => nil,
-        "omit_background" => nil,
-        "quality" => nil,
-        "scale" => nil,
-        "style" => nil,
-        "timeout" => nil,
-        "type" => nil,
+        "mask_color" => :string,
+        "omit_background" => :boolean,
+        "quality" => :integer,
+        "scale" => :string,
+        "style" => :string,
+        "timeout" => :number,
+        "type" => :string,
       }.freeze
       REQUIRED = [].freeze
       attr_reader :animations, :caret, :clip, :full_page, :mask, :mask_color, :omit_background, :quality, :scale, :style, :timeout, :type
@@ -1033,10 +1033,10 @@ module Stagehand
 
     class PageScreenshotClip < Stagehand::Wire::Model
       FIELDS = {
-        "x" => nil,
-        "y" => nil,
-        "width" => nil,
-        "height" => nil,
+        "x" => :number,
+        "y" => :number,
+        "width" => :number,
+        "height" => :number,
       }.freeze
       REQUIRED = %w[x y width height].freeze
       attr_reader :x, :y, :width, :height
@@ -1044,9 +1044,9 @@ module Stagehand
 
     class LocatorDescriptor < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
-        "selector" => nil,
-        "nth" => nil,
+        "page_id" => :string,
+        "selector" => :string,
+        "nth" => :integer,
       }.freeze
       REQUIRED = %w[page_id selector].freeze
       attr_reader :page_id, :selector, :nth
@@ -1054,7 +1054,7 @@ module Stagehand
 
     class PageScreenshotResult < Stagehand::Wire::Model
       FIELDS = {
-        "data" => nil,
+        "data" => :string,
       }.freeze
       REQUIRED = %w[data].freeze
       attr_reader :data
@@ -1062,7 +1062,7 @@ module Stagehand
 
     class PageSnapshotParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
+        "page_id" => :string,
         "options" => "PageSnapshotOptions",
       }.freeze
       REQUIRED = %w[page_id].freeze
@@ -1071,7 +1071,7 @@ module Stagehand
 
     class PageSnapshotOptions < Stagehand::Wire::Model
       FIELDS = {
-        "include_iframes" => nil,
+        "include_iframes" => :boolean,
       }.freeze
       REQUIRED = [].freeze
       attr_reader :include_iframes
@@ -1079,9 +1079,9 @@ module Stagehand
 
     class SnapshotResult < Stagehand::Wire::Model
       FIELDS = {
-        "formatted_tree" => nil,
-        "xpath_map" => nil,
-        "url_map" => nil,
+        "formatted_tree" => :string,
+        "xpath_map" => [:map, :string].freeze,
+        "url_map" => [:map, :string].freeze,
       }.freeze
       REQUIRED = %w[formatted_tree xpath_map url_map].freeze
       attr_reader :formatted_tree, :xpath_map, :url_map
@@ -1089,9 +1089,9 @@ module Stagehand
 
     class PageSetViewportSizeParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
-        "width" => nil,
-        "height" => nil,
+        "page_id" => :string,
+        "width" => :integer,
+        "height" => :integer,
         "options" => "PageSetViewportSizeOptions",
       }.freeze
       REQUIRED = %w[page_id width height].freeze
@@ -1100,7 +1100,7 @@ module Stagehand
 
     class PageSetViewportSizeOptions < Stagehand::Wire::Model
       FIELDS = {
-        "device_scale_factor" => nil,
+        "device_scale_factor" => :number,
       }.freeze
       REQUIRED = [].freeze
       attr_reader :device_scale_factor
@@ -1108,9 +1108,9 @@ module Stagehand
 
     class PageWaitForLoadStateParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
-        "state" => nil,
-        "timeout" => nil,
+        "page_id" => :string,
+        "state" => "LoadState",
+        "timeout" => :integer,
       }.freeze
       REQUIRED = %w[page_id state].freeze
       attr_reader :page_id, :state, :timeout
@@ -1118,8 +1118,8 @@ module Stagehand
 
     class PageWaitForTimeoutParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
-        "ms" => nil,
+        "page_id" => :string,
+        "ms" => :integer,
       }.freeze
       REQUIRED = %w[page_id ms].freeze
       attr_reader :page_id, :ms
@@ -1127,8 +1127,8 @@ module Stagehand
 
     class PageWaitForSelectorParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
-        "selector" => nil,
+        "page_id" => :string,
+        "selector" => :string,
         "options" => "PageWaitForSelectorOptions",
       }.freeze
       REQUIRED = %w[page_id selector].freeze
@@ -1137,9 +1137,9 @@ module Stagehand
 
     class PageWaitForSelectorOptions < Stagehand::Wire::Model
       FIELDS = {
-        "state" => nil,
-        "timeout" => nil,
-        "pierce_shadow" => nil,
+        "state" => :string,
+        "timeout" => :integer,
+        "pierce_shadow" => :boolean,
       }.freeze
       REQUIRED = [].freeze
       attr_reader :state, :timeout, :pierce_shadow
@@ -1147,7 +1147,7 @@ module Stagehand
 
     class PageWaitForSelectorResult < Stagehand::Wire::Model
       FIELDS = {
-        "matched" => nil,
+        "matched" => :boolean,
       }.freeze
       REQUIRED = %w[matched].freeze
       attr_reader :matched
@@ -1155,7 +1155,7 @@ module Stagehand
 
     class PageWebMCPToolsParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
+        "page_id" => :string,
         "options" => "WebMCPToolsOptions",
       }.freeze
       REQUIRED = %w[page_id].freeze
@@ -1164,7 +1164,7 @@ module Stagehand
 
     class WebMCPToolsOptions < Stagehand::Wire::Model
       FIELDS = {
-        "timeout" => nil,
+        "timeout" => :number,
       }.freeze
       REQUIRED = [].freeze
       attr_reader :timeout
@@ -1180,12 +1180,12 @@ module Stagehand
 
     class WebMCPToolDescriptor < Stagehand::Wire::Model
       FIELDS = {
-        "name" => nil,
-        "description" => nil,
-        "input_schema" => nil,
+        "name" => :string,
+        "description" => :string,
+        "input_schema" => [:map, "WebMCPJsonValue"].freeze,
         "annotations" => "WebMCPAnnotation",
-        "frame_id" => nil,
-        "backend_node_id" => nil,
+        "frame_id" => :string,
+        "backend_node_id" => :integer,
       }.freeze
       REQUIRED = %w[name description frame_id].freeze
       attr_reader :name, :description, :input_schema, :annotations, :frame_id, :backend_node_id
@@ -1193,9 +1193,9 @@ module Stagehand
 
     class WebMCPAnnotation < Stagehand::Wire::Model
       FIELDS = {
-        "read_only" => nil,
-        "untrusted_content" => nil,
-        "autosubmit" => nil,
+        "read_only" => :boolean,
+        "untrusted_content" => :boolean,
+        "autosubmit" => :boolean,
       }.freeze
       REQUIRED = [].freeze
       attr_reader :read_only, :untrusted_content, :autosubmit
@@ -1203,10 +1203,10 @@ module Stagehand
 
     class PageWebMCPInvokeToolParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
-        "frame_id" => nil,
-        "tool_name" => nil,
-        "input" => nil,
+        "page_id" => :string,
+        "frame_id" => :string,
+        "tool_name" => :string,
+        "input" => [:map, "WebMCPJsonValue"].freeze,
       }.freeze
       REQUIRED = %w[page_id frame_id tool_name].freeze
       attr_reader :page_id, :frame_id, :tool_name, :input
@@ -1214,10 +1214,10 @@ module Stagehand
 
     class WebMCPInvocationDescriptor < Stagehand::Wire::Model
       FIELDS = {
-        "invocation_id" => nil,
-        "tool_name" => nil,
-        "frame_id" => nil,
-        "input" => nil,
+        "invocation_id" => :string,
+        "tool_name" => :string,
+        "frame_id" => :string,
+        "input" => [:map, "WebMCPJsonValue"].freeze,
       }.freeze
       REQUIRED = %w[invocation_id tool_name frame_id input].freeze
       attr_reader :invocation_id, :tool_name, :frame_id, :input
@@ -1225,8 +1225,8 @@ module Stagehand
 
     class PageWebMCPInvocationResultParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
-        "invocation_id" => nil,
+        "page_id" => :string,
+        "invocation_id" => :string,
         "options" => "WebMCPResultOptions",
       }.freeze
       REQUIRED = %w[page_id invocation_id].freeze
@@ -1235,7 +1235,7 @@ module Stagehand
 
     class WebMCPResultOptions < Stagehand::Wire::Model
       FIELDS = {
-        "timeout" => nil,
+        "timeout" => :number,
       }.freeze
       REQUIRED = [].freeze
       attr_reader :timeout
@@ -1243,11 +1243,11 @@ module Stagehand
 
     class WebMCPToolResponse < Stagehand::Wire::Model
       FIELDS = {
-        "invocation_id" => nil,
-        "status" => nil,
-        "output" => nil,
-        "error_text" => nil,
-        "exception" => nil,
+        "invocation_id" => :string,
+        "status" => "WebMCPInvocationStatus",
+        "output" => "WebMCPJsonValue",
+        "error_text" => :string,
+        "exception" => "WebMCPRemoteObject",
       }.freeze
       REQUIRED = %w[invocation_id status].freeze
       attr_reader :invocation_id, :status, :output, :error_text, :exception
@@ -1259,8 +1259,8 @@ module Stagehand
 
     class PageWebMCPCancelInvocationParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
-        "invocation_id" => nil,
+        "page_id" => :string,
+        "invocation_id" => :string,
       }.freeze
       REQUIRED = %w[page_id invocation_id].freeze
       attr_reader :page_id, :invocation_id
@@ -1268,9 +1268,9 @@ module Stagehand
 
     class LocatorClickParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
-        "selector" => nil,
-        "nth" => nil,
+        "page_id" => :string,
+        "selector" => :string,
+        "nth" => :integer,
         "options" => "LocatorClickOptions",
       }.freeze
       REQUIRED = %w[page_id selector].freeze
@@ -1279,8 +1279,8 @@ module Stagehand
 
     class LocatorClickOptions < Stagehand::Wire::Model
       FIELDS = {
-        "button" => nil,
-        "click_count" => nil,
+        "button" => "MouseButton",
+        "click_count" => :integer,
       }.freeze
       REQUIRED = [].freeze
       attr_reader :button, :click_count
@@ -1288,7 +1288,7 @@ module Stagehand
 
     class LocatorClickResult < Stagehand::Wire::Model
       FIELDS = {
-        "clicked" => nil,
+        "clicked" => :boolean,
       }.freeze
       REQUIRED = %w[clicked].freeze
       attr_reader :clicked
@@ -1296,10 +1296,10 @@ module Stagehand
 
     class LocatorFillParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
-        "selector" => nil,
-        "nth" => nil,
-        "value" => nil,
+        "page_id" => :string,
+        "selector" => :string,
+        "nth" => :integer,
+        "value" => :string,
       }.freeze
       REQUIRED = %w[page_id selector value].freeze
       attr_reader :page_id, :selector, :nth, :value
@@ -1307,7 +1307,7 @@ module Stagehand
 
     class LocatorFillResult < Stagehand::Wire::Model
       FIELDS = {
-        "filled" => nil,
+        "filled" => :boolean,
       }.freeze
       REQUIRED = %w[filled].freeze
       attr_reader :filled
@@ -1315,7 +1315,7 @@ module Stagehand
 
     class LocatorHoverResult < Stagehand::Wire::Model
       FIELDS = {
-        "hovered" => nil,
+        "hovered" => :boolean,
       }.freeze
       REQUIRED = %w[hovered].freeze
       attr_reader :hovered
@@ -1323,10 +1323,10 @@ module Stagehand
 
     class LocatorScrollToParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
-        "selector" => nil,
-        "nth" => nil,
-        "percent" => nil,
+        "page_id" => :string,
+        "selector" => :string,
+        "nth" => :integer,
+        "percent" => [:union, [:number, :string].freeze].freeze,
       }.freeze
       REQUIRED = %w[page_id selector percent].freeze
       attr_reader :page_id, :selector, :nth, :percent
@@ -1334,7 +1334,7 @@ module Stagehand
 
     class LocatorScrollToResult < Stagehand::Wire::Model
       FIELDS = {
-        "scrolled" => nil,
+        "scrolled" => :boolean,
       }.freeze
       REQUIRED = %w[scrolled].freeze
       attr_reader :scrolled
@@ -1342,8 +1342,8 @@ module Stagehand
 
     class LocatorCentroidResult < Stagehand::Wire::Model
       FIELDS = {
-        "x" => nil,
-        "y" => nil,
+        "x" => :number,
+        "y" => :number,
       }.freeze
       REQUIRED = %w[x y].freeze
       attr_reader :x, :y
@@ -1351,9 +1351,9 @@ module Stagehand
 
     class LocatorHighlightParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
-        "selector" => nil,
-        "nth" => nil,
+        "page_id" => :string,
+        "selector" => :string,
+        "nth" => :integer,
         "options" => "LocatorHighlightOptions",
       }.freeze
       REQUIRED = %w[page_id selector].freeze
@@ -1362,7 +1362,7 @@ module Stagehand
 
     class LocatorHighlightOptions < Stagehand::Wire::Model
       FIELDS = {
-        "duration_ms" => nil,
+        "duration_ms" => :integer,
         "border_color" => "RgbaColor",
         "content_color" => "RgbaColor",
       }.freeze
@@ -1372,10 +1372,10 @@ module Stagehand
 
     class RgbaColor < Stagehand::Wire::Model
       FIELDS = {
-        "r" => nil,
-        "g" => nil,
-        "b" => nil,
-        "a" => nil,
+        "r" => :number,
+        "g" => :number,
+        "b" => :number,
+        "a" => :number,
       }.freeze
       REQUIRED = %w[r g b].freeze
       attr_reader :r, :g, :b, :a
@@ -1383,7 +1383,7 @@ module Stagehand
 
     class LocatorHighlightResult < Stagehand::Wire::Model
       FIELDS = {
-        "highlighted" => nil,
+        "highlighted" => :boolean,
       }.freeze
       REQUIRED = %w[highlighted].freeze
       attr_reader :highlighted
@@ -1391,9 +1391,9 @@ module Stagehand
 
     class LocatorSendClickEventParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
-        "selector" => nil,
-        "nth" => nil,
+        "page_id" => :string,
+        "selector" => :string,
+        "nth" => :integer,
         "options" => "LocatorSendClickEventOptions",
       }.freeze
       REQUIRED = %w[page_id selector].freeze
@@ -1402,10 +1402,10 @@ module Stagehand
 
     class LocatorSendClickEventOptions < Stagehand::Wire::Model
       FIELDS = {
-        "bubbles" => nil,
-        "cancelable" => nil,
-        "composed" => nil,
-        "detail" => nil,
+        "bubbles" => :boolean,
+        "cancelable" => :boolean,
+        "composed" => :boolean,
+        "detail" => :number,
       }.freeze
       REQUIRED = [].freeze
       attr_reader :bubbles, :cancelable, :composed, :detail
@@ -1413,7 +1413,7 @@ module Stagehand
 
     class LocatorSendClickEventResult < Stagehand::Wire::Model
       FIELDS = {
-        "clicked" => nil,
+        "clicked" => :boolean,
       }.freeze
       REQUIRED = %w[clicked].freeze
       attr_reader :clicked
@@ -1421,10 +1421,10 @@ module Stagehand
 
     class LocatorTypeParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
-        "selector" => nil,
-        "nth" => nil,
-        "text" => nil,
+        "page_id" => :string,
+        "selector" => :string,
+        "nth" => :integer,
+        "text" => :string,
         "options" => "LocatorTypeOptions",
       }.freeze
       REQUIRED = %w[page_id selector text].freeze
@@ -1433,7 +1433,7 @@ module Stagehand
 
     class LocatorTypeOptions < Stagehand::Wire::Model
       FIELDS = {
-        "delay" => nil,
+        "delay" => :number,
       }.freeze
       REQUIRED = [].freeze
       attr_reader :delay
@@ -1441,7 +1441,7 @@ module Stagehand
 
     class LocatorTypeResult < Stagehand::Wire::Model
       FIELDS = {
-        "typed" => nil,
+        "typed" => :boolean,
       }.freeze
       REQUIRED = %w[typed].freeze
       attr_reader :typed
@@ -1449,10 +1449,10 @@ module Stagehand
 
     class LocatorSelectOptionParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
-        "selector" => nil,
-        "nth" => nil,
-        "values" => nil,
+        "page_id" => :string,
+        "selector" => :string,
+        "nth" => :integer,
+        "values" => [:union, [:string, [:array, :string].freeze].freeze].freeze,
       }.freeze
       REQUIRED = %w[page_id selector values].freeze
       attr_reader :page_id, :selector, :nth, :values
@@ -1460,9 +1460,9 @@ module Stagehand
 
     class LocatorSetInputFilesParams < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
-        "selector" => nil,
-        "nth" => nil,
+        "page_id" => :string,
+        "selector" => :string,
+        "nth" => :integer,
         "files" => [:array, "InputFilePayload"].freeze,
       }.freeze
       REQUIRED = %w[page_id selector files].freeze
@@ -1471,10 +1471,10 @@ module Stagehand
 
     class InputFilePayload < Stagehand::Wire::Model
       FIELDS = {
-        "name" => nil,
-        "mime_type" => nil,
-        "data" => nil,
-        "last_modified" => nil,
+        "name" => :string,
+        "mime_type" => :string,
+        "data" => :string,
+        "last_modified" => :integer,
       }.freeze
       REQUIRED = %w[name data].freeze
       attr_reader :name, :mime_type, :data, :last_modified
@@ -1482,7 +1482,7 @@ module Stagehand
 
     class LocatorSetInputFilesResult < Stagehand::Wire::Model
       FIELDS = {
-        "set" => nil,
+        "set" => :boolean,
       }.freeze
       REQUIRED = %w[set].freeze
       attr_reader :set
@@ -1490,7 +1490,7 @@ module Stagehand
 
     class ResponseIdParams < Stagehand::Wire::Model
       FIELDS = {
-        "response_id" => nil,
+        "response_id" => :string,
       }.freeze
       REQUIRED = %w[response_id].freeze
       attr_reader :response_id
@@ -1498,8 +1498,8 @@ module Stagehand
 
     class ResponseBodyResult < Stagehand::Wire::Model
       FIELDS = {
-        "body" => nil,
-        "base64_encoded" => nil,
+        "body" => :string,
+        "base64_encoded" => :boolean,
       }.freeze
       REQUIRED = %w[body base64_encoded].freeze
       attr_reader :body, :base64_encoded
@@ -1507,7 +1507,7 @@ module Stagehand
 
     class ResponseAllHeadersResult < Stagehand::Wire::Model
       FIELDS = {
-        "headers" => nil,
+        "headers" => [:map, :string].freeze,
       }.freeze
       REQUIRED = %w[headers].freeze
       attr_reader :headers
@@ -1523,8 +1523,8 @@ module Stagehand
 
     class NavigationHeader < Stagehand::Wire::Model
       FIELDS = {
-        "name" => nil,
-        "value" => nil,
+        "name" => :string,
+        "value" => :string,
       }.freeze
       REQUIRED = %w[name value].freeze
       attr_reader :name, :value
@@ -1532,7 +1532,7 @@ module Stagehand
 
     class ResponseSecurityDetailsResult < Stagehand::Wire::Model
       FIELDS = {
-        "value" => [:union, ["NavigationSecurityDetails", nil].freeze].freeze,
+        "value" => [:union, ["NavigationSecurityDetails", :null].freeze].freeze,
       }.freeze
       REQUIRED = %w[value].freeze
       attr_reader :value
@@ -1540,11 +1540,11 @@ module Stagehand
 
     class NavigationSecurityDetails < Stagehand::Wire::Model
       FIELDS = {
-        "issuer" => nil,
-        "protocol" => nil,
-        "subject_name" => nil,
-        "valid_from" => nil,
-        "valid_to" => nil,
+        "issuer" => :string,
+        "protocol" => :string,
+        "subject_name" => :string,
+        "valid_from" => :number,
+        "valid_to" => :number,
       }.freeze
       REQUIRED = %w[issuer protocol subject_name valid_from valid_to].freeze
       attr_reader :issuer, :protocol, :subject_name, :valid_from, :valid_to
@@ -1552,7 +1552,7 @@ module Stagehand
 
     class ResponseServerAddrResult < Stagehand::Wire::Model
       FIELDS = {
-        "value" => [:union, ["NavigationServerAddr", nil].freeze].freeze,
+        "value" => [:union, ["NavigationServerAddr", :null].freeze].freeze,
       }.freeze
       REQUIRED = %w[value].freeze
       attr_reader :value
@@ -1560,8 +1560,8 @@ module Stagehand
 
     class NavigationServerAddr < Stagehand::Wire::Model
       FIELDS = {
-        "ip_address" => nil,
-        "port" => nil,
+        "ip_address" => :string,
+        "port" => :integer,
       }.freeze
       REQUIRED = %w[ip_address port].freeze
       attr_reader :ip_address, :port
@@ -1569,7 +1569,7 @@ module Stagehand
 
     class ResponseFinishedResult < Stagehand::Wire::Model
       FIELDS = {
-        "error" => [:union, ["NavigationFinishedError", nil].freeze].freeze,
+        "error" => [:union, ["NavigationFinishedError", :null].freeze].freeze,
       }.freeze
       REQUIRED = %w[error].freeze
       attr_reader :error
@@ -1577,7 +1577,7 @@ module Stagehand
 
     class NavigationFinishedError < Stagehand::Wire::Model
       FIELDS = {
-        "message" => nil,
+        "message" => :string,
       }.freeze
       REQUIRED = %w[message].freeze
       attr_reader :message
@@ -1585,9 +1585,9 @@ module Stagehand
 
     class StagehandLog < Stagehand::Wire::Model
       FIELDS = {
-        "level" => nil,
-        "message" => nil,
-        "data" => nil,
+        "level" => "StagehandLogLevel",
+        "message" => :string,
+        "data" => "StagehandLogData",
       }.freeze
       REQUIRED = %w[level message data].freeze
       attr_reader :level, :message, :data
@@ -1599,7 +1599,7 @@ module Stagehand
 
     class PageCDPEventNotification < Stagehand::Wire::Model
       FIELDS = {
-        "subscription_id" => nil,
+        "subscription_id" => :string,
         "event" => "PageCDPEvent",
       }.freeze
       REQUIRED = %w[subscription_id event].freeze
@@ -1608,11 +1608,11 @@ module Stagehand
 
     class PageCDPEvent < Stagehand::Wire::Model
       FIELDS = {
-        "page_id" => nil,
-        "method" => nil,
-        "params" => nil,
-        "session_id" => nil,
-        "target_id" => nil,
+        "page_id" => :string,
+        "method" => :string,
+        "params" => "PageCDPEventParams",
+        "session_id" => :string,
+        "target_id" => :string,
       }.freeze
       REQUIRED = %w[page_id method params session_id target_id].freeze
       attr_reader :page_id, :method, :params, :session_id, :target_id
@@ -1621,11 +1621,11 @@ module Stagehand
     class BrowserbaseSessionCreateParams < Stagehand::Wire::Model
       FIELDS = {
         "browser_settings" => "BrowserbaseBrowserSettings",
-        "extension_id" => nil,
-        "keep_alive" => nil,
-        "proxies" => [:union, [[:array, "ProxyConfig"].freeze, nil].freeze].freeze,
-        "region" => nil,
-        "timeout" => nil,
+        "extension_id" => :string,
+        "keep_alive" => :boolean,
+        "proxies" => [:union, [:boolean, [:array, "ProxyConfig"].freeze].freeze].freeze,
+        "region" => "BrowserbaseRegion",
+        "timeout" => :number,
         "user_metadata" => nil,
       }.freeze
       REQUIRED = [].freeze
@@ -1634,18 +1634,18 @@ module Stagehand
 
     class BrowserbaseBrowserSettings < Stagehand::Wire::Model
       FIELDS = {
-        "advanced_stealth" => nil,
-        "block_ads" => nil,
-        "captcha_image_selector" => nil,
-        "captcha_input_selector" => nil,
+        "advanced_stealth" => :boolean,
+        "block_ads" => :boolean,
+        "captcha_image_selector" => :string,
+        "captcha_input_selector" => :string,
         "context" => "BrowserbaseContext",
-        "extension_id" => nil,
+        "extension_id" => :string,
         "fingerprint" => "BrowserbaseFingerprint",
-        "log_session" => nil,
-        "os" => nil,
-        "record_session" => nil,
-        "solve_captchas" => nil,
-        "verified" => nil,
+        "log_session" => :boolean,
+        "os" => :string,
+        "record_session" => :boolean,
+        "solve_captchas" => :boolean,
+        "verified" => :boolean,
         "viewport" => "BrowserbaseViewport",
       }.freeze
       REQUIRED = [].freeze
@@ -1654,8 +1654,8 @@ module Stagehand
 
     class BrowserbaseContext < Stagehand::Wire::Model
       FIELDS = {
-        "id" => nil,
-        "persist" => nil,
+        "id" => :string,
+        "persist" => :boolean,
       }.freeze
       REQUIRED = %w[id].freeze
       attr_reader :id, :persist
@@ -1663,11 +1663,11 @@ module Stagehand
 
     class BrowserbaseFingerprint < Stagehand::Wire::Model
       FIELDS = {
-        "browsers" => nil,
-        "devices" => nil,
-        "http_version" => nil,
-        "locales" => nil,
-        "operating_systems" => nil,
+        "browsers" => [:array, :string].freeze,
+        "devices" => [:array, :string].freeze,
+        "http_version" => :string,
+        "locales" => [:array, :string].freeze,
+        "operating_systems" => [:array, :string].freeze,
         "screen" => "BrowserbaseFingerprintScreen",
       }.freeze
       REQUIRED = [].freeze
@@ -1676,10 +1676,10 @@ module Stagehand
 
     class BrowserbaseFingerprintScreen < Stagehand::Wire::Model
       FIELDS = {
-        "max_height" => nil,
-        "max_width" => nil,
-        "min_height" => nil,
-        "min_width" => nil,
+        "max_height" => :number,
+        "max_width" => :number,
+        "min_height" => :number,
+        "min_width" => :number,
       }.freeze
       REQUIRED = [].freeze
       attr_reader :max_height, :max_width, :min_height, :min_width
@@ -1687,8 +1687,8 @@ module Stagehand
 
     class BrowserbaseViewport < Stagehand::Wire::Model
       FIELDS = {
-        "width" => nil,
-        "height" => nil,
+        "width" => :number,
+        "height" => :number,
       }.freeze
       REQUIRED = [].freeze
       attr_reader :width, :height
@@ -1696,8 +1696,8 @@ module Stagehand
 
     class BrowserbaseProxyConfig < Stagehand::Wire::Model
       FIELDS = {
-        "type" => nil,
-        "domain_pattern" => nil,
+        "type" => :string,
+        "domain_pattern" => :string,
         "geolocation" => "BrowserbaseProxyGeolocation",
       }.freeze
       REQUIRED = %w[type].freeze
@@ -1706,9 +1706,9 @@ module Stagehand
 
     class BrowserbaseProxyGeolocation < Stagehand::Wire::Model
       FIELDS = {
-        "country" => nil,
-        "city" => nil,
-        "state" => nil,
+        "country" => :string,
+        "city" => :string,
+        "state" => :string,
       }.freeze
       REQUIRED = %w[country].freeze
       attr_reader :country, :city, :state
@@ -1716,11 +1716,11 @@ module Stagehand
 
     class ExternalProxyConfig < Stagehand::Wire::Model
       FIELDS = {
-        "type" => nil,
-        "server" => nil,
-        "domain_pattern" => nil,
-        "username" => nil,
-        "password" => nil,
+        "type" => :string,
+        "server" => :string,
+        "domain_pattern" => :string,
+        "username" => :string,
+        "password" => :string,
       }.freeze
       REQUIRED = %w[type server].freeze
       attr_reader :type, :server, :domain_pattern, :username, :password
@@ -1728,9 +1728,9 @@ module Stagehand
 
     class JSONRPCErrorObject < Stagehand::Wire::Model
       FIELDS = {
-        "code" => nil,
-        "message" => nil,
-        "data" => nil,
+        "code" => :integer,
+        "message" => :string,
+        "data" => "__schema14",
       }.freeze
       REQUIRED = %w[code message].freeze
       attr_reader :code, :message, :data
@@ -1740,18 +1740,18 @@ module Stagehand
       "StagehandInitParams" => StagehandInitParams,
       "ImplementationInfo" => ImplementationInfo,
       "BrowserSessionMetadata" => BrowserSessionMetadata,
-      "BrowserbaseRegion" => nil,
+      "BrowserbaseRegion" => [:enum, "BrowserbaseRegion"].freeze,
       "ModelConfig" => ModelConfig,
-      "OpenAIModelName" => nil,
-      "AnthropicModelName" => nil,
-      "GoogleModelName" => nil,
-      "GroqModelName" => nil,
-      "CerebrasModelName" => nil,
-      "ModelName" => nil,
+      "OpenAIModelName" => :string,
+      "AnthropicModelName" => :string,
+      "GoogleModelName" => :string,
+      "GroqModelName" => :string,
+      "CerebrasModelName" => :string,
+      "ModelName" => [:union, ["OpenAIModelName", "AnthropicModelName", "GoogleModelName", "GroqModelName", "CerebrasModelName"].freeze].freeze,
       "ClientModelReference" => ClientModelReference,
       "TelemetryConfig" => TelemetryConfig,
       "TelemetryTraces" => TelemetryTraces,
-      "Caching" => nil,
+      "Caching" => [:union, [:boolean, nil].freeze].freeze,
       "StagehandInitResult" => StagehandInitResult,
       "PageRef" => PageRef,
       "EmptyParams" => EmptyParams,
@@ -1761,13 +1761,13 @@ module Stagehand
       "ActOptions" => ActOptions,
       "Variables" => [:map, "VariableValue"].freeze,
       "VariableValue" => [:union, ["VariablePrimitive", "DescribedVariableValue"].freeze].freeze,
-      "VariablePrimitive" => nil,
+      "VariablePrimitive" => [:union, [:string, :number, :boolean].freeze].freeze,
       "DescribedVariableValue" => DescribedVariableValue,
       "Locator" => Locator,
       "ActResult" => ActResult,
       "ActResultData" => ActResultData,
       "StagehandResultMetadata" => StagehandResultMetadata,
-      "CacheStatus" => nil,
+      "CacheStatus" => [:enum, "CacheStatus"].freeze,
       "CacheTokenSavings" => CacheTokenSavings,
       "CacheMetadata" => CacheMetadata,
       "StagehandResultUsage" => StagehandResultUsage,
@@ -1775,36 +1775,36 @@ module Stagehand
       "ObserveOptions" => ObserveOptions,
       "ObserveResult" => ObserveResult,
       "StagehandExtractParams" => StagehandExtractParams,
-      "__schema0" => nil,
+      "__schema0" => [:union, [:string, :number, :boolean, :null, [:array, "__schema0"].freeze, [:map, "__schema0"].freeze].freeze].freeze,
       "ExtractOptions" => ExtractOptions,
       "ExtractResult" => ExtractResult,
-      "__schema1" => nil,
+      "__schema1" => [:union, [:string, :number, :boolean, :null, [:array, "__schema1"].freeze, [:map, "__schema1"].freeze].freeze].freeze,
       "StagehandMetrics" => StagehandMetrics,
       "CallbackBatchParams" => CallbackBatchParams,
-      "__schema2" => nil,
+      "__schema2" => [:union, [:string, :number, :boolean, :null, [:array, "__schema2"].freeze, [:map, "__schema2"].freeze].freeze].freeze,
       "CallbackBatchOptions" => CallbackBatchOptions,
       "CallbackBatchResult" => CallbackBatchResult,
-      "__schema3" => nil,
+      "__schema3" => [:union, [:string, :number, :boolean, :null, [:array, "__schema3"].freeze, [:map, "__schema3"].freeze].freeze].freeze,
       "LLMGenerateParams" => [:union, ["LLMStructuredGenerateParams", "LLMMessageGenerateParams"].freeze].freeze,
       "LLMStructuredGenerateParams" => LLMStructuredGenerateParams,
       "LLMMessage" => LLMMessage,
-      "LLMRole" => nil,
+      "LLMRole" => [:enum, "LLMRole"].freeze,
       "LLMMessageContentBlock" => [:union, ["LLMTextContent", "LLMImageContent", "LLMToolUseContent", "LLMToolResultContent"].freeze].freeze,
       "LLMTextContent" => LLMTextContent,
       "LLMAnnotations" => LLMAnnotations,
       "LLMImageContent" => LLMImageContent,
       "LLMToolUseContent" => LLMToolUseContent,
-      "__schema4" => nil,
+      "__schema4" => [:union, [:string, :number, :boolean, :null, [:array, "__schema4"].freeze, [:map, "__schema4"].freeze].freeze].freeze,
       "LLMToolResultContent" => LLMToolResultContent,
       "LLMToolResultContentBlock" => [:union, ["LLMTextContent", "LLMImageContent"].freeze].freeze,
-      "__schema5" => nil,
+      "__schema5" => [:union, [:string, :number, :boolean, :null, [:array, "__schema5"].freeze, [:map, "__schema5"].freeze].freeze].freeze,
       "LLMJsonSchemaResponseFormat" => LLMJsonSchemaResponseFormat,
-      "__schema6" => nil,
+      "__schema6" => [:union, [:string, :number, :boolean, :null, [:array, "__schema6"].freeze, [:map, "__schema6"].freeze].freeze].freeze,
       "LLMMessageGenerateParams" => LLMMessageGenerateParams,
       "LLMClientTool" => LLMClientTool,
       "LLMToolIcon" => LLMToolIcon,
       "LLMToolJson" => nil,
-      "__schema7" => nil,
+      "__schema7" => [:union, [:string, :number, :boolean, :null, [:array, "__schema7"].freeze, [:map, "__schema7"].freeze].freeze].freeze,
       "LLMToolExecution" => LLMToolExecution,
       "LLMToolAnnotations" => LLMToolAnnotations,
       "LLMToolChoice" => LLMToolChoice,
@@ -1813,16 +1813,16 @@ module Stagehand
       "LLMMessageGenerateResult" => LLMMessageGenerateResult,
       "LLMUsage" => LLMUsage,
       "LLMStructuredGenerateResult" => LLMStructuredGenerateResult,
-      "__schema8" => nil,
+      "__schema8" => [:union, [:string, :number, :boolean, :null, [:array, "__schema8"].freeze, [:map, "__schema8"].freeze].freeze].freeze,
       "ContextPagesResult" => [:array, "PageRef"].freeze,
       "ContextNewPageParams" => ContextNewPageParams,
-      "ContextActivePageResult" => [:union, ["PageRef", nil].freeze].freeze,
+      "ContextActivePageResult" => [:union, ["PageRef", :null].freeze].freeze,
       "ContextSetActivePageParams" => ContextSetActivePageParams,
       "ContextVoidResult" => ContextVoidResult,
       "ContextCloseResult" => ContextCloseResult,
       "ContextAddInitScriptParams" => ContextAddInitScriptParams,
       "ContextSetExtraHTTPHeadersParams" => ContextSetExtraHTTPHeadersParams,
-      "ContextGetDomainPolicyResult" => [:union, ["DomainPolicy", nil].freeze].freeze,
+      "ContextGetDomainPolicyResult" => [:union, ["DomainPolicy", :null].freeze].freeze,
       "DomainPolicy" => DomainPolicy,
       "ContextSetDomainPolicyParams" => ContextSetDomainPolicyParams,
       "ContextCookiesParams" => ContextCookiesParams,
@@ -1832,20 +1832,20 @@ module Stagehand
       "CookieParam" => CookieParam,
       "ContextClearCookiesParams" => ContextClearCookiesParams,
       "ClearCookieOptions" => ClearCookieOptions,
-      "CookieFilter" => [:union, ["CookieRegex", nil].freeze].freeze,
+      "CookieFilter" => [:union, [:string, "CookieRegex"].freeze].freeze,
       "CookieRegex" => CookieRegex,
       "ContextClipboardTarget" => ContextClipboardTarget,
-      "ContextClipboardReadTextResult" => nil,
+      "ContextClipboardReadTextResult" => :string,
       "ContextClipboardWriteTextParams" => ContextClipboardWriteTextParams,
       "ContextClipboardPasteParams" => ContextClipboardPasteParams,
       "PageGotoParams" => PageGotoParams,
       "PageNavigationOptions" => PageNavigationOptions,
-      "LoadState" => nil,
+      "LoadState" => [:enum, "LoadState"].freeze,
       "PageNavigationResult" => PageNavigationResult,
       "NavigationResponseDescriptor" => NavigationResponseDescriptor,
       "PageIdParams" => PageIdParams,
-      "PageUrlResult" => nil,
-      "PageTitleResult" => nil,
+      "PageUrlResult" => :string,
+      "PageTitleResult" => :string,
       "PageCloseResult" => PageCloseResult,
       "PageReloadParams" => PageReloadParams,
       "PageReloadOptions" => PageReloadOptions,
@@ -1853,7 +1853,7 @@ module Stagehand
       "PageGoForwardParams" => PageGoForwardParams,
       "PageClickParams" => PageClickParams,
       "PageClickOptions" => PageClickOptions,
-      "MouseButton" => nil,
+      "MouseButton" => [:enum, "MouseButton"].freeze,
       "PageVoidResult" => PageVoidResult,
       "PageHoverParams" => PageHoverParams,
       "PageScrollParams" => PageScrollParams,
@@ -1866,10 +1866,10 @@ module Stagehand
       "PageKeyPressOptions" => PageKeyPressOptions,
       "PageEvaluateParams" => PageEvaluateParams,
       "PageEvaluateResult" => PageEvaluateResult,
-      "__schema9" => nil,
+      "__schema9" => [:union, [:string, :number, :boolean, :null, [:array, "__schema9"].freeze, [:map, "__schema9"].freeze].freeze].freeze,
       "PageAddInitScriptParams" => PageAddInitScriptParams,
       "PageOnParams" => PageOnParams,
-      "PageEventName" => nil,
+      "PageEventName" => [:enum, "PageEventName"].freeze,
       "PageOffParams" => PageOffParams,
       "PageSetExtraHTTPHeadersParams" => PageSetExtraHTTPHeadersParams,
       "PageScreenshotParams" => PageScreenshotParams,
@@ -1891,16 +1891,16 @@ module Stagehand
       "WebMCPToolsOptions" => WebMCPToolsOptions,
       "PageWebMCPToolsResult" => PageWebMCPToolsResult,
       "WebMCPToolDescriptor" => WebMCPToolDescriptor,
-      "WebMCPJsonValue" => nil,
-      "__schema10" => nil,
+      "WebMCPJsonValue" => "__schema10",
+      "__schema10" => [:union, [:string, :number, :boolean, :null, [:array, "__schema10"].freeze, [:map, "__schema10"].freeze].freeze].freeze,
       "WebMCPAnnotation" => WebMCPAnnotation,
       "PageWebMCPInvokeToolParams" => PageWebMCPInvokeToolParams,
       "WebMCPInvocationDescriptor" => WebMCPInvocationDescriptor,
       "PageWebMCPInvocationResultParams" => PageWebMCPInvocationResultParams,
       "WebMCPResultOptions" => WebMCPResultOptions,
       "WebMCPToolResponse" => WebMCPToolResponse,
-      "WebMCPInvocationStatus" => nil,
-      "WebMCPRemoteObject" => nil,
+      "WebMCPInvocationStatus" => [:enum, "WebMCPInvocationStatus"].freeze,
+      "WebMCPRemoteObject" => [:map, "WebMCPJsonValue"].freeze,
       "PageWebMCPCancelInvocationParams" => PageWebMCPCancelInvocationParams,
       "LocatorClickParams" => LocatorClickParams,
       "LocatorClickOptions" => LocatorClickOptions,
@@ -1908,13 +1908,13 @@ module Stagehand
       "LocatorFillParams" => LocatorFillParams,
       "LocatorFillResult" => LocatorFillResult,
       "LocatorHoverResult" => LocatorHoverResult,
-      "LocatorCountResult" => nil,
-      "LocatorIsCheckedResult" => nil,
-      "LocatorInputValueResult" => nil,
-      "LocatorIsVisibleResult" => nil,
-      "LocatorInnerTextResult" => nil,
-      "LocatorInnerHtmlResult" => nil,
-      "LocatorTextContentResult" => nil,
+      "LocatorCountResult" => :integer,
+      "LocatorIsCheckedResult" => :boolean,
+      "LocatorInputValueResult" => :string,
+      "LocatorIsVisibleResult" => :boolean,
+      "LocatorInnerTextResult" => :string,
+      "LocatorInnerHtmlResult" => :string,
+      "LocatorTextContentResult" => :string,
       "LocatorScrollToParams" => LocatorScrollToParams,
       "LocatorScrollToResult" => LocatorScrollToResult,
       "LocatorCentroidResult" => LocatorCentroidResult,
@@ -1929,7 +1929,7 @@ module Stagehand
       "LocatorTypeOptions" => LocatorTypeOptions,
       "LocatorTypeResult" => LocatorTypeResult,
       "LocatorSelectOptionParams" => LocatorSelectOptionParams,
-      "LocatorSelectOptionResult" => nil,
+      "LocatorSelectOptionResult" => [:array, :string].freeze,
       "LocatorSetInputFilesParams" => LocatorSetInputFilesParams,
       "InputFilePayload" => InputFilePayload,
       "LocatorSetInputFilesResult" => LocatorSetInputFilesResult,
@@ -1945,13 +1945,13 @@ module Stagehand
       "ResponseFinishedResult" => ResponseFinishedResult,
       "NavigationFinishedError" => NavigationFinishedError,
       "StagehandLog" => StagehandLog,
-      "StagehandLogLevel" => nil,
-      "StagehandLogData" => nil,
-      "__schema11" => nil,
+      "StagehandLogLevel" => [:enum, "StagehandLogLevel"].freeze,
+      "StagehandLogData" => [:map, "__schema11"].freeze,
+      "__schema11" => [:union, [:string, :number, :boolean, :null, [:array, "__schema11"].freeze, [:map, "__schema11"].freeze].freeze].freeze,
       "PageCDPEventNotification" => PageCDPEventNotification,
       "PageCDPEvent" => PageCDPEvent,
-      "PageCDPEventParams" => nil,
-      "__schema12" => nil,
+      "PageCDPEventParams" => [:map, "__schema12"].freeze,
+      "__schema12" => [:union, [:string, :number, :boolean, :null, [:array, "__schema12"].freeze, [:map, "__schema12"].freeze].freeze].freeze,
       "BrowserbaseSessionCreateParams" => BrowserbaseSessionCreateParams,
       "BrowserbaseBrowserSettings" => BrowserbaseBrowserSettings,
       "BrowserbaseContext" => BrowserbaseContext,
@@ -1962,11 +1962,11 @@ module Stagehand
       "BrowserbaseProxyConfig" => BrowserbaseProxyConfig,
       "BrowserbaseProxyGeolocation" => BrowserbaseProxyGeolocation,
       "ExternalProxyConfig" => ExternalProxyConfig,
-      "JSONRPCRequestId" => nil,
-      "__schema13" => nil,
+      "JSONRPCRequestId" => :integer,
+      "__schema13" => [:union, [:string, :number, :boolean, :null, [:array, "__schema13"].freeze, [:map, "__schema13"].freeze].freeze].freeze,
       "JSONRPCErrorObject" => JSONRPCErrorObject,
-      "__schema14" => nil,
-      "JSONRPCErrorResponseId" => nil,
+      "__schema14" => [:union, [:string, :number, :boolean, :null, [:array, "__schema14"].freeze, [:map, "__schema14"].freeze].freeze].freeze,
+      "JSONRPCErrorResponseId" => [:union, ["JSONRPCRequestId", :null].freeze].freeze,
     }.freeze
 
     METHODS = {
@@ -1990,15 +1990,15 @@ module Stagehand
       "context.cookies" => { params: "ContextCookiesParams", result: "ContextCookiesResult" }.freeze,
       "context.add_cookies" => { params: "ContextAddCookiesParams", result: "ContextVoidResult" }.freeze,
       "context.clear_cookies" => { params: "ContextClearCookiesParams", result: "ContextVoidResult" }.freeze,
-      "context.clipboard_read_text" => { params: "ContextClipboardTarget", result: nil }.freeze,
+      "context.clipboard_read_text" => { params: "ContextClipboardTarget", result: "ContextClipboardReadTextResult" }.freeze,
       "context.clipboard_write_text" => { params: "ContextClipboardWriteTextParams", result: "ContextVoidResult" }.freeze,
       "context.clipboard_clear" => { params: "ContextClipboardTarget", result: "ContextVoidResult" }.freeze,
       "context.clipboard_paste" => { params: "ContextClipboardPasteParams", result: "ContextVoidResult" }.freeze,
       "context.clipboard_copy" => { params: "ContextClipboardTarget", result: "ContextVoidResult" }.freeze,
       "context.clipboard_cut" => { params: "ContextClipboardTarget", result: "ContextVoidResult" }.freeze,
       "page.goto" => { params: "PageGotoParams", result: "PageNavigationResult" }.freeze,
-      "page.url" => { params: "PageIdParams", result: nil }.freeze,
-      "page.title" => { params: "PageIdParams", result: nil }.freeze,
+      "page.url" => { params: "PageIdParams", result: "PageUrlResult" }.freeze,
+      "page.title" => { params: "PageIdParams", result: "PageTitleResult" }.freeze,
       "page.close" => { params: "PageIdParams", result: "PageCloseResult" }.freeze,
       "page.reload" => { params: "PageReloadParams", result: "PageNavigationResult" }.freeze,
       "page.go_back" => { params: "PageGoBackParams", result: "PageNavigationResult" }.freeze,
@@ -2027,19 +2027,19 @@ module Stagehand
       "locator.click" => { params: "LocatorClickParams", result: "LocatorClickResult" }.freeze,
       "locator.fill" => { params: "LocatorFillParams", result: "LocatorFillResult" }.freeze,
       "locator.hover" => { params: "LocatorDescriptor", result: "LocatorHoverResult" }.freeze,
-      "locator.count" => { params: "LocatorDescriptor", result: nil }.freeze,
-      "locator.is_checked" => { params: "LocatorDescriptor", result: nil }.freeze,
-      "locator.input_value" => { params: "LocatorDescriptor", result: nil }.freeze,
-      "locator.is_visible" => { params: "LocatorDescriptor", result: nil }.freeze,
-      "locator.inner_text" => { params: "LocatorDescriptor", result: nil }.freeze,
-      "locator.inner_html" => { params: "LocatorDescriptor", result: nil }.freeze,
-      "locator.text_content" => { params: "LocatorDescriptor", result: nil }.freeze,
+      "locator.count" => { params: "LocatorDescriptor", result: "LocatorCountResult" }.freeze,
+      "locator.is_checked" => { params: "LocatorDescriptor", result: "LocatorIsCheckedResult" }.freeze,
+      "locator.input_value" => { params: "LocatorDescriptor", result: "LocatorInputValueResult" }.freeze,
+      "locator.is_visible" => { params: "LocatorDescriptor", result: "LocatorIsVisibleResult" }.freeze,
+      "locator.inner_text" => { params: "LocatorDescriptor", result: "LocatorInnerTextResult" }.freeze,
+      "locator.inner_html" => { params: "LocatorDescriptor", result: "LocatorInnerHtmlResult" }.freeze,
+      "locator.text_content" => { params: "LocatorDescriptor", result: "LocatorTextContentResult" }.freeze,
       "locator.scroll_to" => { params: "LocatorScrollToParams", result: "LocatorScrollToResult" }.freeze,
       "locator.centroid" => { params: "LocatorDescriptor", result: "LocatorCentroidResult" }.freeze,
       "locator.highlight" => { params: "LocatorHighlightParams", result: "LocatorHighlightResult" }.freeze,
       "locator.send_click_event" => { params: "LocatorSendClickEventParams", result: "LocatorSendClickEventResult" }.freeze,
       "locator.type" => { params: "LocatorTypeParams", result: "LocatorTypeResult" }.freeze,
-      "locator.select_option" => { params: "LocatorSelectOptionParams", result: nil }.freeze,
+      "locator.select_option" => { params: "LocatorSelectOptionParams", result: "LocatorSelectOptionResult" }.freeze,
       "locator.set_input_files" => { params: "LocatorSetInputFilesParams", result: "LocatorSetInputFilesResult" }.freeze,
       "response.body" => { params: "ResponseIdParams", result: "ResponseBodyResult" }.freeze,
       "response.all_headers" => { params: "ResponseIdParams", result: "ResponseAllHeadersResult" }.freeze,

--- a/packages/sdk-ruby/lib/stagehand/page.rb
+++ b/packages/sdk-ruby/lib/stagehand/page.rb
@@ -197,9 +197,9 @@ module Stagehand
     # -- events -----------------------------------------------------------
 
     # Subscribes to a page event ("console", ...); the block receives each
-    # Models::PageCDPEvent. Returns a CDPSubscription. The block runs on the
-    # RPC dispatcher thread and may issue RPC calls, but a slow block delays
-    # other inbound work (later events, llm.generate requests).
+    # Models::PageCDPEvent. Returns a CDPSubscription. Each delivery runs on
+    # its own SDK thread — the block may issue RPC calls, and deliveries for
+    # a busy page can run concurrently, so synchronize any shared state.
     def on(event, &listener)
       raise ArgumentError, "a listener block is required" if listener.nil?
 

--- a/packages/sdk-ruby/lib/stagehand/rpc_client.rb
+++ b/packages/sdk-ruby/lib/stagehand/rpc_client.rb
@@ -10,13 +10,12 @@ require_relative "generated/models"
 
 module Stagehand
   # JSON-RPC 2.0 client over a Stagehand transport (the CDP client). Port of
-  # packages/sdk-python/src/stagehand/rpc_client.py onto two background
-  # threads: a reader that routes responses to per-request queues, and a
-  # dispatcher that runs inbound work (server->client requests such as
-  # llm.generate, and notification listeners). Handlers and listeners run on
-  # the dispatcher thread and may issue RPC calls themselves; inbound work is
-  # processed one item at a time, so a slow handler delays later inbound
-  # requests and notifications (Python runs these as concurrent tasks).
+  # packages/sdk-python/src/stagehand/rpc_client.py: a background reader
+  # routes responses to per-request queues, and every inbound item — a
+  # server->client request such as llm.generate, or a notification delivery —
+  # runs on its own tracked thread (the analogue of Python's per-item asyncio
+  # tasks). Handlers and listeners may issue RPC calls and run concurrently;
+  # no ordering is guaranteed between inbound items.
   class RPCClient
     MAX_REQUEST_ID = 9_007_199_254_740_991
     MAX_PENDING_NOTIFICATIONS = 100
@@ -62,11 +61,9 @@ module Stagehand
       @request_handlers = {}
       @notification_listeners = Hash.new { |hash, key| hash[key] = [] }
       @pending_notifications = []
-      @inbound = Thread::Queue.new
+      @inbound_threads = Set.new
       @closed = false
       @close_reason = nil
-      @dispatcher = Thread.new { dispatch_loop }
-      @dispatcher.name = "stagehand-rpc-dispatcher"
       @reader = Thread.new { read_loop }
       @reader.name = "stagehand-rpc-reader"
     end
@@ -113,9 +110,9 @@ module Stagehand
     # Registers the handler for an inbound server->client request (e.g.
     # llm.generate). Params arrive decoded via Models::METHODS; the handler's
     # return value (a wire model or Hash matching the result definition) is
-    # sent back as the JSON-RPC result. The handler runs on the dispatcher
-    # thread and may issue RPC calls. Returns a proc that removes the handler
-    # (a no-op if another handler replaced it in the meantime).
+    # sent back as the JSON-RPC result. Each request runs on its own thread —
+    # handlers may issue RPC calls and run concurrently. Returns a proc that
+    # removes the handler (a no-op if another handler replaced it).
     def on_request(method, &handler)
       raise StagehandError, "RPC client is closed" if @closed
       raise ArgumentError, "a handler block is required" if handler.nil?
@@ -131,8 +128,8 @@ module Stagehand
     end
 
     # Registers a listener for a server notification. Params are decoded via
-    # Models::NOTIFICATIONS when the method is a known notification. Listeners
-    # run on the dispatcher thread (never the caller's), so a notification
+    # Models::NOTIFICATIONS when the method is a known notification. Each
+    # delivery runs on its own thread (never the caller's), so a notification
     # buffered before registration is also replayed asynchronously. Returns a
     # proc that removes the listener.
     def on_notification(method, &listener)
@@ -145,7 +142,9 @@ module Stagehand
         @pending_notifications.reject! { |entry| entry.fetch("method") == method }
         buffered
       end
-      replayable.each { |entry| @inbound << [:notification, method, entry["params"], [listener]] }
+      replayable.each do |entry|
+        track_inbound { dispatch_notification(method, entry["params"], [listener]) }
+      end
 
       lambda do
         @state_mutex.synchronize do
@@ -167,16 +166,18 @@ module Stagehand
         @pending.each_value { |queue| queue << @close_reason }
         @pending.clear
       end
-      @inbound << :close
       @transport.close if close_transport
       unless Thread.current == @reader
         # The real transport unblocks the reader on close; the kill is a
         # backstop for transports that cannot (it is parked in receive).
         @reader.kill unless @reader.join(2)
       end
-      unless Thread.current == @dispatcher
-        # The kill is a backstop for a handler stuck in slow user code.
-        @dispatcher.kill unless @dispatcher.join(2)
+      # Wait out in-flight inbound work (Python's cancel + gather); the kill
+      # is a backstop for a handler stuck in slow user code.
+      inbound = @state_mutex.synchronize { @inbound_threads.to_a }
+      inbound.each do |thread|
+        next if thread == Thread.current
+        thread.kill unless thread.join(2)
       end
       nil
     end
@@ -296,21 +297,22 @@ module Stagehand
           registered.dup
         end
       end
-      @inbound << [:notification, method, message["params"], listeners] if listeners
+      track_inbound { dispatch_notification(method, message["params"], listeners) } if listeners
     end
 
-    def dispatch_loop
-      loop do
-        entry = @inbound.pop
-        break if entry == :close
-        kind, *rest = entry
-        case kind
-        when :notification then dispatch_notification(*rest)
-        when :request then handle_request(rest.first)
-        end
+    # Runs one inbound item on its own tracked thread — the analogue of
+    # Python's _track_inbound tasks. An unexpected escape closes the client.
+    def track_inbound(&work)
+      thread = Thread.new do
+        work.call
+      rescue Exception => error
+        close(error) unless @closed
+      ensure
+        @state_mutex.synchronize { @inbound_threads.delete(Thread.current) }
       end
-    rescue Exception => error
-      close(error) unless @closed
+      thread.name = "stagehand-rpc-inbound"
+      @state_mutex.synchronize { @inbound_threads << thread }
+      nil
     end
 
     def dispatch_notification(method, params, listeners)
@@ -340,12 +342,12 @@ module Stagehand
         return
       end
 
-      @inbound << [:request, message]
+      track_inbound { handle_request(message) }
     end
 
-    # Runs on the dispatcher thread: decode params, run the registered
-    # handler, validate its result against the method's wire definition, and
-    # answer. Errors map to JSON-RPC codes the same way the Python SDK does.
+    # Runs on an inbound thread: decode params, run the registered handler,
+    # validate its result against the method's wire definition, and answer.
+    # Errors map to JSON-RPC codes the same way the Python SDK does.
     def handle_request(message)
       request_id = message["id"]
       registered = @state_mutex.synchronize { @request_handlers[message["method"]] }

--- a/packages/sdk-ruby/lib/stagehand/rpc_client.rb
+++ b/packages/sdk-ruby/lib/stagehand/rpc_client.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "json"
+require "opentelemetry"
 require "set"
 
 require_relative "errors"
@@ -49,6 +50,8 @@ module Stagehand
     ].to_set.freeze
 
     REQUEST_KEYS = %w[jsonrpc id method params traceparent tracestate].freeze
+
+    TRACE_CONTEXT_PROPAGATOR = OpenTelemetry::Trace::Propagation::TraceContext.text_map_propagator
     NOTIFICATION_KEYS = %w[jsonrpc method params].freeze
 
     def initialize(transport)
@@ -92,6 +95,9 @@ module Stagehand
       end
 
       request = { "jsonrpc" => "2.0", "id" => request_id, "method" => method, "params" => wire_params }
+      # W3C trace context rides on the request envelope, like the sibling
+      # SDKs (the direct propagator, independent of any configured SDK).
+      TRACE_CONTEXT_PROPAGATOR.inject(request)
       timeout = self.class.response_timeout_seconds(method, wire_params)
       begin
         @transport.send(request)

--- a/packages/sdk-ruby/lib/stagehand/wire.rb
+++ b/packages/sdk-ruby/lib/stagehand/wire.rb
@@ -13,7 +13,10 @@ module Stagehand
   #
   # Field descriptors:
   #   nil               raw JSON value, passed through verbatim
+  #   :string/:integer/:number/:boolean/:null
+  #                     scalar type check (nil always passes: nullable fields)
   #   String            reference to a definition in Models::DEFS
+  #   [:enum, name]     value must be in Models::<name>::VALUES
   #   [:array, desc]    array of desc
   #   [:map, desc]      string-keyed object whose values are desc
   #   [:union, [desc]]  first structurally-matching variant wins. A nil in
@@ -38,6 +41,9 @@ module Stagehand
       case descriptor
       when nil
         value
+      when Symbol
+        check_scalar(value, descriptor) { |message| raise WireError, message }
+        value
       when String
         decode(value, Models::DEFS.fetch(descriptor) { raise WireError, "unknown wire definition: #{descriptor}" })
       when Class
@@ -53,6 +59,11 @@ module Stagehand
 
     def decode_compound(value, descriptor)
       kind, inner = descriptor
+      case kind
+      when :enum
+        check_scalar(value, descriptor) { |message| raise WireError, message }
+        return value
+      end
       case kind
       when :array
         return value.map { |entry| decode(entry, inner) } if value.is_a?(Array)
@@ -82,12 +93,15 @@ module Stagehand
       variants.each do |variant|
         next if variant.nil?
         descriptor = variant.is_a?(String) ? Models::DEFS[variant] : variant
-        # A reference that resolves to an opaque definition (enum, scalar
-        # alias) accepts any value: the union stays open.
+        # A reference that resolves to an opaque definition accepts any
+        # value: the union stays open.
         open = true if variant.is_a?(String) && descriptor.nil? && Models::DEFS.key?(variant)
+        return value if descriptor.is_a?(Symbol) && scalar_matches?(value, descriptor)
         next unless descriptor.is_a?(Array)
         kind = descriptor.first
         case kind
+        when :enum
+          return value if scalar_matches?(value, descriptor)
         when :array
           return decode(value, descriptor) if value.is_a?(Array)
         when :map
@@ -106,6 +120,43 @@ module Stagehand
       end
       return value if open || value.nil?
       raise WireError, "value matches no union variant"
+    end
+
+    # True when the value satisfies a scalar or enum descriptor (nil always
+    # passes: nullable fields).
+    def scalar_matches?(value, descriptor)
+      return true if value.nil?
+      case descriptor
+      when :string then value.is_a?(String)
+      when :integer then value.is_a?(Integer)
+      when :number then value.is_a?(Numeric) && !value.is_a?(Complex)
+      when :boolean then value == true || value == false
+      when :null then false # non-nil value never matches null
+      when Array then descriptor.first == :enum && enum_values(descriptor.last).include?(value)
+      else false
+      end
+    end
+
+    def check_scalar(value, descriptor)
+      return if scalar_matches?(value, descriptor)
+      expected = descriptor.is_a?(Array) ? "one of #{descriptor.last}::VALUES" : descriptor.to_s
+      yield "expected #{expected}, got #{value.inspect}"
+    end
+
+    def enum_values(name)
+      Models.const_get(name)::VALUES
+    end
+
+    # Resolves a descriptor to its scalar/enum form (following reference
+    # chains), or nil when it is not scalar-checkable.
+    def scalar_descriptor(descriptor, depth = 0)
+      return nil if depth > 16
+      case descriptor
+      when Symbol then descriptor
+      when String then scalar_descriptor(Models::DEFS[descriptor], depth + 1)
+      when Array then descriptor.first == :enum ? descriptor : nil
+      else nil
+      end
     end
 
     # Follows reference chains until a Model class or nil.
@@ -141,6 +192,15 @@ module Stagehand
         values.each do |key, value|
           name = key.to_s
           raise ArgumentError, "unknown field #{name} for #{self.class.name}" unless fields.key?(name)
+          # Scalar and enum fields validate at construction (the analogue of
+          # pydantic's validate-on-construct); structured fields stay shallow
+          # here and validate at the decode boundary.
+          scalar = Wire.scalar_descriptor(fields[name])
+          if scalar
+            Wire.check_scalar(value, scalar) do |message|
+              raise ArgumentError, "#{self.class.name}.#{name}: #{message}"
+            end
+          end
           instance_variable_set(:"@#{name}", value)
           @__set_keys << name
         end

--- a/packages/sdk-ruby/scripts/build.rb
+++ b/packages/sdk-ruby/scripts/build.rb
@@ -28,9 +28,14 @@ FileUtils.mkdir_p(output_directory)
 begin
   FileUtils.cp_r(extension_dist, staged_extension)
 
-  specification = Gem::Specification.load(File.join(package_root, "stagehand.gemspec"))
-  abort "Could not load stagehand.gemspec" if specification.nil?
-  gem_path = Dir.chdir(package_root) { Gem::Package.build(specification) }
+  # The gemspec globs files relative to the working directory, so both the
+  # load and the build must run from the package root (CI invokes this
+  # script from the repository root).
+  gem_path = Dir.chdir(package_root) do
+    specification = Gem::Specification.load("stagehand.gemspec")
+    abort "Could not load stagehand.gemspec" if specification.nil?
+    Gem::Package.build(specification)
+  end
   built = File.join(package_root, gem_path)
   target = File.join(output_directory, File.basename(gem_path))
   FileUtils.mv(built, target)

--- a/packages/sdk-ruby/scripts/generate.rb
+++ b/packages/sdk-ruby/scripts/generate.rb
@@ -109,8 +109,9 @@ class Generator
     end
   end
 
-  # Compiles a schema node to a wire descriptor: nil (raw JSON), a definition
-  # name, [:array, d], [:map, d], or [:union, [d, ...]].
+  # Compiles a schema node to a wire descriptor: nil (raw JSON), a scalar
+  # marker (:string/:integer/:number/:boolean/:null), a definition name,
+  # [:array, d], [:map, d], or [:union, [d, ...]].
   def compile(node)
     return nil unless node.is_a?(Hash)
 
@@ -143,21 +144,28 @@ class Generator
       return nil unless items.is_a?(Hash)
       inner = compile(items)
       inner.nil? ? nil : [:array, inner]
+    when "string" then :string
+    when "integer" then :integer
+    when "number" then :number
+    when "boolean" then :boolean
+    when "null" then :null
     else
+      # Untyped schemas and multi-type arrays stay raw (open).
       nil
     end
   end
 
-  # A descriptor is trivial when it can never reach a generated class, so
-  # decoding it is the identity. Cycles (recursive JSON values) are trivial.
+  # A descriptor is trivial when decoding it is the identity — it can never
+  # reach a generated class, enum, or scalar check. Cycles (recursive JSON
+  # values) are trivial.
   def trivial?(descriptor, seen = {})
     case descriptor
     when nil then true
+    when Symbol then false
     when String
       return true if seen[descriptor]
       seen[descriptor] = true
-      return false if @kinds[descriptor] == :class
-      return true if @kinds[descriptor] == :enum
+      return false if @kinds[descriptor] != :descriptor
       trivial?(@compiled.fetch(descriptor), seen)
     when Array
       kind, inner = descriptor
@@ -172,6 +180,7 @@ class Generator
   def literal(descriptor)
     case descriptor
     when nil then "nil"
+    when Symbol then descriptor.inspect
     when String then descriptor.inspect
     when Array
       kind, inner = descriptor
@@ -226,7 +235,7 @@ class Generator
       value =
         case @kinds.fetch(name)
         when :class then name
-        when :enum then "nil"
+        when :enum then "[:enum, #{name.inspect}].freeze"
         else literal(simplify(@compiled.fetch(name)))
         end
       lines << "      #{name.inspect} => #{value},"

--- a/packages/sdk-ruby/sig/stagehand.rbs
+++ b/packages/sdk-ruby/sig/stagehand.rbs
@@ -60,9 +60,14 @@ module Stagehand
 
   module LocalBrowser
     def self?.launch: (
-      ?headless: bool?, ?devtools: bool?, ?chromium_sandbox: bool?,
       ?args: Array[String]?, ?executable_path: String?, ?port: Integer?,
-      ?user_data_dir: String?, ?viewport_width: Integer, ?viewport_height: Integer
+      ?user_data_dir: String?, ?preserve_user_data_dir: bool?,
+      ?headless: bool?, ?devtools: bool?, ?chromium_sandbox: bool?,
+      ?ignore_default_args: (true | Array[String])?,
+      ?proxy: Hash[Symbol | String, String]?, ?locale: String?,
+      ?viewport: Hash[Symbol | String, Integer]?, ?device_scale_factor: Numeric?,
+      ?has_touch: bool?, ?ignore_https_errors: bool?,
+      ?downloads_path: String?, ?accept_downloads: bool?, ?keep_alive: bool?
     ) -> StagehandBrowser
     def self?.connect: (cdp_url: String, ?extension_id: String?) -> StagehandBrowser
   end

--- a/packages/sdk-ruby/stagehand.gemspec
+++ b/packages/sdk-ruby/stagehand.gemspec
@@ -25,5 +25,6 @@ Gem::Specification.new do |spec|
   spec.files = Dir["lib/**/*", "sig/**/*", "README.md"]
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "opentelemetry-api", "~> 1.5"
   spec.add_dependency "websocket-driver", "~> 0.8"
 end

--- a/packages/sdk-ruby/test/test_file_upload.rb
+++ b/packages/sdk-ruby/test/test_file_upload.rb
@@ -7,6 +7,7 @@ require "tempfile"
 class TestFileUpload < Minitest::Test
   def test_normalizes_a_path_into_a_wire_payload
     Tempfile.create(["report", ".csv"]) do |file|
+      file.binmode # keep the fixture byte-stable on Windows (no CRLF translation)
       file.write("a,b\n1,2\n")
       file.flush
       payloads = Stagehand::FileUpload.normalize_file_input(file.path)

--- a/packages/sdk-ruby/test/test_local_browser_flags.rb
+++ b/packages/sdk-ruby/test/test_local_browser_flags.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+# LocalBrowser option -> Chrome flag mapping (launch_flags is pure; no Chrome
+# is spawned). Semantics mirror packages/sdk-python/src/stagehand/browser.py.
+class TestLocalBrowserFlags < Minitest::Test
+  LocalBrowser = Stagehand::LocalBrowser
+
+  def flags(**options)
+    LocalBrowser.launch_flags(debug_port: 9222, profile_dir: "/tmp/profile", ci: false, **options)
+  end
+
+  def test_default_flag_set
+    result = flags
+    assert_includes result, "--window-size=1280,800"
+    assert_includes result, LocalBrowser::WEBMCP_CHROME_FLAG
+    assert_includes result, "--remote-debugging-port=9222"
+    assert_includes result, "--user-data-dir=/tmp/profile"
+    assert_equal "about:blank", result.last
+    refute_includes result, "--headless"
+    refute_includes result, "--no-sandbox"
+    LocalBrowser::DEFAULT_CHROME_FLAGS.each { |flag| assert_includes result, flag }
+  end
+
+  def test_proxy_locale_viewport_scale_touch_and_https_flags
+    result = flags(
+      proxy: { server: "http://127.0.0.1:8080", bypass: "*.internal" },
+      locale: "de-DE",
+      viewport: { width: 800, height: 600 },
+      device_scale_factor: 2.0,
+      has_touch: true,
+      ignore_https_errors: true,
+    )
+    assert_includes result, "--proxy-server=http://127.0.0.1:8080"
+    assert_includes result, "--proxy-bypass-list=*.internal"
+    assert_includes result, "--lang=de-DE"
+    assert_includes result, "--window-size=800,600"
+    assert_includes result, "--force-device-scale-factor=2"
+    assert_includes result, "--touch-events=enabled"
+    assert_includes result, "--ignore-certificate-errors"
+    refute_includes result, "--window-size=1280,800"
+  end
+
+  def test_fractional_scale_keeps_its_fraction
+    assert_includes flags(device_scale_factor: 1.5), "--force-device-scale-factor=1.5"
+  end
+
+  def test_ignore_default_args_true_drops_all_default_groups
+    result = flags(ignore_default_args: true)
+    LocalBrowser::DEFAULT_CHROME_FLAGS.each { |flag| refute_includes result, flag }
+    LocalBrowser::STAGEHAND_DEFAULT_FLAGS.each { |flag| refute_includes result, flag }
+    refute_includes result, LocalBrowser::WEBMCP_CHROME_FLAG
+    refute_includes result, "--window-size=1280,800"
+    # Non-default machinery survives.
+    assert_includes result, "--remote-debugging-port=9222"
+    assert_includes result, "--user-data-dir=/tmp/profile"
+    assert_equal "about:blank", result.last
+  end
+
+  def test_ignore_default_args_list_is_exact_string_subtraction
+    result = flags(ignore_default_args: ["--mute-audio", "--window-size=1280,800"])
+    refute_includes result, "--mute-audio"
+    refute_includes result, "--window-size=1280,800"
+    assert_includes result, "--no-first-run"
+  end
+
+  def test_explicit_viewport_readds_window_size_even_when_ignored
+    result = flags(ignore_default_args: true, viewport: { width: 1024, height: 768 })
+    assert_includes result, "--window-size=1024,768"
+    listed = flags(ignore_default_args: ["--window-size=1024,768"], viewport: { width: 1024, height: 768 })
+    assert_includes listed, "--window-size=1024,768"
+  end
+
+  def test_sandbox_condition
+    assert_includes flags(chromium_sandbox: false), "--no-sandbox"
+    refute_includes flags(chromium_sandbox: true), "--no-sandbox"
+    assert_includes LocalBrowser.launch_flags(debug_port: 1, profile_dir: "/p", ci: true), "--no-sandbox"
+  end
+
+  def test_user_args_come_after_options_and_before_starting_url
+    result = flags(args: ["--custom-flag"])
+    assert_equal "about:blank", result.last
+    assert_equal "--custom-flag", result[-2]
+  end
+
+  def test_proxy_validation
+    error = assert_raises(NotImplementedError) do
+      LocalBrowser.normalize_proxy({ server: "http://p:1", username: "u", password: "s" })
+    end
+    assert_equal "Authenticated local browser proxies are not implemented yet", error.message
+    assert_raises(ArgumentError) { LocalBrowser.normalize_proxy({ bypass: "*.x" }) }
+    assert_raises(ArgumentError) { LocalBrowser.normalize_proxy("http://p:1") }
+    assert_equal({ server: "http://p:1" }, LocalBrowser.normalize_proxy({ "server" => "http://p:1" }))
+  end
+
+  def test_viewport_validation
+    assert_raises(ArgumentError) { LocalBrowser.normalize_viewport({ width: 100 }) }
+    assert_raises(ArgumentError) { LocalBrowser.normalize_viewport({ width: -1, height: 5 }) }
+    assert_equal({ width: 1, height: 2 }, LocalBrowser.normalize_viewport({ "width" => 1, "height" => 2 }))
+  end
+
+  def test_download_behavior_hook
+    assert_nil LocalBrowser.download_behavior_hook(nil, nil)
+
+    sent = []
+    cdp = Object.new
+    cdp.define_singleton_method(:send_command) { |method, params| sent << [method, params] }
+
+    LocalBrowser.download_behavior_hook("/tmp/dl", nil).call(cdp)
+    assert_equal ["Browser.setDownloadBehavior", { "behavior" => "allow", "downloadPath" => "/tmp/dl" }], sent.last
+
+    LocalBrowser.download_behavior_hook(nil, false).call(cdp)
+    assert_equal ["Browser.setDownloadBehavior", { "behavior" => "deny" }], sent.last
+  end
+end

--- a/packages/sdk-ruby/test/test_models.rb
+++ b/packages/sdk-ruby/test/test_models.rb
@@ -92,6 +92,44 @@ class TestModels < Minitest::Test
     assert_instance_of Models::CookieRegex, regex
   end
 
+  def test_scalar_fields_validate_on_decode
+    assert_raises(Stagehand::WireError) do
+      Models::PageGotoParams.from_wire("page_id" => "p", "url" => 42)
+    end
+    error = assert_raises(Stagehand::WireError) do
+      Stagehand::Wire.decode(true, :integer)
+    end
+    assert_match(/expected integer/, error.message)
+    # :number accepts Integer and Float, never booleans; nil passes (nullable).
+    assert_equal 1, Stagehand::Wire.decode(1, :number)
+    assert_equal 1.5, Stagehand::Wire.decode(1.5, :number)
+    assert_raises(Stagehand::WireError) { Stagehand::Wire.decode(true, :number) }
+    assert_nil Stagehand::Wire.decode(nil, :string)
+  end
+
+  def test_scalar_fields_validate_on_construction
+    error = assert_raises(ArgumentError) { Models::PageGotoParams.new(page_id: "p", url: 42) }
+    assert_match(/url: expected string/, error.message)
+    assert_raises(ArgumentError) { Models::PageClickParams.new(page_id: "p", x: "ten", y: 2) }
+    # Valid construction still works, including nullable omissions.
+    assert_equal "https://x.test", Models::PageGotoParams.new(page_id: "p", url: "https://x.test").url
+  end
+
+  def test_enum_fields_validate_membership
+    message = Models::LLMMessage.from_wire("role" => "user", "content" => { "type" => "text", "text" => "hi" })
+    assert_equal "user", message.role
+    assert_raises(Stagehand::WireError) do
+      Models::LLMMessage.from_wire("role" => "narrator", "content" => { "type" => "text", "text" => "hi" })
+    end
+    assert_raises(ArgumentError) { Models::LLMMessage.new(role: "narrator", content: []) }
+  end
+
+  def test_scalar_union_variants_are_strict
+    # CookieFilter is string | CookieRegex: numbers no longer pass through.
+    assert_equal "session", Stagehand::Wire.decode("session", "CookieFilter")
+    assert_raises(Stagehand::WireError) { Stagehand::Wire.decode(42, "CookieFilter") }
+  end
+
   def test_structural_mismatches_raise
     assert_raises(Stagehand::WireError) { Stagehand::Wire.decode("nope", Models::ActResult) }
     assert_raises(Stagehand::WireError) { Stagehand::Wire.decode({ "a" => 1 }, [:array, "PageRef"]) }

--- a/packages/sdk-ruby/test/test_rpc_client.rb
+++ b/packages/sdk-ruby/test/test_rpc_client.rb
@@ -141,6 +141,31 @@ class TestRPCClient < Minitest::Test
     assert_equal "hi", seen.messages.first.content.text
   end
 
+  def llm_request(id, name)
+    {
+      "jsonrpc" => "2.0", "id" => id, "method" => "llm.generate",
+      "params" => {
+        "messages" => [{ "role" => "user", "content" => { "type" => "text", "text" => "hi" } }],
+        "response_format" => { "type" => "json_schema", "name" => name, "schema" => { "type" => "object" } },
+      },
+    }
+  end
+
+  # Impossible under a serial dispatcher: the first handler blocks until the
+  # second request has been fully answered.
+  def test_inbound_requests_run_concurrently
+    release = Thread::Queue.new
+    @client.on_request("llm.generate") do |params|
+      release.pop if params.response_format.name == "first"
+      release << :go if params.response_format.name == "second"
+      structured_result(structured_content: { "name" => params.response_format.name })
+    end
+    @client.receive(llm_request(21, "first"))
+    @client.receive(llm_request(22, "second"))
+    replies = Array.new(2) { @transport.next_sent }
+    assert_equal [22, 21], replies.map { |reply| reply["id"] }
+  end
+
   def test_request_handler_may_issue_rpc_calls
     @client.on_request("llm.generate") do |_params|
       title = @client.send("page.title", Stagehand::Models::PageIdParams.new(page_id: "page-1"), "PageTitleResult")

--- a/packages/sdk-ruby/test/test_rpc_client.rb
+++ b/packages/sdk-ruby/test/test_rpc_client.rb
@@ -213,6 +213,39 @@ class TestRPCClient < Minitest::Test
     assert_equal(-32_600, reply.dig("error", "code"))
   end
 
+  def test_send_injects_w3c_trace_context_when_a_span_is_current
+    span_context = OpenTelemetry::Trace::SpanContext.new(
+      trace_id: ["0af7651916cd43dd8448eb211c80319c"].pack("H*"),
+      span_id: ["b7ad6b7169203331"].pack("H*"),
+      trace_flags: OpenTelemetry::Trace::TraceFlags::SAMPLED,
+    )
+    span = OpenTelemetry::Trace.non_recording_span(span_context)
+    context = OpenTelemetry::Trace.context_with_span(span)
+
+    responder = Thread.new do
+      request = @transport.next_sent
+      @transport.push({ "jsonrpc" => "2.0", "id" => request["id"], "result" => "t" })
+      request
+    end
+    OpenTelemetry::Context.with_current(context) do
+      @client.send("page.title", Stagehand::Models::PageIdParams.new(page_id: "p"), "PageTitleResult")
+    end
+    request = responder.value
+    assert_equal "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01", request["traceparent"]
+  end
+
+  def test_send_omits_trace_context_without_a_current_span
+    responder = Thread.new do
+      request = @transport.next_sent
+      @transport.push({ "jsonrpc" => "2.0", "id" => request["id"], "result" => "t" })
+      request
+    end
+    @client.send("page.title", Stagehand::Models::PageIdParams.new(page_id: "p"), "PageTitleResult")
+    request = responder.value
+    refute request.key?("traceparent")
+    refute request.key?("tracestate")
+  end
+
   def test_close_rejects_pending_requests
     sender = Thread.new do
       @client.send("stagehand.metrics", Stagehand::Models::EmptyParams.new, "StagehandMetrics")

--- a/packages/sdk-ruby/test/test_wire_fixtures.rb
+++ b/packages/sdk-ruby/test/test_wire_fixtures.rb
@@ -19,12 +19,16 @@ class TestWireFixtures < Minitest::Test
     walk = lambda do |descriptor|
       case descriptor
       when nil then nil
+      when :string, :integer, :number, :boolean, :null then nil
       when String
         assert Stagehand::Models::DEFS.key?(descriptor), "dangling wire reference: #{descriptor}"
       when Array
         kind, inner = descriptor
         if kind == :union
           inner.each { |variant| walk.call(variant) }
+        elsif kind == :enum
+          assert Stagehand::Models.const_defined?(inner), "dangling enum reference: #{inner}"
+          assert_kind_of Array, Stagehand::Models.const_get(inner)::VALUES
         else
           walk.call(inner)
         end

--- a/rules/ast-grep/sdk-client-schema-parity.test.ts
+++ b/rules/ast-grep/sdk-client-schema-parity.test.ts
@@ -447,21 +447,21 @@ async function rubyModuleMethodParameters(
   methodName: string,
 ): Promise<string[]> {
   const root = parse("ruby", await readFile(new URL(file, rubySource), "utf8")).root();
-  const moduleNode = root
-    .findAll({ rule: { kind: "module" } })
-    .find(
-      (node) =>
-        node.children().find((child) => child.isNamed() && child.kind() === "constant")?.text() ===
-        moduleName,
-    );
+  const moduleNode = root.findAll({ rule: { kind: "module" } }).find(
+    (node) =>
+      node
+        .children()
+        .find((child) => child.isNamed() && child.kind() === "constant")
+        ?.text() === moduleName,
+  );
   if (!moduleNode) throw new Error(`${moduleName} was not found in ${file}`);
-  const method = moduleNode
-    .findAll({ rule: { kind: "method" } })
-    .find(
-      (candidate) =>
-        candidate.children().find((child) => child.isNamed() && child.kind() === "identifier")
-          ?.text() === methodName,
-    );
+  const method = moduleNode.findAll({ rule: { kind: "method" } }).find(
+    (candidate) =>
+      candidate
+        .children()
+        .find((child) => child.isNamed() && child.kind() === "identifier")
+        ?.text() === methodName,
+  );
   if (!method) throw new Error(`${moduleName}.${methodName} was not found in ${file}`);
   const parameters = method.field("parameters");
   if (!parameters) return [];

--- a/rules/ast-grep/sdk-client-schema-parity.test.ts
+++ b/rules/ast-grep/sdk-client-schema-parity.test.ts
@@ -16,6 +16,9 @@ type Concept = {
   go: () => Promise<string[]>;
   name: string;
   python: () => Promise<string[]>;
+  // Ruby flattens these option objects into keyword arguments; absent for
+  // intentional language adapters (e.g. logging's flat log_level/on_log).
+  ruby?: () => Promise<string[]>;
   typescript: ObjectSchema;
 };
 
@@ -35,18 +38,21 @@ const concepts: readonly Concept[] = [
     typescript: ClientSchemas.LocalBrowserLaunchOptionsSchema,
     python: () => pythonClassFields("client_types.py", "LocalBrowserLaunchOptions"),
     go: () => goStructFields("browser_factories.go", "LocalBrowserLaunchOptions"),
+    ruby: () => rubyModuleMethodParameters("browser.rb", "LocalBrowser", "launch"),
   },
   {
     name: "LocalBrowserConnectOptions",
     typescript: ClientSchemas.LocalBrowserConnectOptionsSchema,
     python: () => pythonClassFields("client_types.py", "LocalBrowserConnectOptions"),
     go: () => goStructFields("browser_factories.go", "LocalBrowserConnectOptions"),
+    ruby: () => rubyModuleMethodParameters("browser.rb", "LocalBrowser", "connect"),
   },
   {
     name: "BrowserbaseConnectOptions",
     typescript: ClientSchemas.BrowserbaseConnectOptionsSchema,
     python: () => pythonClassFields("client_types.py", "BrowserbaseConnectOptions"),
     go: () => goStructFields("browser_factories.go", "BrowserbaseConnectOptions"),
+    ruby: () => rubyModuleMethodParameters("browser.rb", "Browserbase", "connect"),
   },
   {
     name: "StagehandClientLoggingConfig",
@@ -81,7 +87,11 @@ describe("SDK-owned schemas remain one cross-language contract", () => {
 
     for (const concept of concepts) {
       const expected = schemaFields(concept.typescript);
-      const [pythonFields, goFields] = await Promise.all([concept.python(), concept.go()]);
+      const [pythonFields, goFields, rubyFields] = await Promise.all([
+        concept.python(),
+        concept.go(),
+        concept.ruby?.() ?? Promise.resolve(undefined),
+      ]);
       if (!arraysEqual(pythonFields, expected)) {
         differences.push(
           `${concept.name} Python: expected [${expected.join(", ")}], received [${pythonFields.join(", ")}]`,
@@ -90,6 +100,11 @@ describe("SDK-owned schemas remain one cross-language contract", () => {
       if (!arraysEqual(goFields, expected)) {
         differences.push(
           `${concept.name} Go: expected [${expected.join(", ")}], received [${goFields.join(", ")}]`,
+        );
+      }
+      if (rubyFields && !arraysEqual(rubyFields, expected)) {
+        differences.push(
+          `${concept.name} Ruby: expected [${expected.join(", ")}], received [${rubyFields.join(", ")}]`,
         );
       }
     }
@@ -410,6 +425,45 @@ async function rubyCreateParameters(): Promise<string[]> {
     );
   if (!create) throw new Error("Stagehand::Client.create was not found in client.rb");
   const parameters = create.field("parameters");
+  if (!parameters) return [];
+  return parameters
+    .children()
+    .filter((parameter) => parameter.isNamed())
+    .flatMap((parameter) => {
+      if (parameter.kind() === "identifier") return [parameter.text()];
+      const name = parameter
+        .children()
+        .find((child) => child.isNamed() && child.kind() === "identifier");
+      return name ? [name.text()] : [];
+    })
+    .sort();
+}
+
+// Keyword/positional parameter names of a `module_function` method inside a
+// Ruby module (LocalBrowser.launch etc.).
+async function rubyModuleMethodParameters(
+  file: string,
+  moduleName: string,
+  methodName: string,
+): Promise<string[]> {
+  const root = parse("ruby", await readFile(new URL(file, rubySource), "utf8")).root();
+  const moduleNode = root
+    .findAll({ rule: { kind: "module" } })
+    .find(
+      (node) =>
+        node.children().find((child) => child.isNamed() && child.kind() === "constant")?.text() ===
+        moduleName,
+    );
+  if (!moduleNode) throw new Error(`${moduleName} was not found in ${file}`);
+  const method = moduleNode
+    .findAll({ rule: { kind: "method" } })
+    .find(
+      (candidate) =>
+        candidate.children().find((child) => child.isNamed() && child.kind() === "identifier")
+          ?.text() === methodName,
+    );
+  if (!method) throw new Error(`${moduleName}.${methodName} was not found in ${file}`);
+  const parameters = method.field("parameters");
   if (!parameters) return [];
   return parameters
     .children()


### PR DESCRIPTION
Part of the AP-2857 parity stack:

**Stack:** … ← #2861 (evals) ← #2862 (M6b docs) ← **this PR**

Closes every deviation the pre-publish audit found, one commit per fix. Guiding principle throughout: mirror the Python SDK's semantics.

## 1. Full `LocalBrowser.launch` option parity (was: 9 kwargs vs Python's 20)
All 11 missing options with Python's exact semantics: `proxy` (auth rejected pre-launch, like the siblings), `locale`, `viewport: {width:, height:}` (replaces the spike's flat pair; canonical nested shape per the TS schema and Go struct — Python's flat public kwargs are its own adapter), `device_scale_factor`, `has_touch`, `ignore_https_errors`, `downloads_path`/`accept_downloads` (post-connect CDP `Browser.setDownloadBehavior`), `keep_alive`, `ignore_default_args` (true | exact-string list over the four default flag groups; explicit viewport re-adds `--window-size`), `preserve_user_data_dir`, port range validation. Flag building is a pure, unit-tested function; the `sdk-client-schema-parity` lane now holds Ruby's launch/connect kwargs equal to the canonical TS schemas. Live-verified on real Chrome (viewport/DPR take effect; profile survives under preserve; Chrome keeps serving CDP after close under keep_alive).

## 2. OpenTelemetry trace propagation
`opentelemetry-api` joins as a runtime dependency (both siblings carry it); every outbound JSON-RPC request carries W3C `traceparent`/`tracestate` via the direct TraceContext propagator when a span is current — byte-format-identical to Python's `TraceContextTextMapPropagator`.

## 3. Concurrent inbound dispatch
The single dispatcher thread is gone: every inbound server→client request and notification delivery runs on its own tracked thread (Python's per-item tasks), joined with a kill backstop at close. Proven by a latch test where the first `llm.generate` handler blocks until the second is answered. Retained deviation (commented): a raising notification listener is logged and skipped rather than tearing down the client. All "single dispatcher" wording swept from code comments, README, and docs.

## 4. Strict scalar + enum validation
The generator emits typed descriptors (`:string`/`:integer`/`:number`/`:boolean`/`:null`, `[:enum, Name]`); the wire runtime enforces them on decode (`WireError`) and at model construction (`ArgumentError`), mirroring pydantic strict mode. Scalar union variants become strict alternatives; untyped schemas stay open; nil passes for nullable fields.

## Verification
- Ruby suite: 141 runs / 1,096 assertions + RBS + `SOAK=20` soak; generator drift clean
- All 137 vitest tests green (ast-grep lanes, docs reference suite, release scripts)
- Live: `batch.rb`, `extras/context_and_response.rb`, `custom_llm.rb` (inbound path under real concurrency), evals observe spot-run 10/12 (the two failures are the known bot-wall and site-drift tasks), launch-options probe on real Chrome
- Gem rebuilt and installed-gem smoke passed with the new dependency resolving from RubyGems

The README "Known deviations" section is now a "Parity status" section — none of the four gaps remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)